### PR TITLE
fix(recompiler): special ALU operands — track VCC/ttmp scalar scratch, reject unrepresentable reads

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1075,14 +1075,34 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
 }
 
 // Resolve an operand to its raw 32-bit value (bits). Float ops bitcast these to float.
-uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const Operand& o) {
+// `ok`: cleared when the operand's VALUE is not representable — a Special operand read as ALU DATA
+// (VCC/EXEC live as per-lane bools in rs.vcc/rs.exec; their 32-bit wave-mask value does not exist
+// in the per-invocation model, and M0/SCC/ttmp aren't modeled at all). Only SGPR_NULL (field 125)
+// has a defined value, 0. Previously every Special silently read as 0 and the shader computed
+// garbage (#134); now it rejects, matching the SDWA/DPP reject-rather-than-miscompute discipline.
+uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const Operand& o, bool* ok = nullptr) {
     switch (o.kind) {
         case OperandKind::VGPR: { auto it = rs.vreg.find(o.value); return it == rs.vreg.end() ? b.uconst(0) : it->second; }
         case OperandKind::SGPR: { auto it = rs.sreg.find(o.value); return it == rs.sreg.end() ? b.uconst(0) : it->second; }
         case OperandKind::InlineInt:   return b.uconst((uint32_t)o.value);
         case OperandKind::InlineFloat: return b.uconst(fbits(inline_float_value((uint32_t)o.value)));
         case OperandKind::Literal:     return b.uconst(in.literal);
-        default: return b.uconst(0);
+        case OperandKind::Special:
+            if (o.value == 125) return b.uconst(0);   // SGPR_NULL: the one Special whose data value IS 0
+            // VCC_LO/HI (106/107) and ttmp0..15 (108..123) double as plain scalar SCRATCH in compiled
+            // code — the NGG preamble does `s_bfe_u32 vcc_lo, s3, ...` then reads vcc back as data.
+            // A scalar write lands in rs.sreg[o.value] (the DST field decodes as SGPR); read it back
+            // from there. Only an UNTRACKED read (a VOPC-produced mask, EXEC, M0, SCC) has no
+            // representable per-invocation data value.
+            if (o.value >= 106 && o.value <= 123) {
+                auto it = rs.sreg.find(o.value);
+                if (it != rs.sreg.end()) return it->second;
+            }
+            if (ok) *ok = false;
+            return b.uconst(0);
+        default:
+            if (ok) *ok = false;
+            return b.uconst(0);
     }
 }
 
