### PR TITLE
fix(hle/apr): APR rsp-capture must not be __thread — static-TLS growth crashed the minimal boot

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -501,15 +501,27 @@ HLE(f_apr_resolve) {
 extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
 
 #ifndef _WIN32
-extern "C" __thread uint64_t g_apr_entry_rsp;
-__thread uint64_t g_apr_entry_rsp = 0;
+// MUST NOT be `__thread` (issue #89). An initial-exec thread-local here (`%fs:...@tpoff`) grows the
+// HOST binary's static TLS block, and prosper's guest boot aliases the host TCB through %fs (the
+// guest runs on the host %fs in the non-GUEST_FS boot; the fault-recovery point was moved off
+// `__thread` to gettid-keyed globals for exactly this reason). Adding one static-TLS slot shifted
+// the layout enough to crash The Messenger's minimal boot before graphics init ~9 runs in 10 — a
+// clean bisect to 653cf6f. A plain global is captured on the SAME thread that immediately reads it
+// (the entry shim tail-jumps straight into the handler, which reads apr_stack_arg() first thing),
+// so it is correct as long as APR reads don't overlap across threads — they don't in practice: the
+// engine builds each sceAmprAprCommandBufferReadFile into its single Ampr command buffer and our
+// completion is synchronous. CONFIDENCE: HIGH on the fix (boot restored to 10/10); MED on the
+// serialized-APR assumption — if concurrent APR reads ever appear, key this by gettid (still NOT
+// __thread) rather than reintroducing static TLS.
+extern "C" uint64_t g_apr_entry_rsp;
+uint64_t g_apr_entry_rsp = 0;
 extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
                                         uint64_t a3, uint64_t a4, uint64_t a5);
 asm(".text\n"
     ".globl f_apr_read_submit_entry\n"
     ".type f_apr_read_submit_entry,@function\n"
     "f_apr_read_submit_entry:\n"
-    "  movq %rsp, %fs:g_apr_entry_rsp@tpoff\n"
+    "  movq %rsp, g_apr_entry_rsp(%rip)\n"
     "  jmp f_apr_read_submit_c\n");
 extern "C" void f_apr_read_submit_entry();
 // Fetch the Nth stack argument (0-based: arg7 is n=0) of the in-flight ReadFile call.

--- a/prosper/tests/test_boot_linux.cpp
+++ b/prosper/tests/test_boot_linux.cpp
@@ -8,6 +8,7 @@
 #include "../src/host/exec_image.hpp"
 #include "../src/hle/dispatch.hpp"
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <sys/mman.h>
 #include <sys/wait.h>
@@ -58,7 +59,20 @@ int main(int argc, char** argv) {
            (unsigned long long)prog.entry, prog.init_fns.size());
     pid_t pid = fork();
     if (pid == 0) { run_guest_inits(prog.init_fns); run_entry(prog.imgs[0]); _exit(0); }
-    for (int i = 0; i < 200; i++) { int st; if (waitpid(pid, &st, WNOHANG) == pid) break; struct timespec ts{0, 50 * 1000 * 1000}; nanosleep(&ts, nullptr); }
+    // Wait for the depth milestones, not a fixed wall-clock window. The guest reads the ~GB game
+    // dump over WSL's /mnt/c 9p mount, which on a COLD page cache is far slower than warm — the old
+    // fixed 200×50 ms = 10 s budget made this test flaky (issue #89): a cold first-of-session run
+    // could stall before graphics while a warm run reached gfx in ~1 s. Poll to a generous ceiling
+    // but BREAK as soon as the milestones (GC stop-the-world + a graphics-lib call) are met, so a
+    // warm run still finishes fast. PROSPER_BOOTTEST_TIMEOUT_MS overrides the ceiling for slow CI.
+    long ceil_ms = 60000;
+    if (const char* e = getenv("PROSPER_BOOTTEST_TIMEOUT_MS")) { long v = atol(e); if (v > 0) ceil_ms = v; }
+    const long tick_ms = 50;
+    for (long waited = 0; waited < ceil_ms; waited += tick_ms) {
+        int st; if (waitpid(pid, &st, WNOHANG) == pid) break;           // child exited on its own
+        if (*ex >= 1 && *gfx >= 1) break;                               // milestones reached — done early
+        struct timespec ts{ 0, tick_ms * 1000 * 1000 }; nanosleep(&ts, nullptr);
+    }
     int st; if (waitpid(pid, &st, WNOHANG) == 0) { kill(pid, SIGKILL); waitpid(pid, &st, 0); }
 
     int reached = *p;
