### PR TITLE
diag(host): PROSPER_FAULT_SKIP — step past a specific crash for bring-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ prosper/
   src/host/        host execution: image mapping, import stubs, fault handling (Linux)
   src/gpu/         AGC->Vulkan: PM4 decode, command processor, render state, vk_translate,
                    resource layer, RDNA2->SPIR-V recompiler
-  tools/           self_dump, boot_trace, shader_histo, imgdump, spv_validate
+  tools/           self_dump, boot_trace, shader_histo, imgdump, spv_validate,
+                   snapshot (golden-image rendering regression guard — see tools/AGENTS.md)
   tests/           unit + boot + Vulkan-execution tests (ctest)
 ```
 
@@ -77,7 +78,10 @@ renderer is wired in; the game's **real pixel shader recompiles to valid SPIR-V*
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual
-  eyeballing is required to know a change works.
+  eyeballing is required to know a change works. **After any change that can affect rendered output**
+  (recompiler, AGC decode, render state, detile, executor/present), run the golden-image guard
+  `python3 tools/snapshot/snapshot.py check` (local-only, boots a real game and pixel-hashes an exact
+  frame vs a stored baseline — see `tools/snapshot/AGENTS.md`).
 - **Reaching the running frame loop** needs two gated switches (off by default, so the default boot stays
   stable): `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`. Add `PROSPER_RENDER=1` to run the
   live renderer, `PROSPER_GFXLOG=1` for graphics diagnostics.

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1034,6 +1034,18 @@ namespace {
         g_r14 = (uint64_t)g[REG_R14]; g_r15 = (uint64_t)g[REG_R15];
         g_trap_sig = sig;
         g_trap_kind = (sig == SIGILL) ? 3 : 2;
+        // PROSPER_FAULT_SKIP="<fault-off>[:<resume-off>]" DIAGNOSTIC (bring-up, NOT a fix): when a fault
+        // hits at eboot+<fault-off>, set rax=0 and resume the guest at eboot+<resume-off> (default
+        // fault-off+4, i.e. skip one short instruction). Lets the guest survive ONE specific crash so
+        // you can see whether it gates later progress. Found PPSA02664's boot gate (#238): skipping the
+        // engine state-machine null-handler deref chain (`PROSPER_FAULT_SKIP=0x410b3:0x410bb`) makes the
+        // title load its scene, instantiate MonoBehaviours, and run 76k GPU submits crash-free.
+        if (const char* fsk = getenv("PROSPER_FAULT_SKIP")) {
+            uint64_t foff = strtoull(fsk, nullptr, 0);
+            const char* colon = strchr(fsk, ':');
+            uint64_t roff = colon ? strtoull(colon + 1, nullptr, 0) : foff + 4;
+            if (g_base && g_fault_rip == g_base + foff) { g[REG_RAX] = 0; g[REG_RIP] = g_base + roff; return; }
+        }
         dump_fault_mem();   // no-op unless PROSPER_FAULTMEM is set
         // Dump the HWBP ring on the recoverable (armed/main-thread) crash too — the deser fault is kind=2.
         if (g_hwbp_node_on && !g_hwbp_ring_dumped) { uint64_t sfs = guest_fs_to_host_scoped();

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — prosper/tools
+
+Developer/agent tooling. These are debugging and verification aids, not part of
+the shipped runtime. Build them from `build-linux/` like everything else.
+
+- **`snapshot/`** — golden-image **rendering regression guard**. Run
+  `python3 tools/snapshot/snapshot.py check` before/after any change that can
+  affect rendered output (recompiler, AGC decode, render state, detile, present).
+  See `snapshot/AGENTS.md`. **Run this after touching the render path.**
+- **`boot_trace/`** — boots a SELF/ELF game image through the loader + HLE and
+  runs it, with the fault handler, GPU executor, and (under `PROSPER_RENDER`) the
+  live Vulkan renderer. The main harness for exercising a real title headlessly.
+- **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map
+  (find file offsets for offline disassembly).
+- **`shader_histo/`** — histogram RDNA2 opcodes across a title's shaders.
+- **`imgdump/`** — decode/dump a guest texture to an image for inspection.
+- **`spv_validate/`** — `spirv-val` wrapper for recompiled SPIR-V.
+- **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
+
+Verification here is agentic-first (see `docs/VERIFICATION.md`): prefer a
+programmatic check (ctest exit code, `spirv-val`, a snapshot hash) over eyeballing.

--- a/prosper/tools/snapshot/.gitignore
+++ b/prosper/tools/snapshot/.gitignore
@@ -1,0 +1,4 @@
+failures/
+*.bmp
+*.png
+snap_*/

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md — rendering snapshot tests
+
+Golden-image regression guard for game rendering. **Run this whenever you touch
+anything that can change rendered output** (the RDNA2→SPIR-V recompiler, AGC/PM4
+decode, render state, texture detile, the executor/present path) — before AND
+after your change. A blued title or a mis-decoded texture flips a stored pixel
+hash, so you catch the regression instead of shipping it.
+
+This exists because two recompiler fixes for *other* titles silently blued The
+Messenger to a full-screen clear (PR #227). Nothing had guarded a real game's
+output. Now something does.
+
+## Run it
+
+```bash
+# from prosper/ , with build-linux/boot_trace built for your change
+python3 tools/snapshot/snapshot.py check            # all snapshots; EXIT 1 on any diff
+python3 tools/snapshot/snapshot.py check messenger-title
+python3 tools/snapshot/snapshot.py update [name...]  # re-baseline AFTER an intended output change
+python3 tools/snapshot/snapshot.py verify [name...]  # capture twice; is the frame deterministic?
+python3 tools/snapshot/snapshot.py list
+```
+
+`check` failing → the offending screenshot + boot log are saved to
+`failures/<name>.{bmp,log}`. Eyeball the BMP
+(`python3 -c 'from PIL import Image; Image.open("failures/x.bmp").save("x.png")'`).
+If your change **intentionally** alters output, re-run `update` and commit the new
+hash in `snapshots.json` — with a note in your PR on why the pixels moved.
+
+## Non-negotiables
+
+- **Local only, NEVER CI.** Game dumps are gitignored and must never be committed.
+  Only the pixel **hashes** live in the repo (`snapshots.json`) — a hash is a
+  checksum, not game imagery (same rule as [[pr-screenshots]]: no game imagery in
+  mainline).
+- **`verify` before you trust a new snapshot.** A game boot has threads; if the
+  target frame lands in a transient (loading→title) it won't be deterministic.
+  Pick F in a **static** window (a title/menu loop re-renders the same composite,
+  so its hash is stable). Only F ≤ 59 (and multiples of 10) are dumped.
+- **Don't `update` to make a red `check` green.** A `check` failure is either a
+  real regression (fix it) or an intended change (re-baseline *and explain it*).
+  Silently re-baselining a regression defeats the whole point.
+
+## How a frame is targeted
+
+`RENDER_EVERY=1` renders every draw-carrying submit, so `frame_<F>.bmp` is the
+F-th draw submit's render. `RENDER_SCALE` shrinks the framebuffer (faster; the
+hash is per-scale, so keep `scale` fixed per snapshot). The tool runs a
+uniquely-named copy of `boot_trace` so a concurrent agent's `pkill -x boot_trace`
+can't kill your capture.
+
+## Adding a snapshot (e.g. another title / a specific screen)
+
+1. Add an entry to `snapshots.json`: `name`, `dump` (the `*-app0` dir under
+   `PROSPER_GAME_ROOT`), `frame`, `scale`, optional per-title `env` (e.g. a title
+   that needs extra guest args). Leave `hash` empty.
+2. `verify <name>` — must print DETERMINISTIC. If not, move `frame` later / to a
+   more static screen.
+3. `update <name>` — stores the baseline. Commit `snapshots.json`.
+
+## Env
+
+- `PROSPER_GAME_ROOT`  — dir holding the `*-app0` dumps (default `/mnt/c/Users/matti/repos/ps5ys`)
+- `PROSPER_BOOT_TRACE` — boot_trace path (default `<prosper>/build-linux/boot_trace`)

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -1,0 +1,44 @@
+# Rendering snapshot tests (golden-image, run locally)
+
+Catches rendering regressions in real games: a change that blanks a title, breaks
+a shader recompile, or mis-decodes a texture flips a stored pixel hash. Any agent
+can run it before/after a change.
+
+**Local only — never CI.** The game dumps are gitignored and must not be
+committed, so this can't run in CI. Only the small pixel **hashes** live in the
+repo (`snapshots.json`) — a hash is a checksum, not game imagery.
+
+## Run
+
+```bash
+# from prosper/ (build boot_trace first: build-linux/boot_trace)
+python3 tools/snapshot/snapshot.py check           # all snapshots; exit 1 on any diff
+python3 tools/snapshot/snapshot.py check messenger-title
+python3 tools/snapshot/snapshot.py update           # (re)capture baselines after an INTENDED change
+python3 tools/snapshot/snapshot.py verify           # capture twice; confirm a frame is deterministic
+python3 tools/snapshot/snapshot.py list
+```
+
+On a mismatch, `check` writes the offending screenshot + boot log to
+`tools/snapshot/failures/<name>.{bmp,log}` and returns non-zero. Convert the BMP
+to PNG to eyeball it (`python3 -c 'from PIL import Image; Image.open("x.bmp").save("x.png")'`).
+
+## How it targets a frame
+
+`RENDER_EVERY=1` renders every draw-carrying submit, so `frame_<F>.bmp` is the
+F-th draw submit's render. Pick **F in a stable-content window** — a static
+title/menu loop re-renders the same composite each submit, so its hash is stable.
+Always `verify` a new snapshot's frame before trusting its baseline; if it's
+NON-DETERMINISTIC, move F later (or to a more static screen). Only F ≤ 59 (or
+multiples of 10) are dumped by the renderer.
+
+## Adding a snapshot
+
+Add an entry to `snapshots.json` (`name`, `dump` = the `*-app0` dir under
+`PROSPER_GAME_ROOT`, `frame`, `scale`, optional per-title `env`), then
+`verify` it, then `update` to store the baseline hash.
+
+## Env
+
+- `PROSPER_GAME_ROOT`  — dir holding the `*-app0` dumps (default `/mnt/c/Users/matti/repos/ps5ys`)
+- `PROSPER_BOOT_TRACE` — boot_trace path (default `<prosper>/build-linux/boot_trace`)

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -114,6 +114,39 @@ def capture(entry, run_log=None):
         proc = subprocess.Popen([bt_run, dump], env=env, stdout=logf, stderr=subprocess.STDOUT,
                                 preexec_fn=os.setsid)
         deadline = time.time() + timeout
+        settle = int(entry.get("settle", 0))
+        if settle > 0:
+            # SETTLE MODE: return once the render STABILIZES — the last `settle` frames all hash
+            # identical (a static/settled screen). This is deterministic across runs, unlike the
+            # timing-dependent N-th-draw-submit target (`frame`), which varies with boot threading.
+            seen, recent = {}, []
+            while time.time() < deadline:
+                exited = proc.poll() is not None
+                frames = sorted(f for f in os.listdir(tmp) if f.startswith("frame_") and f.endswith(".bmp"))
+                for i, f in enumerate(frames):
+                    if f in seen:
+                        continue
+                    if i == len(frames) - 1 and not exited:
+                        continue                         # newest frame may be mid-write; hash it next poll
+                    p = os.path.join(tmp, f)
+                    try:
+                        if os.path.getsize(p) <= 0:
+                            continue
+                        h, _ = pixel_hash(p)
+                    except OSError:
+                        continue
+                    seen[f] = h
+                    recent.append((p, h))
+                    if len(recent) >= settle and len({x[1] for x in recent[-settle:]}) == 1:
+                        dst = os.path.join(tmp, "captured.bmp")
+                        shutil.copyfile(p, dst)
+                        return dst, tmp
+                if exited:
+                    raise RuntimeError(f"boot_trace exited (code {proc.returncode}) before settling to "
+                                       f"{settle} stable frames (reached: {_last_frame(tmp)})")
+                time.sleep(0.3)
+            raise RuntimeError(f"timeout after {timeout}s waiting for {settle} stable frames "
+                               f"(reached: {_last_frame(tmp)})")
         last_size = -1
         while time.time() < deadline:
             if proc.poll() is not None and not os.path.exists(target):
@@ -166,15 +199,30 @@ def cmd_list(m, names):
 
 
 def cmd_update(m, names):
+    # Bless a NEW baseline hash — but only if the target is DETERMINISTIC. Capture twice and refuse to
+    # write the hash unless both captures agree; a baseline that isn't reproducible is worse than none
+    # (it fails `check` for every other agent/machine and trains people to ignore the guard). A target
+    # like "the N-th draw submit" (PROSPER_RENDER_EVERY=1) is inherently timing/threading-dependent on a
+    # threaded boot, so it will (correctly) be rejected here until the entry targets a settled/stable
+    # capture point. `--force` blesses a single capture anyway (escape hatch; not recommended).
+    force = "--force" in names
+    names = [n for n in names if n != "--force"]
     rc = 0
     for s in select(m, names):
         try:
-            bmp, tmp = capture(s)
-            h, dims = pixel_hash(bmp)
-            s["hash"] = h
-            s["dims"] = list(dims)
-            print(f"[update] {s['name']}: {dims[0]}x{dims[1]} hash={h[:16]}…")
-            _cleanup(tmp)
+            b1, t1 = capture(s); h1, dims = pixel_hash(b1); _cleanup(t1)
+            if force:
+                s["hash"] = h1; s["dims"] = list(dims)
+                print(f"[update] {s['name']}: {dims[0]}x{dims[1]} hash={h1[:16]}… (FORCED, unverified)")
+                continue
+            b2, t2 = capture(s); h2, _ = pixel_hash(b2); _cleanup(t2)
+            if h1 != h2:
+                print(f"[update] {s['name']}: REFUSED — non-deterministic ({h1[:12]} vs {h2[:12]}); "
+                      f"target a settled/stable frame (or --force to override)", file=sys.stderr)
+                rc = 1
+                continue
+            s["hash"] = h1; s["dims"] = list(dims)
+            print(f"[update] {s['name']}: {dims[0]}x{dims[1]} hash={h1[:16]}… (verified deterministic)")
         except Exception as e:
             print(f"[update] {s['name']}: ERROR {e}", file=sys.stderr)
             rc = 1

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Golden-image snapshot tester for prosper's game rendering.
+
+Runs a game through boot_trace, captures an EXACT rendered frame, hashes its
+pixels, and compares against a stored baseline. On a mismatch it saves the
+offending screenshot and exits non-zero — snapshot testing for the renderer, so
+any agent can catch a rendering regression (e.g. a recompiler change that blanks
+a title) before it ships.
+
+The game dumps are NOT in the repo (gitignored) and MUST NOT be committed, so
+this runs LOCALLY, never in CI. Only the small pixel HASHES live in the repo
+(snapshots.json) — a hash is a checksum, not game imagery.
+
+Usage:
+  snapshot.py check  [name ...]   # compare captures to baselines; exit 1 on any diff/error
+  snapshot.py update [name ...]   # (re)capture and store/overwrite baseline hashes
+  snapshot.py verify [name ...]   # capture twice each; report whether the frame is deterministic
+  snapshot.py list
+
+Env overrides:
+  PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: /mnt/c/Users/matti/repos/ps5ys)
+  PROSPER_BOOT_TRACE  path to the boot_trace binary    (default: <prosper>/build-linux/boot_trace)
+
+A frame is targeted by RENDER_EVERY=1 (render every draw submit) + `frame`=F, so
+frame_<F>.bmp is the F-th draw submit's render. Pick F in a STABLE-content window
+(a static title/menu loop renders the same composite every submit → same hash);
+use `verify` to confirm F is deterministic before trusting a baseline.
+"""
+import sys, os, json, time, hashlib, struct, subprocess, tempfile, shutil, signal
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MANIFEST = os.path.join(HERE, "snapshots.json")
+FAIL_DIR = os.path.join(HERE, "failures")
+GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT", "/mnt/c/Users/matti/repos/ps5ys")
+
+
+def boot_trace_path():
+    p = os.environ.get("PROSPER_BOOT_TRACE")
+    if p:
+        return p
+    # <prosper>/tools/snapshot/ -> <prosper>/build-linux/boot_trace
+    return os.path.normpath(os.path.join(HERE, "..", "..", "build-linux", "boot_trace"))
+
+
+def load_manifest():
+    if not os.path.exists(MANIFEST):
+        return {"snapshots": []}
+    with open(MANIFEST) as f:
+        return json.load(f)
+
+
+def save_manifest(m):
+    with open(MANIFEST, "w") as f:
+        json.dump(m, f, indent=2)
+        f.write("\n")
+
+
+def pixel_hash(bmp_path):
+    """SHA-256 of the BMP's pixel data (header-independent so tool/metadata
+    differences never trip it — only the actual rendered pixels do)."""
+    with open(bmp_path, "rb") as f:
+        d = f.read()
+    if len(d) < 54 or d[:2] != b"BM":
+        raise ValueError(f"{bmp_path}: not a BMP ({len(d)} bytes)")
+    off = struct.unpack_from("<I", d, 10)[0]
+    w = struct.unpack_from("<i", d, 18)[0]
+    h = abs(struct.unpack_from("<i", d, 22)[0])
+    return hashlib.sha256(d[off:]).hexdigest(), (w, h)
+
+
+def resolve_dump(entry):
+    dump = entry["dump"]
+    return dump if os.path.isabs(dump) else os.path.join(GAME_ROOT, dump)
+
+
+def capture(entry, run_log=None):
+    """Boot the game, wait for frame_<F>.bmp, return (bmp_bytes_path_copy, (w,h)).
+    Raises RuntimeError on timeout / crash-before-frame."""
+    bt = boot_trace_path()
+    if not os.path.exists(bt):
+        raise RuntimeError(f"boot_trace not found at {bt} (build it, or set PROSPER_BOOT_TRACE)")
+    dump = resolve_dump(entry)
+    if not os.path.exists(dump):
+        raise RuntimeError(f"game dump not found: {dump} (set PROSPER_GAME_ROOT)")
+
+    frame = int(entry["frame"])
+    scale = int(entry.get("scale", 4))
+    timeout = int(entry.get("timeout", 240))
+
+    env = dict(os.environ)
+    # Defaults every title needs to reach the frame loop, then the render/target knobs. The manifest
+    # entry's own `env` wins so a title can add its specific switches.
+    env.update({
+        "PROSPER_GUEST_FS": "1",
+        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
+        "PROSPER_RENDER": "1",
+        "PROSPER_RENDER_EVERY": "1",     # render every draw submit -> frame_<F> == F-th draw submit
+        "PROSPER_RENDER_FIRST": "0",
+        "PROSPER_RENDER_SCALE": str(scale),
+        "PROSPER_FAULT_ONSTACK": "1",    # a guest-thread fault is reported, not a silent kill
+    })
+    env.update(entry.get("env", {}))
+
+    tmp = tempfile.mkdtemp(prefix="snap_")
+    env["PROSPER_FRAME_DIR"] = tmp
+    target = os.path.join(tmp, "frame_%04d.bmp" % frame)
+    # Run a UNIQUELY-NAMED copy of the binary: this repo is worked by several agents at once, and a
+    # concurrent `pkill -x boot_trace` would otherwise kill our capture mid-boot.
+    bt_run = os.path.join(tmp, "bt_snap")
+    shutil.copyfile(bt, bt_run)
+    os.chmod(bt_run, 0o755)
+    logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
+    try:
+        proc = subprocess.Popen([bt_run, dump], env=env, stdout=logf, stderr=subprocess.STDOUT,
+                                preexec_fn=os.setsid)
+        deadline = time.time() + timeout
+        last_size = -1
+        while time.time() < deadline:
+            if proc.poll() is not None and not os.path.exists(target):
+                raise RuntimeError(f"boot_trace exited (code {proc.returncode}) before frame {frame} "
+                                   f"(reached: {_last_frame(tmp)})")
+            if os.path.exists(target):
+                sz = os.path.getsize(target)
+                if sz > 0 and sz == last_size:          # size stable across a poll -> fully written
+                    dst = os.path.join(tmp, "captured.bmp")
+                    shutil.copyfile(target, dst)
+                    return dst, tmp
+                last_size = sz
+            time.sleep(0.3)
+        raise RuntimeError(f"timeout after {timeout}s waiting for frame {frame} "
+                           f"(reached: {_last_frame(tmp)})")
+    finally:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except Exception:
+            pass
+        if run_log:
+            logf.close()
+
+
+def _last_frame(tmp):
+    fs = sorted(f for f in os.listdir(tmp) if f.startswith("frame_") and f.endswith(".bmp"))
+    return fs[-1] if fs else "no frames"
+
+
+def _cleanup(tmp):
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def select(m, names):
+    snaps = m["snapshots"]
+    if names:
+        by = {s["name"]: s for s in snaps}
+        missing = [n for n in names if n not in by]
+        if missing:
+            print(f"unknown snapshot(s): {', '.join(missing)}", file=sys.stderr)
+            sys.exit(2)
+        return [by[n] for n in names]
+    return snaps
+
+
+def cmd_list(m, names):
+    for s in m["snapshots"]:
+        print(f"  {s['name']:<28} dump={s['dump']} frame={s['frame']} "
+              f"hash={'set' if s.get('hash') else 'MISSING'}")
+
+
+def cmd_update(m, names):
+    rc = 0
+    for s in select(m, names):
+        try:
+            bmp, tmp = capture(s)
+            h, dims = pixel_hash(bmp)
+            s["hash"] = h
+            s["dims"] = list(dims)
+            print(f"[update] {s['name']}: {dims[0]}x{dims[1]} hash={h[:16]}…")
+            _cleanup(tmp)
+        except Exception as e:
+            print(f"[update] {s['name']}: ERROR {e}", file=sys.stderr)
+            rc = 1
+    save_manifest(m)
+    return rc
+
+
+def cmd_verify(m, names):
+    rc = 0
+    for s in select(m, names):
+        try:
+            b1, t1 = capture(s); h1, _ = pixel_hash(b1); _cleanup(t1)
+            b2, t2 = capture(s); h2, _ = pixel_hash(b2); _cleanup(t2)
+            ok = h1 == h2
+            print(f"[verify] {s['name']}: {'DETERMINISTIC' if ok else 'NON-DETERMINISTIC'} "
+                  f"({h1[:12]} vs {h2[:12]})")
+            if not ok:
+                rc = 1
+        except Exception as e:
+            print(f"[verify] {s['name']}: ERROR {e}", file=sys.stderr)
+            rc = 1
+    return rc
+
+
+def cmd_check(m, names):
+    os.makedirs(FAIL_DIR, exist_ok=True)
+    rc = 0
+    for s in select(m, names):
+        base = s.get("hash")
+        if not base:
+            print(f"[check] {s['name']}: NO BASELINE — run `snapshot.py update {s['name']}`", file=sys.stderr)
+            rc = 1
+            continue
+        log = os.path.join(FAIL_DIR, f"{s['name']}.log")
+        try:
+            bmp, tmp = capture(s, run_log=log)
+            h, dims = pixel_hash(bmp)
+            if h == base:
+                print(f"[check] {s['name']}: OK ({dims[0]}x{dims[1]})")
+                os.remove(log) if os.path.exists(log) else None
+            else:
+                out = os.path.join(FAIL_DIR, f"{s['name']}.bmp")
+                shutil.copyfile(bmp, out)
+                print(f"[check] {s['name']}: FAIL — hash {h[:16]}… != baseline {base[:16]}…")
+                print(f"         screenshot: {out}")
+                print(f"         boot log:   {log}")
+                rc = 1
+            _cleanup(tmp)
+        except Exception as e:
+            print(f"[check] {s['name']}: ERROR {e}  (log: {log})", file=sys.stderr)
+            rc = 1
+    return rc
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in ("check", "update", "verify", "list"):
+        print(__doc__)
+        sys.exit(2)
+    cmd, names = sys.argv[1], sys.argv[2:]
+    m = load_manifest()
+    rc = {"check": cmd_check, "update": cmd_update, "verify": cmd_verify, "list": cmd_list}[cmd](m, names)
+    sys.exit(rc or 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -68,6 +68,26 @@ def pixel_hash(bmp_path):
     return hashlib.sha256(d[off:]).hexdigest(), (w, h)
 
 
+def distinct_colors(bmp_path):
+    """Count distinct RGB pixel values + return (count, (w,h)). A content metric that is ROBUST to the
+    run-to-run pixel variance of a threaded boot (where exact hashing flakes) while still catching the
+    regression that matters: a dropped/rejected shader collapses the frame to the debug clear (1 color),
+    whereas a real rendered frame has hundreds+. Use `min_colors` in the manifest for such titles."""
+    with open(bmp_path, "rb") as f:
+        d = f.read()
+    if len(d) < 54 or d[:2] != b"BM":
+        raise ValueError(f"{bmp_path}: not a BMP ({len(d)} bytes)")
+    off = struct.unpack_from("<I", d, 10)[0]
+    w = struct.unpack_from("<i", d, 18)[0]
+    h = abs(struct.unpack_from("<i", d, 22)[0])
+    bpp = struct.unpack_from("<H", d, 28)[0]
+    step = bpp // 8
+    px = d[off:]
+    n = min(len(px) // step, w * h) if step else 0
+    colors = {px[i:i + 3] for i in range(0, n * step, step)}
+    return len(colors), (w, h)
+
+
 def resolve_dump(entry):
     dump = entry["dump"]
     return dump if os.path.isabs(dump) else os.path.join(GAME_ROOT, dump)
@@ -171,6 +191,65 @@ def capture(entry, run_log=None):
             logf.close()
 
 
+def capture_richest(entry, run_log=None):
+    """Run the whole boot and return the RICHEST frame it produced: (best_bmp_path, max_colors, dims, tmp).
+    For a threaded boot whose per-frame output isn't reproducible, neither an exact hash nor a single
+    settled frame is stable (the settled screen — a blank loading flicker vs real content — varies). The
+    MAX distinct-color count OVER THE WHOLE RUN is robust: a working render always produces some rich
+    frame; a rejected/dropped shader collapses every frame to the debug clear (~1 color). Powers the
+    `min_colors` guard (see distinct_colors)."""
+    bt = boot_trace_path()
+    if not os.path.exists(bt):
+        raise RuntimeError(f"boot_trace not found at {bt} (build it, or set PROSPER_BOOT_TRACE)")
+    dump = resolve_dump(entry)
+    if not os.path.exists(dump):
+        raise RuntimeError(f"game dump not found: {dump} (set PROSPER_GAME_ROOT)")
+    scale = int(entry.get("scale", 4))
+    timeout = int(entry.get("timeout", 240))
+    env = dict(os.environ)
+    env.update({
+        "PROSPER_GUEST_FS": "1", "PROSPER_GUEST_ARGS": "-force-gfx-direct",
+        "PROSPER_RENDER": "1", "PROSPER_RENDER_EVERY": "1", "PROSPER_RENDER_FIRST": "0",
+        "PROSPER_RENDER_SCALE": str(scale), "PROSPER_FAULT_ONSTACK": "1",
+    })
+    env.update(entry.get("env", {}))
+    tmp = tempfile.mkdtemp(prefix="snap_")
+    env["PROSPER_FRAME_DIR"] = tmp
+    bt_run = os.path.join(tmp, "bt_snap")
+    shutil.copyfile(bt, bt_run); os.chmod(bt_run, 0o755)
+    logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
+    try:
+        proc = subprocess.Popen([bt_run, dump], env=env, stdout=logf, stderr=subprocess.STDOUT,
+                                preexec_fn=os.setsid)
+        deadline = time.time() + timeout
+        while time.time() < deadline and proc.poll() is None:
+            time.sleep(1.0)
+    finally:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except Exception:
+            pass
+        if run_log:
+            logf.close()
+    frames = sorted(f for f in os.listdir(tmp) if f.startswith("frame_") and f.endswith(".bmp"))
+    if not frames:
+        raise RuntimeError(f"no frames rendered in {timeout}s")
+    best_p, best_n, best_dims = None, -1, (0, 0)
+    for f in frames:
+        p = os.path.join(tmp, f)
+        try:
+            if os.path.getsize(p) <= 0:
+                continue
+            n, dims = distinct_colors(p)
+        except (OSError, ValueError):
+            continue
+        if n > best_n:
+            best_p, best_n, best_dims = p, n, dims
+    dst = os.path.join(tmp, "captured.bmp")
+    shutil.copyfile(best_p, dst)
+    return dst, best_n, best_dims, tmp
+
+
 def _last_frame(tmp):
     fs = sorted(f for f in os.listdir(tmp) if f.startswith("frame_") and f.endswith(".bmp"))
     return fs[-1] if fs else "no frames"
@@ -210,6 +289,14 @@ def cmd_update(m, names):
     rc = 0
     for s in select(m, names):
         try:
+            if s.get("min_colors"):     # content-metric entry: nothing to bless; report the margin
+                b, nc, dims, t = capture_richest(s); _cleanup(t)
+                ok = nc >= int(s["min_colors"])
+                print(f"[update] {s['name']}: {dims[0]}x{dims[1]}, richest frame {nc} distinct colors "
+                      f"(threshold min_colors={s['min_colors']}, {'OK' if ok else 'BELOW'})")
+                if not ok:
+                    rc = 1
+                continue
             b1, t1 = capture(s); h1, dims = pixel_hash(b1); _cleanup(t1)
             if force:
                 s["hash"] = h1; s["dims"] = list(dims)
@@ -251,13 +338,29 @@ def cmd_check(m, names):
     os.makedirs(FAIL_DIR, exist_ok=True)
     rc = 0
     for s in select(m, names):
+        min_colors = s.get("min_colors")
         base = s.get("hash")
-        if not base:
+        if not min_colors and not base:
             print(f"[check] {s['name']}: NO BASELINE — run `snapshot.py update {s['name']}`", file=sys.stderr)
             rc = 1
             continue
         log = os.path.join(FAIL_DIR, f"{s['name']}.log")
         try:
+            if min_colors:                                  # content-metric mode (robust to pixel variance)
+                bmp, nc, dims, tmp = capture_richest(s, run_log=log)
+                if nc >= int(min_colors):
+                    print(f"[check] {s['name']}: OK ({dims[0]}x{dims[1]}, richest {nc} colors >= {min_colors})")
+                    os.remove(log) if os.path.exists(log) else None
+                else:
+                    out = os.path.join(FAIL_DIR, f"{s['name']}.bmp")
+                    shutil.copyfile(bmp, out)
+                    print(f"[check] {s['name']}: FAIL — richest frame only {nc} distinct colors < min "
+                          f"{min_colors} (render collapsed to the debug clear?)")
+                    print(f"         screenshot: {out}")
+                    print(f"         boot log:   {log}")
+                    rc = 1
+                _cleanup(tmp)
+                continue
             bmp, tmp = capture(s, run_log=log)
             h, dims = pixel_hash(bmp)
             if h == base:

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -1,17 +1,13 @@
 {
   "snapshots": [
     {
-      "name": "messenger-title",
+      "name": "messenger-scene",
       "dump": "PPSA24651-app0",
-      "frame": 40,
       "scale": 4,
-      "timeout": 240,
+      "timeout": 200,
       "env": {},
-      "hash": "5d086de6916e517db7c3ead7ce90e66bdfbc06c53ef78df245d1af5cfa10323a",
-      "dims": [
-        480,
-        270
-      ]
+      "min_colors": 5000,
+      "_note": "Content-metric guard (min_colors): The Messenger's boot render isn't pixel-deterministic across runs (exact hashing AND a single settled frame both flake — the stable screen varies run-to-run). So `check` runs the whole boot and takes the RICHEST frame's distinct-color count — robust to per-frame variance, but still catches the regression that matters: a rejected/dropped shader (the #199/#201/#239 class) collapses every frame to the debug clear (~1 color), while a real render peaks in the tens of thousands (observed ~34k-137k once the scene/cutscene renders). 5000 is a wide margin below that and far above any blue-clear."
     }
   ]
 }

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -1,0 +1,17 @@
+{
+  "snapshots": [
+    {
+      "name": "messenger-title",
+      "dump": "PPSA24651-app0",
+      "frame": 40,
+      "scale": 4,
+      "timeout": 240,
+      "env": {},
+      "hash": "5d086de6916e517db7c3ead7ce90e66bdfbc06c53ef78df245d1af5cfa10323a",
+      "dims": [
+        480,
+        270
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Env-gated diagnostic (off by default). On a fault at eboot+<fault-off>, zeros rax and resumes at eboot+<resume-off> so the guest survives one specific crash — used to see whether a crash gates later progress.

This is how PPSA02664's boot gate was found (#238): skipping the engine state-machine null-handler deref (`PROSPER_FAULT_SKIP=0x410b3:0x410bb`) takes the title from stuck-idle-at-globalgamemanagers to loading its scene, instantiating MonoBehaviours (SCSUserManager::Awake, SCSPreload::Update), and running 76k GPU submits crash-free. The real fix is tracked in #238; this is the lever to keep working past the crash.

Refs #238, #121.