### PR TITLE
fix(hle/kernel): EventFlag/Sema delete no longer frees the object under blocked waiters (UAF)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -70,6 +70,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)
 
+  # EventFlag/Sema delete-under-waiter safety (issue #104): delete wakes parked waiters with EACCES
+  # and defers the free to the last one out, instead of free()ing the object under a live wait (UAF).
+  add_executable(test_sync_delete tests/test_sync_delete.cpp)
+  target_link_libraries(test_sync_delete PRIVATE prosper_core)
+  add_test(NAME sync_delete COMMAND test_sync_delete)
+
   # Anchored wall-clock sources (#92): CLOCK_REALTIME ≈ host now, one shared epoch across
   # time()/gettimeofday/sceRtc*, FreeBSD clockid mapping, valid LocalTime calendar dates.
   add_executable(test_wall_clock tests/test_wall_clock.cpp)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -374,10 +374,15 @@ HLE(k_setspecific)   { return (uint64_t)(int64_t)pthread_setspecific((pthread_ke
 
 // --- event flags (SceKernelEventFlag): a bit pattern with wait/set/clear ---
 namespace {
-    struct EventFlag { pthread_mutex_t m; pthread_cond_t c; uint64_t bits; };
+    // `deleted` + `waiters` make sceKernelDeleteEventFlag safe against blocked waiters: delete marks
+    // the flag, wakes everyone, and defers destroy+free to the last waiter leaving (or frees now if
+    // none are parked). Freeing under a live pthread_cond_wait is a UAF — destroying a condvar with
+    // waiters is explicitly UB.
+    struct EventFlag { pthread_mutex_t m; pthread_cond_t c; uint64_t bits; bool deleted; int waiters; };
     bool evf_match(uint64_t bits, uint64_t pat, uint32_t mode) {
         return (mode & 0x1) ? ((bits & pat) == pat) : ((bits & pat) != 0);  // AND vs OR
     }
+    void ef_destroy(EventFlag* e) { pthread_mutex_destroy(&e->m); pthread_cond_destroy(&e->c); free(e); }
 }
 HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
     auto* e = (EventFlag*)calloc(1, sizeof(EventFlag));
@@ -385,7 +390,16 @@ HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
     if (a0) *(void**)(uintptr_t)a0 = e;
     return 0;
 }
-HLE(k_ef_delete)  { if (a0) free((void*)(uintptr_t)a0); return 0; }
+HLE(k_ef_delete)  {
+    auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
+    pthread_mutex_lock(&e->m);
+    e->deleted = true;
+    pthread_cond_broadcast(&e->c);                 // wake every waiter -> they return EACCES
+    bool has_waiters = e->waiters > 0;
+    pthread_mutex_unlock(&e->m);
+    if (!has_waiters) ef_destroy(e);               // none parked -> free now; else the last waiter frees
+    return 0;
+}
 HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits |= a1; pthread_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
 HLE(k_ef_clear)   { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits &= a1; pthread_mutex_unlock(&e->m); return 0; }
 // Absolute CLOCK_REALTIME deadline `usec` microseconds from now (for pthread_cond_timedwait
@@ -405,25 +419,30 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
     uint64_t ret = 0;
     pthread_mutex_lock(&e->m);
+    e->waiters++;
     if (a4) {
         uint32_t usec = *(uint32_t*)(uintptr_t)a4;
         timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
         timespec dl = abs_deadline_us(usec);
         int rc = 0;
-        while (!evf_match(e->bits, a1, (uint32_t)a2) && rc != ETIMEDOUT)
+        while (!evf_match(e->bits, a1, (uint32_t)a2) && rc != ETIMEDOUT && !e->deleted)
             rc = pthread_cond_timedwait(&e->c, &e->m, &dl);
         timespec t1; clock_gettime(CLOCK_MONOTONIC, &t1);
         int64_t spent_i = (int64_t)(t1.tv_sec - t0.tv_sec) * 1000000
                         + ((int64_t)t1.tv_nsec - (int64_t)t0.tv_nsec) / 1000;
         uint64_t spent = spent_i < 0 ? 0u : (uint64_t)spent_i;
         *(uint32_t*)(uintptr_t)a4 = spent >= usec ? 0u : (uint32_t)(usec - spent);
-        if (!evf_match(e->bits, a1, (uint32_t)a2)) ret = 0x8002003Cull;  // KERNEL_ERROR_ETIMEDOUT
+        if (!e->deleted && !evf_match(e->bits, a1, (uint32_t)a2)) ret = 0x8002003Cull;  // ETIMEDOUT
     } else {
-        while (!evf_match(e->bits, a1, (uint32_t)a2)) pthread_cond_wait(&e->c, &e->m);
+        while (!evf_match(e->bits, a1, (uint32_t)a2) && !e->deleted) pthread_cond_wait(&e->c, &e->m);
     }
+    bool deleted = e->deleted;                     // deleted under us -> EACCES (Kyty EventFlag.cpp)
+    if (deleted) ret = 0x8002000Dull;
     uint64_t res = e->bits;
     if (!ret) { if (a2 & 0x10) e->bits = 0; else if (a2 & 0x20) e->bits &= ~a1; }  // CLEAR_ALL / CLEAR_PAT
+    bool last = (--e->waiters == 0) && deleted;    // last waiter out of a deleted flag frees it
     pthread_mutex_unlock(&e->m);
+    if (last) ef_destroy(e);                        // safe: `res` was copied before the free
     if (a3) *(uint64_t*)(uintptr_t)a3 = res;
     return ret;
 }
@@ -438,7 +457,12 @@ HLE(k_ef_poll)    { // (ef, pattern, waitMode, resultPat*)
 }
 
 // --- semaphores (SceKernelSema): counting sem with wait/signal ---
-namespace { struct Sema { pthread_mutex_t m; pthread_cond_t c; int64_t count; }; }
+// deleted/waiters: same defer-free-to-last-waiter scheme as EventFlag above (delete under a blocked
+// waiter would otherwise free the mutex/condvar out from under it — UAF).
+namespace {
+    struct Sema { pthread_mutex_t m; pthread_cond_t c; int64_t count; bool deleted; int waiters; };
+    void sema_destroy(Sema* s) { pthread_mutex_destroy(&s->m); pthread_cond_destroy(&s->c); free(s); }
+}
 HLE(k_sema_create) { // (sema*, name, attr, initCount, maxCount, opt)
     auto* s = (Sema*)calloc(1, sizeof(Sema));
     pthread_mutex_init(&s->m, nullptr); pthread_cond_init(&s->c, nullptr); s->count = (int64_t)(int32_t)a3;
@@ -448,29 +472,43 @@ HLE(k_sema_create) { // (sema*, name, attr, initCount, maxCount, opt)
                          (long long)(int32_t)a3, (long long)(int32_t)a4);
     return 0;
 }
-HLE(k_sema_delete) { if (a0) free((void*)(uintptr_t)a0); return 0; }
+HLE(k_sema_delete) {
+    auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0;
+    pthread_mutex_lock(&s->m);
+    s->deleted = true;
+    pthread_cond_broadcast(&s->c);
+    bool has_waiters = s->waiters > 0;
+    pthread_mutex_unlock(&s->m);
+    if (!has_waiters) sema_destroy(s);
+    return 0;
+}
 HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout honored like k_ef_wait
     auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
     if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
     uint64_t ret = 0;
     pthread_mutex_lock(&s->m);
+    s->waiters++;
     if (a2) {
         uint32_t usec = *(uint32_t*)(uintptr_t)a2;
         timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
         timespec dl = abs_deadline_us(usec);
         int rc = 0;
-        while (s->count < need && rc != ETIMEDOUT) rc = pthread_cond_timedwait(&s->c, &s->m, &dl);
+        while (s->count < need && rc != ETIMEDOUT && !s->deleted) rc = pthread_cond_timedwait(&s->c, &s->m, &dl);
         timespec t1; clock_gettime(CLOCK_MONOTONIC, &t1);
         int64_t spent_i = (int64_t)(t1.tv_sec - t0.tv_sec) * 1000000
                         + ((int64_t)t1.tv_nsec - (int64_t)t0.tv_nsec) / 1000;
         uint64_t spent = spent_i < 0 ? 0u : (uint64_t)spent_i;
         *(uint32_t*)(uintptr_t)a2 = spent >= usec ? 0u : (uint32_t)(usec - spent);
-        if (s->count < need) ret = 0x8002003Cull;    // KERNEL_ERROR_ETIMEDOUT
+        if (!s->deleted && s->count < need) ret = 0x8002003Cull;    // KERNEL_ERROR_ETIMEDOUT
     } else {
-        while (s->count < need) pthread_cond_wait(&s->c, &s->m);
+        while (s->count < need && !s->deleted) pthread_cond_wait(&s->c, &s->m);
     }
+    bool deleted = s->deleted;                       // deleted under us -> EACCES
+    if (deleted) ret = 0x8002000Dull;
     if (!ret) s->count -= need;
+    bool last = (--s->waiters == 0) && deleted;
     pthread_mutex_unlock(&s->m);
+    if (last) sema_destroy(s);
     return ret; }
 HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n = a1 ? (int64_t)a1 : 1;
     if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);

