### PR TITLE
Fix AGC/SPIR-V review findings

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -50,6 +50,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)
 
+  add_executable(test_agc_shader tests/test_agc_shader.cpp)
+  target_link_libraries(test_agc_shader PRIVATE prosper_core)
+  add_test(NAME agc_shader_create COMMAND test_agc_shader)
+
   add_executable(test_stat tests/test_stat.cpp)
   target_link_libraries(test_stat PRIVATE prosper_core)
   add_test(NAME sce_stat_layout COMMAND test_stat)
@@ -74,6 +78,11 @@ if(TARGET prosper_core)
   add_executable(test_rdna2_decode tests/test_rdna2_decode.cpp)
   target_link_libraries(test_rdna2_decode PRIVATE prosper_core)
   add_test(NAME rdna2_decode_walk COMMAND test_rdna2_decode)
+
+  # Structural RDNA2->SPIR-V validation that does not require Vulkan runtime support.
+  add_executable(test_rdna2_spirv_struct tests/test_rdna2_spirv_struct.cpp)
+  target_link_libraries(test_rdna2_spirv_struct PRIVATE prosper_core)
+  add_test(NAME rdna2_spirv_struct COMMAND test_rdna2_spirv_struct)
 
   # shader_histo: data-driven recompiler-coverage report over the game's real embedded RDNA2 shaders.
   add_executable(shader_histo tools/shader_histo/shader_histo.cpp)

--- a/prosper/src/gpu/gpu_resources.cpp
+++ b/prosper/src/gpu/gpu_resources.cpp
@@ -6,15 +6,17 @@
 // layers the actual VkImage/VkBuffer creation on top in the next increment. Handles are opaque and
 // never recycled within a run, so a stale handle is detectably invalid rather than silently aliased.
 #include "gpu_resources.hpp"
+#include <deque>
 #include <mutex>
