### PR TITLE
fix(recompiler): s_mul_hi_i32 is gfx10 SOP2 opcode 0x36, not 0x37 (#462)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1956,7 +1956,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x26: d = b.ibin(Op_IMul, a, c); break;         // s_mul_i32 (low 32 bits; no SCC)
                 case 0x31: d = b.ibin(Op_IAdd, b.ibin(Op_ShiftLeftLogical, a, b.uconst(4)), c); break;  // s_lshl4_add_u32 = (src0<<4)+src1
                 case 0x35: d = b.umul_hi(a, c); break;               // s_mul_hi_u32 (high 32 bits; no SCC)
-                case 0x37: d = b.smul_hi(a, c); break;               // s_mul_hi_i32 (high 32 bits; no SCC)
+                case 0x36: d = b.smul_hi(a, c); break;               // s_mul_hi_i32 (high 32 bits; no SCC).
+                                                                     // gfx10 SOP2 opcode is 0x36 (llvm-mc:
+                                                                     // 0x9b000201>>23&0x7f); 0x37 was WRONG
+                                                                     // (invalid encoding), so the handler was
+                                                                     // dead and s_mul_hi_i32 got rejected. #462
                 case 0x27: {                                         // s_bfe_u32: offset=src1[4:0], width=src1[22:16]
                     uint32_t off = b.ibin(Op_BitwiseAnd, c, b.uconst(0x1f));
                     uint32_t width = b.ibin(Op_BitwiseAnd, b.ibin(Op_ShiftRightLogical, c, b.uconst(16)), b.uconst(0x7f));

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1511,6 +1511,21 @@ int main() {
     }
     CHECK(gotT5b.size()==N && badT5b==0, "T5b: s_max_i32(5,5) sets SCC=1 (>=), s_cselect picks 11 not 4");
 
+    // Kernel T5c (#462): s_mul_hi_i32 is gfx10 SOP2 opcode 0x36 (was mapped to the invalid 0x37, so the
+    // handler was dead and the op rejected -> shader dropped). s1=0x10000; s_mul_hi_i32 s2,-1,s1 = the
+    // SIGNED high dword of (-1 * 0x10000) = high of 0xFFFFFFFFFFFF0000 = 0xFFFFFFFF (unsigned mul_hi would
+    // be 0x0000FFFF — so this also pins the SIGNED semantics). v1 = a0 + 0xFFFFFFFF (= a0 - 1).
+    const uint32_t codeT5c[] = { 0xbe8103ffu, 0x00010000u, 0x9b0201c1u, 0x4a020002u, 0xBF810000u };
+    std::vector<uint32_t> spvT5c = recompile_valu(codeT5c, sizeof(codeT5c)/4, 1, 1);
+    CHECK(!spvT5c.empty(), "recompiled T5c (s_mul_hi_i32 opcode 0x36) -> SPIR-V (was rejected as 0x37)");
+    std::vector<float> gotT5c = prosper::test::run_compute(spvT5c, inX, N, N);
+    uint32_t badT5c = 0;
+    for (uint32_t i = 0; i < N && gotT5c.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotT5c[i], 4);
+        if (gb != bits_of(inX[i]) + 0xFFFFFFFFu) badT5c++;
+    }
+    CHECK(gotT5c.size()==N && badT5c==0, "T5c: s_mul_hi_i32(-1,0x10000)=0xFFFFFFFF (signed high mul)");
+
     // Kernel T6: s_add_u32 carry chain -> s_addc_u32. s0=-1+2 (carry SCC=1); s1=0+0+SCC=1.
     // out bits = bits(a0) + 1.
     const uint32_t codeT6[] = { 0x800082c1u, 0x82018080u, 0x4a020001u, 0xBF810000u };


### PR DESCRIPTION
## Problem
The `s_mul_hi_i32` handler was keyed on `case 0x37`, but the real gfx10 SOP2 opcode is **0x36** (llvm-mc round-trip: `s_mul_hi_i32 s2,-1,s1` → `0x9b0201c1`, `0x9b0201c1>>23&0x7f == 0x36`; `0x37` is an invalid SOP2 encoding). So the handler was dead code and a real `s_mul_hi_i32` fell to `default:` → the shader was rejected and its draw skipped. `s_mul_hi_u32` (0x35) and `s_mul_i32` (0x26) were already correct.

Fail-safe class (reject, not silent miscompile), but any shader using a signed high-multiply — common in fixed-point / 64-bit-address / integer-scaling code — was dropped entirely.

## Verification
`test_rdna2_to_spirv` T5c: `s_mul_hi_i32(-1, 0x10000)` now recompiles and yields `0xFFFFFFFF` (the **signed** high dword; unsigned `mul_hi` would give `0x0000FFFF`), so the test also pins the signed semantics. Full ctest 82/82 green.

Fixes #462