### PR TITLE
docs: replace stale Messenger render frontier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,16 +60,34 @@ prosper/
 ```
 
 Key docs to orient: `prosper/README.md` (status), `prosper/docs/ROADMAP.md`, `prosper/docs/GRAPHICS.md`,
-`prosper/docs/RENDER_LOOP.md` (the active render frontier log), and
-`prosper/docs/NEXT_STEP_EUD_DESCRIPTORS.md` (the current, precisely-scoped next task).
+`prosper/docs/RENDER_LOOP.md` (the historical render bring-up log), and
+`prosper/docs/MESSENGER_BLACK_RENDER.md` (the current, revisioned Messenger investigation status).
 
-## Current frontier (2026-07)
+## Historical frontier (superseded 2026-07-11)
 
 The game **boots through IL2CPP into Unity's frame loop and submits real GPU draws.** A live Vulkan
 renderer is wired in; the game's **real pixel shader recompiles to valid SPIR-V** and its real descriptors
 + 1920×1080 sampled texture decode correctly. The **one** remaining step to the first rendered frame is
 **bindless-dynamic vertex-fetch resolution** for the vertex shader — fully specified in
-`prosper/docs/NEXT_STEP_VERTEX_FETCH.md`. Start there.
+`prosper/docs/NEXT_STEP_VERTEX_FETCH.md`. This paragraph is historical only.
+
+## Current frontier (2026-07-11)
+
+The game now **boots through IL2CPP, renders its intro/title/menu, and reaches gameplay with real GPU
+draws.** The old bindless vertex-fetch frontier is complete: both shader stages recompile and dynamic
+V#/T#/S# resources resolve on current master. Do **not** start from `NEXT_STEP_VERTEX_FETCH.md`; it is
+retained as a historical bring-up record.
+
+The first gameplay level and the save-game list are still black/missing, but there is no verified
+current-master root cause. The immediate frontier is reproducible diagnosis:
+
+1. Re-establish #299 (save list) and #300 (gameplay) independently with controlled input, savedata,
+   revision, and environment.
+2. Capture the failing GPU submit/frame into a local immutable capsule and replay it without Unity boot.
+3. Validate the generated SPIR-V descriptor interface strictly against runtime resources.
+
+Start with `prosper/docs/MESSENGER_BLACK_RENDER.md` and its linked GitHub issues. Treat claims from old
+captures as historical unless reproduced on the revision under test.
 
 ## How to work here
 

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -28,8 +28,13 @@ makes the project possible without console keys. Dumps are user-supplied and git
 - ✅ **The Messenger renders:** intro cutscene (dozens of distinct animating frames), title screen with
   readable text, working gamepad input, and progression into gameplay level loading — all asserted by
   a golden-image snapshot guard.
-- 🚧 **Active frontiers:** full multi-pass scene compositing for the 3D gameplay view, broader shader
-  coverage, and the Unreal title's title-screen composite (see `docs/`).
+- 🚧 **Active frontiers:** revision-locked capture/replay of the black Messenger gameplay frame,
+  strict shader/resource-interface validation, independent diagnosis of the missing save list, broader
+  shader coverage, and the Unreal title's title-screen composite.
+
+The current Messenger frontier is revision-locked capture/replay of the black gameplay frame, strict
+shader/resource-interface validation, and an independent trace of the save-list failure. See
+[`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md).
 
 See [`docs/ROADMAP.md`](docs/ROADMAP.md), [`docs/GRAPHICS.md`](docs/GRAPHICS.md),
 [`docs/RENDER_LOOP.md`](docs/RENDER_LOOP.md), and [`docs/VERIFICATION.md`](docs/VERIFICATION.md)

--- a/prosper/docs/CUTSCENE_RENDER.md
+++ b/prosper/docs/CUTSCENE_RENDER.md
@@ -63,7 +63,8 @@ display-space render.
    texture is bound; its dump shows scrambled/partly-committed content), so the MVP is in **atlas space**,
    not display space. We render that draw straight to the display viewport → off-screen. This is the
    render-to-texture / render-target-management gap: execute the scene→atlas pass into a Vulkan image and
