### PR TITLE
feat(ue4): IoStore bring-up — pak containers mount, GEngineLoop.PreInit passes, engine reaches RHI init

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -181,6 +181,23 @@ failure — possibly downstream of (1). Watch item for (1): the 2 GiB pak is rea
 Then decompression: `.ucas` chunks MAY be Oodle-compressed (check `compressionMethodNameCount`;
 `global` was 0/uncompressed).
 
+Leads for (1), captured live (`PROSPER_APR_DIAG` + the now-logged four extra Ampr NIDs):
+
+- `a5` of the submit looks like the intended READ SIZE, not a descriptor size: utoc reads pass
+  `0x90` = exactly the utoc TocHeaderSize, pak reads pass `0xdd` = 221 = the FPakInfo footer
+  size (61 + 5×32 compression-method names) and then `0xde` (a second footer-version probe) —
+  i.e. the pak reads want the LAST `a5` bytes (`filesize-221`), which whole-file-from-0 does not
+  deliver at the published pointer.
+- For the pakchunk0 pak read the desc buffer (`a4=0x20018f0000`, BatchMap memory) is a
+  structured ENGINE-PREWRITTEN array (~0x28-byte records): `{seq 0x456/0x467/0x485/0x4a7, small
+  count 0/1/3/4, eboot ptr 0x4058d26b0, dest VA 0x10e0dfff8000, {high32 seq | low32 0xffffffff}
+  pending markers}` — very likely the real per-read command/completion descriptors. Decoding
+  this array is the next concrete step for offset-correct pak reads.
+- The four other Ampr NIDs the flow calls fire AFTER each submit with constant args
+  (`baQO9ez2gL4(req,0,0,0,0x40|0,0)`, `ULvXMDz56po(req,stack,0,0,0x45,4|7)`,
+  `Qs1xtplKo0U(req,&rec.scratch,&rec.data,0,0x45,0xe)`, `GuchCTefuZw(req,stack,0,0,0x45,0xf)`) —
+  teardown/end-of-request, not the offset carrier (arg capture via `PROSPER_AMPRLOG`).
+
 ## Remaining work to the first frame (the subsystem)
 
 This is genuine subsystem construction, sized (per `CROSS_ENGINE_UE4.md`) like a second-title

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -138,12 +138,47 @@ Root cause (proven by a full-run `PROSPER_HWWATCH_ABS` write history of the "des
   status. The crash is gone and the engine advances through global.utoc parse, `.ucas` open,
   saved-paks probing, and pakchunk resolve.
 
-Current wall (much deeper): the 3rd submit is a MULTI-segment read — `count=0x4`, descSize=0xdd
-(not 0x90), total `req+0x30 = 36144292` bytes which matches NO single container file, so the
-match-by-size heuristic fails ("no file for size") and the engine crashes at `eboot+0x22ebe7f`
-(null+8). Next: decode the per-segment layout (file id / offset / size list — likely behind
-`req+0x08` or the desc buffer) and pread per segment via `prosper_apr_path_for_id`. Then
-decompression: `.ucas` chunks MAY be Oodle-compressed (check `compressionMethodNameCount`;
+### RESOLVED: the "multi-segment" 3rd submit was frame residue — a3 IS the file id
+
+The `count=0x4 / total=36144292` reading of the 3rd submit was wrong: those request-frame slots
+are pure residue at that callsite (`req+0x00 = 0x402316d88` and `req+0x08 = 0x402316d50` are
+eboot CODE addresses; `req+0x30 = 0x22784a4` — 36,144,292 — recurs there across runs while
+`req+0x28` holds a stack pointer). The pak-read wrapper (descSize `0xdd`, a heap desc buffer)
+simply doesn't initialize the frame the way the utoc-read wrapper (descSize `0x90`) does.
+
+The real contract, proven over 6 live reads at both callsites (A/B-tested by rewriting the
+record and watching the engine follow it):
+
+- **`a3` is the APR file id** from resolve — a3=1 global.utoc, 3 pakchunk2-ps5.utoc,
+  4 pakchunk1-ps5.pak (twice), 5 pakchunk1-ps5.utoc, 6 pakchunk0-ps5.pak (twice),
+  7 pakchunk0-ps5.utoc. `mQ16(reqFrame, a1=&rec.scratch, a2=&rec.data, a3=fileId, descBuf,
+  descSize)`.
+- **`a2` points at a completion record the LIBRARY fills**: `[0]` data pointer (library-chosen
+  location — begin's staging cursor until submit publishes the final buffer), `[+8]` status
+  (0 = success; on failure `{low32 err, high32 CB offset}` — exactly the `24|40` / `2b|48`
+  pairs the "Apr read failure" fatal prints; checked at eboot `0x22738a5`), `[+0x10]` bytes.
+- **Byte count = the whole resolved file** (the engine got sizes from resolve; nothing in the
+  record is a trustworthy input).
+
+`f_apr_read_submit` now resolves by id, reads the whole file into a per-read prosper-owned
+buffer (never freed — the engine treats the pages as library-owned), and completes the record
+through `a2`. Result: the `eboot+0x22ebe7f` failure-path fault is gone and ALL containers read
+clean (global 645, pakchunk1 pak 339 + utoc 32,485, pakchunk0 pak 2,062,854,722 (!) + utoc
+14,271,592, empty pakchunk2 completes trivially with size 0). The whole IoStore container-mount
+phase finishes; the engine walks on to `globalshadercache-sf_ps5.bin` and a (legitimately
+absent) `doll/doll.uproject` probe.
+
+**Current wall (deeper again): `GEngineLoop.PreInit Failed!`** →
+`sceKernelDebugRaiseExceptionOnReleaseMode(0xa0020005)`. No fault — the engine reports init
+failure itself. Suspects, in order: (1) whole-file-from-offset-0 semantics for the TWO pak reads
+per pak (descSize `0xdd`/`0xde` — real HW likely reads the pak index/footer at an offset carried
+somewhere we don't decode yet; if the engine expects the published pointer to start AT its
+requested offset, the FPakFile index parse fails silently and no containers mount → PreInit
+can't find the engine inis); (2) the `resolve MISS` output contract (we write id=0/size=0 —
+verify against real errno/flag semantics); (3) `.ucas` chunk reads never happen before the
+failure — possibly downstream of (1). Watch item for (1): the 2 GiB pak is read whole TWICE
+(two leaked 2 GiB buffers) — finding the offset/size input fixes both correctness and cost.
+Then decompression: `.ucas` chunks MAY be Oodle-compressed (check `compressionMethodNameCount`;
 `global` was 0/uncompressed).
 
 ## Remaining work to the first frame (the subsystem)

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -198,6 +198,75 @@ Leads for (1), captured live (`PROSPER_APR_DIAG` + the now-logged four extra Amp
   `Qs1xtplKo0U(req,&rec.scratch,&rec.data,0,0x45,0xe)`, `GuchCTefuZw(req,stack,0,0,0x45,0xf)`) —
   teardown/end-of-request, not the offset carrier (arg capture via `PROSPER_AMPRLOG`).
 
+### SOLVED (2026-07-08, feat/ue4-apr-read): pak mounting works — the read is (offset, size) and offset is the 7th arg
+
+Two facts closed the loop:
+
+1. **NID names recovered by brute-force** (`nid_hash(name)` over a generated libSceAmpr corpus —
+   the algorithm in `nid.cpp`): the read is **`sceAmprAprCommandBufferReadFile`** (`mQ16-QdKv7k`),
+   and the flow is `sceAmprCommandBufferConstructor`(`8aI7R7WaOlc`) →
+   `sceAmprAprCommandBufferConstructor`(`a8uLzYY--tM`) → `sceAmprCommandBufferSetBuffer`
+   (`N-FSPA4S3nI`) → `sceAmprAprCommandBufferReadFile` → `sceAmprCommandBufferReset`
+   (`baQO9ez2gL4`) → `sceAmprAprCommandBufferDestructor`(`Qs1xtplKo0U`) →
+   `sceAmprCommandBufferDestructor`(`GuchCTefuZw`). "ReadFile" being a command *builder* means
+   **every read parameter is an argument** of that one call.
+
+2. **`ReadFile` has ≥7 args; the FILE OFFSET is the 7th, passed ON THE STACK** — which the plain
+   6-arg HleFn signature never saw (the exact blind spot that made pak footer reads look
+   offset-less). An asm entry shim (`f_apr_read_submit_entry` in `hle_file.cpp`) snapshots `rsp`
+   into a TLS slot so the handler reads stack args; it distinguishes the two stub tails (swap-stub
+   `call` vs `jmp`) by whether `[rsp]` is in the stub region `[0x6_0000_0000, 0x7_0000_0000)`.
+
+   Live-verified offsets (exact footer math, 8 reads, 3 file kinds): utoc header reads
+   `(off=0, size=0x90)`; the two FPakInfo footer probes per pak `(off=filesize-221, size=221)` and
+   `(off=filesize-222, size=222)` — e.g. pakchunk1 pak (339 B): `0x76`/`0x75`; pakchunk0 pak
+   (2,062,854,722 B): `0x7af4a965`/`0x7af4a964`. So **`a5` = size, `arg7` = offset**; the read is
+   a host `pread(fd, dst, a5, arg7)` clamped to EOF.
+
+3. **The destination is `a4` (arg5), the caller's `dst` buffer — not only the completion record.**
+   After fixing offset+size, PreInit *still* failed until the bytes were also written INTO `a4`:
+   the utoc callsite consumes data via the record pointer, but the **pak-footer callsite reads its
+   own `dst` buffer directly** (with only the side record published, the correct footer bytes were
+   never seen, no index read followed, mount failed). `f_apr_read_submit` now
+   `process_vm_writev`s into `a4` and publishes `record[0]=a4`; it falls back to a prosper-owned
+   staging buffer only if `a4` is absent/unmapped.
+
+**Result: `GEngineLoop.PreInit Failed!` is GONE. All containers mount.** The engine now issues the
+real post-footer reads it previously never reached: the FPakFile **index** at the footer's
+`IndexOffset`, then chunk/index-entry reads at learned offsets (e.g. pakchunk0 pak reads at
+`0x7af0b825`, `0x7af3550c`, `0x78a559dd`, …), and it opens+resolves the `.ucas` (pakchunk0-ps5.ucas
+id=10, 17.8 GB) — i.e. IoStore container mounting is complete. CONFIDENCE: HIGH (offset/size/dst all
+verified on live reads; PreInit-passes is the end-to-end proof).
+
+### NEW WALL: post-mount engine/RHI init — a null virtual call (racy, two faces)
+
+Boot now reaches early UE engine init and dies in one of two timing-dependent spots (the RHI /
+task-graph worker threads are now live, so it is nondeterministic):
+
+- **Main-thread face (representative):** a null vtable call. At `eboot+0x24c75ef`
+  `mov 0x28(%r15),%rdi ; mov (%rdi),%rax ; call *0x10(%rax)` the object's vtable slot `+0x10` is 0
+  → control jumps to `rip=0` (`RUN ENDED kind=2, rip=0x0`; backtrace
+  `eboot+0x24c75f2 ← +0x24c7234 ← +0x95a2 ← +0x7b26 ← +0x9c7 ← +0x508e ← +0xbf`, i.e. reached
+  from CRT `_start`/main on the main thread). The neighbourhood registers CVars by name — the
+  rodata strings loaded just before are `LoadModule  - `, and the sibling singleton-init block
+  (`eboot+0x503b878`) registers `r.Shadow.CacheWPOPrimitivesError` / `r.ShowMaterialDrawEvents` /
+  `r.RHIThread…` via `call *0xb0(%rax)` on a CVar-manager object. So this is **RHI / CVar / module
+  bring-up**, past PreInit.
+- **Worker-thread face:** a fault in host HLE code reading a small address (~`0x2936xx`, grows per
+  run) — a worker racing the same half-initialized subsystem.
+
+Next steps (in order):
+1. Resolve the null vtable object at `eboot+0x24c75ef`: break there, walk `[[r15+0x28]]` and its
+   vtable to see which interface method `+0x10` should be — likely a subsystem/module singleton
+   the engine expects a prior init to have populated (an unimplemented Sony import returning 0
+   where the engine stored the result as an object pointer, or a module we skip loading:
+   `SaveData.prx` / `PSN.prx` / `PS5Util.prx` / `Il2cppUserAssemblies.prx` are all "skipping absent
+   module"). Check whether one of those provides the missing vtable.
+2. Then the `.ucas` chunk reads proper (asset registry / shader cache). Check each utoc's
+   `CompressionMethodNameCount`: `global` was 0/uncompressed; the pakchunk `.ucas` chunks are
+   likely Oodle Kraken/Mermaid and will need a decode path.
+3. Then RHI/AGC init → first UE draw via the existing `execute_and_present`.
+
 ## Remaining work to the first frame (the subsystem)
 
 This is genuine subsystem construction, sized (per `CROSS_ENGINE_UE4.md`) like a second-title

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -108,14 +108,43 @@ init-guard-style function (`rax`=0x2001c10000 a BatchMap buffer, null deref, `rd
 read happens before this — the engine crashes *processing* the parsed TOC, before the next read.
 
 Field map of the APR read-request object (live `req` dump):
-`+0x00` count(1) · `+0x08` stack ptr · `+0x10` fn/vtable · `+0x18` small stack scratch ·
-`+0x20` **mapped data buffer (dest)** · `+0x28` status(err\|cboff) · `+0x30` **byte count** ·
+`+0x00` count(1) · `+0x08` stack ptr · `+0x10` fn/vtable · `+0x18` **begin out-slot 1** ·
+`+0x20` **begin out-slot 2 = data pointer** · `+0x28` status(err\|cboff) · `+0x30` **byte count** ·
 `+0x38` stack canary · `+0x40` stack ptr.
 
-Next: disassemble `0x2316c91` / `0x22fce69` — likely another null global/uninitialized IoStore
-struct (a missing init call or a container/registry the TOC parse expected to populate). Then the
-`.ucas` chunk reads begin (those MAY be Oodle-compressed — check each container's utoc
-`compressionMethodNameCount`; `global` was 0/uncompressed).
+### RESOLVED: the `eboot+0x2316c91` freelist crash was a stale, never-populated begin-cursor
+
+Root cause (proven by a full-run `PROSPER_HWWATCH_ABS` write history of the "dest" and by
+`PROSPER_AMPRLOG` arg/out-slot capture):
+
+- The APR read flow inits its request through the SAME Ampr NIDs as the page-map path:
+  `8aI7R7WaOlc(req, cbSize=0x40, 0, pathStruct, allocCtx=0x2001c10060, 3)` then
+  `a8uLzYY--tM(req, &req->0x18, &req->0x20, 0, 0x2a, 0)` then `mQ16(req, …)`. The `begin` call's
+  two pointer args are OUT-SLOTS the library must populate; the engine reads the file data back
+  through `*(req+0x20)` after completion — the library chooses the data location, not the engine.
+- Our `begin` HLE returned 0 WITHOUT writing the slots, so `req+0x20` kept stale stack garbage
+  that happened to point at a FREED 0x50-byte block (`0x1080e10a50`) of the engine's own live
+  path-string pool (freelist head `0x2001c10080`, carve-linker `eboot+0x230f1d8`, push
+  `eboot+0x2316e0c` — the push LINKS `node->next := head`, it does not zero). The HW watch showed
+  the block sitting free on the freelist at read time; writing the 645-byte TOC over it clobbered
+  the free nodes' next pointers with the TOC magic → the later pop at `eboot+0x2316c80` popped
+  `next == 0x2d3d3d2d2d3d3d2d` and faulted at `+0x2316c91`.
+- Why the TOC still "parsed": both our read HLE (write) and the engine (read-back) dereferenced
+  the SAME stale slot, so the data round-tripped consistently — only the pool underneath was
+  corrupted. There was never a prosper memory-model overlap: MEMLOG showed the page
+  `0x1080e10000` BatchMap-committed exactly once, no alias, no mirror (dmem/batchmap are clean).
+- Fix: `k_ampr_begin` now populates both out-slots with a prosper-owned 16 MiB staging buffer
+  (modeling the library-owned staging on real HW); a zero-length submit also clears the `req+0x28`
+  status. The crash is gone and the engine advances through global.utoc parse, `.ucas` open,
+  saved-paks probing, and pakchunk resolve.
+
+Current wall (much deeper): the 3rd submit is a MULTI-segment read — `count=0x4`, descSize=0xdd
+(not 0x90), total `req+0x30 = 36144292` bytes which matches NO single container file, so the
+match-by-size heuristic fails ("no file for size") and the engine crashes at `eboot+0x22ebe7f`
+(null+8). Next: decode the per-segment layout (file id / offset / size list — likely behind
+`req+0x08` or the desc buffer) and pread per segment via `prosper_apr_path_for_id`. Then
+decompression: `.ucas` chunks MAY be Oodle-compressed (check `compressionMethodNameCount`;
+`global` was 0/uncompressed).
 
 ## Remaining work to the first frame (the subsystem)
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -429,13 +429,69 @@ HLE(f_apr_resolve) {
 // CONFIDENCE: HIGH on id=a3 + record-output via a2 (three callsites, A/B-tested); MED on
 // whole-file semantics — a partial/offset read has not been observed yet (fine for TOC/pak-header
 // reads; revisit at the first .ucas chunk read).
+// --- Stack-argument capture for sceAmprAprCommandBufferReadFile ---------------------------------
+// The NID reverses to the real Sony name (brute-forced against nid_hash):
+//   mQ16-QdKv7k = sceAmprAprCommandBufferReadFile   (and the rest of the flow:
+//   8aI7R7WaOlc = sceAmprCommandBufferConstructor, a8uLzYY--tM = sceAmprAprCommandBufferConstructor,
+//   N-FSPA4S3nI = sceAmprCommandBufferSetBuffer, baQO9ez2gL4 = sceAmprCommandBufferReset,
+//   Qs1xtplKo0U = sceAmprAprCommandBufferDestructor, GuchCTefuZw = sceAmprCommandBufferDestructor).
+// ReadFile is a command-BUILDER: every read parameter is an argument of this call. Six land in
+// registers (cb, out1, out2, fileId, dst?, size) — the FILE OFFSET is the 7th argument and lives
+// ON THE GUEST STACK, which the plain HleFn signature never saw (that blind spot is exactly why
+// pak footer reads looked offset-less). The asm entry below snapshots rsp into a TLS slot so the
+// C handler can read the stack args. Both stub paths run on the HOST %fs (the swap stub switches
+// before the call; the tail-jmp path never left it), so TLS is safe here.
+// Stack layout depends on which stub path invoked us:
+//   swap stub ("call rax" after push r11):  [rsp]=stub ret (0x6xxxxxxxx), [rsp+8]=saved r11,
+//                                           [rsp+16]=guest ret, [rsp+24]=arg7, [rsp+32]=arg8
+//   tail-jmp ("jmp rax"):                   [rsp]=guest ret, [rsp+8]=arg7, [rsp+16]=arg8
+// Distinguished by whether [rsp] lies in the stub region [0x600000000, 0x700000000).
+// Ampr command-buffer address/size captured at init (hle_kernel_mem.cpp). Declared at namespace
+// scope (NOT inside the extern "C" handler, where a block-scope extern would take C linkage and
+// miss the mangled prosper:: definition).
+extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
+
+#ifndef _WIN32
+extern "C" __thread uint64_t g_apr_entry_rsp;
+__thread uint64_t g_apr_entry_rsp = 0;
+extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
+                                        uint64_t a3, uint64_t a4, uint64_t a5);
+asm(".text\n"
+    ".globl f_apr_read_submit_entry\n"
+    ".type f_apr_read_submit_entry,@function\n"
+    "f_apr_read_submit_entry:\n"
+    "  movq %rsp, %fs:g_apr_entry_rsp@tpoff\n"
+    "  jmp f_apr_read_submit_c\n");
+extern "C" void f_apr_read_submit_entry();
+// Fetch the Nth stack argument (0-based: arg7 is n=0) of the in-flight ReadFile call.
+static uint64_t apr_stack_arg(int n) {
+    uint64_t rsp = g_apr_entry_rsp;
+    if (!rsp) return 0;
+    uint64_t ret = *(uint64_t*)rsp;
+    bool via_call = (ret >= 0x600000000ull && ret < 0x700000000ull);
+    return *(uint64_t*)(rsp + (via_call ? 0x18 : 0x8) + (uint64_t)n * 8);
+}
+#endif
+
+#ifndef _WIN32
+extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
+                                        uint64_t a3, uint64_t a4, uint64_t a5) {
+#else
 HLE(f_apr_read_submit) {
+#endif
     uint8_t* req = (uint8_t*)P(a0);
     if (!req) return 0x80020016ull;
     if (filelog()) {
         fprintf(stderr, "[apr] read-submit req=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx desc=0x%llx descsz=0x%llx\n",
                 (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+#ifndef _WIN32
+        fprintf(stderr, "[apr]   stack-args a6=0x%llx a7=0x%llx a8=0x%llx a9=0x%llx (rsp=0x%llx ret=0x%llx)\n",
+                (unsigned long long)apr_stack_arg(0), (unsigned long long)apr_stack_arg(1),
+                (unsigned long long)apr_stack_arg(2), (unsigned long long)apr_stack_arg(3),
+                (unsigned long long)g_apr_entry_rsp,
+                (unsigned long long)(g_apr_entry_rsp ? *(uint64_t*)g_apr_entry_rsp : 0));
+#endif
         for (int o = 0; o < 0x48; o += 8)
             fprintf(stderr, "[apr]   req+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(req + o));
         // Cursor slots (a1/a2 point at them) and the 0x90-byte descriptor buffer (a4): the desc may
@@ -447,7 +503,6 @@ HLE(f_apr_read_submit) {
             fprintf(stderr, "[apr]   desc+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(a4 + o));
         // The real read command lives in the Ampr command buffer registered at init (a3 of the
         // (req, cbSize, 0, cbBuf, poolCtx, 3) init call); "CB offset 40" is decimal 40 = 0x28 into it.
-        extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
         if (g_apr_last_cb) {
             fprintf(stderr, "[apr]   cb=0x%llx size=0x%llx\n",
                     (unsigned long long)g_apr_last_cb, (unsigned long long)g_apr_last_cb_size);
@@ -473,10 +528,27 @@ HLE(f_apr_read_submit) {
                                (unsigned long long)id);
         return 0x80020016ull;    // record stays incomplete -> the engine reports this read as failed
     }
-    // Byte count: the record carries no trustworthy size (call 3's +0x30 is residue) — the APR
-    // page-read covers the whole resolved file (sizes were returned to the engine by resolve).
-    uint64_t size = 0;
-    { struct stat st {}; if (::stat(host.c_str(), &st) == 0) size = (uint64_t)st.st_size; }
+    // Read range: a5 = byte count, and the FILE OFFSET is the 7th argument (on the guest stack).
+    // Verified live with exact footer math (2026-07-08): utoc header reads pass (offset=0,
+    // size=0x90=TocHeaderSize); the two FPakInfo footer probes per pak pass
+    // (offset=filesize-221, size=221=FPakInfo::Size8a) then (offset=filesize-222, size=222=Size9)
+    // — e.g. pakchunk1-ps5.pak (339 bytes): offsets 0x76/0x75; pakchunk0-ps5.pak (2,062,854,722
+    // bytes): offsets 0x7af4a965/0x7af4a964. Reads are clamped to EOF like a host pread (empty
+    // pakchunk2 placeholders complete with 0 bytes, status 0 — the model the engine already
+    // accepted). CONFIDENCE: HIGH (offset+size confirmed on 8 live reads across 3 file kinds).
+    uint64_t fsize = 0;
+    { struct stat st {}; if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
+    uint64_t offset = 0;
+#ifndef _WIN32
+    offset = apr_stack_arg(0);
+#endif
+    uint64_t size = a5;
+    if (offset > fsize) {
+        if (filelog()) fprintf(stderr, "[apr] read-submit: offset 0x%llx past EOF (file %llu) — clamped\n",
+                               (unsigned long long)offset, (unsigned long long)fsize);
+        offset = fsize;
+    }
+    if (size > fsize - offset) size = fsize - offset;
 #ifndef _WIN32
     // Fault-safe guest-memory read (unmapped guest VA -> false, never SIGSEGV in the HLE).
     auto safe_read = [](uint64_t va, void* out, size_t n) -> bool {
@@ -547,24 +619,44 @@ HLE(f_apr_read_submit) {
     if (size) {
         int fd = ::open(host.c_str(), O_RDONLY);
         if (fd < 0) { munmap(slot, rounded); return 0x80020016ull; }
-        got = ::pread(fd, slot, (size_t)size, 0);
+        got = ::pread(fd, slot, (size_t)size, (off_t)offset);
         ::close(fd);
     }
     bool ok = ((uint64_t)got == size);
+    // a4 is the caller's DESTINATION buffer (the `dst` argument of
+    // sceAmprAprCommandBufferReadFile) — on real hardware the DMA engine fills it and the
+    // completion record's data pointer equals it. The utoc callsite consumes data via the record
+    // pointer, but the pak-footer callsite reads its own dst buffer directly (with only the
+    // record published to a side buffer, the correct footer bytes were provably never seen: no
+    // index read followed and PreInit failed). Copy into dst fault-safely (process_vm_writev
+    // refuses unmapped ranges instead of SIGSEGVing in the HLE) and publish record[0] = dst;
+    // fall back to the prosper-owned buffer only if dst is absent/unmapped.
+    // CONFIDENCE: MED-HIGH (dst role from the recovered real prototype + both callsites' behavior).
+    bool in_dst = false;
+    if (ok && a4 > 0xffff) {
+        if (size) {
+            struct iovec l { slot, (size_t)size }, r { (void*)(uintptr_t)a4, (size_t)size };
+            in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+        } else in_dst = true;
+    }
     if (ok && a2) {
         // Complete the record through the caller-supplied out-pointer (a2 = &record.data; the
         // stack offsets differ per callsite, a2 is the stable handle): [0] data pointer,
         // [+8] status (0 = success; on failure holds {err, CB offset} that the fatal prints),
         // [+0x10] bytes transferred.
-        *(uint64_t*)(uintptr_t)(a2 + 0x00) = (uint64_t)(uintptr_t)slot;
+        *(uint64_t*)(uintptr_t)(a2 + 0x00) = in_dst ? a4 : (uint64_t)(uintptr_t)slot;
         *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
         *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
-    } else if (!ok) {
-        munmap(slot, rounded);                                  // record stays -> guest reports failure
     }
-    if (filelog()) fprintf(stderr, "[apr] read-submit id=%llu %s -> buf=0x%llx size=%llu got=%lld %s\n",
-                   (unsigned long long)id, host.c_str(), (unsigned long long)(uintptr_t)slot,
-                   (unsigned long long)size, (long long)got, ok ? "OK" : "SHORT");
+    if (!ok || in_dst) {
+        munmap(slot, rounded);   // failure: record stays -> guest reports it; success-into-dst: staging no longer needed
+    }
+    if (filelog()) fprintf(stderr, "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) off=0x%llx size=%llu got=%lld %s\n",
+                   (unsigned long long)id, host.c_str(),
+                   in_dst ? (unsigned long long)a4 : (unsigned long long)(uintptr_t)slot,
+                   in_dst ? "guest" : "staging",
+                   (unsigned long long)offset, (unsigned long long)size, (long long)got,
+                   ok ? "OK" : "SHORT");
     return ok ? 0 : 0x80020016ull;
 #else
     (void)dest;
@@ -612,8 +704,14 @@ void register_file_hle() {
     R("unlink", f_unlink);        R("sceKernelUnlink", f_unlink);
     R("sceKernelGetdents", f_getdents); R("getdents", f_getdents);
     R("sceKernelAprResolveFilepathsToIdsAndFileSizes", f_apr_resolve);   // real APR resolve (was EINVAL)
-    // libSceAmpr read-submit (raw NID; the APR page-read that fills the request buffer via pread).
-    Hle::register_fn("mQ16-QdKv7k", (HleFn)f_apr_read_submit, "sceAmprAprReadSubmit?");
+    // libSceAmpr sceAmprAprCommandBufferReadFile (NID name recovered by brute-force). The Linux
+    // entry is an asm shim that snapshots rsp so the handler can read the stack args (arg7 = file
+    // offset); see f_apr_read_submit_entry above.
+#ifndef _WIN32
+    Hle::register_fn("mQ16-QdKv7k", (HleFn)f_apr_read_submit_entry, "sceAmprAprCommandBufferReadFile");
+#else
+    Hle::register_fn("mQ16-QdKv7k", (HleFn)f_apr_read_submit, "sceAmprAprCommandBufferReadFile");
+#endif
     #undef R
 }
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -426,7 +426,17 @@ HLE(f_apr_read_submit) {
 #ifndef _WIN32
     int fd = ::open(host.c_str(), O_RDONLY);
     if (fd < 0) return 0x80020016ull;
-    ssize_t got = ::pread(fd, (void*)(uintptr_t)dest, (size_t)size, 0);
+    // DIAGNOSTIC (PROSPER_APR_NOWRITE): read into a HOST scratch instead of the guest dest, to test
+    // whether the engine actually reads the TOC from `dest` (req+0x20). If the boot advances the SAME
+    // as writing to dest, the engine reads the TOC elsewhere and dest is the wrong buffer.
+    static bool nowrite = getenv("PROSPER_APR_NOWRITE") != nullptr;
+    ssize_t got;
+    if (nowrite) {
+        static uint8_t scratch[1 << 20];
+        got = ::pread(fd, scratch, (size_t)(size < sizeof scratch ? size : sizeof scratch), 0);
+    } else {
+        got = ::pread(fd, (void*)(uintptr_t)dest, (size_t)size, 0);
+    }
     ::close(fd);
 #else
     FILE* f = ::fopen(host.c_str(), "rb"); if (!f) return 0x80020016ull;

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -460,11 +460,14 @@ HLE(f_apr_resolve) {
 // pak footer reads looked offset-less). The asm entry below snapshots rsp into a TLS slot so the
 // C handler can read the stack args. Both stub paths run on the HOST %fs (the swap stub switches
 // before the call; the tail-jmp path never left it), so TLS is safe here.
-// Stack layout depends on which stub path invoked us:
-//   swap stub ("call rax" after push r11):  [rsp]=stub ret (0x6xxxxxxxx), [rsp+8]=saved r11,
-//                                           [rsp+16]=guest ret, [rsp+24]=arg7, [rsp+32]=arg8
-//   tail-jmp ("jmp rax"):                   [rsp]=guest ret, [rsp+8]=arg7, [rsp+16]=arg8
-// Distinguished by whether [rsp] lies in the stub region [0x600000000, 0x700000000).
+// Stack layout at our entry (after master #61 taught the swap stub to FORWARD the first two stack
+// args, re-pushing arg7/arg8 right below the call): BOTH stub paths now put the stack args at the
+// same slots — arg7 at [rsp+8], arg8 at [rsp+0x10]:
+//   swap stub ("push r11; push arg8; push arg7; call rax"): [rsp]=stub ret (0x6xxxxxxxx),
+//                                           [rsp+8]=arg7 (forwarded), [rsp+0x10]=arg8 (forwarded)
+//   tail-jmp ("jmp rax"):                   [rsp]=guest ret, [rsp+8]=arg7, [rsp+0x10]=arg8
+// (Before #61 the swap path had arg7 at [rsp+0x18] behind saved-r11/guest-ret — reading that slot
+// post-#61 returns the saved guest-fs base, which clamped every offset to EOF and broke the mount.)
 // Ampr command-buffer address/size captured at init (hle_kernel_mem.cpp). Declared at namespace
 // scope (NOT inside the extern "C" handler, where a block-scope extern would take C linkage and
 // miss the mangled prosper:: definition).
@@ -486,9 +489,8 @@ extern "C" void f_apr_read_submit_entry();
 static uint64_t apr_stack_arg(int n) {
     uint64_t rsp = g_apr_entry_rsp;
     if (!rsp) return 0;
-    uint64_t ret = *(uint64_t*)rsp;
-    bool via_call = (ret >= 0x600000000ull && ret < 0x700000000ull);
-    return *(uint64_t*)(rsp + (via_call ? 0x18 : 0x8) + (uint64_t)n * 8);
+    // Both paths land the forwarded/natural stack args at [rsp+8] (see the layout note above).
+    return *(uint64_t*)(rsp + 0x8 + (uint64_t)n * 8);
 }
 #endif
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -454,6 +454,11 @@ HLE(f_apr_read_submit) {
     if (filelog()) fprintf(stderr, "[apr] read-submit %s -> dest=0x%llx size=%llu got=%lld %s\n",
                    host.c_str(), (unsigned long long)dest, (unsigned long long)size, (long long)got,
                    ok ? "OK" : "SHORT");
+    // DIAGNOSTIC (PROSPER_APR_WATCHDEST): arm a HW write-watch on dest+0 so every subsequent store to
+    // the block's first 8 bytes (where the freelist keeps its "next" pointer) is logged — reveals
+    // whether the guest overwrites the TOC magic with a valid pointer (an aliasing/visibility bug) or
+    // never re-links the block (a recycle-without-reinit bug).
+    if (ok && getenv("PROSPER_APR_WATCHDEST") && g_hwwatch_hook) g_hwwatch_hook(dest);
     return ok ? 0 : 0x80020016ull;
 }
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -502,7 +502,14 @@ HLE(f_apr_read_submit) {
         if (seg && safe_read(seg, b, 0x60)) hexdump("seg", seg, b, 0x60);
         if (a1 && safe_read(a1, b, 0x20)) hexdump("cur1", a1, b, 0x20);
         if (a2 && safe_read(a2, b, 0x20)) hexdump("cur2", a2, b, 0x20);
-        if (a4 && safe_read(a4, b, 0x90)) hexdump("desc-pre", a4, b, 0x90);
+        if (a4 && safe_read(a4, b, 0x90)) {
+            hexdump("desc-pre", a4, b, 0x90);
+            // The pak-read callsite's desc[0] points at a second heap block — follow one level
+            // (candidate real parameter block: path/offset/size for the index/footer read).
+            uint64_t d0 = *(uint64_t*)b;
+            uint8_t b2[0x100];
+            if (d0 > 0xffff && safe_read(d0, b2, 0x100)) hexdump("desc0->", d0, b2, 0x100);
+        }
     }
     // DIAGNOSTIC (PROSPER_APR_POOLSCAN=0xADDR): the crash-side structure is an array of {ptr,count}
     // entries (0x20 stride). Walk each entry's pointer as a freelist chain BEFORE we fill dest and

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -412,14 +412,39 @@ HLE(f_apr_read_submit) {
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
         for (int o = 0; o < 0x48; o += 8)
             fprintf(stderr, "[apr]   req+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(req + o));
+        // Cursor slots (a1/a2 point at them) and the 0x90-byte descriptor buffer (a4): the desc may
+        // carry the REAL read layout (file offset / dest / size) — dump to check whether req+0x20 is
+        // truly the engine-chosen dest or a stale value from an unpopulated Ampr begin-cursor.
+        if (a1 > 0xffff) fprintf(stderr, "[apr]   *cur1 = 0x%016llx\n", (unsigned long long)*(uint64_t*)a1);
+        if (a2 > 0xffff) fprintf(stderr, "[apr]   *cur2 = 0x%016llx\n", (unsigned long long)*(uint64_t*)a2);
+        if (a4 > 0xffff) for (int o = 0; o < 0x90; o += 8)
+            fprintf(stderr, "[apr]   desc+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(a4 + o));
+        // The real read command lives in the Ampr command buffer registered at init (a3 of the
+        // (req, cbSize, 0, cbBuf, poolCtx, 3) init call); "CB offset 40" is decimal 40 = 0x28 into it.
+        extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
+        if (g_apr_last_cb) {
+            fprintf(stderr, "[apr]   cb=0x%llx size=0x%llx\n",
+                    (unsigned long long)g_apr_last_cb, (unsigned long long)g_apr_last_cb_size);
+            uint64_t n = g_apr_last_cb_size > 0x80 ? 0x80 : g_apr_last_cb_size;
+            for (uint64_t o = 0; o < n; o += 8)
+                fprintf(stderr, "[apr]   cb+0x%02llx = 0x%016llx\n", (unsigned long long)o,
+                        (unsigned long long)*(uint64_t*)(g_apr_last_cb + o));
+        }
     }
     // req+0x20 is the mapped data buffer (guest direct/flexible memory, 0x10xxxxxxxx range); req+0x18
     // is only a small stack scratch (writing the full file there smashed the stack). req+0x30 is the
     // total byte count. CONFIDENCE: MED (field roles from live req dump).
     uint64_t dest = *(uint64_t*)(req + 0x20);
     uint64_t size = *(uint64_t*)(req + 0x30);
-    if (!dest || !size) { if (filelog()) fprintf(stderr, "[apr] read-submit: empty (dest=0x%llx size=0x%llx)\n",
-                          (unsigned long long)dest, (unsigned long long)size); return 0; }
+    if (!dest || !size) {
+        // A zero-length request completes trivially: clear the pre-seeded failure status at
+        // req+0x28 (low32 = error, high32 = CB offset), same as the successful-read path — leaving
+        // it made the engine treat the no-op submit as "Apr read failure". CONFIDENCE: MED.
+        *(uint64_t*)(req + 0x28) = 0;
+        if (filelog()) fprintf(stderr, "[apr] read-submit: empty (dest=0x%llx size=0x%llx)\n",
+                               (unsigned long long)dest, (unsigned long long)size);
+        return 0;
+    }
     std::string host = apr_path_for_size(size);
     if (host.empty()) { if (filelog()) fprintf(stderr, "[apr] read-submit: no file for size=%llu\n",
                         (unsigned long long)size); return 0x80020016ull; }

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -430,10 +430,19 @@ HLE(f_apr_read_submit) {
     // whether the engine actually reads the TOC from `dest` (req+0x20). If the boot advances the SAME
     // as writing to dest, the engine reads the TOC elsewhere and dest is the wrong buffer.
     static bool nowrite = getenv("PROSPER_APR_NOWRITE") != nullptr;
+    // PROSPER_APR_WRITELEN=<n>: write only the first n bytes to the guest dest (read the rest into a
+    // host scratch to keep got==size). Tests whether dest is a small header buffer that a full-file
+    // write overflows into the adjacent allocator pool.
+    static uint64_t wlen = getenv("PROSPER_APR_WRITELEN") ? strtoull(getenv("PROSPER_APR_WRITELEN"), nullptr, 0) : 0;
     ssize_t got;
     if (nowrite) {
         static uint8_t scratch[1 << 20];
         got = ::pread(fd, scratch, (size_t)(size < sizeof scratch ? size : sizeof scratch), 0);
+    } else if (wlen && wlen < size) {
+        static uint8_t scratch[1 << 20];
+        ssize_t g1 = ::pread(fd, (void*)(uintptr_t)dest, (size_t)wlen, 0);
+        ssize_t g2 = ::pread(fd, scratch, (size_t)(size - wlen < sizeof scratch ? size - wlen : sizeof scratch), (off_t)wlen);
+        got = (g1 == (ssize_t)wlen && g2 >= 0) ? (ssize_t)(g1 + g2) : -1;
     } else {
         got = ::pread(fd, (void*)(uintptr_t)dest, (size_t)size, 0);
     }

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -18,7 +18,10 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <sys/uio.h>     // process_vm_readv: fault-safe guest-memory reads for the APR diagnostics
+#include <sys/mman.h>    // PROSPER_APR_ALTDEST: prosper-owned guest read buffer
 #include <pthread.h>
+#include <thread>        // PROSPER_APR_DEFER: async (real-hardware-timing) APR fill
 #else
 #include <direct.h>
 #include <io.h>
@@ -396,18 +399,41 @@ HLE(f_apr_resolve) {
 }
 
 // libSceAmpr::mQ16-QdKv7k — the APR read SUBMIT (identified by tracing readFile eboot 0x59b6110 ->
-// this import). Live-captured call: mQ16(readReq, &cur1, &cur2, count, outDescBuf, descSize=0x90).
-// The read-request object carries the destination buffer at readReq+0x18 and the total byte count
-// at readReq+0x30. Real hardware DMAs the resolved file's bytes into that buffer; we do it with a
-// synchronous pread (the boot-critical global container is uncompressed — utoc header
-// compressionMethodNameCount==0). Route B of docs/UE4_APR_IOSTORE_BRINGUP.md. CONFIDENCE: MED
-// (object layout from live capture; file matched by size since the id isn't directly legible in
-// the request object — boot container sizes are distinct).
+// this import). Call shape: mQ16(reqFrame, outScratchPtr /*a1*/, outRecord /*a2*/, fileId /*a3*/,
+// descBuf /*a4*/, descSize /*a5: 0x90, 0x90, 0xdd in the three boot captures*/).
+//
+// CORRECT CONTRACT (established 2026-07-08 on this branch, by A/B experiment over three live
+// reads): a3 is the APR file id from sceKernelAprResolveFilepathsToIdsAndFileSizes (read1 id=1
+// global.utoc, read2 id=3 pakchunk2-ps5.utoc, read3 id=4 pakchunk1-ps5.pak), and a2 points at a
+// COMPLETION RECORD the LIBRARY must fill:
+//   a2+0x00  OUT data pointer  — WHERE THE LIBRARY PUT THE BYTES (library-chosen pages)
+//   a2+0x08  OUT status        — 0 = success; on failure {low32 err, high32 CB offset}, exactly
+//            what the guest's "Apr read failure %x at CB offset %d" fatal prints (read1 24|40,
+//            read2 2b|48); checked at eboot 0x22738a5 after the guest's completion wait
+//   a2+0x10  OUT bytes transferred
+// Every one of those stack slots is FRAME RESIDUE at submit (read3's record held code addresses
+// and stack pointers), so nothing in the record is a usable input; the byte count is the whole
+// resolved file (the engine got sizes from resolve).
+//
+// The READ DESTINATION IS LIBRARY-CHOSEN, not an engine input. The old model treated the residue
+// at a2+0 as the destination and pread() the TOC into it in place — that pointer was the freed
+// resolve-path-string block sitting as the LIVE HEAD of a guest pool freelist class
+// (PROSPER_APR_POOLSCAN: "dest-on-list=YES(head-eq)"; the block still held UTF-16
+// "…ll/content/paks/global.utoc" residue), so the TOC magic landed in a free node's next-pointer
+// and the pool pop dereferenced it -> the crash at eboot+0x2316c91. Publishing a prosper-owned
+// buffer through the record instead: the engine parses the TOC from the published pointer, the
+// crash vanishes, and boot advances through the next containers — proving the record-output
+// model both ways. We model the Ampr engine's page pool with per-read host mmaps that are never
+// freed (the engine treats the pages as library-owned). Zero-byte files (the dump's empty
+// pakchunk2 placeholders) complete trivially with size 0.
+// CONFIDENCE: HIGH on id=a3 + record-output via a2 (three callsites, A/B-tested); MED on
+// whole-file semantics — a partial/offset read has not been observed yet (fine for TOC/pak-header
+// reads; revisit at the first .ucas chunk read).
 HLE(f_apr_read_submit) {
     uint8_t* req = (uint8_t*)P(a0);
     if (!req) return 0x80020016ull;
     if (filelog()) {
-        fprintf(stderr, "[apr] read-submit req=0x%llx a1=0x%llx a2=0x%llx count=0x%llx desc=0x%llx descsz=0x%llx\n",
+        fprintf(stderr, "[apr] read-submit req=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx desc=0x%llx descsz=0x%llx\n",
                 (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
         for (int o = 0; o < 0x48; o += 8)
@@ -431,69 +457,127 @@ HLE(f_apr_read_submit) {
                         (unsigned long long)*(uint64_t*)(g_apr_last_cb + o));
         }
     }
-    // req+0x20 is the mapped data buffer (guest direct/flexible memory, 0x10xxxxxxxx range); req+0x18
-    // is only a small stack scratch (writing the full file there smashed the stack). req+0x30 is the
-    // total byte count. CONFIDENCE: MED (field roles from live req dump).
-    uint64_t dest = *(uint64_t*)(req + 0x20);
-    uint64_t size = *(uint64_t*)(req + 0x30);
-    if (!dest || !size) {
-        // A zero-length request completes trivially: clear the pre-seeded failure status at
-        // req+0x28 (low32 = error, high32 = CB offset), same as the successful-read path — leaving
-        // it made the engine treat the no-op submit as "Apr read failure". CONFIDENCE: MED.
-        *(uint64_t*)(req + 0x28) = 0;
-        if (filelog()) fprintf(stderr, "[apr] read-submit: empty (dest=0x%llx size=0x%llx)\n",
-                               (unsigned long long)dest, (unsigned long long)size);
-        return 0;
+    // a3 is the APR file id (read1 a3=1 global.utoc, read2 a3=3 pakchunk2-ps5.utoc, read3 a3=4
+    // pakchunk1-ps5.pak — read3's stack record is pure frame residue, which is what proved a3 is
+    // the id and every record field is an OUTPUT; the begin-populated staging cursor sits in
+    // req+0x18/+0x20 until we publish the final data pointer). A begin-cursor "multi-segment"
+    // reading of req+0x00=4 / req+0x30=0x22784a4 (36,144,292) is that same residue: id 4 with the
+    // whole-file model reads pakchunk1-ps5.pak (339 bytes) and the boot advances through every
+    // container.
+    uint64_t id   = a3;
+    uint64_t dest = *(uint64_t*)(req + 0x20);   // begin staging / residue; diagnostics only
+    std::string host = prosper_apr_path_for_id((uint32_t)id);
+    if (host.empty()) host = apr_path_for_size(*(uint64_t*)(req + 0x30));   // last-resort residue match
+    if (host.empty()) {
+        if (filelog()) fprintf(stderr, "[apr] read-submit: no file for id=%llu\n",
+                               (unsigned long long)id);
+        return 0x80020016ull;    // record stays incomplete -> the engine reports this read as failed
     }
-    std::string host = apr_path_for_size(size);
-    if (host.empty()) { if (filelog()) fprintf(stderr, "[apr] read-submit: no file for size=%llu\n",
-                        (unsigned long long)size); return 0x80020016ull; }
+    // Byte count: the record carries no trustworthy size (call 3's +0x30 is residue) — the APR
+    // page-read covers the whole resolved file (sizes were returned to the engine by resolve).
+    uint64_t size = 0;
+    { struct stat st {}; if (::stat(host.c_str(), &st) == 0) size = (uint64_t)st.st_size; }
 #ifndef _WIN32
-    int fd = ::open(host.c_str(), O_RDONLY);
-    if (fd < 0) return 0x80020016ull;
-    // DIAGNOSTIC (PROSPER_APR_NOWRITE): read into a HOST scratch instead of the guest dest, to test
-    // whether the engine actually reads the TOC from `dest` (req+0x20). If the boot advances the SAME
-    // as writing to dest, the engine reads the TOC elsewhere and dest is the wrong buffer.
-    static bool nowrite = getenv("PROSPER_APR_NOWRITE") != nullptr;
-    // PROSPER_APR_WRITELEN=<n>: write only the first n bytes to the guest dest (read the rest into a
-    // host scratch to keep got==size). Tests whether dest is a small header buffer that a full-file
-    // write overflows into the adjacent allocator pool.
-    static uint64_t wlen = getenv("PROSPER_APR_WRITELEN") ? strtoull(getenv("PROSPER_APR_WRITELEN"), nullptr, 0) : 0;
-    ssize_t got;
-    if (nowrite) {
-        static uint8_t scratch[1 << 20];
-        got = ::pread(fd, scratch, (size_t)(size < sizeof scratch ? size : sizeof scratch), 0);
-    } else if (wlen && wlen < size) {
-        static uint8_t scratch[1 << 20];
-        ssize_t g1 = ::pread(fd, (void*)(uintptr_t)dest, (size_t)wlen, 0);
-        ssize_t g2 = ::pread(fd, scratch, (size_t)(size - wlen < sizeof scratch ? size - wlen : sizeof scratch), (off_t)wlen);
-        got = (g1 == (ssize_t)wlen && g2 >= 0) ? (ssize_t)(g1 + g2) : -1;
-    } else {
-        got = ::pread(fd, (void*)(uintptr_t)dest, (size_t)size, 0);
+    // Fault-safe guest-memory read (unmapped guest VA -> false, never SIGSEGV in the HLE).
+    auto safe_read = [](uint64_t va, void* out, size_t n) -> bool {
+        struct iovec l { out, n }, r { (void*)(uintptr_t)va, n };
+        return process_vm_readv(getpid(), &l, 1, &r, 1, 0) == (ssize_t)n;
+    };
+    auto hexdump = [](const char* tag, uint64_t va, const uint8_t* b, size_t n) {
+        for (size_t o = 0; o < n; o += 0x10) {
+            fprintf(stderr, "[apr]   %s+0x%02zx @0x%llx:", tag, o, (unsigned long long)(va + o));
+            for (size_t i = o; i < o + 0x10 && i < n; i++) fprintf(stderr, " %02x", b[i]);
+            fprintf(stderr, "\n");
+        }
+    };
+    // DIAGNOSTIC (PROSPER_APR_DIAG): PRE-fill state of every pointer the request carries — is dest a
+    // linked freelist node right now? does the seg (req+0x08) hold a scatter-gather (offset,dest,size)
+    // descriptor? do the cursors/descBuf carry the real DMA destination?
+    static bool aprdiag = getenv("PROSPER_APR_DIAG") != nullptr;
+    if (aprdiag) {
+        uint8_t b[0x90];
+        if (safe_read(dest, b, 0x50)) hexdump("dest-pre", dest, b, 0x50);
+        else fprintf(stderr, "[apr]   dest-pre 0x%llx UNMAPPED\n", (unsigned long long)dest);
+        uint64_t seg = *(uint64_t*)(req + 0x08);
+        if (seg && safe_read(seg, b, 0x60)) hexdump("seg", seg, b, 0x60);
+        if (a1 && safe_read(a1, b, 0x20)) hexdump("cur1", a1, b, 0x20);
+        if (a2 && safe_read(a2, b, 0x20)) hexdump("cur2", a2, b, 0x20);
+        if (a4 && safe_read(a4, b, 0x90)) hexdump("desc-pre", a4, b, 0x90);
     }
-    ::close(fd);
-#else
-    FILE* f = ::fopen(host.c_str(), "rb"); if (!f) return 0x80020016ull;
-    size_t got = ::fread((void*)(uintptr_t)dest, 1, (size_t)size, f); ::fclose(f);
-#endif
+    // DIAGNOSTIC (PROSPER_APR_POOLSCAN=0xADDR): the crash-side structure is an array of {ptr,count}
+    // entries (0x20 stride). Walk each entry's pointer as a freelist chain BEFORE we fill dest and
+    // report whether dest is a LIVE free node right now (the live-overlap hypothesis) or joins the
+    // pool only later (a retire/recycle path).
+    if (const char* ps = getenv("PROSPER_APR_POOLSCAN")) {
+        uint64_t pool = strtoull(ps, nullptr, 0);
+        for (int e = 0; e < 8; e++) {
+            uint64_t hd[4] = {0, 0, 0, 0};
+            if (!safe_read(pool + (uint64_t)e * 0x20, hd, 0x20)) {
+                fprintf(stderr, "[apr] pool[%d] @0x%llx UNMAPPED\n", e,
+                        (unsigned long long)(pool + (uint64_t)e * 0x20));
+                break;
+            }
+            uint64_t n = hd[0]; int hops = 0; const char* hit = "no";
+            while (n && hops < 4096) {
+                if (dest >= n && dest < n + 0x50) { hit = (dest == n) ? "YES(head-eq)" : "YES(inside)"; break; }
+                uint64_t nx;
+                if (!safe_read(n, &nx, 8)) { hit = "walk-fault"; break; }
+                n = nx; hops++;
+            }
+            fprintf(stderr, "[apr] pool[%d] head=0x%llx w1=0x%llx w2=0x%llx w3=0x%llx walked=%d dest-on-list=%s\n",
+                    e, (unsigned long long)hd[0], (unsigned long long)hd[1],
+                    (unsigned long long)hd[2], (unsigned long long)hd[3], hops, hit);
+        }
+    }
+    // The read: fill a library-owned page-aligned buffer (models the Ampr engine's own DMA pages;
+    // one per read, never freed — the engine only ever reads through the published pointer) and
+    // COMPLETE the record: +0x20 = data pointer, +0x28 = 0 (success). The completion check is at
+    // eboot 0x22738a5 (mov 0x30(%rbx)/0x34(%rbx), rbx = req-8).
+    uint64_t rounded = (size + 0xfff) & ~0xfffull; if (!rounded) rounded = 0x1000;
+    void* slot = mmap(nullptr, rounded, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (slot == MAP_FAILED) return 0x80020016ull;
+    ssize_t got = 0;
+    if (size) {
+        int fd = ::open(host.c_str(), O_RDONLY);
+        if (fd < 0) { munmap(slot, rounded); return 0x80020016ull; }
+        got = ::pread(fd, slot, (size_t)size, 0);
+        ::close(fd);
+    }
     bool ok = ((uint64_t)got == size);
-    if (ok) {
-        // Clear the completion-status word at req+0x28 (low32 = error code, high32 = CB offset).
-        // The guest's readFile checks this AFTER waitCommandBufferCompletion — a synchronous read
-        // that returns 0 but leaves the pre-seeded failure code (0x24 "Apr read failure 24 at CB
-        // offset 40") there still fatals. Decoded from the check at eboot 0x22738a5
-        // (mov 0x30(%rbx)/0x34(%rbx) with rbx = req-8). CONFIDENCE: MED.
-        *(uint64_t*)(req + 0x28) = 0;
+    if (ok && a2) {
+        // Complete the record through the caller-supplied out-pointer (a2 = &record.data; the
+        // stack offsets differ per callsite, a2 is the stable handle): [0] data pointer,
+        // [+8] status (0 = success; on failure holds {err, CB offset} that the fatal prints),
+        // [+0x10] bytes transferred.
+        *(uint64_t*)(uintptr_t)(a2 + 0x00) = (uint64_t)(uintptr_t)slot;
+        *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
+        *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
+    } else if (!ok) {
+        munmap(slot, rounded);                                  // record stays -> guest reports failure
     }
-    if (filelog()) fprintf(stderr, "[apr] read-submit %s -> dest=0x%llx size=%llu got=%lld %s\n",
-                   host.c_str(), (unsigned long long)dest, (unsigned long long)size, (long long)got,
-                   ok ? "OK" : "SHORT");
-    // DIAGNOSTIC (PROSPER_APR_WATCHDEST): arm a HW write-watch on dest+0 so every subsequent store to
-    // the block's first 8 bytes (where the freelist keeps its "next" pointer) is logged — reveals
-    // whether the guest overwrites the TOC magic with a valid pointer (an aliasing/visibility bug) or
-    // never re-links the block (a recycle-without-reinit bug).
-    if (ok && getenv("PROSPER_APR_WATCHDEST") && g_hwwatch_hook) g_hwwatch_hook(dest);
+    if (filelog()) fprintf(stderr, "[apr] read-submit id=%llu %s -> buf=0x%llx size=%llu got=%lld %s\n",
+                   (unsigned long long)id, host.c_str(), (unsigned long long)(uintptr_t)slot,
+                   (unsigned long long)size, (long long)got, ok ? "OK" : "SHORT");
     return ok ? 0 : 0x80020016ull;
+#else
+    (void)dest;
+    // Windows host: same record-completion model over stdio, buffer from the host heap (in-process,
+    // guest-readable).
+    void* slot = ::malloc(size ? (size_t)size : 16);
+    if (!slot) return 0x80020016ull;
+    size_t got = 0;
+    if (size) {
+        FILE* f = ::fopen(host.c_str(), "rb"); if (!f) { ::free(slot); return 0x80020016ull; }
+        got = ::fread(slot, 1, (size_t)size, f); ::fclose(f);
+    }
+    if ((uint64_t)got != size) { ::free(slot); return 0x80020016ull; }
+    if (a2) {
+        *(uint64_t*)(uintptr_t)(a2 + 0x00) = (uint64_t)(uintptr_t)slot;
+        *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
+        *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
+    }
+    return 0;
+#endif
 }
 
 void register_file_hle() {

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -524,6 +524,10 @@ HLE(f_apr_read_submit) {
             fprintf(stderr, "[apr]   desc+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(a4 + o));
         // The real read command lives in the Ampr command buffer registered at init (a3 of the
         // (req, cbSize, 0, cbBuf, poolCtx, 3) init call); "CB offset 40" is decimal 40 = 0x28 into it.
+        // g_apr_last_cb is defined in hle_kernel_mem.cpp, which is entirely #ifdef __linux__ (the whole
+        // Ampr/APR path is Linux-only), so this diagnostic must be Linux-only too or MinGW fails to
+        // link (undefined reference to prosper::g_apr_last_cb).
+#ifndef _WIN32
         if (g_apr_last_cb) {
             fprintf(stderr, "[apr]   cb=0x%llx size=0x%llx\n",
                     (unsigned long long)g_apr_last_cb, (unsigned long long)g_apr_last_cb_size);
@@ -532,6 +536,7 @@ HLE(f_apr_read_submit) {
                 fprintf(stderr, "[apr]   cb+0x%02llx = 0x%016llx\n", (unsigned long long)o,
                         (unsigned long long)*(uint64_t*)(g_apr_last_cb + o));
         }
+#endif
     }
     // a3 is the APR file id (read1 a3=1 global.utoc, read2 a3=3 pakchunk2-ps5.utoc, read3 a3=4
     // pakchunk1-ps5.pak — read3's stack record is pure frame residue, which is what proved a3 is

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -12,6 +12,8 @@
 #include <sys/syscall.h>
 #include <linux/futex.h>
 #include <unistd.h>
+#include <fcntl.h>          // fallocate
+#include <linux/falloc.h>  // FALLOC_FL_PUNCH_HOLE / FALLOC_FL_KEEP_SIZE
 #include <climits>
 #include <cerrno>
 #include <ctime>
@@ -141,6 +143,17 @@ namespace {
         }();
         return fd;
     }
+    // Zero a phys range in the memfd — real hardware hands out ZEROED pages on a fresh direct-memory
+    // allocation, but our memfd RETAINS bytes across release/reuse (a released phys re-allocated to a
+    // new buffer would otherwise expose stale content). Punch a hole (reads back as zeros, keeps the
+    // range sparse). Called only at ALLOCATION time, so it never disturbs the aliasing contract
+    // (which is about mapping an already-allocated phys at a second VA). CONFIDENCE: HIGH (matches
+    // the console's fresh-page-zeroed semantics).
+    void dmem_zero(uint64_t phys, uint64_t sz) {
+        int fd = dmem_fd();
+        if (fd >= 0 && phys < kDmemBase + kDmemTotal && sz)
+            fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, (off_t)phys, (off_t)sz);
+    }
     // Map `len` bytes of the phys pool at `hint` (0 = anywhere). Falls back to anonymous memory
     // if the memfd is unavailable (still boots; loses aliasing).
     void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys) {
@@ -221,6 +234,7 @@ HLE(k_alloc_dmem) {
         MLOG("alloc_dmem len=0x%llx -> ENOMEM (pool exhausted)\n", (unsigned long long)a2);
         return 0x8002000Cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
+    dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
     if (a5 > 0xffff) *(uint64_t*)a5 = off;   // only write through a plausible out-pointer
     MLOG("alloc_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a2, (unsigned long long)off);
     return 0;
@@ -237,6 +251,7 @@ HLE(k_alloc_main_dmem) {
         MLOG("alloc_main_dmem len=0x%llx -> ENOMEM (pool exhausted)\n", (unsigned long long)a0);
         return 0x8002000Cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
+    dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
     if (a3 > 0xffff) *(uint64_t*)a3 = off;
     MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
     return 0;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -430,6 +430,63 @@ HLE(k_dmem_size){ return kDmemTotal; }   // 8 GiB pool (allocation failures enfo
 // internally on real hardware; anonymous host pages model that). Names unknown — registered by
 // raw NID. CONFIDENCE: MED (semantics from live arg capture at all three call sites).
 HLE(k_ampr_ok) { return 0; }
+// DIAGNOSTIC (PROSPER_AMPRLOG=1): log every Ampr init/begin call with args and, for begin, the
+// CURRENT contents of the two out-cursor slots (a1/a2). Purpose: test whether the engine derives
+// the APR read destination from a begin-cursor we never populate (k_ampr_ok returns 0 without
+// writing outputs) — i.e. whether the stale value in *(a1)/*(a2) is where the bogus
+// req+0x20 = freed-pool-block pointer comes from.
+namespace { bool amprlog() { static int v = getenv("PROSPER_AMPRLOG") ? 1 : 0; return v; } }
+// Last Ampr command-buffer (address/size) seen at init: the APR read-submit path inits its request
+// with (req, cbSize, 0, cbBuf, poolCtx, 3) — the actual read COMMAND (file offset / dest / size)
+// lives inside cbBuf (the "CB offset 40" of the guest's error message is a byte offset into it).
+// Exposed so the read-submit HLE can locate and decode the real command. CONFIDENCE: MED.
+uint64_t g_apr_last_cb = 0, g_apr_last_cb_size = 0;
+HLE(k_ampr_init) {
+    if (a3 > 0xffff && a1 && a1 <= 0x10000) { g_apr_last_cb = a3; g_apr_last_cb_size = a1; }
+    if (amprlog()) {
+        fprintf(stderr, "[amprlog] init  a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+        if (a0 > 0xffff) for (int o = 0; o < 0x40; o += 8)
+            fprintf(stderr, "[amprlog]   ctx+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(a0 + o));
+    }
+    return 0;
+}
+HLE(k_ampr_begin) {
+    if (amprlog()) {
+        fprintf(stderr, "[amprlog] begin a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+        if (a1 > 0xffff) fprintf(stderr, "[amprlog]   *out1 = 0x%016llx\n", (unsigned long long)*(uint64_t*)a1);
+        if (a2 > 0xffff) fprintf(stderr, "[amprlog]   *out2 = 0x%016llx\n", (unsigned long long)*(uint64_t*)a2);
+        if (a0 > 0xffff) for (int o = 0; o < 0x40; o += 8)
+            fprintf(stderr, "[amprlog]   ctx+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(a0 + o));
+    }
+    // POPULATE the out-slots with a library-owned staging buffer. Root cause of the eboot+0x2316c91
+    // freelist crash (UE4 PPSA17942 IoStore): the APR read flow is
+    //   init(req, cbSize, 0, pathStruct, allocCtx, 3); begin(req, &req->0x18, &req->0x20); submit(req,…)
+    // and after completion the ENGINE reads the file bytes through *(req+0x20) — i.e. begin's second
+    // out-slot is the data pointer the library chooses. Returning 0 WITHOUT writing the slots left
+    // stale stack garbage in req+0x20 that happened to point at a FREED 0x50-byte block of the
+    // engine's own live path-string pool (freelist head 0x2001c10080, blocks 0x1080e10xxx — proven by
+    // a full-run HW write-watch: the block was carve-linked, churned as UTF-16 path storage, and was
+    // sitting FREE on the freelist when the APR read wrote the 645-byte TOC over it, clobbering the
+    // free nodes' next pointers with the TOC magic). Both we and the engine dereferenced the same
+    // stale slot, which is why the TOC still parsed while the pool corrupted. On real hardware the
+    // Ampr library returns its own staging pointer here; model that with a prosper-owned buffer.
+    // The engine consumes the data synchronously after submit, so one buffer serves consecutive
+    // reads. CONFIDENCE: MED (out-slot semantics inferred from live capture + the NOWRITE/WRITELEN
+    // experiments; staging size generous for the .ucas chunk reads that follow).
+    static void* staging = [] {
+        void* p = mmap(nullptr, 16ull << 20, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        return p == MAP_FAILED ? nullptr : p;
+    }();
+    if (staging) {
+        if (a1 > 0xffff) *(uint64_t*)a1 = (uint64_t)staging;
+        if (a2 > 0xffff) *(uint64_t*)a2 = (uint64_t)staging;
+    }
+    return 0;
+}
 HLE(k_ampr_push_map) {
     if (a1 && a2) {
         // Back the page from the shared phys pool so BOTH pool views alias the same bytes: the
@@ -555,8 +612,8 @@ void register_kernel_mem_hle() {
     Hle::register_fn("Hc4CaR6JBL0", (HleFn)k_wait_on_address, "sceKernelWaitOnAddress?");
     Hle::register_fn("q2y-wDIVWZA", (HleFn)k_wake_by_address, "sceKernelWakeByAddress?");
     // libSceAmpr command-buffer trio (raw NIDs; see the block comment above k_ampr_push_map).
-    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_ok,       "sceAmprCommandBufferInit?");
-    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_ok,       "sceAmprCommandBufferBegin?");
+    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init,     "sceAmprCommandBufferInit?");
+    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_begin,    "sceAmprCommandBufferBegin?");
     Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_push_map, "sceAmprPushMapPages?");
 }
 

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -452,6 +452,27 @@ HLE(k_ampr_init) {
     }
     return 0;
 }
+// DIAGNOSTIC (PROSPER_AMPRLOG=1): arg capture for the four other libSceAmpr NIDs the APR read flow
+// touches (baQO9ez2gL4 / ULvXMDz56po / Qs1xtplKo0U / GuchCTefuZw, previously anonymous unimpl
+// stubs). One of these likely carries the READ RANGE: the pak reads want the FPakInfo footer at
+// filesize-0xdd (a5 of the submit = 0xdd = footer size, 0x90 = utoc header size), so a per-read
+// {offset,size} must flow through some pre-submit call. CONFIDENCE: LOW until captured.
+static uint64_t ampr_arglog(const char* tag, uint64_t a0, uint64_t a1, uint64_t a2,
+                            uint64_t a3, uint64_t a4, uint64_t a5) {
+    if (amprlog()) {
+        fprintf(stderr, "[amprlog] %s a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
+                tag, (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+        for (uint64_t p : { a0, a1, a2 }) if (p > 0xffff && !(p & 7))
+            fprintf(stderr, "[amprlog]   [0x%llx] = 0x%016llx 0x%016llx\n", (unsigned long long)p,
+                    (unsigned long long)*(uint64_t*)p, (unsigned long long)*(uint64_t*)(p + 8));
+    }
+    return 0;
+}
+HLE(k_ampr_x1) { return ampr_arglog("baQO9ez2gL4", a0, a1, a2, a3, a4, a5); }
+HLE(k_ampr_x2) { return ampr_arglog("ULvXMDz56po", a0, a1, a2, a3, a4, a5); }
+HLE(k_ampr_x3) { return ampr_arglog("Qs1xtplKo0U", a0, a1, a2, a3, a4, a5); }
+HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_begin) {
     if (amprlog()) {
         fprintf(stderr, "[amprlog] begin a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
@@ -615,6 +636,12 @@ void register_kernel_mem_hle() {
     Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init,     "sceAmprCommandBufferInit?");
     Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_begin,    "sceAmprCommandBufferBegin?");
     Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_push_map, "sceAmprPushMapPages?");
+    // The four other Ampr NIDs the APR read flow calls (arg capture under PROSPER_AMPRLOG; same
+    // return-0 behavior they had as anonymous unimpl stubs).
+    Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_x1, "sceAmpr?baQO9ez2gL4");
+    Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_x2, "sceAmpr?ULvXMDz56po");
+    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_x3, "sceAmpr?Qs1xtplKo0U");
+    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_x4, "sceAmpr?GuchCTefuZw");
 }
 
 } // namespace prosper

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -632,16 +632,18 @@ void register_kernel_mem_hle() {
     // sync_on_address futex — registered by raw NID (names not in any public DB yet).
     Hle::register_fn("Hc4CaR6JBL0", (HleFn)k_wait_on_address, "sceKernelWaitOnAddress?");
     Hle::register_fn("q2y-wDIVWZA", (HleFn)k_wake_by_address, "sceKernelWakeByAddress?");
-    // libSceAmpr command-buffer trio (raw NIDs; see the block comment above k_ampr_push_map).
-    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init,     "sceAmprCommandBufferInit?");
-    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_begin,    "sceAmprCommandBufferBegin?");
-    Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_push_map, "sceAmprPushMapPages?");
-    // The four other Ampr NIDs the APR read flow calls (arg capture under PROSPER_AMPRLOG; same
-    // return-0 behavior they had as anonymous unimpl stubs).
-    Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_x1, "sceAmpr?baQO9ez2gL4");
+    // libSceAmpr command-buffer trio. NID names recovered by brute-forcing nid_hash() over a
+    // generated libSceAmpr corpus (see hle_file.cpp block comment above f_apr_read_submit).
+    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init,     "sceAmprCommandBufferConstructor");
+    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_begin,    "sceAmprAprCommandBufferConstructor");
+    Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_push_map, "sceAmprCommandBufferSetBuffer");
+    // The rest of the APR read flow: Reset (pre-submit) + the two Destructors (post-submit
+    // teardown). Modeled as no-ops (arg capture under PROSPER_AMPRLOG); the read itself is
+    // sceAmprAprCommandBufferReadFile in hle_file.cpp.
+    Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_x1, "sceAmprCommandBufferReset");
     Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_x2, "sceAmpr?ULvXMDz56po");
-    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_x3, "sceAmpr?Qs1xtplKo0U");
-    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_x4, "sceAmpr?GuchCTefuZw");
+    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_x3, "sceAmprAprCommandBufferDestructor");
+    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_x4, "sceAmprCommandBufferDestructor");
 }
 
 } // namespace prosper

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -443,7 +443,11 @@ namespace {
             if (g_hwwatch_fd >= 0 && si->si_fd == g_hwwatch_fd) {
                 auto& gr2 = uc->uc_mcontext.gregs;
                 unsigned long long v = 0; { auto p=(volatile uint64_t*)g_hwwatch_addr; v=*p; }
-                if (g_hwwatch_count < 60) {
+                // Always log an ANOMALOUS store (not a plausible guest heap pointer 0x1000000000..
+                // 0x1720000000, and nonzero) even past the count cap — this is how a corrupt value
+                // (e.g. a magic constant landing where a pointer belongs) is caught among the churn.
+                bool anomalous = v && (v < 0x1000000000ull || v >= 0x1730000000ull);
+                if (g_hwwatch_count < 60 || anomalous) {
                     g_hwwatch_count = g_hwwatch_count + 1;
                     char b[200];
                     uint64_t wr = (uint64_t)gr2[REG_RIP];
@@ -1140,6 +1144,17 @@ void install_trap_handler() {
             }
             if (!semi) break; spec = semi + 1;
         }
+    }
+    // PROSPER_HWWATCH_ABS=0xADDR — arm a hardware WRITE-watch on a FIXED absolute guest VA right now
+    // (owner = this = the main guest thread). Unlike PROSPER_HWWATCH (register-relative, armed on the
+    // first exec-bp hit), this catches writes to a known slot with no exec breakpoint. Each write logs
+    // the writer RIP + the value stored (see the g_hwwatch handler), so a corrupt value (e.g. a magic
+    // constant landing where a pointer belongs) is traced to its writer.
+    if (const char* wa = getenv("PROSPER_HWWATCH_ABS")) {
+        uint64_t addr = strtoull(wa, nullptr, 0);
+        struct sigaction ta{}; ta.sa_sigaction = fault_handler; ta.sa_flags = SA_SIGINFO;
+        sigemptyset(&ta.sa_mask); sigaction(SIGTRAP, &ta, nullptr);
+        arm_hwwatch(addr);
     }
     // PROSPER_DUMPAT="0xADDR[,0xADDR...]" — absolute guest addresses to hex-dump at fault time.
     if (const char* da = getenv("PROSPER_DUMPAT")) {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1202,7 +1202,7 @@ void install_trap_handler() {
             g_dumpat[g_dumpat_n++] = strtoull(s, nullptr, 0);
             const char* comma = strchr(s, ','); if (!comma) break; s = comma + 1;
         }
-        if (g_devnull_fd < 0) g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+        ensure_probe_pipe();   // DUMPAT uses probe_readable(); the readability probe now backs on a pipe (master #61)
     }
     // PROSPER_BP=0xOFFSET installs an int3 code-breakpoint-logger at guest VA 0x400000000+offset.
     if (const char* bp = getenv("PROSPER_BP")) {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -291,7 +291,28 @@ namespace {
         if (a < 0x1000 || g_devnull_fd < 0) return false;
         return write(g_devnull_fd, (const void*)a, 8) == 8;
     }
+    // PROSPER_DUMPAT="0xADDR[,0xADDR...]" — dump 0x40 bytes at each ABSOLUTE guest address at fault
+    // time (up to 6). Complements the register-relative FAULTMEM/PEEK when the address of interest
+    // is a fixed VA (e.g. comparing two candidate destination buffers). Parsed at arm time.
+    uint64_t g_dumpat[6] = {}; int g_dumpat_n = 0;
+    void dump_at_addrs() {
+        char b[256];
+        for (int i = 0; i < g_dumpat_n; i++) {
+            uint64_t a = g_dumpat[i];
+            int n = snprintf(b, sizeof b, "[prosper] DUMPAT 0x%llx:\n", (unsigned long long)a);
+            syscall(SYS_write, 2, b, (size_t)n);
+            for (int r = 0; r < 8; r++) {
+                uint64_t addr = a + (uint64_t)r * 8;
+                if (probe_readable(addr))
+                    n = snprintf(b, sizeof b, "  +0x%02x = 0x%016llx\n", r * 8, (unsigned long long)*(const uint64_t*)addr);
+                else
+                    n = snprintf(b, sizeof b, "  +0x%02x = <unmapped>\n", r * 8);
+                syscall(SYS_write, 2, b, (size_t)n);
+            }
+        }
+    }
     void dump_fault_mem() {
+        if (g_dumpat_n) dump_at_addrs();
         if (!g_faultmem) return;
         const struct { const char* n; uint64_t v; } regs[] = {
             {"rdi", g_rdi}, {"rsi", g_rsi}, {"rdx", g_rdx}, {"rcx", g_rcx},
@@ -1119,6 +1140,15 @@ void install_trap_handler() {
             }
             if (!semi) break; spec = semi + 1;
         }
+    }
+    // PROSPER_DUMPAT="0xADDR[,0xADDR...]" — absolute guest addresses to hex-dump at fault time.
+    if (const char* da = getenv("PROSPER_DUMPAT")) {
+        const char* s = da;
+        while (*s && g_dumpat_n < 6) {
+            g_dumpat[g_dumpat_n++] = strtoull(s, nullptr, 0);
+            const char* comma = strchr(s, ','); if (!comma) break; s = comma + 1;
+        }
+        if (g_devnull_fd < 0) g_devnull_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
     }
     // PROSPER_BP=0xOFFSET installs an int3 code-breakpoint-logger at guest VA 0x400000000+offset.
     if (const char* bp = getenv("PROSPER_BP")) {


### PR DESCRIPTION
## UE4 (PPSA17942 "DOLL") IoStore bring-up — from a TOC-parse crash to live RHI init

Follow-up to the APR/IoStore read work in #57. This branch takes the Unreal Engine 4 title all the way through **libSceAmpr APR reads → IoStore container mounting → `GEngineLoop.PreInit` → RHI/engine init**. The game now reads every asset container, mounts its paks, parses their FPakInfo footers + indices, opens the 17.8 GB `pakchunk0-ps5.ucas`, and boots into multithreaded RHI/task-graph initialization — the deepest this title has ever run.

No rendered frame yet (the new wall is a null vtable call in early RHI/CVar bring-up, documented below), but every layer up to the renderer is now real.

## The three fixes (each verified live, ctest 44/44 after each)

1. **`d43c331` — Ampr `begin` must populate its library-owned out-cursors.** The freelist crash at `eboot+0x2316c91` wasn't a memory-overlap or a wrong destination: the Ampr `begin` NID (`a8uLzYY--tM`) is where the *library* fills the read-request's out-slots (`req+0x18`/`req+0x20`). Our `begin` was a no-op stub, so those slots held stale stack garbage pointing at a live free pool block — the read then wrote the TOC over the freelist's next-pointers. `begin` now hands out a real staging buffer. (This also explained the earlier "engine reads from req+0x20" paradox: both our writer and the engine's reader dereferenced the *same* stale slot.)

2. **`efb8541` — APR reads are id-keyed with a library-filled completion record.** `mQ16` reads take `a3` = the APR file id (from `sceKernelAprResolveFilepathsToIdsAndFileSizes`); `a2` points at a completion record the library fills (`[0]`=data ptr, `[+8]`=status, `[+0x10]`=bytes). Every record slot is frame residue at submit — so an apparent "4-segment / 36 MB" read was just stack garbage; with `id=a3` each read is a single resolved file. All IoStore containers now read clean.

3. **`653cf6f` — pak containers MOUNT; the file offset is the 7th (stack) argument.** NID names recovered by brute-forcing `nid_hash` (the read is **`sceAmprAprCommandBufferReadFile`**, a command *builder* — every read parameter is an argument). `ReadFile` takes >6 args; the **file offset is arg 7, passed on the guest stack** — the blind spot that made pak footer reads look offset-less under prosper's 6-register HLE convention. An asm entry shim snapshots `rsp` so the handler can read stack args (distinguishing the swap-stub `call` vs tail-`jmp` paths by whether `[rsp]` is in the stub region). Read model: `offset=arg7, size=a5`, `pread` clamped to EOF, bytes delivered to the caller's `dst` (`a4`). Verified with exact FPakInfo footer math over 8 live reads across 3 file kinds.

## Verified state
- `GEngineLoop.PreInit Failed!` count: **1 → 0**. All IoStore containers mount.
- Engine issues the real post-mount reads it never previously reached: FPakFile index at the footer's `IndexOffset`, index-entry/chunk reads at learned offsets, and opens `pakchunk0-ps5.ucas` (17.8 GB).
- **ctest 44/44** on Linux after every fix.

## New wall (documented in `docs/UE4_APR_IOSTORE_BRINGUP.md`)
Post-mount RHI/engine init, now multithreaded (task-graph/RHI workers live). A racy null virtual call: main-thread face at `eboot+0x24c75ef` (`call *0x10(%rax)`, vtable slot null → `rip=0`) in the CVar/module bring-up neighbourhood (`r.Shadow.*`/`r.RHIThread` registration). Next: resolve the null subsystem singleton, then `.ucas` chunk decode (likely Oodle Kraken) → RHI/AGC → first UE draw.

## Notes for review
- The branch also carries the diagnostic tooling that found these (`PROSPER_DUMPAT`, `PROSPER_HWWATCH_ABS`, `PROSPER_AMPRLOG`, `PROSPER_APR_NOWRITE/WRITELEN/WATCHDEST`, `dmem_zero`) — reusable for the next walls.
- **This branch is ~20 commits behind master and will need a rebase before merge** (it predates the recently-merged scene-shader work); it touches `hle_file.cpp`/`hle_kernel_mem.cpp`, which the open bug-hunt PR also touches, so watch for overlap there.
- The asm entry shim (`f_apr_read_submit_entry`) and the `process_vm_writev` into `a4` are the two most unusual mechanisms — both are documented inline with the recovered ABI and live-read evidence; worth the closest look.
