### PR TITLE
fix(gpu): guard the pend-queue completion write against an unmapped target (#449)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -345,6 +345,7 @@ struct PendQueue {
 };
 PendQueue& pend_q() { static PendQueue* p = new PendQueue; return *p; }
 void apply_effect(const Pm4Command& c);   // fwd (defined with the WAIT_DEFER machinery below)
+void apply_deferred_effect(const Pm4Command& c);   // fwd: apply_effect + a guest_readable guard (#449)
 // Drain returns only when every pending write has LANDED — including one a concurrent drainer
 // popped and is mid-applying (the in-flight window). Without that wait, a caller could observe an
 // empty queue and proceed to apply a LATER same-address write (a released #312 gated item) that
@@ -356,7 +357,12 @@ void pend_drain_locked(PendQueue& p, std::unique_lock<std::mutex>& lk) {
             p.q.pop_front();
             p.inflight++;
             lk.unlock();                 // the write itself never needs the queue lock
-            apply_effect(w.cmd);
+            // Guard the target's mappedness (#449): the pend queue applies completion writes ~1 ms after
+            // enqueue (the pipe-drain window), during which the guest may have freed+decommitted the
+            // label page (MallocBinned3, #312). apply_deferred_effect probes guest_readable before the
+            // raw memcpy — without it an unmapped label SIGSEGVs here, exactly the case the deferred-
+            // stream path already survives (this pend path releases asynchronously too, so it needs it).
+            apply_deferred_effect(w.cmd);
             lk.lock();
             p.inflight--;
             if (p.inflight == 0) p.cv.notify_all();


### PR DESCRIPTION
## Problem
The default (non-`PROSPER_WAIT_DEFER`) completion-write path enqueues fence/label writes to the ~1 ms pipe-drain pend queue, whose worker applied them via `apply_effect()` → `honor_eop_write`/`honor_write_data`/`honor_event_write` with **no** `guest_readable` check — only an alignment (`&3`) guard. The deferred-stream path applies the identical effects through `apply_deferred_effect()`, which probes `guest_readable` first precisely to survive the target being unmapped in the release window. So a completion write whose label page is freed+decommitted during the drain window (MallocBinned3, the #312 class) **SIGSEGVs** on the raw memcpy on the default path — the exact case the deferred path already survives.

## Fix
Route `pend_drain_locked`'s apply through `apply_deferred_effect` (a forward declaration + one call change), so the pend path gets the same mappedness guard. The pend path releases asynchronously (~1 ms later) just like the deferred path, so it needs the identical protection.

## Verification
Existing eop/wait/submit tests green (pend path with mapped targets applies writes correctly — no regression). The SIGSEGV case needs an async unmap mid-drain, impractical in a unit test. Full ctest 82/82 green.

Fixes #449