### PR TITLE
fix(hle/libc): printf-family are real variadic functions (%f/stack/%s-past-4th no longer garbage)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -76,6 +76,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)
 
+  # Variadic libc formatters (issue #122): real va_list capture so %f/XMM + stack + %s-past-4th
+  # args format correctly (was a 3-integer-register forward). Cross-platform (host libc printf).
+  add_executable(test_printf tests/test_printf.cpp)
+  target_link_libraries(test_printf PRIVATE prosper_core)
+  add_test(NAME printf_varargs COMMAND test_printf)
+
   # EventFlag/Sema delete-under-waiter safety (issue #104): delete wakes parked waiters with EACCES
   # and defers the free to the last one out, instead of free()ing the object under a live wait (UAF).
   add_executable(test_sync_delete tests/test_sync_delete.cpp)

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -199,11 +199,29 @@ static double m_expm1(double x){return expm1(x);} static float m_expm1f(float x)
 
 HLE(h_vsnprintf) { va_list ap; if (a3) memcpy(&ap, P(a3), sizeof(va_list)); return (uint64_t)(int64_t)vsnprintf((char*)P(a0), (size_t)a1, (const char*)P(a2), ap); }
 HLE(h_vsprintf)  { va_list ap; if (a2) memcpy(&ap, P(a2), sizeof(va_list)); return (uint64_t)(int64_t)vsprintf((char*)P(a0), (const char*)P(a1), ap); }
-// Variadic forms: forward the register args best-effort (handles the common
-// integer/pointer/≤4-arg case; float/stack args are a later refinement).
-HLE(h_snprintf)  { return (uint64_t)(int64_t)snprintf((char*)P(a0), (size_t)a1, (const char*)P(a2), a3, a4, a5); }
-HLE(h_sprintf)   { return (uint64_t)(int64_t)sprintf((char*)P(a0), (const char*)P(a1), a2, a3, a4, a5); }
-HLE(h_printf)    { return (uint64_t)(int64_t)printf((const char*)P(a0), a1, a2, a3, a4, a5); }
+// Variadic forms: REAL C variadic functions, not the old 3-int-register forward (which dropped
+// %f/XMM args, all stack args, and %s past the 4th argument -> garbage output or a SIGSEGV on a
+// bogus %s pointer). The import stub TAIL-JUMPS into these with the guest's SysV call frame intact
+// (GP regs + XMM + AL + overflow stack), so the compiler-generated variadic prologue captures the
+// full argument set and va_start/v*printf format it correctly. Guest pointers are identity-mapped
+// (guest VA == host VA), so the buffer, format string, and any %s arguments are usable host
+// pointers directly — no P() translation needed (the tail-jump passes the raw guest values).
+// CONFIDENCE: HIGH for register + XMM args (the overwhelmingly common case, correct on both the
+// tail-jmp and GUEST_FS swap-stub paths). MED only for args that spill to the STACK (>6 GP or
+// >8 FP) under the GUEST_FS swap stub, whose reframing shifts the overflow area — rare for a
+// format call, and still strictly better than the old register-only truncation.
+static uint64_t h_snprintf(void* buf, size_t n, const char* fmt, ...) {
+    va_list ap; va_start(ap, fmt); int r = vsnprintf((char*)buf, n, fmt, ap); va_end(ap);
+    return (uint64_t)(int64_t)r;
+}
+static uint64_t h_sprintf(void* buf, const char* fmt, ...) {
+    va_list ap; va_start(ap, fmt); int r = vsprintf((char*)buf, fmt, ap); va_end(ap);
+    return (uint64_t)(int64_t)r;
+}
+static uint64_t h_printf(const char* fmt, ...) {
+    va_list ap; va_start(ap, fmt); int r = vprintf(fmt, ap); va_end(ap);
+    return (uint64_t)(int64_t)r;
+}
 HLE(h_puts)      { int r = fputs((const char*)P(a0), stdout); fputc('\n', stdout); return (uint64_t)(int64_t)r; }
 HLE(h_putchar)   { return (uint64_t)(int64_t)putchar((int)a0); }
 HLE(h_fputs)     { return (uint64_t)(int64_t)fputs((const char*)P(a0), a1 ? (FILE*)P(a1) : stdout); }

