### PR TITLE
fix(gpu): const-fold must not fold an untracked SOFFSET to 0 (#398)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -243,7 +243,13 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 uint32_t soff_val = 0; bool soff_ok = true;
                 if (soff_field < 106) soff_ok = known((int)soff_field, soff_val);          // SGPR
                 else if (soff_field == 106 || soff_field == 107) soff_ok = known((int)soff_field, soff_val); // vcc lo/hi
-                else soff_val = 0;                                          // null/const-0 soffset
+                else if (soff_field == 125) soff_val = 0;                   // SGPR_NULL -> const-0 offset (ok)
+                else soff_ok = false;                                       // m0(124)/exec(126,127)/reserved:
+                                                                            // untracked -> mark UNKNOWN, not 0. The
+                                                                            // old `else soff_val=0` claimed ok=true
+                                                                            // for these, snapshotting a descriptor
+                                                                            // from base+imm+0 instead of +m0/exec
+                                                                            // -> wrong V#/T#, silently (#398).
                 // Descriptor-table use (#294): an s_buffer_load's SBASE is a V# — if that V# was
                 // snapshotted from a table load, report it as a ConstantBuffer use keyed by its load
                 // immediate (matching the recompiler's sreg_srt tag). Recorded BEFORE the dest write
@@ -356,9 +362,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     // words), so add soffset+inst_offset to the descriptor base; an UNKNOWN soffset keeps
                     // the un-offset base (previous behavior). CONFIDENCE: HIGH (fetch-time values traced
                     // live; Messenger's fetches carry SOFFSET=0 so they are byte-identical).
-                    uint32_t soff = 0;
-                    if (!(in.src[2].kind == OperandKind::Special && in.src[2].value == 125))  // NULL -> 0
-                        if (!srcval(in.src[2], soff)) soff = 0;                               // unknown -> 0
+                    uint32_t soff = 0; bool soff_known = true;
+                    if (in.src[2].kind == OperandKind::Special && in.src[2].value == 125)     // SGPR_NULL -> 0
+                        soff = 0;
+                    else if (!srcval(in.src[2], soff))
+                        soff_known = false;                          // real but untracked SOFFSET (#398) — see below
                     const uint32_t inst_off = in.literal & 0xFFFu;
                     const uint32_t fetch_off = soff + inst_off;
                     auto with_off = [&](DecodedBufferDescriptor d) {
@@ -370,8 +378,16 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // it zeros -> a collapsed final vertex).
                         return d;
                     };
-                    if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x\n",
-                                     in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3, k3 ? vv[3] : 0, it != descr.end(), fetch_off);
+                    if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x soff_known=%d\n",
+                                     in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3, k3 ? vv[3] : 0, it != descr.end(), fetch_off, (int)soff_known);
+                    // A real (non-NULL) SOFFSET the fold cannot resolve would silently collapse fetch_off's
+                    // in-record component to 0 — every attribute reads base+inst_off (the "solid banner"
+                    // collapse this fold was written to fix) or a wrong descriptor address. Leave the fetch
+                    // UNRESOLVED (a loud recompile-coverage miss) rather than fabricating offset 0 (#398).
+                    if (!soff_known) {
+                        if (trc) fprintf(stderr, "[dyntrace]   MUBUF pc=%u SOFFSET untracked -> fetch left unresolved (not folded to 0)\n", in.pc);
+                        break;
+                    }
                     // Per-fetch: record THIS fetch's live V# (the SRSRC SGPR is reloaded with a different V#
                     // per vertex attribute — position, uv, color…). Keyed by the fetch's pc so the recompiler
                     // resolves each buffer_load_format to the descriptor as loaded at that instruction.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -134,6 +134,23 @@ int main() {
     CHECK(have_cbuf, "kernel 5 s_buffer_load reports a ConstantBuffer table-use keyed by the V# load imm");
     CHECK(cbuf_ok,   "kernel 5 V# dwords match the table as loaded");
 
+    // Kernel 5m (#398): same as k5 but the T# s_load uses m0 as SOFFSET (field 124), a special register
+    // the fold does not track. It must NOT be folded to offset 0 and snapshotted — that would decode a T#
+    // from base+0x40+0 (the wrong address in general) and report it as valid. The fix marks s[12:19]
+    // UNKNOWN (soff_ok=false), so the image_sample resolves no Texture use. (SOFFSET field = words[1]>>25:
+    // 0xF8000040 -> 124 = m0, vs k5's 0xFA000040 -> 125 = SGPR_NULL.)
+    const uint32_t k5m[] = {
+        0xF40C0304u, 0xF8000040u,   // s_load_dwordx8 s[12:19], s[8:9], m0  (SOFFSET 124 = m0, untracked)
+        0xF4080504u, 0xFA000080u,   // s_load_dwordx4 s[20:23], s[8:9], 0x80 (SSAMP, NULL soffset)
+        0xF0800F08u, 0x00A30000u,   // image_sample v[0:3], v[0:1], s[12:19], s[20:23]
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<SrtUse> uses_m0;
+    resolve_dynamic_fetch(k5m, sizeof(k5m)/sizeof(k5m[0]), seed5, 2, 8, &uses_m0);
+    bool have_tex_m0 = false;
+    for (const auto& u : uses_m0) if (u.kind == 0 && u.key == 0x40) have_tex_m0 = true;
+    CHECK(!have_tex_m0, "#398: m0-SOFFSET s_load marks the T# UNKNOWN (no descriptor fabricated from soffset 0)");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem
`resolve_dynamic_fetch` (the wave-uniform const-fold that recovers V#/T#/S# descriptors) silently substituted **0** for an untracked scalar SOFFSET at two sites and then treated the result as known/valid — snapshotting a descriptor from the wrong address instead of marking it unknown, the opposite of the fold's "reject loudly, don't fabricate" contract.

**Site A (SMEM SOFFSET):** only SGPR_NULL (125) legitimately means offset 0, but the `else soff_val=0` bucket also swallowed m0 (124), exec_lo/hi (126/127) and reserved 108–123 with `soff_ok=true`. An `s_load` using m0/exec as SOFFSET read `base+imm+0` instead of `base+imm+<reg>` and snapshotted the wrong 4/8 dwords → a later vertex fetch / image_sample resolved to the wrong surface.

**Site B (MUBUF vertex-fetch SOFFSET):** a real-but-untracked SOFFSET collapsed to 0, dropping the attribute's in-record byte offset so every attribute read `base+inst_off` (the "solid banner" collapse).

## Fix
- Site A: only `125 → 0/ok`; every other special reg → `soff_ok=false` (dest SGPRs erased = unknown).
- Site B: an unresolved SOFFSET leaves the fetch **unresolved** (loud recompile-coverage miss) rather than emitting a V# with a fabricated offset.

Messenger is unaffected (its fetch shader uses `vcc_hi` SOFFSET, handled, and SOFFSET=0 MUBUF fetches) — this closes a by-construction defect for m0/exec-relative descriptor addressing.

## Verification
`test_dynfetch_fold` k5m: an `s_load` with m0 SOFFSET marks the T# unknown (no Texture use) instead of fabricating one from soffset 0. Full ctest 82/82 green.

Fixes #398