### PR TITLE
fix(gpu): apply the S# anisotropy sampler field (#275)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -345,9 +345,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
                         fr.addr_uvw[0] = r.addr_uvw[0]; fr.addr_uvw[1] = r.addr_uvw[1]; fr.addr_uvw[2] = r.addr_uvw[2];
                         // Remaining S# sampler fields (#262): border color + LOD clamp/bias (applied where
-                        // valid; the decode-only aniso/compare/unnorm stay on ShaderResource).
+                        // valid; the decode-only compare/unnorm stay on ShaderResource).
                         fr.border_color_type = r.border_color_type;
                         fr.min_lod = r.min_lod; fr.max_lod = r.max_lod; fr.lod_bias = r.lod_bias;
+                        // Anisotropy ratio (#275): applied in render_runner.h when the device supports the
+                        // samplerAnisotropy feature and filtering is linear. The Messenger decodes ratio 0
+                        // (isotropic) so this is a no-op for it; carries correct behavior for titles that
+                        // request anisotropic filtering.
+                        fr.max_aniso_ratio = r.max_aniso_ratio;
                         // T# DST_SEL channel remap (#261): apply only to REAL-RGBA texels. The narrow
                         // R->RGBA replication path (narrow_done) already broadcasts coverage to every
                         // channel — keep it identity so the font/mask path (#102/#256) is untouched.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -48,7 +48,8 @@ inline bool dump_bmp(const char* path, const std::vector<uint8_t>& px, uint32_t 
 
 // A texture to bind for a recompiled shader's image_sample: `rgba` points to w*h*4 RGBA8 bytes,
 // bound as a COMBINED_IMAGE_SAMPLER (nearest filter, clamp) at descriptor-set 0, `binding`.
-struct TexDesc { uint32_t binding; uint32_t w; uint32_t h; const uint8_t* rgba; };
+struct TexDesc { uint32_t binding; uint32_t w; uint32_t h; const uint8_t* rgba;
+                 uint32_t max_aniso_ratio = 0; };   // #275: S# anisotropy ratio (0 = isotropic)
 
 // One resource for the general N-binding path (render_triangle_rgba's `gres`): either a storage buffer
 // (dwords non-empty, tex_rgba null) or a combined image sampler (tex_rgba set) at `binding`. Lets a
