### PR TITLE
fix(ue4): SetBuffer no longer maps over live guest heap — boots through RHI/Engine startup (#88)

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -238,7 +238,64 @@ real post-footer reads it previously never reached: the FPakFile **index** at th
 id=10, 17.8 GB) — i.e. IoStore container mounting is complete. CONFIDENCE: HIGH (offset/size/dst all
 verified on live reads; PreInit-passes is the end-to-end proof).
 
-### NEW WALL: post-mount engine/RHI init — a null virtual call (racy, two faces)
+### SOLVED (2026-07-08, issue #88): the null virtual call was a SetBuffer heap clobber
+
+Full causal chain, proven step by step (single-run reg-time vs crash-time dumps + a silent HW
+write-watch):
+
+1. The `eboot+0x24c75ef` `call *0x10(%rax)` is `IModuleInterface::StartupModule()` inside
+   `FModuleManager::LoadModuleWithFailureReason` (the "LoadModule  - " boot scope) — loading
+   **"Engine"** from `SCOPED_BOOT_TIMING("LoadPreInitModules")`. The rbp-chain backtrace hid the
+   real fault: it is INSIDE `FEngineModule::StartupModule` at `eboot+0x503b72e/731`
+   (`mov (%rbx),%rax ; call *0xb0(%rax)`), where `rbx` = a guarded function-local static caching
+   `IConsoleManager::FindConsoleVariable(L"r.Shadow.CacheWPOPrimitives")` — which returned NULL,
+   and the code calls `SetOnChangedCallback` on it with no null check (a sibling block does the
+   same for `r.ShowMaterialDrawEvents`).
+2. The CVar IS registered: the TAutoConsoleVariable static ctor (in the eboot's .ctors table —
+   walked backward from `0x4094939e8` to the -1 sentinel by DT_INIT at eboot+0x10; all 1498 ran)
+   called `RegisterConsoleVariable` successfully; the object sat in FConsoleManager's 3000+ entry
+   map. But by StartupModule time the map entry's FString KEY DATA was ALL ZEROS in place —
+   FindConsoleVariable can never match it.
+3. The zeroing had NO writer (a HW write-watch on the exact key address never fired): it was a
+   MAPPING REPLACED UNDER THE VA. `k_ampr_push_map` (sceAmprCommandBufferSetBuffer HLE) treated
+   EVERY SetBuffer as "map fresh phys page at va (+ mirror at va-0x540000000)". The APR read
+   flow also issues SetBuffer for an ALREADY-LIVE 0x4000-byte descriptor buffer
+   (`va=0x15a0dfc000`), and the MIRROR (`0x1060dfc000`) MAP_FIXED'd fresh zero pages over live
+   MallocBinned heap — the exact 16KB holding the console map's key strings.
+4. Fix (hle_kernel_mem.cpp): the two SetBuffer flavors are discriminated by their own args —
+   captured live: map flavor has `a3 != va, a4 = 0xffffffff sentinel`; existing-buffer flavor has
+   `a3 == va, a4 = allocCtx, a5 = small flags` (13/13 and 3/3 in capture). The existing-buffer
+   flavor is now a memory no-op. The worker-thread face was the same corruption seen from the
+   other side.
+5. Companion fix (hle_file.cpp): the read-submit dst write (`process_vm_writev`) cannot fault
+   through the lazy-commit SIGSEGV handler, so an untouched reserved dst returned EFAULT and the
+   record published the PROSPER-OWNED staging pointer — which the engine later
+   `FMemory::Free()`d ("FMallocBinned3 Attempt to free an unrecognized block"). The dst write now
+   commits lazy 64K pages exactly like the fault handler and retries.
+
+**Result: boot passes LoadPreInitModules, `FConfigCacheIni::InitializeConfigSystem` runs (the
+BinaryConfig probe prints), plugin/localization/ICU pak reads all serve, and the engine reads
+`DefaultEngine.ini` from the pak.** Note this build's PreInit really does run LoadPreInitModules
+BEFORE InitializeConfigSystem (verified in the binary at `eboot+0x7af3` vs `+0x7eda`).
+
+### NEW WALL (deterministic): FMallocBinned3 "Attempt to free an unrecognized block"
+
+Right after the engine reads the `DefaultEngine.ini` pak entry (off=0x2dcc378, 46135 bytes,
+served OK — the command buffer even carries the UTF-16 name), the main thread hits
+`LowLevelFatalError [Line: 1228] FMallocBinned3 Attempt to free an unrecognized block` inside the
+config-load call chain (`eboot+0x2451492 <- +0x245217a <- +0x245288d <- +0x24561a1 <- +0x24b1153
+<- +0x243e8ca <- +0x243ff73 <- +0x24679e8`), then UE's own crash handler prints a backtrace and
+aborts (`libc.prx+0x48e0`). 4/4 runs deterministic. The `[nullpage] addr=0x8 rip=eboot+0x22ebe7f`
+line right before it is BENIGN — that is UE's rbp-chain backtrace walker hitting the null
+terminator during crash reporting, not a fault. Suspects: the freed pointer is likely a pak-read
+buffer pointer the engine did not allocate (check the remaining record/descriptor contract of the
+0xdd/0xde pak callsites for compressed entries — `PakFileCompressionFormats=Oodle`,
+`bCompressed=True`: DefaultEngine.ini's entry is compressed, and the post-read decompress path
+is where the bogus free happens). The five still-unimplemented libSceAmpr NIDs
+(`vWU-odnS+fU sSAUCCU1dv4 tZDDEo2tE5k GnxKOHEawhk H896Pt-yB4I`) fire during mount and may be part
+of the compressed-read contract.
+
+### OLD ANALYSIS (superseded): post-mount engine/RHI init — a null virtual call (racy, two faces)
 
 Boot now reaches early UE engine init and dies in one of two timing-dependent spots (the RHI /
 task-graph worker threads are now live, so it is nondeterministic):

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -499,6 +499,10 @@ HLE(f_apr_resolve) {
 // scope (NOT inside the extern "C" handler, where a block-scope extern would take C linkage and
 // miss the mangled prosper:: definition).
 extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
+// Tracked-mapping state probe (hle_kernel_mem.cpp): 1 = addr is inside a guest-RESERVED range
+// whose pages lazy-commit on first touch. Used by the read path's dst-write to replicate the
+// fault handler's commit-on-write semantics for kernel-side (process_vm_writev) copies.
+extern "C" int prosper_reserved_range_state(uint64_t addr);
 
 #ifndef _WIN32
 // MUST NOT be `__thread` (issue #89). An initial-exec thread-local here (`%fs:...@tpoff`) grows the
@@ -709,6 +713,29 @@ HLE(f_apr_read_submit) {
         if (size) {
             struct iovec l { slot, (size_t)size }, r { (void*)(uintptr_t)a4, (size_t)size };
             in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+            if (!in_dst) {
+                // The kernel-side writev CANNOT fault through prosper's SIGSEGV lazy-commit
+                // handler, so a dst inside a guest-RESERVED range whose pages were never touched
+                // reports EFAULT even though a real guest write would succeed (the fault handler
+                // would back the page). That EFAULT used to demote the read to "publish the
+                // prosper-owned staging pointer through the record" — and the engine later
+                // FMemory::Free()d that HOST pointer: "FMallocBinned3 Attempt to free an
+                // unrecognized block" during config-file loads (issue #88's second face).
+                // Replicate the guest-write semantics instead: commit the lazy 64K pages the
+                // exact way the fault handler does, then retry once. CONFIDENCE: HIGH (same
+                // policy as the lazy-commit path in exec_image_linux.cpp).
+                bool committed = false;
+                for (uint64_t p = a4 & ~0xffffull; p < a4 + size; p += 0x10000) {
+                    unsigned char vec;
+                    if (mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
+                        prosper_reserved_range_state(p) == 1 &&
+                        mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == (void*)(uintptr_t)p)
+                        committed = true;
+                }
+                if (committed)
+                    in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+            }
         } else in_dst = true;
     }
     if (ok && a2) {

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -536,7 +536,42 @@ HLE(k_ampr_begin) {
     return 0;
 }
 HLE(k_ampr_push_map) {
+    MLOG("ampr SetBuffer args a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
     if (a1 && a2) {
+        // Back the page from the shared phys pool so BOTH pool views alias the same bytes: the
+        // guest WRITES its MallocBinned pool-page headers through this (high) view and READS them
+        // through a second view exactly 0x540000000 lower (empirically pinned — the two views'
+        // canary reads returned zeros with independent anonymous pages). Map the mirror too.
+        // CONFIDENCE: LOW on the 0x540000000 rule (observed constant, one title) — refine by
+        // finding the guest's own second-view creation; the aliasing itself is the HW contract.
+        //
+        // TWO FLAVORS of SetBuffer, discriminated by live arg capture (issue #88 root cause):
+        //   MAP flavor      — (cb, va, len, a3!=va, a4=0xffffffff/-1 sentinel, a5=0/0x720):
+        //                     "map fresh direct memory at va" (the AMM pool flow; the guest
+        //                     expects FRESH ZEROED pages, like sceKernelMapDirectMemory).
+        //   BUFFER flavor   — (cb, va, len, a3==va, a4=allocCtx e.g. 0x2001c10060, a5=3/0x2d):
+        //                     "use this ALREADY-EXISTING buffer" (the APR read flow's 0x40-byte
+        //                     completion records and its 0x4000 descriptor buffer). Real HW does
+        //                     NOT touch the buffer's memory here.
+        // The old handler treated BOTH as map requests. For the BUFFER flavor the target
+        // (va=0x15a0dfc000 len=0x4000) — and worse, the va-0x540000000 "second view" mirror —
+        // landed on LIVE MallocBinned heap holding the console manager's registered-CVar name
+        // strings; MAP_FIXED silently replaced them with fresh zero pages (invisible to HW
+        // watchpoints: no CPU store ever happened). The zeroed key made FEngineModule::
+        // StartupModule's FindConsoleVariable("r.Shadow.CacheWPOPrimitives") return null ->
+        // null virtual call -> rip=0: the issue-#88 crash. Registering the buffer is a no-op for
+        // memory state, so the BUFFER flavor now leaves memory strictly untouched.
+        // CONFIDENCE: HIGH on the discriminator (a3==a1 in all 13 captured buffer-flavor calls,
+        // a3!=a1 + a4 sentinel in all 3 captured map-flavor calls) and on the clobber diagnosis
+        // (single-run reg-time vs crash-time key dump + silent HW write-watch).
+        if (a3 == a1) {
+            MLOG("ampr set-buffer va=0x%llx len=0x%llx ctx=0x%llx flags=0x%llx -> no-op (existing buffer)\n",
+                 (unsigned long long)a1, (unsigned long long)a2, (unsigned long long)a4,
+                 (unsigned long long)a5);
+            return 0;
+        }
         // Back the page from the shared phys pool so BOTH pool views alias the same bytes: the
         // guest WRITES its MallocBinned pool-page headers through this (high) view and READS them
         // through a second view exactly 0x540000000 lower (empirically pinned — the two views'

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -1,6 +1,8 @@
 #include "linker.hpp"
 #include <unordered_map>
 #include <cstring>
+#include <cstdio>
+#include <cstdlib>
 
 namespace prosper {
 
@@ -79,6 +81,14 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
     // own ctors via _start; PRX modules need their init_array run by the loader). We run
     // them in reverse load order (deepest dependency first). init_array entries were just
     // relocated to absolute addresses, so read them straight from the image. ---
+    if (getenv("PROSPER_INITLOG")) {
+        for (size_t i = 0; i < out.mods.size(); i++) {
+            const Module& m = *out.mods[i];
+            fprintf(stderr, "[initlog] module %zu base=0x%llx init_va=0x%llx init_array_va=0x%llx entries=%llu\n",
+                    i, (unsigned long long)out.imgs[i].base, (unsigned long long)m.init_va,
+                    (unsigned long long)m.init_array_va, (unsigned long long)(m.init_array_sz / 8));
+        }
+    }
     for (size_t i = out.mods.size(); i-- > 1; ) {
         const Module& m = *out.mods[i];
         LoadedImage& img = out.imgs[i];


### PR DESCRIPTION
## Fixes #88 — UE4 boots through RHI/Engine module startup into config-system init

With IoStore mounting working, the UE4 title (PPSA17942) crashed at a null virtual call (`rip=0x0`) right after `GEngineLoop.PreInit`. Root-caused and fixed; the engine now advances through `FEngineModule::StartupModule`, `FConfigCacheIni::InitializeConfigSystem`, plugin-manifest/localization/ICU reads, and into `DefaultEngine.ini` loading.

### Root cause (two bugs, both in this PR; independently confirmed by three separate investigations)
1. **`k_ampr_push_map` (sceAmprCommandBufferSetBuffer) mapped a mirror over live heap.** It treated *every* SetBuffer as "map fresh phys at `va` + a mirror at `va-0x540000000`". But the APR read flow also SetBuffers an **already-live** descriptor buffer; its mirror `MAP_FIXED`'d fresh zero pages **over live MallocBinned heap** — wiping the CVar key strings, so `FindConsoleVariable("r.Shadow.CacheWPOPrimitives")` returned null and `FEngineModule::StartupModule` called through the null (`call *0xb0` → with NULL_PAGE feeding zeros → `rip=0`). The two SetBuffer flavors are now discriminated by their live-captured args (map: `a3≠va, a4=0xffffffff`; existing-buffer: `a3==va` → strict no-op).
2. **`f_apr_read_submit` published prosper's host staging pointer.** Its `process_vm_writev` into the guest dst couldn't fault through the lazy-commit handler; an untouched reserved dst EFAULT'd and the completion record then published prosper's *host* buffer pointer, which the engine later `FMemory::Free`d. It now commits the lazy 64K pages exactly like the fault handler and retries.

### Verified
- Crash at `eboot+0x24c75ef` (and its worker-thread face) **gone — deterministic across runs**.
- Engine advances through Engine `StartupModule` → config system → `DefaultEngine.ini` read.
- **ctest 50/50**; Messenger render smoke **730–2860+ frames** (no regression to the shared allocator/Ampr paths).

### New wall (documented in `docs/UE4_APR_IOSTORE_BRINGUP.md`)
`FMallocBinned3 "Attempt to free an unrecognized block"` on the main thread right after the **compressed** `DefaultEngine.ini` pak entry read (Oodle, `bCompressed=True`). Prime suspects: the compressed-entry post-read buffer-ownership contract, and five still-unimplemented `libSceAmpr` NIDs that fire during mount.
