### PR TITLE
fix(gpu): enable robustImageAccess at device creation (storage-image OOB contract)

### DIFF
--- a/prosper/tests/image_compute_runner.h
+++ b/prosper/tests/image_compute_runner.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <vulkan/vulkan.h>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 namespace prosper::test {
@@ -48,16 +49,28 @@ inline std::vector<uint32_t> run_image_copy(const std::vector<uint32_t>& spirv,
     // rather than UB. shaderStorageImageRead/WriteWithoutFormat: the module declares the matching
     // StorageImageReadWithoutFormat / WriteWithoutFormat capabilities (the image views carry no format
     // hint in the shader), so these features must be enabled for the SPIR-V to be accepted.
-    // NOTE on OOB image reads: the recompiler issues OpImageRead for all lanes (inactive lanes' values are
-    // discarded by write-back predication), relying on IMAGE ROBUSTNESS (robustImageAccess) for OOB→0 —
-    // the image analogue of robustBufferAccess. This test dispatches exactly `width` (a multiple of the 64
-    // workgroup) invocations, so NO lane's coordinate is out of range and the feature is not needed here;
-    // a runtime running real shaders on non-multiple image sizes must enable robustImageAccess.
     VkPhysicalDeviceFeatures feats{};
     feats.robustBufferAccess = VK_TRUE;
     feats.shaderStorageImageReadWithoutFormat = VK_TRUE;
     feats.shaderStorageImageWriteWithoutFormat = VK_TRUE;
     dci.pEnabledFeatures = &feats;
+    // robustImageAccess (VK_EXT_image_robustness; core in 1.3): the recompiled storage-image load
+    // path issues OpImageRead for ALL invocations — including EXEC-inactive/grid-tail lanes whose
+    // coordinates can be out of range — relying on OOB image reads returning zero (#131). Enable it
+    // whenever the device offers it (feature-query guarded, so a device without it still creates —
+    // then only exact-multiple dispatches are safe, which the fixed-width tests are).
+    VkPhysicalDeviceImageRobustnessFeaturesEXT irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT};
+    const char* img_robust_ext[] = { "VK_EXT_image_robustness" };
+    { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(phys, nullptr, &ne, nullptr);
+      std::vector<VkExtensionProperties> de(ne);
+      vkEnumerateDeviceExtensionProperties(phys, nullptr, &ne, de.data());
+      for (uint32_t i = 0; i < ne; i++) if (!strcmp(de[i].extensionName, "VK_EXT_image_robustness")) {
+          VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+          f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(phys, &f2);
+          if (irf.robustImageAccess) { dci.pNext = &irf;
+              dci.enabledExtensionCount = 1; dci.ppEnabledExtensionNames = img_robust_ext; }
+          break;
+      } }
     VkDevice dev = VK_NULL_HANDLE;
     if (vkCreateDevice(phys, &dci, nullptr, &dev) != VK_SUCCESS || !dev) { vkDestroyInstance(inst, nullptr); return out; }
     VkQueue queue; vkGetDeviceQueue(dev, qfi, 0, &queue);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -116,6 +116,24 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // robustBufferAccess: out-of-range storage-buffer accesses are well-defined, so a predicated memory
     // op run by an inactive lane (narrowed EXEC) can't fault.
     VkPhysicalDeviceFeatures feats{}; feats.robustBufferAccess = VK_TRUE; dci.pEnabledFeatures = &feats;
+    // robustImageAccess (VK_EXT_image_robustness; core in 1.3): the recompiled storage-image load
+    // path issues OpImageRead for ALL invocations — including EXEC-inactive lanes whose coordinates
+    // can be out of range — relying on OOB image reads returning zero (#131). This is the LIVE
+    // render backend (boot_trace registers render_draws_rgba as the submit renderer), so real game
+    // shaders run here on non-multiple image sizes. Feature-query guarded: a device without it
+    // still creates (visibly logged risk is preferable to failing device creation outright).
+    VkPhysicalDeviceImageRobustnessFeaturesEXT irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT};
+    const char* img_robust_ext[] = { "VK_EXT_image_robustness" };
+    { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(phys, nullptr, &ne, nullptr);
+      std::vector<VkExtensionProperties> de(ne);
+      vkEnumerateDeviceExtensionProperties(phys, nullptr, &ne, de.data());
+      for (uint32_t i = 0; i < ne; i++) if (!strcmp(de[i].extensionName, "VK_EXT_image_robustness")) {
+          VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+          f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(phys, &f2);
+          if (irf.robustImageAccess) { dci.pNext = &irf;
+              dci.enabledExtensionCount = 1; dci.ppEnabledExtensionNames = img_robust_ext; }
+          break;
+      } }
     VkDevice dev = VK_NULL_HANDLE;
     if (vkCreateDevice(phys, &dci, nullptr, &dev) != VK_SUCCESS || !dev) { vkDestroyInstance(inst, nullptr); return out; }
     VkQueue queue; vkGetDeviceQueue(dev, qfi, 0, &queue);

