### PR TITLE
fix(gpu): use the game's real fast-clear colour, not hardcoded debug blue (#309)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -434,6 +434,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 return bds;
             };
+            // Clear color for a group: the game's decoded fast-clear taken from the group's first item's
+            // resolved pipeline state, or its default opaque black when no fast-clear was programmed.
+            // Passing this to render_draws_rgba replaces the old hardcoded debug blue on the live path
+            // (#309) — PROSPER_CLEAR_DEBUG still forces blue for spotting unrendered areas.
+            auto clear_for = [](const std::vector<const prosper::gpu::DrawItem*>& g) -> const float* {
+                return g.empty() ? nullptr : g.front()->ps.clear_color;
+            };
             std::vector<uint8_t> px;
             if (pertarget) {
                 // PER-TARGET RTT: a real frame is a sequence of passes, each rendering into a specific
@@ -479,7 +486,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
                         if (sit != g_rtt.end() && sit->second.w == w && sit->second.h == h &&
                             sit->second.rgba.size() == (size_t)w * h * 4) seed = sit->second.rgba.data(); }
-                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(groups[base]), w, h, seed);
+                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(groups[base]), w, h, seed, clear_for(groups[base]));
                     if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = w; s.h = h; }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
@@ -513,7 +520,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // Single-framebuffer path: render_draws_rgba composites every draw into ONE framebuffer.
                 std::vector<const prosper::gpu::DrawItem*> all; all.reserve(items.size());
                 for (const auto& it : items) all.push_back(&it);
