### PR TITLE
fix(recompiler): v_interp_mov reads a flat (provoking-vertex) attribute, not a smooth blend

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -58,7 +58,7 @@ enum : uint32_t {
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
     ImgOp_Lod=2, ImgOp_Sample=0x40,   // ImageOperands bits: explicit LOD (Fetch on sampled img) / MSAA Sample index.
     SC_Workgroup=4, Scope_Workgroup=2, MemSem_WGAcqRel=0x108,   // LDS: Workgroup storage + barrier scope/semantics
-    Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_Location=30, Dec_Binding=33,
+    Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_Flat=14, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
     BI_Position=0, BI_LocalInvocationId=27, BI_GlobalInvocationId=28, BI_VertexIndex=42,
 };
@@ -747,12 +747,19 @@ struct SpirvCompute {
     // --- Interpolated I/O varyings: VS EXP PARAM_n (output) <-> FS v_interp attribute (input) ---
     std::unordered_map<uint32_t, uint32_t> in_varying, out_varying;
     uint32_t t_ptr_in_v4f = 0;
-    // FS: an Input vec4 at Location=attr, smooth-interpolated by the rasterizer (declared on first use).
+    // Attributes read via v_interp_mov (a raw per-vertex / provoking-vertex value, NOT rasterizer-
+    // interpolated) — their FS Input varying is decorated Flat so the driver delivers the provoking
+    // vertex value instead of a smooth blend of the three (#152). Populated by recompile_fragment's
+    // pre-scan; an attribute read via BOTH v_interp_mov (flat) and v_interp_p2 (smooth) is rejected
+    // there (a varying can't be both), so this set never contradicts a smooth read.
+    std::unordered_set<uint32_t> flat_attrs;
+    // FS: an Input vec4 at Location=attr, rasterizer-interpolated (or Flat if flat_attrs says so).
     uint32_t frag_input(uint32_t attr) {
         auto it = in_varying.find(attr); if (it != in_varying.end()) return it->second;
         if (!t_ptr_in_v4f) { t_ptr_in_v4f = id(); put(types, Op_TypePointer, {t_ptr_in_v4f, SC_Input, t_v4f}); }
         uint32_t v = id(); put(types, Op_Variable, {t_ptr_in_v4f, v, SC_Input});
         put(deco, Op_Decorate, {v, Dec_Location, attr});
+        if (flat_attrs.count(attr)) put(deco, Op_Decorate, {v, Dec_Flat});   // un-interpolated (v_interp_mov)
         in_varying[attr] = v; iface.push_back(v); return v;
     }
     // Read component `chan` (0..3) of interpolated attribute `attr` -> float bits (v_interp_p2 / mov).
@@ -2324,6 +2331,20 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
 
     SpirvCompute b;
     b.begin_fragment(rt);
+    // Classify each interpolated attribute by HOW it's read (#152): v_interp_p2 (op 1) = smooth
+    // rasterizer interpolation; v_interp_mov (op 2) = a raw per-vertex / provoking-vertex value (a
+    // flat read). An attribute read only via v_interp_mov gets its Input varying decorated Flat so
+    // the driver delivers the provoking vertex value, not a blend of the three. An attribute read
+    // via BOTH is contradictory (a varying can't be smooth and flat at once) -> reject the shader.
+    { std::unordered_set<uint32_t> smooth_attr;
+      for (const auto& in : ins) {
+          if (in.is_end) break;
+          if (in.fmt != Rdna2Format::VINTRP) continue;
+          if (in.opcode == 1) smooth_attr.insert(in.vintrp_attr);        // v_interp_p2
+          else if (in.opcode == 2) b.flat_attrs.insert(in.vintrp_attr);  // v_interp_mov
+      }
+      for (uint32_t a : b.flat_attrs) if (smooth_attr.count(a)) return {};   // mixed smooth+flat: reject
+    }
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
     bool exported = false;

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -83,6 +83,20 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+// Whether the module contains OpDecorate (71) with the given decoration (word[i+2]).
+bool has_decoration(const std::vector<uint32_t>& spv, uint32_t decoration) {
+    enum : uint32_t { OpDecorateL = 71 };
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        uint32_t word = spv[i];
+        uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == OpDecorateL && wc >= 3 && spv[i + 2] == decoration) return true;
+        i += wc;
+    }
+    return false;
+}
+
 // The largest OpTypeArray length (resolved through its OpConstant) in the module — for LDS sizing
 // (#130), the Workgroup LDS array is the biggest array the compute shell declares.
 uint32_t max_array_length(const std::vector<uint32_t>& spv) {
@@ -266,6 +280,36 @@ int main() {
         return 1;
     }
     printf("  [ok]   lds_bytes>64 KB clamps to the RDNA2 max (16384 dwords)\n");
+
+    // v_interp_mov flat read (#152): an attribute read via v_interp_mov (a provoking-vertex / flat
+    // read) must decorate its FS Input varying Flat so the driver delivers the raw vertex value, not
+    // a smooth blend. An attribute read via BOTH v_interp_mov and v_interp_p2 is contradictory ->
+    // reject. Encodings llvm-mc gfx1030 verified. Dec_Flat = 14.
+    enum : uint32_t { OpDecorate = 71, DecFlat = 14 };
+    // Flat-only: v_interp_mov v3, p0, attr0.x ; exp mrt0 v3,v3,v3,v3 ; s_endpgm
+    const uint32_t ps_flat[] = { 0xc80e0002u, 0xf800000fu, 0x03030303u, 0xbf810000u };
+    std::vector<uint32_t> flat_spv = recompile_fragment(ps_flat, sizeof(ps_flat)/sizeof(ps_flat[0]));
+    if (flat_spv.empty() || !has_decoration(flat_spv, DecFlat)) {
+        printf("  [FAIL] v_interp_mov attribute is not decorated Flat (would smooth-interpolate a flat read)\n");
+        return 1;
+    }
+    printf("  [ok]   v_interp_mov attribute varying is decorated Flat\n");
+    // Smooth-only: v_interp_p1 + v_interp_p2 on attr0 ; exp mrt0 v4 -> NOT Flat.
+    const uint32_t ps_smooth[] = { 0xc8080000u, 0xc8110002u, 0xf800000fu, 0x04040404u, 0xbf810000u };
+    std::vector<uint32_t> smooth_spv = recompile_fragment(ps_smooth, sizeof(ps_smooth)/sizeof(ps_smooth[0]));
+    if (smooth_spv.empty() || has_decoration(smooth_spv, DecFlat)) {
+        printf("  [FAIL] a smooth-interpolated (v_interp_p2) attribute must NOT be decorated Flat\n");
+        return 1;
+    }
+    printf("  [ok]   v_interp_p2-only attribute stays smooth (no Flat decoration)\n");
+    // Mixed: attr0 read via BOTH v_interp_mov (flat) and v_interp_p2 (smooth) -> reject (can't be both).
+    const uint32_t ps_mixed[] = { 0xc80e0002u, 0xc8110002u, 0xf800000fu, 0x03030303u, 0xbf810000u };
+    std::vector<uint32_t> mixed_spv = recompile_fragment(ps_mixed, sizeof(ps_mixed)/sizeof(ps_mixed[0]));
+    if (!mixed_spv.empty()) {
+        printf("  [FAIL] an attribute read via BOTH v_interp_mov and v_interp_p2 must be REJECTED\n");
+        return 1;
+    }
+    printf("  [ok]   mixed flat+smooth read of one attribute is rejected\n");
 
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- `v_interp_mov` (VINTRP op 2) was emitted **identically to `v_interp_p2`** — it returned the rasterizer-interpolated varying and ignored that on hardware it delivers a raw per-vertex / provoking-vertex value (P0/P10/P20), an **un-interpolated flat read**. A pixel shader using it for a genuinely flat per-primitive attribute got a blend of the three vertices instead of the provoking-vertex value.
- `recompile_fragment` now pre-scans the VINTRP ops and classifies each attribute: `v_interp_p2` → smooth, `v_interp_mov` → flat. A flat attribute's FS Input varying is decorated **Flat** (SPIR-V Decoration 14) so the driver delivers the provoking-vertex value. An attribute read via **both** `v_interp_mov` and `v_interp_p2` is contradictory (a varying can't be smooth and flat) and is **rejected** rather than mis-decorated — exactly the issue's two sanctioned options.

## Verification
- New structural checks in `test_rdna2_spirv_struct`: a `v_interp_mov` attribute is decorated Flat; a `v_interp_p2`-only attribute is NOT; the mixed case is rejected. Encodings **llvm-mc gfx1030 verified**; `spv_validate` accepts the Flat modules.
- Full suite in WSL build-linux **including the dump-backed boot and the real-game-shader render tests: 67/67** (no scene-shader regression — they use smooth interpolation).

Fixes #152