### PR TITLE
fix(gpu): guard the fold-time WAIT_REG_MEM 'not satisfied' diagnostic read (#448)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -925,17 +925,23 @@ void GpuState::apply(const Pm4Command& c) {
                     static std::atomic<int> logged{0};
                     int ln = logged.fetch_add(1);
                     if (ln < 40 || (ln & 1023) == 0) {
-                        uint64_t mem = 0; memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
+                        // wait_regmem_satisfied() returns false for an UNMAPPED label too (#380), so this
+                        // "not satisfied" diagnostic is reached with a stale/freed label whose page may be
+                        // gone — a raw 8-byte read then SEGVs, the exact crash #380 fixed but via the log
+                        // path #380 did not cover (#448). Read only when mapped; report UNMAPPED otherwise.
+                        bool label_readable = guest_readable(c.wm_addr, 8);
+                        uint64_t mem = 0; if (label_readable) memcpy(&mem, (const void*)(uintptr_t)c.wm_addr, sizeof mem);
                         // #312 discriminator: build-journal age + freed-heap-shaped label content.
                         uint64_t baddr = 0, bpre = 0, bt = 0;
                         int have = prosper_fence_journal_lookup(pkt_addr(c), &baddr, &bpre, &bt);
-                        fprintf(stderr, "[agc] WaitRegMem #%d NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s\n",
+                        fprintf(stderr, "[agc] WaitRegMem #%d NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s%s\n",
                                 ln, (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
                                 (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
                                 defer_enabled() ? "pausing queue (deferred effects)" : "dependency violated",
                                 (unsigned long long)bt, have ? (long long)(now_ms() - bt) : -1,
                                 (have && baddr != c.wm_addr) ? " TARGET-CHANGED" : "",
-                                (unsigned long long)bpre, ptr_like(mem) ? " CONTENT-PTR-LIKE(freed?)" : "");
+                                (unsigned long long)bpre, ptr_like(mem) ? " CONTENT-PTR-LIKE(freed?)" : "",
+                                label_readable ? "" : " LABEL-UNMAPPED");
                     }
                     if (defer_enabled()) {
                         g_fold_deferring = true;


### PR DESCRIPTION
## Problem
#380 guarded `wait_regmem_satisfied()` itself, but it returns false for an **unmapped** label too — so on the default (barrel-on) path, when a `WAIT_REG_MEM` is unsatisfied, the diagnostic block still did a raw 8-byte `memcpy` of the label address (and `ptr_like(mem)`) with **no readability check**. A stale/freed fence label (recycled command buffer, freed tracking block — the #312 class) therefore **SEGVs** the command processor through the log path #380 did not cover, re-introducing the exact crash. The entry guard only checks alignment, not mappedness, and the first 40 unsatisfied waits are all logged, so the first unmapped one faults.

## Fix
Probe `guest_readable(c.wm_addr, 8)` before the diagnostic read; read the label only when mapped, else report it as `LABEL-UNMAPPED` — mirroring `flush_deferred_streams()`.

## Verification
Build + full ctest 82/82 green.

Fixes #448