### PR TITLE
ci: build the Linux desktop app (prosper-app) with SDL3 + Vulkan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,36 @@ jobs:
       - name: Test
         run: ctest --test-dir prosper/build-ci --output-on-failure
 
+  linux-app:
+    name: Linux App
+    runs-on: ubuntu-latest
+
+    # Builds the desktop frontend (prosper-app) with the SDL3 audio + gamepad frontends and Vulkan,
+    # so the windowing/present/boot glue and the frontends stay compiling. Build-only: the app opens a
+    # window and needs a display, so it isn't run here (the headless core is covered by the `linux` job).
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        # Vulkan (loader + FindVulkan) for the renderer; Wayland/X11 dev libs so the fetched SDL3
+        # builds its video backends; PulseAudio/ALSA for the SDL3 audio backend. SDL3 itself is
+        # fetched + built by CMake (FetchContent), so no libsdl package is needed.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build pkg-config libvulkan-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev libx11-dev \
+            libxext-dev libxcursor-dev libxi-dev libxrandr-dev libxfixes-dev \
+            libpulse-dev libasound2-dev
+
+      - name: Configure
+        run: cmake -S prosper -B prosper/build-app -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
+
+      - name: Build prosper-app
+        # Building this target also builds its deps: prosper_core, prosper_live_renderer, SDL3, and
+        # the prosper_audio_sdl3 / prosper_pad_sdl3 frontends.
+        run: cmake --build prosper/build-app --target prosper-app
+
   windows-mingw:
     name: Windows MinGW
     runs-on: windows-latest


### PR DESCRIPTION
Adds a **`linux-app`** CI job that builds the desktop frontend so it can't silently break.

## What it does
- Configures `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` and builds the `prosper-app` target (which also builds `prosper_core`, `prosper_live_renderer`, SDL3, and the audio/gamepad frontend libs).
- **Vulkan enabled** here (the existing `linux` job disables it), so this also covers the Vulkan-backed renderer + shared `prosper_live_renderer` compiling.
- Installs Vulkan + Wayland/X11 dev libs (so the FetchContent'd SDL3 builds its video backends) + PulseAudio/ALSA for the audio backend. SDL3 itself is fetched + built by CMake — no `libsdl` package needed.

## Build-only, by design
The app opens a window and needs a display, so it isn't *run* in CI — the headless core + ctest stay in the `linux` job. This job guarantees the app + frontends keep compiling and linking.

Verified locally: the exact `cmake -S prosper -B … -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` + `cmake --build … --target prosper-app` produces the `prosper-app` binary.