### PR TITLE
fix(gpu): keep textures off bindings 2/3 so a texture-first shader can't collide the hardwired cbufs

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -258,6 +258,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_build_shader_resources PRIVATE prosper_core)
   add_test(NAME build_shader_resources COMMAND test_build_shader_resources)
 
+  # Descriptor-binding policy (#157): textures/storage images never land on the recompiler's hardwired
+  # cbuf bindings 2/3; constant/vertex buffers assigned first. Pure, no game dump / Vulkan needed.
+  add_executable(test_convention_bindings tests/test_convention_bindings.cpp)
+  target_link_libraries(test_convention_bindings PRIVATE prosper_core)
+  add_test(NAME convention_bindings COMMAND test_convention_bindings)
+
   # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux only).
   if(UNIX AND NOT APPLE)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -61,6 +61,11 @@ std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             const uint32_t* user_sgprs, uint32_t nsgpr,
                                             uint32_t user_sgpr_base);
 
+// Assign each resource in `t` a descriptor binding from `first`: constant/vertex buffers first, then
+// textures / storage images — never on binding 2 or 3 (the recompiler's two hardwired cbufs) so a
+// texture-first shader can't collide two descriptor types at one binding (#157). Exposed for testing.
+void assign_convention_bindings(ShaderResourceTable& t, uint32_t first);
+
 // Build a shader stage's resource table from the folded GpuState: look up the registered shader header
 // by its bound code address, read its user-data SGPR block from the sh register file, decode the V#/T#/S#
 // descriptors, and assign bindings matching the recompiler+backend convention (constant buffer -> binding

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -283,24 +283,32 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     return out;
 }
 
