### PR TITLE
fix(hle): GetDisplaySafeAreaInfo fills ratio=1.0 + #232 reframe (GameThread ticks; PlayGo/SaveData is the gate)

### DIFF
--- a/prosper/.gitignore
+++ b/prosper/.gitignore
@@ -1,1 +1,6 @@
 build-linux/shader0.bin
+
+# render frame dumps — NEVER commit game imagery
+*.bmp
+frame_*.png
+frame_*.bmp

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -991,3 +991,56 @@ what consumes the completed .ucas chunk data (decompression job? FEvent chain? t
 records at the retry list disp+0x198?) and which signal the FlushAsyncLoading packages actually
 poll. SlateLoadingThr + CriManaDecodeTh exist (loading-screen + movie machinery live); DOLL is
 UE4's LEGACY EDL loader (FAsyncLoadingThread strings), not zenloader.
+
+### REFRAMED (2026-07-09 session 4, issue #232): the GameThread is NOT stuck in FlushAsyncLoading — it TICKS; the wall is genuine scene non-activation (0 DrawIndex, 1.66M DispatchDirect)
+
+Live-attach sampling at the steady-state stall (probes `boot232.sh`, `probe232w/x/y/z.py`,
+`cpu232.sh`; target left running via `setsid`, PID in /root/pid232.txt) **overturns the session-3
+"busy FlushAsyncLoading spin" characterization**:
+
+- **The GameThread reaches Tick and runs the engine frame loop indefinitely.** 33/40 RIP samples of
+  the guest main thread land in a **game-side frame-throttle**: a `do { pump(); } while (clock() <
+  start+target)` loop at **eboot+0x5044c01** (containing fn starts eboot+0x5044740, a per-frame state
+  tick taking a `this` object + calling vtable `*0x288`), whose pump path bottoms out in a
+  `scePthreadCondTimedwait` return at **eboot+0x248e556** (an `FEvent::Wait(1ms)`-style sleep). It is
+  NOT the 0x25b2980 ProcessAsyncLoading busy-spin — that function's entry never fires under a
+  163 s breakpoint, because the loader long since drained. The frame loop advances **58k+ GpuFlips**,
+  stable and unbounded.
+- **Async loading has fully DRAINED, not deadlocked.** The `FAsyncLoadingThread` (ALT, name
+  "FAsyncLoadingTh") is **parked on its zenaphore** (`k_cond_wait` via eboot+0x22ea954 ->
+  0x2316b00). Its loader object (recovered from the parked thread's regs/stack, plausibility-gated
+  on the counter layout): **QueuedPackagesCounter[+0x1b0]=0, ExistingAsyncPackagesCounter[+0x1b4]=0,
+  QueuedPackages.Num[+0x58]=0, pendingIoBytes[+0x5d8]=0, ExternalReadQueue[+0x138]->next=0**. Nothing
+  is queued or in flight. (The +0xd8 AsyncPackageLookup histogram is noise — the slot layout guess is
+  wrong for this build; the counters are the reliable signal and they are all zero.) IoDispatcher /
+  IoService / 64 PoolThreads all idle in k_eq_wait/k_cond_wait.
+- **0 draws is GENUINE, not a decoder miss.** Packet-kind histogram over a full boot log:
+  **1,662,586 DispatchDirect and ZERO DrawIndex / DrawIndexAuto** (plus SetRegsIndirect 23.6M,
+  SetShRegDirect 11.6M, EventWrite/AcquireMem/ReleaseMem/WaitRegMem/WriteData, 50k Flip). The game
+  submits only per-frame **compute**, never geometry. The recompiler/PM4 decoder is not dropping
+  draws — the guest never emits a draw packet.
+- **Movie / cutscene is NOT the gate (clean A/B).** New knob `PROSPER_DENY_SUBSTR=.usm` (hle_file
+  `translate()`) makes every `.usm` open/stat fail ENOENT. With all movies denied, DOLL runs the
+  identical frame loop — flips climb 2669 -> 6510, still 0 draws. Confirms (again, cf. session 1) the
+  opening cutscene is coincidental, not the blocker.
+- **Safe-area ratio was a real bug but NOT the draw gate.** `sceSystemServiceGetDisplaySafeAreaInfo`
+  (1n37q1Bvc5Y) was unimplemented -> returned SUCCESS with the out-struct `{float ratio; u8[128]}`
+  unfilled, so ratio read 0.0 (degenerate title-safe rect -> collapsed viewport was a plausible
+  cull-everything cause). Fixed to fill ratio=1.0 (shadPS4 contract). Verified: **still 0 draws**
+  (flips 6463) — so a zero safe-area was not what gated geometry. Kept as a correctness fix (same
+  success+unfilled-out-struct class as GetStatus/ParamGetString/TmpMount2).
+
+**So the #232 wall is: DOLL reaches a stable engine tick loop with async loading complete, but its
+game/world flow never activates a scene that submits geometry.** The per-frame state machine at
+eboot+0x5044740 (reads .data bool gates at 0x9803460/0x9803470, doubles at 0x9603030..48) is the
+game's own boot/flow tick; something it polls has not flipped to "enter gameplay/level visible".
+Threads named **DollLevelPreloa**(der), SaveLoadUpdate, DLCDataUpdate, ShareUpdate all sit in the
+same free-list wait (eboot+0x2316b41/0x2316d50) — game-side loader/update workers idle. Several NIDs
+the boot flow calls are still bare unimpl->0 stubs, now name-resolved (tools/dbg/nidguess.py):
+**scePlayGoInitialize (ts6GlZOKRrE), scePlayGoOpen (M1Gma1ocrGE), sceSaveDataInitialize3
+(TywrFKCoLGY), sceNpTrophy2CreateHandle/RegisterContext, sceShareInitialize** — PlayGo/SaveData are
+the most likely to gate a "content ready -> start game" transition (a game waiting on PlayGo locus =
+"chunk installed" or a SaveData mount result before it loads the first level). **Next: implement
+scePlayGo (report everything installed/locus-local) and sceSaveData (mount succeeds, empty) with real
+out-struct contracts, and trace the eboot+0x5044740 state machine's .data gate to the subsystem it
+polls.**

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -55,10 +55,37 @@ namespace {
         }
         return root;
     }
