### PR TITLE
fix(gpu): detile derives 4KB-tile geometry from the element size (8/16-bpp support)

### DIFF
--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -1,4 +1,4 @@
-// tile.cpp — see tile.hpp. GFX10 SW_4KB_S de-swizzle for 32-bpp surfaces.
+// tile.cpp — see tile.hpp. GFX10 SW_4KB_S de-swizzle, generalized over the element size (#119).
 #include "tile.hpp"
 #include <cstring>
 #include <algorithm>
@@ -9,109 +9,122 @@ bool tile_mode_is_tiled(uint32_t tile_mode) {
     return tile_mode == (uint32_t)TileMode::Sw4KbS;
 }
 
-size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, uint32_t pitch) {
-    if (!tile_mode_is_tiled(tile_mode)) return (size_t)width * height * 4;
-    uint32_t pw = pitch ? pitch : width;
-    uint32_t tiles_per_row = (pw + 31) / 32, tile_rows = (height + 31) / 32;   // pad H up to whole tiles
-    return (size_t)tiles_per_row * tile_rows * (32 * 32) * 4;
-}
-
 namespace {
-// Map linear (x,y) -> the texel's linear INDEX in the tiled surface for SW_4KB_S: 32x32 micro-tiles laid
-// out row-major over the padded pitch, Morton order within a tile with Y in the low bit of each pair.
-inline uint64_t sw4kb_s_index(uint32_t x, uint32_t y, uint32_t tiles_per_row) {
-    constexpr uint32_t T = 32, TB = 5;                 // tile size, log2(tile)
-    uint32_t tx = x >> TB, ty = y >> TB, ix = x & (T - 1), iy = y & (T - 1);
-    uint32_t morton = 0;
-    for (uint32_t b = 0; b < TB; b++) {
-        morton |= ((iy >> b) & 1u) << (2 * b);
-        morton |= ((ix >> b) & 1u) << (2 * b + 1);
+// 4KB standard-swizzle micro-tile geometry for bpe-byte elements: a tile is a FIXED 4096 bytes,
+// so it holds 4096/bpe elements, arranged 2^bx wide x 2^by tall with bx >= by (wide-before-tall):
+//   1 B -> 64x64,  2 B -> 64x32,  4 B -> 32x32,  8 B -> 32x16,  16 B -> 16x16.
+// The old code hardcoded 4 bytes/element (32x32 geometry) everywhere, so any 8/16-bpp surface
+// detiled with the wrong tile dimensions — every texel mis-ordered (#119).
+// CONFIDENCE: HIGH for 4 B (live pixel-verified) and 16 B (BC3, llvmpipe re-tile verified);
+// MED for the rest (standard 4KB-tile arithmetic; verify vs a real surface via PROSPER_DUMP_RAWTILE).
+inline void sw4kb_dims(uint32_t bpe, uint32_t& bx, uint32_t& by) {
+    uint32_t bits = 0; while ((4096u >> bits) > bpe) bits++;   // log2(4096/bpe), bpe a power of two
+    bx = (bits + 1) / 2; by = bits / 2;
+}
+// Morton order within the tile with Y in the LOW bit of each (y,x) pair — the empirically-derived,
+// pixel-verified 32-bpp order — and, for non-square tiles, the wider dimension's extra X bits
+// directly above the shared pairs (x5 at bit 10 for 64x32, etc.).
+inline uint32_t sw4kb_morton(uint32_t ix, uint32_t iy, uint32_t bx, uint32_t by) {
+    uint32_t m = 0;
+    for (uint32_t b = 0; b < by; b++) {
+        m |= ((iy >> b) & 1u) << (2 * b);
+        m |= ((ix >> b) & 1u) << (2 * b + 1);
     }
-    return (uint64_t)(ty * tiles_per_row + tx) * (T * T) + morton;
+    for (uint32_t b = by; b < bx; b++)
+        m |= ((ix >> b) & 1u) << (2 * by + (b - by));
+    return m;
+}
+// Element (x,y) -> its linear element INDEX in the tiled surface: tiles laid out row-major over the
+// padded pitch, sw4kb_morton within a tile.
+inline uint64_t sw4kb_index(uint32_t x, uint32_t y, uint32_t tiles_per_row, uint32_t bx, uint32_t by) {
+    uint32_t tw = 1u << bx, th = 1u << by;
+    uint32_t tx = x >> bx, ty = y >> by, ix = x & (tw - 1), iy = y & (th - 1);
+    return (uint64_t)(ty * tiles_per_row + tx) * ((uint64_t)tw * th) + sw4kb_morton(ix, iy, bx, by);
 }
 
-// The single tiled<->linear walk both public functions share: per texel, the tiled offset (Morton) and
-// the linear offset, moving 4 bytes in the chosen direction so the index math can never diverge between
-// tile and detile. `tiled_bytes` bounds the tiled side; an out-of-range tiled texel reads as zero when
-// detiling and is skipped when tiling (tile_surface pre-zeroes the whole padded destination).
+// The single tiled<->linear walk every public function shares: per element, the tiled offset
+// (Morton) and the linear offset, moving `bpe` bytes in the chosen direction so the index math can
+// never diverge between tile and detile. `tiled_bytes` bounds the tiled side; an out-of-range tiled
+// element reads as zero when detiling and is skipped when tiling (tile pre-zeroes the destination).
 template <bool ToTiled>
-void sw4kb_s_copy(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height, uint32_t pitch,
-                  size_t tiled_bytes) {
-    uint32_t pw = pitch ? pitch : width;
-    uint32_t tiles_per_row = (pw + 31) / 32;
-    for (uint32_t y = 0; y < height; y++)
-        for (uint32_t x = 0; x < width; x++) {
-            uint64_t t = sw4kb_s_index(x, y, tiles_per_row) * 4;   // tiled offset
-            size_t   l = ((size_t)y * width + x) * 4;              // linear offset
-            if (ToTiled) { if (t + 4 <= tiled_bytes) std::memcpy(dst + t, src + l, 4); }
-            else         { if (t + 4 <= tiled_bytes) std::memcpy(dst + l, src + t, 4);
-                           else                      std::memset(dst + l, 0, 4); }
+void sw4kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uint32_t pitch,
+                uint32_t bpe, size_t tiled_bytes) {
+    uint32_t bx = 0, by = 0; sw4kb_dims(bpe, bx, by);
+    uint32_t pw = pitch ? pitch : ew;
+    uint32_t tiles_per_row = (pw + (1u << bx) - 1) >> bx;
+    for (uint32_t y = 0; y < eh; y++)
+        for (uint32_t x = 0; x < ew; x++) {
+            uint64_t t = sw4kb_index(x, y, tiles_per_row, bx, by) * bpe;   // tiled offset
+            size_t   l = ((size_t)y * ew + x) * bpe;                       // linear offset
+            if (ToTiled) { if (t + bpe <= tiled_bytes) std::memcpy(dst + t, src + l, bpe); }
+            else         { if (t + bpe <= tiled_bytes) std::memcpy(dst + l, src + t, bpe);
+                           else                        std::memset(dst + l, 0, bpe); }
         }
+}
+
+size_t sw4kb_tiled_bytes(uint32_t ew, uint32_t eh, uint32_t pitch, uint32_t bpe) {
+    uint32_t bx = 0, by = 0; sw4kb_dims(bpe, bx, by);
+    uint32_t pw = pitch ? pitch : ew;
+    uint32_t tiles_per_row = (pw + (1u << bx) - 1) >> bx;
+    uint32_t tile_rows     = (eh + (1u << by) - 1) >> by;   // pad up to whole tiles
+    return (size_t)tiles_per_row * tile_rows * 4096;        // a 4KB tile is 4096 bytes at ANY bpe
 }
 } // namespace
 
+size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, uint32_t pitch,
+                           uint32_t bytes_per_texel) {
+    if (!tile_mode_is_tiled(tile_mode)) return (size_t)width * height * bytes_per_texel;
+    return sw4kb_tiled_bytes(width, height, pitch, bytes_per_texel);
+}
+
 void detile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
-                    uint32_t tile_mode, uint32_t pitch) {
-    if (!tile_mode_is_tiled(tile_mode)) { std::memcpy(dst, src, (size_t)width * height * 4); return; }
-    sw4kb_s_copy<false>(dst, src, width, height, pitch, tiled_surface_bytes(width, height, tile_mode, pitch));
+                    uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel) {
+    if (!tile_mode_is_tiled(tile_mode)) { std::memcpy(dst, src, (size_t)width * height * bytes_per_texel); return; }
+    sw4kb_copy<false>(dst, src, width, height, pitch, bytes_per_texel,
+                      sw4kb_tiled_bytes(width, height, pitch, bytes_per_texel));
 }
 
 std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t width, uint32_t height,
-                                    uint32_t tile_mode, uint32_t pitch) {
-    std::vector<uint8_t> out((size_t)width * height * 4, 0);
+                                    uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel) {
+    std::vector<uint8_t> out((size_t)width * height * bytes_per_texel, 0);
     if (src.empty()) return out;
     // Enforce the "src holds at least tiled_surface_bytes" precondition here instead of trusting the
     // caller: the pointer overload's bounds guard is computed from the DIMENSIONS (padded height), so a
-    // naturally-sized width*height*4 vector would be read past its heap allocation. Short input is
+    // naturally-sized width*height*bpt vector would be read past its heap allocation. Short input is
     // zero-padded — missing tail texels detile as zero, matching the pointer overload's OOB policy.
-    const size_t need = tiled_surface_bytes(width, height, tile_mode, pitch);
+    const size_t need = tiled_surface_bytes(width, height, tile_mode, pitch, bytes_per_texel);
     if (src.size() < need) {
         std::vector<uint8_t> padded(need, 0);
         std::memcpy(padded.data(), src.data(), src.size());
-        detile_surface(out.data(), padded.data(), width, height, tile_mode, pitch);
+        detile_surface(out.data(), padded.data(), width, height, tile_mode, pitch, bytes_per_texel);
     } else {
-        detile_surface(out.data(), src.data(), width, height, tile_mode, pitch);
+        detile_surface(out.data(), src.data(), width, height, tile_mode, pitch, bytes_per_texel);
     }
     return out;
 }
 
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
-                  uint32_t tile_mode, uint32_t pitch) {
-    if (!tile_mode_is_tiled(tile_mode)) { std::memcpy(dst, src, (size_t)width * height * 4); return; }
-    const size_t dst_bytes = tiled_surface_bytes(width, height, tile_mode, pitch);
+                  uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel) {
+    if (!tile_mode_is_tiled(tile_mode)) { std::memcpy(dst, src, (size_t)width * height * bytes_per_texel); return; }
+    const size_t dst_bytes = tiled_surface_bytes(width, height, tile_mode, pitch, bytes_per_texel);
     std::memset(dst, 0, dst_bytes);   // padding texels (rows beyond height) stay zero
-    sw4kb_s_copy<true>(dst, src, width, height, pitch, dst_bytes);
+    sw4kb_copy<true>(dst, src, width, height, pitch, bytes_per_texel, dst_bytes);
 }
 
