### PR TITLE
gpu: resolve_pipeline_state — RenderState (RDNA2) -> Vulkan-ready pipeline state

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -78,6 +78,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_render_state PRIVATE prosper_core)
   add_test(NAME render_state_extract COMMAND test_render_state)
 
+  # Pipeline-state resolution: RenderState (RDNA2 enums) -> Vulkan-ready pipeline state (pure, no Vulkan).
+  add_executable(test_pipeline_state tests/test_pipeline_state.cpp)
+  target_link_libraries(test_pipeline_state PRIVATE prosper_core)
+  add_test(NAME pipeline_state_resolve COMMAND test_pipeline_state)
+
   # RDNA2 shader instruction-stream walker (first stage of the RDNA2->SPIR-V recompiler).
   add_executable(test_rdna2_decode tests/test_rdna2_decode.cpp)
   target_link_libraries(test_rdna2_decode PRIVATE prosper_core)

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -1,6 +1,7 @@
 // render_state.cpp — see render_state.hpp.
 #include "render_state.hpp"
 #include "pm4_registers.hpp"
+#include "vk_translate.hpp"
 
 namespace prosper::gpu {
 
@@ -60,6 +61,28 @@ RenderState extract_render_state(const GpuState& st) {
     rs.cb_target_mask    = rd(st.cx, P::CB_TARGET_MASK);
 
     return rs;
+}
+
+ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
+    ResolvedPipelineState ps;
+    ps.topology      = static_cast<uint32_t>(vk_topology(rs.prim_type));
+    ps.color0_format = static_cast<uint32_t>(
+        vk_color_format(rs.color0_format, rs.color0_number_type, rs.color0_comp_swap));
+
+    ps.depth_test_enable  = rs.z_enable;
+    ps.depth_write_enable = rs.z_write_enable;
+    ps.depth_compare_op   = vk_compare_op(rs.zfunc);
+
+    ps.blend_enable            = rs.blend_enable;
+    ps.src_color_blend_factor  = vk_blend_factor(rs.color_src_blend);
+    ps.dst_color_blend_factor  = vk_blend_factor(rs.color_dst_blend);
+    ps.color_blend_op          = vk_blend_op(rs.color_comb_fcn);
+
+    // CB_TARGET_MASK holds a 4-bit write mask per MRT; MRT0 is bits [3:0]. RDNA2's R/G/B/A bit order
+    // matches VkColorComponentFlags (R=1,G=2,B=4,A=8), so the nibble maps 1:1.
+    ps.color_write_mask = rs.cb_target_mask & 0xFu;
+
+    return ps;
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -53,4 +53,24 @@ struct RenderState {
 // Extract the render-state from a folded GpuState (pure; reads register files only).
 RenderState extract_render_state(const GpuState& st);
 
+// A pipeline's fixed-function state with every RDNA2 enum already translated to its Vulkan value
+// (via vk_translate). All fields are plain integers equal to the corresponding Vk* enumerators, so
+// the Vulkan backend can drop them straight into a VkGraphicsPipelineCreateInfo with no further
+// mapping — and this resolution is unit-testable with no Vulkan dependency (it runs on any host).
+struct ResolvedPipelineState {
+    uint32_t topology         = 0;   // == VkPrimitiveTopology
+    uint32_t color0_format    = 0;   // == VkFormat (0 = VK_FORMAT_UNDEFINED)
+    bool     depth_test_enable  = false;
+    bool     depth_write_enable = false;
+    uint32_t depth_compare_op  = 0;  // == VkCompareOp
+    bool     blend_enable        = false;
+    uint32_t src_color_blend_factor = 0;   // == VkBlendFactor
+    uint32_t dst_color_blend_factor = 0;   // == VkBlendFactor
+    uint32_t color_blend_op         = 0;   // == VkBlendOp
+    uint32_t color_write_mask       = 0xF; // == VkColorComponentFlags (RGBA); MRT0 nibble of CB_TARGET_MASK
+};
+
+// Translate a RenderState's RDNA2 register semantics into Vulkan-ready pipeline state (pure).
+ResolvedPipelineState resolve_pipeline_state(const RenderState& rs);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_pipeline_state.cpp
+++ b/prosper/tests/test_pipeline_state.cpp
@@ -1,0 +1,52 @@
+// test_pipeline_state — resolve_pipeline_state() turns a RenderState's RDNA2 register semantics into
+// Vulkan-ready pipeline state. Pure (no Vulkan), so it runs on every host. Inputs are chosen so the
+// RDNA2->Vulkan mappings are NON-identity (e.g. RDNA2 triangle-strip=6 -> VK topology 4; DstColor
+// blend=8 -> VK DST_COLOR=4; Min comb=2 -> VK MIN=3) — proving translation, not passthrough.
+#include "../src/gpu/render_state.hpp"
+#include <cstdio>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_pipeline_state ==\n");
+
+    RenderState rs;
+    rs.prim_type          = 6;      // RDNA2 triangle strip  -> VK topology 4 (non-identity)
+    rs.color0_format      = 0xA;    // COLOR_8_8_8_8
+    rs.color0_number_type = 6;      // SRGB
+    rs.color0_comp_swap   = 1;      // BGRA                  -> VK_FORMAT_B8G8R8A8_SRGB (50)
+    rs.z_enable           = true;
+    rs.z_write_enable     = true;
+    rs.zfunc              = 4;       // GREATER               -> VkCompareOp 4
+    rs.blend_enable       = true;
+    rs.color_src_blend    = 0x08;   // DstColor              -> VK DST_COLOR (4)
+    rs.color_dst_blend    = 0x05;   // OneMinusSrcAlpha      -> VK ONE_MINUS_SRC_ALPHA (7)
+    rs.color_comb_fcn     = 2;      // Min                   -> VK_BLEND_OP_MIN (3)
+    rs.cb_target_mask     = 0x7;    // MRT0 write mask RGB (no alpha)
+
+    ResolvedPipelineState ps = resolve_pipeline_state(rs);
+
+    CHECK(ps.topology == 4,               "triangle-strip prim_type 6 -> VK topology 4");
+    CHECK(ps.color0_format == 50,         "8_8_8_8 SRGB BGRA -> VK_FORMAT_B8G8R8A8_SRGB (50)");
+    CHECK(ps.depth_test_enable,           "depth test enabled");
+    CHECK(ps.depth_write_enable,          "depth write enabled");
+    CHECK(ps.depth_compare_op == 4,       "zfunc GREATER -> VkCompareOp 4");
+    CHECK(ps.blend_enable,                "blend enabled");
+    CHECK(ps.src_color_blend_factor == 4, "src DstColor -> VK DST_COLOR (4)");
+    CHECK(ps.dst_color_blend_factor == 7, "dst OneMinusSrcAlpha -> VK ONE_MINUS_SRC_ALPHA (7)");
+    CHECK(ps.color_blend_op == 3,         "comb Min -> VK_BLEND_OP_MIN (3)");
+    CHECK(ps.color_write_mask == 0x7,     "CB_TARGET_MASK MRT0 nibble -> RGB write mask");
+
+    // A default/empty RenderState resolves to a safe pipeline (point list, undefined format, no blend).
+    ResolvedPipelineState def = resolve_pipeline_state(RenderState{});
+    CHECK(def.topology == 0 && def.color0_format == 0 && !def.blend_enable && !def.depth_test_enable,
+          "empty render-state resolves to a safe default pipeline");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
The pure, Vulkan-free half of pipeline realization (back-half lane): translate a `RenderState`'s RDNA2 register semantics into a `ResolvedPipelineState` whose fields equal the `Vk*` enumerators — ready to drop into a `VkGraphicsPipelineCreateInfo` with no further mapping.

## Why
Keeps the semantic RDNA2→Vulkan translation in `prosper_core` (unit-testable on any host, incl. Windows/MinGW), leaving only thin Vulkan-struct filling to the gated backend. This is the state that the `Pipeline` resource kind will back, and it consumes the register stream the CommandProcessor already decodes.

## What
- `ResolvedPipelineState` + `resolve_pipeline_state(RenderState)` in `render_state.{hpp,cpp}`: topology, color format, depth test/write/compare, blend enable/factors/op, color write mask.
- `test_pipeline_state` proves the **non-identity** mappings (tri-strip 6→4, DstColor 8→4, Min 2→3, BGRA-SRGB→50) so it's real translation, not passthrough. Pure/no-Vulkan.

27/27 green (Linux). Next: the Vulkan-gated layer that builds an actual `VkPipeline` from this + renders (offscreen harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)