### PR TITLE
fix(gpu): decode remaining S# sampler fields; apply border color + LOD (Fixes #262)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -252,6 +252,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
                         fr.addr_uvw[0] = r.addr_uvw[0]; fr.addr_uvw[1] = r.addr_uvw[1]; fr.addr_uvw[2] = r.addr_uvw[2];
+                        // Remaining S# sampler fields (#262): border color + LOD clamp/bias (applied where
+                        // valid; the decode-only aniso/compare/unnorm stay on ShaderResource).
+                        fr.border_color_type = r.border_color_type;
+                        fr.min_lod = r.min_lod; fr.max_lod = r.max_lod; fr.lod_bias = r.lod_bias;
                         // T# DST_SEL channel remap (#261): apply only to REAL-RGBA texels. The narrow
                         // R->RGBA replication path (narrow_done) already broadcasts coverage to every
                         // channel — keep it identity so the font/mask path (#102/#256) is untouched.

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -257,10 +257,27 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                         r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
                         r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
                         r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
+                        // Remaining SQ_IMG_SAMP fields (#262). WORD0: MAX_ANISO_RATIO[11:9],
+                        // DEPTH_COMPARE_FUNC[14:12], FORCE_UNNORMALIZED[15]. WORD1: MIN_LOD[11:0],
+                        // MAX_LOD[23:12] (u4.8). WORD2: LOD_BIAS[13:0] (s5.8, signed). WORD3:
+                        // BORDER_COLOR_TYPE[31:30]. CONFIDENCE: HIGH (standard GCN/RDNA2 SQ_IMG_SAMP layout).
+                        r.max_aniso_ratio    = (sm[0] >> 9)  & 0x7u;
+                        r.depth_compare_func = (sm[0] >> 12) & 0x7u;
+                        r.unnormalized       = (sm[0] >> 15) & 0x1u;
+                        r.min_lod            = (float)( sm[1]        & 0xFFFu) / 256.0f;
+                        r.max_lod            = (float)((sm[1] >> 12) & 0xFFFu) / 256.0f;
+                        int32_t bias14       = (int32_t)(sm[2] & 0x3FFFu);
+                        if (bias14 & 0x2000) bias14 -= 0x4000;           // sign-extend the 14-bit s5.8
+                        r.lod_bias           = (float)bias14 / 256.0f;
+                        r.border_color_type  = (sm[3] >> 30) & 0x3u;
                         if (getenv("PROSPER_GFXLOG"))
