### PR TITLE
docs: refresh READMEs to current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,84 @@
 # prosper
 
 **A user-space PlayStation 5 → PC compatibility layer.** Think *Proton/Wine, but for PS5*: prosper
-runs PS5 (Prospero) game binaries on Linux (primary) and Windows (bonus) by translating the
-console's OS, ABI, and (eventually) GPU calls to the host — **not** by emulating a CPU.
+runs PS5 (Prospero) game binaries on Linux (primary) and Windows (secondary) by reimplementing the
+console's OS, ABI, and GPU stack on the host — **not** by emulating a CPU.
 
-> ⚠️ **Early, experimental research project.** It does not run games to playable state yet. See
-> [Status](#status) for exactly how far it gets today.
+> ⚠️ **Experimental research project.** It is not a playable game runner yet, but it now boots real
+> retail titles deep into their engine's frame loop and **renders real frames** to a live Vulkan
+> backend. See [Status](#status) for exactly how far it gets today.
 
 ## Why no CPU emulation?
 
 The PS5 is an x86-64 (AMD Zen 2) machine, so guest game code runs **natively** on any modern PC.
-prosper is therefore shaped like Wine, not like an emulator: the hard work is
+prosper is therefore shaped like Wine, not like an emulator. The engineering is:
 
 - **Loading** Sony's `SELF`/`ELF` module format and linking multiple modules into one address space,
-- **HLE** (high-level emulation) of the PS5 system libraries (`libkernel`, `libc`, `libSceGnmDriver`/
-  `libSceAgc`, `libScePad`, …) by thunking to the host's real facilities (libc, pthreads, `mmap`,
-  `futex`, …),
+- **HLE** (high-level emulation) of the PS5 system libraries (`libkernel`, `libc`, `libSceAgc`,
+  `libScePad`, `libSceSaveData`, `libSceNp`, the dialog/IME libraries, …) by thunking to the host's
+  real facilities (libc, pthreads, `mmap`, `futex`, Vulkan, …),
 - **ABI translation** where the guest's FreeBSD/SysV conventions differ from the host, and
-- **Graphics translation** (the eventual end goal): PS5 **AGC** → Vulkan, including an RDNA2 shader
-  recompiler. This is the largest remaining piece and is now the **active frontier** (see Status).
+- **Graphics translation:** PS5 **AGC** command streams → Vulkan, including a from-scratch
+  **RDNA2 → SPIR-V shader recompiler** and the RDNA2 texture-tiling / block-compression decoders.
 
 Because the PS5 and Steam Deck / AMD Linux machines share the same RDNA2 GPU family, Linux is the
 natural primary target and the long-term dream is running on that hardware.
 
 ## Status
 
-The current bring-up target is a real Unity/IL2CPP title. Starting from its (user-supplied,
-**unencrypted-segment**) module set, prosper today:
+prosper boots **multiple real retail titles** across two engine families — Unity 2022 / IL2CPP
+(*The Messenger*, `PPSA24651`, the primary target) and Unreal Engine (`PPSA17942`) — from a
+user-supplied, **unencrypted-segment** dump. For the primary title it now boots *through* the engine
+and draws real geometry.
 
-**Boot & runtime (host-side OS/ABI/HLE):**
-- ✅ Parses `SELF`/`ELF`, builds a relocatable image, resolves Sony **NID**-hashed imports.
-- ✅ Links the game's modules together with a global export table + per-import HLE stubs.
-- ✅ Runs the Sony CRT, C++ global constructors, and `il2cpp` startup.
-- ✅ Implements enough `libkernel`/`libc` for real memory management (virtual + direct memory),
-  threads (pthreads, TLS, mutexes/conds, event flags, semaphores, `sync_on_address` futex),
-  time, file I/O (with `/app0` path translation), and locale/ctype.
-- ✅ Loads the game's C# metadata, spins up the full IL2CPP GC + worker thread pool, and boots
-  **through** IL2CPP init into Unity's `GfxDevice` bring-up (it loads *unity default resources*).
+**Boot & runtime (host-side OS / ABI / HLE):**
+- ✅ Parses `SELF`/`ELF`, builds a relocatable image, resolves Sony **NID**-hashed imports, links the
+  game's modules with a global export table + per-import HLE stubs, and runs the Sony CRT + C++ global
+  constructors.
+- ✅ Enough `libkernel`/`libc` for real memory management (virtual + direct + flexible memory, guard
+  pages), threads (pthreads, TLS, mutexes/conds, event flags, semaphores, `sync_on_address` futex),
+  scheduling, time, AIO + positioned file I/O (with `/app0` path translation), and locale/ctype.
+- ✅ Loads the C# metadata, spins up the full **IL2CPP GC + worker thread pool**, and boots through
+  IL2CPP init and Unity's `GfxDevice` bring-up into the running frame loop.
+- ✅ System services the game gates on: user/pad service, SaveData (real per-slot memory blocks),
+  AvPlayer / AJM lifecycle, common dialogs + IME (with an optional real SDL3 dialog frontend), NP /
+  online (honest signed-out), system-parameter (language) — implemented as faithful behaviors, not
+  success-returning stubs.
 
-**Graphics (AGC → Vulkan) — the active frontier:**
-- ✅ **AGC command frontend complete:** `sceAgcCreateShader` (relocates the embedded RDNA2 shader
-  ELFs, registers all 36 game shaders) and `sceAgcDriverSubmitDcb`. The boot clears the entire AGC
-  path with **zero unimplemented `libSceAgc` calls remaining**; a real submitted command buffer is
-  decoded (`Dcb` → PM4 packets) and folded into a GPU register-state (regression-locked by a test).
-- ✅ **RDNA2 → SPIR-V shader recompiler** (we recompile the GPU ISA, not emulate it). ~52 ALU ops
-  (scalar/vector/float/int/bitwise/convert/compare/select/bitfield/pack) **plus divergent control
-  flow** — EXEC-mask per-lane predication, `s_*saveexec`/`s_mov_b64 exec` save/restore, and forward
-  `s_cbranch_execz`-style branches (the real if-then idiom) — all proven by execution-differential
-  tests on real Vulkan. A coverage tool (`shader_histo`) reports **67% instruction coverage over the
-  game's 41 real embedded shaders**; the remaining wall is `SMEM` constant/descriptor loads (needs
-  the resource-binding model).
-- ✅ **GpuState → frame spine:** register-state → `render_state`/`vk_translate` →
-  `resolve_pipeline_state` → a real `VkGraphicsPipeline`, with topology/blend/depth/color-write-mask
-  all driven from the decoded registers and **verified by pixel readback**. Both recompiled vertex
-  and fragment shaders render offscreen.
-- 🚧 **Root cause of the current boot fault (found, fix in progress):** Unity's GPU-resource
-  *residency pass is completion-event-driven* — it runs when the game drains a GPU-completion event
-  from the AGC equeue. Our headless equeue never delivers one, so the pass never runs and pipeline
-  objects stay unprocessed (a null companion the engine later dereferences). The fix is to **deliver
-  a real completion event on submit/flip so the game's own pass runs** — *not* to fabricate residency.
-  Once it fires, real draws flow into the `GpuState → frame` spine above.
+**Graphics (AGC → Vulkan):**
+- ✅ **AGC command frontend:** `sceAgcCreateShader` (relocates the embedded RDNA2 shader ELFs) and the
+  submit path; a real submitted `Dcb` is decoded (→ PM4 packets) and folded into a GPU register-state,
+  with GPU-completion (EOP) events and DMA/fence writes delivered on the guest's own timeline
+  (regression-locked by tests).
+- ✅ **RDNA2 → SPIR-V shader recompiler** (we recompile the GPU ISA, not emulate it): full scalar/
+  vector ALU (float/int/bitwise/convert/compare/select/bitfield/pack), `SCC`, **divergent control
+  flow** (EXEC-mask predication, `saveexec`/restore, `execz` if-then and loop exits), `SMEM`
+  constant/descriptor loads, `MUBUF` vertex-fetch + load/store, `MIMG` `image_sample`/`_l`/`_lz`/
+  `image_load`, `LDS` + barriers, `EXP` render-target/position/param exports, and `VINTRP`
+  interpolation. Descriptors that spill into the **Extended User Data (EUD)** area are resolved. Every
+  emitted shader is strictly `spirv-val`-gated.
+- ✅ **Texture decode:** GFX10 `SW_4KB_S` / `SW_64KB_S` de-swizzle for all element sizes (1/2/4/8/16 B,
+  derived from the authoritative addrlib table) plus BC1–BC7 and BC6H block decompression, honoring
+  the T# format, `DST_SEL` channel swizzle, and the paired S# sampler (filter / wrap / anisotropy /
+  LOD / border).
+- ✅ **Frame spine → live renderer:** decoded register-state → `render_state` / `vk_translate` →
+  `resolve_pipeline_state` → real `VkGraphicsPipeline`s, with topology, blend (incl. separate-alpha),
+  depth, stencil, per-MRT color-write-mask, the game's real fast-clear color, and a render-to-texture
+  cache for multi-pass composites — all driven from the decoded registers and pixel-verified.
+- ✅ **The Messenger renders:** it plays its intro **cutscene** (dozens of distinct animating frames),
+  draws its **title screen with readable text**, accepts **gamepad input**, and progresses through
+  New-Game into **gameplay level loading**. Frames are asserted by a golden-image regression guard, not
+  eyeballed.
 
