### PR TITLE
feat(hle/pad): PROSPER_PAD_SCRIPT — timed input for headless menu navigation

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -20,6 +20,8 @@
 #include <cstdlib>
 #include <atomic>
 #include <chrono>
+#include <string>
+#include <vector>
 
 namespace prosper {
 
@@ -52,10 +54,55 @@ uint64_t now_us() {
     return (uint64_t)duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
 }
 
+// --- PROSPER_PAD_SCRIPT: hardware-free timed button sequence -------------------------------------
+// Drives a scripted controller so a headless run can navigate menus (e.g. the title→menu→save→name
+// flow in issue #163) with no host device. Format: a ';'-separated list of "<seconds>:<button>[+..]"
+// entries, e.g. "3:start;9:start;16:cross;24:cross;31:up+cross". Each entry presses its button(s)
+// for PROSPER_PAD_HOLD ms (default 300) starting at <seconds>. When a script is set the pad reports
+// CONNECTED for the whole run (a menu that gates on a controller sees one).
+//
+// Timing is anchored to the FIRST input poll, not process start: the game only reads the pad once it
+// reaches the interactive menu, so t=0 == "menu appeared" — robust to how long asset loading takes.
+// CONFIDENCE: HIGH (mechanism); MED (that the game's submit maps to OPTIONS="Start" / CROSS).
+// The parse + time-eval live in pad.cpp (pure, unit-tested); this file supplies getenv + the clock.
+const std::vector<PadScriptEntry>& pad_script() {
+    static const std::vector<PadScriptEntry> script = [] {
+        const char* env = getenv("PROSPER_PAD_SCRIPT");
+        return env ? parse_pad_script(env) : std::vector<PadScriptEntry>{};
+    }();
+    return script;
+}
+
+double pad_hold_secs() {
+    static const double h = [] {
+        const char* e = getenv("PROSPER_PAD_HOLD");
+        return e ? atof(e) / 1000.0 : 0.30;   // ms -> s
+    }();
+    return h;
+}
+
+// t0 (us) of the first poll; 0 until set. steady_clock so it matches now_us().
+std::atomic<uint64_t> g_pad_t0_us{0};
+
+// Overlay any active scripted press onto `s`. Returns true if a script is driving the pad.
+bool apply_pad_script(HostPadState& s) {
+    const auto& script = pad_script();
+    if (script.empty()) return false;
+    s.connected = true;                                     // a controller is present for the whole run
+    uint64_t t0 = g_pad_t0_us.load(std::memory_order_relaxed);
+    if (t0 == 0) {                                          // anchor to this first poll
+        uint64_t expect = 0, now = now_us();
+        if (g_pad_t0_us.compare_exchange_strong(expect, now)) t0 = now; else t0 = expect;
+    }
+    double elapsed = (now_us() - t0) / 1e6;
+    s.buttons |= pad_script_buttons_at(script, elapsed, pad_hold_secs());
+    return true;
+}
+
 // Snapshot the controller for a given pad handle via the installed backend. With no host frontend
 // installed, prosper_core's default backend reports a neutral, disconnected pad (fully-formed
-// struct). PROSPER_PAD_PRESS overrides with a synthetic connected pad (CROSS held) for hardware-free
-// end-to-end testing — a device-independent successor to the old stub's inline press injection.
+// struct). PROSPER_PAD_PRESS overrides with a synthetic connected pad (CROSS held); PROSPER_PAD_SCRIPT
+// overrides with a timed button sequence — both are device-independent end-to-end test drivers.
 HostPadState snapshot(int /*handle*/, const char* what) {
     HostPadState s;   // neutral, disconnected by default
     pad_backend()->poll(0, s);
@@ -63,6 +110,7 @@ HostPadState snapshot(int /*handle*/, const char* what) {
         s.connected = true;
         s.buttons  |= SCE_PAD_BUTTON_CROSS;
     }
+    apply_pad_script(s);
     padlog_once(what, &s);
     return s;
 }

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -5,6 +5,7 @@
 #include "pad.hpp"
 #include <cstddef>
 #include <cstring>
+#include <cstdlib>
 #include <atomic>
 
 namespace prosper::input {
@@ -99,6 +100,54 @@ void pad_fill_controller_info(ScePadControllerInformation* out, bool connected, 
     out->connected_count = connected_count;
     out->connected       = connected ? 1 : 0;
     out->device_class    = 0;       // SCE_PAD_DEVICE_CLASS_STANDARD
+}
+
+// --- Scripted input (PROSPER_PAD_SCRIPT) pure helpers — see pad.hpp -----------------------------
+uint32_t pad_button_by_name(const std::string& n) {
+    if (n == "start" || n == "options") return SCE_PAD_BUTTON_OPTIONS;
+    if (n == "cross" || n == "x")       return SCE_PAD_BUTTON_CROSS;
+    if (n == "circle" || n == "o")      return SCE_PAD_BUTTON_CIRCLE;
+    if (n == "square")                  return SCE_PAD_BUTTON_SQUARE;
+    if (n == "triangle")                return SCE_PAD_BUTTON_TRIANGLE;
+    if (n == "up")                      return SCE_PAD_BUTTON_UP;
+    if (n == "down")                    return SCE_PAD_BUTTON_DOWN;
+    if (n == "left")                    return SCE_PAD_BUTTON_LEFT;
+    if (n == "right")                   return SCE_PAD_BUTTON_RIGHT;
+    if (n == "l1") return SCE_PAD_BUTTON_L1; if (n == "r1") return SCE_PAD_BUTTON_R1;
+    if (n == "l2") return SCE_PAD_BUTTON_L2; if (n == "r2") return SCE_PAD_BUTTON_R2;
+    if (n == "l3") return SCE_PAD_BUTTON_L3; if (n == "r3") return SCE_PAD_BUTTON_R3;
+    return 0;
+}
+
+std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
+    std::vector<PadScriptEntry> v;
+    size_t i = 0;
+    while (i < spec.size()) {
+        size_t semi = spec.find(';', i);
+        std::string tok = spec.substr(i, semi == std::string::npos ? std::string::npos : semi - i);
+        i = (semi == std::string::npos) ? spec.size() : semi + 1;
+        size_t colon = tok.find(':');
+        if (colon == std::string::npos) continue;
+        double t = atof(tok.substr(0, colon).c_str());
+        std::string btns = tok.substr(colon + 1);
+        uint32_t mask = 0;
+        size_t j = 0;
+        while (j < btns.size()) {                       // '+'-separated buttons pressed together
+            size_t plus = btns.find('+', j);
+            std::string one = btns.substr(j, plus == std::string::npos ? std::string::npos : plus - j);
+            j = (plus == std::string::npos) ? btns.size() : plus + 1;
+            mask |= pad_button_by_name(one);
+        }
+        if (mask) v.push_back({t, mask});
+    }
+    return v;
+}
+
+uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs) {
+    uint32_t mask = 0;
+    for (const auto& e : script)
+        if (elapsed_secs >= e.t_secs && elapsed_secs < e.t_secs + hold_secs) mask |= e.button_mask;
+    return mask;
 }
 
 } // namespace prosper::input

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -14,6 +14,8 @@
 // published Sony ScePadData; asserted byte-for-byte in pad.cpp. CONFIDENCE: HIGH (layout).
 #pragma once
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace prosper::input {
 
@@ -131,6 +133,23 @@ constexpr uint8_t kPadTriggerButtonThreshold = 0x08;   // ~3% of full travel
 // Return the L2/R2 button bits for analog trigger values past the threshold (0 for both at rest).
 // Shared by every backend so the analog->digital rule lives in one unit-tested place.
 uint32_t pad_trigger_buttons(uint8_t l2, uint8_t r2);
+
+// ---- Scripted input (PROSPER_PAD_SCRIPT) — pure, unit-tested -----------------------------------
+// A timed button sequence lets a headless run drive menus with no host device (issue #163). These
+// three helpers are pure (no env, no clock) so the parse + time-eval logic is verifiable; the HLE
+// (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first input poll.
+struct PadScriptEntry { double t_secs; uint32_t button_mask; };
+
+// Map a button name ("start"/"options"/"cross"/"x"/"up"/... case as written) to its SCE_PAD_BUTTON_*
+// bit; 0 if unknown. "start" and "options" both mean the PS5 Options button (the "Start" equivalent).
+uint32_t pad_button_by_name(const std::string& name);
+
+// Parse "<secs>:<btn>[+<btn>...][;<secs>:<btn>...]" into entries (e.g. "3:start;9:cross+up"). Entries
+// with no recognized button are dropped. Whitespace-tolerant only where the spec has none by design.
+std::vector<PadScriptEntry> parse_pad_script(const std::string& spec);
+
+// Buttons held at `elapsed_secs`: OR of every entry whose window [t, t+hold_secs) contains the time.
+uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs);
 
 // ---- Pluggable host backend (mirrors AudioSink / audio_set_sink) -------------------------------
 //

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -124,6 +124,35 @@ int main() {
         }
     }
 
