### PR TITLE
fix(recompiler): verify a forward branch past s_endpgm is a real early-out before clamping

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -954,7 +954,10 @@ struct ForwardIf {
 // per-vertex / per-pixel divergent-if the hardware runs. The 64-lane COMPUTE shell must NOT (its VCC is a
 // wave mask needing a wave-uniform reduce — test_recompile_coverage guards this), so it leaves allow_vcc
 // false and vcc branches fall through to straight-line (which rejects them).
-ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc) {
+// code/dwords: the raw stream, so a branch target past the first s_endpgm can be decoded and
+// verified to be a genuine early-out (see below) instead of blanket-clamped.
+ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
+                            const uint32_t* code, size_t dwords) {
     ForwardIf F; const Rdna2Inst* br = nullptr; int nbranch = 0; uint32_t end_pc = UINT32_MAX;
     for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
     for (const auto& in : ins) {
@@ -973,11 +976,27 @@ ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc) {
     }
     if (nbranch != 1 || !br) return F;
     uint32_t tgt = branch_target(*br);
-    // Early-out: a forward branch to the instruction AFTER s_endpgm skips the rest of the shader. Clamp the
-    // merge to end_pc so the conditional block is [branch_pc+1, end_pc) (the skipped work) and s_endpgm is
-    // emitted normally after the merge — the exact "if (cond) { work } end" early-out shape.
+    // Early-out: a forward branch PAST s_endpgm skips the rest of the shader — but only if execution
+    // at the target immediately terminates. Decode from tgt and require the first non-s_nop
+    // instruction to be s_endpgm (the compiled early-out shape `s_cbranch L; work; s_endpgm;
+    // L: s_endpgm`). Anything else is REAL reachable code (an else-block) that the old blanket clamp
+    // silently discarded — valid SPIR-V, wrong semantics (#129) — so reject instead (the caller's
+    // straight-line fallback also rejects the branch, loudly). When verified, clamp the merge to
+    // end_pc so the conditional block is [branch_pc+1, end_pc) and s_endpgm is emitted after the merge.
     bool early = false;
-    if (tgt > end_pc && tgt != UINT32_MAX) { tgt = end_pc; early = true; }
+    if (tgt > end_pc && tgt != UINT32_MAX) {
+        if (!code || tgt >= dwords) return F;    // target outside the decode window: can't verify
+        std::vector<Rdna2Inst> tail;
+        rdna2_walk(code + tgt, dwords - tgt, tail);
+        bool ends_immediately = false;
+        for (const auto& ti : tail) {
+            if (ti.is_end) { ends_immediately = true; break; }
+            if (ti.fmt == Rdna2Format::SOPP && ti.opcode == 0x00) continue;   // s_nop padding
+            break;                               // real instruction at the target -> not an early-out
+        }
+        if (!ends_immediately) return F;
+        tgt = end_pc; early = true;
+    }
     if (tgt <= br->pc || tgt > end_pc) return F;                     // must be forward, within the stream
     F.found = true; F.branch_pc = br->pc; F.target_pc = tgt; F.early_out = (early || tgt == end_pc);
     F.on_scc0 = (br->opcode == 0x04 || br->opcode == 0x06);         // scc0/vccz: skip block when flag==0
@@ -1948,7 +1967,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
 bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
                bool allow_exec_update, bool allow_smem,
-               const std::function<bool(const Rdna2Inst&)>& exp_fn) {
+               const std::function<bool(const Rdna2Inst&)>& exp_fn,
+               const uint32_t* code = nullptr, size_t dwords = 0) {   // raw stream (forward-if target check)
     const CountedLoop L = detect_counted_loop(ins);
     size_t idx = 0;
     // Cross-lane wave ops (mbcnt) emit LDS + barriers, which are only valid at wave-uniform points — so
@@ -2035,7 +2055,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         }
         // 7. Post-loop body.
         if (!emit_range(L.exit_pc, UINT32_MAX)) return false;
