### PR TITLE
feat(hle): Ime keyboard presence via the PlatformUi hook (#347)

### DIFF
--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -62,6 +62,14 @@ struct SdlPlatformUi : PlatformUi {
 
     // imeDialog* left as the base default (returns false) -> the core's headless auto-complete, since a
     // text-entry field is not a message box (a custom SDL text UI is a separate follow-up).
+
+    // Ime keyboard presence: a windowed session runs on a host with a keyboard, so report one (#347).
+    // This makes sceImeKeyboardGetResourceId/GetInfo report a connected keyboard, enabling a title's
+    // keyboard-input option. (Delivering the raw key events to the guest handler is a further step.)
+    int keyboardResourceIds(int32_t /*userId*/, uint32_t* outIds, int max) override {
+        if (max >= 1 && outIds) { outIds[0] = 1; return 1; }
+        return 0;
+    }
 };
 
 SdlPlatformUi g_sdl_ui;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -150,21 +150,34 @@ HLE(s_mouse_read)     { if (a1) memset(PW(a1), 0, 0x18); return 0; }
 HLE(s_ime_kbd_open) { svc_log("sceImeKeyboardOpen", a0,a1,a2,a3,a4,a5); return 0; }  // register handler; no events to deliver
 HLE(s_ime_update)   { svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5); return 0; }        // pump the queue: no events
 // sceImeKeyboardGetResourceId(userId, OrbisImeKeyboardResourceIdArray* out): report the user's keyboard
-// resource ids — none connected, so an all-zero id array (echoing the queried userId).
+// resource ids. Headless -> none (all-zero). A registered PlatformUi (a windowed frontend with a host
+// keyboard) reports its own ids, so a title enables keyboard input (#347).
 HLE(s_ime_kbd_resid) {
     svc_log("sceImeKeyboardGetResourceId", a0,a1,a2,a3,a4,a5);
     if (!a1) return 0x80BC0031ull;   // ORBIS_IME_ERROR_INVALID_ADDRESS
     uint8_t* p = (uint8_t*)PW(a1);
     *(int32_t*)(p + 0) = (int32_t)a0;                         // user_id echoes the caller
-    for (int i = 0; i < 5; i++) *(uint32_t*)(p + 4 + i * 4) = 0;   // no keyboards connected
+    uint32_t ids[5] = {0, 0, 0, 0, 0};
+    int n = 0;
+    if (auto* ui = platform_ui()) n = ui->keyboardResourceIds((int32_t)a0, ids, 5);
+    if (n < 0) n = 0; if (n > 5) n = 5;
+    for (int i = 0; i < 5; i++) *(uint32_t*)(p + 4 + i * 4) = (i < n) ? ids[i] : 0;
     return 0;
 }
-// sceImeKeyboardGetInfo(resourceId, OrbisImeKeyboardInfo* info): a disconnected (no-device) info.
+// sceImeKeyboardGetInfo(resourceId, OrbisImeKeyboardInfo* info): connected device info when a frontend
+// reports a keyboard, else a disconnected (no-device) info.
 HLE(s_ime_kbd_info) {
     svc_log("sceImeKeyboardGetInfo", a0,a1,a2,a3,a4,a5);
     if (!a1) return 0x80BC0031ull;   // ORBIS_IME_ERROR_INVALID_ADDRESS
-    memset(PW(a1), 0, 36);           // device=0 type=0 repeat=0 status=0(disconnected) reserved=0
-    *(int32_t*)PW(a1) = 1;           // user_id = default user (matches sceUserServiceGetInitialUser)
+    memset(PW(a1), 0, 36);           // default: device=0 type=0 repeat=0 status=0(disconnected)
+    uint8_t* p = (uint8_t*)PW(a1);
+    *(int32_t*)(p + 0) = 1;          // user_id = default user (matches sceUserServiceGetInitialUser)
+    bool connected = false;
+    if (auto* ui = platform_ui()) { uint32_t ids[5]; connected = ui->keyboardResourceIds(1, ids, 5) > 0; }
+    if (connected) {
+        *(uint32_t*)(p + 4)  = 1;    // device  = 1 (a keyboard is present)
+        *(uint32_t*)(p + 20) = 1;    // status  = 1 (connected)
+    }
     return 0;
 }
 

