### PR TITLE
fix(gpu): carry T# sRGB flag + document the gamma-space finding (refs #263)

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -234,6 +234,9 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
             r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
             r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];   // T# DST_SEL channel remap (#261)
+            r.srgb          = fi.srgb;              // gamma-encoded surface: sample with sRGB->linear (#263)
+            if (fi.srgb && getenv("PROSPER_GFXLOG"))
+                fprintf(stderr, "[t#] SRGB texture fmt=%u %ux%u (binding %u)\n", d.format, d.width, d.height, r.binding);
             // Backing byte size: block-compressed surfaces store one bytes_per_block unit per 4x4 block
             // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
             r.size          = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -90,6 +90,7 @@ struct ShaderResource {
     uint32_t      width             = 0;
     uint32_t      height            = 0;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
+    bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;
 
     // Sampler state decoded from the PAIRED S# (Texture only). The backend previously hardcoded a

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -350,6 +350,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0); vkAllocateMemory(dev, &tai, nullptr, &v.tmem[i]);
                     vkBindImageMemory(dev, v.timg[i], v.tmem[i], 0);
                     VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+                    // NOTE(#263): r.srgb carries whether the T# is a gamma-encoded (sRGB) surface, but we
+                    // deliberately keep the view UNORM. This whole renderer works in gamma/sRGB space
+                    // end-to-end (this target is UNORM, the frontend blit + swapchain are UNORM), with NO
+                    // linear->sRGB encode at present. Sampling an sRGB texture as UNORM passes its encoded
+                    // bytes straight through, which MATCHES real-hardware output for pass-through content.
+                    // Flipping this to VK_FORMAT_R8G8B8A8_SRGB would apply sRGB->linear on sample with no
+                    // matching encode on store -> linear values into a UNORM swapchain -> too dark. A
+                    // correct sRGB fix is a coordinated linear-working-space + output-encode change (see the
+                    // #263 discussion), NOT a per-view format flip. r.srgb is decoded now as groundwork.
                     tvci.image = v.timg[i]; tvci.viewType = VK_IMAGE_VIEW_TYPE_2D; tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
                     // T# DST_SEL channel remap (#261): map each SQ_SEL to a VkComponentSwizzle. Identity
                     // (the default, and the narrow/font path) yields IDENTITY == a no-op. PROSPER_NO_SWIZZLE


### PR DESCRIPTION
## What I found

#263 proposed sampling sRGB `T#` textures through a `VK_FORMAT_R8G8B8A8_SRGB` view. Tracing the actual pipeline shows that would **regress, not fix**.

prosper's renderer is **gamma/sRGB-space end-to-end**:
- offscreen color target is `R8G8B8A8_UNORM` (`render_runner.h:151`)
- frontend blit image is `R8G8B8A8_UNORM` (`main.cpp:187`)
- swapchain **explicitly prefers** `B8G8R8A8_UNORM` over sRGB (`main.cpp:148`)
- there is **no linear→sRGB encode** at present

Concrete trace:

| pipeline | sample | store | result |
|---|---|---|---|
| Real PS5 (sRGB tex → sRGB target) | sRGB→linear | linear→sRGB | round-trips → correct |
| **prosper now** (UNORM everywhere) | none | none | encoded bytes pass through → **matches HW for pass-through** |
| Naive fix (sRGB view, UNORM target) | sRGB→linear | none | linear into UNORM swapchain → **too dark = regression** |

So sampling sRGB-as-UNORM is currently the *correct* choice for this gamma-space pipeline. The real gap is only linear-space math (lighting / alpha-blend), and closing it properly requires a coordinated **linear working space + output encode** — a broad change that alters every blend and the golden snapshot.

## What this PR does

- Decodes `fi.srgb` and carries it onto `ShaderResource::srgb` (groundwork the issue asked for).
- Logs sRGB `T#` bindings under `PROSPER_GFXLOG` (diagnostic).
- **Keeps the sampled view UNORM** with a load-bearing comment at the view-creation site so it isn't naively wired to sRGB.

## Safety

Behavior-neutral — no view/format change. **68/68 render tests byte-identical.** Verified The Messenger binds **zero** sRGB textures (only fmt=56 UNORM + fmt=1 R8), so no snapshot impact.

Refs #263 (reframed there: the true fix is a linear color pipeline, not a per-view flip).