### PR TITLE
fix(gpu): back-face stencil honours DB_DEPTH_CONTROL.BACKFACE_ENABLE (#377)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -168,6 +168,20 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         ps.stencil_op_val[1]        = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILOPVAL_BF);
         ps.stencil_compare_mask[1]  = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILMASK_BF);
         ps.stencil_write_mask[1]    = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILWRITEMASK_BF);
+        // DB_DEPTH_CONTROL.BACKFACE_ENABLE == 0 means the FRONT state applies to BOTH faces (the _BF
+        // registers are ignored). Sourcing back from _BF regardless left back faces with the
+        // unprogrammed _BF defaults — STENCILFUNC_BF=0 -> VK_COMPARE_OP_NEVER, dropping every back
+        // face out of a two-sided stencil pass. Match RDNA2 (Kyty GraphicsRender: else back = front). #377
+        if (PM4_FIELD(dc2, DB_DEPTH_CONTROL, BACKFACE_ENABLE) == 0) {
+            ps.stencil_compare_op[1]    = ps.stencil_compare_op[0];
+            ps.stencil_fail_op[1]       = ps.stencil_fail_op[0];
+            ps.stencil_pass_op[1]       = ps.stencil_pass_op[0];
+            ps.stencil_depth_fail_op[1] = ps.stencil_depth_fail_op[0];
+            ps.stencil_ref[1]           = ps.stencil_ref[0];
+            ps.stencil_op_val[1]        = ps.stencil_op_val[0];
+            ps.stencil_compare_mask[1]  = ps.stencil_compare_mask[0];
+            ps.stencil_write_mask[1]    = ps.stencil_write_mask[0];
+        }
     }
 
     ps.blend_enable            = rs.blend_enable;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -167,6 +167,26 @@ int main() {
         CHECK(!p4.has_clear_color, "unmapped format fast-clear -> has_clear_color false (black fallback)");
     }
 
+    // #377: DB_DEPTH_CONTROL.BACKFACE_ENABLE=0 -> front stencil state applies to BOTH faces. Back must
+    // NOT read the (unprogrammed) _BF regs, which would give STENCILFUNC_BF=0 -> NEVER and drop back faces.
+    {
+        RenderState s{};
+        s.stencil_enable    = true;
+        s.db_depth_control  = (1u << 0) | (4u << 8);   // STENCIL_ENABLE | STENCILFUNC=GREATER(4), BACKFACE_ENABLE=0
+        s.db_stencil_control = 0x2;                     // some front op; _BF fields left 0
+        s.db_stencilrefmask  = 0x1234;                 // front ref/mask; _BF left 0
+        ResolvedPipelineState p = resolve_pipeline_state(s);
+        CHECK(p.stencil_compare_op[0] == 4u, "front stencil func = GREATER(4)");
+        CHECK(p.stencil_compare_op[1] == p.stencil_compare_op[0],
+              "BACKFACE_ENABLE=0: back stencil func mirrors front (not NEVER from unprogrammed _BF)");
+        CHECK(p.stencil_ref[1] == p.stencil_ref[0] && p.stencil_compare_mask[1] == p.stencil_compare_mask[0],
+              "BACKFACE_ENABLE=0: back ref/mask mirror front");
+        s.db_depth_control |= (1u << 7);               // BACKFACE_ENABLE=1 -> back independent (from _BF=0 -> NEVER)
+        ResolvedPipelineState p2 = resolve_pipeline_state(s);
+        CHECK(p2.stencil_compare_op[1] != p2.stencil_compare_op[0],
+              "BACKFACE_ENABLE=1: back stencil is independent from front (_BF sourced)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #377. From the GPU-audit.

`resolve_pipeline_state` always sourced back-face stencil from the `_BF` registers. Per RDNA2, `DB_DEPTH_CONTROL.BACKFACE_ENABLE == 0` means the **front** state applies to **both** faces (the `_BF` regs are ignored). With one-sided stencil (BACKFACE_ENABLE=0) and unprogrammed `_BF` regs, back faces got `STENCILFUNC_BF=0` → `VK_COMPARE_OP_NEVER` and dropped out of the pass. Confirmed against Kyty (`else back = front`).

Fix: mirror front→back when `BACKFACE_ENABLE==0`. New test asserts back mirrors front when disabled, stays independent (from `_BF`) when enabled. `ctest` 82/82.