### PR TITLE
fix(agc/hle): four post-load walls — DOLL runs deep, dispatches flow, no OOM (Fixes #222, refs #213/#82)

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -779,3 +779,57 @@ bring-up. In dependency order:
   benign SIGSEGV wedges gdb.
 - Caveat seen this session: batch-gdb breakpoints on guest RWX addresses sometimes don't fire
   cleanly (worker-thread timing); prefer breaking on a host symbol first, then arming guest bps.
+
+### SOLVED (2026-07-09, issue #213/#222): four post-load walls cleared — DOLL runs deep into engine init with the AGC draw-path wired; the remaining wall is characterized
+
+Building on the stable frame loop (#213), four distinct walls between "empty present loop" and
+"scene draws" were RE'd and fixed (all offsets eboot-relative; captures via gdb on the ext4 fast
+path). The game now runs 200+ flips / 470+ compute dispatches, deep into post-load engine init
+(trophy, error-dialog, telemetry subsystems), with 0 faults and 0 OOM.
+
+1. **The #222 EUD-ring fault (eboot+0x59949e4) was the FIRST scene-draw prep crash, not a race.**
+   `+kSrjIVxKFE` (the AGC register-context ctor) is called repeatedly on LIVE contexts (a per-
+   frame/post-bind reset; DOLL even builds contexts on the stack), not once at device init. The
+   guest's SetSource (eboot+0x5994620) EARLY-OUTS when [sub+0x00] still equals the shader being
+   bound; a full bind derives +0x34/+0x38/+0x3c/+0x40/+0x44 from the SAME user_data descriptor,
+   so +0x44!=0 always implies direct-table[10]!=0xffff. Our Stage-1 ctor overwrote ONLY [sub+0x08]
+   with the empty all-0xffff descriptor; after a reset of a bound context, re-binding the SAME
+   shader early-outed, leaving +0x44 stale-nonzero against the sentinel table. The EUD writer
+   (eboot+0x5994940, no 0xffff guard in DOLL's build) then computed slot 0xffff -> spill base 0 +
+   0xffff*4 - 0x80 = 0x3ff7c (the exact captured fault addr). Fix: model the ctor as the guest's
+   own sub-reset (eboot+0x59945e0) — zero [sub+0x00..0x47] + the +0x60/+0x68 cached bank & flags,
+   preserve the +0x48/+0x50 allocator pointers & +0x58 mode byte, install the empty descriptor.
+
+2. **The per-draw fence cluster was never wired.** The guest fence builder (eboot+0x59a1780)
+   allocates a label inside a Dcb NOP data packet, pre-builds WriteData/ReleaseMem/WaitRegMem with
+   NULL placeholder addresses, then patches the label address through three imports that were
+   observe-only glog no-ops: `fPSCdQxgpSw`=WriteData-patch-addr, `3KDcnM3lrcU`=WaitRegMem-patch-
+   addr, `0fWWK5uG9rQ`=ReleaseMem-patch-addr. With them stubbed, every per-draw GPU fence targeted
+   address 0. Implemented all three (each validates the packet header sub-op first; 0 refusals
+   across a full run). Also implemented `k3GhuSNmBLU`=sceAgcDcbDispatchDirect(dcb,x,y,z,modifier)
+   as a new R_DISPATCH_DIRECT packet (guest wrapper eboot+0x220ede0; Kyty Gen4 DispatchDirect ABI)
+   — DOLL's compute prologue issues ~470 of these.
+
+3. **The 34.6 GB OOM / RenderThread-timeout was a trophy success-with-garbage-out.**
+   `sceNpTrophy2GetGameInfo` (NID 4IzqhhUQ3nk, nid_hash brute force) + fill sibling y3zHpdZO6ME:
+   the guest (eboot+0xdbcb43) reads a u32 count from the out-struct and grows two TArrays from it;
+   the unimplemented stub's success-without-write fed heap garbage as the count -> a 34,644,492,288-
+   byte array grow ("Ran out of memory allocating 34644492288 bytes"), or (garbage allocatable-huge)
+   a multi-minute zero-fill that starved the RenderThread until UE's 120 s watchdog fired. Fix:
+   return failure (0x80551500) so the caller takes its clean trophy-unavailable path (eboot+0xdbd239).
+
+4. **sceVideoOutGetOutputStatus (#82) — the ONE consumer is now RE'd.** DOLL's swapchain init
+   (eboot+0x2226fea) reads a u32 at status+0x04 and switches to an HDR pixel format when it == 2.
+   Success-without-write fed it stack garbage. Fix: write a defined {u32 state=0, u32 mode=0}
+   prefix (SDR, 8 bytes — within the caller's 0x50-byte reservation).
+
+**Remaining wall (characterized, next session):** the main GameThread is parked in a ~1 ms
+timed-poll loop — guest fn eboot+0x2cc2340 does a vtable poll (`call *0x20(%rax)` at +0x2cc236a)
+then a `vucomisd` elapsed-time/timeout compare (eboot+0x2324190), backed by a timed cond-wait
+(eboot+0x22ea94f -> the guest's ~1 ms sleep helper). It is polling an async completion that a
+worker never delivers — the same "wait-for-completion-with-timeout" scene-activation shape, now
+reached far deeper (past PreInit, RHI, plugin load, trophy/telemetry init). Next: resolve the
+vtable object at eboot+0x2cc236a's `*0x20(%rax)` (break there, walk the interface) and what the
++0x2324190 double compare gates — likely a streaming-level / world-activation handshake, still on
+the FlushAsyncLoading -> TickAsyncLoading axis. Still 0 graphics draws (DrawIndex/DrawIndexAuto);
+the compute-only dispatch stream is UE4's persistent per-frame GPU setup, not scene geometry.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -205,6 +205,14 @@ void GpuState::apply(const Pm4Command& c) {
                             (unsigned long long)v, c.wm_func, (unsigned long long)r);
             }
             break;
+        case K::DispatchDirect:
+            // Compute dispatch (issue #213 — DOLL's UE4 compute prologue). Recorded for stats/
+            // diagnostics only: prosper has no compute execution path yet. The fence cluster the
+            // guest builds around each dispatch (label init + EOP write + wait) completes at fold
+            // time independently of the dispatch itself, so skipping the shader work cannot hang
+            // the stream — it only leaves compute-written buffers stale (surfaced by the counter).
+            dispatch_count++;
+            break;
         case K::Flip:
             // The GPU reaching the SetFlip packet IS the flip moment (synchronous fold): perform the
             // videoout flip so GetFlipStatus advances and the game's frame pacer sees its flipArg

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -44,6 +44,7 @@ struct GpuState {
         uint64_t modifier = 0;
     };
     std::vector<Draw> draws;                             // one per DrawIndexAuto / DrawIndex
+    uint64_t dispatch_count = 0;                         // DispatchDirect packets seen (no execution yet)
 
     // Safety cap on an indirect register count (a malformed/huge count won't run away).
     static constexpr uint32_t kMaxRegsPerPacket = 4096;

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -111,6 +111,12 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     c.kind = K::DrawIndexAuto;
                     if (npl >= 1) c.index_count = pl[0];
                     break;
+                case R_DISPATCH_DIRECT:
+                    c.kind = K::DispatchDirect;
+                    // payload: [0..2]=threadgroups x/y/z, [3..4]=64-bit dispatch modifier.
+                    if (npl >= 3) { c.tg_x = pl[0]; c.tg_y = pl[1]; c.tg_z = pl[2]; }
+                    if (npl >= 5) c.dispatch_modifier = (uint64_t)pl[3] | ((uint64_t)pl[4] << 32);
+                    break;
                 case R_CX_REGS_INDIRECT:
                 case R_SH_REGS_INDIRECT:
                 case R_UC_REGS_INDIRECT:

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -23,7 +23,7 @@ enum : uint32_t {
     R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
     R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
     R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
-    R_RELEASE_MEM = 0x18, R_NUM = 0x40,
+    R_RELEASE_MEM = 0x18, R_DISPATCH_DIRECT = 0x1a, R_NUM = 0x40,
 };
 
 // The register set a Set*RegistersIndirect packet targets.
@@ -35,7 +35,8 @@ enum class RegClass { Cx, Sh, Uc };
 struct Pm4Command {
     enum class Kind {
         DrawReset, WaitFlipDone, SetShRegDirect, SetRegsIndirect, SetIndexType,
-        DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem, Unknown,
+        DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
+        DispatchDirect, Unknown,
     } kind = Kind::Unknown;
 
     uint32_t        header = 0;
@@ -48,6 +49,12 @@ struct Pm4Command {
     uint64_t regs_vaddr = 0;             // SetRegsIndirect: guest addr of the register array
     uint32_t index_count = 0;            // DrawIndexAuto / DrawIndex
     uint32_t index_size = 0;             // SetIndexType
+
+    // DispatchDirect (sceAgcDcbDispatchDirect -> R_DISPATCH_DIRECT, hle_agc.cpp
+    // agc_dcb_dispatch_direct). Payload: [0..2] = threadgroup counts x/y/z, [3..4] = 64-bit
+    // dispatch modifier (from the CS shader's specials block).
+    uint32_t tg_x = 0, tg_y = 0, tg_z = 0;   // DispatchDirect threadgroup counts
+    uint64_t dispatch_modifier = 0;          // DispatchDirect modifier bits
 
     // DrawIndex (sceAgcDcbDrawIndex -> R_DRAW_INDEX, laid out by hle_agc.cpp agc_dcb_draw_index).
     // Packet payload: [0]=index_count, [1..2]=index-buffer guest address (lo/hi), [3..4]=64-bit draw

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -37,7 +37,7 @@ constexpr uint32_t IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46, I
 constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
                    R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
                    R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
-                   R_RELEASE_MEM = 0x18, R_DMA_DATA = 0x19;
+                   R_RELEASE_MEM = 0x18, R_DMA_DATA = 0x19, R_DISPATCH_DIRECT = 0x1a;
 constexpr uint32_t R_NUM = 0x40;
 inline uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
@@ -687,16 +687,17 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
                     (unsigned long long)g_submit_count, agc_gpu_state().draws.size(), w, h);
     }
     if (getenv("PROSPER_GFXLOG")) {
-        fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu)\n",
-                (unsigned long long)g_submit_count, p->dw_num, applied, agc_gpu_state().draws.size());
+        fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu, dispatches total: %llu)\n",
+                (unsigned long long)g_submit_count, p->dw_num, applied, agc_gpu_state().draws.size(),
+                (unsigned long long)agc_gpu_state().dispatch_count);
         // Dump each packet's kind + first payload dwords so we can see whether the game embeds a
         // completion-label write (WriteData/ReleaseMem/EventWrite) or a GPU-side wait in the stream.
         std::vector<gpu::Pm4Command> ops; gpu::decode_pm4(p->addr, p->dw_num, ops);
         static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetShRegDirect","SetRegsIndirect",
             "SetIndexType","DrawIndex","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem",
