### PR TITLE
feat(gpu): sceAgcDcbJump + SetPredication/SetPacketPredication — execute DOLL's predicated backbuffer-composite segments (refs #319)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -15,6 +15,10 @@ extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx, uint32
 
 namespace prosper::gpu {
 
+// Readability probe (gpu_executor.cpp, declared in gpu_execute.hpp): page-granular check that a
+// guest range is mapped, so the Jump fold below never walks an unmapped segment address.
+bool guest_readable(uint64_t addr, uint32_t bytes);
+
 // Wake any thread blocked in sync_on_address (a futex) on `addr`. A GPU completion label write only
 // changes memory; a futex waiter does NOT wake on a value change — it needs an explicit FUTEX_WAKE. The
 // game's render/producer threads sync_on_address on the very labels the GPU writes via RELEASE_MEM /
@@ -260,6 +264,53 @@ void GpuState::apply(const Pm4Command& c) {
             // the stream — it only leaves compute-written buffers stale (surfaced by the counter).
             dispatch_count++;
             break;
+        case K::SetPredication:
+            // Begin/end a GPU predication window (#319). The begin form carries the condition
+            // address; the end form carries 0. A short-decoded packet conservatively ENDS the
+            // window (never leaves a stale condition gating later jumps).
+            pred_cond_addr = c.pred_valid ? c.pred_addr : 0;
+            break;
+        case K::Jump: {
+            // sceAgcDcbJump (#319): execute `jump_dwords` dwords at `jump_addr`, then resume
+            // (call-with-length — live capture shows the target segment is exactly the passed
+            // size, no jump-back packet, and the parent stream continues after the jump).
+            //
+            // Predication: a packet-predicated jump (jump_pred, set by sceAgcSetPacketPredication)
+            // inside an open SetPredication window executes only when the 64-bit condition reads 0
+            // at fold time. POLARITY (CONFIDENCE: MED, empirically pinned on DOLL's title): the
+            // predicated jump segments are the game's per-frame backbuffer composite draws — a
+            // title frame REQUIRES the composite every frame on real hardware, and the condition
+            // memory reads 0 throughout the title steady state, so 0 must mean "execute" here
+            // ("skip when non-zero", matching PM4 SET_PREDICATION's draw-discard-on-set model).
+            if (!c.jump_valid || !c.jump_addr || (c.jump_addr & 3) || !c.jump_dwords) break;
+            // PROSPER_NO_JUMP=1: diagnostic A/B — reproduce the pre-#319 behavior (jump ignored).
+            static const bool no_jump = [] { const char* e = getenv("PROSPER_NO_JUMP"); return e && e[0] == '1'; }();
+            if (no_jump) break;
+            constexpr uint32_t kMaxJumpDwords = 0x40000;   // 1 MiB of dwords — far past any real segment
+            constexpr uint32_t kMaxJumpDepth  = 8;
+            if (c.jump_dwords > kMaxJumpDwords || jump_depth >= kMaxJumpDepth) break;
+            bool skip = false;
+            uint64_t cond = 0;
+            if (c.jump_pred && pred_cond_addr && !(pred_cond_addr & 7) &&
+                guest_readable(pred_cond_addr, 8)) {
+                memcpy(&cond, (const void*)(uintptr_t)pred_cond_addr, sizeof cond);
+                skip = (cond != 0);
+            }
+            if (getenv("PROSPER_PREDLOG")) {
+                static int logged = 0;
+                if (logged++ < 96)
+                    fprintf(stderr, "[pred] fold Jump target=0x%llx ndw=%u pred=%u cond@0x%llx=0x%llx -> %s\n",
+                            (unsigned long long)c.jump_addr, c.jump_dwords, c.jump_pred,
+                            (unsigned long long)pred_cond_addr, (unsigned long long)cond,
+                            skip ? "SKIP" : "EXEC");
+            }
+            if (skip) break;
+            if (!guest_readable(c.jump_addr, c.jump_dwords * 4)) break;   // whole segment must be mapped
+            jump_depth++;
+            run_command_buffer((const uint32_t*)(uintptr_t)c.jump_addr, c.jump_dwords, *this);
+            jump_depth--;
+            break;
+        }
         case K::Flip:
             // The GPU reaching the SetFlip packet IS the flip moment (synchronous fold): perform the
             // videoout flip so GetFlipStatus advances and the game's frame pacer sees its flipArg

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -60,6 +60,13 @@ struct GpuState {
     std::vector<Draw> draws;                             // one per DrawIndexAuto / DrawIndex
     uint64_t dispatch_count = 0;                         // DispatchDirect packets seen (no execution yet)
 
+    // GPU predication window (#319): the 64-bit condition address the last SetPredication opened
+    // (0 = no window). A packet-predicated Jump inside the window is executed/skipped on the
+    // condition value read at fold time. Cleared by the end form (addr == 0).
+    uint64_t pred_cond_addr = 0;
+    // Jump recursion depth (a jump target could itself contain a jump; bounded to stop a cycle).
+    uint32_t jump_depth = 0;
+
     // Safety cap on an indirect register count (a malformed/huge count won't run away).
     static constexpr uint32_t kMaxRegsPerPacket = 4096;
 

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -418,7 +418,10 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
                                              uint32_t max_shader_dwords = 0x10000,
                                              float vp_scale_x = 1.0f, float vp_scale_y = 1.0f) {
     if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
-    const bool log = getenv("PROSPER_GFXLOG") != nullptr;    // bail-point visibility (why no frame?)
+    // PROSPER_EXECLOG: just the per-draw bail-point/skip logs, without PROSPER_GFXLOG's per-packet
+    // firehose (which is GBs over a minutes-long run) — for "which draws skip and why" surveys (#319).
+    const bool log = getenv("PROSPER_GFXLOG") != nullptr ||
+                     getenv("PROSPER_EXECLOG") != nullptr;   // bail-point visibility (why no frame?)
     // Render each draw from its OWN register snapshot when the submit has MULTIPLE draws — a real
     // multi-geometry scene (the game's in-game/cutscene submits carry 8-11 distinct draws with per-draw
     // shaders/textures/blends). Folding those to just the last draw drops the rest and the frame comes out

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -201,16 +201,19 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
         if (log) {
-            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; es=0x%llx ps=0x%llx)\n",
-                    vs.size(), fs.size(), (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
+            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; es=0x%llx ps=0x%llx color0=0x%llx)\n",
+                    vs.size(), fs.size(), (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                    (unsigned long long)rs.color0_base);
             for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
                 RecompileCoverage c = recompile_coverage((const uint32_t*)(uintptr_t)addr, max_shader_dwords);
                 fprintf(stderr, "[exec]   %s coverage: total=%u alu=%u exp=%u tabledep=%u unsupported=%u "
                                 "first_bad fmt=%d op=0x%x\n", tag, c.total, c.alu, c.exports,
                         c.table_dependent, c.unsupported, c.first_bad_fmt, c.first_bad_op);
                 if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
+                    // 64 KB: a large UE4 post-process PS (~1500 instrs) far exceeds the old 4 KB
+                    // window, which truncated the very control-flow tail the reject is about (#319).
                     char fn[512]; snprintf(fn, sizeof fn, "%s/exec_%s_%llx.bin", dd, tag, (unsigned long long)addr);
-                    if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)addr, 1, 4096, f); fclose(f); }
+                    if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)addr, 1, 0x10000, f); fclose(f); }
                 }
             }
         }

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -135,6 +135,27 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     if (npl >= 1) c.index_offset = pl[0];
                     if (npl >= 2) c.index_count  = pl[1];
                     break;
