### PR TITLE
fix(gpu): s_bfe_u64 const-fold sign-extends negative inline constants

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -179,6 +179,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_rdna2_spirv_struct PRIVATE prosper_core)
   add_test(NAME rdna2_spirv_struct COMMAND test_rdna2_spirv_struct)
 
+  # Scalar const-fold interpreter behind bindless-dynamic vertex-fetch resolution (no Vulkan needed).
+  add_executable(test_dynfetch_fold tests/test_dynfetch_fold.cpp)
+  target_link_libraries(test_dynfetch_fold PRIVATE prosper_core)
+  add_test(NAME dynfetch_fold COMMAND test_dynfetch_fold)
+
   # shader_histo: data-driven recompiler-coverage report over the game's real embedded RDNA2 shaders.
   add_executable(shader_histo tools/shader_histo/shader_histo.cpp)
   target_link_libraries(shader_histo PRIVATE prosper_core)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -12,6 +12,7 @@
 #include "render_state.hpp"        // extract_render_state / resolve_pipeline_state / ResolvedPipelineState
 #include "rdna2_to_spirv.hpp"      // recompile_vertex / recompile_fragment
 #include "shader_resources.hpp"    // ShaderResourceTable
+#include "agc_shader_layout.hpp"   // DecodedBufferDescriptor (DynFetch)
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -50,6 +51,15 @@ using RenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawItem>&
 // (Linux; always-true on Windows), so callers can test a guest pointer without risking a SIGSEGV.
 // Implemented in gpu_executor.cpp; shared by the executor's const-eval and HLE diagnostic probes.
 bool guest_readable(uint64_t addr, uint32_t bytes);
