### PR TITLE
fix(ue4): deliver async APR read completions — reaches AGC RHI bring-up (#115)

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -238,7 +238,64 @@ real post-footer reads it previously never reached: the FPakFile **index** at th
 id=10, 17.8 GB) — i.e. IoStore container mounting is complete. CONFIDENCE: HIGH (offset/size/dst all
 verified on live reads; PreInit-passes is the end-to-end proof).
 
-### NEW WALL: post-mount engine/RHI init — a null virtual call (racy, two faces)
+### SOLVED (2026-07-08, issue #88): the null virtual call was a SetBuffer heap clobber
+
+Full causal chain, proven step by step (single-run reg-time vs crash-time dumps + a silent HW
+write-watch):
+
+1. The `eboot+0x24c75ef` `call *0x10(%rax)` is `IModuleInterface::StartupModule()` inside
+   `FModuleManager::LoadModuleWithFailureReason` (the "LoadModule  - " boot scope) — loading
+   **"Engine"** from `SCOPED_BOOT_TIMING("LoadPreInitModules")`. The rbp-chain backtrace hid the
+   real fault: it is INSIDE `FEngineModule::StartupModule` at `eboot+0x503b72e/731`
+   (`mov (%rbx),%rax ; call *0xb0(%rax)`), where `rbx` = a guarded function-local static caching
+   `IConsoleManager::FindConsoleVariable(L"r.Shadow.CacheWPOPrimitives")` — which returned NULL,
+   and the code calls `SetOnChangedCallback` on it with no null check (a sibling block does the
+   same for `r.ShowMaterialDrawEvents`).
+2. The CVar IS registered: the TAutoConsoleVariable static ctor (in the eboot's .ctors table —
+   walked backward from `0x4094939e8` to the -1 sentinel by DT_INIT at eboot+0x10; all 1498 ran)
+   called `RegisterConsoleVariable` successfully; the object sat in FConsoleManager's 3000+ entry
+   map. But by StartupModule time the map entry's FString KEY DATA was ALL ZEROS in place —
+   FindConsoleVariable can never match it.
+3. The zeroing had NO writer (a HW write-watch on the exact key address never fired): it was a
+   MAPPING REPLACED UNDER THE VA. `k_ampr_push_map` (sceAmprCommandBufferSetBuffer HLE) treated
+   EVERY SetBuffer as "map fresh phys page at va (+ mirror at va-0x540000000)". The APR read
+   flow also issues SetBuffer for an ALREADY-LIVE 0x4000-byte descriptor buffer
+   (`va=0x15a0dfc000`), and the MIRROR (`0x1060dfc000`) MAP_FIXED'd fresh zero pages over live
+   MallocBinned heap — the exact 16KB holding the console map's key strings.
+4. Fix (hle_kernel_mem.cpp): the two SetBuffer flavors are discriminated by their own args —
+   captured live: map flavor has `a3 != va, a4 = 0xffffffff sentinel`; existing-buffer flavor has
+   `a3 == va, a4 = allocCtx, a5 = small flags` (13/13 and 3/3 in capture). The existing-buffer
+   flavor is now a memory no-op. The worker-thread face was the same corruption seen from the
+   other side.
+5. Companion fix (hle_file.cpp): the read-submit dst write (`process_vm_writev`) cannot fault
+   through the lazy-commit SIGSEGV handler, so an untouched reserved dst returned EFAULT and the
+   record published the PROSPER-OWNED staging pointer — which the engine later
+   `FMemory::Free()`d ("FMallocBinned3 Attempt to free an unrecognized block"). The dst write now
+   commits lazy 64K pages exactly like the fault handler and retries.
+
+**Result: boot passes LoadPreInitModules, `FConfigCacheIni::InitializeConfigSystem` runs (the
+BinaryConfig probe prints), plugin/localization/ICU pak reads all serve, and the engine reads
+`DefaultEngine.ini` from the pak.** Note this build's PreInit really does run LoadPreInitModules
+BEFORE InitializeConfigSystem (verified in the binary at `eboot+0x7af3` vs `+0x7eda`).
+
+### NEW WALL (deterministic): FMallocBinned3 "Attempt to free an unrecognized block"
+
+Right after the engine reads the `DefaultEngine.ini` pak entry (off=0x2dcc378, 46135 bytes,
+served OK — the command buffer even carries the UTF-16 name), the main thread hits
+`LowLevelFatalError [Line: 1228] FMallocBinned3 Attempt to free an unrecognized block` inside the
+config-load call chain (`eboot+0x2451492 <- +0x245217a <- +0x245288d <- +0x24561a1 <- +0x24b1153
+<- +0x243e8ca <- +0x243ff73 <- +0x24679e8`), then UE's own crash handler prints a backtrace and
+aborts (`libc.prx+0x48e0`). 4/4 runs deterministic. The `[nullpage] addr=0x8 rip=eboot+0x22ebe7f`
+line right before it is BENIGN — that is UE's rbp-chain backtrace walker hitting the null
+terminator during crash reporting, not a fault. Suspects: the freed pointer is likely a pak-read
+buffer pointer the engine did not allocate (check the remaining record/descriptor contract of the
+0xdd/0xde pak callsites for compressed entries — `PakFileCompressionFormats=Oodle`,
+`bCompressed=True`: DefaultEngine.ini's entry is compressed, and the post-read decompress path
+is where the bogus free happens). The five still-unimplemented libSceAmpr NIDs
+(`vWU-odnS+fU sSAUCCU1dv4 tZDDEo2tE5k GnxKOHEawhk H896Pt-yB4I`) fire during mount and may be part
+of the compressed-read contract.
+
+### OLD ANALYSIS (superseded): post-mount engine/RHI init — a null virtual call (racy, two faces)
 
 Boot now reaches early UE engine init and dies in one of two timing-dependent spots (the RHI /
 task-graph worker threads are now live, so it is nondeterministic):

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -295,6 +295,103 @@ is where the bogus free happens). The five still-unimplemented libSceAmpr NIDs
 (`vWU-odnS+fU sSAUCCU1dv4 tZDDEo2tE5k GnxKOHEawhk H896Pt-yB4I`) fire during mount and may be part
 of the compressed-read contract.
 
