### PR TITLE
diag(RE): 0xba6e08 is a Unity pipeline object — resource-creation premise needs revisiting

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -100,6 +100,44 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - Graphics libs are sparsely documented; most NIDs don't resolve to names — reverse-engineer from
   call args (`PROSPER_GFXLOG`) and `build-linux/tools/pltm` (maps a module GOT offset → NID).
 
+## ⚠ RE UPDATE (2026-07-04): the 0xba6e08 object is a Unity PIPELINE object, and NO resource-creation call feeds [+0x140]
+
+Investigating the resource-layer integration (gpu_resources.hpp contract) turned up evidence that
+**contradicts the "hook one AGC resource-creation NID → store handle at [obj+0x140]" plan** — flagging
+for the back-half agent before writing integration code (per "flag it rather than edit silently").
+
+Findings (via the multi-spec/deref `PROSPER_PEEK`, see below):
+- **No AGC/Gnm resource-creation call fires before the fault.** The complete graphics-call set in the
+  run is register setup (`23LRUSvYu1M`/`BfBDZGbti7A`/`H7uZqCoNuWk`/register-indirect triplets), the
+  register-context builders (now implemented), and `Zw7uUVPulbw`. The only unimplemented graphics
+  calls at fault are 5 pre-graphics `libSceVideoOut` queries. There is no texture/buffer/`createResource`
+  call with a `(gpu_addr, size, width, height, format)` shape anywhere in the trace.
+- **`Zw7uUVPulbw` is a red herring** — disassembly of its consumer (`eboot+0x14dfb04`) shows a
+  GPU-timing/profiler loop (computes frametimes: `×0xf4240`, reciprocal-divide, `vcvtsi2ss`→float,
+  stored to a ring at `rbx+0xc40`). It does not gate resource upload.
+- **The fault object is a Unity pipeline/material object, not a texture/buffer.** `PROSPER_PEEK` of the
+  faulting `r15` (`0x…e2c300`, game-heap): `[+0]=0x2b`, `[+8]=0xf`, `[+0x20]=7`, `[+0x28]=0x19`,
+  `[+0x18]==[+0x40]`→ a shared sub-object holding **packed register-like fields** (`[+0x10]=0x28a7…000e`,
+  `[+0x18]=0xbba2…002b`). `[+0x140]` (the GPU-backing companion, deref'd as `[+0x08]`/`[+0x40]` byte)
+  is null; `[+0x520]/[+0x530]` (an array ptr/count) are 0. It sits in a **3-element collection**
+  (outer `rbx`: array@`+0x78`, count@`+0x88`=3).
+- The deref is **residency-gated**: `0xba6e08` is reached only for resources whose remapped type is in
+  mask `bt 0xc8220` (specific formats) AND whose flag `[+0x1a0]==0` ("not resident"). So this is a
+  GPU-residency check that assumes an upload/creation step already populated `[+0x140]`.
+
+**Interpretation:** Unity's resource-upload/creation path (which on PS5 would allocate GPU memory +
+build a descriptor and set `[+0x140]`) either never ran or was no-op'd by our stubs — but it is *not*
+a direct game→AGC `createResource` call we can hook. Populating `[+0x140]` with a fabricated handle to
+"advance the boot" would be a correctness-first violation (a fake that moves the fault deeper).
+**Proposed next step (needs back-half input):** trace Unity's texture/pipeline upload path to find the
+real creation site (likely built from the shader/pipeline AGC calls already implemented +
+direct-memory allocation), then wire `resource_create()` there. The `ResourceDesc` contract looks
+right for the *eventual* texture case; this specific object is a pipeline object whose companion may
+warrant a distinct `ResourceKind`. Left unresolved pending that trace rather than guess-fabricated.
+
+Tooling: `PROSPER_PEEK` now takes multiple `;`-separated specs and a `*pre+off` one-level pointer
+chase (`[[reg+pre]+off]`), for classifying linked object graphs at fault time.
+
 ## ▶ NEXT FRONTIER (2026-07-04): past all AGC HLE → Unity GPU-resource residency (needs real backing)
 
 After CreateShader + the CommandProcessor submit path (below), the boot advances through the entire

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -55,9 +55,12 @@ namespace {
     bool g_faultmem = false;
     bool g_faultlog = false;
     int  g_devnull_fd = -1;
-    const char* g_peek_reg = nullptr;   // register name for PROSPER_PEEK (e.g. "r15")
-    uint64_t g_peek_off[16] = {0};      // offsets to read off that register at fault time
-    int      g_peek_n = 0;
+    // PROSPER_PEEK dumps offsets off registers at fault time. Supports N specs separated by ';',
+    // each "reg:off,off,..."; an offset may be prefixed '*' to chase one pointer level first
+    // (e.g. "r15:*0x18+0x0" = read [[r15+0x18]+0x0]).
+    struct PeekSpec { char reg[4]; uint64_t off[12]; bool deref[12]; uint64_t pre[12]; int n; };
+    PeekSpec g_peek[6] = {};
+    int      g_peek_specs = 0;
 
     // Async-signal-safe readability probe: write() to /dev/null returns EFAULT (not a fault) for
     // an unmapped source, so we can test guest addresses without risking a nested SIGSEGV.
@@ -95,21 +98,31 @@ namespace {
                          r.n, (unsigned long long)r.v, part[0], part[1], part[2], part[3]);
             write(2, b, n);
         }
