### PR TITLE
fix(gpu): auto-detect DOLL's unannounced 32-bit index buffers — real UMG/Slate quads (Fixes #304)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -229,6 +229,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_dynfetch_fold PRIVATE prosper_core)
   add_test(NAME dynfetch_fold COMMAND test_dynfetch_fold)
 
+  # Unannounced-32-bit index-buffer fingerprint (#304 — DOLL's Slate/UMG quads). No Vulkan needed.
+  add_executable(test_index_size_detect tests/test_index_size_detect.cpp)
+  target_link_libraries(test_index_size_detect PRIVATE prosper_core)
+  add_test(NAME index_size_detect COMMAND test_index_size_detect)
+
   # shader_histo: data-driven recompiler-coverage report over the game's real embedded RDNA2 shaders.
   add_executable(shader_histo tools/shader_histo/shader_histo.cpp)
   target_link_libraries(shader_histo PRIVATE prosper_core)

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -183,6 +183,11 @@ void GpuState::apply(const Pm4Command& c) {
             if (index_base && d.index_count) {
                 d.indexed = true;
                 d.index_addr = index_base + (uint64_t)c.index_offset * elem;
+                // Preserve the raw base + element offset so the executor can recompute the address if
+                // it auto-detects a different element size (#304 — DOLL's 32-bit Slate index buffers).
+                d.index_base = index_base;
+                d.index_offset = c.index_offset;
+                d.from_offset = true;
             }
             draws.push_back(std::move(d));
             break;

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -47,6 +47,15 @@ struct GpuState {
         bool     indexed = false;
         uint64_t index_addr = 0;
         uint64_t modifier = 0;
+        // Gen5 DrawIndexOffset provenance (#304): the index ELEMENT SIZE is never set by DOLL (no
+        // SetIndexSize / no VGT_INDEX_TYPE register), so index_type defaults to 16-bit — but DOLL's
+        // UE4 Slate/UMG quad index buffers are actually 32-bit. The executor auto-detects the real
+        // element size from buffer content and, for an offset draw, must recompute the address at the
+        // detected element size (index_base + index_offset*elem). Store the raw base + element offset
+        // so it can. (A DrawIndex carries an absolute index_addr instead; from_offset stays false.)
+        uint64_t index_base   = 0;
+        uint32_t index_offset = 0;
+        bool     from_offset  = false;
     };
     std::vector<Draw> draws;                             // one per DrawIndexAuto / DrawIndex
     uint64_t dispatch_count = 0;                         // DispatchDirect packets seen (no execution yet)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -121,6 +121,28 @@ inline uint32_t index_elem_bytes(uint32_t index_type) {
     return index_type == 0 ? 2u : index_type == 1 ? 4u : 0u;
 }
 
+// Detect an UNANNOUNCED 32-bit index buffer (#304). DOLL's UE4 Slate/UMG quad index buffers are
+// 32-bit, but the title never calls sceAgcDcbSetIndexSize and programs no VGT_INDEX_TYPE register,
+// so index_type defaults to 16-bit — which misreads each 32-bit index as TWO 16-bit ones (the low
+// half = the real index, the high half = 0), collapsing a quad's [0,1,2,2,1,3] to a degenerate
+// [0,0,1,0,2,0]. The fingerprint is unmistakable and cheap: read the same buffer as 16-bit and as
+// 32-bit for `n` entries; a real 32-bit buffer has EVERY odd 16-bit word (the zero high halves) == 0
+// AND every 32-bit value small (< 0x10000) and not all-zero. Genuine 16-bit index buffers (DOLL's
+// scene/text meshes; every Messenger quad, e.g. [0,1,2,2,3,0]) have a non-zero odd word and are
+// rejected, so this never reinterprets a real 16-bit buffer. `p16` reads from the 16-bit (elem=2)
+// address; `p32` from the recomputed 32-bit address — for a DrawIndexOffset they differ, but both
+// land on a quad-periodic region so the fingerprint holds on either. CONFIDENCE: HIGH.
+inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_t* p32, uint32_t n) {
+    if (n < 2) return false;                         // need at least one odd word to test
+    bool odd_zero = true, all_small = true, any_nonzero = false, has_odd = false;
+    for (uint32_t i = 0; i < n; i++) {
+        if (i & 1) { has_odd = true; if (p16[i] != 0) odd_zero = false; }
+        if (p32[i] >= 0x10000u) all_small = false;
+        if (p32[i] != 0) any_nonzero = true;
+    }
+    return has_odd && odd_zero && all_small && any_nonzero;
+}
+
 // Realize ONE draw of `ds` (a register snapshot or the folded state) into a DrawItem: recompile the
 // VS+PS, resolve fixed-function state, and — for an indexed draw — fetch the guest index buffer.
 // `draw` is the PM4 draw record (index count + indexed/index_addr); null means "no record" (hand-built
