### PR TITLE
fix(recompiler): reject a packed vertex fetch whose element base isn't provably dword-aligned

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1852,6 +1852,22 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // Integer sub-dword formats (Uint8/Sint8/Uint16/Sint16) aren't normalized floats and would
             // need an integer-attribute path; reject rather than mis-normalize.
             if (packed && !is_half && norm == 0.0f) { ok = false; return true; }
+            // Packed (sub-dword) components are extracted at STATIC byte offsets relative to a
+            // DWORD-ALIGNED element base — the low 2 bits of the address (addr&3) are dropped by the
+            // addr>>2 dword index and never folded into the bit extraction (#150). That is only correct
+            // when the element base is provably 4-byte aligned; otherwise a component (a half2 UV after
+            // a snorm16x3 normal, an unorm8 at a byte offset) decodes the wrong bits. A fully general
+            // fix needs a runtime bit position that can straddle dwords; until then, prove alignment
+            // from the address terms and REJECT the packed load/store when it can't be proven (surfacing
+            // the gap) rather than silently mis-decode. Aligned iff: inst offset %4==0; stride %4==0
+            // when idxen; no offen (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0.
+            if (packed) {
+                bool soff_zero = (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
+                                 (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
+                bool base_aligned = ((offset & 3u) == 0) && !offen &&
+                                    (!idxen || (stride & 3u) == 0) && soff_zero;
+                if (!base_aligned) { ok = false; return true; }
+            }
             // Byte address of the element: idxen -> VADDR is an element index (×stride); offen -> VADDR
             // is a byte offset; plus the inst offset and SOFFSET. dword index = addr>>2.
             uint32_t addr = b.uconst(offset);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -495,6 +495,14 @@ int main() {
     printf("  kernel24 mismatches=%u (out[5]=%g expect=%g)\n", bad24, got24.size()==N?got24[5]:-1, got24.size()==N?exp24[5]:-1);
     CHECK(got24.size()==N && bad24==0, "recompiled kernel 24 (unorm8x4 -> 4 normalized floats) correct");
 
+    // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
+    // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
+    // addr&3, so a non-aligned element base would decode the wrong bits — it must be REJECTED (the
+    // alignment can't be proven) rather than silently mis-decoded. Kernel 24 (offset 0) still succeeds.
+    const uint32_t code24b[] = { 0x7e000f00u, 0xe00c2002u, 0x80020100u, 0xbf810000u };
+    CHECK(recompile_valu(code24b, sizeof(code24b)/sizeof(code24b[0]), 1, /*out_vgpr*/1, &rt24).empty(),
+          "kernel 24b (packed unorm8x4 at a non-dword-aligned offset:2) is REJECTED (not mis-decoded)");
+
     // Kernel 25: SNORM16x2 vertex fetch — signed 16-bit fields, normalized /32767 and clamped to -1.0
     // (the SNORM rule: -32768 maps to -1.0, not -1.00003). out = v1 + 10*v2. y is fixed at -32768 to
     // exercise the clamp; x varies per lane to also prove correct sign-extension of the low field.


### PR DESCRIPTION
## Summary
- The packed (sub-dword) format unpack extracts each component at a **static** byte offset relative to a dword-aligned element base and indexes with `addr>>2` — it **drops `addr&3` entirely**. Any attribute whose element byte address is not a multiple of 4 (a half2 UV after a snorm16x3 normal, an unorm8 at byte offset 2) decoded the wrong bits with no error.
- A fully general fix needs a runtime bit position that can **straddle dwords**; until then, prove 4-byte alignment from the address terms and **reject** the packed load/store when it can't be proven — surfacing the gap instead of silently mis-decoding (the project's reject-rather-than-miscompute discipline).
- Provably aligned iff: inst offset %4==0; stride %4==0 when idxen; **no offen** (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0. The common dword-aligned vertex fetch (the live rendering path) is **unchanged**.

## Verification
- Kernel 24 (aligned unorm8x4, the canonical packed case) still recompiles and decodes to 4 normalized floats correctly — regression guard.
- New kernel 24b (the **same** fetch at `offset:2`, non-4-aligned) is **rejected**. Encodings **llvm-mc gfx1030 verified**.
- Full suite in WSL build-linux **including the dump-backed boot: 65/65 passed**.

Note: if a real title turns out to depend on an unaligned packed attribute (it would already be rendering wrong today), the follow-up is the full runtime/straddling unpack — this PR stops the silent miscompile first.

Fixes #150