### PR TITLE
fix(render): decode single-channel (R8) sampled textures instead of reading them as RGBA8

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -84,6 +84,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
                         size_t nb = (size_t)tw * th * 4;
                         texstore.emplace_back(nb, 0x00);
+                        // Real bytes-per-texel of the SAMPLED surface. Single/dual-channel textures (an R8
+                        // font/coverage atlas — this game's 2048x1024 c1 surface) are NOT 4 B/texel; reading
+                        // them as RGBA8 packs adjacent texels into one pixel and over-reads the allocation,
+                        // which is why glyph text rendered as solid white/black BLOCKS (#102). bpt drives a
+                        // narrow read+expand path below. StorageImage / unknown formats keep 4 B (bpt=0->4).
+                        uint32_t bpt = prosper::gpu::data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
+                        if (bpt == 0 || bpt > 4) bpt = 4;
+                        bool narrow_done = false;
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
@@ -124,6 +132,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 safe_copy(lin.data(), r.gpu_addr, comp_bytes);
                             }
                             prosper::gpu::bc_decode_surface(texstore.back().data(), lin.data(), lin.size(), tw, th, r.format);
+                        } else if (bpt < 4) {
+                            // Narrow (single/dual-channel) surface: read at the REAL element size and detile
+                            // with the matching bpe geometry (1 B -> 64x64 micro-tiles, #119), then expand
+                            // each texel to grayscale RGBA8 (replicate to R,G,B,A) so the sampling shader
+                            // reads the coverage in ANY channel it uses (.r for a font atlas, .a for a mask).
+                            std::vector<uint8_t> nlin((size_t)tw * th * bpt, 0);
+                            bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                            if (tiled) {
+                                size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
+                                std::vector<uint8_t> traw(tbytes, 0);
+                                size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                if (got < nlin.size()) safe_copy(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
+                                else prosper::gpu::detile_surface(nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                            } else {
+                                safe_copy(nlin.data(), r.gpu_addr, nlin.size());
+                            }
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint8_t v = nlin[t * bpt];   // first (coverage) channel
+                                uint8_t* p = &texstore.back()[t * 4];
+                                p[0] = p[1] = p[2] = p[3] = v;
+                            }
+                            narrow_done = true;   // already detiled+expanded; skip the 32-bpp auto-detile below
                         } else {
                             safe_copy(texstore.back().data(), r.gpu_addr, nb);
                         }
@@ -154,7 +184,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!rtt_hit && !bcb && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                        if (!rtt_hit && !bcb && !narrow_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
                             size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -112,10 +112,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         fprintf(stderr, "[rt] color0=0x%llx", (unsigned long long)rs.color0_base);
         if (prt) for (const auto& r : prt->resources)
             if (r.cls == ResourceClass::Texture)
-                fprintf(stderr, " tex=0x%llx(%ux%u)", (unsigned long long)r.gpu_addr, r.width, r.height);
+                fprintf(stderr, " tex=0x%llx(%ux%u f%u c%u)", (unsigned long long)r.gpu_addr, r.width, r.height,
+                        (unsigned)r.format, r.num_components);
         if (vrt) for (const auto& r : vrt->resources)
             if (r.cls == ResourceClass::Texture)
-                fprintf(stderr, " vtex=0x%llx(%ux%u)", (unsigned long long)r.gpu_addr, r.width, r.height);
+                fprintf(stderr, " vtex=0x%llx(%ux%u f%u)", (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
         fprintf(stderr, "\n");
     }
     std::vector<uint32_t> vs = recompile_vertex((const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());


### PR DESCRIPTION
## Problem

The live renderer's texture-upload path (`frontends/shared/live_renderer.cpp`) allocated and read **every** sampled texture as `tw*th*4` (RGBA8). A single-channel surface — The Messenger's **2048×1024 Unorm8 `c1`** atlas (a font/coverage/alpha atlas) — is only `tw*th*1` bytes, so reading it as RGBA8:
- over-read the allocation by 4×, and
- packed 4 adjacent coverage bytes into one RGBA pixel,

collapsing glyph/coverage data into solid blocks (the "text as white blocks" symptom tracked in #102).

## Fix

Handle narrow (`bytes_per_texel < 4`) surfaces explicitly:
1. read at the **real** element size,
2. detile with the matching bpe geometry (1 B → 64×64 micro-tiles, #119),
3. expand each texel to grayscale RGBA8 (replicate the coverage byte to R,G,B,A) so the sampling shader reads it in whichever channel it uses — `.r` for a font atlas, `.a` for an alpha mask (the game's alpha-test text PS samples `dmask:0x8` = `.a`).

`bpt` is derived from the T#'s real format/components; StorageImage / unknown formats keep the 4-byte path (`bpt=0 → 4`), so nothing currently-correct changes. Also extends `PROSPER_RTLOG` to print each sampled texture's format+components (what surfaced the single-channel atlas).

## Scope / safety

This is a **prerequisite** for the Messenger's text, not the whole fix. The alpha-tested text draws are still dropped at recompile — their `clip()`/discard branch (`s_cbranch_scc0` after an `image_sample`+`v_cmp`+`s_andn2` alpha test) isn't lowered yet (root-caused with disassembly in #102, overlaps #178). Because **no single-channel texture reaches this path until that lands**, this change cannot regress any currently-visible texture, and it's correct on its own.

**68/68 ctest green.** Refs #102, #119.