### PR TITLE
Fix the level1 (cutscene) load crash — GC allocation lock never locked

### DIFF
--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -166,3 +166,28 @@ remove the GC abort.
 (top open lead: a Unity job-worker created/exiting *during* a stop-the-world — see
 `CUTSCENE_GC_ABORT.md`), AND then the per-draw/multi-draw executor (PR #31) to render the
 cutscene's `mask=0`/`color0_base=0` draws. Neither is a small change.
+
+## 2026-07-07 (third pass) — CORRECTION: the async scene load COMPLETES; the crash is AT activation, not a load stall
+
+Independent re-verification on the current tip (`334dc7f`), `PROSPER_GUEST_FS=1
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PREADLOG=1`. Earlier passes said the load "plateaus ~block 977
+(≈82%)" and "crashes before the load finishes and the scene can activate". That framing is **wrong** — the
+async load runs to completion:
+```
+[preadlog] pread  resources.assets … off=0x49f0000 (blk 1183, ≈97% of the 77.6 MB file)
+[preadlog] close  sharedassets1.assets
+[preadlog] close  level1
+[preadlog] close  resources.assets      <-- Unity closes every scene file: the async load reached 100%
+=== RUN ENDED: SIGSEGV at addr=0x20  rip=Il2cpp+0x1637697 ===   <-- crash fires immediately after
+```
+So the crash is **at scene ACTIVATION** (the main-thread integrate/activate step that runs right after the
+async load closes its files), not a mid-load stall and not an `allowSceneActivation`/progress gate. Every
+one of the preceding ~3000–7500 submits is the level0 1-draw loading composite; the cutscene's multi-draw
+geometry is never submitted because the process dies the instant activation begins. Also re-confirmed this
+pass: no `unimplemented -> returning 0` HLE call fires at activation (last calls are all implemented AGC
+direct-mode), and the `Il2cpp+0x1637697` null (`[callerObj+0x40]`) persists with the incremental-GC pump
+patched to `ret` (`PROSPER_PATCH_RET=0x440005df0`) — so this null is the deser/init one, independent of the
+GC. Which specific terminal fault wins (`Il2cpp+0x1637697` activation-NRE vs. the `libc.prx+0x4a20` GC
+"Unexpected state" abort) is timing-dependent, but both fire at/just-before activation. **Net: the single
+remaining blocker is unchanged — populate the null managed field `[callerObj+0x40]` on the activation path
+(and/or fix the GC stop-the-world race) — but the scene now provably loads to 100% first.**

--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -1,0 +1,70 @@
+# Title/loading screen → cutscene: progression investigation (2026-07-07)
+
+**Goal:** advance the game past the loading screen (the "Werewolf" title art) into the first cutscene
+(mostly-black background + text, 8-bit graphics).
+
+## What was fixed — `sceSystemServiceParamGetString` (committed)
+
+The single biggest blocker was a one-line HLE gap. `sceSystemServiceParamGetString` (NID `SsC-m-S9JTA`)
+was **not registered**, so it fell through to the default `unimplemented → returning 0` stub. That returns
+`0` (Sony SUCCESS) **without writing the caller's string buffer**, so the game read the uninitialized
+buffer as a "valid" system string and dereferenced into it → a null-object crash in managed (Il2cpp) code
+(`SIGSEGV addr=0x20` at `Il2cpp+0x1637697`), reached right after the call.
+
+Implemented it to match this HLE's policy (never leave an output uninitialized): write a valid empty
+NUL-terminated string and report success. **Effect: the game goes from crashing at `SubmitDcb #46` to
+running thousands of frames (`#6530`+) and actively streaming the cutscene scene.** How it was found: the
+NID resolves to `sceSystemServiceParamGetString` (computed via `nid_hash`), and it was the last unimplemented
+call logged before the crash; the faulting instruction (`cmpb $0x0, 0x20(%rbx)`, `rbx=null`) confirmed a
+null-object deref.
+
+## Where the game is now — actively loading the cutscene, then a per-frame Il2cpp crash
+
+With the fix, the game:
+1. Renders and fades in the loading screen (time-driven animation works — verified via frame dumps).
+2. **Streams the cutscene scene's assets**: the loader thread `pread`s progressively through
+   `resources.assets` (77 MB) to ~block 977 (≈82%), plus `resources.resource` / `sharedassets1.assets`
+   (verified with `PROSPER_PREADLOG`; offsets increase monotonically — it is loading, not spinning).
+3. **Crashes on the main thread inside a per-frame Il2cpp runtime call**, before the load finishes and the
+   scene can activate.
+
+### The crash (the remaining blocker)
+
+Every crash shares one call chain from Unity's frame loop:
+```
+eboot+0x147b494 (frame loop) → eboot+0xa8c989 → Il2cpp+0x49d1 → …null-deref
+```
+`Il2cpp+0x49d1` is the return address of a `call 0x5df0` inside a **locked critical section** (acquire
+`[0x267d8a8]` → check a flag → call) — an Il2cpp runtime per-frame pump (GC/finalizer-class). The actual
+fault rip **varies across runs** (`Il2cpp+0x5980`, `+0x1637697`, and a `memcpy(dst, NULL, 8)` at
+`libc.prx+0x4a20`), always a **null / `+0x20`-of-null** dereference. One reachable path leads to an Il2cpp
+abort (`ud2` after loading an error string; the string table there holds `"Unexpected state."`,
+`"No space for mark stack"` — GC messages).
+
+**Interpretation (CONFIDENCE: MED):** the non-deterministic null derefs of managed objects, correlated with
+the cutscene-scene load, point to **deserialization producing corrupt objects** (a managed reference left
+null) that then crash when a per-frame update/GC/finalizer touches them — i.e. the same Unity
+`CachedReader`/`FileCacher` deserialization frontier documented in `DESER_STALE_CACHE_BLOCK.md`
+(loader callers `eboot+0x93a810` / `0xb1767e` match). GC-heap corruption under the scene's heavy allocation
+is the alternative/compounding cause. It is **not** a worker-thread fault (0 observed) and **not** a missing
+HLE call (no unimplemented call fires during the steady-state load).
+
+## Next steps (for reaching the cutscene)
+
+1. **Resolve the scene-load deserialization corruption** (the `FileCacher` stale-block issue in
+   `DESER_STALE_CACHE_BLOCK.md`): a corrupt deserialized object is the most likely source of the null a
+   per-frame update dereferences. Verify by dumping the object graph around the block-977 asset.
+2. **GC stability under load**: confirm our stop-the-world root scanning covers all roots during the
+   cutscene's allocation storm (the `"No space for mark stack"` string suggests GC mark-stack pressure).
+3. **Rendering** (once the game survives to the cutscene): the cutscene's draws currently resolve with
+   `color_write_mask==0` / `color0_base==0` and are skipped by the single-draw executor — the per-draw
+   state / multi-draw executor work addresses this. The guest scanout buffer is black because our renderer
+   targets Vulkan, not guest memory (`PROSPER_DUMP_SCANOUT` confirms).
+
+## Reproduce
+```sh
+VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json \
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PREADLOG=1 \
+  ./build/boot_trace /path/to/PPSA24651-app0
+# watch resources.assets block offsets climb, then a main-thread SIGSEGV in the Il2cpp+0x49d1 chain.
+```

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -32,7 +32,7 @@ namespace {
 // --- PM4 encoding (Kyty Pm4.h) ---------------------------------------------------------------
 constexpr uint32_t IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46, IT_SET_SH_REG = 0x76;
 // Custom sub-opcodes carried inside IT_NOP:
-constexpr uint32_t R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
+constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
                    R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
                    R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
                    R_RELEASE_MEM = 0x18;
@@ -111,6 +111,28 @@ HLE(agc_dcb_draw_index_auto) {  // (buf, index_count, modifier)
     uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DRAW_INDEX_AUTO, &cmd)) return 0;
     cmd[1] = (uint32_t)a1; cmd[2] = 0; return (uint64_t)(uintptr_t)cmd;
 }