-namespace {
+namespace { constexpr uint32_t kPsBindingBase = 32; }
 
-// Give every resource its OWN descriptor binding, starting at `first` (0/1 reserved). The N-buffer model:
-// the shader reads several distinct constant buffers (Unity's per-draw transform, per-frame, …) + vertex
-// buffers + textures, and each must land at a separate binding so they don't collapse. The recompiler
-// declares a storage buffer (cbuf/vbuf) or image sampler (texture) at each binding and resolves an
-// s_buffer_load/image_sample to its resource's binding via provenance (by_sgpr_base / by_srt_offset).
+// Assign each resource its OWN descriptor binding, starting at `first` (0/1 reserved). The N-buffer
+// model: the shader reads several distinct constant buffers (Unity's per-draw transform, per-frame,
+// …) + vertex buffers + textures, and each must land at a separate binding so they don't collapse.
+// The recompiler declares a storage buffer (cbuf/vbuf) or image sampler (texture) at each binding and
+// resolves an s_buffer_load/image_sample to its resource's binding via provenance.
 //
-// The VS and PS tables are bound together in ONE descriptor set by the live renderer, so the two stages'
-// binding ranges MUST be disjoint: both stages numbering from 2 made the PS's small zero-filled cbuf land
-// on the SAME binding as the VS's cbuf holding the UV scale/offset (Unity _MainTex_ST) — the later
-// descriptor write won, the VS read zeros, and every vertex output uv = attr*0 + 0 (a constant, so the
-// whole triangle sampled one texel). VS keeps 2.., PS starts at kPsBindingBase.
-constexpr uint32_t kPsBindingBase = 32;
+// The VS and PS tables are bound together in ONE descriptor set by the live renderer, so the two
+// stages' binding ranges MUST be disjoint (VS keeps 2.., PS starts at kPsBindingBase). Within a
+// stage, constant/vertex BUFFERS are assigned first (from `first`), then TEXTURES / storage images —
+// but never on binding 2 or 3, which the recompiler's declare_cbufs always occupies with its two
+// hardwired storage-buffer cbufs (v_cbuf/v_cbuf1). A shader whose FIRST resource is a texture used to
+// land it on binding 2, declaring BOTH a combined image sampler AND that storage buffer at one
+// binding (two descriptor types -> layout-creation failure, the draw disappears) (#157). Buffers-
+// first keeps the common cbufs-first shaders' bindings byte-identical (cbufs 2/3, textures 4+).
+// External linkage (declared in gpu_execute.hpp) so the binding policy is unit-testable.
 void assign_convention_bindings(ShaderResourceTable& t, uint32_t first) {
     uint32_t next = first;
-    for (auto& r : t.resources) r.binding = next++;
-}
+    for (auto& r : t.resources)
+        if (r.cls == ResourceClass::ConstantBuffer || r.cls == ResourceClass::VertexBuffer)
+            r.binding = next++;
+    uint32_t tex_next = next > first + 2 ? next : first + 2;   // reserve the two hardwired cbuf slots
+    for (auto& r : t.resources)
+        if (r.cls != ResourceClass::ConstantBuffer && r.cls != ResourceClass::VertexBuffer)
+            r.binding = tex_next++;
 }
 
 std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr, bool is_ps) {

--- a/prosper/tests/test_convention_bindings.cpp
+++ b/prosper/tests/test_convention_bindings.cpp
@@ -1,0 +1,85 @@
+// test_convention_bindings — assign_convention_bindings must never place a texture / storage image on
+// binding 2 or 3, which the recompiler's declare_cbufs always occupies with two hardwired storage-
+// buffer cbufs. A shader whose FIRST resource is a texture used to land it on binding 2, declaring two
+// descriptor types at one binding -> layout-creation failure, the draw disappears (#157). Constant/
+// vertex buffers are assigned first (2/3+), matching the common cbufs-first shaders byte-for-byte.
+#include "../src/gpu/gpu_execute.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static ShaderResource res(ResourceClass cls) { ShaderResource r{}; r.cls = cls; return r; }
+
+int main() {
+    printf("== test_convention_bindings ==\n");
+    using RC = ResourceClass;
+
+    // TEXTURE-FIRST (#157 bug): a texture listed before any buffer must NOT get binding 2/3.
+    {
+        ShaderResourceTable t;
+        t.resources = { res(RC::Texture), res(RC::ConstantBuffer) };
+        assign_convention_bindings(t, 2);
+        CHECK(t.resources[1].binding == 2, "the constant buffer gets binding 2 (buffers first)");
+        CHECK(t.resources[0].binding >= 4, "the texture is pushed to binding >= 4, off the hardwired 2/3");
+    }
+
+    // COMMON cbufs-first shape: 2 cbufs + a texture -> byte-identical to the old sequential layout.
+    {
+        ShaderResourceTable t;
+        t.resources = { res(RC::ConstantBuffer), res(RC::ConstantBuffer), res(RC::Texture) };
+        assign_convention_bindings(t, 2);
+        CHECK(t.resources[0].binding == 2 && t.resources[1].binding == 3,
+              "two cbufs stay at 2 and 3 (matching the hardwired v_cbuf/v_cbuf1)");
+        CHECK(t.resources[2].binding == 4, "texture after two cbufs stays at 4 (no regression)");
+    }
+
+    // Texture-ONLY (no buffers): still reserve 2/3.
+    {
+        ShaderResourceTable t;
+        t.resources = { res(RC::Texture), res(RC::Texture) };
+        assign_convention_bindings(t, 2);
+        CHECK(t.resources[0].binding == 4 && t.resources[1].binding == 5,
+              "texture-only VS: textures start at 4 (2/3 reserved for the hardwired cbufs)");
+    }
+
+    // A storage image is treated as a texture-class resource (also kept off 2/3).
+    {
+        ShaderResourceTable t;
+        t.resources = { res(RC::StorageImage), res(RC::VertexBuffer) };
+        assign_convention_bindings(t, 2);
+        CHECK(t.resources[1].binding == 2, "vertex buffer takes binding 2");
+        CHECK(t.resources[0].binding >= 4, "storage image kept off 2/3");
+    }
+
+    // PS range (first = 32): buffers from 32/33, textures from 34 — disjoint from the VS range and
+    // still never colliding two types at one binding.
+    {
+        ShaderResourceTable t;
+        t.resources = { res(RC::Texture), res(RC::ConstantBuffer) };
+        assign_convention_bindings(t, 32);
+        CHECK(t.resources[1].binding == 32, "PS constant buffer at 32");
+        CHECK(t.resources[0].binding >= 34, "PS texture off the 32/33 reserved slots");
+    }
+
+    // All bindings within a table are distinct (no two resources collapse).
+    {
+        ShaderResourceTable t;
+        t.resources = { res(RC::Texture), res(RC::ConstantBuffer), res(RC::Texture), res(RC::VertexBuffer) };
+        assign_convention_bindings(t, 2);
+        bool distinct = true;
+        for (size_t i = 0; i < t.resources.size(); i++)
+            for (size_t j = i + 1; j < t.resources.size(); j++)
+                if (t.resources[i].binding == t.resources[j].binding) distinct = false;
+        CHECK(distinct, "every resource gets a distinct binding");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- `assign_convention_bindings` handed out sequential bindings from 2 **regardless of resource class**, while the recompiler's `declare_cbufs` always declares two hardwired storage-buffer cbufs at bindings 2 and 3. A VS whose **first** resource is a texture landed it on binding 2 — declaring **both** a combined image sampler *and* a storage buffer at set-0/binding-2 (two descriptor types at one binding), which fails pipeline-layout creation and makes the draw disappear.
- Assign constant/vertex **buffers first** (from `first`), then textures / storage images — starting no lower than `first+2`, so a texture never lands on the two hardwired cbuf slots.
- **No regression for the common case:** cbufs-first shaders are byte-identical (cbufs 2/3, textures 4+); only the pathological texture-first / few-cbuf case changes.

## Verification
- `assign_convention_bindings` given external linkage (declared in `gpu_execute.hpp`) so the policy is unit-testable. New `test_convention_bindings` covers texture-first (the bug), cbufs-first (byte-identical, no regression), texture-only, storage image, the PS range, and all-distinct bindings.
- Full suite in WSL build-linux **including the dump-backed boot and the real-game-shader render tests: 68/68 passed**.

Fixes #157