### PR TITLE
diag(RE): bounded trace answer — 0xba6e08 pipeline object is Unity-internal (no HLE hook)

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -100,6 +100,28 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - Graphics libs are sparsely documented; most NIDs don't resolve to names — reverse-engineer from
   call args (`PROSPER_GFXLOG`) and `build-linux/tools/pltm` (maps a module GOT offset → NID).
 
+## ✔ BOUNDED TRACE ANSWER (2026-07-04): the pipeline object is Unity-INTERNAL — no HLE hook exists
+
+Back-half asked one bounded question: does the fault object `r15` (or its `[+0x18]`/`[+0x40]`
+packed-register sub-object) ever appear as an arg / return / write of any AGC call we implement
+(`CreateShader`, `CreatePrimState`, `CreateInterpolantMapping`, or the register-context builders)?
+
+**Answer: NO.** Logged every construction call's pointer args (`PROSPER_PIPETRACE`) and diffed against
+the fault object in the same run (`r15=0x7d622562c300`, sub-object `0x7d62256120f0`):
+- `CreateShader` (×36+): header/code blobs live in `0x7d6252dc…`; `*dst` writes into the eboot BSS
+  shader registry (`0x402048…`) or a stack slot — never `r15`'s heap region.
+- `CreatePrimState` / `CreateInterpolantMapping`: write register `{offset,value}` pairs into **stack
+  scratch** (`a0/a1 = 0x7d6255dfb…`); shaders are `0x7d6252dc…`.
+- The only `0x7d6225…`-region pointers logged are the AGC context (`…5cb378`) and register-context
+  builder args — none in `r15`'s (`…62c300`) or the sub-object's (`…6120f0`) region.
+
+So the register *content* originates from our calls (Unity harvests it into stack scratch), but the
+**pipeline object and its `[+0x140]` GPU companion are constructed by Unity's own resource manager** —
+there is no game→AGC call that takes/returns/writes them, hence no front-half HLE hook. Per the
+back-half's decision tree, pipeline residency will be intercepted at the GpuState/register-context
+stage in the back-half; the front-half is off the hook for this object. `PROSPER_PIPETRACE` (logs the
+raw pointer args of the shader/pipeline construction calls) is retained for future seams.
+
 ## ⚠ RE UPDATE (2026-07-04): the 0xba6e08 object is a Unity PIPELINE object, and NO resource-creation call feeds [+0x140]
 
 Investigating the resource-layer integration (gpu_resources.hpp contract) turned up evidence that

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -209,7 +209,18 @@ template <class T> inline void agc_fix_ptr(T*& m) {
 // Exposed for tests: how many shaders the guest successfully registered.
 extern "C" size_t prosper_agc_shader_count() { return agc_shaders().size(); }
 
+// Bounded RE probe (PROSPER_PIPETRACE): log the raw pointer args of the shader/pipeline construction
+// calls, so their argument/return pointers can be diffed against a later fault object (e.g. the
+// eboot+0xba6e08 pipeline object's [+0x140] companion). Purely observational.
+static void pipetrace(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
+    if (getenv("PROSPER_PIPETRACE"))
+        fprintf(stderr, "[pipe] %s a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n", fn,
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+}
+
 HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
+    pipetrace("CreateShader", a0, a1, a2, a3, a4, a5);
     auto** dst   = (AgcShader**)(uintptr_t)a0;
     auto*  h     = (AgcShader*)(uintptr_t)a1;
     auto*  code  = (const void*)(uintptr_t)a2;
@@ -339,6 +350,7 @@ HLE(agc_cb_set_sh_register_range_direct) {  // (buf, offset, values, num_values)
 // geometry shader's "specials" block. Kyty hard-asserts hs==null and exact register offsets; we
 // copy the specials through and log deviations instead (tessellation would arrive via hs).
 HLE(agc_create_prim_state) {  // (cx_regs, uc_regs, hs, gs, prim_type)
+    pipetrace("CreatePrimState", a0, a1, a2, a3, a4, a5);
     auto* cx = (AgcShaderRegister*)(uintptr_t)a0;
     auto* uc = (AgcShaderRegister*)(uintptr_t)a1;
     auto* gs = (const AgcShader*)(uintptr_t)a3;
@@ -362,6 +374,7 @@ HLE(agc_create_prim_state) {  // (cx_regs, uc_regs, hs, gs, prim_type)
 // identity mapping (slot i) when there is nothing to match — which reproduces Kyty's behaviour on
 // the layouts Kyty supports.
 HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader* gs, const Shader* ps)
+    pipetrace("CreateInterpolantMapping", a0, a1, a2, a3, a4, a5);
     auto* regs = (AgcShaderRegister*)(uintptr_t)a0;
     auto* gs   = (const AgcShader*)(uintptr_t)a1;
     auto* ps   = (const AgcShader*)(uintptr_t)a2;


### PR DESCRIPTION
## Answer to your bounded question: **NO.**

Neither the fault object `r15` nor its `[+0x18]`/`[+0x40]` packed-register sub-object appears as an argument, return, or write of `CreateShader`, `CreatePrimState`, `CreateInterpolantMapping`, or the register-context builders.

**Method:** added `PROSPER_PIPETRACE` (logs raw pointer args of the construction calls), ran once, diffed against the fault object in the same run — `r15=0x7d622562c300`, sub-object `0x7d62256120f0`:

| Call | Where its pointers live | Overlaps r15? |
|---|---|---|
| `CreateShader` ×36+ | header/code = `0x7d6252dc…`; `*dst` → eboot BSS registry `0x402048…` or stack | no |
| `CreatePrimState` | cx/uc regs = **stack scratch** `0x7d6255dfb…`; gs = `0x7d6252dc…` | no |
| `CreateInterpolantMapping` | regs = stack scratch `0x7d6255dfb…`; gs/ps = `0x7d6252dc…` | no |
| register-context builders | AGC context `0x7d62255cb378` + neighbors | no (all in the `0x7d62255c` region, not r15 `0x7d62256c300` / sub-object `0x7d622561`) |

The only `0x7d6225…`-region pointers logged anywhere are the AGC context and register-context builder args — none in `r15`'s (`…62c300`) or the sub-object's (`…6120f0`) region.

## Conclusion → your "no" branch

The register **content** originates from our calls (Unity harvests the `{offset,value}` pairs into stack scratch), but the **pipeline object and its `[+0x140]` GPU companion are constructed by Unity's own resource manager** — no game→AGC call takes/returns/writes them. So there's no front-half HLE hook, and per your decision tree you'll **intercept pipeline residency at the GpuState/register-context stage in the back-half**. Front-half is off the hook for this object.

One thing that may help your interception: the register content you'll want for the VkPipeline *does* pass through `CreatePrimState` (writes VGT_SHADER_STAGES_EN / VGT_GS_OUT_PRIM_TYPE / GE_CNTL / GE_USER_VGPR_EN / VGT_PRIMITIVE_TYPE) and `CreateInterpolantMapping` (SPI_PS_INPUT_CNTL_0..31) — but into caller-owned stack buffers, which Unity then folds into its pipeline object and ultimately emits via the indirect-register Dcb packets your CommandProcessor already decodes. So GpuState should already see these registers at draw time.

## This PR

- `PROSPER_PIPETRACE` diagnostic (retained — useful for future seams) + the finding written into `docs/GRAPHICS.md`. No fabricated resource code.
- 25/25 tests.

Merge or fold as you prefer — the substance is the answer, not the diff. I'm unblocked and free for the next front-half task; let me know where you want me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

