### PR TITLE
fix(gpu): resolve EUD-resident paired samplers in build_shader_resources (#451)

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -362,8 +362,15 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             if (const AgcShaderSharp* samps = ud->sharp_resource_offset[2]) {
                 if (slot < ud->sharp_resource_count[2] && !samps[slot].empty()) {
                     uint32_t soff = samps[slot].offset_dw();
-                    if ((uint64_t)soff + 4 <= num_user_sgprs) {
-                        const uint32_t* sm = &user_sgprs[soff];
+                    // The paired S# may live in the user-SGPR block OR spill to the EUD alongside its T#
+                    // (#451) — fetch it via the same bounds-checked load_sharp used for the T# above,
+                    // instead of indexing user_sgprs directly (which dropped EUD-resident samplers, so the
+                    // texture silently reverted to the default LINEAR/clamp sampler for exactly the
+                    // EUD-resident textures #257 added — a point/wrap sampler read as bilinear/clamped).
+                    // load_sharp copies verbatim from the SGPR block for the in-block case, byte-identical.
+                    uint32_t sm_buf[4];
+                    if (load_sharp(soff, 4, sm_buf) != 0xFFFFFFFFu) {
+                        const uint32_t* sm = sm_buf;
                         r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
                         r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
                         r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -231,15 +231,23 @@ int main() {
     // by_sgpr_base for an unrelated SGPR can't spuriously match its out-of-file index.
     {
         uint32_t sg[32]; memset(sg, 0, sizeof sg);
-        uint32_t eudt[8]; make_tsharp(eudt, 0xAB000000ull, 128, 128, /*fmt*/56, /*tile*/0, /*type 2D*/9);
-        uint64_t ep = (uint64_t)(uintptr_t)eudt;
+        // EUD spill: an 8-dword T# at eoff 0 + a paired 4-dword S# at eoff 8 (12 dwords total).
+        uint32_t eud[12]; memset(eud, 0, sizeof eud);
+        make_tsharp(&eud[0], 0xAB000000ull, 128, 128, /*fmt*/56, /*tile*/0, /*type 2D*/9);
+        // #451: the paired S# also spills to the EUD. Program POINT filter + addr (wrap,mirror,clamp) so
+        // it is distinguishable from the struct defaults (LINEAR + clamp). SQ_IMG_SAMP WORD0: CLAMP_X[2:0],
+        // CLAMP_Y[5:3], CLAMP_Z[8:6]; WORD2 filter bits are 0 -> point.
+        eud[8] = (0u << 0) | (1u << 3) | (2u << 6);   // addr_uvw = {0 wrap, 1 mirror, 2 clamp}
+        uint64_t ep = (uint64_t)(uintptr_t)eud;
         uint16_t dro5[16]; for (auto& x : dro5) x = 0xffff;
         dro5[5] = 24; sg[24] = (uint32_t)ep; sg[25] = (uint32_t)(ep >> 32);   // EUD base pointer
-        AgcShaderSharp et_sharp[1]; et_sharp[0].bits = (uint16_t)(32 & 0x7fff);   // offset_dw 32 -> EUD eoff 0
+        AgcShaderSharp et_sharp[1]; et_sharp[0].bits = (uint16_t)(32 & 0x7fff);   // T# offset_dw 32 -> eoff 0
+        AgcShaderSharp es_sharp[1]; es_sharp[0].bits = (uint16_t)(40 & 0x7fff);   // S# offset_dw 40 -> eoff 8
         AgcShaderUserData etud; memset(&etud, 0, sizeof etud);
         etud.direct_resource_offset = dro5; etud.direct_resource_count = 16;
-        etud.eud_size_dw = 8;
+        etud.eud_size_dw = 12;
         etud.sharp_resource_offset[0] = et_sharp; etud.sharp_resource_count[0] = 1;
+        etud.sharp_resource_offset[2] = es_sharp; etud.sharp_resource_count[2] = 1;   // paired sampler
         AgcShaderHeader etsh; memset(&etsh, 0, sizeof etsh);
         etsh.file_header = 0x34333231u; etsh.version = 0x18; etsh.type = 1; etsh.user_data = &etud;
         ShaderResourceTable et = build_shader_resources(etsh, sg, 32);
@@ -248,6 +256,11 @@ int main() {
         CHECK(etr && etr->cls == ResourceClass::Texture && etr->gpu_addr == 0xAB000000ull,
               "#382: EUD texture decoded from the spill buffer, resolvable by srt_offset");
         CHECK(etr && etr->sgpr_base == 0xFFFFFFFFu, "#382: EUD texture leaves sgpr_base invalid (INDIRECT provenance)");
+        // #451: the EUD-resident paired S# is decoded (not left at the LINEAR/clamp defaults).
+        CHECK(etr && etr->mag_filter == 0u && etr->min_filter == 0u,
+              "#451: EUD-resident sampler decoded -> POINT filter (not the default LINEAR)");
+        CHECK(etr && etr->addr_uvw[0] == 0u && etr->addr_uvw[1] == 1u && etr->addr_uvw[2] == 2u,
+              "#451: EUD-resident sampler addr modes decoded from the spill (not default clamp)");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Problem
#382 fixed the EUD-resident **T#** to fetch via the bounds-checked `load_sharp`, but the paired **S#** decode for that same texture still indexed `user_sgprs[soff]` behind a raw `soff+4 <= num_user_sgprs` guard. When a T# spills to the EUD its sampler spills too, so the guard fails and the texture silently reverts to the default **LINEAR + clamp-to-edge** sampler — for exactly the EUD-resident textures the path was added to support (#257's text/UI family). A title that programmed a POINT + WRAP sampler then samples bilinear/clamped: point-art gets a blur halo, wrap UVs read a clamped edge streak — the opposite of the intent honored for the in-SGPR case (#262).

## Fix
Fetch the 4-dword S# through the same `load_sharp` helper (copies verbatim from the SGPR block for the in-block case → byte-identical; adds the bounds-checked EUD path symmetrically), same shape as the #382 T# fix.

## Verification
`test_build_shader_resources`: the EUD-resource test now also spills the paired S# and asserts its POINT filter + addr modes decode from the spill (not the LINEAR/clamp defaults). Full ctest 82/82 green.

Fixes #451