### PR TITLE
fix(gpu): extract + resolve separate alpha blend (CB_BLEND0_CONTROL) (#381)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -102,6 +102,12 @@ RenderState extract_render_state(const GpuState& st) {
     rs.color_src_blend = PM4_FIELD(bc, CB_BLEND0_CONTROL, COLOR_SRCBLEND);
     rs.color_dst_blend = PM4_FIELD(bc, CB_BLEND0_CONTROL, COLOR_DESTBLEND);
     rs.color_comb_fcn  = PM4_FIELD(bc, CB_BLEND0_CONTROL, COLOR_COMB_FCN);
+    // Separate alpha blend (#381): the alpha channel has its own factors/op when SEPARATE_ALPHA_BLEND
+    // is set (a common UI/premultiplied pattern: color SrcAlpha/OneMinusSrcAlpha but alpha One/OneMinus).
+    rs.separate_alpha_blend = PM4_FIELD(bc, CB_BLEND0_CONTROL, SEPARATE_ALPHA_BLEND) != 0;
+    rs.alpha_src_blend = PM4_FIELD(bc, CB_BLEND0_CONTROL, ALPHA_SRCBLEND);
+    rs.alpha_dst_blend = PM4_FIELD(bc, CB_BLEND0_CONTROL, ALPHA_DESTBLEND);
+    rs.alpha_comb_fcn  = PM4_FIELD(bc, CB_BLEND0_CONTROL, ALPHA_COMB_FCN);
 
     // Faithful raw state registers.
     rs.db_depth_control  = dc;
@@ -188,6 +194,19 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     ps.src_color_blend_factor  = vk_blend_factor(rs.color_src_blend);
     ps.dst_color_blend_factor  = vk_blend_factor(rs.color_dst_blend);
     ps.color_blend_op          = vk_blend_op(rs.color_comb_fcn);
+    // Alpha blend factors/op (#381): use the separate ALPHA_* fields when SEPARATE_ALPHA_BLEND is set,
+    // else mirror the color factors (RDNA2 behavior — Kyty GraphicsRender). The backend reads these
+    // directly, so it no longer has to reuse the color factors for the alpha channel (which corrupted
+    // stored dst-alpha on any target later read back — RTT composites, alpha-test/text layers).
+    if (rs.separate_alpha_blend) {
+        ps.src_alpha_blend_factor = vk_blend_factor(rs.alpha_src_blend);
+        ps.dst_alpha_blend_factor = vk_blend_factor(rs.alpha_dst_blend);
+        ps.alpha_blend_op         = vk_blend_op(rs.alpha_comb_fcn);
+    } else {
+        ps.src_alpha_blend_factor = ps.src_color_blend_factor;
+        ps.dst_alpha_blend_factor = ps.dst_color_blend_factor;
+        ps.alpha_blend_op         = ps.color_blend_op;
+    }
 
     // CB_TARGET_MASK holds a 4-bit write mask per MRT; MRT0 is bits [3:0]. RDNA2's R/G/B/A bit order
     // matches VkColorComponentFlags (R=1,G=2,B=4,A=8), so the nibble maps 1:1.

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -48,6 +48,12 @@ struct RenderState {
     uint32_t color_src_blend = 0;     // COLOR_SRCBLEND
     uint32_t color_dst_blend = 0;     // COLOR_DESTBLEND
     uint32_t color_comb_fcn  = 0;     // COLOR_COMB_FCN (blend op)
+    // Separate alpha-channel blend (CB_BLEND0_CONTROL.SEPARATE_ALPHA_BLEND @29): when set, the alpha
+    // channel blends with its OWN factors/op; when clear, alpha mirrors the color factors (#381).
+    bool     separate_alpha_blend = false;
+    uint32_t alpha_src_blend  = 0;    // ALPHA_SRCBLEND  (@16)
+    uint32_t alpha_dst_blend  = 0;    // ALPHA_DESTBLEND (@24)
+    uint32_t alpha_comb_fcn   = 0;    // ALPHA_COMB_FCN  (@21)
 
     // Raw state registers — remaining bit layouts decoded by the Vulkan backend later (kept faithful).
     uint32_t db_depth_control  = 0;   // DB_DEPTH_CONTROL
@@ -106,6 +112,12 @@ struct ResolvedPipelineState {
     uint32_t src_color_blend_factor = 0;   // == VkBlendFactor
     uint32_t dst_color_blend_factor = 0;   // == VkBlendFactor
     uint32_t color_blend_op         = 0;   // == VkBlendOp
+    // Alpha-channel blend factors/op (== VkBlendFactor/VkBlendOp). Resolve sets these from the separate
+    // ALPHA_* fields when SEPARATE_ALPHA_BLEND is set, else mirrors the color factors — so the backend
+    // can always read ps->*_alpha_* directly instead of guessing (#381).
+    uint32_t src_alpha_blend_factor = 0;   // == VkBlendFactor
+    uint32_t dst_alpha_blend_factor = 0;   // == VkBlendFactor
+    uint32_t alpha_blend_op         = 0;   // == VkBlendOp
     uint32_t color_write_mask       = 0xF; // == VkColorComponentFlags (RGBA); MRT0 nibble of CB_TARGET_MASK
 
     // Guest viewport as a Vulkan viewport rect. `has_viewport` is false when the guest never programmed

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -339,9 +339,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             cba.srcColorBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;
             cba.dstColorBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
             cba.colorBlendOp        = (VkBlendOp)ps->color_blend_op;
-            cba.srcAlphaBlendFactor = (VkBlendFactor)ps->src_color_blend_factor;   // mirror color for alpha
-            cba.dstAlphaBlendFactor = (VkBlendFactor)ps->dst_color_blend_factor;
-            cba.alphaBlendOp        = (VkBlendOp)ps->color_blend_op;
+            // Alpha channel uses its OWN resolved factors (#381): resolve set these from the separate
+            // ALPHA_* blend fields when SEPARATE_ALPHA_BLEND was programmed, else it already mirrored the
+            // color factors — so this is correct in both cases without guessing here.
+            cba.srcAlphaBlendFactor = (VkBlendFactor)ps->src_alpha_blend_factor;
+            cba.dstAlphaBlendFactor = (VkBlendFactor)ps->dst_alpha_blend_factor;
+            cba.alphaBlendOp        = (VkBlendOp)ps->alpha_blend_op;
         }
         VkPipelineColorBlendStateCreateInfo cb{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
         cb.attachmentCount = 1; cb.pAttachments = &cba;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -127,6 +127,27 @@ int main() {
     CHECK(vk_blend_factor(0x08u) == 4u, "RDNA2 DstColor(8) -> VK DST_COLOR(4) (non-identity)");
     CHECK(vk_blend_op(2u) == 3u, "RDNA2 comb Min(2) -> VK MIN(3) (non-identity)");
 
+    // #381: separate alpha blend. The extractor's rs (bit 29 clear) mirrors color into alpha on resolve;
+    // with SEPARATE_ALPHA_BLEND set, the alpha channel resolves from its OWN factors, independent of color.
+    CHECK(!rs.separate_alpha_blend, "SEPARATE_ALPHA_BLEND not set in the sample stream");
+    {
+        ResolvedPipelineState mirror = resolve_pipeline_state(rs);
+        CHECK(mirror.src_alpha_blend_factor == mirror.src_color_blend_factor &&
+              mirror.dst_alpha_blend_factor == mirror.dst_color_blend_factor &&
+              mirror.alpha_blend_op == mirror.color_blend_op,
+              "no SEPARATE_ALPHA_BLEND -> alpha factors mirror color");
+        RenderState sep = rs;
+        sep.separate_alpha_blend = true;
+        sep.alpha_src_blend = 1u;  // One
+        sep.alpha_dst_blend = 5u;  // OneMinusSrcAlpha
+        sep.alpha_comb_fcn  = 0u;  // Add
+        ResolvedPipelineState psep = resolve_pipeline_state(sep);
+        CHECK(psep.src_alpha_blend_factor == vk_blend_factor(1u) &&
+              psep.dst_alpha_blend_factor == vk_blend_factor(5u) &&
+              psep.src_alpha_blend_factor != psep.src_color_blend_factor,
+              "SEPARATE_ALPHA_BLEND -> alpha uses its own factors (One/OneMinusSrcAlpha), not color's");
+    }
+
     CHECK(rs.db_depth_control  == 0x00000046u, "db_depth_control raw preserved");
     CHECK(rs.cb_color_control  == 0x00CC0010u, "cb_color_control raw preserved");
     CHECK(rs.cb_target_mask    == 0x0000000Fu, "cb_target_mask raw preserved");


### PR DESCRIPTION
## Problem
`CB_BLEND0_CONTROL` carries an independent alpha-channel blend equation (`ALPHA_SRCBLEND` @16, `ALPHA_COMB_FCN` @21, `ALPHA_DESTBLEND` @24) gated by `SEPARATE_ALPHA_BLEND` @29. `extract_render_state` read only the **color** fields and `ResolvedPipelineState` had **no alpha members**, so the backend reused the color factors for alpha (`render_runner.h`: *"mirror color for alpha"*).

For a common UI/premultiplied setup — color `(SrcAlpha, OneMinusSrcAlpha)` with a *different* alpha equation like `(One, OneMinusSrcAlpha)` — the destination alpha was computed with the wrong factors, corrupting any later read of that target (RTT composites #167/#286, alpha-test/text layers, multi-pass UI over an intermediate attachment). The final backbuffer is unaffected (alpha ignored at scanout); intermediate targets are not.

## Fix
- `RenderState`: add `separate_alpha_blend` + `alpha_src_blend`/`alpha_dst_blend`/`alpha_comb_fcn`, extracted from the `ALPHA_*` fields (constants already in `pm4_registers.hpp`).
- `ResolvedPipelineState`: add `src/dst_alpha_blend_factor` + `alpha_blend_op`; resolve sets them from the alpha fields when `separate_alpha_blend`, else mirrors the color factors (RDNA2 behavior, matching Kyty `GraphicsRender`).
- `render_runner.h`: bind `ps->*_alpha_*` directly instead of mirroring color.

## Verification
- `test_render_state` asserts alpha mirrors color when the bit is clear and uses its own factors when set.
- Full ctest 82/82 green (alpha factors only affect the output alpha channel, so RGB render tests are unaffected).

Fixes #381