### PR TITLE
fix(hle): sceKernelDlsym honors its module handle via per-module export tables

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -120,6 +120,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)
 
+  # sceKernelDlsym honors its module handle (#147): per-module export tables, real handles from
+  # LoadStartModule for linked-module paths, global first-wins fallback. Pure, no game dump needed.
+  add_executable(test_dlsym_handle tests/test_dlsym_handle.cpp)
+  target_link_libraries(test_dlsym_handle PRIVATE prosper_core)
+  add_test(NAME dlsym_handle COMMAND test_dlsym_handle)
+
   add_executable(test_agc_shader tests/test_agc_shader.cpp)
   target_link_libraries(test_agc_shader PRIVATE prosper_core)
   add_test(NAME agc_shader_create COMMAND test_agc_shader)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -120,6 +120,16 @@ void set_unwind_modules(const UnwindModuleDesc* descs, size_t count);
 // returns the matching export address (e.g. into the loaded PSN.prx). Pointer must outlive the run.
 void set_module_exports(const std::unordered_map<std::string, uint64_t>* exports);
 
+// Per-module export registration (#147): one entry per linked module — its load path and its OWN
+// NID -> address table (Program::mod_exports). sceKernelLoadStartModule hands out a REAL handle
+// when the requested path names one of these (basename match), and sceKernelDlsym consults the
+// handle's module before the global first-definition-wins table. Table pointers must outlive the run.
+struct ModuleExportTable { std::string path; const std::unordered_map<std::string, uint64_t>* nids; };
+void set_module_export_tables(std::vector<ModuleExportTable> tables);
+// Handle for a guest load path naming a registered module (basename match), or 0 if unknown —
+// the caller (k_load_start_mod) then falls back to its synthetic success handle.
+uint64_t module_handle_for_path(const char* path);
+
 // Guest address of the main module's SCE_PROCPARAM segment. sceKernelGetProcParam returns this;
 // real libc reads its heap/malloc config (sceLibcParam) from it, so a correct value is required for
 // real libc.prx's heap to initialize. Set from the eboot's PT_SCE_PROCPARAM segment after mapping.

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -746,16 +746,49 @@ HLE(k_is_stack) {   // sceKernelIsStack(void* addr): is addr within the current 
 }
 // Global export table (NID -> guest addr) registered by the loader, so dlsym can resolve
 // exported symbols by name against loaded modules (e.g. PSN.prx's plugin/init exports).
-namespace { const std::unordered_map<std::string, uint64_t>* g_exports = nullptr; }
+namespace {
+    const std::unordered_map<std::string, uint64_t>* g_exports = nullptr;
+    std::vector<ModuleExportTable> g_mod_exports;   // per-module tables (#147)
+    // Real module handles occupy 0x10000+index — far above the synthetic success counter
+    // (k_load_start_mod's g_module_handle, which starts at 1), so the ranges can't collide.
+    constexpr uint64_t kModuleHandleBase = 0x10000;
+    const char* path_basename(const char* p) {
+        const char* b = p;
+        for (const char* c = p; *c; c++) if (*c == '/' || *c == '\\') b = c + 1;
+        return b;
+    }
+}
 void set_module_exports(const std::unordered_map<std::string, uint64_t>* exports) { g_exports = exports; }
