### PR TITLE
fix(render): restore the RTT live renderer reverted by #360 (reconciled with #404/#409) + #300 pass-order + #319 root-cause

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -7,23 +7,43 @@
 #include "gpu/bc_decode.hpp"            // BC1/2/3 block decompression -> RGBA8 (#121)
 #include "gpu/shader_resources.hpp"     // ShaderResourceTable / ResourceClass
 #include "gpu/rdna2_to_spirv.hpp"       // recompile_fragment (diagnostic solid-color PS)
+#include "gpu/videoout_present.hpp"     // present_front_index (flip-anchored present selection)
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
 
 #include <atomic>
-#include <cstdio>
 #include <climits>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
 #include <vector>
+#include <set>
+#include <unordered_map>
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
 extern "C" int prosper_reserved_range_state(uint64_t addr);
+// VideoOut scanout registry (hle_graphics.cpp) — which guest buffer the game most recently FLIPPED
+// to screen. The flip fires during the Dcb fold (agc_dcb_set_flip -> prosper_vo_flip_from_gpu),
+// BEFORE the submit's execute_and_present, so at render time these identify this frame's scanout VA.
+extern "C" int      prosper_vo_buffer_count();
+extern "C" uint64_t prosper_vo_buffer_addr(int i);
 
 namespace prosper::frontend {
 
+// Render-to-texture surface cache (#167): CB_COLOR0_BASE -> the RGBA pixels we last rendered into it.
+// The game renders its scene into a color target then samples that address as a texture in a later
+// composite pass. Guest memory at that address is never populated on our (CPU-read) side, so without
+// this the composite samples zeros and the frame is black. We cache each submit's rendered pixels under
+// its render-target base and inject them when a subsequent draw samples a texture at a matching base.
+namespace { struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; }; }
+
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     static std::atomic<int> frame_no{0};
+    static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
+    // PROSPER_RTT_PERTARGET renders each distinct CB_COLOR0_BASE into its OWN framebuffer (below) and
+    // implies RTT injection — a group can only sample an earlier group if the injection path is live.
+    static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr;
+    static const bool rtt_on = getenv("PROSPER_RTT") != nullptr || pertarget;
     prosper::gpu::set_submit_renderer(
         [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
             using RC = prosper::gpu::ResourceClass;
@@ -84,13 +104,112 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
-                        size_t nb = (size_t)tw * th * 4;
+                        const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
+                        size_t nb = (size_t)tw * th * 4 * (is_cube ? 6u : 1u);
                         texstore.emplace_back(nb, 0x00);
+                        // PROSPER_TEXCOMMIT: log, once per texture base, how much of the sampled surface is
+                        // COMMITTED guest memory (the same reserved_range_state safe_copy stops at). If the
+                        // level's backgrounds read ~0% committed, they're GPU-DMA'd pages the CPU never
+                        // touched, so we read zeros -> the scene samples black (#300 black-gameplay probe).
+                        if (getenv("PROSPER_TEXCOMMIT")) {
+                            const size_t PG = 0x10000; size_t committed = 0;
+                            for (uint64_t a = r.gpu_addr; a < r.gpu_addr + nb; a += PG)
+                                if (a >= 0x1000 && prosper_reserved_range_state(a) != 0) committed += PG;
+                            static std::set<uint64_t> tcseen;
+                            if (tcseen.insert(r.gpu_addr).second) {
+                                // Also sample the first 8 dwords and count non-zero bytes over the whole
+                                // surface: zero content => the texture was allocated but never filled (a
+                                // GPU-side upload/copy we don't execute); non-zero => it's a decode/tiling
+                                // problem. tile_mode tells tiled vs linear.
+                                uint32_t w0[8] = {0}; size_t nzb = 0;
+                                if (committed) {
+                                    const uint8_t* p = (const uint8_t*)(uintptr_t)r.gpu_addr;
+                                    for (int i = 0; i < 8; i++) w0[i] = ((const uint32_t*)p)[i];
+                                    for (size_t i = 0; i < nb; i += 997) nzb += (p[i] != 0);   // sparse scan
+                                }
+                                fprintf(stderr, "[texcommit] tex 0x%llx %ux%u f%u tile=%u nb=%zu committed=%zu%% "
+                                        "nz~%zu/%zu first=%08x %08x %08x %08x\n",
+                                        (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format, r.tile_mode, nb,
+                                        nb ? (size_t)(100 * committed / nb) : 100, nzb, nb/997,
+                                        w0[0], w0[1], w0[2], w0[3]);
+                            }
+                        }
+                        // Real bytes-per-texel of the SAMPLED surface. Single/dual-channel textures (an R8
+                        // font/coverage atlas — this game's 2048x1024 c1 surface) are NOT 4 B/texel; reading
+                        // them as RGBA8 packs adjacent texels into one pixel and over-reads the allocation,
+                        // which is why glyph text rendered as solid white/black BLOCKS (#102). bpt drives a
+                        // narrow read+expand path below. StorageImage / unknown formats keep 4 B (bpt=0->4).
+                        uint32_t bpt = prosper::gpu::data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
+                        // fp16 surfaces (fmt 71 Float16x4 = 8 B/texel, 29 = 4 B, 13 = 2 B) get a real
+                        // half->UNORM8 conversion path below; everything else unknown/oversized keeps
+                        // the legacy RGBA8 read (bpt=4).
+                        const bool f16 = r.format == prosper::gpu::DataFormat::Float16 &&
+                                         (bpt == 2 || bpt == 4 || bpt == 8);
+                        if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+                        bool narrow_done = false;
+                        bool f16_done = false;
+                        // RTT (#167): if this texture's base is a color target we rendered into, inject those
+                        // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
+                        bool rtt_hit = false;
+                        if (rtt_on) { auto rit = g_rtt.find(r.gpu_addr);
+                            if (rit != g_rtt.end() && rit->second.w && rit->second.h && !rit->second.rgba.empty()) {
+                                const RttSurf& s = rit->second;
+                                for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
+                                    uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
+                                    size_t si = ((size_t)sy * s.w + sx) * 4;
+                                    if (si + 4 <= s.rgba.size()) std::memcpy(&texstore.back()[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
+                                }
+                                rtt_hit = true;
+                            }
+                            if (getenv("PROSPER_RTTLOG"))
+                                fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",
+                                        (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
+                                        rtt_hit ? "HIT" : "miss", g_rtt.size());
+                        }
+                        // CUBE texture (#273 — DOLL's title reflection probes / skybox): six faces,
+                        // each an independently-tiled w x h surface, laid out face-major at
+                        // gpu_addr + f*face_stride; decode each into rows [f*th, (f+1)*th) of the
+                        // stacked w x 6h image the cube-sample lowering addresses. BCn faces block-
+                        // detile + decode; anything else reads 4 B/texel with the surface detiler.
+                        // CONFIDENCE: MED on the face stride (padded tiled footprint) — visually
+                        // validated; a wrong stride garbles faces 1..5, it cannot crash (safe_copy).
+                        bool cube_done = false;
+                        if (is_cube && !rtt_hit) {
+                            const uint32_t cb = prosper::gpu::bc_block_bytes(r.format);
+                            const bool ctiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                            for (uint32_t fface = 0; fface < 6; fface++) {
+                                uint8_t* slice = texstore.back().data() + (size_t)fface * tw * th * 4;
+                                if (cb) {
+                                    uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
+                                    size_t comp = (size_t)bw * bh * cb;
+                                    size_t stride = ctiled ? prosper::gpu::tiled_elements_bytes(bw, bh, cb, r.tile_mode) : comp;
+                                    std::vector<uint8_t> lin(comp, 0);
+                                    if (ctiled) {
+                                        std::vector<uint8_t> traw(stride, 0);
+                                        safe_copy(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
+                                        prosper::gpu::detile_elements(lin.data(), traw.data(), stride, bw, bh, cb, r.tile_mode);
+                                    } else safe_copy(lin.data(), r.gpu_addr + (uint64_t)fface * stride, comp);
+                                    std::vector<uint8_t> face((size_t)tw * th * 4, 0);
+                                    prosper::gpu::bc_decode_surface(face.data(), lin.data(), lin.size(), tw, th, r.format);
+                                    std::memcpy(slice, face.data(), face.size());
+                                } else {
+                                    size_t fb = (size_t)tw * th * 4;
+                                    size_t stride = ctiled ? prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0) : fb;
+                                    if (ctiled) {
+                                        std::vector<uint8_t> traw(stride, 0);
+                                        safe_copy(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
+                                        prosper::gpu::detile_surface(slice, traw.data(), tw, th, r.tile_mode, 0);
+                                    } else safe_copy(slice, r.gpu_addr + (uint64_t)fface * stride, fb);
+                                }
+                            }
+                            cube_done = true;
+                        }
                         // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
                         // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
                         // 16 bytes -> SW_4KB_S 16x16-block micro-tiles). #121.
-                        const uint32_t bcb = prosper::gpu::bc_block_bytes(r.format);
-                        if (bcb) {
+                        const uint32_t bcb = (rtt_hit || cube_done) ? 0u : prosper::gpu::bc_block_bytes(r.format);
+                        if (rtt_hit || cube_done) { /* pixels already injected/stacked above */ }
+                        else if (bcb) {
                             uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
                             // Block-detile: tiled_elements_bytes/detile_elements now derive the 4KB
                             // micro-tile geometry from the block size (bpe) internally (#119) — 16-byte
@@ -107,6 +226,76 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 safe_copy(lin.data(), r.gpu_addr, comp_bytes);
                             }
                             prosper::gpu::bc_decode_surface(texstore.back().data(), lin.data(), lin.size(), tw, th, r.format);
+                        } else if (f16) {
+                            // fp16 texture (#290 wall 1): read at the REAL bytes-per-texel and detile
+                            // with the REAL element size — the old clamp read an 8-B/texel Float16x4
+                            // surface at 4 B AND detiled it with bpe=4 against 8-B tiled elements, so
+                            // the result was doubly wrong ("confetti" regions, e.g. DOLL's 960x540 /
+                            // 480x270 bloom-chain buffers). Convert half->UNORM8 on upload: the backend
+                            // uploads RGBA8 only (the whole render path is 8-bit gamma space — see the
+                            // #263 note in render_runner), so HDR values above 1.0 clamp to 255.
+                            // Missing components read (0,0,0,1) per the hardware rule; the T# DST_SEL
+                            // swizzle still applies. CONFIDENCE: MED — the half decode is exact and
+                            // unit-tested, but the [0,1] clamp loses >1.0 bloom energy (native
+                            // VK_FORMAT_R16G16B16A16_SFLOAT upload is the documented follow-up).
+                            const uint32_t nc = bpt / 2;                    // fp16 components per texel
+                            std::vector<uint8_t> hlin((size_t)tw * th * bpt, 0);
+                            bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                            if (tiled) {
+                                size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
+                                std::vector<uint8_t> traw(tbytes, 0);
+                                size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                if (got < hlin.size()) safe_copy(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
+                                else prosper::gpu::detile_surface(hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                            } else {
+                                safe_copy(hlin.data(), r.gpu_addr, hlin.size());
+                            }
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint8_t* p = &texstore.back()[t * 4];
+                                for (uint32_t c = 0; c < 4; c++) {
+                                    if (c < nc) {
+                                        uint16_t hv; std::memcpy(&hv, &hlin[t * bpt + c * 2], 2);
+                                        float f = prosper::gpu::half_to_float(hv);
+                                        p[c] = (f != f || f <= 0.f) ? 0                     // NaN/neg -> 0
+                                             : (f >= 1.f ? 255 : (uint8_t)(f * 255.f + 0.5f));
+                                    } else p[c] = (c == 3) ? 255 : 0;       // absent: (.,0,0,1)
+                                }
+                            }
+                            f16_done = true;   // read+detiled at the real element size already
+                        } else if (bpt < 4) {
+                            // Narrow (single/dual-channel) surface: read at the REAL element size and detile
+                            // with the matching bpe geometry (1 B -> 64x64 micro-tiles, #119), then expand
+                            // each texel to grayscale RGBA8 (replicate to R,G,B,A) so the sampling shader
+                            // reads the coverage in ANY channel it uses (.r for a font atlas, .a for a mask).
+                            std::vector<uint8_t> nlin((size_t)tw * th * bpt, 0);
+                            bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
+                            if (tiled) {
+                                size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
+                                std::vector<uint8_t> traw(tbytes, 0);
+                                size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                // PROSPER_DUMP_RAWTILE (narrow path): the single/dual-channel RAW TILED bytes,
+                                // once per address, for offline 8-bpp de-swizzle sweeps (the SDF font atlas).
+                                if (getenv("PROSPER_DUMP_RAWTILE") && got >= nlin.size() && tw <= 2048 && th <= 1024) {
+                                    static std::set<uint64_t> nseen;
+                                    if (nseen.insert(r.gpu_addr).second) {
+                                        std::string dd = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
+                                        char bn[512]; snprintf(bn, sizeof bn, "%s/narrowtile_%ux%u_b%u_%llx.bin",
+                                                               dd.c_str(), tw, th, bpt, (unsigned long long)r.gpu_addr);
+                                        if (FILE* bf = fopen(bn, "wb")) { fwrite(traw.data(), 1, traw.size(), bf); fclose(bf);
+                                            fprintf(stderr, "[render] narrow raw tiled -> %s (%zu, bpt=%u)\n", bn, traw.size(), bpt); fflush(stderr); }
+                                    }
+                                }
+                                if (got < nlin.size()) safe_copy(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
+                                else prosper::gpu::detile_surface(nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                            } else {
+                                safe_copy(nlin.data(), r.gpu_addr, nlin.size());
+                            }
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint8_t v = nlin[t * bpt];   // first (coverage) channel
+                                uint8_t* p = &texstore.back()[t * 4];
+                                p[0] = p[1] = p[2] = p[3] = v;
+                            }
+                            narrow_done = true;   // already detiled+expanded; skip the 32-bpp auto-detile below
                         } else {
                             safe_copy(texstore.back().data(), r.gpu_addr, nb);
                         }
@@ -137,7 +326,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!bcb && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                        if (!rtt_hit && !cube_done && !bcb && !narrow_done && !f16_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
                             size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
@@ -150,13 +339,37 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 std::memcpy(tiled.data(), texstore.back().data(), std::min(nb, tiled_bytes));
                             // PROSPER_DUMP_RAWTILE: write the EXACT padded tiled bytes to a .bin (no lossy BMP
                             // round-trip) so the de-swizzle can be reversed offline against a known image (#101).
-                            if (getenv("PROSPER_DUMP_RAWTILE") && frame_no < 200) {
-                                std::string dd = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
-                                char bn[512]; snprintf(bn, sizeof bn, "%s/tiled_f%04d_b%u_%ux%u.bin",
-                                                       dd.c_str(), (int)frame_no, r.binding, tw, th);
-                                if (FILE* bf = fopen(bn, "wb")) { fwrite(tiled.data(), 1, tiled.size(), bf); fclose(bf); }
+                            if (getenv("PROSPER_DUMP_RAWTILE") && (frame_no < 200 || (tw <= 2048 && th <= 1024))) {
+                                // Early frames by binding, PLUS small textures once per address (the font/UI
+                                // atlas can be sampled late — capture whenever first seen).
+                                static std::set<uint64_t> rawseen;
+                                bool small = tw <= 2048 && th <= 1024;
+                                if (!small || rawseen.insert(r.gpu_addr).second) {
+                                    std::string dd = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
+                                    char bn[512];
+                                    if (small) snprintf(bn, sizeof bn, "%s/rawtile_%ux%u_%llx.bin", dd.c_str(), tw, th, (unsigned long long)r.gpu_addr);
+                                    else snprintf(bn, sizeof bn, "%s/tiled_f%04d_b%u_%ux%u.bin", dd.c_str(), (int)frame_no, r.binding, tw, th);
+                                    if (FILE* bf = fopen(bn, "wb")) { fwrite(tiled.data(), 1, tiled.size(), bf); fclose(bf); }
+                                }
                             }
                             prosper::gpu::detile_surface(texstore.back().data(), tiled.data(), tw, th, tmode, pitch);
+                        }
+                        // Packed R11G11B10F (Gen5 IMG_FMT 36 -> DataFormat::Float10_11_11, #294): UE4's
+                        // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
+                        // above already produced linear packed words; unpack each to RGBA8 in place with
+                        // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
+                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Float10_11_11) {
+                            uint8_t* tp = texstore.back().data();
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint32_t v; std::memcpy(&v, tp + t * 4, 4);
+                                const float fc[3] = { prosper::gpu::f11_to_float((uint16_t)(v & 0x7FFu)),
+                                                      prosper::gpu::f11_to_float((uint16_t)((v >> 11) & 0x7FFu)),
+                                                      prosper::gpu::f10_to_float((uint16_t)((v >> 22) & 0x3FFu)) };
+                                for (int c = 0; c < 3; c++)
+                                    tp[t * 4 + c] = (fc[c] != fc[c] || fc[c] <= 0.f) ? 0
+                                                  : (fc[c] >= 1.f ? 255 : (uint8_t)(fc[c] * 255.f + 0.5f));
+                                tp[t * 4 + 3] = 255;
+                            }
                         }
                         // PROSPER_DUMP_TEX: write the RAW texture memory (interpreted linearly) to a BMP,
                         // bypassing the shader — reveals whether the render target is tiled or linear.
@@ -166,20 +379,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::dump_bmp(fn, texstore.back(), tw, th);
                             fprintf(stderr, "[render] dumped raw texture -> %s\n", fn); fflush(stderr);
                         }
-                        fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = th;
-                        // Propagate the decoded S# sampler state + T# DST_SEL swizzle onto the frame
-                        // resource (#369). Without this every live texture falls back to the
-                        // FrameResource defaults (LINEAR + clamp-to-edge + identity swizzle), which
-                        // blurs point-sampled pixel-art, ignores the game's real wrap modes, and drops
-                        // channel remaps (e.g. an alpha-only mask or BGRA surface). The S# fields were
-                        // decoded upstream in shader_resources but never reached the backend sampler.
+                        // PROSPER_DUMP_ATLAS: dump each SMALL sampled texture once per ADDRESS (find the caption
+                        // font among same-size UI textures). Capped.
+                        if (getenv("PROSPER_DUMP_ATLAS") && !texstore.back().empty() && tw <= 2048 && th <= 1024) {
+                            static std::unordered_map<uint64_t,int> seen; static int ndumped = 0;
+                            if (seen[r.gpu_addr]++ == 0 && ndumped++ < 60) {
+                                std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
+                                char fn[512]; snprintf(fn, sizeof fn, "%s/tex_%ux%u_%llx_c%u.bmp", d.c_str(), tw, th,
+                                                       (unsigned long long)r.gpu_addr, r.num_components);
+                                prosper::test::dump_bmp(fn, texstore.back(), tw, th);
+                            }
+                        }
+                        fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
+                        // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
+                        // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
                         fr.addr_uvw[0] = r.addr_uvw[0]; fr.addr_uvw[1] = r.addr_uvw[1]; fr.addr_uvw[2] = r.addr_uvw[2];
+                        // Remaining S# sampler fields (#262): border color + LOD clamp/bias (applied where
+                        // valid; the decode-only compare/unnorm stay on ShaderResource).
                         fr.border_color_type = r.border_color_type;
                         fr.min_lod = r.min_lod; fr.max_lod = r.max_lod; fr.lod_bias = r.lod_bias;
+                        // Anisotropy ratio (#275): applied in render_runner.h when the device supports the
+                        // samplerAnisotropy feature and filtering is linear. The Messenger decodes ratio 0
+                        // (isotropic) so this is a no-op for it; carries correct behavior for titles that
+                        // request anisotropic filtering.
                         fr.max_aniso_ratio = r.max_aniso_ratio;
-                        fr.swizzle[0] = r.swizzle[0]; fr.swizzle[1] = r.swizzle[1];
-                        fr.swizzle[2] = r.swizzle[2]; fr.swizzle[3] = r.swizzle[3];
+                        // T# DST_SEL channel remap (#261): apply only to REAL-RGBA texels. The narrow
+                        // R->RGBA replication path (narrow_done) already broadcasts coverage to every
+                        // channel — keep it identity so the font/mask path (#102/#256) is untouched.
+                        if (narrow_done) { fr.swizzle[0]=4; fr.swizzle[1]=5; fr.swizzle[2]=6; fr.swizzle[3]=7; }
+                        else { for (int k=0;k<4;k++) fr.swizzle[k] = r.swizzle[k]; }
+                        // PROSPER_ALPHA1: force the sampled alpha to constant 1 (opaque). Diagnostic for a
+                        // black scene whose textures decode to real RGB but composite to nothing — if the
+                        // level appears with this, the alpha channel (decode or DST_SEL swizzle) is the bug (#300).
+                        if (getenv("PROSPER_ALPHA1")) fr.swizzle[3] = 1;
                     } else {
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned
                         if (nb >= 4) {
@@ -188,6 +421,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 fr.dwords.assign((const uint32_t*)tmp.data(), (const uint32_t*)(tmp.data() + nb));
                         }
                         if (fr.dwords.empty()) fr.dwords.assign(64, 0);
+                        // PROSPER_CBLOG: log each constant buffer's first 4 dwords as floats, once per
+                        // address. If a scene draw's color/tint CB is (0,0,0,0), the PS outputs black
+                        // regardless of the (correctly-decoded) texture — the #300 black-scene suspect.
+                        if (getenv("PROSPER_CBLOG") && r.cls == RC::ConstantBuffer) {
+                            static std::set<uint64_t> cbseen;
+                            if (cbseen.insert(r.gpu_addr).second) {
+                                const float* fp = (const float*)fr.dwords.data();
+                                size_t n = fr.dwords.size();
+                                fprintf(stderr, "[cb] bind=%u addr=0x%llx size=%u dw=%08x %08x %08x %08x  f=%.3f %.3f %.3f %.3f\n",
+                                        r.binding, (unsigned long long)r.gpu_addr, (unsigned)r.size,
+                                        n>0?fr.dwords[0]:0, n>1?fr.dwords[1]:0, n>2?fr.dwords[2]:0, n>3?fr.dwords[3]:0,
+                                        n>0?fp[0]:0.f, n>1?fp[1]:0.f, n>2?fp[2]:0.f, n>3?fp[3]:0.f);
+                            }
+                        }
                     }
                     R.push_back(std::move(fr));
                 }
@@ -218,40 +465,180 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
             }
             const bool nops = getenv("PROSPER_RENDER_NOPS");
-            // Assemble the backend draws — one per realized DrawItem, each with its own resources +
-            // fixed-function state (or the diagnostic overrides above). render_draws_rgba composites
-            // them into ONE framebuffer.
-            std::vector<prosper::test::BackendDraw> bds;
-            for (const auto& it : items) {
-                prosper::test::BackendDraw bd;
-                bd.vs     = refvs ? refvs_spv : it.vs;
-                bd.fs     = ps_override.empty() ? it.fs : ps_override;
-                bd.vcount = refvs ? 3u : it.vertex_count;
-                bd.ps     = nops ? nullptr : &it.ps;
-                bd.R      = build_R(it.vrt.get(), it.prt.get());
-                // Indexed draw: hand the executor-fetched index data to the backend (vkCmdDrawIndexed).
-                // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
-                if (!refvs) bd.indices = it.indices;
-                if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
-                    "[render] item %zu: %zu resources vcount=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
-                    bds.size(), bd.R.size(), bd.vcount, bd.indices.size(), it.ps.topology,
-                    it.ps.color_write_mask, (int)it.ps.blend_enable);
-                bds.push_back(std::move(bd));
+            // Assemble backend draws for a subset of the submit's items — one BackendDraw per realized
+            // DrawItem with its own resources + fixed-function state (or the diagnostic overrides above).
+            // build_R reads the CURRENT g_rtt, so calling this AFTER an earlier target-group has been
+            // rendered+stored lets the later group sample that group's pixels (a HIT, not empty memory).
+            auto build_bds = [&](const std::vector<const prosper::gpu::DrawItem*>& group) {
+                std::vector<prosper::test::BackendDraw> bds;
+                for (const auto* itp : group) {
+                    const auto& it = *itp;
+                    prosper::test::BackendDraw bd;
+                    bd.vs     = refvs ? refvs_spv : it.vs;
+                    bd.fs     = ps_override.empty() ? it.fs : ps_override;
+                    bd.vcount = refvs ? 3u : it.vertex_count;
+                    bd.ps     = nops ? nullptr : &it.ps;
+                    bd.R      = build_R(it.vrt.get(), it.prt.get());
+                    // Indexed draw: hand the executor-fetched index data to the backend (vkCmdDrawIndexed).
+                    // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
+                    if (!refvs) bd.indices = it.indices;
+                    if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
+                        "[render] item %zu: %zu resources vcount=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
+                        bds.size(), bd.R.size(), bd.vcount, bd.indices.size(), it.ps.topology,
+                        it.ps.color_write_mask, (int)it.ps.blend_enable);
+                    // RTTLOG per-draw detail (render-window-only, unlike the GFXLOG firehose): enough
+                    // state to diagnose a pass whose inputs HIT the RTT cache yet outputs nothing —
+                    // blend factors, write mask, viewport, and each PS-sampled texture address (#319).
+                    if (getenv("PROSPER_RTTLOG")) {
+                        fprintf(stderr, "[rtt]   draw tgt=0x%llx vcount=%u nidx=%zu topo=%u mask=0x%x "
+                                "blend=%d(src=%u dst=%u) vp=%d(%.2f,%.2f %.2fx%.2f) z=%d zw=%d ps=",
+                                (unsigned long long)it.color0_base, bd.vcount, bd.indices.size(),
+                                it.ps.topology, it.ps.color_write_mask, (int)it.ps.blend_enable,
+                                it.ps.src_color_blend_factor, it.ps.dst_color_blend_factor,
+                                (int)it.ps.has_viewport,
+                                it.ps.viewport_x, it.ps.viewport_y, it.ps.viewport_w, it.ps.viewport_h,
+                                (int)it.ps.depth_test_enable, (int)it.ps.depth_write_enable);
+                        if (it.prt) for (const auto& r : it.prt->resources)
+                            if (r.cls == RC::Texture)
+                                fprintf(stderr, " tex@%u=0x%llx(%ux%u f%u)", r.binding,
+                                        (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
+                        fprintf(stderr, "\n");
+                    }
+                    bds.push_back(std::move(bd));
+                }
+                return bds;
+            };
+            // Clear color for a group: the game's decoded fast-clear taken from the group's first item's
+            // resolved pipeline state, or its default opaque black when no fast-clear was programmed.
+            // Passing this to render_draws_rgba replaces the old hardcoded debug blue on the live path
+            // (#309) — PROSPER_CLEAR_DEBUG still forces blue for spotting unrendered areas.
+            auto clear_for = [](const std::vector<const prosper::gpu::DrawItem*>& g) -> const float* {
+                return g.empty() ? nullptr : g.front()->ps.clear_color;
+            };
+            std::vector<uint8_t> px;
+            if (pertarget) {
+                // PER-TARGET RTT: a real frame is a sequence of passes, each rendering into a specific
+                // color target (CB_COLOR0_BASE), and a final composite pass SAMPLES the earlier targets.
+                // The single-framebuffer path below flattens ALL draws into one image and caches it under
+                // only the FIRST item's base — so a draw that targets a different base never gets cached
+                // under its OWN address, and a later composite that samples that address misses -> black.
+                // Here we group items by color0_base (first-appearance order), render each group into its
+                // own framebuffer, and cache each under its base. Because groups render in order and
+                // build_bds re-reads g_rtt, a composite group that samples a scene group rendered earlier
+                // THIS submit now hits — closing the intra-submit multi-pass gap (and cross-submit too,
+                // since g_rtt persists). The final (last) group's pixels — the composite — are presented.
+                // PASSES, not groups (#300): a real frame renders in SUBMIT ORDER as A->B->A->B... (a
+                // ping-pong RT chain, each pass sampling the previous target). Collapsing all draws with
+                // the same color0_base into one group loses that order — an A-pass that samples B then
+                // renders before B exists, reading a stale/empty B -> black cascade (and a 4-deep UE4
+                // post chain propagates nothing). So split items into CONTIGUOUS same-target runs below
+                // and render each in order, caching its RT immediately so the next pass sampling it hits
+                // fresh pixels. (Cross-submit persistence via g_rtt is unchanged.)
+                // Flip-anchored present selection: the correct frame is whatever the guest FLIPS to
+                // screen, i.e. the RTT group whose color-target VA is a registered VideoOut buffer
+                // (preferring the CURRENT front buffer — the in-stream SetFlip fires during the Dcb
+                // fold, before this render, so present_front_index() is this frame's scanout choice).
+                const int      vo_n     = prosper_vo_buffer_count();
+                const int      vo_front = prosper::gpu::present_front_index();
+                const uint64_t front_va = vo_front >= 0 ? prosper_vo_buffer_addr(vo_front) : 0;
+                if (getenv("PROSPER_RTTLOG")) {
+                    fprintf(stderr, "[rtt] flip state: front=%d va=0x%llx of %d registered:",
+                            vo_front, (unsigned long long)front_va, vo_n);
+                    for (int i = 0; i < vo_n && i < 8; i++)
+                        fprintf(stderr, " [%d]=0x%llx", i, (unsigned long long)prosper_vo_buffer_addr(i));
+                    fprintf(stderr, "\n");
+                }
+                std::vector<uint8_t> px_front, px_vo;   // flip-matched / any-scanout-matched candidates
+                // Render-target persistence (default on; PROSPER_RTT_NOSEED reverts to per-pass blue
+                // clear): seed each group's framebuffer with the pixels last rendered into that SAME
+                // target VA, so a pass that draws into an already-written target (UE4's UI pass onto
+                // the backbuffer, incremental HUD updates) composites OVER the earlier content instead
+                // of starting from the diagnostic clear. Real RT memory persists exactly this way.
+                static const bool seed_rtt = getenv("PROSPER_RTT_NOSEED") == nullptr;
+                size_t pass_i = 0;
+                while (pass_i < items.size()) {
+                    const uint64_t base = items[pass_i].color0_base;
+                    std::vector<const prosper::gpu::DrawItem*> pass;
+                    while (pass_i < items.size() && items[pass_i].color0_base == base) { pass.push_back(&items[pass_i]); ++pass_i; }
+                    const uint8_t* seed = nullptr;
+                    if (seed_rtt && base) { auto sit = g_rtt.find(base);
+                        if (sit != g_rtt.end() && sit->second.w == w && sit->second.h == h &&
+                            sit->second.rgba.size() == (size_t)w * h * 4) seed = sit->second.rgba.data(); }
+                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(pass), w, h, seed, clear_for(pass));
+                    if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = w; s.h = h; }
+                    bool is_vo = false;
+                    for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
+                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for (uint8_t b : gpx) nz += (b != 0);
+                        fprintf(stderr, "[rtt] pass target=0x%llx (%zu draws) px_nonzero=%zu cache_size=%zu%s%s\n",
+                                (unsigned long long)base, pass.size(), nz, g_rtt.size(),
+                                is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : ""); }
+                    // PROSPER_DUMP_DRAWSTEPS: for a pass targeting a SCANOUT buffer, re-render the pass
+                    // draw-by-draw (prefix 1, prefix 2, ...) and dump each cumulative result — a one-boot
+                    // bisect for "which draw of the final composite blacks the screen" (#319). Diagnostic.
+                    if (getenv("PROSPER_DUMP_DRAWSTEPS") && is_vo && pass.size() > 1) {
+                        for (size_t k = 1; k <= pass.size(); k++) {
+                            std::vector<const prosper::gpu::DrawItem*> prefix(pass.begin(), pass.begin() + k);
+                            std::vector<uint8_t> spx = prosper::test::render_draws_rgba(build_bds(prefix), w, h, seed, clear_for(prefix));
+                            if (spx.empty()) continue;
+                            size_t snz = 0; for (uint8_t b : spx) snz += (b != 0);
+                            fprintf(stderr, "[rtt] drawstep %zu/%zu tgt=0x%llx px_nonzero=%zu\n",
+                                    k, pass.size(), (unsigned long long)base, snz);
+                            const char* dd = getenv("PROSPER_FRAME_DIR");
+                            char fn[512]; snprintf(fn, sizeof fn, "%s/drawstep_%04d_%zu.bmp",
+                                                   dd ? dd : ".", frame_no.load(), k);
+                            prosper::test::dump_bmp(fn, spx, w, h);
+                        }
+                    }
+                    // PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes>: dump each per-target group's rendered
+                    // pixels (rtgrp_<base>_<frame>.bmp in PROSPER_FRAME_DIR) — to inspect an intermediate
+                    // pass (e.g. the UI/banner RT) instead of only the presented composite. Diagnostic.
+                    if (const char* rg = getenv("PROSPER_DUMP_RTGROUPS"); rg && !gpx.empty()) {
+                        size_t nz = 0; for (uint8_t b : gpx) nz += (b != 0);
+                        if (nz >= (size_t)atol(rg)) {
+                            const char* dd = getenv("PROSPER_FRAME_DIR");
+                            char fn[512]; snprintf(fn, sizeof fn, "%s/rtgrp_%llx_%04d.bmp",
+                                                   dd ? dd : ".", (unsigned long long)base, frame_no.load());
+                            prosper::test::dump_bmp(fn, gpx, w, h);
+                        }
+                    }
+                    if (!gpx.empty()) {
+                        if (base && base == front_va) px_front = gpx;                   // the flipped buffer
+                        if (is_vo)                    px_vo    = gpx;                   // any registered scanout
+                        px = std::move(gpx);                                            // last non-empty (fallback)
+                    }
+                }
+                // Present priority: the flipped front buffer > any registered scanout target > the
+                // legacy "last group" fallback (unchanged behavior when no group targets a VO buffer).
+                if (!px_front.empty())   px = std::move(px_front);
+                else if (!px_vo.empty()) px = std::move(px_vo);
+            } else {
+                // Single-framebuffer path: render_draws_rgba composites every draw into ONE framebuffer.
+                std::vector<const prosper::gpu::DrawItem*> all; all.reserve(items.size());
+                for (const auto& it : items) all.push_back(&it);
+                px = prosper::test::render_draws_rgba(build_bds(all), w, h, nullptr, clear_for(all));
+                // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
+                // composite pass that samples that address gets the scene we drew (not empty guest memory).
+                if (rtt_on && !px.empty()) {
+                    uint64_t tgt = 0;
+                    for (const auto& it : items) if (it.color0_base) { tgt = it.color0_base; break; }
+                    if (tgt) { RttSurf& s = g_rtt[tgt]; s.rgba = px; s.w = w; s.h = h; }
+                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for(size_t i=0;i<px.size();i++) nz+=(px[i]!=0);
+                        fprintf(stderr, "[rtt] store target=0x%llx (%zu items, color0s:", (unsigned long long)tgt, items.size());
+                        for (const auto& it : items) fprintf(stderr, " 0x%llx", (unsigned long long)it.color0_base);
+                        fprintf(stderr, ") px_nonzero=%zu cache_size=%zu\n", nz, g_rtt.size()); }
+                }
             }
