### PR TITLE
feat(gpu): divergent execz-exit loops, BC6H, cube sampling + per-pc descriptor provenance — all 4 title-composite PSes recompile (refs #273)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -92,7 +92,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
-                        size_t nb = (size_t)tw * th * 4;
+                        const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
+                        size_t nb = (size_t)tw * th * 4 * (is_cube ? 6u : 1u);
                         texstore.emplace_back(nb, 0x00);
                         // PROSPER_TEXCOMMIT: log, once per texture base, how much of the sampled surface is
                         // COMMITTED guest memory (the same reserved_range_state safe_copy stops at). If the
@@ -153,11 +154,49 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
                                         rtt_hit ? "HIT" : "miss", g_rtt.size());
                         }
+                        // CUBE texture (#273 — DOLL's title reflection probes / skybox): six faces,
+                        // each an independently-tiled w x h surface, laid out face-major at
+                        // gpu_addr + f*face_stride; decode each into rows [f*th, (f+1)*th) of the
+                        // stacked w x 6h image the cube-sample lowering addresses. BCn faces block-
+                        // detile + decode; anything else reads 4 B/texel with the surface detiler.
+                        // CONFIDENCE: MED on the face stride (padded tiled footprint) — visually
+                        // validated; a wrong stride garbles faces 1..5, it cannot crash (safe_copy).
+                        bool cube_done = false;
+                        if (is_cube && !rtt_hit) {
+                            const uint32_t cb = prosper::gpu::bc_block_bytes(r.format);
+                            const bool ctiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                            for (uint32_t fface = 0; fface < 6; fface++) {
+                                uint8_t* slice = texstore.back().data() + (size_t)fface * tw * th * 4;
+                                if (cb) {
+                                    uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
+                                    size_t comp = (size_t)bw * bh * cb;
+                                    size_t stride = ctiled ? prosper::gpu::tiled_elements_bytes(bw, bh, cb, r.tile_mode) : comp;
+                                    std::vector<uint8_t> lin(comp, 0);
+                                    if (ctiled) {
+                                        std::vector<uint8_t> traw(stride, 0);
+                                        safe_copy(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
+                                        prosper::gpu::detile_elements(lin.data(), traw.data(), stride, bw, bh, cb, r.tile_mode);
+                                    } else safe_copy(lin.data(), r.gpu_addr + (uint64_t)fface * stride, comp);
+                                    std::vector<uint8_t> face((size_t)tw * th * 4, 0);
+                                    prosper::gpu::bc_decode_surface(face.data(), lin.data(), lin.size(), tw, th, r.format);
+                                    std::memcpy(slice, face.data(), face.size());
+                                } else {
+                                    size_t fb = (size_t)tw * th * 4;
+                                    size_t stride = ctiled ? prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0) : fb;
+                                    if (ctiled) {
+                                        std::vector<uint8_t> traw(stride, 0);
+                                        safe_copy(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
+                                        prosper::gpu::detile_surface(slice, traw.data(), tw, th, r.tile_mode, 0);
+                                    } else safe_copy(slice, r.gpu_addr + (uint64_t)fface * stride, fb);
+                                }
+                            }
+                            cube_done = true;
+                        }
                         // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
                         // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
                         // 16 bytes -> SW_4KB_S 16x16-block micro-tiles). #121.
-                        const uint32_t bcb = rtt_hit ? 0u : prosper::gpu::bc_block_bytes(r.format);
-                        if (rtt_hit) { /* pixels already injected from the RTT cache */ }
+                        const uint32_t bcb = (rtt_hit || cube_done) ? 0u : prosper::gpu::bc_block_bytes(r.format);
+                        if (rtt_hit || cube_done) { /* pixels already injected/stacked above */ }
                         else if (bcb) {
                             uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
                             // Block-detile: tiled_elements_bytes/detile_elements now derive the 4KB
@@ -275,7 +314,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!rtt_hit && !bcb && !narrow_done && !f16_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                        if (!rtt_hit && !cube_done && !bcb && !narrow_done && !f16_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
                             size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
@@ -339,7 +378,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 prosper::test::dump_bmp(fn, texstore.back(), tw, th);
                             }
                         }
-                        fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = th;
+                        fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
                         // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -124,7 +124,9 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
         case 176: bcn(DataFormat::Bc4, 1,  8, false, true);       break; // BC4_SNORM (skip-only: signed)
         case 177: bcn(DataFormat::Bc5, 2, 16);                    break; // BC5_UNORM
         case 178: bcn(DataFormat::Bc5, 2, 16, false, true);       break; // BC5_SNORM (skip-only: signed)
-        case 179: case 180: bcn(DataFormat::Bc6, 3, 16); break; // BC6_UFLOAT/_SFLOAT (decode not wired)
+        case 179: bcn(DataFormat::Bc6, 3, 16);              break; // BC6H_UFLOAT (decoded, #273)
+        case 180: bcn(DataFormat::Bc6, 3, 16, false, true); break; // BC6H_SFLOAT (snorm flag = signed;
+                                                                   // still skipped: no live example)
         case 181: bcn(DataFormat::Bc7, 4, 16);        break;   // BC7_UNORM
         case 182: bcn(DataFormat::Bc7, 4, 16, true);  break;   // BC7_SRGB
         default: break;                                         // unmapped -> false
@@ -296,15 +298,16 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 fi.format = DataFormat::Unorm8; fi.num_components = 4; fi.bytes_per_block = 4;
                 fi.block_width = fi.block_height = 1;
             }
-            // Block-compressed: BC1/2/3/4/5/7 are decoded to RGBA8 on upload (bc_decode, #290). Still
-            // skipped: BC6H (HDR half-float — no decode wired) and the SNORM BC4/BC5 variants (the
-            // UNORM8 upload can't carry signed samples; a remapped decode would be numerically wrong).
+            // Block-compressed: BC1/2/3/4/5/7 AND BC6H_UF16 are decoded to RGBA8 on upload
+            // (bc_decode, #290/#273 — BC6H clamps >1.0 HDR energy like the fp16 path). Still
+            // skipped: SIGNED variants (BC4/BC5 SNORM, BC6H SF16 — the UNORM8 upload can't carry
+            // signed samples; a remapped decode would be numerically wrong).
             const bool is_bcn = fi.block_width > 1;
-            if (is_bcn && (fi.format == DataFormat::Bc6 || fi.snorm)) {
+            if (is_bcn && fi.snorm) {
                 if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
                     fprintf(stderr, "[t#] Gen5 IMG_FMT %u is %s (%ux%u T#) -> decode not "
                                     "wired; skipping texture binding\n", d.format,
-                            fi.format == DataFormat::Bc6 ? "BC6H (HDR)" : "SNORM BCn",
+                            fi.format == DataFormat::Bc6 ? "BC6H SF16" : "SNORM BCn",
                             d.width, d.height); }
                 continue;
             }

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -322,6 +322,10 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
             r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
             r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];   // T# DST_SEL channel remap (#261)
+            // T# TYPE -> the MIMG dim convention (GFX10 SQ_RSRC_IMG: 8=1D, 9=2D, 10=3D, 11=CUBE,
+            // 12=1D_ARRAY, 13=2D_ARRAY). A CUBE resource (img_dim 3) uploads as six faces stacked
+            // vertically in one 2D image (#273); everything else keeps the 2D default.
+            r.img_dim       = d.type == 11 ? 3u : d.type == 10 ? 2u : d.type == 13 ? 5u : 1u;
             r.srgb          = fi.srgb;              // gamma-encoded surface: sample with sRGB->linear (#263)
             if (fi.srgb && getenv("PROSPER_GFXLOG"))
                 fprintf(stderr, "[t#] SRGB texture fmt=%u %ux%u (binding %u)\n", d.format, d.width, d.height, r.binding);

--- a/prosper/src/gpu/bc_decode.cpp
+++ b/prosper/src/gpu/bc_decode.cpp
@@ -351,11 +351,684 @@ void decode_bc7_block(const uint8_t* blk, uint8_t out[16][4]) {
 
 } // namespace
 
