### PR TITLE
fix(gpu): track depth-stencil aspect validity

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -248,7 +248,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const VkImageAspectFlags DASPECT = VK_IMAGE_ASPECT_DEPTH_BIT |
                                        (format_has_stencil ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
     VkImage dimg = VK_NULL_HANDLE; VkDeviceMemory dmem = VK_NULL_HANDLE; VkImageView dview = VK_NULL_HANDLE;
-    bool ds_was_initialized = false;
+    bool ds_layout_initialized = false;
+    bool depth_was_valid = false, stencil_was_valid = false;
+    bool depth_used_meaningfully = false;
+    for (const auto& d : draws) {
+        if (!d.ps) continue;
+        depth_used_meaningfully |= d.ps->depth_clear_enable || d.ps->depth_write_enable ||
+            (d.ps->depth_test_enable && d.ps->depth_compare_op != VK_COMPARE_OP_ALWAYS &&
+                                        d.ps->depth_compare_op != VK_COMPARE_OP_NEVER);
+    }
     struct DsKey {
         uint64_t dr, dw, sr, sw; uint32_t w, h, fmt;
         bool operator==(const DsKey& o) const {
@@ -263,8 +271,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             mix(k.dr); mix(k.dw); mix(k.sr); mix(k.sw); mix(k.w); mix(k.h); mix(k.fmt); return h;
         }
     };
-    struct DsImage { VkImage image = VK_NULL_HANDLE; VkDeviceMemory memory = VK_NULL_HANDLE;
-                     VkImageView view = VK_NULL_HANDLE; bool initialized = false; };
+    struct DsImage {
+        VkImage image = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkImageView view = VK_NULL_HANDLE;
+        bool layout_initialized = false;
+        bool depth_valid = false;
+        bool stencil_valid = false;
+    };
     static std::unordered_map<DsKey, DsImage, DsKeyHash> ds_cache;
     DsImage* cached_ds = nullptr;
     DsKey ds_key{};
@@ -273,7 +287,42 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                   identity->stencil_read_base, identity->stencil_write_base, W, H, (uint32_t)DFMT};
         cached_ds = &ds_cache[ds_key];
         dimg = cached_ds->image; dmem = cached_ds->memory; dview = cached_ds->view;
-        ds_was_initialized = cached_ds->initialized;
+        ds_layout_initialized = cached_ds->layout_initialized;
+        depth_was_valid = cached_ds->depth_valid;
+        stencil_was_valid = cached_ds->stencil_valid;
+    }
+    if (getenv("PROSPER_DSLOG")) {
+        static uint64_t call_id = 0;
+        const uint64_t id = ++call_id;
+        fprintf(stderr,
+                "[ds] call=%llu size=%ux%u draws=%zu use=%d/%d persistent=%d valid=%d/%d/%d "
+                "key=%llx/%llx/%llx/%llx fmt=%u initial=%g/%u\n",
+                (unsigned long long)id, W, H, draws.size(), (int)use_depth, (int)use_stencil,
+                (int)persistent_ds, (int)ds_layout_initialized,
+                (int)depth_was_valid, (int)stencil_was_valid,
+                (unsigned long long)ds_key.dr, (unsigned long long)ds_key.dw,
+                (unsigned long long)ds_key.sr, (unsigned long long)ds_key.sw,
+                ds_key.fmt, depth_clear, stencil_clear);
+        for (size_t i = 0; i < draws.size(); ++i) {
+            const auto* ps = draws[i].ps;
+            if (!ps) {
+                fprintf(stderr, "[ds] call=%llu draw=%zu state=none\n",
+                        (unsigned long long)id, i);
+                continue;
+            }
+            fprintf(stderr,
+                    "[ds] call=%llu draw=%zu bases=%llx/%llx/%llx/%llx "
+                    "depth=%d/%d/op%u clear=%d/%g stencil=%d clear=%d/%u\n",
+                    (unsigned long long)id, i,
+                    (unsigned long long)ps->depth_read_base,
+                    (unsigned long long)ps->depth_write_base,
+                    (unsigned long long)ps->stencil_read_base,
+                    (unsigned long long)ps->stencil_write_base,
+                    (int)ps->depth_test_enable, (int)ps->depth_write_enable,
+                    ps->depth_compare_op, (int)ps->depth_clear_enable, ps->depth_clear_value,
+                    (int)ps->stencil_enable, (int)ps->stencil_clear_enable,
+                    ps->stencil_clear_value);
+        }
     }
 
     VkImageCreateInfo imgci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -322,15 +371,18 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // A guest-identified DS surface survives calls. New attachments get a defined initial value;
     // existing ones LOAD. Explicit DB_RENDER_CONTROL clears execute at their draw below, preserving
     // command order instead of being promoted to an unconditional pass-start clear (#518).
-    att[1].loadOp = ds_was_initialized ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
+    // Depth and stencil have independent guest lifetimes even when Vulkan stores them in one D32S8
+    // image. Using stencil must not make an untouched depth plane valid: Unity can stencil-prime a
+    // surface under an ALWAYS, read-only depth test and only later use reverse-Z depth (#540).
+    att[1].loadOp = depth_was_valid ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
     att[1].storeOp = persistent_ds ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE;
     att[1].stencilLoadOp = format_has_stencil
