### PR TITLE
agc: break the graphics boot blocker — real sceAgcCreateShader + shader-derived pipeline state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ---- Game dump: copyrighted, huge, NEVER commit ----
 /PPSA24651-app0/
+/PPSA24651-app0
 *.prx
 *.sprx
 *.self

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -80,6 +80,9 @@ if(TARGET prosper_core)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)
     target_link_libraries(boot_trace PRIVATE prosper_core)
 
+    add_executable(imgdump tools/imgdump/imgdump.cpp)
+    target_link_libraries(imgdump PRIVATE prosper_core)
+
     add_executable(test_trap_linux tests/test_trap_linux.cpp)
     target_link_libraries(test_trap_linux PRIVATE prosper_core)
     add_test(NAME trap_identifies_imports

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -100,7 +100,48 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - Graphics libs are sparsely documented; most NIDs don't resolve to names — reverse-engineer from
   call args (`PROSPER_GFXLOG`) and `build-linux/tools/pltm` (maps a module GOT offset → NID).
 
-## THE BOOT BLOCKER (precisely located, 2026-07): `+kSrjIVxKFE` = AGC context init
+## ✅ THE BOOT BLOCKER — RESOLVED (2026-07-04): the "source" is the Shader; CreateShader was the gap
+
+**Resolution (supersedes the "SDK-gated / parked" conclusion below).** The null register-source
+global `[eboot+0x2048c60]` was never libSceAgc-private state: it is **field +0x10 of a 0x28-byte
+shader-registry slot at `0x2048c50`** — one of ~30 slots for Unity's built-in shaders, registered
+at graphics init by `eboot+0x14bc002..` → `eboot+0x14e74c0(slot, shader_elf, flag)`. That function
+parses a **shader ELF embedded in eboot rodata** (`e_machine=0xe0` EM_AMDGPU; sections
+`.shader_header` / `.shader_text`) and calls `sceAgcCreateShader(&slot->shader, header, code)`
+(NID `f3dg2CSgRKY`, via the arg-validating wrapper `eboot+0x3ae120`). Our stub returned 0 without
+writing `*dst`, so every slot's shader stayed null. The earlier static-scan conclusion "no eboot
+code writes the global" was the classic computed-addressing blind spot (same failure mode as the
+RGCTX hunt): the writer stores through `slot+0x10`, never through the literal address.
+
+The **register source object IS the Shader**: `SetSource` (eboot+0x3af400) reads `[src+0x08]`
+(user_data), `[src+0x28]` (specials), `[src+0x5a]` (type) — exactly the SDK Shader layout (Kyty
+Shader.h:974). The "classify table" ships inside each shader blob; nothing is fabricated.
+
+**Implemented in `hle_agc.cpp` (all real semantics, layout-verified via Kyty + the eboot disasm):**
+- `f3dg2CSgRKY` **sceAgcCreateShader** — relocates the header's self-relative pointers in place,
+  binds the code pointer, patches the leading `SPI/COMPUTE_PGM_LO/HI` sh-register pair (all five
+  stage pairs, beyond Kyty's ES/PS-only), guards double-relocation, writes `*dst`, and registers
+  the shader in a host-side registry (`prosper_agc_shader_count()`) for the AGC→Vulkan pipeline.
+- `V++UgBtQhn0` **sceAgcGetDataPacketPayloadAddress** — called from *inside* eboot's static AGC
+  code (register-bank prepare, `eboot+0x3af040`): the returned payload becomes the register bank
+  `[sub+0x10]`/`[sub+0x18]`. The banks live in the game's own Dcb data packets.
+- `n2fD4A+pb+g` **sceAgcCbSetShRegisterRangeDirect** — IT_SET_SH_REG range packet (+ the marker
+  NOP the real library emits).
+- `D9sr1xGUriE` **sceAgcCreatePrimState**, `HV4j+E0MBHE` **sceAgcCreateInterpolantMapping** —
+  pipeline registers derived from the bound shaders' specials/semantics (generalized semantic
+  matching instead of Kyty's hard-asserted identity layout).
+
+**Result:** all 36 built-in shaders register (`PROSPER_GFXLOG` shows `pgm_patched=1` on each), the
+whole `CreateWorkload` register-context chain (`0x3b5ea6` → `0x3b1562` → `0x3b1533` → `0x3afcff`)
+completes, and **no unimplemented libSceAgc call remains in the boot**. The boot now faults much
+later at `eboot+0xba6e08` (addr=0x8, non-AGC backtrace via `0xd3xxxx`/`0x15fxxxx`) — the next,
+separate frontier. Note: the game passes AGC interface version **13** (Kyty's Gen5 games used 8) —
+layouts verified against this title, not assumed from Kyty.
+
+Tooling added: `build-linux/imgdump <module> <out.img>` dumps a module's flat image for offline
+`objdump -D -b binary -m i386:x86-64` disassembly (how the registry writer was found).
+
+## (Historical) THE BOOT BLOCKER (located 2026-07): `+kSrjIVxKFE` = AGC context init
 
 The boot faults at `eboot+0x3b5ea6` inside a GPU register-setting routine. Full chain, traced under gdb:
 

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -9,9 +9,14 @@
 // reverse-engineered the real libSceAgc ABI. A later CommandProcessor will decode this PM4 stream to
 // Vulkan (see docs/AGC_IMPL_PLAN.md). Registered by raw NID (AGC lib is undocumented).
 #include "dispatch.hpp"
+#include "gpu/pm4_registers.hpp"
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstddef>
+#include <cstring>
+#include <unordered_set>
+#include <vector>
 
 namespace prosper {
 
@@ -131,6 +136,258 @@ HLE(agc_dcb_set_flip) {  // (buf, video_out_handle, display_buffer_index, flip_m
     return (uint64_t)(uintptr_t)cmd;
 }
 
+// --- sceAgcCreateShader (NID f3dg2CSgRKY) — the shader-object constructor. ---------------------
+//
+// THE boot blocker's root (docs/GRAPHICS.md "register source"): Unity registers its ~36 built-in
+// shaders at graphics init via eboot+0x14e74c0, which parses shader ELFs embedded in eboot rodata
+// (e_machine=0xe0 EM_AMDGPU; sections .shader_header / .shader_text) and calls
+// sceAgcCreateShader(&slot->shader, header, code) per shader — through the arg-validating wrapper
+// eboot+0x3ae120 (rejects nulls + non-256-aligned code) that tail-jumps to this import. Our old
+// stub returned 0 WITHOUT writing *dst, so every registry slot's shader stayed null — including
+// [eboot+0x2048c60] (= slot base 0x2048c50 + 0x10), the "source" object whose null pointer flows
+// through SetSource (eboot+0x3af400) into the register-context sub-objects and null-derefs at
+// eboot+0x3b1562/0x3b5ea6. The Shader IS the register source: SetSource reads [src+0x08]
+// (user_data), [src+0x28] (specials), [src+0x5a] (type) — the Shader field offsets below.
+//
+// Semantics per Kyty GraphicsCreateShader (Graphics.cpp:1432) — layout-verified against the real
+// SDK blobs (file_header '1234', version 0x18, matching our captured gfx1030 shaders). The header's
+// pointer fields are stored SELF-RELATIVE in the blob; the constructor relocates them in place
+// (ptr += &ptr), binds the code pointer, and patches the shader-program base address into the
+// leading SPI_SHADER_PGM_LO/HI sh-register pair. Beyond Kyty (which supports only ES/PS pairs and
+// hard-aborts otherwise): we accept all five PGM pairs (PS/GS/ES/HS/CS), guard against double
+// relocation, and never abort — unexpected shapes are logged and survive.
+namespace {
+
+struct AgcShaderRegister { uint32_t offset, value; };   // guest-visible (Kyty Shader.h:941)
+struct AgcShaderUserData {           // guest-visible (Kyty Shader.h:911)
+    uint16_t* direct_resource_offset;   // +0x00  self-relative until relocated
+    void*     sharp_resource_offset[4]; // +0x08  (ShaderSharp*[4])
+    uint16_t  eud_size_dw, srt_size_dw, direct_resource_count, sharp_resource_count[4];
+};
+struct AgcShader {                   // guest-visible (Kyty Shader.h:974)
+    uint32_t           file_header;             // +0x00  '1234' = 0x34333231
+    uint32_t           version;                 // +0x04  0x18
+    AgcShaderUserData* user_data;               // +0x08  \.
+    const void*        code;                    // +0x10   | SetSource consumes +0x08/+0x28/+0x5a
+    AgcShaderRegister* cx_registers;            // +0x18   |
+    AgcShaderRegister* sh_registers;            // +0x20   |
+    void*              specials;                // +0x28  /
+    void*              input_semantics;         // +0x30
+    void*              output_semantics;        // +0x38
+    uint32_t           header_size;             // +0x40
+    uint32_t           shader_size;             // +0x44
+    uint32_t           embedded_constant_buffer_size_dqw; // +0x48
+    uint32_t           target;                  // +0x4c
+    uint32_t           num_input_semantics;     // +0x50
+    uint16_t           scratch_size_dw_per_thread; // +0x54
+    uint16_t           num_output_semantics;    // +0x56
+    uint16_t           special_sizes_bytes;     // +0x58
+    uint8_t            type;                    // +0x5a
+    uint8_t            num_cx_registers;        // +0x5b
+    uint8_t            num_sh_registers;        // +0x5c
+};
+static_assert(offsetof(AgcShader, user_data) == 0x08 && offsetof(AgcShader, code) == 0x10 &&
+              offsetof(AgcShader, specials) == 0x28 && offsetof(AgcShader, type) == 0x5a &&
+              offsetof(AgcShader, num_sh_registers) == 0x5c, "AgcShader must match the SDK blob layout");
+
+// AGC error codes (observed in the eboot wrapper at 0x3ae120).
+constexpr uint64_t kAgcErrInvalidArg = 0x8a6c000aull;
+
+// Shaders whose headers we already relocated (the fixup is not idempotent), and the registry of all
+// created shaders — the AGC->Vulkan pipeline consumes this to find shader code by PGM base.
+std::unordered_set<const void*>& agc_relocated() { static std::unordered_set<const void*> s; return s; }
+std::vector<const AgcShader*>&   agc_shaders()   { static std::vector<const AgcShader*> v; return v; }
+
+// Relocate one self-relative pointer field in place (no-op for null fields).
+template <class T> inline void agc_fix_ptr(T*& m) {
+    if (m) m = reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(m) + reinterpret_cast<uintptr_t>(&m));
+}
+
+}  // namespace
+
+// Exposed for tests: how many shaders the guest successfully registered.
+extern "C" size_t prosper_agc_shader_count() { return agc_shaders().size(); }
+
+HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
+    auto** dst   = (AgcShader**)(uintptr_t)a0;
+    auto*  h     = (AgcShader*)(uintptr_t)a1;
+    auto*  code  = (const void*)(uintptr_t)a2;
+    if (!dst || !h || !code) return kAgcErrInvalidArg;
+
+    if (agc_relocated().insert(h).second) {
+        agc_fix_ptr(h->cx_registers);
+        agc_fix_ptr(h->sh_registers);
+        agc_fix_ptr(h->user_data);
+        agc_fix_ptr(h->specials);
+        agc_fix_ptr(h->input_semantics);
+        agc_fix_ptr(h->output_semantics);
+        if (h->user_data) {
+            agc_fix_ptr(h->user_data->direct_resource_offset);
+            for (auto& sharp : h->user_data->sharp_resource_offset) agc_fix_ptr(sharp);
+        }
+    }
+    h->code = code;
+
+    if (h->file_header != 0x34333231u || h->version != 0x18u) {
+        fprintf(stderr, "[agc] CreateShader: unexpected header magic=0x%08x version=0x%x (want '1234'/0x18)\n",
+                h->file_header, h->version);
+        return kAgcErrInvalidArg;   // wrong layout model — fail loudly rather than corrupt the blob
+    }
+
+    // Patch the shader-program base into the leading SPI/COMPUTE PGM_LO/HI register pair. The blob
+    // pre-seeds the pair's offsets, so match any known stage rather than gating on `type` (Kyty
+    // handles only ES/PS and aborts otherwise; the game also registers other stages).
+    using namespace prosper::agc::Pm4;
+    static constexpr uint32_t kPgmPairs[][2] = {
+        {SPI_SHADER_PGM_LO_PS, SPI_SHADER_PGM_HI_PS}, {SPI_SHADER_PGM_LO_ES, SPI_SHADER_PGM_HI_ES},
+        {SPI_SHADER_PGM_LO_GS, SPI_SHADER_PGM_HI_GS}, {SPI_SHADER_PGM_LO_HS, SPI_SHADER_PGM_HI_HS},
+        {COMPUTE_PGM_LO,       COMPUTE_PGM_HI},
+    };
+    uint64_t base = (uint64_t)(uintptr_t)code;
+    bool patched = false;
+    if (h->sh_registers && h->num_sh_registers >= 2) {
+        for (const auto& pair : kPgmPairs) {
+            if (h->sh_registers[0].offset == pair[0] && h->sh_registers[1].offset == pair[1]) {
+                h->sh_registers[0].value = (uint32_t)((base >> 8) & 0xffffffffu);
+                h->sh_registers[1].value = (uint32_t)((base >> 40) & 0xffu);
+                patched = true;
+                break;
+            }
+        }
+    }
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] CreateShader #%zu: header=%p code=%p type=%u target=0x%x size=%u "
+                        "cx=%u sh=%u pgm_patched=%d\n",
+                agc_shaders().size(), (void*)h, (void*)code, h->type, h->target, h->shader_size,
+                h->num_cx_registers, h->num_sh_registers, (int)patched);
+
+    agc_shaders().push_back(h);
+    *dst = h;               // <- the write our old stub omitted; populates the shader-registry slots
+    return 0;
+}
+
+// --- Shader-derived pipeline-state constructors + register-bank plumbing. ----------------------
+//
+// With CreateShader real, the eboot's register-context machinery runs its true path: it allocates
+// "data packets" in the game's own Dcb and points each register-set sub-object's banks
+// ([sub+0x10]/[sub+0x18]) at the packet payload. The leaf imports it needs are these four
+// (semantics per Kyty Graphics.cpp:1606-1762, generalized — see each note).
+namespace {
+
+struct AgcShaderSemantic {           // guest-visible 32-bit bitfield (Kyty Shader.h:958)
+    uint32_t semantic         : 8;
+    uint32_t hardware_mapping : 8;
+    uint32_t size_in_elements : 4;
+    uint32_t is_f16           : 2;
+    uint32_t is_flat_shaded   : 1;
+    uint32_t is_linear        : 1;
+    uint32_t is_custom        : 1;
+    uint32_t static_vb_index  : 1;
+    uint32_t static_attribute : 1;
+    uint32_t reserved         : 1;
+    uint32_t default_value    : 2;
+    uint32_t default_value_hi : 2;
+};
+static_assert(sizeof(AgcShaderSemantic) == 4, "semantic must be one dword");
+
+struct AgcShaderSpecialRegs {        // guest-visible (Kyty Shader.h:947); pointed to by Shader+0x28
+    AgcShaderRegister ge_cntl;                  // +0x00
+    AgcShaderRegister vgt_shader_stages_en;     // +0x08
+    uint32_t          dispatch_modifier;        // +0x10
+    uint16_t          user_data_range_start;    // +0x14  (consumed by SetSource @ eboot+0x3af400)
+    uint16_t          user_data_range_end;      // +0x16
+    uint64_t          draw_modifier;            // +0x18  (packed ShaderDrawModifier bitfields)
+    AgcShaderRegister vgt_gs_out_prim_type;     // +0x20
+    AgcShaderRegister ge_user_vgpr_en;          // +0x28
+};
+static_assert(offsetof(AgcShaderSpecialRegs, vgt_gs_out_prim_type) == 0x20, "specials layout");
+
+}  // namespace
+
+// sceAgcGetDataPacketPayloadAddress (V++UgBtQhn0) — called from INSIDE eboot's static AGC code
+// (register-bank prepare, eboot+0x3af040 path, callsite +0x3af170): resolve a data packet built in
+// the Dcb to its payload address, which becomes the register bank. Kyty: *addr = cmd + 2 (2-dword
+// packet header), type must be 1. We accept other types with a log instead of aborting.
+HLE(agc_get_data_packet_payload) {  // (uint32_t** addr, uint32_t* cmd, int type)
+    auto** addr = (uint32_t**)(uintptr_t)a0;
+    auto*  cmd  = (uint32_t*)(uintptr_t)a1;
+    if (!addr || !cmd) return kAgcErrInvalidArg;
+    if (a2 != 1 && getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] GetDataPacketPayloadAddress: unexpected type=%d\n", (int)a2);
+    *addr = cmd + 2;
+    return 0;
+}
+
+// sceAgcCbSetShRegisterRangeDirect (n2fD4A+pb+g) — append an IT_SET_SH_REG packet covering
+// [offset, offset+num) with the given values (zeros if values==null); returns the packet pointer
+// (the game patches/fills it afterwards). Kyty also emits a 2-dword NOP marker (payload 0x6875000d)
+// first, mirroring the real library's output; we keep it for stream fidelity (NOP = inert).
+HLE(agc_cb_set_sh_register_range_direct) {  // (buf, offset, values, num_values)
+    uint32_t num = (uint32_t)a3;
+    if (!a0 || !num) return 0;
+    uint32_t* marker; if (begin_packet(a0, 2, IT_NOP, 0, &marker)) marker[1] = 0x6875000du;
+    uint32_t* cmd;    if (!begin_packet(a0, num + 2, IT_SET_SH_REG, 0, &cmd)) return 0;
+    cmd[1] = (uint32_t)a1;
+    auto* values = (const uint32_t*)(uintptr_t)a2;
+    if (values) memcpy(cmd + 2, values, (size_t)num * 4);
+    else        memset(cmd + 2, 0, (size_t)num * 4);
+    return (uint64_t)(uintptr_t)cmd;
+}
+
+// sceAgcCreatePrimState (D9sr1xGUriE) — derive the primitive-pipeline registers from the bound
+// geometry shader's "specials" block. Kyty hard-asserts hs==null and exact register offsets; we
+// copy the specials through and log deviations instead (tessellation would arrive via hs).
+HLE(agc_create_prim_state) {  // (cx_regs, uc_regs, hs, gs, prim_type)
+    auto* cx = (AgcShaderRegister*)(uintptr_t)a0;
+    auto* uc = (AgcShaderRegister*)(uintptr_t)a1;
+    auto* gs = (const AgcShader*)(uintptr_t)a3;
+    if (!cx || !uc || !gs || !gs->specials) return kAgcErrInvalidArg;
+    if (a2 && getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] CreatePrimState: hs shader present (tessellation) — not yet modeled\n");
+    const auto* sp = (const AgcShaderSpecialRegs*)gs->specials;
+    using namespace prosper::agc::Pm4;
+    cx[0] = sp->vgt_shader_stages_en;
+    cx[1] = sp->vgt_gs_out_prim_type;
+    uc[0] = sp->ge_cntl;
+    uc[1] = sp->ge_user_vgpr_en;
+    uc[2] = {VGT_PRIMITIVE_TYPE, (uint32_t)a4};
+    return 0;
+}
+
+// sceAgcCreateInterpolantMapping (HV4j+E0MBHE) — build the 32 SPI_PS_INPUT_CNTL_* registers wiring
+// PS inputs to GS/VS output parameter slots. Generalized beyond Kyty (which asserts Unity's exact
+// identity layout): match each PS input to the GS output with the same semantic id and use that
+// output's parameter slot, with the flat-shade bit (0x400) from the PS side. Falls back to the
+// identity mapping (slot i) when there is nothing to match — which reproduces Kyty's behaviour on
+// the layouts Kyty supports.
+HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader* gs, const Shader* ps)
+    auto* regs = (AgcShaderRegister*)(uintptr_t)a0;
+    auto* gs   = (const AgcShader*)(uintptr_t)a1;
+    auto* ps   = (const AgcShader*)(uintptr_t)a2;
+    if (!regs || !gs) return kAgcErrInvalidArg;
+    using namespace prosper::agc::Pm4;
+    const auto* gs_out = (const AgcShaderSemantic*)gs->output_semantics;
+    const auto* ps_in  = ps ? (const AgcShaderSemantic*)ps->input_semantics : nullptr;
+    uint32_t n = ps ? ps->num_input_semantics : (uint32_t)gs->num_output_semantics;
+    for (uint32_t i = 0; i < 32; i++) {
+        regs[i].offset = SPI_PS_INPUT_CNTL_0 + i;
+        uint32_t value = 0;
+        if (i < n) {
+            uint32_t slot = i; bool flat = false;
+            if (ps_in && gs_out) {
+                flat = ps_in[i].is_flat_shaded != 0;
+                for (uint32_t j = 0; j < gs->num_output_semantics; j++)
+                    if (gs_out[j].semantic == ps_in[i].semantic) { slot = gs_out[j].hardware_mapping; break; }
+            } else if (gs_out) {
+                slot = gs_out[i].hardware_mapping;
+            }
+            value = slot | (flat ? 0x400u : 0u);
+        }
+        regs[i].value = value;
+    }
+    return 0;
+}
+
 // --- Indirect-register patch helpers: modify a packet returned by a Set*RegsIndirect call.
 // cmd = a0 (that returned pointer). Old stub returned 0 for Set*RegsIndirect -> these wrote to null. -
 HLE(agc_patch_set_address) {  // (cmd, regs): cmd[2..3] = regs vaddr
@@ -144,6 +401,11 @@ HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
 
 void register_agc_hle() {
     #define RN(nid, fn) Hle::register_fn(nid, (HleFn)(fn), nid)
+    RN("f3dg2CSgRKY", agc_create_shader);   // sceAgcCreateShader — populates the shader registry
+    RN("V++UgBtQhn0", agc_get_data_packet_payload);          // data packet -> register-bank payload
+    RN("n2fD4A+pb+g", agc_cb_set_sh_register_range_direct);  // SET_SH_REG range packet
+    RN("D9sr1xGUriE", agc_create_prim_state);                // prim registers from gs specials
+    RN("HV4j+E0MBHE", agc_create_interpolant_mapping);       // SPI_PS_INPUT_CNTL_* wiring
     RN("TRO721eVt4g", agc_dcb_reset_queue);
     RN("MWiElSNE8j8", agc_dcb_wait_safe_for_rendering);
     RN("ZvwO9euwYzc", agc_dcb_set_cx_regs_indirect);

--- a/prosper/tools/imgdump/imgdump.cpp
+++ b/prosper/tools/imgdump/imgdump.cpp
@@ -1,0 +1,21 @@
+// imgdump — dump a module's built (unrelocated-base-0) flat image to a file for offline
+// disassembly: objdump -D -b binary -m i386:x86-64 <out.img> then grep by plain VA offset.
+// Usage: imgdump <eboot.bin|*.prx> <out.img>
+#include "self/module.hpp"
+#include <cstdio>
+
+int main(int argc, char** argv) {
+    if (argc != 3) { fprintf(stderr, "usage: %s <module> <out.img>\n", argv[0]); return 1; }
+    std::string err;
+    auto m = prosper::Module::load(argv[1], &err);
+    if (!m) { fprintf(stderr, "load failed: %s\n", err.c_str()); return 1; }
+    auto img = prosper::build_image(*m, 0);
+    FILE* f = fopen(argv[2], "wb");
+    if (!f) { perror("fopen"); return 1; }
+    fwrite(img.mem.data(), 1, img.mem.size(), f);
+    fclose(f);
+    fprintf(stderr, "wrote %zu bytes (min_vaddr=0x%llx max_vaddr=0x%llx entry=0x%llx)\n",
+            img.mem.size(), (unsigned long long)img.min_vaddr,
+            (unsigned long long)img.max_vaddr, (unsigned long long)img.entry);
+    return 0;
+}


### PR DESCRIPTION
## What

Resolves the **libSceAgc boot blocker** (the `CreateWorkload` register-context null-deref chain `0x3b5ea6` → `0x3b1562` → `0x3b1533`) that docs/GRAPHICS.md had parked as "SDK-gated." No SDK headers needed — and **no fabricated objects**: the game supplies everything itself.

## Root cause

The null "register source" global `[eboot+0x2048c60]` is **slot+0x10 of Unity's built-in shader registry** (~30 0x28-byte slots). At graphics init, `eboot+0x14e74c0` parses **shader ELFs embedded in eboot rodata** (EM_AMDGPU, `.shader_header`/`.shader_text`) and calls `sceAgcCreateShader(&slot->shader, header, code)` per shader. Our stub returned 0 **without writing `*dst`** → every slot stayed null → `SetSource` fed null into the register-context sub-objects. The earlier "no writer exists" static scan missed the store because it goes through a register base (`slot+0x10`), not the literal address — the RGCTX blind spot again.

Key insight: **the register-source object IS the SDK `Shader`** (`SetSource` reads `+0x08` user_data / `+0x28` specials / `+0x5a` type). The classify tables ship inside the game's own shader blobs.

## Implemented (hle_agc.cpp)

| NID | Function | Notes |
|---|---|---|
| `f3dg2CSgRKY` | `sceAgcCreateShader` | relocates self-relative header ptrs, binds code, patches `SPI/COMPUTE_PGM_LO/HI` (all 5 stage pairs — Kyty supports only ES/PS and aborts otherwise), double-relocation guard, host-side registry `prosper_agc_shader_count()` for the AGC→Vulkan pipeline |
| `V++UgBtQhn0` | `sceAgcGetDataPacketPayloadAddress` | register banks `[sub+0x10]/[sub+0x18]` = Dcb data-packet payloads |
| `n2fD4A+pb+g` | `sceAgcCbSetShRegisterRangeDirect` | `IT_SET_SH_REG` range packet + the real lib's marker NOP |
| `D9sr1xGUriE` | `sceAgcCreatePrimState` | prim registers from gs specials; logs (not aborts) on tessellation |
| `HV4j+E0MBHE` | `sceAgcCreateInterpolantMapping` | generalized semantic matching for `SPI_PS_INPUT_CNTL_*` (Kyty hard-asserts identity layout) |

Semantics per Kyty (MIT) but layout-verified against **this title's** blobs and eboot disassembly — note the game passes AGC interface **version 13** vs Kyty's 8, so Kyty was treated as a reference, not ground truth.

## Result

- All **36 built-in shaders** register (`PROSPER_GFXLOG`: `pgm_patched=1` each)
- **Zero unimplemented libSceAgc calls** remain in the boot
- Boot advances far past graphics init; next fault is a separate frontier at `eboot+0xba6e08` (addr=0x8, non-AGC backtrace through `0xd3xxxx/0x15fxxxx`) — will chase next
- Tests **20/20** green (WSL2)

## For the back-half pipeline (heads-up @recompiler-agent)

- `prosper_agc_shader_count()` + the internal shader registry give you header+code pointers for every game shader — the `.shader_text` payloads are real gfx1030 streams for the recompiler
- The register banks now fill with real values inside the game's own Dcb data packets — your CommandProcessor will start seeing real `SET_*_REG` traffic once the boot reaches submits
- New tool: `imgdump <module> <out.img>` (flat image for `objdump -b binary` offline disassembly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)