### PR TITLE
fix(hle): __ctype_get_mb_cur_max returns the MB_CUR_MAX value, not a pointer

### DIFF
--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -251,7 +251,9 @@ namespace {
 HLE(h_getpctype)  { build_ctype(); return (uint64_t)(uintptr_t)(g_ctype + 1); }
 HLE(h_getptolow)  { build_ctype(); return (uint64_t)(uintptr_t)(g_tolow + 1); }
 HLE(h_getptoup)   { build_ctype(); return (uint64_t)(uintptr_t)(g_toup + 1); }
-HLE(h_mbcurmax)   { static int one = 1; return (uint64_t)(uintptr_t)&one; }   // __ctype_get_mb_cur_max ptr/val
+// glibc contract: __ctype_get_mb_cur_max returns the VALUE of MB_CUR_MAX (size_t),
+// not a pointer. 1 in the "C" locale we present via setlocale.
+HLE(h_mbcurmax)   { return 1; }
 HLE(h_setlocale)  { static char c[] = "C"; return (uint64_t)(uintptr_t)c; }
 
 // C++/CRT lifecycle: we don't run global destructors, so registration is a no-op.

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -44,6 +44,13 @@ int main() {
     // sync_on_address futex is registered by raw NID (no symbol name) — check it directly.
     if (Hle::lookup("Hc4CaR6JBL0") == nullptr) { printf("  [FAIL] sceKernelWaitOnAddress raw NID\n"); fails++; }
 
+    // __ctype_get_mb_cur_max returns the VALUE of MB_CUR_MAX (1 in the "C" locale we
+    // present), not a pointer to it — guest code sizes buffers as MB_CUR_MAX*n (#141).
+    if (HleFn fn = Hle::lookup(nid_hash("__ctype_get_mb_cur_max"))) {
+        uint64_t v = fn(0, 0, 0, 0, 0, 0);
+        if (v != 1) { printf("  [FAIL] __ctype_get_mb_cur_max returned %llu, want 1 (the value, not a pointer)\n", (unsigned long long)v); fails++; }
+    } else { printf("  [FAIL] not registered: __ctype_get_mb_cur_max\n"); fails++; }
+
     if (fails) { printf("== FAIL: %d function(s) not registered ==\n", fails); return 1; }
     printf("== PASS: all %zu checked HLE functions registered ==\n", sizeof(names)/sizeof(names[0]) + 1);
     return 0;


### PR DESCRIPTION
## Summary
- `__ctype_get_mb_cur_max` (glibc contract) must return the **value** of `MB_CUR_MAX` (`size_t`, 1 in the "C" locale our `setlocale` presents), but the handler returned the **address of a static int**. Guest code computing `MB_CUR_MAX*n` buffer sizes got a ~48-bit host address, causing allocation failure/overflow and broken mbstowcs-style step bounds.
- Fix: return the value `1` directly.
- Test: `test_hle_registered` now also *calls* the handler and asserts it returns 1 (behavioral, not just registration).

## Verification
- Full suite in WSL build-linux: **53/53 passed** with the change.

Fixes #141