### PR TITLE
videoout: preserve submitted flip and buffer state

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -96,6 +96,8 @@ namespace {
     int      g_vo_handle = 0;
     uint64_t g_flip_count = 0;    // incremented per SubmitFlip so GetFlipStatus shows progress
     uint64_t g_vblank_count = 0;
+    int32_t  g_current_buffer = 0;
+    int64_t  g_last_flip_arg = 0;
 
     // The one display we advertise. 1920x1080 @ 59.94Hz (refresh-rate enum 3), 16:9, ~50".
     constexpr uint32_t kDispW = 1920, kDispH = 1080;
@@ -134,14 +136,19 @@ extern "C" uint64_t prosper_vo_buffer_addr(int i) {
 }
 HLE(g_vo_open)        { gfx_tick(); return (uint64_t)(int64_t)(++g_vo_handle + 0x1000); }  // positive handle
 HLE(g_vo_close)       { return 0; }
-HLE(g_vo_submitflip)  { g_flip_count++; return 0; }                            // accept the flip
+HLE(g_vo_submitflip)  {
+    g_flip_count++;
+    g_current_buffer = (int32_t)a1;
+    g_last_flip_arg = (int64_t)a3;
+    return 0;
+}
 HLE(g_vo_flippending) { return 0; }                                            // never pending -> can submit next
 HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our simulated flip count.
     // SceVideoOutFlipStatus is exactly 0x40 bytes — writing more smashes the caller's stack canary!
     if (a1) { uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x40);
               *(uint64_t*)(s + 0x00) = g_flip_count;          // count
-              *(int64_t*) (s + 0x18) = (int64_t)g_flip_count; // flipArg
-              *(int32_t*) (s + 0x38) = 0; }                   // currentBuffer
+              *(int64_t*) (s + 0x18) = g_last_flip_arg;       // flipArg
+              *(int32_t*) (s + 0x38) = g_current_buffer; }    // currentBuffer
     return 0;
 }
 // SceVideoOutResolutionStatus (0x20 bytes, Kyty VideoOutResolutionStatus): report a real 1080p60

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -210,9 +210,9 @@ HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a
     g_display.pixel_format = *(const uint64_t*)(attr + 0x20);
     g_display.tiling_mode  = *(const uint32_t*)(attr + 0x04);
     const auto* bufs = (const VideoOutBuffers*)(uintptr_t)a3;
-    g_display.buffer_num = num;
     for (int i = 0; i < num && start + i < 16; i++)
         g_display.buffer_addr[start + i] = (uint64_t)(uintptr_t)bufs[i].data;
+    if (g_display.buffer_num < start + num) g_display.buffer_num = start + num;
     g_display.configured = true;
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[vo] display surface: %ux%u fmt=0x%llx %d buffers registered\n",

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -30,8 +30,10 @@ int main() {
     auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
     auto cfg    = Hle::lookup("w0hLuNarQxY");   // ConfigureOutput
-    CHECK(res && vbl && cap && issup && setba2 && regb2 && cfg, "VideoOut functions registered");
-    if (!(res && vbl && cap && issup && setba2 && regb2 && cfg)) { printf("== FAIL ==\n"); return 1; }
+    auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
+    auto fstat  = Hle::lookup(nid_hash("sceVideoOutGetFlipStatus"));
+    CHECK(res && vbl && cap && issup && setba2 && regb2 && cfg && flip && fstat, "VideoOut functions registered");
+    if (!(res && vbl && cap && issup && setba2 && regb2 && cfg && flip && fstat)) { printf("== FAIL ==\n"); return 1; }
 
     // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed.
     uint8_t rs[0x20]; memset(rs, 0xEE, sizeof rs);
@@ -78,6 +80,14 @@ int main() {
     CHECK(prosper_vo_display_format() == fmt, "registry recorded the pixel format");
     CHECK(prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
           prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2, "registry recorded each framebuffer address");
+
+    uint8_t fs[0x40]; memset(fs, 0xEE, sizeof fs);
+    CHECK(flip(0x1001, 2 /*buffer*/, 0 /*mode*/, 0x12345678 /*flipArg*/, 0, 0) == 0,
+          "SubmitFlip accepted buffer 2");
+    fstat(0x1001, (uint64_t)(uintptr_t)fs, 0, 0, 0, 0);
+    CHECK(*(uint64_t*)(fs + 0x00) == 1, "flip status count increments");
+    CHECK(*(int64_t*) (fs + 0x18) == 0x12345678, "flip status reports the submitted flipArg");
+    CHECK(*(int32_t*) (fs + 0x38) == 2, "flip status reports the submitted currentBuffer");
 
     // Range validation: out-of-range buffer counts are rejected.
     CHECK(regb2(0x1001, 0, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -81,6 +81,16 @@ int main() {
     CHECK(prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
           prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2, "registry recorded each framebuffer address");
 
+    uint8_t fb1b[16], fb2b[16];
+    VOB offset_buffers[2] = { {fb1b,0,{0,0}}, {fb2b,0,{0,0}} };
+    rc = regb2(0x1001, 0, 1 /*start*/, (uint64_t)(uintptr_t)offset_buffers, 2, (uint64_t)(uintptr_t)attr);
+    CHECK(rc == 0, "RegisterBuffers2 accepted a non-zero buffer_index_start");
+    CHECK(prosper_vo_buffer_count() == 3, "registry exposes the highest registered buffer index");
+    CHECK(prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
+          prosper_vo_buffer_addr(1) == (uint64_t)(uintptr_t)fb1b &&
+          prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2b,
+          "registry records non-zero-start buffers at their absolute indices");
+
     uint8_t fs[0x40]; memset(fs, 0xEE, sizeof fs);
     CHECK(flip(0x1001, 2 /*buffer*/, 0 /*mode*/, 0x12345678 /*flipArg*/, 0, 0) == 0,
           "SubmitFlip accepted buffer 2");


### PR DESCRIPTION
Fixes two VideoOut review findings from the recent swapchain-scaffolding commits.\n\nCommits:\n- videoout: report submitted flip state — SubmitFlip now preserves the submitted buffer index and flipArg, and GetFlipStatus reports them instead of always returning currentBuffer=0.\n- videoout: preserve absolute buffer indices — RegisterBuffers2 now exposes non-zero buffer_index_start registrations by tracking the highest registered absolute index.\n\nTests:\n- Windows build-win-codex: ctest 14/14\n- WSL2 build-wsl-codex: ctest 31/31, including videoout_queries and Vulkan-gated graphics tests\n\nLine endings: touched files verified LF-only (CRLF=0).