### PR TITLE
fix(gpu): map RectList/QuadList topologies; log unmapped prim types (#384)

### DIFF
--- a/prosper/src/gpu/vk_translate.cpp
+++ b/prosper/src/gpu/vk_translate.cpp
@@ -8,7 +8,10 @@ namespace prosper::gpu {
 
 VkTopology vk_topology(uint32_t prim_type) {
     // RDNA2 VGT_DI_PRIMITIVE_TYPE (kPrimitiveType*): 1=point, 2=line list, 3=line strip,
-    // 4=triangle list, 5=triangle fan, 6=triangle strip.
+    // 4=triangle list, 5=triangle fan, 6=triangle strip. RectList(17)/QuadList(19) are the
+    // screen-space primitives drivers emit for full-screen passes / fast clears / resolves;
+    // Kyty (GraphicsRender.cpp) approximates them as TriangleStrip / TriangleFan — far closer
+    // than the old PointList fallback, which rasterized a full-screen effect as 3 stray points.
     switch (prim_type) {
         case 1:  return VkTopology::PointList;
         case 2:  return VkTopology::LineList;
@@ -16,8 +19,25 @@ VkTopology vk_topology(uint32_t prim_type) {
         case 4:  return VkTopology::TriangleList;
         case 5:  return VkTopology::TriangleFan;
         case 6:  return VkTopology::TriangleStrip;
-        default: return VkTopology::PointList;
+        case 17: return VkTopology::TriangleStrip;  // kPrimitiveTypeRectList (3-vertex screen rect ~ strip)
+        case 19: return VkTopology::TriangleFan;    // kPrimitiveTypeQuadList (~ fan)
+        default: break;
     }
+    // Everything else (Patch=9, adjacency LineListAdj=10..TriStripAdj=13, and any unknown value)
+    // falls back to PointList. NOTE: adjacency/patch topologies map 1:1 to Vulkan values but
+    // require a geometry- or tessellation-shader pipeline path prosper does not build yet — emitting
+    // them here would make vkCreateGraphicsPipelines fail (returns {} = nothing) rather than render.
+    // PointList at least produces visible output. Log the specific type ONCE so a silent
+    // points-fallback (which used to hide RectList) is diagnosable — matching vk_color_format.
+    static std::set<uint32_t> logged;
+    static std::mutex logged_mu;
+    {
+        std::lock_guard<std::mutex> lk(logged_mu);
+        if (logged.insert(prim_type).second)
+            fprintf(stderr, "[gpu] vk_topology: unmapped VGT_PRIMITIVE_TYPE=%u -> PointList "
+                            "(adjacency/patch need a GS/tessellation path)\n", prim_type);
+    }
+    return VkTopology::PointList;
 }
 
 VkFormat vk_color_format(uint32_t format, uint32_t number_type, uint32_t comp_swap) {

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -105,6 +105,10 @@ int main() {
     CHECK(vk_topology(rs.prim_type) == VkTopology::TriangleList, "prim_type 4 -> VK TriangleList");
     CHECK(vk_topology(6) == VkTopology::TriangleStrip && vk_topology(1) == VkTopology::PointList,
           "topology map: 6 -> TriangleStrip, 1 -> PointList");
+    // #384: RectList/QuadList are the screen-space primitives full-screen passes emit; they must not
+    // collapse to PointList (3 stray points instead of a covered target). Kyty's strip/fan approximation.
+    CHECK(vk_topology(17) == VkTopology::TriangleStrip, "prim_type 17 (RectList) -> TriangleStrip");
+    CHECK(vk_topology(19) == VkTopology::TriangleFan,   "prim_type 19 (QuadList) -> TriangleFan");
 
     // Decoded DB_DEPTH_CONTROL fields (value 0x46).
     CHECK(rs.z_enable, "z_enable = true (bit 1)");


### PR DESCRIPTION
## Problem
`vk_topology` mapped only `VGT_PRIMITIVE_TYPE` 1..6 and sent **every other value to `PointList`**. `RectList`(17) and `QuadList`(19) — the screen-space primitives drivers emit for full-screen passes, fast clears and resolves — rasterized as 3 stray points instead of covering the target. The fallback returns a *valid* topology, so the failure was silent.

## Fix
- `17 → TriangleStrip`, `19 → TriangleFan` (matches Kyty's `GraphicsRender.cpp` approximation).
- All remaining unmapped types (Patch=9, adjacency 10..13, unknowns) still fall back to `PointList` and now **log once by value** so a silent points-fallback is diagnosable (matching `vk_color_format`).
- Adjacency/patch topologies map 1:1 to Vulkan values but need a geometry/tessellation pipeline path prosper doesn't build yet — emitting them would make `vkCreateGraphicsPipelines` fail (nothing rendered) rather than approximate, so they intentionally stay PointList for now.

## Verification
- `test_render_state` asserts `17 → TriangleStrip`, `19 → TriangleFan`.
- ctest green.

Fixes #384