--- a/prosper/tests/test_printf.cpp
+++ b/prosper/tests/test_printf.cpp
@@ -1,0 +1,65 @@
+// test_printf — guards the variadic libc formatters (hle_libc.cpp, issue #122). The old handlers
+// forwarded only 3 integer registers, so %f (XMM), stack-spilled args, and %s past the 4th argument
+// produced garbage or crashed. The fix makes them real C variadic functions. This looks up the
+// registered function pointer and calls it through its TRUE variadic signature (same SysV ABI the
+// guest uses via the tail-jump stub), exercising the register + XMM + stack capture end to end.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+using SnprintfFn = int (*)(char*, size_t, const char*, ...);
+using SprintfFn  = int (*)(char*, const char*, ...);
+
+int main() {
+    printf("== test_printf ==\n");
+    register_builtin_hle();
+
+    auto snf = (SnprintfFn)(void*)Hle::lookup(nid_hash("snprintf"));
+    auto spf = (SprintfFn)(void*)Hle::lookup(nid_hash("sprintf"));
+    auto snfs = (SnprintfFn)(void*)Hle::lookup(nid_hash("snprintf_s"));
+    CHECK(snf && spf && snfs, "printf-family fns registered");
+    if (!(snf && spf && snfs)) { printf("== FAIL ==\n"); return 1; }
+
+    char buf[256];
+
+    // Mixed args that hit GP registers, XMM (the %f that was totally dropped), AND the stack:
+    // GP varargs: "val"(rcx), 42(r8), 0xabcd(r9), 5(stack), 6(stack) — 5 GP args spill past 3 regs.
+    // FP varargs: 3.25(xmm0). This is the exact shape the old register-only forward mangled.
+    int r = snf(buf, sizeof buf, "%s=%d f=%.2f x=%x a5=%d a6=%lld",
+                "val", 42, 3.25, 0xabcd, 5, (long long)6);
+    CHECK(r > 0, "snprintf returned a positive length");
+    CHECK(strcmp(buf, "val=42 f=3.25 x=abcd a5=5 a6=6") == 0, "snprintf formats %s/%d/%f/%x + stack args");
+
+    // Float-heavy: multiple XMM args must all land correctly.
+    snf(buf, sizeof buf, "%.1f %.1f %.1f %.1f", 1.5, 2.5, 3.5, 4.5);
+    CHECK(strcmp(buf, "1.5 2.5 3.5 4.5") == 0, "snprintf handles multiple %f (XMM) args");
+
+    // %s past the 4th argument (was garbage under the register-only forward).
+    snf(buf, sizeof buf, "%s %s %s %s %s", "a", "b", "c", "d", "e");
+    CHECK(strcmp(buf, "a b c d e") == 0, "snprintf handles %s past the 4th argument");
+
+    // snprintf honors the size bound (truncates, returns the would-be length).
+    char small[8];
+    int wr = snf(small, sizeof small, "%s", "0123456789");
+    CHECK(wr == 10 && strcmp(small, "0123456") == 0, "snprintf truncates to the buffer bound");
+
+    // snprintf_s maps to the same variadic path.
+    snfs(buf, sizeof buf, "%d-%.1f", 7, 2.0);
+    CHECK(strcmp(buf, "7-2.0") == 0, "snprintf_s formats via the variadic path");
+
+    // sprintf (unbounded) into a wide buffer.
+    spf(buf, "%s#%d/%.3f", "k", 9, 0.125);
+    CHECK(strcmp(buf, "k#9/0.125") == 0, "sprintf formats mixed args");
+
+    if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #122

`h_snprintf`/`h_sprintf`/`h_printf` forwarded only the 3 remaining integer registers (`a3/a4/a5`) to host printf, so `%f`/`%g` (XMM), args beyond ~4, and stack-passed args read garbage — and a `%s` pointer past the forwarded registers dereferenced garbage, crashing inside host `vsnprintf`. Guest string formatting was silently corrupt.

They are now **genuine C variadic functions** calling `v*printf`. The import stub tail-jumps into the handler with the guest's SysV frame intact (GP regs + XMM + `AL` + overflow stack), so the compiler-generated variadic prologue captures the full argument set and `va_start` formats it correctly — no hand-written asm. Guest pointers are identity-mapped, so the buffer/format/`%s` pointers are directly usable.

CONFIDENCE: HIGH for register + XMM args (correct on both the tail-jmp and GUEST_FS swap-stub paths); MED only for args that spill to the stack (>6 GP or >8 FP) under the GUEST_FS swap stub, which reframes the call — rare for a format call and still strictly better than the old register-only truncation.

**Verification:** new `test_printf` calls each registered formatter through its true variadic signature (the same SysV ABI the guest uses via the tail-jump) with a mix that exercises GP registers, XMM (`%f`), AND stack spill, plus `%s` past the 4th arg, size-bound truncation, and `snprintf_s`. Full ctest **52/52**; live boot smoke rendered frames with no crash. Cross-platform (host-to-host unit test; real guest execution is Linux-only).

Lane: `area:messenger` (shared libc HLE, isolated file).