### PR TITLE
fix(gpu): restore Messenger grading LUT producer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,16 +78,21 @@ draws.** The old bindless vertex-fetch frontier is complete: both shader stages 
 V#/T#/S# resources resolve on current master. Do **not** start from `NEXT_STEP_VERTEX_FETCH.md`; it is
 retained as a historical bring-up record.
 
-The first gameplay level and the save-game list are still black/missing, but there is no verified
-current-master root cause. The immediate frontier is reproducible diagnosis:
+The save-game list is visible (#299 closed), and retaining color-disabled depth/stencil passes (#520) recovers
+the first level's source scene. The black gameplay root cause is now proven locally on `fix/issue-522-post-pass`:
+the direct 1024x32 RGBA16F grading-LUT producer was skipped because the recompiler lacked
+`V_CVT_OFF_F32_I4`, while the live renderer also treated its offscreen target as a VideoOut-sized surface.
+Resource-producer history (#524) identified the exact writer; implementing the opcode and decoding
+`CB_COLOR0_ATTRIB2` target dimensions (#526/#527) produces the real LUT, preserves it through the original
+grading shader, and yields a visible first-level front buffer without diagnostic resource substitution.
 
-1. Re-establish #299 (save list) and #300 (gameplay) independently with controlled input, savedata,
-   revision, and environment.
-2. Capture the failing GPU submit/frame into a local immutable capsule and replay it without Unity boot.
-3. Validate the generated SPIR-V descriptor interface strictly against runtime resources.
+Until that branch merges, use `prosper/docs/MESSENGER_BLACK_RENDER.md` for the exact evidence and validation
+route. After merge, the immediate frontier returns to ordinary gameplay progression: run the same saved route
+without diagnostics, identify the next first-bad contract, and file a narrowly scoped issue with a retained
+capture or provenance trace.
 
-Start with `prosper/docs/MESSENGER_BLACK_RENDER.md` and its linked GitHub issues. Treat claims from old
-captures as historical unless reproduced on the revision under test.
+Strict generated-SPIR-V/runtime-resource validation remains #515. Do not restart the superseded depth,
+vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.
 
 ## How to work here
 

--- a/prosper/docs/MESSENGER_BLACK_RENDER.md
+++ b/prosper/docs/MESSENGER_BLACK_RENDER.md
@@ -1,94 +1,116 @@
 # Messenger black-render investigation
 
-This is the canonical status for two visible Messenger failures:
-
-- GitHub #300: the first gameplay level submits frames but its scene content is black.
-- GitHub #299: the save-game list is not visible.
-
-GitHub issues track what remains and own live findings. This document defines what evidence is current,
-which conclusions are obsolete, and how the next investigation must be run. Update it when a finding
-changes the investigation boundary; put run-by-run detail on the relevant issue.
+This is the canonical status for the Messenger gameplay-render failure (#300 / #522).
+The formerly invisible save-game list (#299) is visible on current master and that issue is closed.
+GitHub issues own live findings; this document records the current evidence boundary and next experiment.
 
 ## Current conclusion (2026-07-11)
 
-There is **no verified current-master root cause** for either symptom.
+Immutable capture/replay (#514), the color-disabled depth/stencil-pass fix (#520, merged as `376a801`),
+and resource-producer provenance (#524) established this causal chain:
 
-The old project frontier, "the vertex shader cannot recompile because bindless vertex fetch is unresolved",
-is solved. Dynamic fetch const-folding, per-instruction resource provenance, EUD descriptor recovery, and
-both shader stages now execute. `NEXT_STEP_VERTEX_FETCH.md` is a historical implementation record.
+1. The retained current-master capsule contains 46 draws. Replaying draws 0:30 produces the real first-level
+   landscape with 56,036 RGB-nonblack pixels (BMP SHA-256 prefix `f821d2c28aac4cb8`). Geometry, vertex fetch,
+   asset textures, depth/stencil masking, and scene render-target population are working for this frame.
+2. Full-screen post draw 31 consumes that healthy 1920x1080 scene RT at PS binding 34, a white 1x1 RGBA8
+   texture at binding 35, and a 1024x32 RGBA16F texture at binding 36. The last resource's captured backing
+   has only 6 nonzero bytes out of 524,288 (hash `4384046b4840fbaa`). The draw produces zero RGB-nonblack
+   pixels, and downstream composition preserves the black result.
+3. Binding 32 contains `(1/1024, 1/32, 31, 1)`. The fragment shader (SPIR-V hash `1ad0babe1990d5c0`)
+   samples binding 36 at adjacent blue slices and interpolates. Together with the texture dimensions, this
+   identifies binding 36 as a flattened 32x32x32 color-grading LUT.
+4. `PROSPER_TESTLUT32=1` replaces only that decoded resource with an identity 32-cubed LUT. Replaying through
+   draw 31 then restores the complete landscape through the original post shader: all 57,600 output pixels
+   have nonzero RGB, output hash `f962051005b617ef`, and BMP SHA-256
+   `fdfc5d0f2fc208403be1be86c483d94622ec1d19cbb2594b65711b4f8a71fb75`. This proves the source RT,
+   fullscreen geometry, descriptor sampling, 1x1 input, and grading shader are operational.
+5. Retained color-target history finds the direct writer of that 1024x32 resource in the same submit: raw
+   draw 40, immediately before the grading consumer. Re-realizing the producer reports one unsupported pixel
+   instruction, VOP1 opcode `0x0e`, `V_CVT_OFF_F32_I4`. The compute-producer hypothesis is falsified for this
+   resource: retained per-dispatch state contains no matching direct 1024x32 image.
+6. The producer also exposes a second renderer contract error. Its `CB_COLOR0_ATTRIB2` declares 1024x32, but
+   the live renderer previously gave every target the scaled VideoOut extent. Decoding and carrying the native
+   target dimensions lets small lookup surfaces render at their actual resolution while large scene/scanout
+   surfaces retain the configured render scale.
+7. Implementing `V_CVT_OFF_F32_I4` (signed low nibble to f32, scaled by 1/16) and the target-extent fix makes
+   the unmodified producer write 32,734/32,768 RGB-nonblack LUT texels. The original grading consumer hits that
+   cached target and produces 56,008/57,600 RGB-nonblack scene pixels. The selected VideoOut front buffer then
+   contains roughly 37,100-37,500 nonblack pixels and visibly shows the first-level landscape and dialogue UI.
+   No `PROSPER_TESTLUT32` or other synthetic resource override is active.
+8. The earlier 256x16 pixel-art palette is a transitional pass, not the persistent failing shader. A repaired
+   hardware-breakpoint trace (#525) observes `PaletteSwapImageEffect.FadeBlackToGameCoroutine.MoveNext`
+   progress through all eight entries and complete. Managed `Material.SetTexture`, its native `SetTextureImpl`
+   calls, eight distinct native texture pointers, and the corresponding live descriptor addresses all change.
+   That transition eventually produces the expected colored scene before the grading pass erases it.
 
-#300 contains useful measurements, but it also contains mutually incompatible conclusions: texture decode,
-alpha, transform collapse, render-target propagation, and a missing vertex-color binding were each called
-the root cause and later overturned. Those tests were run while the graphics stack changed quickly. They
-cannot be combined into one proof unless repeated on the same commit with the same captured frame.
+The black first-level root cause is therefore a missing shader instruction plus loss of per-target dimensions,
+not depth, a stuck palette fade, compute LUT baking, or detiling of the 256x16 palette. The real fix is currently
+validated on local branch `fix/issue-522-post-pass`; #522 should close only after the implementation merges and
+a clean build repeats the route without diagnostic force-render flags.
 
-The newest focused diagnostic, `772c44a` on `origin/fix/messenger-vertex-color-binding`, found that the
-previously absent binding-9 color vertex buffer had become present with real packed-white data after the
-EUD/resource fixes. The level was still black. That commit is based on `9b5bf27`, 27 commits behind
-`origin/master` at the time of this update, so it narrows history but is not current-master verification.
-
-#299 has only a shared-root hypothesis. It has not been shown whether the save-list rows are absent from
-Unity's draw stream, dropped during realization, or rendered with bad inputs. SaveData persistence and
-filesystem behavior changed recently (#389, #392), and the diagnostic run above reported flaky save-mount
-behavior. Treat #299 as an independent HLE/UI investigation until a capture proves otherwise.
+The old bindless vertex-fetch frontier is solved, and `NEXT_STEP_VERTEX_FETCH.md` is historical. Earlier
+#300 claims about texture decode, alpha, transform collapse, render-target propagation, and a missing
+vertex-color binding were made on changing revisions and were later overturned. Do not combine them into a
+new proof without reproducing them against the retained capsule or a fully recorded current-master run.
 
 ## Evidence policy
 
-Every new finding posted to #299 or #300 must include:
+Every new finding posted to #300 or #522 must include:
 
 - exact git commit and whether local changes were present;
-- title dump ID, savedata directory/seed, input route, and relevant environment flags;
+- title dump ID, savedata directory/seed, exact input route, and relevant environment flags;
 - pad-read, flip, submit, pass, and draw identifiers as applicable;
-- hashes of shader code, resolved resource table, referenced input bytes, and output image/pass;
+- hashes of shader code, resource table, referenced bytes, and output image/pass;
 - the observation, the narrower conclusion it supports, and alternatives it does not distinguish.
 
-Avoid "definitive" or "root cause" until a proposed fix changes the failing replay and a regression test
-fails before the fix and passes after it. A diagnostic override proves only the boundary it directly changes.
+A diagnostic override proves only the boundary it changes. Call something a root cause only when a real fix
+changes the same failing replay/live state and a regression fails before and passes after it.
 
-## Required baseline
+## Required merge validation
 
-Re-establish both symptoms independently on `origin/master`:
+Before closing #522:
 
-1. Use a unique, explicitly recorded `PROSPER_SAVEDATA_DIR` and state whether it starts empty or seeded.
-2. Record the exact inline, frame-anchored `PROSPER_PAD_SCRIPT` value. File-loaded routes are not on
-   current master yet; do not cite a branch-only `scripts/<title>/reach-*.pad` path as the input.
-3. Do not rely on `PROSPER_DET_CLOCK` or pad-read screenshot checkpoints; #302 confirmed those later
-   implementations did not merge with PR #301.
-4. Detect the reached state with a semantic/content metric, not elapsed time or one screenshot hash.
-5. Repeat until the success rate and any alternate states are quantified.
+1. Run the focused recompiler, command-processor, render-state, and capture tests plus the full CTest suite.
+2. Repeat the exact saved gameplay route from a clean build with no `PROSPER_TESTLUT32` override. The targeted
+   `PROSPER_RENDER_RESOURCE_DIM=1024x32` run is valid producer/consumer proof, but normal gameplay must not depend
+   on that diagnostic selection flag.
+3. Confirm the front buffer, not only an intermediate target, contains the landscape for multiple consecutive
+   flips. Record the revision, route, environment, and representative RGB-nonblack counts on #522.
+4. Keep the identity-LUT override and retained provenance tools diagnostic-only. They are useful for future
+   first-bad-contract investigations but are not part of normal title behavior.
 
-Do not begin another graphics hypothesis cycle until this baseline is reliable enough to identify the same
-failing submit/pass across runs. If savedata or guest state prevents that, fix the reproducer first.
+## Tooling
 
-## Tooling milestones
+### Immutable GPU capture/replay (#514, complete)
 
-### 1. Immutable GPU capture/replay (#514)
+`.prgcap` v3 records ordered draws, target transitions, native target dimensions, shaders, resource tables,
+and owned backing bytes,
+then reproduces the live hash without Unity. Use `gpu_replay --inspect-only`, draw-range isolation, resource
+dumping, and shader dumping for offline work. Captures contain game data and remain gitignored.
 
-Capture a failing draw-carrying frame locally: ordered draws, render-target transitions, decoded GPU state,
-shader code, resource tables, referenced VB/CB/texture bytes, initial RT state, and alias/dependency metadata.
-Replay it without loading Unity and require live-versus-replay state and output hashes to match. Captures
-contain game data and remain gitignored; only minimized synthetic fixtures may be committed.
-
-This converts a multi-minute, nondeterministic boot experiment into a revision-locked test that runs in
-seconds and can be bisected, probed, and compared.
-
-### 2. Strict shader/resource contract (#515)
+### Strict shader/resource contract (#515)
 
 Validate the descriptor interface declared by generated SPIR-V against the runtime `ShaderResourceTable`:
 set/binding, descriptor class, stage visibility, guest address, byte range, stride, format, and statically
-known accessed offsets. Diagnostic mode must reject missing, ambiguous, wrong-type, or undersized resources
-before Vulkan robust-buffer behavior silently turns them into zeros.
+known accessed offsets. Strict diagnostic mode must reject missing, ambiguous, wrong-type, or undersized
+resources before Vulkan robust-buffer behavior silently turns them into zeros.
 
-### 3. Structured per-draw probes
+### Resource producer provenance (#524)
+
+`PROSPER_PROVENANCE_DIM=WxH` retains matching color-target writers across submits and reports the last writer
+when a draw samples a matching image. `PROSPER_COMPUTELOG[_DIM]` records dispatch program/resource state. These
+tools found Messenger's direct raw-draw producer and falsified the compute hypothesis; extend the same structured
+history to DMA/COPY/WRITE and CPU-visible operations as future titles require.
+
+### Structured per-draw probes
 
 On a replayed draw, expose vertex position/color/UV, raw texture samples, constant-buffer factors,
 pre-blend fragment output, and final attachment output in a standard report. Existing switches such as
-`PROSPER_RENDER_TESTPS`, `PROSPER_TESTTEX`, `PROSPER_CBUFLOG`, and draw isolation are useful primitives;
-the goal is one repeatable probe rather than another collection of live-only A/B runs.
+`PROSPER_RENDER_TESTPS`, `PROSPER_TESTTEX`, `PROSPER_CBUFLOG`, and draw isolation are useful primitives.
 
 ## Decision boundary
 
-Do not start a persistent render-target-manager rewrite, another whole-stack audit, or an HLE workaround
-based only on the historical #300 comments. Let the current baseline and immutable replay identify the
-first bad contract. Once identified, implement the real behavior, derive a synthetic regression where
-possible, then add a late-state local snapshot/checkpoint guard for the repaired Messenger path.
+Do not start another depth/stencil, vertex-fetch, palette-fade, compute, tiling, or whole-stack rewrite from the
+historical #300 comments. The producer, missing opcode, target extent, consumer, and front-buffer result are now
+connected by one live trace. Preserve that chain as the regression boundary and use the same provenance-first
+method for the next title failure.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -38,11 +38,22 @@ namespace prosper::frontend {
 namespace { struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; }; }
 
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
+    // Resource tables are built before the submit reaches this callback. Publish the renderer's
+    // default mode now so unmapped render-target descriptors remain available for RTT injection.
+    // Outside a registered renderer, resource decoding retains its strict unknown-format policy.
+    if (!getenv("PROSPER_RTT_SINGLE_TARGET") && !getenv("PROSPER_RTT_PERTARGET")) {
+#ifdef _WIN32
+        _putenv_s("PROSPER_RTT_PERTARGET", "1");
+#else
+        setenv("PROSPER_RTT_PERTARGET", "1", 1);
+#endif
+    }
     static std::atomic<int> frame_no{0};
     static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
-    // PROSPER_RTT_PERTARGET renders each distinct CB_COLOR0_BASE into its OWN framebuffer (below) and
-    // implies RTT injection — a group can only sample an earlier group if the injection path is live.
-    static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr;
+    // A real command stream renders each CB_COLOR0_BASE into its own surface. Keep the old flattened
+    // compositor only as a diagnostic fallback; it cannot preserve post chains or target extents.
+    static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr ||
+                                  getenv("PROSPER_RTT_SINGLE_TARGET") == nullptr;
     static const bool rtt_on = getenv("PROSPER_RTT") != nullptr || pertarget;
     prosper::gpu::set_submit_renderer(
         [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
@@ -65,7 +76,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // exact submit at which a scene appears — for aiming PROSPER_RENDER_FIRST at it.
             if (getenv("PROSPER_SUBMITLOG") && (g_this_submit % 1000 == 0))
                 fprintf(stderr, "[submit] index=%d (%zu draw items)\n", g_this_submit, items.size());
-            if (g_this_submit < g_render_first) return {};
+            if (const char* sd = getenv("PROSPER_SUBMITLOG_DIM")) {
+                uint32_t sw = 0, sh = 0;
+                if (sscanf(sd, "%ux%u", &sw, &sh) == 2)
+                    for (const auto& it : items)
+                        if (it.color0_width == sw && it.color0_height == sh) {
+                            fprintf(stderr, "[submit] index=%d target=0x%llx extent=%ux%u (%zu draw items)\n",
+                                    g_this_submit, (unsigned long long)it.color0_base, sw, sh, items.size());
+                            break;
+                        }
+            }
+            bool force_target = false;
+            if (const char* td = getenv("PROSPER_RENDER_TARGET_DIM")) {
+                uint32_t tw = 0, th = 0;
+                if (sscanf(td, "%ux%u", &tw, &th) == 2)
+                    for (const auto& it : items)
+                        if (it.color0_width == tw && it.color0_height == th) { force_target = true; break; }
+            }
+            if (const char* rd = getenv("PROSPER_RENDER_RESOURCE_DIM")) {
+                uint32_t rw = 0, rh = 0;
+                if (sscanf(rd, "%ux%u", &rw, &rh) == 2)
+                    for (const auto& it : items) {
+                        auto has_dim = [&](const prosper::gpu::ShaderResourceTable* table) {
+                            if (!table) return false;
+                            for (const auto& r : table->resources)
+                                if (r.width == rw && r.height == rh) return true;
+                            return false;
+                        };
+                        if (has_dim(it.vrt.get()) || has_dim(it.prt.get())) { force_target = true; break; }
+                    }
+            }
+            // A one-time offscreen producer may occur before a much later consumer render window.
+            // Render that target even before RENDER_FIRST so its RTT cache entry survives skipped
+            // intermediate submits (#526).
+            if (g_this_submit < g_render_first && !force_target) return {};
             // Dump the FIRST item's recompiled SPIR-V (diagnostic; survives a mid-render crash).
             if (getenv("PROSPER_SHADER_DUMP") && !items.empty()) {
                 std::string d = getenv("PROSPER_SHADER_DUMP");
@@ -318,17 +362,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (FILE* f = fopen(fn, "wb")) { fwrite(texstore.back().data(), 1, nb, f); fclose(f);
                                 fprintf(stderr, "[render] dumped raw tiled bytes -> %s (%zu)\n", fn, nb); fflush(stderr); }
                         }
-                        // PROSPER_TESTTEX: overwrite with a recognizable gradient/checker to prove the
-                        // sample path (the game's real render-target texture is empty until we execute
-                        // the scene draws that fill it).
-                        if (getenv("PROSPER_TESTTEX")) {
-                            for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
-                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
-                                bool ck = ((x / 64) ^ (y / 64)) & 1;
-                                p[0] = (uint8_t)(255 * x / tw); p[1] = (uint8_t)(255 * y / th);
-                                p[2] = ck ? 200 : 40; p[3] = 255;
-                            }
-                        }
                         if (getenv("PROSPER_GFXLOG")) { const uint8_t* b = texstore.back().data();
                             size_t nz = 0; for (size_t i = 0; i < nb && i < (1u<<16); i++) nz += (b[i] != 0);
                             fprintf(stderr, "[render] tex binding=%u %ux%u first64k-nonzero=%zu\n", r.binding, tw, th, nz); }
@@ -380,6 +413,59 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     tp[t * 4 + c] = (fc[c] != fc[c] || fc[c] <= 0.f) ? 0
                                                   : (fc[c] >= 1.f ? 255 : (uint8_t)(fc[c] * 255.f + 0.5f));
                                 tp[t * 4 + 3] = 255;
+                            }
+                        }
+                        // PROSPER_PALETTELOG: compact identity/provenance trace for Unity's 256x16
+                        // palette textures. Unlike GFXLOG this is cheap enough for a focused render
+                        // window and reveals both descriptor-address and decoded-content changes.
+                        if (getenv("PROSPER_PALETTELOG") && tw == 256 && th == 16) {
+                            uint64_t hash = 1469598103934665603ull;
+                            size_t rgb_nonblack = 0;
+                            for (size_t t = 0; t < (size_t)tw * th; ++t) {
+                                const uint8_t* p = &texstore.back()[t * 4];
+                                rgb_nonblack += (p[0] != 0 || p[1] != 0 || p[2] != 0);
+                                for (unsigned c = 0; c < 4; ++c) {
+                                    hash ^= p[c]; hash *= 1099511628211ull;
+                                }
+                            }
+                            fprintf(stderr, "[palette] binding=%u addr=0x%llx fnv=%016llx rgb_nonblack=%zu\n",
+                                    r.binding, (unsigned long long)r.gpu_addr,
+                                    (unsigned long long)hash, rgb_nonblack);
+                        }
+                        // Apply the synthetic texture after every decode/conversion step. Applying it before
+                        // auto-detile let the real tiled bytes overwrite the checker, producing a false-negative
+                        // sampling diagnosis (#522).
+                        if (getenv("PROSPER_TESTTEX")) {
+                            for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
+                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
+                                bool ck = ((x / 64) ^ (y / 64)) & 1;
+                                p[0] = (uint8_t)(255 * x / tw); p[1] = (uint8_t)(255 * y / th);
+                                p[2] = ck ? 200 : 40; p[3] = 255;
+                            }
+                        }
+                        // This 256x16 sparse palette is addressed like 16 blue slices, each 16 texels wide.
+                        // The identity probe preserves source color through shaders using
+                        // u=r/17+b*15/16, v=1-g, distinguishing lookup contents from a broken
+                        // source/geometry/sample path (#522).
+                        if (getenv("PROSPER_TESTLUT") && tw == 256 && th == 16) {
+                            for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
+                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
+                                p[0] = (uint8_t)((x % 16) * 255 / 15);
+                                p[1] = (uint8_t)((15 - y) * 255 / 15);
+                                p[2] = (uint8_t)((x / 16) * 255 / 15);
+                                p[3] = 255;
+                            }
+                        }
+                        // Unity's post-processing stack flattens a 32^3 grading LUT into a 1024x32
+                        // strip (32 red samples per blue slice). This isolates a missing LUT producer
+                        // from the persistent post shader and its healthy scene input (#522).
+                        if (getenv("PROSPER_TESTLUT32") && tw == 1024 && th == 32) {
+                            for (uint32_t y = 0; y < th; ++y) for (uint32_t x = 0; x < tw; ++x) {
+                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
+                                p[0] = (uint8_t)((x % 32) * 255 / 31);
+                                p[1] = (uint8_t)(y * 255 / 31);
+                                p[2] = (uint8_t)((x / 32) * 255 / 31);
+                                p[3] = 255;
                             }
                         }
                         // PROSPER_DUMP_TEX: write the RAW texture memory (interpreted linearly) to a BMP,
@@ -571,25 +657,71 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const uint64_t base = items[pass_i].color0_base;
                     std::vector<const prosper::gpu::DrawItem*> pass;
                     while (pass_i < items.size() && items[pass_i].color0_base == base) { pass.push_back(&items[pass_i]); ++pass_i; }
+
+                    // Gen5 render-target extent (#526). Large scene/scanout surfaces retain the
+                    // configured VideoOut render scale; small offscreen targets render at native
+                    // resolution so lookup textures (Messenger's 1024x32 grading LUT) preserve every
+                    // texel. The viewport was already scaled for the global w/h framebuffer by
+                    // execute_gpustate, so correct it from that scale to this pass-local scale.
+                    uint32_t native_w = pass.empty() ? 0u : pass.front()->color0_width;
+                    uint32_t native_h = pass.empty() ? 0u : pass.front()->color0_height;
+                    uint32_t gw = w, gh = h;
+                    const uint32_t present_w = prosper::gpu::present_width();
+                    const uint32_t present_h = prosper::gpu::present_height();
+                    if (native_w && native_h) {
+                        uint64_t native_pixels = (uint64_t)native_w * native_h;
+                        uint64_t global_pixels = (uint64_t)w * h;
+                        if (native_pixels <= global_pixels) {
+                            gw = native_w; gh = native_h;
+                        } else if (present_w && present_h) {
+                            gw = std::max(1u, (uint32_t)(((uint64_t)native_w * w + present_w / 2) / present_w));
+                            gh = std::max(1u, (uint32_t)(((uint64_t)native_h * h + present_h / 2) / present_h));
+                        }
+                    }
+                    std::vector<prosper::gpu::DrawItem> adjusted;
+                    std::vector<const prosper::gpu::DrawItem*> render_pass = pass;
+                    if (native_w && native_h && present_w && present_h && w && h) {
+                        const float ax = ((float)gw / native_w) / ((float)w / present_w);
+                        const float ay = ((float)gh / native_h) / ((float)h / present_h);
+                        if (ax != 1.0f || ay != 1.0f) {
+                            adjusted.reserve(pass.size()); render_pass.clear(); render_pass.reserve(pass.size());
+                            for (const auto* src : pass) {
+                                adjusted.push_back(*src);
+                                auto& item = adjusted.back();
+                                if (item.ps.has_viewport) {
+                                    item.ps.viewport_x *= ax; item.ps.viewport_w *= ax;
+                                    item.ps.viewport_y *= ay; item.ps.viewport_h *= ay;
+                                }
+                                render_pass.push_back(&item);
+                            }
+                        }
+                    }
                     const uint8_t* seed = nullptr;
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
-                        if (sit != g_rtt.end() && sit->second.w == w && sit->second.h == h &&
-                            sit->second.rgba.size() == (size_t)w * h * 4) seed = sit->second.rgba.data(); }
-                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(build_bds(pass), w, h, seed, clear_for(pass));
-                    if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = w; s.h = h; }
+                        if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
+                            sit->second.rgba.size() == (size_t)gw * gh * 4) seed = sit->second.rgba.data(); }
+                    std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
+                        build_bds(render_pass), gw, gh, seed, clear_for(render_pass));
+                    if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = gw; s.h = gh; }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
-                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for (uint8_t b : gpx) nz += (b != 0);
-                        fprintf(stderr, "[rtt] pass target=0x%llx (%zu draws) px_nonzero=%zu cache_size=%zu%s%s\n",
-                                (unsigned long long)base, pass.size(), nz, g_rtt.size(),
+                    if (getenv("PROSPER_RTTLOG")) {
+                        size_t nz = 0, rgb_nz = 0;
+                        for (uint8_t b : gpx) nz += (b != 0);
+                        for (size_t p = 0; p + 3 < gpx.size(); p += 4)
+                            rgb_nz += (gpx[p] != 0 || gpx[p + 1] != 0 || gpx[p + 2] != 0);
+                        fprintf(stderr, "[rtt] pass target=0x%llx extent=%ux%u native=%ux%u (%zu draws) "
+                                "px_nonzero=%zu rgb_nonblack=%zu cache_size=%zu%s%s\n",
+                                (unsigned long long)base, gw, gh, native_w, native_h, pass.size(), nz, rgb_nz, g_rtt.size(),
                                 is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : ""); }
                     // PROSPER_DUMP_DRAWSTEPS: for a pass targeting a SCANOUT buffer, re-render the pass
                     // draw-by-draw (prefix 1, prefix 2, ...) and dump each cumulative result — a one-boot
                     // bisect for "which draw of the final composite blacks the screen" (#319). Diagnostic.
                     if (getenv("PROSPER_DUMP_DRAWSTEPS") && is_vo && pass.size() > 1) {
                         for (size_t k = 1; k <= pass.size(); k++) {
-                            std::vector<const prosper::gpu::DrawItem*> prefix(pass.begin(), pass.begin() + k);
-                            std::vector<uint8_t> spx = prosper::test::render_draws_rgba(build_bds(prefix), w, h, seed, clear_for(prefix));
+                            std::vector<const prosper::gpu::DrawItem*> prefix(render_pass.begin(), render_pass.begin() + k);
+                            std::vector<uint8_t> spx = prosper::test::render_draws_rgba(
+                                build_bds(prefix), gw, gh, seed, clear_for(prefix));
                             if (spx.empty()) continue;
                             size_t snz = 0; for (uint8_t b : spx) snz += (b != 0);
                             fprintf(stderr, "[rtt] drawstep %zu/%zu tgt=0x%llx px_nonzero=%zu\n",
@@ -597,7 +729,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             const char* dd = getenv("PROSPER_FRAME_DIR");
                             char fn[512]; snprintf(fn, sizeof fn, "%s/drawstep_%04d_%zu.bmp",
                                                    dd ? dd : ".", frame_no.load(), k);
-                            prosper::test::dump_bmp(fn, spx, w, h);
+                            prosper::test::dump_bmp(fn, spx, gw, gh);
                         }
                     }
                     // PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes>: dump each per-target group's rendered
@@ -609,7 +741,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             const char* dd = getenv("PROSPER_FRAME_DIR");
                             char fn[512]; snprintf(fn, sizeof fn, "%s/rtgrp_%llx_%04d.bmp",
                                                    dd ? dd : ".", (unsigned long long)base, frame_no.load());
-                            prosper::test::dump_bmp(fn, gpx, w, h);
+                            prosper::test::dump_bmp(fn, gpx, gw, gh);
                         }
                     }
                     if (!gpx.empty()) {
@@ -643,7 +775,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
             // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.
             size_t content_thr = 0; if (const char* c = getenv("PROSPER_DUMP_CONTENT")) content_thr = (size_t)atol(c);
-            size_t px_nz = 0; if (content_thr) for (size_t i = 0; i < px.size(); i++) px_nz += (px[i] != 0);
+            size_t px_nz = 0;
+            if (dump_bmps) for (uint8_t b : px) px_nz += (b != 0);
             if (px.empty()) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);
             } else if (dump_bmps && ((content_thr && px_nz >= content_thr) || (!content_thr && (n < 60 || n % 10 == 0)))) {

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -304,12 +304,9 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             Gen5ImageFormatInfo fi;
             static bool warned[512] = {};                        // once per 9-bit format value
             if (!gen5_image_format(d.format, &fi)) {
-                // Unmapped IMG format. Under RTT (PROSPER_RTT or PROSPER_RTT_PERTARGET — the
-                // per-target mode IMPLIES injection, matching live_renderer's rtt_on gate; a
-                // pertarget-only run previously skipped these T#s at layout level, #294), BIND it
-                // as RGBA8 anyway so the render-to-texture path can inject the pixels we rendered
-                // into this address. Without RTT, keep skipping (a raw RGBA8 read of a real
-                // unmapped texture would sample garbage; #65).
+                // The normal per-target renderer can supply an unmapped image through RTT injection,
+                // so bind it as RGBA8. The legacy single-target diagnostic keeps the old skip policy;
+                // a raw RGBA8 read of an unknown guest format would sample garbage (#65/#294).
                 static const bool rtt_bind = getenv("PROSPER_RTT") != nullptr ||
                                              getenv("PROSPER_RTT_PERTARGET") != nullptr;
                 if (!rtt_bind) {

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1368,6 +1368,13 @@ void GpuState::apply(const Pm4Command& c) {
             // guest builds around each dispatch (label init + EOP write + wait) completes at fold
             // time independently of the dispatch itself, so skipping the shader work cannot hang
             // the stream — it only leaves compute-written buffers stale (surfaced by the counter).
+            if (state_dirty_ || !last_snapshot_) {
+                auto snap = std::make_shared<GpuState>();
+                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+                last_snapshot_ = std::move(snap);
+                state_dirty_ = false;
+            }
+            dispatches.push_back({c.tg_x, c.tg_y, c.tg_z, c.dispatch_modifier, last_snapshot_});
             dispatch_count++;
             break;
         case K::SetPredication:

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -58,7 +58,16 @@ struct GpuState {
         bool     from_offset  = false;
     };
     std::vector<Draw> draws;                             // one per DrawIndexAuto / DrawIndex
-    uint64_t dispatch_count = 0;                         // DispatchDirect packets seen (no execution yet)
+    // Compute dispatch + register state AT the packet. Compute is not executed yet, but retaining
+    // the state makes skipped-producer provenance inspectable instead of reducing every dispatch
+    // to one process-lifetime counter (#524).
+    struct Dispatch {
+        uint32_t tg_x = 0, tg_y = 0, tg_z = 0;
+        uint64_t modifier = 0;
+        std::shared_ptr<const GpuState> state;
+    };
+    std::vector<Dispatch> dispatches;                     // current submit's DispatchDirect packets
+    uint64_t dispatch_count = 0;                          // process-lifetime DispatchDirect count
 
     // GPU predication window (#319): the 64-bit condition address the last SetPredication opened
     // (0 = no window). A packet-predicated Jump inside the window is executed/skipped on the

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -19,7 +19,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 2;
+constexpr uint32_t kVersion = 3;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -285,6 +285,7 @@ bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMeta
     for (const auto& d : items) {
         GpuCapturedDraw c; c.vs = d.vs; c.fs = d.fs; c.ps = d.ps; c.vertex_count = d.vertex_count;
         c.indices = d.indices; c.color0_base = d.color0_base;
+        c.color0_width = d.color0_width; c.color0_height = d.color0_height;
         if (!capture_table(d.vrt.get(), intervals, c.vrt, error) || !capture_table(d.prt.get(), intervals, c.prt, error)) return false;
         out.draws.push_back(std::move(c));
     }
@@ -304,6 +305,7 @@ bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::st
     for (const auto& d : c.draws) {
         w.words(d.vs); w.words(d.fs); write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
         w.u32(d.vertex_count); w.words(d.indices); w.u64(d.color0_base);
+        w.u32(d.color0_width); w.u32(d.color0_height);
     }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     std::filesystem::path target(path), temp = target; temp += ".tmp";
@@ -347,6 +349,7 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
     for (auto& d : c.draws) {
         if (!r.words(d.vs) || !r.words(d.fs) || !read_pipeline(r, d.ps, version) || !read_table(r, d.vrt) ||
             !read_table(r, d.prt) || !r.u32(d.vertex_count) || !r.words(d.indices) || !r.u64(d.color0_base)) return false;
+        if (version >= 3 && (!r.u32(d.color0_width) || !r.u32(d.color0_height))) return false;
     }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -377,6 +380,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
     for (const auto& x : c.draws) {
         DrawItem d; d.vs = x.vs; d.fs = x.fs; d.ps = x.ps; d.vertex_count = x.vertex_count;
         d.indices = x.indices; d.color0_base = x.color0_base;
+        d.color0_width = x.color0_width; d.color0_height = x.color0_height;
         if (!table(x.vrt, d.vrt) || !table(x.prt, d.prt)) return false;
         out.items.push_back(std::move(d));
     }
@@ -386,6 +390,11 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector<DrawItem>& items,
                                                                uint32_t width, uint32_t height) {
     const char* path = std::getenv("PROSPER_GPU_CAPTURE"); if (!path || !*path) return {};
+    static std::atomic<uint64_t> invocation_sequence{0};
+    const uint64_t invocation = invocation_sequence.fetch_add(1);
+    uint64_t after = 0;
+    if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_AFTER")) after = std::strtoull(v, nullptr, 0);
+    if (invocation < after) return {};
     uint64_t min_draws = 0, max_draws = std::numeric_limits<uint64_t>::max();
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MIN_DRAWS")) min_draws = std::strtoull(v, nullptr, 0);
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MAX_DRAWS")) max_draws = std::strtoull(v, nullptr, 0);
@@ -411,7 +420,9 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
         "PROSPER_NO_DEPTH", "PROSPER_NO_STENCIL", "PROSPER_STENCIL_CLEAR", "PROSPER_STENCIL_REPLACE",
         "PROSPER_NO_SWIZZLE", "PROSPER_NODETILE",
         "PROSPER_PITCH", "PROSPER_RENDER_NOPS", "PROSPER_RENDER_REFVS", "PROSPER_RENDER_TESTPS",
-        "PROSPER_RTT", "PROSPER_RTT_NOSEED", "PROSPER_RTT_PERTARGET", "PROSPER_TESTTEX"
+        "PROSPER_RTT", "PROSPER_RTT_NOSEED", "PROSPER_RTT_PERTARGET", "PROSPER_RTT_SINGLE_TARGET",
+        "PROSPER_TESTTEX",
+        "PROSPER_TESTLUT", "PROSPER_TESTLUT32"
     };
     for (const char* name : render_env) if (const char* value = std::getenv(name)) m.renderer_env.emplace_back(name, value);
     auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
@@ -427,8 +438,9 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
     if (!capture_draw_items(items, m, reader, pending->capture, error)) {
         std::fprintf(stderr, "[gpucap] capture failed: %s\n", error.c_str()); return {};
     }
-    std::fprintf(stderr, "[gpucap] captured submit %llu: %zu draws, %zu blobs -> %s\n",
-                 static_cast<unsigned long long>(current), items.size(), pending->capture.blobs.size(), path);
+    std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu blobs -> %s\n",
+                 static_cast<unsigned long long>(current), static_cast<unsigned long long>(invocation),
+                 items.size(), pending->capture.blobs.size(), path);
     return pending;
 }
 

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -49,6 +49,7 @@ struct GpuCapturedDraw {
     uint32_t vertex_count = 3;
     std::vector<uint32_t> indices;
     uint64_t color0_base = 0;
+    uint32_t color0_width = 0, color0_height = 0;
 };
 
 struct GpuCaptureFile {

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -49,6 +49,7 @@ struct DrawItem {
     // subsequent draw samples a texture at a matching base (otherwise the sample reads empty guest
     // memory — the scene RT is never populated on the CPU side — and the frame is a black composite).
     uint64_t color0_base = 0;
+    uint32_t color0_width = 0, color0_height = 0;
 };
 
 // The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8
@@ -118,6 +119,16 @@ void assign_convention_bindings(ShaderResourceTable& t, uint32_t first);
 // 2, vertex buffer -> binding 3, textures -> binding 4+). Returns null if the stage has no shader header
 // or no resources. Implemented in gpu_executor.cpp (needs the AGC registry + descriptor decode).
 std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr, bool is_ps);
+
+// PROSPER_COMPUTELOG diagnostic: resolve every skipped DispatchDirect packet's compute shader and
+// AGC resource table from its retained register snapshot. PROSPER_COMPUTELOG_DIM=WxH restricts output
+// to dispatches referencing an image of that size (for example the Messenger 1024x32 grading LUT).
+void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no);
+
+// PROSPER_PROVENANCE_DIM=WxH: retain color-target address history across submits, then inspect
+// sampled images of that size and report the most recent draw that wrote the same guest address.
+// PROSPER_PROVENANCE_MIN_DRAWS=N limits expensive descriptor resolution to large target submits.
+void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no);
 
 // Byte size of one index element for a GpuState::index_type (the last SetIndexType value).
 // 0 -> 16-bit, 1 -> 32-bit, exactly Kyty's index_type_and_size switch (GraphicsRender.cpp:4724) and
