### PR TITLE
gpu: build_shader_resources stage 2 — vertex buffers (DIRECT sgpr_base provenance)

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -85,8 +85,31 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
         }
     }
 
-    // (Next stage) vertex buffers via direct_resource_offset type 8/10 — the V# is reached through a
-    // pointer in the SGPR block; deferred until stage 2 is wired with the recompiler.
+    // Vertex buffers (stage 2): Sony "direct" resources — the driver places the V# straight in the
+    // user-data SGPRs (contract's DIRECT provenance). Kyty ShaderParseUsage2 usage types: 8 = vertex
+    // buffer, 10 = vertex attrib; direct_resource_offset is indexed by usage type and the value is the
+    // SGPR index where that V# sits (0xffff = absent). We emit a VertexBuffer keyed by sgpr_base so
+    // the recompiler resolves each buffer_load_format_*'s SRSRC directly (no in-shader s_load).
+    if (const uint16_t* dro = ud->direct_resource_offset) {
+        for (uint16_t type = 0; type < ud->direct_resource_count; type++) {
+            if (type != 8 && type != 10) continue;              // vertex buffer / vertex attrib
+            uint32_t reg = dro[type];
+            if (reg == 0xffff) continue;
+            if ((uint64_t)reg + 4 > num_user_sgprs) continue;   // V# (4 dwords) must fit in the block
+            DecodedBufferDescriptor d = decode_buffer_descriptor(&user_sgprs[reg]);
+            ShaderResource r;
+            r.cls            = ResourceClass::VertexBuffer;
+            r.format         = d.format;          // Float32 for this game (dfmt {4,11,13,14}, nfmt 7)
+            r.num_components  = d.num_components;
+            r.binding        = binding++;
+            r.gpu_addr       = d.base;
+            r.size           = d.size_bytes;
+            r.stride         = d.stride;
+            r.sgpr_base      = reg;               // DIRECT provenance key (SRSRC SGPR index)
+            r.srt_offset     = 0xFFFFFFFFu;       // not s_loaded
+            table.resources.push_back(r);
+        }
+    }
     return table;
 }
 

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -65,9 +65,9 @@ void buffer_format(uint32_t dfmt, uint32_t nfmt, DataFormat* out_fmt, uint32_t* 
 // offset_dw (Kyty ShaderParseUsage2 reads them from the user_sgpr block, not the header). Descriptor
 // gpu_addr is a 1:1-mapped guest pointer the pipeline binds directly.
 //
-// NOTE (flagged for agent 1): the doc's signature was `build_shader_resources(const Shader&)`, but the
-// descriptor bytes are in the user-data SGPRs, so the block is required. Currently fills constant
-// buffers (sharp[3]) — stage 1; vertex buffers (direct type 8/10) are the next stage.
+// Signature takes the user-data SGPR block because the V# descriptor bytes live there (confirmed with
+// agent 1). Fills constant buffers (sharp[3], INDIRECT srt_offset provenance) + vertex buffers
+// (direct usage types 8/10, DIRECT sgpr_base provenance). Textures/samplers follow.
 ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                                            const uint32_t* user_sgprs, uint32_t num_user_sgprs);
 

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -78,6 +78,25 @@ int main() {
     ShaderResourceTable t2 = build_shader_resources(shdr, sgprs, 32);
     CHECK(t2.resources.size() == 1, "empty sharp slot (0x7fff) skipped");
 
+    // --- vertex buffers: direct resource usage type 8 (V# inline in the user-data SGPRs) ------------
+    // A 16-entry direct_resource_offset table; type 8 (vertex buffer) points at a V# at SGPR dword 20.
+    uint16_t dro[16]; for (auto& x : dro) x = 0xffff;
+    make_vsharp(&sgprs[20], 0xC0000000ull, 12, 90, /*dfmt*/13, /*nfmt*/7);  // 32_32_32 FLOAT, stride 12
+    dro[8] = 20;                                                            // vertex buffer V# at sgpr 20
+    ud.direct_resource_offset = dro;
+    ud.direct_resource_count  = 16;
+    cbuf_sharps[1].bits = (uint16_t)(12 & 0x7fff);   // restore cbuf1 so we test cbuf + vbuf together
+
+    ShaderResourceTable t3 = build_shader_resources(shdr, sgprs, 32);
+    const ShaderResource* vb = t3.by_sgpr_base(20);
+    CHECK(vb != nullptr, "vertex buffer resolvable by sgpr_base (DIRECT provenance)");
+    CHECK(vb && vb->cls == ResourceClass::VertexBuffer, "type-8 direct resource -> VertexBuffer");
+    CHECK(vb && vb->format == DataFormat::Float32 && vb->num_components == 3, "vbuf format Float32 x3");
+    CHECK(vb && vb->gpu_addr == 0xC0000000ull && vb->stride == 12 && vb->size == 90 * 12, "vbuf base/stride/size");
+    CHECK(vb && vb->srt_offset == 0xFFFFFFFFu, "DIRECT vbuf leaves srt_offset unset");
+    CHECK(t3.by_srt_offset(4 * 4) != nullptr, "constant buffers still present alongside vertex buffers");
+    CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Stage 2 — vertex buffers via the DIRECT `sgpr_base` provenance you added (0e6650f). This is the front-half half of the real-VS unlock.

## What

`build_shader_resources` now also walks `direct_resource_offset` (Kyty `ShaderParseUsage2` usage types: **8 = vertex buffer, 10 = vertex attrib**; the value is the V#'s SGPR index, `0xffff` = absent). For each, it decodes the 4-dword V# **inline at `user_sgprs[reg]`** (per your DIRECT-provenance doc: "the driver places the V# straight in the user-data SGPRs starting at this SGPR index") and emits a `VertexBuffer` with:
- `sgpr_base = reg` (the DIRECT key; `srt_offset` left `0xFFFFFFFF`),
- `format` = decoded (Float32 for this game — `dfmt∈{4,11,13,14}, nfmt 7`), `num_components`, `gpu_addr`, `stride`, `size`, a distinct `binding`.

Constant buffers (`sharp[3]`, INDIRECT `srt_offset`) are unchanged — both provenance modes coexist in one table.

## How it routes with your recompiler

Your stage-2 path (`buffer_load_format_*` → resolve SRSRC by `sgpr_base` → per-lane fetch, float32 = raw dword) now finds each vertex fetch's `VertexBuffer` via `by_sgpr_base(SRSRC_sgpr)`. Front + back halves rendezvous on the SGPR index — the game's vertex+pixel shaders can fetch real geometry.

## Verification

`test_build_shader_resources`: type-8 direct resource → `VertexBuffer`, resolvable `by_sgpr_base`, `Float32 × 3` (dfmt 13) with correct base/stride/size, `srt_offset` unset, coexisting with the constant buffers. 36/36; pure/headless.

## Caveat (unchanged)

Category map is Kyty's (`cbuf=sharp[3]`, `vbuf=type 8`, `vattrib=type 10`, `tex=sharp[0]`, `samp=sharp[2]`) — correctness-checkable against the running game once the GfxDevice wall clears. If real descriptors turn out to be pointer-to-table rather than inline for some path, that's the `srt_offset` (INDIRECT) mode, which the table already supports.

Textures/samplers (stages 3–4) are the remaining front-half descriptor work whenever you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
