### PR TITLE
fix(gpu): map aliased CB packed formats COLOR_10_11_11(0x6)/COLOR_10_10_10_2(0x8) (#465)

### DIFF
--- a/prosper/src/gpu/vk_translate.cpp
+++ b/prosper/src/gpu/vk_translate.cpp
@@ -79,9 +79,13 @@ VkFormat vk_color_format(uint32_t format, uint32_t number_type, uint32_t comp_sw
                           case 4: return VkFormat::R16G16_UINT;  case 5: return VkFormat::R16G16_SINT;
                           case 7: return VkFormat::R16G16_SFLOAT; }
             break;
-        case 0x7u:   // COLOR_11_11_10 (float-only packed HDR target)
+        case 0x6u:   // COLOR_10_11_11 — the ALIAS of COLOR_11_11_10 (0x7). shadPS4 canonicalizes 0x7->0x6
+        case 0x7u:   // COLOR_11_11_10 (float-only packed HDR target). Both codes resolve to R11G11B10F;
+                     // only 0x7 was handled, so a guest HDR/bloom target programming FORMAT=6 (the
+                     // canonical code) fell through to Undefined and its whole pass was dropped (#465).
             if (std_swap && nt == 7u) return VkFormat::B10G11R11_UFLOAT_PACK32;
             break;
+        case 0x8u:   // COLOR_10_10_10_2 — the ALIAS of COLOR_2_10_10_10 (0x9). shadPS4 canonicalizes 0x8->0x9.
         case 0x9u:   // COLOR_2_10_10_10
             if (nt == 0u) return std_swap ? VkFormat::A2B10G10R10_UNORM_PACK32
                         : alt_swap        ? VkFormat::A2R10G10B10_UNORM_PACK32 : VkFormat::Undefined;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -93,6 +93,11 @@ int main() {
     CHECK(vk_color_format(0x9u, 0u, 0u) == VkFormat::A2B10G10R10_UNORM_PACK32, "0x9/UNORM/STD -> A2B10G10R10 (64)");
     CHECK(vk_color_format(0x9u, 0u, 1u) == VkFormat::A2R10G10B10_UNORM_PACK32, "0x9/UNORM/ALT -> A2R10G10B10 (58)");
     CHECK(vk_color_format(0x7u, 7u, 0u) == VkFormat::B10G11R11_UFLOAT_PACK32,  "0x7/FLOAT -> B10G11R11 (122)");
+    // #465: the aliased packed codes 0x6 (COLOR_10_11_11) and 0x8 (COLOR_10_10_10_2) resolve to the same
+    // formats as 0x7 / 0x9 (shadPS4 canonicalizes 0x7->0x6, 0x8->0x9). Previously they fell to Undefined.
+    CHECK(vk_color_format(0x6u, 7u, 0u) == VkFormat::B10G11R11_UFLOAT_PACK32, "0x6 (alias of 0x7)/FLOAT -> B10G11R11");
+    CHECK(vk_color_format(0x8u, 0u, 0u) == VkFormat::A2B10G10R10_UNORM_PACK32, "0x8 (alias of 0x9)/UNORM/STD -> A2B10G10R10");
+    CHECK(vk_color_format(0x8u, 0u, 1u) == VkFormat::A2R10G10B10_UNORM_PACK32, "0x8 (alias of 0x9)/UNORM/ALT -> A2R10G10B10");
     CHECK(vk_color_format(0x10u, 0u, 0u) == VkFormat::R5G6B5_UNORM_PACK16, "0x10/UNORM -> R5G6B5 (4)");
     CHECK(vk_color_format(0x1u, 0u, 0u) == VkFormat::R8_UNORM,   "0x1/UNORM -> R8_UNORM (9, Kyty's R8Unorm row)");
     CHECK(vk_color_format(0x4u, 7u, 0u) == VkFormat::R32_SFLOAT, "0x4/FLOAT -> R32_SFLOAT (100)");


### PR DESCRIPTION
## Problem
`vk_color_format` handled only `COLOR_11_11_10` (0x7) and `COLOR_2_10_10_10` (0x9); their aliases `COLOR_10_11_11` (0x6) and `COLOR_10_10_10_2` (0x8) fell through to `VK_FORMAT_UNDEFINED`, so a guest HDR/bloom target that programs `FORMAT=6` (the canonical R11G11B10-float code) or `FORMAT=8` resolved to Undefined and its whole pass was dropped.

## Verification of the alias (why this isn't a guessed format mapping)
Confirmed against **shadPS4** (`video_core/amdgpu/pixel_format.h:199-202`): it canonicalizes `Format11_11_10(7) → Format10_11_11(6)` and `Format10_10_10_2(8) → Format2_10_10_10(9)` — i.e. `0x6 ≡ 0x7` (R11G11B10F) and `0x8 ≡ 0x9` (2_10_10_10).

## Fix
Add `0x6`/`0x8` as fall-through aliases of the existing `0x7`/`0x9` rows.

## Verification
`test_render_state` asserts `0x6/FLOAT → B10G11R11` and `0x8/UNORM → A2B10G10R10` (STD) / `A2R10G10B10` (ALT). Full ctest 82/82 green.

Fixes #465