### PR TITLE
Audio support: headless sceAudioOut HLE + optional SDL3 frontend

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -60,6 +60,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)
 
+  # sceAudioOut HLE: format decode, port lifecycle, PCM forwarding, volume, batch, error paths
+  # (via a capturing AudioSink — headless, no device).
+  add_executable(test_audio tests/test_audio.cpp)
+  target_link_libraries(test_audio PRIVATE prosper_core)
+  add_test(NAME audio_hle COMMAND test_audio)
+
   add_executable(test_equeue_events tests/test_equeue_events.cpp)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -317,3 +317,62 @@ if(TARGET prosper_core)
     endif()
   endif()
 endif()
+
+# --- optional SDL3 audio frontend (headless core stays dependency-free) ---------------------
+# The sceAudioOut HLE is backend-agnostic (src/hle/audio.hpp). This builds an SDL3-backed sink,
+# entirely OUTSIDE prosper_core, so the guest's audio plays on the host. Off by default.
+#   Enable with:  -DPROSPER_AUDIO_SDL3=ON   (uses a system SDL3 if found, else fetches + builds it)
+option(PROSPER_AUDIO_SDL3 "Build the optional SDL3 audio frontend" OFF)
+if(PROSPER_AUDIO_SDL3 AND TARGET prosper_core)
+  find_package(SDL3 QUIET CONFIG)
+  if(NOT SDL3_FOUND)
+    message(STATUS "SDL3 not found on system — fetching release-3.2.30")
+    include(FetchContent)
+    set(SDL_TEST OFF CACHE BOOL "" FORCE)
+    set(SDL_TESTS OFF CACHE BOOL "" FORCE)
+    set(SDL_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+    set(SDL_STATIC ON CACHE BOOL "" FORCE)
+    # Audio-only build: disabling video drops SDL's hard X11/Wayland requirement so it builds on
+    # headless hosts (SDL_UNIX_CONSOLE_BUILD is SDL's documented "no windowing system" escape hatch).
+    # Trim the other subsystems we don't use to keep the SDL build lean.
+    set(SDL_UNIX_CONSOLE_BUILD ON CACHE BOOL "" FORCE)
+    set(SDL_VIDEO OFF CACHE BOOL "" FORCE)
+    set(SDL_WAYLAND OFF CACHE BOOL "" FORCE)
+    set(SDL_X11 OFF CACHE BOOL "" FORCE)
+    set(SDL_RENDER OFF CACHE BOOL "" FORCE)
+    set(SDL_GPU OFF CACHE BOOL "" FORCE)
+    set(SDL_CAMERA OFF CACHE BOOL "" FORCE)
+    set(SDL_JOYSTICK OFF CACHE BOOL "" FORCE)
+    set(SDL_HAPTIC OFF CACHE BOOL "" FORCE)
+    set(SDL_HIDAPI OFF CACHE BOOL "" FORCE)
+    set(SDL_SENSOR OFF CACHE BOOL "" FORCE)
+    set(SDL_POWER OFF CACHE BOOL "" FORCE)
+    set(SDL_DIALOG OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(SDL3
+      GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+      GIT_TAG release-3.2.30
+      GIT_SHALLOW TRUE)
+    FetchContent_MakeAvailable(SDL3)
+  endif()
+
+  add_library(prosper_audio_sdl3 STATIC frontends/audio_sdl3/audio_sink_sdl3.cpp)
+  target_include_directories(prosper_audio_sdl3 PUBLIC frontends/audio_sdl3 src)
+  target_link_libraries(prosper_audio_sdl3 PUBLIC prosper_core SDL3::SDL3)
+  target_compile_definitions(prosper_audio_sdl3 PUBLIC PROSPER_AUDIO_SDL3=1)
+
+  # Headless self-test of the full SDL3 path (run under the SDL "dummy" audio driver in CI):
+  # install the sink, drive the sceAudioOut HLE, assert grains flow through SDL with no device.
+  add_executable(test_audio_sdl3 frontends/audio_sdl3/test_audio_sdl3.cpp)
+  target_link_libraries(test_audio_sdl3 PRIVATE prosper_audio_sdl3)
+  add_test(NAME audio_sdl3 COMMAND test_audio_sdl3)
+  set_tests_properties(audio_sdl3 PROPERTIES ENVIRONMENT "SDL_AUDIO_DRIVER=dummy")
+
+  # Route the live game's audio to the host when the runner is built (guarded by the macro).
+  if(TARGET boot_trace)
+    target_link_libraries(boot_trace PRIVATE prosper_audio_sdl3)
+    target_compile_definitions(boot_trace PRIVATE PROSPER_AUDIO_SDL3=1)
+  endif()
+
+  message(STATUS "SDL3 audio frontend enabled (prosper_audio_sdl3)")
+endif()

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -1,0 +1,57 @@
+# Audio (`libSceAudioOut`)
+
+prosper implements the PS5 `sceAudioOut*` API as a **headless, backend-agnostic core** with
+**pluggable frontends**. The HLE never depends on any audio library — it decodes the guest's calls
+into a port lifecycle plus interleaved PCM "grains" and forwards them to an installed `AudioSink`.
+This keeps `prosper_core` dependency-free and unit-testable, and lets any frontend (SDL3, a file
+recorder, a network sink, …) be swapped in at runtime.
+
+## Layers
+
+| Layer | File | In `prosper_core`? |
+|---|---|---|
+| Backend interface | `src/hle/audio.hpp` (`AudioSink`, `AudioPortInfo`, format decode) | yes (header) |
+| HLE + default sink | `src/hle/hle_audio.cpp` | yes |
+| SDL3 frontend (optional) | `frontends/audio_sdl3/` | **no** (separate target) |
+
+### HLE coverage (`hle_audio.cpp`)
+`sceAudioOutInit`, `sceAudioOutOpen`, `sceAudioOutOutput`, `sceAudioOutOutputs`,
+`sceAudioOutSetVolume`, `sceAudioOutClose`, `sceAudioOutGetPortState`. A 16-port table tracks each
+open port's `{freq, channels, format, grain}`. `sceAudioOutOpen`'s `param` is decoded into channels
++ sample format (`SceAudioOutParamFormat` 0–7: S16/F32 × mono/stereo/8ch). PCM pointers are read
+directly (guest memory is 1:1-mapped), so grains are forwarded to the sink with **zero copies** in
+the HLE.
+
+### Default backend — silent, real-time paced
+With no frontend installed, `prosper_core` uses a built-in `RealtimeSilentSink`. On real hardware,
+`sceAudioOutOutput` **blocks until the audio ring has room**, which is what paces a game's audio
+thread. The default sink reproduces that pacing by sleeping each grain's wall-clock duration
+(`grain / freq` seconds), so the guest advances at the correct speed with **no device attached** —
+correct timing, no sound. This is the right default for headless bring-up.
+
+### Installing a frontend
+```cpp
+#include "hle/audio.hpp"
+prosper::audio_set_sink(&my_sink);   // AudioSink*; pass nullptr to restore the silent default
+```
+
+## SDL3 frontend (optional)
+
+Builds a real audio backend that plays the guest's output on the host's default device.
+
+```sh
+cmake -S prosper -B build -DPROSPER_AUDIO_SDL3=ON   # uses system SDL3 if present, else fetches release-3.2.30
+```
+- Uses a system SDL3 (`find_package(SDL3)`) if available, otherwise fetches and builds an
+  **audio-only** SDL3 (video/render/joystick/etc. disabled — no X11/Wayland needed).
+- One `SDL_AudioStream` per PS5 port; `output()` pushes PCM and blocks while the device queue is full
+  (matching hardware pacing). Per-channel volumes are mapped to the stream gain.
+- When enabled, `boot_trace` calls `install_sdl3_audio_sink()` at startup automatically.
+
+## Tests (`ctest`)
+- **`audio_hle`** (`tests/test_audio.cpp`) — always built. Drives the real HLE entrypoints through the
+  dispatch table with a capturing sink: format decode (all 8 formats + unknown), port open/close,
+  byte-exact PCM forwarding, `Output`/`Outputs`, volume, port state, exhaustion, and error paths.
+- **`audio_sdl3`** (`frontends/audio_sdl3/test_audio_sdl3.cpp`) — built with `-DPROSPER_AUDIO_SDL3=ON`.
+  End-to-end through the real SDL3 backend under the SDL **dummy** audio driver, so it runs on
+  headless CI with no sound hardware.

--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -1,0 +1,18 @@
+// audio_sdl3.hpp — optional SDL3 audio frontend for the headless sceAudioOut HLE.
+//
+// Built only when -DPROSPER_AUDIO_SDL3=ON. Installs an SDL3-backed AudioSink so the guest's
+// audio actually plays out of the host's default device. The core HLE (src/hle/hle_audio.cpp)
+// has no knowledge of SDL — this frontend lives outside prosper_core and plugs in at runtime.
+#pragma once
+
+namespace prosper {
+
+// Initialise SDL audio and install the SDL3 AudioSink as the active backend. Idempotent.
+// Returns true on success; false (and leaves the default silent sink active) if SDL audio
+// could not be initialised. Safe to call once at startup after register_builtin_hle().
+bool install_sdl3_audio_sink();
+
+// Uninstall the SDL3 sink (restores the default), closing any open streams and SDL audio.
+void shutdown_sdl3_audio_sink();
+
+} // namespace prosper

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -1,0 +1,115 @@
+// audio_sink_sdl3.cpp — SDL3-backed AudioSink for the sceAudioOut HLE (optional frontend).
+//
+// Enabled with -DPROSPER_AUDIO_SDL3=ON. Bridges the headless AudioSink interface (audio.hpp)
+// to SDL3's audio-stream API: one SDL_AudioStream per PS5 audio port, fed the guest's PCM
+// grains. output() blocks while the device's queue is full, reproducing the pacing that
+// sceAudioOutOutput has on real hardware (it blocks until the audio ring has room).
+#include "audio_sdl3.hpp"
+#include "../../src/hle/audio.hpp"
+
+#include <SDL3/SDL.h>
+
+#include <array>
+#include <mutex>
+#include <thread>
+
+namespace prosper {
+namespace {
+
+constexpr int kMaxPorts = 16;
+
+SDL_AudioFormat to_sdl_format(AudioFmt f) { return f == AudioFmt::F32 ? SDL_AUDIO_F32 : SDL_AUDIO_S16; }
+
+class Sdl3AudioSink : public AudioSink {
+public:
+    bool init() {
+        if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
+            SDL_Log("prosper-audio: SDL_InitSubSystem(AUDIO) failed: %s", SDL_GetError());
+            return false;
+        }
+        return true;
+    }
+
+    void quit() {
+        for (int i = 0; i < kMaxPorts; i++) close(i + 1);
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    }
+
+    bool open(int port, const AudioPortInfo& info) override {
+        if (port < 1 || port > kMaxPorts) return false;
+        std::lock_guard<std::mutex> lk(mx_);
+        Slot& s = slots_[port - 1];
+        if (s.stream) { SDL_DestroyAudioStream(s.stream); s.stream = nullptr; }
+        SDL_AudioSpec spec{};
+        spec.format   = to_sdl_format(info.fmt);
+        spec.channels = info.channels;
+        spec.freq     = info.freq;
+        // Bind straight to the default playback device; NULL callback => we push data ourselves.
+        s.stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, nullptr, nullptr);
+        if (!s.stream) { SDL_Log("prosper-audio: OpenAudioDeviceStream failed: %s", SDL_GetError()); return false; }
+        s.frame_bytes = audio_frame_bytes(info);
+        s.grain_bytes = audio_grain_bytes(info);
+        SDL_ResumeAudioStreamDevice(s.stream);
+        return true;
+    }
+
+    void output(int port, const void* pcm, int frames) override {
+        if (port < 1 || port > kMaxPorts) return;
+        SDL_AudioStream* stream; int frame_bytes, grain_bytes;
+        { std::lock_guard<std::mutex> lk(mx_); Slot& s = slots_[port - 1];
+          stream = s.stream; frame_bytes = s.frame_bytes; grain_bytes = s.grain_bytes; }
+        if (!stream) return;
+        int bytes = frames * frame_bytes;
+        SDL_PutAudioStreamData(stream, pcm, bytes);
+        // Pace like real hardware: don't let more than ~4 grains queue up ahead of playback.
+        const int cap = grain_bytes > 0 ? grain_bytes * 4 : bytes * 4;
+        for (int spins = 0; SDL_GetAudioStreamQueued(stream) > cap && spins < 1000; spins++)
+            SDL_Delay(1);
+    }
+
+    void set_volume(int port, uint32_t mask, const int* vols) override {
+        if (port < 1 || port > kMaxPorts || !vols) return;
+        // Approximate the PS5 per-channel volumes as a single stream gain (0..1) from the loudest set channel.
+        int maxv = 0, vi = 0;
+        for (int c = 0; c < 8; c++) if (mask & (1u << c)) { if (vols[vi] > maxv) maxv = vols[vi]; vi++; }
+        float gain = maxv / 32768.0f;                     // SCE_AUDIO_VOLUME_0DB == 32768
+        std::lock_guard<std::mutex> lk(mx_);
+        if (SDL_AudioStream* st = slots_[port - 1].stream) SDL_SetAudioStreamGain(st, gain);
+    }
+
+    void close(int port) override {
+        if (port < 1 || port > kMaxPorts) return;
+        std::lock_guard<std::mutex> lk(mx_);
+        Slot& s = slots_[port - 1];
+        if (s.stream) { SDL_DestroyAudioStream(s.stream); s.stream = nullptr; }
+        s.frame_bytes = s.grain_bytes = 0;
+    }
+
+private:
+    struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0; };
+    std::mutex mx_;
+    std::array<Slot, kMaxPorts> slots_{};
+};
+
+Sdl3AudioSink g_sink;
+bool g_installed = false;
+
+} // namespace
+
+bool install_sdl3_audio_sink() {
+    if (g_installed) return true;
+    if (!g_sink.init()) return false;
+    audio_set_sink(&g_sink);
+    g_installed = true;
+    SDL_Log("prosper-audio: SDL3 audio backend installed");
+    return true;
+}
+
+void shutdown_sdl3_audio_sink() {
+    if (!g_installed) return;
+    audio_set_sink(nullptr);   // restore the default silent sink
+    g_sink.quit();
+    g_installed = false;
+}
+
+} // namespace prosper