-Development is **agentic-first**: correctness is verified programmatically — 31 self-checking tests
+**Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
+evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
+headless `boot_trace`.
+
+Development is **agentic-first**: correctness is verified programmatically — **84 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
-numeric/pixel results), cross-platform CI (Linux + Windows/MinGW), structured logs, and purpose-built
-tooling (`boot_trace`, `shader_histo` coverage, `PROSPER_PEEK`/`PROSPER_PIPETRACE`) — never by hand.
+numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
+that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
+Windows/MinGW), structured logs, and purpose-built tracing tooling — never by hand.
 
 ## Legal / ethical
 
@@ -72,21 +86,25 @@ tooling (`boot_trace`, `shader_histo` coverage, `PROSPER_PEEK`/`PROSPER_PIPETRAC
   will be. You must supply your own legally-obtained dump.
 - prosper only works with **unencrypted** module segments; it contains **no** console decryption
   keys and performs no circumvention of Sony's cryptography.
-- This is an independent interoperability / research project, not affiliated with or endorsed by
-  Sony Interactive Entertainment.
+- Sony's library interfaces are reimplemented from published symbol/NID information, clean-room style,
+  the way Wine reimplements Win32.
+- This is an independent interoperability / preservation research project, not affiliated with or
+  endorsed by Sony Interactive Entertainment.
 
 ## Building (Linux)
 
-Requires a C++20 compiler, CMake, and Ninja.
+Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the graphics tests
+(the CI/headless path uses the `llvmpipe` software ICD).
 
 ```sh
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux
+ctest --test-dir build-linux          # 84 self-checking tests
 ```
 
-A static-linked Windows (mingw) build works for the host-agnostic parts as well.
+Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). A
+static-linked Windows (MinGW) build covers the host-agnostic parts as well.
 
 ## Repository layout
 
@@ -96,11 +114,12 @@ prosper/
   src/loader/     multi-module linker + global export table
   src/hle/        HLE of Sony libraries (libc, libkernel, AGC/graphics, services), NID hashing
   src/host/       host execution: image mapping, stubs, fault handling (Linux)
-  src/gpu/        AGC→Vulkan: PM4 decode, command processor, render state,
-                  vk_translate, and the RDNA2→SPIR-V shader recompiler
-  tools/          debug tooling (boot_trace, self_dump, shader_histo, imgdump, …)
+  src/gpu/        AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
+                  texture tiling + BC decode, and the RDNA2→SPIR-V shader recompiler
+  frontends/      shared boot+render core, the windowed prosper-app, SDL3 audio/dialog, controllers
+  tools/          boot_trace, self_dump, shader_histo, snapshot (golden-image guard), spv_validate, …
   tests/          unit + boot + Vulkan-execution tests (run under ctest)
-  docs/           ROADMAP.md, FINDINGS.md, GRAPHICS.md, VERIFICATION.md
+  docs/           ARCHITECTURE, ROADMAP, GRAPHICS, RENDER_LOOP, VERIFICATION, and per-frontier logs
 ```
 
 ## License

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -1,52 +1,52 @@
 # prosper
 
-A PS5 (Prospero) → **Windows/Linux** user-space compatibility layer — *Proton for PS5*.
+A PS5 (Prospero) → **Linux/Windows** user-space compatibility layer — *Proton for PS5*.
 
-Not a CPU emulator: the PS5 is x86-64, so guest code runs **natively**. `prosper`
-translates the operating system (FreeBSD-derived), the library ABI (Sony NID-linked
-modules), and the GPU (AGC → Vulkan) underneath the unmodified game binary.
+Not a CPU emulator: the PS5 is x86-64, so guest code runs **natively**. `prosper` reimplements the
+operating system (FreeBSD-derived), the library ABI (Sony NID-linked modules), and the GPU
+(AGC → Vulkan) underneath the unmodified game binary.
 
-**Target title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP), whose dump
-lives in `../PPSA24651-app0`. Its SELF segments are unencrypted, which is what
-makes this project possible without console keys.
+**Primary title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP). Also exercised: `PPSA02664`
+(Unity/IL2CPP) and `PPSA17942` (Unreal Engine). Their SELF segments are unencrypted, which is what
+makes the project possible without console keys. Dumps are user-supplied and gitignored.
 
 ## Status
