### PR TITLE
fix(recompiler): apply VOP2 SDWA output modifier (omod/clamp) — unblocks PPSA02664 pixel shaders

### DIFF
--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -74,8 +74,12 @@ void decode_operands(Rdna2Inst& i) {
                 // no SEXT(bit19/27) or reserved(bit22/30) — i.e. mask out neg/abs (0x6) from the nibble check.
                 i.src_neg[0] = ((sd >> 20) & 1u) != 0; i.src_abs[0] = ((sd >> 21) & 1u) != 0;
                 i.src_neg[1] = ((sd >> 28) & 1u) != 0; i.src_abs[1] = ((sd >> 29) & 1u) != 0;
+                // Output modifiers CLAMP@13 / OMOD@[15:14] (×2/×4/×0.5) — the recompiler applies these to the
+                // float result (like VOP3), so they no longer force rejection. Only real sub-dword selects
+                // (dst/src != DWORD=6) or SEXT/reserved keep has_modifier. (PPSA02664 PS: v_mul_f32 ×2, #121.)
+                i.clamp = ((sd >> 13) & 1u) != 0; i.omod = (uint8_t)((sd >> 14) & 3u);
                 if (((sd >> 8) & 7u) == 6u && ((sd >> 16) & 7u) == 6u && ((sd >> 24) & 7u) == 6u &&
-                    !((sd >> 13) & 1u) && !((sd >> 14) & 3u) && !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u))
+                    !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u))
                     i.has_modifier = false;
             } else { i.src[0] = decode_src_field(w & 0x1FFu); i.src[1] = vgpr(w >> 9); i.n_src = 2; }
             break;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1410,7 +1410,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else if (in.omod == 3) d = b.fbin(Op_FMul, d, b.uconst(fbits(0.5f)));
                     if (in.clamp) d = b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, d, b.uconst(fbits(1.0f))), b.uconst(fbits(0.0f)));
                     break;
-                default: break;
+                // A non-float-result opcode carrying a modifier (e.g. an INTEGER SDWA op with CLAMP =
+                // integer saturation) is not modeled by the float-domain omod/clamp above, so applying
+                // nothing would SILENTLY drop the saturation and emit a valid-but-wrong shader. Reject
+                // loudly instead — the same fail-visibly-over-miscompile discipline as the forward-if
+                // clamp (#129/#174). The guard means this only fires for a modifier-carrying op.
+                default: ok = false; break;
             }
             if (ok) predicate_write(b, rs, in.dst.value, old_d);
             return true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1400,6 +1400,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x2F: d = b.pack_half2x16(a, c); break;          // v_cvt_pkrtz_f16_f32 (e32 form)
                 default: ok = false;
             }