-            // Clear color (#367): the game's decoded fast-clear from the first draw's resolved state,
-            // else the ResolvedPipelineState default (opaque black) — never the diagnostic blue on the
-            // live path (that stays gated behind PROSPER_CLEAR_DEBUG inside render_draws_rgba). This
-            // re-connects the resolved clear color (#309) that a later live_renderer refactor unwired,
-            // so a real frame's un-drawn areas are the game's clear, not blue.
-            const float* clear_rgba = items.empty() ? nullptr : items.front().ps.clear_color;
-            std::vector<uint8_t> px = prosper::test::render_draws_rgba(bds, w, h, /*seed*/nullptr, clear_rgba);
             int n = frame_no++;
+            // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
+            // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.
+            size_t content_thr = 0; if (const char* c = getenv("PROSPER_DUMP_CONTENT")) content_thr = (size_t)atol(c);
+            size_t px_nz = 0; if (content_thr) for (size_t i = 0; i < px.size(); i++) px_nz += (px[i] != 0);
             if (px.empty()) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);
-            } else if (dump_bmps && (n < 60 || n % 10 == 0)) {   // periodic screenshots (headless verification only)
+            } else if (dump_bmps && ((content_thr && px_nz >= content_thr) || (!content_thr && (n < 60 || n % 10 == 0)))) {
                 char fn[512]; snprintf(fn, sizeof fn, "%s/frame_%04d.bmp", frame_dir.c_str(), n);
                 prosper::test::dump_bmp(fn, px, w, h);
-                fprintf(stderr, "[render] frame %d rendered (%ux%u) -> %s\n", n, w, h, fn);
+                fprintf(stderr, "[render] frame %d rendered (%ux%u) nz=%zu -> %s\n", n, w, h, px_nz, fn);
             }
             return px;
         });


