### PR TITLE
fix(self): va2foff resolves PT_LOAD before DYNAMIC — unblocks PPSA02664 boot (0→1015 imports)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -60,6 +60,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)
 
+  # va2foff resolution order (issue #113): DYNAMIC/PROCPARAM/TLS must never shadow
+  # the PT_LOAD that truly maps a VA. Pure unit test — no game dump required.
+  add_executable(test_va2foff tests/test_va2foff.cpp)
+  target_link_libraries(test_va2foff PRIVATE prosper_core)
+  add_test(NAME va2foff_load_priority COMMAND test_va2foff)
+
   # sceAudioOut HLE: format decode, port lifecycle, PCM forwarding, volume, batch, error paths
   # (via a capturing AudioSink — headless, no device).
   add_executable(test_audio tests/test_audio.cpp)

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -30,8 +30,21 @@ struct Rela { uint64_t r_offset, r_info; int64_t r_addend; };
 #pragma pack(pop)
 
 int64_t Module::va2foff(uint64_t va) const {
+    // Resolve against PT_LOAD segments FIRST — they define the actual mapped image,
+    // and the dynamic tables (DYNAMIC/strtab/symtab/relocs) physically live inside
+    // them. `loads` also carries non-LOAD file-backed phdrs (DYNAMIC/PROCPARAM/TLS)
+    // as a fallback for layouts where those sit outside every LOAD; but such an entry
+    // must NEVER shadow the LOAD that truly contains the VA. A DYNAMIC phdr whose own
+    // logical p_offset addresses unmapped bytes would otherwise self-resolve when its
+    // phdr precedes the covering LOAD in program-header order, returning garbage —
+    // exactly the "0 imports" boot failure in issue #113 (PPSA02664). Two passes:
+    // LOAD wins; non-LOAD only when no LOAD maps the address.
     for (auto& L : loads)
-        if (va >= L.vaddr && va < L.vaddr + L.filesz) return (int64_t)(L.file_off + (va - L.vaddr));
+        if (L.type == PT_LOAD && va >= L.vaddr && va < L.vaddr + L.filesz)
+            return (int64_t)(L.file_off + (va - L.vaddr));
+    for (auto& L : loads)
+        if (L.type != PT_LOAD && va >= L.vaddr && va < L.vaddr + L.filesz)
+            return (int64_t)(L.file_off + (va - L.vaddr));
     return -1;
 }
 const char* Module::str_at(uint64_t off) const {

--- a/prosper/tests/test_va2foff.cpp
+++ b/prosper/tests/test_va2foff.cpp
@@ -1,0 +1,74 @@
+// test_va2foff — regression guard for issue #113 (PPSA02664 booted 0 imports).
+//
+// The bug: Module::va2foff resolves a guest VA to a file offset by scanning
+// `loads`, which carries PT_LOAD *and* the non-LOAD file-backed phdrs
+// (DYNAMIC/PROCPARAM/TLS). The dynamic tables physically live inside a PT_LOAD,
+// but a DYNAMIC phdr's own logical p_offset points at UNMAPPED bytes. When the
+// DYNAMIC entry precedes the covering LOAD in program-header order (as in
+// PPSA02664, but not PPSA24651), a single-pass scan matched DYNAMIC first and
+// returned its garbage self-offset — so the loader parsed 0 dynamic tags / 0
+// imports and jumped to garbage. The fix: resolve PT_LOAD first, non-LOAD only
+// as a fallback. This test needs no game dump — it is a pure va2foff unit check.
+#include "../src/self/module.hpp"
+#include <cstdio>
+
+using namespace prosper;
+
+static int g_fail = 0, g_pass = 0;
+#define CHECK(cond, ...) do { \
+    if (cond) { g_pass++; } \
+    else { g_fail++; printf("  [FAIL] %s:%d  ", __FILE__, __LINE__); printf(__VA_ARGS__); printf("\n"); } \
+} while (0)
+
+static Segment seg(uint32_t type, uint64_t vaddr, uint64_t filesz, uint64_t file_off) {
+    Segment s; s.type = type; s.vaddr = vaddr; s.filesz = filesz; s.memsz = filesz; s.file_off = file_off;
+    return s;
+}
+
+int main() {
+    printf("== test_va2foff (issue #113 regression) ==\n");
+
+    // Reproduce PPSA02664's ordering: DYNAMIC (vaddr inside the LOAD's range) is
+    // listed BEFORE the PT_LOAD that actually contains its bytes. DYNAMIC's own
+    // file_off is the wrong (logical/unmapped) offset; the LOAD's file_off is the
+    // real one. Numbers mirror the real dump: LOAD [0x1aeabb0, +0xb42c0) @file
+    // 0x19bfe60; DYNAMIC vaddr 0x1b9e350 -> correct file 0x1a73600.
+    {
+        Module m;
+        m.loads.push_back(seg(PT_DYNAMIC, 0x1b9e350, 0xb20, 0x1a724f0)); // wrong self-offset, listed first
+        m.loads.push_back(seg(PT_LOAD,    0x1aeabb0, 0xb42c0, 0x19bfe60)); // covering LOAD, listed second
+        int64_t f = m.va2foff(0x1b9e350);
+        CHECK(f == 0x1a73600, "DYNAMIC-before-LOAD: va2foff=0x%llx expected 0x1a73600 (LOAD-resolved, not self-offset)",
+              (unsigned long long)f);
+    }
+
+    // Order-independence: same result when the LOAD is listed first (PPSA24651's
+    // ordering, which worked before the fix — must still work).
+    {
+        Module m;
+        m.loads.push_back(seg(PT_LOAD,    0x1aeabb0, 0xb42c0, 0x19bfe60));
+        m.loads.push_back(seg(PT_DYNAMIC, 0x1b9e350, 0xb20, 0x1a724f0));
+        int64_t f = m.va2foff(0x1b9e350);
+        CHECK(f == 0x1a73600, "LOAD-before-DYNAMIC: va2foff=0x%llx expected 0x1a73600", (unsigned long long)f);
+    }
+
+    // Fallback: a VA that no PT_LOAD covers must still resolve via a non-LOAD
+    // file-backed segment (e.g. PROCPARAM sitting outside every LOAD).
+    {
+        Module m;
+        m.loads.push_back(seg(PT_LOAD,        0x1000, 0x1000, 0x8000));
+        m.loads.push_back(seg(PT_SCE_PROCPARAM, 0x50000, 0x60, 0x40000));
+        int64_t f = m.va2foff(0x50010);
+        CHECK(f == 0x40010, "non-LOAD fallback: va2foff=0x%llx expected 0x40010", (unsigned long long)f);
+    }
+
+    // Unmapped VA returns -1.
+    {
+        Module m;
+        m.loads.push_back(seg(PT_LOAD, 0x1000, 0x1000, 0x8000));
+        CHECK(m.va2foff(0x99999) == -1, "unmapped VA should return -1");
+    }
+
+    printf("\n== %d passed, %d failed ==\n", g_pass, g_fail);
+    return g_fail;
+}