-size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode) {
-    if (!tile_mode_is_tiled(tile_mode) || tile_side == 0) return (size_t)ew * eh * bpe;
-    uint32_t tiles_per_row = (ew + tile_side - 1) / tile_side, tile_rows = (eh + tile_side - 1) / tile_side;
-    return (size_t)tiles_per_row * tile_rows * (size_t)tile_side * tile_side * bpe;
+size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode) {
+    if (!tile_mode_is_tiled(tile_mode) || bpe == 0) return (size_t)ew * eh * bpe;
+    return sw4kb_tiled_bytes(ew, eh, /*pitch*/0, bpe);
 }
 
 void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
-                     uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode) {
-    if (!tile_mode_is_tiled(tile_mode) || tile_side == 0) {
+                     uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode) {
+    if (!tile_mode_is_tiled(tile_mode) || bpe == 0) {
         size_t n = std::min(src_bytes, (size_t)ew * eh * bpe);
         std::memcpy(dst, src, n);
         if (n < (size_t)ew * eh * bpe) std::memset(dst + n, 0, (size_t)ew * eh * bpe - n);
         return;
     }
-    uint32_t tb = 0; while ((1u << tb) < tile_side) tb++;       // log2(tile_side)
-    uint32_t tiles_per_row = (ew + tile_side - 1) / tile_side;
-    for (uint32_t y = 0; y < eh; y++)
-        for (uint32_t x = 0; x < ew; x++) {
-            uint32_t tx = x >> tb, ty = y >> tb, ix = x & (tile_side - 1), iy = y & (tile_side - 1);
-            uint32_t morton = 0;
-            for (uint32_t b = 0; b < tb; b++) {
-                morton |= ((iy >> b) & 1u) << (2 * b);
-                morton |= ((ix >> b) & 1u) << (2 * b + 1);
-            }
-            uint64_t t = ((uint64_t)(ty * tiles_per_row + tx) * ((uint64_t)tile_side * tile_side) + morton) * bpe;
-            size_t   l = ((size_t)y * ew + x) * bpe;
-            if (t + bpe <= src_bytes) std::memcpy(dst + l, src + (size_t)t, bpe);
-            else                      std::memset(dst + l, 0, bpe);
-        }
+    sw4kb_copy<false>(dst, src, ew, eh, /*pitch*/0, bpe, src_bytes);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -20,37 +20,40 @@ enum class TileMode : uint32_t { Linear = 0, Sw4KbS = 5 };
 // True if `tile_mode` denotes a swizzled layout that detile_surface will de-swizzle.
 bool tile_mode_is_tiled(uint32_t tile_mode);
 
-// Byte size of the TILED surface for `tile_mode` — for swizzled modes the height is padded up to a whole
-// number of 32-texel tile rows (e.g. 1080 -> 1088), so the tiled buffer is larger than width*height*4.
-// The caller must read at least this many bytes of tiled source before detiling. Linear -> width*height*4.
-size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, uint32_t pitch = 0);
+// Byte size of the TILED surface for `tile_mode` — for swizzled modes the dimensions are padded up
+// to whole 4KB micro-tiles, whose texel size depends on bytes_per_texel (a tile is a FIXED 4096
+// bytes: 32x32 at 4 B, 64x32 at 2 B, 64x64 at 1 B — #119), so the tiled buffer is larger than
+// w*h*bpt. The caller must read at least this many bytes of tiled source. Linear -> w*h*bpt.
+size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, uint32_t pitch = 0,
+                           uint32_t bytes_per_texel = 4);
 