-   bind it as the composite's texture (see `docs/NEXT_STEP_VERTEX_FETCH.md` "execute the full draw chain").
+   bind it as the composite's texture (historical context: `docs/NEXT_STEP_VERTEX_FETCH.md`; current
+   Messenger status: `docs/MESSENGER_BLACK_RENDER.md`).
 
 Also: our executor clears to a **debug blue** (BGR 255,0,0); switch to the game's clear color so the black
 letterbox appears even before the island/text draw correctly.

--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -1,5 +1,12 @@
 # Input replay & checkpoints — reaching a game state to reproduce a bug
 
+> **Status (2026-07-11): design plus inline frame anchoring landed; the rest remains open in #302.**
+> Current master supports inline `PROSPER_PAD_SCRIPT` entries anchored as `fN:`/`fA-B:`. PR #301 merged
+> only this design document; later branch commits for `@file` routes, recording, checked-in scripts,
+> `PROSPER_DET_CLOCK`, and pad-read screenshot checkpoints did not merge. Issue comments reporting those
+> steps as landed describe `feat/input-replay`, not current master. Re-verify and land them as focused
+> current-master changes before using them as a reproducibility guarantee. The original design follows.
+
 ## The problem
 
 Now that titles are becoming playable, a bug is often reported at a *state* — "the shop menu", "level 1 boss", "after the first save". To reproduce or observe it, an agent must **navigate the game to that point** and then apply the full debug arsenal (`PROSPER_GFXLOG`, `PROSPER_DRAWDIAG`, `PROSPER_HWBP`, `boot_trace`, `screenshot`, the app). Hand-driving a controller isn't an option for a headless agent.

