### PR TITLE
diag: cutscene blocker pinned to IL2CPP GC "Unexpected state" abort (findings + tooling)

### DIFF
--- a/prosper/docs/CUTSCENE_GC_ABORT.md
+++ b/prosper/docs/CUTSCENE_GC_ABORT.md
@@ -74,6 +74,28 @@ PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PAD_PRESS=1 \
   host stack-protector ("stack smashing detected"). Reverted. The `%fs`-mid-HLE case is a real
   latent hazard worth fixing properly, but it is **not** the (sole) cause of this abort.
 
+## Attempted bypass: disable/defer the GC via its env knobs — BLOCKED (dead end)
+
+bdwgc reads `GC_DONT_GC` / `GC_INITIAL_HEAP_SIZE` / `GC_PRINT_STATS` from the environment; since
+the abort only fires *during* a collection, disabling or deferring collection would sidestep it
+entirely (a bounded leak is fine for a short cutscene — a standard emulator GC-bug workaround).
+Both delivery paths are blocked:
+
+1. **Stack `envp`** — the loader now builds a SysV `envp` from `PROSPER_GUEST_ENV`, but the PS5
+   crt0 does not consume it (`GC_PRINT_STATS=1` produced no GC output). The guest's `environ`
+   stays empty. (PS5 process env likely comes from the Sony process-param / `sceLibcParam`
+   structure, not the SysV stack vector.)
+2. **`getenv` HLE override** — registering our own `getenv` does not intercept the call: the
+   loader resolves imports "cross-module export beats a stub slot" (linker.cpp), and `libc.prx`
+   **exports** `getenv`, so the guest binds to the real libc.prx `getenv` (which reads the empty
+   `environ`). `PROSPER_GETENVLOG` showed zero calls routed to our handler.
+
+To make env-based GC control work, a future change must either fix the crt0 `envp` consumption
+(populate `libc.prx`'s `environ`) or patch the Sony process-param env — and even then it is
+unproven that `GC_DONT_GC` helps, since a Unity scene-transition `GC.Collect()` is explicit and
+`GC_DONT_GC` only disables *automatic* collection. Both env-plumbing changes were reverted (they
+did not function); only the diagnostics below remain.
+
 ## Open leads (ranked, for the next investigator)
 
 1. **A thread created/exited DURING a stop-the-world.** Unity's job system spins worker threads
@@ -104,3 +126,8 @@ PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PAD_PRESS=1 \
   llvmpipe a 1080p render is ~10–20 s and `execute_and_present` is synchronous in the submit
   call, throttling the whole frame loop; sampling lets the game run near full speed toward a
   distant scene while still producing periodic frames.
+- **`PROSPER_PEEK_CODE=0xADDR[,0xADDR…]`** (boot_trace.cpp, under `PROSPER_CRASHPEEK`): dump 512
+  code bytes at each guest address after the recovered fault (guest memory still mapped) for
+  offline `objdump -b binary -m i386:x86-64`. Used to disassemble the guest GC suspend-handler
+  thunk at `0x4c0000210` (confirmed it extracts `ctx[0xf8]` as the thread sp — which our exception
+  delivery already populates correctly — and tail-calls the real handler behind a global pointer).

--- a/prosper/docs/CUTSCENE_GC_ABORT.md
+++ b/prosper/docs/CUTSCENE_GC_ABORT.md
@@ -1,0 +1,106 @@
+# Cutscene blocker — IL2CPP GC "Unexpected state" abort on the level1 (intro) load (2026-07)
+
+After the title screen (`level0`) renders correctly, the game **always reaches the intro
+cutscene's scene load** — it opens `/app0/Media/level1`, `sharedassets1.assets`, and streams
+`resources.resource` — then **crashes in the IL2CPP garbage collector** before the cutscene
+can render. This is the next boot wall after "first real frames". This doc records exactly
+what the crash is, the evidence, what was ruled out, and the open leads.
+
+## TL;DR
+
+The crash is a **Boehm GC (bdwgc, IL2CPP's collector) `ABORT("Unexpected state")`** during a
+stop-the-world collection. The title allocates too little to ever trigger a GC; the cutscene's
+asset load allocates enough to trigger the **first big collection**, which aborts. It is
+**timing-sensitive** (a race): it disappears entirely under `PROSPER_SYNCLOG` (the extra
+logging/serialization perturbs the timing) and manifests on either the main thread (caught as
+`RUN ENDED kind=2`) or a worker thread (`WORKER-THREAD FAULT`, which `_exit(90)`s the process).
+
+## How to reproduce
+
+```
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PAD_PRESS=1 \
+  ./boot_trace <dump>
+```
+
+`PROSPER_PAD_PRESS=1` holds CROSS so the title advances into the level1 load. ~6/6 runs reach
+`level1` and crash. (No renderer needed — the crash is on the CPU asset-load path; with
+`PROSPER_RENDER=1` the title renders many times first, then the same crash fires at level1.)
+
+## Evidence chain (all reproducible)
+
+1. **The fault site is a deliberate GC abort trap.** The main-thread crash is
+   `rip = libc.prx+0x4a20`, whose bytes are `cd 45 90 0f 0b` = `int 0x45 ; nop ; ud2` — a
+   trap, not a normal fault. The caller is `Il2cpp+0x5423: call Il2cpp+0x1e3000 ; ud2` — the
+   classic `call noreturn_abort ; ud2` shape.
+
+2. **The abort function's argument is the message "Unexpected state".** Breaking at the abort
+   function (`PROSPER_HWBP=0x401e3000 PROSPER_HWBP_STRDUMP=1`) shows `rdi -> "Unexpected state"`.
+   The rodata around it (dumped via `PROSPER_CRASHPEEK`) is
+   `"Unexpected state\0No space for mark stack\0suspendCond\0Cannot mark..."` — bdwgc's
+   mark/suspend error-string table. So IL2CPP's bdwgc uses a **condition variable** for
+   suspend/resume ("suspendCond"), and this is the collector's stop-the-world state machine.
+
+3. **The whole call stack is guest code** (`libc.prx` ← `Il2cpp` ← the game's compiled C# at
+   `eboot+0xa8c989` ← the Unity runtime init `eboot+0x147b494 / 0x1485851`). Nothing of ours is
+   on the stack: the collector itself detected a thread in an unexpected suspend state and
+   aborted. Registers are deterministic across runs (`rax`/`rdi`/`rsi=0`/`rdx=8`; only the
+   stack pointer varies with ASLR).
+
+4. **The GC stop-the-world handshake works for many cycles, then fails.** With
+   `PROSPER_SYNCLOG=1`, `[exc]` tracing shows the collector raising exceptions and threads
+   ack/resume correctly for several cycles (16 raises / 16 handler-enters / 15 exits — the last
+   thread simply still-suspended at the kill). Under SYNCLOG the crash does **not** happen at
+   all (it idles on the render watchdog instead). So suspension is not categorically broken —
+   there is a specific race that only the first level1 collection hits.
+
+## Ruled out (with evidence)
+
+- **Semaphore lost-wakeup** (`k_sema_wait/signal`, hle_kernel.cpp): counting sem, `count += n`
+  under the mutex + broadcast; a signal before a wait is retained. Correct.
+- **Condition-variable HLE** (`k_cond_*`): thin pass-throughs to host `pthread_cond_*` with the
+  guest owning the predicate loop. Correct.
+- **sigaltstack `thread_local` aliasing**: `install_sigaltstack` runs in `thread_trampoline`
+  **before** `guest_tls_activate_thread()`, i.e. on the host `%fs`, so its `thread_local` guard
+  is not aliased. Not the bug.
+- **TSD-destructor `%fs` at thread exit** (hypothesis: exited workers don't run bdwgc's cleanup
+  key destructor because `thread_trampoline` returns on the guest `%fs`, so glibc's
+  `__nptl_deallocate_tsd` reads the destructor array through the wrong TCB): **tried** (restore
+  host `%fs` before `thread_trampoline` returns) — **did not remove the abort**. Reverted.
+- **GC handler running on the wrong `%fs`** (hypothesis: the suspend RT-signal interrupts a
+  thread mid-HLE-call on the host `%fs`, so `exc_delivery_handler` runs the guest suspend
+  handler with the wrong TCB — the code even comments that it "must KEEP the guest %fs"):
+  **tried** (ensure guest `%fs` for the handler via a per-thread guest-TP `thread_local`) — the
+  abort **still fired**, and the `%fs`-swap inside the signal handler additionally tripped the
+  host stack-protector ("stack smashing detected"). Reverted. The `%fs`-mid-HLE case is a real
+  latent hazard worth fixing properly, but it is **not** the (sole) cause of this abort.
+
+## Open leads (ranked, for the next investigator)
+
+1. **A thread created/exited DURING a stop-the-world.** Unity's job system spins worker threads
+   up and down during asset load. bdwgc serializes create/exit with the collector via the GC
+   lock + a thread-registration handshake; the codebase already fought one instance of this
+   ("Bad stack base … fast-starting worker ran before the parent's registration",
+   hle_kernel.cpp:183). "Unexpected state" is the collector finding a thread whose
+   `stop_info`/registration state doesn't match the current stop-count — exactly what a
+   create/exit racing the stop produces. **Decisive capture:** log `scePthreadCreate` /
+   thread-exit against the `[exc]` raise/ack timeline (gate on the level1 load) and look for a
+   thread whose lifetime brackets a stop-the-world.
+2. **Disassemble the guest suspend handler** (installed for exception type `0x1e`; the log shows
+   `handler=0x4c0000210`) to learn the exact primitive it acks/blocks on (sem vs the
+   `suspendCond` condvar) and the state field it sets — then verify our delivery preserves that
+   state's invariants. This is the ground truth that ends the hypothesis-guessing.
+3. **RT-signal double-delivery.** RT signals queue (no coalescing). If the collector raises the
+   same thread twice within one stop (or a stale queued signal from a prior cycle is delivered),
+   the guest handler runs twice → double-ack → state mismatch. Instrument `k_raise_exception` to
+   count raises per (thread, stop-count).
+
+## Tooling added this session (gated, no default behavior change)
+
+- **`PROSPER_CRASHPEEK`** (boot_trace.cpp): after a recovered main-thread fault, dump guest
+  memory at the fault registers + 24 instruction bytes at the fault rip and each backtrace
+  frame's call site (for offline `objdump -b binary -m i386:x86-64`). This is what decoded the
+  abort trap and the GC rodata table.
+- **`PROSPER_RENDER_EVERY=K`** (hle_agc.cpp): render only every Kth draw-carrying submit. Under
+  llvmpipe a 1080p render is ~10–20 s and `execute_and_present` is synchronous in the submit
+  call, throttling the whole frame loop; sampling lets the game run near full speed toward a
+  distant scene while still producing periodic frames.

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -287,5 +287,40 @@ int main(int argc, char** argv) {
            (unsigned long long)r.rdx, (unsigned long long)r.rbp, (unsigned long long)r.rsp);
     printf("  backtrace (%zu frames):\n", r.backtrace.size());
     for (uint64_t a : r.backtrace) printf("    %-12s +0x%llx\n", cls(a), (unsigned long long)bof(a));
+    // PROSPER_CRASHPEEK: after a recovered main-thread fault, dump guest memory at the fault registers
+    // (still 1:1-mapped) so a null-source deref (e.g. an IL2CPP memcpy from a null field) can be traced
+    // to the object + field that is null. Reads are bounded by guest_readable (never re-faults).
+    if (getenv("PROSPER_CRASHPEEK") && r.kind == 2) {
+        auto dump = [&](const char* tag, uint64_t addr) {
+            printf("  [peek] %s=0x%llx:", tag, (unsigned long long)addr);
+            if (!addr || !prosper::gpu::guest_readable(addr, 8)) { printf(" <unmapped>\n"); return; }
+            for (int i = 0; i < 8; i++) {
+                uint64_t a = addr + (uint64_t)i * 8;
+                if (prosper::gpu::guest_readable(a, 8)) printf(" %016llx", (unsigned long long)*(const uint64_t*)(uintptr_t)a);
+                else { printf(" ...."); break; }
+            }
+            printf("\n");
+        };
+        dump("rax", r.rax); dump("rdi", r.rdi);
+        // The dest rdi is unaligned; also show the object rax as bytes (type tags / vtable ptr @+0).
+        // Scan rax's first 8 qwords for the null field (the likely memcpy source).
+        for (int i = 0; i < 8; i++) {
+            uint64_t a = r.rax + (uint64_t)i * 8;
+            if (prosper::gpu::guest_readable(a, 8) && *(const uint64_t*)(uintptr_t)a == 0)
+                printf("  [peek] rax+0x%x is NULL (candidate memcpy source field)\n", i * 8);
+        }
+        // Dump 24 instruction bytes at the fault rip and each backtrace frame's return site
+        // (return addr - 5, the call instruction) for offline `objdump -b binary -m i386:x86-64`.
+        auto insn = [&](const char* tag, uint64_t addr) {
+            printf("  [insn] %s 0x%llx:", tag, (unsigned long long)addr);
+            for (int i = 0; i < 24; i++)
+                if (prosper::gpu::guest_readable(addr + i, 1)) printf(" %02x", *(const uint8_t*)(uintptr_t)(addr + i));
+                else { printf(" ??"); break; }
+            printf("\n");
+        };
+        insn("rip", r.fault_rip);
+        for (size_t i = 0; i < r.backtrace.size() && i < 5; i++)
+            insn("call@", r.backtrace[i] >= 5 ? r.backtrace[i] - 5 : r.backtrace[i]);
+    }
     return 0;
 }

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -32,6 +32,12 @@
 #include <unistd.h>
 #endif
 
+// PROSPER_CRASHPEEK (below) needs these in every config — the gpu/*.hpp includes above are gated on
+// PROSPER_HAVE_VULKAN, but guest_readable is a core (non-Vulkan) symbol always linked into prosper_core,
+// and strchr needs <cstring>. Declare/include them unconditionally so the no-Vulkan build compiles.
+#include <cstring>
+namespace prosper::gpu { bool guest_readable(uint64_t addr, uint32_t bytes); }
+
 using namespace prosper;
 
 

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -321,6 +321,21 @@ int main(int argc, char** argv) {
         insn("rip", r.fault_rip);
         for (size_t i = 0; i < r.backtrace.size() && i < 5; i++)
             insn("call@", r.backtrace[i] >= 5 ? r.backtrace[i] - 5 : r.backtrace[i]);
+        // PROSPER_PEEK_CODE=0xADDR[,0xADDR...]: dump 512 code bytes at each guest address (still mapped
+        // post-fault) for offline `objdump -b binary -m i386:x86-64 --adjust-vma=ADDR`. Used to
+        // disassemble the guest GC suspend handler etc. without extracting the SELF module.
+        if (const char* pc = getenv("PROSPER_PEEK_CODE")) {
+            for (const char* p = pc; *p; ) {
+                uint64_t a = strtoull(p, nullptr, 0);
+                printf("  [code] 0x%llx:", (unsigned long long)a);
+                for (int i = 0; i < 512; i++) {
+                    if (prosper::gpu::guest_readable(a + i, 1)) printf(" %02x", *(const uint8_t*)(uintptr_t)(a + i));
+                    else { printf(" ??"); break; }
+                }
+                printf("\n");
+                const char* c = strchr(p, ','); if (!c) break; p = c + 1;
+            }
+        }
     }
     return 0;
 }


