### PR TITLE
fix(hle): sceKernelWaitOnAddress honors the guest timeout by default; drop the 5 s cap

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -500,19 +500,19 @@ HLE(k_wait_on_address) {
     //   futex → the guest's *bounded* semaphore-wait blocked FOREVER and could never reach its
     //   timeout-exhausted branch. Honor it so timed waits actually time out and the guest re-evaluates.
     struct timespec ts, *pts = nullptr;
-    // NOTE: honoring the timeout is gated behind PROSPER_WAIT_TIMEOUT for now. It is the correct
-    // behavior (we were ignoring a timeout the guest passes → bounded semaphore-waits blocked forever),
-    // and it demonstrably changes execution — but it makes the guest take its *timeout* branch, which
-    // throws a C++ exception whose unwind then crashes because sceKernelGetModuleInfoForUnwind is
-    // unimplemented (libunwind reads garbage eh_frame → "Unsupported .eh_frame_hdr version" → stack
-    // smash). Until the unwinder is fed real eh_frame info, default to infinite waits (stable) and let
-    // the flag exercise the exception path during bring-up. See docs/RENDER_LOOP.md.
-    static const bool honor_timeout = getenv("PROSPER_WAIT_TIMEOUT") != nullptr;
+    // Honor the guest's timeout by DEFAULT (#139): ignoring it made a bounded semaphore-wait block
+    // FOREVER and return 0 (=signaled), so the guest consumed a resource never produced (phantom item
+    // -> crash). The original reason for keeping this gated off — the guest's timeout branch threw a
+    // C++ exception whose unwind crashed via the then-unimplemented sceKernelGetModuleInfoForUnwind —
+    // was fixed the same day (ca17aa9) and is stale: a 240 s run honoring the timeout on The Messenger
+    // showed no unwind/eh_frame fault. PROSPER_NO_WAIT_TIMEOUT restores infinite waits for bisection.
+    static const bool honor_timeout = getenv("PROSPER_NO_WAIT_TIMEOUT") == nullptr;
     if (a2 && honor_timeout) {
         uint32_t us = *(volatile uint32_t*)(uintptr_t)a2;
-        // FUTEX_WAIT's timeout is a RELATIVE duration; guard against absurd values.
-        if (us == 0) us = 1;                 // 0 == "poll" — a minimal wait keeps us re-checking
-        if (us > 5000000u) us = 5000000u;    // cap 5s so a huge/garbage value can't hang the thread
+        // FUTEX_WAIT's timeout is a RELATIVE duration. Honor the guest's EXACT value (uint32 µs, so at
+        // most ~71 min — no timespec overflow); the old hardcoded 5 s cap turned a longer legitimate
+        // timeout into an early ETIMEDOUT. Only 0 ("poll") is nudged to a minimal wait so we re-check.
+        if (us == 0) us = 1;
         ts.tv_sec = us / 1000000u; ts.tv_nsec = (long)(us % 1000000u) * 1000L; pts = &ts;
     }
     // --- DIAGNOSTIC punch-through (PROSPER_PUNCH=<secs>) -----------------------------------------

--- a/prosper/tests/test_sync_on_address.cpp
+++ b/prosper/tests/test_sync_on_address.cpp
@@ -46,6 +46,21 @@ int main() {
     CHECK(done.load(std::memory_order_acquire), "wake releases a waiter after the value changes");
     waiter.join();
 
+    // Timed wait honors the timeout by DEFAULT (#139): a wait on a still-matching value with a short
+    // timeout must return the Sony ETIMEDOUT (0x80020060) after ~the timeout — not block forever and
+    // return 0 (=signaled). Previously this was gated off (PROSPER_WAIT_TIMEOUT) so it blocked forever.
+    {
+        alignas(4) uint32_t tw = 5;
+        uint32_t timeout_us = 30000;   // 30 ms
+        auto t0 = std::chrono::steady_clock::now();
+        uint64_t rc = wait((uint64_t)(uintptr_t)&tw, 5 /*expected == value -> blocks*/,
+                           (uint64_t)(uintptr_t)&timeout_us, 0, 0, 0);
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::steady_clock::now() - t0).count();
+        CHECK(rc == 0x80020060ull, "timed wait returns SCE ETIMEDOUT (0x80020060), not 0/blocked-forever");
+        CHECK(elapsed >= 20 && elapsed < 2000, "timed wait actually waited ~the timeout (not the old 5 s cap / forever)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- Timeout support was implemented but **gated behind `PROSPER_WAIT_TIMEOUT` (default off)**, so a timed wait blocked **forever** and returned 0 (=signaled) — the guest then consumed a semaphore/resource never produced (phantom item → crash) instead of taking its timeout-exhausted branch. The gating reason (a C++ unwind crash via the then-unimplemented `sceKernelGetModuleInfoForUnwind`) was fixed the same day (`ca17aa9`) and is **stale** — a 240 s run honoring the timeout on The Messenger showed no unwind/eh_frame fault (per the issue's own data-point comment).
- Honor the timeout by **default**; `PROSPER_NO_WAIT_TIMEOUT` is the opt-OUT for bisection (was the opt-IN `PROSPER_WAIT_TIMEOUT`).
- **Drop the hardcoded 5 s cap** — it turned a longer legitimate timeout into an early ETIMEDOUT. The value is uint32 µs (max ~71 min), so honoring it exactly can't overflow the timespec.

## Verification
- New check in `test_sync_on_address`: a timed wait on a still-matching value returns SCE ETIMEDOUT (`0x80020060`) after ~the timeout, not 0/blocked-forever, and the elapsed time tracks the requested timeout.
- Full suite in WSL build-linux **including the dump-backed boot: 67/67** — the boot now honors timeouts by default and still reaches GC stop-the-world + graphics init (depth unchanged).

Fixes #139