### PR TITLE
fix(hle): hinted map uses MAP_FIXED_NOREPLACE — stop silently clobbering live mappings

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -161,6 +161,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_dmem PRIVATE prosper_core)
   add_test(NAME dmem_available COMMAND test_dmem)
 
+  # Hinted map must not clobber a live mapping (#137): MAP_FIXED_NOREPLACE unless the hint is our
+  # own uncommitted reservation. Drives the real map HLE handlers. Linux-only (mmap semantics).
+  if(UNIX AND NOT APPLE)
+    add_executable(test_map_noreplace tests/test_map_noreplace.cpp)
+    target_link_libraries(test_map_noreplace PRIVATE prosper_core)
+    add_test(NAME map_noreplace COMMAND test_map_noreplace)
+  endif()
+
   # PM4 command-stream decoder (front of the CommandProcessor): decode a Dcb built by the AGC
   # Dcb functions and assert the ops. Pure/cross-platform, no game dump needed.
   add_executable(test_pm4_decode tests/test_pm4_decode.cpp)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -166,6 +166,30 @@ namespace {
                 if (!best || m.base > best->base) best = &m;   // most specific (latest overlay)
         return best;
     }
+    // Is [base, base+len) entirely covered by our OWN UNCOMMITTED (PROT_NONE reservation) mappings?
+    // Only then is a MAP_FIXED replace safe: the guest is committing a range it reserved (#137). A
+    // committed span (live guest memory) or a gap (an untracked host mapping / loaded image) means a
+    // MAP_FIXED would silently destroy it — so map_at/map_phys_at must fail instead. Walks boundary to
+    // boundary (not page by page) so a 512 GiB reservation is checked in a few steps.
+    bool range_is_free_reservation(uint64_t base, uint64_t len) {
+        if (!len) return false;
+        std::lock_guard<std::mutex> lk(g_mx);
+        uint64_t cur = base, end = base + len;
+        while (cur < end) {
+            const Mapping* cover = nullptr;      // most-specific mapping containing cur
+            uint64_t next_start = end;           // nearest mapping that STARTS after cur (a coverage gap boundary)
+            for (auto& m : g_maps) {
+                uint64_t me = m.base + m.size;
+                if (cur >= m.base && cur < me) { if (!cover || m.base > cover->base) cover = &m; }
+                else if (m.base > cur && m.base < next_start) next_start = m.base;
+            }
+            if (!cover || cover->committed) return false;   // gap (untracked) or committed = unsafe to replace
+            uint64_t adv = cover->base + cover->size;
+            if (next_start < adv) adv = next_start;         // don't skip a mapping that starts inside `cover`
+            cur = adv;
+        }
+        return true;
+    }
     // Smallest mapping base strictly greater than addr (0 if none) — for hole reporting.
     uint64_t next_base(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);
