### PR TITLE
feat(tools): screenshot — capture a PNG every N rendered frames from a game run

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -358,6 +358,17 @@ if(TARGET prosper_core)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
       target_link_libraries(boot_trace PRIVATE prosper_live_renderer)
 
+      # screenshot: run a game and capture a PNG every N frames (default 60) until M shots (default
+      # 30). Reuses boot_program + the shared live renderer; writes zlib-compressed PNGs (needs zlib).
+      find_package(ZLIB QUIET)
+      if(ZLIB_FOUND)
+        add_executable(screenshot tools/screenshot/screenshot.cpp)
+        target_include_directories(screenshot PRIVATE src)
+        target_link_libraries(screenshot PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan ZLIB::ZLIB)
+      else()
+        message(STATUS "zlib not found — skipping the screenshot tool")
+      endif()
+
       add_executable(test_vulkan_offscreen tests/test_vulkan_offscreen.cpp)
       target_link_libraries(test_vulkan_offscreen PRIVATE Vulkan::Vulkan)
       add_test(NAME vulkan_offscreen_clear COMMAND test_vulkan_offscreen)

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -19,6 +19,7 @@ namespace prosper::gpu {
 namespace {
 std::atomic<int>      g_front{-1};
 std::atomic<uint64_t> g_present_count{0};
+std::atomic<uint64_t> g_frame_seq{0};   // # of rendered frames handed in via present_write_frame
 
 // The rendered frame the back-half hands us (the "scanout" image). Guarded by a mutex because the
 // renderer thread writes it while guest threads / tests read it via present_readback.
@@ -36,7 +37,10 @@ void present_write_frame(const void* pixels, uint32_t w, uint32_t h) {
     std::memcpy(g_frame.data(), pixels, bytes);
     g_frame_w = w; g_frame_h = h;
     g_have_frame.store(true, std::memory_order_release);
+    g_frame_seq.fetch_add(1, std::memory_order_relaxed);
 }
+
+uint64_t present_frame_seq() { return g_frame_seq.load(std::memory_order_relaxed); }
 
 bool present_has_frame() { return g_have_frame.load(std::memory_order_acquire); }
 

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -30,7 +30,8 @@ void present_write_frame(const void* pixels, uint32_t w, uint32_t h);
 bool present_has_frame();
 
 int      present_front_index();   // currently-presented buffer index (-1 before the first flip)
-uint64_t present_count();         // total flips presented
+uint64_t present_count();         // total flips presented (guest-paced; can be far faster than render)
+uint64_t present_frame_seq();     // count of rendered frames handed in (present_write_frame calls)
 uint32_t present_width();
 uint32_t present_height();
 

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -1,0 +1,63 @@
+# screenshot
+
+Run a game and capture a PNG every N rendered frames until M screenshots, then exit. Handy for
+snapshot-testing a run and for eyeballing progression across a boot.
+
+Reuses the shared boot path (`boot_program`) and the shared live renderer (`frontends/shared`), so
+the game boots and composites exactly as `boot_trace` / `prosper-app` do — this tool just samples the
+present layer periodically and writes PNGs.
+
+## Build
+
+Built automatically wherever Vulkan + zlib are available (same block as `boot_trace`):
+
+```bash
+cmake -S prosper -B build -DPROSPER_APP=ON      # or any config that finds Vulkan
+cmake --build build --target screenshot
+```
+
+## Usage
+
+```
+screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
+```
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `<app0-dir>` | **required** | Game dump root, e.g. `.../PPSA24651-app0` |
+| `--every N` | 60 | Rendered frames between screenshots |
+| `--count M` | 30 | Number of screenshots, then exit |
+| `--out DIR` | `.` | Output directory |
+| `--timeout S` | 900 | Give up after S seconds if the game isn't rendering enough (0 = no limit) |
+
+Only the game is required; everything else has a sane default.
+
+**"Frames" = rendered frames** (composited images handed to the present layer), *not* guest flips —
+the guest flips far faster than llvmpipe renders, so counting flips would bunch every shot into the
+first second. Rendered frames spread the shots evenly across the run.
+
+## Filenames
+
+`<titleCode>_<runTimestamp>_<index>.png`, e.g. `PPSA24651_20260709-195505_00.png`.
+
+- **titleCode** — the dump's basename with a trailing `-app0` removed.
+- **runTimestamp** — `YYYYMMDD-HHMMSS` captured once at start, so every shot in a run shares it and a
+  folder of many runs groups and sorts cleanly.
+- **index** — zero-padded, `00`, `01`, …
+
+## Guest environment
+
+Reaching a rendering frame loop needs the render-frontier guest switches. This tool defaults
+`PROSPER_GUEST_FS=1` and `PROSPER_GUEST_ARGS=-force-gfx-direct` (Unity/Messenger recipe) if unset. For
+other titles set the appropriate env first, e.g. a UE4 title:
+
+```bash
+PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1 screenshot /path/PPSA01885-app0
+```
+
+## Example
+
+```bash
+# 30 shots, one every 60 rendered frames, into ./shots
+screenshot /mnt/c/.../PPSA24651-app0 --out shots
+```

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -1,0 +1,167 @@
+// screenshot — run a game and capture a PNG every N frames until M screenshots, then exit.
+//
+// Reuses the shared boot path (boot_program) and the shared live renderer (frontends/shared), so the
+// game boots and composites exactly as boot_trace / prosper-app do; this tool just samples the
+// present layer (present_readback) periodically and writes PNGs. Frames are counted as display flips
+// (present_count). Files are named <titleCode>_<runTimestamp>_<index>.png so every screenshot from
+// one run shares a prefix and sorts together in a folder of many runs.
+//
+//   screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
+//     <app0-dir>   REQUIRED. The game dump root (e.g. .../PPSA24651-app0). Title code = its basename
+//                  with a trailing "-app0" stripped.
+//     --every N    frames (flips) between screenshots        (default 60)
+//     --count M    number of screenshots to take, then exit  (default 30)
+//     --out DIR    output directory                          (default ".")
+//     --timeout S  give up after S seconds if the game isn't flipping enough (default 900; 0 = none)
+//
+// Reaching a rendering frame loop needs the guest switches the render frontier documents; this tool
+// defaults PROSPER_GUEST_FS=1 and PROSPER_GUEST_ARGS=-force-gfx-direct (Unity/Messenger recipe) if
+// they aren't already set. For other titles, set the appropriate env before running (e.g. a UE4
+// title: PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1). Linux-only (the guest substrate is).
+#include "loader/linker.hpp"          // Program
+#include "host/boot_program.hpp"       // boot_program
+#include "host/exec_image.hpp"         // run_entry
+#include "gpu/videoout_present.hpp"    // present_count / present_readback / present_width/height
+#include "live_renderer.hpp"           // register_live_renderer (frontends/shared)
+
+#include <zlib.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <ctime>
+#include <unistd.h>
+
+using namespace prosper;
+
+namespace {
+
+void put_chunk(FILE* f, const char* type, const uint8_t* data, size_t len) {
+    uint8_t hdr[4] = { (uint8_t)(len >> 24), (uint8_t)(len >> 16), (uint8_t)(len >> 8), (uint8_t)len };
+    fwrite(hdr, 1, 4, f);
+    fwrite(type, 1, 4, f);
+    if (len) fwrite(data, 1, len, f);
+    uint32_t crc = crc32(0, (const Bytef*)type, 4);
+    if (len) crc = crc32(crc, (const Bytef*)data, (uInt)len);
+    uint8_t crcb[4] = { (uint8_t)(crc >> 24), (uint8_t)(crc >> 16), (uint8_t)(crc >> 8), (uint8_t)crc };
+    fwrite(crcb, 1, 4, f);
+}
+
+// Write w*h RGBA8 as an 8-bit RGBA PNG (filter None per row, zlib-compressed IDAT).
+bool write_png(const char* path, const uint8_t* rgba, uint32_t w, uint32_t h) {
+    std::vector<uint8_t> raw;
+    raw.reserve((size_t)h * (1 + (size_t)w * 4));
+    for (uint32_t y = 0; y < h; y++) {
+        raw.push_back(0);   // filter: None
+        raw.insert(raw.end(), rgba + (size_t)y * w * 4, rgba + (size_t)(y + 1) * w * 4);
+    }
+    uLongf clen = compressBound((uLong)raw.size());
+    std::vector<uint8_t> comp(clen);
+    if (compress2(comp.data(), &clen, raw.data(), (uLong)raw.size(), Z_BEST_SPEED) != Z_OK) return false;
+
+    FILE* f = fopen(path, "wb");
+    if (!f) return false;
+    static const uint8_t sig[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    fwrite(sig, 1, 8, f);
+    uint8_t ihdr[13] = {
+        (uint8_t)(w >> 24), (uint8_t)(w >> 16), (uint8_t)(w >> 8), (uint8_t)w,
+        (uint8_t)(h >> 24), (uint8_t)(h >> 16), (uint8_t)(h >> 8), (uint8_t)h,
+        8,   // bit depth
+        6,   // colour type: RGBA
+        0, 0, 0 };
+    put_chunk(f, "IHDR", ihdr, 13);
+    put_chunk(f, "IDAT", comp.data(), clen);
+    put_chunk(f, "IEND", nullptr, 0);
+    fclose(f);
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::string dump, out = ".";
+    int every = 60, count = 30, timeout = 900;
+    for (int i = 1; i < argc; i++) {
+        std::string a = argv[i];
+        if      (a == "--every"   && i + 1 < argc) every = atoi(argv[++i]);
+        else if (a == "--count"   && i + 1 < argc) count = atoi(argv[++i]);
+        else if (a == "--out"     && i + 1 < argc) out   = argv[++i];
+        else if (a == "--timeout" && i + 1 < argc) timeout = atoi(argv[++i]);
+        else if (!a.empty() && a[0] != '-' && dump.empty()) dump = a;
+        else { fprintf(stderr, "screenshot: unknown/duplicate arg '%s'\n", a.c_str()); return 2; }
+    }
+    if (dump.empty()) {
+        fprintf(stderr, "usage: screenshot <app0-dir> [--every N=60] [--count M=30] [--out DIR] [--timeout SECS]\n");
+        return 2;
+    }
+    if (every < 1) every = 1;
+    if (count < 1) count = 1;
+
+    // Title code = dump basename with a trailing "-app0" removed (e.g. PPSA24651-app0 -> PPSA24651).
+    std::string code = dump;
+    if (auto sl = code.find_last_of("/\\"); sl != std::string::npos) code = code.substr(sl + 1);
+    if (!code.empty() && code.back() == '/') code.pop_back();
+    if (auto p = code.rfind("-app0"); p != std::string::npos && p == code.size() - 5) code = code.substr(0, p);
+    if (code.empty()) code = "GAME";
+
+    // Run-start timestamp shared by every screenshot in this run, so a run groups when sorted.
+    char ts[32];
+    { time_t t = time(nullptr); struct tm tmv; localtime_r(&t, &tmv); strftime(ts, sizeof ts, "%Y%m%d-%H%M%S", &tmv); }
+
+    // Zero-pad the index to the width of the largest index (min 2), for correct lexical sort.
+    int pad = 2; for (int m = count - 1, d = 1; ; m /= 10, d++) { if (m < 10) { if (d > pad) pad = d; break; } }
+
+    // Sane render-frontier defaults (don't override if the caller set them for another title).
+    setenv("PROSPER_GUEST_FS",   "1", 0);
+    setenv("PROSPER_GUEST_ARGS", "-force-gfx-direct", 0);
+
+    // Register the shared live renderer (feeds the present layer; no BMP spam), then boot + run the
+    // guest on its own thread while this thread samples the present layer.
+    prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false);
+    Program prog; std::string err;
+    if (!boot_program(dump, prog, &err)) { fprintf(stderr, "screenshot: boot failed: %s\n", err.c_str()); return 1; }
+    std::thread guest([&prog] { run_entry(prog.imgs[0]); });
+    guest.detach();
+
+    fprintf(stderr, "[shot] %s: %d screenshots, every %d frames -> %s/%s_%s_*.png\n",
+            code.c_str(), count, every, out.c_str(), code.c_str(), ts);
+
+    std::vector<uint8_t> buf;
+    int saved = 0;
+    uint64_t next = (uint64_t)every;   // first shot after `every` flips (frame 0 is usually blank)
+    auto t0 = std::chrono::steady_clock::now();
+    while (saved < count) {
+        double el = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+        if (timeout > 0 && el > timeout) {
+            fprintf(stderr, "[shot] timeout after %.0fs with %d/%d saved — game not flipping enough "
+                            "(wrong guest env for this title? see --help notes)\n", el, saved, count);
+            break;
+        }
+        if (gpu::present_has_frame() && gpu::present_frame_seq() >= next) {
+            uint64_t at = gpu::present_frame_seq();   // rendered-frame # at this shot; next is `every` later
+            uint32_t w = gpu::present_width(), h = gpu::present_height();
+            if (w && h) {
+                buf.resize((size_t)w * h * 4);
+                if (gpu::present_readback(buf.data(), buf.size()) == buf.size()) {
+                    char fn[1024];
+                    snprintf(fn, sizeof fn, "%s/%s_%s_%0*d.png", out.c_str(), code.c_str(), ts, pad, saved);
+                    if (write_png(fn, buf.data(), w, h)) {
+                        fprintf(stderr, "[shot] %d/%d  %s  (frame %llu)\n", saved + 1, count, fn, (unsigned long long)at);
+                        saved++;
+                    } else {
+                        fprintf(stderr, "[shot] PNG write failed: %s\n", fn);
+                    }
+                }
+            }
+            next = at + (uint64_t)every;   // schedule `every` flips after THIS shot (not accumulating from 0)
+        } else {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+    fprintf(stderr, "[shot] done: %d screenshot(s) in %s\n", saved, out.c_str());
+    _exit(0);   // the guest thread is detached and running guest code; don't block on teardown
+}


### PR DESCRIPTION
A tool to run a game and capture a PNG every N rendered frames until M screenshots, then exit — for snapshot-testing runs and eyeballing progression.

## Usage
```
screenshot <app0-dir> [--every N=60] [--count M=30] [--out DIR=.] [--timeout SECS=900]
```
Only the game is required; everything else defaults sanely.

## Design
- **Reuses the shared helpers** — `boot_program` (boot) + `frontends/shared/live_renderer` (composite). No duplicated boot/render glue.
- **Real PNGs** via zlib (~40 KB/frame vs 8 MB uncompressed BMPs).
- **Filenames** `<titleCode>_<runTimestamp>_<index>.png` (e.g. `PPSA24651_20260709-195505_00.png`) — one `YYYYMMDD-HHMMSS` stamp per run so a folder of many runs groups and sorts cleanly. titleCode = dump basename minus a trailing `-app0`.
- **"Frames" = rendered frames**, via a new `present_frame_seq()` on the present layer. The guest flips far faster than llvmpipe renders, so counting flips (`present_count`) bunched every shot into the first second; rendered frames spread them across the run. Confirmed: shots land at rendered-frames 20/40/60 exactly.
- Defaults the render-frontier guest env (`PROSPER_GUEST_FS=1`, `PROSPER_GUEST_ARGS=-force-gfx-direct`) if unset; overridable per title (e.g. UE4: `PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1`).

## Verified
- On The Messenger: 3 shots at frames 20/40/60, valid 1920×1080 RGBA PNGs (~43 KB each).
- Full `ctest` **65/65** (the `present_frame_seq` addition is additive; nothing regressed).
- Built wherever Vulkan + zlib are found (same block as `boot_trace`).