### PR TITLE
feat(gpu): add immutable realized-submit capture replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.sprx
 *.self
 eboot.bin
+*.prgcap
 
 # ---- Build output ----
 /prosper/build/

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -26,6 +26,12 @@ if(PROSPER_SRC)
   add_library(prosper_core STATIC ${PROSPER_SRC})
   target_include_directories(prosper_core PUBLIC src)
   target_compile_definitions(prosper_core PRIVATE PROSPER_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+  execute_process(COMMAND git rev-parse --verify HEAD WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/.."
+                  OUTPUT_VARIABLE PROSPER_GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(NOT PROSPER_GIT_REVISION)
+    set(PROSPER_GIT_REVISION "unknown")
+  endif()
+  target_compile_definitions(prosper_core PRIVATE PROSPER_GIT_REVISION="${PROSPER_GIT_REVISION}")
   find_package(Threads REQUIRED)
   target_link_libraries(prosper_core PUBLIC Threads::Threads)
 endif()
@@ -336,6 +342,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_shader_resources PRIVATE prosper_core)
   add_test(NAME shader_resource_contract COMMAND test_shader_resources)
 
+  # Versioned realized-draw capture: explicit round-trip, overlapping-resource alias preservation,
+  # owned replay backing, and corrupt/truncated input rejection. Pure; no Vulkan or game dump.
+  add_executable(test_gpu_capture tests/test_gpu_capture.cpp)
+  target_link_libraries(test_gpu_capture PRIVATE prosper_core)
+  add_test(NAME gpu_capture_roundtrip COMMAND test_gpu_capture)
+
   # Front-half resource-table builder + V# descriptor decode (agc_shader_layout.cpp): shader user_data
   # + user-data SGPRs -> ShaderResourceTable (constant buffers, stage 1). Pure/cross-platform.
   add_executable(test_build_shader_resources tests/test_build_shader_resources.cpp)
@@ -441,6 +453,19 @@ if(TARGET prosper_core)
       target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
       target_link_libraries(boot_trace PRIVATE prosper_live_renderer)
+
+      # Local-only realized-submit replayer (#514): no guest boot, reads a versioned capture whose game
+      # data remains gitignored, renders it through the same live backend, and checks the captured hash.
+      add_executable(gpu_replay tools/gpu_replay/gpu_replay.cpp)
+      target_include_directories(gpu_replay PRIVATE src tests)
+      target_link_libraries(gpu_replay PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
+
+      # Capture -> serialize -> owned replay backing -> SAME live renderer -> pixels. This specifically
+      # proves replay textures do not dereference the captured guest VA and still sample exact bytes.
+      add_executable(test_gpu_capture_render tests/test_gpu_capture_render.cpp)
+      target_include_directories(test_gpu_capture_render PRIVATE src tests tools/boot_trace)
+      target_link_libraries(test_gpu_capture_render PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
+      add_test(NAME gpu_capture_render_replay COMMAND test_gpu_capture_render)
 
       # screenshot: run a game and capture a PNG every N frames (default 60) until M shots (default
       # 30). Reuses boot_program + the shared live renderer; writes zlib-compressed PNGs (needs zlib).

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -102,6 +102,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 if (!t) return;
                 for (auto& r : t->resources) {
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
+                    // Captured replays preserve the logical guest address for RT identity but provide
+                    // owned bytes here. Production resources leave host_data null and use guest memory.
+                    auto copy_resource = [&](uint8_t* dst, uint64_t addr, size_t n) -> size_t {
+                        if (!r.host_data) return safe_copy(dst, addr, n);
+                        if (addr < r.gpu_addr) return 0;
+                        uint64_t off = addr - r.gpu_addr;
+                        if (off >= r.host_data_size) return 0;
+                        size_t take = static_cast<size_t>(std::min<uint64_t>(n, r.host_data_size - off));
+                        std::memcpy(dst, r.host_data + off, take);
+                        return take;
+                    };
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
@@ -186,9 +197,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     std::vector<uint8_t> lin(comp, 0);
                                     if (ctiled) {
                                         std::vector<uint8_t> traw(stride, 0);
-                                        safe_copy(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
+                                        copy_resource(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
                                         prosper::gpu::detile_elements(lin.data(), traw.data(), stride, bw, bh, cb, r.tile_mode);
-                                    } else safe_copy(lin.data(), r.gpu_addr + (uint64_t)fface * stride, comp);
+                                    } else copy_resource(lin.data(), r.gpu_addr + (uint64_t)fface * stride, comp);
                                     std::vector<uint8_t> face((size_t)tw * th * 4, 0);
                                     prosper::gpu::bc_decode_surface(face.data(), lin.data(), lin.size(), tw, th, r.format);
                                     std::memcpy(slice, face.data(), face.size());
@@ -197,9 +208,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     size_t stride = ctiled ? prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0) : fb;
                                     if (ctiled) {
                                         std::vector<uint8_t> traw(stride, 0);
-                                        safe_copy(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
+                                        copy_resource(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
                                         prosper::gpu::detile_surface(slice, traw.data(), tw, th, r.tile_mode, 0);
-                                    } else safe_copy(slice, r.gpu_addr + (uint64_t)fface * stride, fb);
+                                    } else copy_resource(slice, r.gpu_addr + (uint64_t)fface * stride, fb);
                                 }
                             }
                             cube_done = true;
@@ -220,10 +231,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (tiled) {
                                 size_t tbytes = prosper::gpu::tiled_elements_bytes(bw, bh, bcb, r.tile_mode);
                                 std::vector<uint8_t> traw(tbytes, 0);
-                                safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                copy_resource(traw.data(), r.gpu_addr, tbytes);
                                 prosper::gpu::detile_elements(lin.data(), traw.data(), tbytes, bw, bh, bcb, r.tile_mode);
                             } else {
-                                safe_copy(lin.data(), r.gpu_addr, comp_bytes);
+                                copy_resource(lin.data(), r.gpu_addr, comp_bytes);
                             }
                             prosper::gpu::bc_decode_surface(texstore.back().data(), lin.data(), lin.size(), tw, th, r.format);
                         } else if (f16) {
@@ -244,11 +255,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (tiled) {
                                 size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
-                                size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
-                                if (got < hlin.size()) safe_copy(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
+                                size_t got = copy_resource(traw.data(), r.gpu_addr, tbytes);
+                                if (got < hlin.size()) copy_resource(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
                                 else prosper::gpu::detile_surface(hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
-                                safe_copy(hlin.data(), r.gpu_addr, hlin.size());
+                                copy_resource(hlin.data(), r.gpu_addr, hlin.size());
                             }
                             for (size_t t = 0; t < (size_t)tw * th; t++) {
                                 uint8_t* p = &texstore.back()[t * 4];
@@ -272,7 +283,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (tiled) {
                                 size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
-                                size_t got = safe_copy(traw.data(), r.gpu_addr, tbytes);
+                                size_t got = copy_resource(traw.data(), r.gpu_addr, tbytes);
                                 // PROSPER_DUMP_RAWTILE (narrow path): the single/dual-channel RAW TILED bytes,
                                 // once per address, for offline 8-bpp de-swizzle sweeps (the SDF font atlas).
                                 if (getenv("PROSPER_DUMP_RAWTILE") && got >= nlin.size() && tw <= 2048 && th <= 1024) {
@@ -285,10 +296,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                             fprintf(stderr, "[render] narrow raw tiled -> %s (%zu, bpt=%u)\n", bn, traw.size(), bpt); fflush(stderr); }
                                     }
                                 }
-                                if (got < nlin.size()) safe_copy(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
+                                if (got < nlin.size()) copy_resource(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
                                 else prosper::gpu::detile_surface(nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
-                                safe_copy(nlin.data(), r.gpu_addr, nlin.size());
+                                copy_resource(nlin.data(), r.gpu_addr, nlin.size());
                             }
                             for (size_t t = 0; t < (size_t)tw * th; t++) {
                                 uint8_t v = nlin[t * bpt];   // first (coverage) channel
@@ -297,7 +308,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             narrow_done = true;   // already detiled+expanded; skip the 32-bpp auto-detile below
                         } else {
-                            safe_copy(texstore.back().data(), r.gpu_addr, nb);
+                            copy_resource(texstore.back().data(), r.gpu_addr, nb);
                         }
                         // PROSPER_DUMP_RAWTEX: write the raw tiled RGBA bytes (pre-detile) to a .bin for
                         // offline swizzle experimentation.
@@ -331,7 +342,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
                             size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
                             std::vector<uint8_t> tiled(tiled_bytes, 0);
-                            size_t got = safe_copy(tiled.data(), r.gpu_addr, tiled_bytes);
+                            size_t got = copy_resource(tiled.data(), r.gpu_addr, tiled_bytes);
                             if (got < nb)
                                 // The padded tiled buffer's tail (th rounded to whole 32-row tiles) runs past
                                 // the real backing: fall back to the width*height linear bytes copied above
@@ -417,7 +428,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned
                         if (nb >= 4) {
                             std::vector<uint8_t> tmp(nb, 0);
-                            if (safe_copy(tmp.data(), r.gpu_addr, nb) > 0)
+                            if (copy_resource(tmp.data(), r.gpu_addr, nb) > 0)
                                 fr.dwords.assign((const uint32_t*)tmp.data(), (const uint32_t*)(tmp.data() + nb));
                         }
                         if (fr.dwords.empty()) fr.dwords.assign(64, 0);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1,0 +1,429 @@
+#include "gpu_capture.hpp"
+
+#include "bc_decode.hpp"
+#include "tile.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <bit>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <utility>
+
+namespace prosper::gpu {
+namespace {
+
+constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
+constexpr uint32_t kVersion = 1;
+constexpr uint32_t kEndian = 0x01020304u;
+constexpr uint64_t kMaxFileBytes = 4ull << 30;
+constexpr uint64_t kMaxBlobBytes = 1ull << 30;
+constexpr uint64_t kMaxTotalBlobBytes = 3ull << 30;
+constexpr uint32_t kMaxDraws = 65536;
+constexpr uint32_t kMaxResources = 65536;
+constexpr uint32_t kMaxShaderWords = 16u << 20;
+constexpr uint32_t kMaxStringBytes = 1u << 20;
+
+struct Writer {
+    std::vector<uint8_t> data;
+    void raw(const void* p, size_t n) {
+        if (!n) return;
+        const auto* b = static_cast<const uint8_t*>(p);
+        data.insert(data.end(), b, b + n);
+    }
+    void u8(uint8_t v) { data.push_back(v); }
+    void u32(uint32_t v) { for (unsigned i = 0; i < 4; ++i) data.push_back(uint8_t(v >> (8 * i))); }
+    void u64(uint64_t v) { for (unsigned i = 0; i < 8; ++i) data.push_back(uint8_t(v >> (8 * i))); }
+    void f32(float v) { u32(std::bit_cast<uint32_t>(v)); }
+    void string(const std::string& s) { u32(static_cast<uint32_t>(s.size())); raw(s.data(), s.size()); }
+    void words(const std::vector<uint32_t>& v) { u32(static_cast<uint32_t>(v.size())); for (auto x : v) u32(x); }
+    void bytes(const std::vector<uint8_t>& v) { u64(v.size()); raw(v.data(), v.size()); }
+};
+
+struct Reader {
+    const uint8_t* p = nullptr;
+    size_t left = 0;
+    std::string* error = nullptr;
+    bool take(void* dst, size_t n) {
+        if (n > left) { if (error && error->empty()) *error = "truncated capture"; return false; }
+        if (!n) return true;
+        std::memcpy(dst, p, n); p += n; left -= n; return true;
+    }
+    bool u8(uint8_t& v) { return take(&v, 1); }
+    bool u32(uint32_t& v) {
+        uint8_t b[4]; if (!take(b, 4)) return false;
+        v = uint32_t(b[0]) | uint32_t(b[1]) << 8 | uint32_t(b[2]) << 16 | uint32_t(b[3]) << 24;
+        return true;
+    }
+    bool u64(uint64_t& v) {
+        uint8_t b[8]; if (!take(b, 8)) return false; v = 0;
+        for (unsigned i = 0; i < 8; ++i) v |= uint64_t(b[i]) << (8 * i);
+        return true;
+    }
+    bool f32(float& v) { uint32_t x; if (!u32(x)) return false; v = std::bit_cast<float>(x); return true; }
+    bool string(std::string& s) {
+        uint32_t n; if (!u32(n)) return false;
+        if (n > kMaxStringBytes || n > left) { if (error) *error = "invalid string length"; return false; }
+        s.assign(reinterpret_cast<const char*>(p), n); p += n; left -= n; return true;
+    }
+    bool words(std::vector<uint32_t>& v) {
+        uint32_t n; if (!u32(n)) return false;
+        if (n > kMaxShaderWords || uint64_t(n) * 4 > left) { if (error) *error = "invalid word-vector length"; return false; }
+        v.resize(n); for (auto& x : v) if (!u32(x)) return false; return true;
+    }
+    bool bytes(std::vector<uint8_t>& v) {
+        uint64_t n; if (!u64(n)) return false;
+        if (n > kMaxBlobBytes || n > left || n > std::numeric_limits<size_t>::max()) {
+            if (error) *error = "invalid blob length"; return false;
+        }
+        v.resize(static_cast<size_t>(n)); return take(v.data(), v.size());
+    }
+};
+
+void write_pipeline(Writer& w, const ResolvedPipelineState& p) {
+    w.u32(p.topology); w.u32(p.color0_format); w.u8(p.has_clear_color); for (float v : p.clear_color) w.f32(v);
+    w.u8(p.depth_test_enable); w.u8(p.depth_write_enable); w.u32(p.depth_compare_op);
+    w.f32(p.depth_clear_value); w.u32(p.stencil_clear_value); w.u8(p.stencil_enable);
+    for (auto v : p.stencil_compare_op) w.u32(v); for (auto v : p.stencil_fail_op) w.u32(v);
+    for (auto v : p.stencil_pass_op) w.u32(v); for (auto v : p.stencil_depth_fail_op) w.u32(v);
+    for (auto v : p.stencil_ref) w.u32(v); for (auto v : p.stencil_op_val) w.u32(v);
+    for (auto v : p.stencil_compare_mask) w.u32(v); for (auto v : p.stencil_write_mask) w.u32(v);
+    w.u8(p.blend_enable); w.u32(p.src_color_blend_factor); w.u32(p.dst_color_blend_factor);
+    w.u32(p.color_blend_op); w.u32(p.src_alpha_blend_factor); w.u32(p.dst_alpha_blend_factor);
+    w.u32(p.alpha_blend_op); w.u32(p.color_write_mask); w.u8(p.has_viewport);
+    w.f32(p.viewport_x); w.f32(p.viewport_y); w.f32(p.viewport_w); w.f32(p.viewport_h);
+    w.f32(p.min_depth); w.f32(p.max_depth); w.u32(p.cull_mode); w.u32(p.front_face); w.u32(p.polygon_mode);
+}
+
+bool read_pipeline(Reader& r, ResolvedPipelineState& p) {
+    uint8_t b;
+    if (!r.u32(p.topology) || !r.u32(p.color0_format) || !r.u8(b)) return false; p.has_clear_color = b != 0;
+    for (float& v : p.clear_color) if (!r.f32(v)) return false;
+    if (!r.u8(b)) return false; p.depth_test_enable = b != 0;
+    if (!r.u8(b)) return false; p.depth_write_enable = b != 0;
+    if (!r.u32(p.depth_compare_op) || !r.f32(p.depth_clear_value) || !r.u32(p.stencil_clear_value) || !r.u8(b)) return false;
+    p.stencil_enable = b != 0;
+    for (auto& v : p.stencil_compare_op) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_fail_op) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_pass_op) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_depth_fail_op) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_ref) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_op_val) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_compare_mask) if (!r.u32(v)) return false;
+    for (auto& v : p.stencil_write_mask) if (!r.u32(v)) return false;
+    if (!r.u8(b)) return false; p.blend_enable = b != 0;
+    if (!r.u32(p.src_color_blend_factor) || !r.u32(p.dst_color_blend_factor) || !r.u32(p.color_blend_op) ||
+        !r.u32(p.src_alpha_blend_factor) || !r.u32(p.dst_alpha_blend_factor) || !r.u32(p.alpha_blend_op) ||
+        !r.u32(p.color_write_mask) || !r.u8(b)) return false;
+    p.has_viewport = b != 0;
+    return r.f32(p.viewport_x) && r.f32(p.viewport_y) && r.f32(p.viewport_w) && r.f32(p.viewport_h) &&
+           r.f32(p.min_depth) && r.f32(p.max_depth) && r.u32(p.cull_mode) && r.u32(p.front_face) &&
+           r.u32(p.polygon_mode);
+}
+
+void write_resource(Writer& w, const GpuCapturedResource& c) {
+    const auto& r = c.resource;
+    w.u32(static_cast<uint32_t>(r.cls)); w.u32(static_cast<uint32_t>(r.format));
+    w.u32(r.num_components); w.u32(r.binding); w.u64(r.gpu_addr); w.u32(r.size); w.u32(r.stride);
+    w.u32(r.srt_offset); w.u32(r.sgpr_base); w.u32(r.fetch_pc); w.u32(r.img_dim);
+    w.u32(r.width); w.u32(r.height); w.u32(r.tile_mode); w.u8(r.srgb); w.u32(r.sampler_sgpr_base);
+    w.u32(r.mag_filter); w.u32(r.min_filter); w.u32(r.mip_filter); for (auto v : r.addr_uvw) w.u32(v);
+    w.u32(r.border_color_type); w.f32(r.min_lod); w.f32(r.max_lod); w.f32(r.lod_bias);
+    w.u32(r.max_aniso_ratio); w.u32(r.depth_compare_func); w.u32(r.unnormalized);
+    for (auto v : r.swizzle) w.u32(v);
+    w.u32(c.blob_index); w.u64(c.blob_offset);
+}
+
+bool read_resource(Reader& rd, GpuCapturedResource& c) {
+    auto& r = c.resource; uint32_t cls, fmt; uint8_t b;
+    if (!rd.u32(cls) || cls > static_cast<uint32_t>(ResourceClass::StorageImage) ||
+        !rd.u32(fmt) || fmt > static_cast<uint32_t>(DataFormat::Float10_11_11)) return false;
+    r.cls = static_cast<ResourceClass>(cls); r.format = static_cast<DataFormat>(fmt);
+    if (!rd.u32(r.num_components) || !rd.u32(r.binding) || !rd.u64(r.gpu_addr) || !rd.u32(r.size) ||
+        !rd.u32(r.stride) || !rd.u32(r.srt_offset) || !rd.u32(r.sgpr_base) || !rd.u32(r.fetch_pc) ||
+        !rd.u32(r.img_dim) || !rd.u32(r.width) || !rd.u32(r.height) || !rd.u32(r.tile_mode) || !rd.u8(b)) return false;
+    r.srgb = b != 0;
+    if (!rd.u32(r.sampler_sgpr_base) || !rd.u32(r.mag_filter) || !rd.u32(r.min_filter) || !rd.u32(r.mip_filter)) return false;
+    for (auto& v : r.addr_uvw) if (!rd.u32(v)) return false;
+    if (!rd.u32(r.border_color_type) || !rd.f32(r.min_lod) || !rd.f32(r.max_lod) || !rd.f32(r.lod_bias) ||
+        !rd.u32(r.max_aniso_ratio) || !rd.u32(r.depth_compare_func) || !rd.u32(r.unnormalized)) return false;
+    for (auto& v : r.swizzle) if (!rd.u32(v)) return false;
+    return rd.u32(c.blob_index) && rd.u64(c.blob_offset);
+}
+
+void write_table(Writer& w, const GpuCapturedTable& t) {
+    w.u8(t.present); w.u32(static_cast<uint32_t>(t.resources.size()));
+    for (const auto& r : t.resources) write_resource(w, r);
+}
+
+bool read_table(Reader& r, GpuCapturedTable& t) {
+    uint8_t b; uint32_t n; if (!r.u8(b) || !r.u32(n) || n > kMaxResources) return false;
+    t.present = b != 0; t.resources.resize(n); for (auto& x : t.resources) if (!read_resource(r, x)) return false;
+    if (!t.present && n != 0) { if (r.error) *r.error = "absent resource table has resources"; return false; }
+    return true;
+}
+
+uint64_t checked_mul(uint64_t a, uint64_t b) {
+    return a && b > std::numeric_limits<uint64_t>::max() / a ? std::numeric_limits<uint64_t>::max() : a * b;
+}
+
+uint64_t resource_footprint(const ShaderResource& r) {
+    uint64_t result = r.size;
+    if (r.cls != ResourceClass::Texture && r.cls != ResourceClass::StorageImage) return result;
+    const uint64_t faces = r.img_dim == 3u ? 6u : 1u;
+    uint32_t w = r.width ? r.width : 4, h = r.height ? r.height : 4;
+    const uint32_t bc = bc_block_bytes(r.format);
+    uint64_t decoded = 0;
+    if (bc) {
+        uint32_t bw = (w + 3) / 4, bh = (h + 3) / 4;
+        decoded = tile_mode_is_tiled(r.tile_mode) ? tiled_elements_bytes(bw, bh, bc, r.tile_mode)
+                                                  : checked_mul(checked_mul(bw, bh), bc);
+    } else {
+        uint32_t bpt = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
+        const bool f16 = r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8);
+        if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+        decoded = tile_mode_is_tiled(r.tile_mode) ? tiled_surface_bytes(w, h, r.tile_mode, 0, bpt)
+                                                  : checked_mul(checked_mul(w, h), bpt);
+    }
+    decoded = checked_mul(decoded, faces);
+    return std::max(result, decoded);
+}
+
+struct Interval { uint64_t begin, end; };
+
+bool collect_intervals(const std::vector<DrawItem>& items, std::vector<Interval>& intervals, std::string& error) {
+    uint64_t total = 0;
+    auto add_table = [&](const ShaderResourceTable* t) -> bool {
+        if (!t) return true;
+        for (const auto& r : t->resources) {
+            uint64_t n = resource_footprint(r);
+            if (!n) continue;
+            if (n > kMaxBlobBytes || r.gpu_addr > std::numeric_limits<uint64_t>::max() - n) {
+                error = "resource capture range is invalid or exceeds 1 GiB"; return false;
+            }
+            intervals.push_back({r.gpu_addr, r.gpu_addr + n});
+        }
+        return true;
+    };
+    for (const auto& d : items) if (!add_table(d.vrt.get()) || !add_table(d.prt.get())) return false;
+    std::sort(intervals.begin(), intervals.end(), [](auto a, auto b) { return a.begin < b.begin; });
+    std::vector<Interval> merged;
+    for (auto x : intervals) {
+        if (!merged.empty() && x.begin <= merged.back().end) merged.back().end = std::max(merged.back().end, x.end);
+        else merged.push_back(x);
+    }
+    for (auto x : merged) {
+        uint64_t n = x.end - x.begin;
+        if (total > kMaxTotalBlobBytes - n) { error = "capture resource data exceeds 3 GiB"; return false; }
+        total += n;
+    }
+    intervals = std::move(merged); return true;
+}
+
+bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& intervals,
+                   GpuCapturedTable& dst, std::string& error) {
+    dst.present = src != nullptr;
+    if (!src) return true;
+    for (const auto& r : src->resources) {
+        GpuCapturedResource c; c.resource = r; c.resource.host_data = nullptr; c.resource.host_data_size = 0;
+        uint64_t n = resource_footprint(r);
+        if (n) {
+            auto it = std::find_if(intervals.begin(), intervals.end(), [&](auto x) {
+                return x.begin <= r.gpu_addr && r.gpu_addr + n <= x.end;
+            });
+            if (it == intervals.end()) { error = "resource was not assigned to a capture blob"; return false; }
+            c.blob_index = static_cast<uint32_t>(it - intervals.begin()); c.blob_offset = r.gpu_addr - it->begin;
+        }
+        dst.resources.push_back(std::move(c));
+    }
+    return true;
+}
+
+const char* env_or_empty(const char* name) { const char* v = std::getenv(name); return v ? v : ""; }
+
+} // namespace
+
+uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
+    uint64_t h = 1469598103934665603ull;
+    for (size_t i = 0; i < size; ++i) { h ^= data[i]; h *= 1099511628211ull; }
+    return h;
+}
+
+bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
+                        const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error) {
+    error.clear(); out = {}; out.metadata = metadata;
+    if (items.empty() || items.size() > kMaxDraws) { error = "capture must contain 1..65536 draws"; return false; }
+    if (!reader) { error = "capture memory reader is missing"; return false; }
+    std::vector<Interval> intervals;
+    if (!collect_intervals(items, intervals, error)) return false;
+    for (auto x : intervals) {
+        GpuCaptureBlob b; b.guest_addr = x.begin; b.bytes.resize(static_cast<size_t>(x.end - x.begin), 0);
+        b.bytes_read = std::min<uint64_t>(reader(x.begin, b.bytes.data(), b.bytes.size()), b.bytes.size());
+        out.blobs.push_back(std::move(b));
+    }
+    for (const auto& d : items) {
+        GpuCapturedDraw c; c.vs = d.vs; c.fs = d.fs; c.ps = d.ps; c.vertex_count = d.vertex_count;
+        c.indices = d.indices; c.color0_base = d.color0_base;
+        if (!capture_table(d.vrt.get(), intervals, c.vrt, error) || !capture_table(d.prt.get(), intervals, c.prt, error)) return false;
+        out.draws.push_back(std::move(c));
+    }
+    return true;
+}
+
+bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::string& error) {
+    error.clear(); Writer w; w.raw(kMagic, sizeof(kMagic)); w.u32(kVersion); w.u32(kEndian);
+    w.u32(c.metadata.width); w.u32(c.metadata.height); w.u64(c.metadata.submit_index);
+    w.string(c.metadata.revision); w.string(c.metadata.title_id); w.string(c.metadata.input_route); w.string(c.metadata.savedata_dir);
+    w.u32(static_cast<uint32_t>(c.metadata.renderer_env.size()));
+    for (const auto& [name, value] : c.metadata.renderer_env) { w.string(name); w.string(value); }
+    w.u64(c.expected_output_hash); w.u64(c.expected_output_bytes);
+    w.u32(static_cast<uint32_t>(c.blobs.size()));
+    for (const auto& b : c.blobs) { w.u64(b.guest_addr); w.u64(b.bytes_read); w.bytes(b.bytes); }
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& d : c.draws) {
+        w.words(d.vs); w.words(d.fs); write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
+        w.u32(d.vertex_count); w.words(d.indices); w.u64(d.color0_base);
+    }
+    if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
+    std::filesystem::path target(path), temp = target; temp += ".tmp";
+    std::error_code ec; if (target.has_parent_path()) std::filesystem::create_directories(target.parent_path(), ec);
+    std::ofstream f(temp, std::ios::binary | std::ios::trunc);
+    if (!f || !f.write(reinterpret_cast<const char*>(w.data.data()), static_cast<std::streamsize>(w.data.size()))) {
+        error = "cannot write capture temporary file"; return false;
+    }
+    f.close(); std::filesystem::rename(temp, target, ec);
+    if (ec) { std::filesystem::remove(target, ec); ec.clear(); std::filesystem::rename(temp, target, ec); }
+    if (ec) { error = "cannot install capture file: " + ec.message(); return false; }
+    return true;
+}
+
+bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& error) {
+    error.clear(); c = {}; std::error_code ec; uint64_t size = std::filesystem::file_size(path, ec);
+    if (ec || size > kMaxFileBytes || size > std::numeric_limits<size_t>::max()) { error = "invalid capture file size"; return false; }
+    std::vector<uint8_t> bytes(static_cast<size_t>(size)); std::ifstream f(path, std::ios::binary);
+    if (!f || !f.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()))) {
+        error = "cannot read capture file"; return false;
+    }
+    Reader r{bytes.data(), bytes.size(), &error}; char magic[8]; uint32_t version, endian;
+    if (!r.take(magic, 8) || std::memcmp(magic, kMagic, 8) || !r.u32(version) || version != kVersion ||
+        !r.u32(endian) || endian != kEndian) { error = "unsupported capture header"; return false; }
+    auto& m = c.metadata;
+    if (!r.u32(m.width) || !r.u32(m.height) || !r.u64(m.submit_index) || !r.string(m.revision) ||
+        !r.string(m.title_id) || !r.string(m.input_route) || !r.string(m.savedata_dir)) return false;
+    uint32_t ne; if (!r.u32(ne) || ne > 256) { error = "invalid renderer environment count"; return false; }
+    m.renderer_env.resize(ne);
+    for (auto& [name, value] : m.renderer_env) if (!r.string(name) || !r.string(value)) return false;
+    if (!r.u64(c.expected_output_hash) || !r.u64(c.expected_output_bytes)) return false;
+    uint32_t nb; if (!r.u32(nb) || nb > kMaxResources) { error = "invalid blob count"; return false; }
+    uint64_t total = 0; c.blobs.resize(nb);
+    for (auto& b : c.blobs) {
+        if (!r.u64(b.guest_addr) || !r.u64(b.bytes_read) || !r.bytes(b.bytes)) return false;
+        if (b.bytes_read > b.bytes.size() || total > kMaxTotalBlobBytes - b.bytes.size()) { error = "invalid blob metadata"; return false; }
+        total += b.bytes.size();
+    }
+    uint32_t nd; if (!r.u32(nd) || !nd || nd > kMaxDraws) { error = "invalid draw count"; return false; }
+    c.draws.resize(nd);
+    for (auto& d : c.draws) {
+        if (!r.words(d.vs) || !r.words(d.fs) || !read_pipeline(r, d.ps) || !read_table(r, d.vrt) ||
+            !read_table(r, d.prt) || !r.u32(d.vertex_count) || !r.words(d.indices) || !r.u64(d.color0_base)) return false;
+    }
+    if (r.left) { error = "capture has trailing data"; return false; }
+    return true;
+}
+
+bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::string& error) {
+    error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs;
+    out.expected_output_hash = c.expected_output_hash; out.expected_output_bytes = c.expected_output_bytes;
+    auto table = [&](const GpuCapturedTable& src, std::shared_ptr<ShaderResourceTable>& dst) -> bool {
+        if (!src.present) { dst.reset(); return src.resources.empty(); }
+        dst = std::make_shared<ShaderResourceTable>();
+        for (const auto& x : src.resources) {
+            ShaderResource r = x.resource; r.host_data = nullptr; r.host_data_size = 0;
+            if (x.blob_index != 0xFFFFFFFFu) {
+                if (x.blob_index >= out.blobs.size() || x.blob_offset > out.blobs[x.blob_index].bytes.size()) {
+                    error = "resource references an invalid capture blob"; return false;
+                }
+                auto& b = out.blobs[x.blob_index].bytes;
+                uint64_t need = resource_footprint(r);
+                if (need > b.size() - x.blob_offset) { error = "resource footprint exceeds capture blob"; return false; }
+                r.host_data = b.data() + x.blob_offset; r.host_data_size = need;
+            }
+            dst->resources.push_back(r);
+        }
+        return true;
+    };
+    out.items.reserve(c.draws.size());
+    for (const auto& x : c.draws) {
+        DrawItem d; d.vs = x.vs; d.fs = x.fs; d.ps = x.ps; d.vertex_count = x.vertex_count;
+        d.indices = x.indices; d.color0_base = x.color0_base;
+        if (!table(x.vrt, d.vrt) || !table(x.prt, d.prt)) return false;
+        out.items.push_back(std::move(d));
+    }
+    return true;
+}
+
+std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector<DrawItem>& items,
+                                                               uint32_t width, uint32_t height) {
+    const char* path = std::getenv("PROSPER_GPU_CAPTURE"); if (!path || !*path) return {};
+    uint64_t min_draws = 0, max_draws = std::numeric_limits<uint64_t>::max();
+    if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MIN_DRAWS")) min_draws = std::strtoull(v, nullptr, 0);
+    if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MAX_DRAWS")) max_draws = std::strtoull(v, nullptr, 0);
+    if (items.size() < min_draws || items.size() > max_draws) return {};
+    static std::atomic<uint64_t> sequence{0}; static std::atomic<bool> claimed{false};
+    uint64_t current = sequence.fetch_add(1), wanted = 0;
+    if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);
+    if (current != wanted || claimed.exchange(true)) return {};
+    auto pending = std::make_unique<PendingGpuCapture>(); pending->path = path;
+    GpuCaptureMetadata m; m.width = width; m.height = height; m.submit_index = current;
+#ifdef PROSPER_GIT_REVISION
+    m.revision = PROSPER_GIT_REVISION;
+#else
+    m.revision = "unknown";
+#endif
+    if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) m.revision = revision;
+    m.title_id = env_or_empty("PROSPER_CAPTURE_TITLE"); m.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
+    m.savedata_dir = env_or_empty("PROSPER_SAVEDATA_DIR");
+    static const char* render_env[] = {
+        "PROSPER_ALPHA1", "PROSPER_CLEAR_DEBUG", "PROSPER_DEPTH_ALWAYS", "PROSPER_DETILE",
+        "PROSPER_DRAW_ISO", "PROSPER_FS_SPV", "PROSPER_ISO_AT", "PROSPER_ISO_AT2",
+        "PROSPER_ISO_RGB", "PROSPER_ISO_TOL", "PROSPER_NO_BLEND", "PROSPER_NO_CULL",
+        "PROSPER_NO_DEPTH", "PROSPER_NO_STENCIL", "PROSPER_STENCIL_CLEAR", "PROSPER_STENCIL_REPLACE",
+        "PROSPER_NO_SWIZZLE", "PROSPER_NODETILE",
+        "PROSPER_PITCH", "PROSPER_RENDER_NOPS", "PROSPER_RENDER_REFVS", "PROSPER_RENDER_TESTPS",
+        "PROSPER_RTT", "PROSPER_RTT_NOSEED", "PROSPER_RTT_PERTARGET", "PROSPER_TESTTEX"
+    };
+    for (const char* name : render_env) if (const char* value = std::getenv(name)) m.renderer_env.emplace_back(name, value);
+    auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
+        size_t done = 0; constexpr size_t chunk_max = 0x10000;
+        while (done < bytes) {
+            size_t n = std::min(bytes - done, chunk_max);
+            if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
+            std::memcpy(dst + done, reinterpret_cast<const void*>(uintptr_t(addr + done)), n); done += n;
+        }
+        return done;
+    };
+    std::string error;
+    if (!capture_draw_items(items, m, reader, pending->capture, error)) {
+        std::fprintf(stderr, "[gpucap] capture failed: %s\n", error.c_str()); return {};
+    }
+    std::fprintf(stderr, "[gpucap] captured submit %llu: %zu draws, %zu blobs -> %s\n",
+                 static_cast<unsigned long long>(current), items.size(), pending->capture.blobs.size(), path);
+    return pending;
+}
+
+bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
+                                  const std::vector<uint8_t>& output, std::string& error) {
+    if (!pending) return true;
+    pending->capture.expected_output_bytes = output.size(); pending->capture.expected_output_hash = gpu_capture_hash(output);
+    if (!write_gpu_capture(pending->path, pending->capture, error)) return false;
+    std::fprintf(stderr, "[gpucap] wrote %s output_bytes=%zu hash=%016llx\n", pending->path.c_str(), output.size(),
+                 static_cast<unsigned long long>(pending->capture.expected_output_hash));
+    return true;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -1,0 +1,97 @@
+// gpu_capture.hpp - versioned, local-only capture of realized GPU draws.
+#pragma once
+
+#include "gpu_execute.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace prosper::gpu {
+
+struct GpuCaptureMetadata {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint64_t submit_index = 0;
+    std::string revision;
+    std::string title_id;
+    std::string input_route;
+    std::string savedata_dir;
+    std::vector<std::pair<std::string, std::string>> renderer_env;
+};
+
+struct GpuCaptureBlob {
+    uint64_t guest_addr = 0;
+    uint64_t bytes_read = 0;
+    std::vector<uint8_t> bytes;
+};
+
+struct GpuCapturedResource {
+    ShaderResource resource;
+    uint32_t blob_index = 0xFFFFFFFFu;
+    uint64_t blob_offset = 0;
+};
+
+struct GpuCapturedTable {
+    bool present = false;
+    std::vector<GpuCapturedResource> resources;
+};
+
+struct GpuCapturedDraw {
+    std::vector<uint32_t> vs;
+    std::vector<uint32_t> fs;
+    ResolvedPipelineState ps;
+    GpuCapturedTable vrt;
+    GpuCapturedTable prt;
+    uint32_t vertex_count = 3;
+    std::vector<uint32_t> indices;
+    uint64_t color0_base = 0;
+};
+
+struct GpuCaptureFile {
+    GpuCaptureMetadata metadata;
+    std::vector<GpuCaptureBlob> blobs;
+    std::vector<GpuCapturedDraw> draws;
+    uint64_t expected_output_hash = 0;
+    uint64_t expected_output_bytes = 0;
+};
+
+// Reader returns the number of bytes copied. The capture zero-fills the unread suffix, matching the
+// live renderer's guarded-copy behavior for partially committed guest resources.
+using CaptureMemoryReader = std::function<size_t(uint64_t guest_addr, uint8_t* dst, size_t bytes)>;
+
+bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
+                        const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error);
+bool write_gpu_capture(const std::string& path, const GpuCaptureFile& capture, std::string& error);
+bool read_gpu_capture(const std::string& path, GpuCaptureFile& capture, std::string& error);
+
+struct GpuReplayFrame {
+    GpuCaptureMetadata metadata;
+    std::vector<GpuCaptureBlob> blobs;
+    std::vector<DrawItem> items;
+    uint64_t expected_output_hash = 0;
+    uint64_t expected_output_bytes = 0;
+};
+
+bool materialize_gpu_replay(const GpuCaptureFile& capture, GpuReplayFrame& replay, std::string& error);
+uint64_t gpu_capture_hash(const uint8_t* data, size_t size);
+inline uint64_t gpu_capture_hash(const std::vector<uint8_t>& data) {
+    return gpu_capture_hash(data.data(), data.size());
+}
+
+// Runtime hook used by execute_and_present. PROSPER_GPU_CAPTURE=<path> captures exactly one realized
+// submit. MIN_DRAWS/MAX_DRAWS select a semantic candidate class; PROSPER_GPU_CAPTURE_AT=N then selects
+// the zero-based matching invocation (default first match).
+struct PendingGpuCapture {
+    std::string path;
+    GpuCaptureFile capture;
+};
+std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector<DrawItem>& items,
+                                                               uint32_t width, uint32_t height);
+bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
+                                  const std::vector<uint8_t>& output, std::string& error);
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -533,6 +533,11 @@ using LiveRenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawIt
 void set_submit_renderer(LiveRenderFn fn);
 bool have_submit_renderer();
 
