### PR TITLE
fix(gpu): loading screen rendered upside down — honor the guest viewport (PA_CL_VPORT)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -2,6 +2,8 @@
 #include "render_state.hpp"
 #include "pm4_registers.hpp"
 #include "vk_translate.hpp"
+#include <algorithm>
+#include <cstring>
 
 namespace prosper::gpu {
 
@@ -18,6 +20,13 @@ uint32_t rd(const std::unordered_map<uint32_t, uint32_t>& file, uint32_t off) {
 // GraphicsRun.cpp (`(lo<<8) | ((hi&0xff)<<40)`).
 uint64_t addr_of(uint32_t lo, uint32_t hi) {
     return (static_cast<uint64_t>(lo) << 8) | (static_cast<uint64_t>(hi & 0xffu) << 40);
+}
+
+// PA_CL_VPORT_* registers hold IEEE-754 floats.
+float flt(uint32_t bits) {
+    float f;
+    std::memcpy(&f, &bits, sizeof f);
+    return f;
 }
 }  // namespace
 
@@ -62,6 +71,14 @@ RenderState extract_render_state(const GpuState& st) {
     rs.cb_blend0_control = bc;
     rs.cb_target_mask    = rd(st.cx, P::CB_TARGET_MASK);
 
+    // Viewport 0 transform (guest floats; all-zero when never programmed).
+    rs.vport_xscale  = flt(rd(st.cx, P::PA_CL_VPORT_XSCALE));
+    rs.vport_xoffset = flt(rd(st.cx, P::PA_CL_VPORT_XOFFSET));
+    rs.vport_yscale  = flt(rd(st.cx, P::PA_CL_VPORT_YSCALE));
+    rs.vport_yoffset = flt(rd(st.cx, P::PA_CL_VPORT_YOFFSET));
+    rs.vport_zscale  = flt(rd(st.cx, P::PA_CL_VPORT_ZSCALE));
+    rs.vport_zoffset = flt(rd(st.cx, P::PA_CL_VPORT_ZOFFSET));
+
     return rs;
 }
 
@@ -83,6 +100,24 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     // CB_TARGET_MASK holds a 4-bit write mask per MRT; MRT0 is bits [3:0]. RDNA2's R/G/B/A bit order
     // matches VkColorComponentFlags (R=1,G=2,B=4,A=8), so the nibble maps 1:1.
     ps.color_write_mask = rs.cb_target_mask & 0xFu;
+
+    // Viewport: hardware maps screen = offset + scale * ndc; Vulkan maps px = (x + w/2) + ndc * (w/2).
+    // Equating the two: x = xoffset - xscale, w = 2*xscale (same for y). A guest with GNM's +Y-up NDC
+    // programs a NEGATIVE yscale, which lands here as a negative-height Vulkan viewport (core 1.1) —
+    // the exact hardware Y orientation, with no flip heuristics. Depth: hw z = zoffset + zscale * ndc_z
+    // and Vulkan z = min + ndc_z * (max - min), so min = zoffset, max = zoffset + zscale (clamped to
+    // Vulkan's required [0,1]; a zero zscale/zoffset pair means "never programmed" -> default 0..1).
+    if (rs.vport_xscale != 0.0f && rs.vport_yscale != 0.0f) {
+        ps.has_viewport = true;
+        ps.viewport_x   = rs.vport_xoffset - rs.vport_xscale;
+        ps.viewport_w   = 2.0f * rs.vport_xscale;
+        ps.viewport_y   = rs.vport_yoffset - rs.vport_yscale;
+        ps.viewport_h   = 2.0f * rs.vport_yscale;
+        if (rs.vport_zscale != 0.0f || rs.vport_zoffset != 0.0f) {
+            ps.min_depth = std::clamp(rs.vport_zoffset, 0.0f, 1.0f);
+            ps.max_depth = std::clamp(rs.vport_zoffset + rs.vport_zscale, 0.0f, 1.0f);
+        }
+    }
 
     return ps;
 }

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -48,6 +48,14 @@ struct RenderState {
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)
+
+    // Viewport 0 transform (PA_CL_VPORT_{X,Y,Z}{SCALE,OFFSET} — IEEE-754 floats stored in the context
+    // registers; 0 when the guest never set them). Hardware applies screen = offset + scale * ndc, with
+    // screen-space Y increasing downward — a NEGATIVE yscale is how GNM-style +Y-up NDC reaches the
+    // top-left-origin render target.
+    float vport_xscale = 0, vport_xoffset = 0;
+    float vport_yscale = 0, vport_yoffset = 0;
+    float vport_zscale = 0, vport_zoffset = 0;
 };
 
 // Extract the render-state from a folded GpuState (pure; reads register files only).