+            // SDWA output modifier: OMOD scale (×2/×4/×0.5) then CLAMP saturate, on FLOAT-result opcodes
+            // only (int ops never carry omod). Mirrors the VOP3 fresult path; a no-op when omod/clamp unset.
+            if (ok && (in.omod || in.clamp)) switch (in.opcode) {
+                case 0x03: case 0x04: case 0x08: case 0x0F: case 0x10:
+                case 0x1F: case 0x2B: case 0x20: case 0x2C: case 0x21: case 0x2D:
+                    if      (in.omod == 1) d = b.fbin(Op_FMul, d, b.uconst(fbits(2.0f)));
+                    else if (in.omod == 2) d = b.fbin(Op_FMul, d, b.uconst(fbits(4.0f)));
+                    else if (in.omod == 3) d = b.fbin(Op_FMul, d, b.uconst(fbits(0.5f)));
+                    if (in.clamp) d = b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, d, b.uconst(fbits(1.0f))), b.uconst(fbits(0.0f)));
+                    break;
+                default: break;
+            }
             if (ok) predicate_write(b, rs, in.dst.value, old_d);
             return true;
         }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1296,6 +1296,24 @@ int main() {
     CHECK(gotS1.size()==N && badS1==0, "v_cvt_u32_f32 saturates (NaN/neg -> 0, >=2^32 -> UINT_MAX)");
     CHECK(gotS2.size()==N && badS2==0, "v_cvt_i32_f32 saturates (NaN -> 0, clamps to INT_MIN/INT_MAX)");
 
+    // Kernel O: VOP2 v_mul_f32 in SDWA form with OMOD ×2 output modifier. This was a #121 blocker —
+    // PPSA02664's pixel shaders emit `v_mul_f32 v,v,v mul:2` (full-DWORD selects, omod=×2), which the
+    // decoder rejected as an unhandled modifier, failing the whole PS. Now the ×2 is applied.
+    //   w0=0x100002f9 (op 0x08, dst v0, vsrc1 v1, src0=0xF9=SDWA), w1=0x06064600 (dst/s0/s1 sel=DWORD, omod=1)
+    //   => out = (a0 * a1) * 2
+    const uint32_t codeO[] = { 0x100002f9u, 0x06064600u, 0xBF810000u };
+    std::vector<uint32_t> spvO = recompile_valu(codeO, sizeof(codeO)/sizeof(codeO[0]), 2, 0);
+    CHECK(!spvO.empty(), "recompiled v_mul_f32 SDWA omod:2 -> SPIR-V (no longer rejected)");
+    std::vector<float> inO(N * 2), expO(N);
+    for (uint32_t i = 0; i < N; i++) {
+        float a0 = (float)i * 0.1f - 3.0f, a1 = 1.25f;
+        inO[i*2+0] = a0; inO[i*2+1] = a1; expO[i] = (a0 * a1) * 2.0f;
+    }
+    std::vector<float> gotO = prosper::test::run_compute(spvO, inO, N, N);
+    uint32_t badO = 0; for (uint32_t i=0;i<N&&gotO.size()==N;i++) if (std::fabs(gotO[i]-expO[i])>1e-3f) badO++;
+    printf("  kernelO(omod:2) mismatches=%u (out[20]=%g expect=%g)\n", badO, gotO.size()==N?gotO[20]:-1, expO[20]);
+    CHECK(gotO.size()==N && badO==0, "v_mul_f32 SDWA omod:2 doubles the product: out = (a0*a1)*2");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem (part of #121)

After the `v_nop` fix (#124), one recompile failure remained on PPSA02664: a pixel shader failing at `first_bad fmt=6 op=0x8` (VOP2 `v_mul_f32`). Disassembling the dumped shader showed the instructions are the **SDWA** form (`src0=0xF9`) with an **output modifier `omod=×2`** (`mul:2`) — all source/dest selects are full-DWORD, so the *only* thing rejecting them was the modifier. The decoder set `has_modifier=true` → the whole PS failed to recompile → its draw skipped.

## Fix

The recompiler already applies `omod`/`clamp` for the **VOP3** form (`fresult`). This wires the same for **VOP2 SDWA**:
- **decoder** (`rdna2_decode.cpp`): read `CLAMP@13` / `OMOD@[15:14]` from the SDWA control dword; stop treating them as unhandled. Only real sub-dword selects (`sel != DWORD=6`) or `SEXT`/reserved still force rejection.
- **recompiler** (`rdna2_to_spirv.cpp`): apply OMOD (×2/×4/×0.5) then CLAMP to the **float-result** VOP2 opcodes (add/sub/mul/min/max/mac/madmk/madak) — a no-op when unset, never applied to integer ops.

## Result

PPSA02664 now recompiles **all** draws — the executor goes from `skip draw: recompile failed (fs=0)` to `rendering 5 of 5` / `6 of 6` with **zero skips**. The Messenger is unaffected.

- **61/61 ctest green**, including a new execution kernel that runs `v_mul_f32 SDWA omod:2` on Vulkan and asserts `out = (a0*a1)*2`.

## Scope note

This removes the last *recompile* gap for PPSA02664. Frames are still black — that's the separate empty-source-texture / composite issue (the fullscreen composite samples a texture filled by a path we don't execute), tracked under #121. But every draw the game submits now recompiles and rasterizes.

Refs #121