### PR TITLE
fix(gpu): honor guest cull/front-face/polygon mode (PA_SU_SC_MODE_CNTL) (#456)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -118,6 +118,8 @@ RenderState extract_render_state(const GpuState& st) {
 
     // Faithful raw state registers.
     rs.db_depth_control  = dc;
+    // Rasterizer cull/front-face/polygon mode (#456). Absent -> 0 -> CULL_NONE/CCW/FILL (prior default).
+    rs.pa_su_sc_mode_cntl = rd(st.cx, P::PA_SU_SC_MODE_CNTL);
     // Stencil op + ref/mask registers (absent -> 0; stencil_enable already gates whether they apply).
     rs.db_stencil_control   = st.cx.count(P::DB_STENCIL_CONTROL)   ? rd(st.cx, P::DB_STENCIL_CONTROL)   : 0u;
     rs.db_stencilrefmask    = st.cx.count(P::DB_STENCILREFMASK)    ? rd(st.cx, P::DB_STENCILREFMASK)    : 0u;
@@ -245,6 +247,25 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         if (rs.vport_zscale != 0.0f || rs.vport_zoffset != 0.0f) {
             ps.min_depth = std::clamp(rs.vport_zoffset, 0.0f, 1.0f);
             ps.max_depth = std::clamp(rs.vport_zoffset + rs.vport_zscale, 0.0f, 1.0f);
+        }
+    }
+
+    // Rasterizer cull/front-face/polygon mode from PA_SU_SC_MODE_CNTL (#456). CULL_FRONT[0]/CULL_BACK[1]
+    // -> VkCullModeFlags (FRONT_BIT=1, BACK_BIT=2). FACE[2]: 0 = CCW is front, 1 = CW is front -> the guest
+    // default (0) maps to VK_FRONT_FACE_COUNTER_CLOCKWISE, matching the negative-height flipped viewport
+    // that already renders correct-facing geometry. POLY_MODE[4:3]==0 -> FILL; otherwise the front-face
+    // PTYPE[7:5] (0=points,1=lines,2=triangles) selects VkPolygonMode (POINT=2, LINE=1, FILL=0).
+    const uint32_t su = rs.pa_su_sc_mode_cntl;
+    ps.cull_mode  = (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, CULL_FRONT) ? 1u : 0u)
+                  | (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, CULL_BACK)  ? 2u : 0u);
+    ps.front_face = PM4_FIELD(su, PA_SU_SC_MODE_CNTL, FACE) ? 0u /*VK CW*/ : 1u /*VK CCW*/;
+    if (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, POLY_MODE) == 0u) {
+        ps.polygon_mode = 0u;   // FILL
+    } else {
+        switch (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, POLYMODE_FRONT_PTYPE)) {
+            case 0u:  ps.polygon_mode = 2u; break;   // points -> VK_POLYGON_MODE_POINT
+            case 1u:  ps.polygon_mode = 1u; break;   // lines  -> VK_POLYGON_MODE_LINE
+            default:  ps.polygon_mode = 0u; break;   // triangles / other -> FILL
         }
     }
 

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -70,6 +70,10 @@ struct RenderState {
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)
+    // Rasterizer cull/front-face/polygon mode (PA_SU_SC_MODE_CNTL). An ABSENT register reads 0, which
+    // decodes to CULL_NONE + CCW-front + FILL — exactly the prior hardcoded default, so nothing changes
+    // for a guest that never programs it. Decoded in resolve to Vk enums (#456).
+    uint32_t pa_su_sc_mode_cntl = 0;
 
     // Viewport 0 transform (PA_CL_VPORT_{X,Y,Z}{SCALE,OFFSET} — IEEE-754 floats stored in the context
     // registers; 0 when the guest never set them). Hardware applies screen = offset + scale * ndc, with
@@ -140,6 +144,16 @@ struct ResolvedPipelineState {
     bool  has_viewport = false;
     float viewport_x = 0, viewport_y = 0, viewport_w = 0, viewport_h = 0;
     float min_depth = 0.0f, max_depth = 1.0f;
+
+    // Rasterizer state resolved from PA_SU_SC_MODE_CNTL (#456). Values == the Vulkan enumerators, so the
+    // backend drops them straight in. Defaults reproduce the prior hardcode (no cull, CCW front, fill),
+    // so a draw that never programs the register — and every test building a ResolvedPipelineState
+    // directly — is byte-identical. cull_mode == VkCullModeFlags (0=NONE,1=FRONT,2=BACK,3=FRONT_AND_BACK);
+    // front_face == VkFrontFace (0=CW,1=CCW); polygon_mode == VkPolygonMode (0=FILL,1=LINE,2=POINT).
+    uint32_t cull_mode    = 0;   // VK_CULL_MODE_NONE
+    uint32_t front_face   = 1;   // VK_FRONT_FACE_COUNTER_CLOCKWISE (guest FACE=0 default; matches the
+                                 // negative-height flipped viewport that already renders correct-facing geometry)
+    uint32_t polygon_mode = 0;   // VK_POLYGON_MODE_FILL
 };
 
 // Translate a RenderState's RDNA2 register semantics into Vulkan-ready pipeline state (pure).

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -344,6 +344,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         vpst.viewportCount = 1; vpst.pViewports = &vp; vpst.scissorCount = 1; vpst.pScissors = &sc;
         VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
         rs.polygonMode = VK_POLYGON_MODE_FILL; rs.cullMode = VK_CULL_MODE_NONE; rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE; rs.lineWidth = 1.0f;
