### PR TITLE
fix(hle): stop a no-op shadowing scePthreadGetprio/Getaffinity (#330)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -125,6 +125,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_service_getters PRIVATE prosper_core)
   add_test(NAME service_getters COMMAND test_service_getters)
 
+  # pthread scheduling getters fill their out-param (not a shadowing no-op): scePthreadGetprio/
+  # Getaffinity must WRITE priority/mask, else the caller reads uninitialized stack (harmful-stub class).
+  add_executable(test_pthread_sched_getters tests/test_pthread_sched_getters.cpp)
+  target_link_libraries(test_pthread_sched_getters PRIVATE prosper_core)
+  add_test(NAME pthread_sched_getters COMMAND test_pthread_sched_getters)
+
   # libScePad controller input: ScePadData layout + HostPadState mapping + HLE fill contract (pure).
   add_executable(test_pad tests/test_pad.cpp)
   target_link_libraries(test_pad PRIVATE prosper_core)

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -1002,12 +1002,12 @@ void register_kernel_time_hle() {
     R("sceSysmoduleIsLoaded", k_ok);
     R("sceKernelLoadStartModule", k_load_start_mod);
     R("sceKernelStopUnloadModule", k_ok);
-    // thread scheduling hints — safe no-ops
-    R("scePthreadSetaffinity", k_ok);
-    R("scePthreadGetaffinity", k_ok);
-    R("scePthreadSetprio", k_ok);
-    R("scePthreadGetprio", k_ok);
-    R("scePthreadSetschedparam", k_ok);
+    // Thread scheduling: Set*/Get* are registered in hle_kernel.cpp, where the Get* handlers FILL
+    // their out-params (affinity mask 0xff, priority 700) — a Get* that returns success without
+    // writing hands the caller uninitialized stack memory. register_kernel_time_hle() runs AFTER
+    // register_kernel_hle(), so re-registering scePthreadGet{affinity,prio} to a bare k_ok here
+    // (last-write-wins) SILENTLY re-broke exactly that fix. Only scePthreadRename is unique to this
+    // file; leave the scheduling functions to hle_kernel.cpp.
     R("scePthreadRename", k_ok);
     R("sceKernelUuidCreate", k_uuid_create);
     R("_exit", k_exit);

--- a/prosper/tests/test_pthread_sched_getters.cpp
+++ b/prosper/tests/test_pthread_sched_getters.cpp
@@ -1,0 +1,50 @@
+// test_pthread_sched_getters — scePthreadGetprio / scePthreadGetaffinity must FILL their out-param.
+//
+// Both have correct handlers in hle_kernel.cpp (k_getprio writes priority 700; k_attr_getaffinity
+// writes an 8-core mask 0xff). hle_kernel_time.cpp ALSO registered them to a bare no-op (k_ok), and
+// register_kernel_time_hle() runs AFTER register_kernel_hle(), so — registration being last-write-
+// wins — the no-op silently shadowed the real handlers: the getter returned success while never
+// writing its out-param, handing the caller uninitialized stack memory (the exact harmful-stub class
+// the hle_kernel.cpp comment says was already fixed). This locks the shadowing out: a Get* that
+// returns OK MUST have written its out-param. Fails if the no-op registration ever wins again.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_pthread_sched_getters ==\n");
+    register_builtin_hle();
+
+    HleFn getprio     = Hle::lookup(nid_hash("scePthreadGetprio"));
+    HleFn getaffinity = Hle::lookup(nid_hash("scePthreadGetaffinity"));
+    CHECK(getprio != nullptr, "scePthreadGetprio is registered");
+    CHECK(getaffinity != nullptr, "scePthreadGetaffinity is registered");
+    if (!getprio || !getaffinity) { printf("== FAIL ==\n"); return 1; }
+
+    // scePthreadGetprio(thread, int* prio): must write the priority (Sony default 700), not leave the
+    // caller's int untouched. Pre-seed a sentinel that a working handler overwrites.
+    const int32_t SENT = (int32_t)0x0BADF00D;
+    int32_t prio = SENT;
+    uint64_t rp = getprio(1 /*dummy thread*/, (uint64_t)(uintptr_t)&prio, 0, 0, 0, 0);
+    CHECK(rp == 0, "scePthreadGetprio returns OK");
+    CHECK(prio != SENT, "scePthreadGetprio WROTE the prio out-param (not the shadowing no-op)");
+    CHECK(prio == 700, "scePthreadGetprio writes the Sony default priority 700");
+
+    // scePthreadGetaffinity(thread, SceKernelCpumask* mask): must write a usable (non-empty) core mask.
+    uint64_t mask = 0xEEEEEEEEEEEEEEEEull;
+    uint64_t ra = getaffinity(1 /*dummy thread*/, (uint64_t)(uintptr_t)&mask, 0, 0, 0, 0);
+    CHECK(ra == 0, "scePthreadGetaffinity returns OK");
+    CHECK(mask != 0xEEEEEEEEEEEEEEEEull, "scePthreadGetaffinity WROTE the mask out-param (not the shadowing no-op)");
+    CHECK(mask != 0 && (mask & 0x1) != 0, "scePthreadGetaffinity writes a non-empty core mask (>=1 usable CPU)");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #330.

## Bug
`scePthreadGetprio` / `scePthreadGetaffinity` have correct handlers in `hle_kernel.cpp` (`k_getprio` writes priority 700; `k_attr_getaffinity` writes an 8-core mask `0xff`) — precisely because a `Get*` that returns success without writing its out-param hands the caller uninitialized stack memory (the `hle_kernel.cpp:353-357` comment spells this out). But `hle_kernel_time.cpp` **also** registered both to a bare no-op `k_ok`, and `register_kernel_time_hle()` runs **after** `register_kernel_hle()`. Registration is last-write-wins (`dispatch.cpp:33`), so the no-op **silently shadowed** the real handlers — undoing that fix.

Result: the guest calls `scePthreadGetprio(thread, &prio)`, gets **OK** back, and `prio` is never written. A title that sizes its worker pool from the affinity mask or branches on thread priority then acts on garbage — a silent, layers-down corruption.

## Fix
Remove the duplicate scheduling registrations from `hle_kernel_time.cpp` (the `Set*` were harmless no-ops already registered in `hle_kernel.cpp`; the `Get*` were the harmful ones). Only `scePthreadRename` is unique to that file and stays. Pthread scheduling now has a single source of truth.

## Verification
- New `pthread_sched_getters` test asserts each getter **wrote** its out-param (a pre-seeded sentinel must be overwritten): `prio == 700`, mask non-empty with ≥1 usable CPU.
- Confirmed it **FAILS with the shadowing restored** (4 failures — getters return OK, out-params untouched) and passes without it.
- Full `ctest` **72/72 green**, incl. `boot_reaches_first_syscall`.