### PR TITLE
diag(cutscene): refine the block-966 wall to a deterministic 3-object deser loop

### DIFF
--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -437,3 +437,41 @@ that would init `WorkerThread.+0x40` is the gap.
 after the write should have happened — that main-thread-only watch caught nothing). It answers definitively:
 does some worker/pool thread write the field (a dispatch/visibility race) or does no thread ever run the
 init (a never-dispatched work item)? That points straight at the fix.
+
+## Block-966 wall REFINED: a deterministic infinite 3-object deserialization loop (not a deadlock)
+
+Post-#44/#46, with `PROSPER_NULLGUARD=0x4416375e0,13` past the Stopwatch crash, the cutscene streams ~80%
+then hits its true final wall. A parallel session (95a32e9e) drilled it and **refines #46's "deser deadlock"**:
+
+**It is NOT a lost-wakeup, GC thrash, or memory starvation** (each tested & ruled out):
+- Attaching gdb at the stall shows the **main thread busy in `__libc_malloc(16)`** — actively deserializing,
+  NOT blocked on a sync primitive. The 46 parked workers are idle, not starved of a wakeup.
+- Only **20 GC (`type=0x1e`) cycles** over the whole run — not GC thrash.
+- We report **8 GiB** (`sceKernelGetDirectMemorySize`) — the FileCacher is not memory-starved.
+- `PROSPER_WAIT_TIMEOUT` does not break it (the workers aren't on a timed `WaitOnAddress`).
+
+**What it actually is:** the main thread re-reads a **perfect 3-block cycle** forever:
+`blk 961 (RectTransform) → 727 (AnimationClip) → 966 (MonoBehaviour, pathid 18918) → 961 → 727 → 966 → …`
+i.e. it re-deserializes the same 3 objects in a fixed cycle, allocating 16-byte nodes each pass and never
+marking them integrated. The cycle thrashes a **2-slot FileCacher** (`eboot+0xb17601`: checks the request
+key against slot-0 key `[this+0x50]` and slot-1 key `[this+0x68]`; a miss on both reloads via `0xb17340`).
+
+**Full guest call chain of the re-read** (captured via an 8-deep PREADLOG caller walk, this change):
+```
+sceKernelPread
+  <- eboot+0x146c1a9   (chunked read: reads until r13 remaining==0)
+  <- eboot+0x93a810
+  <- eboot+0xb1767e    (2-slot FileCacher body, 0xb17601)
+  <- eboot+0x1d68990
+  <- eboot+0xd4cf19    (offset->block math: `div rcx` then virtual read `call *0x28(rax)`)
+  <- eboot+0xd3ab1b / 0xd226d6   (per-object-TYPE deser dispatch — varies by object)
+  <- eboot+0xd3a996
+  <- eboot+0xd3d34b    (deser body; guards the FileCacher read under PS5 `PlatformMutex.cpp`)
+```
+So the FileCacher read is mutex-guarded (`eboot+0x19b29c0` logs `PlatformMutex.cpp`). Real HW reads each of
+these 3 blocks ONCE (the deser terminates); our env re-reads them forever — a value/state our environment
+feeds the deserializer (a misread field size → offset misalignment, or a never-set "object integrated"
+flag) makes the per-object deser fail to advance. **Next probe:** diff the exact bytes/positions the deser
+requests from block 966 across iterations (does the requested offset advance, or repeat?) to decide
+misalignment-vs-requeue; then find the field/flag our env sets wrong. This is the single remaining wall to
+the cutscene.

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -175,15 +175,16 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
     char path[256] = "?"; char lp[64]; snprintf(lp, sizeof lp, "/proc/self/fd/%lld", (long long)fd);
     ssize_t k = readlink(lp, path, sizeof path - 1); if (k > 0) path[k] = 0; else path[0] = '?', path[1] = 0;
     const char* base = strrchr(path, '/'); base = base ? base + 1 : path;
-    // top 3 distinct eboot-range return addresses on the stack (guest call chain)
-    uint64_t cc[3] = {0,0,0}; int nc = 0; uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
-    for (int i = 0; i < 800 && nc < 3; i++) { uint64_t v = sp[i];
+    // top N distinct eboot-range return addresses on the stack (guest call chain)
+    uint64_t cc[8] = {0,0,0,0,0,0,0,0}; int nc = 0; uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
+    for (int i = 0; i < 1200 && nc < 8; i++) { uint64_t v = sp[i];
         if (v >= 0x400000000ull && v < 0x420000000ull) { uint64_t o = v - 0x400000000ull;
             if (nc == 0 || cc[nc-1] != o) cc[nc++] = o; } }
-    fprintf(stderr, "[preadlog] %-6s %-24s fd=%lld off=0x%llx(blk %lld) cnt=0x%llx tid=%ld callers=eboot+0x%llx,0x%llx,0x%llx\n",
+    fprintf(stderr, "[preadlog] %-6s %-24s fd=%lld off=0x%llx(blk %lld) cnt=0x%llx tid=%ld callers=eboot+0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx\n",
             fn, base, (long long)fd, (unsigned long long)off, (long long)(off / 0x10000),
             (unsigned long long)cnt, (long)syscall(SYS_gettid),
-            (unsigned long long)cc[0], (unsigned long long)cc[1], (unsigned long long)cc[2]);
+            (unsigned long long)cc[0], (unsigned long long)cc[1], (unsigned long long)cc[2], (unsigned long long)cc[3],
+            (unsigned long long)cc[4], (unsigned long long)cc[5], (unsigned long long)cc[6], (unsigned long long)cc[7]);
 }
 #else
 static bool fdlog_on() { return false; }


### PR DESCRIPTION
Builds on merged #44/#46. **Docs + one gated diagnostic** (8-deep PREADLOG caller walk); default boot unchanged, no game IP.

## What this establishes
The post-Stopwatch cutscene wall (#46's "block-966 deser deadlock") is **not** a deadlock/lost-wakeup/GC/memory issue — each was tested and ruled out this session:
- gdb at the stall shows the **main thread busy in `__libc_malloc(16)`** (actively deserializing, not blocked on sync); the 46 parked workers are idle, not starved.
- Only **20 GC cycles** total (no thrash); we report **8 GiB** (FileCacher not memory-starved); `PROSPER_WAIT_TIMEOUT` doesn't break it.

## What it actually is
A **deterministic infinite loop** re-deserializing 3 objects in a perfect cycle:
`blk 961 (RectTransform) → 727 (AnimationClip) → 966 (MonoBehaviour pathid 18918) → …forever`, allocating 16-byte nodes each pass, thrashing a **2-slot FileCacher** (`eboot+0xb17601`). Full guest deser call chain captured (see doc): `pread ← 0x146c1a9 ← 0x93a810 ← 0xb1767e(FileCacher) ← 0x1d68990 ← 0xd4cf19(offset→block `div`) ← type-deser ← 0xd3a996 ← 0xd3d34b(mutex-guarded)`.

Real HW reads each of these blocks once; our env re-reads them forever — a value/state we feed the deserializer (misread field size → offset misalignment, or a never-set "integrated" flag) stops it advancing. **Next probe named in the doc:** does the requested fine offset into block 966 advance or repeat across iterations (misalignment vs requeue).

This does not itself render the cutscene, but converts #46's uncertain "deadlock (lost-wakeup or cache-thrash?)" into a precisely-located, hypothesis-narrowed deser loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)