-            "Flip","ReleaseMem","Unknown"};
+            "Flip","ReleaseMem","DispatchDirect","Unknown"};
         for (auto& c : ops) {
-            uint32_t k = (uint32_t)c.kind; const char* nm = k < 14 ? kKindName[k] : "?";
+            uint32_t k = (uint32_t)c.kind; const char* nm = k < 15 ? kKindName[k] : "?";
             fprintf(stderr, "[agc]   pkt op=0x%02x r=0x%02x len=%u kind=%s pl0=0x%08x pl1=0x%08x pl2=0x%08x\n",
                     c.op, c.r, c.len, nm,
                     c.len > 1 ? c.payload[0] : 0, c.len > 2 ? c.payload[1] : 0, c.len > 3 ? c.payload[2] : 0);
@@ -714,6 +715,69 @@ HLE(agc_patch_set_address) {  // (cmd, regs): cmd[2..3] = regs vaddr
 HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     cmd[1] += (uint32_t)a1; return 0;
+}
+
+// --- Sync-packet address patch family (issue #213/#222 — the DOLL per-draw fence cluster). ------
+//
+// RE'd from DOLL's statically-linked AGC fence builder (eboot+0x59a1780, gdb-verified live): the
+// guest allocates a LABEL inside a Dcb NOP data packet (sceAgcCbNop + sceAgcGetDataPacketPayload-
+// Address), pre-builds WriteData(label:=0) / ReleaseMem(label<-1) / WaitRegMem(label==1) packets
+// with NULL placeholder addresses, then patches the label address into each packet through these
+// three imports (call order fPS->3KD->0fW; the per-draw burst passes each packet at exactly our
+// builders' emitted offsets: WriteData at +0x1c(6dw), ReleaseMem at +0x34(7dw), WaitRegMem at
+// +0x50(9dw) after the 7-dword NOP label packet — the offset arithmetic pins which patch targets
+// which packet kind). Signature is (cmd, address) — the fence-builder disassembly passes exactly
+// two args; the varying a2..a4 seen under GFXLOG are deterministic register residue from the PLT
+// thunks. Leaving these as no-ops was the RenderThread stall: the GPU-side label writes all
+// targeted address 0 (skipped), so the engine's CPU-side poll of the label never completed and
+// "GameThread timed out waiting for RenderThread after 120.00 secs" fired. Each patcher verifies
+// the packet's own header sub-op before writing — a mismatch means the RE drifted, so it logs
+// loudly (once) and refuses to corrupt the stream. CONFIDENCE: HIGH (disassembly + live capture
+// + offset arithmetic all agree).
+namespace {
+inline bool patch_check(uint32_t* cmd, uint32_t want_r, const char* who) {
+    uint32_t r = (cmd[0] >> 2) & (R_NUM - 1u), op = (cmd[0] >> 8) & 0xffu;
+    if (op == IT_NOP && r == want_r) return true;
+    static std::atomic<int> logged{0};
+    if (logged.fetch_add(1) < 8)
+        fprintf(stderr, "[agc] %s: header 0x%08x is not the expected packet (op=0x%x r=0x%x want r=0x%x) — patch refused\n",
+                who, cmd[0], op, r, want_r);
+    return false;
+}
+}
+HLE(agc_patch_write_data_addr) {  // fPSCdQxgpSw (cmd, address): WriteData payload [1..2] = address
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_check(cmd, R_WRITE_DATA, "WriteDataPatchAddress")) return 0;
+    cmd[2] = (uint32_t)(a1 & 0xffffffffu); cmd[3] = (uint32_t)(a1 >> 32u);
+    return 0;
+}
+HLE(agc_patch_wait_reg_mem_addr) {  // 3KDcnM3lrcU (cmd, address): WaitRegMem payload [0..1] = address
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_check(cmd, R_WAIT_MEM_64, "WaitRegMemPatchAddress")) return 0;
+    cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    return 0;
+}
+HLE(agc_patch_release_mem_addr) {  // 0fWWK5uG9rQ (cmd, address): ReleaseMem payload [0..1] = address
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_check(cmd, R_RELEASE_MEM, "ReleaseMemPatchAddress")) return 0;
+    cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    return 0;
+}
+
+// sceAgcDcbDispatchDirect (NID k3GhuSNmBLU) — compute dispatch. RE'd from the guest wrapper
+// eboot+0x220ede0: it reserves Dcb space from the bound CS shader's scratch needs, reads the
+// shader's specials->dispatch_modifier (eboot+0x5999750 = [[sub0.shader]+0x28]+0x10) and calls
+// this import as (dcb, tg_x, tg_y, tg_z, modifier). Kyty's Gen4 GraphicsDispatchDirect carries the
+// same (x, y, z, mode) operand set. DOLL's first real frame issues ~535 of these (UE4's compute
+// prologue: GPUScene build, clears, culling) before any graphics draw. Appending the packet keeps
+// the stream faithful; the CommandProcessor records it (no compute execution yet — that is a later
+// milestone; the fence cluster around each dispatch completes at fold time regardless).
+// CONFIDENCE: HIGH on (dcb,x,y,z) (disassembly), MED on a4=modifier (from specials, unexecuted).
+HLE(agc_dcb_dispatch_direct) {  // (buf, tg_x, tg_y, tg_z, modifier)
+    uint32_t* cmd; if (!begin_packet(a0, 6, IT_NOP, R_DISPATCH_DIRECT, &cmd)) return 0;
+    cmd[1] = (uint32_t)a1; cmd[2] = (uint32_t)a2; cmd[3] = (uint32_t)a3;
+    cmd[4] = (uint32_t)(a4 & 0xffffffffu); cmd[5] = (uint32_t)(a4 >> 32u);
+    return (uint64_t)(uintptr_t)cmd;
 }
 
 void register_agc_hle() {
@@ -742,6 +806,13 @@ void register_agc_hle() {
     RN("Qrj4c+61z4A", agc_patch_set_address);   RN("z2duB-hHQSM", agc_patch_add_registers);   // Sh
     RN("6lNcCp+fxi4", agc_patch_set_address);   RN("vRoArM9zaIk", agc_patch_add_registers);   // Uc
     RN("LtTouSCZjHM", agc_cb_nop);              // sceAgcCbNop — append padding dwords (#117)
+    // Sync-packet address patchers + compute dispatch (issue #213 — the DOLL per-draw fence
+    // cluster; RE write-up at each handler). These OVERRIDE the glog no-op thunks (map insert
+    // order: register_agc_hle runs after the glog registration, same as WmAc2MEj6Io).
+    RN("fPSCdQxgpSw", agc_patch_write_data_addr);    // WriteData packet: set destination address
+    RN("3KDcnM3lrcU", agc_patch_wait_reg_mem_addr);  // WaitRegMem packet: set label address
+    RN("0fWWK5uG9rQ", agc_patch_release_mem_addr);   // ReleaseMem packet: set label address
+    RN("k3GhuSNmBLU", agc_dcb_dispatch_direct);      // sceAgcDcbDispatchDirect (tg_x, tg_y, tg_z, mod)
     RN("WmAc2MEj6Io", agc_dcb_dma_data);        // sceAgcDcbDmaData — append DMA_DATA packet (#117)
     RN("YUeqkyT7mEQ", agc_dcb_set_flip);        // sceAgcDcbSetFlip (Kyty LibGraphicsDriver.cpp:98)
     RN("UglJIZjGssM", agc_driver_submit_dcb);   // sceAgcDriverSubmitDcb -> CommandProcessor replay

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -91,16 +91,48 @@ constexpr int   kAgcCtxSubCount  = 3;               // cx / sh / uc register-set
 constexpr size_t kAgcCtxSubBase  = 0x38;            // first sub-object offset inside the context
 constexpr size_t kAgcCtxSubStride = 0x70;           // per sub-object (matches eboot+0x3b0210: *0x70)
 }
+// RE update (2026-07-09, issue #222 — DOLL/PPSA17942 EUD-ring fault at eboot+0x59949e4): this ctor
+// is ALSO called on LIVE contexts (a per-frame/POST-BIND reset), not just at device init. The sub-
+// object contract, recovered from DOLL's statically-linked AGC context code (identical library to
+// the Messenger eboot's 0x3afxxx block, at DOLL eboot+0x599xxxx):
+//   SetSource (+0x5994620) EARLY-OUTS when [sub+0x00] already equals the shader being bound; a full
+//   bind installs [sub+0x08] = shader->user_data and derives +0x34 (eud_size_dw), +0x38/+0x3c (the
+//   ud register range), +0x40 (0x20 if ud direct table[8] valid), +0x44 (nonzero iff table[10]
+//   valid) — all from the SAME descriptor, so table[10]==0xffff with +0x44!=0 cannot happen on real
+//   hardware. The EUD writer (+0x5994940, gated on +0x44!=0) indexes table[10] with NO 0xffff guard
+//   and stores through bank A [sub+0x10] / spill [sub+0x18]-0x80.
+// Our old Stage-1 ctor overwrote ONLY [sub+0x08] with the empty all-0xffff descriptor. On a live
+// context that had a shader bound, the next SetSource of the SAME shader early-outs (its cache key
+// [sub+0x00] survived), leaving +0x44 stale-nonzero against our sentinel table: the writer computes
+// slot 0xffff -> spill base 0 + 0xffff*4 - 0x80 = the exact observed fault address 0x3ff7c
+// (gdb-captured live: [sub+0x08] == g_agc_ctx_regmap, [sub+0x00] == live shader, +0x44 == 4).
+// Fix: model the ctor as the guest's own sub-reset (DOLL eboot+0x59945e0) — zero the source key,
+// banks and every ud-derived field ([sub+0x00..0x47] and the +0x60 cached bank / +0x68 init flags),
+// PRESERVE the guest-owned allocator pointers (+0x48/+0x50) and the +0x58 mode byte, then install
+// the empty descriptor. A later SetSource can then never early-out against the sentinel — it always
+// re-installs the real shader ud together with its derived fields. First-call behaviour on a fresh
+// zeroed context (the Messenger path) is bit-identical to the old ctor. CONFIDENCE: HIGH on the
+// reset semantics (guest reset fn + SetSource disassembly + live fault capture), MED on sub COUNT
+// (DOLL stage-selects sub indices up to 7; we reset the 3 we install descriptors into — subs we
+// never touched stay guest-consistent by construction).
 HLE(g_agc_ctx_init) {   // a0 = context pointer (device+0x48)
     gfx_tick();
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[gfx] libSceAgc::+kSrjIVxKFE(CtxInit) a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx\n",
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                (unsigned long long)a3);
     if (a0) {
         if (g_agc_ud_no_entries[0] != 0xffffu) {    // one-time: wire the sentinel direct table
             for (auto& e : g_agc_ud_no_entries) e = 0xffffu;
             *(void**)(g_agc_ctx_regmap + 0x00) = g_agc_ud_no_entries;   // direct_resource_offset
         }
         uint8_t* ctx = (uint8_t*)(uintptr_t)a0;
-        for (int i = 0; i < kAgcCtxSubCount; i++)
-            *(void**)(ctx + kAgcCtxSubBase + i * kAgcCtxSubStride + 0x08) = g_agc_ctx_regmap;
+        for (int i = 0; i < kAgcCtxSubCount; i++) {
+            uint8_t* sub = ctx + kAgcCtxSubBase + i * kAgcCtxSubStride;
+            memset(sub + 0x00, 0, 0x48);            // source key, ud ptr, banks, derived fields
+            memset(sub + 0x60, 0, 0x09);            // cached bank (+0x60 qword) + init flags (+0x68)
+            *(void**)(sub + 0x08) = g_agc_ctx_regmap;
+        }
     }
     return 0;
 }

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -360,20 +360,24 @@ HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a
 // advertise one mode (1080p60), so accept the configuration.
 HLE(g_vo_configure_output) { vo_argtrace("ConfigureOutput", a0,a1,a2,a3,a4,a5); return 0; }
 
