### PR TITLE
diag: PROSPER_GUEST_ENV (guest GC env knobs) + GC-collection-is-not-the-sole-blocker finding

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1127,13 +1127,29 @@ BootResult run_entry(const LoadedImage& img) {
         top -= n; memcpy((void*)top, a.c_str(), n);
         argptrs.push_back(top);
     }
+    // PROSPER_GUEST_ENV="KEY=VAL;KEY=VAL": inject environment strings the guest's libc getenv() will see
+    // (the crt0 envp is otherwise empty). Used to feed the guest's bundled Boehm GC its env knobs
+    // (e.g. GC_DONT_GC=1 to disable collection, or GC_INITIAL_HEAP_SIZE) when investigating GC-driven
+    // corruption. ';'-separated so values may contain '='. CONFIDENCE: HIGH on the SysV envp layout.
+    std::vector<uint64_t> envptrs;
+    if (const char* ge = getenv("PROSPER_GUEST_ENV")) {
+        std::string s(ge); size_t i = 0;
+        while (i < s.size()) {
+            size_t j = s.find(';', i);
+            std::string kv = s.substr(i, j == std::string::npos ? std::string::npos : j - i);
+            if (!kv.empty()) { size_t n = kv.size() + 1; top -= n; memcpy((void*)top, kv.c_str(), n); envptrs.push_back(top); }
+            if (j == std::string::npos) break; i = j + 1;
+        }
+        top &= ~(uint64_t)0xf;
+    }
     top &= ~(uint64_t)0xf;
-    // crt0 vector: argc, argv[0..N-1], NULL, envp NULL, auxv AT_NULL(0,0).
+    // crt0 vector: argc, argv[0..N-1], NULL, envp[0..M-1], NULL, auxv AT_NULL(0,0).
     std::vector<uint64_t> vecv;
     vecv.push_back(args.size());
     for (uint64_t pp : argptrs) vecv.push_back(pp);
     vecv.push_back(0);   // argv terminator
-    vecv.push_back(0);   // envp NULL
+    for (uint64_t pp : envptrs) vecv.push_back(pp);
+    vecv.push_back(0);   // envp terminator
     vecv.push_back(0); vecv.push_back(0);   // auxv AT_NULL
     if (vecv.size() & 1) vecv.push_back(0);   // keep an even count so the ≡8(mod16) placement below holds
     const uint64_t* vec = vecv.data(); size_t vecsz = vecv.size() * sizeof(uint64_t);


### PR DESCRIPTION
## `PROSPER_GUEST_ENV` — inject env into the guest crt0 envp (for GC investigation)

The guest's libc `getenv()` saw an empty environment (crt0 `envp` was `NULL`), so the game's bundled Boehm
GC could not read its env knobs. `PROSPER_GUEST_ENV="KEY=VAL;KEY=VAL"` populates `envp` so e.g.
`GC_DONT_GC=1` / `GC_INITIAL_HEAP_SIZE` reach the guest GC — used to test whether GC collection is the
cutscene-activation blocker.

### Finding (data for the ongoing cutscene work)
- `GC_DONT_GC=1` removes the **loader-thread GC block-lookup fault** (`Il2cpp+0x5980`, a `mov 0x20(%r12)`
  with `r12`=null GC block, i.e. the GC dereferencing a freed-but-referenced object) on the pre-pread-fix base.
- With the merged pread short-read fix (#39) already fixing the asset-stream corruption, `GC_DONT_GC` + no
  render still does **not** activate the cutscene scene — the game plateaus at `resources.assets` block ~967
  and worker threads still fault on residual null derefs (`Il2cpp+0xb03b` / `+0x1cc40`).
- **Conclusion:** GC collection is not the sole blocker; residual deserialization/init corruption + scene
  activation remain the wall (consistent with #37's "Unexpected state" GC-abort pinning).

49/49 ctest green; default boot unchanged (opt-in env var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
