### PR TITLE
fix(gpu): decode the T#'s real Gen5 IMG_FMT — texture format/size no longer hardcoded RGBA8

### DIFF
--- a/prosper/docs/RENDER_LOOP.md
+++ b/prosper/docs/RENDER_LOOP.md
@@ -967,7 +967,8 @@ regression test in `test_command_processor`). This was a general register-fideli
 
 **Result:** the `[restab]` descriptors are now real —
 - VS: 4 constant buffers with real bases + `stride=16` (UnityPerDraw/PerFrame/etc.).
-- PS: 1 constant buffer + a **1920×1080** sampled texture (`fmt=9`) — the real full-screen render target
+- PS: 1 constant buffer + a **1920×1080** sampled texture (`fmt=56`, 8_8_8_8_UNORM; this note originally
+  said `fmt=9` — a misread of `type=9`, corrected while fixing #65) — the real full-screen render target
   the draw composites, not the old 1×1.
 Also: read 32 user SGPRs (not 16) since NGG merged shaders use the extended `s16..s31` block; added
 plausibility guards so a non-descriptor SGPR can't emit a garbage V#/T# binding.

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -74,6 +74,50 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
     return d;
 }
 
+// The Gen5 T# carries a 9-bit COMBINED IMG_FMT at dword1 bits[28:20] (the GFX10 image-format enum,
+// not the GCN dfmt/nfmt split). Values 1..77 share the buffer-format numbering decoded by
+// rdna2_buffer_format above; image-only values sit at 128+ — SRGB at 128..130, BC1..BC7 at 169..182 —
+// per AMD's published GFX10 register database (mesa src/amd/registers/gfx10-rsrc.json, enum
+// GFX10_FORMAT). Anchors: fmt=56 (8_8_8_8_UNORM) is Kyty-confirmed (Texture.cpp get_texture_format,
+// gen5 path) AND is the title's live 1920x1080 composite T#; fmt=1 (8_UNORM) is the title's live
+// 2048x1024 single-channel atlas. USCALED/SSCALED, 10/11-bit packed, depth, FMASK and video formats
+// are deliberately left unmapped until a target needs them (callers log + skip, never assume RGBA8).
+// CONFIDENCE: HIGH on 1..77 and the two live anchors, MED on the image-only rows (register-DB-derived,
+// no game-observed instance yet).
+bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
+    Gen5ImageFormatInfo fi;
+    auto plain = [&](DataFormat f, uint32_t n, bool srgb = false) {
+        fi.format = f; fi.num_components = n; fi.bytes_per_block = data_format_bytes(f) * n; fi.srgb = srgb;
+    };
+    auto bcn = [&](DataFormat f, uint32_t n, uint32_t bpb, bool srgb = false) {
+        fi.format = f; fi.num_components = n; fi.bytes_per_block = bpb;
+        fi.block_width = fi.block_height = 4; fi.srgb = srgb;
+    };
+    if (fmt >= 1 && fmt <= 77) {                 // shared with the V# buffer-format numbering
+        DataFormat f = DataFormat::Unknown; uint32_t n = 0;
+        rdna2_buffer_format(fmt, &f, &n);
+        if (f != DataFormat::Unknown) plain(f, n);
+    } else switch (fmt) {
+        case 128: plain(DataFormat::Unorm8, 1, true); break;   // 8_SRGB
+        case 129: plain(DataFormat::Unorm8, 2, true); break;   // 8_8_SRGB
+        case 130: plain(DataFormat::Unorm8, 4, true); break;   // 8_8_8_8_SRGB
+        case 169: bcn(DataFormat::Bc1, 4,  8);        break;   // BC1_UNORM
+        case 170: bcn(DataFormat::Bc1, 4,  8, true);  break;   // BC1_SRGB
+        case 171: bcn(DataFormat::Bc2, 4, 16);        break;   // BC2_UNORM
+        case 172: bcn(DataFormat::Bc2, 4, 16, true);  break;   // BC2_SRGB
+        case 173: bcn(DataFormat::Bc3, 4, 16);        break;   // BC3_UNORM
+        case 174: bcn(DataFormat::Bc3, 4, 16, true);  break;   // BC3_SRGB
+        case 175: case 176: bcn(DataFormat::Bc4, 1,  8); break; // BC4_UNORM/_SNORM (snorm not modeled
+        case 177: case 178: bcn(DataFormat::Bc5, 2, 16); break; // BC5_UNORM/_SNORM  yet — skip-only)
+        case 179: case 180: bcn(DataFormat::Bc6, 3, 16); break; // BC6_UFLOAT/_SFLOAT
+        case 181: bcn(DataFormat::Bc7, 4, 16);        break;   // BC7_UNORM
+        case 182: bcn(DataFormat::Bc7, 4, 16, true);  break;   // BC7_SRGB
+        default: break;                                         // unmapped -> false
+    }
+    if (out) *out = fi;
+    return fi.format != DataFormat::Unknown;
+}
+
 DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     DecodedImageDescriptor d;
     d.base      = (((uint64_t)t[0] | ((uint64_t)t[1] << 32)) & 0xFFFFFFFFFFull) << 8;             // Base40