+    // PROSPER_DENY_SUBSTR: comma-separated substrings; any guest path containing one is
+    // redirected to a guaranteed-missing host path, so open/stat fail with ENOENT.
+    // Diagnostic knob (off by default) — used to A/B whether the title's boot flow gates on a
+    // file class we can't service yet (e.g. .usm movies through the stubbed CRI/AJM decoders).
+    bool deny_path(const std::string& guest) {
+        static std::vector<std::string> subs = [] {
+            std::vector<std::string> v;
+            if (const char* e = getenv("PROSPER_DENY_SUBSTR")) {
+                std::string s = e; size_t pos = 0;
+                while (pos <= s.size()) {
+                    size_t c = s.find(',', pos);
+                    if (c == std::string::npos) c = s.size();
+                    if (c > pos) v.push_back(s.substr(pos, c - pos));
+                    pos = c + 1;
+                }
+            }
+            return v;
+        }();
+        if (subs.empty()) return false;
+        for (const auto& sub : subs)
+            if (guest.find(sub) != std::string::npos) return true;
+        return false;
+    }
     std::string translate(const char* guest) {
         if (!guest) return {};
         std::string p = guest;
         if (g_app0.empty()) { if (const char* e = getenv("PROSPER_APP0")) g_app0 = e; }
+        if (deny_path(p)) {
+            if (filelog()) fprintf(stderr, "[file] DENIED (PROSPER_DENY_SUBSTR) '%s'\n", guest);
+            return "/prosper-denied" + p;
+        }
         // Map /app0[/...] -> <root>[/...], /temp0[/...] -> scratch dir; other paths as-is.
         std::string h = (p.rfind("/app0", 0) == 0)  ? g_app0 + p.substr(5)
                       : (p.rfind("/temp0", 0) == 0) ? temp0_root() + p.substr(6)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -87,6 +87,25 @@ HLE(s_syss_getstatus) {
     return 0;
 }
 
+// sceSystemServiceGetDisplaySafeAreaInfo(SceSystemServiceDisplaySafeAreaInfo* info) — single-arg
+// call, out-struct is ARG 0: { float ratio; uint8_t reserved[128]; } (shadPS4 systemservice.h).
+// The default unimplemented stub returned 0 (SUCCESS) but left `ratio` uninitialized (typically 0.0
+// from a fresh guest heap block). A safe-area ratio of 0 makes UE4's PS5 viewport code compute a
+// DEGENERATE (zero-area) title-safe rect: the game scales its render/UI viewport by the ratio, and a
+// zero ratio collapses the visible region — nothing to rasterize, so the RHI submits setup/compute
+// but never geometry. Real hardware always reports ratio=1.0 for a display with overscan disabled
+// (the modern default); shadPS4 hard-codes 1.0f. Fill ratio=1.0 and zero the reserved tail.
+// CONFIDENCE: MED — struct + 1.0f contract confirmed against shadPS4; that a 0.0 ratio is what
+// gates DOLL's scene draws is a hypothesis under test, but returning success with an unfilled
+// out-struct is a bug regardless (same class as GetStatus / ParamGetString above).
+HLE(s_syss_safearea) {
+    auto* info = (uint8_t*)PW(a0);
+    if (!info) return 0x80A10003ull;   // SYSTEM_SERVICE_ERROR_PARAMETER
+    memset(info, 0, 0x84);             // sizeof {float + uint8_t[128]} = 132
+    *(float*)info = 1.0f;              // ratio = full display, no overscan inset
+    return 0;
+}
+
 // sceAppContentTemporaryDataMount2(option, SceAppContentMountPoint* mp) — mount the app's temp-data
 // area and write its guest path into mp. SceAppContentMountPoint = char data[16] (shadPS4
 // app_content.h; PS4/PS5 identical). shadPS4 writes exactly "/temp0\0" and returns 0. Our previous
@@ -208,6 +227,8 @@ void register_service_hle() {
     R("sceMsgDialogGetResult", s_dialog_result);
     R("sceSystemServiceHideSplashScreen", s_ok);
     R("sceSystemServiceGetStatus", s_syss_getstatus);
+    // sceSystemServiceGetDisplaySafeAreaInfo (1n37q1Bvc5Y) — fill ratio=1.0 (see s_syss_safearea).
+    Hle::register_fn("1n37q1Bvc5Y", (HleFn)s_syss_safearea, "sceSystemServiceGetDisplaySafeAreaInfo");
     #undef R
 }
 

--- a/prosper/tools/dbg/boot232.sh
+++ b/prosper/tools/dbg/boot232.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Issue #232: boot DOLL to the FlushAsyncLoading stall and LEAVE IT RUNNING.
+# PID -> /root/pid232.txt; log -> /root/d232u.log. Kill with: kill -9 $(cat /root/pid232.txt)
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+# kill any previous instance we started
+[ -f /root/pid232.txt ] && kill -9 "$(cat /root/pid232.txt)" 2>/dev/null
+sleep 1
+PID=
+for try in 1 2 3 4 5 6; do
+  setsid ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232u.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+echo "$PID" > /root/pid232.txt
+prev=-1
+for i in $(seq 1 12); do
+  cur=$(grep -ac "read-submit id" /root/d232u.log)
+  echo "t+$((45+i*30)) reads=$cur"
+  if [ "$cur" = "$prev" ] && [ "$cur" -gt 2000 ]; then echo READY; exit 0; fi
+  prev=$cur
+  sleep 30
+  kill -0 $PID 2>/dev/null || { echo DIED-WAITING; exit 1; }
+done
+echo READY-MAYBE

--- a/prosper/tools/dbg/cpu232.sh
+++ b/prosper/tools/dbg/cpu232.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Per-thread CPU usage over 3s for the stalled DOLL (pid in /root/pid232.txt)
+PID=$(cat /root/pid232.txt)
+kill -0 "$PID" || { echo TARGET-DEAD; exit 1; }
+declare -A A
+for t in /proc/$PID/task/*; do
+  tid=${t##*/}
+  read -r -a f < "$t/stat" 2>/dev/null || continue
+  A[$tid]=$(( ${f[13]} + ${f[14]} ))
+done
+sleep 3
+for t in /proc/$PID/task/*; do
+  tid=${t##*/}
+  read -r -a f < "$t/stat" 2>/dev/null || continue
+  now=$(( ${f[13]} + ${f[14]} ))
+  d=$(( now - ${A[$tid]:-0} ))
+  if [ "$d" -gt 0 ]; then
+    name=$(cat "$t/comm" 2>/dev/null)
+    echo "tid=$tid dticks=$d name=$name"
+  fi
+done | sort -t= -k3 -rn
+echo CPU232-DONE

