### PR TITLE
fix(hle/appcontent): sceAppContentAppParamGetInt reports SKU_FLAG = FULL, not 0

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -212,7 +212,11 @@ HLE(s_ime_kbd_info) {
 }
 
 // --- app content ---
-HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = 0; return 0; }
+// sceAppContentAppParamGetInt(paramId, int32_t* value): paramId 0 = SKU_FLAG, whose only valid values are
+// TRIAL=1 / FULL=3 (there is NO 0). Writing 0 for it made the SKU check indeterminate -> a game testing
+// `sku == FULL` drops into trial/demo mode (locked content, "buy full game" gating). Report FULL for a
+// legally-owned title; other params (USER_DEFINED_PARAM_1..4) stay 0 absent a param.sfo read.
+HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = ((int32_t)a0 == 0) ? 3 : 0; return 0; }
 
 // sceSystemServiceParamGetInt(SceSystemServiceParamId paramId, int32_t* value): a0=paramId, a1=value.
 // The system-settings a blanket-zero stub gives are mostly harmless, EXCEPT the LANGUAGE (paramId 1):


### PR DESCRIPTION
paramId 0 = SKU_FLAG has only TRIAL=1/FULL=3 (no 0). Writing 0 makes sku==FULL false -> game drops into trial/demo mode. Both Unity targets call this at boot. Report FULL(3) for paramId 0. Refs #393.