### PR DESCRIPTION
## Summary

**Primarily a regression fix: it restores the render-to-texture live renderer that PR #360 silently reverted.** PR #360 (`f45eae3`) intended to add the ~10-line `PROSPER_RENDER_LAST` diagnostic, but its branch was based on a **pre-RTT** `live_renderer.cpp`, so the merge reverted the whole renderer (**598 → 243 lines, `45+/400−`**). On current master the file is that reverted version (`g_rtt` gone) — which is exactly why the DOLL title post-process chain samples empty memory and the composite is black: **no pass can sample a previous pass's rendered pixels.** #360 touched *only* `live_renderer.cpp` (`git show f45eae3 --stat`), so no other file regressed.

This restores the full RTT renderer and **reconciles it with the two fixes that landed on the reverted renderer while it was broken** — both were re-deriving behavior the full renderer already contains, so they are carried forward (superset), not lost:

- **#404 / #367 (fast-clear colour):** the restored renderer passes each group's decoded fast-clear (`clear_for` → `render_draws_rgba`'s `clear_rgba`) in **both** the pertarget and single-framebuffer paths — the game's clear, never the diagnostic blue (still gated behind `PROSPER_CLEAR_DEBUG`). Equivalent to #404's `items.front().ps.clear_color` wiring.
- **#409 / #369 (S# sampler + T# DST_SEL swizzle → live textures):** the restored renderer copies `mag/min/mip_filter`, `addr_uvw`, `border_color_type`, `min/max_lod`, `lod_bias`, `max_aniso_ratio`, and `swizzle[4]` onto each `FrameResource` — **plus** the correct narrow-R8 identity-swizzle special-case (a coverage atlas broadcasts to every channel, so re-applying DST_SEL would double-swizzle) that plain #409 lacks.