--- a/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
@@ -1,0 +1,55 @@
+// test_audio_sdl3 — end-to-end test of the SDL3 audio frontend, headless under the SDL "dummy"
+// audio driver (set by the ctest env). Installs the SDL3 sink, drives the real sceAudioOut HLE
+// through the dispatch table, and asserts a full port lifecycle flows through SDL with no device.
+#include "audio_sdl3.hpp"
+#include "../../src/hle/dispatch.hpp"
+#include "../../src/hle/nid.hpp"
+#include "../../src/hle/audio.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c) do { if (!(c)) { printf("  [FAIL] %s:%d  %s\n", __FILE__, __LINE__, #c); fails++; } } while (0)
+
+static int64_t call(const char* n, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0,
+                    uint64_t a3 = 0, uint64_t a4 = 0, uint64_t a5 = 0) {
+    HleFn f = Hle::lookup(nid_hash(n));
+    if (!f) { printf("  [FAIL] not registered: %s\n", n); fails++; return -999; }
+    return (int64_t)f(a0, a1, a2, a3, a4, a5);
+}
+static uint64_t PTR(const void* p) { return (uint64_t)(uintptr_t)p; }
+
+int main() {
+    printf("== test_audio_sdl3 ==\n");
+    register_builtin_hle();
+    // Force the dummy driver so this runs on headless CI with no sound hardware.
+    if (!getenv("SDL_AUDIO_DRIVER")) setenv("SDL_AUDIO_DRIVER", "dummy", 1);
+
+    bool ok = install_sdl3_audio_sink();
+    CHECK(ok);
+    if (ok) {
+        CHECK(audio_sink() != nullptr);
+
+        int64_t h = call("sceAudioOutOpen", 1, 0, 0, 256, 48000, 1 /*S16 stereo*/);
+        CHECK(h >= 1);
+
+        std::vector<int16_t> pcm(256 * 2);
+        for (size_t i = 0; i < pcm.size(); i++) pcm[i] = (int16_t)(i * 131 - 4000);
+        CHECK(call("sceAudioOutOutput", (uint64_t)h, PTR(pcm.data())) == 256);
+
+        int vols[2] = { 20000, 20000 };
+        CHECK(call("sceAudioOutSetVolume", (uint64_t)h, 0x3, PTR(vols)) == 0);
+        CHECK(call("sceAudioOutClose", (uint64_t)h) == 0);
+
+        shutdown_sdl3_audio_sink();
+        CHECK(audio_sink() != nullptr);   // default silent sink restored
+    }
+
+    if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
+    printf("== PASS: SDL3 audio frontend end-to-end (dummy driver) ==\n");
+    return 0;
+}