+
+// One resolved bindless-dynamic vertex fetch from the wave-uniform scalar const-fold in
+// gpu_executor.cpp: the exact fetch instruction (pc), its SRSRC SGPR, and the V# live in that SGPR
+// at that instruction. Exposed (with resolve_dynamic_fetch) so the fold's scalar-ALU semantics are
+// unit-testable; production callers stay inside gpu_executor.cpp.
+struct DynFetch { uint32_t fetch_pc; int srsrc; DecodedBufferDescriptor desc; uint32_t desc_v3; };
+std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
+                                            const uint32_t* user_sgprs, uint32_t nsgpr,
+                                            uint32_t user_sgpr_base);
 
 // Build a shader stage's resource table from the folded GpuState: look up the registered shader header
 // by its bound code address, read its user-data SGPR block from the sh register file, decode the V#/T#/S#

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -76,8 +76,6 @@ bool guest_readable(uint64_t a, uint32_t n) {
 bool guest_readable(uint64_t, uint32_t) { return true; }
 #endif
 
-namespace {
-
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------
 // This game's NGG vertex shader loads its vertex-buffer V# from a descriptor table at a RUNTIME-computed
 // offset (e.g. `s_load_dwordx4 s[8:11], s[24:25], vcc_hi` where `vcc_hi = (s64<<4)&0x1f0` and
@@ -89,10 +87,7 @@ namespace {
 // VertexBuffer keyed by sgpr_base so the recompiler's by_sgpr_base() resolves it. Uniform-scalar only: any
 // value that would depend on a VGPR/lane is left unknown (the op's dest becomes unknown), so we never
 // fabricate a per-lane-dependent descriptor. CONFIDENCE: MED (covers this game's fetch-shader shape).
-// One resolved vertex fetch: the exact fetch instruction (pc), its SRSRC SGPR, and the V# live in that
-// SGPR at that instruction. Emitted per-fetch so a reloaded SRSRC (one V# per attribute) doesn't collapse.
-struct DynFetch { uint32_t fetch_pc; int srsrc; DecodedBufferDescriptor desc; uint32_t desc_v3; };
-
+// External linkage (DynFetch + declaration in gpu_execute.hpp) so the fold is unit-testable.
 std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
                       uint32_t user_sgpr_base) {
@@ -160,12 +155,18 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         break;
                     case 0x29: {  // s_bfe_u64: dst[63:0] = bitfield of src0[63:0] (format patch reads a small field)
                         uint32_t off = c & 0x3f, wid = (c >> 16) & 0x7f, ahi = 0;
-                        // src0's high dword: the next SGPR of the pair, or 0 for a 32-bit inline/literal
-                        // constant (zero-extended). Only an SGPR operand may index val[value+1] — a
-                        // literal's `value` is not an SGPR number. And an UNTRACKED high dword must not
-                        // silently fold as 0: if the field reaches bits >= 32 the result is unknown.
-                        bool khi = (in.src[0].kind == OperandKind::SGPR) ? known(in.src[0].value + 1, ahi)
-                                                                         : (ahi = 0, true);
+                        // src0's high dword (RDNA2 ISA 64-bit scalar-operand rules, #155): the next SGPR
+                        // of the pair; SIGN-extension of an integer inline constant (-1..-16 read as a
+                        // 64-bit operand are all-ones in the high dword); or 0 only for a 32-bit literal
+                        // (zero-extended). Inline FLOAT constants read as 64-bit doubles (a different bit
+                        // pattern entirely) — srcval() already leaves those unknown, so they never reach
+                        // here. Only an SGPR operand may index val[value+1] — a literal's `value` is not
+                        // an SGPR number. And an UNTRACKED high dword must not silently fold as 0: if the
+                        // field reaches bits >= 32 the result is unknown.
+                        bool khi;
+                        if (in.src[0].kind == OperandKind::SGPR)           khi = known(in.src[0].value + 1, ahi);
+                        else if (in.src[0].kind == OperandKind::InlineInt) { ahi = in.src[0].value < 0 ? 0xFFFFFFFFu : 0u; khi = true; }
+                        else                                               { ahi = 0; khi = true; }   // 32-bit literal
                         if (!khi && wid != 0 && off + wid > 32) { ok = false; wrote_pair = true; break; }
                         uint64_t src64 = (uint64_t)a | ((uint64_t)ahi << 32);
                         uint64_t res = wid == 0 ? 0 : (wid >= 64 ? (src64 >> off) : ((src64 >> off) & (((uint64_t)1 << wid) - 1)));
@@ -279,6 +280,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     }
     return out;
 }
+
+namespace {
 
 // Give every resource its OWN descriptor binding, starting at `first` (0/1 reserved). The N-buffer model:
 // the shader reads several distinct constant buffers (Unity's per-draw transform, per-frame, …) + vertex

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1,0 +1,79 @@
+// test_dynfetch_fold — unit tests for the wave-uniform scalar const-fold interpreter behind
+// bindless-dynamic vertex-fetch resolution (resolve_dynamic_fetch, gpu_executor.cpp). The fold's
+// s_bfe_u64 must read a 64-bit src0 by the RDNA2 scalar-operand rules (#155): an SGPR pair; a
+// SIGN-extended integer inline constant; a zero-extended 32-bit literal; and an inline FLOAT
+// constant reads as a 64-bit double, which the fold does not model — it must stay UNKNOWN, never
+// fold as a wrong value. A wrong fold flows into the s_cselect tail and the emitted vertex
+// descriptor (a confidently-wrong V#).
+//
+// Observable output: the V# a buffer_load_format_x resolves to. Each kernel builds s[8:11] from
+// tracked values, routing the s_bfe_u64 result into V#.dword3 (desc_v3). All encodings assembled /
+// round-trip verified with llvm-mc -mcpu=gfx1030.
+#include "../src/gpu/gpu_execute.hpp"
+#include <cstdio>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_dynfetch_fold ==\n");
+
+    // Kernel 1: negative INLINE INT src0 sign-extends to 64 bits.
+    //   s_mov_b32 s8, 0x1000 | s_mov_b32 s9, 0 | s_mov_b32 s10, 64
+    //   s_bfe_u64 s[12:13], -1, 0x80028      ; bits [47:40] of 0xFFFF..FF = 0xFF (hi dword all-ones)
+    //   s_mov_b32 s11, s12
+    //   buffer_load_format_x v1, v0, s[8:11], 0 idxen
+    const uint32_t k1[] = {
+        0xBE8803FFu, 0x00001000u,   // s_mov_b32 s8, 0x1000
+        0xBE890380u,                // s_mov_b32 s9, 0
+        0xBE8A03C0u,                // s_mov_b32 s10, 64
+        0x948CFFC1u, 0x00080028u,   // s_bfe_u64 s[12:13], -1, 0x80028 (off=40, wid=8)
+        0xBE8B030Cu,                // s_mov_b32 s11, s12
+        0xE0002000u, 0x80020100u,   // buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<DynFetch> f1 = resolve_dynamic_fetch(k1, sizeof(k1)/sizeof(k1[0]), nullptr, 0, 0);
+    CHECK(f1.size() == 1, "kernel 1 resolves its fetch (all V# dwords known)");
+    CHECK(f1.size() == 1 && f1[0].srsrc == 8, "kernel 1 SRSRC = s8");
+    CHECK(f1.size() == 1 && f1[0].desc_v3 == 0xFFu,
+          "s_bfe_u64 of inline -1 sign-extends: bits[47:40] fold to 0xFF (not 0)");
+
+    // Kernel 2: 32-bit LITERAL src0 zero-extends — a field entirely in the high dword folds to 0.
+    //   s_mov_b32 s14, 0x80020 | s_bfe_u64 s[12:13], 0x12345678, s14   ; bits [39:32] of zext = 0
+    const uint32_t k2[] = {
+        0xBE8803FFu, 0x00001000u,   // s_mov_b32 s8, 0x1000
+        0xBE890380u,                // s_mov_b32 s9, 0
+        0xBE8A03C0u,                // s_mov_b32 s10, 64
+        0xBE8E03FFu, 0x00080020u,   // s_mov_b32 s14, 0x80020 (off=32, wid=8)
+        0x948C0EFFu, 0x12345678u,   // s_bfe_u64 s[12:13], 0x12345678, s14
+        0xBE8B030Cu,                // s_mov_b32 s11, s12
+        0xE0002000u, 0x80020100u,   // buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<DynFetch> f2 = resolve_dynamic_fetch(k2, sizeof(k2)/sizeof(k2[0]), nullptr, 0, 0);
+    CHECK(f2.size() == 1 && f2[0].desc_v3 == 0u,
+          "s_bfe_u64 of a 32-bit literal zero-extends: bits[39:32] fold to 0");
+
+    // Kernel 3: inline FLOAT src0 (1.0) reads as a 64-bit DOUBLE — the fold does not model that
+    // encoding, so the destination must stay UNKNOWN and the fetch must NOT resolve (an unknown V#
+    // dword is dropped, never fabricated).
+    const uint32_t k3[] = {
+        0xBE8803FFu, 0x00001000u,   // s_mov_b32 s8, 0x1000
+        0xBE890380u,                // s_mov_b32 s9, 0
+        0xBE8A03C0u,                // s_mov_b32 s10, 64
+        0x948CFFF2u, 0x00080028u,   // s_bfe_u64 s[12:13], 1.0, 0x80028
+        0xBE8B030Cu,                // s_mov_b32 s11, s12
+        0xE0002000u, 0x80020100u,   // buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<DynFetch> f3 = resolve_dynamic_fetch(k3, sizeof(k3)/sizeof(k3[0]), nullptr, 0, 0);
+    CHECK(f3.empty(), "s_bfe_u64 of an inline FLOAT does not fold (V# dword unknown -> fetch unresolved)");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Per the RDNA2 ISA, a **64-bit scalar operand** reads an integer inline constant **sign-extended** (-1..-16 are all-ones in the high dword) and an inline float constant as a **64-bit double** — only a 32-bit literal is zero-extended. The vertex-fetch const-fold (`resolve_dynamic_fetch`) treated every non-SGPR src0 as hi-dword 0, so an `s_bfe_u64` field reaching bits ≥ 32 of a negative inline constant folded to the wrong value, recorded it as KNOWN, and flowed into the s_cselect tail and the emitted vertex descriptor (a confidently-wrong V#).
- Fix: sign-extend `InlineInt` by its sign; keep hi=0 only for 32-bit literals. Inline **floats** already stay unknown (`srcval` rejects them) — correct, since the fold doesn't model the double encoding; the new test locks that in.
- Exposes `DynFetch` + `resolve_dynamic_fetch` in `gpu_execute.hpp` (previously anonymous-namespace) so the fold's scalar-ALU semantics are unit-testable.

## Verification
- New `test_dynfetch_fold` (no Vulkan needed) drives the three 64-bit operand shapes through a synthetic fetch kernel — encodings **llvm-mc gfx1030 round-trip verified**:
  - inline `-1`: bits[47:40] fold to `0xFF` (sign-extension), observed in the resolved V#
  - 32-bit literal: bits[39:32] fold to 0 (zero-extension)
  - inline float `1.0`: does NOT fold — the fetch stays unresolved (nothing fabricated)
- **Confirmed the new test FAILs on the unfixed logic** (`[FAIL] s_bfe_u64 of inline -1 sign-extends`).
- Full suite in WSL build-linux: **54/54 passed**.

Fixes #155