### PR TITLE
diag(gpu): PROSPER_DRAWDIAG + DUMP_ATLAS-by-address for the caption investigation

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -213,6 +213,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::dump_bmp(fn, texstore.back(), tw, th);
                             fprintf(stderr, "[render] dumped raw texture -> %s\n", fn); fflush(stderr);
                         }
+                        // PROSPER_DUMP_ATLAS: dump each SMALL sampled texture once per ADDRESS (find the caption
+                        // font among same-size UI textures). Capped.
+                        if (getenv("PROSPER_DUMP_ATLAS") && !texstore.back().empty() && tw <= 1024 && th <= 512) {
+                            static std::unordered_map<uint64_t,int> seen; static int ndumped = 0;
+                            if (seen[r.gpu_addr]++ == 0 && ndumped++ < 60) {
+                                std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
+                                char fn[512]; snprintf(fn, sizeof fn, "%s/tex_%ux%u_%llx_c%u.bmp", d.c_str(), tw, th,
+                                                       (unsigned long long)r.gpu_addr, r.num_components);
+                                prosper::test::dump_bmp(fn, texstore.back(), tw, th);
+                            }
+                        }
                         fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = th;
                     } else {
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -161,6 +161,18 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // The cutscene submits ~66 draws/frame that resolve to mask==0; if that is a mis-decode (not a genuine
     // depth-only pass), rendering them reveals whether they are the cutscene content.
     if (ps.color_write_mask == 0) ps.color_write_mask = 0xf;
+    // PROSPER_DRAWDIAG: per-RENDERED-draw geometry/position/texture — to LOCATE specific draws (e.g. the
+    // cutscene caption text: small indexed quads, bottom viewport, blended, sampling a font atlas).
+    if (getenv("PROSPER_DRAWDIAG")) {
+        uint32_t ic = (draw && draw->indexed) ? draw->index_count : vcount_hint;
+        fprintf(stderr, "[draw] idx=%u vp=%d y=%.0f h=%.0f blend=%d cwm=0x%x es=0x%llx", ic,
+                ps.has_viewport, ps.viewport_y, ps.viewport_h, ps.blend_enable, ps.color_write_mask,
+                (unsigned long long)rs.es_addr);
+        if (prt) for (const auto& r : prt->resources)
+            if (r.cls == ResourceClass::Texture)
+                fprintf(stderr, " tex=0x%llx(%ux%u f%u)", (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
+        fprintf(stderr, "\n");
+    }
     uint32_t vertex_count = vcount_hint ? vcount_hint : 3u;
     // The bound vertex buffer's record count (size/stride) — bounds an indexed draw's vertex range, and
     // for a NON-indexed draw is often the truer count: a draw record's index_count can be a low/stale


### PR DESCRIPTION
Two off-by-default gated diagnostics supporting the Messenger cutscene-caption investigation (#102): `PROSPER_DRAWDIAG` logs per-rendered-draw geometry/viewport/blend/mask/textures; `PROSPER_DUMP_ATLAS` dumps each small sampled texture once per address (to find the caption font among same-size UI textures). No behavior change. Refs #102.