### PR TITLE
fix(hle/audio): sceAudioOutOutputs returns one grain, not the sum over ports

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -162,15 +162,18 @@ HLE(audio_outputs) {
     const auto* arr = (const OutParam*)P(a0);
     int num = (int)a1;
     if (!arr || num <= 0) return 0;
-    uint64_t total = 0;
+    // sceAudioOutOutputs writes the SAME time-slice to N ports in parallel; the return is samples-per-
+    // channel of that slice (one grain), NOT the additive sum over ports. Returning the sum made a guest
+    // using the count as a sample-clock over-count by N x (Kyty/shadPS4 both return a single port's grain).
+    uint64_t grain = 0; bool have = false;
     for (int i = 0; i < num; i++) {
         AudioPortInfo info; bool ok;
         { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of(arr[i].handle); ok = (p != nullptr); if (ok) info = p->info; }
         if (!ok) continue;
         if (arr[i].ptr) { if (auto* s = audio_sink()) s->output(arr[i].handle, P(arr[i].ptr), info.grain); }
-        total += info.grain;
+        if (!have) { grain = info.grain; have = true; }
     }
-    return total;
+    return grain;
 }
 
 // sceAudioOutSetVolume(handle, flag(channel mask), int vol[]) -> 0 or negative error.

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -153,8 +153,9 @@ int main() {
     batch[1] = { 999,          0, PTR(pb.data()) };        // invalid handle -> skipped
     batch[2] = { (int32_t)hb, 0, PTR(pb.data()) };
     int64_t tot = call("sceAudioOutOutputs", PTR(batch), 3);
-    CHECK(tot == 128 + 128);                              // two valid entries
-    CHECK(sink.outs.size() == 2);
+    CHECK(tot == 128);                                    // ONE grain (the shared slice), not the sum over
+                                                          // ports (Kyty/shadPS4 both return a single grain)
+    CHECK(sink.outs.size() == 2);                         // ...but both valid entries are still forwarded
 
     // --- restore the default sink so we don't dangle a stack pointer -------------------------
     audio_reset();


### PR DESCRIPTION
Outputs writes the same slice to N ports in parallel; the return is one grain (samples-per-channel), not the additive sum. We summed, so a sample-clock caller over-counted by Nx for >1 port. Return the first valid port's grain (Kyty/shadPS4 agree). Refs #396.