-    } else if (const ForwardIf F = detect_forward_if(ins, /*allow_vcc*/!b.is_compute); F.found) {
+    } else if (const ForwardIf F = detect_forward_if(ins, /*allow_vcc*/!b.is_compute, code, dwords); F.found) {
         // Single structured uniform IF (forward s_cbranch_scc0/scc1): emit as OpSelectionMerge +
         // OpBranchConditional on the SCC bool, with an OpPhi per register written in the conditional
         // block that is live after the merge. Parallels the loop path's phi machinery. CONFIDENCE: MED —
@@ -2096,7 +2116,7 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     for (uint32_t k = 0; k < num_inputs; k++) rs.vreg[(int)k] = b.load_input(k);
     // Compute kernels have no EXP output; reject if one appears.
     if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/true,
-                   [](const Rdna2Inst&){ return false; })) return {};
+                   [](const Rdna2Inst&){ return false; }, code, dwords)) return {};
     auto it = rs.vreg.find((int)out_vgpr);
     uint32_t outbits = it == rs.vreg.end() ? b.uconst(0) : it->second;
     // If EXEC is still narrowed (a v_cmpx with no restore), masked-off lanes keep the output slot's prior
@@ -2119,7 +2139,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     // back-edge + exit, and the forward-if branch) as handled, so coverage matches what actually recompiles
     // (previously the MSAA-resolve loop shaders 031-034 were mis-flagged "blocked" at their s_cbranch_scc0).
     const CountedLoop cL = detect_counted_loop(ins);
-    const ForwardIf   cF = detect_forward_if(ins, /*allow_vcc*/false);   // conservative diagnostic (compute-safe)
+    const ForwardIf   cF = detect_forward_if(ins, /*allow_vcc*/false, code, dwords);   // conservative diagnostic (compute-safe)
     auto cf_reconstructed = [&](const Rdna2Inst& i) {
         if (cL.found && (i.pc == cL.backedge_pc || i.pc == cL.exit_branch_pc)) return true;
         if (cF.found && i.pc == cF.branch_pc) return true;
@@ -2203,7 +2223,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
     // cmpx is now ALLOWED (allow_exec_update=true): a fragment divergent-if (v_cmpx ... s_mov exec,saved)
     // is handled by EXEC predication like compute, and the export is guarded above. Memory ops need a
     // resource table. Loops (if any) are reconstructed by emit_body.
-    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/rt != nullptr, exp_fn)) return {};
+    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) return {};
     if (!exported) return {};
     return b.finish();
 }
@@ -2237,7 +2257,7 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords, cons
         }
         return true;
     };