+// Invoke the registered live backend directly with already-realized draws. Used by the local capture
+// replayer; normal guest execution enters through execute_and_present(). Returns {} when unregistered.
+std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
+                                         uint32_t width, uint32_t height);
+
 // Render a folded GpuState at (width,height) via the registered live renderer and hand the frame to the
 // present path (present_write_frame). Returns true iff a frame was produced and presented. A no-op
 // returning false when there is no renderer registered or the state has no draws — so it is inert on the

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5,6 +5,7 @@
 // pure. No Vulkan here — the backend is a std::function injected by whoever owns a device (the runtime
 // binary at startup, or a test via render_runner.h), so prosper_core links this without Vulkan.
 #include "gpu_execute.hpp"
+#include "gpu_capture.hpp"
 #include "videoout_present.hpp"   // present_write_frame
 #include "agc_shader_layout.hpp"  // AgcShaderHeader + build_shader_resources
 #include "pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
@@ -788,6 +789,10 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
 
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
 bool have_submit_renderer()               { return static_cast<bool>(g_live); }
+std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
+                                         uint32_t width, uint32_t height) {
+    return g_live ? g_live(items, width, height) : std::vector<uint8_t>{};
+}
 
 bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
     if (!g_live || st.draws.empty() || !width || !height) return false;
