### PR TITLE
Improve MinGW Windows portability

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -50,6 +50,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)
 
+  add_executable(test_sync_on_address tests/test_sync_on_address.cpp)
+  target_link_libraries(test_sync_on_address PRIVATE prosper_core)
+  add_test(NAME sync_on_address COMMAND test_sync_on_address)
+
   add_executable(test_agc_shader tests/test_agc_shader.cpp)
   target_link_libraries(test_agc_shader PRIVATE prosper_core)
   add_test(NAME agc_shader_create COMMAND test_agc_shader)

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -13,6 +13,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
+#include <direct.h>
 #include <io.h>
 #endif
 
@@ -35,6 +36,78 @@ namespace {
         if (filelog()) fprintf(stderr, "[file] open '%s' -> '%s'\n", guest, h.c_str());
         return h;
     }
+
+    struct HostStat {
+        uint32_t dev = 0, ino = 0, mode = 0, nlink = 0, uid = 0, gid = 0, rdev = 0;
+        int64_t atime_sec = 0, atime_nsec = 0;
+        int64_t mtime_sec = 0, mtime_nsec = 0;
+        int64_t ctime_sec = 0, ctime_nsec = 0;
+        int64_t size = 0, blocks = 0;
+        uint32_t blksize = 0;
+    };
+
+    int64_t blocks_512_for_size(int64_t size) {
+        return size > 0 ? (size + 511) / 512 : 0;
+    }
+
+    void write_sce_stat(const HostStat& s, uint8_t* out) {
+        memset(out, 0, 0x78);
+        *(uint32_t*)(out + 0x00) = s.dev;
+        *(uint32_t*)(out + 0x04) = s.ino;
+        *(uint16_t*)(out + 0x08) = (uint16_t)s.mode;    // type+perm bits match Linux/MinGW
+        *(uint16_t*)(out + 0x0a) = (uint16_t)s.nlink;
+        *(uint32_t*)(out + 0x0c) = s.uid;
+        *(uint32_t*)(out + 0x10) = s.gid;
+        *(uint32_t*)(out + 0x14) = s.rdev;
+        *(int64_t*)(out + 0x18)  = s.atime_sec; *(int64_t*)(out + 0x20) = s.atime_nsec;
+        *(int64_t*)(out + 0x28)  = s.mtime_sec; *(int64_t*)(out + 0x30) = s.mtime_nsec;
+        *(int64_t*)(out + 0x38)  = s.ctime_sec; *(int64_t*)(out + 0x40) = s.ctime_nsec;
+        *(int64_t*)(out + 0x48)  = s.size;
+        *(int64_t*)(out + 0x50)  = s.blocks;
+        *(uint32_t*)(out + 0x58) = s.blksize;
+    }
+
+#ifndef _WIN32
+    HostStat from_host_stat(const struct stat& s) {
+        HostStat h;
+        h.dev = (uint32_t)s.st_dev; h.ino = (uint32_t)s.st_ino; h.mode = (uint32_t)s.st_mode;
+        h.nlink = (uint32_t)s.st_nlink; h.uid = (uint32_t)s.st_uid; h.gid = (uint32_t)s.st_gid;
+        h.rdev = (uint32_t)s.st_rdev;
+        h.atime_sec = s.st_atim.tv_sec; h.atime_nsec = s.st_atim.tv_nsec;
+        h.mtime_sec = s.st_mtim.tv_sec; h.mtime_nsec = s.st_mtim.tv_nsec;
+        h.ctime_sec = s.st_ctim.tv_sec; h.ctime_nsec = s.st_ctim.tv_nsec;
+        h.size = (int64_t)s.st_size; h.blocks = (int64_t)s.st_blocks; h.blksize = (uint32_t)s.st_blksize;
+        return h;
+    }
+#else
+    HostStat from_host_stat(const struct stat& s) {
+        HostStat h;
+        h.dev = (uint32_t)s.st_dev; h.ino = (uint32_t)s.st_ino; h.mode = (uint32_t)s.st_mode;
+        h.nlink = (uint32_t)s.st_nlink; h.uid = (uint32_t)s.st_uid; h.gid = (uint32_t)s.st_gid;
+        h.rdev = (uint32_t)s.st_rdev;
+        h.atime_sec = (int64_t)s.st_atime;
+        h.mtime_sec = (int64_t)s.st_mtime;
+        h.ctime_sec = (int64_t)s.st_ctime;
+        h.size = (int64_t)s.st_size;
+        h.blocks = blocks_512_for_size(h.size);
+        h.blksize = 4096;
+        return h;
+    }
+
+    HostStat from_host_stat(const struct _stat64& s) {
+        HostStat h;
+        h.dev = (uint32_t)s.st_dev; h.ino = (uint32_t)s.st_ino; h.mode = (uint32_t)s.st_mode;
+        h.nlink = (uint32_t)s.st_nlink; h.uid = (uint32_t)s.st_uid; h.gid = (uint32_t)s.st_gid;
+        h.rdev = (uint32_t)s.st_rdev;
+        h.atime_sec = (int64_t)s.st_atime;
+        h.mtime_sec = (int64_t)s.st_mtime;
+        h.ctime_sec = (int64_t)s.st_ctime;
+        h.size = (int64_t)s.st_size;
+        h.blocks = blocks_512_for_size(h.size);
+        h.blksize = 4096;
+        return h;
+    }
+#endif
 }
 
 void set_app0_root(const std::string& root) { g_app0 = root; }
