### PR TITLE
fix(hle): AGCSHADER dump uses env path + s_endpgm-derived size (#160)

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -16,6 +16,7 @@
 #include "gpu/gpu_execute.hpp"      // guest_readable (safe pointer probe for the diagnostic dumps)
 #include <cstdlib>
 #include <cstring>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <mutex>
@@ -416,10 +417,28 @@ uint64_t glog_impl(const char* nid, void* ra,
         static bool dumped = false;
         if (!dumped && a2 > 0x100000ull) {
             dumped = true;
-            uint64_t sz = (a4 && a4 <= 0x10000) ? a4 : 0x200;   // a4 looks like a size; cap defensively
-            if (FILE* f = fopen("/mnt/c/Users/matti/repos/ps5ys/prosper/build-linux/shader0.bin", "wb")) {
+            // Size: prefer an explicit a4 count; else derive it from the shader's own s_endpgm
+            // terminator (RDNA2 SOPP 0xBF810000) instead of a fixed 0x200 fragment (#160). Scan is
+            // bounded so a bad/short mapping can't run away.
+            uint64_t sz;
+            if (a4 && a4 <= 0x10000) {
+                sz = a4;                                        // a4 is a plausible explicit byte count
+            } else {
+                const uint32_t* w = (const uint32_t*)(uintptr_t)a2;
+                const uint64_t cap = 0x4000 / 4;                // scan up to 16 KiB of dwords
+                uint64_t n = 0;
+                for (; n < cap; n++) if (w[n] == 0xBF810000u) { n++; break; }   // include the s_endpgm dword
+                sz = (n && n < cap) ? n * 4 : 0x2000;           // found -> exact end; else a generous window
+            }
+            // Path from PROSPER_AGCSHADER_OUT (default relative, so it works off this dev's machine);
+            // report an fopen failure instead of silently writing nothing (#160).
+            const char* out = getenv("PROSPER_AGCSHADER_OUT");
+            if (!out || !*out) out = "shader0.bin";
+            if (FILE* f = fopen(out, "wb")) {
                 fwrite((const void*)(uintptr_t)a2, 1, sz, f); fclose(f);
-                fprintf(stderr, "  [wrote shader0.bin: %llu bytes from a2]\n", (unsigned long long)sz);
+                fprintf(stderr, "  [wrote %s: %llu bytes from a2]\n", out, (unsigned long long)sz);
+            } else {
+                fprintf(stderr, "  [PROSPER_AGCSHADER: fopen('%s') failed: %s]\n", out, strerror(errno));
             }
         }
     }


### PR DESCRIPTION
## Problem (#160)

The `PROSPER_AGCSHADER` diagnostic (`hle_graphics.cpp`) dumped the captured shader blob to a **hardcoded absolute developer path** (`/mnt/c/Users/matti/repos/ps5ys/prosper/build-linux/shader0.bin`) — on any other machine `fopen` fails and the `[wrote shader0.bin]` log lies — and **guessed the size** as `a4<=0x10000 ? a4 : 0x200`, truncating the dump to a 0x200 fragment whenever `a4` wasn't the byte count.

## Fix

- **Path** from `PROSPER_AGCSHADER_OUT` (default relative `shader0.bin`, so it works anywhere), and **log the `fopen` failure** (`strerror`) instead of silently writing nothing.
- **Derive the size** from the shader's own `s_endpgm` terminator (RDNA2 SOPP `0xBF810000`), bounded to a 16 KiB scan, instead of the fixed 0x200 fragment. An explicit, plausible `a4` is still preferred when present.

## Scope / risk

Diagnostic-only, `PROSPER_AGCSHADER`-gated — no change to the default path. Full suite **65/65 green**.

Fixes #160