### PR TITLE
feat(hle/pad): implement the 4 remaining libScePad imports (full Messenger coverage)

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -159,6 +159,22 @@ HLE(pad_get_info) {
 // (standard device class, no extra capabilities). Conservative 0x20 write to avoid overrun.
 HLE(pad_ext_info) { if (a1) memset(PW(a1), 0, 0x20); return 0; }
 
+// scePadDeviceClassParseData(handle, const OrbisPadData* in, OrbisPadDeviceClassData* out) -> 0.
+// Parses a raw device-class HID report (steering wheels, guitars, etc.) into a structured form. A
+// standard DualSense carries NO device-class payload, so the correct answer is "no valid data": clear
+// the out's leading fields — deviceClass (u32 @0) = STANDARD/0 and bDataValid (bool @4) = false — so a
+// game's `if (out.bDataValid)` sees false rather than consuming uninitialized memory. Bounded 8-byte
+// write (never the full union) per the oversized-write lesson; cross-checked vs shadPS4 pad.cpp
+// (returns OK). CONFIDENCE: MED — normal input still flows through scePadRead.
+HLE(pad_class_parse) { if (a2) memset(PW(a2), 0, 8); return 0; }
+
+// scePadGetTriggerEffectState(handle, ScePadTriggerEffectState* out) -> 0. DualSense adaptive-trigger
+// feedback state. No reference layout (PS5-only; absent from shadPS4/Kyty) and The Messenger is a 2D
+// platformer that does not drive adaptive triggers, so report a neutral/zeroed state and succeed.
+// Bounded 8-byte clear at the out pointer avoids leaving garbage without risking an overrun of an
+// unknown-size struct. CONFIDENCE: LOW — arg/layout unverified; never called on this title.
+HLE(pad_trigger_state) { if (a1) memset(PW(a1), 0, 8); return 0; }
+
 void register_pad_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("scePadInit", pad_ok);
@@ -178,6 +194,10 @@ void register_pad_hle() {
     R("scePadResetLightBar", pad_ok);
     R("scePadSetLightBar", pad_ok);
     R("scePadResetOrientation", pad_ok);
+    R("scePadSetVibrationMode", pad_ok);       // vibration-mode config (output) — accept, no-op
+    R("scePadSetTriggerEffect", pad_ok);       // DualSense adaptive-trigger effect (output) — accept, no-op
+    R("scePadDeviceClassParseData", pad_class_parse);   // raw device-class report -> "no valid data"
+    R("scePadGetTriggerEffectState", pad_trigger_state);// adaptive-trigger state -> zeroed/neutral
     #undef R
 }
 


### PR DESCRIPTION
## What

The Messenger imports **17** libScePad functions; **13** were registered. The other 4 fell through to the unimplemented handler (`return 0`, no output written — the "success + garbage-out" class):

| Function | Handling |
|---|---|
| `scePadSetVibrationMode` | accept, no-op (output config) |
| `scePadSetTriggerEffect` | accept, no-op (DualSense trigger output) |
| `scePadDeviceClassParseData` | clear `deviceClass` + `bDataValid=false` (8-byte bounded write) so a caller's `if (bDataValid)` sees false, not uninitialized memory. Cross-checked vs shadPS4 `pad.cpp`. **CONFIDENCE: MED** |
| `scePadGetTriggerEffectState` | zeroed/neutral 8-byte out, success (PS5-only, no reference layout). **CONFIDENCE: LOW** |

After this, **all 17 of the title's pad imports are registered.**

## Why now / safety

None of these are on the path to `scePadOpen`, and none are currently reached — the title stalls in managed input init *before* opening the pad (#234). So this **changes no live behavior today**; it closes the coverage gap so these can never silently return garbage once input init is unblocked (increasing correct HLE surface while the input blocker is investigated separately).

Surface identified via the PS5 3.20 firmware library NID map (`../PS5-3.20_Libs`, see #243) cross-referenced with `self_dump` on the eboot.

## Test

`68/68` ctest green.

Refs #234.