### PR TITLE
fix(gpu): honor the game's S# sampler (filter + wrap) instead of a hardcoded LINEAR/clamp

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -245,6 +245,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                         }
                         fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = th;
+                        // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
+                        // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
+                        fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
+                        fr.addr_uvw[0] = r.addr_uvw[0]; fr.addr_uvw[1] = r.addr_uvw[1]; fr.addr_uvw[2] = r.addr_uvw[2];
                     } else {
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned
                         if (nb >= 4) {

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -233,6 +233,30 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                                      : (d.width * d.height * fi.bytes_per_block);
             r.sgpr_base     = user_sgpr_base + off;  // DIRECT provenance key (image_sample SRSRC SGPR)
             r.srt_offset    = 0xFFFFFFFFu;
+            // Paired sampler S# (sharp[2], same slot): decode its filter + wrap modes so the backend
+            // samples the way the game asked (point vs bilinear, wrap vs clamp), instead of a hardcoded
+            // LINEAR/clamp. 4-dword SQ_IMG_SAMP: WORD0 has CLAMP_X/Y/Z (bits [2:0]/[5:3]/[8:6]); WORD2
+            // has XY_MAG_FILTER [21:20], XY_MIN_FILTER [23:22], MIP_FILTER [27:26] (0 = point/nearest).
+            // Absent/garbage sampler -> keep the linear/clamp defaults. CONFIDENCE: HIGH (layout matches
+            // GCN/RDNA2 SQ_IMG_SAMP; verified against decoded raw dwords under PROSPER_GFXLOG).
+            if (const AgcShaderSharp* samps = ud->sharp_resource_offset[2]) {
+                if (slot < ud->sharp_resource_count[2] && !samps[slot].empty()) {
+                    uint32_t soff = samps[slot].offset_dw();
+                    if ((uint64_t)soff + 4 <= num_user_sgprs) {
+                        const uint32_t* sm = &user_sgprs[soff];
+                        r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
+                        r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
+                        r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;
+                        r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
+                        r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
+                        r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
+                        if (getenv("PROSPER_GFXLOG"))
+                            fprintf(stderr, "[s#] slot%u mag=%u min=%u mip=%u addr=%u,%u,%u | raw %08x %08x %08x %08x\n",
+                                    slot, r.mag_filter, r.min_filter, r.mip_filter,
+                                    r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2], sm[0], sm[1], sm[2], sm[3]);
+                    }
+                }
+            }
             table.resources.push_back(r);
         }
     }

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -91,6 +91,18 @@ struct ShaderResource {
     uint32_t      height            = 0;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;
+
+    // Sampler state decoded from the PAIRED S# (Texture only). The backend previously hardcoded a
+    // LINEAR + clamp-to-edge sampler for every texture, which blurs point-sampled content (pixel art
+    // gets an outline halo on every texel) and ignores the game's real wrap modes. Honoring the S#
+    // fixes that for pixel-art titles AND keeps linear-filtered art correct. Defaults preserve the old
+    // LINEAR/clamp behavior for any texture whose S# we cannot resolve.
+    //   mag/min/mip_filter: 0 = point/nearest, 1 = bilinear/linear (SQ_IMG_SAMP XY_*_FILTER / MIP_FILTER).
+    //   addr_uvw:           Gen5 SQ_TEX CLAMP enum per axis (0=wrap,1=mirror,2=clamp-last-texel,6/7=border).
+    uint32_t      mag_filter        = 1;
+    uint32_t      min_filter        = 1;
+    uint32_t      mip_filter        = 0;
+    uint32_t      addr_uvw[3]       = {2, 2, 2};
 };
 
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -61,6 +61,12 @@ struct FrameResource {
     std::vector<uint32_t> dwords;   // storage-buffer contents (empty -> a 1-dword zero buffer)
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
     uint32_t tw = 0, th = 0;
+    // Sampler state (Texture only). Defaults = LINEAR + clamp-to-edge — the harness's prior fixed
+    // sampler — so render tests that build FrameResources directly stay byte-identical. The live path
+    // fills these from the decoded S# (shader_resources.hpp). filter: 0=nearest, 1=linear; addr = Gen5
+    // SQ_TEX CLAMP enum (0=wrap, 1=mirror, 2=clamp-last-texel, 6/7=border).
+    uint32_t mag_filter = 1, min_filter = 1, mip_filter = 0;
+    uint32_t addr_uvw[3] = {2, 2, 2};
     bool is_texture() const { return tex_rgba != nullptr; }
 };
 
