### PR TITLE
tools(il2cpp): resolve.py address→C# symbolicator + complete the setup recipe

### DIFF
--- a/prosper/tools/il2cpp/README.md
+++ b/prosper/tools/il2cpp/README.md
@@ -8,16 +8,38 @@ managed logic (scene load, boot state machines) during emulator debugging.
 
        python3 prx_to_elf.py <dump>/Media/Modules/Il2CppUserAssemblies.prx /tmp/asm.elf
 
-2. Run Il2CppDumper (needs dotnet-sdk). The ELF starts at vaddr 0 so it prompts
-   "input il2cpp dump address" — answer `0` to force the registration auto-scan:
+2. Get Il2CppDumper if you don't have it (it is NOT preinstalled). Only a net8
+   runtime ships in the WSL image, and no `unzip`, so grab the net7 build and
+   force roll-forward:
 
-       printf '0\n0\n0\n' | dotnet Il2CppDumper.dll /tmp/asm.elf \
-           <dump>/Media/Metadata/global-metadata.dat /tmp/out
+       cd /tmp
+       curl -sSL https://github.com/Perfare/Il2CppDumper/releases/download/v6.7.46/Il2CppDumper-net7-v6.7.46.zip -o d.zip
+       python3 -c "import zipfile; zipfile.ZipFile('d.zip').extractall('dumper')"
 
-3. `out/dump.cs` lists every method with a `// RVA: 0x...` comment. The runtime
-   address is `module load base + RVA`. For PPSA02664 the PRX loads at
-   `0x440000000` (verified via gdb `info proc mappings`), so `DoFirstLogin`
-   (RVA `0x2140D0`) is at `0x4402140D0`.
+3. Run it (needs dotnet-sdk). The ELF starts at vaddr 0 so it prompts
+   "input il2cpp dump address" — answer `0` to force the registration auto-scan.
+   Pipe the answers in (headless has no console; the tool still throws a harmless
+   `Cannot read keys` at the very end AFTER all outputs are written — ignore it):
+
+       cd /tmp/dumper && DOTNET_ROLL_FORWARD=LatestMajor \
+         sh -c 'printf "0\n0\n0\n" | dotnet Il2CppDumper.dll /tmp/asm.elf \
+           <dump>/Media/Metadata/global-metadata.dat /tmp/out'
+
+4. `out/dump.cs` lists every method with a `// RVA: 0x...` comment; `out/script.json`
+   has the machine-readable `{Address, Name}` list. The runtime address is
+   `module load base + RVA`. Both PPSA24651 (The Messenger) and PPSA02664 load the
+   IL2CPP PRX at `0x440000000`, so RVA == script.json Address == a prosper
+   `[btrace] il+0x<offset>` frame. `DoFirstLogin` (RVA `0x2140D0`) → `0x4402140D0`.
+
+5. Symbolicate addresses / btrace chains with `resolve.py`:
+
+       python3 resolve.py /tmp/out/script.json il+0x1764ce2 0x11e63c
+       # il+0x1764ce2  ->  Unity.PSN.PS5.Async.WorkerThread$$RunProc (+0xa2)
+       echo '[btrace] ... chain=il+0xde92e9,il+0xde9159' | python3 resolve.py /tmp/out/script.json -
+
+   NOTE: prosper's `[btrace]` validated unwinder must accept INDIRECT call sites
+   (`0xFF` at v-2/-3/-6/-7), not just `0xE8` (call rel32) — IL2CPP dispatches
+   managed methods indirectly, so an 0xE8-only filter drops every managed frame.
 
 ## gdb caveat (prosper)
 prosper installs a SIGSEGV handler for lazy memory commit. Under gdb, ALWAYS use

