### PR TITLE
fix(gpu): set-0 (vertex) textures need VERTEX stageFlags, not fragment-only (#376)

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -404,7 +404,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
                 if (r.is_texture()) {
                     n_sampler++;
-                    lb[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; lb[i].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+                    lb[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+                    // A set-0 texture belongs to the VERTEX shader (build_R tags VS resources into set 0,
+                    // PS into set 1). stageFlags must include every stage that reads the binding, so a
+                    // vertex texture fetch (displacement/heightmap, GPU vertex animation) needs
+                    // VERTEX_BIT — a fragment-only hardcode made set-0 textures invisible to the VS,
+                    // yielding undefined samples / a validation error (#376). Match the storage-buffer path.
+                    lb[i].stageFlags = (r.set == 0)
+                        ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
+                        : VK_SHADER_STAGE_FRAGMENT_BIT;
                     VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
                     tci.imageType = VK_IMAGE_TYPE_2D; tci.format = VK_FORMAT_R8G8B8A8_UNORM; tci.extent = {r.tw, r.th, 1};
                     tci.mipLevels = 1; tci.arrayLayers = 1; tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;


### PR DESCRIPTION
## Problem
Every combined-image-sampler descriptor was created with `stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT` only. `build_R` tags vertex-shader resources into descriptor **set 0** and pixel-shader resources into **set 1**, so a texture from the VS table lands in set 0 but was declared fragment-only. A vertex texture fetch (displacement/heightmap sampling, GPU vertex animation) was therefore invisible to the vertex stage — undefined sample / validation error, VS reads garbage. Storage buffers already used `VERTEX | FRAGMENT` correctly.

## Fix
Derive the image sampler's `stageFlags` from the resource's set: set-0 textures get `VERTEX_BIT | FRAGMENT_BIT`, set-1 textures stay `FRAGMENT_BIT`.

## Verification
Full ctest 82/82 green (existing texture render tests bind PS/set-1 textures, unchanged; the set-0 path is now correct for vertex texture fetch).

Fixes #376