### PR TITLE
fix(gpu/exec): render The Messenger's title screen + intro cutscene (per-draw + viewport-scale)

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -180,7 +180,16 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
                                              uint32_t max_shader_dwords = 0x10000) {
     if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
     const bool log = getenv("PROSPER_GFXLOG") != nullptr;    // bail-point visibility (why no frame?)
-    static const bool perdraw = getenv("PROSPER_PERDRAW") != nullptr;
+    // Render each draw from its OWN register snapshot when the submit has MULTIPLE draws — a real
+    // multi-geometry scene (the game's in-game/cutscene submits carry 8-11 distinct draws with per-draw
+    // shaders/textures/blends). Folding those to just the last draw drops the rest and the frame comes out
+    // as the bare clear; per-draw rendering makes the intro cutscene's real content appear (black scene +
+    // its geometry) instead of a blank blue clear. A single-draw submit stays folded (nothing to composite).
+    // Overridable: PROSPER_PERDRAW forces per-draw always, PROSPER_FOLDED forces the old single-item path.
+    // CONFIDENCE: MED — verified multi-draw scenes render their content per-draw vs. a blank clear folded.
+    static const bool force_perdraw = getenv("PROSPER_PERDRAW") != nullptr;
+    static const bool force_folded  = getenv("PROSPER_FOLDED") != nullptr;
+    const bool perdraw = force_perdraw || (!force_folded && st.draws.size() > 1);
     std::vector<DrawItem> items;
     if (perdraw) {
         for (size_t i = 0; i < st.draws.size(); i++) {


### PR DESCRIPTION
Two complementary executor fixes that together make The Messenger's title screen render in full and its intro cutscene render correctly framed.

## 1. Render multi-draw submits per-draw (4ea43d3)
The default executor folded every submit onto a single item (the last draw's state) — correct for a one-draw composite, but the game's scene/cutscene submits carry 8-11 distinct draws (per-draw shaders/textures/blends). Folding dropped all but one and produced a bare clear. Now: per-draw when a submit has >1 draw; folded for single-draw. `PROSPER_PERDRAW` forces per-draw always, `PROSPER_FOLDED` the old path.

## 2. Scale the guest viewport to the render framebuffer (606ad36)
The guest programs `PA_CL_VPORT` in full present-resolution pixels. When rendering into a reduced-resolution framebuffer (`PROSPER_RENDER_SCALE`, used so the synchronous llvmpipe render doesn't stall the guest submit thread), the viewport stayed full-size — so geometry drew at full-res coordinates into the smaller framebuffer, clipping to the **bottom-left corner**. `execute_and_present` now scales each draw's resolved viewport by the framebuffer/present ratio (preserving the negative-height Y-flip). Default 1.0 (full-res / tests): no change.

## Result
- **Title screen renders in full** — THE MESSENGER logo, the ninja over the moon, the demon horde — vs. the bottom-left crop before.
- **Intro cutscene correctly framed** — black letterbox + the wide blue island centered in the middle, matching real hardware. (The island's *texture* is still scrambled; texture-decode/render-to-texture is the next step, #83.)
- Before per-draw: the post-loading phase was 124/136 frames the pure-blue clear.

Builds clean; all GPU/render ctests green (the 1 failing test is the pre-existing #26 boot regression, #89, unrelated).

Refs #83.