+        // Honor the guest's PA_SU_SC_MODE_CNTL cull/front-face/polygon mode (#456). Resolve encodes these
+        // as the Vk enumerators; an absent register resolves to the same NONE/CCW/FILL default above, so
+        // the null-ps (test) path and any draw that never programs it are byte-identical. PROSPER_NO_CULL
+        // forces CULL_NONE back on (diag escape hatch, matching PROSPER_NO_DEPTH/NO_STENCIL/NO_BLEND) —
+        // if honoring the guest cull ever culls the wrong faces on a live render (a winding/Y-flip edge),
+        // this isolates it without a rebuild.
+        if (ps) { rs.cullMode  = getenv("PROSPER_NO_CULL") ? VK_CULL_MODE_NONE : (VkCullModeFlags)ps->cull_mode;
+                  rs.frontFace = (VkFrontFace)ps->front_face;
+                  rs.polygonMode = (VkPolygonMode)ps->polygon_mode; }
         VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
         ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
         VkPipelineColorBlendAttachmentState cba{}; cba.colorWriteMask = 0xF;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -135,6 +135,24 @@ int main() {
               "programmed DB_DEPTH_CLEAR / DB_STENCIL_CLEAR used verbatim");
     }
 
+    // #456: PA_SU_SC_MODE_CNTL -> cull/front-face/polygon-mode. Absent (the sample stream) -> the prior
+    // hardcode: CULL_NONE(0) / CCW-front(1) / FILL(0). Programmed fields resolve to the Vk enumerators.
+    CHECK(rs.pa_su_sc_mode_cntl == 0u, "no PA_SU_SC_MODE_CNTL in the sample stream");
+    {
+        ResolvedPipelineState pd = resolve_pipeline_state(rs);
+        CHECK(pd.cull_mode == 0u && pd.front_face == 1u && pd.polygon_mode == 0u,
+              "absent PA_SU_SC_MODE_CNTL -> CULL_NONE + CCW + FILL (prior default preserved)");
+        RenderState r2 = rs;
+        r2.pa_su_sc_mode_cntl = (1u << 1);   // CULL_BACK
+        CHECK(resolve_pipeline_state(r2).cull_mode == 2u, "CULL_BACK -> VkCullMode BACK(2)");
+        r2.pa_su_sc_mode_cntl = (1u << 0) | (1u << 1);   // CULL_FRONT | CULL_BACK
+        CHECK(resolve_pipeline_state(r2).cull_mode == 3u, "CULL_FRONT|CULL_BACK -> FRONT_AND_BACK(3)");
+        r2.pa_su_sc_mode_cntl = (1u << 2);   // FACE = 1 (CW is front)
+        CHECK(resolve_pipeline_state(r2).front_face == 0u, "FACE=1 -> VkFrontFace CLOCKWISE(0)");
+        r2.pa_su_sc_mode_cntl = (1u << 3) | (1u << 5);   // POLY_MODE enabled + FRONT_PTYPE=1 (lines)
+        CHECK(resolve_pipeline_state(r2).polygon_mode == 1u, "POLY_MODE lines -> VK_POLYGON_MODE_LINE(1)");
+    }
+
     // Decoded blend state + RDNA2->Vulkan factor/op mapping.
     CHECK(rs.blend_enable, "blend_enable = true (bit 30)");
     CHECK(rs.color_src_blend == 4u && vk_blend_factor(rs.color_src_blend) == 6u,


### PR DESCRIPTION
## Problem
The rasterizer state was hardcoded `CULL_NONE / CCW / FILL` and never reflected the guest's `PA_SU_SC_MODE_CNTL` — `RenderState`/`ResolvedPipelineState` carried no cull/front-face/polygon fields, so back-face culling was effectively always off and winding forced CCW. A back-face-culled + blended draw (two-sided particle/foliage/decal, single-sided additive quad) then rasterized **both** facings and blended twice → over-bright/wrong color; interior faces of solid meshes the guest culls drew and z-fought.

## Fix
- `RenderState`: add raw `pa_su_sc_mode_cntl` (absent → 0 → `CULL_NONE/CCW/FILL`, byte-identical to before for any draw that never programs it).
- `ResolvedPipelineState`: add `cull_mode`/`front_face`/`polygon_mode` (== the Vk enumerators); resolve decodes `CULL_FRONT|CULL_BACK` → `VkCullModeFlags`, `FACE` → `VkFrontFace` (0=CCW-front default matches the negative-height flipped viewport that already renders correct-facing geometry), `POLY_MODE + FRONT_PTYPE` → `VkPolygonMode`.
- `render_runner`: apply when `ps` is non-null; `PROSPER_NO_CULL` forces `CULL_NONE` as a diag escape hatch (matching `PROSPER_NO_DEPTH`/`NO_STENCIL`/`NO_BLEND`).

## Verification
`test_render_state` asserts absent → NONE/CCW/FILL and the programmed CULL_BACK / FRONT_AND_BACK / FACE=CW / POLY_MODE=lines mappings. Full ctest 82/82 green (render tests use the default cull path, unchanged). Live-boot visual verification is limited by the current black-frame state; the escape hatch de-risks a winding edge on a real render.

Fixes #456