### PR TITLE
gpu: build_shader_resources — V# decode + constant-buffer table (resource-binding stage 1)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -130,6 +130,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_shader_resources PRIVATE prosper_core)
   add_test(NAME shader_resource_contract COMMAND test_shader_resources)
 
+  # Front-half resource-table builder + V# descriptor decode (agc_shader_layout.cpp): shader user_data
+  # + user-data SGPRs -> ShaderResourceTable (constant buffers, stage 1). Pure/cross-platform.
+  add_executable(test_build_shader_resources tests/test_build_shader_resources.cpp)
+  target_link_libraries(test_build_shader_resources PRIVATE prosper_core)
+  add_test(NAME build_shader_resources COMMAND test_build_shader_resources)
+
   # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux only).
   if(UNIX AND NOT APPLE)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -1,0 +1,93 @@
+// agc_shader_layout.cpp — see agc_shader_layout.hpp. V# decode + the front-half resource-table build.
+#include "agc_shader_layout.hpp"
+
+namespace prosper::gpu {
+
+// GCN/Gen5 buffer DATA_FORMAT (dfmt) -> component count. 0 = invalid/unhandled.
+static uint32_t dfmt_components(uint32_t dfmt) {
+    switch (dfmt) {
+        case 1: case 2: case 4:            return 1;   // 8 / 16 / 32
+        case 3: case 5: case 11:           return 2;   // 8_8 / 16_16 / 32_32
+        case 13:                           return 3;   // 32_32_32
+        case 10: case 12: case 14:         return 4;   // 8_8_8_8 / 16_16_16_16 / 32_32_32_32
+        default:                           return 0;
+    }
+}
+// dfmt -> per-component byte width (1/2/4).
+static uint32_t dfmt_comp_bytes(uint32_t dfmt) {
+    switch (dfmt) {
+        case 1: case 3: case 10:           return 1;   // 8-bit components
+        case 2: case 5: case 12:           return 2;   // 16-bit components
+        case 4: case 11: case 13: case 14: return 4;   // 32-bit components
+        default:                           return 0;
+    }
+}
+
+void buffer_format(uint32_t dfmt, uint32_t nfmt, DataFormat* out_fmt, uint32_t* out_components) {
+    uint32_t comp_bytes = dfmt_comp_bytes(dfmt);
+    if (out_components) *out_components = dfmt_components(dfmt);
+    // NFMT: 0=unorm, 1=snorm, 4=uint, 5=sint, 7=float.
+    DataFormat f = DataFormat::Unknown;
+    if (comp_bytes == 4) {
+        f = (nfmt == 7) ? DataFormat::Float32 : (nfmt == 5) ? DataFormat::Sint32 : DataFormat::Uint32;
+    } else if (comp_bytes == 2) {
+        f = (nfmt == 7) ? DataFormat::Float16 : (nfmt == 0) ? DataFormat::Unorm16 : (nfmt == 1) ? DataFormat::Snorm16
+          : (nfmt == 5) ? DataFormat::Sint16  : DataFormat::Uint16;
+    } else if (comp_bytes == 1) {
+        f = (nfmt == 0) ? DataFormat::Unorm8 : (nfmt == 1) ? DataFormat::Snorm8
+          : (nfmt == 5) ? DataFormat::Sint8  : DataFormat::Uint8;
+    }
+    if (out_fmt) *out_fmt = f;
+}
+
+DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
+    DecodedBufferDescriptor d;
+    d.base        = ((uint64_t)v[0] | ((uint64_t)v[1] << 32)) & 0xFFFFFFFFFFFFull;  // Base48
+    d.stride      = (v[1] >> 16) & 0x3FFFu;                                          // 14-bit stride
+    d.num_records = v[2];
+    uint32_t nfmt = (v[3] >> 12) & 0x7u;
+    uint32_t dfmt = (v[3] >> 15) & 0xFu;
+    buffer_format(dfmt, nfmt, &d.format, &d.num_components);
+    // num_records is in units of `stride` when strided, else raw bytes.
+    d.size_bytes = d.stride ? d.num_records * d.stride : d.num_records;
+    return d;
+}
+
+ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
+                                           const uint32_t* user_sgprs, uint32_t num_user_sgprs) {
+    ShaderResourceTable table;
+    const AgcShaderUserData* ud = shdr.user_data;
+    if (!ud || !user_sgprs) return table;
+
+    uint32_t binding = 0;
+
+    // Constant buffers: sharp_resource_offset[3] (storage-as-constant). Each slot's offset_dw points at
+    // a 4-dword V# in the user-data SGPR block. srt_offset = the descriptor's byte offset within
+    // user_data (offset_dw * 4) — the recompiler's provenance key.
+    const AgcShaderSharp* cbufs = ud->sharp_resource_offset[3];
+    if (cbufs) {
+        for (uint16_t slot = 0; slot < ud->sharp_resource_count[3]; slot++) {
+            const AgcShaderSharp& s = cbufs[slot];
+            if (s.empty()) continue;
+            uint32_t off = s.offset_dw();
+            if ((uint64_t)off + 4 > num_user_sgprs) continue;   // descriptor must fit in the SGPR block
+            DecodedBufferDescriptor d = decode_buffer_descriptor(&user_sgprs[off]);
+            ShaderResource r;
+            r.cls            = ResourceClass::ConstantBuffer;
+            r.format         = d.format;
+            r.num_components  = d.num_components;
+            r.binding        = binding++;
+            r.gpu_addr       = d.base;
+            r.size           = d.size_bytes;
+            r.stride         = d.stride;
+            r.srt_offset     = off * 4;   // byte offset within user_data
+            table.resources.push_back(r);
+        }
+    }
+
+    // (Next stage) vertex buffers via direct_resource_offset type 8/10 — the V# is reached through a
+    // pointer in the SGPR block; deferred until stage 2 is wired with the recompiler.
+    return table;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -1,0 +1,74 @@
+// agc_shader_layout.hpp — the guest AGC/Gen5 shader-header + V#/T#/S# descriptor layout, and the
+// front-half builder that turns a shader's resource usage into a ShaderResourceTable (the contract in
+// shader_resources.hpp). The bit layouts here are the FRONT-HALF's to own (see RESOURCE_BINDING.md);
+// the recompiler only consumes the resulting DataFormat/binding.
+//
+// Layouts cross-checked against Kyty (PS5/RDNA2 gfx1030, same target): the SDK `Shader`/`ShaderUserData`
+// (Shader.h:911/974) and the buffer resource descriptor V# (ShaderBufferResource getters: Base48,
+// Stride[16:29], NumRecords=word2, Nfmt[12:14], Dfmt[15:18]).
+#pragma once
+#include "shader_resources.hpp"
+#include <cstdint>
+
+namespace prosper::gpu {
+
+// One entry of a ShaderUserData sharp array: a 16-bit {offset_dw:15, size:1}. offset_dw is the dword
+// index of the descriptor within the shader's user-data SGPR block; 0x7fff = empty slot.
+struct AgcShaderSharp {
+    uint16_t bits = 0;
+    uint32_t offset_dw() const { return bits & 0x7fffu; }
+    uint32_t size()      const { return (bits >> 15) & 1u; }
+    bool     empty()     const { return offset_dw() == 0x7fffu; }
+};
+
+// Shader resource-usage table (Kyty ShaderUserData, Shader.h:911). Categories (from ShaderParseUsage2):
+//   direct_resource_offset[type]: type 8 = vertex buffer, type 10 = vertex attrib (value = SGPR index)
+//   sharp_resource_offset[0]: textures2D   [2]: samplers   [3]: constant/storage buffers   [1]: unused
+struct AgcShaderUserData {
+    uint16_t*       direct_resource_offset;      // +0x00
+    AgcShaderSharp* sharp_resource_offset[4];    // +0x08
+    uint16_t        eud_size_dw;                 // +0x28
+    uint16_t        srt_size_dw;                 // +0x2a
+    uint16_t        direct_resource_count;       // +0x2c
+    uint16_t        sharp_resource_count[4];     // +0x2e
+};
+
+// The SDK shader header (Kyty Shader.h:974) — only the fields the resource builder needs.
+struct AgcShaderHeader {
+    uint32_t           file_header;   // +0x00 '1234'
+    uint32_t           version;       // +0x04
+    AgcShaderUserData* user_data;     // +0x08
+    const void*        code;          // +0x10
+    uint8_t            pad[0x5a - 0x18];
+    uint8_t            type;          // +0x5a (2=VS/ES, 1=PS, 0=CS)
+};
+
+// A decoded buffer resource descriptor (V#, 4 dwords). base/stride/num_records per Kyty's getters;
+// format+num_components from the (dfmt,nfmt) split. `size_bytes` is the backing region size.
+struct DecodedBufferDescriptor {
+    uint64_t   base = 0;
+    uint32_t   stride = 0;
+    uint32_t   num_records = 0;
+    uint32_t   size_bytes = 0;
+    DataFormat format = DataFormat::Float32;
+    uint32_t   num_components = 1;
+};
+
+// Decode a 4-dword V# (RDNA2/Gen5 buffer resource). Pure; exposed for reuse + testing.
+DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
+
+// Map a GCN/Gen5 buffer (DFMT, NFMT) pair to a DataFormat + component count. Pure.
+void buffer_format(uint32_t dfmt, uint32_t nfmt, DataFormat* out_fmt, uint32_t* out_components);
+
+// FRONT-HALF DELIVERABLE: build the resource table a shader uses. `user_sgprs` is the shader's bound
+// user-data SGPR block (num_user_sgprs dwords) — the V# descriptors live there at each sharp's
+// offset_dw (Kyty ShaderParseUsage2 reads them from the user_sgpr block, not the header). Descriptor
+// gpu_addr is a 1:1-mapped guest pointer the pipeline binds directly.
+//
+// NOTE (flagged for agent 1): the doc's signature was `build_shader_resources(const Shader&)`, but the
+// descriptor bytes are in the user-data SGPRs, so the block is required. Currently fills constant
+// buffers (sharp[3]) — stage 1; vertex buffers (direct type 8/10) are the next stage.
+ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
+                                           const uint32_t* user_sgprs, uint32_t num_user_sgprs);
+
+} // namespace prosper::gpu

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -1,0 +1,84 @@
+// test_build_shader_resources — guards the front-half resource-table builder + V# decode
+// (agc_shader_layout.cpp). Constructs a synthetic shader whose user-data describes constant buffers,
+// places real V# descriptors in the user-data SGPR block, and asserts build_shader_resources decodes
+// base/stride/size/format and assigns provenance (srt_offset) + bindings — the contract the recompiler
+// and pipeline consume. Pure/headless; validates the decode against hand-built descriptors.
+#include "../src/gpu/agc_shader_layout.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Build a 4-dword V# (buffer resource): Base48, 14-bit stride @[16:29] of word1, num_records=word2,
+// nfmt @[12:14] / dfmt @[15:18] of word3.
+static void make_vsharp(uint32_t v[4], uint64_t base, uint32_t stride, uint32_t records,
+                        uint32_t dfmt, uint32_t nfmt) {
+    v[0] = (uint32_t)(base & 0xffffffffu);
+    v[1] = (uint32_t)((base >> 32) & 0xffffu) | ((stride & 0x3fffu) << 16);
+    v[2] = records;
+    v[3] = ((nfmt & 0x7u) << 12) | ((dfmt & 0xfu) << 15);
+}
+
+int main() {
+    printf("== test_build_shader_resources ==\n");
+
+    // --- V# decode in isolation ---------------------------------------------------------------
+    {
+        uint32_t v[4];
+        make_vsharp(v, 0x123456780ull, 16, 64, /*dfmt*/14, /*nfmt*/7);   // 32_32_32_32 FLOAT, stride 16
+        DecodedBufferDescriptor d = decode_buffer_descriptor(v);
+        CHECK(d.base == 0x123456780ull, "V# base48 decoded");
+        CHECK(d.stride == 16, "V# stride decoded");
+        CHECK(d.num_records == 64, "V# num_records decoded");
+        CHECK(d.size_bytes == 64 * 16, "V# size = records*stride");
+        CHECK(d.format == DataFormat::Float32 && d.num_components == 4, "dfmt14/nfmt7 -> Float32 x4");
+    }
+    {   // format-decode coverage
+        DataFormat f; uint32_t n;
+        buffer_format(4, 7, &f, &n);  CHECK(f == DataFormat::Float32 && n == 1, "dfmt4/nfmt7 -> Float32 x1");
+        buffer_format(10, 0, &f, &n); CHECK(f == DataFormat::Unorm8 && n == 4, "dfmt10/nfmt0 -> Unorm8 x4");
+        buffer_format(5, 5, &f, &n);  CHECK(f == DataFormat::Sint16 && n == 2, "dfmt5/nfmt5 -> Sint16 x2");
+    }
+
+    // --- build_shader_resources: two constant buffers via sharp[3] --------------------------------
+    // user-data SGPR block: V#0 at dword 4, V#1 at dword 12.
+    uint32_t sgprs[32]; memset(sgprs, 0, sizeof sgprs);
+    make_vsharp(&sgprs[4],  0xA0000000ull, 0, 256,  4, 7);   // cbuf0: 256 bytes (stride 0), Float32
+    make_vsharp(&sgprs[12], 0xB0000000ull, 0, 1024, 4, 7);   // cbuf1: 1024 bytes
+
+    AgcShaderSharp cbuf_sharps[2];
+    cbuf_sharps[0].bits = (uint16_t)(4  & 0x7fff);            // offset_dw=4,  size bit 0
+    cbuf_sharps[1].bits = (uint16_t)(12 & 0x7fff);            // offset_dw=12
+    AgcShaderUserData ud; memset(&ud, 0, sizeof ud);
+    ud.sharp_resource_offset[3] = cbuf_sharps;
+    ud.sharp_resource_count[3]  = 2;
+    AgcShaderHeader shdr; memset(&shdr, 0, sizeof shdr);
+    shdr.file_header = 0x34333231u; shdr.version = 0x18; shdr.type = 2;
+    shdr.user_data = &ud;
+
+    ShaderResourceTable t = build_shader_resources(shdr, sgprs, 32);
+    CHECK(t.resources.size() == 2, "built 2 constant-buffer resources");
+
+    const ShaderResource* r0 = t.by_srt_offset(4 * 4);   // provenance key = offset_dw*4 bytes
+    const ShaderResource* r1 = t.by_srt_offset(12 * 4);
+    CHECK(r0 && r0->cls == ResourceClass::ConstantBuffer, "cbuf0 resolvable by srt_offset");
+    CHECK(r0 && r0->gpu_addr == 0xA0000000ull && r0->size == 256, "cbuf0 base+size decoded");
+    CHECK(r1 && r1->gpu_addr == 0xB0000000ull && r1->size == 1024, "cbuf1 base+size decoded");
+    CHECK(r0 && r1 && r0->binding != r1->binding, "distinct bindings assigned");
+    CHECK(t.by_binding(r0 ? r0->binding : 999) == r0, "resolvable by binding");
+    CHECK(t.by_srt_offset(0x999) == nullptr, "unknown srt_offset -> null");
+
+    // An empty slot (0x7fff) is skipped.
+    cbuf_sharps[1].bits = 0x7fff;
+    ShaderResourceTable t2 = build_shader_resources(shdr, sgprs, 32);
+    CHECK(t2.resources.size() == 1, "empty sharp slot (0x7fff) skipped");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Front-half deliverable for the resource-binding contract: `build_shader_resources` + the V# descriptor decode. **Stage 1 (constant buffers)** — the multi-buffer `s_buffer_load` unblock.

## What

`src/gpu/agc_shader_layout.{hpp,cpp}`:

- **`decode_buffer_descriptor(v[4])` + `buffer_format(dfmt, nfmt)`** — decode a Gen5/RDNA2 buffer resource V#: `Base48`, stride `[16:29]`, `num_records`=word2, and format from `(dfmt[15:18], nfmt[12:14])` → `DataFormat` + `num_components`. Cross-checked against Kyty's `ShaderBufferResource` getters (same PS5 gfx1030 target). Covers 8/16/32-bit × 1..4, float/unorm/snorm/uint/sint. (Kyty confirms the game's vertex formats are float32 — `dfmt∈{4,14}, nfmt=7` — i.e. stage 2's fast path.)
- **`build_shader_resources(shdr, user_sgprs, n)`** — walks the shader's `ShaderUserData`. Constant buffers = `sharp_resource_offset[3]` (storage-as-constant, per Kyty `ShaderParseUsage2`); each slot's `offset_dw` indexes a 4-dword V# in the user-data SGPR block. Fills `gpu_addr`(base)/`size`/`stride`/`format`, assigns a set-0 `binding`, and sets `srt_offset = offset_dw*4` — the recompiler's provenance key.

## Two things flagged for you (agent 1)

1. **Signature:** the doc said `build_shader_resources(const Shader&)`, but the V# descriptor **bytes live in the bound user-data SGPRs** — Kyty's `ShaderParseUsage2` reads them from `user_sgpr`, not the header. So I made the SGPR block a required arg: `build_shader_resources(const AgcShaderHeader&, const uint32_t* user_sgprs, uint32_t n)`. If you have a cleaner way to hand me the descriptor source (e.g. you already have the user-data regs in GpuState), say so and I'll match it.
2. **Category map** (from Kyty, needs real-game validation once the pipeline runs past the GfxDevice wall): cbuf = `sharp[3]`, vertex buffer = direct type 8, vertex attrib = type 10, texture = `sharp[0]`, sampler = `sharp[2]`.

## Verification

`test_build_shader_resources`: V# decode (base/stride/size/format), a 2-constant-buffer walk (provenance `by_srt_offset` + distinct bindings), and empty-slot (`0x7fff`) skip. 36/36 tests; pure/headless.

## Next stage (yours to pull when ready)

**Stage 2 — vertex buffers** (direct type 8: a pointer in the SGPR block → a V# table; float32 fast path). That's the real-VS unlock. I held it for a follow-up so stage 1 lands clean and you can confirm the signature/provenance model first — tell me the recompiler's multi-buffer + vertex-fetch expectations and I'll wire stage 2 to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