@@ -1093,7 +1113,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
               const std::unordered_set<uint32_t>* safe_execz = nullptr, bool allow_smem = false,
               const ShaderResourceTable* rt = nullptr, bool allow_wave = false) {
     auto& vreg = rs.vreg; uint32_t& vcc = rs.vcc;
-    auto val = [&](const Operand& o) { return operand_bits(b, rs, in, o); };
+    auto val = [&](const Operand& o) { return operand_bits(b, rs, in, o, &ok); };
     // SDWA/DPP forms carry a sub-dword select or cross-lane control word we don't model. The decoder
     // flags them (and gets their length right); reject here rather than compute with a wrong operand.
     if (in.has_modifier) { ok = false; return true; }
@@ -2239,16 +2259,18 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
         // was never narrowed this is a no-op — the common sRGB/tonemap restore-then-export path.)
         if (rs.exec_narrowed) { b.discard_unless(rs.exec); rs.exec = b.btrue(); rs.exec_narrowed = false; }
         if (in.exp_target <= 7 && !exported) {
+            bool eok = true;   // a Special (wave-mask) source has no data value — reject, don't export 0 (#134)
             if (in.exp_compr) {
                 // COMPR: the 4 channels are two f16x2 pairs — src[0] holds (r,g), src[1] holds (b,a).
                 // Unpack each half to a float and reassemble the vec4 (the pkrtz'd tonemap/sRGB output).
-                uint32_t p0 = operand_bits(b, rs, in, in.src[0]), p1 = operand_bits(b, rs, in, in.src[1]);
+                uint32_t p0 = operand_bits(b, rs, in, in.src[0], &eok), p1 = operand_bits(b, rs, in, in.src[1], &eok);
                 b.export_color(b.unpack_half(p0, 0), b.unpack_half(p0, 1),
                                b.unpack_half(p1, 0), b.unpack_half(p1, 1));
             } else {
-                b.export_color(operand_bits(b, rs, in, in.src[0]), operand_bits(b, rs, in, in.src[1]),
-                               operand_bits(b, rs, in, in.src[2]), operand_bits(b, rs, in, in.src[3]));
+                b.export_color(operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
+                               operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
             }
+            if (!eok) return false;
             exported = true;
         }
         return true;   // ignore NULL / additional exports for now
@@ -2280,15 +2302,16 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords, cons
     if (ngg) rs.vreg[5] = vidx;              // NGG VS ABI: v5 = vertex index
     bool exported = false;
     auto exp_fn = [&](const Rdna2Inst& in) -> bool {         // EXP POS0..3 -> gl_Position; PARAM -> varyings
+        bool eok = true;   // a Special (wave-mask) source has no data value — reject, don't export 0 (#134)
         if (in.exp_target >= 12 && in.exp_target <= 15 && !exported) {
-            b.export_position(operand_bits(b, rs, in, in.src[0]), operand_bits(b, rs, in, in.src[1]),
-                              operand_bits(b, rs, in, in.src[2]), operand_bits(b, rs, in, in.src[3]));
+            b.export_position(operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
+                              operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
             exported = true;
         } else if (in.exp_target >= 32) {                    // PARAM0.. -> Output varying (location N)
-            b.export_param(in.exp_target - 32, operand_bits(b, rs, in, in.src[0]), operand_bits(b, rs, in, in.src[1]),
-                           operand_bits(b, rs, in, in.src[2]), operand_bits(b, rs, in, in.src[3]));
+            b.export_param(in.exp_target - 32, operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
+                           operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
         }
-        return true;
+        return eok;
     };
     if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/false, /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) return {};
     if (!exported) return {};

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1333,6 +1333,41 @@ int main() {
     CHECK(gotS1.size()==N && badS1==0, "v_cvt_u32_f32 saturates (NaN/neg -> 0, >=2^32 -> UINT_MAX)");
     CHECK(gotS2.size()==N && badS2==0, "v_cvt_i32_f32 saturates (NaN -> 0, clamps to INT_MIN/INT_MAX)");
 
+    // Kernels X1..X3: SPECIAL operands read as ALU DATA (#134). VCC/EXEC live as per-lane bools in
+    // the per-invocation model (their 32-bit wave-mask value doesn't exist) and M0 isn't modeled —
+    // such reads previously computed with a silent 0; they must now REJECT. SGPR_NULL (field 125)
+    // is the one Special whose data value IS 0, and must keep recompiling. llvm-mc gfx1030 verified.
+    const uint32_t codeX1[] = { 0x4A02007Eu, 0xBF810000u };   // v_add_nc_u32 v1, exec_lo, v0
+    const uint32_t codeX2[] = { 0x4A02007Cu, 0xBF810000u };   // v_add_nc_u32 v1, m0, v0
+    const uint32_t codeX3[] = { 0x4A02007Du, 0xBF810000u };   // v_add_nc_u32 v1, null, v0
+    CHECK(recompile_valu(codeX1, 2, 1, 1).empty(), "kernel X1 (exec_lo read as ALU data) is REJECTED");
+    CHECK(recompile_valu(codeX2, 2, 1, 1).empty(), "kernel X2 (m0 read as ALU data) is REJECTED");
+    std::vector<uint32_t> spvX3 = recompile_valu(codeX3, 2, 1, /*out_vgpr*/1);
+    CHECK(!spvX3.empty(), "kernel X3 (null read as ALU data) still recompiles (null == 0)");
+    std::vector<float> inX(N);
+    for (uint32_t i = 0; i < N; i++) inX[i] = (float)i;
+    std::vector<float> gotX3 = prosper::test::run_compute(spvX3, inX, N, N);
+    uint32_t badX = 0;
+    for (uint32_t i = 0; i < N && gotX3.size() == N; i++) if (gotX3[i] != inX[i]) badX++;
+    printf("  kernelX3(null+v0) mismatches=%u (out[9]=%g expect %g)\n", badX,
+           gotX3.size()==N?gotX3[9]:-1, inX[9]);
+    CHECK(gotX3.size()==N && badX==0, "kernel X3 computes null(0) + a0 = a0");
+
+    // Kernel X4: VCC as plain scalar SCRATCH (the NGG-preamble pattern: a scalar write to vcc_lo
+    // then a data read of it). s_mov_b32 vcc_lo, 5 ; v_add_nc_u32 v1, vcc_lo, v0 => out = a0 + 5.
+    // The tracked write must be read back (not 0, not rejected).
+    const uint32_t codeX4[] = { 0xBEEA0385u, 0x4A02006Au, 0xBF810000u };
+    std::vector<uint32_t> spvX4 = recompile_valu(codeX4, 3, 1, /*out_vgpr*/1);
+    CHECK(!spvX4.empty(), "kernel X4 (scalar-written vcc_lo read as data) recompiles");
+    std::vector<float> gotX4 = prosper::test::run_compute(spvX4, inX, N, N);
+    uint32_t badX4 = 0;   // integer add on raw VGPR bits: out bits = bits(a0) + 5
+    for (uint32_t i = 0; i < N && gotX4.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotX4[i], 4);
+        if (gb != bits_of(inX[i]) + 5u) badX4++;
+    }
+    printf("  kernelX4(vcc scratch) mismatches=%u\n", badX4);
+    CHECK(gotX4.size()==N && badX4==0, "kernel X4 computes bits(a0) + vcc_lo(5) via the tracked scalar write");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- `operand_bits` returned a silent `uconst(0)` for every **Special** operand (VCC/EXEC/M0/SCC/ttmp read as ALU data), contradicting the reject-rather-than-miscompute discipline used for SDWA/DPP — a shader reading a wave mask as data recompiled and computed with 0 (#134).
- `SGPR_NULL` (field 125) keeps its defined value 0.
- **VCC_LO/HI + ttmp0..15 (fields 106..123) double as plain scalar scratch** in compiled code — the NGG preamble does `s_bfe_u32 vcc_lo, s3, ...` then reads vcc back as data (scalar writes land in `rs.sreg` since the DST field decodes as SGPR-kind). Reads now return the **tracked write** — real data flow where the old code substituted 0.
- Any untracked Special read (VOPC-produced mask, EXEC, M0, SCC) **rejects** the shader; EXP sources reject the same way (fragment + vertex shells).

## Verification
- New execution kernels (**llvm-mc gfx1030 verified**): `exec_lo`/`m0`-as-data → REJECTED; `null`-as-data → recompiles, computes 0; the vcc-scratch NGG pattern (`s_mov_b32 vcc_lo, 5; v_add_nc_u32 v1, vcc_lo, v0`) → computes the tracked value bit-exact on real Vulkan.
- The existing NGG vertex-shader render test **caught my first draft over-rejecting** (it uses vcc as scratch) — the tracked-scratch routing fixed it; geometry re-verified green.
- Full suite in WSL build-linux **including dump-backed boot tests: 62/62 passed**.

Fixes #134