### PR TITLE
fix(gpu): BC4/BC5/BC7 texture decode + real-bpt fp16 upload (Fixes #290)

### DIFF
--- a/prosper/docs/GFX10_SW_64KB_TILING.md
+++ b/prosper/docs/GFX10_SW_64KB_TILING.md
@@ -104,12 +104,23 @@ modes + addrlib golden byte positions). Refs: #288 (this work), #282 (the refram
 
 ## Remaining texture walls after #288 (NOT tiling)
 
-Even with correct 64KB detiling, DOLL's presented frame keeps noise/black regions because:
-- **fp16 textures upload as RGBA8**: `live_renderer.cpp` clamps `bpt > 4` to 4, so fmt 71
-  (Float16×4), 13/14 (Float16) sample as garbage confetti regardless of detile — needs an
-  fp16→RGBA8 (or native-format) upload path.
-- **BC4/BC5/BC6/BC7 bindings are skipped** (`agc_shader_layout.cpp` policy: decode not wired) —
-  fmt 175/177/179/181/182 draws drop; a large share of DOLL's mode-9 materials are BC7 (fmt 182).
-- **RT sampling**: rendered pixels live host-side in `g_rtt` (`PROSPER_RTT` injection); they are
-  never written back tiled to guest memory, so composites sampling an RT need PROSPER_RTT, not
-  the detiler.
+Two of the three walls were closed by #290:
+- ~~fp16 textures upload as RGBA8~~ **FIXED (#290)**: fp16 surfaces (fmt 71 Float16×4, 29, 13) are
+  now read at the real bytes-per-texel, detiled with the real element size, and converted
+  half→UNORM8 (exact binary16 decode, unit-tested; values clamp to [0,1] — native
+  `R16G16B16A16_SFLOAT` upload for HDR >1.0 energy is a documented follow-up).
+- ~~BC4/BC5/BC7 bindings are skipped~~ **FIXED (#290)**: full BC4/BC5/BC7 decoders in
+  `bc_decode.cpp`, fuzz-validated byte-exact vs texture2ddecoder (4000 BC7 blocks covering all 8
+  modes + 1000 each BC4/BC5). Live DOLL BC7_SRGB atlases (fmt 182, 1024×1024 / 2048×1024, mode 9)
+  decode through `detile_elements` + `bc_decode_surface` into fully coherent cloud sprite atlases
+  (TV ≈ 1.6). Still skipped: **BC6H** (fmt 179/180, HDR half-float — no decode) and **SNORM
+  BC4/BC5** (fmt 176/178 — the UNORM8 upload can't carry signed samples).
+- **RT sampling — now the dominant wall**: rendered pixels live host-side in `g_rtt`
+  (`PROSPER_RTT` injection); they are never written back tiled to guest memory, so every draw
+  sampling an RT-mode (tm27) surface reads stale garbage — DOLL's presented frame is dominated by
+  its bloom chain (fmt 71 fp16 RTs, 960×540…240×135) and final composite (fmt 36 =
+  `10_11_11_FLOAT`, the UE4 R11G11B10F scene color, 3840×2160/1920×1080 — unmapped, skipped
+  without RTT) sampling those unwritten RTs. Verified from a live capture: the 480×270 fmt-71
+  "bloom" guest memory decodes to NaN/inf-laden speckle — correctly-decoded garbage input, not a
+  decode bug. Fixing this means RTT injection keyed to those targets (plus mapping fmt 36 for the
+  injection path), not the detiler.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -94,8 +94,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // which is why glyph text rendered as solid white/black BLOCKS (#102). bpt drives a
                         // narrow read+expand path below. StorageImage / unknown formats keep 4 B (bpt=0->4).
                         uint32_t bpt = prosper::gpu::data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
-                        if (bpt == 0 || bpt > 4) bpt = 4;
+                        // fp16 surfaces (fmt 71 Float16x4 = 8 B/texel, 29 = 4 B, 13 = 2 B) get a real
+                        // half->UNORM8 conversion path below; everything else unknown/oversized keeps
+                        // the legacy RGBA8 read (bpt=4).
+                        const bool f16 = r.format == prosper::gpu::DataFormat::Float16 &&
+                                         (bpt == 2 || bpt == 4 || bpt == 8);
+                        if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
                         bool narrow_done = false;
+                        bool f16_done = false;
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
@@ -136,6 +142,42 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 safe_copy(lin.data(), r.gpu_addr, comp_bytes);
                             }
                             prosper::gpu::bc_decode_surface(texstore.back().data(), lin.data(), lin.size(), tw, th, r.format);
+                        } else if (f16) {
+                            // fp16 texture (#290 wall 1): read at the REAL bytes-per-texel and detile
+                            // with the REAL element size — the old clamp read an 8-B/texel Float16x4
+                            // surface at 4 B AND detiled it with bpe=4 against 8-B tiled elements, so
+                            // the result was doubly wrong ("confetti" regions, e.g. DOLL's 960x540 /
+                            // 480x270 bloom-chain buffers). Convert half->UNORM8 on upload: the backend
+                            // uploads RGBA8 only (the whole render path is 8-bit gamma space — see the
+                            // #263 note in render_runner), so HDR values above 1.0 clamp to 255.
+                            // Missing components read (0,0,0,1) per the hardware rule; the T# DST_SEL
+                            // swizzle still applies. CONFIDENCE: MED — the half decode is exact and
+                            // unit-tested, but the [0,1] clamp loses >1.0 bloom energy (native
+                            // VK_FORMAT_R16G16B16A16_SFLOAT upload is the documented follow-up).
+                            const uint32_t nc = bpt / 2;                    // fp16 components per texel
+                            std::vector<uint8_t> hlin((size_t)tw * th * bpt, 0);
+                            bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                            if (tiled) {
+                                size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
+                                std::vector<uint8_t> traw(tbytes, 0);
+                                size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                if (got < hlin.size()) safe_copy(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
+                                else prosper::gpu::detile_surface(hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                            } else {
+                                safe_copy(hlin.data(), r.gpu_addr, hlin.size());
+                            }
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint8_t* p = &texstore.back()[t * 4];
+                                for (uint32_t c = 0; c < 4; c++) {
+                                    if (c < nc) {
+                                        uint16_t hv; std::memcpy(&hv, &hlin[t * bpt + c * 2], 2);
+                                        float f = prosper::gpu::half_to_float(hv);
+                                        p[c] = (f != f || f <= 0.f) ? 0                     // NaN/neg -> 0
+                                             : (f >= 1.f ? 255 : (uint8_t)(f * 255.f + 0.5f));
+                                    } else p[c] = (c == 3) ? 255 : 0;       // absent: (.,0,0,1)
+                                }
+                            }
+                            f16_done = true;   // read+detiled at the real element size already
                         } else if (bpt < 4) {
                             // Narrow (single/dual-channel) surface: read at the REAL element size and detile
                             // with the matching bpe geometry (1 B -> 64x64 micro-tiles, #119), then expand
@@ -200,7 +242,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!rtt_hit && !bcb && !narrow_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                        if (!rtt_hit && !bcb && !narrow_done && !f16_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
                             size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -93,9 +93,9 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
     auto plain = [&](DataFormat f, uint32_t n, bool srgb = false) {
         fi.format = f; fi.num_components = n; fi.bytes_per_block = data_format_bytes(f) * n; fi.srgb = srgb;
     };
-    auto bcn = [&](DataFormat f, uint32_t n, uint32_t bpb, bool srgb = false) {
+    auto bcn = [&](DataFormat f, uint32_t n, uint32_t bpb, bool srgb = false, bool snorm = false) {
         fi.format = f; fi.num_components = n; fi.bytes_per_block = bpb;
-        fi.block_width = fi.block_height = 4; fi.srgb = srgb;
+        fi.block_width = fi.block_height = 4; fi.srgb = srgb; fi.snorm = snorm;
     };
     if (fmt >= 1 && fmt <= 77) {                 // shared with the V# buffer-format numbering
         DataFormat f = DataFormat::Unknown; uint32_t n = 0;
@@ -111,9 +111,11 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
         case 172: bcn(DataFormat::Bc2, 4, 16, true);  break;   // BC2_SRGB
         case 173: bcn(DataFormat::Bc3, 4, 16);        break;   // BC3_UNORM
         case 174: bcn(DataFormat::Bc3, 4, 16, true);  break;   // BC3_SRGB
-        case 175: case 176: bcn(DataFormat::Bc4, 1,  8); break; // BC4_UNORM/_SNORM (snorm not modeled
-        case 177: case 178: bcn(DataFormat::Bc5, 2, 16); break; // BC5_UNORM/_SNORM  yet — skip-only)
-        case 179: case 180: bcn(DataFormat::Bc6, 3, 16); break; // BC6_UFLOAT/_SFLOAT
+        case 175: bcn(DataFormat::Bc4, 1,  8);                    break; // BC4_UNORM
+        case 176: bcn(DataFormat::Bc4, 1,  8, false, true);       break; // BC4_SNORM (skip-only: signed)
+        case 177: bcn(DataFormat::Bc5, 2, 16);                    break; // BC5_UNORM
+        case 178: bcn(DataFormat::Bc5, 2, 16, false, true);       break; // BC5_SNORM (skip-only: signed)
+        case 179: case 180: bcn(DataFormat::Bc6, 3, 16); break; // BC6_UFLOAT/_SFLOAT (decode not wired)
         case 181: bcn(DataFormat::Bc7, 4, 16);        break;   // BC7_UNORM
         case 182: bcn(DataFormat::Bc7, 4, 16, true);  break;   // BC7_SRGB
         default: break;                                         // unmapped -> false
@@ -282,14 +284,16 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 fi.format = DataFormat::Unorm8; fi.num_components = 4; fi.bytes_per_block = 4;
                 fi.block_width = fi.block_height = 1;
             }
-            // Block-compressed: BC1/BC2/BC3 are decoded to RGBA8 on upload (bc_decode). BC4/5/6/7 aren't
-            // decoded yet, so keep skipping them (a raw RGBA8 binding would sample garbage + over-read).
+            // Block-compressed: BC1/2/3/4/5/7 are decoded to RGBA8 on upload (bc_decode, #290). Still
+            // skipped: BC6H (HDR half-float — no decode wired) and the SNORM BC4/BC5 variants (the
+            // UNORM8 upload can't carry signed samples; a remapped decode would be numerically wrong).
             const bool is_bcn = fi.block_width > 1;
-            if (is_bcn && fi.format != DataFormat::Bc1 && fi.format != DataFormat::Bc2 &&
-                          fi.format != DataFormat::Bc3) {
+            if (is_bcn && (fi.format == DataFormat::Bc6 || fi.snorm)) {
                 if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
-                    fprintf(stderr, "[t#] Gen5 IMG_FMT %u is block-compressed BC4-7 (%ux%u T#) -> decode not "
-                                    "wired; skipping texture binding\n", d.format, d.width, d.height); }
+                    fprintf(stderr, "[t#] Gen5 IMG_FMT %u is %s (%ux%u T#) -> decode not "
+                                    "wired; skipping texture binding\n", d.format,
+                            fi.format == DataFormat::Bc6 ? "BC6H (HDR)" : "SNORM BCn",
+                            d.width, d.height); }
                 continue;
             }
             ShaderResource r;

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -83,6 +83,9 @@ struct Gen5ImageFormatInfo {
     uint32_t   block_width = 1, block_height = 1;
     bool       srgb = false;   // gamma-encoded variant (sampling it as UNORM is a gamma error only,
                                // not garbage — the numbering distinguishes e.g. 56 vs 130)
+    bool       snorm = false;  // signed-normalized BCn variant (BC4/BC5_SNORM, fmt 176/178): the
+                               // UNORM8 upload path can't carry signed samples, so callers keep
+                               // skipping these (the UNORM decode would be numerically wrong).
 };
 // Map a T#'s 9-bit Gen5 IMG_FMT value to format info. Returns false (out left Unknown/zero) for
 // values not in the table — callers must not assume RGBA8 for those (#65). Pure; exposed for testing.

--- a/prosper/src/gpu/bc_decode.cpp
+++ b/prosper/src/gpu/bc_decode.cpp
@@ -66,12 +66,296 @@ void decode_bc2_alpha(const uint8_t* blk, uint8_t out[16][4]) {
     }
 }
 
+// BC4 single-channel sub-block (8 bytes): identical structure to the BC3 alpha sub-block — two 8-bit
+// endpoints + 16 x 3-bit indices into an 8-entry ramp (6 interpolants when e0>e1, else 4 interpolants
+// + literal 0 and 255). Emits the 16 channel VALUES; the caller places them in R (BC4) or R/G (BC5).
+void decode_bc4_channel(const uint8_t* blk, uint8_t vals[16]) {
+    uint8_t a0 = blk[0], a1 = blk[1];
+    uint8_t a[8];
+    a[0] = a0; a[1] = a1;
+    if (a0 > a1) for (int i = 1; i <= 6; i++) a[i + 1] = (uint8_t)(((7 - i) * a0 + i * a1) / 7);
+    else { for (int i = 1; i <= 4; i++) a[i + 1] = (uint8_t)(((5 - i) * a0 + i * a1) / 5); a[6] = 0; a[7] = 255; }
+    uint64_t bits = 0; for (int i = 0; i < 6; i++) bits |= (uint64_t)blk[2 + i] << (i * 8);
+    for (int t = 0; t < 16; t++) vals[t] = a[(bits >> (t * 3)) & 0x7u];
+}
+
+// ---------------------------------------------------------------------------------------------------
+// BC7 (BPTC_UNORM) — Khronos Data Format spec §BPTC / Microsoft D3D11 functional spec §19.5.
+// Constant tables (mode field widths, partition/anchor assignments, interpolation weights) are the
+// published spec constants, taken verbatim from bcdec (MIT/Unlicense, Sergii Kudlai) — the partition
+// table entries carry the anchor ("fix-up") flag in bit 7 (128+subset), exactly as bcdec encodes them.
+// Decode logic written against the spec and fuzz-validated byte-exact vs texture2ddecoder (see
+// tests/test_bc_decode.cpp for the hand vectors; the random-block cross-check ran pre-merge).
+
+// Per-mode endpoint component precision: [0] = RGB bits, [1] = alpha bits (0 = opaque mode).
+static const uint8_t kBc7ColorBits[8] = { 4, 6, 5, 7, 5, 7, 7, 5 };
+static const uint8_t kBc7AlphaBits[8] = { 0, 0, 0, 0, 6, 8, 7, 5 };
+// Modes with a per-endpoint p-bit (0,3,6,7) — mode 1 has per-SUBSET shared p-bits, handled separately.
+static const uint8_t kBc7ModeHasPBits = 0xCB;   // 0b11001011
+
+// Partition/anchor table (spec constants; anchor texels flagged with +128, subset id in low bits).
+static const uint8_t kBc7PartitionSets[2][64][4][4] = {
+        {   /* Partition table for 2-subset BPTC */
+            { {128, 0,   1, 1}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {0, 0, 1, 129} }, /*  0 */
+            { {128, 0,   0, 1}, {0, 0,   0, 1}, {  0, 0, 0, 1}, {0, 0, 0, 129} }, /*  1 */
+            { {128, 1,   1, 1}, {0, 1,   1, 1}, {  0, 1, 1, 1}, {0, 1, 1, 129} }, /*  2 */
+            { {128, 0,   0, 1}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} }, /*  3 */
+            { {128, 0,   0, 0}, {0, 0,   0, 1}, {  0, 0, 0, 1}, {0, 0, 1, 129} }, /*  4 */
+            { {128, 0,   1, 1}, {0, 1,   1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} }, /*  5 */
+            { {128, 0,   0, 1}, {0, 0,   1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} }, /*  6 */
+            { {128, 0,   0, 0}, {0, 0,   0, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} }, /*  7 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  0, 0, 0, 1}, {0, 0, 1, 129} }, /*  8 */
+            { {128, 0,   1, 1}, {0, 1,   1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /*  9 */
+            { {128, 0,   0, 0}, {0, 0,   0, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} }, /* 10 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  0, 0, 0, 1}, {0, 1, 1, 129} }, /* 11 */
+            { {128, 0,   0, 1}, {0, 1,   1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /* 12 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /* 13 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /* 14 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  0, 0, 0, 0}, {1, 1, 1, 129} }, /* 15 */
+            { {128, 0,   0, 0}, {1, 0,   0, 0}, {  1, 1, 1, 0}, {1, 1, 1, 129} }, /* 16 */
+            { {128, 1, 129, 1}, {0, 0,   0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} }, /* 17 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {129, 0, 0, 0}, {1, 1, 1,   0} }, /* 18 */
+            { {128, 1, 129, 1}, {0, 0,   1, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} }, /* 19 */
+            { {128, 0, 129, 1}, {0, 0,   0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} }, /* 20 */
+            { {128, 0,   0, 0}, {1, 0,   0, 0}, {129, 1, 0, 0}, {1, 1, 1,   0} }, /* 21 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} }, /* 22 */
+            { {128, 1,   1, 1}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {0, 0, 0, 129} }, /* 23 */
+            { {128, 0, 129, 1}, {0, 0,   0, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} }, /* 24 */
+            { {128, 0,   0, 0}, {1, 0,   0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} }, /* 25 */
+            { {128, 1, 129, 0}, {0, 1,   1, 0}, {  0, 1, 1, 0}, {0, 1, 1,   0} }, /* 26 */
+            { {128, 0, 129, 1}, {0, 1,   1, 0}, {  0, 1, 1, 0}, {1, 1, 0,   0} }, /* 27 */
+            { {128, 0,   0, 1}, {0, 1,   1, 1}, {129, 1, 1, 0}, {1, 0, 0,   0} }, /* 28 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {129, 1, 1, 1}, {0, 0, 0,   0} }, /* 29 */
+            { {128, 1, 129, 1}, {0, 0,   0, 1}, {  1, 0, 0, 0}, {1, 1, 1,   0} }, /* 30 */
+            { {128, 0, 129, 1}, {1, 0,   0, 1}, {  1, 0, 0, 1}, {1, 1, 0,   0} }, /* 31 */
+            { {128, 1,   0, 1}, {0, 1,   0, 1}, {  0, 1, 0, 1}, {0, 1, 0, 129} }, /* 32 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {  0, 0, 0, 0}, {1, 1, 1, 129} }, /* 33 */
+            { {128, 1,   0, 1}, {1, 0, 129, 0}, {  0, 1, 0, 1}, {1, 0, 1,   0} }, /* 34 */
+            { {128, 0,   1, 1}, {0, 0,   1, 1}, {129, 1, 0, 0}, {1, 1, 0,   0} }, /* 35 */
+            { {128, 0, 129, 1}, {1, 1,   0, 0}, {  0, 0, 1, 1}, {1, 1, 0,   0} }, /* 36 */
+            { {128, 1,   0, 1}, {0, 1,   0, 1}, {129, 0, 1, 0}, {1, 0, 1,   0} }, /* 37 */
+            { {128, 1,   1, 0}, {1, 0,   0, 1}, {  0, 1, 1, 0}, {1, 0, 0, 129} }, /* 38 */
+            { {128, 1,   0, 1}, {1, 0,   1, 0}, {  1, 0, 1, 0}, {0, 1, 0, 129} }, /* 39 */
+            { {128, 1, 129, 1}, {0, 0,   1, 1}, {  1, 1, 0, 0}, {1, 1, 1,   0} }, /* 40 */
+            { {128, 0,   0, 1}, {0, 0,   1, 1}, {129, 1, 0, 0}, {1, 0, 0,   0} }, /* 41 */
+            { {128, 0, 129, 1}, {0, 0,   1, 0}, {  0, 1, 0, 0}, {1, 1, 0,   0} }, /* 42 */
+            { {128, 0, 129, 1}, {1, 0,   1, 1}, {  1, 1, 0, 1}, {1, 1, 0,   0} }, /* 43 */
+            { {128, 1, 129, 0}, {1, 0,   0, 1}, {  1, 0, 0, 1}, {0, 1, 1,   0} }, /* 44 */
+            { {128, 0,   1, 1}, {1, 1,   0, 0}, {  1, 1, 0, 0}, {0, 0, 1, 129} }, /* 45 */
+            { {128, 1,   1, 0}, {0, 1,   1, 0}, {  1, 0, 0, 1}, {1, 0, 0, 129} }, /* 46 */
+            { {128, 0,   0, 0}, {0, 1, 129, 0}, {  0, 1, 1, 0}, {0, 0, 0,   0} }, /* 47 */
+            { {128, 1,   0, 0}, {1, 1, 129, 0}, {  0, 1, 0, 0}, {0, 0, 0,   0} }, /* 48 */
+            { {128, 0, 129, 0}, {0, 1,   1, 1}, {  0, 0, 1, 0}, {0, 0, 0,   0} }, /* 49 */
+            { {128, 0,   0, 0}, {0, 0, 129, 0}, {  0, 1, 1, 1}, {0, 0, 1,   0} }, /* 50 */
+            { {128, 0,   0, 0}, {0, 1,   0, 0}, {129, 1, 1, 0}, {0, 1, 0,   0} }, /* 51 */
+            { {128, 1,   1, 0}, {1, 1,   0, 0}, {  1, 0, 0, 1}, {0, 0, 1, 129} }, /* 52 */
+            { {128, 0,   1, 1}, {0, 1,   1, 0}, {  1, 1, 0, 0}, {1, 0, 0, 129} }, /* 53 */
+            { {128, 1, 129, 0}, {0, 0,   1, 1}, {  1, 0, 0, 1}, {1, 1, 0,   0} }, /* 54 */
+            { {128, 0, 129, 1}, {1, 0,   0, 1}, {  1, 1, 0, 0}, {0, 1, 1,   0} }, /* 55 */
+            { {128, 1,   1, 0}, {1, 1,   0, 0}, {  1, 1, 0, 0}, {1, 0, 0, 129} }, /* 56 */
+            { {128, 1,   1, 0}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {1, 0, 0, 129} }, /* 57 */
+            { {128, 1,   1, 1}, {1, 1,   1, 0}, {  1, 0, 0, 0}, {0, 0, 0, 129} }, /* 58 */
+            { {128, 0,   0, 1}, {1, 0,   0, 0}, {  1, 1, 1, 0}, {0, 1, 1, 129} }, /* 59 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {  0, 0, 1, 1}, {0, 0, 1, 129} }, /* 60 */
+            { {128, 0, 129, 1}, {0, 0,   1, 1}, {  1, 1, 1, 1}, {0, 0, 0,   0} }, /* 61 */
+            { {128, 0, 129, 0}, {0, 0,   1, 0}, {  1, 1, 1, 0}, {1, 1, 1,   0} }, /* 62 */
+            { {128, 1,   0, 0}, {0, 1,   0, 0}, {  0, 1, 1, 1}, {0, 1, 1, 129} }  /* 63 */
+        },
+        {   /* Partition table for 3-subset BPTC */
+            { {128, 0, 1, 129}, {0,   0,   1, 1}, {  0,   2,   2, 1}, {  2,   2, 2, 130} }, /*  0 */
+            { {128, 0, 0, 129}, {0,   0,   1, 1}, {130,   2,   1, 1}, {  2,   2, 2,   1} }, /*  1 */
+            { {128, 0, 0,   0}, {2,   0,   0, 1}, {130,   2,   1, 1}, {  2,   2, 1, 129} }, /*  2 */
+            { {128, 2, 2, 130}, {0,   0,   2, 2}, {  0,   0,   1, 1}, {  0,   1, 1, 129} }, /*  3 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {129,   1,   2, 2}, {  1,   1, 2, 130} }, /*  4 */
+            { {128, 0, 1, 129}, {0,   0,   1, 1}, {  0,   0,   2, 2}, {  0,   0, 2, 130} }, /*  5 */
+            { {128, 0, 2, 130}, {0,   0,   2, 2}, {  1,   1,   1, 1}, {  1,   1, 1, 129} }, /*  6 */
+            { {128, 0, 1,   1}, {0,   0,   1, 1}, {130,   2,   1, 1}, {  2,   2, 1, 129} }, /*  7 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {129,   1,   1, 1}, {  2,   2, 2, 130} }, /*  8 */
+            { {128, 0, 0,   0}, {1,   1,   1, 1}, {129,   1,   1, 1}, {  2,   2, 2, 130} }, /*  9 */
+            { {128, 0, 0,   0}, {1,   1, 129, 1}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 10 */
+            { {128, 0, 1,   2}, {0,   0, 129, 2}, {  0,   0,   1, 2}, {  0,   0, 1, 130} }, /* 11 */
+            { {128, 1, 1,   2}, {0,   1, 129, 2}, {  0,   1,   1, 2}, {  0,   1, 1, 130} }, /* 12 */
+            { {128, 1, 2,   2}, {0, 129,   2, 2}, {  0,   1,   2, 2}, {  0,   1, 2, 130} }, /* 13 */
+            { {128, 0, 1, 129}, {0,   1,   1, 2}, {  1,   1,   2, 2}, {  1,   2, 2, 130} }, /* 14 */
+            { {128, 0, 1, 129}, {2,   0,   0, 1}, {130,   2,   0, 0}, {  2,   2, 2,   0} }, /* 15 */
+            { {128, 0, 0, 129}, {0,   0,   1, 1}, {  0,   1,   1, 2}, {  1,   1, 2, 130} }, /* 16 */
+            { {128, 1, 1, 129}, {0,   0,   1, 1}, {130,   0,   0, 1}, {  2,   2, 0,   0} }, /* 17 */
+            { {128, 0, 0,   0}, {1,   1,   2, 2}, {129,   1,   2, 2}, {  1,   1, 2, 130} }, /* 18 */
+            { {128, 0, 2, 130}, {0,   0,   2, 2}, {  0,   0,   2, 2}, {  1,   1, 1, 129} }, /* 19 */
+            { {128, 1, 1, 129}, {0,   1,   1, 1}, {  0,   2,   2, 2}, {  0,   2, 2, 130} }, /* 20 */
+            { {128, 0, 0, 129}, {0,   0,   0, 1}, {130,   2,   2, 1}, {  2,   2, 2,   1} }, /* 21 */
+            { {128, 0, 0,   0}, {0,   0, 129, 1}, {  0,   1,   2, 2}, {  0,   1, 2, 130} }, /* 22 */
+            { {128, 0, 0,   0}, {1,   1,   0, 0}, {130,   2, 129, 0}, {  2,   2, 1,   0} }, /* 23 */
+            { {128, 1, 2, 130}, {0, 129,   2, 2}, {  0,   0,   1, 1}, {  0,   0, 0,   0} }, /* 24 */
+            { {128, 0, 1,   2}, {0,   0,   1, 2}, {129,   1,   2, 2}, {  2,   2, 2, 130} }, /* 25 */
+            { {128, 1, 1,   0}, {1,   2, 130, 1}, {129,   2,   2, 1}, {  0,   1, 1,   0} }, /* 26 */
+            { {128, 0, 0,   0}, {0,   1, 129, 0}, {  1,   2, 130, 1}, {  1,   2, 2,   1} }, /* 27 */
+            { {128, 0, 2,   2}, {1,   1,   0, 2}, {129,   1,   0, 2}, {  0,   0, 2, 130} }, /* 28 */
+            { {128, 1, 1,   0}, {0, 129,   1, 0}, {  2,   0,   0, 2}, {  2,   2, 2, 130} }, /* 29 */
+            { {128, 0, 1,   1}, {0,   1,   2, 2}, {  0,   1, 130, 2}, {  0,   0, 1, 129} }, /* 30 */
+            { {128, 0, 0,   0}, {2,   0,   0, 0}, {130,   2,   1, 1}, {  2,   2, 2, 129} }, /* 31 */
+            { {128, 0, 0,   0}, {0,   0,   0, 2}, {129,   1,   2, 2}, {  1,   2, 2, 130} }, /* 32 */
+            { {128, 2, 2, 130}, {0,   0,   2, 2}, {  0,   0,   1, 2}, {  0,   0, 1, 129} }, /* 33 */
+            { {128, 0, 1, 129}, {0,   0,   1, 2}, {  0,   0,   2, 2}, {  0,   2, 2, 130} }, /* 34 */
+            { {128, 1, 2,   0}, {0, 129,   2, 0}, {  0,   1, 130, 0}, {  0,   1, 2,   0} }, /* 35 */
+            { {128, 0, 0,   0}, {1,   1, 129, 1}, {  2,   2, 130, 2}, {  0,   0, 0,   0} }, /* 36 */
+            { {128, 1, 2,   0}, {1,   2,   0, 1}, {130,   0, 129, 2}, {  0,   1, 2,   0} }, /* 37 */
+            { {128, 1, 2,   0}, {2,   0,   1, 2}, {129, 130,   0, 1}, {  0,   1, 2,   0} }, /* 38 */
+            { {128, 0, 1,   1}, {2,   2,   0, 0}, {  1,   1, 130, 2}, {  0,   0, 1, 129} }, /* 39 */
+            { {128, 0, 1,   1}, {1,   1, 130, 2}, {  2,   2,   0, 0}, {  0,   0, 1, 129} }, /* 40 */
+            { {128, 1, 0, 129}, {0,   1,   0, 1}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 41 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {130,   1,   2, 1}, {  2,   1, 2, 129} }, /* 42 */
+            { {128, 0, 2,   2}, {1, 129,   2, 2}, {  0,   0,   2, 2}, {  1,   1, 2, 130} }, /* 43 */
+            { {128, 0, 2, 130}, {0,   0,   1, 1}, {  0,   0,   2, 2}, {  0,   0, 1, 129} }, /* 44 */
+            { {128, 2, 2,   0}, {1,   2, 130, 1}, {  0,   2,   2, 0}, {  1,   2, 2, 129} }, /* 45 */
+            { {128, 1, 0,   1}, {2,   2, 130, 2}, {  2,   2,   2, 2}, {  0,   1, 0, 129} }, /* 46 */
+            { {128, 0, 0,   0}, {2,   1,   2, 1}, {130,   1,   2, 1}, {  2,   1, 2, 129} }, /* 47 */
+            { {128, 1, 0, 129}, {0,   1,   0, 1}, {  0,   1,   0, 1}, {  2,   2, 2, 130} }, /* 48 */
+            { {128, 2, 2, 130}, {0,   1,   1, 1}, {  0,   2,   2, 2}, {  0,   1, 1, 129} }, /* 49 */
+            { {128, 0, 0,   2}, {1, 129,   1, 2}, {  0,   0,   0, 2}, {  1,   1, 1, 130} }, /* 50 */
+            { {128, 0, 0,   0}, {2, 129,   1, 2}, {  2,   1,   1, 2}, {  2,   1, 1, 130} }, /* 51 */
+            { {128, 2, 2,   2}, {0, 129,   1, 1}, {  0,   1,   1, 1}, {  0,   2, 2, 130} }, /* 52 */
+            { {128, 0, 0,   2}, {1,   1,   1, 2}, {129,   1,   1, 2}, {  0,   0, 0, 130} }, /* 53 */
+            { {128, 1, 1,   0}, {0, 129,   1, 0}, {  0,   1,   1, 0}, {  2,   2, 2, 130} }, /* 54 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {  2,   1, 129, 2}, {  2,   1, 1, 130} }, /* 55 */
+            { {128, 1, 1,   0}, {0, 129,   1, 0}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 56 */
+            { {128, 0, 2,   2}, {0,   0,   1, 1}, {  0,   0, 129, 1}, {  0,   0, 2, 130} }, /* 57 */
+            { {128, 0, 2,   2}, {1,   1,   2, 2}, {129,   1,   2, 2}, {  0,   0, 2, 130} }, /* 58 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {  0,   0,   0, 0}, {  2, 129, 1, 130} }, /* 59 */
+            { {128, 0, 0, 130}, {0,   0,   0, 1}, {  0,   0,   0, 2}, {  0,   0, 0, 129} }, /* 60 */
+            { {128, 2, 2,   2}, {1,   2,   2, 2}, {  0,   2,   2, 2}, {129,   2, 2, 130} }, /* 61 */
+            { {128, 1, 0, 129}, {2,   2,   2, 2}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 62 */
+            { {128, 1, 1, 129}, {2,   0,   1, 1}, {130,   2,   0, 1}, {  2,   2, 2,   0} }  /* 63 */
+        }
+};
+
+static const int kWeight2[4]  = { 0, 21, 43, 64 };
+static const int kWeight3[8]  = { 0, 9, 18, 27, 37, 46, 55, 64 };
+static const int kWeight4[16] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
+
+// Little-endian bit reader over the 128-bit BC7 block.
+struct Bc7Bits {
+    uint64_t lo, hi;
+    uint32_t pos = 0;
+    uint32_t get(uint32_t n) {           // n <= 8 for every BC7 field; fields never straddle bit 64...
+        uint32_t v = 0;                  // ...actually they CAN straddle it, so read bit-by-bit (16 texel
+        for (uint32_t i = 0; i < n; i++) //    fields x <=4 bits: negligible cost, zero edge cases).
+            v |= get1() << i;
+        return v;
+    }
+    uint32_t get1() {
+        uint32_t b = (pos < 64) ? (uint32_t)((lo >> pos) & 1u) : (uint32_t)((hi >> (pos - 64)) & 1u);
+        pos++;
+        return b;
+    }
+};
+
+inline uint8_t bc7_interp(uint32_t a, uint32_t b, int w) {
+    return (uint8_t)((a * (64 - (uint32_t)w) + b * (uint32_t)w + 32) >> 6);
+}
+
+// Decode one 16-byte BC7 block into a 4x4 RGBA8 tile (row-major, 16 texels).
+void decode_bc7_block(const uint8_t* blk, uint8_t out[16][4]) {
+    Bc7Bits bs;
+    std::memcpy(&bs.lo, blk, 8);
+    std::memcpy(&bs.hi, blk + 8, 8);
+
+    int mode = 0;
+    while (mode < 8 && bs.get1() == 0) mode++;
+    if (mode >= 8) {                           // reserved: all-zero mode byte -> transparent black
+        std::memset(out, 0, 16 * 4);
+        return;
+    }
+
+    int num_subsets = 1, partition = 0, rotation = 0, index_selection = 0;
+    if (mode == 0 || mode == 2) num_subsets = 3;
+    else if (mode == 1 || mode == 3 || mode == 7) num_subsets = 2;
+    if (num_subsets > 1) partition = (int)bs.get(mode == 0 ? 4 : 6);
+    if (mode == 4 || mode == 5) {
+        rotation = (int)bs.get(2);
+        if (mode == 4) index_selection = (int)bs.get1();
+    }
+
+    // Endpoints: all R, then all G, then all B, then all A (if the mode carries alpha).
+    const int num_endpoints = num_subsets * 2;
+    uint32_t ep[6][4] = {};
+    for (int c = 0; c < 3; c++)
+        for (int e = 0; e < num_endpoints; e++) ep[e][c] = bs.get(kBc7ColorBits[mode]);
+    if (kBc7AlphaBits[mode])
+        for (int e = 0; e < num_endpoints; e++) ep[e][3] = bs.get(kBc7AlphaBits[mode]);
+
+    // P-bits: appended as the endpoint's LSB (all components share the bit).
+    const bool per_ep_pbit = (kBc7ModeHasPBits >> mode) & 1;
+    if (mode == 1) {                            // shared per-subset p-bits
+        uint32_t p0 = bs.get1(), p1 = bs.get1();
+        for (int e = 0; e < 4; e++)
+            for (int c = 0; c < 3; c++) ep[e][c] = (ep[e][c] << 1) | (e < 2 ? p0 : p1);
+    } else if (per_ep_pbit) {
+        for (int e = 0; e < num_endpoints; e++) {
+            uint32_t p = bs.get1();
+            for (int c = 0; c < 4; c++) ep[e][c] = (ep[e][c] << 1) | p;
+        }
+    }
+
+    // Expand each component to 8 bits (shift so the MSB lands at bit 7, replicate into the low bits).
+    const uint32_t cb = (uint32_t)kBc7ColorBits[mode] + (per_ep_pbit || mode == 1 ? 1u : 0u);
+    const uint32_t ab = kBc7AlphaBits[mode] ? (uint32_t)kBc7AlphaBits[mode] + (per_ep_pbit ? 1u : 0u) : 0u;
+    for (int e = 0; e < num_endpoints; e++) {
+        for (int c = 0; c < 3; c++) { ep[e][c] <<= (8 - cb); ep[e][c] |= ep[e][c] >> cb; }
+        if (ab) { ep[e][3] <<= (8 - ab); ep[e][3] |= ep[e][3] >> ab; }
+        else    ep[e][3] = 255;                 // opaque modes (0-3): alpha = 1.0
+    }
+
+    // Index widths: primary (color unless the mode-4 selection bit swaps) + optional secondary.
+    const int ib  = (mode == 0 || mode == 1) ? 3 : (mode == 6 ? 4 : 2);
+    const int ib2 = (mode == 4) ? 3 : (mode == 5 ? 2 : 0);
+    const int* w1 = (ib == 2) ? kWeight2 : (ib == 3 ? kWeight3 : kWeight4);
+    const int* w2 = (ib2 == 2) ? kWeight2 : kWeight3;
+
+    // Subset id + anchor flag per texel (bit 7 marks the anchor texel, whose index has one less bit).
+    uint8_t pset[16];
+    for (int t = 0; t < 16; t++) {
+        if (num_subsets == 1) pset[t] = (t == 0) ? 128 : 0;
+        else pset[t] = kBc7PartitionSets[num_subsets - 2][partition][t >> 2][t & 3];
+    }
+
+    // Pass 1: the 16 primary indices (bitstream order; anchors read one less bit).
+    uint8_t idx1[16];
+    for (int t = 0; t < 16; t++) idx1[t] = (uint8_t)bs.get((uint32_t)ib - ((pset[t] & 0x80) ? 1 : 0));
+    // Pass 2: secondary indices (modes 4/5), then interpolate + rotate.
+    for (int t = 0; t < 16; t++) {
+        const int s = (pset[t] & 3) * 2;
+        uint32_t r, g, b, a;
+        if (!ib2) {
+            r = bc7_interp(ep[s][0], ep[s + 1][0], w1[idx1[t]]);
+            g = bc7_interp(ep[s][1], ep[s + 1][1], w1[idx1[t]]);
+            b = bc7_interp(ep[s][2], ep[s + 1][2], w1[idx1[t]]);
+            a = bc7_interp(ep[s][3], ep[s + 1][3], w1[idx1[t]]);
+        } else {
+            uint32_t i2 = bs.get((uint32_t)ib2 - (t == 0 ? 1 : 0));   // single-subset: anchor = texel 0
+            const int wc = index_selection ? w2[i2] : w1[idx1[t]];    // color weight
+            const int wa = index_selection ? w1[idx1[t]] : w2[i2];    // alpha weight
+            r = bc7_interp(ep[s][0], ep[s + 1][0], wc);
+            g = bc7_interp(ep[s][1], ep[s + 1][1], wc);
+            b = bc7_interp(ep[s][2], ep[s + 1][2], wc);
+            a = bc7_interp(ep[s][3], ep[s + 1][3], wa);
+        }
+        switch (rotation) {                     // modes 4/5: swap alpha with the "scalar" channel
+            case 1: { uint32_t x = a; a = r; r = x; } break;
+            case 2: { uint32_t x = a; a = g; g = x; } break;
+            case 3: { uint32_t x = a; a = b; b = x; } break;
+        }
+        out[t][0] = (uint8_t)r; out[t][1] = (uint8_t)g; out[t][2] = (uint8_t)b; out[t][3] = (uint8_t)a;
+    }
+}
+
 } // namespace
 
 bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                        uint32_t width, uint32_t height, DataFormat fmt) {
     const uint32_t bb = bc_block_bytes(fmt);
-    if (fmt != DataFormat::Bc1 && fmt != DataFormat::Bc2 && fmt != DataFormat::Bc3) return false;
+    if (fmt != DataFormat::Bc1 && fmt != DataFormat::Bc2 && fmt != DataFormat::Bc3 &&
+        fmt != DataFormat::Bc4 && fmt != DataFormat::Bc5 && fmt != DataFormat::Bc7) return false;
     const uint32_t bw = (width + 3) / 4, bh = (height + 3) / 4;
     std::memset(dst, 0, (size_t)width * height * 4);
     for (uint32_t by = 0; by < bh; by++) {
@@ -82,6 +366,17 @@ bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
             uint8_t texels[16][4];
             if (fmt == DataFormat::Bc1) {
                 decode_color_block(blk, texels, /*dxt1_alpha*/true);
+            } else if (fmt == DataFormat::Bc4) {
+                // Single-channel UNORM: hardware returns (R, 0, 0, 1); the T# DST_SEL swizzle (applied
+                // downstream, #261) routes it into whatever channels the material reads.
+                uint8_t v[16]; decode_bc4_channel(blk, v);
+                for (int t = 0; t < 16; t++) { texels[t][0] = v[t]; texels[t][1] = 0; texels[t][2] = 0; texels[t][3] = 255; }
+            } else if (fmt == DataFormat::Bc5) {
+                // Two-channel UNORM (two BC4 sub-blocks): hardware returns (R, G, 0, 1).
+                uint8_t r[16], g[16]; decode_bc4_channel(blk, r); decode_bc4_channel(blk + 8, g);
+                for (int t = 0; t < 16; t++) { texels[t][0] = r[t]; texels[t][1] = g[t]; texels[t][2] = 0; texels[t][3] = 255; }
+            } else if (fmt == DataFormat::Bc7) {
+                decode_bc7_block(blk, texels);
             } else {                                          // BC2/BC3: alpha sub-block then color sub-block
                 decode_color_block(blk + 8, texels, /*dxt1_alpha*/false);
                 if (fmt == DataFormat::Bc3) decode_bc3_alpha(blk, texels);

--- a/prosper/src/gpu/bc_decode.hpp
+++ b/prosper/src/gpu/bc_decode.hpp
@@ -5,9 +5,10 @@
 // universally advertise BC sampling, so we decode CPU-side on upload. Pure + deterministic + testable:
 // given the compressed block bytes for a WxH surface, produce W*H*4 RGBA8 (row-major, top-left origin).
 //
-// Standard S3TC decode (Khronos DXTn spec): a 4x4-texel block is 8 bytes (BC1/BC4) or 16 bytes
-// (BC2/BC3/BC5/BC7). We implement the two the game uses first — BC1 and BC3 — plus BC2 (same color
-// sub-block, explicit-alpha), which cost nothing extra. BC4/5/6/7 are left to a follow-up.
+// Standard S3TC/BPTC decode (Khronos data-format spec §18-19, MS D3D11 §19.5): a 4x4-texel block is
+// 8 bytes (BC1/BC4) or 16 bytes (BC2/BC3/BC5/BC6/BC7). Implemented: BC1/BC2/BC3 (Messenger UI/text),
+// BC4/BC5 (single/dual-channel ramps) and BC7 (mode-switched; DOLL's material atlases) — #290.
+// BC6H (HDR half-float) is NOT decoded yet; bc_decode_surface returns false for it.
 #pragma once
 #include <cstdint>
 #include "shader_resources.hpp"
@@ -21,7 +22,9 @@ uint32_t bc_block_bytes(DataFormat f);
 // Decode a block-compressed surface `src` (bc_block_bytes(fmt) per 4x4 block, blocks row-major over a
 // ceil(w/4) x ceil(h/4) grid) into `dst` as W*H*4 RGBA8. `dst` must hold width*height*4 bytes.
 // `src_bytes` bounds the read (a short/absent source leaves the unreachable texels transparent-black).
-// Returns true if `fmt` is a supported block format (BC1/BC2/BC3), false otherwise (dst untouched).
+// Returns true if `fmt` is a supported block format (BC1/BC2/BC3/BC4/BC5/BC7), false otherwise
+// (dst untouched). BC4 decodes to (R,0,0,255), BC5 to (R,G,0,255) — the hardware channel rule; the
+// T# DST_SEL swizzle routes them. UNORM only (SNORM BC4/BC5 variants are kept skipped upstream).
 bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                        uint32_t width, uint32_t height, DataFormat fmt);
 

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -14,6 +14,30 @@ uint32_t data_format_bytes(DataFormat f) {
     }
 }
 
+float half_to_float(uint16_t h) {
+    const uint32_t sign = (uint32_t)(h >> 15) & 1u;
+    const uint32_t exp  = (uint32_t)(h >> 10) & 0x1Fu;
+    const uint32_t man  = (uint32_t)h & 0x3FFu;
+    uint32_t bits;
+    if (exp == 0) {
+        if (man == 0) bits = sign << 31;                          // +/- zero
+        else {                                                    // subnormal: normalize into f32
+            uint32_t e = 0, m = man;                              // value = man * 2^-24; after k shifts
+            while (!(m & 0x400u)) { m <<= 1; e++; }               // it's 1.frac * 2^(-14-k), so the f32
+            m &= 0x3FFu;                                          // exponent field is 127-14-k = 113-k
+            bits = (sign << 31) | ((113u - e) << 23) | (m << 13);
+        }
+    } else if (exp == 0x1F) {
+        bits = (sign << 31) | 0x7F800000u | (man << 13);          // inf / NaN (payload preserved)
+    } else {
+        bits = (sign << 31) | ((exp + 112u) << 23) | (man << 13); // normal: rebias 15 -> 127
+    }
+    float f;
+    static_assert(sizeof(f) == sizeof(bits), "float is 32-bit");
+    __builtin_memcpy(&f, &bits, sizeof f);
+    return f;
+}
+
 const ShaderResource* ShaderResourceTable::by_srt_offset(uint32_t srt_offset) const {
     if (srt_offset == 0xFFFFFFFFu) return nullptr;
     for (const auto& r : resources) if (r.srt_offset == srt_offset) return &r;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -26,10 +26,10 @@ enum class DataFormat : uint32_t {
     Float32, Uint32, Sint32,
     Float16, Unorm16, Snorm16, Uint16, Sint16,
     Unorm8,  Snorm8,  Uint8,  Sint8,
-    // Block-compressed texture formats (4x4-texel blocks). RECOGNIZED by the Gen5 T# mapper
-    // (gen5_image_format) so a BCn texture sizes correctly and is skipped explicitly instead of
-    // binding as garbage RGBA8 (#65) — but no backend samples them yet. data_format_bytes()
-    // returns 0 for these (a per-COMPONENT byte size is meaningless for a block format; use
+    // Block-compressed texture formats (4x4-texel blocks). BC1/2/3/4/5/7 are decoded to RGBA8 on
+    // upload (bc_decode, #121/#290); BC6H (HDR) and the SNORM BC4/5 variants are recognized but
+    // still skipped (gen5_image_format flags them). data_format_bytes() returns 0 for these (a
+    // per-COMPONENT byte size is meaningless for a block format; use
     // Gen5ImageFormatInfo::bytes_per_block).
     Bc1, Bc2, Bc3, Bc4, Bc5, Bc6, Bc7,
     // 10/11-bit packed formats are added as the target needs them.
@@ -37,6 +37,10 @@ enum class DataFormat : uint32_t {
 
 // How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).
 uint32_t data_format_bytes(DataFormat f);
+
+// IEEE-754 binary16 -> binary32 (handles subnormals, +/-inf, NaN). Used by the texture upload path to
+// convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
+float half_to_float(uint16_t h);
 
 enum class ResourceClass : uint32_t {
     ConstantBuffer,  // read by s_buffer_load_* (scalar, uniform across the wave)

--- a/prosper/tests/test_bc_decode.cpp
+++ b/prosper/tests/test_bc_decode.cpp
@@ -82,6 +82,117 @@ int main() {
         CHECK(out[7] == 255, "BC3 texel1 alpha index0 -> a0 = 255");
     }
 
+    // --- BC4: single-channel ramp (a0>a1 -> 6 interpolants); hardware channel rule (R,0,0,255) ---
+    {
+        uint8_t blk[8] = {0};
+        blk[0] = 255; blk[1] = 0;   // e0=255, e1=0 (e0>e1 -> 6-interpolant ramp)
+        // 3-bit indices: t0=0 (=e0), t1=1 (=e1), t2=2 (=(6*e0+e1)/7), rest 0
+        uint64_t bits = (1ull << 3) | (2ull << 6);
+        for (int i = 0; i < 6; i++) blk[2 + i] = (uint8_t)(bits >> (i * 8));
+        uint8_t out[4 * 4 * 4];
+        bool ok = bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc4);
+        CHECK(ok, "BC4 decode returns true");
+        CHECK(out[0] == 255 && out[1] == 0 && out[2] == 0 && out[3] == 255, "BC4 t0 idx0 -> (255,0,0,255)");
+        CHECK(out[4] == 0, "BC4 t1 idx1 -> e1 = 0");
+        CHECK(out[8] == (uint8_t)((6 * 255 + 1 * 0) / 7), "BC4 t2 idx2 -> (6*e0+e1)/7 = 218");
+    }
+
+    // --- BC5: two independent channel blocks -> (R,G,0,255) ---
+    {
+        uint8_t blk[16] = {0};
+        blk[0] = 200; blk[1] = 100;  // R channel: e0=200 (idx0 everywhere)
+        blk[8] = 40;  blk[9] = 10;   // G channel: e0=40
+        uint8_t out[4 * 4 * 4];
+        bool ok = bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc5);
+        CHECK(ok, "BC5 decode returns true");
+        CHECK(out[0] == 200 && out[1] == 40 && out[2] == 0 && out[3] == 255, "BC5 -> (R,G,0,255) = (200,40,0,255)");
+    }
+
+    // --- BC7 ---
+    // Bit-writer mirroring the decoder's little-endian stream, to build spec-exact blocks.
+    struct BitW {
+        uint8_t b[16]; uint32_t pos;
+        BitW() : pos(0) { std::memset(b, 0, sizeof b); }
+        void put(uint32_t v, uint32_t n) {
+            for (uint32_t i = 0; i < n; i++, pos++)
+                if ((v >> i) & 1u) b[pos >> 3] |= (uint8_t)(1u << (pos & 7));
+        }
+    };
+
+    // Mode 5 solid color: rotation=0, both endpoints equal, all indices 0.
+    // 7-bit color 0x40 expands to (0x40<<1) | (0x80>>8) = 0x81; alpha is 8-bit literal.
+    {
+        BitW w;
+        w.put(0x20, 6);            // mode 5: five 0 bits then the 1 (LSB-first -> value 0b100000)
+        w.put(0, 2);               // rotation
+        for (int i = 0; i < 2; i++) w.put(0x40, 7);   // R endpoints
+        for (int i = 0; i < 2; i++) w.put(0x40, 7);   // G
+        for (int i = 0; i < 2; i++) w.put(0x40, 7);   // B
+        for (int i = 0; i < 2; i++) w.put(0xC3, 8);   // A endpoints (literal 8-bit)
+        // color indices: anchor texel0 = 1 bit, texels 1..15 = 2 bits, all zero
+        // alpha indices: same widths, all zero -> stream is already zero; nothing to put.
+        uint8_t out[4 * 4 * 4];
+        bool ok = bc_decode_surface(out, w.b, sizeof w.b, 4, 4, DataFormat::Bc7);
+        CHECK(ok, "BC7 decode returns true");
+        bool solid = true;
+        for (int t = 0; t < 16; t++) {
+            const uint8_t* px = out + t * 4;
+            if (px[0] != 0x81 || px[1] != 0x81 || px[2] != 0x81 || px[3] != 0xC3) solid = false;
+        }
+        CHECK(solid, "BC7 mode5 solid: every texel = (0x81,0x81,0x81,0xC3)");
+    }
+
+    // Mode 6 interpolation: ep0 = 0 (p=0), ep1 = 0xFF (raw 0x7F, p=1); texel1 index 8 -> weight 34.
+    {
+        BitW w;
+        w.put(0x40, 7);            // mode 6: six 0 bits then the 1
+        for (int c = 0; c < 4; c++) { w.put(0x00, 7); w.put(0x7F, 7); }  // RGBA endpoint pairs? NO:
+        // ^ WRONG order — endpoints are grouped per channel: e0.r, e1.r, then e0.g, e1.g, ... For
+        //   this block e0.* = 0 and e1.* = 0x7F for every channel, so the grouped order writes the
+        //   same bits either way (0, 0x7F repeated 4x). Kept simple on purpose.
+        w.put(0, 1); w.put(1, 1);  // p-bits: e0 -> 0, e1 -> 1  => e1 = (0x7F<<1)|1 = 0xFF
+        w.put(0, 3);               // texel0 (anchor) 3-bit index = 0
+        w.put(8, 4);               // texel1 4-bit index = 8 -> aWeight4[8] = 34
+        uint8_t out[4 * 4 * 4];
+        bc_decode_surface(out, w.b, sizeof w.b, 4, 4, DataFormat::Bc7);
+        CHECK(out[0] == 0 && out[3] == 0, "BC7 mode6 t0 idx0 -> endpoint0 (0, alpha 0)");
+        uint8_t expect = (uint8_t)((0 * (64 - 34) + 255 * 34 + 32) >> 6);   // = 135
+        CHECK(out[4] == expect && out[5] == expect && out[6] == expect && out[7] == expect,
+              "BC7 mode6 t1 idx8 -> (255*34+32)>>6 = 135 in all channels");
+    }
+
+    // Mode 1 two-subset, partition 0 (left 2 columns subset 0, right 2 subset 1): subset0 = red,
+    // subset1 = blue, all indices 0. 6-bit endpoints + shared p-bit per subset.
+    {
+        BitW w;
+        w.put(0x02, 2);            // mode 1: one 0 bit then the 1
+        w.put(0, 6);               // partition 0
+        // R endpoints for e0..e3 (subset0 e0,e1 then subset1 e0,e1): red -> 0x3F,0x3F,0,0
+        w.put(0x3F, 6); w.put(0x3F, 6); w.put(0x00, 6); w.put(0x00, 6);
+        // G: all 0
+        for (int i = 0; i < 4; i++) w.put(0x00, 6);
+        // B: 0,0,0x3F,0x3F
+        w.put(0x00, 6); w.put(0x00, 6); w.put(0x3F, 6); w.put(0x3F, 6);
+        w.put(0, 1); w.put(0, 1);  // shared p-bits 0: 0x3F -> 7-bit 0x7E -> expands to 0xFD; 0 stays 0
+        // indices: 3-bit, anchors (texel0 subset0, texel15 subset1 for partition 0) 2-bit; all zero.
+        uint8_t out[4 * 4 * 4];
+        bc_decode_surface(out, w.b, sizeof w.b, 4, 4, DataFormat::Bc7);
+        CHECK(out[0] == 0xFD && out[1] == 0 && out[2] == 0 && out[3] == 255, "BC7 mode1 texel(0,0) = red-ish 0xFD (subset 0)");
+        const uint8_t* pr = out + 3 * 4;   // texel (0,3): right column -> subset 1
+        CHECK(pr[0] == 0 && pr[1] == 0 && pr[2] == 0xFD && pr[3] == 255, "BC7 mode1 texel(0,3) = blue-ish 0xFD (subset 1)");
+    }
+
+    // Reserved mode (all 8 mode bits zero) -> transparent black, no crash.
+    {
+        uint8_t blk[16] = {0};
+        uint8_t out[4 * 4 * 4];
+        std::memset(out, 0xAA, sizeof out);
+        bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc7);
+        CHECK(out[0] == 0 && out[3] == 0, "BC7 reserved mode -> transparent black");
+    }
+
+    CHECK(!bc_decode_surface(nullptr, nullptr, 0, 0, 0, DataFormat::Bc6), "BC6H still unsupported -> false");
+
     // --- larger surface: 8x8 BC1, second block a distinct solid color; verify block placement ---
     {
         const uint32_t W = 8, H = 8;                 // 2x2 blocks

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -60,6 +60,15 @@ int main() {
               "IMG_FMT 173 -> BC3, 16 B per 4x4 block");
         CHECK(gen5_image_format(182, &fi) && fi.format == DataFormat::Bc7 && fi.srgb,
               "IMG_FMT 182 -> BC7 SRGB");
+        // #290: BC4/BC5 UNORM vs SNORM split — SNORM carries the snorm flag (upload keeps skipping it).
+        CHECK(gen5_image_format(175, &fi) && fi.format == DataFormat::Bc4 && fi.bytes_per_block == 8 &&
+              !fi.snorm, "IMG_FMT 175 -> BC4 UNORM (decodable)");
+        CHECK(gen5_image_format(176, &fi) && fi.format == DataFormat::Bc4 && fi.snorm,
+              "IMG_FMT 176 -> BC4 SNORM (flagged snorm, skip-only)");
+        CHECK(gen5_image_format(177, &fi) && fi.format == DataFormat::Bc5 && fi.bytes_per_block == 16 &&
+              !fi.snorm, "IMG_FMT 177 -> BC5 UNORM (decodable)");
+        CHECK(gen5_image_format(178, &fi) && fi.format == DataFormat::Bc5 && fi.snorm,
+              "IMG_FMT 178 -> BC5 SNORM (flagged snorm, skip-only)");
         CHECK(!gen5_image_format(0, &fi) && fi.format == DataFormat::Unknown, "IMG_FMT 0 (INVALID) unmapped");
         CHECK(!gen5_image_format(9, &fi), "IMG_FMT 9 (16_USCALED) unmapped -> false");
         CHECK(!gen5_image_format(44, &fi), "IMG_FMT 44 (10_10_10_2) unmapped -> false");

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -54,6 +54,17 @@ int main() {
     CHECK(t.by_sgpr_base(0x99) == nullptr && t.by_sgpr_base(0xFFFFFFFFu) == nullptr,
           "unknown / not-SGPR-keyed resolves to null");
 
+    // half_to_float (#290 fp16 texture upload): exact IEEE binary16 decode incl. subnormals/inf/NaN.
+    CHECK(half_to_float(0x3C00) == 1.0f && half_to_float(0xBC00) == -1.0f, "half 0x3C00/0xBC00 = +/-1.0");
+    CHECK(half_to_float(0x3800) == 0.5f, "half 0x3800 = 0.5 (mid-gray magnitude, not saturated)");
+    CHECK(half_to_float(0x0000) == 0.0f && half_to_float(0x8000) == 0.0f, "half +/-0 = 0.0");
+    CHECK(half_to_float(0x4248) == 3.140625f, "half 0x4248 = 3.140625 (pi to half precision)");
+    CHECK(half_to_float(0x7BFF) == 65504.0f, "half 0x7BFF = 65504 (max finite)");
+    CHECK(half_to_float(0x0001) == 5.9604644775390625e-8f, "half 0x0001 = smallest subnormal");
+    CHECK(half_to_float(0x03FF) == 6.0975551605224609375e-5f, "half 0x03FF = largest subnormal");
+    { float inf = half_to_float(0x7C00); CHECK(inf > 3.4e38f && inf == inf * 2, "half 0x7C00 = +inf"); }
+    { float nan = half_to_float(0x7E01); CHECK(nan != nan, "half 0x7E01 = NaN"); }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #290 — both non-tiling texture-format walls from the #288 verification.

## Wall 2: BC4/BC5/BC7 decode (was: draws skipped)
- Full decoders in `src/gpu/bc_decode.cpp`: BC4 (single-channel ramp, `(R,0,0,255)`), BC5 (dual-channel, `(R,G,0,255)` — T# DST_SEL routes the channels), and mode-switched BC7 (all 8 modes: partitions/anchors, p-bits, rotation, index-selection). Constant tables are the published BPTC spec constants (via bcdec, MIT/Unlicense).
- `agc_shader_layout.cpp` no longer skips those bindings. Still skipped, now precisely: BC6H (fmt 179/180, HDR — no decode) and SNORM BC4/5 (fmt 176/178, new `Gen5ImageFormatInfo::snorm` flag — a UNORM8 upload can't carry signed samples).

**Validation (no eyeballing):**
- Fuzz cross-check vs `texture2ddecoder`: **byte-exact over 4000 BC7 blocks** (400 forced per mode 0–7 + 800 random) **+ 1000 BC4 + 1000 BC5**.
- Hand-built spec vectors in `test_bc_decode` (mode 5 solid, mode 6 interpolation weights, mode 1 two-subset partition + shared p-bits, reserved-mode clear, BC4 ramp, BC5 channel rule).
- Live: DOLL BC7_SRGB atlases (fmt 182, 1024×1024 & 2048×1024, tile_mode 9) captured via `PROSPER_DUMP_TILERAW` decode through the exact runtime pipeline (`detile_elements` + `bc_decode_surface`) into fully coherent photographic cloud sprite atlases (TV ≈ 1.6 vs ~20 for noise); a live BC4 (fmt 175) mask decodes coherently too. In a rendered boot, the previous `[t#] ... BC4-7 -> decode not wired` skips are gone (only BC6H + 3 unmapped packed formats remain), 0 faults.

## Wall 1: fp16 textures (was: clamped to 4 B/texel)
- `live_renderer.cpp` now reads Float16 surfaces (fmt 71 = 8 B/texel, 29, 13) at the REAL bytes-per-texel, detiles with the REAL element size, and converts half→UNORM8 with an exact IEEE binary16 decode (`half_to_float` in `shader_resources.cpp`, incl. subnormals/inf/NaN — unit-tested: 0x3800 → 0.5, not saturated).
- CONFIDENCE: MED on the conversion policy — values clamp to [0,1]; native `VK_FORMAT_R16G16B16A16_SFLOAT` upload (for HDR >1.0 bloom energy) is a documented follow-up. The backend is RGBA8-only by design today (see the #263 note), so conversion was chosen over plumbing a per-resource VkFormat.

## Honest frame assessment
DOLL's presented frame is **still dominated by striped noise** — but live captures prove it is now *correctly decoded garbage input*, not a decode bug: the noise draws sample **RT-mode (tm27) surfaces whose guest memory our host-side renderer never writes back** (the fmt-71 fp16 bloom chain 960×540…240×135 decodes to NaN/inf speckle; the final composite samples fmt 36 = `10_11_11_FLOAT`, UE4's R11G11B10F scene color, 3840×2160). That is the third wall from the #288 doc (RT sampling → needs RTT injection + fmt-36 mapping on the injection path), now the dominant one — follow-up issue filed.

## Regression
- ctest **68/68** green (dump-backed included).
- Messenger snapshot guard: `snapshot.py check` OK (richest 24318 colors ≥ 5000); Messenger boot with `PROSPER_RENDER=1`: 0 faults, BC1 path untouched (additive change).
