### PR TITLE
feat(render): render-to-texture via a color-target RGBA cache (opt-in)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -15,14 +15,24 @@
 #include <cstring>
 #include <algorithm>
 #include <vector>
+#include <unordered_map>
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
 extern "C" int prosper_reserved_range_state(uint64_t addr);
 
 namespace prosper::frontend {
 
+// Render-to-texture surface cache (#167): CB_COLOR0_BASE -> the RGBA pixels we last rendered into it.
+// The game renders its scene into a color target then samples that address as a texture in a later
+// composite pass. Guest memory at that address is never populated on our (CPU-read) side, so without
+// this the composite samples zeros and the frame is black. We cache each submit's rendered pixels under
+// its render-target base and inject them when a subsequent draw samples a texture at a matching base.
+namespace { struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; }; }
+
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     static std::atomic<int> frame_no{0};
+    static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
+    static const bool rtt_on = getenv("PROSPER_RTT") != nullptr;
     prosper::gpu::set_submit_renderer(
         [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
             using RC = prosper::gpu::ResourceClass;
@@ -74,11 +84,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
                         size_t nb = (size_t)tw * th * 4;
                         texstore.emplace_back(nb, 0x00);
+                        // RTT (#167): if this texture's base is a color target we rendered into, inject those
+                        // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
+                        bool rtt_hit = false;
+                        if (rtt_on) { auto rit = g_rtt.find(r.gpu_addr);
+                            if (rit != g_rtt.end() && rit->second.w && rit->second.h && !rit->second.rgba.empty()) {
+                                const RttSurf& s = rit->second;
+                                for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
+                                    uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
+                                    size_t si = ((size_t)sy * s.w + sx) * 4;
+                                    if (si + 4 <= s.rgba.size()) std::memcpy(&texstore.back()[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
+                                }
+                                rtt_hit = true;
+                            }
+                            if (getenv("PROSPER_RTTLOG"))
+                                fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",
+                                        (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
+                                        rtt_hit ? "HIT" : "miss", g_rtt.size());
+                        }
                         // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
                         // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
                         // 16 bytes -> SW_4KB_S 16x16-block micro-tiles). #121.
-                        const uint32_t bcb = prosper::gpu::bc_block_bytes(r.format);
-                        if (bcb) {
+                        const uint32_t bcb = rtt_hit ? 0u : prosper::gpu::bc_block_bytes(r.format);
+                        if (rtt_hit) { /* pixels already injected from the RTT cache */ }
+                        else if (bcb) {
                             uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
                             // Block-detile: tiled_elements_bytes/detile_elements now derive the 4KB
                             // micro-tile geometry from the block size (bpe) internally (#119) — 16-byte
@@ -125,7 +154,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!bcb && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                        if (!rtt_hit && !bcb && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
                             size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
@@ -214,6 +243,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 bds.push_back(std::move(bd));
             }
             std::vector<uint8_t> px = prosper::test::render_draws_rgba(bds, w, h);
+            // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
+            // composite pass that samples that address gets the scene we drew (not empty guest memory).
+            if (rtt_on && !px.empty()) {
+                uint64_t tgt = 0;
+                for (const auto& it : items) if (it.color0_base) { tgt = it.color0_base; break; }
+                if (tgt) { RttSurf& s = g_rtt[tgt]; s.rgba = px; s.w = w; s.h = h; }
+                if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for(size_t i=0;i<px.size();i++) nz+=(px[i]!=0);
+                    fprintf(stderr, "[rtt] store target=0x%llx (%zu items, color0s:", (unsigned long long)tgt, items.size());
+                    for (const auto& it : items) fprintf(stderr, " 0x%llx", (unsigned long long)it.color0_base);
+                    fprintf(stderr, ") px_nonzero=%zu cache_size=%zu\n", nz, g_rtt.size()); }
+            }
             int n = frame_no++;
             if (px.empty()) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -194,10 +194,19 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             Gen5ImageFormatInfo fi;
             static bool warned[512] = {};                        // once per 9-bit format value
             if (!gen5_image_format(d.format, &fi)) {
-                if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
-                    fprintf(stderr, "[t#] UNMAPPED Gen5 IMG_FMT %u (%ux%u T#) -> skipping texture binding "
-                                    "(extend gen5_image_format)\n", d.format, d.width, d.height); }
-                continue;
+                // Unmapped IMG format. Under PROSPER_RTT, BIND it as RGBA8 anyway so the render-to-texture
+                // path can inject the pixels we rendered into this address (the composite that samples a
+                // scene color target uses an unmapped packed format, e.g. fmt=36 — skipping it means the
+                // RTT cache is never consulted and the frame stays black). Without RTT, keep skipping
+                // (a raw RGBA8 read of a real unmapped texture would sample garbage; #65).
+                if (!getenv("PROSPER_RTT")) {
+                    if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
+                        fprintf(stderr, "[t#] UNMAPPED Gen5 IMG_FMT %u (%ux%u T#) -> skipping texture binding "
+                                        "(extend gen5_image_format)\n", d.format, d.width, d.height); }
+                    continue;
+                }
+                fi.format = DataFormat::Unorm8; fi.num_components = 4; fi.bytes_per_block = 4;
+                fi.block_width = fi.block_height = 1;
             }
             // Block-compressed: BC1/BC2/BC3 are decoded to RGBA8 on upload (bc_decode). BC4/5/6/7 aren't
             // decoded yet, so keep skipping them (a raw RGBA8 binding would sample garbage + over-read).

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -41,6 +41,12 @@ struct DrawItem {
     // then IS the fetched index, which the recompiled VS uses for its storage-buffer vertex fetch);
     // empty -> plain vkCmdDraw(vertex_count).
     std::vector<uint32_t> indices;
+    // Render-to-texture (#167): the CB_COLOR0_BASE this draw renders INTO. The game renders its scene
+    // into a color target then samples that same address as a texture in a later composite pass; the
+    // live renderer caches each submit's rendered pixels under this address and injects them when a
+    // subsequent draw samples a texture at a matching base (otherwise the sample reads empty guest
+    // memory — the scene RT is never populated on the CPU side — and the frame is a black composite).
+    uint64_t color0_base = 0;
 };
 
 // The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8
@@ -202,6 +208,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     if (out.indices.empty() && vb_entries > vertex_count) vertex_count = vb_entries;
     out.vs = std::move(vs); out.fs = std::move(fs); out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
+    out.color0_base = rs.color0_base;   // render-to-texture: the target this draw writes into (#167)
     return true;
 }
 


### PR DESCRIPTION
## What (#167)
Render-to-texture: PPSA02664 (and The Messenger) render their scene into a color target, then a composite pass **samples that same address** as a texture. On our CPU-read sample path the target's guest memory is never populated → the composite sampled zeros → black frame (full proof in #121).

## How
- `DrawItem` now carries `color0_base` (the `CB_COLOR0_BASE` it renders into).
- The live renderer **caches each submit's rendered RGBA** under its render-target base, and when a later draw samples a texture whose base matches a cached target, **injects those pixels** (nearest-scaled) instead of reading empty guest memory.
- `build_shader_resources` binds unmapped-IMG-format textures (e.g. the scene target's packed `fmt=36`) as RGBA8 **under `PROSPER_RTT`** so they reach the sample path and the cache can fill them (default — skip unmapped — unchanged).

## Verified
`PROSPER_RTTLOG` shows the composite's 1920×1080 sample **HITs** the cache; stores carry a full-frame render. **68/68 ctest green** (opt-in; default paths unchanged).

## Honest scope
Gated behind `PROSPER_RTT` because it does **not yet produce visible content** for PPSA02664 — the cached render is **RGB=0**: the scene draws currently output pure black because their own source textures are empty at this game state (a separate upstream blocker, #121/#229). This is the RTT infrastructure #167 needs; it surfaces real content the moment the scene draws produce color. Proven end-to-end with `PROSPER_TESTTEX` (gradient textures → visible gradient), which confirms the entire sample→display path is correct.

Refs #167