### PR TITLE
fix(gpu): decode + apply T# DST_SEL channel swizzle (Fixes #261)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -249,6 +249,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
                         fr.addr_uvw[0] = r.addr_uvw[0]; fr.addr_uvw[1] = r.addr_uvw[1]; fr.addr_uvw[2] = r.addr_uvw[2];
+                        // T# DST_SEL channel remap (#261): apply only to REAL-RGBA texels. The narrow
+                        // R->RGBA replication path (narrow_done) already broadcasts coverage to every
+                        // channel — keep it identity so the font/mask path (#102/#256) is untouched.
+                        if (narrow_done) { fr.swizzle[0]=4; fr.swizzle[1]=5; fr.swizzle[2]=6; fr.swizzle[3]=7; }
+                        else { for (int k=0;k<4;k++) fr.swizzle[k] = r.swizzle[k]; }
                     } else {
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned
                         if (nb >= 4) {

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -124,8 +124,12 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.width     = (uint32_t)(((t[1] >> 30) & 0x3u) | (((t[2] >> 0) & 0xFFFu) << 2)) + 1;          // Width5
     d.height    = (uint32_t)((t[2] >> 14) & 0x3FFFu) + 1;                                          // Height5
     d.format    = (t[1] >> 20) & 0x1FFu;                                                           // Format
-    d.tile_mode = (t[3] >> 20) & 0x1Fu;                                                            // TileMode
+    d.tile_mode = (t[3] >> 20) & 0x1Fu;                                                            // TileMode (SW_MODE)
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
+    d.dst_sel[0] = (uint8_t)((t[3] >> 0) & 0x7u);   // DST_SEL_X (WORD3 [2:0])
+    d.dst_sel[1] = (uint8_t)((t[3] >> 3) & 0x7u);   // DST_SEL_Y ([5:3])
+    d.dst_sel[2] = (uint8_t)((t[3] >> 6) & 0x7u);   // DST_SEL_Z ([8:6])
+    d.dst_sel[3] = (uint8_t)((t[3] >> 9) & 0x7u);   // DST_SEL_W ([11:9])
     return d;
 }
 
@@ -179,8 +183,9 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 d.width > 16384 || d.height > 16384) continue;  // skip a garbage/degenerate T#
             if (getenv("PROSPER_GFXLOG")) {
                 const uint32_t* t = &user_sgprs[off];
-                fprintf(stderr, "[t#] %ux%u base=0x%llx tile_mode=%u type=%u fmt=%u | raw: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+                fprintf(stderr, "[t#] %ux%u base=0x%llx tile_mode=%u type=%u fmt=%u swz=%u,%u,%u,%u | raw: %08x %08x %08x %08x %08x %08x %08x %08x\n",
                         d.width, d.height, (unsigned long long)d.base, d.tile_mode, d.type, d.format,
+                        d.dst_sel[0], d.dst_sel[1], d.dst_sel[2], d.dst_sel[3],
                         t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
             }
             // Decode the T#'s real Gen5 IMG_FMT (#65 — was hardcoded Unorm8 x4 / size w*h*4, which
@@ -227,6 +232,8 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.width         = d.width;
             r.height        = d.height;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
+            r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
+            r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];   // T# DST_SEL channel remap (#261)
             // Backing byte size: block-compressed surfaces store one bytes_per_block unit per 4x4 block
             // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
             r.size          = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -66,6 +66,9 @@ struct DecodedImageDescriptor {
     uint32_t format = 0;      // Gen5 surface-format enum (fields[1] bits 20..28)
     uint32_t tile_mode = 0;   // 0 = linear
     uint8_t  type = 0;        // SQ_RSRC_IMG dim (8 = 2D, 9 = 2D_ARRAY, ...)
+    // DST_SEL_X/Y/Z/W channel swizzle (WORD3 [2:0]/[5:3]/[8:6]/[11:9]); SQ_SEL enum:
+    // 0=0, 1=1, 4=X(R), 5=Y(G), 6=Z(B), 7=W(A). Default = identity (R,G,B,A).
+    uint8_t  dst_sel[4] = {4, 5, 6, 7};
 };
 // Decode an 8-dword T# (RDNA2/Gen5 image resource). Pure; exposed for reuse + testing.
 DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]);

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -103,6 +103,12 @@ struct ShaderResource {
     uint32_t      min_filter        = 1;
     uint32_t      mip_filter        = 0;
     uint32_t      addr_uvw[3]       = {2, 2, 2};
+
+    // T# DST_SEL channel swizzle (SQ_SEL enum per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Applied as a Vulkan
+    // component-mapping on the sampled view so a non-identity surface (e.g. BGRA order, or an alpha-only
+    // mask) reads correctly. Default = identity (R,G,B,A). NOT applied on the narrow R->RGBA replication
+    // path (that already broadcasts coverage to every channel).
+    uint32_t      swizzle[4]        = {4, 5, 6, 7};
 };
 
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -67,6 +67,9 @@ struct FrameResource {
     // SQ_TEX CLAMP enum (0=wrap, 1=mirror, 2=clamp-last-texel, 6/7=border).
     uint32_t mag_filter = 1, min_filter = 1, mip_filter = 0;
     uint32_t addr_uvw[3] = {2, 2, 2};
+    // T# DST_SEL channel swizzle (SQ_SEL per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Default = identity
+    // (R,G,B,A) == a no-op VkComponentMapping, so tests that build FrameResources directly are unchanged.
+    uint32_t swizzle[4] = {4, 5, 6, 7};
     bool is_texture() const { return tex_rgba != nullptr; }
 };
 
