### PR TITLE
fix(gpu): lower alpha-test/clip() discard branches so cutout+text draws recompile

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -936,6 +936,39 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
     return safe;
 }
 
+// FRAGMENT alpha-test / clip() discard via a SCALAR BRANCH. A per-lane condition (v_cmp -> VCC) is folded
+// into a saved-EXEC survivor mask by a 64-bit wave-mask op (s_and/s_andn2_b64 sDST,sDST,vcc — which on HW
+// sets SCC = "any lane survives"), then `s_cbranch_scc0 <fwd>` skips the shading when NO lane survives; the
+// block then narrows EXEC (s_wqm exec, sDST) and shades, and the export lowers to an OpKill of the failed
+// lanes. Per-invocation the wave early-out is a pure optimization — running the block for a lane that will
+// be OpKill'd at export is harmless — so the branch is safe to LINEARIZE (drop it, run the block straight-
+// line) exactly like a forward s_cbranch_execz. Recognize it by the mask op IMMEDIATELY preceding the
+// branch (hints ignored). Returns the pc of each such branch. This is the shape of every Unity cutout /
+// text draw; rejecting the branch dropped all of them (The Messenger's missing cutscene text, #102).
+std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& ins) {
+    std::unordered_set<uint32_t> out;
+    const Rdna2Inst* prev = nullptr;
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (sopp_is_noop(in)) continue;                         // hints don't break the mask->branch pairing
+        if (in.fmt == Rdna2Format::SOPP && (in.opcode == 0x04 || in.opcode == 0x05) && in.simm16 > 0) {
+            // scc0/scc1 FORWARD branch whose SCC was set by a 64-bit wave-mask op: SOP2 s_and_b64(0x0f) /
+            // s_or_b64(0x11) / s_xor_b64(0x13) / s_andn2_b64(0x15), or SOP1 s_and/or_saveexec_b64 (0x24/0x25),
+            // writing a plain SGPR-pair kill mask. (A branch on a v_cmp/s_cmp SCC is a REAL uniform-if and is
+            // NOT matched — prev would be a SOPC/ALU, not a mask op.)
+            if (prev) {
+                bool mask_sop2 = prev->fmt == Rdna2Format::SOP2 &&
+                    (prev->opcode == 0x0f || prev->opcode == 0x11 || prev->opcode == 0x13 || prev->opcode == 0x15);
+                bool mask_saveexec = prev->fmt == Rdna2Format::SOP1 && (prev->opcode == 0x24 || prev->opcode == 0x25);
+                if ((mask_sop2 || mask_saveexec) && prev->dst.kind == OperandKind::SGPR && prev->dst.value <= 105)
+                    out.insert(in.pc);
+            }
+        }
+        prev = &in;
+    }
+    return out;
+}
+
 // A recognized COUNTED loop (the game's MSAA-resolve / accumulation shape): a single backward
 // unconditional branch (the back-edge) to a header, with exactly one forward SCC exit branch inside.
 // Anything more complex (nested loops, VCC/EXECNZ exits, multiple back-edges, mid-loop s_branch) is
