### PR TITLE
fix(gpu): live renderer uses the game's fast-clear colour, not debug blue (#367)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -225,7 +225,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     it.ps.color_write_mask, (int)it.ps.blend_enable);
                 bds.push_back(std::move(bd));
             }
-            std::vector<uint8_t> px = prosper::test::render_draws_rgba(bds, w, h);
+            // Clear color (#367): the game's decoded fast-clear from the first draw's resolved state,
+            // else the ResolvedPipelineState default (opaque black) — never the diagnostic blue on the
+            // live path (that stays gated behind PROSPER_CLEAR_DEBUG inside render_draws_rgba). This
+            // re-connects the resolved clear color (#309) that a later live_renderer refactor unwired,
+            // so a real frame's un-drawn areas are the game's clear, not blue.
+            const float* clear_rgba = items.empty() ? nullptr : items.front().ps.clear_color;
+            std::vector<uint8_t> px = prosper::test::render_draws_rgba(bds, w, h, /*seed*/nullptr, clear_rgba);
             int n = frame_no++;
             if (px.empty()) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);


### PR DESCRIPTION
Fixes #367. Found in the GPU-audit.

The executor resolves each frame's fast-clear into `ResolvedPipelineState.clear_color` (#309) and `render_draws_rgba` honours a `clear_rgba` arg, but a later `live_renderer` refactor dropped the wiring — the live submit renderer called the 3-arg `render_draws_rgba`, so the diagnostic **blue** default always won on the real game path (every un-drawn area cleared blue, e.g. PPSA02664's credits background).

Re-connect it: pass the first draw's resolved `clear_color` (opaque black when no fast-clear) to `render_draws_rgba`. `PROSPER_CLEAR_DEBUG` still forces blue for spotting unrendered areas.

**Verification:** `ctest` 82/82; `messenger-scene` snapshot green (29126 colours). The clear-color decode + the `clear_rgba` path are already unit-tested (#309); this is the one-line live-path re-wiring.