### PR TITLE
diag(cutscene): map both remaining blockers — uncaptured color render-state + variable deser/threading

### DIFF
--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -463,3 +463,35 @@ retry) in our environment, the object cursor never advances and it re-reads the 
 next concrete step is to inspect what the game's SafeBinaryRead / il2cpp `Class::GetFields`-driven
 transfer returns for `InventoryItemDefinition` in our il2cpp (vs the 132-byte on-disk layout) — that is
 the precise mismatch to fix, and it is squarely in il2cpp reflection, not the file/GC/Stopwatch layers.
+
+## 2026-07-08 (cont.) — TWO independent blockers mapped: (1) missing color render-state, (2) variable deser/threading
+
+Two concrete findings this round, both verified:
+
+### (1) `FORCE_COLORWRITE` renders the FULL title screen — the color render-target state is not captured
+Running with `PROSPER_FORCE_COLORWRITE` (renders the ~66 skipped `mask==0` draws/frame) produces the
+**complete, correct "THE MESSENGER" title screen** (ninja, moon, logo, monster horde) at 1920×1080 — our
+GPU pipeline recompiles and renders The Messenger's real art correctly. Instrumenting the skipped draws
+shows **`cb_target_mask=0x0`, `cb_color_control=0x0`, `color0_fmt=0` for ALL of them** — the *entire*
+color render-target state is zero/unprogrammed, not just the write mask. So valid color draws are being
+dropped because we never capture their color-target setup (the game programs it via a path we miss;
+`FORCE_COLORWRITE` + the render path's default target is what makes them appear). This is a real,
+separate GPU state-tracking bug — and it means that **even once the load completes, the cutscene draws
+would be invisible without either this fix or `FORCE_COLORWRITE`**. Fix target: find where the guest
+programs CB_TARGET_MASK / CB_COLOR_CONTROL / the color0 surface for these draws and capture it into the
+context-register state (`st.cx`), rather than defaulting to 0.
+
+### (2) The block-966 deser stall is VARIABLE, not purely deterministic
+Re-running the deser trace multiple times (multi-core and single-core via `taskset -c 0`) gives
+**different outcomes per run**: sometimes the heavy block-961..966 loop (4500+ reads), sometimes light
+progress to block ~986/2843 then a worker-thread fault, sometimes a clean-ish exit. So layered on the
+deterministic deser loop there is *also* a **threading race** (the earlier "deterministic single-core"
+reading does not reproduce reliably). Added `PROSPER_DEEPTRACE` (hle_file.cpp): dumps a deep guest
+backtrace (eboot + il2cpp frames) on block-961..966 re-reads to catch the loop head — useful once the
+loop is reliably reproduced.
+
+**Net for the cutscene:** two things now stand between here and a visible cutscene, both mapped:
+(A) async-load completion of `resources.assets` (the InventoryItemDefinition/deser loop + a threading
+race — the primary blocker), and (B) capturing the color render-target state so the composited draws are
+visible (proven by FORCE_COLORWRITE rendering the title). Neither is a mystery anymore; both are scoped
+to one subsystem each (il2cpp deser; GPU context-register capture).

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -91,7 +91,8 @@ inline bool realize_draw_item(const GpuState& ds, uint32_t vcount_hint, uint32_t
     // Skip a draw with no color writes: it contributes no pixels, so recording it (and, in the single-item
     // case, presenting its bare clear) would just overwrite the last real frame (an art/clear flicker).
     if (ps.color_write_mask == 0 && !getenv("PROSPER_FORCE_COLORWRITE")) {
-        if (log) fprintf(stderr, "[exec] skip draw: color_write_mask==0 (no-op)\n");
+        if (log) fprintf(stderr, "[exec] skip draw: color_write_mask==0 (no-op) cb_target_mask=0x%x cb_color_control=0x%x color0_fmt=%u\n",
+                         rs.cb_target_mask, rs.cb_color_control, ps.color0_format);
         return false;
     }
     // PROSPER_FORCE_COLORWRITE: diagnostic — render color_write_mask==0 draws anyway (force mask to RGBA).

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -184,6 +184,23 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
             fn, base, (long long)fd, (unsigned long long)off, (long long)(off / 0x10000),
             (unsigned long long)cnt, (long)syscall(SYS_gettid),
             (unsigned long long)cc[0], (unsigned long long)cc[1], (unsigned long long)cc[2]);
+    // PROSPER_DEEPTRACE: on the block-966 thrash reads of resources.assets (the cutscene deser loop,
+    // blk 961..966 = 0x3c10000..0x3c60000), dump a DEEP guest backtrace including il2cpp frames — reveals
+    // the loop head + whether il2cpp reflection/deser is in the chain. Rate-limited to avoid spam.
+    static int deep_budget = getenv("PROSPER_DEEPTRACE") ? 30 : 0;
+    if (deep_budget > 0 && !strcmp(base, "resources.assets") && off >= 0x3c10000ull && off <= 0x3c60000ull) {
+        deep_budget--;
+        char line[1024]; int p = snprintf(line, sizeof line, "[deeptrace] blk %lld frames:", (long long)(off / 0x10000));
+        int nf = 0; uint64_t last = 0;
+        for (int i = 0; i < 1600 && nf < 20 && p < (int)sizeof line - 24; i++) {
+            uint64_t v = sp[i];
+            const char* m = nullptr; uint64_t o = 0;
+            if (v >= 0x400000000ull && v < 0x420000000ull) { m = "eb"; o = v - 0x400000000ull; }
+            else if (v >= 0x440000000ull && v < 0x4c0000000ull) { m = "il"; o = v - 0x440000000ull; }
+            if (m && o != last) { p += snprintf(line + p, sizeof line - p, " %s+%llx", m, (unsigned long long)o); last = o; nf++; }
+        }
+        fprintf(stderr, "%s\n", line);
+    }
 }
 #else
 static bool fdlog_on() { return false; }


