### PR TITLE
videoout: real 1080p60 display + swapchain scaffolding (+ hypothesis: not the [+0x140] gate)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -139,6 +139,12 @@ if(TARGET prosper_core)
     target_link_libraries(test_agc_submit PRIVATE prosper_core)
     add_test(NAME agc_submit_to_gpustate COMMAND test_agc_submit)
 
+    # libSceVideoOut: query/config functions return real 1080p60 values + swapchain-scaffolding
+    # display-buffer registry records the game's registered framebuffers.
+    add_executable(test_videoout tests/test_videoout.cpp)
+    target_link_libraries(test_videoout PRIVATE prosper_core)
+    add_test(NAME videoout_queries COMMAND test_videoout)
+
     # Graphics-phase foundation + agentic-first verification harness: headless offscreen Vulkan
     # (render/clear -> readback -> pixel/CRC assert). Only built if Vulkan dev files are present.
     find_package(Vulkan QUIET)

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -100,6 +100,31 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - Graphics libs are sparsely documented; most NIDs don't resolve to names — reverse-engineer from
   call args (`PROSPER_GFXLOG`) and `build-linux/tools/pltm` (maps a module GOT offset → NID).
 
+## ✔ libSceVideoOut real 1080p60 + swapchain scaffolding (2026-07-04) — and the [+0x140] gate is NOT the display surface
+
+Implemented the 5 previously-unimplemented VideoOut NIDs with real, self-consistent values (resolved
+via shadPS4 aerolib + Kyty VideoOut.cpp): `Nv8c-Kb+DUM` sceVideoOutIsOutputSupported, `PjS5uASwcV8`
+sceVideoOutSetBufferAttribute2, `rKBUtgRrtbk` sceVideoOutRegisterBuffers2, `utPrVdxio-8`
+sceVideoOutGetOutputStatus, `w0hLuNarQxY` sceVideoOutConfigureOutput. Plus fixed GetResolutionStatus
+(was all-zero → now 1920×1080@59.94Hz) and added GetVblankStatus (advancing counter) +
+GetDeviceCapabilityInfo (SDR). All output-struct writes are size-exact.
+
+**Verified the game requests exactly what we advertise:** `SetBufferAttribute2` arrives with
+`width=0x780 (1920)`, `height=0x438 (1080)`, `pixel_format=0x8000000000000000` (PS5 A8R8G8B8 sRGB);
+`RegisterBuffers2` registers **3** framebuffers (triple-buffered). Recorded them in a display-buffer
+registry (swapchain scaffolding, `prosper_vo_buffer_count/_display_width/_height/_format/_buffer_addr`)
+that the back-half present path turns into swapchain images. test_videoout (27 tests total).
+
+**Hypothesis result (agent-2 asked): the display surface is NOT what gates the `[+0x140]` companion.**
+With all 5 VideoOut calls returning real 1080p60 values + buffers registered, the boot still faults at
+**the same `eboot+0xba6e08`** (unchanged). So VideoOut is eliminated as the suspect — Unity allocates
+the pipeline companion independent of display-surface availability. The residency interception belongs
+in the back-half (GpuState/register-context stage), as concluded below.
+
+Note: `GetOutputStatus` currently traces + returns success without writing its output struct — its
+exact layout/size is unconfirmed and the game tolerates a no-write return (boot reaches the same
+downstream fault). Left non-writing rather than risk a wrong-size write (stack-canary smash).
+
 ## ✔ BOUNDED TRACE ANSWER (2026-07-04): the pipeline object is Unity-INTERNAL — no HLE hook exists
 
 Back-half asked one bounded question: does the fault object `r15` (or its `[+0x18]`/`[+0x40]`

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -84,11 +84,53 @@ HLE(g_agc_ctx_init) {   // a0 = context pointer (device+0x48)
     return 0;
 }
 
-// --- libSceVideoOut (display / frame presentation). Headless: accept opens/flips and simulate
-// flip completion so the game's render loop advances (submit -> wait completion -> submit next).
+// --- libSceVideoOut (display / frame presentation). ------------------------------------------
+// Models a single connected 1080p60 display. Query functions return real, self-consistent values
+// (not zeroed stubs) so the game's display setup — resolution query, output configuration, buffer
+// registration — sees a normal main-bus HDMI output. Struct layouts are the Orbis/Gen5 VideoOut
+// ABI (cross-checked vs Kyty Graphics/VideoOut.cpp + shadPS4 videoout/video_out.h). Frame
+// presentation is still simulated (no swapchain yet); the swapchain lands behind these once a real
+// window/surface exists. All output-struct writes are size-exact — over-writing smashes the guest's
+// stack canary (cf. the historical f_fstat bug).
 namespace {
-    int g_vo_handle = 0;
-    uint64_t g_flip_count = 0;   // incremented per SubmitFlip so GetFlipStatus shows progress
+    int      g_vo_handle = 0;
+    uint64_t g_flip_count = 0;    // incremented per SubmitFlip so GetFlipStatus shows progress
+    uint64_t g_vblank_count = 0;
+
+    // The one display we advertise. 1920x1080 @ 59.94Hz (refresh-rate enum 3), 16:9, ~50".
+    constexpr uint32_t kDispW = 1920, kDispH = 1080;
+    constexpr uint64_t kRefresh5994 = 3;   // SCE_VIDEO_OUT_REFRESH_RATE_59_94HZ
+
+    void vo_argtrace(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
+        if (getenv("PROSPER_GFXLOG"))
+            fprintf(stderr, "[vo] %s a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n", fn,
+                    (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                    (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+    }
+
+    // Swapchain scaffolding: the set of display buffers the game registers via RegisterBuffers2.
+    // These GPU addresses are the framebuffers the game flips between (triple-buffered here). The
+    // back-half present path turns each into a swapchain image; SubmitFlip picks by buffer index.
+    // Recorded now so that surface is ready even before real presentation exists.
+    struct DisplayConfig {
+        uint32_t width = 0, height = 0;
+        uint64_t pixel_format = 0;
+        uint32_t tiling_mode = 0;
+        int      buffer_num = 0;
+        uint64_t buffer_addr[16] = {0};   // guest GPU-VA of each registered framebuffer
+        bool     configured = false;
+    };
+    DisplayConfig g_display;
+    struct VideoOutBuffers { const void* data; const void* metadata; const void* reserved[2]; };
+}
+
+// Exposed for the back-half present path + tests: the registered display surface.
+extern "C" int      prosper_vo_buffer_count()   { return g_display.buffer_num; }
+extern "C" uint32_t prosper_vo_display_width()  { return g_display.width; }
+extern "C" uint32_t prosper_vo_display_height() { return g_display.height; }
+extern "C" uint64_t prosper_vo_display_format() { return g_display.pixel_format; }
+extern "C" uint64_t prosper_vo_buffer_addr(int i) {
+    return (i >= 0 && i < g_display.buffer_num) ? g_display.buffer_addr[i] : 0;
 }
 HLE(g_vo_open)        { gfx_tick(); return (uint64_t)(int64_t)(++g_vo_handle + 0x1000); }  // positive handle
 HLE(g_vo_close)       { return 0; }
@@ -102,7 +144,83 @@ HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our s
               *(int32_t*) (s + 0x38) = 0; }                   // currentBuffer
     return 0;
 }
-HLE(g_vo_resstatus)   { if (a1) memset((void*)(uintptr_t)a1, 0, 0x20); return 0; }  // SceVideoOutResolutionStatus ~0x20
+// SceVideoOutResolutionStatus (0x20 bytes, Kyty VideoOutResolutionStatus): report a real 1080p60
+// panel instead of the previous all-zero (which advertised a 0x0 display).
+HLE(g_vo_resstatus)   {
+    if (a1) { uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x20);
+              *(uint32_t*)(s + 0x00) = kDispW;   *(uint32_t*)(s + 0x04) = kDispH;   // full w/h
+              *(uint32_t*)(s + 0x08) = kDispW;   *(uint32_t*)(s + 0x0c) = kDispH;   // pane w/h
+              *(uint64_t*)(s + 0x10) = kRefresh5994;
+              *(float*)   (s + 0x18) = 50.0f; }                                     // screen size (inch)
+    return 0;
+}
+
+// sceVideoOutGetVblankStatus (SceVideoOutVblankStatus, 0x28 bytes): advancing vblank counter so any
+// vsync wait/poll sees progress.
+HLE(g_vo_vblankstatus) {
+    if (a1) { uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x28);
+              *(uint64_t*)(s + 0x00) = ++g_vblank_count; }   // count
+    return 0;
+}
+// sceVideoOutGetDeviceCapabilityInfo (SceVideoOutDeviceCapabilityInfo: single u64 capability).
+// Advertise a plain SDR display (no HDR/BT2020) — capability 0.
+HLE(g_vo_devcap) { if (a1) *(uint64_t*)(uintptr_t)a1 = 0; return 0; }
+
+// sceVideoOutIsOutputSupported (Nv8c-Kb+DUM): (port_type, mode/feature) -> bool. A standard main-bus
+// output supports the queried mode → 1.
+HLE(g_vo_is_output_supported) { vo_argtrace("IsOutputSupported", a0,a1,a2,a3,a4,a5); return 1; }
+
+// sceVideoOutSetBufferAttribute2 (PjS5uASwcV8): fill the caller's VideoOutBufferAttribute2 (0x50
+// bytes, Kyty layout) from (attr, pixel_format, tiling_mode, width, height, option, [dcc_control,
+// dcc_cb_clear on stack]). Mirrors Kyty's setter. Size-exact write.
+HLE(g_vo_set_buffer_attribute2) {  // a0=attr* a1=pixel_format a2=tiling a3=width a4=height a5=option
+    vo_argtrace("SetBufferAttribute2", a0,a1,a2,a3,a4,a5);
+    if (!a0) return 0;
+    uint8_t* p = (uint8_t*)(uintptr_t)a0; memset(p, 0, 0x50);
+    *(uint32_t*)(p + 0x04) = (uint32_t)a2;   // tiling_mode
+    *(uint32_t*)(p + 0x08) = 0;              // aspect_ratio (16:9)
+    *(uint32_t*)(p + 0x0c) = (uint32_t)a3;   // width
+    *(uint32_t*)(p + 0x10) = (uint32_t)a4;   // height
+    *(uint64_t*)(p + 0x18) = a5;             // option
+    *(uint64_t*)(p + 0x20) = a1;             // pixel_format
+    return 0;
+}
+
+// sceVideoOutRegisterBuffers2 (rKBUtgRrtbk): (handle, set_index, buffer_index_start, buffers,
+// buffer_num, attribute, [category, option on stack]). Validate ranges like Kyty and accept. The
+// buffers' GPU backing becomes swapchain images once the swapchain exists; for now, registration
+// succeeds so the game proceeds to flips.
+HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a3=buffers a4=buffer_num a5=attribute
+    vo_argtrace("RegisterBuffers2", a0,a1,a2,a3,a4,a5);
+    int start = (int)a2, num = (int)a4;
+    if (!a3 || !a5) return (uint64_t)(int64_t)-1;
+    if (start < 0 || start > 15 || num < 1 || num > 16 || start + num > 16) return (uint64_t)(int64_t)-1;
+    // Record the display surface (swapchain scaffolding). attribute is the 0x50-byte
+    // VideoOutBufferAttribute2 we fill in SetBufferAttribute2: width@0x0c, height@0x10, format@0x20.
+    const uint8_t* attr = (const uint8_t*)(uintptr_t)a5;
+    g_display.width        = *(const uint32_t*)(attr + 0x0c);
+    g_display.height       = *(const uint32_t*)(attr + 0x10);
+    g_display.pixel_format = *(const uint64_t*)(attr + 0x20);
+    g_display.tiling_mode  = *(const uint32_t*)(attr + 0x04);
+    const auto* bufs = (const VideoOutBuffers*)(uintptr_t)a3;
+    g_display.buffer_num = num;
+    for (int i = 0; i < num && start + i < 16; i++)
+        g_display.buffer_addr[start + i] = (uint64_t)(uintptr_t)bufs[i].data;
+    g_display.configured = true;
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[vo] display surface: %ux%u fmt=0x%llx %d buffers registered\n",
+                g_display.width, g_display.height, (unsigned long long)g_display.pixel_format, num);
+    return 0;
+}
+
+// sceVideoOutConfigureOutput (w0hLuNarQxY): set the output mode (resolution/refresh/format). We only
+// advertise one mode (1080p60), so accept the configuration.
+HLE(g_vo_configure_output) { vo_argtrace("ConfigureOutput", a0,a1,a2,a3,a4,a5); return 0; }
+
+// sceVideoOutGetOutputStatus (utPrVdxio-8): (handle, status*). PASS 1 — trace only, do NOT write the
+// output struct until its exact size is confirmed from a real call (over-writing smashes the guest
+// stack canary). Filled in once the arg/size is captured.
+HLE(g_vo_get_output_status) { vo_argtrace("GetOutputStatus", a0,a1,a2,a3,a4,a5); return 0; }
 
 // Diagnostic tracer for the (undocumented) libSceAgc / libSceAgcDriver calls: logs the NID, the guest
 // callsite, and all six args (gated on PROSPER_GFXLOG). Behaviour is identical to the unimplemented