+// ---------------------------------------------------------------------------------------------------
+// BC6H (BPTC_FLOAT) — Khronos Data Format spec / Microsoft D3D11 functional spec paragraph 19.6.
+// Decode logic and constants adapted VERBATIM from bcdec (MIT/Unlicense, Sergii Kudlai) — the same
+// reference the BC7 tables above credit — because the 14 mode bit-layouts are heavily scrambled and
+// a hand transcription would be error-prone. Output here is a 4x4 tile of RGB half-floats which
+// decode_bc6h_block converts to RGBA8 (clamp01 * 255): the upload path is 8-bit, so HDR energy
+// above 1.0 clamps — same policy as the fp16-surface path (#290). UNSIGNED (UF16) only for now;
+// the SF16 variant stays skipped upstream (no live example).
+typedef struct bc6h__bitstream {
+    unsigned long long low;
+    unsigned long long high;
+} bc6h__bitstream_t;
+
+static int bc6h__bitstream_read_bits(bc6h__bitstream_t* bstream, int numBits) {
+    unsigned int mask = (1 << numBits) - 1;
+    /* Read the low N bits */
+    unsigned int bits = (bstream->low & mask);
+
+    bstream->low >>= numBits;
+    /* Put the low N bits of "high" into the high 64-N bits of "low". */
+    bstream->low |= (bstream->high & mask) << (sizeof(bstream->high) * 8 - numBits);
+    bstream->high >>= numBits;
+    
+    return bits;
+}
+
+static int bc6h__bitstream_read_bit(bc6h__bitstream_t* bstream) {
+    return bc6h__bitstream_read_bits(bstream, 1);
+}
+
+/*  reversed bits pulling, used in BC6H decoding
+    why ?? just why ??? */
+static int bc6h__bitstream_read_bits_r(bc6h__bitstream_t* bstream, int numBits) {
+    int bits = bc6h__bitstream_read_bits(bstream, numBits);
+    /* Reverse the bits. */
+    int result = 0;
+    while (numBits--) {
+        result <<= 1;
+        result |= (bits & 1);
+        bits >>= 1;
+    }
+    return result;
+}
+
+
+
+
+static int bc6h__extend_sign(int val, int bits) {
+    return (val << (32 - bits)) >> (32 - bits);
+}
+
+static int bc6h__transform_inverse(int val, int a0, int bits, int isSigned) {
+    /* If the precision of A0 is "p" bits, then the transform algorithm is:
+       B0 = (B0 + A0) & ((1 << p) - 1) */
+    val = (val + a0) & ((1 << bits) - 1);
+    if (isSigned) {
+        val = bc6h__extend_sign(val, bits);
+    }
+    return val;
+}
+
+/* pretty much copy-paste from documentation */
+static int bc6h__unquantize(int val, int bits, int isSigned) {
+    int unq, s = 0;
+
+    if (!isSigned) {
+        if (bits >= 15) {
+            unq = val;
+        } else if (!val) {
+            unq = 0;
+        } else if (val == ((1 << bits) - 1)) {
+            unq = 0xFFFF;
+        } else {
+            unq = ((val << 16) + 0x8000) >> bits;
+        }
+    } else {
+        if (bits >= 16) {
+            unq = val;
+        } else {
+            if (val < 0) {
+                s = 1;
+                val = -val;
+            }
+
+            if (val == 0) {
+                unq = 0;
+            } else if (val >= ((1 << (bits - 1)) - 1)) {
+                unq = 0x7FFF;
+            } else {
+                unq = ((val << 15) + 0x4000) >> (bits - 1);
+            }
+
+            if (s) {
+                unq = -unq;
+            }
+        }
+    }
+    return unq;
+}
+
+static int bc6h__interpolate(int a, int b, int* weights, int index) {
+    return (a * (64 - weights[index]) + b * weights[index] + 32) >> 6;
+}
+
+static unsigned short bc6h__finish_unquantize(int val, int isSigned) {
+    int s;
+
+    if (!isSigned) {
+        return (unsigned short)((val * 31) >> 6);                   /* scale the magnitude by 31 / 64 */
+    } else {
+        val = (val < 0) ? -(((-val) * 31) >> 5) : (val * 31) >> 5;  /* scale the magnitude by 31 / 32 */
+        s = 0;
+        if (val < 0) {
+            s = 0x8000;
+            val = -val;
+        }
+        return (unsigned short)(s | val);
+    }
+}
+
+/* modified half_to_float_fast4 from https://gist.github.com/rygorous/2144712 */
+static float bc6h__half_to_float_quick(unsigned short half) {
+    typedef union {
+        unsigned int u;
+        float f;
+    } FP32;
+
+    static const FP32 magic = { 113 << 23 };
+    static const unsigned int shifted_exp = 0x7c00 << 13;   /* exponent mask after shift */
+    FP32 o;
+    unsigned int exp;
+
+    o.u = (half & 0x7fff) << 13;                            /* exponent/mantissa bits */
+    exp = shifted_exp & o.u;                                /* just the exponent */
+    o.u += (127 - 15) << 23;                                /* exponent adjust */
+
+    /* handle exponent special cases */
+    if (exp == shifted_exp) {                               /* Inf/NaN? */
+        o.u += (128 - 16) << 23;                            /* extra exp adjust */
+    } else if (exp == 0) {                                  /* Zero/Denormal? */
+        o.u += 1 << 23;                                     /* extra exp adjust */
+        o.f -= magic.f;                                     /* renormalize */
+    }
+
+    o.u |= (half & 0x8000) << 16;                           /* sign bit */
+    return o.f;
+}
+
+static void bc6h__decode_block_half(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    static char actual_bits_count[4][14] = {
+        { 10, 7, 11, 11, 11, 9, 8, 8, 8, 6, 10, 11, 12, 16 },   /*  W */
+        {  5, 6,  5,  4,  4, 5, 6, 5, 5, 6, 10,  9,  8,  4 },   /* dR */
+        {  5, 6,  4,  5,  4, 5, 5, 6, 5, 6, 10,  9,  8,  4 },   /* dG */
+        {  5, 6,  4,  4,  5, 5, 5, 5, 6, 6, 10,  9,  8,  4 }    /* dB */
+    };
+
+    /* There are 32 possible partition sets for a two-region tile.
+       Each 4x4 block represents a single shape.
+       Here also every fix-up index has MSB bit set. */
+    static unsigned char partition_sets[32][4][4] = {
+        { {128, 0,   1, 1}, {0, 0, 1, 1}, {  0, 0, 1, 1}, {0, 0, 1, 129} },   /*  0 */
+        { {128, 0,   0, 1}, {0, 0, 0, 1}, {  0, 0, 0, 1}, {0, 0, 0, 129} },   /*  1 */
+        { {128, 1,   1, 1}, {0, 1, 1, 1}, {  0, 1, 1, 1}, {0, 1, 1, 129} },   /*  2 */
+        { {128, 0,   0, 1}, {0, 0, 1, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} },   /*  3 */
+        { {128, 0,   0, 0}, {0, 0, 0, 1}, {  0, 0, 0, 1}, {0, 0, 1, 129} },   /*  4 */
+        { {128, 0,   1, 1}, {0, 1, 1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} },   /*  5 */
+        { {128, 0,   0, 1}, {0, 0, 1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} },   /*  6 */
+        { {128, 0,   0, 0}, {0, 0, 0, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} },   /*  7 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  0, 0, 0, 1}, {0, 0, 1, 129} },   /*  8 */
+        { {128, 0,   1, 1}, {0, 1, 1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /*  9 */
+        { {128, 0,   0, 0}, {0, 0, 0, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} },   /* 10 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  0, 0, 0, 1}, {0, 1, 1, 129} },   /* 11 */
+        { {128, 0,   0, 1}, {0, 1, 1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /* 12 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /* 13 */
+        { {128, 0,   0, 0}, {1, 1, 1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /* 14 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  0, 0, 0, 0}, {1, 1, 1, 129} },   /* 15 */
+        { {128, 0,   0, 0}, {1, 0, 0, 0}, {  1, 1, 1, 0}, {1, 1, 1, 129} },   /* 16 */
+        { {128, 1, 129, 1}, {0, 0, 0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} },   /* 17 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {129, 0, 0, 0}, {1, 1, 1,   0} },   /* 18 */
+        { {128, 1, 129, 1}, {0, 0, 1, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} },   /* 19 */
+        { {128, 0, 129, 1}, {0, 0, 0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} },   /* 20 */
+        { {128, 0,   0, 0}, {1, 0, 0, 0}, {129, 1, 0, 0}, {1, 1, 1,   0} },   /* 21 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} },   /* 22 */
+        { {128, 1,   1, 1}, {0, 0, 1, 1}, {  0, 0, 1, 1}, {0, 0, 0, 129} },   /* 23 */
+        { {128, 0, 129, 1}, {0, 0, 0, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} },   /* 24 */
+        { {128, 0,   0, 0}, {1, 0, 0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} },   /* 25 */
+        { {128, 1, 129, 0}, {0, 1, 1, 0}, {  0, 1, 1, 0}, {0, 1, 1,   0} },   /* 26 */
+        { {128, 0, 129, 1}, {0, 1, 1, 0}, {  0, 1, 1, 0}, {1, 1, 0,   0} },   /* 27 */
+        { {128, 0,   0, 1}, {0, 1, 1, 1}, {129, 1, 1, 0}, {1, 0, 0,   0} },   /* 28 */
+        { {128, 0,   0, 0}, {1, 1, 1, 1}, {129, 1, 1, 1}, {0, 0, 0,   0} },   /* 29 */
+        { {128, 1, 129, 1}, {0, 0, 0, 1}, {  1, 0, 0, 0}, {1, 1, 1,   0} },   /* 30 */
+        { {128, 0, 129, 1}, {1, 0, 0, 1}, {  1, 0, 0, 1}, {1, 1, 0,   0} }    /* 31 */
+    };
+
+    static int aWeight3[8] = { 0, 9, 18, 27, 37, 46, 55, 64 };
+    static int aWeight4[16] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
+
+    bc6h__bitstream_t bstream;
+    int mode, partition, numPartitions, i, j, partitionSet, indexBits, index, ep_i, actualBits0Mode;
+    int r[4], g[4], b[4];       /* wxyz */
+    unsigned short* decompressed;
+    int* weights;
+
+    decompressed = (unsigned short*)decompressedBlock;
+
+    bstream.low = ((unsigned long long*)compressedBlock)[0];
+    bstream.high = ((unsigned long long*)compressedBlock)[1];
+
+    r[0] = r[1] = r[2] = r[3] = 0;
+    g[0] = g[1] = g[2] = g[3] = 0;
+    b[0] = b[1] = b[2] = b[3] = 0;
+
+    mode = bc6h__bitstream_read_bits(&bstream, 2);
+    if (mode > 1) {
+        mode |= (bc6h__bitstream_read_bits(&bstream, 3) << 2);
+    }
+
+    /* modes >= 11 (10 in my code) are using 0 one, others will read it from the bitstream */
+    partition = 0;
+
+    switch (mode) {
+        /* mode 1 */
+        case 0b00: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 75 bits (10.555, 10.555, 10.555) */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 0;
+        } break;
+
+        /* mode 2 */
+        case 0b01: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 75 bits (7666, 7666, 7666) */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* gy[5]   */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* gz[5]   */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 7);        /* rw[6:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 7);        /* gw[6:0] */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* by[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 7);        /* bw[6:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* bz[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rx[5:0] */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* gx[5:0] */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* bx[5:0] */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 6);        /* ry[5:0] */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rz[5:0] */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 1;
+        } break;
+
+        /* mode 3 */
+        case 0b00010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (11.555, 11.444, 11.444) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            r[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            g[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* bx[3:0] */
+            b[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 2;
+        } break;
+
+        /* mode 4 */
+        case 0b00110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (11.444, 11.555, 11.444) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* rx[3:0] */
+            r[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            g[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* bx[3:0] */
+            b[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* ry[3:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* rz[3:0] */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 3;
+        } break;
+
+        /* mode 5 */
+        case 0b01010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (11.444, 11.444, 11.555) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* rx[3:0] */
+            r[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            g[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* ry[3:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* rz[3:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */ 
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 4;
+        } break;
+
+        /* mode 6 */
+        case 0b01110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (9555, 9555, 9555) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 9);        /* rw[8:0] */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 9);        /* gw[8:0] */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 9);        /* bw[8:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 5;
+        } break;
+
+        /* mode 7 */
+        case 0b10010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (8666, 8555, 8555) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* rw[7:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* gw[7:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* bw[7:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rx[5:0] */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 6);        /* ry[5:0] */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rz[5:0] */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 6;
+        } break;
+
+        /* mode 8 */
+        case 0b10110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (8555, 8666, 8555) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* rw[7:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* gw[7:0] */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* gy[5]   */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* bw[7:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* gz[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* gx[5:0] */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* zx[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 7;
+        } break;
+
+        /* mode 9 */
+        case 0b11010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (8555, 8555, 8666) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* rw[7:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* gw[7:0] */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* by[5]   */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 8);        /* bw[7:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* bz[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* bw[4:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* bx[5:0] */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 8;
+        } break;
+
+        /* mode 10 */
+        case 0b11110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (6666, 6666, 6666) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rw[5:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 6);        /* gw[5:0] */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* gy[5]   */
+            b[2] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* by[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            g[2] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 6);        /* bw[5:0] */
+            g[3] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* gz[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 5;       /* bz[5]   */
+            b[3] |= bc6h__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rx[5:0] */
+            g[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* gx[5:0] */
+            g[3] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 6);        /* bx[5:0] */
+            b[2] |= bc6h__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bc6h__bitstream_read_bits(&bstream, 6);        /* ry[5:0] */
+            r[3] |= bc6h__bitstream_read_bits(&bstream, 6);        /* rz[5:0] */
+            partition = bc6h__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 9;
+        } break;
+
+        /* mode 11 */
+        case 0b00011: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (10.10, 10.10, 10.10) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rx[9:0] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gx[9:0] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bx[9:0] */
+            mode = 10;
+        } break;
+
+        /* mode 12 */
+        case 0b00111: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (11.9, 11.9, 11.9) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 9);        /* rx[8:0] */
+            r[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 9);        /* gx[8:0] */
+            g[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 9);        /* bx[8:0] */
+            b[0] |= bc6h__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            mode = 11;
+        } break;
+
+        /* mode 13 */
+        case 0b01011: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (12.8, 12.8, 12.8) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 8);        /* rx[7:0] */
+            r[0] |= bc6h__bitstream_read_bits_r(&bstream, 2) << 10;/* rx[10:11] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 8);        /* gx[7:0] */
+            g[0] |= bc6h__bitstream_read_bits_r(&bstream, 2) << 10;/* gx[10:11] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 8);        /* bx[7:0] */
+            b[0] |= bc6h__bitstream_read_bits_r(&bstream, 2) << 10;/* bx[10:11] */
+            mode = 12;
+        } break;
+
+        /* mode 14 */
+        case 0b01111: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (16.4, 16.4, 16.4) */
+            r[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bc6h__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* rx[3:0] */
+            r[0] |= bc6h__bitstream_read_bits_r(&bstream, 6) << 10;/* rw[10:15] */
+            g[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            g[0] |= bc6h__bitstream_read_bits_r(&bstream, 6) << 10;/* gw[10:15] */
+            b[1] |= bc6h__bitstream_read_bits(&bstream, 4);        /* bx[3:0] */
+            b[0] |= bc6h__bitstream_read_bits_r(&bstream, 6) << 10;/* bw[10:15] */
+            mode = 13;
+        } break;
+
+        default: {
+            /* Modes 10011, 10111, 11011, and 11111 (not shown) are reserved.
+               Do not use these in your encoder. If the hardware is passed blocks
+               with one of these modes specified, the resulting decompressed block
+               must contain all zeroes in all channels except for the alpha channel. */
+            for (i = 0; i < 4; ++i) {
+                for (j = 0; j < 4; ++j) {
+                    decompressed[j * 3 + 0] = 0;
+                    decompressed[j * 3 + 1] = 0;
+                    decompressed[j * 3 + 2] = 0;
+                }
+                decompressed += destinationPitch;
+            }
+
+            return;
+        }
+    }
+
+    numPartitions = (mode >= 10) ? 0 : 1;
+
+    actualBits0Mode = actual_bits_count[0][mode];
+    if (isSigned) {
+        r[0] = bc6h__extend_sign(r[0], actualBits0Mode);
+        g[0] = bc6h__extend_sign(g[0], actualBits0Mode);
+        b[0] = bc6h__extend_sign(b[0], actualBits0Mode);
+    }
+
+    /* Mode 11 (like Mode 10) does not use delta compression,
+       and instead stores both color endpoints explicitly.  */
+    if ((mode != 9 && mode != 10) || isSigned) {
+        for (i = 1; i < (numPartitions + 1) * 2; ++i) {
+            r[i] = bc6h__extend_sign(r[i], actual_bits_count[1][mode]);
+            g[i] = bc6h__extend_sign(g[i], actual_bits_count[2][mode]);
+            b[i] = bc6h__extend_sign(b[i], actual_bits_count[3][mode]);
+        }
+    }
+
+    if (mode != 9 && mode != 10) {
+        for (i = 1; i < (numPartitions + 1) * 2; ++i) {
+            r[i] = bc6h__transform_inverse(r[i], r[0], actualBits0Mode, isSigned);
+            g[i] = bc6h__transform_inverse(g[i], g[0], actualBits0Mode, isSigned);
+            b[i] = bc6h__transform_inverse(b[i], b[0], actualBits0Mode, isSigned);
+        }
+    }
+
+    for (i = 0; i < (numPartitions + 1) * 2; ++i) {
+        r[i] = bc6h__unquantize(r[i], actualBits0Mode, isSigned);
+        g[i] = bc6h__unquantize(g[i], actualBits0Mode, isSigned);
+        b[i] = bc6h__unquantize(b[i], actualBits0Mode, isSigned);
+    }
+
+    weights = (mode >= 10) ? aWeight4 : aWeight3;
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            partitionSet = (mode >= 10) ? ((i|j) ? 0 : 128) : partition_sets[partition][i][j];
+
+            indexBits = (mode >= 10) ? 4 : 3;
+            /* fix-up index is specified with one less bit */
+            /* The fix-up index for subset 0 is always index 0 */
+            if (partitionSet & 0x80) {
+                indexBits--;
+            }
+            partitionSet &= 0x01;
+
+            index = bc6h__bitstream_read_bits(&bstream, indexBits);
+
+            ep_i = partitionSet * 2;
+            decompressed[j * 3 + 0] = bc6h__finish_unquantize(
+                                            bc6h__interpolate(r[ep_i], r[ep_i+1], weights, index), isSigned);
+            decompressed[j * 3 + 1] = bc6h__finish_unquantize(
+                                            bc6h__interpolate(g[ep_i], g[ep_i+1], weights, index), isSigned);
+            decompressed[j * 3 + 2] = bc6h__finish_unquantize(
+                                            bc6h__interpolate(b[ep_i], b[ep_i+1], weights, index), isSigned);
+        }
+
+        decompressed += destinationPitch;
+    }
+}
+
+
+// Decode one 16-byte BC6H (UF16) block into a 4x4 RGBA8 tile (row-major).
+void decode_bc6h_block(const uint8_t* blk, uint8_t out[16][4]) {
+    unsigned short halfs[16 * 3];
+    bc6h__decode_block_half(blk, halfs, 4 * 3, /*isSigned*/0);
+    for (int t = 0; t < 16; t++) {
+        for (int c = 0; c < 3; c++) {
+            float f = bc6h__half_to_float_quick(halfs[t * 3 + c]);
+            out[t][c] = (f != f || f <= 0.f) ? 0 : (f >= 1.f ? 255 : (uint8_t)(f * 255.f + 0.5f));
+        }
+        out[t][3] = 255;
+    }
+}
+
 bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                        uint32_t width, uint32_t height, DataFormat fmt) {
     const uint32_t bb = bc_block_bytes(fmt);
     if (fmt != DataFormat::Bc1 && fmt != DataFormat::Bc2 && fmt != DataFormat::Bc3 &&
-        fmt != DataFormat::Bc4 && fmt != DataFormat::Bc5 && fmt != DataFormat::Bc7) return false;
+        fmt != DataFormat::Bc4 && fmt != DataFormat::Bc5 && fmt != DataFormat::Bc6 &&
+        fmt != DataFormat::Bc7) return false;
     const uint32_t bw = (width + 3) / 4, bh = (height + 3) / 4;
     std::memset(dst, 0, (size_t)width * height * 4);
     for (uint32_t by = 0; by < bh; by++) {
@@ -377,6 +1050,8 @@ bool bc_decode_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                 for (int t = 0; t < 16; t++) { texels[t][0] = r[t]; texels[t][1] = g[t]; texels[t][2] = 0; texels[t][3] = 255; }
             } else if (fmt == DataFormat::Bc7) {
                 decode_bc7_block(blk, texels);
+            } else if (fmt == DataFormat::Bc6) {
+                decode_bc6h_block(blk, texels);      // UF16 -> clamped RGBA8 (see the adapter above)
             } else {                                          // BC2/BC3: alpha sub-block then color sub-block
                 decode_color_block(blk + 8, texels, /*dxt1_alpha*/false);
                 if (fmt == DataFormat::Bc3) decode_bc3_alpha(blk, texels);

--- a/prosper/src/gpu/bc_decode.hpp
+++ b/prosper/src/gpu/bc_decode.hpp
@@ -8,7 +8,9 @@
 // Standard S3TC/BPTC decode (Khronos data-format spec §18-19, MS D3D11 §19.5): a 4x4-texel block is
 // 8 bytes (BC1/BC4) or 16 bytes (BC2/BC3/BC5/BC6/BC7). Implemented: BC1/BC2/BC3 (Messenger UI/text),
 // BC4/BC5 (single/dual-channel ramps) and BC7 (mode-switched; DOLL's material atlases) — #290.
-// BC6H (HDR half-float) is NOT decoded yet; bc_decode_surface returns false for it.
+// BC6H UF16 (HDR half-float; DOLL's title skybox/probes, #273) decodes too — then CLAMPS to
+// UNORM8, losing >1.0 energy like the fp16-surface path. SIGNED variants (BC4/5 SNORM, BC6H SF16)
+// stay skipped upstream.
 #pragma once
 #include <cstdint>
 #include "shader_resources.hpp"

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -82,11 +82,19 @@ struct DynFetch {
 // turns each use into a ShaderResource with srt_offset = key.
 struct SrtUse {
     int kind = 0;                    // 0 = texture (t8, + s4 sampler when resolved), 1 = constant buffer (v4)
-    uint32_t key = 0;                // the s_load immediate byte offset (== emit_alu's sreg_srt tag)
+    uint32_t key = 0;                // the s_load immediate byte offset (== emit_alu's sreg_srt tag);
+                                     // 0xFFFFFFFF = key-less (register-SOFFSET / negative-imm load — the
+                                     // recompiler then resolves the use by its instruction pc instead)
     std::array<uint32_t, 8> t8{};    // T# dwords as loaded (kind 0)
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)
+    // PER-USE pc provenance (#273 — DOLL's title-composite image_sample_b): the pc of the consuming
+    // image op. The load-immediate key model breaks when the same immediate appears against two
+    // different table pointers (a key-0 EUD sharp colliding with a key-0 table T#) or when the load
+    // has no usable key; keying the TEXTURE use by its exact instruction (ShaderResource::fetch_pc,
+    // the same per-instruction provenance the vertex fetches use) is unambiguous.
+    uint32_t use_pc = 0xFFFFFFFFu;   // kind 0 only (cbufs keep the key model)
 };
 std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             const uint32_t* user_sgprs, uint32_t nsgpr,
@@ -200,6 +208,17 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                         (unsigned long long)rs.es_addr);
                 g_dyntrace_force = true;
                 (void)build_stage_table(ds, rs.es_addr, false);
+                g_dyntrace_force = false;
+            }
+        }
+        // Same replay for a FAILED pixel stage (#273 — the PS-side descriptor-resolution walls).
+        if (fs.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
+            static std::set<uint64_t> traced_ps;
+            if (traced_ps.insert(rs.ps_addr).second) {
+                fprintf(stderr, "[dynfail] replaying PS 0x%llx resource build with trace:\n",
+                        (unsigned long long)rs.ps_addr);
+                g_dyntrace_force = true;
+                (void)build_stage_table(ds, rs.ps_addr, true);
                 g_dyntrace_force = false;
             }
         }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -289,12 +289,21 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             }
             case Rdna2Format::MIMG: {
                 // Descriptor-table use (#294): an image op's SRSRC (src[1]) is an 8-dword T#; if it was
-                // snapshotted from a keyed table load, report it as a Texture use — with the paired
-                // SSAMP (src[2]) S# when that 4-dword load also resolved. VGPR-only dest: no SGPR state.
+                // snapshotted from a table load, report it as a Texture use — with the paired SSAMP
+                // (src[2]) S# when that 4-dword load also resolved. VGPR-only dest: no SGPR state.
+                // Key-less snapshots (register-SOFFSET loads) are reported too (#273): the use carries
+                // its instruction pc, which the recompiler resolves via ShaderResource::fetch_pc when
+                // the immediate-key model fails or collides.
                 if (srt_uses) {
                     auto tit = descr8.find(in.src[1].value); auto kit = descr8_key.find(in.src[1].value);
-                    if (tit != descr8.end() && kit != descr8_key.end() && kit->second != 0xFFFFFFFFu) {
-                        SrtUse u; u.kind = 0; u.key = kit->second; u.t8 = tit->second;
+                    if (trc) fprintf(stderr, "[dyntrace] MIMG pc=%u srsrc=s%d ssamp=s%d have_t8=%d key=0x%x t8[0]=0x%x\n",
+                                     in.pc, in.src[1].value, in.src[2].value, tit != descr8.end(),
+                                     kit != descr8_key.end() ? kit->second : 0xEEEEEEEEu,
+                                     tit != descr8.end() ? tit->second[0] : 0u);
+                    if (tit != descr8.end()) {
+                        SrtUse u; u.kind = 0; u.t8 = tit->second;
+                        u.key = kit != descr8_key.end() ? kit->second : 0xFFFFFFFFu;
+                        u.use_pc = in.pc;
                         auto sit = descr.find(in.src[2].value);
                         if (sit != descr.end()) { u.has_samp = true; u.s4 = sit->second; }
                         srt_uses->push_back(u);
@@ -303,6 +312,19 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 break;
             }
             case Rdna2Format::MUBUF: {
+                // Descriptor-table V# use (#273 — the title post-chain PSes' per-lane structured-buffer
+                // fetches): a buffer_load_format_* / buffer_load_dword* whose SRSRC V# was s_loaded from
+                // a keyed table slot. Report it as a kind-1 (buffer) use so the consuming instruction
+                // resolves via its sreg_srt tag -> by_srt_offset — the same key model the s_buffer_loads
+                // use. (The VS vertex-fetch path below is unchanged: by_fetch_pc still wins there.)
+                if (srt_uses && (in.opcode <= 3 || (in.opcode >= 0x0C && in.opcode <= 0x0F))) {
+                    int srsrc = in.src[1].value;
+                    auto dit = descr.find(srsrc); auto kit = descr_key.find(srsrc);
+                    if (dit != descr.end() && kit != descr_key.end() && kit->second != 0xFFFFFFFFu) {
+                        SrtUse u; u.kind = 1; u.key = kit->second; u.v4 = dit->second;
+                        srt_uses->push_back(u);
+                    }
+                }
                 // buffer_load_format_* (vertex fetch): opcodes 0..3. Resolve the SRSRC (src[1]) SGPR to the
                 // V# most-recently loaded into it.
                 if (in.opcode <= 3) {
@@ -586,11 +608,16 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         {
             std::set<uint64_t> srt_seen;
             for (const auto& u : srt_uses) {
-                uint64_t dk = ((uint64_t)(uint32_t)u.kind << 32) | u.key;
+                // Dedupe: a cbuf use per key (the s_buffer_load resolves by key); a texture use per
+                // CONSUMING INSTRUCTION (#273 — several image ops may share one key, or have none).
+                // Distinct namespaces: kind-0 pc keys must never collide with kind-1 byte-offset keys.
+                uint64_t dk = u.kind == 0 ? (0x8000000000000000ull | u.use_pc)
+                                          : ((uint64_t)(uint32_t)u.kind << 32) | u.key;
                 if (!srt_seen.insert(dk).second) continue;
-                bool clash = false;
-                for (const auto& r0 : t.resources) if (r0.srt_offset == u.key) { clash = true; break; }
-                if (clash) continue;
+                bool clash = u.key == 0xFFFFFFFFu;       // key-less: never resolvable by srt_offset
+                if (!clash)
+                    for (const auto& r0 : t.resources) if (r0.srt_offset == u.key) { clash = true; break; }
+                if (u.kind == 1 && clash) continue;      // ambiguous cbuf key: keep the existing resource
                 if (u.kind == 1) {                       // constant buffer (V#)
                     DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
                     if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
@@ -604,8 +631,27 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     t.resources.push_back(r);
                 } else {                                  // texture (T# [+ paired S#])
                     DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
+                    if (g_dyntrace_force)
+                        fprintf(stderr, "[dynfail] tex use pc=%u key=0x%x base=0x%llx %ux%u fmt=%u tile=%u\n",
+                                u.use_pc, u.key, (unsigned long long)d.base, d.width, d.height,
+                                d.format, d.tile_mode);
                     if (d.base == 0 || d.width == 0 || d.height == 0 ||
                         d.width > 16384 || d.height > 16384) continue;       // garbage/degenerate T#
+                    // A previous use already produced a resource for this SAME surface (same T# base +
+                    // extent): don't duplicate the binding/upload — just give it this use's pc
+                    // provenance if it has none yet (#273). Uses with a valid unclashed key still
+                    // resolve by key regardless.
+                    {
+                        bool piggybacked = false;
+                        for (auto& r0 : t.resources)
+                            if (r0.cls == ResourceClass::Texture && r0.gpu_addr == d.base &&
+                                r0.width == d.width && r0.height == d.height) {
+                                if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
+                                piggybacked = true;
+                                break;
+                            }
+                        if (piggybacked) continue;
+                    }
                     Gen5ImageFormatInfo fi;
                     if (!gen5_image_format(d.format, &fi)) {
                         // Same unmapped-format policy as build_shader_resources: bind as RGBA8 only
@@ -627,7 +673,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
                                     : (d.width * d.height * fi.bytes_per_block);
-                    r.srt_offset = u.key;
+                    r.srt_offset = clash ? 0xFFFFFFFFu : u.key;   // ambiguous/absent key: pc-only provenance
+                    r.fetch_pc   = u.use_pc;                       // per-instruction provenance (#273)
                     if (u.has_samp) {                     // paired S# (same SQ_IMG_SAMP decode as the sharp path)
                         const uint32_t* sm = u.s4.data();
                         r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -692,6 +692,9 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.format = fi.format; r.num_components = fi.num_components;
                     r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
+                    // T# TYPE -> MIMG dim (GFX10: 9=2D, 10=3D, 11=CUBE, 13=2D_ARRAY); a cube
+                    // uploads as six vertically-stacked faces (#273 — see agc_shader_layout).
+                    r.img_dim = d.type == 11 ? 3u : d.type == 10 ? 2u : d.type == 13 ? 5u : 1u;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -320,8 +320,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 if (srt_uses && (in.opcode <= 3 || (in.opcode >= 0x0C && in.opcode <= 0x0F))) {
                     int srsrc = in.src[1].value;
                     auto dit = descr.find(srsrc); auto kit = descr_key.find(srsrc);
-                    if (dit != descr.end() && kit != descr_key.end() && kit->second != 0xFFFFFFFFu) {
-                        SrtUse u; u.kind = 1; u.key = kit->second; u.v4 = dit->second;
+                    if (dit != descr.end()) {
+                        // Key-less snapshots (an s_buffer_load-fetched V# — a structured-buffer
+                        // descriptor stored INSIDE a constant buffer, DOLL's title post PSes) carry
+                        // the consuming instruction's pc instead; the recompiler resolves those via
+                        // ShaderResource::fetch_pc with the faithful (non-vertex-index) address path.
+                        SrtUse u; u.kind = 1; u.v4 = dit->second;
+                        u.key = kit != descr_key.end() ? kit->second : 0xFFFFFFFFu;
+                        u.use_pc = in.pc;
                         srt_uses->push_back(u);
                     }
                 }
@@ -608,26 +614,43 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         {
             std::set<uint64_t> srt_seen;
             for (const auto& u : srt_uses) {
-                // Dedupe: a cbuf use per key (the s_buffer_load resolves by key); a texture use per
-                // CONSUMING INSTRUCTION (#273 — several image ops may share one key, or have none).
-                // Distinct namespaces: kind-0 pc keys must never collide with kind-1 byte-offset keys.
-                uint64_t dk = u.kind == 0 ? (0x8000000000000000ull | u.use_pc)
-                                          : ((uint64_t)(uint32_t)u.kind << 32) | u.key;
+                // Dedupe: a KEYED cbuf use per key (the s_buffer_load resolves by key); texture and
+                // key-less buffer uses per CONSUMING INSTRUCTION (#273 — several image ops may share
+                // one key, or have none; a key-less V# fetch resolves by its pc).
+                // Distinct namespaces: pc keys must never collide with byte-offset keys.
+                uint64_t dk = (u.kind == 0 || u.key == 0xFFFFFFFFu)
+                                  ? (0x8000000000000000ull | ((uint64_t)(uint32_t)u.kind << 32) | u.use_pc)
+                                  : ((uint64_t)(uint32_t)u.kind << 32) | u.key;
                 if (!srt_seen.insert(dk).second) continue;
                 bool clash = u.key == 0xFFFFFFFFu;       // key-less: never resolvable by srt_offset
                 if (!clash)
                     for (const auto& r0 : t.resources) if (r0.srt_offset == u.key) { clash = true; break; }
-                if (u.kind == 1 && clash) continue;      // ambiguous cbuf key: keep the existing resource
-                if (u.kind == 1) {                       // constant buffer (V#)
+                if (u.kind == 1) {                       // constant buffer / structured-buffer V#
                     DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
                     if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+                    // A keyed use whose key already resolves keeps the existing resource; a key-less
+                    // (or key-clashed) use still needs a pc-provenance entry — piggyback the pc onto
+                    // an existing resource describing the SAME buffer, else create one (#273).
+                    if (clash) {
+                        bool piggybacked = false;
+                        for (auto& r0 : t.resources)
+                            if ((r0.cls == ResourceClass::ConstantBuffer || r0.cls == ResourceClass::VertexBuffer) &&
+                                r0.gpu_addr == d.base && r0.size == d.size_bytes) {
+                                if (r0.fetch_pc == 0xFFFFFFFFu && r0.cls == ResourceClass::ConstantBuffer)
+                                    r0.fetch_pc = u.use_pc;
+                                piggybacked = r0.fetch_pc == u.use_pc || r0.cls == ResourceClass::VertexBuffer;
+                                if (piggybacked) break;
+                            }
+                        if (piggybacked) continue;
+                    }
                     ShaderResource r;
                     r.cls = ResourceClass::ConstantBuffer;
                     r.format = d.format; r.num_components = d.num_components ? d.num_components : 1;
                     r.gpu_addr = d.base; r.size = d.size_bytes; r.stride = d.stride;
-                    r.srt_offset = u.key;
-                    if (log) fprintf(stderr, "[srt] %s cbuf key=0x%x base=0x%llx size=%u\n", is_ps ? "PS" : "VS",
-                                     u.key, (unsigned long long)d.base, d.size_bytes);
+                    r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
+                    if (clash) r.fetch_pc = u.use_pc;    // pc-only provenance (key-less/collided V#)
+                    if (log) fprintf(stderr, "[srt] %s cbuf key=0x%x pc=%u base=0x%llx size=%u\n", is_ps ? "PS" : "VS",
+                                     u.key, u.use_pc, (unsigned long long)d.base, d.size_bytes);
                     t.resources.push_back(r);
                 } else {                                  // texture (T# [+ paired S#])
                     DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
@@ -638,19 +661,19 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     if (d.base == 0 || d.width == 0 || d.height == 0 ||
                         d.width > 16384 || d.height > 16384) continue;       // garbage/degenerate T#
                     // A previous use already produced a resource for this SAME surface (same T# base +
-                    // extent): don't duplicate the binding/upload — just give it this use's pc
-                    // provenance if it has none yet (#273). Uses with a valid unclashed key still
-                    // resolve by key regardless.
+                    // extent): don't duplicate the binding/upload — give it this use's pc provenance
+                    // if it has none yet (#273). If it already carries a DIFFERENT use's pc, fall
+                    // through and create a second resource for this pc (fetch_pc holds one pc; a
+                    // sample whose pc has no mapping would stay unresolved).
                     {
-                        bool piggybacked = false;
+                        bool mapped = false;
                         for (auto& r0 : t.resources)
                             if (r0.cls == ResourceClass::Texture && r0.gpu_addr == d.base &&
                                 r0.width == d.width && r0.height == d.height) {
-                                if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
-                                piggybacked = true;
-                                break;
+                                if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
+                                if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
                             }
-                        if (piggybacked) continue;
+                        if (mapped) continue;
                     }
                     Gen5ImageFormatInfo fi;
                     if (!gen5_image_format(d.format, &fi)) {
@@ -663,7 +686,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         fi.block_width = fi.block_height = 1; fi.srgb = false; fi.snorm = false;
                     }
                     const bool is_bcn = fi.block_width > 1;
-                    if (is_bcn && (fi.format == DataFormat::Bc6 || fi.snorm)) continue;   // decode not wired
+                    if (is_bcn && fi.snorm) continue;   // signed BCn (SNORM / BC6H SF16): decode not wired
                     ShaderResource r;
                     r.cls = ResourceClass::Texture;
                     r.format = fi.format; r.num_components = fi.num_components;

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -74,6 +74,16 @@ void decode_operands(Rdna2Inst& i) {
                         i.sdwa_src0_sel = (uint8_t)s0sel;
                         i.has_modifier = false;
                     }
+                    // BYTE-select move (#273 — byte unpack): dst DWORD + UNUSED_PAD, src0 BYTE_0..3,
+                    // no sext/neg/abs/clamp/omod. The recompiler zero-extends the selected byte.
+                    // (llvm-mc gfx1030: 0x7e0c02f9 0x0000060f -> v_mov_b32_sdwa v6, v15
+                    // dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0.)
+                    else if (dsel == 6u && dun == 0u && s0sel <= 3u &&
+                             !((sd >> 19) & 0x9u) && !i.clamp && !i.omod && !i.src_neg[0] && !i.src_abs[0]) {
+                        i.sdwa_dst_sel = (uint8_t)dsel; i.sdwa_dst_unused = (uint8_t)dun;
+                        i.sdwa_src0_sel = (uint8_t)s0sel;
+                        i.has_modifier = false;
+                    }
                 }
             } else if (i.has_dpp) { i.src[0] = vgpr(i.words[1]); i.n_src = 1; }   // DPP16: real SRC0 in dw1[7:0]
             else { i.src[0] = decode_src_field(w & 0x1FFu); i.n_src = 1; }
@@ -170,7 +180,22 @@ void decode_operands(Rdna2Inst& i) {
             i.src[0] = decode_src_field(d1 & 0x1FFu);
             i.src[1] = decode_src_field((d1 >> 9) & 0x1FFu);
             i.src[2] = decode_src_field((d1 >> 18) & 0x1FFu); i.n_src = 3;
-            if (((w >> 8) & 0xFFu) != 0u || ((d1 >> 27) & 0x1Fu) != 0u) i.has_modifier = true;
+            // v_fma_mix_f32/mixlo/mixhi (0x20-0x22): every modifier bit is MODELED (#273) —
+            // OPSEL_HI[k] selects an f16-half read (which half via OPSEL[k]), NEG negates, NEG_HI
+            // is ABS for the mix family, CLAMP saturates. (llvm-mc gfx1030 round-trip on the live
+            // DOLL bytes: 0xcc200044 0x9a02170b = v_fma_mix_f32 v68, v11, v11, neg(0)
+            // op_sel_hi:[1,1,0].) Other VOP3P ops (v_pk_*, per-half packed semantics) still reject
+            // on any modifier bit.
+            if (i.opcode >= 0x20 && i.opcode <= 0x22) {
+                const uint32_t neg = (d1 >> 29) & 7u, neg_hi = (w >> 8) & 7u;
+                for (int k = 0; k < 3; k++) {
+                    i.src_neg[k] = ((neg >> k) & 1u) != 0;
+                    i.src_abs[k] = ((neg_hi >> k) & 1u) != 0;
+                }
+                i.vop3p_opsel    = (uint8_t)((w >> 11) & 7u);
+                i.vop3p_opsel_hi = (uint8_t)((((d1 >> 27) & 3u)) | (((w >> 14) & 1u) << 2));
+                i.clamp = ((w >> 15) & 1u) != 0;
+            } else if (((w >> 8) & 0xFFu) != 0u || ((d1 >> 27) & 0x1Fu) != 0u) i.has_modifier = true;
             break;
         }
         case Rdna2Format::SOP1:

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -106,6 +106,12 @@ struct Rdna2Inst {
     // opcode = p1(0)/p2(1)/mov(2); dst = vdst; src[0] = vsrc (the i/j barycentric VGPR).
     uint32_t vintrp_attr = 0;
     uint32_t vintrp_chan = 0;
+
+    // VOP3P v_fma_mix* only (#273): per-source half-select bitmasks. Bit k of vop3p_opsel_hi set =
+    // source k reads as an f16 HALF (which half chosen by bit k of vop3p_opsel: 0 = low, 1 = high)
+    // converted to f32; clear = full f32. NEG lands in src_neg[], NEG_HI (abs for the mix ops) in
+    // src_abs[], CLAMP in clamp.
+    uint8_t vop3p_opsel = 0, vop3p_opsel_hi = 0;
 };
 
 // Decode the single instruction at code[0..]; `max_dwords` bounds the read. On a truncated/unknown

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3130,8 +3130,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // the offset-adjust folds into the normalized coords, see image_sample_lz_offset_2d).
             const bool is_sample_lz_o = (in.opcode == 0x37);
             const bool dim2d = (in.mimg_dim == 1u), dim3d = (in.mimg_dim == 2u);
+            const bool dimcube = (in.mimg_dim == 3u);
             if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b && !is_gather_lz &&
-                 !is_gather_lz_o && !is_sample_lz_o) || (!dim2d && !dim3d)) { ok = false; return true; }
+                 !is_gather_lz_o && !is_sample_lz_o) || (!dim2d && !dim3d && !dimcube)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
             // coords (normalized float for sample, integer texel for load). Non-NSA: consecutive from VADDR.
             // NSA (len>2): coord0 = VADDR, coord k>=1 = byte (k-1) of the extra address dwords words[2..3].
@@ -3140,7 +3141,29 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             auto cvg = [&](uint32_t k) -> int { if (!nsa || k == 0) return va + (nsa ? 0 : (int)k);
                 uint32_t j = k - 1; return (int)((in.words[2 + j / 4] >> (8 * (j % 4))) & 0xFFu); };
             uint32_t out[4];
-            if (dim3d) {
+            if (dimcube) {
+                // CUBE sample (#273 — DOLL's title post PSes sample their reflection probes /
+                // skybox with `image_sample_l ..., dim:CUBE`). The compiled coords are the standard
+                // AMD cube-processed form (Mesa ac_prepare_cube_coords): vaddr = { sc*rcp(|ma|)+1.5,
+                // tc*rcp(|ma|)+1.5, face_id [, lod] } — face coords centered at 1.5 (span [1,2]),
+                // face id an integral float from v_cubeid. Our texture backend uploads the cube as
+                // SIX FACES STACKED VERTICALLY in one 2D image (w x 6h — see the live_renderer cube
+                // path), so the sample lowers to a plain 2D sample at u = x-1, v = (face + clamp
+                // (y-1)) / 6 at base LOD (mips aren't uploaded; a >0 LOD clamps to the one level).
+                // The in-face clamp stops bilinear bleed across face seams. CONFIDENCE: MED — the
+                // coordinate convention is Mesa-verified; face memory layout is validated visually.
+                if (!is_sample && !is_sample_l && !is_sample_lz && !is_sample_b) { ok = false; return true; }
+                const uint32_t ci = is_sample_b ? 1u : 0u;              // _b: bias occupies vaddr0
+                uint32_t x = vread(cvg(ci)), y = vread(cvg(ci + 1)), fid = vread(cvg(ci + 2));
+                const uint32_t one = b.uconst(fbits(1.0f)), zero = b.uconst(fbits(0.0f));
+                uint32_t uf = b.fbin(Op_FSub, x, one);
+                uint32_t vf = b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, b.fbin(Op_FSub, y, one), one), zero);
+                uint32_t layer = b.fext1(Glsl_RoundEven,
+                                     b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, fid, b.uconst(fbits(5.0f))), zero));
+                uint32_t v6 = b.fbin(Op_FMul, b.fbin(Op_FAdd, layer, vf), b.uconst(fbits(1.0f / 6.0f)));
+                b.declare_texture(res->binding, Dim_2D);
+                b.image_sample_lod_2d(res->binding, uf, v6, b.uconst(0), out);
+            } else if (dim3d) {
                 // 3D: implicit-LOD / LOD-0 sample, or an integer texel FETCH (image_load — DOLL's
                 // color-grade 3D LUT, #273).
                 if (!is_sample && !is_sample_lz && !is_load) { ok = false; return true; }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2,6 +2,7 @@
 #include "rdna2_to_spirv.hpp"
 #include "rdna2_decode.hpp"
 #include "shader_resources.hpp"
+#include <algorithm>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
@@ -953,6 +954,12 @@ struct RegState {
     // detect_pcrel_tables (an s_getpc_b64-derived V# whose num_records is a known constant). The
     // shader BLOB carries the table; the recompiler folds it into a compile-time constant lookup.
     std::unordered_map<uint32_t, std::vector<uint32_t>> mubuf_pcrel_tables;
+    // SCALAR-SPILL VGPR (#273 — DOLL's big post PS): the compiler packs excess wave-uniform scalars
+    // into one VGPR's lanes via `v_writelane_b32 vN, sX, <const lane>` and reads them back with
+    // `v_readlane_b32 sY, vN, <const lane>`. Per-invocation each (vgpr, lane) slot is just a named
+    // scalar: vgpr -> lane -> SSA id. A vgpr used as a spill array must never be read as ordinary
+    // per-lane data — operand_bits rejects that (fail-visible), keeping the model honest.
+    std::unordered_map<int, std::unordered_map<int, uint32_t>> vgpr_lane_slots;
 };
 
 // Predicate a just-computed VGPR write against EXEC: under a narrowed mask, inactive lanes keep their
@@ -1275,6 +1282,125 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
     return L;
 }
 
+// DIVERGENT EXECZ-EXIT LOOPS (#273 — DOLL's post-process accumulation PSes, the title-composite
+// content producers). The compiled shape:
+//     header: <exec recompute: v_cmpx_.. counter,bound  |  v_cmp..;s_andn2_b64 exec,exec,vcc>
+//             s_cbranch_execz EXIT                      ; leave when no lane remains
+//     body:   ... (nested forward-execz if regions, saveexec/restore, scalar counter++) ...
+//             s_branch header                           ; backward unconditional back-edge
+//     EXIT:   s_mov_b64 exec, <saved>
+// Per-invocation semantics: THIS lane iterates while its EXEC bit (rs.exec, a bool) holds after the
+// header recompute — the canonical `while (cond) body` divergent loop. Hardware keeps the whole wave
+// looping until EVERY lane's bit clears, but a cleared lane's vector writes are masked from then on,
+// so exiting the lane immediately at its own EXECZ is value-identical for everything it can observe
+// EXCEPT scalar state advanced by the extra wave iterations (a loop counter read after the loop
+// would show the wave's MAX trip count, not this lane's) — compiled code consumes such counters
+// inside the loop, so this is the standard per-invocation approximation. CONFIDENCE: MED, gated by
+// spirv-val + execution kernels + the live-boot A/B.
+//
+// A second flavor (DOLL's scalar-indexed unroll): the back-edge is a backward s_cbranch_EXECNZ and
+// the header IS the execz exit (empty condition region); the body may carry an extra forward
+// vccz/execz BREAK to the exit. A break lowers as a plain forward IF over the remainder of the body
+// (skip-to-backedge): the broken lane's EXEC bit is already clear (the compiled break condition
+// mirrors the exec recompute), so the next header check exits it — we REQUIRE the execnz back-edge
+// (exec-governed continue) for any loop carrying breaks, which makes that reasoning structural.
+struct DivLoop {
+    uint32_t header_pc = 0;        // back-edge target; condition region = [header_pc, exit_branch_pc)
+    uint32_t exit_branch_pc = 0;   // the canonical forward s_cbranch_execz whose target is exit_pc
+    uint32_t backedge_pc = 0;      // backward s_branch (unconditional) or s_cbranch_execnz
+    uint32_t exit_pc = 0;          // backedge_pc + its length (first pc after the loop)
+    std::vector<uint32_t> break_pcs;   // extra forward vccz/execz -> exit_pc (lowered as body ifs)
+};
+
+// Returns the loops in header-pc order, or {} when any backward branch doesn't fit the shape (the
+// caller then rejects the stream loudly, exactly as before this feature). `safe` carries the
+// linearized branches (waterfalls etc.) which are not loop back-edges.
+std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
+                                            const std::unordered_set<uint32_t>& safe) {
+    std::vector<DivLoop> out;
+    uint32_t end_pc = UINT32_MAX;
+    for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
+    // Pass 1: each backward s_branch / s_cbranch_execnz is a candidate back-edge.
+    std::vector<bool> backedge_execnz;
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::SOPP) continue;
+        if ((in.opcode != 0x02 && in.opcode != 0x09) || in.simm16 >= 0) continue;
+        if (safe.count(in.pc)) continue;
+        DivLoop L;
+        L.header_pc = branch_target(in);
+        L.backedge_pc = in.pc;
+        L.exit_pc = in.pc + in.len_dwords;
+        if (L.header_pc >= L.backedge_pc || L.exit_pc > end_pc) return {};
+        bool hdr_ok = false;
+        for (const auto& h : ins) { if (h.pc == L.header_pc) { hdr_ok = true; break; } if (h.pc > L.header_pc) break; }
+        if (!hdr_ok) return {};
+        out.push_back(L);
+        backedge_execnz.push_back(in.opcode == 0x09);
+    }
+    if (out.empty()) return out;
+    // Loops must be strictly DISJOINT and in order (nested loops are not modeled). Backward branches
+    // appear in pc order, so headers must too — and each loop must end before the next begins.
+    for (size_t i = 1; i < out.size(); i++)
+        if (out[i].header_pc < out[i - 1].exit_pc) return {};
+    // Pass 2: validate each loop's interior branches and find the canonical exit + breaks.
+    for (size_t li = 0; li < out.size(); li++) {
+        DivLoop& L = out[li];
+        const bool execnz = backedge_execnz[li];
+        for (const auto& in : ins) {
+            if (in.is_end || in.pc >= L.backedge_pc) break;
+            if (in.pc < L.header_pc || in.fmt != Rdna2Format::SOPP) continue;
+            switch (in.opcode) {
+                case 0x02: case 0x04: case 0x05: case 0x06: case 0x07: case 0x08: case 0x09: break;
+                default: continue;   // hints
+            }
+            if (in.simm16 < 0) return {};                       // second back-edge inside -> nested loop
+            if (safe.count(in.pc)) continue;                    // linearized (kill-mask / safe-execz)
+            uint32_t tgt = branch_target(in);
+            if (in.opcode == 0x02) {                            // forward s_branch: an else-arm terminator
+                if (tgt > L.backedge_pc) return {};             // may not leave the body
+                continue;                                       // (validated by detect_forward_ifs)
+            }
+            if (tgt > L.exit_pc) return {};                     // conditional jumping past the loop
+            if (tgt == L.exit_pc) {                             // an exit test
+                if (!L.exit_branch_pc) {                        // first one = the canonical exit
+                    if (in.opcode != 0x08) return {};           // must be execz -> EXIT
+                    L.exit_branch_pc = in.pc;
+                } else {                                        // later ones = breaks
+                    if (in.opcode != 0x06 && in.opcode != 0x08) return {};  // vccz/execz only
+                    if (!execnz) return {};                     // breaks need the exec-governed back-edge
+                    L.break_pcs.push_back(in.pc);
+                }
+            }
+            // (tgt <= backedge_pc: an interior forward if — validated by detect_forward_ifs.)
+        }
+        if (!L.exit_branch_pc) return {};                       // no exit test: not this shape
+        // The canonical exit must be the FIRST branch in the loop, so the condition region
+        // [header, exit_branch) is branch-free (it is emitted straight-line).
+        for (const auto& in : ins) {
+            if (in.pc >= L.exit_branch_pc) break;
+            if (in.pc < L.header_pc || in.fmt != Rdna2Format::SOPP) continue;
+            if (in.opcode >= 0x02 && in.opcode <= 0x09 && in.opcode != 0x03 && !safe.count(in.pc)) return {};
+        }
+        // The execnz flavor's unconditional-continue lowering requires the header check to
+        // immediately re-test EXEC (empty condition region) — see the shape comment.
+        if (execnz && L.exit_branch_pc != L.header_pc) return {};
+    }
+    // Pass 3: no branch from OUTSIDE a loop may target its interior (an unstructured entry edge).
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::SOPP) continue;
+        if (in.opcode < 0x02 || in.opcode > 0x09 || in.opcode == 0x03) continue;
+        uint32_t tgt = branch_target(in);
+        for (const auto& L : out) {
+            const bool inside_br = in.pc >= L.header_pc && in.pc <= L.backedge_pc;
+            const bool inside_tgt = tgt > L.header_pc && tgt < L.exit_pc;
+            if (!inside_br && inside_tgt) return {};
+        }
+    }
+    return out;
+}
+
 // A single structured uniform IF: exactly ONE control-flow branch in the whole stream, and it is a
 // FORWARD s_cbranch_scc0/scc1 (a scalar-uniform conditional — all lanes take the same path). The
 // conditional block is [branch_pc+1, target_pc). Anything more (any s_branch/vcc/execz/execnz branch,
@@ -1369,33 +1495,61 @@ ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
 // CONFIDENCE: HIGH on the structure (guarded by the phi machinery shared with the single-if path).
 std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
                                           const uint32_t* code, size_t dwords,
-                                          const std::unordered_set<uint32_t>* skip = nullptr) {
+                                          const std::unordered_set<uint32_t>* skip = nullptr,
+                                          const std::vector<DivLoop>* loops = nullptr,
+                                          bool* rejected = nullptr) {
     std::vector<ForwardIf> out;
+    if (rejected) *rejected = false;
+    auto reject = [&]() -> std::vector<ForwardIf> { if (rejected) *rejected = true; return {}; };
     uint32_t end_pc = UINT32_MAX;
     for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
+    // Loop-claimed pcs (#273): back-edges + canonical exits are consumed by the loop emitter; a break
+    // lowers as a forward if over the remainder of its loop's body (target clamped to the back-edge).
+    auto loop_backedge = [&](uint32_t pc) { if (loops) for (const auto& L : *loops) if (L.backedge_pc == pc) return true; return false; };
+    auto loop_exit     = [&](uint32_t pc) { if (loops) for (const auto& L : *loops) if (L.exit_branch_pc == pc) return true; return false; };
+    auto loop_break    = [&](uint32_t pc) -> const DivLoop* {
+        if (loops) for (const auto& L : *loops)
+            for (uint32_t bp : L.break_pcs) if (bp == pc) return &L;
+        return nullptr;
+    };
     // Pass 1: collect the conditional branches (else-arm s_branch terminators are claimed in pass 2).
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt != Rdna2Format::SOPP) continue;
         switch (in.opcode) {
             case 0x02: continue;                                     // s_branch: validated in pass 2
-            case 0x09: return {};                                    // execnz -> reject
+            case 0x09:                                               // execnz: only as a loop back-edge
+                if (loop_backedge(in.pc)) continue;
+                return reject();
             case 0x08:                                               // execz: safe-linearized predication
                 if (skip && skip->count(in.pc)) continue;            // branch -> emit_alu no-ops it; else a
-                if (!allow_vcc) return {};                           // DIVERGENT-REGION if (per-invocation
-                break;                                               // stages only — compute has wave VCC/EXEC)
+                if (loop_exit(in.pc)) continue;                      // loop exit test: the loop emitter's
+                if (!allow_vcc) return reject();                     // OpBranchConditional consumes it
+                break;                                               // DIVERGENT-REGION if (per-invocation
+                                                                     // stages only — compute has wave VCC/EXEC)
             case 0x06: case 0x07:                                    // vccz / vccnz
-                if (!allow_vcc) return {};
+                if (!allow_vcc) return reject();
                 break;
             case 0x04: case 0x05:                                    // scc0 / scc1
                 if (skip && skip->count(in.pc)) continue;            // kill-mask branch: linearized, not an if
                 break;
             default: continue;                                       // hints
         }
+        // A loop BREAK (validated vccz/execz -> exit_pc inside an execnz-back-edge loop): a plain
+        // forward if skipping the REST of the body — the exec-governed continue then exits the lane.
+        if (const DivLoop* L = loop_break(in.pc)) {
+            ForwardIf F;
+            F.found = true; F.branch_pc = in.pc; F.target_pc = L->backedge_pc;
+            F.on_scc0 = true;                                        // vccz/execz: skip block when flag==0
+            F.on_vcc  = (in.opcode == 0x06);
+            F.on_exec = (in.opcode == 0x08);
+            out.push_back(F);
+            continue;
+        }
         uint32_t tgt = branch_target(in);
         bool early = false;
         if (tgt > end_pc && tgt != UINT32_MAX) {                     // possible early-out past s_endpgm:
-            if (!code || tgt >= dwords) return {};                   // verify the target terminates (see
+            if (!code || tgt >= dwords) return reject();             // verify the target terminates (see
             std::vector<Rdna2Inst> tail;                             // detect_forward_if for the rationale)
             rdna2_walk(code + tgt, dwords - tgt, tail);
             bool ends_immediately = false;
@@ -1404,10 +1558,10 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 if (ti.fmt == Rdna2Format::SOPP && ti.opcode == 0x00) continue;
                 break;
             }
-            if (!ends_immediately) return {};
+            if (!ends_immediately) return reject();
             tgt = end_pc; early = true;
         }
