### PR TITLE
test: lock in the AGC submit milestone (Dcb → SubmitDcb → GpuState)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -114,6 +114,12 @@ if(TARGET prosper_core)
     target_link_libraries(test_agc_dcb PRIVATE prosper_core)
     add_test(NAME agc_dcb_pm4 COMMAND test_agc_dcb)
 
+    # End-to-end AGC submit: build a Dcb via the HLE fns -> sceAgcDriverSubmitDcb -> CommandProcessor
+    # folds it into a GpuState. Locks in the "first real command buffer executes" milestone.
+    add_executable(test_agc_submit tests/test_agc_submit.cpp)
+    target_link_libraries(test_agc_submit PRIVATE prosper_core)
+    add_test(NAME agc_submit_to_gpustate COMMAND test_agc_submit)
+
     # Graphics-phase foundation + agentic-first verification harness: headless offscreen Vulkan
     # (render/clear -> readback -> pixel/CRC assert). Only built if Vulkan dev files are present.
     find_package(Vulkan QUIET)

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -1,0 +1,91 @@
+// test_agc_submit — end-to-end guard for the AGC submit path: build a Draw Command Buffer through
+// the real Dcb HLE functions (as the game does), submit it via sceAgcDriverSubmitDcb (UglJIZjGssM),
+// and assert the CommandProcessor folded the stream into a GpuState — registers written, draw
+// recorded, submit/draw stats updated. This locks in the "first real command buffer executes"
+// milestone programmatically (previously only observed in a boot log line, which VERIFICATION.md
+// says not to rely on). It exercises the exact front-half -> back-half handoff: Dcb build -> PM4 ->
+// decode -> GpuState.
+#include "../src/hle/dispatch.hpp"
+#include "../src/gpu/command_processor.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper;
+
+// Front-half stats exposed by hle_agc.cpp.
+extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws);
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Game's Dcb struct (must match hle_agc.cpp's AgcDcb byte-for-byte).
+struct Dcb {
+    uint32_t* bottom; uint32_t* top; uint32_t* cursor_up; uint32_t* cursor_down;
+    void* callback; void* user_data; uint32_t reserved_dw; uint32_t pad;
+};
+// The AgcDriver submit descriptor (Kyty Gen5Driver::Packet).
+struct Packet { uint32_t* addr; uint32_t dw_num; uint8_t pad[4]; };
+
+int main() {
+    printf("== test_agc_submit ==\n");
+    register_builtin_hle();
+
+    auto reset  = Hle::lookup("TRO721eVt4g");   // GraphicsDcbResetQueue
+    auto setcx  = Hle::lookup("ZvwO9euwYzc");   // GraphicsDcbSetCxRegistersIndirect
+    auto setidx = Hle::lookup("GIIW2J37e70");   // GraphicsDcbSetIndexSize
+    auto draw   = Hle::lookup("Yw0jKSqop+E");   // GraphicsDcbDrawIndexAuto
+    auto submit = Hle::lookup("UglJIZjGssM");   // GraphicsDriverSubmitDcb
+    CHECK(reset && setcx && setidx && draw && submit, "AGC Dcb + submit functions registered");
+    if (!(reset && setcx && setidx && draw && submit)) { printf("== FAIL ==\n"); return 1; }
+
+    // Baseline stats (other tests in-process may have submitted; measure deltas).
+    uint64_t s0 = 0, d0 = 0; prosper_agc_submit_stats(&s0, &d0);
+
+    // Build a command buffer exactly as the game would: the register-indirect packet carries a
+    // pointer to a real {offset,value} array, which the CommandProcessor reads back at submit time.
+    static uint32_t buffer[256];
+    memset(buffer, 0, sizeof buffer);
+    Dcb dcb{};
+    dcb.bottom = buffer; dcb.top = buffer + 256; dcb.cursor_up = buffer; dcb.cursor_down = buffer + 256;
+    auto D = (uint64_t)(uintptr_t)&dcb;
+
+    struct Reg { uint32_t offset, value; };
+    static Reg cx_regs[] = { {0x10, 0xAAAA}, {0x11, 0xBBBB}, {0x12, 0xCCCC} };
+
+    reset(D, 0x3ff, 0, 0, 0, 0);
+    setcx(D, (uint64_t)(uintptr_t)cx_regs, 3, 0, 0, 0);
+    setidx(D, 1 /*index_size*/, 0, 0, 0, 0);
+    draw(D, 42 /*index_count*/, 0, 0, 0, 0);
+
+    uint32_t dw = (uint32_t)(dcb.cursor_up - buffer);
+    CHECK(dw > 0, "Dcb build advanced the write cursor");
+
+    // Submit it through the real driver entrypoint.
+    Packet pkt{ buffer, dw, {0,0,0,0} };
+    uint64_t rc = submit((uint64_t)(uintptr_t)&pkt, 0, 0, 0, 0, 0);
+    CHECK(rc == 0, "SubmitDcb returned OK (0)");
+
+    uint64_t s1 = 0, d1 = 0; prosper_agc_submit_stats(&s1, &d1);
+    CHECK(s1 == s0 + 1, "submit count incremented by 1");
+    CHECK(d1 == d0 + 1, "draw count incremented by 1 (one DrawIndexAuto)");
+
+    // Replay the same buffer through the CommandProcessor directly to inspect the folded GpuState
+    // (SubmitDcb uses a private state internally; this asserts the same decode produces the right
+    // register file + draw — the exact transformation the submit performed).
+    {
+        gpu::GpuState st;
+        size_t packets = gpu::run_command_buffer(buffer, dw, st);
+        CHECK(packets == 4, "CommandProcessor decoded 4 packets (reset/setcx/setidx/draw)");
+        CHECK(st.cx[0x10] == 0xAAAA && st.cx[0x11] == 0xBBBB && st.cx[0x12] == 0xCCCC,
+              "folded the indirect Cx registers (0x10/0x11/0x12) from the pointed-to array");
+        CHECK(st.index_type == 1, "folded the index type");
+        CHECK(st.draws.size() == 1 && st.draws[0].index_count == 42,
+              "recorded one DrawIndexAuto with index_count=42");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## What

The "first real command buffer executes" milestone (from #2) was only proven by a boot-log line — `SubmitDcb #1: 71 dwords -> 12 packets applied` — which docs/VERIFICATION.md explicitly says not to rely on. This adds the agentic-first gate.

The test builds a Draw Command Buffer through the **real** Dcb HLE functions (`GraphicsDcbResetQueue` → `SetCxRegistersIndirect` → `SetIndexSize` → `DrawIndexAuto`), submits it via the **real** `sceAgcDriverSubmitDcb` entrypoint, and asserts the CommandProcessor folded the stream into a `GpuState`:

- indirect Cx registers (0x10/0x11/0x12) read back from the pointed-to `{offset,value}` array
- index type set
- one `DrawIndexAuto` with the right `index_count`
- `prosper_agc_submit_stats()` submit/draw deltas

It exercises the exact front-half → back-half handoff (Dcb build → PM4 → decode → GpuState) as a regression guard, independent of the (resource-backing-blocked) boot.

Tests **22/22**.

## Context

This is the milestone lock-in for the AGC command frontend, which is now complete (zero unimplemented libSceAgc calls in the boot). The next frontier — `eboot+0xba6e08`, Unity dereferencing a null GPU-backing pointer during resource load — needs the real Vulkan resource layer (M4/M5), which is where the front and back halves meet. Flagging for coordination rather than starting it solo in the back-half's active files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)