--- a/prosper/tools/dbg/nidguess.py
+++ b/prosper/tools/dbg/nidguess.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Guess NID names: sha1(name + Sony salt), first 8 bytes reversed, Sony b64, 11 chars.
+import hashlib, sys
+
+SALT = bytes([0x51,0x8D,0x64,0xA6,0x35,0xDE,0xD8,0xC1,0xE6,0xB0,0x39,0xB1,0xC3,0xE5,0x52,0x30])
+A = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-"
+
+def nid(name):
+    d = hashlib.sha1(name.encode() + SALT).digest()
+    r = d[7::-1]
+    out = ""
+    v = 0
+    bits = 0
+    for b in r:
+        v = (v << 8) | b
+        bits += 8
+        while bits >= 6:
+            bits -= 6
+            out += A[(v >> bits) & 63]
+    if bits:
+        out += A[(v << (6 - bits)) & 63]
+    return out[:11]
+
+targets = {
+    "ts6GlZOKRrE": "libScePlayGo", "M1Gma1ocrGE": "libScePlayGo",
+    "1n37q1Bvc5Y": "libSceSystemService",
+    "uW4vfTwMQVo": "sd", "sDCBrmc61XU": "sd", "ie7qhZ4X0Cc": "sd",
+    "gjRZNnw0JPE": "sd", "ZP4e7rlzOUk": "sd", "TywrFKCoLGY": "sd",
+    "vYU8P9Td2Zo": "kern", "rqwFKI4PAiM": "kern", "nu4a0-arQis": "kern",
+    "bBfz7kMF2Ho": "kern", "6xVpy0Fdq+I": "kern",
+    "sUXGfNMalIo": "trophy2", "bIDov3wBu5Q": "trophy2", "Gz1rmUZpROM": "trophy2",
+    "U8IfNl6-Css": "voiceqos", "hdpVEUDFW3s": "ssl", "RnDibcGCPKw": "videodec2",
+    "nBDD66kiFW8": "share", "T64o-315wbg": "share", "ORspsWDXPps": "share",
+    "WV1GwM32NgY": "npwebapi2", "+o9816YQhqQ": "npwebapi2",
+    "tpFJ8LIKvPw": "npuds", "sjaobBgqeB4": "npuds", "hT0IAEvN+M0": "npuds", "5zBnau1uIEo": "npuds",
+    "Xs9hdiD7sAA": "posix",
+}
+
+cands = []
+for base in ["scePlayGo"]:
+    for fn in ["Initialize","Terminate","Open","Close","GetLocus","SetToDoList","GetToDoList",
+               "GetProgress","GetInstallSpeed","SetInstallSpeed","Prefetch","GetEta",
+               "GetLanguageMask","SetLanguageMask","GetChunkId","RequestInstall",
+               "GetInstallStatus","GetTotalProgress","Snapshot","GetDiscStatus"]:
+        cands.append(base + fn)
+for base in ["sceSystemService"]:
+    for fn in ["GetStatus","HideSplashScreen","ReceiveEvent","ParamGetInt","ParamGetString",
+               "GetDisplaySafeAreaInfo","ReportAbnormalTermination","LoadExec","EnableMusicPlayer",
+               "DisableMusicPlayer","GetAppSecurityZone","IsScreenSaverOn","ActivateChatApp",
+               "GetLocalProcessStatusList","KillLocalProcess","LaunchApp","GetAppStatus",
+               "GetAppIdOfMiniApp","GetAppIdOfBigApp","AcquireBgmCpuBudget","ReleaseBgmCpuBudget",
+               "AcquireBgmCpu","ReleaseBgmCpu"]:
+        cands.append(base + fn)
+for base in ["sceSaveData"]:
+    for fn in ["Initialize","Initialize2","Initialize3","Terminate","Mount","Mount2","Mount5",
+               "Umount","UmountWithBackup","DirNameSearch","Delete","SetupSaveDataMemory",
+               "SetupSaveDataMemory2","GetSaveDataMemory","GetSaveDataMemory2","SetSaveDataMemory",
+               "SetSaveDataMemory2","SyncSaveDataMemory","GetEventResult","GetSaveDataRootDir",
+               "GetMountInfo","GetParam","SetParam","LoadIcon","SaveIcon","DirNameSearchInternal",
+               "CheckBackupData","RestoreBackupData","GetProgress","ClearProgress",
+               "TransferringMount","GetSaveDataCount",
+               # broader PS4 SDK surface
+               "Backup","CheckSaveDataBroken","CheckSaveDataVersion","CheckSaveDataVersionLatest",
+               "DebugCleanMount","DebugCompiledSdkVersion","DebugCreateSaveDataRoot",
+               "DebugGetThreadId","DebugRemoveSaveDataRoot","DebugSetSaveDataRoot",
+               "DeleteAllUser","DeleteCloudData","DeleteUser","DirNameSearch2",
+               "DownloadCloudData","GetAllSize","GetAppLaunchedUser","GetAutoUploadConditions",
+               "GetAutoUploadRequestInfo","GetAutoUploadSetting","GetBoundPsnAccountCount",
+               "GetClientThreadPriority","GetCloudQuotaInfo","GetDataBaseFilePath",
+               "GetEventInfo","GetFormat","GetMountedSaveDataCount","GetSaveDataCount2",
+               "GetSaveDataMemorySync","GetUpdatedDataCount","GetUserSaveDataCount",
+               "IsDeletingUsbData","IsMounted","IsUsbAccessible","LoadIconAsync",
+               "RegisterEventCallback","RestoreBackupDataForCdlg","RestoreLoadSaveDataMemory",
+               "SaveIconAsync","SetAutoUploadSetting","SetEventInfo","SetSaveDataLibraryUser",
+               "ShrinkSaveData","SyncCloudList","UnregisterEventCallback","UploadCloudData",
+               # event-queue style (PS5)
+               "GetEvent","ClearEvent","AbortEvent","WaitEvent","GetEventStatus",
+               "CreateEventQueue","DeleteEventQueue","RegisterEventQueue","UnregisterEventQueue",
+               "MountPs4","MountPs5","MountReadOnly","MountRdwr","MountCreate",
+               "GetMountPoint","GetMountPointByName","GetMountStatus","MountAuto"]:
+        cands.append(base + fn)
+for base in ["sceNpTrophy2"]:
+    for fn in ["CreateContext","DestroyContext","CreateHandle","DestroyHandle","RegisterContext",
+               "AbortHandle","GetGameInfo","GetGroupInfo","GetTrophyInfo","GetGameIcon",
+               "UnlockTrophy","ShowTrophyList","GetTrophyUnlockState","SetPlayedWithUsers"]:
+        cands.append(base + fn)
+for fn in ["sceKernelIsProspero","sceKernelGetSystemSwVersion","sceKernelGetCpuFrequency",
+           "sceKernelGetCpuTemperature","sceKernelGetSocSensorTemperature","sceKernelSetGPO",
+           "sceKernelGetGPI","sceKernelGetProcessType","sceKernelIsTestKit","sceKernelIsDevKit",
+           "sceKernelSetFsstParam","sceKernelSetCompressionAttribute","sceKernelSetMemoryPstate",
+           "sceKernelGetCurrentCpu","sceKernelMprotect","sceKernelGetProcessName",
+           "sceKernelSetVirtualRangeName","sceKernelDebugOutText","sceKernelGetAppInfo",
+           "sceKernelSetProcessProperty","sceKernelSetAppInfo","get_page_table_stats",
+           "sceKernelInternalMemoryGetAvailableSize","sceKernelAvailableFlexibleMemorySize",
+           "sceKernelGetPrtAperture","sceKernelSetPrtAperture","sceKernelGetExtLibcHandle",
+           "sceKernelGetSanitizerMallocReplace","sceKernelGetSanitizerNewReplace",
+           "sceKernelGetSanitizerMallocReplaceExternal","sceKernelIsAddressSanitizerEnabled",
+           "sceKernelNotifyAppStateChanged","sceKernelGetAppState","scePthreadSetAffinity",
+           "scePthreadGetAffinity","sceKernelGetCurrentFrequency","sceKernelGetTraceMemorySize"]:
+    cands.append(fn)
+for base in ["sceShare"]:
+    for fn in ["Initialize","Terminate","OpenParameter","CloseParameter","SetParameter",
+               "GetCurrentStatus","EnableScreenshot","DisableScreenshot","EnableVideoRecording",
+               "DisableVideoRecording","NotifyEventFinish"]:
+        cands.append(base + fn)
+
+hit = 0
+for c in cands:
+    h = nid(c)
+    if h in targets:
+        print("%s = %s (%s)" % (h, c, targets[h]))
+        hit += 1
+print("matched %d/%d targets" % (hit, len(targets)))