-        if (tgt <= in.pc || tgt > end_pc) return {};                 // must be forward, within the stream
+        if (tgt <= in.pc || tgt > end_pc) return reject();           // must be forward, within the stream
         ForwardIf F;
         F.found = true; F.branch_pc = in.pc; F.target_pc = tgt; F.early_out = (early || tgt == end_pc);
         F.on_scc0 = (in.opcode == 0x04 || in.opcode == 0x06 || in.opcode == 0x08);
@@ -1421,39 +1575,52 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 if (sb.pc <= in.pc || sb.pc >= tgt) continue;
                 if (sb.fmt != Rdna2Format::SOPP || sb.opcode != 0x02) continue;
                 if (sb.pc + sb.len_dwords != tgt) continue;          // must be the arm's LAST instruction
-                if (sb.simm16 <= 0) return {};                       // backward else-jump: a loop, not an if
+                if (loop_backedge(sb.pc)) continue;                  // a loop's back-edge, not an else-jump
+                if (sb.simm16 <= 0) return reject();                 // backward else-jump: a loop, not an if
                 uint32_t lm = branch_target(sb);
-                if (lm <= tgt || lm > end_pc) return {};             // merge must be forward, in-stream
+                if (lm <= tgt || lm > end_pc) return reject();       // merge must be forward, in-stream
                 F.has_else = true; F.sb_pc = sb.pc; F.merge_pc = lm;
                 break;
             }
         }
         out.push_back(F);
     }