-                px = prosper::test::render_draws_rgba(build_bds(all), w, h);
+                px = prosper::test::render_draws_rgba(build_bds(all), w, h, nullptr, clear_for(all));
                 // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
                 // composite pass that samples that address gets the scene we drew (not empty guest memory).
                 if (rtt_on && !px.empty()) {

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -3,6 +3,7 @@
 #include "pm4_registers.hpp"
 #include "vk_translate.hpp"
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 
 namespace prosper::gpu {
@@ -28,6 +29,37 @@ float flt(uint32_t bits) {
     std::memcpy(&f, &bits, sizeof f);
     return f;
 }
+
+// sRGB (gamma-encoded) 8-bit sample -> linear [0,1]. VkClearColorValue's float channels are LINEAR
+// for an sRGB attachment (Vulkan re-encodes on store), so an sRGB fast-clear word must be linearized
+// here to round-trip to the exact stored byte. Identity at 0 and 1, so black/white are exact.
+float srgb_to_linear(float c) {
+    return c <= 0.04045f ? c / 12.92f : std::pow((c + 0.055f) / 1.055f, 2.4f);
+}
+
+// Decode a CB fast-clear word into an RGBA float clear color (Vulkan order: out[0]=R). Returns false
+// for formats we do not decode yet, so the caller falls back to opaque black — the correct PS5
+// default and never worse than the old debug blue. CONFIDENCE: HIGH for 8_8_8_8 (the live-verified
+// Messenger / PPSA02664 target); the byte order matches vk_color_format's 0xA row (STD->R8G8B8A8,
+// ALT->B8G8R8A8) and the sRGB rows are linearized. Other formats: MED -> left to the black fallback.
+bool decode_clear_color(const RenderState& rs, float out[4]) {
+    if (!rs.color0_has_clear) return false;
+    const uint32_t w0 = rs.color0_clear_word0;
+    if (rs.color0_format == 0xAu) {  // COLOR_8_8_8_8
+        const float b0 = (w0 & 0xFFu) / 255.0f, b1 = ((w0 >> 8) & 0xFFu) / 255.0f,
+                    b2 = ((w0 >> 16) & 0xFFu) / 255.0f, b3 = ((w0 >> 24) & 0xFFu) / 255.0f;
+        float r, g, b, a = b3;                     // alpha is byte 3 for both swaps
+        if (rs.color0_comp_swap == 1u) { r = b2; g = b1; b = b0; }   // ALT: B8G8R8A8 (byte0=B)
+        else                            { r = b0; g = b1; b = b2; }  // STD: R8G8B8A8 (byte0=R)
+        const bool is_srgb = (rs.color0_number_type == 6u);
+        out[0] = is_srgb ? srgb_to_linear(r) : r;
+        out[1] = is_srgb ? srgb_to_linear(g) : g;
+        out[2] = is_srgb ? srgb_to_linear(b) : b;
+        out[3] = a;                                // alpha is always linear
+        return true;
+    }
+    return false;  // unmapped format -> caller uses opaque-black fallback
+}
 }  // namespace
 
 RenderState extract_render_state(const GpuState& st) {
@@ -45,6 +77,12 @@ RenderState extract_render_state(const GpuState& st) {
     rs.color0_format           = PM4_FIELD(cinfo, CB_COLOR0_INFO, FORMAT);
     rs.color0_number_type      = PM4_FIELD(cinfo, CB_COLOR0_INFO, NUMBER_TYPE);
     rs.color0_comp_swap        = PM4_FIELD(cinfo, CB_COLOR0_INFO, COMP_SWAP);
+
+    // CB fast-clear color (CB_COLOR0_CLEAR_WORD0/1). Present only when the game programs a fast-clear
+    // for MRT 0; the words carry the clear value in the target's pixel format (decoded in resolve).
+    rs.color0_has_clear   = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) || st.cx.count(P::CB_COLOR0_CLEAR_WORD1);
+    rs.color0_clear_word0 = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) ? rd(st.cx, P::CB_COLOR0_CLEAR_WORD0) : 0u;
+    rs.color0_clear_word1 = st.cx.count(P::CB_COLOR0_CLEAR_WORD1) ? rd(st.cx, P::CB_COLOR0_CLEAR_WORD1) : 0u;
 
     // Primitive topology. VGT_PRIMITIVE_TYPE (0x242) is a UCONFIG register in RDNA2 (the game sets it via
     // a Uc-class SetRegsIndirect / CreatePrimState's uc[2]), NOT a context register — read it from st.uc.
@@ -98,6 +136,11 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     ps.topology      = static_cast<uint32_t>(vk_topology(rs.prim_type));
     ps.color0_format = static_cast<uint32_t>(
         vk_color_format(rs.color0_format, rs.color0_number_type, rs.color0_comp_swap));
+
+    // Fast-clear color: decode the CB_COLOR0_CLEAR_WORD when the game programmed one (#309). A
+    // decode miss (no fast-clear, or an unmapped format) leaves has_clear_color false and the
+    // default opaque-black clear_color, which the backend uses instead of the old debug blue.
+    ps.has_clear_color = decode_clear_color(rs, ps.clear_color);
 
     ps.depth_test_enable  = rs.z_enable;
     ps.depth_write_enable = rs.z_write_enable;

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -26,6 +26,12 @@ struct RenderState {
     uint32_t color0_number_type = 0;   // CB_COLOR0_INFO.NUMBER_TYPE  (UNORM/SRGB/…)
     uint32_t color0_comp_swap   = 0;   // CB_COLOR0_INFO.COMP_SWAP    (channel order: RGBA/BGRA/…)
 
+    // CB fast-clear for MRT 0 (CB_COLOR0_CLEAR_WORD0/1 = 0x323/0x324). `has_clear` is true when the
+    // game PROGRAMMED the clear words (register present); the words hold the clear value in the
+    // target's pixel format, decoded to an RGBA float in resolve_pipeline_state (#309).
+    bool     color0_has_clear   = false;
+    uint32_t color0_clear_word0 = 0, color0_clear_word1 = 0;
+
     // Primitive topology (VGT_PRIMITIVE_TYPE.PRIM_TYPE).
     uint32_t prim_type = 0;
 
@@ -71,6 +77,13 @@ RenderState extract_render_state(const GpuState& st);
 struct ResolvedPipelineState {
     uint32_t topology         = 0;   // == VkPrimitiveTopology
     uint32_t color0_format    = 0;   // == VkFormat (0 = VK_FORMAT_UNDEFINED)
+
+    // Color-target clear value, decoded from CB_COLOR0_CLEAR_WORD0/1 per the surface format (#309).
+    // has_clear_color == the game programmed a fast-clear that we decoded; clear_color is RGBA in
+    // Vulkan order (float32[0]=R). When has_clear_color is false the backend clears to opaque black —
+    // NOT the old diagnostic blue, which now lives behind the PROSPER_CLEAR_DEBUG env in render_runner.
+    bool     has_clear_color  = false;
+    float    clear_color[4]   = {0.0f, 0.0f, 0.0f, 1.0f};
     bool     depth_test_enable  = false;
     bool     depth_write_enable = false;
     uint32_t depth_compare_op  = 0;  // == VkCompareOp

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -111,8 +111,14 @@ struct BackendDraw {
 // content — without it every pass starts from the diagnostic blue clear, so cross-submit
 // accumulation (UE4's UI-onto-backbuffer after a separate composite submit) is lost. Null (the
 // default) keeps the blue-clear behavior byte-identical for every existing caller.
+// `clear_rgba` (optional): 4 floats (RGBA, Vulkan order) to clear the color attachment to when no
+// seed is supplied. Null keeps the legacy diagnostic blue — every test harness caller passes null,
+// so their behavior is byte-identical. The live renderer passes the game's decoded fast-clear color
+// (or opaque black when none), so real frames no longer start from blue (#309). PROSPER_CLEAR_DEBUG
+// forces the blue back on regardless, so unrendered areas can still be spotted during development.
 inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H,
-                                              const uint8_t* seed_rgba = nullptr) {
+                                              const uint8_t* seed_rgba = nullptr,
+                                              const float* clear_rgba = nullptr) {
     std::vector<uint8_t> out;
     if (draws.empty()) return out;
     VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO}; app.apiVersion = VK_API_VERSION_1_1;
@@ -543,7 +549,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT; b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b1);
     }
-    VkClearValue clear[2]{}; clear[0].color = {{0.0f, 0.0f, 1.0f, 1.0f}};   // blue
+    // Clear color: the caller's clear_rgba (game fast-clear / black on the live path), else the
+    // legacy diagnostic blue. PROSPER_CLEAR_DEBUG forces blue back on even when a color is passed.
+    float cc[4] = {0.0f, 0.0f, 1.0f, 1.0f};   // diagnostic blue
+    if (clear_rgba && getenv("PROSPER_CLEAR_DEBUG") == nullptr)
+        for (int i = 0; i < 4; i++) cc[i] = clear_rgba[i];
+    VkClearValue clear[2]{}; clear[0].color = {{cc[0], cc[1], cc[2], cc[3]}};
     clear[1].depthStencil = {0.5f, 0};   // depth cleared to 0.5 (fragments at z=0.0 pass LESS, fail GREATER)
     VkRenderPassBeginInfo rpbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
     rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_ds ? 2 : 1; rpbi.pClearValues = clear;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -7,6 +7,7 @@
 #include "../src/gpu/render_state.hpp"
 #include "../src/gpu/vk_translate.hpp"
 #include "../src/gpu/pm4_registers.hpp"
+#include <cmath>
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
@@ -18,6 +19,12 @@ namespace P = prosper::agc::Pm4;
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
+#define CHECK_NEAR(a, b, m) CHECK(std::fabs((a) - (b)) < 1e-4f, m)
+
+// Mirror of render_state.cpp's sRGB->linear (VkClearColorValue floats are linear for sRGB targets).
+static float srgb2lin(float c) {
+    return c <= 0.04045f ? c / 12.92f : std::pow((c + 0.055f) / 1.055f, 2.4f);
+}
 
 struct Dcb { uint32_t* bottom; uint32_t* top; uint32_t* cursor_up; uint32_t* cursor_down;
              void* callback; void* user_data; uint32_t reserved_dw; uint32_t pad; };
@@ -47,6 +54,9 @@ int main() {
         // CB_BLEND0_CONTROL: ENABLE(bit30) | SRCBLEND=4/SrcAlpha | DESTBLEND=5/OneMinusSrcAlpha | COMB_FCN=0/Add
         { P::CB_BLEND0_CONTROL,  (1u << 30) | (4u << 0) | (5u << 8) | (0u << 5) },
         { P::CB_TARGET_MASK,     0x0000000Fu },
+        // CB fast-clear (#309): CLEAR_WORD0 holds one texel in the surface's 8_8_8_8 format.
+        { P::CB_COLOR0_CLEAR_WORD0, 0x11223344u },
+        { P::CB_COLOR0_CLEAR_WORD1, 0x00000000u },
     };
     // Shader-stage program addresses.
     ShaderReg sh_regs[] = {
@@ -116,6 +126,46 @@ int main() {
     CHECK(rs.db_depth_control  == 0x00000046u, "db_depth_control raw preserved");
     CHECK(rs.cb_color_control  == 0x00CC0010u, "cb_color_control raw preserved");
     CHECK(rs.cb_target_mask    == 0x0000000Fu, "cb_target_mask raw preserved");
+
+    // #309: CB fast-clear word extraction + format-aware decode in resolve_pipeline_state.
+    CHECK(rs.color0_has_clear, "color0_has_clear = true (CLEAR_WORD programmed)");
+    CHECK(rs.color0_clear_word0 == 0x11223344u, "color0_clear_word0 preserved");
+    {
+        // This target is ALT/BGRA + SRGB, so byte0=B, byte1=G, byte2=R, byte3=A, with RGB linearized.
+        ResolvedPipelineState ps = resolve_pipeline_state(rs);
+        CHECK(ps.has_clear_color, "resolve decodes the fast-clear color");
+        CHECK_NEAR(ps.clear_color[0], srgb2lin(0x22 / 255.0f), "clear R = byte2 (ALT swap), sRGB-linearized");
+        CHECK_NEAR(ps.clear_color[1], srgb2lin(0x33 / 255.0f), "clear G = byte1, sRGB-linearized");
+        CHECK_NEAR(ps.clear_color[2], srgb2lin(0x44 / 255.0f), "clear B = byte0 (ALT swap), sRGB-linearized");
+        CHECK_NEAR(ps.clear_color[3], 0x11 / 255.0f,           "clear A = byte3, linear (no sRGB on alpha)");
+    }
+    {
+        // STD/RGBA + UNORM: byte0=R, byte1=G, byte2=B, byte3=A, no sRGB — exact byte/255.
+        RenderState r2{};
+        r2.color0_format = 0xAu; r2.color0_number_type = 0u; r2.color0_comp_swap = 0u;
+        r2.color0_has_clear = true; r2.color0_clear_word0 = 0x11223344u;
+        ResolvedPipelineState p2 = resolve_pipeline_state(r2);
+        CHECK(p2.has_clear_color, "STD/UNORM fast-clear decodes");
+        CHECK_NEAR(p2.clear_color[0], 0x44 / 255.0f, "STD clear R = byte0");
+        CHECK_NEAR(p2.clear_color[1], 0x33 / 255.0f, "STD clear G = byte1");
+        CHECK_NEAR(p2.clear_color[2], 0x22 / 255.0f, "STD clear B = byte2");
+        CHECK_NEAR(p2.clear_color[3], 0x11 / 255.0f, "STD clear A = byte3");
+    }
+    {
+        // No fast-clear programmed -> has_clear_color false, default opaque black (never blue) (#309).
+        RenderState r3{}; r3.color0_format = 0xAu; r3.color0_has_clear = false;
+        ResolvedPipelineState p3 = resolve_pipeline_state(r3);
+        CHECK(!p3.has_clear_color, "no fast-clear -> has_clear_color false");
+        CHECK(p3.clear_color[0] == 0.0f && p3.clear_color[1] == 0.0f &&
+              p3.clear_color[2] == 0.0f && p3.clear_color[3] == 1.0f,
+              "no fast-clear -> default opaque-black clear color {0,0,0,1}");
+    }
+    {
+        // Unmapped format with a clear word set -> undecoded, falls back to black (not a bogus color).
+        RenderState r4{}; r4.color0_format = 0xCu; r4.color0_has_clear = true; r4.color0_clear_word0 = 0x11223344u;
+        ResolvedPipelineState p4 = resolve_pipeline_state(r4);
+        CHECK(!p4.has_clear_color, "unmapped format fast-clear -> has_clear_color false (black fallback)");
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Fixes #309.

## Problem
`render_draws_rgba` cleared every colour target to a hardcoded debug blue (`{0,0,1,1}`). Any region the game never drew over rendered blue — most visibly PPSA02664's credits screen, whose background should be black. Every rendered frame's background was affected.

## Fix
Decode and use the CB fast-clear the game actually programs:

- **`RenderState`**: adds `color0_has_clear` + `color0_clear_word0/1`, read from `CB_COLOR0_CLEAR_WORD0/1` (`0x323`/`0x324`) in `extract_render_state`.
- **`resolve_pipeline_state`**: decodes the clear word into an RGBA float per the target format — `8_8_8_8` STD→`R8G8B8A8` / ALT→`B8G8R8A8`, with sRGB rows linearised so `VkClearColorValue` round-trips to the stored byte. Unmapped formats leave `has_clear_color=false`. *CONFIDENCE: HIGH* for `8_8_8_8` (the live-verified Messenger/PPSA02664 target); *MED* for other formats, which fall through to the black fallback.
- **`render_draws_rgba`**: takes an optional `clear_rgba`. The live renderer (`live_renderer.cpp`) passes the decoded colour, or **opaque black `{0,0,0,1}`** when the game programmed no fast-clear. `PROSPER_CLEAR_DEBUG` forces the old blue back on so unrendered areas can still be spotted during development.

Test-harness callers pass `null` and keep the blue clear byte-identical, so the existing render tests (which assert the blue background, e.g. `test_pipeline_render`) are unchanged.

## Verification
- `test_render_state` extended: fast-clear extraction + format-aware decode (ALT/sRGB swap, STD/UNORM exact, no-clear→black, unmapped-format→black fallback).
- Full `ctest` **68/68 green** in the worktree.
- `messenger-scene` golden-image guard still renders a rich frame (**24318 colours ≥ 5000**) — the clear change doesn't regress the scene render. The guard is a content metric, not a pixel hash, so no re-baseline was needed.