### PR TITLE
feat(gpu): BC1/BC2/BC3 texture decode -> RGBA8 on upload

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -117,6 +117,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_tile PRIVATE prosper_core)
   add_test(NAME gpu_surface_detile COMMAND test_tile)
 
+  # BC1/BC2/BC3 block decompression to RGBA8 (#121): hand-built blocks with known output. Pure.
+  add_executable(test_bc_decode tests/test_bc_decode.cpp)
+  target_link_libraries(test_bc_decode PRIVATE prosper_core)
+  add_test(NAME bc_decode COMMAND test_bc_decode)
+
   add_executable(test_stat tests/test_stat.cpp)
   target_link_libraries(test_stat PRIVATE prosper_core)
   add_test(NAME sce_stat_layout COMMAND test_stat)

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -199,11 +199,14 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                                     "(extend gen5_image_format)\n", d.format, d.width, d.height); }
                 continue;
             }
-            if (fi.block_width > 1) {
+            // Block-compressed: BC1/BC2/BC3 are decoded to RGBA8 on upload (bc_decode). BC4/5/6/7 aren't
+            // decoded yet, so keep skipping them (a raw RGBA8 binding would sample garbage + over-read).
+            const bool is_bcn = fi.block_width > 1;
+            if (is_bcn && fi.format != DataFormat::Bc1 && fi.format != DataFormat::Bc2 &&
+                          fi.format != DataFormat::Bc3) {
                 if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
-                    fprintf(stderr, "[t#] Gen5 IMG_FMT %u is block-compressed (%ux%u T#) -> recognized but "
-                                    "BCn sampling is not wired; skipping texture binding\n",
-                            d.format, d.width, d.height); }
+                    fprintf(stderr, "[t#] Gen5 IMG_FMT %u is block-compressed BC4-7 (%ux%u T#) -> decode not "
+                                    "wired; skipping texture binding\n", d.format, d.width, d.height); }
                 continue;
             }
             ShaderResource r;
@@ -215,7 +218,10 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.width         = d.width;
             r.height        = d.height;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
-            r.size          = d.width * d.height * fi.bytes_per_block;   // real bytes-per-texel (fmt=56 -> *4)
+            // Backing byte size: block-compressed surfaces store one bytes_per_block unit per 4x4 block
+            // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
+            r.size          = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
+                                     : (d.width * d.height * fi.bytes_per_block);
             r.sgpr_base     = user_sgpr_base + off;  // DIRECT provenance key (image_sample SRSRC SGPR)
             r.srt_offset    = 0xFFFFFFFFu;
             table.resources.push_back(r);

