### PR TITLE
fix(hle/mem): implement sceKernelReleaseFlexibleMemory (was fake-success -> VA leak)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1047,6 +1047,11 @@ void register_kernel_mem_hle() {
     R("sceKernelMapDirectMemory", k_map_dmem);
     R("sceKernelMapNamedDirectMemory", k_map_dmem);
     R("sceKernelMunmap", k_munmap);
+    // sceKernelReleaseFlexibleMemory(addr, len): same shape as munmap (unmap + untrack the flexible range).
+    // Was MISSING -> the stub returned success without releasing, so the range stayed mapped and its
+    // tracking entry lingered -> VirtualQuery / the fault-handler probe report a freed VA as live, and host
+    // VA leaks on churn. Reuse k_munmap (identical (addr, len) contract).
+    R("sceKernelReleaseFlexibleMemory", k_munmap);
     R("sceKernelMprotect", k_mprotect);
     R("sceKernelReleaseDirectMemory", k_release_dmem);
     R("sceKernelCheckedReleaseDirectMemory", k_release_dmem);


### PR DESCRIPTION
Was MISSING -> stub returned success without releasing, so the flexible range stayed mapped + its tracking entry lingered (VirtualQuery/fault-probe report a freed VA as live; host VA leaks on churn). Same (addr,len) contract as munmap -> register to k_munmap. Refs #387.