### PR TITLE
feat(input): frame-anchored PROSPER_PAD_SCRIPT (f<N>: = flip N) — deterministic state-reach (#302)

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -84,6 +84,18 @@ double pad_hold_secs() {
 // t0 (us) of the first poll; 0 until set. steady_clock so it matches now_us().
 std::atomic<uint64_t> g_pad_t0_us{0};
 
+// Frame anchor: the flip count at the first poll, so `f<N>:` entries measure flips-since-first-poll.
+// prosper_vo_flip_count() is the guest's presented-frame counter (hle_graphics.cpp), boot-speed-
+// invariant — unlike wall-clock it lands the same input on the same game state across builds (#302).
+extern "C" uint64_t prosper_vo_flip_count();
+std::atomic<uint64_t> g_pad_flip0{0};
+std::atomic<bool>     g_pad_flip0_set{false};
+
+int64_t pad_frame_hold() {   // how many flips to hold a frame-anchored press (default 8)
+    static const int64_t h = [] { const char* e = getenv("PROSPER_PAD_FRAME_HOLD"); return e ? (int64_t)atoll(e) : 8; }();
+    return h;
+}
+
 // Overlay any active scripted press onto `s`. Returns true if a script is driving the pad.
 bool apply_pad_script(HostPadState& s) {
     const auto& script = pad_script();
@@ -95,7 +107,11 @@ bool apply_pad_script(HostPadState& s) {
         if (g_pad_t0_us.compare_exchange_strong(expect, now)) t0 = now; else t0 = expect;
     }
     double elapsed = (now_us() - t0) / 1e6;
-    s.buttons |= pad_script_buttons_at(script, elapsed, pad_hold_secs());
+    // Frame count = flips since the first poll (anchor the flip baseline on that same first poll).
+    uint64_t flips = prosper_vo_flip_count();
+    if (!g_pad_flip0_set.exchange(true)) g_pad_flip0.store(flips, std::memory_order_relaxed);
+    int64_t frame = (int64_t)(flips - g_pad_flip0.load(std::memory_order_relaxed));
+    s.buttons |= pad_script_buttons_at(script, elapsed, pad_hold_secs(), frame, pad_frame_hold());
     return true;
 }
 

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -128,7 +128,10 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
         i = (semi == std::string::npos) ? spec.size() : semi + 1;
         size_t colon = tok.find(':');
         if (colon == std::string::npos) continue;
-        double t = atof(tok.substr(0, colon).c_str());
+        std::string head = tok.substr(0, colon);
+        // A leading 'f' marks a FRAME-anchored entry ("f300:cross" -> flip 300); else it's seconds.
+        bool frame_anchored = (!head.empty() && (head[0] == 'f' || head[0] == 'F'));
+        double t = atof(frame_anchored ? head.c_str() + 1 : head.c_str());
         std::string btns = tok.substr(colon + 1);
         uint32_t mask = 0;
         size_t j = 0;
@@ -138,15 +141,22 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
             j = (plus == std::string::npos) ? btns.size() : plus + 1;
             mask |= pad_button_by_name(one);
         }
-        if (mask) v.push_back({t, mask});
+        if (mask) v.push_back({t, mask, frame_anchored});
     }
     return v;
 }
 
-uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs) {
+uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs,
+                               int64_t frame_count, int64_t frame_hold) {
     uint32_t mask = 0;
-    for (const auto& e : script)
-        if (elapsed_secs >= e.t_secs && elapsed_secs < e.t_secs + hold_secs) mask |= e.button_mask;
+    for (const auto& e : script) {
+        if (e.frame_anchored) {
+            int64_t f = (int64_t)e.t_secs;   // frame number lives in t_secs for frame-anchored entries
+            if (frame_count >= 0 && frame_count >= f && frame_count < f + frame_hold) mask |= e.button_mask;
+        } else {
+            if (elapsed_secs >= e.t_secs && elapsed_secs < e.t_secs + hold_secs) mask |= e.button_mask;
+        }
+    }
     return mask;
 }
 

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -140,18 +140,26 @@ uint32_t pad_trigger_buttons(uint8_t l2, uint8_t r2);
 // A timed button sequence lets a headless run drive menus with no host device (issue #163). These
 // three helpers are pure (no env, no clock) so the parse + time-eval logic is verifiable; the HLE
 // (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first input poll.
-struct PadScriptEntry { double t_secs; uint32_t button_mask; };
+// t_secs holds a wall-clock time (default) OR, when frame_anchored, a FRAME NUMBER (flips since the
+// first poll). Frame-anchoring is boot-speed-invariant: `f300:cross` fires at the same game state on a
+// fast GPU and slow llvmpipe, where a wall-clock `10:cross` would drift — essential for deterministic
+// menu-reach across builds (bisect/regression repro). See #302.
+struct PadScriptEntry { double t_secs; uint32_t button_mask; bool frame_anchored = false; };
 
 // Map a button name ("start"/"options"/"cross"/"x"/"up"/... case as written) to its SCE_PAD_BUTTON_*
 // bit; 0 if unknown. "start" and "options" both mean the PS5 Options button (the "Start" equivalent).
 uint32_t pad_button_by_name(const std::string& name);
 
