### PR TITLE
Full-history bug hunt: 18 verified fixes from a 405-commit review

### DIFF
--- a/prosper/docs/BUG_HUNT_BACKLOG.md
+++ b/prosper/docs/BUG_HUNT_BACKLOG.md
@@ -1,0 +1,180 @@
+# History bug-hunt: verified-active findings backlog
+
+A full review of all 405 mainline commits (oldest → newest, 14 parallel review passes,
+2026-07-08) hunting defects, hacks, hardcoded stand-ins, and silent simplifications.
+Every finding below was **verified to still exist on master @ 96c80b2** before being
+recorded; candidates that later history already fixed were discarded (~60 of them).
+
+Severity legend: how likely it is to bite + how silent the failure is.
+Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior ·
+[hardcoded] magic value where a real parsed/computed value belongs ·
+[simplification] silently narrower semantics than the real API/ISA.
+
+## Fixed on branch `fix/history-bug-hunt` (18 bugs, 15 commits)
+
+- MUBUF SOFFSET decoded with a 7-bit mask — inline-0 (0x80) read as SGPR s0.
+- R_X86_64_DTPOFF64 computed as S *or* A instead of S + A.
+- v_mul_legacy_f32 emitted as IEEE FMul (0×Inf gave NaN, not 0).
+- sceSystemServiceGetStatus wrote 4 bytes through stale RSI, real out-struct unwritten.
+- __cxa_guard_acquire / _Execute_once raced (concurrent double-construction).
+- FreeBSD→Linux open(2) flag words passed raw (O_CREAT became O_TRUNC).
+- sceKernelWaitEventFlag / WaitSema ignored their timeout (silent forever-block).
+- scePthread(Attr)Getschedparam/Getprio returned success with unwritten out-params.
+- EVFILT_VIDEO_OUT was -10 (FreeBSD EVFILT_LIO); Kyty + shadPS4 agree on -13.
+- guest_readable/probe_readable probed via /dev/null, which never faults → all guards
+  were no-ops (now a drained O_NONBLOCK pipe; raw syscalls in the fault handler).
+- Lazy GPU-VA backing ignored si_code (clobbered live RO mappings; infinite fault loop
+  on in-window instruction fetches). Now SEGV_MAPERR-only and addr != RIP.
+- SceAudioOutPortState layout diverged from Kyty (volume written into flag); audio
+  errors were generic -1 instead of 0x80260003/0x80260005.
+- Guest-%fs swap stubs shifted stack args by 2 qwords — ReleaseMem's (data_sel, fence
+  value) read a TCB pointer + return address under PROSPER_GUEST_FS. Stub now forwards
+  the first two stack args (verified live: data_sel=0x2/0x3 with real fence values).
+- DrawIndexAuto dropped its modifier and left cmd[3..6] uninitialized.
+- WriteData silently clamped to 60 dwords (now accepts PM4 14-bit max, rejects loudly).
+- AGC shader registry iterated lock-free against push_back (UAF on realloc).
+- s_waitcnt_vscnt mapped as nonexistent SOPP 0x7d — real one (SOPK 0x17) failed the
+  shader; waitcnt family now no-op'd in SOPK. Plus: execz linearization now rejects
+  VALU ops with unpredicated scalar writes (readfirstlane/carry ops); v_cndmask_e64
+  honors neg/abs modifiers; VOP3B untracked carry-in rejects instead of assuming 0.
+- Direct vertex-buffer provenance keyed without user_sgpr_base (off by 8 in VS).
+- munmap/BatchMap-UNMAP never untracked g_maps; mprotect never re-tagged (stale
+  "committed" state defeated safe_copy and the lazy-commit fault probe).
+
+## High-priority remaining
+
+1. **[hack] APR read resolves the file by BYTE-SIZE match** — `hle_file.cpp`
+   apr_path_for_size/f_apr_read_submit: request matched against stat'd sizes of known
+   containers; whole-file reads at offset 0 only. Two same-size files ⇒ wrong bytes,
+   silently. Decode the file id (prosper_apr_path_for_id exists) + offset/chunk support;
+   at minimum refuse loudly on size collision. (introduced 41b01f3)
+2. **[simplification] Indexed draws silently dropped** — hle_agc.cpp emits R_DRAW_INDEX
+   (0x03) but pm4_decode never decodes it: every sceAgcDcbDrawIndex vanishes downstream
+   while the guest sees success. Decode it (verify a2/a3 roles vs Kyty), push a Draw
+   with index data, round-trip test. Directly relevant to scene-content rendering.
+   (8d26489)
+3. **[hack] Quad-fan topology heuristic** — gpu_execute.hpp:107-112 rewrites any draw
+   whose bound VB has 4 records to vertex_count=4 TRIANGLE_FAN. Stands in for real
+   index-buffer support; wrong for real 4-vertex meshes. Supersede with #2 then delete.
+   (b1f3420)
+4. **[hardcoded] Sampled textures assumed RGBA8** — agc_shader_layout.cpp:144,151: the
+   decoded 9-bit T# format is thrown away; everything uploads as Unorm8 ×4 with
+   size = w*h*4 (over-reads BCn allocations up to 8×). Add a Gen5 IMG_FMT→DataFormat
+   mapper (Kyty tables), size from block size, loud skip on unmapped. (13d70f7)
+5. **[defect] release-mem data_sel default write** — command_processor.cpp:58-67 writes
+   8 bytes for ANY unrecognized data_sel and cases 1/2 lack the rel_value_valid guard.
+   With the stub-frame fix in, data_sel now decodes correctly — make the default
+   log-and-skip and guard cases 1/2. (858c47e)
+6. **[defect] Equeue lifetime + semantics cluster** — hle_kernel_time.cpp:
+   (a) k_eq_delete deletes EqState while waiters may sit in wait (UAF; registrations in
+   g_*_regs never purged — address reuse resurrects them); (b) WaitEqueue returns
+   SUCCESS with *out=0 on timeout/unknown queue (Kyty/shadPS4 return ETIMEDOUT) and
+   caps NULL timeout at 100 ms returning success; (c) eq_post drops the NEWEST event
+   when 4 queued (a flip event can be the one dropped — coalesce by ident/filter
+   instead); (d) detached HR-timer threads post to possibly-deleted queues and
+   Delete*Event are no-ops. shared_ptr EqState + purge + ETIMEDOUT + coalescing.
+   (61e7ee8, 534bcc1)
+7. **[defect] TLS DTV keyed by recyclable thread id, never purged** — hle_kernel.cpp
+   __tls_get_addr: pthread id reuse hands a new thread the dead thread's dirty TLS
+   block; blocks leak. Purge at thread exit (trampoline) or key by a monotonic token.
+   (a76140b/6495dbc; flagged by three passes)
+8. **[simplification] pthread_once / _Execute_once-style global-lock deadlock** —
+   k_pthread_once holds ONE global recursive mutex across the guest init routine;
+   cross-thread-dependent inits deadlock. Per-control state (3-state word + condvar),
+   callback outside the lock (h_execute_once now shows the shape). (5fae501)
+9. **[defect] WaitRegMem args destroyed at build time** — hle_agc.cpp zeroes the whole
+   9-dword payload; the wait can never be honored downstream. Encode Kyty's layout;
+   CP should at least assert the condition already holds at fold time. (2e4b9de)
+10. **[hardcoded] Ampr mirror view at fixed −0x540000000** — hle_kernel_mem.cpp:431:
+    one-title constant, MAP_FIXED over whatever lives there. Track the guest's real
+    second view via the phys-keyed memfd instead. (a51d7ce)
+
+## Medium
+
+- [defect] init-fault dump derefs unchecked g_fault_rip (mprotect result ignored;
+  forces R|X on RW pages) — exec_image_linux.cpp:~1290. Probe first; restore prot. (b51ad10)
+- [hardcoded] RTC/time: wall clock = uptime + 1700000000 (frozen Nov 2023), three
+  disagreeing time sources; LocalTime ignores tz — hle_kernel_time.cpp:43-96. Base off
+  host CLOCK_REALTIME once at startup. (e1473f8/efaf7cf)
+- [simplification] forward-branch clamp swallows real code past s_endpgm —
+  rdna2_to_spirv.cpp:~968: clamp only tgt == end_pc+1, else reject. (4e65a94)
+- [defect] flip-status triple (g_flip_count/g_current_buffer/g_last_flip_arg) is
+  read/written by 3 threads with no sync — hle_graphics.cpp. Mutex or atomic seq. (dcff92e)
+- [simplification] untyped MUBUF loads/stores hardcode binding 2 (never resolve SRSRC)
+  — rdna2_to_spirv.cpp:~1648. Mirror the format-load provenance resolution. (e9b62dd)
+- [hardcoded] LDS fixed at 16 KB (RDNA2 allows 64 KB; size is per-shader RSRC2 data) —
+  rdna2_to_spirv.cpp declare_lds. (fbfd8da)
+- [defect] robustImageAccess required by the recompiler's storage-image contract but
+  never enabled at either vkCreateDevice — render_runner.h:113, image_compute_runner.h:57. (e3951c1)
+- [simplification] EventWrite drops its address arg (label-carrying events can never
+  write) — hle_agc.cpp:136. (2e4b9de)
+- [hardcoded] vk_color_format maps ONLY 8_8_8_8 (else silently Undefined) —
+  vk_translate.cpp:20. Port Kyty rows; log unmapped. (822cd24)
+- [simplification] Special-operand ALU sources (VCC/EXEC/M0 as data) silently read 0 —
+  rdna2_to_spirv.cpp operand_bits default. Route to tracked bools or reject. (e13f469)
+- [defect] v_cvt_u32_f32/i32_f32 emit bare OpConvertFToU/S (UB out-of-range; hardware
+  saturates, NaN→0) — rdna2_to_spirv.cpp:~1266. Clamp + NaN→0. (ac1e536)
+- [simplification] DTPMOD64 always resolves to the local module; the promised
+  "unhandled" log for cross-module TLS doesn't exist — module.cpp:237. (d499c1d)
+- [defect] mmap hint forces MAP_FIXED (silently clobbers live mappings) — map_at,
+  hle_kernel_mem.cpp:124. MAP_FIXED_NOREPLACE unless replacing own reservation. (cf2495c)
+- [defect] guest thread stacks (8 MiB) never freed; g_stacks never erased; attr
+  stacksize ignored — hle_kernel.cpp:281. (caa9443)
+- [defect] EventFlag/Sema delete frees under active waiters (UAF); Sony wakes with
+  WAIT_DELETE first — hle_kernel.cpp:335/369. (caa9443)
+- [defect] sceKernelAvailableDirectMemorySize aliased to GetSize (out-params never
+  written) — hle_kernel_mem.cpp. Walk g_dmem gaps. (cf2495c)
+- [simplification] printf-family forwards only integer regs (floats/stack args read
+  garbage; %s can fault) — hle_libc.cpp:199. Needs a va-marshaling shim. (3e16200)
+- [simplification] alloc_dmem ignores searchStart/End — constrain the gap walk. (efaf7cf)
+- [simplification] wait_on_address timeout honor still gated OFF behind
+  PROSPER_WAIT_TIMEOUT with an obsolete justification (unwinder long fixed) + 5 s cap —
+  hle_kernel_mem.cpp:334. Flip the default. (0e121a5)
+- [simplification] folded multi-draw uses draws[0].index_count with the LAST draw's
+  state (chimera draw) — gpu_execute.hpp:136. Use consistent provenance / PERDRAW default. (d99e3c6)
+- [defect] detached timer threads + eq delete UAF (see cluster #6). (534bcc1)
+- [simplification] type-0 AGC data packets get the type-1 payload offset (never RE'd) —
+  hle_agc.cpp agc_get_data_packet_payload. Per-type offset or loud diagnostic. (54b7b81)
+- [defect] mb_cur_max returns a POINTER (address of static) where the value is the
+  contract — hle_libc.cpp:233. (5b781e4)
+- [simplification] Windows k_wait_on_address fallback drops the timeout + global cv —
+  hle_kernel_mem.cpp #else branch. (8e7a661)
+- [simplification] guest static-TLS layout hardcodes 16-byte alignment instead of
+  PT_TLS p_align (Variant II tpoff mismatch for p_align>16) — guest_tls.cpp:47. (45016d8)
+
+## Lower priority / latent
+
+- vblank count advances per POLL, not per 16.67 ms — hle_graphics.cpp:248. (d83b2e6)
+- sceVideoOutGetOutputStatus returns success without writing the out-struct —
+  hle_graphics.cpp:311. (d83b2e6)
+- MsgDialog reports FINISHED before any Open — hle_service.cpp. 3-state lifecycle. (1b14b79)
+- all guest mutexes forced RECURSIVE (settype discarded; static sentinels too) —
+  hle_kernel.cpp:55,73-89. Map sentinel/attr → real type. (cf2495c/8d26489)
+- LoadStartModule returns a fake success handle for unknown paths — ENOENT for misses. (e1473f8)
+- dlsym ignores the module handle (global first-wins table) — per-module exports. (b51ad10)
+- pad handle ignored (always backend index 0); getenv per poll — hle_pad.cpp:59. (8564d73)
+- MUBUF idxen+offen drops the second VADDR (per-lane byte offset) — reject or decode
+  both. (66e82a0)
+- SMEM register SOFFSET never decoded (silently dropped — can't even reject) and the
+  21-bit imm treated unsigned — rdna2_decode.cpp:149. (3bff9d0)
+- packed vertex attributes assume dword-aligned element addresses — rdna2_to_spirv.cpp
+  packed load/store paths. Fold addr&3 or reject. (08b1f5c)
+- image_sample → ImplicitLod even in compute/vertex shells (invalid SPIR-V) — gate on
+  fragment, else explicit LOD 0. (f8bcad1)
+- v_interp_mov ignores its P0/P10/P20 selector (flat reads interpolated). (636cf47)
+- v_readfirstlane models "this lane" (marked SPECULATIVE) — use
+  OpGroupNonUniformBroadcastFirst where available. (836394c)
+- NGG vertex index hardcoded to v5 via an s_sendmsg heuristic — derive from
+  SPI_SHADER_PGM_RSRC/GE state. (6b29017)
+- s_bfe_u64 fold zero-extends negative inline constants (ISA sign-extends). (f8c7371)
+- gpu_clock64 writes steady_clock ns, not GPU-tick units (data_sel=3 deltas wrong). (3685104)
+- detile treats all tile modes except 5 as linear, silently; 32 bpp only — log
+  unrecognized modes once. (1ecc260)
+- VS texture-first binding collision with hardwired SB bindings 2/3 —
+  assign_convention_bindings should start at 4. (d99e3c6)
+- dynfetch: fixed 0x4000-dword code walk (bound by AgcShaderHeader size), Unknown
+  format → Float32×4 default, size fallback "stride*4" — gpu_executor.cpp:344-386. (21589ee)
+- two glibc write() + one getenv() left inside the fault handler's HWBP diag paths
+  (guest-%fs unsafe) — exec_image_linux.cpp:~489/~580. (b51ad10)
+- shader-capture dump path hardcoded to this machine's WSL layout — hle_graphics.cpp:384. (7089e48)
+- three disagreeing "now" sources (see RTC above) — clock_gettime ignores clockid. (e1473f8)

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -182,7 +182,12 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.gpu_addr       = d.base;
             r.size           = d.size_bytes;
             r.stride         = d.stride;
-            r.sgpr_base      = reg;               // DIRECT provenance key (SRSRC SGPR index)
+            // DIRECT provenance key in SHADER-SGPR space: user_sgpr_base + block index, exactly
+            // like the cbuf/texture classes above. `reg` alone is the user-data BLOCK index; the
+            // recompiler looks resources up by shader SGPR (by_sgpr_base_cls on the fetch's SRSRC),
+            // and vertex buffers only matter in the VS where user_sgpr_base is 8 — the un-based key
+            // could never match (or collided with an unrelated SGPR).
+            r.sgpr_base      = user_sgpr_base + reg;
             r.srt_offset     = 0xFFFFFFFFu;       // not s_loaded
             table.resources.push_back(r);
         }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -50,6 +50,14 @@ void read_user_sgprs(const std::unordered_map<uint32_t, uint32_t>& sh, uint32_t 
 // pass wild addresses).
 #ifndef _WIN32
 static int g_probe_pipe[2] = {-1, -1};
+// One-time pipe creation via a C++11 magic static (thread-safe). guest_readable is shared with
+// the multi-threaded HLE pointer probes: an unguarded `if (fd < 0) pipe2(...)` lazy init let two
+// first-callers each pipe2 into the array — a torn pair (write-end of pipe B, read-end of pipe A)
+// never drains, fills, and EAGAINs: VALID memory reported unreadable, silently. (PR #61 review.)
+static bool probe_pipe_ok() {
+    static const bool ok = pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) == 0;
+    return ok;
+}
 static bool probe_byte(uint64_t a) {
     ssize_t w = write(g_probe_pipe[1], (const void*)(uintptr_t)a, 1);
     if (w == 1) { char c; (void)!read(g_probe_pipe[0], &c, 1); return true; }
@@ -58,10 +66,7 @@ static bool probe_byte(uint64_t a) {
 bool guest_readable(uint64_t a, uint32_t n) {
     if (a < 0x1000 || n == 0) return false;
     if (a + n < a) return false;   // wrap
-    if (g_probe_pipe[0] < 0 && pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) != 0) {
-        g_probe_pipe[0] = g_probe_pipe[1] = -1;
-        return false;
-    }
+    if (!probe_pipe_ok()) return false;
     uint64_t last_page = (a + n - 1) & ~0xfffull;
     for (uint64_t p = a & ~0xfffull; p <= last_page; p += 0x1000)
         if (!probe_byte(p < a ? a : p)) return false;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -39,17 +39,33 @@ void read_user_sgprs(const std::unordered_map<uint32_t, uint32_t>& sh, uint32_t 
 } // namespace (guest_readable below has external linkage — declared in gpu_execute.hpp, shared with
   // the HLE diagnostic probes that chase raw guest pointers)
 
-// Async-signal-safe-ish readability probe (guest memory is 1:1-mapped, but a mis-decoded address could
-// be unmapped): write() to /dev/null returns EFAULT for an unmapped source, so we can test a guest
-// address without risking a nested SIGSEGV on the render/submit thread. Always-true on Windows (the
-// const-eval only runs on the live-render path, which is Linux; tests never pass wild addresses).
+// Readability probe (guest memory is 1:1-mapped, but a mis-decoded address could be unmapped),
+// so guarded derefs on the render/submit thread don't risk a SIGSEGV. NOTE: /dev/null does NOT
+// work for this — the kernel's null_write returns count without ever touching the source buffer,
+// so the old probe reported EVERY address >= 0x1000 "readable" and all guards built on it were
+// no-ops (verified empirically on this project's WSL kernel). A pipe write actually imports the
+// user pages and returns EFAULT for unmapped memory. Readability is page-granular: probe one byte
+// in each page the range touches, draining after every write so the pipe can never fill. Always-
+// true on Windows (the const-eval only runs on the live-render path, which is Linux; tests never
+// pass wild addresses).
 #ifndef _WIN32
-static int g_devnull = -1;
+static int g_probe_pipe[2] = {-1, -1};
+static bool probe_byte(uint64_t a) {
+    ssize_t w = write(g_probe_pipe[1], (const void*)(uintptr_t)a, 1);
+    if (w == 1) { char c; (void)!read(g_probe_pipe[0], &c, 1); return true; }
+    return false;   // EFAULT: unmapped (EAGAIN can't happen — we drain after every byte)
+}
 bool guest_readable(uint64_t a, uint32_t n) {
-    if (a < 0x1000) return false;
-    if (g_devnull < 0) g_devnull = open("/dev/null", O_WRONLY | O_CLOEXEC);
-    if (g_devnull < 0) return false;
-    return write(g_devnull, (const void*)(uintptr_t)a, n) == (ssize_t)n;
+    if (a < 0x1000 || n == 0) return false;
+    if (a + n < a) return false;   // wrap
+    if (g_probe_pipe[0] < 0 && pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) != 0) {
+        g_probe_pipe[0] = g_probe_pipe[1] = -1;
+        return false;
+    }
+    uint64_t last_page = (a + n - 1) & ~0xfffull;
+    for (uint64_t p = a & ~0xfffull; p <= last_page; p += 0x1000)
+        if (!probe_byte(p < a ? a : p)) return false;
+    return true;
 }
 #else
 bool guest_readable(uint64_t, uint32_t) { return true; }

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -150,14 +150,17 @@ void decode_operands(Rdna2Inst& i) {
             i.n_src = 1; break;
         case Rdna2Format::MUBUF: {
             // Untyped buffer op. opcode[24:18]; VDATA (dest/src VGPR) d1[15:8]; VADDR d1[7:0];
-            // SRSRC (V# descriptor base SGPR, field ×4) d1[20:16]; SOFFSET d1[30:24]. 12-bit inst
+            // SRSRC (V# descriptor base SGPR, field ×4) d1[20:16]; SOFFSET d1[31:24]. 12-bit inst
             // offset d0[11:0] + offen d0[12] + idxen d0[13] packed into `literal`.
             const uint32_t d1 = i.words[1];
             i.opcode = (w >> 18) & 0x7Fu;
             i.dst    = vgpr(d1 >> 8);                          // VDATA
             i.src[0] = vgpr(d1);                              // VADDR
             i.src[1] = sgpr(((d1 >> 16) & 0x1Fu) << 2);       // SRSRC (descriptor base)
-            i.src[2] = decode_src_field((d1 >> 24) & 0x7Fu);  // SOFFSET
+            // SOFFSET is a full 8-bit src field: 0x80 = inline 0 (the standard "no soffset" encoding).
+            // A 7-bit mask folded 0x80 onto SGPR s0, silently adding a live descriptor dword to every
+            // buffer address whenever a shader wrote s0 before the fetch.
+            i.src[2] = decode_src_field((d1 >> 24) & 0xFFu);  // SOFFSET
             i.literal = (w & 0xFFFu) | (((w >> 12) & 1u) << 12) | (((w >> 13) & 1u) << 13);
             i.n_src = 3; break;
         }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -780,7 +780,8 @@ bool sopp_is_noop(const Rdna2Inst& in) {
         case 0x20:   // s_inst_prefetch
         case 0x21:   // s_clause
         case 0x22:   // s_wait_idle
-        case 0x7d:   // s_waitcnt_vscnt
+            // NOTE: s_waitcnt_vscnt is NOT SOPP on gfx10 — it is SOPK opcode 0x17
+            // (round-trip: llvm-mc gfx1010 encodes it 0xBBFD0000). Handled in the SOPK case.
             return true;
         default:
             return false;
@@ -850,11 +851,22 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
             // (VOP1/2/3) predicates its writes; memory ops (MIMG/MUBUF/DS) predicate their VGPR loads (and
             // are fault-free under robust access) and EXEC-predicate their stores. SGPR/VCC writes (SOP*/
             // VOPC/SMEM) are NOT predicated and would be observed past the merge -> still unsafe.
-            if (in.fmt == Rdna2Format::VOP1 || in.fmt == Rdna2Format::VOP2 || in.fmt == Rdna2Format::VOP3 ||
-                in.fmt == Rdna2Format::MIMG || in.fmt == Rdna2Format::MUBUF || in.fmt == Rdna2Format::DS ||
-                sopp_is_noop(in)) {
+            // CARVE-OUTS: three op groups inside the "safe" VALU formats have UNPREDICATED scalar side
+            // effects (emit_alu writes rs.sreg/rs.vcc/rs.sreg_bool for them, and predicate_write only
+            // covers VGPRs) — on hardware the skipped block would have preserved VCC/the SGPR:
+            //   VOP1 0x02 v_readfirstlane_b32 (writes an SGPR), VOP2 0x28-0x2A carry ops (write VCC),
+            //   VOP3B 0x128-0x12A (write the carry-out SGPR pair/VCC).
+            const bool scalar_side_effect =
+                (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x02) ||
+                (in.fmt == Rdna2Format::VOP2 && in.opcode >= 0x28 && in.opcode <= 0x2A) ||
+                (in.fmt == Rdna2Format::VOP3 && in.opcode >= 0x128 && in.opcode <= 0x12A);
+            if (!scalar_side_effect &&
+                (in.fmt == Rdna2Format::VOP1 || in.fmt == Rdna2Format::VOP2 || in.fmt == Rdna2Format::VOP3 ||
+                 in.fmt == Rdna2Format::MIMG || in.fmt == Rdna2Format::MUBUF || in.fmt == Rdna2Format::DS ||
+                 sopp_is_noop(in))) {
                 continue;
             }
+            if (scalar_side_effect) { ok = false; break; }
             // A pure scalar move (s_mov_b32/b64: no SCC/VCC/memory side effect) whose destination SGPR is
             // DEAD at the merge is also safe to linearize: the unconditional write is overwritten before any
             // later read, so masked-off lanes never observe it. (The tonemap/sRGB divergent-ifs load a scalar
@@ -1242,6 +1254,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // already sign-extended simm16 to 32 bits. (s_cmovk/s_cmpk/s_addk/s_mulk deferred.)
             switch (in.opcode) {
                 case 0x00: rs.sreg[in.dst.value] = b.uconst((uint32_t)in.simm16); break;   // s_movk_i32
+                // s_waitcnt_vscnt/vmcnt/expcnt/lgkmcnt: wait-for-counter — benign no-ops in our
+                // synchronous model (like SOPP s_waitcnt). These are SOPK on gfx10, NOT SOPP 0x7d
+                // as previously claimed (that case was unreachable dead code, and a real
+                // s_waitcnt_vscnt — routinely emitted after buffer/image stores — failed the whole
+                // shader recompile via this default). VERIFIED(round-trip llvm-mc gfx1010):
+                // vscnt=0xBBFD0000 (op 0x17), vmcnt=0xBC7D0000 (0x18), expcnt=0xBCFD0000 (0x19),
+                // lgkmcnt=0xBD7D0000 (0x1A).
+                case 0x17: case 0x18: case 0x19: case 0x1A: break;
                 default: ok = false;
             }
             return true;
@@ -1479,30 +1499,36 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // Add/sub with carry-in + carry-out (VOP3B): v_add_co_ci_u32 (0x128), v_sub_co_ci (0x129),
                 // v_subrev_co_ci (0x12A). carry-in = src2 mask (VCC or an SGPR bool); carry-out -> sdst mask.
                 // dst = s0 (+/-) s1 (+/-) cin; carryout = unsigned overflow (add) / borrow (sub).
-                const Operand& s2 = in.src[2]; uint32_t cin_mask = b.bfalse();
+                // Carry-in from an UNTRACKED mask must reject (like cndmask above), not silently
+                // default to 0 — a wrong carry produces 64-bit address math off by one in the low
+                // word with no diagnostic.
+                const Operand& s2 = in.src[2]; uint32_t cin_mask = 0;
                 if (s2.value == 106 || s2.value == 107) cin_mask = rs.vcc;
                 else if (s2.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(s2.value); if (it != rs.sreg_bool.end()) cin_mask = it->second; }
-                uint32_t a = val(in.src[0]), c = val(in.src[1]);
-                uint32_t cin = b.sel(cin_mask, b.uconst(1), b.uconst(0));
-                uint32_t res, cout;
-                if (in.opcode == 0x128) {                             // add: (a + b) + cin
-                    uint32_t s1 = b.ibin(Op_IAdd, a, c);
-                    uint32_t c1 = b.ucmp(Op_ULessThan, s1, a);        // wrap in a+b
-                    res = b.ibin(Op_IAdd, s1, cin);
-                    uint32_t c2 = b.ucmp(Op_ULessThan, res, s1);      // wrap in +cin
-                    cout = b.bsel(c1, b.btrue(), c2);                 // c1 || c2
-                } else {                                              // sub / subrev: (a - b) - cin (borrow)
-                    uint32_t x = in.opcode == 0x129 ? a : c, y = in.opcode == 0x129 ? c : a;  // subrev swaps
-                    uint32_t s1 = b.ibin(Op_ISub, x, y);
-                    uint32_t b1 = b.ucmp(Op_ULessThan, x, y);         // borrow in x-y
-                    res = b.ibin(Op_ISub, s1, cin);
-                    uint32_t b2 = b.ucmp(Op_ULessThan, s1, cin);      // borrow in -cin
-                    cout = b.bsel(b1, b.btrue(), b2);
+                if (!cin_mask) ok = false;
+                else {
+                    uint32_t a = val(in.src[0]), c = val(in.src[1]);
+                    uint32_t cin = b.sel(cin_mask, b.uconst(1), b.uconst(0));
+                    uint32_t res, cout;
+                    if (in.opcode == 0x128) {                             // add: (a + b) + cin
+                        uint32_t s1 = b.ibin(Op_IAdd, a, c);
+                        uint32_t c1 = b.ucmp(Op_ULessThan, s1, a);        // wrap in a+b
+                        res = b.ibin(Op_IAdd, s1, cin);
+                        uint32_t c2 = b.ucmp(Op_ULessThan, res, s1);      // wrap in +cin
+                        cout = b.bsel(c1, b.btrue(), c2);                 // c1 || c2
+                    } else {                                              // sub / subrev: (a - b) - cin (borrow)
+                        uint32_t x = in.opcode == 0x129 ? a : c, y = in.opcode == 0x129 ? c : a;  // subrev swaps
+                        uint32_t s1 = b.ibin(Op_ISub, x, y);
+                        uint32_t b1 = b.ucmp(Op_ULessThan, x, y);         // borrow in x-y
+                        res = b.ibin(Op_ISub, s1, cin);
+                        uint32_t b2 = b.ucmp(Op_ULessThan, s1, cin);      // borrow in -cin
+                        cout = b.bsel(b1, b.btrue(), b2);
+                    }
+                    vreg[in.dst.value] = res;
+                    // carry-out -> sdst mask (VCC or a saved SGPR-pair bool).
+                    if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = cout;
+                    else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = cout;
                 }
-                vreg[in.dst.value] = res;
-                // carry-out -> sdst mask (VCC or a saved SGPR-pair bool).
-                if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = cout;
-                else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = cout;
             } else if ((in.opcode == 0x365 || in.opcode == 0x366) && allow_wave && b.is_compute) {
                 // v_mbcnt_lo/hi_u32_b32 (cross-lane): dst = src1 + count of lanes below this one whose mask
                 // bit (src0) is set, in the low/high 32. The per-lane "mask bit" comes from src0: EXEC
@@ -1542,7 +1568,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const Operand& s2 = in.src[2]; uint32_t m = 0;        // src2 is an SGPR-pair (or VCC) wave mask
                 if (s2.value == 106 || s2.value == 107) m = rs.vcc;
                 else if (s2.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(s2.value); if (it != rs.sreg_bool.end()) m = it->second; }
-                if (!m) ok = false; else vreg[in.dst.value] = b.sel(m, val(in.src[1]), val(in.src[0]));
+                // fv (not val): cndmask is float-modifier-capable and compilers emit it with -v/|v|
+                // sources (sign-select idioms). Raw val() silently dropped neg/abs — the shader
+                // recompiled "successfully" and computed the un-negated value. fv == val when no
+                // modifier bits are set.
+                if (!m) ok = false; else vreg[in.dst.value] = b.sel(m, fv(1), fv(0));
             } else if (in.opcode == 0x11F) {                          // v_mac_f32_e64 (VOP3 form of VOP2 0x1f)
                 // dst = src0*src1 + dst, with the VOP3 float source modifiers (neg/abs via fv) and output
                 // modifiers (omod/clamp via fresult). The scene VS emits this e64 form with a `-|v10|`
@@ -1567,8 +1597,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x20:   // s_inst_prefetch  (I-cache hint)
                 case 0x21:   // s_clause         (memory-clause scheduling hint)
                 case 0x22:   // s_wait_idle
-                case 0x7d:   // s_waitcnt_vscnt
-                    break;
+                    break;   // (s_waitcnt_vscnt is SOPK on gfx10, not SOPP 0x7d — see the SOPK case)
                 case 0x08:                                          // s_cbranch_execz
                     if (in.simm16 < 0) ok = false;                 // backward = loop -> unsupported
                     else if (rs.exec_narrowed && (!safe_execz || !safe_execz->count(in.pc))) ok = false;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1531,8 +1531,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 vreg[in.dst.value] = fresult(b.fext2(Glsl_FMin, fv(0), fv(1)));
             } else if (in.opcode == 0x110) {                          // v_max_f32 (VOP3 form)
                 vreg[in.dst.value] = fresult(b.fext2(Glsl_FMax, fv(0), fv(1)));
-            } else if (in.opcode == 0x107) {                          // v_mul_legacy_f32 ~= s0*s1
-                vreg[in.dst.value] = fresult(b.fbin(Op_FMul, fv(0), fv(1)));
+            } else if (in.opcode == 0x107) {                          // v_mul_legacy_f32: DX9 multiply —
+                // 0 * x == 0 for ALL x including ±Inf/NaN (that guarantee is WHY compilers emit it,
+                // e.g. attenuation=0 times 1/dist). Plain IEEE FMul gives NaN for 0*Inf, so emit
+                // select(s0==0 || s1==0, 0, s0*s1). ±0.0 both compare equal to 0.0 under FOrdEqual.
+                uint32_t s0b = fv(0), s1b = fv(1), zb = b.uconst(0);
+                uint32_t anyz = b.lor(b.fcmp(Op_FOrdEqual, s0b, zb), b.fcmp(Op_FOrdEqual, s1b, zb));
+                vreg[in.dst.value] = fresult(b.sel(anyz, zb, b.fbin(Op_FMul, s0b, s1b)));
             } else if (in.opcode == 0x101) {                          // v_cndmask_b32_e64: src2_mask ? src1 : src0
                 const Operand& s2 = in.src[2]; uint32_t m = 0;        // src2 is an SGPR-pair (or VCC) wave mask
                 if (s2.value == 106 || s2.value == 107) m = rs.vcc;

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <unordered_set>
 #include <vector>
+#include <mutex>
 
 namespace prosper {
 
@@ -109,7 +110,13 @@ HLE(agc_dcb_set_index_size) {  // (buf, index_size, cache_policy)
 }
 HLE(agc_dcb_draw_index_auto) {  // (buf, index_count, modifier)
     uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DRAW_INDEX_AUTO, &cmd)) return 0;
-    cmd[1] = (uint32_t)a1; cmd[2] = 0; return (uint64_t)(uintptr_t)cmd;
+    cmd[1] = (uint32_t)a1;
+    // Store the draw modifier (ShaderDrawModifier bits) instead of dropping it, and zero the
+    // packet tail — cmd[3..6] previously carried stale ring-buffer memory inside a packet whose
+    // header says len=7 (poisoned GFXLOG dumps; live bug the moment a consumer reads past pl[0]).
+    cmd[2] = (uint32_t)(a2 & 0xffffffffu); cmd[3] = (uint32_t)(a2 >> 32u);
+    cmd[4] = cmd[5] = cmd[6] = 0;
+    return (uint64_t)(uintptr_t)cmd;
 }
 // sceAgcDcbDrawIndex (NID q88lQ+GP5Yk, name via shadPS4 aerolib.inl) — the indexed-draw sibling of
 // DrawIndexAuto. Kyty has no Gen5 reference; arg shape inferred from the Gen4 form
@@ -145,6 +152,9 @@ HLE(agc_dcb_acquire_mem) {  // (buf, engine, cb_db_op, gcr_cntl, ...) — 8 dw
 HLE(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address, data_sel, data, …)
     // ABI pinned to Kyty GraphicsCbReleaseMem (Graphics.cpp:1763): a5=label address, then the two stack
     // args are data_sel (7th) and the 64-bit fence value (8th). SysV: fp[1]=ret, fp[2]=data_sel, fp[3]=data.
+    // Valid under BOTH stub shapes: the guest-%fs swap stub forwards the first two stack args
+    // (exec_image_linux.cpp emit_swap_stub) — previously fp[2]/fp[3] were the saved guest-fs base and
+    // guest return address there, so every fence under PROSPER_GUEST_FS was written with garbage.
     volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
     uint64_t data_sel = fp[2], data = fp[3];
     if (getenv("PROSPER_GFXLOG"))
@@ -166,7 +176,14 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     // ABI per Kyty GraphicsDcbWriteData (Graphics.cpp:2061): a1=dst, a3=addr, a4=data ptr, a5=num_dwords.
     const uint32_t* src = (const uint32_t*)(uintptr_t)a4;
     uint32_t num = (uint32_t)a5;
-    if (num > 60) num = 60;   // clamp to keep the packet within a reasonable bound (labels/fences are tiny)
+    // Real PM4 WRITE_DATA carries a 14-bit dword count — accept up to that, and REJECT (loudly)
+    // anything larger as a mis-decoded arg. The previous silent clamp to 60 returned success while
+    // dropping the tail of any larger write (e.g. a 256-byte descriptor table), leaving the
+    // destination stale beyond dword 60 with no diagnostic. begin_packet bounds-checks the Dcb.
+    if (num > 0x3FFF) {
+        fprintf(stderr, "[agc] WriteData REJECTED num_dwords=%u (>PM4 max 0x3FFF — mis-decoded arg?)\n", num);
+        return 0;
+    }
     if (getenv("PROSPER_GFXLOG")) fprintf(stderr, "[agc] WriteData dst=0x%llx addr=0x%llx num=%u src=%p\n",
         (unsigned long long)a1,(unsigned long long)a3, num, (const void*)src);
     // Copy the inline data into the packet so the CommandProcessor can perform the write at submit time.
@@ -253,7 +270,11 @@ constexpr uint64_t kAgcErrInvalidArg = 0x8a6c000aull;
 
 // Shaders whose headers we already relocated (the fixup is not idempotent), and the registry of all
 // created shaders — the AGC->Vulkan pipeline consumes this to find shader code by PGM base.
+// The registry mutex covers CreateShader's push_back (guest loader threads) against the submit
+// thread's lookup iteration: an unsynchronized push_back REALLOCATION frees the vector's backing
+// store mid-iteration — a use-after-free read, not the "benign stale read" it was assumed to be.
 std::unordered_set<const void*>& agc_relocated() { static std::unordered_set<const void*> s; return s; }
+std::mutex&                      agc_shaders_mx() { static std::mutex m; return m; }
 std::vector<const AgcShader*>&   agc_shaders()   { static std::vector<const AgcShader*> v; return v; }
 
 // Relocate one self-relative pointer field in place (no-op for null fields).
@@ -264,16 +285,20 @@ template <class T> inline void agc_fix_ptr(T*& m) {
 }  // namespace
 
 // Exposed for tests: how many shaders the guest successfully registered.
-extern "C" size_t prosper_agc_shader_count() { return agc_shaders().size(); }
+extern "C" size_t prosper_agc_shader_count() {
+    std::lock_guard<std::mutex> lk(agc_shaders_mx());
+    return agc_shaders().size();
+}
 
 // Look up a registered shader header by its bound code address (the SHADER_PGM base the executor
 // recovers from the sh registers). Returns the AgcShader* (layout-compatible with gpu::AgcShaderHeader
 // — file_header@0, user_data@0x08, code@0x10, type@0x5a) so the GPU executor can build the shader's
 // resource table from its user_data descriptors. Null if no registered shader binds that code. The
-// registry is append-only during boot and CreateShader is main-thread; reads here are on the submit
-// thread — benign for a lookup (worst case a just-registered shader isn't seen yet, then it retries).
+// registry is written by guest loader threads (CreateShader) and read on the submit thread; both
+// sides take the registry mutex (an unlocked read raced push_back's reallocation — UAF).
 extern "C" const void* prosper_agc_shader_header_for_code(uint64_t code_addr) {
     if (!code_addr) return nullptr;
+    std::lock_guard<std::mutex> lk(agc_shaders_mx());
     for (const AgcShader* h : agc_shaders())
         if (h && (uint64_t)(uintptr_t)h->code == code_addr) return h;
     return nullptr;
@@ -412,7 +437,7 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
     }
     pipetrace_shader_user_data("CreateShader", h);
 
-    agc_shaders().push_back(h);
+    { std::lock_guard<std::mutex> lk(agc_shaders_mx()); agc_shaders().push_back(h); }
     *dst = h;               // <- the write our old stub omitted; populates the shader-registry slots
     return 0;
 }

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -179,7 +179,9 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     // Real PM4 WRITE_DATA carries a 14-bit dword count — accept up to that, and REJECT (loudly)
     // anything larger as a mis-decoded arg. The previous silent clamp to 60 returned success while
     // dropping the tail of any larger write (e.g. a 256-byte descriptor table), leaving the
-    // destination stale beyond dword 60 with no diagnostic. begin_packet bounds-checks the Dcb.
+    // destination stale beyond dword 60 with no diagnostic. An accepted-but-large num cannot
+    // overrun the ring: begin_packet -> allocate_dw() checks 5+num against available_dw() (with
+    // the grow callback) and returns null on failure, which takes the `return 0` path below.
     if (num > 0x3FFF) {
         fprintf(stderr, "[agc] WriteData REJECTED num_dwords=%u (>PM4 max 0x3FFF — mis-decoded arg?)\n", num);
         return 0;

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -27,10 +27,18 @@ constexpr int kVolume0dB = 32768;   // SCE_AUDIO_VOLUME_0DB
 
 struct Port {
     bool          in_use = false;
+    int           type = 0;   // SceAudioOutPortType (0=MAIN, 1=BGM, 2=VOICE, 3=PERSONAL, 4=PADSPK, 127=AUX)
     AudioPortInfo info;
     int           vol[8] = { kVolume0dB, kVolume0dB, kVolume0dB, kVolume0dB,
                              kVolume0dB, kVolume0dB, kVolume0dB, kVolume0dB };
 };
+
+// SCE audio error codes the guest actually tests for (Kyty Errno.h:342/344). A generic -1 is
+// unrecognizable to retry-vs-abort logic (a single wrong errno already caused a full render
+// stall once — see hle_service.cpp's GetEvent note). Sign-extended: the guest ABI returns
+// int32 in eax (negative), and host-side callers/tests compare the full u64 as int64.
+constexpr uint64_t kAudioErrInvalidPort = (uint64_t)(int64_t)(int32_t)0x80260003;
+constexpr uint64_t kAudioErrPortFull    = (uint64_t)(int64_t)(int32_t)0x80260005;
 
 std::mutex g_mx;                 // guards the port table
 Port       g_ports[kMaxPorts];
@@ -109,23 +117,25 @@ HLE(audio_init) { (void)a0; return 0; }   // sceAudioOutInit: idempotent success
 
 // sceAudioOutOpen(userId, type, index, len, freq, param) -> handle (>=1) or negative error.
 HLE(audio_open) {
-    (void)a0; (void)a1; (void)a2;
+    (void)a0; (void)a2;
     AudioPortInfo info;
     info.grain = (int)(a3 ? a3 : 256);
     info.freq  = (int)(a4 ? a4 : 48000);
     audio_decode_format((uint32_t)a5, info.channels, info.fmt);
+    int type = (int)a1;   // kept for GetPortState's type-dependent output/channel report
 
     int handle = 0;
     { std::lock_guard<std::mutex> lk(g_mx);
       for (int i = 0; i < kMaxPorts; i++) {
           if (g_ports[i].in_use) continue;
           g_ports[i].in_use = true;
+          g_ports[i].type = type;
           g_ports[i].info = info;
           for (int c = 0; c < 8; c++) g_ports[i].vol[c] = kVolume0dB;
           handle = i + 1;
           break;
       } }
-    if (!handle) return (uint64_t)(int64_t)-1;   // no free port
+    if (!handle) return kAudioErrPortFull;
     if (auto* s = audio_sink()) s->open(handle, info);
     return (uint64_t)handle;
 }
@@ -133,7 +143,7 @@ HLE(audio_open) {
 // sceAudioOutOutput(handle, ptr) -> frames written (>=0) or negative error. ptr==0 => drain.
 HLE(audio_output) {
     AudioPortInfo info;
-    { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return (uint64_t)(int64_t)-1; info = p->info; }
+    { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return kAudioErrInvalidPort; info = p->info; }
     if (a1 == 0) return 0;   // drain/flush: nothing buffered in the headless model
     if (auto* s = audio_sink()) s->output((int)a0, P(a1), info.grain);
     return (uint64_t)info.grain;
@@ -162,7 +172,7 @@ HLE(audio_set_volume) {
     uint32_t mask = (uint32_t)a1;
     const int* vols = (const int*)P(a2);
     { std::lock_guard<std::mutex> lk(g_mx);
-      Port* p = port_of((int)a0); if (!p) return (uint64_t)(int64_t)-1;
+      Port* p = port_of((int)a0); if (!p) return kAudioErrInvalidPort;
       if (vols) { int vi = 0; for (int c = 0; c < 8; c++) if (mask & (1u << c)) p->vol[c] = vols[vi++]; } }
     if (auto* s = audio_sink()) s->set_volume((int)a0, mask, vols);
     return 0;
@@ -172,21 +182,29 @@ HLE(audio_set_volume) {
 HLE(audio_close) {
     int handle = (int)a0;
     { std::lock_guard<std::mutex> lk(g_mx);
-      Port* p = port_of(handle); if (!p) return (uint64_t)(int64_t)-1; p->in_use = false; }
+      Port* p = port_of(handle); if (!p) return kAudioErrInvalidPort; p->in_use = false; }
     if (auto* s = audio_sink()) s->close(handle);
     return 0;
 }
 
 // sceAudioOutGetPortState(handle, SceAudioOutPortState* state) -> 0 or negative error.
+// Layout per Kyty Audio.cpp:340 (the previous fill invented its own: channel as u16 @2
+// clobbering reserved1, volume as u32 @8 — which is the FLAG field — and left the real
+// volume @4 zero, i.e. "muted"): uint16 output @0; uint8 channel @2; uint8 reserved @3;
+// int16 volume @4; uint16 reroute_counter @6; uint64 flag @8; uint64 reserved2[2] @0x10.
 HLE(audio_get_port_state) {
-    int channels;
-    { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return (uint64_t)(int64_t)-1; channels = p->info.channels; }
-    if (a1) {   // SceAudioOutPortState (0x20): uint16 output; uint16 channel; ...; uint32 volume
+    int channels, type;
+    { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return kAudioErrInvalidPort;
+      channels = p->info.channels; type = p->type; }
+    if (a1) {
         auto* st = (uint8_t*)P(a1);
         memset(st, 0, 0x20);
-        *(uint16_t*)(st + 0) = 1;                     // output: enabled
-        *(uint16_t*)(st + 2) = (uint16_t)channels;    // channels
-        *(uint32_t*)(st + 8) = (uint32_t)kVolume0dB;  // volume
+        *(int16_t*)(st + 4) = 127;   // volume (Kyty AudioOutGetPortState reports 127)
+        switch (type) {              // output/channel are port-type dependent (Kyty :432-448)
+            case 3: case 127: /* output=0, channel=0 */ break;
+            case 4:  *(uint16_t*)(st + 0) = 4; st[2] = 1; break;                          // pad speaker
+            default: *(uint16_t*)(st + 0) = 1; st[2] = (uint8_t)(channels > 2 ? 2 : channels); break;
+        }
     }
     return 0;
 }

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -234,7 +234,26 @@ static void preadlog(const char*, uint64_t, uint64_t, uint64_t) {}
 // spurious guest close(0) then kills a live file mid-load (proven: unity_builtin_extra's block-2
 // pread hit EBADF -> Unity silently kept a stale 64KB cache block -> deser crash at eboot+0x46beb4).
 // So: (a) never return fd<3 from open (dup up); (b) refuse guest closes of fd 0-2.
-HLE(f_open)  { std::string h = translate(CS(a0)); int fd = (int)::open(h.c_str(), (int)a1, (mode_t)a2);
+// FreeBSD/Orbis open(2) flags share only the access mode with Linux: SCE O_CREAT=0x0200,
+// O_TRUNC=0x0400, O_EXCL=0x0800 vs Linux 0x40/0x200/0x80. Passing the guest word raw turned
+// "O_WRONLY|O_CREAT" (0x201) into Linux "O_WRONLY|O_TRUNC" — write-path opens failed with
+// ENOENT on new files and silently truncated existing ones. Translate bit by bit (same
+// FreeBSD-vs-Linux reason the stat struct is already translated below).
+static int host_open_flags(uint64_t f) {
+    int h = (int)(f & 3);                       // O_RDONLY/O_WRONLY/O_RDWR coincide
+    if (f & 0x0008) h |= O_APPEND;              // FreeBSD O_APPEND
+    if (f & 0x0200) h |= O_CREAT;
+    if (f & 0x0400) h |= O_TRUNC;
+    if (f & 0x0800) h |= O_EXCL;
+#ifndef _WIN32
+    if (f & 0x0004) h |= O_NONBLOCK;
+    if (f & 0x0080) h |= O_SYNC;                // FreeBSD O_FSYNC
+    if (f & 0x0100) h |= O_NOFOLLOW;
+    if (f & 0x00020000) h |= O_DIRECTORY;
+#endif
+    return h;
+}
+HLE(f_open)  { std::string h = translate(CS(a0)); int fd = (int)::open(h.c_str(), host_open_flags(a1), (mode_t)a2);
 #ifndef _WIN32
                while (fd >= 0 && fd < 3) { int nfd = fcntl(fd, F_DUPFD, 3); ::close(fd); fd = nfd; }
 #endif

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -239,6 +239,24 @@ HLE(k_attr_getaffinity) {
     if (a1) *(uint64_t*)(uintptr_t)a1 = one ? 0x01 : 0xff;
     return 0;
 }
+// Scheduling Get* handlers. The Set* side is a legitimate no-op (we don't re-prioritize host
+// threads), but a Get* that returns SUCCESS while never writing its out-params hands the caller
+// uninitialized stack memory — the exact harmful-stub class k_attr_getaffinity above was fixed
+// for. Report deterministic defaults: policy SCHED_OTHER(=1)-equivalent RR, priority 700 (the
+// Sony default thread priority; Kyty Pthread.cpp uses the same 700 midpoint).
+HLE(k_getschedparam)      { // scePthread/pthread_getschedparam(thread, int* policy, SchedParam* param)
+    if (a1) *(int32_t*)(uintptr_t)a1 = 1;
+    if (a2) *(int32_t*)(uintptr_t)a2 = 700;   // SceKernelSchedParam = { int sched_priority }
+    return 0;
+}
+HLE(k_attr_getschedparam) { // scePthreadAttrGetschedparam(attr, SchedParam* param)
+    if (a1) *(int32_t*)(uintptr_t)a1 = 700;
+    return 0;
+}
+HLE(k_getprio)            { // scePthreadGetprio(thread, int* prio)
+    if (a1) *(int32_t*)(uintptr_t)a1 = 700;
+    return 0;
+}
 
 // --- thread creation: run the guest entry on a real host thread (ABI matches) ---
 // We give each worker a stack we allocate and TRACK, so GC/thread-stack queries get
@@ -335,15 +353,44 @@ HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
 HLE(k_ef_delete)  { if (a0) free((void*)(uintptr_t)a0); return 0; }
 HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits |= a1; pthread_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
 HLE(k_ef_clear)   { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits &= a1; pthread_mutex_unlock(&e->m); return 0; }
-HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, timeout*)
+// Absolute CLOCK_REALTIME deadline `usec` microseconds from now (for pthread_cond_timedwait
+// on default-attr condvars, which time against CLOCK_REALTIME).
+static timespec abs_deadline_us(uint64_t usec) {
+    timespec ts; clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec  += (time_t)(usec / 1000000u);
+    ts.tv_nsec += (long)(usec % 1000000u) * 1000L;
+    if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
+    return ts;
+}
+HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* timeout)
+    // The timeout arg (a4) was previously IGNORED — a bounded guest wait blocked forever (the
+    // same class of silent hang root-caused for wait_on_address, hle_kernel_mem.cpp). Sony
+    // semantics: *timeout is a u32 microsecond budget, updated on return with the time left;
+    // expiry returns KERNEL_ERROR_ETIMEDOUT (Kyty EventFlag.cpp / Errno.h 0x8002003C).
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
+    uint64_t ret = 0;
     pthread_mutex_lock(&e->m);
-    while (!evf_match(e->bits, a1, (uint32_t)a2)) pthread_cond_wait(&e->c, &e->m);
+    if (a4) {
+        uint32_t usec = *(uint32_t*)(uintptr_t)a4;
+        timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
+        timespec dl = abs_deadline_us(usec);
+        int rc = 0;
+        while (!evf_match(e->bits, a1, (uint32_t)a2) && rc != ETIMEDOUT)
+            rc = pthread_cond_timedwait(&e->c, &e->m, &dl);
+        timespec t1; clock_gettime(CLOCK_MONOTONIC, &t1);
+        int64_t spent_i = (int64_t)(t1.tv_sec - t0.tv_sec) * 1000000
+                        + ((int64_t)t1.tv_nsec - (int64_t)t0.tv_nsec) / 1000;
+        uint64_t spent = spent_i < 0 ? 0u : (uint64_t)spent_i;
+        *(uint32_t*)(uintptr_t)a4 = spent >= usec ? 0u : (uint32_t)(usec - spent);
+        if (!evf_match(e->bits, a1, (uint32_t)a2)) ret = 0x8002003Cull;  // KERNEL_ERROR_ETIMEDOUT
+    } else {
+        while (!evf_match(e->bits, a1, (uint32_t)a2)) pthread_cond_wait(&e->c, &e->m);
+    }
     uint64_t res = e->bits;
-    if (a2 & 0x10) e->bits = 0; else if (a2 & 0x20) e->bits &= ~a1;   // CLEAR_ALL / CLEAR_PAT
+    if (!ret) { if (a2 & 0x10) e->bits = 0; else if (a2 & 0x20) e->bits &= ~a1; }  // CLEAR_ALL / CLEAR_PAT
     pthread_mutex_unlock(&e->m);
     if (a3) *(uint64_t*)(uintptr_t)a3 = res;
-    return 0;
+    return ret;
 }
 HLE(k_ef_poll)    { // (ef, pattern, waitMode, resultPat*)
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
@@ -367,9 +414,29 @@ HLE(k_sema_create) { // (sema*, name, attr, initCount, maxCount, opt)
     return 0;
 }
 HLE(k_sema_delete) { if (a0) free((void*)(uintptr_t)a0); return 0; }
-HLE(k_sema_wait)   { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
+HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout honored like k_ef_wait
+    auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
     if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
-    pthread_mutex_lock(&s->m); while (s->count < need) pthread_cond_wait(&s->c, &s->m); s->count -= need; pthread_mutex_unlock(&s->m); return 0; }
+    uint64_t ret = 0;
+    pthread_mutex_lock(&s->m);
+    if (a2) {
+        uint32_t usec = *(uint32_t*)(uintptr_t)a2;
+        timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
+        timespec dl = abs_deadline_us(usec);
+        int rc = 0;
+        while (s->count < need && rc != ETIMEDOUT) rc = pthread_cond_timedwait(&s->c, &s->m, &dl);
+        timespec t1; clock_gettime(CLOCK_MONOTONIC, &t1);
+        int64_t spent_i = (int64_t)(t1.tv_sec - t0.tv_sec) * 1000000
+                        + ((int64_t)t1.tv_nsec - (int64_t)t0.tv_nsec) / 1000;
+        uint64_t spent = spent_i < 0 ? 0u : (uint64_t)spent_i;
+        *(uint32_t*)(uintptr_t)a2 = spent >= usec ? 0u : (uint32_t)(usec - spent);
+        if (s->count < need) ret = 0x8002003Cull;    // KERNEL_ERROR_ETIMEDOUT
+    } else {
+        while (s->count < need) pthread_cond_wait(&s->c, &s->m);
+    }
+    if (!ret) s->count -= need;
+    pthread_mutex_unlock(&s->m);
+    return ret; }
 HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n = a1 ? (int64_t)a1 : 1;
     if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
     pthread_mutex_lock(&s->m); s->count += n; pthread_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
@@ -716,16 +783,16 @@ void register_kernel_hle() {
     R("scePthreadAttrSetschedpolicy", k_attr_noop);
     R("scePthreadAttrSetschedparam", k_attr_noop);
     R("scePthreadAttrSetdetachstate", k_attr_noop);
-    R("scePthreadAttrGetschedparam", k_attr_noop);
+    R("scePthreadAttrGetschedparam", k_attr_getschedparam);
     R("scePthreadAttrGet", k_attr_get);
     R("scePthreadAttrGetstackaddr", k_attr_getstackaddr);
     R("scePthreadAttrGetstacksize", k_attr_getstacksize);
     R("scePthreadAttrGetaffinity", k_attr_getaffinity);  // report 8 cores (not an empty mask)
     R("scePthreadAttrSetaffinity", k_attr_noop);         // accept affinity requests (we don't pin)
     R("scePthreadGetaffinity", k_attr_getaffinity);      R("scePthreadSetaffinity", k_attr_noop);
-    R("scePthreadGetschedparam", k_attr_noop);  R("pthread_getschedparam", k_attr_noop);
+    R("scePthreadGetschedparam", k_getschedparam);  R("pthread_getschedparam", k_getschedparam);
     R("scePthreadSetschedparam", k_attr_noop);  R("scePthreadSetprio", k_attr_noop);
-    R("scePthreadGetprio", k_attr_noop);
+    R("scePthreadGetprio", k_getprio);
     R("scePthreadGetstack", k_attr_getstackaddr);
     // TLS keys (POSIX + Sony names -> host pthread keys)
     R("pthread_key_create", k_key_create);   R("scePthreadKeyCreate", k_key_create);

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -95,6 +95,33 @@ namespace {
         if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
         g_maps.push_back(m);
     }
+    // Trim/split tracked mappings overlapping [base, base+len). munmap/BatchMap-UNMAP must remove
+    // their tracking (this never happened before — g_maps only ever grew): stale "committed"
+    // records made VirtualQuery report freed VAs as live, made the fault handler's lazy-commit
+    // probe (prosper_reserved_range_state) mis-decide on re-reserved ranges, and let the render
+    // thread's safe_copy memcpy a texture whose backing the game had batch-unmapped — the exact
+    // SIGSEGV class safe_copy exists to prevent (same overlap-trim shape as dmem_release above).
+    void untrack(uint64_t base, uint64_t len) {
+        if (!len) return;
+        uint64_t end = base + len;
+        std::lock_guard<std::mutex> lk(g_mx);
+        std::vector<Mapping> out;
+        out.reserve(g_maps.size() + 1);
+        for (auto& m : g_maps) {
+            uint64_t me = m.base + m.size;
+            if (me <= base || m.base >= end) { out.push_back(m); continue; }
+            if (m.base < base) { Mapping lo = m; lo.size = base - m.base; out.push_back(lo); }
+            if (me > end)      { Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi); }
+        }
+        g_maps.swap(out);
+    }
+    // Re-tag [base, base+len) with a new protection (mprotect): replace the overlapped span so
+    // VirtualQuery/the fault probe report the CURRENT prot, not the one from map time.
+    void retrack_prot(uint64_t base, uint64_t len, int prot, const char* nm) {
+        if (!len) return;
+        untrack(base, len);
+        track(base, len, prot, true, nm);
+    }
     const Mapping* find(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);
         const Mapping* best = nullptr;
@@ -401,8 +428,8 @@ HLE(k_wake_by_address) {
     return 0;
 }
 
-HLE(k_munmap)   { if (a0) munmap((void*)a0, a1); return 0; }
-HLE(k_mprotect) { if (a0) mprotect((void*)a0, a1, host_prot(a2)); return 0; }
+HLE(k_munmap)   { if (a0) { munmap((void*)a0, a1); untrack(a0, a1); } return 0; }
+HLE(k_mprotect) { if (a0) { mprotect((void*)a0, a1, host_prot(a2)); retrack_prot(a0, a1, host_prot(a2), "mprotect"); } return 0; }
 HLE(k_dmem_size){ return kDmemTotal; }   // 8 GiB pool (allocation failures enforce this bound)
 
 // --- libSceAmpr (PS5 async memory-programming engine) -------------------------------------------
@@ -499,9 +526,10 @@ HLE(k_batch_map) {
                 if (ok) track((uint64_t)p, len, host_prot(prot), true, "batch-flex");
                 break;
             }
-            case 1: if (start) munmap((void*)(uintptr_t)start, len); break;              // UNMAP
+            case 1: if (start) { munmap((void*)(uintptr_t)start, len); untrack(start, len); } break;  // UNMAP
             case 2: case 4:                                                              // PROTECT / TYPE_PROTECT
-                if (start) mprotect((void*)(uintptr_t)start, len, host_prot(prot)); break;
+                if (start) { mprotect((void*)(uintptr_t)start, len, host_prot(prot));
+                             retrack_prot(start, len, host_prot(prot), "batch-prot"); } break;
             default: ok = false; ret = 0x80020016ull; break;
         }
         if (!ok) { if (!ret) ret = 0x8002000Cull; break; }   // ENOMEM on a failed map

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -158,7 +158,11 @@ namespace {
     // fflags@0xC(u32), data@0x10, udata@0x18. The game reads udata (its flip context) + data.
     struct SceKEvent { int64_t ident; int16_t filter; uint16_t flags; uint32_t fflags; int64_t data; uint64_t udata; };
     // PS5 filter ids (negative, FreeBSD-style). VideoOut flip/vblank use the DISPLAY filter family.
-    constexpr int16_t EVFILT_VIDEO_OUT = -0x0a;   // SCE VideoOut event filter (flip + vblank)
+    // SCE VideoOut event filter (flip + vblank): -13 per BOTH references (Kyty EventQueue.h:19
+    // KERNEL_EVFILT_VIDEO_OUT = -13; shadPS4 equeue.h Filter::VideoOut = -13). The previous -10
+    // is FreeBSD's EVFILT_LIO and matched neither — guest code switching on event.filter (the
+    // standard way to recognize a flip kevent, cf. Kyty's assert) would never match our events.
+    constexpr int16_t EVFILT_VIDEO_OUT = -13;
     // VideoOut event idents (Kyty VideoOut.cpp:34): the kevent's ident names the EVENT KIND, not the
     // videoout handle. A flip event's data is the completed flip's flipArg (Kyty
     // flip_event_trigger_func) — the game compares it against the arg it submitted.

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -11,6 +11,9 @@
 #include <cctype>
 #include <cmath>
 #include <cerrno>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
 #ifdef _WIN32
 #include <malloc.h>   // _aligned_malloc
 #endif
@@ -237,22 +240,66 @@ HLE(h_setlocale)  { static char c[] = "C"; return (uint64_t)(uintptr_t)c; }
 HLE(h_atexit)      { return 0; }
 HLE(h_cxa_atexit)  { return 0; }
 HLE(h_cxa_finalize){ return 0; }
-// Itanium C++ ABI static-init guards: byte 0 of the guard = "initialized".
-HLE(h_guard_acquire) { uint8_t* g = (uint8_t*)P(a0); return (*g) ? 0 : 1; }
-HLE(h_guard_release) { uint8_t* g = (uint8_t*)P(a0); *g = 1; return 0; }
-HLE(h_guard_abort)   { return 0; }
+// Itanium C++ ABI static-init guards: byte 0 of the guard = "initialized", byte 1 = an init is in
+// flight. The old implementation was a non-atomic check with no blocking, so two threads racing an
+// uninitialized function-local static BOTH got "you initialize" — concurrent double-construction
+// (torn singletons) in the guest's 15-thread IL2CPP pool. Real contract: acquire returns 1 to
+// exactly one thread and blocks the rest until release/abort. Contenders park on one global
+// mutex/condvar pair (init is cold; the winner runs its constructor OUTSIDE the lock, so
+// independent guards cannot deadlock each other); the fast path stays a lock-free acquire-load.
+namespace { std::mutex g_guard_mx; std::condition_variable g_guard_cv; }
+HLE(h_guard_acquire) {
+    auto* g = (std::atomic<uint8_t>*)P(a0);
+    if (g->load(std::memory_order_acquire)) return 0;      // already initialized
+    std::unique_lock<std::mutex> lk(g_guard_mx);
+    for (;;) {
+        if (g->load(std::memory_order_acquire)) return 0;  // init finished while we waited
+        uint8_t* busy = (uint8_t*)g + 1;
+        if (!*busy) { *busy = 1; return 1; }               // we win: caller runs the initializer
+        g_guard_cv.wait(lk);
+    }
+}
+HLE(h_guard_release) {
+    auto* g = (std::atomic<uint8_t>*)P(a0);
+    { std::lock_guard<std::mutex> lk(g_guard_mx);
+      ((uint8_t*)g)[1] = 0;
+      g->store(1, std::memory_order_release); }
+    g_guard_cv.notify_all();
+    return 0;
+}
+HLE(h_guard_abort) {   // initializer threw: clear busy so another thread can retry
+    auto* g = (std::atomic<uint8_t>*)P(a0);
+    { std::lock_guard<std::mutex> lk(g_guard_mx); ((uint8_t*)g)[1] = 0; }
+    g_guard_cv.notify_all();
+    return 0;
+}
 
 // std::_Execute_once(once_flag&, int(*cb)(void*,void*,void**), void* arg) — the guts
 // of std::call_once. It MUST invoke the callback (which runs the real one-time init),
-// exactly once per flag, and return nonzero on success (call_once throws on 0).
+// exactly once per flag, and return nonzero on success (call_once throws on 0). The old
+// check-then-run had no synchronization: concurrent first calls ran the initializer twice
+// in parallel. Flag word: 0 = not run, 2 = running, 1 = done; the callback runs OUTSIDE
+// the lock so once-inits that depend on other threads' progress can't deadlock.
 HLE(h_execute_once) {
-    uint32_t* flag = (uint32_t*)P(a0);
-    if (flag && *flag) return 1;                 // already executed
+    auto* flag = (std::atomic<uint32_t>*)P(a0);
     auto cb = (int (*)(void*, void*, void**))P(a1);
-    int r = 1;
-    if (cb) { void* ctx = nullptr; r = cb((void*)P(a0), (void*)P(a2), &ctx); }
-    if (flag) *flag = 1;
-    return (uint64_t)(r ? 1 : 0);
+    if (!flag) { void* ctx = nullptr; return (uint64_t)((!cb || cb(nullptr, (void*)P(a2), &ctx)) ? 1 : 0); }
+    for (;;) {
+        if (flag->load(std::memory_order_acquire) == 1) return 1;   // already executed
+        std::unique_lock<std::mutex> lk(g_guard_mx);
+        uint32_t v = flag->load(std::memory_order_acquire);
+        if (v == 1) return 1;
+        if (v == 2) { g_guard_cv.wait(lk); continue; }              // another thread is running it
+        flag->store(2, std::memory_order_relaxed);
+        lk.unlock();
+        void* ctx = nullptr;
+        int r = cb ? cb((void*)P(a0), (void*)P(a2), &ctx) : 1;
+        lk.lock();
+        flag->store(r ? 1u : 0u, std::memory_order_release);        // failure -> retryable next call
+        lk.unlock();
+        g_guard_cv.notify_all();
+        return (uint64_t)(r ? 1 : 0);
+    }
 }
 // C++ exception refcounting — no-op is safe for the non-throwing boot path.
 HLE(h_cxa_dec_refcount) { return 0; }

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -60,6 +60,20 @@ HLE(s_mouse_read)     { if (a1) memset(PW(a1), 0, 0x18); return 0; }
 // --- app content ---
 HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = 0; return 0; }
 
+// sceSystemServiceGetStatus(SceSystemServiceStatus* status) — the out-struct is ARG 0 (single-arg
+// call). This was aliased to s_appcontent_int, which returned success while writing 4 bytes through
+// a1 — whatever stale value the caller left in RSI — and left the real status struct uninitialized.
+// Layout cross-checked against Kyty LibSystemService.cpp:83: int32 eventNum @0; bool
+// isSystemUiOverlaid @4, isInBackgroundExecution @5, isCpuMode7CpuNormal @6 (defaults TRUE),
+// isGameLiveStreamingOnAir @7, isOutOfVrPlayArea @8; 12 bytes with tail padding.
+HLE(s_syss_getstatus) {
+    auto* st = (uint8_t*)PW(a0);
+    if (!st) return 0x80A10003ull;   // SYSTEM_SERVICE_ERROR_PARAMETER (Kyty Errno.h:382)
+    memset(st, 0, 12);
+    st[6] = 1;                       // isCpuMode7CpuNormal = true
+    return 0;
+}
+
 // sceAppContentTemporaryDataMount2(option, SceAppContentMountPoint* mp) — mount the app's temp-data
 // area and write its guest path into mp. SceAppContentMountPoint = char data[16] (shadPS4
 // app_content.h; PS4/PS5 identical). shadPS4 writes exactly "/temp0\0" and returns 0. Our previous
@@ -152,7 +166,7 @@ void register_service_hle() {
     R("sceMsgDialogGetStatus", s_dialog_finished);
     R("sceMsgDialogGetResult", s_dialog_result);
     R("sceSystemServiceHideSplashScreen", s_ok);
-    R("sceSystemServiceGetStatus", s_appcontent_int);
+    R("sceSystemServiceGetStatus", s_syss_getstatus);
     #undef R
 }
 

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -58,7 +58,14 @@ namespace {
     // trustworthy way to inspect deep crashes (e.g. the null std::ctype facet at eboot+0x3b5ea6).
     bool g_faultmem = false;
     bool g_faultlog = false;
-    int  g_devnull_fd = -1;
+    // Probe pipe for probe_readable() below — a pipe write imports the source pages (EFAULT on
+    // unmapped memory) where a /dev/null write does not. O_NONBLOCK so a full pipe can never
+    // block the fault handler; drained after every probe.
+    int  g_probe_pipe[2] = {-1, -1};
+    void ensure_probe_pipe() {
+        if (g_probe_pipe[0] < 0 && pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) != 0)
+            g_probe_pipe[0] = g_probe_pipe[1] = -1;
+    }
     // DIAGNOSTIC (PROSPER_SKIP_NULL_COMPANION, default off): at the Unity GfxDevice pipeline reader
     // eboot+0xba6e08 — which derefs a null GPU-companion pointer [obj+0x140] for pipelines that were
     // never processed — log the object state and redirect RIP to the reader's own skip label
@@ -285,11 +292,18 @@ namespace {
     PeekSpec g_peek[6] = {};
     int      g_peek_specs = 0;
 
-    // Async-signal-safe readability probe: write() to /dev/null returns EFAULT (not a fault) for
-    // an unmapped source, so we can test guest addresses without risking a nested SIGSEGV.
+    // Async-signal-safe readability probe. NOTE: /dev/null does NOT work for this — the kernel's
+    // null_write returns count without ever touching the source buffer, so it reports EVERY
+    // address "readable" (verified empirically on this project's WSL kernel: writing an unmapped
+    // pointer to /dev/null returned success; the same write to a pipe returned EFAULT). A pipe
+    // write actually imports the user pages. Raw syscalls: this runs inside the fault handler
+    // where glibc write()/read() are guest-%fs-unsafe; we drain what we wrote immediately so the
+    // pipe can never fill (probes are single small reads, well under PIPE_BUF).
     bool probe_readable(uint64_t a) {
-        if (a < 0x1000 || g_devnull_fd < 0) return false;
-        return write(g_devnull_fd, (const void*)a, 8) == 8;
+        if (a < 0x1000 || g_probe_pipe[1] < 0) return false;
+        long w = syscall(SYS_write, g_probe_pipe[1], (const void*)a, 8);
+        if (w > 0) { char b[8]; syscall(SYS_read, g_probe_pipe[0], b, (size_t)w); }
+        return w == 8;
     }
     void dump_fault_mem() {
         if (!g_faultmem) return;
@@ -824,17 +838,27 @@ namespace {
             }
         }
         // Lazy unified-memory backing: back an unmapped GPU-VA page on demand and retry.
-        if (sig == SIGSEGV && si->si_addr) {
+        // Gates (both required — everything interesting lives inside the 4-64 GiB window,
+        // including guest module images and dmem mappings):
+        //  - si_code == SEGV_MAPERR: only back genuinely UNMAPPED pages. A protection fault
+        //    (SEGV_ACCERR, e.g. a guest write to a CPU_READ-only dmem mapping) must NOT be
+        //    "handled" by mmap'ing a detached zero page over the live mapping — that silently
+        //    destroys the original contents and breaks memfd CPU/GPU aliasing.
+        //  - fault addr != RIP: an instruction fetch through a garbage-but-in-window pointer
+        //    would get a non-executable RW page mapped at RIP, refault with SEGV_ACCERR at the
+        //    same address forever (infinite fault loop) instead of a clean fault report.
+        if (sig == SIGSEGV && si->si_addr && si->si_code == SEGV_MAPERR) {
             uint64_t a = (uint64_t)si->si_addr;
-            if (a >= GPU_VA_LO && a < GPU_VA_HI) {
+            uint64_t rip = (uint64_t)((ucontext_t*)uctx)->uc_mcontext.gregs[REG_RIP];
+            if (a >= GPU_VA_LO && a < GPU_VA_HI && a != rip) {
                 void* page = (void*)(a & ~(uint64_t)0xfff);
                 bool ok = mmap(page, 0x1000, PROT_READ | PROT_WRITE,
                                MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == page;
                 if (g_faultlog) {
-                    char b[128]; auto* uc = (ucontext_t*)uctx;
+                    char b[128];
                     int n = snprintf(b, sizeof b, "[fault] GPU-VA %s addr=0x%llx rip=0x%llx\n",
                                      ok ? "mapped" : "MMAP-FAILED", (unsigned long long)a,
-                                     (unsigned long long)uc->uc_mcontext.gregs[REG_RIP]);
+                                     (unsigned long long)rip);
                     syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
                 }
                 if (ok) { g_lazy_pages = g_lazy_pages + 1; return; }  // re-execute against the now-mapped page
@@ -1093,8 +1117,7 @@ void install_trap_handler() {
     g_watch_companion = getenv("PROSPER_WATCH_COMPANION") != nullptr;
     if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
     if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
-    if ((g_faultmem || g_skip_null_companion) && g_devnull_fd < 0)
-        g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+    if (g_faultmem || g_skip_null_companion) ensure_probe_pipe();
     // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
     // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).
     if (const char* pk = getenv("PROSPER_PEEK")) {
@@ -1124,7 +1147,7 @@ void install_trap_handler() {
     if (const char* bp = getenv("PROSPER_BP")) {
         g_bp_addr = 0x400000000ull + strtoull(bp, nullptr, 0);
         if (const char* m = getenv("PROSPER_BP_MAX")) g_bp_max = (int)strtoul(m, nullptr, 0);
-        if (g_devnull_fd < 0) g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+        ensure_probe_pipe();
         g_bp_on = true;   // the actual 0xCC is written after the image is mapped (arm_bp below)
     }
     // PROSPER_HWBP=0xOFFSET installs a race-free hardware execute breakpoint at guest VA 0x400000000+off.
@@ -1142,7 +1165,7 @@ void install_trap_handler() {
         if (getenv("PROSPER_HWBP_STRDUMP")) g_hwbp_strdump = true;
         if (getenv("PROSPER_HWBP_KLASS")) g_hwbp_klass = true;
         if (getenv("PROSPER_HWBP_ALLTHREADS")) g_hwbp_allthreads = true;
-        if (g_devnull_fd < 0) g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+        ensure_probe_pipe();
         g_hwbp_on = true;   // perf_event_open done in arm_hwbp() after the image is mapped
         // PROSPER_HWWATCH=<signed delta>: on the first exec-bp hit, arm a data write-watch on [rax+delta]
         // (default -0x80). Reveals what writes the thread-local device slot the ctor reads.

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -62,9 +62,13 @@ namespace {
     // unmapped memory) where a /dev/null write does not. O_NONBLOCK so a full pipe can never
     // block the fault handler; drained after every probe.
     int  g_probe_pipe[2] = {-1, -1};
+    // One-time init via a C++11 magic static (thread-safe): the unguarded `if (fd < 0) pipe2`
+    // pattern could tear the fd pair under two concurrent first-calls (PR #61 review). Called
+    // only from install-time paths (never from the signal handler itself), so the guard's
+    // internal locking is safe here.
     void ensure_probe_pipe() {
-        if (g_probe_pipe[0] < 0 && pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) != 0)
-            g_probe_pipe[0] = g_probe_pipe[1] = -1;
+        static const bool ok = pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) == 0;
+        if (!ok) g_probe_pipe[0] = g_probe_pipe[1] = -1;
     }
     // DIAGNOSTIC (PROSPER_SKIP_NULL_COMPANION, default off): at the Unity GfxDevice pipeline reader
     // eboot+0xba6e08 — which derefs a null GPU-companion pointer [obj+0x140] for pipelines that were

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -999,9 +999,17 @@ namespace {
     // it checks a magic at [fs+0x108] that marks OUR guest TCB (guest_tls.cpp). If present (guest thread),
     // it swaps %fs to the stashed host TCB [fs+0x100] for the handler call, then restores the guest %fs.
     // If absent (a host-context thread, or the main thread during pre-entry init), it just tail-calls the
-    // handler on the current fs — exactly the old behavior. Uses FSGSBASE. `push r11` also re-aligns rsp to
-    // the SysV rsp≡8(mod16) contract. Clobbers only rax/r11 (never the arg regs rdi..r9).
-    // Keep 0x108/0x100/magic in sync with guest_tls.cpp (MAGIC_OFF/HOSTFS_OFF/TCB_MAGIC).
+    // handler on the current fs — exactly the old behavior. Uses FSGSBASE. Clobbers only rax/r11 (never
+    // the arg regs rdi..r9).
+    //
+    // STACK-ARG FORWARDING: the guest path interposes `push r11` + `call` between the guest caller and
+    // the handler, which shifts the caller's STACK args (args 7+) by two qwords — a handler reading its
+    // 7th arg at the SysV frame slot fp[2] silently got the saved guest-fs base instead (ReleaseMem read
+    // a TCB pointer as data_sel and the guest return address as the 64-bit fence value). The stub now
+    // re-pushes the first TWO stack args before the call, so handlers see the documented SysV layout
+    // (fp[2]=arg7, fp[3]=arg8) on BOTH paths. Alignment: entry rsp≡8 (caller's call), +3 pushes ≡0,
+    // call ≡8 at handler entry — the SysV contract. Handlers needing >2 stack args would need this
+    // widened. Keep 0x108/0x100/magic in sync with guest_tls.cpp (MAGIC_OFF/HOSTFS_OFF/TCB_MAGIC).
     void emit_swap_stub(uint8_t* p, uint32_t idx, uint64_t fn, bool unimpl) {
         uint8_t* s = p;
         auto mid = [&](uint8_t*& q) {   // per-variant: unimpl loads its slot index into edi first
@@ -1013,12 +1021,16 @@ namespace {
         *p++=0x41; *p++=0x81; *p++=0xBB; uint32_t mo=0x108; memcpy(p,&mo,4); p+=4;
         uint32_t magic=0x50524F53u; memcpy(p,&magic,4); p+=4;
         *p++=0x75; uint8_t* jne_rel = p++;                                  // jne rel8 (patched below)
-        // .guest: push r11 ; mov rax,[r11+0x100] ; wrfsbase rax ; <mid> ; call rax ; pop r11 ; wrfsbase r11 ; ret
+        // .guest: push r11 ; push [rsp+0x18] (arg8) ; push [rsp+0x18] (arg7) ; mov rax,[r11+0x100] ;
+        //         wrfsbase rax ; <mid> ; call rax ; add rsp,0x10 ; pop r11 ; wrfsbase r11 ; ret
         *p++=0x41; *p++=0x53;
+        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x18;                         // push qword [rsp+0x18] = arg8
+        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x18;                         // push qword [rsp+0x18] = arg7
         *p++=0x49; *p++=0x8B; *p++=0x83; uint32_t ho=0x100; memcpy(p,&ho,4); p+=4;
         *p++=0xF3; *p++=0x48; *p++=0x0F; *p++=0xAE; *p++=0xD0;
         mid(p);
         *p++=0xFF; *p++=0xD0;                                               // call rax
+        *p++=0x48; *p++=0x83; *p++=0xC4; *p++=0x10;                         // add rsp, 0x10
         *p++=0x41; *p++=0x5B;                                               // pop r11
         *p++=0xF3; *p++=0x49; *p++=0x0F; *p++=0xAE; *p++=0xD3;              // wrfsbase r11
         *p++=0xC3;                                                          // ret
@@ -1064,7 +1076,7 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
     if (got == MAP_FAILED || got != want) return fail("mmap stub region failed");
 
     bool swap = guest_tls_enabled();   // gated: emit the %fs swap stubs so HLE handlers run on the host TCB
-    if (swap && stub_size < 80) return fail("stub_size too small for guest-%fs swap stub (need >= 80)");
+    if (swap && stub_size < 96) return fail("stub_size too small for guest-%fs swap stub (need >= 96)");
     uint8_t* base = (uint8_t*)got;
     for (uint64_t i = 0; i < n; i++) {
         uint8_t* slot = base + i * stub_size;

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -236,9 +236,10 @@ size_t apply_relocations(const Module& m, LoadedImage& img) {
             // appears. DTPOFF64 = the TLS symbol's offset within its module's TLS block.
             case R_X86_64_DTPMOD64:  if (write64(va, img.tls_modid)) applied++; break;
             case R_X86_64_DTPOFF64: {
-                uint64_t off = (r.sym && r.sym < m.symbols.size()) ? m.symbols[r.sym].value
-                                                                   : (uint64_t)r.addend;
-                if (write64(va, off)) applied++;
+                // psABI: DTPOFF64 = S + A. The addend addresses a field INSIDE the TLS object
+                // (e.g. a struct member); picking S *or* A drops it and resolves to the object base.
+                uint64_t sv = (r.sym && r.sym < m.symbols.size()) ? m.symbols[r.sym].value : 0;
+                if (write64(va, sv + (uint64_t)r.addend)) applied++;
                 break;
             }
             default: unhandled[r.type]++; break;

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -112,13 +112,16 @@ int main() {
     // --- 5. get port state fills the struct --------------------------------------------------
     uint8_t state[0x20]; memset(state, 0xEE, sizeof state);
     CHECK(call("sceAudioOutGetPortState", (uint64_t)h, PTR(state)) == 0);
+    // Layout per Kyty Audio.cpp:340: u16 output @0; u8 channel @2; i16 volume @4; u16 reroute @6; u64 flag @8.
     CHECK(*(uint16_t*)(state + 0) == 1);                  // output enabled
-    CHECK(*(uint16_t*)(state + 2) == 2);                  // channels
+    CHECK(*(uint8_t*)(state + 2) == 2);                   // channel (u8, capped at 2 for main port)
+    CHECK(*(int16_t*)(state + 4) == 127);                 // volume (Kyty reports 127)
+    CHECK(*(uint64_t*)(state + 8) == 0);                  // flag must NOT carry a bogus volume
 
-    // --- 6. error paths ---------------------------------------------------------------------
-    CHECK(call("sceAudioOutOutput", 999, PTR(pcm.data())) < 0);     // bad handle
-    CHECK(call("sceAudioOutSetVolume", 999, 0x1, PTR(vols)) < 0);
-    CHECK(call("sceAudioOutClose", 999) < 0);
+    // --- 6. error paths: the real SCE codes (Kyty Errno.h), not a generic -1 -----------------
+    CHECK((int32_t)call("sceAudioOutOutput", 999, PTR(pcm.data())) == (int32_t)0x80260003);  // INVALID_PORT
+    CHECK((int32_t)call("sceAudioOutSetVolume", 999, 0x1, PTR(vols)) == (int32_t)0x80260003);
+    CHECK((int32_t)call("sceAudioOutClose", 999) == (int32_t)0x80260003);
     CHECK(call("sceAudioOutInit", 0) == 0);
 
     // --- 7. close, then output-after-close fails --------------------------------------------
@@ -131,7 +134,7 @@ int main() {
     int opened = 0;
     for (int i = 0; i < 16; i++) if (call("sceAudioOutOpen", 1, 0, 0, 512, 44100, 4 /*F32 stereo*/) >= 1) opened++;
     CHECK(opened == 16);
-    CHECK(call("sceAudioOutOpen", 1, 0, 0, 512, 44100, 4) < 0);     // no free port
+    CHECK((int32_t)call("sceAudioOutOpen", 1, 0, 0, 512, 44100, 4) == (int32_t)0x80260005);  // PORT_FULL
     CHECK(sink.opens.size() == 16);
     if (!sink.opens.empty()) {
         CHECK(sink.opens[0].info.fmt == AudioFmt::F32);

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -95,11 +95,14 @@ int main() {
     CHECK(ins[7].fmt == Rdna2Format::SMEM && ins[7].opcode == 0x2u && isS(ins[7].dst, 0) &&
           isS(ins[7].src[0], 4) && ins[7].literal == 0x0u, "s_load_dwordx4 SMEM op/SDATA/SBASE/offset");
     // MUBUF decode: buffer_load_dwordx4 v[4:7], v2, s[8:11], 0 offen -> op 0xe, VDATA v4, VADDR v2,
-    // SRSRC s8 (×4), offen bit set in `literal`.
+    // SRSRC s8 (×4), offen bit set in `literal`. SOFFSET field is 0x80 = inline integer 0 (llvm-mc's
+    // encoding of literal `0`) — it must NOT decode as SGPR s0 (8-bit field, not 7).
     const uint32_t mubuf[] = { 0xe0381000u, 0x80020402u };
     Rdna2Inst mb = rdna2_decode_one(mubuf, 2);
     CHECK(mb.fmt == Rdna2Format::MUBUF && mb.opcode == 0xeu && isV(mb.dst, 4) && isV(mb.src[0], 2) &&
           isS(mb.src[1], 8) && ((mb.literal >> 12) & 1u), "buffer_load_dwordx4 MUBUF op/VDATA/VADDR/SRSRC/offen");
+    CHECK(mb.src[2].kind == OperandKind::InlineInt && mb.src[2].value == 0,
+          "MUBUF SOFFSET 0x80 decodes as inline 0, not SGPR s0");
     // VOP SDWA/DPP forms carry a mandatory 2nd (control) dword — the decoder must count it (miss it and
     // the whole downstream stream mis-aligns) and flag has_modifier so the recompiler rejects it.
     // Encodings from llvm-mc gfx1030: SDWA src0=0xf9, DPP16 src0=0xfa, DPP8 src0=0xe9.


### PR DESCRIPTION
## What this is

A systematic review of **all 405 mainline commits, oldest first**, hunting defects, hacks, hardcoded stand-ins, and silent simplifications. Every candidate finding was verified to still exist on current master before being acted on (~60 historical bugs turned out to be already fixed and were discarded; ~90 survived verification). This PR fixes 18 of them — the crisp, high-confidence ones — and commits the remaining prioritized backlog as `prosper/docs/BUG_HUNT_BACKLOG.md`.

## Headline fixes

- **`guest_readable`/`probe_readable` never probed** — they wrote to `/dev/null`, whose kernel handler never touches the source buffer, so *every* address ≥ 0x1000 passed and every guard built on them was a no-op (verified empirically on this WSL kernel). Now a drained `O_NONBLOCK` pipe (EFAULT works), raw syscalls in the fault-handler variant.
- **EOP fences were written with garbage under `PROSPER_GUEST_FS`** — the swap stub inserts `push r11` + `call`, shifting stack args by two qwords, so `sceAgcCbReleaseMem` read a TCB pointer as `data_sel` and a guest return address as the 64-bit fence value. The stub now forwards the first two stack args; verified live (`data_sel=0x2/0x3` with real fence values where the log previously showed pointers).
- **MUBUF `SOFFSET` masked to 7 bits** — the standard "soffset = 0" encoding (0x80) decoded as **SGPR s0**, adding whatever the shader last put in s0 to every buffer address. Now 8-bit, with the existing decode fixture extended to assert it.
- **`s_waitcnt_vscnt` mapped as SOPP 0x7d, which doesn't exist on gfx10** — it is SOPK 0x17 (llvm-mc gfx1010 round-trip). The intended no-op was dead code and real shaders using it failed recompilation. The waitcnt family (0x17–0x1A) is now no-op'd where it actually decodes.
- **FreeBSD→Linux open(2) flags passed raw** — SCE `O_CREAT` (0x200) is Linux `O_TRUNC`, so "create my save file" became "truncate it and don't create". Now translated bit by bit.

## The rest

- `__cxa_guard_acquire`/`_Execute_once` raced (concurrent double-construction in the 15-thread IL2CPP pool) — now real once semantics, initializers run outside the lock.
- `sceKernelWaitEventFlag`/`WaitSema` ignored their timeouts (silent forever-blocks) — now `KERNEL_ERROR_ETIMEDOUT` + remaining-time writeback.
- `sceSystemServiceGetStatus` wrote 4 bytes through stale RSI; real out-struct left uninitialized — dedicated handler, Kyty-cross-checked layout.
- `scePthread(Attr)Getschedparam`/`Getprio` returned success with unwritten out-params — deterministic defaults.
- `EVFILT_VIDEO_OUT` was -10 (FreeBSD `EVFILT_LIO`); Kyty and shadPS4 both say **-13**.
- Lazy GPU-VA backing ignored `si_code` — a protection fault on a live read-only mapping was "handled" by mmap'ing a zero page over it (data loss, broken memfd aliasing), and an in-window wild jump looped forever. Now `SEGV_MAPERR`-only and fault-addr ≠ RIP.
- `SceAudioOutPortState` layout diverged from Kyty (volume written into the `flag` field, real volume left 0 = muted); audio errors were generic -1 — now `0x80260003`/`0x80260005`, tests lock in layout and codes.
- `DrawIndexAuto` dropped its draw modifier and left 4 dwords of stale ring memory in the packet; `WriteData` silently clamped to 60 dwords (now accepts the PM4 14-bit max, rejects loudly); the AGC shader registry was iterated lock-free against `push_back` (UAF on realloc) — now mutexed.
- Recompiler: execz linearization now rejects VALU ops with **unpredicated scalar side effects** (`v_readfirstlane`, carry ops); `v_cndmask_b32_e64` honors neg/abs source modifiers; VOP3B untracked carry-in rejects instead of silently assuming 0; `R_X86_64_DTPOFF64` is S + A per the psABI; `v_mul_legacy_f32` gets DX9 semantics (0 × anything == 0, incl. Inf/NaN).
- Direct vertex-buffer provenance keyed in shader-SGPR space (`user_sgpr_base + reg`), matching the other resource classes.
- `munmap`/BatchMap-UNMAP now untrack `g_maps` and `mprotect` re-tags — stale "committed" records defeated `safe_copy` (the exact render-thread SIGSEGV class it exists to prevent) and the lazy-commit fault probe.

## Verification

- 44/44 ctest green on Linux after every fix round.
- Live render smoke (`PROSPER_GUEST_FS=1 -force-gfx-direct PROSPER_RENDER=1`): 430+ frames rendered at 1920×1080, **0 shader recompile skips**, no faults.
- Swap-stub fix verified against live GFXLOG output (ReleaseMem args before/after).
- New/extended test assertions: MUBUF SOFFSET inline-0 decode, audio port-state layout + exact SCE error codes.

## Review notes

The commit to look at hardest is `891323a` (swap-stub stack-arg forwarding) — it changes emitted machine code. Alignment math and the byte encodings are documented inline, and it has both unit-suite and live-boot evidence. `prosper/docs/BUG_HUNT_BACKLOG.md` carries the ~60 remaining verified findings, prioritized, with locations and suggested fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkzuSLnBc87sbwwzi7f7j6