--- a/prosper/tools/dbg/probe232u.py
+++ b/prosper/tools/dbg/probe232u.py
@@ -1,0 +1,116 @@
+# gdb -p PID -batch -x probe232u.py — issue #232: at the FlushAsyncLoading stall, capture
+# FAsyncLoadingThread2 state (UE 4.27 zenloader). ProcessAsyncLoading=eboot+0x25b2980 spins
+# INSIDE its do-while, so break on in-loop addresses:
+#   0x25b2ac4 loop-condition head (rbx=this, r15=ThreadState)
+#   0x25b29e0 CreateAsyncPackagesFromQueue callsite (rbx=this)
+#   0x25acf40 CreateAsyncPackagesFromQueue entry (rdi=this)
+# Layout: QueuedPackagesCounter=this+0x1b0, ExistingAsyncPackagesCounter=this+0x1b4,
+# QueuedPackages TArray={data +0x50,num +0x58}, AsyncPackageLookup TMap elements=+0xd8
+# (24-byte {u64 PackageId, FAsyncPackage2*, i32 hashnext}), slots num=+0xe0, free=+0x10c,
+# ExternalReadQueue head=+0x138, DeferredDeleteQueue=+0xa8, pkg state byte=pkg+0xe0,
+# pkg ExternalReadDependencies={data pkg+0x110, num pkg+0x118}.
+import gdb, struct, time
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+EB = 0x400000000
+
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+
+def hx(v):
+    return hex(v) if v is not None else "??"
+
+hit = {"this": 0, "ts": 0, "where": ""}
+
+class B1(gdb.Breakpoint):  # loop head: rbx=this r15=ThreadState
+    def stop(self):
+        hit["this"] = int(gdb.parse_and_eval("$rbx"))
+        hit["ts"] = int(gdb.parse_and_eval("$r15"))
+        hit["where"] = "loophead"
+        return True
+
+class B2(gdb.Breakpoint):  # capq entry: rdi=this rsi=ThreadState
+    def stop(self):
+        hit["this"] = int(gdb.parse_and_eval("$rdi"))
+        hit["ts"] = int(gdb.parse_and_eval("$rsi"))
+        hit["where"] = "capq"
+        return True
+
+class B3(gdb.Breakpoint):  # PAL entry: rdi=this rsi=ThreadState
+    def stop(self):
+        hit["this"] = int(gdb.parse_and_eval("$rdi"))
+        hit["ts"] = int(gdb.parse_and_eval("$rsi"))
+        hit["where"] = "entry"
+        return True
+
+b1 = B1("*0x%x" % (EB + 0x25b2ac4))
+b2 = B2("*0x%x" % (EB + 0x25acf40))
+b3 = B3("*0x%x" % (EB + 0x25b2980))
+t0 = time.time()
+gdb.execute("continue")
+dt = time.time() - t0
+thr = gdb.selected_thread()
+this = hit["this"]
+ts = hit["ts"]
+print("HIT %s after %.3fs on lwp=%d name=%s this=0x%x tstate=0x%x" %
+      (hit["where"], dt, thr.ptid[1], thr.name or "?", this, ts))
+b1.delete(); b2.delete(); b3.delete()
+
+qnum = rd(this + 0x58, 4)
+print("QueuedPackagesCounter   [this+0x1b0] =", hx(rd(this + 0x1b0, 4)))
+print("ExistingAsyncPkgCounter [this+0x1b4] =", hx(rd(this + 0x1b4, 4)))
+print("ctr [this+0x140] =", hx(rd(this + 0x140, 4)), " heapnum [this+0x5d0] =", hx(rd(this + 0x5d0, 4)))
+print("suspend [this+0x19] =", hx(rd(this + 0x19, 1)), " [this+0x18] =", hx(rd(this + 0x18, 1)))
+print("QueuedPackages num [this+0x58] =", hx(qnum), " data =", hx(rd(this + 0x50)))
+erq = rd(this + 0x138)
+print("ExternalReadQueue [this+0x138] =", hx(erq), "-> next", hx(rd(erq or 0)))
+ddq = rd(this + 0xa8)
+print("DeferredDeleteQ   [this+0xa8]  =", hx(ddq), "-> next", hx(rd(ddq or 0)))
+print("evq arr [this+0x800658] =", hx(rd(this + 0x800658)), "cnt =", hx(rd(this + 0x800660, 4)))
+print("ThreadState +0x18 defrees =", hx(rd(ts + 0x18, 4)), " +0x30 curnode =", hx(rd(ts + 0x30)),
+      " +0x39 usetl =", hx(rd(ts + 0x39, 1)))
+
+arr = rd(this + 0x800658)
+cnt = rd(this + 0x800660, 4) or 0
+if arr and cnt and cnt < 16:
+    for i in range(cnt):
+        q = rd(arr + 8 * i)
+        if not q:
+            continue
+        print("  evq[%d]=0x%x zenaphore=%s commit(+0x8)=%s pop(+0x10)=%s ring[pop&mask]=%s" % (
+            i, q, hx(rd(q)), hx(rd(q + 8)), hx(rd(q + 0x10)),
+            hx(rd(q + 0x18 + 8 * ((rd(q + 0x10) or 0) & 0x7ffff)))))
+
+# AsyncPackageLookup: enumerate all packages + state bytes
+slots = rd(this + 0xe0, 4) or 0
+free = rd(this + 0x10c, 4) or 0
+data = rd(this + 0xd8)
+print("AsyncPackageLookup: slots=%d free=%d live=%d data=%s" % (slots, free, slots - free, hx(data)))
+if data and 0 < slots < 20000:
+    states = {}
+    stuck = []
+    for i in range(slots):
+        e = data + 24 * i
+        pid = rd(e)
+        pkg = rd(e + 8)
+        if not pkg or pkg < 0x10000000 or pkg > 0x7000000000 or not pid:
+            continue
+        st = rd(pkg + 0xe0, 1)
+        if st is None:
+            continue
+        states[st] = states.get(st, 0) + 1
+        if st != 11 and len(stuck) < 40:
+            stuck.append((pid, pkg, st))
+    print("state histogram:", {k: v for k, v in sorted(states.items())})
+    for pid, pkg, st in stuck:
+        print("  pkg=0x%x id=0x%016x state=%d extreads num=%s idx=%s refc(+0x140)=%s desc0x10=%s" % (
+            pkg, pid, st, hx(rd(pkg + 0x118, 4)), hx(rd(pkg + 0xd8, 4)),
+            hx(rd(pkg + 0x140, 4)), hx(rd(rd(pkg + 0x10) or 0))))
+        # dump some raw package words for layout discovery
+        print("    raw:", " ".join(hx(rd(pkg + o)) for o in range(0xd0, 0x120, 8)))
+gdb.execute("detach")

