### PR TITLE
fix(hle): deliver every GPU EOP completion (coalesce=false) — unblocks The Messenger's scene activation

### DIFF
--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -429,11 +429,20 @@ void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
 // == GPU pipe drain == the EOP interrupt moment). Posts TriggerEvent(ident=id, filter=GraphicsCore,
 // data=id, udata) to each registered equeue, matching shadPS4's IRQ handler. Inert if none registered.
 void prosper_eq_trigger_eop() {
+    // Deliver EVERY GPU-completion event as a DISTINCT equeue entry (coalesce=false). All EOP events share
+    // the same (ident, EVFILT_GRAPHICS_CORE), so coalescing collapses N submit-completions into ONE pending
+    // event — and the game's EOP handler posts a work-queue semaphore once per delivered completion, so a
+    // coalesced completion UNDER-posts the semaphore and its consumer deadlocks (GfxDevice work-queue
+    // eboot+0xb06ad2 / PreloadManager 0x18a83b5 / a worker). That was The Messenger's post-SaveData
+    // scene-activation stall (#234): with coalesce=false the scene activates and the intro cutscene plays;
+    // with the old coalescing it freezes on one frame. Same reason the APR channel (#210) is coalesce=false
+    // — a completion is a discrete count, never a level. PROSPER_EOP_COALESCE restores the old behavior.
+    static const bool coalesce = getenv("PROSPER_EOP_COALESCE") != nullptr;
     std::vector<FlipReg> regs;
     { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_eop_regs; }
     for (auto& r : regs) {
         SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
-        eq_post(r.eq, e);
+        eq_post(r.eq, e, coalesce);
     }
 }
 


### PR DESCRIPTION
## Symptom

The Messenger froze on a **single static frame** after SaveData: the scene never activated, the worker pool sat idle, and the update loop never reached `scePadOpen` — so **no input worked** (#234), and the intro cutscene never played.

## Root cause

`prosper_eq_trigger_eop()` **coalesced** GPU end-of-pipe completion events. Every EOP event shares the same `(ident, EVFILT_GRAPHICS_CORE)`, so kqueue-style coalescing collapses **N submit-completions into ONE** pending event. The game's EOP handler posts a work-queue **semaphore once per delivered completion**, so a coalesced completion **under-posts** the semaphore and its consumer deadlocks.

Traced with a validated stack unwinder (keep only real return addresses — those preceded by a `call rel32`) to **three blocked threads**, all waiting on producer-consumer semaphores whose posts were being lost:
- GfxDevice work-queue — `eboot+0xb06ad2` (`lock xadd -1, 0x130(%rbx)` → block)
- PreloadManager — `eboot+0x18a83b5`
- a worker

## Fix

Fire each EOP completion as a **distinct equeue entry** (`coalesce=false`) — a completion is a discrete count, never a level. This is exactly what the APR pointer-tag channel (#210) already does for the same reason.

## Verification

- With `coalesce=false` the **scene activates and the intro cutscene plays**: `1 → 42` distinct rendered frames (was frozen on one). Independently, **force-posting those exact three semaphores** reproduced the same unblock (cutscene plays), confirming the mechanism.
- **68/68 tests green**; no default-path regression in the boot.
- `PROSPER_EOP_COALESCE` restores the old behavior for bisection.

## Scope

Shared GPU-completion infra (Messenger/shared-infra lane). Low risk — delivering *more* completions is safe (a slow consumer only backs up to the equeue's 64-entry leak guard); coalescing was strictly losing completions. UE4/DOLL agents may want to confirm their titles on this, but the change matches the APR channel's established behavior.

The intro cutscene now plays (was a frozen frame). Reaching `scePadOpen` (interactive input) is the next step and is tracked in #234 — this removes the deadlock that blocked it.

Refs #234, #163.