@@ -68,6 +76,14 @@ struct ResolvedPipelineState {
     uint32_t dst_color_blend_factor = 0;   // == VkBlendFactor
     uint32_t color_blend_op         = 0;   // == VkBlendOp
     uint32_t color_write_mask       = 0xF; // == VkColorComponentFlags (RGBA); MRT0 nibble of CB_TARGET_MASK
+
+    // Guest viewport as a Vulkan viewport rect. `has_viewport` is false when the guest never programmed
+    // PA_CL_VPORT (then the backend keeps its full-target default). A guest with a negative yscale
+    // resolves to a NEGATIVE viewport_h — Vulkan's core-1.1 (maintenance1) flipped viewport — which
+    // reproduces the hardware's Y orientation exactly.
+    bool  has_viewport = false;
+    float viewport_x = 0, viewport_y = 0, viewport_w = 0, viewport_h = 0;
+    float min_depth = 0.0f, max_depth = 1.0f;
 };
 
 // Translate a RenderState's RDNA2 register semantics into Vulkan-ready pipeline state (pure).

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -887,6 +887,10 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
     dispatch_init(&slots, g_nid_db);
 
     uint64_t n = slots.size();
+    // Zero unresolved imports (e.g. a title whose every import resolved cross-module, or a dump whose
+    // dynamic section yields none): nothing to emit — a 0-byte mmap would fail with EINVAL, so record
+    // the empty table and succeed.
+    if (n == 0) { g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = 0; return true; }
     uint64_t region = page_up(n * stub_size);
     void* want = (void*)stub_base;
     void* got = mmap(want, region, PROT_READ | PROT_WRITE | PROT_EXEC,

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -187,7 +187,12 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
     VkPipelineVertexInputStateCreateInfo vin{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
     VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
     ia.topology = ps ? (VkPrimitiveTopology)ps->topology : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    // Default: full-target viewport. When the resolved state carries the guest's PA_CL_VPORT transform,
+    // honor it — a guest yscale < 0 arrives as a negative viewport_h (Vulkan core-1.1 flipped viewport,
+    // instance is created with apiVersion 1.1 above), reproducing the hardware's Y orientation.
     VkViewport vp{0, 0, (float)W, (float)H, 0, 1}; VkRect2D sc{{0, 0}, {W, H}};
+    if (ps && ps->has_viewport)
+        vp = {ps->viewport_x, ps->viewport_y, ps->viewport_w, ps->viewport_h, ps->min_depth, ps->max_depth};
     VkPipelineViewportStateCreateInfo vpst{VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
     vpst.viewportCount = 1; vpst.pViewports = &vp; vpst.scissorCount = 1; vpst.pScissors = &sc;
     VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};

--- a/prosper/tests/test_pipeline_render.cpp
+++ b/prosper/tests/test_pipeline_render.cpp
@@ -12,6 +12,7 @@
 #include "render_runner.h"
 #include "spirv_triangle.h"
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -108,6 +109,44 @@ int main() {
         printf("  center (z GREATER)   = (%u,%u,%u)\n", r, imgzf[center+1], b);
         CHECK(b > 128 && r < 128, "depth GREATER: fragment z=0 > clear 0.5 fails -> stays blue (depth honored)");
     } else { CHECK(false, "depth GREATER render produced a frame"); }
+
+    // Viewport honored: a guest PA_CL_VPORT with NEGATIVE yscale (GNM's +Y-up NDC) resolves to a
+    // negative-height Vulkan viewport, which must render the scene vertically MIRRORED relative to
+    // the default full-target viewport. Proof: the flipped render matches the default render mirrored
+    // row-by-row (small tolerance for edge fill-rule differences), and the triangle is vertically
+    // asymmetric so the comparison cannot pass vacuously.
+    {
+        namespace P = prosper::agc::Pm4;
+        auto f2u = [](float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; };
+        GpuState st;
+        st.uc[P::VGT_PRIMITIVE_TYPE]   = 4;                    // triangle list
+        st.cx[P::CB_TARGET_MASK]       = 0xF;
+        st.cx[P::PA_CL_VPORT_XSCALE]   = f2u((float)W / 2);    // full-target X
+        st.cx[P::PA_CL_VPORT_XOFFSET]  = f2u((float)W / 2);
+        st.cx[P::PA_CL_VPORT_YSCALE]   = f2u(-(float)H / 2);   // +Y-up NDC -> Vulkan flip
+        st.cx[P::PA_CL_VPORT_YOFFSET]  = f2u((float)H / 2);
+        st.cx[P::PA_CL_VPORT_ZSCALE]   = f2u(1.0f);
+        st.cx[P::PA_CL_VPORT_ZOFFSET]  = f2u(0.0f);
+        ResolvedPipelineState flip = resolve_pipeline_state(extract_render_state(st));
+        CHECK(flip.has_viewport, "PA_CL_VPORT registers resolved to a guest viewport");
+        CHECK(flip.viewport_h == -(float)H && flip.viewport_y == (float)H,
+              "negative yscale resolved to a negative-height (flipped) Vulkan viewport");
+        std::vector<uint8_t> imgf = render_triangle_rgba(vert, frag, W, H, &flip);
+        CHECK(imgf.size() == (size_t)W*H*4, "rendered with flipped guest viewport");
+        if (imgf.size() == (size_t)W*H*4) {
+            auto redat = [&](const std::vector<uint8_t>& im, uint32_t x, uint32_t y) {
+                const uint8_t* p = &im[((size_t)y * W + x) * 4]; return p[0] > 128 && p[2] < 128; };
+            // The default render (`img`, full mask, from above) mirrored must match the flipped render.
+            size_t mismatch = 0, self_mismatch = 0;
+            for (uint32_t y = 0; y < H; y++) for (uint32_t x = 0; x < W; x++) {
+                if (redat(imgf, x, y) != redat(img, x, H - 1 - y)) mismatch++;
+                if (redat(img,  x, y) != redat(img, x, H - 1 - y)) self_mismatch++;
+            }
+            printf("  flip mismatch=%zu asymmetry=%zu (of %u px)\n", mismatch, self_mismatch, W * H);
+            CHECK(mismatch < (size_t)W * H / 50, "flipped viewport == default render mirrored vertically");
+            CHECK(self_mismatch > (size_t)W * H / 50, "triangle is vertically asymmetric (test not vacuous)");
+        }
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_pipeline_state.cpp
+++ b/prosper/tests/test_pipeline_state.cpp
@@ -45,6 +45,20 @@ int main() {
     ResolvedPipelineState def = resolve_pipeline_state(RenderState{});
     CHECK(def.topology == 0 && def.color0_format == 0 && !def.blend_enable && !def.depth_test_enable,
           "empty render-state resolves to a safe default pipeline");
+    CHECK(!def.has_viewport, "empty render-state has no guest viewport (backend keeps full-target default)");
+
+    // GNM-style 1080p viewport: xscale=960 xoffset=960, yscale=-540 yoffset=540 (+Y-up NDC). Resolves to
+    // the Vulkan FLIPPED viewport {x=0, y=1080, w=1920, h=-1080} (negative height = core-1.1 Y flip).
+    RenderState vv;
+    vv.vport_xscale = 960.0f;  vv.vport_xoffset = 960.0f;
+    vv.vport_yscale = -540.0f; vv.vport_yoffset = 540.0f;
+    vv.vport_zscale = 1.0f;    vv.vport_zoffset = 0.0f;
+    ResolvedPipelineState vp = resolve_pipeline_state(vv);
+    CHECK(vp.has_viewport, "programmed PA_CL_VPORT -> has_viewport");
+    CHECK(vp.viewport_x == 0.0f && vp.viewport_w == 1920.0f, "xscale/xoffset 960/960 -> x=0 w=1920");
+    CHECK(vp.viewport_y == 1080.0f && vp.viewport_h == -1080.0f,
+          "negative yscale (-540, +Y-up NDC) -> flipped Vulkan viewport y=1080 h=-1080");
+    CHECK(vp.min_depth == 0.0f && vp.max_depth == 1.0f, "zscale/zoffset 1/0 -> depth range 0..1");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -247,9 +247,11 @@ int main(int argc, char** argv) {
                     }
                 }
                 if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
-                    "[render] ps: topo=%u fmt=%u depth(test=%d write=%d op=%u) blend(en=%d src=%u dst=%u op=%u) mask=0x%x\n",
+                    "[render] ps: topo=%u fmt=%u depth(test=%d write=%d op=%u) blend(en=%d src=%u dst=%u op=%u) mask=0x%x "
+                    "vp(has=%d x=%.1f y=%.1f w=%.1f h=%.1f z=%.3f..%.3f)\n",
                     ps.topology, ps.color0_format, ps.depth_test_enable, ps.depth_write_enable, ps.depth_compare_op,
-                    ps.blend_enable, ps.src_color_blend_factor, ps.dst_color_blend_factor, ps.color_blend_op, ps.color_write_mask);
+                    ps.blend_enable, ps.src_color_blend_factor, ps.dst_color_blend_factor, ps.color_blend_op, ps.color_write_mask,
+                    ps.has_viewport, ps.viewport_x, ps.viewport_y, ps.viewport_w, ps.viewport_h, ps.min_depth, ps.max_depth);
                 // PROSPER_RENDER_NOPS: bypass the game's resolved pipeline state (default state instead) to
                 // isolate whether blend/depth/color-mask is discarding the fragments.
                 const prosper::gpu::ResolvedPipelineState* ps_use = getenv("PROSPER_RENDER_NOPS") ? nullptr : &ps;

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -66,6 +66,14 @@ int main(int argc, char** argv) {
         { d + "/Media/Modules/PS5Util.prx", PS5UTIL },
         { d + "/sce_module/libc.prx", LIBC },
     };
+    // Cross-title tolerance (docs/CROSS_ENGINE_UE4.md step 1, minimal form): drop dependent modules
+    // whose file doesn't exist in this dump — e.g. the UE4 title ships no Il2cpp/PS5Util, so it links
+    // eboot + libc.prx only. The eboot (index 0) is always kept; each module keeps its fixed base.
+    // For the primary target every file exists, so its link is byte-for-byte unchanged.
+    for (size_t i = in.size(); i-- > 1; ) {
+        if (FILE* f = fopen(in[i].path.c_str(), "rb")) fclose(f);
+        else { printf("skipping absent module: %s\n", in[i].path.c_str()); in.erase(in.begin() + (ptrdiff_t)i); }
+    }
     if (!link_program(in, STUB, p, &e)) { printf("link failed: %s\n", e.c_str()); return 1; }
     printf("linked %zu modules; %zu imports (%zu cross-module, %zu stub slots); %zu init fns\n",
            p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(), p.init_fns.size());


### PR DESCRIPTION
# Fix: loading screen rendered upside down — honor the guest viewport (PA_CL_VPORT)

## The bug

Every rendered frame was vertically mirrored — visible on the loading/title screen, which does not progress further, so it was the permanent view of the game:

| Before (upside down) | After (this PR) |
|---|---|
| ![before](https://raw.githubusercontent.com/mattias800/ps5ys/pr-assets/messenger-loading-before.png) | ![after](https://raw.githubusercontent.com/mattias800/ps5ys/pr-assets/messenger-loading-after.png) |

## Root cause

The live render path never consulted the guest's viewport-transform registers. `render_triangle_rgba` (render_runner.h) hardcoded a **positive-height** full-target Vulkan viewport, while the game programs GNM's **+Y-up NDC** convention — a **negative `PA_CL_VPORT_YSCALE`**. On real RDNA2 hardware the viewport transform (`screen = offset + scale × ndc`, screen-Y down) performs the Y flip; skipping it left every frame mirrored.

## The fix (correctness-first, no flip heuristics)

- `extract_render_state` now reads `PA_CL_VPORT_{X,Y,Z}{SCALE,OFFSET}` (IEEE floats in the cx register file) into `RenderState`.
- `resolve_pipeline_state` translates them to a Vulkan viewport rect by equating the two transforms: `x = xoffset − xscale`, `w = 2·xscale` (same for Y). A negative guest yscale therefore lands as a **negative-height Vulkan viewport** (core 1.1 / maintenance1) — the exact hardware Y orientation. Depth range maps `min = zoffset`, `max = zoffset + zscale` (clamped to [0,1]).
- `render_triangle_rgba` honors the resolved viewport; states that never program `PA_CL_VPORT` keep the previous full-target default (all existing tests/paths unchanged).

## Verification (programmatic)

- **ctest 43/43 green**, including two new gates:
  - `test_pipeline_state`: GNM-style 1080p registers (`xscale/xoffset=960/960`, `yscale/yoffset=−540/540`) resolve to `{x=0, y=1080, w=1920, h=−1080}`, depth 0..1; empty state ⇒ `has_viewport=false`.
  - `test_pipeline_render`: end-to-end Vulkan proof — a draw through a flipped guest viewport equals the default render mirrored row-for-row (**0/4096 px mismatch**), with a non-vacuousness guard (the test triangle is measurably asymmetric: 968 px differ between the default render and its own mirror).
- **Live run**: `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_FRAME_DIR=… ./boot_trace <dump>` → 20 frames rendered; the loading screen is right-side up (screenshot above).

## Bonus: cross-title smoke test — the UE4 title (PPSA17942) now reaches its entry point

Per request, the second game in the folder (UE4 4.27, CRIWARE) was booted. Two minimal generalizations from `docs/CROSS_ENGINE_UE4.md` step 1 (second commit):

- `boot_trace` skips dependent modules whose file doesn't exist in the dump (the UE4 title ships no `Il2cpp`/`PS5Util`; The Messenger's link is unchanged since all its files exist).
- `install_stubs` no longer hard-fails on **zero** unresolved imports (`mmap(len=0)` → EINVAL); it records an empty stub table.

Result: the 189 MB UE4 eboot links (eboot + `libc.prx`), maps, and **jumps to its guest entry point**, faulting ~50 bytes in at `eboot+0xb2` — its dynamic section yields 0 imports from this dump, so this is the expected wall. Full UE4 bring-up remains a separate project per the doc.

![ue4 boot result](https://raw.githubusercontent.com/mattias800/ps5ys/pr-assets/ue4-ppsa17942-boot-result.png)

> **Note on screenshots:** to keep game imagery out of mainline history (per the PR #33 policy), the images above live on the non-merge [`pr-assets`](https://github.com/mattias800/ps5ys/tree/pr-assets) branch and are hot-linked. Delete that branch and the images disappear; nothing in this PR's diff contains game content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZDzeB73TmdwmakWEurFB9