### PR DESCRIPTION
Builds on merged #44/#46/#48. Two concrete, verified findings that fully scope the remaining path to a visible cutscene.

## (1) Our GPU renders The Messenger correctly — but color render-state is uncaptured

`PROSPER_FORCE_COLORWRITE` (renders the ~66 skipped `mask==0` draws/frame) produces the **complete, correct "THE MESSENGER" title screen** at 1920×1080 (ninja, moon, logo, monster horde). So the RDNA2→SPIR-V recompiler + Vulkan renderer handle the game's real art.

Instrumenting the skip path shows all skipped draws have **`cb_target_mask=0x0`, `cb_color_control=0x0`, `color0_fmt=0`** — the *entire* color render-target state is zero/unprogrammed, not just the write mask. Valid color draws are dropped because we never capture their color-target setup; `FORCE_COLORWRITE` + the render path's default target is what makes them appear.

**Implication:** even once the load completes, the cutscene draws would be invisible without capturing this state. Fix target: find where the guest programs `CB_TARGET_MASK`/`CB_COLOR_CONTROL`/the color0 surface for these draws and capture it into `st.cx`.

## (2) The block-966 deser stall is VARIABLE (threading race layered on the deser loop)

Re-running the deser trace (multi-core and single-core via `taskset -c 0`) gives **different outcomes per run** — heavy block-961..966 loop (4500+ reads), or light progress to block ~986 then a worker-thread fault, or a clean-ish exit. So there's a **threading race** on top of the deterministic deser loop; the earlier "deterministic single-core" reading doesn't reproduce reliably. Added `PROSPER_DEEPTRACE` (deep guest backtrace on block-961..966 re-reads) to catch the loop head once reliably reproduced.

## Net

The two things between here and a visible cutscene are both now mapped and scoped to one subsystem each:
- **(A)** async-load completion of `resources.assets` (InventoryItemDefinition/deser loop + threading race) — the primary blocker;
- **(B)** capturing the color render-target state (proven by FORCE_COLORWRITE rendering the title).

Docs + gated diagnostics only (raw-register skip logging, `PROSPER_DEEPTRACE`). 49/49 ctest green. Does not itself render the cutscene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)