### PR TITLE
fix(gpu): widen vertex-texture upload barrier to the VERTEX stage (#454)

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -618,7 +618,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         b1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL; b1.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         b1.image = v.timg[i]; b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT; b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b1);
+        // The dst stage must cover EVERY stage that samples this image. #376 made set-0 textures
+        // VS-visible (stageFlags VERTEX|FRAGMENT), so a vertex texture fetch reads it in the VERTEX
+        // stage — a FRAGMENT-only barrier leaves the transfer-write→shader-read dependency unordered
+        // for that stage (SYNC-HAZARD-READ-AFTER-WRITE; garbage vertex fetch on GPUs that don't
+        // over-synchronize). Include the vertex stage to match the binding's stageFlags (#454).
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &b1);
     }
     // Clear color: the caller's clear_rgba (game fast-clear / black on the live path), else the
     // legacy diagnostic blue. PROSPER_CLEAR_DEBUG forces blue back on even when a color is passed.


### PR DESCRIPTION
## Problem
The per-texture upload barrier in `render_draws_rgba` transitioned each sampled image to `SHADER_READ_ONLY_OPTIMAL` with `dstStageMask = FRAGMENT_SHADER` only. #376 made set-0 textures VS-visible (`stageFlags VERTEX|FRAGMENT`), so a vertex texture fetch (displacement/heightmap, GPU vertex animation — the exact case #376 enabled) now samples an image whose transfer-write→shader-read dependency does **not** cover the VERTEX stage. FRAGMENT is later in the pipeline and provides no ordering for a vertex-stage read → **SYNC-HAZARD-READ-AFTER-WRITE**, and on GPUs that don't over-synchronize the vertex stage may observe the image pre-copy / mid-transition → garbage vertex fetch → collapsed geometry. A regression directly created by #376.

## Fix
Widen the barrier's `dstStageMask` to `VERTEX_SHADER | FRAGMENT_SHADER`, matching the binding's `stageFlags`.

## Verification
Full ctest 82/82 green (llvmpipe over-synchronizes so the render tests were green either way; this satisfies the Vulkan sync rule deterministically).

Fixes #454