-// De-swizzle a 32-bpp (RGBA8) surface from tiled `src` into linear `dst` (each width*height*4 bytes).
-// `tile_mode` selects the swizzle; Linear/unknown modes do a straight copy. `pitch` is the padded row
-// pitch in texels (0 -> use `width`).
+// De-swizzle a surface of `bytes_per_texel`-byte texels from tiled `src` into linear `dst` (each
+// width*height*bpt bytes). `tile_mode` selects the swizzle; Linear/unknown modes do a straight
+// copy. `pitch` is the padded row pitch in texels (0 -> use `width`).
 void detile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
-                    uint32_t tile_mode, uint32_t pitch = 0);
+                    uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4);
 
 // Convenience wrapper: detile `src` (tiled) into a returned linear vector. Returns a copy of `src` for
 // linear/unknown modes.
 std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t width, uint32_t height,
-                                    uint32_t tile_mode, uint32_t pitch = 0);
+                                    uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4);
 
 // Inverse of detile_surface (linear -> tiled). Provided for testing the round-trip; the runtime only
 // detiles. Same parameters.
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
-                  uint32_t tile_mode, uint32_t pitch = 0);
+                  uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4);
 
-// General SW_4KB_S de-swizzle for `bpe`-byte ELEMENTS (not fixed at 4). The 4KB micro-tile holds
-// 4096/bpe elements arranged `tile_side`x`tile_side` (Morton order, Y in the low bit of each pair,
-// identical structure to the 32-bpp path). Block-compressed surfaces use this with element = one
-// compressed block (BC3 = 16 bytes -> tile_side 16). `dst` holds ew*eh*bpe linear bytes; `src_bytes`
-// bounds the tiled read (short/OOB elements detile to zero). tile_mode!=SW_4KB_S -> straight copy.
+// General SW_4KB_S de-swizzle for `bpe`-byte ELEMENTS. The 4KB micro-tile holds 4096/bpe elements;
+// its dimensions derive from bpe (wide-before-tall: 16 B -> 16x16, 8 B -> 32x16, ...) — previously
+// a caller-supplied SQUARE tile_side, which could not represent the non-square 8 B geometry (#119).
+// Block-compressed surfaces use this with element = one compressed block (BC3 = 16 bytes). `dst`
+// holds ew*eh*bpe linear bytes; `src_bytes` bounds the tiled read (short/OOB elements detile to
+// zero). tile_mode!=SW_4KB_S -> straight copy.
 void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
