### PR TITLE
fix(hle): guest thread stacks are glibc-owned and reclaimed; attr stacksize honored; registry purged on exit

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -328,17 +328,30 @@ HLE(k_getprio)            { // scePthreadGetprio(thread, int* prio)
 }
 
 // --- thread creation: run the guest entry on a real host thread (ABI matches) ---
-// We give each worker a stack we allocate and TRACK, so GC/thread-stack queries get
-// accurate bounds (see k_attr_get) without relying on pthread_getattr_np.
+// Worker stacks are GLIBC-OWNED (#138): create passes only a stacksize (honoring the guest attr),
+// so glibc allocates the stack and — crucially — RECLAIMS it when the thread is joined or a
+// detached thread exits. The old code mmap'd a fixed 8 MiB per thread via pthread_attr_setstack
+// and never munmapped it (glibc never frees a CALLER-owned stack): a thread-churning title leaked
+// 8 MiB per exited thread. The trampoline still TRACKS the bounds (via pthread_getattr_np, keyed
+// by our tid) so GC/thread-stack queries stay accurate, and unregisters them on exit — pthread
+// ids are recycled, so a stale entry would serve the next thread the dead thread's bounds.
 #ifdef __linux__
 namespace {
-struct ThreadStart { void* (*entry)(void*); void* arg; void* sbase; uint64_t ssz; };
+struct ThreadStart { void* (*entry)(void*); void* arg; };
 // Runs first on the new thread: register our own stack (keyed by our tid) BEFORE any guest code,
 // so an early GC_register_my_thread / stack-base query from this thread finds it. Closes a race
 // where a fast-starting worker ran before the parent's post-create registration → "Bad stack base".
 void* thread_trampoline(void* p) {
     auto* ts = (ThreadStart*)p;
-    if (ts->sbase) register_thread_stack((uint64_t)pthread_self(), ts->sbase, ts->ssz);
+    {
+        pthread_attr_t sa;
+        if (pthread_getattr_np(pthread_self(), &sa) == 0) {
+            void* sb = nullptr; size_t ss = 0;
+            if (pthread_attr_getstack(&sa, &sb, &ss) == 0 && sb)
+                register_thread_stack((uint64_t)pthread_self(), sb, ss);
+            pthread_attr_destroy(&sa);
+        }
+    }
     install_sigaltstack();   // so a guest stack overflow on this worker is still catchable
     auto entry = ts->entry; void* arg = ts->arg; free(ts);   // all host libc — MUST run on the host %fs
     // gated (PROSPER_GUEST_FS): give this guest worker its own guest TCB + static TLS and switch %fs to it
@@ -357,6 +370,7 @@ void* thread_trampoline(void* p) {
     // exit via scePthreadExit never get here — k_pthread_exit purges before host pthread_exit.
     uint64_t sfs = guest_fs_to_host_scoped();
     tls_dtv_purge_current_thread();
+    unregister_thread_stack((uint64_t)pthread_self());   // ids recycle; stale bounds = wrong bounds (#138)
     guest_fs_restore_scoped(sfs);
     return rv;
 }
@@ -371,26 +385,30 @@ HLE(k_pthread_create) {
                 (unsigned long long)a2, (unsigned long long)a3, a4 ? (const char*)(uintptr_t)a4 : "");
     pthread_t tid;
 #ifdef __linux__
-    pthread_attr_t la; bool own = false;
-    pthread_attr_t* at;
-    if (a1 && *(void**)a1) at = (pthread_attr_t*)*(void**)a1;
-    else { pthread_attr_init(&la); at = &la; own = true; }
-    size_t ssz = 8 * 1024 * 1024;
-    void* sbase = mmap(nullptr, ssz, PROT_READ | PROT_WRITE,
-                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
-    int r;
-    if (sbase != MAP_FAILED) {
-        pthread_attr_setstack(at, sbase, ssz);
-        auto* ts = (ThreadStart*)malloc(sizeof(ThreadStart));
-        ts->entry = entry; ts->arg = arg; ts->sbase = sbase; ts->ssz = ssz;
-        r = pthread_create(&tid, at, thread_trampoline, ts);   // trampoline registers the stack first
-        if (r) free(ts);
-    } else {
-        r = pthread_create(&tid, at, entry, arg);
+    // Stack size: honor the guest attr's stacksize (previously ignored — everything got a fixed
+    // 8 MiB), floored at 1 MiB because our HLE + host libc frames run deeper than Sony's runtime
+    // would on the same stack. No attr (or no explicit size) keeps the 8 MiB default.
+    constexpr size_t kStackFloor = 1 * 1024 * 1024, kStackDefault = 8 * 1024 * 1024;
+    size_t ssz = kStackDefault;
+    int detach = PTHREAD_CREATE_JOINABLE;
+    if (a1 && *(void**)a1) {
+        auto* gat = (pthread_attr_t*)*(void**)a1;
+        size_t req = 0;
+        if (pthread_attr_getstacksize(gat, &req) == 0 && req)
+            ssz = req < kStackFloor ? kStackFloor : req;
+        pthread_attr_getdetachstate(gat, &detach);
     }
-    if (own) pthread_attr_destroy(&la);
-    if (r) { if (sbase != MAP_FAILED) munmap(sbase, ssz); return (uint64_t)r; }
-    if (sbase != MAP_FAILED) register_thread_stack((uint64_t)tid, sbase, ssz);  // redundant safety net
+    // A local attr with setstackSIZE (not setstack): glibc allocates AND RECLAIMS the stack
+    // (join / detached exit) — the old caller-owned mmap was never freed (#138). Also stops
+    // mutating the guest's own attr object (setstack used to be applied to it in place).
+    pthread_attr_t la; pthread_attr_init(&la);
+    pthread_attr_setstacksize(&la, ssz);
+    pthread_attr_setdetachstate(&la, detach);
+    auto* ts = (ThreadStart*)malloc(sizeof(ThreadStart));
+    ts->entry = entry; ts->arg = arg;
+    int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
+    pthread_attr_destroy(&la);
+    if (r) { free(ts); return (uint64_t)r; }
 #else
     pthread_attr_t* at = (a1 && *(void**)a1) ? (pthread_attr_t*)*(void**)a1 : nullptr;
     int r = pthread_create(&tid, at, entry, arg);
@@ -403,10 +421,13 @@ HLE(k_pthread_join)   { void* rv = nullptr; pthread_join((pthread_t)a0, a1 ? &rv
 HLE(k_pthread_detach) { pthread_detach((pthread_t)a0); return 0; }
 HLE(k_pthread_exit)   {
     // Host pthread_exit unwinds without ever returning through thread_trampoline, so this is its own
-    // thread-exit path: purge the exiting thread's __tls_get_addr DTV first (#68). HLE handlers run
-    // under the HOST %fs (the import stubs swap), so the host libc below is safe. No-op for threads
-    // that never touched __tls_get_addr.
+    // thread-exit path: purge the exiting thread's __tls_get_addr DTV first (#68) and drop its stack
+    // registration (#138 — pthread ids recycle). HLE handlers run under the HOST %fs (the import
+    // stubs swap), so the host libc below is safe. No-op for threads that never touched either.
     tls_dtv_purge_current_thread();
+#ifdef __linux__
+    unregister_thread_stack((uint64_t)pthread_self());
+#endif
     pthread_exit((void*)(uintptr_t)a0);
     return 0;
 }

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -46,6 +46,9 @@ struct BootResult {
 // Register the stack a guest thread runs on (main thread + workers we spawn), keyed by
 // its pthread id, so GC/thread code gets accurate bounds without pthread_getattr_np.
 void register_thread_stack(uint64_t tid, void* base, uint64_t size);
+// Remove a dead thread's entry. pthread ids are RECYCLED — a stale entry would serve the next
+// thread on the same id the old thread's bounds (#138). Called on every HLE thread-exit path.
+void unregister_thread_stack(uint64_t tid);
 // Arm the PROSPER_HWBP execute breakpoint on the calling (worker) thread (no-op unless
 // PROSPER_HWBP_ALLTHREADS is set). Lets off-main-thread execution of the target be observed.
 void arm_hwbp_this_thread();

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1367,6 +1367,10 @@ void register_thread_stack(uint64_t tid, void* base, uint64_t size) {
     std::lock_guard<std::mutex> lk(g_smx);
     g_stacks[tid] = { (uint64_t)base, size };
 }
+void unregister_thread_stack(uint64_t tid) {
+    std::lock_guard<std::mutex> lk(g_smx);
+    g_stacks.erase(tid);
+}
 bool guest_stack_for_thread(uint64_t tid, void** base, size_t* size) {
     std::lock_guard<std::mutex> lk(g_smx);
     auto it = g_stacks.find(tid);

--- a/prosper/tests/test_stack_registry.cpp
+++ b/prosper/tests/test_stack_registry.cpp
@@ -2,8 +2,11 @@
 // GC_get_stack_base rely on (and that the k_pthread_create trampoline populates). A regression
 // here reintroduces "Bad stack base in GC_register_my_thread" during the boot.
 #include "../src/host/exec_image.hpp"
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstddef>
+#include <cstdint>
 
 using namespace prosper;
 
@@ -30,6 +33,53 @@ int main() {
     register_thread_stack(0x1111, (void*)0x60000000ull, 0x4000);
     CHECK(guest_stack_for_thread(0x1111, &base, &sz) && base == (void*)0x60000000ull && sz == 0x4000,
           "re-registration updates the entry");
+
+    // Unregister erases (#138): pthread ids recycle, so a dead thread's entry must not survive to
+    // serve the NEXT thread on the same id the old bounds.
+    unregister_thread_stack(0x1111);
+    CHECK(!guest_stack_for_thread(0x1111, &base, &sz), "unregister erases the entry");
+
+    // End-to-end HLE thread lifecycle (#138): the guest attr's stacksize is honored (was: fixed
+    // 8 MiB), the running thread sees its own registered bounds, and after join the entry is GONE
+    // (the trampoline unregisters on exit; the glibc-owned stack is reclaimed with the thread).
+#ifdef __linux__
+    {
+        register_builtin_hle();
+        auto attr_init = Hle::lookup(nid_hash("scePthreadAttrInit"));
+        auto attr_ssz  = Hle::lookup(nid_hash("scePthreadAttrSetstacksize"));
+        auto t_create  = Hle::lookup(nid_hash("scePthreadCreate"));
+        auto t_join    = Hle::lookup(nid_hash("scePthreadJoin"));
+        CHECK(attr_init && attr_ssz && t_create && t_join, "thread HLE functions registered");
+        struct Probe { size_t sz = 0; bool found = false; };
+        auto entry = +[](void* p) -> void* {
+            auto* pr = (Probe*)p;
+            void* b = nullptr; size_t s = 0;
+            pr->found = guest_stack_for_current_thread(&b, &s);
+            pr->sz = s;
+            return nullptr;
+        };
+        auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
+
+        // 2 MiB request: registered size ~= the request (glibc may round up by pages).
+        void* at = nullptr; attr_init(U(&at), 0, 0, 0, 0, 0);
+        attr_ssz(U(&at), 2 * 1024 * 1024, 0, 0, 0, 0);
+        uint64_t tid = 0; Probe pr;
+        CHECK(t_create(U(&tid), U(&at), U((void*)entry), U(&pr), 0, 0) == 0, "create with 2 MiB attr");
+        t_join(tid, 0, 0, 0, 0, 0);
+        CHECK(pr.found, "thread saw its own registered stack bounds");
+        CHECK(pr.sz >= 2 * 1024 * 1024 && pr.sz < 3 * 1024 * 1024,
+              "attr stacksize honored (~2 MiB, not the old fixed 8 MiB)");
+        CHECK(!guest_stack_for_thread(tid, &base, &sz), "entry unregistered after the thread exited");
+
+        // Tiny request: floored (our HLE + host libc need headroom the Sony runtime doesn't).
+        void* at2 = nullptr; attr_init(U(&at2), 0, 0, 0, 0, 0);
+        attr_ssz(U(&at2), 64 * 1024, 0, 0, 0, 0);
+        uint64_t tid2 = 0; Probe pr2;
+        CHECK(t_create(U(&tid2), U(&at2), U((void*)entry), U(&pr2), 0, 0) == 0, "create with 64 KiB attr");
+        t_join(tid2, 0, 0, 0, 0, 0);
+        CHECK(pr2.found && pr2.sz >= 1 * 1024 * 1024, "tiny request floored to >= 1 MiB");
+    }
+#endif
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary
- `k_pthread_create` mmap'd a fixed **8 MiB stack per guest thread** via `pthread_attr_setstack` and never munmapped it — glibc never reclaims a caller-owned stack, so a thread-churning title **leaked 8 MiB per exited thread**. The `g_stacks` registry entry was never erased (pthread ids recycle → stale bounds served to the next thread on the same id), and the guest attr's stacksize was ignored.
- Create now passes only a stack**size** on a **local** attr (also stops mutating the caller's attr object in place): glibc allocates **and reclaims** the stack on join / detached exit — the leak is gone by construction, no self-munmap gymnastics.
- The guest attr's stacksize is **honored**, floored at 1 MiB (our HLE + host libc frames run deeper than Sony's runtime would); no attr keeps the 8 MiB default. Detach state is forwarded.
- The trampoline registers its own bounds via `pthread_getattr_np` (same register-before-guest-code ordering that fixed the "Bad stack base" race) and **unregisters** on both exit paths (trampoline return + `scePthreadExit`); new `unregister_thread_stack` in the host registry.

## Verification
- `test_stack_registry` extended: unregister semantics, plus an end-to-end HLE thread lifecycle — 2 MiB attr honored (~2 MiB registered, not 8 MiB), bounds visible from inside the thread, **entry gone after join**, 64 KiB request floored to ≥ 1 MiB.
- Full suite in WSL build-linux **including dump-backed boot tests: 63/63 passed** (the boot churns real worker threads through this path).

Fixes #138