### PR TITLE
Add Linux and Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Configure
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+
+      - name: Build
+        run: cmake --build prosper/build-ci
+
+      - name: Test
+        run: ctest --test-dir prosper/build-ci --output-on-failure
+
+  windows-mingw:
+    name: Windows MinGW
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+
+      - name: Configure
+        shell: msys2 {0}
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        shell: msys2 {0}
+        run: cmake --build prosper/build-ci
+
+      - name: Test
+        shell: msys2 {0}
+        run: ctest --test-dir prosper/build-ci --output-on-failure

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -34,17 +34,27 @@ endif()
 enable_testing()
 # Path to the (gitignored) local game dump; override with -DGAME_DUMP=...
 set(GAME_DUMP "${CMAKE_SOURCE_DIR}/../PPSA24651-app0" CACHE PATH "Local PS5 game dump root")
+set(HAVE_GAME_DUMP OFF)
+if(EXISTS "${GAME_DUMP}/eboot.bin")
+  set(HAVE_GAME_DUMP ON)
+else()
+  message(STATUS "Game dump not found at ${GAME_DUMP} — skipping dump-backed tests")
+endif()
 
 if(TARGET prosper_core)
   add_executable(test_module tests/test_module.cpp)
   target_link_libraries(test_module PRIVATE prosper_core)
-  add_test(NAME module_loads_eboot
-           COMMAND test_module "${GAME_DUMP}/eboot.bin")
+  if(HAVE_GAME_DUMP)
+    add_test(NAME module_loads_eboot
+             COMMAND test_module "${GAME_DUMP}/eboot.bin")
+  endif()
 
   add_executable(test_nid tests/test_nid.cpp)
   target_link_libraries(test_nid PRIVATE prosper_core)
-  add_test(NAME nid_hash_matches_imports
-           COMMAND test_nid "${GAME_DUMP}/eboot.bin")
+  if(HAVE_GAME_DUMP)
+    add_test(NAME nid_hash_matches_imports
+             COMMAND test_nid "${GAME_DUMP}/eboot.bin")
+  endif()
 
   add_executable(test_hle_registered tests/test_hle_registered.cpp)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
@@ -108,13 +118,17 @@ if(TARGET prosper_core)
 
     add_executable(test_trap_linux tests/test_trap_linux.cpp)
     target_link_libraries(test_trap_linux PRIVATE prosper_core)
-    add_test(NAME trap_identifies_imports
-             COMMAND test_trap_linux "${GAME_DUMP}")
+    if(HAVE_GAME_DUMP)
+      add_test(NAME trap_identifies_imports
+               COMMAND test_trap_linux "${GAME_DUMP}")
+    endif()
 
     add_executable(test_boot_linux tests/test_boot_linux.cpp)
     target_link_libraries(test_boot_linux PRIVATE prosper_core)
-    add_test(NAME boot_reaches_first_syscall
-             COMMAND test_boot_linux "${GAME_DUMP}")
+    if(HAVE_GAME_DUMP)
+      add_test(NAME boot_reaches_first_syscall
+               COMMAND test_boot_linux "${GAME_DUMP}")
+    endif()
 
     # Regression test for the real setjmp/longjmp impl (x86-64 asm; used by the GC's root scan).
     add_executable(test_setjmp tests/test_setjmp.cpp)


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for Linux and Windows/MinGW
- configure, build, and run CTest on every push and PR
- skip private dump-backed tests automatically when GAME_DUMP/eboot.bin is absent
- keep CI GPU-independent by disabling Vulkan discovery in the Linux workflow; local builds still run Vulkan tests when Vulkan is found

## Validation
- Windows/MinGW no dump: configure + build + ctest (10/10 passed)
- WSL2/Linux no dump, Vulkan disabled: configure + build + ctest (15/15 passed)
- Windows/MinGW with local dump: configure + build + ctest (12/12 passed)
- WSL2/Linux with local dump + Vulkan: configure + build + ctest (26/26 passed)
