### PR TITLE
fix(host): guest static-TLS layout uses each module's real PT_TLS p_align

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -72,6 +72,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_va2foff PRIVATE prosper_core)
   add_test(NAME va2foff_load_priority COMMAND test_va2foff)
 
+  # Guest static-TLS Variant II layout uses each module's real PT_TLS p_align (#143). The layout
+  # code is Linux-only (guest %fs), so gate the test on it too.
+  if(UNIX AND NOT APPLE)
+    add_executable(test_guest_tls_align tests/test_guest_tls_align.cpp)
+    target_link_libraries(test_guest_tls_align PRIVATE prosper_core)
+    add_test(NAME guest_tls_align COMMAND test_guest_tls_align)
+  endif()
+
   # AMD SSE4a INSERTQ/EXTRQ emulation (the SIGILL handler emulates these Zen2-only ops on Intel
   # hosts). Golden bit-math vectors — header-only, no game dump required.
   add_executable(test_sse4a tests/test_sse4a.cpp)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -76,8 +76,10 @@ void set_exc_raise_counter(volatile int* counter);
 void set_gfx_call_counter(volatile int* counter);
 // Per-module TLS template for the general-dynamic model (see linker.cpp / __tls_get_addr).
 // init_va = mapped tdata (guest==host addr); a per-thread block of memsz is allocated lazily,
-// filesz bytes copied from init_va, the rest zeroed. Indexed by module TLS id.
-struct TlsModuleDesc { uint64_t init_va = 0, filesz = 0, memsz = 0; };
+// filesz bytes copied from init_va, the rest zeroed. `align` is the module's PT_TLS p_align — the
+// static-TLS layout must round each module's offset to it so an x86-64 Variant II initial-exec
+// %fs:-N access lands where the guest static linker compiled it (#143). Indexed by module TLS id.
+struct TlsModuleDesc { uint64_t init_va = 0, filesz = 0, memsz = 0, align = 0; };
 // Install the TLS templates (call AFTER images are mapped, so init_va is readable). Enables the
 // __tls_get_addr HLE to serve real per-thread TLS blocks for loaded modules (e.g. real libc.prx).
 void set_tls_modules(const TlsModuleDesc* descs, size_t count);
@@ -101,6 +103,10 @@ uint64_t guest_tls_activate_thread();   // per guest thread at entry; returns gu
 void guest_fs_enter_host_for_signal();  // crash-signal-handler entry: swap guest %fs -> host %fs (no-op if not guest TCB)
 uint64_t guest_fs_to_host_scoped();     // diagnostic handler (returns to guest): swap to host %fs, return prev fs
 void guest_fs_restore_scoped(uint64_t prev_fs);  // restore the fs returned by guest_fs_to_host_scoped
+// Diagnostic (test): the Variant II static-TLS distance below the thread pointer for module id
+// `modid`, and the total below TP — verifies the per-module PT_TLS p_align layout (#143). Linux-only.
+uint64_t guest_tls_module_below(uint32_t modid);
+uint64_t guest_tls_total_below();
 
 // Per-module info for C++ exception unwinding (sceKernelGetModuleInfoForUnwind). The guest's libunwind
 // asks, for a code address, where that module's .eh_frame_hdr / text segment live. `lo/hi` is the module's

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -57,7 +57,7 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
 
     set_app0_root(d);
     for (auto& img : p.imgs) if (!map_image(img, &e)) return fail("map failed: " + e);
