### PR TITLE
fix(loader): DTPMOD64 resolves a cross-module TLS import to the defining module's id

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -72,6 +72,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_va2foff PRIVATE prosper_core)
   add_test(NAME va2foff_load_priority COMMAND test_va2foff)
 
+  # DTPMOD64 cross-module TLS resolution (#136): a TLS import resolves to the DEFINING module's
+  # tls_modid, not the relocating module's. Pure unit test (synthetic Module/LoadedImage).
+  add_executable(test_dtpmod_tls tests/test_dtpmod_tls.cpp)
+  target_link_libraries(test_dtpmod_tls PRIVATE prosper_core)
+  add_test(NAME dtpmod_tls_cross_module COMMAND test_dtpmod_tls)
+
   # AMD SSE4a INSERTQ/EXTRQ emulation (the SIGILL handler emulates these Zen2-only ops on Intel
   # hosts). Golden bit-math vectors — header-only, no game dump required.
   add_executable(test_sse4a tests/test_sse4a.cpp)

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -77,9 +77,21 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         }
     }
 
+    // --- TLS module-id by exported symbol NID (#136): so a cross-module DTPMOD64 (a TLS symbol
+    // imported from another module) resolves to the DEFINING module's TLS module id, not the
+    // relocating module's. Only TLS-bearing modules (tls_modid != 0) contribute their exported
+    // (defined, non-import) symbols. First definition wins (same rule as the global export table). ---
+    std::unordered_map<std::string, uint32_t> tls_modid_by_nid;
+    for (size_t i = 0; i < out.mods.size(); i++) {
+        uint32_t mid = out.imgs[i].tls_modid;
+        if (!mid) continue;
+        for (auto& s : out.mods[i]->symbols)
+            if (!s.is_import && !s.nid.empty()) tls_modid_by_nid.emplace(s.nid, mid);
+    }
+
     // --- Pass 3: apply relocations now that all import addresses are known. ---
     for (size_t i = 0; i < out.mods.size(); i++)
-        apply_relocations(*out.mods[i], out.imgs[i]);
+        apply_relocations(*out.mods[i], out.imgs[i], &tls_modid_by_nid);
 
     // --- Collect init functions for dependent modules (module 0 = main exe runs its
     // own ctors via _start; PRX modules need their init_array run by the loader). We run

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -247,7 +247,8 @@ void bind_imports_to_stubs(const Module& m, LoadedImage& img, uint64_t stub_base
         img.import_addr[m.imports[i].sym_index] = stub_base + i * stub_size;
 }
 
