### PR TITLE
fix(gpu): resolve EUD-resident textures in build_shader_resources (#382)

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -229,8 +229,15 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             const AgcShaderSharp& s = texs[slot];
             if (s.empty()) continue;
             uint32_t off = s.offset_dw();
-            if ((uint64_t)off + 8 > num_user_sgprs) continue;   // T# (8 dwords) must fit in the block
-            DecodedImageDescriptor d = decode_image_descriptor(&user_sgprs[off]);
+            // A T# may live in the user-SGPR block OR spill into the EUD, exactly like the cbuf path
+            // (#257/#382) — the old hard `continue` for off+8 > num_user_sgprs silently DROPPED any
+            // EUD-resident texture, so its sampling draw rendered untextured. Fetch the 8 dwords via
+            // load_sharp (bounds-checked; copies verbatim from the SGPR block for the in-block case, so
+            // that path stays byte-identical) and decode from that buffer.
+            uint32_t tv[8]; uint32_t tsrt = load_sharp(off, 8, tv);
+            if (tsrt == 0xFFFFFFFFu) continue;                  // out of block / EUD absent / unreadable
+            const bool tex_in_eud = (uint64_t)off + 8 > num_user_sgprs;
+            DecodedImageDescriptor d = decode_image_descriptor(tv);
             if (d.base == 0 || d.width == 0 || d.height == 0 ||
                 d.width > 16384 || d.height > 16384) continue;  // skip a garbage/degenerate T#
             // PROSPER_DUMP_TILERAW (issue #282 derivation): dump the raw guest texel bytes of a tiled
@@ -272,7 +279,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 }
             }
             if (getenv("PROSPER_GFXLOG")) {
-                const uint32_t* t = &user_sgprs[off];
+                const uint32_t* t = tv;   // the fetched T# (SGPR block or EUD spill)
                 fprintf(stderr, "[t#] %ux%u base=0x%llx tile_mode=%u type=%u fmt=%u swz=%u,%u,%u,%u | raw: %08x %08x %08x %08x %08x %08x %08x %08x\n",
                         d.width, d.height, (unsigned long long)d.base, d.tile_mode, d.type, d.format,
                         d.dst_sel[0], d.dst_sel[1], d.dst_sel[2], d.dst_sel[3],
@@ -341,8 +348,11 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
             r.size          = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
                                      : (d.width * d.height * fi.bytes_per_block);
-            r.sgpr_base     = user_sgpr_base + off;  // DIRECT provenance key (image_sample SRSRC SGPR)
-            r.srt_offset    = 0xFFFFFFFFu;
+            // SGPR-resident T#: DIRECT provenance (image_sample SRSRC SGPR). EUD-resident T#: INDIRECT
+            // (the s_load immediate = tsrt), and sgpr_base must be invalid so a stray by_sgpr_base for an
+            // unrelated op reading that (bogus, out-of-file) SGPR number can't spuriously match it (#382).
+            r.sgpr_base     = tex_in_eud ? 0xFFFFFFFFu : (user_sgpr_base + off);
+            r.srt_offset    = tex_in_eud ? tsrt : 0xFFFFFFFFu;
             // Paired sampler S# (sharp[2], same slot): decode its filter + wrap modes so the backend
             // samples the way the game asked (point vs bilinear, wrap vs clamp), instead of a hardcoded
             // LINEAR/clamp. 4-dword SQ_IMG_SAMP: WORD0 has CLAMP_X/Y/Z (bits [2:0]/[5:3]/[8:6]); WORD2

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -225,6 +225,31 @@ int main() {
         CHECK(tt.by_sgpr_base(24) == nullptr, "unmapped IMG_FMT T# skipped (no silent RGBA8)");
     }
 
+    // #382: an EUD-resident texture (T# spilled beyond the user-SGPR block) must be emitted, mirroring
+    // the cbuf EUD path — the old hard `continue` dropped it, so the sampling draw rendered untextured.
+    // Provenance is INDIRECT (srt_offset = the s_load immediate); sgpr_base is invalid so a stray
+    // by_sgpr_base for an unrelated SGPR can't spuriously match its out-of-file index.
+    {
+        uint32_t sg[32]; memset(sg, 0, sizeof sg);
+        uint32_t eudt[8]; make_tsharp(eudt, 0xAB000000ull, 128, 128, /*fmt*/56, /*tile*/0, /*type 2D*/9);
+        uint64_t ep = (uint64_t)(uintptr_t)eudt;
+        uint16_t dro5[16]; for (auto& x : dro5) x = 0xffff;
+        dro5[5] = 24; sg[24] = (uint32_t)ep; sg[25] = (uint32_t)(ep >> 32);   // EUD base pointer
+        AgcShaderSharp et_sharp[1]; et_sharp[0].bits = (uint16_t)(32 & 0x7fff);   // offset_dw 32 -> EUD eoff 0
+        AgcShaderUserData etud; memset(&etud, 0, sizeof etud);
+        etud.direct_resource_offset = dro5; etud.direct_resource_count = 16;
+        etud.eud_size_dw = 8;
+        etud.sharp_resource_offset[0] = et_sharp; etud.sharp_resource_count[0] = 1;
+        AgcShaderHeader etsh; memset(&etsh, 0, sizeof etsh);
+        etsh.file_header = 0x34333231u; etsh.version = 0x18; etsh.type = 1; etsh.user_data = &etud;
+        ShaderResourceTable et = build_shader_resources(etsh, sg, 32);
+        CHECK(et.resources.size() == 1, "#382: EUD-resident texture is emitted (not dropped)");
+        const ShaderResource* etr = et.by_srt_offset(0);   // EUD provenance key = eoff*4 = 0
+        CHECK(etr && etr->cls == ResourceClass::Texture && etr->gpu_addr == 0xAB000000ull,
+              "#382: EUD texture decoded from the spill buffer, resolvable by srt_offset");
+        CHECK(etr && etr->sgpr_base == 0xFFFFFFFFu, "#382: EUD texture leaves sgpr_base invalid (INDIRECT provenance)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem
`build_shader_resources` resolved constant buffers from either the user-SGPR block OR the EUD spill (via `load_sharp`/`eud_base`), but the **texture** loop only ever read the SGPR block: a T# whose `offset_dw` landed beyond `num_user_sgprs` hit a hard `continue` and was silently dropped, so the sampling draw rendered untextured. A PS with several textures + samplers easily overflows the ~16-dword user-SGPR block, so the driver spills later T#s into the EUD — exactly the situation #257 fixed for the color **constant** buffers.

## Fix
Mirror the cbuf path: fetch the 8-dword T# via `load_sharp` (bounds-checked by #375; copies verbatim from the SGPR block for the in-block case, so **that path stays byte-identical**) and decode from that buffer. For an EUD-resident T#, set INDIRECT provenance (`srt_offset` = the s_load immediate) and leave `sgpr_base` invalid so a stray `by_sgpr_base` can't spuriously match its out-of-file SGPR index. The in-block path is unchanged (DIRECT `sgpr_base`).

## Verification
`test_build_shader_resources`: an EUD-resident texture is emitted, resolvable by `srt_offset`, decoded from the spill buffer, with `sgpr_base` invalid. The existing in-block texture asserts still pass (byte-identical). Full ctest 82/82 green.

Note: an EUD-resident *sampler* S# (sharp[2]) still falls back to LINEAR/clamp defaults — a graceful degrade, not a crash; left as a follow-up.

Fixes #382