### PR TITLE
fix(gpu): stencil REPLACE writes STENCILOPVAL, not STENCILTESTVAL

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -161,9 +161,11 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         ps.stencil_pass_op[1]       = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZPASS_BF));
         ps.stencil_depth_fail_op[1] = vk_stencil_op(PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZFAIL_BF));
         ps.stencil_ref[0]           = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILTESTVAL);
+        ps.stencil_op_val[0]        = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILOPVAL);
         ps.stencil_compare_mask[0]  = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILMASK);
         ps.stencil_write_mask[0]    = PM4_FIELD(rm,  DB_STENCILREFMASK,    STENCILWRITEMASK);
         ps.stencil_ref[1]           = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILTESTVAL_BF);
+        ps.stencil_op_val[1]        = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILOPVAL_BF);
         ps.stencil_compare_mask[1]  = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILMASK_BF);
         ps.stencil_write_mask[1]    = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILWRITEMASK_BF);
     }

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -97,7 +97,8 @@ struct ResolvedPipelineState {
     uint32_t stencil_fail_op[2]      = {0, 0};        // == VkStencilOp (0 = KEEP)
     uint32_t stencil_pass_op[2]      = {0, 0};        // depth-pass op
     uint32_t stencil_depth_fail_op[2]= {0, 0};
-    uint32_t stencil_ref[2]          = {0, 0};
+    uint32_t stencil_ref[2]          = {0, 0};        // STENCILTESTVAL — the COMPARE reference
+    uint32_t stencil_op_val[2]       = {0, 0};        // STENCILOPVAL — the value written by a REPLACE op
     uint32_t stencil_compare_mask[2] = {0xFF, 0xFF};
     uint32_t stencil_write_mask[2]   = {0xFF, 0xFF};
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -364,10 +364,23 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 s.compareOp   = (VkCompareOp)ps->stencil_compare_op[fb];
                 s.compareMask = ps->stencil_compare_mask[fb];
                 s.writeMask   = ps->stencil_write_mask[fb];
-                s.reference   = ps->stencil_ref[fb];
+                // AMD splits the stencil reference: STENCILTESTVAL is the COMPARE reference, but a REPLACE
+                // op writes STENCILOPVAL. Vulkan has one `reference` for both. When this draw REPLACEs
+                // (its whole purpose is to WRITE a mask value, and its compare is typically ALWAYS so the
+                // compare-ref is irrelevant), use STENCILOPVAL so the mask is written with the value the
+                // game intended — else a mask-write with TESTVAL=0/OPVAL=1 writes 0 and every later
+                // test==1 draw is wrongly culled (PPSA02664's whole UI vanished; #270).
+                const uint32_t REPLACE = 2;   // VK_STENCIL_OP_REPLACE
+                bool does_replace = (ps->stencil_pass_op[fb] == REPLACE || ps->stencil_fail_op[fb] == REPLACE ||
+                                     ps->stencil_depth_fail_op[fb] == REPLACE);
+                s.reference   = does_replace ? ps->stencil_op_val[fb] : ps->stencil_ref[fb];
                 return s;
             };
             dss.front = mkop(0); dss.back = mkop(1);
+            if (getenv("PROSPER_STENCILLOG"))
+                fprintf(stderr, "[stencil] front{cmp=%u ref=%u opval=%u cmask=0x%x wmask=0x%x fail=%u pass=%u zfail=%u} vkref=%u depth_test=%d\n",
+                        ps->stencil_compare_op[0], ps->stencil_ref[0], ps->stencil_op_val[0], ps->stencil_compare_mask[0], ps->stencil_write_mask[0],
+                        ps->stencil_fail_op[0], ps->stencil_pass_op[0], ps->stencil_depth_fail_op[0], dss.front.reference, (int)ps->depth_test_enable);
         }
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         v.R = bd.R; auto& R = v.R;


### PR DESCRIPTION
## Bug
AMD splits the stencil reference into two fields:
- `DB_STENCILREFMASK.STENCILTESTVAL` — the **compare** reference
- `DB_STENCILREFMASK.STENCILOPVAL` — the value written by a **REPLACE** stencil op

Vulkan has a single `VkStencilOpState::reference` used for **both** the compare and the value written by REPLACE. We baked `reference = STENCILTESTVAL` unconditionally. So a mask-writing draw (compare=ALWAYS, passOp=REPLACE) with `STENCILTESTVAL=0` but `STENCILOPVAL=1` wrote **0** instead of 1 — and every later `test == 1` draw was then wrongly culled.

## Fix
Extract `STENCILOPVAL` (front + back) into `ResolvedPipelineState`, and when a draw performs a REPLACE (its purpose is to **write** the mask; its compare is typically ALWAYS so the compare-ref is irrelevant) use `STENCILOPVAL` as the Vulkan reference; otherwise keep `STENCILTESTVAL` for the compare.

## Evidence (PPSA02664)
The game's UI mask-write draws are `ALWAYS/REPLACE` with `STENCILOPVAL=0xFF` (and `STENCILTESTVAL=0`), so they were writing stencil **0**; the credits/UI sprites that test `stencil bit0 == 1` were **all culled** and the frame showed only the clear colour. Captured with the new `PROSPER_STENCILLOG`:
```
front{cmp=EQUAL  ref=1 opval=1   ...} vkref=1     <- sprite test (unchanged)
front{cmp=ALWAYS ref=0 opval=255 ... REPLACE} vkref=255   <- mask write: 0 -> 255 with the fix
```

## Test
- All 4 render unit tests pass (`render_state_extract`, `multidraw_render`, `texture_sample_render`, `indexed_render`).
- Adds `PROSPER_STENCILLOG` (per-draw stencil state) + `PROSPER_STENCIL_CLEAR` (override clear value) diagnostics.

This is a general stencil-correctness fix (independent of the PPSA02664 render work); it also affects any Messenger stencil-masked UI. Refs #270.