### PR TITLE
fix(gpu): clear depth to guest DB_DEPTH_CLEAR / compare-op default, not 0.5 (#371)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -96,6 +96,13 @@ RenderState extract_render_state(const GpuState& st) {
     rs.z_write_enable = PM4_FIELD(dc, DB_DEPTH_CONTROL, Z_WRITE_ENABLE) != 0;
     rs.zfunc          = PM4_FIELD(dc, DB_DEPTH_CONTROL, ZFUNC);
 
+    // Depth/stencil clear values (DB_DEPTH_CLEAR = IEEE-754 float, DB_STENCIL_CLEAR = 8-bit). Present
+    // only when the game programmed them; the depth attachment's LOAD_OP_CLEAR must use the guest's
+    // value (not a fixed 0.5) or a standard depth test wrongly rejects fragments (#371).
+    rs.has_depth_clear     = st.cx.count(P::DB_DEPTH_CLEAR) != 0;
+    rs.depth_clear_value   = rs.has_depth_clear ? flt(rd(st.cx, P::DB_DEPTH_CLEAR)) : 1.0f;
+    rs.stencil_clear_value = PM4_FIELD(rd(st.cx, P::DB_STENCIL_CLEAR), DB_STENCIL_CLEAR, CLEAR);
+
     // Color blend state (decoded fields of CB_BLEND0_CONTROL).
     const uint32_t bc = rd(st.cx, P::CB_BLEND0_CONTROL);
     rs.blend_enable    = PM4_FIELD(bc, CB_BLEND0_CONTROL, ENABLE) != 0;
@@ -151,6 +158,17 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     ps.depth_test_enable  = rs.z_enable;
     ps.depth_write_enable = rs.z_write_enable;
     ps.depth_compare_op   = vk_compare_op(rs.zfunc);
+    // Depth clear value (#371): use the guest's DB_DEPTH_CLEAR when programmed. Otherwise pick a default
+    // matching the resolved compare op — LESS/LESS_OR_EQUAL clear to 1.0 (far), GREATER/GREATER_OR_EQUAL
+    // (reversed-Z) clear to 0.0 (near) — the overwhelmingly common convention, and never a fixed 0.5
+    // (which discards every fragment on the wrong side of 0.5 under a standard depth test).
+    if (rs.has_depth_clear) {
+        ps.depth_clear_value = rs.depth_clear_value;
+    } else {
+        const uint32_t op = ps.depth_compare_op;   // VkCompareOp: LESS=1, LEQUAL=3, GREATER=4, GEQUAL=6
+        ps.depth_clear_value = (op == 4u || op == 6u) ? 0.0f : 1.0f;
+    }
+    ps.stencil_clear_value = rs.stencil_clear_value;
 
     // Stencil: compare func from DB_DEPTH_CONTROL (STENCILFUNC / _BF), ops from DB_STENCIL_CONTROL,
     // ref/masks from DB_STENCILREFMASK[_BF]. [0]=front, [1]=back. Only meaningful when stencil_enable.

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -42,6 +42,13 @@ struct RenderState {
     bool     stencil_enable = false;
     uint32_t zfunc          = 0;      // compare op, 0..7 (RDNA2 order == VkCompareOp order)
 
+    // Depth/stencil CLEAR values (DB_DEPTH_CLEAR = float depth, DB_STENCIL_CLEAR = 8-bit stencil).
+    // has_depth_clear == the game PROGRAMMED DB_DEPTH_CLEAR (register present); otherwise resolve picks
+    // a compare-op-appropriate default (1.0 for LESS, 0.0 for GREATER) instead of a fixed 0.5 (#371).
+    bool     has_depth_clear     = false;
+    float    depth_clear_value   = 1.0f;
+    uint32_t stencil_clear_value = 0;
+
     // Color blend state for MRT 0, decoded from CB_BLEND0_CONTROL (RDNA2 factor/op enum values;
     // map to Vulkan with vk_blend_factor / vk_blend_op).
     bool     blend_enable    = false;
@@ -93,6 +100,12 @@ struct ResolvedPipelineState {
     bool     depth_test_enable  = false;
     bool     depth_write_enable = false;
     uint32_t depth_compare_op  = 0;  // == VkCompareOp
+    // Depth/stencil CLEAR value for VK_ATTACHMENT_LOAD_OP_CLEAR. Resolve sets depth_clear_value from the
+    // guest's DB_DEPTH_CLEAR when programmed, else a compare-op-appropriate default (1.0 for LESS/LEQUAL,
+    // 0.0 for GREATER/GEQUAL) — never a fixed 0.5, which wrongly rejects far-half geometry under a
+    // standard depth test (#371). stencil_clear_value from DB_STENCIL_CLEAR.
+    float    depth_clear_value   = 1.0f;
+    uint32_t stencil_clear_value = 0;
 
     // Stencil test state, resolved from DB_DEPTH_CONTROL (enable + STENCILFUNC) + DB_STENCIL_CONTROL
     // (ops) + DB_STENCILREFMASK[_BF] (ref / compare-mask / write-mask). Index [0]=front, [1]=back.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -200,8 +200,18 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // fixed attachment set); each draw's pipeline sets its own depthTest/Write/CompareOp. A frame with
     // no depth-using draw takes the color-only path unchanged.
     bool use_depth = false, use_stencil = false;
+    // Depth/stencil clear values for the render pass's LOAD_OP_CLEAR: take them from the first
+    // depth-testing draw's resolved state (#371). Resolve set depth_clear_value from the guest's
+    // DB_DEPTH_CLEAR, or a compare-op-appropriate default (1.0 for LESS, 0.0 for GREATER) — never the
+    // old fixed 0.5, which discarded far-half geometry under a standard LESS test.
+    float    depth_clear   = 1.0f;
+    uint32_t stencil_clear = 0;
+    bool     got_ds_clear  = false;
     for (const auto& d : draws) { if (d.ps && d.ps->depth_test_enable) use_depth = true;
-                                  if (d.ps && d.ps->stencil_enable)    use_stencil = true; }
+                                  if (d.ps && d.ps->stencil_enable)    use_stencil = true;
+                                  if (d.ps && (d.ps->depth_test_enable || d.ps->stencil_enable) && !got_ds_clear) {
+                                      depth_clear = d.ps->depth_clear_value;
+                                      stencil_clear = d.ps->stencil_clear_value; got_ds_clear = true; } }
     if (getenv("PROSPER_NO_DEPTH"))   use_depth = false;     // diag: isolate depth-test rejection
     if (getenv("PROSPER_NO_STENCIL")) use_stencil = false;   // diag: isolate stencil masking
     const bool use_ds = use_depth || use_stencil;
@@ -608,7 +618,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     if (clear_rgba && getenv("PROSPER_CLEAR_DEBUG") == nullptr)
         for (int i = 0; i < 4; i++) cc[i] = clear_rgba[i];
     VkClearValue clear[2]{}; clear[0].color = {{cc[0], cc[1], cc[2], cc[3]}};
-    clear[1].depthStencil = {0.5f, 0};   // depth cleared to 0.5 (fragments at z=0.0 pass LESS, fail GREATER)
+    clear[1].depthStencil = {depth_clear, stencil_clear};   // guest DB_DEPTH_CLEAR / compare-op default (#371)
     VkRenderPassBeginInfo rpbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
     rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}}; rpbi.clearValueCount = use_ds ? 2 : 1; rpbi.pClearValues = clear;
     if (getenv("PROSPER_PIPELOG")) {   // diag: how many draws' pipelines built + will be recorded

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -117,6 +117,24 @@ int main() {
     CHECK(rs.zfunc == 4u, "zfunc = 4 (bits [6:4])");
     CHECK(vk_compare_op(rs.zfunc) == 4u, "zfunc 4 -> VkCompareOp GREATER (1:1)");
 
+    // #371: depth clear value. The sample stream programs no DB_DEPTH_CLEAR, so resolve defaults it by
+    // the compare op — 0.0 for GREATER (this stream), 1.0 for LESS — never a fixed 0.5. A programmed
+    // DB_DEPTH_CLEAR is used verbatim.
+    CHECK(!rs.has_depth_clear, "no DB_DEPTH_CLEAR programmed in the sample stream");
+    {
+        ResolvedPipelineState pd = resolve_pipeline_state(rs);
+        CHECK(pd.depth_compare_op == 4u && pd.depth_clear_value == 0.0f,
+              "no DB_DEPTH_CLEAR + GREATER -> depth clears to 0.0 (reversed-Z near), not 0.5");
+        RenderState less_rs = rs; less_rs.zfunc = 1u;   // LESS
+        CHECK(resolve_pipeline_state(less_rs).depth_clear_value == 1.0f,
+              "no DB_DEPTH_CLEAR + LESS -> depth clears to 1.0 (far), not 0.5");
+        RenderState prog = rs; prog.has_depth_clear = true; prog.depth_clear_value = 0.25f;
+        prog.stencil_clear_value = 7u;
+        ResolvedPipelineState pp = resolve_pipeline_state(prog);
+        CHECK(pp.depth_clear_value == 0.25f && pp.stencil_clear_value == 7u,
+              "programmed DB_DEPTH_CLEAR / DB_STENCIL_CLEAR used verbatim");
+    }
+
     // Decoded blend state + RDNA2->Vulkan factor/op mapping.
     CHECK(rs.blend_enable, "blend_enable = true (bit 30)");
     CHECK(rs.color_src_blend == 4u && vk_blend_factor(rs.color_src_blend) == 6u,


### PR DESCRIPTION
## Problem
The depth attachment was always cleared to a hardcoded **0.5**, ignoring the guest's `DB_DEPTH_CLEAR`. `ResolvedPipelineState` had no depth-clear field, so there was no path for the guest value to reach the backend. With a standard depth test this wrongly rejects fragments: a conventional pass clears depth to 1.0 and draws with `LESS`, but against a 0.5 background every fragment whose NDC depth is in (0.5, 1.0] fails the test and vanishes (far-half geometry disappears); a reversed-Z `GREATER` pass clearing to 0.0 loses the near half.

## Fix
- `RenderState`: add `has_depth_clear` + `depth_clear_value` + `stencil_clear_value`, extracted from `DB_DEPTH_CLEAR` (float) / `DB_STENCIL_CLEAR`.
- `ResolvedPipelineState`: add `depth_clear_value` + `stencil_clear_value`; resolve uses the guest value when programmed, else a compare-op-appropriate default (**1.0** for LESS/LEQUAL, **0.0** for GREATER/GEQUAL) — never a fixed 0.5.
- `render_runner.h`: `clear[1].depthStencil` now uses the first depth/stencil-testing draw's resolved clear values instead of `{0.5, 0}`.

## Verification
`test_render_state` asserts the GREATER stream defaults to 0.0, a LESS variant to 1.0, and a programmed `DB_DEPTH_CLEAR`/`DB_STENCIL_CLEAR` is used verbatim. Full ctest 82/82 green.

Fixes #371