### PR TITLE
feat(gpu): multi-draw executor + backend (opt-in), on the per-draw snapshot foundation

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -288,6 +288,12 @@ if(TARGET prosper_core)
       target_link_libraries(test_texture_sample_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME texture_sample_render COMMAND test_texture_sample_render)
 
+      # Multi-draw backend: N draws composited into ONE cleared-once framebuffer (red opaque + green
+      # additive -> yellow center proves accumulation into a single target).
+      add_executable(test_multidraw_render tests/test_multidraw_render.cpp)
+      target_link_libraries(test_multidraw_render PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME multidraw_render COMMAND test_multidraw_render)
+
       # Storage images: a recompiled compute kernel does MIMG image_load->image_store (no sampler) to
       # copy a 1D storage image bit-exact (the game's blit/copy compute-shader class).
       add_executable(test_storage_image_copy tests/test_storage_image_copy.cpp)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -23,16 +23,23 @@ namespace prosper::gpu {
 
 struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backend so it can bind resources
 
-// The pluggable Vulkan backend: given recompiled VS+PS SPIR-V, resolved pipeline state, and the two
-// stages' resource tables (so it can bind the constant/vertex buffers + textures the shaders declare,
-// reading their bytes from 1:1-mapped guest memory), render and return W*H*4 RGBA8 pixels (or {} on
-// failure). The tables may be null (e.g. the simple offscreen tests that render color-only shaders).
-using RenderFn = std::function<std::vector<uint8_t>(const std::vector<uint32_t>& vs,
-                                                    const std::vector<uint32_t>& fs,
-                                                    const ResolvedPipelineState& ps,
-                                                    const ShaderResourceTable* vrt,
-                                                    const ShaderResourceTable* prt,
-                                                    uint32_t vertex_count)>;
+// One realized draw of a submit: recompiled VS+PS SPIR-V, the draw's OWN resolved fixed-function
+// state, the two stages' resource tables (so the backend can bind the constant/vertex buffers +
+// textures the shaders declare, reading their bytes from 1:1-mapped guest memory), and its vertex
+// count. execute_gpustate() emits one per realized draw; the backend records ALL of them into ONE
+// render pass (clear once, then draw each with its own pipeline + descriptors) so a multi-draw submit
+// — e.g. Unity's background + composite, whose per-draw masks/blends/shaders differ — composites
+// correctly instead of collapsing onto a single draw. The tables may be null (color-only shaders).
+struct DrawItem {
+    std::vector<uint32_t> vs, fs;                     // recompiled SPIR-V
+    ResolvedPipelineState ps;                         // THIS draw's fixed-function state
+    std::shared_ptr<ShaderResourceTable> vrt, prt;    // may be null
+    uint32_t vertex_count = 3;
+};
+
+// The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8
+// pixels (or {} on failure). Empty list -> {} (nothing to draw).
+using RenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawItem>& items)>;
 
 // Safe guest-address readability probe: write() to /dev/null returns EFAULT for an unmapped source
 // (Linux; always-true on Windows), so callers can test a guest pointer without risking a SIGSEGV.
@@ -46,91 +53,104 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 // or no resources. Implemented in gpu_executor.cpp (needs the AGC registry + descriptor decode).
 std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr, bool is_ps);
 