-        // Deep field peek (PROSPER_PEEK="rN:0xoff,0xoff,..."): read specific offsets off one register
-        // to classify a large object beyond the 0x20-byte window above. Env is parsed once at arm
-        // time into g_peek_* (getenv is not signal-safe). Values are read at fault time.
-        if (g_peek_reg) {
+        // Deep field peek (PROSPER_PEEK, parsed once at arm time — getenv is not signal-safe): read
+        // specific offsets off one or more registers to classify a large object beyond the 0x20-byte
+        // window above. See g_peek definition for the syntax.
+        for (int sp = 0; sp < g_peek_specs; sp++) {
+            const PeekSpec& ps = g_peek[sp];
             uint64_t base = 0;
-            for (auto& r : regs) { bool m = true; for (int i=0;i<3;i++) if (r.n[i]!=g_peek_reg[i]&&!(r.n[i]==' '&&g_peek_reg[i]==0)) { m=false; break; } if (m) { base=r.v; break; } }
-            n = snprintf(b, sizeof b, "  PEEK %s=0x%llx:\n", g_peek_reg, (unsigned long long)base);
+            for (auto& r : regs) { bool m = true; for (int i=0;i<3;i++) if (r.n[i]!=ps.reg[i]&&!(r.n[i]==' '&&ps.reg[i]==0)) { m=false; break; } if (m) { base=r.v; break; } }
+            n = snprintf(b, sizeof b, "  PEEK %s=0x%llx:\n", ps.reg, (unsigned long long)base);
             write(2, b, n);
-            for (int k = 0; k < g_peek_n; k++) {
-                uint64_t addr = base + g_peek_off[k];
+            for (int k = 0; k < ps.n; k++) {
+                uint64_t obj = base;
+                if (ps.deref[k]) {   // chase one pointer level: obj = [base + pre]
+                    uint64_t pa = base + ps.pre[k];
+                    if (!probe_readable(pa)) { n = snprintf(b, sizeof b, "    [+0x%llx]-><unmapped>\n", (unsigned long long)ps.pre[k]); write(2,b,n); continue; }
+                    obj = *(const uint64_t*)pa;
+                }
+                uint64_t addr = obj + ps.off[k];
+                const char* pfx = ps.deref[k] ? "*" : "";
                 if (probe_readable(addr))
-                    n = snprintf(b, sizeof b, "    [+0x%llx] = 0x%llx\n",
-                                 (unsigned long long)g_peek_off[k], (unsigned long long)*(const uint64_t*)addr);
+                    n = snprintf(b, sizeof b, "    %s[+0x%llx]@+0x%llx = 0x%llx\n", pfx,
+                                 (unsigned long long)ps.pre[k], (unsigned long long)ps.off[k],
+                                 (unsigned long long)*(const uint64_t*)addr);
                 else
-                    n = snprintf(b, sizeof b, "    [+0x%llx] = <unmapped>\n", (unsigned long long)g_peek_off[k]);
+                    n = snprintf(b, sizeof b, "    %s[+0x%llx]@+0x%llx = <unmapped>\n", pfx,
+                                 (unsigned long long)ps.pre[k], (unsigned long long)ps.off[k]);
                 write(2, b, n);
             }
         }
@@ -255,16 +268,29 @@ void install_trap_handler() {
     g_faultlog = getenv("PROSPER_FAULTLOG") != nullptr;
     if (g_faultmem && g_devnull_fd < 0)
         g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
-    // PROSPER_PEEK="r15:0x140,0x1a0,0x1e4c" — parse the register + offsets once (signal-safe at fault).
+    // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
+    // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).
     if (const char* pk = getenv("PROSPER_PEEK")) {
-        static char reg[4] = {0};
-        const char* colon = strchr(pk, ':');
-        if (colon && colon - pk <= 3) {
-            for (const char* c = pk; c < colon; c++) reg[c - pk] = *c;
-            g_peek_reg = reg;
-            const char* s = colon + 1;
-            while (*s && g_peek_n < 16) { g_peek_off[g_peek_n++] = strtoull(s, nullptr, 0);
-                const char* comma = strchr(s, ','); if (!comma) break; s = comma + 1; }
+        const char* spec = pk;
+        while (*spec && g_peek_specs < 6) {
+            const char* semi = strchr(spec, ';');
+            const char* end  = semi ? semi : spec + strlen(spec);
+            const char* colon = strchr(spec, ':');
+            if (colon && colon < end && colon - spec <= 3) {
+                PeekSpec& ps = g_peek[g_peek_specs++];
+                for (const char* c = spec; c < colon; c++) ps.reg[c - spec] = *c;
+                const char* s = colon + 1;
+                while (s < end && ps.n < 12) {
+                    if (*s == '*') { ps.deref[ps.n] = true; s++;
+                        ps.pre[ps.n] = strtoull(s, nullptr, 0);
+                        const char* plus = strchr(s, '+');
+                        ps.off[ps.n] = (plus && plus < end) ? strtoull(plus + 1, nullptr, 0) : 0;
+                    } else ps.off[ps.n] = strtoull(s, nullptr, 0);
+                    ps.n++;
+                    const char* comma = strchr(s, ','); if (!comma || comma >= end) break; s = comma + 1;
+                }
+            }
+            if (!semi) break; spec = semi + 1;
         }
     }
     install_sigaltstack();


### PR DESCRIPTION
**Flagging before writing integration code** (per your "flag it rather than edit silently" — this is bigger than a ResourceDesc field mismatch). Your resource-layer contract (gpu_resources.hpp) is landed and looks right; the issue is *where* to call it.

## The task assumed an AGC resource-creation NID populates `[obj+0x140]`. The evidence says otherwise.

Using the multi-spec/deref `PROSPER_PEEK` (added here), I traced the `0xba6e08` object and the call sequence:

1. **No AGC/Gnm resource-creation call fires before the fault.** The complete graphics-call set in the run is register/context setup (`23LRUSvYu1M`, `BfBDZGbti7A`, `H7uZqCoNuWk`, the register-indirect triplets) + the register-context builders (implemented) + `Zw7uUVPulbw`. The only unimplemented graphics calls at fault are 5 pre-graphics `libSceVideoOut` queries. **There is no `(gpu_addr, size, width, height, format)`-shaped create call anywhere in the trace.**

2. **`Zw7uUVPulbw` is a red herring** (I suspected it gated resource upload — it doesn't). Its consumer at `eboot+0x14dfb04` is a GPU-timing/profiler loop: computes frametimes (`×0xf4240`, reciprocal-divide, `vcvtsi2ss`→float) into a ring at `rbx+0xc40`.

3. **The fault object is a Unity pipeline/material object, not a texture/buffer.** `r15` (game-heap): `[+0]=0x2b`, `[+0x20]=7`, `[+0x28]=0x19`; `[+0x18]==[+0x40]` → a shared sub-object holding **packed register-like fields** (`[+0x10]=0x28a7…000e`, `[+0x18]=0xbba2…002b`). `[+0x140]` (the GPU companion, deref'd as `[+8]`) is null; `[+0x520]/[+0x530]` (array ptr/count) are 0. It's in a **3-element collection** (outer `rbx`: array@`+0x78`, count@`+0x88`=3).

4. **The deref is residency-gated:** `0xba6e08` is only reached for resources whose remapped type is in mask `bt 0xc8220` AND whose flag `[+0x1a0]==0` ("not resident"). So it assumes an upload/creation step already set `[+0x140]`.

## Interpretation + proposed next step

Unity's resource-upload path (which on PS5 allocates GPU memory + builds a descriptor and sets `[+0x140]`) either never ran or was no-op'd — but it's **not a direct game→AGC `createResource` call I can hook.** Fabricating a `[+0x140]` handle to advance the boot would violate correctness-first (moves the fault deeper).

**I think the real creation site is built from the shader/pipeline AGC calls already implemented (CreateShader/CreatePrimState) + direct-memory allocation, inside Unity's own resource manager.** Finding it needs a trace of Unity's texture/pipeline upload path. Two questions for you:
- Does your Vulkan resource model expect a distinct `ResourceKind` for pipeline/program objects (vs the Buffer/Texture2D/RenderTarget in the contract)? This `r15` is pipeline-shaped.
- Want me to keep tracing the upload path to the creation site (front-half RE), or do you want to drive the resource lifecycle from the back-half side given it's entangled with your GPU-memory model?

## This PR contains

- **No fabricated resource code** — just the RE findings written into `docs/GRAPHICS.md` so we align on the mechanism.
- **`PROSPER_PEEK` upgrade**: multiple `;`-separated specs + a `*pre+off` one-level pointer chase (`[[reg+pre]+off]`), for classifying linked object graphs at fault time.

23/23 tests. Don't merge if you'd rather fold the doc into your own understanding — the substance is the findings, not the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)