-    { std::vector<TlsModuleDesc> td; for (auto& t : p.tls_templates) td.push_back({t.init_va, t.filesz, t.memsz});
+    { std::vector<TlsModuleDesc> td; for (auto& t : p.tls_templates) td.push_back({t.init_va, t.filesz, t.memsz, t.align});
       set_tls_modules(td.data(), td.size());              // __tls_get_addr for loaded modules (real libc.prx)
       guest_tls_set_templates(td.data(), td.size()); }    // gated PROSPER_GUEST_FS: guest initial-exec %fs TLS
 

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -22,11 +22,12 @@ namespace prosper {
 
 namespace {
     std::vector<TlsModuleDesc> g_mods;   // index 0 reserved; 1 = main exe (eboot), then deps
+    std::vector<uint64_t> g_below;       // per-module distance below TP (parallel to g_mods; [0] unused)
     uint64_t g_total_below = 0;          // bytes of static TLS below the thread pointer
     bool     g_enabled = false;
     bool     g_configured = false;
 
-    inline uint64_t align_up(uint64_t v, uint64_t a) { return (v + a - 1) & ~(a - 1); }
+    inline uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
     inline uint64_t rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
     inline void     wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
 }
@@ -42,11 +43,26 @@ static constexpr uint32_t TCB_MAGIC       = 0x50524F53u;  // "PROS" — marks OU
 void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
     g_enabled = getenv("PROSPER_GUEST_FS") != nullptr;
     g_mods.assign(descs, descs + count);
-    // Variant II: sum each module's aligned static-TLS size. Module 1 (main exe) ends up closest to TP.
-    g_total_below = 0;
-    for (size_t i = 1; i < g_mods.size(); i++)
-        g_total_below += align_up(g_mods[i].memsz, 16);
-    g_total_below = align_up(g_total_below, 64);
+    // x86-64 Variant II static-TLS layout (glibc _dl_determine_tlsoffset, TLS_TCB_AT_TP): each
+    // module's block sits BELOW the thread pointer at a distance rounded to that module's REAL
+    // PT_TLS p_align — off[i] = round_up(off[i-1] + memsz[i], align[i]) — so its start (TP - off[i])
+    // is p_align-aligned and a symbol at byte X reads at %fs:(X - off[i]), exactly the tpoff the
+    // guest static linker baked into its initial-exec accesses. The old code rounded each module's
+    // SIZE to a hardcoded 16 (and the total to 64), which for a module with p_align > 16 placed the
+    // block at the wrong offset -> every %fs:-N read resolved off (#143). For the common p_align<=16
+    // case the per-module offsets are identical to before (round_up up a 16-multiple running total by
+    // 16 == the old per-size rounding), so nothing changes there.
+    g_below.assign(g_mods.size(), 0);
+    uint64_t off = 0, max_align = 16;
+    for (size_t i = 1; i < g_mods.size(); i++) {
+        uint64_t a = g_mods[i].align ? g_mods[i].align : 16;
+        if (a > max_align) max_align = a;
+        off = align_up(off + g_mods[i].memsz, a);
+        g_below[i] = off;
+    }
+    // Round the total (hence the TP position within the page-aligned block) up to the max module
+    // align, with a 64-byte floor preserved from the original (TCB/cache-line headroom).
+    g_total_below = align_up(off, max_align < 64 ? 64 : max_align);
     g_configured = true;
     if (getenv("PROSPER_TLSLOG"))
         fprintf(stderr, "[tls] guest-fs %s; static TLS below TP = 0x%llx bytes\n",
@@ -67,13 +83,11 @@ uint64_t guest_tls_activate_thread() {
     if (block == MAP_FAILED) return 0;
     memset(block, 0, total);                    // tbss + TCB start zeroed
     uint64_t tp = (uint64_t)block + g_total_below;
-    // Lay each module's TLS below TP, main exe (module 1) closest. Copy tdata (filesz), leave tbss zero.
-    uint64_t off = 0;
+    // Lay each module's TLS below TP at the precomputed Variant II offset (#143). Copy tdata (filesz),
+    // leave tbss zero. g_below[i] is the module's distance below TP, so its block start is tp-g_below[i].
     for (size_t i = 1; i < g_mods.size(); i++) {
-        uint64_t sz = align_up(g_mods[i].memsz, 16);
-        off += sz;
         if (g_mods[i].filesz && g_mods[i].init_va)
-            memcpy((void*)(tp - off), (const void*)(uintptr_t)g_mods[i].init_va, g_mods[i].filesz);
+            memcpy((void*)(tp - g_below[i]), (const void*)(uintptr_t)g_mods[i].init_va, g_mods[i].filesz);
     }
     *(uint64_t*)(tp + 0)          = tp;         // TCB self-pointer
     *(uint64_t*)(tp + HOSTFS_OFF) = host_fs;    // stash for the stub swap-back
@@ -115,6 +129,13 @@ uint64_t guest_fs_to_host_scoped() {
     return 0;
 }
 void guest_fs_restore_scoped(uint64_t prev_fs) { if (prev_fs) wr_fsbase(prev_fs); }
+
+// Diagnostic/test accessors for the Variant II static-TLS layout (#143): the distance below the
+// thread pointer at which module `modid`'s block starts (0 if out of range), and the total static
+// TLS below TP. Computed by guest_tls_set_templates regardless of the PROSPER_GUEST_FS gate, so a
+// test can verify the per-module p_align offsets without wrfsbase / an enabled guest-fs.
+uint64_t guest_tls_module_below(uint32_t modid) { return modid < g_below.size() ? g_below[modid] : 0; }
+uint64_t guest_tls_total_below() { return g_total_below; }
 
 } // namespace prosper
 #endif

--- a/prosper/tests/test_guest_tls_align.cpp
+++ b/prosper/tests/test_guest_tls_align.cpp
@@ -1,0 +1,61 @@
+// test_guest_tls_align — the x86-64 Variant II static-TLS layout must round each module's offset to
+// its REAL PT_TLS p_align (#143), not a hardcoded 16. Otherwise a module with p_align > 16 gets its
+// block at the wrong distance below the thread pointer and every initial-exec %fs:-N access resolves
+// off. Drives guest_tls_set_templates (which computes the layout regardless of the PROSPER_GUEST_FS
+// gate) and reads back the per-module offsets. Linux-only (the layout code is __linux__).
+#include "../src/hle/dispatch.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static uint64_t align_up(uint64_t v, uint64_t a) { return (v + a - 1) & ~(a - 1); }
+
+int main() {
+    printf("== test_guest_tls_align ==\n");
+
+    // descs[0] is the reserved slot (module id 0 = "no TLS"); real modules start at index 1.
+    // Module 1: memsz 0x30, p_align 64 (aligned TLS vars — the case the old 16-hardcode broke).
+    // Module 2: memsz 0x10, p_align 16.
+    std::vector<TlsModuleDesc> descs = {
+        { 0, 0, 0, 0 },
+        { /*init_va*/0, /*filesz*/0, /*memsz*/0x30, /*align*/64 },
+        { 0, 0, /*memsz*/0x10, /*align*/16 },
+    };
+    guest_tls_set_templates(descs.data(), descs.size());
+
+    // Variant II: off[i] = round_up(off[i-1] + memsz[i], align[i]); block start = TP - off[i].
+    uint64_t exp1 = align_up(0 + 0x30, 64);          // = 0x40 (rounded to 64, NOT 0x30)
+    uint64_t exp2 = align_up(exp1 + 0x10, 16);       // = 0x50
+    CHECK(guest_tls_module_below(1) == exp1, "module 1 offset rounds to its real p_align 64 (0x40, was 0x30)");
+    CHECK(guest_tls_module_below(2) == exp2, "module 2 offset accumulates from module 1 (0x50)");
+    CHECK(guest_tls_module_below(1) != 0x30, "the old 16-byte rounding (0x30) is NOT used for p_align 64");
+    // TP must be aligned to the max module align (64 here), so the total is >= exp2 rounded to 64.
+    CHECK(guest_tls_total_below() >= exp2 && (guest_tls_total_below() % 64) == 0,
+          "total below TP is a multiple of the max module align (64)");
+
+    // Regression: the common p_align <= 16 case is byte-identical to the old per-size rounding
+    // (round_up of a 16-multiple running total by 16 == summing round_up(memsz,16)).
+    std::vector<TlsModuleDesc> descs16 = {
+        { 0, 0, 0, 0 },
+        { 0, 0, 0x08, 16 },
+        { 0, 0, 0x14, 16 },
+    };
+    guest_tls_set_templates(descs16.data(), descs16.size());
+    CHECK(guest_tls_module_below(1) == align_up(0x08, 16),                      "p_align16 module 1 == round_up(0x08,16)=0x10");
+    CHECK(guest_tls_module_below(2) == align_up(0x10 + 0x14, 16),               "p_align16 module 2 == 0x30 (accumulated)");
+
+    // A zero align field falls back to 16 (defensive — a module with p_align 0/1 is treated as 16).
+    std::vector<TlsModuleDesc> descs0 = { { 0, 0, 0, 0 }, { 0, 0, 0x10, 0 } };
+    guest_tls_set_templates(descs0.data(), descs0.size());
+    CHECK(guest_tls_module_below(1) == 0x10, "zero p_align falls back to 16-byte rounding");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- The x86-64 **Variant II** static-TLS layout hardcoded a 16-byte per-module alignment (and 64 for the total) instead of each module's real `PT_TLS` `p_align`. A module whose TLS segment has `p_align > 16` got its block at a different distance below the thread pointer than the guest static linker baked into its initial-exec `%fs:-N` accesses → every such read resolved off (garbage/corruption).
- `TlsModuleDesc` now carries `align`; `boot_program` threads it from the linker's `TlsTemplate` (already decoded from `p_align`).
- `guest_tls` computes the glibc `_dl_determine_tlsoffset` formula with the **real per-module align**: `off[i] = round_up(off[i-1] + memsz[i], align[i])`; the block start (`TP - off[i]`) is then `p_align`-aligned and a symbol at byte X reads at `%fs:(X - off[i])`. The total below TP rounds to the max module align (64-byte floor preserved). Offsets are precomputed once (`g_below`) so set_templates and activate_thread can't drift.

**No regression for the common case:** for `p_align <= 16` the per-module offsets are **byte-identical** to before (round_up of a 16-multiple running total by 16 == the old per-size rounding), so the default boot is unaffected.

## Verification
- New Linux test `test_guest_tls_align`: a module with `p_align 64` lands at offset `0x40` (not the old `0x30`); `p_align`-16 modules match the old layout exactly; zero `p_align` falls back to 16; the total is a multiple of the max module align.
- Full suite in WSL build-linux **including the dump-backed boot: 66/66 passed**.

Fixes #143