+// sceAgcDcbDrawIndex (NID q88lQ+GP5Yk, name via shadPS4 aerolib.inl) — the indexed-draw sibling of
+// DrawIndexAuto. Kyty has no Gen5 reference; arg shape inferred from the Gen4 form
+// (index_count, index_addr, …) + the Gen5 Dcb convention (buf first, modifier last):
+// (Dcb* buf, uint32_t index_count, const void* indices, uint64_t modifier). CONFIDENCE: LOW on
+// a2/a3 meaning — the packet stores them raw and pm4_decode currently skips R_DRAW_INDEX (indexed
+// draws are the documented "remaining polish"). What this fixes NOW: every Dcb append returns the
+// allocated packet pointer, and the previous unimplemented stub returned 0 — a caller patching
+// its draw packet through that return (the AGC patch idiom, cf. agc_patch_set_address) would have
+// written through NULL/garbage instead of into the DCB.
+HLE(agc_dcb_draw_index) {
+    uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DRAW_INDEX, &cmd)) return 0;
+    cmd[1] = (uint32_t)a1;
+    cmd[2] = (uint32_t)(a2 & 0xffffffffu); cmd[3] = (uint32_t)(a2 >> 32u);
+    cmd[4] = (uint32_t)(a3 & 0xffffffffu); cmd[5] = (uint32_t)(a3 >> 32u);
+    cmd[6] = 0;
+    return (uint64_t)(uintptr_t)cmd;
+}
+// sceAgcSuspendPoint (NID h9z6+0hEydk, name via shadPS4) — the TRC R5089 GPU suspend point the
+// game forces in a loop ("Forcing call to sce::Agc::suspendPoint" spam). It has no out-params and
+// no game-visible state; on a devkit it just gives the system a safe suspend opportunity.
+// Returning 0 (OK) is the full contract for us — registered so it stops logging as unimplemented.
+HLE(agc_suspend_point) { return 0; }
 HLE(agc_dcb_event_write) {  // (buf, event_type, address)
     uint32_t* cmd; if (!begin_packet(a0, 2, IT_EVENT_WRITE, 0, &cmd)) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffu); return (uint64_t)(uintptr_t)cmd;