+### SOLVED (2026-07-08, issue #107): the Ampr map-flavor MIRROR clobbered live MallocBinned heap
+
+Deep diagnosis of the `FMallocBinned3 Attempt to free an unrecognized block` crash. Every ticket
+hypothesis (Oodle decompress; compressed-pak buffer ownership; the 5 unimplemented Ampr NIDs) was
+tested and **disproven**. The real fault is a guest-side MallocBinned heap overlap; prosper serves
+the config bytes correctly.
+
+- **The freed pointer is `0xd` (13), not a real allocation.** Captured at the free site by both the
+  in-process int3 logger (`PROSPER_BP=0x22f527a`) and a gdb HW watchpoint: `rdi=0xd`. The message
+  "...unrecognized block d" is literally the `%p` of `0xd`. The free instruction is
+  `eboot+0x22f5270  mov 0x18(%r14,%r15,1),%rdi ; test ; call 0x231ece0` — a loop freeing
+  `element[idx]+0x18` (0x30-byte stride) of an array whose base `r14 = *object = 0x12dadfcf80`
+  (stable across runs). The freed object is a **stack-temp** container (`object r15 = 0x7fffec7fee20`,
+  a `0x7fff…` stack VA), idx=0.
+
+- **DECOMPRESSION IS NOT NEEDED — the entry is plaintext.** `dd` of `pakchunk0-ps5.pak` at the exact
+  read offset `0x2dcc378` shows ASCII INI for all 46135 bytes: begins `[Core.System]\r\n
+  CanUseUnversionedPropertySerialization=True…`, ends `…bCompileBlueprintsInDevelopmentMode=False
+  \r\n\r\n\0`. So `bCompressed=True` in the ticket referred to the ini's *directive*, not this
+  entry; the FPakEntry data is stored uncompressed. No Oodle/Kraken path is required here.
+
+- **THE READ PATH IS CORRECT.** `PROSPER_DUMPAT=0x2007a4002a` (the read dst `a4`) shows the correct
+  plaintext landed in the guest buffer, and the config parse *did* consume it (the crash element's
+  SavedValue is a valid 100-char UTF-16 config value `(Material="/Engine/BufferVisualization/…`).
+  A gated experiment mirroring the bytes into the begin-cursor staging buffer too
+  (`PROSPER_APR_FILL_CUR1`) left the crash bit-identical — the guest reads its data from `a4`, not
+  the cursor, so the read contract is not implicated.
+
+- **ROOT CAUSE: two live guest containers share memory 0x10 apart (heap overlap).** A gdb HW
+  write-watch on the exact freed slot `0x12dadfcf98` traced who wrote `0xd`: a
+  `TSparseArray`/`TSet` element-relocation loop at `eboot+0x2467850…0x2467927`
+  (`mov (%rbx),%rax` src = `*mapObject`; per-field 0x30-byte MOVE with FString move-semantics on the
+  two FStrings at `+0x08`/`+0x18`; heap object `rbx=0x1620e05148`). That loop writes its element at
+  **base `0x12dadfcf70`**, and `0xd` is that element's `+0x28` field (a valid TSparseArray
+  hash-next / free-list index). But the stack-temp free loop reads the SAME region at **base
+  `0x12dadfcf80`** (0x10 higher), so the neighbour's `+0x28` bookkeeping word aliases the freed
+  object's `+0x18` `FConfigValue::ProcessedValue.Data` slot — which on real HW is null (empty,
+  skipped by the `test rdi,rdi; je`). Two DISTINCT live objects (heap map @0x…cf70 relocation dest,
+  stack-temp array @0x…cf80) with overlapping storage ⇒ a MallocBinned pool corruption. The page
+  `0x12dadf0000` is freshly lazy-committed (zeroed) right before, so `0xd` is actively written by
+  the guest, not stale residue — the guest's own allocator handed out overlapping blocks.
+
+- **The 5 Ampr NIDs are a dead end for this crash.** Named 2 by brute-forcing `nid_hash` over a
+  generated libSceAmpr corpus: `tZDDEo2tE5k = sceAmprCommandBufferGetSize`,
+  `ULvXMDz56po = sceAmprCommandBufferClearBuffer` (both now registered in `hle_kernel_mem.cpp`).
+  `GetSize` fires during APR read teardown; making it return the real cb size instead of 0 left the
+  crash bit-identical, confirming the Ampr teardown functions do not gate it. The other three
+  (`vWU-odnS+fU sSAUCCU1dv4 GnxKOHEawhk H896Pt-yB4I`) resisted the corpus (non-`CommandBuffer<Verb>`
+  shapes) and are harmless no-ops (returning 0) — they are not on the corruption path.
+
+- **THE CLOBBER, PROVEN BY MEMLOG.** `PROSPER_MEMLOG` shows page `0x11e0df0000` appears TWICE:
+  `[lazy-commit] mapped page=0x11e0df0000` (line 321 — the guest wrote there, so prosper committed
+  it as a normal anon MallocBinned heap page) and later `[memhle] ampr push-map va=0x1720df0000 …
+  mirror=0x11e0df0000` (line 453 — strictly LATER). `k_ampr_push_map`'s map flavor maps the buffer
+  at `va` AND `MAP_FIXED`s a "mirror" at `va - 0x540000000` (a LOW-confidence rule pinned on The
+  Messenger). For this title `va = 0x1720df0000` ⇒ mirror `0x11e0df0000`, which is exactly the live
+  heap page — so `MAP_FIXED` replaced the heap page with a fresh page aliased to the Ampr buffer's
+  phys `0x10220000`, destroying the pool bookkeeping there. Downstream, MallocBinned carved two
+  blocks 0x10 apart (`0x12dadfcf70` heap-map relocation dest vs `0x12dadfcf80` stack-temp array),
+  their fields aliased, and the teardown freed the `0xd` bookkeeping word. Same clobber class as
+  issue #88 (SetBuffer over live heap), here via the **map-flavor mirror** instead of the
+  existing-buffer flavor.
+
+- **FIX (hle_kernel_mem.cpp, `k_ampr_push_map`):** only create the mirror when its target VA is NOT
+  already backed guest memory (`mincore(mirror,1,&vec) == 0` means fully mapped == live ⇒ skip). A
+  live target means the guest is using that VA as its own heap, not as a second view of the Ampr
+  pool, so the mirror is a false positive of the `0x540000000` heuristic and must not overwrite it.
+  Verified: the `FMallocBinned3` crash is GONE and DOLL boots through `InitializeConfigSystem` all
+  the way into UE's online/PSN subsystem init (SSL, HTTP, NpWebApi, Json, NpManager, NpTrophy2,
+  VoiceQoS, SystemService, Share, NetCtl, GameUpdate, NpUniversalDataSystem, NpGameIntent). The
+  Messenger is UNAFFECTED: its mirror targets are unmapped at map time (`mincore` fails), so it takes
+  the create-mirror path exactly as before — smoke shows 0 mirror-skips, 30k+ render lines, no crash;
+  ctest 50/50. CONFIDENCE: HIGH (collision proven by MEMLOG page-double-listing + strict ordering;
+  fix is target-conditional so it cannot regress the create-mirror case).
+
+- **NEW WALL: UE online/PSN subsystem init.** After config, the engine constructs its online
+  subsystem and hits a long run of unimplemented online/social NIDs
+  (`libSceNpManager qQJfO8HAiaY`, `libSceNpTrophy2 sUXGfNMalIo`, `libSceNpWebApi2`, `libSceHttp/Http2`,
+  `libSceSsl`, `libSceJson2 *`, `libSceNetCtl obuxdTiwkF8/iQw3iQPhvUQ`, `libSceSystemService`,
+  `libSceShare`, `libSceVoiceQoS`, `libSceGameUpdate`, `libSceNpGameIntent`), all returning 0. The
+  boot does not crash but does not visibly advance to RHI/AGC within 200s — likely blocked/polling in
+  online init (a service call that must report "signed out / offline" rather than 0, or an init that
+  the engine waits on). NEXT: trace which online-init call the main thread blocks on (break after the
+  last new NID; `PROSPER_BP`/gdb), and give the NpManager/NetCtl/SystemService "get state" queries a
+  real offline/no-network status so the engine proceeds to RHI creation → AGC → first UE draw (the
+  same `libSceAgc` path The Messenger renders through).
+
+### The remaining 3 unnamed Ampr NIDs (issue #107, not on the crash path)
+
+`vWU-odnS+fU`, `sSAUCCU1dv4`, `GnxKOHEawhk`, `H896Pt-yB4I` still resist the generated
+`sceAmprCommandBuffer<Verb><Noun>` corpus (the same brute-forcer that named the other 8 Ampr NIDs).
+They fire during mount, return 0 via the generic unimplemented stub, and are proven irrelevant to the
+config crash (fixed without them). Likely non-`CommandBuffer`-shaped names (Amm/Measure/util helpers);
+leave as no-ops until a future frontier needs them.
+
+### (superseded) original issue-#107 diagnosis notes
+
 ### OLD ANALYSIS (superseded): post-mount engine/RHI init — a null virtual call (racy, two faces)
 
 Boot now reaches early UE engine init and dies in one of two timing-dependent spots (the RHI /

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -382,6 +382,64 @@ the config bytes correctly.
   real offline/no-network status so the engine proceeds to RHI creation → AGC → first UE draw (the
   same `libSceAgc` path The Messenger renders through).
 
+### SOLVED (2026-07-09, issue #115): the "online init hang" was CreateGlobalShaderMap waiting on
+### APR async-read completions that prosper never delivered
+
+The issue-#115 hypothesis (main thread polling an online/PSN "get state" call) was **disproven** by
+evidence: every unimplemented online NID fires exactly ONCE (dispatch dedupe counts), and a gdb
+all-thread dump at the hang showed every thread parked in waits — no poller. The online subsystem
+init completes fine with the return-0 stubs. The real chain, recovered by guest stack scan + live
+disassembly (all offsets eboot-relative):
+
+1. Main thread parks in `FEventPThread::Wait` (+0x22eaa2b) ← a blocking "wait for archive" reader
+   (+0x24ae6e0: `IAsyncReadRequest::WaitCompletion(0)` then `WaitCompletion(INFINITE)` on
+   `*(obj+0x28)`) ← **`CreateGlobalShaderMap`** (+0x4ea8c20 — UTF-16 scope strings "Creating
+   Global Shader Map...", "GlobalShaderCache", "VerifyShaderSourceFiles"). The file being read:
+   `../../../Engine/GlobalShaderCache-SF_PS5.bin`, 0x107e3a bytes, **inside pakchunk0-ps5.pak**.
+2. The async read completes on real HW via the **APREventQueue**: the engine creates that equeue,
+   registers APR completions on it, and runs an `FAPREventQueueListener` thread in
+   `WaitEqueue(eq, evs, 15, ...)` (+0x22740b0). Each event is decoded with `sceKernelGetEventData`:
+   **`data = (ring_index << 58) | completion_counter`**; for every newly completed counter the
+   listener calls the completion handler (+0x229dcb0), which matches the token against the tracked
+   request's `+0x10` slot, else a hash map keyed by the full token. prosper served the READS
+   (synchronously) but never posted any EVENT → the listener never woke → WaitCompletion waited
+   forever. That is the whole hang.
+3. The previously-unknown NIDs, pinned by live arg capture + thunk→GOT→stub mapping:
+   - `libSceAmpr::sSAUCCU1dv4 (eq, id=0x7502, 0, 0, 0x43, 0)` — register APR completion events on
+     the equeue.
+   - `libSceAmpr::H896Pt-yB4I (cbCtx, eq, id, 0x10000000000003e8, 0, 7)` — bind a command-buffer
+     ctx to the equeue.
+   - `libSceAmpr::vWU-odnS+fU (fileId=8, dst, size=0x107e3a, off=0x7adec90a, off, 4)` — the DIRECT
+     async read: exactly the GlobalShaderCache region of pakchunk0-ps5.pak (fileId from APR
+     resolve). Implemented as `f_apr_read_direct` in hle_file.cpp (pread + lazy-commit dst write +
+     completion token/event).
+   - `libkernel::ASoW5WE-UPo (cb, ring_1based, u64* out1, u64* out2)` — the APR **submit**
+     (wrapper +0x59b6420 → thunk +0x669afd0; the completion handler resubmits queued CBs with
+     `ring = (data>>58)+1`, proving 1-based). Nonzero return = error (checked at +0x22a1d55);
+     the completion token is returned through the OUT slots. Implemented as `k_apr_submit`.
+4. Contract subtleties (each crash-verified live, both ways):
+   - **No phantom sequence numbers.** Pre-registration (mount-era) submits are consumed by
+     polling the completion record; delivering their seqs after registration makes the listener
+     hand the handler tokens with no tracking entry, and the handler's hash-miss path is NOT
+     null-tolerant (`vmovups` from `0x10`, fault at +0x229df3e). Untracked rings reset to 0 at
+     first registration so post-registration submissions start at seq 1 (matching the listener's
+     zero-initialized per-ring "last processed").
+   - **Completions must be delivered ASYNCHRONOUSLY.** Posting the event inside the submit loses
+     the race the real DMA never runs (the engine inserts its {token→request} entry right after
+     submit returns); prosper defers each post ~2 ms and posts the ring's counter at post time.
+   - **Sync-flow submits (`ring_1based == 6`, hardcoded at +0x22a1d89) get NO events** — their
+     completions are record-polled; ring-4 (tracked async) events are consumed correctly. The
+     real discriminator is likely the H896 cb↔eq binding; ring-id gating reproduces observed
+     behavior (CONFIDENCE MED).
+   - `sceKernelGetEventData/Id/Filter/Fflags/UserData/Error` implemented (Kyty field-read
+     semantics) — the listener consumes events exclusively through GetEventData.
+
+**Result: the GlobalShaderMap loads, PreInit continues through online/PSN init (which was never
+the blocker), pak/precacher async reads flow (180+ served in one run), and the boot reaches the
+AGC RHI bring-up — AgcCleanupThread/AgcInterruptThread/AgcSubmissionThread + AgcEqueue with
+AgcDriverAddEqEvent(id=0x20, id=0x0) + user event 6144 — then keeps loading content.** ctest
+50/50, Messenger smoke unaffected.
+
 ### The remaining 3 unnamed Ampr NIDs (issue #107, not on the crash path)
 
 `vWU-odnS+fU`, `sSAUCCU1dv4`, `GnxKOHEawhk`, `H896Pt-yB4I` still resist the generated

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -440,6 +440,37 @@ AGC RHI bring-up — AgcCleanupThread/AgcInterruptThread/AgcSubmissionThread + A
 AgcDriverAddEqEvent(id=0x20, id=0x0) + user event 6144 — then keeps loading content.** ctest
 50/50, Messenger smoke unaffected.
 
+Follow-on fixes landed in the same change (each its own live-diagnosed wall):
+
+- **POSIX `pthread_cond_timedwait` (libScePosix 27bAgiJmOh0)** implemented for real (shared
+  cond/mutex pointer-slot scheme; FreeBSD ETIMEDOUT=60). The unimplemented-0 stub returned
+  "signaled" instantly, spinning UE's `IAsyncReadRequest::WaitCompletion(timeout)` loop at 100%
+  CPU (caught live: the only busy thread's RA 0x4022ea954 inside prosper_on_unimpl).
+- **`sceRtcSetTick` / `sceRtcGetTick`** (tick <-> UTC datetime, shadPS4 semantics). Unimplemented
+  SetTick left the out datetime zeroed and UE spammed
+  `LowLevelFatalError: Invalid Date values. Y:0, M:0, D:0...` thousands of times during the
+  post-shader-map load.
+- **Per-container host fd cache for APR reads.** open()+close() per read against the 2 GB pak
+  over the WSL 9p mount cost ~1.7 s/read; the whole load phase now runs ~15x faster.
+- **Race-free stack-arg capture for `sceAmprAprCommandBufferReadFile`.** The entry shim now
+  passes its %rsp as a real 7th argument instead of a plain global — with completions delivered,
+  loader/precacher threads submit APR reads CONCURRENTLY and a cross-thread overwrite of the
+  global made the handler read the file OFFSET from another thread's frame (wrong-offset reads
+  served as "OK"). No TLS (issue #89 constraint respected).
+
+### NEW WALL: MallocBinned3 free-block canary corruption during the parallel content-load burst
+
+With loading fast and parallel, the boot dies ~10 s in, right after online init, spamming
+`LowLevelFatalError [Line: 186] MallocBinned3 Corruption Canary was 0xN, will be 0x1` (N varies
+run to run: 0x0, 0x2) until a SIGSEGV. Established so far: NOT a prosper page clobber (MEMLOG
+shows zero lazy-commit/batchmap overlaps, zero remaps, the #107 mirror is SKIPPED cleanly, and
+all 951 BatchMap ops in the window are plain op=0 commits — no unmaps); NOT caused by the RTC or
+timedwait fixes (A/B-verified: corruption persists with them unregistered, only the canary value
+changes). The phase is a burst of MallocBinned3 arena growth (hundreds of 64K batchmap commits)
+under multiple loading threads — candidates: guest-%fs TLS-cache interaction (MB3 per-thread
+caches under PROSPER_GUEST_FS), or a completion-delivery race making the engine free a block on
+two paths. Needs its own session with a HW write-watch on a corrupted free-block header.
+
 ### The remaining 3 unnamed Ampr NIDs (issue #107, not on the crash path)
 
 `vWU-odnS+fU`, `sSAUCCU1dv4`, `GnxKOHEawhk`, `H896Pt-yB4I` still resist the generated

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -499,6 +499,10 @@ HLE(f_apr_resolve) {
 // scope (NOT inside the extern "C" handler, where a block-scope extern would take C linkage and
 // miss the mangled prosper:: definition).
 extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
+// Tracked-mapping state probe (hle_kernel_mem.cpp): 1 = addr is inside a guest-RESERVED range
+// whose pages lazy-commit on first touch. Used by the read path's dst-write to replicate the
+// fault handler's commit-on-write semantics for kernel-side (process_vm_writev) copies.
+extern "C" int prosper_reserved_range_state(uint64_t addr);
 
 #ifndef _WIN32
 // MUST NOT be `__thread` (issue #89). An initial-exec thread-local here (`%fs:...@tpoff`) grows the
@@ -709,6 +713,29 @@ HLE(f_apr_read_submit) {
         if (size) {
             struct iovec l { slot, (size_t)size }, r { (void*)(uintptr_t)a4, (size_t)size };
             in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+            if (!in_dst) {
+                // The kernel-side writev CANNOT fault through prosper's SIGSEGV lazy-commit
+                // handler, so a dst inside a guest-RESERVED range whose pages were never touched
+                // reports EFAULT even though a real guest write would succeed (the fault handler
+                // would back the page). That EFAULT used to demote the read to "publish the
+                // prosper-owned staging pointer through the record" — and the engine later
+                // FMemory::Free()d that HOST pointer: "FMallocBinned3 Attempt to free an
+                // unrecognized block" during config-file loads (issue #88's second face).
+                // Replicate the guest-write semantics instead: commit the lazy 64K pages the
+                // exact way the fault handler does, then retry once. CONFIDENCE: HIGH (same
+                // policy as the lazy-commit path in exec_image_linux.cpp).
+                bool committed = false;
+                for (uint64_t p = a4 & ~0xffffull; p < a4 + size; p += 0x10000) {
+                    unsigned char vec;
+                    if (mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
+                        prosper_reserved_range_state(p) == 1 &&
+                        mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == (void*)(uintptr_t)p)
+                        committed = true;
+                }
+                if (committed)
+                    in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+            }
         } else in_dst = true;
     }
     if (ok && a2) {

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -12,6 +12,7 @@
 #include <cerrno>
 #include <string>
 #include <mutex>
+#include <map>
 #include <vector>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -538,6 +539,49 @@ static uint64_t apr_stack_arg(int n) {
 #endif
 
 #ifndef _WIN32
+// Cached host fd per resolved APR container path. The engine issues hundreds of small reads
+// against the 2 GB pak during shader-library/asset loading; an open()+close() pair per read over
+// the WSL 9p filesystem dominated the boot (~1.7 s/read live-measured). Containers are immutable
+// game data, so a per-path fd held for the process lifetime is safe.
+static int apr_cached_fd(const std::string& host) {
+    static std::mutex mx;
+    static std::map<std::string, int> fds;
+    std::lock_guard<std::mutex> lk(mx);
+    auto it = fds.find(host);
+    if (it != fds.end()) return it->second;
+    int fd = ::open(host.c_str(), O_RDONLY);
+    if (fd >= 0) fds[host] = fd;
+    return fd;
+}
+
+// Write `size` bytes into guest VA `dst`, committing lazy-reserved 64K pages the same way the
+// SIGSEGV fault handler does. The kernel-side writev CANNOT fault through prosper's lazy-commit
+// handler, so a dst inside a guest-RESERVED range whose pages were never touched reports EFAULT
+// even though a real guest write would succeed. That EFAULT used to demote the read to "publish
+// the prosper-owned staging pointer through the record" — and the engine later FMemory::Free()d
+// that HOST pointer: "FMallocBinned3 Attempt to free an unrecognized block" (issue #88's second
+// face). Commit the pages exactly like the fault handler and retry once. CONFIDENCE: HIGH (same
+// policy as the lazy-commit path in exec_image_linux.cpp). Shared by the record-based
+// sceAmprAprCommandBufferReadFile path and the direct vWU-odnS+fU read (issue #115).
+static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
+    if (!size) return true;
+    struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
+    if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) return true;
+    bool committed = false;
+    for (uint64_t p = dst & ~0xffffull; p < dst + size; p += 0x10000) {
+        unsigned char vec;
+        if (mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
+            prosper_reserved_range_state(p) == 1 &&
+            mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == (void*)(uintptr_t)p)
+            committed = true;
+    }
+    if (!committed) return false;
+    return process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+}
+#endif
+
+#ifndef _WIN32
 extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
                                         uint64_t a3, uint64_t a4, uint64_t a5) {
 #else
@@ -555,6 +599,19 @@ HLE(f_apr_read_submit) {
                 (unsigned long long)apr_stack_arg(2), (unsigned long long)apr_stack_arg(3),
                 (unsigned long long)g_apr_entry_rsp,
                 (unsigned long long)(g_apr_entry_rsp ? *(uint64_t*)g_apr_entry_rsp : 0));
+        // Guest call chain: first eboot-range return addresses on the stack (identifies which engine
+        // wrapper submitted this read — sync mount path vs async FAPREventQueue path, issue #115).
+        if (g_apr_entry_rsp) {
+            const uint64_t* sp = (const uint64_t*)g_apr_entry_rsp;
+            int shown = 0;
+            for (int i = 0; i < 160 && shown < 6; i++) {
+                uint64_t v = sp[i];
+                if (v < 0x400000000ull || v >= 0x4c0000000ull) continue;
+                fprintf(stderr, "[apr]   guest-ra[%d] = eboot+0x%llx\n", i,
+                        (unsigned long long)(v - 0x400000000ull));
+                shown++;
+            }
+        }
 #endif
         for (int o = 0; o < 0x48; o += 8)
             fprintf(stderr, "[apr]   req+0x%02x = 0x%016llx\n", o, (unsigned long long)*(uint64_t*)(req + o));
@@ -693,10 +750,9 @@ HLE(f_apr_read_submit) {
     if (slot == MAP_FAILED) return 0x80020016ull;
     ssize_t got = 0;
     if (size) {
-        int fd = ::open(host.c_str(), O_RDONLY);
+        int fd = apr_cached_fd(host);
         if (fd < 0) { munmap(slot, rounded); return 0x80020016ull; }
         got = ::pread(fd, slot, (size_t)size, (off_t)offset);
-        ::close(fd);
     }
     bool ok = ((uint64_t)got == size);
     // a4 is the caller's DESTINATION buffer (the `dst` argument of
@@ -708,36 +764,7 @@ HLE(f_apr_read_submit) {
     // refuses unmapped ranges instead of SIGSEGVing in the HLE) and publish record[0] = dst;
     // fall back to the prosper-owned buffer only if dst is absent/unmapped.
     // CONFIDENCE: MED-HIGH (dst role from the recovered real prototype + both callsites' behavior).
-    bool in_dst = false;
-    if (ok && a4 > 0xffff) {
-        if (size) {
-            struct iovec l { slot, (size_t)size }, r { (void*)(uintptr_t)a4, (size_t)size };
-            in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
-            if (!in_dst) {
-                // The kernel-side writev CANNOT fault through prosper's SIGSEGV lazy-commit
-                // handler, so a dst inside a guest-RESERVED range whose pages were never touched
-                // reports EFAULT even though a real guest write would succeed (the fault handler
-                // would back the page). That EFAULT used to demote the read to "publish the
-                // prosper-owned staging pointer through the record" — and the engine later
-                // FMemory::Free()d that HOST pointer: "FMallocBinned3 Attempt to free an
-                // unrecognized block" during config-file loads (issue #88's second face).
-                // Replicate the guest-write semantics instead: commit the lazy 64K pages the
-                // exact way the fault handler does, then retry once. CONFIDENCE: HIGH (same
-                // policy as the lazy-commit path in exec_image_linux.cpp).
-                bool committed = false;
-                for (uint64_t p = a4 & ~0xffffull; p < a4 + size; p += 0x10000) {
-                    unsigned char vec;
-                    if (mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
-                        prosper_reserved_range_state(p) == 1 &&
-                        mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,
-                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == (void*)(uintptr_t)p)
-                        committed = true;
-                }
-                if (committed)
-                    in_dst = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
-            }
-        } else in_dst = true;
-    }
+    bool in_dst = ok && a4 > 0xffff && apr_write_guest_dst(a4, slot, size);
     if (ok && a2) {
         // Complete the record through the caller-supplied out-pointer (a2 = &record.data; the
         // stack offsets differ per callsite, a2 is the stable handle): [0] data pointer,
@@ -778,6 +805,55 @@ HLE(f_apr_read_submit) {
 #endif
 }
 
+#ifndef _WIN32
+// libSceAmpr vWU-odnS+fU — the APR DIRECT (whole-range) async file read, issue #115. Live capture
+// at the CreateGlobalShaderMap hang:
+//   vWU-odnS+fU(fileId=8, dst=0x2002860000, size=0x107e3a, off=0x7adec90a, off, 5thArg=4)
+// — fileId 8 = pakchunk0-ps5.pak from APR resolve, and (off,size) is EXACTLY the engine's
+// GlobalShaderCache-SF_PS5.bin region inside that pak (size matched the reader global's recorded
+// file size 0x107e3a). No command buffer, no completion record: the read completes by posting a
+// completion token to the registered APREventQueue (see hle_kernel_time.cpp), where the
+// FAPREventQueueListener picks it up and signals the waiting FEvent. a3==a4 in the only capture;
+// a5 is modeled as the 1-based ring index like the ASoW5WE-UPo submit (the completion handler
+// proves 1-based for that path; if a5 turns out to be flags the hash-map fallback in the guest's
+// handler still matches the token). CONFIDENCE: HIGH on (id,dst,size,off) — verified against the
+// resolved file and the reader's recorded size; MED on a5-as-ring.
+uint64_t prosper_apr_next_token(unsigned ring, bool tracked_catchup);   // hle_kernel_time.cpp
+void prosper_eq_trigger_apr(uint64_t token);                            // "
+HLE(f_apr_read_direct) {
+    uint64_t id = a0, dst = a1, size = a2, offset = a3;
+    std::string host = prosper_apr_path_for_id((uint32_t)id);
+    if (host.empty()) {
+        if (filelog()) fprintf(stderr, "[apr] read-direct: no file for id=%llu\n", (unsigned long long)id);
+        return 0x80020016ull;   // EINVAL-class: engine sees a synchronous submit failure
+    }
+    uint64_t fsize = 0;
+    { struct stat st {}; if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
+    if (offset > fsize) offset = fsize;
+    if (size > fsize - offset) size = fsize - offset;
+    uint64_t rounded = (size + 0xfff) & ~0xfffull; if (!rounded) rounded = 0x1000;
+    void* buf = mmap(nullptr, rounded, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (buf == MAP_FAILED) return 0x80020016ull;
+    ssize_t got = 0;
+    if (size) {
+        int fd = apr_cached_fd(host);
+        if (fd < 0) { munmap(buf, rounded); return 0x80020016ull; }
+        got = ::pread(fd, buf, (size_t)size, (off_t)offset);
+    }
+    bool ok = (uint64_t)got == size && (size == 0 || apr_write_guest_dst(dst, buf, size));
+    munmap(buf, rounded);
+    if (filelog()) fprintf(stderr, "[apr] read-direct id=%llu %s -> dst=0x%llx off=0x%llx size=%llu %s\n",
+                           (unsigned long long)id, host.c_str(), (unsigned long long)dst,
+                           (unsigned long long)offset, (unsigned long long)size, ok ? "OK" : "FAIL");
+    if (!ok) return 0x80020016ull;
+    unsigned ring = a5 ? (unsigned)(a5 - 1) & 0x3f : 0;
+    prosper_eq_trigger_apr(prosper_apr_next_token(ring, /*tracked_catchup=*/true));
+    return 0;
+}
+// APR completion-token plumbing (hle_kernel_time.cpp) — see the k_apr_submit block in
+// hle_kernel_mem.cpp for the recovered contract.
+#endif
+
 void register_file_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("fopen", f_fopen);   R("fclose", f_fclose); R("fread", f_fread);   R("fwrite", f_fwrite);
@@ -808,6 +884,8 @@ void register_file_hle() {
     // offset); see f_apr_read_submit_entry above.
 #ifndef _WIN32
     Hle::register_fn("mQ16-QdKv7k", (HleFn)f_apr_read_submit_entry, "sceAmprAprCommandBufferReadFile");
+    // The direct (whole-range) APR read — completion via the APREventQueue (issue #115).
+    Hle::register_fn("vWU-odnS+fU", (HleFn)f_apr_read_direct, "AprReadFileDirect?");
 #else
     Hle::register_fn("mQ16-QdKv7k", (HleFn)f_apr_read_submit, "sceAmprAprCommandBufferReadFile");
 #endif

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -506,35 +506,35 @@ extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
 extern "C" int prosper_reserved_range_state(uint64_t addr);
 
 #ifndef _WIN32
-// MUST NOT be `__thread` (issue #89). An initial-exec thread-local here (`%fs:...@tpoff`) grows the
-// HOST binary's static TLS block, and prosper's guest boot aliases the host TCB through %fs (the
-// guest runs on the host %fs in the non-GUEST_FS boot; the fault-recovery point was moved off
-// `__thread` to gettid-keyed globals for exactly this reason). Adding one static-TLS slot shifted
-// the layout enough to crash The Messenger's minimal boot before graphics init ~9 runs in 10 — a
-// clean bisect to 653cf6f. A plain global is captured on the SAME thread that immediately reads it
-// (the entry shim tail-jumps straight into the handler, which reads apr_stack_arg() first thing),
-// so it is correct as long as APR reads don't overlap across threads — they don't in practice: the
-// engine builds each sceAmprAprCommandBufferReadFile into its single Ampr command buffer and our
-// completion is synchronous. CONFIDENCE: HIGH on the fix (boot restored to 10/10); MED on the
-// serialized-APR assumption — if concurrent APR reads ever appear, key this by gettid (still NOT
-// __thread) rather than reintroducing static TLS.
-extern "C" uint64_t g_apr_entry_rsp;
-uint64_t g_apr_entry_rsp = 0;
+// The entry shim passes its %rsp to the C handler as a SEVENTH argument (on the stack, per SysV).
+// History: this was a plain global (`g_apr_entry_rsp`) — NOT `__thread`, because an initial-exec
+// TLS slot grows the HOST binary's static TLS block and prosper's non-GUEST_FS boot aliases the
+// host TCB through %fs (issue #89: one static-TLS slot crashed The Messenger's minimal boot 9/10).
+// The global relied on APR reads never overlapping across threads. With APR completion EVENTS
+// delivered (issue #115) the engine's loader/precacher threads DO submit concurrently, and a
+// cross-thread overwrite makes the handler read arg7 (the FILE OFFSET) from another thread's
+// frame — wrong-offset reads served as "OK" corrupt whatever the engine parses. Passing rsp as a
+// real argument is race-free with no TLS. Alignment: at shim entry rsp%16==8; the single push
+// re-aligns for the call and lands the 7th arg at the callee's [rsp+8], exactly where SysV wants
+// it. CONFIDENCE: HIGH.
 extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
-                                        uint64_t a3, uint64_t a4, uint64_t a5);
+                                        uint64_t a3, uint64_t a4, uint64_t a5,
+                                        uint64_t entry_rsp);
 asm(".text\n"
     ".globl f_apr_read_submit_entry\n"
     ".type f_apr_read_submit_entry,@function\n"
     "f_apr_read_submit_entry:\n"
-    "  movq %rsp, g_apr_entry_rsp(%rip)\n"
-    "  jmp f_apr_read_submit_c\n");
+    "  movq %rsp, %rax\n"
+    "  pushq %rax\n"
+    "  call f_apr_read_submit_c\n"
+    "  addq $8, %rsp\n"
+    "  ret\n");
 extern "C" void f_apr_read_submit_entry();
 // Fetch the Nth stack argument (0-based: arg7 is n=0) of the in-flight ReadFile call.
-static uint64_t apr_stack_arg(int n) {
-    uint64_t rsp = g_apr_entry_rsp;
-    if (!rsp) return 0;
-    // Both paths land the forwarded/natural stack args at [rsp+8] (see the layout note above).
-    return *(uint64_t*)(rsp + 0x8 + (uint64_t)n * 8);
+// Both stub paths land the forwarded/natural stack args at [entry_rsp+8] (layout note above).
+static uint64_t apr_stack_arg(uint64_t entry_rsp, int n) {
+    if (!entry_rsp) return 0;
+    return *(uint64_t*)(entry_rsp + 0x8 + (uint64_t)n * 8);
 }
 #endif
 
@@ -583,7 +583,8 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
 
 #ifndef _WIN32
 extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
-                                        uint64_t a3, uint64_t a4, uint64_t a5) {
+                                        uint64_t a3, uint64_t a4, uint64_t a5,
+                                        uint64_t entry_rsp) {
 #else
 HLE(f_apr_read_submit) {
 #endif
@@ -595,14 +596,14 @@ HLE(f_apr_read_submit) {
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
 #ifndef _WIN32
         fprintf(stderr, "[apr]   stack-args a6=0x%llx a7=0x%llx a8=0x%llx a9=0x%llx (rsp=0x%llx ret=0x%llx)\n",
-                (unsigned long long)apr_stack_arg(0), (unsigned long long)apr_stack_arg(1),
-                (unsigned long long)apr_stack_arg(2), (unsigned long long)apr_stack_arg(3),
-                (unsigned long long)g_apr_entry_rsp,
-                (unsigned long long)(g_apr_entry_rsp ? *(uint64_t*)g_apr_entry_rsp : 0));
+                (unsigned long long)apr_stack_arg(entry_rsp, 0), (unsigned long long)apr_stack_arg(entry_rsp, 1),
+                (unsigned long long)apr_stack_arg(entry_rsp, 2), (unsigned long long)apr_stack_arg(entry_rsp, 3),
+                (unsigned long long)entry_rsp,
+                (unsigned long long)(entry_rsp ? *(uint64_t*)entry_rsp : 0));
         // Guest call chain: first eboot-range return addresses on the stack (identifies which engine
         // wrapper submitted this read — sync mount path vs async FAPREventQueue path, issue #115).
-        if (g_apr_entry_rsp) {
-            const uint64_t* sp = (const uint64_t*)g_apr_entry_rsp;
+        if (entry_rsp) {
+            const uint64_t* sp = (const uint64_t*)entry_rsp;
             int shown = 0;
             for (int i = 0; i < 160 && shown < 6; i++) {
                 uint64_t v = sp[i];
@@ -673,7 +674,7 @@ HLE(f_apr_read_submit) {
     { struct stat st {}; if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
     uint64_t offset = 0;
 #ifndef _WIN32
-    offset = apr_stack_arg(0);
+    offset = apr_stack_arg(entry_rsp, 0);
 #endif
     uint64_t size = a5;
     if (offset > fsize) {

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -143,6 +143,25 @@ HLE(k_cond_wait)      { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.ent
     { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
       if (c && m) pthread_cond_wait(c, m); }
     if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
+// POSIX pthread_cond_timedwait(cond_slot, mutex_slot, const timespec* abstime) — abstime is an
+// ABSOLUTE CLOCK_REALTIME deadline ({i64 sec, i64 nsec}, FreeBSD == Linux x86-64 layout), and the
+// POSIX shim returns the errno VALUE directly (FreeBSD ETIMEDOUT = 60). This was an unimplemented
+// stub returning 0 = "signaled": UE's IAsyncReadRequest::WaitCompletion(timeout) loop (guest
+// eboot+0x22ea8ca, live-caught spinning at 100% CPU with RA 0x4022ea954 inside prosper_on_unimpl)
+// re-checked its predicate and retried instantly, forever. The cond/mutex SLOTS are the same
+// pointer-slot scheme as scePthreadCond* (the same objects flow through k_cond_wait's infinite
+// branch), so ensure_cond/ensure_mutex map them to the identical host objects.
+// CONFIDENCE: HIGH (POSIX semantics; spin diagnosed live; FreeBSD errno per Kyty Errno.h).
+HLE(k_cond_timedwait) {
+    auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
+    if (!c || !m) return 22;                                   // EINVAL
+    if (!a2) { pthread_cond_wait(c, m); return 0; }
+    const int64_t* gts = (const int64_t*)(uintptr_t)a2;
+    struct timespec dl { (time_t)gts[0], (long)gts[1] };
+    int rc = pthread_cond_timedwait(c, m, &dl);
+    if (rc == ETIMEDOUT) return 60;                            // FreeBSD ETIMEDOUT
+    return (uint64_t)rc;
+}
 
 // --- read/write locks (opaque handle -> host pthread_rwlock_t). Real libc.prx uses these for its
 // internal state (locale, stdio, malloc arenas); stubbing them to no-ops leaves that state UNLOCKED
@@ -912,6 +931,7 @@ void register_kernel_hle() {
     R("pthread_cond_init", k_cond_init);      R("pthread_cond_destroy", k_cond_destroy);
     R("pthread_cond_signal", k_cond_signal);  R("pthread_cond_broadcast", k_cond_broadcast);
     R("pthread_cond_wait", k_cond_wait);
+    R("pthread_cond_timedwait", k_cond_timedwait);   // issue #115: unimpl-0 spun WaitCompletion loops
     R("pthread_condattr_init", k_condattr_init); R("pthread_condattr_destroy", k_condattr_destroy);
     R("pthread_attr_init", k_attr_init);      R("pthread_attr_destroy", k_attr_destroy);
     R("pthread_attr_setstacksize", k_attr_setstacksize);

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -566,6 +566,64 @@ HLE(k_ampr_getsize) {
 }
 HLE(k_ampr_x3) { return ampr_arglog("Qs1xtplKo0U", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }
+// --- APR completion-event plumbing (issue #115: DOLL hangs in CreateGlobalShaderMap because its
+// FAPREventQueueListener never receives read-completion events). Live-captured contract:
+//   sSAUCCU1dv4(eq=APREventQueue, id=0x7502, 0, 0, 0x43, 0)      — register APR events on an equeue
+//   H896Pt-yB4I(cbCtx, eq, id=0x7502, 0x10000000000003e8, 0, 7)  — bind a command buffer to the eq
+//   ASoW5WE-UPo(cb, ring_1based, u64* out1, u64* out2)           — libkernel: SUBMIT the APR cb;
+//     the engine treats a nonzero return as an error (test eax,eax at eboot+0x4022a1d55) and the
+//     completion handler (eboot+0x40229dcb0) RESUBMITS the next queued cb with ring = (data>>58)+1,
+//     proving the ring argument is 1-based and the out slots carry the completion token the
+//     listener later matches ((ring<<58)|counter — see hle_kernel_time.cpp).
+// prosper's reads complete synchronously inside the builders, so submit == complete: assign the
+// token, publish it through the out slots, and fire the equeue event.
+// CONFIDENCE: HIGH on listener decode + 1-based ring (disassembly); MED on out-slot roles (both
+// receive the token — the tracking object stores whichever it uses).
+uint64_t prosper_apr_next_token(unsigned ring, bool tracked_catchup);   // hle_kernel_time.cpp
+void prosper_eq_trigger_apr(uint64_t token);                            // "
+void prosper_eq_add_apr(uint64_t eq, int64_t id);                       // "
+namespace {
+    // Command-buffer ctxs bound to the APR event queue via H896Pt-yB4I. Only THEIR submissions
+    // generate completion events (confirmed live: the one bound ctx 0x1060e090c8 is exactly the
+    // one submit — ring1b=5 — whose event the listener consumed; all 70+ unbound stack-frame cbs
+    // submit on ring1b=6 and are consumed by record polling. Delivering events for unbound
+    // submissions hands the listener sequence numbers with no tracking entry, and its hash-miss
+    // path faults: eboot+0x229df3e, addr 0x10 — 2/2 runs, gone when gated).
+    std::mutex g_apr_bound_mx;
+    std::vector<uint64_t> g_apr_bound_cbs;
+    bool apr_cb_bound(uint64_t cb) {
+        std::lock_guard<std::mutex> lk(g_apr_bound_mx);
+        for (uint64_t b : g_apr_bound_cbs) if (b == cb) return true;
+        return false;
+    }
+}
+HLE(k_apr_set_equeue) {          // sSAUCCU1dv4 (eq, id, ...)
+    ampr_arglog("sSAUCCU1dv4(SetEqueue)", a0, a1, a2, a3, a4, a5);
+    if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
+    return 0;
+}
+HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I (cbCtx, eq, id, ...)
+    ampr_arglog("H896Pt-yB4I(CbSetEqueue)", a0, a1, a2, a3, a4, a5);
+    if (a1) prosper_eq_add_apr(a1, (int64_t)a2);
+    if (a0) { std::lock_guard<std::mutex> lk(g_apr_bound_mx); g_apr_bound_cbs.push_back(a0); }
+    return 0;
+}
+HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1, out2)
+    unsigned ring = a1 ? (unsigned)(a1 - 1) & 0x3f : 0;
+    uint64_t token = prosper_apr_next_token(ring, /*tracked_catchup=*/false);
+    if (a2 > 0xffff) *(uint64_t*)(uintptr_t)a2 = token;
+    if (a3 > 0xffff) *(uint64_t*)(uintptr_t)a3 = token;
+    if (amprlog()) fprintf(stderr, "[amprlog] ASoW5WE-UPo(Submit) cb=0x%llx ring1b=%llu -> token=0x%llx%s\n",
+                           (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)token,
+                           apr_cb_bound(a0) ? " (bound)" : "");
+    // Completion events only for submissions of an equeue-BOUND cb (see g_apr_bound_cbs).
+    // CONFIDENCE: MED-HIGH (bound-vs-unbound split observed exactly once each way; the crash the
+    // gate prevents reproduced 2/2 without it).
+    if (apr_cb_bound(a0)) prosper_eq_trigger_apr(token);
+    return 0;
+}
+// Still-unnamed mount-time Ampr NID (state query?); arg-logging no-op under PROSPER_AMPRLOG.
+HLE(k_ampr_u3) { return ampr_arglog("GnxKOHEawhk", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_begin) {
     if (amprlog()) {
         fprintf(stderr, "[amprlog] begin a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
@@ -800,6 +858,12 @@ void register_kernel_mem_hle() {
     Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");
     Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_x3, "sceAmprAprCommandBufferDestructor");
     Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_x4, "sceAmprCommandBufferDestructor");
+    // APR completion-event plumbing (issue #115). vWU-odnS+fU (the direct async file read) is
+    // registered in hle_file.cpp next to the other APR read path.
+    Hle::register_fn("sSAUCCU1dv4", (HleFn)k_apr_set_equeue,    "AprSetEventQueue?");
+    Hle::register_fn("H896Pt-yB4I", (HleFn)k_apr_cb_set_equeue, "AprCbSetEventQueue?");
+    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,        "AprSubmitCommandBuffer?");
+    Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_u3,           "AmprUnknown3");
 }
 
 } // namespace prosper

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -539,6 +539,17 @@ static uint64_t ampr_arglog(const char* tag, uint64_t a0, uint64_t a1, uint64_t 
 }
 HLE(k_ampr_x1) { return ampr_arglog("baQO9ez2gL4", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_x2) { return ampr_arglog("ULvXMDz56po", a0, a1, a2, a3, a4, a5); }
+// sceAmprCommandBufferGetSize (NID tZDDEo2tE5k, recovered by brute-forcing nid_hash over a
+// generated libSceAmpr corpus). Returns the command buffer's byte size. It fires during APR read
+// teardown; verified (issue #107) NOT to gate the config-load FMallocBinned3 crash — returning the
+// recorded cb size vs 0 leaves the crash bit-identical, so the value is non-critical here.
+// CONFIDENCE: MED (name from the same corpus that yielded the other 7 verified Ampr NIDs; exact
+// semantics of "size" — total vs used — unconfirmed, so we report the recorded cb size).
+HLE(k_ampr_getsize) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    ampr_arglog("tZDDEo2tE5k(GetSize)", a0, a1, a2, a3, a4, a5);
+    return g_apr_last_cb_size;
+}
 HLE(k_ampr_x3) { return ampr_arglog("Qs1xtplKo0U", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_begin) {
@@ -626,11 +637,35 @@ HLE(k_ampr_push_map) {
         if (p) track((uint64_t)p, a2, PROT_READ | PROT_WRITE, true, "ampr-map");
         if (p && have_phys && a1 > 0x540000000ull + 0x1000000000ull) {
             uint64_t mirror = a1 - 0x540000000ull;
-            void* q = map_phys_at(mirror, a2, PROT_READ | PROT_WRITE, phys);
-            if (q) track((uint64_t)q, a2, PROT_READ | PROT_WRITE, true, "ampr-mirror");
+            // issue #107: the mirror is a LOW-confidence heuristic (the 0x540000000 rule was pinned
+            // on one title, The Messenger). On UE4 PPSA17942 the mirror VA lands squarely on LIVE
+            // MallocBinned heap that the guest already lazy-committed and filled (e.g. mirror
+            // 0x11e0df0000 aliases Ampr buffer phys 0x10220000 but was committed as heap earlier):
+            // MAP_FIXED'ing the aliased page there DESTROYS the heap page, corrupting the pool so it
+            // later carves two blocks 0x10 apart. That overlap is what makes FConfigCacheIni's
+            // teardown free a bookkeeping word (0xd) as a pointer -> "FMallocBinned3 Attempt to free
+            // an unrecognized block". This is the same clobber class as issue #88 (SetBuffer over
+            // live heap), here via the map-flavor mirror. Only create the mirror when its target is
+            // NOT already backed guest memory (mincore succeeds == fully mapped == live): that keeps
+            // the Messenger's genuine two-view pool working (its mirror target is unmapped at map
+            // time) while never overwriting a live heap page. CONFIDENCE: HIGH (the collision is
+            // proven by MEMLOG: page 0x11e0df0000 appears as both [lazy-commit] heap and ampr
+            // mirror; the mirror map is strictly later, so it clobbers the live page).
+            unsigned char vec;
+            bool mirror_live = (mincore((void*)(uintptr_t)mirror, 1, &vec) == 0);
+            void* q = nullptr;
+            if (mirror_live) {
+                MLOG("ampr push-map va=0x%llx mirror=0x%llx SKIPPED (target is live guest memory — "
+                     "map-flavor mirror would clobber MallocBinned heap, issue #107)\n",
+                     (unsigned long long)a1, (unsigned long long)mirror);
+            } else {
+                q = map_phys_at(mirror, a2, PROT_READ | PROT_WRITE, phys);
+                if (q) track((uint64_t)q, a2, PROT_READ | PROT_WRITE, true, "ampr-mirror");
+            }
             MLOG("ampr push-map va=0x%llx len=0x%llx phys=0x%llx mirror=0x%llx -> %s/%s\n",
                  (unsigned long long)a1, (unsigned long long)a2, (unsigned long long)phys,
-                 (unsigned long long)mirror, p ? "ok" : "FAIL", q ? "ok" : "FAIL");
+                 (unsigned long long)mirror, p ? "ok" : "FAIL",
+                 mirror_live ? "skip" : (q ? "ok" : "FAIL"));
         } else {
             MLOG("ampr push-map va=0x%llx len=0x%llx -> %s\n",
                  (unsigned long long)a1, (unsigned long long)a2, p ? "ok" : "FAILED");
@@ -745,7 +780,10 @@ void register_kernel_mem_hle() {
     // teardown). Modeled as no-ops (arg capture under PROSPER_AMPRLOG); the read itself is
     // sceAmprAprCommandBufferReadFile in hle_file.cpp.
     Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_x1, "sceAmprCommandBufferReset");
-    Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_x2, "sceAmpr?ULvXMDz56po");
+    // ULvXMDz56po and tZDDEo2tE5k names recovered by brute-forcing nid_hash() over a generated
+    // libSceAmpr corpus (sceAmprCommandBuffer<Verb>): ClearBuffer and GetSize.
+    Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_x2, "sceAmprCommandBufferClearBuffer");
+    Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");
     Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_x3, "sceAmprAprCommandBufferDestructor");
     Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_x4, "sceAmprCommandBufferDestructor");
 }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -536,7 +536,42 @@ HLE(k_ampr_begin) {
     return 0;
 }
 HLE(k_ampr_push_map) {
+    MLOG("ampr SetBuffer args a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
     if (a1 && a2) {
+        // Back the page from the shared phys pool so BOTH pool views alias the same bytes: the
+        // guest WRITES its MallocBinned pool-page headers through this (high) view and READS them
+        // through a second view exactly 0x540000000 lower (empirically pinned — the two views'
+        // canary reads returned zeros with independent anonymous pages). Map the mirror too.
+        // CONFIDENCE: LOW on the 0x540000000 rule (observed constant, one title) — refine by
+        // finding the guest's own second-view creation; the aliasing itself is the HW contract.
+        //
+        // TWO FLAVORS of SetBuffer, discriminated by live arg capture (issue #88 root cause):
+        //   MAP flavor      — (cb, va, len, a3!=va, a4=0xffffffff/-1 sentinel, a5=0/0x720):
+        //                     "map fresh direct memory at va" (the AMM pool flow; the guest
+        //                     expects FRESH ZEROED pages, like sceKernelMapDirectMemory).
+        //   BUFFER flavor   — (cb, va, len, a3==va, a4=allocCtx e.g. 0x2001c10060, a5=3/0x2d):
+        //                     "use this ALREADY-EXISTING buffer" (the APR read flow's 0x40-byte
+        //                     completion records and its 0x4000 descriptor buffer). Real HW does
+        //                     NOT touch the buffer's memory here.
+        // The old handler treated BOTH as map requests. For the BUFFER flavor the target
+        // (va=0x15a0dfc000 len=0x4000) — and worse, the va-0x540000000 "second view" mirror —
+        // landed on LIVE MallocBinned heap holding the console manager's registered-CVar name
+        // strings; MAP_FIXED silently replaced them with fresh zero pages (invisible to HW
+        // watchpoints: no CPU store ever happened). The zeroed key made FEngineModule::
+        // StartupModule's FindConsoleVariable("r.Shadow.CacheWPOPrimitives") return null ->
+        // null virtual call -> rip=0: the issue-#88 crash. Registering the buffer is a no-op for
+        // memory state, so the BUFFER flavor now leaves memory strictly untouched.
+        // CONFIDENCE: HIGH on the discriminator (a3==a1 in all 13 captured buffer-flavor calls,
+        // a3!=a1 + a4 sentinel in all 3 captured map-flavor calls) and on the clobber diagnosis
+        // (single-run reg-time vs crash-time key dump + silent HW write-watch).
+        if (a3 == a1) {
+            MLOG("ampr set-buffer va=0x%llx len=0x%llx ctx=0x%llx flags=0x%llx -> no-op (existing buffer)\n",
+                 (unsigned long long)a1, (unsigned long long)a2, (unsigned long long)a4,
+                 (unsigned long long)a5);
+            return 0;
+        }
         // Back the page from the shared phys pool so BOTH pool views alias the same bytes: the
         // guest WRITES its MallocBinned pool-page headers through this (high) view and READS them
         // through a second view exactly 0x540000000 lower (empirically pinned — the two views'

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -438,21 +438,21 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
     static const bool waitcaller = getenv("PROSPER_WAITCALLER") != nullptr;
     if (waitcaller) {
         static std::atomic<int> shown{0};
-        if (shown.load() < 4 && shown.fetch_add(1) < 4) {
+        if (shown.load() < 8 && shown.fetch_add(1) < 8) {
             uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
-            for (int i = 0; i < 80; i++) {
+            for (int i = 0; i < 160; i++) {
                 uint64_t v = sp[i];
                 if (v < 0x400000000ull || v >= 0x4c0000000ull) continue;   // eboot / IL2CPP executable range
-                // PRECISE: a genuine caller is a return address whose preceding 5 bytes are `call rel32`
-                // (0xe8) targeting the STUB region (0x6..) — i.e. the game's actual import call site, not an
-                // unrelated eboot address that happens to be on the stack (e.g. a Vorbis-decode frame).
-                const uint8_t* pre = (const uint8_t*)(uintptr_t)(v - 5);
-                if (pre[0] != 0xe8) continue;
-                int32_t rel = *(const int32_t*)(pre + 1);
-                uint64_t target = v + (uint64_t)(int64_t)rel;
-                if (target < 0x600000000ull || target >= 0x700000000ull) continue;   // must call a stub
-                fprintf(stderr, "[waitcaller] stack[%d] eboot+0x%llx -> stub+0x%llx | loopcode:", i,
-                        (unsigned long long)(v - 0x400000000ull), (unsigned long long)(target - 0x600000000ull));
+                // A genuine caller is a return address preceded by a call: `call rel32` (0xe8 at v-5,
+                // any target — the import call goes through an in-eboot thunk, NOT straight to the
+                // stub region, so no target filter) or an indirect `call` (0xff at v-6/-3/-2).
+                const uint8_t* pre = (const uint8_t*)(uintptr_t)(v - 8);
+                bool is_call = pre[3] == 0xe8 ||                            // call rel32 at v-5
+                               pre[2] == 0xff || pre[5] == 0xff || pre[6] == 0xff;  // call r/m64 forms
+                if (!is_call) continue;
+                fprintf(stderr, "[waitcaller] eq=0x%llx num=%llu stack[%d] eboot+0x%llx | code@ra-0x18:",
+                        (unsigned long long)a0, (unsigned long long)a2, i,
+                        (unsigned long long)(v - 0x400000000ull));
                 const uint8_t* code = (const uint8_t*)(uintptr_t)(v - 0x18);
                 for (int b = 0; b < 0x40; b++) fprintf(stderr, "%02x", code[b]);
                 fprintf(stderr, "\n");
@@ -503,6 +503,118 @@ HLE(k_eq_getcount){
     if (evlog()) fprintf(stderr, "[ev] GetEventCount eq=0x%llx -> %d\n", (unsigned long long)a0, n);
     return (uint64_t)n;
 }
+
+// --- APR (Ampr file-read engine) completion events — issue #115. ------------------------------
+// UE4's PS5 platform file layer runs an "FAPREventQueueListener" thread that blocks in
+// WaitEqueue(APREventQueue, evs, 15, ...) and decodes each event with sceKernelGetEventData():
+//   data = (ring_index << 58) | completion_counter      (live-disassembled at eboot+0x4022740b0:
+//   r15 = data >> 0x3a; cnt = bzhi(data, 0x3a); per-ring "last processed" at listener+0xc8+ring*40;
+//   for seq in last+1..cnt: handler(ctx, (ring<<58)|seq) — eboot+0x40229dcb0 matches the token
+//   against the tracking object's +0x10 slot, else a hash-map keyed by the full token.)
+// The token the engine stores at submit time comes OUT of the submit call (ASoW5WE-UPo writes it
+// through its two out-pointers; the vWU-odnS+fU direct read returns it). prosper's APR reads are
+// synchronous, so "submit" == "complete": we assign the token and immediately post the event.
+// Event shape: guest code reads ONLY data (GetEventData) — ident/filter are never inspected — but
+// eq_post coalesces on (ident,filter), so ident carries the ring index to keep concurrent rings'
+// completions from replacing each other (per-ring coalescing to the HIGHEST counter is exactly the
+// kqueue/"completed up to" semantics the listener's range loop implements).
+// CONFIDENCE: HIGH on the data encoding + listener decode (disassembly); MED on registration arg
+// order (live capture: sSAUCCU1dv4(eq, id=0x7502, 0, 0, 0x43, 0), H896Pt-yB4I(ctx, eq, id, ...)).
+namespace {
+    constexpr int16_t EVFILT_AMPR_MODELED = -24;   // guest never reads filter; distinct on purpose
+    struct AprEqReg { uint64_t eq; int64_t id; };
+    // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
+    std::mutex g_apr_mx;
+    std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx
+    uint64_t g_apr_ring_seq[64]     = {};              // per-ring completion counters (guarded)
+    bool     g_apr_ring_catchup[64] = {};              // ring had a TRACKED pre-registration read
+    void apr_post(const AprEqReg& r, unsigned ring, uint64_t token) {   // no APR lock held
+        SceKEvent e{}; e.ident = r.id + (int64_t)ring; e.filter = EVFILT_AMPR_MODELED;
+        e.data = (int64_t)token; e.udata = 0;
+        eq_post(r.eq, e);
+    }
+}
+// Assign the next completion token for `ring` (0-based, 6 bits). Called by the APR submit paths.
+// `tracked_catchup`: the caller's completion must survive a registration that happens AFTER the
+// submit (the vWU direct read fires 2 calls before sSAUCCU1dv4 registers the queue). Untracked
+// submissions (the mount-era synchronous ASoW flow, consumed by polling the completion record)
+// must NOT replay at registration: the listener's range loop would hand their seqs to the
+// completion handler, whose hash-miss path is not null-tolerant (live crash: phantom ring-5 seqs
+// 1..13 -> vmovups from 0x10 at eboot+0x229df3e). Their rings reset to 0 instead, so the first
+// post-registration submission is seq 1 — matching the listener's zero-initialized per-ring
+// "last processed" counter. CONFIDENCE: MED-HIGH (crash-verified both ways).
+uint64_t prosper_apr_next_token(unsigned ring, bool tracked_catchup) {
+    ring &= 0x3f;
+    std::lock_guard<std::mutex> lk(g_apr_mx);
+    uint64_t seq = ++g_apr_ring_seq[ring];
+    if (tracked_catchup && g_apr_eq_regs.empty()) g_apr_ring_catchup[ring] = true;
+    return ((uint64_t)ring << 58) | (seq & ((1ull << 58) - 1));
+}
+// Post the completion event for `token`'s ring to every registered APR event queue — DEFERRED by
+// ~2 ms on a detached thread. Posting synchronously inside the submit loses the race the real
+// hardware never runs: the engine inserts its {token -> request} hash entry right AFTER the
+// submit call returns, and the listener's hash-MISS path is not tolerant (it copies from
+// entry 0 + 0x10 — the live eboot+0x229df3e fault). A real DMA read takes far longer than the
+// submitter's few bookkeeping instructions; the delay models that latency. The deferred post
+// reads the ring's counter AT POST TIME (not the captured token), so out-of-order wakeups can
+// never regress the coalesced event's "completed up to" counter. CONFIDENCE: MED (latency model;
+// the guest-visible contract — event data = (ring<<58)|counter after the tracking insert — is
+// crash-verified in both failure modes).
+namespace {
+void apr_schedule_post(unsigned ring) {
+    std::thread([ring] {
+        struct timespec ts{ 0, 2000000 };   // 2 ms
+        nanosleep(&ts, nullptr);
+        std::vector<AprEqReg> regs; uint64_t cur;
+        {
+            std::lock_guard<std::mutex> lk(g_apr_mx);
+            regs = g_apr_eq_regs;
+            cur  = g_apr_ring_seq[ring];
+        }
+        if (!cur) return;
+        uint64_t tok = ((uint64_t)ring << 58) | (cur & ((1ull << 58) - 1));
+        for (auto& r : regs) apr_post(r, ring, tok);
+        if (evlog()) fprintf(stderr, "[ev] AprComplete posted ring=%u upto=%llu -> %zu eq(s)\n",
+            ring, (unsigned long long)cur, regs.size());
+    }).detach();
+}
+}
+void prosper_eq_trigger_apr(uint64_t token) {
+    unsigned ring = (unsigned)(token >> 58) & 0x3f;
+    if (evlog()) fprintf(stderr, "[ev] AprComplete token=0x%llx (ring=%u seq=%llu) scheduled\n",
+        (unsigned long long)token, ring, (unsigned long long)(token & ((1ull << 58) - 1)));
+    apr_schedule_post(ring);
+}
+// Register an APR completion target. Tracked pre-registration completions (vWU direct reads) are
+// re-delivered so their listener wake-up isn't lost; untracked rings reset (see above).
+void prosper_eq_add_apr(uint64_t eq, int64_t id) {
+    bool pending[64] = {};
+    {
+        std::lock_guard<std::mutex> lk(g_apr_mx);
+        for (auto& r : g_apr_eq_regs) if (r.eq == eq && r.id == id) return;   // idempotent
+        bool first = g_apr_eq_regs.empty();
+        g_apr_eq_regs.push_back({ eq, id });
+        for (unsigned ring = 0; ring < 64; ring++) {
+            if (!g_apr_ring_seq[ring]) continue;
+            if (g_apr_ring_catchup[ring]) pending[ring] = true;
+            else if (first)               g_apr_ring_seq[ring] = 0;   // drop untracked history
+        }
+    }
+    // Deferred like every completion post (the engine may still be inserting its tracking entry
+    // for the pre-registration read when this registration call runs).
+    for (unsigned ring = 0; ring < 64; ring++)
+        if (pending[ring]) apr_schedule_post(ring);
+}
+
+// --- SceKernelEvent field accessors (Kyty EventQueue.cpp:318-378: plain field reads). The APR
+// listener consumes its events EXCLUSIVELY through sceKernelGetEventData; unimplemented-0 here made
+// every event decode as ring 0 / counter 0 (a no-op for the range loop). ---
+HLE(k_get_event_data)    { return a0 ? (uint64_t)((const SceKEvent*)P(a0))->data   : 0; }
+HLE(k_get_event_id)      { return a0 ? (uint64_t)((const SceKEvent*)P(a0))->ident  : 0; }
+HLE(k_get_event_filter)  { return a0 ? (uint64_t)(int64_t)((const SceKEvent*)P(a0))->filter : 0; }
+HLE(k_get_event_fflags)  { return a0 ? (uint64_t)((const SceKEvent*)P(a0))->fflags : 0; }
+HLE(k_get_event_udata)   { return a0 ? ((const SceKEvent*)P(a0))->udata : 0; }
+HLE(k_get_event_error)   { return 0; }
 
 // --- User + timer event sources (sceKernelAddUserEvent / TriggerUserEvent / AddHRTimerEvent /
 // AddTimerEvent). Previously no-ops, which starved any equeue the game feeds via these (e.g. Unity's
@@ -599,6 +711,10 @@ void register_kernel_time_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("sceKernelCreateEqueue", k_eq_create);   R("sceKernelDeleteEqueue", k_eq_delete);
     R("sceKernelWaitEqueue", k_eq_wait);        R("sceKernelGetEventCount", k_eq_getcount);
+    // SceKernelEvent accessors (the APR listener reads its events only through GetEventData)
+    R("sceKernelGetEventData", k_get_event_data);     R("sceKernelGetEventId", k_get_event_id);
+    R("sceKernelGetEventFilter", k_get_event_filter); R("sceKernelGetEventFflags", k_get_event_fflags);
+    R("sceKernelGetEventUserData", k_get_event_udata);R("sceKernelGetEventError", k_get_event_error);
     R("sceKernelAddHRTimerEvent", k_add_hrtimer_event); R("sceKernelAddUserEvent", k_add_user_event);
     R("sceKernelAddUserEventEdge", k_add_user_event);   R("sceKernelTriggerUserEvent", k_trigger_user_event);
     R("sceKernelDeleteUserEvent", k_del_user_event);   R("sceKernelDeleteHRTimerEvent", k_del_timer_event);

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -186,6 +186,44 @@ HLE(k_rtc_get_clock_utc) {
     return 0;
 }
 
+// sceRtcSetTick(SceRtcDateTime* dt, const SceRtcTick* tick): broken-down UTC datetime from a tick
+// (u64 µs since 0001-01-01, the Orbis RTC convention above). Reference: shadPS4 rtc.cpp
+// sceRtcSetTick (tick - UNIX_EPOCH_TICKS -> gmtime). Unimplemented-0 left the out struct at the
+// caller's zero-init, and UE4's FDateTime(Y:0,M:0,D:0,...) "Invalid Date values" fatal spammed
+// thousands of times during the post-shader-map load (issue #115 follow-on wall). glibc gmtime_r
+// handles pre-1970 (negative time_t) fine, so ticks below the unix epoch still convert.
+// CONFIDENCE: MED-HIGH (shadPS4 reference; struct layout shared with the GetCurrentClock family).
+HLE(k_rtc_set_tick) {   // (SceRtcDateTime* dt, const SceRtcTick* tick)
+    if (!a0 || !a1) return 0x80250001ull;   // SCE_RTC_ERROR_INVALID_POINTER
+    int64_t us = (int64_t)*(const uint64_t*)P(a1) - (int64_t)kRtcUnixEpochOffsetUs;
+    time_t secs = (time_t)(us >= 0 ? us / 1000000ll : (us - 999999ll) / 1000000ll);   // floor
+    int64_t rem = us - (int64_t)secs * 1000000ll;
+    struct tm tmv {};
+#ifdef _WIN32
+    gmtime_s(&tmv, &secs);
+#else
+    gmtime_r(&secs, &tmv);
+#endif
+    fill_rtc_datetime(P(a0), tmv, (uint32_t)rem);
+    return 0;
+}
+// sceRtcGetTick(const SceRtcDateTime* dt, SceRtcTick* tick): the inverse (datetime assumed UTC).
+HLE(k_rtc_get_tick) {   // (const SceRtcDateTime* dt, SceRtcTick* tick)
+    if (!a0 || !a1) return 0x80250001ull;
+    const uint16_t* d = (const uint16_t*)P(a0);
+    struct tm tmv {};
+    tmv.tm_year = (int)d[0] - 1900; tmv.tm_mon = (int)d[1] - 1; tmv.tm_mday = (int)d[2];
+    tmv.tm_hour = (int)d[3]; tmv.tm_min = (int)d[4]; tmv.tm_sec = (int)d[5];
+#ifdef _WIN32
+    int64_t secs = _mkgmtime64(&tmv);
+#else
+    int64_t secs = (int64_t)timegm(&tmv);
+#endif
+    *(uint64_t*)P(a1) = (uint64_t)(secs * 1000000ll + (int64_t)*(const uint32_t*)(d + 6)
+                                   + (int64_t)kRtcUnixEpochOffsetUs);
+    return 0;
+}
+
 // real sleeps so timed wait loops actually yield the CPU (and advance real time)
 HLE(k_usleep)   { uint64_t us = a0; struct timespec ts{ (time_t)(us / 1000000), (long)((us % 1000000) * 1000) }; nanosleep(&ts, nullptr); return 0; }
 HLE(k_sleep_s)  { struct timespec ts{ (time_t)a0, 0 }; nanosleep(&ts, nullptr); return (uint64_t)a0; }
@@ -738,6 +776,8 @@ void register_kernel_time_hle() {
     R("sceRtcGetCurrentClockLocalTime", k_rtc_get_clock_localtime); // (dt) — host-local tz
     R("sceRtcGetCurrentClock", k_rtc_get_current_clock);            // (dt, tz_minutes)
     R("sceRtcGetCurrentDateTimeUtc", k_rtc_get_clock_utc);
+    R("sceRtcSetTick", k_rtc_set_tick);   // tick -> UTC datetime (issue #115 follow-on: FDateTime spam)
+    R("sceRtcGetTick", k_rtc_get_tick);   // UTC datetime -> tick
     // module loading (report success; real PRX are already resident in our address space)
     R("sceSysmoduleLoadModule", k_ok);
     R("sceSysmoduleUnloadModule", k_ok);

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -1,6 +1,8 @@
 #include "linker.hpp"
 #include <unordered_map>
 #include <cstring>
+#include <cstdio>
+#include <cstdlib>
 
 namespace prosper {
 
@@ -79,6 +81,14 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
     // own ctors via _start; PRX modules need their init_array run by the loader). We run
     // them in reverse load order (deepest dependency first). init_array entries were just
     // relocated to absolute addresses, so read them straight from the image. ---
+    if (getenv("PROSPER_INITLOG")) {
+        for (size_t i = 0; i < out.mods.size(); i++) {
+            const Module& m = *out.mods[i];
+            fprintf(stderr, "[initlog] module %zu base=0x%llx init_va=0x%llx init_array_va=0x%llx entries=%llu\n",
+                    i, (unsigned long long)out.imgs[i].base, (unsigned long long)m.init_va,
+                    (unsigned long long)m.init_array_va, (unsigned long long)(m.init_array_sz / 8));
+        }
+    }
     for (size_t i = out.mods.size(); i-- > 1; ) {
         const Module& m = *out.mods[i];
         LoadedImage& img = out.imgs[i];


### PR DESCRIPTION
## Fixes #115 — UE4 reaches AGC RHI bring-up (the graphics path)

Follow-on from #107. With config init fixed, the UE4 title (PPSA17942) *hung* — no crash, but it never reached RHI/AGC. **The "online/PSN poll" hypothesis was disproven:** every online NID fires exactly once and a gdb all-thread dump showed nothing polling online state.

### Root cause — async APR read completions were never delivered
The main thread blocks in `CreateGlobalShaderMap` on `IAsyncReadRequest::WaitCompletion()` for an async APR read of `GlobalShaderCache-SF_PS5.bin` (inside `pakchunk0-ps5.pak`). UE's `FAPREventQueueListener` thread waits on the `APREventQueue` and decodes each event via `sceKernelGetEventData` as `(ring<<58)|completion_counter`. prosper served the reads **synchronously but never posted the completion event** → the listener never woke → permanent deadlock.

### Implemented (real async-event machinery)
- `libSceAmpr::sSAUCCU1dv4`/`H896Pt-yB4I` — register the APR event equeue; record the bound cb ctx.
- `libkernel::ASoW5WE-UPo` — APR submit `(cb, ring_1based, u64* out1, u64* out2)`; assigns the packed token through the out slots. Events fire **only for bound-cb submissions** (unbound record-polled submissions would hit the listener's hash-miss crash path — reproduced 2/2, gone with the gate).
- `libSceAmpr::vWU-odnS+fU` — the direct async read for the shader-cache region (pread + lazy-commit dst + deferred event).
- Token discipline: per-ring counters, deferred ~2 ms post carrying the ring's current counter (closes the submit-vs-tracking-insert race; kqueue coalescing then means "completed up to" exactly).
- `sceKernelGetEventData/Id/Filter/Fflags/UserData/Error` (Kyty field-read semantics).

### Follow-on walls fixed en route
POSIX `pthread_cond_timedwait` (unimpl→0 spun `WaitCompletion` at 100% CPU); `sceRtcSetTick`/`GetTick` (zeroed datetime → thousands of `FDateTime` fatals); APR per-container fd cache (~15× faster over 9p); race-free 7th-arg rsp capture for concurrent `sceAmprAprCommandBufferReadFile`.

### How far it gets now
GlobalShaderMap loads → PreInit clears online init unchanged → **AGC RHI bring-up** (`AgcCleanup`/`Interrupt`/`SubmissionThread` + `AgcEqueue`, `sceAgcDriverAddEqEvent id=0x20/0x0`) → 180+ pak reads served. This is the same `libSceAgc` path The Messenger renders through.

### Verified
- **ctest 52/52**; Messenger render smoke healthy (1920×1080, zero fatals in 240 s).

### New wall (filed as #161)
`MallocBinned3 Corruption Canary` spam ~10 s into the parallel content-load burst, then SIGSEGV. A/B-proven independent of these fixes; MEMLOG rules out every prosper page-clobber class. Top suspect: MB3 per-thread caches vs guest-`%fs` TLS for freshly-spawned loader threads.
