### PR TITLE
fix(hle/mem): prot 0 maps to PROT_NONE, not a default RW (#342)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -227,6 +227,12 @@ if(TARGET prosper_core)
     add_executable(test_map_noreplace tests/test_map_noreplace.cpp)
     target_link_libraries(test_map_noreplace PRIVATE prosper_core)
     add_test(NAME map_noreplace COMMAND test_map_noreplace)
+
+    # A guest mprotect(prot=0) makes the page PROT_NONE, not a default RW (#342): guard pages must
+    # actually guard. Drives the real sceKernelMprotect + a SIGSEGV probe. Linux-only.
+    add_executable(test_prot_none tests/test_prot_none.cpp)
+    target_link_libraries(test_prot_none PRIVATE prosper_core)
+    add_test(NAME prot_none COMMAND test_prot_none)
   endif()
 
   # PM4 command-stream decoder (front of the CommandProcessor): decode a Dcb built by the AGC

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -199,13 +199,18 @@ namespace {
         return n;
     }
 
+    // Map guest Orbis protection bits (READ=1, WRITE=2 [implies read], EXEC=4) to host PROT_* flags.
+    // prot 0 is SCE_KERNEL_PROT_NONE — a LEGITIMATE "no access" request (guard pages, reserved
+    // redzones), so it must map to PROT_NONE, not a default RW. Every caller passes the guest's real
+    // prot arg (never a "please default me" sentinel), so there is no case where 0 should mean RW; the
+    // old `if(!hp) hp = RW` fallback silently turned an explicit guard page into a writable one, so an
+    // overrun never faulted and allocator/stack tripwires never fired (#342).
     int host_prot(uint64_t p) {
         int hp = 0;
         if (p & 0x1) hp |= PROT_READ;
         if (p & 0x2) hp |= PROT_READ | PROT_WRITE;
         if (p & 0x4) hp |= PROT_EXEC;
-        if (!hp) hp = PROT_READ | PROT_WRITE;
-        return hp;
+        return hp;   // p == 0 -> PROT_NONE (no access), NOT read-write
     }
     uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
     void* map_at(uint64_t hint, uint64_t len, int prot) {

--- a/prosper/tests/test_prot_none.cpp
+++ b/prosper/tests/test_prot_none.cpp
@@ -1,0 +1,71 @@
+// test_prot_none (#342) — a guest mprotect with prot 0 (SCE_KERNEL_PROT_NONE) must make the page
+// INACCESSIBLE, not read-write. host_prot() used to default prot 0 to RW, so a guest guard page stayed
+// writable and an overrun never faulted. This drives the real sceKernelMprotect HLE and probes the page
+// with a SIGSEGV handler: after prot 0 a read must fault; after prot RW it must be writable again (so
+// the common non-zero path is unbroken). Linux-only (mmap/mprotect/signals).
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <csetjmp>
+#include <csignal>
+#include <sys/mman.h>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static sigjmp_buf g_jmp;
+static volatile sig_atomic_t g_faulted;
+static void on_segv(int) { g_faulted = 1; siglongjmp(g_jmp, 1); }
+
+// Returns true if READING *p faulted (i.e. the page is not readable).
+static bool read_faults(const volatile uint32_t* p) {
+    struct sigaction sa{}, old{}; sa.sa_handler = on_segv; sigemptyset(&sa.sa_mask);
+    sigaction(SIGSEGV, &sa, &old);
+    g_faulted = 0;
+    if (sigsetjmp(g_jmp, 1) == 0) { volatile uint32_t v = *p; (void)v; }
+    sigaction(SIGSEGV, &old, nullptr);
+    return g_faulted != 0;
+}
+
+int main() {
+    printf("== test_prot_none ==\n");
+    register_builtin_hle();
+    auto flexible = Hle::lookup(nid_hash("sceKernelMapFlexibleMemory"));
+    auto mprotect_fn = Hle::lookup(nid_hash("sceKernelMprotect"));
+    CHECK(flexible && mprotect_fn, "map/mprotect HLE registered");
+    if (!(flexible && mprotect_fn)) { printf("== FAIL ==\n"); return 1; }
+
+    auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
+    const uint64_t LEN = 0x10000;
+
+    // Commit a RW page and confirm it is writable.
+    uint64_t va = 0;
+    CHECK(flexible(U(&va), LEN, 0x2 /*RW*/, 0, U("prot-test"), 0) == 0 && va, "MapFlexible(RW) succeeds");
+    if (!va) { printf("== FAIL ==\n"); return 1; }
+    volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)va;
+    *cell = 0xABCD1234u;
+    CHECK(!read_faults(cell) && *cell == 0xABCD1234u, "RW page: readable + writable");
+
+    // mprotect to prot 0 -> the page must become PROT_NONE (a read faults). This is the bug: it used to
+    // stay RW.
+    mprotect_fn(va, LEN, 0 /*SCE_KERNEL_PROT_NONE*/, 0, 0, 0);
+    CHECK(read_faults(cell), "after mprotect(prot=0): page is PROT_NONE (read FAULTS, not silently RW)");
+
+    // mprotect back to RW -> writable again (the common non-zero path is unbroken).
+    mprotect_fn(va, LEN, 0x2 /*RW*/, 0, 0, 0);
+    CHECK(!read_faults(cell), "after mprotect(prot=RW): page is accessible again");
+    *cell = 0x5A5A5A5Au;
+    CHECK(*cell == 0x5A5A5A5Au, "restored RW page is writable");
+
+    // mprotect to READ-only (prot 1) -> readable but not writable (host_prot maps 1 -> PROT_READ).
+    mprotect_fn(va, LEN, 0x1 /*READ*/, 0, 0, 0);
+    CHECK(!read_faults(cell), "after mprotect(prot=READ): page is readable");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #342.

## Bug
`host_prot()` had `if(!hp) hp = PROT_READ|PROT_WRITE`, so a guest protection of `0` (`SCE_KERNEL_PROT_NONE`) became **read-write**. `PROT_NONE` is a legitimate "no access" request — a guest that installs a guard page via `sceKernelMprotect(addr, size, 0)` (or maps a redzone with prot 0) got a fully writable page instead. An overrun into it **never faulted**, and any allocator/stack tripwire that relies on the `SIGSEGV` never fired → corruption went undetected.

## Fix
Every `host_prot()` caller (`map_flexible` / `map_dmem` / `mprotect` / `batch_map`) passes the guest's **real** prot arg, never a "please default me" sentinel — so the fallback was always wrong. Remove it; `prot 0` now yields `PROT_NONE`.

**Latent on current titles**: they don't issue an explicit prot 0, and prosper's reservation path hardcodes `PROT_NONE` separately rather than via `host_prot`, so no boot behavior changes — but guard pages now actually guard.

## Verification
`test_prot_none` drives the real `sceKernelMprotect` and a `SIGSEGV` probe: after `prot 0` a read **faults** (was silently RW), and `prot RW`/`READ` still work. Confirmed it **fails with the fallback restored**. Full `ctest` **81/81**, incl. `boot_reaches_first_syscall` (shared mem path unregressed on the Messenger).

## Not this PR
The sibling #343 (`retrack_prot` forces `committed=true`) interacts with the UE4 commit-on-demand model and its own issue says to coordinate with `area:ue4` + boot-test UE4 — left for that lane.