--- a/prosper/tools/dbg/probe232w.py
+++ b/prosper/tools/dbg/probe232w.py
@@ -1,0 +1,55 @@
+# gdb -p PID -batch -x probe232w.py — issue #232: sample ALL threads' RIPs at the stall;
+# print guest pc / guest return addresses to pin the busy-spin loop.
+import gdb, struct, time, threading
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def sym(v):
+    if v is None:
+        return "??"
+    if 0x400000000 <= v < 0x406700000:
+        return "eboot+0x%x" % (v - 0x400000000)
+    if 0x600000000 <= v < 0x700000000:
+        return "prx+0x%x" % (v - 0x600000000)
+    return None
+
+def sample(rnd):
+    for t in inf.threads():
+        try:
+            t.switch()
+            pc = int(gdb.parse_and_eval("$pc")) & 0xffffffffffffffff
+            sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+        except gdb.error:
+            continue
+        pcs = sym(pc)
+        ras = []
+        try:
+            mem = bytes(inf.read_memory(sp, 3072))
+            for off in range(0, len(mem) - 7, 8):
+                v = struct.unpack_from("<Q", mem, off)[0]
+                s = sym(v)
+                if s:
+                    ras.append(s)
+                if len(ras) >= 8:
+                    break
+        except gdb.error:
+            pass
+        # only print threads with guest presence
+        if pcs or ras:
+            print("r%d lwp=%d name=%s pc=%s | %s" % (rnd, t.ptid[1], t.name or "?", pcs or hex(pc), " ".join(ras)), flush=True)
+
+for i in range(6):
+    sample(i)
+    done = threading.Event()
+    def stopper():
+        time.sleep(0.25)
+        gdb.post_event(lambda: gdb.execute("interrupt"))
+    threading.Thread(target=stopper, daemon=True).start()
+    try:
+        gdb.execute("continue")
+    except gdb.error as e:
+        print("cont err", e)
+        break
+gdb.execute("detach")

--- a/prosper/tools/dbg/probe232w.sh
+++ b/prosper/tools/dbg/probe232w.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# attach probe232w to the live stalled DOLL (pid in /root/pid232.txt), keep target alive
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+PID=$(cat /root/pid232.txt)
+kill -0 "$PID" || { echo TARGET-DEAD; exit 1; }
+timeout 240 gdb -p "$PID" -batch -x "$WT/tools/dbg/$1" 2>&1 \
+  | grep -v "^\[New\|libthread_db\|debuginfod\|Debuginfod\|warning:\|^\[Thread\|^Downloading\|^Reading\|futex-internal\|clock_nanosleep\|^[0-9]*\Win \|^#"
+echo PROBE-DONE

