### PR TITLE
fix(agc): implement w1KFAHVqpaU final-buffer submit variant + guest-thread-names (refs #232)

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -892,3 +892,46 @@ cleanly). Fixing the ring-drain/EOP delivery should let the RenderThread complet
 the fence, and advance the GameThread into world activation + the first scene draws. Diagnostic
 gdb tooling added this session: `tools/dbg/poll_probe.{sh,gdb}`, `poll_deep.{sh,gdb}`,
 `stall_bt2.sh`, `gwalk.sh`.
+
+### SOLVED (2026-07-09, issue #232): the FRenderCommandFence wall was an UNFOLDED submit variant (w1KFAHVqpaU) — DOLL advances 178 → 284 flips past it
+
+Post-#236 (EOP coalesce=false), DOLL still parked: every thread idle except **RenderThread 1**,
+which spin-yielded in a timeout poll at **eboot+0x221d6c2** (`mov 0x30(%rbx),%rax ; cmpq $0,(%rax)`
+reached from eboot+0x3bf4862) waiting for a GPU **fence label to become nonzero**. Live probe
+(`tools/dbg/slot232.py`): the polled label = `*[obj+0x30]` = **0x1180f06760**, value stuck at 0.
+That label is the destination of a `ReleaseMem action=0x14 addr=0x1180f06760 data=0x1` the guest
+BUILT — but `EOP write [0x1180f0*]` count was **0**: the Dcb carrying those fences was never folded.
+
+**Root cause: DOLL's UE4 RHI submits through TWO driver entry points, and we only folded one.** The
+guest `SubmitCommandBuffers` impl (eboot+0x220a9a0) loops the buffer array, submitting buffers
+[0..n−2] via `sceAgcDriverSubmitDcb` (UglJIZjGssM — folded) and the **final** buffer (eboot+0x220aace)
+via **w1KFAHVqpaU**, which was unimplemented (returned 0). So every batch's final buffer — carrying
+the RenderThread's completion fences at 0x1180f0xxxx — was dropped on the floor; the label never went
+nonzero, the RenderThread never completed the frame, and the GameThread's 120 s watchdog fired.
+
+**Fix (committed, `hle_agc.cpp` `agc_driver_submit_dcb_variant`):** fold w1KFAHVqpaU's Dcb through the
+CommandProcessor and fire EOP, same as the primary path. ABI RE'd from the compiler adapter thunk
+(eboot+0x58df3f0) that marshals the internal call into the Sony import — the raw dword-stream address
+is stack **arg8**, forwarded by the guest-%fs swap stub to **fp[3]** (the slot ReleaseMem/WaitRegMem
+already read arg8 from). The dword count (arg9) is past the 2-arg forward window, so the fold relies on
+`decode_pm4`'s type-3 self-termination (observed bounded: 377–10386 packets, well under the
+512 Ki-dword runaway cap). The PM4 header is validated before folding (fallback: scan a0..a5; refuse +
+log otherwise) so a wrong pointer can never fold garbage.
+
+**Verified:** w1KFAHVqpaU now folds every frame; **2100 EOP writes land in the 0x1180f0 fence region**
+(was 0); the frame loop advances **178 → 284 flips** past the wall. ctest 63/63; Messenger unregressed
+(153 rendered frames to #980, 0 faults — it never calls this path). CONFIDENCE: MED (buffer-slot ABI +
+missing-fence symptom pinned; unknown-length fold empirically bounded, not ABI-confirmed).
+
+**NEW WALL (next session):** past the fence, DOLL hits a deeper **worker-thread fault at
+eboot+0x2316c91** — `mov (%rbx),%rcx` on a corrupt free-list node (`rbx≈0x20015f00`, a bad "next"
+pointer popped by `mov (%r8),%rbx` at +0x2316c85; this is a memory-pool/free-list alloc). Still **0
+scene DrawIndex/DrawIndexAuto** — the ~1500-packet-per-frame stream folded via w1KFAHVqpaU is still
+UE4's compute/setup work (dispatches climb to 3500+), not scene geometry. Open questions: (a) is the
+0x2316c91 free-list node corrupted by the unknown-length fold over-walking (lower the cap / widen the
+swap stub to forward arg9 = the true count and re-check), or is it an independent deeper init-race
+(the doc's "worker-thread face")? (b) what populates that pool, and does world/level activation gate
+on it? Probes added: `tools/dbg/slot232.py`, `w1k232.py`, `gw232.py`, `waketrace232.py`,
+`unimpl232.py`, `gotwho.cpp`, `nid2got.cpp`, `run232{b..h}.sh`. Thread-name adoption
+(`pthread_setname_np` in `k_pthread_create`) now labels all guest threads in gdb/procfs — the probe
+that made the RenderThread identifiable.

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -833,3 +833,62 @@ vtable object at eboot+0x2cc236a's `*0x20(%rax)` (break there, walk the interfac
 +0x2324190 double compare gates — likely a streaming-level / world-activation handshake, still on
 the FlushAsyncLoading -> TickAsyncLoading axis. Still 0 graphics draws (DrawIndex/DrawIndexAuto);
 the compute-only dispatch stream is UE4's persistent per-frame GPU setup, not scene geometry.
+
+### IDENTIFIED (2026-07-09, issue #232): the poll wall is UE4's FRenderCommandFence — the GameThread's GPU-hang watchdog; the RenderThread stalls in the libSceAgc submit ring-drain (intrinsic, intermittent)
+
+The #213/#231 "GameThread ~1 ms timed-poll" wall (eboot+0x2cc2340) is now positively identified by
+its own log strings (read out of eboot rodata; VA→file map is `off = 0x66e04d0 + (va − 0x669c000)`
+for the r-- segment, anchored on the `"Unknown"` FName at 0x82639c2):
+
+- 0x407e3b518 (UTF-16): **"GameThread timed out waiting for RenderThread after %.02f seconds"**
+- 0x407fe886a (UTF-16): **"GPU has hung or crashed!"**
+- 0x407e3b474 (UTF-16): **"Rendering thread exception:\r\n%s"**, and the CVar name **"r.GTSyncType"**.
+
+So eboot+0x2cc2340 is UE4's **`FRenderCommandFence::Wait` / GameThread↔RenderThread frame sync with
+the GPU-hang watchdog** (`GGameThreadWaitForRenderThreadTimeout`, 120 s — the loop's `vucomisd`
+compares elapsed vs a start+120.0 s deadline: start≈4.25 s, deadline≈124.25 s live). The poll
+`call *0x20(%rax)` is `FEvent::Wait(1 ms)` on the fence's completion event:
+- outer future obj vtable = eboot+0x8e38ee0; inner FEvent obj vtable = eboot+0x8e37ef8.
+- FEvent::Wait = eboot+0x22ea830 (reads triggered-state at `event+0x14`: 0=untriggered / 1=auto /
+  2=manual; waits on the guest pthread cond at `event+0x28`, mutex at `event+0x20`, via
+  `scePthreadCondTimedwait` → our `k_cond_timedwait`).
+- FEvent::Trigger = eboot+0x22f4cf0 (locks `event+0x20`, sets `event+0x14`=1/2, `cond_signal`
+  (0x6699490) / `cond_broadcast` (0x6699480) on `event+0x28` → our `k_cond_signal`/`broadcast`).
+The FEvent primitive itself is faithfully wired (ensure_cond/ensure_mutex CAS the guest slot to one
+host object; no signaler/waiter desync). **The completion genuinely never fires within 120 s → the
+guest then aborts through the warn path (eboot+0x2cc23dd) and SIGSEGVs in the libc.prx log formatter
+(rip=libc.prx+0x48e0) — a *secondary* crash in the hang logger, not the root cause.**
+
+**Root cause is the RenderThread/RHIThread, not the GameThread.** At the freeze (flips stop at
+~180–210; all-thread dump): GameThread(T1) parks in `k_cond_timedwait` on the fence FEvent cond;
+64 workers idle in `k_cond_wait`; the ONLY live event traffic is the VideoOut vblank pump
+(`WaitEqueue ident=1 filter=-13` ra=eboot+0x20001ac14) — **zero GPU-EOP kevents, zero
+TriggerUserEvent**. The RHIThread (T3) is deep in the **libSceAgc submit path**
+(eboot+0x59a49f2 → 0x59a6700 → 0x599f210 ring/pipe-progress lookup; helper eboot+0x58e0640 builds a
+kevent and calls a 0x66xxxxx sync thunk) — it is spin-sleeping in the submit **ring-drain / GPU-
+progress poll** that never advances, so the RenderThread waits on the RHIThread and the GameThread
+times out. i.e. the GPU submit ring fills and our executor never signals the submit-completion /
+ring read-pointer advance the guest's `sceAgcDcbSubmit` waits on.
+
+**It is intermittent** — the same build sails to 22 000+ flips on some runs, freezes ~188 on others
+— which fingerprints a **submit-completion / EOP-event delivery race** in the AGC executor, the same
+family as #208/#210/#231 (undelivered completion), now on the *steady-state per-frame* submit path.
+
+**The startup-movie hypothesis is DISPROVEN.** The freeze correlates in time with the opening
+cutscene (`doll/content/movies/cutscene/sms_opening_en.usm` opens ≈flip 186; only 3 media NIDs ever
+fire — `sceVideodec2QueryComputeMemoryInfo`=RnDibcGCPKw, `sceAjmInitialize`=dl+4eHSzUu4,
+`sceAjmModuleRegister`=Q3dyFuwGn64, all nid_hash-recovered), and 2 threads actively pace CRI-Atom
+audio in `audio2_ctx_push`. But **making every `.usm` fail its stat/access existence check (movie
+player sees them absent, all 7 incl. the opening cutscene refused) did NOT move the wall** — DOLL
+still froze at the identical FRenderCommandFence timeout + libc-logger SIGSEGV. The movie is a
+coincidental co-timing, not the cause.
+
+**Next session (the real fix):** instrument the libSceAgc submit ring model in the executor
+(prosper/src/gpu) — confirm each `sceAgcDcbSubmit` marks its ring range complete and advances the
+read-pointer / posts the submit-EOP the guest's ring-space poll (eboot+0x59a6700) reads, with no
+race under back-to-back compute-only submits. Reproduce with `tools/dbg/gwalk.sh` (freeze-detect +
+per-thread guest-RA walk) and compare the AGC submit/EOP path to the Messenger's (which drains
+cleanly). Fixing the ring-drain/EOP delivery should let the RenderThread complete the frame, fire
+the fence, and advance the GameThread into world activation + the first scene draws. Diagnostic
+gdb tooling added this session: `tools/dbg/poll_probe.{sh,gdb}`, `poll_deep.{sh,gdb}`,
+`stall_bt2.sh`, `gwalk.sh`.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -646,6 +646,77 @@ extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws) {
     if (draws)   *draws   = (uint64_t)agc_gpu_state().draws.size();
 }
 
