### PR TITLE
feat(gpu): flip-anchored present + RT persistence + UE4 SRT descriptor resolution + gather4_lz_o (refs #294)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -7,6 +7,7 @@
 #include "gpu/bc_decode.hpp"            // BC1/2/3 block decompression -> RGBA8 (#121)
 #include "gpu/shader_resources.hpp"     // ShaderResourceTable / ResourceClass
 #include "gpu/rdna2_to_spirv.hpp"       // recompile_fragment (diagnostic solid-color PS)
+#include "gpu/videoout_present.hpp"     // present_front_index (flip-anchored present selection)
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
 
 #include <atomic>
@@ -20,6 +21,11 @@
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
 extern "C" int prosper_reserved_range_state(uint64_t addr);
+// VideoOut scanout registry (hle_graphics.cpp) — which guest buffer the game most recently FLIPPED
+// to screen. The flip fires during the Dcb fold (agc_dcb_set_flip -> prosper_vo_flip_from_gpu),
+// BEFORE the submit's execute_and_present, so at render time these identify this frame's scanout VA.
+extern "C" int      prosper_vo_buffer_count();
+extern "C" uint64_t prosper_vo_buffer_addr(int i);
 
 namespace prosper::frontend {
 
@@ -402,14 +408,50 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (groups.find(k) == groups.end()) order.push_back(k);
                     groups[k].push_back(&it);
                 }
-                for (uint64_t base : order) {
-                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(groups[base]), w, h);
-                    if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = w; s.h = h; }
-                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for (uint8_t b : gpx) nz += (b != 0);
-                        fprintf(stderr, "[rtt] group target=0x%llx (%zu draws) px_nonzero=%zu cache_size=%zu\n",
-                                (unsigned long long)base, groups[base].size(), nz, g_rtt.size()); }
-                    if (!gpx.empty()) px = std::move(gpx);                              // present the last non-empty group
+                // Flip-anchored present selection: the correct frame is whatever the guest FLIPS to
+                // screen, i.e. the RTT group whose color-target VA is a registered VideoOut buffer
+                // (preferring the CURRENT front buffer — the in-stream SetFlip fires during the Dcb
+                // fold, before this render, so present_front_index() is this frame's scanout choice).
+                const int      vo_n     = prosper_vo_buffer_count();
+                const int      vo_front = prosper::gpu::present_front_index();
+                const uint64_t front_va = vo_front >= 0 ? prosper_vo_buffer_addr(vo_front) : 0;
+                if (getenv("PROSPER_RTTLOG")) {
+                    fprintf(stderr, "[rtt] flip state: front=%d va=0x%llx of %d registered:",
+                            vo_front, (unsigned long long)front_va, vo_n);
+                    for (int i = 0; i < vo_n && i < 8; i++)
+                        fprintf(stderr, " [%d]=0x%llx", i, (unsigned long long)prosper_vo_buffer_addr(i));
+                    fprintf(stderr, "\n");
                 }
+                std::vector<uint8_t> px_front, px_vo;   // flip-matched / any-scanout-matched candidates
+                // Render-target persistence (default on; PROSPER_RTT_NOSEED reverts to per-pass blue
+                // clear): seed each group's framebuffer with the pixels last rendered into that SAME
+                // target VA, so a pass that draws into an already-written target (UE4's UI pass onto
+                // the backbuffer, incremental HUD updates) composites OVER the earlier content instead
+                // of starting from the diagnostic clear. Real RT memory persists exactly this way.
+                static const bool seed_rtt = getenv("PROSPER_RTT_NOSEED") == nullptr;
+                for (uint64_t base : order) {
+                    const uint8_t* seed = nullptr;
+                    if (seed_rtt && base) { auto sit = g_rtt.find(base);
+                        if (sit != g_rtt.end() && sit->second.w == w && sit->second.h == h &&
+                            sit->second.rgba.size() == (size_t)w * h * 4) seed = sit->second.rgba.data(); }
+                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(groups[base]), w, h, seed);
+                    if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = w; s.h = h; }
+                    bool is_vo = false;
+                    for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
+                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for (uint8_t b : gpx) nz += (b != 0);
+                        fprintf(stderr, "[rtt] group target=0x%llx (%zu draws) px_nonzero=%zu cache_size=%zu%s%s\n",
+                                (unsigned long long)base, groups[base].size(), nz, g_rtt.size(),
+                                is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : ""); }
+                    if (!gpx.empty()) {
+                        if (base && base == front_va) px_front = gpx;                   // the flipped buffer
+                        if (is_vo)                    px_vo    = gpx;                   // any registered scanout
+                        px = std::move(gpx);                                            // last non-empty (fallback)
+                    }
+                }
+                // Present priority: the flipped front buffer > any registered scanout target > the
+                // legacy "last group" fallback (unchanged behavior when no group targets a VO buffer).
+                if (!px_front.empty())   px = std::move(px_front);
+                else if (!px_vo.empty()) px = std::move(px_vo);
             } else {
                 // Single-framebuffer path: render_draws_rgba composites every draw into ONE framebuffer.
                 std::vector<const prosper::gpu::DrawItem*> all; all.reserve(items.size());

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -64,7 +64,15 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 // gpu_executor.cpp: the exact fetch instruction (pc), its SRSRC SGPR, and the V# live in that SGPR
 // at that instruction. Exposed (with resolve_dynamic_fetch) so the fold's scalar-ALU semantics are
 // unit-testable; production callers stay inside gpu_executor.cpp.
-struct DynFetch { uint32_t fetch_pc; int srsrc; DecodedBufferDescriptor desc; uint32_t desc_v3; };
+struct DynFetch {
+    uint32_t fetch_pc; int srsrc; DecodedBufferDescriptor desc; uint32_t desc_v3;
+    // True when the V# came from the user-data SEED fallback (never s_loaded/patched-tracked). A
+    // seed entry must NOT shadow a metadata-described direct vertex buffer at the same SGPRs: the
+    // by_fetch_pc dyn path models the element address as gl_VertexIndex*stride (per-attribute
+    // patched V#s fold their in-record offset into the base), while a single direct V# needs the
+    // faithful VADDR/inst-offset address — shadowing it collapses every attribute onto offset 0.
+    bool from_seed = false;
+};
 
 // One descriptor-TABLE use recovered by the same const-fold (#294): UE4 shaders load their T#/S#/V#
 // descriptors with `s_load_dwordx4/x8 sN, s[ptr:ptr+1], <imm>` from a resource table whose pointer

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -13,6 +13,7 @@
 #include "rdna2_to_spirv.hpp"      // recompile_vertex / recompile_fragment
 #include "shader_resources.hpp"    // ShaderResourceTable
 #include "agc_shader_layout.hpp"   // DecodedBufferDescriptor (DynFetch)
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -64,9 +65,25 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 // at that instruction. Exposed (with resolve_dynamic_fetch) so the fold's scalar-ALU semantics are
 // unit-testable; production callers stay inside gpu_executor.cpp.
 struct DynFetch { uint32_t fetch_pc; int srsrc; DecodedBufferDescriptor desc; uint32_t desc_v3; };
+
+// One descriptor-TABLE use recovered by the same const-fold (#294): UE4 shaders load their T#/S#/V#
+// descriptors with `s_load_dwordx4/x8 sN, s[ptr:ptr+1], <imm>` from a resource table whose pointer
+// sits in the user-data SGPRs, then consume them (image_sample SRSRC/SSAMP, s_buffer_load SBASE).
+// The recompiler tags such a load's dest SGPRs with the load IMMEDIATE (sreg_srt) and resolves the
+// consumer via by_srt_offset(imm) — so `key` here is exactly that immediate, and build_stage_table
+// turns each use into a ShaderResource with srt_offset = key.
+struct SrtUse {
+    int kind = 0;                    // 0 = texture (t8, + s4 sampler when resolved), 1 = constant buffer (v4)
+    uint32_t key = 0;                // the s_load immediate byte offset (== emit_alu's sreg_srt tag)
+    std::array<uint32_t, 8> t8{};    // T# dwords as loaded (kind 0)
+    std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
+    bool has_samp = false;
+    std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)
+};
 std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             const uint32_t* user_sgprs, uint32_t nsgpr,