--- a/prosper/src/hle/audio.hpp
+++ b/prosper/src/hle/audio.hpp
@@ -1,0 +1,54 @@
+// audio.hpp — backend-agnostic audio sink for the sceAudioOut HLE.
+//
+// The audio HLE (hle_audio.cpp) decodes the PS5 sceAudioOut* calls into port lifecycle
+// events + interleaved PCM "grains" and forwards them to a pluggable AudioSink. The core
+// is HEADLESS: prosper_core ships a silent, real-time-paced default sink (no dependencies),
+// so the guest's audio thread is paced correctly even with no audio device. A concrete
+// frontend (e.g. SDL3, see frontends/audio_sdl3/) lives OUTSIDE prosper_core and installs
+// itself via audio_set_sink(), keeping prosper_core dependency-free and unit-testable.
+#pragma once
+#include <cstdint>
+
+namespace prosper {
+
+// Sample format, decoded from sceAudioOutOpen's `param`.
+enum class AudioFmt : int { S16 = 0, F32 = 1 };
+
+// Fully-decoded parameters of an open audio port.
+struct AudioPortInfo {
+    int      freq     = 48000;          // sample rate (Hz)
+    int      channels = 2;              // 1 (mono), 2 (stereo), 8 (7.1)
+    AudioFmt fmt      = AudioFmt::S16;  // interleaved sample format
+    int      grain    = 256;            // frames delivered per sceAudioOutOutput call (the open `len`)
+};
+
+inline int audio_bytes_per_sample(AudioFmt f) { return f == AudioFmt::F32 ? 4 : 2; }
+inline int audio_frame_bytes(const AudioPortInfo& p) { return p.channels * audio_bytes_per_sample(p.fmt); }
+inline int audio_grain_bytes(const AudioPortInfo& p) { return p.grain * audio_frame_bytes(p); }
+
+// Decode a sceAudioOutOpen `param` word into channels + sample format. The low byte is the
+// SceAudioOutParamFormat enum; higher bits are attributes (ignored here). Unknown -> S16 stereo.
+void audio_decode_format(uint32_t param, int& channels, AudioFmt& fmt);
+
+// Pluggable audio backend. All calls arrive on the guest's audio thread; output() MAY block to
+// pace it (as real hardware does — sceAudioOutOutput blocks until the ring has room).
+struct AudioSink {
+    virtual ~AudioSink() = default;
+    // Open (or reconfigure) a port. Return true on success. Called before any output().
+    virtual bool open(int port, const AudioPortInfo& info) { (void)port; (void)info; return true; }
+    // Deliver one grain (info.grain frames) of interleaved PCM. `pcm` is host-readable, non-owning.
+    virtual void output(int port, const void* pcm, int frames) = 0;
+    // Per-channel volume in [0, 32768] (SCE_AUDIO_VOLUME_0DB). `mask` selects which channels
+    // `vols` covers (bit i -> channel i); `vols` is a host-readable array of set bits' values.
+    virtual void set_volume(int port, uint32_t mask, const int* vols) { (void)port; (void)mask; (void)vols; }
+    virtual void close(int port) { (void)port; }
+};
+
+// Install a backend. Non-owning; pass nullptr to restore the built-in silent/real-time sink.
+void audio_set_sink(AudioSink* sink);
+AudioSink* audio_sink();
+
+// Close all ports and restore the default sink. Intended for tests.
+void audio_reset();
+
+} // namespace prosper

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -43,6 +43,8 @@ void set_app0_root(const std::string& root);
 void register_service_hle();
 // Headless graphics bring-up (libSceAgc/libSceVideoOut placeholders); see hle_graphics.cpp.
 void register_graphics_hle();