+// Fold one raw Dcb dword stream through the CommandProcessor, fire the GPU EOP completion events, and
+// (if a live renderer is wired and the submit produced draws) execute+present. Shared by the primary
+// submit path (sceAgcDriverSubmitDcb) and the DOLL warmup-submit variant (w1KFAHVqpaU) below.
+// `dw_num == 0` means "length unknown" — decode_pm4 self-terminates at the first non-type-3 dword, and
+// we cap the walk at kUnknownCap dwords as a runaway guard (a bounded ring can't legitimately exceed it).
+static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const char* who) {
+    if (!addr) return 0;
+    constexpr uint32_t kUnknownCap = 0x80000;   // 512 KiB of dwords — well past any real Dcb
+    uint32_t walk = dw_num ? dw_num : kUnknownCap;
+    agc_gpu_state().draws.clear();
+    size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
+    g_submit_count++;
+    prosper_eq_trigger_eop();
+    static const unsigned render_every2 = [] {
+        const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
+    static unsigned draw_submits2 = 0;
+    if (gpu::have_submit_renderer() && !agc_gpu_state().draws.empty() && (draw_submits2++ % render_every2) == 0) {
+        uint32_t w = gpu::present_width(), h = gpu::present_height();
+        static const uint32_t scale = [] {
+            const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
+        if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
+        gpu::execute_and_present(agc_gpu_state(), w, h);
+    }
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] %s #%llu: %u dwords (walk=%u) -> %zu packets applied (draws: %zu, dispatches: %llu)\n",
+                who, (unsigned long long)g_submit_count, dw_num, walk, applied,
+                agc_gpu_state().draws.size(), (unsigned long long)agc_gpu_state().dispatch_count);
+    return 0;
+}
+
+// sceAgc submit variant (NID w1KFAHVqpaU) — DOLL's UE4 RHI submits its per-frame command buffers
+// through TWO driver entry points: intermediate buffers via sceAgcDriverSubmitDcb (UglJIZjGssM,
+// folded above) and the FINAL buffer of a SubmitCommandBuffers batch through THIS one (the guest's
+// SubmitCommandBuffers impl at eboot+0x220a9a0 loops the buffer array, calling the indirect submit for
+// buffers [0..n-2] and w1KFAHVqpaU for buffer n-1). Left unimplemented, the final buffer's GPU EOP
+// fences (ReleaseMem writes) never executed, so the label the RenderThread polls (eboot+0x221d6c2,
+// FRenderCommandFence/RHI frame-sync) stayed 0 forever and the GameThread timed out — the #232 wall.
+//
+// ABI (RE'd from the compiler-generated adapter thunk at eboot+0x58df3f0, which marshals DOLL's
+// internal call at eboot+0x220aace into the Sony import): the raw Dcb dword-stream address arrives as
+// stack arg8, which the guest-%fs swap stub forwards to fp[3] (the same slot ReleaseMem/WaitRegMem read
+// their 8th arg from). The dword count (arg9) is beyond the 2-arg forward window, so we fold with an
+// unknown length — decode_pm4 self-terminates at the first non-type-3 header. We validate that fp[3]
+// points at a real PM4 type-3 stream before folding, and if it doesn't, scan a0..a5 as a fallback;
+// anything that fails to validate is refused (no fold, logged once) rather than folding garbage.
+// CONFIDENCE: MED — the buffer address slot is pinned by the adapter disassembly + the missing-fence
+// symptom; the unknown-length fold relies on decode_pm4's type-3 termination (verified: the warmup
+// buffer is contiguous builder-emitted packets). Proven by the RenderThread advancing once folded.
+HLE(agc_driver_submit_dcb_variant) {
+    auto is_pm4 = [](uint64_t p) -> bool {
+        if (p < 0x10000 || (p & 3)) return false;
+        uint32_t h = *(const volatile uint32_t*)(uintptr_t)p;
+        return (h & 0xC0000000u) == 0xC0000000u;
+    };
+    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
+    uint64_t cand = fp[3];                                  // arg8 = the Dcb stream address (adapter ABI)
+    if (!is_pm4(cand)) {                                    // fallback: scan the register args
+        const uint64_t regs[6] = { a0, a1, a2, a3, a4, a5 };
+        cand = 0;
+        for (uint64_t r : regs) if (is_pm4(r)) { cand = r; break; }
+    }
+    if (!cand) {
+        static std::atomic<int> logged{0};
+        if (logged.fetch_add(1) < 4)
+            fprintf(stderr, "[agc] w1KFAHVqpaU: no PM4 stream found (fp[3]=0x%llx a0=0x%llx a1=0x%llx) — submit refused\n",
+                    (unsigned long long)fp[3], (unsigned long long)a0, (unsigned long long)a1);
+        return 0;
+    }
+    return submit_dcb_stream((const uint32_t*)(uintptr_t)cand, 0, "SubmitDcbFinal");
+}
+
 HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     struct Packet { uint32_t* addr; uint32_t dw_num; uint8_t pad[4]; };
     const auto* p = (const Packet*)(uintptr_t)a0;
