### PR TITLE
fix(hle/mem): sceKernelAllocateDirectMemory honors searchStart/searchEnd

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -54,20 +54,31 @@ namespace {
     std::mutex g_dmx;
     std::vector<DMem> g_dmem;
 
-    // Claim `sz` bytes of direct memory at `align` (first-fit over the pool's free gaps). False (no
-    // state change) when nothing fits — callers translate that to SCE_KERNEL_ERROR_ENOMEM
-    // (0x8002000C, Kyty Errno.h). First-fit (not bump) because guests genuinely RELEASE ranges:
-    // UE4 (PPSA17942) probes the pool full with halving allocations, releases the probes, then
-    // allocates its real pools — a bump cursor would be permanently exhausted.
-    bool dmem_take(uint64_t sz, uint64_t align, int type, uint64_t& off_out) {
+    // Claim `sz` bytes of direct memory at `align`, first-fit over the pool's free gaps WITHIN the
+    // caller's [lo, hi) search window (default = the whole pool). False (no state change) when
+    // nothing fits — callers translate that to SCE_KERNEL_ERROR_ENOMEM (0x8002000C, Kyty Errno.h).
+    // sceKernelAllocateDirectMemory passes searchStart/searchEnd here: a guest that partitions
+    // physical memory by window (GPU pool above a CPU pool, etc.) must get an offset inside its
+    // window, not wherever the base-first walk lands. First-fit (not bump) because guests genuinely
+    // RELEASE ranges: UE4 (PPSA17942) probes the pool full with halving allocations, releases the
+    // probes, then allocates its real pools — a bump cursor would be permanently exhausted.
+    bool dmem_take(uint64_t sz, uint64_t align, int type, uint64_t& off_out,
+                   uint64_t lo = 0, uint64_t hi = ~0ull) {
         if (!align) align = 0x4000;
+        if (lo < kDmemBase) lo = kDmemBase;
+        if (hi > kDmemBase + kDmemTotal) hi = kDmemBase + kDmemTotal;
+        if (lo >= hi) return false;
         std::lock_guard<std::mutex> lk(g_dmx);
         uint64_t cursor = kDmemBase;
         size_t insert_at = 0;
         for (size_t i = 0; i <= g_dmem.size(); i++) {
+            uint64_t gap_beg = cursor;
             uint64_t gap_end = (i < g_dmem.size()) ? g_dmem[i].start : kDmemBase + kDmemTotal;
-            uint64_t off = (cursor + align - 1) & ~(align - 1);
-            if (off + sz <= gap_end) { insert_at = i; off_out = off; goto found; }
+            // Clip the free gap to the search window, then align the start.
+            uint64_t beg = gap_beg < lo ? lo : gap_beg;
+            uint64_t end = gap_end > hi ? hi : gap_end;
+            uint64_t off = (beg + align - 1) & ~(align - 1);
+            if (off + sz <= end) { insert_at = i; off_out = off; goto found; }
             if (i < g_dmem.size()) cursor = g_dmem[i].end;
         }
         return false;
@@ -276,12 +287,15 @@ HLE(k_map_flexible) {
 }
 
 // sceKernelAllocateDirectMemory(off_t start, off_t end, size_t len, size_t align, int memType, off_t* physOut)
-HLE(k_alloc_dmem) {
+HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, physAddrOut)
     uint64_t align = a3 ? a3 : 0x4000;
     uint64_t sz = align_up(a2, align);
     uint64_t off;
-    if (!dmem_take(sz, align, (int)a4, off)) {
-        MLOG("alloc_dmem len=0x%llx -> ENOMEM (pool exhausted)\n", (unsigned long long)a2);
+    // Honor the [searchStart, searchEnd) window (a0/a1) — dropping it handed the guest an offset
+    // outside the window it asked for.
+    if (!dmem_take(sz, align, (int)a4, off, a0, a1 ? a1 : ~0ull)) {
+        MLOG("alloc_dmem len=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
+             (unsigned long long)a2, (unsigned long long)a0, (unsigned long long)a1);
         return 0x8002000Cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
     dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -82,6 +82,24 @@ int main() {
     avail(0, kEnd, 0x4000, (uint64_t)(uintptr_t)&phys, (uint64_t)(uintptr_t)&size, 0);
     CHECK(phys == kBase && size == kTotal, "available after release -> whole pool free again");
 
+    // --- Allocate HONORS the search window (issue #108): a request constrained to a window well
+    //     above the pool base must land INSIDE that window, not at the base as before. ---
+    {
+        uint64_t wlo = 0x40000000ull;                 // 1 GiB into the pool
+        uint64_t p = 0;
+        uint64_t rr = alloc(wlo, wlo + 0x200000, 0x100000, 0x4000, 0, (uint64_t)(uintptr_t)&p);
+        CHECK(rr == 0 && p >= wlo && p + 0x100000 <= wlo + 0x200000,
+              "allocate honors [searchStart,searchEnd) -> phys inside the window");
+        release(p, 0x100000, 0, 0, 0, 0);
+    }
+    // A window too small for the request -> ENOMEM (not a base-of-pool fallback).
+    {
+        uint64_t wlo = 0x50000000ull; uint64_t p = 0xdead;
+        uint64_t rr = alloc(wlo, wlo + 0x1000 /*window < 0x100000 request*/, 0x100000, 0x4000, 0,
+                            (uint64_t)(uintptr_t)&p);
+        CHECK((uint32_t)rr == 0x8002000Cu, "allocate with too-small window -> ENOMEM (no out-of-window fallback)");
+    }
+
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #108

`k_alloc_dmem` dropped its `searchStart`/`searchEnd` args (a0/a1) and always first-fit from the pool base. A guest that partitions physical memory by window — the standard Orbis/Prospero pattern (a GPU-visible pool above a CPU pool, etc.) — could receive a phys offset **outside** the window it requested; an assert or bitmap indexed by `(phys - searchStart)` then runs out of range.

`dmem_take` now accepts an optional `[lo, hi)` window and clips each free gap to it. The two non-ranged callers (`AllocateMainDirectMemory`, the Ampr push-map) keep the whole-pool default; `AllocateDirectMemory` passes its window and returns `ENOMEM` when nothing fits inside it. Naturally pairs with the `dmem_largest_free` range walk added in #99.

**Verification:** `test_dmem` extended — a windowed allocation lands inside `[searchStart, searchEnd)`, and a window too small for the request returns `ENOMEM` rather than the old out-of-window base fallback. Full ctest **50/50** (Linux; the dmem test is `#ifdef __linux__`-guarded and skips on the Windows/MinGW build where the memory HLE doesn't exist — the fix applied in #100).

Lane: `area:messenger` (shared kernel infra).