@@ -185,9 +209,21 @@ namespace {
     }
     uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
     void* map_at(uint64_t hint, uint64_t len, int prot) {
-        int flags = MAP_PRIVATE | MAP_ANONYMOUS | (hint ? MAP_FIXED : 0);
-        void* p = mmap((void*)hint, len, prot, flags, -1, 0);
-        return p == MAP_FAILED ? nullptr : p;
+        if (!hint) {
+            void* p = mmap(nullptr, len, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            return p == MAP_FAILED ? nullptr : p;
+        }
+        // Non-zero hint: claim it WITHOUT clobbering (#137). MAP_FIXED_NOREPLACE fails if anything
+        // is already there; only if the occupant is entirely our own uncommitted reservation do we
+        // replace it with MAP_FIXED (the guest is committing a range it reserved). A hint that
+        // overlaps a committed mapping or an untracked host mapping fails instead of destroying it.
+        void* p = mmap((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+        if (p != MAP_FAILED) return p;
+        if (range_is_free_reservation(hint, len)) {
+            p = mmap((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+            return p == MAP_FAILED ? nullptr : p;
+        }
+        return nullptr;
     }
 
     // The direct-memory pool is backed by ONE shared memfd so every mapping of a phys offset
@@ -220,8 +256,22 @@ namespace {
     void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys) {
         int fd = dmem_fd();
         if (fd >= 0 && phys < kDmemBase + kDmemTotal) {
-            void* p = mmap((void*)hint, len, prot, MAP_SHARED | (hint ? MAP_FIXED : 0), fd, (off_t)phys);
-            if (p != MAP_FAILED) return p;
+            if (!hint) {
+                void* p = mmap(nullptr, len, prot, MAP_SHARED, fd, (off_t)phys);
+                if (p != MAP_FAILED) return p;
+            } else {
+                // Same no-clobber discipline as map_at (#137): NOREPLACE first, MAP_FIXED replace
+                // only over our own uncommitted reservation, else refuse rather than destroy a live
+                // (committed / untracked) mapping — the exact clobber class of issues #88 / #107.
+                void* p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED_NOREPLACE, fd, (off_t)phys);
+                if (p != MAP_FAILED) return p;
+                if (range_is_free_reservation(hint, len)) {
+                    p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
+                    if (p != MAP_FAILED) return p;
+                } else {
+                    return nullptr;
+                }
+            }
         }
         return map_at(hint, len, prot);
     }

--- a/prosper/tests/test_map_noreplace.cpp
+++ b/prosper/tests/test_map_noreplace.cpp
@@ -1,0 +1,61 @@
+// test_map_noreplace — a hinted map must NOT silently clobber a live mapping (#137). The old
+// map_at/map_phys_at forced MAP_FIXED for any non-zero hint, so a MapFlexible/MapDirectMemory
+// whose hint overlapped a committed mapping (or a loaded guest image) destroyed it. The fix:
+// MAP_FIXED_NOREPLACE, upgraded to MAP_FIXED only when the hint is entirely our own uncommitted
+// reservation. This drives the real HLE handlers and asserts a committed range survives a
+// colliding map, that committing an OWN reservation still works, and that a free hint is honored.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <sys/mman.h>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_map_noreplace ==\n");
+    register_builtin_hle();
+    auto reserve  = Hle::lookup(nid_hash("sceKernelReserveVirtualRange"));
+    auto flexible = Hle::lookup(nid_hash("sceKernelMapNamedFlexibleMemory"));
+    CHECK(reserve && flexible, "map HLE functions registered");
+    if (fails) { printf("== FAIL ==\n"); return 1; }
+
+    auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
+    const uint64_t LEN = 0x10000;   // 64 KiB
+
+    // 1. Commit a range via MapFlexible at hint=0 (kernel picks a free VA), write a sentinel.
+    uint64_t va = 0;
+    CHECK(flexible(U(&va), LEN, 0x2 /*RW*/, 0, U("live"), 0) == 0 && va, "MapFlexible(hint=0) succeeds");
+    volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)va;
+    *cell = 0xC0FFEE42u;
+
+    // 2. Map AGAIN at the same (now COMMITTED) hint. The old code MAP_FIXED'd fresh zero pages over
+    //    it, erasing the sentinel; the fix refuses (the range is committed, not a free reservation).
+    uint64_t va2 = va;
+    uint64_t r2 = flexible(U(&va2), LEN, 0x2, 0, U("colliding"), 0);
+    CHECK(r2 != 0, "MapFlexible over a COMMITTED hint fails (does not clobber)");
+    CHECK(*cell == 0xC0FFEE42u, "the committed range's contents SURVIVED the colliding map");
+
+    // 3. Committing an OWN reservation must still work: reserve fixed, then map into it.
+    //    Find a free high VA by probing with the host mmap the handler uses.
+    void* probe = mmap(nullptr, LEN, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(probe != MAP_FAILED, "probe mmap for a free VA");
+    uint64_t rbase = (uint64_t)(uintptr_t)probe;
+    munmap(probe, LEN);   // free it again; the reserve below re-claims the same VA (nothing raced in)
+    uint64_t rv = rbase;
+    CHECK(reserve(U(&rv), LEN, 0x10 /*SCE_KERNEL_MAP_FIXED*/, 0x4000, 0, 0) == 0 && rv == rbase,
+          "ReserveVirtualRange(fixed) tracks an uncommitted reservation");
+    uint64_t mv = rbase;
+    CHECK(flexible(U(&mv), LEN, 0x2, 0, U("into-reservation"), 0) == 0 && mv == rbase,
+          "MapFlexible INTO our own reservation succeeds (commits it in place)");
+    *(volatile uint32_t*)(uintptr_t)rbase = 0x1234u;   // writable now (was PROT_NONE reservation)
+    CHECK(*(volatile uint32_t*)(uintptr_t)rbase == 0x1234u, "the committed reservation is writable");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- `map_at` / `map_phys_at` forced `MAP_FIXED` for any non-zero hint, so a `MapDirectMemory` / `MapFlexibleMemory` (or the Ampr mirror) whose hint overlapped a committed mapping — live guest memory, a loaded module image, an untracked host mapping — **silently unmapped it** and dropped fresh zero pages on top. This is the exact clobber class issues #88 / #107 worked around with ad-hoc `mincore`/discriminator guards.
- Both helpers now: (1) try `MAP_FIXED_NOREPLACE`; (2) upgrade to `MAP_FIXED` **only** when the whole range is our own uncommitted `PROT_NONE` reservation (`range_is_free_reservation` walks the tracker boundary-to-boundary, so a committed overlay *inside* a large reservation is caught, not skipped); (3) otherwise **return failure** — the guest sees EINVAL rather than losing live memory.
- Committing an own reservation (the normal `MapDirectMemory`-into-reserved flow the boot depends on) still works: NOREPLACE fails on the `PROT_NONE` reservation, the range check passes, `MAP_FIXED` replaces it. `hint=0` (anywhere) is unchanged.
- Note for the **area:ue4** lane: this *strengthens* the Ampr map path (`map_phys_at`) — clobbering committed memory there was the #88/#107 bug; the shared helper now refuses it centrally.

## Verification
- New `test_map_noreplace` drives the real HLE handlers: a committed range's contents **survive** a colliding map (old code erased them — **verified the test FAILs without the fix**), committing an own reservation succeeds, `hint=0` works.
- **Boot-safety (issue flagged risky vs boot):** full suite **65/65 including the dump-backed Messenger boot**, which maps direct/flexible memory into its reservations on this exact path.

Fixes #137