### PR TITLE
fix(hle/apr): safe size-keyed APR reads — refuse ambiguous/chunk reads loudly

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -97,6 +97,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_stat PRIVATE prosper_core)
   add_test(NAME sce_stat_layout COMMAND test_stat)
 
+  # APR container registry + size-keyed read matching (issue #62): stable ids, path dedup, and
+  # the ambiguity/chunk-read refusal the read-submit path relies on. Pure, no game dump needed.
+  add_executable(test_apr_registry tests/test_apr_registry.cpp)
+  target_link_libraries(test_apr_registry PRIVATE prosper_core)
+  add_test(NAME apr_registry_size_keying COMMAND test_apr_registry)
+
   # PM4 command-stream decoder (front of the CommandProcessor): decode a Dcb built by the AGC
   # Dcb functions and assert the ops. Pure/cross-platform, no game dump needed.
   add_executable(test_pm4_decode tests/test_pm4_decode.cpp)

--- a/prosper/docs/BUG_HUNT_BACKLOG.md
+++ b/prosper/docs/BUG_HUNT_BACKLOG.md
@@ -44,10 +44,14 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
 ## High-priority remaining
 
 1. **[hack] APR read resolves the file by BYTE-SIZE match** — `hle_file.cpp`
-   apr_path_for_size/f_apr_read_submit: request matched against stat'd sizes of known
-   containers; whole-file reads at offset 0 only. Two same-size files ⇒ wrong bytes,
-   silently. Decode the file id (prosper_apr_path_for_id exists) + offset/chunk support;
-   at minimum refuse loudly on size collision. (introduced 41b01f3)
+   f_apr_read_submit: request matched against stat'd sizes of known containers;
+   whole-file reads at offset 0 only. SAFE-FALLBACK LANDED (#62): size collisions and
+   partial/chunk reads are now detected and refused loudly (EINVAL + unconditional
+   stderr), resolve dedups re-registered paths, and PROSPER_FILELOG dumps the 0x90-byte
+   descriptor buffer for the remaining RE. Still open: decode the real (file id, offset)
+   from the descriptor buffer / Ampr CB read command and read via
+   prosper_apr_path_for_id — required for the compressed .ucas chunk reads.
+   (introduced 41b01f3)
 2. **[simplification] Indexed draws silently dropped** — hle_agc.cpp emits R_DRAW_INDEX
    (0x03) but pm4_decode never decodes it: every sceAgcDcbDrawIndex vanishes downstream
    while the guest sees success. Decode it (verify a2/a3 roles vs Kyty), push a Draw

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -378,12 +378,32 @@ std::string prosper_apr_path_for_id(uint32_t id) {
     std::lock_guard<std::mutex> lk(g_apr_mx);
     return (id >= 1 && id <= g_apr_files.size()) ? g_apr_files[id - 1].path : std::string();
 }
-// Find the resolved host path for a given file size (the APR read-request object carries the total
-// size at obj+0x30 but no directly-legible id; sizes of the boot-critical containers are distinct).
-static std::string apr_path_for_size(uint64_t size) {
+// Register a resolved container and return its stable 1-based id. Re-resolving the same host path
+// returns the existing id (updated size) instead of a duplicate entry — a duplicate would make
+// every size-keyed read of that file look ambiguous. Exposed (not static) for the unit test.
+uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
     std::lock_guard<std::mutex> lk(g_apr_mx);
-    for (auto& f : g_apr_files) if (f.size == size) return f.path;
-    return {};
+    for (size_t i = 0; i < g_apr_files.size(); i++)
+        if (g_apr_files[i].path == path) { g_apr_files[i].size = size; return (uint32_t)(i + 1); }
+    g_apr_files.push_back({ path, size });
+    return (uint32_t)g_apr_files.size();
+}
+// Test hook: drop all registered containers (the registry is process-global).
+void prosper_apr_reset_for_test() {
+    std::lock_guard<std::mutex> lk(g_apr_mx);
+    g_apr_files.clear();
+}
+// Find resolved host paths whose TOTAL size equals `size`. Returns the match count and sets
+// *out_path to the first match. The read path may only act on an unambiguous (count==1) match:
+// the APR read-request object carries the total byte count at obj+0x30 but the file id is NOT
+// legible in the captured request layout (docs/UE4_APR_IOSTORE_BRINGUP.md field map, +0x00..+0x40),
+// so size is the only correlation currently available. Exposed (not static) for the unit test.
+int prosper_apr_match_by_size(uint64_t size, std::string* out_path) {
+    std::lock_guard<std::mutex> lk(g_apr_mx);
+    int n = 0;
+    for (auto& f : g_apr_files)
+        if (f.size == size) { if (n++ == 0 && out_path) *out_path = f.path; }
+    return n;
 }
 HLE(f_apr_resolve) {
     const char** paths = (const char**)P(a0);
@@ -405,7 +425,14 @@ HLE(f_apr_resolve) {
 #endif
         else { if (out_ids) out_ids[i] = 0; if (out_sizes) out_sizes[i] = 0; if (out_flags) out_flags[i] = 0;
                if (filelog()) fprintf(stderr, "[apr] resolve MISS %s\n", gp ? gp : "(null)"); continue; }
-        { std::lock_guard<std::mutex> lk(g_apr_mx); g_apr_files.push_back({ host, size }); id = (uint32_t)g_apr_files.size(); }
+        // Warn loudly (unconditionally) when a DIFFERENT container shares this size: the read
+        // path is size-keyed (see f_apr_read_submit) and will refuse such reads as ambiguous.
+        std::string clash; int same_size = prosper_apr_match_by_size(size, &clash);
+        id = prosper_apr_register(host, size);
+        if (same_size > 0 && clash != host)
+            fprintf(stderr, "[apr] WARNING: %s and %s share byte size %llu — size-keyed reads of "
+                    "either will be refused as ambiguous (issue #62)\n",
+                    host.c_str(), clash.c_str(), (unsigned long long)size);
         if (out_ids)   out_ids[i]   = id;
         if (out_sizes) out_sizes[i] = size;
         if (out_flags) out_flags[i] = 0;
@@ -420,8 +447,16 @@ HLE(f_apr_resolve) {
 // at readReq+0x30. Real hardware DMAs the resolved file's bytes into that buffer; we do it with a
 // synchronous pread (the boot-critical global container is uncompressed — utoc header
 // compressionMethodNameCount==0). Route B of docs/UE4_APR_IOSTORE_BRINGUP.md. CONFIDENCE: MED
-// (object layout from live capture; file matched by size since the id isn't directly legible in
-// the request object — boot container sizes are distinct).
+// (object layout from live capture).
+//
+// File identification (issue #62): the captured request layout (+0x00 count, +0x08/+0x40 stack
+// ptrs, +0x10 fn/vtable, +0x18 stack scratch, +0x20 dest, +0x28 status, +0x30 byte count, +0x38
+// canary) contains NO legible file id and NO offset field, so the file is keyed by TOTAL size and
+// read whole from offset 0. That key is only sound when unambiguous, so reads are REFUSED loudly
+// when (a) two registered containers share the size, or (b) the count matches no container's
+// total size (a partial/chunk read — unsupported until the id/offset linkage is decoded from the
+// 0x90-byte descriptor buffer (a4) or the Ampr CB read command; both are dumped/loggable below
+// for that RE). CONFIDENCE: LOW on file identification — safe-refuse fallback, not a real decode.
 HLE(f_apr_read_submit) {
     uint8_t* req = (uint8_t*)P(a0);
     if (!req) return 0x80020016ull;
@@ -431,6 +466,14 @@ HLE(f_apr_read_submit) {
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
         for (int o = 0; o < 0x48; o += 8)
             fprintf(stderr, "[apr]   req+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(req + o));
+        // Dump the descriptor buffer (a4, a5 bytes — 0x90 in the live capture): the most likely
+        // home of the real (file id, offset, size) tuples needed to retire the size keying.
+        if (a4 && a5 && a5 <= 0x200) {
+            const uint8_t* d = (const uint8_t*)P(a4);
+            for (uint64_t o = 0; o + 8 <= a5; o += 8)
+                fprintf(stderr, "[apr]   desc+0x%02llx = 0x%016llx\n",
+                        (unsigned long long)o, (unsigned long long)*(const uint64_t*)(d + o));
+        }
     }
     // req+0x20 is the mapped data buffer (guest direct/flexible memory, 0x10xxxxxxxx range); req+0x18
     // is only a small stack scratch (writing the full file there smashed the stack). req+0x30 is the
@@ -439,9 +482,20 @@ HLE(f_apr_read_submit) {
     uint64_t size = *(uint64_t*)(req + 0x30);
     if (!dest || !size) { if (filelog()) fprintf(stderr, "[apr] read-submit: empty (dest=0x%llx size=0x%llx)\n",
                           (unsigned long long)dest, (unsigned long long)size); return 0; }
-    std::string host = apr_path_for_size(size);
-    if (host.empty()) { if (filelog()) fprintf(stderr, "[apr] read-submit: no file for size=%llu\n",
-                        (unsigned long long)size); return 0x80020016ull; }
+    std::string host;
+    int matches = prosper_apr_match_by_size(size, &host);
+    if (matches == 0) {   // no container has this TOTAL size: a partial/chunk read we cannot place
+        fprintf(stderr, "[apr] ERROR: read-submit for %llu bytes matches no resolved container's "
+                "total size — partial/chunk reads are unsupported until the file id + offset are "
+                "decoded from the request (issue #62); refusing\n", (unsigned long long)size);
+        return 0x80020016ull;   // EINVAL
+    }
+    if (matches > 1) {    // ambiguous: serving the first match could deliver the WRONG file's bytes
+        fprintf(stderr, "[apr] ERROR: read-submit for %llu bytes is AMBIGUOUS (%d resolved "
+                "containers share that size, first: %s) — refusing rather than guessing "
+                "(issue #62)\n", (unsigned long long)size, matches, host.c_str());
+        return 0x80020016ull;   // EINVAL
+    }
 #ifndef _WIN32
     int fd = ::open(host.c_str(), O_RDONLY);
     if (fd < 0) return 0x80020016ull;

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -1,0 +1,68 @@
+// test_apr_registry — guards the APR container registry and its size-keyed read matching
+// (issue #62). The APR read-submit handler identifies WHICH file to read by total byte size,
+// because the captured read-request object carries no legible file id. That key is only sound
+// when unambiguous, so this locks in: stable 1-based id assignment, path-dedup on re-resolve
+// (a duplicate entry would make every read of that file look ambiguous), and the match counts
+// the read path uses to refuse ambiguous / unplaceable (chunk) reads instead of guessing.
+#include <cstdio>
+#include <cstdint>
+#include <string>
+
+namespace prosper {
+    uint32_t    prosper_apr_register(const std::string& path, uint64_t size);
+    void        prosper_apr_reset_for_test();
+    int         prosper_apr_match_by_size(uint64_t size, std::string* out_path);
+    std::string prosper_apr_path_for_id(uint32_t id);
+}
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    printf("== test_apr_registry ==\n");
+    prosper_apr_reset_for_test();
+
+    // Stable 1-based ids in resolve order.
+    uint32_t a = prosper_apr_register("/dump/global.utoc", 645);
+    uint32_t b = prosper_apr_register("/dump/global.ucas", 100000);
+    CHECK(a == 1 && b == 2, "ids assigned 1-based in resolve order");
+    CHECK(prosper_apr_path_for_id(1) == "/dump/global.utoc", "path_for_id(1)");
+    CHECK(prosper_apr_path_for_id(2) == "/dump/global.ucas", "path_for_id(2)");
+    CHECK(prosper_apr_path_for_id(0).empty() && prosper_apr_path_for_id(3).empty(),
+          "out-of-range ids resolve to empty");
+
+    // Unambiguous size keying (the only case the read path may serve).
+    std::string p;
+    CHECK(prosper_apr_match_by_size(645, &p) == 1 && p == "/dump/global.utoc",
+          "unique size matches exactly one container");
+
+    // A count that equals no container's TOTAL size (i.e. a partial/chunk read) must not match.
+    CHECK(prosper_apr_match_by_size(644, nullptr) == 0, "chunk-sized count matches nothing");
+
+    // Two containers sharing a size: the read path must see the ambiguity (count > 1).
+    uint32_t c = prosper_apr_register("/dump/pakchunk0-ps5.utoc", 645);
+    CHECK(c == 3, "distinct path gets a new id even at a colliding size");
+    CHECK(prosper_apr_match_by_size(645, &p) == 2, "size collision reported as 2 matches");
+
+    // Re-resolving the same host path must return the SAME id (no duplicate entry), so a game
+    // that resolves a container twice doesn't turn every read of it ambiguous.
+    uint32_t a2 = prosper_apr_register("/dump/global.utoc", 645);
+    CHECK(a2 == a, "re-resolving a path returns its existing id");
+    CHECK(prosper_apr_match_by_size(645, &p) == 2, "re-resolve does not add a duplicate entry");
+
+    // Re-resolve with a changed size updates the record (single source of truth per path).
+    prosper_apr_register("/dump/global.ucas", 200000);
+    CHECK(prosper_apr_match_by_size(100000, nullptr) == 0 &&
+          prosper_apr_match_by_size(200000, &p) == 1 && p == "/dump/global.ucas",
+          "re-resolve updates the stored size");
+
+    prosper_apr_reset_for_test();
+    CHECK(prosper_apr_match_by_size(645, nullptr) == 0 && prosper_apr_path_for_id(1).empty(),
+          "reset clears the registry");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Refs #62 (partial fix — safe fallback; the full file-id decode remains open, see the issue comment).

## Defect

`prosper/src/hle/hle_file.cpp` `f_apr_read_submit` (the `libSceAmpr::mQ16-QdKv7k` read-submit HLE) identified WHICH container to read by matching the request's byte count (`req+0x30`) against the stat'd size of every previously-resolved container, silently serving the **first** match, and always `pread`-ing the whole file from offset 0.

- Two same-size containers ⇒ the WRONG file's bytes delivered with no error.
- Any partial/chunk read (the upcoming `.ucas` chunk reads) ⇒ quiet EINVAL, or worse, a collision with another container's total size.
- The game could also re-resolve a path, creating a duplicate registry entry that made every read of that file ambiguous.

## Why not a full id decode

The evidence does not support one yet. The live-captured request layout (`docs/UE4_APR_IOSTORE_BRINGUP.md`) covers `+0x00`..`+0x40` and explicitly records that **the file id is NOT legible in the request object**; there is no offset field either. The 0x90-byte descriptor buffer (arg 4) is the likely home of the real `(id, offset, size)` tuples, but it was never dumped, so decoding from it would be invented field offsets — contrary to the project's correctness-first rule. This PR lands the documented safe fallback instead and instruments the path for that follow-up RE.

## Fix

- **Resolve** (`f_apr_resolve`): re-registering the same host path now returns its existing stable id instead of pushing a duplicate; registering a second container with a colliding byte size warns unconditionally on stderr.
- **Read-submit** (`f_apr_read_submit`): matching is now count-aware (`prosper_apr_match_by_size`). Exactly one match ⇒ unchanged behavior. Zero matches (a partial/chunk read) or 2+ matches (ambiguous size) ⇒ **loud, unconditional stderr diagnostic + EINVAL** instead of silently serving possibly-wrong bytes.
- **RE instrumentation**: `PROSPER_FILELOG=1` now also hex-dumps the 0x90-byte descriptor buffer (arg 4/5) on every submit — the data needed to retire size keying entirely.
- Remaining gap marked `CONFIDENCE: LOW` on file identification, per convention; `docs/BUG_HUNT_BACKLOG.md` entry updated.

## Verification

- New unit test `apr_registry_size_keying` (`prosper/tests/test_apr_registry.cpp`, pure — no game dump needed): stable 1-based id assignment, `prosper_apr_path_for_id` bounds, unique-size match, zero-match for chunk-sized counts, 2-match on size collision, path dedup on re-resolve, size update on re-resolve, registry reset.
- Full suite in WSL Ubuntu-24.04: **45/45 ctest green**, including the new test.
- The boot-critical UE4 path is behaviorally unchanged for the known-good case (all boot container sizes are distinct), so the PPSA17942 TOC read continues to take the exact same single-match branch.