### PR TITLE
fix(recompiler): s_max_i32/s_max_u32 SCC is >= (not >) on ties (#397)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1921,12 +1921,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.scc = b.bsel(k1, b.btrue(), k2); break;
                 }
                 // s_min/max (0x06 min_i32, 0x07 min_u32, 0x08 max_i32, 0x09 max_u32): SCC = "src0 was
-                // selected" (S0<S1 for min, S0>S1 for max — RDNA2 ISA). Round-trip llvm-mc gfx1010:
+                // selected". The RDNA2 ISA min/max SCC split is intentionally ASYMMETRIC so a min/max
+                // pair partitions ties consistently: S_MIN uses strict `S0 < S1`, S_MAX uses non-strict
+                // `S0 >= S1` (S_MAX_I32: D=(S0>=S1)?S0:S1, SCC=(S0>=S1)). Using strict `>` for max set
+                // SCC=0 on exact-equality operands where hardware sets 1 (#397) — D is unaffected (SMax
+                // returns the equal value either way), so it was purely an SCC-flag defect that could
+                // mis-step a downstream s_cbranch_scc/s_cselect on a tie. Round-trip llvm-mc gfx1010:
                 // 0x83000201/0x83800201/0x84000201/0x84800201. CONFIDENCE: HIGH.
-                case 0x06: rs.scc = b.scmp(Op_SLessThan, a, c);    d = b.sext2(Glsl_SMin, a, c); break;
-                case 0x07: rs.scc = b.ucmp(Op_ULessThan, a, c);    d = b.uext2(Glsl_UMin, a, c); break;
-                case 0x08: rs.scc = b.scmp(Op_SGreaterThan, a, c); d = b.sext2(Glsl_SMax, a, c); break;
-                case 0x09: rs.scc = b.ucmp(Op_UGreaterThan, a, c); d = b.uext2(Glsl_UMax, a, c); break;
+                case 0x06: rs.scc = b.scmp(Op_SLessThan, a, c);         d = b.sext2(Glsl_SMin, a, c); break;
+                case 0x07: rs.scc = b.ucmp(Op_ULessThan, a, c);         d = b.uext2(Glsl_UMin, a, c); break;
+                case 0x08: rs.scc = b.scmp(Op_SGreaterThanEqual, a, c); d = b.sext2(Glsl_SMax, a, c); break;
+                case 0x09: rs.scc = b.ucmp(Op_UGreaterThanEqual, a, c); d = b.uext2(Glsl_UMax, a, c); break;
                 case 0x0A: d = b.sel(rs.scc, a, c); break;           // s_cselect_b32: SCC ? src0 : src1
                 case 0x0E: d = b.ibin(Op_BitwiseAnd, a, c); scc_nz(d); break;   // s_and_b32
                 case 0x10: d = b.ibin(Op_BitwiseOr,  a, c); scc_nz(d); break;   // s_or_b32

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1496,6 +1496,21 @@ int main() {
     }
     CHECK(gotT5.size()==N && badT5==0, "T5: s_min_u32(7,3)=3 + s_max_i32(-2,5)=5");
 
+    // Kernel T5b (#397): s_max SCC on a TIE. s_max_i32 s2,5,5 -> SCC=(5>=5)=1 per RDNA2 ISA (the
+    // asymmetric min/max split: min uses strict `<`, max uses non-strict `>=`). s_cselect_b32 s3 =
+    // SCC ? 11 : 4, then v1 = a0 + s3. Locks SCC=1 on equality: out bits = bits(a0) + 11. The old
+    // strict `>` set SCC=0 on the tie -> s3=4 -> bits(a0)+4, which this catches. (llvm-mc gfx1010.)
+    const uint32_t codeT5b[] = { 0x84028585u, 0x8503848bu, 0x4a020003u, 0xBF810000u };
+    std::vector<uint32_t> spvT5b = recompile_valu(codeT5b, sizeof(codeT5b)/4, 1, 1);
+    CHECK(!spvT5b.empty(), "recompiled T5b (s_max_i32 SCC on a tie + s_cselect) -> SPIR-V");
+    std::vector<float> gotT5b = prosper::test::run_compute(spvT5b, inX, N, N);
+    uint32_t badT5b = 0;
+    for (uint32_t i = 0; i < N && gotT5b.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotT5b[i], 4);
+        if (gb != bits_of(inX[i]) + 11u) badT5b++;
+    }
+    CHECK(gotT5b.size()==N && badT5b==0, "T5b: s_max_i32(5,5) sets SCC=1 (>=), s_cselect picks 11 not 4");
+
     // Kernel T6: s_add_u32 carry chain -> s_addc_u32. s0=-1+2 (carry SCC=1); s1=0+0+SCC=1.
     // out bits = bits(a0) + 1.
     const uint32_t codeT6[] = { 0x800082c1u, 0x82018080u, 0x4a020001u, 0xBF810000u };


### PR DESCRIPTION
## Problem
The RDNA2 scalar min/max SCC split is intentionally asymmetric so a min/max pair partitions ties consistently: `S_MIN` uses strict `S0 < S1`, `S_MAX` uses **non-strict** `S0 >= S1` (`S_MAX_I32: D=(S0>=S1)?S0:S1, SCC=(S0>=S1)`). The recompiler emitted a strict `>` for the max SCC, so on exact-equality operands (`S0==S1`) it set `SCC=0` where hardware sets `1`.

`D` was unaffected (SMax returns the equal value on a tie), so this was a pure SCC-flag defect — but a subsequent `s_cbranch_scc` / `s_cselect` / `s_addc` consuming it would take the wrong wave-uniform path with no diagnostic.

## Fix
Use `Op_SGreaterThanEqual` / `Op_UGreaterThanEqual` for the `0x08`/`0x09` max SCC (mirroring the min asymmetry), and correct the misleading comment.

## Verification
`test_rdna2_to_spirv` T5b (new): `s_max_i32 s2,5,5` (a tie) → SCC must be 1, so `s_cselect` picks 11 not 4 (out = `a0 + 11`); the old strict `>` produced `a0 + 4`. Kernel encodings assembled with `llvm-mc-18 -mcpu=gfx1010`. ctest green.

Fixes #397