### PR TITLE
fix(hle): ImeDialog status uses its own enum (Finished=2), not common-dialog 3

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -280,14 +280,15 @@ HLE(s_dialog_result) {
     return 0;
 }
 
-// --- libSceImeDialog (on-screen text-entry dialog) — same common-dialog lifecycle as MsgDialog
-// (#191). We have no keyboard UI, so the dialog auto-completes: Init -> FINISHED(3) immediately, so
-// the game's "poll GetStatus until != RUNNING" loop exits at once instead of hanging on a dialog
-// that never appears; GetResult reports endStatus = OK/ENTER with the (unchanged/empty) input buffer;
-// Term/Abort return to NONE. Status enum is the shared SceCommonDialogStatus (0=NONE,1=INITIALIZED,
-// 2=RUNNING,3=FINISHED). CONFIDENCE: HIGH on the lifecycle (mirrors MsgDialog); MED on the exact
-// GetResult layout — we write only the 4-byte endStatus at offset 0 (the field the game branches on),
-// never more, so a wrong tail-field guess can't corrupt the caller's struct.
+// --- libSceImeDialog (on-screen text-entry dialog) (#191). We have no keyboard UI, so the dialog
+// auto-completes: Init -> FINISHED immediately, so the game's "poll GetStatus until Finished" loop
+// exits at once instead of hanging on a dialog that never appears; GetResult reports endStatus =
+// OK/ENTER with the (unchanged/empty) input buffer; Term/Abort return to NONE.
+// IMPORTANT: sceImeDialogGetStatus returns the IME-dialog's OWN enum (OrbisImeDialogStatus: NONE=0,
+// RUNNING=1, FINISHED=2) — NOT the 4-value SceCommonDialogStatus that MsgDialog/ErrorDialog use
+// (…RUNNING=2, FINISHED=3). Verified in shadPS4 ime_dialog.cpp. Returning 3 here made a game's poll
+// loop never see Finished(2). We write only the 4-byte endStatus at GetResult offset 0 (the field the
+// game branches on), never more, so a wrong tail-field guess can't corrupt the caller's struct.
 // A registered PlatformUi (the app frontend) gets first refusal on the dialog: if it takes it
 // (imeDialogOpen -> true), status/result/close route there so a real text field is shown; otherwise
 // the core auto-completes headlessly (below). `g_imedialog_backed` records which path Init chose so a