-    // Pass 2: every s_branch in the stream must be a claimed else-arm terminator — any other
-    // unconditional branch is control flow this structurizer doesn't model.
+    // Pass 2: every s_branch in the stream must be a claimed else-arm terminator or a loop back-edge —
+    // any other unconditional branch is control flow this structurizer doesn't model.
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt != Rdna2Format::SOPP || in.opcode != 0x02) continue;
+        if (loop_backedge(in.pc)) continue;
         bool claimed = false;
         for (const auto& F : out) if (F.has_else && F.sb_pc == in.pc) { claimed = true; break; }
-        if (!claimed) return {};
+        if (!claimed) return reject();
     }
     // Structural nesting check (branches are already in pc order): each region must lie entirely
     // inside the innermost still-open region, or start after it closed. A region spans to its merge
-    // (if/else) or target (plain if). EXCEPTION (the shared-outer-merge cascade): an if/else whose
-    // merge_pc escapes the innermost open region is accepted here and re-validated during emission
-    // (emit_structured requires the escaping merge to equal the enclosing merge chain's continuation,
-    // i.e. no instructions are skipped) — a violation rejects the shader there, fail-visible.
+    // (if/else) or target (plain if); a LOOP is an opaque region [header_pc, exit_pc) that must nest
+    // strictly. EXCEPTION (the shared-outer-merge cascade): an if/else whose merge_pc escapes the
+    // innermost open region is accepted here and re-validated during emission (emit_structured
+    // requires the escaping merge to equal the enclosing merge chain's continuation, i.e. no
+    // instructions are skipped) — a violation rejects the shader there, fail-visible.
     std::vector<uint32_t> open;