-                                            uint32_t user_sgpr_base);
+                                            uint32_t user_sgpr_base,
+                                            std::vector<SrtUse>* srt_uses = nullptr);
 
 // Assign each resource in `t` a descriptor binding from `first`: constant/vertex buffers first, then
 // textures / storage images — never on binding 2 or 3 (the recompiler's two hardwired cbufs) so a

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <set>
 #include <vector>
 #include <unordered_map>
 #ifndef _WIN32
@@ -90,7 +91,7 @@ bool guest_readable(uint64_t, uint32_t) { return true; }
 // External linkage (DynFetch + declaration in gpu_execute.hpp) so the fold is unit-testable.
 std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
-                      uint32_t user_sgpr_base) {
+                      uint32_t user_sgpr_base, std::vector<SrtUse>* srt_uses) {
     std::vector<DynFetch> out;
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
@@ -98,6 +99,16 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     const bool trc = getenv("PROSPER_DYNTRACE") != nullptr;
     std::unordered_map<int, uint32_t> val;                 // known concrete SGPR values (by SHADER SGPR #)
     std::unordered_map<int, std::array<uint32_t, 4>> descr; // SGPR -> the 4-dword V# it holds (load-time snapshot)
+    // Descriptor-TABLE provenance (#294): for each snapshotted 4/8-dword s_load, the load's IMMEDIATE
+    // byte offset — the recompiler's sreg_srt/by_srt_offset key. 0xFFFFFFFF = not provenance-usable
+    // (register-SOFFSET or negative-immediate load, which emit_alu doesn't tag).
+    std::unordered_map<int, uint32_t> descr_key;
+    std::unordered_map<int, std::array<uint32_t, 8>> descr8;  // SGPR -> 8-dword T# (load-time snapshot)
+    std::unordered_map<int, uint32_t> descr8_key;
+    // SGPRs overwritten by an s_load since seeding — the seed-V# MUBUF fallback below must not use a
+    // stale user-data snapshot once the register was RELOADED from memory (ALU patches deliberately
+    // don't count: descriptor snapshots are load-time semantics, pre-patch, like `descr`).
+    std::set<int> reloaded;
     int scc = -1;   // tracked SCC (-1 unknown): set by s_cmp_*, consumed by s_cselect (the format patch's tail)
     // The SPI loads the user-data block starting at shader SGPR `user_sgpr_base` (s0..s7 are NGG system
     // SGPRs). So user-data block index k lands in shader SGPR (user_sgpr_base + k).
@@ -220,6 +231,18 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 if (soff_field < 106) soff_ok = known((int)soff_field, soff_val);          // SGPR
                 else if (soff_field == 106 || soff_field == 107) soff_ok = known((int)soff_field, soff_val); // vcc lo/hi
                 else soff_val = 0;                                          // null/const-0 soffset
+                // Descriptor-table use (#294): an s_buffer_load's SBASE is a V# — if that V# was
+                // snapshotted from a table load, report it as a ConstantBuffer use keyed by its load
+                // immediate (matching the recompiler's sreg_srt tag). Recorded BEFORE the dest write
+                // below (SBASE and SDST ranges may overlap).
+                if (srt_uses && is_buffer) {
+                    auto dit = descr.find(sbase); auto kit = descr_key.find(sbase);
+                    if (dit != descr.end() && kit != descr_key.end() && kit->second != 0xFFFFFFFFu) {
+                        SrtUse u; u.kind = 1; u.key = kit->second; u.v4 = dit->second;
+                        srt_uses->push_back(u);
+                    }
+                }
+                for (uint32_t k = 0; k < n; k++) reloaded.insert(sdst + (int)k);   // dest now holds memory data
                 uint64_t base = 0; bool base_ok;
                 if (is_buffer) { uint32_t b0, b1; base_ok = known(sbase, b0) && known(sbase + 1, b1);
                                  base = ((uint64_t)b0 | ((uint64_t)b1 << 32)) & 0xFFFFFFFFFFFFull; }   // V#.Base48
@@ -237,9 +260,33 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                                     for (uint32_t k = 0; k < n; k++) val.erase(sdst + (int)k); break; }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
                 for (uint32_t k = 0; k < n; k++) val[sdst + (int)k] = mem[k];