@@ -47,21 +120,13 @@ void set_app0_root(const std::string& root) { g_app0 = root; }
 // Exposed (not file-local) so tests can guard the layout — writing the wrong size/offsets here
 // once smashed a guest stack canary (st_size must land at 0x48, st_mode at 0x08, total 0x78).
 void to_sce_stat(const struct stat& s, uint8_t* out) {
-        memset(out, 0, 0x78);
-        *(uint32_t*)(out + 0x00) = (uint32_t)s.st_dev;
-        *(uint32_t*)(out + 0x04) = (uint32_t)s.st_ino;
-        *(uint16_t*)(out + 0x08) = (uint16_t)s.st_mode;    // type+perm bits match Linux
-        *(uint16_t*)(out + 0x0a) = (uint16_t)s.st_nlink;
-        *(uint32_t*)(out + 0x0c) = (uint32_t)s.st_uid;
-        *(uint32_t*)(out + 0x10) = (uint32_t)s.st_gid;
-        *(uint32_t*)(out + 0x14) = (uint32_t)s.st_rdev;
-        *(int64_t*)(out + 0x18)  = s.st_atim.tv_sec; *(int64_t*)(out + 0x20) = s.st_atim.tv_nsec;
-        *(int64_t*)(out + 0x28)  = s.st_mtim.tv_sec; *(int64_t*)(out + 0x30) = s.st_mtim.tv_nsec;
-        *(int64_t*)(out + 0x38)  = s.st_ctim.tv_sec; *(int64_t*)(out + 0x40) = s.st_ctim.tv_nsec;
-        *(int64_t*)(out + 0x48)  = s.st_size;
-        *(int64_t*)(out + 0x50)  = s.st_blocks;
-        *(uint32_t*)(out + 0x58) = (uint32_t)s.st_blksize;
+    write_sce_stat(from_host_stat(s), out);
 }
+#ifdef _WIN32
+void to_sce_stat64(const struct _stat64& s, uint8_t* out) {
+    write_sce_stat(from_host_stat(s), out);
+}
+#endif
 
 // --- stdio FILE* ---
 HLE(f_fopen)   { std::string h = translate(CS(a0)); return (uint64_t)(uintptr_t)fopen(h.c_str(), CS(a1)); }
