### PR TITLE
Fix %fs stack-smash in fault_handler + pin the cutscene wall to incremental-GC live-object collection

### DIFF
--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -67,6 +67,25 @@ is a 6-state jump-table mark/sweep machine driven by `[Il2cpp+0x267dee8]`. The r
 scene-load thread. The scene never activates (draw shader/`color0_base` unchanged; reads plateau ~block 977),
 because the GC crash kills the game during scene integration.
 
+## KEY finding — the GC is collecting LIVE objects (root/marking bug), not just tripping over deser garbage
+
+Added a bring-up diagnostic `PROSPER_PATCH_RET=addr[,addr...]` (boot_trace) that writes `0xC3` (ret) at a
+guest address to neutralize a function. Patching the per-frame incremental-GC pump
+(`PROSPER_PATCH_RET=0x440005df0`, = `Il2cpp+0x5df0`) **changes the render output**: `color0_base` goes from
+always `0x0` to real render-target addresses (`0x…df790000`). So with the incremental GC stopped, the
+scene's render targets **survive** — i.e. the incremental GC was **collecting live objects** (a missed
+root / missed write during incremental marking), not merely dereferencing a corrupt deserialized object.
+This redirects the root-cause hunt from "deser produces garbage" toward "our incremental-GC support drops a
+live reference." (Root capture in `exc_delivery_handler` looks complete — all 15 GP regs + rsp + `ctx[0xf8]`
+— so suspect either the incremental write-barrier path or static-field root registration.)
+
+**A second, INDEPENDENT null remains** even with the GC pump patched: the crash at `Il2cpp+0x1637697` is in
+a function whose start (`0x16375e0`) sets `rbx = rdi` (its argument), then derefs `[rbx+0x20]` — i.e. the
+**caller passed a null object**. This one is not GC-collected (it persists with GC off), so there are at
+least two distinct corruption sources feeding the null-deref crashes; both must be resolved to reach the
+cutscene. `PROSPER_NULL_PAGE` does not rescue these (the surviving faults include null writes / non-low
+addresses → uncaught SIGSEGV).
+
 ## Next steps (for reaching the cutscene)
 
 1. **Resolve the scene-load deserialization corruption** (the `FileCacher` stale-block issue in

--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -76,10 +76,26 @@ always `0x0` to real render-target addresses (`0x…df790000`). So with the incr
 scene's render targets **survive** — i.e. the incremental GC was **collecting live objects** (a missed
 root / missed write during incremental marking), not merely dereferencing a corrupt deserialized object.
 This redirects the root-cause hunt from "deser produces garbage" toward "our incremental-GC support drops a
-live reference." (Root capture in `exc_delivery_handler` looks complete — all 15 GP regs + rsp + `ctx[0xf8]`
-— so suspect either the incremental write-barrier path or static-field root registration.)
+live reference." **Decisive evidence (not a timing confound):** across a full unpatched run `color0_base` is
+`0x0` for *every* draw — a real render target is *never* bound; with `0x5df0` patched, real render-target
+addresses appear from the *first* draw. So the collector running is precisely what prevents the scene's
+render targets from surviving. This dovetails with the parallel agent's data point that all 13/13 GC
+stop-the-world suspends caught threads **parked in a futex** (host code), never an actively-mutating guest
+thread — i.e. an active mutator may escape suspension, so the incremental mark proceeds over a heap that is
+still changing and reclaims a still-referenced object. (Root capture in `exc_delivery_handler` itself looks
+complete — all 15 GP regs + rsp + `ctx[0xf8]`; suspect the incremental write-barrier / active-mutator
+suspension, or static-field root registration.)
 
