### PR TITLE
hle: reduce startup stubs — UserService getters + libkernel no-ops (audit)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -60,6 +60,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)
 
+  # UserService/libkernel startup stubs (HLE audit): getters write deterministic defaults; the
+  # libkernel registration/hook calls resolve to benign OK no-ops.
+  add_executable(test_service_getters tests/test_service_getters.cpp)
+  target_link_libraries(test_service_getters PRIVATE prosper_core)
+  add_test(NAME service_getters COMMAND test_service_getters)
+
   add_executable(test_sync_on_address tests/test_sync_on_address.cpp)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -531,6 +531,21 @@ void register_kernel_hle() {
     R("sceKernelCreateSema", k_sema_create);    R("sceKernelDeleteSema", k_sema_delete);
     R("sceKernelWaitSema", k_sema_wait);        R("sceKernelSignalSema", k_sema_signal);
     R("sceKernelPollSema", k_sema_poll);
+    // Registration / hook / debug libkernel calls the app makes at startup that have no observable
+    // effect in our headless boot — returning OK without side effects is the correct behavior:
+    //  - SetThreadDtors / SetThreadAtexitCount / SetThreadAtexitReport: per-thread exit bookkeeping;
+    //    our guest threads never cleanly exit (process is torn down), so there's nothing to run.
+    //  - RtldSetApplicationHeapAPI: lets the app give the dynamic linker a custom malloc; unset -> the
+    //    linker uses its default heap, which is what we already run on.
+    //  - GetSanitizerNewReplaceExternal: reports whether a sanitizer replaced operator new; 0 = none.
+    //  - SetVirtualRangeName: debug label for a VA range; no runtime effect.
+    // Registered by raw NID (guaranteed match; names not in our NidDb).
+    Hle::register_fn("rNhWz+lvOMU", (HleFn)k_attr_noop, "sceKernelSetThreadDtors");
+    Hle::register_fn("pB-yGZ2nQ9o", (HleFn)k_attr_noop, "sceKernelSetThreadAtexitCount");
+    Hle::register_fn("WhCc1w3EhSI", (HleFn)k_attr_noop, "sceKernelSetThreadAtexitReport");
+    Hle::register_fn("p5EcQeEeJAE", (HleFn)k_attr_noop, "sceKernelRtldSetApplicationHeapAPI");
+    Hle::register_fn("bnZxYgAFeA0", (HleFn)k_attr_noop, "sceKernelGetSanitizerNewReplaceExternal");
+    Hle::register_fn("DGMG3JshrZU", (HleFn)k_attr_noop, "sceKernelSetVirtualRangeName");
     #undef R
     register_kernel_mem_hle();    // virtual/direct memory
     register_kernel_time_hle();   // time/clock + C11 threads + stubs

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -24,6 +24,7 @@ HLE(s_user_idlist)    { if (a0) { int32_t* p = (int32_t*)PW(a0); p[0] = 1; for (
 // stack-smash if a2 is large/garbage). snprintf writes only the string + NUL.
 HLE(s_user_name)      { if (a1) snprintf((char*)PW(a1), a2 ? (size_t)a2 : 17, "%s", "Player"); return 0; }
 HLE(s_user_int_out)   { if (a1) *(int32_t*)PW(a1) = 0; return 0; }           // accessibility getters -> 0
+HLE(s_user_age)       { if (a1) *(int32_t*)PW(a1) = 18; return 0; }          // GetAgeLevel -> adult (no restriction)
 HLE(s_ok)             { return 0; }
 
 // --- NP / online (single-player: report signed-out / unreachable, success) ---
@@ -57,6 +58,15 @@ void register_service_hle() {
     R("sceUserServiceGetAccessibilityVibration", s_user_int_out);
     R("sceUserServiceGetAccessibilityPressAndHoldDelay", s_user_int_out);
     R("sceUserServiceGetAccessibilityZoomEnabled", s_user_int_out);
+    // More (userId, int* out) getters the game queries at startup — same family: write a sane default
+    // (accessibility off = 0; age level = adult) so the caller reads a deterministic value instead of
+    // uninitialized stack. Registered by raw NID (guaranteed match; these names aren't in our NidDb).
+    Hle::register_fn("woNpu+45RLk", (HleFn)s_user_age,     "sceUserServiceGetAgeLevel");
+    Hle::register_fn("rnEhHqG-4xo", (HleFn)s_user_int_out, "sceUserServiceGetAccessibilityChatTranscription");
+    Hle::register_fn("O6IW1-Dwm-w", (HleFn)s_user_int_out, "sceUserServiceGetAccessibilityZoomFollowFocus");
+    Hle::register_fn("-3Y5GO+-i78", (HleFn)s_user_int_out, "sceUserServiceGetAccessibilityTriggerEffect");
+    // NOTE: sceUserServiceGetGamePresets (-sD02mFDBh4) intentionally left unimplemented — its output is
+    // a struct of unknown layout; writing a wrong-size default would risk a stack smash (cf. f_fstat).
     R("sceUserServiceInitialize", s_ok);
     R("sceUserServiceTerminate", s_ok);
     // NP

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -1,0 +1,53 @@
+// test_service_getters — guards the UserService/libkernel startup stubs reduced in the HLE audit.
+// The UserService getters are (userId, out*) queries that must write a deterministic default to the
+// output pointer (accessibility off = 0, age level = adult) rather than leave it uninitialized; the
+// libkernel registration/hook calls must resolve to a benign OK-returning no-op. Registered by raw
+// NID, so this looks them up by NID and exercises the output contract.
+#include "../src/hle/dispatch.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Call an (userId, int* out) getter and return the value it wrote (sentinel-initialized to catch a
+// no-write).
+static int32_t call_int_getter(HleFn fn, int32_t sentinel) {
+    int32_t out = sentinel;
+    fn(1 /*userId*/, (uint64_t)(uintptr_t)&out, 0, 0, 0, 0);
+    return out;
+}
+
+int main() {
+    printf("== test_service_getters ==\n");
+    register_builtin_hle();
+
+    // UserService getters: age level -> adult (18), accessibility -> off (0). Must WRITE the output.
+    struct { const char* nid; int32_t want; const char* what; } getters[] = {
+        {"woNpu+45RLk", 18, "GetAgeLevel -> adult (18)"},
+        {"rnEhHqG-4xo",  0, "GetAccessibilityChatTranscription -> 0"},
+        {"O6IW1-Dwm-w",  0, "GetAccessibilityZoomFollowFocus -> 0"},
+        {"-3Y5GO+-i78",  0, "GetAccessibilityTriggerEffect -> 0"},
+    };
+    for (auto& g : getters) {
+        HleFn fn = Hle::lookup(g.nid);
+        CHECK(fn != nullptr, g.what);
+        if (fn) CHECK(call_int_getter(fn, (int32_t)0xDEAD) == g.want, g.what);
+    }
+
+    // libkernel registration/no-op calls: resolve + return OK (0), no crash.
+    const char* noops[] = {"rNhWz+lvOMU", "pB-yGZ2nQ9o", "WhCc1w3EhSI",
+                           "p5EcQeEeJAE", "bnZxYgAFeA0", "DGMG3JshrZU"};
+    for (const char* nid : noops) {
+        HleFn fn = Hle::lookup(nid);
+        CHECK(fn != nullptr, nid);
+        if (fn) CHECK(fn(0, 0, 0, 0, 0, 0) == 0, nid);
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Secondary lane: audited the non-graphics HLE the boot exercises and resolved **10** of the boot's unimplemented calls with safe, correct handlers — leaving the rest deliberately (documented why). Boot count dropped 18 → 8 unimplemented; the remaining 8 are parked audio + uncertain-output structs I won't guess-size.

## Resolved

**UserService `(userId, int* out)` getters** — write a deterministic default so the caller reads a real value instead of uninitialized stack (reuses the proven `s_user_int_out` pattern; age gets an adult default):

| NID | Function | Default |
|---|---|---|
| `woNpu+45RLk` | `sceUserServiceGetAgeLevel` | `18` (adult, no restriction) |
| `rnEhHqG-4xo` | `GetAccessibilityChatTranscription` | `0` (off) |
| `O6IW1-Dwm-w` | `GetAccessibilityZoomFollowFocus` | `0` (off) |
| `-3Y5GO+-i78` | `GetAccessibilityTriggerEffect` | `0` (off) |

**libkernel registration/hook/debug calls** with no observable effect headless → benign OK no-op (correct behavior, no output writes): `SetThreadDtors`, `SetThreadAtexitCount`, `SetThreadAtexitReport` (thread-exit bookkeeping — guest threads never cleanly exit here), `RtldSetApplicationHeapAPI` (linker uses its default heap), `GetSanitizerNewReplaceExternal` (`0` = none), `SetVirtualRangeName` (debug label).

All registered by **raw NID** (guaranteed match — these names aren't in our NidDb).

## Deliberately not touched

Output is a struct of unknown layout, so a wrong-size default would risk a stack smash (the `f_fstat` lesson), or it's parked audio: `sceUserServiceGetGamePresets`, `sceSystemServiceGetHdrToneMapLuminance`, `sceLibcHeapGetTraceInfo`, `sceAppContentTemporaryDataMount2`, the `libSceAmpr` audio calls, and one unresolved NID (`6xVpy0Fdq+I`). Better an honest stub than a corrupting guess.

## Verification

`test_service_getters` looks up each by NID and asserts the getters write their defaults (sentinel-initialized to catch a no-write) and the no-ops return 0. Boot unchanged (same parked graphics fault). **34/34 tests.**

Note: cross-checked against shadPS4 — it stubs many of these the same way (return OK), so the game tolerates them; this makes the reads *deterministic* rather than fixing a blocker. Honest ROI: modest but real (removes latent read-uninitialized behavior), and the surface is now cleanly documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
