### PR TITLE
fix(gpu): skip zero-vertex-count draws instead of fabricating geometry (#400)

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -335,6 +335,17 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             vertex_count = max_index + 1;
         }
     }
+    // A genuinely empty draw (vcount_hint == 0 — engines emit 0-vertex DrawIndexAuto/DrawIndexOffset as
+    // no-ops) that resolved NO indices above must render nothing, exactly as it does on hardware. Do NOT
+    // fall through: `vertex_count = vcount_hint ? vcount_hint : 3` already fabricated 3, and the
+    // vb_entries override below would then sweep the ENTIRE residual vertex pool (0..vb_entries-1) of
+    // whatever geometry the last-bound VB still holds — turning a no-op into a phantom triangle or a
+    // full-VB draw of stale geometry composited into the frame (#400). The vb_entries "truer count"
+    // override exists to correct a LOW/stale count, never to synthesize one for a zero-count draw.
+    if (vcount_hint == 0 && out.indices.empty()) {
+        if (log) fprintf(stderr, "[exec] skip draw: zero vertex count (no-op draw)\n");
+        return false;
+    }
     if (out.indices.empty() && vb_entries > vertex_count) vertex_count = vb_entries;
     // Bindless per-glyph vertex fetch (#257): the fetch-shader patches a SMALL per-glyph V# (num_records=4
     // = one glyph's 4 corners, size=304). But the draw indexes ALL vertices (gl_VertexIndex 0..N-1) out of

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -114,6 +114,18 @@ int main() {
     std::vector<uint8_t> pxu = execute_gpustate(sti, backend_idx);
     CHECK(pxu == px, "unknown index_type falls back to a non-indexed draw of the hint count");
 
+    // #400: a zero-vertex-count non-indexed draw is a hardware no-op. realize_draw_item must SKIP it
+    // (return false), not fabricate a phantom triangle (the vcount default was 3) nor sweep the residual
+    // vertex pool. A positive count still realizes — the guard is specific to zero, not a regression.
+    {
+        DrawItem it0;
+        bool made0 = realize_draw_item(st, nullptr, /*vcount_hint*/0u, 0x10000u, /*log*/false, it0);
+        CHECK(!made0, "zero vertex-count draw is skipped (no phantom triangle / VB sweep)");
+        DrawItem it3;
+        bool made3 = realize_draw_item(st, nullptr, /*vcount_hint*/3u, 0x10000u, /*log*/false, it3);
+        CHECK(made3 && it3.vertex_count == 3u, "non-zero vertex-count draw still realizes");
+    }
+
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");


### PR DESCRIPTION
## Problem
`realize_draw_item` never rejected a genuinely empty (0-count) non-indexed draw. Engines legitimately emit 0-vertex `DrawIndexAuto`/`DrawIndexOffset` as no-ops (hardware draws nothing). In prosper:

1. `vertex_count = vcount_hint ? vcount_hint : 3` → **3** (a phantom triangle from VB record 0).
2. Then `if (out.indices.empty() && vb_entries > vertex_count) vertex_count = vb_entries` → sweeps the **entire residual vertex pool** of whatever the last-bound VB still holds.

So a no-op becomes a stray triangle or a full-VB draw of stale geometry composited into the frame. In a folded single-draw submit that spurious frame overwrites the last real one.

## Fix
Reject it explicitly: if `vcount_hint == 0` and no indices resolved, `return false` (skip) **before** the `vb_entries` inflation. The override's stated job is correcting a *low/stale* count, never synthesizing one for a zero-count draw. The indexed path is unaffected (guarded by `draw->index_count`).

## Verification
- `test_gpu_execute` asserts a 0-count draw is skipped (`return false`) while a positive count still realizes with `vertex_count == 3`.
- ctest green.

Fixes #400