Also restored/kept: `PROSPER_RTT_PERTARGET` per-target passes + flip-anchored present + RT-persistence seeding (#269/#294/#296); narrow-R8 / fp16 / R11G11B10F / CUBE decode (#237/#290/#295/#273); `DUMP_CONTENT` / `TEXCOMMIT` / `CBLOG` / `ALPHA1` probes (#267/#311). Re-applies #360's intended `PROSPER_RENDER_LAST`/`SUBMITLOG` diag on top; folds in the stranded **#300 pass-ordering fix** (contiguous same-target runs in submit order, so a ping-pong / 4-deep RT chain propagates pass-to-pass); and adds the **#319** per-draw `PROSPER_RTTLOG` state + `PROSPER_DUMP_DRAWSTEPS` scanout bisect.

## #319 root-cause map (the still-black title)

With the renderer restored, A/B ruled out every earlier hypothesis and pinned the exact link:

| Hypothesis | Result |
|---|---|
| Viewport/scissor clips post draws | **Ruled out** — real scene + composite draws render full `vp=(0,540 960×−540)`; the `(0,0 0×−0)` cases are 1×1 dummy RTs scaled by 0.25. |
| RT→RT propagation broken | **Works** — samples HIT `g_rtt`; `PROSPER_RENDER_TESTPS` (magenta) propagates fully to scanout, and `PROSPER_TESTTEX` (checker) lights up the whole chain (0 black RTs, final post 79,650 colors). Geometry rasterizes; propagation + present work. |
| Barrier ordering (`PROSPER_WAIT_DEFER=1`) | **Ruled out** — doesn't un-black it, destabilizes the run. Matches #327's "no unsatisfied waits." |

**The real link — GPU-only render targets read as zero.** `PROSPER_TEXCOMMIT` shows the split: real source atlases are committed **with** content (clouds 18,926 colors; 4K f1 `nz~19301`; f11 `nz~12976`), while **every post-chain RT is committed=100% but all-zero in guest memory** — `0x2075350000` 3840×2160 **f20 (Float10_11_11 = UE4 scene-color)** `nz~0`, plus the f9/f20 bloom→tonemap→FXAA targets. `g_rtt` intercepts these samples (HIT) but caches black, because the pass rendering *into* each also produced black — a cascade rooted in the **scene-color pass**, whose geometry draws sample both real atlases **and** all-zero GPU-only RTs in one material, collapsing the output.

**Remaining for the textured title** (= why this is `refs`, not `Fixes` #319): the **#300 black-scene frontier** — give the scene-color pass real color (multi-MRT G-buffer population and/or remaining material descriptor resolution) so the f20 scene-color target holds content the post chain can amplify. Separate, larger executor change; this PR is the necessary render-side foundation.

## Verification
- **ctest 82/82** (Linux) — `savedata_ime` needs a clean `/tmp/prosper-savedata-mem` (#432 disk persistence leftover state; unrelated to this change).
- **Messenger snapshot: OK** — `messenger-scene` 24,318 colors, shared renderer/executor unregressed.
- Rebased onto current master; single-file diff (`live_renderer.cpp`); **MERGEABLE**, no conflicts.

No game imagery or dump committed.

refs #319, refs #300, refs #367, refs #369

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
