### PR TITLE
feat(gpu): WAIT_REG_MEM barrier model (per-address ordering + EOP visibility contract), opt-in — and the measured demolition of the #312 wait-ordering hypothesis (refs #312)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -211,6 +211,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_eop_write PRIVATE prosper_core)
   add_test(NAME eop_write COMMAND test_eop_write)
 
+  # #312 per-queue WAIT_REG_MEM barrier model: unsatisfied waits gate downstream memory effects,
+  # streams release independently, jumps don't un-gate, timeout backstop preserves liveness.
+  add_executable(test_wait_barrier tests/test_wait_barrier.cpp)
+  target_link_libraries(test_wait_barrier PRIVATE prosper_core)
+  add_test(NAME wait_barrier COMMAND test_wait_barrier)
+
   # Render-state extraction: fold a stream into a GpuState, then interpret RDNA2 registers.
   add_executable(test_render_state tests/test_render_state.cpp)
   target_link_libraries(test_render_state PRIVATE prosper_core)

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -7,6 +7,13 @@
 // flip does. The game's frame pacer polls that status for its submitted flipArg; a dropped in-stream
 // flip stalls the frame loop at one rendered frame.
 extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx, uint32_t flip_mode, int64_t flip_arg);
+// hle_kernel_time.cpp: fire the GPU EOP equeue events the game registered via sceGnmAddEqEvent.
+// The submit paths pulse at submit time; flush_deferred_streams pulses AGAIN when a deferred
+// stream's gated writes finally land (#312 barrier model) — an equeue waiter that consumed the
+// submit-time pulse, checked its still-gated label and went back to sleep would otherwise never
+// be woken (wake_on_label only wakes sync_on_address futex waiters, not equeue waiters; observed
+// live as DOLL's "GameThread timed out waiting for RenderThread after 120.00 secs" wedge).
+namespace prosper { void prosper_eq_trigger_eop(); }
 #include <cstdlib>
 #include <cstdint>
 #include <cstdio>
@@ -14,6 +21,7 @@ extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx, uint32
 #include <chrono>
 #include <atomic>
 #include <deque>
+#include <unordered_set>
 #include <condition_variable>
 #include <thread>
 
