### PR TITLE
fix(recompiler): clamp bitfield-extract so Offset+Count <= 32 (avoid SPIR-V UB) (#455)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -222,8 +222,14 @@ struct SpirvCompute {
     uint32_t scmp(uint32_t op, uint32_t a, uint32_t b) { uint32_t r = id(); put(code, op, {t_bool, r, bcs(a), bcs(b)}); return r; }
     uint32_t ucmp(uint32_t op, uint32_t a, uint32_t b) { uint32_t r = id(); put(code, op, {t_bool, r, a, b}); return r; }
     // Bitfield extract (base, offset, count) -> bits. Unsigned and signed variants.
-    uint32_t bfe_u(uint32_t base, uint32_t off, uint32_t cnt) { uint32_t r = id(); put(code, Op_BitFieldUExtract, {t_u32, r, base, off, cnt}); return r; }
-    uint32_t bfe_s(uint32_t base, uint32_t off, uint32_t cnt) { uint32_t ri = id(); put(code, Op_BitFieldSExtract, {t_i32, ri, bcs(base), off, cnt}); return i2u(ri); }
+    // Clamp so Offset+Count <= 32 (#455). SPIR-V OpBitField*Extract is UNDEFINED when off+cnt exceeds
+    // the 32-bit operand width, but s_bfe's 7-bit width field (0..127) and v_bfe's off+cnt (up to 62)
+    // can exceed it. RDNA2 reads bits past the source MSB as 0 (unsigned) / sign (signed), i.e. the
+    // effective count is min(cnt, 32-off) — reproduce that instead of emitting UB (the constant-offset
+    // callers already satisfy off+cnt<=32, so the umin/isub fold to no-ops there).
+    uint32_t bfe_clamp_cnt(uint32_t offc, uint32_t cnt) { return uext2(Glsl_UMin, cnt, ibin(Op_ISub, uconst(32), offc)); }
+    uint32_t bfe_u(uint32_t base, uint32_t off, uint32_t cnt) { uint32_t offc = uext2(Glsl_UMin, off, uconst(32)); uint32_t r = id(); put(code, Op_BitFieldUExtract, {t_u32, r, base, offc, bfe_clamp_cnt(offc, cnt)}); return r; }
+    uint32_t bfe_s(uint32_t base, uint32_t off, uint32_t cnt) { uint32_t offc = uext2(Glsl_UMin, off, uconst(32)); uint32_t ri = id(); put(code, Op_BitFieldSExtract, {t_i32, ri, bcs(base), offc, bfe_clamp_cnt(offc, cnt)}); return i2u(ri); }
     // Lazily declared 64-bit uint (+ Int64 capability), for s_bfe_u64 etc. that operate on SGPR pairs.
     uint32_t t_u64_cache = 0; bool declared_int64 = false;
     uint32_t t_u64() { if (!t_u64_cache) { if (!declared_int64) { put(caps, Op_Capability, {Cap_Int64}); declared_int64 = true; }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1551,6 +1551,21 @@ int main() {
     }
     CHECK(gotT7.size()==N && badT7==0, "T7: s_ashr_i32 sign-extends the shift");
 
+    // Kernel T7b (#455): v_bfe_u32 with offset+count > 32 must not emit UB. v_bfe_u32 v1, v0, 20, 16 has
+    // off=20, count=16 -> off+count = 36 > 32 (SPIR-V OpBitFieldUExtract is UNDEFINED there). RDNA2 reads
+    // bits past the MSB as 0, i.e. effective count = min(16, 32-20) = 12, so v1 = (v0 >> 20) & 0xFFF =
+    // v0 >> 20 (only 12 bits exist above bit 20). The clamp makes this well-defined.
+    const uint32_t codeT7b[] = { 0xd5480001u, 0x02412900u, 0xBF810000u };
+    std::vector<uint32_t> spvT7b = recompile_valu(codeT7b, sizeof(codeT7b)/4, 1, 1);
+    CHECK(!spvT7b.empty(), "recompiled T7b (v_bfe_u32 off+count>32) -> SPIR-V");
+    std::vector<float> gotT7b = prosper::test::run_compute(spvT7b, inX, N, N);
+    uint32_t badT7b = 0;
+    for (uint32_t i = 0; i < N && gotT7b.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotT7b[i], 4);
+        if (gb != (bits_of(inX[i]) >> 20)) badT7b++;
+    }
+    CHECK(gotT7b.size()==N && badT7b==0, "T7b: v_bfe_u32(v0,20,16) clamps count to 12 -> (v0>>20), not UB");
+
     // Kernel T8: s_mov_b64 as plain DATA-pair copy (not a wave mask): s2=9; s[0:1]=s[2:3];
     // out bits = bits(a0) + 9. Previously rejected (src not a recognizable mask).
     const uint32_t codeT8[] = { 0xbe820389u, 0xbe800402u, 0x4a020000u, 0xBF810000u };


### PR DESCRIPTION
## Problem
`bfe_u`/`bfe_s` fed the guest offset and count straight into `OpBitFieldUExtract`/`SExtract`. SPIR-V leaves the result **undefined** when `Offset+Count` exceeds the 32-bit operand width, but `s_bfe`'s 7-bit width field is 0..127 and `v_bfe`'s off+count can reach 62 — both clearly exceed 32. A guest `s_bfe`/`v_bfe` with e.g. offset=20,width=16 (both legal hardware fields, sum 36) then produced driver-dependent garbage where RDNA2 is well-defined: bits past the source MSB read as 0 (unsigned) / sign (signed), i.e. effective count = `min(count, 32-offset)`.

## Fix
Clamp in the helpers: `offc = umin(off, 32)`, `cnt' = umin(cnt, 32-offc)`, so `off+cnt' <= 32` for every input while reproducing the hardware read-past-MSB behavior. The constant-offset callers (unpack_norm, vertex fetch) already satisfy `off+cnt<=32`, so the umin/isub fold to no-ops and their results are byte-identical.

## Verification
`test_rdna2_to_spirv` T7b: `v_bfe_u32(v0, 20, 16)` (off+count=36) yields `(v0 >> 20)` — the count clamped to 12 — instead of UB. Full ctest 82/82 green.

Fixes #455