### PR TITLE
fix(gpu): correct SW_4KB_S within-tile order for 2/8/16-byte elements (#379)

### DIFF
--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -15,44 +15,55 @@ bool tile_mode_is_tiled(uint32_t tile_mode) {
 }
 
 namespace {
+// One addrlib swizzle-pattern entry: the (x-mask, y-mask) coordinate bits an offset bit is built from.
+// Defined here (and the SW_64K_S table forward-declared) so sw4kb_morton below can derive the 4KB order
+// from the low bits of the SAME authoritative 64KB pattern (#379); both are defined together lower down.
+struct PatBit { uint16_t x, y; };
+extern const PatBit kSw64kS[5][16];
+
 // 4KB standard-swizzle micro-tile geometry for bpe-byte elements: a tile is a FIXED 4096 bytes,
 // so it holds 4096/bpe elements, arranged 2^bx wide x 2^by tall with bx >= by (wide-before-tall):
 //   1 B -> 64x64,  2 B -> 64x32,  4 B -> 32x32,  8 B -> 32x16,  16 B -> 16x16.
 // The old code hardcoded 4 bytes/element (32x32 geometry) everywhere, so any 8/16-bpp surface
 // detiled with the wrong tile dimensions — every texel mis-ordered (#119).
-// CONFIDENCE: HIGH for 4 B (live pixel-verified) and 16 B (BC3, llvmpipe re-tile verified);
-// MED for the rest (standard 4KB-tile arithmetic; verify vs a real surface via PROSPER_DUMP_RAWTILE).
+// CONFIDENCE: HIGH — sw4kb_dims is pure 4KB-tile arithmetic and sw4kb_morton now derives the within-
+// tile order from the authoritative addrlib SW_64KB_S table (#379), which reproduces the 1 B / 4 B
+// pixel-verified orders exactly, so all five element sizes share one validated source of truth.
 inline void sw4kb_dims(uint32_t bpe, uint32_t& bx, uint32_t& by) {
     uint32_t bits = 0; while ((4096u >> bits) > bpe) bits++;   // log2(4096/bpe), bpe a power of two
     bx = (bits + 1) / 2; by = bits / 2;
 }
 // GFX10 SW_4KB_S element order within the tile. The order is BYTES-PER-ELEMENT-DEPENDENT (AMD's
-// standard-swizzle SW_PATTERN genuinely differs per bpp) — two orders are pixel-verified against The
-// Messenger's live surfaces, and both share the shape "a low block of L X-bits then L Y-bits, then
-// interleaved (y,x) Morton pairs above":
+// standard-swizzle SW_PATTERN genuinely differs per bpp). The 4KB order is exactly the LOW-BIT
+// TRUNCATION of the authoritative addrlib SW_64KB_S pattern (docs/GFX10_SW_64KB_TILING.md), so we
+// derive it from the SAME in-file kSw64kS table used by the 64KB detiler rather than an ad-hoc
+// generator — one source of truth, correct at every element size.
 //
-//   32-bpp (32x32 tile, bx=by=5): L=2 -> [x0,x1, y0,y1, y2,x2, y3,x3, y4,x4]           #118 (title art)
-//    8-bpp (64x64 tile, bx=by=6): L=4 -> [x0,x1,x2,x3, y0,y1,y2,y3, y4,x4, y5,x5]       (R8 font atlas)
-//
-// The previous code applied the 32-bpp L=2 pattern at EVERY bpe. That serrated edges at 32-bpp until
-// #118 fixed the low nibble, but at 8-bpp (the game's ONLY R8 surface — the 2048x1024 caption font
-// atlas) the L=2 pattern is badly wrong: it scrambles every 64x64 tile into an unreadable weave, so
-// the intro caption text renders as invisible/garbage. The 8-bpp order below is pixel-verified: it
-// resolves the atlas into a clean grid of readable Latin + CJK glyphs. CONFIDENCE: HIGH for bx=by=5
-// (32-bpp) and bx=by=6 (8-bpp) — both live-verified; the L=2 fallback covers 16-bpp/BC-block geometries
-// (bx=by=4, bx=5/by=4) which round-trip but have no game-observed instance to pixel-verify yet.
+// kSw64kS[elem_log2][k] gives, for byte-offset bit k of the 64KB block, the single element-coordinate
+// bit (x-mask or y-mask) it carries. The first elem_log2 entries are the within-element byte bits
+// ({0,0}); the next (bx+by) entries are this 4KB tile's element-index bits, low->high. So element
+// index bit e reads pattern entry [elem_log2 + e], whose set x/y mask names the coordinate bit that
+// lands at output bit e. This reproduces all five ground-truth orders (both derivations in #379 agree,
+// and the two pixel-verified cases — 32-bpp #118 and 8-bpp R8 font atlas — come out identical):
+//   1 B  (64x64): x0 x1 x2 x3 y0 y1 y2 y3 y4 x4 y5 x5
+//   2 B  (64x32): x0 x1 x2 y0 y1 y2 x3 y3 x4 y4 x5
+//   4 B  (32x32): x0 x1 y0 y1 y2 x2 y3 x3 y4 x4
+//   8 B  (32x16): x0 y0 y1 x1 x2 y2 x3 y3 x4
+//   16 B (16x16): y0 y1 x0 x1 y2 x2 y3 x3
+// The prior L-generator was correct only at 1 B and 4 B; it swapped the low X/Y pairs at 2/8/16 B,
+// scrambling any SW_4KB_S BC1/BC4 (8 B) / BC2/3/5/6/7 (16 B) / R16 (2 B) surface into a coherent weave
+// (the #118/#102 failure class at those bpe). #379.
 inline uint32_t sw4kb_morton(uint32_t ix, uint32_t iy, uint32_t bx, uint32_t by) {
+    const uint32_t bits = bx + by;            // log2(elements per 4KB tile) = log2(4096/bpe)
+    const uint32_t elem_log2 = 12u - bits;    // 4096 == 2^12, bpe == 2^elem_log2 -> bits == 12 - elem_log2
     uint32_t m = 0;
-    // Low-block half-width L: 4 for the 64x64 (8-bpp) tile, else 2 (the #118-verified 32-bpp nibble).
-    const uint32_t L = (bx == 6 && by == 6) ? 4u : 2u;
-    uint32_t bit = 0;
-    for (uint32_t b = 0; b < L && b < bx; b++) m |= ((ix >> b) & 1u) << (bit++);   // low X bits
-    for (uint32_t b = 0; b < L && b < by; b++) m |= ((iy >> b) & 1u) << (bit++);   // low Y bits
-    for (uint32_t b = L; b < by; b++) {                                            // (y,x) Morton pairs
-        m |= ((iy >> b) & 1u) << (bit++);
-        if (b < bx) m |= ((ix >> b) & 1u) << (bit++);
+    for (uint32_t e = 0; e < bits; e++) {
+        const PatBit& pb = kSw64kS[elem_log2][elem_log2 + e];
+        if (pb.x) { uint32_t b = 0; while (!((pb.x >> b) & 1u)) b++; m |= ((ix >> b) & 1u) << e; }
+        else if (pb.y) { uint32_t b = 0; while (!((pb.y >> b) & 1u)) b++; m |= ((iy >> b) & 1u) << e; }
+        // pb == {0,0} cannot occur in a standard-swizzle element-addressing bit; if it ever did, that
+        // output bit stays 0 (a benign degenerate) rather than looping forever on a zero mask.
     }
-    for (uint32_t b = by; b < bx; b++) m |= ((ix >> b) & 1u) << (bit++);           // wider-dim extra X
     return m;
 }
 // Element (x,y) -> its linear element INDEX in the tiled surface: tiles laid out row-major over the
@@ -111,10 +122,9 @@ size_t sw4kb_tiled_bytes(uint32_t ew, uint32_t eh, uint32_t pitch, uint32_t bpe)
 // the pattern depends on the GPU's pipe count, which for PS5 is fixed hardware but not publicly
 // documented — see sw64kb_rx_pipes_log2 below. CONFIDENCE: MED for R_X (equation exact per addrlib,
 // pipe-count parameter selected empirically).
-struct PatBit { uint16_t x, y; };
-
 // SW_64K_S: one 16-bit pattern per element size (identical for every pipe count / RB+ in addrlib).
-static const PatBit kSw64kS[5][16] = {
+// (PatBit is declared up top; sw4kb_morton truncates this table for the 4KB order — #379.)
+const PatBit kSw64kS[5][16] = {
     { {0x0001,0x0000}, {0x0002,0x0000}, {0x0004,0x0000}, {0x0008,0x0000}, {0x0000,0x0001}, {0x0000,0x0002}, {0x0000,0x0004}, {0x0000,0x0008}, {0x0000,0x0010}, {0x0010,0x0000}, {0x0000,0x0020}, {0x0020,0x0000}, {0x0000,0x0040}, {0x0040,0x0000}, {0x0000,0x0080}, {0x0080,0x0000} },  // 1 bpe
     { {0x0000,0x0000}, {0x0001,0x0000}, {0x0002,0x0000}, {0x0004,0x0000}, {0x0000,0x0001}, {0x0000,0x0002}, {0x0000,0x0004}, {0x0008,0x0000}, {0x0000,0x0008}, {0x0010,0x0000}, {0x0000,0x0010}, {0x0020,0x0000}, {0x0000,0x0020}, {0x0040,0x0000}, {0x0000,0x0040}, {0x0080,0x0000} },  // 2 bpe
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0002,0x0000}, {0x0000,0x0001}, {0x0000,0x0002}, {0x0000,0x0004}, {0x0004,0x0000}, {0x0000,0x0008}, {0x0008,0x0000}, {0x0000,0x0010}, {0x0010,0x0000}, {0x0000,0x0020}, {0x0020,0x0000}, {0x0000,0x0040}, {0x0040,0x0000} },  // 4 bpe

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -166,6 +166,58 @@ int main() {
         CHECK(t8[4096] == lin8[(size_t)0 * 128 + 64], "8-bpp golden: texel (64,0) starts tile 1 (byte 4096, 64-wide tile)");
     }
 
+    // #379: golden within-tile order for the remaining element sizes 2/8/16 B — derived from the low
+    // (bx+by) bits of the authoritative kSw64kS pattern (docs/GFX10_SW_64KB_TILING.md: the 4KB order is
+    // the low-bit truncation of the 64KB order). The old L-generator was correct only at 1 B / 4 B; at
+    // 2/8/16 B it swapped the low X/Y pairs, scrambling every SW_4KB_S R16 / BC1/BC4 / BC2/3/5/6/7
+    // surface into a coherent-looking weave. Each element stores x in byte0 and y in byte1, so a checked
+    // element uniquely identifies its source texel and a mis-order cannot pass on a coincidental byte.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw4KbS;
+        auto fill = [](std::vector<uint8_t>& lin, uint32_t w, uint32_t h, uint32_t bpt) {
+            for (uint32_t y = 0; y < h; y++) for (uint32_t x = 0; x < w; x++) {
+                lin[((size_t)y * w + x) * bpt + 0] = (uint8_t)x;
+                lin[((size_t)y * w + x) * bpt + 1] = (uint8_t)y;
+            }
+        };
+        // The check: element `idx` (its byte0/byte1) equals source texel (x,y)'s byte0/byte1.
+        #define GOLD(t, lin, w, bpt, idx, tx, ty, msg) \
+            CHECK((t)[(size_t)(idx)*(bpt)+0] == (lin)[((size_t)(ty)*(w)+(tx))*(bpt)+0] && \
+                  (t)[(size_t)(idx)*(bpt)+1] == (lin)[((size_t)(ty)*(w)+(tx))*(bpt)+1], msg)
+
+        // 2 B/element (64x32 tile): order x0 x1 x2 y0 y1 y2 x3 y3 x4 y4 x5.
+        std::vector<uint8_t> lin2((size_t)128 * 64 * 2, 0); fill(lin2, 128, 64, 2);
+        std::vector<uint8_t> t2(tiled_surface_bytes(128, 64, M, 0, 2), 0);
+        tile_surface(t2.data(), lin2.data(), 128, 64, M, 0, 2);
+        GOLD(t2, lin2, 128, 2, 1,  1, 0, "2 B golden: texel (1,0) -> element 1 (x0 at bit 0)");
+        GOLD(t2, lin2, 128, 2, 2,  2, 0, "2 B golden: texel (2,0) -> element 2 (x1 at bit 1)");
+        GOLD(t2, lin2, 128, 2, 4,  4, 0, "2 B golden: texel (4,0) -> element 4 (x2 at bit 2)");
+        GOLD(t2, lin2, 128, 2, 8,  0, 1, "2 B golden: texel (0,1) -> element 8 (y0 at bit 3)");
+        GOLD(t2, lin2, 128, 2, 16, 0, 2, "2 B golden: texel (0,2) -> element 16 (y1 at bit 4)");
+
+        // 8 B/element (32x16 tile, BC1/BC4 blocks): order x0 y0 y1 x1 x2 y2 x3 y3 x4.
+        std::vector<uint8_t> lin8b((size_t)64 * 32 * 8, 0); fill(lin8b, 64, 32, 8);
+        std::vector<uint8_t> t8b(tiled_surface_bytes(64, 32, M, 0, 8), 0);
+        tile_surface(t8b.data(), lin8b.data(), 64, 32, M, 0, 8);
+        GOLD(t8b, lin8b, 64, 8, 1,  1, 0, "8 B golden: texel (1,0) -> element 1 (x0 at bit 0)");
+        GOLD(t8b, lin8b, 64, 8, 2,  0, 1, "8 B golden: texel (0,1) -> element 2 (y0 at bit 1)");
+        GOLD(t8b, lin8b, 64, 8, 4,  0, 2, "8 B golden: texel (0,2) -> element 4 (y1 at bit 2)");
+        GOLD(t8b, lin8b, 64, 8, 8,  2, 0, "8 B golden: texel (2,0) -> element 8 (x1 at bit 3)");
+        GOLD(t8b, lin8b, 64, 8, 16, 4, 0, "8 B golden: texel (4,0) -> element 16 (x2 at bit 4)");
+
+        // 16 B/element (16x16 tile, BC2/3/5/6/7 blocks): order y0 y1 x0 x1 y2 x2 y3 x3 — Y pair FIRST.
+        // The old code emitted the X pair first, swapping every non-(0,0) block in the micro-tile.
+        std::vector<uint8_t> lin16((size_t)32 * 32 * 16, 0); fill(lin16, 32, 32, 16);
+        std::vector<uint8_t> t16(tiled_surface_bytes(32, 32, M, 0, 16), 0);
+        tile_surface(t16.data(), lin16.data(), 32, 32, M, 0, 16);
+        GOLD(t16, lin16, 32, 16, 1,  0, 1, "16 B golden: texel (0,1) -> element 1 (y0 at bit 0)");
+        GOLD(t16, lin16, 32, 16, 2,  0, 2, "16 B golden: texel (0,2) -> element 2 (y1 at bit 1)");
+        GOLD(t16, lin16, 32, 16, 4,  1, 0, "16 B golden: texel (1,0) -> element 4 (x0 at bit 2)");
+        GOLD(t16, lin16, 32, 16, 8,  2, 0, "16 B golden: texel (2,0) -> element 8 (x1 at bit 3)");
+        GOLD(t16, lin16, 32, 16, 16, 0, 4, "16 B golden: texel (0,4) -> element 16 (y2 at bit 4)");
+        #undef GOLD
+    }
+
     // --- GFX10 64KB modes (#288): SW_64KB_S (tile_mode 9) and SW_64KB_R_X (tile_mode 27). ---
     CHECK(tile_mode_is_tiled((uint32_t)TileMode::Sw64KbS),  "tile_mode 9 (SW_64KB_S) is tiled");
     CHECK(tile_mode_is_tiled((uint32_t)TileMode::Sw64KbRX), "tile_mode 27 (SW_64KB_R_X) is tiled");


### PR DESCRIPTION
## Problem
`sw4kb_morton` computed the GFX10 `SW_4KB_S` element order with an ad-hoc *"L low-X, L low-Y, then (y,x) Morton pairs"* generator (L=4 for the 1-byte tile, L=2 otherwise). That is correct **only at 1 bpe and 4 bpe** — the two pixel-verified cases — and **wrong at 2, 8 and 16 bpe**: it swaps the low X/Y coordinate pairs, so every `SW_4KB_S` surface with a 2 B (R16/R5G6B5), 8 B (BC1/BC4 blocks) or 16 B (BC2/3/5/6/7 blocks) element de-swizzles into a coherent-looking-but-scrambled weave — the #118/#102 failure class at those element sizes.

CI missed it because `test_tile` only checked `tile∘detile` round-trip identity (self-consistent with the same wrong order) plus golden orders for the two verified cases.

## Fix
The `SW_4KB_S` order is exactly the low-`(bx+by)`-bit truncation of the authoritative addrlib `SW_64KB_S` pattern (`docs/GFX10_SW_64KB_TILING.md`). Derive it from the in-file `kSw64kS` table already used by the 64KB detiler: element index bit `e` reads pattern entry `[elem_log2 + e]`, whose set x/y mask names the coordinate bit at output bit `e`. One validated source of truth for both tile sizes; reproduces all five ground-truth orders (1 B and 4 B pixel-verified cases unchanged):

| bpe | order (low→high) |
|-----|------------------|
| 1 B | x0 x1 x2 x3 y0 y1 y2 y3 y4 x4 y5 x5 |
| 2 B | x0 x1 x2 y0 y1 y2 x3 y3 x4 y4 x5 |
| 4 B | x0 x1 y0 y1 y2 x2 y3 x3 y4 x4 |
| 8 B | x0 y0 y1 x1 x2 y2 x3 y3 x4 |
| 16 B | y0 y1 x0 x1 y2 x2 y3 x3 |

## Verification
- `test_tile` now asserts golden element positions for **all of 2/8/16 B** (each element stores its x,y so a mis-order cannot pass on the round-trip alone). Both derivations in the issue agree and reproduce the pixel-verified 1 B / 4 B orders exactly.
- Full ctest 82/82 green.

Fixes #379