### PR TITLE
fix(hle): APR id-0 pointer-tag completions are per-request/uncoalesced — DOLL frame loop runs (#210)

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -345,6 +345,28 @@ HLE(g_vo_get_output_status) {
     return 0;
 }
 
+// sceVideoOutGetEventId (U2JJtSqNKZI — named via nid_hash brute-force over the libSceVideoOut stub
+// corpus, issue #210): decode which VideoOut event a kevent delivered on a VideoOut equeue is.
+// Contract (Kyty EventQueue.cpp:354 KernelGetEventId = plain ev->ident read; the VideoOut wrapper is
+// the same field read on PS4 — shadPS4 videoout returns ev->ident after a filter check): the kevent's
+// ident IS the event id (FLIP=0, VBLANK=1 — exactly what our flip/vblank posts set). The previous
+// unimplemented-0 return decoded EVERY event (vblank included) as a FLIP: UE4's VideoOut pump thread
+// dispatched vblank ticks into its flip-completion handler and never saw a real vblank tick.
+// SceKernelEvent layout: ident @0 (i64), filter @8 (i16). CONFIDENCE: HIGH (both references agree and
+// the field is ours to define — we post these events).
+HLE(g_vo_get_event_id) {
+    if (!a0) return (uint64_t)(int64_t)(int32_t)0x80290002;   // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    const uint8_t* ev = (const uint8_t*)(uintptr_t)a0;
+    if (*(const int16_t*)(ev + 8) != -13)                     // not a VideoOut-filter kevent
+        return (uint64_t)(int64_t)(int32_t)0x80290011;        // SCE_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE
+    return (uint64_t)*(const int64_t*)ev;                     // ident: FLIP=0 / VBLANK=1 / ...
+}
+
+// sceVideoOutSetWindowModeMargins (MTxxrOCeSig — same brute-force naming): windowed-mode margin
+// hint for the system compositor. No compositor here — accept and ignore. CONFIDENCE: HIGH (pure
+// cosmetic setter; success unblocks the caller).
+HLE(g_vo_set_window_mode_margins) { vo_argtrace("SetWindowModeMargins", a0,a1,a2,a3,a4,a5); return 0; }
+
 // Diagnostic tracer for the (undocumented) libSceAgc / libSceAgcDriver calls: logs the NID, the guest
 // callsite, and all six args (gated on PROSPER_GFXLOG). Behaviour is identical to the unimplemented
 // stub — returns 0, changes no control flow — it is purely observable. This is the RE bootstrap for
@@ -535,6 +557,8 @@ void register_graphics_hle() {
     RN("rKBUtgRrtbk", g_vo_register_buffers2);       // sceVideoOutRegisterBuffers2
     RN("utPrVdxio-8", g_vo_get_output_status);        // sceVideoOutGetOutputStatus
     RN("w0hLuNarQxY", g_vo_configure_output);          // sceVideoOutConfigureOutput
+    RN("U2JJtSqNKZI", g_vo_get_event_id);              // sceVideoOutGetEventId (#210)
+    RN("MTxxrOCeSig", g_vo_set_window_mode_margins);   // sceVideoOutSetWindowModeMargins (#210)
     RN("b0xyllnVY-I", g_gnm_add_eq_event);             // sceGnmAddEqEvent / GraphicsAddEqEvent (GPU EOP)
     #undef R
     #undef RN

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -347,7 +347,7 @@ namespace {
         auto it = g_eqs.find(eq);
         return it == g_eqs.end() ? nullptr : it->second;
     }
-    void eq_post(uint64_t eq, const SceKEvent& e) {
+    void eq_post(uint64_t eq, const SceKEvent& e, bool coalesce = true) {
         auto s = eq_find(eq); if (!s) return;
         std::lock_guard<std::mutex> lk(s->m);
         if (s->deleted) return;
@@ -356,8 +356,12 @@ namespace {
         // 60 Hz vblank pump safe: previously a fixed 4-entry cap dropped the NEWEST event once the
         // queue filled with pumped vblanks — and the dropped one could be the flip-completion event
         // carrying the exact flipArg the game's pacer was waiting to observe (frame-pacing stall).
-        for (auto& q : s->ready)
-            if (q.ident == e.ident && q.filter == e.filter) { q = e; s->cv.notify_all(); return; }
+        // coalesce=false queues a distinct entry instead: the APR pointer-tag channel (#210) needs
+        // EVERY completion delivered — two in-flight completions share (ident, filter) but carry
+        // different request tags in data, and replacing one loses a completion forever.
+        if (coalesce)
+            for (auto& q : s->ready)
+                if (q.ident == e.ident && q.filter == e.filter) { q = e; s->cv.notify_all(); return; }
         // Distinct (ident, filter) pairs are few; the cap is a leak guard only. If it ever fires,
         // shed the OLDEST event — never the just-posted one.
         if (s->ready.size() >= 64) s->ready.pop_front();
@@ -618,6 +622,32 @@ namespace {
 // coalesced knote must never regress the "completed up to" counter (the listener walks
 // last+1..cnt, so the highest counter covers every pending batch on the ring).
 void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
+    // TWO tag dialects share the H896 binding call, discriminated by the binding's id (a2):
+    //   id = 0x74fe+ring (the FAPREventQueueListener channel, #208): tag = (ring<<58)|counter with
+    //     a ctor-seeded dense per-ring counter. The listener range-walks last+1..cnt, so the knote
+    //     coalesces per ring to the HIGHEST counter ("completed up to" — the kqueue semantics the
+    //     walk implements). Handled below with the per-ring HWM.
+    //   id = 0 (the IoDispatcher direct channel, #210 — live capture: H896(cb, ioDispatcherEq,
+    //     id=0, tag=REQUEST POINTER, 0, 7|0xf)): the tag is an opaque per-request pointer, NOT a
+    //     counter. Ring/HWM math on a pointer is nonsense (every post regressed to the max pointer
+    //     ever seen, and eq_post's (ident,filter) coalescing replaced still-pending completions —
+    //     two of the last three in-flight IoDispatcher reads never completed, which is exactly the
+    //     post-first-flip flush-async-loading hang: the packages behind those reads never advanced).
+    //     Post the EXACT tag, one distinct queued event per submit, no coalescing.
+    // CONFIDENCE: HIGH on the discrimination (both dialects live-captured; id 0x7501 tags are
+    // counters, id 0 tags are request pointers in every capture); MED on the id-0 event shape
+    // (ident=id=0 kept, guest consumes via GetEventData like the #208 listener).
+    if (id == 0) {
+        if (evlog()) fprintf(stderr, "[ev] AprPtrTagComplete tag=0x%llx -> eq=0x%llx scheduled\n",
+                             (unsigned long long)token, (unsigned long long)eq);
+        std::thread([eq, id, token] {
+            struct timespec ts{ 0, 2000000 };   // 2 ms (same modeled DMA latency as the #208 path)
+            nanosleep(&ts, nullptr);
+            SceKEvent e{}; e.ident = id; e.filter = EVFILT_AMPR_MODELED; e.data = (int64_t)token;
+            eq_post(eq, e, /*coalesce=*/false);
+        }).detach();
+        return;
+    }
     unsigned ring = (unsigned)(token >> 58) & 0x3f;
     uint64_t cnt = token & ((1ull << 58) - 1);
     {


### PR DESCRIPTION
## Fixes #210 — async-loading flush completes; DOLL runs a stable frame loop (127 flips, no crash)

Follow-on from #208. After the first flip, DOLL's main thread spun in a flush-async-loading lock-poll while every IoDispatcher/IoService/TaskGraph worker parked — no draw work, no progress.

### Root cause — two APR tag dialects share the `H896` binding, one is a per-request pointer
The APR completion path has **two dialects**, discriminated by the binding id (a2):
- `id = 0x74fe+ring` (the `FAPREventQueueListener` channel, #208): tag = `(ring<<58)|counter`, a ctor-seeded dense per-ring counter; the listener range-walks `last+1..cnt`, so the knote **coalesces** per ring to the highest counter.
- `id = 0` (the **IoDispatcher direct channel**, live-captured `H896(cb, ioDispatcherEq, id=0, tag=REQUEST POINTER, 0, 7|0xf)`): the tag is an **opaque per-request pointer**, not a counter. The previous code applied ring/HWM coalescing to it — nonsense on a pointer: every post regressed to the max pointer seen, and `(ident,filter)` coalescing replaced still-pending completions, so two of the last few in-flight IoDispatcher reads never completed → the packages behind them never advanced → the post-first-flip flush hung.

### The fix (`hle_kernel_time.cpp` + `hle_graphics.cpp`)
Discriminate the dialects: `id == 0` posts the **exact tag, one distinct uncoalesced event per submit**; the `0x74fe+ring` counter path keeps its per-ring high-water-mark coalescing. CONFIDENCE: HIGH on the discrimination (both dialects live-captured), MED on the id-0 event shape.

### Verified
- Post-flip flush **completes**; DOLL runs a **stable frame loop: 127 flips / 128 DCB submits over 240 s, no crash** (was: hung spinning at ~70% CPU).
- **ctest 60/60**; Messenger render smoke unregressed.
- Integrated onto current master via cherry-pick (not merge — `8acc1cc` predates the #208 squash on master; a back-merge corrupted the overlapping `hle_kernel_time.cpp` edits and SIGSEGV'd, so the single #210 commit is cherry-picked clean instead).

### Next wall (filed as #213)
**0 draws.** The frame loop flips but submits no scene geometry — the DCBs are AGC control packets (EventWrite/AcquireMem/ReleaseMem), not draws. DOLL is presenting empty frames (loading/black) — the render path is live but the game hasn't begun submitting drawn geometry. Same class as The Messenger's scene-activation gap.
