### PR TITLE
fix(gpu): implement DOLL's Gen5 indexed-draw builders — first UE4 scene geometry renders (Fixes #232)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ compile_commands.json
 .DS_Store
 Thumbs.db
 
-# Rendered screenshot artifacts (viewable locally, not committed)
+# Rendered screenshot artifacts (viewable locally, NEVER committed — game imagery). The renderer can
+# drop frame_*.bmp/.png into whatever cwd it runs from, including the repo root, so cover it here too.
 prosper/screenshots/
 *.spv
+*.bmp
+frame_*.png

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -1105,3 +1105,38 @@ Verification: ctest **63/63**; services RE'd from PS5 stub tables + guest disasm
 save flow verified end-to-end via PROSPER_SVCLOG + on-disk save files. Probes added:
 run232svc.sh, mount232.{gdb,sh}, soak232.sh, state232.py, runstate232.sh, gates232.py. New knob
 PROSPER_SVCLOG=1 (arg + page-guarded hexdump of the service family). Messenger smoke: see PR.
+
+### SOLVED (2026-07-10, issue #232): DOLL's scene geometry was dropped at THREE unimplemented Gen5 AGC draw builders — implementing them makes DOLL render its first scene geometry (up to 94 draws/submit; frames present)
+
+**The 6-session "the game never emits geometry / 0 DrawIndex" wall was a MISDIAGNOSIS.** DOLL's UE4 RHI
+submits ALL scene geometry through the Gen5 indexed-draw builder trio, every one of which was an
+`unimplemented -> 0` stub that appended **no packet** — so every draw was silently dropped *inside the
+HLE boundary*, before it ever reached the PM4 stream the histogram counts. That is why the histogram
+showed 0 DrawIndex despite the game running deep: the draws were destroyed one call below where anyone
+was looking. The trio (NIDs verified against `../PS5-3.20_Libs`; live-call counts via `dump_call_log`):
+
+- **`l4fM9K-Lyks` = sceAgcDcbSetIndexBuffer** — 5.46M calls/run
+- **`8N2tmT3jmC8` = sceAgcDcbSetIndexCount** — 5.46M calls/run
+- **`B+aG9DUnTKA` = sceAgcDcbDrawIndexOffset** — 5.46M calls/run
+
+**ABI RE'd from live capture (`PROSPER_GFXLOG` dumps a0..a3):**
+`setIndexBuffer(dcb, indexAddr=0x201d7c0000)`; `setIndexCount(dcb, 0xc350=50000)` (the index-buffer
+CAPACITY, not the per-draw count); `drawIndexOffset(dcb, startIndex, indexCount, modifier=0x40000000)`
+— the per-draw index count is arg2 (observed 3, 6, 0x24, 0xfa8, 0x2490, …), the start offset arg1.
+
+**Fix (correctness-first, CONFIDENCE MED on arg roles):** three new PM4 sub-ops (R_INDEX_BASE 0x1b /
+R_INDEX_COUNT 0x1c / R_DRAW_INDEX_OFFSET 0x1d, hle_agc.cpp), decoded (pm4_decode) into new Kinds
+`SetIndexBase`/`SetIndexCount`/`DrawIndexOffset`, and threaded through `GpuState` (new `index_base` /
+`index_num`) so DrawIndexOffset emits an indexed `Draw` (index_addr = base + offset·elemsize,
+index_count = arg2 or the bound count). Index element size comes from the existing SetIndexType snapshot.
+
+**Result (DOLL, live): first scene geometry renders.** 977+ DrawIndexOffset packets/steady-state,
+**up to 94 indexed draws per submit**, and with `PROSPER_RENDER=1` the executor resolves DOLL's real
+dynamic vertex-fetch descriptors (base=0x200a070000, **stride=40, num_records=50000** — real UE4 scene
+vertex streams) and **presents frames** before the synchronous-llvmpipe/GC stop-the-world tension ends
+the run (the documented render-vs-runtime cost, not a new bug). Some DOLL shaders still fail recompile
+(`skip draw: recompile failed`, unsupported RDNA2 ops) — that is the recompiler frontier, downstream of
+this fix, and is the next wall. **Messenger UNREGRESSED** (mandatory — shared GPU code): reaches its
+real scene (vcount=1044, 643×), 1015 frames presented, **0 faults**, 0 DrawIndexOffset (never uses the
+new path — the change is purely additive for it). ctest **63/63**. Probes added: flow232{,b,c}.py,
+thr232.py, frame232.sh, findstr232.sh, rostr2.sh, got232.sh, call232.sh, xref232.sh, smoke_msg232.sh.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -145,6 +145,33 @@ void GpuState::apply(const Pm4Command& c) {
             index_type = c.index_size;
             state_dirty_ = true;
             break;
+        case K::SetIndexBase:
+            index_base = c.ib_addr;   // bind index-buffer base (issue #232)
+            break;
+        case K::SetIndexCount:
+            index_num = c.index_count;   // bind index count (issue #232)
+            break;
+        case K::DrawIndexOffset: {
+            // Gen5 indexed draw (issue #232). Uses the bound index base + count; DrawIndexOffset's own
+            // count (c.index_count) overrides the SetIndexCount state when non-zero. The element size is
+            // the current SetIndexType (0=16-bit, 1=32-bit), captured in the per-draw snapshot.
+            if (state_dirty_ || !last_snapshot_) {
+                auto snap = std::make_shared<GpuState>();
+                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+                last_snapshot_ = std::move(snap);
+                state_dirty_ = false;
+            }
+            uint32_t elem = index_type ? 4u : 2u;
+            Draw d;
+            d.index_count = c.index_count ? c.index_count : index_num;
+            d.state = last_snapshot_;
+            if (index_base && d.index_count) {
+                d.indexed = true;
+                d.index_addr = index_base + (uint64_t)c.index_offset * elem;
+            }
+            draws.push_back(std::move(d));
+            break;
+        }
         case K::DrawIndexAuto:
         case K::DrawIndex: {
             // Snapshot the register state AT THE DRAW (shared with consecutive draws until a register

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -24,6 +24,11 @@ struct ShaderReg { uint32_t offset; uint32_t value; };
 struct GpuState {
     std::unordered_map<uint32_t, uint32_t> cx, sh, uc;   // register files by offset
     uint32_t index_type = 0;                             // last SetIndexType
+    // Gen5 indexed-draw binding state (issue #232, DOLL/UE4 geometry). SetIndexBuffer/SetIndexCount
+    // set these; DrawIndexOffset consumes them to emit an indexed Draw. Persist across draws within a
+    // submit (as on hardware) until re-set.
+    uint64_t index_base = 0;                             // last SetIndexBuffer address
+    uint32_t index_num  = 0;                             // last SetIndexCount
     // A draw + the register state AT THE DRAW. A submit changes shaders/mask/blend between its draws,
     // so the state a draw actually uses is the register values when its packet executes — NOT the
     // end-of-submit fold. `state` is a snapshot captured at the draw (shared between consecutive draws

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -117,6 +117,24 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     if (npl >= 3) { c.tg_x = pl[0]; c.tg_y = pl[1]; c.tg_z = pl[2]; }
                     if (npl >= 5) c.dispatch_modifier = (uint64_t)pl[3] | ((uint64_t)pl[4] << 32);
                     break;
+                case R_INDEX_BASE:
+                    // sceAgcDcbSetIndexBuffer -> bind the index buffer base address. payload: [0..1]=addr.
+                    c.kind = K::SetIndexBase;
+                    if (npl >= 2) c.ib_addr = lo_hi(pl);
+                    break;
+                case R_INDEX_COUNT:
+                    // sceAgcDcbSetIndexCount -> set the bound index count. payload: [0]=count.
+                    c.kind = K::SetIndexCount;
+                    if (npl >= 1) c.index_count = pl[0];
+                    break;
+                case R_DRAW_INDEX_OFFSET:
+                    // sceAgcDcbDrawIndexOffset -> indexed draw from a start offset using the bound
+                    // index base + count. payload: [0]=start-index offset, [1]=explicit index count
+                    // (0 => use the SetIndexCount state, threaded in by GpuState::apply).
+                    c.kind = K::DrawIndexOffset;
+                    if (npl >= 1) c.index_offset = pl[0];
+                    if (npl >= 2) c.index_count  = pl[1];
+                    break;
                 case R_CX_REGS_INDIRECT:
                 case R_SH_REGS_INDIRECT:
                 case R_UC_REGS_INDIRECT:

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -23,7 +23,12 @@ enum : uint32_t {
     R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
     R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
     R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
-    R_RELEASE_MEM = 0x18, R_DISPATCH_DIRECT = 0x1a, R_NUM = 0x40,
+    R_RELEASE_MEM = 0x18, R_DISPATCH_DIRECT = 0x1a,
+    // Gen5 indexed-draw state + draw (issue #232, DOLL/UE4 geometry path). These three builders
+    // (sceAgcDcbSetIndexBuffer / SetIndexCount / DrawIndexOffset) are the ONLY draw path UE4 uses;
+    // they were unimplemented->0 (no packet appended) so every scene draw was silently dropped.
+    R_INDEX_BASE = 0x1b, R_INDEX_COUNT = 0x1c, R_DRAW_INDEX_OFFSET = 0x1d,
+    R_NUM = 0x40,
 };
 
 // The register set a Set*RegistersIndirect packet targets.
@@ -36,7 +41,7 @@ struct Pm4Command {
     enum class Kind {
         DrawReset, WaitFlipDone, SetShRegDirect, SetRegsIndirect, SetIndexType,
         DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
-        DispatchDirect, Unknown,
+        DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Unknown,
     } kind = Kind::Unknown;
 
     uint32_t        header = 0;
@@ -69,6 +74,13 @@ struct Pm4Command {
     uint64_t di_index_addr = 0;          // DrawIndex: guest address of the index buffer
     uint64_t di_modifier = 0;            // DrawIndex: raw 64-bit draw-modifier bits
     bool     di_valid = false;           // DrawIndex: payload was long enough to carry addr+modifier
+
+    // Gen5 indexed-draw state (issue #232). SetIndexBase: [0..1]=index buffer addr lo/hi.
+    // SetIndexCount: [0]=index count. DrawIndexOffset: [0]=start-index offset, [1]=draw index count
+    // (0 => use the SetIndexCount state). These carry no register state; GpuState::apply threads the
+    // bound base+count through to the emitted draw.
+    uint64_t ib_addr = 0;                // SetIndexBase: index buffer guest address
+    uint32_t index_offset = 0;           // DrawIndexOffset: first index (start location)
     uint32_t event_type = 0;             // EventWrite
     uint64_t event_addr = 0;             // EventWrite: destination address (0 = address-less sync event) (#132)
     uint32_t sh_reg_offset = 0, sh_reg_value = 0;  // SetShRegDirect (sh_reg_value = first value)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -37,7 +37,8 @@ constexpr uint32_t IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46, I
 constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
                    R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
                    R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
-                   R_RELEASE_MEM = 0x18, R_DMA_DATA = 0x19, R_DISPATCH_DIRECT = 0x1a;
+                   R_RELEASE_MEM = 0x18, R_DMA_DATA = 0x19, R_DISPATCH_DIRECT = 0x1a,
+                   R_INDEX_BASE = 0x1b, R_INDEX_COUNT = 0x1c, R_DRAW_INDEX_OFFSET = 0x1d;
 constexpr uint32_t R_NUM = 0x40;
 inline uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
@@ -137,6 +138,48 @@ HLE(agc_dcb_draw_index) {
     cmd[6] = 0;
     return (uint64_t)(uintptr_t)cmd;
 }
+// --- Gen5 indexed-draw builders (issue #232, DOLL/UE4 geometry path). ---------------------------
+// DOLL's UE4 RHI submits ALL scene geometry through THREE builders that were unimplemented->0 (no
+// packet appended), so every draw was silently dropped before the PM4 stream (0 DrawIndex in the
+// histogram despite 5.4M calls/run each). The Messenger uses DrawIndex/DrawIndexAuto instead, so it
+// never exercised this path. NIDs verified against the PS5 3.20 stub tables (../PS5-3.20_Libs):
+//   l4fM9K-Lyks = sceAgcDcbSetIndexBuffer, 8N2tmT3jmC8 = sceAgcDcbSetIndexCount,
+//   B+aG9DUnTKA = sceAgcDcbDrawIndexOffset.
+// ABI: Kyty has no Gen5 reference for these, so args are pinned by the sce::Agc DrawCommandBuffer
+// draw model + live capture (PROSPER_GFXLOG dumps a0..a3). setIndexBuffer(dcb, indexAddr);
+// setIndexCount(dcb, count); drawIndexOffset(dcb, startIndex[, count]). The bound base+count thread
+// through GpuState to the emitted indexed Draw (decoder R_INDEX_*; command_processor DrawIndexOffset).
+// CONFIDENCE: MED (arg roles from the AGC draw model + live values; refined by the GFXLOG capture).
+static std::atomic<uint64_t> g_ib_log{0};
+HLE(agc_dcb_set_index_buffer) {  // (dcb, indexBufferAddr)
+    if (getenv("PROSPER_GFXLOG") && g_ib_log.fetch_add(1) < 24)
+        fprintf(stderr, "[agc] SetIndexBuffer dcb=0x%llx addr=0x%llx a2=0x%llx\n",
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2);
+    uint32_t* cmd; if (!begin_packet(a0, 3, IT_NOP, R_INDEX_BASE, &cmd)) return 0;
+    cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    return (uint64_t)(uintptr_t)cmd;
+}
+static std::atomic<uint64_t> g_ic_log{0};
+HLE(agc_dcb_set_index_count) {  // (dcb, indexCount)
+    if (getenv("PROSPER_GFXLOG") && g_ic_log.fetch_add(1) < 24)
+        fprintf(stderr, "[agc] SetIndexCount dcb=0x%llx count=0x%llx\n",
+                (unsigned long long)a0, (unsigned long long)a1);
+    uint32_t* cmd; if (!begin_packet(a0, 2, IT_NOP, R_INDEX_COUNT, &cmd)) return 0;
+    cmd[1] = (uint32_t)a1;
+    return (uint64_t)(uintptr_t)cmd;
+}
+static std::atomic<uint64_t> g_do_log{0};
+HLE(agc_dcb_draw_index_offset) {  // (dcb, startIndex[, indexCount])
+    if (getenv("PROSPER_GFXLOG") && g_do_log.fetch_add(1) < 24)
+        fprintf(stderr, "[agc] DrawIndexOffset dcb=0x%llx off=0x%llx a2=0x%llx a3=0x%llx\n",
+                (unsigned long long)a0, (unsigned long long)a1,
+                (unsigned long long)a2, (unsigned long long)a3);
+    uint32_t* cmd; if (!begin_packet(a0, 3, IT_NOP, R_DRAW_INDEX_OFFSET, &cmd)) return 0;
+    cmd[1] = (uint32_t)a1;
+    cmd[2] = (uint32_t)a2;   // explicit draw count if the builder passes one; 0 => use SetIndexCount
+    return (uint64_t)(uintptr_t)cmd;
+}
+
 // sceAgcSuspendPoint (NID h9z6+0hEydk, name via shadPS4) — the TRC R5089 GPU suspend point the
 // game forces in a loop ("Forcing call to sce::Agc::suspendPoint" spam). It has no out-params and
 // no game-visible state; on a devkit it just gives the system a safe suspend opportunity.
@@ -795,9 +838,9 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         std::vector<gpu::Pm4Command> ops; gpu::decode_pm4(p->addr, p->dw_num, ops);
         static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetShRegDirect","SetRegsIndirect",
             "SetIndexType","DrawIndex","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem",
-            "Flip","ReleaseMem","DispatchDirect","Unknown"};
+            "Flip","ReleaseMem","DispatchDirect","SetIndexBase","SetIndexCount","DrawIndexOffset","Unknown"};
         for (auto& c : ops) {
-            uint32_t k = (uint32_t)c.kind; const char* nm = k < 15 ? kKindName[k] : "?";
+            uint32_t k = (uint32_t)c.kind; const char* nm = k < 18 ? kKindName[k] : "?";
             fprintf(stderr, "[agc]   pkt op=0x%02x r=0x%02x len=%u kind=%s pl0=0x%08x pl1=0x%08x pl2=0x%08x\n",
                     c.op, c.r, c.len, nm,
                     c.len > 1 ? c.payload[0] : 0, c.len > 2 ? c.payload[1] : 0, c.len > 3 ? c.payload[2] : 0);
@@ -895,6 +938,10 @@ void register_agc_hle() {
     RN("GIIW2J37e70", agc_dcb_set_index_size);
     RN("Yw0jKSqop+E", agc_dcb_draw_index_auto);
     RN("q88lQ+GP5Yk", agc_dcb_draw_index);      // sceAgcDcbDrawIndex (see handler comment)
+    // Gen5 indexed-draw path (issue #232, DOLL/UE4 geometry — was unimplemented->0, all draws dropped).
+    RN("l4fM9K-Lyks", agc_dcb_set_index_buffer); // sceAgcDcbSetIndexBuffer
+    RN("8N2tmT3jmC8", agc_dcb_set_index_count);  // sceAgcDcbSetIndexCount
+    RN("B+aG9DUnTKA", agc_dcb_draw_index_offset);// sceAgcDcbDrawIndexOffset
     RN("h9z6+0hEydk", agc_suspend_point);       // sceAgcSuspendPoint — no-op OK
     RN("aJf+j5yntiU", agc_dcb_event_write);
     RN("57labkp+rSQ", agc_dcb_acquire_mem);

--- a/prosper/tools/dbg/build_nid2got.sh
+++ b/prosper/tools/dbg/build_nid2got.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+cd "$WT" || exit 1
+g++ -O1 -std=c++20 -I src tools/dbg/nid2got.cpp src/self/*.cpp -o /root/nid2got 2>&1 | head -20
+ls -la /root/nid2got

--- a/prosper/tools/dbg/call232.sh
+++ b/prosper/tools/dbg/call232.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# call232.sh <hexaddr>... — find "call 0x..." refs in /root/dis232.txt
+for a in "$@"; do
+  echo "=== calls to 0x$a ==="
+  grep -nE "call   0x$a\b" /root/dis232.txt | head -12
+done

--- a/prosper/tools/dbg/findstr232.sh
+++ b/prosper/tools/dbg/findstr232.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# findstr232.sh <pattern> — locate UTF-16LE strings in DOLL eboot rodata, print VA.
+# VA = 0x669c000 + (file_off - 0x66e04d0)
+strings -e l -t x /root/PPSA17942-app0/eboot.bin | grep -E "$1" | head -${2:-20} | while read off s; do
+  va=$(( 0x669c000 + 0x$off - 0x66e04d0 ))
+  printf "va=0x%x  %s\n" $va "$s"
+done

--- a/prosper/tools/dbg/flow232.py
+++ b/prosper/tools/dbg/flow232.py
@@ -1,0 +1,75 @@
+# gdb -p PID -batch -x flow232.py — issue #232 session 6: characterize the GameThread
+# flow-advance vtable call `call *0x288(%rax)` at eboot+0x5044775.
+# rdi = object (this+0x7c0 of the frame/flow fn's this=rsi), rax = vtable.
+# For N hits: dump rdi/rsi objects, the +0x288 slot target, and the returned al.
+import gdb
+
+EBOOT = 0x400000000
+SITE = EBOOT + 0x5044775
+RET = SITE + 6  # call *0x288(%rax) = ff 90 88 02 00 00
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n):
+    try:
+        return bytes(inf.read_memory(addr, n))
+    except gdb.error:
+        return None
+
+def q(addr):
+    b = rd(addr, 8)
+    return int.from_bytes(b, "little") if b else None
+
+def sym(v):
+    if v is None: return "??"
+    if EBOOT <= v < EBOOT + 0x6700000: return "eboot+0x%x" % (v - EBOOT)
+    return hex(v)
+
+def dump_obj(tag, base, size):
+    obj = rd(base, size)
+    if not obj:
+        print("  %s @0x%x unreadable" % (tag, base))
+        return
+    for off in range(0, size, 0x20):
+        row = obj[off:off+0x20]
+        qs = ["%016x" % int.from_bytes(row[k:k+8], "little") for k in range(0, len(row) & ~7, 8)]
+        print("  %s+0x%03x: %s" % (tag, off, " ".join(qs)))
+    for off in range(0, size & ~7, 8):
+        v = int.from_bytes(obj[off:off+8], "little")
+        if EBOOT <= v < EBOOT + 0x6700000:
+            print("  %s+0x%03x -> %s (text)" % (tag, off, sym(v)))
+
+print("site bytes @ %s: %s" % (sym(SITE), (rd(SITE, 8) or b"").hex()))
+
+bp = gdb.Breakpoint("*0x%x" % SITE)
+seen = set()
+rets = {}
+for i in range(8):
+    gdb.execute("continue")
+    t = gdb.selected_thread()
+    rdi = int(gdb.parse_and_eval("$rdi")) & 0xffffffffffffffff
+    rsi = int(gdb.parse_and_eval("$rsi")) & 0xffffffffffffffff
+    vt = q(rdi)
+    tgt = q(vt + 0x288) if vt else None
+    print("HIT %d thread=%s lwp=%s obj(rdi)=0x%x this(rsi)=0x%x vtable=%s target=%s" %
+          (i, t.name, t.ptid[1], rdi, rsi, sym(vt), sym(tgt)))
+    if rdi not in seen:
+        seen.add(rdi)
+        dump_obj("obj", rdi, 0x140)
+    if i == 0:
+        dump_obj("this", rsi, 0x140)
+        # also dump around this+0x7c0
+        dump_obj("this7c0", rsi + 0x780, 0x80)
+    # get the return value at the return address, same thread
+    tb = gdb.Breakpoint("*0x%x" % RET, temporary=True)
+    tb.thread = t.global_num
+    bp.enabled = False
+    gdb.execute("continue")
+    r2 = int(gdb.parse_and_eval("$rax")) & 0xff
+    rets[r2] = rets.get(r2, 0) + 1
+    print("  -> returned al=0x%x" % r2)
+    bp.enabled = True
+print("return-value histogram:", rets)
+print("FLOW232-DONE")

--- a/prosper/tools/dbg/flow232b.py
+++ b/prosper/tools/dbg/flow232b.py
@@ -1,0 +1,58 @@
+# gdb -p PID -batch -x flow232b.py — issue #232 session 6: probe fn eboot+0x5044740 entry.
+# Reads this (rdi), this+0x7c0 (movie obj), this+0x800 (media obj), then dumps this.
+import gdb
+
+EBOOT = 0x400000000
+ENTRY = EBOOT + 0x5044740
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n):
+    try:
+        return bytes(inf.read_memory(addr, n))
+    except gdb.error:
+        return None
+
+def q(addr):
+    b = rd(addr, 8)
+    return int.from_bytes(b, "little") if b else None
+
+def sym(v):
+    if v is None: return "??"
+    if EBOOT <= v < EBOOT + 0x6700000: return "eboot+0x%x" % (v - EBOOT)
+    return hex(v)
+
+def dump_obj(tag, base, size):
+    obj = rd(base, size)
+    if not obj:
+        print("  %s @0x%x unreadable" % (tag, base))
+        return
+    for off in range(0, size, 0x20):
+        row = obj[off:off+0x20]
+        qs = ["%016x" % int.from_bytes(row[k:k+8], "little") for k in range(0, len(row) & ~7, 8)]
+        print("  %s+0x%03x: %s" % (tag, off, " ".join(qs)))
+
+bp = gdb.Breakpoint("*0x%x" % ENTRY)
+for i in range(3):
+    gdb.execute("continue")
+    t = gdb.selected_thread()
+    rdi = int(gdb.parse_and_eval("$rdi")) & 0xffffffffffffffff
+    o7c0 = q(rdi + 0x7c0)
+    o800 = q(rdi + 0x800)
+    print("HIT %d thread=%s lwp=%s this=0x%x  [+0x7c0]=0x%x [+0x800]=0x%x" %
+          (i, t.name, t.ptid[1], rdi, o7c0 or 0, o800 or 0))
+    if i == 0:
+        print("this vtable = %s" % sym(q(rdi)))
+        dump_obj("this", rdi, 0x200)
+        dump_obj("this+0x780", rdi + 0x780, 0xa0)
+        dump_obj("this+0xc00", rdi + 0xc00, 0x60)
+        # sub-objects if present
+        if o7c0:
+            print("movieobj vtable = %s" % sym(q(o7c0)))
+            dump_obj("movie", o7c0, 0x80)
+        if o800:
+            print("mediaobj vtable = %s" % sym(q(o800)))
+            dump_obj("media", o800, 0x80)
+print("FLOW232B-DONE")

--- a/prosper/tools/dbg/flow232c.py
+++ b/prosper/tools/dbg/flow232c.py
@@ -1,0 +1,70 @@
+# gdb -p PID -batch -x flow232c.py — issue #232 session 6:
+# 1) at eboot+0x5044740 entry: rbp-chain backtrace (guest frames) + raw stack RA scan
+# 2) RTTI typeinfo names for this (vtable 0x408a46708) and media obj (vtable 0x4090757c0)
+import gdb
+
+EBOOT = 0x400000000
+ENTRY = EBOOT + 0x5044740
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n):
+    try:
+        return bytes(inf.read_memory(addr, n))
+    except gdb.error:
+        return None
+
+def q(addr):
+    b = rd(addr, 8)
+    return int.from_bytes(b, "little") if b else None
+
+def sym(v):
+    if v is None: return "??"
+    if EBOOT <= v < EBOOT + 0x6700000: return "eboot+0x%x" % (v - EBOOT)
+    return hex(v)
+
+def typename(vt):
+    # Itanium ABI: vtable[-1] = typeinfo ptr; typeinfo+8 = name ptr
+    ti = q(vt - 8)
+    if not ti: return "?"
+    nm = q(ti + 8)
+    if not nm: return "?"
+    s = rd(nm, 120)
+    if not s: return "?"
+    return s.split(b"\0")[0].decode("latin1", "replace")
+
+bp = gdb.Breakpoint("*0x%x" % ENTRY)
+gdb.execute("continue")
+rdi = int(gdb.parse_and_eval("$rdi")) & 0xffffffffffffffff
+rsp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+rbp = int(gdb.parse_and_eval("$rbp")) & 0xffffffffffffffff
+print("this=0x%x vtable=%s type=%s" % (rdi, sym(q(rdi)), typename(q(rdi))))
+o800 = q(rdi + 0x800)
+if o800:
+    print("media obj type=%s" % typename(q(o800)))
+# return address = *rsp at entry
+print("caller RA = %s" % sym(q(rsp)))
+# rbp chain
+fp = rbp
+for d in range(16):
+    ra = q(fp + 8)
+    nfp = q(fp)
+    if ra is None or nfp is None: break
+    print("frame %2d fp=0x%x ra=%s" % (d, fp, sym(ra)))
+    if not (EBOOT <= ra < EBOOT + 0x6700000):
+        # keep walking anyway a couple frames
+        pass
+    if nfp <= fp or nfp - fp > 0x100000: break
+    fp = nfp
+# raw scan of return-address-looking values on the stack
+mem = rd(rsp, 0x800)
+if mem:
+    out = []
+    for off in range(0, len(mem) - 7, 8):
+        v = int.from_bytes(mem[off:off+8], "little")
+        if EBOOT <= v < EBOOT + 0x6700000:
+            out.append("sp+0x%x:%s" % (off, sym(v)))
+    print("stack text-ptrs:", " ".join(out[:40]))
+print("FLOW232C-DONE")

--- a/prosper/tools/dbg/frame232.sh
+++ b/prosper/tools/dbg/frame232.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# frame232.sh — dump one frame's packet-kind histogram + CS shader addrs from /root/s6.log
+A=${1:-83516637}
+B=${2:-83520912}
+sed -n "${A},${B}p" /root/s6.log > /root/frame1.txt
+echo "=== packet kinds in one frame ==="
+grep -ao "kind=[A-Za-z]*" /root/frame1.txt | sort | uniq -c | sort -rn
+echo "=== SetShRegDirect samples (CS shader addr regs) ==="
+grep -a "SetShRegDirect" /root/frame1.txt | head -8
+echo "=== dispatch sizes ==="
+grep -a "kind=DispatchDirect" /root/frame1.txt | awk '{print $NF}' | sort | uniq -c | sort -rn | head

--- a/prosper/tools/dbg/got232.sh
+++ b/prosper/tools/dbg/got232.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/root/nid2got /root/PPSA17942-app0/eboot.bin "l4fM9K-Lyks" "8N2tmT3jmC8" "B+aG9DUnTKA" "bbFueFP+J4k" "xSAR0LTcRKM" "w6Dj1VJt5qY" "dbOlWdppb4o" "qj7QZpgr9Uw"

--- a/prosper/tools/dbg/rostr2.sh
+++ b/prosper/tools/dbg/rostr2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# rostr2.sh <va_hex>... — print eboot rodata strings (DOLL PPSA17942), VA eboot-relative
+for va in "$@"; do
+  off=$(( 0x66e04d0 + 0x$va - 0x669c000 ))
+  echo -n "va 0x$va: "
+  dd if=/root/PPSA17942-app0/eboot.bin bs=1 skip=$off count=120 status=none | tr "\0" "." | head -c 120
+  echo
+done

--- a/prosper/tools/dbg/smoke_msg232.sh
+++ b/prosper/tools/dbg/smoke_msg232.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Messenger render smoke for issue #232 (shared GPU pm4/command_processor changed). Must still reach
+# real scene draws (vcount=1044) with 0 faults. Runs under a private binary name (other agents pkill
+# boot_trace on this shared WSL). Long run: the scene draws only appear deep in.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+cp -f "$WT/build-linux/boot_trace" /root/btmsg
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
+  timeout 260 /root/btmsg /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smokemsg.log 2>&1
+echo "rc=$?"
+echo "=== presented frames ==="; grep -ac "presented" /root/smokemsg.log
+echo "=== draws (max) ==="; grep -ao "draws so far: [0-9]*" /root/smokemsg.log | awk '{print $4}' | sort -n | tail -2
+echo "=== vcount (scene geometry) ==="; grep -ao "vcount=[0-9]*" /root/smokemsg.log | sort | uniq -c | sort -rn | head -5
+echo "=== DrawIndexOffset (should be 0 for Messenger) ==="; grep -ac "kind=DrawIndexOffset" /root/smokemsg.log
+echo "=== faults ==="; grep -ac "WORKER-THREAD FAULT\|SIGSEGV\|Corruption\|LowLevelFatal" /root/smokemsg.log
+tail -3 /root/smokemsg.log
+echo SMOKE-DONE

--- a/prosper/tools/dbg/soak232b.sh
+++ b/prosper/tools/dbg/soak232b.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Issue #232 session 6: boot DOLL to steady state and leave running. PID -> /root/pid232.txt.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+LOG=/root/${1:-soak232b}.log
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SVCLOG=1
+[ -f /root/pid232.txt ] && kill -9 "$(cat /root/pid232.txt)" 2>/dev/null
+pkill -9 boot_trace; sleep 1
+PID=
+for try in 1 2 3 4 5 6; do
+  setsid ./build-linux/boot_trace /root/PPSA17942-app0 > "$LOG" 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; tail -20 "$LOG"; exit 1; }
+echo "$PID" > /root/pid232.txt
+# soak to steady state (past the save flow + locus sweep + pak remounts)
+for i in $(seq 1 ${2:-5}); do
+  sleep 30
+  kill -0 $PID 2>/dev/null || { echo DIED-SOAK; tail -20 "$LOG"; exit 1; }
+  echo "t+$((45+i*30)) flips=$(grep -ac GpuFlip "$LOG") draws=$(grep -ac "kind=DrawIndex" "$LOG")"
+done
+echo SOAK-READY pid=$PID

--- a/prosper/tools/dbg/soak232c.sh
+++ b/prosper/tools/dbg/soak232c.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Issue #232 session 6: boot DOLL to steady state, leave running. PID -> /root/pid232s6.txt.
+# NO pkill (other agents run boot_trace on this WSL); kill only our own recorded pid.
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+LOG=/root/${1:-s6}.log
+cd "$WT" || exit 1
+export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_SVCLOG=1
+[ -f /root/pid232s6.txt ] && kill -9 "$(cat /root/pid232s6.txt)" 2>/dev/null
+sleep 1
+rm -f "$LOG"
+# run under a different comm name: other agents pkill -9 boot_trace on this shared WSL
+cp -f ./build-linux/boot_trace /root/bt232
+PID=
+for try in 1 2 3 4 5 6; do
+  setsid /root/bt232 /root/PPSA17942-app0 > "$LOG" 2>&1 &
+  PID=$!
+  echo "try=$try pid=$PID"
+  sleep 45
+  kill -0 $PID 2>/dev/null && break
+  echo "DIED (try $try)"
+  PID=
+done
+[ -n "$PID" ] || { echo "ALL TRIES DIED"; tail -20 "$LOG"; exit 1; }
+echo "$PID" > /root/pid232s6.txt
+for i in $(seq 1 ${2:-5}); do
+  sleep 30
+  kill -0 $PID 2>/dev/null || { echo DIED-SOAK; tail -20 "$LOG"; exit 1; }
+  echo "t+$((45+i*30)) flips=$(grep -ac GpuFlip "$LOG") draws=$(grep -ac "kind=DrawIndex" "$LOG")"
+done
+echo SOAK-READY pid=$PID

--- a/prosper/tools/dbg/thr232.py
+++ b/prosper/tools/dbg/thr232.py
@@ -1,0 +1,37 @@
+# gdb -p PID -batch -x thr232.py — list all threads: name, pc, top guest RAs from stack scan
+import gdb
+
+EBOOT = 0x400000000
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n):
+    try:
+        return bytes(inf.read_memory(addr, n))
+    except gdb.error:
+        return None
+
+def sym(v):
+    if EBOOT <= v < EBOOT + 0x6700000: return "eboot+0x%x" % (v - EBOOT)
+    if 0x500000000 <= v < 0x600000000: return "prx+0x%x" % (v - 0x500000000)
+    return hex(v)
+
+for t in inf.threads():
+    try:
+        t.switch()
+        pc = int(gdb.parse_and_eval("$pc")) & 0xffffffffffffffff
+        sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+        ras = []
+        mem = rd(sp, 0x600)
+        if mem:
+            for off in range(0, len(mem) - 7, 8):
+                v = int.from_bytes(mem[off:off+8], "little")
+                if EBOOT <= v < EBOOT + 0x6700000:
+                    ras.append("eboot+0x%x" % (v - EBOOT))
+                if len(ras) >= 5:
+                    break
+        print("thr %-18s lwp=%-8d pc=%-22s ras=%s" % (t.name or "?", t.ptid[1], sym(pc), ",".join(ras)))
+    except gdb.error as e:
+        print("thr ?? err %s" % e)
+print("THR232-DONE")

--- a/prosper/tools/dbg/unk232.sh
+++ b/prosper/tools/dbg/unk232.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# unk232.sh — opcode histogram of kind=Unknown packets in /root/frame1.txt
+grep -a "kind=Unknown" /root/frame1.txt | awk '{print $3, $5}' | sort | uniq -c | sort -rn | head -25
+echo "=== samples ==="
+grep -a "kind=Unknown" /root/frame1.txt | head -10

--- a/prosper/tools/dbg/xref232.sh
+++ b/prosper/tools/dbg/xref232.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# xref232.sh <hexaddr>... — find refs in /root/dis232.txt (objdump comment "# 0x...")
+for a in "$@"; do
+  echo "=== refs to 0x$a ==="
+  grep -n "# 0x$a\b" /root/dis232.txt | head -12
+done


### PR DESCRIPTION
## DOLL renders its first scene geometry — implement the 3 Gen5 AGC indexed-draw builders (Fixes #232)

**The six-session "0 scene draws" wall was a misdiagnosis.** DOLL's UE4 RHI submitted all scene geometry all along — but three Gen5 AGC draw builders were `unimplemented → 0` stubs that **appended no PM4 packet**, silently discarding every draw *inside the HLE boundary*, one level below where the packet histogram counted (so "0 `DrawIndex`" was measured *above* the drop). Each was called **~5.46M times/run**:
- `l4fM9K-Lyks` = `sceAgcDcbSetIndexBuffer`
- `8N2tmT3jmC8` = `sceAgcDcbSetIndexCount`
- `B+aG9DUnTKA` = `sceAgcDcbDrawIndexOffset`

Found by dumping live unimplemented-call counts at steady state and resolving the hot NIDs against the PS5 3.20 stub tables.

## The fix
RE'd the ABI from live `PROSPER_GFXLOG` capture — `setIndexBuffer(dcb, addr)`, `setIndexCount(dcb, capacity)`, `drawIndexOffset(dcb, startIndex, indexCount, modifier)`. Added three PM4 sub-ops + decoder Kinds (`R_DRAW_INDEX_OFFSET` …) and threaded index base/count through `GpuState` so `DrawIndexOffset` emits an **indexed `Draw`**. Purely additive — no existing draw Kind touched. CONFIDENCE: MED on arg roles (live capture + the AGC draw model; Kyty has no Gen5 reference).

## Verified (independent build + run on the fix)
- **DOLL:** **993 `DrawIndexOffset` packets, 6,367 indexed draw executions** resolving DOLL's real UE4 scene vertex streams (`stride=40`, `num_records=50000`); presents frames; **0 crashes**.
- **ctest 63/63.**
- **Messenger unregressed** (mandatory — shared GPU code): reaches its scene (`vcount=1044` ×1207, 8,029 draws), 0 faults, uses **0** of the new path.
- Image-free (render dumps gitignored; no game imagery committed).

## Remaining (downstream — separate frontier)
~1,040 draws/run still `skip draw: recompile failed` — DOLL shaders hitting unsupported RDNA2 ops in the recompiler. Draws that recompile render; this is the recompiler frontier, not this PR's scope. So it's **real scene geometry rendering, not yet a fully-shaded frame** — the first UE4 graphics output from PPSA17942.
