### PR TITLE
fix(gpu): in-SGPR cbufs set only sgpr_base, not srt_offset (no by_srt_offset false-match) (#453)

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -213,8 +213,16 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.gpu_addr       = d.base;
             r.size           = d.size_bytes;
             r.stride         = d.stride;
-            r.srt_offset     = srt;                     // byte offset within user_data / EUD (indirect path)
-            r.sgpr_base      = user_sgpr_base + off;    // the shader SGPR holding this V# (s_buffer_load SBASE)
+            // Provenance, mirroring the #382 texture fix (#453). An IN-SGPR cbuf resolves DIRECTLY —
+            // the recompiler matches its s_buffer_load SBASE to sgpr_base (by_sgpr_base_cls); its V# is
+            // never s_loaded, so SBASE carries no sreg_srt tag and by_srt_offset is never consulted for
+            // it. Setting BOTH keys made the in-SGPR key (off*4) collide with an EUD cbuf at the same
+            // spill offset (eoff*4) under by_srt_offset (first-match-wins) -> wrong uniform block bound.
+            // So set ONLY the applicable key: EUD -> srt_offset (INDIRECT, == the s_load immediate),
+            // in-SGPR -> sgpr_base (DIRECT); null the other so a stray lookup can't false-match.
+            const bool cbuf_in_eud = (uint64_t)off + 4 > num_user_sgprs;
+            r.srt_offset = cbuf_in_eud ? srt : 0xFFFFFFFFu;
+            r.sgpr_base  = cbuf_in_eud ? 0xFFFFFFFFu : (user_sgpr_base + off);
             table.resources.push_back(r);
         }
     }

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -122,14 +122,18 @@ int main() {
     ShaderResourceTable t = build_shader_resources(shdr, sgprs, 32);
     CHECK(t.resources.size() == 2, "built 2 constant-buffer resources");
 
-    const ShaderResource* r0 = t.by_srt_offset(4 * 4);   // provenance key = offset_dw*4 bytes
-    const ShaderResource* r1 = t.by_srt_offset(12 * 4);
-    CHECK(r0 && r0->cls == ResourceClass::ConstantBuffer, "cbuf0 resolvable by srt_offset");
+    // In-SGPR cbufs resolve by DIRECT provenance (the s_buffer_load SBASE SGPR), NOT by srt_offset:
+    // their V# is never s_loaded, so the recompiler matches sgpr_base via by_sgpr_base_cls (#453).
+    const ShaderResource* r0 = t.by_sgpr_base(4);    // cbuf0 V# at user-SGPR dword 4 (user_sgpr_base 0)
+    const ShaderResource* r1 = t.by_sgpr_base(12);   // cbuf1 V# at dword 12
+    CHECK(r0 && r0->cls == ResourceClass::ConstantBuffer, "cbuf0 resolvable by sgpr_base (in-SGPR = DIRECT)");
     CHECK(r0 && r0->gpu_addr == 0xA0000000ull && r0->size == 256, "cbuf0 base+size decoded");
     CHECK(r1 && r1->gpu_addr == 0xB0000000ull && r1->size == 1024, "cbuf1 base+size decoded");
     CHECK(r0 && r1 && r0->binding != r1->binding, "distinct bindings assigned");
     CHECK(t.by_binding(r0 ? r0->binding : 999) == r0, "resolvable by binding");
-    CHECK(t.by_srt_offset(0x999) == nullptr, "unknown srt_offset -> null");
+    CHECK(r0 && r0->srt_offset == 0xFFFFFFFFu,
+          "#453: in-SGPR cbuf leaves srt_offset UNSET (can't false-match an EUD cbuf at the same spill offset)");
+    CHECK(t.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
 
     // An empty slot (0x7fff) is skipped.
     cbuf_sharps[1].bits = 0x7fff;
@@ -177,7 +181,7 @@ int main() {
     CHECK(vb && vb->format == DataFormat::Float32 && vb->num_components == 3, "vbuf format Float32 x3");
     CHECK(vb && vb->gpu_addr == 0xC0000000ull && vb->stride == 12 && vb->size == 90 * 12, "vbuf base/stride/size");
     CHECK(vb && vb->srt_offset == 0xFFFFFFFFu, "DIRECT vbuf leaves srt_offset unset");
-    CHECK(t3.by_srt_offset(4 * 4) != nullptr, "constant buffers still present alongside vertex buffers");
+    CHECK(t3.by_sgpr_base(4) != nullptr, "constant buffers still present alongside vertex buffers");
     CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
 
     // --- textures: sharp[0] T#s carry their real format + byte size; BC1/2/3 are bound (decoded to RGBA8


### PR DESCRIPTION
## Problem
The cbuf loop set **both** `r.srt_offset` (= `load_sharp`'s `off*4` for an in-SGPR cbuf) and `r.sgpr_base` unconditionally. An EUD-resident cbuf whose spill begins at the SGPR-block boundary gets `srt_offset = eoff*4 = 0,4,8,…`, colliding with an in-SGPR cbuf at `off = 0,1,2,…`; `by_srt_offset` (first-match-wins) then returns the **wrong** buffer, binding the wrong uniform block. Asymmetric with the #382 texture fix, which already nulls the non-applicable provenance key.

## Why nulling the in-SGPR `srt_offset` is safe (the analysis that gated this)
The recompiler resolves an `s_buffer_load`'s SBASE via `by_srt_offset(sreg_srt[SBASE])` **only when SBASE was tagged by an s_load** (the EUD/indirect case), else falls through to `by_sgpr_base_cls` (`rdna2_to_spirv.cpp:2740-2744`). An in-SGPR cbuf's V# is never s_loaded, so SBASE carries no `sreg_srt` tag and `by_srt_offset` is never consulted for it — its `srt_offset` field is unused by the real path.

## Fix
Mirror #382: EUD cbuf → `srt_offset` only (INDIRECT), in-SGPR cbuf → `sgpr_base` only (DIRECT); null the other.

## Verification
Updated `test_build_shader_resources` to resolve the in-SGPR cbufs by `by_sgpr_base` (the real provenance) and to assert their `srt_offset` is unset (collision impossible). Full ctest 82/82 green — cbuf resolution is unchanged (the #257 EUD-cbuf text path keeps its `srt_offset` key).

Fixes #453