@@ -139,16 +183,39 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                         d.width, d.height, (unsigned long long)d.base, d.tile_mode, d.type, d.format,
                         t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
             }
+            // Decode the T#'s real Gen5 IMG_FMT (#65 — was hardcoded Unorm8 x4 / size w*h*4, which
+            // mis-samples any non-RGBA8 texture and over-reads a BCn allocation up to 8x). Policy:
+            //   * mapped uncompressed  -> emit truthfully (format/components/real byte size);
+            //   * mapped BCn           -> recognized but no backend samples blocks yet: log once + SKIP
+            //     (a wrong RGBA8 binding samples garbage AND reads w*h*4 past the real allocation);
+            //   * unmapped value       -> log once, loudly, + SKIP (never silently assume RGBA8).
+            // Skipping mirrors the degenerate-T# guard above: the sampling shader fails to recompile
+            // and its draw is dropped, which is diagnosable — garbage pixels are not.
+            Gen5ImageFormatInfo fi;
+            static bool warned[512] = {};                        // once per 9-bit format value
+            if (!gen5_image_format(d.format, &fi)) {
+                if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
+                    fprintf(stderr, "[t#] UNMAPPED Gen5 IMG_FMT %u (%ux%u T#) -> skipping texture binding "
+                                    "(extend gen5_image_format)\n", d.format, d.width, d.height); }
+                continue;
+            }
+            if (fi.block_width > 1) {
+                if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
+                    fprintf(stderr, "[t#] Gen5 IMG_FMT %u is block-compressed (%ux%u T#) -> recognized but "
+                                    "BCn sampling is not wired; skipping texture binding\n",
+                            d.format, d.width, d.height); }
+                continue;
+            }
             ShaderResource r;
             r.cls           = ResourceClass::Texture;
-            r.format        = DataFormat::Unorm8;   // sampled UI textures are 8-bit UNORM RGBA
-            r.num_components = 4;
+            r.format        = fi.format;
+            r.num_components = fi.num_components;
             r.binding       = binding++;
             r.gpu_addr      = d.base;
             r.width         = d.width;
             r.height        = d.height;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
-            r.size          = d.width * d.height * 4;
+            r.size          = d.width * d.height * fi.bytes_per_block;   // real bytes-per-texel (fmt=56 -> *4)
             r.sgpr_base     = user_sgpr_base + off;  // DIRECT provenance key (image_sample SRSRC SGPR)
             r.srt_offset    = 0xFFFFFFFFu;
             table.resources.push_back(r);

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -70,6 +70,21 @@ struct DecodedImageDescriptor {
 // Decode an 8-dword T# (RDNA2/Gen5 image resource). Pure; exposed for reuse + testing.
 DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]);
 
