### PR TITLE
fix(recompiler): v_cvt_pkrtz saturates f16 overflow instead of emitting Inf (#452)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -259,10 +259,22 @@ struct SpirvCompute {
     // Lazily declared 2-float vector type (types are emitted as a block before code, so on-demand is safe).
     uint32_t t_v2f_cache = 0;
     uint32_t t_v2f() { if (!t_v2f_cache) { t_v2f_cache = id(); put(types, Op_TypeVector, {t_v2f_cache, t_f32, 2}); } return t_v2f_cache; }
-    // v_cvt_pkrtz_f16_f32: pack src0->low f16, src1->high f16 of a 32-bit result (raw VGPR bits).
+    // pack two f32 (raw VGPR bits) into a dword of two f16 halves (src0->low, src1->high). Uses SPIR-V
+    // PackHalf2x16, which is round-to-nearest-even — correct for the RTE store path (pack_half_lo).
     uint32_t pack_half2x16(uint32_t a, uint32_t b) {
         uint32_t vec = id(); put(code, Op_CompositeConstruct, {t_v2f(), vec, bcf(a), bcf(b)});
         uint32_t r = id(); putv(code, Op_ExtInst, {t_u32, r, glsl, Glsl_PackHalf2x16, vec}); return r;
+    }
+    // v_cvt_pkrtz_f16_f32 is round-toward-ZERO. PackHalf2x16 is round-to-nearest-even — within range that
+    // differs by <=1 ULP (accepted), but at the f16 OVERFLOW boundary RTE yields +/-Inf where RTZ clamps
+    // to the max finite f16 (+/-65504). Clamp each source to [-65504, 65504] before packing so an HDR
+    // value above the f16 range becomes 65504 (matching RTZ's saturate) instead of an Inf/NaN that then
+    // propagates through blending/compositing (#452). The RTE store path (pack_half_lo) is unaffected.
+    uint32_t pack_half2x16_rtz(uint32_t a, uint32_t b) {
+        const uint32_t hi = bcu(fconstf(65504.0f)), lo = bcu(fconstf(-65504.0f));
+        uint32_t ca = fext2(Glsl_FMax, fext2(Glsl_FMin, a, hi), lo);
+        uint32_t cb = fext2(Glsl_FMax, fext2(Glsl_FMin, b, hi), lo);
+        return pack_half2x16(ca, cb);
     }
     // Vertex-attribute unpacking (buffer_load_format_* with a packed data format). Each returns the
     // component as raw float VGPR bits, matching how the hardware presents a format load to the shader.
@@ -2255,7 +2267,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // madak/fmaak = src0*src1 + K. (mad vs fma differ only in fused rounding — immaterial here.)
                 case 0x20: case 0x2C: d = b.fbin(Op_FAdd, b.fbin(Op_FMul, a, b.uconst(in.literal)), c); break;  // v_madmk / v_fmamk
                 case 0x21: case 0x2D: d = b.fbin(Op_FAdd, b.fbin(Op_FMul, a, c), b.uconst(in.literal)); break;  // v_madak / v_fmaak
-                case 0x2F: d = b.pack_half2x16(a, c); break;          // v_cvt_pkrtz_f16_f32 (e32 form)
+                case 0x2F: d = b.pack_half2x16_rtz(a, c); break;      // v_cvt_pkrtz_f16_f32 (e32 form): RTZ clamp (#452)
                 case 0x35: {   // v_mul_f16: 16-bit float multiply. Sources read their selected halves
                     // (SDWA WORD_1 = high 16; DWORD/WORD_0 = low 16 — an f16 op reads bits[15:0]);
                     // f16xf16 products are exact in f32, so multiply in f32 and round once to f16.
@@ -2590,7 +2602,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (active) vreg[in.dst.value] = b.mbcnt(active, val(in.src[1]), in.opcode == 0x365);
                 else ok = false;
             } else if (in.opcode == 0x12F) {                          // v_cvt_pkrtz_f16_f32 = pack(s0->lo, s1->hi)
-                vreg[in.dst.value] = b.pack_half2x16(fv(0), fv(1));    // float sources honor neg/abs modifiers
+                vreg[in.dst.value] = b.pack_half2x16_rtz(fv(0), fv(1)); // v_cvt_pkrtz VOP3: RTZ clamp (#452)
             } else if (in.opcode == 0x103) {                          // v_add_f32 (VOP3 form)
                 vreg[in.dst.value] = fresult(b.fbin(Op_FAdd, fv(0), fv(1)));
             } else if (in.opcode == 0x104) {                          // v_sub_f32 (VOP3 form) = s0 - s1

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1581,6 +1581,20 @@ int main() {
     }
     CHECK(gotT7b.size()==N && badT7b==0, "T7b: v_bfe_u32(v0,20,16) clamps count to 12 -> (v0>>20), not UB");
 
+    // Kernel T7c (#452): v_cvt_pkrtz_f16_f32 is round-toward-ZERO -> an f32 above the f16 range saturates
+    // to the max finite f16 (65504 = 0x7BFF), NOT +Inf (0x7C00) as PackHalf2x16's round-to-nearest-even
+    // would give. s0 = 100000.0f (0x47c35000, > 65504); v1 = pkrtz(s0, 0) -> low f16 0x7BFF, high 0.
+    const uint32_t codeT7c[] = { 0xbe8003ffu, 0x47c35000u, 0xd52f0001u, 0x00010000u, 0xBF810000u };
+    std::vector<uint32_t> spvT7c = recompile_valu(codeT7c, sizeof(codeT7c)/4, 1, 1);
+    CHECK(!spvT7c.empty(), "recompiled T7c (v_cvt_pkrtz overflow) -> SPIR-V");
+    std::vector<float> gotT7c = prosper::test::run_compute(spvT7c, inX, N, N);
+    uint32_t badT7c = 0;
+    for (uint32_t i = 0; i < N && gotT7c.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotT7c[i], 4);
+        if (gb != 0x00007BFFu) badT7c++;
+    }
+    CHECK(gotT7c.size()==N && badT7c==0, "T7c: pkrtz(100000) saturates to max-finite f16 0x7BFF, not Inf 0x7C00");
+
     // Kernel T8: s_mov_b64 as plain DATA-pair copy (not a wave mask): s2=9; s[0:1]=s[2:3];
     // out bits = bits(a0) + 9. Previously rejected (src not a recognizable mask).
     const uint32_t codeT8[] = { 0xbe820389u, 0xbe800402u, 0x4a020000u, 0xBF810000u };


### PR DESCRIPTION
## Problem
`v_cvt_pkrtz_f16_f32` is round-toward-**zero**, but it was lowered via SPIR-V `PackHalf2x16` (round-to-nearest-even). Within the f16 range that differs by ≤1 ULP (accepted), but at the **overflow** boundary RTE yields ±Inf where RTZ clamps to the max finite f16 (±65504) — so an HDR value above the f16 range became `+Inf` and propagated NaN/Inf through blending/compositing.

## Fix
The builder has no Float16 capability wired (true `OpFConvert`-RTZ would need the `shaderFloat16` device feature, unsupported on llvmpipe), so fix the failure that actually bites: clamp each source to `[-65504, 65504]` before packing, applied **only** at the two `v_cvt_pkrtz` sites via a new `pack_half2x16_rtz` helper — the RTE store path (`pack_half_lo`, which mirrors `v_cvt_f16`'s RTE) is untouched. This reproduces RTZ's saturate exactly at overflow; the residual ≤1 ULP in-range rounding difference is within tolerance (and the issue's stated scope).

## Verification
`test_rdna2_to_spirv` T7c: `pkrtz(100000.0)` → `0x7BFF` (65504), not `0x7C00` (Inf). Full ctest 82/82 green.

Fixes #452