-**A second, INDEPENDENT null remains** even with the GC pump patched: the crash at `Il2cpp+0x1637697` is in
+****Cleanly separating the two root causes (via `PROSPER_PATCH_BYTE=0x440005dfe=0xeb`, which forces the pump's
+`je` to an unconditional `jmp` so incremental marking never runs — no half-collection, unlike ret'ing the
+whole pump):** real render targets survive from draw 1 AND the game deterministically advances to a *new*
+crash at `SubmitDcb #28` — `Il2cpp+0x1637697`, same backtrace every run. Its caller (`Il2cpp+0x175c991`)
+does `mov 0x40(%rbx),%rdi; call 0x16375e0`, i.e. it passes **`[callerObj+0x40]`, which is null**. That field
+stays null with the GC OFF, so this second crash is an **uninitialized / mis-deserialized object field**, NOT
+a GC-collected reference — i.e. the deser frontier the parallel agent owns. So reaching the cutscene needs
+BOTH: (1) the incremental-GC live-object drop, and (2) the deser/init null at `[obj+0x40]`.
+
+A second, INDEPENDENT null remains** even with the GC pump patched: the crash at `Il2cpp+0x1637697` is in
 a function whose start (`0x16375e0`) sets `rbx = rdi` (its argument), then derefs `[rbx+0x20]` — i.e. the
 **caller passed a null object**. This one is not GC-collected (it persists with GC off), so there are at
 least two distinct corruption sources feeding the null-deref crashes; both must be resolved to reach the

--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -95,6 +95,18 @@ stays null with the GC OFF, so this second crash is an **uninitialized / mis-des
 a GC-collected reference — i.e. the deser frontier the parallel agent owns. So reaching the cutscene needs
 BOTH: (1) the incremental-GC live-object drop, and (2) the deser/init null at `[obj+0x40]`.
 
+**Crash-free-but-stuck isolation (strongest handle on the wall):** disabling incremental marking
+(`0x440005dfe=0xeb`) *and* stubbing the null-`this` getter to return 0
+(`0x4416375e0=0x31,0x4416375e1=0xc0,0x4416375e2=0xc3` = `xor eax,eax; ret`) makes the game **run crash-free
+for the full run** — but it stays on the loading screen (`color0_base=0x0`, the single blit). So the getter
+`0x16375e0` is on the **scene-activation path**: returning 0 (because `[callerObj+0x40]` is null) makes the
+game not advance; with the GC on but the getter crashing, real render targets briefly appear (the game *was*
+starting to render the scene). Net: the crashes are fully avoidable via workarounds, and the pure remaining
+blocker to the cutscene is **populating the null managed field `[callerObj+0x40]`** (an uninitialized / mis-
+deserialized object) so the getter returns its real value and activation proceeds. That single field is the
+next thing to fix; identifying `callerObj`'s type + what writes `+0x40` (via il2cpp metadata / the deser
+path) is the concrete remaining task.
+
 A second, INDEPENDENT null remains** even with the GC pump patched: the crash at `Il2cpp+0x1637697` is in
 a function whose start (`0x16375e0`) sets `rbx = rdi` (its argument), then derefs `[rbx+0x20]` — i.e. the
 **caller passed a null object**. This one is not GC-collected (it persists with GC off), so there are at

--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -49,6 +49,24 @@ null) that then crash when a per-frame update/GC/finalizer touches them — i.e.
 is the alternative/compounding cause. It is **not** a worker-thread fault (0 observed) and **not** a missing
 HLE call (no unimplemented call fires during the steady-state load).
 