+// A Gen5/GFX10 T# IMG_FMT (the 9-bit combined format field) decoded to sizing + conversion info.
+// bytes_per_block is the byte size of one block_width x block_height texel block — for uncompressed
+// formats block dims are 1x1 and it equals bytes-per-texel; for BCn blocks are 4x4.
+struct Gen5ImageFormatInfo {
+    DataFormat format         = DataFormat::Unknown;
+    uint32_t   num_components = 0;
+    uint32_t   bytes_per_block = 0;
+    uint32_t   block_width = 1, block_height = 1;
+    bool       srgb = false;   // gamma-encoded variant (sampling it as UNORM is a gamma error only,
+                               // not garbage — the numbering distinguishes e.g. 56 vs 130)
+};
+// Map a T#'s 9-bit Gen5 IMG_FMT value to format info. Returns false (out left Unknown/zero) for
+// values not in the table — callers must not assume RGBA8 for those (#65). Pure; exposed for testing.
+bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out);
+
 // Map a GCN/Gen5 buffer (DFMT, NFMT) pair to a DataFormat + component count. Pure.
 // Decode an RDNA2 (GFX10/PS5) buffer V# combined 7-bit FORMAT field (dword3 bits[18:12]) into a
 // DataFormat + component count. (Replaces the GCN dfmt/nfmt split, which is wrong for PS5 V#s.)

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -26,10 +26,16 @@ enum class DataFormat : uint32_t {
     Float32, Uint32, Sint32,
     Float16, Unorm16, Snorm16, Uint16, Sint16,
     Unorm8,  Snorm8,  Uint8,  Sint8,
-    // 10/11-bit packed and block-compressed formats are added as the target needs them.
+    // Block-compressed texture formats (4x4-texel blocks). RECOGNIZED by the Gen5 T# mapper
+    // (gen5_image_format) so a BCn texture sizes correctly and is skipped explicitly instead of
+    // binding as garbage RGBA8 (#65) — but no backend samples them yet. data_format_bytes()
+    // returns 0 for these (a per-COMPONENT byte size is meaningless for a block format; use
+    // Gen5ImageFormatInfo::bytes_per_block).
+    Bc1, Bc2, Bc3, Bc4, Bc5, Bc6, Bc7,
+    // 10/11-bit packed formats are added as the target needs them.
 };
 