--- a/prosper/tools/dbg/probe232x.py
+++ b/prosper/tools/dbg/probe232x.py
@@ -1,0 +1,73 @@
+# gdb -p PID -batch -x probe232x.py — issue #232: catch ProcessLoadedPackages (0x259f440)
+# on the flushing GameThread, capture this, dump loader state + all async packages.
+import gdb, struct, time
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+EB = 0x400000000
+
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+
+def hx(v):
+    return hex(v) if v is not None else "??"
+
+bp = gdb.Breakpoint("*0x%x" % (EB + 0x259f440))
+t0 = time.time()
+gdb.execute("continue")
+dt = time.time() - t0
+thr = gdb.selected_thread()
+this = int(gdb.parse_and_eval("$rdi"))
+a1 = int(gdb.parse_and_eval("$esi")) & 0xffffffff
+a2 = int(gdb.parse_and_eval("$rdx"))
+a3 = int(gdb.parse_and_eval("$rcx"))
+a4 = int(gdb.parse_and_eval("$r8"))
+print("HIT PLP after %.4fs lwp=%d name=%s this=0x%x esi=0x%x rdx=0x%x rcx=0x%x r8=0x%x" %
+      (dt, thr.ptid[1], thr.name or "?", this, a1, a2, a3, a4))
+bp.delete()
+
+print("== loader `this` raw 0x000..0x240 ==")
+for base in range(0, 0x240, 0x20):
+    print("  +0x%03x: %s" % (base, " ".join(hx(rd(this + base + i)) for i in range(0, 0x20, 8))))
+print("counters: +0x1b0=%s +0x1b4=%s +0x5d0=%s +0x5d8=%s +0x800678=%s" % (
+    hx(rd(this + 0x1b0, 4)), hx(rd(this + 0x1b4, 4)), hx(rd(this + 0x5d0, 4)),
+    hx(rd(this + 0x5d8)), hx(rd(this + 0x800678, 4))))
+print("QueuedPackages num +0x58 =", hx(rd(this + 0x58, 4)))
+print("ExternalReadQueue +0x138 =", hx(rd(this + 0x138)), "->", hx(rd(rd(this + 0x138) or 0)))
+print("DeferredDeleteQ +0xa8 =", hx(rd(this + 0xa8)), "->", hx(rd(rd(this + 0xa8) or 0)))
+# LoadedPackagesToProcess-ish arrays seen in PLP: +0x78/+0x80 and +0x88/+0x90, +0xf0/+0xf8
+for off in (0x78, 0x88, 0xf0):
+    print("arr @+0x%x: data=%s num=%s" % (off, hx(rd(this + off)), hx(rd(this + off + 8, 4))))
+
+# AsyncPackageLookup at +0xd8 (zen layout). Verify plausibility first.
+slots = rd(this + 0xe0, 4) or 0
+free = rd(this + 0x10c, 4) or 0
+data = rd(this + 0xd8)
+print("pkg map: data=%s slots=%d free=%d" % (hx(data), slots, free))
+if data and 0 < slots < 50000:
+    states = {}
+    stuck = []
+    for i in range(slots):
+        e = data + 24 * i
+        pid = rd(e)
+        pkg = rd(e + 8)
+        if not pkg or pkg < 0x10000000 or pkg > 0x7000000000 or not pid or pid == 0xffffffffffffffff:
+            continue
+        st = rd(pkg + 0xe0, 1)
+        if st is None:
+            continue
+        states[st] = states.get(st, 0) + 1
+        if len(stuck) < 24:
+            stuck.append((pid, pkg, st))
+    print("state histogram:", {k: v for k, v in sorted(states.items())})
+    for pid, pkg, st in stuck:
+        print("  pkg=0x%x id=0x%016x st=%d | +0x160(size)=%s +0x16c(prio)=%s +0x140=%s +0x118(extN)=%s" % (
+            pkg, pid, st, hx(rd(pkg + 0x160)), hx(rd(pkg + 0x16c, 4)), hx(rd(pkg + 0x140, 4)),
+            hx(rd(pkg + 0x118, 4))))
+        print("    raw+0x00:", " ".join(hx(rd(pkg + o)) for o in range(0, 0x40, 8)))
+        print("    raw+0xc0:", " ".join(hx(rd(pkg + o)) for o in range(0xc0, 0x100, 8)))
+gdb.execute("detach")

--- a/prosper/tools/dbg/probe232y.py
+++ b/prosper/tools/dbg/probe232y.py
@@ -1,0 +1,40 @@
+# gdb -p PID -batch -x probe232y.py — issue #232: dump thread1's remaining stack (to the top
+# of its mapping) qword by qword; classify guest addresses.
+import gdb, struct
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def sym(v):
+    if 0x400000000 <= v < 0x406700000:
+        return "eboot+0x%x" % (v - 0x400000000)
+    if 0x600000000 <= v < 0x700000000:
+        return "stub+0x%x" % (v - 0x600000000)
+    return None
+
+for t in inf.threads():
+    if t.num == 1:
+        t.switch()
+        break
+pc = int(gdb.parse_and_eval("$pc")) & 0xffffffffffffffff
+sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+top = (sp + 0x1000) & ~0xfff
+print("thread1 pc=0x%x sp=0x%x top=0x%x" % (pc, sp, top))
+try:
+    mem = bytes(inf.read_memory(sp, top - sp))
+except gdb.error:
+    # fall back: byte at a time pages
+    mem = b""
+    a = sp
+    while a < top:
+        try:
+            mem += bytes(inf.read_memory(a, 8))
+        except gdb.error:
+            break
+        a += 8
+for off in range(0, len(mem) - 7, 8):
+    v = struct.unpack_from("<Q", mem, off)[0]
+    s = sym(v)
+    print("  sp+0x%03x: 0x%016x%s" % (off, v, (" " + s) if s else ""))
+gdb.execute("detach")

