### PR TITLE
videoout: flip→present path over the display-buffer registry (headless scanout)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -169,6 +169,12 @@ if(TARGET prosper_core)
     target_link_libraries(test_videoout PRIVATE prosper_core)
     add_test(NAME videoout_queries COMMAND test_videoout)
 
+    # libSceVideoOut flip->present: SubmitFlip scans out the registered buffer; present_readback
+    # returns the presented frame's real pixels. The surface the renderer presents frames to.
+    add_executable(test_present tests/test_present.cpp)
+    target_link_libraries(test_present PRIVATE prosper_core)
+    add_test(NAME videoout_present COMMAND test_present)
+
     # Graphics-phase foundation + agentic-first verification harness: headless offscreen Vulkan
     # (render/clear -> readback -> pixel/CRC assert). Only built if Vulkan dev files are present.
     find_package(Vulkan QUIET)

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -1,0 +1,50 @@
+// videoout_present.cpp — see videoout_present.hpp.
+#include "videoout_present.hpp"
+#include <atomic>
+#include <cstring>
+
+// The display surface lives in the libSceVideoOut buffer registry (hle_graphics.cpp), exposed via
+// these C hooks. Reading through them keeps the present layer decoupled from the HLE.
+extern "C" int      prosper_vo_buffer_count();
+extern "C" uint32_t prosper_vo_display_width();
+extern "C" uint32_t prosper_vo_display_height();
+extern "C" uint64_t prosper_vo_display_format();
+extern "C" uint64_t prosper_vo_buffer_addr(int i);
+
+namespace prosper::gpu {
+namespace {
+std::atomic<int>      g_front{-1};
+std::atomic<uint64_t> g_present_count{0};
+}
+
+void present_flip(int buffer_index, int64_t /*flip_arg*/) {
+    // Only accept a buffer the game actually registered; otherwise leave the front unchanged (an
+    // invalid index shouldn't corrupt scanout state).
+    if (buffer_index >= 0 && buffer_index < prosper_vo_buffer_count())
+        g_front.store(buffer_index, std::memory_order_relaxed);
+    g_present_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+int      present_front_index() { return g_front.load(std::memory_order_relaxed); }
+uint64_t present_count()       { return g_present_count.load(std::memory_order_relaxed); }
+uint32_t present_width()       { return prosper_vo_display_width(); }
+uint32_t present_height()      { return prosper_vo_display_height(); }
+
+size_t present_readback(void* dst, size_t dst_cap) {
+    int front = g_front.load(std::memory_order_relaxed);
+    if (front < 0 || !dst) return 0;
+    uint64_t addr = prosper_vo_buffer_addr(front);
+    uint32_t w = prosper_vo_display_width(), h = prosper_vo_display_height();
+    if (!addr || !w || !h) return 0;
+    size_t bytes = (size_t)w * h * 4;   // 32-bit color (BGRA/RGBA per the registered pixel format)
+    if (dst_cap < bytes) return 0;
+    std::memcpy(dst, (const void*)(uintptr_t)addr, bytes);
+    return bytes;
+}
+
+void present_reset() {
+    g_front.store(-1, std::memory_order_relaxed);
+    g_present_count.store(0, std::memory_order_relaxed);
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -1,0 +1,34 @@
+// videoout_present.hpp — headless present / swapchain over the libSceVideoOut display buffers.
+//
+// libSceVideoOut registers N framebuffers (the swapchain images) via RegisterBuffers2; the game
+// then calls SubmitFlip(buffer_index) to present one. This module is the present side of that path:
+// it tracks which buffer is currently scanned out (the "front" buffer) and lets the presented frame
+// be read back (for verification now, and for a real window/offscreen Vulkan swapchain later).
+//
+// It reads the display surface from the prosper_vo_* buffer registry (hle_graphics.cpp), so it stays
+// decoupled: sceVideoOutSubmitFlip just calls present_flip(). The framebuffer memory is guest GPU
+// memory (unified, 1:1-mapped), so readback copies real pixels — nothing is faked. Until the renderer
+// writes real frames into those buffers the contents are whatever the guest put there (zero), but the
+// flip→present→scanout plumbing is exercised and testable end-to-end.
+#pragma once
+#include <cstdint>
+#include <cstddef>
+
+namespace prosper::gpu {
+
+// Present the display buffer `buffer_index` (from sceVideoOutSubmitFlip). Records it as the front
+// buffer and bumps the present counter. `flip_arg` is the guest's flip label (echoed in flip status).
+void present_flip(int buffer_index, int64_t flip_arg);
+
+int      present_front_index();   // currently-presented buffer index (-1 before the first flip)
+uint64_t present_count();         // total flips presented
+uint32_t present_width();
+uint32_t present_height();
+
+// Copy the presented frame's pixels (width*height, 4 bytes/pixel) from the front buffer's guest
+// memory into `dst`. Returns bytes written, or 0 if there is no surface / no flip yet / dst too small.
+size_t present_readback(void* dst, size_t dst_cap);
+
+void present_reset();             // tests: clear front/count
+
+} // namespace prosper::gpu

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -12,6 +12,7 @@
 // Sony libs, so they're registered by raw NID with a note on the observed role.
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "gpu/videoout_present.hpp"
 #include <cstdlib>
 #include <cstring>
 #include <cstdint>
@@ -140,6 +141,7 @@ HLE(g_vo_submitflip)  {
     g_flip_count++;
     g_current_buffer = (int32_t)a1;
     g_last_flip_arg = (int64_t)a3;
+    gpu::present_flip((int)(int32_t)a1, (int64_t)a3);   // present the buffer (scanout front + count)
     return 0;
 }
 HLE(g_vo_flippending) { return 0; }                                            // never pending -> can submit next

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -1,0 +1,78 @@
+// test_present — guards the libSceVideoOut flip→present path (videoout_present.cpp on top of the
+// prosper_vo_* buffer registry). Registers a real triple-buffered surface whose framebuffers hold
+// known pixel patterns, drives SubmitFlip through the NID registry, and asserts that the present
+// layer scans out the flipped buffer and reads back exactly its pixels. This proves the present
+// plumbing end-to-end headlessly — the surface the renderer will present real frames to.
+#include "../src/hle/dispatch.hpp"
+#include "../src/gpu/videoout_present.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_present ==\n");
+    register_builtin_hle();
+    gpu::present_reset();
+
+    auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
+    auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
+    auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
+    CHECK(setba2 && regb2 && flip, "VideoOut functions registered");
+    if (!(setba2 && regb2 && flip)) { printf("== FAIL ==\n"); return 1; }
+
+    // A small surface so the test framebuffers are cheap: 16x8 BGRA (512 bytes each), triple-buffered.
+    const uint32_t W = 16, H = 8;
+    const size_t   FB_BYTES = (size_t)W * H * 4;
+    std::vector<uint8_t> fb0(FB_BYTES), fb1(FB_BYTES), fb2(FB_BYTES);
+    for (size_t i = 0; i < FB_BYTES; i++) { fb0[i] = 0x11; fb1[i] = 0x22; fb2[i] = 0x33; }  // distinct fills
+
+    // SetBufferAttribute2 with our test dimensions, then RegisterBuffers2 with the 3 framebuffers.
+    uint8_t attr[0x50]; memset(attr, 0, sizeof attr);
+    setba2((uint64_t)(uintptr_t)attr, 0x8000000000000000ull /*fmt*/, 0 /*tiling*/, W, H, 0 /*option*/);
+    struct VOB { const void* data; const void* metadata; const void* reserved[2]; };
+    VOB buffers[3] = { {fb0.data(),0,{0,0}}, {fb1.data(),0,{0,0}}, {fb2.data(),0,{0,0}} };
+    uint64_t rc = regb2(0x1001, 0, 0, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
+    CHECK(rc == 0, "registered a 3-buffer 16x8 surface");
+    CHECK(gpu::present_width() == W && gpu::present_height() == H, "present layer sees the surface dimensions");
+
+    // Before any flip there is no front buffer.
+    CHECK(gpu::present_front_index() == -1, "no front buffer before the first flip");
+    std::vector<uint8_t> out(FB_BYTES, 0xEE);
+    CHECK(gpu::present_readback(out.data(), out.size()) == 0, "readback yields nothing before a flip");
+
+    // Flip buffer 1 -> it becomes the presented (scanned-out) frame.
+    uint64_t base_count = gpu::present_count();
+    flip(0x1001, 1 /*buffer*/, 0 /*mode*/, 0xABCD /*flipArg*/, 0, 0);
+    CHECK(gpu::present_front_index() == 1, "flip selected buffer 1 as front");
+    CHECK(gpu::present_count() == base_count + 1, "present count incremented");
+    size_t got = gpu::present_readback(out.data(), out.size());
+    CHECK(got == FB_BYTES, "readback produced a full frame");
+    CHECK(out[0] == 0x22 && out[FB_BYTES - 1] == 0x22, "presented frame is buffer 1's pixels");
+
+    // Flip buffer 2 -> scanout follows.
+    flip(0x1001, 2, 0, 0, 0, 0);
+    CHECK(gpu::present_front_index() == 2, "flip selected buffer 2 as front");
+    gpu::present_readback(out.data(), out.size());
+    CHECK(out[0] == 0x33, "presented frame now buffer 2's pixels");
+
+    // Update buffer 2's contents (as a renderer would) and re-present: readback reflects live memory.
+    for (size_t i = 0; i < FB_BYTES; i++) fb2[i] = 0x44;
+    flip(0x1001, 2, 0, 0, 0, 0);
+    gpu::present_readback(out.data(), out.size());
+    CHECK(out[0] == 0x44 && out[100] == 0x44, "readback reflects updated framebuffer memory");
+
+    // Out-of-range flip index leaves the front buffer unchanged (but still counts as a flip).
+    flip(0x1001, 99, 0, 0, 0, 0);
+    CHECK(gpu::present_front_index() == 2, "out-of-range flip index does not corrupt the front buffer");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
My assigned lane: the libSceVideoOut **flip→present** path, built on the `prosper_vo_*` display-buffer registry. Headless-offscreen (WSL has no window), non-conflicting (new module + one-line HLE wire), and it's the surface the renderer presents real frames to.

## What

`src/gpu/videoout_present.{hpp,cpp}`:
- `present_flip(buffer_index, flip_arg)` — `sceVideoOutSubmitFlip` records the flipped buffer as the scanned-out **front** buffer and bumps a present counter.
- `present_readback(dst)` — copies the presented frame's **real pixels** from the front buffer's guest memory (unified, 1:1-mapped). Nothing is faked; until the renderer writes frames, the contents are whatever the guest put there.
- `present_front_index` / `present_count` / `present_width` / `present_height` / `present_reset`.

Decoupled: the module reads the surface via the `prosper_vo_*` C hooks, so the only HLE change is **one call** wiring `g_vo_submitflip → present_flip` (minimal overlap with the videoout functions agent 3 recently touched).

## Verification (headless, agentic-first)

`test_present` registers a real triple-buffered 16×8 surface with distinct per-buffer pixel fills, flips through them via the NID registry, and asserts the present layer:
- scans out the flipped buffer (`front_index` follows the flip),
- reads back exactly that buffer's pixels,
- reflects **live** framebuffer updates (write new pixels → re-flip → readback shows them),
- ignores out-of-range flip indices without corrupting scanout.

Boot unchanged (the `0xba6e08` fault is still pre-first-flip, so `present_flip` isn't exercised in-boot yet, but the wiring is safe). **32/32 tests.**

## Next layers (structured for, not built yet)

- A real window / headless-offscreen **Vulkan swapchain** layers behind `present_readback` when there's a display or when we want GPU-side present — the CPU scanout core is the verifiable increment now.
- When the back-half renderer writes frames into the registered buffers (or blits its VkImage into the front buffer), `present_readback` immediately yields real presented frames — no present-side change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