-- ✅ **M0 — Recon & tooling.** Format cracked, full HLE work-list extracted.
-- ✅ **M1 — Loader.** SELF/ELF → relocatable image → multi-module link → NID import binding.
-- ✅ **M2/M3 — HLE + boot.** libkernel/libc (memory, threads, futex, time, file I/O, locale);
-  IL2CPP GC + thread pool; boots **through** IL2CPP into Unity's GfxDevice bring-up.
-- 🚧 **M4/M5 — Graphics (AGC → Vulkan), active.** AGC command frontend complete (CreateShader +
-  SubmitDcb, zero unimplemented `libSceAgc` calls); PM4 decode → command processor → render state →
-  `resolve_pipeline_state` → a real `VkGraphicsPipeline` (topology/blend/depth/write-mask
-  pixel-verified). **RDNA2→SPIR-V recompiler — the back-half render path is comprehensively done:**
-  full ALU (float/int/bitwise/convert/compare/select) + `SCC` (`s_cmp`/`s_cselect`); **divergent
-  control flow** (EXEC predication, saveexec/restore, forward + guard-to-`s_endpgm` `execz`); **memory**
-  — `SMEM` x1–x16, `MUBUF` load + vertex-fetch (float32/unorm/snorm/f16) + store (raw + packed),
-  `MIMG` `image_sample`/`_l`/`_lz`/`image_load` (real textures), `LDS` + `s_barrier`; **shader I/O** —
-  `EXP` MRT/POS/PARAM + `VINTRP` interpolation. Every path is strictly `spirv-val`-verified
-  (`spv_validate`). Coverage over the 41 real game shaders: **79.7% recompilable in context**, 10/41
-  fully covered *given resource tables* (`shader_histo`). End-to-end demos render a **textured triangle
-  with interpolated UVs** and the game's **own recompiled pixel shader** (see `screenshots/`). The
-  remaining gap to the game's *own* format-dependent shaders is the **resource table** — which is built
-  from the shader's *draw-time* bound descriptors, so it is gated on the game reaching draw submission =
-  the Unity **GfxDevice boot wall** (front-half), not the recompiler. See
-  [`docs/GRAPHICS.md`](docs/GRAPHICS.md) and [`docs/RESOURCE_BINDING.md`](docs/RESOURCE_BINDING.md).
+- ✅ **M0–M1 — Recon, tooling & loader.** Format cracked; SELF/ELF → relocatable image → multi-module
+  link → NID import binding.
+- ✅ **M2–M3 — HLE + boot.** libkernel/libc (virtual/direct/flexible memory + guard pages, threads,
+  futex, AIO + file I/O, time, locale); IL2CPP GC + thread pool; system services the games gate on
+  (user/pad, SaveData, AvPlayer/AJM, common dialogs + IME, NP/online, system language). Boots
+  **through** IL2CPP and Unity's GfxDevice into the running frame loop.
+- ✅ **M4 — Graphics (AGC → Vulkan).** AGC frontend (CreateShader + submit; PM4 decode → command
+  processor → register-state fold; EOP/DMA/fence writes on the guest timeline). **RDNA2→SPIR-V
+  recompiler:** full ALU + `SCC`; divergent control flow (EXEC predication, saveexec/restore, `execz`
+  if-then + loop exits); `SMEM`, `MUBUF` vertex-fetch/load/store, `MIMG` sample/load, `LDS`+barriers,
+  `EXP`/`VINTRP`; EUD-resident descriptor resolution; every shader `spirv-val`-gated. Texture decode:
+  GFX10 `SW_4KB_S`/`SW_64KB_S` de-swizzle for all element sizes + BC1–7/BC6H, T# format + `DST_SEL`
+  swizzle + paired S# sampler. Frame spine → `resolve_pipeline_state` → real `VkGraphicsPipeline`s
+  with blend (incl. separate-alpha)/depth/stencil/write-mask/fast-clear + a render-to-texture cache.
+- ✅ **The Messenger renders:** intro cutscene (dozens of distinct animating frames), title screen with
+  readable text, working gamepad input, and progression into gameplay level loading — all asserted by
+  a golden-image snapshot guard.
+- 🚧 **Active frontiers:** full multi-pass scene compositing for the 3D gameplay view, broader shader
+  coverage, and the Unreal title's title-screen composite (see `docs/`).
 