-#include <vector>
 
 namespace prosper::gpu {
 
 namespace {
     std::mutex g_mtx;
     // Slot 0 is reserved so handle 0 stays "invalid"; a handle is simply (index into g_res).
-    std::vector<ResourceDesc> g_res = { ResourceDesc{} };
+    // deque keeps existing descriptor addresses stable as new resources are appended; callers hold
+    // resource_get() pointers after the registry lock is released.
+    std::deque<ResourceDesc> g_res = { ResourceDesc{} };
 }
 
 ResourceHandle resource_create(const ResourceDesc& desc) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -136,7 +136,7 @@ struct SpirvCompute {
 
     void begin(uint32_t input_stride) {
         stride = input_stride;
-        t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_v3u = id(); t_bool = id();
+        t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_v3u = id(); t_bool = id();
         uint32_t t_ptr_in_v3u = id(); v_gid = id();
         uint32_t t_rta = id(), t_struct = id(), t_ptr_sb_struct = id();
         v_in = id(); v_out = id(); t_ptr_sb_f32 = id();

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -215,6 +215,12 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
     auto*  code  = (const void*)(uintptr_t)a2;
     if (!dst || !h || !code) return kAgcErrInvalidArg;
 
+    if (h->file_header != 0x34333231u || h->version != 0x18u) {
+        fprintf(stderr, "[agc] CreateShader: unexpected header magic=0x%08x version=0x%x (want '1234'/0x18)\n",
+                h->file_header, h->version);
+        return kAgcErrInvalidArg;   // wrong layout model -- fail loudly rather than corrupt the blob
+    }
+
     if (agc_relocated().insert(h).second) {
         agc_fix_ptr(h->cx_registers);
         agc_fix_ptr(h->sh_registers);
@@ -228,12 +234,6 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
         }
     }
     h->code = code;
-
-    if (h->file_header != 0x34333231u || h->version != 0x18u) {
-        fprintf(stderr, "[agc] CreateShader: unexpected header magic=0x%08x version=0x%x (want '1234'/0x18)\n",
-                h->file_header, h->version);
-        return kAgcErrInvalidArg;   // wrong layout model — fail loudly rather than corrupt the blob
-    }
 
     // Patch the shader-program base into the leading SPI/COMPUTE PGM_LO/HI register pair. The blob
     // pre-seeds the pair's offsets, so match any known stage rather than gating on `type` (Kyty

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -1,0 +1,104 @@
+// test_agc_shader -- focused guards for sceAgcCreateShader's guest-visible side effects.
+#include "../src/hle/dispatch.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+namespace {
+
+constexpr uint64_t kAgcErrInvalidArg = 0x8a6c000aull;
+
+struct ShaderRegister { uint32_t offset, value; };
+struct ShaderUserData {
+    uint16_t* direct_resource_offset;
+    void* sharp_resource_offset[4];
+    uint16_t eud_size_dw, srt_size_dw, direct_resource_count, sharp_resource_count[4];
+};
+struct Shader {
+    uint32_t file_header;
+    uint32_t version;
+    ShaderUserData* user_data;
+    const void* code;
+    ShaderRegister* cx_registers;
+    ShaderRegister* sh_registers;
+    void* specials;
+    void* input_semantics;
+    void* output_semantics;
+    uint32_t header_size;
+    uint32_t shader_size;
+    uint32_t embedded_constant_buffer_size_dqw;
+    uint32_t target;
+    uint32_t num_input_semantics;
+    uint16_t scratch_size_dw_per_thread;
+    uint16_t num_output_semantics;
+    uint16_t special_sizes_bytes;
+    uint8_t type;
+    uint8_t num_cx_registers;
+    uint8_t num_sh_registers;
+};
+
+static_assert(offsetof(Shader, user_data) == 0x08 && offsetof(Shader, code) == 0x10 &&
+              offsetof(Shader, specials) == 0x28 && offsetof(Shader, type) == 0x5a &&
+              offsetof(Shader, num_sh_registers) == 0x5c, "test Shader layout must mirror hle_agc");
+
+int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+} // namespace
+
+extern "C" size_t prosper_agc_shader_count();
+
+int main() {
+    printf("== test_agc_shader ==\n");
+    register_builtin_hle();
+
+    HleFn create_shader = Hle::lookup("f3dg2CSgRKY");
+    CHECK(create_shader != nullptr, "sceAgcCreateShader registered");
+    if (!create_shader) return 1;
+
+    size_t count0 = prosper_agc_shader_count();
+
+    Shader bad{};
+    bad.file_header = 0;
+    bad.version = 0;
+    bad.code = reinterpret_cast<const void*>(0x11111111ull);
+    bad.cx_registers = reinterpret_cast<ShaderRegister*>(0x10ull);
+    bad.sh_registers = reinterpret_cast<ShaderRegister*>(0x20ull);
+    bad.specials = reinterpret_cast<void*>(0x30ull);
+    bad.input_semantics = reinterpret_cast<void*>(0x40ull);
+    bad.output_semantics = reinterpret_cast<void*>(0x50ull);
+
+    Shader* dst = reinterpret_cast<Shader*>(0x12345678ull);
+    uint64_t rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&bad),
+                                0x1000, 0, 0, 0);
+    CHECK(rc == kAgcErrInvalidArg, "invalid shader header is rejected");
+    CHECK(dst == reinterpret_cast<Shader*>(0x12345678ull), "invalid shader does not write *dst");
+    CHECK(bad.code == reinterpret_cast<const void*>(0x11111111ull), "invalid shader does not overwrite code");
+    CHECK(bad.cx_registers == reinterpret_cast<ShaderRegister*>(0x10ull) &&
+          bad.sh_registers == reinterpret_cast<ShaderRegister*>(0x20ull) &&
+          bad.specials == reinterpret_cast<void*>(0x30ull) &&
+          bad.input_semantics == reinterpret_cast<void*>(0x40ull) &&
+          bad.output_semantics == reinterpret_cast<void*>(0x50ull),
+          "invalid shader does not relocate pointer fields");
+    CHECK(prosper_agc_shader_count() == count0, "invalid shader does not enter registry");
+
+    Shader good{};
+    good.file_header = 0x34333231u; // '1234'
+    good.version = 0x18u;
+    good.shader_size = 64;
+    good.type = 1;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&good),
+                       0x2000, 0, 0, 0);
+    CHECK(rc == 0, "valid minimal shader header succeeds");
+    CHECK(dst == &good, "valid shader writes *dst");
+    CHECK(good.code == reinterpret_cast<const void*>(0x2000ull), "valid shader stores code pointer");
+    CHECK(prosper_agc_shader_count() == count0 + 1, "valid shader enters registry");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_gpu_resources.cpp
+++ b/prosper/tests/test_gpu_resources.cpp
@@ -45,6 +45,18 @@ int main() {
     CHECK(resource_get(h_vb + 100) == nullptr && !resource_valid(h_vb + 100),
           "an out-of-range handle is invalid (no silent aliasing)");
 
+    const ResourceDesc* pinned_rt = resource_get(h_rt);
+    for (int i = 0; i < 4096; i++) {
+        ResourceDesc tmp{};
+        tmp.kind = ResourceKind::Buffer;
+        tmp.gpu_addr = 0xE0000000ull + (uint64_t)i * 0x1000u;
+        tmp.size = 256;
+        tmp.usage = Usage_Storage;
+        resource_create(tmp);
+    }
+    CHECK(pinned_rt == resource_get(h_rt) && pinned_rt && pinned_rt->width == 1920,
+          "resource_get pointers remain stable as the registry grows");
+
     resource_reset();
     CHECK(resource_count() == 0 && !resource_valid(h_rt), "reset clears the registry");
 

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1,0 +1,101 @@
+// test_rdna2_spirv_struct -- structural checks for RDNA2->SPIR-V output that do not require Vulkan.
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace prosper::gpu;
+
+namespace {
+
+enum : uint32_t {
+    OpTypeVoid = 19,
+    OpTypeBool = 20,
+    OpTypeInt = 21,
+    OpTypeFloat = 22,
+    OpTypeVector = 23,
+    OpTypeRuntimeArray = 29,
+    OpTypeStruct = 30,
+    OpTypePointer = 32,
+    OpTypeFunction = 33,
+};
+
+bool is_type_decl(uint32_t op) {
+    switch (op) {
+        case OpTypeVoid:
+        case OpTypeBool:
+        case OpTypeInt:
+        case OpTypeFloat:
+        case OpTypeVector:
+        case OpTypeRuntimeArray:
+        case OpTypeStruct:
+        case OpTypePointer:
+        case OpTypeFunction:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool type_result_ids_are_nonzero(const std::vector<uint32_t>& spv, uint32_t* bad_op) {
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        uint32_t word = spv[i];
+        uint32_t op = word & 0xffffu;
+        uint32_t wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (is_type_decl(op) && (wc < 2 || spv[i + 1] == 0)) {
+            if (bad_op) *bad_op = op;
+            return false;
+        }
+        i += wc;
+    }
+    return true;
+}
+
+bool has_signed_i32_type(const std::vector<uint32_t>& spv) {
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        uint32_t word = spv[i];
+        uint32_t op = word & 0xffffu;
+        uint32_t wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == OpTypeInt && wc == 4 && spv[i + 1] != 0 && spv[i + 2] == 32 && spv[i + 3] == 1)
+            return true;
+        i += wc;
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    printf("== test_rdna2_spirv_struct ==\n");
+
+    // Uses signed convert/min/max/ashr, which requires a valid signed i32 type declaration.
+    const uint32_t signed_kernel[] = {
+        0x7E001100u, 0x7E021101u, 0x7E041102u, 0x22060300u, 0x24080300u,
+        0x4C060704u, 0x30060702u, 0x7E000B03u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv = recompile_valu(signed_kernel, sizeof(signed_kernel) / sizeof(signed_kernel[0]), 3, 0);
+    if (spv.empty()) {
+        printf("  [FAIL] signed kernel did not recompile\n");
+        return 1;
+    }
+
+    uint32_t bad_op = 0;
+    if (!type_result_ids_are_nonzero(spv, &bad_op)) {
+        printf("  [FAIL] SPIR-V type declaration has invalid result id (op=%u)\n", bad_op);
+        return 1;
+    }
+    printf("  [ok]   SPIR-V type declaration result ids are nonzero\n");
+
+    if (!has_signed_i32_type(spv)) {
+        printf("  [FAIL] signed kernel SPIR-V lacks a nonzero signed i32 type\n");
+        return 1;
+    }
+    printf("  [ok]   signed kernel SPIR-V declares signed i32 with a nonzero id\n");
+
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/shader_histo/shader_histo.cpp
+++ b/prosper/tools/shader_histo/shader_histo.cpp
@@ -29,6 +29,10 @@ int main(int argc, char** argv) {
     int shaders = 0; size_t total = 0, unknown = 0, maxsz = 0;
     for (size_t i = 0; i + 64 < f.size(); i++) {
         if (!(f[i] == 0x7f && f[i+1] == 'E' && f[i+2] == 'L' && f[i+3] == 'F')) continue;
+        auto inside = [&](uint64_t off, uint64_t len) {
+            uint64_t avail = (uint64_t)(f.size() - i);
+            return off <= avail && len <= avail - off;
+        };
         uint16_t machine; memcpy(&machine, &f[i+18], 2);
         if (machine != 0xE0) continue;                       // EM_AMDGPU
         const uint8_t* e = &f[i];
@@ -36,15 +40,19 @@ int main(int argc, char** argv) {
         uint16_t shentsize; memcpy(&shentsize, e+0x3A, 2);
         uint16_t shnum; memcpy(&shnum, e+0x3C, 2);
         uint16_t shstrndx; memcpy(&shstrndx, e+0x3E, 2);
-        if (!shoff || !shnum || shstrndx >= shnum || i + shoff + (size_t)shnum*shentsize > f.size()) continue;
-        uint64_t shstr_off; memcpy(&shstr_off, e + shoff + (size_t)shstrndx*shentsize + 0x18, 8);
+        if (!shoff || !shnum || shstrndx >= shnum || shentsize < 0x40 ||
+            !inside(shoff, (uint64_t)shnum * shentsize)) continue;
+        const uint8_t* shstr = e + shoff + (size_t)shstrndx * shentsize;
+        uint64_t shstr_off, shstr_size; memcpy(&shstr_off, shstr + 0x18, 8); memcpy(&shstr_size, shstr + 0x20, 8);
+        if (!inside(shstr_off, shstr_size)) continue;
         for (int s = 0; s < shnum; s++) {
             const uint8_t* sh = e + shoff + (size_t)s*shentsize;
             uint32_t noff; memcpy(&noff, sh, 4);
+            if ((uint64_t)noff + 12 > shstr_size) continue;
             const char* name = (const char*)(e + shstr_off + noff);
-            if (i + shstr_off + noff >= f.size() || strncmp(name, ".shader_text", 12) != 0) continue;
+            if (strncmp(name, ".shader_text", 12) != 0) continue;
             uint64_t so, sz; memcpy(&so, sh+0x18, 8); memcpy(&sz, sh+0x20, 8);
-            if (sz < 4 || i + so + sz > f.size()) continue;
+            if (sz < 4 || !inside(so, sz)) continue;
             const uint32_t* code = (const uint32_t*)(e + so);
             if (argc > 2 && sz > maxsz) { maxsz = sz; if (FILE* d = fopen(argv[2], "wb")) { fwrite(code, 1, sz, d); fclose(d); } }
             std::vector<Rdna2Inst> ins; rdna2_walk(code, sz/4, ins);


### PR DESCRIPTION
## Summary
- assign the missing signed i32 SPIR-V type id in the RDNA2 compute shell and add a non-Vulkan structural regression test
- validate AGC shader headers before relocating/writing guest-visible fields, with a focused CreateShader side-effect test
- keep GPU resource descriptor pointers stable across registry growth
- harden shader_histo embedded-ELF bounds checks before reading section/string data

## Validation
- WSL/Linux: cmake --build prosper/build-wsl-codex
- WSL/Linux: ctest --output-on-failure (25/25 passed)

Note: the MinGW build still fails in pre-existing Windows stat portability code (hle_file.cpp/test_stat.cpp), before these changes are reached.