--- a/prosper/tools/self_dump/self_dump.cpp
+++ b/prosper/tools/self_dump/self_dump.cpp
@@ -224,7 +224,7 @@ int main(int argc, char** argv) {
     // resolve DYNAMIC and the dynamic tables (strtab/symtab) by virtual address.
     // In the SELF segment table, the actual data segments have bit 0x800 set;
     // the companion "info/digest" segments (0x..10004) are skipped.
-    struct Load { uint64_t vaddr, memsz, foff, fsz; };
+    struct Load { uint64_t vaddr, memsz, foff, fsz; uint32_t type; };
     std::vector<Load> loads;
     std::map<uint64_t, SelfSegment> data_seg_by_id;   // phdr index -> data segment
     if (is_self)
@@ -235,10 +235,14 @@ int main(int argc, char** argv) {
         uint64_t foff;
         if (is_self && data_seg_by_id.count(i)) foff = data_seg_by_id[i].file_offset;
         else                                    foff = elf_base + p.p_offset;
-        loads.push_back({ p.p_vaddr, p.p_memsz, foff, p.p_filesz });
+        loads.push_back({ p.p_vaddr, p.p_memsz, foff, p.p_filesz, p.p_type });
     }
+    // PT_LOAD wins; non-LOAD file-backed phdrs (DYNAMIC/PROCPARAM/TLS) only resolve a
+    // VA when no LOAD maps it. Mirrors Module::va2foff — without this, a DYNAMIC phdr
+    // preceding its covering LOAD self-resolves to unmapped bytes (issue #113).
     auto va2foff = [&](uint64_t va) -> int64_t {
-        for (auto& L : loads) if (va >= L.vaddr && va < L.vaddr + L.fsz) return (int64_t)(L.foff + (va - L.vaddr));
+        for (auto& L : loads) if (L.type == 1 && va >= L.vaddr && va < L.vaddr + L.fsz) return (int64_t)(L.foff + (va - L.vaddr));
+        for (auto& L : loads) if (L.type != 1 && va >= L.vaddr && va < L.vaddr + L.fsz) return (int64_t)(L.foff + (va - L.vaddr));
         return -1;
     };
 


### PR DESCRIPTION
## Problem (issue #113)

Booting **PPSA02664** (a Unity/IL2CPP title) parsed **zero imports** from the eboot and immediately jumped to garbage:

```
linked 5 modules; 0 imports (0 cross-module, 0 stub slots); 0 init fns
=== RUN ENDED: kind=2  SIGSEGV at addr=0x16588b6  rip=0x16588b6 ===
```

A Unity/IL2CPP eboot necessarily imports hundreds of libkernel/libc/graphics symbols, so `0 imports` was the smoking gun: the dynamic import tables weren't being located for this title's SELF layout.

## Root cause

`Module::va2foff()` maps a guest VA → file offset by scanning `loads`, which carries **PT_LOAD plus the non-LOAD file-backed phdrs** (DYNAMIC/PROCPARAM/TLS). It returned the *first* entry whose `[vaddr, vaddr+filesz)` contained the VA.

The dynamic tables physically live **inside a PT_LOAD**, but a `PT_DYNAMIC` phdr's own logical `p_offset` addresses **unmapped** bytes in a PS5 SELF. When the DYNAMIC entry appears **before** its covering LOAD in program-header order, the single-pass scan matched DYNAMIC first and returned that garbage self-offset → 0 dynamic tags → 0 imports.

- **PPSA24651 (The Messenger)** lists the covering LOAD (ph8) *before* DYNAMIC (ph10) → resolved correctly **by luck**.
- **PPSA02664** lists DYNAMIC (ph6) *before* its LOAD (ph9) → hit the bug.

Verified against raw bytes: the DYNAMIC section resolved to file `0x1a724f0` (garbage `d_tag=0x12f00000000`); the correct LOAD-relative offset is `0x1a73600`, where valid tags (`DT_NEEDED`, `DT_SCE_NEEDED_MODULE`, …) actually begin.

## Fix

Two-pass resolution in `va2foff`: **PT_LOAD wins**; non-LOAD file-backed segments resolve a VA only when no LOAD maps it (preserving the outside-any-LOAD fallback intent). Applied identically to `self_dump` so the diagnostic matches the loader.

## Result

**PPSA02664** after the fix:
```
linked 5 modules; 1015 imports (326 cross-module, 556 stub slots); 4 init fns
```
178 dynamic tags + 583 symbol imports parse (libSceAgc, libScePosix, libSceAvPlayer, …). Boot now advances from the instant garbage-jump SIGSEGV all the way through LocalFileSystem/VideoOut/`ScreenManagerPS5::SetResolutionImmediate` into Unity's `GfxDevicePS5SharedData::CreateWorkload` before a **new, unrelated** downstream crash (filed separately as a follow-up).

**PPSA24651 (The Messenger)** is byte-for-byte unchanged — 612 imports, identical DYNAMIC/strtab/symtab offsets. No regression.

## Tests

- New `test_va2foff` — a **dump-free** unit test pinning: LOAD-priority resolution, order-independence (both phdr orderings), the non-LOAD fallback, and unmapped→`-1`. Runs in CI without a game dump.
- Full suite green: **56/56** ctest on Linux.

Fixes #113