### PR TITLE
diag(agc): surface an unconfirmed GetDataPacketPayloadAddress packet type loudly

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -22,6 +22,7 @@
 #include <unordered_set>
 #include <vector>
 #include <mutex>
+#include <atomic>
 
 namespace prosper {
 
@@ -523,14 +524,25 @@ static_assert(offsetof(AgcShaderSpecialRegs, vgt_gs_out_prim_type) == 0x20, "spe
 
 // sceAgcGetDataPacketPayloadAddress (V++UgBtQhn0) — called from INSIDE eboot's static AGC code
 // (register-bank prepare, eboot+0x3af040 path, callsite +0x3af170): resolve a data packet built in
-// the Dcb to its payload address, which becomes the register bank. Kyty: *addr = cmd + 2 (2-dword
-// packet header), type must be 1. We accept other types with a log instead of aborting.
+// the Dcb to its payload address, which becomes the register bank the guest reads/writes through.
+// Kyty only reverse-engineered the TYPE-1 data packet: payload at cmd+2 (a 2-dword header). This
+// title also builds TYPE-0 data packets whose header size / payload offset were NEVER RE'd, so
+// cmd+2 is a best-effort guess for them — a wrong offset makes the returned bank alias the wrong
+// dwords and silently corrupts the register set (#140). Until the type-0 header is confirmed (RE the
+// eboot packet builder), surface any non-type-1 packet LOUDLY — once per type, UNCONDITIONALLY (not
+// GFXLOG-gated as before) — while keeping the cmd+2 best-effort so the register-bank prepare still
+// gets a usable pointer (erroring here would fail the eboot's static AGC init).
 HLE(agc_get_data_packet_payload) {  // (uint32_t** addr, uint32_t* cmd, int type)
     auto** addr = (uint32_t**)(uintptr_t)a0;
     auto*  cmd  = (uint32_t*)(uintptr_t)a1;
     if (!addr || !cmd) return kAgcErrInvalidArg;
-    if (a2 != 1 && getenv("PROSPER_GFXLOG"))
-        fprintf(stderr, "[agc] GetDataPacketPayloadAddress: unexpected type=%d\n", (int)a2);
+    if (a2 != 1) {
+        static std::atomic<uint32_t> logged_mask{0};
+        uint32_t bit = ((int)a2 >= 0 && (int)a2 < 31) ? (1u << (uint32_t)a2) : (1u << 31);
+        if (!(logged_mask.fetch_or(bit, std::memory_order_relaxed) & bit))
+            fprintf(stderr, "[agc] GetDataPacketPayloadAddress: UNCONFIRMED packet type=%d — payload "
+                    "offset assumed cmd+2 (only type-1 is RE'd; type-0 header unknown, #140)\n", (int)a2);
+    }
     *addr = cmd + 2;
     return 0;
 }

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -67,6 +67,22 @@ int main() {
     p_addr(rc, 0xAABBCCDD00112233ull, 0, 0, 0, 0);
     CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu, "PatchSetAddress rewrote cmd[2]/cmd[3]");
 
+    // sceAgcGetDataPacketPayloadAddress (#140): resolves a data packet to its register-bank payload.
+    // Type 1 is the RE'd case (payload at cmd+2); type 0 is unconfirmed and returns cmd+2 best-effort
+    // (loud-once, not silent). Null out-ptr / null cmd -> invalid-arg. Verify the *addr contract.
+    auto getpayload = Hle::lookup("V++UgBtQhn0");
+    CHECK(getpayload != nullptr, "GetDataPacketPayloadAddress registered");
+    if (getpayload) {
+        uint32_t pkt[8]; uint32_t* out = nullptr;
+        CHECK(getpayload((uint64_t)(uintptr_t)&out, (uint64_t)(uintptr_t)pkt, /*type*/1, 0, 0, 0) == 0 &&
+              out == pkt + 2, "type 1: *addr = cmd+2, rc 0");
+        out = nullptr;
+        CHECK(getpayload((uint64_t)(uintptr_t)&out, (uint64_t)(uintptr_t)pkt, /*type*/0, 0, 0, 0) == 0 &&
+              out == pkt + 2, "type 0 (unconfirmed): *addr = cmd+2 best-effort, rc 0 (not aborted)");
+        CHECK(getpayload(0, (uint64_t)(uintptr_t)pkt, 1, 0, 0, 0) != 0, "null out-ptr -> invalid-arg");
+        CHECK(getpayload((uint64_t)(uintptr_t)&out, 0, 1, 0, 0, 0) != 0, "null cmd -> invalid-arg");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- `sceAgcGetDataPacketPayloadAddress` returned `cmd+2` (Kyty's **type-1** payload offset) for **every** packet type. This title also builds **type-0** data packets whose header size / payload offset were never reverse-engineered, so `cmd+2` is a best-effort guess for them — and since the returned pointer becomes the **register bank** the guest reads/writes through, a wrong offset silently corrupts the register set. The only signal was a `GFXLOG`-gated `fprintf`, off by default.
- Log any non-type-1 packet **unconditionally** (once per type, so no spam) instead of only under `GFXLOG`, and document that `cmd+2` is unconfirmed for `type != 1`.
- **Behavior unchanged:** `cmd+2` is kept as the best-effort so the eboot's static AGC register-bank prepare still gets a usable pointer (erroring would fail its init). The real fix is to RE the type-0 header — which the log now makes visible whenever it's exercised, per the issue's "at minimum log unconditionally."

## Verification
- New contract checks in `test_agc_dcb`: type 1 → `*addr = cmd+2`, rc 0; type 0 → `cmd+2` best-effort, rc 0 (not aborted); null out-ptr / null cmd → invalid-arg. The once-per-type `UNCONFIRMED packet type=0` log is observed.
- Full suite in WSL build-linux **including the dump-backed boot: 67/67 passed**.

Fixes #140