### PR TITLE
fix(hle/file): route the AIO write path through write_full (was raw pwrite)

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -455,7 +455,7 @@ uint64_t aio_submit(uint64_t reqs, int32_t n, bool is_write, uint64_t out_id) {
     for (int32_t i = 0; i < n; i++) {
         int64_t r;
 #ifndef _WIN32
-        r = is_write ? (int64_t)::pwrite(req[i].fd, req[i].buf, (size_t)req[i].nbyte, (off_t)req[i].offset)
+        r = is_write ? write_full(req[i].fd, req[i].buf, (size_t)req[i].nbyte, true, (off_t)req[i].offset)
                      : read_full(req[i].fd, req[i].buf, (size_t)req[i].nbyte, true, (off_t)req[i].offset);
 #else
         // Windows host (secondary): emulate positioned IO with lseek+read/write on the CRT fd.


### PR DESCRIPTION
The AIO write half issued a single raw ::pwrite and reported a short count as completed -- the save-truncation class write_full (#419) fixed on the sync path, left open on the async half (DOLL SaveLoadUpdate writes go through AIO). Make it symmetric with the read half's read_full. Refs #389.