### PR TITLE
feat(hle): implement libSceIme keyboard API (#186)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -137,6 +137,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_savedata_ime PRIVATE prosper_core)
   add_test(NAME savedata_ime COMMAND test_savedata_ime)
 
+  # libSceIme keyboard API (#186): reports a consistent "no keyboard connected" state (empty resource
+  # array + disconnected info, bounds-checked) so the per-frame input poll never reads garbage.
+  add_executable(test_ime_keyboard tests/test_ime_keyboard.cpp)
+  target_link_libraries(test_ime_keyboard PRIVATE prosper_core)
+  add_test(NAME ime_keyboard COMMAND test_ime_keyboard)
+
   # pthread scheduling getters fill their out-param (not a shadowing no-op): scePthreadGetprio/
   # Getaffinity must WRITE priority/mask, else the caller reads uninitialized stack (harmful-stub class).
   add_executable(test_pthread_sched_getters tests/test_pthread_sched_getters.cpp)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -136,6 +136,37 @@ HLE(s_open)           { return g_handle++; }                                 // 
 // mouse attached: zero one entry defensively, report 0 events.
 HLE(s_mouse_read)     { if (a1) memset(PW(a1), 0, 0x18); return 0; }
 
+// --- libSceIme keyboard API (#186) ---
+// PPSA02664 polls this every frame in its input loop. We have no physical PS5 keyboard, so we report a
+// consistent "no keyboard connected" state: Open/Update succeed, GetResourceId returns an empty
+// resource array (no keyboards), GetInfo reports a disconnected device — the game then uses controller
+// / on-screen input instead of waiting on a keyboard. Struct layouts + field offsets verified against
+// shadPS4 src/core/libraries/ime/ime_common.h; error codes from ime_error.h. Note sceImeKeyboardOpen
+// returns an Error (0 = SCE_OK), NOT a handle — so success is 0. CONFIDENCE: HIGH on the layouts; MED
+// on the device/status enum "disconnected" == 0.
+//   OrbisImeKeyboardResourceIdArray: user_id@0(s32) resource_id[5]@4(u32)                     size 24
+//   OrbisImeKeyboardInfo: user_id@0 device@4 type@8 repeat_delay@12 repeat_rate@16 status@20 rsv[12]@24  size 36
+HLE(s_ime_kbd_open) { svc_log("sceImeKeyboardOpen", a0,a1,a2,a3,a4,a5); return 0; }  // register handler; no events to deliver
+HLE(s_ime_update)   { svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5); return 0; }        // pump the queue: no events
+// sceImeKeyboardGetResourceId(userId, OrbisImeKeyboardResourceIdArray* out): report the user's keyboard
+// resource ids — none connected, so an all-zero id array (echoing the queried userId).
+HLE(s_ime_kbd_resid) {
+    svc_log("sceImeKeyboardGetResourceId", a0,a1,a2,a3,a4,a5);
+    if (!a1) return 0x80BC0031ull;   // ORBIS_IME_ERROR_INVALID_ADDRESS
+    uint8_t* p = (uint8_t*)PW(a1);
+    *(int32_t*)(p + 0) = (int32_t)a0;                         // user_id echoes the caller
+    for (int i = 0; i < 5; i++) *(uint32_t*)(p + 4 + i * 4) = 0;   // no keyboards connected
+    return 0;
+}
+// sceImeKeyboardGetInfo(resourceId, OrbisImeKeyboardInfo* info): a disconnected (no-device) info.
+HLE(s_ime_kbd_info) {
+    svc_log("sceImeKeyboardGetInfo", a0,a1,a2,a3,a4,a5);
+    if (!a1) return 0x80BC0031ull;   // ORBIS_IME_ERROR_INVALID_ADDRESS
+    memset(PW(a1), 0, 36);           // device=0 type=0 repeat=0 status=0(disconnected) reserved=0
+    *(int32_t*)PW(a1) = 1;           // user_id = default user (matches sceUserServiceGetInitialUser)
+    return 0;
+}
+
 // --- app content ---
 HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = 0; return 0; }
 
