### PR TITLE
feat(hle): PlatformUi backend hook — frontend can service ImeDialog (#347)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -131,6 +131,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_service_getters PRIVATE prosper_core)
   add_test(NAME service_getters COMMAND test_service_getters)
 
+  # PlatformUi hook (#347): the app frontend can service the guest's ImeDialog with real UI; with no
+  # backend registered the headless auto-complete default is unchanged. Pure, no game dump.
+  add_executable(test_platform_ui tests/test_platform_ui.cpp)
+  target_link_libraries(test_platform_ui PRIVATE prosper_core)
+  add_test(NAME platform_ui COMMAND test_platform_ui)
+
   # libSceImeDialog lifecycle + libSceSaveData memory API round-trip (#191): auto-completing dialog
   # (no hang) + a real per-(user,slot) Set->Get memory block with verified shadPS4 struct layouts.
   add_executable(test_savedata_ime tests/test_savedata_ime.cpp)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -5,6 +5,7 @@
 // (Game-controller input — libScePad — moved to hle_pad.cpp with a real host backend.)
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "platform_ui.hpp"
 #include <cstdint>
 #include <cstring>
 #include <cstdio>
@@ -272,12 +273,28 @@ HLE(s_dialog_result)   { if (a0) memset(PW(a0), 0, 0x2C); return 0; }
 // 2=RUNNING,3=FINISHED). CONFIDENCE: HIGH on the lifecycle (mirrors MsgDialog); MED on the exact
 // GetResult layout — we write only the 4-byte endStatus at offset 0 (the field the game branches on),
 // never more, so a wrong tail-field guess can't corrupt the caller's struct.
-namespace { std::atomic<int> g_imedialog_status{0 /*NONE*/}; }
-HLE(s_imedlg_init)   { g_imedialog_status.store(3 /*FINISHED — auto-complete, no keyboard UI*/); return 0; }
-HLE(s_imedlg_status) { return (uint64_t)(unsigned)g_imedialog_status.load(); }
-HLE(s_imedlg_result) { if (a0) *(int32_t*)PW(a0) = 0 /*SCE_IME_DIALOG_END_STATUS_OK*/; return 0; }
-HLE(s_imedlg_term)   { g_imedialog_status.store(0 /*NONE*/); return 0; }
-HLE(s_imedlg_abort)  { g_imedialog_status.store(0 /*NONE*/); return 0; }
+// A registered PlatformUi (the app frontend) gets first refusal on the dialog: if it takes it
+// (imeDialogOpen -> true), status/result/close route there so a real text field is shown; otherwise
+// the core auto-completes headlessly (below). `g_imedialog_backed` records which path Init chose so a
+// later poll/result/term goes to the same place. See platform_ui.hpp (#347).
+namespace { std::atomic<int> g_imedialog_status{0 /*NONE*/}; std::atomic<int> g_imedialog_backed{0}; }
+HLE(s_imedlg_init) {
+    if (auto* ui = platform_ui(); ui && ui->imeDialogOpen(a0, a1)) { g_imedialog_backed.store(1); return 0; }
+    g_imedialog_backed.store(0);
+    g_imedialog_status.store(3 /*FINISHED — auto-complete, no keyboard UI*/);
+    return 0;
+}
+HLE(s_imedlg_status) {
+    if (g_imedialog_backed.load()) { if (auto* ui = platform_ui()) return (uint64_t)(unsigned)ui->imeDialogStatus(); }
+    return (uint64_t)(unsigned)g_imedialog_status.load();
+}
+HLE(s_imedlg_result) {
+    if (g_imedialog_backed.load()) { if (auto* ui = platform_ui()) { (void)ui->imeDialogResult(a0); return 0; } }
+    if (a0) *(int32_t*)PW(a0) = 0 /*SCE_IME_DIALOG_END_STATUS_OK*/;
+    return 0;
+}
+HLE(s_imedlg_term)  { if (g_imedialog_backed.exchange(0)) { if (auto* ui = platform_ui()) ui->imeDialogClose(); } g_imedialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_imedlg_abort) { if (g_imedialog_backed.exchange(0)) { if (auto* ui = platform_ui()) ui->imeDialogClose(); } g_imedialog_status.store(0 /*NONE*/); return 0; }
 
 // --- libSceNpTrophy2 (PS5 trophy system) — the DOLL 34.6 GB OOM (issue #213 diagnosis). ---------
 // The guest's trophy bring-up (eboot+0xdbcb43..0xdbcc2e, gdb-captured live) calls

--- a/prosper/src/hle/platform_ui.cpp
+++ b/prosper/src/hle/platform_ui.cpp
@@ -1,0 +1,13 @@
+// platform_ui.cpp — the registry for the interactive-UI backend (see platform_ui.hpp). Just holds the
+// single registered pointer; the frontend sets it at startup and the dialog HLE handlers read it.
+#include "platform_ui.hpp"
+#include <atomic>
+
+namespace prosper {
+
+namespace { std::atomic<PlatformUi*> g_platform_ui{nullptr}; }
+
+PlatformUi* platform_ui() { return g_platform_ui.load(std::memory_order_acquire); }
+void        set_platform_ui(PlatformUi* ui) { g_platform_ui.store(ui, std::memory_order_release); }
+
+} // namespace prosper

--- a/prosper/src/hle/platform_ui.hpp
+++ b/prosper/src/hle/platform_ui.hpp
@@ -1,0 +1,43 @@
+// platform_ui.hpp — a host-owned interactive-UI backend the app frontend registers so the guest's
+// blocking dialogs / IME are serviced by REAL UI instead of the core's headless auto-complete.
+//
+// This is the same core<->frontend pattern already used for the renderer (gpu::set_submit_renderer),
+// audio (audio_set_sink) and controllers (pad backends): the core owns the Sony API surface and its
+// headless default; a concrete frontend (SDL3, ...) installs a PlatformUi from OUTSIDE the core via
+// set_platform_ui(). When none is registered, the dialog/IME HLE handlers keep their current headless
+// behavior (auto-complete / no-device), so boot_trace and CI are unchanged.
+//
+// The core passes the guest struct POINTERS through opaquely (guest == host address). Only the frontend
+// needs to know the Orbis struct layouts (OrbisImeDialogParam / Result, etc.) — the core stays
+// layout-agnostic, so there's no duplicated, drifting layout knowledge in prosper_core.
+//
+// Status values are the shared SceCommonDialogStatus: 0=NONE, 1=INITIALIZED, 2=RUNNING, 3=FINISHED.
+#pragma once
+#include <cstdint>
+
+namespace prosper {
+
+struct PlatformUi {
+    virtual ~PlatformUi() = default;
+
+    // --- libSceImeDialog (on-screen text entry) ---
+    // Begin showing a text-entry dialog. `param`/`extended` are the guest sceImeDialogInit arguments
+    // (OrbisImeDialogParam* and the extended param, as guest addresses). Return true to OWN the dialog
+    // — the core then routes status/result/close here; return false to let the core auto-complete it.
+    virtual bool imeDialogOpen(uint64_t param, uint64_t extended) { (void)param; (void)extended; return false; }
+    // The dialog's current status, polled by the guest until it is no longer RUNNING(2). Runs on the
+    // guest's polling thread; the frontend advances the real UI on its own thread.
+    virtual int  imeDialogStatus() { return 3 /*FINISHED*/; }
+    // Write the outcome into the guest OrbisImeDialogResult* `result` (the endStatus, plus any entered
+    // text into the input buffer the guest supplied at Init) and return the endStatus (0=OK,1=CANCELED).
+    virtual int  imeDialogResult(uint64_t result) { (void)result; return 0; }
+    // Tear down / abort the dialog (guest called Term or Abort).
+    virtual void imeDialogClose() {}
+};
+
+// The registered backend, or nullptr when headless. The frontend calls set_platform_ui once at startup
+// (before running the guest); the getter is used by the dialog HLE handlers on the guest thread.
+PlatformUi* platform_ui();
+void        set_platform_ui(PlatformUi* ui);
+
+} // namespace prosper

--- a/prosper/tests/test_platform_ui.cpp
+++ b/prosper/tests/test_platform_ui.cpp
@@ -1,0 +1,75 @@
+// test_platform_ui (#347) — the PlatformUi hook lets the app frontend service the guest's ImeDialog
+// with real UI, while the headless default (auto-complete) stays the behavior when none is registered.
+// This drives the sceImeDialog* HLE handlers both ways: no backend -> headless FINISHED; a registered
+// backend -> Init/Status/Result/Close route to it (a real dialog's timing + outcome).
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/platform_ui.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// A stand-in frontend: takes ownership of the dialog, stays RUNNING until the test advances it, and
+// reports USER_CANCELED with the entered (empty) text.
+struct MockUi : PlatformUi {
+    int status = 2 /*RUNNING*/, opens = 0, closes = 0, results = 0;
+    uint64_t last_param = 0, last_extended = 0, last_result = 0;
+    bool imeDialogOpen(uint64_t param, uint64_t extended) override {
+        opens++; last_param = param; last_extended = extended; status = 2; return true;
+    }
+    int  imeDialogStatus() override { return status; }
+    int  imeDialogResult(uint64_t result) override { results++; last_result = result;
+        if (result) *(int32_t*)result = 1 /*USER_CANCELED*/; return 1; }
+    void imeDialogClose() override { closes++; status = 0; }
+};
+
+int main() {
+    printf("== test_platform_ui ==\n");
+    register_builtin_hle();
+
+    HleFn init = Hle::lookup("NUeBrN7hzf0"), status = Hle::lookup("IADmD4tScBY"),
+          result = Hle::lookup("x01jxu+vxlc"), term = Hle::lookup("gyTyVn+bXMw");
+    CHECK(init && status && result && term, "ImeDialog handlers registered");
+    if (!(init && status && result && term)) { printf("== FAIL ==\n"); return 1; }
+
+    // --- No backend (headless default): Init -> FINISHED immediately; result writes OK(0). ---
+    set_platform_ui(nullptr);
+    term(0,0,0,0,0,0);
+    init(0,0,0,0,0,0);
+    CHECK(status(0,0,0,0,0,0) == 3, "headless: Init auto-completes to FINISHED(3)");
+    int32_t endStatus = 0x55;
+    result((uint64_t)(uintptr_t)&endStatus, 0,0,0,0,0);
+    CHECK(endStatus == 0, "headless: GetResult writes endStatus OK(0)");
+    term(0,0,0,0,0,0);
+
+    // --- With a registered backend: the dialog routes to it. ---
+    MockUi ui;
+    set_platform_ui(&ui);
+    init(0x1234 /*param*/, 0x5678 /*extended*/, 0,0,0,0);
+    CHECK(ui.opens == 1 && ui.last_param == 0x1234 && ui.last_extended == 0x5678,
+          "backend: Init forwards the guest param pointers to imeDialogOpen");
+    CHECK(status(0,0,0,0,0,0) == 2, "backend: status reflects the frontend (RUNNING while shown)");
+    ui.status = 3;   // the frontend finishes the dialog (user confirmed/cancelled)
+    CHECK(status(0,0,0,0,0,0) == 3, "backend: status follows the frontend to FINISHED");
+    int32_t es = 0x55;
+    result((uint64_t)(uintptr_t)&es, 0,0,0,0,0);
+    CHECK(ui.results == 1 && ui.last_result == (uint64_t)(uintptr_t)&es,
+          "backend: GetResult forwards the guest result pointer to imeDialogResult");
+    CHECK(es == 1, "backend: the frontend's outcome (USER_CANCELED) reached the guest result struct");
+    term(0,0,0,0,0,0);
+    CHECK(ui.closes == 1, "backend: Term routes to imeDialogClose");
+
+    // --- Unregister -> headless again (no dangling delegation to the freed backend). ---
+    set_platform_ui(nullptr);
+    init(0,0,0,0,0,0);
+    CHECK(status(0,0,0,0,0,0) == 3, "after unregister: back to headless auto-complete");
+    CHECK(ui.opens == 1, "after unregister: the old backend is no longer consulted");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Refs #347 (foundation increment). The interactive-UI Sony surfaces (ImeDialog now; MsgDialog/keyboard later) had only a **headless default** — they auto-complete. A windowed frontend (`prosper-app`) needs to show a real text field and feed the user's input back to the guest. This adds the same **core↔frontend hook** the renderer (`set_submit_renderer`), audio (`audio_set_sink`) and controllers already use.

## What this adds
- **`PlatformUi` interface** (`platform_ui.hpp`) + a `set_platform_ui` / `platform_ui` registry (`platform_ui.cpp`). The core passes the **guest struct pointers through opaquely**, so only the frontend needs to know the Orbis layouts (`OrbisImeDialogParam` / `Result`) — no duplicated, drifting layout knowledge in `prosper_core`.
- **`sceImeDialogInit`** now offers the dialog to a registered backend first (`imeDialogOpen` → `true` takes ownership); `GetStatus` / `GetResult` / `Term` then route to it, so a real dialog's timing and entered text reach the guest. **With no backend registered, the existing headless auto-complete is byte-identical** — `boot_trace` / CI unchanged.

## Design note
The guest drives dialogs by *polling* `GetStatus` until it's no longer `RUNNING`, so `PlatformUi` is a polled state machine (`open()` starts showing; `status()` is polled; `result()` reads the outcome) rather than a fire-and-forget callback — matching how the guest actually uses the API.

## Verification
`test_platform_ui` drives **both** paths: headless (no backend → FINISHED, OK result) and delegated (a mock frontend receives the param/result pointers, advances `status` RUNNING→FINISHED, and its `USER_CANCELED` outcome reaches the guest result struct). Full `ctest` **76/76**, incl. `boot_reaches_first_syscall`.

## Follow-ups (tracked on #347)
1. MsgDialog / ErrorDialog routing through `PlatformUi`.
2. Ime keyboard device presence.
3. An SDL3 `PlatformUi` implementation in `prosper-app`.