### PR TITLE
fix: reject graphics cmpx without export predication

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -288,7 +288,7 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
 // Emit one ALU instruction (VOP1/2/C/3 or SOP1/2) into `b`, updating `rs`. Returns true if `in` is an
 // ALU format handled here; sets ok=false if it is an ALU op this stage doesn't support yet. Non-ALU
 // formats (EXP/memory/...) return false so the stage-specific caller can handle them.
-bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok) {
+bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool allow_exec_update) {
     auto& vreg = rs.vreg; uint32_t& vcc = rs.vcc;
     auto val = [&](const Operand& o) { return operand_bits(b, rs, in, o); };
     switch (in.fmt) {
@@ -376,6 +376,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok) {
             uint32_t op = in.opcode;
             bool is_cmpx = (op >= 0x10 && op <= 0x1f) || (op >= 0x90 && op <= 0x9f) ||
                            (op >= 0xd0 && op <= 0xdf);
+            if (is_cmpx && !allow_exec_update) { ok = false; return true; }
             uint32_t eff = is_cmpx ? op - 0x10 : op;
             uint32_t cmp = 0;
             switch (eff) {
@@ -471,7 +472,7 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     for (const auto& in : ins) {
         if (in.is_end) break;
         bool ok = true;
-        if (!emit_alu(b, rs, in, ok) || !ok) return {};   // compute kernels are pure ALU
+        if (!emit_alu(b, rs, in, ok, true) || !ok) return {};   // compute kernels are pure ALU
     }
 
     auto it = rs.vreg.find((int)out_vgpr);
@@ -502,7 +503,9 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords) {
             continue;   // ignore NULL / additional exports for now
         }
         bool ok = true;
-        if (!emit_alu(b, rs, in, ok) || !ok) return {};
+        // Graphics-stage exports do not yet model EXEC-masked export/discard, so reject cmpx for now
+        // instead of accepting a shader that would export from inactive lanes.
+        if (!emit_alu(b, rs, in, ok, false) || !ok) return {};
     }
     if (!exported) return {};
     return b.finish();
@@ -529,7 +532,9 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords) {
             continue;   // ignore PARAM exports (varyings) for now
         }
         bool ok = true;
-        if (!emit_alu(b, rs, in, ok) || !ok) return {};
+        // Graphics-stage exports do not yet model EXEC-masked export/discard, so reject cmpx for now
+        // instead of accepting a shader that would export from inactive lanes.
+        if (!emit_alu(b, rs, in, ok, false) || !ok) return {};
     }
     if (!exported) return {};
     return b.finish();

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -96,6 +96,26 @@ int main() {
     }
     printf("  [ok]   signed kernel SPIR-V declares signed i32 with a nonzero id\n");
 
+    // v_cmpx_* narrows EXEC. Compute has a predicated store for that, but graphics-stage exporters
+    // do not yet model EXEC-masked export/discard, so fragment/vertex recompilation must reject it.
+    const uint32_t cmpx_fragment[] = {
+        0x7DA80300u, 0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
+    if (!recompile_fragment(cmpx_fragment, sizeof(cmpx_fragment) / sizeof(cmpx_fragment[0])).empty()) {
+        printf("  [FAIL] fragment cmpx shader was accepted without EXEC-masked export support\n");
+        return 1;
+    }
+    printf("  [ok]   fragment cmpx shader is rejected until EXEC-masked export is modeled\n");
+
+    const uint32_t cmpx_vertex[] = {
+        0x7DA80300u, 0xF80008CFu, 0x03020100u, 0xBF810000u,
+    };
+    if (!recompile_vertex(cmpx_vertex, sizeof(cmpx_vertex) / sizeof(cmpx_vertex[0])).empty()) {
+        printf("  [FAIL] vertex cmpx shader was accepted without EXEC-masked export support\n");
+        return 1;
+    }
+    printf("  [ok]   vertex cmpx shader is rejected until EXEC-masked export is modeled\n");
+
     printf("== PASS ==\n");
     return 0;
 }


### PR DESCRIPTION
Review fix from the latest post-PR5 commits.

Finding:
- Commit 50613c1 made `v_cmpx_*` update EXEC through the shared ALU path. Compute has an EXEC-predicated output store, but fragment/vertex exports still store unconditionally. That let graphics-stage recompilation silently accept shaders whose inactive lanes should not export/discard.

Fix:
- Make EXEC-writing compares opt-in in `emit_alu`.
- Keep compute `v_cmpx_*` support enabled.
- Reject fragment/vertex `v_cmpx_*` until EXEC-masked export/discard is modeled.
- Add structural regression coverage that does not require Vulkan.

Validation:
- Windows/MinGW: configure + build + ctest, 12/12 passed.
- WSL2/Linux without Vulkan: configure + build + ctest, 19/19 passed.
- WSL2/Linux with Vulkan: configure + build + ctest, 26/26 passed.

Additional review notes:
- The diagnostic commits 02752b7 and 2ec262d are observational/docs plus tracing; no correctness fix needed.
- Reviewed origin/backhalf/pipeline-state commit 74c11ca; the pure pipeline-state mapping looked consistent with the existing vk_translate mappings.