--- a/prosper/tools/dbg/probe232z.py
+++ b/prosper/tools/dbg/probe232z.py
@@ -1,0 +1,159 @@
+# gdb -p PID -batch -x probe232z.py — issue #232:
+# 1) read the parked FAsyncLoadingThread2 (ALT) thread's regs/stack to recover `this`,
+#    then dump async-loading counters + package-state histogram.
+# 2) sample the GameThread (thread 1) 40x for a guest-RA histogram of its tick phase.
+import gdb, struct, time, threading
+from collections import Counter
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n=8):
+    try:
+        return int.from_bytes(bytes(inf.read_memory(addr, n)), "little")
+    except gdb.error:
+        return None
+
+def hx(v):
+    return hex(v) if v is not None else "??"
+
+def sym(v):
+    if v is None:
+        return "??"
+    if 0x400000000 <= v < 0x406700000:
+        return "eboot+0x%x" % (v - 0x400000000)
+    if 0x600000000 <= v < 0x700000000:
+        return "stub+0x%x" % (v - 0x600000000)
+    return hex(v)
+
+# --- part 1: ALT thread ---
+alt = None
+for t in inf.threads():
+    if t.name and t.name.startswith("FAsyncLoading"):
+        alt = t
+        break
+cands = []
+if alt:
+    alt.switch()
+    print("ALT lwp=%d" % alt.ptid[1])
+    for r in ("rbx", "r12", "r13", "r14", "r15", "rbp", "rdi", "rsi"):
+        v = int(gdb.parse_and_eval("$" + r)) & 0xffffffffffffffff
+        print("  %s=0x%x" % (r, v))
+        if 0x10000000 < v < 0x7000000000:
+            cands.append(v)
+    sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+    try:
+        mem = bytes(inf.read_memory(sp, 2048))
+        ras = []
+        for off in range(0, len(mem) - 7, 8):
+            v = struct.unpack_from("<Q", mem, off)[0]
+            if 0x400000000 <= v < 0x406700000:
+                ras.append("sp+0x%x:%s" % (off, sym(v)))
+            elif 0x10000000 < v < 0x7000000000:
+                cands.append(v)
+        print("  ALT guest RAs:", " ".join(ras[:14]))
+    except gdb.error:
+        pass
+
+def plausible_loader(v):
+    # zen loader `this`: +0x1b0/+0x1b4 small counters, +0x58 small, +0xe0 slots>=0 small,
+    # +0x10c <= +0xe0, +0xd8 pointer-ish or 0, +0x800660 small (evq count), +0x5d0 small
+    c1 = rd(v + 0x1b0, 4); c2 = rd(v + 0x1b4, 4)
+    if c1 is None or c2 is None or c1 > 100000 or c2 > 100000:
+        return False
+    n = rd(v + 0x58, 4); slots = rd(v + 0xe0, 4); fr = rd(v + 0x10c, 4)
+    if n is None or slots is None or fr is None or n > 1000000 or slots > 1000000 or fr > slots:
+        return False
+    qn = rd(v + 0x800660, 4)
+    if qn is None or qn > 64:
+        return False
+    return True
+
+seen = set()
+loader = None
+for v in cands:
+    for base in (v, v - 0x10, v - 0x20):
+        if base in seen or base < 0:
+            continue
+        seen.add(base)
+        if plausible_loader(base):
+            loader = base
+            print("LOADER CANDIDATE this=0x%x (from 0x%x)" % (base, v))
+            break
+    if loader:
+        break
+
+if loader:
+    print("QueuedPackagesCounter +0x1b0 =", hx(rd(loader + 0x1b0, 4)))
+    print("ExistingAsyncPkgCtr   +0x1b4 =", hx(rd(loader + 0x1b4, 4)))
+    print("QueuedPackages.Num    +0x58  =", hx(rd(loader + 0x58, 4)))
+    print("pendingIoBytes        +0x5d8 =", hx(rd(loader + 0x5d8)))
+    print("heapNum               +0x5d0 =", hx(rd(loader + 0x5d0, 4)))
+    print("ExternalReadQueue     +0x138 =", hx(rd(loader + 0x138)), "->", hx(rd(rd(loader + 0x138) or 0)))
+    slots = rd(loader + 0xe0, 4) or 0
+    free = rd(loader + 0x10c, 4) or 0
+    data = rd(loader + 0xd8)
+    print("pkg map: data=%s slots=%d free=%d" % (hx(data), slots, free))
+    if data and 0 < slots < 50000:
+        states = Counter()
+        sample_pkgs = {}
+        for i in range(slots):
+            e = data + 24 * i
+            pid = rd(e)
+            pkg = rd(e + 8)
+            if not pkg or pkg < 0x10000000 or pkg > 0x7000000000 or not pid:
+                continue
+            st = rd(pkg + 0xe0, 1)
+            if st is None:
+                continue
+            states[st] += 1
+            if st not in sample_pkgs:
+                sample_pkgs[st] = (pid, pkg)
+        print("pkg state histogram:", dict(states))
+        for st, (pid, pkg) in sorted(sample_pkgs.items()):
+            print("  st=%d sample pkg=0x%x id=0x%016x" % (st, pkg, pid))
+else:
+    print("no loader candidate found")
+
+# --- part 2: GameThread RA histogram ---
+hist = Counter()
+for i in range(40):
+    for t in inf.threads():
+        if t.num == 1:
+            t.switch()
+            break
+    try:
+        pc = int(gdb.parse_and_eval("$pc")) & 0xffffffffffffffff
+        sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+        top = (sp + 0x1000) & ~0xfff
+        first = None
+        try:
+            mem = bytes(inf.read_memory(sp, min(top - sp, 1024)))
+            for off in range(0, len(mem) - 7, 8):
+                v = struct.unpack_from("<Q", mem, off)[0]
+                if 0x400000000 <= v < 0x406700000:
+                    first = v
+                    break
+        except gdb.error:
+            pass
+        if 0x400000000 <= pc < 0x406700000:
+            hist[("pc", pc & ~0x3f)] += 1
+        elif first:
+            hist[("ra", first)] += 1
+        else:
+            hist[("host", 0)] += 1
+    except gdb.error:
+        pass
+    def stopper():
+        time.sleep(0.05)
+        gdb.post_event(lambda: gdb.execute("interrupt"))
+    threading.Thread(target=stopper, daemon=True).start()
+    try:
+        gdb.execute("continue")
+    except gdb.error:
+        break
+print("GT sample histogram:")
+for (k, v), c in hist.most_common(12):
+    print("  %2d x %s %s" % (c, k, sym(v) if v else "-"))
+gdb.execute("detach")

--- a/prosper/tools/dbg/rostr.sh
+++ b/prosper/tools/dbg/rostr.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# rostr.sh <va_hex_eboot_relative>... — print eboot rodata strings (DOLL PPSA17942)
+for va in "$@"; do
+  off=$(( 0x66e04d0 + 0x$va - 0x669c000 ))
+  echo -n "va 0x$va: "
+  dd if=/root/PPSA17942-app0/eboot.bin bs=1 skip=$off count=160 status=none | tr "\0" "." | head -c 160
+  echo
+done

