### PR TITLE
fix(gpu): recompile 2D_ARRAY image_sample instead of rejecting the shader (refs #325)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2747,7 +2747,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // gfx1010 round-trip on live DOLL FXAA bytes: 0xf0dc0808/0xf0dc080a "image_sample_lz_o";
             // the offset-adjust folds into the normalized coords, see image_sample_lz_offset_2d).
             const bool is_sample_lz_o = (in.opcode == 0x37);
-            const bool dim2d = (in.mimg_dim == 1u), dim3d = (in.mimg_dim == 2u);
+            // 2D_ARRAY (dim=5) is sampled here as its base 2D slice: the (u,v) coords are read as usual and
+            // the array-index coord is dropped, so the shader RECOMPILES instead of being rejected (previously
+            // dim!=1&&dim!=2 -> ok=false, silently SKIPPING the whole draw — real content loss, #325). Correct
+            // for single-layer arrays (e.g. Unity's default textures, which are 4x4x1); a multi-layer array is
+            // sampled at slice 0, a documented limitation pending full VK_IMAGE_VIEW_TYPE_2D_ARRAY support.
+            const bool dim2d = (in.mimg_dim == 1u || in.mimg_dim == 5u), dim3d = (in.mimg_dim == 2u);
+            if (in.mimg_dim == 5u && getenv("PROSPER_GFXLOG"))
+                fprintf(stderr, "[recompile] 2D_ARRAY image_sample -> sampled as base slice 0 (array index dropped; #325)\n");
             if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b && !is_gather_lz &&
                  !is_gather_lz_o && !is_sample_lz_o) || (!dim2d && !dim3d)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
@@ -3270,9 +3277,11 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     if (i.opcode == 0x00u) return st_dim || i.mimg_dim == 6u || i.mimg_dim == 7u;   // image_load (+ 2D_MSAA[_ARRAY])
                     if (i.opcode == 0x08u) return st_dim;                       // image_store (no per-sample MSAA store)
                     // sample*: 2D (NSA ok); plus implicit-LOD image_sample (0x20) / LOD-0 image_sample_lz
-                    // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D.
-                    if (i.opcode == 0x20u || i.opcode == 0x27u) return i.mimg_dim == 1u || i.mimg_dim == 2u;
-                    if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u;
+                    // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D. 2D_ARRAY (dim 5)
+                    // is accepted for all sample paths and handled as its base 2D slice (array index dropped,
+                    // #325) — so array-sampling draws recompile+render instead of being skipped.
+                    if (i.opcode == 0x20u || i.opcode == 0x27u) return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
+                    if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
                     return false;
                 }
                 case Rdna2Format::MUBUF:  return i.opcode <= 0x07u ||                    // load/store_format_*

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -58,6 +58,18 @@ int main() {
     CHECK(e.unsupported == 0,
           "a narrowed EXEC branch to s_endpgm over a dead scalar write is linearized (guard-to-end shape)");
 
+    // #325: a 2D_ARRAY (SQ_RSRC_IMG_2D_ARRAY, DIM=5) image_sample is now accepted — handled as its base
+    // 2D slice (array index dropped) — instead of rejecting the whole shader (previously DIM!=1&&!=2 was
+    // truly-unsupported, silently skipping the draw). Same bytes as the 2D image_sample (0xF0800F08) with
+    // DIM (dword0 bits[5:3]) = 5 -> 0xF0800F28. It is `table_dependent` (needs a resource table), NOT
+    // `unsupported`, so a real recompile (with the T#) proceeds.
+    const uint32_t arr_sample[] = { 0xF0800F28u, 0x00A30000u, 0xBF810000u };
+    RecompileCoverage f = recompile_coverage(arr_sample, sizeof(arr_sample)/sizeof(arr_sample[0]));
+    printf("  2d_array-sample: total=%u table_dependent=%u unsupported=%u first_bad_fmt=%d\n",
+           f.total, f.table_dependent, f.unsupported, f.first_bad_fmt);
+    CHECK(f.unsupported == 0 && f.table_dependent >= 1 && f.first_bad_fmt < 0,
+          "#325: a 2D_ARRAY image_sample is recompilable-in-context (base slice), not unsupported");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem
A texture-array sample (MIMG `DIM=5`, `SQ_RSRC_IMG_2D_ARRAY`) was neither `dim2d` nor `dim3d`, so:
- the sampled path hit `ok=false`, and
- the recompile-eligibility pre-check (`table_dependent`) counted it as **truly unsupported**.

Result: the **entire shader was rejected** and every draw using it was **silently skipped** — real content loss, not a wrong slice. Any title with array-sampling shaders (common in modern engines / UE) loses that geometry with no diagnostic.

## Fix
Accept `DIM=5` on the sample path and handle it as its **base 2D slice**: read `(u,v)` as usual, drop the array-index coord, so the shader recompiles and the draw renders.
- **Correct** for single-layer arrays — e.g. Unity's default textures are `4×4×1` (The Messenger's title shine samples exactly such a default, see #240).
- A multi-layer array is sampled at **slice 0** — a documented limitation pending full `VK_IMAGE_VIEW_TYPE_2D_ARRAY` support (real per-slice upload + `Arrayed` `OpTypeImage`), left as the **#325 follow-up**.
- Diagnostic logged under `PROSPER_GFXLOG`.

## Risk / verification
Low risk — routes `DIM=5` through the **well-tested 2D sample path**; 2D (`DIM=1`) behavior is unchanged.
- New `test_recompile_coverage` case: a `DIM=5` image_sample is now `table_dependent` (not `unsupported`) — `total=1 table_dependent=1 unsupported=0`.
- **72/72 ctest green.**
- **Messenger golden-image snapshot unchanged** (richest 24318 colors ≥ 5000).

Refs #325 (full per-slice array support remains the follow-up there).