### PR TITLE
fix(tool): capture raw scanout before renderer frames

### DIFF
--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -7,6 +7,10 @@ Reuses the shared boot path (`boot_program`) and the shared live renderer (`fron
 the game boots and composites exactly as `boot_trace` / `prosper-app` do — this tool just samples the
 present layer periodically and writes PNGs.
 
+Readback prefers the latest composited renderer frame. Before one exists, a flipped guest display
+buffer is captured through the present layer's raw-scanout fallback, so the tool records real black or
+partial early output instead of waiting indefinitely for a Vulkan draw.
+
 ## Build
 
 Built automatically wherever Vulkan + zlib are available (same block as `boot_trace`):

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -152,14 +152,18 @@ int main(int argc, char** argv) {
         }
         bool due = time_mode ? (std::chrono::duration<double>(now - last_cap).count() >= seconds)
                              : (gpu::present_frame_seq() >= next);
-        if (gpu::present_has_frame() && due) {
+        const bool rendered = gpu::present_has_frame();
+        const bool raw_scanout = gpu::present_front_index() >= 0 &&
+                                 gpu::present_width() > 0 && gpu::present_height() > 0;
+        if ((rendered || raw_scanout) && due) {
             uint64_t at = gpu::present_frame_seq();
             // Size the buffer from the RENDERED frame's dims, not the guest display dims: under
             // PROSPER_RENDER_SCALE the frame is smaller, and present_readback returns g_frame.size()
             // (scaled). Using the display dims made buf.size() != readback bytes, so the exact-size
             // guard below dropped EVERY screenshot silently (#399). Fall back to display dims only when
             // no rendered frame is present (the raw-scanout path).
-            uint32_t fw = gpu::present_frame_width(), fh = gpu::present_frame_height();
+            uint32_t fw = rendered ? gpu::present_frame_width() : 0;
+            uint32_t fh = rendered ? gpu::present_frame_height() : 0;
             uint32_t w = fw ? fw : gpu::present_width(), h = fh ? fh : gpu::present_height();
             if (w && h) {
                 buf.resize((size_t)w * h * 4);


### PR DESCRIPTION
## Summary
- let wall-clock screenshot runs capture a valid flipped guest scanout before any Vulkan frame exists
- retain composited renderer frames as the preferred readback
- document the raw-scanout startup behavior

## Verification
- `test_present` passes, including raw guest-buffer readback and rendered-frame precedence
- Blasphemous 2 now records exactly 120 actual 1920x1080 raw-scanout PNGs instead of timing out at 0/120
- The Messenger records exactly 120 composited 480x270 PNGs through the normal preferred path

Fixes #535