-// Recompile + resolve a GpuState and render it via `render`. Returns the pixels, or {} if there is nothing
-// to draw or a stage fails to recompile. `max_shader_dwords` bounds the recompiler's walk (it stops at
-// S_ENDPGM, so this is just an upper bound). CONFIDENCE: HIGH on the orchestration (mirrors the verified
-// test_gpustate_render spine); the general multi-draw / vertex-fetch path is handled by the backend.
-inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
-                                             uint32_t max_shader_dwords = 0x10000) {
-    if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
-    RenderState rs = extract_render_state(st);
-    const bool log = getenv("PROSPER_GFXLOG") != nullptr;    // bail-point visibility (why no frame?)
-    if (!rs.es_addr || !rs.ps_addr) {                        // no vertex/pixel program bound
-        if (log) fprintf(stderr, "[exec] skip: no PGM bound (es=0x%llx ps=0x%llx, %zu draws)\n",
-                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr, st.draws.size());
-        return {};
+// Realize ONE draw of `ds` (a register snapshot or the folded state) into a DrawItem: recompile the
+// VS+PS, resolve fixed-function state, apply the fullscreen-quad fan heuristic + env overrides. Returns
+// false (and leaves `out` untouched) if the draw is a no-op (no PGM bound, recompile failed, or
+// color_write_mask==0). Shared by the default (folded-state, one item) and PROSPER_PERDRAW (per-draw)
+// paths so their per-draw handling is identical.
+inline bool realize_draw_item(const GpuState& ds, uint32_t vcount_hint, uint32_t max_shader_dwords,
+                              bool log, DrawItem& out) {
+    RenderState rs = extract_render_state(ds);
+    if (!rs.es_addr || !rs.ps_addr) {
+        if (log) fprintf(stderr, "[exec] skip draw: no PGM bound (es=0x%llx ps=0x%llx)\n",
+                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
+        return false;
     }
-    std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(st, rs.es_addr, false);
-    std::shared_ptr<ShaderResourceTable> prt = build_stage_table(st, rs.ps_addr, true);
+    std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(ds, rs.es_addr, false);
+    std::shared_ptr<ShaderResourceTable> prt = build_stage_table(ds, rs.ps_addr, true);
     std::vector<uint32_t> vs = recompile_vertex((const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());
     std::vector<uint32_t> fs = recompile_fragment((const uint32_t*)(uintptr_t)rs.ps_addr, max_shader_dwords, prt.get());
-    if (vs.empty() || fs.empty()) {                          // an unsupported shader — leave frame untouched
+    if (vs.empty() || fs.empty()) {
         if (log) {
-            fprintf(stderr, "[exec] skip: recompile failed (vs=%zu fs=%zu dwords; es=0x%llx ps=0x%llx)\n",
+            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; es=0x%llx ps=0x%llx)\n",
                     vs.size(), fs.size(), (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
             for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
                 RecompileCoverage c = recompile_coverage((const uint32_t*)(uintptr_t)addr, max_shader_dwords);
                 fprintf(stderr, "[exec]   %s coverage: total=%u alu=%u exp=%u tabledep=%u unsupported=%u "
-                                "first_bad fmt=%d op=0x%x\n",
-                        tag, c.total, c.alu, c.exports, c.table_dependent, c.unsupported,
-                        c.first_bad_fmt, c.first_bad_op);
-                // PROSPER_SHADER_DUMP: write the raw code (4 KB cap) for offline llvm-mc disassembly.
+                                "first_bad fmt=%d op=0x%x\n", tag, c.total, c.alu, c.exports,
+                        c.table_dependent, c.unsupported, c.first_bad_fmt, c.first_bad_op);
                 if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
-                    char fn[512]; snprintf(fn, sizeof fn, "%s/exec_%s_%llx.bin", dd, tag,
-                                           (unsigned long long)addr);
+                    char fn[512]; snprintf(fn, sizeof fn, "%s/exec_%s_%llx.bin", dd, tag, (unsigned long long)addr);
                     if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)addr, 1, 4096, f); fclose(f); }
                 }
             }
         }
-        return {};
+        return false;
     }
-    if (log) { fprintf(stderr, "[exec] BOTH stages recompiled: vs=%zu fs=%zu dwords -> rendering | "
-                       "color0_base=0x%llx fmt=%u %ux? es=0x%llx ps=0x%llx draws=%zu vcount=%u\n",
-                       vs.size(), fs.size(), (unsigned long long)rs.color0_base, rs.color0_format,
-                       0u, (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr, st.draws.size(),
-                       st.draws.empty() ? 0u : st.draws[0].index_count); fflush(stderr); }
     ResolvedPipelineState ps = resolve_pipeline_state(rs);
-    // Skip a draw with no color writes (CB_TARGET_MASK/color_write_mask == 0): it contributes no pixels, so
-    // rendering + presenting its bare clear would overwrite the last real frame (an art/clear flicker).
-    // (Ported from PR #31.)
+    // Skip a draw with no color writes: it contributes no pixels, so recording it (and, in the single-item
+    // case, presenting its bare clear) would just overwrite the last real frame (an art/clear flicker).
     if (ps.color_write_mask == 0) {
-        if (log) fprintf(stderr, "[exec] skip: color_write_mask==0 (no-op draw)\n");
-        return {};
+        if (log) fprintf(stderr, "[exec] skip draw: color_write_mask==0 (no-op)\n");
+        return false;
     }
-    // The draw's vertex count (first draw; 3 as a fallback) so the VS runs for the right # of vertices.
-    uint32_t vertex_count = st.draws.empty() ? 3u : st.draws[0].index_count;
-    if (vertex_count == 0) vertex_count = 3;
-    // Fullscreen-composite quad fill. The game tiles a 4-corner quad buffer into two triangles via
-    // *indexed* triangle-list draws; our single-draw offscreen spine renders draws[0] (one triangle),
-    // leaving the other half as the clear. When the bound vertex buffer is exactly a 4-vertex quad, render
-    // its 4 corners as a triangle FAN — for a convex quad in perimeter order (BL,TL,TR,BR) the fan tris
-    // {0,1,2},{0,2,3} tile the whole quad. Only triggers for a 4-record buffer, so real triangle meshes
-    // (records != 4) keep the single-draw behavior. Proper fix = honor indexed/multi-draw (see
-    // docs/REAL_FRAMES_FINDINGS.md). CONFIDENCE: MED (heuristic; correct for this game's fullscreen blit).
-    if (vrt) for (const auto& r : vrt->resources) {
+    uint32_t vertex_count = vcount_hint ? vcount_hint : 3u;
+    // Fullscreen-composite quad fill: the game tiles a 4-corner quad buffer into two triangles via indexed
+    // draws; rendering only 3 vertices paints half the quad. When the bound vertex buffer is exactly a
+    // 4-vertex quad, render its corners as a triangle FAN (perimeter order BL,TL,TR,BR -> tris {0,1,2},
+    // {0,2,3} tile the quad). Only triggers for a 4-record buffer, so real meshes are unaffected.
+    if (vrt) for (const auto& r : vrt->resources)
         if (r.cls == ResourceClass::VertexBuffer && r.stride && (r.size / r.stride) == 4 && vertex_count <= 4) {
             vertex_count = 4; ps.topology = 5 /*VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN*/; break;
         }
-    }
     if (const char* vc = getenv("PROSPER_VCOUNT")) { int v = atoi(vc); if (v > 0) vertex_count = (uint32_t)v; }
     if (const char* tp = getenv("PROSPER_TOPO")) { int t = atoi(tp); if (t >= 0) ps.topology = (uint32_t)t; }
-    if (getenv("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu:", st.draws.size());
-        for (auto& d : st.draws) fprintf(stderr, " ic=%u", d.index_count); fprintf(stderr, " topo=%u -> vcount=%u\n", rs.prim_type, vertex_count); fflush(stderr); }
-    return render(vs, fs, ps, vrt.get(), prt.get(), vertex_count);
+    out.vs = std::move(vs); out.fs = std::move(fs); out.ps = ps;
+    out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
+    return true;
+}
+
+// Recompile + resolve a GpuState's draws and render them via `render`. Default: ONE item from the folded
+// end state (the fullscreen-quad fan fills the current title composite). PROSPER_PERDRAW=1: ONE item per
+// draw, each realized from ITS OWN register snapshot (Draw::state), so per-draw masks/blends/shaders
+// composite correctly — the path for multi-geometry scenes (opt-in until the AGC context-log section
+// semantics that stage duplicate register writes are fully RE'd; see docs/REAL_FRAMES_FINDINGS.md).
+// `max_shader_dwords` bounds the recompiler's walk (it stops at S_ENDPGM).
+inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
+                                             uint32_t max_shader_dwords = 0x10000) {
+    if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
+    const bool log = getenv("PROSPER_GFXLOG") != nullptr;    // bail-point visibility (why no frame?)
+    static const bool perdraw = getenv("PROSPER_PERDRAW") != nullptr;
+    std::vector<DrawItem> items;
+    if (perdraw) {
+        for (size_t i = 0; i < st.draws.size(); i++) {
+            DrawItem it;
+            if (realize_draw_item(st.state_at_draw(i), st.draws[i].index_count, max_shader_dwords, log, it))
+                items.push_back(std::move(it));
+        }
+    } else {
+        // Default: render the submit's composite from the folded end state as a single item (the fan
+        // heuristic fills the fullscreen quad). Preserves the merged single-draw behavior exactly.
+        DrawItem it;
+        uint32_t vcount = st.draws.empty() ? 3u : st.draws[0].index_count;
+        if (realize_draw_item(st, vcount, max_shader_dwords, log, it)) items.push_back(std::move(it));
+    }
+    if (getenv("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu perdraw=%d -> %zu item(s):",
+        st.draws.size(), (int)perdraw, items.size());
+        for (auto& it : items) fprintf(stderr, " (vcount=%u topo=%u mask=0x%x)", it.vertex_count, it.ps.topology, it.ps.color_write_mask);
+        fprintf(stderr, "\n"); fflush(stderr); }
+    if (items.empty()) return {};
+    if (log) fprintf(stderr, "[exec] rendering %zu draw item(s) (of %zu draws)\n", items.size(), st.draws.size());
+    return render(items);
 }
 
 // --- Live submit renderer registry (Stage A wiring; implemented in gpu_executor.cpp) --------------------
 // The live renderer additionally receives the target width/height (from videoout) so it can size its
 // attachments. Registered by whoever owns a persistent Vulkan device — the runtime binary at startup, or a
-// test — so prosper_core itself stays Vulkan-free (this just stores a std::function). Signature adds w,h to
-// RenderFn; the tests' render_triangle_rgba already takes (vs, fs, w, h, &ps).
-using LiveRenderFn = std::function<std::vector<uint8_t>(const std::vector<uint32_t>& vs,
-                                                        const std::vector<uint32_t>& fs,
-                                                        const ResolvedPipelineState& ps,
-                                                        const ShaderResourceTable* vrt,
-                                                        const ShaderResourceTable* prt,
-                                                        uint32_t width, uint32_t height,
-                                                        uint32_t vertex_count)>;
+// test — so prosper_core itself stays Vulkan-free (this just stores a std::function). Same DrawItem-list
+// shape as RenderFn, plus (w,h).
+using LiveRenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawItem>& items,
+                                                        uint32_t width, uint32_t height)>;
 
 // Register (or clear, with {}) the live render backend that agc_driver_submit_dcb uses on each submit.
 void set_submit_renderer(LiveRenderFn fn);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -433,9 +433,7 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
     // Bind the target dimensions and defer to the pure core, which recompiles the shaders from their
     // SHADER_PGM addresses and resolves fixed-function state before calling back into the live renderer.
     std::vector<uint8_t> px = execute_gpustate(st,
-        [&](const std::vector<uint32_t>& vs, const std::vector<uint32_t>& fs,
-            const ResolvedPipelineState& ps, const ShaderResourceTable* vrt,
-            const ShaderResourceTable* prt, uint32_t vcount) { return g_live(vs, fs, ps, vrt, prt, width, height, vcount); });
+        [&](const std::vector<DrawItem>& items) { return g_live(items, width, height); });
     if (px.size() != static_cast<size_t>(width) * height * 4) return false;   // recompile/render failed
     present_write_frame(px.data(), width, height);
     return true;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -76,16 +76,20 @@ struct FrameResource {
 //
 // When `tex` is non-null, its RGBA8 texels are uploaded to a sampled VkImage and bound as a combined
 // image sampler at tex->binding — how a recompiled pixel shader's image_sample reaches a real texture.
-inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& vert,
-                                                 const std::vector<uint32_t>& frag,
-                                                 uint32_t W, uint32_t H,
-                                                 const prosper::gpu::ResolvedPipelineState* ps = nullptr,
-                                                 const std::vector<uint32_t>* vbuf = nullptr,
-                                                 const std::vector<uint32_t>* cbuf = nullptr,
-                                                 const TexDesc* tex = nullptr,
-                                                 const std::vector<FrameResource>* gres = nullptr,
-                                                 uint32_t vcount = 3) {
+// One draw for the multi-draw backend: recompiled VS+PS SPIR-V, its resolved fixed-function state, its
+// set-tagged resources, and its vertex count. render_draws_rgba records ALL of a submit's draws into ONE
+// render pass (clear once, then per-draw pipeline+descriptors+draw) so a multi-draw frame composites
+// correctly. render_triangle_rgba is a thin single-draw wrapper (below).
+struct BackendDraw {
+    std::vector<uint32_t> vs, fs;
+    const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
+    std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
+    uint32_t vcount = 3;
+};
+
+inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H) {
     std::vector<uint8_t> out;
+    if (draws.empty()) return out;
     VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO}; app.apiVersion = VK_API_VERSION_1_1;
     VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; ici.pApplicationInfo = &app;
     VkInstance inst = VK_NULL_HANDLE;
