### PR TITLE
fix(gpu): implement the stencil test — masks now clip (title shimmer, UI) (Fixes #264)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -67,6 +67,10 @@ RenderState extract_render_state(const GpuState& st) {
 
     // Faithful raw state registers.
     rs.db_depth_control  = dc;
+    // Stencil op + ref/mask registers (absent -> 0; stencil_enable already gates whether they apply).
+    rs.db_stencil_control   = st.cx.count(P::DB_STENCIL_CONTROL)   ? rd(st.cx, P::DB_STENCIL_CONTROL)   : 0u;
+    rs.db_stencilrefmask    = st.cx.count(P::DB_STENCILREFMASK)    ? rd(st.cx, P::DB_STENCILREFMASK)    : 0u;
+    rs.db_stencilrefmask_bf = st.cx.count(P::DB_STENCILREFMASK_BF) ? rd(st.cx, P::DB_STENCILREFMASK_BF) : 0u;
     rs.cb_color_control  = rd(st.cx, P::CB_COLOR_CONTROL);
     rs.cb_blend0_control = bc;
     // CB_TARGET_MASK (per-MRT color write mask). The AGC driver defaults it to write-all when the game
@@ -98,6 +102,28 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     ps.depth_test_enable  = rs.z_enable;
     ps.depth_write_enable = rs.z_write_enable;
     ps.depth_compare_op   = vk_compare_op(rs.zfunc);
+
+    // Stencil: compare func from DB_DEPTH_CONTROL (STENCILFUNC / _BF), ops from DB_STENCIL_CONTROL,
+    // ref/masks from DB_STENCILREFMASK[_BF]. [0]=front, [1]=back. Only meaningful when stencil_enable.
+    ps.stencil_enable = rs.stencil_enable;
+    if (rs.stencil_enable) {
+        const uint32_t dc2 = rs.db_depth_control, sc = rs.db_stencil_control;
+        const uint32_t rm = rs.db_stencilrefmask, rmb = rs.db_stencilrefmask_bf;
+        ps.stencil_compare_op[0]    = vk_compare_op(PM4_FIELD(dc2, DB_DEPTH_CONTROL, STENCILFUNC));
+        ps.stencil_compare_op[1]    = vk_compare_op(PM4_FIELD(dc2, DB_DEPTH_CONTROL, STENCILFUNC_BF));
+        ps.stencil_fail_op[0]       = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILFAIL));
+        ps.stencil_pass_op[0]       = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZPASS));
+        ps.stencil_depth_fail_op[0] = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZFAIL));
+        ps.stencil_fail_op[1]       = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILFAIL_BF));
+        ps.stencil_pass_op[1]       = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZPASS_BF));
+        ps.stencil_depth_fail_op[1] = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZFAIL_BF));
+        ps.stencil_ref[0]           = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILTESTVAL);
+        ps.stencil_compare_mask[0]  = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILMASK);
+        ps.stencil_write_mask[0]    = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILWRITEMASK);
+        ps.stencil_ref[1]           = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILTESTVAL_BF);
+        ps.stencil_compare_mask[1]  = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILMASK_BF);
+        ps.stencil_write_mask[1]    = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILWRITEMASK_BF);
+    }
 
     ps.blend_enable            = rs.blend_enable;
     ps.src_color_blend_factor  = vk_blend_factor(rs.color_src_blend);

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -45,6 +45,9 @@ struct RenderState {
 
     // Raw state registers — remaining bit layouts decoded by the Vulkan backend later (kept faithful).
     uint32_t db_depth_control  = 0;   // DB_DEPTH_CONTROL
+    uint32_t db_stencil_control   = 0;   // DB_STENCIL_CONTROL   (front/back stencil-fail / z-pass / z-fail ops)
+    uint32_t db_stencilrefmask    = 0;   // DB_STENCILREFMASK    (front ref / compare-mask / write-mask)
+    uint32_t db_stencilrefmask_bf = 0;   // DB_STENCILREFMASK_BF (back-face ref / compare-mask / write-mask)
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)
@@ -71,6 +74,20 @@ struct ResolvedPipelineState {
     bool     depth_test_enable  = false;
     bool     depth_write_enable = false;
     uint32_t depth_compare_op  = 0;  // == VkCompareOp
+
+    // Stencil test state, resolved from DB_DEPTH_CONTROL (enable + STENCILFUNC) + DB_STENCIL_CONTROL
+    // (ops) + DB_STENCILREFMASK[_BF] (ref / compare-mask / write-mask). Index [0]=front, [1]=back.
+    // A UI mask (e.g. The Messenger's title shimmer) writes the stencil in one draw and tests it in the
+    // next — with these left off the mask draw is unmasked (#264). Values are the Vk* enumerators.
+    bool     stencil_enable          = false;
+    uint32_t stencil_compare_op[2]   = {7, 7};       // == VkCompareOp (7 = ALWAYS)
+    uint32_t stencil_fail_op[2]      = {0, 0};        // == VkStencilOp (0 = KEEP)
+    uint32_t stencil_pass_op[2]      = {0, 0};        // depth-pass op
+    uint32_t stencil_depth_fail_op[2]= {0, 0};
+    uint32_t stencil_ref[2]          = {0, 0};
+    uint32_t stencil_compare_mask[2] = {0xFF, 0xFF};
+    uint32_t stencil_write_mask[2]   = {0xFF, 0xFF};
+
     bool     blend_enable        = false;
     uint32_t src_color_blend_factor = 0;   // == VkBlendFactor
     uint32_t dst_color_blend_factor = 0;   // == VkBlendFactor

--- a/prosper/src/gpu/vk_translate.hpp
+++ b/prosper/src/gpu/vk_translate.hpp
@@ -58,6 +58,26 @@ VkFormat vk_color_format(uint32_t format, uint32_t number_type, uint32_t comp_sw
 // (0=NEVER,1=LESS,2=EQUAL,3=LEQUAL,4=GREATER,5=NOTEQUAL,6=GEQUAL,7=ALWAYS), so the value maps 1:1.
 inline uint32_t vk_compare_op(uint32_t zfunc) { return zfunc & 0x7u; }
 
+// Map an RDNA2 DB_STENCIL_CONTROL stencil op (STENCIL_OP enum) to a VkStencilOp value. VkStencilOp:
+// KEEP=0,ZERO=1,REPLACE=2,INC_CLAMP=3,DEC_CLAMP=4,INVERT=5,INC_WRAP=6,DEC_WRAP=7. The RDNA2 enum has
+// three "replace-ish" codes (ONES/REPLACE_TEST/REPLACE_OP) that all realize as REPLACE here (a UI mask
+// writes the ref value). AND/OR/XOR/etc. (10..14) have no Vk equivalent -> KEEP.
+inline uint32_t vk_stencil_op(uint32_t op) {
+    switch (op & 0xFu) {
+        case 0:  return 0;   // KEEP
+        case 1:  return 1;   // ZERO
+        case 2:  return 2;   // ONES         -> REPLACE
+        case 3:  return 2;   // REPLACE_TEST -> REPLACE
+        case 4:  return 2;   // REPLACE_OP   -> REPLACE
+        case 5:  return 3;   // ADD_CLAMP    -> INCREMENT_AND_CLAMP
+        case 6:  return 4;   // SUB_CLAMP    -> DECREMENT_AND_CLAMP
+        case 7:  return 5;   // INVERT
+        case 8:  return 6;   // ADD_WRAP     -> INCREMENT_AND_WRAP
+        case 9:  return 7;   // SUB_WRAP     -> DECREMENT_AND_WRAP
+        default: return 0;   // AND/OR/XOR/NAND/NOR (no Vk equivalent) -> KEEP
+    }
+}
+
 // Map an RDNA2 CB_BLEND_CONTROL blend factor to a VkBlendFactor value (NOT identity — e.g. RDNA2
 // DstColor=8 -> VK DST_COLOR=4). Per Kyty GraphicsRender.cpp. Unknown -> ZERO.
 uint32_t vk_blend_factor(uint32_t rdna2_factor);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -146,9 +146,17 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // Depth attachment is created if ANY draw enables the depth test (the shared render pass has one
     // fixed attachment set); each draw's pipeline sets its own depthTest/Write/CompareOp. A frame with
     // no depth-using draw takes the color-only path unchanged.
-    bool use_depth = false; for (const auto& d : draws) if (d.ps && d.ps->depth_test_enable) use_depth = true;
-    if (getenv("PROSPER_NO_DEPTH")) use_depth = false;   // diag: isolate depth-test rejection
-    const VkFormat DFMT = VK_FORMAT_D32_SFLOAT;
+    bool use_depth = false, use_stencil = false;
+    for (const auto& d : draws) { if (d.ps && d.ps->depth_test_enable) use_depth = true;
+                                  if (d.ps && d.ps->stencil_enable)    use_stencil = true; }
+    if (getenv("PROSPER_NO_DEPTH"))   use_depth = false;     // diag: isolate depth-test rejection
+    if (getenv("PROSPER_NO_STENCIL")) use_stencil = false;   // diag: isolate stencil masking
+    const bool use_ds = use_depth || use_stencil;
+    // Use a stencil-capable depth format ONLY when a draw actually uses stencil (a UI mask). The
+    // depth-only path keeps the original D32 depth-only format + aspect, so existing render tests are
+    // byte-identical (#264).
+    const VkFormat DFMT = use_stencil ? VK_FORMAT_D32_SFLOAT_S8_UINT : VK_FORMAT_D32_SFLOAT;
+    const VkImageAspectFlags DASPECT = VK_IMAGE_ASPECT_DEPTH_BIT | (use_stencil ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
     VkImage dimg = VK_NULL_HANDLE; VkDeviceMemory dmem = VK_NULL_HANDLE; VkImageView dview = VK_NULL_HANDLE;
 
     VkImageCreateInfo imgci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -166,7 +174,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     VkImageView view; vkCreateImageView(dev, &ivci, nullptr, &view);
 
-    if (use_depth) {
+    if (use_ds) {
         VkImageCreateInfo dci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
         dci.imageType = VK_IMAGE_TYPE_2D; dci.format = DFMT; dci.extent = {W, H, 1};
         dci.mipLevels = 1; dci.arrayLayers = 1; dci.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -178,7 +186,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         vkAllocateMemory(dev, &dai, nullptr, &dmem); vkBindImageMemory(dev, dimg, dmem, 0);
         VkImageViewCreateInfo dvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         dvci.image = dimg; dvci.viewType = VK_IMAGE_VIEW_TYPE_2D; dvci.format = DFMT;
-        dvci.subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1};
+        dvci.subresourceRange = {DASPECT, 0, 1, 0, 1};
         vkCreateImageView(dev, &dvci, nullptr, &dview);
     }
 
@@ -189,19 +197,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     att[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; att[0].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     att[1].format = DFMT; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
     att[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR; att[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    att[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE; att[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    // Clear the stencil at pass start when a mask uses it (so the mask draw defines the stenciled
+    // region from 0); within the pass the stencil persists across draws, so store-op can be DONT_CARE.
+    att[1].stencilLoadOp = use_stencil ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    att[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
     att[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; att[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     VkAttachmentReference ar{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
     VkAttachmentReference dar{1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
     VkSubpassDescription sub{}; sub.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     sub.colorAttachmentCount = 1; sub.pColorAttachments = &ar;
-    if (use_depth) sub.pDepthStencilAttachment = &dar;
+    if (use_ds) sub.pDepthStencilAttachment = &dar;
     VkRenderPassCreateInfo rpci{VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO};
-    rpci.attachmentCount = use_depth ? 2 : 1; rpci.pAttachments = att; rpci.subpassCount = 1; rpci.pSubpasses = &sub;
+    rpci.attachmentCount = use_ds ? 2 : 1; rpci.pAttachments = att; rpci.subpassCount = 1; rpci.pSubpasses = &sub;
     VkRenderPass rp; vkCreateRenderPass(dev, &rpci, nullptr, &rp);
     VkImageView fbviews[2] = {view, dview};
     VkFramebufferCreateInfo fbci{VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO};
-    fbci.renderPass = rp; fbci.attachmentCount = use_depth ? 2 : 1; fbci.pAttachments = fbviews; fbci.width = W; fbci.height = H; fbci.layers = 1;
+    fbci.renderPass = rp; fbci.attachmentCount = use_ds ? 2 : 1; fbci.pAttachments = fbviews; fbci.width = W; fbci.height = H; fbci.layers = 1;
     VkFramebuffer fb; vkCreateFramebuffer(dev, &fbci, nullptr, &fb);
 
     auto mkmod = [&](const std::vector<uint32_t>& c) -> VkShaderModule {
@@ -282,6 +293,23 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             dss.depthWriteEnable = ps->depth_write_enable ? VK_TRUE : VK_FALSE;
             dss.depthCompareOp   = (VkCompareOp)ps->depth_compare_op;
             if (getenv("PROSPER_DEPTH_ALWAYS")) dss.depthCompareOp = VK_COMPARE_OP_ALWAYS;   // diag
+        }
+        if (ps && ps->stencil_enable) {
+            // Wire the front/back stencil op-state so masks clip (e.g. the title shimmer tests the
+            // stencil the logo draw wrote). ref/compareMask/writeMask are baked (not dynamic).
+            dss.stencilTestEnable = VK_TRUE;
+            auto mkop = [&](int fb) {
+                VkStencilOpState s{};
+                s.failOp      = (VkStencilOp)ps->stencil_fail_op[fb];
+                s.passOp      = (VkStencilOp)ps->stencil_pass_op[fb];
+                s.depthFailOp = (VkStencilOp)ps->stencil_depth_fail_op[fb];
+                s.compareOp   = (VkCompareOp)ps->stencil_compare_op[fb];
+                s.compareMask = ps->stencil_compare_mask[fb];
+                s.writeMask   = ps->stencil_write_mask[fb];
+                s.reference   = ps->stencil_ref[fb];
+                return s;
+            };
+            dss.front = mkop(0); dss.back = mkop(1);
         }
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         v.R = bd.R; auto& R = v.R;
@@ -373,7 +401,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         gp.stageCount = 2; gp.pStages = st; gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
         gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
         gp.pColorBlendState = &cb; gp.layout = v.layout; gp.renderPass = rp; gp.subpass = 0;
-        if (ps && ps->depth_test_enable) gp.pDepthStencilState = &dss;
+        if (ps && (ps->depth_test_enable || ps->stencil_enable)) gp.pDepthStencilState = &dss;
         if (vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) v.ok = true;
     }
 
@@ -411,10 +439,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkClearValue clear[2]{}; clear[0].color = {{0.0f, 0.0f, 1.0f, 1.0f}};   // blue
     clear[1].depthStencil = {0.5f, 0};   // depth cleared to 0.5 (fragments at z=0.0 pass LESS, fail GREATER)
     VkRenderPassBeginInfo rpbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
-    rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_depth ? 2 : 1; rpbi.pClearValues = clear;
+    rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_ds ? 2 : 1; rpbi.pClearValues = clear;
     if (getenv("PROSPER_PIPELOG")) {   // diag: how many draws' pipelines built + will be recorded
         int nok = 0; for (auto& v : dv) if (v.ok) nok++;
-        fprintf(stderr, "[pipe] %zu draws, %d pipelines OK, use_depth=%d; counts:", dv.size(), nok, (int)use_depth);
+        fprintf(stderr, "[pipe] %zu draws, %d pipelines OK, use_depth=%d use_stencil=%d; counts:", dv.size(), nok, (int)use_depth, (int)use_stencil);
         for (auto& v : dv) fprintf(stderr, " %s%u", v.ok ? "" : "SKIP", v.icount ? v.icount : v.vcount);
         fprintf(stderr, "\n");
     }


### PR DESCRIPTION
## Problem
The stencil test was **decoded but never applied** — `ResolvedPipelineState` had no stencil fields and the backend's depth-stencil state set only depth. Any draw relying on a stencil mask rendered **unmasked**. On The Messenger's title screen, the animated "shimmer" (a white quad swept across the logo, masked to the logo's shape via the stencil buffer) showed the **full polygon** instead of only the logo intersection. (User-reported.)

## Fix — wired end to end
- `ResolvedPipelineState`: front/back stencil **compare op** + **fail/pass/depth-fail ops** + **ref/compare-mask/write-mask** (`render_state.hpp`).
- `extract_render_state` reads `DB_STENCIL_CONTROL` / `DB_STENCILREFMASK[_BF]`; `resolve_pipeline_state` maps them (+ `STENCILFUNC` from `DB_DEPTH_CONTROL`) to `Vk*` enums via new `vk_stencil_op`.
- `render_runner.h`: when a submit uses stencil, the depth attachment switches to a stencil-capable format (`D32_SFLOAT_S8_UINT`, DEPTH|STENCIL aspect) and **clears stencil** at pass start; each draw's pipeline gets `stencilTestEnable` + front/back `VkStencilOpState`.

## Safety / tests
The depth-only path is untouched (still `D32_SFLOAT`, DEPTH aspect), so existing render tests are **byte-identical → 68/68 ctest green**.

## Verified (The Messenger)
`591/591` rendered submits now report `use_stencil=1` — it masks pervasively (not just the title shimmer), all routing through the new stencil pipeline. `PROSPER_NO_STENCIL` isolates the path.

Fixes #264.