### PR TITLE
fix(render): clear colour to black (game's real clear), not the debug blue (#309)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -4,6 +4,8 @@
 #include "vk_translate.hpp"
 #include <algorithm>
 #include <cstring>
+#include <cstdlib>
+#include <set>
 
 namespace prosper::gpu {
 
@@ -45,6 +47,17 @@ RenderState extract_render_state(const GpuState& st) {
     rs.color0_format           = PM4_FIELD(cinfo, CB_COLOR0_INFO, FORMAT);
     rs.color0_number_type      = PM4_FIELD(cinfo, CB_COLOR0_INFO, NUMBER_TYPE);
     rs.color0_comp_swap        = PM4_FIELD(cinfo, CB_COLOR0_INFO, COMP_SWAP);
+    // PROSPER_CLEARLOG: does the game program a CB fast-clear colour for this target, and in what format?
+    // (Investigation for the debug-blue clear -> real clear colour, #309.)
+    if (getenv("PROSPER_CLEARLOG")) {
+        uint32_t cw0 = rd(st.cx, P::CB_COLOR0_CLEAR_WORD0), cw1 = rd(st.cx, P::CB_COLOR0_CLEAR_WORD1);
+        static std::set<uint64_t> seen;
+        uint64_t key = ((uint64_t)cw0 << 32) | (rs.color0_base & 0xffffffffu);
+        if (seen.insert(key).second)
+            fprintf(stderr, "[clear] base=0x%llx fmt=%u numtype=%u swap=%u CLEAR_WORD0=0x%08x WORD1=0x%08x\n",
+                    (unsigned long long)rs.color0_base, rs.color0_format, rs.color0_number_type,
+                    rs.color0_comp_swap, cw0, cw1);
+    }
 
     // Primitive topology. VGT_PRIMITIVE_TYPE (0x242) is a UCONFIG register in RDNA2 (the game sets it via
     // a Uc-class SetRegsIndirect / CreatePrimState's uc[2]), NOT a context register — read it from st.uc.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -543,7 +543,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT; b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b1);
     }
-    VkClearValue clear[2]{}; clear[0].color = {{0.0f, 0.0f, 1.0f, 1.0f}};   // blue
+    // Clear to BLACK — the game clears its color target to its CB fast-clear value, and this title's
+    // CB_COLOR0_CLEAR_WORD is 0 (black) for every target (verified with PROSPER_CLEARLOG, #309). Blue was
+    // a bring-up debug colour to make unrendered areas visible; keep it behind PROSPER_CLEAR_DEBUG.
+    // (A non-zero, format-decoded fast-clear colour is a future enhancement; this game clears to black.)
+    VkClearValue clear[2]{};
+    clear[0].color = getenv("PROSPER_CLEAR_DEBUG") ? VkClearColorValue{{0.0f, 0.0f, 1.0f, 1.0f}}
+                                                   : VkClearColorValue{{0.0f, 0.0f, 0.0f, 1.0f}};
     clear[1].depthStencil = {0.5f, 0};   // depth cleared to 0.5 (fragments at z=0.0 pass LESS, fail GREATER)
     VkRenderPassBeginInfo rpbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
     rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_ds ? 2 : 1; rpbi.pClearValues = clear;


### PR DESCRIPTION
## Problem
The offscreen render backend cleared every colour target to a **hardcoded debug blue** `{0,0,1,1}` (`tests/render_runner.h`, literal `// blue`). This is not PS5 behaviour — it was a bring-up colour to make unrendered areas visible. It's why rendered frames (e.g. PPSA02664's credits) show a **blue background** where no draw covers.

## Investigation
On GNM/AGC the colour target's clear value comes from the game's CB fast-clear (`CB_COLOR0_CLEAR_WORD0/1`). Added `PROSPER_CLEARLOG` to dump those registers per target: for PPSA02664 every target reports `CLEAR_WORD0=0x00000000` — the game clears to **black**.
```
[clear] base=0x... fmt=6  ... CLEAR_WORD0=0x00000000 WORD1=0x00000000
[clear] base=0x... fmt=10 ... CLEAR_WORD0=0x00000000 WORD1=0x00000000
```

## Fix
- Default the clear colour to **black** `{0,0,0,1}` — the game's real clear.
- Keep the debug blue behind `PROSPER_CLEAR_DEBUG` (still handy for spotting unrendered areas during bring-up).
- Add `PROSPER_CLEARLOG` (per-target CB fast-clear dump) for future work.

A non-zero, format-decoded fast-clear colour (`CLEAR_WORD != 0`, per `CB_COLOR0_INFO.FORMAT`) is a future enhancement; this title clears to black.

## Test
- Render unit tests pass.
- PPSA02664 credits now render on the correct black backdrop (matches the game). Changes every rendered frame's background — worth a golden-image `update` pass.

Fixes #309.