@@ -116,9 +120,10 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
             if ((bits & (1u << i)) && (memp.memoryTypes[i].propertyFlags & want) == want) return i;
         return UINT32_MAX; };
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
-    // Depth is opt-in: only when the resolved state enables the depth test. Every caller that passes
-    // no state (or depth disabled) takes the exact color-only path below — unchanged.
-    const bool use_depth = ps && ps->depth_test_enable;
+    // Depth attachment is created if ANY draw enables the depth test (the shared render pass has one
+    // fixed attachment set); each draw's pipeline sets its own depthTest/Write/CompareOp. A frame with
+    // no depth-using draw takes the color-only path unchanged.
+    bool use_depth = false; for (const auto& d : draws) if (d.ps && d.ps->depth_test_enable) use_depth = true;
     const VkFormat DFMT = VK_FORMAT_D32_SFLOAT;
     VkImage dimg = VK_NULL_HANDLE; VkDeviceMemory dmem = VK_NULL_HANDLE; VkImageView dview = VK_NULL_HANDLE;
 
@@ -179,166 +184,156 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
         VkShaderModuleCreateInfo s{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
         s.codeSize = c.size() * 4; s.pCode = c.data(); VkShaderModule m = VK_NULL_HANDLE;
         vkCreateShaderModule(dev, &s, nullptr, &m); return m; };