+void set_module_export_tables(std::vector<ModuleExportTable> tables) { g_mod_exports = std::move(tables); }
+uint64_t module_handle_for_path(const char* path) {
+    if (!path || !*path) return 0;
+    const char* want = path_basename(path);
+    for (size_t i = 0; i < g_mod_exports.size(); i++)
+        if (strcmp(path_basename(g_mod_exports[i].path.c_str()), want) == 0)
+            return kModuleHandleBase + i;
+    return 0;
+}
 
 HLE(k_dlsym) {   // sceKernelDlsym(SceKernelModule handle, const char* name, void** funcAddr)
-    // Resolve the requested symbol by name against the linked program's global export table
-    // (Unity's native-plugin loader dlsym's UnityPluginLoad / PSN_PrxInitialize by name). We hash
-    // the name to its Sony NID (nid_hash) and look it up among all loaded modules' exports; a hit
-    // is written through *funcAddr and reported as success. This is what makes the native PSN.prx
-    // plugin's exports reachable so the managed PSN bootstrap + worker pool start.
+    // Resolve the requested symbol by name against the HANDLE'S module first (#147) — a real
+    // handle from k_load_start_mod names one linked module, and two modules exporting the same
+    // NID must not alias to the global table's first definition — then fall back to the global
+    // export table (Unity's native-plugin loader dlsym's UnityPluginLoad / PSN_PrxInitialize by
+    // name; synthetic handles for unknown paths land here). We hash the name to its Sony NID
+    // (nid_hash); a hit is written through *funcAddr and reported as success.
     const char* name = a1 ? (const char*)(uintptr_t)a1 : nullptr;
+    if (name && a0 >= kModuleHandleBase && a0 - kModuleHandleBase < g_mod_exports.size()) {
+        if (const auto* nids = g_mod_exports[a0 - kModuleHandleBase].nids) {
+            auto it = nids->find(nid_hash(name));
+            if (it != nids->end()) {
+                if (a2) *(uint64_t*)(uintptr_t)a2 = it->second;
+                if (getenv("PROSPER_SYNCLOG"))
+                    fprintf(stderr, "[dlsym] '%s' (module handle 0x%llx) -> 0x%llx\n",
+                            name, (unsigned long long)a0, (unsigned long long)it->second);
+                return 0;
+            }
+        }
+    }
     if (name && g_exports) {
         auto it = g_exports->find(nid_hash(name));
         if (it != g_exports->end()) {

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -231,7 +231,14 @@ HLE(k_nanosleep){ if (a0) nanosleep((const struct timespec*)P(a0), a1 ? (struct 
 
 // --- assorted libkernel stubs ---
 HLE(k_ok)              { return 0; }                       // generic success no-op
-HLE(k_load_start_mod)  { return g_module_handle++; }       // return a positive module id
+// sceKernelLoadStartModule(path, ...): the PRX are pre-linked into our address space, so
+// "loading" resolves the path to its linked module and returns a REAL handle — dlsym then
+// consults that module's own exports first (#147). An unknown path still gets the synthetic
+// success counter (that behavior is #146's scope) so optional plugins don't fail the boot.
+HLE(k_load_start_mod)  {
+    if (uint64_t h = module_handle_for_path(a0 ? (const char*)P(a0) : nullptr)) return h;
+    return g_module_handle++;
+}
 
 // _exit(status): terminate the process. Previously an unimplemented stub RETURNED 0, so libc's
 // exit path fell through into its deliberate ud2 (SIGILL) — terminate for real, loudly.

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -42,9 +42,13 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
     for (size_t i = 0; i < out.mods.size(); i++) {
         const Module& m = *out.mods[i];
         uint64_t base = out.imgs[i].base;
+        Program::ModuleExports me; me.path = m.path;
         for (auto& s : m.symbols)
-            if (!s.is_import && !s.nid.empty() && s.value != 0)
+            if (!s.is_import && !s.nid.empty() && s.value != 0) {
                 exports.emplace(s.nid, base + s.value);
+                me.nids.emplace(s.nid, base + s.value);   // per-module view for handle-first dlsym (#147)
+            }
+        out.mod_exports.push_back(std::move(me));
     }
 
     // --- Pass 2: resolve every import. Cross-module export beats a stub slot. ---

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -34,6 +34,12 @@ struct Program {
     // the native PSN.prx plugin's PSN_PrxInitialize / UnityPluginLoad exports for Unity's plugin loader.
     std::unordered_map<std::string, uint64_t> exports;
 
+    // Per-module export tables (parallel to mods): the module's load path + its own NID -> guest
+    // address map. sceKernelDlsym resolves against the HANDLE'S module first (#147) — with only the
+    // global first-definition-wins table, two modules exporting the same NID alias to the first.
+    struct ModuleExports { std::string path; std::unordered_map<std::string, uint64_t> nids; };
+    std::vector<ModuleExports> mod_exports;
+
     // Stats for reporting.
     size_t total_imports = 0, resolved_cross_module = 0, stubbed = 0;
 };

--- a/prosper/tests/test_dlsym_handle.cpp
+++ b/prosper/tests/test_dlsym_handle.cpp
@@ -1,0 +1,71 @@
+// test_dlsym_handle — sceKernelDlsym must honor its MODULE HANDLE (#147). Two modules exporting
+// the same NID: a lookup against the second module's handle must return the SECOND's address —
+// the old global first-definition-wins table aliased it to the first (wrong plugin initialized).
+// LoadStartModule resolves a linked-module path (basename match) to a real handle; unknown paths
+// keep the synthetic success counter (#146's scope), which falls back to the global table.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <unordered_map>
+#include <string>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_dlsym_handle ==\n");
+    register_builtin_hle();
+    auto load  = Hle::lookup(nid_hash("sceKernelLoadStartModule"));
+    auto dlsym = Hle::lookup(nid_hash("sceKernelDlsym"));
+    CHECK(load && dlsym, "LoadStartModule + Dlsym registered");
+    if (fails) { printf("== FAIL ==\n"); return 1; }
+
+    // Two synthetic modules that BOTH export PSN_PrxInitialize, at different addresses; the
+    // global table holds the first definition (what the linker's first-wins pass produces).
+    static const std::unordered_map<std::string, uint64_t> modA{ { nid_hash("PSN_PrxInitialize"), 0x1111 },
+                                                                 { nid_hash("OnlyInA"),           0xAAAA } };
+    static const std::unordered_map<std::string, uint64_t> modB{ { nid_hash("PSN_PrxInitialize"), 0x2222 } };
+    static const std::unordered_map<std::string, uint64_t> global{ { nid_hash("PSN_PrxInitialize"), 0x1111 },
+                                                                   { nid_hash("OnlyInA"),           0xAAAA } };
+    set_module_export_tables({ { "/host/dump/sce_module/A.prx", &modA },
+                               { "/host/dump/sce_module/B.prx", &modB } });
+    set_module_exports(&global);
+
+    auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
+    uint64_t hA = load(U("/app0/sce_module/A.prx"), 0, 0, 0, 0, 0);
+    uint64_t hB = load(U("/app0/sce_module/B.prx"), 0, 0, 0, 0, 0);
+    CHECK(hA >= 0x10000 && hB >= 0x10000 && hA != hB,
+          "linked-module paths resolve to real, distinct handles (basename match)");
+
+    uint64_t addr = 0;
+    CHECK(dlsym(hA, U("PSN_PrxInitialize"), U(&addr), 0, 0, 0) == 0 && addr == 0x1111,
+          "dlsym(handle A) returns A's export");
+    addr = 0;
+    CHECK(dlsym(hB, U("PSN_PrxInitialize"), U(&addr), 0, 0, 0) == 0 && addr == 0x2222,
+          "dlsym(handle B) returns B's export (NOT the global first definition)");
+
+    // A symbol absent from the handle's module falls back to the global table.
+    addr = 0;
+    CHECK(dlsym(hB, U("OnlyInA"), U(&addr), 0, 0, 0) == 0 && addr == 0xAAAA,
+          "dlsym(handle B, symbol only in A) falls back to the global table");
+
+    // Unknown path -> synthetic handle (below the real-handle range) -> global resolution.
+    uint64_t hX = load(U("/app0/sce_module/NotLinked.prx"), 0, 0, 0, 0, 0);
+    CHECK(hX > 0 && hX < 0x10000, "unknown path keeps the synthetic success handle");
+    addr = 0;
+    CHECK(dlsym(hX, U("PSN_PrxInitialize"), U(&addr), 0, 0, 0) == 0 && addr == 0x1111,
+          "dlsym(synthetic handle) resolves via the global table");
+
+    // Unknown symbol: ESRCH, out param untouched (callers pre-seed a fallback).
+    addr = 0xFEED;
+    CHECK(dlsym(hA, U("NoSuchExport"), U(&addr), 0, 0, 0) == 0x80020003 && addr == 0xFEED,
+          "unknown symbol -> ESRCH, *funcAddr untouched");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -117,6 +117,11 @@ int main(int argc, char** argv) {
     // PSN.prx plugin's PSN_PrxInitialize / UnityPluginLoad), so Unity's native-plugin loader binds
     // real export addresses instead of getting ESRCH.
     set_module_exports(&p.exports);
+    // Per-module tables (#147): LoadStartModule hands out real handles for linked-module paths and
+    // dlsym consults the handle's module before the global first-definition-wins table.
+    { std::vector<ModuleExportTable> mt;
+      for (const auto& me : p.mod_exports) mt.push_back({ me.path, &me.nids });
+      set_module_export_tables(std::move(mt)); }
 
     register_builtin_hle();
 #ifdef PROSPER_AUDIO_SDL3


### PR DESCRIPTION
## Summary
- `k_dlsym` discarded the handle and resolved every name against the global first-definition-wins export table: two modules exporting the same NID made a lookup against the second return the **first** module's address (wrong plugin initialized).
- The linker keeps a per-module export view (`Program::mod_exports`: path + NID→address, parallel to `mods`) alongside the global table.
- `sceKernelLoadStartModule` resolves a linked-module path (basename match) to a **real handle** (`0x10000+index` — a range the synthetic success counter, #146's scope, can't collide with); unknown paths keep the synthetic counter **unchanged**.
- `k_dlsym` consults the handle's module first, then falls back to the global table — synthetic handles and cross-module symbols land there, preserving the existing PSN.prx / UnityPluginLoad behavior.
- `boot_trace` registers the per-module tables at link time.

## Verification
- New pure test `test_dlsym_handle`: same-NID two-module disambiguation (handle B → B's address, not the global first), per-handle miss → global fallback, synthetic-handle path, and the ESRCH-leaves-`*funcAddr`-untouched contract.
- Full suite in WSL build-linux **including dump-backed boot tests: 63/63 passed**.

Fixes #147