@@ -615,6 +637,8 @@ void register_agc_hle() {
     RN("hvUfkUIQcOE", agc_dcb_set_uc_regs_indirect);
     RN("GIIW2J37e70", agc_dcb_set_index_size);
     RN("Yw0jKSqop+E", agc_dcb_draw_index_auto);
+    RN("q88lQ+GP5Yk", agc_dcb_draw_index);      // sceAgcDcbDrawIndex (see handler comment)
+    RN("h9z6+0hEydk", agc_suspend_point);       // sceAgcSuspendPoint — no-op OK
     RN("aJf+j5yntiU", agc_dcb_event_write);
     RN("57labkp+rSQ", agc_dcb_acquire_mem);
     RN("wr23dPKyWc0", agc_cb_release_mem);

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -28,12 +28,31 @@ namespace prosper {
 namespace {
     std::string g_app0;   // host directory backing guest "/app0"
     bool filelog() { static int v = getenv("PROSPER_FILELOG") ? 1 : 0; return v; }
+    // Host directory backing guest "/temp0" — the app temp-data area that
+    // sceAppContentTemporaryDataMount2 (hle_service.cpp) reports to the game. Created on first
+    // use; override with PROSPER_TEMP0. A scratch dir outside the dump keeps the game's writes
+    // out of /app0 (which is read-only content).
+    std::string temp0_root() {
+        static std::string root;
+        if (root.empty()) {
+            const char* e = getenv("PROSPER_TEMP0");
+            root = e ? e : "/tmp/prosper-temp0";
+#ifdef _WIN32
+            _mkdir(root.c_str());
+#else
+            ::mkdir(root.c_str(), 0777);
+#endif
+        }
+        return root;
+    }
     std::string translate(const char* guest) {
         if (!guest) return {};
         std::string p = guest;
         if (g_app0.empty()) { if (const char* e = getenv("PROSPER_APP0")) g_app0 = e; }
-        // Map /app0[/...] -> <root>[/...]; leave other absolute paths as-is.
-        std::string h = (p.rfind("/app0", 0) == 0) ? g_app0 + p.substr(5) : p;
+        // Map /app0[/...] -> <root>[/...], /temp0[/...] -> scratch dir; other paths as-is.
+        std::string h = (p.rfind("/app0", 0) == 0)  ? g_app0 + p.substr(5)
+                      : (p.rfind("/temp0", 0) == 0) ? temp0_root() + p.substr(6)
+                      : p;
         if (filelog()) fprintf(stderr, "[file] open '%s' -> '%s'\n", guest, h.c_str());
         return h;
     }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -620,6 +620,12 @@ void register_kernel_hle() {
     R("sceKernelWaitSema", k_sema_wait);        R("sceKernelSignalSema", k_sema_signal);
     R("sceKernelPollSema", k_sema_poll);
     R("sceKernelGetModuleInfoForUnwind", k_get_module_info_for_unwind);   // C++ exception unwinding
+    // sceSysmoduleGetModuleInfoForUnwind (libSceSysmodule, NID 4fU5yvOkVG4): same contract — shadPS4's
+    // implementation just delegates to sceKernelGetModuleInfoForUnwind (sysmodule.cpp:31). It was an
+    // unimplemented stub returning 0 (= SUCCESS) with the caller's 0x130-byte info struct left
+    // uninitialized, so any exception unwound through a sysmodule-resolved frame read a garbage
+    // eh_frame_hdr — the same stack-smash failure mode the kernel variant had before it was implemented.
+    Hle::register_fn("4fU5yvOkVG4", (HleFn)k_get_module_info_for_unwind, "sceSysmoduleGetModuleInfoForUnwind");
     // Registration / hook / debug libkernel calls the app makes at startup that have no observable
     // effect in our headless boot — returning OK without side effects is the correct behavior:
     //  - SetThreadDtors / SetThreadAtexitCount / SetThreadAtexitReport: per-thread exit bookkeeping;

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -58,6 +58,62 @@ HLE(k_mutexattr_setpshared)  { return 0; }
 HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 
 // --- mutexes ---
+// FreeBSD/PS5 pthread objects are POINTERS, and a STATICALLY-INITIALIZED object is a small
+// sentinel (PTHREAD_MUTEX_INITIALIZER == NULL, adaptive == 1, ...). Real libthr SELF-INITIALIZES
+// such an object on first use (Kyty models the same with its PthreadStaticObject lazy creation).
+// We previously treated a NULL handle as a no-op that RETURNED SUCCESS — which silently voided
+// every statically-initialized lock. ROOT CAUSE of the level1 scene-load heap corruption: the
+// IL2CPP/bdwgc GC allocation lock (GC_allocate_ml, a static PTHREAD_MUTEX_INITIALIZER in
+// Il2cppUserAssemblies' .bss, locked via libScePosix pthread_mutex_trylock/lock) never locked,
+// so the collector raced concurrently-allocating / lazy-sweeping mutator threads and corrupted
+// the GC free lists ("Rewired_" ASCII popped as a free-list link, marker ABORT "Unexpected
+// state", varying downstream SIGSEGVs). Self-init closes that class for mutex/cond/rwlock.
+// CONFIDENCE: HIGH (semantics cross-checked against FreeBSD libthr + the Kyty reference).
+namespace {
+    inline bool pt_static_sentinel(void* v) { return (uintptr_t)v < 0x1000; }  // NULL/1/2/3... = static initializer
+    pthread_mutex_t* ensure_mutex(uint64_t slot_addr) {
+        if (!slot_addr) return nullptr;
+        void** slot = (void**)(uintptr_t)slot_addr;
+        void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+        if (!pt_static_sentinel(cur)) return (pthread_mutex_t*)cur;
+        auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
+        pthread_mutexattr_t at; pthread_mutexattr_init(&at);
+        pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE);
+        pthread_mutex_init(m, &at);
+        pthread_mutexattr_destroy(&at);
+        if (__atomic_compare_exchange_n(slot, &cur, (void*)m, false,
+                                        __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+            return m;
+        pthread_mutex_destroy(m); free(m);          // lost the init race: use the winner's object
+        return (pthread_mutex_t*)cur;
+    }
+    pthread_cond_t* ensure_cond(uint64_t slot_addr) {
+        if (!slot_addr) return nullptr;
+        void** slot = (void**)(uintptr_t)slot_addr;
+        void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+        if (!pt_static_sentinel(cur)) return (pthread_cond_t*)cur;
+        auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t));
+        pthread_cond_init(c, nullptr);
+        if (__atomic_compare_exchange_n(slot, &cur, (void*)c, false,
+                                        __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+            return c;
+        pthread_cond_destroy(c); free(c);
+        return (pthread_cond_t*)cur;
+    }
+    pthread_rwlock_t* ensure_rwlock(uint64_t slot_addr) {
+        if (!slot_addr) return nullptr;
+        void** slot = (void**)(uintptr_t)slot_addr;
+        void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
+        if (!pt_static_sentinel(cur)) return (pthread_rwlock_t*)cur;
+        auto* rw = (pthread_rwlock_t*)calloc(1, sizeof(pthread_rwlock_t));
+        pthread_rwlock_init(rw, nullptr);
+        if (__atomic_compare_exchange_n(slot, &cur, (void*)rw, false,
+                                        __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+            return rw;
+        pthread_rwlock_destroy(rw); free(rw);
+        return (pthread_rwlock_t*)cur;
+    }
+}
 HLE(k_mutex_init) {
     if (!a0) return 0x16;
     auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
@@ -69,20 +125,21 @@ HLE(k_mutex_init) {
     *(void**)a0 = m;
     return 0;
 }
-HLE(k_mutex_destroy) { if (a0 && *(void**)a0) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)a0); free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
-HLE(k_mutex_lock)    { if (a0 && *(void**)a0) pthread_mutex_lock((pthread_mutex_t*)*(void**)a0); return 0; }
-HLE(k_mutex_trylock) { return (a0 && *(void**)a0) ? (uint64_t)pthread_mutex_trylock((pthread_mutex_t*)*(void**)a0) : 0x16; }
-HLE(k_mutex_unlock)  { if (a0 && *(void**)a0) pthread_mutex_unlock((pthread_mutex_t*)*(void**)a0); return 0; }
+HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
+HLE(k_mutex_lock)    { if (auto* m = ensure_mutex(a0)) pthread_mutex_lock(m); return 0; }
+HLE(k_mutex_trylock) { auto* m = ensure_mutex(a0); return m ? (uint64_t)pthread_mutex_trylock(m) : 0x16; }
+HLE(k_mutex_unlock)  { if (auto* m = ensure_mutex(a0)) pthread_mutex_unlock(m); return 0; }
 
 // --- condition variables ---
 HLE(k_condattr_init)    { if (a0) { auto* c = (pthread_condattr_t*)calloc(1, sizeof(pthread_condattr_t)); pthread_condattr_init(c); *(void**)a0 = c; } return 0; }
 HLE(k_condattr_destroy) { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 HLE(k_cond_init)      { if (!a0) return 0x16; auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)a0 = c; return 0; }
-HLE(k_cond_destroy)   { if (a0 && *(void**)a0) { pthread_cond_destroy((pthread_cond_t*)*(void**)a0); free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
-HLE(k_cond_signal)    { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (a0 && *(void**)a0) pthread_cond_signal((pthread_cond_t*)*(void**)a0); return 0; }
-HLE(k_cond_broadcast) { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (a0 && *(void**)a0) pthread_cond_broadcast((pthread_cond_t*)*(void**)a0); return 0; }
+HLE(k_cond_destroy)   { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_cond_destroy((pthread_cond_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
+HLE(k_cond_signal)    { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) pthread_cond_signal(c); return 0; }
+HLE(k_cond_broadcast) { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) pthread_cond_broadcast(c); return 0; }
 HLE(k_cond_wait)      { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
-    if (a0 && *(void**)a0 && a1 && *(void**)a1) pthread_cond_wait((pthread_cond_t*)*(void**)a0, (pthread_mutex_t*)*(void**)a1);
+    { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
+      if (c && m) pthread_cond_wait(c, m); }
     if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
 
 // --- read/write locks (opaque handle -> host pthread_rwlock_t). Real libc.prx uses these for its
@@ -95,12 +152,12 @@ HLE(k_rwlock_init) {
     *(void**)a0 = rw;   // store handle through caller's slot (a1=attr, a2=name ignored)
     return 0;
 }
-HLE(k_rwlock_destroy) { if (a0 && *(void**)a0) { pthread_rwlock_destroy((pthread_rwlock_t*)*(void**)a0); free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
-HLE(k_rwlock_rdlock)  { if (a0 && *(void**)a0) pthread_rwlock_rdlock((pthread_rwlock_t*)*(void**)a0); return 0; }
-HLE(k_rwlock_wrlock)  { if (a0 && *(void**)a0) pthread_rwlock_wrlock((pthread_rwlock_t*)*(void**)a0); return 0; }
-HLE(k_rwlock_unlock)  { if (a0 && *(void**)a0) pthread_rwlock_unlock((pthread_rwlock_t*)*(void**)a0); return 0; }
-HLE(k_rwlock_tryrdlock){ return (a0 && *(void**)a0) ? (uint64_t)pthread_rwlock_tryrdlock((pthread_rwlock_t*)*(void**)a0) : 0x16; }
-HLE(k_rwlock_trywrlock){ return (a0 && *(void**)a0) ? (uint64_t)pthread_rwlock_trywrlock((pthread_rwlock_t*)*(void**)a0) : 0x16; }
+HLE(k_rwlock_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_rwlock_destroy((pthread_rwlock_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
+HLE(k_rwlock_rdlock)  { if (auto* rw = ensure_rwlock(a0)) pthread_rwlock_rdlock(rw); return 0; }
+HLE(k_rwlock_wrlock)  { if (auto* rw = ensure_rwlock(a0)) pthread_rwlock_wrlock(rw); return 0; }
+HLE(k_rwlock_unlock)  { if (auto* rw = ensure_rwlock(a0)) pthread_rwlock_unlock(rw); return 0; }
+HLE(k_rwlock_tryrdlock){ auto* rw = ensure_rwlock(a0); return rw ? (uint64_t)pthread_rwlock_tryrdlock(rw) : 0x16; }
+HLE(k_rwlock_trywrlock){ auto* rw = ensure_rwlock(a0); return rw ? (uint64_t)pthread_rwlock_trywrlock(rw) : 0x16; }
 
 // scePthreadOnce(once_control*, init_routine): run init exactly once. We run it UNDER a lock so all
 // callers see it complete before returning (pthread_once semantics). A recursive mutex avoids
@@ -373,12 +430,49 @@ void set_unwind_modules(const UnwindModuleDesc* d, size_t c) { g_unwind_mods.ass
 namespace {
 uint64_t g_exc_handlers[128] = {0};   // guest handler fn ptr, indexed by exception type
 bool g_exc_log = false;               // set once (outside signal ctx) from PROSPER_SYNCLOG
+// PROSPER_EXCLOG: dedicated, cheap GC stop-the-world tracing (raise/deliver/ack) — used to correlate
+// GC suspend cycles with the level1 loader heap-corruption crash. Independent of the very verbose
+// PROSPER_SYNCLOG. Read once (getenv is not signal-safe).
+bool g_exc_log2 = false;
 volatile int* g_exc_counter = nullptr; // optional fork-safe raise counter (tests)
 #ifdef __linux__
 int  g_exc_sig = -1;
 void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
     int type = si->si_value.sival_int;
-    if (type < 0 || type >= 128 || !g_exc_handlers[type]) return;
+    if (type < 0 || type >= 128 || !g_exc_handlers[type]) {
+        if (g_exc_log2) {   // a suspend request that silently does NOTHING = an unstopped thread
+            // %fs-safe: this handler can interrupt guest code running on the GUEST %fs, where host
+            // libc TLS (locale, stack canary) reads garbage — swap to host %fs for the logging.
+            uint64_t sfs = guest_fs_to_host_scoped();
+            char b[96]; int n = snprintf(b, sizeof b, "[exc2] DROPPED type=%d tid=%ld (no handler)\n",
+                                         type, (long)syscall(SYS_gettid));
+            (void)!write(2, b, n);
+            guest_fs_restore_scoped(sfs);
+        }
+        return;
+    }
+    if (g_exc_log2) {
+        // Log the interrupted context: rip (classified guest module+off / host) and whether the
+        // thread was on the guest or host %fs at interrupt time. %fs-safe (scoped host swap).
+        uint64_t irip = (uint64_t)((ucontext_t*)uc_)->uc_mcontext.gregs[REG_RIP];
+        uint64_t sfs = guest_fs_to_host_scoped();
+        const char* fss = sfs ? "guest" : "host";
+        char b[160]; int n;
+        if (irip >= 0x400000000ull && irip < 0x420000000ull)
+            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=eboot+0x%llx\n",
+                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)(irip - 0x400000000ull));
+        else if (irip >= 0x440000000ull && irip < 0x443000000ull)
+            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=il2cpp+0x%llx\n",
+                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)(irip - 0x440000000ull));
+        else if (irip >= 0x500000000ull && irip < 0x501000000ull)
+            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=libc+0x%llx\n",
+                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)(irip - 0x500000000ull));
+        else
+            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=host:0x%llx\n",
+                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)irip);
+        (void)!write(2, b, n);
+        guest_fs_restore_scoped(sfs);
+    }
     auto* uc = (ucontext_t*)uc_;
     greg_t* g = uc->uc_mcontext.gregs;
     // FreeBSD amd64 mcontext_t: rdi@0x08 rsi@0x10 rdx@0x18 rcx@0x20 r8@0x28 r9@0x30 rax@0x38
@@ -404,10 +498,18 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
     if (g_exc_log) { const char m[] = "[exc] handler ENTER on target\n"; (void)!write(2, m, sizeof m - 1); }
     ((void (*)(uint64_t, void*))(uintptr_t)g_exc_handlers[type])((uint64_t)type, ctx);
     if (g_exc_log) { const char m[] = "[exc] handler EXIT (resumed)\n";   (void)!write(2, m, sizeof m - 1); }
+    if (g_exc_log2) {
+        uint64_t sfs = guest_fs_to_host_scoped();   // %fs-safe logging (see ENTER)
+        char b[96]; int n = snprintf(b, sizeof b, "[exc2] RESUME tid=%ld type=%d\n",
+                                     (long)syscall(SYS_gettid), type);
+        (void)!write(2, b, n);
+        guest_fs_restore_scoped(sfs);
+    }
 }
 void ensure_exc_sig() {
     if (g_exc_sig != -1) return;
     g_exc_log = getenv("PROSPER_SYNCLOG") != nullptr;
+    g_exc_log2 = getenv("PROSPER_EXCLOG") != nullptr;
     g_exc_sig = SIGRTMIN + 4;                    // free RT signal (not our SIGSEGV/ILL/BUS)
     struct sigaction sa; memset(&sa, 0, sizeof sa);
     sa.sa_sigaction = exc_delivery_handler;
@@ -444,7 +546,14 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
 #ifdef __linux__
     if (a0 && a1 < 128 && g_exc_handlers[a1]) {
         union sigval sv; sv.sival_int = (int)a1;
-        pthread_sigqueue((pthread_t)a0, g_exc_sig, sv);
+        int qr = pthread_sigqueue((pthread_t)a0, g_exc_sig, sv);
+        if (g_exc_log2)
+            fprintf(stderr, "[exc2] RAISE by tid=%ld target=0x%llx type=0x%llx sigqueue=%d\n",
+                    sctid(), (unsigned long long)a0, (unsigned long long)a1, qr);
+        if (qr != 0) return 0x80020000u | (uint32_t)qr;   // deliverance FAILED — report, don't lie
+    } else if (g_exc_log2) {
+        fprintf(stderr, "[exc2] RAISE-NOOP by tid=%ld target=0x%llx type=0x%llx (no handler)\n",
+                sctid(), (unsigned long long)a0, (unsigned long long)a1);
     }
 #endif
     return 0;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -91,7 +91,25 @@ HLE(k_reserve_vrange) {
     uint64_t align = a3 ? a3 : 0x4000;
     if (hint) {
         void* p = mmap((void*)hint, a1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
-        if (p == MAP_FAILED) { MLOG("reserve hint=0x%llx FAILED\n", (unsigned long long)hint); return 0x16; }
+        if (p == MAP_FAILED) {
+            // The hint region is already mapped. If it's ALREADY one of OUR reservations (uncommitted),
+            // the guest is re-reserving its own fixed range — PS5's reserve is idempotent for the caller's
+            // own range (the game's allocator no-hint-reserves, records the base, then re-claims it with a
+            // fixed hint). Returning an error here made the guest allocator hand back NULL, which the level1
+            // asset-load FileCacher then memcpy'd from (crash: memcpy(dst, NULL, n) during deserialization).
+            // Treat a re-reserve of our own reservation as success. CONFIDENCE: HIGH (matches the observed
+            // no-hint@line23 -> fixed-hint@line143 collision that precedes the loader-thread SIGSEGV).
+            bool ours = false;
+            { std::lock_guard<std::mutex> lk(g_mx);
+              for (auto& m : g_maps)
+                  if (!m.committed && hint >= m.base && hint < m.base + m.size) { ours = true; break; } }
+            if (ours) {
+                if (a0) *(uint64_t*)a0 = hint;
+                MLOG("reserve hint=0x%llx re-reserve-of-own-range -> OK\n", (unsigned long long)hint);
+                return 0;
+            }
+            MLOG("reserve hint=0x%llx FAILED\n", (unsigned long long)hint); return 0x16;
+        }
         if (a0) *(uint64_t*)a0 = (uint64_t)p;
         track((uint64_t)p, a1, 0, false, "reserved");
         MLOG("reserve(hint) -> 0x%llx len=0x%llx align=0x%llx\n", (unsigned long long)p, (unsigned long long)a1, (unsigned long long)align);

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -258,8 +258,37 @@ HLE(h_execute_once) {
 HLE(h_cxa_dec_refcount) { return 0; }
 HLE(h_cxa_inc_refcount) { return 0; }
 
+// sceLibcHeapGetTraceInfo (libSceLibcInternalExt, NID NWtTN10cJzE) — the guest allocator's
+// malloc-trace coordination block. Contract (Kyty LibC.cpp:139 + shadPS4 kernel.cpp:161, identical):
+// the caller passes a 32-byte struct { u64 size(=32, caller-set); u32 flag; u32 getSegmentInfo;
+// u64* mspace_atomic_id_mask; u64* mstate_table } and the callee fills the two pointers with
+// PERSISTENT storage (Kyty: static u64 + static u64[64]) that the guest mspace allocator then
+// reads AND WRITES on allocation paths. Our previous behavior (unimplemented stub -> return 0,
+// struct untouched) handed the guest two garbage stack values as pointers: every subsequent
+// traced-mspace operation stored through random addresses — silent heap/stack corruption that
+// surfaces only under heavy allocation (e.g. the level1 resources.assets loader thread).
+// CONFIDENCE: HIGH — two independent references agree on layout and semantics.
+namespace { uint64_t g_mspace_atomic_id_mask = 0; uint64_t g_mstate_table[64] = {0}; }
+HLE(h_heap_get_trace_info) {
+    uint8_t* info = (uint8_t*)P(a0);
+    if (!info) return 0;
+    // The size field is caller-set; only fill the layout we know (exactly 32 bytes — never write
+    // past the caller's struct; cf. the f_fstat oversized-write lesson).
+    if (*(uint64_t*)info != 32) {
+        fprintf(stderr, "[prosper] sceLibcHeapGetTraceInfo: unexpected info->size=%llu (want 32) — leaving untouched\n",
+                (unsigned long long)*(uint64_t*)info);
+        return 0;
+    }
+    *(uint32_t*)(info + 0x0c)  = 0;                        // getSegmentInfo: no segment-info callback
+    *(uint64_t**)(info + 0x10) = &g_mspace_atomic_id_mask; // persistent, zero-initialized
+    *(uint64_t**)(info + 0x18) = g_mstate_table;
+    return 0;
+}
+
 void register_builtin_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
+    // libSceLibcInternalExt heap-trace hookup (raw NID — guaranteed match; see handler comment).
+    Hle::register_fn("NWtTN10cJzE", (HleFn)h_heap_get_trace_info, "sceLibcHeapGetTraceInfo");
     R("memcpy", h_memcpy);   R("memmove", h_memmove); R("memset", h_memset);
     R("memcmp", h_memcmp);   R("memchr", h_memchr);
     R("strlen", h_strlen);   R("strnlen", h_strnlen);

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -78,6 +78,14 @@ HLE(s_appcontent_tmpmount2) {
 // value games use to size caches/allocations.
 HLE(s_appcontent_tmpspace) { if (a1) *(uint64_t*)PW(a1) = 1048576ull; return 0; }
 
+// sceSystemServiceParamGetString(paramId, char* buf, size_t bufSize): fetch a system string parameter
+// (e.g. the console/user nickname). The default unimplemented stub returned 0 (SUCCESS) but never wrote
+// the buffer, so the game read whatever uninitialized bytes were there as a "valid" string and derefed
+// into it (null-deref crash in managed code during scene load). Match this file's policy: write a valid
+// NUL-terminated string and report success. CONFIDENCE: MED — signature (paramId, buf, size) is the
+// documented Sony ABI; an empty string is a safe, defined default when we have no real system value.
+HLE(s_param_string)   { if (a1 && a2) ((char*)PW(a1))[0] = '\0'; return 0; }
+
 // Common/message dialogs: report FINISHED immediately so the game's "wait until dismissed" loop
 // exits and it proceeds (we have no interactive dialog UI yet). Status enum: NONE=0, INITIALIZED=1,
 // RUNNING=2, FINISHED=3. GetResult -> zeroed struct = OK/no button pressed.
@@ -135,6 +143,8 @@ void register_service_hle() {
     Hle::register_fn("bcolXMmp6qQ", (HleFn)s_ok,                  "sceAppContentTemporaryDataUnmount");
     R("sceCommonDialogInitialize", s_ok);
     R("sceSystemServiceParamGetInt", s_appcontent_int);
+    // sceSystemServiceParamGetString (SsC-m-S9JTA): write a valid empty string (not an unfilled buffer).
+    Hle::register_fn("SsC-m-S9JTA", (HleFn)s_param_string, "sceSystemServiceParamGetString");
     // message dialog: auto-dismiss (report FINISHED) so the startup dialog flow completes
     R("sceMsgDialogInitialize", s_ok);      R("sceMsgDialogTerminate", s_ok);
     R("sceMsgDialogOpen", s_ok);            R("sceMsgDialogClose", s_ok);

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -41,6 +41,7 @@ HLE(s_user_getevent)  {
     return 0x80960007ull;   // SCE_USER_SERVICE_ERROR_NO_EVENT
 }
 HLE(s_ok)             { return 0; }
+HLE(s_gamepresets)    { return 0x80960006ull; }   // SCE_USER_SERVICE_ERROR_OPERATION_NOT_SUPPORTED (see reg. comment)
 
 // --- NP / online (single-player: report signed-out / unreachable, success) ---
 HLE(s_np_state)       { if (a1) *(int32_t*)PW(a1) = 1; return 0; }           // SCE_NP_STATE_SIGNED_OUT
@@ -59,11 +60,32 @@ HLE(s_mouse_read)     { if (a1) memset(PW(a1), 0, 0x18); return 0; }
 // --- app content ---
 HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = 0; return 0; }
 
+// sceAppContentTemporaryDataMount2(option, SceAppContentMountPoint* mp) — mount the app's temp-data
+// area and write its guest path into mp. SceAppContentMountPoint = char data[16] (shadPS4
+// app_content.h; PS4/PS5 identical). shadPS4 writes exactly "/temp0\0" and returns 0. Our previous
+// behavior (unimplemented stub -> return 0 = SUCCESS with mp untouched) made the game treat 16 bytes
+// of uninitialized memory as its temp-data mount path and build file paths from it. We write EXACTLY
+// 7 bytes ("/temp0" + NUL) — never the full 16, never more (cf. the f_fstat oversized-write lesson).
+// hle_file.cpp translates the /temp0 prefix to a host-backed directory so subsequent I/O works.
+HLE(s_appcontent_tmpmount2) {
+    char* mp = (char*)PW(a1);
+    if (!mp) return 0x80D90002ull;              // SCE_APP_CONTENT_ERROR_PARAMETER
+    memcpy(mp, "/temp0", 7);
+    return 0;
+}
+// sceAppContentTemporaryDataGetAvailableSpaceKb(mp, uint64_t* kb): temp0 is a 1 GiB scratch area on
+// PS5; report it all free (shadPS4 does the same). The stub's return-0-only left *kb garbage — a
+// value games use to size caches/allocations.
+HLE(s_appcontent_tmpspace) { if (a1) *(uint64_t*)PW(a1) = 1048576ull; return 0; }
+
 // Common/message dialogs: report FINISHED immediately so the game's "wait until dismissed" loop
 // exits and it proceeds (we have no interactive dialog UI yet). Status enum: NONE=0, INITIALIZED=1,
 // RUNNING=2, FINISHED=3. GetResult -> zeroed struct = OK/no button pressed.
 HLE(s_dialog_finished) { return 3; }
-HLE(s_dialog_result)   { if (a0) memset(PW(a0), 0, 0x30); return 0; }  // SceMsgDialogResult ~0x30 (don't overflow)
+// SceMsgDialogResult = { u32 mode; u32 result; u32 buttonId; char reserved[32] } = 0x2C bytes
+// (shadPS4 msgdialog_ui.h DialogResult). Was memset(0x30) — 4 bytes PAST the caller's struct,
+// exactly the f_fstat oversized-write class this file warns about.
+HLE(s_dialog_result)   { if (a0) memset(PW(a0), 0, 0x2C); return 0; }
 
 void register_service_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
@@ -82,8 +104,15 @@ void register_service_hle() {
     Hle::register_fn("rnEhHqG-4xo", (HleFn)s_user_int_out, "sceUserServiceGetAccessibilityChatTranscription");
     Hle::register_fn("O6IW1-Dwm-w", (HleFn)s_user_int_out, "sceUserServiceGetAccessibilityZoomFollowFocus");
     Hle::register_fn("-3Y5GO+-i78", (HleFn)s_user_int_out, "sceUserServiceGetAccessibilityTriggerEffect");
-    // NOTE: sceUserServiceGetGamePresets (-sD02mFDBh4) intentionally left unimplemented — its output is
-    // a struct of unknown layout; writing a wrong-size default would risk a stack smash (cf. f_fstat).
+    // sceUserServiceGetGamePresets (-sD02mFDBh4): output struct layout unknown (shadPS4 has only a
+    // stub; no Kyty reference), so we must NOT write into it (wrong-size default = stack-smash risk,
+    // cf. f_fstat). But the generic unimplemented stub returned 0 = SUCCESS with the struct untouched,
+    // so the game consumed uninitialized memory as its preset data. Returning a clean UserService
+    // error makes the game take its no-presets fallback instead. OPERATION_NOT_SUPPORTED is a terminal
+    // (non-retryable) errno — deliberately NOT NO_EVENT/NOT_LOGGED_IN, which drain loops retry (the
+    // GetEvent 0x80960009 stall taught us a poll-class errno can spin the caller forever).
+    // CONFIDENCE: MED on errno choice; HIGH that success+garbage is wrong.
+    Hle::register_fn("-sD02mFDBh4", (HleFn)s_gamepresets, "sceUserServiceGetGamePresets");
     R("sceUserServiceInitialize", s_ok);
     R("sceUserServiceTerminate", s_ok);
     // NP
@@ -100,6 +129,10 @@ void register_service_hle() {
     // app content / dialogs
     R("sceAppContentInitialize", s_ok);
     R("sceAppContentAppParamGetInt", s_appcontent_int);
+    // temp-data mount: raw NIDs (names not in our NidDb). Unmount = OK (nothing to tear down).
+    Hle::register_fn("buYbeLOGWmA", (HleFn)s_appcontent_tmpmount2, "sceAppContentTemporaryDataMount2");
+    Hle::register_fn("SaKib2Ug0yI", (HleFn)s_appcontent_tmpspace, "sceAppContentTemporaryDataGetAvailableSpaceKb");
+    Hle::register_fn("bcolXMmp6qQ", (HleFn)s_ok,                  "sceAppContentTemporaryDataUnmount");
     R("sceCommonDialogInitialize", s_ok);
     R("sceSystemServiceParamGetInt", s_appcontent_int);
     // message dialog: auto-dismiss (report FINISHED) so the startup dialog flow completes

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -122,6 +122,13 @@ int main(int argc, char** argv) {
                const prosper::gpu::ResolvedPipelineState& ps,
                const prosper::gpu::ShaderResourceTable* vrt, const prosper::gpu::ShaderResourceTable* prt,
                uint32_t w, uint32_t h, uint32_t draw_vcount) {
+                // PROSPER_RENDER_FIRST=<N>: skip the slow (~400x) Vulkan render for the first N GPU submits so
+                // the game reaches a LATE scene (e.g. the level1 cutscene, which only starts submitting after
+                // ~5000 title-loop submits) at native speed, then renders + dumps only the late frames.
+                // Without this, rendering from boot is far too slow to ever reach the cutscene.
+                static std::atomic<int> g_submit_idx{0};
+                static int g_render_first = getenv("PROSPER_RENDER_FIRST") ? atoi(getenv("PROSPER_RENDER_FIRST")) : 0;
+                if (g_submit_idx++ < g_render_first) return;
                 // Dump the recompiled SPIR-V FIRST (before the slow Vulkan render), so it survives even if
                 // a concurrent worker fault kills the process mid-render — lets us spirv-val it offline.
                 if (getenv("PROSPER_SHADER_DUMP")) {


### PR DESCRIPTION
## Fix the level1 (cutscene) load crash — the GC allocation lock never locked

**The wall this clears:** *The Messenger* boots through the loading screen, then loads its intro **cutscene**
(Unity scene `level1`). For several prior sessions the game crashed on the loader thread ~60 MB into
`resources.assets` with an IL2CPP GC **"Unexpected state"** abort — the cutscene scene never finished loading.
This PR makes **level1 deserialize to 100% (EOF, block 1183)** — further than any prior session reached.

### Root cause (found via gdb forensics)

prosper's pthread-mutex HLE treated a **NULL mutex handle as a no-op that returned success**, so IL2CPP's
**GC allocation lock (`GC_allocate_ml`) never actually locked.** On FreeBSD/PS5 `pthread_mutex_t` is a
*pointer* and `PTHREAD_MUTEX_INITIALIZER` is NULL (libthr self-initializes on first lock); bdwgc's allocation
lock is exactly such a static mutex. So the collector, the allocator fast path, and the incremental sweep all
ran with **zero mutual exclusion** → the sweep raced concurrent `GC_malloc` free-list pops; freed-live blocks
received deserialized string bytes (`"Rewired_…"`) over their free-list links, and the next allocation popped
that ASCII as a pointer → the crash (rip varies; the `"Unexpected state"` abort and stack-smash reports are
the same corruption). **Proof:** with the fix the full 77 MB stream deserializes to EOF, Unity closes every
scene file (load = 100%), 60 healthy GC stop-the-world cycles, **zero worker faults**.

### What's in this PR

- **`hle_kernel.cpp`** — `ensure_mutex`/`ensure_cond`/`ensure_rwlock` lazily create the host sync object when
  the guest slot holds a static-initializer sentinel (`<0x1000`), CAS-guarded against concurrent first-lockers;
  destroy recognizes sentinels. **(The crash-1 fix.)**
- **`hle_service.cpp`** — `sceSystemServiceParamGetString` writes a valid empty string instead of leaving the
  caller's buffer garbage (unblocks scene streaming, from #35); 6 HLE-contract fixes (oversized
  `sceMsgDialogGetResult` write 0x30→0x2C, `/temp0` temp-data mount, `sceLibcHeapGetTraceInfo`,
  `sceSysmoduleGetModuleInfoForUnwind`, `sceUserServiceGetGamePresets`, AGC stubs).
- **`hle_kernel_mem.cpp`** — `sceKernelReserveVirtualRange` is idempotent for the caller's own range (a
  re-reserve of an address we already handed out returned an error → the allocator got NULL; secondary).
- **`boot_trace.cpp`** — `PROSPER_RENDER_FIRST=<N>` skips the slow render for the first N submits so a late
  scene can be captured at native speed.
- Merges origin/master: multi-draw executor (`PROSPER_PERDRAW` #34), full pread/read (#39), viewport (#38).

Linux **49/49 ctest green**.

### Honest status — the cutscene still doesn't *display* (one wall further in)

The scene now loads to 100%, but the game crashes **at scene activation** (immediately after the files close),
so it never submits the cutscene geometry. The crash is a deterministic managed `NullReferenceException`: a
ticks→seconds getter whose argument `[callerObj+0x40]` — a **time-source object on the scene-activation
path** — is **null** (mis-deserialized). Ruled out (with evidence): missing HLE, the incremental GC
(`PROSPER_PATCH_RET` neutralizing the GC pump crashes at the identical rip), a frozen clock, and AJM audio.
Stubbing the getter runs crash-free but stays on the loading screen — so this is a deeper Unity
**deserialization** gap (mis-deserialized scene-activation objects), the documented `DESER_STALE_CACHE_BLOCK`
frontier, not one more HLE value. No cutscene frame is captured because the game provably never submits the
cutscene draws — it crashes at activation first. That deserialization null is the precise hand-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