-    for (const auto& F : out) {
-        uint32_t span_end = F.has_else ? F.merge_pc : F.target_pc;
-        while (!open.empty() && open.back() <= F.branch_pc) open.pop_back();
-        if (!open.empty() && span_end > open.back()) {
-            if (!F.has_else) return {};                  // plain if escaping its region: not a tree
-            span_end = open.back();                      // cascade if/else: clamped to the enclosing
-        }                                                // region for nesting purposes (see above)
-        open.push_back(span_end);
+    {
+        size_t fi = 0, li = 0;
+        const size_t nl = loops ? loops->size() : 0;
+        while (fi < out.size() || li < nl) {
+            const bool take_loop = li < nl &&
+                (fi >= out.size() || (*loops)[li].header_pc < out[fi].branch_pc);
+            const uint32_t start = take_loop ? (*loops)[li].header_pc : out[fi].branch_pc;
+            uint32_t span_end    = take_loop ? (*loops)[li].exit_pc
+                                 : (out[fi].has_else ? out[fi].merge_pc : out[fi].target_pc);
+            const bool clampable = !take_loop && out[fi].has_else;
+            while (!open.empty() && open.back() <= start) open.pop_back();
+            if (!open.empty() && span_end > open.back()) {
+                if (!clampable) return reject();         // plain if / loop escaping its region: not a tree
+                span_end = open.back();                  // cascade if/else: clamped to the enclosing
+            }                                            // region for nesting purposes (see above)
+            open.push_back(span_end);
+            if (take_loop) li++; else fi++;
+        }
     }
     return out;
 }
@@ -1470,8 +1637,11 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
             case Rdna2Format::VOP1:
                 if (in.opcode == 0x02) sregs.insert(in.dst.value);        // v_readfirstlane -> SGPR
                 else vregs.insert(in.dst.value); break;
-            case Rdna2Format::VOP2: case Rdna2Format::VOP3: case Rdna2Format::VOP3P:
+            case Rdna2Format::VOP2: case Rdna2Format::VOP3P:
                 vregs.insert(in.dst.value); break;
+            case Rdna2Format::VOP3:
+                if (in.opcode == 0x360) sregs.insert(in.dst.value);       // v_readlane -> SGPR
+                else vregs.insert(in.dst.value); break;                   // (writelane: slots, not SSA)
             case Rdna2Format::DS:                                          // ds_read writes one VGPR
                 if (in.opcode == 0x36) vregs.insert(in.dst.value); break;
             case Rdna2Format::MUBUF: {                                     // load_format/load: N consecutive VGPRs
@@ -1503,7 +1673,10 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
 // garbage (#134); now it rejects, matching the SDWA/DPP reject-rather-than-miscompute discipline.
 uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const Operand& o, bool* ok = nullptr) {
     switch (o.kind) {
-        case OperandKind::VGPR: { auto it = rs.vreg.find(o.value); return it == rs.vreg.end() ? b.uconst(0) : it->second; }
+        case OperandKind::VGPR: {
+            // A scalar-spill vgpr (v_writelane slots) has no per-lane data value — reject, don't read 0.
+            if (rs.vgpr_lane_slots.count(o.value)) { if (ok) *ok = false; return b.uconst(0); }
+            auto it = rs.vreg.find(o.value); return it == rs.vreg.end() ? b.uconst(0) : it->second; }
         case OperandKind::SGPR: { auto it = rs.sreg.find(o.value); return it == rs.sreg.end() ? b.uconst(0) : it->second; }
         case OperandKind::InlineInt:   return b.uconst((uint32_t)o.value);
         case OperandKind::InlineFloat: return b.uconst(fbits(inline_float_value((uint32_t)o.value)));
@@ -1597,7 +1770,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     } else {                                // s_mov_b64 sDST, <mask-or-data> : save a mask / copy a pair
                         uint32_t m = src_mask(in.src[0]);
                         if (m) { rs.sreg_bool[in.dst.value] = m;
-                                 rs.sreg_bool_narrowed[in.dst.value] = is_exec(in.src[0]) ? rs.exec_narrowed : saved_narrowed(in.src[0]); }
+                                 rs.sreg_bool_narrowed[in.dst.value] = is_exec(in.src[0]) ? rs.exec_narrowed : saved_narrowed(in.src[0]);
+                                 // A move INTO VCC is a VCC write (DOLL's scalar-indexed unroll does
+                                 // `s_mov_b64 vcc, s[4:5]` before its vccz break, #273): the branch reads
+                                 // rs.vcc, so it must be updated too — sreg_bool[106] alone left the
+                                 // branch on a stale VCC. (The SOP2 mask ops already special-case 106.)
+                                 if (in.dst.value == 106) rs.vcc = m; }
                         // s_mov_b64 ALSO moves a plain 64-bit VALUE (a descriptor pair, a scratch pair,
                         // an inline constant) — compilers use it to shuffle T#/V# halves and constants,
                         // not just wave masks. Copy the data SSA + descriptor provenance (sreg_srt) for
@@ -2128,6 +2306,31 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::VOP3: {
+            // SCALAR-SPILL lane slots (#273): v_writelane_b32 (0x361) / v_readlane_b32 (0x360) with a
+            // COMPILE-TIME lane index — the pack-scalars-into-a-VGPR's-lanes idiom (DOLL's big post PS
+            // spills 19 s_buffer_load results into v36 and reads them back). Per-invocation each
+            // (vgpr, lane) is a named wave-uniform scalar; a dynamic lane index (a real cross-lane
+            // read) still rejects. Neither op is EXEC-predicated on hardware, so no predicate_write.
+            // VERIFIED(round-trip llvm-mc gfx1030: 0xd761 v_writelane_b32 / 0xd760 v_readlane_b32).
+            if (in.opcode == 0x361) {                                 // v_writelane_b32 vDST, sSRC, lane
+                if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
+                    ok = false; return true;
+                }
+                rs.vgpr_lane_slots[in.dst.value][in.src[1].value] = val(in.src[0]);
+                return true;
+            }
+            if (in.opcode == 0x360) {                                 // v_readlane_b32 sDST, vSRC, lane
+                if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
+                    ok = false; return true;
+                }
+                auto vit = rs.vgpr_lane_slots.find(in.src[0].value);
+                if (vit == rs.vgpr_lane_slots.end()) { ok = false; return true; }   // not a spill array
+                auto sit = vit->second.find(in.src[1].value);
+                if (sit == vit->second.end()) { ok = false; return true; }          // slot never written
+                rs.sreg[in.dst.value] = sit->second;   // dst field is the SGPR number (like readfirstlane)
+                rs.sreg_srt.erase(in.dst.value);
+                return true;
+            }
             uint32_t old_d = vreg_old(b, rs, in.dst.value);
             // Float source with its VOP3 modifiers applied: OpFAbs then OpFNegate (hardware order neg(abs(x))).
             // Returns raw bits (fbin/fext re-bitcast), so it's a drop-in for val() in the FLOAT ops only —
@@ -2507,7 +2710,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
                         if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
                 }
-                if (!res) { ok = false; return true; }
+                if (!res) {
+                    if (getenv("PROSPER_DBG")) {   // which provenance step failed for this format load
+                        auto it = rs.sreg_srt.find(in.src[1].value);
+                        fprintf(stderr, "[mubuf-unresolved] pc=%u srsrc=s%d srt_tag=%s0x%x key_res=%s (%zu res)\n",
+                                in.pc, in.src[1].value, it != rs.sreg_srt.end() ? "" : "NONE ",
+                                it != rs.sreg_srt.end() ? it->second : 0u,
+                                it != rs.sreg_srt.end() && rt->by_srt_offset(it->second) ? "yes" : "null",
+                                rt->resources.size());
+                    }
+                    ok = false; return true;
+                }
                 binding = res->binding;
                 stride = res->stride;
                 fmt = res->format;
@@ -2554,7 +2767,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case DataFormat::Snorm16: norm = 32767.0f; break;
                 default: break;
             }
-            if (packed && !is_half && !is_uint && !is_sint && norm == 0.0f) { ok = false; return true; }
+            if (packed && !is_half && !is_uint && !is_sint && norm == 0.0f) {
+                if (getenv("PROSPER_DBG"))
+                    fprintf(stderr, "[mubuf-badfmt] pc=%u fmt=%u comp_bytes=%u stride=%u n=%u\n",
+                            in.pc, (unsigned)fmt, comp_bytes, stride, n);
+                ok = false; return true;
+            }
             // Packed (sub-dword) components are extracted at STATIC byte offsets relative to a
             // DWORD-ALIGNED element base — the low 2 bits of the address (addr&3) are dropped by the
             // addr>>2 dword index and never folded into the bit extraction (#150). That is only correct
@@ -2581,7 +2799,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     base_aligned = ((offset & 3u) == 0) && !offen &&
                                    (!idxen || (stride & 3u) == 0) && soff_zero;
                 }
-                if (!base_aligned) { ok = false; return true; }
+                if (!base_aligned) {
+                    if (getenv("PROSPER_DBG"))
+                        fprintf(stderr, "[mubuf-unaligned] pc=%u fmt=%u off=%u offen=%d idxen=%d stride=%u\n",
+                                in.pc, (unsigned)fmt, offset, (int)offen, (int)idxen, stride);
+                    ok = false; return true;
+                }
             }
             // Byte address of the element (#148): idxen -> a VADDR VGPR is an element index (×stride);
             // offen -> a per-lane byte offset; both terms ADD; when idxen AND offen are set VADDR is TWO
@@ -2677,6 +2900,29 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             { auto it = rs.sreg_srt.find(in.src[1].value);
               if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
               if (!res) res = rt->by_sgpr_base(in.src[1].value); }
+            // PER-USE pc provenance fallback (#273 — DOLL's title-composite image_sample_b): the
+            // executor's const-fold walk snapshots the T# each image op consumes and keys it by the
+            // INSTRUCTION pc (ShaderResource::fetch_pc). Used when the key/SGPR chains found nothing,
+            // or found a NON-image resource — the load-immediate key model collides when two different
+            // tables reuse one immediate (a key-0 EUD sharp vs the key-0 table T# here).
+            if (!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage)) {
+                if (const ShaderResource* pr = rt->by_fetch_pc(in.pc);
+                    pr && (pr->cls == ResourceClass::Texture || pr->cls == ResourceClass::StorageImage))
+                    res = pr;
+            }
+            if ((!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage))
+                && getenv("PROSPER_DBG")) {
+                // Resolution-failure diagnostic: which provenance step failed for this image op.
+                auto it = rs.sreg_srt.find(in.src[1].value);
+                const ShaderResource* pk = it != rs.sreg_srt.end() ? rt->by_srt_offset(it->second) : nullptr;
+                const ShaderResource* pp = rt->by_fetch_pc(in.pc);
+                fprintf(stderr, "[mimg-unresolved] pc=%u srsrc=s%d srt_tag=%s0x%x key_res=%s pc_res=%s (%zu res)\n",
+                        in.pc, in.src[1].value, it != rs.sreg_srt.end() ? "" : "NONE ",
+                        it != rs.sreg_srt.end() ? it->second : 0u,
+                        pk ? (pk->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
+                        pp ? (pp->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
+                        rt->resources.size());
+            }
             if (!res) { ok = false; return true; }
 
             // --- Storage-image path: image_load (0x00) / image_store (0x08), no sampler, any dim ---
@@ -3065,7 +3311,24 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         }
         // 7. Post-loop body.
         if (!emit_range(L.exit_pc, UINT32_MAX)) return false;
-    } else if (const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe); !Fs.empty()) {
+    } else if (std::vector<DivLoop> Ls; true) {
+        // DIVERGENT execz-exit loops (#273) + structured uniform/divergent IFs. Loops are detected
+        // for the per-invocation stages only (fragment/vertex — the compute shell keeps its
+        // wave-level VCC/EXEC contract); each is emitted as a real structured SPIR-V loop
+        // (OpLoopMerge + header OpPhi per carried register/mask) whose per-lane condition is THIS
+        // lane's EXEC bool after the header's exec recompute. The IF machinery is unchanged and
+        // recurses INTO loop bodies (their nested forward-execz regions).
+        if (!b.is_compute) Ls = detect_divergent_loops(ins, safe);
+        bool cf_rejected = false;
+        const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe,
+                                                             Ls.empty() ? nullptr : &Ls, &cf_rejected);
+        if (cf_rejected) Ls.clear();   // unmodeled CF somewhere: fall through to straight-line (loud reject)
+        if (Fs.empty() && Ls.empty()) {
+            wave_ok = true;   // straight-line: barriers are wave-uniform, so cross-lane mbcnt is safe here
+            if (!emit_range(0, UINT32_MAX)) return false;   // loop-free: straight-line, unchanged behavior
+            (void)safe_branches;
+            return true;
+        }
         // Structured uniform IFs (forward s_cbranch_scc*/vcc*), possibly SEQUENTIAL and/or NESTED
         // (detect_forward_ifs verified the region tree). Each if emits as OpSelectionMerge +
         // OpBranchConditional on the SCC/VCC bool, with an OpPhi per register written in the
