### PR TITLE
fix(recompiler): buffer_load_format_* default-fills missing components (0,0,0,1) (#368)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2799,6 +2799,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // Format of the fetched components. Untyped buffer_load_dword* is raw 32-bit (comp_bytes=4);
             // buffer_load_format_* takes the format from the resolved V# descriptor.
             DataFormat fmt = DataFormat::Uint32;   // untyped default: raw dwords
+            uint32_t fmt_ncomp = 0;    // the V#'s real component count (format loads only); 0 = don't default-fill
             bool dyn_vfetch = false;   // set when the V# came from by_fetch_pc — a const-folded per-vertex
                                        // attribute fetch, whose element address is exactly gl_VertexIndex*stride.
             if (is_format) {
@@ -2842,6 +2843,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 binding = res->binding;
                 stride = res->stride;
                 fmt = res->format;
+                fmt_ncomp = res->num_components;   // for the format default-fill below (#368)
             } else if (rt) {
                 // RAW (untyped) MUBUF with a resource table: resolve SRSRC (src[1]) exactly like the
                 // format path — a raw buffer op targets whatever buffer its V# describes, NOT a fixed
@@ -2995,11 +2997,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
+            // Integer-typed format? Its absent-component default for W/A is integer 1, not float 1.0.
+            const bool fmt_is_int = (fmt == DataFormat::Uint8  || fmt == DataFormat::Uint16 || fmt == DataFormat::Uint32 ||
+                                     fmt == DataFormat::Sint8  || fmt == DataFormat::Sint16 || fmt == DataFormat::Sint32);
             for (uint32_t k = 0; k < n; k++) {
                 int d = in.dst.value + (int)k;
                 uint32_t old = vreg_old(b, rs, d);
                 uint32_t value;
-                if (!packed) {
+                // Format default-fill (#368): BUFFER_LOAD_FORMAT_* returns only the components the V#'s
+                // format defines; a component the OPCODE requests beyond that (e.g. _xyzw against a
+                // 32_32_32 position, or _xyz against a 32_32 UV) is filled with the standard vector
+                // default — 0 for G/B/Z, 1 for A/W — NOT read from adjacent memory (which yielded the
+                // next vertex's bytes, or robust-0 at the buffer tail, so a vec4 read of a vec3 attribute
+                // got W = garbage/0 instead of 1.0 -> broken transforms). Only for format loads with a
+                // known component count; untyped raw MUBUF loads keep every opcode component.
+                if (is_format && fmt_ncomp && k >= fmt_ncomp) {
+                    uint32_t one = fmt_is_int ? 1u : 0x3f800000u;   // integer 1 vs float 1.0 (raw bits)
+                    value = b.uconst(k == 3 ? one : 0u);            // W/A -> 1, G/B/Z -> 0
+                } else if (!packed) {
                     uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
                     value = b.cbuf_load(kidx, binding);                  // raw 32-bit component
                 } else if (dyn_half) {

--- a/prosper/tests/test_vertex_fetch_render.cpp
+++ b/prosper/tests/test_vertex_fetch_render.cpp
@@ -67,6 +67,27 @@ int main() {
     printf("  center=(%u,%u,%u,%u)  green samples %u/%u\n", c[0],c[1],c[2],c[3], green, total);
     CHECK(green == total, "every sampled pixel is GREEN (VS fetched real positions from the vertex buffer)");
 
+    // #368: format default-fill. This VS uses buffer_load_format_XYZW (4 components) against the SAME
+    // Float32 x2 vertex buffer, and exports the FETCHED z,w directly (no hardcoded v3=0/v4=1.0). The V#
+    // only provides x,y — so the recompiler must default z=0.0 and W=1.0, NOT read the next vertex's
+    // bytes. With the correct W=1.0 the clip-space triangle covers the viewport (green everywhere); the
+    // old code read w from adjacent memory (next vertex / robust-0), collapsing the triangle.
+    const uint32_t vs4[] = {
+        0xe00c2000u, 0x80020100u,   // buffer_load_format_xyzw v[1:4], v0, s[8:11], 0 idxen
+        0xf80008cfu, 0x04030201u,   // exp pos0 v1, v2, v3, v4 done  (uses the FETCHED z=v3, w=v4)
+        0xbf810000u,                // s_endpgm
+    };
+    std::vector<uint32_t> vert4 = recompile_vertex(vs4, sizeof(vs4)/sizeof(vs4[0]), &rt);
+    CHECK(!vert4.empty() && vert4[0] == 0x07230203u, "recompiled xyzw-fetch VS -> SPIR-V");
+    if (!vert4.empty()) {
+        std::vector<uint8_t> px4 = prosper::test::render_triangle_rgba(vert4, frag, W, H, nullptr, &vbuf);
+        uint32_t g4 = 0, t4 = 0;
+        auto isGreen4 = [&](uint32_t x, uint32_t y) { const uint8_t* p = &px4[((size_t)y*W+x)*4];
+                                                      return p[1] > 0x80 && p[0] < 0x40 && p[2] < 0x40; };
+        for (uint32_t y : ys) for (uint32_t x : xs) { t4++; if (px4.size() == px.size() && isGreen4(x, y)) g4++; }
+        CHECK(g4 == t4, "#368: xyzw fetch of a 2-comp attribute defaults W=1.0 (not adjacent memory) -> green");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Problem
In the MUBUF format-load path the component count came solely from the opcode (`_x`/`_xy`/`_xyz`/`_xyzw`); the V#'s real component count (`ShaderResource::num_components`) was never consulted. When the opcode requested more components than the format provides — e.g. `buffer_load_format_xyzw` against a 32_32_32 position, or `_xyz` against a 32_32 UV — the extra components were read from **adjacent buffer bytes** (the next vertex's data, or robust-0 at the tail) instead of the hardware's format-fill defaults: **0 for G/B/Z and 1 for A/W**. A vec4 read of a vec3 attribute thus got `W = neighbor byte / 0` rather than `1.0`, breaking transforms/normalization.

## Fix
Thread the V#'s `num_components` into the fetch loop and, for a format load whose component index `k >= num_components`, write the standard default (1 for W/A, 0 for G/B/Z) — integer `1` for UINT/SINT formats, float `1.0` otherwise — instead of a memory load. Untyped raw MUBUF loads are unaffected (they keep every opcode component).

## Verification
`test_vertex_fetch_render`: a `buffer_load_format_xyzw` of a Float32 x2 attribute that exports the **fetched** z,w renders green (W defaulted to 1.0 → the clip triangle covers the viewport); the old adjacent-memory read collapsed it. Full ctest 82/82 green.

Fixes #368