### PR DESCRIPTION
## Status: the game REACHES the cutscene load, then the IL2CPP GC aborts — root cause characterized, not yet fixed

After the title screen renders, the game **always advances into the intro cutscene's scene load** — it opens `/app0/Media/level1` + `sharedassets1.assets` and streams `resources.resource` — then **crashes in the IL2CPP garbage collector** before the cutscene can display. This PR does **not** fix the crash; it pins it precisely, rules out several causes, records two attempted fixes that didn't work, and adds the diagnostics that got there. Full writeup: `prosper/docs/CUTSCENE_GC_ABORT.md`.

I'm opening it as a findings PR (no default-behavior change, 48/48 tests green) so the next session starts from a precise, evidenced position rather than re-deriving it — the same pattern the earlier `docs/*.md` investigation notes used.

## What the crash is (evidence in the doc)

- **A deliberate Boehm-GC abort trap**: `rip = libc.prx+0x4a20` = `int 0x45 ; nop ; ud2`; caller `Il2cpp+0x5423: call GC_abort ; ud2`.
- **Message = "Unexpected state"** (confirmed by breaking at the abort function: `rdi -> "Unexpected state"`); surrounding rodata is bdwgc's mark/suspend table (`"No space for mark stack"`, `"suspendCond"`, `"Cannot mark"`). IL2CPP's collector uses a condvar-based stop-the-world.
- **Whole stack is guest code** (`libc.prx ← Il2cpp ← game C# ← Unity runtime init`) — the collector itself found a thread in an unexpected suspend state.
- **Timing-sensitive race**: it vanishes entirely under `PROSPER_SYNCLOG` and hits either the main thread (`RUN ENDED kind=2`) or a worker (`WORKER-THREAD FAULT`, which `_exit`s). The title never GCs (too little allocation); level1's asset load triggers the **first big collection**, which aborts.

