### PR TITLE
fix(gpu): stencil ONES op writes 0xFF; pick the REPLACE reference per op (#466)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -194,6 +194,24 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         ps.stencil_op_val[1]        = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILOPVAL_BF);
         ps.stencil_compare_mask[1]  = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILMASK_BF);
         ps.stencil_write_mask[1]    = PM4_FIELD(rmb, DB_STENCILREFMASK_BF, STENCILWRITEMASK_BF);
+        // #466: ONES(2)/REPLACE_TEST(3)/REPLACE_OP(4) all resolve to VK REPLACE but write DIFFERENT
+        // values — ONES writes the constant 0xFF, REPLACE_TEST writes STENCILTESTVAL, REPLACE_OP writes
+        // STENCILOPVAL. The backend feeds stencil_op_val as the Vk REPLACE `reference` (does_replace path),
+        // so set it to what the face's replace op actually writes. Vulkan has ONE reference per face, so a
+        // face mixing replace variants can't be fully represented — precedence ONES > REPLACE_TEST (the
+        // common case is a single replace op per face, e.g. an ALWAYS-compare stencil-prime that writes
+        // 0xFF). Runs BEFORE the #377 back-face mirror so a mirrored back inherits the corrected value.
+        const uint32_t raw_ops[2][3] = {
+            { PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILFAIL),    PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZPASS),    PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZFAIL) },
+            { PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILFAIL_BF), PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZPASS_BF), PM4_FIELD(sc, DB_STENCIL_CONTROL, STENCILZFAIL_BF) },
+        };
+        for (int fb = 0; fb < 2; fb++) {
+            bool ones = false, rtest = false;
+            for (int k = 0; k < 3; k++) { uint32_t o = raw_ops[fb][k] & 0xFu; if (o == 2u) ones = true; else if (o == 3u) rtest = true; }
+            if (ones)       ps.stencil_op_val[fb] = 0xFFu;                // ONES writes the constant 0xFF
+            else if (rtest) ps.stencil_op_val[fb] = ps.stencil_ref[fb];  // REPLACE_TEST writes STENCILTESTVAL
+            // else REPLACE_OP (or no replace): keep STENCILOPVAL, already set.
+        }
         // DB_DEPTH_CONTROL.BACKFACE_ENABLE == 0 means the FRONT state applies to BOTH faces (the _BF
         // registers are ignored). Sourcing back from _BF regardless left back faces with the
         // unprogrammed _BF defaults — STENCILFUNC_BF=0 -> VK_COMPARE_OP_NEVER, dropping every back

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -153,6 +153,29 @@ int main() {
         CHECK(resolve_pipeline_state(r2).polygon_mode == 1u, "POLY_MODE lines -> VK_POLYGON_MODE_LINE(1)");
     }
 
+    // #466: the three "replace-ish" stencil ops (ONES=2, REPLACE_TEST=3, REPLACE_OP=4) all resolve to
+    // VK REPLACE but write DIFFERENT values via the backend's stencil_op_val reference. Build a stencil
+    // state (ALWAYS compare, one pass op) and check the resolved op-val picks the right source.
+    {
+        RenderState s{};
+        s.stencil_enable = true;
+        s.db_depth_control = (1u << 0) | (7u << 8);   // STENCIL_ENABLE | STENCILFUNC=ALWAYS(7), BACKFACE_ENABLE=0
+        s.db_stencilrefmask = (0x33u << 24) | 0x22u;  // STENCILOPVAL=0x33, STENCILTESTVAL=0x22
+        s.db_stencil_control = (2u << 4);             // STENCILZPASS = ONES(2)
+        CHECK(resolve_pipeline_state(s).stencil_op_val[0] == 0xFFu,
+              "#466: ONES stencil op writes the constant 0xFF (not STENCILOPVAL)");
+        s.db_stencil_control = (3u << 4);             // STENCILZPASS = REPLACE_TEST(3)
+        CHECK(resolve_pipeline_state(s).stencil_op_val[0] == 0x22u,
+              "#466: REPLACE_TEST writes STENCILTESTVAL (0x22)");
+        s.db_stencil_control = (4u << 4);             // STENCILZPASS = REPLACE_OP(4)
+        CHECK(resolve_pipeline_state(s).stencil_op_val[0] == 0x33u,
+              "#466: REPLACE_OP writes STENCILOPVAL (0x33), unchanged");
+        // Back face mirrors front (BACKFACE_ENABLE=0) — ONES 0xFF propagates to the back op-val too.
+        s.db_stencil_control = (2u << 4);
+        CHECK(resolve_pipeline_state(s).stencil_op_val[1] == 0xFFu,
+              "#466: mirrored back face inherits the ONES 0xFF write value");
+    }
+
     // Decoded blend state + RDNA2->Vulkan factor/op mapping.
     CHECK(rs.blend_enable, "blend_enable = true (bit 30)");
     CHECK(rs.color_src_blend == 4u && vk_blend_factor(rs.color_src_blend) == 6u,


### PR DESCRIPTION
## Problem
RDNA2's three replace-ish stencil ops all collapse to `VK_STENCIL_OP_REPLACE` in `vk_stencil_op` but write **different** values: `ONES(2)` writes the constant `0xFF`, `REPLACE_TEST(3)` writes `STENCILTESTVAL`, `REPLACE_OP(4)` writes `STENCILOPVAL`. Resolve left `stencil_op_val = STENCILOPVAL` for all of them, and the backend feeds `stencil_op_val` as the Vk REPLACE reference — so an `ONES` stencil-prime pass (mark a region `0xFF`, test `== 0xFF` later) wrote `STENCILOPVAL` (often 0) instead of `0xFF`, and the later masked draw's test never matched → the masked geometry vanished.

## Fix
In resolve, set `stencil_op_val` to what the face's replace op actually writes: `ONES → 0xFF`, `REPLACE_TEST → STENCILTESTVAL`, `REPLACE_OP → STENCILOPVAL` (precedence ONES > REPLACE_TEST; Vulkan has one reference per face, so a face mixing replace variants is inherently unrepresentable — the common single-op prime pattern is now correct). Matches Kyty's per-op reference selection. Runs before the #377 back-face mirror so a mirrored back inherits the value.

## Verification
`test_render_state` asserts `ONES→0xFF`, `REPLACE_TEST→STENCILTESTVAL`, `REPLACE_OP→STENCILOPVAL`, and the mirrored-back inheritance. Full ctest 82/82 green.

Fixes #466