+    // (7) PROSPER_PAD_SCRIPT pure helpers — parse + time-eval (drives menus headless, issue #163).
+    {
+        CHECK(pad_button_by_name("start")   == SCE_PAD_BUTTON_OPTIONS, "name: start -> OPTIONS");
+        CHECK(pad_button_by_name("options") == SCE_PAD_BUTTON_OPTIONS, "name: options -> OPTIONS");
+        CHECK(pad_button_by_name("cross")   == SCE_PAD_BUTTON_CROSS,   "name: cross -> CROSS");
+        CHECK(pad_button_by_name("x")       == SCE_PAD_BUTTON_CROSS,   "name: x -> CROSS");
+        CHECK(pad_button_by_name("up")      == SCE_PAD_BUTTON_UP,      "name: up -> UP");
+        CHECK(pad_button_by_name("nonsense")== 0,                      "name: unknown -> 0");
+
+        auto s = parse_pad_script("3:start;9.5:cross;16:up+cross");
+        CHECK(s.size() == 3, "parse: 3 entries");
+        CHECK(s[0].t_secs == 3.0 && s[0].button_mask == SCE_PAD_BUTTON_OPTIONS, "parse: entry0 t/mask");
+        CHECK(s[1].t_secs == 9.5 && s[1].button_mask == SCE_PAD_BUTTON_CROSS,   "parse: fractional time");
+        CHECK(s[2].button_mask == (SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS),   "parse: '+' combines buttons");
+
+        // Malformed pieces are skipped, not fatal; an all-unknown entry drops out.
+        auto s2 = parse_pad_script("nocolon;5:garbagebtn;7:down");
+        CHECK(s2.size() == 1 && s2[0].button_mask == SCE_PAD_BUTTON_DOWN, "parse: skips malformed/empty entries");
+
+        // Time-eval: a button is held only within [t, t+hold).
+        const double hold = 0.30;
+        CHECK(pad_script_buttons_at(s, 2.9, hold) == 0,                       "eval: before window -> none");
+        CHECK(pad_script_buttons_at(s, 3.0, hold) == SCE_PAD_BUTTON_OPTIONS,  "eval: at window start -> pressed");
+        CHECK(pad_script_buttons_at(s, 3.29, hold) == SCE_PAD_BUTTON_OPTIONS, "eval: within window -> pressed");
+        CHECK(pad_script_buttons_at(s, 3.30, hold) == 0,                      "eval: at window end (exclusive) -> released");
+        CHECK(pad_script_buttons_at(s, 16.1, hold) == (SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS), "eval: combined press");
+        CHECK(parse_pad_script("").empty(), "parse: empty spec -> no entries");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## What

Adds `PROSPER_PAD_SCRIPT`: a device-free way to drive the controller through a timed sequence of button presses, so a headless boot run can navigate the game's menus (the title→menu→save-select→name-entry flow traced in #163) with no host gamepad.

**Format:** `"<secs>:<btn>[+<btn>...][;...]"` — e.g. `"3:start;9:cross;16:up+cross"`. Buttons: `start`/`options`, `cross`/`x`, `circle`/`o`, `square`, `triangle`, `up`/`down`/`left`/`right`, `l1`..`r3`.

## Key design: anchored to the first input poll

Timing is relative to the **first input poll**, not process start. The game only reads the pad once it reaches the interactive menu, so `t=0` == "menu appeared" — making a script robust to how long asset loading takes (which varies a lot). While a script is set the pad reports **connected** for the whole run so a menu that gates on a controller sees one. `PROSPER_PAD_HOLD` (ms, default 300) tunes the press window.

## Structure

Parse + time-eval are **pure functions** in `pad.cpp` (`parse_pad_script`, `pad_script_buttons_at`, `pad_button_by_name`), unit-tested in `test_pad` — name mapping, `+` combos, fractional times, malformed-entry skipping, and `[t, t+hold)` window edges. `hle_pad.cpp` supplies only `getenv` + the steady clock + the first-poll anchor. Keeps `prosper_core`'s pure layer verifiable without hardware.

## Testing

`ctest -R pad` green (17 new assertions). No behavior change unless `PROSPER_PAD_SCRIPT` is set.

## Context

This is infrastructure for reaching interactive gameplay in The Messenger (#163). The game now boots through the intro cutscene into title service-init + SaveData mount/unmount; once it reaches the interactive menu this mechanism drives the navigation sequence.