### PR TITLE
diag: preserve companion watchpoint result

### DIFF
--- a/prosper/docs/GFXDEVICE_BRINGUP_PROBLEM.md
+++ b/prosper/docs/GFXDEVICE_BRINGUP_PROBLEM.md
@@ -2,8 +2,9 @@
 
 **Status:** open, blocking. **Audience:** an agent who has *not* lived this investigation and needs
 full context. **Ask:** a fresh framework / a second pair of eyes on why Unity's GfxDevice object
-graph comes up systematically null in our environment. Three mechanism-hypotheses have missed; we
-think the way forward is *ground-truth observation*, not a fourth guess (see §8).
+graph comes up systematically null in our environment. Four mechanism-hypotheses have missed; the
+latest watchpoint result changes the question from "who builds the missing companion?" to "why does
+the reader require a companion that this pipeline class legitimately lacks?" (see §8).
 
 ---
 
@@ -96,6 +97,11 @@ draw). So we are stuck in **CPU-side engine construction**, before any real rend
    by an AGC call, it's a call we *do* implement — as a no-op / return-0 — not a missing one.
 6. The GfxDevice sub-object graph is **systematically null** (one zero page satisfies every null
    field read), terminating in a **virtual call on a null object**.
+7. **The companion slot is not built late.** `PROSPER_WATCH_COMPANION` showed the faulting
+   `[obj+0x140]` slot is written many times, but every observed write stores zero from reset/memset
+   paths on both the reader thread and a worker thread. The object tag stays `[+0]=0x2b`, so this is
+   the same live object being zeroed, not a non-null builder that races the reader. No non-null
+   companion write was observed.
 
 ---
 
@@ -141,6 +147,8 @@ evidence. The pattern — reasoning *about* Unity's internals from the fault sit
   Kyty's VS→PS linkage expects). The faulting pair are genuinely **zero-varying** shaders
   (position-only / blit / clear) — so the empty reflection worklist is a *correct* consequence for
   them, not a surfacing bug. (One PS does have a single `sharp[3]` storage-buffer binding.)
+- **Late writer / ordering race** is not the gate: the companion watchpoint saw only zero writes, not
+  a delayed non-null construction. The `[+0x140]` companion is absent by design for this object shape.
 
 ---
 
@@ -182,6 +190,9 @@ shifted across probes — treat offsets as observations, not confirmed semantics
 - `PROSPER_SKIP_NULL_COMPANION` — at `0xba6e08`, skip the null-companion deref (RIP redirect) and log.
 - `PROSPER_NULL_PAGE` — back low-address read faults with a shared zero page; leaves write/call-through
   -null unbacked (the real endpoints). Reveals the whole null-read chain.
+- `PROSPER_WATCH_COMPANION` — at the first `0xba6e08` null read, arm a page-protection
+  write-watchpoint on `[obj+0x140]`, single-step writer faults, and log writer PC/thread plus the
+  post-write slot value. Its first result: only zero writes from reset/memset paths.
 - `PROSPER_FAULTMEM` / `PROSPER_FAULTLOG` — fault-time register/memory dump + logging.
 - `tools/boot_trace` — links all modules, boots headless, prints the unimplemented-call trace +
   register state + module-classified rbp backtrace on fault.
@@ -192,24 +203,30 @@ shifted across probes — treat offsets as observations, not confirmed semantics
 
 ---
 
-## 8. Current plan — stop guessing the mechanism, observe it
+## 8. Current plan — the watchpoint answered; decide whether to keep chasing this wall
 
-Three misses all came from *inferring* Unity's internals. The proposed next step is **ground truth**:
+Four misses all came from *inferring* Unity's internals. The watchpoint supplied the requested ground
+truth and refuted the last ordering theory: `[obj+0x140]` is zero-initialized/reset, never populated
+with a real companion. Combined with the `0xd58710` predicate result, this means the companion is
+legitimately absent for these zero-varying pipelines.
 
-> **Watchpoint the null slot.** Pick the *earliest* null sub-object slot in the chain (not the deep
-> `0x95c823` one). Put a **write-watchpoint** on its address (hardware debug register `DR0–3`, or
-> `mprotect` the page + catch the write — same fault machinery as the probes) and replay the boot.
-> Report: (a) does *anything* ever write that slot? (b) if yes — from what PC/function, storing what,
-> and what were the last few HLE calls before it? (c) if nothing ever writes it — what is the last HLE
-> call before the slot is *read* as null?
+The remaining question is now narrower and harder:
 
