### PR TITLE
fix(hle): track the MsgDialog lifecycle — NONE before Open, not spurious FINISHED

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -100,10 +100,19 @@ HLE(s_appcontent_tmpspace) { if (a1) *(uint64_t*)PW(a1) = 1048576ull; return 0; 
 // documented Sony ABI; an empty string is a safe, defined default when we have no real system value.
 HLE(s_param_string)   { if (a1 && a2) ((char*)PW(a1))[0] = '\0'; return 0; }
 
-// Common/message dialogs: report FINISHED immediately so the game's "wait until dismissed" loop
-// exits and it proceeds (we have no interactive dialog UI yet). Status enum: NONE=0, INITIALIZED=1,
-// RUNNING=2, FINISHED=3. GetResult -> zeroed struct = OK/no button pressed.
-HLE(s_dialog_finished) { return 3; }
+// Message-dialog LIFECYCLE (#144). Status enum: NONE=0, INITIALIZED=1, RUNNING=2, FINISHED=3.
+// The old handler returned FINISHED(3) UNCONDITIONALLY — including before any Open, where the real
+// API reports NONE/INITIALIZED — so a guest polling GetStatus as a guard saw "dialog already done"
+// at the wrong stage and skipped/duplicated its dialog logic. We track the real transitions:
+// Initialize -> INITIALIZED, Open -> auto-dismiss to FINISHED (headless: no interactive UI, so the
+// game's "wait until dismissed" loop still exits immediately), Close/Terminate -> back to NONE.
+// GetResult -> zeroed struct = OK/no button pressed.
+namespace { std::atomic<int> g_msgdialog_status{0 /*NONE*/}; }
+HLE(s_dialog_initialize) { g_msgdialog_status.store(1 /*INITIALIZED*/); return 0; }
+HLE(s_dialog_open)       { g_msgdialog_status.store(3 /*FINISHED (auto-dismiss)*/); return 0; }
+HLE(s_dialog_close)      { g_msgdialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_dialog_terminate)  { g_msgdialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_dialog_status)     { return (uint64_t)(unsigned)g_msgdialog_status.load(); }
 // SceMsgDialogResult = { u32 mode; u32 result; u32 buttonId; char reserved[32] } = 0x2C bytes
 // (shadPS4 msgdialog_ui.h DialogResult). Was memset(0x30) — 4 bytes PAST the caller's struct,
 // exactly the f_fstat oversized-write class this file warns about.
@@ -159,11 +168,12 @@ void register_service_hle() {
     R("sceSystemServiceParamGetInt", s_appcontent_int);
     // sceSystemServiceParamGetString (SsC-m-S9JTA): write a valid empty string (not an unfilled buffer).
     Hle::register_fn("SsC-m-S9JTA", (HleFn)s_param_string, "sceSystemServiceParamGetString");
-    // message dialog: auto-dismiss (report FINISHED) so the startup dialog flow completes
-    R("sceMsgDialogInitialize", s_ok);      R("sceMsgDialogTerminate", s_ok);
-    R("sceMsgDialogOpen", s_ok);            R("sceMsgDialogClose", s_ok);
-    R("sceMsgDialogUpdateStatus", s_dialog_finished);
-    R("sceMsgDialogGetStatus", s_dialog_finished);
+    // message dialog: track the Initialize/Open/Close lifecycle (#144) — NONE/INITIALIZED before an
+    // Open, then auto-dismiss to FINISHED so the startup dialog flow still completes headless.
+    R("sceMsgDialogInitialize", s_dialog_initialize);  R("sceMsgDialogTerminate", s_dialog_terminate);
+    R("sceMsgDialogOpen", s_dialog_open);              R("sceMsgDialogClose", s_dialog_close);
+    R("sceMsgDialogUpdateStatus", s_dialog_status);
+    R("sceMsgDialogGetStatus", s_dialog_status);
     R("sceMsgDialogGetResult", s_dialog_result);
     R("sceSystemServiceHideSplashScreen", s_ok);
     R("sceSystemServiceGetStatus", s_syss_getstatus);

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -4,6 +4,7 @@
 // libkernel registration/hook calls must resolve to a benign OK-returning no-op. Registered by raw
 // NID, so this looks them up by NID and exercises the output contract.
 #include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
 
@@ -45,6 +46,30 @@ int main() {
         HleFn fn = Hle::lookup(nid);
         CHECK(fn != nullptr, nid);
         if (fn) CHECK(fn(0, 0, 0, 0, 0, 0) == 0, nid);
+    }
+
+    // Message-dialog lifecycle (#144): GetStatus must report NONE before an Open (the old handler
+    // returned FINISHED unconditionally, so a guest guarding on GetStatus saw "done" at the wrong
+    // stage). Transitions: Initialize -> INITIALIZED(1); Open -> FINISHED(3, auto-dismiss); Close ->
+    // NONE(0). Registered by name; look up the NIDs.
+    {
+        auto init   = Hle::lookup(nid_hash("sceMsgDialogInitialize"));
+        auto open   = Hle::lookup(nid_hash("sceMsgDialogOpen"));
+        auto close  = Hle::lookup(nid_hash("sceMsgDialogClose"));
+        auto status = Hle::lookup(nid_hash("sceMsgDialogGetStatus"));
+        auto upd    = Hle::lookup(nid_hash("sceMsgDialogUpdateStatus"));
+        CHECK(init && open && close && status && upd, "MsgDialog lifecycle functions registered");
+        if (init && open && close && status && upd) {
+            close(0,0,0,0,0,0);   // reset to a known idle state
+            CHECK(status(0,0,0,0,0,0) == 0, "GetStatus before Initialize -> NONE(0) (was FINISHED)");
+            init(0,0,0,0,0,0);
+            CHECK(status(0,0,0,0,0,0) == 1, "after Initialize -> INITIALIZED(1)");
+            CHECK(upd(0,0,0,0,0,0) == 1, "UpdateStatus before Open also reports INITIALIZED, not FINISHED");
+            open(0,0,0,0,0,0);
+            CHECK(status(0,0,0,0,0,0) == 3, "after Open -> FINISHED(3) (auto-dismiss)");
+            close(0,0,0,0,0,0);
+            CHECK(status(0,0,0,0,0,0) == 0, "after Close -> back to NONE(0)");
+        }
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Summary
- `sceMsgDialogUpdateStatus` / `sceMsgDialogGetStatus` returned **FINISHED(3) unconditionally**, including before any Open, where the real API reports NONE/INITIALIZED. A guest polling GetStatus as a guard saw dialog-already-completed at the wrong lifecycle stage and **skipped or duplicated** its dialog logic.
- Track the real 3-state transitions with a small atomic: `Initialize` → INITIALIZED(1); `Open` → FINISHED(3) (headless **auto-dismiss**, so the game's wait-until-dismissed loop still exits immediately); `Close`/`Terminate` → NONE(0). GetStatus/UpdateStatus report the current state.
- The auto-dismiss policy is **unchanged** — only the pre-Open state is fixed (NONE/INITIALIZED instead of FINISHED), exactly as the issue scoped it.

## Verification
- New checks in `test_service_getters`: GetStatus is NONE before Initialize, INITIALIZED after it (also via UpdateStatus), FINISHED after Open, and NONE again after Close.
- Full suite in WSL build-linux **including the dump-backed boot: 65/65 passed** (the startup dialog flow still completes headless).

Fixes #144