@@ -315,7 +323,7 @@ static void honor_write_data(const Pm4Command& c) {
 // PROSPER_EOP_WRITE_SYNC=1 restores the old synchronous writes (A/B lever + fallback).
 // CONFIDENCE: HIGH on the invariant (completion is post-submit by construction on real HW; Kyty
 // writes fences from its GPU thread, never inside the submit call). The cross-queue wait ordering
-// is handled by the per-queue WAIT_REG_MEM barrier model below (default ON).
+// is handled by the WAIT_REG_MEM barrier model below (opt-in, PROSPER_WAIT_DEFER=1).
 namespace {
 bool eop_write_sync() {
     static const bool v = [] { const char* e = getenv("PROSPER_EOP_WRITE_SYNC");
@@ -333,16 +341,29 @@ struct PendQueue {
     std::condition_variable cv;
     std::deque<PendWrite> q;
     bool worker_started = false;
+    int  inflight = 0;    // items popped but whose write hasn't landed yet (see drain)
 };
 PendQueue& pend_q() { static PendQueue* p = new PendQueue; return *p; }
 void apply_effect(const Pm4Command& c);   // fwd (defined with the WAIT_DEFER machinery below)
+// Drain returns only when every pending write has LANDED — including one a concurrent drainer
+// popped and is mid-applying (the in-flight window). Without that wait, a caller could observe an
+// empty queue and proceed to apply a LATER same-address write (a released #312 gated item) that
+// overtakes the in-flight one — the exact per-address inversion the barrier model exists to stop.
 void pend_drain_locked(PendQueue& p, std::unique_lock<std::mutex>& lk) {
-    while (!p.q.empty()) {
-        PendWrite w = std::move(p.q.front());
-        p.q.pop_front();
-        lk.unlock();                     // the write itself never needs the queue lock
-        apply_effect(w.cmd);
-        lk.lock();
+    for (;;) {
+        if (!p.q.empty()) {
+            PendWrite w = std::move(p.q.front());
+            p.q.pop_front();
+            p.inflight++;
+            lk.unlock();                 // the write itself never needs the queue lock
+            apply_effect(w.cmd);
+            lk.lock();
+            p.inflight--;
+            if (p.inflight == 0) p.cv.notify_all();
+            continue;
+        }
+        if (p.inflight == 0) break;
+        p.cv.wait(lk);                   // another drainer is mid-apply — wait for it to land
     }
 }
 void pend_worker() {
@@ -397,30 +418,74 @@ extern "C" void prosper_gpu_drain_completion_writes() {
 // ordering (PROSPER_WAIT_DEFER=1, 5/5) had ZERO corruption fatals; default runs stomped at
 // t=40-150 s.
 //
-// The model (DEFAULT ON; PROSPER_WAIT_DEFER=0 restores the old barrel-on behavior):
-//   - When a fold hits an UNSATISFIED wait, that stream becomes a PAUSED QUEUE TAIL: its remaining
-//     guest-visible memory effects (ReleaseMem / EVENT_WRITE / WRITE_DATA / DMA_DATA and any
-//     further waits) are deferred IN ORDER behind the barrier.
-//   - Each deferred stream is gated ONLY by its own barriers (per-queue independence): a blocked
-//     stream never head-of-line blocks another stream's release — on real hardware a paused queue
-//     doesn't stop the other queues, and the cross-queue producer that satisfies the barrier may
-//     itself be a later submit.
-//   - Streams are re-checked at every subsequent submit and by hle_agc's 2 ms watchdog ticker;
-//     effects release the moment their gating condition reads satisfied (the producer's own fence
-//     write — via the pipe-drain queue — or a CPU-written label).
+// VERDICT AFTER LIVE MEASUREMENT (2026-07-10, ~20 instrumented DOLL menu-drive runs, same build
+// A/B): the model is OPT-IN (PROSPER_WAIT_DEFER=1), not default. What the A/B showed:
+//   - Model ON eliminates the headline "MallocBinned3 Corruption Canary was 0x3" (Line 152)
+//     fatal: 0/6 model runs vs 2/2 barrel-on runs at t~70 s — the class the wait-ordering
+//     violation genuinely seeds.
+//   - BUT a SECOND, wait-order-INDEPENDENT corruption leg remains and dominates: a burst of ~96
+//     ReleaseMem(value=1) writes at t~10 s landing on labels whose qword reads 0x1000000000
+//     (producing the exact "free an unrecognized block 0x1000000001" fatal + the 0x20015f00
+//     pool-metadata-read crashes). It appears in EVERY config — barrel-on, full deferral with
+//     ZERO timeouts, PROSPER_NO_JUMP=1, and PROSPER_EOP_WRITE_SYNC=1 (labels are ptr-valued
+//     already AT FENCE BUILD TIME) — so no ordering/timing model of honest writes can remove it.
+//   - Under the burst, model-ON runs die EARLIER (t=15-45 s, worker-fault/free-unrecognized
+//     family) than barrel-on (t~70 s, canary) — deferral latency shifts guest timing into the
+//     already-injected corruption sooner. Net: defaulting ON buys no gameplay and costs run
+//     length, so the default stays barrel-on until the injection leg is found.
+//   - The historical "5/5 PROSPER_WAIT_DEFER=1 runs have zero corruption" evidence (issue #312)
+//     is CONFOUNDED: every one of those runs lost liveness within a minute (semi-frozen guest =
+//     no content-load burst = no corruption window). This session's liveness-correct model
+//     dissolves that isolation.
+//
+// The model (opt-in via PROSPER_WAIT_DEFER=1; default = the old barrel-on behavior):
+//   - prosper models ONE submission queue today: both driver entry points (sceAgcDriverSubmitDcb
+//     and the w1KFAHVqpaU final-submit variant) feed the same guest gfx ring — the guest's own
+//     SubmitCommandBuffers batch splits its buffer array across BOTH (RE'd at eboot+0x220a9a0),
+//     so they are one stream and MUST keep mutual order. Compute rides the same Dcb
+//     (DISPATCH_DIRECT inline). The only cross-queue producers are guest CPU label writes, which
+//     are never gated by us.
+//   - When a fold hits an UNSATISFIED wait, ITS stream pauses: the wait and this stream's
+//     remaining guest-visible memory effects (ReleaseMem / EVENT_WRITE / WRITE_DATA / DMA_DATA,
+//     and further waits) defer IN ORDER behind the barrier.
+//   - PER-ADDRESS ORDERING DOMAINS for later submits: while gated items are pending, a NEW fold's
+//     memory effect defers (in ring order, behind everything already gated) IFF it touches an
+//     address that already has a gated pending write — per-address write order is exactly what
+//     the guest's consumed-marker protocol observes (DmaData label:=0 / ReleaseMem label<-1 /
+//     poll==1 / free / realloc at the same recycled address), and letting a later write overtake
+//     a gated one at the same label swaps fence generations and re-seeds the #312 stomp (measured:
+//     run with full independence stomped with ZERO timeouts). Effects to untouched addresses FLOW
+//     — gating them recreated a CPU<->GPU circular stall (guest polls fence F gated behind barrier
+//     W; the guest write that would satisfy W happens after F's poll -> 1 s timeout cascade,
+//     measured as an early-boot wedge + violation stomps).
+//   - The gated tail releases in STRICT submission order (one FIFO), so every gated write lands
+//     in ring order; it is re-checked at every subsequent submit and by hle_agc's 2 ms watchdog
+//     ticker; the front barrier releases the moment it reads satisfied (a pend-queue fence write
+//     from an earlier submit, a flowing later fence, or a CPU-written label — real producers
+//     measured up to ~216 ms under load). Later same-queue writes to an awaited address are NOT
+//     gated by the wait itself: WAIT_REG_MEM polls memory, so a later write satisfying an earlier
+//     blocked wait matches hardware (the producer is another engine/queue/CPU from the ring's
+//     point of view).
 //   - NEVER gated (liveness, measured: gating these wedged every naive-pause run): draws/register
-//     state (touch no guest memory), the in-stream Flip and the submit's EOP equeue pulse (they
-//     drive the guest's frame pacer; on real HW they signal from other engines/queues).
+//     state (touch no guest memory) and the in-stream Flip (the frame pacer; on real HW the flip
+//     engine signals independently). The submit's EOP equeue PULSE follows the hardware
+//     visibility contract instead: immediate when no gated writes are pending, otherwise OWED and
+//     delivered when the tail drains — see submit_completion_pulse below (pulsing while gated
+//     writes were pending let the guest's completion scan free live label blocks: stomps with
+//     ZERO ordering violations, measured; withholding without ever re-firing wedged the
+//     RenderThread, also measured).
 //   - Liveness backstop: a barrier pending longer than defer_timeout_ms() (PROSPER_WAIT_TIMEOUT_MS,
-//     default 50) falls back to the old proceed-with-loud-log behavior, so a genuinely
+//     default 1000) falls back to the old proceed-with-loud-log behavior, so a genuinely
 //     never-written label (or a producer we fail to model) degrades to the pre-#312 state instead
-//     of wedging the queue — and a guest CPU-polling a deferred label waits at most one timeout.
+//     of wedging the queue. Every timeout is a dependency violation — the corruption mechanism —
+//     so the default is generous (50 ms measurably re-seeded the fatal via real-but-slow
+//     producers).
 // All of this runs under the caller's submit mutex (hle_agc g_agc_state_mu).
 // CONFIDENCE: HIGH on the wait semantics (Kyty/shadPS4 both block the queue's execution thread
 // until the condition holds — deferral-in-order is the synchronous-fold equivalent) and on the
-// corruption mechanism (live A/B above); MED on per-stream independence for SAME-queue
-// back-to-back submits (hardware would keep them ordered; the barrier conditions the guest itself
-// emits encode the cross-stream ordering it relies on, and the timeout bounds any residual skew).
+// single-queue strict-FIFO ordering (it is what the ring guarantees on hardware); MED on the
+// never-gated flip/EOP-pulse liveness exceptions (hardware would order them too, but gating them
+// deadlocks our synchronous fold — the re-pulse keeps the guest-observable protocol sound).
 namespace {
 bool wait_regmem_satisfied(const Pm4Command& c) {
     uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
@@ -450,26 +515,101 @@ std::vector<DeferredStream> g_deferred;   // paused queue tails; guarded by the 
 bool     g_fold_deferring = false;        // current fold hit an unsatisfied wait
 uint64_t g_defer_streams = 0, g_defer_timeouts = 0;
 size_t   g_defer_items = 0;               // total queued items across streams (memory guard)
-// 50 ms default: real producer fences satisfy the barrier within ~1 ms via the pend queue;
-// anything pending longer is a dependency we don't model — degrade fast instead of stalling the
-// stream half a second. Tunable for experiments (per-stream independence means a longer timeout
-// no longer slows the rest of the pipeline, only the blocked stream itself).
+// 1000 ms default. The timeout is the CORRUPTION knob, not a perf knob: every timeout is a
+// dependency violation (the pre-#312 corruption mechanism), so it must be rare — and under
+// per-stream independence a blocked stream stalls nothing but itself (EOP pulses, flips and all
+// other streams flow), so a generous value costs only latency on a genuinely-unmodeled
+// dependency. Measured on DOLL's menu content-load burst: at 50 ms the burst produced 8 timeouts
+// and the MallocBinned3 fatal returned (late producers — the guest CPU writes some of these
+// labels itself under heavy load); satisfied barriers otherwise cluster near ~1 ms via the pend
+// queue. Tunable via PROSPER_WAIT_TIMEOUT_MS.
 uint64_t defer_timeout_ms() {
     static const uint64_t v = [] {
         const char* e = getenv("PROSPER_WAIT_TIMEOUT_MS");
         long n = e ? strtol(e, nullptr, 0) : 0;
-        return n > 0 ? (uint64_t)n : 50ull; }();
+        return n > 0 ? (uint64_t)n : 1000ull; }();
     return v;
 }
 constexpr size_t   kDeferMaxStreams = 256;   // runaway guard: force-flush oldest beyond this
 constexpr size_t   kDeferMaxItems = 200000;  // memory guard (#312 WAIT_DEFER OOM): force-flush
 
+// Opt-in gate for the whole model (PROSPER_WAIT_DEFER=1). Default OFF = the pre-#312 barrel-on
+// behavior — see the measured verdict in the model block above for why this is not (yet) the
+// default: the model is semantically right and kills the canary-152 class, but the remaining
+// wait-order-independent injection makes deferral a net loss for DOLL run length today.
+bool defer_enabled() {
+    static const bool v = [] {
+        const char* e = getenv("PROSPER_WAIT_DEFER");
+        return e && strtol(e, nullptr, 0) != 0; }();
+    return v;
+}
+
+// --- Per-address ordering domains: which guest addresses currently have a GATED pending write.
+// Small writes (fence labels — the protocol-critical case) index by 8-byte granule in a hash set;
+// large fills (the 64 KiB DmaData chunk zero-fills) go in a range list. Entries accumulate while
+// the queue tail is non-empty and are cleared when it fully drains: a partial drain can leave
+// STALE entries, which only OVER-gates (an extra write joins the ordered tail — safe, order is
+// still exact; the tail drains within the watchdog cadence anyway).
+std::unordered_set<uint64_t> g_gated_granules;                 // addr >> 3
+std::vector<std::pair<uint64_t, uint64_t>> g_gated_ranges;     // [lo, hi)
+// The guest-memory span a command writes (0 bytes = writes nothing we track).
+void effect_span(const Pm4Command& c, uint64_t* addr, uint64_t* bytes) {
+    using K = Pm4Command::Kind;
+    switch (c.kind) {
+        case K::ReleaseMem: *addr = c.rel_addr;   *bytes = 8; break;
+        case K::EventWrite: *addr = c.event_addr; *bytes = 8; break;
+        case K::WriteData:  *addr = c.wd_addr;    *bytes = (uint64_t)c.wd_num * 4; break;
+        case K::DmaData:    *addr = c.dd_dst;     *bytes = c.dd_bytes; break;
+        default:            *addr = 0;            *bytes = 0; break;
+    }
+}
+void gated_register(const Pm4Command& c) {
+    uint64_t a = 0, n = 0;
+    effect_span(c, &a, &n);
+    if (!a || !n) return;
+    if (n <= 32) {
+        for (uint64_t g = a >> 3; g <= ((a + n - 1) >> 3); g++) g_gated_granules.insert(g);
+    } else {
+        g_gated_ranges.emplace_back(a, a + n);
+    }
+}
+bool addr_gated(uint64_t a, uint64_t n) {
+    if (!a || !n) return false;
+    if (!g_gated_granules.empty())
+        for (uint64_t g = a >> 3; g <= ((a + n - 1) >> 3); g++)
+            if (g_gated_granules.count(g)) return true;
+    for (const auto& r : g_gated_ranges)
+        if (a < r.second && r.first < a + n) return true;
+    return false;
+}
+bool effect_gated(const Pm4Command& c) {
+    uint64_t a = 0, n = 0;
+    effect_span(c, &a, &n);
+    return addr_gated(a, n);
+}
+
+// Should this command join the gated tail? Yes when its own fold is paused (everything downstream
+// of the fold's unsatisfied wait keeps stream order), or when it writes into an address domain
+// that already has a gated pending write (per-address ring order across folds).
+bool defer_gate(const Pm4Command& c) {
+    if (g_fold_deferring) return true;
+    if (g_deferred.empty()) return false;
+    return effect_gated(c);
+}
+
+bool g_fold_stream_open = false;   // current top-level fold already opened its deferred stream
 void defer_push(const Pm4Command& c) {
+    if (!g_fold_stream_open) {     // one deferred stream per fold that defers anything
+        g_deferred.emplace_back();
+        g_fold_stream_open = true;
+        g_defer_streams++;
+    }
     DeferItem it; it.cmd = c;
     if (c.kind == Pm4Command::Kind::WriteData && c.wd_data && c.wd_num) {
         it.wd_copy.assign(c.wd_data, c.wd_data + c.wd_num);   // cb memory may be recycled before flush
         it.cmd.wd_data = it.wd_copy.data();
     }
+    gated_register(it.cmd);
     g_deferred.back().items.push_back(std::move(it));
     g_defer_items++;
 }
@@ -515,18 +655,37 @@ void apply_deferred_effect(const Pm4Command& c) {
 bool last_fold_deferred() { return g_fold_deferring; }
 bool deferred_pending()   { return !g_deferred.empty(); }
 
+// --- EOP pulse visibility contract (#312, the decisive leg). -------------------------------------
+// On real hardware the EOP interrupt for a submission fires only after EVERYTHING before it in
+// the ring has executed — the guest's completion scan (AgcInterrupt -> cleanup, label sweeps,
+// frame-end label batch-free at eboot+0x220bd50) relies on it: when the interrupt arrives, every
+// fence write of that frame is visible. Firing the pulse while gated tail writes are still
+// pending lets the scan observe a half-retired frame, free live label blocks, and take the stomp
+// when the gated write lands — corruption WITHOUT any ordering violation among the writes
+// themselves (observed live: stomps with zero DEFER timeouts). So: a submit's pulse fires
+// immediately only when the gated tail is empty; otherwise it is OWED and fires when the tail
+// fully drains (flush below). Liveness: flips flow regardless, the 2 ms watchdog drains the tail
+// the moment its front barrier satisfies, and the timeout bounds a genuinely-stuck barrier.
+// CONFIDENCE: HIGH on the hardware contract (ring-ordered interrupt), MED that pulse-on-full-
+// drain (vs per-stream) is the right granularity — it only errs later, the safe direction.
+namespace { uint64_t g_owed_pulses = 0; }
+void submit_completion_pulse() {
+    if (!g_deferred.empty()) { g_owed_pulses++; return; }
+    prosper_eq_trigger_eop();
+}
+
 // Release deferred streams (call at every submit and from hle_agc's watchdog ticker, under the
-// submit mutex). PER-QUEUE INDEPENDENCE (#312): every stream is one paused queue tail, gated only
-// by ITS OWN next barrier — a blocked stream is skipped, never head-of-line blocking another
-// stream's release. Within a stream the items apply strictly in order (queue semantics). A barrier
+// submit mutex). STRICT QUEUE FIFO (#312): the deferred streams are the paused tail of prosper's
+// single submission queue — items apply strictly in submission order, and the front stream's
+// blocked barrier holds everything behind it (exactly the ring order hardware guarantees;
+// releasing later streams around a blocked one was measured to re-seed the corruption). A barrier
 // pending > defer_timeout_ms() proceeds with the pre-#312 "dependency violated" loud log (liveness
 // backstop). Returns how many streams fully completed.
 int flush_deferred_streams() {
     if (g_deferred.empty()) return 0;
-    // Intra-stream order: a stream's PRE-barrier writes ride the 1 ms pipe-drain queue while its
-    // post-barrier writes are applied here directly. Drain first so a released tail never
-    // overtakes its own head — and so a producer fence still sitting in the pend queue is visible
-    // to the barrier checks below.
+    // Intra-queue order: PRE-pause writes ride the 1 ms pipe-drain queue while gated writes are
+    // applied here directly. Drain first so a released tail never overtakes its own head — and so
+    // a producer fence still sitting in the pend queue is visible to the barrier checks below.
     prosper_gpu_drain_completion_writes();
     int completed = 0;
     for (size_t si = 0; si < g_deferred.size(); ) {
@@ -539,6 +698,19 @@ int flush_deferred_streams() {
                 // The label page can be unmapped by the time we re-check (freed mid-defer):
                 // treat as never-satisfiable and take the timeout path immediately.
                 bool readable = guest_readable(it.cmd.wm_addr, 8);
+                if (readable && it.first_blocked_ms && wait_regmem_satisfied(it.cmd)) {
+                    // Barrier-latency telemetry (bounded): how long do REAL producers take? This
+                    // is the data the timeout default is tuned against.
+                    uint64_t waited = defer_now_ms() - it.first_blocked_ms;
+                    if (waited > 20) {
+                        static std::atomic<int> n{0};
+                        int ln = n.fetch_add(1);
+                        if (ln < 32 || (ln & 511) == 0)
+                            fprintf(stderr, "[agc] WaitRegMem satisfied after %llums blocked: [0x%llx] ref=0x%llx\n",
+                                    (unsigned long long)waited, (unsigned long long)it.cmd.wm_addr,
+                                    (unsigned long long)it.cmd.wm_ref);
+                    }
+                }
                 if (!readable || !wait_regmem_satisfied(it.cmd)) {
                     uint64_t now = defer_now_ms();
                     if (!it.first_blocked_ms) it.first_blocked_ms = now;
@@ -562,10 +734,25 @@ int flush_deferred_streams() {
             apply_deferred_effect(it.cmd);
             s.next++;
         }
-        if (blocked) { si++; continue; }
+        if (blocked) break;   // strict FIFO: the front barrier holds the whole gated tail
         g_defer_items -= s.items.size() < g_defer_items ? s.items.size() : g_defer_items;
         g_deferred.erase(g_deferred.begin() + si);
         completed++;
+    }
+    if (g_deferred.empty()) {
+        // Address-domain index entries are added per gated item and only cleared here, on full
+        // drain (a partial drain leaves stale entries that merely over-gate — see the index note).
+        g_gated_granules.clear();
+        g_gated_ranges.clear();
+        // The tail is fully visible again: deliver every owed EOP pulse (one per submit whose
+        // pulse was withheld while gated writes were pending — see submit_completion_pulse).
+        // Distinct pulses, not coalesced (#236: a lost completion is a lost semaphore). This is
+        // also the re-pulse that wakes an equeue waiter which consumed an earlier pulse and found
+        // its label still gated (DOLL's "GameThread timed out waiting for RenderThread" wedge).
+        uint64_t owed = g_owed_pulses;
+        g_owed_pulses = 0;
+        if (!owed && completed > 0) owed = 1;   // deferral began before any pulse was owed
+        while (owed--) prosper_eq_trigger_eop();
     }
     return completed;
 }
@@ -679,19 +866,20 @@ void GpuState::apply(const Pm4Command& c) {
             break;
         }
         case K::ReleaseMem:
-            // EOP completion label write. Once this stream hit an unsatisfied wait, the write is
-            // deferred behind that barrier (see the #312 block above) — completing the fence
-            // early is what let the game free live label memory. Otherwise it goes through the
-            // pipe-drain queue: completion becomes guest-visible only after the submit returns.
-            if (g_fold_deferring) { defer_push(c); break; }
+            // EOP completion label write. While the queue is paused (this fold hit an unsatisfied
+            // wait, or an earlier submit's gated tail is still pending), the write queues behind
+            // the barrier IN RING ORDER (see the #312 block above) — completing a fence early is
+            // what let the game free live label memory. Otherwise it goes through the pipe-drain
+            // queue: completion becomes guest-visible only after the submit returns.
+            if (defer_gate(c)) { defer_push(c); break; }
             if (eop_write_sync()) honor_eop_write(c); else pend_enqueue(c);
             break;
         case K::WriteData:
-            if (g_fold_deferring) { defer_push(c); break; }
+            if (defer_gate(c)) { defer_push(c); break; }
             if (eop_write_sync()) honor_write_data(c); else pend_enqueue(c);
             break;
         case K::EventWrite:
-            if (g_fold_deferring) { defer_push(c); break; }
+            if (defer_gate(c)) { defer_push(c); break; }
             if (eop_write_sync()) honor_event_write(c); else pend_enqueue(c);
             break;
         case K::DmaData:
@@ -699,7 +887,7 @@ void GpuState::apply(const Pm4Command& c) {
             // as the other guest-visible writes: stream order between a generation's ReleaseMem
             // (label <- 1) and the NEXT generation's DmaData (label := 0) at the same recycled
             // address is exactly what the guest's consumption poll depends on.
-            if (g_fold_deferring) { defer_push(c); break; }
+            if (defer_gate(c)) { defer_push(c); break; }
             if (eop_write_sync()) honor_dma_data(c); else pend_enqueue(c);
             break;
         case K::WaitRegMem:
@@ -708,19 +896,23 @@ void GpuState::apply(const Pm4Command& c) {
             // at subsequent submits by flush_deferred_streams; loud timeout fallback preserves
             // liveness). A satisfied wait is a no-op, as before.
             if (c.wm_valid && c.wm_addr && !(c.wm_addr & 3)) {
-                if (g_fold_deferring) { defer_push(c); break; }   // ordered behind the first barrier
+                // Own fold already paused — the wait keeps stream order. OR: the awaited address
+                // has a GATED PENDING WRITE (an earlier-in-ring write it must observe): evaluating
+                // now against the stale value could wrong-satisfy — join the tail in ring order.
+                // (The rest of this fold's effects then gate too: stream order.)
+                if (g_fold_deferring || (!g_deferred.empty() && addr_gated(c.wm_addr, 8))) {
+                    g_fold_deferring = true;
+                    defer_push(c);
+                    break;
+                }
                 // A prior submit's fence write may still sit in the pipe-drain queue — a consumer's
                 // wait must see it (data dependency): drain before evaluating.
                 prosper_gpu_drain_completion_writes();
                 if (!wait_regmem_satisfied(c)) {
-                    // Per-queue barrier model (#312), DEFAULT ON: pause this queue — defer the
-                    // stream's remaining memory effects until the condition holds (see the model
-                    // block above; A/B: 5/5 zero-corruption with deferral vs ~80% fatal without).
-                    // PROSPER_WAIT_DEFER=0 restores the old barrel-on ("dependency violated")
-                    // behavior — the escape hatch.
-                    static const bool defer_on = [] {
-                        const char* e = getenv("PROSPER_WAIT_DEFER");
-                        return !(e && strtol(e, nullptr, 0) == 0); }();
+                    // Barrier model (#312), opt-in via PROSPER_WAIT_DEFER=1: pause the queue —
+                    // everything downstream defers until the condition holds (see the model
+                    // block above, including the measured verdict on why this is not default).
+                    // Default: the old barrel-on ("dependency violated") behavior.
                     // Bounded diagnostic (an unsatisfied wait is now NORMAL, handled state — and
                     // under the content-load burst it fires thousands of times a minute).
                     static std::atomic<int> logged{0};
@@ -733,18 +925,14 @@ void GpuState::apply(const Pm4Command& c) {
                         fprintf(stderr, "[agc] WaitRegMem #%d NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s\n",
                                 ln, (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
                                 (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
-                                defer_on ? "pausing queue (deferred effects)" : "dependency violated",
+                                defer_enabled() ? "pausing queue (deferred effects)" : "dependency violated",
                                 (unsigned long long)bt, have ? (long long)(now_ms() - bt) : -1,
                                 (have && baddr != c.wm_addr) ? " TARGET-CHANGED" : "",
                                 (unsigned long long)bpre, ptr_like(mem) ? " CONTENT-PTR-LIKE(freed?)" : "");
                     }
-                    if (defer_on) {
+                    if (defer_enabled()) {
                         g_fold_deferring = true;
-                        g_defer_streams++;
-                        g_deferred.emplace_back();
-                        DeferItem it; it.cmd = c; it.first_blocked_ms = defer_now_ms();
-                        g_deferred.back().items.push_back(std::move(it));
-                        g_defer_items++;
+                        defer_push(c);
                     }
                 }
             }
@@ -826,13 +1014,14 @@ void GpuState::apply(const Pm4Command& c) {
 }
 
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
-    // Each TOP-LEVEL stream starts unpaused (#312 queue-pause state is per-fold). A Jump recursion
-    // must NOT reset the flag: the jump target executes INSIDE the paused stream, and resetting
-    // mid-stream both un-gated the parent's remaining effects (ordering break) and made
-    // last_fold_deferred() read false at submit end, so hle_agc never started the release watchdog
-    // — the observed WAIT_DEFER wedge with zero DEFER-TIMEOUT logs (a deferred stream nobody ever
-    // re-checked while the guest CPU-polled one of its labels).
-    if (st.jump_depth == 0) g_fold_deferring = false;
+    // Each TOP-LEVEL stream starts a fresh fold state (#312: the pause flag and the lazily-opened
+    // deferred stream are per-fold). A Jump recursion must NOT reset them: the jump target
+    // executes INSIDE the paused stream, and resetting mid-stream both un-gated the parent's
+    // remaining effects (ordering break) and made last_fold_deferred() read false at submit end,
+    // so hle_agc never started the release watchdog — the observed WAIT_DEFER wedge with zero
+    // DEFER-TIMEOUT logs (a deferred stream nobody ever re-checked while the guest CPU-polled one
+    // of its labels).
+    if (st.jump_depth == 0) { g_fold_deferring = false; g_fold_stream_open = false; }
     std::vector<Pm4Command> ops;
     decode_pm4(buf, dwords, ops);
     for (const auto& c : ops) st.apply(c);

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -314,9 +314,8 @@ static void honor_write_data(const Pm4Command& c) {
 //   - the EOP-event worker drains before posting (an event must never overtake its data writes).
 // PROSPER_EOP_WRITE_SYNC=1 restores the old synchronous writes (A/B lever + fallback).
 // CONFIDENCE: HIGH on the invariant (completion is post-submit by construction on real HW; Kyty
-// writes fences from its GPU thread, never inside the submit call); MED that this closes ALL of
-// #312 (the cross-queue wait-ordering approximation remains, gated separately behind
-// PROSPER_WAIT_DEFER).
+// writes fences from its GPU thread, never inside the submit call). The cross-queue wait ordering
+// is handled by the per-queue WAIT_REG_MEM barrier model below (default ON).
 namespace {
 bool eop_write_sync() {
     static const bool v = [] { const char* e = getenv("PROSPER_EOP_WRITE_SYNC");
@@ -382,33 +381,46 @@ extern "C" void prosper_gpu_drain_completion_writes() {
     pend_drain_locked(p, lk);
 }
 
-// --- WAIT_REG_MEM queue-pause semantics (issue #312 heap-corruption root cause). -----------------
+// --- WAIT_REG_MEM per-queue barrier model (issue #312 heap-corruption root cause). ---------------
 //
-// On real hardware WAIT_REG_MEM BLOCKS the queue until its condition holds; packets after it —
+// On real hardware WAIT_REG_MEM BLOCKS its queue until its condition holds; packets after it —
 // including the RELEASE_MEM fence the game polls — execute only once the dependency is satisfied.
-// Our fold is synchronous at submit time, and DOLL's UE4 RHI submits from two guest threads, so a
-// consumer Dcb (wait label==1, then EOP fence write) routinely arrives BEFORE its producer (the
-// Dcb whose RELEASE_MEM writes that label). The old fold logged "dependency violated" and barreled
-// on: the consumer's fence completed early, the game freed the heap block holding the transient
-// semaphore label, and the producer's later RELEASE_MEM value-1 write landed on the freed
-// MallocBinned3 FFreeBlock header — the "Canary was 0x3, should be 0x1" / "free an unrecognized
-// block 0x1000000001" fatals (a 4-byte 0x1 stomp over NextFreeBlock; attributed live by the GPU
-// write-ring: 13 ReleaseMem value-1 writes at exactly the corrupted qword's address).
+// Other queues keep running while one is paused. Our fold is synchronous at submit time, and
+// DOLL's UE4 RHI submits from two guest threads, so a consumer Dcb (wait label==1, then EOP fence
+// write) routinely arrives BEFORE its producer (the Dcb whose RELEASE_MEM writes that label). The
+// old fold logged "dependency violated" and barreled on: the consumer's fence completed early, the
+// game freed the heap block holding the transient semaphore label, and the producer's later
+// RELEASE_MEM value-1 write landed on the freed MallocBinned3 FFreeBlock header — the "Canary was
+// 0x3, should be 0x1" / "free an unrecognized block 0x1000000001" fatals (a 4-byte 0x1 stomp over
+// NextFreeBlock; attributed live by the GPU write-ring: 13 ReleaseMem value-1 writes at exactly
+// the corrupted qword's address). A/B evidence (issue #312): every run that honored the barrier
+// ordering (PROSPER_WAIT_DEFER=1, 5/5) had ZERO corruption fatals; default runs stomped at
+// t=40-150 s.
 //
-// Honest semantics with a synchronous fold: when a fold hits an UNSATISFIED wait, the rest of that
-// stream's guest-visible memory effects (ReleaseMem / EVENT_WRITE / WRITE_DATA / Flip and any
-// further waits) are DEFERRED in order. Deferred streams are flushed FIFO at every subsequent
-// submit (the producer's own fold is what satisfies the barrier; a CPU-written label is re-checked
-// at the same points), and the submit's EOP equeue pulse fires only when its stream fully flushes.
-// Draws/register state still fold immediately — they touch no guest memory, so they cannot corrupt
-// (worst case is the same rendering-order approximation as before). Liveness: a barrier pending
-// longer than kDeferTimeoutMs falls back to the old proceed-with-loud-log behavior, so a genuinely
-// never-written label (or a producer we fail to model) degrades to today's state instead of
-// wedging the queue. All of this runs under the caller's submit mutex (hle_agc g_agc_state_mu).
-// CONFIDENCE: HIGH on the mechanism + the wait semantics; MED on cross-stream write ordering while
-// a stream is deferred (independent queues on real HW run concurrently, so a later submit's
-// effects landing before a paused stream's tail matches hardware; same-queue back-to-back submits
-// would be reordered, which hardware forbids — accepted, logged, and bounded by the timeout).
+// The model (DEFAULT ON; PROSPER_WAIT_DEFER=0 restores the old barrel-on behavior):
+//   - When a fold hits an UNSATISFIED wait, that stream becomes a PAUSED QUEUE TAIL: its remaining
+//     guest-visible memory effects (ReleaseMem / EVENT_WRITE / WRITE_DATA / DMA_DATA and any
+//     further waits) are deferred IN ORDER behind the barrier.
+//   - Each deferred stream is gated ONLY by its own barriers (per-queue independence): a blocked
+//     stream never head-of-line blocks another stream's release — on real hardware a paused queue
+//     doesn't stop the other queues, and the cross-queue producer that satisfies the barrier may
+//     itself be a later submit.
+//   - Streams are re-checked at every subsequent submit and by hle_agc's 2 ms watchdog ticker;
+//     effects release the moment their gating condition reads satisfied (the producer's own fence
+//     write — via the pipe-drain queue — or a CPU-written label).
+//   - NEVER gated (liveness, measured: gating these wedged every naive-pause run): draws/register
+//     state (touch no guest memory), the in-stream Flip and the submit's EOP equeue pulse (they
+//     drive the guest's frame pacer; on real HW they signal from other engines/queues).
+//   - Liveness backstop: a barrier pending longer than defer_timeout_ms() (PROSPER_WAIT_TIMEOUT_MS,
+//     default 50) falls back to the old proceed-with-loud-log behavior, so a genuinely
+//     never-written label (or a producer we fail to model) degrades to the pre-#312 state instead
+//     of wedging the queue — and a guest CPU-polling a deferred label waits at most one timeout.
+// All of this runs under the caller's submit mutex (hle_agc g_agc_state_mu).
+// CONFIDENCE: HIGH on the wait semantics (Kyty/shadPS4 both block the queue's execution thread
+// until the condition holds — deferral-in-order is the synchronous-fold equivalent) and on the
+// corruption mechanism (live A/B above); MED on per-stream independence for SAME-queue
+// back-to-back submits (hardware would keep them ordered; the barrier conditions the guest itself
+// emits encode the cross-stream ordering it relies on, and the timeout bounds any residual skew).
 namespace {
 bool wait_regmem_satisfied(const Pm4Command& c) {
     uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
@@ -434,14 +446,21 @@ struct DeferItem {
     uint64_t first_blocked_ms = 0;     // barrier only: when it was first found unsatisfied
 };
 struct DeferredStream { std::vector<DeferItem> items; size_t next = 0; };
-std::vector<DeferredStream> g_deferred;   // FIFO; guarded by the caller's submit mutex
+std::vector<DeferredStream> g_deferred;   // paused queue tails; guarded by the caller's submit mutex
 bool     g_fold_deferring = false;        // current fold hit an unsatisfied wait
 uint64_t g_defer_streams = 0, g_defer_timeouts = 0;
 size_t   g_defer_items = 0;               // total queued items across streams (memory guard)
-// 50 ms: real producer fences satisfy the barrier within ~1 ms via the pend queue; anything
-// pending longer is a dependency we don't model — degrade fast instead of stalling the stream
-// half a second (the 500 ms value made a WAIT_DEFER boot crawl at 2 submits/s).
-constexpr uint64_t kDeferTimeoutMs = 50;
+// 50 ms default: real producer fences satisfy the barrier within ~1 ms via the pend queue;
+// anything pending longer is a dependency we don't model — degrade fast instead of stalling the
+// stream half a second. Tunable for experiments (per-stream independence means a longer timeout
+// no longer slows the rest of the pipeline, only the blocked stream itself).
+uint64_t defer_timeout_ms() {
+    static const uint64_t v = [] {
+        const char* e = getenv("PROSPER_WAIT_TIMEOUT_MS");
+        long n = e ? strtol(e, nullptr, 0) : 0;
+        return n > 0 ? (uint64_t)n : 50ull; }();
+    return v;
+}
 constexpr size_t   kDeferMaxStreams = 256;   // runaway guard: force-flush oldest beyond this
 constexpr size_t   kDeferMaxItems = 200000;  // memory guard (#312 WAIT_DEFER OOM): force-flush
 
@@ -466,42 +485,86 @@ void apply_effect(const Pm4Command& c) {
         default: break;
     }
 }
+// The guest-memory span a deferred effect writes (0 = none / self-guarded). A deferred effect can
+// be released tens of ms after its fold; guard against the guest having unmapped the target in the
+// window (MallocBinned3 decommits pool pages) — the fold-time path writes "immediately" and never
+// needed this. honor_dma_data() range-checks itself.
+uint64_t effect_target(const Pm4Command& c, uint32_t* bytes) {
+    using K = Pm4Command::Kind;
+    switch (c.kind) {
+        case K::ReleaseMem: *bytes = 8; return c.rel_addr;
+        case K::EventWrite: *bytes = 8; return c.event_addr;
+        case K::WriteData:  *bytes = c.wd_num * 4; return c.wd_addr;
+        default: *bytes = 0; return 0;
+    }
+}
+void apply_deferred_effect(const Pm4Command& c) {
+    uint32_t bytes = 0;
+    uint64_t t = effect_target(c, &bytes);
+    if (t && bytes && !guest_readable(t, bytes)) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 24)
+            fprintf(stderr, "[agc] deferred effect target unmapped — write SKIPPED: kind=%u addr=0x%llx bytes=%u\n",
+                    (unsigned)c.kind, (unsigned long long)t, bytes);
+        return;
+    }
+    apply_effect(c);
+}
 } // namespace
 
 bool last_fold_deferred() { return g_fold_deferring; }
+bool deferred_pending()   { return !g_deferred.empty(); }
 
-// Flush deferred streams FIFO. Returns how many streams COMPLETED (the caller owes one EOP equeue
-// pulse per completed stream). A stream whose next barrier is still unsatisfied blocks the flush
-// (strict FIFO among deferred effects) unless it has been pending > kDeferTimeoutMs, in which case
-// it proceeds with the pre-#312 "dependency violated" loud log.
+// Release deferred streams (call at every submit and from hle_agc's watchdog ticker, under the
+// submit mutex). PER-QUEUE INDEPENDENCE (#312): every stream is one paused queue tail, gated only
+// by ITS OWN next barrier — a blocked stream is skipped, never head-of-line blocking another
+// stream's release. Within a stream the items apply strictly in order (queue semantics). A barrier
+// pending > defer_timeout_ms() proceeds with the pre-#312 "dependency violated" loud log (liveness
+// backstop). Returns how many streams fully completed.
 int flush_deferred_streams() {
+    if (g_deferred.empty()) return 0;
+    // Intra-stream order: a stream's PRE-barrier writes ride the 1 ms pipe-drain queue while its
+    // post-barrier writes are applied here directly. Drain first so a released tail never
+    // overtakes its own head — and so a producer fence still sitting in the pend queue is visible
+    // to the barrier checks below.
+    prosper_gpu_drain_completion_writes();
     int completed = 0;
-    while (!g_deferred.empty()) {
-        DeferredStream& s = g_deferred.front();
+    for (size_t si = 0; si < g_deferred.size(); ) {
+        DeferredStream& s = g_deferred[si];
         bool blocked = false;
         bool force = g_deferred.size() > kDeferMaxStreams || g_defer_items > kDeferMaxItems;
         while (s.next < s.items.size()) {
             DeferItem& it = s.items[s.next];
             if (it.cmd.kind == Pm4Command::Kind::WaitRegMem) {
-                if (!wait_regmem_satisfied(it.cmd)) {
+                // The label page can be unmapped by the time we re-check (freed mid-defer):
+                // treat as never-satisfiable and take the timeout path immediately.
+                bool readable = guest_readable(it.cmd.wm_addr, 8);
+                if (!readable || !wait_regmem_satisfied(it.cmd)) {
                     uint64_t now = defer_now_ms();
                     if (!it.first_blocked_ms) it.first_blocked_ms = now;
-                    if (!force && now - it.first_blocked_ms < kDeferTimeoutMs) { blocked = true; break; }
+                    if (readable && !force && now - it.first_blocked_ms < defer_timeout_ms()) {
+                        blocked = true; break;
+                    }
                     g_defer_timeouts++;
-                    fprintf(stderr, "[agc] WaitRegMem DEFER TIMEOUT after %llums: [0x%llx]&0x%llx func=%u ref=0x%llx — dependency violated (proceeding)\n",
-                            (unsigned long long)(now - it.first_blocked_ms),
-                            (unsigned long long)it.cmd.wm_addr, (unsigned long long)it.cmd.wm_mask,
-                            it.cmd.wm_func, (unsigned long long)it.cmd.wm_ref);
+                    static std::atomic<int> logged{0};
+                    int ln = logged.fetch_add(1);
+                    if (ln < 64 || (ln & 255) == 0)
+                        fprintf(stderr, "[agc] WaitRegMem DEFER TIMEOUT #%llu after %llums: [0x%llx]&0x%llx func=%u ref=0x%llx%s — dependency violated (proceeding)\n",
+                                (unsigned long long)g_defer_timeouts,
+                                (unsigned long long)(now - it.first_blocked_ms),
+                                (unsigned long long)it.cmd.wm_addr, (unsigned long long)it.cmd.wm_mask,
+                                it.cmd.wm_func, (unsigned long long)it.cmd.wm_ref,
+                                readable ? "" : " (label UNMAPPED)");
                 }
                 s.next++;
                 continue;
             }
-            apply_effect(it.cmd);
+            apply_deferred_effect(it.cmd);
             s.next++;
         }
-        if (blocked) break;
+        if (blocked) { si++; continue; }
         g_defer_items -= s.items.size() < g_defer_items ? s.items.size() : g_defer_items;
-        g_deferred.erase(g_deferred.begin());
+        g_deferred.erase(g_deferred.begin() + si);
         completed++;
     }
     return completed;
@@ -650,32 +713,38 @@ void GpuState::apply(const Pm4Command& c) {
                 // wait must see it (data dependency): drain before evaluating.
                 prosper_gpu_drain_completion_writes();
                 if (!wait_regmem_satisfied(c)) {
-                    uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
-                    // PROSPER_WAIT_DEFER=1 (experimental): pause the queue — defer the stream's
-                    // remaining memory effects until the condition holds. Default OFF: label
-                    // slots are recycled with residue frequently equal to the awaited value, so
-                    // value-based gating cannot distinguish a satisfied wait from stale residue
-                    // (measured live: enabling it moved the #312 fatal EARLIER). Kept for
-                    // experiments while the real per-queue model is built.
+                    // Per-queue barrier model (#312), DEFAULT ON: pause this queue — defer the
+                    // stream's remaining memory effects until the condition holds (see the model
+                    // block above; A/B: 5/5 zero-corruption with deferral vs ~80% fatal without).
+                    // PROSPER_WAIT_DEFER=0 restores the old barrel-on ("dependency violated")
+                    // behavior — the escape hatch.
                     static const bool defer_on = [] {
                         const char* e = getenv("PROSPER_WAIT_DEFER");
-                        return e && strtol(e, nullptr, 0) != 0; }();
-                    // #312 discriminator: build-journal age + freed-heap-shaped label content.
-                    uint64_t baddr = 0, bpre = 0, bt = 0;
-                    int have = prosper_fence_journal_lookup(pkt_addr(c), &baddr, &bpre, &bt);
-                    fprintf(stderr, "[agc] WaitRegMem NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s\n",
-                            (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
-                            (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
-                            defer_on ? "pausing queue (deferred effects)" : "dependency violated",
-                            (unsigned long long)bt, have ? (long long)(now_ms() - bt) : -1,
-                            (have && baddr != c.wm_addr) ? " TARGET-CHANGED" : "",
-                            (unsigned long long)bpre, ptr_like(mem) ? " CONTENT-PTR-LIKE(freed?)" : "");
+                        return !(e && strtol(e, nullptr, 0) == 0); }();
+                    // Bounded diagnostic (an unsatisfied wait is now NORMAL, handled state — and
+                    // under the content-load burst it fires thousands of times a minute).
+                    static std::atomic<int> logged{0};
+                    int ln = logged.fetch_add(1);
+                    if (ln < 40 || (ln & 1023) == 0) {
+                        uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
+                        // #312 discriminator: build-journal age + freed-heap-shaped label content.
+                        uint64_t baddr = 0, bpre = 0, bt = 0;
+                        int have = prosper_fence_journal_lookup(pkt_addr(c), &baddr, &bpre, &bt);
+                        fprintf(stderr, "[agc] WaitRegMem #%d NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s\n",
+                                ln, (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
+                                (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
+                                defer_on ? "pausing queue (deferred effects)" : "dependency violated",
+                                (unsigned long long)bt, have ? (long long)(now_ms() - bt) : -1,
+                                (have && baddr != c.wm_addr) ? " TARGET-CHANGED" : "",
+                                (unsigned long long)bpre, ptr_like(mem) ? " CONTENT-PTR-LIKE(freed?)" : "");
+                    }
                     if (defer_on) {
                         g_fold_deferring = true;
                         g_defer_streams++;
                         g_deferred.emplace_back();
                         DeferItem it; it.cmd = c; it.first_blocked_ms = defer_now_ms();
                         g_deferred.back().items.push_back(std::move(it));
+                        g_defer_items++;
                     }
                 }
             }
@@ -757,7 +826,13 @@ void GpuState::apply(const Pm4Command& c) {
 }
 
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
-    g_fold_deferring = false;   // each stream starts unpaused (#312 queue-pause state is per-fold)
+    // Each TOP-LEVEL stream starts unpaused (#312 queue-pause state is per-fold). A Jump recursion
+    // must NOT reset the flag: the jump target executes INSIDE the paused stream, and resetting
+    // mid-stream both un-gated the parent's remaining effects (ordering break) and made
+    // last_fold_deferred() read false at submit end, so hle_agc never started the release watchdog
+    // — the observed WAIT_DEFER wedge with zero DEFER-TIMEOUT logs (a deferred stream nobody ever
+    // re-checked while the guest CPU-polled one of its labels).
+    if (st.jump_depth == 0) g_fold_deferring = false;
     std::vector<Pm4Command> ops;
     decode_pm4(buf, dwords, ops);
     for (const auto& c : ops) st.apply(c);

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -87,18 +87,28 @@ private:
 // Decode `dwords` dwords at `buf` and apply every op to `st`. Returns the number of packets applied.
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st);
 
-// WAIT_REG_MEM per-queue barrier model, DEFAULT ON (issue #312 — see the block comment in
-// command_processor.cpp; PROSPER_WAIT_DEFER=0 is the escape hatch back to barrel-on semantics).
+// WAIT_REG_MEM barrier model, OPT-IN via PROSPER_WAIT_DEFER=1 (issue #312 — see the block
+// comment in command_processor.cpp, including the measured verdict on why it is not default:
+// it eliminates the canary-152 wait-ordering corruption class but a second, order-independent
+// injection remains and deferral latency makes DOLL menu-drive runs die earlier overall).
 // last_fold_deferred(): the most recent top-level run_command_buffer hit an unsatisfied wait, so
 // its remaining memory effects are gated behind that barrier in a deferred stream.
 // deferred_pending(): one or more deferred streams still hold gated effects — the caller must
 // ensure a re-check cadence exists (hle_agc's 2 ms watchdog) so a satisfied/timed-out barrier
 // releases even if the guest never submits again.
-// flush_deferred_streams(): re-check every deferred stream independently (call at every submit,
-// under the same submit mutex as run_command_buffer); returns how many streams fully completed.
+// flush_deferred_streams(): release the queue's gated tail in strict submission order (call at
+// every submit, under the same submit mutex as run_command_buffer); returns how many streams
+// fully completed, and re-fires the EOP equeue pulse when any did.
 bool last_fold_deferred();
 bool deferred_pending();
 int  flush_deferred_streams();
+// submit_completion_pulse(): fire the submit's GPU-EOP equeue pulse — immediately when no gated
+// writes are pending, else OWED and delivered when the gated tail drains (the hardware contract:
+// the EOP interrupt fires only after everything before it in the ring executed; pulsing earlier
+// lets the guest's completion scan free label blocks our gated writes then stomp — see the
+// visibility-contract block in command_processor.cpp). Call instead of prosper_eq_trigger_eop
+// from the submit paths, under the submit mutex.
+void submit_completion_pulse();
 
 } // namespace prosper::gpu
 

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -87,13 +87,17 @@ private:
 // Decode `dwords` dwords at `buf` and apply every op to `st`. Returns the number of packets applied.
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st);
 
-// WAIT_REG_MEM queue-pause support (issue #312 — see the block comment in command_processor.cpp).
-// last_fold_deferred(): the most recent run_command_buffer hit an unsatisfied wait, so its
-// remaining memory effects (and its EOP equeue pulse) are pending in the deferred FIFO.
-// flush_deferred_streams(): re-check the FIFO (call at every submit, under the same submit mutex
-// as run_command_buffer); returns how many deferred streams COMPLETED — the caller owes one EOP
-// equeue pulse per completed stream.
+// WAIT_REG_MEM per-queue barrier model, DEFAULT ON (issue #312 — see the block comment in
+// command_processor.cpp; PROSPER_WAIT_DEFER=0 is the escape hatch back to barrel-on semantics).
+// last_fold_deferred(): the most recent top-level run_command_buffer hit an unsatisfied wait, so
+// its remaining memory effects are gated behind that barrier in a deferred stream.
+// deferred_pending(): one or more deferred streams still hold gated effects — the caller must
+// ensure a re-check cadence exists (hle_agc's 2 ms watchdog) so a satisfied/timed-out barrier
+// releases even if the guest never submits again.
+// flush_deferred_streams(): re-check every deferred stream independently (call at every submit,
+// under the same submit mutex as run_command_buffer); returns how many streams fully completed.
 bool last_fold_deferred();
+bool deferred_pending();
 int  flush_deferred_streams();
 
 } // namespace prosper::gpu

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -953,12 +953,12 @@ extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws) {
 }
 
 namespace {
-// PROSPER_WAIT_DEFER watchdog (#312): deferred streams were only re-checked at SUBSEQUENT submits,
-// but a guest that waits for a deferred stream's EOP before submitting again deadlocks (observed:
-// boot wedged at submit #1 under WAIT_DEFER). A 2 ms ticker re-runs the flush (same submit mutex),
-// firing the owed EOP pulse the moment a paused stream's condition satisfies (typically via the
-// pend-queue completion writes) or its timeout expires. Started lazily on the first deferred fold;
-// inert unless PROSPER_WAIT_DEFER=1 ever pauses a stream.
+// Barrier-model release watchdog (#312): deferred streams were only re-checked at SUBSEQUENT
+// submits, but a guest that CPU-polls a deferred stream's label before submitting again deadlocks
+// (observed: boot wedged at submit #1 under the first WAIT_DEFER experiment). A 2 ms ticker
+// re-runs the flush (same submit mutex), releasing a paused stream's gated writes the moment its
+// condition satisfies (typically via the pend-queue completion writes) or its timeout expires.
+// Started lazily the first time a deferred stream exists; inert while no stream is paused.
 void start_defer_watchdog() {
     static std::atomic<bool> started{false};
     bool expect = false;
@@ -990,14 +990,16 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     agc_gpu_state().draws.clear();
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
-    // #312 WAIT_DEFER liveness: the EOP pulse fires at every submit even when the fold paused on
-    // an unsatisfied barrier — withholding it starved the frame pacer and wedged every WAIT_DEFER
+    // #312 barrier-model liveness: the EOP pulse fires at every submit even when the fold paused on
+    // an unsatisfied barrier — withholding it starved the frame pacer and wedged every naive-pause
     // run (submits stop, so the producer that would satisfy the barrier never arrives). Only the
     // stream's MEMORY writes stay deferred; the watchdog flushes them the moment the barrier
-    // satisfies (or the 50 ms timeout degrades to the old proceed-loudly behavior).
+    // satisfies (or the bounded timeout degrades to the old proceed-loudly behavior).
     prosper_eq_trigger_eop();
-    if (gpu::last_fold_deferred()) start_defer_watchdog();
     gpu::flush_deferred_streams();
+    // Watchdog keys off PENDING streams, not just this fold: streams can outlive their fold (and
+    // the Jump-recursion flag reset once hid a deferring fold entirely — the wedge class).
+    if (gpu::deferred_pending()) start_defer_watchdog();
     static const unsigned render_every2 = [] {
         const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
     static unsigned draw_submits2 = 0;
@@ -1105,11 +1107,11 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     g_submit_count++;
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
-    // #312 WAIT_DEFER liveness: the pulse fires even for a fold paused on an unsatisfied barrier —
+    // #312 barrier-model liveness: the pulse fires even for a fold paused on an unsatisfied barrier —
     // only the stream's MEMORY writes stay deferred (see submit_dcb_stream).
     prosper_eq_trigger_eop();
-    if (gpu::last_fold_deferred()) start_defer_watchdog();
     gpu::flush_deferred_streams();
+    if (gpu::deferred_pending()) start_defer_watchdog();
     // Stage A: if a live renderer has been registered (runtime binary wires a Vulkan device) and this
     // submit accumulated draws, execute the folded GpuState and present the frame. Inert (returns false)
     // on the pure-HLE path until a device is registered, so it never perturbs the existing boot behavior.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -990,13 +990,14 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     agc_gpu_state().draws.clear();
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
-    // #312 barrier-model liveness: the EOP pulse fires at every submit even when the fold paused on
-    // an unsatisfied barrier — withholding it starved the frame pacer and wedged every naive-pause
-    // run (submits stop, so the producer that would satisfy the barrier never arrives). Only the
-    // stream's MEMORY writes stay deferred; the watchdog flushes them the moment the barrier
-    // satisfies (or the bounded timeout degrades to the old proceed-loudly behavior).
-    prosper_eq_trigger_eop();
+    // #312 EOP visibility contract: the pulse fires immediately only when no gated writes are
+    // pending; otherwise it is OWED and delivered when the tail drains (the guest's completion
+    // scan must never observe a half-retired frame — see command_processor.cpp). The flip and the
+    // pipe-drain writes still flow, and the watchdog + timeout bound the delay, so the pacer
+    // stays alive (the naive always-pulse variant let the scan free live labels; the naive
+    // never-pulse variant starved the pacer — both measured).
     gpu::flush_deferred_streams();
+    gpu::submit_completion_pulse();
     // Watchdog keys off PENDING streams, not just this fold: streams can outlive their fold (and
     // the Jump-recursion flag reset once hid a deferring fold entirely — the wedge class).
     if (gpu::deferred_pending()) start_defer_watchdog();
@@ -1107,10 +1108,10 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     g_submit_count++;
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
-    // #312 barrier-model liveness: the pulse fires even for a fold paused on an unsatisfied barrier —
-    // only the stream's MEMORY writes stay deferred (see submit_dcb_stream).
-    prosper_eq_trigger_eop();
+    // #312 EOP visibility contract: pulse only when no gated writes are pending, else owed until
+    // the tail drains (see submit_dcb_stream / command_processor.cpp).
     gpu::flush_deferred_streams();
+    gpu::submit_completion_pulse();
     if (gpu::deferred_pending()) start_defer_watchdog();
     // Stage A: if a live renderer has been registered (runtime binary wires a Vulkan device) and this
     // submit accumulated draws, execute the folded GpuState and present the frame. Inert (returns false)

--- a/prosper/tests/test_wait_barrier.cpp
+++ b/prosper/tests/test_wait_barrier.cpp
@@ -1,0 +1,176 @@
+// test_wait_barrier — the #312 per-queue WAIT_REG_MEM barrier model (command_processor.cpp).
+//
+// Semantics under test (default configuration — the model is ON by default):
+//   1. An UNSATISFIED WaitRegMem gates the stream's DOWNSTREAM memory effects (they must not become
+//      guest-visible until the condition holds) — the exact ordering whose violation stomped
+//      MallocBinned3 free-block headers in DOLL's menu content-load burst.
+//   2. Effects UPSTREAM of the barrier still flush promptly (the guest CPU polls those labels).
+//   3. Releasing is per-queue INDEPENDENT: a blocked stream never head-of-line blocks another
+//      deferred stream whose own condition is satisfied.
+//   4. A Jump executed inside a paused stream must NOT un-gate the parent's remaining effects
+//      (the recursive fold once reset the pause flag — the WAIT_DEFER wedge/ordering bug), and the
+//      jump target's own memory effects are gated too.
+//   5. A barrier that never satisfies releases via the bounded timeout (liveness backstop), so a
+//      guest polling a gated label can wait at most one timeout.
+//   6. A SATISFIED wait is a pass-through no-op (the fast path every healthy frame takes).
+#include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/pm4_decode.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
+#include <thread>
+#include <chrono>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// PM4 type-3 NOP-wrapped header, identical to hle_agc.cpp PM4(): len = total dwords incl. header.
+static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
+    return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
+}
+
+// Emit a ReleaseMem(label <- value, data_sel=1) at buf: 7 dwords.
+static void emit_release(uint32_t* buf, uint64_t addr, uint32_t value) {
+    buf[0] = PM4(7, IT_NOP, R_RELEASE_MEM);
+    buf[1] = (uint32_t)addr; buf[2] = (uint32_t)(addr >> 32);
+    buf[3] = 1;                      // data_sel = Data32Low
+    buf[4] = value; buf[5] = 0;
+    buf[6] = 0x2d;                   // event action (as DOLL's consumed-marker fences carry)
+}
+// Emit a WaitRegMem([addr]&mask == ref) at buf: 8 dwords.
+static void emit_wait_eq(uint32_t* buf, uint64_t addr, uint64_t ref) {
+    buf[0] = PM4(8, IT_NOP, R_WAIT_MEM_64);
+    buf[1] = (uint32_t)addr; buf[2] = (uint32_t)(addr >> 32);
+    buf[3] = 0xffffffffu; buf[4] = 0;               // mask (low 32)
+    buf[5] = (uint32_t)ref; buf[6] = (uint32_t)(ref >> 32);
+    buf[7] = 3;                                     // compare function: ==
+}
+
+// Fold + drain the pipe-drain queue (upstream effects become guest-visible at a drain point).
+static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
+    size_t n = run_command_buffer(buf, dwords, st);
+    prosper_gpu_drain_completion_writes();
+    return n;
+}
+
+int main() {
+    // A generous release timeout so the gating assertions below are not raced by the liveness
+    // backstop (test 5 sleeps past it deliberately). Must be set before the first fold caches it.
+#ifdef _WIN32
+    _putenv_s("PROSPER_WAIT_TIMEOUT_MS", "400");
+#else
+    setenv("PROSPER_WAIT_TIMEOUT_MS", "400", 1);
+#endif
+    printf("== test_wait_barrier ==\n");
+
+    // 1+2: [ReleaseMem(pre <- 1)] [WaitRegMem(cond==1)] [ReleaseMem(post <- 1)]
+    {
+        volatile uint64_t cond = 0;                 // the awaited label (unsatisfied)
+        uint64_t pre = 0, post = 0;
+        uint32_t buf[7 + 8 + 7];
+        emit_release(buf, (uint64_t)(uintptr_t)&pre, 1);
+        emit_wait_eq(buf + 7, (uint64_t)(uintptr_t)&cond, 1);
+        emit_release(buf + 15, (uint64_t)(uintptr_t)&post, 1);
+        GpuState st;
+        size_t n = run_cb(buf, 22, st);
+        CHECK(n == 3, "stream decoded as 3 packets");
+        CHECK(last_fold_deferred(), "unsatisfied WaitRegMem paused the stream");
+        CHECK(deferred_pending(), "a deferred stream is pending");
+        CHECK(pre == 1, "effect UPSTREAM of the barrier flushed promptly");
+        flush_deferred_streams();
+        CHECK(post == 0, "effect DOWNSTREAM of the barrier stays gated while the condition is unmet");
+        cond = 1;                                    // producer arrives (CPU-visible label write)
+        flush_deferred_streams();
+        CHECK(post == 1, "downstream effect released once the condition was satisfied");
+        CHECK(!deferred_pending(), "stream completed and left the deferred queue");
+    }
+
+    // 3: per-queue independence — two paused streams; the SECOND stream's condition satisfies
+    // first, and its write must release even though an older stream is still blocked.
+    {
+        volatile uint64_t cond1 = 0, cond2 = 0;
+        uint64_t l1 = 0, l2 = 0;
+        uint32_t s1[8 + 7], s2[8 + 7];
+        emit_wait_eq(s1, (uint64_t)(uintptr_t)&cond1, 1);
+        emit_release(s1 + 8, (uint64_t)(uintptr_t)&l1, 1);
+        emit_wait_eq(s2, (uint64_t)(uintptr_t)&cond2, 1);
+        emit_release(s2 + 8, (uint64_t)(uintptr_t)&l2, 1);
+        GpuState st;
+        run_cb(s1, 15, st);
+        run_cb(s2, 15, st);
+        cond2 = 1;                                   // ONLY the younger stream's producer arrives
+        flush_deferred_streams();
+        CHECK(l2 == 1, "younger stream released independently (no head-of-line blocking)");
+        CHECK(l1 == 0, "older blocked stream stays gated");
+        CHECK(deferred_pending(), "older stream still pending");
+        cond1 = 1;
+        flush_deferred_streams();
+        CHECK(l1 == 1 && !deferred_pending(), "older stream released once its own condition held");
+    }
+
+    // 4: a Jump inside a paused stream — the jump target's ReleaseMem must be gated with the
+    // parent stream, and the parent's post-jump effects must STAY gated (the recursion once reset
+    // the pause flag, un-gating them).
+    {
+        volatile uint64_t cond = 0;
+        uint64_t in_jump = 0, post = 0;
+        uint32_t seg[7];                             // the jump target: one ReleaseMem
+        emit_release(seg, (uint64_t)(uintptr_t)&in_jump, 1);
+        uint32_t buf[8 + 5 + 7];
+        emit_wait_eq(buf, (uint64_t)(uintptr_t)&cond, 1);
+        uint64_t seg_addr = (uint64_t)(uintptr_t)seg;
+        buf[8]  = PM4(5, IT_NOP, R_JUMP);
+        buf[9]  = (uint32_t)seg_addr; buf[10] = (uint32_t)(seg_addr >> 32);
+        buf[11] = 7;                                 // dword count of the target segment
+        buf[12] = 0;                                 // not predicated
+        emit_release(buf + 13, (uint64_t)(uintptr_t)&post, 1);
+        GpuState st;
+        run_cb(buf, 20, st);
+        flush_deferred_streams();
+        CHECK(in_jump == 0, "jump-target effect gated with the paused parent stream");
+        CHECK(post == 0, "parent's post-jump effect STAYS gated (recursion must not reset the pause)");
+        CHECK(last_fold_deferred(), "fold still reports deferred after an inner Jump");
+        cond = 1;
+        flush_deferred_streams();
+        CHECK(in_jump == 1 && post == 1, "both released in order once the condition held");
+    }
+
+    // 5: liveness backstop — a condition NOBODY ever satisfies releases via the bounded timeout.
+    {
+        volatile uint64_t cond = 0;                  // never written
+        uint64_t label = 0;
+        uint32_t buf[8 + 7];
+        emit_wait_eq(buf, (uint64_t)(uintptr_t)&cond, 1);
+        emit_release(buf + 8, (uint64_t)(uintptr_t)&label, 1);
+        GpuState st;
+        run_cb(buf, 15, st);
+        flush_deferred_streams();
+        CHECK(label == 0, "gated before the timeout");
+        std::this_thread::sleep_for(std::chrono::milliseconds(450));   // > PROSPER_WAIT_TIMEOUT_MS
+        flush_deferred_streams();
+        CHECK(label == 1, "timeout released the gated write (liveness backstop)");
+        CHECK(!deferred_pending(), "timed-out stream completed");
+    }
+
+    // 6: a SATISFIED wait is a pass-through — nothing defers (the healthy-frame fast path).
+    {
+        volatile uint64_t cond = 1;
+        uint64_t label = 0;
+        uint32_t buf[8 + 7];
+        emit_wait_eq(buf, (uint64_t)(uintptr_t)&cond, 1);
+        emit_release(buf + 8, (uint64_t)(uintptr_t)&label, 1);
+        GpuState st;
+        run_cb(buf, 15, st);
+        CHECK(!last_fold_deferred(), "satisfied wait does not pause the stream");
+        CHECK(!deferred_pending(), "no deferred stream created");
+        CHECK(label == 1, "downstream effect flushed promptly");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_wait_barrier.cpp
+++ b/prosper/tests/test_wait_barrier.cpp
@@ -1,12 +1,16 @@
-// test_wait_barrier — the #312 per-queue WAIT_REG_MEM barrier model (command_processor.cpp).
+// test_wait_barrier — the #312 WAIT_REG_MEM barrier model (command_processor.cpp).
 //
-// Semantics under test (default configuration — the model is ON by default):
+// Semantics under test (with the model enabled — PROSPER_WAIT_DEFER=1, set below; the model is
+// opt-in, see the verdict block in command_processor.cpp):
 //   1. An UNSATISFIED WaitRegMem gates the stream's DOWNSTREAM memory effects (they must not become
 //      guest-visible until the condition holds) — the exact ordering whose violation stomped
 //      MallocBinned3 free-block headers in DOLL's menu content-load burst.
 //   2. Effects UPSTREAM of the barrier still flush promptly (the guest CPU polls those labels).
-//   3. Releasing is per-queue INDEPENDENT: a blocked stream never head-of-line blocks another
-//      deferred stream whose own condition is satisfied.
+//   3. PER-ADDRESS ORDERING DOMAINS: while gated writes are pending, a LATER submit's effect to
+//      the SAME address joins the gated tail in ring order (overtaking swaps fence generations at
+//      recycled labels — the #312 stomp), and a later WAIT on a gated address evaluates in ring
+//      order (after the gated writes it must observe) — but effects to untouched addresses FLOW
+//      (gating them created a CPU<->GPU circular stall, an early-boot wedge measured live).
 //   4. A Jump executed inside a paused stream must NOT un-gate the parent's remaining effects
 //      (the recursive fold once reset the pause flag — the WAIT_DEFER wedge/ordering bug), and the
 //      jump target's own memory effects are gated too.
@@ -58,11 +62,14 @@ static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
 }
 
 int main() {
-    // A generous release timeout so the gating assertions below are not raced by the liveness
-    // backstop (test 5 sleeps past it deliberately). Must be set before the first fold caches it.
+    // Enable the (opt-in) model, and set a generous release timeout so the gating assertions
+    // below are not raced by the liveness backstop (test 5 sleeps past it deliberately). Both
+    // must be set before the first fold caches them.
 #ifdef _WIN32
+    _putenv_s("PROSPER_WAIT_DEFER", "1");
     _putenv_s("PROSPER_WAIT_TIMEOUT_MS", "400");
 #else
+    setenv("PROSPER_WAIT_DEFER", "1", 1);
     setenv("PROSPER_WAIT_TIMEOUT_MS", "400", 1);
 #endif
     printf("== test_wait_barrier ==\n");
@@ -89,27 +96,35 @@ int main() {
         CHECK(!deferred_pending(), "stream completed and left the deferred queue");
     }
 
-    // 3: per-queue independence — two paused streams; the SECOND stream's condition satisfies
-    // first, and its write must release even though an older stream is still blocked.
+    // 3: per-address ordering domains — while L has a gated pending write:
+    //    - a later submit's write to L joins the tail (ring order; final value = LAST write),
+    //    - a later submit's WAIT on L evaluates in ring order (sees the gated writes),
+    //    - a later submit's write to an UNRELATED address flows immediately (no circular stall).
     {
-        volatile uint64_t cond1 = 0, cond2 = 0;
-        uint64_t l1 = 0, l2 = 0;
-        uint32_t s1[8 + 7], s2[8 + 7];
+        volatile uint64_t cond1 = 0;
+        uint64_t L = 0, M = 0, N = 0;
+        uint32_t s1[8 + 7], s2[7], s3[7], s4[8 + 7];
         emit_wait_eq(s1, (uint64_t)(uintptr_t)&cond1, 1);
-        emit_release(s1 + 8, (uint64_t)(uintptr_t)&l1, 1);
-        emit_wait_eq(s2, (uint64_t)(uintptr_t)&cond2, 1);
-        emit_release(s2 + 8, (uint64_t)(uintptr_t)&l2, 1);
+        emit_release(s1 + 8, (uint64_t)(uintptr_t)&L, 1);   // gated: L <- 1
+        emit_release(s2, (uint64_t)(uintptr_t)&L, 2);       // later write to L: must NOT overtake
+        emit_release(s3, (uint64_t)(uintptr_t)&M, 1);       // unrelated address: must FLOW
+        emit_wait_eq(s4, (uint64_t)(uintptr_t)&L, 2);       // wait on gated L: ring order (sees L=2)
+        emit_release(s4 + 8, (uint64_t)(uintptr_t)&N, 1);
         GpuState st;
         run_cb(s1, 15, st);
-        run_cb(s2, 15, st);
-        cond2 = 1;                                   // ONLY the younger stream's producer arrives
+        run_cb(s2, 7, st);
+        run_cb(s3, 7, st);
+        run_cb(s4, 15, st);
         flush_deferred_streams();
-        CHECK(l2 == 1, "younger stream released independently (no head-of-line blocking)");
-        CHECK(l1 == 0, "older blocked stream stays gated");
-        CHECK(deferred_pending(), "older stream still pending");
-        cond1 = 1;
+        CHECK(L == 0, "gated-address writes stay gated (no overtake)");
+        CHECK(M == 1, "unrelated-address write flowed immediately");
+        CHECK(N == 0, "stream behind a gated-address wait stays gated");
+        CHECK(deferred_pending(), "tail pending");
+        cond1 = 1;                                   // front producer arrives -> tail drains in order
         flush_deferred_streams();
-        CHECK(l1 == 1 && !deferred_pending(), "older stream released once its own condition held");
+        CHECK(L == 2, "same-address writes landed in ring order (final = later write)");
+        CHECK(N == 1, "gated-address wait evaluated in ring order and released its stream");
+        CHECK(!deferred_pending(), "queue fully drained");
     }
 
     // 4: a Jump inside a paused stream — the jump target's ReleaseMem must be gated with the


### PR DESCRIPTION
## What this PR is

The per-queue `WAIT_REG_MEM` barrier model specified in the #312 trail, built out to full ring semantics, unit-locked, and then **A/B'd live (~20 instrumented DOLL menu-drive runs on one build)**. The measurement forced an honest conclusion the trail did not anticipate: the barrier model **eliminates the headline canary-152 fatal class but does NOT close #312** — a second, wait-order-independent corruption leg dominates. The model therefore ships **opt-in** (`PROSPER_WAIT_DEFER=1`), with the default path behaviorally unchanged.

## The model (opt-in)

- **Stream pause**: an unsatisfied wait defers everything downstream of it in its own fold, in order.
- **Per-address ordering domains**: while gated writes are pending, a later submit's write or wait touching a *gated address* joins the tail in ring order; effects to untouched addresses flow. (Full-queue FIFO was tried and measured: it recreates a CPU↔GPU circular stall — guest polls a fence gated behind a barrier whose producing CPU write happens after the poll — an early-boot wedge.)
- **EOP visibility contract**: a submit's equeue pulse fires immediately only when no gated writes are pending; otherwise it is *owed* and delivered when the tail drains. On hardware the EOP interrupt cannot precede the visibility of writes before it in the ring. Both failure directions were measured live: pulsing early lets the guest's completion scan free live label blocks (stomps with **zero** ordering violations); never re-firing wedges the RenderThread (`GameThread timed out waiting for RenderThread after 120.00 secs`).
- **Liveness**: 2 ms watchdog keyed off pending streams; timeout raised 50→1000 ms (50 ms measurably violated *real* producers — barrier satisfaction observed up to **216 ms** under load; every timeout is a dependency violation, i.e. the corruption mechanism); barrier-latency telemetry; label-page readability guards.
- **Always-active fixes** (independent of the model): the Jump-recursion fold reset that un-gated a paused stream mid-fold *and* hid the deferral from the watchdog trigger (the historical 'WAIT_DEFER wedge with zero timeout logs'), and a pend-drain in-flight race (a drainer could observe an empty queue while an item was mid-apply and let a later same-address write overtake it).

`test_wait_barrier` locks the enabled-model contract: downstream gating, prompt upstream flush, per-address domains (no overtake, unrelated flows), jumps don't un-gate, timeout backstop, satisfied-wait fast path.

## The measurement (why this is opt-in and why #312 is still open)

Same build, exact issue-312 `PROSPER_PAD_SCRIPT` menu-drive repro:

| Config | Runs | Outcome |
|---|---|---|
| barrel-on (default) | 2 | classic **canary-152** fatal, both at t≈70 s, rich menus (360 draws/frame) |
| model ON (default cfg of the mid-PR build) | 6 | **zero canary-152** — but all die t=0–41 s in the *other* family (`free an unrecognized block 0x1000000001`, worker SIGSEGV reading pool-metadata `0x20015f00`, wedges) |
| model ON + `PROSPER_NO_JUMP=1` | 2 | same family |
| model ON + `PROSPER_EOP_WRITE_SYNC=1` | 2 | same family |

The discriminating observation: a burst of ~96 `ReleaseMem(value=1)` writes at t≈10 s lands on labels whose qword reads `0x1000000000` **in every configuration**, including runs with *zero* barrier violations and with fully synchronous writes (the labels are pointer-valued already **at fence-build time**). `0x1000000000 | 1 = 0x1000000001` — the exact fatal block pointer. No ordering or timing model of honest writes can remove an injection that is upstream of both.

**The '5/5 `PROSPER_WAIT_DEFER=1` runs have zero corruption' evidence in the issue trail is confounded**: every one of those runs lost liveness within a minute — a semi-frozen guest generates no content-load burst and thus no corruption window. This PR's liveness-correct model dissolves that causal isolation.

## Verification

- ctest **79/79** (includes the new `wait_barrier` suite)
- Messenger: `snapshot.py check` **OK** (richest 24318 colors), clean 120 s boot, 0 faults — the default path is behaviorally master's (minus the pend-drain race fix)
- DOLL default config: unchanged from master (barrel-on); opt-in model verified as above

## Where #312 goes next (comment on the issue has the full detail)

1. The t≈10 s injection: attribute who writes `0x1000000000` into fenced labels (value-triggered page watch — the plain watch capped out on benign MB3 traffic) and RE the second consumed-marker emitter (`eboot+0x220d2bc`, state==2 gate).
2. The deterministic pool-info stomp `[poolbase+0x20] = 0x20015f00` (byte-shifted `0x20015f0000`) — no aligned 1/0/clock-valued GPU write of ours can produce it; likely a guest computation on already-corrupted input, or an entirely different writer.

refs #312