@@ -800,7 +805,16 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
     float sx = fw ? (float)width  / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
     std::vector<uint8_t> px = execute_gpustate(st,
-        [&](const std::vector<DrawItem>& items) { return g_live(items, width, height); },
+        [&](const std::vector<DrawItem>& items) {
+            auto pending = begin_requested_gpu_capture(items, width, height);
+            std::vector<uint8_t> rendered = g_live(items, width, height);
+            if (pending) {
+                std::string error;
+                if (!finish_requested_gpu_capture(std::move(pending), rendered, error))
+                    std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
+            }
+            return rendered;
+        },
         0x10000, sx, sy);
     if (px.size() != static_cast<size_t>(width) * height * 4) return false;   // recompile/render failed
     present_write_frame(px.data(), width, height);

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -150,6 +150,12 @@ struct ShaderResource {
     // mask) reads correctly. Default = identity (R,G,B,A). NOT applied on the narrow R->RGBA replication
     // path (that already broadcasts coverage to every channel).
     uint32_t      swizzle[4]        = {4, 5, 6, 7};
+
+    // Replay-only backing. `gpu_addr` remains the captured logical guest address so render-target
+    // identity/alias checks stay faithful; the live renderer reads from host_data when non-null.
+    // Production resource tables leave both fields zero and continue reading 1:1 guest memory.
+    const uint8_t* host_data        = nullptr;
+    uint64_t       host_data_size   = 0;
 };
 
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -224,6 +224,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (d.ps->stencil_enable) { use_stencil = true;
             if (!got_stencil_clear) { stencil_clear = d.ps->stencil_clear_value; got_stencil_clear = true; } }
     }
