### PR TITLE
diag+fix(#312): capture the MallocBinned3 corruptor — prosper's GPU value-1 fence write forges a freelist pointer (HOST)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -306,6 +306,42 @@ static void poolshift_check(const char* kind, uint64_t dst, uint64_t bytes, uint
         }
     }
 }
+// #312 (session-10 capture): the ROOT corruptor forges a freelist next-pointer. A per-thread MB3
+// pool cache head was caught being written 0x20015f00 by the guest allocator's own freelist POP
+// (eboot+0x2316ad2) — propagating an already-corrupt chain whose old head was 0x1000000001. That
+// 0x1000000001 = 0x1000000000 | 1, i.e. a live freelist next-pointer 0x1000000000 (a 64 KiB-aligned
+// block, low dword ZERO) whose low dword was overwritten with our 4-byte fence value 1. The pop then
+// misaligned-reads *(0x1000000001) = the adjacent block's pool pointer 0x20015f0000 shifted one byte
+// = 0x20015f00 (the "byte-shift" is a READ ARTIFACT, not an off-by-one store — this overturns the
+// session-8 theory and unifies all three fatal signatures into ONE root write). The existing
+// REL1-LIVE guard (case 1) MISSES this because it requires pre_low != 0; a 0x1000000000-shaped
+// pointer has pre_low == 0. forges_freelist_ptr() detects that missed case.
+static inline bool forges_freelist_ptr(uint64_t pre, uint64_t width, uint64_t value) {
+    if (!ptr_like(pre)) return false;        // dst must currently hold a heap/pool pointer
+    if ((uint32_t)pre != 0) return false;    // low dword already nonzero -> the REL1-LIVE guard covers it
+    if (width >= 8) return false;            // a full-width write replaces the whole qword (no forge)
+    return (uint32_t)value != 0;             // our sub-qword write makes the low dword nonzero -> pre|value
+}
+// Log-only tripwire (PROSPER_FORGE_TRIP=1): report a GPU write that forges a freelist pointer, with
+// the packet builder callsite — deciding host(GPU)-vs-guest for the root write. Default OFF (no-op).
+static void forge_trip(const char* kind, uint64_t dst, uint64_t pre, uint64_t value, uint64_t width, uint64_t pkt) {
+    static const bool on = getenv("PROSPER_FORGE_TRIP") != nullptr;
+    if (!on || !forges_freelist_ptr(pre, width, value)) return;
+    static std::atomic<int> n{0};
+    if (n.fetch_add(1) < 64)
+        fprintf(stderr, "[agc] FORGE-STOMP kind=%s dst=0x%llx pre=0x%llx val=0x%llx -> 0x%llx pkt=eboot+0x%llx t=%llums\n",
+                kind, (unsigned long long)dst, (unsigned long long)pre, (unsigned long long)value,
+                (unsigned long long)(pre | (value & 0xffffffffull)), (unsigned long long)pkt,
+                (unsigned long long)now_ms());
+}
+// #312 ROOT fix gate (default ON; PROSPER_REL1_FORGE_GUARD=0 for A/B baseline). Suppress a fence
+// write that would forge a freelist next-pointer (see forges_freelist_ptr), gated to the consumed-
+// marker label population so plain fence labels (Messenger) are untouched.
+static bool forge_guard() {
+    static const bool v = [] { const char* e = getenv("PROSPER_REL1_FORGE_GUARD");
+                               return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
+    return v;
+}
 // #312: report one suspicious fence write with its build-journal verdict. kindtag: "REL1" etc.
 //
 // RUN-2026-07-10 FINDING (this instrumentation's own history): the historical "~96 pointer-valued
@@ -400,6 +436,17 @@ static void honor_eop_write(const Pm4Command& c) {
                       }
                       else if (pre_low == 1 && (pre >> 32))
                           report_suspect_write("REL1-NOINIT", c.rel_addr, c.rel_value, pre, pkt_addr(c));
+                  }
+                  // #312 ROOT (session-10): the missed case — pre is a freelist next-pointer with a
+                  // ZERO low dword (0x1000000000-shaped). The pre_low!=0 branch above never sees it,
+                  // so the value-1 write below would forge pre|1 (0x1000000001) and seed the crash.
+                  else if (forges_freelist_ptr(pre, 4, c.rel_value)) {
+                      forge_trip("REL1", c.rel_addr, pre, c.rel_value, 4, pkt_addr(c));
+                      if (forge_guard() && label_is_consumed_marker(c.rel_addr)) {
+                          report_suspect_write("REL1-FORGE", c.rel_addr, c.rel_value, pre, pkt_addr(c));
+                          label_hist_rel_exec(c.rel_addr, pre);   // ring visibility; write skipped
+                          return;
+                      }
                   }
                   // In-flight overlap: a second init+fence pair to this label is already built but
                   // not executed — two fence generations in the pipe together (see label_rel_overlap).