+                // Provenance key: the recompiler tags an IMMEDIATE-only descriptor load's dest SGPRs
+                // with the load immediate (sreg_srt = in.literal); register-SOFFSET / negative loads
+                // are not tagged, so mark those snapshots key-less.
+                const bool imm_only = (soff_field == 125) && (int32_t)in.literal >= 0;   // SGPR_NULL soffset
                 // A 4-dword load is a V# candidate — snapshot it now (before any later stride patch) so a
-                // vertex fetch using these SGPRs resolves to the descriptor as loaded.
-                if (n == 4) descr[sdst] = { mem[0], mem[1], mem[2], mem[3] };
+                // vertex fetch using these SGPRs resolves to the descriptor as loaded. An 8-dword load is
+                // a T# candidate (image_sample SRSRC), snapshotted the same way (#294).
+                if (n == 4) { descr[sdst] = { mem[0], mem[1], mem[2], mem[3] };
+                              // only s_load (not s_buffer_load) dests get the recompiler's sreg_srt tag
+                              descr_key[sdst] = (imm_only && !is_buffer) ? in.literal : 0xFFFFFFFFu; }
+                if (n == 8) { descr8[sdst] = { mem[0], mem[1], mem[2], mem[3], mem[4], mem[5], mem[6], mem[7] };
+                              descr8_key[sdst] = (imm_only && !is_buffer) ? in.literal : 0xFFFFFFFFu; }
+                break;
+            }
+            case Rdna2Format::MIMG: {
+                // Descriptor-table use (#294): an image op's SRSRC (src[1]) is an 8-dword T#; if it was
+                // snapshotted from a keyed table load, report it as a Texture use — with the paired
+                // SSAMP (src[2]) S# when that 4-dword load also resolved. VGPR-only dest: no SGPR state.
+                if (srt_uses) {
+                    auto tit = descr8.find(in.src[1].value); auto kit = descr8_key.find(in.src[1].value);
+                    if (tit != descr8.end() && kit != descr8_key.end() && kit->second != 0xFFFFFFFFu) {
+                        SrtUse u; u.kind = 0; u.key = kit->second; u.t8 = tit->second;
+                        auto sit = descr.find(in.src[2].value);
+                        if (sit != descr.end()) { u.has_samp = true; u.s4 = sit->second; }
+                        srt_uses->push_back(u);
+                    }
+                }
                 break;
             }
             case Rdna2Format::MUBUF: {
@@ -264,6 +311,29 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     if (patched)          out.push_back({ in.pc, srsrc, decode_buffer_descriptor(vv), vv[3] });
                     else if (it != descr.end())
                         out.push_back({ in.pc, srsrc, decode_buffer_descriptor(it->second.data()), it->second[3] });
+                    else if (srsrc >= (int)user_sgpr_base && srsrc + 4 <= (int)(user_sgpr_base + nsgpr) &&
+                             !reloaded.count(srsrc) && !reloaded.count(srsrc + 1) &&
+                             !reloaded.count(srsrc + 2) && !reloaded.count(srsrc + 3)) {
+                        // SEED fallback (#294): the SRSRC V# was placed directly in the user-data SGPRs
+                        // by the driver (never s_loaded — so no `descr` snapshot) and the shader's
+                        // stride/format patch left the CURRENT dwords partially unknown (its s_cselect
+                        // condition reads an NGG system SGPR we don't model). Use the SEED values — the
+                        // same load-time/pre-patch semantics as the `descr` fallback above. Refused if
+                        // any of the 4 SGPRs was RELOADED from memory since seeding (a stale seed then
+                        // no longer describes the register). DOLL's scene-geometry VS fetches resolve
+                        // through exactly this path. CONFIDENCE: MED (patch-ignoring, like `descr`).
+                        const uint32_t sv[4] = { user_sgprs[srsrc - (int)user_sgpr_base],
+                                                 user_sgprs[srsrc - (int)user_sgpr_base + 1],
+                                                 user_sgprs[srsrc - (int)user_sgpr_base + 2],
+                                                 user_sgprs[srsrc - (int)user_sgpr_base + 3] };
+                        DecodedBufferDescriptor d = decode_buffer_descriptor(sv);
+                        // Plausibility: only emit a real-looking V# (mirrors the direct-resource guard).
+                        if (d.base > 0x10000 && d.size_bytes != 0 && d.size_bytes <= 0x10000000u) {
+                            if (trc) fprintf(stderr, "[dyntrace]   MUBUF pc=%u seed-V# fallback SRSRC=s%d base=0x%llx\n",
+                                             in.pc, srsrc, (unsigned long long)d.base);
+                            out.push_back({ in.pc, srsrc, d, sv[3] });
+                        }
+                    }
                 }
                 break;
             }