--- a/prosper/tools/dbg/run232safe.sh
+++ b/prosper/tools/dbg/run232safe.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Issue #232: does sceSystemServiceGetDisplaySafeAreaInfo=1.0 produce scene draws?
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+[ -f /root/pid232.txt ] && kill -9 "$(cat /root/pid232.txt)" 2>/dev/null
+sleep 1
+PID=
+for try in 1 2 3 4 5 6; do
+  setsid ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232safe.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+echo "$PID" > /root/pid232.txt
+for i in $(seq 1 10); do
+  f=$(grep -ac GpuFlip /root/d232safe.log)
+  d=$(grep -ac "kind=DrawIndex" /root/d232safe.log)
+  v=$(grep -a "draws: [1-9]" /root/d232safe.log | tail -1 | grep -oE "draws: [0-9]+")
+  echo "t+$((45+i*30)) flips=$f drawpkts=$d lastdraws='$v'"
+  sleep 30
+  kill -0 $PID 2>/dev/null || { echo DIED; break; }
+done
+echo "safe-area calls: $(grep -ac 'GetDisplaySafeArea\|1n37q1Bvc5Y' /root/d232safe.log)"
+kill -9 $PID 2>/dev/null
+echo RUN232SAFE-DONE

--- a/prosper/tools/dbg/run232u.sh
+++ b/prosper/tools/dbg/run232u.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Issue #232: boot to the FlushAsyncLoading stall, then probe FAsyncLoadingThread2 state.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+PID=
+for try in 1 2 3 4 5 6; do
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232u.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+# wait for the stall: reads frozen for 30 s and > 2000
+prev=-1
+for i in $(seq 1 12); do
+  cur=$(grep -ac "read-submit id" /root/d232u.log)
+  echo "t+$((45+i*30)) reads=$cur"
+  if [ "$cur" = "$prev" ] && [ "$cur" -gt 2000 ]; then echo STALLED; break; fi
+  prev=$cur
+  sleep 30
+  kill -0 $PID 2>/dev/null || { echo DIED-WAITING; exit 1; }
+done
+echo "$PID" > /root/pid232.txt
+timeout 180 gdb -p $PID -batch -x "$WT/tools/dbg/probe232u.py" 2>&1 \
+  | grep -v "^\[New\|libthread_db\|debuginfod\|Debuginfod\|warning:\|^\[Thread\|^Downloading" | tail -80
+kill -9 $PID 2>/dev/null
+echo RUN232U-DONE

--- a/prosper/tools/dbg/run232v.sh
+++ b/prosper/tools/dbg/run232v.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Issue #232: A/B — deny all .usm movie files; does DOLL advance past the (suspected)
+# opening-cutscene gate into real scene draws?
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
+export PROSPER_DENY_SUBSTR=.usm
+[ -f /root/pid232.txt ] && kill -9 "$(cat /root/pid232.txt)" 2>/dev/null
+sleep 1
+PID=
+for try in 1 2 3 4 5 6; do
+  setsid ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232v.log 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; exit 1; }
+echo "$PID" > /root/pid232.txt
+for i in $(seq 1 10); do
+  r=$(grep -ac "read-submit id" /root/d232v.log)
+  d=$(grep -ac "kind=DrawIndex" /root/d232v.log)
+  di=$(grep -ac "DrawIndexAuto" /root/d232v.log)
+  f=$(grep -ac GpuFlip /root/d232v.log)
+  dn=$(grep -ac "DENIED" /root/d232v.log)
+  v=$(grep -ac "draws: [1-9]" /root/d232v.log)
+  echo "t+$((45+i*30)) flips=$f reads=$r denied=$dn drawpkts=$d drawauto=$di drawsub=$v"
+  sleep 30
+  kill -0 $PID 2>/dev/null || { echo DIED; break; }
+done
+echo RUN232V-DONE


### PR DESCRIPTION
## `sceSystemServiceGetDisplaySafeAreaInfo` fills `ratio=1.0` (was success + unfilled out-struct) + #232 reframe/probes

Part of #232 (DOLL 0 scene draws). `sceSystemServiceGetDisplaySafeAreaInfo` (`1n37q1Bvc5Y`) was unimplemented — it returned **SUCCESS with the out-struct `{float ratio; u8[128]}` left unfilled**, so the guest read `ratio = 0.0` (a degenerate title-safe rect). Now fills `ratio = 1.0` per the shadPS4 contract — the same *success-with-unfilled-out-struct* bug class as several other service stubs. **Verified this is NOT the 0-draws gate** (draws still 0 after it), but it's a real correctness bug, so kept. Also adds a `PROSPER_DENY_SUBSTR=.usm` A/B knob (used to rule out the cutscene as the gate).

### The #232 reframe (docs + `tools/dbg/` probes)
Live RIP/CPU sampling overturned the earlier "stuck in FlushAsyncLoading" reading:
- **DOLL's GameThread TICKS** — a game-side frame-throttle loop (`eboot+0x5044c01`, `FEvent::Wait(1ms)`); a 163 s breakpoint on `ProcessAsyncLoading` never fired; the frame loop runs **58k+ stable flips**.
- **Async loading is fully DRAINED** (all `FAsyncLoadingThread` counters 0), not deadlocked.
- **0 draws is genuine:** full-boot packet histogram = **1,662,586 `DispatchDirect`, 0 `DrawIndex`** — pure compute.
- The wall: the game-level state machine at `eboot+0x5044740` polls `.data` bool gates (`0x9803460`/`0x9803470`) that never flip; `DollLevelPreloader`/`SaveLoadUpdate`/`DLCDataUpdate`/`ShareUpdate` idle on unimplemented `scePlayGo`/`sceSaveData`/`sceNpTrophy2`/`sceShare`. **That's the next work** (implement those contracts so the preloader runs).

### Verified
- **ctest 63/63**; Messenger render smoke unregressed (real draws `vcount=1044`, 0 faults) — shared `hle_service.cpp`/`hle_file.cpp` safe.
- (Also gitignores render `*.bmp`/`frame_*.png` dumps — no game imagery is ever committed.)
