### PR TITLE
fix(hle/time): anchor all wall-clock sources to the host real-time clock

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -70,6 +70,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)
 
+  # Anchored wall-clock sources (#92): CLOCK_REALTIME ≈ host now, one shared epoch across
+  # time()/gettimeofday/sceRtc*, FreeBSD clockid mapping, valid LocalTime calendar dates.
+  add_executable(test_wall_clock tests/test_wall_clock.cpp)
+  target_link_libraries(test_wall_clock PRIVATE prosper_core)
+  add_test(NAME wall_clock COMMAND test_wall_clock)
+
   # UserService/libkernel startup stubs (HLE audit): getters write deterministic defaults; the
   # libkernel registration/hook calls resolve to benign OK no-ops.
   add_executable(test_service_getters tests/test_service_getters.cpp)

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -35,6 +35,31 @@ namespace {
     clk::time_point g_start = clk::now();
     uint64_t ns_now() { return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(clk::now() - g_start).count(); }
     std::atomic<uint64_t> g_module_handle{1};
+
+    // --- Wall-clock anchor (#92). The host real-time clock is sampled ONCE, paired with the
+    // monotonic ns_now() at the same instant; every wall-clock surface (CLOCK_REALTIME,
+    // gettimeofday, time(), sceRtc*) derives from base + monotonic-elapsed. This makes all of
+    // them (a) agree on one "now", (b) show the true current date instead of the old synthetic
+    // bases (uptime-since-1970 for clock_gettime/gettimeofday vs frozen 1700000000 ≈ Nov 2023
+    // for time()/sceRtc — three notions of now, ~54 years apart), and (c) advance strictly
+    // monotonically — a host NTP step after boot cannot make guest wall time jump backwards.
+    struct WallAnchor { uint64_t base_us; uint64_t mono_ns; };
+    const WallAnchor& wall_anchor() {
+        static const WallAnchor a = [] {
+            uint64_t mono = ns_now();
+            uint64_t us = (uint64_t)std::chrono::duration_cast<std::chrono::microseconds>(
+                              std::chrono::system_clock::now().time_since_epoch()).count();
+            return WallAnchor{ us, mono };
+        }();
+        return a;
+    }
+    uint64_t wall_now_us() {   // microseconds since the unix epoch, monotonically advancing
+        const WallAnchor& a = wall_anchor();
+        return a.base_us + (ns_now() - a.mono_ns) / 1000ull;
+    }
+    // RTC epoch: SceRtcTick counts microseconds since 0001-01-01 00:00:00 UTC; the unix epoch is
+    // 62135596800 s after it (the documented Orbis RTC convention, also shadPS4 UNIX_EPOCH_TICKS).
+    constexpr uint64_t kRtcUnixEpochOffsetUs = 62135596800ull * 1000000ull;
 }
 
 // --- time / clock (return real, advancing time so wait-for-time loops progress) ---
@@ -43,43 +68,113 @@ HLE(k_get_ptc_freq)   { return 1000000000ull; }            // counter is in ns -
 HLE(k_get_proc_time)  { return ns_now() / 1000; }          // microseconds
 HLE(k_read_tsc)       { return ns_now(); }
 HLE(k_tsc_freq)       { return 1000000000ull; }