@@ -71,6 +72,9 @@ struct FrameResource {
     // transparent-black, LOD 0..0, no bias), so FrameResources built directly by tests are byte-identical.
     uint32_t border_color_type = 0;
     float    min_lod = 0.0f, max_lod = 0.0f, lod_bias = 0.0f;
+    // Anisotropy ratio (S# WORD0[11:9]; maxAnisotropy = 1<<ratio). 0 = isotropic (the default) -> the
+    // sampler is byte-identical to before, so tests building FrameResources directly are unaffected (#275).
+    uint32_t max_aniso_ratio = 0;
     // T# DST_SEL channel swizzle (SQ_SEL per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Default = identity
     // (R,G,B,A) == a no-op VkComponentMapping, so tests that build FrameResources directly are unchanged.
     uint32_t swizzle[4] = {4, 5, 6, 7};
@@ -136,6 +140,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // robustBufferAccess: out-of-range storage-buffer accesses are well-defined, so a predicated memory
     // op run by an inactive lane (narrowed EXEC) can't fault.
     VkPhysicalDeviceFeatures feats{}; feats.robustBufferAccess = VK_TRUE; dci.pEnabledFeatures = &feats;
+    // samplerAnisotropy (#275): the game's S# can request anisotropic filtering (max_aniso_ratio > 0).
+    // Enable the feature only when the physical device advertises it (a headless/software device may
+    // not) — otherwise sampler creation with anisotropyEnable would be invalid usage. maxSamplerAnisotropy
+    // is the device's ceiling; we clamp the requested ratio to it at sampler-build time.
+    VkPhysicalDeviceFeatures supported{}; vkGetPhysicalDeviceFeatures(phys, &supported);
+    VkPhysicalDeviceProperties phys_props{}; vkGetPhysicalDeviceProperties(phys, &phys_props);
+    const bool  aniso_enabled = supported.samplerAnisotropy;
+    const float max_aniso_limit = phys_props.limits.maxSamplerAnisotropy;
+    if (aniso_enabled) feats.samplerAnisotropy = VK_TRUE;
     // robustImageAccess (VK_EXT_image_robustness; core in 1.3): the recompiled storage-image load
     // path issues OpImageRead for ALL invocations — including EXEC-inactive lanes whose coordinates
     // can be out of range — relying on OOB image reads returning zero (#131). This is the LIVE
@@ -416,9 +429,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     //   border color: only bites with CLAMP_TO_BORDER wrap. 3 = register/custom (needs
                     //     VK_EXT_custom_border_color); fall back to opaque-black.
                     //   LOD min/max/bias: honored; harmless with our single uploaded mip.
+                    // Anisotropy (#275): applied when the S# requests a ratio, the device feature is
+                    // enabled, and filtering is linear (Vulkan requires anisotropyEnable only with linear
+                    // mag/min filters). maxAnisotropy = 1<<ratio, clamped to the device ceiling. ratio 0
+                    // (isotropic) leaves anisotropyEnable false -> the sampler is unchanged.
+                    if (r.max_aniso_ratio > 0 && aniso_enabled &&
+                        sci.magFilter == VK_FILTER_LINEAR && sci.minFilter == VK_FILTER_LINEAR) {
+                        sci.anisotropyEnable = VK_TRUE;
+                        float want = (float)(1u << r.max_aniso_ratio);
+                        sci.maxAnisotropy = want < max_aniso_limit ? want : max_aniso_limit;
+                    }
                     // NOT applied here (need machinery the current path lacks — decoded under GFXLOG only):
-                    //   anisotropy (needs the samplerAnisotropy device feature), depth_compare_func (needs a
-                    //   depth/shadow sampler over a depth image), unnormalized coords (strict validity rules).
+                    //   depth_compare_func (needs a depth/shadow sampler over a depth image),
+                    //   unnormalized coords (strict validity rules + recompiler coord semantics).
                     switch (r.border_color_type) {
                         case 1:  sci.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK; break;
                         case 2:  sci.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE; break;
@@ -629,7 +652,7 @@ inline std::vector<uint8_t> render_triangle_rgba(const std::vector<uint32_t>& ve
             FrameResource b2; b2.binding = 2; b2.set = s2; if (cbuf) b2.dwords = *cbuf; d.R.push_back(std::move(b2));
             FrameResource b3; b3.binding = 3; b3.set = s2; if (vbuf) b3.dwords = *vbuf; d.R.push_back(std::move(b3));
         }
-        if (tex) { FrameResource t; t.binding = tex->binding; t.set = 1; t.tex_rgba = tex->rgba; t.tw = tex->w; t.th = tex->h; d.R.push_back(std::move(t)); }
+        if (tex) { FrameResource t; t.binding = tex->binding; t.set = 1; t.tex_rgba = tex->rgba; t.tw = tex->w; t.th = tex->h; t.max_aniso_ratio = tex->max_aniso_ratio; d.R.push_back(std::move(t)); }
     }
     return render_draws_rgba({std::move(d)}, W, H);
 }

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -81,6 +81,26 @@ int main() {
     printf("  (0.25,0.75) center=(%u,%u,%u)\n", ok2?rgb[0]:0, ok2?rgb[1]:0, ok2?rgb[2]:0);
     CHECK(ok2 && rgb[2] > 0x80 && rgb[0] < 0x40 && rgb[1] < 0x40, "sampling texel (0,1) yields BLUE (proves v routing)");
 
+    // #275: anisotropy applied. A sampler built with max_aniso_ratio > 0 (here 4 -> 16x) must create
+    // validly and still sample correctly — the fullscreen quad isn't minified, so aniso changes nothing
+    // about the result, but a broken apply (invalid usage / wrong sampler) would blank the frame or move
+    // the texel. Same (0.75,0.25) -> texel (1,0) = GREEN check, now through the anisotropic sampler.
+    {
+        prosper::test::TexDesc td_a{ /*binding*/4, /*w*/2, /*h*/2, texels, /*max_aniso_ratio*/4u };
+        std::vector<uint32_t> ps(ps_template, ps_template + sizeof(ps_template)/sizeof(ps_template[0]));
+        ps[1] = C075; ps[3] = C025;
+        std::vector<uint32_t> frag = recompile_fragment(ps.data(), ps.size(), &rt);
+        bool okA = !frag.empty() && frag[0] == 0x07230203u;
+        if (okA) {
+            std::vector<uint8_t> px = prosper::test::render_triangle_rgba(vert, frag, W, H, nullptr, nullptr, nullptr, &td_a);
+            okA = px.size() == (size_t)W*H*4;
+            if (okA) { const uint8_t* c = &px[((size_t)(H/2)*W + W/2)*4]; rgb[0]=c[0]; rgb[1]=c[1]; rgb[2]=c[2]; }
+        }
+        printf("  aniso(16x) (0.75,0.25) center=(%u,%u,%u)\n", okA?rgb[0]:0, okA?rgb[1]:0, okA?rgb[2]:0);
+        CHECK(okA && rgb[1] > 0x80 && rgb[0] < 0x40 && rgb[2] < 0x40,
+              "anisotropic sampler (ratio 4/16x) still samples texel (1,0) = GREEN (valid apply)");
+    }
+
     // image_load (integer texel fetch, no sampler): x,y = inline-int coords into v0,v1; image_load
     // v[0:3], v[0:1], s[8:15]; exp mrt0. Coord (x,y) directly indexes the texel — no filtering.
     const uint32_t il_template[] = {


### PR DESCRIPTION
Partially addresses #275 — implements the **anisotropy** checkbox (of three). Depth-compare and unnormalized-coords stay open (see below).

## Problem
`max_aniso_ratio` (SQ_IMG_SAMP WORD0[11:9]) was decoded and logged under `PROSPER_GFXLOG` but never applied — the combined-image-sampler path had no machinery for it, so an anisotropic-filtering request from the game's S# was silently dropped.

## Fix
- `render_draws_rgba` enables the `samplerAnisotropy` device feature **only when the physical device advertises it** (a headless/software device may not — enabling unconditionally would make sampler creation with `anisotropyEnable` invalid usage), and captures `maxSamplerAnisotropy` as the clamp ceiling.
- The sampler sets `anisotropyEnable` + `maxAnisotropy = min(1<<ratio, limit)` when the S# requests `ratio > 0` **and** filtering is linear (Vulkan requires anisotropy only with linear mag/min filters). `ratio 0` (isotropic) leaves the sampler byte-identical.
- `FrameResource` gains `max_aniso_ratio`; `live_renderer.cpp`'s `build_R` carries it from the decoded `ShaderResource`.

## Verification
- `test_texture_sample_render` gains an anisotropic-sampler case (ratio 4 / 16×): the same `(0.75,0.25) → texel (1,0) = GREEN` routing still holds through the anisotropic sampler. A broken apply (invalid usage / wrong sampler) would blank the frame or move the texel.
- Full `ctest` **68/68 green**.
- `messenger-scene` golden-image guard **unchanged (24318 colours)** — The Messenger decodes `ratio 0`, so this is a no-op for it; the change is correctness for lit/3D titles that request anisotropic filtering.

## Still open on #275
- **Depth-compare** (`depth_compare_func`): needs a real depth/shadow sampling path (sampled image must be a depth format + `compareEnable`); no current title exercises it. Applying `compareEnable` on our color-UNORM sampled images is invalid usage, so it's blocked on a shadow-map bind path.
- **Unnormalized coords** (`unnormalized`): needs a guarded apply meeting Vulkan's strict constraints (single mip, equal filters, clamp addressing, `minLod==maxLod==0`, no compare/aniso) *and* matching recompiler coordinate semantics; deferred.