+    if (const char* v = getenv("PROSPER_STENCIL_CLEAR"))
+        stencil_clear = static_cast<uint32_t>(strtoul(v, nullptr, 0)) & 0xFFu;
     if (getenv("PROSPER_NO_DEPTH"))   use_depth = false;     // diag: isolate depth-test rejection
     if (getenv("PROSPER_NO_STENCIL")) use_stencil = false;   // diag: isolate stencil masking
     const bool use_ds = use_depth || use_stencil;
@@ -408,6 +410,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 bool does_replace = (ps->stencil_pass_op[fb] == REPLACE || ps->stencil_fail_op[fb] == REPLACE ||
                                      ps->stencil_depth_fail_op[fb] == REPLACE);
                 s.reference   = does_replace ? ps->stencil_op_val[fb] : ps->stencil_ref[fb];
+                if (does_replace && s.compareOp == VK_COMPARE_OP_ALWAYS)
+                    if (const char* v = getenv("PROSPER_STENCIL_REPLACE"))
+                        s.reference = static_cast<uint32_t>(strtoul(v, nullptr, 0)) & 0xFFu;
                 return s;
             };
             dss.front = mkop(0); dss.back = mkop(1);

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1,0 +1,77 @@
+#include "../src/gpu/gpu_capture.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_capture ==\n");
+    std::vector<uint8_t> memory(32);
+    for (size_t i = 0; i < memory.size(); ++i) memory[i] = static_cast<uint8_t>(0x40 + i);
+    auto reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr < 0x1000 || addr >= 0x1000 + memory.size()) return 0;
+        size_t off = static_cast<size_t>(addr - 0x1000), take = std::min(n, memory.size() - off);
+        std::memcpy(dst, memory.data() + off, take); return take;
+    };
+
+    auto table = std::make_shared<ShaderResourceTable>();
+    ShaderResource a{}; a.cls = ResourceClass::VertexBuffer; a.binding = 9; a.gpu_addr = 0x1000;
+    a.size = 16; a.stride = 4; a.format = DataFormat::Unorm8; a.num_components = 4; a.fetch_pc = 12;
+    ShaderResource b{}; b.cls = ResourceClass::ConstantBuffer; b.binding = 2; b.gpu_addr = 0x1008;
+    b.size = 16; b.format = DataFormat::Float32; b.num_components = 4; b.srt_offset = 0x20;
+    table->resources = {a, b};
+
+    DrawItem draw; draw.vs = {0x07230203, 1, 2}; draw.fs = {0x07230203, 3}; draw.vrt = table;
+    draw.vertex_count = 6; draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
+    draw.ps.topology = 3; draw.ps.color0_format = 37; draw.ps.blend_enable = true;
+    draw.ps.has_viewport = true; draw.ps.viewport_w = 1920; draw.ps.viewport_h = -1080;
+
+    GpuCaptureMetadata meta; meta.width = 480; meta.height = 270; meta.submit_index = 42;
+    meta.revision = "deadbeef"; meta.title_id = "PPSA24651"; meta.input_route = "@reach-level.pad";
+    meta.savedata_dir = "/tmp/prosper-test-save";
+    meta.renderer_env = {{"PROSPER_RTT_PERTARGET", "1"}, {"PROSPER_NO_CULL", "1"}};
+    GpuCaptureFile captured; std::string error;
+    CHECK(capture_draw_items({draw}, meta, reader, captured, error), "capture realized draw succeeds");
+    CHECK(captured.blobs.size() == 1 && captured.blobs[0].guest_addr == 0x1000 && captured.blobs[0].bytes.size() == 24,
+          "overlapping resource ranges merge into one alias-preserving blob");
+    CHECK(captured.blobs[0].bytes_read == 24 && captured.blobs[0].bytes[8] == memory[8],
+          "capture records readable byte count and resource contents");
+    CHECK(captured.draws[0].vrt.resources[0].blob_index == captured.draws[0].vrt.resources[1].blob_index &&
+          captured.draws[0].vrt.resources[1].blob_offset == 8, "resource references preserve overlap offsets");
+    captured.expected_output_hash = 0x1122334455667788ull; captured.expected_output_bytes = 480ull * 270 * 4;
+
+    auto path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_test.prgcap";
+    CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
+    GpuCaptureFile loaded;
+    CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
+    CHECK(loaded.metadata.submit_index == 42 && loaded.metadata.title_id == "PPSA24651" &&
+          loaded.metadata.renderer_env.size() == 2 && loaded.metadata.renderer_env[0].first == "PROSPER_RTT_PERTARGET" &&
+          loaded.draws.size() == 1 && loaded.draws[0].indices.size() == 6, "metadata and draw data round-trip");
+    CHECK(loaded.draws[0].ps.viewport_h == -1080 && loaded.draws[0].ps.blend_enable,
+          "fixed-function pipeline state round-trips explicitly");
+
+    GpuReplayFrame replay;
+    CHECK(materialize_gpu_replay(loaded, replay, error), "capture materializes owned replay draw items");
+    const auto& rr = replay.items[0].vrt->resources;
+    CHECK(rr[0].gpu_addr == 0x1000 && rr[1].gpu_addr == 0x1008, "replay retains logical guest addresses");
+    CHECK(rr[0].host_data && rr[1].host_data == rr[0].host_data + 8 && rr[1].host_data[0] == memory[8],
+          "replay resources point into shared owned backing at captured offsets");
+    CHECK(replay.expected_output_hash == captured.expected_output_hash, "expected render hash round-trips");
+
+    auto truncated = path; truncated += ".truncated";
+    std::filesystem::copy_file(path, truncated, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::resize_file(truncated, std::filesystem::file_size(truncated) - 5);
+    GpuCaptureFile bad;
+    CHECK(!read_gpu_capture(truncated.string(), bad, error) && !error.empty(), "truncated capture fails loudly");
+    std::filesystem::remove(path); std::filesystem::remove(truncated);
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n"); return 0;
+}

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1,0 +1,64 @@
+#include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../frontends/shared/live_renderer.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_capture_render ==\n");
+    constexpr uint32_t W = 64, H = 64;
+
+    const uint32_t vs_rdna[] = {
+        0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u, 0x7E0C02F2u, 0x10020B01u,
+        0x08020D01u, 0x10040B02u, 0x08040D02u, 0x7E060280u, 0x7E0802F2u, 0xF80008CFu, 0x04030201u, 0xBF810000u,
+    };
+    const uint32_t ps_rdna[] = {
+        0x7e0002ffu, 0x3e800000u, 0x7e0202ffu, 0x3e800000u, 0xf0800f08u, 0x00820000u,
+        0xf800000fu, 0x03020100u, 0xbf810000u,
+    };
+    ShaderResourceTable compile_rt;
+    ShaderResource tex{}; tex.cls = ResourceClass::Texture; tex.binding = 4; tex.img_dim = 1;
+    tex.width = 2; tex.height = 2; tex.size = 16; tex.sgpr_base = 8; tex.gpu_addr = 0x100000;
+    tex.mag_filter = tex.min_filter = 0; compile_rt.resources.push_back(tex);
+    DrawItem item; item.vs = recompile_vertex(vs_rdna, std::size(vs_rdna));
+    item.fs = recompile_fragment(ps_rdna, std::size(ps_rdna), &compile_rt);
+    item.prt = std::make_shared<ShaderResourceTable>(compile_rt); item.vertex_count = 3;
+    item.ps.topology = 3; item.ps.color_write_mask = 0xF; item.color0_base = 0x200000;
+    CHECK(!item.vs.empty() && !item.fs.empty(), "test shaders compile to SPIR-V");
+
+    const std::vector<uint8_t> texture = {
+        255, 0, 0, 255,   0, 255, 0, 255,
+        0, 0, 255, 255,   255, 255, 255, 255,
+    };
+    auto reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr != tex.gpu_addr) return 0; n = std::min(n, texture.size()); std::memcpy(dst, texture.data(), n); return n;
+    };
+    GpuCaptureMetadata meta; meta.width = W; meta.height = H; meta.revision = "render-test";
+    GpuCaptureFile capture; std::string error;
+    CHECK(capture_draw_items({item}, meta, reader, capture, error), "textured draw captures");
+    GpuReplayFrame replay;
+    CHECK(materialize_gpu_replay(capture, replay, error), "textured draw materializes with owned bytes");
+    CHECK(replay.items[0].prt->resources[0].gpu_addr == tex.gpu_addr &&
+          replay.items[0].prt->resources[0].host_data_size == texture.size(),
+          "replay keeps logical VA and exposes exact host backing size");
+
+    prosper::frontend::register_live_renderer(".", false);
+    std::vector<uint8_t> pixels = render_submit_items(replay.items, W, H);
+    CHECK(pixels.size() == static_cast<size_t>(W) * H * 4, "replayed draw renders through live backend");
+    if (!pixels.empty()) {
+        const uint8_t* center = &pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+        CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
+              "replay samples captured red texel from owned backing");
+    }
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n"); return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -14,8 +14,32 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   (find file offsets for offline disassembly).
 - **`shader_histo/`** — histogram RDNA2 opcodes across a title's shaders.
 - **`imgdump/`** — decode/dump a guest texture to an image for inspection.
