### PR TITLE
diag(ue4): DOLL loading-progression verdict (STALLED at front-end patch/entitlement gate) + reusable progress diagnostics (refs #306)

### DIFF
--- a/prosper/docs/DOLL_LOADING_PROGRESSION.md
+++ b/prosper/docs/DOLL_LOADING_PROGRESSION.md
@@ -1,0 +1,251 @@
+# DOLL (PPSA17942, "Dragon Quest VII Reimagined") — why it never leaves the loading screen
+
+**Verdict: STALLED — a correctness wall, not llvmpipe slowness.** The game reaches a fully-alive,
+60 fps engine steady state within ~6 seconds of boot (all asset IO complete), renders its
+`DOLLLoadingScreen` UMG widget forever, and never advances its boot flow. Wall-clock speed is not
+a factor: with the renderer OFF the guest experiences a full 60 fps for 7+ minutes of game time
+(25,000+ flips) and still never progresses, performs **zero** file IO after second 6, and never
+enqueues a level-load task. Something in its boot-flow state machine never transitions.
+CONFIDENCE: HIGH on the verdict. The missing piece is narrowed (by the runs below, incl. a direct
+NetCtl-callback-delivery experiment that came back NEGATIVE) to the front-end boot flow's
+**"content/patch/entitlement ready" gate** — the online / GameUpdate / EntitlementAccess init
+chain returns success-with-garbage-out instead of an honest offline failure, so the flow can't
+take its offline path to the title. CONFIDENCE MED on the exact subsystem, pending a trace of the
+flow target eboot+0x124beb0.
+
+Diagnosed 2026-07-10 on `diag/doll-loading-progression` (= master e116cd4) with the new
+`PROSPER_PROGRESS` heartbeat + `PROSPER_PROGRESS_UNIMPL` call-count dump (this branch). All runs:
+WSL2 ext4 fast path (`/root/PPSA17942-app0`), `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1`.
+Tracked as **issue #306** (`bug`, `area:ue4`).
+
+## 1. The steady state, measured (run 1: no renderer, 420 s)
+
+`[progress]` heartbeat every 5 s (submits / draws / dispatches / flips are cumulative):
+
+| t | submits | draws_cum | dispatches | flips |
+|------|---------|-----------|------------|-------|
+| 60s | 4,054 | 334,258 | 100,801 | 3,565 |
+| 180s | 12,319 | 1,059,829 | 315,961 | 10,737 |
+| 300s | 20,587 | 1,787,135 | 531,212 | 17,912 |
+| 415s | 28,531 | 2,485,159 | 737,822 | 24,799 |
+
+- **Perfectly linear**: ~59.8 flips/s (vsync-paced 60 fps), ~69 submits/s, ~100 draws +
+  ~1,500 compute dispatches per frame, for the entire run. The engine is not degrading, not
+  loading, not leaking — it is parked in a steady frame loop rendering the same UI.
+- **All IO happens in the first 6 seconds**: 781 file opens, 5,430 APR reads — 100% in minute 0,
+  zero in minutes 1–6 (bucketed FILELOG). The last file activity (t=6 s) is the game
+  **enumerating `movies/cutscene/` and `movies/ui/`** and opening the four
+  `fms_ui_systemsettingcamera0*.usm` — it never opens `sms_opening_*.usm` (the opening movie).
+- draws_last oscillates 100↔12–27: the loading widget is animating (the screen is live, not
+  frozen).
+
+## 2. Every thread is parked (run 4: gdb all-thread dump at t=180 s)
+
+`tools/dbg/thr232.py` dump, 80+ threads, all healthy and ALL idle:
+
+- GameThread (main): sleeping in the per-frame throttle (`clock_nanosleep`, no guest frames on
+  the sampled stack) — ticking, not blocked.
+- FAsyncLoadingThread: parked on its zenaphore — **async loading fully drained** (same as the
+  session-4/5 finding in `UE4_APR_IOSTORE_BRINGUP.md`).
+- IoDispatcher / IoService / 20+ TaskGraph + pool threads: parked in eq/cond waits.
+- Game-side workers **DollLevelPreloader / SaveLoadUpdate / DLCDataUpdate / ShareUpdate**: parked
+  in the generic pool-worker wait — named workers that were never given work.
+- **The whole CRI middleware stack is up and idle**: CRI Server Manager, CRI FS File Access ×2,
+  CRI FS Data Dec, CRI FS Memory F, CRI Audio Output, 12× CRI MPV Worker, CriManaDecodeTh —
+  all in CRI's own sleep loops. FMediaTicker (UE media framework) idle.
+- RenderThread / RHIThread / AgcSubmission / AgcInterrupt / AgcCleanup: normal frame-loop waits.
+- OnlineAsyncTask + HttpManagerThread: parked (OnlineAsyncTaskManager has no completing work).
+
+Nothing is deadlocked in a wait-primitive sense; the game's *flow state machine* simply never
+transitions. This is scene non-activation at the game-flow level, exactly the shape of the
+(pre-drawbuilder) #232 wall, now one screen further along.
+
+## 3. What the game polls every frame (the smoking gun)
+
+`PROSPER_PROGRESS_UNIMPL` (periodic `dump_call_log`) at t=241 s of run 2 — per-call counts of
+UNIMPLEMENTED NIDs (deduped first-seen logging hides these; the counts do not lie):
+
+| calls | NID | name (PS5 3.20 libs) | note |
+|-------|-----|----------------------|------|
+| 14,191 | libSceNetCtl `iQw3iQPhvUQ` | **sceNetCtlCheckCallback** | exactly once per frame |
+| 14,191 | libSceErrorDialog `WWiGuh9XfgQ` | **sceErrorDialogUpdateStatus** | exactly once per frame |
+| 227,380 | libSceAgc `bbFueFP+J4k` | sceAgcDcbSetPredication | per-draw, render-side |
+| 113,690 | libSceAgc `xSAR0LTcRKM` | sceAgcDcbJump | per-draw, render-side |
+| 113,690 | libSceAgc `w6Dj1VJt5qY` | sceAgcSetPacketPredication | per-draw, render-side |
+| 1,079 | libkernel `rqwFKI4PAiM` | sceKernelAprWaitCommandBuffer | load-phase only |
+| 951 | libkernel `6xVpy0Fdq+I` | _sigprocmask | |
+| 50 | libScePosix `Xs9hdiD7sAA` | pthread_setschedparam | |
+| 3 | libSceNpEntitlementAccess `jO8DM8oyego` | sceNpEntitlementAccessInitialize | **retried 3×** |
+| 1 each | see §5 | one-shot init calls | |
+
+The game **pumps `sceNetCtlCheckCallback` every frame, forever** (from the SystemEventGatherer
+thread, run 6). This looked like a network-state spin, so it was tested directly
+(`PROSPER_NETCTL_CB` experiment, runs 7 + 9): deliver the registered callback with
+`DISCONNECTED` on first CheckCallback, plus `sceNetCtlGetState → DISCONNECTED`.
+
+**Result: the callback delivers cleanly (correct guest-%fs handling, no crash) and the game
+consumes it — `sceNetCtlGetState` is then called EXACTLY ONCE and never again — but the flow
+still does not advance** (no new IO, no pad-open change, no new NIDs, identical steady state).
+So the per-frame CheckCallback pump is the **generic PS callback pump** (it re-pumps every
+registered callback each frame), NOT a spin on network state, and NetCtl delivery — while correct
+infrastructure the game needed — is **not the gate by itself**. This is the key negative result
+of the investigation: it rules out the most obvious per-frame signal and points the gate deeper
+into the online/update/entitlement flow (below).
+
+The surrounding one-shot init calls draw the picture of a boot flow stuck at its
+**network/update/entitlement check step**:
+
+- `sceGameUpdateInitialize` fired once — but `sceGameUpdateCreateRequest`/`sceGameUpdateCheck`
+  (the calls that would actually perform the update check; full surface in
+  `../PS5-3.20_Libs/libSceGameUpdate.c`) were **never called**. The update check started
+  initializing and then waited on a precondition that never arrived.
+- The eboot contains UE4's PatchCheck/InstallBundleManager subsystem
+  (`EInstallBundleManagerPatchCheckResult::*`, "Could not download patch data. Please check your
+  internet connection, and try again.") — the standard console boot-flow gate that DQ7R runs
+  before the title screen.
+- `sceNpRegisterStateCallbackA` (once): the Np sign-in state callback is registered and likewise
+  never delivered (our `sceNpCheckCallback` is a return-0 no-op).
+- `sceNpGetOnlineId` (once): unimplemented → returned **0 = success with a garbage out-struct**
+  (the recurring success+garbage-out class) — a signed-OUT console must return the signed-out
+  error here; "success" tells the game a user is signed in and can push the flow into online
+  branches that then wait on Http/WebApi machinery that goes nowhere.
+- `sceHttpInit`/`sceHttpCreateTemplate`/`sceHttp2Init`/`sceSslInit`/`sceNpWebApi2Initialize`/
+  `sceNpCppWebApi ×4`/`sceNetResolverCreate`/`sceNetPoolCreate`: each once, all returning
+  0-with-garbage — the whole online transport is a house of cards of fake handles.
+- `sceNpEntitlementAccessInitialize` tried **3 times** (the only retried one-shot) — something
+  keeps re-initializing entitlement access because the follow-up never works (DLC check; the
+  parked DLCDataUpdate worker is its consumer).
+
+`sceErrorDialogUpdateStatus` pumping per-frame is the standard per-frame dialog pump
+(no `sceErrorDialogOpen`-class NID ever fires, so no dialog was actually opened — it is
+housekeeping, not a stuck modal).
+
+## 4. Ruled out by A/B or measurement
+
+- **llvmpipe / render throughput (the "SLOW" hypothesis)**: with `PROSPER_RENDER=1` the guest is
+  throttled hard by synchronous llvmpipe (see §7 numbers) — but with the renderer OFF the game
+  runs a true 60 fps and *still* never progresses. Progression is not wall-clock-, IO- or
+  GPU-bound. A faster GPU changes nothing about this wall.
+- **Asset streaming**: all reads complete in 6 s on ext4; nothing is ever read again. Not
+  IO-bound, not Oodle (containers are uncompressed), not a stuck async read (FAsyncLoadingThread
+  drained; the #115/#208 completion machinery works — 5,430 APR reads served cleanly).
+- **Movies**: `PROSPER_DENY_SUBSTR=.usm` (every movie ENOENT, run 2) changes nothing — same
+  steady state, same per-frame pumps. The stall is upstream of movie playback (the opening movie
+  is never even opened; only the 4 settings-screen UI movies get existence-probed at t=4 s).
+- **Input** (corrected mid-investigation, then A/B tested): the game DOES open and poll the pad —
+  `scePadOpen` at t=0 and `scePadReadState` at ~220 calls/s (visible only under `PROSPER_PADLOG`;
+  the pad HLE is implemented, so its absence from the unimplemented log proves nothing). The
+  neutral backend reports connected=0, so a "reconnect controller / press any button" gate was a
+  live suspect. **Run 8a (`PROSPER_PAD_PRESS=1` — connected=1, CROSS held all run) does NOT
+  advance the flow** (56,000+ pad reads with buttons=0x4000, zero IO after t=6 s). Not an
+  input/controller gate.
+- **NetCtl network state** (runs 7 + 9, `PROSPER_NETCTL_CB=1`): delivering the DISCONNECTED
+  callback + GetState does NOT advance the flow either (§3). The most obvious per-frame signal is
+  ruled out.
+- **PlayGo / SaveData / Trophy2 / Share**: implemented with real contracts in the session-5 work
+  (`hle_service.cpp`); the save-data flow completes end-to-end (files written). Not the gate.
+- **GPU fence/EOP delivery**: 28,500 submits complete, flips fire, no FRenderCommandFence
+  timeout, no watchdog abort — the #232/#236/#278 fixes hold.
+
+## 5. One-shot unimplemented calls (complete list, run 1)
+
+libSceAgc: dbOlWdppb4o (50×), qj7QZpgr9Uw (20×) [driver-info-class, unnamed];
+libSceAjm: sceAjmInitialize, sceAjmModuleRegister; libSceAmpr: 4fgtGfXDrFc;
+libSceCoredump: sceCoredumpRegisterCoredumpHandler; libSceGameUpdate: sceGameUpdateInitialize;
+libSceHttp: sceHttpInit, sceHttpCreateTemplate; libSceHttp2: sceHttp2Init;
+libSceJson2: 6 NIDs (parser objects for the online config);
+libSceNet: sceNetPoolCreate (3×), sceNetResolverCreate;
+libSceNetCtl: sceNetCtlRegisterCallback, sceNetCtlGetInfo, sceNetCtlCheckCallback (per-frame);
+libSceNpCppWebApi: 4 NIDs; libSceNpEntitlementAccess: sceNpEntitlementAccessInitialize (3×);
+libSceNpGameIntent: sceNpGameIntentInitialize; libSceNpManager: sceNpRegisterStateCallbackA,
+sceNpGetOnlineId; libSceNpWebApi2: sceNpWebApi2Initialize, sceNpWebApi2PushEventCreateHandle;
+libSceSsl: sceSslInit (2×); libSceVideodec2: sceVideodec2QueryComputeMemoryInfo (2×);
+libSceVoiceQoS: sceVoiceQoSInit;
+libkernel: sceKernelAio{InitializeImpl,InitializeParam,SubmitReadCommands,WaitRequest,
+DeleteRequest} (the CRI FS IO path — will matter the moment a movie actually plays),
+sceKernelAddAmprEvent, sceKernelAprWaitCommandBuffer (1,079×), _sigprocmask (951×);
+libScePosix: pthread_setschedparam (50×).
+
+## 6. Who makes the per-frame calls (runs 5/6: gdb probes)
+
+- The per-frame tick object (`this` of eboot+0x5044740, vtable eboot+0x8a46708, `*0x288` target =
+  **eboot+0x124beb0**) is completely static across frames — no RTTI typename resolvable; the flow
+  state lives deeper (flow5.py).
+- Caller-chain histogram of all unimplemented calls at steady state (flow6.py, breakpoint on
+  `prosper_on_unimpl`, 40 hits):
+  - The dominant chains are the **libSceAgc trio** (SetPredication ×2 / SetPacketPredication /
+    DcbJump — import idx 1624/1592/1498) from four consecutive call sites in one guest function
+    (eboot+0x2212144/57/64/6c ← eboot+0x2219bd6|0x2219d36 ← 0x2c61ae6 ← 0x2c841ea ← 0x2c8401a ←
+    thread-runner) — the **RHIThread's command-list translate loop**. These are render-side
+    (ignored predication/jump packets — a rendering-correctness item, not a progression gate).
+  - `sceNetCtlCheckCallback` is pumped from **eboot+0x27ebb05 — the SystemEventGatherer thread's
+    gather loop** (run-4 dump shows that thread's wait at eboot+0x27eba63). The delivered
+    callback would fire on that thread and post state the GameThread flow consumes.
+  - `sceErrorDialogUpdateStatus` is called from a non-eboot module (no eboot RAs on its stack).
+
+## 7. Render-path throughput (run 3: PROSPER_RENDER=1, llvmpipe)
+
+For completeness (the game is STALLED, so throughput never lets it "finish" — but it quantifies
+the render cost for when the wall falls). `execute_and_present` is **synchronous on the guest
+submit thread**, so each presented frame blocks the whole guest:
+
+| t | flips | presents | submits |
+|------|-------|----------|---------|
+| 69 s | 34 | 33 | 39 |
+| 88 s | 38 | 38 | 44 |
+
+- **~0.43 flips/s with the renderer on** vs **~59.8/s off** — a ~140× slowdown; each llvmpipe
+  present (reduced-res draw list) costs ~2 s and stalls the guest for its duration. This is the
+  documented synchronous-llvmpipe cost, not a new bug. It confirms a real-GPU Vulkan path (vs
+  llvmpipe) is the unlock for *watchable* frame rate — but it is orthogonal to the progression
+  wall (§1: the game does not progress even at a free-running 60 fps with the renderer off).
+- The renderer presents DOLL's real backbuffer compose (the loading screen) every frame; 42 BMPs
+  captured to `/root/doll_r3_frames/` (never committed).
+
+## 8. The highest-leverage next step
+
+**Two parallel tracks. NetCtl delivery is DONE-and-insufficient (proven), so the lead is the
+online/update/entitlement honesty pass + a flow-target trace.**
+
+Tested and insufficient (kept as gated experiment `PROSPER_NETCTL_CB=1`, `hle_service.cpp`):
+NetCtl callback delivery (`sceNetCtlRegisterCallback`/`CheckCallback`/`GetState` as an offline
+console). It delivers cleanly and is consumed, but does not move the wall — see §3. Land it as
+correct infra, but it is not the gate.
+
+Lead A — **make the whole online/update/entitlement init chain honest** (one focused
+`area:ue4` PR, shared-infra files):
+1. `sceNpGetOnlineId` → signed-out error (PS4: 0x80550006 SCE_NP_ERROR_SIGNED_OUT; verify PS5
+   value) instead of success+garbage; `sceNpRegisterStateCallbackA`/`sceNpCheckCallback` →
+   deliver SIGNED_OUT once (same guest-%fs callback discipline the NetCtl experiment proves
+   works).
+2. `sceNpEntitlementAccessInitialize` (retried 3× — a real "keeps failing" signal) and
+   `sceGameUpdateInitialize`/`CreateRequest`/`Check`: return honest FAILURE or a valid
+   "no patch required / no entitlement, offline" result per their real ABI, so UE4's
+   `InstallBundleManager` PatchCheck resolves to `NoPatchRequired`/`NoLoggedInUser` and the flow
+   takes its offline path rather than waiting on fake Http/WebApi handles.
+3. If dismissing produces the "Could not download patch data..." dialog, give `sceErrorDialog`
+   (or CommonDialog) the minimal Initialize/Open→Status FINISHED lifecycle so it can be
+   dismissed, then drive the confirm with `PROSPER_PAD_SCRIPT` (#202).
+
+Lead B — **trace the flow gate directly** (no guessing): the front-end tick calls through
+`vtable*0x288 = eboot+0x124beb0` (run 5). Break there / disassemble it and the predicate it
+returns to; it decides "advance to title / begin level load." Whatever boolean or async result it
+polls names the exact subsystem — feed Lead A from it. `tools/dbg/flow5.py` + `flow6.py` are the
+starting probes.
+
+Verification for either: re-run run 1's heartbeat — the wall has fallen when IO resumes after
+t=6 s (front-end map load), the pad-open path changes, or `sms_opening_en.usm` finally opens.
+The next surfaces are already visible (§5: Videodec2 + sceKernelAio for the opening movie, then
+pad → title menu → `PROSPER_PAD_SCRIPT` press Start → first level).
+
+## Appendix: how to reproduce
+
+```
+# heartbeat + call-count boot (no renderer, full speed):
+timeout 420 env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+  PROSPER_PROGRESS=5 PROSPER_PROGRESS_UNIMPL=1 \
+  ./build-linux/boot_trace /root/PPSA17942-app0 > /root/doll.log 2>&1
+# scripts: scripts/diag/run{1..5}*.sh on diag/doll-loading-progression
+# thread dump: gdb -p <pid> -batch -x tools/dbg/thr232.py
+# flow probe:  gdb -p <pid> -batch -x tools/dbg/flow5.py
+```

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <mutex>
 #include <atomic>
+#include <chrono>
 
 namespace prosper {
 
@@ -694,6 +695,42 @@ std::mutex g_agc_state_mu;
 // via sceGnmAddEqEvent. Our fold is synchronous, so a completed SubmitDcb == the GPU pipe having drained.
 void prosper_eq_trigger_eop();
 
+// Total flips so far (hle_graphics.cpp) — part of the PROSPER_PROGRESS heartbeat below.
+extern "C" uint64_t prosper_vo_flip_count();
+
+namespace {
+// PROSPER_PROGRESS=<secs>: emit a one-line timestamped forward-progress heartbeat at most every
+// <secs> seconds, from the GPU submit path (both entry points). Purpose: long diagnostic runs need
+// a cheap progression signal (is the frame loop advancing? are draws/dispatches still growing?)
+// without PROSPER_GFXLOG's per-packet firehose (GBs over a 10-minute run). Called under
+// g_agc_state_mu. Additive, default-off. CONFIDENCE: HIGH (diagnostic only, no behavior change).
+uint64_t g_presents_cum = 0;   // frames handed to the present path (bumped at each render call site)
+void progress_heartbeat(size_t draws_last, uint64_t submits, uint64_t dispatches) {
+    static const long interval = [] {
+        const char* e = getenv("PROSPER_PROGRESS"); return e ? atol(e) : 0; }();
+    if (interval <= 0) return;
+    static uint64_t draws_cum = 0;
+    draws_cum += draws_last;
+    static const std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
+    static std::chrono::steady_clock::time_point next = t0;
+    auto now = std::chrono::steady_clock::now();
+    if (now < next) return;
+    next = now + std::chrono::seconds(interval);
+    double t = std::chrono::duration<double>(now - t0).count();
+    fprintf(stderr, "[progress] t=%.1fs submits=%llu draws_last=%zu draws_cum=%llu dispatches=%llu flips=%llu presents=%llu\n",
+            t, (unsigned long long)submits, draws_last, (unsigned long long)draws_cum,
+            (unsigned long long)dispatches, (unsigned long long)prosper_vo_flip_count(),
+            (unsigned long long)g_presents_cum);
+    // PROSPER_PROGRESS_UNIMPL=1: with the heartbeat on, also dump the unimplemented-NID call-count
+    // table every ~12 heartbeats. Purpose: the first-seen unimpl log is deduped, so a guest POLLING
+    // an unimplemented call (the classic "waits on a wrong stub answer" stall) is invisible without
+    // the per-call counts — and a `timeout`-killed diagnostic run never reaches the exit dump.
+    static const bool dump_unimpl = getenv("PROSPER_PROGRESS_UNIMPL") != nullptr;
+    static unsigned hb = 0;
+    if (dump_unimpl && (hb++ % 12) == 0) dump_call_log(stderr);
+}
+}
+
 extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws) {
     std::lock_guard<std::mutex> lk(g_agc_state_mu);
     if (submits) *submits = g_submit_count;
@@ -722,12 +759,14 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
         static const uint32_t scale = [] {
             const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
         if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
-        gpu::execute_and_present(agc_gpu_state(), w, h);
+        if (gpu::execute_and_present(agc_gpu_state(), w, h)) g_presents_cum++;
     }
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc] %s #%llu: %u dwords (walk=%u) -> %zu packets applied (draws: %zu, dispatches: %llu)\n",
                 who, (unsigned long long)g_submit_count, dw_num, walk, applied,
                 agc_gpu_state().draws.size(), (unsigned long long)agc_gpu_state().dispatch_count);
+    progress_heartbeat(agc_gpu_state().draws.size(), g_submit_count,
+                       (uint64_t)agc_gpu_state().dispatch_count);
     return 0;
 }
 
@@ -838,6 +877,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
             const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
         if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
         bool presented = gpu::execute_and_present(agc_gpu_state(), w, h);
+        if (presented) g_presents_cum++;
         if (presented && getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc] SubmitDcb #%llu: executed %zu draws -> presented %ux%u frame\n",
                     (unsigned long long)g_submit_count, agc_gpu_state().draws.size(), w, h);
@@ -859,6 +899,8 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
                     c.len > 1 ? c.payload[0] : 0, c.len > 2 ? c.payload[1] : 0, c.len > 3 ? c.payload[2] : 0);
         }
     }