@@ -66,27 +80,22 @@ int main(int argc, char** argv) {
     int gfxcalls = *gfx;
     printf("  guest reached %d distinct unimplemented system calls; %d GC stop-the-world exception(s); %d graphics-lib call(s)\n",
            reached, raises, gfxcalls);
-    // (1) unimpl count *drops* as we implement more functions (boot then advances to new, deeper
-    // calls) — so this is a floor, not a target. It reached 1 once sceKernelDlsym became a real
-    // by-name resolver (PSN.prx plugin path) — fewer *distinct* unimplemented calls, yet the boot
-    // now runs DEEPER (graphics + GC below, and the full boot reaches in-game levels). >=1 still
-    // proves the pipeline reached running game code; the graphics + GC milestones below are the
-    // real depth proof and are forward-compatible.
-    const int THRESHOLD = 1;
-    // (2) >=1 exception raise proves the boot got *through* the IL2CPP GC thread-suspension
-    // handshake (the deadlock we fixed) and ran the exception-based stop-the-world + stack scan.
-    // (3) >=1 graphics-lib call proves the boot ran the whole runtime into GPU/display init — the
-    // deepest reproducible milestone. Forward-compatible: stays true as deeper blockers are fixed.
-    bool pipeline = reached >= THRESHOLD;
+    // Pass gates on the two DEPTH milestones, which are forward-compatible (they stay true as deeper
+    // blockers are fixed):
+    // (1) >=1 GC stop-the-world exception proves the boot got *through* the IL2CPP GC thread-
+    //     suspension handshake (the deadlock we fixed) and ran the exception-based stop-the-world.
+    // (2) >=1 graphics-lib call proves the boot ran the whole runtime into GPU/display init.
+    // The distinct-unimplemented-syscall count is now INFORMATIONAL only, not a gate: it legitimately
+    // DROPS toward 0 as functions get implemented (the boot then advances to deeper, already-handled
+    // calls), so the old `>=1` floor produced false failures independent of real boot depth.
     bool gc_stw   = raises  >= 1;
     bool graphics = gfxcalls >= 1;
-    if (pipeline && gc_stw && graphics) {
-        printf("\n== PASS: booted through IL2CPP + GC stop-the-world into graphics init (%d>=%d unimpl, %d>=1 raise, %d>=1 gfx) ==\n",
-               reached, THRESHOLD, raises, gfxcalls);
+    if (gc_stw && graphics) {
+        printf("\n== PASS: booted through IL2CPP + GC stop-the-world into graphics init (%d unimpl [informational], %d>=1 raise, %d>=1 gfx) ==\n",
+               reached, raises, gfxcalls);
         return 0;
     }
-    if (!pipeline) printf("\n== FAIL: stalled early (%d < %d unimpl) ==\n", reached, THRESHOLD);
     if (!gc_stw)   printf("\n== FAIL: GC stop-the-world never ran (%d raises) — deadlock/GC regression? ==\n", raises);
-    if (!graphics) printf("\n== FAIL: never reached graphics init (%d gfx calls) — boot regressed before GPU/display ==\n", gfxcalls);
+    if (!graphics) printf("\n== FAIL: never reached graphics init (%d gfx calls) in %ld ms — boot regressed before GPU/display (or raise PROSPER_BOOTTEST_TIMEOUT_MS) ==\n", gfxcalls, ceil_ms);
     return 2;
 }


### PR DESCRIPTION
Fixes #89

## Root cause (bisected, not guessed)

The minimal 3-module boot (`test_boot_linux` / the `boot_reaches_first_syscall` gate) regressed: it reaches the IL2CPP GC but no longer reaches graphics init. I first suspected a timing/flaky test and nearly "fixed" it by loosening the timeout — but measuring win ratios disproved that:

- pre-window `2f682f5`: reaches graphics **10/10**
- current master: **1/10**

So it's a real code regression, not flakiness. A ratio-keyed `git bisect` (8 runs/step, good ≥6, bad ≤2) pinned it to a clean 8/8 → 0/8 transition at **`653cf6f`** ("feat(ue4): pak containers MOUNT…").

That commit's only behavioral change for a non-APR-calling game (The Messenger is IL2CPP, not UE4) is a new **initial-exec `__thread` variable** — `g_apr_entry_rsp`, written from an asm shim via `%fs:g_apr_entry_rsp@tpoff` — used to snapshot rsp so the APR handler can read stack arg 7 (the file offset). Adding a host thread-local **grows the executable's static TLS block**, and prosper's guest boot aliases the host TCB through %fs (the guest runs on the host %fs in the non-GUEST_FS boot; the fault-recovery point was already moved off `__thread` to gettid-keyed globals for this exact hazard). The one extra static-TLS slot shifts the layout enough to crash the boot before graphics ~9 runs in 10.

Confirmed by swapping the `__thread` for a plain RIP-relative global in the asm shim: boot immediately recovered to **10/10**.

## The fix

`g_apr_entry_rsp` becomes a plain global. This is correct: the entry shim tail-jumps straight into the handler, which reads `apr_stack_arg()` on the **same thread** first thing, so its own rsp is never stale. It assumes APR reads don't overlap across threads — they don't in practice (the engine builds each `sceAmprAprCommandBufferReadFile` into its single Ampr command buffer; completion is synchronous). Documented with a CONFIDENCE note: if concurrent APR ever appears, key by gettid — **never reintroduce static TLS**. UE4's arg7/offset capture is unchanged (same-thread read), so pak mounting is unaffected.

## Secondary: test hardening (separate commit)

Independent of the root cause, `test_boot_linux` had two fragilities that made this look like flakiness:
- The pass condition required `distinct-unimplemented-syscalls >= 1` — a count that legitimately falls to 0 as functions get implemented. Now informational; the gate is the two forward-compatible depth milestones (GC stop-the-world + a graphics-lib call).
- The fixed 10 s child budget became an adaptive poll to a 60 s ceiling that breaks as soon as milestones are met (warm runs still finish in ~1 s), so a cold-page-cache dump read over WSL's `/mnt/c` 9p mount can't spuriously time out. `PROSPER_BOOTTEST_TIMEOUT_MS` overrides the ceiling.

## Verification

- Full `ctest`: **47/47** green.
- Minimal boot win ratio after the fix: **10/10** (was 1/10 on master).