+- **`gpu_replay/`** — replay a local `PROSPER_GPU_CAPTURE` realized-submit capsule through the same
+  Vulkan backend without booting the guest. Capsules include game shaders/resources, use `.prgcap`,
+  are gitignored, and must never be committed. The tool exits non-zero on output-hash mismatch.
 - **`spv_validate/`** — `spirv-val` wrapper for recompiled SPIR-V.
 - **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
 
 Verification here is agentic-first (see `docs/VERIFICATION.md`): prefer a
 programmatic check (ctest exit code, `spirv-val`, a snapshot hash) over eyeballing.
+
+Capture one draw-carrying renderer invocation with:
+
+```bash
+PROSPER_GPU_CAPTURE=/tmp/messenger-level.prgcap PROSPER_GPU_CAPTURE_AT=0 \
+  PROSPER_GPU_CAPTURE_MIN_DRAWS=30 \
+  PROSPER_CAPTURE_REVISION=$(git rev-parse HEAD) \
+  PROSPER_CAPTURE_TITLE=PPSA24651 <normal boot_trace command>
+./build-linux/gpu_replay /tmp/messenger-level.prgcap /tmp/replayed.bmp
+```
+
+`PROSPER_GPU_CAPTURE_MIN_DRAWS`/`MAX_DRAWS` filter by realized item count; `PROSPER_GPU_CAPTURE_AT`
+counts matching invocations that reach the registered renderer, after the normal `RENDER_EVERY`
+sampling. Aim the live run near the target first; the capture itself writes once.
+Set `PROSPER_CAPTURE_REVISION` explicitly in WSL worktrees: WSL Git cannot resolve their Windows-path
+gitdir links, so the build-time fallback revision is `unknown` there.
+
+For a differential replay, `PROSPER_STENCIL_CLEAR=<0..255>` overrides the initial stencil attachment
+value and `PROSPER_STENCIL_REPLACE=<0..255>` overrides the replacement reference of an
+ALWAYS+REPLACE stencil-prime draw. These are diagnostic controls only; they do not change guest-state
+extraction or the default render path.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1,0 +1,136 @@
+#include "gpu/gpu_capture.hpp"
+#include "gpu/gpu_execute.hpp"
+#include "live_renderer.hpp"
+#include "render_runner.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool set_environment(const std::string& name, const std::string& value) {
+#ifdef _WIN32
+    return _putenv_s(name.c_str(), value.c_str()) == 0;
+#else
+    return setenv(name.c_str(), value.c_str(), 1) == 0;
+#endif
+}
+
+void usage(const char* argv0) {
+    std::fprintf(stderr, "usage: %s [--inspect|--inspect-only] [--draw N] [--allow-mismatch] "
+                         "<capture.prgcap> [output.bmp]\n", argv0);
+}
+
+const char* class_name(prosper::gpu::ResourceClass c) {
+    using RC = prosper::gpu::ResourceClass;
+    switch (c) {
+    case RC::ConstantBuffer: return "CB"; case RC::VertexBuffer: return "VB";
+    case RC::Texture: return "TEX"; case RC::Sampler: return "SAMP"; case RC::StorageImage: return "STORAGE";
+    }
+    return "?";
+}
+
+void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* table) {
+    if (!table) { std::printf("  %s: none\n", stage); return; }
+    for (const auto& r : table->resources) {
+        size_t nz = 0; uint32_t first = 0;
+        if (r.host_data) {
+            for (uint64_t i = 0; i < r.host_data_size; ++i) nz += r.host_data[i] != 0;
+            if (r.host_data_size >= 4) std::memcpy(&first, r.host_data, 4);
+        }
+        uint64_t hash = r.host_data ? prosper::gpu::gpu_capture_hash(r.host_data, static_cast<size_t>(r.host_data_size)) : 0;
+        std::printf("  %s %-7s b=%u addr=%016llx bytes=%llu nz=%zu hash=%016llx first=%08x "
+                    "fmt=%u nc=%u stride=%u %ux%u tile=%u srt=%08x sgpr=%08x pc=%08x\n",
+                    stage, class_name(r.cls), r.binding, static_cast<unsigned long long>(r.gpu_addr),
+                    static_cast<unsigned long long>(r.host_data_size), nz, static_cast<unsigned long long>(hash), first,
+                    static_cast<unsigned>(r.format), r.num_components, r.stride, r.width, r.height, r.tile_mode,
+                    r.srt_offset, r.sgpr_base, r.fetch_pc);
+    }
+}
+
+void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
+    for (size_t i = 0; i < replay.items.size(); ++i) {
+        const auto& d = replay.items[i];
+        std::printf("draw[%zu] target=%016llx vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
+                    "depth=%d/%d/%u stencil=%d blend=%d viewport=%d %.1f,%.1f %.1fx%.1f "
+                    "vs=%zu/%016llx fs=%zu/%016llx\n",
+                    i, static_cast<unsigned long long>(d.color0_base), d.vertex_count, d.indices.size(),
+                    d.ps.topology, d.ps.color0_format, d.ps.color_write_mask, d.ps.depth_test_enable,
+                    d.ps.depth_write_enable, d.ps.depth_compare_op, d.ps.stencil_enable, d.ps.blend_enable,
+                    d.ps.has_viewport, d.ps.viewport_x, d.ps.viewport_y, d.ps.viewport_w, d.ps.viewport_h,
+                    d.vs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
+                        reinterpret_cast<const uint8_t*>(d.vs.data()), d.vs.size() * 4)),
+                    d.fs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
+                        reinterpret_cast<const uint8_t*>(d.fs.data()), d.fs.size() * 4)));
+        std::printf("  stencil clear=%u cmp=%u/%u fail=%u/%u pass=%u/%u zfail=%u/%u "
+                    "ref=%u/%u opval=%u/%u cmask=%02x/%02x wmask=%02x/%02x\n",
+                    d.ps.stencil_clear_value, d.ps.stencil_compare_op[0], d.ps.stencil_compare_op[1],
+                    d.ps.stencil_fail_op[0], d.ps.stencil_fail_op[1], d.ps.stencil_pass_op[0],
+                    d.ps.stencil_pass_op[1], d.ps.stencil_depth_fail_op[0], d.ps.stencil_depth_fail_op[1],
+                    d.ps.stencil_ref[0], d.ps.stencil_ref[1], d.ps.stencil_op_val[0], d.ps.stencil_op_val[1],
+                    d.ps.stencil_compare_mask[0], d.ps.stencil_compare_mask[1],
+                    d.ps.stencil_write_mask[0], d.ps.stencil_write_mask[1]);
+        inspect_table("VS", d.vrt.get()); inspect_table("PS", d.prt.get());
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    bool inspect = false, inspect_only = false, allow_mismatch = false; int draw_index = -1;
+    std::vector<const char*> positional;
+    for (int i = 1; i < argc; ++i) {
+        if (std::string(argv[i]) == "--inspect") inspect = true;
+        else if (std::string(argv[i]) == "--inspect-only") inspect = inspect_only = true;
+        else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
+        else if (std::string(argv[i]) == "--draw" && i + 1 < argc) draw_index = std::atoi(argv[++i]);
+        else positional.push_back(argv[i]);
+    }
+    if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
+    prosper::gpu::GpuCaptureFile capture; std::string error;
+    if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {
+        std::fprintf(stderr, "gpu_replay: %s: %s\n", positional[0], error.c_str()); return 2;
+    }
+    for (const auto& [name, value] : capture.metadata.renderer_env) {
+        if (!set_environment(name, value)) {
+            std::fprintf(stderr, "gpu_replay: cannot set %s\n", name.c_str()); return 2;
+        }
+    }
+    // A replay is already at its target submit; live-run windowing must never skip it.
+    set_environment("PROSPER_RENDER_FIRST", "0"); set_environment("PROSPER_RENDER_LAST", "2147483647");
+    prosper::gpu::GpuReplayFrame replay;
+    if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
+        std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    if (draw_index >= 0) {
+        if (static_cast<size_t>(draw_index) >= replay.items.size()) {
+            std::fprintf(stderr, "gpu_replay: draw index %d is out of range\n", draw_index); return 2;
+        }
+        prosper::gpu::DrawItem selected = std::move(replay.items[draw_index]); replay.items.clear();
+        replay.items.push_back(std::move(selected)); allow_mismatch = true;
+        std::fprintf(stderr, "[gpureplay] selected original draw %d\n", draw_index);
+    }
+    const auto& m = replay.metadata;
+    std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu blobs=%zu\n",
+                 m.revision.c_str(), m.title_id.c_str(), static_cast<unsigned long long>(m.submit_index),
+                 m.width, m.height, replay.items.size(), replay.blobs.size());
+    if (inspect) inspect_frame(replay);
+    if (inspect_only) return 0;
+    prosper::frontend::register_live_renderer(".", false);
+    std::vector<uint8_t> pixels = prosper::gpu::render_submit_items(replay.items, m.width, m.height);
+    uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
+    std::fprintf(stderr, "[gpureplay] output_bytes=%zu hash=%016llx expected_bytes=%llu expected_hash=%016llx\n",
+                 pixels.size(), static_cast<unsigned long long>(hash),
+                 static_cast<unsigned long long>(replay.expected_output_bytes),
+                 static_cast<unsigned long long>(replay.expected_output_hash));
+    if (positional.size() == 2 && !pixels.empty() && !prosper::test::dump_bmp(positional[1], pixels, m.width, m.height)) {
+        std::fprintf(stderr, "gpu_replay: cannot write %s\n", positional[1]); return 2;
+    }
+    if (!allow_mismatch && (pixels.size() != replay.expected_output_bytes || hash != replay.expected_output_hash)) {
+        std::fprintf(stderr, "gpu_replay: output mismatch\n"); return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a versioned, bounds-checked realized-submit capture format with owned resource blobs and alias preservation
- add `gpu_replay` for offline render/hash verification, state/resource inspection, and per-draw isolation
- capture live renderer metadata, SPIR-V, fixed-function state, indices, resource bytes, environment, and expected output
- add pure round-trip/corruption tests and a Vulkan capture-to-replay pixel-identity test
- add surgical stencil clear/replace replay controls used to isolate #518

Real game capsules contain game data, use `.prgcap`, and are gitignored.

## Messenger proof
Current-master capsule:
- revision `7553eadcc52d4f8f288c7496fe611e348611679d`
- 33 realized draws, 59 merged resource blobs, 480x270
- live output FNV-1a `3e5d9ef1b3e75d83`
- offline replay output: exact same byte count/hash in 0.6 s

The capsule then isolated the source scene's initial-stencil dependency; findings are in #300 and the missing clear/persistence contract is #518.

## Verification
- full build: pass
- `ctest --output-on-failure -j2`: 84/84 pass
- `snapshot.py check messenger-scene`: 24,318 colors, threshold 5,000
- real early Messenger submit: exact live/replay hash
- real black gameplay submit: exact live/replay hash
- `git diff --check`: pass

Closes #514