### PR TITLE
fix(gpu): decode R_DRAW_INDEX so sceAgcDcbDrawIndex draws reach the draw list

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -118,17 +118,29 @@ void GpuState::apply(const Pm4Command& c) {
             index_type = c.index_size;
             state_dirty_ = true;
             break;
-        case K::DrawIndexAuto: {
+        case K::DrawIndexAuto:
+        case K::DrawIndex: {
             // Snapshot the register state AT THE DRAW (shared with consecutive draws until a register
             // write dirties it), so a future per-draw executor can render each draw under its own
             // shaders/mask/blend instead of the end-of-submit fold. Inert for the current renderer.
+            // The snapshot also carries index_type — the index element size a DrawIndex needs (#64).
             if (state_dirty_ || !last_snapshot_) {
                 auto snap = std::make_shared<GpuState>();
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
-            draws.push_back({ c.index_count, last_snapshot_ });
+            Draw d;
+            d.index_count = c.index_count;
+            d.state = last_snapshot_;
+            if (c.kind == K::DrawIndex) {
+                // Mark as indexed only when the packet was fully decoded — a short packet's addr/
+                // modifier would be fabricated zeros, and `indexed` promises index_addr is real.
+                d.indexed = c.di_valid;
+                d.index_addr = c.di_index_addr;
+                d.modifier = c.di_modifier;
+            }
+            draws.push_back(std::move(d));
             break;
         }
         case K::ReleaseMem:

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -31,8 +31,19 @@ struct GpuState {
     // states), and callers fall back to the folded end state. Foundational for a future multi-draw
     // executor (a reference consumer exists in the sibling PR #31); the default renderer still uses the
     // folded state, so this field is inert until that executor lands. (Snapshot infra ported from #31.)
-    struct Draw { uint32_t index_count; std::shared_ptr<const GpuState> state; };
-    std::vector<Draw> draws;                             // one per DrawIndexAuto
+    // Indexed draws (sceAgcDcbDrawIndex): `indexed` is set only when the packet carried the full
+    // operand set; `index_addr` is the guest address of the index buffer (1:1-mapped, so directly
+    // readable) and `modifier` the raw 64-bit draw-modifier bits. The index ELEMENT SIZE lives in the
+    // draw's register snapshot (`state->index_type`, from the preceding SetIndexType). The current
+    // executor does not consume the index buffer yet (renders these like DrawIndexAuto) — issue #64.
+    struct Draw {
+        uint32_t index_count;
+        std::shared_ptr<const GpuState> state;
+        bool     indexed = false;
+        uint64_t index_addr = 0;
+        uint64_t modifier = 0;
+    };
+    std::vector<Draw> draws;                             // one per DrawIndexAuto / DrawIndex
 
     // Safety cap on an indirect register count (a malformed/huge count won't run away).
     static constexpr uint32_t kMaxRegsPerPacket = 4096;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -128,6 +128,10 @@ inline bool realize_draw_item(const GpuState& ds, uint32_t vcount_hint, uint32_t
 // composite correctly — the path for multi-geometry scenes (opt-in until the AGC context-log section
 // semantics that stage duplicate register writes are fully RE'd; see docs/REAL_FRAMES_FINDINGS.md).
 // `max_shader_dwords` bounds the recompiler's walk (it stops at S_ENDPGM).
+// Indexed draws (Draw::indexed, from sceAgcDcbDrawIndex): the index buffer (Draw::index_addr +
+// the snapshot's index_type) is carried on the draw record but NOT consumed yet — these render
+// exactly like a DrawIndexAuto with the same count (the fan heuristic above included). Wiring the
+// index buffer into vertex fetch (and retiring the quad-fan hack) is issue #64.
 inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
                                              uint32_t max_shader_dwords = 0x10000) {
     if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -85,6 +85,14 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                         c.flip_valid  = true;
                     }
                     break;
+                case R_DRAW_INDEX:
+                    // payload: [0]=index_count, [1..2]=index-buffer addr lo/hi, [3..4]=64-bit draw
+                    // modifier lo/hi (see agc_dcb_draw_index + the ABI evidence in pm4_decode.hpp).
+                    c.kind = K::DrawIndex;
+                    if (npl >= 1) c.index_count = pl[0];
+                    if (npl >= 3) c.di_index_addr = lo_hi(pl + 1);
+                    if (npl >= 5) { c.di_modifier = lo_hi(pl + 3); c.di_valid = true; }
+                    break;
                 case R_DRAW_INDEX_AUTO:
                     c.kind = K::DrawIndexAuto;
                     if (npl >= 1) c.index_count = pl[0];

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -20,7 +20,7 @@ enum : uint32_t {
     IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46, IT_SET_SH_REG = 0x76,
 };
 enum : uint32_t {
-    R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
+    R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
     R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
     R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
     R_RELEASE_MEM = 0x18, R_NUM = 0x40,
@@ -35,7 +35,7 @@ enum class RegClass { Cx, Sh, Uc };
 struct Pm4Command {
     enum class Kind {
         DrawReset, WaitFlipDone, SetShRegDirect, SetRegsIndirect, SetIndexType,
-        DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem, Unknown,
+        DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem, Unknown,
     } kind = Kind::Unknown;
 
     uint32_t        header = 0;
@@ -46,8 +46,22 @@ struct Pm4Command {
     RegClass reg_class = RegClass::Cx;   // SetRegsIndirect
     uint32_t num_regs = 0;               // SetRegsIndirect
     uint64_t regs_vaddr = 0;             // SetRegsIndirect: guest addr of the register array
-    uint32_t index_count = 0;            // DrawIndexAuto
+    uint32_t index_count = 0;            // DrawIndexAuto / DrawIndex
     uint32_t index_size = 0;             // SetIndexType
+
+    // DrawIndex (sceAgcDcbDrawIndex -> R_DRAW_INDEX, laid out by hle_agc.cpp agc_dcb_draw_index).
+    // Packet payload: [0]=index_count, [1..2]=index-buffer guest address (lo/hi), [3..4]=64-bit draw
+    // modifier (lo/hi). Field roles cross-checked against Kyty: GraphicsDrawIndex (Graphics.cpp:313)
+    // emits exactly cmd[1]=index_count, cmd[2..3]=index_addr lo/hi under R_DRAW_INDEX, and its consumer
+    // cp_op_draw_index (GraphicsRun.cpp:2757) reads buffer[0]=index_count, buffer[1..2]=index_addr —
+    // CONFIDENCE: HIGH for count/address. [3..4] follows the Gen5 Dcb convention of a trailing 64-bit
+    // ShaderDrawModifier (cf. GraphicsDcbDrawIndexAuto (buf, index_count, modifier), Graphics.cpp:1971);
+    // Kyty's Gen4 form carries 32-bit flags+type there instead — CONFIDENCE: MED, decoded raw.
+    // The index ELEMENT SIZE is not in this packet: it comes from the preceding SetIndexType
+    // (GpuState::index_type), which the per-draw snapshot already captures.
+    uint64_t di_index_addr = 0;          // DrawIndex: guest address of the index buffer
+    uint64_t di_modifier = 0;            // DrawIndex: raw 64-bit draw-modifier bits
+    bool     di_valid = false;           // DrawIndex: payload was long enough to carry addr+modifier
     uint32_t event_type = 0;             // EventWrite
     uint32_t sh_reg_offset = 0, sh_reg_value = 0;  // SetShRegDirect (sh_reg_value = first value)
     uint32_t sh_reg_count = 0;                 // SetShRegDirect: # of consecutive registers this packet sets

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -119,14 +119,15 @@ HLE(agc_dcb_draw_index_auto) {  // (buf, index_count, modifier)
     return (uint64_t)(uintptr_t)cmd;
 }
 // sceAgcDcbDrawIndex (NID q88lQ+GP5Yk, name via shadPS4 aerolib.inl) — the indexed-draw sibling of
-// DrawIndexAuto. Kyty has no Gen5 reference; arg shape inferred from the Gen4 form
-// (index_count, index_addr, …) + the Gen5 Dcb convention (buf first, modifier last):
-// (Dcb* buf, uint32_t index_count, const void* indices, uint64_t modifier). CONFIDENCE: LOW on
-// a2/a3 meaning — the packet stores them raw and pm4_decode currently skips R_DRAW_INDEX (indexed
-// draws are the documented "remaining polish"). What this fixes NOW: every Dcb append returns the
-// allocated packet pointer, and the previous unimplemented stub returned 0 — a caller patching
-// its draw packet through that return (the AGC patch idiom, cf. agc_patch_set_address) would have
-// written through NULL/garbage instead of into the DCB.
+// DrawIndexAuto: (Dcb* buf, uint32_t index_count, const void* indices, uint64_t modifier).
+// Kyty has no Gen5 reference, but the a1/a2 roles are pinned by its Gen4 pair: GraphicsDrawIndex
+// (Graphics.cpp:313) emits this same R_DRAW_INDEX custom packet as cmd[1]=index_count,
+// cmd[2..3]=index_addr lo/hi, and its CommandProcessor consumer cp_op_draw_index
+// (GraphicsRun.cpp:2757) reads buffer[0]=index_count, buffer[1..2]=index_addr — CONFIDENCE: HIGH.
+// a3 follows the Gen5 Dcb convention of a trailing 64-bit ShaderDrawModifier (cf.
+// GraphicsDcbDrawIndexAuto (buf, index_count, modifier), Graphics.cpp:1971), where Gen4 carried
+// 32-bit flags+type instead — CONFIDENCE: MED, stored raw. pm4_decode decodes this packet as
+// Kind::DrawIndex (issue #63); the index ELEMENT SIZE comes from the preceding SetIndexSize packet.
 HLE(agc_dcb_draw_index) {
     uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DRAW_INDEX, &cmd)) return 0;
     cmd[1] = (uint32_t)a1;
@@ -642,10 +643,10 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         // completion-label write (WriteData/ReleaseMem/EventWrite) or a GPU-side wait in the stream.
         std::vector<gpu::Pm4Command> ops; gpu::decode_pm4(p->addr, p->dw_num, ops);
         static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetShRegDirect","SetRegsIndirect",
-            "SetIndexType","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem","Flip",
-            "ReleaseMem","Unknown"};
+            "SetIndexType","DrawIndex","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem",
+            "Flip","ReleaseMem","Unknown"};
         for (auto& c : ops) {
-            uint32_t k = (uint32_t)c.kind; const char* nm = k < 13 ? kKindName[k] : "?";
+            uint32_t k = (uint32_t)c.kind; const char* nm = k < 14 ? kKindName[k] : "?";
             fprintf(stderr, "[agc]   pkt op=0x%02x r=0x%02x len=%u kind=%s pl0=0x%08x pl1=0x%08x pl2=0x%08x\n",
                     c.op, c.r, c.len, nm,
                     c.len > 1 ? c.payload[0] : 0, c.len > 2 ? c.payload[1] : 0, c.len > 3 ? c.payload[2] : 0);

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -118,6 +118,33 @@ int main() {
         }
     }
 
+    // Indexed draw (sceAgcDcbDrawIndex -> R_DRAW_INDEX, issue #63): the packet must land in
+    // GpuState::draws carrying its index data — previously it decoded as an unknown NOP and every
+    // indexed draw the guest submitted was silently dropped while the HLE returned success.
+    {
+        auto drawi = Hle::lookup("q88lQ+GP5Yk");                                 // sceAgcDcbDrawIndex
+        CHECK(drawi != nullptr, "DrawIndex builder registered");
+        if (drawi) {
+            static uint16_t indices[6] = { 0, 1, 2, 0, 2, 3 };
+            uint32_t ibuf[64]; memset(ibuf, 0, sizeof ibuf);
+            Dcb id{}; id.bottom = ibuf; id.top = ibuf + 64; id.cursor_up = ibuf; id.cursor_down = ibuf + 64;
+            auto ID = (uint64_t)(uintptr_t)&id;
+            idx(ID, /*index_size*/ 2, 0, 0, 0, 0);              // 16-bit indices
+            drawi(ID, /*index_count*/ 6, (uint64_t)(uintptr_t)indices, /*modifier*/ 0x40000000ull, 0, 0);
+            GpuState s5;
+            run_command_buffer(ibuf, 64, s5);
+            CHECK(s5.draws.size() == 1, "DrawIndex recorded one draw");
+            if (s5.draws.size() == 1) {
+                const auto& d = s5.draws[0];
+                CHECK(d.indexed, "draw is marked indexed (fully-decoded packet)");
+                CHECK(d.index_count == 6, "indexed draw index_count = 6");
+                CHECK(d.index_addr == (uint64_t)(uintptr_t)indices, "index-buffer address carried through");
+                CHECK(d.modifier == 0x40000000ull, "draw modifier carried through");
+                CHECK(d.state && d.state->index_type == 2, "snapshot carries the index element size (SetIndexType)");
+            }
+        }
+    }
+
     // Per-draw register snapshots: each DrawIndexAuto captures the register state AT the draw, so a
     // register changed between two draws is visible in the first draw's snapshot at its old value.
     // (Consecutive draws with no writes in between share one snapshot.)

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -33,9 +33,10 @@ int main() {
     auto p_add = Hle::lookup("d-6uF9sZDIU");   // patch: AddRegisters
     auto p_adr = Hle::lookup("vcmNN+AAXnY");   // patch: SetAddress
     auto draw  = Hle::lookup("Yw0jKSqop+E");   // DrawIndexAuto
+    auto drawi = Hle::lookup("q88lQ+GP5Yk");   // DrawIndex (indexed sibling)
     auto evt   = Hle::lookup("aJf+j5yntiU");   // EventWrite
-    CHECK(reset && idx && setcx && p_add && p_adr && draw && evt, "AGC Dcb builders registered");
-    if (!(reset && idx && setcx && p_add && p_adr && draw && evt)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(reset && idx && setcx && p_add && p_adr && draw && drawi && evt, "AGC Dcb builders registered");
+    if (!(reset && idx && setcx && p_add && p_adr && draw && drawi && evt)) { printf("== FAIL ==\n"); return 1; }
 
     uint32_t buffer[256];
     memset(buffer, 0, sizeof buffer);          // zero => any tail dword is a non-type3 stream end
@@ -50,6 +51,7 @@ int main() {
     p_add(rc, 5, 0, 0, 0, 0);                                     // num_regs: 3 -> 8
     p_adr(rc, 0xCAFEF00DDEADBEEFull, 0, 0, 0, 0);                 // rewrite the regs vaddr
     draw(D, /*index_count*/ 0x1234, 0, 0, 0, 0);
+    drawi(D, /*index_count*/ 0x0600, /*indices*/ 0xDEAD0000BEEF0040ull, /*modifier*/ 0x40000000ull, 0, 0);
     evt(D, /*event_type*/ 0x42, 0, 0, 0, 0);
 
     size_t used_dw = (size_t)(dcb.cursor_up - dcb.bottom);
@@ -58,8 +60,8 @@ int main() {
     std::vector<Pm4Command> ops;
     size_t consumed = decode_pm4(buffer, 256, ops);   // pass full buffer; decoder stops at the zero tail
     CHECK(consumed == used_dw, "decoder consumed exactly the built dwords (stops at zero pad)");
-    CHECK(ops.size() == 5, "decoded 5 packets");
-    if (ops.size() != 5) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
+    CHECK(ops.size() == 6, "decoded 6 packets");
+    if (ops.size() != 6) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
 
     using K = Pm4Command::Kind;
     CHECK(ops[0].kind == K::DrawReset, "op0 = DrawReset");
@@ -73,7 +75,13 @@ int main() {
 
     CHECK(ops[3].kind == K::DrawIndexAuto && ops[3].index_count == 0x1234, "op3 = DrawIndexAuto(0x1234)");
 
-    CHECK(ops[4].kind == K::EventWrite && ops[4].event_type == 0x42, "op4 = EventWrite(0x42)");
+    // DrawIndex round-trip (issue #63): the builder wrote [1]=count, [2..3]=index addr, [4..5]=modifier;
+    // the decoder must hand every field back (indexed draws were previously dropped as unknown NOPs).
+    CHECK(ops[4].kind == K::DrawIndex && ops[4].index_count == 0x0600, "op4 = DrawIndex(count=0x600)");
+    CHECK(ops[4].di_index_addr == 0xDEAD0000BEEF0040ull, "op4 index-buffer address round-trips");
+    CHECK(ops[4].di_modifier == 0x40000000ull && ops[4].di_valid, "op4 modifier round-trips (valid)");
+
+    CHECK(ops[5].kind == K::EventWrite && ops[5].event_type == 0x42, "op5 = EventWrite(0x42)");
 
     // Every decoded packet's len must match its header, and the payload pointer must be in-buffer.
     bool spans_ok = true;


### PR DESCRIPTION
## Defect

`hle_agc.cpp` `agc_dcb_draw_index` (sceAgcDcbDrawIndex, NID `q88lQ+GP5Yk`) emits an `R_DRAW_INDEX` (0x03) IT_NOP packet, but `pm4_decode.cpp` had no case for opcode 0x03. Every indexed draw the guest submitted decoded as `Kind::Unknown`, never reached `GpuState::draws`, and the HLE returned success to the guest — geometry silently dropped. Directly relevant to the scene-content frontier.

## ABI evidence (packet field roles, previously CONFIDENCE: LOW)

- **index_count / index_addr — CONFIDENCE: HIGH.** Kyty `GraphicsDrawIndex` (`Graphics.cpp:313`) emits this same `R_DRAW_INDEX` custom packet as `cmd[1]=index_count`, `cmd[2..3]=index_addr lo/hi`, and Kyty''s CommandProcessor consumer `cp_op_draw_index` (`GraphicsRun.cpp:2757`, registered for `Pm4::R_DRAW_INDEX`) reads back exactly `buffer[0]=index_count`, `buffer[1..2]=index_addr`. That matches what prosper''s builder writes (`cmd[1]=a1`, `cmd[2..3]=a2 lo/hi`).
- **modifier — CONFIDENCE: MED, decoded raw.** `cmd[4..5]=a3 lo/hi` follows the Gen5 Dcb convention of a trailing 64-bit ShaderDrawModifier (cf. `GraphicsDcbDrawIndexAuto (buf, index_count, modifier)`, `Graphics.cpp:1971`). Kyty''s Gen4 form carries 32-bit `flags`+`type` there instead, so the field is stored/decoded raw and documented as such.
- The index **element size** is not in this packet — it comes from the preceding SetIndexType and already rides in the per-draw register snapshot (`GpuState::index_type`).

## Fix

- `pm4_decode.hpp/.cpp`: new `Kind::DrawIndex` + `di_index_addr`/`di_modifier`/`di_valid`; `R_DRAW_INDEX` decoded under IT_NOP like its siblings.
- `command_processor`: `DrawIndex` shares the `DrawIndexAuto` snapshot path and pushes a `Draw` carrying `indexed`/`index_addr`/`modifier` (`indexed` set only for fully-decoded packets, so a truncated packet can''t fabricate an address).
- Executor: **no behavior change** — indexed draws render exactly like a `DrawIndexAuto` of the same count; the index data is carried but unconsumed. Consuming the index buffer and retiring the quad-fan hack is #64, which builds directly on this.
- GFXLOG kind-name table in `hle_agc.cpp` updated for the new enum value.

## Verification

- New builder→decoder round-trip in `test_pm4_decode` (count, address, modifier, validity) and a decode+apply case in `test_command_processor` (draw record fields + snapshot `index_type`), following the SetFlip precedent.
- 44/44 ctest green (WSL Ubuntu-24.04).
- Live render smoke: `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 timeout 60 ./boot_trace` — 77 `[render] frame` lines, frames still render.

Fixes #63