@@ -192,7 +310,16 @@ void register_graphics_hle() {
     R("sceVideoOutSetFlipRate", g_vo_close);    R("sceVideoOutAddFlipEvent", g_vo_close);
     R("sceVideoOutGetFlipStatus", g_vo_flipstatus);
     R("sceVideoOutGetResolutionStatus", g_vo_resstatus);
+    R("sceVideoOutGetVblankStatus", g_vo_vblankstatus);
+    R("sceVideoOutGetDeviceCapabilityInfo", g_vo_devcap);
     R("sceVideoOutRegisterBuffers", g_vo_close);R("sceVideoOutSetBufferAttribute", g_vo_close);
+    // PS5 "2"/query variants — the 5 previously-unimplemented VideoOut NIDs (resolved via shadPS4
+    // aerolib + Kyty VideoOut.cpp). Registered by raw NID (PS5-specific, not in our name DB).
+    RN("Nv8c-Kb+DUM", g_vo_is_output_supported);   // sceVideoOutIsOutputSupported
+    RN("PjS5uASwcV8", g_vo_set_buffer_attribute2);  // sceVideoOutSetBufferAttribute2
+    RN("rKBUtgRrtbk", g_vo_register_buffers2);       // sceVideoOutRegisterBuffers2
+    RN("utPrVdxio-8", g_vo_get_output_status);        // sceVideoOutGetOutputStatus
+    RN("w0hLuNarQxY", g_vo_configure_output);          // sceVideoOutConfigureOutput
     #undef R
     #undef RN
 }

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -1,0 +1,89 @@
+// test_videoout — guards the libSceVideoOut HLE (hle_graphics.cpp): the query/config functions must
+// return real, self-consistent 1080p60 values (not zeroed stubs), and the display-buffer registration
+// (swapchain scaffolding) must record the surface the game set up. Drives the functions through the
+// NID registry exactly as the guest does, then asserts the reported display + recorded buffers.
+#include "../src/hle/dispatch.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper;
+
+extern "C" int      prosper_vo_buffer_count();
+extern "C" uint32_t prosper_vo_display_width();
+extern "C" uint32_t prosper_vo_display_height();
+extern "C" uint64_t prosper_vo_display_format();
+extern "C" uint64_t prosper_vo_buffer_addr(int i);
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_videoout ==\n");
+    register_builtin_hle();
+
+    auto res    = Hle::lookup(nid_hash("sceVideoOutGetResolutionStatus"));
+    auto vbl    = Hle::lookup(nid_hash("sceVideoOutGetVblankStatus"));
+    auto cap    = Hle::lookup(nid_hash("sceVideoOutGetDeviceCapabilityInfo"));
+    auto issup  = Hle::lookup("Nv8c-Kb+DUM");   // IsOutputSupported
+    auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
+    auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
+    auto cfg    = Hle::lookup("w0hLuNarQxY");   // ConfigureOutput
+    CHECK(res && vbl && cap && issup && setba2 && regb2 && cfg, "VideoOut functions registered");
+    if (!(res && vbl && cap && issup && setba2 && regb2 && cfg)) { printf("== FAIL ==\n"); return 1; }
+
+    // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed.
+    uint8_t rs[0x20]; memset(rs, 0xEE, sizeof rs);
+    res(0x1001, (uint64_t)(uintptr_t)rs, 0, 0, 0, 0);
+    CHECK(*(uint32_t*)(rs + 0x00) == 1920 && *(uint32_t*)(rs + 0x04) == 1080, "resolution 1920x1080 (full)");
+    CHECK(*(uint32_t*)(rs + 0x08) == 1920 && *(uint32_t*)(rs + 0x0c) == 1080, "resolution 1920x1080 (pane)");
+    CHECK(*(uint64_t*)(rs + 0x10) == 3, "refresh rate = 59.94Hz (enum 3)");
+
+    // Vblank counter advances across calls.
+    uint8_t vb[0x28];
+    vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c0 = *(uint64_t*)vb;
+    vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c1 = *(uint64_t*)vb;
+    CHECK(c1 == c0 + 1, "vblank counter advances");
+
+    // Device capability: plain SDR display (capability 0).
+    uint64_t dc = 0xDEAD;
+    cap(0x1001, (uint64_t)(uintptr_t)&dc, 0, 0, 0, 0);
+    CHECK(dc == 0, "device capability = 0 (SDR)");
+
+    // IsOutputSupported → supported.
+    CHECK(issup(0x1001, 0xd000000a, 0, 0, 0, 0) == 1, "IsOutputSupported returns 1");
+
+    // SetBufferAttribute2 fills the 0x50 attribute struct from (fmt, tiling, w, h, option).
+    uint8_t attr[0x50]; memset(attr, 0xEE, sizeof attr);
+    uint64_t fmt = 0x8000000000000000ull;   // the PS5 format the game requests (A8R8G8B8 sRGB)
+    setba2((uint64_t)(uintptr_t)attr, fmt, 0 /*tiling*/, 1920, 1080, 0 /*option*/);
+    CHECK(*(uint32_t*)(attr + 0x0c) == 1920 && *(uint32_t*)(attr + 0x10) == 1080, "attribute width/height set");
+    CHECK(*(uint64_t*)(attr + 0x20) == fmt, "attribute pixel_format set");
+    CHECK(*(uint32_t*)(attr + 0x04) == 0, "attribute tiling_mode set");
+
+    // ConfigureOutput accepts the (single advertised) mode.
+    CHECK(cfg(0x1001, 1, 0, 0, 0, 0) == 0, "ConfigureOutput accepted");
+
+    // RegisterBuffers2: triple-buffered surface. buffers = array of VideoOutBuffers {data, ...}.
+    struct VOB { const void* data; const void* metadata; const void* reserved[2]; };
+    uint8_t fb0[16], fb1[16], fb2[16];
+    VOB buffers[3] = { {fb0,0,{0,0}}, {fb1,0,{0,0}}, {fb2,0,{0,0}} };
+    uint64_t rc = regb2(0x1001, 0 /*set*/, 0 /*start*/, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
+    CHECK(rc == 0, "RegisterBuffers2 accepted 3 buffers");
+
+    // Swapchain scaffolding recorded the surface.
+    CHECK(prosper_vo_buffer_count() == 3, "registry recorded 3 display buffers");
+    CHECK(prosper_vo_display_width() == 1920 && prosper_vo_display_height() == 1080, "registry recorded 1080p surface");
+    CHECK(prosper_vo_display_format() == fmt, "registry recorded the pixel format");
+    CHECK(prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
+          prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2, "registry recorded each framebuffer address");
+
+    // Range validation: out-of-range buffer counts are rejected.
+    CHECK(regb2(0x1001, 0, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,
+          "RegisterBuffers2 rejects an out-of-range buffer_num");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Both goals from your message, plus the hypothesis test.

## 1. The 5 VideoOut NIDs — real 1080p60, not stubs

Resolved via shadPS4 aerolib + Kyty `VideoOut.cpp`:

| NID | Function | Behavior |
|---|---|---|
| `Nv8c-Kb+DUM` | `sceVideoOutIsOutputSupported` | returns 1 (supported) |
| `PjS5uASwcV8` | `sceVideoOutSetBufferAttribute2` | fills the 0x50 attribute struct (Kyty layout) |
| `rKBUtgRrtbk` | `sceVideoOutRegisterBuffers2` | validates ranges + records the surface |
| `utPrVdxio-8` | `sceVideoOutGetOutputStatus` | trace-only (see caveat) |
| `w0hLuNarQxY` | `sceVideoOutConfigureOutput` | accepts the mode |

Also fixed `GetResolutionStatus` (was **all-zero** — advertised a 0×0 display!) → now 1920×1080 @ 59.94Hz, and added `GetVblankStatus` (advancing counter) + `GetDeviceCapabilityInfo` (SDR, capability 0). Every output-struct write is size-exact (no stack-canary smash).

**The game requests exactly what we now advertise** — captured live:
- `SetBufferAttribute2`: `width=0x780` (1920), `height=0x438` (1080), `pixel_format=0x8000000000000000` (PS5 64-bit A8R8G8B8 sRGB / BGRA)
- `RegisterBuffers2`: **3** framebuffers (triple-buffered)

## 2. Swapchain scaffolding

`RegisterBuffers2` now records the display surface into a buffer registry — resolution, format, and each framebuffer's GPU-VA — exposed for your present path:
```
prosper_vo_buffer_count() / _display_width() / _display_height() / _display_format() / _buffer_addr(i)
```
These are the images your swapchain wraps; `SubmitFlip` selects by buffer index. Built now so the surface is ready before real presentation exists (WSL is headless, so no window yet).

## 3. Hypothesis result: **the display surface is NOT the `[+0x140]` gate**

With all 5 calls returning real 1080p60 values and 3 buffers registered, the boot **still faults at the same `eboot+0xba6e08`** — unchanged. So Unity allocates the pipeline companion independent of display-surface availability. **Biggest suspect eliminated** — the residency interception belongs in the back-half (GpuState/register-context stage), as you planned.

## Caveat

`GetOutputStatus` traces its args and returns success **without writing** its output struct — I couldn't confirm the exact struct size, and the game tolerates a no-write success return (it reaches the same downstream fault regardless). I chose not to risk a wrong-size write (the `f_fstat` stack-smash lesson). If you know the `SceVideoOutOutputStatus` layout, I'll fill it — flagging rather than guessing.

`test_videoout` added (drives all functions through the NID registry, asserts the 1080p60 values + the recorded surface). 27/27 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