-                            fprintf(stderr, "[s#] slot%u mag=%u min=%u mip=%u addr=%u,%u,%u | raw %08x %08x %08x %08x\n",
+                            fprintf(stderr, "[s#] slot%u mag=%u min=%u mip=%u addr=%u,%u,%u | aniso=%u cmp=%u unnorm=%u "
+                                    "lod=[%.3f,%.3f] bias=%.3f border=%u | raw %08x %08x %08x %08x\n",
                                     slot, r.mag_filter, r.min_filter, r.mip_filter,
-                                    r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2], sm[0], sm[1], sm[2], sm[3]);
+                                    r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2],
+                                    r.max_aniso_ratio, r.depth_compare_func, r.unnormalized,
+                                    r.min_lod, r.max_lod, r.lod_bias, r.border_color_type,
+                                    sm[0], sm[1], sm[2], sm[3]);
                     }
                 }
             }

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -104,6 +104,29 @@ struct ShaderResource {
     uint32_t      mip_filter        = 0;
     uint32_t      addr_uvw[3]       = {2, 2, 2};
 
+    // Remaining SQ_IMG_SAMP fields (#262). Defaults reproduce the current Vulkan sampler exactly, so a
+    // texture whose S# we cannot resolve — and every render test that fills a ShaderResource directly —
+    // is byte-identical. Applied where valid on the current color combined-image-sampler path; the three
+    // that need extra machinery (depth-compare, unnormalized, anisotropy) are decoded but NOT applied yet
+    // (see the render-runner sampler site for why each is gated).
+    //   border_color_type:  WORD3[31:30] SQ_TEX_BORDER_COLOR (0=transparent-black,1=opaque-black,
+    //                       2=opaque-white,3=register/custom). Only affects CLAMP_TO_BORDER wrap.
+    //   min_lod/max_lod:    WORD1 [11:0]/[23:12], unsigned u4.8 (raw/256.0). LOD clamp.
+    //   lod_bias:           WORD2 [13:0], signed s5.8 (sign-extended raw/256.0). mip LOD bias.
+    //   max_aniso_ratio:    WORD0 [11:9] enum (maxAnisotropy = 1<<ratio). NEEDS the samplerAnisotropy
+    //                       device feature — decoded only.
+    //   depth_compare_func: WORD0 [14:12] SQ compare enum for shadow/PCF samplers. NEEDS a depth/shadow
+    //                       sampling path (our images are color UNORM) — decoded only.
+    //   unnormalized:       WORD0 [15] FORCE_UNNORMALIZED. NEEDS strict validity (no mips, equal filters,
+    //                       clamp addressing, minLod=maxLod=0) — decoded only.
+    uint32_t      border_color_type = 0;
+    float         min_lod           = 0.0f;
+    float         max_lod           = 0.0f;
+    float         lod_bias          = 0.0f;
+    uint32_t      max_aniso_ratio   = 0;
+    uint32_t      depth_compare_func = 0;
+    uint32_t      unnormalized      = 0;
+
     // T# DST_SEL channel swizzle (SQ_SEL enum per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Applied as a Vulkan
     // component-mapping on the sampled view so a non-identity surface (e.g. BGRA order, or an alpha-only
     // mask) reads correctly. Default = identity (R,G,B,A). NOT applied on the narrow R->RGBA replication

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -67,6 +67,10 @@ struct FrameResource {
     // SQ_TEX CLAMP enum (0=wrap, 1=mirror, 2=clamp-last-texel, 6/7=border).
     uint32_t mag_filter = 1, min_filter = 1, mip_filter = 0;
     uint32_t addr_uvw[3] = {2, 2, 2};
+    // Remaining S# sampler fields (#262). Defaults reproduce the current Vulkan sampler exactly (border
+    // transparent-black, LOD 0..0, no bias), so FrameResources built directly by tests are byte-identical.
+    uint32_t border_color_type = 0;
+    float    min_lod = 0.0f, max_lod = 0.0f, lod_bias = 0.0f;
     // T# DST_SEL channel swizzle (SQ_SEL per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Default = identity
     // (R,G,B,A) == a no-op VkComponentMapping, so tests that build FrameResources directly are unchanged.
     uint32_t swizzle[4] = {4, 5, 6, 7};
@@ -386,6 +390,21 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     sci.addressModeU = vkaddr(r.addr_uvw[0]);
                     sci.addressModeV = vkaddr(r.addr_uvw[1]);
                     sci.addressModeW = vkaddr(r.addr_uvw[2]);
+                    // Remaining S# fields (#262), applied where valid on this color combined-image-sampler.
+                    // Defaults (border 0 / LOD 0,0 / bias 0) reproduce the previous fixed sampler exactly.
+                    //   border color: only bites with CLAMP_TO_BORDER wrap. 3 = register/custom (needs
+                    //     VK_EXT_custom_border_color); fall back to opaque-black.
+                    //   LOD min/max/bias: honored; harmless with our single uploaded mip.
+                    // NOT applied here (need machinery the current path lacks — decoded under GFXLOG only):
+                    //   anisotropy (needs the samplerAnisotropy device feature), depth_compare_func (needs a
+                    //   depth/shadow sampler over a depth image), unnormalized coords (strict validity rules).
+                    switch (r.border_color_type) {
+                        case 1:  sci.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK; break;
+                        case 2:  sci.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE; break;
+                        case 3:  sci.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK; break;   // custom unsupported
+                        default: sci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK; break;
+                    }
+                    sci.minLod = r.min_lod; sci.maxLod = r.max_lod; sci.mipLodBias = r.lod_bias;
                     vkCreateSampler(dev, &sci, nullptr, &v.tsamp[i]);
                     VkDeviceSize tbytes = (VkDeviceSize)r.tw * r.th * 4;
                     VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;


### PR DESCRIPTION
## What

#260 decoded only the S# filter + wrap. This decodes the **rest** of the 4-dword `SQ_IMG_SAMP` and logs it under `PROSPER_GFXLOG`:

| field | bits | → |
|---|---|---|
| MAX_ANISO_RATIO | WORD0 [11:9] | anisotropy enum |
| DEPTH_COMPARE_FUNC | WORD0 [14:12] | shadow/PCF compare |
| FORCE_UNNORMALIZED | WORD0 [15] | unnormalized coords |
| MIN_LOD / MAX_LOD | WORD1 [11:0]/[23:12] | u4.8 LOD clamp |
| LOD_BIAS | WORD2 [13:0] | s5.8 signed bias |
| BORDER_COLOR_TYPE | WORD3 [31:30] | border color |

## Applied vs decode-only

**Applied** (unconditionally valid on the current color combined-image-sampler):
- **border color** → `VkBorderColor` (bites only with `CLAMP_TO_BORDER` wrap)
- **LOD min / max / bias** → `minLod` / `maxLod` / `mipLodBias`

**Decoded but not applied** (the current path lacks the machinery — each documented at the sampler site, left as #262 follow-ups):
- **anisotropy** — needs the `samplerAnisotropy` device feature enabled (only `robustBufferAccess` is on today)
- **depth_compare_func** — needs a depth/shadow sampler over a depth image; our sampled images are color UNORM, so `compareEnable` would be invalid usage
- **unnormalized coords** — strict Vulkan validity (no mips, equal filters, clamp addressing, minLod=maxLod=0)

## Safety

Every new sampler field **defaults to the exact previous fixed value** (border transparent-black, LOD 0..0, bias 0), so FrameResources built directly by tests are byte-identical → **68/68 render tests green**. The Messenger's real S# decodes to all-defaults except `max_lod=15.996`, which clamps to level 0 identically with our single uploaded mip. **Golden-image snapshot guard OK** (richest 24318 colors ≥ 5000).

Fixes #262