### PR TITLE
test(hle): guard against the register_fn double-registration shadow class (#330)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -60,6 +60,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)
 
+  # No NID registered twice with a DIFFERENT handler (the #330 shadow class): a later register_*()
+  # silently overwriting a real impl with a stub returns garbage to the guest. Pure, no game dump.
+  add_executable(test_hle_no_shadow tests/test_hle_no_shadow.cpp)
+  target_link_libraries(test_hle_no_shadow PRIVATE prosper_core)
+  add_test(NAME hle_no_shadow COMMAND test_hle_no_shadow)
+
   # Cooperative stop signal (issue #164 P0): request_stop/stop_requested the frontend uses to wind
   # the guest run-loop down on window-close. Pure, no deps.
   add_executable(test_lifecycle tests/test_lifecycle.cpp)

--- a/prosper/src/hle/dispatch.cpp
+++ b/prosper/src/hle/dispatch.cpp
@@ -5,7 +5,11 @@
 namespace prosper {
 
 namespace {
-    struct Reg { HleFn fn; std::string name; };
+    // `placeholder` marks a deliberately-overridable registration (e.g. hle_graphics' per-NID glog
+    // tracing thunks, which a real handler in hle_agc is EXPECTED to replace later). Overwriting a
+    // placeholder is intended and not flagged; overwriting a REAL handler with a different fn is the
+    // accidental-shadow class (#330) that register_fn records.
+    struct Reg { HleFn fn; std::string name; bool placeholder = false; };
     std::unordered_map<std::string, Reg>& registry() {
         static std::unordered_map<std::string, Reg> r; return r;
     }
@@ -29,9 +33,30 @@ void dispatch_set_progress(volatile int* counter) { g_progress = counter; }
 
 void (*g_hwwatch_hook)(uint64_t) = nullptr;   // set by the Linux exec harness (perf HW watchpoints)
 
+namespace { std::vector<ShadowedReg>& shadow_list() { static std::vector<ShadowedReg> s; return s; } }
+
 void Hle::register_fn(const std::string& nid, HleFn fn, const char* name) {
-    registry()[nid] = { fn, name ? name : "" };
+    auto& reg = registry();
+    auto it = reg.find(nid);
+    // A second registration of the same NID with a DIFFERENT handler silently shadows the first
+    // (last-write-wins). Record it so a test can flag the real-impl-shadowed-by-stub class (#330) —
+    // UNLESS the existing entry is a deliberately-overridable placeholder (that override is intended).
+    // A re-registration with the SAME fn (harmless dedup) is not recorded.
+    if (it != reg.end() && it->second.fn != fn && !it->second.placeholder)
+        shadow_list().push_back({ nid, it->second.name, name ? name : "" });
+    reg[nid] = { fn, name ? name : "", false };
 }
+void Hle::register_placeholder(const std::string& nid, HleFn fn, const char* name) {
+    // Same as register_fn but marks the entry overridable, so a later real handler replacing it is
+    // not flagged as an accidental shadow. Does NOT itself overwrite a real (non-placeholder) entry
+    // silently: if one already exists with a different fn, that's still recorded.
+    auto& reg = registry();
+    auto it = reg.find(nid);
+    if (it != reg.end() && it->second.fn != fn && !it->second.placeholder)
+        shadow_list().push_back({ nid, it->second.name, name ? name : "" });
+    reg[nid] = { fn, name ? name : "", true };
+}
+const std::vector<ShadowedReg>& Hle::shadowed_registrations() { return shadow_list(); }
 HleFn Hle::lookup(const std::string& nid) {
     auto it = registry().find(nid);
     return it == registry().end() ? nullptr : it->second.fn;

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -20,12 +20,31 @@ using HleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uin
 // is the stub slot number; the trap logger names calls via this table.
 struct ImportSlot { std::string lib, nid; };
 
+// One case where register_fn OVERWROTE an already-registered NID with a DIFFERENT handler.
+// Registration is last-write-wins with no warning, so whichever register_*() runs last silently
+// takes the NID — and if the loser was a real implementation and the winner a naive stub, the guest
+// gets the stub (e.g. #330: a Get* that no longer wrote its out-param). Recorded at registration time
+// so the winner/loser reflect the true runtime order, not a static guess.
+struct ShadowedReg {
+    std::string nid;          // the collided key
+    std::string prev_name;    // display name of the registration that was overwritten
+    std::string new_name;     // display name of the registration that won
+};
+
 // Registry of implemented functions, keyed by NID.
 class Hle {
 public:
     static void  register_fn(const std::string& nid, HleFn fn, const char* name);
+    // Like register_fn, but marks the entry as a deliberately-overridable placeholder (a diagnostic/
+    // tracing thunk that a real handler is expected to replace later). A subsequent register_fn that
+    // overwrites a placeholder is NOT flagged as a shadow — that override is the intent.
+    static void  register_placeholder(const std::string& nid, HleFn fn, const char* name);
     static HleFn lookup(const std::string& nid);          // nullptr if unimplemented
     static const char* name_of(const std::string& nid);   // registered display name or ""
+    // Every NID that was registered 2+ times with DIFFERING handlers, in registration order. Empty
+    // is the healthy state; a non-empty list is the #330 double-registration-shadow class and must be
+    // reviewed (the winner is the LAST registration). Populated as register_fn runs.
+    static const std::vector<ShadowedReg>& shadowed_registrations();
 };
 
 // Wire the unimplemented-call logger to the global stub-slot table + name DB.

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -561,7 +561,9 @@ __attribute__((noinline)) uint64_t glog_thunk(uint64_t a0, uint64_t a1, uint64_t
 }
 template <size_t... Is>
 void register_agc_tracers(std::index_sequence<Is...>) {
-    (Hle::register_fn(kAgcNids[Is], (HleFn)&glog_thunk<Is>, kAgcNids[Is]), ...);
+    // Placeholders: hle_agc registers the REAL handlers for the implemented subset later and is meant
+    // to override these tracing thunks — so mark them overridable and that override is not a shadow.
+    (Hle::register_placeholder(kAgcNids[Is], (HleFn)&glog_thunk<Is>, kAgcNids[Is]), ...);
 }
 }
 

--- a/prosper/tests/test_hle_no_shadow.cpp
+++ b/prosper/tests/test_hle_no_shadow.cpp
@@ -1,0 +1,71 @@
+// test_hle_no_shadow — guards the whole double-registration-shadow class (#330).
+//
+// Hle::register_fn is last-write-wins with no warning: register a NID in two files and whichever
+// register_*() runs LAST silently takes it. When the loser was a real implementation and the winner
+// a naive stub, the guest gets the stub (e.g. scePthreadGetprio returning OK without writing its
+// out-param). register_fn now records every collision where the handler CHANGED; this test asserts
+// there are none left. If an intentional override is ever added, list its NID in kAllowed with a
+// justification — silence here is the healthy state.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+
+using namespace prosper;
+
+static uint64_t dummy_a(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { return 1; }
+static uint64_t dummy_b(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { return 2; }
+
+int main() {
+    printf("== test_hle_no_shadow ==\n");
+    // Reverse map: NID -> readable name, from the built-in symbol list (for diagnostics only).
+    std::unordered_map<std::string, std::string> nid2name;
+    for (const auto& n : builtin_symbol_names()) nid2name.emplace(nid_hash(n), n);
+    auto name_of = [&](const std::string& nid) -> std::string {
+        auto it = nid2name.find(nid); return it == nid2name.end() ? std::string("?") : it->second;
+    };
+    register_builtin_hle();
+
+    const auto& shadows = Hle::shadowed_registrations();
+    // Known-intentional overrides (none today). Format: NID that a later registration deliberately
+    // replaces with a better handler. Keep this empty unless there's a documented reason.
+    static const char* kAllowed[] = { nullptr };
+
+    int unexpected = 0;
+    for (const auto& s : shadows) {
+        bool allowed = false;
+        for (const char** a = kAllowed; *a; ++a) if (s.nid == *a) { allowed = true; break; }
+        printf("  %s NID=%s (%s) : \"%s\" was overwritten by \"%s\"\n",
+               allowed ? "[allowed]" : "[SHADOW]", s.nid.c_str(), name_of(s.nid).c_str(),
+               s.prev_name.c_str(), s.new_name.c_str());
+        if (!allowed) unexpected++;
+    }
+    if (shadows.empty()) printf("  (no NID registered twice with differing handlers)\n");
+
+    if (unexpected) {
+        printf("== FAIL: %d unexpected shadowed registration(s) — a later register_*() silently\n"
+               "   replaced a handler. If the WINNER is a naive stub shadowing a real impl, that is\n"
+               "   the #330 bug (getter returns OK without writing its out-param). Remove the duplicate\n"
+               "   (leave the function in one file), or allowlist it in kAllowed with a reason. ==\n",
+               unexpected);
+        return 1;
+    }
+
+    // Self-validation: prove the detector actually fires, so a clean list above means "no shadow",
+    // not "detector broken". A real->real overwrite IS recorded; a placeholder->real override is NOT.
+    size_t before = Hle::shadowed_registrations().size();
+    Hle::register_fn("test.dummy.shadow", (HleFn)dummy_a, "dummy_a");
+    Hle::register_fn("test.dummy.shadow", (HleFn)dummy_b, "dummy_b");   // real->real, different fn
+    bool caught = Hle::shadowed_registrations().size() == before + 1;
+    printf("  [%s] mechanism: overwriting a real handler with a different fn is recorded\n", caught ? "ok" : "FAIL");
+    Hle::register_placeholder("test.dummy.ph", (HleFn)dummy_a, "ph");
+    size_t mid = Hle::shadowed_registrations().size();
+    Hle::register_fn("test.dummy.ph", (HleFn)dummy_b, "real");          // placeholder->real override
+    bool ignored = Hle::shadowed_registrations().size() == mid;
+    printf("  [%s] mechanism: overriding a placeholder is NOT recorded\n", ignored ? "ok" : "FAIL");
+    if (!caught || !ignored) { printf("== FAIL: shadow detector is not working ==\n"); return 1; }
+
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #330 (merged). That was one instance of a whole class: `Hle::register_fn` is **last-write-wins with no warning**, so any NID registered in two files silently resolves to whichever `register_*()` runs last. In #330 a `k_ok` stub overwrote the real `scePthreadGet{prio,affinity}`, so the getters returned OK while leaving their out-param uninitialized — a silent, layers-down corruption. Nothing guarded the class, so it could recur.

## What this adds
- **Detection**: `register_fn` records every collision where an existing handler is overwritten by a **different** fn, exposed via `Hle::shadowed_registrations()` (order-accurate — recorded at registration time, so the winner is the true runtime winner, not a static guess).
- **Intent, made explicit**: `register_placeholder` marks a deliberately-overridable entry. `hle_graphics` registers a per-NID **glog tracing thunk** for every AGC NID, and `hle_agc` replaces the implemented subset with the **real** handler later — an intended override (the safe direction: real wins). Marking the 23 glog thunks as placeholders keeps that override off the shadow list while still flagging accidental `real→real` / `real→stub` collisions.
- **Guard test** `hle_no_shadow`: asserts the shadow list is empty after `register_builtin_hle()`.

## The audit result
Enumerating every collision across the whole HLE surface found **exactly 23**, and all 23 are the safe `glog placeholder → real AGC handler` override. **No harmful shadow remains** beyond the already-fixed #330. The guard now prevents a new one from landing silently.

The test **self-validates the detector** (so a clean list means "no shadow", not "detector broken"): it registers a dummy NID twice with different fns and asserts that IS recorded, then overrides a placeholder and asserts that is NOT.

## Verification
Full `ctest` **73/73 green**, incl. `boot_reaches_first_syscall`.