### PR TITLE
fix(recompiler): size the LDS array from the shader's real allocation, not a hardcoded 16 KB

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -494,11 +494,18 @@ struct SpirvCompute {
         put(code, Op_Label, {merge}); cur_block = merge;
     }
     // LDS (Local Data Share) — a workgroup-shared u32 array for compute ds_read/ds_write. Declared on
-    // first use. 4096 dwords (16 KB, the RDNA2 per-workgroup LDS size).
+    // first use, sized to `lds_dwords`. RDNA2's per-workgroup LDS MAX is 64 KB (16384 dwords); the real
+    // per-shader allocation is COMPUTE_PGM_RSRC2.LDS_SIZE. `lds_dwords` defaults to 4096 (16 KB) — a
+    // shader whose real allocation exceeds that would ds_read/write past the array (OOB Workgroup
+    // access, UB — NOT covered by robustBufferAccess), so recompile_valu raises it from the plumbed
+    // size when known (#130). Kept at 16 KB by default because it must also stay within the target
+    // device's VkPhysicalDeviceLimits::maxComputeSharedMemorySize (e.g. llvmpipe = 32 KB), so we can't
+    // just declare the full 64 KB unconditionally.
+    uint32_t lds_dwords = 4096;
     uint32_t lds_var = 0, t_ptr_wg_u32 = 0;
     void declare_lds() {
         if (lds_var) return;
-        uint32_t len = uconst(4096);
+        uint32_t len = uconst(lds_dwords);
         uint32_t t_arr = id();        put(types, Op_TypeArray, {t_arr, t_u32, len});
         uint32_t t_ptr_wg_arr = id(); put(types, Op_TypePointer, {t_ptr_wg_arr, SC_Workgroup, t_arr});
         lds_var = id();               put(types, Op_Variable, {t_ptr_wg_arr, lds_var, SC_Workgroup});
@@ -2179,10 +2186,16 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
 
 std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      uint32_t num_inputs, uint32_t out_vgpr,
-                                     const ShaderResourceTable* rt) {
+                                     const ShaderResourceTable* rt, uint32_t lds_bytes) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     SpirvCompute b;
+    // Size the LDS array from the shader's real allocation when known (#130): bytes -> dwords, at
+    // least the ds ops need, clamped to the RDNA2 64 KB (16384-dword) max. 0 keeps the 16 KB default.
+    if (lds_bytes) {
+        uint32_t dw = (lds_bytes + 3) / 4;
+        b.lds_dwords = dw > 16384u ? 16384u : (dw ? dw : 1u);
+    }
     b.begin(num_inputs ? num_inputs : 1);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -22,9 +22,12 @@ struct ShaderResourceTable;   // resource-binding contract (shader_resources.hpp
 // Translate a straight-line float-VALU RDNA2 stream to a compute-shader SPIR-V module.
 // Returns {} if the stream contains an opcode/format this stage does not yet handle. An optional
 // ShaderResourceTable routes SMEM constant-buffer loads to distinct bindings via descriptor provenance.
+// `lds_bytes` is the shader's real per-workgroup LDS allocation (COMPUTE_PGM_RSRC2.LDS_SIZE): the
+// emitted Workgroup array is sized to it, clamped to the RDNA2 64 KB max (#130). 0 = the 16 KB
+// default (also the safe cap for the common maxComputeSharedMemorySize of 32 KB).
 std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      uint32_t num_inputs, uint32_t out_vgpr,
-                                     const ShaderResourceTable* rt = nullptr);
+                                     const ShaderResourceTable* rt = nullptr, uint32_t lds_bytes = 0);
 
 // Recompile a pixel/fragment shader to a fragment SPIR-V module: run the VALU, and on EXP to an MRT
 // target write vec4(src0..3) to the location-0 color output. Returns {} if unsupported / no export.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -3,6 +3,7 @@
 #include "../src/gpu/shader_resources.hpp"
 #include <cstdint>
 #include <cstdio>
+#include <unordered_map>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -80,6 +81,27 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
         i += wc;
     }
     return false;
+}
+
+// The largest OpTypeArray length (resolved through its OpConstant) in the module — for LDS sizing
+// (#130), the Workgroup LDS array is the biggest array the compute shell declares.
+uint32_t max_array_length(const std::vector<uint32_t>& spv) {
+    enum : uint32_t { OpTypeArrayL = 28, OpConstantL = 43 };
+    if (spv.size() < 5) return 0;
+    std::unordered_map<uint32_t, uint32_t> const_val;   // result id -> u32 constant value
+    uint32_t best = 0;
+    for (size_t i = 5; i < spv.size();) {
+        uint32_t word = spv[i];
+        uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) break;
+        if (op == OpConstantL && wc >= 4) const_val[spv[i + 2]] = spv[i + 3];   // {type,result,value}
+        if (op == OpTypeArrayL && wc >= 4) {                                    // {result,elem,length-id}
+            auto it = const_val.find(spv[i + 3]);
+            if (it != const_val.end() && it->second > best) best = it->second;
+        }
+        i += wc;
+    }
+    return best;
 }
 
 } // namespace