@@ -296,7 +297,7 @@ namespace { std::atomic<int> g_imedialog_status{0 /*NONE*/}; std::atomic<int> g_
 HLE(s_imedlg_init) {
     if (auto* ui = platform_ui(); ui && ui->imeDialogOpen(a0, a1)) { g_imedialog_backed.store(1); return 0; }
     g_imedialog_backed.store(0);
-    g_imedialog_status.store(3 /*FINISHED — auto-complete, no keyboard UI*/);
+    g_imedialog_status.store(2 /*OrbisImeDialogStatus::Finished — auto-complete, no keyboard UI*/);
     return 0;
 }
 HLE(s_imedlg_status) {

--- a/prosper/src/hle/platform_ui.hpp
+++ b/prosper/src/hle/platform_ui.hpp
@@ -25,9 +25,11 @@ struct PlatformUi {
     // (OrbisImeDialogParam* and the extended param, as guest addresses). Return true to OWN the dialog
     // — the core then routes status/result/close here; return false to let the core auto-complete it.
     virtual bool imeDialogOpen(uint64_t param, uint64_t extended) { (void)param; (void)extended; return false; }
-    // The dialog's current status, polled by the guest until it is no longer RUNNING(2). Runs on the
-    // guest's polling thread; the frontend advances the real UI on its own thread.
-    virtual int  imeDialogStatus() { return 3 /*FINISHED*/; }
+    // The dialog's current status (OrbisImeDialogStatus: NONE=0, RUNNING=1, FINISHED=2 — the IME
+    // dialog's OWN enum, NOT the 4-value common-dialog status MsgDialog uses), polled by the guest
+    // until it reads FINISHED(2). Runs on the guest's polling thread; the frontend advances the real
+    // UI on its own thread.
+    virtual int  imeDialogStatus() { return 2 /*OrbisImeDialogStatus::Finished*/; }
     // Write the outcome into the guest OrbisImeDialogResult* `result` (the endStatus, plus any entered
     // text into the input buffer the guest supplied at Init) and return the endStatus (0=OK,1=CANCELED).
     virtual int  imeDialogResult(uint64_t result) { (void)result; return 0; }

--- a/prosper/tests/test_platform_ui.cpp
+++ b/prosper/tests/test_platform_ui.cpp
@@ -17,10 +17,10 @@ static int fails = 0;
 // A stand-in frontend: takes ownership of the dialog, stays RUNNING until the test advances it, and
 // reports USER_CANCELED with the entered (empty) text.
 struct MockUi : PlatformUi {
-    int status = 2 /*RUNNING*/, opens = 0, closes = 0, results = 0;
+    int status = 1 /*OrbisImeDialogStatus::Running*/, opens = 0, closes = 0, results = 0;
     uint64_t last_param = 0, last_extended = 0, last_result = 0;
     bool imeDialogOpen(uint64_t param, uint64_t extended) override {
-        opens++; last_param = param; last_extended = extended; status = 2; return true;
+        opens++; last_param = param; last_extended = extended; status = 1; return true;
     }
     int  imeDialogStatus() override { return status; }
     int  imeDialogResult(uint64_t result) override { results++; last_result = result;
@@ -54,7 +54,7 @@ int main() {
     set_platform_ui(nullptr);
     term(0,0,0,0,0,0);
     init(0,0,0,0,0,0);
-    CHECK(status(0,0,0,0,0,0) == 3, "headless: Init auto-completes to FINISHED(3)");
+    CHECK(status(0,0,0,0,0,0) == 2, "headless: Init auto-completes to ImeDialog Finished(2)");
     int32_t endStatus = 0x55;
     result((uint64_t)(uintptr_t)&endStatus, 0,0,0,0,0);
     CHECK(endStatus == 0, "headless: GetResult writes endStatus OK(0)");
@@ -66,9 +66,9 @@ int main() {
     init(0x1234 /*param*/, 0x5678 /*extended*/, 0,0,0,0);
     CHECK(ui.opens == 1 && ui.last_param == 0x1234 && ui.last_extended == 0x5678,
           "backend: Init forwards the guest param pointers to imeDialogOpen");
-    CHECK(status(0,0,0,0,0,0) == 2, "backend: status reflects the frontend (RUNNING while shown)");
-    ui.status = 3;   // the frontend finishes the dialog (user confirmed/cancelled)
-    CHECK(status(0,0,0,0,0,0) == 3, "backend: status follows the frontend to FINISHED");
+    CHECK(status(0,0,0,0,0,0) == 1, "backend: status reflects the frontend (ImeDialog Running=1 while shown)");
+    ui.status = 2;   // the frontend finishes the dialog (user confirmed/cancelled)
+    CHECK(status(0,0,0,0,0,0) == 2, "backend: status follows the frontend to ImeDialog Finished(2)");
     int32_t es = 0x55;
     result((uint64_t)(uintptr_t)&es, 0,0,0,0,0);
     CHECK(ui.results == 1 && ui.last_result == (uint64_t)(uintptr_t)&es,
@@ -80,7 +80,7 @@ int main() {
     // --- Unregister -> headless again (no dangling delegation to the freed backend). ---
     set_platform_ui(nullptr);
     init(0,0,0,0,0,0);
-    CHECK(status(0,0,0,0,0,0) == 3, "after unregister: back to headless auto-complete");
+    CHECK(status(0,0,0,0,0,0) == 2, "after unregister: back to headless auto-complete (Finished=2)");
     CHECK(ui.opens == 1, "after unregister: the old backend is no longer consulted");
 
     // --- MsgDialog: headless auto-dismiss vs backend delegation. ---

--- a/prosper/tests/test_savedata_ime.cpp
+++ b/prosper/tests/test_savedata_ime.cpp
@@ -41,7 +41,7 @@ int main() {
         ime_term(0,0,0,0,0,0);
         CHECK(ime_status(0,0,0,0,0,0) == 0, "ImeDialog status is NONE(0) before Init");
         ime_init(0,0,0,0,0,0);
-        CHECK(ime_status(0,0,0,0,0,0) == 3, "after Init -> FINISHED(3) so a poll loop exits (no keyboard UI)");
+        CHECK(ime_status(0,0,0,0,0,0) == 2, "after Init -> OrbisImeDialogStatus::Finished(2) so a poll loop exits");
         int32_t endStatus = (int32_t)0xDEAD;
         ime_result((uint64_t)(uintptr_t)&endStatus, 0, 0, 0, 0, 0);
         CHECK(endStatus == 0, "GetResult writes endStatus = OK(0)");


### PR DESCRIPTION
Found while pulling the `OrbisImeDialogParam` layout for the ImeDialog text-entry UI — a latent bug in the merged ImeDialog work (#191/#349).

## The bug
`sceImeDialogGetStatus` returns **`OrbisImeDialogStatus`** — `NONE=0, RUNNING=1, FINISHED=2` — the IME dialog's *own* 3-value enum. It is **not** the 4-value `SceCommonDialogStatus` (`…RUNNING=2, FINISHED=3`) that MsgDialog / ErrorDialog use. Verified in shadPS4 `ime_dialog.cpp`/`.h`.

The merged code returned `3` for FINISHED (it mirrored MsgDialog), so a game that shows an IME dialog and polls *"GetStatus until Finished(2)"* would never see it → **hang**. It hadn't surfaced because ImeDialog isn't invoked during the current boot window — exactly the latent-hang class.

## Fix
- Headless auto-complete: `Init` → status **2** (was 3).
- `PlatformUi::imeDialogStatus()` default → **2** (was 3).
- Comments corrected (ImeDialog `Running=1`/`Finished=2`; MsgDialog/ErrorDialog **keep** common-dialog `2`/`3` — unchanged).
- Tests updated: `test_savedata_ime` + `test_platform_ui` now assert the IME enum (headless Finished=2; mock frontend Running=1→Finished=2).

## Verification
Full `ctest` **78/78**, incl. `boot_reaches_first_syscall`. MsgDialog/ErrorDialog status paths untouched.