+                case R_JUMP:
+                    // sceAgcDcbJump (#319): call-with-length of a side command segment.
+                    // payload: [0..1]=target addr lo/hi, [2]=dword count, [3]=predicated flag.
+                    c.kind = K::Jump;
+                    if (npl >= 4) {
+                        c.jump_addr   = lo_hi(pl);
+                        c.jump_dwords = pl[2];
+                        c.jump_pred   = pl[3];
+                        c.jump_valid  = true;
+                    }
+                    break;
+                case R_SET_PRED:
+                    // sceAgcDcbSetPredication (#319): begin/end a predication window.
+                    // payload: [0..1]=condition addr lo/hi (0 = end), [2]=raw op.
+                    c.kind = K::SetPredication;
+                    if (npl >= 3) {
+                        c.pred_addr  = lo_hi(pl);
+                        c.pred_op    = pl[2];
+                        c.pred_valid = true;
+                    }
+                    break;
                 case R_CX_REGS_INDIRECT:
                 case R_SH_REGS_INDIRECT:
                 case R_UC_REGS_INDIRECT:

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -28,6 +28,13 @@ enum : uint32_t {
     // (sceAgcDcbSetIndexBuffer / SetIndexCount / DrawIndexOffset) are the ONLY draw path UE4 uses;
     // they were unimplemented->0 (no packet appended) so every scene draw was silently dropped.
     R_INDEX_BASE = 0x1b, R_INDEX_COUNT = 0x1c, R_DRAW_INDEX_OFFSET = 0x1d,
+    // Command-buffer call + GPU predication (issue #319, DOLL/UE4 backbuffer composite).
+    // sceAgcDcbJump appends R_JUMP = "execute `jump_dwords` dwords at `jump_addr`, then resume"
+    // (a call-with-length: live capture shows each target segment is exactly the passed size with
+    // no jump-back packet, and the parent stream continues after — so the CP must return).
+    // sceAgcDcbSetPredication appends R_SET_PRED = "begin (addr!=0) / end (addr==0) a predication
+    // window over the following packets, condition = the 64-bit value at addr".
+    R_JUMP = 0x1e, R_SET_PRED = 0x1f,
     R_NUM = 0x40,
 };
 