@@ -3077,6 +3340,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         auto vget = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
         auto sget = [&](int r){ auto it = rs.sreg.find(r); return it == rs.sreg.end() ? b.uconst(0) : it->second; };
         size_t bi = 0;   // next unconsumed branch in Fs (pc order; recursion consumes nested ones)
+        size_t li = 0;   // next unconsumed loop in Ls (pc order)
         // `cont` = the pc control flows to after `hi` — the enclosing construct's merge chain. An
         // if/else whose merge ESCAPES the current region (the shared-outer-merge cascade) is legal
         // only when it targets exactly this continuation (no skipped instructions); anything else
@@ -3084,10 +3348,100 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // may enter/leave with EXEC narrowed — EXEC is phi'd across the merge like any other value.
         // CONFIDENCE: MED — per-invocation lowering of wave-level branches; spirv-val + exec-diff
         // kernels + the live-boot A/B gate it.
-        std::function<bool(uint32_t, uint32_t, uint32_t)> emit_structured =
+        std::function<bool(uint32_t, uint32_t, uint32_t)> emit_structured;
+        // Emit one DIVERGENT execz-exit loop (#273) as a structured SPIR-V loop. Same block shape as
+        // the counted-loop path (hdr -> chk -> body -> cont -> hdr, exit chk->merge) with three
+        // differences: (1) the loop condition is THIS lane's EXEC bool after the header's exec
+        // recompute (v_cmpx / s_andn2 exec) — continue while set, exit at execz; (2) the body is
+        // emitted RECURSIVELY (nested forward-execz if regions live inside it); (3) per-lane MASKS
+        // (VCC/EXEC/saved sreg_bool pairs) are loop-carried too, so each gets a header phi. At the
+        // merge, a register written in the condition region keeps its exit-iteration (chk) value —
+        // it dominates the merge — while body-written state takes the header phi (its value when the
+        // exiting check ran); masks CREATED inside the loop are dropped at the merge (an SSA id from
+        // inside the body does not dominate it — a later read then rejects loudly instead of
+        // emitting invalid SPIR-V). CONFIDENCE: MED (per-invocation lowering of a wave-level loop;
+        // spirv-val + execution kernels + the live-boot A/B gate it).
+        std::function<bool(const DivLoop&)> emit_divloop = [&](const DivLoop& L) -> bool {
+            std::set<int> cv, cs, condv, conds;
+            loop_written_regs(ins, L.header_pc, L.backedge_pc, cv, cs);
+            loop_written_regs(ins, L.header_pc, L.exit_branch_pc, condv, conds);
+            const uint32_t preheader = b.cur_block;
+            const uint32_t hdr = b.id(), chk = b.id(), body = b.id(), cont = b.id(), merge = b.id();
+            b.emit_branch(hdr); b.emit_label(hdr);
+            struct PhiRec { int reg; int dom; uint32_t phi; size_t patch; };  // dom: 0=vreg,1=sreg,2=scc,3=vcc,4=exec,5=mask
+            std::vector<PhiRec> phis;
+            for (int r : cv) { size_t p; uint32_t ph = b.emit_phi2(b.t_u32, vget(r), preheader, p); rs.vreg[r] = ph; phis.push_back({r, 0, ph, p}); }
+            for (int r : cs) { size_t p; uint32_t ph = b.emit_phi2(b.t_u32, sget(r), preheader, p); rs.sreg[r] = ph; phis.push_back({r, 1, ph, p}); }
+            { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc, preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
+            { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+            { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.exec, preheader, p); rs.exec = ph; phis.push_back({0, 4, ph, p}); }
+            std::vector<int> mask_keys;                        // saved masks live at entry: loop-carried bools
+            for (auto& kv : rs.sreg_bool) mask_keys.push_back(kv.first);
+            std::sort(mask_keys.begin(), mask_keys.end());     // deterministic emission order
+            for (int k : mask_keys) { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.sreg_bool[k], preheader, p); rs.sreg_bool[k] = ph; phis.push_back({k, 5, ph, p}); }
+            b.emit_loopmerge(merge, cont); b.emit_branch(chk); b.emit_label(chk);
+            // Inside the loop EXEC is the per-lane loop condition — vector writes must predicate.
+            rs.exec_narrowed = true;
+            // Condition region [header, exit_branch): branch-free (validated), straight-line.
+            if (!emit_range(L.header_pc, L.exit_branch_pc)) return false;
+            // chk-end snapshots: the exit path flows THROUGH this block, so these dominate the merge.
+            std::unordered_map<int, uint32_t> condv_val, conds_val;
+            for (int r : condv) condv_val[r] = vget(r);
+            for (int r : conds) conds_val[r] = sget(r);
+            const uint32_t exec_chk = rs.exec, vcc_chk = rs.vcc, scc_chk = rs.scc;
+            const std::unordered_map<int, uint32_t> bool_chk = rs.sreg_bool;
+            b.emit_condbranch(rs.exec, body, merge);           // execz exit: continue while EXEC bit set
+            while (idx < ins.size() && ins[idx].pc < L.exit_branch_pc) ++idx;
+            if (idx < ins.size() && ins[idx].pc == L.exit_branch_pc) ++idx;   // consume the exit branch
+            b.emit_label(body);
+            // Body (recursive: nested if regions + breaks); ends just before the back-edge.
+            if (!emit_structured(L.exit_branch_pc + 1, L.backedge_pc, L.backedge_pc)) return false;
+            if (idx < ins.size() && ins[idx].pc == L.backedge_pc) ++idx;      // consume the back-edge
+            b.emit_branch(cont); b.emit_label(cont);
+            for (auto& pr : phis) {
+                uint32_t nv = pr.dom == 0 ? vget(pr.reg)
+                            : pr.dom == 1 ? sget(pr.reg)
+                            : pr.dom == 2 ? rs.scc
+                            : pr.dom == 3 ? rs.vcc
+                            : pr.dom == 4 ? rs.exec
+                            : (rs.sreg_bool.count(pr.reg) ? rs.sreg_bool[pr.reg] : pr.phi);
+                b.patch_phi(pr.patch, nv, cont);
+            }
+            b.emit_branch(hdr);
+            b.emit_label(merge);
+            for (auto& pr : phis) {
+                if (pr.dom == 0)      rs.vreg[pr.reg] = condv.count(pr.reg) ? condv_val[pr.reg] : pr.phi;
+                else if (pr.dom == 1) rs.sreg[pr.reg] = conds.count(pr.reg) ? conds_val[pr.reg] : pr.phi;
+                else if (pr.dom == 2) rs.scc = scc_chk;    // flags/masks: the chk (exit-iteration) value
+                else if (pr.dom == 3) rs.vcc = vcc_chk;    // dominates the merge and is exact (the phi is
+                else if (pr.dom == 4) rs.exec = exec_chk;  // the pre-recompute value)
+                else { auto itc = bool_chk.find(pr.reg);
+                       rs.sreg_bool[pr.reg] = itc != bool_chk.end() ? itc->second : pr.phi; }
+            }
+            // Masks CREATED inside the loop: their ids do not dominate the merge — drop them.
+            for (auto it = rs.sreg_bool.begin(); it != rs.sreg_bool.end();) {
+                if (!std::binary_search(mask_keys.begin(), mask_keys.end(), it->first)) {
+                    rs.sreg_bool_narrowed.erase(it->first);
+                    it = rs.sreg_bool.erase(it);
+                } else ++it;
+            }
+            // Post-loop, this lane's EXEC bool is the (false) chk value until the compiled restore
+            // (`s_mov_b64 exec, <saved>`) — keep writes predicated.
+            rs.exec_narrowed = true;
+            return true;
+        };
+        emit_structured =
             [&](uint32_t lo, uint32_t hi, uint32_t cont) -> bool {
             for (;;) {
                 const uint32_t next_br = (bi < Fs.size() && Fs[bi].branch_pc < hi) ? Fs[bi].branch_pc : hi;
+                const uint32_t next_lp = (li < Ls.size() && Ls[li].header_pc < hi) ? Ls[li].header_pc : hi;
+                if (next_lp < next_br) {                     // a loop begins before the next if
+                    if (!emit_range(lo, next_lp)) return false;
+                    const DivLoop& L = Ls[li++];
+                    if (!emit_divloop(L)) return false;
+                    lo = L.exit_pc;
+                    continue;
+                }
                 if (!emit_range(lo, next_br)) return false;
                 if (next_br == hi) return true;
                 const ForwardIf F = Fs[bi++];
@@ -3189,9 +3543,6 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             }
         };
         if (!emit_structured(0, UINT32_MAX, UINT32_MAX)) return false;
-    } else {
-        wave_ok = true;   // straight-line: barriers are wave-uniform, so cross-lane mbcnt is safe here
-        if (!emit_range(0, UINT32_MAX)) return false;   // loop-free: straight-line, unchanged behavior
     }
     (void)safe_branches;
     return true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -960,6 +960,12 @@ struct RegState {
     // scalar: vgpr -> lane -> SSA id. A vgpr used as a spill array must never be read as ordinary
     // per-lane data — operand_bits rejects that (fail-visible), keeping the model honest.
     std::unordered_map<int, std::unordered_map<int, uint32_t>> vgpr_lane_slots;
+    // LDS ADDTID per-lane spill slots (#273 — DOLL's title post PSes): `s_movk m0, K;
+    // ds_write_addtid_b32 vN` spills THIS lane's vN to LDS[M0 + offset + tid*4], and the matching
+    // `ds_read_addtid_b32` reloads it. Per-invocation the slot is one value, keyed by the M0 SSA id
+    // + the instruction offset (uconst is interned, so equal constant M0s share one id). A read of a
+    // never-written slot rejects (fail-visible).
+    std::unordered_map<uint64_t, uint32_t> lds_addtid;
 };
 
 // Predicate a just-computed VGPR write against EXEC: under a narrowed mask, inactive lanes keep their
@@ -1643,7 +1649,7 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 if (in.opcode == 0x360) sregs.insert(in.dst.value);       // v_readlane -> SGPR
                 else vregs.insert(in.dst.value); break;                   // (writelane: slots, not SSA)
             case Rdna2Format::DS:                                          // ds_read writes one VGPR
-                if (in.opcode == 0x36) vregs.insert(in.dst.value); break;
+                if (in.opcode == 0x36 || in.opcode == 0xb1) vregs.insert(in.dst.value); break;
             case Rdna2Format::MUBUF: {                                     // load_format/load: N consecutive VGPRs
                 uint32_t n = 1; switch (in.opcode) { case 0x1: case 0x5: case 0xD: n=2; break;
                     case 0x2: case 0x6: case 0xF: n=3; break; case 0x3: case 0x7: case 0xE: n=4; break; }
@@ -1975,7 +1981,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // v_fma_mixlo_f16 v0, 1.0, v0, v5 — the live blur bytes).
             if (in.opcode != 0x20 && in.opcode != 0x21 && in.opcode != 0x22) { ok = false; return true; }
             uint32_t old_d = vreg_old(b, rs, in.dst.value);
-            uint32_t r = b.fbin(Op_FAdd, b.fbin(Op_FMul, val(in.src[0]), val(in.src[1])), val(in.src[2]));
+            // Per-source mix resolve (#273): OPSEL_HI[k] -> f16 half (OPSEL[k]: 0=lo,1=hi) converted
+            // to f32; else full f32. An inline constant is already a full-width value, so the half
+            // select is a no-op for it (hardware reads the f16-converted constant — same value).
+            // NEG_HI = abs, NEG = negate (abs first, hardware order).
+            auto mixv = [&](int k) -> uint32_t {
+                uint32_t v = val(in.src[k]);
+                const bool half = (in.vop3p_opsel_hi >> k) & 1u;
+                if (half && in.src[k].kind != OperandKind::InlineFloat && in.src[k].kind != OperandKind::InlineInt)
+                    v = b.unpack_half(v, (in.vop3p_opsel >> k) & 1u);
+                if (in.src_abs[k]) v = b.fext1(Glsl_FAbs, v);
+                if (in.src_neg[k]) v = b.fbin(Op_FSub, b.uconst(0), v);
+                return v;
+            };
+            uint32_t r = b.fbin(Op_FAdd, b.fbin(Op_FMul, mixv(0), mixv(1)), mixv(2));
+            if (in.clamp) r = b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, r, b.uconst(fbits(1.0f))), b.uconst(fbits(0.0f)));
             uint32_t& d = rs.vreg[in.dst.value];
             if (in.opcode == 0x20) d = r;
             else if (in.opcode == 0x21)
@@ -2069,6 +2089,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 predicate_write(b, rs, in.dst.value, old_d);
                 return true;
             }
