### PR TITLE
diag(gpu): render-frontier tooling — VS SPIR-V dump, cbuf/pipeline logs, backend isolation switches

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -109,6 +109,17 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     std::vector<uint32_t> vs = recompile_vertex((const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());
     std::vector<uint32_t> fs = recompile_fragment((const uint32_t*)(uintptr_t)rs.ps_addr, max_shader_dwords, prt.get());
+    if (const char* dd = getenv("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection
+        static int nd = 0;
+        if (nd < 3 && !vs.empty()) {
+            char fn[512];
+            snprintf(fn, sizeof fn, "%s/vs_%d_%llx.spv", dd, nd, (unsigned long long)rs.es_addr);
+            if (FILE* f = fopen(fn, "wb")) { fwrite(vs.data(), 4, vs.size(), f); fclose(f); }
+            snprintf(fn, sizeof fn, "%s/vs_%d_%llx.bin", dd, nd, (unsigned long long)rs.es_addr);
+            if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)rs.es_addr, 1, 4096, f); fclose(f); }
+            nd++;
+        }
+    }
     if (vs.empty() || fs.empty()) {
         if (log) {
             fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; es=0x%llx ps=0x%llx)\n",

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1690,14 +1690,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // (per-draw transform, per-frame, …) don't collapse onto one. For s_buffer_load, SBASE
             // (src[0]) is the V#: resolve it by an earlier s_load's SRT tag (indirect) or directly by its
             // user-data SGPR index (the V# was placed in SGPRs by the driver). Default binding 2.
-            uint32_t binding = 2;
+            uint32_t binding = 2; bool cbuf_resolved = false;
             if (rt) { const ShaderResource* res = nullptr;
                 auto it = rs.sreg_srt.find(in.src[0].value);
                 if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
                 // A scalar buffer load reads a CONSTANT buffer — resolve the SBASE SGPR to a constant
                 // buffer specifically (the same SGPR may also hold a vertex-buffer V# elsewhere).
                 if (!res) res = rt->by_sgpr_base_cls(in.src[0].value, ResourceClass::ConstantBuffer);
-                if (res) binding = res->binding; }
+                if (res) { binding = res->binding; cbuf_resolved = true; } }
+            if (getenv("PROSPER_CBUFLOG"))
+                fprintf(stderr, "[cbuf] s_buffer_load x%u src0=s%d off=0x%x(dw%u) -> binding=%u %s\n",
+                        n, in.src[0].value, in.literal, base_idx, binding, cbuf_resolved ? "resolved" : "DEFAULT-2");
             for (uint32_t k = 0; k < n; k++)
                 rs.sreg[in.dst.value + (int)k] = b.cbuf_load(b.uconst(base_idx + k), binding);
             // A wide scalar load is a descriptor fetch — tag its dest SGPRs with the SRT offset so a

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -129,6 +129,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // fixed attachment set); each draw's pipeline sets its own depthTest/Write/CompareOp. A frame with
     // no depth-using draw takes the color-only path unchanged.
     bool use_depth = false; for (const auto& d : draws) if (d.ps && d.ps->depth_test_enable) use_depth = true;
+    if (getenv("PROSPER_NO_DEPTH")) use_depth = false;   // diag: isolate depth-test rejection
     const VkFormat DFMT = VK_FORMAT_D32_SFLOAT;
     VkImage dimg = VK_NULL_HANDLE; VkDeviceMemory dmem = VK_NULL_HANDLE; VkImageView dview = VK_NULL_HANDLE;
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -248,6 +248,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (ps) {
             cba.colorWriteMask = ps->color_write_mask;
             cba.blendEnable    = ps->blend_enable ? VK_TRUE : VK_FALSE;
+            if (getenv("PROSPER_NO_BLEND")) cba.blendEnable = VK_FALSE;   // diag: isolate blend compositing
             cba.srcColorBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;
             cba.dstColorBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
             cba.colorBlendOp        = (VkBlendOp)ps->color_blend_op;
@@ -262,6 +263,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             dss.depthTestEnable  = VK_TRUE;
             dss.depthWriteEnable = ps->depth_write_enable ? VK_TRUE : VK_FALSE;
             dss.depthCompareOp   = (VkCompareOp)ps->depth_compare_op;
+            if (getenv("PROSPER_DEPTH_ALWAYS")) dss.depthCompareOp = VK_COMPARE_OP_ALWAYS;   // diag
         }
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         v.R = bd.R; auto& R = v.R;
@@ -392,6 +394,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     clear[1].depthStencil = {0.5f, 0};   // depth cleared to 0.5 (fragments at z=0.0 pass LESS, fail GREATER)
     VkRenderPassBeginInfo rpbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
     rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_depth ? 2 : 1; rpbi.pClearValues = clear;
+    if (getenv("PROSPER_PIPELOG")) {   // diag: how many draws' pipelines built + will be recorded
+        int nok = 0; for (auto& v : dv) if (v.ok) nok++;
+        fprintf(stderr, "[pipe] %zu draws, %d pipelines OK, use_depth=%d; counts:", dv.size(), nok, (int)use_depth);
+        for (auto& v : dv) fprintf(stderr, " %s%u", v.ok ? "" : "SKIP", v.icount ? v.icount : v.vcount);
+        fprintf(stderr, "\n");
+    }
     // ONE render pass (cleared once): record every realized draw with its own pipeline + descriptors.
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     for (auto& v : dv) {


### PR DESCRIPTION
## What
Env-gated diagnostics (all default-off, 62/62 tests green) built while tracing why PPSA01885 — now fully in its render loop after the loader (#125) + SSE4a (#170) fixes — submits 130k+ draws/frame but renders only the blue clear.

- **PROSPER_VS_DUMP**: dump SUCCESSFUL VS recompiles as `.spv` (first way to `spirv-dis` an accepted shader; the existing SHADER_DUMP only dumps raw bytes on failure).
- **PROSPER_CBUFLOG**: log each graphics `s_buffer_load`'s resolved binding/offset + binding-2-default hits.
- **PROSPER_PIPELOG / DEPTH_ALWAYS / NO_BLEND / NO_DEPTH**: backend isolation switches.

## Findings (frontier redirect)
The old render-loop doc assumed the recompiler couldn't do the VS transform ("geometry collapse to w=0"). That's **outdated**:
- `spirv-dis` of the scene VS shows `gl_Position` built from the **correct binding-4 matrix** (dword 83 = w-row) × the fetched position, with a real FMA chain. VS SPIR-V is `spirv-val`-clean.
- Const-fold resolves **real vertex positions**; `[rt]` shows valid color targets + 2048² textures.
- The blue is the **render_runner clear color**, not the game.
- Backend fully exonerated: **14/14 pipelines build, all draws record**; disabling depth + blend + cull + forcing w=1 changes nothing.

**Conclusion:** the remaining defect is that the recompiled VS emits **wrong x/y clip coords** despite correct inputs — a mismatch between the const-fold's resolved V# and the shader's actual per-vertex fetch/transform. This tooling localizes the frontier to a single, focused question and is reusable for closing it.

Refs #126