@@ -370,12 +440,20 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     // Bindless-dynamic vertex fetch (VS): const-fold the scalar setup to resolve each buffer_load_format's
     // V#, then emit it as a VertexBuffer keyed by its SRSRC SGPR so the recompiler's by_sgpr_base resolves
     // it. Only meaningful for the vertex stage (the PS has no vertex fetch).
+    // The SAME const-fold also recovers descriptor-TABLE uses for BOTH stages (#294): UE4 shaders
+    // s_load their T#/S#/V# descriptors from a table pointer in the user-data SGPRs and consume them
+    // via image_sample / s_buffer_load — srt_uses reports each with its load-immediate key, which
+    // becomes the resource's srt_offset (the recompiler's by_srt_offset provenance).
     std::vector<DynFetch> dyn_vb;
-    if (!is_ps) {
+    std::vector<SrtUse> srt_uses;
+    if (is_ps) {
+        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0], sgprs);
+        resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 0, &srt_uses);
+    } else {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0], sgprs);
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
         // shader's s[8:11]/s[24:25] descriptor pointers to the register file at GS_0+offset).
-        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 8);
+        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 8, &srt_uses);
         if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_RESDUMP")) {
             fprintf(stderr, "[dynvb] VS resolved %zu dynamic vertex-fetch descriptor(s):\n", dyn_vb.size());
             for (auto& kv : dyn_vb) {
@@ -423,6 +501,81 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             r.fetch_pc      = kv.fetch_pc;        // PER-FETCH provenance = the exact fetch instruction
             r.srt_offset    = 0xFFFFFFFFu;
             t.resources.push_back(r);
+        }
+        // Descriptor-TABLE resources (#294): one ShaderResource per distinct table use, keyed by the
+        // s_load immediate (srt_offset) so the recompiler's sreg_srt/by_srt_offset provenance resolves
+        // the consuming image_sample / s_buffer_load. Never shadow an existing resource at the same
+        // srt_offset (the EUD-sharp path may already have emitted it — first match wins in
+        // by_srt_offset, and two DIFFERENT tables reusing one immediate would be ambiguous anyway).
+        {
+            std::set<uint64_t> srt_seen;
+            for (const auto& u : srt_uses) {
+                uint64_t dk = ((uint64_t)(uint32_t)u.kind << 32) | u.key;
+                if (!srt_seen.insert(dk).second) continue;
+                bool clash = false;
+                for (const auto& r0 : t.resources) if (r0.srt_offset == u.key) { clash = true; break; }
+                if (clash) continue;
+                if (u.kind == 1) {                       // constant buffer (V#)
+                    DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                    if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+                    ShaderResource r;
+                    r.cls = ResourceClass::ConstantBuffer;
+                    r.format = d.format; r.num_components = d.num_components ? d.num_components : 1;
+                    r.gpu_addr = d.base; r.size = d.size_bytes; r.stride = d.stride;
+                    r.srt_offset = u.key;
+                    if (log) fprintf(stderr, "[srt] %s cbuf key=0x%x base=0x%llx size=%u\n", is_ps ? "PS" : "VS",
+                                     u.key, (unsigned long long)d.base, d.size_bytes);
+                    t.resources.push_back(r);
+                } else {                                  // texture (T# [+ paired S#])
+                    DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
+                    if (d.base == 0 || d.width == 0 || d.height == 0 ||
+                        d.width > 16384 || d.height > 16384) continue;       // garbage/degenerate T#
+                    Gen5ImageFormatInfo fi;
+                    if (!gen5_image_format(d.format, &fi)) {
+                        // Same unmapped-format policy as build_shader_resources: bind as RGBA8 only
+                        // under RTT (so render-to-texture injection can supply the pixels), else skip.
+                        static const bool rtt_bind = getenv("PROSPER_RTT") != nullptr ||
+                                                     getenv("PROSPER_RTT_PERTARGET") != nullptr;
+                        if (!rtt_bind) continue;
+                        fi.format = DataFormat::Unorm8; fi.num_components = 4; fi.bytes_per_block = 4;
+                        fi.block_width = fi.block_height = 1; fi.srgb = false; fi.snorm = false;
+                    }
+                    const bool is_bcn = fi.block_width > 1;
+                    if (is_bcn && (fi.format == DataFormat::Bc6 || fi.snorm)) continue;   // decode not wired
+                    ShaderResource r;
+                    r.cls = ResourceClass::Texture;
+                    r.format = fi.format; r.num_components = fi.num_components;
+                    r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
+                    r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
+                    r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
+                    r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
+                    r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
+                                    : (d.width * d.height * fi.bytes_per_block);
+                    r.srt_offset = u.key;
+                    if (u.has_samp) {                     // paired S# (same SQ_IMG_SAMP decode as the sharp path)
+                        const uint32_t* sm = u.s4.data();
+                        r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
+                        r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
+                        r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;
+                        r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
+                        r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
+                        r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
+                        r.max_aniso_ratio    = (sm[0] >> 9)  & 0x7u;
+                        r.depth_compare_func = (sm[0] >> 12) & 0x7u;
+                        r.unnormalized       = (sm[0] >> 15) & 0x1u;
+                        r.min_lod            = (float)( sm[1]        & 0xFFFu) / 256.0f;
+                        r.max_lod            = (float)((sm[1] >> 12) & 0xFFFu) / 256.0f;
+                        int32_t bias14       = (int32_t)(sm[2] & 0x3FFFu);
+                        if (bias14 & 0x2000) bias14 -= 0x4000;
+                        r.lod_bias           = (float)bias14 / 256.0f;
+                        r.border_color_type  = (sm[3] >> 30) & 0x3u;
+                    }
+                    if (log) fprintf(stderr, "[srt] %s tex key=0x%x %ux%u fmt=%u base=0x%llx tile=%u samp=%d\n",
+                                     is_ps ? "PS" : "VS", u.key, d.width, d.height, d.format,
+                                     (unsigned long long)d.base, d.tile_mode, (int)u.has_samp);
+                    t.resources.push_back(r);
+                }
+            }
         }
         if (t.resources.empty()) continue;
         assign_convention_bindings(t, is_ps ? kPsBindingBase : 2u);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -331,7 +331,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         if (d.base > 0x10000 && d.size_bytes != 0 && d.size_bytes <= 0x10000000u) {
                             if (trc) fprintf(stderr, "[dyntrace]   MUBUF pc=%u seed-V# fallback SRSRC=s%d base=0x%llx\n",
                                              in.pc, srsrc, (unsigned long long)d.base);
-                            out.push_back({ in.pc, srsrc, d, sv[3] });
+                            out.push_back({ in.pc, srsrc, d, sv[3], /*from_seed=*/true });
                         }
                     }
                 }
