### PR TITLE
diag: log SIGILL faulting bytes + guest canary on __stack_chk_fail (refs #283)

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -94,6 +94,21 @@ HLE(k_mutexattr_settype) {
     return 0;
 }
 HLE(k_mutexattr_setprotocol) { return 0; }
+
+// __stack_chk_fail (Ou3iL1abvng): the guest's -fstack-protector epilogue jumps here when its stack
+// canary check fails; the [[noreturn]] contract lets the compiler place a trailing UD2, so our old
+// blanket "return 0" stub fell into that UD2 -> SIGILL crash on the New Game path (#163-progress). Log
+// the current guest canary at %fs:0x28: a normal high-entropy value (low byte 0x00) => the TLS is fine
+// and a real stack overflow corrupted the on-stack copy; 0 / a weird value => a guest-TCB canary
+// divergence. Still returns (the crash is unavoidable here) — this is diagnostic-only for now.
+HLE(k_stack_chk_fail) {
+    uint64_t c = 0;
+    __asm__ volatile ("movq %%fs:0x28, %0" : "=r"(c));
+    static int n = 0;
+    if (n++ < 4) fprintf(stderr, "[stackchk] __stack_chk_fail: guest canary @fs:0x28 = 0x%016llx\n",
+                         (unsigned long long)c);
+    return 0;
+}
 HLE(k_mutexattr_setpshared)  { return 0; }
 HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 
@@ -1013,6 +1028,7 @@ void register_kernel_hle() {
     R("scePthreadSelf", k_pthread_self);
     R("scePthreadEqual", k_pthread_equal);
     R("scePthreadYield", k_pthread_yield);
+    R("__stack_chk_fail", k_stack_chk_fail);   // diagnostic: log the guest canary on a canary-check failure
     R("scePthreadCreate", k_pthread_create);
     R("scePthreadJoin", k_pthread_join);
     R("scePthreadDetach", k_pthread_detach);

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -59,7 +59,6 @@ namespace {
     // trustworthy way to inspect deep crashes (e.g. the null std::ctype facet at eboot+0x3b5ea6).
     bool g_faultmem = false;
     bool g_faultlog = false;
-    bool g_fatal_trap = false;                 // PROSPER_FATAL_TRAP: SIGTRAP (core/gdb stop) at the real fatal fault
     // Probe pipe for probe_readable() below — a pipe write imports the source pages (EFAULT on
     // unmapped memory) where a /dev/null write does not. O_NONBLOCK so a full pipe can never
     // block the fault handler; drained after every probe.
@@ -487,6 +486,16 @@ namespace {
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
         // Emulate AMD-only SSE4a bitfield ops (insertq/extrq) that #UD on Intel hosts, then resume.
         if (sig == SIGILL && try_emulate_sse4a((ucontext_t*)uctx)) return;
+        // A SIGILL we did NOT emulate: log the faulting instruction bytes so the offending opcode can be
+        // identified (another AMD-only ISA extension, or a decode miss in try_emulate_sse4a). #163-progress.
+        if (sig == SIGILL) {
+            uint64_t rip = (uint64_t)((ucontext_t*)uctx)->uc_mcontext.gregs[REG_RIP];
+            const uint8_t* p = (const uint8_t*)rip;
+            char b[96]; int n = snprintf(b, sizeof b, "[sigill] rip=0x%llx bytes:", (unsigned long long)rip);
+            for (int k = 0; k < 16 && n < (int)sizeof b - 4; k++) n += snprintf(b + n, sizeof b - n, " %02x", p[k]);
+            if (n < (int)sizeof b - 1) b[n++] = '\n';
+            ssize_t w = syscall(SYS_write, 2, b, (size_t)n); (void)w;
+        }
         // PROSPER_HWBP race-free hardware breakpoint. The perf event is disabled while single-stepping,
         // so a SIGTRAP while g_hwbp_stepping is the step-completion (TF) -> re-enable + clear TF. Any
         // other SIGTRAP while armed is a HW-breakpoint hit -> log registers, then disable + single-step
@@ -1056,14 +1065,6 @@ namespace {
             if (g_base && g_fault_rip == g_base + foff) { g[REG_RAX] = 0; g[REG_RIP] = g_base + roff; return; }
         }
         dump_fault_mem();   // no-op unless PROSPER_FAULTMEM is set
-        // PROSPER_FATAL_TRAP=1: re-raise the fatal fault as a default-action SIGTRAP HERE, with the
-        // faulting thread's full context intact — under gdb this stops at the real fault (instead of
-        // the process racing on to siglongjmp/_exit), and bare it dumps a core with EVERY thread's
-        // stack (the cross-thread evidence a data-race diagnosis needs). Diagnostic only.
-        if (g_fatal_trap) {
-            signal(SIGTRAP, SIG_DFL);
-            syscall(SYS_tgkill, (pid_t)syscall(SYS_getpid), (pid_t)cur_tid(), SIGTRAP);
-        }
         // Dump the HWBP ring on the recoverable (armed/main-thread) crash too — the deser fault is kind=2.
         if (g_hwbp_node_on && !g_hwbp_ring_dumped) { uint64_t sfs = guest_fs_to_host_scoped();
             hwbp_dump_ring("recover"); guest_fs_restore_scoped(sfs); }
@@ -1247,7 +1248,6 @@ void install_trap_handler() {
         arm_hwwatch(addr);
     };
     g_faultlog = getenv("PROSPER_FAULTLOG") != nullptr;
-    g_fatal_trap = getenv("PROSPER_FATAL_TRAP") != nullptr;   // latched (getenv is not signal-safe)
     g_skip_null_companion = getenv("PROSPER_SKIP_NULL_COMPANION") != nullptr;
     g_null_page = getenv("PROSPER_NULL_PAGE") != nullptr;
     g_watch_companion = getenv("PROSPER_WATCH_COMPANION") != nullptr;

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -262,9 +262,17 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
         return 0;
     };
     std::unordered_map<uint32_t, uint64_t> histo, unhandled;
+    // PROSPER_GOT_NID=<image-relative GOT vaddr>: log which import NID fills that slot. Used to map a
+    // PLT stub (jmp *GOT) seen in a disassembly/crash back to its Sony symbol (e.g. #283).
+    uint64_t want_got = 0;
+    if (const char* g = getenv("PROSPER_GOT_NID")) want_got = strtoull(g, nullptr, 0);
     for (auto& r : m.relocs) {
         uint64_t va = img.base + r.offset;
         histo[r.type]++;
+        if (want_got && r.offset == want_got && r.sym < m.symbols.size())
+            fprintf(stderr, "[got-nid] GOT reloc @0x%llx (loaded 0x%llx) type=%u -> import '%s'\n",
+                    (unsigned long long)r.offset, (unsigned long long)va, r.type,
+                    m.symbols[r.sym].nid.c_str());
         switch (r.type) {
             case R_X86_64_RELATIVE:  if (write64(va, img.base + (uint64_t)r.addend)) applied++; break;
             case R_X86_64_64:        if (write64(va, sym_addr(r.sym) + (uint64_t)r.addend)) applied++; break;


### PR DESCRIPTION
Two small diagnostics that pinned down the New Game gameplay-wall crash (#283): SIGILL byte logging (revealed the fault is UD2, not a missing ISA op) and a __stack_chk_fail canary logger. Diagnostic-only. Refs #283.