-// How many bytes one component of `format` occupies (0 for Unknown).
+// How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).
 uint32_t data_format_bytes(DataFormat f);
 
 enum class ResourceClass : uint32_t {

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -24,8 +24,48 @@ static void make_vsharp(uint32_t v[4], uint64_t base, uint32_t stride, uint32_t 
     v[3] = (fmt & 0x7Fu) << 12;
 }
 
+// Build an 8-dword T# (Gen5 image resource): Base40 (stored >>8), 9-bit IMG_FMT @[28:20] of word1,
+// Width5-1 split over word1[31:30] (lo) + word2[11:0] (hi), Height5-1 @word2[27:14], TileMode
+// @word3[24:20], Type @word3[31:28]. Mirrors decode_image_descriptor / Kyty's Gen5 getters.
+static void make_tsharp(uint32_t t[8], uint64_t base, uint32_t w, uint32_t h, uint32_t fmt,
+                        uint32_t tile_mode, uint32_t type) {
+    memset(t, 0, 8 * sizeof(uint32_t));
+    uint64_t b = base >> 8;                       // 256-byte-aligned base, stored >>8
+    t[0] = (uint32_t)(b & 0xffffffffu);
+    t[1] = (uint32_t)((b >> 32) & 0xffu) | ((fmt & 0x1ffu) << 20) | (((w - 1) & 0x3u) << 30);
+    t[2] = (((w - 1) >> 2) & 0xfffu) | (((h - 1) & 0x3fffu) << 14);
+    t[3] = ((tile_mode & 0x1fu) << 20) | ((type & 0xfu) << 28);
+}
+
 int main() {
     printf("== test_build_shader_resources ==\n");
+
+    // --- Gen5 IMG_FMT mapper (pure table, #65) --------------------------------------------------
+    {
+        Gen5ImageFormatInfo fi;
+        // The two title-live anchors: fmt=56 (composite RT, Kyty-confirmed) and fmt=1 (2048x1024 atlas).
+        CHECK(gen5_image_format(56, &fi) && fi.format == DataFormat::Unorm8 && fi.num_components == 4 &&
+              fi.bytes_per_block == 4 && fi.block_width == 1 && !fi.srgb, "IMG_FMT 56 -> Unorm8 x4, 4 B/texel");
+        CHECK(gen5_image_format(1, &fi) && fi.format == DataFormat::Unorm8 && fi.num_components == 1 &&
+              fi.bytes_per_block == 1, "IMG_FMT 1 -> Unorm8 x1 (R8), 1 B/texel");
+        CHECK(gen5_image_format(14, &fi) && fi.format == DataFormat::Unorm8 && fi.num_components == 2 &&
+              fi.bytes_per_block == 2, "IMG_FMT 14 -> Unorm8 x2 (RG8)");
+        CHECK(gen5_image_format(71, &fi) && fi.format == DataFormat::Float16 && fi.num_components == 4 &&
+              fi.bytes_per_block == 8, "IMG_FMT 71 -> Float16 x4 (RGBA16F), 8 B/texel");
+        CHECK(gen5_image_format(130, &fi) && fi.format == DataFormat::Unorm8 && fi.num_components == 4 &&
+              fi.bytes_per_block == 4 && fi.srgb, "IMG_FMT 130 -> Unorm8 x4 SRGB");
+        CHECK(gen5_image_format(169, &fi) && fi.format == DataFormat::Bc1 && fi.bytes_per_block == 8 &&
+              fi.block_width == 4 && fi.block_height == 4, "IMG_FMT 169 -> BC1, 8 B per 4x4 block");
+        CHECK(gen5_image_format(173, &fi) && fi.format == DataFormat::Bc3 && fi.bytes_per_block == 16,
+              "IMG_FMT 173 -> BC3, 16 B per 4x4 block");
+        CHECK(gen5_image_format(182, &fi) && fi.format == DataFormat::Bc7 && fi.srgb,
+              "IMG_FMT 182 -> BC7 SRGB");
+        CHECK(!gen5_image_format(0, &fi) && fi.format == DataFormat::Unknown, "IMG_FMT 0 (INVALID) unmapped");
+        CHECK(!gen5_image_format(9, &fi), "IMG_FMT 9 (16_USCALED) unmapped -> false");
+        CHECK(!gen5_image_format(44, &fi), "IMG_FMT 44 (10_10_10_2) unmapped -> false");
+        CHECK(!gen5_image_format(157, &fi), "IMG_FMT 157 (FMASK) unmapped -> false");
+        CHECK(!gen5_image_format(511, &fi), "IMG_FMT 511 out-of-table -> false");
+    }
 
     // --- V# decode in isolation ---------------------------------------------------------------
     {
@@ -101,6 +141,47 @@ int main() {
     CHECK(vb && vb->srt_offset == 0xFFFFFFFFu, "DIRECT vbuf leaves srt_offset unset");
     CHECK(t3.by_srt_offset(4 * 4) != nullptr, "constant buffers still present alongside vertex buffers");
     CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
+
+    // --- textures: sharp[0] T#s carry their real format + byte size; BCn/unmapped are skipped (#65) ---
+    {
+        uint32_t tsgprs[32]; memset(tsgprs, 0, sizeof tsgprs);
+        make_tsharp(&tsgprs[0],  0xD0000000ull, 1920, 1080, /*fmt*/56,  /*tile*/5, /*type 2D*/9);
+        make_tsharp(&tsgprs[8],  0xE0000000ull, 2048, 1024, /*fmt*/1,   /*tile*/5, /*type*/9);
+        make_tsharp(&tsgprs[16], 0xF0000000ull,  256,  256, /*fmt*/169, /*tile*/5, /*type*/9);  // BC1
+        make_tsharp(&tsgprs[24], 0xF0010000ull,  128,  128, /*fmt*/44,  /*tile*/5, /*type*/9);  // unmapped
+
+        {   // T# decode round-trip of the first descriptor
+            DecodedImageDescriptor d = decode_image_descriptor(&tsgprs[0]);
+            CHECK(d.base == 0xD0000000ull && d.width == 1920 && d.height == 1080 &&
+                  d.format == 56 && d.tile_mode == 5 && d.type == 9, "T# decode round-trip (base/w/h/fmt/tile/type)");
+        }
+
+        AgcShaderSharp tex_sharps[4];
+        for (int i = 0; i < 4; i++) tex_sharps[i].bits = (uint16_t)(i * 8);
+        AgcShaderUserData tud; memset(&tud, 0, sizeof tud);
+        tud.sharp_resource_offset[0] = tex_sharps;
+        tud.sharp_resource_count[0]  = 4;
+        AgcShaderHeader tshdr; memset(&tshdr, 0, sizeof tshdr);
+        tshdr.file_header = 0x34333231u; tshdr.version = 0x18; tshdr.type = 1;   // PS
+        tshdr.user_data = &tud;
+
+        ShaderResourceTable tt = build_shader_resources(tshdr, tsgprs, 32);
+        CHECK(tt.resources.size() == 2, "BC1 + unmapped-format T#s skipped; 2 textures emitted");
+
+        const ShaderResource* t0 = tt.by_sgpr_base(0);
+        CHECK(t0 && t0->cls == ResourceClass::Texture, "fmt=56 texture emitted (title composite path)");
+        CHECK(t0 && t0->format == DataFormat::Unorm8 && t0->num_components == 4,
+              "fmt=56 -> Unorm8 x4 (current behavior preserved)");
+        CHECK(t0 && t0->size == 1920u * 1080u * 4u, "fmt=56 size = w*h*4 (unchanged)");
+
+        const ShaderResource* t1 = tt.by_sgpr_base(8);
+        CHECK(t1 && t1->format == DataFormat::Unorm8 && t1->num_components == 1,
+              "fmt=1 -> Unorm8 x1 (R8, no longer assumed RGBA)");
+        CHECK(t1 && t1->size == 2048u * 1024u, "fmt=1 size = w*h (was w*h*4, an 8 MB over-read of 2 MB)");
+
+        CHECK(tt.by_sgpr_base(16) == nullptr, "BC1 T# skipped (recognized, not yet sampleable)");
+        CHECK(tt.by_sgpr_base(24) == nullptr, "unmapped IMG_FMT T# skipped (no silent RGBA8)");
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Fixes #65.

## Problem

`build_shader_resources` decoded the T#'s 9-bit Gen5 format field (`decode_image_descriptor`) and then discarded it: every sampled texture was emitted as `DataFormat::Unorm8` x4 with `size = w*h*4`. Any non-RGBA8 texture samples as garbage, and for BCn the hardcoded size over-reads the real allocation by up to 8x.

This is not hypothetical — a live GFXLOG capture of the title shows it in the current boot:

```
[t#] 1920x1080 base=0x78d6fefc1000 tile_mode=5 type=9 fmt=56   <- composite RT (RGBA8, correct today)
[t#] 2048x1024 base=0x78d69c641000 tile_mode=5 type=9 fmt=1    <- 8_UNORM (R8) atlas, was sized 8 MB against a 2 MB allocation
```

(The `fmt=9` noted in RENDER_LOOP.md was a misread of `type=9`; the composite is `fmt=56`.)

## Format-table evidence

The Gen5 T# format field is the GFX10 combined IMG_FMT enum:

* **Values 1..77** share the V# buffer-format numbering already implemented (and Kyty-confirmed) in `rdna2_buffer_format`.
* **Image-only values** per AMD's published GFX10 register database (mesa `src/amd/registers/gfx10-rsrc.json`, enum `GFX10_FORMAT`): SRGB at 128..130, BC1..BC7 at 169..182.
* **Anchors:** `fmt=56` (8_8_8_8_UNORM) is Kyty-confirmed (`Texture.cpp get_texture_format`, gen5 path) *and* is the title's live composite; `fmt=1` (8_UNORM) fits the title's live single-channel 2048x1024 atlas.

## Change

* New pure mapper `gen5_image_format(fmt)` -> `Gen5ImageFormatInfo { DataFormat, num_components, bytes_per_block, block dims, srgb }`. Mapped: all buffer-table formats 1..77 (R8/RG8/RGBA8 unorm/snorm/uint/sint, 16-bit unorm/float incl. RGBA16F, 32-bit), SRGB 128..130, BC1..BC7 169..182 (new `DataFormat::Bc1..Bc7`). USCALED/SSCALED, 10/11-bit packed, depth, FMASK, video formats deliberately unmapped.
* `build_shader_resources` texture policy:
  * mapped uncompressed -> emit truthfully; `r.size = w*h*bytes_per_texel` (fmt=56 -> `w*h*4`, unchanged);
  * BCn -> **recognized but skipped** (log once per value): no backend samples blocks yet, and a wrong RGBA8 binding both samples garbage and reads `w*h*4` past the allocation;
  * unmapped -> **log once per value, loudly, + skip** — never silently assume RGBA8.

BCn *sampling* (VK BC formats / block-aware detile) is intentionally not wired in this PR; the mapper carries block dims + bytes-per-block so that step has real sizing to build on.

## No regression (verified)

* Texture-class `format/num_components/size` currently have no downstream consumer (recompiler uses only `binding` for `image_sample`; boot_trace uploads `tw*th*4` RGBA8 itself), and both live title formats (56, 1) remain emitted — bindings unchanged.
* Live smoke (`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`): 88 frames rendered, zero new log lines, and the rendered title composite is **pixel-identical** (full-frame pixel MD5 `70366d67...`) to a pre-change baseline build.
* `ctest`: 46/46 green; `test_build_shader_resources` extended with a mapper table test + a synthetic-T# build test (fmt=56 emitted unchanged, fmt=1 emitted as R8 with `w*h`, BC1 and unmapped skipped).