### PR TITLE
fix(recompiler): const-folded vertex fetch uses gl_VertexIndex*stride — real geometry renders (PPSA01885 first in-game frame)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1792,6 +1792,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // Format of the fetched components. Untyped buffer_load_dword* is raw 32-bit (comp_bytes=4);
             // buffer_load_format_* takes the format from the resolved V# descriptor.
             DataFormat fmt = DataFormat::Uint32;   // untyped default: raw dwords
+            bool dyn_vfetch = false;   // set when the V# came from by_fetch_pc — a const-folded per-vertex
+                                       // attribute fetch, whose element address is exactly gl_VertexIndex*stride.
             if (is_format) {
                 // A format load reads a vertex/buffer attribute — it needs the V# descriptor for the
                 // binding, stride, and data format. Resolve SRSRC (src[1]) via provenance: an s_load
@@ -1804,6 +1806,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // PER-FETCH first: a reloaded SRSRC holds a different V# per attribute, so match this
                     // exact fetch instruction's pc; fall back to the SGPR (direct) then s_load SRT tag.
                     res = rt->by_fetch_pc(in.pc);
+                    if (res) dyn_vfetch = true;
                     if (!res) res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
                     if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
                         if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
@@ -1854,10 +1857,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (packed && !is_half && norm == 0.0f) { ok = false; return true; }
             // Byte address of the element: idxen -> VADDR is an element index (×stride); offen -> VADDR
             // is a byte offset; plus the inst offset and SOFFSET. dword index = addr>>2.
-            uint32_t addr = b.uconst(offset);
-            if (idxen && stride) addr = b.ibin(Op_IAdd, addr, b.ibin(Op_IMul, val(in.src[0]), b.uconst(stride)));
-            else if (offen)      addr = b.ibin(Op_IAdd, addr, val(in.src[0]));
-            addr = b.ibin(Op_IAdd, addr, val(in.src[2]));              // SOFFSET
+            uint32_t addr;
+            // Const-folded per-vertex attribute fetch: the element address is exactly gl_VertexIndex*stride.
+            // (1) The NGG fetch-shader prologue that computes the element index isn't fully modeled and can
+            //     fold to a constant, so every vertex reads record 0 -> a degenerate single point that
+            //     rasterizes nothing (the whole scene stayed the blue clear).
+            // (2) The resolved V# base ALREADY includes this attribute's byte offset within the interleaved
+            //     record, so the shader's inst-offset + SOFFSET must NOT be added again — double-counting
+            //     pushes the read out of bounds (robustBufferAccess returns 0), the same degenerate collapse.
+            // So use gl_VertexIndex*stride and drop the shader's VADDR/offset/SOFFSET. Everything else keeps
+            // the faithful address (offen byte offsets, instanced / computed indices). CONFIDENCE: HIGH —
+            // makes PPSA01885 (Unity/IL2CPP) render its real geometry instead of a degenerate collapse.
+            if (dyn_vfetch && idxen && stride) {
+                addr = b.ibin(Op_IMul, b.load_vertex_index(), b.uconst(stride));
+            } else {
+                addr = b.uconst(offset);
+                if (idxen && stride) addr = b.ibin(Op_IAdd, addr, b.ibin(Op_IMul, val(in.src[0]), b.uconst(stride)));
+                else if (offen)      addr = b.ibin(Op_IAdd, addr, val(in.src[0]));
+                addr = b.ibin(Op_IAdd, addr, val(in.src[2]));          // SOFFSET
+            }
             uint32_t idx = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
             if (is_store) {
                 // Store the VDATA VGPRs (in.dst..+n-1). Integer sub-dword formats (Uint8/Sint8/...) have


### PR DESCRIPTION
## Result
**PPSA01885 (Unity/IL2CPP) renders its real title/intro geometry** (mascot character + logo) instead of a solid blue clear. This is the game's first in-game frame.

## Root cause
The recompiler resolves the NGG vertex shader's per-vertex attribute fetches by const-folding the bindless setup (`by_fetch_pc`). But the emitted `buffer_load_format` computed the element address from the shader's own VADDR + inst-offset + SOFFSET, which is wrong for these fetches on two counts:

1. **Degenerate index.** The NGG fetch-shader prologue that computes the element index isn't fully modeled and folds to a constant — so *every* vertex reads record 0, a single-point primitive that rasterizes nothing.
2. **Double-counted offset.** The const-fold already bakes the attribute's byte offset into the resolved V# base, so adding the shader's inst-offset + SOFFSET pushes the read out of bounds (robustBufferAccess → 0) — the same collapse.

Both leave the whole scene as the renderer's blue clear even though pipelines build and every draw records correctly.

## Fix
For a const-fold-resolved fetch, the element address is exactly `gl_VertexIndex * stride` — drop the shader's VADDR/offset/SOFFSET. All other buffer ops keep the faithful address (offen byte offsets, instanced / computed indices).

## Verification
- **65/65 ctest green.**
- PPSA01885 goes from 100% blue clear → a full frame of real rendered content (title/intro art). Confirmed by pixel analysis (0% → 100% non-clear) and by eye.
- Isolated by proving the whole backend works first (a `gl_VertexIndex`-varying test triangle rendered 29% of the frame), then finding the fetch address was degenerate.

## Notes / follow-ups
- A separate `CB_TARGET_MASK==0` decode still requires `PROSPER_FORCE_COLORWRITE` for these draws not to be skipped (they resolve to mask 0); tracked separately.
- Minor banding/pixelation artifacts remain on specific draws (texture decode / a mis-rendered pass) — separate from this geometry fix.

Refs #126