### PR TITLE
feat(hle): route MsgDialog + ErrorDialog through the PlatformUi hook (#347)

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -254,16 +254,31 @@ HLE(s_param_string)   { if (a1 && a2) ((char*)PW(a1))[0] = '\0'; return 0; }
 // Initialize -> INITIALIZED, Open -> auto-dismiss to FINISHED (headless: no interactive UI, so the
 // game's "wait until dismissed" loop still exits immediately), Close/Terminate -> back to NONE.
 // GetResult -> zeroed struct = OK/no button pressed.
-namespace { std::atomic<int> g_msgdialog_status{0 /*NONE*/}; }
-HLE(s_dialog_initialize) { g_msgdialog_status.store(1 /*INITIALIZED*/); return 0; }
-HLE(s_dialog_open)       { g_msgdialog_status.store(3 /*FINISHED (auto-dismiss)*/); return 0; }
-HLE(s_dialog_close)      { g_msgdialog_status.store(0 /*NONE*/); return 0; }
-HLE(s_dialog_terminate)  { g_msgdialog_status.store(0 /*NONE*/); return 0; }
-HLE(s_dialog_status)     { return (uint64_t)(unsigned)g_msgdialog_status.load(); }
+// A registered PlatformUi gets first refusal at Open; if it takes the dialog, status/result/close
+// route there (real message box). Otherwise the core auto-dismisses headlessly. `g_msgdialog_backed`
+// records which path Open chose. See platform_ui.hpp (#347).
+namespace { std::atomic<int> g_msgdialog_status{0 /*NONE*/}; std::atomic<int> g_msgdialog_backed{0}; }
+HLE(s_dialog_initialize) { g_msgdialog_backed.store(0); g_msgdialog_status.store(1 /*INITIALIZED*/); return 0; }
+HLE(s_dialog_open) {
+    if (auto* ui = platform_ui(); ui && ui->msgDialogOpen(a0)) { g_msgdialog_backed.store(1); return 0; }
+    g_msgdialog_backed.store(0);
+    g_msgdialog_status.store(3 /*FINISHED (auto-dismiss)*/);
+    return 0;
+}
+HLE(s_dialog_close)      { if (g_msgdialog_backed.exchange(0)) { if (auto* ui = platform_ui()) ui->msgDialogClose(); } g_msgdialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_dialog_terminate)  { if (g_msgdialog_backed.exchange(0)) { if (auto* ui = platform_ui()) ui->msgDialogClose(); } g_msgdialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_dialog_status) {
+    if (g_msgdialog_backed.load()) { if (auto* ui = platform_ui()) return (uint64_t)(unsigned)ui->msgDialogStatus(); }
+    return (uint64_t)(unsigned)g_msgdialog_status.load();
+}
 // SceMsgDialogResult = { u32 mode; u32 result; u32 buttonId; char reserved[32] } = 0x2C bytes
 // (shadPS4 msgdialog_ui.h DialogResult). Was memset(0x30) — 4 bytes PAST the caller's struct,
 // exactly the f_fstat oversized-write class this file warns about.
-HLE(s_dialog_result)   { if (a0) memset(PW(a0), 0, 0x2C); return 0; }
+HLE(s_dialog_result) {
+    if (g_msgdialog_backed.load()) { if (auto* ui = platform_ui()) { (void)ui->msgDialogResult(a0); return 0; } }
+    if (a0) memset(PW(a0), 0, 0x2C);
+    return 0;
+}
 
 // --- libSceImeDialog (on-screen text-entry dialog) — same common-dialog lifecycle as MsgDialog
 // (#191). We have no keyboard UI, so the dialog auto-completes: Init -> FINISHED(3) immediately, so
@@ -750,18 +765,24 @@ extern "C" uint64_t s_np_check_cb_c(uint64_t, uint64_t, uint64_t, uint64_t, uint
 // { s32 size; s32 errorCode; s32 userId; s32 reserved } (shadPS4 error_dialog.cpp Param); the
 // errorCode is printed unconditionally — a one-shot, high-value diagnostic of WHAT the game
 // thinks failed. CONFIDENCE: HIGH (shadPS4 implements this exact lifecycle).
-namespace { std::atomic<int> g_errdialog_status{0 /*NONE*/}; }
-HLE(s_errdialog_init)   { g_errdialog_status.store(1 /*INITIALIZED*/); return 0; }
+namespace { std::atomic<int> g_errdialog_status{0 /*NONE*/}; std::atomic<int> g_errdialog_backed{0}; }
+HLE(s_errdialog_init)   { g_errdialog_backed.store(0); g_errdialog_status.store(1 /*INITIALIZED*/); return 0; }
 HLE(s_errdialog_open)   {
+    // Offer the error dialog to a registered PlatformUi first (a real message box); else auto-dismiss.
+    if (auto* ui = platform_ui(); ui && ui->errorDialogOpen(a0)) { g_errdialog_backed.store(1); return 0; }
+    g_errdialog_backed.store(0);
     uint32_t code = 0;
     if (svc_ptrish(a0)) code = *(const uint32_t*)((const char*)PW(a0) + 4);
     fprintf(stderr, "[svc] sceErrorDialogOpen(errorCode=%#x) -> auto-dismiss FINISHED\n", code);
     g_errdialog_status.store(3 /*FINISHED (auto-dismiss)*/);
     return 0;
 }
-HLE(s_errdialog_close)  { g_errdialog_status.store(3 /*FINISHED*/); return 0; }
-HLE(s_errdialog_term)   { g_errdialog_status.store(0 /*NONE*/);     return 0; }
-HLE(s_errdialog_status) { return (uint64_t)(unsigned)g_errdialog_status.load(); }
+HLE(s_errdialog_close)  { if (g_errdialog_backed.exchange(0)) { if (auto* ui = platform_ui()) ui->errorDialogClose(); } g_errdialog_status.store(3 /*FINISHED*/); return 0; }
+HLE(s_errdialog_term)   { if (g_errdialog_backed.exchange(0)) { if (auto* ui = platform_ui()) ui->errorDialogClose(); } g_errdialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_errdialog_status) {
+    if (g_errdialog_backed.load()) { if (auto* ui = platform_ui()) return (uint64_t)(unsigned)ui->errorDialogStatus(); }
+    return (uint64_t)(unsigned)g_errdialog_status.load();
+}
 
 // --- libSceNpEntitlementAccess / libSceGameUpdate: observability first. -------------------------
 // PS5-only surfaces with NO reference implementation (absent from Kyty and shadPS4); the PS5 3.20

--- a/prosper/src/hle/platform_ui.hpp
+++ b/prosper/src/hle/platform_ui.hpp
@@ -33,6 +33,22 @@ struct PlatformUi {
     virtual int  imeDialogResult(uint64_t result) { (void)result; return 0; }
     // Tear down / abort the dialog (guest called Term or Abort).
     virtual void imeDialogClose() {}
+
+    // --- libSceMsgDialog (message dialog: text + buttons: OK/YES-NO/progress) ---
+    // Show a message dialog. `param` is the guest sceMsgDialogOpen argument (SceMsgDialogParam*, opaque
+    // guest address). Return true to OWN it; false -> the core auto-dismisses headlessly.
+    virtual bool msgDialogOpen(uint64_t param) { (void)param; return false; }
+    virtual int  msgDialogStatus() { return 3 /*FINISHED*/; }
+    // Write the guest SceMsgDialogResult* `result` (mode / result / buttonId) and return the buttonId.
+    virtual int  msgDialogResult(uint64_t result) { (void)result; return 0; }
+    virtual void msgDialogClose() {}
+
+    // --- libSceErrorDialog (single-button error message; no result struct) ---
+    // Show an error dialog. `param` is the guest sceErrorDialogOpen argument (opaque). Return true to
+    // OWN it; false -> the core auto-dismisses headlessly (and logs the errorCode).
+    virtual bool errorDialogOpen(uint64_t param) { (void)param; return false; }
+    virtual int  errorDialogStatus() { return 3 /*FINISHED*/; }
+    virtual void errorDialogClose() {}
 };
 
 // The registered backend, or nullptr when headless. The frontend calls set_platform_ui once at startup

--- a/prosper/tests/test_platform_ui.cpp
+++ b/prosper/tests/test_platform_ui.cpp
@@ -4,6 +4,7 @@
 // backend -> Init/Status/Result/Close route to it (a real dialog's timing + outcome).
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/platform_ui.hpp"
+#include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
 
@@ -25,6 +26,19 @@ struct MockUi : PlatformUi {
     int  imeDialogResult(uint64_t result) override { results++; last_result = result;
         if (result) *(int32_t*)result = 1 /*USER_CANCELED*/; return 1; }
     void imeDialogClose() override { closes++; status = 0; }
+
+    // MsgDialog
+    int msg_status = 2, msg_opens = 0, msg_closes = 0, msg_results = 0; uint64_t msg_last_param = 0;
+    bool msgDialogOpen(uint64_t param) override { msg_opens++; msg_last_param = param; msg_status = 2; return true; }
+    int  msgDialogStatus() override { return msg_status; }
+    int  msgDialogResult(uint64_t result) override { msg_results++; if (result) *(uint32_t*)(result + 8) = 2 /*buttonId*/; return 2; }
+    void msgDialogClose() override { msg_closes++; msg_status = 0; }
+
+    // ErrorDialog
+    int err_status = 2, err_opens = 0, err_closes = 0; uint64_t err_last_param = 0;
+    bool errorDialogOpen(uint64_t param) override { err_opens++; err_last_param = param; err_status = 2; return true; }
+    int  errorDialogStatus() override { return err_status; }
+    void errorDialogClose() override { err_closes++; err_status = 0; }
 };
 
 int main() {
@@ -68,6 +82,43 @@ int main() {
     init(0,0,0,0,0,0);
     CHECK(status(0,0,0,0,0,0) == 3, "after unregister: back to headless auto-complete");
     CHECK(ui.opens == 1, "after unregister: the old backend is no longer consulted");
+
+    // --- MsgDialog: headless auto-dismiss vs backend delegation. ---
+    HleFn m_init = Hle::lookup(nid_hash("sceMsgDialogInitialize")), m_open = Hle::lookup(nid_hash("sceMsgDialogOpen")),
+          m_status = Hle::lookup(nid_hash("sceMsgDialogGetStatus")), m_result = Hle::lookup(nid_hash("sceMsgDialogGetResult")),
+          m_close = Hle::lookup(nid_hash("sceMsgDialogClose"));
+    CHECK(m_init && m_open && m_status && m_result && m_close, "MsgDialog handlers registered");
+    if (m_init && m_open) {
+        set_platform_ui(nullptr);
+        m_init(0,0,0,0,0,0); m_open(0,0,0,0,0,0);
+        CHECK(m_status(0,0,0,0,0,0) == 3, "MsgDialog headless: Open auto-dismisses to FINISHED");
+        m_close(0,0,0,0,0,0);
+        set_platform_ui(&ui);
+        m_init(0,0,0,0,0,0); m_open(0xAAAA,0,0,0,0,0);
+        CHECK(ui.msg_opens == 1 && ui.msg_last_param == 0xAAAA, "MsgDialog backend: Open forwards the param");
+        CHECK(m_status(0,0,0,0,0,0) == 2, "MsgDialog backend: status follows the frontend (RUNNING)");
+        uint32_t mres[3] = {0,0,0};
+        m_result((uint64_t)(uintptr_t)mres, 0,0,0,0,0);
+        CHECK(ui.msg_results == 1 && mres[2] == 2, "MsgDialog backend: GetResult writes the frontend's buttonId");
+        m_close(0,0,0,0,0,0);
+        CHECK(ui.msg_closes == 1, "MsgDialog backend: Close routes to msgDialogClose");
+    }
+
+    // --- ErrorDialog: headless auto-dismiss vs backend delegation. ---
+    HleFn e_init = Hle::lookup("I88KChlynSs"), e_open = Hle::lookup("M2ZF-ClLhgY"),
+          e_status = Hle::lookup("t2FvHRXzgqk"), e_term = Hle::lookup("9XAxK2PMwk8");
+    CHECK(e_init && e_open && e_status, "ErrorDialog handlers registered");
+    if (e_init && e_open) {
+        set_platform_ui(nullptr);
+        e_init(0,0,0,0,0,0); e_open(0,0,0,0,0,0);
+        CHECK(e_status(0,0,0,0,0,0) == 3, "ErrorDialog headless: Open auto-dismisses to FINISHED");
+        set_platform_ui(&ui);
+        e_init(0,0,0,0,0,0); e_open(0xBBBB,0,0,0,0,0);
+        CHECK(ui.err_opens == 1 && ui.err_last_param == 0xBBBB, "ErrorDialog backend: Open forwards the param");
+        CHECK(e_status(0,0,0,0,0,0) == 2, "ErrorDialog backend: status follows the frontend (RUNNING)");
+        if (e_term) { e_term(0,0,0,0,0,0); CHECK(ui.err_closes == 1, "ErrorDialog backend: Term routes to errorDialogClose"); }
+    }
+    set_platform_ui(nullptr);
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Refs #347 (second increment, after the ImeDialog foundation in #349). Extends the `PlatformUi` interface with `msgDialog*` / `errorDialog*` and wires the existing handlers so a registered frontend can show a **real message / error box**:

- **`sceMsgDialogOpen`** offers the dialog to the backend (`msgDialogOpen` → `true` takes it); `GetStatus` / `GetResult` / `Close` then route there, with `GetResult` writing the frontend's `buttonId` into the guest `SceMsgDialogResult`. Else the headless auto-dismiss (FINISHED, zeroed result) is byte-identical.
- **`sceErrorDialogOpen`** likewise offers it to the backend; else the existing `errorCode` log + auto-dismiss. `Status`/`Term` route to the backend when it owns the dialog.

The core keeps forwarding the guest struct pointers **opaquely** — only the frontend knows the layouts. With no backend registered, `boot_trace` / CI are unchanged.

## Verification
`test_platform_ui` extended: both dialogs verified **headless** (auto-dismiss) and **delegated** (param forwarded, status follows the frontend RUNNING→done, MsgDialog `buttonId` reaches the guest result, Close/Term route to the backend). Full `ctest` **77/77**, incl. `boot_reaches_first_syscall`.

## Remaining on #347
- [ ] Ime keyboard device presence (a frontend with a real/virtual keyboard reports it).
- [ ] An SDL3 `PlatformUi` implementation in `prosper-app` (the consumer that actually shows the dialogs).