### PR TITLE
fix(hle): Windows sceKernelWaitOnAddress honors the guest timeout (mirror the Linux path)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1063,9 +1063,11 @@ void register_kernel_mem_hle() {
 
 #else
 #include <atomic>
+#include <chrono>
 #include <climits>
 #include <condition_variable>
 #include <cstdint>
+#include <cstdlib>
 #include <mutex>
 
 namespace prosper {
@@ -1083,7 +1085,25 @@ HLE(k_wait_on_address) {
     auto& raw = *(uint32_t*)(uintptr_t)a0;
     std::atomic_ref<uint32_t> addr(raw);
     uint32_t expected = (uint32_t)a1;
+    // Honor the guest timeout by default (#142) — the same fix the Linux futex path got (#139).
+    // Previously this global-cv fallback IGNORED the timeout arg and blocked FOREVER while
+    // *addr == expected, returning 0 (=signaled), so a Windows-build timed wait could never take its
+    // timeout branch. Parse *a2 as uint32 microseconds, wait to that deadline, and return SCE
+    // ETIMEDOUT on expiry. PROSPER_NO_WAIT_TIMEOUT restores infinite waits (parity with Linux).
+    // The 32-bit compare is a shared limitation with the Linux FUTEX_WAIT path (WaitOnAddress can
+    // wait on 1/2/4/8-byte values; only 4 is modeled) — unchanged here.
+    static const bool honor_timeout = getenv("PROSPER_NO_WAIT_TIMEOUT") == nullptr;
     std::unique_lock<std::mutex> lk(g_sync_mx);
+    if (a2 && honor_timeout) {
+        uint32_t us = *(volatile uint32_t*)(uintptr_t)a2;
+        if (us == 0) us = 1;   // 0 == "poll" -> a minimal wait so we re-check
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(us);
+        while (addr.load(std::memory_order_acquire) == expected)
+            if (g_sync_cv.wait_until(lk, deadline) == std::cv_status::timeout &&
+                addr.load(std::memory_order_acquire) == expected)
+                return 0x80020060ull;   // SCE_KERNEL_ERROR_ETIMEDOUT
+        return 0;
+    }
     while (addr.load(std::memory_order_acquire) == expected) g_sync_cv.wait(lk);
     return 0;
 }


### PR DESCRIPTION
## Summary
- The Windows `#else` fallback waited on a single global `condition_variable` while `*addr == expected`, **ignoring the timeout arg** — the same forever-block the Linux futex path had. On the Windows build a timed wait could never take its timeout branch: it blocked forever and returned 0 (=signaled), so the guest consumed a resource never produced.
- Mirror the Linux behavior (#139): parse `*a2` as uint32 microseconds, `cv.wait_until` to that deadline, and return SCE ETIMEDOUT (`0x80020060`) on expiry; honor by default with `PROSPER_NO_WAIT_TIMEOUT` as the opt-OUT, for platform parity.
- The 32-bit compare is a **shared limitation** with the Linux `FUTEX_WAIT` path (WaitOnAddress can wait on 1/2/4/8-byte values; only 4 is modeled) — documented, unchanged.

## Verification
- Windows is the secondary target and can't run in the Linux CI, so the timeout **logic** — identical to the Linux path exercised by `test_sync_on_address`'s ETIMEDOUT test — was **compile-and-run verified standalone** (g++ -std=c++20, no Windows APIs, portable stdlib only).
- The Linux suite is unaffected: **67/67** (the change is entirely in the Windows-only `#else` branch).

Note: this is the Windows counterpart of #139 (Linux default flip); both converge on honor-by-default + `PROSPER_NO_WAIT_TIMEOUT`.

Fixes #142