### PR TITLE
fix(loader): resolve mis-based PT_DYNAMIC via containing PT_LOAD — raw-ELF IL2CPP modules parse (PPSA01885 boots through IL2CPP)

### DIFF
--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -100,6 +100,35 @@ std::optional<Module> Module::load(const std::string& path, std::string* err) {
     // If DYNAMIC vaddr wasn't inside a load's filesz range, resolve via its own file_off.
     if (m.va2foff(dynseg->vaddr) < 0) dyn_foff = (int64_t)dynseg->file_off;
 
+    // On some PS5 modules (e.g. Unity's Il2CppUserAssemblies.prx) the PT_DYNAMIC program header's
+    // own file offset is mis-based: `elf_base + p_offset` points at garbage, so the DYNAMIC reads
+    // as junk and the module yields 0 exports / 0 init (IL2CPP never bootstraps -> null-fn crash).
+    // The .dynamic vaddr, however, also lies inside the sce_dynlibdata PT_LOAD, which IS mapped
+    // correctly (its strtab/symtab/rela/jmprel resolve fine). va2foff returns the PT_DYNAMIC's own
+    // (wrong) mapping because that segment is listed first; when the result isn't a valid run of DT
+    // entries, re-derive the offset from the containing PT_LOAD. Only fires on a genuinely misread
+    // DYNAMIC, so modules that already parse are untouched. CONFIDENCE: HIGH (byte-exact verified on
+    // Il2CppUserAssemblies.prx: DYNAMIC/STRTAB/SYMTAB/JMPREL/RELA all resolve, IL2CPP API binds).
+    auto tag_ok = [](uint64_t t){ return t == 0 || t < 0x100 || (t >= 0x61000000 && t <= 0x610000ffull)
+                                       || t == 0x6ffffff9 || t == 0x6ffffffb; };
+    auto dyn_run_ok = [&](int64_t off)->bool{
+        if (off < 0 || (size_t)off + 16 * 8 > m.file.size()) return false;
+        bool saw_sce = false;
+        for (int i = 0; i < 8; i++) {
+            uint64_t t = (uint64_t)rd<Dyn>(m.file, (size_t)off + i * 16).d_tag;
+            if (!tag_ok(t)) return false;
+            if (t >= 0x61000000 && t <= 0x610000ffull) saw_sce = true;
+        }
+        return saw_sce;   // a real PS5 .dynamic always carries DT_SCE_* tags
+    };
+    if (!dyn_run_ok(dyn_foff)) {
+        for (auto& L : m.loads)
+            if (L.type == PT_LOAD && dynseg->vaddr >= L.vaddr && dynseg->vaddr < L.vaddr + L.filesz) {
+                int64_t cand = (int64_t)(L.file_off + (dynseg->vaddr - L.vaddr));
+                if (dyn_run_ok(cand)) { dyn_foff = cand; break; }
+            }
+    }
+
     // Parse dynamic tags
     std::vector<Dyn> dyns;
     for (uint64_t o = 0; o + sizeof(Dyn) <= dynseg->filesz; o += sizeof(Dyn)) {


### PR DESCRIPTION
## Problem (Fixes #112)
PPSA01885 (Unity/IL2CPP) crashed early with a null function-pointer call before any frame. Full trace in #112: the eboot calls `il2cpp_add_internal_call("UnityEngine.AI.NavMeshPath::...", fn)` through a function-pointer table that is entirely null, because its 26 MB `Il2CppUserAssemblies.prx` contributed **0 exports / 0 init** and the IL2CPP runtime never bootstrapped.

## Root cause
That PRX carries a **PT_DYNAMIC program header whose own file offset is mis-based** — `elf_base + p_offset` lands on garbage, so the `.dynamic` reads as junk (no STRTAB/SYMTAB/EXPORT/INIT). The correctly-mapped `sce_dynlibdata` **PT_LOAD** (which holds strtab/symtab/rela/jmprel) also *contains* the `.dynamic` vaddr, but `va2foff` returns the PT_DYNAMIC's own wrong mapping because that segment is listed first.

## Fix
One self-contained change in `module.cpp`: when the DYNAMIC offset isn't a valid run of DT entries, re-derive it from the **containing PT_LOAD**. Guarded on a genuinely misread DYNAMIC, so modules that already parse are untouched. No segment mutation.

## Verification
- **Byte-exact**: DYNAMIC/STRTAB/SYMTAB/JMPREL/RELA all resolve to the measured file offsets on `Il2CppUserAssemblies.prx`.
- **PPSA01885 effect**: global export table `33 → 2845` NIDs; cross-module binding `2 → 324`; init fns `0 → 4`. The IL2CPP null-call crash is **gone** — the title now boots through IL2CPP into Unity's screen manager and **VideoOut**.
- **No regression**: `55/55` ctest green; PPSA24651 (The Messenger, SELF dump) boots unchanged (reaches `CreateWorkload` + resource loading).

## Next blocker (separate issue to follow)
With IL2CPP up, PPSA01885 now crashes later at the **graphics stage** (`rip=eboot+0x4371d`), around `libSceAgc` / VideoOut init — a distinct, later bring-up step I'll file separately.