-That single observation distinguishes the remaining possibilities **with data instead of a guess**:
-- a write happens but stores null / early-returns → that's the builder; see *why* it produced null;
-- nothing ever writes it → the builder never ran → correlate the expected-write moment against the
-  HLE call trace to find what *should* have triggered it (tests "an AGC call we no-op should populate
-  it");
-- a write comes from a completion/readback path → then (and only then) does "needs real GPU execution"
-  have evidence.
+> Why does the `0xba6e08` reader take the companion-required path for a pipeline whose companion is
+> legitimately absent?
+
+The plausible next probes are reader-side, not writer-side:
+- Watch `[obj+0x1a0]` and the type/mask inputs to prove whether a "processed/no-companion-needed" bit
+  is never set, is reset to zero, or is not the real gate.
+- Disassemble/trace `0xba6720..0xba6e40` enough to prove the exact branch contract before changing
+  any state. A local RIP skip is still only a diagnostic; it is not a correctness fix.
+- Compare the faulting zero-varying pipeline against a non-faulting pipeline that does get a
+  companion, focusing on the reflection records consumed by `0xd58710` and the reader's type remap.
+
+Strategically, this path now has uncertain ROI. The renderer and shader path are already verified
+offscreen; absent new reference evidence for the Unity PS5 reader contract, parking `0xba6e08` as a
+well-characterized Unity-init wall and redirecting effort to present/swapchain, recompiler coverage,
+or a real-shader demonstration frame is defensible.
 
 ### A hypothesis we explicitly do NOT endorse yet
 "These sub-objects are built by **GPU-execution side-effects** we don't perform, so this needs real

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -69,6 +69,17 @@ namespace {
     bool     g_null_page = false;              // PROSPER_NULL_PAGE: back low null reads with zero page
     volatile sig_atomic_t g_null_page_count = 0;
     unsigned g_null_page_mask = 0;             // which of the 16 low pages [0,0x10000) are backed
+    // PROSPER_WATCH_COMPANION: write-watchpoint on the companion slot [obj+0x140] that the reader
+    // eboot+0xba6e08 finds null. Armed on the first such read (r15 known); the slot is null there, so
+    // any real writer MUST run after — this catches all of them. Implemented by mprotect-ing the
+    // slot's page read-only and single-stepping (trap flag) over each write, logging writes that land
+    // in the 8-byte slot with the writer's PC. Answers: does ANYTHING write it, and from where.
+    bool     g_watch_companion = false;
+    uint64_t g_watch_addr = 0;                 // r15+0x140
+    uint64_t g_watch_page = 0;
+    bool     g_watch_armed = false;
+    bool     g_watch_stepping = false;
+    volatile sig_atomic_t g_watch_hits = 0;
     // PROSPER_PEEK dumps offsets off registers at fault time. Supports N specs separated by ';',
     // each "reg:off,off,..."; an offset may be prefixed '*' to chase one pointer level first
     // (e.g. "r15:*0x18+0x0" = read [[r15+0x18]+0x0]).
@@ -152,6 +163,70 @@ namespace {
     volatile sig_atomic_t g_lazy_pages = 0;                 // count (diagnostic)
 
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
+        // Companion-slot write-watchpoint: SIGTRAP after single-stepping a write to the watched page —
+        // re-arm (re-protect read-only) and clear the trap flag so we keep watching.
+        if (sig == SIGTRAP && g_watch_stepping) {
+            auto* uc = (ucontext_t*)uctx;
+            uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;   // clear TF
+            // Post-write: log the slot's new value + the object's type tag [r15+0] (0x2b if it's still
+            // the same live object; changed => the memory was freed and reused, so the write is churn).
+            unsigned long long slot = *(const uint64_t*)g_watch_addr;
+            unsigned long long tag  = *(const uint64_t*)(g_watch_addr - 0x140);
+            char b[128];
+            int n = snprintf(b, sizeof b, "[watch]   -> slot now=0x%llx  obj[+0]=0x%llx\n", slot, tag);
+            write(2, b, n);
+            mprotect((void*)g_watch_page, 0x1000, PROT_READ);
+            g_watch_stepping = false;
+            return;
+        }
+        // Arm the watchpoint on the first companion read (rip == the reader deref, slot still null).
+        if (g_watch_companion && sig == SIGSEGV && !g_watch_armed) {
+            auto* uc = (ucontext_t*)uctx;
+            if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
+                uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
+                g_watch_addr = r15 + 0x140;
+                g_watch_page = g_watch_addr & ~(uint64_t)0xfff;
+                if (mprotect((void*)g_watch_page, 0x1000, PROT_READ) == 0) {
+                    g_watch_armed = true;
+                    char b[128];
+                    int n = snprintf(b, sizeof b, "[watch] armed on companion slot 0x%llx (obj r15=0x%llx) reader-tid=%ld\n",
+                                     (unsigned long long)g_watch_addr, (unsigned long long)r15, cur_tid());
+                    write(2, b, n);
+                }
+                // Skip this (null) read so the boot proceeds; the slot's page is now watched.
+                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                return;
+            }
+        }
+        // A write to the watched page (x86 page-fault error code bit 1 = write) while armed: log if it
+        // lands in the 8-byte companion slot, then single-step past it (unprotect + set TF).
+        if (g_watch_armed && sig == SIGSEGV && si->si_addr) {
+            uint64_t fa = (uint64_t)si->si_addr;
+            auto* uc = (ucontext_t*)uctx;
+            if ((fa & ~(uint64_t)0xfff) == g_watch_page && (uc->uc_mcontext.gregs[REG_ERR] & 2)) {
+                if (fa >= g_watch_addr && fa < g_watch_addr + 8) {
+                    g_watch_hits = g_watch_hits + 1;
+                    char b[160];
+                    int n = snprintf(b, sizeof b, "[watch] WRITE to companion slot 0x%llx from rip=0x%llx writer-tid=%ld (hit #%d)\n",
+                                     (unsigned long long)fa,
+                                     (unsigned long long)uc->uc_mcontext.gregs[REG_RIP], cur_tid(),
+                                     (int)g_watch_hits);
+                    write(2, b, n);
+                }
+                mprotect((void*)g_watch_page, 0x1000, PROT_READ | PROT_WRITE);
+                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // set TF -> single-step the write
+                g_watch_stepping = true;
+                return;
+            }
+        }
+        // Repeated companion reads (later reader passes): skip them too so the boot keeps running.
+        if (g_watch_armed && sig == SIGSEGV) {
+            auto* uc = (ucontext_t*)uctx;
+            if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
+                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                return;
+            }
+        }
         // Lazy unified-memory backing: back an unmapped GPU-VA page on demand and retry.
         if (sig == SIGSEGV && si->si_addr) {
             uint64_t a = (uint64_t)si->si_addr;
@@ -332,6 +407,7 @@ void install_trap_handler() {
     g_faultlog = getenv("PROSPER_FAULTLOG") != nullptr;
     g_skip_null_companion = getenv("PROSPER_SKIP_NULL_COMPANION") != nullptr;
     g_null_page = getenv("PROSPER_NULL_PAGE") != nullptr;
+    g_watch_companion = getenv("PROSPER_WATCH_COMPANION") != nullptr;
     if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
     if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
     if ((g_faultmem || g_skip_null_companion) && g_devnull_fd < 0)
@@ -370,6 +446,7 @@ void install_trap_handler() {
     sigaction(SIGSEGV, &sa, nullptr);
     sigaction(SIGBUS,  &sa, nullptr);
     sigaction(SIGILL,  &sa, nullptr);
+    if (g_watch_companion) sigaction(SIGTRAP, &sa, nullptr);   // single-step for the write-watchpoint
 }
 
 uint64_t stub_addr(uint64_t idx) { return g_stub_base + idx * g_stub_size; }

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -241,7 +241,7 @@ namespace {
                                      (unsigned long long)uc->uc_mcontext.gregs[REG_RIP]);
                     write(2, b, n);
                 }
-                if (ok) { g_lazy_pages++; return; }  // re-execute against the now-mapped page
+                if (ok) { g_lazy_pages = g_lazy_pages + 1; return; }  // re-execute against the now-mapped page
             }
         }
         // NULL-CHAIN probe (PROSPER_NULL_PAGE, default off): back a low-address read fault with a


### PR DESCRIPTION
## Summary
- carry Agent 2's PROSPER_WATCH_COMPANION probe onto current master without deleting GFXDEVICE_BRINGUP_PROBLEM.md
- document the decisive watchpoint result: the companion slot is only zero-initialized/reset, never populated with a non-null companion
- remove the volatile increment warning in the touched Linux fault-handler file

## Interpretation
The evidence flips the current GfxDevice question from a missing/late writer to reader-side divergence: why does eboot+0xba6e08 require a companion for a zero-varying pipeline whose companion is legitimately absent? The brief now recommends reader-side probes or parking this well-characterized wall in favor of present/swapchain, recompiler coverage, or a real-shader demonstration frame.

## Verification
- Windows: cmake --build build-win-codex
- Windows: ctest --test-dir build-win-codex --output-on-failure (14/14)
- WSL2: cmake --build build-wsl-codex
- WSL2: ctest --test-dir build-wsl-codex --output-on-failure (31/31)
- LF-only touched files: GFXDEVICE_BRINGUP_PROBLEM.md, exec_image_linux.cpp