### PR TITLE
fix(recompiler): handle VOP1 v_nop — unblocks PPSA02664 vertex shaders (draws no longer skipped)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1280,6 +1280,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             uint32_t& d = vreg[in.dst.value];
             switch (in.opcode) {
+                case 0x00: return true;                              // v_nop — no-op (writes nothing; common
+                                                                     // scheduling/hazard filler in real shaders)
                 case 0x01: d = a; break;                              // v_mov_b32
                 case 0x05: d = b.cvt_i2f(a); break;                   // v_cvt_f32_i32
                 case 0x06: d = b.cvt_u2f(a); break;                   // v_cvt_f32_u32

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1232,6 +1232,23 @@ int main() {
       printf("  kernel68 mismatches=%u (buf[6]=%g expect=12)\n", bad68, f6); }
     CHECK(stored68_out.size() == N && bad68 == 0, "recompiled kernel 68 (raw store routes to binding 3 via SRSRC) correct");
 
+    // Kernel N: v_nop (VOP1 op 0x00) between real ALU ops must be a transparent no-op. This was the
+    // #121 blocker — PPSA02664's vertex shaders contain v_nop (a common scheduling/hazard filler), and
+    // the recompiler rejected it, failing the whole shader and skipping ~182 draws/frame (black screen).
+    //   v_add_f32 v0,v0,v1 | v_nop | v_mul_f32 v0,v0,v2 | s_endpgm  =>  out = (a0+a1)*a2
+    const uint32_t codeN[] = { 0x06000300u, 0x7E000000u, 0x10000500u, 0xBF810000u };
+    std::vector<uint32_t> spvN = recompile_valu(codeN, sizeof(codeN)/sizeof(codeN[0]), 3, 0);
+    CHECK(!spvN.empty(), "recompiled kernel with v_nop -> SPIR-V (v_nop no longer fails the shader)");
+    std::vector<float> inN(N * 3), expN(N);
+    for (uint32_t i = 0; i < N; i++) {
+        float a0 = (float)i * 0.2f - 8.0f, a1 = (float)i * 0.05f + 2.0f, a2 = 1.5f;
+        inN[i*3+0]=a0; inN[i*3+1]=a1; inN[i*3+2]=a2; expN[i] = (a0 + a1) * a2;
+    }
+    std::vector<float> gotN = prosper::test::run_compute(spvN, inN, N, N);
+    uint32_t badN = 0; for (uint32_t i=0;i<N&&gotN.size()==N;i++) if (std::fabs(gotN[i]-expN[i])>1e-3f) badN++;
+    printf("  kernelN(v_nop) mismatches=%u (out[33]=%g expect=%g)\n", badN, gotN.size()==N?gotN[33]:-1, expN[33]);
+    CHECK(gotN.size()==N && badN==0, "v_nop is transparent: out = (a0+a1)*a2 computed correctly");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem (part of #121)

PPSA02664 boots into Unity's render loop and **submits real geometry** (105K DrawIndex, 97K DrawIndexAuto, 90K SubmitDcb) — but the screen is black. Instrumenting the executor showed ~182 draws/frame skipped with `recompile failed (vs=0 ...)`: the **vertex shaders fail to recompile**.

Coverage diagnostic pinned the cause: `first_bad fmt=7 op=0x0` — **VOP1 opcode 0x00 = `v_nop`**. The RDNA2→SPIR-V VOP1 handler had no case for it, so it fell through to `default: ok=false`, failing the entire shader. `v_nop` is a no-op the shader compiler routinely emits as scheduling/hazard filler.

## Fix

Treat `v_nop` as a transparent no-op (handled, writes nothing).

## Effect

Vertex shaders recompile; the executor goes from "rendering 1 draw item (of 2)" to "rendering 2 (of 2)" / "4 (of 5)" / "5 (of 6)". The Messenger (PPSA24651) is unaffected. **56/56 ctest green.**

Adds an execution-kernel regression to `test_rdna2_to_spirv`: `v_nop` between `v_add_f32`/`v_mul_f32` recompiles, runs on Vulkan, and is numerically transparent (out = (a0+a1)*a2).

## Not yet fixed (remaining #121 work — frames still black)

With the VS unblocked, the rendered draws now sample **empty/skipped textures**:
- **Gen5 IMG_FMT 36** (1920×1080, tile_mode 27) is unmapped — it's in the packed-format region (30–55) of the GFX10 combined IMG_FORMAT enum; needs authoritative identification (likely a packed HDR target) before mapping, not a guess.
- **IMG_FMT 173 = BC3** is recognized but **BCn sampling is not wired** in the backend, so the 2048×1024 compressed textures are skipped.

These are the next steps to actual visible pixels; tracked in #121.

Refs #121