### PR TITLE
feat(render): present the compositor group + reliable-capture diagnostics

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -325,9 +325,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
                     if (!refvs) bd.indices = it.indices;
                     if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
-                        "[render] item %zu: %zu resources vcount=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
+                        "[render] item %zu: %zu resources vcount=%u nidx=%zu topo=%u mask=0x%x blend=%d src=%u dst=%u op=%u\n",
                         bds.size(), bd.R.size(), bd.vcount, bd.indices.size(), it.ps.topology,
-                        it.ps.color_write_mask, (int)it.ps.blend_enable);
+                        it.ps.color_write_mask, (int)it.ps.blend_enable,
+                        it.ps.src_color_blend_factor, it.ps.dst_color_blend_factor, it.ps.color_blend_op);
                     bds.push_back(std::move(bd));
                 }
                 return bds;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -47,7 +47,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // reach a post-loading-screen scene.
             static std::atomic<int> g_submit_idx{0};
             static int g_render_first = getenv("PROSPER_RENDER_FIRST") ? atoi(getenv("PROSPER_RENDER_FIRST")) : 0;
-            if (g_submit_idx++ < g_render_first) return {};
+            int g_this_submit = g_submit_idx++;
+            // PROSPER_FIND_CONTENT: at NATIVE speed (before the slow render), scan this submit's PS textures
+            // for a real content atlas (large sampled texture, not the 4x4/17x1 defaults) and log the submit
+            // index. Pinpoints which submit shows the 2D content (e.g. the credits) so RENDER_FIRST can be
+            // aimed there — the render is too slow to sweep blindly for a timing-shifted content window.
+            if (getenv("PROSPER_FIND_CONTENT")) {
+                for (const auto& it : items) {
+                    const auto* t = it.prt.get();
+                    if (!t) continue;
+                    for (const auto& r : t->resources)
+                        if ((r.cls == RC::Texture || r.cls == RC::StorageImage) && r.width >= 700 && r.height >= 100) {
+                            fprintf(stderr, "[find] submit %d has content tex %ux%u addr=0x%llx\n",
+                                    g_this_submit, r.width, r.height, (unsigned long long)r.gpu_addr);
+                            break;
+                        }
+                }
+            }
+            if (g_this_submit < g_render_first) return {};
             // Dump the FIRST item's recompiled SPIR-V (diagnostic; survives a mid-render crash).
             if (getenv("PROSPER_SHADER_DUMP") && !items.empty()) {
                 std::string d = getenv("PROSPER_SHADER_DUMP");
@@ -334,13 +351,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (groups.find(k) == groups.end()) order.push_back(k);
                     groups[k].push_back(&it);
                 }
+                // Which group to PRESENT? The scanned-out frame is the COMPOSITOR pass — the one that draws
+                // the real content (sprites/UI) over the background — NOT necessarily the last-submitted
+                // group, which is often a single-draw solid background/clear fill of a different buffer.
+                // Presenting "last" makes the visible frame flip between content and the bg fill depending
+                // on submission order (the intermittent-content problem). PROSPER_RTT_PRESENT_MAXDRAWS
+                // instead presents the group with the most draws (a compositor blends many sprites; a fill
+                // is one fullscreen draw) — a stable choice. Ties keep the later group.
+                static const bool present_maxdraws = getenv("PROSPER_RTT_PRESENT_MAXDRAWS") != nullptr;
+                size_t best_draws = 0;
                 for (uint64_t base : order) {
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(groups[base]), w, h);
                     if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = w; s.h = h; }
                     if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for (uint8_t b : gpx) nz += (b != 0);
                         fprintf(stderr, "[rtt] group target=0x%llx (%zu draws) px_nonzero=%zu cache_size=%zu\n",
                                 (unsigned long long)base, groups[base].size(), nz, g_rtt.size()); }
-                    if (!gpx.empty()) px = std::move(gpx);                              // present the last non-empty group
+                    if (!gpx.empty()) {
+                        if (!present_maxdraws) px = std::move(gpx);                     // last non-empty group
+                        else if (groups[base].size() >= best_draws) {                   // compositor = most draws
+                            best_draws = groups[base].size(); px = std::move(gpx);
+                        }
+                    }
                 }
             } else {
                 // Single-framebuffer path: render_draws_rgba composites every draw into ONE framebuffer.
@@ -360,12 +391,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
             }
             int n = frame_no++;
+            // PROSPER_DUMP_CONTENT=<min-green-px>: dump ONLY frames whose GREEN channel is active in at
+            // least that many pixels. The debug clear colour is pure blue (green==0 everywhere), so a
+            // green-active threshold discriminates real content (skin, text AA, coloured logos) from the
+            // blue clear — catching the intermittent content frames the periodic policy misses.
+            // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames with at least that many nonzero
+            // bytes. The blue clear alone is ~259198 nonzero at 480x270; real composited content pushes it
+            // higher, so a threshold just above the clear baseline (e.g. 260000) captures the intermittent
+            // content frames and skips the pure-clear ones.
+            size_t nz_thr = 0; if (const char* c = getenv("PROSPER_DUMP_CONTENT")) nz_thr = (size_t)atol(c);
+            size_t nz = 0; if (nz_thr) for (size_t i = 0; i < px.size(); i++) nz += (px[i] != 0);
             if (px.empty()) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);
-            } else if (dump_bmps && (n < 60 || n % 10 == 0)) {   // periodic screenshots (headless verification only)
+            } else if (dump_bmps && ((nz_thr && nz >= nz_thr) ||
+                                     (!nz_thr && (n < 60 || n % 10 == 0)))) {
                 char fn[512]; snprintf(fn, sizeof fn, "%s/frame_%04d.bmp", frame_dir.c_str(), n);
                 prosper::test::dump_bmp(fn, px, w, h);
-                fprintf(stderr, "[render] frame %d rendered (%ux%u) -> %s\n", n, w, h, fn);
+                fprintf(stderr, "[render] frame %d rendered (%ux%u) nz=%zu -> %s\n", n, w, h, nz, fn);
             }
             return px;
         });


### PR DESCRIPTION
Stacked on #269 (per-target RTT).

## Problem
Under per-target RTT the presented frame was the **last** non-empty colour-target group. But a submit's groups are a content **compositor** (many sprite/UI draws over a sampled background) plus a single-draw solid **background/clear fill** of another buffer. Which is 'last' depends on submission order, so the visible frame flip-flopped between real content and the fill — PPSA02664's credits composited in only **~3% of frames** (looked like nondeterministic rendering).

## Fix
`PROSPER_RTT_PRESENT_MAXDRAWS` presents the group with the **most draws** (the compositor; a fill is one fullscreen draw). Ties keep the later group. On PPSA02664 this takes the rich credits from ~3% → **~29% of frames**, every content frame the full 738-colour image — reliable capture instead of timing luck. Opt-in; default (last-group) behaviour unchanged.

## Capture diagnostics
- `PROSPER_FIND_CONTENT`: at native speed (before the slow render) log which submits bind a real content atlas, to aim `RENDER_FIRST`.
- `PROSPER_DUMP_CONTENT=<min-nonzero>`: dump only frames above a nonzero-byte threshold (skip pure-clear frames).
- GFXLOG item line now logs resolved `src=/dst=/op=` blend factors (used to confirm the credits' blend is correct straight/premultiplied alpha — the earlier 'dim sprites' were a low-res artifact, #310).

## Test
- `prosper_live_renderer` builds clean.
- Verified end-to-end: PPSA02664 credits render reliably at full res with this + NO_STENCIL (see #270).

Refs #270.