### PR TITLE
fix(gpu/hle): execute DCB flip + wire sceAgcDriverAddEqEvent (frame-loop stall)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -118,8 +118,18 @@ void GpuState::apply(const Pm4Command& c) {
         case K::WriteData:
             honor_write_data(c);    // inline data write requested by the Dcb
             break;
+        case K::Flip:
+            // Capture the game's real per-frame flip (R_FLIP payload: [0]=handle, [1]=buffer index,
+            // [2]=mode, [3..4]=64-bit flip_arg). The submit path executes it after the fold. Previously
+            // dropped, which starved Unity's flip-done wait (the frame-loop stall). CONFIDENCE: HIGH
+            // (payload layout matches the sceAgcDcbSetFlip builder).
+            if (c.payload && c.len >= 6) {
+                pending_flip = { true, (int)c.payload[0], (int)c.payload[1], (int)c.payload[2],
+                                 (uint64_t)c.payload[3] | ((uint64_t)c.payload[4] << 32) };
+            }
+            break;
         default:
-            break;   // events / flips / unknown: no register-state effect (handled later)
+            break;   // events / unknown: no register-state effect
     }
 }
 

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -26,6 +26,13 @@ struct GpuState {
     struct Draw { uint32_t index_count; };
     std::vector<Draw> draws;                             // one per DrawIndexAuto
 
+    // A DCB-embedded Flip packet (R_FLIP / sceAgcDcbSetFlip) captured during the fold: the game's real
+    // per-frame flip. The submit path executes it after the fold (advance flip status + present + post a
+    // VIDEO_OUT flip event carrying flip_arg) so Unity's frame-pacing sees ITS flip complete. Without this
+    // the flip is silently dropped and the main thread parks forever waiting on the flip-done it never gets.
+    struct PendingFlip { bool valid = false; int handle = 0, bufidx = 0, mode = 0; uint64_t arg = 0; };
+    PendingFlip pending_flip;
+
     // Safety cap on an indirect register count (a malformed/huge count won't run away).
     static constexpr uint32_t kMaxRegsPerPacket = 4096;
 

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -540,6 +540,9 @@ uint64_t g_submit_count = 0;
 // EOP completion signaling (hle_kernel_time.cpp): fire the GPU end-of-pipe events the game registered
 // via sceGnmAddEqEvent. Our fold is synchronous, so a completed SubmitDcb == the GPU pipe having drained.
 void prosper_eq_trigger_eop();
+// Execute a DCB-embedded flip (hle_graphics.cpp): advance flip status, present, and post the VIDEO_OUT
+// flip-done event carrying flip_arg. This is the completion Unity's frame-pacing loop waits on.
+void prosper_vo_dcb_flip(int handle, int bufidx, int mode, uint64_t flip_arg);
 
 extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws) {
     if (submits) *submits = g_submit_count;
@@ -564,6 +567,17 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         if (presented && getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc] SubmitDcb #%llu: executed %zu draws -> presented %ux%u frame\n",
                     (unsigned long long)g_submit_count, agc_gpu_state().draws.size(), w, h);
