### PR TITLE
feat(app): ImeDialog text entry — real SDL text field via a main-thread pump (#347)

### DIFF
--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -49,4 +49,73 @@ uint32_t read_error_code(uint64_t param) {
     return code;
 }
 
+// --- ImeDialog text entry ---
+
+void utf8_append_cp(std::string& s, uint32_t cp) {
+    if (cp < 0x80) {
+        s += (char)cp;
+    } else if (cp < 0x800) {
+        s += (char)(0xC0 | (cp >> 6)); s += (char)(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        s += (char)(0xE0 | (cp >> 12)); s += (char)(0x80 | ((cp >> 6) & 0x3F)); s += (char)(0x80 | (cp & 0x3F));
+    } else {
+        s += (char)(0xF0 | (cp >> 18)); s += (char)(0x80 | ((cp >> 12) & 0x3F));
+        s += (char)(0x80 | ((cp >> 6) & 0x3F)); s += (char)(0x80 | (cp & 0x3F));
+    }
+}
+
+std::string u16_to_utf8(uint64_t u16ptr) {
+    std::string out;
+    if (!u16ptr) return out;
+    const uint16_t* u = (const uint16_t*)(uintptr_t)u16ptr;
+    const uint32_t CAP = 4096;   // guard a non-terminated guest string from a runaway read
+    for (uint32_t i = 0; i < CAP && u[i]; ) {
+        uint32_t cp = u[i++];
+        if (cp >= 0xD800 && cp <= 0xDBFF && i < CAP && u[i] >= 0xDC00 && u[i] <= 0xDFFF)
+            cp = 0x10000 + ((cp - 0xD800) << 10) + (u[i++] - 0xDC00);   // surrogate pair
+        utf8_append_cp(out, cp);
+    }
+    return out;
+}
+
+ImeRequest read_ime_request(uint64_t param) {
+    ImeRequest r{0, 0, {}, {}};
+    if (!param) return r;
+    std::memcpy(&r.max_text_length, (const void*)(uintptr_t)(param + 36), 4);
+    std::memcpy(&r.input_buffer,    (const void*)(uintptr_t)(param + 40), 8);
+    uint64_t titlep = 0;
+    std::memcpy(&titlep, (const void*)(uintptr_t)(param + 72), 8);
+    r.title   = u16_to_utf8(titlep);
+    r.initial = u16_to_utf8(r.input_buffer);
+    return r;
+}
+
+uint32_t write_ime_text(uint64_t input_buffer, uint32_t max_len, const std::string& utf8) {
+    if (!input_buffer) return 0;
+    uint16_t* out = (uint16_t*)(uintptr_t)input_buffer;
+    uint32_t n = 0;                                   // UTF-16 code units written (excl. NUL)
+    for (size_t i = 0; i < utf8.size() && n < max_len; ) {
+        unsigned char c = (unsigned char)utf8[i];
+        uint32_t cp; int len;
+        if (c < 0x80)              { cp = c;                 len = 1; }
+        else if ((c >> 5) == 0x6)  { cp = c & 0x1F;          len = 2; }
+        else if ((c >> 4) == 0xE)  { cp = c & 0x0F;          len = 3; }
+        else if ((c >> 3) == 0x1E) { cp = c & 0x07;          len = 4; }
+        else                       { i++;                    continue; }   // stray continuation byte
+        if (i + (size_t)len > utf8.size()) break;
+        for (int k = 1; k < len; k++) cp = (cp << 6) | ((unsigned char)utf8[i + k] & 0x3F);
+        i += len;
+        if (cp < 0x10000) {
+            out[n++] = (uint16_t)cp;
+        } else {                                       // encode as a UTF-16 surrogate pair
+            if (n + 2 > max_len) break;
+            cp -= 0x10000;
+            out[n++] = (uint16_t)(0xD800 | (cp >> 10));
+            out[n++] = (uint16_t)(0xDC00 | (cp & 0x3FF));
+        }
+    }
+    out[n] = 0;   // NUL-terminate (Sony input buffer is sized max_text_length + 1)
+    return n;
+}
+
 } // namespace prosper

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -10,6 +10,7 @@
 //   ErrorDialog param:    s32 size @0 ; s32 errorCode @4 ; s32 userId @8 ; s32 reserved @12
 #pragma once
 #include <cstdint>
+#include <string>
 
 namespace prosper {
 
@@ -34,5 +35,25 @@ void write_msg_result(uint64_t result, uint32_t buttonId);
 
 // Read errorCode (@4) from a guest OrbisErrorDialogParam*.
 uint32_t read_error_code(uint64_t param);
+
+// --- ImeDialog (text entry) --- offsets from shadPS4 ime/ime_common.h OrbisImeDialogParam:
+//   user_id@0 type@4 ... max_text_length@36(u32) input_text_buffer@40(char16_t*) ... title@72(char16_t*)
+struct ImeRequest {
+    uint64_t    input_buffer;    // guest char16_t* the entered text is written into (0 if none)
+    uint32_t    max_text_length; // max UTF-16 code units (excluding NUL) the buffer holds
+    std::string title;           // UTF-8 of the title (for the prompt); empty if none
+    std::string initial;         // UTF-8 of any text already in the input buffer
+};
+// Parse a guest OrbisImeDialogParam* into an ImeRequest (title/initial converted UTF-16 -> UTF-8).
+ImeRequest read_ime_request(uint64_t param);
+
+// Write `utf8` into the guest UTF-16 input buffer (at `input_buffer`), NUL-terminated, clamped to
+// max_len code units (never overruns). Returns the number of code units written (excluding NUL).
+uint32_t write_ime_text(uint64_t input_buffer, uint32_t max_len, const std::string& utf8);
+
+// UTF-16 (guest, host-endian) <-> UTF-8. u16_to_utf8 reads a NUL-terminated char16_t* at a guest addr.
+std::string u16_to_utf8(uint64_t u16ptr);
+// Append one UTF-8-encoded Unicode code point for `cp` (used to build strings from typed input).
+void utf8_append_cp(std::string& s, uint32_t cp);
 
 } // namespace prosper

--- a/prosper/frontends/dialog_sdl3/dialog_sdl3.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_sdl3.hpp
@@ -15,4 +15,9 @@ bool install_sdl3_platform_ui();
 // Uninstall (restore the headless default).
 void shutdown_sdl3_platform_ui();
 
+// Pump pending interactive UI on the MAIN thread — call once per frame from the app's event/present
+// loop. The ImeDialog text-entry modal (SDL windowing is main-thread only) runs here; MsgDialog/
+// ErrorDialog use SDL_ShowMessageBox directly and don't need it. Safe to call when nothing is pending.
+void sdl_platform_ui_pump();
+
 } // namespace prosper

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -9,6 +9,9 @@
 #include <SDL3/SDL.h>
 #include <atomic>
 #include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
 
 namespace prosper {
 namespace {
@@ -27,6 +30,50 @@ int show_box(uint32_t sdl_flags, const char* title, const char* msg, const MsgBu
     int clicked = -1;
     if (!SDL_ShowMessageBox(&d, &clicked)) { SDL_Log("prosper: SDL_ShowMessageBox failed: %s", SDL_GetError()); return -1; }
     return clicked;
+}
+
+// Run a modal text-entry window (MAIN thread only). Returns endStatus (0=OK, 1=CANCELED) and, on OK,
+// writes the entered text (UTF-16) into the request's guest input buffer (bounded by max_text_length).
+int run_ime_modal(const ImeRequest& req) {
+    SDL_Window* win = nullptr; SDL_Renderer* ren = nullptr;
+    const char* wtitle = req.title.empty() ? "prosper — text entry" : req.title.c_str();
+    if (!SDL_CreateWindowAndRenderer(wtitle, 560, 150, 0, &win, &ren)) {
+        SDL_Log("prosper: ime window failed: %s", SDL_GetError());
+        return 1;   // treat as cancel
+    }
+    SDL_StartTextInput(win);
+    std::string text = req.initial;
+    int endstatus = 1 /*USER_CANCELED*/;
+    bool done = false;
+    while (!done) {
+        SDL_Event ev;
+        while (SDL_PollEvent(&ev)) {
+            if (ev.type == SDL_EVENT_QUIT) { endstatus = 1; done = true; }
+            else if (ev.type == SDL_EVENT_TEXT_INPUT) { text += ev.text.text; }   // UTF-8; write bounds it
+            else if (ev.type == SDL_EVENT_KEY_DOWN) {
+                SDL_Keycode k = ev.key.key;
+                if (k == SDLK_RETURN || k == SDLK_KP_ENTER) { endstatus = 0 /*OK*/; done = true; }
+                else if (k == SDLK_ESCAPE) { endstatus = 1; done = true; }
+                else if (k == SDLK_BACKSPACE && !text.empty()) {           // pop one UTF-8 code point
+                    size_t n = text.size();
+                    do { n--; } while (n > 0 && ((unsigned char)text[n] & 0xC0) == 0x80);
+                    text.resize(n);
+                }
+            }
+        }
+        SDL_SetRenderDrawColor(ren, 28, 30, 40, 255); SDL_RenderClear(ren);
+        SDL_SetRenderDrawColor(ren, 225, 225, 230, 255);
+        SDL_RenderDebugText(ren, 12, 16, req.title.empty() ? "Enter text:" : req.title.c_str());
+        std::string shown = text + "_";
+        SDL_RenderDebugText(ren, 12, 52, shown.c_str());
+        SDL_RenderDebugText(ren, 12, 118, "Enter = OK     Esc = Cancel");
+        SDL_RenderPresent(ren);
+        SDL_Delay(8);
+    }
+    SDL_StopTextInput(win);
+    SDL_DestroyRenderer(ren); SDL_DestroyWindow(win);
+    if (endstatus == 0) write_ime_text(req.input_buffer, req.max_text_length, text);
+    return endstatus;
 }
 
 struct SdlPlatformUi : PlatformUi {
@@ -60,15 +107,49 @@ struct SdlPlatformUi : PlatformUi {
     int  errorDialogStatus() override { return err_status.load(); }
     void errorDialogClose() override { err_status.store(0); }
 
-    // imeDialog* left as the base default (returns false) -> the core's headless auto-complete, since a
-    // text-entry field is not a message box (a custom SDL text UI is a separate follow-up).
-
     // Ime keyboard presence: a windowed session runs on a host with a keyboard, so report one (#347).
     // This makes sceImeKeyboardGetResourceId/GetInfo report a connected keyboard, enabling a title's
     // keyboard-input option. (Delivering the raw key events to the guest handler is a further step.)
     int keyboardResourceIds(int32_t /*userId*/, uint32_t* outIds, int max) override {
         if (max >= 1 && outIds) { outIds[0] = 1; return 1; }
         return 0;
+    }
+
+    // ImeDialog (text entry). Cross-thread: the guest thread calls Open/Status/Result; the MAIN thread
+    // runs the actual SDL window (SDL windowing/events are main-thread only) when prosper-app calls
+    // sdl_platform_ui_pump() each frame. Open records the request + RUNNING; pump() shows the modal and
+    // sets FINISHED; the guest polls Status and then reads its input buffer (written before FINISHED).
+    std::mutex          ime_mx;
+    ImeRequest          ime_req{};
+    std::atomic<int>    ime_status{0 /*OrbisImeDialogStatus::None*/};
+    std::atomic<bool>   ime_pending{false};
+    std::atomic<int>    ime_endstatus{1 /*USER_CANCELED until confirmed*/};
+
+    bool imeDialogOpen(uint64_t param, uint64_t /*extended*/) override {
+        ImeRequest r = read_ime_request(param);
+        if (!r.input_buffer) return false;   // nothing to fill -> let the core headless-handle it
+        { std::lock_guard<std::mutex> lk(ime_mx); ime_req = r; }
+        ime_endstatus.store(1);
+        ime_status.store(1 /*Running*/);
+        ime_pending.store(true);
+        return true;
+    }
+    int  imeDialogStatus() override { return ime_status.load(); }
+    int  imeDialogResult(uint64_t result) override {
+        int es = ime_endstatus.load();
+        if (result) { uint32_t v = (uint32_t)es; std::memcpy((void*)(uintptr_t)result, &v, 4); }  // endstatus @0
+        return es;
+    }
+    void imeDialogClose() override { ime_pending.store(false); ime_status.store(0 /*None*/); }
+
+    // MAIN-thread: if a text dialog is pending, run its modal to completion (writes the guest buffer,
+    // then flips status to FINISHED so the guest's next poll — and its buffer read — see it).
+    void pump() {
+        if (!ime_pending.exchange(false)) return;
+        ImeRequest r; { std::lock_guard<std::mutex> lk(ime_mx); r = ime_req; }
+        int es = run_ime_modal(r);
+        ime_endstatus.store(es);
+        ime_status.store(2 /*Finished*/);
     }
 };
 
@@ -78,9 +159,10 @@ SdlPlatformUi g_sdl_ui;
 
 bool install_sdl3_platform_ui() {
     set_platform_ui(&g_sdl_ui);
-    SDL_Log("prosper: SDL3 dialog backend installed (MsgDialog/ErrorDialog -> SDL_ShowMessageBox)");
+    SDL_Log("prosper: SDL3 dialog backend installed (MsgDialog/ErrorDialog + ImeDialog text entry)");
     return true;
 }
 void shutdown_sdl3_platform_ui() { set_platform_ui(nullptr); }
+void sdl_platform_ui_pump() { g_sdl_ui.pump(); }
 
 } // namespace prosper

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -56,6 +56,40 @@ int main() {
     CHECK(read_error_code((uint64_t)(uintptr_t)ep) == 0x80AABBCC, "read_error_code: errorCode @4");
     CHECK(read_error_code(0) == 0, "read_error_code(NULL) -> 0 (no deref)");
 
+    // --- ImeDialog: read_ime_request from a synthetic OrbisImeDialogParam (96 bytes) ---
+    {
+        char16_t title[] = u"Enter name";
+        char16_t inbuf[32]; inbuf[0] = u'H'; inbuf[1] = u'i'; inbuf[2] = 0;
+        uint8_t iparam[96] = {};
+        uint32_t maxlen = 16;                    std::memcpy(iparam + 36, &maxlen, 4);   // max_text_length @36
+        uint64_t ibp = (uint64_t)(uintptr_t)inbuf; std::memcpy(iparam + 40, &ibp, 8);    // input_text_buffer @40
+        uint64_t tp  = (uint64_t)(uintptr_t)title; std::memcpy(iparam + 72, &tp, 8);     // title @72
+        ImeRequest r = read_ime_request((uint64_t)(uintptr_t)iparam);
+        CHECK(r.max_text_length == 16, "read_ime_request: max_text_length @36");
+        CHECK(r.input_buffer == ibp, "read_ime_request: input_text_buffer @40");
+        CHECK(r.title == "Enter name", "read_ime_request: title @72 (UTF-16 -> UTF-8)");
+        CHECK(r.initial == "Hi", "read_ime_request: initial text read from the input buffer");
+    }
+
+    // write_ime_text: bounded, NUL-terminated, never overruns max_len (+ the NUL slot).
+    {
+        char16_t buf[8]; for (auto& c : buf) c = 0xAAAA;
+        uint32_t n = write_ime_text((uint64_t)(uintptr_t)buf, 5, "Hello");
+        CHECK(n == 5 && buf[0] == u'H' && buf[4] == u'o' && buf[5] == 0, "write_ime_text: 'Hello' -> 5 units + NUL");
+        for (auto& c : buf) c = 0xAAAA;
+        n = write_ime_text((uint64_t)(uintptr_t)buf, 3, "Hello");
+        CHECK(n == 3 && buf[3] == 0 && buf[4] == 0xAAAA, "write_ime_text: clamps to max_len (no overrun past max_len+NUL)");
+        for (auto& c : buf) c = 0xAAAA;
+        n = write_ime_text((uint64_t)(uintptr_t)buf, 7, "caf\xC3\xA9");   // "café" (é = U+00E9)
+        CHECK(n == 4 && buf[3] == 0x00E9 && buf[4] == 0, "write_ime_text: multibyte UTF-8 é -> one UTF-16 unit");
+    }
+
+    // UTF-16 surrogate pair round-trips (U+1F600 grinning face).
+    {
+        char16_t emoji[] = { 0xD83D, 0xDE00, 0 };
+        CHECK(u16_to_utf8((uint64_t)(uintptr_t)emoji) == "\xF0\x9F\x98\x80", "u16_to_utf8: surrogate pair -> 4-byte UTF-8");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -417,6 +417,9 @@ int main(int argc, char** argv) {
         }
         if (!running) break;
         poll_keyboard();   // snapshot key state for the guest's pad reads
+#ifdef PROSPER_HAVE_DIALOG_SDL3
+        prosper::sdl_platform_ui_pump();   // run a pending ImeDialog text-entry modal on this (main) thread
+#endif
 
         static const uint32_t kPatW = 1920, kPatH = 1080;
         if (testPattern) feed_test_pattern(kPatW, kPatH, patFrame++);


### PR DESCRIPTION
Refs #347 — completes the interactive-dialog set. The guest's on-screen keyboard (ImeDialog) now collects **real text** in prosper-app instead of the headless empty-cancel.

> ⚠️ **Stacked on #356** (the ImeDialog status-enum fix, `Finished=2`). Merge #356 first; this PR's diff then reduces to just the text-entry commit.

## The two problems solved
1. **Threading** — a message box can't do text input, and SDL windowing/events are **main-thread only**, but the guest calls the dialog from its own thread. So this uses the polled state-machine the `PlatformUi` was designed for:
   - `imeDialogOpen` (guest thread) parses `OrbisImeDialogParam`, records the request, reports `RUNNING`.
   - `sdl_platform_ui_pump()` — called each frame from prosper-app's main loop — runs a **modal SDL text window** (`SDL_StartTextInput` + `SDL_RenderDebugText`, Enter=OK / Esc=Cancel / Backspace), writes the entered **UTF-16** into the guest input buffer (bounded), and flips status to `FINISHED` so the guest's next poll — and its buffer read — see it.
   - `imeDialogResult` writes the `endStatus`.
2. **Layout + encoding** — `OrbisImeDialogParam` offsets from shadPS4 (`input_text_buffer`@40, `max_text_length`@36, `title`@72) and a UTF-8↔UTF-16 converter (incl. surrogate pairs).

## Verifiability
The layout + encoding logic is **pure and unit-tested in normal CI** (`test_dialog_helpers`): `read_ime_request` at the verified offsets, `write_ime_text` **clamped to `max_len`** (proven not to overrun past the NUL slot), multibyte + surrogate-pair round-trips. Only the SDL modal is gated behind `PROSPER_APP`.

## Verification
- `test_dialog_helpers` — 8 new ImeDialog assertions (21 total). Full headless `ctest` **78/78**.
- SDL modal + pump **compiled and linked** into prosper-app under `-DPROSPER_APP=ON`.

## #347 — now essentially complete
- [x] Interface + ImeDialog routing (#349), MsgDialog/ErrorDialog routing (#351), SDL message boxes (#353)
- [x] **ImeDialog text entry (this PR)**
- [ ] Optional: Ime keyboard device presence (a frontend reporting a real/virtual keyboard) — minor leftover