--- a/prosper/tools/il2cpp/resolve.py
+++ b/prosper/tools/il2cpp/resolve.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# resolve.py — map runtime addresses / btrace frames to C# method names using the
+# Il2CppDumper output (script.json). Companion to prx_to_elf.py; see README.md.
+#
+# The IL2CPP PRX loads at a fixed guest base (0x440000000 for both PPSA24651 and
+# PPSA02664), so a method's runtime address = base + RVA, and script.json's
+# "Address" field == RVA (the flattened ELF has p_offset == p_vaddr). A prosper
+# [btrace] chain prints frames as "il+0x<offset>", where <offset> is already the
+# RVA — feed those straight in.
+#
+# Usage:
+#   python3 resolve.py <script.json> 0x16b981 0x11e63c ...      # bare RVAs
+#   python3 resolve.py <script.json> il+0x16b981,eb+0xada254    # a btrace chain
+#   echo '[btrace] ... chain=il+0x1e23b8,il+0xde92e9' | python3 resolve.py <script.json> -
+#   python3 resolve.py <script.json> --base 0x440000000 0x4402140d0   # absolute runtime addr
+import json, bisect, re, sys
+
+def load(path):
+    sj = json.load(open(path))
+    addrs = sorted((m['Address'], m['Name']) for m in sj.get('ScriptMethod', []) if 'Address' in m)
+    return addrs, [a for a, _ in addrs]
+
+def resolve_one(addrs, keys, off):
+    i = bisect.bisect_right(keys, off) - 1
+    if i >= 0 and off - addrs[i][0] < 0x8000:
+        a, name = addrs[i]
+        return f"{name}  (+0x{off - a:x})"
+    return "<il2cpp runtime / no managed method at this offset>"
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__); return 1
+    script = argv[1]
+    rest = argv[2:]
+    base = 0
+    if '--base' in rest:
+        k = rest.index('--base'); base = int(rest[k+1], 0); del rest[k:k+2]
+    addrs, keys = load(script)
+    tokens = []
+    for a in rest:
+        if a == '-':
+            tokens += re.findall(r'(?:il|eb)\+0x[0-9a-f]+|0x[0-9a-f]+', sys.stdin.read())
+        else:
+            tokens += re.split(r'[,\s]+', a.strip())
+    for t in tokens:
+        if not t: continue
+        m = re.match(r'(il|eb)\+0x([0-9a-f]+)$', t)
+        if m:
+            if m.group(1) == 'eb':
+                print(f"{t:22}  (eboot / Unity native — not managed)"); continue
+            off = int(m.group(2), 16)
+        else:
+            v = int(t, 0)
+            off = v - base if v >= base and base else v
+        print(f"{t:22}  {resolve_one(addrs, keys, off)}")
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Builds on #242 (`prx_to_elf.py`). During the #234 input investigation I got IL2CPP symbolication working end-to-end and it was decisive — it proved the game is **not** deadlocked (the "blocked" threads are idle `Unity.PSN.PS5.*` network threads on WaitHandles) and located the input class `PS5Input`. This PR captures that capability so it isn't lost.

**Adds `resolve.py`** — maps runtime addresses / prosper `[btrace] il+0x<off>` frames to C# method names via Il2CppDumper's `script.json`. Accepts bare RVAs, comma-separated chains, absolute addresses (`--base`), or a chain on stdin.

**Expands the README** with the non-obvious setup steps:
- Il2CppDumper isn't preinstalled; WSL has only a net8 runtime and no `unzip` → fetch the net7 build, extract via `python zipfile`, run under `DOTNET_ROLL_FORWARD=LatestMajor`.
- The dumper throws a harmless `Cannot read keys` at the end *after* writing all outputs (headless has no console) — ignore it.
- **The `[btrace]` unwinder must accept indirect call sites (`0xFF`), not only `0xE8`** — IL2CPP dispatches managed methods indirectly, so an `0xE8`-only filter drops every managed frame. (This is exactly why my first symbolication attempts only recovered `WaitHandle` and missed `WorkerThread::RunProc`.)

Verified end-to-end on PPSA24651:
- `il+0x1764ce2` → `Unity.PSN.PS5.Async.WorkerThread::RunProc`
- `il+0xde92e9` → `System.Threading.WaitHandle::WaitOneNative`

Docs/tools only; no runtime code. Refs #234, #242.