### PR TITLE
fix(hle/kernel): purge __tls_get_addr DTV on thread exit (stale TLS on recycled ids + leak)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -210,6 +210,12 @@ if(TARGET prosper_core)
     target_link_libraries(test_rwlock_once PRIVATE prosper_core)
     add_test(NAME rwlock_once_semantics COMMAND test_rwlock_once)
 
+    # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68):
+    # a recycled pthread id must get fresh zero/tdata-initialized TLS, never a dead thread's bytes.
+    add_executable(test_tls_dtv_purge tests/test_tls_dtv_purge.cpp)
+    target_link_libraries(test_tls_dtv_purge PRIVATE prosper_core)
+    add_test(NAME tls_dtv_purge_on_thread_exit COMMAND test_tls_dtv_purge)
+
     add_executable(test_agc_dcb tests/test_agc_dcb.cpp)
     target_link_libraries(test_agc_dcb PRIVATE prosper_core)
     add_test(NAME agc_dcb_pm4 COMMAND test_agc_dcb)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -81,6 +81,15 @@ struct TlsModuleDesc { uint64_t init_va = 0, filesz = 0, memsz = 0; };
 // Install the TLS templates (call AFTER images are mapped, so init_va is readable). Enables the
 // __tls_get_addr HLE to serve real per-thread TLS blocks for loaded modules (e.g. real libc.prx).
 void set_tls_modules(const TlsModuleDesc* descs, size_t count);
+// Free + forget the CURRENT thread's __tls_get_addr DTV blocks. Called on every HLE-controlled
+// thread-exit path (thread_trampoline's normal return, scePthreadExit/pthread_exit): glibc recycles
+// pthread ids, so a stale DTV entry would hand a new thread the dead thread's dirty TLS blocks
+// instead of the fresh zero/tdata-initialized state the ABI guarantees — and leak them (#68).
+// Safe (no-op) on threads that never called __tls_get_addr, incl. the main thread.
+void tls_dtv_purge_current_thread();
+// Number of threads currently holding live DTV entries (test/diagnostic introspection: lets the
+// regression test assert that thread exit really purged — i.e. no per-thread-churn leak).
+size_t tls_dtv_thread_count();
 
 // Guest initial-exec TLS (Linux; GATED behind PROSPER_GUEST_FS, default off). Backs guest %fs-relative
 // static thread-locals by giving each guest thread its own guest TCB + Variant-II static TLS and running

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -279,7 +279,17 @@ void* thread_trampoline(void* p) {
     // is host glibc (host-TLS tcache) — running it under the guest %fs corrupts the host heap.
     arm_hwbp_this_thread();   // no-op unless PROSPER_HWBP_ALLTHREADS; MUST run on host %fs (host libc calls)
     guest_tls_activate_thread();
-    return entry ? entry(arg) : nullptr;
+    void* rv = entry ? entry(arg) : nullptr;
+    // Normal-return exit path: purge this thread's __tls_get_addr DTV entries and free the blocks
+    // (#68 — glibc recycles pthread ids, so a stale entry would hand the NEXT thread on this id the
+    // dead thread's dirty TLS). The guest entry can return with %fs still = the guest TP
+    // (PROSPER_GUEST_FS), and the purge is host libc (mutex/free), so run it under the host %fs
+    // (scoped swap; both calls are no-ops when the gate is off / not on a guest TCB). Threads that
+    // exit via scePthreadExit never get here — k_pthread_exit purges before host pthread_exit.
+    uint64_t sfs = guest_fs_to_host_scoped();
+    tls_dtv_purge_current_thread();
+    guest_fs_restore_scoped(sfs);
+    return rv;
 }
 }
 #endif
@@ -322,7 +332,15 @@ HLE(k_pthread_create) {
 }
 HLE(k_pthread_join)   { void* rv = nullptr; pthread_join((pthread_t)a0, a1 ? &rv : nullptr); if (a1) *(void**)(uintptr_t)a1 = rv; return 0; }
 HLE(k_pthread_detach) { pthread_detach((pthread_t)a0); return 0; }
