### PR TITLE
fix(loader): mask the SELF data-segment key to 12 bits (#339)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -78,6 +78,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_va2foff PRIVATE prosper_core)
   add_test(NAME va2foff_load_priority COMMAND test_va2foff)
 
+  # SELF data-segment key masks flag bits >= 32 (#339): the SCE segment id is bits [31:20]; without
+  # the mask a data segment keys the map wrong and every phdr lookup misses. Pure, no game dump.
+  add_executable(test_self_segment_key tests/test_self_segment_key.cpp)
+  target_link_libraries(test_self_segment_key PRIVATE prosper_core)
+  add_test(NAME self_segment_key COMMAND test_self_segment_key)
+
   # Guest static-TLS Variant II layout uses each module's real PT_TLS p_align (#143). The layout
   # code is Linux-only (guest %fs), so gate the test on it too.
   if(UNIX AND NOT APPLE)

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -10,6 +10,13 @@ namespace prosper {
 template<class T> static T rd(const std::vector<uint8_t>& b, size_t off) {
     T v{}; if (off + sizeof(T) <= b.size()) memcpy(&v, b.data() + off, sizeof(T)); return v;
 }
+// The SCE self-segment id (the phdr index a data segment maps to) is bits [31:20] of the segment
+// flags — 12 bits; higher bits hold other block/property info and MUST be masked off. Without the
+// mask, a data segment with any flag bit >= 32 keys the data-segment map by a garbage index, so every
+// phdr lookup misses and every segment silently falls back to `elf_base + p_offset` (mapping garbage
+// bytes — the fatal-but-silent failure the load() comment warns about). Matches Kyty Elf.cpp:270. #339
+uint64_t self_segment_key(uint64_t flags) { return (flags >> 20) & 0xFFFu; }
+
 static int b64val(const std::string& s) {
     static const char* B = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-";
     int v = 0; for (char c : s) { const char* p = strchr(B, c); if (!p) return -1; v = v * 64 + (int)(p - B); }
@@ -74,7 +81,7 @@ std::optional<Module> Module::load(const std::string& path, std::string* err) {
     if (sh.magic == 0x1D3D154F || sh.magic == 0xEEF51454) {
         for (int i = 0; i < sh.num_segments; i++) {
             auto s = rd<SelfSegment>(m.file, 0x20 + i * sizeof(SelfSegment));
-            if (s.flags & 0x800) data_seg[s.flags >> 20] = s;
+            if (s.flags & 0x800) data_seg[self_segment_key(s.flags)] = s;
         }
         m.elf_base = 0x20 + (size_t)sh.num_segments * sizeof(SelfSegment);
     }

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -113,6 +113,11 @@ struct LoadedImage {
 // Build a flat image from a parsed module at guest base `base`.
 LoadedImage build_image(const Module& m, uint64_t base);
 
+// The phdr-index key a SELF data segment maps to: bits [31:20] of its flags, masked to 12 bits (the
+// SCE self-segment id). Higher flag bits must be masked off or the data-segment map is keyed wrong.
+// Exposed for testing; see module.cpp / issue #339.
+uint64_t self_segment_key(uint64_t flags);
+
 // Bind each import to a synthetic stub address: stub_base + index*stub_size.
 // (At M2 these become real logging-trap stubs.) Records into img.import_addr.
 void bind_imports_to_stubs(const Module& m, LoadedImage& img,

--- a/prosper/tests/test_self_segment_key.cpp
+++ b/prosper/tests/test_self_segment_key.cpp
@@ -1,0 +1,36 @@
+// test_self_segment_key (#339) — the SELF data-segment map key is the SCE self-segment id in flag
+// bits [31:20], masked to 12 bits. Without the mask, a data segment whose flags carry any bit >= 32
+// keys the map by a garbage index, so every phdr lookup misses and the segment silently falls back to
+// `elf_base + p_offset` (mapping garbage bytes). This pins the mask math (matches Kyty Elf.cpp).
+#include "../src/self/module.hpp"
+#include <cstdio>
+#include <cstdint>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_self_segment_key ==\n");
+
+    // Real Messenger-style flags (data flag 0x800 + id in [31:20], no upper bits): key == the id.
+    CHECK(self_segment_key(0x002804) == 0, "flags 0x002804 -> id 0");
+    CHECK(self_segment_key(0x102804) == 1, "flags 0x102804 -> id 1");
+    CHECK(self_segment_key(0x302804) == 3, "flags 0x302804 -> id 3");
+    CHECK(self_segment_key(0xb02804) == 0xb, "flags 0xb02804 -> id 0xb");
+
+    // The id field is 12 bits [31:20]; its max is 0xFFF.
+    CHECK(self_segment_key(0xFFF00000) == 0xFFF, "max 12-bit id 0xFFF");
+
+    // The bug: a flag bit >= 32 must NOT leak into the key. Bit 40 set alongside id 1 -> still id 1
+    // (unmasked this would be 0x100001, a garbage index that misses every phdr lookup).
+    CHECK(self_segment_key(0x10000102804ull) == 1, "bit 40 set + id 1 -> masked to id 1 (not 0x100001)");
+    CHECK((0x10000102804ull >> 20) == 0x100001ull, "  (sanity: the UNMASKED key would be garbage 0x100001)");
+    CHECK(self_segment_key(0xFFFFFFFF00000000ull | 0x702804) == 7, "all upper bits set + id 7 -> id 7");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #339.

## Bug
The SCE self-segment id (the phdr index a data segment maps to) is bits **[31:20]** of the segment flags — 12 bits; higher bits hold other block/property info. The key was `s.flags >> 20` with **no mask**, so a data segment whose flags carry any bit ≥ 32 keyed the data-segment map by a garbage index. Every phdr lookup then misses and the segment silently falls back to `elf_base + p_offset` — **mapping garbage bytes** (the fatal-but-silent failure `load()`'s own comment warns about). It survives on a dump only when that fallback happens to coincide with the real layout.

## Fix
`(flags >> 20) & 0xFFF`, matching the SCE format and Kyty (`Elf.cpp:270`). Extracted as `self_segment_key()` so the mask is documented and unit-testable.

## Proven safe (per the issue's guidance)
I logged the computed key for **every data segment while loading all of the Messenger's modules** — every one has flags `< 2^32` (max `0xb02804`), so masked == unmasked and the change is a **pure no-op** there. The mask can only *fix* (a dump whose data-segment flags have upper bits set → currently keyed wrong) or *no-op* (upper bits clear), never regress — it strictly drops bits the SCE format says aren't part of the id.

## Verification
- `test_self_segment_key` pins the math: the real Messenger flags (`0x102804` etc.) as the no-op cases, plus upper-bit garbage (`bit 40 + id 1`) masked back to the true id.
- Full `ctest` **81/81**; `boot_reaches_first_syscall` green; `messenger-scene` snapshot green (29126 colours).