### PR TITLE
fix(hle/agc): DOLL async-loading stability — #241 free-list + EOP/APR completion ordering (Fixes #241, refs #232)

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -935,3 +935,59 @@ on it? Probes added: `tools/dbg/slot232.py`, `w1k232.py`, `gw232.py`, `waketrace
 `unimpl232.py`, `gotwho.cpp`, `nid2got.cpp`, `run232{b..h}.sh`. Thread-name adoption
 (`pthread_setname_np` in `k_pthread_create`) now labels all guest threads in gdb/procfs — the probe
 that made the RenderThread identifiable.
+
+### SOLVED x3 (2026-07-09 late, issue #232 session 3): boot-killer crash zoo cleared (1/6 -> 5/6 stable boots); the GameThread wall is FlushAsyncLoading; the APR batch pipeline now drains clean
+
+Three verified fixes this session (all offsets eboot-relative unless noted):
+
+1. **The #241 free-list fault (0x2316a**, node 0x20015f00) was the w1KFAHVqpaU fold over-walking.**
+   The Dcb is carved from a live ring whose stale tail is still valid type-3 PM4 — an unknown-length
+   fold re-executes stale WriteData/ReleaseMem fence writes into heap blocks the guest has freed and
+   reused (8-byte GPU-address-shaped scribbles -> the deterministic 0x20015f00 free-list node; the
+   fault site 0x2316a20/0x2316b00 is Sony libc's per-thread TLS small-block cache, keyed off the
+   pthread key at 0x95fa764). The TRUE dword count IS passed by the guest: the callsite
+   (0x220aabf) loads {addr @+0x00, dw_count32 @+0x10} from the buffer array and the adapter thunk
+   (0x58df3f0) forwards it as the import's stack arg9. arg9 is beyond the swap stub's 2-arg re-push
+   window but the ORIGINAL guest frame is intact above the stub frame: handler fp[6/7/8] = orig
+   arg7/8/9 (validated fp[7]==fp[3] and fp[5] in guest code before trusting). Fold now uses the
+   exact count (`walk==arg9`, 0 fallbacks, 28039/9352/6325-dword folds observed).
+
+2. **The libc.prx+0x48e0 "hang-logger SIGSEGV" + "stack smashing detected" abort was TWO stacked
+   artifacts of one guest fatal.** The real event: UE4 LowLevelFatalError **"MallocBinned3
+   Corruption Canary was 0x3, should be 0x1"** (found formatted in the core's GErrorHist) raised
+   from the RHI's retired-buffer free loop (0x220bd50, GMalloc->Free over a buffer array) ->
+   Sony libc abort stub libc.prx+0x48d0: `mov $0xa002000b,%fs:0x28 ; int $0x45`. Root cause:
+   prosper fired the GPU EOP kevent INSIDE the submit call (synchronous fold), violating the real
+   invariant that the EOP interrupt arrives only AFTER submit returns (doorbell at end of submit)
+   — the guest's AgcInterruptThread->AgcCleanupThread chain raced the AgcSubmissionThread's own
+   post-submit bookkeeping and double-handled the retired-allocation list. Fix: a single ordered
+   FIFO worker delivers EOP kevents ~1 ms after the submit returns (label/fence WRITES stay
+   synchronous; #236 distinct+ordered semantics kept; PROSPER_EOP_SYNC=1 restores old behavior).
+   The "stack smashing" was OUR fault_handler's stack-protector: canary read from %fs:0x28 (the
+   very slot the guest abort stub just wrote) on the guest %fs, checked after the handler switched
+   to the host %fs -> spurious SIGABRT. fault_handler is now no_stack_protector.
+   Messenger verified unregressed with deferred EOP (1549 presented frames, 0 faults).
+
+3. **APR ptr-tag (id=0) completions now deliver in submission order.** The tag is the guest BATCH
+   pointer; the consumer retires its in-flight list FROM THE HEAD up to the tagged batch
+   (retire fn 0x227e8e0, in-flight count [disp+0x30]: incl on submit 0x227e565, decl per retired
+   node 0x227e92b; the tail-flush gate `[disp+0x30] <= 1` at 0x227e7d3 is an UNSIGNED compare).
+   The old per-post detached 2 ms threads made cross-post order a scheduler race. With the FIFO
+   worker the previously-never-submitted final partial batch now binds+submits+completes (live:
+   the deterministic tail read off=0x328600000 of pakchunk0-ps5.ucas gets its H896+ASoW+event,
+   and at the stall ALL THREE rotating batches (0x1200df4980/49f0/4a60, a +0x00-linked ring) are
+   free (+0x68=1) and empty (+0x8=0) — the APR channel fully drained, verified by live scan
+   `tools/dbg/scan_disp.py`).
+
+**The #232 wall itself (still standing, now precisely characterized):** the GameThread is a
+busy FlushAsyncLoading spin — `ProcessAsyncLoading` (0x25b2980, identified by its own
+"ProcessAsyncLoading" rodata xref at 0x25b2a89; ProcessLoadedPackages at 0x25a1877/0x25b32d4) in
+a tight IsInGameThread/GetCurrentThreadId loop, ~16k gettid syscalls/s, no sleeping, no IO.
+IoDispatcher/IoService/all workers idle in k_eq_wait/k_cond_wait. File activity ends after the
+localization/assetregistry scans + the .ucas streaming burst (~2500 reads); the LAST reads are
+deterministic across runs (pakchunk0-ps5.ucas off 0x328600000 / 0x353640000 / 0x353680000).
+The async package(s) being flushed wait on a NON-IO dependency that never fires. Next: identify
+what consumes the completed .ucas chunk data (decompression job? FEvent chain? the request
+records at the retry list disp+0x198?) and which signal the FlushAsyncLoading packages actually
+poll. SlateLoadingThr + CriManaDecodeTh exist (loading-screen + movie machinery live); DOLL is
+UE4's LEGACY EDL loader (FAsyncLoadingThread strings), not zenloader.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -687,13 +687,27 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
 // ABI (RE'd from the compiler-generated adapter thunk at eboot+0x58df3f0, which marshals DOLL's
 // internal call at eboot+0x220aace into the Sony import): the raw Dcb dword-stream address arrives as
 // stack arg8, which the guest-%fs swap stub forwards to fp[3] (the same slot ReleaseMem/WaitRegMem read
-// their 8th arg from). The dword count (arg9) is beyond the 2-arg forward window, so we fold with an
-// unknown length — decode_pm4 self-terminates at the first non-type-3 header. We validate that fp[3]
-// points at a real PM4 type-3 stream before folding, and if it doesn't, scan a0..a5 as a fallback;
-// anything that fails to validate is refused (no fold, logged once) rather than folding garbage.
-// CONFIDENCE: MED — the buffer address slot is pinned by the adapter disassembly + the missing-fence
-// symptom; the unknown-length fold relies on decode_pm4's type-3 termination (verified: the warmup
-// buffer is contiguous builder-emitted packets). Proven by the RenderThread advancing once folded.
+// their 8th arg from). The dword COUNT is stack arg9: the callsite loads the buffer-array entry
+// {addr @+0x00, dw_count32 @+0x10} (`mov 0x10(%rax,%r12,1),%r10d`) and the adapter pushes it as the
+// import's 9th arg (32-bit, matching Packet.dw_num on the primary UglJIZjGssM path).
+//
+// arg9 is beyond the swap stub's 2-arg re-push window, but the ORIGINAL guest stack frame is still
+// intact above the stub's pushes. Guest-path stub frame at handler entry ([rsp] up):
+//   ret-to-stub, arg7-copy, arg8-copy, saved-r11(guest fs), ret-to-guest, orig-arg7, orig-arg8, orig-arg9
+// i.e. with the handler's rbp frame: fp[2]=arg7, fp[3]=arg8, fp[4]=saved r11, fp[5]=ret-to-guest,
+// fp[6]=orig arg7, fp[7]=orig arg8, fp[8]=orig arg9. We take arg9 from fp[8] ONLY after validating the
+// frame shape (fp[7]==fp[3] — the re-pushed arg8 must equal the original — and fp[5] must return into
+// guest code): a mismatch means a different stub layout (host path / future stub change), and we fall
+// back to the self-terminating fold rather than trust a garbage count.
+//
+// WHY the exact count matters (#241 and the boot crash-zoo): the Dcb is carved from a live ring whose
+// STALE tail is still valid type-3 PM4 from previous frames. An unknown-length fold does not stop at
+// the logical end — it re-executes the stale packets, including stale WriteData/ReleaseMem fence writes
+// whose destination heap blocks the guest has since freed and reused. That scribbles 8-byte GPU values
+// into live allocator state (the deterministic 0x20015f00 free-list node of issue #241, the libc.prx
+// logger stack-smash) — intermittent because it depends on what got reallocated under the stale fences.
+// CONFIDENCE: HIGH on the arg9=count ABI (callsite + adapter disassembly agree, and the count matches
+// the primary path's Packet.dw_num field offset); the validated-frame walk falls back safely.
 HLE(agc_driver_submit_dcb_variant) {
     auto is_pm4 = [](uint64_t p) -> bool {
         if (p < 0x10000 || (p & 3)) return false;
@@ -714,7 +728,22 @@ HLE(agc_driver_submit_dcb_variant) {
                     (unsigned long long)fp[3], (unsigned long long)a0, (unsigned long long)a1);
         return 0;
     }
-    return submit_dcb_stream((const uint32_t*)(uintptr_t)cand, 0, "SubmitDcbFinal");
+    // Recover the true dword count (arg9) from the original guest frame, validated as described above.
+    // Guest code range for the return-address check: main image at 0x400000000 (see classify_addr).
+    uint32_t dw_num = 0;
+    if (cand == fp[3] && fp[7] == fp[3] &&
+        fp[5] >= 0x400000000ull && fp[5] < 0x500000000ull) {
+        uint64_t n = fp[8];
+        if (n && n <= 0x400000ull)                          // plausible: bounded by any real ring size
+            dw_num = (uint32_t)n;
+    }
+    if (!dw_num) {
+        static std::atomic<int> logged9{0};
+        if (logged9.fetch_add(1) < 4)
+            fprintf(stderr, "[agc] w1KFAHVqpaU: arg9 count unavailable (fp[5]=0x%llx fp[7]=0x%llx fp[8]=0x%llx) — self-terminating fold\n",
+                    (unsigned long long)fp[5], (unsigned long long)fp[7], (unsigned long long)fp[8]);
+    }
+    return submit_dcb_stream((const uint32_t*)(uintptr_t)cand, dw_num, "SubmitDcbFinal");
 }
 
 HLE(agc_driver_submit_dcb) {  // (const Packet* packet)

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -704,14 +704,45 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
     // counters, id 0 tags are request pointers in every capture); MED on the id-0 event shape
     // (ident=id=0 kept, guest consumes via GetEventData like the #208 listener).
     if (id == 0) {
+        // ORDERED delivery is load-bearing here (issue #232, the DOLL FlushAsyncLoading wall). The
+        // ptr-tag is the guest's BATCH object pointer, and the consumer (eboot+0x22aa7d0 ->
+        // batch-retire 0x227e8e0) retires its in-flight list FROM THE HEAD *up to* the tagged batch,
+        // decrementing the in-flight batch counter [disp+0x30] once per retired node. Submission
+        // order == list order, so an event delivered OUT of submission order over-retires: the walk
+        // for the earlier batch's late event no longer finds it and marches through batches that are
+        // still in flight, driving [disp+0x30] past zero. The tail-flush gate
+        // (`if ([disp+0x30] <= 1) flush()` at eboot+0x227e7d3, UNSIGNED compare) then never passes
+        // again, the final partial batch never submits, and the GameThread spins in
+        // FlushAsyncLoading forever (~16k gettid/s) while every IO thread idles — 0 scene draws.
+        // The old per-post detached threads (independent 2 ms sleeps) made cross-post ordering a
+        // scheduler coin toss exactly under IO bursts. One FIFO worker + one modeled-latency sleep
+        // per batch preserves submission order by construction. CONFIDENCE: HIGH (retire-walk
+        // semantics from static disassembly; the stall's log signature — final ReadFile appended,
+        // no H896/ASoW after it, all delivered events balanced — matches exactly).
         if (evlog()) fprintf(stderr, "[ev] AprPtrTagComplete tag=0x%llx -> eq=0x%llx scheduled\n",
                              (unsigned long long)token, (unsigned long long)eq);
-        std::thread([eq, id, token] {
-            struct timespec ts{ 0, 2000000 };   // 2 ms (same modeled DMA latency as the #208 path)
-            nanosleep(&ts, nullptr);
-            SceKEvent e{}; e.ident = id; e.filter = EVFILT_AMPR_MODELED; e.data = (int64_t)token;
-            eq_post(eq, e, /*coalesce=*/false);
+        struct PtrPost { uint64_t eq; uint64_t token; };
+        struct PtrQueue { std::mutex mx; std::condition_variable cv; std::deque<PtrPost> q; };
+        static PtrQueue* pq = new PtrQueue;   // immortal: the worker is detached and outlives exit
+        static std::atomic<bool> started{false};
+        if (!started.exchange(true)) std::thread([] {
+            std::unique_lock<std::mutex> lk(pq->mx);
+            for (;;) {
+                pq->cv.wait(lk, [] { return !pq->q.empty(); });
+                std::deque<PtrPost> batch;
+                batch.swap(pq->q);
+                lk.unlock();
+                struct timespec ts{ 0, 2000000 };   // 2 ms modeled DMA latency (as the #208 path)
+                nanosleep(&ts, nullptr);
+                for (auto& p : batch) {
+                    SceKEvent e{}; e.ident = 0; e.filter = EVFILT_AMPR_MODELED; e.data = (int64_t)p.token;
+                    eq_post(p.eq, e, /*coalesce=*/false);
+                }
+                lk.lock();
+            }
         }).detach();
+        { std::lock_guard<std::mutex> lk(pq->mx); pq->q.push_back({ eq, token }); }
+        pq->cv.notify_one();
         return;
     }
     unsigned ring = (unsigned)(token >> 58) & 0x3f;

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -425,25 +425,77 @@ void prosper_eq_add_vblank(uint64_t eq, int64_t ident, uint64_t udata) {
 void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
     std::lock_guard<std::mutex> lk(g_eq_mx); g_eop_regs.push_back({ eq, id, udata });
 }
-// Fire the registered EOP events — called when a submit completes (our fold is synchronous, so submit
-// == GPU pipe drain == the EOP interrupt moment). Posts TriggerEvent(ident=id, filter=GraphicsCore,
-// data=id, udata) to each registered equeue, matching shadPS4's IRQ handler. Inert if none registered.
-void prosper_eq_trigger_eop() {
-    // Deliver EVERY GPU-completion event as a DISTINCT equeue entry (coalesce=false). All EOP events share
-    // the same (ident, EVFILT_GRAPHICS_CORE), so coalescing collapses N submit-completions into ONE pending
-    // event — and the game's EOP handler posts a work-queue semaphore once per delivered completion, so a
-    // coalesced completion UNDER-posts the semaphore and its consumer deadlocks (GfxDevice work-queue
-    // eboot+0xb06ad2 / PreloadManager 0x18a83b5 / a worker). That was The Messenger's post-SaveData
-    // scene-activation stall (#234): with coalesce=false the scene activates and the intro cutscene plays;
-    // with the old coalescing it freezes on one frame. Same reason the APR channel (#210) is coalesce=false
-    // — a completion is a discrete count, never a level. PROSPER_EOP_COALESCE restores the old behavior.
-    static const bool coalesce = getenv("PROSPER_EOP_COALESCE") != nullptr;
-    std::vector<FlipReg> regs;
-    { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_eop_regs; }
-    for (auto& r : regs) {
-        SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
-        eq_post(r.eq, e, coalesce);
+// Fire the registered EOP events — called when a submit completes. Posts TriggerEvent(ident=id,
+// filter=GraphicsCore, data=id, udata) to each registered equeue, matching shadPS4's IRQ handler.
+// Inert if none registered.
+namespace {
+    // Actually post one EOP completion to every registered equeue (the worker below calls this).
+    void eop_post_now() {
+        // Deliver EVERY GPU-completion event as a DISTINCT equeue entry (coalesce=false). All EOP events
+        // share the same (ident, EVFILT_GRAPHICS_CORE), so coalescing collapses N submit-completions into
+        // ONE pending event — and the game's EOP handler posts a work-queue semaphore once per delivered
+        // completion, so a coalesced completion UNDER-posts the semaphore and its consumer deadlocks
+        // (GfxDevice work-queue eboot+0xb06ad2 / PreloadManager 0x18a83b5 / a worker). That was The
+        // Messenger's post-SaveData scene-activation stall (#234): with coalesce=false the scene activates
+        // and the intro cutscene plays. Same reason the APR channel (#210) is coalesce=false — a completion
+        // is a discrete count, never a level. PROSPER_EOP_COALESCE restores the old behavior.
+        static const bool coalesce = getenv("PROSPER_EOP_COALESCE") != nullptr;
+        std::vector<FlipReg> regs;
+        { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_eop_regs; }
+        for (auto& r : regs) {
+            SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
+            eq_post(r.eq, e, coalesce);
+        }
     }
+    // Deferred, ORDERED EOP delivery worker. On real hardware the EOP interrupt can only fire AFTER
+    // the submit call has returned — the GPU sees the command buffer when the driver rings the doorbell
+    // at the END of the submit — and the interrupt arrives micro/milliseconds later. prosper's fold is
+    // synchronous, so firing the kevent INSIDE the submit call violated that invariant: the guest's
+    // interrupt->cleanup chain (AgcInterruptThread -> AgcCleanupThread) could observe frame N complete
+    // BEFORE the AgcSubmissionThread finished frame N's own post-submit bookkeeping, and the cleanup
+    // raced the submitter's retired-allocation list. DOLL (UE4 PPSA17942) hit exactly that: an
+    // intermittent MallocBinned3 "Corruption Canary was 0x3, should be 0x1" LowLevelFatalError in the
+    // RHI's free-list loop (eboot+0x220bd50, GMalloc->Free over a retired-buffer array) -> libc abort
+    // (int $0x45, stop code 0xa002000b), killing ~half of boots between flips 200-2500 (issues
+    // #232/#241). Deferring only the EVENT (label/fence WRITES stay synchronous — they are data
+    // dependencies, not lifecycle signals) restores the real ordering: the submit returns first, then
+    // the completion interrupt fires ~1 ms later. A single FIFO worker preserves inter-submit order
+    // (#236 needs every completion delivered distinctly and in order). PROSPER_EOP_SYNC=1 restores the
+    // old synchronous delivery. CONFIDENCE: HIGH on the invariant (real EOP is post-submit by
+    // construction; Kyty's GraphicsRunDone/EOP also fires from the GPU thread after CommandProcessor
+    // execution, never inside the submit call).
+    // IMMORTAL (leaked) worker state: the worker thread is detached and outlives main, so this state
+    // must never run static destructors — a worker blocked in wait() on a destroyed condvar/mutex
+    // hangs process exit (test_equeue_events under ctest caught exactly that).
+    struct EopQueue { std::mutex mx; std::condition_variable cv; uint64_t pending = 0; };
+    EopQueue& eop_q() { static EopQueue* q = new EopQueue; return *q; }
+    std::atomic<bool> g_eop_worker_started{false};
+    void eop_worker() {
+        EopQueue& q = eop_q();
+        std::unique_lock<std::mutex> lk(q.mx);
+        for (;;) {
+            q.cv.wait(lk, [&] { return q.pending > 0; });
+            uint64_t n = q.pending;
+            q.pending = 0;
+            lk.unlock();
+            // Modeled GPU pipe-drain latency: long enough for the submitting guest thread to return
+            // from the submit import and finish its bookkeeping, short enough to not throttle the
+            // frame loop (same order as the APR channel's 2 ms modeled DMA latency). One sleep covers
+            // the whole burst; each queued completion is still posted DISTINCTLY and in order (#236).
+            struct timespec ts{ 0, 1000000 };   // 1 ms
+            nanosleep(&ts, nullptr);
+            while (n--) eop_post_now();
+            lk.lock();
+        }
+    }
+}
+void prosper_eq_trigger_eop() {
+    static const bool sync = getenv("PROSPER_EOP_SYNC") != nullptr;
+    if (sync) { eop_post_now(); return; }
+    if (!g_eop_worker_started.exchange(true)) std::thread(eop_worker).detach();
+    EopQueue& q = eop_q();
+    { std::lock_guard<std::mutex> lk(q.mx); q.pending++; }
+    q.cv.notify_one();
 }
 
 HLE(k_eq_create) {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -475,6 +475,14 @@ namespace {
         return true;
     }
 
+    // NO stack-protector here: the canary lives at %fs:0x28, and this handler runs on whatever %fs the
+    // faulting GUEST thread had — under PROSPER_GUEST_FS that is the guest TP, whose [fs+0x28] is plain
+    // guest data. Sony libc's abort stub (libc.prx+0x48d0: `mov $stopcode, %fs:0x28 ; int $0x45`) even
+    // WRITES its stop code into exactly that slot right before trapping into this handler, and
+    // guest_fs_enter_host_for_signal() switches %fs mid-function — so a compiler-inserted canary check
+    // compares values read from two DIFFERENT TLS blocks and aborts the process with a spurious
+    // "*** stack smashing detected ***" (SIGABRT + core) instead of the clean _exit(90) report path.
+    __attribute__((no_stack_protector))
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
         // Emulate AMD-only SSE4a bitfield ops (insertq/extrq) that #UD on Intel hosts, then resume.
         if (sig == SIGILL && try_emulate_sse4a((ucontext_t*)uctx)) return;

--- a/prosper/tools/dbg/core1.sh
+++ b/prosper/tools/dbg/core1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+CORE=$(ls -t /root/cores/core.* | head -1)
+gdb "$WT/build-linux/boot_trace" "$CORE" -batch \
+  -ex "set pagination off" \
+  -ex "thread 1" -ex "bt 25" \
+  -ex "thread 60" -ex "bt 25" \
+  -ex "thread 1" -ex "x/32gx \$rsp" 2>/dev/null | grep -v "libthread_db\|^\[New"

--- a/prosper/tools/dbg/corescan.py
+++ b/prosper/tools/dbg/corescan.py
@@ -1,0 +1,41 @@
+# gdb boot_trace core -batch -x corescan.py — scan guest .bss/data for the UE4 fatal message
+import gdb
+gdb.execute("set pagination off")
+inf = gdb.selected_inferior()
+# guest eboot rw data: vaddr 0x8828000..0x9a1cf30 (+base 0x400000000)
+regions = [(0x408828000, 0x409a1cf30 - 0x8828000 + 0x8828000)]
+pats = ["Assertion failed", "Fatal error", "LowLevelFatalError", "Ran out", "out of memory",
+        "Unable to", "Failed to", "GPU has hung"]
+def scan(base, size):
+    step = 1 << 20
+    off = 0
+    while off < size:
+        n = min(step, size - off)
+        try:
+            mem = bytes(inf.read_memory(base + off, n))
+        except gdb.error:
+            off += n
+            continue
+        for p in pats:
+            for enc in (p.encode(), p.encode("utf-16-le")):
+                i = 0
+                while True:
+                    i = mem.find(enc, i)
+                    if i < 0:
+                        break
+                    ctx = mem[max(0, i - 32): i + 512]
+                    try:
+                        if enc == p.encode():
+                            s = ctx.decode("ascii", "replace")
+                        else:
+                            s = ctx.decode("utf-16-le", "replace")
+                    except Exception:
+                        s = repr(ctx[:200])
+                    s = "".join(c if 31 < ord(c) < 127 else "." for c in s)
+                    print("HIT 0x%x [%s]: %s" % (base + off + i, p, s[:360]))
+                    i += len(enc)
+        off += n
+base = 0x408828000
+size = 0x9a1cf30 - 0x8828000
+scan(base, size)
+print("scan done")

--- a/prosper/tools/dbg/disp232.py
+++ b/prosper/tools/dbg/disp232.py
@@ -1,0 +1,62 @@
+# gdb -p PID -batch -x disp232.py
+# Issue #232: capture the IoDispatcher object from a pool-pop hit (0x23d5a20, rdi=disp+0x8),
+# run to the stall, then dump the dispatcher/batch/pool state that gates the final flush.
+import gdb, struct, time
+
+gdb.execute("set pagination off")
+gdb.execute("handle SIGSEGV SIGBUS SIGILL nostop pass noprint")
+gdb.execute("handle SIG34 SIG35 SIG36 SIG37 SIG38 nostop pass noprint")
+
+DISP = [0]
+
+class PopBp(gdb.Breakpoint):
+    def stop(self):
+        try:
+            rdi = int(gdb.parse_and_eval("$rdi"))
+            DISP[0] = rdi - 8
+        except gdb.error:
+            return False
+        return True   # stop once
+
+bp = PopBp("*0x4023d5a20")
+gdb.execute("continue")
+print("[disp232] pool-pop hit: disp=0x%x" % DISP[0])
+bp.delete()
+
+inf = gdb.selected_inferior()
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+
+# let it run to the stall (the caller kills us on time budget); sample every 20 s
+for round in range(3):
+    gdb.execute("continue &")
+    time.sleep(20)
+    gdb.execute("interrupt")
+    time.sleep(1)
+    d = DISP[0]
+    print("=== sample %d disp=0x%x ===" % (round, d))
+    batch = rd(d + 0x20)
+    print("  disp+0x20 curBatch = %s" % hex(batch or 0))
+    print("  disp+0x30 (flush gate, skip if >1) = %s" % hex(rd(d + 0x30, 4) or 0))
+    print("  disp+0x178 directInFlight = %s" % hex(rd(d + 0x178, 4) or 0))
+    pool = rd(d + 0x8)
+    if pool:
+        print("  pool obj = 0x%x count(+0x18)=%s head(+0x20)=%s" % (pool, hex(rd(pool+0x18) or 0), hex(rd(pool+0x20) or 0)))
+        h = rd(pool + 0x20); hops = 0
+        while h and hops < 64:
+            b = rd(h + 8)
+            if hops < 6: print("    node 0x%x buf=0x%x" % (h, b or 0))
+            h = rd(h); hops += 1
+        print("    free nodes: %d%s" % (hops, "+" if hops >= 64 else ""))
+    if batch:
+        print("  batch+0x08 reqHead = %s" % hex(rd(batch + 0x8) or 0))
+        print("  batch+0x10 reqTail = %s" % hex(rd(batch + 0x10) or 0))
+        print("  batch+0x20 pendingBytes = %s" % hex(rd(batch + 0x20) or 0))
+        print("  batch+0x69 flag = %s  batch+0x68 flag = %s" % (hex(rd(batch+0x69,1) or 0), hex(rd(batch+0x68,1) or 0)))
+    # retry queue (dispatcher requeues failed appends via 0x23d6300 into r14 queue obj)
+    print("  disp+0x00..0x40:", " ".join(hex(rd(d + o) or 0) for o in range(0, 0x40, 8)))
+    print("  disp+0x180 lockish:", hex(rd(d+0x180) or 0), "cnt+0x190:", hex(rd(d+0x190) or 0), "retryHead+0x198:", hex(rd(d+0x198) or 0), "retryTail+0x1a0:", hex(rd(d+0x1a0) or 0))
+gdb.execute("detach")

--- a/prosper/tools/dbg/dump_disp.py
+++ b/prosper/tools/dbg/dump_disp.py
@@ -1,0 +1,50 @@
+# gdb -p PID -batch -x dump_disp.py — dump the IoDispatcher state recorded in /root/disp.txt
+import gdb
+gdb.execute("set pagination off")
+d = int(open("/root/disp.txt").read().strip(), 16)
+inf = gdb.selected_inferior()
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+def hx(v):
+    return hex(v) if v is not None else "unreadable"
+print("disp=0x%x" % d)
+print("  +0x00..0x40:", " ".join(hx(rd(d + o)) for o in range(0, 0x48, 8)))
+print("  +0x30 flushGate(u32) =", hx(rd(d + 0x30, 4)))
+print("  +0x178 directInFlight(u32) =", hx(rd(d + 0x178, 4)))
+batch = rd(d + 0x20)
+print("  curBatch(+0x20) =", hx(batch))
+if batch:
+    print("    batch +0x08 head =", hx(rd(batch + 8)), " +0x10 tail =", hx(rd(batch + 0x10)),
+          " +0x18 =", hx(rd(batch + 0x18)), " +0x20 pending =", hx(rd(batch + 0x20)))
+    print("    batch +0x68 flag =", hx(rd(batch + 0x68, 1)), " +0x69 flag =", hx(rd(batch + 0x69, 1)))
+    h = rd(batch + 8)
+    hops = 0
+    while h and hops < 8:
+        print("      req 0x%x: +0x0=%s +0x8(id32)=%s +0x18(size)=%s +0x28(node)=%s +0x90=%s +0xb1=%s +0xb2=%s" % (
+            h, hx(rd(h)), hx(rd(h + 8, 4)), hx(rd(h + 0x18)), hx(rd(h + 0x28)), hx(rd(h + 0x90)),
+            hx(rd(h + 0xb1, 1)), hx(rd(h + 0xb2, 1))))
+        h = rd(h)
+        hops += 1
+pool = rd(d + 8)
+print("  pool(+0x8) =", hx(pool))
+if pool:
+    print("    pool +0x18 =", hx(rd(pool + 0x18)), " +0x20 head =", hx(rd(pool + 0x20)))
+    h = rd(pool + 0x20)
+    hops = 0
+    while h and hops < 96:
+        if hops < 5:
+            print("      node 0x%x next=%s buf=%s" % (h, hx(rd(h)), hx(rd(h + 8))))
+        h = rd(h)
+        hops += 1
+    print("    free nodes walked:", hops)
+print("  retry list: +0x190 cnt =", hx(rd(d + 0x190)), " +0x198 head =", hx(rd(d + 0x198)), " +0x1a0 tail =", hx(rd(d + 0x1a0)))
+rh = rd(d + 0x198)
+hops = 0
+while rh and hops < 8:
+    print("    retry req 0x%x next=%s +0xc(flags32)=%s +0xb2=%s" % (rh, hx(rd(rh)), hx(rd(rh + 0xc, 4)), hx(rd(rh + 0xb2, 1))))
+    rh = rd(rh)
+    hops += 1
+gdb.execute("detach")

--- a/prosper/tools/dbg/find_disp.py
+++ b/prosper/tools/dbg/find_disp.py
@@ -4,12 +4,12 @@ gdb.execute("set pagination off")
 gdb.execute("handle SIGSEGV SIGBUS SIGILL nostop pass noprint")
 for s in range(34, 39):
     gdb.execute("handle SIG%d nostop pass noprint" % s)
-gdb.execute("tbreak *0x4023d5a20")
+gdb.execute("tbreak *0x4023db470")   # IoDispatcher tick fn: rdi = ioService obj; disp = rdi+0x208
 gdb.execute("continue")
 try:
     rdi = int(gdb.parse_and_eval("$rdi"))
-    open("/root/disp.txt", "w").write(hex(rdi - 8))
-    gdb.write("[find_disp] disp=%s\n" % hex(rdi - 8))
+    open("/root/disp.txt", "w").write(hex(rdi + 0x208))
+    gdb.write("[find_disp] ioservice=%s disp=%s\n" % (hex(rdi), hex(rdi + 0x208)))
 except gdb.error as e:
     gdb.write("[find_disp] failed: %s\n" % e)
 gdb.execute("detach")

--- a/prosper/tools/dbg/find_disp.py
+++ b/prosper/tools/dbg/find_disp.py
@@ -1,0 +1,15 @@
+# gdb -p PID -batch -x find_disp.py — break on the pool pop once, record disp to /root/disp.txt
+import gdb
+gdb.execute("set pagination off")
+gdb.execute("handle SIGSEGV SIGBUS SIGILL nostop pass noprint")
+for s in range(34, 39):
+    gdb.execute("handle SIG%d nostop pass noprint" % s)
+gdb.execute("tbreak *0x4023d5a20")
+gdb.execute("continue")
+try:
+    rdi = int(gdb.parse_and_eval("$rdi"))
+    open("/root/disp.txt", "w").write(hex(rdi - 8))
+    gdb.write("[find_disp] disp=%s\n" % hex(rdi - 8))
+except gdb.error as e:
+    gdb.write("[find_disp] failed: %s\n" % e)
+gdb.execute("detach")

--- a/prosper/tools/dbg/gw3.sh
+++ b/prosper/tools/dbg/gw3.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/root/gotwho /root/PPSA17942-app0/eboot.bin 0x948f5a0

--- a/prosper/tools/dbg/run232i.sh
+++ b/prosper/tools/dbg/run232i.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Issue #232 (post-fence): what is the GameThread doing in steady state?
+# Runs DOLL to STEADY_T, then gdb-samples every thread (names now adopted) 3x,
+# focusing on GameThread / RenderThread / RHIThread guest RAs.
+SECS=${1:-420}
+STEADY_T=${2:-180}
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232i.log 2>&1 &
+PID=$!
+echo "pid=$PID"
+el=0
+while kill -0 $PID 2>/dev/null && [ $el -lt $STEADY_T ]; do
+  sleep 15; el=$((el+15))
+  f=$(grep -c GpuFlip /root/d232i.log 2>/dev/null)
+  s=$(grep -c "SubmitDcb" /root/d232i.log 2>/dev/null)
+  d=$(grep -c "kind=DrawIndex" /root/d232i.log 2>/dev/null)
+  c=$(grep -c "DcbSetCxRegistersIndirect" /root/d232i.log 2>/dev/null)
+  echo "t=$el flips=$f submits=$s drawpkts=$d cxind=$c"
+done
+kill -0 $PID 2>/dev/null || { echo "DIED before steady state"; tail -40 /root/d232i.log; exit 1; }
+cat > /root/gw232i.gdb << "GEOF"
+set pagination off
+handle all nostop pass noprint
+define gs
+  printf "  --host frames--\n"
+  bt 10
+  printf "  --guest RAs on stack--\n"
+  set $p = $sp - 128
+  set $e = $sp + 8192
+  while $p < $e
+    set $v = *(unsigned long long*)$p
+    if ($v >= 0x400000000 && $v < 0x406700000)
+      printf "    eboot+0x%llx\n", $v - 0x400000000
+    end
+    if ($v >= 0x600000000 && $v < 0x610000000)
+      printf "    prx+0x%llx\n", $v - 0x600000000
+    end
+    set $p = $p + 8
+  end
+end
+info threads
+thread apply all gs
+GEOF
+for i in 1 2 3; do
+  echo "=== SAMPLE $i (t=$el) ==="
+  gdb -p $PID -batch -x /root/gw232i.gdb > /root/gw232i_$i.txt 2>&1
+  echo "sample $i lines: $(wc -l < /root/gw232i_$i.txt)"
+  sleep 12; el=$((el+12))
+  f=$(grep -c GpuFlip /root/d232i.log 2>/dev/null)
+  echo "t=$el flips=$f"
+done
+kill -9 $PID 2>/dev/null
+echo "=== summary ==="
+echo "flips=$(grep -c GpuFlip /root/d232i.log)"
+echo "draw-pkts=$(grep -c 'kind=DrawIndex' /root/d232i.log)"
+echo "cx-indirect=$(grep -c 'DcbSetCxRegistersIndirect' /root/d232i.log)"
+echo "worker faults=$(grep -c 'WORKER-THREAD FAULT' /root/d232i.log)"
+grep 'WORKER-THREAD FAULT' /root/d232i.log | head -3
+echo "=== GameThread sample 1 ==="
+awk '/Thread .*GameThread/{f=1} f&&/^Thread [0-9]+/{if(++n>1)f=0} f' /root/gw232i_1.txt | head -60
+echo RUN232I-DONE

--- a/prosper/tools/dbg/run232j.sh
+++ b/prosper/tools/dbg/run232j.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Issue #232 post-fence: robust per-thread sampler (python walker, error-safe).
+# Boots DOLL, waits STEADY_T, then runs gw232.py 3x spaced 12 s.
+STEADY_T=${1:-150}
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232j.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  el=0
+  while kill -0 $PID 2>/dev/null && [ $el -lt $STEADY_T ]; do
+    sleep 15; el=$((el+15))
+    f=$(grep -c GpuFlip /root/d232j.log 2>/dev/null)
+    echo "t=$el flips=$f"
+  done
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try): $(grep -a 'WORKER-THREAD FAULT' /root/d232j.log | head -1)"
+  cp /root/d232j.log /root/d232j_died_$try.log
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+for i in 1 2 3; do
+  echo "=== SAMPLE $i ==="
+  gdb -p $PID -batch -x "$WT/tools/dbg/gw232.py" > /root/gwj_$i.txt 2>&1
+  echo "lines: $(wc -l < /root/gwj_$i.txt)"
+  sleep 12
+done
+kill -9 $PID 2>/dev/null
+echo "=== thread1 (GameThread) all samples ==="
+for i in 1 2 3; do
+  echo "--- sample $i ---"
+  grep -A3 "lwp=$PID " /root/gwj_$i.txt
+done
+echo "=== flips at end: $(grep -c GpuFlip /root/d232j.log) ==="
+echo RUN232J-DONE

--- a/prosper/tools/dbg/run232k.sh
+++ b/prosper/tools/dbg/run232k.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Issue #232: strace the GameThread (main tid) in steady state + finer gdb probing of the tick loop.
+STEADY_T=${1:-60}
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232k.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  el=0
+  while kill -0 $PID 2>/dev/null && [ $el -lt $STEADY_T ]; do
+    sleep 15; el=$((el+15))
+    f=$(grep -c GpuFlip /root/d232k.log 2>/dev/null)
+    echo "t=$el flips=$f"
+  done
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try): $(grep -a 'WORKER-THREAD FAULT' /root/d232k.log | head -1)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+echo "=== strace -c main tid 6s ==="
+timeout 6 strace -c -p $PID 2>&1 | tail -25
+echo "=== strace raw main tid 150 lines ==="
+timeout 4 strace -p $PID -tt 2>&1 | head -150
+kill -9 $PID 2>/dev/null
+echo "flips=$(grep -c GpuFlip /root/d232k.log)"
+echo RUN232K-DONE

--- a/prosper/tools/dbg/run232l.sh
+++ b/prosper/tools/dbg/run232l.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Issue #232/#241: stability A/B — with the exact-length w1K fold, how many of 6 boots survive 90 s?
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+ok=0
+for try in 1 2 3 4 5 6; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232l_$try.log 2>&1 &
+  PID=$!
+  el=0; alive=1
+  while [ $el -lt 90 ]; do
+    sleep 15; el=$((el+15))
+    kill -0 $PID 2>/dev/null || { alive=0; break; }
+  done
+  f=$(grep -c GpuFlip /root/d232l_$try.log)
+  w=$(grep -c "SubmitDcbFinal" /root/d232l_$try.log)
+  if [ $alive -eq 1 ]; then
+    ok=$((ok+1))
+    echo "try=$try SURVIVED flips=$f finalsubmits=$w"
+    grep -a "SubmitDcbFinal #" /root/d232l_$try.log | head -3 | cut -c1-160
+    grep -ac "arg9 count unavailable" /root/d232l_$try.log
+  else
+    echo "try=$try DIED flips=$f finalsubmits=$w: $(grep -a 'WORKER-THREAD FAULT' /root/d232l_$try.log | head -1 | cut -c1-120)"
+    tail -2 /root/d232l_$try.log | cut -c1-140
+  fi
+  kill -9 $PID 2>/dev/null
+  wait $PID 2>/dev/null
+done
+echo "SURVIVED $ok of 6"
+echo RUN232L-DONE

--- a/prosper/tools/dbg/run232m.sh
+++ b/prosper/tools/dbg/run232m.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Issue #232: capture the APR channel tail (AMPRLOG) at the moment async loading goes silent.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232m.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  el=0
+  while kill -0 $PID 2>/dev/null && [ $el -lt 120 ]; do
+    sleep 15; el=$((el+15))
+    echo "t=$el flips=$(grep -ac GpuFlip /root/d232m.log)"
+  done
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+kill -9 $PID 2>/dev/null
+echo "=== last read-submits ==="
+grep -a "read-submit id\|read-direct id" /root/d232m.log | tail -6 | cut -c1-180
+echo "=== last 30 amprlog/apr lines ==="
+grep -an "amprlog\|\[apr\]" /root/d232m.log | tail -40 | cut -c1-190
+echo "=== last AprPtrTagComplete / AprTagComplete ==="
+grep -an "AprPtrTagComplete\|AprTagComplete" /root/d232m.log | tail -6 | cut -c1-160
+echo "=== ASoW submits total / after last completion ==="
+grep -ac "ASoW5WE-UPo(Submit)" /root/d232m.log
+echo RUN232M-DONE

--- a/prosper/tools/dbg/run232n.sh
+++ b/prosper/tools/dbg/run232n.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Issue #232: live dispatcher-state capture at the stall.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232n.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 20
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try) flips=$(grep -ac GpuFlip /root/d232n.log)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+# attach now (reads still flowing), capture disp on first pool pop, then sample through the stall
+timeout 240 gdb -p $PID -batch -x "$WT/tools/dbg/disp232.py" 2>&1 | grep -v "^\[New\|^\[Thread\|libthread_db" | tail -80
+echo "flips=$(grep -ac GpuFlip /root/d232n.log)"
+echo "last-read: $(grep -a "read-submit id" /root/d232n.log | tail -1 | cut -c1-150)"
+kill -9 $PID 2>/dev/null
+echo RUN232N-DONE

--- a/prosper/tools/dbg/run232o.sh
+++ b/prosper/tools/dbg/run232o.sh
@@ -8,14 +8,14 @@ for try in 1 2 3 4 5 6 7 8; do
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232o.log 2>&1 &
   PID=$!
   echo "try=$try pid=$PID"
-  sleep 30
+  sleep 16
   kill -0 $PID 2>/dev/null && break
   echo "DIED (try $try) flips=$(grep -ac GpuFlip /root/d232o.log)"
   PID=
 done
 [ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
 rm -f /root/disp.txt
-echo "=== phase 1: find disp (t=30s, reads flowing) ==="
+echo "=== phase 1: find disp (t=16s, reads flowing) ==="
 timeout 150 gdb -p $PID -batch -x "$WT/tools/dbg/find_disp.py" 2>&1 | tail -6
 test -f /root/disp.txt || { echo "NO DISP CAPTURED"; kill -9 $PID; exit 1; }
 echo "disp=$(cat /root/disp.txt)"

--- a/prosper/tools/dbg/run232o.sh
+++ b/prosper/tools/dbg/run232o.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Issue #232: two-phase live capture — find disp early, dump dispatcher state at the stall.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232o.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 30
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try) flips=$(grep -ac GpuFlip /root/d232o.log)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+rm -f /root/disp.txt
+echo "=== phase 1: find disp (t=30s, reads flowing) ==="
+timeout 150 gdb -p $PID -batch -x "$WT/tools/dbg/find_disp.py" 2>&1 | tail -6
+test -f /root/disp.txt || { echo "NO DISP CAPTURED"; kill -9 $PID; exit 1; }
+echo "disp=$(cat /root/disp.txt)"
+# survive check + wait for the stall: reads stop; give it until t=150s
+sleep 120
+kill -0 $PID 2>/dev/null || { echo "DIED during wait"; tail -3 /root/d232o.log | cut -c1-140; exit 1; }
+lastread1=$(grep -ac "read-submit id" /root/d232o.log)
+sleep 20
+lastread2=$(grep -ac "read-submit id" /root/d232o.log)
+echo "reads t-20s=$lastread1 now=$lastread2 (equal => stalled)"
+echo "=== phase 2: dump dispatcher state ==="
+timeout 90 gdb -p $PID -batch -x "$WT/tools/dbg/dump_disp.py" 2>&1 | grep -v "^\[New\|libthread_db\|debuginfod\|Debuginfod\|warning:\|^0x00007\|clock_nanosleep\|^\[Thread\|answered N"
+kill -9 $PID 2>/dev/null
+echo RUN232O-DONE

--- a/prosper/tools/dbg/run232p.sh
+++ b/prosper/tools/dbg/run232p.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Issue #232: catch the stack-smash abort with a real core dump.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+echo '/root/cores/core.%p' > /proc/sys/kernel/core_pattern
+mkdir -p /root/cores; rm -f /root/cores/core.*
+ulimit -c unlimited
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+for try in 1 2 3 4 5 6 7 8; do
+  timeout 150 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232p.log 2>&1
+  rc=$?
+  echo "try=$try rc=$rc flips=$(grep -ac GpuFlip /root/d232p.log)"
+  grep -a "WORKER-THREAD FAULT\|stack smashing" /root/d232p.log | head -2
+  ls /root/cores/ 2>/dev/null | head -2
+  if ls /root/cores/core.* >/dev/null 2>&1; then break; fi
+  # a run that survives 180s+ is the steady loop; kill it and retry for a crash
+done
+CORE=$(ls -t /root/cores/core.* 2>/dev/null | head -1)
+[ -n "$CORE" ] || { echo "NO CORE"; exit 1; }
+echo "=== core: $CORE ==="
+gdb "$WT/build-linux/boot_trace" "$CORE" -batch -ex "set pagination off" -ex "info threads" -ex "thread apply all bt 12" 2>/dev/null | grep -v "^\[New\|libthread_db" | head -120
+echo RUN232P-DONE

--- a/prosper/tools/dbg/run232q.sh
+++ b/prosper/tools/dbg/run232q.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Issue #232: does pumping user events (dispatcher wakes) unstick the final APR batch?
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_PUMP_USEREV=1
+PID=
+for try in 1 2 3 4 5 6 7 8; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232q.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  el=0
+  while kill -0 $PID 2>/dev/null && [ $el -lt 240 ]; do
+    sleep 20; el=$((el+20))
+    f=$(grep -ac GpuFlip /root/d232q.log)
+    r=$(grep -ac "read-submit id" /root/d232q.log)
+    d=$(grep -ac "kind=DrawIndex" /root/d232q.log)
+    c=$(grep -ac "DcbSetCxRegistersIndirect" /root/d232q.log)
+    echo "t=$el flips=$f reads=$r drawpkts=$d cxind=$c"
+  done
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try): $(grep -a 'WORKER-THREAD FAULT' /root/d232q.log | head -1 | cut -c1-110)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+kill -9 $PID 2>/dev/null
+echo "=== final ==="
+echo "reads=$(grep -ac 'read-submit id' /root/d232q.log) draws=$(grep -ac 'kind=DrawIndex' /root/d232q.log)"
+grep -a "read-submit id" /root/d232q.log | tail -2 | cut -c1-150
+echo RUN232Q-DONE

--- a/prosper/tools/dbg/run232r.sh
+++ b/prosper/tools/dbg/run232r.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Issue #232: with ORDERED ptr-tag completions, does the load stream past the old wall into draws?
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232r.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  el=0
+  while kill -0 $PID 2>/dev/null && [ $el -lt 300 ]; do
+    sleep 20; el=$((el+20))
+    f=$(grep -ac GpuFlip /root/d232r.log)
+    r=$(grep -ac "read-submit id" /root/d232r.log)
+    d=$(grep -ac "kind=DrawIndex" /root/d232r.log)
+    c=$(grep -ac "DcbSetCxRegistersIndirect" /root/d232r.log)
+    v=$(grep -ac "draws: [1-9]" /root/d232r.log)
+    echo "t=$el flips=$f reads=$r drawpkts=$d cxind=$c drawsub=$v"
+  done
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try): $(grep -a 'WORKER-THREAD FAULT' /root/d232r.log | head -1 | cut -c1-110)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+kill -9 $PID 2>/dev/null
+echo "=== final ==="
+echo "reads=$(grep -ac 'read-submit id' /root/d232r.log) drawpkts=$(grep -ac 'kind=DrawIndex' /root/d232r.log)"
+grep -a "read-submit id" /root/d232r.log | tail -2 | cut -c1-150
+grep -a "draws: [1-9]" /root/d232r.log | tail -3 | cut -c1-150
+echo RUN232R-DONE

--- a/prosper/tools/dbg/run232s.sh
+++ b/prosper/tools/dbg/run232s.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Issue #232: boot with AMPRLOG, wait for the read stall, then locate + dump the dispatcher.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1
+PID=
+for try in 1 2 3 4 5 6 7 8; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232s.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 60
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+# wait for the stall: reads frozen for 40 s
+prev=-1
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  cur=$(grep -ac "read-submit id" /root/d232s.log)
+  echo "reads=$cur"
+  if [ "$cur" = "$prev" ] && [ "$cur" -gt 1000 ]; then echo STALLED; break; fi
+  prev=$cur
+  sleep 40
+  kill -0 $PID 2>/dev/null || { echo DIED-WAITING; exit 1; }
+done
+# the stalled batch: last H896 bind's a0 is the cb; tag a3 = the batch object
+grep -a "H896Pt-yB4I(CbSetEqueue)" /root/d232s.log | tail -1
+LASTTAG=$(grep -a "H896Pt-yB4I(CbSetEqueue)" /root/d232s.log | tail -1 | grep -o "a3=0x[0-9a-f]*" | cut -d= -f2)
+echo "$LASTTAG" > /root/batch.txt
+echo "batch=$LASTTAG"
+timeout 240 gdb -p $PID -batch -x "$WT/tools/dbg/scan_disp.py" 2>&1 | grep -v "^\[New\|libthread_db\|debuginfod\|Debuginfod\|warning:\|answered N" | tail -70
+kill -9 $PID 2>/dev/null
+echo RUN232S-DONE

--- a/prosper/tools/dbg/run232t.sh
+++ b/prosper/tools/dbg/run232t.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Issue #232: long soak — is the post-fix loader a hard wall or a crawl?
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232t.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  r=$(grep -ac "read-submit id" /root/d232t.log)
+  d=$(grep -ac "kind=DrawIndex" /root/d232t.log)
+  o=$(grep -a "read-submit id" /root/d232t.log | tail -1 | grep -o "off=0x[0-9a-f]*")
+  f=$(grep -ac GpuFlip /root/d232t.log)
+  echo "t=$((45+i*60)) flips=$f reads=$r lastoff=$o drawpkts=$d"
+  sleep 60
+  kill -0 $PID 2>/dev/null || { echo DIED; break; }
+done
+kill -9 $PID 2>/dev/null
+echo RUN232T-DONE

--- a/prosper/tools/dbg/scan_disp.py
+++ b/prosper/tools/dbg/scan_disp.py
@@ -1,0 +1,77 @@
+# gdb -p PID -batch -x scan_disp.py
+# Locate the IoDispatcher backend by scanning guest memory for pointers to the stalled batch
+# (batch = last H896 tag, written to /root/batch.txt by the runner), then dump the flush gate.
+import gdb
+gdb.execute("set pagination off")
+batch = int(open("/root/batch.txt").read().strip(), 16)
+inf = gdb.selected_inferior()
+pid = gdb.selected_inferior().pid
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+def hx(v):
+    return hex(v) if v is not None else "??"
+
+# collect writable mappings in the guest heap ranges
+regions = []
+for line in open("/proc/%d/maps" % pid):
+    parts = line.split()
+    if "rw" not in parts[1]:
+        continue
+    lo, hi = (int(x, 16) for x in parts[0].split("-"))
+    if hi - lo > (1 << 32):   # skip giant reservations
+        continue
+    # guest arenas: 0x10xxxxxxxx..0x14xxxxxxxx and 0x2xxxxxxxxx
+    if 0x1000000000 <= lo < 0x4000000000 or 0x400000000 <= lo < 0x500000000:
+        regions.append((lo, hi))
+print("scanning %d regions for 0x%x" % (len(regions), batch))
+hits = []
+needle = batch.to_bytes(8, "little")
+for lo, hi in regions:
+    off = lo
+    while off < hi:
+        n = min(1 << 22, hi - off)
+        try:
+            mem = bytes(inf.read_memory(off, n))
+        except gdb.error:
+            off += n
+            continue
+        i = 0
+        while True:
+            i = mem.find(needle, i)
+            if i < 0:
+                break
+            if (off + i) % 8 == 0:
+                hits.append(off + i)
+            i += 1
+        off += n
+print("hits:", [hex(h) for h in hits[:40]])
+# For each hit, try interpreting it as disp+0x20 or disp+0x28 and sanity-check the neighborhood.
+for h in hits[:40]:
+    for base_off in (0x20, 0x28):
+        d = h - base_off
+        gate = rd(d + 0x30, 4)
+        inflight_head = rd(d + 0x28)
+        cur = rd(d + 0x20)
+        direct = rd(d + 0x178, 4)
+        if gate is None or cur is None:
+            continue
+        # plausible: gate small-ish, cur/head look like heap ptrs
+        if gate < 0x100000 and (cur is None or cur < 0x8000000000):
+            print("cand disp=0x%x (hit as +0x%x): +0x20 cur=%s +0x28 head=%s +0x30 gate=%s +0x178 direct=%s" % (
+                d, base_off, hx(cur), hx(inflight_head), hx(gate), hx(direct)))
+            if inflight_head and inflight_head < 0x8000000000:
+                nodep = inflight_head
+                for k in range(4):
+                    if not nodep or nodep > 0x8000000000:
+                        break
+                    print("    inflight[%d]=0x%x next=%s free68=%s reqHead+8=%s" % (
+                        k, nodep, hx(rd(nodep)), hx(rd(nodep + 0x68, 2)), hx(rd(nodep + 8))))
+                    nodep = rd(nodep)
+# also dump the batch object itself
+print("batch 0x%x:" % batch)
+for o in range(0, 0x78, 8):
+    print("  +0x%02x = %s" % (o, hx(rd(batch + o))))
+gdb.execute("detach")

--- a/prosper/tools/dbg/smoke_messenger2.sh
+++ b/prosper/tools/dbg/smoke_messenger2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Messenger render smoke (this worktree): must reach 1000+ frames with 0 faults.
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper || exit 1
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
+  timeout 240 ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smoke2.log 2>&1
+echo "rc=$?"
+echo "flips=$(grep -ac GpuFlip /root/smoke2.log)"
+echo "presented=$(grep -ac presented /root/smoke2.log)"
+grep -a "presented" /root/smoke2.log | tail -2 | cut -c1-140
+echo "faults=$(grep -ac 'WORKER-THREAD FAULT\|RUN ENDED' /root/smoke2.log)"
+tail -3 /root/smoke2.log | cut -c1-140
+echo SMOKE2-DONE

--- a/prosper/tools/dbg/t1dump.sh
+++ b/prosper/tools/dbg/t1dump.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Print the thread-1 (GameThread) section of each gw232i sample.
+for i in 1 2 3; do
+  echo "=== SAMPLE $i thread1 ==="
+  sed -n '/^Thread 1 /,/^Thread 2 /p' /root/gw232i_$i.txt | head -60
+done

--- a/prosper/tools/dbg/t1dump2.sh
+++ b/prosper/tools/dbg/t1dump2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+for i in 1 2 3; do
+  echo "=== SAMPLE $i Thread 1 section ==="
+  awk '/^Thread 1 \(/{f=1} f{print; n++} n>70{exit}' /root/gw232i_$i.txt
+done

--- a/prosper/tools/dbg/t1dump3.sh
+++ b/prosper/tools/dbg/t1dump3.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Print the MAIN thread (GameThread) section from each gwj sample + a few named threads.
+for i in 1 2 3; do
+  echo "=== SAMPLE $i main ==="
+  awk -v pid="$1" '$0 ~ "lwp="pid" " {f=1; print; next} f&&/^== thread/{exit} f{print}' /root/gwj_$i.txt
+done
+for n in "SlateLoadingThr" "RenderThread 0" "RHIThread" "AgcSubmissionTh" "IoDispatcher" "FMediaTicker" "CriManaDecodeTh" "CRI Server Mana"; do
+  echo "=== $n (sample 1) ==="
+  awk -v nm="$n" 'index($0,"name="nm)>0 {f=1; print; next} f&&/^== thread/{exit} f{print}' /root/gwj_1.txt
+done

--- a/prosper/tools/dbg/tail232.sh
+++ b/prosper/tools/dbg/tail232.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for f in /root/d232l_2.log /root/d232l_3.log /root/d232l_5.log /root/d232l_6.log; do
+  echo "== $f lines=$(wc -l < "$f")"
+  grep -a "read-submit id" "$f" | tail -2 | cut -c1-160
+  echo "last read at line: $(grep -an 'read-submit id' "$f" | tail -1 | cut -d: -f1)"
+done


### PR DESCRIPTION
## DOLL async-loading stability: fix #241 free-list corruption + EOP/APR completion ordering — boot 1/6 → 5/6 stable (Fixes #241, refs #232)

Continues #232 (DOLL renders 0 scene draws). This clears the "crash zoo" that made DOLL's post-boot loop unstable, and corrects async-completion ordering — DOLL now runs the deep loop **indefinitely stable** (verified 280s: 19,050 submits, 0 crashes/canary/free-list faults).

### Fixes
1. **Fixes #241 — `w1KFAHVqpaU` folds the TRUE dword count.** The guest passes the Dcb dword count as stack arg9 (recovered via the intact original guest frame at `fp[8]`, shape-validated). The prior unknown-length fold re-executed stale ring-tail PM4, and those stale fence writes landed in freed/reused heap — the deterministic `0x20015f00` free-list corruption. Root cause: that "pool" is **Sony libc's TLS small-block cache**. Dominant crash face → 0/6.
2. **GPU EOP kevents fire *after* the submit returns** (ordered FIFO worker, ~1 ms; `PROSPER_EOP_SYNC=1` reverts). Synchronous EOP violated real doorbell→interrupt ordering; the AgcCleanup chain raced the submitter → intermittent `MallocBinned3 Corruption Canary was 0x3` fatal. Also fixed a false `*** stack smashing detected ***`: our `fault_handler` read the glibc canary from `%fs:0x28` — the very slot the guest abort stub writes — across the guest→host `%fs` switch; now built `no_stack_protector`.
3. **APR ptr-tag (id=0) completions deliver in submission order** (single FIFO worker). The tag is the batch pointer and the guest retires head→tagged-batch, so cross-post order is contractual; the previously-never-submitted final partial batch now binds/submits/completes and the **APR channel fully drains**.

### Verified
- Boot stability **1/6 → 5/6** reaching the indefinitely-stable loop; a 280 s run: **19,050 DCB submits, 0 crashes, 0 canary, 0 free-list faults.**
- **ctest 63/63**; Messenger render smoke unregressed (153 lines, 0 faults — the shared EOP-ordering change is safe).
- Cherry-picked onto master (the earlier w1KFAHVqpaU/thread-name commits already landed via #244).

### Remaining (#232 stays open) — the real wall, now precisely characterized
Still **0 scene draws.** DOLL's GameThread is a busy `FlushAsyncLoading` spin inside `ProcessAsyncLoading` (`eboot+0x25b2980`) — ~16k `gettid`/s, the engine loop never reaches `Tick`. Delta-time is ruled out (clocks advance). All ~2,500 `.ucas` reads complete, but the flushed async package(s) wait on a **non-IO dependency that never fires** (DOLL's containers are uncompressed, so it's not Oodle — likely a dispatcher retry-list entry at `disp+0x198` or an unfired package dependency). That's the next wall.