-See [`docs/ROADMAP.md`](docs/ROADMAP.md) for milestones, [`docs/GRAPHICS.md`](docs/GRAPHICS.md) for
-the graphics frontier, and [`docs/VERIFICATION.md`](docs/VERIFICATION.md) for the agentic-first
-(programmatic, no-manual-eyeballing) verification strategy.
+See [`docs/ROADMAP.md`](docs/ROADMAP.md), [`docs/GRAPHICS.md`](docs/GRAPHICS.md),
+[`docs/RENDER_LOOP.md`](docs/RENDER_LOOP.md), and [`docs/VERIFICATION.md`](docs/VERIFICATION.md)
+(the agentic-first, programmatic, no-manual-eyeballing verification strategy).
 
 ## Layout
 ```
 prosper/
-  docs/            architecture, roadmap, findings, graphics, verification
+  docs/            architecture, roadmap, graphics, verification, per-frontier logs
   src/self/        SELF/ELF parsing → relocatable module image
   src/loader/      multi-module linker + global export table
-  src/hle/         HLE of Sony libraries (libc, libkernel, AGC/graphics), NID hashing
+  src/hle/         HLE of Sony libraries (libc, libkernel, AGC/graphics, services), NID hashing
   src/host/        host execution: image mapping, stubs, fault handling (Linux)
-  src/gpu/         AGC→Vulkan: PM4 decode, command processor, render state,
-                   vk_translate, resource layer (gpu_resources), RDNA2→SPIR-V recompiler
-  tools/           self_dump, boot_trace, shader_histo, imgdump, spv_validate
+  src/gpu/         AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
+                   texture tiling + BC decode, RDNA2→SPIR-V recompiler
+  frontends/       shared boot+render core, windowed prosper-app, SDL3 audio/dialog, controllers
+  tools/           self_dump, boot_trace, shader_histo, snapshot (golden-image guard), spv_validate
   tests/           unit + boot + Vulkan-execution tests (ctest)
   CMakeLists.txt
 ```