@@ -490,6 +490,16 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         // (a raw 32-bit-per-component fetch, correct for float attributes like positions).
         for (auto& kv : dyn_vb) {
             const auto& d = kv.desc;
+            // A SEED-fallback entry must not shadow a metadata-described DIRECT vertex buffer at the
+            // same SGPRs (see DynFetch::from_seed): the direct resource resolves the fetch through
+            // the faithful address path, which is the correct model for a single un-patched V#.
+            if (kv.from_seed) {
+                bool direct_exists = false;
+                for (const auto& r0 : t.resources)
+                    if (r0.cls == ResourceClass::VertexBuffer && r0.sgpr_base == (uint32_t)kv.srsrc)
+                        { direct_exists = true; break; }
+                if (direct_exists) continue;
+            }
             ShaderResource r;
             r.cls           = ResourceClass::VertexBuffer;
             r.format        = (d.format == DataFormat::Unknown) ? DataFormat::Float32 : d.format;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -55,6 +55,8 @@ enum : uint32_t {
     Cap_StorageImageMultisample=27,      // MS=1 storage image (read/write a multisampled image)
     Cap_ImageMSArray=48,                 // MS=1 AND Arrayed=1 image (2D_MSAA_ARRAY)
     Cap_StorageImageReadWithoutFormat=55, Cap_StorageImageWriteWithoutFormat=56,  // for Format=Unknown storage images
+    Cap_ImageGatherExtended=25,          // dynamic (non-const) Offset image operand on OpImageGather
+    ImgOp_Offset=0x10,                   // ImageOperands bit: dynamic texel offset (needs ImageGatherExtended)
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Sample=0x40,   // ImageOperands bits: LOD bias / explicit LOD / MSAA Sample index.
@@ -377,6 +379,26 @@ struct SpirvCompute {
         uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
         uint32_t res   = id(); put(code, Op_ImageGather, {t_v4f, res, si, coord, uconst(comp)});
+        for (uint32_t c = 0; c < 4; c++) {
+            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
+        }
+    }
+    // image_gather4_lz_o 2D: gather with the MIMG _o per-pixel OFFSET operand. The offset VGPR packs
+    // signed 6-bit TEXEL offsets (x = bits[5:0], y = bits[13:8] — AMD RDNA2 ISA "offset" packing, the
+    // same fields image_sample_*_o uses). SPIR-V's dynamic Offset image operand requires the
+    // ImageGatherExtended capability (the offset VGPR is not a compile-time constant in our SSA model,
+    // even though shaders typically v_mov an immediate into it).
+    bool declared_gather_ext = false;
+    uint32_t t_v2i_cache = 0;
+    uint32_t t_v2i() { if (!t_v2i_cache) { t_v2i_cache = id(); put(types, Op_TypeVector, {t_v2i_cache, t_i32, 2}); } return t_v2i_cache; }
+    void image_gather_offset_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t comp,
+                                uint32_t off_bits, uint32_t out[4]) {
+        if (!declared_gather_ext) { put(caps, Op_Capability, {Cap_ImageGatherExtended}); declared_gather_ext = true; }
+        uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
+        uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+        uint32_t ox    = bfe_s(off_bits, 0, 6), oy = bfe_s(off_bits, 8, 6);   // signed 6-bit texel offsets
+        uint32_t offv  = id(); put(code, Op_CompositeConstruct, {t_v2i(), offv, bcs(ox), bcs(oy)});
+        uint32_t res   = id(); put(code, Op_ImageGather, {t_v4f, res, si, coord, uconst(comp), ImgOp_Offset, offv});
         for (uint32_t c = 0; c < 4; c++) {
             uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
         }
@@ -2407,9 +2429,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const bool is_sample = (in.opcode == 0x20), is_load = (in.opcode == 0x00);
             const bool is_sample_l = (in.opcode == 0x24), is_sample_lz = (in.opcode == 0x27);
             const bool is_sample_b = (in.opcode == 0x25), is_gather_lz = (in.opcode == 0x47);
+            // image_gather4_lz_o = 0x57 (gather at base level with the _o packed-offset operand in the
+            // FIRST vaddr — llvm-mc gfx1030 round-trip on live DOLL bytes: 0xf15c0808 "image_gather4_lz_o
+            // v[4:7], [v0, v18, v19], ..." — coords follow the offset, matching image_sample_b's
+            // modifier-first vaddr convention). DOLL's FXAA/upsample pass PS (#294).
+            const bool is_gather_lz_o = (in.opcode == 0x57);
             const bool dim2d = (in.mimg_dim == 1u), dim3d = (in.mimg_dim == 2u);
-            if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b && !is_gather_lz) ||
-                (!dim2d && !dim3d)) { ok = false; return true; }
+            if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b && !is_gather_lz &&
+                 !is_gather_lz_o) || (!dim2d && !dim3d)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
             // coords (normalized float for sample, integer texel for load). Non-NSA: consecutive from VADDR.
             // NSA (len>2): coord0 = VADDR, coord k>=1 = byte (k-1) of the extra address dwords words[2..3].
