### PR TITLE
fix(hle): implement libkernel/posix signal + time-conversion stubs (#190)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -213,6 +213,12 @@ if(TARGET prosper_core)
       PROSPER_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
   add_test(NAME messenger_recompile_guard COMMAND test_messenger_recompile_guard)
 
+  # libkernel/libScePosix signal + time-conversion surface (#190): NID match, registration, and real
+  # behavior (UTC<->localtime round-trip fills its out-param; pthread_setcancelstate old-state + EINVAL).
+  add_executable(test_kernel_signal_time tests/test_kernel_signal_time.cpp)
+  target_link_libraries(test_kernel_signal_time PRIVATE prosper_core)
+  add_test(NAME kernel_signal_time COMMAND test_kernel_signal_time)
+
   # Pipeline-state resolution: RenderState (RDNA2 enums) -> Vulkan-ready pipeline state (pure, no Vulkan).
   add_executable(test_pipeline_state tests/test_pipeline_state.cpp)
   target_link_libraries(test_pipeline_state PRIVATE prosper_core)

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -884,6 +884,85 @@ HLE(k_add_timer_event) {   // (eq, id, usec, udata) — coarse timer, same one-s
     return 0;
 }
 
+// --- libkernel/libScePosix signal + time-conversion surface (#190) ---
+// PPSA02664 calls these; previously all fell to the generic unimplemented stub (return 0), which for
+// the time-convert pair left the caller's out-param uninitialized (cf. #82 — garbage time_t out).
+
+// Host UTC offset (seconds EAST of UTC) and DST flag for a given unix time, portably. The convert
+// functions below approximate the offset by running the HOST timezone over the input instant — the
+// same approach shadPS4 takes; it is exact except within the ~1 h wall-clock ambiguity of a DST
+// transition, which no title depends on. CONFIDENCE: HIGH for the offset itself.
+static void host_local_offset(time_t t, long& gmtoff_sec, int& isdst) {
+    struct tm lt{};
+#ifdef _WIN32
+    localtime_s(&lt, &t);
+    // Windows struct tm has no tm_gmtoff: reinterpret the local wall values as UTC and diff. The
+    // isdst flag from localtime_s drives the DST-seconds field below.
+    time_t as_utc = _mkgmtime64(&lt);
+    gmtoff_sec = (long)(as_utc - t);
+    isdst = lt.tm_isdst;
+#else
+    localtime_r(&t, &lt);
+    gmtoff_sec = lt.tm_gmtoff;
+    isdst = lt.tm_isdst;
+#endif
+}
+
+// OrbisTimesec out-struct written by both convert functions: { s64 t; u32 west_sec; u32 dst_sec }
+// (shadPS4 time_management OrbisTimesec). `west_sec` is seconds WEST of UTC (= -gmtoff); `dst_sec` is
+// the DST correction in seconds. CONFIDENCE: MED on the struct's field semantics; the primary
+// converted-time out-param (filled first, and what callers actually read) is HIGH.
+static void fill_timesec(void* p, int64_t converted, long gmtoff_sec, int isdst) {
+    uint8_t* b = (uint8_t*)p;
+    int64_t  t = converted;             memcpy(b + 0, &t, 8);
+    uint32_t west = (uint32_t)(-gmtoff_sec); memcpy(b + 8, &west, 4);
+    uint32_t dst  = (uint32_t)(isdst > 0 ? 3600 : 0); memcpy(b + 12, &dst, 4);
+}
+
+// sceKernelConvertUtcToLocaltime(time_t utc, time_t* local_out, OrbisTimesec* st, u64* dst_sec).
+// local = utc + gmtoff. CONFIDENCE: MED-HIGH (shadPS4 prototype; primary out-param HIGH).
+HLE(k_convert_utc_to_local) {
+    time_t utc = (time_t)(int64_t)a0;
+    long gmtoff; int isdst; host_local_offset(utc, gmtoff, isdst);
+    int64_t local = (int64_t)utc + (int64_t)gmtoff;
+    if (a1) *(int64_t*)P(a1) = local;
+    if (a2) fill_timesec(P(a2), local, gmtoff, isdst);
+    if (a3) *(uint64_t*)P(a3) = (uint64_t)(isdst > 0 ? 3600 : 0);
+    return 0;
+}
+
+// sceKernelConvertLocaltimeToUtc(time_t local, u64 unk, time_t* utc_out, OrbisTimesec* st, u64* dst).
+// utc = local - gmtoff. The 2nd arg is an unused/opaque u64 in the shadPS4 prototype, so the UTC
+// result is at a2. CONFIDENCE: MED (prototype incl. the a1 gap; primary out-param HIGH).
+HLE(k_convert_local_to_utc) {
+    time_t local = (time_t)(int64_t)a0;
+    long gmtoff; int isdst; host_local_offset(local, gmtoff, isdst);
+    int64_t utc = (int64_t)local - (int64_t)gmtoff;
+    if (a2) *(int64_t*)P(a2) = utc;
+    if (a3) fill_timesec(P(a3), utc, gmtoff, isdst);
+    if (a4) *(uint64_t*)P(a4) = (uint64_t)(isdst > 0 ? 3600 : 0);
+    return 0;
+}
+
+// pthread_setcancelstate(int state, int* old_state) — Orbis enum 0=ENABLE, 1=DISABLE (Kyty
+// PthreadSetcancelstate). prosper never cancels guest threads, so cancellation is a no-op; we validate
+// the state, report the POSIX default ENABLE(0) as the previous state, and return OK. (No per-thread
+// tracking: a host thread_local here pulls TLS-init machinery into the runtime that perturbs the
+// guest-%fs handling enough to break the Messenger boot — and the tracked value is unobservable since
+// nothing is ever cancelled.) CONFIDENCE: HIGH.
+HLE(k_pthread_setcancelstate) {
+    int state = (int)a0;
+    if (state != 0 && state != 1) return 0x80020016ull;   // EINVAL
+    if (a1) *(int*)P(a1) = 0;                              // previous state = ENABLE (default)
+    return 0;
+}
+
+// Signal machinery we do not model (guest runs natively; no guest-directed POSIX signals). Explicit
+// no-ops so they resolve here instead of the unimplemented logger. _sigprocmask's callers pass a null
+// oldset in the boot path; returning 0 (success, mask unchanged) is the correct no-op. CONFIDENCE: HIGH.
+HLE(k_sigprocmask_noop)    { return 0; }
+HLE(k_is_signal_return)    { return 0; }   // "is this frame a signal return?" — never, for us
+
 void register_kernel_time_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("sceKernelCreateEqueue", k_eq_create);   R("sceKernelDeleteEqueue", k_eq_delete);
@@ -942,6 +1021,12 @@ void register_kernel_time_hle() {
     R("_Mtx_destroy", m_mtx_destroy);
     R("_Cnd_init", m_cnd_init);   R("_Cnd_signal", m_cnd_signal); R("_Cnd_broadcast", m_cnd_broadcast);
     R("_Cnd_wait", m_cnd_wait);   R("_Cnd_destroy", m_cnd_destroy);
+    // libkernel/libScePosix signal + time-conversion surface (#190)
+    R("sceKernelConvertUtcToLocaltime", k_convert_utc_to_local);
+    R("sceKernelConvertLocaltimeToUtc", k_convert_local_to_utc);
+    R("pthread_setcancelstate", k_pthread_setcancelstate);
+    R("_sigprocmask", k_sigprocmask_noop);
+    R("_is_signal_return", k_is_signal_return);
     #undef R
 }
 

--- a/prosper/tests/test_kernel_signal_time.cpp
+++ b/prosper/tests/test_kernel_signal_time.cpp
@@ -1,0 +1,78 @@
+// test_kernel_signal_time (#190) — the libkernel/libScePosix signal + time-conversion surface that
+// PPSA02664 imports and that previously fell to the generic unimplemented stub. Verifies each name
+// hashes to the exact import NID the game uses (so the import resolves to our impl), that all five are
+// registered, and the real behavior: the UTC<->localtime pair round-trips and fills its out-param,
+// and pthread_setcancelstate reports the previous state + rejects a bad state.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_kernel_signal_time ==\n");
+    register_builtin_hle();
+
+    // Name -> NID must match the game's imports (#190 table), else the import never reaches our impl.
+    struct { const char* name; const char* nid; } syms[] = {
+        { "_sigprocmask",                    "6xVpy0Fdq+I" },
+        { "_is_signal_return",               "crb5j7mkk1c" },
+        { "sceKernelConvertLocaltimeToUtc",  "0NTHN1NKONI" },
+        { "sceKernelConvertUtcToLocaltime",  "-o5uEDpN+oY" },
+        { "pthread_setcancelstate",          "lZzFeSxPl08" },
+    };
+    for (auto& s : syms) {
+        std::string h = nid_hash(s.name);
+        char msg[160]; snprintf(msg, sizeof msg, "%s hashes to its import NID %s (got %s)", s.name, s.nid, h.c_str());
+        CHECK(h == s.nid, msg);
+        snprintf(msg, sizeof msg, "%s is registered (resolves to a real impl, not the stub)", s.name);
+        CHECK(Hle::lookup(s.nid) != nullptr, msg);
+    }
+
+    HleFn utc2local = Hle::lookup("-o5uEDpN+oY");
+    HleFn local2utc = Hle::lookup("0NTHN1NKONI");
+    HleFn setcancel = Hle::lookup("lZzFeSxPl08");
+    if (!utc2local || !local2utc || !setcancel) { printf("== FAIL (unresolved) ==\n"); return 1; }
+
+    // UTC -> localtime -> UTC round-trips exactly (tz-independent: whatever the host offset is, the
+    // inverse conversion undoes it). Also proves both fill their primary out-param (pre-seeded with a
+    // sentinel that must be overwritten). 1e9 = 2001-09-09 UTC, a plain non-DST-edge instant.
+    const int64_t UTC = 1000000000;
+    int64_t local = (int64_t)0x0BADF00D, back = (int64_t)0x0BADF00D;
+    uint64_t r1 = utc2local((uint64_t)UTC, (uint64_t)(uintptr_t)&local, 0, 0, 0, 0);
+    CHECK(r1 == 0, "ConvertUtcToLocaltime returns OK");
+    CHECK(local != (int64_t)0x0BADF00D, "ConvertUtcToLocaltime WROTE the local-time out-param (was uninitialized before)");
+    uint64_t r2 = local2utc((uint64_t)local, 0 /*unk*/, (uint64_t)(uintptr_t)&back, 0, 0, 0);
+    CHECK(r2 == 0, "ConvertLocaltimeToUtc returns OK");
+    CHECK(back != (int64_t)0x0BADF00D, "ConvertLocaltimeToUtc WROTE the utc out-param (result is at arg index 2)");
+    CHECK(back == UTC, "UTC -> localtime -> UTC round-trips exactly (offset applied then undone)");
+
+    // The OrbisTimesec struct out-param (arg 2) is filled: its first field is the converted time.
+    int64_t ts_buf[2] = { (int64_t)0x0BADF00D, 0 };
+    utc2local((uint64_t)UTC, (uint64_t)(uintptr_t)&local, (uint64_t)(uintptr_t)ts_buf, 0, 0, 0);
+    CHECK(ts_buf[0] == local, "ConvertUtcToLocaltime fills OrbisTimesec.t with the converted time");
+
+    // pthread_setcancelstate: valid states return OK and write the previous state (ENABLE(0), the POSIX
+    // default — prosper never cancels guest threads, so no per-thread state is tracked); a NULL out-ptr
+    // is fine; an out-of-range state is EINVAL. (A host thread_local for real tracking broke the boot —
+    // see the impl comment — and its value would be unobservable anyway.)
+    int oldst = -1;
+    uint64_t c1 = setcancel(1 /*DISABLE*/, (uint64_t)(uintptr_t)&oldst, 0, 0, 0, 0);
+    CHECK(c1 == 0 && oldst == 0, "setcancelstate(DISABLE) -> OK, writes previous state ENABLE(0)");
+    oldst = -1;
+    uint64_t c2 = setcancel(0 /*ENABLE*/, (uint64_t)(uintptr_t)&oldst, 0, 0, 0, 0);
+    CHECK(c2 == 0 && oldst == 0, "setcancelstate(ENABLE) -> OK, writes previous state ENABLE(0)");
+    uint64_t c2b = setcancel(1 /*DISABLE*/, 0 /*NULL old*/, 0, 0, 0, 0);
+    CHECK(c2b == 0, "setcancelstate with NULL old_state -> OK (no write)");
+    uint64_t c3 = setcancel(7 /*invalid*/, 0, 0, 0, 0, 0);
+    CHECK(c3 == 0x80020016ull, "setcancelstate(invalid) -> EINVAL");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #190.

## Problem
PPSA02664 imports five low-level libkernel/libScePosix functions that all fell to the generic unimplemented stub (`return 0`). For the time-convert pair that left the caller's out-param **uninitialized** — a garbage `time_t` handed back to the engine (the #82 class of bug).

## Fix
- **`sceKernelConvertUtcToLocaltime` / `sceKernelConvertLocaltimeToUtc`** — convert via the host timezone (`localtime_r`'s `tm_gmtoff`; a portable `_mkgmtime` diff on Windows) and fill the result out-param plus the `OrbisTimesec` struct. *CONFIDENCE: MED* on the exact shadPS4 prototype (incl. `ConvertLocaltimeToUtc`'s opaque 2nd arg, result at arg 2); *HIGH* on the primary converted-time out-param callers actually read. Every write is null-guarded.
- **`pthread_setcancelstate`** — validate the Orbis state enum (0=ENABLE / 1=DISABLE, per Kyty), write the previous state (ENABLE default), return OK; EINVAL on bad input.
- **`_sigprocmask` / `_is_signal_return`** — explicit no-ops (signal machinery prosper doesn't model — the guest runs natively), so they resolve here instead of the unimplemented logger.

## A non-obvious boot gotcha (found and avoided)
The first draft tracked per-thread cancel state in a host `thread_local`. That **deterministically broke the Messenger boot** (`boot_reaches_first_syscall` went red 5/5) — even though `setcancelstate` is *never called* during boot. Root cause: the TLS-init machinery a referenced `thread_local` pulls into the HLE runtime perturbs prosper's guest-`%fs` handling. Confirmed by bisect (pure-`return 0` body passed 5/5; full body with the `thread_local` failed 5/5; the debug print proved the function body never executes). Dropped the `thread_local` — the tracked value is unobservable anyway since prosper never cancels a guest thread.

## Verification
- New `kernel_signal_time` test: asserts each name hashes to the **exact game import NID** (so the import resolves to our impl), all five register, the UTC↔localtime pair **round-trips exactly** and fills its out-param (pre-seeded sentinel must be overwritten), and `setcancelstate`'s state / old-state / EINVAL contract.
- Full `ctest` **70/70 green**.
- `boot_reaches_first_syscall` **3/3 green** with all five registered (the boot-perturbation regression is gone).