### PR TITLE
fix(gpu): GPU EOP timestamp shares the guest TSC clock (RELEASE_MEM data_sel=3)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -33,12 +33,15 @@ static bool eop_writes_disabled() {
     return off && off[0] == '1';
 }
 
-// A monotonic 64-bit "GPU clock" for RELEASE_MEM data_sel==3 (GpuClock64). Real hardware writes the GPU
-// timestamp; a strictly increasing counter has the property the game's poll needs (a later fence reads a
-// larger value). CONFIDENCE: MED — units differ from HW ticks, but monotonicity is what a >= poll checks.
-static uint64_t gpu_clock64() {
-    return (uint64_t)std::chrono::steady_clock::now().time_since_epoch().count();
-}
+// A monotonic 64-bit "GPU clock" for RELEASE_MEM data_sel==3 (GpuClock64). On real hardware the GPU
+// EOP timestamp is the SAME counter the guest reads via sceKernelReadTsc (Kyty: GraphicsRender writes
+// KernelReadTsc() for the EOP timestamp; GetGpuCoreClockFrequency == GetTscFrequency), so we share
+// the guest TSC clock rather than a separate steady_clock (#156). It reports monotonic nanoseconds at
+// the 1 GHz that sceKernelGetTscFrequency advertises, so a guest that reads two fence timestamps and
+// divides the delta by the queried frequency gets real seconds — AND a GPU fence timestamp lies on the
+// same timeline as a CPU sceKernelReadTsc value (the old steady_clock had a disjoint epoch/period).
+extern "C" uint64_t prosper_guest_tsc_ns();   // hle_kernel_time.cpp — same source as sceKernelReadTsc
+static uint64_t gpu_clock64() { return prosper_guest_tsc_ns(); }
 
 // Honor a RELEASE_MEM / EVENT_WRITE_EOP completion write. data_sel (Kyty GraphicsCbReleaseMem allows {2,3};
 // shadPS4 DataSelect enum): 1=write 32-bit value, 2=write 64-bit value, 3=write 64-bit GPU clock. The write

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -68,6 +68,15 @@ HLE(k_get_ptc_freq)   { return 1000000000ull; }            // counter is in ns -
 HLE(k_get_proc_time)  { return ns_now() / 1000; }          // microseconds
 HLE(k_read_tsc)       { return ns_now(); }
 HLE(k_tsc_freq)       { return 1000000000ull; }
+
+// The GPU EOP timestamp (RELEASE_MEM data_sel=3 / an address-carrying EVENT_WRITE) is, on real
+// hardware, the SAME counter the guest reads via sceKernelReadTsc (Kyty: GraphicsRender writes
+// KernelReadTsc() for the EOP timestamp; GetGpuCoreClockFrequency == GetTscFrequency). prosper
+// models that counter as this monotonic-ns clock at 1 GHz (k_tsc_freq). Exposed so the
+// CommandProcessor's gpu_clock64 shares the EXACT clock + epoch (#156) — previously it used a
+// separate steady_clock with a different epoch and an unspecified period, so a guest correlating a
+// GPU fence timestamp with a CPU sceKernelReadTsc value saw two disjoint timelines.
+extern "C" uint64_t prosper_guest_tsc_ns() { return ns_now(); }
 // sceKernelClockGettime / clock_gettime(clockid, struct timespec*). The PS5 inherits FreeBSD's
 // clockid numbering (shadPS4 time.h ORBIS_CLOCK_* == FreeBSD sys/time.h CLOCK_*; Kyty Pthread.cpp
 // KernelClockGettime agrees on 0=REALTIME, 4=MONOTONIC). Previously the id was IGNORED — every

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -12,6 +12,10 @@
 
 using namespace prosper::gpu;
 
+// The guest TSC clock the GPU EOP timestamp shares (hle_kernel_time.cpp) — same source as
+// sceKernelReadTsc, so a GPU fence timestamp and a CPU TSC read lie on one timeline (#156).
+extern "C" uint64_t prosper_guest_tsc_ns();
+
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
@@ -68,6 +72,24 @@ int main() {
         build(b1, (uint64_t)(uintptr_t)&l1); build(b2, (uint64_t)(uintptr_t)&l2);
         GpuState st; run_command_buffer(b1, 7, st); run_command_buffer(b2, 7, st);
         CHECK(l1 != 0 && l2 >= l1, "RELEASE_MEM (data_sel=3) wrote a monotonic non-zero GPU clock");
+    }
+
+    // #156: the GPU EOP timestamp must share the guest TSC timeline (sceKernelReadTsc) — on real
+    // hardware they are the SAME counter. A data_sel=3 fence value must fall between a TSC read
+    // taken just before and just after the submit (the old steady_clock had a disjoint epoch, so
+    // it would land far outside this window).
+    {
+        uint64_t label = 0;
+        uint32_t buf[7];
+        uint64_t addr = (uint64_t)(uintptr_t)&label;
+        buf[0] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        buf[1] = (uint32_t)(addr & 0xffffffffu); buf[2] = (uint32_t)(addr >> 32);
+        buf[3] = 3; buf[4] = 0; buf[5] = 0; buf[6] = 0x04;
+        uint64_t before = prosper_guest_tsc_ns();
+        GpuState st; run_command_buffer(buf, 7, st);
+        uint64_t after = prosper_guest_tsc_ns();
+        CHECK(label >= before && label <= after,
+              "data_sel=3 fence lies on the sceKernelReadTsc timeline (shared guest TSC, not steady_clock)");
     }
 
     // WRITE_DATA: [0]=hdr [1]=dst [2..3]=addr [4]=num_dwords [5..]=data.


### PR DESCRIPTION
## Summary
- `gpu_clock64` (the `data_sel=3` / GpuClock64 fence write) used a private `steady_clock`, whose epoch and period are unrelated to the clock the guest reads via `sceKernelReadTsc`. On real hardware the GPU EOP timestamp **is that same counter** (Kyty: `GraphicsRender` writes `KernelReadTsc()` for the EOP timestamp, and `GetGpuCoreClockFrequency == GetTscFrequency`), so a guest correlating a GPU fence timestamp with a CPU `sceKernelReadTsc` value (GPU/CPU frame pacing, profiling) got **two disjoint timelines**, and a delta between two fence timestamps was in an unspecified unit that only happened to be ns on glibc.
- Share the guest TSC: `hle_kernel_time.cpp` exposes `prosper_guest_tsc_ns()` (the same monotonic-ns source as `sceKernelReadTsc`), and `gpu_clock64` calls it. prosper models this counter at **1 GHz** (`sceKernelGetTscFrequency` already returns `1e9`), so a delta divided by the queried frequency is real seconds, and a fence timestamp now lies on the `sceKernelReadTsc` timeline.

### On the reported frequency
The issue suggested scaling to a fixed PS5 GPU tick rate, but both reference emulators (Kyty, shadPS4) model the GPU timestamp as the **host high-resolution counter** and report **its** frequency via `sceKernelGetTscFrequency` — keeping timestamp and frequency *consistent* rather than pinning an absolute Hz. prosper already reports `1e9`, so the correct fix is to make the GPU timestamp use that same ns clock (done here), not to invent a different absolute rate.

## Verification
- New assertion in `test_eop_write`: a `data_sel=3` fence value falls **between** a `sceKernelReadTsc` read taken just before and just after the submit (the old `steady_clock` epoch landed far outside that window). Monotonicity test retained.
- Full suite in WSL build-linux **including the dump-backed boot: 65/65 passed**.

Fixes #156