-HLE(k_pthread_exit)   { pthread_exit((void*)(uintptr_t)a0); return 0; }
+HLE(k_pthread_exit)   {
+    // Host pthread_exit unwinds without ever returning through thread_trampoline, so this is its own
+    // thread-exit path: purge the exiting thread's __tls_get_addr DTV first (#68). HLE handlers run
+    // under the HOST %fs (the import stubs swap), so the host libc below is safe. No-op for threads
+    // that never touched __tls_get_addr.
+    tls_dtv_purge_current_thread();
+    pthread_exit((void*)(uintptr_t)a0);
+    return 0;
+}
 
 // --- thread-local storage keys (IL2CPP uses these heavily) -> host pthread keys ---
 HLE(k_key_create) {
@@ -687,7 +705,35 @@ HLE(k_dlsym) {   // sceKernelDlsym(SceKernelModule handle, const char* name, voi
 // module id, lazily allocated from the module's PT_TLS template (memsz block, filesz copied from
 // the init image, tbss zeroed). This is the general-dynamic model — no %fs needed (that's only for
 // the main exe's initial-exec TLS, which the current boot already tolerates).
-namespace { std::vector<TlsModuleDesc> g_tls_mods; }
+namespace {
+std::vector<TlsModuleDesc> g_tls_mods;
+// Per-thread DTV (thread -> module id -> TLS block). MUST NOT use a host `thread_local`: guest threads
+// run under the GUEST %fs, and host thread_local storage is %fs-relative, so it ALIASES guest memory —
+// reads come back as garbage (an unordered_map whose bucket_count reads 0 → `hash % 0` → SIGFPE).
+// This is the same host↔guest %fs-aliasing landmine as the GfxDevice boot wall. Key by
+// std::thread::id in a mutex-guarded global map instead. CONFIDENCE: HIGH (root-caused via gdb:
+// SIGFPE in k_tls_get_addr with a corrupt thread_local map under a guest %fs).
+// The map is PURGED on every HLE-controlled thread-exit path (thread_trampoline return +
+// scePthreadExit/pthread_exit) via tls_dtv_purge_current_thread(): glibc recycles pthread ids, so a
+// stale entry would hand a NEW thread the dead thread's dirty TLS blocks instead of the fresh
+// zero/tdata-initialized state the ABI guarantees — and the blocks would leak per thread churn (#68).
+std::mutex g_dtv_mx;
+std::unordered_map<std::thread::id, std::unordered_map<uint64_t, void*>> g_dtv;
+}
+void tls_dtv_purge_current_thread() {
+    std::unordered_map<uint64_t, void*> mine;
+    { std::lock_guard<std::mutex> lk(g_dtv_mx);
+      auto it = g_dtv.find(std::this_thread::get_id());
+      if (it == g_dtv.end()) return;   // main/host threads may never have touched __tls_get_addr
+      mine = std::move(it->second);
+      g_dtv.erase(it);
+    }
+    for (auto& kv : mine) free(kv.second);   // free the blocks outside the lock
+}
+size_t tls_dtv_thread_count() {   // test/diagnostic introspection: threads with live DTV entries
+    std::lock_guard<std::mutex> lk(g_dtv_mx);
+    return g_dtv.size();
+}
 void set_tls_modules(const TlsModuleDesc* descs, size_t count) {
     g_tls_mods.assign(descs, descs + count);
     if (getenv("PROSPER_TLSLOG"))
@@ -700,17 +746,9 @@ HLE(k_tls_get_addr) {   // __tls_get_addr(tls_index* ti): ti[0]=module id, ti[1]
     const uint64_t* ti = (const uint64_t*)(uintptr_t)a0;
     if (!ti) return 0;
     uint64_t modid = ti[0], off = ti[1];
-    // Per-thread DTV (module id -> TLS block). MUST NOT use a host `thread_local` here: guest threads run
-    // under the GUEST %fs, and host thread_local storage is %fs-relative, so it ALIASES guest memory —
-    // reads come back as garbage (an unordered_map whose bucket_count reads 0 → `hash % 0` → SIGFPE).
-    // This is the same host↔guest %fs-aliasing landmine as the GfxDevice boot wall. Key by the host tid
-    // (a syscall, %fs-independent) in a mutex-guarded global map instead. CONFIDENCE: HIGH (root-caused
-    // via gdb: SIGFPE in k_tls_get_addr with a corrupt thread_local map under a guest %fs).
-    static std::mutex s_dtv_mx;
-    static std::unordered_map<std::thread::id, std::unordered_map<uint64_t, void*>> s_dtv;   // per-thread DTV
     std::thread::id tid = std::this_thread::get_id();   // portable per-OS-thread key (no %fs, no syscall)
-    { std::lock_guard<std::mutex> lk(s_dtv_mx);
-      auto& dtv = s_dtv[tid];
+    { std::lock_guard<std::mutex> lk(g_dtv_mx);
+      auto& dtv = g_dtv[tid];
       auto it = dtv.find(modid);
       if (it != dtv.end()) return (uint64_t)(uintptr_t)it->second + off;
     }
@@ -720,9 +758,9 @@ HLE(k_tls_get_addr) {   // __tls_get_addr(tls_index* ti): ti[0]=module id, ti[1]
         filesz = g_tls_mods[modid].filesz;
         init_va = g_tls_mods[modid].init_va;
     }
-    void* blk = calloc(1, memsz);
+    void* blk = calloc(1, memsz);   // zero-init (tbss), then copy the tdata image
     if (init_va && filesz) memcpy(blk, (const void*)(uintptr_t)init_va, filesz);
-    { std::lock_guard<std::mutex> lk(s_dtv_mx); s_dtv[tid][modid] = blk; }
+    { std::lock_guard<std::mutex> lk(g_dtv_mx); g_dtv[tid][modid] = blk; }
     return (uint64_t)(uintptr_t)blk + off;
 }
 

--- a/prosper/tests/test_tls_dtv_purge.cpp
+++ b/prosper/tests/test_tls_dtv_purge.cpp
@@ -1,0 +1,112 @@
+// test_tls_dtv_purge — regression guard for #68: the __tls_get_addr per-thread DTV must be purged
+// (entries erased, blocks freed) on EVERY HLE-controlled thread-exit path. glibc recycles pthread
+// ids, so a stale entry hands a new guest thread landing on a recycled id the dead thread's dirty
+// TLS blocks instead of the zero/tdata-initialized state the ABI guarantees (real libc.prx keeps
+// errno/locale/allocator state there) — and the blocks leak per thread churn.
+// Covers: (1) fresh zero+tdata init of a new block, (2) purge-then-refetch returns fresh state on
+// the same thread (the recycled-id scenario, simulated deterministically), (3) the trampoline
+// normal-return exit path purges, (4) the scePthreadExit path (host pthread_exit — never returns
+// through the trampoline) purges, (5) main/host threads with no DTV entries purge as a no-op.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static HleFn TLSGET, CREATE, JOIN, EXITF;
+
+// One TLS module template: 8 tdata bytes, memsz 32 (24 tbss bytes that must come up zero).
+static unsigned char g_tdata[8] = { 0xA5, 0x5A, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 };
+enum { kMemsz = 32, kFilesz = 8 };
+
+static unsigned char* tls_block() {   // __tls_get_addr({module 0, offset 0})
+    uint64_t ti[2] = { 0, 0 };
+    return (unsigned char*)(uintptr_t)TLSGET((uint64_t)(uintptr_t)ti, 0, 0, 0, 0, 0);
+}
+static bool block_is_fresh(const unsigned char* p) {
+    if (!p) return false;
+    if (memcmp(p, g_tdata, kFilesz) != 0) return false;          // tdata image copied
+    for (int i = kFilesz; i < kMemsz; i++) if (p[i]) return false;   // tbss zeroed
+    return true;
+}
+
+// Worker body: fetch this thread's block, record whether it came up fresh, then DIRTY it — the
+// purge on exit must not let those bytes survive into any later thread.
+struct WorkerResult { int fresh = -1; };
+static void tls_touch_and_dirty(WorkerResult* r) {
+    unsigned char* blk = tls_block();
+    r->fresh = block_is_fresh(blk) ? 1 : 0;
+    if (blk) memset(blk, 0xEE, kMemsz);
+}
+static void* worker_return(void* p) {   // exit path 1: normal return through thread_trampoline
+    tls_touch_and_dirty((WorkerResult*)p);
+    return nullptr;
+}
+static void* worker_exit(void* p) {     // exit path 2: scePthreadExit (host pthread_exit, no return)
+    tls_touch_and_dirty((WorkerResult*)p);
+    EXITF(0, 0, 0, 0, 0, 0);
+    return (void*)0xdead;               // not reached
+}
+
+int main() {
+    printf("== test_tls_dtv_purge ==\n");
+    register_builtin_hle();
+
+    TLSGET = Hle::lookup(nid_hash("__tls_get_addr"));
+    CREATE = Hle::lookup(nid_hash("scePthreadCreate"));
+    JOIN   = Hle::lookup(nid_hash("scePthreadJoin"));
+    EXITF  = Hle::lookup(nid_hash("scePthreadExit"));
+    CHECK(TLSGET && CREATE && JOIN && EXITF, "__tls_get_addr + scePthreadCreate/Join/Exit registered");
+    if (!(TLSGET && CREATE && JOIN && EXITF)) { printf("== FAIL ==\n"); return 1; }
+
+    TlsModuleDesc desc; desc.init_va = (uint64_t)(uintptr_t)g_tdata; desc.filesz = kFilesz; desc.memsz = kMemsz;
+    set_tls_modules(&desc, 1);
+
+    // (5) purge on a thread with no DTV entries is a graceful no-op (main/host threads).
+    tls_dtv_purge_current_thread();
+    CHECK(tls_dtv_thread_count() == 0, "purge with no DTV entries is a no-op");
+
+    // (1) first lookup allocates a fresh block: tdata copied, tbss zeroed.
+    unsigned char* blk = tls_block();
+    CHECK(block_is_fresh(blk), "new TLS block is tdata-initialized and tbss-zeroed");
+    CHECK(tls_block() == blk, "repeat lookup on the same thread returns the same block");
+    CHECK(tls_dtv_thread_count() == 1, "one thread holds a DTV entry");
+
+    // (2) the recycled-id scenario, deterministically: dirty the block, purge (what thread exit
+    // does), then look up again AS IF a new thread landed on the same id — must be fresh state,
+    // never the dead thread's dirty bytes.
+    memset(blk, 0xEE, kMemsz);
+    tls_dtv_purge_current_thread();
+    CHECK(tls_dtv_thread_count() == 0, "purge erased this thread's DTV entry");
+    CHECK(block_is_fresh(tls_block()), "post-purge lookup gets fresh state, not the dirty block");
+    tls_dtv_purge_current_thread();
+
+    // (3)+(4) both real thread-exit paths purge; churn several threads and assert no DTV growth
+    // (the per-thread-churn leak) and that every thread saw a fresh block (stale-TLS symptom if a
+    // pthread id does get recycled across iterations).
+    for (int i = 0; i < 8; i++) {
+        bool via_exit = (i & 1) != 0;
+        WorkerResult r;
+        uint64_t tid = 0;
+        uint64_t rc = CREATE((uint64_t)(uintptr_t)&tid, 0,
+                             (uint64_t)(uintptr_t)(via_exit ? worker_exit : worker_return),
+                             (uint64_t)(uintptr_t)&r, 0, 0);
+        if (rc != 0) { printf("  [FAIL] scePthreadCreate rc=%llu (iter %d)\n", (unsigned long long)rc, i); fails++; continue; }
+        JOIN(tid, 0, 0, 0, 0, 0);
+        char msg[96];
+        snprintf(msg, sizeof msg, "iter %d (%s): worker saw a fresh block", i, via_exit ? "scePthreadExit" : "return");
+        CHECK(r.fresh == 1, msg);
+        snprintf(msg, sizeof msg, "iter %d (%s): DTV entry purged on thread exit", i, via_exit ? "scePthreadExit" : "return");
+        CHECK(tls_dtv_thread_count() == 0, msg);
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Defect (#68)

`hle_kernel.cpp` kept the per-thread DTV for `__tls_get_addr` as a global map keyed by `std::this_thread::get_id()` with **no cleanup at thread exit**. glibc aggressively recycles pthread ids, so a new guest thread landing on a recycled id inherited the dead thread's DTV: its TLS blocks contained the previous thread's final values instead of the fresh zero/tdata-initialized state the ELF TLS ABI guarantees (real libc.prx keeps errno/locale/allocator state there). The blocks also leaked once per thread of churn.

## Fix

New `tls_dtv_purge_current_thread()` (declared in `dispatch.hpp`): under the DTV mutex, erase the **current** thread's entry only, then free its blocks outside the lock. No-op for threads that never called `__tls_get_addr` (main/host threads). It runs on every thread-exit path the HLE controls:

- **`thread_trampoline` normal return** — the guest entry can return with `%fs` still on the guest TCB (`PROSPER_GUEST_FS`), and the purge is host libc (mutex/`free`), so it runs under a scoped `guest_fs_to_host_scoped()` / `guest_fs_restore_scoped()` swap (both no-ops when the gate is off).
- **`k_pthread_exit`** (`scePthreadExit` / `pthread_exit`) — this calls host `pthread_exit` directly and never returns through the trampoline, so it purges first. HLE handlers already run under the host `%fs` (import-stub swap), so no fs handling is needed there.

Keying scheme is unchanged (minimal fix per the issue); the block-creation path still `calloc`s (tbss zero) + copies the tdata image. DTV statics were hoisted from function-locals to file scope so the purge can reach them; the `%fs`-aliasing rationale comment moved with them.

Edge case left as-is (noted for the record): a guest TSD destructor that calls `__tls_get_addr` *during* `pthread_exit` would repopulate the entry after the purge. No current guest path does this; handling it would need a pthread-key destructor with iteration rounds, which is riskier on the trampoline-return path (destructors there run under the guest `%fs`).

## Verification

- New regression test `tls_dtv_purge_on_thread_exit` (`prosper/tests/test_tls_dtv_purge.cpp`), driving the real HLE entry points via the NID registry:
  1. fresh block is tdata-initialized + tbss-zeroed;
  2. deterministic recycled-id simulation: dirty the block, purge, refetch → fresh state, never the dead thread's bytes;
  3. 8-thread churn alternating **both** exit paths (trampoline return and `scePthreadExit`), asserting every worker sees a fresh block and the DTV is empty after each join (leak check, via a small `tls_dtv_thread_count()` introspection helper);
  4. purge on a thread with no entries is a graceful no-op.
- **Negative check:** with the two purge call sites disabled, the test fails on all 8 churn iterations (both paths) — then passes with the fix restored.
- Full WSL Ubuntu-24.04 suite: `ctest` **45/45 green** (includes the new test).

Fixes #68