-size_t apply_relocations(const Module& m, LoadedImage& img) {
+size_t apply_relocations(const Module& m, LoadedImage& img,
+                         const std::unordered_map<std::string, uint32_t>* tls_modid_by_nid) {
     size_t applied = 0;
     auto write64 = [&](uint64_t va, uint64_t val) -> bool {
         uint8_t* p = img.at(va);
@@ -271,12 +272,31 @@ size_t apply_relocations(const Module& m, LoadedImage& img) {
             case R_X86_64_JUMP_SLOT:  if (write64(va, sym_addr(r.sym))) applied++; break;
             // TLS (general-dynamic model, used by .prx shared libs like libc.prx). A GOT
             // tls_index{module_id, offset} pair is patched by DTPMOD64 + DTPOFF64; the guest then
-            // calls __tls_get_addr(tls_index*) which our HLE resolves to a per-thread block. We
-            // resolve the module id to THIS module's assigned id (correct for module-local TLS,
-            // which is the common case for libc's own errno/locale state); a cross-module TLS ref
-            // (import symbol) would need the defining module's id — logged as unhandled if it ever
-            // appears. DTPOFF64 = the TLS symbol's offset within its module's TLS block.
-            case R_X86_64_DTPMOD64:  if (write64(va, img.tls_modid)) applied++; break;
+            // calls __tls_get_addr(tls_index*) which our HLE resolves to a per-thread block. For a
+            // module-LOCAL TLS symbol the module id is THIS module's assigned id (the common case:
+            // libc's own errno/locale state). A cross-module TLS ref (an IMPORT symbol defined in
+            // another module) needs the DEFINING module's id — resolved via tls_modid_by_nid when
+            // the linker supplies it (#136), else logged unhandled with a best-effort local fallback
+            // (previously it silently used the wrong module's id). DTPOFF64 = offset within the block.
+            case R_X86_64_DTPMOD64: {
+                uint32_t modid = img.tls_modid;
+                if (r.sym && r.sym < m.symbols.size() && m.symbols[r.sym].is_import) {
+                    bool resolved = false;
+                    if (tls_modid_by_nid) {
+                        auto it = tls_modid_by_nid->find(m.symbols[r.sym].nid);
+                        if (it != tls_modid_by_nid->end()) { modid = it->second; resolved = true; }
+                    }
+                    if (!resolved) {
+                        unhandled[r.type]++;
+                        if (getenv("PROSPER_RELOC_HISTO"))
+                            fprintf(stderr, "[reloc]   DTPMOD64 cross-module TLS import '%s' unresolved "
+                                    "-> best-effort local modid %u\n",
+                                    m.symbols[r.sym].nid.c_str(), modid);
+                    }
+                }
+                if (write64(va, modid)) applied++;
+                break;
+            }
             case R_X86_64_DTPOFF64: {
                 // psABI: DTPOFF64 = S + A. The addend addresses a field INSIDE the TLS object
                 // (e.g. a struct member); picking S *or* A drops it and resolves to the object base.

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <optional>
 
 namespace prosper {
@@ -119,6 +120,11 @@ void bind_imports_to_stubs(const Module& m, LoadedImage& img,
 
 // Apply all relocations into img.mem. Symbol relocs use img.import_addr for imports
 // and the module's own symbol values for internal defs. Returns #applied.
-size_t apply_relocations(const Module& m, LoadedImage& img);
+// `tls_modid_by_nid` (optional) maps an exported symbol's NID to its defining module's TLS module
+// id, so a cross-module DTPMOD64 (a TLS reference imported from another module) resolves to the
+// RIGHT module's TLS block instead of this one's (#136). Null -> module-local resolution only
+// (correct for the common case; a cross-module TLS import is then logged unhandled).
+size_t apply_relocations(const Module& m, LoadedImage& img,
+                         const std::unordered_map<std::string, uint32_t>* tls_modid_by_nid = nullptr);
 
 } // namespace prosper

--- a/prosper/tests/test_dtpmod_tls.cpp
+++ b/prosper/tests/test_dtpmod_tls.cpp
@@ -1,0 +1,71 @@
+// test_dtpmod_tls — DTPMOD64 must resolve a cross-module TLS reference to the DEFINING module's
+// TLS module id, not the relocating module's (#136). A module-local TLS symbol keeps this module's
+// id. Builds synthetic Module + LoadedImage (no game dump) and drives apply_relocations directly.
+#include "../src/self/module.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <unordered_map>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static uint64_t rd64(const LoadedImage& img, uint64_t off) {
+    uint64_t v = 0; std::memcpy(&v, img.mem.data() + off, 8); return v;
+}
+
+int main() {
+    printf("== test_dtpmod_tls ==\n");
+
+    // Module with TLS assigned id 5; symbol[1] is a cross-module TLS IMPORT (nid "TLSX"),
+    // symbol[2] is a module-local TLS def. Two DTPMOD64 relocs, one per symbol.
+    Module m;
+    m.symbols.resize(3);
+    m.symbols[1].nid = "TLSX"; m.symbols[1].is_import = true;  m.symbols[1].value = 0;
+    m.symbols[2].nid = "local"; m.symbols[2].is_import = false; m.symbols[2].value = 0x40;
+    m.relocs.push_back({ /*offset*/ 0x00, R_X86_64_DTPMOD64, /*sym*/ 1, /*addend*/ 0, false });
+    m.relocs.push_back({ /*offset*/ 0x08, R_X86_64_DTPMOD64, /*sym*/ 2, /*addend*/ 0, false });
+
+    auto make_img = [&]() {
+        LoadedImage img;
+        img.base = 0; img.min_vaddr = 0; img.max_vaddr = 0x100;
+        img.mem.assign(0x100, 0);
+        img.tls_modid = 5;   // THIS module's TLS id
+        return img;
+    };
+
+    // 1. WITH the resolver map: the import "TLSX" is defined by module id 9.
+    {
+        std::unordered_map<std::string, uint32_t> tls_by_nid{ {"TLSX", 9} };
+        LoadedImage img = make_img();
+        size_t applied = apply_relocations(m, img, &tls_by_nid);
+        CHECK(applied == 2, "both DTPMOD64 relocs applied");
+        CHECK(rd64(img, 0x00) == 9, "cross-module TLS import resolves to the DEFINING module id (9), not 5");
+        CHECK(rd64(img, 0x08) == 5, "module-local TLS resolves to this module's id (5)");
+    }
+
+    // 2. WITHOUT a resolver (the old behavior / a table-less caller): the import can't be resolved,
+    //    so it falls back to the local id AND is counted unhandled — no longer a silent mis-resolve.
+    {
+        LoadedImage img = make_img();
+        size_t applied = apply_relocations(m, img, /*tls_modid_by_nid*/ nullptr);
+        CHECK(rd64(img, 0x00) == 5, "no resolver: cross-module import falls back to local id (documented)");
+        CHECK(rd64(img, 0x08) == 5, "no resolver: module-local TLS still resolves to the local id");
+        (void)applied;
+    }
+
+    // 3. An unknown import (not in the map) also falls back + logs, never mis-resolves silently.
+    {
+        std::unordered_map<std::string, uint32_t> tls_by_nid{ {"OTHER", 7} };
+        LoadedImage img = make_img();
+        apply_relocations(m, img, &tls_by_nid);
+        CHECK(rd64(img, 0x00) == 5, "import absent from the map falls back to the local id");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- `R_X86_64_DTPMOD64` unconditionally wrote the **relocating** module's own `tls_modid` without checking whether the symbol was an import. The comment claimed a cross-module TLS reference would be logged as unhandled, but **no such check existed** — a TLS symbol imported from another module silently resolved to the **wrong** module's TLS block (a later `__tls_get_addr` then handed back the wrong per-thread storage).
- The linker builds a `NID -> tls_modid` map from every TLS-bearing module's exported symbols and passes it to `apply_relocations`.
- `DTPMOD64` now resolves an **import** symbol via that map (the **defining** module's id); a module-local symbol keeps this module's id, unchanged.
- When the import can't be resolved (no map, or absent from it) it is **counted unhandled and logged** under `PROSPER_RELOC_HISTO` — making the old comment true — with a documented best-effort local-id fallback instead of a silent mis-resolve.

## Verification
- New pure test `test_dtpmod_tls` (synthetic `Module`/`LoadedImage`, no game dump): a cross-module TLS import resolves to the **defining module id (9)** with the map and falls back to the local id (5, logged) without it, while a module-local TLS symbol always resolves to 5.
- Full suite in WSL build-linux **including the dump-backed boot: 66/66 passed** (the boot relocates libc.prx's real TLS through this path — behavior unchanged for the module-local common case).

Fixes #136