### PR TITLE
fix(hle/service): ParamGetInt ENTER_BUTTON_ASSIGN defaults to Cross, not Circle

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -215,6 +215,11 @@ HLE(s_syss_param_int) {
     if (paramId == 1) {                      // SCE_SYSTEM_SERVICE_PARAM_ID_LANG
         val = 1;                             // SCE_SYSTEM_PARAM_LANG_ENGLISH_US
         if (const char* e = getenv("PROSPER_SYS_LANG")) val = (int32_t)strtol(e, nullptr, 0);
+    } else if (paramId == 1000) {            // SCE_SYSTEM_SERVICE_PARAM_ID_ENTER_BUTTON_ASSIGN
+        // Cross = confirm (Western default). Previously fell through to val=0 = Circle, which inverts
+        // ✕/○ confirm/cancel and on-screen button prompts relative to the en-US locale we present.
+        val = 1;                             // Cross (shadPS4 default; Circle=0)
+        if (const char* e = getenv("PROSPER_ENTER_BUTTON")) val = (int32_t)strtol(e, nullptr, 0);
     }
     if (a1) *(int32_t*)PW(a1) = val;
     return 0;


### PR DESCRIPTION
ParamGetInt only handled paramId 1 (LANG); ENTER_BUTTON_ASSIGN (1000) fell through to 0=Circle, inverting confirm/cancel vs the en-US locale we present. Return Cross(1), env-overridable via PROSPER_ENTER_BUTTON. Refs #392.