-        ? (ds_was_initialized ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR)
+        ? (stencil_was_valid ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR)
         : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     att[1].stencilStoreOp = (persistent_ds && format_has_stencil)
         ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    att[1].initialLayout = ds_was_initialized ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-                                               : VK_IMAGE_LAYOUT_UNDEFINED;
+    att[1].initialLayout = ds_layout_initialized ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+                                                  : VK_IMAGE_LAYOUT_UNDEFINED;
     att[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     VkAttachmentReference ar{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
     VkAttachmentReference dar{1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
@@ -749,7 +801,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount = 1; si.pCommandBuffers = &cmd;
     VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev, &fci, nullptr, &fence);
     vkQueueSubmit(queue, 1, &si, fence); vkWaitForFences(dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
-    if (cached_ds) cached_ds->initialized = true;
+    if (cached_ds) {
+        cached_ds->layout_initialized = true;
+        cached_ds->depth_valid |= use_depth && depth_used_meaningfully;
+        cached_ds->stencil_valid |= use_stencil;
+    }
 
     out.resize(bytes);
     void* mp = nullptr; vkMapMemory(dev, bmem, 0, bytes, 0, &mp);

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -112,6 +112,40 @@ int main() {
         CHECK(cc && cc[1] < 0x80, "explicit guest stencil clear executes in order before the draw");
     }
 
+    // Initializing one aspect of a combined D32S8 image must not make the other aspect valid. Unity
+    // first uses this surface for stencil while depth is ALWAYS and read-only, then changes to GEQUAL.
+    // The later draw must initialize the still-unused depth plane from its reverse-Z clear value (0),
+    // rather than LOADing the depth fallback (1) used while only stencil contents mattered (#540).
+    {
+        ResolvedPipelineState stencil_first = opaque;
+        stencil_first.color_write_mask = 0;
+        stencil_first.depth_test_enable = true;
+        stencil_first.depth_compare_op = 7; // ALWAYS
+        stencil_first.depth_clear_value = 1.0f;
+        stencil_first.depth_read_base = stencil_first.depth_write_base = 0x33330000;
+        stencil_first.stencil_enable = true;
+        stencil_first.stencil_compare_op[0] = stencil_first.stencil_compare_op[1] = 7; // ALWAYS
+        stencil_first.stencil_pass_op[0] = stencil_first.stencil_pass_op[1] = 2;       // REPLACE
+        stencil_first.stencil_op_val[0] = stencil_first.stencil_op_val[1] = 1;
+        stencil_first.stencil_read_base = stencil_first.stencil_write_base = 0x44440000;
+
+        ResolvedPipelineState depth_later = opaque;
+        depth_later.depth_test_enable = true;
+        depth_later.depth_compare_op = 6; // GEQUAL
+        depth_later.depth_clear_value = 0.0f;
+        depth_later.depth_read_base = depth_later.depth_write_base = 0x33330000;
+        depth_later.stencil_read_base = depth_later.stencil_write_base = 0x44440000;
+
+        prosper::test::BackendDraw s; s.vs = vs; s.fs = red; s.ps = &stencil_first; s.vcount = 3;
+        prosper::test::BackendDraw d; d.vs = vs; d.fs = green; d.ps = &depth_later; d.vcount = 3;
+        (void)prosper::test::render_draws_rgba({s}, W, H, nullptr, nullptr, true);
+        std::vector<uint8_t> initialized =
+            prosper::test::render_draws_rgba({d}, W, H, nullptr, nullptr, true);
+        const uint8_t* c = center(initialized);
+        CHECK(c && c[1] > 0xC0 && c[0] < 0x40,
+              "stencil-only initialization does not poison a later reverse-Z depth plane");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary
- track persistent D32S8 layout, depth validity, and stencil validity independently
- initialize a previously unused depth aspect from the first compare-dependent draw's clear/default
- add `PROSPER_DSLOG` lifecycle tracing and a Vulkan regression for Messenger's stencil-first/depth-later sequence

## Root cause
PR #532 used one `initialized` bit for a combined depth-stencil image. Messenger's intro surface is first used for stencil while depth is `ALWAYS` and read-only. That incorrectly made depth valid with a fallback value of 1.0. When the intro changed to reverse-Z `GEQUAL`, the cached attachment loaded 1.0 and rejected the cutscene draws instead of initializing the untouched depth plane near zero.

Bisect boundaries:
- good: PR #511 merge `af54ee5`
- first bad: PR #532 commit `48dcd57`

## Verification
- `test_multidraw_render`: regression fails on master, passes with this fix
- `ctest -j8 --output-on-failure`: 85/85 passed
- 12-second no-input Messenger capture: 9 distinct frames and visible intro scene; master produced 5 logo/dim/black states
- `python3 tools/snapshot/snapshot.py check messenger-scene`: 24,318 colors >= 5,000

Fixes #540