### PR TITLE
fix(hle): sceKernelLoadStartModule returns ENOENT for a path not in the linked set

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -10,6 +10,7 @@
 #include "../host/exec_image.hpp"
 #include <pthread.h>
 #include <cerrno>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -837,6 +838,15 @@ namespace {
         for (const char* c = p; *c; c++) if (*c == '/' || *c == '\\') b = c + 1;
         return b;
     }
+    // Case-INSENSITIVE basename compare: the guest's runtime sceKernelLoadStartModule path can differ
+    // in case from the linker's preload path (observed: the Messenger loads "Il2CppUserAssemblies.prx"
+    // but the module is preloaded as "Il2cppUserAssemblies.prx"), and PS5 module paths are effectively
+    // case-insensitive. Without this the game's own PRX miss the match and — with #146's ENOENT — the
+    // load fails, so IL2CPP never bootstraps.
+    inline bool ieq(const char* a, const char* b) {
+        for (; *a && *b; a++, b++) if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) return false;
+        return *a == *b;
+    }
 }
 void set_module_exports(const std::unordered_map<std::string, uint64_t>* exports) { g_exports = exports; }
 void set_module_export_tables(std::vector<ModuleExportTable> tables) { g_mod_exports = std::move(tables); }
@@ -844,7 +854,7 @@ uint64_t module_handle_for_path(const char* path) {
     if (!path || !*path) return 0;
     const char* want = path_basename(path);
     for (size_t i = 0; i < g_mod_exports.size(); i++)
-        if (strcmp(path_basename(g_mod_exports[i].path.c_str()), want) == 0)
+        if (ieq(path_basename(g_mod_exports[i].path.c_str()), want))
             return kModuleHandleBase + i;
     return 0;
 }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -35,7 +35,6 @@ namespace {
     using clk = std::chrono::steady_clock;
     clk::time_point g_start = clk::now();
     uint64_t ns_now() { return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(clk::now() - g_start).count(); }
-    std::atomic<uint64_t> g_module_handle{1};
 
     // --- Wall-clock anchor (#92). The host real-time clock is sampled ONCE, paired with the
     // monotonic ns_now() at the same instant; every wall-clock surface (CLOCK_REALTIME,
@@ -241,13 +240,19 @@ HLE(k_nanosleep){ if (a0) nanosleep((const struct timespec*)P(a0), a1 ? (struct 
 
 // --- assorted libkernel stubs ---
 HLE(k_ok)              { return 0; }                       // generic success no-op
-// sceKernelLoadStartModule(path, ...): the PRX are pre-linked into our address space, so
-// "loading" resolves the path to its linked module and returns a REAL handle — dlsym then
-// consults that module's own exports first (#147). An unknown path still gets the synthetic
-// success counter (that behavior is #146's scope) so optional plugins don't fail the boot.
+// sceKernelLoadStartModule(path, ...): the PRX are pre-linked into our address space, so "loading"
+// resolves the path to its linked module and returns a REAL handle — dlsym then consults that
+// module's own exports first (#147). A path NOT in the linked set previously got a fake
+// monotonically-increasing success handle while loading nothing (#146): the guest then believed the
+// load succeeded and called exports that resolved to ESRCH fallbacks / the wrong module instead of
+// getting the honest ENOENT. Return SCE_KERNEL_ERROR_ENOENT for a miss so the guest takes its
+// module-not-found path. Both current titles preload every PRX they use, so no real load misses.
 HLE(k_load_start_mod)  {
     if (uint64_t h = module_handle_for_path(a0 ? (const char*)P(a0) : nullptr)) return h;
-    return g_module_handle++;
+    if (getenv("PROSPER_MODLOG"))
+        fprintf(stderr, "[loadmod] '%s' not in the linked module set -> ENOENT\n",
+                a0 ? (const char*)P(a0) : "(null)");
+    return 0x80020002ull;   // SCE_KERNEL_ERROR_ENOENT (a non-preloaded PRX isn't present)
 }
 
 // _exit(status): terminate the process. Previously an unimplemented stub RETURNED 0, so libc's

--- a/prosper/tests/test_boot_linux.cpp
+++ b/prosper/tests/test_boot_linux.cpp
@@ -35,6 +35,14 @@ int main(int argc, char** argv) {
     printf("  linked %zu modules: %zu imports (%zu cross-module, %zu stubbed / %zu slots)\n",
            prog.mods.size(), prog.total_imports, prog.resolved_cross_module, prog.stubbed, prog.slots.size());
 
+    // Register the linked module set so sceKernelLoadStartModule resolves the game's OWN runtime
+    // PRX loads to real handles (#146/#147) — the guest LoadStartModule's its preloaded Il2Cpp/
+    // PS5Util modules, which must succeed for IL2CPP to bootstrap. Mirrors boot_program.cpp.
+    set_module_exports(&prog.exports);
+    { std::vector<ModuleExportTable> mt;
+      for (const auto& me : prog.mod_exports) mt.push_back({ me.path, &me.nids });
+      set_module_export_tables(std::move(mt)); }
+
     register_builtin_hle();
     set_app0_root(dump);                        // guest "/app0" -> the game dump directory
     for (auto& img : prog.imgs)

--- a/prosper/tests/test_dlsym_handle.cpp
+++ b/prosper/tests/test_dlsym_handle.cpp
@@ -1,8 +1,8 @@
 // test_dlsym_handle — sceKernelDlsym must honor its MODULE HANDLE (#147). Two modules exporting
 // the same NID: a lookup against the second module's handle must return the SECOND's address —
 // the old global first-definition-wins table aliased it to the first (wrong plugin initialized).
-// LoadStartModule resolves a linked-module path (basename match) to a real handle; unknown paths
-// keep the synthetic success counter (#146's scope), which falls back to the global table.
+// LoadStartModule resolves a linked-module path (basename match) to a real handle; an unknown path
+// returns ENOENT (#146) — dlsym against a non-module handle still falls back to the global table.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <cstdio>
@@ -40,6 +40,11 @@ int main() {
     uint64_t hB = load(U("/app0/sce_module/B.prx"), 0, 0, 0, 0, 0);
     CHECK(hA >= 0x10000 && hB >= 0x10000 && hA != hB,
           "linked-module paths resolve to real, distinct handles (basename match)");
+    // Case-INSENSITIVE basename match (#146): the guest's runtime path can differ in case from the
+    // preload path (the Messenger loads "Il2CppUserAssemblies.prx" vs preloaded "Il2cpp..."). A
+    // different-case load of A.prx must resolve to the SAME real handle, not ENOENT.
+    CHECK(load(U("/app0/other/a.PRX"), 0, 0, 0, 0, 0) == hA,
+          "different-case basename resolves to the same module handle (case-insensitive)");
 
     uint64_t addr = 0;
     CHECK(dlsym(hA, U("PSN_PrxInitialize"), U(&addr), 0, 0, 0) == 0 && addr == 0x1111,
@@ -53,12 +58,15 @@ int main() {
     CHECK(dlsym(hB, U("OnlyInA"), U(&addr), 0, 0, 0) == 0 && addr == 0xAAAA,
           "dlsym(handle B, symbol only in A) falls back to the global table");
 
-    // Unknown path -> synthetic handle (below the real-handle range) -> global resolution.
+    // Unknown path -> ENOENT (#146): a PRX not in the linked set isn't present, so LoadStartModule
+    // reports module-not-found instead of a fake success handle that loads nothing.
     uint64_t hX = load(U("/app0/sce_module/NotLinked.prx"), 0, 0, 0, 0, 0);
-    CHECK(hX > 0 && hX < 0x10000, "unknown path keeps the synthetic success handle");
+    CHECK(hX == 0x80020002ull, "unknown path -> SCE_KERNEL_ERROR_ENOENT (not a fake success handle)");
+    // A dlsym against a non-module handle (0, or the ENOENT value) still falls back to the global
+    // export table — the PSN.prx / UnityPluginLoad by-name path is unaffected.
     addr = 0;
-    CHECK(dlsym(hX, U("PSN_PrxInitialize"), U(&addr), 0, 0, 0) == 0 && addr == 0x1111,
-          "dlsym(synthetic handle) resolves via the global table");
+    CHECK(dlsym(0, U("PSN_PrxInitialize"), U(&addr), 0, 0, 0) == 0 && addr == 0x1111,
+          "dlsym(non-module handle) resolves via the global table");
 
     // Unknown symbol: ESRCH, out param untouched (callers pre-seed a fallback).
     addr = 0xFEED;


### PR DESCRIPTION
## Summary
- `LoadStartModule` returned a monotonically-increasing **fake success handle for any path**, loading nothing. A title runtime-loading a PRX not in the preload list believed the load succeeded, then called exports that resolved to ESRCH fallbacks / the wrong module instead of getting the honest ENOENT.
- Return `SCE_KERNEL_ERROR_ENOENT` for a genuine miss.
- Removing the fake-success fallback **surfaced two latent gaps it had been masking** for the game's *own* preloaded PRX (the Messenger runtime-`LoadStartModule`'s its Il2Cpp/PS5Util modules) — both fixed here so those loads resolve to real handles instead of newly-honest ENOENT:
  - `module_handle_for_path` now matches the basename **case-insensitively**: the guest loads `Il2CppUserAssemblies.prx` but the module is preloaded as `Il2cppUserAssemblies.prx` (PS5 paths are effectively case-insensitive).
  - `test_boot_linux` now registers the module export tables (it links directly, bypassing `boot_program`), so the deep boot actually exercises the real-handle path instead of relying on fake success.

## Verification
- **Caught a real boot regression** from the naive ENOENT-for-misses (the game's own PRX started missing) and fixed the root cause — the dump-backed boot now reaches **IL2CPP + GC stop-the-world + graphics init (2 GC raises)**, and a truly-non-preloaded path returns ENOENT.
- `test_dlsym_handle` covers the case-insensitive match + the ENOENT-for-unknown-path contract.
- Full suite in WSL build-linux **including the dump-backed boot: 66/66 passed**.

Fixes #146