### PR TITLE
fix(recompiler): image_sample_l on a 2D_ARRAY takes LOD from the 4th coord, not the slice (#373)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3212,7 +3212,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     uint32_t cu = vread(cvg(0)), cv = vread(cvg(1));
                     if (is_sample)         b.image_sample_2d(res->binding, cu, cv, out);
                     else if (is_sample_lz) b.image_sample_lod_2d(res->binding, cu, cv, b.uconst(0), out);      // LOD 0
-                    else if (is_sample_l)  b.image_sample_lod_2d(res->binding, cu, cv, vread(cvg(2)), out);    // LOD = 3rd coord
+                    // Explicit-LOD sample: LOD is the coord AFTER the spatial (+ array) coords. Plain 2D
+                    // vaddr = [u, v, lod] -> cvg(2); 2D_ARRAY (dim 5) vaddr = [u, v, slice, lod] -> cvg(3).
+                    // The slice sits at cvg(2), so reading LOD from cvg(2) on a 2D_ARRAY took the array
+                    // index as the LOD (#373). (Slice itself is still dropped — 2D lowering, #325.)
+                    else if (is_sample_l)  b.image_sample_lod_2d(res->binding, cu, cv,
+                                                                 vread(cvg(in.mimg_dim == 5u ? 3 : 2)), out);
                     else                   b.image_fetch_2d (res->binding, cu, cv, out);
                 }
             }


### PR DESCRIPTION
## Problem
A 2D_ARRAY texture (`mimg_dim == 5`) is lowered as a plain 2D sample (array slice dropped, #325). For `image_sample_l` the LOD was read from coordinate index 2 — correct for plain 2D (`[u, v, lod]`), but on a 2D_ARRAY the vaddr is `[u, v, slice, lod]`, so index 2 is the **array slice** and the LOD is index 3. The sample was issued with `LOD = slice-index`.

## Fix
Take the explicit LOD from `cvg(3)` when `mimg_dim == 5`, `cvg(2)` otherwise. The slice itself is still dropped (the 2D-lowering limitation tracked by #325), so this only fully manifests with a nonzero slice — but the operand-index math was wrong regardless.

## Verification
Build + full ctest 82/82 green (no regression to the plain-2D path, which is unchanged). A meaningful isolated exec test would require mipmapped 2D_ARRAY sampling, which the render harness doesn't set up; the fix is a direct operand-index correction against the RDNA2 MIMG coordinate order.

Fixes #373