@@ -2424,14 +2451,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (is_sample) b.image_sample_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
                 else           b.image_sample_lod_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)),
                                                      b.uconst(0), out);         // _lz: base level
-            } else if (is_gather_lz) {
+            } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
                 // four texels of that channel -> 4 consecutive VDATA VGPRs, gather order preserved.
                 uint32_t dm = in.mimg_dmask;
                 if (dm != 1u && dm != 2u && dm != 4u && dm != 8u) { ok = false; return true; }
                 uint32_t comp = dm == 1u ? 0u : dm == 2u ? 1u : dm == 4u ? 2u : 3u;
                 b.declare_texture(res->binding, Dim_2D);
-                b.image_gather_2d(res->binding, vread(cvg(0)), vread(cvg(1)), comp, out);
+                if (is_gather_lz_o)   // vaddr order for _o: [packed offset, u, v]
+                    b.image_gather_offset_2d(res->binding, vread(cvg(1)), vread(cvg(2)), comp, vread(cvg(0)), out);
+                else
+                    b.image_gather_2d(res->binding, vread(cvg(0)), vread(cvg(1)), comp, out);
                 int vd = in.dst.value;
                 for (uint32_t c = 0; c < 4; c++) {
                     uint32_t old = vreg_old(b, rs, vd + (int)c);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -105,7 +105,14 @@ struct BackendDraw {
     std::vector<uint32_t> indices;
 };
 
-inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H) {
+// `seed_rgba` (optional): W*H*4 RGBA8 pixels to PRELOAD the color attachment with before the draws
+// run (loadOp LOAD instead of the blue clear). This is real render-target memory semantics: a game
+// pass that draws into a target it (or an earlier submit) already rendered composites OVER that
+// content — without it every pass starts from the diagnostic blue clear, so cross-submit
+// accumulation (UE4's UI-onto-backbuffer after a separate composite submit) is lost. Null (the
+// default) keeps the blue-clear behavior byte-identical for every existing caller.
+inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H,
+                                              const uint8_t* seed_rgba = nullptr) {
     std::vector<uint8_t> out;
     if (draws.empty()) return out;
     VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO}; app.apiVersion = VK_API_VERSION_1_1;
@@ -176,7 +183,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     imgci.imageType = VK_IMAGE_TYPE_2D; imgci.format = FMT; imgci.extent = {W, H, 1};
     imgci.mipLevels = 1; imgci.arrayLayers = 1; imgci.samples = VK_SAMPLE_COUNT_1_BIT;
     imgci.tiling = VK_IMAGE_TILING_OPTIMAL;
