### PR TITLE
fix(hle): honor Dead Cells memory initialization contracts

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -326,6 +326,20 @@ HLE(k_attr_init)        { if (a0) { auto* at = (pthread_attr_t*)calloc(1, sizeof
 HLE(k_attr_destroy)     { if (a0 && *(void**)a0) { pthread_attr_destroy((pthread_attr_t*)*(void**)a0); free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 HLE(k_attr_setstacksize){ if (a0 && *(void**)a0 && a1 >= 16384) pthread_attr_setstacksize((pthread_attr_t*)*(void**)a0, a1); return 0; }
 HLE(k_attr_noop)        { return 0; }
+
+// sceKernelGetSanitizerMallocReplaceExternal returns the process replacement table, even when no
+// sanitizer callbacks are installed. Returning nullptr made runtimes dereference null while checking
+// the table (Dead Cells reads +0x18 during module initialization). Layout is shared by Kyty/SharpEmu:
+// one size qword followed by 13 function pointers.
+struct SanitizerMallocReplace {
+    uint64_t size = sizeof(SanitizerMallocReplace);
+    uint64_t callbacks[13]{};
+};
+static_assert(sizeof(SanitizerMallocReplace) == 0x70);
+HLE(k_get_sanitizer_malloc_replace) {
+    static SanitizerMallocReplace table;
+    return (uint64_t)(uintptr_t)&table;
+}
 // scePthreadAttrSetdetachstate: store DETACHED/JOINABLE into the host attr so k_pthread_create (which
 // reads pthread_attr_getdetachstate and applies it, line ~465) actually honors a detached-thread request.
 // This was a no-op, so a thread the guest marked DETACHED was created JOINABLE and, never joined, leaked
@@ -1254,6 +1268,8 @@ void register_kernel_hle() {
     Hle::register_fn("WhCc1w3EhSI", (HleFn)k_attr_noop, "sceKernelSetThreadAtexitReport");
     Hle::register_fn("p5EcQeEeJAE", (HleFn)k_attr_noop, "sceKernelRtldSetApplicationHeapAPI");
     Hle::register_fn("bnZxYgAFeA0", (HleFn)k_attr_noop, "sceKernelGetSanitizerNewReplaceExternal");
+    Hle::register_fn("py6L8jiVAN8", (HleFn)k_get_sanitizer_malloc_replace,
+                     "sceKernelGetSanitizerMallocReplaceExternal");
     Hle::register_fn("DGMG3JshrZU", (HleFn)k_attr_noop, "sceKernelSetVirtualRangeName");
     #undef R
     register_kernel_mem_hle();    // virtual/direct memory

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -256,14 +256,35 @@ namespace {
         if (fd >= 0 && phys < kDmemBase + kDmemTotal && sz)
             fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, (off_t)phys, (off_t)sz);
     }
+    // Reserve an anonymous span whose returned base satisfies `align`. Linux mmap only promises
+    // host-page alignment, while Orbis direct-memory callers can require larger alignment.
+    void* reserve_aligned(uint64_t len, uint64_t align) {
+        const uint64_t page = (uint64_t)sysconf(_SC_PAGESIZE);
+        if (align < page) align = page;
+        if ((align & (align - 1)) != 0 || len > UINT64_MAX - align) return nullptr;
+        void* raw = mmap(nullptr, len + align, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (raw == MAP_FAILED) return nullptr;
+        uint64_t raw_base = (uint64_t)raw;
+        uint64_t base = align_up(raw_base, align);
+        if (base > raw_base) munmap(raw, base - raw_base);
+        uint64_t used_end = base + len, raw_end = raw_base + len + align;
+        if (raw_end > used_end) munmap((void*)used_end, raw_end - used_end);
+        return (void*)base;
+    }
+
     // Map `len` bytes of the phys pool at `hint` (0 = anywhere). Falls back to anonymous memory
-    // if the memfd is unavailable (still boots; loses aliasing).
-    void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys) {
+    // if the memfd is unavailable (still boots; loses aliasing). A zero-hint mapping honors the
+    // caller's requested VA alignment; the old host-page-aligned mmap violated that ABI contract.
+    void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align = 0) {
         int fd = dmem_fd();
         if (fd >= 0 && phys < kDmemBase + kDmemTotal) {
             if (!hint) {
-                void* p = mmap(nullptr, len, prot, MAP_SHARED, fd, (off_t)phys);
-                if (p != MAP_FAILED) return p;
+                void* reserved = reserve_aligned(len, align ? align : 0x4000);
+                if (reserved) {
+                    void* p = mmap(reserved, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
+                    if (p != MAP_FAILED) return p;
+                    munmap(reserved, len);
+                }
             } else {
                 // Same no-clobber discipline as map_at (#137): NOREPLACE first, MAP_FIXED replace
                 // only over our own uncommitted reservation, else refuse rather than destroy a live
@@ -278,7 +299,12 @@ namespace {
                 }
             }
         }
-        return map_at(hint, len, prot);
+        if (hint) return map_at(hint, len, prot);
+        void* reserved = reserve_aligned(len, align ? align : 0x4000);
+        if (!reserved) return nullptr;
+        void* p = mmap(reserved, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+        if (p == MAP_FAILED) { munmap(reserved, len); return nullptr; }
+        return p;
     }
 }
 
@@ -461,12 +487,13 @@ HLE(k_direct_memory_query) {
 // sceKernelMapDirectMemory(void** addrInOut, size_t len, int prot, int flags, off_t phys, size_t align)
 HLE(k_map_dmem) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
-    void* p = map_phys_at(hint, a1, host_prot(a2), a4);
+    void* p = map_phys_at(hint, a1, host_prot(a2), a4, a5);
     if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), true, "direct");
-    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx\n",
-         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4, (unsigned long long)a2);
+    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx align=0x%llx\n",
+         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4,
+         (unsigned long long)a2, (unsigned long long)a5);
     return 0;
 }
 
@@ -1047,6 +1074,8 @@ void register_kernel_mem_hle() {
     R("sceKernelReserveVirtualRange", k_reserve_vrange);
     R("sceKernelMapNamedFlexibleMemory", k_map_flexible);
     R("sceKernelMapFlexibleMemory", k_map_flexible_noname);   // no name arg: a4 is garbage r8, don't deref it
+    Hle::register_fn("4h6F1LLbTiw", (HleFn)k_map_flexible_noname,
+                     "sceKernelMapFlexibleMemoryInternal");
     R("sceKernelAvailableFlexibleMemorySize", k_avail_flexible);   // was MISSING -> uninitialized budget
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
     R("sceKernelAllocateMainDirectMemory", k_alloc_main_dmem);  // 4-arg signature (physOut at arg3)

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -8,6 +8,9 @@
 #include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
 
 using namespace prosper;
 
@@ -33,9 +36,10 @@ int main() {
 
     auto avail   = Hle::lookup(nid_hash("sceKernelAvailableDirectMemorySize"));
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
+    auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
-    CHECK(avail && alloc && release, "dmem fns registered");
-    if (!(avail && alloc && release)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(avail && alloc && map && release, "dmem fns registered");
+    if (!(avail && alloc && map && release)) { printf("== FAIL ==\n"); return 1; }
 
     // Fresh pool: the largest free block is the whole pool, and BOTH out-params are written.
     uint64_t phys = 0xdead, size = 0xdead;
@@ -98,6 +102,19 @@ int main() {
         uint64_t rr = alloc(wlo, wlo + 0x1000 /*window < 0x100000 request*/, 0x100000, 0x4000, 0,
                             (uint64_t)(uintptr_t)&p);
         CHECK((uint32_t)rr == 0x8002000Cu, "allocate with too-small window -> ENOMEM (no out-of-window fallback)");
+    }
+
+    // A zero-hint direct mapping must honor its explicit VA alignment. Linux mmap only promises
+    // 4 KiB, which made HashLink reject a mapping requested at 64 KiB alignment during startup.
+    {
+        uint64_t p = 0, va = 0;
+        uint64_t rr = alloc(0, kEnd, 0x10000, 0x10000, 0, (uint64_t)(uintptr_t)&p);
+        CHECK(rr == 0, "allocate 64KiB-aligned direct page succeeds");
+        rr = map((uint64_t)(uintptr_t)&va, 0x10000, 0x2 /*RW*/, 0, p, 0x10000);
+        CHECK(rr == 0 && va && (va & 0xffff) == 0,
+              "map direct memory honors requested 64KiB VA alignment");
+        if (va) munmap((void*)(uintptr_t)va, 0x10000);
+        if (p) release(p, 0x10000, 0, 0, 0, 0);
     }
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }

--- a/prosper/tests/test_prot_none.cpp
+++ b/prosper/tests/test_prot_none.cpp
@@ -35,12 +35,17 @@ int main() {
     printf("== test_prot_none ==\n");
     register_builtin_hle();
     auto flexible = Hle::lookup(nid_hash("sceKernelMapFlexibleMemory"));
+    auto flexible_internal = Hle::lookup("4h6F1LLbTiw");
     auto mprotect_fn = Hle::lookup(nid_hash("sceKernelMprotect"));
-    CHECK(flexible && mprotect_fn, "map/mprotect HLE registered");
-    if (!(flexible && mprotect_fn)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(flexible && flexible_internal && mprotect_fn, "map/internal-map/mprotect HLE registered");
+    if (!(flexible && flexible_internal && mprotect_fn)) { printf("== FAIL ==\n"); return 1; }
 
     auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
     const uint64_t LEN = 0x10000;
+
+    uint64_t internal_va = 0;
+    CHECK(flexible_internal(U(&internal_va), LEN, 0x2 /*RW*/, 0, 0, 0) == 0 && internal_va,
+          "MapFlexibleMemoryInternal aliases the non-named flexible mapper");
 
     // Commit a RW page and confirm it is writable.
     uint64_t va = 0;

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -49,6 +49,24 @@ int main() {
         if (fn) CHECK(fn(0, 0, 0, 0, 0, 0) == 0, nid);
     }
 
+    // Sanitizer malloc replacement query returns a real empty table, not nullptr. Runtimes inspect
+    // callback slots even when no sanitizer is active (Dead Cells reads slot +0x18 during startup).
+    {
+        HleFn fn = Hle::lookup("py6L8jiVAN8");
+        CHECK(fn != nullptr, "sceKernelGetSanitizerMallocReplaceExternal registered");
+        if (fn) {
+            uint64_t addr = fn(0, 0, 0, 0, 0, 0);
+            CHECK(addr != 0, "sanitizer malloc replacement table is non-null");
+            if (addr) {
+                const uint64_t* table = (const uint64_t*)(uintptr_t)addr;
+                CHECK(table[0] == 0x70, "sanitizer malloc replacement table reports size 0x70");
+                bool empty = true;
+                for (int i = 1; i < 14; ++i) empty &= table[i] == 0;
+                CHECK(empty, "sanitizer malloc replacement callbacks default to null");
+            }
+        }
+    }
+
     // Message-dialog lifecycle (#144): GetStatus must report NONE before an Open (the old handler
     // returned FINISHED unconditionally, so a guest guarding on GetStatus saw "done" at the wrong
     // stage). Transitions: Initialize -> INITIALIZED(1); Open -> FINISHED(3, auto-dismiss); Close ->


### PR DESCRIPTION
## Summary
- return a valid empty sanitizer malloc-replacement table for HashLink startup
- register the PS5 internal flexible-memory mapping import
- honor `sceKernelMapDirectMemory`'s requested VA alignment

## Verification
- all 85 CTest tests pass
- Dead Cells completes asset/shader initialization and a 120-second screenshot run (120/120 frames)

Fixes #537