@@ -91,8 +156,13 @@ HLE(f_pwrite) { return (uint64_t)(int64_t)::pwrite((int)a0, P(a1), (size_t)a2, (
 HLE(f_pread)  { return (uint64_t)-1; }
 HLE(f_pwrite) { return (uint64_t)-1; }
 #endif
+#ifndef _WIN32
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct stat st; int r = ::stat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+#else
+HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+HLE(f_fstat) { struct _stat64 st; int r = ::_fstat64((int)a0, &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+#endif
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -255,5 +255,44 @@ void register_kernel_mem_hle() {
 } // namespace prosper
 
 #else
-namespace prosper { void register_kernel_mem_hle() {} }
+#include <atomic>
+#include <climits>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+namespace prosper {
+
+#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5)
+
+namespace {
+std::mutex g_sync_mx;
+std::condition_variable g_sync_cv;
+}
+
+HLE(k_wait_on_address) {
+    if (!a0) return 0;
+    auto& raw = *(uint32_t*)(uintptr_t)a0;
+    std::atomic_ref<uint32_t> addr(raw);
+    uint32_t expected = (uint32_t)a1;
+    std::unique_lock<std::mutex> lk(g_sync_mx);
+    while (addr.load(std::memory_order_acquire) == expected) g_sync_cv.wait(lk);
+    return 0;
+}
+
+HLE(k_wake_by_address) {
+    std::lock_guard<std::mutex> lk(g_sync_mx);
+    int n = a1 ? (int)a1 : INT_MAX;
+    if (n == 1) g_sync_cv.notify_one();
+    else        g_sync_cv.notify_all();
+    return 0;
+}
+
+void register_kernel_mem_hle() {
+    Hle::register_fn("Hc4CaR6JBL0", (HleFn)k_wait_on_address, "sceKernelWaitOnAddress?");
+    Hle::register_fn("q2y-wDIVWZA", (HleFn)k_wake_by_address, "sceKernelWakeByAddress?");
+}
+
+} // namespace prosper
 #endif

--- a/prosper/tests/test_stat.cpp
+++ b/prosper/tests/test_stat.cpp
@@ -5,8 +5,14 @@
 #include <cstdint>
 #include <cstring>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <io.h>
+#endif
 
 namespace prosper { void to_sce_stat(const struct stat& s, uint8_t* out); }
+#ifdef _WIN32
+namespace prosper { void to_sce_stat64(const struct _stat64& s, uint8_t* out); }
+#endif
 
 static int fails = 0;
 #define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
@@ -14,23 +20,40 @@ static int fails = 0;
 
 int main() {
     printf("== test_stat ==\n");
+#ifndef _WIN32
     struct stat s; memset(&s, 0, sizeof s);
     s.st_mode  = S_IFREG | 0644;   // regular file, rw-r--r--
     s.st_size  = 0x123456789ULL;   // a >32-bit size to catch truncation/misplacement
     s.st_nlink = 1;
     s.st_blocks = 42;
     s.st_blksize = 4096;
+#else
+    struct _stat64 s; memset(&s, 0, sizeof s);
+    s.st_mode  = S_IFREG | 0644;   // regular file, rw-r--r--
+    s.st_size  = 0x123456789LL;    // a >32-bit size to catch truncation/misplacement
+    s.st_nlink = 1;
+#endif
 
     // Write into a canary-guarded buffer: 0x78 payload + a sentinel that must remain intact.
     uint8_t buf[0x80];
     memset(buf, 0xAB, sizeof buf);
     const uint8_t SENT = 0xAB;
+#ifndef _WIN32
     prosper::to_sce_stat(s, buf);
+#else
+    prosper::to_sce_stat64(s, buf);
+#endif
 
     CHECK(*(uint16_t*)(buf + 0x08) == (uint16_t)(S_IFREG | 0644), "st_mode at 0x08 (16-bit)");
     CHECK(*(int64_t*)(buf + 0x48)  == (int64_t)0x123456789ULL,   "st_size at 0x48 (full 64-bit, no truncation)");
+#ifndef _WIN32
     CHECK(*(int64_t*)(buf + 0x50)  == 42,                        "st_blocks at 0x50");
     CHECK(*(uint32_t*)(buf + 0x58) == 4096,                      "st_blksize at 0x58");
+#else
+    CHECK(*(int64_t*)(buf + 0x50)  == ((int64_t)0x123456789LL + 511) / 512,
+          "st_blocks at 0x50 synthesized from 64-bit size");
+    CHECK(*(uint32_t*)(buf + 0x58) == 4096,                      "st_blksize at 0x58 synthesized");
+#endif
     // Nothing past the documented 0x78 was touched (no canary smash).
     bool clean = true; for (int i = 0x78; i < 0x80; i++) if (buf[i] != SENT) clean = false;
     CHECK(clean, "no write past 0x78 (stack canary safe)");

--- a/prosper/tests/test_sync_on_address.cpp
+++ b/prosper/tests/test_sync_on_address.cpp
@@ -1,0 +1,52 @@
+// test_sync_on_address -- basic behavior for the raw wait/wake-by-address HLE NIDs.
+#include "../src/hle/dispatch.hpp"
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    printf("== test_sync_on_address ==\n");
+    register_builtin_hle();
+
+    HleFn wait = Hle::lookup("Hc4CaR6JBL0");
+    HleFn wake = Hle::lookup("q2y-wDIVWZA");
+    CHECK(wait && wake, "wait/wake-by-address NIDs registered");
+    if (!wait || !wake) return 1;
+
+    alignas(4) uint32_t word = 2;
+    std::atomic_ref<uint32_t> word_atomic(word);
+    wait((uint64_t)(uintptr_t)&word, 1, 0, 0, 0, 0);
+    CHECK(word_atomic.load(std::memory_order_acquire) == 2, "wait returns immediately when value does not match expected");
+
+    word_atomic.store(1, std::memory_order_release);
+    std::atomic<bool> started{false};
+    std::atomic<bool> done{false};
+    std::thread waiter([&] {
+        started.store(true, std::memory_order_release);
+        wait((uint64_t)(uintptr_t)&word, 1, 0, 0, 0, 0);
+        done.store(true, std::memory_order_release);
+    });
+
+    while (!started.load(std::memory_order_acquire))
+        std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    CHECK(!done.load(std::memory_order_acquire), "wait blocks while value matches expected");
+
+    word_atomic.store(2, std::memory_order_release);
+    wake((uint64_t)(uintptr_t)&word, 1, 0, 0, 0, 0);
+    for (int i = 0; i < 100 && !done.load(std::memory_order_acquire); i++)
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    CHECK(done.load(std::memory_order_acquire), "wake releases a waiter after the value changes");
+    waiter.join();
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- translate host stat data through a platform-neutral shape so MinGW can build without Linux-only st_atim/st_blocks fields
- use _stat64/_fstat64 for Windows file HLE so SceKernelStat keeps 64-bit file sizes
- register a portable wait/wake-by-address fallback on non-Linux hosts
- add a cross-platform sync_on_address behavior test and extend stat layout coverage for Windows

## Validation
- Windows/MinGW: cmake -S prosper -B prosper/build-win-codex -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGAME_DUMP=C:/Users/matti/repos/ps5ys/PPSA24651-app0
- Windows/MinGW: cmake --build prosper/build-win-codex
- Windows/MinGW: ctest --test-dir prosper/build-win-codex --output-on-failure (12/12 passed)
- WSL2/Linux: cmake -S prosper -B prosper/build-wsl-codex -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGAME_DUMP=/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0
- WSL2/Linux: cmake --build prosper/build-wsl-codex
- WSL2/Linux: ctest --output-on-failure (26/26 passed)
