### PR TITLE
feat(app): SDL3 PlatformUi — real message boxes for MsgDialog/ErrorDialog (#347)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -143,6 +143,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_platform_ui PRIVATE prosper_core)
   add_test(NAME platform_ui COMMAND test_platform_ui)
 
+  # SDL3 dialog frontend's guest-struct parsing (#347): pure, SDL-free, so it runs in normal CI even
+  # though the SDL_ShowMessageBox glue is display-only. Verifies the MsgDialog/ErrorDialog layouts.
+  add_executable(test_dialog_helpers frontends/dialog_sdl3/test_dialog_helpers.cpp
+                                     frontends/dialog_sdl3/dialog_helpers.cpp)
+  add_test(NAME dialog_helpers COMMAND test_dialog_helpers)
+
   # libSceImeDialog lifecycle + libSceSaveData memory API round-trip (#191): auto-completing dialog
   # (no hang) + a real per-(user,slot) Set->Get memory block with verified shadPS4 struct layouts.
   add_executable(test_savedata_ime tests/test_savedata_ime.cpp)
@@ -606,6 +612,15 @@ if(PROSPER_APP AND TARGET SDL3::SDL3)
       target_link_libraries(prosper-app PRIVATE prosper_live_renderer)
       target_compile_definitions(prosper-app PRIVATE PROSPER_HAVE_LIVE_RENDERER=1)
     endif()
+    # SDL3 dialog frontend (#347): real SDL_ShowMessageBox for the guest's MsgDialog/ErrorDialog via
+    # the PlatformUi hook. The layout parsing (dialog_helpers) is pure + unit-tested (see below); this
+    # module adds the SDL glue and needs SDL3 video (already required by prosper-app).
+    add_library(prosper_dialog_sdl3 STATIC
+                frontends/dialog_sdl3/platform_ui_sdl3.cpp frontends/dialog_sdl3/dialog_helpers.cpp)
+    target_include_directories(prosper_dialog_sdl3 PUBLIC frontends/dialog_sdl3 src)
+    target_link_libraries(prosper_dialog_sdl3 PUBLIC prosper_core SDL3::SDL3)
+    target_link_libraries(prosper-app PRIVATE prosper_dialog_sdl3)
+    target_compile_definitions(prosper-app PRIVATE PROSPER_HAVE_DIALOG_SDL3=1)
     message(STATUS "prosper-app frontend enabled (SDL3 window + Vulkan present)")
   else()
     message(WARNING "PROSPER_APP=ON but Vulkan not found — skipping prosper-app")

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -1,0 +1,52 @@
+// dialog_helpers.cpp — see dialog_helpers.hpp. Pure struct parsing (no SDL). memcpy is used for every
+// guest read/write so unaligned guest structs and strict aliasing are both safe.
+#include "dialog_helpers.hpp"
+#include <cstring>
+
+namespace prosper {
+
+MsgRequest read_msg_request(uint64_t param) {
+    MsgRequest r{0, 0, nullptr};
+    if (!param) return r;
+    std::memcpy(&r.mode, (const void*)(uintptr_t)(param + 56), 4);
+    uint64_t ump = 0;
+    std::memcpy(&ump, (const void*)(uintptr_t)(param + 64), 8);   // userMsgParam pointer
+    if (ump) {
+        std::memcpy(&r.buttonType, (const void*)(uintptr_t)(ump + 0), 4);
+        uint64_t msgp = 0;
+        std::memcpy(&msgp, (const void*)(uintptr_t)(ump + 8), 8);
+        r.msg = (const char*)(uintptr_t)msgp;
+    }
+    return r;
+}
+
+MsgButtons msg_buttons_for(uint32_t bt) {
+    // OrbisMsgDialogButtonType (shadPS4): OK=0, YESNO=1, NONE=2, OK_CANCEL=3, WAIT=5, WAIT_CANCEL=6,
+    // YESNO_FOCUS_NO=7, OK_CANCEL_FOCUS_CANCEL=8, TWO_BUTTONS=9.
+    switch (bt) {
+        case 1: case 7: return {2, {"Yes", "No", nullptr},        {1, 2, 0}};   // YESNO[_FOCUS_NO]
+        case 3: case 8: return {2, {"OK", "Cancel", nullptr},     {1, 2, 0}};   // OK_CANCEL[_FOCUS_CANCEL]
+        case 9:         return {2, {"Button 1", "Button 2", nullptr}, {1, 2, 0}}; // TWO_BUTTONS (labels are custom; ids are 1/2)
+        case 2:         return {0, {nullptr, nullptr, nullptr},    {0, 0, 0}};   // NONE
+        case 5: case 6: return {0, {nullptr, nullptr, nullptr},    {0, 0, 0}};   // WAIT[_CANCEL] (progress; no buttons)
+        case 0:
+        default:        return {1, {"OK", nullptr, nullptr},       {1, 0, 0}};   // OK
+    }
+}
+
+void write_msg_result(uint64_t result, uint32_t buttonId) {
+    if (!result) return;
+    uint32_t mode = 0;
+    uint32_t res  = (buttonId == 2u) ? 1u : 0u;   // NO / Cancel (id 2) -> USER_CANCELED, else OK
+    std::memcpy((void*)(uintptr_t)(result + 0), &mode,     4);
+    std::memcpy((void*)(uintptr_t)(result + 4), &res,      4);
+    std::memcpy((void*)(uintptr_t)(result + 8), &buttonId, 4);
+}
+
+uint32_t read_error_code(uint64_t param) {
+    uint32_t code = 0;
+    if (param) std::memcpy(&code, (const void*)(uintptr_t)(param + 4), 4);
+    return code;
+}
+
+} // namespace prosper

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -1,0 +1,38 @@
+// dialog_helpers.hpp — pure (SDL-free) parsing of the guest MsgDialog / ErrorDialog structs for the
+// SDL3 PlatformUi frontend. Kept separate from the SDL glue so this layout-sensitive code is unit-
+// tested in normal CI (no display needed); only the SDL_ShowMessageBox call lives in the gated module.
+//
+// Struct offsets verified against shadPS4 src/core/libraries/system/{msgdialog_ui,commondialog}.h:
+//   OrbisMsgDialogParam:  CommonDialog::BaseParam baseParam [48] ; size_t size @48 ; mode @56 ;
+//                         (pad @60) ; UserMessageParam* userMsgParam @64 ; ...
+//   UserMessageParam:     ButtonType buttonType @0 ; (pad @4) ; const char* msg @8 ; ...
+//   DialogResult:         u32 mode @0 ; Result result @4 ; ButtonId buttonId @8 ; u8 reserved[32]
+//   ErrorDialog param:    s32 size @0 ; s32 errorCode @4 ; s32 userId @8 ; s32 reserved @12
+#pragma once
+#include <cstdint>
+
+namespace prosper {
+
+enum { ORBIS_MSG_DIALOG_MODE_USER_MSG = 1 };   // 2=PROGRESS_BAR, 3=SYSTEM_MSG (no buttons -> headless)
+
+// The SDL button set a MsgDialog ButtonType maps to: labels + the guest ButtonId each returns.
+struct MsgButtons { int count; const char* label[3]; uint32_t id[3]; };
+
+// What we read out of a guest OrbisMsgDialogParam* to build the message box.
+struct MsgRequest { uint32_t mode; uint32_t buttonType; const char* msg; };
+
+// Read mode + buttonType + message pointer from a guest OrbisMsgDialogParam* (guest==host address).
+MsgRequest read_msg_request(uint64_t param);
+
+// Map an OrbisMsgDialogButtonType to its button set (OK / Yes-No / OK-Cancel / ...). ButtonId per
+// shadPS4: OK=1, YES=1, NO=2, BUTTON1=1, BUTTON2=2. count 0 = a no-button mode (progress/system).
+MsgButtons msg_buttons_for(uint32_t buttonType);
+
+// Write the guest OrbisMsgDialogResult*: mode@0=0, result@4 (0=OK, 1=USER_CANCELED — NO/Cancel is id 2),
+// buttonId@8. Bounded to the 3 leading u32s; never touches the caller's reserved tail.
+void write_msg_result(uint64_t result, uint32_t buttonId);
+
+// Read errorCode (@4) from a guest OrbisErrorDialogParam*.
+uint32_t read_error_code(uint64_t param);
+
+} // namespace prosper

--- a/prosper/frontends/dialog_sdl3/dialog_sdl3.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_sdl3.hpp
@@ -1,0 +1,18 @@
+// dialog_sdl3.hpp — optional SDL3 dialog frontend for the interactive-UI HLE (PlatformUi, #347).
+//
+// Built only when -DPROSPER_APP=ON (needs SDL3 video). Installs a PlatformUi that shows real
+// SDL_ShowMessageBox dialogs for the guest's MsgDialog / ErrorDialog, so a windowed session presents
+// them instead of the core's headless auto-dismiss. ImeDialog text entry (which needs a custom text
+// field, not a message box) is not handled yet, so it falls back to the core's headless default.
+#pragma once
+
+namespace prosper {
+
+// Install the SDL3 PlatformUi as the active interactive-UI backend. Idempotent; call once at startup
+// after register_builtin_hle(). Returns true.
+bool install_sdl3_platform_ui();
+
+// Uninstall (restore the headless default).
+void shutdown_sdl3_platform_ui();
+
+} // namespace prosper

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -1,0 +1,78 @@
+// platform_ui_sdl3.cpp — the SDL3 PlatformUi (see dialog_sdl3.hpp). Shows real SDL_ShowMessageBox
+// dialogs for the guest MsgDialog / ErrorDialog; the layout parsing is in dialog_helpers.cpp (pure,
+// unit-tested). Built only under -DPROSPER_APP=ON. The guest drives dialogs by polling GetStatus until
+// it leaves RUNNING, so Open shows the modal (blocking the guest's dialog thread — intended for a
+// modal), records the result, and reports FINISHED; the next poll returns it.
+#include "dialog_sdl3.hpp"
+#include "dialog_helpers.hpp"
+#include "hle/platform_ui.hpp"
+#include <SDL3/SDL.h>
+#include <atomic>
+#include <cstdio>
+
+namespace prosper {
+namespace {
+
+// Show a modal message box. Returns the clicked button's id (which we set to the guest ButtonId), or
+// -1 if it was dismissed without a button (window closed) or SDL failed.
+int show_box(uint32_t sdl_flags, const char* title, const char* msg, const MsgButtons& b) {
+    SDL_MessageBoxButtonData btns[3] = {};
+    for (int i = 0; i < b.count; i++) { btns[i].buttonID = (int)b.id[i]; btns[i].text = b.label[i]; }
+    if (b.count > 0) {
+        btns[0].flags            |= SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT;   // first = default (Enter)
+        btns[b.count - 1].flags  |= SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT;   // last  = cancel (Esc)
+    }
+    SDL_MessageBoxData d = {};
+    d.flags = sdl_flags; d.title = title; d.message = msg ? msg : ""; d.numbuttons = b.count; d.buttons = btns;
+    int clicked = -1;
+    if (!SDL_ShowMessageBox(&d, &clicked)) { SDL_Log("prosper: SDL_ShowMessageBox failed: %s", SDL_GetError()); return -1; }
+    return clicked;
+}
+
+struct SdlPlatformUi : PlatformUi {
+    std::atomic<int>      msg_status{0}, err_status{0};
+    std::atomic<uint32_t> msg_btn{1 /*OK*/};
+
+    // MsgDialog. Only user-message mode maps to a message box; progress/system modes fall back to the
+    // core's headless handling (return false).
+    bool msgDialogOpen(uint64_t param) override {
+        MsgRequest r = read_msg_request(param);
+        if (r.mode != ORBIS_MSG_DIALOG_MODE_USER_MSG) return false;
+        MsgButtons b = msg_buttons_for(r.buttonType);
+        if (b.count == 0) return false;
+        int clicked = show_box(SDL_MESSAGEBOX_INFORMATION, "prosper", r.msg, b);
+        msg_btn.store(clicked >= 0 ? (uint32_t)clicked : b.id[0]);
+        msg_status.store(3 /*FINISHED*/);
+        return true;
+    }
+    int  msgDialogStatus() override { return msg_status.load(); }
+    int  msgDialogResult(uint64_t result) override { uint32_t id = msg_btn.load(); write_msg_result(result, id); return (int)id; }
+    void msgDialogClose() override { msg_status.store(0); }
+
+    // ErrorDialog: a single-OK box reporting the error code.
+    bool errorDialogOpen(uint64_t param) override {
+        char buf[96];
+        std::snprintf(buf, sizeof buf, "An error occurred.\n\nError code: 0x%08X", read_error_code(param));
+        show_box(SDL_MESSAGEBOX_ERROR, "prosper — Error", buf, msg_buttons_for(0 /*OK*/));
+        err_status.store(3 /*FINISHED*/);
+        return true;
+    }
+    int  errorDialogStatus() override { return err_status.load(); }
+    void errorDialogClose() override { err_status.store(0); }
+
+    // imeDialog* left as the base default (returns false) -> the core's headless auto-complete, since a
+    // text-entry field is not a message box (a custom SDL text UI is a separate follow-up).
+};
+
+SdlPlatformUi g_sdl_ui;
+
+} // namespace
+
+bool install_sdl3_platform_ui() {
+    set_platform_ui(&g_sdl_ui);
+    SDL_Log("prosper: SDL3 dialog backend installed (MsgDialog/ErrorDialog -> SDL_ShowMessageBox)");
+    return true;
+}
+void shutdown_sdl3_platform_ui() { set_platform_ui(nullptr); }
+
+} // namespace prosper

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -1,0 +1,62 @@
+// test_dialog_helpers — the SDL3 dialog frontend's pure struct parsing (#347). No SDL / no display, so
+// it runs in normal CI: it builds synthetic guest MsgDialog structs at the shadPS4-verified offsets and
+// checks read_msg_request / msg_buttons_for / write_msg_result / read_error_code.
+#include "../dialog_sdl3/dialog_helpers.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_dialog_helpers ==\n");
+
+    // Synthetic OrbisMsgDialogParam (>=72 bytes) + UserMessageParam at the verified offsets.
+    uint8_t umsg[32] = {};
+    const char* message = "Delete this save?";
+    uint32_t btnType = 1;   // YESNO
+    std::memcpy(umsg + 0, &btnType, 4);                 // buttonType @0
+    uint64_t msgp = (uint64_t)(uintptr_t)message; std::memcpy(umsg + 8, &msgp, 8);  // msg @8
+
+    uint8_t param[80] = {};
+    uint32_t mode = ORBIS_MSG_DIALOG_MODE_USER_MSG; std::memcpy(param + 56, &mode, 4);     // mode @56
+    uint64_t ump = (uint64_t)(uintptr_t)umsg;       std::memcpy(param + 64, &ump, 8);      // userMsgParam @64
+
+    MsgRequest r = read_msg_request((uint64_t)(uintptr_t)param);
+    CHECK(r.mode == 1, "read_msg_request: mode @56 (USER_MSG)");
+    CHECK(r.buttonType == 1, "read_msg_request: buttonType @64->@0 (YESNO)");
+    CHECK(r.msg && std::strcmp(r.msg, message) == 0, "read_msg_request: msg pointer @64->@8 resolves the text");
+
+    // Button mapping.
+    MsgButtons ok = msg_buttons_for(0);
+    CHECK(ok.count == 1 && ok.id[0] == 1, "msg_buttons_for(OK) -> 1 button, id OK(1)");
+    MsgButtons yn = msg_buttons_for(1);
+    CHECK(yn.count == 2 && yn.id[0] == 1 && yn.id[1] == 2, "msg_buttons_for(YESNO) -> Yes(1)/No(2)");
+    MsgButtons okc = msg_buttons_for(3);
+    CHECK(okc.count == 2 && std::strcmp(okc.label[1], "Cancel") == 0, "msg_buttons_for(OK_CANCEL) -> OK/Cancel");
+    CHECK(msg_buttons_for(2).count == 0, "msg_buttons_for(NONE) -> no buttons (progress/system -> headless)");
+    CHECK(msg_buttons_for(5).count == 0, "msg_buttons_for(WAIT) -> no buttons");
+
+    // Result writing: buttonId @8, result @4 (NO/Cancel=id 2 -> USER_CANCELED), mode @0. Bounded to 12 bytes.
+    uint8_t res[44]; std::memset(res, 0xAB, sizeof res);
+    write_msg_result((uint64_t)(uintptr_t)res, 1 /*OK/YES*/);
+    uint32_t w_mode, w_res, w_btn; std::memcpy(&w_mode, res+0, 4); std::memcpy(&w_res, res+4, 4); std::memcpy(&w_btn, res+8, 4);
+    CHECK(w_mode == 0 && w_res == 0 && w_btn == 1, "write_msg_result(1) -> mode 0, result OK(0), buttonId 1");
+    CHECK((uint8_t)res[12] == 0xAB && (uint8_t)res[43] == 0xAB, "write_msg_result writes only 12 bytes (reserved tail untouched)");
+    write_msg_result((uint64_t)(uintptr_t)res, 2 /*NO/Cancel*/);
+    std::memcpy(&w_res, res+4, 4); std::memcpy(&w_btn, res+8, 4);
+    CHECK(w_res == 1 && w_btn == 2, "write_msg_result(2) -> result USER_CANCELED(1), buttonId 2");
+
+    // ErrorDialog param: errorCode @4.
+    uint8_t ep[16] = {}; uint32_t code = 0x80AABBCC; std::memcpy(ep + 4, &code, 4);
+    CHECK(read_error_code((uint64_t)(uintptr_t)ep) == 0x80AABBCC, "read_error_code: errorCode @4");
+    CHECK(read_error_code(0) == 0, "read_error_code(NULL) -> 0 (no deref)");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -27,6 +27,9 @@
 #ifdef PROSPER_PAD_SDL3
 #include "pad_sdl3.hpp"                // install_sdl3_pad_backend (route a host controller to libScePad)
 #endif
+#ifdef PROSPER_HAVE_DIALOG_SDL3
+#include "dialog_sdl3.hpp"             // install_sdl3_platform_ui (real SDL message boxes for dialogs)
+#endif
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_vulkan.h>
@@ -357,6 +360,10 @@ int main(int argc, char** argv) {
 #endif
 #ifdef PROSPER_PAD_SDL3
             if (prosper::install_sdl3_pad_backend()) fprintf(stderr, "[app] controller backend installed.\n");
+#endif
+#ifdef PROSPER_HAVE_DIALOG_SDL3
+            prosper::install_sdl3_platform_ui();   // real SDL message boxes for MsgDialog/ErrorDialog (#347)
+            fprintf(stderr, "[app] dialog backend installed.\n");
 #endif
         };
         if (!boot_program(dump, prog, &err, install_backends)) { fprintf(stderr, "[app] boot failed: %s\n", err.c_str()); return 1; }


### PR DESCRIPTION
Refs #347 — the capstone of the PlatformUi hook. `prosper-app` now shows **real dialogs** instead of the headless auto-dismiss: `install_sdl3_platform_ui()` registers an SDL3 `PlatformUi` that renders the guest's MsgDialog / ErrorDialog via `SDL_ShowMessageBox` and feeds the pressed button back to the guest.

- **MsgDialog**: reads `buttonType` + message from `OrbisMsgDialogParam`, shows the matching buttons (OK / Yes-No / OK-Cancel), and writes the clicked `ButtonId` into `OrbisMsgDialogResult` (NO/Cancel → `USER_CANCELED`). Progress/system modes fall back to the core's headless handling.
- **ErrorDialog**: a single-OK box reporting the `errorCode`.
- **ImeDialog** text entry is left to the headless default — a message box isn't a text field, so a custom SDL text UI is a follow-up.

## Verifiability (the interesting part)
The layout-sensitive guest-struct parsing lives in a **pure, SDL-free** `dialog_helpers.cpp`, split out precisely so it's unit-tested in **normal CI** even though `SDL_ShowMessageBox` itself needs a display. `test_dialog_helpers` (always built) checks `read_msg_request` at the shadPS4-verified offsets, the button mapping, `write_msg_result` **bounded to 12 bytes** (reserved tail untouched), and the error-code read. Only the `SDL_ShowMessageBox` glue is gated behind `PROSPER_APP`.

Struct offsets verified vs shadPS4 `src/core/libraries/system/{msgdialog_ui,commondialog}.h` (`OrbisMsgDialogParam`: baseParam[48] → mode@56 → userMsgParam@64; `DialogResult`: buttonId@8).

## Verification
- `test_dialog_helpers` — 13 assertions, in the default suite. Full headless `ctest` **78/78**.
- Built + **linked** under `-DPROSPER_APP=ON` (SDL3 fetched) — which caught a real bug: SDL3's field is `buttonID`, not SDL2's `buttonid`. Fixed and rebuilt clean.

## #347 status
- [x] ImeDialog foundation (#349), MsgDialog/ErrorDialog routing (#351)
- [x] SDL3 `PlatformUi` in prosper-app (this PR) — MsgDialog + ErrorDialog
- [ ] ImeDialog text-entry UI (custom SDL text field) + Ime keyboard presence — remaining follow-ups