### PR TITLE
fix(gpu): decode SMEM SOFFSET register + sign-extend the 21-bit immediate

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -230,7 +230,9 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                  is_buffer ? "bufload" : "load", sdst, sbase, (unsigned long long)base, base_ok,
                                  soff_field, soff_val, soff_ok, in.literal, n);
                 if (n == 0 || !base_ok || !soff_ok) { for (uint32_t k = 0; k < n; k++) val.erase(sdst + (int)k); break; }
-                uint64_t addr = base + in.literal + soff_val;
+                // in.literal is the SIGN-EXTENDED 21-bit immediate (#149) — add it as signed so a
+                // negative offset subtracts from the base instead of wrapping to a huge address.
+                uint64_t addr = base + (uint64_t)(int64_t)(int32_t)in.literal + soff_val;
                 if (!guest_readable(addr, n * 4)) { if (trc) fprintf(stderr, "[dyntrace]   addr 0x%llx unreadable\n", (unsigned long long)addr);
                                                     for (uint32_t k = 0; k < n; k++) val.erase(sdst + (int)k); break; }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -143,15 +143,21 @@ void decode_operands(Rdna2Inst& i) {
             for (int k = 0; k < 4; k++) i.src[k] = vgpr((d1 >> (8 * k)) & 0xFFu);
             i.n_src = 4; break;
         }
-        case Rdna2Format::SMEM:
+        case Rdna2Format::SMEM: {
             // Scalar memory load. opcode[25:18]; SDATA (dest SGPR) [12:6]; SBASE (SGPR *pair*, field
-            // is the pair index so ×2) [5:0]; 21-bit immediate byte OFFSET in dword1[20:0] (stored in
-            // `literal`). Register-offset (SOFFSET) and buffer descriptors are not decoded yet.
+            // is the pair index so ×2) [5:0]. Address = SBASE + SOFFSET-reg + OFFSET, where dword1[20:0]
+            // is a SIGNED 21-bit immediate byte OFFSET (stored sign-extended in `literal`) and
+            // dword1[31:25] is the 7-bit SOFFSET register field (125 = NULL = immediate-only). Both are
+            // decoded now (#149): SOFFSET into src[1] so a register-offset load can be recognized (and
+            // rejected until supported) instead of silently translating with the immediate alone.
             i.opcode = (w >> 18) & 0xFFu;
             i.dst    = sgpr(w >> 6);                 // SDATA
             i.src[0] = sgpr((w & 0x3Fu) << 1);       // SBASE (pair base)
-            i.literal = i.words[1] & 0x1FFFFFu;       // immediate byte offset (not a trailing constant)
-            i.n_src = 1; break;
+            uint32_t off21 = i.words[1] & 0x1FFFFFu;
+            i.literal = (off21 & 0x100000u) ? (off21 | 0xFFE00000u) : off21;   // sign-extend bit 20
+            i.src[1] = decode_src_field((i.words[1] >> 25) & 0x7Fu);           // SOFFSET (125 = NULL)
+            i.n_src = 2; break;
+        }
         case Rdna2Format::MUBUF: {
             // Untyped buffer op. opcode[24:18]; VDATA (dest/src VGPR) d1[15:8]; VADDR d1[7:0];
             // SRSRC (V# descriptor base SGPR, field ×4) d1[20:16]; SOFFSET d1[31:24]. 12-bit inst

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1726,8 +1726,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x2: case 0xA: n = 4;  break;   // s_load_dwordx4   / s_buffer_load_dwordx4
                 case 0x3: case 0xB: n = 8;  break;   // s_load_dwordx8   / s_buffer_load_dwordx8
                 case 0x4: case 0xC: n = 16; break;   // s_load_dwordx16  / s_buffer_load_dwordx16
-                default: ok = false; return true;    // register-offset / stores / others not yet
+                default: ok = false; return true;    // stores / others not yet
             }
