### PR TITLE
fix(hle/savedata): sceSaveDataDirNameSearch enumerates real saves (#299)

### DIFF
--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -63,6 +63,7 @@ void set_app0_root(const std::string& root);
 // (sceSaveDataMount3 HLE). create=true makes the dir; create=false fails if it doesn't exist.
 bool savedata0_mount(const char* dirname, bool create);
 void savedata0_umount();
+std::vector<std::string> savedata0_list_dirs();   // existing save dirs under the host save root (#299)
 // PS5 system services (user/NP/mouse/appcontent/dialog); called by register_builtin_hle().
 void register_service_hle();
 // libScePad game-controller input (real host controller via input/pad.cpp); called by register_builtin_hle().

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -20,6 +20,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <dirent.h>      // opendir/readdir: savedata0_list_dirs (sceSaveDataDirNameSearch, #299)
 #include <sys/uio.h>     // process_vm_readv: fault-safe guest-memory reads for the APR diagnostics
 #include <sys/mman.h>    // PROSPER_APR_ALTDEST: prosper-owned guest read buffer
 #include <pthread.h>
@@ -214,6 +215,25 @@ bool savedata0_mount(const char* dirname, bool create) {
     return true;
 }
 void savedata0_umount() { std::lock_guard<std::mutex> lk(g_save0_mx); g_save0.clear(); }
+// List the save-dir names that exist under the host save root (each subdir is one save the guest created
+// via sceSaveDataMount3 create-mode). sceSaveDataDirNameSearch reports these so a prior session's saves
+// appear in the game's load/continue list (#299 — the saves persisted but were invisible).
+std::vector<std::string> savedata0_list_dirs() {
+    std::vector<std::string> out;
+#ifndef _WIN32
+    std::string base = save0_base();
+    if (DIR* dp = opendir(base.c_str())) {
+        while (struct dirent* de = readdir(dp)) {
+            if (de->d_name[0] == '.') continue;
+            struct stat st{};
+            if (::stat((base + "/" + de->d_name).c_str(), &st) == 0 && S_ISDIR(st.st_mode))
+                out.emplace_back(de->d_name);
+        }
+        closedir(dp);
+    }
+#endif   // Windows host is secondary; report no saves there.
+    return out;
+}
 
 // Translate a host (Linux) struct stat into the FreeBSD/Orbis SceKernelStat layout the
 // guest expects: 0x78 bytes, different field order. Writing the host layout (144 bytes,

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -656,9 +656,28 @@ HLE(s_savedata_commit)  { svc_log("sceSaveDataCommit", a0,a1,a2,a3,a4,a5); retur
 HLE(s_savedata_dirsearch) {
     svc_log("sceSaveDataDirNameSearch", a0,a1,a2,a3,a4,a5);
     if (!a1) return 0x809F0000ull;        // SAVE_DATA_ERROR_PARAMETER
-    uint32_t* res = (uint32_t*)PW(a1);
-    res[0] = 0;                            // hitNum = 0 (no existing saves)
-    res[5] = 0;                            // setNum (offset 0x14) = 0
+    uint8_t* res = (uint8_t*)PW(a1);
+    // Enumerate the save dirs on disk so a prior session's saves show up in the load/continue list (#299).
+    // Was hard-coded to 0 hits, so persisted saves were invisible. Optional cond->dirName filter @cond+0x10.
+    const char* filter = nullptr;
+    if (a0) { uint64_t dnp = *(uint64_t*)((uint8_t*)PW(a0) + 0x10); if (dnp) filter = (const char*)PW(dnp); }
+    std::vector<std::string> dirs = savedata0_list_dirs();
+    uint32_t cap = *(uint32_t*)(res + 0x10);            // dirNamesNum (caller buffer capacity, entries)
+    if (cap > 0x400) cap = 0x400;                        // clamp to the documented buffer size
+    uint64_t buf = *(uint64_t*)(res + 0x08);            // DirName* dirNames (caller buffer)
+    uint32_t total = 0;
+    for (const std::string& name : dirs) {
+        if (filter && name != filter) continue;
+        if (buf && (!cap || total < cap)) {              // SceSaveDataDirName = char dirName[32]
+            char* entry = (char*)PW(buf) + (size_t)total * 32;
+            memset(entry, 0, 32);
+            strncpy(entry, name.c_str(), 31);
+        }
+        total++;
+    }
+    uint32_t hit = (cap && total > cap) ? cap : total;
+    *(uint32_t*)(res + 0x00) = hit;        // hitNum
+    *(uint32_t*)(res + 0x14) = hit;        // setNum
     return 0;
 }
 


### PR DESCRIPTION
DirNameSearch hard-coded hitNum=0, so persisted saves (Mount3 dirs + SaveDataMemory) were invisible in the load list -- the #299 symptom. Add savedata0_list_dirs() and fill the caller's DirName buffer with the on-disk save dirs (with cond->dirName filter + capacity clamp), reporting real hitNum/setNum. Refs #392, #299.