### PR TITLE
fix(gpu): bounds-check EUD descriptor reads in build_shader_resources (#375)

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -181,9 +181,17 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             return off * 4;                                   // byte offset within user_data
         }
         if (!eud_base) return 0xFFFFFFFFu;
-        const uint32_t* src = (const uint32_t*)(uintptr_t)(eud_base + (uint64_t)(off - num_user_sgprs) * 4);
+        // Bounds-check the EUD read (#375): offset_dw is a 15-bit field (up to ~128 KB past eud_base),
+        // so an out-of-range cbuf slot would dereference unmapped guest memory and SIGSEGV the front-half
+        // build on EVERY draw that binds this shader. Reject unless the read fits the guest-declared EUD
+        // size AND is actually mapped — mirroring the guarded in-SGPR path above and the T# path below
+        // (which already calls guest_readable). eud_size_dw was decoded but never used to bound a read.
+        const uint64_t eoff = (uint64_t)(off - num_user_sgprs);
+        if (ud->eud_size_dw && eoff + n > ud->eud_size_dw) return 0xFFFFFFFFu;   // beyond declared EUD
+        if (!guest_readable(eud_base + eoff * 4, n * 4))    return 0xFFFFFFFFu;   // unmapped guest memory
+        const uint32_t* src = (const uint32_t*)(uintptr_t)(eud_base + eoff * 4);
         for (uint32_t i = 0; i < n; i++) buf[i] = src[i];
-        return (off - num_user_sgprs) * 4;                    // matches the shader's s_load immediate
+        return (uint32_t)(eoff * 4);                          // matches the shader's s_load immediate
     };
 
     // Constant buffers: sharp_resource_offset[3] (storage-as-constant). Each slot's offset_dw points at

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -136,6 +136,31 @@ int main() {
     ShaderResourceTable t2 = build_shader_resources(shdr, sgprs, 32);
     CHECK(t2.resources.size() == 1, "empty sharp slot (0x7fff) skipped");
 
+    // --- #375: EUD-resident cbuf reads are bounds-checked (no SIGSEGV on an out-of-range offset_dw) --
+    // An offset_dw >= num_user_sgprs lands in the guest EUD spill (base from direct_resource_offset[5]).
+    // The read must be rejected when it runs past the declared eud_size_dw, instead of dereferencing
+    // unmapped memory. Here: one in-bounds slot (eoff 0) resolves, one out-of-range slot is dropped.
+    {
+        uint32_t sg[32]; memset(sg, 0, sizeof sg);
+        uint32_t eud[4]; make_vsharp(eud, 0xD0000000ull, 0, 512, 22);   // a real readable 4-dword spill
+        uint64_t eud_ptr = (uint64_t)(uintptr_t)eud;
+        uint16_t dro5[16]; for (auto& x : dro5) x = 0xffff;
+        dro5[5] = 24; sg[24] = (uint32_t)eud_ptr; sg[25] = (uint32_t)(eud_ptr >> 32);   // EUD base pointer
+        AgcShaderSharp eud_cbufs[2];
+        eud_cbufs[0].bits = (uint16_t)(32 & 0x7fff);   // offset_dw 32 == num_user_sgprs -> EUD eoff 0 (in bounds)
+        eud_cbufs[1].bits = (uint16_t)(40 & 0x7fff);   // offset_dw 40 -> eoff 8, +4 = 12 > eud_size_dw 4 -> rejected
+        AgcShaderUserData eud_ud; memset(&eud_ud, 0, sizeof eud_ud);
+        eud_ud.direct_resource_offset = dro5; eud_ud.direct_resource_count = 16;
+        eud_ud.eud_size_dw = 4;                        // declared EUD size: 4 dwords
+        eud_ud.sharp_resource_offset[3] = eud_cbufs; eud_ud.sharp_resource_count[3] = 2;
+        AgcShaderHeader eud_sh; memset(&eud_sh, 0, sizeof eud_sh);
+        eud_sh.file_header = 0x34333231u; eud_sh.version = 0x18; eud_sh.type = 2; eud_sh.user_data = &eud_ud;
+        ShaderResourceTable te = build_shader_resources(eud_sh, sg, 32);
+        CHECK(te.resources.size() == 1, "#375: in-bounds EUD cbuf resolves; slot past eud_size_dw skipped (no SIGSEGV)");
+        const ShaderResource* re = te.by_srt_offset(0);   // EUD provenance key = eoff*4 = 0
+        CHECK(re && re->gpu_addr == 0xD0000000ull, "#375: in-bounds EUD cbuf decoded from the spill buffer");
+    }
+
     // --- vertex buffers: direct resource usage type 8 (V# inline in the user-data SGPRs) ------------
     // A 16-entry direct_resource_offset table; type 8 (vertex buffer) points at a V# at SGPR dword 20.
     uint16_t dro[16]; for (auto& x : dro) x = 0xffff;


### PR DESCRIPTION
## Problem
`load_sharp`'s Extended-User-Data branch read spilled descriptor dwords straight off a raw guest pointer with **no bounds check** — neither the declared `eud_size_dw` nor `guest_readable()` was consulted. A constant-buffer sharp whose `offset_dw` (a 15-bit field, up to ~128 KB past `eud_base`) points beyond the EUD allocation dereferenced unmapped guest memory and **SIGSEGV'd the front-half stage build on every draw that binds the shader** — a hard crash, not a wrong pixel, since it runs at T#-decode time for each draw's stage build.

The sibling paths were already guarded (the in-SGPR read bounds-checks against `num_user_sgprs`; the T# TILERAW dump calls `guest_readable`) — the EUD branch was the lone omission, and `eud_size_dw` was decoded but only ever printed.

## Fix
Reject the EUD read unless it fits the guest-declared `eud_size_dw` **and** is mapped (`guest_readable`), returning `0xFFFFFFFF` (the existing "unreadable" sentinel the caller already skips on).

## Verification
`test_build_shader_resources`: an in-bounds EUD cbuf resolves from the spill buffer; a slot whose offset runs past `eud_size_dw` is skipped (no crash). Full ctest 82/82 green.

Note: the secondary `sgpr_base` aliasing concern from the issue is left as a separate follow-up — it touches the live-verified #257 text path and warrants its own change.

Fixes #375