+            // BYTE-select v_mov_b32_sdwa (#273 — DOLL's title post PSes unpack a packed dword:
+            // `v_mov_b32_sdwa v6, v15 src0_sel:BYTE_0`): dst is the whole dword (UNUSED_PAD), so the
+            // result is the selected byte zero-extended.
+            if (in.opcode == 0x01 && in.sdwa_dst_sel == 6 && in.sdwa_src0_sel <= 3) {
+                d = b.bfe_u(a, b.uconst(8u * in.sdwa_src0_sel), b.uconst(8));
+                predicate_write(b, rs, in.dst.value, old_d);
+                return true;
+            }
             switch (in.opcode) {
                 case 0x00: return true;                              // v_nop — no-op (writes nothing; common
                                                                      // scheduling/hazard filler in real shaders)
@@ -2077,6 +2105,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x06: d = b.cvt_u2f(a); break;                   // v_cvt_f32_u32
                 case 0x07: d = b.cvt_f2u(a); break;                   // v_cvt_u32_f32
                 case 0x08: d = b.cvt_f2i(a); break;                   // v_cvt_i32_f32
+                // f16<->f32 converts (#273 — DOLL's title post PSes carry f16 intermediates):
+                // v_cvt_f16_f32 packs into the LOW half (high bits zero); v_cvt_f32_f16 unpacks the
+                // low half. VERIFIED(round-trip llvm-mc gfx1030: 0x0a/0x0b).
+                case 0x0A: d = b.pack_half_lo(a); break;              // v_cvt_f16_f32
+                case 0x0B: d = b.unpack_half(a, 0); break;            // v_cvt_f32_f16
                 case 0x20: d = b.fext1(Glsl_Fract, a); break;         // v_fract_f32
                 case 0x21: d = b.fext1(Glsl_Trunc, a); break;         // v_trunc_f32
                 case 0x22: d = b.fext1(Glsl_Ceil, a); break;          // v_ceil_f32
@@ -2125,7 +2158,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // opcodes only (mirrors the VOP2/VOP3 fresult path; DOLL VS: `v_exp_f32_sdwa … clamp`).
             // A modifier on a non-float-result op would silently drop — reject loudly instead.
             if (ok && (in.omod || in.clamp)) switch (in.opcode) {
-                case 0x05: case 0x06: case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
+                case 0x05: case 0x06: case 0x0B: case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
                 case 0x25: case 0x27: case 0x2A: case 0x2B: case 0x2E: case 0x33: case 0x35: case 0x36:
                     if      (in.omod == 1) d = b.fbin(Op_FMul, d, b.uconst(fbits(2.0f)));
                     else if (in.omod == 2) d = b.fbin(Op_FMul, d, b.uconst(fbits(4.0f)));
@@ -2249,7 +2282,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::VOPC: {                                     // v_cmp_* -> VCC; v_cmpx_* also -> EXEC
-            uint32_t a = val(in.src[0]), c = val(in.src[1]);
+            const uint32_t ra = val(in.src[0]), rc = val(in.src[1]);  // raw bits (f16 compares re-derive)
+            uint32_t a = ra, c = rc;
             // Float source modifiers (abs then neg — hardware order), set only on FLOAT compares by the
             // assembler (VOP3-encoded e64 or SDWA forms; e.g. DOLL's `v_cmp_gt_f32_sdwa vcc, |v5|, s4`).
             if (in.src_abs[0]) a = b.fext1(Glsl_FAbs, a);
@@ -2290,6 +2324,33 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0xC4: cmp = b.ucmp(Op_UGreaterThan, a, c); break;         // v_cmp_gt_u32
                 case 0xC5: cmp = b.ucmp(Op_INotEqual, a, c); break;            // v_cmp_ne_u32
                 case 0xC6: cmp = b.ucmp(Op_UGreaterThanEqual, a, c); break;    // v_cmp_ge_u32
+                // f16 compares (0xC8-0xCF; cmpx at +0x10 = 0xD8-0xDF folds here too — DOLL's title
+                // post PSes: `v_cmp_lt_f16_sdwa s6, 0, v7`). VERIFIED(round-trip llvm-mc gfx1030:
+                // v_cmp_lt/eq/le/gt/lg/ge_f16 = VOPC 0xC9-0xCE). The f16 value lives in the source's
+                // LOW half — unpack to f32 and compare there (exact: f16 order-embeds into f32); an
+                // inline FLOAT constant is already an f32 value, so it is used directly. abs/neg
+                // modifiers are applied after conversion (equivalent, conversion is monotone/exact).
+                case 0xC9: case 0xCA: case 0xCB: case 0xCC: case 0xCD: case 0xCE: {
+                    auto f16v = [&](int k, uint32_t raw) -> uint32_t {
+                        uint32_t v = (in.src[k].kind == OperandKind::InlineFloat ||
+                                      in.src[k].kind == OperandKind::InlineInt)
+                                         ? raw                       // inline: already a full-width value
+                                         : b.unpack_half(raw, 0);    // register/literal: f16 in the low half
+                        if (in.src_abs[k]) v = b.fext1(Glsl_FAbs, v);
+                        if (in.src_neg[k]) v = b.fbin(Op_FSub, b.uconst(0), v);
+                        return v;
+                    };
+                    uint32_t ha = f16v(0, ra), hc = f16v(1, rc);
+                    switch (eff) {
+                        case 0xC9: cmp = b.fcmp(Op_FOrdLessThan, ha, hc); break;          // v_cmp_lt_f16
+                        case 0xCA: cmp = b.fcmp(Op_FOrdEqual, ha, hc); break;             // v_cmp_eq_f16
+                        case 0xCB: cmp = b.fcmp(Op_FOrdLessThanEqual, ha, hc); break;     // v_cmp_le_f16
+                        case 0xCC: cmp = b.fcmp(Op_FOrdGreaterThan, ha, hc); break;       // v_cmp_gt_f16
+                        case 0xCD: cmp = b.fcmp(Op_FOrdNotEqual, ha, hc); break;          // v_cmp_lg_f16
+                        default:   cmp = b.fcmp(Op_FOrdGreaterThanEqual, ha, hc); break;  // v_cmp_ge_f16
+                    }
+                    break;
+                }
                 default: ok = false;
             }
             // A compare result is a per-lane mask. The e64/SDWAB form can target an SGPR pair (SDST)
@@ -2380,6 +2441,48 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t lo = b.uext2(Glsl_UMin, val(in.src[0]), b.uconst(0xFFFFu));
                 uint32_t hi = b.uext2(Glsl_UMin, val(in.src[1]), b.uconst(0xFFFFu));
                 vreg[in.dst.value] = b.ibin(Op_BitwiseOr, lo, b.ibin(Op_ShiftLeftLogical, hi, b.uconst(16)));
+            } else if (in.opcode >= 0x144 && in.opcode <= 0x147) {
+                // Cubemap coordinate ops (#273 — DOLL's title post PSes' reflection-probe math):
+                // v_cubeid_f32 (0x144) face id, v_cubesc_f32 (0x145) S numerator, v_cubetc_f32
+                // (0x146) T numerator, v_cubema_f32 (0x147) 2*major-axis. Src order (x, y, z);
+                // face-major selection per the AMD ISA / GL cubemap convention:
+                //   |z|>=|x| && |z|>=|y| : id = z<0?5:4  sc = z<0?-x:x  tc = -y      ma = 2z
+                //   else |y|>=|x|        : id = y<0?3:2  sc = x         tc = z<0.. = y<0?-z...
+                //   (see per-op emission below)
+                // VERIFIED(round-trip llvm-mc gfx1030: 0xd544-0xd547). Execution-tested (kernel in
+                // test_rdna2_to_spirv) against the GL major-axis table. CONFIDENCE: MED.
+                uint32_t x = fv(0), y = fv(1), z = fv(2);
+                uint32_t ax = b.fext1(Glsl_FAbs, x), ay = b.fext1(Glsl_FAbs, y), az = b.fext1(Glsl_FAbs, z);
+                uint32_t zmaj = b.land(b.fcmp(Op_FOrdGreaterThanEqual, az, ax),
+                                       b.fcmp(Op_FOrdGreaterThanEqual, az, ay));
+                uint32_t ymaj = b.fcmp(Op_FOrdGreaterThanEqual, ay, ax);      // (only used when !zmaj)
+                uint32_t zneg = b.fcmp(Op_FOrdLessThan, z, b.uconst(0));
+                uint32_t yneg = b.fcmp(Op_FOrdLessThan, y, b.uconst(0));
+                uint32_t xneg = b.fcmp(Op_FOrdLessThan, x, b.uconst(0));
+                auto fneg = [&](uint32_t v) { return b.fbin(Op_FSub, b.uconst(0), v); };
+                uint32_t r2;
+                switch (in.opcode) {
+                    case 0x144: {   // face id: z-major 4/5, y-major 2/3, x-major 0/1 (negative = +1)
+                        uint32_t idz = b.sel(zneg, b.uconst(fbits(5.0f)), b.uconst(fbits(4.0f)));
+                        uint32_t idy = b.sel(yneg, b.uconst(fbits(3.0f)), b.uconst(fbits(2.0f)));
+                        uint32_t idx2 = b.sel(xneg, b.uconst(fbits(1.0f)), b.uconst(fbits(0.0f)));
+                        r2 = b.sel(zmaj, idz, b.sel(ymaj, idy, idx2)); break;
+                    }
+                    case 0x145: {   // sc: z-major: z<0 ? -x : x; y-major: x; x-major: x<0 ? z : -z
+                        uint32_t scz = b.sel(zneg, fneg(x), x);
+                        uint32_t scx = b.sel(xneg, z, fneg(z));
+                        r2 = b.sel(zmaj, scz, b.sel(ymaj, x, scx)); break;
+                    }
+                    case 0x146: {   // tc: z-major: -y; y-major: y<0 ? -z : z; x-major: -y
+                        uint32_t tcy = b.sel(yneg, fneg(z), z);
+                        r2 = b.sel(zmaj, fneg(y), b.sel(ymaj, tcy, fneg(y))); break;
+                    }
+                    default: {      // 0x147 ma: 2 * major axis (signed)
+                        uint32_t maj = b.sel(zmaj, z, b.sel(ymaj, y, x));
+                        r2 = b.fbin(Op_FMul, b.uconst(fbits(2.0f)), maj); break;
+                    }
+                }
+                vreg[in.dst.value] = fresult(r2);
             } else if (in.opcode == 0x143) {                          // v_mad_u32_u24 = (s0&0xFFFFFF)*(s1&0xFFFFFF)+s2
                 uint32_t m24 = b.uconst(0xFFFFFF);
                 uint32_t p = b.ibin(Op_IMul, b.ibin(Op_BitwiseAnd, val(in.src[0]), m24),
@@ -2704,11 +2807,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (rt) {
                     // PER-FETCH first: a reloaded SRSRC holds a different V# per attribute, so match this
                     // exact fetch instruction's pc; fall back to the SGPR (direct) then s_load SRT tag.
+                    // Only a VERTEX-buffer pc entry implies the vertex-index address model — a pc-keyed
+                    // CONSTANT/structured buffer (a PS's per-lane table fetch, #273) keeps the faithful
+                    // VADDR*stride+offset address below.
                     res = rt->by_fetch_pc(in.pc);
-                    if (res) dyn_vfetch = true;
+                    if (res) dyn_vfetch = (res->cls == ResourceClass::VertexBuffer);
                     if (!res) res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
                     if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
                         if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
+                    // DIRECT user-data V# of any class (#273 — DOLL's title post PSes format-fetch
+                    // through a V# the metadata labels a CONSTANT buffer sharp at s[24:27]): the class
+                    // label doesn't change the descriptor's fields. Only when the SGPR was never
+                    // REWRITTEN in-shader (no rs.sreg entry) — a reloaded register no longer holds the
+                    // seed-time sharp, and trusting it would fetch through a stale descriptor.
+                    if (!res && rs.sreg.find(in.src[1].value) == rs.sreg.end())
+                        res = rt->by_sgpr_base(in.src[1].value);
                 }
                 if (!res) {
                     if (getenv("PROSPER_DBG")) {   // which provenance step failed for this format load
@@ -2782,6 +2895,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // from the address terms and REJECT the packed load/store when it can't be proven (surfacing
             // the gap) rather than silently mis-decode. Aligned iff: inst offset %4==0; stride %4==0
             // when idxen; no offen (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0.
+            bool dyn_half = false;   // 16-bit element at a runtime dword half (stride-2 buffers, #273)
             if (packed) {
                 bool base_aligned;
                 if (dyn_vfetch) {
@@ -2800,10 +2914,22 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                    (!idxen || (stride & 3u) == 0) && soff_zero;
                 }
                 if (!base_aligned) {
-                    if (getenv("PROSPER_DBG"))
-                        fprintf(stderr, "[mubuf-unaligned] pc=%u fmt=%u off=%u offen=%d idxen=%d stride=%u\n",
-                                in.pc, (unsigned)fmt, offset, (int)offen, (int)idxen, stride);
-                    ok = false; return true;
+                    // HALFWORD-ALIGNED single-component 16-bit load (#273 — DOLL's title post PSes
+                    // fetch from a STRIDE-2 uint16 table: `buffer_load_format_x v, vIDX, V#` with
+                    // stride 2). The element sits at a RUNTIME dword half — bit offset (addr&2)*8 —
+                    // which never straddles a dword, so extract it dynamically instead of rejecting.
+                    // Provable iff every address term is 2-aligned and there is no per-lane byte
+                    // offset (offen). Loads only (the packed store path still rejects sub-dword ints).
+                    bool soff_zero = (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
+                                     (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
+                    dyn_half = !is_store && n == 1 && comp_bytes == 2 && !offen && !dyn_vfetch &&
+                               (offset & 1u) == 0 && (!idxen || (stride & 1u) == 0) && soff_zero;
+                    if (!dyn_half) {
+                        if (getenv("PROSPER_DBG"))
+                            fprintf(stderr, "[mubuf-unaligned] pc=%u fmt=%u off=%u offen=%d idxen=%d stride=%u\n",
+                                    in.pc, (unsigned)fmt, offset, (int)offen, (int)idxen, stride);
+                        ok = false; return true;
+                    }
                 }
             }
             // Byte address of the element (#148): idxen -> a VADDR VGPR is an element index (×stride);
@@ -2871,6 +2997,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (!packed) {
                     uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
                     value = b.cbuf_load(kidx, binding);                  // raw 32-bit component
+                } else if (dyn_half) {
+                    // Runtime dword half (n==1, 16-bit element, 2-aligned address): shift the loaded
+                    // dword right by (addr&2)*8 and decode the 16-bit field at bit 0.
+                    uint32_t dw   = b.cbuf_load(idx, binding);
+                    uint32_t boff = b.ibin(Op_ShiftLeftLogical, b.ibin(Op_BitwiseAnd, addr, b.uconst(2)), b.uconst(3));
+                    uint32_t dws  = b.ibin(Op_ShiftRightLogical, dw, boff);
+                    value = is_half ? b.unpack_half(dws, 0)
+                          : is_uint ? b.bfe_u(dws, b.uconst(0), b.uconst(16))
+                          : is_sint ? b.bfe_s(dws, b.uconst(0), b.uconst(16))
+                                    : b.unpack_norm(dws, 0, 16, is_snorm, norm);
                 } else {
                     // Component k lives at byte k*comp_bytes within the element: pick its dword + field.
                     uint32_t byte_off = k * comp_bytes;
@@ -3056,12 +3192,33 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::DS: {
-            // ds_write_addtid_b32 (0xb0) in a GRAPHICS stage (#273): DOLL's scene PS writes one
-            // per-lane dword to LDS (addr = M0 + tid*4) and NEVER reads LDS back anywhere in the
-            // stream — a wave-scratch spill nothing in our per-invocation model can observe. No-op
-            // it in non-compute shells; any LDS READ in a graphics stage still rejects loudly below.
-            // VERIFIED(round-trip llvm-mc gfx1010: 0xdac00000/0x00000f00 -> ds_write_addtid_b32 v15).
-            if (!b.is_compute && in.opcode == 0xb0) return true;
+            // ds_write_addtid_b32 (0xb0) / ds_read_addtid_b32 (0xb1) in a GRAPHICS stage (#273):
+            // a per-lane VGPR spill through LDS (addr = M0 + offset + tid*4) — DOLL's title post
+            // PSes spill v15 before their accumulation loop and reload it after. Per-invocation the
+            // slot is ONE value: track it in rs.lds_addtid keyed by (M0 SSA id, inst offset); the
+            // matching read returns the spilled SSA value. A write with UNTRACKED M0 still no-ops
+            // (nothing in this model can observe it) but poisons nothing; a read with untracked M0
+            // or a never-written slot rejects loudly. VERIFIED(round-trip llvm-mc gfx1010:
+            // 0xdac00000/0x00000f00 -> ds_write_addtid_b32 v15; llvm-mc gfx1030:
+            // 0xdac40000/0x0f000000 -> ds_read_addtid_b32 v15).
+            if (!b.is_compute && (in.opcode == 0xb0 || in.opcode == 0xb1)) {
+                auto m0 = rs.sreg.find(124);
+                if (in.opcode == 0xb0) {
+                    if (m0 != rs.sreg.end()) {
+                        auto vr = rs.vreg.find(in.src[1].value);
+                        rs.lds_addtid[((uint64_t)m0->second << 32) | in.literal] =
+                            vr != rs.vreg.end() ? vr->second : b.uconst(0);
+                    }
+                    return true;   // spill: unobservable beyond the tracked slot
+                }
+                if (m0 == rs.sreg.end()) { ok = false; return true; }
+                auto slot = rs.lds_addtid.find(((uint64_t)m0->second << 32) | in.literal);
+                if (slot == rs.lds_addtid.end()) { ok = false; return true; }
+                uint32_t old = vreg_old(b, rs, in.dst.value);
+                rs.vreg[in.dst.value] = slot->second;
+                predicate_write(b, rs, in.dst.value, old);
+                return true;
+            }
             // LDS (workgroup shared memory), compute-only. ds_write_b32 (0x0d) / ds_read_b32 (0x36);
             // GDS and wider widths deferred. Byte address = ADDR VGPR + inst offset; dword index = >>2.
             if (!b.is_compute || (in.opcode != 0x0d && in.opcode != 0x36)) { ok = false; return true; }

--- a/prosper/tests/test_bc_decode.cpp
+++ b/prosper/tests/test_bc_decode.cpp
@@ -191,7 +191,29 @@ int main() {
         CHECK(out[0] == 0 && out[3] == 0, "BC7 reserved mode -> transparent black");
     }
 
-    CHECK(!bc_decode_surface(nullptr, nullptr, 0, 0, 0, DataFormat::Bc6), "BC6H still unsupported -> false");
+    // --- BC6H (UF16) -> clamped RGBA8 (#273) ---
+    {
+        // All-zero block: mode 0 (2-subset 10.555), every endpoint/index 0 -> RGB 0, alpha 255.
+        uint8_t blk[16]; std::memset(blk, 0, sizeof blk);
+        uint8_t out[4 * 4 * 4];
+        CHECK(bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc6), "BC6H surface decodes (UF16 wired)");
+        CHECK(out[0] == 0 && out[1] == 0 && out[2] == 0 && out[3] == 255, "BC6H zero block -> opaque black");
+    }
+    {
+        // Mode 11 (5-bit mode 00011: one subset, direct 10-bit endpoints, no delta). Constant-color
+        // block: rw=511, gw=0, bw=100, endpoint1/indices all 0 -> every texel = endpoint 0.
+        // Expected per the spec math: R unq = ((511<<16)+0x8000)>>10 = 32736, finish (x*31)>>6 =
+        // 15856 = half 0x3DF0 ~ 1.48 -> clamps to 255; G = 0; B: ((100<<16)+0x8000)>>10 = 6432 ->
+        // 3115 = half 0x0C2B ~ 0.0004 -> 0. So (255, 0, 0, 255).
+        uint8_t blk[16]; std::memset(blk, 0, sizeof blk);
+        const uint64_t low = 3ull | (511ull << 5) | (100ull << 25);   // mode(5b) rw(10b) gw(10b) bw(10b...)
+        std::memcpy(blk, &low, 8);
+        uint8_t out[4 * 4 * 4];
+        bc_decode_surface(out, blk, sizeof blk, 4, 4, DataFormat::Bc6);
+        const uint8_t* p5 = out + ((size_t)1 * 4 + 1) * 4;   // interior texel, same expectation
+        CHECK(out[0] == 255 && out[1] == 0 && out[2] == 0 && out[3] == 255, "BC6H mode-11 endpoint0 -> (255,0,0,255)");
+        CHECK(p5[0] == 255 && p5[1] == 0 && p5[2] == 0, "BC6H mode-11 constant across the block");
+    }
 
     // --- larger surface: 8x8 BC1, second block a distinct solid color; verify block placement ---
     {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1745,6 +1745,26 @@ int main() {
     printf("  T20(bitcmp1) mismatches=%u (out[2]=%g expect=100)\n", badT20, gotT20.size()==8?gotT20[2]:-1);
     CHECK(gotT20.size()==8 && badT20==0, "T20: s_bitcmp1_b32 sets SCC from the selected bit");
 
+    // Kernel T23: v_cube{id,sc,tc,ma}_f32 (#273 — DOLL's reflection-probe cube math). Direction
+    // (x,y,z) = (1.0, 0.5, -2.0): |z| is the major axis and z<0, so per the GL cube table
+    // id=5, sc=-x=-1, tc=-y=-0.5, ma=2z=-4. out = id*100 + sc*10 + tc + ma/1024
+    //     = 500 - 10 - 0.5 - 0.00390625 = 489.4961. (Assembled by llvm-mc gfx1030.)
+    const uint32_t codeT23[] = {
+        0x7E0202F2u, 0x7E0402F0u, 0x7E0602F5u, 0xD5440004u, 0x040E0501u, 0xD5450005u,
+        0x040E0501u, 0xD5460006u, 0x040E0501u, 0xD5470007u, 0x040E0501u, 0x100808FFu,
+        0x42C80000u, 0x100A0AFFu, 0x41200000u, 0x06080B04u, 0x06080D04u, 0x100E0EFFu,
+        0x3A800000u, 0x06000F04u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spvT23 = recompile_valu(codeT23, sizeof(codeT23)/sizeof(codeT23[0]), 1, 0);
+    CHECK(!spvT23.empty(), "recompiled kernel T23 (v_cube* ops) -> SPIR-V");
+    std::vector<float> inT23(8, 0.f);
+    std::vector<float> gotT23 = prosper::test::run_compute(spvT23, inT23, 8, 8);
+    uint32_t badT23 = 0;
+    for (uint32_t i = 0; i < 8 && gotT23.size() == 8; i++)
+        if (std::fabs(gotT23[i] - 489.4961f) > 1e-2f) badT23++;
+    printf("  kernelT23 mismatches=%u (out[0]=%g expect=489.4961)\n", badT23, gotT23.size()==8?gotT23[0]:-1);
+    CHECK(gotT23.size()==8 && badT23==0, "T23: cube id/sc/tc/ma match the GL major-axis table");
+
     // Kernel T21: v_fma_mixlo_f16 / mixhi (#273 — DOLL's box-blur f16 packing). v1=(a0*2+3) via
     // fma_mix_f32; then mixlo packs (a0+1) into v2's low half and mixhi packs (a0+2) into its high
     // half; out = f16lo(v2) + f16hi(v2) = (a0+1)+(a0+2) recovered via unpack (v_cvt_f32_f16-free:

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -100,6 +100,81 @@ int main() {
         }
     }
 
+    // DIVERGENT EXECZ-EXIT LOOP (#273 — DOLL's title post-process accumulation PS shape).
+    //   header: v_cmpx_lt_u32 s0, v1 (per-lane trip bound); s_cbranch_execz EXIT;
+    //   body:   a NESTED execz if (saveexec + v_cmpx s0<2 + restore) adding 0.25 to v2 (red/blue),
+    //           an unconditional 0.25 add to v3 (green), s0++; s_branch header (backward).
+    //   EXIT:   restore exec; export (v2, v3, v2, 1.0).
+    // 4 iterations, inner if true for the first 2 => color (0.5, 1.0, 0.5, 1.0).
+    // (Assembled by llvm-mc gfx1030 from labeled source; encodings are the assembler's own.)
+    {
+        const uint32_t ps[] = {
+            0x7E020284u, 0xBE800380u, 0x7E040280u, 0x7E060280u, 0x7E080282u, 0x7E0A02F2u,
+            0xBE82047Eu, 0x7DA20200u, 0xBF88000Au, 0xBE84047Eu, 0x7DA20800u, 0xBF880002u,
+            0x060404FFu, 0x3E800000u, 0xBEFE0404u, 0x060606FFu, 0x3E800000u, 0x81008100u,
+            0xBF82FFF4u, 0xBEFE0402u, 0xF800180Fu, 0x05020302u, 0xBF810000u,
+        };
+        std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+        CHECK(!frg.empty(), "recompiled divergent execz-exit LOOP PS -> SPIR-V");
+        if (!frg.empty()) {
+            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
+            CHECK(px2.size() == (size_t)W*H*4, "rendered the divergent-loop PS");
+            if (px2.size() == (size_t)W*H*4) {
+                const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
+                printf("  divloop center=(%u,%u,%u,%u) expect ~(128,255,128,255)\n", cc[0],cc[1],cc[2],cc[3]);
+                CHECK(cc[1] > 0xF0 && cc[0] > 0x70 && cc[0] < 0x90 && cc[2] > 0x70 && cc[2] < 0x90,
+                      "divergent loop: 4 iterations, nested if 2 -> (0.5, 1.0, 0.5)");
+            }
+        }
+    }
+
+    // EXECNZ-back-edge loop with a mid-body vccz BREAK (#273 — DOLL's scalar-indexed unroll shape):
+    //   LOOP: s_cbranch_execz EXIT (header exit); s_cmp_lt_u32 s0,s1; s_cselect_b64 s[4:5],exec,0;
+    //         vcc=exec=s[4:5]; s_cbranch_vccz EXIT (break); v2 += 0.25; s0++; s_cbranch_execnz LOOP.
+    // 3 iterations add 0.25 => gray (0.75, 0.75, 0.75, 1.0).
+    {
+        const uint32_t ps[] = {
+            0xBE82047Eu, 0xBE800380u, 0xBE810383u, 0x7E040280u, 0x7E0A02F2u, 0xBF880009u,
+            0xBF0A0100u, 0x8584807Eu, 0xBEEA0404u, 0xBEFE0404u, 0xBF860004u, 0x060404FFu,
+            0x3E800000u, 0x81008100u, 0xBF89FFF6u, 0xBEFE0402u, 0xF800180Fu, 0x05020202u,
+            0xBF810000u,
+        };
+        std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+        CHECK(!frg.empty(), "recompiled execnz-backedge loop + vccz break PS -> SPIR-V");
+        if (!frg.empty()) {
+            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
+            CHECK(px2.size() == (size_t)W*H*4, "rendered the execnz-loop PS");
+            if (px2.size() == (size_t)W*H*4) {
+                const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
+                printf("  execnz loop center=(%u,%u,%u,%u) expect ~(191,191,191,255)\n", cc[0],cc[1],cc[2],cc[3]);
+                CHECK(cc[0] > 0xA8 && cc[0] < 0xD8 && cc[1] > 0xA8 && cc[1] < 0xD8,
+                      "execnz loop + break: exactly 3 iterations -> 0.75 gray");
+            }
+        }
+    }
+
+    // SCALAR-SPILL lane slots (#273): v_writelane_b32 packs two scalars into v10's lanes 3/7 and
+    // v_readlane_b32 restores them; export uses the round-tripped values -> (0.25, 1.0, 0.25, 1.0).
+    {
+        const uint32_t ps[] = {
+            0xBE8503FFu, 0x3E800000u, 0xBE8603F2u, 0xD761000Au, 0x00010605u, 0xD761000Au,
+            0x00010E06u, 0xD7600007u, 0x0001070Au, 0xD7600008u, 0x00010F0Au, 0x7E000207u,
+            0x7E020208u, 0xF800180Fu, 0x01000100u, 0xBF810000u,
+        };
+        std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+        CHECK(!frg.empty(), "recompiled writelane/readlane scalar-spill PS -> SPIR-V");
+        if (!frg.empty()) {
+            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
+            CHECK(px2.size() == (size_t)W*H*4, "rendered the lane-slot PS");
+            if (px2.size() == (size_t)W*H*4) {
+                const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
+                printf("  laneslot center=(%u,%u,%u,%u) expect ~(64,255,64,255)\n", cc[0],cc[1],cc[2],cc[3]);
+                CHECK(cc[1] > 0xF0 && cc[0] > 0x30 && cc[0] < 0x50,
+                      "writelane/readlane: slots round-trip (0.25, 1.0)");
+            }
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -149,6 +149,24 @@ int main(int argc, char** argv) {
     { const uint32_t c[] = {0x7e020280u,0x7e0002f2u,0x7c2200f0u,0xbf880002u,0xbe8503f2u,0x7e020205u,
                             0x7e040205u,0xf800180fu,0x01010101u,0xbf810000u};
       dump(dir, "fragment_execz_if", recompile_fragment(c, sizeof(c)/4, nullptr)); }
+    // Fragment: DIVERGENT execz-exit loop with a nested execz if in the body (#273 — the DOLL
+    // title post-process accumulation shape; test_recompiled_fragment executes it).
+    { const uint32_t c[] = {0x7E020284u,0xBE800380u,0x7E040280u,0x7E060280u,0x7E080282u,0x7E0A02F2u,
+                            0xBE82047Eu,0x7DA20200u,0xBF88000Au,0xBE84047Eu,0x7DA20800u,0xBF880002u,
+                            0x060404FFu,0x3E800000u,0xBEFE0404u,0x060606FFu,0x3E800000u,0x81008100u,
+                            0xBF82FFF4u,0xBEFE0402u,0xF800180Fu,0x05020302u,0xBF810000u};
+      dump(dir, "fragment_divergent_loop", recompile_fragment(c, sizeof(c)/4, nullptr)); }
+    // Fragment: EXECNZ-back-edge loop with a mid-body vccz break (#273 — the scalar-indexed unroll).
+    { const uint32_t c[] = {0xBE82047Eu,0xBE800380u,0xBE810383u,0x7E040280u,0x7E0A02F2u,0xBF880009u,
+                            0xBF0A0100u,0x8584807Eu,0xBEEA0404u,0xBEFE0404u,0xBF860004u,0x060404FFu,
+                            0x3E800000u,0x81008100u,0xBF89FFF6u,0xBEFE0402u,0xF800180Fu,0x05020202u,
+                            0xBF810000u};
+      dump(dir, "fragment_execnz_loop", recompile_fragment(c, sizeof(c)/4, nullptr)); }
+    // Fragment: v_writelane/v_readlane scalar-spill slots (#273).
+    { const uint32_t c[] = {0xBE8503FFu,0x3E800000u,0xBE8603F2u,0xD761000Au,0x00010605u,0xD761000Au,
+                            0x00010E06u,0xD7600007u,0x0001070Au,0xD7600008u,0x00010F0Au,0x7E000207u,
+                            0x7E020208u,0xF800180Fu,0x01000100u,0xBF810000u};
+      dump(dir, "fragment_lane_slots", recompile_fragment(c, sizeof(c)/4, nullptr)); }
 
     if (fails) { printf("== FAIL: %d shader(s) failed recompile/validation ==\n", fails); return 1; }
     printf("== PASS%s ==\n", have_val ? " (all modules pass spirv-val)" : " (recompiled; spirv-val not found)");


### PR DESCRIPTION
## What

The four pixel shaders blocking DOLL's backbuffer composite (#273, last comment; executing since #327) from sampling real content now ALL recompile. Live DOLL boot recompile-skips: **~500/run → 1/run** (the remaining one is the known stale-bind draw class, #305).

### 1. Divergent execz-exit loop structurizer (the 3 loop PSes' control flow)
`header: <exec recompute>; s_cbranch_execz EXIT; body; s_branch header` — emitted as a real structured SPIR-V loop (OpLoopMerge, header OpPhi per carried reg/flag/saved mask, per-lane EXEC as the loop condition; condition-region values dominate the merge, counted-loop style). The forward-if machinery recurses INTO loop bodies (their ~20 nested execz regions) and loops nest inside if regions. Also the EXECNZ-back-edge flavor with mid-body vccz breaks (lowered as skip-to-backedge ifs), plus an `s_mov_b64 vcc, sX` fix (the break read a stale VCC — caught by the new execution kernel, visible in the emitted SPIR-V).

### 2. Descriptor provenance completes (the `image_sample_b` pc=265 class + the top scene PS)
- MIMG + MUBUF uses resolve by **exact instruction pc** (`ShaderResource::fetch_pc`) when the s_load-immediate key model fails or collides (key-0 EUD sharp vs key-0 table T#; s_buffer_load-fetched structured-buffer V#s are key-less by construction).
- Multiple uses of one surface each get a pc mapping; direct user-data V#s of any sharp class resolve for format loads when never rewritten in-shader; `dyn_vfetch`'s vertex-index address model now applies only to VertexBuffer-class entries.
- `PROSPER_DYNTRACE_FAIL` now replays failed **PS** stages too; `PROSPER_DBG` prints per-step resolution failures (`[mimg-unresolved]`/`[mubuf-unresolved]`).

### 3. BC6H (UF16) decode
The title skybox (2048×1024) and probe textures are BC6H — previously skipped at binding, so the samples could never resolve. Adapted verbatim from **bcdec** (MIT/Unlicense — the same reference the BC7 tables credit), decoding to clamped RGBA8 (HDR >1.0 clamps, same policy as the fp16 path). Unit vectors cross-checked against independently-computed spec math. SF16/SNORM stay skipped (flagged distinctly).

### 4. CUBE image_sample (the loop PSes' final instruction)
`image_sample_l dim:CUBE` with Mesa-convention coords (`sc*rcp(|ma|)+1.5, tc*rcp(|ma|)+1.5, face_id [, lod]`) lowers to a 2D sample of the six faces stacked vertically (w×6h): `u = x-1, v = (face + clamp(y-1))/6`. T# TYPE decodes into `img_dim`; the upload path detiles+decodes each face independently and stacks them. CONFIDENCE: MED on the face stride (fail-soft: garbled faces, never a crash).

### Ops added (every encoding llvm-mc round-tripped)
f16 compares (0xC9–0xCE + cmpx fold), v_cvt_f16_f32/f32_f16, SDWA BYTE_0..3 selects, v_fma_mix* op_sel/neg/abs/clamp modifiers, v_cube{id,sc,tc,ma}_f32 (GL major-axis table), v_writelane/v_readlane scalar-spill slots, ds_read_addtid (paired per-lane LDS spill), stride-2 uint16 format loads (dynamic dword-half extraction).

## Verification
- **ctest 71/71**, including new execution kernels: divergent loop w/ nested if → (0.5, 1.0, 0.5); execnz loop + break → exactly 3 iterations; writelane/readlane round-trip; cube ops vs the GL table; BC6H spec vectors. New spirv-val gates in `spv_validate` (divergent loop, execnz loop, lane slots).
- **Messenger (shared recompiler): snapshot check OK** (24,318 colors) after every batch; ctest green throughout.
- **Live DOLL**: skips ~500 → 1 per 220 s run; all four target shaders verified recompiling on real boots.

## Honest visual status
The composite executes and every content-producing PS now compiles, but a **recognizable textured title frame is not yet captured**: with the full 1500-instruction post chain now actually rendering at 3840×2160 under llvmpipe, guest progress to the title inside a capture run is extremely slow (25 min runs still show the loading banner). The pixel A/B (black composite → textured title) needs either a long soak run or the pending render-side dependency work (#319 follow-ups). All recompiler evidence says the content now flows; the screenshot is the next session's first check.

refs #273