@@ -453,6 +464,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     out.vs = std::move(vs); out.fs = std::move(fs); out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
     out.color0_base = rs.color0_base;   // render-to-texture: the target this draw writes into (#167)
+    out.color0_width = rs.color0_width; out.color0_height = rs.color0_height; // per-target extent (#526)
     return true;
 }
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -703,8 +703,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     }
                     Gen5ImageFormatInfo fi;
                     if (!gen5_image_format(d.format, &fi)) {
-                        // Same unmapped-format policy as build_shader_resources: bind as RGBA8 only
-                        // under RTT (so render-to-texture injection can supply the pixels), else skip.
+                        // Same policy as build_shader_resources: the normal per-target renderer can
+                        // bind this as RGBA8 for RTT injection; legacy single-target mode skips it.
                         static const bool rtt_bind = getenv("PROSPER_RTT") != nullptr ||
                                                      getenv("PROSPER_RTT_PERTARGET") != nullptr;
                         if (!rtt_bind) continue;
@@ -785,6 +785,175 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     if (log) fprintf(stderr, "[restab] %s code=0x%llx -> no resources in any user-data base\n",
                      is_ps ? "PS" : "VS", (unsigned long long)code_addr);
     return nullptr;
+}
+
+void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
+    const char* enabled = getenv("PROSPER_COMPUTELOG");
+    const char* dim_env = getenv("PROSPER_COMPUTELOG_DIM");
+    if ((!enabled || !*enabled) && (!dim_env || !*dim_env)) return;
+
+    uint32_t want_w = 0, want_h = 0;
+    if (dim_env && *dim_env && sscanf(dim_env, "%ux%u", &want_w, &want_h) != 2) {
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            fprintf(stderr, "[compute] invalid PROSPER_COMPUTELOG_DIM='%s' (expected WxH)\n", dim_env);
+        }
+        want_w = want_h = 0;
+    }
+
+    namespace P = prosper::agc::Pm4;
+    auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
+        auto it = regs.find(off); return it == regs.end() ? 0u : it->second;
+    };
+    auto pgm_addr = [&](const GpuState& ds) {
+        uint32_t lo = rd(ds.sh, P::COMPUTE_PGM_LO), hi = rd(ds.sh, P::COMPUTE_PGM_HI);
+        return (static_cast<uint64_t>(lo) << 8) | (static_cast<uint64_t>(hi & 0xffu) << 40);
+    };
+
+    size_t matched = 0;
+    for (size_t i = 0; i < st.dispatches.size(); ++i) {
+        const auto& d = st.dispatches[i];
+        const GpuState& ds = d.state ? *d.state : st;
+        const uint64_t code_addr = pgm_addr(ds);
+        const auto* hdr = static_cast<const AgcShaderHeader*>(prosper_agc_shader_header_for_code(code_addr));
+
+        uint32_t range_start = 0;
+        if (hdr && hdr->specials && guest_readable((uint64_t)(uintptr_t)hdr->specials,
+                                                   sizeof(AgcShaderSpecials))) {
+            uint32_t s = hdr->specials->user_data_range_start;
+            uint32_t e = hdr->specials->user_data_range_end;
+            if (s < kUserSgprs && e > s && e <= 2 * kUserSgprs) range_start = s;
+        }
+
+        ShaderResourceTable table;
+        if (hdr) {
+            uint32_t sgprs[kUserSgprs];
+            read_user_sgprs(ds.sh, P::COMPUTE_USER_DATA_0 + range_start, sgprs);
+            table = build_shader_resources(*hdr, sgprs, kUserSgprs, 0);
+            assign_convention_bindings(table, 2);
+        }
+
+        bool dim_match = !want_w || !want_h;
+        if (!dim_match) {
+            for (const auto& r : table.resources)
+                if (r.width == want_w && r.height == want_h) { dim_match = true; break; }
+        }
+        if (!dim_match) continue;
+        matched++;
+
+        uint64_t code_hash = 1469598103934665603ull;
+        if (code_addr && guest_readable(code_addr, 4096)) {
+            const uint8_t* p = reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(code_addr));
+            for (size_t n = 0; n < 4096; ++n) { code_hash ^= p[n]; code_hash *= 1099511628211ull; }
+        } else {
+            code_hash = 0;
+        }
+        fprintf(stderr,
+                "[compute] submit=%llu dispatch=%zu groups=%ux%ux%u modifier=0x%llx "
+                "code=0x%llx hash4k=%016llx header=%s resources=%zu\n",
+                (unsigned long long)submit_no, i, d.tg_x, d.tg_y, d.tg_z,
+                (unsigned long long)d.modifier, (unsigned long long)code_addr,
+                (unsigned long long)code_hash, hdr ? "yes" : "no", table.resources.size());
+        for (const auto& r : table.resources) {
+            fprintf(stderr,
+                    "[compute]   cls=%u binding=%u addr=0x%llx size=%u dims=%ux%u "
+                    "fmt=%u comps=%u tile=%u sgpr=%u srt=0x%x\n",
+                    (unsigned)r.cls, r.binding, (unsigned long long)r.gpu_addr, r.size,
+                    r.width, r.height, (unsigned)r.format, r.num_components, r.tile_mode,
+                    r.sgpr_base, r.srt_offset);
+        }
+    }
+
+    if (want_w && want_h && !st.dispatches.empty() && matched == 0 && enabled && enabled[0] == 'a') {
+        fprintf(stderr, "[compute] submit=%llu dispatches=%zu: no resource matched %ux%u\n",
+                (unsigned long long)submit_no, st.dispatches.size(), want_w, want_h);
+    }
+}
+
+void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
+    const char* dim_env = getenv("PROSPER_PROVENANCE_DIM");
+    if (!dim_env || !*dim_env) return;
+
+    uint32_t want_w = 0, want_h = 0;
+    if (sscanf(dim_env, "%ux%u", &want_w, &want_h) != 2 || !want_w || !want_h) {
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            fprintf(stderr, "[provenance] invalid PROSPER_PROVENANCE_DIM='%s' (expected WxH)\n", dim_env);
+        }
+        return;
+    }
+    const size_t min_draws = [] {
+        const char* e = getenv("PROSPER_PROVENANCE_MIN_DRAWS");
+        return e ? static_cast<size_t>(strtoull(e, nullptr, 0)) : size_t{0};
+    }();
+
+    struct ColorWrite {
+        uint64_t submit = 0;
+        uint64_t draw_submit = 0;
+        size_t draw = 0;
+        uint64_t vs = 0, ps = 0;
+        uint32_t width = 0, height = 0;
+        GpuState::Draw draw_record{};
+    };
+    static std::unordered_map<uint64_t, ColorWrite> last_color_write;
+    static uint64_t draw_submit_ordinal = 0;
+    const uint64_t this_draw_submit = st.draws.empty() ? draw_submit_ordinal : draw_submit_ordinal++;
+
+    const bool inspect_consumers = st.draws.size() >= min_draws;
+    for (size_t i = 0; i < st.draws.size(); ++i) {
+        const GpuState& ds = st.draws[i].state ? *st.draws[i].state : st;
+        const RenderState rs = extract_render_state(ds);
+
+        // Query before recording this draw's target: a feedback draw should resolve to the preceding
+        // writer, not identify itself as its own producer.
+        if (inspect_consumers && rs.ps_addr) {
+            auto prt = build_stage_table(ds, rs.ps_addr, true);
+            if (prt) for (const auto& r : prt->resources) {
+                if (r.width != want_w || r.height != want_h) continue;
+                auto it = last_color_write.find(r.gpu_addr);
+                if (it == last_color_write.end()) {
+                    fprintf(stderr,
+                            "[provenance] consumer submit=%llu draw=%zu ps=0x%llx samples "
+                            "addr=0x%llx dims=%ux%u draw_submit=%llu: no prior color-target write\n",
+                            (unsigned long long)submit_no, i, (unsigned long long)rs.ps_addr,
+                            (unsigned long long)r.gpu_addr, r.width, r.height,
+                            (unsigned long long)this_draw_submit);
+                } else {
+                    const ColorWrite& w = it->second;
+                    fprintf(stderr,
+                            "[provenance] consumer submit=%llu draw=%zu ps=0x%llx samples "
+                            "addr=0x%llx dims=%ux%u draw_submit=%llu: last color write submit=%llu "
+                            "draw_submit=%llu draw=%zu target_extent=%ux%u "
+                            "vs=0x%llx ps=0x%llx\n",
+                            (unsigned long long)submit_no, i, (unsigned long long)rs.ps_addr,
+                            (unsigned long long)r.gpu_addr, r.width, r.height,
+                            (unsigned long long)this_draw_submit, (unsigned long long)w.submit,
+                            (unsigned long long)w.draw_submit, w.draw, w.width, w.height,
+                            (unsigned long long)w.vs, (unsigned long long)w.ps);
+                    static std::set<uint64_t> probed;
+                    if (probed.insert(r.gpu_addr).second && w.draw_record.state) {
+                        DrawItem producer;
+                        bool realized = realize_draw_item(*w.draw_record.state, &w.draw_record,
+                                                         w.draw_record.index_count, 0x10000, true, producer);
+                        fprintf(stderr,
+                                "[provenance] producer-realize addr=0x%llx result=%s extent=%ux%u "
+                                "items-target=0x%llx\n",
+                                (unsigned long long)r.gpu_addr, realized ? "success" : "dropped",
+                                producer.color0_width, producer.color0_height,
+                                (unsigned long long)producer.color0_base);
+                    }
+                }
+            }
+        }
+
+        if (rs.color0_base)
+            last_color_write[rs.color0_base] = {
+                submit_no, this_draw_submit, i, rs.es_addr, rs.ps_addr,
+                rs.color0_width, rs.color0_height, st.draws[i]
+            };
+    }
 }
 
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2137,6 +2137,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // low half. VERIFIED(round-trip llvm-mc gfx1030: 0x0a/0x0b).
                 case 0x0A: d = b.pack_half_lo(a); break;              // v_cvt_f16_f32
                 case 0x0B: d = b.unpack_half(a, 0); break;            // v_cvt_f32_f16