--- a/prosper/src/hle/platform_ui.hpp
+++ b/prosper/src/hle/platform_ui.hpp
@@ -49,6 +49,15 @@ struct PlatformUi {
     virtual bool errorDialogOpen(uint64_t param) { (void)param; return false; }
     virtual int  errorDialogStatus() { return 3 /*FINISHED*/; }
     virtual void errorDialogClose() {}
+
+    // --- libSceIme keyboard device presence ---
+    // Fill up to `max` connected keyboard resource ids for `userId` into `outIds`, and return the
+    // count. The headless default is 0 (no keyboard); a windowed frontend with a host keyboard reports
+    // its own (a resource id must be non-zero). sceImeKeyboardGetResourceId/GetInfo consult this so a
+    // title enables keyboard input only when a real keyboard is present.
+    virtual int keyboardResourceIds(int32_t userId, uint32_t* outIds, int max) {
+        (void)userId; (void)outIds; (void)max; return 0;
+    }
 };
 
 // The registered backend, or nullptr when headless. The frontend calls set_platform_ui once at startup

--- a/prosper/tests/test_ime_keyboard.cpp
+++ b/prosper/tests/test_ime_keyboard.cpp
@@ -3,12 +3,21 @@
 // info) rather than leaving the caller's structs uninitialized. Struct layouts mirror shadPS4
 // src/core/libraries/ime/ime_common.h (offsets asserted below).
 #include "../src/hle/dispatch.hpp"
+#include "../src/hle/platform_ui.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
 
 using namespace prosper;
+
+// A stand-in frontend that reports one connected keyboard (id 42) via the PlatformUi hook (#347).
+struct KbdUi : PlatformUi {
+    int keyboardResourceIds(int32_t /*userId*/, uint32_t* out, int max) override {
+        if (max >= 1 && out) { out[0] = 42; return 1; }
+        return 0;
+    }
+};
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
@@ -51,6 +60,23 @@ int main() {
     // Null out-pointer -> INVALID_ADDRESS, never a wild write.
     CHECK(resid(1, 0, 0, 0, 0, 0) == 0x80BC0031ull, "GetResourceId(NULL) -> INVALID_ADDRESS");
     CHECK(info(1, 0, 0, 0, 0, 0) == 0x80BC0031ull, "GetInfo(NULL) -> INVALID_ADDRESS");
+
+    // --- PlatformUi hook (#347): a registered frontend that reports a keyboard flips presence on. ---
+    KbdUi kbd; set_platform_ui(&kbd);
+    KbdResIds ids2; memset(&ids2, 0xAB, sizeof ids2);
+    resid(1, (uint64_t)(uintptr_t)&ids2, 0, 0, 0, 0);
+    CHECK(ids2.user_id == 1 && ids2.resource_id[0] == 42 && ids2.resource_id[1] == 0,
+          "backend: GetResourceId reports the frontend's keyboard (id 42) then zeros");
+    uint8_t buf2[40]; memset(buf2, 0xAB, sizeof buf2);
+    info(42 /*the reported id*/, (uint64_t)(uintptr_t)buf2, 0, 0, 0, 0);
+    KbdInfo* ki2 = (KbdInfo*)buf2;
+    CHECK(ki2->device == 1 && ki2->status == 1, "backend: GetInfo reports a CONNECTED keyboard (device/status = 1)");
+    CHECK(buf2[36] == 0xAB, "backend: GetInfo still bounded to 36 bytes");
+    set_platform_ui(nullptr);
+    // Back to headless: presence off again.
+    KbdResIds ids3; memset(&ids3, 0xAB, sizeof ids3);
+    resid(1, (uint64_t)(uintptr_t)&ids3, 0, 0, 0, 0);
+    CHECK(ids3.resource_id[0] == 0, "after unregister: GetResourceId reports no keyboards again");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Refs #347 — the last PlatformUi leftover. `sceImeKeyboardGetResourceId`/`GetInfo` reported "no keyboard" unconditionally (#186's headless default); now they consult a registered `PlatformUi`, so a windowed frontend on a host with a keyboard can report one and a title enables its keyboard-input option.

- `PlatformUi` gains `keyboardResourceIds(userId, outIds, max) -> count` (headless default 0).
- `sceImeKeyboardGetResourceId` fills the id array from the hook (bounded to 5); `sceImeKeyboardGetInfo` reports `device`/`status` = connected(1) when the hook reports any keyboard, else the disconnected default. Both stay **bounded** (`GetInfo` never writes past its 36-byte struct), and with **no backend** the behavior is byte-identical — so #186's headless test is unaffected.
- The SDL3 frontend reports one host keyboard (id 1).

Delivering the raw key **events** to the guest's Ime handler is a further step; this is the *presence* half (what the issue scoped).

## Verification
`test_ime_keyboard` gains a backend case (a mock reporting id 42 → `GetResourceId`/`GetInfo` report connected; unregister → none again). Full `ctest` **78/78**; the SDL frontend compiles with the new override.

This closes out the interactive-UI work on #347 (dialogs + text entry + keyboard presence); only raw keyboard-event delivery remains as an optional future step.