### PR TITLE
diag(#312): label free-state WAF guard — strictly-correct, does not close; residual is GPU-side-undetectable

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -230,6 +230,46 @@ int label_rel_overlap(uint64_t addr) {
 bool label_is_consumed_marker(uint64_t addr) {
     return label_hist_slot(addr).dma_built_n.load(std::memory_order_relaxed) > 0;
 }
+// #312 CLOSE — label free-state model (sessions 3-10 established the residual is a write-after-free,
+// NOT resolvable from write CONTENT alone). A LIVE consumed-marker label, at ReleaseMem(<-value)
+// time, holds exactly one of: its DmaData-init'd 0, or the already-signaled fence `value` (idempotent
+// re-fence). The guest polls it, and the instant it reads the fence value it FREES the 0x20 block and
+// LIFO-recycles it. So any deviation identifies a FREED/reused block:
+//   Case A (content): pre is neither 0 nor `value` -> the block was freed and its memory reused for an
+//     FFreeBlock header (a 64 KiB-aligned next-pointer 0x1000000000, a canary, or a size/count field).
+//     Writing `value` over it forges the exact #312 corruption — the pointer-forge (#510), the
+//     0x20015f00 misaligned-read artifact, AND the "Canary was 0x3, should be 0x1" fatal are all this
+//     one sub-qword write landing on different FFreeBlock fields. Subsumes #510's forges_freelist_ptr
+//     and #505's REL1-LIVE (both are pre!=0 && pre_low != value shapes).
+//   Case B (protocol free-state): pre == 0 is ambiguous — a live init'd label AND a freed block whose
+//     NextFreeBlock reads NULL both read 0, and writing 1 over a NULL next-pointer forges
+//     NextFreeBlock==0x1 (the deref-0x1 worker fault). Disambiguate via TRACKED lifecycle counters:
+//     each real DmaData(:=0) exec bumps dma_exec_n, each honored ReleaseMem bumps rel_exec_n (a
+//     SUPPRESSED write bumps NEITHER). A live fence therefore has a pending un-signaled init
+//     (dma_exec_n > rel_exec_n) here; when signals have caught up to inits (rel_exec_n >= dma_exec_n,
+//     dma_exec_n>0) this ReleaseMem is a stale/duplicate fence to an already-consumed+freed block.
+// Gated by the caller to consumed-marker labels only, so plain fence labels (Messenger) never qualify.
+// Strictly correct: a freed block satisfies no live WaitRegMem==value consumer (its content is not
+// `value`, or the guest already consumed the value and freed it). CONFIDENCE: MED-HIGH.
+// Returns the freed-manifestation category (for verification logging), or 0 if the label looks live.
+//   1 = Case A, pointer-shaped freed FFreeBlock next-pointer (the #505/#510 family)
+//   2 = Case A, NON-pointer freed content — a canary / size / count field (the "Canary 0x3" residual)
+//   3 = Case B, content 0 but protocol shows a stale/duplicate fence to a consumed+freed block
+int label_freed_marker_kind(uint64_t addr, uint64_t pre, uint64_t value) {
+    uint32_t lo = (uint32_t)pre;
+    if (pre != 0 && lo != (uint32_t)value && pre != value) {             // Case A
+        bool ptr = (pre >= 0x1000000000ull && pre < 0x1200000000ull) ||
+                   (pre >= 0x2000000000ull && pre < 0x2100000000ull);
+        return ptr ? 1 : 2;
+    }
+    if (pre == 0) {                                                       // Case B
+        LabelHist& h = label_hist_slot(addr);
+        uint32_t dx = h.dma_exec_n.load(std::memory_order_relaxed);
+        uint32_t rx = h.rel_exec_n.load(std::memory_order_relaxed);
+        if (dx > 0 && rx >= dx) return 3;
+    }
+    return 0;
+}
 // Format the event ring for a suspect report, oldest first. b=built x=exec, aux in hex.
 void label_hist_report(uint64_t addr, char* out, size_t cap) {
     static const char* nm[] = {"?", "dmaB", "relB", "waitB", "dmaX", "relX", "dmaSKIP"};
@@ -342,6 +382,26 @@ static bool forge_guard() {
                                return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
     return v;
 }
+// #312 CLOSE gate (default ON; PROSPER_REL1_WAF_GUARD=0 restores the session-10 behavior for A/B).
+// The label free-state write-after-free guard — see label_is_freed_marker. This is the residual
+// closer over #505/#510's value-shape guards: it keys on TRACKED free state, so it also catches the
+// freed manifestations whose content is not pointer-shaped (the "Canary was 0x3" family).
+static bool waf_guard() {
+    static const bool v = [] { const char* e = getenv("PROSPER_REL1_WAF_GUARD");
+                               return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
+    return v;
+}
+// #312 CLOSE: bounded log of a suppressed write-after-free. PER-CATEGORY caps so a rare non-pointer
+// (canary-residual) or Case-B suppression is always visible even after the common pointer case fills.
+static void waf_report(const char* kind, uint64_t addr, uint64_t pre, uint64_t value, int cat) {
+    static const char* catname[] = {"?", "A-ptr", "A-canary", "B-stale0"};
+    static std::atomic<int> nc[4] = {};
+    int cap = (cat == 1) ? 32 : 512;   // pointer case is common (#510 covered it); log the rest fully
+    if (nc[cat & 3].fetch_add(1) < cap)
+        fprintf(stderr, "[agc] REL-WAF-SUPPRESS kind=%s cat=%s [0x%llx] pre=0x%llx value=0x%llx t=%llums\n",
+                kind, catname[cat & 3], (unsigned long long)addr, (unsigned long long)pre,
+                (unsigned long long)value, (unsigned long long)now_ms());
+}
 // #312: report one suspicious fence write with its build-journal verdict. kindtag: "REL1" etc.
 //
 // RUN-2026-07-10 FINDING (this instrumentation's own history): the historical "~96 pointer-valued
@@ -410,6 +470,17 @@ static void honor_eop_write(const Pm4Command& c) {
                   // target-region trigger caught only benign fences and burned the report cap.
                   // Trigger on pointer-like PRE-CONTENT only.)
                   uint64_t pre = 0; memcpy(&pre, dst, sizeof pre);
+                  // #312 CLOSE — label free-state write-after-free guard (the residual closer). Runs
+                  // FIRST, before the value-shape guards below: it keys on tracked lifecycle state and
+                  // subsumes both #505's REL1-LIVE and #510's forge cases while ALSO catching the
+                  // non-pointer freed manifestation (the "Canary was 0x3" fatal). Suppress the write
+                  // and record NO rel_exec (a suppressed fence must not advance the signal counter, or
+                  // Case B would mis-count the next generation). CONFIDENCE: MED-HIGH.
+                  if (int cat; waf_guard() && label_is_consumed_marker(c.rel_addr) &&
+                      (cat = label_freed_marker_kind(c.rel_addr, pre, c.rel_value)) != 0) {
+                      waf_report("REL1", c.rel_addr, pre, c.rel_value, cat);
+                      return;
+                  }
                   // Post-init state (low dword 0 or an already-signaled 1 from OUR OWN just-landed
                   // write... no: low==1 means the previous generation's fence value survived with
                   // NO re-init between — the init leg missed. Classify (see the finding above):
@@ -476,6 +547,12 @@ static void honor_eop_write(const Pm4Command& c) {
                   // fatal). Skip when the target still holds a live heap pointer (its DmaData init
                   // never landed) — see honor case 1. CONFIDENCE: HIGH.
                   uint64_t pre = 0; memcpy(&pre, dst, sizeof pre);
+                  // #312 CLOSE — same label free-state WAF guard as case 1 (8-byte fence leg).
+                  if (int cat; waf_guard() && label_is_consumed_marker(c.rel_addr) &&
+                      (cat = label_freed_marker_kind(c.rel_addr, pre, c.rel_value)) != 0) {
+                      waf_report("REL2", c.rel_addr, pre, c.rel_value, cat);
+                      return;
+                  }
                   if (rel1_stomp_guard() && ptr_like(pre) && (uint32_t)pre != 0 &&
                       pre != c.rel_value && label_is_consumed_marker(c.rel_addr)) {
                       report_suspect_write("REL2-LIVE", c.rel_addr, c.rel_value, pre, pkt_addr(c));

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -252,17 +252,27 @@ bool label_is_consumed_marker(uint64_t addr) {
 // Strictly correct: a freed block satisfies no live WaitRegMem==value consumer (its content is not
 // `value`, or the guest already consumed the value and freed it). CONFIDENCE: MED-HIGH.
 // Returns the freed-manifestation category (for verification logging), or 0 if the label looks live.
-//   1 = Case A, pointer-shaped freed FFreeBlock next-pointer (the #505/#510 family)
-//   2 = Case A, NON-pointer freed content — a canary / size / count field (the "Canary 0x3" residual)
-//   3 = Case B, content 0 but protocol shows a stale/duplicate fence to a consumed+freed block
+//   2 = the fence's LOW DWORD (the 4 bytes the guest polls) is neither the DmaData-init'd 0 nor the
+//       fence value — a freed/reused FFreeBlock header field (canary / size / count) sits there. This
+//       is the "Canary 0x3" residual that value-SHAPE (ptr_like) guards miss. A live consumed-marker
+//       label's low dword is ONLY ever 0 or the fence value, so this cannot be a live label. NOTE: we
+//       key on the LOW DWORD, not the qword — the high dword of a live 4-byte-fence label is malloc
+//       residue (e.g. pre=0x1_00000000, low dword 0 = a LIVE init'd label; suppressing on the qword
+//       wrongly killed those and crashed boot). The ptr_like next-pointer cases (#505 REL1-LIVE, #510
+//       forge, which have low dword 0 or a real pointer half) are handled by the guards below.
+//   3 = LOW DWORD is 0 (looks like a freshly init'd LIVE label) BUT the tracked protocol counters
+//       show NO pending un-signaled DmaData init (rel_exec_n >= dma_exec_n): this is a stale/
+//       duplicate fence to a block the guest already consumed + freed + LIFO-recycled, whose
+//       FFreeBlock next-pointer reads NULL — writing the fence value would forge NextFreeBlock==0x1
+//       (the eboot+0x231012b deref-0x1 fatal / "Canary 0x3"). Content is INDISTINGUISHABLE from a
+//       live label here (both read low dword 0), so ONLY the lifecycle counters resolve it — this is
+//       the guest-free-state track the residual needs. A live fence always has its paired init
+//       pending (dma_exec_n > rel_exec_n) at this point, so it is never suppressed.
 int label_freed_marker_kind(uint64_t addr, uint64_t pre, uint64_t value) {
     uint32_t lo = (uint32_t)pre;
-    if (pre != 0 && lo != (uint32_t)value && pre != value) {             // Case A
-        bool ptr = (pre >= 0x1000000000ull && pre < 0x1200000000ull) ||
-                   (pre >= 0x2000000000ull && pre < 0x2100000000ull);
-        return ptr ? 1 : 2;
-    }
-    if (pre == 0) {                                                       // Case B
+    uint32_t vlo = (uint32_t)value;
+    if (lo != 0 && lo != vlo) return 2;                                  // Case A'
+    if (lo == 0 && vlo != 0) {                                           // Case B (free-state track)
         LabelHist& h = label_hist_slot(addr);
         uint32_t dx = h.dma_exec_n.load(std::memory_order_relaxed);
         uint32_t rx = h.rel_exec_n.load(std::memory_order_relaxed);
@@ -382,13 +392,23 @@ static bool forge_guard() {
                                return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
     return v;
 }
-// #312 CLOSE gate (default ON; PROSPER_REL1_WAF_GUARD=0 restores the session-10 behavior for A/B).
-// The label free-state write-after-free guard — see label_is_freed_marker. This is the residual
-// closer over #505/#510's value-shape guards: it keys on TRACKED free state, so it also catches the
-// freed manifestations whose content is not pointer-shaped (the "Canary was 0x3" family).
+// #312 label free-state write-after-free guard — see label_freed_marker_kind. Default OFF
+// (PROSPER_REL1_WAF_GUARD=1 to arm). RATIONALE (session-11 A/B, ~30 menu-drive runs): this guard is
+// STRICTLY-CORRECT — every write it suppresses is a genuine write-after-free into an MB3
+// consumed-marker label the guest already freed — but it does NOT close #312, because the DOMINANT
+// residual is undetectable from the GPU side: the guest frees the 0x20 label block while BOTH its
+// DmaData(:=0) init AND its ReleaseMem(<-1) fence are still in flight, so our init writes 0 to the
+// freed block's next-pointer field (making it read exactly like a freshly-init'd LIVE label, low
+// dword 0) AND bumps dma_exec_n (making the protocol counters read as a live pending fence). Neither
+// content nor tracked counters can separate that freed block from a live label — only the guest's
+// actual FREELIST MEMBERSHIP can, and cheaply hooking the MB3 free-push is infeasible (it is far too
+// hot to trap without destroying the repro's timing). So the guard ships OFF: the default boot stays
+// at the proven #505/#510 state, and this remains armed A/B instrumentation for the freelist-
+// membership approach the close ultimately needs. CONFIDENCE: HIGH on the mechanism + why it can't
+// be resolved GPU-side (definitive per-write capture, session 10-11).
 static bool waf_guard() {
     static const bool v = [] { const char* e = getenv("PROSPER_REL1_WAF_GUARD");
-                               return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
+                               return e && strtol(e, nullptr, 0) != 0; }();   // default OFF
     return v;
 }
 // #312 CLOSE: bounded log of a suppressed write-after-free. PER-CATEGORY caps so a rare non-pointer
@@ -470,12 +490,11 @@ static void honor_eop_write(const Pm4Command& c) {
                   // target-region trigger caught only benign fences and burned the report cap.
                   // Trigger on pointer-like PRE-CONTENT only.)
                   uint64_t pre = 0; memcpy(&pre, dst, sizeof pre);
-                  // #312 CLOSE — label free-state write-after-free guard (the residual closer). Runs
-                  // FIRST, before the value-shape guards below: it keys on tracked lifecycle state and
-                  // subsumes both #505's REL1-LIVE and #510's forge cases while ALSO catching the
-                  // non-pointer freed manifestation (the "Canary was 0x3" fatal). Suppress the write
-                  // and record NO rel_exec (a suppressed fence must not advance the signal counter, or
-                  // Case B would mis-count the next generation). CONFIDENCE: MED-HIGH.
+                  // #312 — label free-state write-after-free guard (default OFF; A/B instrumentation,
+                  // see waf_guard). Keys on tracked lifecycle state; suppresses genuine WAFs but does
+                  // NOT close the gate (the dominant residual is GPU-side-undetectable — see waf_guard).
+                  // Records NO rel_exec (a suppressed fence must not advance the signal counter, or
+                  // Case B would mis-count the next generation).
                   if (int cat; waf_guard() && label_is_consumed_marker(c.rel_addr) &&
                       (cat = label_freed_marker_kind(c.rel_addr, pre, c.rel_value)) != 0) {
                       waf_report("REL1", c.rel_addr, pre, c.rel_value, cat);

--- a/prosper/tools/dbg/waf_inspect.sh
+++ b/prosper/tools/dbg/waf_inspect.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Inspect a set of waf validation logs. Usage: waf_inspect.sh <logfile> [logfile...]
+for L in "$@"; do
+  echo "===== $L ====="
+  echo "-- fatal signature --"
+  grep -iE "MallocBinned3 Corruption|unrecognized block|WORKER-THREAD FAULT|Canary was|LowLevelFatal|Assertion failed|Fatal error" "$L" | head -4
+  echo "-- last progress --"
+  grep "\[progress\]" "$L" | tail -1
+  echo "-- WAF categories (count) --"
+  grep -oE "cat=[A-Za-z0-9-]+" "$L" | sort | uniq -c
+  echo "-- non-pointer/canary/stale suppressions (first 5) --"
+  grep -E "REL-WAF-SUPPRESS.*cat=(A-canary|B-stale0)" "$L" | head -5
+  echo "-- guest wedge/timeout markers --"
+  grep -cE "timed out waiting|GameThread timed|watchdog abort|DEFER-TIMEOUT" "$L"
+done

--- a/prosper/tools/dbg/waf_sync.sh
+++ b/prosper/tools/dbg/waf_sync.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# #312: test whether SYNCHRONOUS fence writes (PROSPER_EOP_WRITE_SYNC=1, no pend deferral) + the WAF
+# guard close the gate. Usage: waf_sync.sh <first> <N> <timeout_s> [SYNC] [GUARD]
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a8f10a7598f626404/prosper
+cd "$WT" || exit 1
+FIRST=${1:-1}; N=${2:-3}; TMO=${3:-120}; SYNC=${4:-1}; GUARD=${5:-1}
+SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"
+pkill -9 boot_trace 2>/dev/null; sleep 1
+fatal=0; clean=0
+for i in $(seq 0 $((N-1))); do
+  n=$((FIRST+i))
+  log=/root/doll312_sync_s${SYNC}_g${GUARD}_${n}.log
+  timeout "$TMO" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=20 \
+    PROSPER_EOP_WRITE_SYNC=$SYNC PROSPER_REL1_WAF_GUARD=$GUARD "PROSPER_PAD_SCRIPT=${SCRIPT}" \
+    ./build-linux/boot_trace /root/PPSA17942-app0 > "$log" 2>&1
+  rc=$?
+  f=$(grep -cE "MallocBinned3 Corruption|unrecognized block|WORKER-THREAD FAULT|Canary was 0x" "$log")
+  can=$(grep -oE "Canary was 0x[0-9a-f]+|unrecognized block [0-9a-f]+|WORKER-THREAD FAULT[^\"]*" "$log" | head -1)
+  prog=$(grep "\[progress\]" "$log" | tail -1 | grep -oE "t=[0-9.]+s|draws_cum=[0-9]+|flips=[0-9]+" | tr '\n' ' ')
+  if [ "$f" -gt 0 ]; then fatal=$((fatal+1)); tag=FATAL; else clean=$((clean+1)); tag=clean; fi
+  echo "  [sync=$SYNC g=$GUARD n=$n] rc=$rc $tag fatals=$f [$can] | $prog"
+done
+echo "=== SYNC=$SYNC GUARD=$GUARD : FATAL=${fatal}/${N} CLEAN=${clean}/${N} ==="

--- a/prosper/tools/dbg/waf_val.sh
+++ b/prosper/tools/dbg/waf_val.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# #312 CLOSE validation — label free-state WAF guard. N synchronous menu-drive runs, undistorted
+# timing (no MB3WATCH). Tallies ALL fatal signatures (Canary / unrecognized block / worker-fault /
+# 0x20015f00) + WAF suppression activity + DOLL progression. Vars live in-file (cmdline-strip safe).
+# Usage: waf_val.sh <first> <N> <timeout_s> [GUARD]   (GUARD=0 for the session-10 A/B baseline)
+WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a8f10a7598f626404/prosper
+cd "$WT" || exit 1
+FIRST=${1:-1}; N=${2:-4}; TMO=${3:-120}; GUARD=${4:-1}
+SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"
+pkill -9 boot_trace 2>/dev/null; sleep 1
+fatal=0; clean=0; oom=0
+for i in $(seq 0 $((N-1))); do
+  n=$((FIRST+i))
+  log=/root/doll312_waf_g${GUARD}_${n}.log
+  timeout "$TMO" env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_PROGRESS=20 \
+    PROSPER_REL1_WAF_GUARD=$GUARD "PROSPER_PAD_SCRIPT=${SCRIPT}" \
+    ./build-linux/boot_trace /root/PPSA17942-app0 > "$log" 2>&1
+  rc=$?
+  f=$(grep -cE "MallocBinned3 Corruption|unrecognized block|WORKER-THREAD FAULT|Canary was 0x" "$log")
+  canary=$(grep -oE "Canary was 0x[0-9a-f]+" "$log" | head -1)
+  sh=$(grep -c "20015f00" "$log")
+  waf=$(grep -c "REL-WAF-SUPPRESS" "$log")
+  prog=$(grep "\[progress\]" "$log" | tail -1 | grep -oE "t=[0-9.]+s|draws_cum=[0-9]+|flips=[0-9]+" | tr '\n' ' ')
+  if [ "$f" -gt 0 ]; then fatal=$((fatal+1)); tag=FATAL;
+  elif [ "$rc" = "137" ]; then oom=$((oom+1)); tag=OOM;
+  else clean=$((clean+1)); tag=clean; fi
+  echo "  [g=$GUARD n=$n] rc=$rc $tag fatals=$f canary=[$canary] 20015f00=$sh waf_suppress=$waf | $prog"
+done
+echo "=== WAF GUARD=$GUARD : FATAL=${fatal}/${N} CLEAN=${clean}/${N} OOM=${oom}/${N} ==="


### PR DESCRIPTION
Refs #312. Session-11 close attempt: modeled the MB3 consumed-marker label lifecycle to suppress our GPU value-1 write-after-free, per the session-10 direction. **The gate is NOT closed** — but the residual is now characterized definitively, with a per-write mechanism proof of *why* it is unresolvable from the GPU side, and strictly-correct free-state instrumentation lands default-OFF for the next attempt.

## What was built (`PROSPER_REL1_WAF_GUARD=1`, default OFF)
A label free-state guard in `honor_eop_write` (both the 4- and 8-byte fence legs), gated to consumed-marker labels (DmaData-init history), keyed on **tracked lifecycle state** not value shape:
- **Case A'** — the fence's LOW DWORD (the 4 bytes the guest polls) is neither the init'd 0 nor the fence value → a freed FFreeBlock header field (canary/size/count) sits there.
- **Case B** — low dword 0 but the tracked protocol counters (`dma_exec_n` vs `rel_exec_n`) show no pending un-signaled init → a stale/duplicate fence to an already-consumed+freed block.

Every write it suppresses is a genuine WAF. It is strictly correct and Messenger-safe (0 activity, gated out).

## Why it does NOT close (the definitive mechanism)
Live per-write A/B (`PROSPER_NULL_PAGE` deep dump + GPU write ring) shows the dominant residual is **GPU-side-undetectable**: the guest frees the 0x20 label block while **BOTH** its `DmaData(:=0)` init **and** its `ReleaseMem(<-1)` fence are still in flight. So:
- our init writes 0 to the freed block's next-pointer field → it reads **exactly like a freshly-init'd LIVE label** (low dword 0), and
- the init **bumps `dma_exec_n`** → the protocol counters read as a live pending fence.

Then our fence writes 1 → `NextFreeBlock = 0x1` → the `eboot+0x231012b` deref-0x1 fault / `Canary was 0x3, should be 0x1` / `free an unrecognized block 1000000000` fatals (all one root, confirming the session-10 unification). Neither write **content** nor tracked lifecycle **counters** can separate that freed block from a live label — only the guest's actual **MB3 freelist membership** can.

The first-cut guard keyed on the full qword and suppressed LIVE labels (high-dword malloc residue e.g. `0x1_00000000`, low dword 0) → crashed boot at t=0; the shipped detector keys on the low dword + counters and does not break boot.

## A/B (each arm ≥4-8 synchronous menu-drive runs, timeout-bounded)
| config | fatal rate |
|---|---|
| baseline (#510, guard off, deferred) | ~4/7 |
| WAF guard on (deferred) | 5/8 |
| `EOP_WRITE_SYNC=1`, guard off | 3/4 |
| `EOP_WRITE_SYNC=1` + guard | 2/8 |

Variance is high and **no configuration robustly closes or clearly moves the rate**. Fatal signatures still present under the guard: `Canary was 0x3`, `free unrecognized block 1000000000`, `WORKER-THREAD FAULT`. The `0x20015f00` signature stays eliminated (#510). DOLL does not reach a save-load; clean runs render to t=100-120s / 1.9M draws.

## Sharpest lead for the close
The `EOP_WRITE_SYNC` half-result points at the **deferral window** as the WAF enabler, but sync alone still stomps — the guest fences blocks that are freed at *build* time, so the true close is **guest MB3 freelist-membership tracking** of the label blocks, NOT another GPU-side content/counter guard. Cheap free-push hooking is infeasible (the push site is far too hot to trap without destroying the repro timing) — the next mechanism needs a non-trapping membership signal.

## Regression
- Messenger snapshot check OK (24318 colors), boot_trace 0 real faults, **WAF activity 0** (gated to consumed-marker labels).
- **ctest 82/82** green.
- Default boot unchanged (guard default OFF).

Tooling: `tools/dbg/waf_{val,sync,inspect}.sh` (synchronous A/B harness), categorized `REL-WAF-SUPPRESS` logs.
