### PR TITLE
fix(host): emulate AMD SSE4a insertq/extrq on Intel hosts — Zen2 guest code runs (PPSA01885 past CreateWorkload)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -66,6 +66,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_va2foff PRIVATE prosper_core)
   add_test(NAME va2foff_load_priority COMMAND test_va2foff)
 
+  # AMD SSE4a INSERTQ/EXTRQ emulation (the SIGILL handler emulates these Zen2-only ops on Intel
+  # hosts). Golden bit-math vectors — header-only, no game dump required.
+  add_executable(test_sse4a tests/test_sse4a.cpp)
+  add_test(NAME sse4a_insertq_extrq COMMAND test_sse4a)
+
   # sceAudioOut HLE: format decode, port lifecycle, PCM forwarding, volume, batch, error paths
   # (via a capturing AudioSink — headless, no device).
   add_executable(test_audio tests/test_audio.cpp)

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1,6 +1,7 @@
 // exec_image_linux.cpp — Linux host backing + HLE stubs (M2/M3). Compiles to nothing
 // on non-Linux so the shared (mingw) build is unaffected.
 #include "exec_image.hpp"
+#include "sse4a.hpp"
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
 
@@ -412,7 +413,59 @@ namespace {
     // the canary on exactly this %fs-switching handler removes the false positive at its source (more
     // robust than copying the canary into every guest TCB, which is per-thread-fragile).
     __attribute__((no_stack_protector))
+    // AMD SSE4a (insertq/extrq) emulation. PS5 guest code is compiled for Zen2 (AMD) and emits SSE4a
+    // bitfield instructions that #UD (SIGILL) on Intel hosts. Decode the faulting instruction from the
+    // signal context, emulate it against the guest XMM registers, advance RIP, and let sigreturn resume.
+    // Register-operand forms only (the compiler-emitted ones) — returns false for anything else so the
+    // real fatal path still handles genuine SIGILLs. Async-signal-safe: touches only the ucontext and
+    // the mapped, executable instruction bytes at RIP.
+    //   INSERTQ (F2 0F 78 /r ib ib  and  F2 0F 79 /r): insert low `len` bits of src into dst at bit `idx`.
+    //   EXTRQ   (66 0F 78 /0 ib ib  and  66 0F 79 /r): extract `len` bits at `idx`, zero-extend into low 64.
+    // Control for the /78 imm forms is the two trailing imm8s; for the /79 reg forms it comes from the
+    // source xmm (EXTRQ: rm[13:0]; INSERTQ: rm[77:64]).  len==0 means 64. CONFIDENCE: HIGH (Intel SDM).
+    volatile unsigned long g_sse4a_emulated = 0;
+    bool try_emulate_sse4a(ucontext_t* uc) {
+        auto& g = uc->uc_mcontext.gregs;
+        uint64_t rip = (uint64_t)g[REG_RIP];
+        const uint8_t* p = (const uint8_t*)rip;
+        size_t i = 0;
+        uint8_t pfx = p[i];
+        if (pfx != 0xF2 && pfx != 0x66) return false;   // INSERTQ=F2, EXTRQ=66
+        i++;
+        uint8_t rex = 0;
+        if ((p[i] & 0xF0) == 0x40) rex = p[i++];
+        if (p[i++] != 0x0F) return false;
+        uint8_t op = p[i++];
+        if (op != 0x78 && op != 0x79) return false;
+        uint8_t modrm = p[i++];
+        if ((modrm >> 6) != 3) return false;            // register operands only
+        int reg = ((modrm >> 3) & 7) | ((rex & 4) ? 8 : 0);
+        int rm  = (modrm & 7)       | ((rex & 1) ? 8 : 0);
+        auto* fp = uc->uc_mcontext.fpregs;
+        if (!fp) return false;
+        auto lo  = [&](int n) { const uint32_t* e = fp->_xmm[n].element; return (uint64_t)e[0] | ((uint64_t)e[1] << 32); };
+        auto hi  = [&](int n) { const uint32_t* e = fp->_xmm[n].element; return (uint64_t)e[2] | ((uint64_t)e[3] << 32); };
+        auto set = [&](int n, uint64_t v) { uint32_t* e = fp->_xmm[n].element; e[0] = (uint32_t)v; e[1] = (uint32_t)(v >> 32); };
+        bool insertq = (pfx == 0xF2);
+        uint32_t len, idx;
+        if (op == 0x78)       { len = p[i++]; idx = p[i++]; }
+        else if (insertq)     { uint64_t c = hi(rm); len = (uint32_t)(c & 0x3f); idx = (uint32_t)((c >> 8) & 0x3f); }
+        else                  { uint64_t c = lo(rm); len = (uint32_t)(c & 0x3f); idx = (uint32_t)((c >> 8) & 0x3f); }
+        len &= 0x3f; idx &= 0x3f;                       // 6-bit fields; sse4a_* treat len==0 as 64
+        if (insertq)                                    // INSERTQ dst=reg, field source=rm
+            set(reg, sse4a_insertq(lo(reg), lo(rm), len, idx));
+        else {                                          // EXTRQ: imm form in-place on rm, reg form on reg
+            int dr = (op == 0x78) ? rm : reg;
+            set(dr, sse4a_extrq(lo(dr), len, idx));
+        }
+        g[REG_RIP] = (greg_t)(rip + i);
+        g_sse4a_emulated++;
+        return true;
+    }
+
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
+        // Emulate AMD-only SSE4a bitfield ops (insertq/extrq) that #UD on Intel hosts, then resume.
+        if (sig == SIGILL && try_emulate_sse4a((ucontext_t*)uctx)) return;
         // PROSPER_HWBP race-free hardware breakpoint. The perf event is disabled while single-stepping,
         // so a SIGTRAP while g_hwbp_stepping is the step-completion (TF) -> re-enable + clear TF. Any
         // other SIGTRAP while armed is a HW-breakpoint hit -> log registers, then disable + single-step

--- a/prosper/src/host/sse4a.hpp
+++ b/prosper/src/host/sse4a.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+
+// AMD SSE4a bitfield semantics (INSERTQ / EXTRQ), extracted as pure functions so the signal-handler
+// emulator in exec_image_linux.cpp can be unit-tested (tests/test_sse4a.cpp). PS5 guest code is
+// compiled for Zen2 and emits these; they #UD (SIGILL) on Intel hosts, so we emulate them.
+// Reference: Intel SDM Vol. 2 (INSERTQ/EXTRQ) — length/index are 6-bit fields; length 0 means 64;
+// results with index+length > 64 are architecturally undefined (we let the 64-bit shifts drop them).
+namespace prosper {
+
+// INSERTQ: replace `len` bits of `dst` starting at bit `idx` with the low `len` bits of `src`.
+// Only the low 64 bits participate; bits of dst outside [idx, idx+len) are preserved.
+inline uint64_t sse4a_insertq(uint64_t dst, uint64_t src, uint32_t len, uint32_t idx) {
+    if (len == 0) len = 64;
+    uint64_t mask  = (len >= 64) ? ~0ull : ((1ull << len) - 1);
+    uint64_t field = src & mask;
+    uint64_t sh    = (idx >= 64) ? 0 : (mask  << idx);
+    uint64_t sf    = (idx >= 64) ? 0 : (field << idx);
+    return (dst & ~sh) | sf;
+}
+
+// EXTRQ: extract `len` bits of `src` starting at bit `idx`, zero-extended into the low 64 bits.
+inline uint64_t sse4a_extrq(uint64_t src, uint32_t len, uint32_t idx) {
+    if (len == 0) len = 64;
+    uint64_t mask = (len >= 64) ? ~0ull : ((1ull << len) - 1);
+    return (idx >= 64 ? 0 : (src >> idx)) & mask;
+}
+
+} // namespace prosper

--- a/prosper/tests/test_sse4a.cpp
+++ b/prosper/tests/test_sse4a.cpp
@@ -1,0 +1,39 @@
+// test_sse4a — golden vectors for the AMD SSE4a INSERTQ/EXTRQ emulation used by the SIGILL handler
+// in exec_image_linux.cpp (PS5 Zen2 guest code #UDs these on Intel hosts). Values hand-computed
+// from the Intel SDM bitfield semantics; this locks the arithmetic independently of the signal path.
+#include "../src/host/sse4a.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+static int g_fail = 0, g_pass = 0;
+#define CHECK(expr, expect) do { uint64_t _v = (expr); if (_v == (uint64_t)(expect)) g_pass++; else { \
+    g_fail++; printf("  [FAIL] %s:%d  %s = 0x%llx, expected 0x%llx\n", __FILE__, __LINE__, #expr, \
+    (unsigned long long)_v, (unsigned long long)(uint64_t)(expect)); } } while (0)
+
+int main() {
+    printf("== test_sse4a ==\n");
+
+    // --- INSERTQ: replace `len` bits of dst at bit `idx` with low `len` bits of src ---
+    CHECK(sse4a_insertq(0x0, 0xAB, 8, 8), 0xAB00);                    // insert byte at bit 8
+    CHECK(sse4a_insertq(0x12, 0x12, 8, 8), 0x1212);                  // the real crash form: byte1 := byte0
+    CHECK(sse4a_insertq(0x0, 0xF, 4, 32), 0x0000000F00000000ull);    // nibble at bit 32
+    CHECK(sse4a_insertq(~0ull, 0x0, 4, 0), 0xFFFFFFFFFFFFFFF0ull);   // clear low nibble, keep rest
+    CHECK(sse4a_insertq(~0ull, 0x123456789ABCDEF0ull, 0, 0),         // len==0 => 64: full replace
+                        0x123456789ABCDEF0ull);
+    CHECK(sse4a_insertq(0xFF00, 0xFF, 8, 0), 0xFFFF);                // low byte := src, high byte kept
+
+    // --- EXTRQ: extract `len` bits at bit `idx`, zero-extend into low 64 ---
+    CHECK(sse4a_extrq(0xAB00, 8, 8), 0xAB);                          // pull byte 1
+    CHECK(sse4a_extrq(0x123456789ABCDEF0ull, 16, 16), 0x9ABC);      // bits [31:16]
+    CHECK(sse4a_extrq(0xFF, 4, 0), 0xF);                            // low nibble
+    CHECK(sse4a_extrq(0x123456789ABCDEF0ull, 0, 0),                 // len==0 => 64: whole qword
+                      0x123456789ABCDEF0ull);
+    CHECK(sse4a_extrq(~0ull, 1, 63), 0x1);                         // top bit -> bit 0
+
+    // Round-trip: insert then extract the same field recovers it.
+    CHECK(sse4a_extrq(sse4a_insertq(0x0, 0x3C, 8, 24), 8, 24), 0x3C);
+
+    printf("== test_sse4a: %d passed, %d failed ==\n", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
## Problem
PS5 guest code is compiled for **Zen2 (AMD)** and emits **SSE4a** bitfield instructions (`INSERTQ`/`EXTRQ`). Those instructions **don't exist on Intel** — they `#UD` → SIGILL. PPSA01885 crashed deterministically at:
```
eboot+0xce3c4a:  insertq $0x8,$0x8,%xmm0,%xmm0
```
inside `GfxDevicePS5SharedData::CreateWorkload` (a compiler byte-broadcast sequence, surrounded by `vmovd`/`vpinsrb`/`vpor`). Host here is an Intel i7-13700K (no SSE4a); the SIGILL handler previously just reported the fault.

## Fix
Emulate the AMD-only ops in the SIGILL handler: decode the faulting instruction from the signal context, operate on the guest XMM regs in `uc_mcontext.fpregs`, advance RIP, and let `sigreturn` resume. Register-operand forms of both ops:
- `INSERTQ  F2 0F 78 /r ib ib` and `F2 0F 79 /r`
- `EXTRQ    66 0F 78 /0 ib ib` and `66 0F 79 /r`

`len==0 ⇒ 64`; control for the `/79` reg forms comes from the source xmm. Anything else returns false so real SIGILLs still hit the fatal path. Async-signal-safe (touches only the ucontext + the mapped instruction bytes).

## Verification
- Bit-math extracted to header-only `sse4a.hpp`, locked by **`tests/test_sse4a.cpp` — 12 golden vectors** hand-derived from the Intel SDM (INSERTQ/EXTRQ semantics), so the emulation is verified independently of the signal path.
- **59/59 ctest green.**
- **Effect:** the SIGILL is gone; PPSA01885 now boots **past `CreateWorkload`** (it later stalls on unrelated `libSceIme`/`SystemService` init — a separate, softer blocker).

General infrastructure fix — benefits any AMD-compiled title that emits SSE4a on Intel hosts. Refs #126 (this was the actual deterministic crash behind that graphics-stage investigation).