@@ -316,8 +322,23 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     tvci.image = v.timg[i]; tvci.viewType = VK_IMAGE_VIEW_TYPE_2D; tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
                     tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}; vkCreateImageView(dev, &tvci, nullptr, &v.tview[i]);
                     VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
-                    sci.magFilter = sci.minFilter = VK_FILTER_LINEAR; sci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-                    sci.addressModeU = sci.addressModeV = sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+                    // Honor the game's decoded S# (r.mag/min/mip_filter, r.addr_uvw) instead of a fixed
+                    // LINEAR/clamp sampler — point-sampled art (pixel-art titles) no longer gets a blurred
+                    // per-texel outline, and real wrap modes work. Gen5 CLAMP enum -> Vk address mode.
+                    auto vkflt  = [](uint32_t f){ return f ? VK_FILTER_LINEAR : VK_FILTER_NEAREST; };
+                    auto vkaddr = [](uint32_t c) -> VkSamplerAddressMode {
+                        switch (c) {
+                            case 0:  return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+                            case 1:  return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+                            case 6: case 7: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+                            default: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;   // 2,3,4,5: clamp-ish
+                        }
+                    };
+                    sci.magFilter = vkflt(r.mag_filter); sci.minFilter = vkflt(r.min_filter);
+                    sci.mipmapMode = r.mip_filter ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
+                    sci.addressModeU = vkaddr(r.addr_uvw[0]);
+                    sci.addressModeV = vkaddr(r.addr_uvw[1]);
+                    sci.addressModeW = vkaddr(r.addr_uvw[2]);
                     vkCreateSampler(dev, &sci, nullptr, &v.tsamp[i]);
                     VkDeviceSize tbytes = (VkDeviceSize)r.tw * r.th * 4;
                     VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;


### PR DESCRIPTION
## Problem
The texture path decoded the **T# image** descriptor but **ignored the paired S# sampler descriptor entirely** — every sampled texture got a fixed `VK_FILTER_LINEAR` + clamp-to-edge sampler. For point-sampled content (pixel-art titles like The Messenger) that blurs every texel, leaving a visible **outline/halo on every pixel**, and it ignores the game's real wrap modes.

## Fix
Decode the paired sampler (`sharp_resource_offset[2]`, same slot as the T#): `XY_MAG/MIN_FILTER` + `MIP_FILTER` (WORD2 `[21:20]/[23:22]/[27:26]`, `0=point/nearest`) and `CLAMP_X/Y/Z` (WORD0 `[2:0]/[5:3]/[8:6]`), and plumb it through `ShaderResource → FrameResource → VkSampler`.

Defaults preserve the prior LINEAR/clamp for any texture whose S# can't be resolved, so **render tests are byte-identical (68/68 green)**.

## Verified (The Messenger, `PROSPER_GFXLOG` `[s#]`)
Textures are a **mix**:
- **1935 draws** `mag=0 min=0` (nearest — pixel art) ← previously wrongly LINEAR (the title-screen "outline on every pixel")
- 686 draws `mag=1 min=1 addr=wrap` (linear gradients / tiled backgrounds — still correct)

Each is now sampled as the game asked. Raw-dword layout cross-checked against GCN/RDNA2 `SQ_IMG_SAMP`.

## Scope
This fixes the general "wrong texture filtering" class for **all** games (not a pixel-art hack). Fields still not decoded (border color, anisotropy, LOD, depth-compare, T# swizzle, sRGB) are filed as follow-up issues.