@@ -1004,7 +1037,8 @@ struct ForwardIf {
 // code/dwords: the raw stream, so a branch target past the first s_endpgm can be decoded and
 // verified to be a genuine early-out (see below) instead of blanket-clamped.
 ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
-                            const uint32_t* code, size_t dwords) {
+                            const uint32_t* code, size_t dwords,
+                            const std::unordered_set<uint32_t>* skip = nullptr) {
     ForwardIf F; const Rdna2Inst* br = nullptr; int nbranch = 0; uint32_t end_pc = UINT32_MAX;
     for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
     for (const auto& in : ins) {
@@ -1017,6 +1051,8 @@ ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
                 if (!allow_vcc) return F;                            // compute: needs a wave-uniform VCC test
                 br = &in; nbranch++; break;
             case 0x04: case 0x05:                                    // scc0 / scc1 (SCC is scalar/wave-uniform)
+                if (skip && skip->count(in.pc)) break;               // alpha-test kill-mask branch: handled by
+                                                                     // straight-line linearization, not a struct-if
                 br = &in; nbranch++; break;
             default: break;                                          // hints (nop/waitcnt/…) are fine
         }
@@ -1712,6 +1748,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else ok = false;                                // barrier only meaningful in compute
                     break;
                 case 0x04: case 0x05:                              // s_cbranch_scc0 / scc1
+                    // An alpha-test / clip() kill-mask early-out (SCC = "any lane survives", set by a 64-bit
+                    // wave-mask op — see mask_test_branches) is a pure wave optimization: per-invocation the
+                    // survivor mask narrows EXEC in the block below and the export OpKills the failed lanes,
+                    // so the branch LINEARIZES away exactly like a forward s_cbranch_execz. Only these
+                    // recognized branches are dropped; any other SCC branch is still a real uniform-if we
+                    // can't model straight-line, so it rejects.
+                    if (safe_execz && safe_execz->count(in.pc)) break;   // recognized kill-mask branch -> no-op
+                    ok = false;
+                    break;
                 case 0x06: case 0x07:                              // s_cbranch_vccz / vccnz
                 case 0x09:                                         // s_cbranch_execnz
                     ok = false;
@@ -2211,7 +2256,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         }
         // 7. Post-loop body.
         if (!emit_range(L.exit_pc, UINT32_MAX)) return false;
-    } else if (const ForwardIf F = detect_forward_if(ins, /*allow_vcc*/!b.is_compute, code, dwords); F.found) {
+    } else if (const ForwardIf F = detect_forward_if(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe); F.found) {
         // Single structured uniform IF (forward s_cbranch_scc0/scc1): emit as OpSelectionMerge +
         // OpBranchConditional on the SCC bool, with an OpPhi per register written in the conditional
         // block that is live after the merge. Parallels the loop path's phi machinery. CONFIDENCE: MED —
@@ -2372,6 +2417,11 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
     }
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
+    // FRAGMENT-only: also linearize alpha-test / clip() kill-mask s_cbranch_scc0/scc1 early-outs (Unity
+    // cutout + text draws). Merged into the same set so emit_alu drops the branch and detect_forward_if
+    // skips it; the block's EXEC narrow + the export's OpKill do the per-invocation discard (#102). This is
+    // NOT added for the vertex/compute shells (their scc branches are real uniform-ifs / NGG culling).
+    for (uint32_t pc : mask_test_branches(ins)) safe_branches.insert(pc);
     bool exported = false;
     auto exp_fn = [&](const Rdna2Inst& in) -> bool {         // EXP MRT0..7 -> the color output
         // An export while EXEC is narrowed (lanes killed by an alpha test / v_cmpx and not restored to

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -166,6 +166,42 @@ int main() {
       } }
     printf("  [ok]   fragment cmpx export lowers to a discard (OpKill + export), valid SPIR-V\n");
 
