### PR TITLE
fix(gpu): sceAgcCbNop(dcb,1) must not underflow the PM4 length field (#401)

### DIFF
--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -20,7 +20,16 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
     size_t i = 0;
     while (i < dwords) {
         uint32_t h = buf[i];
-        if (!is_type3(h)) break;                       // not a packet -> stop (pad/garbage)
+        if (!is_type3(h)) {
+            // PM4 TYPE-2 (bits[31:30] == 0b10, e.g. 0x80000000) is a single-dword filler NOP — the CP
+            // skips it and keeps executing. sceAgcCbNop(dcb, 1) emits one (a 1-dword pad cannot be a
+            // type-3 packet, whose minimum is 2 dwords). Skip it and continue rather than ending the
+            // walk, so a 1-dword pad does not truncate the rest of the submit (#401). Any OTHER
+            // non-type-3 dword (type-0 register writes we never emit, zero padding, garbage) still
+            // ends the walk as before.
+            if ((h & 0xC0000000u) == 0x80000000u) { i += 1; continue; }
+            break;                                     // not a packet -> stop (pad/garbage)
+        }
         uint32_t len = hdr_len(h);
         if (len == 0 || i + len > dwords) break;        // truncated packet -> stop
 

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -281,6 +281,18 @@ HLE(agc_suspend_point) { return 0; }
 // sceAgcCbNop (LtTouSCZjHM) — append a1 padding dwords as a single NOP packet; return its pointer.
 HLE(agc_cb_nop) {  // (dcb, num_dwords, ...)
     uint32_t num = (uint32_t)a1; if (!a0 || !num) return 0;
+    // A type-3 NOP packet is at minimum 2 dwords (header + >=1 body). PM4() encodes the length as
+    // (num-2), so num==1 would UNDERFLOW the 14-bit length field to 0x3fff — a header claiming ~0x4001
+    // dwords for a physically 1-dword packet, which mis-frames (drops or truncates) the entire rest of
+    // the submit fold (#401). A genuine 1-dword pad is a PM4 TYPE-2 filler NOP (0x80000000), which the
+    // CP / our decoder now skips as a single dword — emit that instead of a malformed type-3 header.
+    if (num == 1) {
+        auto* dcb = (AgcDcb*)(uintptr_t)a0;
+        uint32_t* cmd = dcb->allocate_dw(1);
+        if (!cmd) return 0;
+        cmd[0] = 0x80000000u;   // PM4 type-2 single-dword NOP filler
+        return (uint64_t)(uintptr_t)cmd;
+    }
     uint32_t* cmd; if (!begin_packet(a0, num, IT_NOP, 0, &cmd)) return 0;
     for (uint32_t i = 1; i < num; i++) cmd[i] = 0;
     return (uint64_t)(uintptr_t)cmd;

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -94,6 +94,32 @@ int main() {
     }
     CHECK(spans_ok, "all packet lengths/payload spans are in-bounds");
 
+    // #401: sceAgcCbNop(dcb, 1) must NOT underflow the type-3 length field (num-2 == 0x3fff) and
+    // mis-frame the whole submit. A 1-dword pad is emitted as a PM4 TYPE-2 filler (0x80000000) that
+    // the decoder skips, so a real packet placed AFTER a 1-dword NOP still decodes — before the fix
+    // the malformed 0x4001-dword header swallowed or truncated everything after it.
+    {
+        auto nop = Hle::lookup("LtTouSCZjHM");   // sceAgcCbNop
+        CHECK(nop, "sceAgcCbNop registered");
+        uint32_t buf2[64]; memset(buf2, 0, sizeof buf2);
+        Dcb d2{}; d2.bottom = buf2; d2.top = buf2 + 64; d2.cursor_up = buf2; d2.cursor_down = buf2 + 64;
+        auto D2 = (uint64_t)(uintptr_t)&d2;
+        uint64_t np = nop(D2, /*num_dwords*/ 1, 0, 0, 0, 0);
+        CHECK(np && *(const uint32_t*)(uintptr_t)np == 0x80000000u,
+              "cb_nop(1) emits a 1-dword PM4 type-2 filler (0x80000000), not an underflowed type-3 header");
+        CHECK((size_t)(d2.cursor_up - d2.bottom) == 1, "cb_nop(1) advanced the cursor by exactly 1 dword");
+        draw(D2, /*index_count*/ 0x0055, 0, 0, 0, 0);   // a real packet AFTER the 1-dword NOP
+        std::vector<Pm4Command> ops2;
+        decode_pm4(buf2, 64, ops2);
+        CHECK(ops2.size() == 1 && ops2[0].kind == K::DrawIndexAuto && ops2[0].index_count == 0x0055,
+              "the type-2 filler is skipped and the draw after a 1-dword NOP still decodes (fold intact)");
+        // A normal multi-dword NOP still frames as one type-3 packet (regression guard).
+        uint32_t buf3[64]; memset(buf3, 0, sizeof buf3);
+        Dcb d3{}; d3.bottom = buf3; d3.top = buf3 + 64; d3.cursor_up = buf3; d3.cursor_down = buf3 + 64;
+        nop((uint64_t)(uintptr_t)&d3, /*num_dwords*/ 4, 0, 0, 0, 0);
+        CHECK((size_t)(d3.cursor_up - d3.bottom) == 4, "cb_nop(4) reserves 4 dwords (type-3 NOP unchanged)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem
`agc_cb_nop` built its header with `PM4(num, IT_NOP, 0)`, which encodes length as `(num-2)`, and only guarded `num==0`. For `num==1` the 14-bit length field **underflowed to 0x3fff** — a header claiming ~0x4001 dwords for a physically 1-dword packet. `decode_pm4` then either swallowed the following ~0x4000 dwords (real register sets / draws / fences) as the NOP's body, or hit `i+len > dwords` and broke — **truncating the walk**. Either way every packet after the NOP was lost from the submit fold.

## Fix
A type-3 NOP is minimum 2 dwords (header + ≥1 body); a genuine 1-dword pad is a PM4 **type-2** filler (`0x80000000`) that hardware's CP skips.
- `agc_cb_nop`: for `num==1`, emit a 1-dword type-2 filler instead of a malformed type-3 header (`num>=2` unchanged).
- `decode_pm4`: skip a type-2 dword (`bits[31:30]==0b10`) and continue the walk instead of ending it. Any other non-type-3 dword (type-0, zero padding, garbage) still ends the walk as before.

## Verification
- `test_pm4_decode` asserts `cb_nop(1)` emits `0x80000000` in exactly one dword, a real draw placed **after** a 1-dword NOP still decodes (fold intact), and a multi-dword NOP still frames as one type-3 packet.
- Full ctest 82/82 green.

Fixes #401