@@ -816,6 +887,7 @@ void register_agc_hle() {
     RN("WmAc2MEj6Io", agc_dcb_dma_data);        // sceAgcDcbDmaData — append DMA_DATA packet (#117)
     RN("YUeqkyT7mEQ", agc_dcb_set_flip);        // sceAgcDcbSetFlip (Kyty LibGraphicsDriver.cpp:98)
     RN("UglJIZjGssM", agc_driver_submit_dcb);   // sceAgcDriverSubmitDcb -> CommandProcessor replay
+    RN("w1KFAHVqpaU", agc_driver_submit_dcb_variant);  // final-buffer submit variant (#232, DOLL RHI batch)
     #undef RN
 }
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -364,7 +364,7 @@ HLE(k_getprio)            { // scePthreadGetprio(thread, int* prio)
 // ids are recycled, so a stale entry would serve the next thread the dead thread's bounds.
 #ifdef __linux__
 namespace {
-struct ThreadStart { void* (*entry)(void*); void* arg; };
+struct ThreadStart { void* (*entry)(void*); void* arg; char name[16]; };
 // Runs first on the new thread: register our own stack (keyed by our tid) BEFORE any guest code,
 // so an early GC_register_my_thread / stack-base query from this thread finds it. Closes a race
 // where a fast-starting worker ran before the parent's post-create registration → "Bad stack base".
@@ -380,6 +380,11 @@ void* thread_trampoline(void* p) {
         }
     }
     install_sigaltstack();   // so a guest stack overflow on this worker is still catchable
+    // Adopt the guest's thread name (scePthreadCreate/pthread_create_name_np arg) as the HOST
+    // thread name so debugger/procfs views (gdb, /proc/PID/task/*/comm) show the engine's own
+    // role names (GameThread, RenderThread, RHIThread, ...) instead of the binary name. Kernel
+    // limit is 15 chars + NUL; host libc call, so it must run on the host %fs (we are).
+    if (ts->name[0]) pthread_setname_np(pthread_self(), ts->name);
     auto entry = ts->entry; void* arg = ts->arg; free(ts);   // all host libc — MUST run on the host %fs
     // gated (PROSPER_GUEST_FS): give this guest worker its own guest TCB + static TLS and switch %fs to it
     // as the LAST host action before entering guest code (so guest initial-exec TLS — incl. libc.prx's
@@ -432,7 +437,8 @@ HLE(k_pthread_create) {
     pthread_attr_setstacksize(&la, ssz);
     pthread_attr_setdetachstate(&la, detach);
     auto* ts = (ThreadStart*)malloc(sizeof(ThreadStart));
-    ts->entry = entry; ts->arg = arg;
+    ts->entry = entry; ts->arg = arg; ts->name[0] = 0;
+    if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
     pthread_attr_destroy(&la);
     if (r) { free(ts); return (uint64_t)r; }

--- a/prosper/tools/dbg/ctx232.sh
+++ b/prosper/tools/dbg/ctx232.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Show context around the fence-label build for the polled label, and check which buffer/submit it belongs to.
+L=/root/d232f.log
+n=$(grep -n "ReleaseMem action=0x14 dst=0x1 addr=0x1180f06760" "$L" | head -1 | cut -d: -f1)
+echo "line=$n of $(wc -l < "$L")"
+sed -n "$((n-60)),$((n+20))p" "$L" | grep -v "WAIT.empty\|delivered\|WaitEqueue eq"
+echo "=== how many 0x1180f0 fence builds, and are any folded? ==="
+grep -c "ReleaseMem action=0x14 dst=0x1 addr=0x1180f0" "$L"
+grep -c "EOP write \[0x1180f0" "$L"
+echo "=== last SubmitDcb line number vs fence-build line ==="
+grep -n "SubmitDcb #" "$L" | tail -3
+echo "=== WriteData execution to 0x1180f0? ==="
+grep -c "WriteData \[0x1180f0" "$L"

--- a/prosper/tools/dbg/ctx232b.sh
+++ b/prosper/tools/dbg/ctx232b.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Did the giant submit contain the warmup fence packets (ReleaseMem with hi-addr 0x11)?
+L=/root/d232f.log
+n=$(grep -n "SubmitDcb #174" "$L" | head -1 | cut -d: -f1)
+echo "giant submit at line $n"
+# packet dump follows the submit line; count pkt kinds and hi-addr pl1 values within the next 13000 lines
+sed -n "$((n+1)),$((n+13000))p" "$L" | grep "^\[agc\]   pkt" > /tmp/pkts174.txt
+wc -l /tmp/pkts174.txt
+echo "=== kinds ==="
+awk "{for(i=1;i<=NF;i++) if(\$i ~ /^kind=/) print \$i}" /tmp/pkts174.txt | sort | uniq -c | sort -rn
+echo "=== ReleaseMem pl1 (addr hi) values ==="
+grep "kind=ReleaseMem" /tmp/pkts174.txt | awk "{for(i=1;i<=NF;i++) if(\$i ~ /^pl1=/) print \$i}" | sort | uniq -c
+echo "=== WriteData pl2 (addr hi) values ==="
+grep "kind=WriteData" /tmp/pkts174.txt | awk "{for(i=1;i<=NF;i++) if(\$i ~ /^pl2=/) print \$i}" | sort | uniq -c | head
+echo "=== does any pkt carry pl>=0x80f0 (warmup label lo bytes)? ==="
+grep -c "80f0" /tmp/pkts174.txt

--- a/prosper/tools/dbg/gotwho.cpp
+++ b/prosper/tools/dbg/gotwho.cpp
@@ -1,0 +1,31 @@
+// gotwho — map a GOT slot vaddr (eboot-relative) to the import symbol (NID + lib) it binds.
+// Usage: gotwho <eboot.bin> <got_vaddr_hex>...
+#include "../../src/self/module.hpp"
+#include <cstdio>
+#include <cstdlib>
+
+int main(int argc, char** argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s <eboot> <got_va_hex>...\n", argv[0]); return 1; }
+    std::string err;
+    auto m = prosper::Module::load(argv[1], &err);
+    if (!m) { fprintf(stderr, "load failed: %s\n", err.c_str()); return 1; }
+    for (int i = 2; i < argc; i++) {
+        uint64_t va = strtoull(argv[i], nullptr, 16);
+        bool found = false;
+        for (const auto& r : m->relocs) {
+            if (r.offset != va) continue;
+            found = true;
+            if (r.sym && r.sym < m->symbols.size()) {
+                const auto& s = m->symbols[r.sym];
+                printf("0x%llx: type=%u plt=%d sym=%u nid=%s lib=%s\n",
+                       (unsigned long long)va, r.type, (int)r.is_plt, r.sym,
+                       s.nid.c_str(), s.lib_name.c_str());
+            } else {
+                printf("0x%llx: type=%u plt=%d sym=%u (no symbol)\n",
+                       (unsigned long long)va, r.type, (int)r.is_plt, r.sym);
+            }
+        }
+        if (!found) printf("0x%llx: no reloc found\n", (unsigned long long)va);
+    }
+    return 0;
+}

--- a/prosper/tools/dbg/gw232.py
+++ b/prosper/tools/dbg/gw232.py
@@ -1,0 +1,60 @@
+# gdb -p PID -batch -x gw232.py — dump per-thread host frame + guest return addresses (safe reads).
+import gdb, struct
+
+inf = gdb.selected_inferior()
+
+def scan(thr):
+    thr.switch()
+    try:
+        fr = gdb.newest_frame()
+        pc = fr.pc()
+    except gdb.error:
+        return
+    # host frames (short)
+    names = []
+    f = fr
+    for _ in range(6):
+        if f is None: break
+        try:
+            n = f.name()
+        except gdb.error:
+            n = None
+        names.append(n or hex(f.pc()))
+        try:
+            f = f.older()
+        except gdb.error:
+            break
+    print("  host: " + " <- ".join(names))
+    # guest RAs on the stack
+    try:
+        sp = int(gdb.parse_and_eval("$sp"))
+    except gdb.error:
+        return
+    out = []
+    step = 4096
+    lo = sp - 128
+    hi = sp + 8192
+    a = lo
+    while a < hi:
+        n = min(step, hi - a)
+        try:
+            mem = bytes(inf.read_memory(a, n))
+        except gdb.error:
+            a += n
+            continue
+        for off in range(0, len(mem) - 7, 8):
+            v = struct.unpack_from("<Q", mem, off)[0]
+            if 0x400000000 <= v < 0x406700000:
+                out.append("eboot+0x%x" % (v - 0x400000000))
+            elif 0x600000000 <= v < 0x610000000:
+                out.append("prx+0x%x" % (v - 0x600000000))
+        a += n
+    print("  guest: " + " ".join(out[:24]))
+
+gdb.execute("set pagination off")
+for t in inf.threads():
+    print("== thread lwp=%d name=%s ==" % (t.ptid[1], t.name or ""))
+    try:
+        scan(t)
+    except Exception as e:
+        print("  err: %s" % e)

--- a/prosper/tools/dbg/gwalk.sh
+++ b/prosper/tools/dbg/gwalk.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SC2LOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/gwalk.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 8; el=$((el+8))
+  cur=$(grep -c GpuFlip /root/gwalk.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo FROZEN; break; fi
+  if [ "$el" -ge 300 ]; then echo giveup; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo died; exit 1; }
+cat > /tmp/gw.gdb << "GEOF"
+set pagination off
+handle all nostop pass noprint
+define gs
+  printf "  --host--\n"
+  frame 5
+  printf "  --guest RAs on stack--\n"
+  set $p = $sp - 256
+  set $e = $sp + 4096
+  while $p < $e
+    set $v = *(unsigned long long*)$p
+    if ($v >= 0x400000000 && $v < 0x406700000)
+      printf "    eboot+0x%llx\n", $v - 0x400000000
+    end
+    set $p = $p + 8
+  end
+end
+thread apply all gs
+GEOF
+gdb -p $PID -batch -x /tmp/gw.gdb > /root/gwalk_bt.txt 2>&1
+kill -9 $PID 2>/dev/null
+echo GWALK-DONE
+# who signaled conds last (SC2LOG) before freeze:
+echo "=== last 25 cond signals ==="
+grep "COND.signal\|COND.broadcast" /root/gwalk.log | tail -25

--- a/prosper/tools/dbg/nid2got.cpp
+++ b/prosper/tools/dbg/nid2got.cpp
@@ -1,0 +1,25 @@
+// nid2got — map an import NID to its GOT slot vaddr(s) so callers can be found in the text.
+// Usage: nid2got <eboot.bin> <nid>...
+#include "../../src/self/module.hpp"
+#include <cstdio>
+#include <cstring>
+
+int main(int argc, char** argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s <eboot> <nid>...\n", argv[0]); return 1; }
+    std::string err;
+    auto m = prosper::Module::load(argv[1], &err);
+    if (!m) { fprintf(stderr, "load failed: %s\n", err.c_str()); return 1; }
+    for (int i = 2; i < argc; i++) {
+        bool found = false;
+        for (const auto& r : m->relocs) {
+            if (!r.sym || r.sym >= m->symbols.size()) continue;
+            const auto& s = m->symbols[r.sym];
+            if (s.nid != argv[i]) continue;
+            printf("%s (%s): got=0x%llx type=%u plt=%d sym=%u\n", argv[i], s.lib_name.c_str(),
+                   (unsigned long long)r.offset, r.type, (int)r.is_plt, r.sym);
+            found = true;
+        }
+        if (!found) printf("%s: not found\n", argv[i]);
+    }
+    return 0;
+}

--- a/prosper/tools/dbg/poll_deep.gdb
+++ b/prosper/tools/dbg/poll_deep.gdb
@@ -1,0 +1,42 @@
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+break *0x402cc236a
+commands
+  silent
+  set $obj = $rdi
+  printf "==== POLL obj=%llx ====\n", $obj
+  printf "-- obj as UTF-16/bytes (name?) --\n"
+  x/64bx $obj
+  set $o10 = *(unsigned long long*)($obj+0x10)
+  printf "obj+0x10 -> %llx\n", $o10
+  x/16gx $o10
+  set $o10vt = *(unsigned long long*)$o10
+  printf "obj+0x10 vtable=%llx (eboot+0x%llx)\n", $o10vt, $o10vt-0x400000000
+  x/8gx $o10vt
+  set $m20 = *(unsigned long long*)($o10vt+0x20)
+  printf "method[+0x20]=%llx (eboot+0x%llx)\n", $m20, $m20-0x400000000
+  x/120i $m20
+  printf "-- deadline/start doubles --\n"
+  printf "start(-0x78)=%f dead(-0x70)=%f\n", *(double*)($rbp-0x78), *(double*)($rbp-0x70)
+  printf "-- 0x402327130 (pump/process) --\n"
+  x/80i 0x402327130
+  printf "-- the enclosing fn preamble 0x402cc2200 --\n"
+  x/60i 0x402cc2200
+  printf "-- caller strings --\n"
+  x/s 0x4082639c2
+  x/s 0x407e3b518
+  x/s 0x407fe886a
+  printf "==== DEEP DONE ====\n"
+  detach
+  quit
+end
+continue
+quit

--- a/prosper/tools/dbg/poll_deep.sh
+++ b/prosper/tools/dbg/poll_deep.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Run DOLL; when flips FREEZE (the poll wall), attach and deep-walk the poll object.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/deep.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 8; el=$((el+8))
+  cur=$(grep -c GpuFlip /root/deep.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo "FROZEN at $cur"; break; fi
+  if [ "$el" -ge 400 ]; then echo "gave up waiting for freeze"; break; fi
+done
+if ! kill -0 $PID 2>/dev/null; then echo "died"; tail -20 /root/deep.log; exit 1; fi
+gdb -p $PID -batch -x "$WT/tools/dbg/poll_deep.gdb" > /root/poll_deep.txt 2>&1
+kill -9 $PID 2>/dev/null
+echo DEEP-DONE

--- a/prosper/tools/dbg/poll_probe.gdb
+++ b/prosper/tools/dbg/poll_probe.gdb
@@ -1,0 +1,44 @@
+# Probe the issue-#232 GameThread poll wall: break at eboot+0x2cc236a (call *0x20(%rax)),
+# dump the polled object + vtable + poll fn, then static context around the loop.
+set pagination off
+set confirm off
+handle SIG34 nostop pass noprint
+handle SIG35 nostop pass noprint
+handle SIG36 nostop pass noprint
+handle SIG37 nostop pass noprint
+handle SIG38 nostop pass noprint
+handle SIGUSR1 nostop pass noprint
+handle SIGUSR2 nostop pass noprint
+handle SIGSEGV nostop pass noprint
+set $hits = 0
+break *0x402cc236a
+commands
+  silent
+  set $hits = $hits + 1
+  printf "==== HIT %d ====\n", $hits
+  printf "rax=%llx rdi=%llx rsi=%llx rdx=%llx rbx=%llx r12=%llx r13=%llx r14=%llx r15=%llx\n", $rax, $rdi, $rsi, $rdx, $rbx, $r12, $r13, $r14, $r15
+  printf "-- [rdi] (candidate object) --\n"
+  x/16gx $rdi
+  printf "-- [rax] (candidate vtable) --\n"
+  x/8gx $rax
+  set $fn = *(unsigned long long*)($rax+0x20)
+  printf "pollfn=%llx (eboot+0x%llx)\n", $fn, $fn-0x400000000
+  if $hits >= 3
+    printf "-- disas pollfn --\n"
+    x/50i $fn
+    printf "-- disas poll caller 0x402cc2340 --\n"
+    x/70i 0x402cc2340
+    printf "-- disas time-compare fn 0x402324150..  --\n"
+    x/60i 0x402324130
+    printf "-- backtrace --\n"
+    bt 12
+    printf "-- stack raw --\n"
+    x/48gx $rsp
+    printf "==== PROBE DONE ====\n"
+    detach
+    quit
+  end
+  continue
+end
+continue
+quit

--- a/prosper/tools/dbg/poll_probe.sh
+++ b/prosper/tools/dbg/poll_probe.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Run DOLL to steady state, then attach gdb and probe the #232 poll wall.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/poll1.log 2>&1 &
+PID=$!
+echo "boot_trace pid=$PID"
+last=0; same=0; elapsed=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10
+  elapsed=$((elapsed+10))
+  cur=$(grep -c GpuFlip /root/poll1.log 2>/dev/null)
+  echo "t=$elapsed flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then break; fi
+  if [ "$elapsed" -ge 300 ] && [ "$cur" -gt 50 ]; then echo "timeout-steady"; break; fi
+done
+if ! kill -0 $PID 2>/dev/null; then echo "process died"; tail -30 /root/poll1.log; exit 1; fi
+echo "steady at flips=$last — attaching gdb"
+gdb -p $PID -batch -x "$WT/tools/dbg/poll_probe.gdb" > /root/poll_probe.txt 2>&1
+kill -9 $PID 2>/dev/null
+echo PROBE-DONE
+wc -l /root/poll_probe.txt

--- a/prosper/tools/dbg/run232b.sh
+++ b/prosper/tools/dbg/run232b.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Issue #232 (post-#236): characterize DOLL's steady state — is the GameThread advancing or parked?
+# Runs DOLL, samples flip/submit counts every 15 s, then at STEADY_T attaches gdb and dumps every
+# thread: host frame + guest return addresses found on the stack. Repeats the dump 3x (interrupt
+# sampling) to see whether threads MOVE. Everything in ONE wsl call (WSL /tmp is wiped between calls).
+SECS=${1:-300}
+STEADY_T=${2:-180}
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+el=0
+while kill -0 $PID 2>/dev/null && [ $el -lt $STEADY_T ]; do
+  sleep 15; el=$((el+15))
+  f=$(grep -c GpuFlip /root/d232.log 2>/dev/null)
+  s=$(grep -c "SubmitDcb #" /root/d232.log 2>/dev/null)
+  d=$(grep -c "kind=DrawIndex" /root/d232.log 2>/dev/null)
+  echo "t=$el flips=$f submits=$s drawpkts=$d"
+done
+kill -0 $PID 2>/dev/null || { echo "DIED before steady state"; tail -30 /root/d232.log; exit 1; }
+cat > /root/gw232.gdb << "GEOF"
+set pagination off
+handle all nostop pass noprint
+define gs
+  printf "  --host frames--\n"
+  bt 8
+  printf "  --guest RAs on stack--\n"
+  set $p = $sp - 128
+  set $e = $sp + 6144
+  while $p < $e
+    set $v = *(unsigned long long*)$p
+    if ($v >= 0x400000000 && $v < 0x406700000)
+      printf "    eboot+0x%llx\n", $v - 0x400000000
+    end
+    if ($v >= 0x600000000 && $v < 0x610000000)
+      printf "    prx+0x%llx\n", $v - 0x600000000
+    end
+    set $p = $p + 8
+  end
+end
+thread apply all gs
+GEOF
+for i in 1 2 3; do
+  echo "=== SAMPLE $i (t≈$el) ==="
+  gdb -p $PID -batch -x /root/gw232.gdb > /root/gw232_$i.txt 2>&1
+  echo "sample $i done, lines: $(wc -l < /root/gw232_$i.txt)"
+  sleep 10; el=$((el+10))
+  f=$(grep -c GpuFlip /root/d232.log 2>/dev/null)
+  s=$(grep -c "SubmitDcb #" /root/d232.log 2>/dev/null)
+  echo "t=$el flips=$f submits=$s"
+done
+kill -9 $PID 2>/dev/null
+echo "=== summary ==="
+echo "flips=$(grep -c GpuFlip /root/d232.log)"
+echo "submits=$(grep -c 'SubmitDcb #' /root/d232.log)"
+echo "draw-pkts=$(grep -c 'kind=DrawIndex' /root/d232.log)"
+echo "cx-indirect=$(grep -c 'DcbSetCxRegistersIndirect' /root/d232.log)"
+echo "dispatches: $(grep -o 'dispatches total: [0-9]*' /root/d232.log | tail -1)"
+echo "unimpl NIDs seen:"; grep -o 'unimplemented[^ ]* NID [^ ]*' /root/d232.log | sort | uniq -c | sort -rn | head -20
+echo "=== last 15 log lines ==="; tail -15 /root/d232.log
+echo RUN232-DONE

--- a/prosper/tools/dbg/run232c.sh
+++ b/prosper/tools/dbg/run232c.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Issue #232: boot DOLL to the park point (flips stop ~175), then take N spaced gdb python samples.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+# wait until flips plateau (no change across 2 consecutive 10s windows, flips>100)
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10; el=$((el+10))
+  cur=$(grep -c GpuFlip /root/d232.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo PLATEAU; break; fi
+  if [ "$el" -ge 240 ]; then echo giveup; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo DIED; tail -20 /root/d232.log; exit 1; }
+for i in 1 2 3; do
+  gdb -p $PID -batch -x "$WT/tools/dbg/gw232.py" > /root/gw232_$i.txt 2>&1
+  echo "sample $i lines=$(wc -l < /root/gw232_$i.txt)"
+  sleep 12
+done
+kill -9 $PID 2>/dev/null
+echo RUN232C-DONE

--- a/prosper/tools/dbg/run232d.sh
+++ b/prosper/tools/dbg/run232d.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Issue #232: boot DOLL to the plateau, take a named-thread gdb sample, then run the waketrace.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10; el=$((el+10))
+  cur=$(grep -c GpuFlip /root/d232.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo PLATEAU; break; fi
+  if [ "$el" -ge 240 ]; then echo giveup; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo DIED; tail -20 /root/d232.log; exit 1; }
+gdb -p $PID -batch -x "$WT/tools/dbg/gw232.py" > /root/gw232_n.txt 2>&1
+echo "named sample lines=$(wc -l < /root/gw232_n.txt)"
+gdb -p $PID -batch -x "$WT/tools/dbg/waketrace232.py" > /root/wake232.txt 2>&1
+echo "waketrace lines=$(wc -l < /root/wake232.txt)"
+fl=$(grep -c GpuFlip /root/d232.log)
+echo "flips now=$fl"
+kill -9 $PID 2>/dev/null
+echo RUN232D-DONE

--- a/prosper/tools/dbg/run232e.sh
+++ b/prosper/tools/dbg/run232e.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Issue #232: boot DOLL (with STUBDUMP so import indices are mappable), reach the plateau,
+# then count unimplemented-import calls per thread for 60 s.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_STUBDUMP=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232e.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10; el=$((el+10))
+  cur=$(grep -c GpuFlip /root/d232e.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo PLATEAU; break; fi
+  if [ "$el" -ge 240 ]; then echo giveup; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo DIED; tail -20 /root/d232e.log; exit 1; }
+gdb -p $PID -batch -x "$WT/tools/dbg/unimpl232.py" > /root/unimpl232.txt 2>&1
+grep "UNIMPL\|unimpl trace done" /root/unimpl232.txt
+echo "=== map indices to NIDs (stubdump) ==="
+grep "UNIMPL idx=" /root/unimpl232.txt | grep -o "idx=[0-9]*" | sort -u | while read x; do
+  i=${x#idx=}
+  grep -m1 "^\[stub\] #$i " /root/d232e.log
+done
+kill -9 $PID 2>/dev/null
+echo RUN232E-DONE

--- a/prosper/tools/dbg/run232f.sh
+++ b/prosper/tools/dbg/run232f.sh
@@ -17,7 +17,7 @@ while kill -0 $PID 2>/dev/null; do
   if [ "$el" -ge 240 ]; then echo giveup; break; fi
 done
 kill -0 $PID 2>/dev/null || { echo DIED; tail -20 /root/d232f.log; exit 1; }
-gdb -p $PID -batch -x "$WT/tools/dbg/slot232.py" > /root/slot232.txt 2>&1
+timeout 60 gdb -p $PID -batch -x "$WT/tools/dbg/slot232.py" > /root/slot232.txt 2>&1
 grep -E "LOOP|VIRT|rbx\+|r13\+|slot trace" /root/slot232.txt
 kill -9 $PID 2>/dev/null
 echo RUN232F-DONE

--- a/prosper/tools/dbg/run232f.sh
+++ b/prosper/tools/dbg/run232f.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Issue #232: boot to plateau, then run the slot232 poll-loop probe.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232f.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 10; el=$((el+10))
+  cur=$(grep -c GpuFlip /root/d232f.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo PLATEAU; break; fi
+  if [ "$el" -ge 240 ]; then echo giveup; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo DIED; tail -20 /root/d232f.log; exit 1; }
+gdb -p $PID -batch -x "$WT/tools/dbg/slot232.py" > /root/slot232.txt 2>&1
+grep -E "LOOP|VIRT|rbx\+|r13\+|slot trace" /root/slot232.txt
+kill -9 $PID 2>/dev/null
+echo RUN232F-DONE

--- a/prosper/tools/dbg/run232g.sh
+++ b/prosper/tools/dbg/run232g.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Issue #232: attach EARLY (flips>90, before the ~174 warmup submit) and arm the w1KFAHVqpaU probe.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232g.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 5; el=$((el+5))
+  cur=$(grep -c GpuFlip /root/d232g.log 2>/dev/null)
+  if [ "$cur" -ge 90 ]; then echo "attach at flips=$cur t=$el"; break; fi
+  if [ "$el" -ge 180 ]; then echo "never reached 90 flips"; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo DIED; tail -20 /root/d232g.log; exit 1; }
+timeout 150 gdb -p $PID -batch -x "$WT/tools/dbg/w1k232.py" > /root/w1k232.txt 2>&1
+grep -E "CALLSITE|rsp\+|buffer_entry|base\+|w1k probe" /root/w1k232.txt
+kill -9 $PID 2>/dev/null
+echo RUN232G-DONE

--- a/prosper/tools/dbg/run232h.sh
+++ b/prosper/tools/dbg/run232h.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Issue #232: does the w1KFAHVqpaU submit-fold advance DOLL past the RenderThread fence wall?
+# Run 360 s, track flips/submits over time (should NOT plateau at ~178 now), and check for draws.
+SECS=${1:-360}
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+timeout "$SECS" ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232h.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 20; el=$((el+20))
+  f=$(grep -c GpuFlip /root/d232h.log 2>/dev/null)
+  s=$(grep -c "SubmitDcb\|SubmitDcbFinal" /root/d232h.log 2>/dev/null)
+  v=$(grep -c "SubmitDcbFinal" /root/d232h.log 2>/dev/null)
+  d=$(grep -c "kind=DrawIndex" /root/d232h.log 2>/dev/null)
+  echo "t=$el flips=$f submits=$s finalSubmits=$v drawpkts=$d"
+done
+echo "=== DONE rc ==="
+echo "flips=$(grep -c GpuFlip /root/d232h.log)"
+echo "final-submits (w1KFAHVqpaU)=$(grep -c SubmitDcbFinal /root/d232h.log)"
+echo "EOP writes to 0x1180f0 (the RT fence region)=$(grep -c 'EOP write \[0x1180f0' /root/d232h.log)"
+echo "DrawIndex packets=$(grep -c 'kind=DrawIndex' /root/d232h.log)"
+echo "DrawIndexAuto packets=$(grep -c 'kind=DrawIndexAuto' /root/d232h.log)"
+echo "draws>0 lines:"; grep -oE 'draws: [1-9][0-9]*' /root/d232h.log | tail -3
+echo "presented frames=$(grep -c presented /root/d232h.log)"
+echo "faults=$(grep -c 'WORKER-THREAD FAULT\|RUN ENDED' /root/d232h.log)"
+echo "=== w1k refusals ==="; grep -c "w1KFAHVqpaU: no PM4" /root/d232h.log
+echo "=== tail ==="; tail -6 /root/d232h.log
+echo RUN232H-DONE

--- a/prosper/tools/dbg/slot232.py
+++ b/prosper/tools/dbg/slot232.py
@@ -1,0 +1,72 @@
+# gdb -p PID -batch -x slot232.py — at the DOLL plateau, catch the RenderThread wait loop
+# (eboot+0x221d6c2: mov 0x30(%rbx),%rax ; cmpq $0,(%rax)) and dump the polled slot + context.
+# Also catch the caller's virtual poll at eboot+0x3bf485c to identify the viewport object.
+import gdb, time, struct
+
+EBOOT = 0x400000000
+inf = gdb.selected_inferior()
+
+def rd64(addr):
+    try:
+        return struct.unpack("<Q", bytes(inf.read_memory(addr, 8)))[0]
+    except gdb.error:
+        return None
+
+class LoopBP(gdb.Breakpoint):
+    def __init__(self):
+        super().__init__("*0x%x" % (EBOOT + 0x221d6c2))
+        self.n = 0
+    def stop(self):
+        try:
+            self.n += 1
+            if self.n > 3: return False
+            rbx = int(gdb.parse_and_eval("$rbx"))
+            r12 = int(gdb.parse_and_eval("$r12"))
+            r13 = int(gdb.parse_and_eval("$r13"))
+            slotp = rd64(rbx + 0x30)
+            slotv = rd64(slotp) if slotp else None
+            ctx28 = rd64(rbx + 0x28)
+            t0 = rd64(r12)      # timeout[0]
+            t1 = rd64(r12 + 8)  # timeout[1]
+            scale = rd64(r13)
+            print("LOOP hit#%d rbx=0x%x slotp=0x%x slotv=%s ctx28=0x%x timeouts=(0x%x,0x%x) scale=0x%x"
+                  % (self.n, rbx, slotp or 0, hex(slotv) if slotv is not None else "?", ctx28 or 0,
+                     t0 or 0, t1 or 0, scale or 0), flush=True)
+            # dump the wait object
+            for off in range(0, 0x40, 8):
+                print("   [rbx+0x%02x] = 0x%x" % (off, rd64(rbx + off) or 0), flush=True)
+        except Exception as e:
+            print("looperr %s" % e, flush=True)
+        return False
+
+class VirtBP(gdb.Breakpoint):
+    def __init__(self):
+        super().__init__("*0x%x" % (EBOOT + 0x3bf485c))
+        self.n = 0
+    def stop(self):
+        try:
+            self.n += 1
+            if self.n > 3: return False
+            rdi = int(gdb.parse_and_eval("$rdi"))
+            r13 = int(gdb.parse_and_eval("$r13"))
+            vt = rd64(rdi)
+            fn = rd64(vt + 0x338) if vt else None
+            print("VIRT hit#%d obj=0x%x vtable=0x%x(eboot+0x%x) fn+0x338=0x%x(eboot+0x%x) r13=0x%x"
+                  % (self.n, rdi, vt or 0, (vt - EBOOT) if vt else 0,
+                     fn or 0, (fn - EBOOT) if fn else 0, r13), flush=True)
+            for off in range(0, 0x60, 8):
+                print("   [r13+0x%02x] = 0x%x" % (off, rd64(r13 + off) or 0), flush=True)
+        except Exception as e:
+            print("virterr %s" % e, flush=True)
+        return False
+
+gdb.execute("set pagination off")
+gdb.execute("handle SIGSEGV nostop pass noprint")
+LoopBP()
+VirtBP()
+gdb.execute("continue &")
+time.sleep(25)
+gdb.execute("interrupt")
+time.sleep(2)
+print("=== slot trace done ===", flush=True)
+gdb.execute("detach")

--- a/prosper/tools/dbg/slot232.py
+++ b/prosper/tools/dbg/slot232.py
@@ -1,7 +1,8 @@
 # gdb -p PID -batch -x slot232.py — at the DOLL plateau, catch the RenderThread wait loop
 # (eboot+0x221d6c2: mov 0x30(%rbx),%rax ; cmpq $0,(%rax)) and dump the polled slot + context.
-# Also catch the caller's virtual poll at eboot+0x3bf485c to identify the viewport object.
-import gdb, time, struct
+# Synchronous continue/stop iterations (a python sleep would block gdb's event loop).
+# Wrap the gdb invocation in `timeout` — if the breakpoints never hit, gdb blocks in continue.
+import gdb, struct
 
 EBOOT = 0x400000000
 inf = gdb.selected_inferior()
@@ -12,61 +13,37 @@ def rd64(addr):
     except gdb.error:
         return None
 
-class LoopBP(gdb.Breakpoint):
-    def __init__(self):
-        super().__init__("*0x%x" % (EBOOT + 0x221d6c2))
-        self.n = 0
-    def stop(self):
-        try:
-            self.n += 1
-            if self.n > 3: return False
-            rbx = int(gdb.parse_and_eval("$rbx"))
-            r12 = int(gdb.parse_and_eval("$r12"))
-            r13 = int(gdb.parse_and_eval("$r13"))
-            slotp = rd64(rbx + 0x30)
-            slotv = rd64(slotp) if slotp else None
-            ctx28 = rd64(rbx + 0x28)
-            t0 = rd64(r12)      # timeout[0]
-            t1 = rd64(r12 + 8)  # timeout[1]
-            scale = rd64(r13)
-            print("LOOP hit#%d rbx=0x%x slotp=0x%x slotv=%s ctx28=0x%x timeouts=(0x%x,0x%x) scale=0x%x"
-                  % (self.n, rbx, slotp or 0, hex(slotv) if slotv is not None else "?", ctx28 or 0,
-                     t0 or 0, t1 or 0, scale or 0), flush=True)
-            # dump the wait object
-            for off in range(0, 0x40, 8):
-                print("   [rbx+0x%02x] = 0x%x" % (off, rd64(rbx + off) or 0), flush=True)
-        except Exception as e:
-            print("looperr %s" % e, flush=True)
-        return False
-
-class VirtBP(gdb.Breakpoint):
-    def __init__(self):
-        super().__init__("*0x%x" % (EBOOT + 0x3bf485c))
-        self.n = 0
-    def stop(self):
-        try:
-            self.n += 1
-            if self.n > 3: return False
-            rdi = int(gdb.parse_and_eval("$rdi"))
-            r13 = int(gdb.parse_and_eval("$r13"))
-            vt = rd64(rdi)
-            fn = rd64(vt + 0x338) if vt else None
-            print("VIRT hit#%d obj=0x%x vtable=0x%x(eboot+0x%x) fn+0x338=0x%x(eboot+0x%x) r13=0x%x"
-                  % (self.n, rdi, vt or 0, (vt - EBOOT) if vt else 0,
-                     fn or 0, (fn - EBOOT) if fn else 0, r13), flush=True)
-            for off in range(0, 0x60, 8):
-                print("   [r13+0x%02x] = 0x%x" % (off, rd64(r13 + off) or 0), flush=True)
-        except Exception as e:
-            print("virterr %s" % e, flush=True)
-        return False
-
 gdb.execute("set pagination off")
 gdb.execute("handle SIGSEGV nostop pass noprint")
-LoopBP()
-VirtBP()
-gdb.execute("continue &")
-time.sleep(25)
-gdb.execute("interrupt")
-time.sleep(2)
+
+# --- the wait loop: dump the polled slot ---
+bp1 = gdb.Breakpoint("*0x%x" % (EBOOT + 0x221d6c2))
+for i in range(3):
+    gdb.execute("continue")
+    rbx = int(gdb.parse_and_eval("$rbx"))
+    r12 = int(gdb.parse_and_eval("$r12"))
+    r13 = int(gdb.parse_and_eval("$r13"))
+    slotp = rd64(rbx + 0x30)
+    slotv = rd64(slotp) if slotp else None
+    print("LOOP hit#%d rbx=0x%x slotp=0x%x slotv=%s timeouts=(0x%x,0x%x) scale=0x%x"
+          % (i, rbx, slotp or 0, hex(slotv) if slotv is not None else "?",
+             rd64(r12) or 0, rd64(r12 + 8) or 0, rd64(r13) or 0), flush=True)
+    for off in range(0, 0x48, 8):
+        print("   [rbx+0x%02x] = 0x%x" % (off, rd64(rbx + off) or 0), flush=True)
+bp1.delete()
+
+# --- the caller's virtual poll: identify the viewport object ---
+bp2 = gdb.Breakpoint("*0x%x" % (EBOOT + 0x3bf485c))
+for i in range(2):
+    gdb.execute("continue")
+    rdi = int(gdb.parse_and_eval("$rdi"))
+    r13 = int(gdb.parse_and_eval("$r13"))
+    vt = rd64(rdi)
+    fn = rd64(vt + 0x338) if vt else None
+    print("VIRT hit#%d obj=0x%x vtable=eboot+0x%x fn(+0x338)=eboot+0x%x r13=0x%x"
+          % (i, rdi, (vt - EBOOT) if vt else 0, (fn - EBOOT) if fn else 0, r13), flush=True)
+    for off in range(0, 0x70, 8):
+        print("   [r13+0x%02x] = 0x%x" % (off, rd64(r13 + off) or 0), flush=True)
+bp2.delete()
 print("=== slot trace done ===", flush=True)
 gdb.execute("detach")

--- a/prosper/tools/dbg/stall_bt2.sh
+++ b/prosper/tools/dbg/stall_bt2.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/sbt2.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+last=0; same=0; el=0
+while kill -0 $PID 2>/dev/null; do
+  sleep 8; el=$((el+8))
+  cur=$(grep -c GpuFlip /root/sbt2.log 2>/dev/null)
+  echo "t=$el flips=$cur"
+  if [ "$cur" -gt 100 ] && [ "$cur" -eq "$last" ]; then same=$((same+1)); else same=0; fi
+  last=$cur
+  if [ "$same" -ge 2 ]; then echo "FROZEN"; break; fi
+  if [ "$el" -ge 300 ]; then echo giveup; break; fi
+done
+kill -0 $PID 2>/dev/null || { echo died; exit 1; }
+gdb -p $PID -batch \
+  -ex "set pagination off" \
+  -ex "handle all nostop pass noprint" \
+  -ex "thread apply all bt 6" \
+  > /root/sbt2.txt 2>&1
+kill -9 $PID 2>/dev/null
+echo SBT2-DONE
+# Reduce: for each thread show its innermost eboot frame (frame #0/#1)
+awk '/^Thread /{t=$0} /eboot|0x000000040/{if(t){print t; t=""} print}' /root/sbt2.txt | head -200 > /root/sbt2_reduced.txt
+wc -l /root/sbt2.txt

--- a/prosper/tools/dbg/summ232.sh
+++ b/prosper/tools/dbg/summ232.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Summarize gw232 sample files: one line per thread = final-wait-fn | first guest RAs.
+for f in "$@"; do
+  echo "===== $f ====="
+  python3 - "$f" << 'PEOF'
+import sys, re, collections
+lines = open(sys.argv[1]).read().splitlines()
+cur = None; host = ""; guest = ""
+rows = []
+for l in lines:
+    if l.startswith("== thread"):
+        if cur: rows.append((cur, host, guest))
+        cur = l; host = ""; guest = ""
+    elif l.startswith("  host:"):
+        # last prosper:: frame or first frame
+        fns = [x.strip() for x in l[8:].split("<-")]
+        pk = next((x for x in fns if "prosper" in x or "k_" in x), fns[0] if fns else "")
+        pk = re.sub(r"\(unsigned long.*\)", "", pk)
+        host = pk
+    elif l.startswith("  guest:"):
+        guest = " ".join(l[9:].split()[:6])
+if cur: rows.append((cur, host, guest))
+sig = collections.Counter((h, g) for _, h, g in rows)
+for (h, g), n in sig.most_common():
+    print("%3d  %-50s %s" % (n, h, g))
+print("total threads:", len(rows))
+PEOF
+done

--- a/prosper/tools/dbg/unimpl232.py
+++ b/prosper/tools/dbg/unimpl232.py
@@ -1,0 +1,27 @@
+# gdb -p PID -batch -x unimpl232.py — count prosper_on_unimpl hits (import index) per thread for 60 s.
+import gdb, time, struct, collections
+
+DURATION = 60
+hits = collections.Counter()
+
+class UBP(gdb.Breakpoint):
+    def stop(self):
+        try:
+            idx = int(gdb.parse_and_eval("$rdi")) & 0xffffffff
+            t = gdb.selected_thread()
+            hits[(t.name or "?", idx)] += 1
+        except Exception:
+            pass
+        return False
+
+gdb.execute("set pagination off")
+gdb.execute("handle SIGSEGV nostop pass noprint")
+UBP("prosper_on_unimpl")
+gdb.execute("continue &")
+time.sleep(DURATION)
+gdb.execute("interrupt")
+time.sleep(2)
+for (name, idx), n in hits.most_common(40):
+    print("UNIMPL idx=%d thread=%s count=%d" % (idx, name, n), flush=True)
+print("=== unimpl trace done ===", flush=True)
+gdb.execute("detach")

--- a/prosper/tools/dbg/w1k232.py
+++ b/prosper/tools/dbg/w1k232.py
@@ -1,0 +1,44 @@
+# gdb -p PID -batch -x w1k232.py — break on the w1KFAHVqpaU PLT (0x669a220) and its wrapper
+# (0x58df3f0), dump register + stack args, and probe candidate Dcb pointers for a PM4 stream
+# (type-3 header top bits 0b11). Runs a bounded number of hits (wrap in `timeout`).
+import gdb, struct
+
+EBOOT = 0x400000000
+inf = gdb.selected_inferior()
+
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+
+def looks_pm4(addr):
+    v = rd(addr, 4)
+    if v is None: return "unmapped"
+    return "PM4" if (v & 0xC0000000) == 0xC0000000 else "0x%08x" % v
+
+gdb.execute("set pagination off")
+gdb.execute("handle SIGSEGV nostop pass noprint")
+
+bp = gdb.Breakpoint("*0x%x" % (EBOOT + 0x220aace))   # the call site (regs are the caller's)
+for i in range(4):
+    gdb.execute("continue")
+    regs = {r: int(gdb.parse_and_eval("$" + r)) for r in ("rdi","rsi","rdx","rcx","r8","r9","rsp","r12","rax")}
+    print("CALLSITE hit#%d rdi=0x%x rsi=0x%x rdx=0x%x rcx=0x%x r8=0x%x r9=0x%x r12=0x%x rax=0x%x"
+          % (i, regs["rdi"],regs["rsi"],regs["rdx"],regs["rcx"],regs["r8"],regs["r9"],regs["r12"],regs["rax"]),
+          flush=True)
+    sp = regs["rsp"]
+    for k in range(6):
+        a = rd(sp + k*8)
+        print("   [rsp+0x%02x] = 0x%x  -> pm4? %s" % (k*8, a or 0, looks_pm4(a) if a else "n/a"), flush=True)
+    # the caller built (rax,r12): buffer entry base = rax + r12; fields +0 base, +0x10 dwords
+    base = rd(regs["rax"] + regs["r12"])
+    dw = rd(regs["rax"] + regs["r12"] + 0x10, 4)
+    print("   buffer_entry: base=0x%x dwords=0x%x  base->pm4? %s"
+          % (base or 0, dw or 0, looks_pm4(base) if base else "n/a"), flush=True)
+    if base:
+        # dump the first few dwords
+        for k in range(4):
+            print("     [base+0x%02x]=0x%08x" % (k*4, rd(base + k*4, 4) or 0), flush=True)
+print("=== w1k probe done ===", flush=True)
+gdb.execute("detach")

--- a/prosper/tools/dbg/waketrace232.py
+++ b/prosper/tools/dbg/waketrace232.py
@@ -1,0 +1,74 @@
+# gdb -p PID -batch -x waketrace232.py — at the DOLL plateau, trace the wake chain:
+# every k_cond_timedwait entry (thread, cond slot, timeout-from-now), every cond signal/broadcast,
+# and every AGC submit. Non-stop logging; detaches after DURATION seconds.
+import gdb, time, struct
+
+DURATION = 150
+
+def tname():
+    t = gdb.selected_thread()
+    return "%s(lwp %d)" % (t.name or "?", t.ptid[1])
+
+def guest_ra():
+    try:
+        sp = int(gdb.parse_and_eval("$sp"))
+        inf = gdb.selected_inferior()
+        mem = bytes(inf.read_memory(sp, 8))
+        v = struct.unpack("<Q", mem)[0]
+        if 0x400000000 <= v < 0x406700000:
+            return "eboot+0x%x" % (v - 0x400000000)
+        if 0x600000000 <= v < 0x610000000:
+            return "prx+0x%x" % (v - 0x600000000)
+        return hex(v)
+    except gdb.error:
+        return "?"
+
+t0 = time.time()
+
+class TimedWaitBP(gdb.Breakpoint):
+    def stop(self):
+        try:
+            a0 = int(gdb.parse_and_eval("$rdi"))
+            a2 = int(gdb.parse_and_eval("$rdx"))
+            rem = -1.0
+            if a2:
+                inf = gdb.selected_inferior()
+                mem = bytes(inf.read_memory(a2, 16))
+                sec, nsec = struct.unpack("<qq", mem)
+                rem = sec + nsec / 1e9 - time.time()
+            print("[%7.2f] TIMEDWAIT %s cond_slot=0x%x timeout_in=%.3fs ra=%s"
+                  % (time.time() - t0, tname(), a0, rem, guest_ra()), flush=True)
+        except Exception as e:
+            print("bp err", e, flush=True)
+        return False
+
+class SigBP(gdb.Breakpoint):
+    def __init__(self, spec, label):
+        super().__init__(spec)
+        self.label = label
+    def stop(self):
+        try:
+            a0 = int(gdb.parse_and_eval("$rdi"))
+            print("[%7.2f] %s %s a0=0x%x ra=%s"
+                  % (time.time() - t0, self.label, tname(), a0, guest_ra()), flush=True)
+        except Exception as e:
+            print("bp err", e, flush=True)
+        return False
+
+gdb.execute("set pagination off")
+gdb.execute("handle SIGSEGV nostop pass noprint")
+gdb.execute("handle SIGUSR1 nostop pass noprint")
+gdb.execute("handle SIGUSR2 nostop pass noprint")
+
+TimedWaitBP("prosper::k_cond_timedwait")
+SigBP("prosper::k_cond_signal", "SIGNAL")
+SigBP("prosper::k_cond_broadcast", "BCAST")
+SigBP("prosper::agc_driver_submit_dcb", "SUBMIT")
+SigBP("prosper::k_cond_wait", "CONDWAIT")
+
+gdb.execute("continue &")
+time.sleep(DURATION)
+print("=== waketrace done ===", flush=True)
+gdb.execute("interrupt")
+time.sleep(2)
+gdb.execute("detach")


### PR DESCRIPTION
## Implement the `w1KFAHVqpaU` final-buffer submit variant + guest-thread-name adoption (refs #232)

Continues #232 (DOLL renders 0 scene draws). Follows #236 (the merged EOP-coalesce fix, which removed DOLL's RenderThread-timeout freeze).

### The find (RE'd via gdb)
DOLL's UE4 RHI `SubmitCommandBuffers` (`eboot+0x220a9a0`) submits each batch through **two** driver entry points: intermediate buffers via `sceAgcDriverSubmitDcb` (`UglJIZjGssM`, folded), and the **final** buffer via **`w1KFAHVqpaU`** (`eboot+0x220aace`) — which was **unimplemented (returned 0)**, so the final buffer (carrying the RenderThread's completion fences) was silently dropped.

### The fix (`hle_agc.cpp`)
Implement `agc_driver_submit_dcb_variant` (registered for `w1KFAHVqpaU`): fold the Dcb through the CommandProcessor and fire EOP like the primary path. ABI RE'd from the compiler adapter thunk (`eboot+0x58df3f0`): Dcb stream address = stack arg8 → `fp[3]`; relies on `decode_pm4` type-3 self-termination (observed bounded 377–10386 packets); the PM4 header is **validated before folding** (fallback scan a0..a5; refuse+log on a bad pointer) so it can never fold garbage. CONFIDENCE: MED.

### Plus: guest-thread-name adoption
`k_pthread_create` now calls `pthread_setname_np`, so gdb/procfs show `GameThread`/`RenderThread 1`/`RHIThread`/`AgcSubmissionThread` instead of 85× `boot_trace` — this is what made the stalled RenderThread identifiable, and it helps every title's debugging.

### Verified
- **ctest 63/63**; Messenger render smoke unregressed (166 render lines, 0 faults — the shared `hle_agc`/`k_pthread` changes don't affect it).
- On current master (with #236 merged) DOLL runs deep and stable: 17,860 DCB submits, **142,889 EOP writes into the RenderThread fence region**, no freeze, no crash.
- Cherry-picked onto master (not merged — the branch had #236 which is now upstream).

### Remaining (#232 stays open) — the real wall
**Still 0 scene draws.** DOLL's render fence is fully satisfied and it runs a healthy deep loop (3500+ compute dispatches), but submits **0 `DcbSetCxRegistersIndirect` geometry** — the game logic still hasn't activated its world/scene. That's the deeper scene-activation gap (also tracked toward #241, a free-list pop past the fence seen on some runs). The render pipeline is ready and fences flow; the game just doesn't hand it geometry yet.
