### PR TITLE
fix(recompiler): v_cvt_u32_f32 / v_cvt_i32_f32 saturate like the hardware

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -129,7 +129,21 @@ struct SpirvCompute {
     uint32_t fext2(uint32_t inst, uint32_t a, uint32_t b) { uint32_t r = id(); putv(code, Op_ExtInst, {t_f32, r, glsl, inst, bcf(a), bcf(b)}); return bcu(r); }
     uint32_t frcp(uint32_t a) { uint32_t rf = id(); put(code, Op_FDiv, {t_f32, rf, fconstf(1.0f), bcf(a)}); return bcu(rf); }
     uint32_t cvt_u2f(uint32_t u) { uint32_t rf = id(); put(code, Op_ConvertUToF, {t_f32, rf, u}); return bcu(rf); }   // uint -> float bits
-    uint32_t cvt_f2u(uint32_t bits) { uint32_t r = id(); put(code, Op_ConvertFToU, {t_u32, r, bcf(bits)}); return r; }
+    // v_cvt_u32_f32 SATURATES: NaN -> 0, negative -> 0, >= 2^32 -> 0xFFFFFFFF. A bare OpConvertFToU
+    // has an undefined result out of range (#135), so clamp first. FMin/FMax are themselves
+    // NaN-undefined, so NaN is routed to 0 explicitly. 4294967040.0f (0x4F7FFFFF) is the largest
+    // float < 2^32 — the next float IS 2^32, so the clamp is exact for every in-range input;
+    // inputs >= 2^32 (incl. +inf) select UINT_MAX.
+    uint32_t cvt_f2u(uint32_t bits) {
+        uint32_t f = bcf(bits);
+        uint32_t nan = id();  put(code, Op_FUnordNotEqual, {t_bool, nan, f, f});   // true iff NaN
+        uint32_t safe = id(); put(code, Op_Select, {t_f32, safe, nan, fconstf(0.0f), f});
+        uint32_t lo = id();   putv(code, Op_ExtInst, {t_f32, lo, glsl, Glsl_FMax, safe, fconstf(0.0f)});
+        uint32_t cl = id();   putv(code, Op_ExtInst, {t_f32, cl, glsl, Glsl_FMin, lo, fconstf(4294967040.0f)});
+        uint32_t r = id();    put(code, Op_ConvertFToU, {t_u32, r, cl});
+        uint32_t big = id();  put(code, Op_FOrdGreaterThanEqual, {t_bool, big, f, fconstf(4294967296.0f)});
+        return sel(big, uconst(0xFFFFFFFFu), r);
+    }
     // Float ordered compare on bit-operands -> bool (for VCC). select() picks bits by a bool condition.
     uint32_t fcmp(uint32_t cmpop, uint32_t a, uint32_t b) { uint32_t r = id(); put(code, cmpop, {t_bool, r, bcf(a), bcf(b)}); return r; }
     uint32_t bfalse() { if (!bconst_false) { bconst_false = id(); put(types, Op_ConstantFalse, {t_bool, bconst_false}); } return bconst_false; }
@@ -184,7 +198,19 @@ struct SpirvCompute {
     }
     uint32_t sbin(uint32_t op, uint32_t a, uint32_t b) { uint32_t ri = id(); put(code, op, {t_i32, ri, bcs(a), bcs(b)}); return i2u(ri); }
     uint32_t sext2(uint32_t inst, uint32_t a, uint32_t b) { uint32_t ri = id(); putv(code, Op_ExtInst, {t_i32, ri, glsl, inst, bcs(a), bcs(b)}); return i2u(ri); }
-    uint32_t cvt_f2i(uint32_t bits) { uint32_t ri = id(); put(code, Op_ConvertFToS, {t_i32, ri, bcf(bits)}); return i2u(ri); }
+    // v_cvt_i32_f32 SATURATES: NaN -> 0, clamp to [INT_MIN, INT_MAX] (#135). 2147483520.0f
+    // (0x4EFFFFFF) is the largest float < 2^31, so the high clamp is exact in range and inputs
+    // >= 2^31 select INT_MAX; -2^31 is exactly representable, so the low clamp needs no select.
+    uint32_t cvt_f2i(uint32_t bits) {
+        uint32_t f = bcf(bits);
+        uint32_t nan = id();  put(code, Op_FUnordNotEqual, {t_bool, nan, f, f});   // true iff NaN
+        uint32_t safe = id(); put(code, Op_Select, {t_f32, safe, nan, fconstf(0.0f), f});
+        uint32_t hi = id();   putv(code, Op_ExtInst, {t_f32, hi, glsl, Glsl_FMin, safe, fconstf(2147483520.0f)});
+        uint32_t cl = id();   putv(code, Op_ExtInst, {t_f32, cl, glsl, Glsl_FMax, hi, fconstf(-2147483648.0f)});
+        uint32_t ri = id();   put(code, Op_ConvertFToS, {t_i32, ri, cl});
+        uint32_t big = id();  put(code, Op_FOrdGreaterThanEqual, {t_bool, big, f, fconstf(2147483648.0f)});
+        return sel(big, uconst(0x7FFFFFFFu), i2u(ri));
+    }
     uint32_t cvt_i2f(uint32_t bits) { uint32_t rf = id(); put(code, Op_ConvertSToF, {t_f32, rf, bcs(bits)}); return bcu(rf); }
     // Integer compares -> bool. scmp treats operands as signed, ucmp as unsigned.
     uint32_t scmp(uint32_t op, uint32_t a, uint32_t b) { uint32_t r = id(); put(code, op, {t_bool, r, bcs(a), bcs(b)}); return r; }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1249,6 +1249,53 @@ int main() {
     printf("  kernelN(v_nop) mismatches=%u (out[33]=%g expect=%g)\n", badN, gotN.size()==N?gotN[33]:-1, expN[33]);
     CHECK(gotN.size()==N && badN==0, "v_nop is transparent: out = (a0+a1)*a2 computed correctly");
 
+    // Kernels S1/S2: v_cvt_u32_f32 / v_cvt_i32_f32 SATURATION (#135). RDNA2 saturates the
+    // float->int converts (NaN -> 0, negative -> 0 for u32, out-of-range clamps to the type
+    // min/max); a bare OpConvertFToU/S is undefined out of range, so drivers returned garbage.
+    // Round-trip through v_cvt_f32_u32 / v_cvt_f32_i32 so the output buffer holds a comparable
+    // float. Encodings llvm-mc gfx1030 round-trip verified.
+    //   S1: v_cvt_u32_f32 v0,v0 | v_cvt_f32_u32 v0,v0 | s_endpgm
+    //   S2: v_cvt_i32_f32 v0,v0 | v_cvt_f32_i32 v0,v0 | s_endpgm
+    const uint32_t codeS1[] = { 0x7E000F00u, 0x7E000D00u, 0xBF810000u };
+    const uint32_t codeS2[] = { 0x7E001100u, 0x7E000B00u, 0xBF810000u };
+    std::vector<uint32_t> spvS1 = recompile_valu(codeS1, sizeof(codeS1)/sizeof(codeS1[0]), 1, 0);
+    std::vector<uint32_t> spvS2 = recompile_valu(codeS2, sizeof(codeS2)/sizeof(codeS2[0]), 1, 0);
+    CHECK(!spvS1.empty(), "recompiled kernel S1 (v_cvt_u32_f32 saturating) -> SPIR-V");
+    CHECK(!spvS2.empty(), "recompiled kernel S2 (v_cvt_i32_f32 saturating) -> SPIR-V");
+    const float satIn[] = { 3.7f, 0.0f, -0.5f, -5.5f, 255.9f, -1e10f, 1e10f, 4294967040.0f,
+                            2147483520.0f, std::nanf(""), INFINITY, -INFINITY };
+    const uint32_t NSAT = sizeof(satIn)/sizeof(satIn[0]);
+    auto sat_u32 = [](float x) -> uint32_t {
+        if (std::isnan(x)) return 0u;
+        if (x <= 0.0f) return 0u;
+        if (x >= 4294967296.0f) return 0xFFFFFFFFu;
+        return (uint32_t)x;
+    };
+    auto sat_i32 = [](float x) -> int32_t {
+        if (std::isnan(x)) return 0;
+        if (x <= -2147483648.0f) return INT32_MIN;
+        if (x >= 2147483648.0f) return INT32_MAX;
+        return (int32_t)x;
+    };
+    std::vector<float> inS(N), expS1(N), expS2(N);
+    for (uint32_t i = 0; i < N; i++) {
+        float a = satIn[i % NSAT];
+        inS[i] = a; expS1[i] = (float)sat_u32(a); expS2[i] = (float)sat_i32(a);
+    }
+    std::vector<float> gotS1 = prosper::test::run_compute(spvS1, inS, N, N);
+    std::vector<float> gotS2 = prosper::test::run_compute(spvS2, inS, N, N);
+    uint32_t badS1 = 0, badS2 = 0;
+    for (uint32_t i = 0; i < N && gotS1.size() == N; i++)
+        if (std::fabs(gotS1[i] - expS1[i]) > 1e-3f + 1e-6f*std::fabs(expS1[i])) badS1++;
+    for (uint32_t i = 0; i < N && gotS2.size() == N; i++)
+        if (std::fabs(gotS2[i] - expS2[i]) > 1e-3f + 1e-6f*std::fabs(expS2[i])) badS2++;
+    printf("  kernelS1(u32 sat) mismatches=%u (nan->%g, -5.5->%g, 1e10->%g expect 0,0,%g)\n", badS1,
+           gotS1.size()==N?gotS1[9]:-1, gotS1.size()==N?gotS1[3]:-1, gotS1.size()==N?gotS1[6]:-1, expS1[6]);
+    printf("  kernelS2(i32 sat) mismatches=%u (nan->%g, -1e10->%g, 1e10->%g expect 0,%g,%g)\n", badS2,
+           gotS2.size()==N?gotS2[9]:-1, gotS2.size()==N?gotS2[5]:-1, gotS2.size()==N?gotS2[6]:-1, expS2[5], expS2[6]);
+    CHECK(gotS1.size()==N && badS1==0, "v_cvt_u32_f32 saturates (NaN/neg -> 0, >=2^32 -> UINT_MAX)");
+    CHECK(gotS2.size()==N && badS2==0, "v_cvt_i32_f32 saturates (NaN -> 0, clamps to INT_MIN/INT_MAX)");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- RDNA2 **saturates** `v_cvt_u32_f32` / `v_cvt_i32_f32`: NaN → 0, negative → 0 (u32), out-of-range clamps to the type min/max. The `cvt_f2u`/`cvt_f2i` helpers emitted bare `OpConvertFToU/S`, whose result is **undefined** in SPIR-V for out-of-range/NaN inputs — a shader relying on the hardware clamp got a driver-dependent garbage index (OOB access / per-GPU wrong render).
- Fix in the shared helpers (both VOP1 call sites + `pack_norm` benefit):
  - clamp in the float domain first, to the largest exactly-representable in-range float (`0x4F7FFFFF` = 4294967040.0 for u32, `0x4EFFFFFF` = 2147483520.0 for i32 — the *next* float is exactly 2^32 / 2^31, so in-range behavior is exact),
  - route NaN to 0 explicitly via a self-compare select (GLSL.std.450 FMin/FMax are themselves NaN-undefined),
  - select the exact `UINT_MAX` / `INT_MAX` endpoints for inputs ≥ 2^32 / 2^31 (incl. +inf) so boundary behavior matches hardware bit-exactly. −2^31 is exactly representable, so the i32 low clamp needs no select.

## Verification
- New execution kernels S1/S2 in `test_rdna2_to_spirv` (VOP1 encodings **llvm-mc gfx1030 round-trip verified**) drive NaN / ±inf / negative / ±1e10 / boundary inputs through the recompiled converts on real Vulkan compute:
  - `kernelS1(u32 sat) mismatches=0 (nan->0, -5.5->0, 1e10->4.29497e+09)`
  - `kernelS2(i32 sat) mismatches=0 (nan->0, -1e10->-2.14748e+09, 1e10->2.14748e+09)`
- Full suite in WSL build-linux: **53/53 passed**.

Fixes #135