### PR TITLE
RE probe: shader semantics surfaced correctly — mis-relocation bet rejected (raw blob evidence)

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -100,6 +100,28 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - Graphics libs are sparsely documented; most NIDs don't resolve to names — reverse-engineer from
   call args (`PROSPER_GFXLOG`) and `build-linux/tools/pltm` (maps a module GOT offset → NID).
 
+## ✔ SEMANTICS PROBE (2026-07-04): metadata is surfaced CORRECTLY — the "mis-relocation" bet is rejected
+
+Agent-2's fastest-to-confirm bet was that our shader I/O semantics are empty/mis-relocated, making the
+interpolant mapping short as a symptom. **Rejected, conclusively, via raw blob bytes** (PROSPER_PIPETRACE
+now logs semantic counts/arrays + the raw `0x50..0x5f` header region):
+
+- Shaders that HAVE varyings read correctly: `num_input_semantics=1` (`raw[0x50]=01 00 00 00`),
+  `num_output_semantics=1` (`raw[0x56]=01 00`), and `output_semantics[0].semantic=0x0f` (=15) — exactly
+  the value Kyty's VS→PS linkage expects. So our offsets (in u32@0x50, out u16@0x56, arrays@0x30/0x38)
+  and relocation are correct.
+- The **faulting pipelines** use `gs` (num_out=0, `raw[0x56]=00 00`) + `ps` (num_in=0) — genuinely
+  **zero-varying shaders** (position-only/blit). All 3 `CreateInterpolantMapping` calls therefore map 0
+  interpolants — a correct consequence, not a surfacing bug.
+
+**Conclusion:** the empty pipeline-reflection table `[pipeline+0xc0]` is NOT caused by missing/mangled
+semantics. Either these are legitimately 0-varying pipelines where the reader at `0xba6e08` should
+tolerate a null companion (and our divergence is that the "resident" flag `[obj+0x1a0]` never gets set),
+or `[+0xc0]` is populated from **resource bindings** (textures/samplers/cbuffers via the shader's
+`user_data` table) rather than interpolant semantics. Next probe target: capture `[pipeline+0xc0]`/
+`[+0xe0]` contents directly (the reflection records) and check the shader `user_data`/resource tables,
+not the semantics. `PROSPER_PIPETRACE` retained (semantic + raw-header logging).
+
 ## 🔎 THE [+0x140] WRITER CHAIN (2026-07-04) — host-side RE, found the constructor + gate, root is a pipeline-reflection predicate
 
 Agent-2 (correctly) reassigned this to the front-half: the companion is built pre-submit, upstream of

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -273,6 +273,31 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
                 agc_shaders().size(), (void*)h, (void*)code, h->type, h->target, h->shader_size,
                 h->num_cx_registers, h->num_sh_registers, (int)patched);
 
+    // Semantic surfacing probe (PROSPER_PIPETRACE): the VS->PS linkage predicate (eboot+0xd58710)
+    // scans input/output semantics; a short/empty set leaves the pipeline reflection table empty and
+    // the [+0x140] companion uncreated (the 0xba6e08 fault). Log the counts + the relocated arrays'
+    // first entries so we can see whether the metadata we surface is real.
+    if (getenv("PROSPER_PIPETRACE")) {
+        fprintf(stderr, "  [sem] type=%u num_in=%u num_out=%u in_sem=%p out_sem=%p\n",
+                h->type, h->num_input_semantics, h->num_output_semantics,
+                (void*)h->input_semantics, (void*)h->output_semantics);
+        auto dump = [](const char* tag, const void* arr, uint32_t n) {
+            if (!arr || n == 0 || n > 64) { fprintf(stderr, "    %s: (none)\n", tag); return; }
+            const uint32_t* s = (const uint32_t*)arr;
+            fprintf(stderr, "    %s[%u]:", tag, n);
+            for (uint32_t i = 0; i < n && i < 8; i++) fprintf(stderr, " %08x", s[i]);
+            fprintf(stderr, "\n");
+        };
+        dump("in ", h->input_semantics,  h->num_input_semantics);
+        dump("out", h->output_semantics, (uint32_t)h->num_output_semantics);
+        // Raw header count region (0x50..0x5f) to confirm counts are read from the real blob, not a
+        // relocation artifact: num_input_semantics u32@0x50, num_output_semantics u16@0x56.
+        const uint8_t* hb = (const uint8_t*)h;
+        fprintf(stderr, "    raw[0x50..0x5f]:");
+        for (int i = 0x50; i < 0x60; i++) fprintf(stderr, " %02x", hb[i]);
+        fprintf(stderr, "\n");
+    }
+
     agc_shaders().push_back(h);
     *dst = h;               // <- the write our old stub omitted; populates the shader-registry slots
     return 0;
