### PR TITLE
fix(recompiler): v_cmpx writes EXEC only, not VCC (#464)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2366,12 +2366,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // instead of VCC — track it in sreg_bool so a later v_cndmask_b32_e64 / s_cselect can read it.
             // Otherwise it writes VCC; keep VCC's narrowed-state in sync (106/107 = VCC_LO/HI).
             if (ok) {
-                if (in.dst.kind == OperandKind::SGPR && in.dst.value <= 105) {
+                if (is_cmpx) {
+                    // v_cmpx writes EXEC ONLY on gfx10 (EXEC &= cmp) — it has NO VCC/SGPR destination.
+                    // The old shared handler fell into the `else` and set vcc = cmp for cmpx too,
+                    // clobbering a VCC value kept live ACROSS the cmpx, so a later v_cndmask/s_cbranch_vccz/
+                    // v_add_co_ci reading VCC got the compare mask instead of the real predicate (#464).
+                    rs.exec = b.land(rs.exec, cmp); rs.exec_narrowed = true;
+                } else if (in.dst.kind == OperandKind::SGPR && in.dst.value <= 105) {
                     rs.sreg_bool[in.dst.value] = cmp; rs.sreg_bool_narrowed[in.dst.value] = true;
                 } else {
                     vcc = cmp; rs.sreg_bool_narrowed[106] = true; rs.sreg_bool_narrowed[107] = true;
                 }
-                if (is_cmpx) { rs.exec = b.land(rs.exec, cmp); rs.exec_narrowed = true; }
             }
             return true;
         }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1526,6 +1526,21 @@ int main() {
     }
     CHECK(gotT5c.size()==N && badT5c==0, "T5c: s_mul_hi_i32(-1,0x10000)=0xFFFFFFFF (signed high mul)");
 
+    // Kernel T5d (#464): v_cmpx must NOT clobber VCC (gfx10: cmpx writes EXEC only). Keep a VCC value
+    // live ACROSS a cmpx and read it via v_cndmask. v_cmp_lt_u32 vcc,v0,v0 = FALSE (a live predicate);
+    // v_cmpx_eq_u32 v0,v0 leaves EXEC on (v0==v0) and must PRESERVE vcc; v_cndmask v1,v0,v2,vcc then
+    // selects v0 (vcc FALSE) — the old code set vcc=cmpx result (TRUE) -> selected v2 = v0+5. Out = a0.
+    const uint32_t codeT5d[] = { 0x7d820100u, 0x7da40100u, 0x4a040085u, 0x02020500u, 0xBF810000u };
+    std::vector<uint32_t> spvT5d = recompile_valu(codeT5d, sizeof(codeT5d)/4, 1, 1);
+    CHECK(!spvT5d.empty(), "recompiled T5d (v_cmpx VCC preservation) -> SPIR-V");
+    std::vector<float> gotT5d = prosper::test::run_compute(spvT5d, inX, N, N);
+    uint32_t badT5d = 0;
+    for (uint32_t i = 0; i < N && gotT5d.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotT5d[i], 4);
+        if (gb != bits_of(inX[i])) badT5d++;
+    }
+    CHECK(gotT5d.size()==N && badT5d==0, "T5d: v_cmpx preserves VCC (cndmask reads the v_cmp result, not cmpx)");
+
     // Kernel T6: s_add_u32 carry chain -> s_addc_u32. s0=-1+2 (carry SCC=1); s1=0+0+SCC=1.
     // out bits = bits(a0) + 1.
     const uint32_t codeT6[] = { 0x800082c1u, 0x82018080u, 0x4a020001u, 0xBF810000u };


### PR DESCRIPTION
## Problem
The shared VOPC handler set `rs.vcc = cmp` for **every** compare, including the `v_cmpx_*` variants. On gfx10 `v_cmpx` writes its result to **EXEC only** (`EXEC &= cmp`) — it has no VCC/SGPR destination (llvm-mc: `v_cmp` carries a `vcc_lo` dest, `v_cmpx` carries none). The decoder forces `in.dst = {Special, VCC_LO}` for all VOPC e32 forms, so the `else` (VCC-write) branch fired for cmpx too, clobbering a VCC value kept live **across** the cmpx. A later `v_cndmask`/`s_cbranch_vccz`/`v_add_co_ci` reading VCC then got the compare mask instead of the real predicate → wrong lane selection / branch.

## Fix
Restructure so `is_cmpx` updates **only** exec (`exec &= cmp`), never vcc or an SGPR dest. The common alpha-test discard idiom (cmpx then no vcc read) is unaffected.

## Verification
`test_rdna2_to_spirv` T5d: `v_cmp_lt` sets vcc FALSE, a `v_cmpx` runs, and a `v_cndmask` reading vcc selects the `v_cmp` result (out = a0); the old code let the cmpx overwrite vcc (out = a0 + 5). Full ctest 82/82 green.

Fixes #464