@@ -863,6 +894,11 @@ void register_service_hle() {
     Hle::register_fn("gyTyVn+bXMw", (HleFn)s_imedlg_term,   "sceImeDialogTerm");
     Hle::register_fn("oBmw4xrmfKs", (HleFn)s_imedlg_abort,  "sceImeDialogAbort");
     R("sceSystemServiceHideSplashScreen", s_ok);
+    // libSceIme keyboard API (#186): no physical keyboard -> consistent "none connected" state. Raw NIDs.
+    Hle::register_fn("eaFXjfJv3xs", (HleFn)s_ime_kbd_open,  "sceImeKeyboardOpen");
+    Hle::register_fn("-4GCfYdNF1s", (HleFn)s_ime_update,    "sceImeUpdate");
+    Hle::register_fn("VkqLPArfFdc", (HleFn)s_ime_kbd_info,  "sceImeKeyboardGetInfo");
+    Hle::register_fn("dKadqZFgKKQ", (HleFn)s_ime_kbd_resid, "sceImeKeyboardGetResourceId");
     // libSceAvPlayer (#324): let a post-credits / intro video complete so the game reaches its scene.
     // Init/InitEx must return a non-NULL handle; IsActive must report finished; the rest succeed as no-ops.
     R("sceAvPlayerInit",           s_avplayer_init);

--- a/prosper/tests/test_ime_keyboard.cpp
+++ b/prosper/tests/test_ime_keyboard.cpp
@@ -1,0 +1,58 @@
+// test_ime_keyboard (#186) — the libSceIme keyboard API PPSA02664 polls every frame. No physical
+// keyboard, so it reports a consistent "none connected" state (empty resource array, disconnected
+// info) rather than leaving the caller's structs uninitialized. Struct layouts mirror shadPS4
+// src/core/libraries/ime/ime_common.h (offsets asserted below).
+#include "../src/hle/dispatch.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+struct KbdResIds { int32_t user_id; uint32_t resource_id[5]; };
+struct KbdInfo   { int32_t user_id; uint32_t device; uint32_t type; uint32_t repeat_delay;
+                   uint32_t repeat_rate; uint32_t status; int8_t reserved[12]; };
+static_assert(sizeof(KbdResIds) == 24, "ResourceIdArray size");
+static_assert(sizeof(KbdInfo) == 36 && offsetof(KbdInfo, status) == 20, "KeyboardInfo layout");
+
+int main() {
+    printf("== test_ime_keyboard ==\n");
+    register_builtin_hle();
+
+    HleFn open  = Hle::lookup("eaFXjfJv3xs"), update = Hle::lookup("-4GCfYdNF1s"),
+          info  = Hle::lookup("VkqLPArfFdc"), resid  = Hle::lookup("dKadqZFgKKQ");
+    CHECK(open && update && info && resid, "Ime keyboard functions registered");
+    if (!(open && update && info && resid)) { printf("== FAIL ==\n"); return 1; }
+
+    CHECK(open(1, 0, 0, 0, 0, 0) == 0, "sceImeKeyboardOpen -> OK (Error, not a handle)");
+    CHECK(update(0, 0, 0, 0, 0, 0) == 0, "sceImeUpdate -> OK (no events to pump)");
+
+    // GetResourceId(userId=1, out): echoes userId, reports no connected keyboards (all-zero ids).
+    KbdResIds ids; memset(&ids, 0xAB, sizeof ids);
+    CHECK(resid(1, (uint64_t)(uintptr_t)&ids, 0, 0, 0, 0) == 0, "GetResourceId -> OK");
+    CHECK(ids.user_id == 1, "GetResourceId echoes the queried userId");
+    bool empty = true; for (int i = 0; i < 5; i++) if (ids.resource_id[i] != 0) empty = false;
+    CHECK(empty, "GetResourceId reports an empty id array (no keyboards connected)");
+
+    // GetInfo(resourceId, info): a disconnected device — all zero except user_id — and no write past 36.
+    uint8_t buf[40]; memset(buf, 0xAB, sizeof buf);
+    CHECK(info(1, (uint64_t)(uintptr_t)buf, 0, 0, 0, 0) == 0, "GetInfo -> OK");
+    KbdInfo* ki = (KbdInfo*)buf;
+    CHECK(ki->user_id == 1, "GetInfo user_id = default user 1");
+    CHECK(ki->device == 0 && ki->type == 0 && ki->status == 0, "GetInfo reports a disconnected/no-device keyboard");
+    CHECK(ki->repeat_delay == 0 && ki->repeat_rate == 0, "GetInfo repeat fields zeroed");
+    CHECK(buf[36] == 0xAB && buf[39] == 0xAB, "GetInfo does NOT write past its 36-byte struct");
+
+    // Null out-pointer -> INVALID_ADDRESS, never a wild write.
+    CHECK(resid(1, 0, 0, 0, 0, 0) == 0x80BC0031ull, "GetResourceId(NULL) -> INVALID_ADDRESS");
+    CHECK(info(1, 0, 0, 0, 0, 0) == 0x80BC0031ull, "GetInfo(NULL) -> INVALID_ADDRESS");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #186. PPSA02664 polls the libSceIme keyboard API **every frame** in its input loop; all four functions fell through to the generic unimplemented stub. Now they report a consistent **"no physical keyboard connected"** state so the game uses controller / on-screen input instead of reading uninitialized structs or waiting on a device.

- `sceImeKeyboardOpen` → OK. (It returns an `Error`, **not** a handle — `0` is `SCE_OK`, so the issue's "0 is likely wrong" worry doesn't apply once the signature is confirmed against shadPS4.)
- `sceImeUpdate` → OK (pumps the event queue; no events).
- `sceImeKeyboardGetResourceId` → echoes the queried `userId` + an **all-zero id array** (no keyboards connected).
- `sceImeKeyboardGetInfo` → a **disconnected/no-device** info struct, written exactly (36 bytes, never past the caller's struct).

Null out-pointer → `ORBIS_IME_ERROR_INVALID_ADDRESS` (`0x80BC0031`), never a wild write.

## Correctness
Struct layouts + field offsets verified against shadPS4 `src/core/libraries/ime/ime_common.h`; error codes from `ime_error.h`. The test `static_assert`s the offsets. *CONFIDENCE: HIGH* on the layouts; *MED* on the `device`/`status` enum "disconnected" == 0.

## Verification
`test_ime_keyboard`: empty-array / disconnected-info contract, the **no-write-past-struct** bound, and the null-param error path. Full `ctest` **74/74**, incl. `boot_reaches_first_syscall`.