@@ -55,14 +55,15 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
+ctest --test-dir build          # 84 self-checking tests
 ```
-Or the tool directly:
+Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```
 g++ -O2 -std=c++20 tools/self_dump/self_dump.cpp -o self_dump
 ./self_dump ../PPSA24651-app0/eboot.bin [--symbols]
 ```
 
 ## Legal / scope
-Interoperability & preservation research on a legally-owned title. `prosper` ships
-**no** Sony code, firmware, or keys — it reimplements published library interfaces.
-It only operates on **already-unencrypted** dumps; it does not defeat DRM/encryption.
+Interoperability & preservation research on legally-owned titles. `prosper` ships **no** Sony code,
+firmware, or keys — it reimplements published library interfaces clean-room style. It only operates on
+**already-unencrypted** dumps; it does not defeat DRM/encryption.


### PR DESCRIPTION
The root and `prosper/` READMEs still described the long-solved GfxDevice completion-event boot wall, a single title, ~31 tests, and a partial recompiler blocked on SMEM. This brings both current:

- boots multiple retail titles (Unity/IL2CPP + Unreal); for The Messenger, renders its cutscene + title text, accepts gamepad input + dialogs, and progresses into gameplay level loading
- live Vulkan renderer (full frame spine: blend incl. separate-alpha, depth, stencil, write-mask, fast-clear, RTT), GFX10 SW_4KB_S/64KB_S de-swizzle for all element sizes + BC1–7/BC6H, T#/DST_SEL/S# sampler
- comprehensive RDNA2→SPIR-V recompiler (divergent control flow, SMEM/MUBUF/MIMG, EUD-resident descriptors, spirv-val-gated)
- `prosper-app` windowed frontend (SDL3 window/render/audio/pad/dialogs)
- 84 self-checking ctest tests + golden-image snapshot regression guard

Docs-only.