+// sceKernelClockGettime / clock_gettime(clockid, struct timespec*). The PS5 inherits FreeBSD's
+// clockid numbering (shadPS4 time.h ORBIS_CLOCK_* == FreeBSD sys/time.h CLOCK_*; Kyty Pthread.cpp
+// KernelClockGettime agrees on 0=REALTIME, 4=MONOTONIC). Previously the id was IGNORED — every
+// clock, including CLOCK_REALTIME, returned uptime-since-process-start, i.e. wall time = Jan 1
+// 1970 + uptime (#92). Realtime family -> the anchored wall clock; monotonic/uptime family -> the
+// steady clock (FreeBSD's UPTIME clocks ARE its MONOTONIC clocks — both count since boot).
+// CONFIDENCE: HIGH on ids {0,4,5,7,8,9,10,11,12,13} (FreeBSD + both references); MED on the
+// default branch (cpu-time ids 1/2/14 fall back to the steady clock rather than real cpu time —
+// still monotonic, never backwards).
 HLE(k_clock_gettime) {                                     // (clockid, struct timespec*)
-    if (!a1) return 0;
-    uint64_t ns = ns_now();
-    ((int64_t*)P(a1))[0] = (int64_t)(ns / 1000000000ull);   // tv_sec
-    ((int64_t*)P(a1))[1] = (int64_t)(ns % 1000000000ull);   // tv_nsec
+    if (!a1) return 0x8002000eull;                          // SCE_KERNEL_ERROR_EFAULT (Kyty/shadPS4)
+    int64_t sec, nsec;
+    switch ((int)a0) {
+    case 0: case 9: case 10: {                              // REALTIME / _PRECISE / _FAST
+        uint64_t us = wall_now_us();
+        sec = (int64_t)(us / 1000000ull); nsec = (int64_t)(us % 1000000ull) * 1000;
+        break;
+    }
+    case 13: {                                              // CLOCK_SECOND: realtime, 1 s resolution
+        sec = (int64_t)(wall_now_us() / 1000000ull); nsec = 0;
+        break;
+    }
+    case 4: case 5: case 7: case 8: case 11: case 12:       // MONOTONIC/UPTIME family
+    case 15:                                                // PROCTIME (uptime == our process time)
+    default: {                                              // incl. cpu-time ids — steady fallback
+        uint64_t ns = ns_now();
+        sec = (int64_t)(ns / 1000000000ull); nsec = (int64_t)(ns % 1000000000ull);
+        break;
+    }
+    }
+    ((int64_t*)P(a1))[0] = sec;                             // tv_sec
+    ((int64_t*)P(a1))[1] = nsec;                            // tv_nsec
     return 0;
 }
 HLE(k_gettimeofday) {                                      // (struct timeval*, tz*)
     if (!a0) return 0;
-    uint64_t us = ns_now() / 1000;
+    uint64_t us = wall_now_us();
     ((int64_t*)P(a0))[0] = (int64_t)(us / 1000000ull);      // tv_sec
     ((int64_t*)P(a0))[1] = (int64_t)(us % 1000000ull);      // tv_usec
     return 0;
 }
-HLE(k_time) { uint64_t s = ns_now() / 1000000000ull + 1700000000ull; if (a0) *(int64_t*)P(a0) = (int64_t)s; return s; }
+HLE(k_time) { uint64_t s = wall_now_us() / 1000000ull; if (a0) *(int64_t*)P(a0) = (int64_t)s; return s; }
 HLE(k_clock) { return ns_now() / 1000; }   // clock(): CLOCKS_PER_SEC=1e6 -> microseconds
 // sceRtcGetCurrentTick(SceRtcTick* tick): a SceRtcTick is a single u64 = microseconds since the Sony RTC
-// epoch 0001-01-01 00:00:00 UTC. Was unimplemented (→0), which zeroes the game's wall-clock and skews any
-// timestamp/interval math derived from it. Return a real, monotonically-advancing tick built from our
-// synthetic unix time (base 1700000000 ≈ 2023-11) + the RTC↔unix epoch offset (62135596800 s).
-// CONFIDENCE: MED — SceRtcTick = bare u64 µs and the 62135596800 s offset are the documented Orbis RTC
-// convention; the wall-clock base is synthetic (we don't read the host RTC) but advances correctly.
+// epoch 0001-01-01 00:00:00 UTC. Built from the anchored wall clock (#92 — was the frozen synthetic base
+// 1700000000 ≈ Nov 2023) + the RTC↔unix epoch offset. CONFIDENCE: HIGH — SceRtcTick = bare u64 µs and the
+// 62135596800 s offset are the documented Orbis RTC convention (shadPS4 rtc.cpp UNIX_EPOCH_TICKS agrees).
 HLE(k_rtc_get_current_tick) {
     if (!a0) return 0;
-    uint64_t unix_us = (ns_now() / 1000ull) + 1700000000ull * 1000000ull;
-    uint64_t tick = unix_us + 62135596800ull * 1000000ull;   // shift to the 0001-01-01 RTC epoch
-    *(uint64_t*)P(a0) = tick;
+    *(uint64_t*)P(a0) = wall_now_us() + kRtcUnixEpochOffsetUs;
     return 0;
 }