+    // Alpha-test discard via the SCALAR-BRANCH form (not v_cmpx): compare a sampled/interpolated value,
+    // ANDN2 the survivor mask into a saved EXEC copy (SCC = "any lane survives"), and s_cbranch_scc0 skips
+    // the shading if NO lane survives; the block then narrows EXEC (s_wqm exec, survivors) and shades. This
+    // is Unity's clip()/cutout text+sprite shape (The Messenger's cutscene text, #102). The recompiler must
+    // lower it — drop the wave early-out, run the block, OpKill the failed lanes at export — instead of
+    // rejecting the s_cbranch_scc0, which dropped every alpha-tested text/sprite draw. Bytes assembled with
+    // llvm-mc gfx1010 (round-trip verified).
+    const uint32_t altest_kill_branch[] = {
+        0xbe82047eu,               // s_mov_b64  s[2:3], exec
+        0x7c020300u,               // v_cmp_lt_f32_e32 vcc_lo, v0, v1      (alpha < ref -> vcc)
+        0x8a826a02u,               // s_andn2_b64 s[2:3], s[2:3], vcc      (survivors; SCC = any-survivor)
+        0xbf840003u,               // s_cbranch_scc0 +3                    (skip shading if none survive)
+        0xbefe0a02u,               // s_wqm_b64  exec, s[2:3]              (narrow EXEC to survivors)
+        0x7e040300u,               // v_mov_b32  v2, v0
+        0x7e060301u,               // v_mov_b32  v3, v1
+        0x7e0802f2u,               // v_mov_b32  v4, 1.0
+        0x7e0a02f2u,               // v_mov_b32  v5, 1.0
+        0xf800180fu, 0x05040302u,  // exp mrt0 v2, v3, v4, v5 done vm
+        0xbf810000u,               // s_endpgm
+    };
+    auto altest_spv = recompile_fragment(altest_kill_branch, sizeof(altest_kill_branch) / sizeof(altest_kill_branch[0]));
+    if (altest_spv.empty()) {
+        printf("  [FAIL] alpha-test scalar-branch discard (s_cbranch_scc0 on kill mask) was rejected\n");
+        return 1;
+    }
+    { uint32_t bad_op = 0;
+      if (!type_result_ids_are_nonzero(altest_spv, &bad_op)) {
+          printf("  [FAIL] alpha-test discard SPIR-V has an invalid result id (op=%u)\n", bad_op);
+          return 1;
+      } }
+    { bool has_kill = false;                       // the discard must actually emit OpKill (op 252)
+      for (size_t i = 5; i < altest_spv.size(); ) { uint32_t wc = altest_spv[i] >> 16, op = altest_spv[i] & 0xffff;
+          if (op == 252u) { has_kill = true; break; } i += wc ? wc : 1; }
+      if (!has_kill) { printf("  [FAIL] alpha-test discard SPIR-V lacks an OpKill\n"); return 1; } }
+    printf("  [ok]   alpha-test scalar-branch (s_andn2+s_cbranch_scc0) lowers to a discard (OpKill), valid SPIR-V\n");
+
     const uint32_t cmpx_vertex[] = {
         0x7DA80300u, 0xF80008CFu, 0x03020100u, 0xBF810000u,
     };


### PR DESCRIPTION
## The missing-text root cause (traced in #102)

The Messenger's cutscene text, title logo, and character sprites are **alpha-tested** (Unity `clip()`/cutout) draws. Their fragment shader is:
```
image_sample v6, ..., dmask:0x8      ; sample coverage (alpha)
v_cmp_lt_f32 vcc, v6, vREF           ; alpha < threshold?
s_andn2_b64 sSAVE, sSAVE, vcc        ; survivor mask; SCC = "any lane survives"
s_cbranch_scc0 <tail>                ; wave early-out if none survive   <-- REJECTED
s_wqm_b64 exec, sSAVE                 ; narrow EXEC to survivors
... shade ...  export
```
The recompiler rejected the `s_cbranch_scc0`, so `recompile_fragment` returned empty and **every alpha-tested draw was dropped** (~102/frame) — the missing cutscene text, the absent title logo, and much of the "dither" (which was largely failed sprite draws).

## Fix

Per-invocation, the wave early-out is a pure optimization: the survivor mask already narrows EXEC in the block below, and the export lowers to an `OpKill` of the failed lanes (the existing `discard_unless` path). So the branch **linearizes away exactly like a forward `s_cbranch_execz`**.

`mask_test_branches()` recognizes the idiom — a forward `s_cbranch_scc0/scc1` whose SCC was set by a 64-bit wave-mask op (`s_and/andn2/or/xor_b64` or `saveexec`). In the **fragment shell only**, the branch is dropped (`emit_alu` no-ops it; `detect_forward_if` skips it). Vertex/compute shells are untouched (their scc branches are real uniform-ifs / NGG culling), so nothing else changes.

## Result

- Messenger alpha-tested draws recompile: **recompile-failed 102 → 0**.
- The title **"MESSENGER" logo text** and the cutscene **character sprite** now render (both were entirely absent), and the scene dither drops sharply.
- New unit test (llvm-mc-assembled gfx1010 shader) asserts the idiom lowers to valid SPIR-V containing an `OpKill`.
- **68/68 ctest green.**

Best viewed together with #237 (single-channel R8 atlas decode) — the two are independent code-wise but jointly produce crisp alpha-tested text. Refs #102, #178.