@@ -41,7 +48,7 @@ struct Pm4Command {
     enum class Kind {
         DrawReset, WaitFlipDone, SetShRegDirect, SetRegsIndirect, SetIndexType,
         DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
-        DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Unknown,
+        DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Jump, SetPredication, Unknown,
     } kind = Kind::Unknown;
 
     uint32_t        header = 0;
@@ -119,6 +126,21 @@ struct Pm4Command {
     // display_buffer_index, flip_mode, flip_arg). Packet payload: [0]=videoout handle, [1]=display
     // buffer index, [2]=flip mode, [3..4]=64-bit flipArg. The GPU processing this packet IS the flip
     // moment: it must advance the videoout flip status (count/flipArg/currentBuffer) the game polls.
+    // Jump (sceAgcDcbJump -> R_JUMP, hle_agc.cpp agc_dcb_jump; #319). Payload: [0..1]=target
+    // address lo/hi, [2]=segment dword count, [3]=predicated flag (set by sceAgcSetPacketPredication
+    // patching the built packet). The CommandProcessor folds the target segment inline (call-with-
+    // length), gated by the active predication window when the flag is set.
+    uint64_t jump_addr = 0;              // Jump: target segment guest address
+    uint32_t jump_dwords = 0;            // Jump: segment length in dwords
+    uint32_t jump_pred = 0;              // Jump: 1 = packet-predicated (participates in the window)
+    bool     jump_valid = false;         // Jump: payload carried the full operand set
+
+    // SetPredication (sceAgcDcbSetPredication -> R_SET_PRED; #319). Payload: [0..1]=condition
+    // address lo/hi (0 = end the window), [2]=raw predication op (live capture: 3 on begin, 0 on end).
+    uint64_t pred_addr = 0;              // SetPredication: 64-bit condition address (0 = window end)
+    uint32_t pred_op = 0;                // SetPredication: raw op field
+    bool     pred_valid = false;         // SetPredication: payload carried the operands
+
     uint32_t flip_handle = 0;            // Flip: sceVideoOut handle
     int32_t  flip_bufidx = -1;           // Flip: display buffer index (-1 = not decoded)
     uint32_t flip_mode = 0;              // Flip: flip mode

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -39,7 +39,8 @@ constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET =
                    R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
                    R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
                    R_RELEASE_MEM = 0x18, R_DMA_DATA = 0x19, R_DISPATCH_DIRECT = 0x1a,
-                   R_INDEX_BASE = 0x1b, R_INDEX_COUNT = 0x1c, R_DRAW_INDEX_OFFSET = 0x1d;
+                   R_INDEX_BASE = 0x1b, R_INDEX_COUNT = 0x1c, R_DRAW_INDEX_OFFSET = 0x1d,
+                   R_JUMP = 0x1e, R_SET_PRED = 0x1f;
 constexpr uint32_t R_NUM = 0x40;
 inline uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
@@ -80,6 +81,19 @@ inline uint32_t* begin_packet(uint64_t buf, uint32_t n, uint32_t op, uint32_t r,
     if (cmd) cmd[0] = PM4(n, op, r);
     *out = cmd;
     return cmd;
+}
+
+// Verify a to-be-patched packet's own header sub-op before writing — a mismatch means the RE
+// drifted, so log loudly (once) and refuse to corrupt the stream. Shared by the sync-packet
+// address patchers (#213/#222) and SetPacketPredication (#319).
+inline bool patch_check(uint32_t* cmd, uint32_t want_r, const char* who) {
+    uint32_t r = (cmd[0] >> 2) & (R_NUM - 1u), op = (cmd[0] >> 8) & 0xffu;
+    if (op == IT_NOP && r == want_r) return true;
+    static std::atomic<int> logged{0};
+    if (logged.fetch_add(1) < 8)
+        fprintf(stderr, "[agc] %s: header 0x%08x is not the expected packet (op=0x%x r=0x%x want r=0x%x) — patch refused\n",
+                who, cmd[0], op, r, want_r);
+    return false;
 }
 
 }  // namespace
@@ -181,6 +195,70 @@ HLE(agc_dcb_draw_index_offset) {  // (dcb, startIndex[, indexCount])
     return (uint64_t)(uintptr_t)cmd;
 }
 
+// --- Command-buffer call (Jump) + GPU predication (issue #319, the DOLL untextured-title cause). --
+//
+// DOLL's UE4 RHI records its per-frame BACKBUFFER COMPOSITE (the fullscreen-triangle pass that
+// writes the textured scene into the VideoOut scanout buffer) NOT inline in the main Dcb, but in
+// small side segments invoked via sceAgcDcbJump under sceAgcDcbSetPredication windows:
+//
+//   sceAgcDcbSetPredication(dcb, 1, 3, 1, condAddr)   <- begin window, 64-bit condition at condAddr
+//   pkt = sceAgcDcbJump(dcb, 0, 0, target, ndw)       <- call `ndw` dwords at `target`
+//   sceAgcSetPacketPredication(pkt, ...)              <- mark that jump packet as predicated
+//   sceAgcDcbSetPredication(dcb, 1, 0, 1, 0)          <- end window
+//
+// Live capture (PROSPER_PREDLOG, title steady state): 8 such clusters per frame — the SAME two
+// composite segments (one per scanout buffer 0x8fc0000000/0x8fc2000000) each invoked at 4 points
+// with 4 distinct conditions; every segment is exactly `ndw` dwords of Set*RegsIndirect (full
+// render state: CB_COLOR0_BASE = the scanout buffer, 3840x2160 viewport, ES PGM) + DrawIndexAuto(3)
+// (a fullscreen triangle), with NO jump-back packet, and the parent stream continues after the
+// cluster — so Jump is a CALL-WITH-LENGTH, not a goto. With these three calls unimplemented
+// (return 0, no packet), the composite never executed and the presented backbuffer only ever held
+// the direct-to-scanout UI rectangle draws — the #319 "untextured title".
+//
+// No Kyty/shadPS4 reference exists for these Gen5 calls; the ABI below is pinned by the live
+// capture (arg roles consistent over 100k+ calls/run). CONFIDENCE: HIGH on (a3=target, a4=dword
+// count) and (a4=condition address begin / 0 end) — the dword count equals the decoded segment
+// length exactly, and the condition addresses are re-recorded per frame from a descending
+// per-frame allocation. CONFIDENCE: MED on the remaining flag args (recorded raw in the packet).
+HLE(agc_dcb_jump) {  // sceAgcDcbJump(dcb, ?, ?, target_addr, num_dw)
+    if (getenv("PROSPER_PREDLOG")) {
+        static std::atomic<uint64_t> n{0};
+        uint64_t k = n.fetch_add(1);
+        if (k < 32 || (k % 4096) == 0)
+            fprintf(stderr, "[pred] DcbJump #%llu dcb=0x%llx target=0x%llx ndw=0x%llx a1=0x%llx a2=0x%llx\n",
+                    (unsigned long long)k, (unsigned long long)a0, (unsigned long long)a3,
+                    (unsigned long long)a4, (unsigned long long)a1, (unsigned long long)a2);
+    }
+    uint32_t* cmd; if (!begin_packet(a0, 5, IT_NOP, R_JUMP, &cmd)) return 0;
+    cmd[1] = (uint32_t)(a3 & 0xffffffffu); cmd[2] = (uint32_t)(a3 >> 32u);
+    cmd[3] = (uint32_t)a4;
+    cmd[4] = 0;   // predicated flag — set by sceAgcSetPacketPredication on this returned packet
+    return (uint64_t)(uintptr_t)cmd;
+}
+HLE(agc_dcb_set_predication) {  // sceAgcDcbSetPredication(dcb, 1, op, 1, cond_addr) / (dcb, 1, 0, 1, 0)=end
+    if (getenv("PROSPER_PREDLOG")) {
+        static std::atomic<uint64_t> n{0};
+        uint64_t k = n.fetch_add(1);
+        if (k < 32 || (k % 4096) == 0)
+            fprintf(stderr, "[pred] DcbSetPredication #%llu dcb=0x%llx cond=0x%llx op=0x%llx a1=0x%llx a3=0x%llx\n",
+                    (unsigned long long)k, (unsigned long long)a0, (unsigned long long)a4,
+                    (unsigned long long)a2, (unsigned long long)a1, (unsigned long long)a3);
+    }
+    uint32_t* cmd; if (!begin_packet(a0, 4, IT_NOP, R_SET_PRED, &cmd)) return 0;
+    cmd[1] = (uint32_t)(a4 & 0xffffffffu); cmd[2] = (uint32_t)(a4 >> 32u);
+    cmd[3] = (uint32_t)a2;
+    return (uint64_t)(uintptr_t)cmd;
+}
+HLE(agc_set_packet_predication) {  // sceAgcSetPacketPredication(packet, ...)
+    // Marks an already-built packet as participating in the enclosing predication window. For our
+    // R_JUMP encoding that is payload[3] (cmd[4]). Header-verified like the other packet patchers —
+    // a different packet kind means the RE drifted, so refuse loudly rather than corrupt the stream.
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_check(cmd, R_JUMP, "SetPacketPredication")) return 0;
+    cmd[4] = 1;
+    return 0;
+}
+
 // sceAgcSuspendPoint (NID h9z6+0hEydk, name via shadPS4) — the TRC R5089 GPU suspend point the
 // game forces in a loop ("Forcing call to sce::Agc::suspendPoint" spam). It has no out-params and
 // no game-visible state; on a devkit it just gives the system a safe suspend opportunity.
