### PR TITLE
fix(gpu): map UE4 scene-color fmt 36 (R11G11B10F) + unify RTT gate + RT-sample write-back (refs #294)

### DIFF
--- a/prosper/docs/GFX10_SW_64KB_TILING.md
+++ b/prosper/docs/GFX10_SW_64KB_TILING.md
@@ -115,12 +115,25 @@ Two of the three walls were closed by #290:
   decode through `detile_elements` + `bc_decode_surface` into fully coherent cloud sprite atlases
   (TV ≈ 1.6). Still skipped: **BC6H** (fmt 179/180, HDR half-float — no decode) and **SNORM
   BC4/BC5** (fmt 176/178 — the UNORM8 upload can't carry signed samples).
-- **RT sampling — now the dominant wall**: rendered pixels live host-side in `g_rtt`
-  (`PROSPER_RTT` injection); they are never written back tiled to guest memory, so every draw
-  sampling an RT-mode (tm27) surface reads stale garbage — DOLL's presented frame is dominated by
-  its bloom chain (fmt 71 fp16 RTs, 960×540…240×135) and final composite (fmt 36 =
-  `10_11_11_FLOAT`, the UE4 R11G11B10F scene color, 3840×2160/1920×1080 — unmapped, skipped
-  without RTT) sampling those unwritten RTs. Verified from a live capture: the 480×270 fmt-71
-  "bloom" guest memory decodes to NaN/inf-laden speckle — correctly-decoded garbage input, not a
-  decode bug. Fixing this means RTT injection keyed to those targets (plus mapping fmt 36 for the
-  injection path), not the detiler.
+- **RT sampling — largely addressed (#294)**: rendered pixels live host-side in `g_rtt`
+  (`PROSPER_RTT` / `PROSPER_RTT_PERTARGET` injection). Previously fmt 36 (`10_11_11_FLOAT`, the
+  UE4 R11G11B10F scene color) was unmapped and dropped, and the layout-level RTT bind only checked
+  `PROSPER_RTT` — so a pertarget-only run skipped the fmt-36 T# entirely. Now:
+  - **fmt 36 is mapped** to `DataFormat::Float10_11_11` (3 comps, 4 B/texel) unconditionally in
+    `gen5_image_format`; the live_renderer unpacks the packed word to RGBA8 (`f11_to_float` /
+    `f10_to_float`, same NaN/clamp semantics as the fp16 path) for the non-RTT-hit case. Kept out
+    of `rdna2_buffer_format` (vertex fetch has no packed conversion). Unit-tested.
+  - **The RTT env gate is unified**: `agc_shader_layout`'s unmapped-format bind now accepts
+    `PROSPER_RTT_PERTARGET` too, matching `live_renderer`'s `rtt_on`.
+  - **Result** (live DOLL capture, `PROSPER_RTT_PERTARGET=1`): 0 `UNMAPPED` skips, the scene-color
+    fmt-36 targets (1920×1080 / 3840×2160) and the fp16 bloom chain (960×540…60×34) all resolve as
+    RTT **HITs** (497 fmt-20 scene-color HITs) — the composite samples real rendered pixels, not
+    NaN speckle. The `PROSPER_RTT=1` single-framebuffer flatten renders a coherent smooth
+    yellow-green radial bloom gradient (587 distinct colors) instead of striped garbage.
+  - **Remaining**: the presented frame is not yet a recognizable scene. Under pertarget, the
+    "present the last group" heuristic surfaces a solid-blue clear/UI pass; under single-FB the
+    output is a smooth bloom gradient with no scene geometry detail — i.e. the scene-color RT
+    carries coherent post-process content but the underlying scene draws don't yet write
+    recognizable geometry into it. Next wall is scene-geometry detail in the scene-color RT (and a
+    present-selection heuristic that picks the composite group, not the last small pass), not the
+    RT-sampling plumbing.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -270,6 +270,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             prosper::gpu::detile_surface(texstore.back().data(), tiled.data(), tw, th, tmode, pitch);
                         }
+                        // Packed R11G11B10F (Gen5 IMG_FMT 36 -> DataFormat::Float10_11_11, #294): UE4's
+                        // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
+                        // above already produced linear packed words; unpack each to RGBA8 in place with
+                        // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
+                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Float10_11_11) {
+                            uint8_t* tp = texstore.back().data();
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint32_t v; std::memcpy(&v, tp + t * 4, 4);
+                                const float fc[3] = { prosper::gpu::f11_to_float((uint16_t)(v & 0x7FFu)),
+                                                      prosper::gpu::f11_to_float((uint16_t)((v >> 11) & 0x7FFu)),
+                                                      prosper::gpu::f10_to_float((uint16_t)((v >> 22) & 0x3FFu)) };
+                                for (int c = 0; c < 3; c++)
+                                    tp[t * 4 + c] = (fc[c] != fc[c] || fc[c] <= 0.f) ? 0
+                                                  : (fc[c] >= 1.f ? 255 : (uint8_t)(fc[c] * 255.f + 0.5f));
+                                tp[t * 4 + 3] = 255;
+                            }
+                        }
                         // PROSPER_DUMP_TEX: write the RAW texture memory (interpreted linearly) to a BMP,
                         // bypassing the shader — reveals whether the render target is tiled or linear.
                         if (getenv("PROSPER_DUMP_TEX") && !texstore.back().empty() && frame_no < 200) {

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -97,7 +97,16 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
         fi.format = f; fi.num_components = n; fi.bytes_per_block = bpb;
         fi.block_width = fi.block_height = 4; fi.srgb = srgb; fi.snorm = snorm;
     };
