### PR TITLE
fix(host): preload PSNCore.prx/PSNCommon.prx so the Unity PSN plugin init resolves

### DIFF
--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -26,11 +26,20 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         // (PSN_PrxInitialize / UnityPluginLoad / PrxSaveDataInitialize ...) resolve via sceKernelDlsym.
         { d + "/Media/Plugins/PSN.prx", BOOT_PSN },
         { d + "/Media/Plugins/SaveData.prx", BOOT_SAVEDATA },
+        // Some titles (e.g. PPSA02664) ship the Unity PSN plugin as PSNCore.prx (+ PSNCommon.prx
+        // dependency) rather than PSN.prx. Preload them so the C# P/Invoke ("PSNCore"::"PrxInitialize")
+        // resolves via sceKernelDlsym. Without this the il2cpp P/Invoke resolver tries to on-demand-load
+        // PSNCore.prx and HANGS, stalling the whole app-init -> scene-load chain (#238). PSNCommon later
+        // in the list => its init runs first (it's PSNCore's dependency). Absent-file titles skip these.
+        { d + "/Media/Plugins/PSNCore.prx", BOOT_PSNCORE },
+        { d + "/Media/Plugins/PSNCommon.prx", BOOT_PSNCOMMON },
         { d + "/sce_module/libc.prx", BOOT_LIBC },
     };
     if (getenv("PROSPER_NO_PSN"))
         for (size_t i = in.size(); i-- > 0; )
             if (in[i].path.find("PSN.prx") != std::string::npos ||
+                in[i].path.find("PSNCore.prx") != std::string::npos ||
+                in[i].path.find("PSNCommon.prx") != std::string::npos ||
                 in[i].path.find("SaveData.prx") != std::string::npos) in.erase(in.begin() + (ptrdiff_t)i);
     // Cross-title tolerance: drop dependent modules whose file doesn't exist in this dump (the eboot
     // at index 0 is always kept; each module keeps its fixed base).
@@ -85,7 +94,8 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     // started with (argc=0, argp=NULL). Register their guest ranges so run_guest_inits starts them
     // with the real descriptor. Skipped when PROSPER_NO_PSN drops them.
     if (!getenv("PROSPER_NO_PSN"))
-        set_module_start_param_ranges({ { BOOT_PSN, BOOT_SAVEDATA }, { BOOT_SAVEDATA, BOOT_LIBC } });
+        set_module_start_param_ranges({ { BOOT_PSN, BOOT_SAVEDATA }, { BOOT_SAVEDATA, BOOT_LIBC },
+                                        { BOOT_PSNCORE, 0x490000000ull }, { BOOT_PSNCOMMON, 0x4b0000000ull } });
 
     run_guest_inits(p.init_fns);
     return true;

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -16,6 +16,8 @@ namespace prosper {
 inline constexpr uint64_t BOOT_EBOOT    = 0x400000000ull;
 inline constexpr uint64_t BOOT_IL2CPP   = 0x440000000ull;
 inline constexpr uint64_t BOOT_PS5UTIL  = 0x4c0000000ull;
+inline constexpr uint64_t BOOT_PSNCORE  = 0x480000000ull;   // PPSA02664's Unity PSN native plugin
+inline constexpr uint64_t BOOT_PSNCOMMON= 0x4a0000000ull;   //   (PSNCore.prx + PSNCommon.prx)
 inline constexpr uint64_t BOOT_PSN      = 0x4e0000000ull;
 inline constexpr uint64_t BOOT_SAVEDATA = 0x4f0000000ull;
 inline constexpr uint64_t BOOT_LIBC     = 0x500000000ull;


### PR DESCRIPTION
Some titles (PPSA02664) ship the Unity PSN plugin as **PSNCore.prx** (+ PSNCommon.prx), not PSN.prx. They were never preloaded, so the C# P/Invoke resolving `PSNCore::PrxInitialize` tried to on-demand-load PSNCore.prx and **hung** inside the il2cpp resolver — stalling the whole boot (SCSAppManager.InitializePS5PSNLibrary never completed → SCSPreload waited forever on appInit → black screen).

Preloading them (with module-start param ranges, like PSN.prx) makes the exports resolve via sceKernelDlsym. **Verified** (past the 0x410b3 boot gate via PROSPER_FAULT_SKIP #250): PrxInitialize now resolves + succeeds, the app-init chain advances PSN→UDS→Trophies, and SCSPreload's `SetAppInit` fires. Remaining SCSPreload gates (save/user init) are separate.

Refs #238, #121.