-// Parse "<secs>:<btn>[+<btn>...][;<secs>:<btn>...]" into entries (e.g. "3:start;9:cross+up"). Entries
+// Parse "<secs>:<btn>[+<btn>...][;...]" into entries (e.g. "3:start;9:cross+up"). An entry whose time
+// token starts with 'f' is FRAME-anchored: "f300:cross" fires at flip 300 since the first poll. Entries
 // with no recognized button are dropped. Whitespace-tolerant only where the spec has none by design.
 std::vector<PadScriptEntry> parse_pad_script(const std::string& spec);
 
-// Buttons held at `elapsed_secs`: OR of every entry whose window [t, t+hold_secs) contains the time.
-uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs);
+// Buttons held now: OR of every entry whose window contains the current time. A seconds-anchored entry
+// matches [t, t+hold_secs) against `elapsed_secs`; a frame-anchored entry matches [f, f+frame_hold)
+// against `frame_count` (pass -1 when no frame count is available -> frame entries never fire).
+uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs,
+                               int64_t frame_count = -1, int64_t frame_hold = 8);
 
 // ---- Pluggable host backend (mirrors AudioSink / audio_set_sink) -------------------------------
 //

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -154,6 +154,25 @@ int main() {
         CHECK(pad_script_buttons_at(s, 3.30, hold) == 0,                      "eval: at window end (exclusive) -> released");
         CHECK(pad_script_buttons_at(s, 16.1, hold) == (SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS), "eval: combined press");
         CHECK(parse_pad_script("").empty(), "parse: empty spec -> no entries");
+
+        // Frame-anchored entries (#302): "f<N>:" fires at flip N, not wall-clock second N.
+        auto fs = parse_pad_script("f300:cross;5:start");
+        CHECK(fs.size() == 2, "frame: 2 entries");
+        CHECK(fs[0].frame_anchored && fs[0].t_secs == 300.0 && fs[0].button_mask == SCE_PAD_BUTTON_CROSS,
+              "frame: 'f300:cross' parses frame-anchored at 300");
+        CHECK(!fs[1].frame_anchored && fs[1].t_secs == 5.0, "frame: '5:start' stays seconds-anchored");
+        // Frame entry ignores wall-clock, fires in [f, f+frame_hold); seconds entry ignores frame_count.
+        const int64_t fhold = 8;
+        CHECK(pad_script_buttons_at(fs, /*secs*/999.0, hold, /*frame*/299, fhold) == 0,
+              "frame: before flip window (even far in wall-time) -> none");
+        CHECK(pad_script_buttons_at(fs, 999.0, hold, 300, fhold) == SCE_PAD_BUTTON_CROSS,
+              "frame: at flip 300 -> pressed");
+        CHECK(pad_script_buttons_at(fs, 999.0, hold, 307, fhold) == SCE_PAD_BUTTON_CROSS,
+              "frame: within [300,308) -> pressed");
+        CHECK(pad_script_buttons_at(fs, 999.0, hold, 308, fhold) == 0,
+              "frame: at window end (exclusive) -> released");
+        CHECK(pad_script_buttons_at(fs, 5.1, hold, /*no frame info*/-1, fhold) == SCE_PAD_BUTTON_OPTIONS,
+              "frame: seconds entry still fires with frame_count=-1; frame entry does not");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Why
`PROSPER_PAD_SCRIPT` is **wall-clock-anchored**, so the same `"10:cross"` lands on a different game state depending on boot speed (fast GPU vs slow llvmpipe, and across builds). That non-determinism makes any "reach a game state" workflow flaky — I hit it hard trying to bisect the menu-black regression (#508): the menu-reach flaked, and two bisects gave false positives.

## What
Add a **frame-anchored** entry syntax to the pad script: a time token starting with `f` (`"f300:cross"`) fires at **flip 300 since the first pad poll**, using the guest's presented-frame counter (`prosper_vo_flip_count`). Flip count is boot-speed-invariant, so the same script reaches the same state on every build.

- Seconds-anchored entries unchanged (**back-compat**): `"3:start"` still works, mixable with `f` entries.
- `PROSPER_PAD_FRAME_HOLD` sets the per-press flip window (default 8).
- Parse + eval stay **pure and unit-tested** (`test_pad` frame cases added).

This implements the core determinism piece of **#302** (frame-anchored checkpoints).

## Verification
- **82/82 ctest green**, `boot_reaches_first_syscall` green (touches the pad poll path).
- New unit tests: `f300:cross` parses frame-anchored; fires in `[300, 308)` against the flip count and ignores wall-clock; seconds entries still fire with no frame info.

Refs #302, #508 (the regression this unblocks reliable bisection of).