### PR TITLE
fix(gpu): expose rendered-frame dims so scaled-render screenshots aren't dropped (#399)

### DIFF
--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -69,6 +69,13 @@ int      present_front_index() { return g_front.load(std::memory_order_relaxed);
 uint64_t present_count()       { return g_present_count.load(std::memory_order_relaxed); }
 uint32_t present_width()       { return prosper_vo_display_width(); }
 uint32_t present_height()      { return prosper_vo_display_height(); }
+// Dimensions of the RENDERED frame handed in via present_write_frame (0 if none present). Distinct from
+// present_width/height (the guest DISPLAY dims): under PROSPER_RENDER_SCALE the rendered frame is smaller
+// than the display, so a readback consumer (screenshot) must size its buffer from THESE when a rendered
+// frame exists — else present_readback returns g_frame.size() != display*4 and the exact-size guard drops
+// every frame silently (#399). Fall back to present_width/height only on the raw-scanout path.
+uint32_t present_frame_width()  { std::lock_guard<std::mutex> lk(g_frame_mx); return g_frame_w; }
+uint32_t present_frame_height() { std::lock_guard<std::mutex> lk(g_frame_mx); return g_frame_h; }
 
 size_t present_readback(void* dst, size_t dst_cap) {
     if (!dst) return 0;
@@ -98,6 +105,7 @@ void present_reset() {
     g_present_count.store(0, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(g_frame_mx);
     g_frame.clear(); g_frame_w = g_frame_h = 0;
+    g_frame_seq.store(0, std::memory_order_relaxed);   // #399: reset the rendered-frame counter too
     g_have_frame.store(false, std::memory_order_release);
 }
 

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -34,6 +34,11 @@ uint64_t present_count();         // total flips presented (guest-paced; can be 
 uint64_t present_frame_seq();     // count of rendered frames handed in (present_write_frame calls)
 uint32_t present_width();
 uint32_t present_height();
+// Dimensions of the rendered frame handed in via present_write_frame (0 if none). Differ from
+// present_width/height (the guest display dims) whenever the frame was rendered at a reduced size
+// (PROSPER_RENDER_SCALE); a readback consumer must size its buffer from these when non-zero (#399).
+uint32_t present_frame_width();
+uint32_t present_frame_height();
 
 // Copy the presented frame's pixels (width*height, 4 bytes/pixel) from the front buffer's guest
 // memory into `dst`. Returns bytes written, or 0 if there is no surface / no flip yet / dst too small.

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -65,6 +65,10 @@ int main() {
     prosper::gpu::present_reset();
     prosper::gpu::present_write_frame(px.data(), W, H);
     CHECK(prosper::gpu::present_has_frame(), "present accepted the executor's frame");
+    // #399: the rendered-frame dims are reported separately from the display dims, so a scaled-render
+    // readback consumer (screenshot) can size its buffer correctly instead of dropping every frame.
+    CHECK(prosper::gpu::present_frame_width() == W && prosper::gpu::present_frame_height() == H,
+          "present_frame_width/height report the rendered frame's actual dims");
     std::vector<uint8_t> scan((size_t)W * H * 4, 0);
     size_t n = prosper::gpu::present_readback(scan.data(), scan.size());
     CHECK(n == px.size() && scan == px, "present_readback returns the executor's frame byte-for-byte");

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -154,7 +154,13 @@ int main(int argc, char** argv) {
                              : (gpu::present_frame_seq() >= next);
         if (gpu::present_has_frame() && due) {
             uint64_t at = gpu::present_frame_seq();
-            uint32_t w = gpu::present_width(), h = gpu::present_height();
+            // Size the buffer from the RENDERED frame's dims, not the guest display dims: under
+            // PROSPER_RENDER_SCALE the frame is smaller, and present_readback returns g_frame.size()
+            // (scaled). Using the display dims made buf.size() != readback bytes, so the exact-size
+            // guard below dropped EVERY screenshot silently (#399). Fall back to display dims only when
+            // no rendered frame is present (the raw-scanout path).
+            uint32_t fw = gpu::present_frame_width(), fh = gpu::present_frame_height();
+            uint32_t w = fw ? fw : gpu::present_width(), h = fh ? fh : gpu::present_height();
             if (w && h) {
                 buf.resize((size_t)w * h * 4);
                 if (gpu::present_readback(buf.data(), buf.size()) == buf.size()) {


### PR DESCRIPTION
## Problem
The present layer stored a rendered frame with its dimensions but never exposed them; `present_width/height` report the guest **display** dims (1920×1080). Under `PROSPER_RENDER_SCALE=N` the frame is rendered at `w/scale × h/scale`, so `present_readback` returns `g_frame.size()` (scaled), which `!= present_width()*present_height()*4`. `screenshot.cpp` sized its buffer to the full display dims and gated on an exact-size match, so **every screenshot of a scaled run was silently dropped** — and scale+screenshot is the documented deep-cutscene workflow.

## Fix
- `videoout_present`: add `present_frame_width()`/`present_frame_height()` returning the rendered frame's `g_frame_w/g_frame_h` (0 when none present).
- `screenshot.cpp`: size the readback buffer from the rendered-frame dims when a frame is present, falling back to display dims for the raw-scanout path.
- `present_reset()` now also clears `g_frame_seq` (the adjacent nit noted in the issue).

## Verification
`test_gpu_execute` asserts `present_frame_width/height` report the written frame's dims. Full ctest 82/82 green.

Fixes #399