### PR TITLE
diag: companion write-watchpoint — slot only zero-inited, no builder (ordering theory refuted)

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -69,6 +69,17 @@ namespace {
     bool     g_null_page = false;              // PROSPER_NULL_PAGE: back low null reads with zero page
     volatile sig_atomic_t g_null_page_count = 0;
     unsigned g_null_page_mask = 0;             // which of the 16 low pages [0,0x10000) are backed
+    // PROSPER_WATCH_COMPANION: write-watchpoint on the companion slot [obj+0x140] that the reader
+    // eboot+0xba6e08 finds null. Armed on the first such read (r15 known); the slot is null there, so
+    // any real writer MUST run after — this catches all of them. Implemented by mprotect-ing the
+    // slot's page read-only and single-stepping (trap flag) over each write, logging writes that land
+    // in the 8-byte slot with the writer's PC. Answers: does ANYTHING write it, and from where.
+    bool     g_watch_companion = false;
+    uint64_t g_watch_addr = 0;                 // r15+0x140
+    uint64_t g_watch_page = 0;
+    bool     g_watch_armed = false;
+    bool     g_watch_stepping = false;
+    volatile sig_atomic_t g_watch_hits = 0;
     // PROSPER_PEEK dumps offsets off registers at fault time. Supports N specs separated by ';',
     // each "reg:off,off,..."; an offset may be prefixed '*' to chase one pointer level first
     // (e.g. "r15:*0x18+0x0" = read [[r15+0x18]+0x0]).
@@ -152,6 +163,70 @@ namespace {
     volatile sig_atomic_t g_lazy_pages = 0;                 // count (diagnostic)
 
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
+        // Companion-slot write-watchpoint: SIGTRAP after single-stepping a write to the watched page —
+        // re-arm (re-protect read-only) and clear the trap flag so we keep watching.
+        if (sig == SIGTRAP && g_watch_stepping) {
+            auto* uc = (ucontext_t*)uctx;
+            uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;   // clear TF
+            // Post-write: log the slot's new value + the object's type tag [r15+0] (0x2b if it's still
+            // the same live object; changed => the memory was freed and reused, so the write is churn).
+            unsigned long long slot = *(const uint64_t*)g_watch_addr;
+            unsigned long long tag  = *(const uint64_t*)(g_watch_addr - 0x140);
+            char b[128];
+            int n = snprintf(b, sizeof b, "[watch]   -> slot now=0x%llx  obj[+0]=0x%llx\n", slot, tag);
+            write(2, b, n);
+            mprotect((void*)g_watch_page, 0x1000, PROT_READ);
+            g_watch_stepping = false;
+            return;
+        }
+        // Arm the watchpoint on the first companion read (rip == the reader deref, slot still null).
+        if (g_watch_companion && sig == SIGSEGV && !g_watch_armed) {
+            auto* uc = (ucontext_t*)uctx;
+            if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
+                uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
+                g_watch_addr = r15 + 0x140;
+                g_watch_page = g_watch_addr & ~(uint64_t)0xfff;
+                if (mprotect((void*)g_watch_page, 0x1000, PROT_READ) == 0) {
+                    g_watch_armed = true;
+                    char b[128];
+                    int n = snprintf(b, sizeof b, "[watch] armed on companion slot 0x%llx (obj r15=0x%llx) reader-tid=%ld\n",
+                                     (unsigned long long)g_watch_addr, (unsigned long long)r15, cur_tid());
+                    write(2, b, n);
+                }
+                // Skip this (null) read so the boot proceeds; the slot's page is now watched.
+                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                return;
+            }
+        }
+        // A write to the watched page (x86 page-fault error code bit 1 = write) while armed: log if it
+        // lands in the 8-byte companion slot, then single-step past it (unprotect + set TF).
+        if (g_watch_armed && sig == SIGSEGV && si->si_addr) {
+            uint64_t fa = (uint64_t)si->si_addr;
+            auto* uc = (ucontext_t*)uctx;
+            if ((fa & ~(uint64_t)0xfff) == g_watch_page && (uc->uc_mcontext.gregs[REG_ERR] & 2)) {
+                if (fa >= g_watch_addr && fa < g_watch_addr + 8) {
+                    g_watch_hits = g_watch_hits + 1;
+                    char b[160];
+                    int n = snprintf(b, sizeof b, "[watch] WRITE to companion slot 0x%llx from rip=0x%llx writer-tid=%ld (hit #%d)\n",
+                                     (unsigned long long)fa,
+                                     (unsigned long long)uc->uc_mcontext.gregs[REG_RIP], cur_tid(),
+                                     (int)g_watch_hits);
+                    write(2, b, n);
+                }
+                mprotect((void*)g_watch_page, 0x1000, PROT_READ | PROT_WRITE);
+                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // set TF -> single-step the write
+                g_watch_stepping = true;
+                return;
+            }
+        }
+        // Repeated companion reads (later reader passes): skip them too so the boot keeps running.
+        if (g_watch_armed && sig == SIGSEGV) {
+            auto* uc = (ucontext_t*)uctx;
+            if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
+                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                return;
+            }
+        }
         // Lazy unified-memory backing: back an unmapped GPU-VA page on demand and retry.
         if (sig == SIGSEGV && si->si_addr) {
             uint64_t a = (uint64_t)si->si_addr;
@@ -332,6 +407,7 @@ void install_trap_handler() {
     g_faultlog = getenv("PROSPER_FAULTLOG") != nullptr;
     g_skip_null_companion = getenv("PROSPER_SKIP_NULL_COMPANION") != nullptr;
     g_null_page = getenv("PROSPER_NULL_PAGE") != nullptr;
+    g_watch_companion = getenv("PROSPER_WATCH_COMPANION") != nullptr;
     if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
     if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
     if ((g_faultmem || g_skip_null_companion) && g_devnull_fd < 0)
@@ -370,6 +446,7 @@ void install_trap_handler() {
     sigaction(SIGSEGV, &sa, nullptr);
     sigaction(SIGBUS,  &sa, nullptr);
     sigaction(SIGILL,  &sa, nullptr);
+    if (g_watch_companion) sigaction(SIGTRAP, &sa, nullptr);   // single-step for the write-watchpoint
 }
 
 uint64_t stub_addr(uint64_t idx) { return g_stub_base + idx * g_stub_size; }

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -75,7 +75,8 @@ namespace {
     // slot's page read-only and single-stepping (trap flag) over each write, logging writes that land
     // in the 8-byte slot with the writer's PC. Answers: does ANYTHING write it, and from where.
     bool     g_watch_companion = false;
-    uint64_t g_watch_addr = 0;                 // r15+0x140
+    uint64_t g_watch_off = 0x140;              // PROSPER_WATCH_OFF: which slot off r15 (0x140 companion, 0x1a0 gate)
+    uint64_t g_watch_addr = 0;                 // r15+g_watch_off
     uint64_t g_watch_page = 0;
     bool     g_watch_armed = false;
     bool     g_watch_stepping = false;
@@ -184,14 +185,36 @@ namespace {
             auto* uc = (ucontext_t*)uctx;
             if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
                 uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
-                g_watch_addr = r15 + 0x140;
+                g_watch_addr = r15 + g_watch_off;
                 g_watch_page = g_watch_addr & ~(uint64_t)0xfff;
                 if (mprotect((void*)g_watch_page, 0x1000, PROT_READ) == 0) {
                     g_watch_armed = true;
-                    char b[128];
-                    int n = snprintf(b, sizeof b, "[watch] armed on companion slot 0x%llx (obj r15=0x%llx) reader-tid=%ld\n",
-                                     (unsigned long long)g_watch_addr, (unsigned long long)r15, cur_tid());
+                    char b[192];
+                    int n = snprintf(b, sizeof b, "[watch] armed on slot [+0x%llx]=0x%llx (obj r15=0x%llx) reader-tid=%ld\n",
+                                     (unsigned long long)g_watch_off, (unsigned long long)g_watch_addr,
+                                     (unsigned long long)r15, cur_tid());
                     write(2, b, n);
+                    // Capture the type the reader tested (bt 0xc8220): O=[rsp+0x30], typ=[[O]+0x1e4c],
+                    // remapped=table[typ] at eboot+0x1ca3b80. We're past the type gate (deref reached),
+                    // so this shows WHICH type/remap value let these pipelines through.
+                    // Scan the reader's stack frame for the type-source object O (the one whose
+                    // [*O+0x1e4c] remaps INTO mask 0xc8220 — that's what let this deref through).
+                    uint64_t rsp = (uint64_t)uc->uc_mcontext.gregs[REG_RSP];
+                    for (uint64_t off = 0; off <= 0x100; off += 8) {
+                        uint64_t sa = rsp + off;
+                        if (!probe_readable(sa)) continue;
+                        uint64_t O = *(const uint64_t*)sa;
+                        if (!probe_readable(O) || !probe_readable(O + 0x1e4c)) continue;
+                        uint32_t typ = *(const uint32_t*)(*(const uint64_t*)O + 0x1e4c);
+                        uint64_t taddr = 0x401ca3b80ull + (uint64_t)typ * 4;
+                        if (!probe_readable(taddr)) continue;
+                        uint32_t remap = *(const uint32_t*)taddr;
+                        if (remap <= 0x13 && ((0xc8220u >> remap) & 1)) {   // matches the reader's gate
+                            n = snprintf(b, sizeof b, "[watch] type-source @rsp+0x%llx: raw=0x%x remapped=0x%x IN-MASK\n",
+                                         (unsigned long long)off, typ, remap);
+                            write(2, b, n);
+                        }
+                    }
                 }
                 // Skip this (null) read so the boot proceeds; the slot's page is now watched.
                 uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
@@ -408,9 +431,10 @@ void install_trap_handler() {
     g_skip_null_companion = getenv("PROSPER_SKIP_NULL_COMPANION") != nullptr;
     g_null_page = getenv("PROSPER_NULL_PAGE") != nullptr;
     g_watch_companion = getenv("PROSPER_WATCH_COMPANION") != nullptr;
+    if (const char* wo = getenv("PROSPER_WATCH_OFF")) g_watch_off = strtoull(wo, nullptr, 0);
     if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
     if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
-    if ((g_faultmem || g_skip_null_companion) && g_devnull_fd < 0)
+    if ((g_faultmem || g_skip_null_companion || g_watch_companion) && g_devnull_fd < 0)
         g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
     // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
     // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).


### PR DESCRIPTION
Watchpoint done — observed, not inferred. **The companion slot is only ever zero-initialized; no builder ever writes a real companion.**

## Method

`PROSPER_WATCH_COMPANION` (default off): arm a write-watchpoint on `[obj+0x140]` at the first `0xba6e08` read (slot is null there, so any real writer must run *after* — caught). `mprotect` the slot's page read-only + single-step (trap flag / `SIGTRAP`) over each write, logging writer PC, thread, and the post-write value + object type tag.

## Result (decisive)

```
[watch] armed on companion slot 0x…c440 (obj r15=0x…c300) reader-tid=537
[watch]   -> slot now=0x0  obj[+0]=0x2b      (×50, from both reader-tid + a worker-tid)
writer rips: 0x500003ef4 (×47), 0x5000103f9 (×2)  = libc memset/memcpy
```

- The slot **is** written ~50×, by both the reader thread and a worker thread, from libc `memset`/`memcpy`.
- But **every write stores `0`** (post-write slot=`0x0`), and `obj[+0]=0x2b` throughout (same live object, not freed/reused).

So the writes are **zero-initialization / reset**, not a companion builder. A real (non-null) companion pointer is **never** written.

## What this settles

- **(a)** Anything write it? Yes — but only value `0`.
- **(b)** From where? libc `memset` (`0x500003ef4`) on the reader thread + a worker.
- **(c)** A non-null write? **Never** → no builder runs for these objects.

This **refutes the late-builder/ordering-race theory** (the writes are just zeroing). The companion is genuinely never built — not built-late, not raced. So the fix isn't "fire the residency pass at the right time"; there is no pass writing it. The builder is either never invoked or gated on a condition absent in our env.

## Strategy fork

Four theories have now been eliminated by data: companion-writer-object (wrong object), event-queue (timing thread), degenerate-device (init succeeds), and now late-builder/ordering (writes are zero-init). What remains: the companion builder is **conditionally skipped** — recall the builder I traced (`0x15ae`, sibling type) was gated by predicate `0xd58710` scanning a reflection worklist, and for these zero-varying pipelines that worklist is legitimately empty → builder correctly skips → but the reader derefs anyway. That points back to: **on real hardware, does a zero-varying pipeline even reach this reader with a null companion, or does the reader tolerate null?** I think the productive question is no longer "what builds it" (nothing does, correctly) but "why does our reader path fault on a legitimately-absent companion when hardware wouldn't." Your call on whether that's worth chasing or whether we've mapped this fault enough to park it and move to something with better ROI.

31/31 tests. Watchpoint retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