--- a/prosper/tests/test_storage_image_copy.cpp
+++ b/prosper/tests/test_storage_image_copy.cpp
@@ -71,6 +71,25 @@ int main() {
         CHECK(bad == 0, "OpImageRead->OpImageWrite copied every RGBA texel bit-exact (src == dst)");
     }
 
+    // NON-multiple width (#131): 70 texels dispatch ceil(70/64)=2 workgroups = 128 invocations, so
+    // lanes 70..127 read AND write out of the image's range. With robustImageAccess (now enabled by
+    // the runner when the device offers it) OOB reads return zero and OOB writes are discarded —
+    // the copy of the real 70 texels must still be bit-exact and nothing may fault.
+    const uint32_t W2 = 70;
+    std::vector<uint32_t> src2(W2 * 4);
+    for (uint32_t i = 0; i < W2; i++) {
+        src2[i*4+0] = 0x10000000u + i;        src2[i*4+1] = 0x20000000u + i*3u + 1u;
+        src2[i*4+2] = 0x30000000u + i*11u+2u; src2[i*4+3] = 0x40000000u + i*17u + 3u;
+    }
+    std::vector<uint32_t> dst2 = prosper::test::run_image_copy(spv, W2, src2);
+    CHECK(dst2.size() == src2.size(), "non-multiple-width copy ran (OOB tail lanes tolerated)");
+    if (dst2.size() == src2.size()) {
+        uint32_t bad2 = 0;
+        for (uint32_t i = 0; i < W2 * 4; i++) if (dst2[i] != src2[i]) bad2++;
+        printf("  non-multiple width: mismatched components = %u / %u\n", bad2, W2*4);
+        CHECK(bad2 == 0, "70-texel copy bit-exact with a 128-invocation dispatch (grid-tail OOB safe)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- The recompiler's storage-image load path issues `OpImageRead` for **all** invocations — including EXEC-inactive/grid-tail lanes with possibly-OOB coordinates — on the premise that `robustImageAccess` is enabled (OOB reads → 0, OOB writes discarded). Both device-creation sites enabled only `robustBufferAccess`; an OOB storage-image access without the feature is **UB** (device-lost at worst).
- `render_runner.h` is the **live** render backend (boot_trace registers `render_draws_rgba` as the submit renderer), so real game shaders ran under this UB on non-multiple image sizes.
- Fix: chain `VkPhysicalDeviceImageRobustnessFeaturesEXT` into both `vkCreateDevice` calls (`render_runner.h`, `image_compute_runner.h`), guarded by an extension + feature query (`VK_EXT_image_robustness`; core in Vulkan 1.3) so a device without it still creates.
- Not touched: `compute_runner.h` (buffers only, no storage images) and `prosper-app`'s device (present-only blit; also the other workstream's active area).

## Verification
- `test_storage_image_copy` now also runs a **70-texel (non-multiple-of-64)** copy: the 128-invocation dispatch sends lanes 70..127 out of range in both read and write; the real 70 texels copy **bit-exact** and nothing faults.
- Full suite in WSL build-linux: **57/57 passed**.

Fixes #131