### PR TITLE
Real indexed draws in the executor; retire the quad-fan heuristic (Fixes #64)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -306,6 +306,12 @@ if(TARGET prosper_core)
       target_link_libraries(test_multidraw_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME multidraw_render COMMAND test_multidraw_render)
 
+      # Indexed draws (#64): vkCmdDrawIndexed from a BackendDraw's index data — the [0,1,2,2,3,0] quad
+      # must match the retired perimeter-fan rendering pixel-exact, and indices must really be applied.
+      add_executable(test_indexed_render tests/test_indexed_render.cpp)
+      target_link_libraries(test_indexed_render PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME indexed_render COMMAND test_indexed_render)
+
       # Storage images: a recompiled compute kernel does MIMG image_load->image_store (no sampler) to
       # copy a 1D storage image bit-exact (the game's blit/copy compute-shader class).
       add_executable(test_storage_image_copy tests/test_storage_image_copy.cpp)

--- a/prosper/docs/CUTSCENE_RENDER.md
+++ b/prosper/docs/CUTSCENE_RENDER.md
@@ -74,7 +74,8 @@ letterbox appears even before the island/text draw correctly.
   (+ `PROSPER_RENDER_FIRST=140` to skip to the post-loading phase).
 - `PROSPER_DRAWLOG` (per-draw counts), `PROSPER_SHADER_DUMP=<dir>` (`frame_vs.spv`/`frame_fs.spv` +
   `exec_*_*.bin` for *failed* recompiles), `PROSPER_DUMP_TEX` (bound textures → BMP),
-  `PROSPER_FORCE_COLORWRITE`, `PROSPER_VCOUNT`/`PROSPER_TOPO` overrides.
+  `PROSPER_FORCE_COLORWRITE`. (`PROSPER_VCOUNT`/`PROSPER_TOPO` overrides and the quad-fan topology
+  heuristic were removed with real indexed-draw support, issue #64.)
 - **Disassemble PS5 shaders with `llvm-mc -mcpu=gfx1010`, NOT gfx1030** — the PS5 keeps RDNA1-era encodings
   (e.g. `v_mac_f32` at VOP2 op 0x1f, invalid on gfx1030). See PR #58.
 - Frames are BMP; read via PIL→PNG (`ImageFile.LOAD_TRUNCATED_IMAGES=True` for `safe_copy`-truncated tails).

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -34,8 +34,8 @@ struct GpuState {
     // Indexed draws (sceAgcDcbDrawIndex): `indexed` is set only when the packet carried the full
     // operand set; `index_addr` is the guest address of the index buffer (1:1-mapped, so directly
     // readable) and `modifier` the raw 64-bit draw-modifier bits. The index ELEMENT SIZE lives in the
-    // draw's register snapshot (`state->index_type`, from the preceding SetIndexType). The current
-    // executor does not consume the index buffer yet (renders these like DrawIndexAuto) — issue #64.
+    // draw's register snapshot (`state->index_type`, from the preceding SetIndexType; 0 = 16-bit,
+    // 1 = 32-bit). The executor fetches the index data and renders with vkCmdDrawIndexed (#64).
     struct Draw {
         uint32_t index_count;
         std::shared_ptr<const GpuState> state;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -35,6 +35,11 @@ struct DrawItem {
     ResolvedPipelineState ps;                         // THIS draw's fixed-function state
     std::shared_ptr<ShaderResourceTable> vrt, prt;    // may be null
     uint32_t vertex_count = 3;
+    // Indexed draw (sceAgcDcbDrawIndex): the guest index buffer, fetched from 1:1-mapped memory and
+    // widened to 32-bit. Non-empty -> the backend must render with vkCmdDrawIndexed (gl_VertexIndex
+    // then IS the fetched index, which the recompiled VS uses for its storage-buffer vertex fetch);
+    // empty -> plain vkCmdDraw(vertex_count).
+    std::vector<uint32_t> indices;
 };
 
 // The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8
@@ -53,13 +58,24 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 // or no resources. Implemented in gpu_executor.cpp (needs the AGC registry + descriptor decode).
 std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr, bool is_ps);
 
+// Byte size of one index element for a GpuState::index_type (the last SetIndexType value).
+// 0 -> 16-bit, 1 -> 32-bit, exactly Kyty's index_type_and_size switch (GraphicsRender.cpp:4724) and
+// the hardware VGT_INDEX_TYPE encoding; 0 is also the reset default, matching this title, which never
+// emits SetIndexType yet packs its quad index streams 12 bytes apart (6 x 2-byte indices) — live
+// capture confirms 16-bit. CONFIDENCE: HIGH for 0/1; any other value is unseen -> returns 0 and the
+// caller falls back to a non-indexed draw (loudly), rather than mis-reading the buffer.
+inline uint32_t index_elem_bytes(uint32_t index_type) {
+    return index_type == 0 ? 2u : index_type == 1 ? 4u : 0u;
+}
+
 // Realize ONE draw of `ds` (a register snapshot or the folded state) into a DrawItem: recompile the
-// VS+PS, resolve fixed-function state, apply the fullscreen-quad fan heuristic + env overrides. Returns
-// false (and leaves `out` untouched) if the draw is a no-op (no PGM bound, recompile failed, or
-// color_write_mask==0). Shared by the default (folded-state, one item) and PROSPER_PERDRAW (per-draw)
-// paths so their per-draw handling is identical.
-inline bool realize_draw_item(const GpuState& ds, uint32_t vcount_hint, uint32_t max_shader_dwords,
-                              bool log, DrawItem& out) {
+// VS+PS, resolve fixed-function state, and — for an indexed draw — fetch the guest index buffer.
+// `draw` is the PM4 draw record (index count + indexed/index_addr); null means "no record" (hand-built
+// states) and renders vcount_hint vertices non-indexed. Returns false (and leaves `out` untouched) if
+// the draw is a no-op (no PGM bound, recompile failed, or color_write_mask==0). Shared by the default
+// (folded-state, one item) and PROSPER_PERDRAW (per-draw) paths so their per-draw handling is identical.
+inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, uint32_t vcount_hint,
+                              uint32_t max_shader_dwords, bool log, DrawItem& out) {
     RenderState rs = extract_render_state(ds);
     if (!rs.es_addr || !rs.ps_addr) {
         if (log) fprintf(stderr, "[exec] skip draw: no PGM bound (es=0x%llx ps=0x%llx)\n",
@@ -100,38 +116,66 @@ inline bool realize_draw_item(const GpuState& ds, uint32_t vcount_hint, uint32_t
     // depth-only pass), rendering them reveals whether they are the cutscene content.
     if (ps.color_write_mask == 0) ps.color_write_mask = 0xf;
     uint32_t vertex_count = vcount_hint ? vcount_hint : 3u;
-    // Real vertex count: the draw's index_count (vcount_hint) is often a low/stale value for these NGG draws
-    // (folding uses draws[0]'s count), so rendering it paints only a degenerate sliver of the mesh (4 of ~20
-    // verts -> nothing on screen). The bound vertex buffer's entry count (size/stride) is the true per-vertex
-    // record count; use the largest bound VB's entry count when it exceeds the hint so the whole mesh renders.
-    // (A shader fetching past a real vertex reads 0 under robustBufferAccess -> a degenerate, clipped vertex,
-    // so a slightly-generous count is harmless; a too-small count drops geometry.)
+    // The bound vertex buffer's record count (size/stride) — bounds an indexed draw's vertex range, and
+    // for a NON-indexed draw is often the truer count: a draw record's index_count can be a low/stale
+    // value for these NGG draws (4 of ~20 verts -> a degenerate sliver), while the VB's record count is
+    // the whole mesh. A shader fetching past a real vertex reads 0 under robustBufferAccess -> a
+    // degenerate, clipped vertex, so a slightly-generous count is harmless.
     uint32_t vb_entries = 0;
     if (vrt) for (const auto& r : vrt->resources)
         if (r.cls == ResourceClass::VertexBuffer && r.stride)
             vb_entries = std::max(vb_entries, r.size / r.stride);
     if (vb_entries > 65536u) vb_entries = 65536u;   // sanity cap: don't stall llvmpipe on an over-sized VB
-    if (vb_entries > vertex_count) vertex_count = vb_entries;
-    // Fullscreen-composite quad fill: a 4-corner quad buffer tiles into two triangles; render its corners as
-    // a triangle FAN (perimeter order BL,TL,TR,BR -> tris {0,1,2}, {0,2,3}). Only for a 4-record buffer.
-    if (vb_entries == 4) ps.topology = 5 /*VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN*/;
-    if (const char* vc = getenv("PROSPER_VCOUNT")) { int v = atoi(vc); if (v > 0) vertex_count = (uint32_t)v; }
-    if (const char* tp = getenv("PROSPER_TOPO")) { int t = atoi(tp); if (t >= 0) ps.topology = (uint32_t)t; }
+    // Indexed draw (sceAgcDcbDrawIndex): fetch the real index data from guest memory (1:1-mapped) and
+    // hand it to the backend, which renders it with vkCmdDrawIndexed. This replaced the old "4-record
+    // VB -> TRIANGLE_FAN" heuristic (issue #64): the sprite quads that heuristic guessed at are in fact
+    // DrawIndex packets with a 6-entry index list ([0,1,2, 2,3,0]-style two-triangle quads), so the
+    // real indices + the real decoded VGT_PRIMITIVE_TYPE topology render every 4-vertex mesh correctly,
+    // whatever its vertex order. Unknown element size or an unreadable buffer falls back (loudly) to a
+    // non-indexed draw of the hint count instead of reading garbage.
+    static constexpr uint32_t kMaxIndices = 1u << 20;   // sanity cap (largest seen live: 0x61e)
+    if (draw && draw->indexed && draw->index_addr && draw->index_count) {
+        const uint32_t esz = index_elem_bytes(ds.index_type);
+        uint32_t n = std::min(draw->index_count, kMaxIndices);
+        if (esz == 0) {
+            if (log) fprintf(stderr, "[exec] indexed draw: UNKNOWN index_type=%u — falling back to non-indexed\n",
+                             ds.index_type);
+        } else if (!guest_readable(draw->index_addr, n * esz)) {
+            if (log) fprintf(stderr, "[exec] indexed draw: index buffer 0x%llx (%u x %uB) unreadable — "
+                             "falling back to non-indexed\n",
+                             (unsigned long long)draw->index_addr, n, esz);
+        } else {
+            out.indices.resize(n);
+            uint32_t max_index = 0;
+            if (esz == 2) {
+                const uint16_t* src = (const uint16_t*)(uintptr_t)draw->index_addr;
+                for (uint32_t i = 0; i < n; i++) { out.indices[i] = src[i]; max_index = std::max(max_index, out.indices[i]); }
+            } else {
+                const uint32_t* src = (const uint32_t*)(uintptr_t)draw->index_addr;
+                for (uint32_t i = 0; i < n; i++) { out.indices[i] = src[i]; max_index = std::max(max_index, out.indices[i]); }
+            }
+            // Vertex count = the indexed range (max index + 1), bounded by the bound VB's record count
+            // (an index past the VB reads 0 under robustBufferAccess — same degenerate-vertex fallback).
+            vertex_count = max_index + 1;
+            if (vb_entries && vertex_count > vb_entries) vertex_count = vb_entries;
+        }
+    }
+    if (out.indices.empty() && vb_entries > vertex_count) vertex_count = vb_entries;
     out.vs = std::move(vs); out.fs = std::move(fs); out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
     return true;
 }
 
 // Recompile + resolve a GpuState's draws and render them via `render`. Default: ONE item from the folded
-// end state (the fullscreen-quad fan fills the current title composite). PROSPER_PERDRAW=1: ONE item per
-// draw, each realized from ITS OWN register snapshot (Draw::state), so per-draw masks/blends/shaders
-// composite correctly — the path for multi-geometry scenes (opt-in until the AGC context-log section
-// semantics that stage duplicate register writes are fully RE'd; see docs/REAL_FRAMES_FINDINGS.md).
+// end state, realized as the submit's LAST draw — the folded register file IS the state at the last
+// draw, so that is the one draw record (count + index buffer) coherent with it. (The pre-#64 code paired
+// the end state with draws[0]'s count instead, and needed a "4-record VB -> TRIANGLE_FAN" heuristic to
+// paper over the mismatch; the title composite is in fact the submit's last draw, a 6-index DrawIndex
+// quad, which now renders through the real indexed path.) PROSPER_PERDRAW=1: ONE item per draw, each
+// realized from ITS OWN register snapshot (Draw::state), so per-draw masks/blends/shaders composite
+// correctly — the path for multi-geometry scenes (opt-in until the AGC context-log section semantics
+// that stage duplicate register writes are fully RE'd; see docs/REAL_FRAMES_FINDINGS.md).
 // `max_shader_dwords` bounds the recompiler's walk (it stops at S_ENDPGM).
-// Indexed draws (Draw::indexed, from sceAgcDcbDrawIndex): the index buffer (Draw::index_addr +
-// the snapshot's index_type) is carried on the draw record but NOT consumed yet — these render
-// exactly like a DrawIndexAuto with the same count (the fan heuristic above included). Wiring the
-// index buffer into vertex fetch (and retiring the quad-fan hack) is issue #64.
 inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
                                              uint32_t max_shader_dwords = 0x10000) {
     if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
@@ -141,21 +185,24 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
     if (perdraw) {
         for (size_t i = 0; i < st.draws.size(); i++) {
             DrawItem it;
-            if (realize_draw_item(st.state_at_draw(i), st.draws[i].index_count, max_shader_dwords, log, it))
+            if (realize_draw_item(st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
+                                  max_shader_dwords, log, it))
                 items.push_back(std::move(it));
         }
     } else {
-        // Default: render the submit's composite from the folded end state as a single item (the fan
-        // heuristic fills the fullscreen quad). Preserves the merged single-draw behavior exactly.
+        // Default: render the submit's last draw from the folded end state as a single item.
         DrawItem it;
-        uint32_t vcount = st.draws.empty() ? 3u : st.draws[0].index_count;
-        if (realize_draw_item(st, vcount, max_shader_dwords, log, it)) items.push_back(std::move(it));
+        const GpuState::Draw& last = st.draws.back();
+        if (realize_draw_item(st, &last, last.index_count, max_shader_dwords, log, it))
+            items.push_back(std::move(it));
     }
     if (getenv("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu perdraw=%d -> %zu item(s): raw index_counts=[",
         st.draws.size(), (int)perdraw, items.size());
-        for (size_t i = 0; i < st.draws.size(); i++) fprintf(stderr, "%s%u", i?",":"", st.draws[i].index_count);
+        for (size_t i = 0; i < st.draws.size(); i++) fprintf(stderr, "%s%u%s", i?",":"", st.draws[i].index_count,
+                                                             st.draws[i].indexed ? "i" : "");
         fprintf(stderr, "] items:");
-        for (auto& it : items) fprintf(stderr, " (vcount=%u topo=%u mask=0x%x)", it.vertex_count, it.ps.topology, it.ps.color_write_mask);
+        for (auto& it : items) fprintf(stderr, " (vcount=%u nidx=%zu topo=%u mask=0x%x)",
+                                       it.vertex_count, it.indices.size(), it.ps.topology, it.ps.color_write_mask);
         fprintf(stderr, "\n"); fflush(stderr); }
     if (items.empty()) return {};
     if (log) fprintf(stderr, "[exec] rendering %zu draw item(s) (of %zu draws)\n", items.size(), st.draws.size());

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -85,6 +85,11 @@ struct BackendDraw {
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
     uint32_t vcount = 3;
+    // Indexed draw: 32-bit index data (the executor widens guest 16-bit indices). Non-empty -> the draw
+    // is recorded as vkCmdBindIndexBuffer + vkCmdDrawIndexed(indices.size()), so gl_VertexIndex is the
+    // fetched index — exactly what the recompiled VS's storage-buffer vertex fetch expects. Empty ->
+    // plain vkCmdDraw(vcount).
+    std::vector<uint32_t> indices;
 };
 
 inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H) {
@@ -193,7 +198,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         std::vector<VkBuffer> sbuf, tstage; std::vector<VkDeviceMemory> sbmem, tmem, tstagemem;
         std::vector<VkImage> timg; std::vector<VkImageView> tview; std::vector<VkSampler> tsamp;
         VkPipelineLayout layout = VK_NULL_HANDLE; VkPipeline pipe = VK_NULL_HANDLE;
-        uint32_t n_sets = 1, vcount = 3; bool use_desc = false, ok = false;
+        VkBuffer ibuf = VK_NULL_HANDLE; VkDeviceMemory ibmem = VK_NULL_HANDLE;   // index buffer (indexed draws)
+        uint32_t n_sets = 1, vcount = 3, icount = 0; bool use_desc = false, ok = false;
     };
     std::vector<DV> dv(draws.size());
     // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
@@ -204,6 +210,21 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (!v.vs || !v.fs) continue;   // rejected SPIR-V -> skip this draw
         const prosper::gpu::ResolvedPipelineState* ps = bd.ps;
         v.vcount = bd.vcount;
+        // Indexed draw: upload the 32-bit index data to a host-visible VkIndexBuffer now; the record
+        // pass binds it and issues vkCmdDrawIndexed instead of vkCmdDraw.
+        if (!bd.indices.empty()) {
+            VkDeviceSize isz = (VkDeviceSize)bd.indices.size() * 4;
+            VkBufferCreateInfo ibci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+            ibci.size = isz; ibci.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+            vkCreateBuffer(dev, &ibci, nullptr, &v.ibuf);
+            VkMemoryRequirements imr; vkGetBufferMemoryRequirements(dev, v.ibuf, &imr);
+            VkMemoryAllocateInfo imai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; imai.allocationSize = imr.size;
+            imai.memoryTypeIndex = pick(imr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            vkAllocateMemory(dev, &imai, nullptr, &v.ibmem); vkBindBufferMemory(dev, v.ibuf, v.ibmem, 0);
+            void* ip = nullptr; vkMapMemory(dev, v.ibmem, 0, isz, 0, &ip);
+            std::memcpy(ip, bd.indices.data(), (size_t)isz); vkUnmapMemory(dev, v.ibmem);
+            v.icount = (uint32_t)bd.indices.size();
+        }
         VkPipelineShaderStageCreateInfo st[2]{};
         st[0] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[0].stage = VK_SHADER_STAGE_VERTEX_BIT; st[0].module = v.vs; st[0].pName = "main";
         st[1] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT; st[1].module = v.fs; st[1].pName = "main";
@@ -376,7 +397,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (!v.ok) continue;
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
-        vkCmdDraw(cmd, v.vcount, 1, 0, 0);
+        if (v.icount) {
+            vkCmdBindIndexBuffer(cmd, v.ibuf, 0, VK_INDEX_TYPE_UINT32);
+            vkCmdDrawIndexed(cmd, v.icount, 1, 0, 0, 0);
+        } else {
+            vkCmdDraw(cmd, v.vcount, 1, 0, 0);
+        }
     }
     vkCmdEndRenderPass(cmd);
     VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {W, H, 1};
@@ -395,6 +421,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (auto& v : dv) {   // per-draw objects
         if (v.pipe)   vkDestroyPipeline(dev, v.pipe, nullptr);
         if (v.layout) vkDestroyPipelineLayout(dev, v.layout, nullptr);
+        if (v.ibuf)   vkDestroyBuffer(dev, v.ibuf, nullptr);
+        if (v.ibmem)  vkFreeMemory(dev, v.ibmem, nullptr);
         if (v.vs)     vkDestroyShaderModule(dev, v.vs, nullptr);
         if (v.fs)     vkDestroyShaderModule(dev, v.fs, nullptr);
         if (v.dpool)  vkDestroyDescriptorPool(dev, v.dpool, nullptr);

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -73,6 +73,47 @@ int main() {
     GpuState empty; empty.draws.clear();
     CHECK(execute_gpustate(empty, backend).empty(), "a draw-less GpuState renders no frame (state-only submit)");
 
+    // --- Indexed draws through the executor (issue #64) -------------------------------------------------
+    // realize_draw_item fetches a REAL 16-bit guest index buffer (index_type 0, the SetIndexType reset
+    // default this title relies on) and the backend renders it with vkCmdDrawIndexed — gl_VertexIndex is
+    // then the FETCHED index. kVs computes the fullscreen triangle from gl_VertexIndex, so indices
+    // {0,1,2} reproduce the non-indexed green frame exactly, while degenerate indices {0,0,0} collapse
+    // the triangle and leave the frame blue (clear) — proving the index data actually drives the draw.
+    auto backend_idx = [&](const std::vector<DrawItem>& items) -> std::vector<uint8_t> {
+        if (items.empty()) return {};
+        prosper::test::BackendDraw d;
+        d.vs = items[0].vs; d.fs = items[0].fs; d.ps = &items[0].ps;
+        d.vcount = items[0].vertex_count; d.indices = items[0].indices;
+        return prosper::test::render_draws_rgba({std::move(d)}, W, H);
+    };
+    static const uint16_t kIdx012[3] = {0, 1, 2};
+    static const uint16_t kIdx000[3] = {0, 0, 0};
+    GpuState sti = st;
+    sti.index_type = 0;   // 16-bit
+    auto set_indexed = [&](const uint16_t* idx, uint32_t n) {
+        GpuState::Draw d; d.index_count = n; d.indexed = true;
+        d.index_addr = (uint64_t)(uintptr_t)idx;
+        sti.draws.clear(); sti.draws.push_back(d);
+    };
+    set_indexed(kIdx012, 3);
+    std::vector<uint8_t> pxi = execute_gpustate(sti, backend_idx);
+    CHECK(pxi.size() == px.size() && pxi == px,
+          "16-bit indexed draw {0,1,2} renders the SAME green frame as the non-indexed triangle");
+    set_indexed(kIdx000, 3);
+    std::vector<uint8_t> pxz = execute_gpustate(sti, backend_idx);
+    bool all_blue = pxz.size() == (size_t)W * H * 4;
+    if (all_blue) for (uint32_t y : {0u, H/2, H-1}) for (uint32_t x : {0u, W/2, W-1}) {
+        const uint8_t* p = &pxz[((size_t)y*W+x)*4];
+        if (!(p[2] > 0x80 && p[0] < 0x40 && p[1] < 0x40)) all_blue = false;
+    }
+    CHECK(all_blue, "degenerate indices {0,0,0} collapse the triangle (frame stays clear-blue)");
+    // Unknown index element size -> loud fallback to a NON-indexed draw of the hint count (never
+    // misread the buffer): with kVs that is the plain fullscreen triangle again.
+    set_indexed(kIdx012, 3);
+    sti.index_type = 7;   // no such encoding (0=16-bit, 1=32-bit)
+    std::vector<uint8_t> pxu = execute_gpustate(sti, backend_idx);
+    CHECK(pxu == px, "unknown index_type falls back to a non-indexed draw of the hint count");
+
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");

--- a/prosper/tests/test_indexed_render.cpp
+++ b/prosper/tests/test_indexed_render.cpp
@@ -1,0 +1,102 @@
+// test_indexed_render — REAL indexed draws (issue #64): the render backend consumes a BackendDraw's
+// index data via vkCmdBindIndexBuffer + vkCmdDrawIndexed, so gl_VertexIndex IS the fetched index and
+// the recompiled VS's storage-buffer vertex fetch pulls the right records whatever the vertex order.
+//
+// Case A — the retired quad-fan heuristic's contract: a 4-vertex quad VB in perimeter order
+// (BL,TL,TR,BR) drawn with the 6-entry index list [0,1,2, 2,3,0] as TRIANGLE_LIST must produce
+// EXACTLY the pixels the old "4-record VB -> TRIANGLE_FAN" hack produced (byte-identical frames).
+// This is the live title composite's shape: a DrawIndex quad with 6 x 16-bit indices.
+//
+// Case B — indices are actually applied: indices [1,2,3] select the fullscreen triangle stored at VB
+// records 1..3 (record 0 is an off-screen decoy). A path that ignored the indices would draw records
+// 0..2 instead and leave the sampled corners blue.
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include "../src/gpu/render_state.hpp"
+#include "render_runner.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_indexed_render ==\n");
+    const uint32_t W = 64, H = 64;
+
+    // Vertex-fetch VS (llvm-mc gfx1030, same blob as test_vertex_fetch_render): fetch (x,y) from the
+    // vertex buffer indexed by vid, pos=(x,y,0,1). Green PS.
+    const uint32_t vs[] = {
+        0x7e060280u, 0x7e0802f2u, 0xe0042000u, 0x80020100u, 0xf80008cfu, 0x04030201u, 0xbf810000u,
+    };
+    const uint32_t ps[] = { 0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u };
+
+    ShaderResourceTable rt;
+    ShaderResource vb{};
+    vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32; vb.num_components = 2;
+    vb.binding = 3; vb.stride = 8; vb.sgpr_base = 8;
+    rt.resources.push_back(vb);
+
+    std::vector<uint32_t> vert = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &rt);
+    std::vector<uint32_t> frag = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+    CHECK(!vert.empty() && !frag.empty(), "recompiled vertex-fetch VS + green PS");
+    if (vert.empty() || frag.empty()) { printf("== FAIL ==\n"); return 1; }
+
+    auto f = [](float v) { union { float f; uint32_t u; } c; c.f = v; return c.u; };
+    auto isGreen = [&](const std::vector<uint8_t>& px, uint32_t x, uint32_t y) {
+        const uint8_t* p = &px[((size_t)y * W + x) * 4];
+        return p[1] > 0x80 && p[0] < 0x40 && p[2] < 0x40;
+    };
+    auto greenAt9 = [&](const std::vector<uint8_t>& px) {   // 9-point sample grid, all green?
+        const uint32_t xs[] = {0, W/2, W-1}, ys[] = {0, H/2, H-1};
+        uint32_t g = 0; for (uint32_t y : ys) for (uint32_t x : xs) if (isGreen(px, x, y)) g++;
+        return g == 9u;
+    };
+    auto draw_of = [&](const std::vector<uint32_t>& vbuf, const ResolvedPipelineState* st,
+                       uint32_t vcount, std::vector<uint32_t> idx) {
+        prosper::test::BackendDraw d;
+        d.vs = vert; d.fs = frag; d.ps = st; d.vcount = vcount; d.indices = std::move(idx);
+        prosper::test::FrameResource r; r.binding = 3; r.set = 0; r.dwords = vbuf;
+        d.R.push_back(std::move(r));
+        return d;
+    };
+
+    // --- Case A: indexed quad (TRIANGLE_LIST, indices [0,1,2, 2,3,0]) == old fan path, pixel-exact ---
+    // Full-viewport quad, perimeter order BL,TL,TR,BR (the order the fan heuristic assumed).
+    std::vector<uint32_t> quad = { f(-1.f), f(-1.f),   f(-1.f), f(1.f),
+                                   f( 1.f), f( 1.f),   f( 1.f), f(-1.f) };
+    ResolvedPipelineState list_ps; list_ps.topology = 3;   // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+    ResolvedPipelineState fan_ps;  fan_ps.topology  = 5;   // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN
+
+    std::vector<uint8_t> px_idx = prosper::test::render_draws_rgba(
+        { draw_of(quad, &list_ps, 4, {0,1,2, 2,3,0}) }, W, H);
+    std::vector<uint8_t> px_fan = prosper::test::render_draws_rgba(
+        { draw_of(quad, &fan_ps, 4, {}) }, W, H);
+    CHECK(px_idx.size() == (size_t)W*H*4 && px_fan.size() == (size_t)W*H*4, "both quad renders produced frames");
+    if (px_idx.size() != (size_t)W*H*4 || px_fan.size() != (size_t)W*H*4) { printf("== FAIL ==\n"); return 1; }
+    CHECK(greenAt9(px_idx), "indexed [0,1,2,2,3,0] TRIANGLE_LIST quad fills the viewport GREEN");
+    CHECK(px_idx == px_fan, "indexed quad is byte-identical to the old perimeter-fan rendering");
+
+    // --- Case B: indices select records 1..3 (fullscreen triangle); record 0 is an off-screen decoy ---
+    std::vector<uint32_t> vbufB = { f(9.f), f(9.f),                     // rec 0: decoy (off-screen)
+                                    f(-1.f), f(-1.f), f(3.f), f(-1.f), f(-1.f), f(3.f) };  // recs 1..3
+    std::vector<uint8_t> px_tri = prosper::test::render_draws_rgba(
+        { draw_of(vbufB, &list_ps, 4, {1,2,3}) }, W, H);
+    CHECK(px_tri.size() == (size_t)W*H*4, "indexed triangle rendered");
+    if (px_tri.size() != (size_t)W*H*4) { printf("== FAIL ==\n"); return 1; }
+    CHECK(greenAt9(px_tri), "indices [1,2,3] fetched records 1..3 (fullscreen GREEN triangle)");
+    // Negative control: the same draw WITHOUT indices draws records 0..2 (decoy included) — a different
+    // picture. Guards against a backend that silently ignores the index buffer.
+    std::vector<uint8_t> px_noidx = prosper::test::render_draws_rgba(
+        { draw_of(vbufB, &list_ps, 3, {}) }, W, H);
+    CHECK(px_noidx.size() == (size_t)W*H*4 && px_noidx != px_tri,
+          "dropping the indices changes the picture (indices are really applied)");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -407,9 +407,13 @@ int main(int argc, char** argv) {
                     bd.vcount = refvs ? 3u : it.vertex_count;
                     bd.ps     = nops ? nullptr : &it.ps;
                     bd.R      = build_R(it.vrt.get(), it.prt.get());
+                    // Indexed draw: hand the executor-fetched index data to the backend (vkCmdDrawIndexed).
+                    // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
+                    if (!refvs) bd.indices = it.indices;
                     if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
-                        "[render] item %zu: %zu resources vcount=%u topo=%u mask=0x%x blend=%d\n",
-                        bds.size(), bd.R.size(), bd.vcount, it.ps.topology, it.ps.color_write_mask, (int)it.ps.blend_enable);
+                        "[render] item %zu: %zu resources vcount=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
+                        bds.size(), bd.R.size(), bd.vcount, bd.indices.size(), it.ps.topology,
+                        it.ps.color_write_mask, (int)it.ps.blend_enable);
                     bds.push_back(std::move(bd));
                 }
                 std::vector<uint8_t> px = prosper::test::render_draws_rgba(bds, w, h);


### PR DESCRIPTION
## What

Implements real index-buffer support for `sceAgcDcbDrawIndex` draws in the GPU executor and **deletes** the `4-record VB -> vertex_count=4 TRIANGLE_FAN` heuristic plus the `PROSPER_VCOUNT`/`PROSPER_TOPO` env overrides it came with (issue #64). Builds on #63/#80's `R_DRAW_INDEX` decode.

**Strategy: real `VkIndexBuffer` + `vkCmdDrawIndexed`** (not CPU index expansion). The renderer does shader-side vertex fetch from storage buffers keyed on `gl_VertexIndex`, and with `vkCmdDrawIndexed` `gl_VertexIndex` *is* the fetched index — so the indexed path needed no shader or descriptor changes, just an index buffer bind.

- `gpu_execute.hpp`: `realize_draw_item` takes the PM4 draw record; for `indexed` draws it bounds-checks (`guest_readable`) and fetches the guest index buffer, widening to 32-bit on the `DrawItem`. Element size from `GpuState::index_type`: `0`=16-bit, `1`=32-bit (Kyty `index_type_and_size`, GraphicsRender.cpp:4724; also the hardware reset default). Unknown encodings fall back **loudly** to a non-indexed draw rather than misreading the buffer. Vertex count for indexed draws = max index + 1, bounded by the bound VB's record count.
- The folded default path now realizes the submit's **last** draw record — the folded register file is the state *at* the last draw, so record and registers are coherent. (The old code paired the end state with `draws[0]`'s count; that mismatch is what the fan hack papered over.)
- `render_runner.h` (`BackendDraw.indices`) + `boot_trace` live renderer: bind a `VkIndexBuffer`, record `vkCmdDrawIndexed`.

## What the live boot showed (why the heuristic could go)

`PROSPER_GFXLOG` packet dumps of the title loop:

- The title composite is a **`DrawIndex` quad with a 6-entry 16-bit index buffer** — consecutive quad index streams are 12 bytes apart (6 x 2 bytes), confirming 16-bit. It is the **last** draw of its submit.
- `DrawIndexAuto` appears only as `count=3` fullscreen-triangle passes.
- The game **never emits `SetIndexType`** — it relies on the 16-bit reset default (matches Kyty's `m_index_type_and_size = 0`).
- A title submit is `[3, 3, 6i, 6i, 6i, 6i, 6i, 6i, 6i, 6i, 1566i]` — the sprite-quad `6i` draws are exactly the "bread and butter" meshes the issue said the fan hack would corrupt.

## Verification

- **ctest 47/47** (WSL llvmpipe), including new `test_indexed_render`: the `[0,1,2, 2,3,0]` indexed `TRIANGLE_LIST` quad renders **byte-identical** to the old perimeter-fan output, and an index-selection case (decoy record 0, indices `[1,2,3]`) proves indices are really applied. `test_gpu_execute` grows executor-level cases: 16-bit fetch reproduces the non-indexed frame, degenerate indices `{0,0,0}` collapse it, unknown `index_type` falls back non-indexed.
- **Live smoke** (`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`, 1/4 scale, 90 s): 260 frames rendered; indexed draws flow (`nidx=6/24/12/528/1566`, real decoded topology `TRIANGLE_LIST`).
- **Pixel-hash vs baseline** (git-stash rebuild technique): the stable post-fade frame is **byte-identical** to the pre-change build — md5 `cd6fed5f4fd60f97b7d98402c6dd58ab` over dozens of consecutive frames in both builds — and the intro-art fade frames match the baseline sequence at mean |diff| 1.2/255 (fade-step alignment between runs).
- Note: with mask==0 wait-loop submits no longer realized against a stale `draws[0]` record, the run skips them quickly (they present nothing, per the existing `color_write_mask==0` skip), so the boot reaches the title faster; the rendered content is unchanged.

Fixes #64