@@ -199,6 +277,15 @@ HLE(agc_cb_nop) {  // (dcb, num_dwords, ...)
 // address, a5 = size in dwords, a1 = dst (0 here, patched later via DmaDataPatchSetDstAddressOrOffset).
 // Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=src lo/hi, [5]=size_dw, [6]=flags. Return ptr.
 HLE(agc_dcb_dma_data) {  // (dcb, dst, cache_policy, flags, src, size_dw)
+    // #319 probe: is DmaData part of the per-frame render stream (a GPU-side copy we never execute)?
+    static std::atomic<uint64_t> g_dma_n{0};
+    if (getenv("PROSPER_PREDLOG")) {
+        uint64_t k = g_dma_n.fetch_add(1);
+        if (k < 48 || (k % 4096) == 0)
+            fprintf(stderr, "[pred] DcbDmaData #%llu dst=0x%llx src=0x%llx size_dw=0x%llx flags=0x%llx\n",
+                    (unsigned long long)k, (unsigned long long)a1, (unsigned long long)a4,
+                    (unsigned long long)a5, (unsigned long long)a3);
+    }
     uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DMA_DATA, &cmd)) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
     cmd[3] = (uint32_t)(a4 & 0xffffffffu); cmd[4] = (uint32_t)(a4 >> 32u);