-// sceVideoOutGetOutputStatus (utPrVdxio-8): (handle, status*). The out-struct layout has NO
-// reference anywhere (Kyty predates it, shadPS4 only stubs the name, neither SDK repo declares it),
-// so inventing field offsets would be worse than not writing — but returning success with an
-// UNWRITTEN out-struct silently hands the caller stale stack as a "valid" status (the harmful-stub
-// pattern). Until the layout is captured from a real call, the gap is at least LOUD: warn once per
-// boot, unconditionally. CONFIDENCE: LOW — success-without-write retained only because the current
-// title demonstrably tolerates it and a wrong guessed layout could smash its stack canary.
+// sceVideoOutGetOutputStatus (utPrVdxio-8): (handle, status*). The full out-struct layout has NO
+// reference (Kyty predates it, shadPS4 only stubs the name), but the ONE consumer in the wild is
+// now RE'd (issue #82; DOLL/PPSA17942 swapchain-init, eboot+0x2226fea..0x2227042, gdb-captured):
+// it reads a single u32 at status+0x04 and compares it to 2 — the ==2 branch (together with two
+// runtime capability checks) switches the display pipe to an HDR pixel format
+// (0x8100070400000000) — i.e. status+0x04 is the output's dynamic-range/colorimetry mode with
+// 2 = HDR. Previously we returned success with the struct UNWRITTEN, so the caller consumed
+// uninitialized stack (usually != 2 -> SDR by luck — the classic success+garbage-out hazard).
+// Write a defined 8-byte {u32 state=0, u32 mode=0} prefix: mode 0 selects the SDR path
+// deterministically, matching prosper's advertised SDR-only display. 8 bytes cannot overrun any
+// plausible real struct (the DOLL caller reserves 0x50 stack bytes for it). CONFIDENCE: MED on
+// field semantics (single consumer, unambiguous read), HIGH that a defined write beats garbage.
 HLE(g_vo_get_output_status) {
     vo_argtrace("GetOutputStatus", a0,a1,a2,a3,a4,a5);
-    static std::atomic<bool> warned{false};
-    if (!warned.exchange(true))
-        fprintf(stderr, "[vo] WARNING: sceVideoOutGetOutputStatus returns success WITHOUT filling the "
-                        "status struct (layout unknown — no Kyty/shadPS4/SDK reference); caller reads "
-                        "uninitialized memory. Capture the struct size to fix (issue #82).\n");
+    if (a1 > 0xffffull) {
+        *(uint32_t*)(uintptr_t)a1       = 0;   // +0x00: output state (0 = the boring/default state)
+        *(uint32_t*)(uintptr_t)(a1 + 4) = 0;   // +0x04: dynamic-range mode (2 = HDR; 0 = SDR)
+    }
     return 0;
 }
 

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -118,8 +118,29 @@ HLE(s_dialog_status)     { return (uint64_t)(unsigned)g_msgdialog_status.load();
 // exactly the f_fstat oversized-write class this file warns about.
 HLE(s_dialog_result)   { if (a0) memset(PW(a0), 0, 0x2C); return 0; }
 
+// --- libSceNpTrophy2 (PS5 trophy system) — the DOLL 34.6 GB OOM (issue #213 diagnosis). ---------
+// The guest's trophy bring-up (eboot+0xdbcb43..0xdbcc2e, gdb-captured live) calls
+// sceNpTrophy2GetGameInfo(ctx, handle, out*, 0) — NID 4IzqhhUQ3nk named via nid_hash brute force —
+// then grows TWO arrays from the out-struct's counts (u32 at out+0x4: 32-byte entries; a second
+// 0x520-byte-entry array) and calls a sibling (y3zHpdZO6ME, unnamed) to fill them. The generic
+// unimplemented stub returned 0 = SUCCESS with the out-struct UNWRITTEN, so the engine consumed
+// heap garbage as a trophy count: gdb-captured count 0x408bd000 -> a 34,644,492,288-byte TArray
+// grow ("Ran out of memory allocating 34644492288 bytes") — and when the garbage happened to be
+// allocatable-huge instead, the minutes-long zero-fill starved the RenderThread until UE's
+// "GameThread timed out waiting for RenderThread after 120.00 secs" watchdog killed the boot.
+// Without a trophy backend the honest answer is FAILURE: a negative return takes the caller's
+// clean invalid path (eboot+0xdbd239/0xdbd242: mark the trophy config unavailable, continue) —
+// exactly the state a real console reports with no signed-in user. Only the SIGN of the return is
+// consumed by this caller; the exact NpTrophy2 error space is unverified (no Kyty/shadPS4/stub
+// reference), so the value is chosen inside the documented SCE_NP_TROPHY (0x8055xxxx) range.
+// CONFIDENCE: HIGH that failure beats success+garbage; LOW on the specific error constant.
+HLE(s_nptrophy2_unavailable) { return 0x80551500ull; }
+
 void register_service_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
+    // NpTrophy2: the config/info queries whose success-with-garbage-out crashed DOLL (see above).
+    Hle::register_fn("4IzqhhUQ3nk", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetGameInfo");
+    Hle::register_fn("y3zHpdZO6ME", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetGameInfo-fill?");
     // user service
     R("sceUserServiceGetInitialUser", s_user_initial);
     R("sceUserServiceGetEvent", s_user_getevent);   // deliver the initial-user LOGIN event once

--- a/prosper/tools/dbg/catch222.gdb
+++ b/prosper/tools/dbg/catch222.gdb
@@ -1,0 +1,45 @@
+# Catch the issue-#222 EUD-ring store fault at eboot+0x59949e4 and dump the object graph.
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+catch signal SIGSEGV
+commands
+  silent
+  if $rip == 0x4059949e4
+    printf "==== FATAL 222 CAUGHT ====\n"
+    info registers rip rax rbx rcx rdx rsi rdi r14 r15
+    printf "---- sub object (rbx) ----\n"
+    x/16gx $rbx
+    printf "---- descriptor ud = [rbx+8] ----\n"
+    set $ud = *(unsigned long long*)($rbx+8)
+    printf "ud=%llx\n", $ud
+    x/10gx $ud
+    printf "---- direct_resource_offset table (u16[32]) = [ud+0] ----\n"
+    set $dro = *(unsigned long long*)$ud
+    printf "dro=%llx\n", $dro
+    x/32hx $dro
+    printf "---- ring object = [rbx+0x50] ----\n"
+    set $ring = *(unsigned long long*)($rbx+0x50)
+    printf "ring=%llx\n", $ring
+    x/12gx $ring
+    printf "---- caller frame: ret addrs on stack ----\n"
+    x/16gx $rsp
+    printf "---- backtrace ----\n"
+    bt 8
+    printf "---- thread id ----\n"
+    thread
+    printf "==== DUMP DONE ====\n"
+    kill
+    quit
+  else
+    signal SIGSEGV
+  end
+end
+run
+quit

--- a/prosper/tools/dbg/count18.gdb
+++ b/prosper/tools/dbg/count18.gdb
@@ -1,0 +1,46 @@
+# Inspect the swapchain-init object at the [rbx+0x18] count read (eboot+0x2227052).
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+handle SIGILL nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+# The guest image is not mapped at gdb start: arm a host-side breakpoint first, then plant the
+# guest breakpoint once the image exists (GetOutputStatus runs from the same guest function).
+break _ZN7prosperL22g_vo_get_output_statusEmmmmmm
+commands
+  silent
+  break *0x402227052
+  commands
+    silent
+    printf "==== count-read hit: rbx=0x%llx [rbx+0x18]=0x%x ====\n", $rbx, *(unsigned int*)($rbx+0x18)
+    printf "---- object dump ----\n"
+    x/16gx $rbx
+    printf "---- guest RAs ----\n"
+    set $p = $sp
+    set $e = $sp + 1024
+    while $p < $e
+      set $v = *(unsigned long long*)$p
+      if ($v >= 0x400000000 && $v < 0x40a000000)
+        printf "sp+0x%04x: eboot+0x%llx\n", (unsigned int)($p - $sp), $v - 0x400000000
+      end
+      set $p = $p + 8
+    end
+    printf "==== HIT DONE ====\n"
+    if (*(unsigned int*)($rbx+0x18)) > 0x10000
+      printf "==== GARBAGE COUNT — stopping ====\n"
+      kill
+      quit
+    end
+    continue
+  end
+  disable 1
+  continue
+end
+run
+quit

--- a/prosper/tools/dbg/dis.sh
+++ b/prosper/tools/dbg/dis.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Disassemble a range of the DOLL eboot .text from /tmp/text.bin
+# Usage: dis.sh <start_hex_off> <len_hex>  (offsets are eboot-relative)
+START=$1
+LEN=$2
+objdump -D -b binary -m i386:x86-64 --start-address=$((START)) --stop-address=$((START + LEN)) /tmp/text.bin | tail -n +8

--- a/prosper/tools/dbg/drawnid.gdb
+++ b/prosper/tools/dbg/drawnid.gdb
@@ -1,0 +1,44 @@
+# RE the DOLL per-draw AGC NIDs: break in glog_impl when nid==fPSCdQxgpSw,
+# dump guest RA chain at an early hit and a late (render-burst) hit.
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+set $cnt = 0
+break prosper::(anonymous namespace)::glog_impl(char const*, void*, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long) if ((char*)$rdi)[0]=='f' && ((char*)$rdi)[1]=='P' && ((char*)$rdi)[2]=='S'
+commands
+  silent
+  set $cnt = $cnt + 1
+  if $cnt == 5 || $cnt == 2900
+    printf "==== fPSCdQxgpSw hit #%d ====\n", $cnt
+    printf "args a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx\n", $rdx, $rcx, $r8, $r9
+    printf "---- guest RAs on stack ----\n"
+    set $p = $sp
+    set $e = $sp + 3072
+    while $p < $e
+      set $v = *(unsigned long long*)$p
+      if ($v >= 0x400000000 && $v < 0x40a000000)
+        printf "sp+0x%04x: eboot+0x%llx\n", (unsigned int)($p - $sp), $v - 0x400000000
+      end
+      set $p = $p + 8
+    end
+    printf "---- a1 base buffer ----\n"
+    x/32wx $rcx
+    printf "---- a0 buffer ----\n"
+    x/16wx $rdx
+    printf "==== HIT DONE ====\n"
+  end
+  if $cnt == 2900
+    kill
+    quit
+  end
+  continue
+end
+run
+quit

--- a/prosper/tools/dbg/drawnid2.gdb
+++ b/prosper/tools/dbg/drawnid2.gdb
@@ -1,0 +1,41 @@
+# Capture guest RA chain for k3GhuSNmBLU (per-draw emitter suspect).
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+set $cnt = 0
+break prosper::(anonymous namespace)::glog_impl(char const*, void*, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long) if ((char*)$rdi)[0]=='k' && ((char*)$rdi)[1]=='3' && ((char*)$rdi)[2]=='G'
+commands
+  silent
+  set $cnt = $cnt + 1
+  if $cnt == 3 || $cnt == 40
+    printf "==== k3GhuSNmBLU hit #%d ====\n", $cnt
+    printf "args a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx\n", $rdx, $rcx, $r8, $r9
+    printf "---- guest RAs on stack ----\n"
+    set $p = $sp
+    set $e = $sp + 2048
+    while $p < $e
+      set $v = *(unsigned long long*)$p
+      if ($v >= 0x400000000 && $v < 0x40a000000)
+        printf "sp+0x%04x: eboot+0x%llx\n", (unsigned int)($p - $sp), $v - 0x400000000
+      end
+      set $p = $p + 8
+    end
+    printf "---- a0 object ----\n"
+    x/32gx $rdx
+    printf "==== HIT DONE ====\n"
+  end
+  if $cnt == 40
+    kill
+    quit
+  end
+  continue
+end
+run
+quit

--- a/prosper/tools/dbg/gotmap.gdb
+++ b/prosper/tools/dbg/gotmap.gdb
@@ -1,0 +1,25 @@
+# Read the GOT slots 0x40948d138/0x40948d140 once the image is linked, then map stubs to NIDs
+# by dumping the stub-region addresses. Break late (GetOutputStatus) so relocation is done.
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+handle SIGILL nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+break _ZN7prosperL22g_vo_get_output_statusEmmmmmm
+commands
+  silent
+  printf "GOT[0xa8]=0x%llx\n", *(unsigned long long*)0x40948d130
+  printf "GOT[0xa9]=0x%llx (the count query)\n", *(unsigned long long*)0x40948d138
+  printf "GOT[0xaa]=0x%llx (the fill call)\n", *(unsigned long long*)0x40948d140
+  printf "GOT[0xab]=0x%llx\n", *(unsigned long long*)0x40948d148
+  kill
+  quit
+end
+run
+quit

--- a/prosper/tools/dbg/kill_doll.sh
+++ b/prosper/tools/dbg/kill_doll.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Kill stray DOLL boot_trace processes (not Messenger, not ourselves)
+for p in /proc/[0-9]*/cmdline; do
+  d=${p%/cmdline}; pid=${d#/proc/}
+  [ "$pid" = "$$" ] && continue
+  if tr "\0" " " < "$p" 2>/dev/null | grep -q "boot_trace /root/PPSA17942"; then
+    echo "killing $pid"; kill -9 "$pid" 2>/dev/null
+  fi
+done
+echo kill_doll done

--- a/prosper/tools/dbg/run222.sh
+++ b/prosper/tools/dbg/run222.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Run DOLL under gdb catching the #222 fault.
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+gdb -batch -x tools/dbg/catch222.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/catch222.log 2>&1
+echo "gdb done, exit=$?"
+grep -n "FATAL 222" /root/catch222.log | head -2
+tail -120 /root/catch222.log

--- a/prosper/tools/dbg/run_count18.sh
+++ b/prosper/tools/dbg/run_count18.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1
+gdb -batch -x tools/dbg/count18.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/count18.log 2>&1
+echo "rc=$?"
+sed -n "/count-read hit/,/==== DONE/p" /root/count18.log | head -40

--- a/prosper/tools/dbg/run_doll.sh
+++ b/prosper/tools/dbg/run_doll.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Run DOLL for N seconds with full logging, then summarize draw evidence.
+SECS=${1:-300}
+LOG=${2:-/root/scene2.log}
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+  timeout "$SECS" ./build-linux/boot_trace /root/PPSA17942-app0 > "$LOG" 2>&1
+echo "run done rc=$?"
+echo "=== flips ==="; grep -c "GpuFlip" "$LOG"
+echo "=== last flip ==="; grep "GpuFlip" "$LOG" | tail -2
+echo "=== submits ==="; grep -c "SubmitDcb" "$LOG"
+echo "=== draws (SetCxRegistersIndirect / DrawIndex) ==="
+grep -cE "kind=DrawIndex" "$LOG"
+grep -E "draws so far: [1-9]" "$LOG" | tail -5
+echo "=== ctxinit calls ==="; grep -c "CtxInit" "$LOG"
+grep "CtxInit" "$LOG" | head -5
+grep "CtxInit" "$LOG" | tail -3
+echo "=== worker faults ==="; grep -c "WORKER-THREAD FAULT" "$LOG"
+grep -A2 "WORKER-THREAD FAULT" "$LOG" | head -6
+echo "=== presented ==="; grep -c "presented" "$LOG"
+grep "presented" "$LOG" | tail -3
+echo "=== tail ==="; tail -5 "$LOG"

--- a/prosper/tools/dbg/run_drawnid.sh
+++ b/prosper/tools/dbg/run_drawnid.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1
+gdb -batch -x tools/dbg/drawnid.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/drawnid.log 2>&1
+echo "gdb done rc=$?"
+grep -n "HIT DONE\|hit #" /root/drawnid.log | head
+sed -n "/hit #5 /,/HIT DONE/p" /root/drawnid.log | head -80

--- a/prosper/tools/dbg/run_drawnid2.sh
+++ b/prosper/tools/dbg/run_drawnid2.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1
+gdb -batch -x tools/dbg/drawnid2.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/drawnid2.log 2>&1
+echo "gdb done rc=$?"
+sed -n "/hit #3 /,/HIT DONE/p" /root/drawnid2.log | head -70
+sed -n "/hit #40 /,/HIT DONE/p" /root/drawnid2.log | head -70

--- a/prosper/tools/dbg/run_gotmap.sh
+++ b/prosper/tools/dbg/run_gotmap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_STUBDUMP=1
+gdb -batch -x tools/dbg/gotmap.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/gotmap.log 2>&1
+echo "rc=$?"
+grep -E "GOT\[" /root/gotmap.log
+# map the stub addresses to NIDs via the stub dump
+for g in $(grep -oE "GOT\[0x(a9|aa)\]=0x[0-9a-f]+" /root/gotmap.log | cut -d= -f2); do
+  off=$(( g - 0x600000000 ))
+  printf "stub offset for %s = +0x%x\n" "$g" "$off"
+  grep -iE "\+0x0*$(printf %x $off)\b" /root/gotmap.log | head -2
+done

--- a/prosper/tools/dbg/run_vostatus.sh
+++ b/prosper/tools/dbg/run_vostatus.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1
+gdb -batch -x tools/dbg/vostatus.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/vostatus.log 2>&1
+echo "rc=$?"
+sed -n "/GetOutputStatus a0/,/==== DONE/p" /root/vostatus.log | head -40

--- a/prosper/tools/dbg/sample_bt.sh
+++ b/prosper/tools/dbg/sample_bt.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Diagnostic: run DOLL to steady state, then sample all-thread backtraces with gdb.
+# Usage: sample_bt.sh <sleep_seconds> <nsamples>
+SLEEP=${1:-150}
+N=${2:-5}
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene1.log 2>&1 &
+PID=$!
+echo "boot_trace pid=$PID"
+sleep "$SLEEP"
+echo "=== thread cpu usage (utime+stime, tid, comm) ===" > /root/bt_samples.txt
+for t in /proc/$PID/task/*; do
+  tid=$(basename "$t")
+  read -r -a f < "$t/stat" 2>/dev/null || continue
+  # comm may contain spaces; stat fields after comm shift. comm is field 2 in parens.
+  utime=$(awk '{ for(i=1;i<=NF;i++) if ($i ~ /\)$/) { print $(i+12)+$(i+13); exit } }' "$t/stat" 2>/dev/null)
+  name=$(cat "$t/comm" 2>/dev/null)
+  echo "$utime $tid $name"
+done | sort -rn | head -14 >> /root/bt_samples.txt
+for i in $(seq 1 "$N"); do
+  echo "=== SAMPLE $i ===" >> /root/bt_samples.txt
+  gdb -p "$PID" -batch -ex "set pagination off" -ex "thread apply all bt 24" >> /root/bt_samples.txt 2>&1
+  sleep 3
+done
+kill -9 "$PID" 2>/dev/null
+echo "=== log tail ==="
+tail -30 /root/scene1.log

--- a/prosper/tools/dbg/sample_stall.sh
+++ b/prosper/tools/dbg/sample_stall.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Run DOLL; when GpuFlip count stops advancing for 30s, gdb-sample all threads (the RenderThread stall).
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene3.log 2>&1 &
+PID=$!
+echo "boot_trace pid=$PID"
+last=0; same=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10
+  cur=$(grep -c GpuFlip /root/scene3.log 2>/dev/null)
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then
+    same=$((same+1))
+  else
+    same=0
+  fi
+  last=$cur
+  if [ "$same" -ge 3 ]; then break; fi
+done
+if ! kill -0 $PID 2>/dev/null; then echo "process died before stall detection"; exit 1; fi
+echo "stall detected at flips=$last — sampling"
+echo "=== thread cpu (utime+stime tid comm) ===" > /root/bt_samples.txt
+for t in /proc/$PID/task/*; do
+  tid=$(basename "$t")
+  utime=$(awk '{ for(i=1;i<=NF;i++) if ($i ~ /\)$/) { print $(i+12)+$(i+13); exit } }' "$t/stat" 2>/dev/null)
+  name=$(cat "$t/comm" 2>/dev/null)
+  echo "$utime $tid $name"
+done | sort -rn | head -16 >> /root/bt_samples.txt
+for i in 1 2; do
+  echo "=== SAMPLE $i ===" >> /root/bt_samples.txt
+  gdb -p "$PID" -batch -ex "set pagination off" -ex "thread apply all bt 14" >> /root/bt_samples.txt 2>&1
+  sleep 2
+done
+kill -9 "$PID"
+echo SAMPLING-DONE

--- a/prosper/tools/dbg/smoke_messenger.sh
+++ b/prosper/tools/dbg/smoke_messenger.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Messenger render smoke: must render frames (presented) with the live renderer.
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
+  timeout 240 ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smoke.log 2>&1
+echo "rc=$?"
+echo "=== presented frames ==="
+grep -c "presented" /root/smoke.log
+grep "presented" /root/smoke.log | tail -2
+echo "=== draws ==="
+grep -E "draws so far: [1-9]" /root/smoke.log | tail -2
+echo "=== faults ==="
+grep -c "WORKER-THREAD FAULT\|RUN ENDED" /root/smoke.log
+tail -3 /root/smoke.log

--- a/prosper/tools/dbg/stall_guest_bt.sh
+++ b/prosper/tools/dbg/stall_guest_bt.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Run DOLL; at flip stall, dump raw stacks of ALL threads and extract guest (0x4xxxxxxxx) RAs.
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene4.log 2>&1 &
+PID=$!
+echo "boot_trace pid=$PID"
+last=0; same=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10
+  cur=$(grep -c GpuFlip /root/scene4.log 2>/dev/null)
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 3 ]; then break; fi
+done
+if ! kill -0 $PID 2>/dev/null; then echo "process died before stall"; exit 1; fi
+echo "stall at flips=$last — dumping guest stacks"
+cat > /tmp/gbt.gdb << "GEOF"
+set pagination off
+define gstack
+  printf "===== THREAD-STACK %d =====\n", $arg0
+  thread $arg0
+  set $p = $sp
+  set $e = $sp + 4096
+  while $p < $e
+    set $v = *(unsigned long long*)$p
+    if ($v >= 0x400000000 && $v < 0x40a000000) || ($v >= 0x600000000 && $v < 0x600100000)
+      printf "sp+0x%04x: 0x%llx\n", (unsigned int)($p - $sp), $v
+    end
+    set $p = $p + 8
+  end
+end
+GEOF
+NT=$(ls /proc/$PID/task | wc -l)
+echo "threads: $NT"
+{
+  echo "set pagination off"
+  echo "source /tmp/gbt.gdb"
+  i=1
+  while [ $i -le $NT ]; do
+    echo "gstack $i"
+    i=$((i+1))
+  done
+} > /tmp/gbt_all.gdb
+gdb -p $PID -batch -x /tmp/gbt_all.gdb > /root/guest_stacks.txt 2>&1
+kill -9 $PID
+echo GSTACK-DONE
+wc -l /root/guest_stacks.txt

--- a/prosper/tools/dbg/thunks.sh
+++ b/prosper/tools/dbg/thunks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Disassemble the AGC import thunks to reveal their GOT slots.
+for a in 0x58deee0 0x58def30 0x58def70 0x58defc0 0x58df020 0x58df440 0x58df4b0 0x58df510 \
+         0x58dfa10 0x58dfa90 0x58dfd30 0x58dfc30 0x58dfaf0 0x58dfae0 0x58dfb00 0x58dfc00 0x58fdb00; do
+  echo "== $a =="
+  objdump -D -b binary -m i386:x86-64 --start-address=$((a)) --stop-address=$((a + 0x14)) /tmp/text.bin | tail -n +8 | head -4
+done

--- a/prosper/tools/dbg/trophy_names.sh
+++ b/prosper/tools/dbg/trophy_names.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Brute-force candidate names for the NpTrophy2 NIDs via the nid test tool if it supports hashing,
+# else compile a one-off hasher against nid.cpp.
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cat > /tmp/nidhash.cpp << "EOF"
+#include <cstdio>
+#include <string>
+namespace prosper { std::string nid_hash(const std::string& name); }
+int main(int argc, char** argv) {
+    for (int i = 1; i < argc; i++)
+        printf("%-52s %s\n", argv[i], prosper::nid_hash(argv[i]).c_str());
+    return 0;
+}
+EOF
+g++ -O1 -std=c++17 -Isrc /tmp/nidhash.cpp src/hle/nid.cpp -o /tmp/nidhash 2>/tmp/nidhash.err || { cat /tmp/nidhash.err | head -5; exit 1; }
+/tmp/nidhash \
+  sceNpTrophy2GetTrophySetInfo sceNpTrophy2GetTrophySetInfoInGroup \
+  sceNpTrophy2GetTrophyInfo sceNpTrophy2GetTrophyInfoList sceNpTrophy2GetTrophyInfos \
+  sceNpTrophy2GetGroupInfo sceNpTrophy2GetGroupInfoList sceNpTrophy2GetGroupInfos \
+  sceNpTrophy2GetTrophyList sceNpTrophy2GetTrophies sceNpTrophy2GetTrophyDetails \
+  sceNpTrophy2CreateContext sceNpTrophy2DestroyContext sceNpTrophy2RegisterContext \
+  sceNpTrophy2AbortHandle sceNpTrophy2CreateHandle sceNpTrophy2DestroyHandle \
+  sceNpTrophy2UnlockTrophy sceNpTrophy2GetUnlockedTrophies \
+  sceNpTrophy2GetTrophyGameDetails sceNpTrophy2GetTrophyGameData \
+  sceNpTrophy2SetInfoGetTrophyNum sceNpTrophy2GetTrophyNum \
+  sceNpTrophy2ShowTrophyList sceNpTrophy2GetGameInfo \
+  sceNpTrophy2SystemGetTrophyGameInfo sceNpTrophy2SystemGetTrophyInfo

--- a/prosper/tools/dbg/vostatus.gdb
+++ b/prosper/tools/dbg/vostatus.gdb
@@ -1,0 +1,33 @@
+# Capture the guest caller of sceVideoOutGetOutputStatus and its out-struct usage.
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+break _ZN7prosperL22g_vo_get_output_statusEmmmmmm
+commands
+  silent
+  printf "==== GetOutputStatus a0=0x%llx a1=0x%llx ====\n", $rdi, $rsi
+  printf "---- guest RAs on stack ----\n"
+  set $p = $sp
+  set $e = $sp + 1024
+  while $p < $e
+    set $v = *(unsigned long long*)$p
+    if ($v >= 0x400000000 && $v < 0x40a000000)
+      printf "sp+0x%04x: eboot+0x%llx\n", (unsigned int)($p - $sp), $v - 0x400000000
+    end
+    set $p = $p + 8
+  end
+  printf "---- out struct BEFORE (stack garbage) ----\n"
+  x/16gx $rsi
+  printf "==== DONE ====\n"
+  kill
+  quit
+end
+run
+quit


### PR DESCRIPTION
## Four post-load walls cleared — DOLL runs deep & stable (17k+ dispatches, 0 crash/0 OOM); Fixes #222

Continues the #213 investigation (DOLL renders 0 draws). Four distinct post-load walls between the empty present-loop and scene draws were RE'd (gdb capture + static disassembly of the eboot's statically-linked AGC library) and cleared. DOLL now runs **hundreds of flips / 17k+ compute dispatches deep into post-load engine init with 0 faults and 0 OOM** (was: crash at ~flip 140, or 34 GB OOM).

### Fixes
1. **Fixes #222 — the EUD-ring fault (`eboot+0x59949e4`) was scene-draw-prep, not a race.** `+kSrjIVxKFE` (AGC register-context ctor) is a live-context **reset**, not one-time init. The Stage-1 handler only overwrote `[sub+0x08]`, leaving `+0x44` stale-nonzero, so re-binding a shader early-outed in SetSource and the EUD writer stored at slot `0xffff` → `0 + 0xffff*4 - 0x80 = 0x3ff7c` (the exact captured fault addr). Now models the guest's own sub-reset. Fired deterministically at title-screen activation.
2. **Per-draw fence cluster + DispatchDirect wired.** Three glog-stubbed NIDs are AGC sync-packet address patchers (`fPSCdQxgpSw`=WriteData, `3KDcnM3lrcU`=WaitRegMem, `0fWWK5uG9rQ`=ReleaseMem) — stubbed, every per-draw GPU fence targeted address 0. Also implemented `k3GhuSNmBLU`=`sceAgcDcbDispatchDirect` (new `R_DISPATCH_DIRECT` PM4 packet); dispatches now flow with 0 patch refusals.
3. **34.6 GB OOM was a trophy garbage-out.** `sceNpTrophy2GetGameInfo` (`4IzqhhUQ3nk`) returned success with an unwritten out-struct → the engine grew a 34,644,492,288-byte TArray from heap garbage. Now returns failure → clean trophy-unavailable path.
4. **sceVideoOutGetOutputStatus (#82) consumer RE'd** — DOLL reads `status+0x04` (dynamic-range mode) for its swapchain HDR/SDR switch; now writes a defined `{state=0, mode=0}` SDR prefix.

### Verified
- DOLL: **17,824 dispatches / 17,809 DCB submits over 300 s, 0 crashes, 0 OOM.**
- **ctest 63/63**; Messenger render smoke unregressed (the overridden NIDs are DOLL-specific — 0 calls in Messenger).
- Cherry-picked onto current master (not merged — the branch predates the #210/#224 squashes).

### Remaining (#213 stays open)
Still **0 scene draws** — the 17k dispatches are UE4's persistent per-frame *compute*, not geometry. The GameThread now parks far deeper, in a ~1 ms timed-poll loop: guest `eboot+0x2cc2340` vtable poll (`call *0x20(%rax)`) + a `vucomisd` elapsed-time compare (`eboot+0x2324190`), backed by a ~1 ms cond-wait (`eboot+0x22ea94f`). It polls an async completion a worker never delivers — the same undelivered-completion scene-activation shape as #208/#210, reached far deeper.