+                // v_cvt_off_f32_i4: sign-extend the low 4-bit integer and scale by 1/16.
+                // AMD RDNA2 ISA: "4-bit signed int to 32-bit float"; LLVM's intrinsic
+                // contract specifies result = 0.0625f * src_i4. This is the only opcode
+                // that blocked The Messenger's 1024x32 grading-LUT producer (#527).
+                case 0x0E:
+                    d = b.fbin(Op_FMul,
+                               b.cvt_i2f(b.bfe_s(a, b.uconst(0), b.uconst(4))),
+                               b.uconst(fbits(0.0625f)));
+                    break;
                 case 0x20: d = b.fext1(Glsl_Fract, a); break;         // v_fract_f32
                 case 0x21: d = b.fext1(Glsl_Trunc, a); break;         // v_trunc_f32
                 case 0x22: d = b.fext1(Glsl_Ceil, a); break;          // v_ceil_f32
@@ -2185,7 +2194,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // opcodes only (mirrors the VOP2/VOP3 fresult path; DOLL VS: `v_exp_f32_sdwa … clamp`).
             // A modifier on a non-float-result op would silently drop — reject loudly instead.
             if (ok && (in.omod || in.clamp)) switch (in.opcode) {
-                case 0x05: case 0x06: case 0x0B: case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
+                case 0x05: case 0x06: case 0x0B: case 0x0E: case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
                 case 0x25: case 0x27: case 0x2A: case 0x2B: case 0x2E: case 0x33: case 0x35: case 0x36:
                     if      (in.omod == 1) d = b.fbin(Op_FMul, d, b.uconst(fbits(2.0f)));
                     else if (in.omod == 2) d = b.fbin(Op_FMul, d, b.uconst(fbits(4.0f)));

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -78,6 +78,13 @@ RenderState extract_render_state(const GpuState& st) {
     rs.color0_number_type      = PM4_FIELD(cinfo, CB_COLOR0_INFO, NUMBER_TYPE);
     rs.color0_comp_swap        = PM4_FIELD(cinfo, CB_COLOR0_INFO, COMP_SWAP);
 
+    auto color_attrib2 = st.cx.find(P::CB_COLOR0_ATTRIB2);
+    if (color_attrib2 != st.cx.end()) {
+        rs.color0_has_extent = true;
+        rs.color0_width  = PM4_FIELD(color_attrib2->second, CB_COLOR0_ATTRIB2, MIP0_WIDTH) + 1u;
+        rs.color0_height = PM4_FIELD(color_attrib2->second, CB_COLOR0_ATTRIB2, MIP0_HEIGHT) + 1u;
+    }
+
     // CB fast-clear color (CB_COLOR0_CLEAR_WORD0/1). Present only when the game programs a fast-clear
     // for MRT 0; the words carry the clear value in the target's pixel format (decoded in resolve).
     rs.color0_has_clear   = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) || st.cx.count(P::CB_COLOR0_CLEAR_WORD1);

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -26,6 +26,11 @@ struct RenderState {
     uint32_t color0_number_type = 0;   // CB_COLOR0_INFO.NUMBER_TYPE  (UNORM/SRGB/…)
     uint32_t color0_comp_swap   = 0;   // CB_COLOR0_INFO.COMP_SWAP    (channel order: RGBA/BGRA/…)
 
+    // Gen5 target extent from CB_COLOR0_ATTRIB2. Fields store dimension-1. This is independent
+    // of VideoOut and of the viewport: Unity's grading LUT is a 1024x32 render target (#526).
+    bool     color0_has_extent = false;
+    uint32_t color0_width = 0, color0_height = 0;
+
     // CB fast-clear for MRT 0 (CB_COLOR0_CLEAR_WORD0/1 = 0x323/0x324). `has_clear` is true when the
     // game PROGRAMMED the clear words (register present); the words hold the clear value in the
     // target's pixel format, decoded to an RGBA float in resolve_pipeline_state (#309).

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1021,8 +1021,11 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
+    agc_gpu_state().dispatches.clear();
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
+    gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
+    gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     // #312 EOP visibility contract: the pulse fires immediately only when no gated writes are
     // pending; otherwise it is OWED and delivered when the tail drains (the guest's completion
     // scan must never observe a half-retired frame — see command_processor.cpp). The flip and the
@@ -1137,8 +1140,11 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
+    agc_gpu_state().dispatches.clear();
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;
+    gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
+    gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
     // #312 EOP visibility contract: pulse only when no gated writes are pending, else owed until

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -157,12 +157,41 @@ namespace {
     // (e.g. an async-loader worker) which a main-thread-only bp misses. Per-thread fd + stepping state.
     bool                 g_hwbp_allthreads = false;
     thread_local int     t_hwbp_fd = -1;       // this thread's own bp fd (main thread mirrors g_hwbp_fd)
-    thread_local bool    t_hwbp_stepping = false;
+    // Signal handlers can run while the guest owns %fs, so C++ thread_local state is not usable there.
+    // Publish perf fds by kernel tid before enabling them; the handler then finds its own step state
+    // without touching host TLS. Fixed storage also keeps lookup allocation/lock-free in the handler.
+    static constexpr int HWBP_THREAD_MAX = 512;
+    struct HwbpThreadState {
+        volatile long tid;
+        volatile sig_atomic_t fd;
+        volatile sig_atomic_t stepping;
+    };
+    HwbpThreadState g_hwbp_threads[HWBP_THREAD_MAX] = {};
+    volatile int g_hwbp_thread_count = 0;
+    HwbpThreadState* hwbp_thread_state(long tid) {
+        const int count = __atomic_load_n(&g_hwbp_thread_count, __ATOMIC_ACQUIRE);
+        for (int i = 0; i < count && i < HWBP_THREAD_MAX; ++i) {
+            if (__atomic_load_n(&g_hwbp_threads[i].tid, __ATOMIC_ACQUIRE) == tid)
+                return &g_hwbp_threads[i];
+        }
+        return nullptr;
+    }
+    bool hwbp_register_thread(long tid, int fd) {
+        const int slot = __atomic_fetch_add(&g_hwbp_thread_count, 1, __ATOMIC_ACQ_REL);
+        if (slot >= HWBP_THREAD_MAX) return false;
+        g_hwbp_threads[slot].fd = fd;
+        g_hwbp_threads[slot].stepping = 0;
+        __atomic_store_n(&g_hwbp_threads[slot].tid, tid, __ATOMIC_RELEASE);
+        return true;
+    }
     // PROSPER_HWBP_R15=<hex>: only LOG when r15 == this value (a condition, evaluated in-process = no gdb
     // round-trip). When matched, also dump a window of memory around rax + classify rax's mapping. Built to
     // catch the one deserializer read that produces a garbage std::string length without the gdb-bp overhead
     // that times out on hot addresses. r15 is used because it carries the read length at eboot+0x7e40e1.
     uint64_t g_hwbp_r15 = 0; bool g_hwbp_r15_on = false;
+    // PROSPER_HWBP_RET=<absolute VA>: only log calls whose stack return address matches. This isolates
+    // one caller of a hot shared function while still stepping/rearming silently for all other hits.
+    uint64_t g_hwbp_ret = 0; bool g_hwbp_ret_on = false;
     // PROSPER_HWBP_RAXMIN=<hex>: only LOG when rax >= this (a cursor-range gate). Lets a trace of a hot
     // shared reader isolate one buffer/context (e.g. the 16 MB shader pool at 0x7ffefc…) out of thousands
     // of unrelated small-string reads, so the log + the max-count apply to the context of interest.
@@ -744,6 +773,7 @@ namespace {
         // safe on hot/multi-threaded functions.
         if (sig == SIGTRAP && ((g_hwbp_on && g_hwbp_fd >= 0) || g_hwwatch_fd >= 0)) {
             auto* uc = (ucontext_t*)uctx;
+            HwbpThreadState* hwbp_state = hwbp_thread_state(cur_tid());
             // Step-window: continuous single-step from driver hit N to the next driver hit. On each step,
             // find the live read cursor (a GP reg pointing inside [base,end]) and ring-log advances.
             if (g_stepwin_active && si->si_code == TRAP_TRACE) {
@@ -774,10 +804,15 @@ namespace {
                 }
                 return;
             }
-            if ((t_hwbp_stepping || g_hwbp_stepping) && si->si_code == TRAP_TRACE) {
-                ioctl(t_hwbp_fd >= 0 ? t_hwbp_fd : g_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
+            // perf's asynchronous SIGTRAP delivery does not reliably preserve TRAP_TRACE for the
+            // TF completion on every host/kernel combination. The perf event is disabled while this
+            // state is set, so the next trap is the single-step completion by construction.
+            if ((hwbp_state && hwbp_state->stepping) || g_hwbp_stepping) {
+                const int fd = hwbp_state ? hwbp_state->fd : g_hwbp_fd;
+                ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
                 uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;
-                t_hwbp_stepping = false; g_hwbp_stepping = false;
+                if (hwbp_state) hwbp_state->stepping = 0;
+                g_hwbp_stepping = false;
                 return;
             }
             // Chained DATA write-watchpoint hit (a write to the watched slot completed): log the writer
@@ -808,7 +843,10 @@ namespace {
             // This handler returns to the guest, which may be on the guest %fs — swap to host %fs for the
             // host-libc logging below, restore before returning. No-op off the guest-fs path.
             uint64_t saved_fs = guest_fs_to_host_scoped();
-            bool cond_ok = (!g_hwbp_r15_on || (r15 == g_hwbp_r15)) && (rax >= g_hwbp_raxmin);
+            const uint64_t rsp = (uint64_t)gr[REG_RSP];
+            const uint64_t ret = probe_readable(rsp + 7) ? *(const uint64_t*)rsp : 0;
+            bool cond_ok = (!g_hwbp_r15_on || (r15 == g_hwbp_r15)) &&
+                           (!g_hwbp_ret_on || (ret == g_hwbp_ret)) && (rax >= g_hwbp_raxmin);
             // PROSPER_HWBP_ANOM ring trace: push every gated hit; when a read yields a value >= the
             // anomaly threshold, dump the ring (the cursor walk into the over-read) exactly once.
             if (g_hwbp_anom_on && cond_ok && !g_hwbp_ring_dumped) {
@@ -928,13 +966,21 @@ namespace {
                 }
             }
             // PROSPER_HWBP_ARGS=1: at a method-entry bp, print the SysV integer-arg registers
-            // (rdi/rsi/rdx/rcx/r8/r9) + the return address, so a call's arguments (e.g. an enum/mode
-            // in esi) are visible per hit without a gdb round-trip. Generic; composes with the count cap.
+            // (rdi/rsi/rdx/rcx/r8/r9), guarded [rdi+0x10]/[rdx+0x10], and the return address, so a
+            // call's arguments (and UnityEngine.Object m_CachedPtr values) are visible per hit without
+            // a gdb round-trip. Generic; composes with the count cap.
             if (g_hwbp_args && cond_ok) {
-                char b[192]; int n = snprintf(b, sizeof b,
-                    "[hwbp-args] rdi=0x%llx rsi=0x%llx rdx=0x%llx rcx=0x%llx r8=0x%llx r9=0x%llx ret=eboot+0x%llx\n",
-                    (unsigned long long)gr[REG_RDI], (unsigned long long)gr[REG_RSI],
-                    (unsigned long long)gr[REG_RDX], (unsigned long long)gr[REG_RCX],
+                auto arg_field = [](uint64_t p) -> uint64_t {
+                    return probe_readable(p + 0x17) ? *(const uint64_t*)(p + 0x10) : 0;
+                };
+                char b[256]; int n = snprintf(b, sizeof b,
+                    "[hwbp-args] rdi=0x%llx [+10]=0x%llx rsi=0x%llx rdx=0x%llx [+10]=0x%llx rcx=0x%llx r8=0x%llx r9=0x%llx ret=eboot+0x%llx\n",
+                    (unsigned long long)gr[REG_RDI],
+                    (unsigned long long)arg_field((uint64_t)gr[REG_RDI]),
+                    (unsigned long long)gr[REG_RSI],
+                    (unsigned long long)gr[REG_RDX],
+                    (unsigned long long)arg_field((uint64_t)gr[REG_RDX]),
+                    (unsigned long long)gr[REG_RCX],
                     (unsigned long long)gr[REG_R8], (unsigned long long)gr[REG_R9],
                     (unsigned long long)(probe_readable((uint64_t)gr[REG_RSP]) ? (*(const uint64_t*)(uint64_t)gr[REG_RSP] - 0x400000000ull) : 0));
                 syscall(SYS_write, 2, b, (size_t)n);
@@ -1046,7 +1092,9 @@ namespace {
                 else if (!strcmp(r,"rbp")) base = (uint64_t)gr[REG_RBP];
                 arm_hwwatch(base + (uint64_t)g_hwwatch_delta);
             }
-            ioctl(t_hwbp_fd >= 0 ? t_hwbp_fd : g_hwbp_fd, PERF_EVENT_IOC_DISABLE, 0);   // disable so we can step off the bp address
+            const int hit_fd = hwbp_state ? hwbp_state->fd :
+                               (si->si_fd >= 0 ? si->si_fd : g_hwbp_fd);
+            ioctl(hit_fd, PERF_EVENT_IOC_DISABLE, 0);   // disable so we can step off the bp address
             // Step-window ENTRY: on the Nth driver hit, begin continuous single-stepping (bp stays disabled;
             // the window ends when we single-step back to the driver = next hit). Buffer range is [base,
             // base+0x20000) — the reader's own end grows across the window, so use a generous span.
@@ -1070,7 +1118,7 @@ namespace {
             // can be 0 to suppress the per-hit log yet keep the bp live feeding the ring until it dumps).
             if (g_hwbp_count < g_hwbp_max || ((g_hwbp_anom_on || g_hwbp_node_on) && !g_hwbp_ring_dumped)) {
                 uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;
-                if (t_hwbp_fd >= 0) t_hwbp_stepping = true; else g_hwbp_stepping = true;
+                if (hwbp_state) hwbp_state->stepping = 1; else g_hwbp_stepping = true;
             }                                              // else: leave disabled (one-and-done at the cap)
             guest_fs_restore_scoped(saved_fs);             // back to guest %fs before returning to guest code
             return;
@@ -1761,6 +1809,7 @@ void install_trap_handler() {
         g_hwbp_addr = 0x400000000ull + strtoull(hb, nullptr, 0);
         if (const char* m = getenv("PROSPER_HWBP_MAX")) g_hwbp_max = (int)strtoul(m, nullptr, 0);
         if (const char* c = getenv("PROSPER_HWBP_R15")) { g_hwbp_r15 = strtoull(c, nullptr, 0); g_hwbp_r15_on = true; }
+        if (const char* c = getenv("PROSPER_HWBP_RET")) { g_hwbp_ret = strtoull(c, nullptr, 0); g_hwbp_ret_on = true; }
         if (const char* c = getenv("PROSPER_HWBP_RAXMIN")) g_hwbp_raxmin = strtoull(c, nullptr, 0);
         if (const char* c = getenv("PROSPER_HWBP_ANOM")) { g_hwbp_anom = strtoull(c, nullptr, 0); g_hwbp_anom_on = true; }
         if (getenv("PROSPER_HWBP_NODE")) g_hwbp_node_on = true;
@@ -1835,6 +1884,12 @@ void arm_hwbp() {
     fcntl(g_hwbp_fd, F_SETSIG, SIGTRAP);
     struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
     fcntl(g_hwbp_fd, F_SETOWN_EX, &ow);
+    if (!hwbp_register_thread(ow.pid, g_hwbp_fd)) {
+        int n = snprintf(b, sizeof b, "[hwbp] thread-state table full for tid=%ld - HW bp disabled\n",
+                         (long)ow.pid);
+        syscall(SYS_write, 2, b, (size_t)n);
+        close(g_hwbp_fd); g_hwbp_fd = -1; g_hwbp_on = false; return;
+    }
     ioctl(g_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     t_hwbp_fd = g_hwbp_fd;   // main thread uses the same fd for its per-thread stepping state
     int n = snprintf(b, sizeof b, "[hwbp] armed HW execute bp at eboot+0x%llx (fd=%d tid=%ld)\n",
@@ -1857,6 +1912,12 @@ void arm_hwbp_this_thread() {
     fcntl(t_hwbp_fd, F_SETSIG, SIGTRAP);
     struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
     fcntl(t_hwbp_fd, F_SETOWN_EX, &ow);
+    if (!hwbp_register_thread(ow.pid, t_hwbp_fd)) {
+        char b[112]; int n = snprintf(b, sizeof b,
+            "[hwbp] thread-state table full for worker tid=%ld - not armed\n", (long)ow.pid);
+        syscall(SYS_write, 2, b, n);
+        close(t_hwbp_fd); t_hwbp_fd = -1; return;
+    }
     ioctl(t_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     char b[128]; int n = snprintf(b, sizeof b, "[hwbp] armed on worker tid=%ld (fd=%d) for eboot+0x%llx\n",
         (long)syscall(SYS_gettid), t_hwbp_fd, (unsigned long long)(g_hwbp_addr - 0x400000000ull));

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -6,6 +6,7 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/pm4_registers.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
@@ -39,8 +40,9 @@ int main() {
     auto setcx = Hle::lookup("ZvwO9euwYzc");   // SetCxRegistersIndirect
     auto setsh = Hle::lookup("-HOOCn0JY48");   // SetShRegistersIndirect
     auto draw  = Hle::lookup("Yw0jKSqop+E");   // DrawIndexAuto
-    CHECK(reset && idx && setcx && setsh && draw, "AGC Dcb builders registered");
-    if (!(reset && idx && setcx && setsh && draw)) { printf("== FAIL ==\n"); return 1; }
+    auto dispatch = Hle::lookup("k3GhuSNmBLU"); // DispatchDirect
+    CHECK(reset && idx && setcx && setsh && draw && dispatch, "AGC Dcb builders registered");
+    if (!(reset && idx && setcx && setsh && draw && dispatch)) { printf("== FAIL ==\n"); return 1; }
 
     uint32_t buffer[256];
     memset(buffer, 0, sizeof buffer);
@@ -177,6 +179,41 @@ int main() {
             CHECK(s4.draws[2].state->sh.at(0x42) == 0xBBBB, "draw 2 snapshot holds the updated value");
             CHECK(s4.sh.at(0x42) == 0xBBBB, "folded end state is the last write");
             CHECK(&s4.state_at_draw(0) == s4.draws[0].state.get(), "state_at_draw returns the snapshot");
+        }
+    }
+
+    // Compute is not executed yet, but each DispatchDirect must retain its exact register state so
+    // producer-provenance diagnostics can resolve the bound shader and resources (#524).
+    {
+        namespace P = prosper::agc::Pm4;
+        uint32_t cbuf[128]; memset(cbuf, 0, sizeof cbuf);
+        Dcb cd{}; cd.bottom = cbuf; cd.top = cbuf + 128; cd.cursor_up = cbuf; cd.cursor_down = cbuf + 128;
+        auto CD = (uint64_t)(uintptr_t)&cd;
+        ShaderReg cregs0[2] = {
+            {P::COMPUTE_PGM_LO, 0x00123456u},
+            {P::COMPUTE_USER_DATA_0 + 3, 0xAAAA1111u},
+        };
+        ShaderReg cregs1[1] = {{P::COMPUTE_USER_DATA_0 + 3, 0xBBBB2222u}};
+        reset(CD, 0x3ff, 0, 0, 0, 0);
+        setsh(CD, (uint64_t)(uintptr_t)cregs0, 2, 0, 0, 0);
+        dispatch(CD, 32, 4, 1, 0x1122334455667788ull, 0);
+        setsh(CD, (uint64_t)(uintptr_t)cregs1, 1, 0, 0, 0);
+        dispatch(CD, 8, 2, 3, 0x8877665544332211ull, 0);
+        GpuState cs;
+        run_cb(cbuf, 128, cs);
+        CHECK(cs.dispatch_count == 2 && cs.dispatches.size() == 2,
+              "2 compute dispatches counted and retained");
+        if (cs.dispatches.size() == 2) {
+            CHECK(cs.dispatches[0].tg_x == 32 && cs.dispatches[0].tg_y == 4 && cs.dispatches[0].tg_z == 1,
+                  "dispatch 0 threadgroup counts retained");
+            CHECK(cs.dispatches[0].modifier == 0x1122334455667788ull,
+                  "dispatch 0 modifier retained");
+            CHECK(cs.dispatches[0].state &&
+                  cs.dispatches[0].state->sh.at(P::COMPUTE_USER_DATA_0 + 3) == 0xAAAA1111u,
+                  "dispatch 0 snapshot retains pre-update compute user data");
+            CHECK(cs.dispatches[1].state &&
+                  cs.dispatches[1].state->sh.at(P::COMPUTE_USER_DATA_0 + 3) == 0xBBBB2222u,
+                  "dispatch 1 snapshot retains updated compute user data");
         }
     }
 

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -30,6 +30,7 @@ int main() {
 
     DrawItem draw; draw.vs = {0x07230203, 1, 2}; draw.fs = {0x07230203, 3}; draw.vrt = table;
     draw.vertex_count = 6; draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
+    draw.color0_width = 1024; draw.color0_height = 32;
     draw.ps.topology = 3; draw.ps.color0_format = 37; draw.ps.blend_enable = true;
     draw.ps.has_viewport = true; draw.ps.viewport_w = 1920; draw.ps.viewport_h = -1080;
     draw.ps.db_render_control = 2; draw.ps.stencil_clear_enable = true;
@@ -60,6 +61,8 @@ int main() {
           loaded.draws.size() == 1 && loaded.draws[0].indices.size() == 6, "metadata and draw data round-trip");
     CHECK(loaded.draws[0].ps.viewport_h == -1080 && loaded.draws[0].ps.blend_enable,
           "fixed-function pipeline state round-trips explicitly");
+    CHECK(loaded.draws[0].color0_width == 1024 && loaded.draws[0].color0_height == 32,
+          "per-target extent round-trips");
     CHECK(loaded.draws[0].ps.db_render_control == 2 && loaded.draws[0].ps.stencil_clear_enable &&
           loaded.draws[0].ps.has_stencil_clear && loaded.draws[0].ps.stencil_clear_value == 3 &&
           loaded.draws[0].ps.stencil_read_base == 0x12345000 &&

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -59,6 +59,34 @@ int main() {
               "replay samples captured red texel from owned backing");
     }
 
+    // A non-VideoOut producer must render at CB_COLOR0_ATTRIB2's extent, be cached under its
+    // target address, and feed a later pass. Before #526 both passes used the global 64x64 extent.
+    DrawItem producer = replay.items[0];
+    producer.color0_base = 0x300000;
+    producer.color0_width = 32;
+    producer.color0_height = 2;
+
+    DrawItem consumer = replay.items[0];
+    consumer.color0_base = 0x400000;
+    consumer.color0_width = 16;
+    consumer.color0_height = 16;
+    auto consumer_rt = std::make_shared<ShaderResourceTable>(*consumer.prt);
+    consumer_rt->resources[0].gpu_addr = producer.color0_base;
+    consumer_rt->resources[0].width = producer.color0_width;
+    consumer_rt->resources[0].height = producer.color0_height;
+    consumer_rt->resources[0].host_data = nullptr;
+    consumer_rt->resources[0].host_data_size = 0;
+    consumer.prt = std::move(consumer_rt);
+
+    std::vector<uint8_t> chained = render_submit_items({producer, consumer}, W, H);
+    CHECK(chained.size() == static_cast<size_t>(16) * 16 * 4,
+          "per-target chain returns the last pass at its declared 16x16 extent");
+    if (chained.size() == static_cast<size_t>(16) * 16 * 4) {
+        const uint8_t* center = &chained[(8u * 16u + 8u) * 4];
+        CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
+              "later pass samples pixels cached from the 32x2 producer target");
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;
 }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1897,6 +1897,26 @@ int main() {
            gotT22.size()==8?gotT22[3]:-1, expT22[3]);
     CHECK(gotT22.size()==8 && badT22==0, "T22: WORD-dst f16 mul + WORD-to-WORD mov preserve halves exactly");
 
+    // Kernel T24: v_cvt_off_f32_i4 (#527). The low nibble is a signed i4 [-8,7],
+    // converted to f32 and scaled by 1/16. Exercise every nibble, including both signs.
+    const uint32_t codeT24[] = { 0x7e001d00u, 0xbf810000u };
+    std::vector<uint32_t> spvT24 = recompile_valu(codeT24, sizeof(codeT24)/4, 1, 0);
+    CHECK(!spvT24.empty(), "recompiled T24 (v_cvt_off_f32_i4) -> SPIR-V");
+    std::vector<float> inT24(16), expT24(16);
+    for (uint32_t i = 0; i < 16; ++i) {
+        uint32_t raw = i; std::memcpy(&inT24[i], &raw, sizeof raw);
+        int32_t s4 = (i & 8u) ? (int32_t)i - 16 : (int32_t)i;
+        expT24[i] = (float)s4 * 0.0625f;
+    }
+    std::vector<float> gotT24 = prosper::test::run_compute(spvT24, inT24, 16, 16);
+    uint32_t badT24 = 0;
+    for (uint32_t i = 0; i < 16 && gotT24.size() == 16; ++i)
+        if (gotT24[i] != expT24[i]) badT24++;
+    printf("  T24(i4 offset convert) mismatches=%u (nibble 7=%g, 8=%g)\n", badT24,
+           gotT24.size()==16?gotT24[7]:-9.f, gotT24.size()==16?gotT24[8]:-9.f);
+    CHECK(gotT24.size()==16 && badT24==0,
+          "T24: signed i4 values convert to f32 multiples of 1/16 exactly");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -70,6 +70,11 @@ int main() {
     CHECK(f.unsupported == 0 && f.table_dependent >= 1 && f.first_bad_fmt < 0,
           "#325: a 2D_ARRAY image_sample is recompilable-in-context (base slice), not unsupported");
 
+    const uint32_t cvt_i4[] = { 0x7e001d00u, 0xBF810000u }; // v_cvt_off_f32_i4 v0,v0
+    RecompileCoverage g = recompile_coverage(cvt_i4, sizeof(cvt_i4)/sizeof(cvt_i4[0]));
+    CHECK(g.total == 1 && g.alu == 1 && g.unsupported == 0,
+          "#527: v_cvt_off_f32_i4 is covered by the VOP1 recompiler");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -64,6 +64,7 @@ int main() {
         // CB fast-clear (#309): CLEAR_WORD0 holds one texel in the surface's 8_8_8_8 format.
         { P::CB_COLOR0_CLEAR_WORD0, 0x11223344u },
         { P::CB_COLOR0_CLEAR_WORD1, 0x00000000u },
+        { P::CB_COLOR0_ATTRIB2, ((1024u - 1u) << 14) | (32u - 1u) },
     };
     // Shader-stage program addresses.
     ShaderReg sh_regs[] = {
@@ -91,6 +92,8 @@ int main() {
     CHECK(rs.color0_format == 0x0Au, "color0_format = 0x0A (FORMAT field)");
     CHECK(rs.color0_number_type == 6u, "color0_number_type = 6 (SRGB)");
     CHECK(rs.color0_comp_swap == 1u, "color0_comp_swap = 1 (BGRA)");
+    CHECK(rs.color0_has_extent && rs.color0_width == 1024 && rs.color0_height == 32,
+          "CB_COLOR0_ATTRIB2 dimension-minus-one fields decode to 1024x32");
     CHECK(vk_color_format(rs.color0_format, rs.color0_number_type, rs.color0_comp_swap)
               == VkFormat::B8G8R8A8_SRGB, "color format -> VK B8G8R8A8_SRGB");
     CHECK(vk_color_format(0x0Au, 0u, 0u) == VkFormat::R8G8B8A8_UNORM, "0xA/UNORM/RGBA -> R8G8B8A8_UNORM");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -36,13 +36,44 @@ PROSPER_GPU_CAPTURE=/tmp/messenger-level.prgcap PROSPER_GPU_CAPTURE_AT=0 \
 `PROSPER_GPU_CAPTURE_MIN_DRAWS`/`MAX_DRAWS` filter by realized item count; `PROSPER_GPU_CAPTURE_AT`
 counts matching invocations that reach the registered renderer, after the normal `RENDER_EVERY`
 sampling. Aim the live run near the target first; the capture itself writes once.
+`PROSPER_GPU_CAPTURE_AFTER=N` ignores the first `N` renderer invocations before applying the draw-count
+filters and `AT` counter. Pair it with `PROSPER_SUBMITLOG`/`PROSPER_RENDER_FIRST` when several early
+scenes share the same draw count as a late target.
 Set `PROSPER_CAPTURE_REVISION` explicitly in WSL worktrees: WSL Git cannot resolve their Windows-path
 gitdir links, so the build-time fallback revision is `unknown` there.
+`PROSPER_SUBMITLOG_DIM=WxH` prints the exact renderer invocation for any submit targeting that Gen5
+surface extent, even while `PROSPER_RENDER_FIRST` skips Vulkan work. Use it to start a later render
+window on a one-time offscreen producer rather than after the producer has already been lost.
+`PROSPER_RENDER_TARGET_DIM=WxH` executes matching target submits even before `PROSPER_RENDER_FIRST`.
+This preserves a one-time producer in the RTT cache while still skipping an expensive gap before its
+late consumer.
+`PROSPER_RENDER_RESOURCE_DIM=WxH` likewise executes submits that sample a matching image, allowing a
+producer/consumer A/B without rendering every unrelated submit between them.
+Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
+single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
+offscreen target dimensions.
 
-Use `gpu_replay --inspect-only` to print fixed-function state, resource hashes, explicit clear intent,
-guest depth/stencil surface identities, and raw stencil-op provenance. `--draw N:M` replays an
+Use `gpu_replay --inspect-only` to print fixed-function state, native color-target dimensions, resource
+hashes, explicit clear intent, guest depth/stencil surface identities, and raw stencil-op provenance.
+`--draw N:M` replays an
 inclusive contiguous draw range, which is useful for rendering one pass without its downstream
 composite/scanout draws; a single `--draw N` remains supported.
+`--dump-resource DRAW:vs|ps:BINDING PATH` writes one captured resource's exact backing bytes for
+external numeric/image inspection without dereferencing the original guest address.
+`--dump-shader DRAW:vs|fs PATH` writes the captured SPIR-V module for validation/disassembly.
+
+For skipped-compute producer provenance, `PROSPER_COMPUTELOG=1` records each `DispatchDirect` packet's
+threadgroup counts, compute-program address/hash, and AGC-resolved resources from the register state at
+that exact packet. Add `PROSPER_COMPUTELOG_DIM=WxH` to emit only dispatches referencing an image with
+those dimensions (for example `1024x32` for Messenger's grading LUT). `PROSPER_COMPUTELOG=all` also
+prints a per-submit no-match line while a dimension filter is active. Compute remains unexecuted; this
+trace identifies work and resource contracts that the HLE currently skips.
+
+`PROSPER_PROVENANCE_DIM=WxH` retains every decoded `CB_COLOR0_BASE` write across submits, then reports
+the last matching writer whenever a draw samples an image of that size. Descriptor resolution can be
+limited to likely target submits with `PROSPER_PROVENANCE_MIN_DRAWS=N`; color-target history is still
+recorded for smaller earlier submits. This distinguishes a sampled GPU image produced by a draw from
+one populated by compute/copy/CPU work without requiring the live Vulkan renderer.
 
 For a differential replay, `PROSPER_STENCIL_CLEAR=<0..255>` overrides the initial stencil attachment
 value and `PROSPER_STENCIL_REPLACE=<0..255>` overrides the replacement reference of an

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -20,7 +20,9 @@ bool set_environment(const std::string& name, const std::string& value) {
 }
 
 void usage(const char* argv0) {
-    std::fprintf(stderr, "usage: %s [--inspect|--inspect-only] [--draw N[:M]] [--allow-mismatch] "
+    std::fprintf(stderr, "usage: %s [--inspect|--inspect-only] [--draw N[:M]] "
+                         "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
+                         "[--dump-shader DRAW:vs|fs PATH] "
                          "<capture.prgcap> [output.bmp]\n", argv0);
 }
 
@@ -43,21 +45,33 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
         }
         uint64_t hash = r.host_data ? prosper::gpu::gpu_capture_hash(r.host_data, static_cast<size_t>(r.host_data_size)) : 0;
         std::printf("  %s %-7s b=%u addr=%016llx bytes=%llu nz=%zu hash=%016llx first=%08x "
-                    "fmt=%u nc=%u stride=%u %ux%u tile=%u srt=%08x sgpr=%08x pc=%08x\n",
+                    "fmt=%u nc=%u stride=%u %ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
+                    "srt=%08x sgpr=%08x pc=%08x\n",
                     stage, class_name(r.cls), r.binding, static_cast<unsigned long long>(r.gpu_addr),
                     static_cast<unsigned long long>(r.host_data_size), nz, static_cast<unsigned long long>(hash), first,
                     static_cast<unsigned>(r.format), r.num_components, r.stride, r.width, r.height, r.tile_mode,
+                    r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2],
+                    r.swizzle[0], r.swizzle[1], r.swizzle[2], r.swizzle[3],
+                    r.mag_filter, r.min_filter, r.mip_filter,
                     r.srt_offset, r.sgpr_base, r.fetch_pc);
+        if (r.host_data && r.host_data_size >= 16 &&
+            (r.cls == prosper::gpu::ResourceClass::ConstantBuffer ||
+             r.cls == prosper::gpu::ResourceClass::VertexBuffer)) {
+            uint32_t u[4]; float f[4]; std::memcpy(u, r.host_data, sizeof(u)); std::memcpy(f, u, sizeof(f));
+            std::printf("    first4 u32=%08x,%08x,%08x,%08x f32=%g,%g,%g,%g\n",
+                        u[0], u[1], u[2], u[3], f[0], f[1], f[2], f[3]);
+        }
     }
 }
 
 void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
-        std::printf("draw[%zu] target=%016llx vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
+        std::printf("draw[%zu] target=%016llx extent=%ux%u vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
                     "depth=%d/%d/%u stencil=%d blend=%d viewport=%d %.1f,%.1f %.1fx%.1f "
                     "vs=%zu/%016llx fs=%zu/%016llx\n",
-                    i, static_cast<unsigned long long>(d.color0_base), d.vertex_count, d.indices.size(),
+                    i, static_cast<unsigned long long>(d.color0_base), d.color0_width, d.color0_height,
+                    d.vertex_count, d.indices.size(),
                     d.ps.topology, d.ps.color0_format, d.ps.color_write_mask, d.ps.depth_test_enable,
                     d.ps.depth_write_enable, d.ps.depth_compare_op, d.ps.stencil_enable, d.ps.blend_enable,
                     d.ps.has_viewport, d.ps.viewport_x, d.ps.viewport_y, d.ps.viewport_w, d.ps.viewport_h,
@@ -93,6 +107,7 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
 
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, allow_mismatch = false; int draw_first = -1, draw_last = -1;
+    std::string dump_spec, dump_path, shader_spec, shader_path;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
@@ -102,6 +117,12 @@ int main(int argc, char** argv) {
             std::string range = argv[++i]; size_t colon = range.find(':');
             draw_first = std::atoi(range.c_str());
             draw_last = colon == std::string::npos ? draw_first : std::atoi(range.c_str() + colon + 1);
+        }
+        else if (std::string(argv[i]) == "--dump-resource" && i + 2 < argc) {
+            dump_spec = argv[++i]; dump_path = argv[++i];
+        }
+        else if (std::string(argv[i]) == "--dump-shader" && i + 2 < argc) {
+            shader_spec = argv[++i]; shader_path = argv[++i];
         }
         else positional.push_back(argv[i]);
     }
@@ -120,6 +141,46 @@ int main(int argc, char** argv) {
     prosper::gpu::GpuReplayFrame replay;
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    if (!dump_spec.empty()) {
+        size_t c1 = dump_spec.find(':'), c2 = c1 == std::string::npos ? c1 : dump_spec.find(':', c1 + 1);
+        if (c1 == std::string::npos || c2 == std::string::npos) { usage(argv[0]); return 2; }
+        int di = std::atoi(dump_spec.c_str()); std::string stage = dump_spec.substr(c1 + 1, c2 - c1 - 1);
+        int binding = std::atoi(dump_spec.c_str() + c2 + 1);
+        if (di < 0 || static_cast<size_t>(di) >= replay.items.size() || (stage != "vs" && stage != "ps")) {
+            std::fprintf(stderr, "gpu_replay: invalid resource selector %s\n", dump_spec.c_str()); return 2;
+        }
+        const auto* table = stage == "vs" ? replay.items[di].vrt.get() : replay.items[di].prt.get();
+        const prosper::gpu::ShaderResource* found = nullptr;
+        if (table) for (const auto& resource : table->resources)
+            if (static_cast<int>(resource.binding) == binding) { found = &resource; break; }
+        if (!found || !found->host_data) {
+            std::fprintf(stderr, "gpu_replay: resource %s not found or has no captured bytes\n", dump_spec.c_str()); return 2;
+        }
+        FILE* f = std::fopen(dump_path.c_str(), "wb");
+        if (!f || std::fwrite(found->host_data, 1, static_cast<size_t>(found->host_data_size), f) != found->host_data_size) {
+            if (f) std::fclose(f); std::fprintf(stderr, "gpu_replay: cannot write %s\n", dump_path.c_str()); return 2;
+        }
+        std::fclose(f);
+        std::fprintf(stderr, "[gpureplay] dumped %s (%llu bytes) to %s\n", dump_spec.c_str(),
+                     static_cast<unsigned long long>(found->host_data_size), dump_path.c_str());
+    }
+    if (!shader_spec.empty()) {
+        size_t colon = shader_spec.find(':');
+        int di = std::atoi(shader_spec.c_str()); std::string stage =
+            colon == std::string::npos ? std::string{} : shader_spec.substr(colon + 1);
+        if (colon == std::string::npos || di < 0 || static_cast<size_t>(di) >= replay.items.size() ||
+            (stage != "vs" && stage != "fs")) {
+            std::fprintf(stderr, "gpu_replay: invalid shader selector %s\n", shader_spec.c_str()); return 2;
+        }
+        const auto& words = stage == "vs" ? replay.items[di].vs : replay.items[di].fs;
+        FILE* f = std::fopen(shader_path.c_str(), "wb"); size_t bytes = words.size() * sizeof(uint32_t);
+        if (!f || std::fwrite(words.data(), 1, bytes, f) != bytes) {
+            if (f) std::fclose(f); std::fprintf(stderr, "gpu_replay: cannot write %s\n", shader_path.c_str()); return 2;
+        }
+        std::fclose(f);
+        std::fprintf(stderr, "[gpureplay] dumped %s (%zu bytes) to %s\n", shader_spec.c_str(), bytes,
+                     shader_path.c_str());
     }
     if (draw_first >= 0) {
         if (draw_last < draw_first || static_cast<size_t>(draw_last) >= replay.items.size()) {


### PR DESCRIPTION
## Summary

Restores The Messenger's real 1024x32 color-grading LUT producer and makes the first gameplay level visible without a synthetic texture override.

The root cause had two required parts:

- the producer pixel shader was dropped because `V_CVT_OFF_F32_I4` was unsupported;
- the live renderer ignored `CB_COLOR0_ATTRIB2` and rendered every target at VideoOut dimensions.

## Implementation

- implement `V_CVT_OFF_F32_I4` as signed low-i4 to f32 scaled by 1/16;
- decode and carry native color-target extents through render state, draw items, capture v3, replay, and inspection;
- render small offscreen targets at native size and rescale programmed viewports for each pass;
- make per-target RTT the registered frontend default, with `PROSPER_RTT_SINGLE_TARGET=1` as the legacy diagnostic fallback;
- retain compute dispatch snapshots and color-target producer history for future first-bad-contract investigations;
- add capture resource/shader dumps and focused live target/resource selectors;
- repair HW execute-breakpoint single-step rearming under guest FS and add return-address/argument tracing;
- update the canonical Messenger investigation and contributor/tooling docs.

## Verification

- full WSL Vulkan CTest suite: **79/79 passed**;
- differential `V_CVT_OFF_F32_I4` test covers all 16 signed nibble values;
- integration regression renders a 32x2 producer, samples it from a later 16x16 target, and checks extent/content;
- clean live Messenger route, fresh savedata, no `PROSPER_RTT_PERTARGET`, no `PROSPER_TESTLUT32`:
  - real LUT producer: 32,734 / 32,768 RGB-nonblack texels;
  - original grading pass: 56,008 / 57,600 RGB-nonblack pixels;
  - front buffer: 37,564-37,573 RGB-nonblack pixels across dozens of flips;
  - dumped front buffer visibly contains the first-level landscape and dialogue.

Fixes #300
Fixes #522
Fixes #524
Fixes #525
Fixes #526
Fixes #527