### PR TITLE
fix(gpu/recompiler): resolve SRSRC for untyped MUBUF ops — never silently binding 2

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1679,8 +1679,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             uint32_t offset = in.literal & 0xFFFu;
             bool offen = (in.literal >> 12) & 1u, idxen = (in.literal >> 13) & 1u;
-            uint32_t binding = 2, stride = 0;   // untyped buffer_load defaults to binding 2 (compute cbuf);
-                                                // a format load (vertex fetch) overrides with its V#'s binding
+            uint32_t binding = 2, stride = 0;   // overwritten by SRSRC resolution below whenever a resource
+                                                // table is present (format AND raw ops); the binding-2 default
+                                                // survives only on the table-less offline path (see below)
             // Format of the fetched components. Untyped buffer_load_dword* is raw 32-bit (comp_bytes=4);
             // buffer_load_format_* takes the format from the resolved V# descriptor.
             DataFormat fmt = DataFormat::Uint32;   // untyped default: raw dwords
@@ -1704,7 +1705,27 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 binding = res->binding;
                 stride = res->stride;
                 fmt = res->format;
+            } else if (rt) {
+                // RAW (untyped) MUBUF with a resource table: resolve SRSRC (src[1]) exactly like the
+                // format path — a raw buffer op targets whatever buffer its V# describes, NOT a fixed
+                // binding (#91: the old hardcoded binding-2 silently read/wrote the wrong buffer for
+                // any other target). Raw ops don't imply a resource class the way a format load implies
+                // VertexBuffer, so the direct-SGPR lookup is class-unrestricted (by_sgpr_base).
+                // Provenance order mirrors the format path: exact fetch pc, then s_load SRT tag
+                // (indirect), then user-data SGPR (direct).
+                const ShaderResource* res = rt->by_fetch_pc(in.pc);
+                if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
+                    if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
+                if (!res) res = rt->by_sgpr_base(in.src[1].value);
+                if (!res) { ok = false; return true; }   // unresolvable V# -> reject; NEVER default to binding 2
+                binding = res->binding;
+                stride  = res->stride;
+                // fmt stays raw Uint32: untyped ops move raw dwords regardless of the V#'s declared format.
             }
