### PR TITLE
fix(gpu): execute AGC DMA_DATA immediate fills — the #312 consumed-marker label-init protocol leg (refs #312)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -138,6 +138,9 @@ static bool ptr_like(uint64_t v) {
 // #312: report one suspicious fence write with its build-journal verdict. kindtag: "REL1" etc.
 static void report_suspect_write(const char* kindtag, uint64_t addr, uint64_t value, uint64_t pre,
                                  uint64_t pkt) {
+    // Skip the first 10 s: boot-time label-array allocations carry benign freelist residue that
+    // burned the whole report budget at t=3.4 s in every run; the corruption class is mid-burst.
+    if (now_ms() < 10000) return;
     static std::atomic<int> n{0};
     if (n.fetch_add(1) >= 96) return;
     uint64_t baddr = 0, bpre = 0, bt = 0;
@@ -241,8 +244,10 @@ static void honor_event_write(const Pm4Command& c) {
 static void honor_dma_data(const Pm4Command& c) {
     if (eop_writes_disabled() || !c.dd_valid) return;
     constexpr uint32_t kMaxFill = 0x1000000;   // 16 MiB — far past any observed fill
+    // dst >= 0x10000: a small dst is a GDS offset (unmodeled), and the PROSPER_NULL_PAGE
+    // read-only zero page would otherwise pass guest_readable() and SEGV the memset.
     bool imm_form = c.dd_bytes >= 1 && c.dd_bytes <= kMaxFill &&
-                    c.dd_dst && !(c.dd_dst & 3) && c.dd_src <= 0xffffffffull;
+                    c.dd_dst >= 0x10000 && !(c.dd_dst & 3) && c.dd_src <= 0xffffffffull;
     if (!imm_form || !guest_readable(c.dd_dst, c.dd_bytes)) {
         // Not the immediate-fill form we model (or unmapped dst) — log so the gap stays visible.
         static std::atomic<int> n{0};

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -61,6 +61,12 @@ struct GpuWriteRec { uint64_t addr; uint64_t value; uint64_t pkt; uint32_t seq; 
 constexpr uint32_t kWriteRingSize = 16384;              // power of two
 GpuWriteRec g_write_ring[kWriteRingSize];
 std::atomic<uint32_t> g_write_seq{0};
+// Coarse monotonic ms since process start (diagnostic timestamps for the #312 fence journal).
+uint64_t now_ms() {
+    static const auto t0 = std::chrono::steady_clock::now();
+    return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+}
 // `pkt` = the guest address of the PM4 packet that requested the write (c.payload-1). The stale-
 // vs-live discriminator: a STALE ring-tail packet re-executed across frames has the SAME pkt
 // address in every record; a legitimately re-recorded per-frame write moves with the ring.
@@ -92,6 +98,60 @@ extern "C" int prosper_gpu_write_ring_scan(uint64_t lo, uint64_t hi, char* out, 
     return found;
 }
 
+// --- #312 fence BUILD journal: the timing-vs-wrong-target discriminator. -------------------------
+// The AGC builders/patchers record, per fence packet (keyed by the packet's guest address):
+// the target label address the GUEST passed, the 8 bytes the target held AT BUILD TIME, and a
+// build timestamp. When honor_eop_write later catches a fence write landing over pointer-like
+// (freed-heap-header-shaped) memory, the journal answers: (a) did the packet's target change
+// between build and fold (packet mutated/mis-decoded => wrong-target), (b) was the target ALREADY
+// freed-looking when the guest built the fence (stale guest structure), or (c) was it clean at
+// build and freed in the build->write window (ordering: our write lands after the guest's free)?
+// Direct-mapped by packet address — collisions just replace (diagnostic-grade).
+namespace {
+struct FenceBuildRec { uint64_t pkt, addr, pre; uint64_t t_ms; };
+constexpr uint32_t kJournalSize = 65536;                // power of two
+FenceBuildRec g_fence_journal[kJournalSize];
+inline uint32_t journal_slot(uint64_t pkt) { return (uint32_t)((pkt >> 2) * 2654435761u) & (kJournalSize - 1); }
+}
+extern "C" void prosper_fence_journal_record(uint64_t pkt, uint64_t addr) {
+    if (!pkt) return;
+    uint64_t pre = 0;
+    if (addr >= 0x10000 && !(addr & 3)) memcpy(&pre, (const void*)(uintptr_t)addr, sizeof pre);
+    FenceBuildRec& r = g_fence_journal[journal_slot(pkt)];
+    r.pkt = pkt; r.addr = addr; r.pre = pre; r.t_ms = now_ms();
+}
+extern "C" int prosper_fence_journal_lookup(uint64_t pkt, uint64_t* addr, uint64_t* pre, uint64_t* t_ms) {
+    if (!pkt) return 0;
+    const FenceBuildRec& r = g_fence_journal[journal_slot(pkt)];
+    if (r.pkt != pkt) return 0;
+    *addr = r.addr; *pre = r.pre; *t_ms = r.t_ms;
+    return 1;
+}
+
+// #312: "pointer-like" pre-content — a freed MallocBinned3 block header holds heap pointers into
+// the 512 GiB arena (0x1000000000) or the allocator-metadata pools (0x2000000000 region, where the
+// FPoolInfo tables live — e.g. the 0x20015f0000 pool-info table of #161/#241).
+static bool ptr_like(uint64_t v) {
+    return (v >= 0x1000000000ull && v < 0x1200000000ull) ||
+           (v >= 0x2000000000ull && v < 0x2100000000ull);
+}
+// #312: report one suspicious fence write with its build-journal verdict. kindtag: "REL1" etc.
+static void report_suspect_write(const char* kindtag, uint64_t addr, uint64_t value, uint64_t pre,
+                                 uint64_t pkt) {
+    static std::atomic<int> n{0};
+    if (n.fetch_add(1) >= 96) return;
+    uint64_t baddr = 0, bpre = 0, bt = 0;
+    int have = prosper_fence_journal_lookup(pkt, &baddr, &bpre, &bt);
+    fprintf(stderr, "[agc] SUSPECT-%s [0x%llx] pre=0x%llx value=0x%llx pkt=0x%llx t=%llums | "
+                    "journal:%s built@%llums(age=%lldms) built-addr=0x%llx%s pre@build=0x%llx%s\n",
+            kindtag, (unsigned long long)addr, (unsigned long long)pre, (unsigned long long)value,
+            (unsigned long long)pkt, (unsigned long long)now_ms(),
+            have ? "" : " MISS", (unsigned long long)bt,
+            have ? (long long)(now_ms() - bt) : -1,
+            (unsigned long long)baddr, (have && baddr != addr) ? " TARGET-CHANGED" : "",
+            (unsigned long long)bpre, (have && ptr_like(bpre)) ? " STALE-AT-BUILD" : "");
+}
+
 // Honor a RELEASE_MEM / EVENT_WRITE_EOP completion write. data_sel (Kyty GraphicsCbReleaseMem allows {2,3};
 // shadPS4 DataSelect enum): 1=write 32-bit value, 2=write 64-bit value, 3=write 64-bit GPU clock. The write
 // uses memcpy so an only-4-byte-aligned 64-bit label is handled portably. CONFIDENCE: HIGH — address,
@@ -111,16 +171,15 @@ static void honor_eop_write(const Pm4Command& c) {
                   // #312 stomp-catcher: a live fence label holds small ints/timestamps; a freed
                   // MallocBinned3 FFreeBlock header holds heap POINTERS. Pointer-like pre-content
                   // means this fence write is landing in freed (or reused) memory — log it in the
-                  // act, with the packet address for attribution. Diagnostic only, always-on
-                  // (one 8-byte read per fence write), bounded to 64 reports.
+                  // act, with the packet address + the build-journal verdict (timing vs wrong-
+                  // target). A fence TARGET inside the allocator-metadata region (0x20xxxxxxxx,
+                  // the FPoolInfo tables) is suspect regardless of content. Diagnostic, bounded.
+                  // (Run-1 finding: legit fence labels DO live in the 0x20xxxxxxxx region — a
+                  // target-region trigger caught only benign fences and burned the report cap.
+                  // Trigger on pointer-like PRE-CONTENT only.)
                   uint64_t pre = 0; memcpy(&pre, dst, sizeof pre);
-                  if (pre >= 0x1000000000ull && pre < 0x1200000000ull) {
-                      static std::atomic<int> n{0};
-                      if (n.fetch_add(1) < 64)
-                          fprintf(stderr, "[agc] EOP-WRITE-OVER-POINTER [0x%llx] pre=0x%llx value=0x%llx pkt=0x%llx\n",
-                                  (unsigned long long)c.rel_addr, (unsigned long long)pre,
-                                  (unsigned long long)c.rel_value, (unsigned long long)pkt_addr(c));
-                  }
+                  if (ptr_like(pre))
+                      report_suspect_write("REL1", c.rel_addr, c.rel_value, pre, pkt_addr(c));
                   uint32_t v = (uint32_t)c.rel_value; memcpy(dst, &v, sizeof v);
                   ring_record(c.rel_addr, v, 4, 1, pkt_addr(c)); break; }
         case 2: { if (!c.rel_value_valid) return;
@@ -168,6 +227,13 @@ static void honor_event_write(const Pm4Command& c) {
 // Honor a WRITE_DATA packet: copy the inline dwords to the destination address (same synchronous timing).
 static void honor_write_data(const Pm4Command& c) {
     if (eop_writes_disabled() || !c.wd_addr || (c.wd_addr & 3) || !c.wd_data || !c.wd_num) return;
+    // #312 stomp-catcher (same as the ReleaseMem one): a small label-init WriteData landing over
+    // pointer-like memory, or targeting the allocator-metadata region, is a suspect stomp.
+    if (c.wd_num <= 4) {
+        uint64_t pre = 0; memcpy(&pre, (const void*)(uintptr_t)c.wd_addr, sizeof pre);
+        if (ptr_like(pre))
+            report_suspect_write("WDATA", c.wd_addr, c.wd_data[0], pre, pkt_addr(c));
+    }
     memcpy((void*)(uintptr_t)c.wd_addr, c.wd_data, (size_t)c.wd_num * 4);
     ring_record(c.wd_addr, c.wd_data[0], (uint8_t)(c.wd_num * 4 > 255 ? 255 : c.wd_num * 4), 3, pkt_addr(c));
     if (getenv("PROSPER_GFXLOG"))
@@ -530,10 +596,16 @@ void GpuState::apply(const Pm4Command& c) {
                     static const bool defer_on = [] {
                         const char* e = getenv("PROSPER_WAIT_DEFER");
                         return e && strtol(e, nullptr, 0) != 0; }();
-                    fprintf(stderr, "[agc] WaitRegMem NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s\n",
+                    // #312 discriminator: build-journal age + freed-heap-shaped label content.
+                    uint64_t baddr = 0, bpre = 0, bt = 0;
+                    int have = prosper_fence_journal_lookup(pkt_addr(c), &baddr, &bpre, &bt);
+                    fprintf(stderr, "[agc] WaitRegMem NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s\n",
                             (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
                             (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
-                            defer_on ? "pausing queue (deferred effects)" : "dependency violated");
+                            defer_on ? "pausing queue (deferred effects)" : "dependency violated",
+                            (unsigned long long)bt, have ? (long long)(now_ms() - bt) : -1,
+                            (have && baddr != c.wm_addr) ? " TARGET-CHANGED" : "",
+                            (unsigned long long)bpre, ptr_like(mem) ? " CONTENT-PTR-LIKE(freed?)" : "");
                     if (defer_on) {
                         g_fold_deferring = true;
                         g_defer_streams++;

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -79,7 +79,7 @@ uint64_t pkt_addr(const Pm4Command& c) { return c.payload ? (uint64_t)(uintptr_t
 }
 // Scan the ring for writes intersecting [lo, hi); format up to `max` matches into out (NUL-
 // terminated). Async-signal-safe: no locks, no allocation, tolerates racy ring slots. kind:
-// 1=RELEASE_MEM 2=EVENT_WRITE 3=WRITE_DATA.
+// 1=RELEASE_MEM 2=EVENT_WRITE 3=WRITE_DATA 4=DMA_DATA.
 extern "C" int prosper_gpu_write_ring_scan(uint64_t lo, uint64_t hi, char* out, size_t cap) {
     size_t off = 0; int found = 0;
     uint32_t seq_now = g_write_seq.load(std::memory_order_relaxed);
@@ -222,6 +222,49 @@ static void honor_event_write(const Pm4Command& c) {
         fprintf(stderr, "[agc]   EventWrite [0x%llx] event_type=%u -> clock 0x%llx\n",
                 (unsigned long long)c.event_addr, c.event_type, (unsigned long long)v);
     wake_on_label(c.event_addr);   // wake any sync_on_address futex waiter on this completion label
+}
+
+// Honor a DMA_DATA packet's memory effect (issue #312 — the MallocBinned3 heap-corruption root
+// cause). DOLL's RHIThread emits DmaData(srcOrImm=0, dst=<per-chunk fence label>, 4 bytes) per
+// translated segment: the GPU-side INIT (label := 0) of the consumed-marker protocol whose
+// completion leg is ReleaseMem(label <- 1). We previously DROPPED every DMA_DATA packet, so the
+// LIFO-recycled label kept the previous generation's 1 and the guest's consumption poll freed the
+// label while fences to it were still in flight (full evidence chain: hle_agc agc_dcb_dma_data).
+// Execution is deliberately GATED to the immediate-fill form (srcOrImm is a 32-bit value, PM4
+// CP-DMA src_sel=DATA semantics: the value is replicated across the destination). DOLL uses two
+// instances of it: the 4-byte per-segment label init above, and 64 KiB zero-fills of freshly
+// allocated 64 KiB-aligned command-stream CHUNKS (whose boundary headers hold the label pointers
+// the consumed-marker emitter reads — a recycled chunk with a stale header is the same stomp).
+// General CP-DMA copies (real src addresses / GDS) stay unexecuted with a bounded log, as before.
+// CONFIDENCE: HIGH on the init form (three-callsite ABI + live page-watch protocol capture);
+// MED on the large-fill form (same selectors + src=0 + fresh-buffer destinations).
+static void honor_dma_data(const Pm4Command& c) {
+    if (eop_writes_disabled() || !c.dd_valid) return;
+    constexpr uint32_t kMaxFill = 0x1000000;   // 16 MiB — far past any observed fill
+    bool imm_form = c.dd_bytes >= 1 && c.dd_bytes <= kMaxFill &&
+                    c.dd_dst && !(c.dd_dst & 3) && c.dd_src <= 0xffffffffull;
+    if (!imm_form || !guest_readable(c.dd_dst, c.dd_bytes)) {
+        // Not the immediate-fill form we model (or unmapped dst) — log so the gap stays visible.
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 24)
+            fprintf(stderr, "[agc] DMA_DATA not executed (unmodeled form): dst=0x%llx src=0x%llx bytes=%u sels=0x%x\n",
+                    (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes, c.dd_sels);
+        return;
+    }
+    uint32_t v32 = (uint32_t)c.dd_src;
+    uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;
+    if (v32 == 0) {
+        memset(dst, 0, c.dd_bytes);
+    } else {
+        uint32_t i = 0;
+        for (; i + 4 <= c.dd_bytes; i += 4) memcpy(dst + i, &v32, 4);
+        if (i < c.dd_bytes) memcpy(dst + i, &v32, c.dd_bytes - i);
+    }
+    ring_record(c.dd_dst, c.dd_src, (uint8_t)(c.dd_bytes > 255 ? 255 : c.dd_bytes), 4, pkt_addr(c));
+    if (getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc]   DmaData [0x%llx] := 0x%x (%u bytes)\n",
+                (unsigned long long)c.dd_dst, v32, c.dd_bytes);
+    wake_on_label(c.dd_dst);
 }
 
 // Honor a WRITE_DATA packet: copy the inline dwords to the destination address (same synchronous timing).
@@ -406,6 +449,7 @@ void apply_effect(const Pm4Command& c) {
         case K::ReleaseMem: honor_eop_write(c); break;
         case K::EventWrite: honor_event_write(c); break;
         case K::WriteData:  honor_write_data(c); break;
+        case K::DmaData:    honor_dma_data(c); break;
         case K::Flip:       if (c.flip_valid) prosper_vo_flip_from_gpu(c.flip_handle, c.flip_bufidx,
                                                                        c.flip_mode, c.flip_arg); break;
         default: break;
@@ -574,6 +618,14 @@ void GpuState::apply(const Pm4Command& c) {
         case K::EventWrite:
             if (g_fold_deferring) { defer_push(c); break; }
             if (eop_write_sync()) honor_event_write(c); else pend_enqueue(c);
+            break;
+        case K::DmaData:
+            // CP-DMA memory effect (#312: the per-segment fence-label INIT). Rides the same FIFO
+            // as the other guest-visible writes: stream order between a generation's ReleaseMem
+            // (label <- 1) and the NEXT generation's DmaData (label := 0) at the same recycled
+            // address is exactly what the guest's consumption poll depends on.
+            if (g_fold_deferring) { defer_push(c); break; }
+            if (eop_write_sync()) honor_dma_data(c); else pend_enqueue(c);
             break;
         case K::WaitRegMem:
             // Real WAIT_REG_MEM semantics (#312): an unsatisfied wait PAUSES this queue — the

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -738,12 +738,16 @@ void GpuState::apply(const Pm4Command& c) {
         case K::Flip:
             // The GPU reaching the SetFlip packet IS the flip moment: perform the videoout flip so
             // GetFlipStatus advances and the game's frame pacer sees its flipArg complete. Only for
-            // a fully-decoded payload — a short packet must not fabricate a flip. Behind an
-            // unsatisfied wait the flip defers with the other effects (#312); otherwise it rides
-            // the pipe-drain queue like every completion signal (a flip is a lifecycle signal —
-            // the game recycles display buffers on it — and must not be observable mid-submit).
+            // a fully-decoded payload — a short packet must not fabricate a flip.
+            //
+            // #312 WAIT_DEFER liveness: the flip is NOT held behind an unsatisfied barrier. Every
+            // WAIT_DEFER run that paused flips wedged the frame loop within seconds (the pacer
+            // starves and the guest stops submitting — including the producer that would satisfy
+            // the barrier). Withholding only the MEMORY writes (ReleaseMem/WriteData/DmaData) keeps
+            // the corruption-relevant ordering (never show a fence value ahead of its barrier)
+            // while the pacing signals flow; the failure direction becomes "label still reads 0 a
+            // little longer" — the safe side of the guest's consumption poll. CONFIDENCE: MED.
             if (!c.flip_valid) break;
-            if (g_fold_deferring) { defer_push(c); break; }
             if (eop_write_sync()) prosper_vo_flip_from_gpu(c.flip_handle, c.flip_bufidx, c.flip_mode, c.flip_arg);
             else pend_enqueue(c);
             break;

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -437,8 +437,13 @@ struct DeferredStream { std::vector<DeferItem> items; size_t next = 0; };
 std::vector<DeferredStream> g_deferred;   // FIFO; guarded by the caller's submit mutex
 bool     g_fold_deferring = false;        // current fold hit an unsatisfied wait
 uint64_t g_defer_streams = 0, g_defer_timeouts = 0;
-constexpr uint64_t kDeferTimeoutMs = 500;
+size_t   g_defer_items = 0;               // total queued items across streams (memory guard)
+// 50 ms: real producer fences satisfy the barrier within ~1 ms via the pend queue; anything
+// pending longer is a dependency we don't model — degrade fast instead of stalling the stream
+// half a second (the 500 ms value made a WAIT_DEFER boot crawl at 2 submits/s).
+constexpr uint64_t kDeferTimeoutMs = 50;
 constexpr size_t   kDeferMaxStreams = 256;   // runaway guard: force-flush oldest beyond this
+constexpr size_t   kDeferMaxItems = 200000;  // memory guard (#312 WAIT_DEFER OOM): force-flush
 
 void defer_push(const Pm4Command& c) {
     DeferItem it; it.cmd = c;
@@ -447,6 +452,7 @@ void defer_push(const Pm4Command& c) {
         it.cmd.wd_data = it.wd_copy.data();
     }
     g_deferred.back().items.push_back(std::move(it));
+    g_defer_items++;
 }
 void apply_effect(const Pm4Command& c) {
     using K = Pm4Command::Kind;
@@ -473,7 +479,7 @@ int flush_deferred_streams() {
     while (!g_deferred.empty()) {
         DeferredStream& s = g_deferred.front();
         bool blocked = false;
-        bool force = g_deferred.size() > kDeferMaxStreams;
+        bool force = g_deferred.size() > kDeferMaxStreams || g_defer_items > kDeferMaxItems;
         while (s.next < s.items.size()) {
             DeferItem& it = s.items[s.next];
             if (it.cmd.kind == Pm4Command::Kind::WaitRegMem) {
@@ -494,6 +500,7 @@ int flush_deferred_streams() {
             s.next++;
         }
         if (blocked) break;
+        g_defer_items -= s.items.size() < g_defer_items ? s.items.size() : g_defer_items;
         g_deferred.erase(g_deferred.begin());
         completed++;
     }

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -146,6 +146,18 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                         c.jump_valid  = true;
                     }
                     break;
+                case R_DMA_DATA:
+                    // sceAgcDcbDmaData / sceAgcAcbDmaData (#312): CP-DMA. payload: [0..1]=dst lo/hi,
+                    // [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels (see agc_dcb_dma_data).
+                    c.kind = K::DmaData;
+                    if (npl >= 6) {
+                        c.dd_dst   = lo_hi(pl);
+                        c.dd_src   = lo_hi(pl + 2);
+                        c.dd_bytes = pl[4];
+                        c.dd_sels  = pl[5];
+                        c.dd_valid = true;
+                    }
+                    break;
                 case R_SET_PRED:
                     // sceAgcDcbSetPredication (#319): begin/end a predication window.
                     // payload: [0..1]=condition addr lo/hi (0 = end), [2]=raw op.

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -23,7 +23,7 @@ enum : uint32_t {
     R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
     R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12, R_UC_REGS_INDIRECT = 0x13,
     R_ACQUIRE_MEM = 0x14, R_WRITE_DATA = 0x15, R_WAIT_MEM_64 = 0x16, R_FLIP = 0x17,
-    R_RELEASE_MEM = 0x18, R_DISPATCH_DIRECT = 0x1a,
+    R_RELEASE_MEM = 0x18, R_DMA_DATA = 0x19, R_DISPATCH_DIRECT = 0x1a,
     // Gen5 indexed-draw state + draw (issue #232, DOLL/UE4 geometry path). These three builders
     // (sceAgcDcbSetIndexBuffer / SetIndexCount / DrawIndexOffset) are the ONLY draw path UE4 uses;
     // they were unimplemented->0 (no packet appended) so every scene draw was silently dropped.
@@ -48,7 +48,8 @@ struct Pm4Command {
     enum class Kind {
         DrawReset, WaitFlipDone, SetShRegDirect, SetRegsIndirect, SetIndexType,
         DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
-        DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Jump, SetPredication, Unknown,
+        DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Jump, SetPredication,
+        DmaData, Unknown,
     } kind = Kind::Unknown;
 
     uint32_t        header = 0;
@@ -140,6 +141,20 @@ struct Pm4Command {
     uint64_t pred_addr = 0;              // SetPredication: 64-bit condition address (0 = window end)
     uint32_t pred_op = 0;                // SetPredication: raw op field
     bool     pred_valid = false;         // SetPredication: payload carried the operands
+
+    // DmaData (sceAgcDcbDmaData / sceAgcAcbDmaData -> R_DMA_DATA; issue #312). The CP-DMA engine
+    // packet. ABI re-pinned from three eboot callsites (see agc_dcb_dma_data): a1 = source address
+    // OR immediate value (the patcher family is named sceAgcDmaDataPatchSetSrcAddressOrOffsetOr-
+    // IMMEDIATE), a4 = DESTINATION address (a callsite passes a freshly-malloc'd buffer there),
+    // stack arg9 = byte count. DOLL's RHI translate loop emits DmaData(src=0, dst=<per-chunk fence
+    // label>, 4 bytes) per segment — the GPU-side label INIT (label := 0) of the consumed-marker
+    // protocol whose completion leg is ReleaseMem(label <- 1). Packet payload:
+    // [0..1]=dst lo/hi, [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels (a2 | a3<<8).
+    uint64_t dd_dst = 0;                 // DmaData: destination address
+    uint64_t dd_src = 0;                 // DmaData: source address OR immediate value
+    uint32_t dd_bytes = 0;               // DmaData: byte count (0 = unrecovered -> not executed)
+    uint32_t dd_sels = 0;                // DmaData: raw selector args (a2 | a3<<8)
+    bool     dd_valid = false;           // DmaData: payload carried the full operand set
 
     uint32_t flip_handle = 0;            // Flip: sceVideoOut handle
     int32_t  flip_bufidx = -1;           // Flip: display buffer index (-1 = not decoded)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
+#include <thread>
 
 #ifndef _WIN32
 // #312 label-slot write watch (exec_image_linux.cpp). Weak: tools that link the AGC HLE without

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -29,7 +29,12 @@
 // #312 label-slot write watch (exec_image_linux.cpp). Weak: tools that link the AGC HLE without
 // the Linux host exec image simply skip the arm.
 extern "C" void prosper_arm_label_watch(uint64_t addr) __attribute__((weak));
+extern "C" void prosper_arm_label_watch_force(uint64_t addr) __attribute__((weak));
 #endif
+// #312 fence BUILD journal (command_processor.cpp): records, per fence packet, the guest-passed
+// target + the target's content at build time + a timestamp — the timing-vs-wrong-target
+// discriminator consulted by the stomp catcher when a fence write lands over freed heap.
+extern "C" void prosper_fence_journal_record(uint64_t pkt, uint64_t addr);
 
 namespace prosper {
 
@@ -333,8 +338,27 @@ HLE(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cac
 #ifndef _WIN32
         // #312 label watch (PROSPER_WATCH_LABEL=1): watch the first heap-resident fence label's
         // block for the game's allocator free-path writing over it while cbs still signal it.
-        if (prosper_arm_label_watch && a5 >= 0x1000000000ull && a5 < 0x1200000000ull)
+        // Under PROSPER_WATCH_ABS the passed address is ignored (fixed slot) — call unconditionally
+        // so the arm retries until the fixed slot's page is mapped.
+        if (prosper_arm_label_watch &&
+            (getenv("PROSPER_WATCH_ABS") || (a5 >= 0x1000000000ull && a5 < 0x1200000000ull)))
             prosper_arm_label_watch(a5);
+#ifndef _WIN32
+        // PROSPER_WATCH_HOT=N (#312): arm the page watch on the Nth fence BUILD targeting the
+        // same heap-resident label — a long-lived hot label is exactly the population that later
+        // gets freed by the guest while still being fenced (the corruption class). Catches the
+        // allocator's free-path writes over it WITH call stacks (see lwatch).
+        static const long hot_n = [] { const char* e = getenv("PROSPER_WATCH_HOT");
+                                       return e ? atol(e) : 0; }();
+        if (hot_n > 0 && prosper_arm_label_watch_force && a5 >= 0x1000000000ull && a5 < 0x1200000000ull) {
+            constexpr uint32_t kHotSize = 8192;                     // direct-mapped addr -> count
+            static uint64_t hot_addr[kHotSize];
+            static uint32_t hot_cnt[kHotSize];
+            uint32_t s = (uint32_t)((a5 >> 4) * 2654435761u) & (kHotSize - 1);
+            if (hot_addr[s] != a5) { hot_addr[s] = a5; hot_cnt[s] = 0; }
+            if (++hot_cnt[s] == (uint32_t)hot_n) prosper_arm_label_watch_force(a5);
+        }
+#endif
 #endif
         static std::atomic<int> seen_n{0};
         static uint64_t seen_ra[16];
@@ -369,6 +393,7 @@ HLE(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cac
     cmd[3] = (uint32_t)data_sel;
     cmd[4] = (uint32_t)(data & 0xffffffffu); cmd[5] = (uint32_t)(data >> 32u);
     cmd[6] = (uint32_t)a1;
+    if (data_sel == 1) prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a5);   // #312 discriminator
     return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address_or_offset, data*, num_dwords, …)
@@ -393,6 +418,7 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     cmd[2] = (uint32_t)(a3 & 0xffffffffu); cmd[3] = (uint32_t)(a3 >> 32u);
     cmd[4] = num;
     if (src) for (uint32_t i = 0; i < num; i++) cmd[5 + i] = src[i];
+    if (num <= 4) prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a3);   // #312 discriminator
     return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_wait_reg_mem) {  // sceAgcDcbWaitRegMem(buf, size, compare_func, op, cache_policy, address, reference, mask, poll_cycles)
@@ -415,6 +441,7 @@ HLE(agc_dcb_wait_reg_mem) {  // sceAgcDcbWaitRegMem(buf, size, compare_func, op,
     cmd[5] = (uint32_t)(reference & 0xffffffffu); cmd[6] = (uint32_t)(reference >> 32u);
     cmd[7] = (uint32_t)a2;                        // compare_function
     cmd[8] = 0;                                   // poll interval hint (arg9 not forwarded; unused by our fold)
+    prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a5);   // #312 discriminator (wait leg)
     return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_set_flip) {  // (buf, video_out_handle, display_buffer_index, flip_mode, flip_arg) — 6 dw
@@ -1074,18 +1101,21 @@ HLE(agc_patch_write_data_addr) {  // fPSCdQxgpSw (cmd, address): WriteData paylo
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     if (!patch_check(cmd, R_WRITE_DATA, "WriteDataPatchAddress")) return 0;
     cmd[2] = (uint32_t)(a1 & 0xffffffffu); cmd[3] = (uint32_t)(a1 >> 32u);
+    prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build
     return 0;
 }
 HLE(agc_patch_wait_reg_mem_addr) {  // 3KDcnM3lrcU (cmd, address): WaitRegMem payload [0..1] = address
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     if (!patch_check(cmd, R_WAIT_MEM_64, "WaitRegMemPatchAddress")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build
     return 0;
 }
 HLE(agc_patch_release_mem_addr) {  // 0fWWK5uG9rQ (cmd, address): ReleaseMem payload [0..1] = address
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     if (!patch_check(cmd, R_RELEASE_MEM, "ReleaseMemPatchAddress")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build
     return 0;
 }
 

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -967,12 +967,9 @@ void start_defer_watchdog() {
         for (;;) {
             struct timespec ts{ 0, 2000000 };   // 2 ms cadence
             nanosleep(&ts, nullptr);
-            int n;
-            {
-                std::lock_guard<std::mutex> lk(g_agc_state_mu);
-                n = gpu::flush_deferred_streams();
-            }
-            for (; n > 0; n--) prosper_eq_trigger_eop();
+            // EOP pulses fire at submit time (liveness); the flush only applies deferred writes.
+            std::lock_guard<std::mutex> lk(g_agc_state_mu);
+            gpu::flush_deferred_streams();
         }
     }).detach();
 }
@@ -989,15 +986,18 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     uint32_t walk = dw_num ? dw_num : kUnknownCap;
     std::lock_guard<std::mutex> lk(g_agc_state_mu);   // serialize with the other submit entry (#278)
     // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
-    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
+    gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
-    // A fold that PAUSED on an unsatisfied wait has not completed — its EOP pulse fires when its
-    // deferred effects flush (one pulse per completed stream, owed by flush_deferred_streams).
-    if (!gpu::last_fold_deferred()) prosper_eq_trigger_eop();
-    else start_defer_watchdog();   // #312: a paused stream must flush even if no submit follows
-    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
+    // #312 WAIT_DEFER liveness: the EOP pulse fires at every submit even when the fold paused on
+    // an unsatisfied barrier — withholding it starved the frame pacer and wedged every WAIT_DEFER
+    // run (submits stop, so the producer that would satisfy the barrier never arrives). Only the
+    // stream's MEMORY writes stay deferred; the watchdog flushes them the moment the barrier
+    // satisfies (or the 50 ms timeout degrades to the old proceed-loudly behavior).
+    prosper_eq_trigger_eop();
+    if (gpu::last_fold_deferred()) start_defer_watchdog();
+    gpu::flush_deferred_streams();
     static const unsigned render_every2 = [] {
         const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
     static unsigned draw_submits2 = 0;
@@ -1099,16 +1099,17 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     // Clearing here (not after) keeps this submit's draws inspectable once the handler returns. (Ported
     // from PRs #31/#32.)
     // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
-    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
+    gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
-    // #312: a fold that PAUSED on an unsatisfied wait has not completed — its pulse fires at flush.
-    if (!gpu::last_fold_deferred()) prosper_eq_trigger_eop();
-    else start_defer_watchdog();   // #312: a paused stream must flush even if no submit follows
-    for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
+    // #312 WAIT_DEFER liveness: the pulse fires even for a fold paused on an unsatisfied barrier —
+    // only the stream's MEMORY writes stay deferred (see submit_dcb_stream).
+    prosper_eq_trigger_eop();
+    if (gpu::last_fold_deferred()) start_defer_watchdog();
+    gpu::flush_deferred_streams();
     // Stage A: if a live renderer has been registered (runtime binary wires a Vulkan device) and this
     // submit accumulated draws, execute the folded GpuState and present the frame. Inert (returns false)
     // on the pure-HLE path until a device is registered, so it never perturbs the existing boot behavior.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -951,6 +951,32 @@ extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws) {
     if (draws)   *draws   = (uint64_t)agc_gpu_state().draws.size();
 }
 
+namespace {
+// PROSPER_WAIT_DEFER watchdog (#312): deferred streams were only re-checked at SUBSEQUENT submits,
+// but a guest that waits for a deferred stream's EOP before submitting again deadlocks (observed:
+// boot wedged at submit #1 under WAIT_DEFER). A 2 ms ticker re-runs the flush (same submit mutex),
+// firing the owed EOP pulse the moment a paused stream's condition satisfies (typically via the
+// pend-queue completion writes) or its timeout expires. Started lazily on the first deferred fold;
+// inert unless PROSPER_WAIT_DEFER=1 ever pauses a stream.
+void start_defer_watchdog() {
+    static std::atomic<bool> started{false};
+    bool expect = false;
+    if (!started.compare_exchange_strong(expect, true)) return;
+    std::thread([] {
+        for (;;) {
+            struct timespec ts{ 0, 2000000 };   // 2 ms cadence
+            nanosleep(&ts, nullptr);
+            int n;
+            {
+                std::lock_guard<std::mutex> lk(g_agc_state_mu);
+                n = gpu::flush_deferred_streams();
+            }
+            for (; n > 0; n--) prosper_eq_trigger_eop();
+        }
+    }).detach();
+}
+}
+
 // Fold one raw Dcb dword stream through the CommandProcessor, fire the GPU EOP completion events, and
 // (if a live renderer is wired and the submit produced draws) execute+present. Shared by the primary
 // submit path (sceAgcDriverSubmitDcb) and the DOLL warmup-submit variant (w1KFAHVqpaU) below.
@@ -969,6 +995,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     // A fold that PAUSED on an unsatisfied wait has not completed — its EOP pulse fires when its
     // deferred effects flush (one pulse per completed stream, owed by flush_deferred_streams).
     if (!gpu::last_fold_deferred()) prosper_eq_trigger_eop();
+    else start_defer_watchdog();   // #312: a paused stream must flush even if no submit follows
     for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
     static const unsigned render_every2 = [] {
         const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
@@ -1079,6 +1106,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
     // #312: a fold that PAUSED on an unsatisfied wait has not completed — its pulse fires at flush.
     if (!gpu::last_fold_deferred()) prosper_eq_trigger_eop();
+    else start_defer_watchdog();   // #312: a paused stream must flush even if no submit follows
     for (int i = gpu::flush_deferred_streams(); i > 0; i--) prosper_eq_trigger_eop();
     // Stage A: if a live renderer has been registered (runtime binary wires a Vulkan device) and this
     // submit accumulated draws, execute the folded GpuState and present the frame. Inert (returns false)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -284,24 +284,84 @@ HLE(agc_cb_nop) {  // (dcb, num_dwords, ...)
     for (uint32_t i = 1; i < num; i++) cmd[i] = 0;
     return (uint64_t)(uintptr_t)cmd;
 }
-// sceAgcDcbDmaData (WmAc2MEj6Io) — append a DMA_DATA packet; observed args (live capture): a4 = src
-// address, a5 = size in dwords, a1 = dst (0 here, patched later via DmaDataPatchSetDstAddressOrOffset).
-// Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=src lo/hi, [5]=size_dw, [6]=flags. Return ptr.
-HLE(agc_dcb_dma_data) {  // (dcb, dst, cache_policy, flags, src, size_dw)
-    // #319 probe: is DmaData part of the per-frame render stream (a GPU-side copy we never execute)?
+// sceAgcDcbDmaData (WmAc2MEj6Io) — append a CP-DMA packet (issue #312, the MallocBinned3 heap-
+// corruption root cause). ABI RE-pinned from three eboot callsites (disassembly, this branch):
+//   sceAgcDcbDmaData(dcb, srcAddressOrOffsetOrImmediate, srcSel?, dstSel?, dstAddressOrOffset,
+//                    <sel/policy>, stack7, stack8, stack9=numBytes, ..., stack12=isBlocking)
+// Evidence for the roles:
+//  - eboot+0x221ad2d..6c: GMalloc->Malloc(size) result (+ running offset) is passed in A4 and the
+//    packet fills it — a freshly-allocated buffer can only be a DESTINATION, so a4 = dst.
+//  - the patcher family names are sceAgcDmaDataPatchSetDstAddressOrOffset (patches [1..2] below)
+//    and sceAgcDmaDataPatchSetSrcAddressOrOffsetOrIMMEDIATE — src can be an immediate value.
+//  - eboot+0x2212384 / 0x220d31e (the RHIThread translate loop's per-segment consumed-marker
+//    emitters): DmaData(src=0, sels=3/3, dst=<chunk fence label>, stack9=4 bytes, blocking) right
+//    before ReleaseMem(label <- 1, data_sel=1). This is the GPU-side LABEL INIT (label := 0): the
+//    guest never CPU-initializes these labels (live page-watch capture), and the labels are LIFO-
+//    recycled heap blocks — without the init, the guest's consumption poll reads the STALE 1 of the
+//    previous generation at the same address, "retires" the segment instantly, frees the label while
+//    this generation's fence packets are still in flight, and our (faithful) value-1 fence writes
+//    then land in freed MallocBinned3 memory — the #312 "Canary was 0x3, should be 0x1" /
+//    "free an unrecognized block 0x1000000001" / 0x20015f00 freelist-pop fatals.
+// numBytes is stack arg9 — beyond the swap stub's 2-arg re-push window, recovered from the intact
+// original guest frame exactly like agc_driver_submit_dcb_variant's arg9 (validated: the re-pushed
+// args must match the originals and the return address must be guest text; on mismatch numBytes
+// stays 0 and the CommandProcessor skips the packet with a loud log — the pre-fix behavior).
+// Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=srcOrImm lo/hi, [5]=numBytes, [6]=sels.
+// CONFIDENCE: HIGH on a4=dst/a1=srcOrImm (malloc-destination callsite + patcher names + protocol);
+// MED on the selector args (recorded raw; the executor only honors the small-immediate form).
+HLE(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, ..., stack9=numBytes)
+    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
+    uint64_t num_bytes = 0;
+    if (fp[6] == fp[2] && fp[7] == fp[3] &&
+        fp[5] >= 0x400000000ull && fp[5] < 0x500000000ull) {
+        uint64_t n = fp[8];                       // original stack arg9 = byte count
+        if (n && n <= 0x10000000ull) num_bytes = n;
+    }
     static std::atomic<uint64_t> g_dma_n{0};
-    if (getenv("PROSPER_PREDLOG")) {
+    if (getenv("PROSPER_PREDLOG") || getenv("PROSPER_GFXLOG")) {
         uint64_t k = g_dma_n.fetch_add(1);
         if (k < 48 || (k % 4096) == 0)
-            fprintf(stderr, "[pred] DcbDmaData #%llu dst=0x%llx src=0x%llx size_dw=0x%llx flags=0x%llx\n",
-                    (unsigned long long)k, (unsigned long long)a1, (unsigned long long)a4,
-                    (unsigned long long)a5, (unsigned long long)a3);
+            fprintf(stderr, "[pred] DcbDmaData #%llu dst=0x%llx srcOrImm=0x%llx bytes=0x%llx sels=0x%llx/0x%llx\n",
+                    (unsigned long long)k, (unsigned long long)a4, (unsigned long long)a1,
+                    (unsigned long long)num_bytes, (unsigned long long)a2, (unsigned long long)a3);
     }
     uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DMA_DATA, &cmd)) return 0;
-    cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
-    cmd[3] = (uint32_t)(a4 & 0xffffffffu); cmd[4] = (uint32_t)(a4 >> 32u);
-    cmd[5] = (uint32_t)a5; cmd[6] = (uint32_t)a3;
+    cmd[1] = (uint32_t)(a4 & 0xffffffffu); cmd[2] = (uint32_t)(a4 >> 32u);
+    cmd[3] = (uint32_t)(a1 & 0xffffffffu); cmd[4] = (uint32_t)(a1 >> 32u);
+    cmd[5] = (uint32_t)num_bytes;
+    cmd[6] = (uint32_t)((a2 & 0xffu) | ((a3 & 0xffu) << 8));
     return (uint64_t)(uintptr_t)cmd;
+}
+// sceAgcAcbDmaData (-RnpfpxIhec) — the async-compute-queue sibling. Same operation, shifted ABI
+// (RE'd from the Acb consumed-marker emitter at eboot+0x220d31e, which pairs it with the same
+// sceAgcCbReleaseMem(label<-1): (acb, srcSel?=3, dstSel?=3, dst=label, 2, 3, stack7=srcOrImm=0,
+// stack8=numBytes=4). srcOrImm/numBytes are stack args 7/8 = fp[2]/fp[3], INSIDE the swap stub's
+// forwarded window. CONFIDENCE: MED (single callsite; the executor gate limits the blast radius).
+HLE(agc_acb_dma_data) {  // (acb, srcSel?, dstSel?, dst, ?, ?, stack7=srcOrImm, stack8=numBytes)
+    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
+    uint64_t src_imm = fp[2], num_bytes = fp[3];
+    if (num_bytes > 0x10000000ull) num_bytes = 0;
+    uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DMA_DATA, &cmd)) return 0;
+    cmd[1] = (uint32_t)(a3 & 0xffffffffu); cmd[2] = (uint32_t)(a3 >> 32u);
+    cmd[3] = (uint32_t)(src_imm & 0xffffffffu); cmd[4] = (uint32_t)(src_imm >> 32u);
+    cmd[5] = (uint32_t)num_bytes;
+    cmd[6] = (uint32_t)((a1 & 0xffu) | ((a2 & 0xffu) << 8));
+    return (uint64_t)(uintptr_t)cmd;
+}
+// sceAgcDmaDataPatchSetDstAddressOrOffset (IxYiarKlXxM) / ...SetSrcAddressOrOffsetOrImmediate
+// (cdDRpqcFGbU): patch a built DMA_DATA packet's dst / src field (same patch-placeholder pattern
+// as the #213 sync-packet address patchers; header-verified before writing).
+HLE(agc_patch_dma_data_dst) {  // (cmd, address)
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_check(cmd, R_DMA_DATA, "DmaDataPatchSetDst")) return 0;
+    cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    return 0;
+}
+HLE(agc_patch_dma_data_src) {  // (cmd, addressOrImmediate)
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_check(cmd, R_DMA_DATA, "DmaDataPatchSetSrc")) return 0;
+    cmd[3] = (uint32_t)(a1 & 0xffffffffu); cmd[4] = (uint32_t)(a1 >> 32u);
+    return 0;
 }
 HLE(agc_dcb_event_write) {  // (buf, event_type, address)
     // Widen the packet to carry the address (a2) like ReleaseMem (#132): an address-carrying
@@ -1056,9 +1116,10 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         std::vector<gpu::Pm4Command> ops; gpu::decode_pm4(p->addr, p->dw_num, ops);
         static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetShRegDirect","SetRegsIndirect",
             "SetIndexType","DrawIndex","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem",
-            "Flip","ReleaseMem","DispatchDirect","SetIndexBase","SetIndexCount","DrawIndexOffset","Unknown"};
+            "Flip","ReleaseMem","DispatchDirect","SetIndexBase","SetIndexCount","DrawIndexOffset",
+            "Jump","SetPredication","DmaData","Unknown"};
         for (auto& c : ops) {
-            uint32_t k = (uint32_t)c.kind; const char* nm = k < 18 ? kKindName[k] : "?";
+            uint32_t k = (uint32_t)c.kind; const char* nm = k < 21 ? kKindName[k] : "?";
             fprintf(stderr, "[agc]   pkt op=0x%02x r=0x%02x len=%u kind=%s pl0=0x%08x pl1=0x%08x pl2=0x%08x\n",
                     c.op, c.r, c.len, nm,
                     c.len > 1 ? c.payload[0] : 0, c.len > 2 ? c.payload[1] : 0, c.len > 3 ? c.payload[2] : 0);
@@ -1176,7 +1237,10 @@ void register_agc_hle() {
     RN("3KDcnM3lrcU", agc_patch_wait_reg_mem_addr);  // WaitRegMem packet: set label address
     RN("0fWWK5uG9rQ", agc_patch_release_mem_addr);   // ReleaseMem packet: set label address
     RN("k3GhuSNmBLU", agc_dcb_dispatch_direct);      // sceAgcDcbDispatchDirect (tg_x, tg_y, tg_z, mod)
-    RN("WmAc2MEj6Io", agc_dcb_dma_data);        // sceAgcDcbDmaData — append DMA_DATA packet (#117)
+    RN("WmAc2MEj6Io", agc_dcb_dma_data);        // sceAgcDcbDmaData — append DMA_DATA packet (#117/#312)
+    RN("-RnpfpxIhec", agc_acb_dma_data);        // sceAgcAcbDmaData — async-compute sibling (#312)
+    RN("IxYiarKlXxM", agc_patch_dma_data_dst);  // sceAgcDmaDataPatchSetDstAddressOrOffset
+    RN("cdDRpqcFGbU", agc_patch_dma_data_src);  // sceAgcDmaDataPatchSetSrcAddressOrOffsetOrImmediate
     RN("YUeqkyT7mEQ", agc_dcb_set_flip);        // sceAgcDcbSetFlip (Kyty LibGraphicsDriver.cpp:98)
     RN("UglJIZjGssM", agc_driver_submit_dcb);   // sceAgcDriverSubmitDcb -> CommandProcessor replay
     RN("w1KFAHVqpaU", agc_driver_submit_dcb_variant);  // final-buffer submit variant (#232, DOLL RHI batch)

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -102,6 +102,7 @@ namespace {
     // from prosper's own fence writes (host rip), i.e. catching a write-after-free in the act.
     uint64_t g_lwatch_slot = 0;
     uint64_t g_lwatch_page = 0;
+    int      g_lwatch_max  = 400;   // PROSPER_WATCH_MAX (latched at arm time; getenv is not signal-safe)
     volatile sig_atomic_t g_lwatch_armed = 0;
     bool     g_lwatch_stepping = false;
     uint64_t g_lwatch_step_rip = 0;
@@ -998,18 +999,34 @@ namespace {
                 g_lwatch_step_rip = 0;
                 if (fa >= g_lwatch_slot - 0x18 && fa < g_lwatch_slot + 0x20) {
                     g_lwatch_hits = g_lwatch_hits + 1;
-                    char b[224];
+                    char b[512];
                     bool guest = rip >= 0x400000000ull && rip < 0x4c0000000ull;
                     int n = snprintf(b, sizeof b,
-                        "[lwatch] #%d write fa=0x%llx rip=%s0x%llx tid=%ld pre[0]=0x%llx pre[8]=0x%llx\n",
+                        "[lwatch] #%d write fa=0x%llx rip=%s0x%llx tid=%ld pre[0]=0x%llx pre[8]=0x%llx",
                         (int)g_lwatch_hits, (unsigned long long)fa,
                         guest ? "eboot+" : "host:",
                         (unsigned long long)(guest ? rip - 0x400000000ull : rip), cur_tid(),
                         (unsigned long long)*(const uint64_t*)g_lwatch_slot,
                         (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8));
+                    // #312: call-stack capture — scan the writer's stack for eboot-text return
+                    // addresses (up to 8), so the guest free/alloc path above the raw write is
+                    // identifiable (async-signal-safe: bounded reads of the faulting thread's
+                    // own stack).
+                    uint64_t rsp = (uint64_t)uc->uc_mcontext.gregs[REG_RSP];
+                    int found = 0;
+                    for (uint64_t o = 0; o < 0x400 && found < 8 && n < (int)sizeof b - 24; o += 8) {
+                        if (!probe_readable(rsp + o)) break;
+                        uint64_t v = *(const uint64_t*)(rsp + o);
+                        if (v >= 0x400000000ull && v < 0x40a000000ull) {
+                            n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
+                                          (unsigned long long)(v - 0x400000000ull));
+                            found++;
+                        }
+                    }
+                    if (n < (int)sizeof b - 1) b[n++] = '\n';
                     syscall(SYS_write, 2, b, (size_t)n);
                     g_lwatch_step_rip = rip;
-                    if (g_lwatch_hits >= 400) {   // bounded: disarm after enough evidence
+                    if (g_lwatch_hits >= g_lwatch_max) {   // bounded: disarm after enough evidence
                         mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
                         g_lwatch_armed = 0;
                         return;
@@ -1251,6 +1268,10 @@ namespace {
                 rdb(g_fault_rip+4), rdb(g_fault_rip+5), rdb(g_fault_rip+6), rdb(g_fault_rip+7),
                 (unsigned long long)(probe_readable(g_rsp) ? *(const uint64_t*)g_rsp : 0));
             syscall(SYS_write, 2,ib, m);
+            // #312: full register + heap-window + GPU-write-ring dump at the worker fault too (the
+            // MallocBinned3 freelist-pop faults — e.g. rcx=0x20015f00 at eboot+0x2316acf — land here,
+            // not on the nullpage path). Reuses the async-signal-safe nullpage attribution dump.
+            nullpage_deep_dump(uc, g_fault_rip);
             // If PROSPER_HWBP_NODE ring-capture is active, the crash node's typetree metadata is the tail.
             if (g_hwbp_node_on) hwbp_dump_ring("worker-fault");
         }
@@ -1388,16 +1409,34 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
 // first heap-resident value-1 fence label address; protects the label's page and logs every write
 // into the label's block with the writer's rip (guest allocator free-path vs prosper fence write),
 // catching a write-after-free in the act. Diagnostic, one page, bounded to 400 logged hits.
-extern "C" void prosper_arm_label_watch(uint64_t addr) {
-    static const bool on = getenv("PROSPER_WATCH_LABEL") != nullptr;
-    if (!on || g_lwatch_armed || !addr) return;
+// Arm the watch on `addr` unconditionally (shared body). Used by the env-gated wrapper below and
+// by the PROSPER_WATCH_HOT trigger (hle_agc), which picks its own slot.
+extern "C" void prosper_arm_label_watch_force(uint64_t addr) {
+    if (g_lwatch_armed || !addr) return;
+    if (const char* mx = getenv("PROSPER_WATCH_MAX")) {
+        long v = atol(mx); if (v > 0) g_lwatch_max = (int)v;
+    }
     g_lwatch_slot = addr;
     g_lwatch_page = addr & ~(uint64_t)0xfff;
     if (mprotect((void*)g_lwatch_page, 0x1000, PROT_READ) == 0) {
         g_lwatch_armed = 1;
-        fprintf(stderr, "[lwatch] armed slot=0x%llx page=0x%llx\n",
-                (unsigned long long)addr, (unsigned long long)g_lwatch_page);
+        fprintf(stderr, "[lwatch] armed slot=0x%llx page=0x%llx max=%d\n",
+                (unsigned long long)addr, (unsigned long long)g_lwatch_page, g_lwatch_max);
     }
+}
+extern "C" void prosper_arm_label_watch(uint64_t addr) {
+    static const bool on = getenv("PROSPER_WATCH_LABEL") != nullptr;
+    // PROSPER_WATCH_ABS=0xADDR (#312): watch a FIXED slot (e.g. the MallocBinned3 pool free-list
+    // head found by the fault deep-dump) instead of the first fence label. The arm is retried on
+    // every builder call until the slot's page is actually mapped (the pool region appears later
+    // in boot than the first fence). Catches EVERY writer process-wide (guest or host) — the
+    // definitive attribution for the 0x20015f00 head stomp.
+    static const uint64_t abs_slot = [] { const char* e = getenv("PROSPER_WATCH_ABS");
+                                          return e ? strtoull(e, nullptr, 0) : 0ull; }();
+    if (g_lwatch_armed) return;
+    if (abs_slot) addr = abs_slot;
+    else if (!on || !addr) return;
+    prosper_arm_label_watch_force(addr);
 }
 
 // Install a per-thread alternate signal stack so the fault handler can run even when the faulting
@@ -1529,7 +1568,9 @@ void install_trap_handler() {
     sigaction(SIGBUS,  &sa, nullptr);
     sigaction(SIGILL,  &sa, nullptr);
     if (g_watch_companion || g_bp_on || g_hwbp_on
-        || getenv("PROSPER_WATCH_LABEL")) sigaction(SIGTRAP, &sa, nullptr);   // single-step / breakpoint
+        || getenv("PROSPER_WATCH_LABEL")
+        || getenv("PROSPER_WATCH_ABS")
+        || getenv("PROSPER_WATCH_HOT")) sigaction(SIGTRAP, &sa, nullptr);   // single-step / breakpoint
 }
 
 // Write the 0xCC breakpoint into the (now-mapped) guest image. Call after the image load.

--- a/prosper/tools/dbg/diswin.sh
+++ b/prosper/tools/dbg/diswin.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# diswin.sh <va_hex> <len_hex> — disassemble an eboot text window (DOLL PPSA17942).
+# Text LOAD file offset base = 0x34050 for VA 0 (self_dump segment table).
+VA=$(( $1 ))
+LEN=$(( $2 ))
+OFF=$(( VA + 0x34050 ))
+dd if=/root/PPSA17942-app0/eboot.bin of=/tmp/diswin.bin bs=1 skip=$OFF count=$LEN 2>/dev/null
+objdump -D -b binary -m i386:x86-64 --adjust-vma=$VA /tmp/diswin.bin | tail -n +8

--- a/prosper/tools/dbg/findcalls.py
+++ b/prosper/tools/dbg/findcalls.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# findcalls.py <target_va_hex> [...] — scan DOLL eboot text for e8-rel32 calls to the target VA(s).
+# Text LOAD: VA 0 at file offset 0x34050, size 0x669b81c.
+import sys, struct
+
+EBOOT = "/root/PPSA17942-app0/eboot.bin"
+BASE_OFF = 0x34050
+TEXT_SIZE = 0x669b81c
+
+targets = {int(a, 16) for a in sys.argv[1:]}
+data = open(EBOOT, "rb").read(BASE_OFF + TEXT_SIZE)[BASE_OFF:]
+hits = []
+idx = 0
+while True:
+    idx = data.find(b"\xe8", idx)
+    if idx < 0 or idx + 5 > len(data):
+        break
+    rel = struct.unpack_from("<i", data, idx + 1)[0]
+    tgt = (idx + 5 + rel) & 0xFFFFFFFFFFFFFFFF
+    if tgt in targets:
+        hits.append((idx, tgt))
+    idx += 1
+for va, tgt in hits:
+    print(f"call @0x{va:x} -> 0x{tgt:x}")
+print(f"{len(hits)} hits")

--- a/prosper/tools/dbg/findrefs.py
+++ b/prosper/tools/dbg/findrefs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# findrefs.py <va_hex> — find e9 jumps, e8 calls, lea-rip refs and 8-byte pointer literals to a VA
+# anywhere in the DOLL eboot file (text VA0 @0x34050; rodata VA 0x669c000 @0x66e04d0; data VA
+# 0x8828000 @0x8871930 per the self_dump segment/phdr tables).
+import sys, struct
+
+EBOOT = "/root/PPSA17942-app0/eboot.bin"
+target = int(sys.argv[1], 16)
+data = open(EBOOT, "rb").read()
+
+TEXT_OFF, TEXT_VA, TEXT_SZ = 0x34050, 0, 0x669b81c
+SEGS = [
+    (0x34050, 0x0, 0x669b81c, "text"),
+    (0x66e04d0, 0x669c000, 0x218b0f8, "rodata"),
+    (0x8871930, 0x8828000, 0xc6ba68, "data"),
+    (0x9511650, 0x9494000, 0x27050, "data2"),
+]
+
+# pointer literals
+pat = struct.pack("<Q", target)
+for off, va, sz, nm in SEGS:
+    seg = data[off:off + sz]
+    i = 0
+    while True:
+        i = seg.find(pat, i)
+        if i < 0:
+            break
+        print(f"ptr-literal in {nm} @va 0x{va + i:x}")
+        i += 1
+
+# calls/jmps in text
+seg = data[TEXT_OFF:TEXT_OFF + TEXT_SZ]
+for opcode, name in ((0xE8, "call"), (0xE9, "jmp")):
+    i = 0
+    while True:
+        i = seg.find(bytes([opcode]), i)
+        if i < 0 or i + 5 > len(seg):
+            break
+        rel = struct.unpack_from("<i", seg, i + 1)[0]
+        if (i + 5 + rel) == target:
+            print(f"{name} @va 0x{i:x}")
+        i += 1
+# lea rip-relative (48 8d ?? rel32) — check 3-byte opcodes 48 8d 05..3d
+i = 0
+while True:
+    i = seg.find(b"\x48\x8d", i)
+    if i < 0 or i + 7 > len(seg):
+        break
+    modrm = seg[i + 2]
+    if (modrm & 0xC7) == 0x05:
+        rel = struct.unpack_from("<i", seg, i + 3)[0]
+        if (i + 7 + rel) == target:
+            print(f"lea @va 0x{i:x}")
+    i += 1
+print("done")


### PR DESCRIPTION
## What

Implements execution of `sceAgcDcbDmaData` / `sceAgcAcbDmaData` immediate-fill packets in the CommandProcessor — a real, previously-dropped AGC protocol leg that is directly implicated in the #312 MallocBinned3 heap-corruption fatal — plus the attribution tooling that pinned it, and a deadlock fix for the experimental `PROSPER_WAIT_DEFER` queue-pause model.

**This does NOT fully close #312** (details below, and in the issue comment): the menu-drive fatal still reproduces in most runs, but time-to-fatal moved later (55–150 s and one full clean 175 s run vs. the 40–90 s baseline), and the fixed surface is exercised protocol, not a shim.

## The protocol (RE'd this session, live-verified)

DOLL's RHIThread translate loop emits, per translated command-stream segment:

```
DmaData(srcOrImm=0, sels=3/3, dst=<label>, 4 bytes, blocking)   <- GPU-side label INIT (label := 0)
ReleaseMem(label <- 1, data_sel=1, action=0x28/0x2b/0x2d/0x14)  <- consumed marker (EOP)
```

- The **label** is a LIFO-recycled 0x20-byte MallocBinned3 block (`GMalloc->Malloc(0x20, 8)` at `eboot+0x2211b33`), whose pointer lives in a **64 KiB command-chunk boundary header** `{label_ptr @+0, flags @+0x30, state @+0x34}` (chunk align = the global at `0x969d8c8`).
- The guest **never CPU-initializes the label** (proven by a page-watch capture of the full alloc→fence→free→realloc lifecycle with call stacks) — the DmaData is the only init.
- Labels are batch-freed at frame end (`GMalloc->Free` loop at `eboot+0x220bd50`, the same frames as the canary-fatal backtrace).
- The label `+0` field is **overloaded**: intrusive pending-list next-pointer / fence value / pool next — so any fence write landing out of order mangles a live chain.

DmaData ABI (re-pinned from three eboot callsites; the old `a1=dst / a4=src` reading was backwards):
`(dcb, a1=srcAddressOrOffsetOrImmediate, a2/a3=sels, a4=dstAddressOrOffset, ..., stack9=numBytes, stack12=isBlocking)` — at `eboot+0x221ad2d` the guest passes a freshly-malloc'd buffer in **a4** (a destination by construction), and the patcher family is `sceAgcDmaDataPatchSetSrcAddressOrOffsetOr**Immediate**`. `numBytes` is recovered via the validated-guest-frame walk (same pattern as `w1KFAHVqpaU`'s arg9).

DOLL uses two instances: the 4-byte label init, and **64 KiB zero-fills** of fresh 64 KiB-aligned chunk pages (whose boundary headers hold the label pointers). Both now execute, ordered through the same completion-write FIFO as the ReleaseMem leg (generation order at a recycled address is exactly what the guest's consumption poll depends on). Unmodeled forms (real address-to-address copies, GDS) log-and-skip as before.

## Also in this PR

- `sceAgcAcbDmaData` (`-RnpfpxIhec`, async-compute sibling) + both DmaData packet patchers (`IxYiarKlXxM`, `cdDRpqcFGbU`) registered.
- `PROSPER_WAIT_DEFER` boot-deadlock fix: a lazy 2 ms watchdog flushes deferred streams (previously only re-checked at subsequent submits — a guest waiting on a paused stream's EOP wedged at submit #1). Still default-off.
- #312 attribution tooling: per-packet fence **build journal** (target + pre-content at build + timestamp; the timing-vs-wrong-target discriminator), `PROSPER_WATCH_ABS` / `PROSPER_WATCH_HOT` page-watch variants with **call-stack capture**, worker-fault deep dump (registers + heap windows + GPU write-ring at the MB3 freelist-pop faults), `tools/dbg/diswin.sh` + `findcalls.py`/`findrefs.py` eboot disassembly helpers.
- GFXLOG packet kind-name table refreshed (Jump/SetPredication/DmaData were mislabeled).

## Discriminator results (the session's assignment)

1. **Our fence writes are faithful and prompt**: journal proves built-addr == written-addr in every observed case (no wrong-target computation), ages 0–9 ms.
2. The `0x20015f00` freelist-pop fault head slot was captured live (pool struct at `0x206de60000`, `head=0x20015f00`, deterministic value = a byte-shifted pool pointer read through a corrupted chain).
3. The corruption mechanism end-to-end: the guest's consumption scans assume "value 1 visible ⇒ GPU completely done with this label"; without the DmaData init the LIFO-recycled label carried the *previous generation's* 1, so labels were freed while fences to them were still in flight — our (correct) writes then landed in freed heap, producing all three fatal signatures (`Canary 0x3`, `free an unrecognized block 0x1000000001`, `0x20015f00`).

## Status / verification

- Menu-drive repro (`PROSPER_PAD_SCRIPT`, 8 post-fix runs): 2 full-length clean runs, fatals in the rest at t=45–150 s (baseline: ~85% fatal at t=40–90 s). **Gate not cleared — `refs`, not `Fixes`.**
- `PROSPER_WAIT_DEFER=1` + this fix: no corruption fatals in 2 runs, but ~2× slowdown and one OOM kill — documented as the next lead (see issue comment).
- ctest: 69/72 (3 failures are the known environmental class: Messenger-dump tests against a DOLL `GAME_DUMP`; CI is the arbiter).
- Messenger regression: 240 s render boot, 278 frames with real content, no faults; `tools/snapshot/snapshot.py check` **OK**.

refs #312