### PR TITLE
fix(hle): honor guest mutex types — Sony/FreeBSD ERRORCHECK default, settype mapped, FreeBSD errnos

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -120,6 +120,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)
 
+  # Guest mutex TYPE semantics (#145): settype honored, Sony/FreeBSD ERRORCHECK default (incl.
+  # static-sentinel self-init), FreeBSD errno values (EDEADLK=11). Pure, no game dump needed.
+  add_executable(test_mutex_types tests/test_mutex_types.cpp)
+  target_link_libraries(test_mutex_types PRIVATE prosper_core)
+  add_test(NAME mutex_types COMMAND test_mutex_types)
+
   add_executable(test_agc_shader tests/test_agc_shader.cpp)
   target_link_libraries(test_agc_shader PRIVATE prosper_core)
   add_test(NAME agc_shader_create COMMAND test_agc_shader)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -9,6 +9,7 @@
 #include "nid.hpp"
 #include "../host/exec_image.hpp"
 #include <pthread.h>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -54,7 +55,23 @@ HLE(k_mutexattr_init) {
     *(void**)a0 = at;                     // store handle through caller's slot
     return 0;
 }
-HLE(k_mutexattr_settype)     { return 0; } // type/protocol/pshared ignored for now
+// Sony/FreeBSD mutex types: 1=ERRORCHECK (the FreeBSD/Sony DEFAULT), 2=RECURSIVE, 3=NORMAL,
+// 4=ADAPTIVE_NP (NORMAL semantics + spin). Kyty's PthreadMutexattrSettype uses exactly this
+// mapping and its attr-init defaults to type 1 — PS4-inherited surface, so solid evidence (#145).
+// Previously a no-op, and init forced RECURSIVE: a guest relying on trylock-fails-on-owner or
+// EDEADLK semantics silently got different behavior.
+HLE(k_mutexattr_settype) {
+    if (!a0 || !*(void**)a0) return 0x16;
+    int host;
+    switch ((int)a1) {
+        case 1: host = PTHREAD_MUTEX_ERRORCHECK; break;
+        case 2: host = PTHREAD_MUTEX_RECURSIVE;  break;
+        case 3: case 4: host = PTHREAD_MUTEX_NORMAL; break;
+        default: return 0x16;   // EINVAL
+    }
+    pthread_mutexattr_settype((pthread_mutexattr_t*)*(void**)a0, host);
+    return 0;
+}
 HLE(k_mutexattr_setprotocol) { return 0; }
 HLE(k_mutexattr_setpshared)  { return 0; }
 HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
@@ -80,7 +97,11 @@ namespace {
         if (!pt_static_sentinel(cur)) return (pthread_mutex_t*)cur;
         auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
         pthread_mutexattr_t at; pthread_mutexattr_init(&at);
-        pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE);
+        // The FreeBSD static sentinel ENCODES the type: NULL = PTHREAD_MUTEX_INITIALIZER (the
+        // DEFAULT type, which is ERRORCHECK on FreeBSD), 1 = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
+        // (NORMAL semantics + spin). Previously every sentinel self-init forced RECURSIVE (#145).
+        pthread_mutexattr_settype(&at, (uintptr_t)cur == 1 ? PTHREAD_MUTEX_NORMAL
+                                                           : PTHREAD_MUTEX_ERRORCHECK);
         pthread_mutex_init(m, &at);
         pthread_mutexattr_destroy(&at);
         if (__atomic_compare_exchange_n(slot, &cur, (void*)m, false,
@@ -116,21 +137,32 @@ namespace {
         return (pthread_rwlock_t*)cur;
     }
 }
+// scePthreadMutexInit(mutex_slot, attr_slot, name) / pthread_mutex_init(mutex_slot, attr_slot):
+// honor the caller's attr (type set via k_mutexattr_settype); no attr means Sony's default,
+// ERRORCHECK — FreeBSD PTHREAD_MUTEX_DEFAULT, and what Kyty's attr-init settype(1) produces (#145).
 HLE(k_mutex_init) {
     if (!a0) return 0x16;
     auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
-    // Default to recursive: game code often locks re-entrantly and Sony's default differs.
-    pthread_mutexattr_t at; pthread_mutexattr_init(&at);
-    pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE);
-    pthread_mutex_init(m, &at);
-    pthread_mutexattr_destroy(&at);
+    pthread_mutexattr_t* at = (a1 && !pt_static_sentinel(*(void**)a1)) ? (pthread_mutexattr_t*)*(void**)a1 : nullptr;
+    pthread_mutexattr_t def;
+    if (!at) { pthread_mutexattr_init(&def); pthread_mutexattr_settype(&def, PTHREAD_MUTEX_ERRORCHECK); at = &def; }
+    pthread_mutex_init(m, at);
+    if (at == &def) pthread_mutexattr_destroy(&def);
     *(void**)a0 = m;
     return 0;
 }