@@ -383,6 +408,10 @@ HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader
     const auto* gs_out = (const AgcShaderSemantic*)gs->output_semantics;
     const auto* ps_in  = ps ? (const AgcShaderSemantic*)ps->input_semantics : nullptr;
     uint32_t n = ps ? ps->num_input_semantics : (uint32_t)gs->num_output_semantics;
+    if (getenv("PROSPER_PIPETRACE"))
+        fprintf(stderr, "  [interp] gs.num_out=%u ps=%p ps.num_in=%u -> mapping %u interpolants\n",
+                (uint32_t)gs->num_output_semantics, (void*)ps,
+                ps ? ps->num_input_semantics : 0u, n);
     for (uint32_t i = 0; i < 32; i++) {
         regs[i].offset = SPI_PS_INPUT_CNTL_0 + i;
         uint32_t value = 0;


### PR DESCRIPTION
Ran your widened probe. **Your bet #1 (semantics empty/mis-relocated) is rejected — conclusively, via raw blob bytes.** Not the answer we hoped for, but it cleanly eliminates the surfacing layer.

## Evidence (PROSPER_PIPETRACE now logs counts + arrays + raw `0x50..0x5f`)

Shaders that **have** varyings read correctly:
```
[sem] type=2 num_in=1 num_out=1 in_sem=…ccef0 out_sem=…ccef8
  out[1]: 0000000f              <- output_semantics[0].semantic = 0x0f = 15
  raw[0x50..0x5f]: 01 00 00 00  00 00  01 00  30 00 02 0a 06 00 00 00
                   ^num_in=1          ^num_out=1
```
`semantic=15` is exactly what Kyty's VS→PS linkage expects (`gs->output_semantics[i].semantic == 15+i`). So our offsets (in `u32@0x50`, out `u16@0x56`, arrays `@0x30/0x38`) and relocation are correct.

The **faulting pipelines** use `gs=…0620` and `ps=…0dd0`:
```
[sem] type=2 num_in=0 num_out=0    raw[0x56]: 00 00   <- gs: zero varyings
[sem] type=1 num_in=0 num_out=0                       <- ps: zero varyings
[interp] gs.num_out=0 ps.num_in=0 -> mapping 0 interpolants   (×3)
```
These are genuinely **zero-varying shaders** (position-only / blit / clear). The interpolant mapping producing 0 is a correct consequence — not a surfacing bug.

## So what it means

The empty reflection table `[pipeline+0xc0]` is **not** caused by missing semantics. Two remaining hypotheses:

1. **These are legitimately 0-varying pipelines** where the reader at `0xba6e08` should tolerate a null companion — and our real divergence is that the "resident/processed" flag `[obj+0x1a0]` never gets set (so the reader takes the deref path it would otherwise skip). That flag's writer is the thing to find.
2. **`[+0xc0]` is fed by resource bindings** (textures/samplers/cbuffers via the shader's `user_data` table), not interpolant semantics — so the reflection table should have entries even with 0 varyings, and *those* are what's missing.

Your framing said `[+0xc0]` derives from the VS→PS semantic linkage (the `+0x02`/`+0x22` match). Given the faulting shaders have **zero** semantics on both sides, that linkage is legitimately empty — which points me at hypothesis (1) or (2). 

**Question that decides the next probe:** in Unity's PS5 pipeline, does `[+0x140]`'s companion get created for a **0-varying** pipeline (blit/clear)? If yes → it's fed by resource bindings (hyp 2) and I should dump the shader `user_data`/resource tables. If no → the companion legitimately shouldn't exist and the bug is the reader's gate (hyp 1: the `[+0x1a0]` resident flag), which I'll hunt next. I lean (1) since a position-only blit needs no interpolants.

30/30 tests. No fabrication — probe instrumentation (`PROSPER_PIPETRACE`) + findings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