--- a/prosper/tests/test_sync_delete.cpp
+++ b/prosper/tests/test_sync_delete.cpp
@@ -1,0 +1,87 @@
+// test_sync_delete — guards sceKernelDeleteEventFlag / sceKernelDeleteSema against blocked waiters
+// (issue #104). Deleting an event flag or semaphore while a thread is parked in WaitEventFlag /
+// WaitSema previously free()'d the object out from under the waiter (destroying a pthread condvar
+// with waiters is UB). The fix marks the object deleted, wakes waiters (which return EACCES), and
+// defers the free to the last waiter leaving. This drives it through the NID registry: park a
+// waiter, delete from the main thread, and assert the waiter wakes with EACCES and nothing crashes.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static constexpr uint32_t kEACCES = 0x8002000Du;
+
+int main() {
+    printf("== test_sync_delete ==\n");
+    register_builtin_hle();
+
+    auto ef_create = Hle::lookup(nid_hash("sceKernelCreateEventFlag"));
+    auto ef_wait   = Hle::lookup(nid_hash("sceKernelWaitEventFlag"));
+    auto ef_delete = Hle::lookup(nid_hash("sceKernelDeleteEventFlag"));
+    auto se_create = Hle::lookup(nid_hash("sceKernelCreateSema"));
+    auto se_wait   = Hle::lookup(nid_hash("sceKernelWaitSema"));
+    auto se_delete = Hle::lookup(nid_hash("sceKernelDeleteSema"));
+    CHECK(ef_create && ef_wait && ef_delete && se_create && se_wait && se_delete, "ef/sema fns registered");
+    if (!(ef_create && ef_wait && ef_delete && se_create && se_wait && se_delete)) { printf("== FAIL ==\n"); return 1; }
+
+    // --- EventFlag: park a thread on an infinite wait for a bit-pattern that never gets set, then
+    //     delete the flag. The waiter must wake with EACCES (not hang, not crash on freed memory). ---
+    {
+        void* ef = nullptr;
+        ef_create((uint64_t)(uintptr_t)&ef, 0, 0, 0 /*initPattern*/, 0, 0);
+        CHECK(ef != nullptr, "event flag created");
+        std::atomic<uint64_t> wret{~0ull}; std::atomic<bool> done{false};
+        std::thread t([&]{
+            uint64_t r = ef_wait((uint64_t)(uintptr_t)ef, 0x1 /*pattern*/, 0 /*mode OR*/, 0, 0 /*infinite*/, 0);
+            wret.store(r); done.store(true);
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));   // let it block in the wait
+        CHECK(!done.load(), "event-flag waiter is parked before delete");
+        ef_delete((uint64_t)(uintptr_t)ef, 0, 0, 0, 0, 0);
+        for (int i = 0; i < 200 && !done.load(); i++) std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        CHECK(done.load(), "DeleteEventFlag woke the parked waiter (no hang)");
+        if (done.load()) t.join(); else { t.detach(); }
+        CHECK((uint32_t)wret.load() == kEACCES, "woken event-flag waiter returned EACCES");
+    }
+
+    // --- Semaphore: same shape — park on a count that never arrives, delete, expect EACCES wake. ---
+    {
+        void* se = nullptr;
+        se_create((uint64_t)(uintptr_t)&se, 0, 0, 0 /*initCount*/, 8 /*maxCount*/, 0);
+        CHECK(se != nullptr, "semaphore created");
+        std::atomic<uint64_t> wret{~0ull}; std::atomic<bool> done{false};
+        std::thread t([&]{
+            uint64_t r = se_wait((uint64_t)(uintptr_t)se, 1 /*need*/, 0 /*infinite*/, 0, 0, 0);
+            wret.store(r); done.store(true);
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+        CHECK(!done.load(), "semaphore waiter is parked before delete");
+        se_delete((uint64_t)(uintptr_t)se, 0, 0, 0, 0, 0);
+        for (int i = 0; i < 200 && !done.load(); i++) std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        CHECK(done.load(), "DeleteSema woke the parked waiter (no hang)");
+        if (done.load()) t.join(); else { t.detach(); }
+        CHECK((uint32_t)wret.load() == kEACCES, "woken semaphore waiter returned EACCES");
+    }
+
+    // --- Delete with NO waiters must also be safe (frees immediately, no crash on a later create). ---
+    {
+        void* ef = nullptr; ef_create((uint64_t)(uintptr_t)&ef, 0, 0, 0, 0, 0);
+        ef_delete((uint64_t)(uintptr_t)ef, 0, 0, 0, 0, 0);
+        void* se = nullptr; se_create((uint64_t)(uintptr_t)&se, 0, 0, 0, 8, 0);
+        se_delete((uint64_t)(uintptr_t)se, 0, 0, 0, 0, 0);
+        CHECK(true, "delete with no waiters frees cleanly");
+    }
+
+    if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #104

`k_ef_delete` / `k_sema_delete` `free()`'d the primitive while other threads could be blocked in `pthread_cond_wait` on its embedded mutex/condvar — destroying a condvar with waiters is UB, and the woken waiter then touched freed memory. Sony wakes waiters with an error first (Kyty `EventFlag.cpp`: a wait on a deleted flag returns `KERNEL_ERROR_EACCES` = 0x8002000D).

Both `EventFlag` and `Sema` gain `deleted` + `waiters`:
- **delete** marks the object, `pthread_cond_broadcast`es to wake every waiter, and — if any are parked — defers the destroy+free to the last waiter leaving; with no waiters it frees immediately.
- **wait** loops re-check `deleted`, return EACCES when deleted under them, and the last waiter out of a deleted object destroys the mutex/cond and frees it (the result value is copied to a local before the free).

The object is freed exactly once, by whichever actor is last out — no leak, no double-free, no UAF. Rare (teardown race) but a genuine UAF, fully isolated in `hle_kernel.cpp`.

**Verification:** new `test_sync_delete` parks a real thread in an infinite `WaitEventFlag` / `WaitSema`, deletes from the main thread, and asserts the waiter wakes with EACCES and neither hangs nor crashes on freed memory; plus the no-waiter delete path. Full ctest **49/49**.

Lane: `area:messenger` (shared kernel infra).