### PR TITLE
diag: trace shader user-data bindings

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -100,6 +100,30 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - Graphics libs are sparsely documented; most NIDs don't resolve to names — reverse-engineer from
   call args (`PROSPER_GFXLOG`) and `build-linux/tools/pltm` (maps a module GOT offset → NID).
 
+## ✔ USER-DATA PROBE (2026-07-04): zero-varying fault pair still has PS resource bindings
+
+Follow-up to PR #14's fork between "legitimate zero-varying pipeline, bad resident flag" and
+"`[+0xc0]` is fed by shader resource bindings." `PROSPER_PIPETRACE` now logs Kyty's
+`ShaderUserData` resource-binding table: direct resource offsets, `eud_size_dw`/`srt_size_dw`, and
+the four sharp-resource arrays (`sharp[0]` texture, `sharp[2]` sampler, `sharp[3]` storage buffer).
+
+One traced WSL2 boot of the faulting pair showed:
+
+```
+CreateInterpolantMapping gs=...c0620 ps=...c0dd0 -> mapping 0 interpolants
+  gs user_data: direct_count=11 sharp_counts={0,0,0,0}
+  ps user_data: direct_count=11 sharp_counts={0,0,0,1}
+    sharp[3] storage: slot0={off=0000,size=1}
+```
+
+So the semantics conclusion still holds: this is a genuine zero-varying pair. But the pixel shader is
+not resource-empty: it has one storage-buffer sharp binding. That makes hypothesis (2) the better next
+thread: the pipeline reflection table `[pipeline+0xc0]` is likely populated from shader resource
+bindings/user-data as well as, or instead of, interpolants for this path. The next probe should catch
+the Unity builder that folds `ShaderUserData` into `[pipeline+0xc0]/[+0xe0]` and compare the expected
+storage binding against the records seen by predicate `eboot+0xd58710`. Chasing `[obj+0x1a0]` first is
+lower signal until the resource-binding reflection path is ruled out.
+
 ## ✔ SEMANTICS PROBE (2026-07-04): metadata is surfaced CORRECTLY — the "mis-relocation" bet is rejected
 
 Agent-2's fastest-to-confirm bet was that our shader I/O semantics are empty/mis-relocated, making the

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -219,6 +219,42 @@ static void pipetrace(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2, uin
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
 }
 
+static void pipetrace_shader_user_data(const char* tag, const AgcShader* h) {
+    if (!getenv("PROSPER_PIPETRACE")) return;
+    if (!h) { fprintf(stderr, "  [ud] %s shader=(null)\n", tag); return; }
+    const AgcShaderUserData* ud = h->user_data;
+    if (!ud) { fprintf(stderr, "  [ud] %s shader=%p user_data=(null)\n", tag, (const void*)h); return; }
+
+    fprintf(stderr,
+            "  [ud] %s shader=%p user_data=%p eud=%u srt=%u direct_count=%u sharp_counts={%u,%u,%u,%u}\n",
+            tag, (const void*)h, (const void*)ud, ud->eud_size_dw, ud->srt_size_dw,
+            ud->direct_resource_count, ud->sharp_resource_count[0], ud->sharp_resource_count[1],
+            ud->sharp_resource_count[2], ud->sharp_resource_count[3]);
+
+    if (ud->direct_resource_offset && ud->direct_resource_count && ud->direct_resource_count <= 64) {
+        fprintf(stderr, "    direct offsets:");
+        for (uint16_t i = 0; i < ud->direct_resource_count && i < 16; i++)
+            fprintf(stderr, " type%u=%04x", i, ud->direct_resource_offset[i]);
+        if (ud->direct_resource_count > 16) fprintf(stderr, " ...");
+        fprintf(stderr, "\n");
+    }
+
+    for (int imm = 0; imm < 4; imm++) {
+        const uint16_t count = ud->sharp_resource_count[imm];
+        auto* raw = (const uint16_t*)ud->sharp_resource_offset[imm];
+        if (!raw || count == 0 || count > 64) continue;
+        const char* kind = (imm == 0) ? "texture" : (imm == 2) ? "sampler" :
+                           (imm == 3) ? "storage" : "sharp1";
+        fprintf(stderr, "    sharp[%d] %s:", imm, kind);
+        for (uint16_t slot = 0; slot < count && slot < 16; slot++) {
+            uint16_t v = raw[slot];
+            fprintf(stderr, " slot%u={off=%04x,size=%u}", slot, (unsigned)(v & 0x7fffu), (unsigned)(v >> 15));
+        }
+        if (count > 16) fprintf(stderr, " ...");
+        fprintf(stderr, "\n");
+    }
+}
+
 HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
     pipetrace("CreateShader", a0, a1, a2, a3, a4, a5);
     auto** dst   = (AgcShader**)(uintptr_t)a0;
@@ -297,6 +333,7 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
         for (int i = 0x50; i < 0x60; i++) fprintf(stderr, " %02x", hb[i]);
         fprintf(stderr, "\n");
     }
+    pipetrace_shader_user_data("CreateShader", h);
 
     agc_shaders().push_back(h);
     *dst = h;               // <- the write our old stub omitted; populates the shader-registry slots
@@ -412,6 +449,8 @@ HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader
         fprintf(stderr, "  [interp] gs.num_out=%u ps=%p ps.num_in=%u -> mapping %u interpolants\n",
                 (uint32_t)gs->num_output_semantics, (void*)ps,
                 ps ? ps->num_input_semantics : 0u, n);
+    pipetrace_shader_user_data("CreateInterpolant.gs", gs);
+    pipetrace_shader_user_data("CreateInterpolant.ps", ps);
     for (uint32_t i = 0; i < 32; i++) {
         regs[i].offset = SPI_PS_INPUT_CNTL_0 + i;
         uint32_t value = 0;


### PR DESCRIPTION
Follow-up to PR #14.

PR #14 ruled out shader semantic relocation: the faulting GS/PS pair is genuinely zero-varying. That left two hypotheses:

1. the companion is legitimately absent and `[obj+0x1a0]` should have been set; or
2. `[pipeline+0xc0]` is populated from shader resource bindings, not just interpolants.

This PR adds a targeted `PROSPER_PIPETRACE` dump of Kyty's `ShaderUserData` fields:
- direct resource offsets;
- `eud_size_dw` / `srt_size_dw`;
- `sharp[0]` texture bindings;
- `sharp[2]` sampler bindings;
- `sharp[3]` storage-buffer bindings.

I also ran one traced WSL2 boot with the new dump. The same zero-varying fault pair showed:

```text
CreateInterpolantMapping gs=...c0620 ps=...c0dd0 -> mapping 0 interpolants
  gs user_data: direct_count=11 sharp_counts={0,0,0,0}
  ps user_data: direct_count=11 sharp_counts={0,0,0,1}
    sharp[3] storage: slot0={off=0000,size=1}
```

So the pixel shader is not resource-empty. This makes hypothesis (2) the higher-signal next thread: catch the Unity builder that folds `ShaderUserData` into `[pipeline+0xc0]/[+0xe0]`, then compare that expected storage binding against predicate `eboot+0xd58710`'s record scan.

Validation:
- Windows/MinGW build + ctest: 13/13 passed.
- WSL2/Linux build + ctest, Vulkan disabled: 21/21 passed.
- WSL2 traced boot with `PROSPER_PIPETRACE=1`: reached the known downstream fault and produced the user-data evidence above.