@@ -932,17 +1019,6 @@ HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
 // the packet's own header sub-op before writing — a mismatch means the RE drifted, so it logs
 // loudly (once) and refuses to corrupt the stream. CONFIDENCE: HIGH (disassembly + live capture
 // + offset arithmetic all agree).
-namespace {
-inline bool patch_check(uint32_t* cmd, uint32_t want_r, const char* who) {
-    uint32_t r = (cmd[0] >> 2) & (R_NUM - 1u), op = (cmd[0] >> 8) & 0xffu;
-    if (op == IT_NOP && r == want_r) return true;
-    static std::atomic<int> logged{0};
-    if (logged.fetch_add(1) < 8)
-        fprintf(stderr, "[agc] %s: header 0x%08x is not the expected packet (op=0x%x r=0x%x want r=0x%x) — patch refused\n",
-                who, cmd[0], op, r, want_r);
-    return false;
-}
-}
 HLE(agc_patch_write_data_addr) {  // fPSCdQxgpSw (cmd, address): WriteData payload [1..2] = address
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     if (!patch_check(cmd, R_WRITE_DATA, "WriteDataPatchAddress")) return 0;
@@ -998,6 +1074,10 @@ void register_agc_hle() {
     RN("8N2tmT3jmC8", agc_dcb_set_index_count);  // sceAgcDcbSetIndexCount
     RN("B+aG9DUnTKA", agc_dcb_draw_index_offset);// sceAgcDcbDrawIndexOffset
     RN("h9z6+0hEydk", agc_suspend_point);       // sceAgcSuspendPoint — no-op OK
+    // Command-buffer call + GPU predication (#319 — the DOLL backbuffer-composite path).
+    RN("xSAR0LTcRKM", agc_dcb_jump);               // sceAgcDcbJump (call-with-length)
+    RN("bbFueFP+J4k", agc_dcb_set_predication);    // sceAgcDcbSetPredication (window begin/end)
+    RN("w6Dj1VJt5qY", agc_set_packet_predication); // sceAgcSetPacketPredication (mark jump packet)
     RN("aJf+j5yntiU", agc_dcb_event_write);
     RN("57labkp+rSQ", agc_dcb_acquire_mem);
     RN("wr23dPKyWc0", agc_cb_release_mem);


### PR DESCRIPTION
## What this is

Implements the two missing GPU-side mechanisms named in #319 — **DcbJump** and **GPU predication** — with semantics pinned by live capture, and delivers the #319 investigation verdict: the untextured title is a **two-stage** problem, and this PR closes stage 1.

## Investigation (evidence-first)

New `PROSPER_PREDLOG` capture at the DOLL title steady state shows 8 clusters/frame of:

```
sceAgcDcbSetPredication(dcb, 1, 3, 1, condAddr)   <- begin window, 64-bit cond at condAddr
pkt = sceAgcDcbJump(dcb, 0, 0, target, ndw)       <- call ndw dwords at target
sceAgcSetPacketPredication(pkt, ...)              <- mark the jump packet predicated
sceAgcDcbSetPredication(dcb, 1, 0, 1, 0)          <- end window
```

Decoding the jump targets: each segment is **exactly `ndw` dwords** of `SetCx/Sh/UcRegsIndirect + DrawIndexAuto(3)` — a fullscreen triangle with `CB_COLOR0_BASE = 0x8fc0000000/0x8fc2000000` (the two VideoOut scanout buffers) and a full 3840x2160 viewport: **the game's per-frame backbuffer composite lives in predicated side segments**, invoked 4x per scanout buffer under 4 distinct conditions. With the three NIDs unimplemented (return 0, no packet), the composite never executed — the presented backbuffer only ever held the direct-to-scanout UI draws.

There is no jump-back packet and the parent stream continues after the cluster, so Jump is a **call-with-length**, not a goto.

**Predication polarity** pinned empirically at fold time: every per-frame composite condition reads 0 (and a composite MUST run each frame on real HW for a title frame to exist), while a disabled depth-pass segment's condition reads 1 and is the only SKIP observed live. So non-zero = skip. CONFIDENCE: HIGH on arg roles (target/count/cond-addr consistent over 100k+ calls), MED on polarity/flag args.

## Implementation

- `hle_agc.cpp`: real builders for `xSAR0LTcRKM` (sceAgcDcbJump -> `R_JUMP` packet: target lo/hi, dword count, pred flag), `bbFueFP+J4k` (sceAgcDcbSetPredication -> `R_SET_PRED`: cond addr lo/hi, op; addr 0 = window end), `w6Dj1VJt5qY` (sceAgcSetPacketPredication: header-verified patch of the jump packet's pred flag).
- `pm4_decode`: decode both packets; `command_processor`: fold the jump target inline (depth/size/readability-guarded recursion), gating a packet-predicated jump on the fold-time 64-bit condition inside an open window.
- Diagnostics: `PROSPER_PREDLOG` (builder + fold decisions), `PROSPER_EXECLOG` (per-draw skip logs without the GFXLOG firehose), `PROSPER_NO_JUMP=1` A/B kill-switch, 64KB shader dumps + color0 in the recompile-fail log.

## Honest pixel A/B (llvmpipe, quarter-res, pad-driven to the menus)

**No presented-pixel delta yet.** With jumps followed, the composite draws fold, realize (recompile OK) and render into the scanout group (7 draws vs ~3; alpha-coverage change visible) — but they output black because **their sampled sources are black**: the four post-process passes that produce the image the composite samples (two offscreen RTs, e.g. 0x2075550000/0x2087740000) fail RDNA2 recompile every frame:

| PS | size | live reject |
|----|------|-------------|
| 0x2087230000-class | 1490 instr | divergent execz-exit loop (backedge 1349->865) -> straight-line rejects at first vccz (pc=162) |
| 0x2087250000-class | 1011 instr | same family (execz loop + vccz tail), rejects pc=75 |
| 0x20872e0000-class | 1671 instr | loops + vccnz, rejects pc=381 |
| 0x2087270000-class | 287 instr | only 2 nested vccz, but its `image_sample_b` (pc=265) T# fails descriptor RESOLUTION (`!res`) |

That is stage 2 — the #273 recompiler frontier (divergent execz-exit loops + one descriptor-resolution case), now precisely scoped by this PR's instrumentation. The menu screen itself (UMG panels, banner, vignette backdrop) renders identically before/after.

## Verification

- ctest **69/69** (worktree, with dump).
- **Messenger unregressed** (shared executor/decoder): `tools/snapshot/snapshot.py check` -> `messenger-scene: OK (480x270, richest 24318 colors)`; boot run 0 worker faults, deep-scene items realize.
- DOLL: no crashes attributable to the fold (the known #312 input-driven MallocBinned3 fatal reproduces unchanged); draws/frame +8 as expected; the one live SKIP proves the predication path is exercised.

refs #319 (not `Fixes` — the title is not yet textured; the remaining cause is tracked with exact shader addresses/PCs above and in the #273 comment).