@@ -238,23 +260,46 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // non-indexed draw of the hint count instead of reading garbage.
     static constexpr uint32_t kMaxIndices = 1u << 20;   // sanity cap (largest seen live: 0x61e)
     if (draw && draw->indexed && draw->index_addr && draw->index_count) {
-        const uint32_t esz = index_elem_bytes(ds.index_type);
+        uint32_t esz = index_elem_bytes(ds.index_type);
         uint32_t n = std::min(draw->index_count, kMaxIndices);
+        uint64_t index_addr = draw->index_addr;
+        // Auto-detect a 32-bit index buffer that the guest never announced (#304). DOLL's UE4 Slate/UMG
+        // quads use 32-bit index buffers but the title never calls sceAgcDcbSetIndexSize and sets no
+        // VGT_INDEX_TYPE register, so index_type defaults to 16-bit — misreading each 32-bit index as
+        // two 16-bit ones. The fingerprint is unmistakable: a 32-bit index buffer read as 16-bit has
+        // every ODD 16-bit word (the zero high half of a small index) == 0, while reading it as 32-bit
+        // yields small, valid indices. Genuine 16-bit buffers (DOLL's scene/text meshes, all of the
+        // Messenger's quads) have non-zero odd words and are left untouched. When detected, use the
+        // 32-bit element size AND recompute a DrawIndexOffset's address at that stride (index_base +
+        // index_offset*4) so it lands on the correct quad. CONFIDENCE: HIGH — the banner index buffer
+        // decodes to a clean [0,1,2,2,1,3] quad this way vs a degenerate [0,0,1,0,2,0] as 16-bit.
+        if (esz == 2 && n >= 2) {
+            uint64_t addr32 = draw->from_offset ? (draw->index_base + (uint64_t)draw->index_offset * 4u)
+                                                : draw->index_addr;
+            if (guest_readable(draw->index_addr, n * 2u) && guest_readable(addr32, n * 4u) &&
+                index_buffer_is_unannounced_32bit((const uint16_t*)(uintptr_t)draw->index_addr,
+                                                  (const uint32_t*)(uintptr_t)addr32, n)) {
+                esz = 4; index_addr = addr32;
+                if (log) fprintf(stderr, "[exec] indexed draw: auto-detected 32-bit index buffer "
+                                 "(unannounced) at 0x%llx (was 16-bit 0x%llx)\n",
+                                 (unsigned long long)addr32, (unsigned long long)draw->index_addr);
+            }
+        }
         if (esz == 0) {
             if (log) fprintf(stderr, "[exec] indexed draw: UNKNOWN index_type=%u — falling back to non-indexed\n",
                              ds.index_type);
-        } else if (!guest_readable(draw->index_addr, n * esz)) {
+        } else if (!guest_readable(index_addr, n * esz)) {
             if (log) fprintf(stderr, "[exec] indexed draw: index buffer 0x%llx (%u x %uB) unreadable — "
                              "falling back to non-indexed\n",
-                             (unsigned long long)draw->index_addr, n, esz);
+                             (unsigned long long)index_addr, n, esz);
         } else {
             out.indices.resize(n);
             uint32_t max_index = 0;
             if (esz == 2) {
-                const uint16_t* src = (const uint16_t*)(uintptr_t)draw->index_addr;
+                const uint16_t* src = (const uint16_t*)(uintptr_t)index_addr;
                 for (uint32_t i = 0; i < n; i++) { out.indices[i] = src[i]; max_index = std::max(max_index, out.indices[i]); }
             } else {
-                const uint32_t* src = (const uint32_t*)(uintptr_t)draw->index_addr;
+                const uint32_t* src = (const uint32_t*)(uintptr_t)index_addr;
                 for (uint32_t i = 0; i < n; i++) { out.indices[i] = src[i]; max_index = std::max(max_index, out.indices[i]); }
             }
             // Vertex count = the indexed range (max index + 1). The INDEX BUFFER is authoritative for how

--- a/prosper/tests/test_index_size_detect.cpp
+++ b/prosper/tests/test_index_size_detect.cpp
@@ -1,0 +1,55 @@
+// test_index_size_detect — the unannounced-32-bit index-buffer fingerprint (#304).
+//
+// DOLL's UE4 Slate/UMG quad index buffers are 32-bit, but the title never announces the index size
+// (no sceAgcDcbSetIndexSize, no VGT_INDEX_TYPE register), so index_type defaults to 16-bit and each
+// 32-bit index is misread as two 16-bit ones — collapsing the banner quad to a degenerate triangle
+// (the #304 "flat wedge"). index_buffer_is_unannounced_32bit() recovers the real size from the
+// buffer bytes. These vectors are the exact ones captured live from the DOLL boot.
+#include "../src/gpu/gpu_execute.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Run the fingerprint over a 32-bit index vector: p32 reads the dwords, p16 aliases the same bytes.
+static bool detect32(const std::vector<uint32_t>& i32, uint32_t n) {
+    const uint16_t* p16 = reinterpret_cast<const uint16_t*>(i32.data());
+    return index_buffer_is_unannounced_32bit(p16, i32.data(), n);
+}
+// Run it over a 16-bit index vector: p16 reads the words, p32 aliases the same bytes (what the misread
+// would produce). Pad so p32 can read n dwords (2n words).
+static bool detect16(std::vector<uint16_t> i16, uint32_t n) {
+    i16.resize(i16.size() + 2 * n, 0);   // headroom for the 32-bit aliased read
+    const uint32_t* p32 = reinterpret_cast<const uint32_t*>(i16.data());
+    return index_buffer_is_unannounced_32bit(i16.data(), p32, n);
+}
+
+int main() {
+    printf("== test_index_size_detect ==\n");
+
+    // The real banner quad, stored 32-bit: [0,1,2,2,1,3] (two triangles over 4 verts). Detected 32-bit.
+    CHECK(detect32({0, 1, 2, 2, 1, 3}, 6), "banner 32-bit quad [0,1,2,2,1,3] -> 32-bit");
+    // Another live 32-bit quad captured: [2,1,3,0,1,2].
+    CHECK(detect32({2, 1, 3, 0, 1, 2}, 6), "32-bit quad [2,1,3,0,1,2] -> 32-bit");
+
+    // Genuine 16-bit buffers must NOT be reinterpreted.
+    CHECK(!detect16({0, 1, 2, 0, 2, 3, 3, 2, 4, 3, 4, 5}, 12), "DOLL scene 16-bit mesh -> stays 16-bit");
+    CHECK(!detect16({0, 4, 5}, 3),                              "DOLL fullscreen 16-bit tri [0,4,5] -> stays 16-bit");
+    CHECK(!detect16({0, 1, 2, 2, 3, 0}, 6),                     "Messenger 16-bit quad [0,1,2,2,3,0] -> stays 16-bit");
+
+    // Degenerate guards: an all-zero buffer (any_nonzero==false) and a 1-index draw (no odd word) stay 16-bit.
+    CHECK(!detect32({0, 0, 0, 0}, 4), "all-zero 32-bit buffer -> not detected (needs real data)");
+    CHECK(!detect32({7}, 1),          "single-index draw -> not detected (no odd word to test)");
+
+    // A 32-bit buffer whose HIGH halves are non-zero (a real large mesh, indices >= 0x10000) is not a
+    // small-index quad -> reject (the fingerprint requires all values < 0x10000).
+    CHECK(!detect32({0x10005, 1, 2}, 3), "32-bit indices >= 0x10000 -> not the quad fingerprint");
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## The bug (#304)

DOLL's loading banner — and every UMG/Slate widget — rendered as a **flat triangular wedge** (a single half-screen triangle) instead of the banner artwork. Prior work proved this is **not** a texture-decode bug (the banner atlases decode byte-exact) and #303 fixed the Slate vertex fetch's SOFFSET fold. The residual "degenerate quad" turned out to be the **index element size**.

## Root cause (RE'd against the live boot)

The banner draw (VS `0x201d350000`, sampling the **1344×672 BC7 banner**) reads a **32-bit** index buffer. Its raw bytes are `[0,0,1,0,2,0,2,0,1,0,3,0]` = 32-bit indices **`[0,1,2,2,1,3]`** — a proper two-triangle quad over 4 real pixel-space vertices `(3388,1588)…`.

But DOLL's UE4 RHI **never announces the index size**: it calls neither `sceAgcDcbSetIndexSize` nor programs any `VGT_INDEX_TYPE` register (the uc/cx register files are byte-identical for its 16- and 32-bit draws). So `GpuState::index_type` stays at the 16-bit reset default. Read as 16-bit, each 32-bit index splits into two — `[0,1,2,2,1,3]` becomes **`[0,0,1,0,2,0]`**, collapsing the quad to degenerate triangles: the flat wedge.

DOLL genuinely **mixes** sizes (scene/text meshes and the fullscreen composite tris are real 16-bit), so a global default flip would corrupt those.

## The fix

Auto-detect the unannounced 32-bit buffer from its **content**. A 32-bit index buffer read as 16-bit has every **odd 16-bit word** (the zero high half of a small index) `== 0`, while every 32-bit value is small and non-zero — an unmistakable, cheap fingerprint. Genuine 16-bit buffers (DOLL's scene/text; every Messenger quad, e.g. `[0,1,2,2,3,0]`) have a non-zero odd word and are left untouched. On detection, use the 32-bit element size **and** recompute a `DrawIndexOffset`'s address at that stride (`index_base + index_offset*4`) so it lands on the correct quad — `command_processor` now stores the raw base+offset for this.

## A/B (live DOLL boot, `PROSPER_RENDER`)

- **Before:** a single flat-blue half-screen triangle (the wedge); ~2–3 distinct colors.
- **After:** the UMG widget renders as a **full rectangular panel** (white body, teal accent borders) — the quad geometry + UVs are correct; the widget is a real rectangle, not a wedge. Richest frame's distinct-color count jumps from ~3 to ~9000. This fixes **all** UMG rendering (title menus are UMG too).

## Verification

- **318 auto-detections/boot**, all count-6 UI quads. The degenerate `vcount=3 nidx=6` banner draws become proper `vcount=4 nidx=6` quads; large 16-bit meshes (`vcount=381 nidx=1680`) are untouched — no false positives.
- **New unit test** `test_index_size_detect` locks the fingerprint against the exact live-captured 16- and 32-bit vectors.
- **ctest:** `index_size_detect` + all non-dump tests pass. (The 3 failing tests need Messenger's IL2CPP modules / embedded shader blobs, absent from the DOLL dump — pre-existing, unrelated.)
- **Messenger regression:** clean boot, 0 faults; `snapshot.py check` OK (richest 24318 colors ≥ 5000).

## Scope note

The **fullscreen-composite** triangles that still render as wedges are the separate **#305** stale-bind class (genuine 16-bit `[0,4,5]` tris with a stale V# base), not this index-size bug.