### PR TITLE
fix(hle/mem): sceKernelAvailableDirectMemorySize reports the real largest free block

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -109,6 +109,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_apr_registry PRIVATE prosper_core)
   add_test(NAME apr_registry_size_keying COMMAND test_apr_registry)
 
+  # Direct-memory allocate/available (issue #99): AvailableDirectMemorySize reports the largest
+  # free aligned block in the search window and writes both out-params (was a total-size stub).
+  add_executable(test_dmem tests/test_dmem.cpp)
+  target_link_libraries(test_dmem PRIVATE prosper_core)
+  add_test(NAME dmem_available COMMAND test_dmem)
+
   # PM4 command-stream decoder (front of the CommandProcessor): decode a Dcb built by the AGC
   # Dcb functions and assert the ops. Pure/cross-platform, no game dump needed.
   add_executable(test_pm4_decode tests/test_pm4_decode.cpp)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -76,6 +76,29 @@ namespace {
         return true;
     }
 
+    // Largest FREE aligned block within [lo, hi) of the direct-memory pool (for
+    // sceKernelAvailableDirectMemorySize). Walks the same sorted free gaps dmem_take allocates from,
+    // clipping each gap to the requested [lo, hi) window and aligning its start. Returns the biggest
+    // such block's aligned offset + size; size 0 means nothing fits (caller -> ENOMEM).
+    void dmem_largest_free(uint64_t lo, uint64_t hi, uint64_t align, uint64_t& off_out, uint64_t& size_out) {
+        if (!align) align = 0x4000;
+        if (lo < kDmemBase) lo = kDmemBase;
+        if (hi > kDmemBase + kDmemTotal) hi = kDmemBase + kDmemTotal;
+        off_out = 0; size_out = 0;
+        std::lock_guard<std::mutex> lk(g_dmx);
+        uint64_t cursor = kDmemBase;
+        for (size_t i = 0; i <= g_dmem.size(); i++) {
+            uint64_t gap_beg = cursor;
+            uint64_t gap_end = (i < g_dmem.size()) ? g_dmem[i].start : kDmemBase + kDmemTotal;
+            // Clip the free gap to the caller's search window, then align its start.
+            uint64_t beg = gap_beg < lo ? lo : gap_beg;
+            uint64_t end = gap_end > hi ? hi : gap_end;
+            uint64_t aligned = (beg + align - 1) & ~(align - 1);
+            if (end > aligned && end - aligned > size_out) { off_out = aligned; size_out = end - aligned; }
+            if (i < g_dmem.size()) cursor = g_dmem[i].end;
+        }
+    }
+
     // Release [start, start+len): remove or trim every overlapping allocation (kernel semantics —
     // the range is freed regardless of how it was carved into allocations).
     void dmem_release(uint64_t start, uint64_t len) {
@@ -446,6 +469,24 @@ HLE(k_wake_by_address) {
 HLE(k_munmap)   { if (a0) { munmap((void*)a0, a1); untrack(a0, a1); } return 0; }
 HLE(k_mprotect) { if (a0) { mprotect((void*)a0, a1, host_prot(a2)); retrack_prot(a0, a1, host_prot(a2), "mprotect"); } return 0; }
 HLE(k_dmem_size){ return kDmemTotal; }   // 8 GiB pool (allocation failures enforce this bound)
+// sceKernelAvailableDirectMemorySize(searchStart, searchEnd, alignment, off_t* physAddrOut,
+// size_t* sizeOut) — report the LARGEST free aligned direct-memory block in [searchStart, searchEnd).
+// Signature per shadPS4 memory.cpp:120 (NID C0f7TJcbfac, PS4-inherited). Was aliased to
+// k_dmem_size, which returned the pool TOTAL and never wrote the out-params — a caller sizing an
+// allocation from *sizeOut or seeding a search from *physAddrOut read uninitialized stack after a
+// "success". Now walks the real free gaps.
+HLE(k_avail_dmem) {   // a0=searchStart a1=searchEnd a2=alignment a3=physAddrOut a4=sizeOut
+    if (!a3 || !a4) return 0x80020016ull;                 // EINVAL: out-params required
+    uint64_t off = 0, size = 0;
+    dmem_largest_free(a0, a1 ? a1 : (kDmemBase + kDmemTotal), a2, off, size);
+    if (!size) return 0x8002000Cull;                      // ENOMEM: nothing available in the window
+    *(uint64_t*)(uintptr_t)a3 = off;
+    *(uint64_t*)(uintptr_t)a4 = size;
+    MLOG("avail-dmem [0x%llx,0x%llx) align=0x%llx -> phys=0x%llx size=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)off, (unsigned long long)size);
+    return 0;
+}
 
 // --- libSceAmpr (PS5 async memory-programming engine) -------------------------------------------
 // The UE4 title (PPSA17942) commits one class of its allocator pool pages through an Ampr command
@@ -655,7 +696,7 @@ void register_kernel_mem_hle() {
     R("sceKernelVirtualQuery", k_virtual_query);
     R("sceKernelDirectMemoryQuery", k_direct_memory_query);
     R("sceKernelGetDirectMemorySize", k_dmem_size);
-    R("sceKernelAvailableDirectMemorySize", k_dmem_size);
+    R("sceKernelAvailableDirectMemorySize", k_avail_dmem);
     #undef R
     // sync_on_address futex — registered by raw NID (names not in any public DB yet).
     Hle::register_fn("Hc4CaR6JBL0", (HleFn)k_wait_on_address, "sceKernelWaitOnAddress?");

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -1,0 +1,81 @@
+// test_dmem — guards sceKernelAvailableDirectMemorySize (issue #99). It must report the LARGEST
+// free aligned direct-memory block within the caller's [searchStart, searchEnd) window and write
+// BOTH out-params — it was aliased to the total-size stub, which returned success while leaving
+// physAddrOut/sizeOut uninitialized (a caller sizing an allocation from *sizeOut read stack garbage).
+// Drives the handlers through the NID registry exactly as the guest does. Each ctest binary is its
+// own process, so the process-global direct-memory pool starts empty here.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Pool bounds mirror hle_kernel_mem.cpp (kDmemBase / kDmemTotal).
+static constexpr uint64_t kBase  = 0x10000000ull;
+static constexpr uint64_t kTotal = 8ull * 1024 * 1024 * 1024;
+static constexpr uint64_t kEnd   = kBase + kTotal;
+
+int main() {
+    printf("== test_dmem ==\n");
+    register_builtin_hle();
+
+    auto avail   = Hle::lookup(nid_hash("sceKernelAvailableDirectMemorySize"));
+    auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
+    auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
+    CHECK(avail && alloc && release, "dmem fns registered");
+    if (!(avail && alloc && release)) { printf("== FAIL ==\n"); return 1; }
+
+    // Fresh pool: the largest free block is the whole pool, and BOTH out-params are written.
+    uint64_t phys = 0xdead, size = 0xdead;
+    uint64_t r = avail(0, kEnd, 0x4000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
+    CHECK(r == 0, "available(fresh) returns success");
+    CHECK(phys == kBase, "available(fresh) phys == pool base");
+    CHECK(size == kTotal, "available(fresh) size == whole pool");
+
+    // Null out-pointers -> EINVAL, and it must NOT be the old success-with-garbage.
+    CHECK((uint32_t)avail(0, kEnd, 0x4000, 0, (uint64_t)(uintptr_t)&size, 0) == 0x80020016u,
+          "available(null physAddrOut) -> EINVAL");
+    CHECK((uint32_t)avail(0, kEnd, 0x4000, (uint64_t)(uintptr_t)&phys, 0, 0) == 0x80020016u,
+          "available(null sizeOut) -> EINVAL");
+
+    // Allocate 1 MiB (args: searchStart, searchEnd, len, align, type, physOut) at the pool base.
+    uint64_t ap = 0;
+    uint64_t ar = alloc(0, kEnd, 0x100000, 0x4000, 0, (uint64_t)(uintptr_t)&ap);
+    CHECK(ar == 0 && ap == kBase, "allocate 1MiB -> phys at pool base");
+
+    // Now the largest free block starts just past the allocation and is the pool minus 1 MiB.
+    phys = size = 0;
+    avail(0, kEnd, 0x4000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
+    CHECK(phys == kBase + 0x100000, "available after alloc -> phys past the allocation");
+    CHECK(size == kTotal - 0x100000, "available after alloc -> size shrank by the allocation");
+
+    // A search window entirely within free space clamps the reported block to the window.
+    uint64_t wlo = 0x20000000ull, wsz = 0x40000ull;
+    phys = size = 0;
+    r = avail(wlo, wlo + wsz, 0x4000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
+    CHECK(r == 0 && phys == wlo && size == wsz, "available(window in free space) clamps to the window");
+
+    // A search window entirely inside the allocated region has nothing free -> ENOMEM.
+    r = avail(kBase, kBase + 0x80000, 0x4000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
+    CHECK((uint32_t)r == 0x8002000Cu, "available(window fully allocated) -> ENOMEM");
+
+    // Alignment is honored: a 1 MiB-aligned search over free space returns a 1 MiB-aligned phys.
+    phys = 0;
+    avail(0x20000123ull, kEnd, 0x100000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
+    CHECK((phys & 0xfffff) == 0 && phys >= 0x20000123ull, "available honors the requested alignment");
+
+    // Release the allocation -> the whole pool is available again.
+    release(kBase, 0x100000, 0, 0, 0, 0);
+    phys = size = 0;
+    avail(0, kEnd, 0x4000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
+    CHECK(phys == kBase && size == kTotal, "available after release -> whole pool free again");
+
+    if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -22,6 +22,13 @@ static constexpr uint64_t kEnd   = kBase + kTotal;
 
 int main() {
     printf("== test_dmem ==\n");
+#ifndef __linux__
+    // The direct-memory HLE (hle_kernel_mem.cpp) is #ifdef __linux__ — its functions aren't
+    // registered on other platforms (e.g. the Windows/MinGW CI build), so there is nothing to
+    // exercise here. Skip cleanly rather than fail on the absent registrations.
+    printf("  [skip] direct-memory HLE is Linux-only on this build\n== PASS ==\n");
+    return 0;
+#else
     register_builtin_hle();
 
     auto avail   = Hle::lookup(nid_hash("sceKernelAvailableDirectMemorySize"));
@@ -78,4 +85,5 @@ int main() {
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;
+#endif
 }


### PR DESCRIPTION
Fixes #99

`sceKernelAvailableDirectMemorySize` was aliased to `k_dmem_size` — it returned the pool total (8 GiB) and **never wrote its out-params**, so a guest that sizes an allocation from `*sizeOut` or seeds a search from `*physAddrOut` read uninitialized stack after a "successful" call (the same harmful-stub class already fixed for `GetStatus` / `Getschedparam`).

Real signature per shadPS4 `memory.cpp:120` (NID `C0f7TJcbfac`, PS4-inherited — trustworthy): `(searchStart, searchEnd, alignment, off_t* physAddrOut, size_t* sizeOut)` returning the **largest free aligned block** in `[searchStart, searchEnd)`. New `dmem_largest_free()` walks the same sorted free gaps `dmem_take` allocates from, clips each to the window, aligns the start, and returns the biggest; the handler writes both out-params and returns `EINVAL` on a null out-ptr / `ENOMEM` when the window has nothing free. `GetDirectMemorySize` stays on the total-size handler.

**Verification:** new `test_dmem` (13 assertions: fresh whole-pool report, both out-params written, EINVAL on null ptrs, shrink-after-alloc, window clamping, fully-allocated-window ENOMEM, alignment honored, grow-back after release). Full ctest **49/49**.

Lane: `area:messenger` (shared kernel infra, no UE-specific surface).