-    imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                  (seed_rgba ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
     VkImage img; vkCreateImage(dev, &imgci, nullptr, &img);
     VkMemoryRequirements ir; vkGetImageMemoryRequirements(dev, img, &ir);
     VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
@@ -205,9 +213,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
 
     VkAttachmentDescription att[2]{};
     att[0].format = FMT; att[0].samples = VK_SAMPLE_COUNT_1_BIT;
-    att[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR; att[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    // Seeded: the attachment already holds the preloaded pixels (uploaded before the pass below), so
+    // LOAD them instead of clearing, and declare the matching initial layout.
+    att[0].loadOp = seed_rgba ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
+    att[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     att[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE; att[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    att[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; att[0].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    att[0].initialLayout = seed_rgba ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+    att[0].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     att[1].format = DFMT; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
     att[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR; att[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
     // Clear the stencil at pass start when a mask uses it (so the mask draw defines the stenciled
@@ -488,6 +500,33 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkCommandBuffer cmd; vkAllocateCommandBuffers(dev, &cbai, &cmd);
     VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(cmd, &cbbi);
+    // Preload the color attachment with the seed pixels (render-target persistence): staging upload +
+    // transition to COLOR_ATTACHMENT_OPTIMAL, matching att[0]'s LOAD/initialLayout above.
+    VkBuffer seedbuf = VK_NULL_HANDLE; VkDeviceMemory seedmem = VK_NULL_HANDLE;
+    if (seed_rgba) {
+        VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        sci.size = bytes; sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        vkCreateBuffer(dev, &sci, nullptr, &seedbuf);
+        VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, seedbuf, &sr);
+        VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; sai.allocationSize = sr.size;
+        sai.memoryTypeIndex = pick(sr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        vkAllocateMemory(dev, &sai, nullptr, &seedmem); vkBindBufferMemory(dev, seedbuf, seedmem, 0);
+        void* sp = nullptr; vkMapMemory(dev, seedmem, 0, bytes, 0, &sp);
+        memcpy(sp, seed_rgba, (size_t)bytes); vkUnmapMemory(dev, seedmem);
+        VkImageMemoryBarrier s0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        s0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; s0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        s0.image = img; s0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        s0.srcAccessMask = 0; s0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &s0);
+        VkBufferImageCopy sc{}; sc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; sc.imageExtent = {W, H, 1};
+        vkCmdCopyBufferToImage(cmd, seedbuf, img, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &sc);
+        VkImageMemoryBarrier s1{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        s1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL; s1.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        s1.image = img; s1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        s1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        s1.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, nullptr, 0, nullptr, 1, &s1);
+    }
     // Upload each draw's textures: UNDEFINED -> TRANSFER_DST, copy staging buffer, TRANSFER_DST -> SHADER_READ.
     for (auto& v : dv) for (size_t i = 0; i < v.R.size(); i++) {
         if (!v.R[i].is_texture()) continue;
@@ -561,6 +600,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             if (v.tstagemem[i])vkFreeMemory(dev, v.tstagemem[i], nullptr);
         }
     }
+    if (seedbuf) vkDestroyBuffer(dev, seedbuf, nullptr);
+    if (seedmem) vkFreeMemory(dev, seedmem, nullptr);
     vkDestroyBuffer(dev, rb, nullptr); vkFreeMemory(dev, bmem, nullptr);
     vkDestroyFramebuffer(dev, fb, nullptr); vkDestroyRenderPass(dev, rp, nullptr); vkDestroyImageView(dev, view, nullptr);
     vkDestroyImage(dev, img, nullptr); vkFreeMemory(dev, imem, nullptr);

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -73,6 +73,67 @@ int main() {
     std::vector<DynFetch> f3 = resolve_dynamic_fetch(k3, sizeof(k3)/sizeof(k3[0]), nullptr, 0, 0);
     CHECK(f3.empty(), "s_bfe_u64 of an inline FLOAT does not fold (V# dword unknown -> fetch unresolved)");
 
+    // Kernel 4: SEED-V# fallback (#294). The V# sits directly in the user-data SGPRs (s[8:11] =
+    // user block index 0..3, user_sgpr_base 8) and an ALU patch makes one dword UNKNOWN (s_mov from
+    // an untracked SGPR — DOLL's format patch does this via an s_cselect on an NGG system SGPR).
+    // Neither 'patched' nor 'descr' resolves; the fetch must fall back to the SEED (load-time /
+    // pre-patch) descriptor. No s_load touches s[8:11], so the reloaded guard stays clear.
+    const uint32_t k4[] = {
+        0xBE8B0332u,                // s_mov_b32 s11, s50 (s50 unknown -> s11 unknown; ALU, not a reload)
+        0xE0002000u, 0x80020100u,   // buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,                // s_endpgm
+    };
+    const uint32_t seed4[4] = { 0x00020000u, 0x00100000u, 64u, 0u };   // base=0x20000 stride=16 recs=64
+    std::vector<DynFetch> f4 = resolve_dynamic_fetch(k4, sizeof(k4)/sizeof(k4[0]), seed4, 4, 8);
+    CHECK(f4.size() == 1, "kernel 4 seed-V# fallback resolves the fetch");
+    CHECK(f4.size() == 1 && f4[0].desc.base == 0x20000ull && f4[0].desc.stride == 16u,
+          "kernel 4 fallback V# = the SEED (user-data) descriptor");
+
+    // Kernel 4b: same, but s11 was RELOADED from memory (s_load_dword) — the stale seed must NOT be
+    // used (the register no longer holds user data). The load's address is unknown (s[40:41]
+    // untracked), so the value is unknown too and the fetch must stay unresolved.
+    const uint32_t k4b[] = {
+        0xF40002D4u, 0xFA000000u,   // s_load_dword s11, s[40:41], 0x0 (unknown base -> s11 reloaded+unknown)
+        0xE0002000u, 0x80020100u,   // buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<DynFetch> f4b = resolve_dynamic_fetch(k4b, sizeof(k4b)/sizeof(k4b[0]), seed4, 4, 8);
+    CHECK(f4b.empty(), "kernel 4b reloaded SGPR blocks the seed fallback (no fabricated V#)");
+
+    // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
+    // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample
+    // (SRSRC/SSAMP) and s_buffer_load (SBASE). Each use must be reported with the load immediate as
+    // its key and the dwords as loaded. (Encodings llvm-mc gfx1030 round-trip verified.)
+    static uint32_t table[64];
+    for (int i = 0; i < 64; i++) table[i] = 0xD0000000u + (uint32_t)i;
+    // The V# at +0x80 must be a READABLE buffer for the interpreter's s_buffer_load data read:
+    // point it back at `table` itself (num_records=256 bytes, stride 0).
+    uint64_t tbase = (uint64_t)(uintptr_t)table;
+    table[32] = (uint32_t)tbase; table[33] = (uint32_t)(tbase >> 32) & 0xFFFFu; table[34] = 256u; table[35] = 0u;
+    const uint32_t k5[] = {
+        0xF40C0304u, 0xFA000040u,   // s_load_dwordx8 s[12:19], s[8:9], 0x40
+        0xF4080504u, 0xFA000080u,   // s_load_dwordx4 s[20:23], s[8:9], 0x80
+        0xF0800F08u, 0x00A30000u,   // image_sample v[0:3], v[0:1], s[12:19], s[20:23] dmask:0xf 2D
+        0xF420060Au, 0xFA000010u,   // s_buffer_load_dword s24, s[20:23], 0x10
+        0xBF810000u,                // s_endpgm
+    };
+    uint32_t seed5[2] = { (uint32_t)tbase, (uint32_t)(tbase >> 32) };
+    std::vector<SrtUse> uses;
+    resolve_dynamic_fetch(k5, sizeof(k5)/sizeof(k5[0]), seed5, 2, 8, &uses);
+    bool have_tex = false, have_cbuf = false, tex_ok = false, samp_ok = false, cbuf_ok = false;
+    for (const auto& u : uses) {
+        if (u.kind == 0 && u.key == 0x40) { have_tex = true;
+            tex_ok  = (u.t8[0] == table[16] && u.t8[7] == table[23]);
+            samp_ok = (u.has_samp && u.s4[0] == table[32] && u.s4[3] == table[35]); }
+        if (u.kind == 1 && u.key == 0x80) { have_cbuf = true;
+            cbuf_ok = (u.v4[0] == table[32] && u.v4[2] == 256u); }
+    }
+    CHECK(have_tex,  "kernel 5 image_sample reports a Texture table-use keyed by the T# load imm");
+    CHECK(tex_ok,    "kernel 5 T# dwords match the table as loaded");
+    CHECK(samp_ok,   "kernel 5 paired SSAMP S# resolved alongside the T#");
+    CHECK(have_cbuf, "kernel 5 s_buffer_load reports a ConstantBuffer table-use keyed by the V# load imm");
+    CHECK(cbuf_ok,   "kernel 5 V# dwords match the table as loaded");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
refs #294 (wall A — present selection — closed; wall B advanced, remaining blockers precisely identified below). refs #273.

## What this does

**Wall A — flip-anchored present selection (closed).** Under `PROSPER_RTT_PERTARGET`, present the RTT group whose color-target VA matches the guest's **flipped VideoOut buffer** (front buffer > any registered scanout > legacy last-group fallback). Live DOLL captures show per-frame groups targeting the two registered scanout buffers (`0x8fc0000000`/`0x8fc2000000`, alternating with each in-stream SetFlip, which fires during the Dcb fold — before the submit render — so the front index is this frame's scanout choice). Fully inside the pertarget branch: Messenger's default present path is untouched (snapshot guard green, identical 24318-color richest frame).

**RT persistence seeding.** `render_draws_rgba` grows an optional `seed_rgba` (staging upload + `loadOp LOAD`); the pertarget path seeds each group with the pixels last rendered into that same target VA — real RT-memory semantics, so a UI pass drawing onto an already-composited backbuffer in a later submit no longer starts from the diagnostic blue clear. Default-null seed keeps every existing caller byte-identical; `PROSPER_RTT_NOSEED` opts out.

**Wall B — three recompile-unblockers** (from `PROSPER_DBG` reject tracing + llvm-mc disassembly of the dumped failing shaders):
1. **UE4 descriptor-table (SRT) resolution** — the dominant reject class. DOLL's shaders `s_load_dwordx4/x8` their T#/S#/V# descriptors from a table pointer in the user-data SGPRs and consume them via `image_sample` SRSRC/SSAMP and `s_buffer_load` SBASE. The const-fold interpreter (`resolve_dynamic_fetch`) now snapshots 8-dword T# loads, reports each consumer as an `SrtUse` keyed by the load immediate, and `build_stage_table` emits those as `ShaderResource`s with `srt_offset = key` — exactly the recompiler's existing `sreg_srt`/`by_srt_offset` provenance. Includes the paired S# sampler decode and the same T#-format policies as the sharp path.
2. **MIMG 0x57 = `image_gather4_lz_o`** (llvm-mc gfx1030 round-trip on live bytes): OpImageGather with a dynamic Offset operand (signed 6-bit texel offsets unpacked from the offset VGPR; ImageGatherExtended capability). Was the FXAA/upsample pass's first reject.
3. **Seed-V# vertex-fetch fallback**: DOLL's scene VS keeps its vertex V# directly in user-data SGPRs and runtime-patches the format field behind an `s_cmp` on an NGG system SGPR the fold can't know; fall back to the seed (pre-patch) descriptor — refused if the SGPRs were reloaded from memory, and never shadowing a metadata-described direct vertex buffer (`DynFetch::from_seed`).

## Measured effect (live DOLL boots, before → after)

- The presented frame is now the guest's real **backbuffer compose**: the bottom-center loading-banner widget and the black rounded-corner screen border composite onto the flipped scanout target (previously an arbitrary "last group" — a bare clear).
- Scanout groups: 2 → 4 realized draws; **830 realized 3840x2160 texture uploads** per run (the tonemap/upsample chain now feeds real draws that were previously recompile-rejected); the final blit-to-backbuffer PS's `image_sample` T# (table offset 0x20) and the scene PS's samples now **resolve**.
- **Honest state: the frame is NOT yet recognizable.** The screen is the loading-phase UI skeleton (banner solid-red — its text VS still fails on `v_movrels_b32`), and scene geometry still does not reach scene-color: those draws are recompile-rejected, not routed wrong (see below).

## Remaining blockers (exact, from PROSPER_DBG + disassembly of the dumped shaders)

1. **Final blit-to-backbuffer PS**: if/else cascades whose `s_branch` else-arms jump to the *outermost* merge (`vccz@35/60/62, vccnz@67 → s_branch@83/96 → merge@103`) — needs structurizer if/else + early-exit-to-merge support.
2. **FXAA PS**: `v_cmpx` + `s_cbranch_execz` over a 241-dword refinement block containing `image_sample_lz_o` (0x37) and an inner loop — needs divergent-execz region support.
3. **Scene-geometry pair**: VS `buffer_load_format_xyzw` at pc 69/77 (V#-table reloads at computed offsets between consecutive fetches), PS vccz cascades (pc 75/162).
4. **UI text VS**: `v_movrels_b32` (M0-relative register moves) — blocks the banner text.
5. `s_buffer_load_dwordx4` with register SOFFSET; one `fmt17` decode gap; one `v_mov` special-operand reject.

## Verification

- ctest **68/68** green (incl. new `test_dynfetch_fold` kernels 4/4b/5: seed fallback, reload guard, SrtUse extraction — encodings llvm-mc round-trip verified).
- **Messenger regression**: `tools/snapshot/snapshot.py check` → `messenger-scene: OK (480x270, richest 24318 colors >= 5000)`, run twice (before and after the from_seed guard). 0 faults.
- DOLL boot recipe: `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_RTT_PERTARGET=1 [PROSPER_RTTLOG=1 PROSPER_RTLOG=1 PROSPER_GFXLOG=1 PROSPER_DBG=1] PROSPER_RENDER_SCALE=2 boot_trace /root/PPSA17942-app0`.
