### PR TITLE
fix(gpu/exec): scale the guest viewport to the render framebuffer (reduced-res showed only bottom-left crop)

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -176,8 +176,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
 // correctly — the path for multi-geometry scenes (opt-in until the AGC context-log section semantics
 // that stage duplicate register writes are fully RE'd; see docs/REAL_FRAMES_FINDINGS.md).
 // `max_shader_dwords` bounds the recompiler's walk (it stops at S_ENDPGM).
+// vp_scale_{x,y}: scale each draw's guest viewport by this factor. The guest programs PA_CL_VPORT in
+// full present-resolution pixels; when we render into a reduced-resolution framebuffer (PROSPER_RENDER_SCALE)
+// the viewport must shrink by the same ratio, or a full-res viewport into a small framebuffer clips the
+// image to its bottom-left corner. Default 1.0 (full-res / tests: no change).
 inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
-                                             uint32_t max_shader_dwords = 0x10000) {
+                                             uint32_t max_shader_dwords = 0x10000,
+                                             float vp_scale_x = 1.0f, float vp_scale_y = 1.0f) {
     if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
     const bool log = getenv("PROSPER_GFXLOG") != nullptr;    // bail-point visibility (why no frame?)
     // Render each draw from its OWN register snapshot when the submit has MULTIPLE draws — a real
@@ -214,6 +219,14 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
                                        it.vertex_count, it.indices.size(), it.ps.topology, it.ps.color_write_mask);
         fprintf(stderr, "\n"); fflush(stderr); }
     if (items.empty()) return {};
+    // Scale each item's guest viewport to the actual (possibly reduced-resolution) framebuffer. Skip if
+    // 1.0 (full-res) or if this draw has no guest viewport (the backend then uses the full-target default).
+    if (vp_scale_x != 1.0f || vp_scale_y != 1.0f)
+        for (auto& it : items)
+            if (it.ps.has_viewport) {
+                it.ps.viewport_x *= vp_scale_x; it.ps.viewport_w *= vp_scale_x;
+                it.ps.viewport_y *= vp_scale_y; it.ps.viewport_h *= vp_scale_y;
+            }
     if (log) fprintf(stderr, "[exec] rendering %zu draw item(s) (of %zu draws)\n", items.size(), st.draws.size());
     return render(items);
 }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -453,8 +453,15 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
     if (!g_live || st.draws.empty() || !width || !height) return false;
     // Bind the target dimensions and defer to the pure core, which recompiles the shaders from their
     // SHADER_PGM addresses and resolves fixed-function state before calling back into the live renderer.
+    // Scale the guest viewport to our framebuffer: `width`/`height` are the render target (reduced by
+    // PROSPER_RENDER_SCALE), while the guest programs its viewport in full present-resolution pixels — so
+    // without this a 1/N render shows only the bottom-left 1/N of the frame.
+    uint32_t fw = present_width(), fh = present_height();
+    float sx = fw ? (float)width  / (float)fw : 1.0f;
+    float sy = fh ? (float)height / (float)fh : 1.0f;
     std::vector<uint8_t> px = execute_gpustate(st,
-        [&](const std::vector<DrawItem>& items) { return g_live(items, width, height); });
+        [&](const std::vector<DrawItem>& items) { return g_live(items, width, height); },
+        0x10000, sx, sy);
     if (px.size() != static_cast<size_t>(width) * height * 4) return false;   // recompile/render failed
     present_write_frame(px.data(), width, height);
     return true;

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -351,9 +351,12 @@ int main(int argc, char** argv) {
                             // PROSPER_DUMP_TEX: write the RAW texture memory (interpreted linearly) to a BMP,
                             // bypassing the shader — reveals whether the render target is tiled (scrambled) or
                             // linear (recognizable), and the tiling structure.
-                            if (getenv("PROSPER_DUMP_TEX") && !texstore.back().empty()) {
+                            if (getenv("PROSPER_DUMP_TEX") && !texstore.back().empty() && frame_no < 200) {
                                 std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
-                                char fn[512]; snprintf(fn, sizeof fn, "%s/rawtex_b%u.bmp", d.c_str(), r.binding);
+                                // Frame-numbered so a specific frame's texture (loading screen, cutscene) can be
+                                // recovered — a bare per-binding name overwrites every frame. Bounded to the first
+                                // 200 frames (loading + intro) so a long run doesn't fill the disk.
+                                char fn[512]; snprintf(fn, sizeof fn, "%s/rawtex_f%04d_b%u.bmp", d.c_str(), (int)frame_no, r.binding);
                                 prosper::test::dump_bmp(fn, texstore.back(), tw, th);
                                 fprintf(stderr, "[render] dumped raw texture -> %s\n", fn); fflush(stderr);
                             }


### PR DESCRIPTION
Follow-up to #93 (per-draw rendering, merged). That made the scene's draws render; this fixes their **framing**.

## Bug
The guest programs `PA_CL_VPORT` in full present-resolution pixels (e.g. 1920×1080). When we render into a reduced-resolution framebuffer (`PROSPER_RENDER_SCALE=N`, used so the synchronous llvmpipe render doesn't stall the guest submit thread), the viewport stayed full-size — so geometry drew at full-res coordinates into the smaller framebuffer, **clipping the image to its bottom-left corner**.

## Fix
`execute_and_present` computes the framebuffer/present ratio; `execute_gpustate` gains `vp_scale_x/y` params (default 1.0 — no change for full-res or the render tests) and scales each draw's resolved viewport by it, preserving a negative height's Y-flip.

## Result (The Messenger)
- **Title screen renders in FULL** — logo + hero + moon + demon horde — vs. just the bottom-left crop.
- **Intro cutscene correctly framed** — black letterbox + the wide blue island centered, matching real hardware.

(Textures are still scrambled — a separate de-swizzle issue, #101 — and the cutscene text is missing, #102.)

## Also included
`diag(boot_trace)`: frame-number `PROSPER_DUMP_TEX` output (was overwriting per frame) so a specific frame's texture can be captured for the de-swizzle RE. Debug-only, gated on the env var.

Builds clean; all GPU/render ctests green (the 1 failing test is the pre-existing #26 boot regression, #89, unrelated). Refs #83.