### PR TITLE
fix(gpu): fold MUBUF SOFFSET/inst-offset into dynamic vertex-fetch V# bases — real Slate UI vertex attributes (refs #273)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -442,6 +442,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fprintf(stderr, "[rtt] group target=0x%llx (%zu draws) px_nonzero=%zu cache_size=%zu%s%s\n",
                                 (unsigned long long)base, groups[base].size(), nz, g_rtt.size(),
                                 is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : ""); }
+                    // PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes>: dump each per-target group's rendered
+                    // pixels (rtgrp_<base>_<frame>.bmp in PROSPER_FRAME_DIR) — to inspect an intermediate
+                    // pass (e.g. the UI/banner RT) instead of only the presented composite. Diagnostic.
+                    if (const char* rg = getenv("PROSPER_DUMP_RTGROUPS"); rg && !gpx.empty()) {
+                        size_t nz = 0; for (uint8_t b : gpx) nz += (b != 0);
+                        if (nz >= (size_t)atol(rg)) {
+                            const char* dd = getenv("PROSPER_FRAME_DIR");
+                            char fn[512]; snprintf(fn, sizeof fn, "%s/rtgrp_%llx_%04d.bmp",
+                                                   dd ? dd : ".", (unsigned long long)base, frame_no.load());
+                            prosper::test::dump_bmp(fn, gpx, w, h);
+                        }
+                    }
                     if (!gpx.empty()) {
                         if (base && base == front_va) px_front = gpx;                   // the flipped buffer
                         if (is_vo)                    px_vo    = gpx;                   // any registered scanout

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -33,13 +33,27 @@ struct AgcShaderUserData {
     uint16_t        sharp_resource_count[4];     // +0x2e
 };
 
+// The shader "specials" block (Kyty Shader.h:947; pointed to by header +0x28) — only the user-data
+// range. user_data_range_start/end give the DWORD range within the stage's SPI_SHADER_USER_DATA_*
+// register block that this shader's SGPR-visible user data occupies (e.g. DOLL's UE4 Slate VS
+// declares [0,8) for its {V#, ptr, ptr} block). Every shader observed live declares start=0; the
+// executor honors a non-zero start as latent support (guarded).
+struct AgcShaderSpecials {
+    uint8_t  pad[0x14];
+    uint16_t user_data_range_start;   // +0x14 (dwords, relative to USER_DATA_<stage>_0)
+    uint16_t user_data_range_end;     // +0x16
+};
+
 // The SDK shader header (Kyty Shader.h:974) — only the fields the resource builder needs.
 struct AgcShaderHeader {
     uint32_t           file_header;   // +0x00 '1234'
     uint32_t           version;       // +0x04
     AgcShaderUserData* user_data;     // +0x08
     const void*        code;          // +0x10
-    uint8_t            pad[0x5a - 0x18];
+    const void*        cx_registers;  // +0x18
+    const void*        sh_registers;  // +0x20
+    const AgcShaderSpecials* specials;// +0x28
+    uint8_t            pad[0x5a - 0x30];
     uint8_t            type;          // +0x5a (2=VS/ES, 1=PS, 0=CS)
 };
 

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -119,9 +119,9 @@ void GpuState::apply(const Pm4Command& c) {
                        : (c.reg_class == RegClass::Sh) ? sh : uc;
             if (getenv("PROSPER_RESDUMP")) {
                 const char* cn = c.reg_class == RegClass::Cx ? "Cx" : c.reg_class == RegClass::Sh ? "Sh" : "Uc";
-                fprintf(stderr, "[regindir] class=%s num=%u vaddr=0x%llx first pairs:", cn, c.num_regs,
+                fprintf(stderr, "[regindir] class=%s num=%u vaddr=0x%llx pairs:", cn, c.num_regs,
                         (unsigned long long)c.regs_vaddr);
-                for (uint32_t i = 0; i < c.num_regs && i < 6; i++)
+                for (uint32_t i = 0; i < c.num_regs && i < 40; i++)
                     fprintf(stderr, " (off=0x%x val=0x%x)", regs[i].offset, regs[i].value);
                 fprintf(stderr, "\n");
             }
@@ -133,6 +133,15 @@ void GpuState::apply(const Pm4Command& c) {
             // SET_SH_REG writes a consecutive RANGE (the driver uploads the whole user-data SGPR block
             // this way). Write every value, not just the first — else all descriptors past the range's
             // first register are silently dropped (which left the shaders' V#/T# SGPRs empty).
+            if (getenv("PROSPER_RESDUMP")) {
+                fprintf(stderr, "[shdirect] off=0x%x count=%u vals:", c.sh_reg_offset,
+                        c.sh_reg_data ? c.sh_reg_count : 1u);
+                if (c.sh_reg_data && c.sh_reg_count)
+                    for (uint32_t k = 0; k < c.sh_reg_count && k < 40; k++)
+                        fprintf(stderr, " 0x%x", c.sh_reg_data[k]);
+                else fprintf(stderr, " 0x%x", c.sh_reg_value);
+                fprintf(stderr, "\n");
+            }
             if (c.sh_reg_data && c.sh_reg_count) {
                 for (uint32_t k = 0; k < c.sh_reg_count && c.sh_reg_count <= kMaxRegsPerPacket; k++)
                     sh[c.sh_reg_offset + k] = c.sh_reg_data[k];
@@ -155,6 +164,12 @@ void GpuState::apply(const Pm4Command& c) {
             // Gen5 indexed draw (issue #232). Uses the bound index base + count; DrawIndexOffset's own
             // count (c.index_count) overrides the SetIndexCount state when non-zero. The element size is
             // the current SetIndexType (0=16-bit, 1=32-bit), captured in the per-draw snapshot.
+            if (getenv("PROSPER_RESDUMP")) {   // draw-vs-bind association diagnostic (#273)
+                auto rd = [&](uint32_t off) { auto it = sh.find(off); return it == sh.end() ? 0u : it->second; };
+                fprintf(stderr, "[drawpkt] idx#%zu es=0x%08x count=%u dirty=%d ud=[%08x %08x %08x %08x | %08x %08x %08x %08x]\n",
+                        draws.size(), rd(0xc8), c.index_count ? c.index_count : index_num, (int)state_dirty_,
+                        rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f), rd(0x90), rd(0x91), rd(0x92), rd(0x93));
+            }
             if (state_dirty_ || !last_snapshot_) {
                 auto snap = std::make_shared<GpuState>();
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -93,6 +93,12 @@ std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             uint32_t user_sgpr_base,
                                             std::vector<SrtUse>* srt_uses = nullptr);
 
+// PROSPER_DYNTRACE_FAIL support (gpu_executor.cpp): while true, resolve_dynamic_fetch traces its
+// walk and build_stage_table dumps the user-data SGPR blocks. realize_draw_item sets it around a
+// replay of a FAILED vertex-stage resource build, so the diagnostic captures exactly the failing
+// draw without needing the shader's address up front (the UI draws it targets are rare/phase-bound).
+extern bool g_dyntrace_force;
+
 // Assign each resource in `t` a descriptor binding from `first`: constant/vertex buffers first, then
 // textures / storage images — never on binding 2 or 3 (the recompiler's two hardwired cbufs) so a
 // texture-first shader can't collide two descriptor types at one binding (#157). Exposed for testing.
@@ -159,6 +165,19 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
     }
     if (vs.empty() || fs.empty()) {
+        // PROSPER_DYNTRACE_FAIL=1: replay the FAILED vertex stage's resource build with the
+        // dynamic-fetch walk trace + user-data block dump forced on (once per distinct VS), so the
+        // failing draw's exact seeding/s_load chain is captured without knowing its address up front.
+        if (vs.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
+            static std::set<uint64_t> traced;
+            if (traced.insert(rs.es_addr).second) {
+                fprintf(stderr, "[dynfail] replaying VS 0x%llx resource build with trace:\n",
+                        (unsigned long long)rs.es_addr);
+                g_dyntrace_force = true;
+                (void)build_stage_table(ds, rs.es_addr, false);
+                g_dyntrace_force = false;
+            }
+        }
         if (log) {
             fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; es=0x%llx ps=0x%llx)\n",
                     vs.size(), fs.size(), (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -40,6 +40,12 @@ void read_user_sgprs(const std::unordered_map<uint32_t, uint32_t>& sh, uint32_t 
 } // namespace (guest_readable below has external linkage — declared in gpu_execute.hpp, shared with
   // the HLE diagnostic probes that chase raw guest pointers)
 
+// PROSPER_DYNTRACE_FAIL support: while true, resolve_dynamic_fetch traces its walk and
+// build_stage_table dumps the user-data blocks, regardless of the PROSPER_DYNTRACE/RESDUMP
+// envs. Set (and cleared) by realize_draw_item's failure replay — the submit path is serialized
+// by the HLE submit mutex, so a plain global is safe there.
+bool g_dyntrace_force = false;
+
 // Readability probe (guest memory is 1:1-mapped, but a mis-decoded address could be unmapped),
 // so guarded derefs on the render/submit thread don't risk a SIGSEGV. NOTE: /dev/null does NOT
 // work for this — the kernel's null_write returns count without ever touching the source buffer,
@@ -96,7 +102,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
 
-    const bool trc = getenv("PROSPER_DYNTRACE") != nullptr;
+    // PROSPER_DYNTRACE traces the whole const-fold walk; PROSPER_DYNTRACE_ADDR=<hex code addr>
+    // narrows it to ONE shader (a full run otherwise traces every draw's walk — unusable volume).
+    // g_dyntrace_force: set by the PROSPER_DYNTRACE_FAIL failure-replay path (gpu_execute.hpp) so
+    // the walk of a shader that just FAILED to recompile is traced without knowing its address.
+    bool trc = g_dyntrace_force || getenv("PROSPER_DYNTRACE") != nullptr;
+    if (trc && !g_dyntrace_force)
+        if (const char* fa = getenv("PROSPER_DYNTRACE_ADDR"))
+            trc = strtoull(fa, nullptr, 16) == (uint64_t)(uintptr_t)code;
     std::unordered_map<int, uint32_t> val;                 // known concrete SGPR values (by SHADER SGPR #)
     std::unordered_map<int, std::array<uint32_t, 4>> descr; // SGPR -> the 4-dword V# it holds (load-time snapshot)
     // Descriptor-TABLE provenance (#294): for each snapshotted 4/8-dword s_load, the load's IMMEDIATE
@@ -398,7 +411,12 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
 
     // PROSPER_RESDUMP: raw dump of the user-data struct + SGPR block per base, so the EUD layout
     // (which sharps have offset_dw>=16, and where the EUD pointer sits) can be read empirically.
-    if (getenv("PROSPER_RESDUMP")) {
+    bool resdump = getenv("PROSPER_RESDUMP") != nullptr;
+    if (resdump)   // PROSPER_RESDUMP_ADDR=<hex code addr>: narrow the dump to one shader
+        if (const char* fa = getenv("PROSPER_RESDUMP_ADDR"))
+            resdump = strtoull(fa, nullptr, 16) == code_addr;
+    if (g_dyntrace_force) resdump = true;   // failure replay: always dump the failing stage's blocks
+    if (resdump) {
         const AgcShaderUserData* ud = hdr->user_data;
         fprintf(stderr, "[resdump] %s code=0x%llx type=%u ud=%p\n", is_ps ? "PS" : "VS",
                 (unsigned long long)code_addr, hdr->type, (const void*)ud);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -316,14 +316,40 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                          k2 = known(srsrc + 2, vv[2]), k3 = known(srsrc + 3, vv[3]);
                     bool patched = k0 && k1 && k2 && k3;
                     auto it = descr.find(srsrc);
-                    if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d\n",
-                                     in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3, k3 ? vv[3] : 0, it != descr.end());
+                    // Fold the fetch's CONSTANT byte offset into the emitted V# base (#273 item 1, the
+                    // "solid banner" bug): the recompiler's per-fetch (by_fetch_pc) address model is
+                    // exactly gl_VertexIndex*stride from the resolved base — it assumes the attribute's
+                    // in-record byte offset is already IN the base. Unity-style fetch shaders satisfy
+                    // that by patching each attribute's V# base; DOLL's UE4 Slate VS instead uses ONE
+                    // un-patched V# and carries each attribute's offset in the MUBUF SOFFSET register
+                    // (+ the 12-bit inst offset). Without the fold, all four Slate attributes (pos, uv,
+                    // material-uv, color) read the position bytes -> the loading-banner widget rendered
+                    // as a solid bar. The walk knows the SOFFSET value (it computed it from the attr-spec
+                    // words), so add soffset+inst_offset to the descriptor base; an UNKNOWN soffset keeps
+                    // the un-offset base (previous behavior). CONFIDENCE: HIGH (fetch-time values traced
+                    // live; Messenger's fetches carry SOFFSET=0 so they are byte-identical).
+                    uint32_t soff = 0;
+                    if (!(in.src[2].kind == OperandKind::Special && in.src[2].value == 125))  // NULL -> 0
+                        if (!srcval(in.src[2], soff)) soff = 0;                               // unknown -> 0
+                    const uint32_t inst_off = in.literal & 0xFFFu;
+                    const uint32_t fetch_off = soff + inst_off;
+                    auto with_off = [&](DecodedBufferDescriptor d) {
+                        d.base += fetch_off;
+                        // size_bytes stays num_records*stride: the hardware bound is INDEX < num_records
+                        // (record granularity), so from the offset base the last record's attribute still
+                        // lies within (num_records-1)*stride + fetch_off + attr bytes — trimming the size
+                        // by fetch_off cut the LAST vertex's attribute off the upload (guarded reads made
+                        // it zeros -> a collapsed final vertex).
+                        return d;
+                    };
+                    if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x\n",
+                                     in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3, k3 ? vv[3] : 0, it != descr.end(), fetch_off);
                     // Per-fetch: record THIS fetch's live V# (the SRSRC SGPR is reloaded with a different V#
                     // per vertex attribute — position, uv, color…). Keyed by the fetch's pc so the recompiler
                     // resolves each buffer_load_format to the descriptor as loaded at that instruction.
-                    if (patched)          out.push_back({ in.pc, srsrc, decode_buffer_descriptor(vv), vv[3] });
+                    if (patched)          out.push_back({ in.pc, srsrc, with_off(decode_buffer_descriptor(vv)), vv[3] });
                     else if (it != descr.end())
-                        out.push_back({ in.pc, srsrc, decode_buffer_descriptor(it->second.data()), it->second[3] });
+                        out.push_back({ in.pc, srsrc, with_off(decode_buffer_descriptor(it->second.data())), it->second[3] });
                     else if (srsrc >= (int)user_sgpr_base && srsrc + 4 <= (int)(user_sgpr_base + nsgpr) &&
                              !reloaded.count(srsrc) && !reloaded.count(srsrc + 1) &&
                              !reloaded.count(srsrc + 2) && !reloaded.count(srsrc + 3)) {
@@ -344,7 +370,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         if (d.base > 0x10000 && d.size_bytes != 0 && d.size_bytes <= 0x10000000u) {
                             if (trc) fprintf(stderr, "[dyntrace]   MUBUF pc=%u seed-V# fallback SRSRC=s%d base=0x%llx\n",
                                              in.pc, srsrc, (unsigned long long)d.base);
-                            out.push_back({ in.pc, srsrc, d, sv[3], /*from_seed=*/true });
+                            out.push_back({ in.pc, srsrc, with_off(d), sv[3], /*from_seed=*/true });
                         }
                     }
                 }
@@ -409,6 +435,27 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     if (is_ps) { bases[0] = P::SPI_SHADER_USER_DATA_PS_0; bases[1] = P::SPI_SHADER_USER_DATA_GS_0; bases[2] = P::SPI_SHADER_USER_DATA_VS_0; }
     else       { bases[0] = P::SPI_SHADER_USER_DATA_GS_0; bases[1] = P::SPI_SHADER_USER_DATA_VS_0; bases[2] = P::SPI_SHADER_USER_DATA_PS_0; }
 
+    // Per-shader user-data RANGE: the shader blob's "specials" block declares which DWORD range of
+    // the stage's USER_DATA register block holds this shader's SGPR-visible user data
+    // (user_data_range_start/end — the range SetSource programs; e.g. DOLL's UE4 Slate VS declares
+    // [0,8) matching its 8-dword {V#, ptr, ptr} block). Header sharp/direct offsets are relative to
+    // range_start, so seed the SGPR block from USER_DATA_<stage>_<range_start>. Every shader
+    // observed live (DOLL + Messenger) declares start=0, so this is currently behavior-identical —
+    // LATENT support for a start!=0 shader, guarded back to 0 on insane metadata.
+    // CONFIDENCE: LOW on start!=0 semantics (no live example yet); zero risk for start==0.
+    uint32_t range_start = 0;
+    if (hdr->specials && guest_readable((uint64_t)(uintptr_t)hdr->specials, sizeof(AgcShaderSpecials))) {
+        const uint32_t s = hdr->specials->user_data_range_start;
+        const uint32_t e = hdr->specials->user_data_range_end;
+        if (s < kUserSgprs && e > s && e <= 2 * kUserSgprs) range_start = s;
+        if (log && range_start) {   // once per shader: non-zero ranges are the rare/interesting case
+            static std::set<uint64_t> logged;
+            if (logged.insert(code_addr).second)
+                fprintf(stderr, "[agc] %s 0x%llx user_data_range=[%u,%u) -> seeding from USER_DATA_%u\n",
+                        is_ps ? "PS" : "VS", (unsigned long long)code_addr, s, e, range_start);
+        }
+    }
+
     // PROSPER_RESDUMP: raw dump of the user-data struct + SGPR block per base, so the EUD layout
     // (which sharps have offset_dw>=16, and where the EUD pointer sits) can be read empirically.
     bool resdump = getenv("PROSPER_RESDUMP") != nullptr;
@@ -418,8 +465,9 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     if (g_dyntrace_force) resdump = true;   // failure replay: always dump the failing stage's blocks
     if (resdump) {
         const AgcShaderUserData* ud = hdr->user_data;
-        fprintf(stderr, "[resdump] %s code=0x%llx type=%u ud=%p\n", is_ps ? "PS" : "VS",
-                (unsigned long long)code_addr, hdr->type, (const void*)ud);
+        fprintf(stderr, "[resdump] %s code=0x%llx type=%u ud=%p range_start=%u (end=%u)\n",
+                is_ps ? "PS" : "VS", (unsigned long long)code_addr, hdr->type, (const void*)ud,
+                range_start, hdr->specials ? (uint32_t)hdr->specials->user_data_range_end : 0u);
         if (ud) {
             fprintf(stderr, "[resdump]   eud_size_dw=%u srt_size_dw=%u direct_count=%u sharp_counts={%u,%u,%u,%u}\n",
                     ud->eud_size_dw, ud->srt_size_dw, ud->direct_resource_count,
@@ -465,10 +513,10 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     std::vector<DynFetch> dyn_vb;
     std::vector<SrtUse> srt_uses;
     if (is_ps) {
-        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0], sgprs);
+        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
         resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 0, &srt_uses);
     } else {
-        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0], sgprs);
+        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
         // shader's s[8:11]/s[24:25] descriptor pointers to the register file at GS_0+offset).
         dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 8, &srt_uses);
@@ -500,7 +548,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     // (an s_buffer_load/image_sample's SBASE/SRSRC register) is in that shader-SGPR space.
     const uint32_t user_sgpr_base = is_ps ? 0u : 8u;
     for (uint32_t base : bases) {
-        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, base, sgprs);
+        uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, base + range_start, sgprs);
         ShaderResourceTable t = build_shader_resources(*hdr, sgprs, kUserSgprs, user_sgpr_base);
         // Add the const-fold-resolved dynamic vertex buffers, keyed by their SRSRC SGPR so the
         // recompiler's by_sgpr_base() resolves each buffer_load_format. The V#'s data format is patched


### PR DESCRIPTION
## What (refs #273 — item 1, the UI/loading-banner recognizability item)

DOLL's UE4 **Slate/UMG vertex shader** fetches all four vertex attributes (uv, material-uv, position, color) through **one un-patched V#**, carrying each attribute's byte offset within the 40-byte `FSlateVertex` record in the **MUBUF SOFFSET register** (computed from attr-spec words its fetch-shader s_loads). `resolve_dynamic_fetch` ignored SOFFSET, so all four attributes resolved to the record start: **position read texcoord data**, color read texcoords, etc. Every Slate widget rendered as a mis-placed flat rectangle — the 'solid banner bar with no text'.

The recompiler's per-fetch (`by_fetch_pc`) address model is `gl_VertexIndex*stride` from the resolved base and **assumes the attribute's in-record offset is already folded into the base** (true for Unity-style fetch shaders, which patch each attribute's V# base). This PR folds the walk's **known** SOFFSET value + the 12-bit instruction offset into the emitted descriptor base, making that assumption hold for the SOFFSET-carrying style too. Faithful to hardware addressing (`base + index*stride + soffset + offset`); fetches with SOFFSET=0 (The Messenger, Unity titles) are byte-identical.

**Verified live:** the four Slate attribute fetches now resolve to base+24 (position), +0 (uv), +16 (material-uv), +32 (color) — the exact FSlateVertex layout — and the position stream decodes real screen coordinates ((0,0)/(3840,0)/(0,2160) for the fullscreen widget). The Slate-widget VS **no longer appears in the recompile-skip log** (was 27–33 'vs=0 fs=6401' skips/run; 0 in the final run).

Also:
- honor the shader specials' `user_data_range_start` when seeding user-data SGPRs (latent: every shader observed live declares 0; sanity-guarded)
- diagnostics used for the investigation, kept for reuse: `PROSPER_DYNTRACE_ADDR`/`PROSPER_RESDUMP_ADDR` filters, `PROSPER_DYNTRACE_FAIL` failed-VS replay, `[drawpkt]` draw-vs-bind association log, `[shdirect]`/full-pair `[regindir]` dumps, `PROSPER_DUMP_RTGROUPS` per-target BMP dump

## Honest frame A/B

- **Before:** loading banner = flat solid red bar + blue rectangle (UV data rasterized as positions), zero texture content, no text.
- **After:** banner geometry is real and the widget samples its **real material textures** — the banner region now shows dense texture content and structure instead of flat fills. **It is NOT yet recognizable and no text is readable**: the sampled content renders as vertical-striped noise (a texture pixel-decode / RT-injection mismatch on the banner content path — the next wall, filed separately), and one half of the widget quad still shades flat.

So: this lands the vertex-fetch half of the banner correctly and removes the UI-VS recompile rejections; the recognizable-banner milestone now gates on the banner content pixel path.

## Verification

- ctest **68/68** green
- **Messenger snapshot check: OK** (richest frame 24,318 colors ≥ 5000) — bindless text path unregressed
- Messenger boot: 2,240+ frames, 0 faults
- DOLL 7-min runs: Slate-widget skips 27–33 → 0; remaining vs=0 skips (0–4/run) are a distinct stale-bind class (first draws of a submit carrying the previous pipeline's user data — separate issue)

refs #273 (closes the item-1 'UI banner-text VS seeding' investigation: root cause was NOT user-SGPR base seeding — base-8/GS_0 is correct and confirmed — but the missing SOFFSET fold, plus a separate stale-bind class)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>