## Ruled out (evidence in the doc)

Semaphore/condvar HLE primitives (correct), sigaltstack `thread_local` aliasing (runs on host fs), and **two attempted fixes** — restoring host `%fs` before a worker's `thread_trampoline` returns (so glibc runs bdwgc's TSD cleanup destructor), and ensuring the GC suspend handler runs on the guest `%fs` — **neither removed the abort** (the second also tripped the host stack-protector inside the signal handler). Both reverted.

## Top open lead

A Unity **job-system worker created/exiting DURING a stop-the-world** produces exactly a stop-count/registration "Unexpected state". The codebase already fought one instance of this class ("Bad stack base … fast-starting worker ran before registration"). Decisive next step (in the doc): correlate `scePthreadCreate`/thread-exit with the `[exc]` raise/ack timeline, gated on the level1 load; and disassemble the guest suspend handler (`type 0x1e`, `handler=0x4c0000210`) for the exact state invariant.

## Tooling added (gated, no default behavior change)

- **`PROSPER_CRASHPEEK`** — after a recovered main-thread fault, dump guest memory at the fault registers + instruction bytes at the fault rip and backtrace call sites. This decoded the abort trap and the GC rodata table.
- **`PROSPER_RENDER_EVERY=K`** — render only every Kth draw-carrying submit, so the synchronous llvmpipe render (~10–20 s/frame) doesn't throttle the frame loop to a crawl on the way to a distant scene.

Verified: 48/48 ctest green on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhrNzDBN986tKzU7wpAEjK