### PR TITLE
fix(gpu): render the color state — absent CB_TARGET_MASK defaults to write-all (fixes the blue screen)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -69,7 +69,14 @@ RenderState extract_render_state(const GpuState& st) {
     rs.db_depth_control  = dc;
     rs.cb_color_control  = rd(st.cx, P::CB_COLOR_CONTROL);
     rs.cb_blend0_control = bc;
-    rs.cb_target_mask    = rd(st.cx, P::CB_TARGET_MASK);
+    // CB_TARGET_MASK (per-MRT color write mask). The AGC driver defaults it to write-all when the game
+    // does not program register 0x8E explicitly — and this game NEVER emits it (verified with
+    // PROSPER_RESDUMP: the title/cutscene bind CB_COLOR0_BASE/INFO but no 0x8E), relying on that default.
+    // Our register file starts empty, so an ABSENT CB_TARGET_MASK must resolve to write-all (0xF per MRT),
+    // NOT 0 — reading 0 dropped every color draw (color_write_mask==0 skip), i.e. the "blue screen" where
+    // the real art rendered only under PROSPER_FORCE_COLORWRITE. A register that IS present (even 0) is
+    // honored, so a genuine depth-only pass that programs mask 0 still skips correctly.
+    rs.cb_target_mask    = st.cx.count(P::CB_TARGET_MASK) ? rd(st.cx, P::CB_TARGET_MASK) : 0xFFFFFFFFu;
 
     // Viewport 0 transform (guest floats; all-zero when never programmed).
     rs.vport_xscale  = flt(rd(st.cx, P::PA_CL_VPORT_XSCALE));


### PR DESCRIPTION
## Blocker (B): the game's real art now renders (was a blue screen)

![The Messenger title rendered by prosper](https://github.com/mattias800/ps5ys/raw/pr-assets/messenger_title_B.png)

*THE MESSENGER title screen, rendered by prosper at 1920×1080 through the game's own shaders.*

### Root cause
Building on #51's finding (`FORCE_COLORWRITE` renders the correct title, so the GPU pipeline works but the color state is uncaptured), I traced it with `PROSPER_RESDUMP`: the game binds the render target (`CB_COLOR0_BASE`/`CB_COLOR0_INFO`, regs 0x318/0x31c) but **never emits `CB_TARGET_MASK` (reg 0x8e)** — it relies on the AGC driver's **write-all default** for the per-MRT color write mask.

Our context-register file starts empty, so `resolve_pipeline_state` read the *absent* `CB_TARGET_MASK` as **0** → `color_write_mask == 0` → `realize_draw_item` **skipped every color draw** (~66/frame), leaving only the clear = the blue screen. The real art only appeared under `PROSPER_FORCE_COLORWRITE`.

### Fix (one line, `render_state.cpp`)
When `CB_TARGET_MASK` is **absent** from `st.cx`, resolve it to write-all (`0xFFFFFFFF`), matching the driver default. A register that **is** present (even 0) is still honored — so a genuine depth-only pass that programs mask 0 still skips correctly (no regression).

### Verified
- `mask==0` skips drop from ~66/frame to **0**.
- The title renders in **73 of 77 frames** (best: 2611 distinct colors) via the default folded executor.
- **49/49 ctest green.**

### Notes
- This is one of the two blockers to the cutscene (mapped in #51). It ensures that once the async-load completes (blocker A — the `InventoryItemDefinition` deser loop, owned by the parallel effort), the cutscene's composited draws will be **visible** rather than skipped.
- Separately observed: the opt-in `PROSPER_PERDRAW` executor still renders blue here while the default folded executor renders correctly — a per-draw-path issue worth a follow-up, but it does not affect the default path this fix targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhrNzDBN986tKzU7wpAEjK