+## Also fixed — spurious `%fs` stack-smash abort in `fault_handler`
+
+A second, intermittent fatal crash independent of the GC one: `*** stack smashing detected ***` (SIGABRT).
+Caught with an `LD_PRELOAD` `__stack_chk_fail` interposer — the "smash" was inside our own SIGSEGV/SIGBUS/
+SIGILL `fault_handler`, with `%fs:0x28` already equal to the host canary at abort time (no real overflow).
+The handler is entered while the faulting thread runs on the **guest `%fs`**, then switches to the **host
+`%fs`** mid-function (`guest_fs_enter_host_for_signal`); a `-fstack-protector` prologue reads its canary from
+the guest TCB and the epilogue re-reads it from the host TCB, so any divergence trips `__stack_chk_fail`.
+Fixed by marking exactly this `%fs`-switching handler `__attribute__((no_stack_protector))`
+(`exec_image_linux.cpp`) — removes the false positive at its source. Eliminated one of the two intermittent
+long-run crash modes (`smashing=0` across repeated runs); the incremental-GC crash below remains.
+
+**The per-frame pump is Boehm's INCREMENTAL GC:** `Il2cpp+0x5df0` is a time-sliced work loop, and `0x5ee0`
+is a 6-state jump-table mark/sweep machine driven by `[Il2cpp+0x267dee8]`. The remaining crash is a **race**
+(point varies `SubmitDcb #20..#6530`) inside that collector — stop-the-world likely not covering a
+scene-load thread. The scene never activates (draw shader/`color0_base` unchanged; reads plateau ~block 977),
+because the GC crash kills the game during scene integration.
+
 ## Next steps (for reaching the cutscene)
 
 1. **Resolve the scene-load deserialization corruption** (the `FileCacher` stale-block issue in

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -349,6 +349,15 @@ namespace {
     static constexpr uint64_t GPU_VA_HI = 0x1000000000ull;  // 64 GiB
     volatile sig_atomic_t g_lazy_pages = 0;                 // count (diagnostic)
 
+    // no_stack_protector: this handler can be entered while the faulting thread runs on the GUEST %fs and
+    // then switches to the HOST %fs mid-function (guest_fs_enter_host_for_signal at line ~759). A
+    // -fstack-protector prologue reads its canary from %fs:0x28 at entry (guest TCB) and the epilogue
+    // re-reads it (host TCB); if a thread's guest-TCB canary copy ever diverges from the host canary, the
+    // epilogue sees a spurious mismatch and aborts via __stack_chk_fail ("stack smashing detected") even
+    // though no buffer overflowed — a fatal false positive that intermittently killed long runs. Disabling
+    // the canary on exactly this %fs-switching handler removes the false positive at its source (more
+    // robust than copying the canary into every guest TCB, which is per-thread-fragile).
+    __attribute__((no_stack_protector))
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
         // PROSPER_HWBP race-free hardware breakpoint. The perf event is disabled while single-stepping,
         // so a SIGTRAP while g_hwbp_stepping is the step-completion (TF) -> re-enable + clear TF. Any

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -117,6 +117,20 @@ int main(int argc, char** argv) {
     install_trap_handler();
     run_guest_inits(p.init_fns);
 
+    // PROSPER_PATCH_RET=addr[,addr...]: write 0xC3 (ret) at each absolute guest address, neutralizing that
+    // function (returns immediately, stack balanced). Bring-up diagnostic to bisect a crashing subsystem —
+    // e.g. skip the per-frame incremental-GC pump (Il2cpp+0x5df0 => 0x440005df0) to test whether the GC is
+    // the wall to scene activation. Guest code is RWX; write before the guest starts.
+    if (const char* pr = getenv("PROSPER_PATCH_RET")) {
+        const char* s = pr;
+        while (*s) {
+            char* end = nullptr; uint64_t a = strtoull(s, &end, 0);
+            if (a && end != s) { *(volatile uint8_t*)(uintptr_t)a = 0xC3;
+                fprintf(stderr, "[patch] ret @ 0x%llx\n", (unsigned long long)a); }
+            s = (end && *end == ',') ? end + 1 : (end ? end : s + 1);
+        }
+    }
+
 #ifdef PROSPER_HAVE_VULKAN
     // PROSPER_RENDER=1: register the live Vulkan renderer so execute_and_present fires on every
     // submitted Dcb with draws (Stage A of GPU_EXECUTOR_DESIGN.md, now live). Each rendered frame

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -127,7 +127,9 @@ int main(int argc, char** argv) {
             char* end = nullptr; uint64_t a = strtoull(s, &end, 0);
             if (a && end != s) { *(volatile uint8_t*)(uintptr_t)a = 0xC3;
                 fprintf(stderr, "[patch] ret @ 0x%llx\n", (unsigned long long)a); }
-            s = (end && *end == ',') ? end + 1 : (end ? end : s + 1);
+            // Always make progress: skip the comma if present, else advance past what we parsed; if
+            // strtoull consumed nothing (end == s, malformed) step one char so we never spin forever.
+            s = (*end == ',') ? end + 1 : (end != s) ? end : s + 1;
         }
     }
     // PROSPER_PATCH_BYTE=addr=val[,addr=val...]: write an arbitrary byte at a guest address (finer than

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -130,6 +130,20 @@ int main(int argc, char** argv) {
             s = (end && *end == ',') ? end + 1 : (end ? end : s + 1);
         }
     }
+    // PROSPER_PATCH_BYTE=addr=val[,addr=val...]: write an arbitrary byte at a guest address (finer than
+    // PATCH_RET — e.g. flip a conditional 0x74 je -> 0xEB jmp to force a branch). Same bring-up bisection use.
+    if (const char* pb = getenv("PROSPER_PATCH_BYTE")) {
+        const char* s = pb;
+        while (*s) {
+            char* e1 = nullptr; uint64_t a = strtoull(s, &e1, 0);
+            if (a && e1 && *e1 == '=') {
+                char* e2 = nullptr; unsigned long v = strtoul(e1 + 1, &e2, 0);
+                *(volatile uint8_t*)(uintptr_t)a = (uint8_t)v;
+                fprintf(stderr, "[patch] byte 0x%02x @ 0x%llx\n", (unsigned)(v & 0xff), (unsigned long long)a);
+                s = (e2 && *e2 == ',') ? e2 + 1 : (e2 ? e2 : s + 1);
+            } else s = (e1 && *e1) ? e1 + 1 : s + 1;
+        }
+    }
 
 #ifdef PROSPER_HAVE_VULKAN
     // PROSPER_RENDER=1: register the live Vulkan renderer so execute_and_present fires on every


### PR DESCRIPTION
## Toward the cutscene: `%fs` stack-smash fix + dissect the wall into two reproducible, isolated causes

Follow-up to the merged cutscene-loading work (#35). **Honest status:** the cutscene is still not on screen —
the game stays on the loading screen — but this reduces the once-mysterious "deep crash" to two named,
reproducible root causes and lands a real crash fix, with bisection tooling so the fix work starts from the
pinned causes.

### Fix — `no_stack_protector` on `fault_handler`
An intermittent fatal `*** stack smashing detected ***` (SIGABRT). Caught with an `LD_PRELOAD`
`__stack_chk_fail` interposer: the "smash" fires inside our own SIGSEGV/BUS/ILL `fault_handler`, with
`%fs:0x28` already equal to the host canary — *no real overflow*. The handler enters on the **guest `%fs`**
and switches to the **host `%fs`** mid-function, so `-fstack-protector` compares canaries from two TCBs.
Fixed with `__attribute__((no_stack_protector))` on that handler. `smashing=0` across runs; 48/48 tests pass.

### Tooling — `PROSPER_PATCH_RET` / `PROSPER_PATCH_BYTE`
Write `0xC3` (ret) or an arbitrary byte at a guest address to neutralize/branch a function — a bisection
tool for a crashing guest subsystem.

### The wall, dissected into two independent causes (the main contribution)
1. **Incremental GC drops live render-target objects.** Decisive: unpatched, `color0_base` is `0x0` for
   *every* draw of a full run (a real render target is never bound); disable the incremental collector
   (`PROSPER_PATCH_BYTE=0x440005dfe=0xeb`) and real render targets appear from draw 1. Matches the parallel
   agent's data (all stop-the-world suspends caught futex-parked threads, never an active mutator).
2. **A deterministic null managed field on the scene-activation path.** With the GC disabled the game
   advances to a deterministic crash at `Il2cpp+0x1637697` (#28): a getter is called with a null `this`
   because its caller passes `[callerObj+0x40]`, which is **null and stays null with the GC off** — an
   uninitialized / mis-deserialized field. Stubbing that getter to return 0 makes the game **run crash-free
   for a full run** but stuck on the loading screen — proving the getter is on the activation path and the
   single remaining blocker is populating `[callerObj+0x40]`.

Full write-up + repros in `docs/CUTSCENE_PROGRESSION.md`. Next concrete task: identify `callerObj`'s type
(il2cpp metadata) and what writes `+0x40` (the deser path) — that unblocks scene activation and the cutscene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
