### PR TITLE
fix(hle): honest sceKernelAio* + pipe-drain completion-write model + #312 attribution tooling (refs #312)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -12,6 +12,10 @@ extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx, uint32
 #include <cstdio>
 #include <cstring>
 #include <chrono>
+#include <atomic>
+#include <deque>
+#include <condition_variable>
+#include <thread>
 
 namespace prosper::gpu {
 
@@ -47,6 +51,47 @@ static bool eop_writes_disabled() {
 extern "C" uint64_t prosper_guest_tsc_ns();   // hle_kernel_time.cpp — same source as sceKernelReadTsc
 static uint64_t gpu_clock64() { return prosper_guest_tsc_ns(); }
 
+// --- GPU-write attribution ring (diagnostic for issue #312 heap-corruption hunt). ---------------
+// Records every guest-memory write this command processor performs (EOP label / WRITE_DATA /
+// EVENT_WRITE) in a fixed lock-free ring so the fault handler can answer, async-signal-safely,
+// "did the GPU recently write near address X?" — the attribution question for a stomped
+// MallocBinned3 free-block canary. Always-on: 3 relaxed atomics per honored write, no allocation.
+namespace {
+struct GpuWriteRec { uint64_t addr; uint64_t value; uint64_t pkt; uint32_t seq; uint8_t size; uint8_t kind; };
+constexpr uint32_t kWriteRingSize = 16384;              // power of two
+GpuWriteRec g_write_ring[kWriteRingSize];
+std::atomic<uint32_t> g_write_seq{0};
+// `pkt` = the guest address of the PM4 packet that requested the write (c.payload-1). The stale-
+// vs-live discriminator: a STALE ring-tail packet re-executed across frames has the SAME pkt
+// address in every record; a legitimately re-recorded per-frame write moves with the ring.
+void ring_record(uint64_t addr, uint64_t value, uint8_t size, uint8_t kind, uint64_t pkt) {
+    uint32_t s = g_write_seq.fetch_add(1, std::memory_order_relaxed);
+    GpuWriteRec& r = g_write_ring[s & (kWriteRingSize - 1)];
+    r.addr = addr; r.value = value; r.pkt = pkt; r.seq = s; r.size = size; r.kind = kind;
+}
+uint64_t pkt_addr(const Pm4Command& c) { return c.payload ? (uint64_t)(uintptr_t)(c.payload - 1) : 0; }
+}
+// Scan the ring for writes intersecting [lo, hi); format up to `max` matches into out (NUL-
+// terminated). Async-signal-safe: no locks, no allocation, tolerates racy ring slots. kind:
+// 1=RELEASE_MEM 2=EVENT_WRITE 3=WRITE_DATA.
+extern "C" int prosper_gpu_write_ring_scan(uint64_t lo, uint64_t hi, char* out, size_t cap) {
+    size_t off = 0; int found = 0;
+    uint32_t seq_now = g_write_seq.load(std::memory_order_relaxed);
+    uint32_t n = seq_now < kWriteRingSize ? seq_now : kWriteRingSize;
+    for (uint32_t i = 0; i < n && off + 96 < cap; i++) {
+        const GpuWriteRec& r = g_write_ring[i & (kWriteRingSize - 1)];
+        if (!r.addr || r.addr + r.size <= lo || r.addr >= hi) continue;
+        int m = snprintf(out + off, cap - off,
+                         "[gpuring] seq=%u kind=%u addr=0x%llx size=%u value=0x%llx pkt=0x%llx (age=%u)\n",
+                         r.seq, r.kind, (unsigned long long)r.addr, r.size,
+                         (unsigned long long)r.value, (unsigned long long)r.pkt, seq_now - r.seq);
+        if (m > 0) off += (size_t)m;
+        found++;
+    }
+    if (off < cap) out[off] = 0;
+    return found;
+}
+
 // Honor a RELEASE_MEM / EVENT_WRITE_EOP completion write. data_sel (Kyty GraphicsCbReleaseMem allows {2,3};
 // shadPS4 DataSelect enum): 1=write 32-bit value, 2=write 64-bit value, 3=write 64-bit GPU clock. The write
 // uses memcpy so an only-4-byte-aligned 64-bit label is handled portably. CONFIDENCE: HIGH — address,
@@ -63,10 +108,26 @@ static void honor_eop_write(const Pm4Command& c) {
         // packet's rel_value is a fabricated 0 that could move a satisfied fence label BACKWARDS
         // (re-blocking a `*label >= expected` poll).
         case 1: { if (!c.rel_value_valid) return;
-                  uint32_t v = (uint32_t)c.rel_value; memcpy(dst, &v, sizeof v); break; }
+                  // #312 stomp-catcher: a live fence label holds small ints/timestamps; a freed
+                  // MallocBinned3 FFreeBlock header holds heap POINTERS. Pointer-like pre-content
+                  // means this fence write is landing in freed (or reused) memory — log it in the
+                  // act, with the packet address for attribution. Diagnostic only, always-on
+                  // (one 8-byte read per fence write), bounded to 64 reports.
+                  uint64_t pre = 0; memcpy(&pre, dst, sizeof pre);
+                  if (pre >= 0x1000000000ull && pre < 0x1200000000ull) {
+                      static std::atomic<int> n{0};
+                      if (n.fetch_add(1) < 64)
+                          fprintf(stderr, "[agc] EOP-WRITE-OVER-POINTER [0x%llx] pre=0x%llx value=0x%llx pkt=0x%llx\n",
+                                  (unsigned long long)c.rel_addr, (unsigned long long)pre,
+                                  (unsigned long long)c.rel_value, (unsigned long long)pkt_addr(c));
+                  }
+                  uint32_t v = (uint32_t)c.rel_value; memcpy(dst, &v, sizeof v);
+                  ring_record(c.rel_addr, v, 4, 1, pkt_addr(c)); break; }
         case 2: { if (!c.rel_value_valid) return;
-                  uint64_t v = c.rel_value;           memcpy(dst, &v, sizeof v); break; }
-        case 3: { uint64_t v = gpu_clock64();         memcpy(dst, &v, sizeof v); break; }
+                  uint64_t v = c.rel_value;           memcpy(dst, &v, sizeof v);
+                  ring_record(c.rel_addr, v, 8, 1, pkt_addr(c)); break; }
+        case 3: { uint64_t v = gpu_clock64();         memcpy(dst, &v, sizeof v);
+                  ring_record(c.rel_addr, v, 8, 1, pkt_addr(c)); break; }
         // Unknown selector: LOG AND SKIP. The old default wrote the 64-bit value for ANY
         // unrecognized data_sel — a band-aid for the swap-stub stack-arg mis-extraction that made
         // data_sel arrive as a pointer (fixed in exec_image_linux.cpp emit_swap_stub: handlers now
@@ -97,6 +158,7 @@ static void honor_event_write(const Pm4Command& c) {
     if (eop_writes_disabled() || !c.event_addr || (c.event_addr & 3)) return;
     uint64_t v = gpu_clock64();
     memcpy((void*)(uintptr_t)c.event_addr, &v, sizeof v);
+    ring_record(c.event_addr, v, 8, 2, pkt_addr(c));
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   EventWrite [0x%llx] event_type=%u -> clock 0x%llx\n",
                 (unsigned long long)c.event_addr, c.event_type, (unsigned long long)v);
@@ -107,10 +169,220 @@ static void honor_event_write(const Pm4Command& c) {
 static void honor_write_data(const Pm4Command& c) {
     if (eop_writes_disabled() || !c.wd_addr || (c.wd_addr & 3) || !c.wd_data || !c.wd_num) return;
     memcpy((void*)(uintptr_t)c.wd_addr, c.wd_data, (size_t)c.wd_num * 4);
+    ring_record(c.wd_addr, c.wd_data[0], (uint8_t)(c.wd_num * 4 > 255 ? 255 : c.wd_num * 4), 3, pkt_addr(c));
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   WriteData [0x%llx] %u dwords (first=0x%08x)\n",
                 (unsigned long long)c.wd_addr, c.wd_num, c.wd_data[0]);
     wake_on_label(c.wd_addr);   // wake any sync_on_address futex waiter on this written label
+}
+
+// --- Deferred completion writes: the pipe-drain model for fence/label writes (issue #312). ------
+//
+// On real hardware NO completion side-effect of a submit — fence label writes, EVENT_WRITE
+// timestamps, WRITE_DATA fence values, the flip — is observable until after the submit call has
+// returned (the GPU only sees the Dcb when the driver rings the doorbell at the end of the
+// submit) plus the pipe-drain latency. prosper's synchronous fold performed these writes INSIDE
+// the submit call. The EOP *event* was already deferred for exactly this reason (#232/#241:
+// hle_kernel_time.cpp's 1 ms FIFO worker — DOLL's AgcInterrupt->AgcCleanup chain observed frame N
+// complete before the AgcSubmissionThread finished its own post-submit bookkeeping and the
+// cleanup raced the submitter's retired-allocation list: the SAME "MallocBinned3 Corruption
+// Canary was 0x3, should be 0x1" fatal). But DOLL's cleanup ALSO polls the fence LABELS, which
+// still became visible mid-submit — under the menu-driven content-load burst (#312) that lets the
+// game retire+free GPU-tracking heap blocks while cbs referencing them are still being submitted,
+// and our later label writes stomp MallocBinned3 free-block headers (live-attributed: the GPU
+// write-ring shows our RELEASE_MEM value-1 writes at exactly the corrupted qword).
+//
+// Model: honor_* enqueue the write; a FIFO worker applies them in submission order after a 1 ms
+// modeled pipe-drain latency (same constant as the EOP-event worker). Synchronous drain points
+// keep every intra-model data dependency exact:
+//   - WaitRegMem fold checks drain first (a prior submit's fence must be visible to its consumer),
+//   - execute_and_present's callers drain first (the renderer reads WRITE_DATA-uploaded memory),
+//   - the EOP-event worker drains before posting (an event must never overtake its data writes).
+// PROSPER_EOP_WRITE_SYNC=1 restores the old synchronous writes (A/B lever + fallback).
+// CONFIDENCE: HIGH on the invariant (completion is post-submit by construction on real HW; Kyty
+// writes fences from its GPU thread, never inside the submit call); MED that this closes ALL of
+// #312 (the cross-queue wait-ordering approximation remains, gated separately behind
+// PROSPER_WAIT_DEFER).
+namespace {
+bool eop_write_sync() {
+    static const bool v = [] { const char* e = getenv("PROSPER_EOP_WRITE_SYNC");
+                               return e && strtol(e, nullptr, 0) != 0; }();
+    return v;
+}
+struct PendWrite {
+    Pm4Command cmd;
+    std::vector<uint32_t> wd_copy;     // owns a WriteData payload (cmd.wd_data repointed here)
+};
+// IMMORTAL (leaked) worker state — same pattern as the EOP-event worker (hle_kernel_time.cpp):
+// the worker is detached and outlives main; static destructors must never run for it.
+struct PendQueue {
+    std::mutex mx;
+    std::condition_variable cv;
+    std::deque<PendWrite> q;
+    bool worker_started = false;
+};
+PendQueue& pend_q() { static PendQueue* p = new PendQueue; return *p; }
+void apply_effect(const Pm4Command& c);   // fwd (defined with the WAIT_DEFER machinery below)
+void pend_drain_locked(PendQueue& p, std::unique_lock<std::mutex>& lk) {
+    while (!p.q.empty()) {
+        PendWrite w = std::move(p.q.front());
+        p.q.pop_front();
+        lk.unlock();                     // the write itself never needs the queue lock
+        apply_effect(w.cmd);
+        lk.lock();
+    }
+}
+void pend_worker() {
+    PendQueue& p = pend_q();
+    std::unique_lock<std::mutex> lk(p.mx);
+    for (;;) {
+        p.cv.wait(lk, [&] { return !p.q.empty(); });
+        lk.unlock();
+        struct timespec ts{ 0, 1000000 };   // 1 ms modeled pipe-drain latency (matches the EOP worker)
+        nanosleep(&ts, nullptr);
+        lk.lock();
+        pend_drain_locked(p, lk);
+    }
+}
+void pend_enqueue(const Pm4Command& c) {
+    PendQueue& p = pend_q();
+    PendWrite w; w.cmd = c;
+    if (c.kind == Pm4Command::Kind::WriteData && c.wd_data && c.wd_num) {
+        w.wd_copy.assign(c.wd_data, c.wd_data + c.wd_num);   // cb memory may be recycled before drain
+        w.cmd.wd_data = w.wd_copy.data();
+    }
+    {
+        std::lock_guard<std::mutex> lk(p.mx);
+        if (!p.worker_started) { p.worker_started = true; std::thread(pend_worker).detach(); }
+        p.q.push_back(std::move(w));
+    }
+    p.cv.notify_one();
+}
+} // namespace
+
+// Synchronous drain: apply every pending completion write NOW, in order. Called from the fold's
+// WaitRegMem check, before the renderer executes, and by the EOP-event worker before it posts.
+extern "C" void prosper_gpu_drain_completion_writes() {
+    PendQueue& p = pend_q();
+    std::unique_lock<std::mutex> lk(p.mx);
+    pend_drain_locked(p, lk);
+}
+
+// --- WAIT_REG_MEM queue-pause semantics (issue #312 heap-corruption root cause). -----------------
+//
+// On real hardware WAIT_REG_MEM BLOCKS the queue until its condition holds; packets after it —
+// including the RELEASE_MEM fence the game polls — execute only once the dependency is satisfied.
+// Our fold is synchronous at submit time, and DOLL's UE4 RHI submits from two guest threads, so a
+// consumer Dcb (wait label==1, then EOP fence write) routinely arrives BEFORE its producer (the
+// Dcb whose RELEASE_MEM writes that label). The old fold logged "dependency violated" and barreled
+// on: the consumer's fence completed early, the game freed the heap block holding the transient
+// semaphore label, and the producer's later RELEASE_MEM value-1 write landed on the freed
+// MallocBinned3 FFreeBlock header — the "Canary was 0x3, should be 0x1" / "free an unrecognized
+// block 0x1000000001" fatals (a 4-byte 0x1 stomp over NextFreeBlock; attributed live by the GPU
+// write-ring: 13 ReleaseMem value-1 writes at exactly the corrupted qword's address).
+//
+// Honest semantics with a synchronous fold: when a fold hits an UNSATISFIED wait, the rest of that
+// stream's guest-visible memory effects (ReleaseMem / EVENT_WRITE / WRITE_DATA / Flip and any
+// further waits) are DEFERRED in order. Deferred streams are flushed FIFO at every subsequent
+// submit (the producer's own fold is what satisfies the barrier; a CPU-written label is re-checked
+// at the same points), and the submit's EOP equeue pulse fires only when its stream fully flushes.
+// Draws/register state still fold immediately — they touch no guest memory, so they cannot corrupt
+// (worst case is the same rendering-order approximation as before). Liveness: a barrier pending
+// longer than kDeferTimeoutMs falls back to the old proceed-with-loud-log behavior, so a genuinely
+// never-written label (or a producer we fail to model) degrades to today's state instead of
+// wedging the queue. All of this runs under the caller's submit mutex (hle_agc g_agc_state_mu).
+// CONFIDENCE: HIGH on the mechanism + the wait semantics; MED on cross-stream write ordering while
+// a stream is deferred (independent queues on real HW run concurrently, so a later submit's
+// effects landing before a paused stream's tail matches hardware; same-queue back-to-back submits
+// would be reordered, which hardware forbids — accepted, logged, and bounded by the timeout).
+namespace {
+bool wait_regmem_satisfied(const Pm4Command& c) {
+    uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
+    uint64_t v = mem & c.wm_mask, r = c.wm_ref;
+    switch (c.wm_func) {           // PM4 WAIT_REG_MEM compare functions
+        case 0: return true;
+        case 1: return v <  r;
+        case 2: return v <= r;
+        case 3: return v == r;
+        case 4: return v != r;
+        case 5: return v >= r;
+        case 6: return v >  r;
+        default: return false;
+    }
+}
+uint64_t defer_now_ms() {
+    return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+struct DeferItem {
+    Pm4Command cmd;                    // barrier (WaitRegMem) or effect (ReleaseMem/EventWrite/WriteData/Flip)
+    std::vector<uint32_t> wd_copy;     // owns a WriteData payload (cmd.wd_data repointed into this)
+    uint64_t first_blocked_ms = 0;     // barrier only: when it was first found unsatisfied
+};
+struct DeferredStream { std::vector<DeferItem> items; size_t next = 0; };
+std::vector<DeferredStream> g_deferred;   // FIFO; guarded by the caller's submit mutex
+bool     g_fold_deferring = false;        // current fold hit an unsatisfied wait
+uint64_t g_defer_streams = 0, g_defer_timeouts = 0;
+constexpr uint64_t kDeferTimeoutMs = 500;
+constexpr size_t   kDeferMaxStreams = 256;   // runaway guard: force-flush oldest beyond this
+
+void defer_push(const Pm4Command& c) {
+    DeferItem it; it.cmd = c;
+    if (c.kind == Pm4Command::Kind::WriteData && c.wd_data && c.wd_num) {
+        it.wd_copy.assign(c.wd_data, c.wd_data + c.wd_num);   // cb memory may be recycled before flush
+        it.cmd.wd_data = it.wd_copy.data();
+    }
+    g_deferred.back().items.push_back(std::move(it));
+}
+void apply_effect(const Pm4Command& c) {
+    using K = Pm4Command::Kind;
+    switch (c.kind) {
+        case K::ReleaseMem: honor_eop_write(c); break;
+        case K::EventWrite: honor_event_write(c); break;
+        case K::WriteData:  honor_write_data(c); break;
+        case K::Flip:       if (c.flip_valid) prosper_vo_flip_from_gpu(c.flip_handle, c.flip_bufidx,
+                                                                       c.flip_mode, c.flip_arg); break;
+        default: break;
+    }
+}
+} // namespace
+
+bool last_fold_deferred() { return g_fold_deferring; }
+
+// Flush deferred streams FIFO. Returns how many streams COMPLETED (the caller owes one EOP equeue
+// pulse per completed stream). A stream whose next barrier is still unsatisfied blocks the flush
+// (strict FIFO among deferred effects) unless it has been pending > kDeferTimeoutMs, in which case
+// it proceeds with the pre-#312 "dependency violated" loud log.
+int flush_deferred_streams() {
+    int completed = 0;
+    while (!g_deferred.empty()) {
+        DeferredStream& s = g_deferred.front();
+        bool blocked = false;
+        bool force = g_deferred.size() > kDeferMaxStreams;
+        while (s.next < s.items.size()) {
+            DeferItem& it = s.items[s.next];
+            if (it.cmd.kind == Pm4Command::Kind::WaitRegMem) {
+                if (!wait_regmem_satisfied(it.cmd)) {
+                    uint64_t now = defer_now_ms();
+                    if (!it.first_blocked_ms) it.first_blocked_ms = now;
+                    if (!force && now - it.first_blocked_ms < kDeferTimeoutMs) { blocked = true; break; }
+                    g_defer_timeouts++;
+                    fprintf(stderr, "[agc] WaitRegMem DEFER TIMEOUT after %llums: [0x%llx]&0x%llx func=%u ref=0x%llx — dependency violated (proceeding)\n",
+                            (unsigned long long)(now - it.first_blocked_ms),
+                            (unsigned long long)it.cmd.wm_addr, (unsigned long long)it.cmd.wm_mask,
+                            it.cmd.wm_func, (unsigned long long)it.cmd.wm_ref);
+                }
+                s.next++;
+                continue;
+            }
+            apply_effect(it.cmd);
+            s.next++;
+        }
+        if (blocked) break;
+        g_deferred.erase(g_deferred.begin());
+        completed++;
+    }
+    return completed;
 }
 
 void GpuState::apply(const Pm4Command& c) {
@@ -222,38 +494,54 @@ void GpuState::apply(const Pm4Command& c) {
             break;
         }
         case K::ReleaseMem:
-            honor_eop_write(c);     // EOP completion label write (correct synchronous end-of-pipe timing)
+            // EOP completion label write. Once this stream hit an unsatisfied wait, the write is
+            // deferred behind that barrier (see the #312 block above) — completing the fence
+            // early is what let the game free live label memory. Otherwise it goes through the
+            // pipe-drain queue: completion becomes guest-visible only after the submit returns.
+            if (g_fold_deferring) { defer_push(c); break; }
+            if (eop_write_sync()) honor_eop_write(c); else pend_enqueue(c);
             break;
         case K::WriteData:
-            honor_write_data(c);    // inline data write requested by the Dcb
+            if (g_fold_deferring) { defer_push(c); break; }
+            if (eop_write_sync()) honor_write_data(c); else pend_enqueue(c);
             break;
         case K::EventWrite:
-            honor_event_write(c);   // address-carrying (timestamp/label) EVENT_WRITE completion (#132)
+            if (g_fold_deferring) { defer_push(c); break; }
+            if (eop_write_sync()) honor_event_write(c); else pend_enqueue(c);
             break;
         case K::WaitRegMem:
-            // Synchronous fold: by the time we process this packet the CPU-side producer has
-            // usually already written the label, so the wait is normally satisfied. We can't
-            // BLOCK here (single-threaded fold) — but a wait that is NOT satisfied means the
-            // dependency would have been violated (packets after this one read data the guest
-            // hadn't produced at submit), so surface it loudly instead of silently proceeding.
+            // Real WAIT_REG_MEM semantics (#312): an unsatisfied wait PAUSES this queue — the
+            // stream's remaining memory effects are deferred until the condition holds (flushed
+            // at subsequent submits by flush_deferred_streams; loud timeout fallback preserves
+            // liveness). A satisfied wait is a no-op, as before.
             if (c.wm_valid && c.wm_addr && !(c.wm_addr & 3)) {
-                uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
-                uint64_t v = mem & c.wm_mask, r = c.wm_ref;
-                bool sat;
-                switch (c.wm_func) {           // PM4 WAIT_REG_MEM compare functions
-                    case 0: sat = true;    break;
-                    case 1: sat = v <  r;  break;
-                    case 2: sat = v <= r;  break;
-                    case 3: sat = v == r;  break;
-                    case 4: sat = v != r;  break;
-                    case 5: sat = v >= r;  break;
-                    case 6: sat = v >  r;  break;
-                    default: sat = false;  break;
-                }
-                if (!sat)
-                    fprintf(stderr, "[agc] WaitRegMem NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — dependency violated\n",
+                if (g_fold_deferring) { defer_push(c); break; }   // ordered behind the first barrier
+                // A prior submit's fence write may still sit in the pipe-drain queue — a consumer's
+                // wait must see it (data dependency): drain before evaluating.
+                prosper_gpu_drain_completion_writes();
+                if (!wait_regmem_satisfied(c)) {
+                    uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
+                    // PROSPER_WAIT_DEFER=1 (experimental): pause the queue — defer the stream's
+                    // remaining memory effects until the condition holds. Default OFF: label
+                    // slots are recycled with residue frequently equal to the awaited value, so
+                    // value-based gating cannot distinguish a satisfied wait from stale residue
+                    // (measured live: enabling it moved the #312 fatal EARLIER). Kept for
+                    // experiments while the real per-queue model is built.
+                    static const bool defer_on = [] {
+                        const char* e = getenv("PROSPER_WAIT_DEFER");
+                        return e && strtol(e, nullptr, 0) != 0; }();
+                    fprintf(stderr, "[agc] WaitRegMem NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s\n",
                             (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
-                            (unsigned long long)v, c.wm_func, (unsigned long long)r);
+                            (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
+                            defer_on ? "pausing queue (deferred effects)" : "dependency violated");
+                    if (defer_on) {
+                        g_fold_deferring = true;
+                        g_defer_streams++;
+                        g_deferred.emplace_back();
+                        DeferItem it; it.cmd = c; it.first_blocked_ms = defer_now_ms();
+                        g_deferred.back().items.push_back(std::move(it));
+                    }
+                }
             }
             break;
         case K::DispatchDirect:
@@ -312,10 +600,16 @@ void GpuState::apply(const Pm4Command& c) {
             break;
         }
         case K::Flip:
-            // The GPU reaching the SetFlip packet IS the flip moment (synchronous fold): perform the
-            // videoout flip so GetFlipStatus advances and the game's frame pacer sees its flipArg
-            // complete. Only for a fully-decoded payload — a short packet must not fabricate a flip.
-            if (c.flip_valid) prosper_vo_flip_from_gpu(c.flip_handle, c.flip_bufidx, c.flip_mode, c.flip_arg);
+            // The GPU reaching the SetFlip packet IS the flip moment: perform the videoout flip so
+            // GetFlipStatus advances and the game's frame pacer sees its flipArg complete. Only for
+            // a fully-decoded payload — a short packet must not fabricate a flip. Behind an
+            // unsatisfied wait the flip defers with the other effects (#312); otherwise it rides
+            // the pipe-drain queue like every completion signal (a flip is a lifecycle signal —
+            // the game recycles display buffers on it — and must not be observable mid-submit).
+            if (!c.flip_valid) break;
+            if (g_fold_deferring) { defer_push(c); break; }
+            if (eop_write_sync()) prosper_vo_flip_from_gpu(c.flip_handle, c.flip_bufidx, c.flip_mode, c.flip_arg);
+            else pend_enqueue(c);
             break;
         default:
             break;   // events / waits / unknown: no register-state effect (handled later)
@@ -323,6 +617,7 @@ void GpuState::apply(const Pm4Command& c) {
 }
 
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
+    g_fold_deferring = false;   // each stream starts unpaused (#312 queue-pause state is per-fold)
     std::vector<Pm4Command> ops;
     decode_pm4(buf, dwords, ops);
     for (const auto& c : ops) st.apply(c);

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -87,4 +87,22 @@ private:
 // Decode `dwords` dwords at `buf` and apply every op to `st`. Returns the number of packets applied.
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st);
 
+// WAIT_REG_MEM queue-pause support (issue #312 — see the block comment in command_processor.cpp).
+// last_fold_deferred(): the most recent run_command_buffer hit an unsatisfied wait, so its
+// remaining memory effects (and its EOP equeue pulse) are pending in the deferred FIFO.
+// flush_deferred_streams(): re-check the FIFO (call at every submit, under the same submit mutex
+// as run_command_buffer); returns how many deferred streams COMPLETED — the caller owes one EOP
+// equeue pulse per completed stream.
+bool last_fold_deferred();
+int  flush_deferred_streams();
+
+} // namespace prosper::gpu
+
+// Apply every pending pipe-drain completion write NOW, in submission order (#312 — see the
+// deferred-completion-write block in command_processor.cpp). Callable from C (the EOP-event
+// worker in hle_kernel_time.cpp binds it weakly).
+extern "C" void prosper_gpu_drain_completion_writes();
+
+namespace prosper::gpu {
+
 } // namespace prosper::gpu

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -25,6 +25,12 @@
 #include <atomic>
 #include <chrono>
 
+#ifndef _WIN32
+// #312 label-slot write watch (exec_image_linux.cpp). Weak: tools that link the AGC HLE without
+// the Linux host exec image simply skip the arm.
+extern "C" void prosper_arm_label_watch(uint64_t addr) __attribute__((weak));
+#endif
+
 namespace prosper {
 
 #define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
@@ -320,6 +326,40 @@ HLE(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cac
         fprintf(stderr, "[agc] ReleaseMem action=0x%llx dst=0x%llx addr=0x%llx data_sel=0x%llx data=0x%llx\n",
             (unsigned long long)a1,(unsigned long long)a3,(unsigned long long)a5,
             (unsigned long long)data_sel,(unsigned long long)data);
+    // #312 attribution probe: the heap-corrupting writes are 32-bit value-1 fences into 0x20-
+    // stride label arrays. Log each DISTINCT guest callsite that builds one (first eboot-range
+    // return address on the stack), so the owning guest subsystem can be disassembled. Bounded.
+    if (data_sel == 1 && data == 1) {
+#ifndef _WIN32
+        // #312 label watch (PROSPER_WATCH_LABEL=1): watch the first heap-resident fence label's
+        // block for the game's allocator free-path writing over it while cbs still signal it.
+        if (prosper_arm_label_watch && a5 >= 0x1000000000ull && a5 < 0x1200000000ull)
+            prosper_arm_label_watch(a5);
+#endif
+        static std::atomic<int> seen_n{0};
+        static uint64_t seen_ra[16];
+        uint64_t ra = 0, ra2 = 0, ra3 = 0;
+        for (int i = 1; i < 96; i++) {
+            uint64_t v = fp[i];
+            if (v >= 0x400000000ull && v < 0x4c0000000ull) {
+                if (!ra) ra = v; else if (!ra2) ra2 = v; else { ra3 = v; break; }
+            }
+        }
+        uint64_t key = ra2 ? ra2 : ra;
+        if (key) {
+            bool logged = false;
+            int n = seen_n.load();
+            for (int i = 0; i < n && i < 16; i++) if (seen_ra[i] == key) { logged = true; break; }
+            if (!logged && n < 16) {
+                seen_ra[seen_n.fetch_add(1) & 15] = key;
+                fprintf(stderr, "[agc] fence1-builder ra=eboot+0x%llx ra2=eboot+0x%llx ra3=eboot+0x%llx addr=0x%llx action=0x%llx\n",
+                        (unsigned long long)(ra - 0x400000000ull),
+                        (unsigned long long)(ra2 ? ra2 - 0x400000000ull : 0),
+                        (unsigned long long)(ra3 ? ra3 - 0x400000000ull : 0),
+                        (unsigned long long)a5, (unsigned long long)a1);
+            }
+        }
+    }
     // EOP fence: stash the label address (a5), the data_sel, the full 64-bit value, and the event action
     // into the packet so the CommandProcessor performs the completion write at SUBMIT time (correct
     // end-of-pipe timing — our GPU folds synchronously, so submit == pipe drain). CONFIDENCE: HIGH — the
@@ -834,10 +874,15 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     constexpr uint32_t kUnknownCap = 0x80000;   // 512 KiB of dwords — well past any real Dcb
     uint32_t walk = dw_num ? dw_num : kUnknownCap;
     std::lock_guard<std::mutex> lk(g_agc_state_mu);   // serialize with the other submit entry (#278)
+    // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
+    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
     agc_gpu_state().draws.clear();
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
-    prosper_eq_trigger_eop();
+    // A fold that PAUSED on an unsatisfied wait has not completed — its EOP pulse fires when its
+    // deferred effects flush (one pulse per completed stream, owed by flush_deferred_streams).
+    if (!gpu::last_fold_deferred()) prosper_eq_trigger_eop();
+    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
     static const unsigned render_every2 = [] {
         const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
     static unsigned draw_submits2 = 0;
@@ -846,6 +891,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
         static const uint32_t scale = [] {
             const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
         if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
+        prosper_gpu_drain_completion_writes();   // renderer reads WRITE_DATA-uploaded guest memory (#312)
         if (gpu::execute_and_present(agc_gpu_state(), w, h)) g_presents_cum++;
     }
     if (getenv("PROSPER_GFXLOG"))
@@ -937,12 +983,16 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     // must NOT accumulate — otherwise it grows unbounded and every later frame re-renders stale geometry.
     // Clearing here (not after) keeps this submit's draws inspectable once the handler returns. (Ported
     // from PRs #31/#32.)
+    // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
+    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
     agc_gpu_state().draws.clear();
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
-    prosper_eq_trigger_eop();
+    // #312: a fold that PAUSED on an unsatisfied wait has not completed — its pulse fires at flush.
+    if (!gpu::last_fold_deferred()) prosper_eq_trigger_eop();
+    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
     // Stage A: if a live renderer has been registered (runtime binary wires a Vulkan device) and this
     // submit accumulated draws, execute the folded GpuState and present the frame. Inert (returns false)
     // on the pure-HLE path until a device is registered, so it never perturbs the existing boot behavior.
@@ -963,6 +1013,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         static const uint32_t scale = [] {
             const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
         if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
+        prosper_gpu_drain_completion_writes();   // renderer reads WRITE_DATA-uploaded guest memory (#312)
         bool presented = gpu::execute_and_present(agc_gpu_state(), w, h);
         if (presented) g_presents_cum++;
         if (presented && getenv("PROSPER_GFXLOG"))

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -12,6 +12,7 @@
 #include <cerrno>
 #include <string>
 #include <mutex>
+#include <atomic>        // sceKernelAio* submit-id/state table
 #include <map>
 #include <vector>
 #include <fcntl.h>
@@ -374,6 +375,89 @@ HLE(f_pwrite) { return (uint64_t)(int64_t)::pwrite((int)a0, P(a1), (size_t)a2, (
 HLE(f_pread)  { return (uint64_t)-1; }
 HLE(f_pwrite) { return (uint64_t)-1; }
 #endif
+
+// --- sceKernelAio* — the kernel async-IO command API (issue #312 suspect list). -----------------
+// PS4-inherited contract, reference shadPS4 core/libraries/kernel/aio.cpp (the PS5 3.20 libkernel
+// exports the IDENTICAL NID set — verified against ../PS5-3.20_Libs/libkernel.c). The kernel model
+// we implement (same as shadPS4): commands complete synchronously at submit — prosper's guest fds
+// ARE host fds, so each element performs a positioned read/write immediately; each request's
+// result out-struct {s64 returnValue; u32 state} is filled per element; *id receives a nonzero
+// submit id whose state Poll/Wait return; Delete/Cancel write their out-params and recycle the id.
+// The previous unimplemented stubs returned 0 WITHOUT writing *id, *state, or any result — the
+// guest (DOLL's SaveLoadUpdate worker submits its GameSaveData writes here; CRI FS submits movie
+// reads) then consumed uninitialized ids and poll states. DOLL calls the singular variants; the
+// plural/Multiple ones are registered to the same helpers where the ABI is element-wise.
+// AioSetParam is init-tuning (no out-params) -> honest success. CONFIDENCE: HIGH on the ABI
+// (shadPS4 + identical PS5 NIDs); MED on error constants (0x8002000e EFAULT, shadPS4's choice).
+namespace {
+constexpr uint64_t kAioErrFault = 0x8002000eull;             // SCE_KERNEL_ERROR_EFAULT
+enum : int32_t { kAioProcessing = 2, kAioCompleted = 3, kAioAborted = 4 };
+struct AioResult { int64_t return_value; uint32_t state; };
+struct AioReq { int64_t offset; int64_t nbyte; void* buf; AioResult* result; int32_t fd; };
+constexpr uint32_t kAioQueue = 512;                          // shadPS4 MAX_QUEUE
+std::atomic<int32_t> g_aio_state[kAioQueue];                 // id -> state (0 = never used)
+std::atomic<uint32_t> g_aio_next{1};
+uint64_t aio_submit(uint64_t reqs, int32_t n, bool is_write, uint64_t out_id) {
+    if (!reqs || !out_id) return kAioErrFault;
+    auto* req = (AioReq*)P(reqs);
+    uint32_t raw = g_aio_next.fetch_add(1) % kAioQueue;
+    if (!raw) raw = g_aio_next.fetch_add(1) % kAioQueue;     // id 0 is "no request"
+    int32_t id = (int32_t)raw;
+    g_aio_state[raw].store(kAioProcessing);
+    for (int32_t i = 0; i < n; i++) {
+        int64_t r;
+#ifndef _WIN32
+        r = is_write ? (int64_t)::pwrite(req[i].fd, req[i].buf, (size_t)req[i].nbyte, (off_t)req[i].offset)
+                     : read_full(req[i].fd, req[i].buf, (size_t)req[i].nbyte, true, (off_t)req[i].offset);
+#else
+        // Windows host (secondary): emulate positioned IO with lseek+read/write on the CRT fd.
+        long long prev = ::_lseeki64(req[i].fd, 0, SEEK_CUR);
+        ::_lseeki64(req[i].fd, req[i].offset, SEEK_SET);
+        r = is_write ? (int64_t)::_write(req[i].fd, req[i].buf, (unsigned)req[i].nbyte)
+                     : (int64_t)::_read(req[i].fd, req[i].buf, (unsigned)req[i].nbyte);
+        if (prev >= 0) ::_lseeki64(req[i].fd, prev, SEEK_SET);
+#endif
+        if (req[i].result) {
+            req[i].result->return_value = r;
+            req[i].result->state = (r < 0) ? kAioAborted : kAioCompleted;
+        }
+        if (filelog()) fprintf(stderr, "[file] aio-%s fd=%d off=0x%llx n=0x%llx -> %lld\n",
+                               is_write ? "write" : "read", req[i].fd,
+                               (unsigned long long)req[i].offset, (unsigned long long)req[i].nbyte,
+                               (long long)r);
+    }
+    g_aio_state[raw].store(kAioCompleted);
+    *(int32_t*)P(out_id) = id;
+    return 0;
+}
+}
+HLE(k_aio_init)         { return 0; }                        // InitializeImpl / InitializeParam / SetParam
+HLE(k_aio_submit_read)  { return aio_submit(a0, (int32_t)a1, false, a3); }   // (req[], n, prio, id*)
+HLE(k_aio_submit_write) { return aio_submit(a0, (int32_t)a1, true,  a3); }
+HLE(k_aio_wait)  {   // (id, s32* state, u32* usec) — everything completed at submit: report and return
+    if (!a1) return kAioErrFault;
+    *(int32_t*)P(a1) = g_aio_state[(uint32_t)a0 % kAioQueue].load();
+    return 0;
+}
+HLE(k_aio_poll)  {   // (id, s32* state)
+    if (!a1) return kAioErrFault;
+    *(int32_t*)P(a1) = g_aio_state[(uint32_t)a0 % kAioQueue].load();
+    return 0;
+}
+HLE(k_aio_delete) {  // (id, s32* ret)
+    if (!a1) return kAioErrFault;
+    g_aio_state[(uint32_t)a0 % kAioQueue].store(kAioAborted);
+    *(int32_t*)P(a1) = 0;
+    return 0;
+}
+HLE(k_aio_cancel) {  // (id, s32* state): nothing is in flight to cancel — report current/aborted
+    if (!a1) return kAioErrFault;
+    if (a0) { g_aio_state[(uint32_t)a0 % kAioQueue].store(kAioAborted);
+              *(int32_t*)P(a1) = kAioAborted; }
+    else    *(int32_t*)P(a1) = kAioProcessing;   // shadPS4: id 0 -> "processing"
+    return 0;
+}
+
 #ifndef _WIN32
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct stat st; int r = ::stat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
@@ -979,6 +1063,17 @@ void register_file_hle() {
     R("rmdir", f_rmdir);          R("sceKernelRmdir", f_rmdir);
     R("unlink", f_unlink);        R("sceKernelUnlink", f_unlink);
     R("sceKernelGetdents", f_getdents); R("getdents", f_getdents);
+    // sceKernelAio* (issue #312): NIDs verified identical in shadPS4's PS4 registration table and
+    // the PS5 3.20 libkernel stub dump. Raw-NID registration (names not in our NidDb).
+    Hle::register_fn("vYU8P9Td2Zo", (HleFn)k_aio_init,         "sceKernelAioInitializeImpl");
+    Hle::register_fn("nu4a0-arQis", (HleFn)k_aio_init,         "sceKernelAioInitializeParam");
+    Hle::register_fn("9WK-vhNXimw", (HleFn)k_aio_init,         "sceKernelAioSetParam");
+    Hle::register_fn("HgX7+AORI58", (HleFn)k_aio_submit_read,  "sceKernelAioSubmitReadCommands");
+    Hle::register_fn("XQ8C8y+de+E", (HleFn)k_aio_submit_write, "sceKernelAioSubmitWriteCommands");
+    Hle::register_fn("KOF-oJbQVvc", (HleFn)k_aio_wait,         "sceKernelAioWaitRequest");
+    Hle::register_fn("2pOuoWoCxdk", (HleFn)k_aio_poll,         "sceKernelAioPollRequest");
+    Hle::register_fn("5TgME6AYty4", (HleFn)k_aio_delete,       "sceKernelAioDeleteRequest");
+    Hle::register_fn("fR521KIGgb8", (HleFn)k_aio_cancel,       "sceKernelAioCancelRequest");
     R("sceKernelAprResolveFilepathsToIdsAndFileSizes", f_apr_resolve);   // real APR resolve (was EINVAL)
     // libSceAmpr sceAmprAprCommandBufferReadFile (NID name recovered by brute-force). The Linux
     // entry is an asm shim that snapshots rsp so the handler can read the stack args (arg7 = file

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -981,6 +981,11 @@ HLE(k_batch_map) {
         uint64_t len   = *(const uint64_t*)(e + 0x10);
         uint8_t  prot  = e[0x18];
         int32_t  op    = *(const int32_t*)(e + 0x1c);
+        // Per-entry phys trace (#312 alias hunt): log map/unmap WITH the phys offset so an offline
+        // pass can prove/disprove two live VAs aliasing one phys range through the shared memfd.
+        MLOG("bm op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
+             op, (unsigned long long)start, (unsigned long long)phys,
+             (unsigned long long)len, prot);
         bool ok = true;
         switch (op) {
             case 0: {                               // MAP_DIRECT: phys-backed (aliasing preserved)

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -428,9 +428,14 @@ void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
 // Fire the registered EOP events — called when a submit completes. Posts TriggerEvent(ident=id,
 // filter=GraphicsCore, data=id, udata) to each registered equeue, matching shadPS4's IRQ handler.
 // Inert if none registered.
+// GPU pipe-drain completion-write drain (src/gpu/command_processor.cpp, #312): an EOP EVENT must
+// never overtake its submit's fence/label WRITES — drain the write queue before posting. Weak so
+// binaries that link the kernel HLE without the gpu lib still link.
+extern "C" void prosper_gpu_drain_completion_writes() __attribute__((weak));
 namespace {
     // Actually post one EOP completion to every registered equeue (the worker below calls this).
     void eop_post_now() {
+        if (prosper_gpu_drain_completion_writes) prosper_gpu_drain_completion_writes();
         // Deliver EVERY GPU-completion event as a DISTINCT equeue entry (coalesce=false). All EOP events
         // share the same (ident, EVFILT_GRAPHICS_CORE), so coalescing collapses N submit-completions into
         // ONE pending event — and the game's EOP handler posts a work-queue semaphore once per delivered

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -96,6 +96,16 @@ namespace {
     bool     g_watch_armed = false;
     bool     g_watch_stepping = false;
     volatile sig_atomic_t g_watch_hits = 0;
+    // #312 label-slot write watch (PROSPER_WATCH_LABEL=1): armed by the AGC fence builder on the
+    // first heap-resident 32-bit value-1 fence label; every write into the label's 0x20-byte block
+    // is logged with the writer's rip — distinguishing the game's allocator free-path (guest rip)
+    // from prosper's own fence writes (host rip), i.e. catching a write-after-free in the act.
+    uint64_t g_lwatch_slot = 0;
+    uint64_t g_lwatch_page = 0;
+    volatile sig_atomic_t g_lwatch_armed = 0;
+    bool     g_lwatch_stepping = false;
+    uint64_t g_lwatch_step_rip = 0;
+    volatile sig_atomic_t g_lwatch_hits = 0;
     // PROSPER_BP=0xOFFSET (guest image offset): int3 code-breakpoint that LOGS registers at each hit,
     // then steps over and re-arms. Diagnostic (never changes control flow). Used to enumerate the
     // GfxDevice drain (proved every category-{5,9,15,18,19} pipeline has a null [+0x140] companion).
@@ -392,6 +402,107 @@ namespace {
                     n = snprintf(b, sizeof b, "    %s[+0x%llx]@+0x%llx = <unmapped>\n", pfx,
                                  (unsigned long long)ps.pre[k], (unsigned long long)ps.off[k]);
                 syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+            }
+        }
+    }
+
+    // GPU write-attribution ring scanner (src/gpu/command_processor.cpp). Weak: tools that link
+    // the host exec image without the gpu lib get a null and skip the scan.
+    extern "C" int prosper_gpu_write_ring_scan(uint64_t lo, uint64_t hi, char* out, size_t cap)
+        __attribute__((weak));
+
+    // Issue-#312 heap-corruption attribution dump, fired on the first PROSPER_NULL_PAGE hit (the
+    // deterministic precursor of DOLL's MallocBinned3 "Canary was 0x3" fatal: a read of address
+    // 0x1 at eboot+0x231012b — the game's free path following a corrupted free-block field).
+    // Dumps: the faulting instruction bytes, all GPRs, a 0x60-byte window of guest memory around
+    // every heap-pointer-looking register (the corrupted FFreeBlock header will be among them),
+    // and any recent GPU-performed writes (EOP/WRITE_DATA ring) near those addresses — the
+    // attribution question. Async-signal-safe: raw syscalls + probe_readable only.
+    void nullpage_deep_dump(ucontext_t* uc, uint64_t rip) {
+        char b[512]; int n;
+        // instruction bytes at rip (decode offline)
+        if (probe_readable(rip)) {
+            const uint8_t* p = (const uint8_t*)(uintptr_t)rip;
+            n = snprintf(b, sizeof b, "[nullpage]   insn @rip:"
+                         " %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x\n",
+                         p[0],p[1],p[2],p[3],p[4],p[5],p[6],p[7],p[8],p[9],p[10],p[11],p[12],p[13],p[14],p[15]);
+            syscall(SYS_write, 2, b, (size_t)n);
+        }
+        auto& g = uc->uc_mcontext.gregs;
+        const struct { const char* nm; uint64_t v; } regs[] = {
+            {"rax", (uint64_t)g[REG_RAX]}, {"rbx", (uint64_t)g[REG_RBX]},
+            {"rcx", (uint64_t)g[REG_RCX]}, {"rdx", (uint64_t)g[REG_RDX]},
+            {"rsi", (uint64_t)g[REG_RSI]}, {"rdi", (uint64_t)g[REG_RDI]},
+            {"rbp", (uint64_t)g[REG_RBP]}, {"rsp", (uint64_t)g[REG_RSP]},
+            {"r8 ", (uint64_t)g[REG_R8]},  {"r9 ", (uint64_t)g[REG_R9]},
+            {"r10", (uint64_t)g[REG_R10]}, {"r11", (uint64_t)g[REG_R11]},
+            {"r12", (uint64_t)g[REG_R12]}, {"r13", (uint64_t)g[REG_R13]},
+            {"r14", (uint64_t)g[REG_R14]}, {"r15", (uint64_t)g[REG_R15]},
+        };
+        n = 0;
+        for (int i = 0; i < 16; i++) {
+            n += snprintf(b + n, sizeof b - (size_t)n, "%s%s=0x%llx", (i % 4) ? " " : "[nullpage]   ",
+                          regs[i].nm, (unsigned long long)regs[i].v);
+            if (i % 4 == 3) { b[n++] = '\n'; syscall(SYS_write, 2, b, (size_t)n); n = 0; }
+        }
+        for (int i = 0; i < 16; i++) {
+            uint64_t v = regs[i].v;
+            if (v < 0x10000 || !probe_readable(v)) continue;
+            // rbp: the canary-walk keeps its locals at rbp-0x78..-0x48 (pool-table ptr, chain
+            // heads) — start the window at rbp-0x80 so they're captured.
+            uint64_t base = (v & ~0xfull) - (i == 6 /*rbp*/ ? 0x80 : 0x20);
+            if (!probe_readable(base)) base = v & ~0xfull;
+            int nw = (i == 6) ? 20 : 12;
+            n = snprintf(b, sizeof b, "[nullpage]   %s=0x%llx mem@0x%llx:", regs[i].nm,
+                         (unsigned long long)v, (unsigned long long)base);
+            for (int w = 0; w < nw; w++) {
+                uint64_t addr = base + (uint64_t)w * 8;
+                if (probe_readable(addr))
+                    n += snprintf(b + n, sizeof b - (size_t)n, " %016llx",
+                                  (unsigned long long)*(const uint64_t*)addr);
+                else
+                    n += snprintf(b + n, sizeof b - (size_t)n, " ????????????????");
+            }
+            n += snprintf(b + n, sizeof b - (size_t)n, "\n");
+            syscall(SYS_write, 2, b, (size_t)n);
+            // Corrupted-header hunt: the canary walk faulted following a NextFreeBlock == 0x1, so
+            // the stomped FFreeBlock header is a qword equal to 0x1 somewhere in the current slab
+            // (a 64 KiB-aligned guest-heap register, r13 in the observed walk). Scan the slab for
+            // qword==1 candidates, dump each header, and tight-match the GPU write ring at exactly
+            // that address — if the ring has a 4-byte value-1 write there, OUR ReleaseMem stomped it.
+            if (v >= 0x1000000000ull && v < 0x1200000000ull && (v & 0xffff) == 0) {
+                // Slab-wide ring scan first (the corrupted header may no longer read as ==1 by
+                // dump time — the walk pops nodes as it goes), then the qword==1 candidates.
+                if (prosper_gpu_write_ring_scan) {
+                    static char slab_out[16384];
+                    if (prosper_gpu_write_ring_scan(v, v + 0x10000, slab_out, sizeof slab_out) > 0)
+                        syscall(SYS_write, 2, slab_out, strlen(slab_out));
+                }
+                int hits = 0;
+                for (uint64_t o = 0; o < 0x10000 && hits < 24; o += 8) {
+                    uint64_t addr = v + o;
+                    if (!probe_readable(addr)) break;
+                    if (*(const uint64_t*)addr != 0x1ull) continue;
+                    hits++;
+                    const uint64_t* q = (const uint64_t*)(addr - 8);
+                    n = snprintf(b, sizeof b,
+                                 "[nullpage]   slab+0x%04llx qword==1 @0x%llx: [-8]=%016llx [0]=%016llx [+8]=%016llx [+10]=%016llx\n",
+                                 (unsigned long long)o, (unsigned long long)addr,
+                                 (unsigned long long)q[0], (unsigned long long)q[1],
+                                 (unsigned long long)q[2], (unsigned long long)q[3]);
+                    syscall(SYS_write, 2, b, (size_t)n);
+                    if (prosper_gpu_write_ring_scan) {
+                        static char hit_out[1024];
+                        if (prosper_gpu_write_ring_scan(addr - 8, addr + 16, hit_out, sizeof hit_out) > 0)
+                            syscall(SYS_write, 2, hit_out, strlen(hit_out));
+                    }
+                }
+            } else if (prosper_gpu_write_ring_scan) {
+                // recent GPU writes near this register's address (attribution ring, gpu lib; weak —
+                // tools that link exec_image without the gpu lib simply skip this)
+                static char ring_out[4096];
+                if (prosper_gpu_write_ring_scan(v - 0x100, v + 0x100, ring_out, sizeof ring_out) > 0)
+                    syscall(SYS_write, 2, ring_out, strlen(ring_out));
             }
         }
     }
@@ -860,6 +971,56 @@ namespace {
                 return;
             }
         }
+        // #312 label-slot watch: SIGTRAP after single-stepping a write to the watched label page —
+        // log the slot's post-write value, re-protect, keep watching.
+        if (sig == SIGTRAP && g_lwatch_stepping) {
+            auto* uc = (ucontext_t*)uctx;
+            uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;   // clear TF
+            if (g_lwatch_step_rip) {   // the stepped write was inside the watched block: log post-value
+                char b[160];
+                int n = snprintf(b, sizeof b, "[lwatch]   -> slot now [0]=0x%llx [8]=0x%llx\n",
+                                 (unsigned long long)*(const uint64_t*)g_lwatch_slot,
+                                 (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8));
+                syscall(SYS_write, 2, b, (size_t)n);
+                g_lwatch_step_rip = 0;
+            }
+            if (g_lwatch_armed) mprotect((void*)g_lwatch_page, 0x1000, PROT_READ);
+            g_lwatch_stepping = false;
+            return;
+        }
+        // A write into the watched label page while armed: log writes that land in the label's
+        // 0x20-byte block (with pre-content + writer rip), then single-step past the write.
+        if (g_lwatch_armed && sig == SIGSEGV && si->si_addr) {
+            uint64_t fa = (uint64_t)si->si_addr;
+            auto* uc = (ucontext_t*)uctx;
+            if ((fa & ~(uint64_t)0xfff) == g_lwatch_page && (uc->uc_mcontext.gregs[REG_ERR] & 2)) {
+                uint64_t rip = (uint64_t)uc->uc_mcontext.gregs[REG_RIP];
+                g_lwatch_step_rip = 0;
+                if (fa >= g_lwatch_slot - 0x18 && fa < g_lwatch_slot + 0x20) {
+                    g_lwatch_hits = g_lwatch_hits + 1;
+                    char b[224];
+                    bool guest = rip >= 0x400000000ull && rip < 0x4c0000000ull;
+                    int n = snprintf(b, sizeof b,
+                        "[lwatch] #%d write fa=0x%llx rip=%s0x%llx tid=%ld pre[0]=0x%llx pre[8]=0x%llx\n",
+                        (int)g_lwatch_hits, (unsigned long long)fa,
+                        guest ? "eboot+" : "host:",
+                        (unsigned long long)(guest ? rip - 0x400000000ull : rip), cur_tid(),
+                        (unsigned long long)*(const uint64_t*)g_lwatch_slot,
+                        (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8));
+                    syscall(SYS_write, 2, b, (size_t)n);
+                    g_lwatch_step_rip = rip;
+                    if (g_lwatch_hits >= 400) {   // bounded: disarm after enough evidence
+                        mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
+                        g_lwatch_armed = 0;
+                        return;
+                    }
+                }
+                mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
+                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // TF -> single-step the write
+                g_lwatch_stepping = true;
+                return;
+            }
+        }
         // Companion-slot write-watchpoint: SIGTRAP after single-stepping a write to the watched page —
         // re-arm (re-protect read-only) and clear the trap flag so we keep watching.
         if (sig == SIGTRAP && g_watch_stepping) {
@@ -1000,6 +1161,7 @@ namespace {
                                      (int)g_null_page_count, (unsigned long long)a,
                                      (unsigned long long)(rip - 0x400000000ull));
                     syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                    nullpage_deep_dump(uc, rip);   // issue-#312 attribution dump (registers + heap + GPU ring)
                     return;   // re-execute; the null read now sees zero
                 }
             }
@@ -1222,6 +1384,22 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
     return true;
 }
 
+// #312 label-slot write watch (PROSPER_WATCH_LABEL=1): called by the AGC fence builder with the
+// first heap-resident value-1 fence label address; protects the label's page and logs every write
+// into the label's block with the writer's rip (guest allocator free-path vs prosper fence write),
+// catching a write-after-free in the act. Diagnostic, one page, bounded to 400 logged hits.
+extern "C" void prosper_arm_label_watch(uint64_t addr) {
+    static const bool on = getenv("PROSPER_WATCH_LABEL") != nullptr;
+    if (!on || g_lwatch_armed || !addr) return;
+    g_lwatch_slot = addr;
+    g_lwatch_page = addr & ~(uint64_t)0xfff;
+    if (mprotect((void*)g_lwatch_page, 0x1000, PROT_READ) == 0) {
+        g_lwatch_armed = 1;
+        fprintf(stderr, "[lwatch] armed slot=0x%llx page=0x%llx\n",
+                (unsigned long long)addr, (unsigned long long)g_lwatch_page);
+    }
+}
+
 // Install a per-thread alternate signal stack so the fault handler can run even when the faulting
 // thread's own stack is exhausted (a guest stack overflow otherwise delivers SIGSEGV with no usable
 // stack -> the handler can't run -> the process cores uncatchably). Idempotent per thread. Worker
@@ -1253,7 +1431,7 @@ void install_trap_handler() {
     g_watch_companion = getenv("PROSPER_WATCH_COMPANION") != nullptr;
     if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
     if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
-    if (g_faultmem || g_skip_null_companion) ensure_probe_pipe();
+    if (g_faultmem || g_skip_null_companion || g_null_page) ensure_probe_pipe();
     // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
     // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).
     if (const char* pk = getenv("PROSPER_PEEK")) {
@@ -1350,7 +1528,8 @@ void install_trap_handler() {
     sigaction(SIGSEGV, &sa, nullptr);
     sigaction(SIGBUS,  &sa, nullptr);
     sigaction(SIGILL,  &sa, nullptr);
-    if (g_watch_companion || g_bp_on || g_hwbp_on) sigaction(SIGTRAP, &sa, nullptr);   // single-step / breakpoint
+    if (g_watch_companion || g_bp_on || g_hwbp_on
+        || getenv("PROSPER_WATCH_LABEL")) sigaction(SIGTRAP, &sa, nullptr);   // single-step / breakpoint
 }
 
 // Write the 0xCC breakpoint into the (now-mapped) guest image. Call after the image load.

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -22,6 +22,14 @@ struct Dcb {   // mirror of hle_agc.cpp's AgcDcb
     void* callback; void* user_data; uint32_t reserved_dw; uint32_t pad;
 };
 
+// Fold + drain: completion writes ride the modeled pipe-drain queue (#312) and become
+// guest-visible at a drain point — tests assert the guest-visible (post-drain) state.
+static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
+    size_t n = run_command_buffer(buf, dwords, st);
+    prosper_gpu_drain_completion_writes();
+    return n;
+}
+
 int main() {
     printf("== test_command_processor ==\n");
     register_builtin_hle();
@@ -53,7 +61,7 @@ int main() {
     draw(D, 0x0006, 0, 0, 0, 0);
 
     GpuState st;
-    size_t n = run_command_buffer(buffer, 256, st);
+    size_t n = run_cb(buffer, 256, st);
     printf("  applied %zu packets\n", n);
 
     // Cx register file: the three offsets set to their values.
@@ -85,7 +93,7 @@ int main() {
         pkt[1] = 0x100u;                                        // start register offset
         for (uint32_t k = 0; k < 5; k++) pkt[2 + k] = 0xD0000000u + k;
         GpuState s2;
-        run_command_buffer(pkt, 1 + M, s2);
+        run_cb(pkt, 1 + M, s2);
         CHECK(s2.sh.size() == 5, "SET_SH_REG range set all 5 registers (not just the first)");
         bool all = true;
         for (uint32_t k = 0; k < 5; k++) all &= (s2.sh.count(0x100u + k) && s2.sh[0x100u + k] == 0xD0000000u + k);
@@ -107,7 +115,7 @@ int main() {
             Dcb fd{}; fd.bottom = fbuf; fd.top = fbuf + 64; fd.cursor_up = fbuf; fd.cursor_down = fbuf + 64;
             setflip((uint64_t)(uintptr_t)&fd, 0x1001, 1, 2, 0x1234567890abcdefull, 0);
             GpuState s3;
-            run_command_buffer(fbuf, 64, s3);
+            run_cb(fbuf, 64, s3);
             flipstatus(0x1001, (uint64_t)(uintptr_t)st_after, 0, 0, 0, 0);
             uint64_t cnt_b = *(uint64_t*)(st_before + 0x00), cnt_a = *(uint64_t*)(st_after + 0x00);
             int64_t  arg_a = *(int64_t*)(st_after + 0x18);
@@ -132,7 +140,7 @@ int main() {
             idx(ID, /*index_size*/ 2, 0, 0, 0, 0);              // 16-bit indices
             drawi(ID, /*index_count*/ 6, (uint64_t)(uintptr_t)indices, /*modifier*/ 0x40000000ull, 0, 0);
             GpuState s5;
-            run_command_buffer(ibuf, 64, s5);
+            run_cb(ibuf, 64, s5);
             CHECK(s5.draws.size() == 1, "DrawIndex recorded one draw");
             if (s5.draws.size() == 1) {
                 const auto& d = s5.draws[0];
@@ -153,15 +161,15 @@ int main() {
         auto set_sh = [&](uint32_t off, uint32_t val, GpuState& s) {
             pkt[0] = 0xC0000000u | (1u << 16) | (0x76u << 8);   // SET_SH_REG, 2 payload dwords
             pkt[1] = off; pkt[2] = val;
-            run_command_buffer(pkt, 3, s);
+            run_cb(pkt, 3, s);
         };
         uint32_t draw_pkt[3] = { 0xC0000000u | (1u << 16) | (0x10u << 8) | (0x04u << 2), 6, 0 };
         GpuState s4;
         set_sh(0x42, 0xAAAA, s4);
-        run_command_buffer(draw_pkt, 3, s4);                    // draw 0 under 0xAAAA
-        run_command_buffer(draw_pkt, 3, s4);                    // draw 1: no writes since draw 0
+        run_cb(draw_pkt, 3, s4);                    // draw 0 under 0xAAAA
+        run_cb(draw_pkt, 3, s4);                    // draw 1: no writes since draw 0
         set_sh(0x42, 0xBBBB, s4);
-        run_command_buffer(draw_pkt, 3, s4);                    // draw 2 under 0xBBBB
+        run_cb(draw_pkt, 3, s4);                    // draw 2 under 0xBBBB
         CHECK(s4.draws.size() == 3 && s4.draws[0].state && s4.draws[2].state, "3 draws with snapshots");
         if (s4.draws.size() == 3 && s4.draws[0].state && s4.draws[2].state) {
             CHECK(s4.draws[0].state->sh.at(0x42) == 0xAAAA, "draw 0 snapshot holds the value AT the draw");

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -25,6 +25,14 @@ static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
 }
 
+// Fold + drain: completion writes ride the modeled pipe-drain queue (#312) and become
+// guest-visible at a drain point — tests assert the guest-visible (post-drain) state.
+static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
+    size_t n = run_command_buffer(buf, dwords, st);
+    prosper_gpu_drain_completion_writes();
+    return n;
+}
+
 int main() {
     printf("== test_eop_write ==\n");
 
@@ -40,7 +48,7 @@ int main() {
         buf[4] = 0xF00DBEEFu; buf[5] = 0x12345678u;   // value = 0x12345678F00DBEEF
         buf[6] = 0x04;                                // event action
         GpuState st;
-        size_t n = run_command_buffer(buf, 7, st);
+        size_t n = run_cb(buf, 7, st);
         CHECK(n == 1, "RELEASE_MEM decoded as one packet");
         CHECK(label == 0x12345678F00DBEEFull, "RELEASE_MEM (data_sel=2) wrote the 64-bit fence value to the label");
     }
@@ -55,7 +63,7 @@ int main() {
         buf[3] = 1;                                   // data_sel = Data32Low
         buf[4] = 0x0000CAFEu; buf[5] = 0;
         buf[6] = 0x04;
-        GpuState st; run_command_buffer(buf, 7, st);
+        GpuState st; run_cb(buf, 7, st);
         CHECK((label & 0xffffffffu) == 0x0000CAFEu, "RELEASE_MEM (data_sel=1) wrote the low 32 bits");
         CHECK((label >> 32) == 0xAAAAAAAAu, "RELEASE_MEM (data_sel=1) left the upper 32 bits untouched");
     }
@@ -70,7 +78,7 @@ int main() {
         };
         uint32_t b1[7], b2[7];
         build(b1, (uint64_t)(uintptr_t)&l1); build(b2, (uint64_t)(uintptr_t)&l2);
-        GpuState st; run_command_buffer(b1, 7, st); run_command_buffer(b2, 7, st);
+        GpuState st; run_cb(b1, 7, st); run_cb(b2, 7, st);
         CHECK(l1 != 0 && l2 >= l1, "RELEASE_MEM (data_sel=3) wrote a monotonic non-zero GPU clock");
     }
 
@@ -86,7 +94,7 @@ int main() {
         buf[1] = (uint32_t)(addr & 0xffffffffu); buf[2] = (uint32_t)(addr >> 32);
         buf[3] = 3; buf[4] = 0; buf[5] = 0; buf[6] = 0x04;
         uint64_t before = prosper_guest_tsc_ns();
-        GpuState st; run_command_buffer(buf, 7, st);
+        GpuState st; run_cb(buf, 7, st);
         uint64_t after = prosper_guest_tsc_ns();
         CHECK(label >= before && label <= after,
               "data_sel=3 fence lies on the sceKernelReadTsc timeline (shared guest TSC, not steady_clock)");
@@ -102,7 +110,7 @@ int main() {
         buf[2] = (uint32_t)(addr & 0xffffffffu); buf[3] = (uint32_t)(addr >> 32);
         buf[4] = 3;                                   // num_dwords
         buf[5] = 0x11111111u; buf[6] = 0x22222222u; buf[7] = 0x33333333u;
-        GpuState st; run_command_buffer(buf, 8, st);
+        GpuState st; run_cb(buf, 8, st);
         CHECK(target[0] == 0x11111111u && target[1] == 0x22222222u && target[2] == 0x33333333u,
               "WRITE_DATA copied all 3 inline dwords to the destination");
     }
@@ -116,7 +124,7 @@ int main() {
         buf[1] = 0; buf[2] = (uint32_t)(addr & 0xffffffffu); buf[3] = (uint32_t)(addr >> 32);
         buf[4] = 99;                                  // lies: claims 99 dwords, only 2 present (buf[5],buf[6])
         buf[5] = 0xDEADu; buf[6] = 0xBEEFu;
-        GpuState st; run_command_buffer(buf, 7, st);
+        GpuState st; run_cb(buf, 7, st);
         CHECK(target[0] == 0xDEADu && target[1] == 0xBEEFu && target[2] == 0 && target[3] == 0,
               "WRITE_DATA clamped num_dwords to what the packet actually holds");
     }
@@ -131,7 +139,7 @@ int main() {
         buf[0] = PM4(4, IT_EVENT_WRITE, 0);
         buf[1] = 0x14;                                // some event_type
         buf[2] = (uint32_t)(addr & 0xffffffffu); buf[3] = (uint32_t)(addr >> 32);
-        GpuState st; run_command_buffer(buf, 4, st);
+        GpuState st; run_cb(buf, 4, st);
         CHECK(label != 0, "address-carrying EVENT_WRITE wrote a completion value to the label (was dropped)");
     }
     // An address-LESS EVENT_WRITE (event_addr == 0, a pipeline-sync event) must remain a no-op.
@@ -140,7 +148,7 @@ int main() {
         buf[0] = PM4(4, IT_EVENT_WRITE, 0);
         buf[1] = 0x16; buf[2] = 0; buf[3] = 0;        // no address
         GpuState st;
-        size_t n = run_command_buffer(buf, 4, st);    // must not fault / write anywhere
+        size_t n = run_cb(buf, 4, st);    // must not fault / write anywhere
         CHECK(n == 1, "address-less EVENT_WRITE decodes and is a harmless no-op");
     }
 


### PR DESCRIPTION
## What this is

Root-cause work on the **#312 MallocBinned3 heap-corruption fatal** (DOLL/PPSA17942, menu-driven content-load burst). Rebased onto current master; the AGC predicated-jump builders I had prototyped were **dropped** — #327 already landed a superior implementation of `sceAgcDcbJump`/`SetPredication`/`SetPacketPredication` (which also renders DOLL's composite). This PR keeps only the independently-valuable pieces:

**1. `sceKernelAio*` implemented honestly** (`src/hle/hle_file.cpp`) — Submit{Read,Write}Commands perform the positioned IO immediately (guest fds are host fds), fill each request's `{returnValue, state}` result, hand back a real submit id; Wait/Poll/Delete/Cancel write their real out-params. Reference: shadPS4 `aio.cpp`; NIDs verified identical in the PS5 3.20 libkernel dump. Previously success+garbage-out stubs on DOLL's save-write path (and the known CRI movie gate). Live-verified: `GameSaveData` now actually writes (`aio-write fd=17 n=0xc28 -> 3112`). CONFIDENCE: HIGH.

**2. Pipe-drain completion-write model** (`src/gpu/command_processor.cpp`) — fence label writes, EVENT_WRITE timestamps, WRITE_DATA and the in-stream flip become guest-visible via a 1 ms FIFO worker (extends #232's EOP-event model to the data writes) instead of INSIDE the submit call; synchronous drains keep every data dependency exact (WaitRegMem evaluation, execute_and_present, EOP-event post). `PROSPER_EOP_WRITE_SYNC=1` restores the old behavior. Reconciled cleanly with #327's command-processor changes (its recursive Jump fold and this model interoperate — jumped-segment effects flow through the same drain). CONFIDENCE: HIGH on the invariant.

**3. Attribution/diagnostic tooling** (bounded or env-gated) that pinned the corruption mechanism (see issue #312): GPU write-ring + async-signal-safe scanner wired into the PROSPER_NULL_PAGE fault dump (registers, instruction bytes, slab scan, ring matches), EOP-write-over-pointer catcher, fence1-builder guest-callsite probe, `PROSPER_WATCH_LABEL` mprotect single-step label watch (`PROSPER_HWWATCH_ABS` family), per-entry BatchMap phys MLOG.

## The bug is NOT fixed
The MallocBinned3 fatal still reproduces (~85% of input-driven runs). The corruptor is **conclusively attributed**: prosper's own RELEASE_MEM (data_sel=1) value-1 per-segment consumed-marker fence writes landing in freed MallocBinned3 heap (write-ring matched our writes at exactly the corrupted qwords; `PROSPER_WATCH_LABEL` caught the literal `0x1000000001` being produced). Next lead documented on the issue.

## Verification
- ctest **71/71** (post-rebase, master's 3 new tests included)
- Messenger golden-image guard: `snapshot.py check` → **messenger-scene OK** (24,318 colors)
- DOLL menu drive on the rebased branch reached t=135s / 1.65M draws with 0 fatal this run (no new destabilization from pipe-drain on top of #327's now-executing jumps)

refs #312