-// sceRtcGetCurrentClockLocalTime / sceRtcGetCurrentClock(SceRtcDateTime* dt[, int tz_minutes]) —
-// fill the 16-byte SceRtcDateTime {u16 year,month,day,hour,minute,second; u32 microsecond} from the
-// same synthetic wall clock as sceRtcGetCurrentTick. Unimplemented-zero output (month=0, day=0)
-// trips UE4's FDateTime "Invalid Date values" assert, whose failed-assert handler then calls a
-// null crash-handler pointer — so a REAL calendar conversion is load-bearing for the UE4 boot.
+// Fill the 16-byte SceRtcDateTime {u16 year,month,day,hour,minute,second; u32 microsecond} from a
+// broken-down tm + microsecond remainder. A real calendar conversion is load-bearing for the UE4
+// boot: zeroed output (month=0, day=0) trips UE4's FDateTime "Invalid Date values" assert, whose
+// failed-assert handler then calls a null crash-handler pointer.
+static void fill_rtc_datetime(void* out, const struct tm& tmv, uint32_t usec) {
+    uint16_t* d = (uint16_t*)out;
+    d[0] = (uint16_t)(tmv.tm_year + 1900);
+    d[1] = (uint16_t)(tmv.tm_mon + 1);
+    d[2] = (uint16_t)tmv.tm_mday;
+    d[3] = (uint16_t)tmv.tm_hour;
+    d[4] = (uint16_t)tmv.tm_min;
+    d[5] = (uint16_t)tmv.tm_sec;
+    *(uint32_t*)(d + 6) = usec;
+}
+// sceRtcGetCurrentClockLocalTime(SceRtcDateTime* dt) — the current wall clock in the HOST's local
+// timezone (previously gmtime on the frozen synthetic base: "local" was UTC and the date was stuck
+// at Nov 2023, #92). Reference: shadPS4 rtc.cpp sceRtcGetCurrentClockLocalTime = current tick +
+// the sceKernelGettimezone offset (minuteswest/dst) — i.e. the host tz including DST, which is
+// exactly what localtime_r/localtime_s compute. Kyty has no LibRtc to cross-check; single-arg
+// signature and host-tz semantics per shadPS4. CONFIDENCE: MED.
 HLE(k_rtc_get_clock_localtime) {
     if (!a0) return 0;
-    uint64_t us = (ns_now() / 1000ull) + 1700000000ull * 1000000ull;
+    uint64_t us = wall_now_us();
+    time_t secs = (time_t)(us / 1000000ull);
+    struct tm tmv {};
+#ifdef _WIN32
+    localtime_s(&tmv, &secs);
+#else
+    localtime_r(&secs, &tmv);
+#endif
+    fill_rtc_datetime(P(a0), tmv, (uint32_t)(us % 1000000ull));
+    return 0;
+}
+// sceRtcGetCurrentClock(SceRtcDateTime* dt, int tz_minutes) — the current wall clock shifted by an
+// EXPLICIT caller-supplied timezone offset in minutes (tz was previously ignored). Reference:
+// shadPS4 rtc.cpp sceRtcGetCurrentClock does tick + sceRtcTickAddMinutes(timeZone). Signed: west
+// of UTC is negative. CONFIDENCE: MED (shadPS4 only; Kyty has no LibRtc).
+HLE(k_rtc_get_current_clock) {
+    if (!a0) return 0;
+    int64_t us = (int64_t)wall_now_us() + (int64_t)(int32_t)a1 * 60000000ll;
+    if (us < 0) us = 0;                                     // absurd tz on a near-epoch clock: clamp
+    time_t secs = (time_t)(us / 1000000ll);
+    struct tm tmv {};
+#ifdef _WIN32
+    gmtime_s(&tmv, &secs);
+#else
+    gmtime_r(&secs, &tmv);
+#endif
+    fill_rtc_datetime(P(a0), tmv, (uint32_t)(us % 1000000ll));
+    return 0;
+}
+// sceRtcGetCurrentDateTimeUtc(SceRtcDateTime* dt) — plain UTC.
+HLE(k_rtc_get_clock_utc) {
+    if (!a0) return 0;
+    uint64_t us = wall_now_us();
     time_t secs = (time_t)(us / 1000000ull);
     struct tm tmv {};
 #ifdef _WIN32
@@ -87,14 +182,7 @@ HLE(k_rtc_get_clock_localtime) {
 #else
     gmtime_r(&secs, &tmv);
 #endif
-    uint16_t* d = (uint16_t*)P(a0);
-    d[0] = (uint16_t)(tmv.tm_year + 1900);
-    d[1] = (uint16_t)(tmv.tm_mon + 1);
-    d[2] = (uint16_t)tmv.tm_mday;
-    d[3] = (uint16_t)tmv.tm_hour;
-    d[4] = (uint16_t)tmv.tm_min;
-    d[5] = (uint16_t)tmv.tm_sec;
-    *(uint32_t*)(d + 6) = (uint32_t)(us % 1000000ull);
+    fill_rtc_datetime(P(a0), tmv, (uint32_t)(us % 1000000ull));
     return 0;
 }
 
@@ -531,9 +619,9 @@ void register_kernel_time_hle() {
     R("clock", k_clock);
     R("sceRtcGetCurrentTick", k_rtc_get_current_tick);
     R("sceRtcGetCurrentNetworkTick", k_rtc_get_current_tick);
-    R("sceRtcGetCurrentClockLocalTime", k_rtc_get_clock_localtime);
-    R("sceRtcGetCurrentClock", k_rtc_get_clock_localtime);          // (dt, tz) — tz ignored (UTC clock)
-    R("sceRtcGetCurrentDateTimeUtc", k_rtc_get_clock_localtime);
+    R("sceRtcGetCurrentClockLocalTime", k_rtc_get_clock_localtime); // (dt) — host-local tz
+    R("sceRtcGetCurrentClock", k_rtc_get_current_clock);            // (dt, tz_minutes)
+    R("sceRtcGetCurrentDateTimeUtc", k_rtc_get_clock_utc);
     // module loading (report success; real PRX are already resident in our address space)
     R("sceSysmoduleLoadModule", k_ok);
     R("sceSysmoduleUnloadModule", k_ok);

--- a/prosper/tests/test_wall_clock.cpp
+++ b/prosper/tests/test_wall_clock.cpp
@@ -1,0 +1,135 @@
+// test_wall_clock — the anchored wall-clock sources (hle_kernel_time.cpp, #92).
+//
+// Previously the wall-clock surfaces were synthetic AND mutually inconsistent: clock_gettime
+// ignored the clockid (CLOCK_REALTIME returned uptime-since-1970), gettimeofday the same, while
+// time()/sceRtc* sat on a frozen base of 1700000000 (~Nov 2023) — three notions of "now" that
+// disagreed by ~54 years, and sceRtcGetCurrentClockLocalTime used gmtime for "local". Now every
+// wall surface derives from ONE anchor (host CLOCK_REALTIME paired with the monotonic ns_now()),
+// so this verifies: CLOCK_REALTIME ≈ the host's real now, all wall surfaces agree on one epoch,
+// the FreeBSD clockid families map correctly, LocalTime is a valid calendar date, and the
+// monotonic sources (ptc/tsc/MONOTONIC) still count uptime and never go backwards.
+// Deliberately no exact-time asserts — everything is tolerance-based.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static int64_t iabs64(int64_t v) { return v < 0 ? -v : v; }
+
+// SceRtcDateTime (16 bytes): u16 year,month,day,hour,minute,second; u32 microsecond.
+struct RtcDateTime { uint16_t year, month, day, hour, minute, second; uint32_t microsecond; };
+static_assert(sizeof(RtcDateTime) == 16, "SceRtcDateTime must be 16 bytes");
+
+int main() {
+    printf("== test_wall_clock ==\n");
+    register_builtin_hle();
+
+    auto clock_gettime_fn = Hle::lookup(nid_hash("sceKernelClockGettime"));
+    auto gettimeofday_fn  = Hle::lookup(nid_hash("sceKernelGettimeofday"));
+    auto time_fn          = Hle::lookup(nid_hash("time"));
+    auto rtc_tick_fn      = Hle::lookup(nid_hash("sceRtcGetCurrentTick"));
+    auto rtc_local_fn     = Hle::lookup(nid_hash("sceRtcGetCurrentClockLocalTime"));
+    auto rtc_clock_fn     = Hle::lookup(nid_hash("sceRtcGetCurrentClock"));
+    auto rtc_utc_fn       = Hle::lookup(nid_hash("sceRtcGetCurrentDateTimeUtc"));
+    auto ptc_fn           = Hle::lookup(nid_hash("sceKernelGetProcessTimeCounter"));
+    auto tsc_fn           = Hle::lookup(nid_hash("sceKernelReadTsc"));
+    CHECK(clock_gettime_fn && gettimeofday_fn && time_fn && rtc_tick_fn && rtc_local_fn &&
+          rtc_clock_fn && rtc_utc_fn && ptc_fn && tsc_fn, "all time fns registered");
+    if (fails) { printf("== FAIL ==\n"); return 1; }
+
+    // --- CLOCK_REALTIME (FreeBSD id 0) tracks the HOST's real now (± seconds, not ± decades). ---
+    int64_t ts[2] = { 0, 0 };
+    uint64_t rc = clock_gettime_fn(0, (uint64_t)(uintptr_t)ts, 0, 0, 0, 0);
+    int64_t host_now = (int64_t)::time(nullptr);
+    CHECK(rc == 0, "clock_gettime(CLOCK_REALTIME) returned 0");
+    CHECK(iabs64(ts[0] - host_now) <= 30, "CLOCK_REALTIME within 30s of host now");
+    CHECK(ts[1] >= 0 && ts[1] < 1000000000ll, "CLOCK_REALTIME tv_nsec in range");
+    // Regression guard for the two historical failure modes: uptime-as-wall (~1970) and the
+    // frozen synthetic base 1700000000 (~Nov 2023). Any real run of this test is after 2026.
+    CHECK(ts[0] > 1750000000ll, "CLOCK_REALTIME is not the 1970/2023 synthetic base");
+
+    // --- All wall surfaces agree on ONE epoch (each pair within 2 s of live drift). ---
+    int64_t tv[2] = { 0, 0 };
+    gettimeofday_fn((uint64_t)(uintptr_t)tv, 0, 0, 0, 0, 0);
+    int64_t time_s = (int64_t)time_fn(0, 0, 0, 0, 0, 0);
+    uint64_t tick = 0;
+    rtc_tick_fn((uint64_t)(uintptr_t)&tick, 0, 0, 0, 0, 0);
+    int64_t rtc_unix_s = (int64_t)(tick / 1000000ull) - 62135596800ll;   // undo the 0001-01-01 epoch
+    CHECK(iabs64(tv[0] - ts[0]) <= 2, "gettimeofday agrees with CLOCK_REALTIME");
+    CHECK(iabs64(time_s - ts[0]) <= 2, "time() agrees with CLOCK_REALTIME");
+    CHECK(iabs64(rtc_unix_s - ts[0]) <= 2, "RtcGetCurrentTick agrees with CLOCK_REALTIME");
+
+    // --- CLOCK_SECOND (id 13) is the realtime clock at 1 s resolution. ---
+    int64_t tsec[2] = { -1, -1 };
+    clock_gettime_fn(13, (uint64_t)(uintptr_t)tsec, 0, 0, 0, 0);
+    CHECK(iabs64(tsec[0] - ts[0]) <= 2, "CLOCK_SECOND tracks CLOCK_REALTIME");
+    CHECK(tsec[1] == 0, "CLOCK_SECOND has 1s resolution (tv_nsec == 0)");
+
+    // --- MONOTONIC/UPTIME family (ids 4/5/7) counts since process start, NOT wall time. ---
+    for (int id : { 4, 5, 7 }) {
+        int64_t tm2[2] = { -1, -1 };
+        clock_gettime_fn((uint64_t)id, (uint64_t)(uintptr_t)tm2, 0, 0, 0, 0);
+        char msg[64]; snprintf(msg, sizeof msg, "clockid %d is uptime-scale (< 1h)", id);
+        CHECK(tm2[0] >= 0 && tm2[0] < 3600, msg);
+    }
+
+    // --- Monotonic sources unaffected: ptc/tsc are uptime-scale and never go backwards. ---
+    uint64_t p1 = ptc_fn(0, 0, 0, 0, 0, 0), t1 = tsc_fn(0, 0, 0, 0, 0, 0);
+    uint64_t p2 = ptc_fn(0, 0, 0, 0, 0, 0), t2 = tsc_fn(0, 0, 0, 0, 0, 0);
+    CHECK(p1 < 3600ull * 1000000000ull, "ProcessTimeCounter is uptime-scale (not wall)");
+    CHECK(t1 < 3600ull * 1000000000ull, "ReadTsc is uptime-scale (not wall)");
+    CHECK(p2 >= p1 && t2 >= t1, "monotonic sources never go backwards");
+    int64_t r2[2] = { 0, 0 };
+    clock_gettime_fn(0, (uint64_t)(uintptr_t)r2, 0, 0, 0, 0);
+    CHECK(r2[0] > ts[0] || (r2[0] == ts[0] && r2[1] >= ts[1]), "CLOCK_REALTIME never goes backwards");
+
+    // --- LocalTime is a VALID calendar date (the UE4 FDateTime constraint: month/day >= 1). ---
+    RtcDateTime lt{};
+    rtc_local_fn((uint64_t)(uintptr_t)&lt, 0, 0, 0, 0, 0);
+    CHECK(lt.year >= 2026 && lt.year <= 2200, "LocalTime year is current-era");
+    CHECK(lt.month >= 1 && lt.month <= 12, "LocalTime month in 1..12");
+    CHECK(lt.day >= 1 && lt.day <= 31, "LocalTime day in 1..31");
+    CHECK(lt.hour <= 23 && lt.minute <= 59 && lt.second <= 60, "LocalTime h/m/s in range");
+    CHECK(lt.microsecond < 1000000u, "LocalTime microsecond in range");
+
+    // --- sceRtcGetCurrentClock applies its tz_minutes argument: +90 min shifts the result. ---
+    RtcDateTime c0{}, c90{};
+    rtc_clock_fn((uint64_t)(uintptr_t)&c0, 0, 0, 0, 0, 0);                       // tz = 0 (UTC)
+    rtc_clock_fn((uint64_t)(uintptr_t)&c90, (uint64_t)(uint32_t)90, 0, 0, 0, 0); // tz = +90 min
+    struct tm tm0 {}, tm90 {};
+    tm0.tm_year = c0.year - 1900;  tm0.tm_mon = c0.month - 1;  tm0.tm_mday = c0.day;
+    tm0.tm_hour = c0.hour;         tm0.tm_min = c0.minute;     tm0.tm_sec = c0.second;
+    tm90.tm_year = c90.year - 1900; tm90.tm_mon = c90.month - 1; tm90.tm_mday = c90.day;
+    tm90.tm_hour = c90.hour;        tm90.tm_min = c90.minute;    tm90.tm_sec = c90.second;
+#ifdef _WIN32
+    int64_t s0 = (int64_t)_mkgmtime(&tm0), s90 = (int64_t)_mkgmtime(&tm90);
+#else
+    int64_t s0 = (int64_t)timegm(&tm0), s90 = (int64_t)timegm(&tm90);
+#endif
+    CHECK(iabs64((s90 - s0) - 90 * 60) <= 2, "sceRtcGetCurrentClock(+90min) shifts by 90 minutes");
+
+    // --- The UTC datetime agrees with CLOCK_REALTIME (round-trips through the calendar). ---
+    RtcDateTime utc{};
+    rtc_utc_fn((uint64_t)(uintptr_t)&utc, 0, 0, 0, 0, 0);
+    struct tm tmu {};
+    tmu.tm_year = utc.year - 1900; tmu.tm_mon = utc.month - 1; tmu.tm_mday = utc.day;
+    tmu.tm_hour = utc.hour;        tmu.tm_min = utc.minute;    tmu.tm_sec = utc.second;
+#ifdef _WIN32
+    int64_t su = (int64_t)_mkgmtime(&tmu);
+#else
+    int64_t su = (int64_t)timegm(&tmu);
+#endif
+    CHECK(iabs64(su - ts[0]) <= 2, "DateTimeUtc agrees with CLOCK_REALTIME");
+
+    if (fails) printf("== FAIL (%d) ==\n", fails);
+    else       printf("== PASS ==\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #92

## Problem

All wall-clock surfaces in `prosper/src/hle/hle_kernel_time.cpp` were synthetic and mutually inconsistent:

- `k_clock_gettime` ignored its clockid — every clock including `CLOCK_REALTIME` returned ns-since-process-start (wall time = Jan 1 1970 + uptime)
- `k_gettimeofday` the same
- `time()` / `sceRtc*` built on the hardcoded base `1700000000` (frozen ~Nov 2023)
- `sceRtcGetCurrentClockLocalTime` used `gmtime` for "local" and `sceRtcGetCurrentClock` ignored its tz argument

Three notions of "now" disagreed by ~54 years within one process.

## Fix

**One anchor.** Host `CLOCK_REALTIME` (`std::chrono::system_clock`) is sampled once, paired with the monotonic `ns_now()` at the same instant (`wall_anchor()`); `wall_now_us()` = base + monotonic-elapsed. Every wall surface derives from it, so they all agree on one epoch, show the true current date, and can never go backwards (a host NTP step after boot cannot reach the guest).

**Clockid mapping** (PS5 inherits FreeBSD's numbering; evidence: shadPS4 `time.h` `ORBIS_CLOCK_*` == FreeBSD `sys/time.h`, Kyty `Pthread.cpp` `KernelClockGettime` agrees on 0=REALTIME / 4=MONOTONIC):

| ids | clock | source |
|---|---|---|
| 0, 9, 10 | REALTIME / _PRECISE / _FAST | anchored wall clock |
| 13 | SECOND | wall clock @ 1 s resolution (`tv_nsec=0`) |
| 4, 5, 7, 8, 11, 12 | MONOTONIC + UPTIME families | steady clock (FreeBSD's UPTIME clocks are its monotonic clocks — both count since boot) |
| 15 | PROCTIME | steady clock (== our process time) |
| 1, 2, 14 (default) | cpu-time ids | steady fallback — CONFIDENCE: MED (not real cpu time, but monotonic and never backwards) |

Null `tp` now returns `SCE_KERNEL_ERROR_EFAULT` (both references agree).

**tz decision.** `sceRtcGetCurrentClockLocalTime(dt)` applies the HOST local timezone via `localtime_r`/`localtime_s` — shadPS4 `rtc.cpp` implements it as current tick + the `sceKernelGettimezone` offset (`-(tz_minuteswest - tz_dsttime*60)`), i.e. host tz including DST, which is exactly what `localtime_r` computes. Kyty has no LibRtc to cross-check, so CONFIDENCE: MED. `sceRtcGetCurrentClock(dt, tz_minutes)` gets its own handler honoring the explicit signed tz-minutes argument (per shadPS4 `tick + sceRtcTickAddMinutes(timeZone)`); `sceRtcGetCurrentDateTimeUtc` stays plain UTC. All three keep real calendar conversion (UE4's FDateTime valid-date assert stays satisfied), and `sceRtcGetCurrentTick` preserves the 62135596800 s 0001-01-01 RTC epoch offset.

**Untouched:** ptc/tsc/ProcessTime/`clock()` (monotonic sources), all sleeps.

## Verification

- New `test_wall_clock` (24 assertions, all tolerance-based): CLOCK_REALTIME ≈ host now (±30 s) and is not the 1970/2023 synthetic bases; `time()`/`gettimeofday`/`RtcGetCurrentTick` agree on one epoch (±2 s); CLOCK_SECOND semantics; monotonic ids 4/5/7 + ptc/tsc stay uptime-scale and never go backwards; LocalTime is a valid calendar date; `sceRtcGetCurrentClock(+90 min)` shifts by exactly 90 minutes.
- Full WSL ctest: **52/53 green**. The single failure is `boot_reaches_first_syscall` — the pre-existing regression tracked in #89, which fails identically on pristine current master in this environment (verified 5/5 runs on a master-only build and on the main repo's prebuilt binary); unrelated to this change.
- Live render smoke (`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`, 60 s `boot_trace`): **123 frames rendered at 1920×1080** reaching frame 680 — matches a same-session master baseline (126 frames / frame 710) within noise.