### PR TITLE
fix(pad): ScePadControllerInformation is 28 bytes, not 32 — stops a guest stack overflow (Fixes #283)

### DIFF
--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -25,7 +25,7 @@ static_assert(offsetof(ScePadData, ext_unit_id)        == 0x58, "ext_unit_id");
 static_assert(offsetof(ScePadData, connected_count)    == 0x68, "connected_count");
 static_assert(offsetof(ScePadData, device_unique_data) == 0x6c, "device_unique_data");
 
-static_assert(sizeof(ScePadControllerInformation) == 32, "ScePadControllerInformation must be 32 bytes");
+static_assert(sizeof(ScePadControllerInformation) == 28, "ScePadControllerInformation must be 28 bytes (Sony reserve[8], #283)");
 static_assert(offsetof(ScePadControllerInformation, device_class) == 0x10, "device_class");
 
 uint8_t pad_axis_u8(int raw, int min, int max) {

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -111,8 +111,10 @@ struct ScePadControllerInformation {
     uint8_t  connected;                     // 0x0c (bool)
     uint8_t  info_pad[3];                    // 0x0d (align device_class to 4)
     int32_t  device_class;                  // 0x10
-    uint8_t  reserve[12];                    // 0x14
-};                                          // 0x20 = 32 bytes
+    uint8_t  reserve[8];                     // 0x14
+};                                          // 0x1c = 28 bytes (Sony's real size — reserve[8], NOT [12];
+                                            // a 32-byte struct overran the game's 28-byte stack buffer
+                                            // into its stack canary -> __stack_chk_fail crash, #283)
 
 // ---- Pure mapping (no hardware, no globals) ---------------------------------------------------
 

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -29,7 +29,10 @@ int main() {
     CHECK(offsetof(ScePadData, connected) == 0x4c, "connected @ 0x4c");
     CHECK(offsetof(ScePadData, timestamp) == 0x50, "timestamp @ 0x50");
     CHECK(offsetof(ScePadData, connected_count) == 0x68, "connected_count @ 0x68");
-    CHECK(sizeof(ScePadControllerInformation) == 32, "sizeof(ScePadControllerInformation) == 32");
+    // Sony's real ScePadControllerInformation is 0x1c = 28 bytes (deviceClass@0x10 + reserve[8]),
+    // matched by shadPS4/Kyty AND by the live guest, whose compiler placed its stack canary exactly
+    // 0x1c after the struct. A 32-byte struct overran that 28-byte buffer -> canary crash (#283).
+    CHECK(sizeof(ScePadControllerInformation) == 28, "sizeof(ScePadControllerInformation) == 28");
     CHECK(offsetof(ScePadControllerInformation, device_class) == 0x10, "device_class @ 0x10");
 
     // (2) Neutral state -> centered sticks, zero buttons, released triggers, identity orientation.


### PR DESCRIPTION
## What

`ScePadControllerInformation` was declared with `reserve[12]` (32 bytes); Sony's real layout is `deviceClass@0x10` + `reserve[8]` = **0x1c = 28 bytes**. `pad_fill_controller_info` does `memset(out, 0, sizeof)` + fills, so on `scePadGetControllerInformation` we wrote **4 bytes past the guest's 28-byte stack buffer**, clobbering its stack canary. The guest's `-fstack-protector` epilogue then failed the canary check, called `__stack_chk_fail`, and fell into the trailing `UD2` → **SIGILL** at `eboot+0x69d44b`. This crashed the **New Game / gameplay-start** path (the first caller of this function).

## Evidence (three independent sources agree on 28 bytes)
- **Live guest:** the crashing function `eboot+0x69d310` placed its canary copy exactly `0x1c` after the out-struct base (`-0x4c(%rbp)` struct, `-0x30(%rbp)` canary) — the game's compiler reserved 28 bytes.
- **shadPS4** (`pad/pad.h`): `OrbisPadControllerInformation` = `deviceClass` + `u8 reserve[8]`.
- **Kyty** (`Controller.cpp`): struct ends at `device_class` (≤ 28 bytes).

## Fix
`reserve[12]` → `reserve[8]` (struct now 28 bytes). Updated the compile-time `static_assert` and the `test_pad` size check to 28. No field offsets change (`device_class` stays @0x10).

## Verification
- `test_pad` green; full `ctest` build clean.
- **Boot:** the New Game input path that previously SIGILL'd at `eboot+0x69d44b` now runs the full 200s with **zero crash markers** and progresses into gameplay **level loading (level0–level5)**.

The diagnostics that found this (SIGILL byte log, `__stack_chk_fail` logger, `PROSPER_GOT_NID`) are in #285.

Fixes #283.