### PR TITLE
docs(claude): area lanes so parallel workstreams don't collide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,13 @@ renderer is wired in; the game's **real pixel shader recompiles to valid SPIR-V*
        or park the work, comment what state it's in and remove the `in-progress` label.
     6. Claims expire: `in-progress` with no open PR and no activity for 24 h is stale — anyone
        may re-claim after posting a takeover comment.
+  - **Stay in your area lane (multi-workstream).** Separate workstreams run in parallel, each
+    possibly coordinating its own sub-agents, split by title/subsystem via `area:` labels:
+    `area:ue4` (PPSA17942 / Unreal Engine — IoStore/APR/Ampr, RHI, the UE allocator) and
+    `area:messenger` (PPSA24651 / The Messenger, IL2CPP/Unity, and shared infra: loader, libc,
+    libkernel, the recompiler, generic GPU/AGC). **Do NOT touch code or claim issues outside your
+    workstream's area** — cross-lane edits collide with the other workstream's in-flight sub-agents.
+    If a fix genuinely spans both (shared infra that a UE issue also needs), coordinate on the issue
+    first; default to the shared-infra/Messenger lane owning shared files. Label every new issue with
+    its `area:` so the lanes stay legible; when unsure which lane a file belongs to, check which
+    title's boot path exercises it.


### PR DESCRIPTION
Per the maintainer: a separate workstream is driving UE4 (PPSA17942) work with its own coordinating sub-agents, in parallel with this Messenger/IL2CPP + shared-infra workstream. Without a lane boundary the two collide on the same files/issues.

Adds an **area-lane rule** to the existing issue protocol in CLAUDE.md:
- Issues carry `area:ue4` (PPSA17942 / Unreal — IoStore/APR/Ampr, RHI, UE allocator) or `area:messenger` (PPSA24651 / The Messenger, IL2CPP/Unity + shared infra: loader, libc, libkernel, recompiler, generic GPU/AGC).
- Agents must not touch code or claim issues outside their workstream's lane.
- Shared-infra files default to the Messenger/shared lane; a genuinely cross-lane fix coordinates on the issue first.
- Every new issue gets an `area:` label so the split stays legible.

Labels `area:ue4` / `area:messenger` created; open UE issues #71 (Ampr mirror) and #88 (RHI null-call) tagged `area:ue4`, #83 (Messenger cutscene render-to-texture) tagged `area:messenger`. My bug-hunt loop is already scoped to the Messenger/shared lane and will leave the UE issues to that workstream.