+            // Register SOFFSET (src[1] not the NULL sentinel) adds an SGPR-computed byte offset we don't
+            // model — reject rather than translate with the immediate alone (#149). Immediate-only loads
+            // encode SOFFSET = SGPR_NULL (125). A negative signed immediate can't index a constant
+            // buffer (dword index would wrap), so reject that too.
+            if (!(in.src[1].kind == OperandKind::Special && in.src[1].value == 125)) { ok = false; return true; }
+            if ((int32_t)in.literal < 0) { ok = false; return true; }
             uint32_t base_idx = in.literal >> 2;    // immediate byte offset -> dword index
             // Descriptor provenance: pick which bound constant buffer via the resource table, routing this
             // load to that buffer's OWN binding (N-buffer model) — so Unity's several constant buffers

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -158,6 +158,23 @@ int main() {
     CHECK(decode_src_field(193).kind == OperandKind::InlineInt && decode_src_field(193).value == -1, "field 193 -> int -1");
     CHECK(decode_src_field(242).kind == OperandKind::InlineFloat && inline_float_value(242) == 1.0f, "field 242 -> float 1.0");
 
+    // SMEM SOFFSET + signed immediate (#149). Encodings from llvm-mc gfx1030.
+    //   imm:  s_buffer_load_dword s0, s[4:7], 0x10 -> SOFFSET=NULL(125), offset 0x10
+    //   reg:  s_buffer_load_dword s0, s[4:7], s8   -> SOFFSET=SGPR s8, offset 0
+    const uint32_t smem_imm[] = { 0xf4200002u, 0xfa000010u };
+    Rdna2Inst si = rdna2_decode_one(smem_imm, 2);
+    CHECK(si.fmt == Rdna2Format::SMEM && si.n_src == 2 && si.literal == 0x10u &&
+          si.src[1].kind == OperandKind::Special && si.src[1].value == 125,
+          "SMEM immediate: offset 0x10, SOFFSET decodes to NULL(125)");
+    const uint32_t smem_reg[] = { 0xf4200002u, 0x10000000u };
+    Rdna2Inst sr = rdna2_decode_one(smem_reg, 2);
+    CHECK(sr.fmt == Rdna2Format::SMEM && sr.literal == 0u && isS(sr.src[1], 8),
+          "SMEM register offset: SOFFSET decodes to SGPR s8 (was silently dropped)");
+    // Signed 21-bit immediate: a raw 0x1FFFF8 sign-extends to -8 (offset = -8 bytes).
+    const uint32_t smem_neg[] = { 0xf4000002u, 0xfa1ffff8u };
+    Rdna2Inst sn = rdna2_decode_one(smem_neg, 2);
+    CHECK((int32_t)sn.literal == -8, "SMEM 21-bit immediate is sign-extended (0x1ffff8 -> -8)");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -411,6 +411,15 @@ int main() {
     printf("  kernel20 mismatches=%u (out[0]=%g expect=50)\n", bad20, got20.size()==N?got20[0]:-1);
     CHECK(got20.size()==N && bad20==0, "recompiled kernel 20 (SMEM: cbuf[1]+cbuf[2] from constant buffer) correct");
 
+    // Kernel 20b (#149): a register-SOFFSET s_buffer_load must be REJECTED, not silently translated
+    // with the immediate alone (the register offset is unmodeled). s_buffer_load_dword s0, s[..], s8.
+    // Same first-load prefix as kernel 20 so the difference is purely the register SOFFSET.
+    const uint32_t code20b[] = {
+        0xf4000001u, 0xfa000004u, 0xf4200002u, 0x10000008u, 0x7e000c00u, 0xbf810000u,
+    };
+    CHECK(recompile_valu(code20b, sizeof(code20b)/sizeof(code20b[0]), 1, 0).empty(),
+          "kernel 20b (s_buffer_load with a register SOFFSET) is REJECTED (not silently mistranslated)");
+
     // Kernel 21: MUBUF per-lane buffer_load_dword (the vertex-fetch mechanism). v0=(uint)gid;
     // v0<<=2 (byte offset); buffer_load_dword v0, v0 offen -> cbuf[gid]; out=(float)cbuf[gid].
     const uint32_t code21[] = {


### PR DESCRIPTION
## Summary
- The SMEM decoder stored only `dword1[20:0]` as the offset: the register **SOFFSET** field (`dword1[31:25]`) was never decoded, so an `s_buffer_load` with a register offset translated using the immediate **alone** (wrong), and couldn't even be rejected — the info was discarded at decode time. The 21-bit immediate was also treated **unsigned** though RDNA2 signs it.
- **Decoder**: decode `dword1[31:25]` into `src[1]` (125 = `SGPR_NULL` = immediate-only), `n_src = 2`; sign-extend the 21-bit OFFSET into `literal`.
- **Recompiler**: reject an `s_buffer_load` whose SOFFSET is a real register (unmodeled) instead of silently using the immediate; reject a negative signed offset (can't index a constant buffer). Immediate-only loads (SOFFSET = NULL) are unchanged.
- **Executor**: add the immediate as a **signed** value so a negative offset subtracts from the base rather than wrapping to a huge address. It already read SOFFSET from the raw words, so its address math is otherwise unaffected.

## Verification
- Decode test: asserts NULL vs SGPR SOFFSET decode + sign-extension (`0x1ffff8` → `-8`).
- Recompiler test: a register-SOFFSET `s_buffer_load` (kernel 20b) is **rejected**, while the immediate-only kernel 20 still computes `cbuf[1]+cbuf[2]` correctly on real Vulkan.
- All encodings **llvm-mc gfx1030 verified**. Full suite **64/64 including the dump-backed boot** (the boot's constant-buffer loads are all immediate-only, unchanged).

Fixes #149