### PR TITLE
fix(gpu): don't latch depth clear from an ALWAYS-compare draw — Messenger menu no longer black (Fixes #508)

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -213,7 +213,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (const auto& d : draws) {
         if (!d.ps) continue;
         if (d.ps->depth_test_enable) { use_depth = true;
-            if (!got_depth_clear) { depth_clear = d.ps->depth_clear_value; got_depth_clear = true; } }
+            // An ALWAYS-compare draw passes regardless of the depth clear, so it must NOT dictate it.
+            // The Messenger menu primes depth with an ALWAYS+write draw (its compare-op default clear is
+            // 1.0), then draws the real UI with GEQUAL (default clear 0.0). Latching 1.0 off the ALWAYS
+            // draw made every GEQUAL fragment fail (z >= 1.0) -> the whole menu went black (#508). Latch
+            // the clear from the first draw whose compare actually depends on it (skip ALWAYS/NEVER).
+            if (!got_depth_clear && d.ps->depth_compare_op != VK_COMPARE_OP_ALWAYS
+                                 && d.ps->depth_compare_op != VK_COMPARE_OP_NEVER) {
+                depth_clear = d.ps->depth_clear_value; got_depth_clear = true; } }
         if (d.ps->stencil_enable) { use_stencil = true;
             if (!got_stencil_clear) { stencil_clear = d.ps->stencil_clear_value; got_stencil_clear = true; } }
     }


### PR DESCRIPTION
## The regression
#425 (10b1de0) replaced the hardcoded `0.5` depth clear with the guest `DB_DEPTH_CLEAR` / a compare-op-appropriate default (1.0 for LESS, 0.0 for GREATER/GEQUAL), **latched from the submit's first depth-testing draw.** That regressed the **Messenger main menu to fully black.**

## Root cause
The menu submit's depth draws are:
```
[op=7 ALWAYS w=1 cv=1.00]   <- primes depth (writes), clear default 1.0
[op=6 GEQUAL w=0 cv=0.00] x N  <- the real UI (ring/text), clear default 0.0
```
The clear was latched off the **ALWAYS** prime → shared depth cleared to **1.0**. Every **GEQUAL** UI fragment then failed (`z >= 1.0`), so the whole menu vanished. The old fixed `0.5` accidentally let `z >= 0.5` pass.

## The fix
An `ALWAYS` (or `NEVER`) compare passes/fails regardless of the clear, so such a draw must **not dictate** the shared framebuffer's depth clear. Skip `ALWAYS`/`NEVER` when latching, so the first draw whose compare *actually depends* on the clear (the GEQUAL UI) sets it to its correct **0.0** → menu renders. Same class as the #457 depth/stencil-latch coupling fix. **#425's benefit is preserved** (compare-op-appropriate clears, no far-half loss) — it just latches from the right draw now.

## How it was found & verified
- **Reliable `git bisect`** over the 68-commit range → culprit **10b1de0 (#425)**. (This needed a deterministic menu-reach — two earlier wall-clock bisects gave false positives — so I built frame-anchored input, **PR #509 / #302**.)
- **Mechanism confirmed:** `PROSPER_DEPTH_ALWAYS=1` restored the menu (0 → 1964 gold); a per-draw depth-op capture showed the ALWAYS-prime + GEQUAL-UI pattern.
- **Fix verified:** menu-ring gold **0 → 1964** (renders); **82/82 ctest**; Messenger snapshot **unchanged (24318 colors)** — cutscene/#425 path intact.

Fixes #508. Complements #509 (frame-anchored input, used for the deterministic repro).