-    if (fmt >= 1 && fmt <= 77) {                 // shared with the V# buffer-format numbering
+    if (fmt == 36) {
+        // GFX10_FORMAT_10_11_11_FLOAT — packed 32-bit R11G11B10F (R=bits[10:0], G=[21:11],
+        // B=[31:22], unsigned small floats, no alpha). UE4's scene-color render-target format;
+        // DOLL's final composite samples it at 3840x2160/1920x1080 (#294). Mapped HERE (not in
+        // rdna2_buffer_format) on purpose: as a texture the upload path unpacks it to RGBA8, but
+        // the vertex-fetch recompiler has no packed-component conversion, so a V# with this
+        // format must keep falling back rather than mis-convert. CONFIDENCE: HIGH (value from
+        // AMD's GFX10 register DB; live DOLL T#s confirmed fmt=36 at scene-color dimensions).
+        fi.format = DataFormat::Float10_11_11; fi.num_components = 3; fi.bytes_per_block = 4;
+    } else if (fmt >= 1 && fmt <= 77) {          // shared with the V# buffer-format numbering
         DataFormat f = DataFormat::Unknown; uint32_t n = 0;
         rdna2_buffer_format(fmt, &f, &n);
         if (f != DataFormat::Unknown) plain(f, n);
@@ -270,12 +279,15 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             Gen5ImageFormatInfo fi;
             static bool warned[512] = {};                        // once per 9-bit format value
             if (!gen5_image_format(d.format, &fi)) {
-                // Unmapped IMG format. Under PROSPER_RTT, BIND it as RGBA8 anyway so the render-to-texture
-                // path can inject the pixels we rendered into this address (the composite that samples a
-                // scene color target uses an unmapped packed format, e.g. fmt=36 — skipping it means the
-                // RTT cache is never consulted and the frame stays black). Without RTT, keep skipping
-                // (a raw RGBA8 read of a real unmapped texture would sample garbage; #65).
-                if (!getenv("PROSPER_RTT")) {
+                // Unmapped IMG format. Under RTT (PROSPER_RTT or PROSPER_RTT_PERTARGET — the
+                // per-target mode IMPLIES injection, matching live_renderer's rtt_on gate; a
+                // pertarget-only run previously skipped these T#s at layout level, #294), BIND it
+                // as RGBA8 anyway so the render-to-texture path can inject the pixels we rendered
+                // into this address. Without RTT, keep skipping (a raw RGBA8 read of a real
+                // unmapped texture would sample garbage; #65).
+                static const bool rtt_bind = getenv("PROSPER_RTT") != nullptr ||
+                                             getenv("PROSPER_RTT_PERTARGET") != nullptr;
+                if (!rtt_bind) {
                     if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
                         fprintf(stderr, "[t#] UNMAPPED Gen5 IMG_FMT %u (%ux%u T#) -> skipping texture binding "
                                         "(extend gen5_image_format)\n", d.format, d.width, d.height); }

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -38,6 +38,17 @@ float half_to_float(uint16_t h) {
     return f;
 }
 
+float f11_to_float(uint16_t v) {
+    // 5-bit exp (bias 15) + 6-bit mantissa, unsigned. Widen the mantissa into a half's 10-bit
+    // field: subnormal m/64*2^-14 == (m<<4)/1024*2^-14, normal/inf/NaN carry the exponent as-is.
+    return half_to_float((uint16_t)(((v & 0x7FFu) >> 6 << 10) | ((v & 0x3Fu) << 4)));
+}
+
+float f10_to_float(uint16_t v) {
+    // 5-bit exp (bias 15) + 5-bit mantissa, unsigned.
+    return half_to_float((uint16_t)(((v & 0x3FFu) >> 5 << 10) | ((v & 0x1Fu) << 5)));
+}
+
 const ShaderResource* ShaderResourceTable::by_srt_offset(uint32_t srt_offset) const {
     if (srt_offset == 0xFFFFFFFFu) return nullptr;
     for (const auto& r : resources) if (r.srt_offset == srt_offset) return &r;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -32,7 +32,13 @@ enum class DataFormat : uint32_t {
     // per-COMPONENT byte size is meaningless for a block format; use
     // Gen5ImageFormatInfo::bytes_per_block).
     Bc1, Bc2, Bc3, Bc4, Bc5, Bc6, Bc7,
-    // 10/11-bit packed formats are added as the target needs them.
+    // Packed 32-bit R11G11B10 unsigned-float (GFX10 IMG_FMT 36 "10_11_11_FLOAT", DX
+    // R11G11B10_FLOAT, VK B10G11R11_UFLOAT_PACK32): R = bits[10:0] (5e6m), G = bits[21:11]
+    // (5e6m), B = bits[31:22] (5e5m), no sign bits, no alpha. UE4's scene-color render-target
+    // format (#294). data_format_bytes() returns 0 (packed — per-component size is meaningless;
+    // the texel is 4 bytes, carried by Gen5ImageFormatInfo::bytes_per_block).
+    Float10_11_11,
+    // Other 10/11-bit packed formats are added as the target needs them.
 };
 
 // How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).
@@ -41,6 +47,13 @@ uint32_t data_format_bytes(DataFormat f);
 // IEEE-754 binary16 -> binary32 (handles subnormals, +/-inf, NaN). Used by the texture upload path to
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
 float half_to_float(uint16_t h);
+
+// Unsigned small-float components of a packed Float10_11_11 texel (#294). Both share binary16's
+// 5-bit exponent (bias 15) with a shortened mantissa (6 bits for the 11-bit R/G, 5 for the 10-bit B)
+// and NO sign bit — so a left-shift of the mantissa into a half's 10-bit field is an exact
+// widening (subnormals scale identically, inf/NaN preserved). Pure + testable.
+float f11_to_float(uint16_t v);   // low 11 bits used
+float f10_to_float(uint16_t v);   // low 10 bits used
 
 enum class ResourceClass : uint32_t {
     ConstantBuffer,  // read by s_buffer_load_* (scalar, uniform across the wave)

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -69,6 +69,10 @@ int main() {
               !fi.snorm, "IMG_FMT 177 -> BC5 UNORM (decodable)");
         CHECK(gen5_image_format(178, &fi) && fi.format == DataFormat::Bc5 && fi.snorm,
               "IMG_FMT 178 -> BC5 SNORM (flagged snorm, skip-only)");
+        // #294: fmt 36 = 10_11_11_FLOAT (UE4 R11G11B10F scene color) — packed 4-byte texel, 3 comps.
+        CHECK(gen5_image_format(36, &fi) && fi.format == DataFormat::Float10_11_11 &&
+              fi.num_components == 3 && fi.bytes_per_block == 4 && fi.block_width == 1 && !fi.srgb,
+              "IMG_FMT 36 -> Float10_11_11 packed, 4 B/texel");
         CHECK(!gen5_image_format(0, &fi) && fi.format == DataFormat::Unknown, "IMG_FMT 0 (INVALID) unmapped");
         CHECK(!gen5_image_format(9, &fi), "IMG_FMT 9 (16_USCALED) unmapped -> false");
         CHECK(!gen5_image_format(44, &fi), "IMG_FMT 44 (10_10_10_2) unmapped -> false");

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -65,6 +65,21 @@ int main() {
     { float inf = half_to_float(0x7C00); CHECK(inf > 3.4e38f && inf == inf * 2, "half 0x7C00 = +inf"); }
     { float nan = half_to_float(0x7E01); CHECK(nan != nan, "half 0x7E01 = NaN"); }
 
+    // f11/f10 unsigned small floats (#294, packed R11G11B10F scene color): binary16 exponent
+    // (bias 15), shortened mantissa (6/5 bits), no sign.
+    CHECK(f11_to_float(0x3C0) == 1.0f && f10_to_float(0x1E0) == 1.0f, "f11 0x3C0 / f10 0x1E0 = 1.0");
+    CHECK(f11_to_float(0x380) == 0.5f && f10_to_float(0x1C0) == 0.5f, "f11 0x380 / f10 0x1C0 = 0.5");
+    CHECK(f11_to_float(0) == 0.0f && f10_to_float(0) == 0.0f, "f11/f10 0 = 0.0");
+    CHECK(f11_to_float(0x3E0) == 1.5f, "f11 0x3E0 = 1.5 (mantissa MSB)");
+    CHECK(f10_to_float(0x1F0) == 1.5f, "f10 0x1F0 = 1.5 (mantissa MSB)");
+    CHECK(f11_to_float(0x001) == half_to_float(0x0010), "f11 smallest subnormal == half m<<4 subnormal");
+    CHECK(f10_to_float(0x001) == half_to_float(0x0020), "f10 smallest subnormal == half m<<5 subnormal");
+    CHECK(f11_to_float(0x7BF) == 65024.0f, "f11 0x7BF = max finite (65024)");
+    { float inf = f11_to_float(0x7C0); CHECK(inf > 3.4e38f && inf == inf * 2, "f11 0x7C0 = +inf"); }
+    { float nan = f10_to_float(0x3E1); CHECK(nan != nan, "f10 0x3E1 = NaN"); }
+    CHECK(data_format_bytes(DataFormat::Float10_11_11) == 0,
+          "Float10_11_11 is packed: per-component bytes = 0 (texel size lives in bytes_per_block)");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
refs #294 (wall #1 — partial; RT-sampling plumbing closed, recognizable-frame payoff not yet reached)

## What this does
Closes the RT-sampling **plumbing** for DOLL's post-process chain — the scene-color and bloom render targets now bind and carry real rendered content instead of being dropped or read as NaN garbage.

1. **Map Gen5 IMG_FMT 36 = `10_11_11_FLOAT`** (UE4 R11G11B10F scene color) to a new `DataFormat::Float10_11_11` (3 comps, 4 B/texel) in `gen5_image_format`. Previously unmapped → the 1920×1080 / 3840×2160 scene-color T#s were skipped without RTT. Mapped unconditionally (not gated on RTT). Kept out of `rdna2_buffer_format` on purpose: the vertex-fetch recompiler has no packed-component conversion, so a V# with this format must keep falling back rather than mis-convert.
2. **Unpack path**: `f11_to_float` / `f10_to_float` (exact — binary16 exponent, shortened unsigned mantissa via a widening shift into `half_to_float`; unit-tested incl. subnormals/inf/NaN/max-finite). `live_renderer` unpacks the detiled packed word to RGBA8 with the same NaN/neg→0, clamp-[0,1], A=255 semantics as the fp16 path (skipped on an RTT hit, where pixels are already injected).
3. **Unify the RTT env gate**: `agc_shader_layout`'s unmapped-format RTT bind checked `getenv("PROSPER_RTT")` only, while `live_renderer`'s `rtt_on` also accepts `PROSPER_RTT_PERTARGET`. A pertarget-only run therefore skipped unmapped T#s at layout level. Both now accept either var.

All changes are gated/additive; the default (no-RTT) render path is unchanged except that fmt 36 now decodes instead of being skipped.

## Verification (live DOLL capture, ext4 fast path)
Env: `PROSPER_FRAME_DIR=… PROSPER_DUMP_CONTENT=100000 PROSPER_RENDER=1 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RTT_PERTARGET=1`
- **0 `UNMAPPED Gen5 IMG_FMT 36`** skips (was: skipped without RTT).
- Scene-color fmt-36 targets (1920×1080 / 3840×2160) + fp16 bloom chain (960×540…60×34) all resolve as RTT **HITs** — **497 fmt-20 scene-color HITs**, 4 misses. The composite samples real rendered pixels, not NaN/inf speckle.
- `PROSPER_RTT=1` single-framebuffer flatten renders a **coherent smooth radial bloom gradient** (587 distinct colors), not striped garbage.

### Honest frame result
The presented frame is **not yet a recognizable scene**. Under `PROSPER_RTT_PERTARGET` the "present the last group" heuristic surfaces a solid-blue clear/UI pass; under single-FB the output is a smooth bloom gradient with no scene-geometry detail. i.e. the RT-sampling pipeline is correct (real content flows RT→sample→composite), but the underlying scene draws don't yet write recognizable geometry into the scene-color RT. **Next wall**: scene-geometry detail in the scene-color RT + a present-selection heuristic that picks the composite group rather than the last small pass — not the RT plumbing this PR fixes. Deferred tails from #294 (BC6H, SNORM BC4/5, native-fp16) untouched.

## Tests
- `ctest`: **68/68 green**. New assertions: `test_shader_resources` (f11/f10 decode + `Float10_11_11` packed byte size), `test_build_shader_resources` (IMG_FMT 36 → Float10_11_11, 4 B/texel).
- Messenger regression via `tools/snapshot/snapshot.py check`: **OK** — richest frame 480x270 with 24318 distinct colors (>= 5000 threshold), no regression (text/UI unchanged; my RTT changes are additive and off by default).

CONFIDENCE: HIGH on the fmt-36 map + unpack + gate (unit-tested, live HITs confirmed); MED that a recognizable frame needs only the two named next-wall items.