+    }
+    // Execute the game's DCB-embedded flip (captured during the fold), if any. This advances flip status,
+    // presents the buffer, and posts the flip-done event carrying flip_arg — the signal Unity's main-thread
+    // frame loop blocks on (UnityFTMFlipQueue). Previously the R_FLIP packet was dropped, so that flip never
+    // "completed" and the frame loop parked forever. CONFIDENCE: HIGH (root cause cross-confirmed vs Kyty).
+    if (auto& pf = agc_gpu_state().pending_flip; pf.valid) {
+        prosper_vo_dcb_flip(pf.handle, pf.bufidx, pf.mode, pf.arg);
+        if (getenv("PROSPER_GFXLOG"))
+            fprintf(stderr, "[agc] SubmitDcb #%llu: DCB flip -> buf=%d arg=0x%llx\n",
+                    (unsigned long long)g_submit_count, pf.bufidx, (unsigned long long)pf.arg);
+        pf.valid = false;
     }
     if (getenv("PROSPER_GFXLOG")) {
         fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu)\n",

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -157,6 +157,10 @@ namespace { bool evlog() { static int v = getenv("PROSPER_EVLOG") ? 1 : 0; retur
 void prosper_eq_add_flip(uint64_t eq, int64_t ident, uint64_t udata);
 void prosper_eq_add_vblank(uint64_t eq, int64_t ident, uint64_t udata);
 void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata);
+// Post a flip-done event carrying the game's flip_arg to every registered flip equeue (vs the pump's
+// generic frame counter). Unity matches event.data against the flipArg it submitted, so a real flip must
+// carry it or the game never recognizes ITS flip completed.
+void prosper_eq_post_flip(int64_t flip_arg);
 // sceGnmAddEqEvent / GraphicsAddEqEvent (NID b0xyllnVY-I): register a GPU EOP/compute-ring completion
 // event source on an equeue. Mirrors shadPS4 sceGnmAddEqEvent (id=GfxEop=0x40 for gfx). The submit path
 // (hle_agc.cpp) fires prosper_eq_trigger_eop() on completion. NOTE: our target (The Messenger) never
@@ -164,6 +168,18 @@ void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata);
 // the correct, ref-validated behavior for the general case and lets test_equeue_events verify the path.
 HLE(g_gnm_add_eq_event) {   // (eq, id, udata)
     if (evlog()) fprintf(stderr, "[ev] GnmAddEqEvent eq=0x%llx id=0x%llx udata=0x%llx\n",
+        (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2);
+    prosper_eq_add_eop(a0, (int64_t)a1, a2);
+    return 0;
+}
+// sceAgcDriverAddEqEvent (NID w2rJhmD+dsE) — the libSceAgc *driver* path's GPU-completion event
+// registration (the Agc analogue of sceGnmAddEqEvent; The Messenger uses the Agc path, not Gnm). The game
+// registers this on its UnityFTMFlipQueue and EOP QUEUE, then the main thread blocks on the flip queue for
+// GPU-submit completion. Previously a trace-only stub, so no source was registered and that queue starved
+// forever (the frame-loop stall). Wire it to the same EOP backend the submit path fires each SubmitDcb.
+// CONFIDENCE: MED — a0=equeue is confirmed; id/udata mapping mirrors the Gnm variant.
+HLE(g_agc_add_eq_event) {   // (eq, id, udata, ...)
+    if (evlog()) fprintf(stderr, "[ev] AgcDriverAddEqEvent eq=0x%llx id=0x%llx udata=0x%llx\n",
         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2);
     prosper_eq_add_eop(a0, (int64_t)a1, a2);
     return 0;
@@ -191,6 +207,18 @@ HLE(g_vo_submitflip)  {
     g_last_flip_arg = (int64_t)a3;
     gpu::present_flip((int)(int32_t)a1, (int64_t)a3);   // present the buffer (scanout front + count)
     return 0;
+}
+// Execute a DCB-embedded flip (R_FLIP / sceAgcDcbSetFlip), called from the AGC submit path. The game
+// submits its REAL per-frame flip inside the Dcb (not via sceVideoOutSubmitFlip), so this is where that
+// flip actually completes: advance flip status (so GetFlipStatus shows progress), present the buffer, and
+// post a flip-done event carrying flip_arg to the registered flip equeues. Mirrors g_vo_submitflip.
+void prosper_vo_dcb_flip(int handle, int bufidx, int mode, uint64_t flip_arg) {
+    (void)handle; (void)mode;
+    g_flip_count++;
+    g_current_buffer = bufidx;
+    g_last_flip_arg = (int64_t)flip_arg;
+    gpu::present_flip(bufidx, (int64_t)flip_arg);
+    prosper_eq_post_flip((int64_t)flip_arg);
 }
 HLE(g_vo_flippending) { if (evlog()) fprintf(stderr, "[ev] IsFlipPending\n"); return 0; }        // never pending
 HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our simulated flip count.
@@ -429,6 +457,9 @@ void register_graphics_hle() {
     // Override the +kSrjIVxKFE tracer with the real register-context constructor (must come AFTER the
     // tracer registration above so it wins; registry is last-write-wins per NID).
     RN("+kSrjIVxKFE", g_agc_ctx_init);      // AGC register-context init (installs classify table)
+    // Override the w2rJhmD+dsE tracer with the real sceAgcDriverAddEqEvent (registers the GPU-completion
+    // event source the game's frame loop waits on — the un-parking fix). Must come AFTER the tracers.
+    RN("w2rJhmD+dsE", g_agc_add_eq_event);   // sceAgcDriverAddEqEvent (GPU EOP completion, Agc driver path)
     // libSceVideoOut display / flip
     R("sceVideoOutOpen", g_vo_open);            R("sceVideoOutClose", g_vo_close);
     R("sceVideoOutSubmitFlip", g_vo_submitflip);R("sceVideoOutIsFlipPending", g_vo_flippending);

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -174,6 +174,18 @@ void prosper_eq_trigger_eop() {
         eq_post(r.eq, e);
     }
 }
+// Post a real flip-done event (VIDEO_OUT filter) carrying the game's flip_arg to every registered flip
+// equeue. Called from the DCB-flip path (hle_graphics.cpp prosper_vo_dcb_flip) when the game's actual
+// per-frame flip completes. The pump posts a generic frame counter as `data`; a real flip must carry the
+// submitted flip_arg so the guest's "did MY flip land?" predicate matches.
+void prosper_eq_post_flip(int64_t flip_arg) {
+    std::vector<FlipReg> regs;
+    { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_flip_regs; }
+    for (auto& r : regs) {
+        SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_VIDEO_OUT; e.data = flip_arg; e.udata = r.udata;
+        eq_post(r.eq, e);
+    }
+}
 
 HLE(k_eq_create) {
     EqState* s = new EqState();


### PR DESCRIPTION
## The frame-loop stall: diagnosis + fix

The game boots into Unity, submits **one** composite frame, then the **main thread parks forever** in a `sceKernelWaitEqueue` (500 ms) loop. This PR fixes the two root-cause bugs behind that stall.

### Diagnosis (independently confirmed 4×)
An equeue trace shows the main thread blocks on an equeue named **`UnityFTMFlipQueue`** (Unity's Frame Timing Manager) that is **completely starved**: 1193+ waits, **0 deliveries**, while the healthy render queue (`Flip Event Queue GfxDeviceAgc`) delivers ~1:1. That queue never fired because of two independent gaps — cross-confirmed by a Kyty (reference PS5 emulator) source comparison and three stubbed-call sweep agents, which all converged on the same conclusion:

1. **The game's real per-frame flip was dropped.** Unity submits its flip as a **DCB-embedded `R_FLIP` packet** (`sceAgcDcbSetFlip`), not via `sceVideoOutSubmitFlip`. `command_processor` decoded `K::Flip` but ignored it ("events/flips … handled later"). So flip status never advanced (frozen at the initial blank flip `arg=0`) and no flip event carrying the game's `flipArg` was ever posted — only the pump's generic frame counter.
2. **`sceAgcDriverAddEqEvent` was a no-op stub.** The game registers its GPU-completion event source on the FTM/EOP queues via `sceAgcDriverAddEqEvent` (NID `w2rJhmD+dsE`) — the Agc-driver analogue of `sceGnmAddEqEvent` (this title uses the Agc path, not Gnm). It was in the trace-only stub list, so **no source was ever registered** on the queue the main thread waits on.

### The fix
- **Execute the DCB flip.** `GpuState` captures the `R_FLIP` payload (`[handle, bufidx, mode, flipArg]`) during the fold; the submit path runs `prosper_vo_dcb_flip()` — advance flip count/arg/buffer, present, and post a `VIDEO_OUT` flip event with `data = flipArg`.
- **Wire `sceAgcDriverAddEqEvent`** to the existing `prosper_eq_add_eop` backend that fires on every `SubmitDcb` (same mechanism already used for `sceGnmAddEqEvent`).

### Result
- DCB flips now execute with real incrementing flip args (`0x8000000000000000`, `…0001`).
- The previously-starved `UnityFTMFlipQueue` now **receives events (0 → 2)**.
- **Linux 48/48 tests green.**

### Honest status — necessary, not yet sufficient
The game does **not** yet fully cycle its frame loop: the main thread now *wakes* on the FTM event but **re-waits**, so submit count is unchanged (still 2 unique submits). The remaining gate is the **post-wake predicate** the FTM thread checks — most likely a `sceVideoOutGetFlipStatus` `flipArg`/`count` comparison that isn't satisfied by the current flip-status content. That's the next step: match the flip-status/event payload to what Unity's FTM checks after waking.

Both changes are correct root-cause fixes (a dropped packet and a stubbed registration) and are prerequisites for the loop regardless of the follow-up.

### Files
- `src/gpu/command_processor.{hpp,cpp}` — capture the `R_FLIP` packet into `GpuState`.
- `src/hle/hle_agc.cpp` — execute the captured flip after the fold.
- `src/hle/hle_graphics.cpp` — `prosper_vo_dcb_flip()` + real `sceAgcDriverAddEqEvent` handler.
- `src/hle/hle_kernel_time.cpp` — `prosper_eq_post_flip()` (flip event carrying `flipArg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSBb8kGAYaNpmnHXjwsrxk
