### PR TITLE
agc: first real command buffer executes — SubmitDcb → CommandProcessor

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -10,6 +10,7 @@
 // Vulkan (see docs/AGC_IMPL_PLAN.md). Registered by raw NID (AGC lib is undocumented).
 #include "dispatch.hpp"
 #include "gpu/pm4_registers.hpp"
+#include "gpu/command_processor.hpp"
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -388,6 +389,35 @@ HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader
     return 0;
 }
 
+// --- sceAgcDriverSubmitDcb (AgcDriver NID UglJIZjGssM) — the GPU submission point. -------------
+//
+// The game hands us a Packet {dcb_addr, dw_num} (Kyty Gen5Driver::Packet, Graphics.cpp:2168). We
+// replay the PM4 stream through the CommandProcessor into a persistent GpuState — register files +
+// draw list — which the AGC->Vulkan translation (render_state/vk_translate) consumes. No rendering
+// happens here yet; this is the semantic execution of the submit, observable via PROSPER_GFXLOG and
+// prosper_agc_submit_stats(). The Dcb address is a guest pointer, valid 1:1 in-process.
+namespace {
+gpu::GpuState& agc_gpu_state() { static gpu::GpuState st; return st; }
+uint64_t g_submit_count = 0;
+}
+
+extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws) {
+    if (submits) *submits = g_submit_count;
+    if (draws)   *draws   = (uint64_t)agc_gpu_state().draws.size();
+}
+
+HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
+    struct Packet { uint32_t* addr; uint32_t dw_num; uint8_t pad[4]; };
+    const auto* p = (const Packet*)(uintptr_t)a0;
+    if (!p || !p->addr || !p->dw_num) return kAgcErrInvalidArg;
+    size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
+    g_submit_count++;
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu)\n",
+                (unsigned long long)g_submit_count, p->dw_num, applied, agc_gpu_state().draws.size());
+    return 0;
+}
+
 // --- Indirect-register patch helpers: modify a packet returned by a Set*RegsIndirect call.
 // cmd = a0 (that returned pointer). Old stub returned 0 for Set*RegsIndirect -> these wrote to null. -
 HLE(agc_patch_set_address) {  // (cmd, regs): cmd[2..3] = regs vaddr
@@ -420,7 +450,10 @@ void register_agc_hle() {
     RN("VmW0Tdpy420", agc_dcb_wait_reg_mem);
     // Indirect-register patch helpers (SetAddress patches cmd[2..3]; AddRegisters patches cmd[1]).
     RN("vcmNN+AAXnY", agc_patch_set_address);   RN("d-6uF9sZDIU", agc_patch_add_registers);   // Cx
+    RN("Qrj4c+61z4A", agc_patch_set_address);   RN("z2duB-hHQSM", agc_patch_add_registers);   // Sh
     RN("6lNcCp+fxi4", agc_patch_set_address);   RN("vRoArM9zaIk", agc_patch_add_registers);   // Uc
+    RN("YUeqkyT7mEQ", agc_dcb_set_flip);        // sceAgcDcbSetFlip (Kyty LibGraphicsDriver.cpp:98)
+    RN("UglJIZjGssM", agc_driver_submit_dcb);   // sceAgcDriverSubmitDcb -> CommandProcessor replay
     #undef RN
 }
 

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -124,6 +124,7 @@ const char* const kAgcNids[] = {
     "VmW0Tdpy420", "ZvwO9euwYzc", "vcmNN+AAXnY", "d-6uF9sZDIU", "+kSrjIVxKFE", "H7uZqCoNuWk",
     "f3dg2CSgRKY", "hvUfkUIQcOE", "6lNcCp+fxi4", "vRoArM9zaIk", "0fWWK5uG9rQ", "3KDcnM3lrcU",
     "57labkp+rSQ", "LtTouSCZjHM", "V++UgBtQhn0", "aJf+j5yntiU", "fPSCdQxgpSw", "i1jyy49AjXU",
+    "tSBxhAPyytQ",   // fires once after the Sh patch pair during CreateWorkload; not in Kyty — RE via args
 };
 constexpr size_t kAgcNidCount = sizeof(kAgcNids) / sizeof(kAgcNids[0]);
 


### PR DESCRIPTION
## What

The boot now reaches **GPU submission**, and the first game-built command buffer executes through the CommandProcessor:

```
[agc] SubmitDcb #1: 71 dwords -> 12 packets applied
```

- **`UglJIZjGssM` `sceAgcDriverSubmitDcb`** — reads the Kyty-verified `Packet{addr, dw_num}`, replays the PM4 stream via `gpu::run_command_buffer` into a persistent `GpuState` (register files + draw list). This is the front-half → back-half handoff: your CommandProcessor is now consuming live game-built streams, not just test fixtures. `prosper_agc_submit_stats()` exposes submit/draw counts.
- **`YUeqkyT7mEQ` `sceAgcDcbSetFlip`** — the implementation existed but the NID was never registered.
- **`Qrj4c+61z4A` / `z2duB-hHQSM`** — Sh variants of the indirect-patch helpers (alias the existing Cx/Uc handlers).
- **`tSBxhAPyytQ`** added to arg tracers — fires once during CreateWorkload with `(ctx, 1, 0x11, 0x55, 0x69)` = the cx/sh/uc register-set counts; not in Kyty.

## Observed after this change

- Heavy register-set traffic (`fPSCdQxgpSw`/`3KDcnM3lrcU`/`0fWWK5uG9rQ` triplets with the same 0x11/0x55/0x78 counts)
- A `Zw7uUVPulbw` polling loop (likely workload-status; we return 0 forever — needs real semantics)
- Unity proceeds into **`unity default resources` loading** before the terminal fault

## Known issues / next frontier

- Terminal fault unchanged: `eboot+0xba6e08`, null `[r15+0x140]` on a small typed Unity gfx object (header `0x2b`) during default-resource load — next RE target, likely tied to `Zw7uUVPulbw` semantics
- **Data packets of type 0 exist** — Kyty only handles type 1 (`payload = cmd+2`); the type-0 payload offset needs RE (currently warned via `PROSPER_GFXLOG`)
- New unimplemented NID: `k3GhuSNmBLU` (fires once)

Tests **21/21** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)