+// libSceAudioOut HLE backed by a pluggable, headless AudioSink; see hle_audio.cpp / audio.hpp.
+void register_audio_hle();
 // libSceAgc "Gen5" Draw Command Buffer HLE (real PM4-building Dcb functions); see hle_agc.cpp.
 // Call AFTER register_graphics_hle so these override the observe-only glog stubs.
 void register_agc_hle();

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1,0 +1,206 @@
+// hle_audio.cpp — libSceAudioOut HLE, backed by a pluggable AudioSink (see audio.hpp).
+//
+// Decodes the PS5 sceAudioOut* calls into port lifecycle + interleaved PCM grains and forwards
+// them to the installed backend. prosper_core ships only the headless default (silent, real-time
+// paced) so it stays dependency-free; a concrete frontend (SDL3, ...) installs itself via
+// audio_set_sink() from outside the core.
+#include "dispatch.hpp"
+#include "nid.hpp"
+#include "audio.hpp"
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <thread>
+
+namespace prosper {
+
+#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5)
+#define P(x) ((void*)(uintptr_t)(x))
+
+namespace {
+
+constexpr int kMaxPorts  = 16;
+constexpr int kVolume0dB = 32768;   // SCE_AUDIO_VOLUME_0DB
+
+struct Port {
+    bool          in_use = false;
+    AudioPortInfo info;
+    int           vol[8] = { kVolume0dB, kVolume0dB, kVolume0dB, kVolume0dB,
+                             kVolume0dB, kVolume0dB, kVolume0dB, kVolume0dB };
+};
+
+std::mutex g_mx;                 // guards the port table
+Port       g_ports[kMaxPorts];
+
+// --- default backend: silent, real-time paced (headless) --------------------------------
+// sceAudioOutOutput on real hardware blocks until the audio ring has room, which paces the
+// game's audio thread at real time. With no device attached we reproduce that pacing by
+// sleeping each grain's wall-clock duration, so the guest advances at the correct speed.
+struct RealtimeSilentSink : AudioSink {
+    struct Pace { std::chrono::steady_clock::time_point next{}; long long ns_per_grain = 0; };
+    Pace p_[kMaxPorts];
+    bool open(int port, const AudioPortInfo& info) override {
+        if (port < 1 || port > kMaxPorts) return false;
+        int freq = info.freq > 0 ? info.freq : 48000;
+        int grain = info.grain > 0 ? info.grain : 256;
+        p_[port - 1].ns_per_grain = (long long)grain * 1000000000LL / freq;
+        p_[port - 1].next = {};
+        return true;
+    }
+    void output(int port, const void*, int frames) override {
+        if (port < 1 || port > kMaxPorts) return;
+        auto& s = p_[port - 1];
+        long long ns = s.ns_per_grain > 0 ? s.ns_per_grain : ((long long)frames * 1000000000LL / 48000);
+        auto now = std::chrono::steady_clock::now();
+        auto dur = std::chrono::nanoseconds(ns);
+        // (Re)sync if unset or we fell far behind (e.g. after a stall) to avoid burst catch-up.
+        if (s.next.time_since_epoch().count() == 0 || s.next < now - dur * 4) s.next = now;
+        s.next += dur;
+        if (s.next > now) std::this_thread::sleep_until(s.next);
+    }
+    void close(int port) override { if (port >= 1 && port <= kMaxPorts) p_[port - 1] = {}; }
+};
+
+RealtimeSilentSink        g_default_sink;
+std::atomic<AudioSink*>   g_sink{ &g_default_sink };
+
+// Caller must hold g_mx.
+Port* port_of(int handle) {
+    if (handle < 1 || handle > kMaxPorts) return nullptr;
+    Port& p = g_ports[handle - 1];
+    return p.in_use ? &p : nullptr;
+}
+
+} // namespace
+
+// --- public backend hooks (audio.hpp) ---------------------------------------------------
+void audio_set_sink(AudioSink* sink) { g_sink.store(sink ? sink : &g_default_sink); }
+AudioSink* audio_sink() { return g_sink.load(); }
+
+void audio_decode_format(uint32_t param, int& channels, AudioFmt& fmt) {
+    switch (param & 0xff) {                                   // SceAudioOutParamFormat (low byte)
+        case 0: channels = 1; fmt = AudioFmt::S16; break;     // S16_MONO
+        case 1: channels = 2; fmt = AudioFmt::S16; break;     // S16_STEREO
+        case 2: channels = 8; fmt = AudioFmt::S16; break;     // S16_8CH
+        case 3: channels = 1; fmt = AudioFmt::F32; break;     // FLOAT_MONO
+        case 4: channels = 2; fmt = AudioFmt::F32; break;     // FLOAT_STEREO
+        case 5: channels = 8; fmt = AudioFmt::F32; break;     // FLOAT_8CH
+        case 6: channels = 8; fmt = AudioFmt::S16; break;     // S16_8CH_STD
+        case 7: channels = 8; fmt = AudioFmt::F32; break;     // FLOAT_8CH_STD
+        default: channels = 2; fmt = AudioFmt::S16; break;    // unknown -> S16 stereo
+    }
+}
+
+void audio_reset() {
+    AudioSink* s = audio_sink();
+    std::lock_guard<std::mutex> lk(g_mx);
+    for (int i = 0; i < kMaxPorts; i++) {
+        if (g_ports[i].in_use && s) s->close(i + 1);
+        g_ports[i] = Port{};
+    }
+    g_sink.store(&g_default_sink);
+}
+
+// --- sceAudioOut HLE --------------------------------------------------------------------
+HLE(audio_init) { (void)a0; return 0; }   // sceAudioOutInit: idempotent success
+
+// sceAudioOutOpen(userId, type, index, len, freq, param) -> handle (>=1) or negative error.
+HLE(audio_open) {
+    (void)a0; (void)a1; (void)a2;
+    AudioPortInfo info;
+    info.grain = (int)(a3 ? a3 : 256);
+    info.freq  = (int)(a4 ? a4 : 48000);
+    audio_decode_format((uint32_t)a5, info.channels, info.fmt);
+
+    int handle = 0;
+    { std::lock_guard<std::mutex> lk(g_mx);
+      for (int i = 0; i < kMaxPorts; i++) {
+          if (g_ports[i].in_use) continue;
+          g_ports[i].in_use = true;
+          g_ports[i].info = info;
+          for (int c = 0; c < 8; c++) g_ports[i].vol[c] = kVolume0dB;
+          handle = i + 1;
+          break;
+      } }
+    if (!handle) return (uint64_t)(int64_t)-1;   // no free port
+    if (auto* s = audio_sink()) s->open(handle, info);
+    return (uint64_t)handle;
+}
+
+// sceAudioOutOutput(handle, ptr) -> frames written (>=0) or negative error. ptr==0 => drain.
+HLE(audio_output) {
+    AudioPortInfo info;
+    { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return (uint64_t)(int64_t)-1; info = p->info; }
+    if (a1 == 0) return 0;   // drain/flush: nothing buffered in the headless model
+    if (auto* s = audio_sink()) s->output((int)a0, P(a1), info.grain);
+    return (uint64_t)info.grain;
+}
+
+// sceAudioOutOutputs(SceAudioOutOutputParam param[], int num) -> total frames or negative error.
+// SceAudioOutOutputParam = { int32 handle; int32 reserved; void* ptr } (16 bytes).
+HLE(audio_outputs) {
+    struct OutParam { int32_t handle; int32_t reserved; uint64_t ptr; };
+    const auto* arr = (const OutParam*)P(a0);
+    int num = (int)a1;
+    if (!arr || num <= 0) return 0;
+    uint64_t total = 0;
+    for (int i = 0; i < num; i++) {
+        AudioPortInfo info; bool ok;
+        { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of(arr[i].handle); ok = (p != nullptr); if (ok) info = p->info; }
+        if (!ok) continue;
+        if (arr[i].ptr) { if (auto* s = audio_sink()) s->output(arr[i].handle, P(arr[i].ptr), info.grain); }
+        total += info.grain;
+    }
+    return total;
+}
+
+// sceAudioOutSetVolume(handle, flag(channel mask), int vol[]) -> 0 or negative error.
+HLE(audio_set_volume) {
+    uint32_t mask = (uint32_t)a1;
+    const int* vols = (const int*)P(a2);
+    { std::lock_guard<std::mutex> lk(g_mx);
+      Port* p = port_of((int)a0); if (!p) return (uint64_t)(int64_t)-1;
+      if (vols) { int vi = 0; for (int c = 0; c < 8; c++) if (mask & (1u << c)) p->vol[c] = vols[vi++]; } }
+    if (auto* s = audio_sink()) s->set_volume((int)a0, mask, vols);
+    return 0;
+}
+
+// sceAudioOutClose(handle) -> 0 or negative error.
+HLE(audio_close) {
+    int handle = (int)a0;
+    { std::lock_guard<std::mutex> lk(g_mx);
+      Port* p = port_of(handle); if (!p) return (uint64_t)(int64_t)-1; p->in_use = false; }
+    if (auto* s = audio_sink()) s->close(handle);
+    return 0;
+}
+
+// sceAudioOutGetPortState(handle, SceAudioOutPortState* state) -> 0 or negative error.
+HLE(audio_get_port_state) {
+    int channels;
+    { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return (uint64_t)(int64_t)-1; channels = p->info.channels; }
+    if (a1) {   // SceAudioOutPortState (0x20): uint16 output; uint16 channel; ...; uint32 volume
+        auto* st = (uint8_t*)P(a1);
+        memset(st, 0, 0x20);
+        *(uint16_t*)(st + 0) = 1;                     // output: enabled
+        *(uint16_t*)(st + 2) = (uint16_t)channels;    // channels
+        *(uint32_t*)(st + 8) = (uint32_t)kVolume0dB;  // volume
+    }
+    return 0;
+}
+
+void register_audio_hle() {
+    #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
+    R("sceAudioOutInit", audio_init);
+    R("sceAudioOutOpen", audio_open);
+    R("sceAudioOutOutput", audio_output);
+    R("sceAudioOutOutputs", audio_outputs);
+    R("sceAudioOutSetVolume", audio_set_volume);
+    R("sceAudioOutClose", audio_close);
+    R("sceAudioOutGetPortState", audio_get_port_state);
+    #undef R
+}
+
+} // namespace prosper

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -324,6 +324,7 @@ void register_builtin_hle() {
     #undef R
     register_file_hle();     // file I/O (stdio + POSIX, /app0 translation)
     register_service_hle();  // PS5 system services (user/NP/pad/mouse/appcontent)
+    register_audio_hle();    // libSceAudioOut backed by a headless/pluggable AudioSink
     register_graphics_hle(); // headless libSceAgc/libSceVideoOut placeholders (bring-up)
     register_agc_hle();      // real AGC Dcb functions (override the glog stubs for Dcb NIDs)
     register_kernel_hle();   // libkernel primitives (pthread/sync/...)

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -1,0 +1,162 @@
+// test_audio — behavioral test for the sceAudioOut HLE (hle_audio.cpp) via a capturing sink.
+//
+// Agentic-first: no device, no PATH/DLL setup. Installs a fake AudioSink, drives the real HLE
+// entrypoints through the dispatch table (so registration + arg decoding + forwarding are all
+// exercised), and asserts the port lifecycle, format decoding, PCM forwarding, volume and error
+// paths. Exit code is truth.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/audio.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond) do { if (!(cond)) { printf("  [FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); fails++; } } while (0)
+
+// Records every backend event so the test can assert on them.
+struct CapturingSink : AudioSink {
+    struct OpenEv  { int port; AudioPortInfo info; };
+    struct OutEv   { int port; int frames; std::vector<uint8_t> pcm; };
+    struct VolEv   { int port; uint32_t mask; std::vector<int> vols; };
+    std::vector<OpenEv> opens;
+    std::vector<OutEv>  outs;
+    std::vector<VolEv>  vols_;
+    std::vector<int>    closes;
+
+    bool open(int port, const AudioPortInfo& info) override { opens.push_back({port, info}); return true; }
+    void output(int port, const void* pcm, int frames) override {
+        OutEv e; e.port = port; e.frames = frames;
+        // Copy the delivered grain so we can verify byte-for-byte (uses the port's most-recent open).
+        int fb = frames * (opens.empty() ? 4 : audio_frame_bytes(opens.back().info));
+        e.pcm.assign((const uint8_t*)pcm, (const uint8_t*)pcm + fb);
+        outs.push_back(std::move(e));
+    }
+    void set_volume(int port, uint32_t mask, const int* v) override {
+        VolEv e; e.port = port; e.mask = mask;
+        for (int c = 0; c < 8; c++) if (mask & (1u << c)) e.vols.push_back(v[c]);
+        vols_.push_back(std::move(e));
+    }
+    void close(int port) override { closes.push_back(port); }
+};
+
+// Typed shims over the dispatch table.
+static HleFn FN(const char* n) { return Hle::lookup(nid_hash(n)); }
+static int64_t call(const char* n, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0,
+                    uint64_t a3 = 0, uint64_t a4 = 0, uint64_t a5 = 0) {
+    HleFn f = FN(n);
+    if (!f) { printf("  [FAIL] not registered: %s\n", n); fails++; return -999; }
+    return (int64_t)f(a0, a1, a2, a3, a4, a5);
+}
+static uint64_t PTR(const void* p) { return (uint64_t)(uintptr_t)p; }
+
+int main() {
+    printf("== test_audio ==\n");
+    register_builtin_hle();
+
+    // --- 1. format decoding (all 8 SceAudioOutParamFormat values + an unknown) ---------------
+    struct { uint32_t param; int ch; AudioFmt fmt; } fmts[] = {
+        {0, 1, AudioFmt::S16}, {1, 2, AudioFmt::S16}, {2, 8, AudioFmt::S16}, {3, 1, AudioFmt::F32},
+        {4, 2, AudioFmt::F32}, {5, 8, AudioFmt::F32}, {6, 8, AudioFmt::S16}, {7, 8, AudioFmt::F32},
+        {0x1234, 2, AudioFmt::S16},                     // unknown low byte 0x34 -> default stereo S16
+    };
+    for (auto& t : fmts) {
+        int ch; AudioFmt f; audio_decode_format(t.param, ch, f);
+        CHECK(ch == t.ch); CHECK(f == t.fmt);
+    }
+
+    // --- 2. open -> handle + backend.open with decoded params --------------------------------
+    audio_reset();
+    CapturingSink sink; audio_set_sink(&sink);
+
+    // sceAudioOutOpen(userId=1, type=0(MAIN), index=0, len=256, freq=48000, param=1(S16_STEREO))
+    int64_t h = call("sceAudioOutOpen", 1, 0, 0, 256, 48000, 1);
+    CHECK(h >= 1);
+    CHECK(sink.opens.size() == 1);
+    if (!sink.opens.empty()) {
+        auto& o = sink.opens[0];
+        CHECK(o.port == (int)h);
+        CHECK(o.info.freq == 48000); CHECK(o.info.channels == 2);
+        CHECK(o.info.fmt == AudioFmt::S16); CHECK(o.info.grain == 256);
+        CHECK(audio_grain_bytes(o.info) == 256 * 2 * 2);   // 256 frames * 2ch * 2B
+    }
+
+    // --- 3. output forwards the exact grain (frames + bytes) ---------------------------------
+    std::vector<uint8_t> pcm(256 * 2 * 2);
+    for (size_t i = 0; i < pcm.size(); i++) pcm[i] = (uint8_t)(i * 7 + 3);
+    int64_t n = call("sceAudioOutOutput", (uint64_t)h, PTR(pcm.data()));
+    CHECK(n == 256);                                      // returns frames written
+    CHECK(sink.outs.size() == 1);
+    if (!sink.outs.empty()) {
+        CHECK(sink.outs[0].port == (int)h);
+        CHECK(sink.outs[0].frames == 256);
+        CHECK(sink.outs[0].pcm == pcm);                  // byte-for-byte forwarded
+    }
+    // ptr == 0 is a drain request: returns 0, does NOT forward a grain.
+    CHECK(call("sceAudioOutOutput", (uint64_t)h, 0) == 0);
+    CHECK(sink.outs.size() == 1);
+
+    // --- 4. set volume forwards mask + values -----------------------------------------------
+    int vols[2] = { 20000, 15000 };
+    CHECK(call("sceAudioOutSetVolume", (uint64_t)h, 0x3 /*ch0|ch1*/, PTR(vols)) == 0);
+    CHECK(sink.vols_.size() == 1);
+    if (!sink.vols_.empty()) {
+        CHECK(sink.vols_[0].mask == 0x3);
+        CHECK(sink.vols_[0].vols.size() == 2);
+        CHECK(sink.vols_[0].vols[0] == 20000); CHECK(sink.vols_[0].vols[1] == 15000);
+    }
+
+    // --- 5. get port state fills the struct --------------------------------------------------
+    uint8_t state[0x20]; memset(state, 0xEE, sizeof state);
+    CHECK(call("sceAudioOutGetPortState", (uint64_t)h, PTR(state)) == 0);
+    CHECK(*(uint16_t*)(state + 0) == 1);                  // output enabled
+    CHECK(*(uint16_t*)(state + 2) == 2);                  // channels
+
+    // --- 6. error paths ---------------------------------------------------------------------
+    CHECK(call("sceAudioOutOutput", 999, PTR(pcm.data())) < 0);     // bad handle
+    CHECK(call("sceAudioOutSetVolume", 999, 0x1, PTR(vols)) < 0);
+    CHECK(call("sceAudioOutClose", 999) < 0);
+    CHECK(call("sceAudioOutInit", 0) == 0);
+
+    // --- 7. close, then output-after-close fails --------------------------------------------
+    CHECK(call("sceAudioOutClose", (uint64_t)h) == 0);
+    CHECK(!sink.closes.empty() && sink.closes.back() == (int)h);
+    CHECK(call("sceAudioOutOutput", (uint64_t)h, PTR(pcm.data())) < 0);
+
+    // --- 8. exhaustion: 16 ports open, 17th fails; float format decoded on open --------------
+    audio_reset(); sink = CapturingSink{}; audio_set_sink(&sink);
+    int opened = 0;
+    for (int i = 0; i < 16; i++) if (call("sceAudioOutOpen", 1, 0, 0, 512, 44100, 4 /*F32 stereo*/) >= 1) opened++;
+    CHECK(opened == 16);
+    CHECK(call("sceAudioOutOpen", 1, 0, 0, 512, 44100, 4) < 0);     // no free port
+    CHECK(sink.opens.size() == 16);
+    if (!sink.opens.empty()) {
+        CHECK(sink.opens[0].info.fmt == AudioFmt::F32);
+        CHECK(sink.opens[0].info.freq == 44100);
+        CHECK(audio_grain_bytes(sink.opens[0].info) == 512 * 2 * 4);
+    }
+
+    // --- 9. sceAudioOutOutputs (batch) forwards each valid entry -----------------------------
+    audio_reset(); sink = CapturingSink{}; audio_set_sink(&sink);
+    int64_t ha = call("sceAudioOutOpen", 1, 0, 0, 128, 48000, 1);
+    int64_t hb = call("sceAudioOutOpen", 1, 0, 0, 128, 48000, 1);
+    CHECK(ha >= 1 && hb >= 1);
+    struct OutParam { int32_t handle; int32_t reserved; uint64_t ptr; } batch[3];
+    std::vector<uint8_t> pa(128 * 2 * 2, 0x11), pb(128 * 2 * 2, 0x22);
+    batch[0] = { (int32_t)ha, 0, PTR(pa.data()) };
+    batch[1] = { 999,          0, PTR(pb.data()) };        // invalid handle -> skipped
+    batch[2] = { (int32_t)hb, 0, PTR(pb.data()) };
+    int64_t tot = call("sceAudioOutOutputs", PTR(batch), 3);
+    CHECK(tot == 128 + 128);                              // two valid entries
+    CHECK(sink.outs.size() == 2);
+
+    // --- restore the default sink so we don't dangle a stack pointer -------------------------
+    audio_reset();
+
+    if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
+    printf("== PASS: sceAudioOut HLE (format/open/output/volume/state/close/batch/errors) ==\n");
+    return 0;
+}

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -36,6 +36,9 @@ int main() {
         "sceSystemServiceHideSplashScreen",
         // graphics (headless bring-up)
         "sceVideoOutOpen", "sceVideoOutSubmitFlip", "sceVideoOutGetFlipStatus",
+        // audio (headless / pluggable backend)
+        "sceAudioOutInit", "sceAudioOutOpen", "sceAudioOutOutput", "sceAudioOutOutputs",
+        "sceAudioOutSetVolume", "sceAudioOutClose", "sceAudioOutGetPortState",
     };
     for (const char* n : names) must(n);
     // sync_on_address futex is registered by raw NID (no symbol name) — check it directly.

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -7,6 +7,9 @@
 #include "hle/dispatch.hpp"
 #include <cstdio>
 #include <string>
+#ifdef PROSPER_AUDIO_SDL3
+#include "audio_sdl3.hpp"                 // optional SDL3 audio frontend (-DPROSPER_AUDIO_SDL3=ON)
+#endif
 #ifdef PROSPER_HAVE_VULKAN
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"       // ShaderResourceTable / ResourceClass (bind the shaders' resources)
@@ -141,6 +144,9 @@ int main(int argc, char** argv) {
            p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(), p.init_fns.size());
 
     register_builtin_hle();
+#ifdef PROSPER_AUDIO_SDL3
+    prosper::install_sdl3_audio_sink();   // route the guest's sceAudioOut output to the host via SDL3
+#endif
     set_app0_root(d);
     for (auto& img : p.imgs) if (!map_image(img, &e)) { printf("map failed: %s\n", e.c_str()); return 1; }
     { std::vector<TlsModuleDesc> td; for (auto& t : p.tls_templates) td.push_back({t.init_va, t.filesz, t.memsz});


### PR DESCRIPTION
Adds PS5 audio (`libSceAudioOut`) as a **headless, backend-agnostic core** with **pluggable frontends** — so `prosper_core` stays dependency-free and unit-testable, and any audio sink (SDL3, a recorder, …) plugs in at runtime. SDL3 is optional.

## Design
The HLE decodes the guest's `sceAudioOut*` calls into a port lifecycle + interleaved PCM "grains" and forwards them to an installed `AudioSink`. It never touches an audio library.

| Layer | File |
|---|---|
| Backend interface | `src/hle/audio.hpp` (`AudioSink`, `AudioPortInfo`, format decode) |
| HLE + default sink | `src/hle/hle_audio.cpp` |
| SDL3 frontend (optional) | `frontends/audio_sdl3/` (outside `prosper_core`) |

**HLE coverage:** `sceAudioOutInit/Open/Output/Outputs/SetVolume/Close/GetPortState` — 16-port table; `SceAudioOutParamFormat` decode (S16/F32 × mono/stereo/8ch); zero-copy PCM forwarding.

**Default backend (headless):** a silent, **real-time-paced** sink. On hardware `sceAudioOutOutput` blocks until the audio ring has room (this paces the game's audio thread); the default reproduces that by sleeping each grain's wall-clock duration — correct timing, no device.

**SDL3 frontend (`-DPROSPER_AUDIO_SDL3=ON`):** one `SDL_AudioStream` per port; `output()` blocks while the device queue is full (hardware-matching pacing); volumes → stream gain. Uses a system SDL3 if present, else FetchContent-builds an **audio-only** SDL3 (no X11/Wayland needed). `boot_trace` installs it automatically when enabled.

## Tests (agentic-first, exit-code = truth)
- **`audio_hle`** — always built. Drives the real HLE through the dispatch table with a capturing sink: format decode (all 8 + unknown), port lifecycle, **byte-exact** PCM forwarding, `Output`/`Outputs`, volume, port state, exhaustion, error paths.
- **`audio_sdl3`** — with the option on. Full path through real SDL3 under the **dummy** audio driver, so it runs on headless CI.

## Verification
- Default build: **41/41 ctest pass** (no SDL3, no regressions).
- `-DPROSPER_AUDIO_SDL3=ON`: SDL3 builds; **`audio_hle` + `audio_sdl3` both pass**.

See `docs/AUDIO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)