### PR TITLE
fix(hle): memory HLE returns real SCE error codes, not raw errno 0x16

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -320,7 +320,7 @@ HLE(k_reserve_vrange) {
                 MLOG("reserve hint=0x%llx re-reserve-of-own-range -> OK\n", (unsigned long long)hint);
                 return 0;
             }
-            MLOG("reserve FIXED hint=0x%llx FAILED\n", (unsigned long long)hint); return 0x16;
+            MLOG("reserve FIXED hint=0x%llx FAILED\n", (unsigned long long)hint); return 0x8002000cull; // ENOMEM
         }
         if (a0) *(uint64_t*)a0 = (uint64_t)p;
         track((uint64_t)p, a1, 0, false, "reserved");
@@ -359,7 +359,7 @@ HLE(k_reserve_vrange) {
     // Over-map by `align`, then trim the head/tail slack to yield an aligned span.
     uint64_t total = a1 + align;
     void* raw = mmap(nullptr, total, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (raw == MAP_FAILED) { MLOG("reserve len=0x%llx FAILED\n", (unsigned long long)a1); return 0x16; }
+    if (raw == MAP_FAILED) { MLOG("reserve len=0x%llx FAILED\n", (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
     uint64_t base = align_up((uint64_t)raw, align);
     if (base > (uint64_t)raw) munmap(raw, base - (uint64_t)raw);
     uint64_t used_end = base + a1, raw_end = (uint64_t)raw + total;
@@ -375,7 +375,7 @@ HLE(k_reserve_vrange) {
 HLE(k_map_flexible) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
     void* p = map_at(hint, a1, host_prot(a2));
-    if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x16; }
+    if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), true, a4 ? (const char*)a4 : "flexible");
     MLOG("mapflexible -> 0x%llx len=0x%llx prot=0x%llx name=%s\n",
@@ -421,7 +421,7 @@ HLE(k_alloc_main_dmem) {
 // sceKernelDirectMemoryQuery(off_t offset, int flags, SceKernelDirectMemoryQueryInfo* info, size_t infoSize)
 //   info: 0x00 off_t start; 0x08 off_t end; 0x10 i32 memoryType. flags&1 = find next.
 HLE(k_direct_memory_query) {
-    if (!a2) return 0x16;
+    if (!a2) return 0x80020016ull;   // EINVAL (null out-param)
     uint8_t* info = (uint8_t*)a2;
     uint64_t sz = a3 ? (a3 > 0x18 ? 0x18 : a3) : 0x18;
     memset(info, 0, sz);
@@ -445,7 +445,7 @@ HLE(k_direct_memory_query) {
 HLE(k_map_dmem) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
     void* p = map_phys_at(hint, a1, host_prot(a2), a4);
-    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x16; }
+    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), true, "direct");
     MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx\n",
@@ -456,7 +456,7 @@ HLE(k_map_dmem) {
 // sceKernelVirtualQuery(const void* addr, int flags, SceKernelVirtualQueryInfo* info, size_t infoSize)
 //   0x00 start; 0x08 end; 0x10 offset; 0x18 i32 prot; 0x1C i32 memType; 0x20 u32 flags; 0x24 name[32]
 HLE(k_virtual_query) {
-    if (!a2) return 0x16;
+    if (!a2) return 0x80020016ull;   // EINVAL (null out-param)
     uint8_t* info = (uint8_t*)a2;
     uint64_t sz = a3 ? (a3 > 0x48 ? 0x48 : a3) : 0x48;
     memset(info, 0, sz);


### PR DESCRIPTION
## Problem
Six failure paths in the virtual-memory HLE (`hle_kernel_mem.cpp`) returned a bare **`0x16`** (= errno `EINVAL` 22), which is **not a valid `SCE_KERNEL_ERROR_*` value**. Every other error return in the same file already uses the `0x8002xxxx` SCE space — e.g. `0x80020016` (EINVAL) for `len==0`, `0x8002000c` (ENOMEM) for "no free range".

A guest that classifies the result by SCE code misbehaves: the direct-memory allocator loops until it observes **ENOMEM** (and #115 already demonstrated this allocator is sensitive to the exact code — a wrong error there made it hand back `NULL`, which a `FileCacher` then `memcpy`'d from). `0x16` matches no SCE code, so the guest can't take its retry/back-off branch or misclassifies EINVAL vs ENOMEM.

## Fix
Split by cause, matching shadPS4 (`memory.cpp`: EINVAL for bad args, ENOMEM for allocation failure):

| site | call | was | now |
|---|---|---|---|
| :323 | reserve fixed-hint collision | `0x16` | `0x8002000c` ENOMEM |
| :362 | reserve mmap failure | `0x16` | `0x8002000c` ENOMEM |
| :378 | `MapNamedFlexibleMemory` map failure | `0x16` | `0x8002000c` ENOMEM |
| :448 | `MapDirectMemory` map failure | `0x16` | `0x8002000c` ENOMEM |
| :424 | `DirectMemoryQuery` null out-param | `0x16` | `0x80020016` EINVAL |
| :459 | `VirtualQuery` null out-param | `0x16` | `0x80020016` EINVAL |

## Risk
All six are **error paths, not on the success boot path**, so the change is strictly more correct and cannot regress a working boot. Found in a systematic read-only bug-hunt of the libkernel HLE (companion issues #338/#339 from the same review cover latent loader/TLS gaps).

## Verification
- 73/73 ctest green
- `boot_reaches_first_syscall` green
- Messenger golden-image snapshot unchanged (24318 colors ≥ 5000)