### PR TITLE
diag(hle/pad): log scePadOpen/Init for input-init observability

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -70,10 +70,13 @@ HostPadState snapshot(int /*handle*/, const char* what) {
 } // namespace
 
 // scePadInit / scePadClose / effector no-ops -> OK.
-HLE(pad_ok) { return 0; }
+HLE(pad_ok) { if (padlog()) fprintf(stderr, "[pad] init/ok call\n"); return 0; }
 
 // scePadOpen(userId, type, index, param) -> positive handle.
-HLE(pad_open) { return (uint64_t)g_pad_handle.fetch_add(1); }
+HLE(pad_open) { int h = g_pad_handle.fetch_add(1);
+    if (padlog()) fprintf(stderr, "[pad] OPEN userId=%llu type=%llu index=%llu -> handle=%d\n",
+                          (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2, h);
+    return (uint64_t)h; }
 
 // scePadGetHandle(userId, type, index) -> handle (games that opened once may re-query it).
 HLE(pad_get_handle) { return 1; }


### PR DESCRIPTION
Small debug-only logging (gated on PROSPER_PADLOG) of scePadOpen/scePadInit, used while driving The Messenger toward gameplay (#163). Finding: the game opens the pad but doesn't poll it during the intro cutscene — progression to the input-polling state is throughput-bound (SSE4a SIGILL emulation ~10fps). No effect on normal runs.