-    VkShaderModule vs = mkmod(vert), fs = mkmod(frag);
-    if (!vs || !fs) return out;   // rejected SPIR-V
-    VkPipelineShaderStageCreateInfo st[2]{};
-    st[0] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[0].stage = VK_SHADER_STAGE_VERTEX_BIT; st[0].module = vs; st[0].pName = "main";
-    st[1] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT; st[1].module = fs; st[1].pName = "main";
-    VkPipelineVertexInputStateCreateInfo vin{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
-    VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
-    ia.topology = ps ? (VkPrimitiveTopology)ps->topology : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-    // Default: full-target viewport. When the resolved state carries the guest's PA_CL_VPORT transform,
-    // honor it — a guest yscale < 0 arrives as a negative viewport_h (Vulkan core-1.1 flipped viewport,
-    // instance is created with apiVersion 1.1 above), reproducing the hardware's Y orientation.
-    VkViewport vp{0, 0, (float)W, (float)H, 0, 1}; VkRect2D sc{{0, 0}, {W, H}};
-    if (ps && ps->has_viewport)
-        vp = {ps->viewport_x, ps->viewport_y, ps->viewport_w, ps->viewport_h, ps->min_depth, ps->max_depth};
-    VkPipelineViewportStateCreateInfo vpst{VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
-    vpst.viewportCount = 1; vpst.pViewports = &vp; vpst.scissorCount = 1; vpst.pScissors = &sc;
-    VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
-    rs.polygonMode = VK_POLYGON_MODE_FILL; rs.cullMode = VK_CULL_MODE_NONE; rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE; rs.lineWidth = 1.0f;
-    VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
-    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    VkPipelineColorBlendAttachmentState cba{}; cba.colorWriteMask = 0xF;
-    if (ps) {
-        cba.colorWriteMask = ps->color_write_mask;
-        cba.blendEnable    = ps->blend_enable ? VK_TRUE : VK_FALSE;
-        cba.srcColorBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;
-        cba.dstColorBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
-        cba.colorBlendOp        = (VkBlendOp)ps->color_blend_op;
-        cba.srcAlphaBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;   // mirror color for alpha
-        cba.dstAlphaBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
-        cba.alphaBlendOp        = (VkBlendOp)ps->color_blend_op;
-    }
-    VkPipelineColorBlendStateCreateInfo cb{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
-    cb.attachmentCount = 1; cb.pAttachments = &cba;
-    VkPipelineDepthStencilStateCreateInfo dss{VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
-    if (use_depth) {
-        dss.depthTestEnable  = VK_TRUE;
-        dss.depthWriteEnable = ps->depth_write_enable ? VK_TRUE : VK_FALSE;
-        dss.depthCompareOp   = (VkCompareOp)ps->depth_compare_op;
-    }
-    // Build the descriptor-set resource list. Either the general `gres` list (a real game shader's several
-    // constant/vertex buffers + textures, each at its own binding) OR — for the simple tests — bindings 2/3
-    // from cbuf/vbuf (always present, zero-filled if null) plus the optional `tex`.
-    std::vector<FrameResource> R;
-    if (gres && !gres->empty()) { R = *gres; }
-    else {
-        // The recompiler places FRAGMENT-stage resources in descriptor set 1 (the VS owns set 0), and a
-        // legacy test may exercise either stage with the same cbuf/vbuf convention (bindings 2/3) -- so
-        // mirror the buffers into BOTH sets (the copy the shader does not reference is simply unused).
-        for (uint32_t s2 = 0; s2 < 2; s2++) {
-            FrameResource b2; b2.binding = 2; b2.set = s2; if (cbuf) b2.dwords = *cbuf; R.push_back(std::move(b2));
-            FrameResource b3; b3.binding = 3; b3.set = s2; if (vbuf) b3.dwords = *vbuf; R.push_back(std::move(b3));
+    // Per-draw Vulkan objects — kept alive until after the queue submit, freed at the end.
+    struct DV {
+        VkShaderModule vs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
+        std::vector<FrameResource> R;
+        std::vector<VkDescriptorSetLayout> dsls; std::vector<VkDescriptorSet> dsets;
+        VkDescriptorPool dpool = VK_NULL_HANDLE;
+        std::vector<VkBuffer> sbuf, tstage; std::vector<VkDeviceMemory> sbmem, tmem, tstagemem;
+        std::vector<VkImage> timg; std::vector<VkImageView> tview; std::vector<VkSampler> tsamp;
+        VkPipelineLayout layout = VK_NULL_HANDLE; VkPipeline pipe = VK_NULL_HANDLE;
+        uint32_t n_sets = 1, vcount = 3; bool use_desc = false, ok = false;
+    };
+    std::vector<DV> dv(draws.size());
+    // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
+    for (size_t di = 0; di < draws.size(); di++) {
+        const BackendDraw& bd = draws[di];
+        DV& v = dv[di];
+        v.vs = mkmod(bd.vs); v.fs = mkmod(bd.fs);
+        if (!v.vs || !v.fs) continue;   // rejected SPIR-V -> skip this draw
+        const prosper::gpu::ResolvedPipelineState* ps = bd.ps;
+        v.vcount = bd.vcount;
+        VkPipelineShaderStageCreateInfo st[2]{};
+        st[0] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[0].stage = VK_SHADER_STAGE_VERTEX_BIT; st[0].module = v.vs; st[0].pName = "main";
+        st[1] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT; st[1].module = v.fs; st[1].pName = "main";
+        VkPipelineVertexInputStateCreateInfo vin{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+        VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+        ia.topology = ps ? (VkPrimitiveTopology)ps->topology : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        // Default: full-target viewport. When the resolved state carries the guest's PA_CL_VPORT transform,
+        // honor it — a guest yscale < 0 arrives as a negative viewport_h (Vulkan core-1.1 flipped viewport),
+        // reproducing the hardware's Y orientation (#38; each draw item keeps its own resolved viewport).
+        VkViewport vp{0, 0, (float)W, (float)H, 0, 1}; VkRect2D sc{{0, 0}, {W, H}};
+        if (ps && ps->has_viewport)
+            vp = {ps->viewport_x, ps->viewport_y, ps->viewport_w, ps->viewport_h, ps->min_depth, ps->max_depth};
+        VkPipelineViewportStateCreateInfo vpst{VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
+        vpst.viewportCount = 1; vpst.pViewports = &vp; vpst.scissorCount = 1; vpst.pScissors = &sc;
+        VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+        rs.polygonMode = VK_POLYGON_MODE_FILL; rs.cullMode = VK_CULL_MODE_NONE; rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE; rs.lineWidth = 1.0f;
+        VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+        ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+        VkPipelineColorBlendAttachmentState cba{}; cba.colorWriteMask = 0xF;
+        if (ps) {
+            cba.colorWriteMask = ps->color_write_mask;
+            cba.blendEnable    = ps->blend_enable ? VK_TRUE : VK_FALSE;
+            cba.srcColorBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;
+            cba.dstColorBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
+            cba.colorBlendOp        = (VkBlendOp)ps->color_blend_op;
+            cba.srcAlphaBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;   // mirror color for alpha
+            cba.dstAlphaBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
+            cba.alphaBlendOp        = (VkBlendOp)ps->color_blend_op;
         }
-        // A sampled texture is a fragment-stage resource -> descriptor set 1 (the recompiler puts PS
-        // resources in set 1; the VS owns set 0). Binding it in set 0 would not match the FS's layout.
-        if (tex) { FrameResource t; t.binding = tex->binding; t.set = 1; t.tex_rgba = tex->rgba; t.tw = tex->w; t.th = tex->h; R.push_back(std::move(t)); }
-    }
-    const bool use_desc = !R.empty();
-    // VS and PS resources live in SEPARATE descriptor sets (r.set: VS=0, PS=1) so their independent
-    // binding numbering (both start at 2) can't collide within one set. Create one layout+set per set
-    // index present (0..n_sets-1); empty sets still get a layout so the pipeline-layout set indices stay
-    // contiguous and match the SPIR-V's DescriptorSet decorations.
-    uint32_t n_sets = 1; for (auto& r : R) n_sets = std::max(n_sets, r.set + 1);
-    std::vector<VkDescriptorSetLayout> dsls(n_sets, VK_NULL_HANDLE);
-    std::vector<VkDescriptorSet> dsets(n_sets, VK_NULL_HANDLE);
-    VkDescriptorPool dpool = VK_NULL_HANDLE;
-    // Per-resource Vulkan objects (freed at the end). Storage buffers use sbuf/sbmem; textures use the
-    // image/view/sampler/staging quintet (indexed parallel to R; unused entries stay VK_NULL_HANDLE).
-    std::vector<VkBuffer> sbuf(R.size(), VK_NULL_HANDLE), tstage(R.size(), VK_NULL_HANDLE);
-    std::vector<VkDeviceMemory> sbmem(R.size(), VK_NULL_HANDLE), tmem(R.size(), VK_NULL_HANDLE), tstagemem(R.size(), VK_NULL_HANDLE);
-    std::vector<VkImage> timg(R.size(), VK_NULL_HANDLE);
-    std::vector<VkImageView> tview(R.size(), VK_NULL_HANDLE);
-    std::vector<VkSampler> tsamp(R.size(), VK_NULL_HANDLE);
-    if (use_desc) {
-        std::vector<VkDescriptorSetLayoutBinding> lb(R.size());
-        std::vector<VkDescriptorBufferInfo> dbi(R.size());
-        std::vector<VkDescriptorImageInfo> dii(R.size());
-        std::vector<VkWriteDescriptorSet> wr(R.size());
-        uint32_t n_storage = 0, n_sampler = 0;
-        for (size_t i = 0; i < R.size(); i++) {
-            const FrameResource& r = R[i];
-            lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
-            if (r.is_texture()) {
-                n_sampler++;
-                lb[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lb[i].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-                VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-                tci.imageType = VK_IMAGE_TYPE_2D; tci.format = VK_FORMAT_R8G8B8A8_UNORM; tci.extent = {r.tw, r.th, 1};
-                tci.mipLevels = 1; tci.arrayLayers = 1; tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
-                tci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-                vkCreateImage(dev, &tci, nullptr, &timg[i]);
-                VkMemoryRequirements tr; vkGetImageMemoryRequirements(dev, timg[i], &tr);
-                VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; tai.allocationSize = tr.size;
-                tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0); vkAllocateMemory(dev, &tai, nullptr, &tmem[i]);
-                vkBindImageMemory(dev, timg[i], tmem[i], 0);
-                VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
-                tvci.image = timg[i]; tvci.viewType = VK_IMAGE_VIEW_TYPE_2D; tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
-                tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}; vkCreateImageView(dev, &tvci, nullptr, &tview[i]);
-                VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
-                sci.magFilter = sci.minFilter = VK_FILTER_LINEAR; sci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-                sci.addressModeU = sci.addressModeV = sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-                vkCreateSampler(dev, &sci, nullptr, &tsamp[i]);
-                VkDeviceSize tbytes = (VkDeviceSize)r.tw * r.th * 4;
-                VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-                vkCreateBuffer(dev, &stci, nullptr, &tstage[i]);
-                VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, tstage[i], &sr);
-                VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; sai.allocationSize = sr.size;
-                sai.memoryTypeIndex = pick(sr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                vkAllocateMemory(dev, &sai, nullptr, &tstagemem[i]); vkBindBufferMemory(dev, tstage[i], tstagemem[i], 0);
-                void* sp = nullptr; vkMapMemory(dev, tstagemem[i], 0, tbytes, 0, &sp);
-                std::memcpy(sp, r.tex_rgba, (size_t)tbytes); vkUnmapMemory(dev, tstagemem[i]);
-                dii[i] = {tsamp[i], tview[i], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-                wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
-                wr[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; wr[i].pImageInfo = &dii[i];
-            } else {
-                n_storage++;
-                lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-                VkDeviceSize sz = r.dwords.empty() ? 4 : (VkDeviceSize)r.dwords.size() * 4;
-                VkBufferCreateInfo sbci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; sbci.size = sz; sbci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-                vkCreateBuffer(dev, &sbci, nullptr, &sbuf[i]);
-                VkMemoryRequirements mr; vkGetBufferMemoryRequirements(dev, sbuf[i], &mr);
-                VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; mai.allocationSize = mr.size;
-                mai.memoryTypeIndex = pick(mr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                vkAllocateMemory(dev, &mai, nullptr, &sbmem[i]); vkBindBufferMemory(dev, sbuf[i], sbmem[i], 0);
-                void* p = nullptr; vkMapMemory(dev, sbmem[i], 0, sz, 0, &p);
-                if (r.dwords.empty()) ((uint32_t*)p)[0] = 0; else std::memcpy(p, r.dwords.data(), r.dwords.size() * 4);
-                vkUnmapMemory(dev, sbmem[i]);
-                dbi[i] = {sbuf[i], 0, VK_WHOLE_SIZE};
-                wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
-                wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
+        VkPipelineColorBlendStateCreateInfo cb{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+        cb.attachmentCount = 1; cb.pAttachments = &cba;
+        VkPipelineDepthStencilStateCreateInfo dss{VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+        if (ps && ps->depth_test_enable) {
+            dss.depthTestEnable  = VK_TRUE;
+            dss.depthWriteEnable = ps->depth_write_enable ? VK_TRUE : VK_FALSE;
+            dss.depthCompareOp   = (VkCompareOp)ps->depth_compare_op;
+        }
+        // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
+        v.R = bd.R; auto& R = v.R;
+        v.use_desc = !R.empty();
+        for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
+        v.dsls.assign(v.n_sets, VK_NULL_HANDLE); v.dsets.assign(v.n_sets, VK_NULL_HANDLE);
+        v.sbuf.assign(R.size(), VK_NULL_HANDLE); v.tstage.assign(R.size(), VK_NULL_HANDLE);
+        v.sbmem.assign(R.size(), VK_NULL_HANDLE); v.tmem.assign(R.size(), VK_NULL_HANDLE); v.tstagemem.assign(R.size(), VK_NULL_HANDLE);
+        v.timg.assign(R.size(), VK_NULL_HANDLE); v.tview.assign(R.size(), VK_NULL_HANDLE); v.tsamp.assign(R.size(), VK_NULL_HANDLE);
+        if (v.use_desc) {
+            std::vector<VkDescriptorSetLayoutBinding> lb(R.size());
+            std::vector<VkDescriptorBufferInfo> dbi(R.size());
+            std::vector<VkDescriptorImageInfo> dii(R.size());
+            std::vector<VkWriteDescriptorSet> wr(R.size());
+            uint32_t n_storage = 0, n_sampler = 0;
+            for (size_t i = 0; i < R.size(); i++) {
+                const FrameResource& r = R[i];
+                lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
+                if (r.is_texture()) {
+                    n_sampler++;
+                    lb[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lb[i].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+                    VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+                    tci.imageType = VK_IMAGE_TYPE_2D; tci.format = VK_FORMAT_R8G8B8A8_UNORM; tci.extent = {r.tw, r.th, 1};
+                    tci.mipLevels = 1; tci.arrayLayers = 1; tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
+                    tci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                    vkCreateImage(dev, &tci, nullptr, &v.timg[i]);
+                    VkMemoryRequirements tr; vkGetImageMemoryRequirements(dev, v.timg[i], &tr);
+                    VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; tai.allocationSize = tr.size;
+                    tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0); vkAllocateMemory(dev, &tai, nullptr, &v.tmem[i]);
+                    vkBindImageMemory(dev, v.timg[i], v.tmem[i], 0);
+                    VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+                    tvci.image = v.timg[i]; tvci.viewType = VK_IMAGE_VIEW_TYPE_2D; tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
+                    tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}; vkCreateImageView(dev, &tvci, nullptr, &v.tview[i]);
+                    VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
+                    sci.magFilter = sci.minFilter = VK_FILTER_LINEAR; sci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+                    sci.addressModeU = sci.addressModeV = sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+                    vkCreateSampler(dev, &sci, nullptr, &v.tsamp[i]);
+                    VkDeviceSize tbytes = (VkDeviceSize)r.tw * r.th * 4;
+                    VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+                    vkCreateBuffer(dev, &stci, nullptr, &v.tstage[i]);
+                    VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, v.tstage[i], &sr);
+                    VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; sai.allocationSize = sr.size;
+                    sai.memoryTypeIndex = pick(sr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                    vkAllocateMemory(dev, &sai, nullptr, &v.tstagemem[i]); vkBindBufferMemory(dev, v.tstage[i], v.tstagemem[i], 0);
+                    void* sp = nullptr; vkMapMemory(dev, v.tstagemem[i], 0, tbytes, 0, &sp);
+                    std::memcpy(sp, r.tex_rgba, (size_t)tbytes); vkUnmapMemory(dev, v.tstagemem[i]);
+                    dii[i] = {v.tsamp[i], v.tview[i], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+                    wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
+                    wr[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; wr[i].pImageInfo = &dii[i];
+                } else {
+                    n_storage++;
+                    lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+                    VkDeviceSize sz = r.dwords.empty() ? 4 : (VkDeviceSize)r.dwords.size() * 4;
+                    VkBufferCreateInfo sbci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; sbci.size = sz; sbci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+                    vkCreateBuffer(dev, &sbci, nullptr, &v.sbuf[i]);
+                    VkMemoryRequirements mr; vkGetBufferMemoryRequirements(dev, v.sbuf[i], &mr);
+                    VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; mai.allocationSize = mr.size;
+                    mai.memoryTypeIndex = pick(mr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                    vkAllocateMemory(dev, &mai, nullptr, &v.sbmem[i]); vkBindBufferMemory(dev, v.sbuf[i], v.sbmem[i], 0);
+                    void* p = nullptr; vkMapMemory(dev, v.sbmem[i], 0, sz, 0, &p);
+                    if (r.dwords.empty()) ((uint32_t*)p)[0] = 0; else std::memcpy(p, r.dwords.data(), r.dwords.size() * 4);
+                    vkUnmapMemory(dev, v.sbmem[i]);
+                    dbi[i] = {v.sbuf[i], 0, VK_WHOLE_SIZE};
+                    wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
+                    wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
+                }
             }
+            for (uint32_t s = 0; s < v.n_sets; s++) {
+                std::vector<VkDescriptorSetLayoutBinding> slb;
+                for (size_t i = 0; i < R.size(); i++) if (R[i].set == s) slb.push_back(lb[i]);
+                VkDescriptorSetLayoutCreateInfo dslci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+                dslci.bindingCount = (uint32_t)slb.size(); dslci.pBindings = slb.data();
+                vkCreateDescriptorSetLayout(dev, &dslci, nullptr, &v.dsls[s]);
+            }
+            VkDescriptorPoolSize psz[2] = {{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, n_storage ? n_storage : 1},
+                                           {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, n_sampler ? n_sampler : 1}};
+            VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+            dpci.maxSets = v.n_sets; dpci.poolSizeCount = n_sampler ? 2 : 1; dpci.pPoolSizes = psz; vkCreateDescriptorPool(dev, &dpci, nullptr, &v.dpool);
+            VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+            dsai.descriptorPool = v.dpool; dsai.descriptorSetCount = v.n_sets; dsai.pSetLayouts = v.dsls.data();
+            vkAllocateDescriptorSets(dev, &dsai, v.dsets.data());
+            for (size_t i = 0; i < R.size(); i++) wr[i].dstSet = v.dsets[R[i].set];
+            vkUpdateDescriptorSets(dev, (uint32_t)wr.size(), wr.data(), 0, nullptr);
         }
-        // One descriptor-set layout per set index, each holding only its own resources' bindings.
-        for (uint32_t s = 0; s < n_sets; s++) {
-            std::vector<VkDescriptorSetLayoutBinding> slb;
-            for (size_t i = 0; i < R.size(); i++) if (R[i].set == s) slb.push_back(lb[i]);
-            VkDescriptorSetLayoutCreateInfo dslci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-            dslci.bindingCount = (uint32_t)slb.size(); dslci.pBindings = slb.data();
-            VkResult _dslr = vkCreateDescriptorSetLayout(dev, &dslci, nullptr, &dsls[s]);
-            if (getenv("PROSPER_GFXLOG")) { fprintf(stderr, "[rr] set %u dslayout result=%d bindings:", s, (int)_dslr);
-                for (auto& x : slb) fprintf(stderr, " %u(t%d)", x.binding, (int)x.descriptorType); fprintf(stderr, "\n"); }
-        }
-        VkDescriptorPoolSize psz[2] = {{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, n_storage ? n_storage : 1},
-                                       {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, n_sampler ? n_sampler : 1}};
-        VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
-        dpci.maxSets = n_sets; dpci.poolSizeCount = n_sampler ? 2 : 1; dpci.pPoolSizes = psz; vkCreateDescriptorPool(dev, &dpci, nullptr, &dpool);
-        VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
-        dsai.descriptorPool = dpool; dsai.descriptorSetCount = n_sets; dsai.pSetLayouts = dsls.data();
-        vkAllocateDescriptorSets(dev, &dsai, dsets.data());
-        for (size_t i = 0; i < R.size(); i++) wr[i].dstSet = dsets[R[i].set];
-        vkUpdateDescriptorSets(dev, (uint32_t)wr.size(), wr.data(), 0, nullptr);
+        VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+        if (v.use_desc) { plci.setLayoutCount = v.n_sets; plci.pSetLayouts = v.dsls.data(); }
+        vkCreatePipelineLayout(dev, &plci, nullptr, &v.layout);
+        VkGraphicsPipelineCreateInfo gp{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+        gp.stageCount = 2; gp.pStages = st; gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
+        gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
+        gp.pColorBlendState = &cb; gp.layout = v.layout; gp.renderPass = rp; gp.subpass = 0;
+        if (ps && ps->depth_test_enable) gp.pDepthStencilState = &dss;
+        if (vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) v.ok = true;
     }
-    VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-    if (use_desc) { plci.setLayoutCount = n_sets; plci.pSetLayouts = dsls.data(); }
-    VkPipelineLayout layout; vkCreatePipelineLayout(dev, &plci, nullptr, &layout);
-    VkGraphicsPipelineCreateInfo gp{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
-    gp.stageCount = 2; gp.pStages = st; gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
-    gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
-    gp.pColorBlendState = &cb; gp.layout = layout; gp.renderPass = rp; gp.subpass = 0;
-    if (use_depth) gp.pDepthStencilState = &dss;
-    VkPipeline pipe;
-    if (vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &gp, nullptr, &pipe) != VK_SUCCESS) return out;
 
     VkDeviceSize bytes = (VkDeviceSize)W * H * 4;
     VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; bci.size = bytes; bci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -355,19 +350,19 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
     VkCommandBuffer cmd; vkAllocateCommandBuffers(dev, &cbai, &cmd);
     VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(cmd, &cbbi);
-    // Upload each texture's texels: UNDEFINED -> TRANSFER_DST, copy staging buffer, TRANSFER_DST -> SHADER_READ.
-    for (size_t i = 0; i < R.size(); i++) {
-        if (!R[i].is_texture()) continue;
+    // Upload each draw's textures: UNDEFINED -> TRANSFER_DST, copy staging buffer, TRANSFER_DST -> SHADER_READ.
+    for (auto& v : dv) for (size_t i = 0; i < v.R.size(); i++) {
+        if (!v.R[i].is_texture()) continue;
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-        b0.image = timg[i]; b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        b0.image = v.timg[i]; b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         b0.srcAccessMask = 0; b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
-        VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; tc.imageExtent = {R[i].tw, R[i].th, 1};
-        vkCmdCopyBufferToImage(cmd, tstage[i], timg[i], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
+        VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; tc.imageExtent = {v.R[i].tw, v.R[i].th, 1};
+        vkCmdCopyBufferToImage(cmd, v.tstage[i], v.timg[i], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
         VkImageMemoryBarrier b1{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL; b1.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        b1.image = timg[i]; b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        b1.image = v.timg[i]; b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT; b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b1);
     }
@@ -375,10 +370,14 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
     clear[1].depthStencil = {0.5f, 0};   // depth cleared to 0.5 (fragments at z=0.0 pass LESS, fail GREATER)
     VkRenderPassBeginInfo rpbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
     rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_depth ? 2 : 1; rpbi.pClearValues = clear;
+    // ONE render pass (cleared once): record every realized draw with its own pipeline + descriptors.
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
-    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    if (use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, n_sets, dsets.data(), 0, nullptr);
-    vkCmdDraw(cmd, vcount, 1, 0, 0);
+    for (auto& v : dv) {
+        if (!v.ok) continue;
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
+        if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
+        vkCmdDraw(cmd, v.vcount, 1, 0, 0);
+    }
     vkCmdEndRenderPass(cmd);
     VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {W, H, 1};
     vkCmdCopyImageToBuffer(cmd, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
@@ -393,28 +392,54 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
     vkUnmapMemory(dev, bmem);
 
     vkDestroyFence(dev, fence, nullptr); vkDestroyCommandPool(dev, pool, nullptr);
-    vkDestroyPipeline(dev, pipe, nullptr); vkDestroyPipelineLayout(dev, layout, nullptr);
-    vkDestroyShaderModule(dev, vs, nullptr); vkDestroyShaderModule(dev, fs, nullptr);
+    for (auto& v : dv) {   // per-draw objects
+        if (v.pipe)   vkDestroyPipeline(dev, v.pipe, nullptr);
+        if (v.layout) vkDestroyPipelineLayout(dev, v.layout, nullptr);
+        if (v.vs)     vkDestroyShaderModule(dev, v.vs, nullptr);
+        if (v.fs)     vkDestroyShaderModule(dev, v.fs, nullptr);
+        if (v.dpool)  vkDestroyDescriptorPool(dev, v.dpool, nullptr);
+        for (auto d : v.dsls) if (d) vkDestroyDescriptorSetLayout(dev, d, nullptr);
+        for (size_t i = 0; i < v.R.size(); i++) {
+            if (v.sbuf[i])     vkDestroyBuffer(dev, v.sbuf[i], nullptr);
+            if (v.sbmem[i])    vkFreeMemory(dev, v.sbmem[i], nullptr);
+            if (v.tsamp[i])    vkDestroySampler(dev, v.tsamp[i], nullptr);
+            if (v.tview[i])    vkDestroyImageView(dev, v.tview[i], nullptr);
+            if (v.timg[i])     vkDestroyImage(dev, v.timg[i], nullptr);
+            if (v.tmem[i])     vkFreeMemory(dev, v.tmem[i], nullptr);
+            if (v.tstage[i])   vkDestroyBuffer(dev, v.tstage[i], nullptr);
+            if (v.tstagemem[i])vkFreeMemory(dev, v.tstagemem[i], nullptr);
+        }
+    }
     vkDestroyBuffer(dev, rb, nullptr); vkFreeMemory(dev, bmem, nullptr);
     vkDestroyFramebuffer(dev, fb, nullptr); vkDestroyRenderPass(dev, rp, nullptr); vkDestroyImageView(dev, view, nullptr);
     vkDestroyImage(dev, img, nullptr); vkFreeMemory(dev, imem, nullptr);
     if (use_depth) { vkDestroyImageView(dev, dview, nullptr); vkDestroyImage(dev, dimg, nullptr); vkFreeMemory(dev, dmem, nullptr); }
-    if (use_desc) {
-        vkDestroyDescriptorPool(dev, dpool, nullptr);
-        for (auto d : dsls) if (d) vkDestroyDescriptorSetLayout(dev, d, nullptr);
-        for (size_t i = 0; i < R.size(); i++) {
-            if (sbuf[i])     vkDestroyBuffer(dev, sbuf[i], nullptr);
-            if (sbmem[i])    vkFreeMemory(dev, sbmem[i], nullptr);
-            if (tsamp[i])    vkDestroySampler(dev, tsamp[i], nullptr);
-            if (tview[i])    vkDestroyImageView(dev, tview[i], nullptr);
-            if (timg[i])     vkDestroyImage(dev, timg[i], nullptr);
-            if (tmem[i])     vkFreeMemory(dev, tmem[i], nullptr);
-            if (tstage[i])   vkDestroyBuffer(dev, tstage[i], nullptr);
-            if (tstagemem[i])vkFreeMemory(dev, tstagemem[i], nullptr);
-        }
-    }
     vkDestroyDevice(dev, nullptr); vkDestroyInstance(inst, nullptr);
     return out;
+}
+
+// Single-draw entry — a thin wrapper over render_draws_rgba, preserving the exact signature/behavior the
+// recompiled-shader render tests rely on. Builds one draw's set-tagged resources (`gres`, or the legacy
+// cbuf/vbuf@bindings 2/3 mirrored into both sets + optional `tex` in set 1).
+inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& vert,
+                                                 const std::vector<uint32_t>& frag,
+                                                 uint32_t W, uint32_t H,
+                                                 const prosper::gpu::ResolvedPipelineState* ps = nullptr,
+                                                 const std::vector<uint32_t>* vbuf = nullptr,
+                                                 const std::vector<uint32_t>* cbuf = nullptr,
+                                                 const TexDesc* tex = nullptr,
+                                                 const std::vector<FrameResource>* gres = nullptr,
+                                                 uint32_t vcount = 3) {
+    BackendDraw d; d.vs = vert; d.fs = frag; d.ps = ps; d.vcount = vcount;
+    if (gres && !gres->empty()) { d.R = *gres; }
+    else {
+        for (uint32_t s2 = 0; s2 < 2; s2++) {
+            FrameResource b2; b2.binding = 2; b2.set = s2; if (cbuf) b2.dwords = *cbuf; d.R.push_back(std::move(b2));
+            FrameResource b3; b3.binding = 3; b3.set = s2; if (vbuf) b3.dwords = *vbuf; d.R.push_back(std::move(b3));
+        }
+        if (tex) { FrameResource t; t.binding = tex->binding; t.set = 1; t.tex_rgba = tex->rgba; t.tw = tex->w; t.th = tex->h; d.R.push_back(std::move(t)); }
+    }
+    return render_draws_rgba({std::move(d)}, W, H);
 }
 
 } // namespace prosper::test

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -46,9 +46,11 @@ int main() {
 
     // The executor core, with the offscreen Vulkan renderer supplied as the backend (as the HLE will
     // supply the live-device renderer). execute_gpustate does recompile + resolve + render internally.
-    auto backend = [&](const std::vector<uint32_t>& vs, const std::vector<uint32_t>& fs,
-                       const ResolvedPipelineState& ps, const ShaderResourceTable*, const ShaderResourceTable*, uint32_t) {
-        return prosper::test::render_triangle_rgba(vs, fs, W, H, &ps);
+    // The backend gets the submit's DrawItem list; this test submits a single draw, so render items[0] via
+    // the single-draw wrapper (default empty-buffer resources), exactly as before.
+    auto backend = [&](const std::vector<DrawItem>& items) -> std::vector<uint8_t> {
+        if (items.empty()) return {};
+        return prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, W, H, &items[0].ps);
     };
     std::vector<uint8_t> px = execute_gpustate(st, backend);
     CHECK(px.size() == (size_t)W * H * 4, "execute_gpustate rendered a frame from the GpuState");
@@ -74,10 +76,9 @@ int main() {
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");
-    set_submit_renderer([&](const std::vector<uint32_t>& vs, const std::vector<uint32_t>& fs,
-                            const ResolvedPipelineState& ps, const ShaderResourceTable*,
-                            const ShaderResourceTable*, uint32_t w, uint32_t h, uint32_t) {
-        return prosper::test::render_triangle_rgba(vs, fs, w, h, &ps);
+    set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
+        if (items.empty()) return {};
+        return prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, w, h, &items[0].ps);
     });
     CHECK(have_submit_renderer(), "live renderer registered");
     prosper::gpu::present_reset();

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -1,0 +1,73 @@
+// test_multidraw_render — the multi-draw backend (render_runner.h render_draws_rgba) records N draws
+// into ONE framebuffer (cleared once), each with its own pipeline + blend state. Proof: a red OPAQUE
+// fullscreen draw followed by a green ADDITIVE fullscreen draw composites to YELLOW at the center — a
+// color that is impossible unless both draws hit the same accumulating target (a fresh clear per draw
+// would leave only the last draw's green). This exercises the multi-draw spine independently of the
+// game's per-draw register-snapshot resolution.
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/render_state.hpp"
+#include "render_runner.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_multidraw_render ==\n");
+    const uint32_t W = 64, H = 64;
+
+    // Known-good fullscreen-triangle vertex shader (SPIR-V), shared by both draws.
+    #include "../tools/boot_trace/refvs.inc"
+    std::vector<uint32_t> vs(kRefVs, kRefVs + sizeof(kRefVs) / 4);
+
+    // Two solid-color pixel shaders, recompiled from tiny RDNA2 EXP blobs (v_mov the 4 color VGPRs, then
+    // EXP mrt0). Inline consts: 0xF2 = 1.0f, 0x80 = 0.0f.  RED = (1,0,0,1)  GREEN = (0,1,0,1).
+    static const uint32_t kRedPs[]   = {0x7E0002F2u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u};
+    static const uint32_t kGreenPs[] = {0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u};
+    std::vector<uint32_t> red   = recompile_fragment(kRedPs,   sizeof(kRedPs)   / 4, nullptr);
+    std::vector<uint32_t> green = recompile_fragment(kGreenPs, sizeof(kGreenPs) / 4, nullptr);
+    CHECK(!vs.empty() && !red.empty() && !green.empty(), "fullscreen VS + red/green PS available");
+
+    ResolvedPipelineState opaque{};
+    opaque.topology = 3 /*VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST*/; opaque.color_write_mask = 0xF;
+    ResolvedPipelineState additive = opaque;              // green = src*ONE + dst*ONE (accumulate onto red)
+    additive.blend_enable = true;
+    additive.src_color_blend_factor = 1 /*VK_BLEND_FACTOR_ONE*/;
+    additive.dst_color_blend_factor = 1 /*VK_BLEND_FACTOR_ONE*/;
+    additive.color_blend_op         = 0 /*VK_BLEND_OP_ADD*/;
+
+    auto center = [&](const std::vector<uint8_t>& px) -> const uint8_t* {
+        return px.empty() ? nullptr : &px[((size_t)(H / 2) * W + W / 2) * 4];
+    };
+
+    // Single opaque red draw -> red center (baseline; no accumulation).
+    {
+        prosper::test::BackendDraw d; d.vs = vs; d.fs = red; d.ps = &opaque; d.vcount = 3;
+        std::vector<uint8_t> px = prosper::test::render_draws_rgba({d}, W, H);
+        CHECK(px.size() == (size_t)W * H * 4, "single-draw path rendered a frame");
+        const uint8_t* c = center(px);
+        if (c) CHECK(c[0] > 0xC0 && c[1] < 0x40 && c[2] < 0x40, "one opaque red draw -> RED center");
+    }
+
+    // Red opaque THEN green additive, in one submit -> yellow center (both composited into one target).
+    {
+        prosper::test::BackendDraw d0; d0.vs = vs; d0.fs = red;   d0.ps = &opaque;   d0.vcount = 3;
+        prosper::test::BackendDraw d1; d1.vs = vs; d1.fs = green; d1.ps = &additive; d1.vcount = 3;
+        std::vector<uint8_t> px = prosper::test::render_draws_rgba({d0, d1}, W, H);
+        CHECK(px.size() == (size_t)W * H * 4, "two-draw submit rendered a frame");
+        const uint8_t* c = center(px);
+        if (c) {
+            CHECK(c[0] > 0xC0 && c[1] > 0xC0 && c[2] < 0x40,
+                  "two draws composite into ONE cleared-once framebuffer -> YELLOW center (red+green)");
+        }
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -162,29 +162,25 @@ int main(int argc, char** argv) {
         static std::atomic<int> frame_no{0};
         static std::string fdir = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
         prosper::gpu::set_submit_renderer(
-            [](const std::vector<uint32_t>& vs, const std::vector<uint32_t>& fs,
-               const prosper::gpu::ResolvedPipelineState& ps,
-               const prosper::gpu::ShaderResourceTable* vrt, const prosper::gpu::ShaderResourceTable* prt,
-               uint32_t w, uint32_t h, uint32_t draw_vcount) {
-                // Dump the recompiled SPIR-V FIRST (before the slow Vulkan render), so it survives even if
-                // a concurrent worker fault kills the process mid-render — lets us spirv-val it offline.
-                if (getenv("PROSPER_SHADER_DUMP")) {
-                    std::string d = getenv("PROSPER_SHADER_DUMP");
-                    if (FILE* f = fopen((d + "/frame_vs.spv").c_str(), "wb")) { fwrite(vs.data(), 4, vs.size(), f); fclose(f); }
-                    if (FILE* f = fopen((d + "/frame_fs.spv").c_str(), "wb")) { fwrite(fs.data(), 4, fs.size(), f); fclose(f); }
-                    fprintf(stderr, "[render] dumped SPIR-V vs=%zu fs=%zu dwords\n", vs.size(), fs.size()); fflush(stderr);
-                }
-                // Bind EVERY resource each shader declares, each at its own descriptor binding, reading the
-                // bytes from 1:1-mapped guest memory (an unbound image_sample/storage binding is UB). The
-                // executor gave each constant/vertex buffer + texture a distinct binding; the recompiler
-                // declared a storage buffer / image sampler at each, so we must bind them all.
+            [](const std::vector<prosper::gpu::DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
                 using RC = prosper::gpu::ResourceClass;
+                // Dump the FIRST item's recompiled SPIR-V (diagnostic; survives a mid-render crash).
+                if (getenv("PROSPER_SHADER_DUMP") && !items.empty()) {
+                    std::string d = getenv("PROSPER_SHADER_DUMP");
+                    if (FILE* f = fopen((d + "/frame_vs.spv").c_str(), "wb")) { fwrite(items[0].vs.data(), 4, items[0].vs.size(), f); fclose(f); }
+                    if (FILE* f = fopen((d + "/frame_fs.spv").c_str(), "wb")) { fwrite(items[0].fs.data(), 4, items[0].fs.size(), f); fclose(f); }
+                    fprintf(stderr, "[render] dumped SPIR-V vs=%zu fs=%zu dwords\n", items[0].vs.size(), items[0].fs.size()); fflush(stderr);
+                }
                 int dn = open("/dev/null", O_WRONLY);
                 auto readable = [&](uint64_t a, size_t n){ return a > 0x1000 && dn >= 0 && write(dn, (const void*)(uintptr_t)a, n) == (ssize_t)n; };
-                std::vector<prosper::test::FrameResource> R;
-                static std::vector<std::vector<uint8_t>> texstore;  // keep texture bytes alive across the call
+                static std::vector<std::vector<uint8_t>> texstore;  // keep every item's texture bytes alive
                 texstore.clear();
-                auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set){
+                // Build one draw's set-tagged resources from its VS (set 0) + PS (set 1) tables — read the
+                // bytes from 1:1-mapped guest memory, detile textures. (Each constant/vertex buffer + texture
+                // gets its own binding; the recompiler declared a storage buffer / image sampler at each.)
+                auto build_R = [&](const prosper::gpu::ShaderResourceTable* vrt, const prosper::gpu::ShaderResourceTable* prt) {
+                  std::vector<prosper::test::FrameResource> R;
+                  auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set){
                     if (!t) return;
                     for (auto& r : t->resources) {
                         prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
@@ -255,52 +251,51 @@ int main(int argc, char** argv) {
                         }
                         R.push_back(std::move(fr));
                     }
+                  };
+                  add(vrt, 0); add(prt, 1);   // VS resources -> descriptor set 0, PS -> set 1
+                  return R;
                 };
-                add(vrt, 0); add(prt, 1);   // VS resources -> descriptor set 0, PS -> set 1 (no binding collision)
-                if (dn >= 0) close(dn);
-                if (getenv("PROSPER_GFXLOG")) { fprintf(stderr, "[render] binding %zu resources (draw %u verts)\n",
-                    R.size(), draw_vcount); fflush(stderr); }
-                // PROSPER_RENDER_REFVS: replace the game's (intricate) vertex shader with a known-good
-                // fullscreen-triangle VS that exports uv in [0,1] across the screen (location 1) + white
-                // (location 0). Paired with the game's REAL pixel shader + texture, this shows the game's
-                // actual composited texture — isolating the VS from the rest of the pipeline.
-                std::vector<uint32_t> vs_use = vs; uint32_t vcount_use = draw_vcount;
-                if (getenv("PROSPER_RENDER_REFVS")) {
-                    #include "refvs.inc"
-                    vs_use.assign(kRefVs, kRefVs + sizeof(kRefVs) / 4); vcount_use = 3;
-                }
-                // PROSPER_RENDER_TESTPS: replace the real pixel shader with a solid MAGENTA one (recompiled
-                // from a tiny RDNA2 EXP blob) to isolate VS geometry from PS shading — if the VS positions
-                // are on-screen, magenta triangles appear regardless of the texture/PS math.
-                std::vector<uint32_t> fs_use = fs;
+                // Diagnostic shader/state overrides (computed once, applied to EVERY draw item):
+                //   REFVS  -> a known-good fullscreen-triangle VS (isolates the game's real VS).
+                //   TESTPS -> a solid-magenta PS (isolates VS geometry from PS shading).
+                //   FS_SPV -> a caller-supplied PS SPIR-V (e.g. a UV visualizer).
+                //   NOPS   -> bypass the resolved pipeline state (default state).
+                #include "refvs.inc"
+                const bool refvs = getenv("PROSPER_RENDER_REFVS");
+                std::vector<uint32_t> refvs_spv(kRefVs, kRefVs + sizeof(kRefVs) / 4);
+                std::vector<uint32_t> ps_override;
                 if (getenv("PROSPER_RENDER_TESTPS")) {
                     static const uint32_t kMagentaPs[] = {   // v0=1.0(R) v1=0.0(G) v2=1.0(B) v3=1.0(A); exp mrt0; endpgm
                         0x7E0002F2u, 0x7E020280u, 0x7E0402F2u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u };
-                    auto m = prosper::gpu::recompile_fragment(kMagentaPs, sizeof(kMagentaPs) / 4, nullptr);
-                    if (!m.empty()) fs_use = m;
+                    ps_override = prosper::gpu::recompile_fragment(kMagentaPs, sizeof(kMagentaPs) / 4, nullptr);
                 }
-                // PROSPER_FS_SPV=<file.spv>: replace the fragment shader with a caller-supplied SPIR-V
-                // module (diagnostic: e.g. a UV-visualizer PS that writes the interpolated location-1
-                // varying as color, to see EXACTLY what the real VS feeds the interpolators).
                 if (const char* fsp = getenv("PROSPER_FS_SPV")) {
                     if (FILE* f = fopen(fsp, "rb")) {
                         fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
                         std::vector<uint32_t> m((size_t)sz / 4);
-                        if (sz >= 20 && fread(m.data(), 4, m.size(), f) == m.size()) fs_use = std::move(m);
+                        if (sz >= 20 && fread(m.data(), 4, m.size(), f) == m.size()) ps_override = std::move(m);
                         fclose(f);
                     }
                 }
-                if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
-                    "[render] ps: topo=%u fmt=%u depth(test=%d write=%d op=%u) blend(en=%d src=%u dst=%u op=%u) mask=0x%x "
-                    "vp(has=%d x=%.1f y=%.1f w=%.1f h=%.1f z=%.3f..%.3f)\n",
-                    ps.topology, ps.color0_format, ps.depth_test_enable, ps.depth_write_enable, ps.depth_compare_op,
-                    ps.blend_enable, ps.src_color_blend_factor, ps.dst_color_blend_factor, ps.color_blend_op, ps.color_write_mask,
-                    ps.has_viewport, ps.viewport_x, ps.viewport_y, ps.viewport_w, ps.viewport_h, ps.min_depth, ps.max_depth);
-                // PROSPER_RENDER_NOPS: bypass the game's resolved pipeline state (default state instead) to
-                // isolate whether blend/depth/color-mask is discarding the fragments.
-                const prosper::gpu::ResolvedPipelineState* ps_use = getenv("PROSPER_RENDER_NOPS") ? nullptr : &ps;
-                std::vector<uint8_t> px = prosper::test::render_triangle_rgba(vs_use, fs_use, w, h, ps_use,
-                    nullptr, nullptr, nullptr, R.empty() ? nullptr : &R, vcount_use);
+                const bool nops = getenv("PROSPER_RENDER_NOPS");
+                // Assemble the backend draws — one per realized DrawItem, each with its own resources +
+                // fixed-function state (or the diagnostic overrides above). render_draws_rgba composites
+                // them into ONE framebuffer.
+                std::vector<prosper::test::BackendDraw> bds;
+                for (const auto& it : items) {
+                    prosper::test::BackendDraw bd;
+                    bd.vs     = refvs ? refvs_spv : it.vs;
+                    bd.fs     = ps_override.empty() ? it.fs : ps_override;
+                    bd.vcount = refvs ? 3u : it.vertex_count;
+                    bd.ps     = nops ? nullptr : &it.ps;
+                    bd.R      = build_R(it.vrt.get(), it.prt.get());
+                    if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
+                        "[render] item %zu: %zu resources vcount=%u topo=%u mask=0x%x blend=%d\n",
+                        bds.size(), bd.R.size(), bd.vcount, it.ps.topology, it.ps.color_write_mask, (int)it.ps.blend_enable);
+                    bds.push_back(std::move(bd));
+                }
+                if (dn >= 0) close(dn);
+                std::vector<uint8_t> px = prosper::test::render_draws_rgba(bds, w, h);
                 int n = frame_no++;
                 if (px.empty()) {
                     fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);


### PR DESCRIPTION
Small follow-up to the merged real-frames PR (#33). Builds the **multi-draw path** on top of the per-draw register snapshots that #33 already landed, so a submit's draws can each render under their own shaders/blend/mask/descriptors instead of collapsing onto a single draw.

Reuses the existing (good) single-draw Vulkan code — the single-draw entry is now a thin wrapper.

## What's here
- **`gpu_execute.hpp`** — `RenderFn` now takes `const std::vector<DrawItem>&`. A shared `realize_draw_item()` does recompile + resolve + the fullscreen-quad fan heuristic + no-op (`mask==0`) skip.
  - **Default:** one item from the folded end state → **renders the title frame byte-identically** (137k colors, 0% clear).
  - **`PROSPER_PERDRAW=1`:** one item per draw from its **own** register snapshot (`state_at_draw`).
- **`render_runner.h`** — `render_draws_rgba(list, W, H)`: shared instance/device/render-pass/framebuffer, **cleared once**, then per-draw pipeline + the same two-set descriptors + draw. `render_triangle_rgba` is now a thin single-draw wrapper (recompiled-shader tests unchanged).
- **`gpu_executor.cpp` / `boot_trace.cpp`** — `LiveRenderFn` takes the list; boot_trace builds each item's resources (guest-memory read + detile) and applies the `REFVS`/`TESTPS`/`FS_SPV`/`NOPS` diagnostics per item.
- **New `test_multidraw_render`** — red-opaque + green-additive → **yellow center** proves N draws accumulate into ONE framebuffer (a per-draw clear would leave only green).

## Verification
- **Linux `ctest` 49/49** (new `multidraw_render`); MinGW core compiles.
- Default `boot_trace` render is unchanged: full title, 137k colors, 0% clear-color.

## Honest status of `PROSPER_PERDRAW`
It's **opt-in and currently renders blue**. The multi-draw *spine* works (proven by the yellow test), but the game's AGC context-log packets stage **duplicate register writes in sections** (current-draw vs staged post-draw state), so per-draw snapshots resolve state "one draw off" — carried over from #31's finding. Decoding that section format is the one remaining step to compositing real multi-geometry scenes; the snapshots + multi-draw backend are now in place for it. (No current visible regression: the only geometry the game submits today is the fullscreen composite, which the default fan path fills.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)