### PR TITLE
fix(gpu): RELEASE_MEM stops guess-writing on unknown data_sel; WaitRegMem carries and verifies its real wait parameters

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -52,19 +52,24 @@ static void honor_eop_write(const Pm4Command& c) {
         // at a live label address (and a mis-extraction that yields 0 has a garbage value dword too,
         // so skipping is right in both readings). CONFIDENCE: MED.
         case 0: return;
-        case 1: { uint32_t v = (uint32_t)c.rel_value; memcpy(dst, &v, sizeof v); break; }
-        case 2: { uint64_t v = c.rel_value;           memcpy(dst, &v, sizeof v); break; }
+        // Cases 1/2 need the same rel_value_valid guard the default case got: a short-decoded
+        // packet's rel_value is a fabricated 0 that could move a satisfied fence label BACKWARDS
+        // (re-blocking a `*label >= expected` poll).
+        case 1: { if (!c.rel_value_valid) return;
+                  uint32_t v = (uint32_t)c.rel_value; memcpy(dst, &v, sizeof v); break; }
+        case 2: { if (!c.rel_value_valid) return;
+                  uint64_t v = c.rel_value;           memcpy(dst, &v, sizeof v); break; }
         case 3: { uint64_t v = gpu_clock64();         memcpy(dst, &v, sizeof v); break; }
-        // A RELEASE_MEM ALWAYS writes a completion fence — that's its purpose. Our stack-arg ABI
-        // extraction can mis-read data_sel (it arrives as a pointer, not the 1/2/3 enum), so don't SKIP the
-        // write on an unrecognized selector: default to the 64-bit value. Skipping it starved the render
-        // thread's completion wait and stalled the frame loop after the first real draw. CONFIDENCE: MED.
+        // Unknown selector: LOG AND SKIP. The old default wrote the 64-bit value for ANY
+        // unrecognized data_sel — a band-aid for the swap-stub stack-arg mis-extraction that made
+        // data_sel arrive as a pointer (fixed in exec_image_linux.cpp emit_swap_stub: handlers now
+        // see real stack args, verified live with data_sel=0x2/0x3). With the root cause gone, an
+        // unknown selector means a genuinely unexpected packet: writing 8 bytes on a guess could
+        // clobber the dword after a 32-bit label. Log so the gap is visible, never write.
         default:
-            // ... but only when the packet actually carried a value: a short-decoded packet's
-            // rel_value is a fabricated 0 that could move a fence label BACKWARDS.
-            if (!c.rel_value_valid) return;
-            { uint64_t v = c.rel_value;               memcpy(dst, &v, sizeof v); }
-            break;
+            fprintf(stderr, "[agc] RELEASE_MEM: unknown data_sel=%u addr=0x%llx value=0x%llx — write SKIPPED\n",
+                    c.rel_data_sel, (unsigned long long)c.rel_addr, (unsigned long long)c.rel_value);
+            return;
     }
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   EOP write [0x%llx] data_sel=%u value=0x%llx\n",
@@ -136,6 +141,32 @@ void GpuState::apply(const Pm4Command& c) {
             break;
         case K::WriteData:
             honor_write_data(c);    // inline data write requested by the Dcb
+            break;
+        case K::WaitRegMem:
+            // Synchronous fold: by the time we process this packet the CPU-side producer has
+            // usually already written the label, so the wait is normally satisfied. We can't
+            // BLOCK here (single-threaded fold) — but a wait that is NOT satisfied means the
+            // dependency would have been violated (packets after this one read data the guest
+            // hadn't produced at submit), so surface it loudly instead of silently proceeding.
+            if (c.wm_valid && c.wm_addr && !(c.wm_addr & 3)) {
+                uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
+                uint64_t v = mem & c.wm_mask, r = c.wm_ref;
+                bool sat;
+                switch (c.wm_func) {           // PM4 WAIT_REG_MEM compare functions
+                    case 0: sat = true;    break;
+                    case 1: sat = v <  r;  break;
+                    case 2: sat = v <= r;  break;
+                    case 3: sat = v == r;  break;
+                    case 4: sat = v != r;  break;
+                    case 5: sat = v >= r;  break;
+                    case 6: sat = v >  r;  break;
+                    default: sat = false;  break;
+                }
+                if (!sat)
+                    fprintf(stderr, "[agc] WaitRegMem NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — dependency violated\n",
+                            (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
+                            (unsigned long long)v, c.wm_func, (unsigned long long)r);
+            }
             break;
         case K::Flip:
             // The GPU reaching the SetFlip packet IS the flip moment (synchronous fold): perform the

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -65,7 +65,18 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                         c.wd_data = (c.wd_num > 0) ? &pl[4] : nullptr;
                     }
                     break;
-                case R_WAIT_MEM_64:   c.kind = K::WaitRegMem;   break;
+                case R_WAIT_MEM_64:
+                    c.kind = K::WaitRegMem;
+                    // payload: [0..1]=addr lo/hi, [2..3]=mask lo/hi, [4..5]=reference lo/hi,
+                    // [6]=compare_function (Kyty GraphicsDcbWaitRegMem layout; see agc_dcb_wait_reg_mem).
+                    if (npl >= 7) {
+                        c.wm_addr = lo_hi(pl);
+                        c.wm_mask = (uint64_t)pl[2] | ((uint64_t)pl[3] << 32);
+                        c.wm_ref  = (uint64_t)pl[4] | ((uint64_t)pl[5] << 32);
+                        c.wm_func = pl[6];
+                        c.wm_valid = true;
+                    }
+                    break;
                 case R_RELEASE_MEM:
                     c.kind = K::ReleaseMem;
                     // payload: [0..1]=label addr lo/hi, [2]=data_sel, [3..4]=64-bit value (see agc_cb_release_mem)

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -64,6 +64,16 @@ struct Pm4Command {
     uint64_t rel_value = 0;              // ReleaseMem: 64-bit fence value (for data_sel 1/2)
     bool rel_value_valid = false;        // ReleaseMem: packet was long enough to carry rel_value
 
+    // WaitRegMem — laid out by hle_agc.cpp agc_dcb_wait_reg_mem per sceAgcDcbWaitRegMem(buf, size,
+    // compare_func, op, cache_policy, address, reference, mask, poll_cycles) (Kyty
+    // GraphicsDcbWaitRegMem, Graphics.cpp:2096). Payload: [0..1]=addr, [2..3]=mask, [4..5]=reference,
+    // [6]=compare_function (PM4 WAIT_REG_MEM: 0=always 1=< 2=<= 3=== 4=!= 5=>= 6=>), [7]=interval.
+    uint64_t wm_addr = 0;                // WaitRegMem: label address to poll
+    uint64_t wm_mask = 0;                // WaitRegMem: AND-mask applied to the memory value
+    uint64_t wm_ref  = 0;                // WaitRegMem: reference value
+    uint32_t wm_func = 0;                // WaitRegMem: compare function
+    bool     wm_valid = false;           // WaitRegMem: packet carried the full operand set
+
     // WriteData — laid out by hle_agc.cpp agc_dcb_write_data per sceAgcDcbWriteData(buf, dst, cache_policy,
     // address_or_offset, data*, num_dwords, …) (Kyty GraphicsDcbWriteData, Graphics.cpp:2061). Packet
     // payload: [0]=dst, [1..2]=destination address (lo/hi), [3]=num_dwords, [4..]=inline data dwords.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -196,15 +196,27 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     if (src) for (uint32_t i = 0; i < num; i++) cmd[5 + i] = src[i];
     return (uint64_t)(uintptr_t)cmd;
 }
-HLE(agc_dcb_wait_reg_mem) {  // (buf, ...) — 9 dw
-    if (getenv("PROSPER_GFXLOG")) {
-        volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
-        fprintf(stderr, "[agc] WaitRegMem a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx | ret=0x%llx a6=0x%llx a7=0x%llx\n",
-            (unsigned long long)a1,(unsigned long long)a2,(unsigned long long)a3,(unsigned long long)a4,(unsigned long long)a5,
-            (unsigned long long)fp[1],(unsigned long long)fp[2],(unsigned long long)fp[3]);
-    }
+HLE(agc_dcb_wait_reg_mem) {  // sceAgcDcbWaitRegMem(buf, size, compare_func, op, cache_policy, address, reference, mask, poll_cycles)
+    // ABI pinned to Kyty GraphicsDcbWaitRegMem (Graphics.cpp:2096): a5 = label address; the 7th/8th
+    // args (reference, mask) are STACK args, readable at fp[2]/fp[3] under both stub shapes (the
+    // guest-%fs swap stub forwards two stack args). poll_cycles (9th) is beyond the forwarded
+    // window and is only a poll-interval hint — encode 0. The payload previously ZEROED every
+    // wait parameter at build time (address/ref/mask/function destroyed — the wait could never be
+    // honored downstream); now it mirrors Kyty's layout exactly:
+    // [1..2]=addr lo/hi, [3..4]=mask lo/hi, [5..6]=reference lo/hi, [7]=compare_function, [8]=interval.
+    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
+    uint64_t reference = fp[2], mask = fp[3];
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] WaitRegMem size=%llu func=%llu op=%llu addr=0x%llx ref=0x%llx mask=0x%llx\n",
+            (unsigned long long)a1,(unsigned long long)a2,(unsigned long long)a3,
+            (unsigned long long)a5,(unsigned long long)reference,(unsigned long long)mask);
     uint32_t* cmd; if (!begin_packet(a0, 9, IT_NOP, R_WAIT_MEM_64, &cmd)) return 0;
-    for (int i = 1; i < 9; i++) cmd[i] = 0; return (uint64_t)(uintptr_t)cmd;
+    cmd[1] = (uint32_t)(a5 & 0xffffffffu);        cmd[2] = (uint32_t)(a5 >> 32u);
+    cmd[3] = (uint32_t)(mask & 0xffffffffu);      cmd[4] = (uint32_t)(mask >> 32u);
+    cmd[5] = (uint32_t)(reference & 0xffffffffu); cmd[6] = (uint32_t)(reference >> 32u);
+    cmd[7] = (uint32_t)a2;                        // compare_function
+    cmd[8] = 0;                                   // poll interval hint (arg9 not forwarded; unused by our fold)
+    return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_set_flip) {  // (buf, video_out_handle, display_buffer_index, flip_mode, flip_arg) — 6 dw
     uint32_t* cmd; if (!begin_packet(a0, 6, IT_NOP, R_FLIP, &cmd)) return 0;


### PR DESCRIPTION
Fixes #66
Fixes #70

Two related AGC sync-packet fixes, both unblocked by the swap-stub stack-arg fix in #61:

**#66 — RELEASE_MEM default write.** `honor_eop_write` wrote an 8-byte value for ANY unrecognized `data_sel` — a band-aid for the stack-arg mis-extraction that #61 removed at the root (live boots now decode `data_sel` as the real 1/2/3 enum). The default now logs loudly and skips, so a genuinely unexpected packet can no longer clobber the dword after a 32-bit label on a guess. Cases 1/2 also gain the `rel_value_valid` guard the default already had: a short-decoded packet's fabricated 0 could move a satisfied fence label backwards and re-block a `*label >= expected` poll.

**#70 — WaitRegMem.** `sceAgcDcbWaitRegMem` zeroed its entire 9-dword payload at build time, destroying the compare address/reference/mask/function — the wait could never be honored downstream. The packet now mirrors Kyty `GraphicsDcbWaitRegMem` (Graphics.cpp:2096) exactly; the stack args (reference, mask) are read at `fp[2]/fp[3]`, valid under both stub shapes post-#61 (`poll_cycles`, beyond the 2-slot forwarding window, is only a poll-interval hint and is encoded 0). The decoder extracts the fields, and the command processor now **evaluates the wait condition at fold time**: the synchronous model can't block, but an unsatisfied condition means downstream packets read data the guest hadn't produced at submit — that dependency violation is surfaced loudly instead of silently ignored.

**Verification:** 44/44 ctest green. Live render config (`PROSPER_GUEST_FS=1 -force-gfx-direct PROSPER_RENDER=1`): frames render, 30k+ EOP fence writes flow, zero `unknown data_sel` and zero `WaitRegMem NOT satisfied` occurrences — i.e. the stricter paths never fire on the known-good title, they only remove silent-corruption modes.