+            // else (rt == nullptr): table-less offline compute shell (recompile_valu without a resource
+            // table — the unit-test harness). Keep the legacy single-cbuf convention: binding 2, stride 0.
+            // The live graphics path can never reach here table-less: recompile_vertex/recompile_fragment
+            // set allow_smem = (rt != nullptr), so MUBUF already rejected above when rt is null there.
             const uint32_t comp_bytes = data_format_bytes(fmt);
             if (comp_bytes == 0) { ok = false; return true; }   // unknown / unsupported format
             // Per-component decode. 4-byte formats (Float32/Uint32/Sint32) are a raw dword load — no

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1183,6 +1183,55 @@ int main() {
     printf("  kernel65 mismatches=%u (out[9]=%g exp=%g)\n", bad65, got65.size()==N?got65[9]:-1, exp65[9]);
     CHECK(got65.size()==N && bad65==0, "recompiled kernel 65 (v_mbcnt -1 = localid) correct");
 
+    // Kernel 66: RAW MUBUF SRSRC RESOLUTION (#91). Same code as kernel 21 (buffer_load_dword v0, v0
+    // offen, SRSRC s[8:11]) but WITH a resource table mapping s[8:11] -> binding 3. The load must
+    // route to binding 3 (cbuf1), not the old hardcoded binding 2 — binding 2 (cbuf0) is bound with
+    // DECOY values, so any binding-2 read fails the value check.
+    const uint32_t code66[] = {
+        0x7e000f00u, 0x34000082u, 0xe0301000u, 0x80020000u, 0x7e000d00u, 0xbf810000u,
+    };
+    ShaderResourceTable rt66;
+    { ShaderResource rb{}; rb.cls = ResourceClass::ConstantBuffer; rb.format = DataFormat::Float32;
+      rb.num_components = 1; rb.binding = 3; rb.stride = 0; rb.sgpr_base = 8; rt66.resources.push_back(rb); }
+    std::vector<uint32_t> spv66 = recompile_valu(code66, sizeof(code66)/sizeof(code66[0]), 1, 0, &rt66);
+    CHECK(!spv66.empty(), "recompiled kernel 66 (raw buffer_load_dword, SRSRC via table -> binding 3) -> SPIR-V");
+    std::vector<float> in66(N); std::vector<uint32_t> decoy66(N, 0xDEADu), buf66(N);
+    for (uint32_t i = 0; i < N; i++) { in66[i] = (float)i; buf66[i] = 500u + i; }
+    std::vector<float> got66 = prosper::test::run_compute(spv66, in66, N, N, /*binding2=decoy*/decoy66, /*binding3*/buf66);
+    uint32_t bad66 = 0; for (uint32_t i=0;i<N&&got66.size()==N;i++) if (std::fabs(got66[i]-(float)(500u+i))>1e-3f) bad66++;
+    printf("  kernel66 mismatches=%u (out[7]=%g expect=507)\n", bad66, got66.size()==N?got66[7]:-1);
+    CHECK(got66.size()==N && bad66==0, "recompiled kernel 66 (raw load resolves SRSRC -> binding 3, not binding 2) correct");
+
+    // Kernel 67: RAW MUBUF UNRESOLVABLE SRSRC -> REJECT (#91). Same code, but the table's only
+    // resource lives at sgpr_base 4 — SRSRC s[8:11] resolves to nothing. With a table present the
+    // recompiler must reject (empty SPIR-V), never silently fall back to binding 2.
+    ShaderResourceTable rt67;
+    { ShaderResource rb{}; rb.cls = ResourceClass::ConstantBuffer; rb.format = DataFormat::Float32;
+      rb.num_components = 1; rb.binding = 3; rb.stride = 0; rb.sgpr_base = 4; rt67.resources.push_back(rb); }
+    std::vector<uint32_t> spv67 = recompile_valu(code66, sizeof(code66)/sizeof(code66[0]), 1, 0, &rt67);
+    CHECK(spv67.empty(), "kernel 67 (raw MUBUF, table present, SRSRC unresolvable) REJECTED (no binding-2 fallback)");
+
+    // Kernel 68: RAW MUBUF STORE via the table (#91 store side). v2=(uint)gid; v3=2*float(gid);
+    // buffer_store_dword v3, v2, s[8:11] idxen (op 0x1C) -> table maps s[8:11] to binding 3, stride 4
+    // => buf[gid] = bits(2*gid). The old code stored these into binding 2, corrupting the wrong buffer.
+    const uint32_t code68[] = { 0x7e040f00u, 0x06060100u, 0xe0702000u, 0x80020302u, 0xbf810000u };
+    ShaderResourceTable rt68;
+    { ShaderResource rb{}; rb.cls = ResourceClass::ConstantBuffer; rb.format = DataFormat::Float32;
+      rb.num_components = 1; rb.binding = 3; rb.stride = 4; rb.sgpr_base = 8; rt68.resources.push_back(rb); }
+    std::vector<uint32_t> spv68 = recompile_valu(code68, sizeof(code68)/sizeof(code68[0]), 1, 0, &rt68);
+    CHECK(!spv68.empty(), "recompiled kernel 68 (raw buffer_store_dword, SRSRC via table -> binding 3) -> SPIR-V");
+    std::vector<float> in68(N); for (uint32_t i = 0; i < N; i++) in68[i] = (float)i;
+    std::vector<uint32_t> stored68(N, 0), stored68_out;
+    prosper::test::run_compute(spv68, in68, N, N, /*binding2*/{}, /*binding3=store target*/stored68, &stored68_out);
+    uint32_t bad68 = 0;
+    for (uint32_t i = 0; i < N && stored68_out.size() == N; i++) {
+        float f; std::memcpy(&f, &stored68_out[i], 4);
+        if (std::fabs(f - 2.0f*(float)i) > 1e-3f) bad68++;
+    }
+    { float f6 = 0; if (stored68_out.size()==N) std::memcpy(&f6, &stored68_out[6], 4);
+      printf("  kernel68 mismatches=%u (buf[6]=%g expect=12)\n", bad68, f6); }
+    CHECK(stored68_out.size() == N && bad68 == 0, "recompiled kernel 68 (raw store routes to binding 3 via SRSRC) correct");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #91

## Problem

In `rdna2_to_spirv.cpp`, the SRSRC binding-resolution block in the MUBUF case ran only for `is_format` ops. Raw/untyped ops (`buffer_load_dword/x2/x4`, `buffer_store_dword/x2/x4`) never resolved their SRSRC V# descriptor and always read/wrote hardcoded **binding 2** ("compute cbuf"). A raw op whose V# describes any other buffer silently read wrong data — and a raw store silently corrupted the binding-2 buffer while the real target stayed unwritten.

## Fix

Untyped MUBUF now mirrors the format-load SRSRC resolution through the resource table:

- Provenance order matches the format path: `by_fetch_pc` (exact pc), then s_load SRT tag → `by_srt_offset` (indirect), then `by_sgpr_base` (direct user-data). The direct lookup is **class-unrestricted** — a raw op doesn't imply VertexBuffer the way a format load does; it targets whatever its V# describes.
- `binding` AND `stride` (for idxen addressing) come from the resolved resource. `fmt` stays raw Uint32 — untyped ops move raw dwords regardless of the V#'s declared format.
- **Table present + unresolvable SRSRC → reject (`ok=false`)**, never a silent binding-2 default.

## Fallback scoping (care point from the issue)

The legacy binding-2 convention survives **only when `rt == nullptr`** — the table-less offline compute shells (`recompile_valu` in the unit tests, e.g. execution kernel 21), with an explicit comment at the site. The live graphics path can never reach that branch table-less: `recompile_vertex` / `recompile_fragment` set `allow_smem = (rt != nullptr)`, so MUBUF is already rejected there when no table exists (verified at the `emit_body` call sites).

## Tests (execution kernels 66–68, `test_rdna2_to_spirv`)

- **66**: raw `buffer_load_dword` (SRSRC s[8:11]) with a table mapping it to **binding 3**; binding 2 is bound with decoy values, so any binding-2 read fails the value assertions. Executed on real Vulkan compute; values correct.
- **67**: table present, SRSRC resolves to nothing (resource at sgpr_base 4, op uses s[8:11]) → recompile **rejected** (empty SPIR-V).
- **68**: raw `buffer_store_dword` idxen routed via the table to binding 3 (stride 4), stored buffer read back and asserted `buf[gid] = 2*gid`.

## Verification

- WSL build clean; **ctest 47/47 green**.
- Live render smoke (`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`, 45–60 s): **65–80 frames rendered at 1920x1080**; `PROSPER_GFXLOG=1` shows **zero** `recompile failed` skips (the only skips are pre-existing `color_write_mask==0` no-ops) — shader-skip count did not increase (it is 0, as before).