### PR TITLE
fix(agc): EventWrite carries its address and honors the completion write

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -77,6 +77,25 @@ static void honor_eop_write(const Pm4Command& c) {
     wake_on_label(c.rel_addr);   // wake any sync_on_address futex waiter on this completion label
 }
 
+// Honor an address-carrying EVENT_WRITE (#132): the timestamp/label variant writes a completion
+// value to its address. Our GPU folds synchronously (submit == pipe drain), so by the time we
+// process this packet the event has "happened" — write a monotonic GPU clock (the value a timestamp
+// event carries) and wake any waiter, resolving the "a guest waiting on the label blocks forever"
+// case. Address-less events (event_addr == 0, the pipeline-sync variants: partial-flush, cache
+// inval) stay no-ops. CONFIDENCE: LOW on the value for the counter-sample event types
+// (ZPASS_DONE / streamout stats read a counter, not a timestamp) — but a defined monotonic write is
+// strictly better than the old discard (no write at all, which is what blocked the waiter). No title
+// currently exercises this (the Messenger fences via ReleaseMem/WriteData), so it's latent.
+static void honor_event_write(const Pm4Command& c) {
+    if (eop_writes_disabled() || !c.event_addr || (c.event_addr & 3)) return;
+    uint64_t v = gpu_clock64();
+    memcpy((void*)(uintptr_t)c.event_addr, &v, sizeof v);
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc]   EventWrite [0x%llx] event_type=%u -> clock 0x%llx\n",
+                (unsigned long long)c.event_addr, c.event_type, (unsigned long long)v);
+    wake_on_label(c.event_addr);   // wake any sync_on_address futex waiter on this completion label
+}
+
 // Honor a WRITE_DATA packet: copy the inline dwords to the destination address (same synchronous timing).
 static void honor_write_data(const Pm4Command& c) {
     if (eop_writes_disabled() || !c.wd_addr || (c.wd_addr & 3) || !c.wd_data || !c.wd_num) return;
@@ -153,6 +172,9 @@ void GpuState::apply(const Pm4Command& c) {
             break;
         case K::WriteData:
             honor_write_data(c);    // inline data write requested by the Dcb
+            break;
+        case K::EventWrite:
+            honor_event_write(c);   // address-carrying (timestamp/label) EVENT_WRITE completion (#132)
             break;
         case K::WaitRegMem:
             // Synchronous fold: by the time we process this packet the CPU-side producer has

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -40,6 +40,9 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
         } else if (c.op == IT_EVENT_WRITE) {
             c.kind = K::EventWrite;
             if (npl >= 1) c.event_type = pl[0] & 0xffu;
+            // Address-carrying (timestamp/label) variant: [1..2] = address lo/hi (#132). Address-less
+            // pipeline-sync events leave event_addr == 0 (a no-op in the CommandProcessor).
+            if (npl >= 3) c.event_addr = (uint64_t)pl[1] | ((uint64_t)pl[2] << 32);
         } else if (c.op == IT_SET_SH_REG) {
             // SET_SH_REG sets a RANGE: pl[0] = start register offset, pl[1..npl-1] = consecutive values
             // (this is how the driver uploads the whole user-data descriptor block in one packet — e.g. a

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -63,6 +63,7 @@ struct Pm4Command {
     uint64_t di_modifier = 0;            // DrawIndex: raw 64-bit draw-modifier bits
     bool     di_valid = false;           // DrawIndex: payload was long enough to carry addr+modifier
     uint32_t event_type = 0;             // EventWrite
+    uint64_t event_addr = 0;             // EventWrite: destination address (0 = address-less sync event) (#132)
     uint32_t sh_reg_offset = 0, sh_reg_value = 0;  // SetShRegDirect (sh_reg_value = first value)
     uint32_t sh_reg_count = 0;                 // SetShRegDirect: # of consecutive registers this packet sets
     const uint32_t* sh_reg_data = nullptr;     // SetShRegDirect: -> the value dwords (count of them) in-packet

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -161,8 +161,15 @@ HLE(agc_dcb_dma_data) {  // (dcb, dst, cache_policy, flags, src, size_dw)
     return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_event_write) {  // (buf, event_type, address)
-    uint32_t* cmd; if (!begin_packet(a0, 2, IT_EVENT_WRITE, 0, &cmd)) return 0;
-    cmd[1] = (uint32_t)(a1 & 0xffu); return (uint64_t)(uintptr_t)cmd;
+    // Widen the packet to carry the address (a2) like ReleaseMem (#132): an address-carrying
+    // EVENT_WRITE (the timestamp/label variant) writes a completion value there, and discarding it
+    // left a guest waiting on that label blocked forever. cmd[1]=event_type, cmd[2..3]=address lo/hi.
+    // An address-less event (a2=0, the pipeline-sync variants: partial-flush, cache-inval) stays a
+    // no-op in the CommandProcessor (event_addr==0), exactly as before.
+    uint32_t* cmd; if (!begin_packet(a0, 4, IT_EVENT_WRITE, 0, &cmd)) return 0;
+    cmd[1] = (uint32_t)(a1 & 0xffu);
+    cmd[2] = (uint32_t)(a2 & 0xffffffffu); cmd[3] = (uint32_t)(a2 >> 32u);
+    return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_acquire_mem) {  // (buf, engine, cb_db_op, gcr_cntl, ...) — 8 dw
     uint32_t* cmd; if (!begin_packet(a0, 8, IT_NOP, R_ACQUIRE_MEM, &cmd)) return 0;

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -99,6 +99,29 @@ int main() {
               "WRITE_DATA clamped num_dwords to what the packet actually holds");
     }
 
+    // Address-carrying EVENT_WRITE (#132): the widened packet ([0]=hdr [1]=event_type [2..3]=addr)
+    // writes a monotonic completion value to its address so a guest waiting on that label unblocks
+    // (the old 2-dword packet discarded the address -> the CommandProcessor no-op'd -> wait forever).
+    {
+        uint64_t label = 0;
+        uint32_t buf[4];
+        uint64_t addr = (uint64_t)(uintptr_t)&label;
+        buf[0] = PM4(4, IT_EVENT_WRITE, 0);
+        buf[1] = 0x14;                                // some event_type
+        buf[2] = (uint32_t)(addr & 0xffffffffu); buf[3] = (uint32_t)(addr >> 32);
+        GpuState st; run_command_buffer(buf, 4, st);
+        CHECK(label != 0, "address-carrying EVENT_WRITE wrote a completion value to the label (was dropped)");
+    }
+    // An address-LESS EVENT_WRITE (event_addr == 0, a pipeline-sync event) must remain a no-op.
+    {
+        uint32_t buf[4];
+        buf[0] = PM4(4, IT_EVENT_WRITE, 0);
+        buf[1] = 0x16; buf[2] = 0; buf[3] = 0;        // no address
+        GpuState st;
+        size_t n = run_command_buffer(buf, 4, st);    // must not fault / write anywhere
+        CHECK(n == 1, "address-less EVENT_WRITE decodes and is a harmless no-op");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -52,7 +52,7 @@ int main() {
     p_adr(rc, 0xCAFEF00DDEADBEEFull, 0, 0, 0, 0);                 // rewrite the regs vaddr
     draw(D, /*index_count*/ 0x1234, 0, 0, 0, 0);
     drawi(D, /*index_count*/ 0x0600, /*indices*/ 0xDEAD0000BEEF0040ull, /*modifier*/ 0x40000000ull, 0, 0);
-    evt(D, /*event_type*/ 0x42, 0, 0, 0, 0);
+    evt(D, /*event_type*/ 0x42, /*address*/ 0x1400ABCD00ull, 0, 0, 0);
 
     size_t used_dw = (size_t)(dcb.cursor_up - dcb.bottom);
     printf("  built %zu dwords\n", used_dw);
@@ -82,6 +82,9 @@ int main() {
     CHECK(ops[4].di_modifier == 0x40000000ull && ops[4].di_valid, "op4 modifier round-trips (valid)");
 
     CHECK(ops[5].kind == K::EventWrite && ops[5].event_type == 0x42, "op5 = EventWrite(0x42)");
+    // Address-carrying EVENT_WRITE (#132): the widened packet now round-trips its destination
+    // address (was discarded, so an address-carrying event lost its write target).
+    CHECK(ops[5].event_addr == 0x1400ABCD00ull, "op5 EventWrite address round-trips (was dropped)");
 
     // Every decoded packet's len must match its header, and the payload pointer must be in-buffer.
     bool spans_ok = true;


### PR DESCRIPTION
## Summary
- `agc_dcb_event_write` encoded only `event_type` into a 2-dword packet and **discarded its address argument**; the CommandProcessor treated every EVENT_WRITE as a no-op. An address-carrying EVENT_WRITE (the timestamp/label variant) lost its write target, so a guest waiting on that label **blocked forever**.
- Widen the packet to 4 dwords: `[1]`=event_type, `[2..3]`=address lo/hi (like ReleaseMem). `pm4_decode` reads `event_addr`; an address-less pipeline-sync event leaves it 0.
- The CommandProcessor now honors an address-carrying EVENT_WRITE: our GPU folds synchronously (submit == pipe drain), so it writes a monotonic GPU clock to the address and wakes any `sync_on_address` waiter — resolving the block-forever case. Address-less events (partial-flush / cache-inval) stay **no-ops, unchanged**.

`CONFIDENCE: LOW` on the value for the counter-sample event types (ZPASS_DONE / streamout read a counter, not a timestamp), but a defined monotonic write is strictly better than the old discard. **Latent** — the Messenger fences via ReleaseMem/WriteData, so no title exercises it yet.

## Verification
- `test_pm4_decode`: EventWrite **address round-trips** (was dropped).
- `test_eop_write`: an address-carrying EVENT_WRITE writes a non-zero completion value; an address-less one stays a harmless no-op.
- Full suite in WSL build-linux **including the dump-backed boot: 65/65** (the boot submits real address-less EVENT_WRITE sync packets — correctly no-op'd).

Fixes #132