+    progress_heartbeat(agc_gpu_state().draws.size(), g_submit_count,
+                       (uint64_t)agc_gpu_state().dispatch_count);
     return 0;
 }
 

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -191,6 +191,9 @@ namespace {
 }
 
 // Exposed for the back-half present path + tests: the registered display surface.
+// prosper_vo_flip_count: total flips so far (either flip path) — read by the PROSPER_PROGRESS
+// heartbeat in hle_agc.cpp as a cheap forward-progress signal for long diagnostic runs.
+extern "C" uint64_t prosper_vo_flip_count() { std::lock_guard<std::mutex> lk(g_flip_mx); return g_flip_count; }
 extern "C" int      prosper_vo_buffer_count()   { return g_display.buffer_num; }
 extern "C" uint32_t prosper_vo_display_width()  { return g_display.width; }
 extern "C" uint32_t prosper_vo_display_height() { return g_display.height; }

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -380,8 +380,93 @@ HLE(s_npuds_create) { svc_log("sceNpUniversalDataSystemCreate*", a0,a1,a2,a3,a4,
                       if (svc_ptrish(a0)) *(int32_t*)PW(a0) = 1; return 0; }
 HLE(s_npuds_ok)     { return 0; }
 
+// --- libSceNetCtl state-callback delivery — GATED EXPERIMENT (PROSPER_NETCTL_CB=1) --------------
+// Diagnostic for the DOLL loading-screen stall (docs/DOLL_LOADING_PROGRESSION.md): DOLL registers
+// a NetCtl state callback once at boot (sceNetCtlRegisterCallback) and then pumps
+// sceNetCtlCheckCallback EXACTLY once per frame forever (14,191 calls in a 240 s run — the
+// per-frame call-count signature). On real hardware CheckCallback invokes the registered callback
+// on the calling thread with the current state — an offline console still delivers an immediate
+// DISCONNECTED — and the boot flow proceeds down its offline path. Our unimplemented stubs never
+// deliver ANY state, so the game can never finish its network/update check step.
+//
+// This experiment implements the minimal real contract: Register records {func,arg} and writes the
+// callback id; CheckCallback invokes the callback ONCE with SCE_NET_CTL_EVENT_TYPE_DISCONNECTED
+// (PS4-inherited constant = 1; identical export names on PS5 3.20 — CONFIDENCE MED on the PS5
+// value). The callback is guest code: under PROSPER_GUEST_FS the HLE runs on the HOST %fs (the
+// import swap-stub switched), so the guest callback must run with the GUEST %fs restored or its
+// TLS accesses (UE MallocBinned caches!) read host TLS garbage. The swap-stub saves the guest fs
+// base in its frame (push r11), so an asm entry shim (the f_apr_read_submit_entry pattern) hands
+// the handler its entry %rsp: [rsp]=ret-to-stub, [+8/+0x10]=re-pushed args7/8, [+0x18]=guest fs,
+// [+0x20]=guest RA. A [rsp] outside the stub region [0x6_0000_0000,0x7_0000_0000) means the
+// host-context tail-jmp path (no swap happened) — call the callback on the current fs.
+// Registration is gated on the env var so the default boot is bit-identical. CONFIDENCE: HIGH on
+// the mechanism, MED on the event constant.
+#ifndef _WIN32
+namespace {
+std::atomic<uint64_t> g_netctl_cb_fn{0};
+std::atomic<uint64_t> g_netctl_cb_arg{0};
+std::atomic<int>      g_netctl_cb_delivered{0};
+inline uint64_t netctl_rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
+inline void     netctl_wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
+}
+HLE(s_netctl_register_cb) {   // (func, arg, int* cid)
+    svc_log("sceNetCtlRegisterCallback", a0,a1,a2,a3,a4,a5);
+    g_netctl_cb_fn.store(a0);
+    g_netctl_cb_arg.store(a1);
+    if (svc_ptrish(a2)) *(int32_t*)PW(a2) = 1;   // callback id (Kyty Network.cpp NetCtlRegisterCallback)
+    return 0;
+}
+// sceNetCtlGetState(int* state): 0 = DISCONNECTED (Kyty Network.cpp:1398 writes exactly this).
+// Run-7 live capture: the game calls this for the FIRST time immediately after the DISCONNECTED
+// callback delivery — the unimplemented success+garbage-out answer is what re-wedged the flow.
+HLE(s_netctl_getstate) {
+    svc_log("sceNetCtlGetState", a0,a1,a2,a3,a4,a5);
+    if (svc_ptrish(a0)) *(int32_t*)PW(a0) = 0;   // SCE_NET_CTL_STATE_DISCONNECTED
+    return 0;
+}
+extern "C" uint64_t s_netctl_check_cb_c(uint64_t a0, uint64_t a1, uint64_t a2,
+                                        uint64_t a3, uint64_t a4, uint64_t a5,
+                                        uint64_t entry_rsp);
+asm(".text\n"
+    ".globl s_netctl_check_cb_entry\n"
+    ".type s_netctl_check_cb_entry,@function\n"
+    "s_netctl_check_cb_entry:\n"
+    "  movq %rsp, %rax\n"
+    "  pushq %rax\n"
+    "  call s_netctl_check_cb_c\n"
+    "  addq $8, %rsp\n"
+    "  ret\n");
+extern "C" void s_netctl_check_cb_entry();
+extern "C" uint64_t s_netctl_check_cb_c(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                                        uint64_t entry_rsp) {
+    uint64_t fn = g_netctl_cb_fn.load();
+    if (!fn || g_netctl_cb_delivered.exchange(1)) return 0;   // deliver the initial state exactly once
+    uint64_t shim_ret = entry_rsp ? *(uint64_t*)entry_rsp : 0;
+    uint64_t guest_fs = 0;
+    if (shim_ret >= 0x600000000ull && shim_ret < 0x700000000ull)
+        guest_fs = *(uint64_t*)(entry_rsp + 0x18);            // the swap-stub's saved r11
+    uint64_t host_fs = 0;
+    if (guest_fs) { host_fs = netctl_rd_fsbase(); netctl_wr_fsbase(guest_fs); }
+    ((void (*)(int, void*))(uintptr_t)fn)(1 /*SCE_NET_CTL_EVENT_TYPE_DISCONNECTED*/,
+                                          (void*)(uintptr_t)g_netctl_cb_arg.load());
+    if (guest_fs) netctl_wr_fsbase(host_fs);
+    fprintf(stderr, "[svc] NetCtl state callback DELIVERED (eventType=DISCONNECTED, guest_fs=%d)\n",
+            guest_fs ? 1 : 0);
+    return 0;
+}
+#endif
+
 void register_service_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
+#ifndef _WIN32
+    // NetCtl state delivery experiment (see block comment above). Default OFF: without the env the
+    // NIDs stay unimplemented (their current behavior).
+    if (getenv("PROSPER_NETCTL_CB")) {
+        R("sceNetCtlRegisterCallback", s_netctl_register_cb);      // UJ+Z7Q+4ck0
+        R("sceNetCtlCheckCallback",    s_netctl_check_cb_entry);   // iQw3iQPhvUQ
+        R("sceNetCtlGetState",         s_netctl_getstate);         // uBPlr0lbuiI
+    }
+#endif
     // NpTrophy2: the config/info queries whose success-with-garbage-out crashed DOLL (see above).
     Hle::register_fn("4IzqhhUQ3nk", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetGameInfo");
     Hle::register_fn("y3zHpdZO6ME", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetTrophyInfoArray");

--- a/prosper/tools/dbg/flow5.py
+++ b/prosper/tools/dbg/flow5.py
@@ -1,0 +1,112 @@
+# gdb -p PID -batch -x flow5.py — DOLL loading-progression diagnosis (diag/doll-loading-progression):
+# the game ticks its per-frame state fn eboot+0x5044740 (`this` + vtable call *0x288) forever on the
+# loading screen. Identify the ticked object (RTTI typename), the *0x288 target, diff the object's
+# fields across ~300 frames (what changes vs what is parked), and histogram the GameThread's RIP/RA
+# between frames to find the poll site.
+import gdb, time
+from collections import Counter
+
+EBOOT = 0x400000000
+ENTRY = EBOOT + 0x5044740
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n):
+    try:
+        return bytes(inf.read_memory(addr, n))
+    except gdb.error:
+        return None
+
+def q(addr):
+    b = rd(addr, 8)
+    return int.from_bytes(b, "little") if b else None
+
+def sym(v):
+    if v is None: return "??"
+    if EBOOT <= v < EBOOT + 0x6700000: return "eboot+0x%x" % (v - EBOOT)
+    if 0x500000000 <= v < 0x600000000: return "prx+0x%x" % (v - 0x500000000)
+    if 0x600000000 <= v < 0x700000000: return "stub+0x%x" % (v - 0x600000000)
+    return hex(v)
+
+def typename(vt):
+    if not vt: return "?"
+    ti = q(vt - 8)
+    if not ti: return "?"
+    nm = q(ti + 8)
+    if not nm: return "?"
+    s = rd(nm, 160)
+    if not s: return "?"
+    return s.split(b"\0")[0].decode("latin1", "replace")
+
+def snap(obj, nwords):
+    out = []
+    for i in range(nwords):
+        out.append(q(obj + i * 8))
+    return out
+
+bp = gdb.Breakpoint("*0x%x" % ENTRY)
+gdb.execute("continue")
+rdi = int(gdb.parse_and_eval("$rdi")) & 0xffffffffffffffff
+vt = q(rdi)
+print("tick this=0x%x vtable=%s type=%s" % (rdi, sym(vt), typename(vt)))
+if vt:
+    tgt = q(vt + 0x288)
+    print("vtable*0x288 target = %s" % sym(tgt))
+snap1 = snap(rdi, 0x30)
+
+# let ~300 frames pass with the bp disabled
+bp.enabled = False
+gdb.execute("continue &")
+time.sleep(5.0)
+gdb.execute("interrupt")
+time.sleep(0.5)
+snap2 = snap(rdi, 0x30)
+print("--- object field diff over ~5s (offset: then -> now) ---")
+for i in range(0x30):
+    a, b = snap1[i], snap2[i]
+    tag = "SAME " if a == b else "CHANG"
+    print("  +0x%03x %s %-18s -> %-18s %s" % (i * 8, tag,
+          hex(a) if a is not None else "??", hex(b) if b is not None else "??",
+          ("(" + typename(a) + ")") if (tag == "SAME " and a and EBOOT < a < EBOOT + 0x9000000 and (a % 8 == 0)) else ""))
+
+# GameThread RIP/RA histogram: 80 quick samples
+print("--- GameThread sample histogram (80 samples) ---")
+hist = Counter()
+rahist = Counter()
+t1 = None
+for t in inf.threads():
+    if t.ptid[1] == inf.pid:  # main thread lwp == pid
+        t1 = t
+        break
+if t1 is None:
+    t1 = inf.threads()[-1]
+for i in range(80):
+    gdb.execute("continue &")
+    time.sleep(0.04)
+    gdb.execute("interrupt")
+    time.sleep(0.02)
+    try:
+        t1.switch()
+        pc = int(gdb.parse_and_eval("$pc")) & 0xffffffffffffffff
+        sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+        hist[sym(pc)] += 1
+        mem = rd(sp, 0x300)
+        if mem:
+            ras = []
+            for off in range(0, len(mem) - 7, 8):
+                v = int.from_bytes(mem[off:off+8], "little")
+                if EBOOT <= v < EBOOT + 0x6700000:
+                    ras.append(sym(v))
+                if len(ras) >= 3:
+                    break
+            rahist[",".join(ras)] += 1
+    except gdb.error as e:
+        print("sample err %s" % e)
+for k, v in hist.most_common(12):
+    print("  pc %-24s x%d" % (k, v))
+print("--- top stack-RA triples ---")
+for k, v in rahist.most_common(12):
+    print("  ras [%s] x%d" % (k, v))
+print("FLOW5-DONE")

--- a/prosper/tools/dbg/flow6.py
+++ b/prosper/tools/dbg/flow6.py
@@ -1,0 +1,47 @@
+# gdb -p PID -batch -x flow6.py — DOLL loading-progression: who pumps the per-frame unimplemented
+# calls? Break on the host dispatcher prosper_on_unimpl, capture the import index (rdi) + the guest
+# RA chain off the stack for ~40 hits, and histogram them. The two dominant chains are the
+# per-frame sceNetCtlCheckCallback and sceErrorDialogUpdateStatus pumps — their callers identify
+# the engine/game subsystem that is waiting on network-state delivery.
+import gdb
+from collections import Counter
+
+EBOOT = 0x400000000
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+inf = gdb.selected_inferior()
+
+def rd(addr, n):
+    try:
+        return bytes(inf.read_memory(addr, n))
+    except gdb.error:
+        return None
+
+def sym(v):
+    if EBOOT <= v < EBOOT + 0x6700000: return "eboot+0x%x" % (v - EBOOT)
+    if 0x600000000 <= v < 0x700000000: return "stub+0x%x" % (v - 0x600000000)
+    return hex(v)
+
+bp = gdb.Breakpoint("prosper_on_unimpl")
+chains = Counter()
+for i in range(40):
+    gdb.execute("continue")
+    try:
+        idx = int(gdb.parse_and_eval("$rdi")) & 0xffffffff
+        sp = int(gdb.parse_and_eval("$sp")) & 0xffffffffffffffff
+        mem = rd(sp, 0x1200)
+        ras = []
+        if mem:
+            for off in range(0, len(mem) - 7, 8):
+                v = int.from_bytes(mem[off:off+8], "little")
+                if EBOOT <= v < EBOOT + 0x6700000:
+                    ras.append(sym(v))
+                if len(ras) >= 8:
+                    break
+        chains["idx=%d [%s]" % (idx, " <- ".join(ras))] += 1
+    except gdb.error as e:
+        print("hit err %s" % e)
+print("--- unimpl-call chains over 40 hits ---")
+for k, v in chains.most_common(20):
+    print("  x%-3d %s" % (v, k))
+print("FLOW6-DONE")

--- a/scripts/diag/build.sh
+++ b/scripts/diag/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Build prosper in this agent worktree (run inside WSL Ubuntu-24.04 as root).
+set -e
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+cd "$WT/prosper"
+if [ ! -f build-linux/CMakeCache.txt ]; then
+  cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0
+fi
+cmake --build build-linux -j16 2>&1 | tail -5
+echo BUILD_OK

--- a/scripts/diag/run1_norender.sh
+++ b/scripts/diag/run1_norender.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# DOLL progression probe, run 1: NO renderer (isolates game-logic progression from llvmpipe cost).
+# Boots for DUR seconds with file/event logging + the PROSPER_PROGRESS heartbeat, samples /proc
+# every 20 s, then prints a bucketed progression analysis. Run inside WSL Ubuntu-24.04 as root.
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+BT="$WT/prosper/build-linux/boot_trace"
+DUMP=/root/PPSA17942-app0
+DUR=${DUR:-420}
+LOG=/root/doll_r1.log
+SAMP=/root/doll_r1.samples
+
+rm -f "$LOG" "$SAMP"
+
+# Boot with wall-clock timestamps on every line.
+( timeout "$DUR" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+      PROSPER_PROGRESS=5 "$BT" "$DUMP" 2>&1 | \
+  gawk '{ if (!t0) t0 = systime(); printf "%4d %s\n", systime()-t0, $0; fflush() }' > "$LOG" ) &
+RUNNER=$!
+
+# Sampler: /proc io + cpu + thread count every 20 s.
+sleep 5
+PID=$(pgrep -f "boot_trace $DUMP" | head -1)
+echo "boot pid: ${PID:-NONE}" >> "$SAMP"
+T0=$(date +%s)
+while kill -0 "${PID:-0}" 2>/dev/null; do
+    NOW=$(( $(date +%s) - T0 ))
+    RB=$(grep read_bytes /proc/$PID/io 2>/dev/null | awk '{print $2}')
+    RC=$(grep rchar /proc/$PID/io 2>/dev/null | head -1 | awk '{print $2}')
+    NT=$(ls /proc/$PID/task 2>/dev/null | wc -l)
+    CPU=$(awk '{print $14+$15}' /proc/$PID/stat 2>/dev/null)
+    echo "t=$NOW rchar=$RC read_bytes=$RB threads=$NT cpu_ticks=$CPU" >> "$SAMP"
+    # top-3 busiest threads by recent utime (name + state)
+    for t in /proc/$PID/task/*/stat; do
+        awk '{printf "%s %s %s %s\n", $1, $2, $3, $14+$15}' "$t" 2>/dev/null
+    done | sort -k4 -rn | head -4 | sed 's/^/    thr /' >> "$SAMP"
+    sleep 20
+done
+wait $RUNNER
+
+echo "=================== ANALYSIS ==================="
+echo "--- log size:"; wc -l "$LOG"
+echo "--- [progress] heartbeat (all lines):"
+grep -a '\[progress\]' "$LOG" | head -100
+echo "--- APR reads per 60s bucket:"
+grep -a 'read-submit\|read-direct' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d reads\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- file opens per 60s bucket:"
+grep -a '\[file\] open' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d opens\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- GpuFlip per 60s bucket:"
+grep -a 'GpuFlip' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d flips\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- last 15 file-layer lines:"
+grep -a '\[file\]\|\[apr\]' "$LOG" | tail -15
+echo "--- last 12 distinct non-flip/non-wait event lines:"
+grep -a '\[ev\]' "$LOG" | grep -av 'GpuFlip\|WaitEqueue\|delivered\|IsFlipPending\|WAIT.empty' | tail -12
+echo "--- unimplemented NIDs called in LAST 120s of run:"
+LAST=$(tail -1 "$LOG" | awk '{print $1}')
+grep -a 'unimplemented\|unimpl' "$LOG" | awk -v c="$LAST" '$1 > c-120' | sed 's/^ *[0-9]* //' | sort | uniq -c | sort -rn | head -20
+echo "--- samples:"
+cat "$SAMP"
+echo "--- log tail:"
+tail -20 "$LOG"
+echo RUN1_DONE

--- a/scripts/diag/run2_denyusm.sh
+++ b/scripts/diag/run2_denyusm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# DOLL progression probe, run 2: NO renderer + PROSPER_DENY_SUBSTR=.usm (movie-denial A/B).
+# If the front-end flow is wedged waiting on CRI movie playback that our missing sceVideodec2
+# can't deliver, denying the .usm files should CHANGE progression (skip-movie path).
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+BT="$WT/prosper/build-linux/boot_trace"
+DUMP=/root/PPSA17942-app0
+DUR=${DUR:-420}
+LOG=/root/doll_r2.log
+rm -f "$LOG"
+
+( timeout "$DUR" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+      PROSPER_PROGRESS=5 PROSPER_PROGRESS_UNIMPL=1 PROSPER_DENY_SUBSTR=.usm "$BT" "$DUMP" 2>&1 | \
+  gawk '{ if (!t0) t0 = systime(); printf "%4d %s\n", systime()-t0, $0; fflush() }' > "$LOG" ) &
+wait
+
+echo "=================== ANALYSIS (deny .usm) ==================="
+wc -l "$LOG"
+echo "--- [progress] heartbeats:"
+grep -a '\[progress\]' "$LOG" | head -100
+echo "--- DENIED lines:"
+grep -a 'DENIED' "$LOG" | head -10
+echo "--- APR reads per 60s bucket:"
+grep -a 'read-submit\|read-direct' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d reads\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- file opens per 60s bucket:"
+grep -a '\[file\] open' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d opens\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- last 15 file-layer lines:"
+grep -a '\[file\]\|\[apr\]' "$LOG" | tail -15
+echo "--- unimplemented (distinct, whole run):"
+grep -a 'unimplemented:' "$LOG" | sed 's/^ *[0-9]* //' | sort | uniq -c | sort -rn | head -25
+echo RUN2_DONE

--- a/scripts/diag/run3_render.sh
+++ b/scripts/diag/run3_render.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# DOLL progression probe, run 3: WITH live renderer (llvmpipe) — quantify presented-frame
+# throughput and whether render throttling changes guest progression. PADLOG shows input polling.
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
+BT=/root/bt_diag
+DUMP=/root/PPSA17942-app0
+DUR=${DUR:-420}
+LOG=/root/doll_r3.log
+SAMP=/root/doll_r3.samples
+rm -f "$LOG" "$SAMP"
+mkdir -p /root/doll_r3_frames && rm -f /root/doll_r3_frames/frame_*.bmp
+
+( timeout "$DUR" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_RTT_PERTARGET=1 \
+      PROSPER_FILELOG=1 PROSPER_PROGRESS=5 PROSPER_PROGRESS_UNIMPL=1 PROSPER_PADLOG=1 \
+      PROSPER_FRAME_DIR=/root/doll_r3_frames PROSPER_DUMP_CONTENT=64 "$BT" "$DUMP" 2>&1 | \
+  gawk '{ if (!t0) t0 = systime(); printf "%4d %s\n", systime()-t0, $0; fflush() }' > "$LOG" ) &
+
+sleep 8
+# find the real boot_trace PID (comm match, not the timeout wrapper)
+PID=""
+for p in $(pgrep -f "$DUMP"); do
+    if [ "$(cat /proc/$p/comm 2>/dev/null)" = "bt_diag" ]; then PID=$p; fi
+done
+echo "boot pid: ${PID:-NONE}" >> "$SAMP"
+T0=$(date +%s)
+while [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; do
+    NOW=$(( $(date +%s) - T0 ))
+    IOL=$(tr '\n' ' ' < /proc/$PID/io 2>/dev/null)
+    NT=$(ls /proc/$PID/task 2>/dev/null | wc -l)
+    CPU=$(awk '{print $14+$15}' /proc/$PID/stat 2>/dev/null)
+    echo "t=$NOW threads=$NT cpu_ticks=$CPU io: $IOL" >> "$SAMP"
+    for t in /proc/$PID/task/*/stat; do
+        awk '{printf "%s %s %s %s\n", $1, $2, $3, $14+$15}' "$t" 2>/dev/null
+    done | sort -k4 -rn | head -5 | sed 's/^/    thr /' >> "$SAMP"
+    sleep 30
+done
+wait
+
+echo "=================== ANALYSIS (render) ==================="
+wc -l "$LOG"
+echo "--- [progress] heartbeats:"
+grep -a '\[progress\]' "$LOG" | head -120
+echo "--- pad lines:"
+grep -a '\[pad\]' "$LOG" | head -20
+echo "--- file opens per 60s bucket:"
+grep -a '\[file\] open' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d opens\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- APR reads per 60s bucket:"
+grep -a 'read-submit\|read-direct' "$LOG" | awk '{ b = int($1/60); n[b]++ } END { for (i in n) printf "min %d: %d reads\n", i, n[i] }' | sort -t' ' -k2 -n
+echo "--- last 15 file-layer lines:"
+grep -a '\[file\]\|\[apr\]' "$LOG" | tail -15
+echo "--- samples:"
+cat "$SAMP"
+echo "--- log tail:"
+tail -15 "$LOG"
+echo RUN3_DONE

--- a/scripts/diag/run3_render.sh
+++ b/scripts/diag/run3_render.sh
@@ -6,7 +6,7 @@ WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 BT=/root/bt_diag
 DUMP=/root/PPSA17942-app0
-DUR=${DUR:-420}
+DUR=${DUR:-180}
 LOG=/root/doll_r3.log
 SAMP=/root/doll_r3.samples
 rm -f "$LOG" "$SAMP"

--- a/scripts/diag/run4_threads.sh
+++ b/scripts/diag/run4_threads.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# DOLL progression probe, run 4: boot no-render to steady state, then gdb-attach twice (60 s apart)
+# and dump every thread's name/pc/guest-RAs — is anything blocked, and does the picture CHANGE?
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+BT="$WT/prosper/build-linux/boot_trace"
+DUMP=/root/PPSA17942-app0
+LOG=/root/doll_r4.log
+rm -f "$LOG"
+
+env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=5 "$BT" "$DUMP" > "$LOG" 2>&1 &
+sleep 3
+PID=""
+for p in $(pgrep -f "$DUMP"); do
+    if [ "$(cat /proc/$p/comm 2>/dev/null)" = "boot_trace" ]; then PID=$p; fi
+done
+echo "boot pid: ${PID:-NONE}"
+[ -z "$PID" ] && exit 1
+
+sleep 180
+echo "=== THREAD DUMP 1 (t=180s) ==="
+gdb -p "$PID" -batch -x "$WT/prosper/tools/dbg/thr232.py" 2>/dev/null | grep -v "^\[" | head -120
+sleep 60
+echo "=== THREAD DUMP 2 (t=240s) ==="
+gdb -p "$PID" -batch -x "$WT/prosper/tools/dbg/thr232.py" 2>/dev/null | grep -v "^\[" | head -120
+echo "=== heartbeat tail ==="
+grep -a '\[progress\]' "$LOG" | tail -8
+kill -9 "$PID" 2>/dev/null
+echo RUN4_DONE

--- a/scripts/diag/run5_flow.sh
+++ b/scripts/diag/run5_flow.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# DOLL progression probe, run 5: boot no-render to steady state, attach gdb with flow5.py.
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+# Run under a different binary name: sibling agents' cleanup scripts pkill 'boot_trace' and have
+# killed our diagnostic boots mid-probe.
+cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
+BT=/root/bt_diag
+DUMP=/root/PPSA17942-app0
+LOG=/root/doll_r5.log
+rm -f "$LOG"
+
+env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=5 "$BT" "$DUMP" > "$LOG" 2>&1 &
+sleep 3
+PID=""
+for p in $(pgrep -f "$DUMP"); do
+    if [ "$(cat /proc/$p/comm 2>/dev/null)" = "bt_diag" ]; then PID=$p; fi
+done
+echo "boot pid: ${PID:-NONE}"
+[ -z "$PID" ] && exit 1
+sleep 150
+timeout 240 gdb -p "$PID" -batch -x "$WT/prosper/tools/dbg/flow5.py" 2>&1 \
+  | grep -vE "New LWP|Thread debugging|libthread|warning:|Download|debuginfod|answered|No such file|\[Thread"
+echo "=== heartbeat tail ==="
+grep -a '\[progress\]' "$LOG" | tail -4
+kill -9 "$PID" 2>/dev/null
+echo RUN5_DONE

--- a/scripts/diag/run6_pumps.sh
+++ b/scripts/diag/run6_pumps.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# DOLL progression probe, run 6: identify the guest callers of the per-frame unimplemented pumps.
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
+DUMP=/root/PPSA17942-app0
+LOG=/root/doll_r6.log
+rm -f "$LOG"
+
+env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=5 /root/bt_diag "$DUMP" > "$LOG" 2>&1 &
+sleep 3
+PID=""
+for p in $(pgrep -f "$DUMP"); do
+    if [ "$(cat /proc/$p/comm 2>/dev/null)" = "bt_diag" ]; then PID=$p; fi
+done
+echo "boot pid: ${PID:-NONE}"
+[ -z "$PID" ] && exit 1
+sleep 150
+timeout 300 gdb -p "$PID" -batch -x "$WT/prosper/tools/dbg/flow6.py" 2>&1 \
+  | grep -vE "New LWP|Thread debugging|libthread|warning:|Download|debuginfod|answered|No such file|\[Thread|hit Breakpoint|in prosper_on_unimpl|^$"
+kill -9 "$PID" 2>/dev/null
+echo RUN6_DONE

--- a/scripts/diag/run7_netctl.sh
+++ b/scripts/diag/run7_netctl.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# DOLL progression probe, run 7: THE DECISIVE EXPERIMENT — deliver the NetCtl DISCONNECTED
+# callback (PROSPER_NETCTL_CB=1) and watch whether the boot flow advances (new file IO after the
+# t=6s wall, pad open, sms_opening movie open, new NIDs).
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
+DUMP=/root/PPSA17942-app0
+DUR=${DUR:-300}
+LOG=/root/doll_r7.log
+rm -f "$LOG"
+
+( timeout "$DUR" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_PADLOG=1 \
+      PROSPER_PROGRESS=5 PROSPER_PROGRESS_UNIMPL=1 PROSPER_NETCTL_CB=1 PROSPER_SVCLOG=1 \
+      /root/bt_diag "$DUMP" 2>&1 | \
+  gawk '{ if (!t0) t0 = systime(); printf "%4d %s\n", systime()-t0, $0; fflush() }' > "$LOG" ) &
+wait
+
+echo "=================== ANALYSIS (NetCtl delivery) ==================="
+wc -l "$LOG"
+echo "--- DELIVERED line:"
+grep -a 'DELIVERED' "$LOG"
+echo "--- heartbeats (every 6th):"
+grep -a '\[progress\]' "$LOG" | awk 'NR % 6 == 1'
+echo "--- file opens per 30s bucket:"
+grep -a '\[file\] open' "$LOG" | awk '{ b = int($1/30); n[b]++ } END { for (i in n) printf "t%03d: %d opens\n", i*30, n[i] }' | sort
+echo "--- APR reads per 30s bucket:"
+grep -a 'read-submit\|read-direct' "$LOG" | awk '{ b = int($1/30); n[b]++ } END { for (i in n) printf "t%03d: %d reads\n", i*30, n[i] }' | sort
+echo "--- pad lines:"
+grep -a '\[pad\]' "$LOG" | head -10
+echo "--- usm/movie activity:"
+grep -a 'usm' "$LOG" | tail -8
+echo "--- file activity after t=20:"
+grep -a '\[file\] open' "$LOG" | awk '$1 > 20' | head -20
+echo "--- last unimpl dump:"
+grep -a 'x  lib' "$LOG" | tail -35
+echo "--- svc lines (last 25):"
+grep -a '\[svc\]' "$LOG" | tail -25
+echo RUN7_DONE

--- a/scripts/diag/run8_matrix.sh
+++ b/scripts/diag/run8_matrix.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# DOLL progression probe, run 8: pad-connected matrix. 8a = PAD_PRESS only; 8b = PAD_PRESS+NETCTL_CB.
+# Usage: run8_matrix.sh a|b
+set -u
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+V=$1
+cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag_$V
+DUMP=/root/PPSA17942-app0
+DUR=${DUR:-240}
+LOG=/root/doll_r8$V.log
+rm -f "$LOG"
+
+EXTRA=""
+if [ "$V" = "b" ]; then EXTRA="PROSPER_NETCTL_CB=1"; fi
+
+( timeout "$DUR" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_PADLOG=1 \
+      PROSPER_PROGRESS=5 PROSPER_PAD_PRESS=1 $EXTRA \
+      /root/bt_diag_$V "$DUMP" 2>&1 | \
+  gawk '{ if (!t0) t0 = systime(); printf "%4d %s\n", systime()-t0, $0; fflush() }' > "$LOG" ) &
+wait
+
+echo "=================== ANALYSIS (8$V: PAD_PRESS ${EXTRA:-only}) ==================="
+echo "--- file opens per 30s bucket:"
+grep -a '\[file\] open' "$LOG" | awk '{ b = int($1/30); n[b]++ } END { for (i in n) printf "t%03d: %d opens\n", i*30, n[i] }' | sort
+echo "--- APR reads per 30s bucket:"
+grep -a 'read-submit\|read-direct' "$LOG" | awk '{ b = int($1/30); n[b]++ } END { for (i in n) printf "t%03d: %d reads\n", i*30, n[i] }' | sort
+echo "--- file activity after t=20 (first 15):"
+grep -a '\[file\]' "$LOG" | awk '$1 > 20' | head -15
+echo "--- usm:"
+grep -a 'usm' "$LOG" | tail -5
+echo "--- heartbeats every 6th:"
+grep -a '\[progress\]' "$LOG" | awk 'NR % 6 == 1' | tail -10
+echo "--- log tail:"
+tail -5 "$LOG"
+echo RUN8${V}_DONE


### PR DESCRIPTION
Diagnostic session answering **why DOLL (PPSA17942) never advances past its loading screen**.

## Verdict: STALLED (correctness wall), not llvmpipe slowness
DOLL reaches a full **60fps engine steady state in ~6s** (all IO complete, `DOLLLoadingScreen` UMG widget rendering) and never advances. Proven not speed-bound: with the renderer OFF it runs true 60fps for 7+ min / 25,000+ flips, does **zero file IO after t=6s**, and never enqueues a level-load.

**Smoking gun:** the game pumps `sceNetCtlCheckCallback` + `sceErrorDialogUpdateStatus` once/frame, and the online/update/entitlement init chain (`sceNpGetOnlineId`, `sceGameUpdateInitialize`, `sceNpEntitlementAccessInitialize`, Http/Ssl/WebApi/Json/NetResolver) fires once returning **success-with-garbage-out** → UE4 `InstallBundleManager` PatchCheck never resolves. Follow-up fix tracked in **#306**.

Ruled out by A/B: slowness, `.usm` movies, input/controller, and network-state (a gated `PROSPER_NETCTL_CB` DISCONNECTED-callback experiment delivers cleanly + is consumed but does NOT move the wall — the per-frame pump is the generic PS callback pump, not a net-state spin).

## What this PR lands (all additive, gated default-off)
- **`docs/DOLL_LOADING_PROGRESSION.md`** — full verdict + evidence.
- Reusable diagnostics: `PROSPER_PROGRESS` (per-window flip/draw/dispatch heartbeat), `PROSPER_PROGRESS_UNIMPL` (per-frame unimpl-call-count dump — the tool that found the pump), `PROSPER_NETCTL_CB` (gated net-state experiment), `tools/dbg/flow5.py`/`flow6.py`, `scripts/diag/run{1..8}*.sh` (the A/B methodology).

## Verification
ctest 68/68; Messenger unaffected (diagnostics default-off); no imagery committed.

refs #306.