+// The guest sees FreeBSD errno values; EBUSY(16)/EPERM(1)/EINVAL(22) coincide with Linux but
+// EDEADLK differs (FreeBSD 11, Linux 35) — an ERRORCHECK relock must report the FreeBSD value.
+namespace { inline uint64_t fbsd_errno(int host) {
+#ifdef __linux__
+    if (host == EDEADLK) return 11;
+#endif
+    return (uint64_t)(unsigned)host;
+} }
 HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
-HLE(k_mutex_lock)    { if (auto* m = ensure_mutex(a0)) pthread_mutex_lock(m); return 0; }
-HLE(k_mutex_trylock) { auto* m = ensure_mutex(a0); return m ? (uint64_t)pthread_mutex_trylock(m) : 0x16; }
-HLE(k_mutex_unlock)  { if (auto* m = ensure_mutex(a0)) pthread_mutex_unlock(m); return 0; }
+HLE(k_mutex_lock)    { auto* m = ensure_mutex(a0); return m ? fbsd_errno(pthread_mutex_lock(m))    : 0x16; }
+HLE(k_mutex_trylock) { auto* m = ensure_mutex(a0); return m ? fbsd_errno(pthread_mutex_trylock(m)) : 0x16; }
+HLE(k_mutex_unlock)  { auto* m = ensure_mutex(a0); return m ? fbsd_errno(pthread_mutex_unlock(m))  : 0x16; }
 
 // --- condition variables ---
 HLE(k_condattr_init)    { if (a0) { auto* c = (pthread_condattr_t*)calloc(1, sizeof(pthread_condattr_t)); pthread_condattr_init(c); *(void**)a0 = c; } return 0; }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -151,12 +151,13 @@ HLE(k_mutex_init) {
     *(void**)a0 = m;
     return 0;
 }
-// The guest sees FreeBSD errno values; EBUSY(16)/EPERM(1)/EINVAL(22) coincide with Linux but
-// EDEADLK differs (FreeBSD 11, Linux 35) — an ERRORCHECK relock must report the FreeBSD value.
+// The guest sees FreeBSD errno values; EBUSY(16)/EPERM(1)/EINVAL(22) coincide with both Linux and
+// MinGW, but EDEADLK differs on every host (FreeBSD 11, Linux 35, MinGW/winpthreads 36) — an
+// ERRORCHECK relock must report the FreeBSD value. `EDEADLK` is the HOST's own constant, so the
+// comparison remaps whatever the host returns on ALL platforms (the Windows CI build hit exactly
+// this: winpthreads returned its EDEADLK=36 and the old __linux__-only guard left it unremapped).
 namespace { inline uint64_t fbsd_errno(int host) {
-#ifdef __linux__
     if (host == EDEADLK) return 11;
-#endif
     return (uint64_t)(unsigned)host;
 } }
 HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }

--- a/prosper/tests/test_mutex_types.cpp
+++ b/prosper/tests/test_mutex_types.cpp
@@ -1,0 +1,88 @@
+// test_mutex_types — guest mutexes must honor their TYPE (#145). Sony/FreeBSD semantics:
+// attr type 1=ERRORCHECK (the DEFAULT — FreeBSD PTHREAD_MUTEX_DEFAULT; Kyty's attr-init
+// settype(1)), 2=RECURSIVE, 3/4=NORMAL/ADAPTIVE. Previously settype was a no-op and every
+// mutex (incl. static-sentinel self-inits) was forced RECURSIVE: trylock-on-owned SUCCEEDED
+// and relock never reported EDEADLK, silently diverging from the console. Guest-visible
+// errnos are FreeBSD values (EBUSY=16, EDEADLK=11 — NOT Linux's 35).
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_mutex_types ==\n");
+    register_builtin_hle();
+    auto attr_init    = Hle::lookup(nid_hash("scePthreadMutexattrInit"));
+    auto attr_settype = Hle::lookup(nid_hash("scePthreadMutexattrSettype"));
+    auto attr_destroy = Hle::lookup(nid_hash("scePthreadMutexattrDestroy"));
+    auto m_init    = Hle::lookup(nid_hash("scePthreadMutexInit"));
+    auto m_lock    = Hle::lookup(nid_hash("scePthreadMutexLock"));
+    auto m_trylock = Hle::lookup(nid_hash("scePthreadMutexTrylock"));
+    auto m_unlock  = Hle::lookup(nid_hash("scePthreadMutexUnlock"));
+    auto m_destroy = Hle::lookup(nid_hash("scePthreadMutexDestroy"));
+    CHECK(attr_init && attr_settype && attr_destroy && m_init && m_lock && m_trylock && m_unlock && m_destroy,
+          "mutex HLE functions registered");
+    if (fails) { printf("== FAIL ==\n"); return 1; }
+
+    auto U = [](void* p) { return (uint64_t)(uintptr_t)p; };
+
+    // 1. DEFAULT (no attr) = ERRORCHECK: trylock-on-owned fails EBUSY(16); relock reports
+    //    EDEADLK as the FreeBSD value 11 (not Linux 35); unlock releases.
+    void* mtx = nullptr;
+    CHECK(m_init(U(&mtx), 0, 0, 0, 0, 0) == 0 && mtx, "default init creates a mutex");
+    CHECK(m_lock(U(&mtx), 0, 0, 0, 0, 0) == 0, "default: first lock succeeds");
+    CHECK(m_trylock(U(&mtx), 0, 0, 0, 0, 0) == 16, "default: trylock on owned fails EBUSY(16)");
+    CHECK(m_lock(U(&mtx), 0, 0, 0, 0, 0) == 11, "default: relock reports FreeBSD EDEADLK(11)");
+    CHECK(m_unlock(U(&mtx), 0, 0, 0, 0, 0) == 0, "default: unlock succeeds");
+    CHECK(m_trylock(U(&mtx), 0, 0, 0, 0, 0) == 0 && m_unlock(U(&mtx), 0, 0, 0, 0, 0) == 0,
+          "default: trylock after unlock succeeds");
+    m_destroy(U(&mtx), 0, 0, 0, 0, 0);
+
+    // 2. Type 2 = RECURSIVE (settype honored): relock succeeds; needs two unlocks.
+    void* attr = nullptr; void* rmtx = nullptr;
+    CHECK(attr_init(U(&attr), 0, 0, 0, 0, 0) == 0 && attr, "attr init");
+    CHECK(attr_settype(U(&attr), 2, 0, 0, 0, 0) == 0, "settype(2 RECURSIVE) accepted");
+    CHECK(m_init(U(&rmtx), U(&attr), 0, 0, 0, 0) == 0, "recursive init");
+    CHECK(m_lock(U(&rmtx), 0, 0, 0, 0, 0) == 0 && m_lock(U(&rmtx), 0, 0, 0, 0, 0) == 0,
+          "recursive: relock on owner succeeds");
+    CHECK(m_trylock(U(&rmtx), 0, 0, 0, 0, 0) == 0, "recursive: trylock on owner succeeds");
+    CHECK(m_unlock(U(&rmtx), 0, 0, 0, 0, 0) == 0 && m_unlock(U(&rmtx), 0, 0, 0, 0, 0) == 0 &&
+          m_unlock(U(&rmtx), 0, 0, 0, 0, 0) == 0, "recursive: three unlocks release the three locks");
+    m_destroy(U(&rmtx), 0, 0, 0, 0, 0);
+    attr_destroy(U(&attr), 0, 0, 0, 0, 0);
+
+    // 3. Type 3 = NORMAL: trylock-on-owned fails EBUSY.
+    void* nattr = nullptr; void* nmtx = nullptr;
+    attr_init(U(&nattr), 0, 0, 0, 0, 0);
+    CHECK(attr_settype(U(&nattr), 3, 0, 0, 0, 0) == 0, "settype(3 NORMAL) accepted");
+    m_init(U(&nmtx), U(&nattr), 0, 0, 0, 0);
+    CHECK(m_lock(U(&nmtx), 0, 0, 0, 0, 0) == 0, "normal: lock");
+    CHECK(m_trylock(U(&nmtx), 0, 0, 0, 0, 0) == 16, "normal: trylock on owned fails EBUSY(16)");
+    CHECK(m_unlock(U(&nmtx), 0, 0, 0, 0, 0) == 0, "normal: unlock");
+    m_destroy(U(&nmtx), 0, 0, 0, 0, 0);
+    attr_destroy(U(&nattr), 0, 0, 0, 0, 0);
+
+    // 4. Invalid type rejected.
+    void* battr = nullptr;
+    attr_init(U(&battr), 0, 0, 0, 0, 0);
+    CHECK(attr_settype(U(&battr), 99, 0, 0, 0, 0) == 0x16, "settype(99) rejected EINVAL(22)");
+    attr_destroy(U(&battr), 0, 0, 0, 0, 0);
+
+    // 5. STATIC SENTINEL self-init (PTHREAD_MUTEX_INITIALIZER == NULL) = DEFAULT = ERRORCHECK:
+    //    this is the bdwgc GC_allocate_ml shape — trylock on an owned static lock MUST fail
+    //    (before this fix the self-init forced RECURSIVE and trylock succeeded on the owner).
+    void* smtx = nullptr;   // NULL sentinel; first use self-initializes
+    CHECK(m_lock(U(&smtx), 0, 0, 0, 0, 0) == 0 && smtx, "static sentinel self-initializes on lock");
+    CHECK(m_trylock(U(&smtx), 0, 0, 0, 0, 0) == 16, "static default: trylock on owned fails EBUSY(16)");
+    CHECK(m_unlock(U(&smtx), 0, 0, 0, 0, 0) == 0, "static default: unlock");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- `scePthreadMutexattrSettype` was a **no-op** and every mutex init (including the static-sentinel self-init) forced `PTHREAD_MUTEX_RECURSIVE`. A guest relying on non-recursive semantics (trylock-fails-on-owner, EDEADLK on relock) silently got different behavior than the console.
- `settype` now maps the Sony/FreeBSD constants 1=ERRORCHECK, 2=RECURSIVE, 3/4=NORMAL/ADAPTIVE — exactly Kyty's `PthreadMutexattrSettype` (PS4-inherited surface → solid evidence); invalid types return EINVAL.
- Mutex init honors the caller's attr; **no attr = Sony's default, ERRORCHECK** (FreeBSD `PTHREAD_MUTEX_DEFAULT`; Kyty's attr-init does `settype(1)`).
- Static sentinels decode their type: NULL initializer → default (ERRORCHECK); sentinel 1 (`PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP`) → NORMAL.
- lock/trylock/unlock now **return their real result** (previously swallowed → an ERRORCHECK relock would have silently not held the lock), with EDEADLK mapped to the FreeBSD value **11** (Linux is 35); EBUSY/EPERM/EINVAL coincide.

## Verification
- New `test_mutex_types`: all four types + the static-sentinel shape (the bdwgc `GC_allocate_ml` case from the level1 heap-corruption fix) + FreeBSD errno values + invalid-type rejection.
- **Behavioral-risk check (per the issue):** full suite **63/63 passed including the dump-backed boot tests** (`-DGAME_DUMP` wired in this worktree) — the title still boots with ERRORCHECK defaults.

Fixes #145