### PR TITLE
docs: update current project status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,18 @@ Resource-producer history (#524) identified the exact writer; implementing the o
 `CB_COLOR0_ATTRIB2` target dimensions (#526/#527) produces the real LUT, preserves it through the original
 grading shader, and yields a visible first-level front buffer without diagnostic resource substitution.
 
-The immediate frontier is ordinary gameplay progression: run the saved route without diagnostic substitutions,
-identify the next first-bad contract, and file a narrowly scoped issue with a retained capture or provenance
-trace. `PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` provide the shader/resource
-contract gate tracked by #515. Do not restart the superseded depth, vertex-fetch, geometry, palette, or tiling
-hypotheses without contradictory new evidence.
+Two later fixes complete the hardware-oracle composition and restore boot progression: #534 corrects reversed
+`VkFrontFace` enum translation, recovering the foreground tree, terrain/platforms, waterline, and structures;
+#541 tracks depth and stencil validity independently in persistent D32S8 surfaces, so stencil-only logo use
+cannot poison the intro's reverse-Z depth plane. A clean scripted route produced 180 native 1920×1080 frames,
+and the user confirmed the first-level graphics match the hardware reference. #530 and #540 are closed.
+
+The immediate frontier is cross-title breadth plus repeatable tooling: stabilize *Dead Cells* AGC startup
+(#539), finish reusable input checkpoints and multi-title snapshots (#302/#248), then apply `.prgcap` replay
+and strict descriptor validation to an existing 3D Unity/Unreal workload.
+`PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` are landed capabilities from #515.
+Do not restart the superseded
+Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.
 
 ## How to work here
 
@@ -119,7 +126,7 @@ hypotheses without contradictory new evidence.
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 45/45 expected green on Linux
+  cmake --build . -j8 && ctest        # 85/85 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -6,9 +6,10 @@ Not a CPU emulator: the PS5 is x86-64, so guest code runs **natively**. `prosper
 operating system (FreeBSD-derived), the library ABI (Sony NID-linked modules), and the GPU
 (AGC → Vulkan) underneath the unmodified game binary.
 
-**Primary title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP). Also exercised: `PPSA02664`
-(Unity/IL2CPP) and `PPSA17942` (Unreal Engine). Their SELF segments are unencrypted, which is what
-makes the project possible without console keys. Dumps are user-supplied and gitignored.
+**Primary title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP). Also exercised:
+`PPSA02664` (Unity/IL2CPP), `PPSA17942` (Unreal Engine), `PPSA13579` (*Blasphemous 2*), and
+`PPSA15552` (*Dead Cells*). Their SELF segments are unencrypted, which is what makes the project
+possible without console keys. Dumps are user-supplied and gitignored.
 
 ## Status
 - ✅ **M0–M1 — Recon, tooling & loader.** Format cracked; SELF/ELF → relocatable image → multi-module
@@ -25,16 +26,22 @@ makes the project possible without console keys. Dumps are user-supplied and git
   GFX10 `SW_4KB_S`/`SW_64KB_S` de-swizzle for all element sizes + BC1–7/BC6H, T# format + `DST_SEL`
   swizzle + paired S# sampler. Frame spine → `resolve_pipeline_state` → real `VkGraphicsPipeline`s
   with blend (incl. separate-alpha)/depth/stencil/write-mask/fast-clear + a render-to-texture cache.
-- ✅ **The Messenger renders:** intro cutscene (dozens of distinct animating frames), title screen with
-  readable text, working gamepad input, and progression into gameplay level loading — all asserted by
-  a golden-image snapshot guard.
-- 🚧 **Active frontiers:** revision-locked capture/replay of the black Messenger gameplay frame,
-  strict shader/resource-interface validation, independent diagnosis of the missing save list, broader
-  shader coverage, and the Unreal title's title-screen composite.
+- ✅ **The Messenger renders through gameplay:** intro, title, menus, save list, and the complete first
+  level render at native 1920×1080 with working scripted gamepad progression. The LUT producer,
+  foreground culling, and cross-call depth/stencil lifecycle fixes are regression-covered by Vulkan
+  tests and the real-game snapshot guard.
+- ✅ **Graphics investigation tooling:** versioned live GPU capture/replay (`.prgcap`), per-draw/resource
+  inspection and isolation, strict reflected SPIR-V/runtime descriptor validation, render-target producer
+  provenance, normal screenshot capture, and a local content-metric snapshot guard.
+- 🚧 **Active frontiers:** stabilize *Dead Cells* graphics startup (#539), finish reusable input
+  checkpoints and multi-title snapshot coverage (#302/#248), then apply the capture/replay and contract
+  tools to the existing Unity and Unreal 3D workloads. UE4's first measured GPU blocker is unresolved
+  image/vertex descriptor provenance (#485), not an assumed missing instruction class.
 
-The current Messenger frontier is revision-locked capture/replay of the black gameplay frame, strict
-shader/resource-interface validation, and an independent trace of the save-list failure. See
-[`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md).
+The completed Messenger black-render investigation and reusable evidence boundary are recorded in
+[`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub
+issues; title failures should produce a reproducible route/capture and a narrowly scoped issue rather
+than a moving-revision hypothesis log.
 
 See [`docs/ROADMAP.md`](docs/ROADMAP.md), [`docs/GRAPHICS.md`](docs/GRAPHICS.md),
 [`docs/RENDER_LOOP.md`](docs/RENDER_LOOP.md), and [`docs/VERIFICATION.md`](docs/VERIFICATION.md)
@@ -51,7 +58,7 @@ prosper/
   src/gpu/         AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
                    texture tiling + BC decode, RDNA2→SPIR-V recompiler
   frontends/       shared boot+render core, windowed prosper-app, SDL3 audio/dialog, controllers
-  tools/           self_dump, boot_trace, shader_histo, snapshot (golden-image guard), spv_validate
+  tools/           self_dump, boot_trace, shader_histo, screenshot, snapshot, gpu_replay, spv_validate
   tests/           unit + boot + Vulkan-execution tests (ctest)
   CMakeLists.txt
 ```
@@ -60,7 +67,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # 84 self-checking tests
+ctest --test-dir build          # 85 self-checking tests
 ```
 Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```

--- a/prosper/docs/MESSENGER_BLACK_RENDER.md
+++ b/prosper/docs/MESSENGER_BLACK_RENDER.md
@@ -1,8 +1,9 @@
 # Messenger black-render investigation
 
-This is the canonical status for the Messenger gameplay-render failure (#300 / #522).
-The formerly invisible save-game list (#299) is visible on current master and that issue is closed.
-GitHub issues own live findings; this document records the current evidence boundary and next experiment.
+This is the canonical completed record for the Messenger gameplay-render failure (#300 / #522).
+The formerly invisible save-game list (#299), missing foreground (#530), and boot-to-intro regression (#540)
+are fixed and closed. GitHub issues own live findings; this document preserves the evidence boundary that
+connected each visible failure to a specific replay, renderer contract, and regression.
 
 ## Current conclusion (2026-07-11)
 
@@ -43,10 +44,24 @@ and resource-producer provenance (#524) established this causal chain:
    calls, eight distinct native texture pointers, and the corresponding live descriptor addresses all change.
    That transition eventually produces the expected colored scene before the grading pass erases it.
 
-The black first-level root cause was therefore a missing shader instruction plus loss of per-target dimensions,
+The original black first-level root cause was therefore a missing shader instruction plus loss of per-target dimensions,
 not depth, a stuck palette fade, compute LUT baking, or detiling of the 256x16 palette. The fix merged as #528
 (`e5fce22`) after a clean exact-route run without the identity-LUT substitution: the LUT, grading output, and
 selected VideoOut front buffer remained nonblack across consecutive flips. #300 and #522 are closed.
+
+The hardware oracle then exposed two independent follow-up defects hidden by the black frame. #534
+(`3941533`) fixes reversed Vulkan front-face enum values; retaining culling with the corrected winding restores
+the foreground canopy/tree, rock slopes, player platform, waterline structures, and right-side terrain that
+were absent from the first visible frame. #541 (`ded4a60`) separates persistent D32S8 layout initialization
+from logical depth and stencil validity; earlier stencil-only `ALWAYS`/read-only use no longer makes untouched
+depth contents valid, so the later intro `GEQUAL` draw initializes reverse-Z depth correctly instead of loading
+the logo fallback and rendering black.
+
+Final validation used a fresh save, the recorded gamepad route, no rendering substitutions, and 180 normal
+screenshots at one-second intervals at native 1920×1080. The sequence covers startup through the first-level
+dialogue with the full hardware-reference composition, and the user confirmed the graphics look correct.
+#530 and #540 are closed. Timing of the fade remains an observation, not a diagnosed emulator defect: the
+screenshot tool samples the current buffer on wall time and can repeat frames under synchronous rendering.
 
 The old bindless vertex-fetch frontier is solved, and `NEXT_STEP_VERTEX_FETCH.md` is historical. Earlier
 #300 claims about texture decode, alpha, transform collapse, render-target propagation, and a missing
@@ -116,4 +131,5 @@ pre-blend fragment output, and final attachment output in a standard report. Exi
 Do not start another depth/stencil, vertex-fetch, palette-fade, compute, tiling, or whole-stack rewrite from the
 historical #300 comments. The producer, missing opcode, target extent, consumer, and front-buffer result are now
 connected by one live trace. Preserve that chain as the regression boundary and use the same provenance-first
-method for the next title failure.
+method for the next title failure. Active work has moved to Dead Cells startup stability (#539), reusable
+checkpoints/snapshots (#302/#248), and then existing 3D Unity/Unreal workloads.

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -26,15 +26,19 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
 
 ## Current status (2026-07-11) - at a glance
 
-- **Messenger renders through gameplay submission:** the former GfxDevice, draw-submission, and
-  bindless vertex-fetch blockers are solved. The intro, title, and menu render; a real multi-pass
-  gameplay frame is submitted, but its scene content remains black. The save-game list is also missing.
-- **No current-master root cause is established:** #300 accumulated contradictory diagnoses on changing
-  revisions, and the former missing binding-9 vertex-color resource was later observed populated while
-  the level remained black. #299 has not been independently traced, so SaveData/HLE remains plausible.
-- **Immediate milestone:** create an immutable local GPU frame capture/replay, then strictly validate the
-  generated SPIR-V descriptor interface against runtime resources. Canonical evidence and next steps are
-  in `docs/MESSENGER_BLACK_RENDER.md` and GitHub issues #299, #300, #514, and #515.
+- **Messenger reaches and renders the first level:** intro, title, menus, save list, dialogue, player,
+  background, foreground tree/terrain, water, and structures render at native 1920×1080. The causal fixes
+  are the grading-LUT producer/target extent (#528), Vulkan front-face translation (#534), and independent
+  depth/stencil aspect validity in the persistent guest-surface cache (#541). The full-resolution route was
+  user-confirmed against the hardware reference; #299, #300, #522, #530, and #540 are closed.
+- **The investigation tools are operational:** #514 provides versioned live GPU capture/replay with exact
+  live/replay hashes and per-draw/resource isolation; #515 provides reflected SPIR-V/runtime descriptor
+  validation in live and offline replay paths. Producer provenance, normal screenshot capture, and the local
+  content-metric snapshot guard complete the current first-bad-contract workflow.
+- **Immediate milestone:** stabilize *Dead Cells* startup around AGC resource registration (#539), turning
+  the work into reusable structured HLE-call/output tracing and a repeated-startup gate. Then finish input
+  checkpoints and multi-title snapshots (#302/#248) before using an existing Unity/Unreal 3D workload to
+  expand graphics coverage. UE4's current measured shader rejection boundary is descriptor provenance (#485).
 
 ## Historical status (2026-07-05) - retained for the milestone log
 


### PR DESCRIPTION
## Summary
- update README and roadmap from the obsolete black-gameplay/save-list status
- record the #528, #534, and #541 Messenger completion boundary and full-resolution validation
- mark capture/replay and descriptor validation as landed tools
- set Dead Cells #539, checkpoints #302, and multi-title snapshots #248 as the active direction
- update the documented Linux test count and tool inventory

Historical milestone and investigation logs remain intact and explicitly historical.

## Verification
- `git diff --check`
- stale-current-status phrase scan across all edited surfaces
- verified all referenced local documentation paths exist

Fixes #542