--- a/prosper/docs/MESSENGER_BLACK_RENDER.md
+++ b/prosper/docs/MESSENGER_BLACK_RENDER.md
@@ -1,0 +1,94 @@
+# Messenger black-render investigation
+
+This is the canonical status for two visible Messenger failures:
+
+- GitHub #300: the first gameplay level submits frames but its scene content is black.
+- GitHub #299: the save-game list is not visible.
+
+GitHub issues track what remains and own live findings. This document defines what evidence is current,
+which conclusions are obsolete, and how the next investigation must be run. Update it when a finding
+changes the investigation boundary; put run-by-run detail on the relevant issue.
+
+## Current conclusion (2026-07-11)
+
+There is **no verified current-master root cause** for either symptom.
+
+The old project frontier, "the vertex shader cannot recompile because bindless vertex fetch is unresolved",
+is solved. Dynamic fetch const-folding, per-instruction resource provenance, EUD descriptor recovery, and
+both shader stages now execute. `NEXT_STEP_VERTEX_FETCH.md` is a historical implementation record.
+
+#300 contains useful measurements, but it also contains mutually incompatible conclusions: texture decode,
+alpha, transform collapse, render-target propagation, and a missing vertex-color binding were each called
+the root cause and later overturned. Those tests were run while the graphics stack changed quickly. They
+cannot be combined into one proof unless repeated on the same commit with the same captured frame.
+
+The newest focused diagnostic, `772c44a` on `origin/fix/messenger-vertex-color-binding`, found that the
+previously absent binding-9 color vertex buffer had become present with real packed-white data after the
+EUD/resource fixes. The level was still black. That commit is based on `9b5bf27`, 27 commits behind
+`origin/master` at the time of this update, so it narrows history but is not current-master verification.
+
+#299 has only a shared-root hypothesis. It has not been shown whether the save-list rows are absent from
+Unity's draw stream, dropped during realization, or rendered with bad inputs. SaveData persistence and
+filesystem behavior changed recently (#389, #392), and the diagnostic run above reported flaky save-mount
+behavior. Treat #299 as an independent HLE/UI investigation until a capture proves otherwise.
+
+## Evidence policy
+
+Every new finding posted to #299 or #300 must include:
+
+- exact git commit and whether local changes were present;
+- title dump ID, savedata directory/seed, input route, and relevant environment flags;
+- pad-read, flip, submit, pass, and draw identifiers as applicable;
+- hashes of shader code, resolved resource table, referenced input bytes, and output image/pass;
+- the observation, the narrower conclusion it supports, and alternatives it does not distinguish.
+
+Avoid "definitive" or "root cause" until a proposed fix changes the failing replay and a regression test
+fails before the fix and passes after it. A diagnostic override proves only the boundary it directly changes.
+
+## Required baseline
+
+Re-establish both symptoms independently on `origin/master`:
+
+1. Use a unique, explicitly recorded `PROSPER_SAVEDATA_DIR` and state whether it starts empty or seeded.
+2. Record the exact inline, frame-anchored `PROSPER_PAD_SCRIPT` value. File-loaded routes are not on
+   current master yet; do not cite a branch-only `scripts/<title>/reach-*.pad` path as the input.
+3. Do not rely on `PROSPER_DET_CLOCK` or pad-read screenshot checkpoints; #302 confirmed those later
+   implementations did not merge with PR #301.
+4. Detect the reached state with a semantic/content metric, not elapsed time or one screenshot hash.
+5. Repeat until the success rate and any alternate states are quantified.
+
+Do not begin another graphics hypothesis cycle until this baseline is reliable enough to identify the same
+failing submit/pass across runs. If savedata or guest state prevents that, fix the reproducer first.
+
+## Tooling milestones
+
+### 1. Immutable GPU capture/replay (#514)
+
+Capture a failing draw-carrying frame locally: ordered draws, render-target transitions, decoded GPU state,
+shader code, resource tables, referenced VB/CB/texture bytes, initial RT state, and alias/dependency metadata.
+Replay it without loading Unity and require live-versus-replay state and output hashes to match. Captures
+contain game data and remain gitignored; only minimized synthetic fixtures may be committed.
+
+This converts a multi-minute, nondeterministic boot experiment into a revision-locked test that runs in
+seconds and can be bisected, probed, and compared.
+
+### 2. Strict shader/resource contract (#515)
+
+Validate the descriptor interface declared by generated SPIR-V against the runtime `ShaderResourceTable`:
+set/binding, descriptor class, stage visibility, guest address, byte range, stride, format, and statically
+known accessed offsets. Diagnostic mode must reject missing, ambiguous, wrong-type, or undersized resources
+before Vulkan robust-buffer behavior silently turns them into zeros.
+
+### 3. Structured per-draw probes
+
+On a replayed draw, expose vertex position/color/UV, raw texture samples, constant-buffer factors,
+pre-blend fragment output, and final attachment output in a standard report. Existing switches such as
+`PROSPER_RENDER_TESTPS`, `PROSPER_TESTTEX`, `PROSPER_CBUFLOG`, and draw isolation are useful primitives;
+the goal is one repeatable probe rather than another collection of live-only A/B runs.
+
+## Decision boundary
+
+Do not start a persistent render-target-manager rewrite, another whole-stack audit, or an HLE workaround
+based only on the historical #300 comments. Let the current baseline and immutable replay identify the
+first bad contract. Once identified, implement the real behavior, derive a synthetic regression where
+possible, then add a late-state local snapshot/checkpoint guard for the repaired Messenger path.

--- a/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
+++ b/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
@@ -1,5 +1,11 @@
 # NEXT STEP — bindless-dynamic vertex fetch → the first real game frame
 
+> **SUPERSEDED (2026-07-11).** This document describes an old state where the Messenger vertex shader
+> did not recompile. Dynamic vertex-fetch resolution, per-PC descriptor provenance, and the associated
+> resource plumbing have since landed. Do not use the TL;DR, reproduction output, or expected result
+> below as current status. Start from `MESSENGER_BLACK_RENDER.md` and GitHub issues #299, #300, #514,
+> and #515. The remainder is retained as implementation history.
+>
 > **Project context (read `../../CLAUDE.md` first).** prosper is a **PS5→PC compatibility layer** —
 > "Wine/Proton for PS5" — that runs a **legally-owned** game natively by reimplementing Sony's published
 > library ABI and translating the console's GPU commands + RDNA2 shaders to Vulkan/SPIR-V. This is

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -24,9 +24,21 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
 
 ---
 
-## Current status (2026-07-05) — at a glance
+## Current status (2026-07-11) - at a glance
 
-*(The milestone log below is a historical, append-only record; this section is the current truth.)*
+- **Messenger renders through gameplay submission:** the former GfxDevice, draw-submission, and
+  bindless vertex-fetch blockers are solved. The intro, title, and menu render; a real multi-pass
+  gameplay frame is submitted, but its scene content remains black. The save-game list is also missing.
+- **No current-master root cause is established:** #300 accumulated contradictory diagnoses on changing
+  revisions, and the former missing binding-9 vertex-color resource was later observed populated while
+  the level remained black. #299 has not been independently traced, so SaveData/HLE remains plausible.
+- **Immediate milestone:** create an immutable local GPU frame capture/replay, then strictly validate the
+  generated SPIR-V descriptor interface against runtime resources. Canonical evidence and next steps are
+  in `docs/MESSENGER_BLACK_RENDER.md` and GitHub issues #299, #300, #514, and #515.
+
+## Historical status (2026-07-05) - retained for the milestone log
+
+*(The milestone log below is a historical, append-only record. Claims in it are not current status.)*
 
 - ✅ **M0–M3 done:** loader (SELF/ELF → relocatable image → multi-module link → NID binding), host
   execution (mmap + import-trap dispatch), and enough libkernel/libc/services that the game boots

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -1,64 +1,54 @@
-# AGENTS.md — rendering snapshot tests
+# AGENTS.md - rendering snapshot tests
 
-Golden-image regression guard for game rendering. **Run this whenever you touch
-anything that can change rendered output** (the RDNA2→SPIR-V recompiler, AGC/PM4
-decode, render state, texture detile, the executor/present path) — before AND
-after your change. A blued title or a mis-decoded texture flips a stored pixel
-hash, so you catch the regression instead of shipping it.
+Real-game rendering regression guard. Run this whenever a change can affect
+rendered output: RDNA2-to-SPIR-V recompilation, AGC/PM4 decoding, render state,
+texture detiling, or executor/present behavior.
 
-This exists because two recompiler fixes for *other* titles silently blued The
-Messenger to a full-screen clear (PR #227). Nothing had guarded a real game's
-output. Now something does.
+The current Messenger guard records the richest frame's distinct-color count
+across the boot. This catches a render collapsed to a clear while tolerating the
+title's run-to-run frame variance.
 
-## Run it
+## Run It
 
 ```bash
-# from prosper/ , with build-linux/boot_trace built for your change
-python3 tools/snapshot/snapshot.py check            # all snapshots; EXIT 1 on any diff
-python3 tools/snapshot/snapshot.py check messenger-title
-python3 tools/snapshot/snapshot.py update [name...]  # re-baseline AFTER an intended output change
-python3 tools/snapshot/snapshot.py verify [name...]  # capture twice; is the frame deterministic?
-python3 tools/snapshot/snapshot.py list
+# From prosper/, with build-linux/boot_trace built for the change.
+python3 tools/snapshot/snapshot.py check
+python3 tools/snapshot/snapshot.py check messenger-scene
 ```
 
-`check` failing → the offending screenshot + boot log are saved to
-`failures/<name>.{bmp,log}`. Eyeball the BMP
-(`python3 -c 'from PIL import Image; Image.open("failures/x.bmp").save("x.png")'`).
-If your change **intentionally** alters output, re-run `update` and commit the new
-hash in `snapshots.json` — with a note in your PR on why the pixels moved.
+On failure, the screenshot and boot log are written to
+`tools/snapshot/failures/<name>.{bmp,log}`. Convert a BMP for inspection with:
 
-## Non-negotiables
+```bash
+python3 -c 'from PIL import Image; Image.open("x.bmp").save("x.png")'
+```
 
-- **Local only, NEVER CI.** Game dumps are gitignored and must never be committed.
-  Only the pixel **hashes** live in the repo (`snapshots.json`) — a hash is a
-  checksum, not game imagery (same rule as [[pr-screenshots]]: no game imagery in
-  mainline).
-- **`verify` before you trust a new snapshot.** A game boot has threads; if the
-  target frame lands in a transient (loading→title) it won't be deterministic.
-  Pick F in a **static** window (a title/menu loop re-renders the same composite,
-  so its hash is stable). Only F ≤ 59 (and multiples of 10) are dumped.
-- **Don't `update` to make a red `check` green.** A `check` failure is either a
-  real regression (fix it) or an intended change (re-baseline *and explain it*).
-  Silently re-baselining a regression defeats the whole point.
+## Non-Negotiables
 
-## How a frame is targeted
+- Local only, never CI. Game dumps and captured imagery must not be committed.
+- Only thresholds or pixel hashes live in `snapshots.json`.
+- Do not lower `min_colors` merely to make a failing check pass. Investigate the
+  regression, or explain an intentional baseline change in the PR.
 
-`RENDER_EVERY=1` renders every draw-carrying submit, so `frame_<F>.bmp` is the
-F-th draw submit's render. `RENDER_SCALE` shrinks the framebuffer (faster; the
-hash is per-scale, so keep `scale` fixed per snapshot). The tool runs a
-uniquely-named copy of `boot_trace` so a concurrent agent's `pkill -x boot_trace`
-can't kill your capture.
+## Guard Modes
 
-## Adding a snapshot (e.g. another title / a specific screen)
+- `min_colors`: run the full configured timeout, inspect every dumped frame,
+  and require the richest frame to meet the threshold. `messenger-scene` uses
+  this because exact frame hashes are not stable across threaded boots.
+- `frame` plus `hash`: target one draw-submit frame. Use `verify <name>` before
+  trusting a new exact baseline, then `update <name>` after an intentional pixel
+  change.
 
-1. Add an entry to `snapshots.json`: `name`, `dump` (the `*-app0` dir under
-   `PROSPER_GAME_ROOT`), `frame`, `scale`, optional per-title `env` (e.g. a title
-   that needs extra guest args). Leave `hash` empty.
-2. `verify <name>` — must print DETERMINISTIC. If not, move `frame` later / to a
-   more static screen.
-3. `update <name>` — stores the baseline. Commit `snapshots.json`.
+`RENDER_SCALE` shrinks the framebuffer. Keep `scale` fixed for either mode.
 
-## Env
+## Adding A Snapshot
 
-- `PROSPER_GAME_ROOT`  — dir holding the `*-app0` dumps (default `/mnt/c/Users/matti/repos/ps5ys`)
-- `PROSPER_BOOT_TRACE` — boot_trace path (default `<prosper>/build-linux/boot_trace`)
+Add `name`, `dump`, `scale`, `timeout`, optional `env`, and either:
+
+- a justified `min_colors` threshold for a run-level content guard; or
+- `frame` plus an exact `hash`, established with `verify` then `update`.
+
+## Environment
+
+- `PROSPER_GAME_ROOT`: directory holding `*-app0` dumps; defaults to the repo.
+- `PROSPER_BOOT_TRACE`: boot_trace path; defaults to `build-linux/boot_trace`.

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -1,44 +1,38 @@
-# Rendering snapshot tests (golden-image, run locally)
+# Rendering Regression Snapshots
 
-Catches rendering regressions in real games: a change that blanks a title, breaks
-a shader recompile, or mis-decodes a texture flips a stored pixel hash. Any agent
-can run it before/after a change.
+This local tool catches real-game rendering regressions. A snapshot can use an
+exact frame hash, or a run-level content metric for titles whose threaded boots
+do not land on a deterministic frame.
 
-**Local only — never CI.** The game dumps are gitignored and must not be
-committed, so this can't run in CI. Only the small pixel **hashes** live in the
-repo (`snapshots.json`) — a hash is a checksum, not game imagery.
+Game dumps and screenshots are local and gitignored, so this does not run in
+CI. Only hashes or content thresholds live in `snapshots.json`.
 
 ## Run
 
 ```bash
-# from prosper/ (build boot_trace first: build-linux/boot_trace)
-python3 tools/snapshot/snapshot.py check           # all snapshots; exit 1 on any diff
-python3 tools/snapshot/snapshot.py check messenger-title
-python3 tools/snapshot/snapshot.py update           # (re)capture baselines after an INTENDED change
-python3 tools/snapshot/snapshot.py verify           # capture twice; confirm a frame is deterministic
-python3 tools/snapshot/snapshot.py list
+# From prosper/, after building build-linux/boot_trace.
+python3 tools/snapshot/snapshot.py check
+python3 tools/snapshot/snapshot.py check messenger-scene
 ```
 
-On a mismatch, `check` writes the offending screenshot + boot log to
-`tools/snapshot/failures/<name>.{bmp,log}` and returns non-zero. Convert the BMP
-to PNG to eyeball it (`python3 -c 'from PIL import Image; Image.open("x.bmp").save("x.png")'`).
+On failure, `check` writes the screenshot and boot log to
+`tools/snapshot/failures/<name>.{bmp,log}` and exits nonzero.
 
-## How it targets a frame
+## Guard Modes
 
-`RENDER_EVERY=1` renders every draw-carrying submit, so `frame_<F>.bmp` is the
-F-th draw submit's render. Pick **F in a stable-content window** — a static
-title/menu loop re-renders the same composite each submit, so its hash is stable.
-Always `verify` a new snapshot's frame before trusting its baseline; if it's
-NON-DETERMINISTIC, move F later (or to a more static screen). Only F ≤ 59 (or
-multiples of 10) are dumped by the renderer.
+- `min_colors`: run for the configured timeout and require the richest rendered
+  frame to reach a distinct-color threshold. The current `messenger-scene`
+  guard uses this mode and tolerates frame timing variance.
+- `frame` plus `hash`: compare one targeted draw-submit frame exactly. Run
+  `verify <name>` before establishing its baseline with `update <name>`.
 
-## Adding a snapshot
+## Adding A Snapshot
 
-Add an entry to `snapshots.json` (`name`, `dump` = the `*-app0` dir under
-`PROSPER_GAME_ROOT`, `frame`, `scale`, optional per-title `env`), then
-`verify` it, then `update` to store the baseline hash.
+Add an entry to `snapshots.json` with `name`, `dump`, `scale`, `timeout`, optional
+per-title `env`, and either a justified `min_colors` threshold or a verified
+`frame`/`hash` baseline.
 
-## Env
+## Environment
 
-- `PROSPER_GAME_ROOT`  — dir holding the `*-app0` dumps (default `/mnt/c/Users/matti/repos/ps5ys`)
-- `PROSPER_BOOT_TRACE` — boot_trace path (default `<prosper>/build-linux/boot_trace`)
+- `PROSPER_GAME_ROOT`: directory holding `*-app0` dumps; defaults to the repo.
+- `PROSPER_BOOT_TRACE`: boot_trace path; defaults to `build-linux/boot_trace`.


### PR DESCRIPTION
## Summary

- replace stale current-frontier pointers with a revisioned Messenger black-render status
- mark the old vertex-fetch and July 5 roadmap states as historical
- document evidence requirements, current unknowns, and the capture/replay + resource-validation milestones
- separate #299 from #300 until independently traced
- record the implemented input-replay capabilities and residual nondeterminism

## Verification

- `git diff --check`
- referenced documentation paths verified locally
- documentation-only change; no runtime tests required

Fixes #516