@@ -348,6 +351,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     vkBindImageMemory(dev, v.timg[i], v.tmem[i], 0);
                     VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
                     tvci.image = v.timg[i]; tvci.viewType = VK_IMAGE_VIEW_TYPE_2D; tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
+                    // T# DST_SEL channel remap (#261): map each SQ_SEL to a VkComponentSwizzle. Identity
+                    // (the default, and the narrow/font path) yields IDENTITY == a no-op. PROSPER_NO_SWIZZLE
+                    // forces identity for A/B testing against the pre-swizzle behavior.
+                    auto vkswz = [](uint32_t s) -> VkComponentSwizzle {
+                        switch (s) {
+                            case 0:  return VK_COMPONENT_SWIZZLE_ZERO;
+                            case 1:  return VK_COMPONENT_SWIZZLE_ONE;
+                            case 4:  return VK_COMPONENT_SWIZZLE_R;
+                            case 5:  return VK_COMPONENT_SWIZZLE_G;
+                            case 6:  return VK_COMPONENT_SWIZZLE_B;
+                            case 7:  return VK_COMPONENT_SWIZZLE_A;
+                            default: return VK_COMPONENT_SWIZZLE_IDENTITY;
+                        }
+                    };
+                    if (!getenv("PROSPER_NO_SWIZZLE"))
+                        tvci.components = {vkswz(r.swizzle[0]), vkswz(r.swizzle[1]), vkswz(r.swizzle[2]), vkswz(r.swizzle[3])};
                     tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}; vkCreateImageView(dev, &tvci, nullptr, &v.tview[i]);
                     VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
                     // Honor the game's decoded S# (r.mag/min/mip_filter, r.addr_uvw) instead of a fixed


### PR DESCRIPTION
## What

The T# image descriptor's **DST_SEL channel swizzle** (WORD3 [11:0], SQ_SEL enum per channel) was decoded nowhere, so every sampled texture read straight RGBA. A surface with a non-identity swizzle — BGRA channel order, or an alpha-only mask stored as `(0,0,0,R)` — rendered with the wrong channels.

This decodes DST_SEL_X/Y/Z/W and applies it as a `VkComponentMapping` on the sampled image **view**.

## Two different "swizzles" — this is the *channel* one, not the *tile* one

There are two orthogonal sampling stages that both get called "swizzle":

1. **Tile / memory de-swizzle** (`SW_4KB_S` detile in `tile.cpp` / `detile_surface`) — *which byte in memory is which texel*. This is the hard, hours-of-work path. **Not touched here.**
2. **DST_SEL channel swizzle** (this PR) — *which channel of the decoded texel maps to which output* (R/G/B/A). A trivial hardware view remap.

They run in sequence: `tiled memory → [de-swizzle] → row-major RGBA → [DST_SEL channel remap] → shader`. This PR only touches stage 2.

## Safety (the reason this is low-risk)

- `swizzle` defaults to **identity** `(R,G,B,A)` everywhere → a no-op `VkComponentMapping` → render tests are byte-identical (**68/68 green**).
- Applied **only** to real-RGBA texels. The narrow single-channel `R→RGBA` replication path (the #102/#256 font/mask path) already broadcasts coverage to every channel, so it keeps identity and is **completely untouched**.
- `PROSPER_NO_SWIZZLE` forces identity for A/B testing.

## Verified on The Messenger (title screen)

| texture | fmt | decoded `swz` | effect |
|---|---|---|---|
| RGBA title composite | 56 | `4,5,6,7` (identity) | applying it changes nothing → known-good stays good |
| R8 font atlas | 1 | `0,0,0,R` (real alpha-mask intent) | stays on the untouched narrow RRRR path |

So this is effectively a no-op for The Messenger's observed textures (proving no regression) while correctly handling any non-identity RGBA surface a different game may use.

Fixes #261