-                     uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode);
+                     uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode);
 
-// Byte size of the TILED element surface (element grid padded up to whole tile_side tiles). The caller
+// Byte size of the TILED element surface (element grid padded up to whole 4KB tiles). The caller
 // must read at least this many bytes of tiled source before detiling.
-size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_side, uint32_t tile_mode);
+size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode);
 
 } // namespace prosper::gpu

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -91,6 +91,64 @@ int main() {
         CHECK(perm, "SW_4KB_S tiling is a bijective permutation (no texel dropped or duplicated)");
     }
 
+    // --- Per-bpp geometry (#119): a 4KB tile is a FIXED 4096 bytes, so its texel dims depend on
+    // bytes_per_texel (1 B -> 64x64, 2 B -> 64x32, 4 B -> 32x32). The old code hardcoded 4 B.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw4KbS;
+        CHECK(tiled_surface_bytes(1920, 1080, M) == (size_t)60 * 34 * 4096,
+              "32-bpp tile geometry unchanged (1920x1080 -> 60x34 tiles)");
+        CHECK(tiled_surface_bytes(100, 100, M, 0, 1) == (size_t)2 * 2 * 4096,
+              "8-bpp: 100x100 -> 2x2 tiles of 64x64 (NOT the 32-bpp 4x4)");
+        CHECK(tiled_surface_bytes(100, 100, M, 0, 2) == (size_t)2 * 4 * 4096,
+              "16-bpp: 100x100 -> 2x4 tiles of 64x32");
+        CHECK(tiled_elements_bytes(20, 20, 16, M) == (size_t)2 * 2 * 4096,
+              "16-byte elements (BC3 blocks): 20x20 -> 2x2 tiles of 16x16 (unchanged)");
+        CHECK(tiled_elements_bytes(40, 20, 8, M) == (size_t)2 * 2 * 4096,
+              "8-byte elements (BC1 blocks): 40x20 -> 2x2 tiles of 32x16 (was square-approximated)");
+    }
+
+    // Round-trip identity per element size (the shared indexer makes tile/detile exact inverses;
+    // this proves the per-bpp geometry is self-consistent incl. non-square 64x32 / 32x16 tiles).
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw4KbS;
+        auto rt_bpe = [&](uint32_t w, uint32_t h, uint32_t bpe) -> bool {
+            std::vector<uint8_t> ref((size_t)w * h * bpe);
+            for (size_t i = 0; i < ref.size(); i++) ref[i] = (uint8_t)((i * 2654435761u) >> 13);
+            std::vector<uint8_t> tiled(tiled_surface_bytes(w, h, M, 0, bpe), 0);
+            tile_surface(tiled.data(), ref.data(), w, h, M, 0, bpe);
+            std::vector<uint8_t> back((size_t)w * h * bpe, 0);
+            detile_surface(back.data(), tiled.data(), w, h, M, 0, bpe);
+            return back == ref;
+        };
+        CHECK(rt_bpe(200, 130, 1), "round-trip 200x130 @ 1 B/texel (64x64 tiles, unaligned dims)");
+        CHECK(rt_bpe(130, 70, 2),  "round-trip 130x70 @ 2 B/texel (64x32 tiles)");
+        CHECK(rt_bpe(96, 64, 4),   "round-trip 96x64 @ 4 B/texel (explicit-bpt path == default)");
+        CHECK(rt_bpe(70, 40, 8),   "round-trip 70x40 @ 8 B/elem (32x16 tiles)");
+        CHECK(rt_bpe(40, 40, 16),  "round-trip 40x40 @ 16 B/elem (16x16 tiles)");
+    }
+
+    // Golden positions: the 32-bpp order must be BYTE-IDENTICAL to the shipped, pixel-verified
+    // layout (y0 in the low Morton bit: (0,1) -> element 1, (1,0) -> element 2), and the 8-bpp
+    // cross-tile step must be one whole 4KB tile.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw4KbS;
+        std::vector<uint8_t> lin32((size_t)64 * 32 * 4, 0);
+        for (uint32_t y = 0; y < 32; y++) for (uint32_t x = 0; x < 64; x++)
+            lin32[((size_t)y * 64 + x) * 4] = (uint8_t)(x ^ (y << 4) ^ 0x5A);
+        std::vector<uint8_t> t32(tiled_surface_bytes(64, 32, M), 0);
+        tile_surface(t32.data(), lin32.data(), 64, 32, M);
+        CHECK(t32[1 * 4] == lin32[((size_t)1 * 64 + 0) * 4], "32-bpp golden: texel (0,1) at element 1 (y0 low)");
+        CHECK(t32[2 * 4] == lin32[((size_t)0 * 64 + 1) * 4], "32-bpp golden: texel (1,0) at element 2");
+        CHECK(t32[4096]  == lin32[((size_t)0 * 64 + 32) * 4], "32-bpp golden: texel (32,0) starts tile 1 (byte 4096)");
+
+        std::vector<uint8_t> lin8((size_t)128 * 64, 0);
+        for (size_t i = 0; i < lin8.size(); i++) lin8[i] = (uint8_t)(i * 31 + 7);
+        std::vector<uint8_t> t8(tiled_surface_bytes(128, 64, M, 0, 1), 0);
+        tile_surface(t8.data(), lin8.data(), 128, 64, M, 0, 1);
+        CHECK(t8[1] == lin8[(size_t)1 * 128 + 0], "8-bpp golden: texel (0,1) at element 1 (same Morton order)");
+        CHECK(t8[4096] == lin8[(size_t)0 * 128 + 64], "8-bpp golden: texel (64,0) starts tile 1 (byte 4096, 64-wide tile)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -311,20 +311,17 @@ int main(int argc, char** argv) {
                             const uint32_t bcb = prosper::gpu::bc_block_bytes(r.format);
                             if (bcb) {
                                 uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
-                                // CONFIDENCE: MED — SW_4KB_S keeps a 4KB micro-tile, so element count =
-                                // 4096/bpe arranged square: 16-byte blocks (BC2/3/5/7) -> 16x16, 8-byte
-                                // (BC1/4) -> 32x16 (approximated as 32 here). Verified against the 32-bpp
-                                // path (bpe=4 -> 32x32) and llvmpipe re-tiling, but NOT yet against a
-                                // structured (non-uniform) BC surface — the one live BC3 tex is ~solid white.
-                                uint32_t tside = (bcb == 16) ? 16u : 32u;
+                                // The 4KB micro-tile's element dims now derive from bpe inside the
+                                // detiler (16-byte blocks -> 16x16, 8-byte -> 32x16, #119) — the old
+                                // caller-supplied square tile_side mis-shaped the 8-byte geometry.
                                 size_t comp_bytes = (size_t)bw * bh * bcb;
                                 std::vector<uint8_t> lin(comp_bytes, 0);
                                 bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                                 if (tiled) {
-                                    size_t tbytes = prosper::gpu::tiled_elements_bytes(bw, bh, bcb, tside, r.tile_mode);
+                                    size_t tbytes = prosper::gpu::tiled_elements_bytes(bw, bh, bcb, r.tile_mode);
                                     std::vector<uint8_t> traw(tbytes, 0);
                                     safe_copy(traw.data(), r.gpu_addr, tbytes);
-                                    prosper::gpu::detile_elements(lin.data(), traw.data(), tbytes, bw, bh, bcb, tside, r.tile_mode);
+                                    prosper::gpu::detile_elements(lin.data(), traw.data(), tbytes, bw, bh, bcb, r.tile_mode);
                                 } else {
                                     safe_copy(lin.data(), r.gpu_addr, comp_bytes);
                                 }


### PR DESCRIPTION
## Summary
- `tile.cpp` hardcoded **4 bytes/texel** throughout. A GFX10 4KB micro-tile is a **fixed 4096 bytes**, so its texel dims depend on bpp: 32-bpp → 32×32 (the shipped, pixel-verified case), 16-bpp → 64×32, 8-bpp → 64×64. The title binds a 2048×1024 `fmt=1` (8_UNORM) texture — detiled with 32-bpp geometry, every texel mis-orders (latent today; hits any 8/16-bpp mask/atlas, possibly the missing cutscene glyphs #102).
- One generalized indexer now serves every path: dims `2^bx × 2^by` (bx≥by) from `4096/bpe`, Morton with **Y in the low bit of each pair** (the live-verified 32-bpp order), wider dimension's extra X bits directly above the shared pairs.
- `tiled_surface_bytes`/`detile_surface`/`tile_surface` gain a `bytes_per_texel` param (default 4 — existing callers unchanged). `detile_elements` derives dims from `bpe`, **fixing the BC1 8-byte-block square approximation** (was 32×32 geometry; correct is 32×16). `CONFIDENCE: HIGH` for 4 B/16 B (pixel-/llvmpipe-verified), `MED` for the rest (standard 4KB arithmetic; verify vs a real surface via `PROSPER_DUMP_RAWTILE`).

## Verification
- `test_tile` extended: per-bpp tiled byte sizes; round-trip identity at 1/2/4/8/16 B (non-square tiles + unaligned dims); **golden byte positions locking the 32-bpp layout byte-identical** to the shipped order ((0,1)→element 1, (1,0)→element 2, (32,0)→byte 4096) and the 8-bpp 64-wide tile boundary.
- Full suite in WSL build-linux **including dump-backed boot tests: 62/62 passed**.

Fixes #119