### PR TITLE
fix(gpu): cap the indexed-draw vertex range to prevent a multi-GB VB upload (#461)

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -333,6 +333,18 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             // to it would drop every glyph but the first (#257). The VB is grown below to span this range;
             // a truly-unmapped tail still degrades safely (safe_copy stops at the mapping edge -> zero).
             vertex_count = max_index + 1;
+            // Sanity-cap the VALUE-derived vertex range (#461). kMaxIndices already caps the index COUNT,
+            // but a single garbage/torn 32-bit index VALUE — an announced 32-bit index buffer skips the
+            // <0x10000 fingerprint, and the index buffer is read from guest memory another thread may be
+            // freeing/rewriting — would inflate vertex_count to hundreds of millions and force a multi-GB
+            // VB upload (OOM / llvmpipe stall / crash on the submit thread). A real single-draw mesh is far
+            // below this ceiling; anything above it is garbage, so clamp (this only shrinks a garbage draw,
+            // never a legitimate one; the VB-grow below is 64-bit-safe + capped regardless).
+            if (vertex_count > kMaxIndices) {
+                if (log) fprintf(stderr, "[exec] indexed draw: max_index %u exceeds sanity cap %u — clamped "
+                                 "(garbage/torn indices?)\n", max_index, kMaxIndices);
+                vertex_count = kMaxIndices;
+            }
         }
     }
     // A genuinely empty draw (vcount_hint == 0 — engines emit 0-vertex DrawIndexAuto/DrawIndexOffset as
@@ -355,8 +367,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // gl_VertexIndex reads the real per-vertex data. (Correct in general: a VB must span the drawn range.)
     if (vrt) for (auto& r : vrt->resources)
         if (r.cls == ResourceClass::VertexBuffer && r.stride) {
-            uint32_t need = vertex_count * r.stride;
-            if (r.size < need) r.size = need;
+            // 64-bit to avoid a uint32 overflow (vertex_count up to 1M x a 14-bit stride overflows 32-bit),
+            // and cap the grown size to the same 256 MB plausibility ceiling the V# decode uses — a VB this
+            // large is never real, and an unbounded r.size drives a multi-GB upload (#461). Vertices past
+            // the real backing degrade safely (safe_copy stops at the mapping edge -> robust-0).
+            uint64_t need = (uint64_t)vertex_count * r.stride;
+            if (need > 0x10000000ull) need = 0x10000000ull;   // 256 MB cap
+            if ((uint64_t)r.size < need) r.size = (uint32_t)need;
         }
     // PROSPER_CAPTION_DIAG: for the caption text mesh (a draw whose PS samples the 2048x1024 R8 font
     // atlas), dump everything needed to see WHY its geometry collapses — vertex count, the bound vertex

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -130,6 +130,22 @@ int main() {
         CHECK(made3 && it3.vertex_count == 3u, "non-zero vertex-count draw still realizes");
     }
 
+    // #461: an indexed draw whose fetched index buffer contains a garbage-large value (an announced
+    // 32-bit index buffer, or a torn read of concurrently-freed guest memory) must NOT inflate
+    // vertex_count / the VB upload unboundedly (OOM guard). realize_draw_item clamps vertex_count to the
+    // index-count ceiling (1<<20) instead of max_index+1 = ~0x0F000001.
+    {
+        static const uint32_t kBigIdx[3] = { 0u, 1u, 0x0F000000u };   // one garbage/huge 32-bit index
+        GpuState sbig = st;
+        sbig.index_type = 1;   // 32-bit (announced -> the <0x10000 fingerprint is not run)
+        GpuState::Draw db; db.index_count = 3; db.indexed = true; db.index_addr = (uint64_t)(uintptr_t)kBigIdx;
+        sbig.draws.clear(); sbig.draws.push_back(db);
+        DrawItem itb;
+        bool madeb = realize_draw_item(sbig, &sbig.draws[0], sbig.draws[0].index_count, 0x10000u, /*log*/false, itb);
+        CHECK(madeb && itb.vertex_count == (1u << 20),
+              "#461: garbage-large index clamps vertex_count to the 1<<20 ceiling (no multi-GB VB)");
+    }
+
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");


### PR DESCRIPTION
## Problem
For an indexed draw the executor derived `vertex_count = max_index + 1` from the fetched index buffer and grew every bound vertex buffer to `vertex_count*stride` with **no ceiling**. A single garbage/torn 32-bit index VALUE — an announced 32-bit index buffer skips the `<0x10000` unannounced-fingerprint, and the index buffer is read from guest memory another thread may be freeing/rewriting — inflates `vertex_count` to hundreds of millions, forcing a multi-GB VB upload (**OOM / llvmpipe stall / crash** on the submit thread). `kMaxIndices` already caps index COUNT; there was no matching ceiling on index VALUE / derived count, and `vertex_count * stride` could also overflow uint32.

## Fix
Clamp the value-derived `vertex_count` to `kMaxIndices` (a real single-draw mesh is far below it; clamping only shrinks a garbage draw), and compute the VB grow in 64-bit capped at the 256 MB plausibility ceiling the V# decode already uses. Vertices past the real backing degrade safely (`safe_copy` → robust-0).

## Verification
`test_gpu_execute`: an indexed draw with a garbage-large 32-bit index clamps `vertex_count` to `1<<20` instead of `~0x0F000001`. Full ctest 82/82 green.

Fixes #461