--- a/prosper/src/gpu/bc_decode.cpp
+++ b/prosper/src/gpu/bc_decode.cpp
@@ -1,0 +1,102 @@
+// bc_decode.cpp — see bc_decode.hpp. Reference S3TC/DXTn decode (Khronos data-format spec §18-19).
+#include "bc_decode.hpp"
+#include <cstring>
+
+namespace prosper::gpu {
+
+uint32_t bc_block_bytes(DataFormat f) {
+    switch (f) {
+        case DataFormat::Bc1: case DataFormat::Bc4:                       return 8;
+        case DataFormat::Bc2: case DataFormat::Bc3:
+        case DataFormat::Bc5: case DataFormat::Bc6: case DataFormat::Bc7: return 16;
+        default: return 0;
+    }
+}
+
+namespace {
+
+inline uint16_t rd16(const uint8_t* p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+
+// RGB565 -> RGB888 with the standard bit-replication expansion (so 0x1F/0x3F map to 0xFF).
+inline void unpack565(uint16_t c, uint8_t& r, uint8_t& g, uint8_t& b) {
+    uint8_t r5 = (uint8_t)((c >> 11) & 0x1F), g6 = (uint8_t)((c >> 5) & 0x3F), b5 = (uint8_t)(c & 0x1F);
+    r = (uint8_t)((r5 << 3) | (r5 >> 2));
+    g = (uint8_t)((g6 << 2) | (g6 >> 4));
+    b = (uint8_t)((b5 << 3) | (b5 >> 2));
+}
+
+// Decode one BC1 color sub-block (8 bytes) into a 4x4 RGBA8 tile (row-major, 16 texels). `dxt1_alpha`
+// enables BC1's 1-bit punch-through alpha (color index 3 in the c0<=c1 branch = transparent black);
+// BC2/BC3 always use the 4-color branch and supply alpha separately, so pass false there.
+void decode_color_block(const uint8_t* blk, uint8_t out[16][4], bool dxt1_alpha) {
+    uint16_t c0 = rd16(blk), c1 = rd16(blk + 2);
+    uint8_t r[4], g[4], b[4], a[4] = {255, 255, 255, 255};
+    unpack565(c0, r[0], g[0], b[0]);
+    unpack565(c1, r[1], g[1], b[1]);
+    if (c0 > c1 || !dxt1_alpha) {                 // 4-color mode (BC2/BC3 always take this path)
+        r[2] = (uint8_t)((2 * r[0] + r[1]) / 3); g[2] = (uint8_t)((2 * g[0] + g[1]) / 3); b[2] = (uint8_t)((2 * b[0] + b[1]) / 3);
+        r[3] = (uint8_t)((r[0] + 2 * r[1]) / 3); g[3] = (uint8_t)((g[0] + 2 * g[1]) / 3); b[3] = (uint8_t)((b[0] + 2 * b[1]) / 3);
+    } else {                                      // 3-color + transparent (BC1 punch-through)
+        r[2] = (uint8_t)((r[0] + r[1]) / 2); g[2] = (uint8_t)((g[0] + g[1]) / 2); b[2] = (uint8_t)((b[0] + b[1]) / 2);
+        r[3] = g[3] = b[3] = 0; a[3] = 0;
+    }
+    uint32_t idx = (uint32_t)blk[4] | ((uint32_t)blk[5] << 8) | ((uint32_t)blk[6] << 16) | ((uint32_t)blk[7] << 24);
+    for (int t = 0; t < 16; t++) {
+        uint32_t i = (idx >> (t * 2)) & 0x3u;
+        out[t][0] = r[i]; out[t][1] = g[i]; out[t][2] = b[i]; out[t][3] = a[i];
+    }
+}
+
+// BC3 alpha sub-block (8 bytes): two 8-bit endpoints + 16 x 3-bit indices into an 8-entry ramp.
+void decode_bc3_alpha(const uint8_t* blk, uint8_t out[16][4]) {
+    uint8_t a0 = blk[0], a1 = blk[1];
+    uint8_t a[8];
+    a[0] = a0; a[1] = a1;
+    if (a0 > a1) for (int i = 1; i <= 6; i++) a[i + 1] = (uint8_t)(((7 - i) * a0 + i * a1) / 7);
+    else { for (int i = 1; i <= 4; i++) a[i + 1] = (uint8_t)(((5 - i) * a0 + i * a1) / 5); a[6] = 0; a[7] = 255; }
+    uint64_t bits = 0; for (int i = 0; i < 6; i++) bits |= (uint64_t)blk[2 + i] << (i * 8);
+    for (int t = 0; t < 16; t++) out[t][3] = a[(bits >> (t * 3)) & 0x7u];
+}
+
+// BC2 alpha sub-block (8 bytes): 16 x 4-bit direct alpha (bit-replicated to 8-bit).
+void decode_bc2_alpha(const uint8_t* blk, uint8_t out[16][4]) {
+    for (int t = 0; t < 16; t++) {
+        uint8_t nib = (blk[t / 2] >> ((t & 1) * 4)) & 0xF;
+        out[t][3] = (uint8_t)((nib << 4) | nib);
+    }
+}
+
+} // namespace
+
+bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                       uint32_t width, uint32_t height, DataFormat fmt) {
+    const uint32_t bb = bc_block_bytes(fmt);
+    if (fmt != DataFormat::Bc1 && fmt != DataFormat::Bc2 && fmt != DataFormat::Bc3) return false;
+    const uint32_t bw = (width + 3) / 4, bh = (height + 3) / 4;
+    std::memset(dst, 0, (size_t)width * height * 4);
+    for (uint32_t by = 0; by < bh; by++) {
+        for (uint32_t bx = 0; bx < bw; bx++) {
+            size_t boff = ((size_t)by * bw + bx) * bb;
+            if (boff + bb > src_bytes) continue;             // short source -> leave block transparent
+            const uint8_t* blk = src + boff;
+            uint8_t texels[16][4];
+            if (fmt == DataFormat::Bc1) {
+                decode_color_block(blk, texels, /*dxt1_alpha*/true);
+            } else {                                          // BC2/BC3: alpha sub-block then color sub-block
+                decode_color_block(blk + 8, texels, /*dxt1_alpha*/false);
+                if (fmt == DataFormat::Bc3) decode_bc3_alpha(blk, texels);
+                else                        decode_bc2_alpha(blk, texels);
+            }
+            for (int ty = 0; ty < 4; ty++) {
+                uint32_t y = by * 4 + ty; if (y >= height) break;
+                for (int tx = 0; tx < 4; tx++) {
+                    uint32_t x = bx * 4 + tx; if (x >= width) break;
+                    std::memcpy(dst + ((size_t)y * width + x) * 4, texels[ty * 4 + tx], 4);
+                }
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/bc_decode.hpp
+++ b/prosper/src/gpu/bc_decode.hpp
@@ -1,0 +1,28 @@
+// bc_decode.hpp — S3TC/BCn block decompression to linear RGBA8.
+//
+// PS5 art textures are commonly stored block-compressed (BC1/BC2/BC3 = DXT1/3/5). The host upload
+// path needs linear RGBA8 (our sampled-texture backend uploads 4-bytes/texel), and llvmpipe does not
+// universally advertise BC sampling, so we decode CPU-side on upload. Pure + deterministic + testable:
+// given the compressed block bytes for a WxH surface, produce W*H*4 RGBA8 (row-major, top-left origin).
+//
+// Standard S3TC decode (Khronos DXTn spec): a 4x4-texel block is 8 bytes (BC1/BC4) or 16 bytes
+// (BC2/BC3/BC5/BC7). We implement the two the game uses first — BC1 and BC3 — plus BC2 (same color
+// sub-block, explicit-alpha), which cost nothing extra. BC4/5/6/7 are left to a follow-up.
+#pragma once
+#include <cstdint>
+#include "shader_resources.hpp"
+
+namespace prosper::gpu {
+
+// Bytes per 4x4 block for a block-compressed DataFormat (8 for BC1/BC4, 16 for the rest; 0 if `f` is
+// not block-compressed).
+uint32_t bc_block_bytes(DataFormat f);
+
+// Decode a block-compressed surface `src` (bc_block_bytes(fmt) per 4x4 block, blocks row-major over a
+// ceil(w/4) x ceil(h/4) grid) into `dst` as W*H*4 RGBA8. `dst` must hold width*height*4 bytes.
+// `src_bytes` bounds the read (a short/absent source leaves the unreachable texels transparent-black).
+// Returns true if `fmt` is a supported block format (BC1/BC2/BC3), false otherwise (dst untouched).
+bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                       uint32_t width, uint32_t height, DataFormat fmt);
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -1,6 +1,7 @@
 // tile.cpp — see tile.hpp. GFX10 SW_4KB_S de-swizzle for 32-bpp surfaces.
 #include "tile.hpp"
 #include <cstring>
+#include <algorithm>
 
 namespace prosper::gpu {
 
@@ -80,6 +81,37 @@ void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t hei
     const size_t dst_bytes = tiled_surface_bytes(width, height, tile_mode, pitch);
     std::memset(dst, 0, dst_bytes);   // padding texels (rows beyond height) stay zero
     sw4kb_s_copy<true>(dst, src, width, height, pitch, dst_bytes);
+}
+
+size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode) {
+    if (!tile_mode_is_tiled(tile_mode) || tile_side == 0) return (size_t)ew * eh * bpe;
+    uint32_t tiles_per_row = (ew + tile_side - 1) / tile_side, tile_rows = (eh + tile_side - 1) / tile_side;
+    return (size_t)tiles_per_row * tile_rows * (size_t)tile_side * tile_side * bpe;
+}
+
+void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                     uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode) {
+    if (!tile_mode_is_tiled(tile_mode) || tile_side == 0) {
+        size_t n = std::min(src_bytes, (size_t)ew * eh * bpe);
+        std::memcpy(dst, src, n);
+        if (n < (size_t)ew * eh * bpe) std::memset(dst + n, 0, (size_t)ew * eh * bpe - n);
+        return;
+    }
+    uint32_t tb = 0; while ((1u << tb) < tile_side) tb++;       // log2(tile_side)
+    uint32_t tiles_per_row = (ew + tile_side - 1) / tile_side;
+    for (uint32_t y = 0; y < eh; y++)
+        for (uint32_t x = 0; x < ew; x++) {
+            uint32_t tx = x >> tb, ty = y >> tb, ix = x & (tile_side - 1), iy = y & (tile_side - 1);
+            uint32_t morton = 0;
+            for (uint32_t b = 0; b < tb; b++) {
+                morton |= ((iy >> b) & 1u) << (2 * b);
+                morton |= ((ix >> b) & 1u) << (2 * b + 1);
+            }
+            uint64_t t = ((uint64_t)(ty * tiles_per_row + tx) * ((uint64_t)tile_side * tile_side) + morton) * bpe;
+            size_t   l = ((size_t)y * ew + x) * bpe;
+            if (t + bpe <= src_bytes) std::memcpy(dst + l, src + (size_t)t, bpe);
+            else                      std::memset(dst + l, 0, bpe);
+        }
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -41,4 +41,16 @@ std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t wi
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
                   uint32_t tile_mode, uint32_t pitch = 0);
 
+// General SW_4KB_S de-swizzle for `bpe`-byte ELEMENTS (not fixed at 4). The 4KB micro-tile holds
+// 4096/bpe elements arranged `tile_side`x`tile_side` (Morton order, Y in the low bit of each pair,
+// identical structure to the 32-bpp path). Block-compressed surfaces use this with element = one
+// compressed block (BC3 = 16 bytes -> tile_side 16). `dst` holds ew*eh*bpe linear bytes; `src_bytes`
+// bounds the tiled read (short/OOB elements detile to zero). tile_mode!=SW_4KB_S -> straight copy.
+void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                     uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode);
+
+// Byte size of the TILED element surface (element grid padded up to whole tile_side tiles). The caller
+// must read at least this many bytes of tiled source before detiling.
+size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_bc_decode.cpp
+++ b/prosper/tests/test_bc_decode.cpp
@@ -1,0 +1,103 @@
+// test_bc_decode — verify BC1/BC2/BC3 block decompression against hand-built blocks with known output.
+// Exit code 0 = pass. Pure, no Vulkan/game dump.
+#include "../src/gpu/bc_decode.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } else { printf("  [ok]   %s\n", m); } } while (0)
+
+static void put16(uint8_t* p, uint16_t v) { p[0] = (uint8_t)(v & 0xFF); p[1] = (uint8_t)(v >> 8); }
+
+// RGB565 constants
+static const uint16_t RED565 = 0xF800, BLUE565 = 0x001F, GREEN565 = 0x07E0, BLACK565 = 0x0000;
+
+int main() {
+    printf("== test_bc_decode ==\n");
+
+    CHECK(bc_block_bytes(DataFormat::Bc1) == 8, "BC1 block = 8 bytes");
+    CHECK(bc_block_bytes(DataFormat::Bc3) == 16, "BC3 block = 16 bytes");
+    CHECK(bc_block_bytes(DataFormat::Float32) == 0, "non-BC format -> 0 block bytes");
+
+    // --- BC1: solid red 4x4 (c0>c1, all indices 0) ---
+    {
+        uint8_t blk[8] = {0};
+        put16(blk + 0, RED565);   // c0
+        put16(blk + 2, BLUE565);  // c1 (c0>c1 -> 4-color mode)
+        // indices all 0 -> every texel = color0 = red
+        uint8_t out[4 * 4 * 4];
+        bool ok = bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc1);
+        CHECK(ok, "BC1 decode returns true");
+        bool all_red = true;
+        for (int t = 0; t < 16; t++) {
+            const uint8_t* px = out + t * 4;
+            if (px[0] != 255 || px[1] != 0 || px[2] != 0 || px[3] != 255) all_red = false;
+        }
+        CHECK(all_red, "BC1 solid: all 16 texels = opaque red (255,0,0,255)");
+    }
+
+    // --- BC1: interpolated color at index 2 = (2*c0 + c1)/3 ---
+    {
+        uint8_t blk[8] = {0};
+        put16(blk + 0, RED565);    // c0 = (255,0,0)
+        put16(blk + 2, GREEN565);  // c1 = (0,255,0);  c0>c1
+        // set texel 0 to index 2 (2 bits = 0b10 in the low bits)
+        blk[4] = 0x02;
+        uint8_t out[4 * 4 * 4];
+        bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc1);
+        // color2 = (2*255+0)/3=170 R, (2*0+255)/3=85 G
+        CHECK(out[0] == 170 && out[1] == 85 && out[2] == 0, "BC1 index2 = (2*c0+c1)/3 (170,85,0)");
+    }
+
+    // --- BC1: punch-through (c0<=c1) index 3 = transparent black ---
+    {
+        uint8_t blk[8] = {0};
+        put16(blk + 0, BLUE565);   // c0
+        put16(blk + 2, RED565);    // c1 -> c0<c1 -> 3-color+alpha mode
+        blk[4] = 0x03;             // texel 0 index = 3 -> transparent black
+        uint8_t out[4 * 4 * 4];
+        bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc1);
+        CHECK(out[0] == 0 && out[1] == 0 && out[2] == 0 && out[3] == 0, "BC1 punch-through index3 = transparent black");
+    }
+
+    // --- BC3: color = red (4-color, ignores c0<=c1 alpha rule), alpha ramp a0=255/a1=0 ---
+    {
+        uint8_t blk[16] = {0};
+        blk[0] = 255; blk[1] = 0;  // alpha endpoints a0>a1 -> a[0]=255, a[1]=0
+        // alpha indices (bytes 2..7): texel0 -> index 1 (=a1=0), texel1 -> index 0 (=a0=255), rest 0
+        // 3 bits each: texel0=1 (0b001), texel1=0. bits = 0b...000 001 -> byte2 low bits = 0x01
+        blk[2] = 0x01;
+        put16(blk + 8, RED565);    // color c0
+        put16(blk + 10, BLUE565);  // color c1
+        // color indices 0 -> all red
+        uint8_t out[4 * 4 * 4];
+        bool ok = bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc3);
+        CHECK(ok, "BC3 decode returns true");
+        CHECK(out[0] == 255 && out[1] == 0 && out[2] == 0, "BC3 color sub-block = red");
+        CHECK(out[3] == 0, "BC3 texel0 alpha index1 -> a1 = 0");
+        CHECK(out[7] == 255, "BC3 texel1 alpha index0 -> a0 = 255");
+    }
+
+    // --- larger surface: 8x8 BC1, second block a distinct solid color; verify block placement ---
+    {
+        const uint32_t W = 8, H = 8;                 // 2x2 blocks
+        uint8_t blocks[4][8]; std::memset(blocks, 0, sizeof blocks);
+        const uint16_t cols[4] = {RED565, GREEN565, BLUE565, 0xFFFF /*white*/};
+        for (int i = 0; i < 4; i++) { put16(blocks[i] + 0, cols[i]); put16(blocks[i] + 2, BLACK565); } // c0>c1, idx0
+        uint8_t out[W * H * 4];
+        bc_decode_surface(out, (const uint8_t*)blocks, sizeof blocks, W, H, DataFormat::Bc1);
+        // block (1,1) covers texels x=4..7,y=4..7 -> color index 3 = white
+        const uint8_t* px = out + ((size_t)5 * W + 5) * 4;
+        CHECK(px[0] == 255 && px[1] == 255 && px[2] == 255, "BC1 8x8: bottom-right block = white (block layout correct)");
+        // block (0,0) top-left = red
+        CHECK(out[0] == 255 && out[1] == 0 && out[2] == 0, "BC1 8x8: top-left block = red");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -142,7 +142,8 @@ int main() {
     CHECK(t3.by_srt_offset(4 * 4) != nullptr, "constant buffers still present alongside vertex buffers");
     CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
 
-    // --- textures: sharp[0] T#s carry their real format + byte size; BCn/unmapped are skipped (#65) ---
+    // --- textures: sharp[0] T#s carry their real format + byte size; BC1/2/3 are bound (decoded to RGBA8
+    // on upload, #121); BC4-7 + unmapped formats are still skipped (#65) ---
     {
         uint32_t tsgprs[32]; memset(tsgprs, 0, sizeof tsgprs);
         make_tsharp(&tsgprs[0],  0xD0000000ull, 1920, 1080, /*fmt*/56,  /*tile*/5, /*type 2D*/9);
@@ -166,7 +167,7 @@ int main() {
         tshdr.user_data = &tud;
 
         ShaderResourceTable tt = build_shader_resources(tshdr, tsgprs, 32);
-        CHECK(tt.resources.size() == 2, "BC1 + unmapped-format T#s skipped; 2 textures emitted");
+        CHECK(tt.resources.size() == 3, "fmt56 + fmt1 + BC1 emitted; unmapped fmt44 skipped (3 textures)");
 
         const ShaderResource* t0 = tt.by_sgpr_base(0);
         CHECK(t0 && t0->cls == ResourceClass::Texture, "fmt=56 texture emitted (title composite path)");
@@ -179,7 +180,10 @@ int main() {
               "fmt=1 -> Unorm8 x1 (R8, no longer assumed RGBA)");
         CHECK(t1 && t1->size == 2048u * 1024u, "fmt=1 size = w*h (was w*h*4, an 8 MB over-read of 2 MB)");
 
-        CHECK(tt.by_sgpr_base(16) == nullptr, "BC1 T# skipped (recognized, not yet sampleable)");
+        const ShaderResource* t2 = tt.by_sgpr_base(16);
+        CHECK(t2 && t2->format == DataFormat::Bc1, "BC1 T# now bound (decoded to RGBA8 on upload)");
+        CHECK(t2 && t2->size == ((256u + 3) / 4) * ((256u + 3) / 4) * 8u,
+              "BC1 size = ceil(w/4)*ceil(h/4)*8 (compressed block bytes, not w*h*4)");
         CHECK(tt.by_sgpr_base(24) == nullptr, "unmapped IMG_FMT T# skipped (no silent RGBA8)");
     }
 

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -20,6 +20,7 @@
 #ifdef PROSPER_HAVE_VULKAN
 #include "gpu/gpu_execute.hpp"
 #include "gpu/tile.hpp"                   // render-target de-swizzle (detile_surface, tiled_surface_bytes)
+#include "gpu/bc_decode.hpp"              // BC1/2/3 block decompression -> RGBA8 (#121)
 #include "gpu/shader_resources.hpp"       // ShaderResourceTable / ResourceClass (bind the shaders' resources)
 #include "gpu/rdna2_to_spirv.hpp"         // recompile_fragment (diagnostic solid-color PS)
 #include "../../tests/render_runner.h"   // offscreen Vulkan backend (render_triangle_rgba) + dump_bmp
@@ -304,7 +305,33 @@ int main(int argc, char** argv) {
                             uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
                             size_t nb = (size_t)tw * th * 4;
                             texstore.emplace_back(nb, 0x00);
-                            safe_copy(texstore.back().data(), r.gpu_addr, nb);
+                            // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
+                            // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
+                            // 16 bytes -> SW_4KB_S 16x16-block micro-tiles). #121.
+                            const uint32_t bcb = prosper::gpu::bc_block_bytes(r.format);
+                            if (bcb) {
+                                uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
+                                // CONFIDENCE: MED — SW_4KB_S keeps a 4KB micro-tile, so element count =
+                                // 4096/bpe arranged square: 16-byte blocks (BC2/3/5/7) -> 16x16, 8-byte
+                                // (BC1/4) -> 32x16 (approximated as 32 here). Verified against the 32-bpp
+                                // path (bpe=4 -> 32x32) and llvmpipe re-tiling, but NOT yet against a
+                                // structured (non-uniform) BC surface — the one live BC3 tex is ~solid white.
+                                uint32_t tside = (bcb == 16) ? 16u : 32u;
+                                size_t comp_bytes = (size_t)bw * bh * bcb;
+                                std::vector<uint8_t> lin(comp_bytes, 0);
+                                bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                                if (tiled) {
+                                    size_t tbytes = prosper::gpu::tiled_elements_bytes(bw, bh, bcb, tside, r.tile_mode);
+                                    std::vector<uint8_t> traw(tbytes, 0);
+                                    safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                    prosper::gpu::detile_elements(lin.data(), traw.data(), tbytes, bw, bh, bcb, tside, r.tile_mode);
+                                } else {
+                                    safe_copy(lin.data(), r.gpu_addr, comp_bytes);
+                                }
+                                prosper::gpu::bc_decode_surface(texstore.back().data(), lin.data(), lin.size(), tw, th, r.format);
+                            } else {
+                                safe_copy(texstore.back().data(), r.gpu_addr, nb);
+                            }
                             // PROSPER_DUMP_RAWTEX: write the raw tiled RGBA bytes (pre-detile) to a .bin for
                             // offline swizzle experimentation.
                             if (getenv("PROSPER_DUMP_RAWTEX") && !texstore.back().empty()) {
@@ -333,7 +360,8 @@ int main(int argc, char** argv) {
                             // disables it. Reads the PADDED tiled buffer (height rounded to whole 32-texel tile rows).
                             bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                             const char* dt = getenv("PROSPER_DETILE");
-                            if (!getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                            // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
+                            if (!bcb && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
                                 const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                                 // PROSPER_PITCH: padded row pitch in texels for surfaces whose pitch > width.
                                 const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;


### PR DESCRIPTION
## What (part of #121)

PS5 art textures are block-compressed (BC1/2/3 = DXT1/3/5). The Gen5 T# mapper *recognized* them but the renderer **skipped every BCn binding** ("BCn sampling is not wired"), so any draw sampling an art texture got an empty binding and rendered nothing. This wires the first real BCn sampling path.

## Changes

- **`bc_decode.{hpp,cpp}`** — reference S3TC decoder → linear RGBA8:
  - BC1 (4-color + 1-bit punch-through alpha), BC2 (explicit 4-bit alpha), BC3 (8-entry alpha ramp). Pure + deterministic.
- **`test_bc_decode`** — hand-built blocks with known output: solid color, interpolated index `(2·c0+c1)/3`, punch-through transparent, and 8×8 multi-block placement.
- **`tile.cpp`** — `detile_elements()` / `tiled_elements_bytes()` generalize the SW_4KB_S de-swizzle to N-byte **elements** (compressed blocks): a 4KB micro-tile ⇒ 16×16 for 16-byte BC3 blocks (`bpe=4` ⇒ 32×32, matching the existing 32-bpp path).
- **`agc_shader_layout`** — bind BC1/2/3 T#s (was skip) with the correct **compressed** byte size `ceil(w/4)·ceil(h/4)·block_bytes`; BC4–7 still skipped.
- **`boot_trace` upload** — for a BCn resource: read the (block-tiled) compressed bytes, block-detile, decode to RGBA8; the 32-bpp auto-detiler is skipped for these.

## Verification

- **58/58 ctest green** (new decoder test + updated `build_shader_resources` expectations reflecting BC1/2/3 now bound).
- Live PPSA02664: the 2048×1024 BC3 texture now **populates with data** (was empty/skipped) and decodes to a valid image. (This early frame's texture happens to be ~solid white — a UI/placeholder surface — so it doesn't visually change the frame yet.)

## Honest scope

- Frames are **still black** — but that's the separate **compositing / render-to-texture** gap (draws render, but the scene target isn't resolved into the presented frame), not a texture-decode issue. This PR makes BCn *sampleable*; it's a prerequisite, not the whole picture.
- The BC-block detile `tile_side` is **CONFIDENCE: MED** — principled (4KB micro-tile, consistent with the verified 32-bpp path) but not yet validated against a *structured* (non-uniform) BC surface, since the one live BC3 texture is ~uniform.

Refs #121