@@ -505,6 +552,7 @@ static void honor_dma_data(const Pm4Command& c) {
     uint32_t v32 = (uint32_t)c.dd_src;
     uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;
     uint64_t pre_dma = peek_qword(c.dd_dst);   // #312: pre-content for the label event ring
+    forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, pkt_addr(c));   // #312 session-10 tripwire (log-only)
     if (v32 == 0) {
         memset(dst, 0, c.dd_bytes);
     } else {
@@ -530,6 +578,7 @@ static void honor_write_data(const Pm4Command& c) {
         uint64_t pre = 0; memcpy(&pre, (const void*)(uintptr_t)c.wd_addr, sizeof pre);
         if (ptr_like(pre))
             report_suspect_write("WDATA", c.wd_addr, c.wd_data[0], pre, pkt_addr(c));
+        forge_trip("WDATA", c.wd_addr, pre, c.wd_data[0], 4, pkt_addr(c));   // #312 session-10 tripwire
     }
     memcpy((void*)(uintptr_t)c.wd_addr, c.wd_data, (size_t)c.wd_num * 4);
     ring_record(c.wd_addr, c.wd_data[0], (uint8_t)(c.wd_num * 4 > 255 ? 255 : c.wd_num * 4), 3, pkt_addr(c));

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -442,7 +442,12 @@ static void honor_eop_write(const Pm4Command& c) {
                   // so the value-1 write below would forge pre|1 (0x1000000001) and seed the crash.
                   else if (forges_freelist_ptr(pre, 4, c.rel_value)) {
                       forge_trip("REL1", c.rel_addr, pre, c.rel_value, 4, pkt_addr(c));
-                      if (forge_guard() && label_is_consumed_marker(c.rel_addr)) {
+                      // No consumed-marker gate here (unlike REL1-LIVE): pre == a 0x1000000000-shaped
+                      // freelist next-pointer only ever occurs on a FREED/recycled MB3 block — a live
+                      // fence label (Messenger or DOLL) holds 0 / a small fence value there, never a
+                      // 64 KiB-aligned heap pointer. So this is always a write-after-free; suppressing
+                      // it can never re-block a live WaitRegMem==1 consumer. CONFIDENCE: HIGH.
+                      if (forge_guard()) {
                           report_suspect_write("REL1-FORGE", c.rel_addr, c.rel_value, pre, pkt_addr(c));
                           label_hist_rel_exec(c.rel_addr, pre);   // ring visibility; write skipped
                           return;

--- a/prosper/src/hle/dispatch.cpp
+++ b/prosper/src/hle/dispatch.cpp
@@ -32,6 +32,7 @@ namespace {
 void dispatch_set_progress(volatile int* counter) { g_progress = counter; }
 
 void (*g_hwwatch_hook)(uint64_t) = nullptr;   // set by the Linux exec harness (perf HW watchpoints)
+void (*g_mb3_arm_hook)(uint64_t) = nullptr;   // #312: set by the Linux exec harness (PROSPER_MB3WATCH)
 
 namespace { std::vector<ShadowedReg>& shadow_list() { static std::vector<ShadowedReg> s; return s; } }
 

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -175,4 +175,12 @@ void reset_call_log();
 // register-context sub-object fields. One watch at a time; extra calls are ignored.
 extern void (*g_hwwatch_hook)(uint64_t addr);
 
+// #312 diagnostic hook: arm a per-thread hardware write-watch on a MallocBinned3 per-thread
+// pool-descriptor cache base (base+0x20 = size-class idx=1 head — the corruptor's target) the
+// instant the guest is handed that base via pthread_get/setspecific. Set by the Linux exec harness
+// under PROSPER_MB3WATCH; null elsewhere. Arms on the CALLING (owning) guest thread so the watch is
+// on the right per-thread debug registers, before any corrupting store. HLE calls through it (when
+// non-null) from k_getspecific/k_setspecific.
+extern void (*g_mb3_arm_hook)(uint64_t base);
+
 } // namespace prosper

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -539,8 +539,19 @@ HLE(k_key_create) {
     return 0;
 }
 HLE(k_key_delete)    { pthread_key_delete((pthread_key_t)a0); return 0; }
-HLE(k_getspecific)   { return (uint64_t)(uintptr_t)pthread_getspecific((pthread_key_t)a0); }
-HLE(k_setspecific)   { return (uint64_t)(int64_t)pthread_setspecific((pthread_key_t)a0, (void*)(uintptr_t)a1); }
+HLE(k_getspecific)   {
+    uint64_t rv = (uint64_t)(uintptr_t)pthread_getspecific((pthread_key_t)a0);
+    // #312: the MallocBinned3 per-thread free-block cache base is fetched via getspecific; arm a
+    // per-thread head watch on it the moment this (owning) thread receives it (no-op unless armed).
+    if (g_mb3_arm_hook && rv) g_mb3_arm_hook(rv);
+    return rv;
+}
+HLE(k_setspecific)   {
+    // #312: catch the cache the instant it is FIRST installed (base passed to setspecific), which is
+    // right after allocation — before any head store — the earliest "descriptor established" moment.
+    if (g_mb3_arm_hook && a1) g_mb3_arm_hook(a1);
+    return (uint64_t)(int64_t)pthread_setspecific((pthread_key_t)a0, (void*)(uintptr_t)a1);
+}
 
 // --- event flags (SceKernelEventFlag): a bit pattern with wait/set/clear ---
 namespace {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -23,6 +23,7 @@
 #include <cerrno>
 #include <map>
 #include <mutex>
+#include <atomic>
 
 namespace prosper {
 
@@ -320,6 +321,59 @@ namespace {
         ioctl(g_hwwatch_fd, PERF_EVENT_IOC_ENABLE, 0);
         int n = snprintf(b, sizeof b, "[hwwatch] armed W-watch at 0x%llx (fd=%d)\n",
                          (unsigned long long)addr, g_hwwatch_fd); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+    }
+    // ---- #312 per-thread MallocBinned3 pool-descriptor HEAD watch (PROSPER_MB3WATCH) -----------
+    // The per-run corruptor stomps poolArray[idx].head (struct +0x20, size-class idx=1) of the MB3
+    // per-THREAD free-block cache. That cache's base is the return of pthread_getspecific(key) /
+    // the value passed to pthread_setspecific(key,base) — BOTH prosper HLE calls (k_getspecific /
+    // k_setspecific), so we learn the per-run base in-process. Sessions 1-9's fixed / process-wide
+    // page watches lost the discover-then-arm race: the base varies per run AND the corrupting store
+    // fires on a WORKER thread whose per-thread hardware debug registers a main-thread watch never
+    // observes. Here each guest thread, the instant IT is handed its own cache base (in HLE, on host
+    // %fs), arms a hardware WRITE-watch on base+0x20 on ITS OWN thread — before any store — so the
+    // corrupting write (host or guest) traps on the owning thread with its RIP captured. One HW-DR
+    // per thread (well under the 4/thread limit). A global fd->addr table lets the SIGTRAP handler
+    // attribute a hit without a %fs-fragile thread_local. Default OFF (strict no-op unless armed).
+    bool             g_mb3w_on = false;      // PROSPER_MB3WATCH
+    int              g_mb3w_off = 0x20;      // PROSPER_MB3WATCH_OFF (head slot; idx=1 -> 0x20)
+    int              g_mb3w_nslots = 1;      // PROSPER_MB3WATCH_N (consecutive 0x20-stride slots/thread)
+    struct Mb3W { int fd; uint64_t addr; };
+    Mb3W             g_mb3w[64];
+    unsigned char    g_mb3w_seen[64] = {0};   // per-slot benign-write log budget (see handler)
+    std::atomic<int> g_mb3w_cnt{0};
+    int mb3w_match(int fd) {
+        int n = g_mb3w_cnt.load(std::memory_order_acquire);
+        for (int i = 0; i < n && i < 64; i++) if (g_mb3w[i].fd == fd) return i;
+        return -1;
+    }
+    // Arm on the CURRENT (calling guest) thread. Called from HLE (host %fs) so glibc is safe, but we
+    // use raw syscalls throughout to keep the code identical to the handler's constraints.
+    void mb3w_arm_current_thread(uint64_t base) {
+        if (!g_mb3w_on || !base) return;
+        for (int s = 0; s < g_mb3w_nslots; s++) {
+            uint64_t addr = base + (uint64_t)g_mb3w_off + (uint64_t)s * 0x20ull;
+            int n = g_mb3w_cnt.load(std::memory_order_acquire);
+            bool dup = false;
+            for (int i = 0; i < n && i < 64; i++) if (g_mb3w[i].addr == addr) { dup = true; break; }
+            if (dup || n >= 64) continue;
+            long fd = perf_bp_open(addr, HW_BREAKPOINT_W);
+            if (fd < 0) { char b[128]; int k = snprintf(b, sizeof b,
+                "[mb3watch] arm FAILED addr=0x%llx tid=%ld errno=%d\n",
+                (unsigned long long)addr, cur_tid(), errno);
+                syscall(SYS_write, 2, b, (size_t)k); continue; }
+            fcntl((int)fd, F_SETFL, O_ASYNC);
+            fcntl((int)fd, F_SETSIG, SIGTRAP);
+            struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
+            fcntl((int)fd, F_SETOWN_EX, &ow);
+            ioctl((int)fd, PERF_EVENT_IOC_ENABLE, 0);
+            int slot = g_mb3w_cnt.fetch_add(1, std::memory_order_acq_rel);
+            if (slot < 64) { g_mb3w[slot].addr = addr; g_mb3w[slot].fd = (int)fd; }
+            char b[176]; int k = snprintf(b, sizeof b,
+                "[mb3watch] ARMED head watch @0x%llx (base=0x%llx off=0x%x) fd=%ld tid=%ld slot=%d\n",
+                (unsigned long long)addr, (unsigned long long)base, g_mb3w_off,
+                fd, cur_tid(), slot);
+            syscall(SYS_write, 2, b, (size_t)k);
+        }
     }
     // PROSPER_PEEK dumps offsets off registers at fault time. Supports N specs separated by ';',
     // each "reg:off,off,..."; an offset may be prefixed '*' to chase one pointer level first
@@ -622,6 +676,66 @@ namespace {
             for (int k = 0; k < 16 && n < (int)sizeof b - 4; k++) n += snprintf(b + n, sizeof b - n, " %02x", p[k]);
             if (n < (int)sizeof b - 1) b[n++] = '\n';
             ssize_t w = syscall(SYS_write, 2, b, (size_t)n); (void)w;
+        }
+        // #312 per-thread MB3 head watch: a hardware WRITE-watch on a poolArray head slot fired.
+        // Write-watchpoints trap AFTER the store, so RIP already points past it — just log the
+        // writer RIP + the value now in the slot and return (the watch stays armed for the next
+        // write). A byte-shifted pool pointer (0x20015f0000 stored as 0x20015f00) IS the corruptor;
+        // dump its full register + guest-stack context. Raw syscalls only (may run on a guest-%fs
+        // worker); globals + fd table, no thread_local.
+        if (sig == SIGTRAP && g_mb3w_cnt.load(std::memory_order_acquire) > 0) {
+            int mi = mb3w_match(si->si_fd);
+            if (mi >= 0) {
+                auto& gr2 = ((ucontext_t*)uctx)->uc_mcontext.gregs;
+                uint64_t addr = g_mb3w[mi].addr;
+                unsigned long long v = *(volatile uint64_t*)addr;
+                uint64_t wr = (uint64_t)gr2[REG_RIP];
+                bool in_eboot = (wr >= 0x400000000ull && wr < 0x420000000ull);
+                bool shifted = lwatch_is_pool_shift(v);
+                // base+0x20 is a HOT free-list head (every idx-1 malloc/free touches it), so logging
+                // every benign write floods I/O and stalls the run before the t~60s corruption burst.
+                // Log only the corruptor (a byte-shifted pool pointer) + the first couple of hits per
+                // slot (confirmation that the watch is live). g_mb3w_hits packs a per-slot small count.
+                if (!shifted && g_mb3w[mi].fd >= 0) {
+                    if (g_mb3w_seen[mi] >= 3) return;   // silent steady-state
+                    g_mb3w_seen[mi]++;
+                }
+                char b[256]; int n = snprintf(b, sizeof b,
+                    "[mb3watch] WRITE [0x%llx]=0x%llx by rip=%s0x%llx tid=%ld%s\n",
+                    (unsigned long long)addr, v, in_eboot ? "eboot+" : "host:",
+                    (unsigned long long)(in_eboot ? wr - 0x400000000ull : wr), cur_tid(),
+                    shifted ? "  <<<<< POOLSHIFT CORRUPTOR" : "");
+                syscall(SYS_write, 2, b, (size_t)n);
+                if (!in_eboot) classify_addr(wr);
+                if (shifted) {
+                    char rb[420]; int rn = snprintf(rb, sizeof rb,
+                        "[mb3watch]   regs rax=0x%llx rbx=0x%llx rcx=0x%llx rdx=0x%llx rsi=0x%llx "
+                        "rdi=0x%llx r8=0x%llx r9=0x%llx r10=0x%llx r11=0x%llx rbp=0x%llx rsp=0x%llx\n",
+                        (unsigned long long)gr2[REG_RAX], (unsigned long long)gr2[REG_RBX],
+                        (unsigned long long)gr2[REG_RCX], (unsigned long long)gr2[REG_RDX],
+                        (unsigned long long)gr2[REG_RSI], (unsigned long long)gr2[REG_RDI],
+                        (unsigned long long)gr2[REG_R8],  (unsigned long long)gr2[REG_R9],
+                        (unsigned long long)gr2[REG_R10], (unsigned long long)gr2[REG_R11],
+                        (unsigned long long)gr2[REG_RBP], (unsigned long long)gr2[REG_RSP]);
+                    syscall(SYS_write, 2, rb, (size_t)rn);
+                    // Guest call stack: scan [rsp, rsp+0x200) for eboot-range return addresses.
+                    uint64_t rsp = (uint64_t)gr2[REG_RSP];
+                    char sb[320]; int sn = snprintf(sb, sizeof sb, "[mb3watch]   guest-stack:");
+                    int found = 0;
+                    for (uint64_t p = rsp; p < rsp + 0x200 && found < 10; p += 8) {
+                        if (!probe_readable(p)) break;
+                        uint64_t ra = *(const uint64_t*)p;
+                        if (ra >= 0x400000000ull && ra < 0x420000000ull) {
+                            sn += snprintf(sb + sn, sizeof sb - sn, " eboot+0x%llx",
+                                           (unsigned long long)(ra - 0x400000000ull));
+                            found++;
+                        }
+                    }
+                    sn += snprintf(sb + sn, sizeof sb - sn, "\n");
+                    syscall(SYS_write, 2, sb, (size_t)sn);
+                }
+                return;
+            }
         }
         // PROSPER_HWBP race-free hardware breakpoint. The perf event is disabled while single-stepping,
         // so a SIGTRAP while g_hwbp_stepping is the step-completion (TF) -> re-enable + clear TF. Any
@@ -1576,6 +1690,19 @@ void install_trap_handler() {
     if (const char* r = getenv("PROSPER_SKIP_RIP"))    g_skip_rip    = strtoull(r, nullptr, 0);
     if (const char* t = getenv("PROSPER_SKIP_TARGET")) g_skip_target = strtoull(t, nullptr, 0);
     g_bp_shift = getenv("PROSPER_BP_SHIFT") != nullptr;
+    // #312 per-thread MB3 head watch: expose an HLE-side arm hook. k_getspecific/k_setspecific call
+    // through it with the per-thread cache base the instant it is handed to the guest; we arm a HW
+    // write-watch on base+0x20 on the OWNING thread, before any store. Region-filtered to the MB3
+    // FPoolInfo/cache range [0x2000000000,0x2100000000) so only real MB3 caches are watched.
+    g_mb3w_on = getenv("PROSPER_MB3WATCH") != nullptr;
+    if (const char* o = getenv("PROSPER_MB3WATCH_OFF")) g_mb3w_off = (int)strtol(o, nullptr, 0);
+    if (const char* n = getenv("PROSPER_MB3WATCH_N"))   g_mb3w_nslots = (int)strtol(n, nullptr, 0);
+    if (g_mb3w_on) {
+        g_mb3_arm_hook = [](uint64_t base) {
+            if (base < 0x2000000000ull || base >= 0x2100000000ull) return;   // MB3 pool-region only
+            mb3w_arm_current_thread(base);
+        };
+    }
     if (g_faultmem || g_skip_null_companion || g_null_page) ensure_probe_pipe();
     // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
     // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).
@@ -1677,6 +1804,7 @@ void install_trap_handler() {
     if (g_watch_companion || g_bp_on || g_hwbp_on
         || getenv("PROSPER_WATCH_LABEL")
         || getenv("PROSPER_WATCH_ABS")
+        || getenv("PROSPER_MB3WATCH")
         || getenv("PROSPER_WATCH_HOT")) sigaction(SIGTRAP, &sa, nullptr);   // single-step / breakpoint
 }
 

--- a/prosper/tools/dbg/canary_ctx.sh
+++ b/prosper/tools/dbg/canary_ctx.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+L=$1
+N=$(grep -n "Canary was 0x3" "$L" | head -1 | cut -d: -f1)
+echo "=== 40 lines BEFORE first Canary-0x3 (deep dump) ==="
+A=$((N-42)); B=$((N-1)); sed -n "${A},${B}p" "$L"

--- a/prosper/tools/dbg/forge_prove.sh
+++ b/prosper/tools/dbg/forge_prove.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# #312 forge-guard proof: N synchronous menu-drive runs (no MB3WATCH, undistorted timing) with the
+# REL1-FORGE guard (default ON unless GUARD=0 passed). Tallies fatal/clean/oom + DOLL progression.
+# Usage: forge_prove.sh <N> <timeout_s> [GUARD]   (GUARD=0 to A/B the baseline)
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+cd "$WT" || exit 1
+N=${1:-8}; TMO=${2:-150}; GUARD=${3:-1}
+SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"
+pkill -9 boot_trace 2>/dev/null; sleep 1
+fatal=0; clean=0; oom=0
+for n in $(seq 1 "$N"); do
+  log=/root/doll312_forge_g${GUARD}_${n}.log
+  timeout "$TMO" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=20 \
+    PROSPER_REL1_FORGE_GUARD=$GUARD "PROSPER_PAD_SCRIPT=${SCRIPT}" \
+    ./build-linux/boot_trace /root/PPSA17942-app0 > "$log" 2>&1
+  rc=$?
+  f=$(grep -cE "MallocBinned3 Corruption|unrecognized block|WORKER-THREAD FAULT" "$log")
+  sh=$(grep -c "20015f00" "$log")
+  prog=$(grep "\[progress\]" "$log" | tail -1 | grep -oE "t=[0-9.]+s|draws_cum=[0-9]+|flips=[0-9]+" | tr '\n' ' ')
+  if [ "$f" -gt 0 ]; then fatal=$((fatal+1)); tag=FATAL;
+  elif [ "$rc" = "137" ]; then oom=$((oom+1)); tag=OOM;
+  else clean=$((clean+1)); tag=clean; fi
+  echo "  [g=$GUARD n=$n] rc=$rc $tag fatals=$f 20015f00=$sh | $prog"
+done
+echo "=== GUARD=$GUARD : FATAL=${fatal}/${N} CLEAN=${clean}/${N} OOM=${oom}/${N} ==="

--- a/prosper/tools/dbg/mb3_analyze.sh
+++ b/prosper/tools/dbg/mb3_analyze.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+L=$1
+echo "=== fatal signatures ==="
+grep -cE "MallocBinned3 Corruption" "$L" | sed 's/^/  MallocBinned3 Corruption: /'
+grep -cE "unrecognized block" "$L" | sed 's/^/  unrecognized block: /'
+grep -cE "WORKER-THREAD FAULT" "$L" | sed 's/^/  WORKER-THREAD FAULT: /'
+grep -c "1000000001" "$L" | sed 's/^/  1000000001 refs: /'
+grep -c "20015f00" "$L" | sed 's/^/  20015f00 refs: /'
+grep -c "REL1-FORGE" "$L" | sed 's/^/  REL1-FORGE suppressed: /'
+echo "=== first fatal + context ==="
+N=$(grep -nE "MallocBinned3 Corruption|unrecognized block|WORKER-THREAD FAULT" "$L" | head -1 | cut -d: -f1)
+if [ -n "$N" ]; then A=$((N-4)); B=$((N+34)); sed -n "${A},${B}p" "$L"; fi

--- a/prosper/tools/dbg/mb3watch_run.sh
+++ b/prosper/tools/dbg/mb3watch_run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# #312 MB3WATCH capture harness. Arms a per-thread HW write-watch on the MB3 per-thread pool cache
+# head slot (base+0x20) the instant getspecific/setspecific hands the guest that base — before any
+# store — to catch the off-by-one corruptor in the act. Vars live in this file (safe from cmdline
+# stripping). Usage: mb3watch_run.sh <first> <count> [extra env VAR=VAL ...]
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+cd "$WT" || exit 1
+FIRST=${1:-1}; COUNT=${2:-1}; shift 2 2>/dev/null
+SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"
+pkill -9 boot_trace 2>/dev/null; sleep 1
+for n in $(seq "$FIRST" $((FIRST + COUNT - 1))); do
+  LOG=/root/doll312_mb3_${n}.log
+  timeout 150 env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=10 \
+    PROSPER_MB3WATCH=1 \
+    "PROSPER_PAD_SCRIPT=${SCRIPT}" "$@" ./build-linux/boot_trace /root/PPSA17942-app0 > "$LOG" 2>&1
+  RC=$?
+  ARMED=$(grep -c "\[mb3watch\] ARMED" "$LOG")
+  HITS=$(grep -c "\[mb3watch\] WRITE" "$LOG")
+  CORRUPT=$(grep -c "POOLSHIFT CORRUPTOR" "$LOG")
+  CRASH=$(grep -oE "Canary was 0x[0-9a-f]+|unrecognized block [0-9a-fx]+|WORKER-THREAD FAULT[^\n]*" "$LOG" | head -1)
+  PROG=$(grep "\[progress\]" "$LOG" | tail -1 | grep -oE "t=[0-9.]+s|draws_cum=[0-9]+|flips=[0-9]+" | tr '\n' ' ')
+  echo "=== run ${n} rc=${RC} armed=${ARMED} writes=${HITS} CORRUPTOR=${CORRUPT} crash=[${CRASH}]"
+  echo "    ${PROG}"
+  if [ "$CORRUPT" -gt 0 ]; then
+    echo "    --- CORRUPTOR CAPTURE ---"
+    grep -A6 "POOLSHIFT CORRUPTOR" "$LOG" | head -30
+  fi
+done

--- a/prosper/tools/dbg/msg_reg.sh
+++ b/prosper/tools/dbg/msg_reg.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+cd "$WT" || exit 1
+pkill -9 boot_trace 2>/dev/null; sleep 1
+L=/root/msg_reg.log
+timeout 130 env PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+  ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > "$L" 2>&1
+echo "rc=$?"
+echo "lines=$(wc -l < $L)"
+echo "vcount: $(grep -oE 'vcount=[0-9]+' $L | tail -1)"
+echo "frames: $(grep -oiE 'frame[s]?[ =:]+[0-9]+' $L | tail -1)"
+echo "faults: $(grep -icE 'WORKER-THREAD FAULT|SIGSEGV|LowLevelFatal|smashing' $L)"
+echo "forge/mb3 leakage (should be 0): $(grep -cE 'REL1-FORGE|FORGE-STOMP|mb3watch' $L)"
+tail -4 $L

--- a/prosper/tools/dbg/snap_check.sh
+++ b/prosper/tools/dbg/snap_check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper || exit 1
+pkill -9 boot_trace 2>/dev/null; sleep 1
+python3 tools/snapshot/snapshot.py check
+echo "SNAPSHOT_RC=$?"


### PR DESCRIPTION
Refs #312. The session-9 "arm a HW watchpoint the instant the MB3 descriptor is established" plan worked — the corruptor is **captured and classified HOST**, and one of #312's three fatal signatures is fixed. The gate is **not** closed (a distinct `Canary 0x3` residual remains); see the issue for the full session-10 writeup.

## New capture mechanism (`PROSPER_MB3WATCH`, default OFF)
The MB3 per-thread pool-cache base is `pthread_getspecific(key)` — a prosper HLE call. `k_getspecific`/`k_setspecific` now arm a **per-thread hardware WRITE-watch on `base+0x20`** (idx=1 head) the instant the owning guest thread receives its cache base, before any store. This removes both races that defeated sessions 1-9 (per-run-varying base; per-thread debug registers). Attribution via a global fd→addr table so the signal handler needs no `%fs`-fragile thread_local.

## What it captured
The write of `0x20015f00` into `poolArray[1].head` is the **guest allocator's own freelist POP** (`eboot+0x2316ad2`) propagating an already-corrupt chain (old head = `0x1000000001`). The `0x20015f00` "byte-shift" is a **misaligned-READ ARTIFACT** of `*(0x1000000001)`, not an off-by-one store — this overturns the session-8 theory and unifies all three fatal signatures into one root.

## Root cause — HOST (confirmed live via `PROSPER_FORGE_TRIP`)
```
[agc] FORGE-STOMP kind=REL1 dst=0x10216cb3c0 pre=0x1000000000 val=0x1 -> 0x1000000001 pkt=eboot+...
```
prosper's own `honor_eop_write` (ReleaseMem `data_sel=1`, value=1) overwrites the low dword of a freed MB3 freelist next-pointer `0x1000000000`, forging `0x1000000001`. #505's REL1-LIVE guard missed it because it requires `pre_low != 0` (a `0x1000000000`-shaped pointer has `pre_low == 0`).

## Fix (`PROSPER_REL1_FORGE_GUARD`, default ON)
`forges_freelist_ptr()` catches the missed case; `honor_eop_write` suppresses the forge. Safe unconditionally (a `0x1000000000`-shaped pointer at a fence label is always a freed block; no live `WaitRegMem==1` consumer). **The `0x20015f00` worker-fault signature is eliminated 0/8 guard-ON runs.**

## Regression
- Messenger snapshot check OK (24318 colors), **ctest 82/82**, 0 faults, zero guard activity on Messenger.

## Not closed
`MallocBinned3 Corruption Canary was 0x3` (Line 152) persists (~75%) — the same broad GPU-value-1-write-after-free class, different manifestation, not caught by value-shape guards. The real close needs label-lifecycle tracking (sessions 3-4 barrier model), not more value-shape guards. Full detail + CONFIDENCE in the #312 session-10 comment.

Tooling (default-OFF except the forge guard): `PROSPER_MB3WATCH`, `PROSPER_FORGE_TRIP`, `tools/dbg/{mb3watch_run,forge_prove,msg_reg,snap_check,mb3_analyze,canary_ctx}.sh`.
