### PR TITLE
fix(loader): make an unhandled TLS relocation loud, not silent (#338)

### DIFF
--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -319,7 +319,21 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
                 if (write64(va, sv + (uint64_t)r.addend)) applied++;
                 break;
             }
-            default: unhandled[r.type]++; break;
+            default: {
+                // Make an unhandled TLS relocation LOUD (once per type) even without
+                // PROSPER_RELOC_HISTO: a silently-skipped TLS reloc leaves the GOT slot 0, so the guest
+                // reads/writes thread-local storage at the wrong (often zero) offset and corrupts it
+                // INVISIBLY. The notable gap is TPOFF64 (18) — declared in module.hpp but with no case
+                // here (its correct value needs the guest static-TLS layout; types 19-23 are other TLS
+                // models). No current title emits these (verified), so this never fires today; when one
+                // does, it fails visibly instead of silently corrupting TLS. #338.
+                uint64_t& cnt = unhandled[r.type];
+                if (cnt == 0 && r.type >= 16 && r.type <= 23)
+                    fprintf(stderr, "[reloc] WARNING: unhandled TLS relocation type %u in %s — "
+                            "thread-local storage may be corrupted (issue #338)\n", r.type, m.path.c_str());
+                cnt++;
+                break;
+            }
         }
     }
     if (getenv("PROSPER_RELOC_HISTO")) {


### PR DESCRIPTION
Refs #338 (the issue's suggested **safe hardening**; the full TLS math stays a follow-up).

## The gap
`R_X86_64_TPOFF64` (18) is declared in `module.hpp` but has **no case** in `apply_relocations`, so it — and other TLS models (types 19–23) — falls into `default: unhandled[r.type]++` and is **silently skipped**. The GOT slot stays 0, so the guest reads/writes thread-local storage at the wrong (often zero) offset and corrupts it invisibly (only counted under `PROSPER_RELOC_HISTO`).

## This PR
Emit a **one-time-per-type** `stderr` WARNING when an unhandled relocation is a TLS type (16–23), so a future title/toolchain that emits one fails **visibly** instead of silently corrupting TLS.

- **No current title emits types 18–23** (verified via `PROSPER_RELOC_HISTO` across all four dumps — the only TLS reloc any emits is `DTPMOD64` (16), which *is* handled). So this never fires today and changes no behavior; it just makes the silent failure mode loud.
- The correct `TPOFF64`/`DTPOFF64` offset math (thread-pointer-relative; needs the guest static-TLS layout, and TLS changes can deterministically break the boot — see the memory notes) stays a **documented follow-up** on #338.

## Verification
Full `ctest` **82/82**; `boot_reaches_first_syscall` green. (No isolated test: the warning provably never fires on any current dump, and triggering it needs a synthetic module carrying a TPOFF64 reloc.)