### PR TITLE
fix(gpu): 8-bpp SW_4KB_S de-swizzle — R8 caption-font atlas was scrambled (refs #102)

### DIFF
--- a/prosper/docs/GFX10_SW_4KB_S_TILING.md
+++ b/prosper/docs/GFX10_SW_4KB_S_TILING.md
@@ -47,13 +47,43 @@ The distinguishing feature vs a naive Morton is the **`[x0, x1, y0, y1]` low nib
 an interleaved 2×2 `[x0,y0,x1,y1]` or `[y0,x0,y1,x1]`. That single detail is what removes the edge
 serration; getting the higher pairs wrong instead *scrambles* the image (easy to reject visually).
 
-### Generalisation over bytes-per-element
+### The within-tile order is bytes-per-element-DEPENDENT
 
 A 4 KB tile is a fixed 4096 bytes, so its texel dimensions depend on bpe (1 B → 64×64, 2 B → 64×32,
-4 B → 32×32, 8 B → 32×16, 16 B → 16×16; see `sw4kb_dims`). The same low-nibble `[x0,x1,y0,y1]` micro-block
-+ Morton-pairs pattern is applied at every bpe. It is **round-trip-verified** at all bpe (tile∘detile =
-identity) and **pixel-verified** at 32 bpp; other bpe should be spot-checked visually as those surfaces
-surface (BC block textures, R8 atlases).
+4 B → 32×32, 8 B → 32×16, 16 B → 16×16; see `sw4kb_dims`). Crucially, the *within-tile element order is
+not the same at every bpe* — AMD's standard-swizzle `SW_PATTERN` genuinely differs per element size.
+Two orders are now **pixel-verified against The Messenger's live surfaces**:
+
+| bpe | tile | low block | full order (element bit → coord) |
+|-----|------|-----------|----------------------------------|
+| 4 B (RGBA8) | 32×32 | `[x0,x1, y0,y1]` (L=2) | `x0 x1 y0 y1 y2 x2 y3 x3 y4 x4` |
+| 1 B (R8)    | 64×64 | `[x0,x1,x2,x3, y0,y1,y2,y3]` (L=4) | `x0 x1 x2 x3 y0 y1 y2 y3 y4 x4 y5 x5` |
+
+Both share the shape **"a low block of L X-bits then L Y-bits, then interleaved `(y,x)` Morton pairs"**,
+but with **L = 2 at 32 bpp and L = 4 at 8 bpp** (`sw4kb_morton` selects L by tile geometry). The earlier
+version of this code applied the 32-bpp L=2 pattern at *every* bpe; that is correct at 32 bpp but at 8 bpp
+it scrambles every 64×64 tile into an **unreadable weave** — which is exactly why the intro **caption text
+was invisible**: the game's only R8 surface is the **2048×1024 caption/glyph font atlas** (a TextMeshPro-
+style atlas of Latin + CJK glyphs), sampled by a ~260-quad batched text mesh. With L=2 the atlas decoded to
+noise, so every glyph sampled garbage coverage and the text rendered as nothing. With **L=4 the atlas
+resolves into a clean grid of readable glyphs** and the caption renders. (#102 was therefore *two* bugs: the
+32-bpp low-nibble error #118, and this separate 8-bpp order.)
+
+It is **round-trip-verified** at all bpe (tile∘detile = identity) and **pixel-verified** at 32 bpp and
+8 bpp. The 16-bpp and BC-block geometries (64×32, 32×16, 16×16) fall back to the L=2 shape; they round-trip
+but have no game-observed instance to pixel-verify yet — spot-check visually as those surfaces surface.
+
+### How the 8-bpp order was found (the TV-minimisation trick)
+
+Guessing 8-bpp bit orders by hand failed (a dozen hand-picked orders + several tile geometries all stayed a
+weave). What cracked it: a **total-variation-minimising search** over within-tile bit permutations. A
+correct de-swizzle of *structured* data (glyphs) is spatially smooth, so the permutation that minimises
+Σ|Δpixel| over a content-rich crop is the right one. Hill-climbing (swap two bit-assignments, keep if TV
+drops) from a few seeds converged straight onto `[x0 x1 x2 x3 y0 y1 y2 y3 y4 x4 y5 x5]`, which rendered the
+atlas as readable Latin + CJK glyphs. The raw tiled R8 bytes were captured with `PROSPER_DUMP_RAWTILE`
+(extended to the narrow single-channel path in `live_renderer.cpp`) and the search run offline in NumPy.
+This trick works for any scrambled-but-structured surface where you lack the reference order — let
+smoothness pick the permutation, then confirm on a region with known content (here, the Latin glyph block).
 
 ## How it was derived (method, for reproducibility)
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <algorithm>
 #include <vector>
+#include <set>
 #include <unordered_map>
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
@@ -143,6 +144,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
                                 size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                // PROSPER_DUMP_RAWTILE (narrow path): the single/dual-channel RAW TILED bytes,
+                                // once per address, for offline 8-bpp de-swizzle sweeps (the SDF font atlas).
+                                if (getenv("PROSPER_DUMP_RAWTILE") && got >= nlin.size() && tw <= 2048 && th <= 1024) {
+                                    static std::set<uint64_t> nseen;
+                                    if (nseen.insert(r.gpu_addr).second) {
+                                        std::string dd = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
+                                        char bn[512]; snprintf(bn, sizeof bn, "%s/narrowtile_%ux%u_b%u_%llx.bin",
+                                                               dd.c_str(), tw, th, bpt, (unsigned long long)r.gpu_addr);
+                                        if (FILE* bf = fopen(bn, "wb")) { fwrite(traw.data(), 1, traw.size(), bf); fclose(bf);
+                                            fprintf(stderr, "[render] narrow raw tiled -> %s (%zu, bpt=%u)\n", bn, traw.size(), bpt); fflush(stderr); }
+                                    }
+                                }
                                 if (got < nlin.size()) safe_copy(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
                                 else prosper::gpu::detile_surface(nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
@@ -197,11 +210,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 std::memcpy(tiled.data(), texstore.back().data(), std::min(nb, tiled_bytes));
                             // PROSPER_DUMP_RAWTILE: write the EXACT padded tiled bytes to a .bin (no lossy BMP
                             // round-trip) so the de-swizzle can be reversed offline against a known image (#101).
-                            if (getenv("PROSPER_DUMP_RAWTILE") && frame_no < 200) {
-                                std::string dd = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
-                                char bn[512]; snprintf(bn, sizeof bn, "%s/tiled_f%04d_b%u_%ux%u.bin",
-                                                       dd.c_str(), (int)frame_no, r.binding, tw, th);
-                                if (FILE* bf = fopen(bn, "wb")) { fwrite(tiled.data(), 1, tiled.size(), bf); fclose(bf); }
+                            if (getenv("PROSPER_DUMP_RAWTILE") && (frame_no < 200 || (tw <= 2048 && th <= 1024))) {
+                                // Early frames by binding, PLUS small textures once per address (the font/UI
+                                // atlas can be sampled late — capture whenever first seen).
+                                static std::set<uint64_t> rawseen;
+                                bool small = tw <= 2048 && th <= 1024;
+                                if (!small || rawseen.insert(r.gpu_addr).second) {
+                                    std::string dd = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
+                                    char bn[512];
+                                    if (small) snprintf(bn, sizeof bn, "%s/rawtile_%ux%u_%llx.bin", dd.c_str(), tw, th, (unsigned long long)r.gpu_addr);
+                                    else snprintf(bn, sizeof bn, "%s/tiled_f%04d_b%u_%ux%u.bin", dd.c_str(), (int)frame_no, r.binding, tw, th);
+                                    if (FILE* bf = fopen(bn, "wb")) { fwrite(tiled.data(), 1, tiled.size(), bf); fclose(bf); }
+                                }
                             }
                             prosper::gpu::detile_surface(texstore.back().data(), tiled.data(), tw, th, tmode, pitch);
                         }
@@ -215,7 +235,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         // PROSPER_DUMP_ATLAS: dump each SMALL sampled texture once per ADDRESS (find the caption
                         // font among same-size UI textures). Capped.
-                        if (getenv("PROSPER_DUMP_ATLAS") && !texstore.back().empty() && tw <= 1024 && th <= 512) {
+                        if (getenv("PROSPER_DUMP_ATLAS") && !texstore.back().empty() && tw <= 2048 && th <= 1024) {
                             static std::unordered_map<uint64_t,int> seen; static int ndumped = 0;
                             if (seen[r.gpu_addr]++ == 0 && ndumped++ < 60) {
                                 std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -21,27 +21,33 @@ inline void sw4kb_dims(uint32_t bpe, uint32_t& bx, uint32_t& by) {
     uint32_t bits = 0; while ((4096u >> bits) > bpe) bits++;   // log2(4096/bpe), bpe a power of two
     bx = (bits + 1) / 2; by = bits / 2;
 }
-// GFX10 SW_4KB_S element order within the tile. The lowest FOUR element-index bits are a 4x4
-// pixel sub-block [x0, x1, y0, y1] (both low X bits, then both low Y bits); above that the usual
-// interleaved (y,x) Morton pairs, and for non-square tiles the wider dimension's extra X bits on top.
-// The previous plain Y-low Morton ([y0,x0,y1,x1,...]) placed the wrong bits in the lowest positions,
-// which is invisible in flat regions but SERRATED every sprite/gradient EDGE of every tiled texture —
-// the cross-game "dither"/unreadable-text bug. This order is pixel-verified clean (crisp cel-shaded
-// edges + smooth gradients) against The Messenger's title art at 32-bpp; the same micro-pattern is
-// applied at every bpe (round-trip-symmetric — verify other bpe visually as surfaces surface). #118.
+// GFX10 SW_4KB_S element order within the tile. The order is BYTES-PER-ELEMENT-DEPENDENT (AMD's
+// standard-swizzle SW_PATTERN genuinely differs per bpp) — two orders are pixel-verified against The
+// Messenger's live surfaces, and both share the shape "a low block of L X-bits then L Y-bits, then
+// interleaved (y,x) Morton pairs above":
+//
+//   32-bpp (32x32 tile, bx=by=5): L=2 -> [x0,x1, y0,y1, y2,x2, y3,x3, y4,x4]           #118 (title art)
+//    8-bpp (64x64 tile, bx=by=6): L=4 -> [x0,x1,x2,x3, y0,y1,y2,y3, y4,x4, y5,x5]       (R8 font atlas)
+//
+// The previous code applied the 32-bpp L=2 pattern at EVERY bpe. That serrated edges at 32-bpp until
+// #118 fixed the low nibble, but at 8-bpp (the game's ONLY R8 surface — the 2048x1024 caption font
+// atlas) the L=2 pattern is badly wrong: it scrambles every 64x64 tile into an unreadable weave, so
+// the intro caption text renders as invisible/garbage. The 8-bpp order below is pixel-verified: it
+// resolves the atlas into a clean grid of readable Latin + CJK glyphs. CONFIDENCE: HIGH for bx=by=5
+// (32-bpp) and bx=by=6 (8-bpp) — both live-verified; the L=2 fallback covers 16-bpp/BC-block geometries
+// (bx=by=4, bx=5/by=4) which round-trip but have no game-observed instance to pixel-verify yet.
 inline uint32_t sw4kb_morton(uint32_t ix, uint32_t iy, uint32_t bx, uint32_t by) {
     uint32_t m = 0;
-    // low 4 bits: x0, x1, y0, y1  (a 4x4 sub-block; requires bx>=2 and by>=2, true for every real bpe)
-    m |= (ix & 1u) << 0;
-    m |= ((ix >> 1) & 1u) << 1;
-    m |= (iy & 1u) << 2;
-    m |= ((iy >> 1) & 1u) << 3;
-    for (uint32_t b = 2; b < by; b++) {
-        m |= ((iy >> b) & 1u) << (2 * b);
-        m |= ((ix >> b) & 1u) << (2 * b + 1);
+    // Low-block half-width L: 4 for the 64x64 (8-bpp) tile, else 2 (the #118-verified 32-bpp nibble).
+    const uint32_t L = (bx == 6 && by == 6) ? 4u : 2u;
+    uint32_t bit = 0;
+    for (uint32_t b = 0; b < L && b < bx; b++) m |= ((ix >> b) & 1u) << (bit++);   // low X bits
+    for (uint32_t b = 0; b < L && b < by; b++) m |= ((iy >> b) & 1u) << (bit++);   // low Y bits
+    for (uint32_t b = L; b < by; b++) {                                            // (y,x) Morton pairs
+        m |= ((iy >> b) & 1u) << (bit++);
+        if (b < bx) m |= ((ix >> b) & 1u) << (bit++);
     }
-    for (uint32_t b = by; b < bx; b++)
-        m |= ((ix >> b) & 1u) << (2 * by + (b - by));
+    for (uint32_t b = by; b < bx; b++) m |= ((ix >> b) & 1u) << (bit++);           // wider-dim extra X
     return m;
 }
 // Element (x,y) -> its linear element INDEX in the tiled surface: tiles laid out row-major over the

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -145,11 +145,22 @@ int main() {
         CHECK(t32[8 * 4] == lin32[((size_t)2 * 64 + 0) * 4], "32-bpp golden: texel (0,2) at element 8 (y1 at bit 3)");
         CHECK(t32[4096]  == lin32[((size_t)0 * 64 + 32) * 4], "32-bpp golden: texel (32,0) starts tile 1 (byte 4096)");
 
+        // 8-bpp uses a DIFFERENT within-tile order than 32-bpp (the 64x64 tile's SW_4KB_S order is
+        // pixel-verified against the game's 2048x1024 R8 caption-font atlas): the low EIGHT element bits
+        // are a 16x16 sub-block [x0,x1,x2,x3, y0,y1,y2,y3] (four low X bits, then four low Y bits), then
+        // (y,x) Morton pairs [y4,x4, y5,x5]. So (1,0)->1 (x0), (4,0)->4 (x2), (8,0)->8 (x3),
+        // (0,1)->16 (y0 at bit 4), (0,2)->32 (y1), (16,0)->512 (x4 at bit 9). The OLD code shared the
+        // 32-bpp [x0,x1,y0,y1] low nibble here, which scrambled every 64x64 tile into a weave.
         std::vector<uint8_t> lin8((size_t)128 * 64, 0);
         for (size_t i = 0; i < lin8.size(); i++) lin8[i] = (uint8_t)(i * 31 + 7);
         std::vector<uint8_t> t8(tiled_surface_bytes(128, 64, M, 0, 1), 0);
         tile_surface(t8.data(), lin8.data(), 128, 64, M, 0, 1);
-        CHECK(t8[4] == lin8[(size_t)1 * 128 + 0], "8-bpp golden: texel (0,1) at element 4 (same [x0,x1,y0,y1] order)");
+        CHECK(t8[1]    == lin8[(size_t)0 * 128 + 1],  "8-bpp golden: texel (1,0) at element 1 (x0)");
+        CHECK(t8[4]    == lin8[(size_t)0 * 128 + 4],  "8-bpp golden: texel (4,0) at element 4 (x2)");
+        CHECK(t8[8]    == lin8[(size_t)0 * 128 + 8],  "8-bpp golden: texel (8,0) at element 8 (x3)");
+        CHECK(t8[16]   == lin8[(size_t)1 * 128 + 0],  "8-bpp golden: texel (0,1) at element 16 (y0 at bit 4)");
+        CHECK(t8[32]   == lin8[(size_t)2 * 128 + 0],  "8-bpp golden: texel (0,2) at element 32 (y1 at bit 5)");
+        CHECK(t8[512]  == lin8[(size_t)0 * 128 + 16], "8-bpp golden: texel (16,0) at element 512 (x4 at bit 9)");
         CHECK(t8[4096] == lin8[(size_t)0 * 128 + 64], "8-bpp golden: texel (64,0) starts tile 1 (byte 4096, 64-wide tile)");
     }
 


### PR DESCRIPTION
## What

The GFX10 `SW_4KB_S` within-tile element order is **bytes-per-element-dependent** (AMD's standard-swizzle `SW_PATTERN` genuinely differs by element size), but `sw4kb_morton` applied the **32-bpp** order (low block `[x0,x1,y0,y1]`, `L=2`) at *every* bpe.

That is correct for 4 B/texel RGBA8 (32×32 tile — verified in #251) but **wrong for 1 B/texel R8** (64×64 tile): it scrambled every tile into an unreadable weave.

## Why it matters — the missing intro text (#102)

The game's **only R8 surface** is the **2048×1024 caption/glyph font atlas** (a TextMeshPro-style Latin+CJK atlas, sampled by a ~260-quad batched text mesh). With the wrong 8-bpp order the atlas decoded to noise, so every caption glyph sampled garbage coverage and the intro story text rendered as **nothing**.

**Before → after** (same raw bytes, wrong vs correct 8-bpp de-swizzle):

| before (`L=2`, scrambled) | after (`L=4`, readable) |
|---|---|
| unreadable weave | clean grid of Latin + CJK glyphs |

## The fix

Correct 8-bpp order: `[x0 x1 x2 x3 y0 y1 y2 y3 y4 x4 y5 x5]` — a low 16×16 block (four low X bits, then four low Y bits) then `(y,x)` Morton pairs (`L=4`). `sw4kb_morton` now selects the low-block half-width `L` by tile geometry (`L=4` for the 64×64 R8 tile, else the #251-verified `L=2`). The 32-bpp / 16-bpp / BC-block paths are byte-for-byte unchanged.

Found by a **total-variation-minimising search** over bit permutations (a correct de-swizzle of structured glyph data is spatially smooth) and pixel-verified against the atlas's Latin block.

## Verification

- `test_tile`: 8-bpp golden positions updated to the verified 64×64 order; round-trips + 32-bpp goldens untouched.
- **68/68 ctest green** on master base.
- Offline: the atlas resolves into readable Latin + CJK glyphs.
- In-game: the R8 path now renders (title-screen menu glyph); rebuilt renderer boots clean.

## Scope / honest caveat

This fixes the **root-cause decode** of the R8 font atlas. I could **not** yet confirm the *story captions* appear in-game because the capture reaches the **attract loop** (title demo + scene slides), whose scene-slide letterboxes are pure black — the actual story intro (with captions) is behind a New Game → controller-input path this workstream doesn't drive. So this is filed **Refs #102**, not Fixes, pending confirmation on the story-intro path.

## Also

- `live_renderer.cpp`: `PROSPER_DUMP_RAWTILE` now also dumps the narrow (single-channel) raw tiled bytes (gated) — the capture that cracked this; aids future R8 verification.
- `docs/GFX10_SW_4KB_S_TILING.md`: documents the per-bpe order + the TV-minimisation method.