### PR TITLE
diag: skip-null-companion probe — systemic (residency pass never ran), stop per-object writer hunt

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -146,6 +146,28 @@ or `[+0xc0]` is populated from **resource bindings** (textures/samplers/cbuffers
 `[+0xe0]` contents directly (the reflection records) and check the shader `user_data`/resource tables,
 not the semantics. `PROSPER_PIPETRACE` retained (semantic + raw-header logging).
 
+## ✔ SKIP PROBE (2026-07-04): the null companion is systemic, not a single gap → STOP hunting per-object writers
+
+Env-gated diagnostic `PROSPER_SKIP_NULL_COMPANION` (exec_image_linux.cpp; default off): at the reader
+`eboot+0xba6e08`, log the object's state and redirect RIP to the reader's own skip label
+`eboot+0xba6e40` (where its type/flag branches already land), continuing as if the companion weren't
+needed. A probe to reveal the *shape* past the fault — NOT a fix (companions are still not real).
+
+Result of one run: **4 bounded skips** (distinct objects, all `[+0x140]=0`; resident-flag low byte
+`[+0x1a0]&0xff == 0` on every one — none processed), then the boot advances **past `0xba6e08` to a
+NEW null-object deref at `eboot+0x95c823`** (`mov (%r14),%rdi; mov (%rdi),%rax` with `[r14]`→null).
+
+**Interpretation (per the agreed decision tree): systemic, not a narrow gap.** It is NOT an infinite
+cascade of the same deref (bounded at the collection size = 4), and it does NOT reach a frame — it
+lands on the *next* null GfxDevice object. So the pipeline-residency subsystem simply never ran: every
+pipeline lacks a companion and the resident flag, and past that lies another null object of the same
+"placeholder is zeroed" kind. **Chasing per-object `[+0x140]` writers is unproductive — skipping one
+only reveals the next null.** The productive direction is systemic: drive Unity's deferred
+processing/residency pass (the "deferred to a submit/flip/frame boundary we never pump" theme — no
+`SubmitFlip` fires before the fault), which ties into the swapchain scaffolding (`prosper_vo_*`) and
+the back-half pipeline realization. Next: find what triggers the residency pass and whether pumping
+submit/flip fires it, rather than reconstructing per-object writers.
+
 ## 🔎 THE [+0x140] WRITER CHAIN (2026-07-04) — host-side RE, found the constructor + gate, root is a pipeline-reflection predicate
 
 Agent-2 (correctly) reassigned this to the front-half: the companion is built pre-submit, upstream of

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -55,6 +55,17 @@ namespace {
     bool g_faultmem = false;
     bool g_faultlog = false;
     int  g_devnull_fd = -1;
+    // DIAGNOSTIC (PROSPER_SKIP_NULL_COMPANION, default off): at the Unity GfxDevice pipeline reader
+    // eboot+0xba6e08 — which derefs a null GPU-companion pointer [obj+0x140] for pipelines that were
+    // never processed — log the object state and redirect RIP to the reader's own skip label
+    // (eboot+0xba6e40, where its type/flag-check branches already land) so processing continues as if
+    // the companion weren't needed. This is a *probe* to reveal whether the null companion is the sole
+    // blocker or one of a cascade — NOT a fix (the companions are still not real). eboot base is the
+    // fixed 0x400000000 in this project; overridable via PROSPER_SKIP_RIP / PROSPER_SKIP_TARGET.
+    bool     g_skip_null_companion = false;
+    uint64_t g_skip_rip    = 0x400ba6e08ull;   // reader companion deref (mov 0x8(%rsi),%rax; rsi=null)
+    uint64_t g_skip_target = 0x400ba6e40ull;   // reader skip label (continues via [obj+0x520/0x530])
+    volatile sig_atomic_t g_skip_count = 0;
     // PROSPER_PEEK dumps offsets off registers at fault time. Supports N specs separated by ';',
     // each "reg:off,off,..."; an offset may be prefixed '*' to chase one pointer level first
     // (e.g. "r15:*0x18+0x0" = read [[r15+0x18]+0x0]).
@@ -153,6 +164,28 @@ namespace {
                     write(2, b, n);
                 }
                 if (ok) { g_lazy_pages++; return; }  // re-execute against the now-mapped page
+            }
+        }
+        // Null-companion skip probe (diagnostic; see g_skip_null_companion). Redirect the reader past
+        // the null [obj+0x140] deref to its own skip label, logging each object's state.
+        if (g_skip_null_companion && sig == SIGSEGV) {
+            auto* uc = (ucontext_t*)uctx;
+            uint64_t rip = (uint64_t)uc->uc_mcontext.gregs[REG_RIP];
+            if (rip == g_skip_rip) {
+                uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
+                g_skip_count = g_skip_count + 1;
+                auto rd = [](uint64_t a) -> unsigned long long {
+                    return probe_readable(a) ? (unsigned long long)*(const uint64_t*)a : 0xBADBADull;
+                };
+                char b[256];
+                int n = snprintf(b, sizeof b,
+                    "[skip] #%d r15=0x%llx [+0xc0]=0x%llx [+0xe0]=0x%llx [+0x138]=0x%llx [+0x140]=0x%llx "
+                    "[+0x1a0]=0x%llx -> skip to 0x%llx\n",
+                    (int)g_skip_count, (unsigned long long)r15, rd(r15+0xc0), rd(r15+0xe0),
+                    rd(r15+0x138), rd(r15+0x140), rd(r15+0x1a0), (unsigned long long)g_skip_target);
+                write(2, b, n);
+                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                return;   // re-execute from the reader's skip label
             }
         }
         if (g_faultlog) {
@@ -266,7 +299,10 @@ void install_sigaltstack() {
 void install_trap_handler() {
     g_faultmem = getenv("PROSPER_FAULTMEM") != nullptr;   // read once (getenv is not signal-safe)
     g_faultlog = getenv("PROSPER_FAULTLOG") != nullptr;
-    if (g_faultmem && g_devnull_fd < 0)
+    g_skip_null_companion = getenv("PROSPER_SKIP_NULL_COMPANION") != nullptr;
+    if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
+    if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
+    if ((g_faultmem || g_skip_null_companion) && g_devnull_fd < 0)
         g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
     // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
     // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).


### PR DESCRIPTION
Ran the probe you approved. **The result is your bet (1): systemic — the pipeline-residency pass never ran. Stop hunting per-object writers.**

## Probe

Env-gated `PROSPER_SKIP_NULL_COMPANION` (default off). At the reader `eboot+0xba6e08`, log the object's state and redirect RIP to the reader's own skip label `eboot+0xba6e40` (where its type/flag branches already land), continuing as if the companion weren't needed. A diagnostic, not a fix — companions are still not real. Also `PROSPER_SKIP_RIP`/`PROSPER_SKIP_TARGET` to retarget.

## Result (one run)

```
[skip] #1 r15=…e2c300 [+0xc0]=0x7 [+0xe0]=…e120f0 [+0x138]=0x7 [+0x140]=0x0 [+0x1a0]=0x0        -> skip
[skip] #2 r15=…2e0940 [+0xc0]=0x4 [+0xe0]=…7d0c90 [+0x138]=0x4 [+0x140]=0x0 [+0x1a0]=0x9b838200 -> skip
[skip] #3 r15=…2e3100 [+0xc0]=0x7 [+0xe0]=…853390 [+0x138]=0x7 [+0x140]=0x0 [+0x1a0]=0x0        -> skip
[skip] #4 r15=…561c80 [+0xc0]=0x6 [+0xe0]=…d58b80 [+0x138]=0x6 [+0x140]=0x0 [+0x1a0]=0xffffff00 -> skip
=== RUN ENDED: SIGSEGV rip=eboot+0x95c823 ===   (mov (%r14),%rdi; mov (%rdi),%rax; [r14]->null)
```

- **4 bounded skips** — not an infinite cascade of the same deref (bounded = collection size), so it's not a tight loop.
- **All 4 have `[+0x140]=0` and resident-flag low byte `[+0x1a0]&0xff = 0`** — every pipeline lacks a companion *and* the processed marker. Nothing ran on any of them. (Note `[+0x1a0]` has non-zero *high* bytes on #2/#4 but the reader tests the low byte, which is 0 — so they all take the deref path.)
- **It does NOT reach a frame** — past the companion nulls it immediately hits another null GfxDevice object at `0x95c823`.

## Verdict

This is the systemic signal, not a narrow gap: the pipeline-residency subsystem simply **never ran**, so every pipeline is null-companion + unprocessed, and skipping past them just surfaces the next null object of the same "zeroed placeholder" kind. **Per-object `[+0x140]` writer hunting is confirmed unproductive** — which retroactively explains why the writer target kept turning out to be the wrong object.

The productive direction is systemic, matching your theme: **drive Unity's deferred processing/residency pass** (no `SubmitFlip` fires before the fault; the pass is very likely gated on a submit/flip/frame boundary we never pump). That ties into the swapchain scaffolding I built (`prosper_vo_*`) and your back-half pipeline realization waiting downstream.

**Proposed next step (mine):** find what triggers the residency pass — trace who would call it on a submit/flip, and whether pumping `SubmitDcb`/`SubmitFlip` (which we can drive now that VideoOut buffers are registered) makes it fire. That's front-half + ties to your back-half. Sound? Or do you want to set up the submit/flip drive from the back-half side since it feeds your pipeline realization?

30/30 tests. Probe retained as a strategy tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