-    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/false, /*allow_smem*/rt != nullptr, exp_fn)) return {};
+    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/false, /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) return {};
     if (!exported) return {};
     return b.finish();
 }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1249,6 +1249,43 @@ int main() {
     printf("  kernelN(v_nop) mismatches=%u (out[33]=%g expect=%g)\n", badN, gotN.size()==N?gotN[33]:-1, expN[33]);
     CHECK(gotN.size()==N && badN==0, "v_nop is transparent: out = (a0+a1)*a2 computed correctly");
 
+    // Kernels J1/J2/J3: forward-branch targets PAST the first s_endpgm (#129). A branch past
+    // s_endpgm is a benign early-out ONLY if execution at the target immediately terminates
+    // (s_nop* then s_endpgm). Real code at the target (an else-block) used to be silently
+    // discarded by a blanket clamp — valid SPIR-V, wrong semantics; it must now REJECT.
+    // Shape: s0=7; s1=7|8; s_cmp_eq_u32; s_cbranch_scc0 +3 (-> pc7); v0=42.0; s_endpgm; <target...>
+    //   J1: target is s_endpgm            -> accept; SCC=1 runs the block (42), SCC=0 skips (input)
+    //   J2: target is REAL code (v0=9.0)  -> REJECT (was: clamped, taken path silently lost v0=9)
+    //   J3: target is s_nop; s_endpgm     -> accept (nop padding before the end is still an early-out)
+    // Encodings llvm-mc gfx1030 verified.
+    const uint32_t codeJ1t[] = { 0xbe800387u, 0xbe810387u, 0xbf060100u, 0xbf840003u,
+                                 0x7e0002ffu, 0x42280000u, 0xbf810000u, 0xbf810000u };
+    const uint32_t codeJ1f[] = { 0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
+                                 0x7e0002ffu, 0x42280000u, 0xbf810000u, 0xbf810000u };
+    const uint32_t codeJ2[]  = { 0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
+                                 0x7e0002ffu, 0x42280000u, 0xbf810000u,
+                                 0x7e0002ffu, 0x41100000u, 0xbf810000u };
+    const uint32_t codeJ3[]  = { 0xbe800387u, 0xbe810387u, 0xbf060100u, 0xbf840003u,
+                                 0x7e0002ffu, 0x42280000u, 0xbf810000u, 0xbf800000u, 0xbf810000u };
+    std::vector<uint32_t> spvJ1t = recompile_valu(codeJ1t, sizeof(codeJ1t)/sizeof(codeJ1t[0]), 1, 0);
+    std::vector<uint32_t> spvJ1f = recompile_valu(codeJ1f, sizeof(codeJ1f)/sizeof(codeJ1f[0]), 1, 0);
+    std::vector<uint32_t> spvJ2  = recompile_valu(codeJ2,  sizeof(codeJ2)/sizeof(codeJ2[0]),  1, 0);
+    std::vector<uint32_t> spvJ3  = recompile_valu(codeJ3,  sizeof(codeJ3)/sizeof(codeJ3[0]),  1, 0);
+    CHECK(!spvJ1t.empty() && !spvJ1f.empty(), "kernel J1 (early-out branch to a trailing s_endpgm) -> SPIR-V");
+    CHECK(spvJ2.empty(), "kernel J2 (branch past s_endpgm into REAL code) is REJECTED, not clamped");
+    CHECK(!spvJ3.empty(), "kernel J3 (early-out through s_nop padding) -> SPIR-V");
+    std::vector<float> inJ(N);
+    for (uint32_t i = 0; i < N; i++) inJ[i] = (float)i * 0.25f;
+    std::vector<float> gotJt = prosper::test::run_compute(spvJ1t, inJ, N, N);
+    std::vector<float> gotJf = prosper::test::run_compute(spvJ1f, inJ, N, N);
+    uint32_t badJ = 0;
+    for (uint32_t i = 0; i < N && gotJt.size() == N; i++) if (std::fabs(gotJt[i] - 42.0f) > 1e-3f) badJ++;
+    for (uint32_t i = 0; i < N && gotJf.size() == N; i++) if (std::fabs(gotJf[i] - inJ[i]) > 1e-3f) badJ++;
+    printf("  kernelJ mismatches=%u (scc1->%g expect 42, scc0->%g expect %g)\n", badJ,
+           gotJt.size()==N?gotJt[8]:-1, gotJf.size()==N?gotJf[8]:-1, inJ[8]);
+    CHECK(gotJt.size()==N && gotJf.size()==N && badJ==0,
+          "kernel J1 early-out: block runs on SCC=1 (42), skipped on SCC=0 (input)");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- The forward-if clamp treated **any** branch target beyond the first `s_endpgm` as a benign early-out. A branch into real code past `s_endpgm` (an else-block: `cbranch L; work; s_endpgm; L: more; s_endpgm`) had that code **silently discarded** — the module stays valid SPIR-V, so spirv-val cannot catch the wrong semantics.
- `detect_forward_if` now decodes the raw stream at the target and accepts the clamp only when execution there **immediately terminates** (`s_nop` padding then `s_endpgm`). Anything else rejects the shader — the straight-line fallback then rejects the branch loudly (coverage diagnostics show it) instead of miscompiling. `emit_body` threads the raw code through (default-null args keep the signature compatible).

## Verification
- New execution kernels J1/J2/J3 in `test_rdna2_to_spirv` (encodings **llvm-mc gfx1030 verified**):
  - J1 (branch → trailing `s_endpgm`): still recompiles; both SCC paths compute correctly on real Vulkan (taken → input preserved, not-taken → block runs).
  - J2 (branch → **real code** past `s_endpgm`): now **rejected**. **Confirmed J2 FAILs against the old blanket clamp** (stash-revert run).
  - J3 (branch → `s_nop` then `s_endpgm`): still accepted.
- Full suite in WSL build-linux: **53/53 passed** (includes the real-game-shader recompile tests — no regression from the tightened clamp).

Fixes #129