### PR TITLE
fix(gpu): reject over-length PM4 packets in begin_packet + WriteData (#450)

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -89,6 +89,12 @@ struct AgcDcb {
 inline uint32_t* begin_packet(uint64_t buf, uint32_t n, uint32_t op, uint32_t r, uint32_t** out) {
     auto* dcb = (AgcDcb*)(uintptr_t)buf;
     if (!dcb) { *out = nullptr; return nullptr; }
+    // A type-3 PM4 packet's length is a 14-bit field encoded as (n-2), so a valid packet is 2..0x4001
+    // dwords. An out-of-range n wraps the length field and emits a header claiming a tiny packet for a
+    // physically huge one — mis-framing (truncating) the rest of the submit fold. This is the shared
+    // choke point for every builder, so guarding it here covers WriteData, CbNop and the SetShReg range
+    // at once (#450, the overflow sibling of #401's num==1 underflow). Reject rather than corrupt.
+    if (n < 2u || n > 0x4001u) { *out = nullptr; return nullptr; }
     uint32_t* cmd = dcb->allocate_dw(n);
     if (cmd) cmd[0] = PM4(n, op, r);
     *out = cmd;
@@ -479,8 +485,12 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     // destination stale beyond dword 60 with no diagnostic. An accepted-but-large num cannot
     // overrun the ring: begin_packet -> allocate_dw() checks 5+num against available_dw() (with
     // the grow callback) and returns null on failure, which takes the `return 0` path below.
-    if (num > 0x3FFF) {
-        fprintf(stderr, "[agc] WriteData REJECTED num_dwords=%u (>PM4 max 0x3FFF — mis-decoded arg?)\n", num);
+    // The emitted packet is 5 + num dwords, and a type-3 PM4 packet is at most 0x4001 dwords (14-bit
+    // length field). Bound `num` against the PACKET limit, not the raw data count: num > 0x3FFC would
+    // make 5+num overflow the length field and mis-frame the submit (#450). begin_packet re-checks the
+    // same 0x4001 ceiling defensively, but reject early here with a clear diagnostic.
+    if (num > 0x3FFCu) {
+        fprintf(stderr, "[agc] WriteData REJECTED num_dwords=%u (5+num > PM4 max 0x4001 — mis-decoded arg?)\n", num);
         return 0;
     }
     if (getenv("PROSPER_GFXLOG")) fprintf(stderr, "[agc] WriteData dst=0x%llx addr=0x%llx num=%u src=%p\n",

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -118,6 +118,23 @@ int main() {
         Dcb d3{}; d3.bottom = buf3; d3.top = buf3 + 64; d3.cursor_up = buf3; d3.cursor_down = buf3 + 64;
         nop((uint64_t)(uintptr_t)&d3, /*num_dwords*/ 4, 0, 0, 0, 0);
         CHECK((size_t)(d3.cursor_up - d3.bottom) == 4, "cb_nop(4) reserves 4 dwords (type-3 NOP unchanged)");
+
+        // #450: begin_packet rejects an OVER-LENGTH packet (n > 0x4001) at the shared choke point rather
+        // than wrapping the 14-bit length field into a header claiming a tiny packet. cb_nop(0x4002) must
+        // emit nothing (return 0) and not advance the cursor — the overflow sibling of #401's underflow.
+        uint32_t buf4[64]; memset(buf4, 0, sizeof buf4);
+        Dcb d4{}; d4.bottom = buf4; d4.top = buf4 + 64; d4.cursor_up = buf4; d4.cursor_down = buf4 + 64;
+        uint64_t big = nop((uint64_t)(uintptr_t)&d4, /*num_dwords*/ 0x4002, 0, 0, 0, 0);
+        CHECK(big == 0 && d4.cursor_up == d4.bottom, "cb_nop(0x4002) rejected (packet > 0x4001, no cursor advance)");
+
+        // #450: sceAgcDcbWriteData bounds num against the 5-dword packet overhead — num=0x3FFF (5+num =
+        // 0x4004 > 0x4001) must be REJECTED, not emit a wrapped header that truncates the submit.
+        auto wd = Hle::lookup("i1jyy49AjXU");   // sceAgcDcbWriteData
+        CHECK(wd, "sceAgcDcbWriteData registered");
+        uint32_t buf5[64]; memset(buf5, 0, sizeof buf5);
+        Dcb d5{}; d5.bottom = buf5; d5.top = buf5 + 64; d5.cursor_up = buf5; d5.cursor_down = buf5 + 64;
+        uint64_t wr = wd((uint64_t)(uintptr_t)&d5, /*dst*/0, /*policy*/0, /*addr*/0, /*data*/0, /*num*/0x3FFF);
+        CHECK(wr == 0 && d5.cursor_up == d5.bottom, "WriteData(num=0x3FFF) rejected (5+num overflows the length field)");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Problem
A type-3 PM4 packet's length is a 14-bit field encoded as `(n-2)`, so the max representable packet is `0x4001` dwords. `sceAgcDcbWriteData` guarded `num_dwords` against `0x3FFF`, but the emitted packet is `5+num` dwords, so `num` in `{0x3FFD..0x3FFF}` makes `5+num` wrap the length field → a header claiming a 2-4-dword packet for a physically ~16K-dword one, which mis-frames (truncates) the rest of the submit fold. The same wrap is reachable via `agc_cb_nop` and the SetShReg range, which had no upper bound at all. The overflow sibling of #401's `num==1` underflow.

## Fix
Guard the shared choke point: `begin_packet` now rejects `n < 2 || n > 0x4001` (covers WriteData, CbNop, SetShReg range at once), and WriteData's own guard is tightened to `num > 0x3FFC` (`5+num > 0x4001`) with a clear diagnostic.

## Verification
`test_pm4_decode`: `cb_nop(0x4002)` and `WriteData(num=0x3FFF)` are both rejected (return 0, no cursor advance). Full ctest 82/82 green.

Fixes #450