### PR TITLE
fix(hle/file): loop sceKernelWrite/Pwrite to the full-write contract

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -357,6 +357,21 @@ static int64_t read_full(int fd, void* buf, size_t count, bool positioned, off_t
     }
     return (int64_t)done;
 }
+// Symmetric FULL write: sceKernelWrite/Pwrite on PS5 return the full count for a regular file, and the
+// same save/asset code assumes it. A short host ::write (signal, buffer boundary, near-ENOSPC) returned
+// verbatim would silently truncate a save; the guest, assuming the full contract, never re-issues the
+// remainder. Loop to the full-write contract. Returns bytes written (== count on success), or -1/errno.
+static int64_t write_full(int fd, const void* buf, size_t count, bool positioned, off_t off) {
+    size_t done = 0;
+    while (done < count) {
+        ssize_t w = positioned ? ::pwrite(fd, (const char*)buf + done, count - done, off + (off_t)done)
+                               : ::write(fd, (const char*)buf + done, count - done);
+        if (w < 0) { if (errno == EINTR) continue; return done ? (int64_t)done : (int64_t)-1; }
+        if (w == 0) break;   // no progress on a regular file — avoid an infinite loop
+        done += (size_t)w;
+    }
+    return (int64_t)done;
+}
 #endif
 HLE(f_read)  { if (fdlog_on()) preadlog("read", a0, (uint64_t)::lseek((int)a0, 0, SEEK_CUR), a2);
 #ifndef _WIN32
@@ -365,12 +380,18 @@ HLE(f_read)  { if (fdlog_on()) preadlog("read", a0, (uint64_t)::lseek((int)a0, 0
                return (uint64_t)(int64_t)::read((int)a0, P(a1), (size_t)a2);
 #endif
              }
-HLE(f_write) { return (uint64_t)(int64_t)::write((int)a0, P(a1), (size_t)a2); }
+HLE(f_write) {
+#ifndef _WIN32
+               return (uint64_t)write_full((int)a0, P(a1), (size_t)a2, false, 0);
+#else
+               return (uint64_t)(int64_t)::write((int)a0, P(a1), (size_t)a2);
+#endif
+             }
 HLE(f_lseek) { if (fdlog_on() && ((int)a2 != SEEK_CUR || a1 != 0)) preadlog("lseek", a0, a1, (uint64_t)a2);
                return (uint64_t)(int64_t)::lseek((int)a0, (off_t)a1, (int)a2); }
 #ifndef _WIN32
 HLE(f_pread)  { preadlog("pread", a0, a3, a2); return (uint64_t)read_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3); }
-HLE(f_pwrite) { return (uint64_t)(int64_t)::pwrite((int)a0, P(a1), (size_t)a2, (off_t)a3); }
+HLE(f_pwrite) { return (uint64_t)write_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3); }
 #else
 HLE(f_pread)  { return (uint64_t)-1; }
 HLE(f_pwrite) { return (uint64_t)-1; }


### PR DESCRIPTION
Read side already loops (read_full); the write side didn't -> a short host write truncates a save the guest never re-issues. Add write_full() mirroring read_full and route f_write/f_pwrite through it. Refs #389.