### PR TITLE
fix(hle/kernel): scePthreadOnce serializes per control (global lock could cross-deadlock)

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -16,6 +16,8 @@
 #include <unordered_map>
 #include <mutex>
 #include <thread>
+#include <atomic>
+#include <condition_variable>
 #ifdef __linux__
 #include <sys/mman.h>
 #include <sys/syscall.h>
@@ -159,21 +161,36 @@ HLE(k_rwlock_unlock)  { if (auto* rw = ensure_rwlock(a0)) pthread_rwlock_unlock(
 HLE(k_rwlock_tryrdlock){ auto* rw = ensure_rwlock(a0); return rw ? (uint64_t)pthread_rwlock_tryrdlock(rw) : 0x16; }
 HLE(k_rwlock_trywrlock){ auto* rw = ensure_rwlock(a0); return rw ? (uint64_t)pthread_rwlock_trywrlock(rw) : 0x16; }
 
-// scePthreadOnce(once_control*, init_routine): run init exactly once. We run it UNDER a lock so all
-// callers see it complete before returning (pthread_once semantics). A recursive mutex avoids
-// self-deadlock if an init routine itself calls scePthreadOnce. The once-control's first int is the
-// done-flag. init is a guest fn (guest ABI == host SysV) so it's callable directly.
+// scePthreadOnce(once_control*, init_routine): run init exactly once, PER CONTROL. The old
+// implementation held ONE process-global recursive mutex across the guest init routine — if init
+// routine A blocked on another thread's progress and that thread touched ANY other once-control,
+// both deadlocked (impossible on real hardware, which serializes per control). Now the control
+// word itself is the state machine (0 = not run, 2 = running, 1 = done — same shape as
+// h_execute_once in hle_libc.cpp), losers park on a condvar, and the init routine runs OUTSIDE
+// the lock so independent once-inits never serialize. Same-thread re-entry (an init calling
+// scePthreadOnce on ANOTHER control) works naturally; re-entry on the SAME control would be a
+// guest bug on real hardware too (pthread_once self-deadlocks there).
 HLE(k_pthread_once) {
-    auto* ctl = (volatile int*)(uintptr_t)a0;
+    auto* ctl = (std::atomic<int>*)(uintptr_t)a0;
     auto init = (void (*)())(uintptr_t)a1;
     if (!ctl || !init) return 0x16;
-    static pthread_mutex_t om = []{ pthread_mutex_t m; pthread_mutexattr_t a;
-        pthread_mutexattr_init(&a); pthread_mutexattr_settype(&a, PTHREAD_MUTEX_RECURSIVE);
-        pthread_mutex_init(&m, &a); pthread_mutexattr_destroy(&a); return m; }();
-    pthread_mutex_lock(&om);
-    if (*ctl == 0) { init(); *ctl = 1; }
-    pthread_mutex_unlock(&om);
-    return 0;
+    static std::mutex om;                    // guards state TRANSITIONS only, never held during init()
+    static std::condition_variable ocv;
+    for (;;) {
+        if (ctl->load(std::memory_order_acquire) == 1) return 0;   // fast path: already done
+        std::unique_lock<std::mutex> lk(om);
+        int v = ctl->load(std::memory_order_acquire);
+        if (v == 1) return 0;
+        if (v == 2) { ocv.wait(lk); continue; }   // another thread runs this control's init
+        ctl->store(2, std::memory_order_relaxed);
+        lk.unlock();
+        init();
+        lk.lock();
+        ctl->store(1, std::memory_order_release);
+        lk.unlock();
+        ocv.notify_all();
+        return 0;
+    }
 }
 
 // --- thread identity ---

--- a/prosper/tests/test_rwlock_once.cpp
+++ b/prosper/tests/test_rwlock_once.cpp
@@ -7,6 +7,9 @@
 #include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <atomic>
+#include <chrono>
+#include <thread>
 
 using namespace prosper;
 
@@ -52,6 +55,33 @@ int main() {
     int ctl = 0; g_once_count = 0;
     for (int i = 0; i < 3; i++) call2(ONCE, (uint64_t)(uintptr_t)&ctl, (uint64_t)(uintptr_t)&once_init);
     CHECK(g_once_count == 1, "scePthreadOnce runs init exactly once across 3 calls");
+
+    // Cross-control independence (#69): init routine for control X blocks until ANOTHER thread
+    // completes once(Y). The old one-global-recursive-mutex implementation deadlocked here (Y's
+    // caller parked behind X's global lock; X waited on Y forever). Per-control serialization
+    // (real pthread_once semantics) must let Y proceed while X's init is still running.
+    {
+        static HleFn s_once = ONCE;
+        static int s_ctl_y = 0;
+        static std::atomic<bool> s_y_done{false};
+        static auto s_init_y = +[]() { s_y_done.store(true); };
+        static auto s_init_x = +[]() {
+            // From inside X's init: run once(Y) on a worker and WAIT for it — cross-thread,
+            // cross-control dependency, legal on real hardware.
+            std::thread t([]{ s_once((uint64_t)(uintptr_t)&s_ctl_y, (uint64_t)(uintptr_t)+s_init_y, 0, 0, 0, 0); });
+            t.join();
+        };
+        int ctl_x = 0;
+        std::atomic<bool> x_returned{false};
+        std::thread xt([&]{ s_once((uint64_t)(uintptr_t)&ctl_x, (uint64_t)(uintptr_t)+s_init_x, 0, 0, 0, 0);
+                            x_returned.store(true); });
+        // Deadlock watchdog: the whole thing must finish well within 5 s.
+        for (int i = 0; i < 500 && !x_returned.load(); i++)
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        CHECK(x_returned.load(), "once(X) whose init depends on another thread's once(Y) completes (no global-lock deadlock)");
+        CHECK(s_y_done.load(), "the dependent once(Y) actually ran");
+        if (x_returned.load()) xt.join(); else xt.detach();   // don't hang the test binary on failure
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Fixes #69

`k_pthread_once` held one process-global recursive mutex across the guest's init routine — if init A blocked on another thread's progress and that thread touched ANY other once-control, both deadlocked (impossible on real hardware, which serializes per control; the recursive type only covered same-thread re-entry). The control word itself is now the state machine (0/2/1 = not-run/running/done, mirroring the `_Execute_once` fix from #61), waiters park on a condvar, and init runs outside the lock so independent once-inits never serialize.

Regression test added: `once(X)` whose init spawns a worker running `once(Y)` and joins it — the old code deadlocks (Y parks behind X's global lock), the new code completes; a watchdog makes a future regression fail rather than hang the suite.

Note: this issue was briefly auto-closed by PR #75's mislabeled `Fixes #69` (that PR fixed #70, WaitRegMem); the tracker has been repaired (#69 reopened, #70 closed with attribution) and this PR is the real fix.

Verification: 46/46 ctest; live render config boots and renders 180+ frames.