### PR TITLE
fix(hle): correct sceAvPlayerInitEx ABI (error-code + out-param handle)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -109,6 +109,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_ajm PRIVATE prosper_core)
   add_test(NAME ajm_hle COMMAND test_ajm)
 
+  add_executable(test_avplayer tests/test_avplayer.cpp)
+  target_link_libraries(test_avplayer PRIVATE prosper_core)
+  add_test(NAME avplayer_hle COMMAND test_avplayer)
+
   add_executable(test_equeue_events tests/test_equeue_events.cpp)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -90,6 +90,13 @@ HLE(s_ok)             { return 0; }
 // NULL handle from a stubbed InitEx. No decode needed to progress; the game's while(IsActive) frame
 // loop simply doesn't run (or ends at once) and it moves on.
 HLE(s_avplayer_init)     { return g_handle.fetch_add(1); }   // non-NULL SceAvPlayerHandle
+// sceAvPlayerInitEx(const SceAvPlayerInitDataEx* data, SceAvPlayerHandle* out) has a DIFFERENT ABI from
+// sceAvPlayerInit: it returns an int32 ERROR CODE (0 = success) and writes the handle to the *out*
+// param — it does NOT return the handle. Registering it to s_avplayer_init (return-the-handle) makes the
+// game read a non-zero handle as an error code: The Messenger-family PS5VideoPlayback wrapper logs
+// "[PS5VideoPlayback] ERROR: sceAvPlayerInitEx() failed" and aborts the intro video (live-captured;
+// PPSA02664). Return 0 and write a valid non-NULL handle to a1. CONFIDENCE: HIGH (live guest error log).
+HLE(s_avplayer_initex)   { if (a1) *(uint64_t*)PW(a1) = g_handle.fetch_add(1); return 0; }
 HLE(s_avplayer_isactive) { return 0; }                       // 0 = not active -> stream done -> proceed
 // sceUserServiceGetGamePresets(userId, presets): MUST return success (0). The Unity engine's
 // per-controller connection check (eboot 0x14707e0, reached from the pad "reset" path 0x1470ca0)
@@ -940,7 +947,7 @@ void register_service_hle() {
     // libSceAvPlayer (#324): let a post-credits / intro video complete so the game reaches its scene.
     // Init/InitEx must return a non-NULL handle; IsActive must report finished; the rest succeed as no-ops.
     R("sceAvPlayerInit",           s_avplayer_init);
-    R("sceAvPlayerInitEx",         s_avplayer_init);
+    R("sceAvPlayerInitEx",         s_avplayer_initex);
     R("sceAvPlayerPostInit",       s_ok);
     R("sceAvPlayerSetLogCallback", s_ok);
     R("sceAvPlayerAddSource",      s_ok);

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -1,0 +1,45 @@
+// test_avplayer (#324) — libSceAvPlayer lifecycle. prosper doesn't decode video, but the two init
+// entry points have DIFFERENT ABIs and must be distinguished, or the guest's video wrapper misreads the
+// result. sceAvPlayerInit RETURNS the handle; sceAvPlayerInitEx returns an int32 error code (0 = success)
+// and WRITES the handle to its out-param. Registering InitEx to the return-the-handle handler made
+// PPSA02664's PS5VideoPlayback wrapper read a non-zero handle as an error code and abort the intro video
+// ("[PS5VideoPlayback] ERROR: sceAvPlayerInitEx() failed"). This locks the InitEx out-param contract.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_avplayer ==\n");
+    register_builtin_hle();
+
+    HleFn init   = Hle::lookup(nid_hash("sceAvPlayerInit"));
+    HleFn initex = Hle::lookup(nid_hash("sceAvPlayerInitEx"));
+    HleFn active = Hle::lookup(nid_hash("sceAvPlayerIsActive"));
+    CHECK(init && initex && active, "AvPlayer Init/InitEx/IsActive registered");
+    if (!(init && initex && active)) { printf("== FAIL ==\n"); return 1; }
+
+    // sceAvPlayerInit(data) -> handle (the RETURN value is the handle; non-NULL so the game proceeds).
+    uint64_t h1 = init(0, 0, 0, 0, 0, 0);
+    CHECK(h1 != 0, "sceAvPlayerInit returns a non-NULL handle");
+
+    // sceAvPlayerInitEx(data, out) -> 0 (success error-code), handle written to *out. It must NOT return
+    // the handle as its result — that is the regression this test guards.
+    uint64_t out = 0xDEAD;
+    uint64_t rc = initex(0, (uint64_t)(uintptr_t)&out, 0, 0, 0, 0);
+    CHECK(rc == 0, "sceAvPlayerInitEx returns 0 (success error code), NOT the handle");
+    CHECK(out != 0 && out != 0xDEAD, "sceAvPlayerInitEx WROTE a valid non-NULL handle to the out-param");
+
+    // IsActive must report "not active" so the game's while(IsActive) playback loop ends and it advances.
+    CHECK(active(out, 0, 0, 0, 0, 0) == 0, "sceAvPlayerIsActive -> 0 (finished, proceed)");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
`sceAvPlayerInit` RETURNS the handle; `sceAvPlayerInitEx` returns an int32 error code (0=success) and WRITES the handle to its out-param. #326 registered `InitEx` to the return-the-handle handler, so PPSA02664's PS5VideoPlayback wrapper reads a non-zero handle as an error code, logs `"[PS5VideoPlayback] ERROR: sceAvPlayerInitEx() failed"`, and aborts the intro video.

## Fix
- Distinct `s_avplayer_initex`: returns `0`, writes a non-NULL handle to `a1`.
- New `test_avplayer` unit test locks the contract (would fail against the old registration).

Trust basis: prosper live guest error log (trust order #1); Kyty implements only `AvPlayerInit`, not `InitEx`.

All 76 unit tests green.

Fixes #354