@@ -211,6 +233,39 @@ int main() {
         return 1;
     }
     printf("  [ok]   fragment image_sample still uses OpImageSampleImplicitLod\n");
+
+    // LDS array is sized from the shader's real allocation (#130), not a hardcoded 16 KB. A compute
+    // kernel that uses ds_write/ds_read declares a Workgroup array; its length must be 4096 dwords
+    // (16 KB) by default and rise to the requested size (clamped to the RDNA2 64 KB / 16384-dword max)
+    // when lds_bytes is plumbed. code32 = lane i writes lds[i], barrier, reads lds[63-i].
+    const uint32_t code_lds[] = {
+        0x7e020f00u, 0x34040282u, 0x34060281u, 0x4a060681u, 0xd8340000u, 0x00000302u, 0xbf8a0000u,
+        0x4c0a02bfu, 0x340c0a82u, 0xd8d80000u, 0x07000006u, 0x7e000d07u, 0xbf810000u,
+    };
+    const size_t n_lds = sizeof(code_lds)/sizeof(code_lds[0]);
+    std::vector<uint32_t> lds_def = recompile_valu(code_lds, n_lds, 1, 0, nullptr);
+    std::vector<uint32_t> lds_32k = recompile_valu(code_lds, n_lds, 1, 0, nullptr, 32 * 1024);
+    std::vector<uint32_t> lds_big = recompile_valu(code_lds, n_lds, 1, 0, nullptr, 128 * 1024);   // > 64 KB
+    if (lds_def.empty() || lds_32k.empty() || lds_big.empty()) {
+        printf("  [FAIL] LDS kernel did not recompile\n");
+        return 1;
+    }
+    if (max_array_length(lds_def) != 4096u) {
+        printf("  [FAIL] default LDS array length = %u dwords, want 4096 (16 KB)\n", max_array_length(lds_def));
+        return 1;
+    }
+    printf("  [ok]   default LDS array is 4096 dwords (16 KB)\n");
+    if (max_array_length(lds_32k) != 8192u) {
+        printf("  [FAIL] lds_bytes=32K -> array length = %u dwords, want 8192\n", max_array_length(lds_32k));
+        return 1;
+    }
+    printf("  [ok]   lds_bytes=32 KB -> 8192-dword LDS array\n");
+    if (max_array_length(lds_big) != 16384u) {
+        printf("  [FAIL] lds_bytes=128K -> array length = %u dwords, want 16384 (clamped to 64 KB)\n",
+               max_array_length(lds_big));
+        return 1;
+    }
+    printf("  [ok]   lds_bytes>64 KB clamps to the RDNA2 max (16384 dwords)\n");
 
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- `declare_lds` hardcoded a 4096-dword (16 KB) Workgroup array and mis-commented it as the RDNA2 maximum. RDNA2's per-workgroup LDS max is **64 KB**; the real allocation is `COMPUTE_PGM_RSRC2.LDS_SIZE`. A compute shader allocating >16 KB LDS emitted `ds_read`/`ds_write` **past the array** — OOB Workgroup access (UB, *not* covered by robustBufferAccess).
- `lds_dwords` is now a member; `declare_lds` sizes the array from it. `recompile_valu` gains an optional `lds_bytes` param (default 0): when set, the array is sized to it (bytes→dwords, **clamped to the RDNA2 64 KB / 16384-dword max**).
- **Kept at 16 KB by default, deliberately NOT an unconditional 64 KB**: the Workgroup array must also fit the device's `maxComputeSharedMemorySize` (llvmpipe = 32 KB), so over-declaring would fail pipeline creation. The default-arg keeps all ~100 existing callers byte-for-byte unchanged; decoding RSRC2.LDS_SIZE to feed `lds_bytes` is the follow-up — the plumbing lands here.
- Comment corrected (64 KB max, RSRC2.LDS_SIZE is the real size).

## Verification
- New structural check in `test_rdna2_spirv_struct`: an LDS kernel's declared Workgroup-array length is **4096 dwords by default, 8192 at `lds_bytes=32 KB`, and clamps to 16384 above 64 KB**.
- Full suite in WSL build-linux **including the LDS execution test (kernel 32): 64/64 passed**.

Fixes #130