### PR TITLE
fix(hle): initialize AGC resource name limit

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1252,6 +1252,19 @@ HLE(agc_patch_release_mem_addr) {  // 0fWWK5uG9rQ (cmd, address): ReleaseMem pay
     return 0;
 }
 
+// sceAgcDriverGetResourceRegistrationMaxNameLength. Dead Cells asks for this before formatting
+// every resource name into a dynamic stack buffer. The generic success stub left *out untouched;
+// stale stack data became a multi-gigabyte alloca and faulted at eboot+0x172cebd (#539). Its
+// registration configuration passes 0xfc as the maximum, matching the driver-visible limit here.
+// The error value is inherited from the PS4 resource-registration ABI; PS5 retains the API family.
+// CONFIDENCE: HIGH on the pointer/output contract and 0xfc value (live caller + core), MED on error.
+HLE(agc_driver_get_resource_registration_max_name_length) {
+    if (!a0)
+        return (uint64_t)(int64_t)(int32_t)0x80D19013u;
+    *(uint32_t*)(uintptr_t)a0 = 0xfcu;
+    return 0;
+}
+
 // sceAgcDcbDispatchDirect (NID k3GhuSNmBLU) — compute dispatch. RE'd from the guest wrapper
 // eboot+0x220ede0: it reserves Dcb space from the bound CS shader's scratch needs, reads the
 // shader's specials->dispatch_modifier (eboot+0x5999750 = [[sub0.shader]+0x28]+0x10) and calls
@@ -1271,6 +1284,7 @@ HLE(agc_dcb_dispatch_direct) {  // (buf, tg_x, tg_y, tg_z, modifier)
 void register_agc_hle() {
     #define RN(nid, fn) Hle::register_fn(nid, (HleFn)(fn), nid)
     RN("f3dg2CSgRKY", agc_create_shader);   // sceAgcCreateShader — populates the shader registry
+    RN("uJziRsODk1c", agc_driver_get_resource_registration_max_name_length);
     RN("V++UgBtQhn0", agc_get_data_packet_payload);          // data packet -> register-bank payload
     RN("n2fD4A+pb+g", agc_cb_set_sh_register_range_direct);  // SET_SH_REG range packet
     RN("D9sr1xGUriE", agc_create_prim_state);                // prim registers from gs specials

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -430,8 +430,20 @@ const char* const kAgcNids[] = {
     "k3GhuSNmBLU",   // fires once just before "unity default resources" load; not in Kyty — RE via args
     "WmAc2MEj6Io",   // sceAgcDcbDmaData (shadPS4 aerolib) — OVERRIDDEN by agc_dcb_dma_data (real appender, #117)
     "IxYiarKlXxM",   // sceAgcDmaDataPatchSetDstAddressOrOffset — observe-only (packet now gets valid ptrs, #117)
+    // Dead Cells resource-registration startup path (#539). These trace entries preserve the original
+    // six arguments, which the generic unimplemented stub cannot do because it replaces a0 with the
+    // import index. The max-name-length query is overridden by its real handler in hle_agc.
+    "AOLcoIkQDgM",   // sceAgcDriverQueryResourceRegistrationUserMemoryRequirements
+    "F0Y42t-3e18",   // sceAgcDriverInitResourceRegistration
+    "U9ueyEhSkF4",   // sceAgcDriverRegisterDefaultOwner (shadPS4 symbol map)
+    "X-Nm5KLREeg",   // sceAgcDriverRegisterOwner
+    "W5z4eZrjEas",   // sceAgcDriverRegisterResource
+    "F0ZXt5q0ZTA",   // sceAgcDriverGetDefaultOwner (shadPS4 symbol map)
+    "uJziRsODk1c",   // sceAgcDriverGetResourceRegistrationMaxNameLength (overridden in hle_agc)
 };
+constexpr size_t kDefaultAgcNidCount = 32;
 constexpr size_t kAgcNidCount = sizeof(kAgcNids) / sizeof(kAgcNids[0]);
+static_assert(kAgcNidCount == kDefaultAgcNidCount + 7);
 
 uint64_t glog_impl(const char* nid, void* ra,
                    uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
@@ -559,11 +571,12 @@ __attribute__((noinline)) uint64_t glog_thunk(uint64_t a0, uint64_t a1, uint64_t
                                               uint64_t a3, uint64_t a4, uint64_t a5) {
     return glog_impl(kAgcNids[I], __builtin_return_address(0), a0, a1, a2, a3, a4, a5);
 }
-template <size_t... Is>
+template <size_t Offset, size_t... Is>
 void register_agc_tracers(std::index_sequence<Is...>) {
     // Placeholders: hle_agc registers the REAL handlers for the implemented subset later and is meant
     // to override these tracing thunks — so mark them overridable and that override is not a shadow.
-    (Hle::register_placeholder(kAgcNids[Is], (HleFn)&glog_thunk<Is>, kAgcNids[Is]), ...);
+    (Hle::register_placeholder(kAgcNids[Offset + Is], (HleFn)&glog_thunk<Offset + Is>,
+                               kAgcNids[Offset + Is]), ...);
 }
 }
 
@@ -574,7 +587,12 @@ void register_graphics_hle() {
     RN("2JtWUUiYBXs", g_agc_regdefs);       // GraphicsGetRegisterDefaults2       -> g_reg_defaults1
     RN("wRbq6ZjNop4", g_agc_regdefs_int);   // GraphicsGetRegisterDefaults2Internal -> g_reg_defaults2
     // All traced libSceAgc/AgcDriver NIDs → per-NID logging thunks (still return 0; observable only).
-    register_agc_tracers(std::make_index_sequence<kAgcNidCount>{});
+    register_agc_tracers<0>(std::make_index_sequence<kDefaultAgcNidCount>{});
+    // Extra resource-registration tracing changes the generic unimplemented-stub scheduling enough to
+    // suppress Dead Cells' intermittent startup failure (#539), so it must be explicitly diagnostic.
+    if (getenv("PROSPER_AGC_REG_TRACE"))
+        register_agc_tracers<kDefaultAgcNidCount>(
+            std::make_index_sequence<kAgcNidCount - kDefaultAgcNidCount>{});
     // Override the +kSrjIVxKFE tracer with the real register-context constructor (must come AFTER the
     // tracer registration above so it wins; registry is last-write-wins per NID).
     RN("+kSrjIVxKFE", g_agc_ctx_init);      // AGC register-context init (installs classify table)

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -37,8 +37,18 @@ int main() {
     auto setidx = Hle::lookup("GIIW2J37e70");   // GraphicsDcbSetIndexSize
     auto draw   = Hle::lookup("Yw0jKSqop+E");   // GraphicsDcbDrawIndexAuto
     auto submit = Hle::lookup("UglJIZjGssM");   // GraphicsDriverSubmitDcb
-    CHECK(reset && setcx && setidx && draw && submit, "AGC Dcb + submit functions registered");
-    if (!(reset && setcx && setidx && draw && submit)) { printf("== FAIL ==\n"); return 1; }
+    auto maxname = Hle::lookup("uJziRsODk1c");   // sceAgcDriverGetResourceRegistrationMaxNameLength
+    CHECK(reset && setcx && setidx && draw && submit && maxname,
+          "AGC Dcb, submit, and resource-registration functions registered");
+    if (!(reset && setcx && setidx && draw && submit && maxname)) { printf("== FAIL ==\n"); return 1; }
+
+    uint32_t max_name_length = 0xdeadbeefu;
+    CHECK(maxname((uint64_t)(uintptr_t)&max_name_length, 0, 0, 0, 0, 0) == 0,
+          "resource-registration max-name query returned OK");
+    CHECK(max_name_length == 0xfc,
+          "resource-registration max-name query initialized the poisoned output");
+    CHECK((int64_t)maxname(0, 0, 0, 0, 0, 0) < 0,
+          "resource-registration max-name query rejects a null output");
 
     // Baseline stats (other tests in-process may have submitted; measure deltas).
     uint64_t s0 = 0, d0 = 0; prosper_agc_submit_stats(&s0, &d0);


### PR DESCRIPTION
## Summary
- implement `sceAgcDriverGetResourceRegistrationMaxNameLength` and initialize its output to the configured `0xfc` limit
- reject a null output using the inherited resource-registration error
- add a poisoned-output HLE regression
- add opt-in argument-preserving tracing for the seven Dead Cells registration-path NIDs

## Root cause
The WSL ELF core stops at Dead Cells `eboot+0x172cebd`. The caller passes `&local_length` to raw NID `uJziRsODk1c`, then dynamically subtracts the returned length from RSP before formatting a resource name. The generic stub returned success without writing the output. In the retained failure, `local_length=0xe53b210e`, producing an invalid stack pointer and host SIGSEGV.

`uJziRsODk1c` resolves to `sceAgcDriverGetResourceRegistrationMaxNameLength`; the live registration configuration supplies `0xfc` as its maximum.

## Verification
- pre-fix default matrices: 4/12 and 2/12 startup SIGSEGVs
- fixed default matrix: 30/30 fresh starts wrote a presented frame, zero faults/timeouts
- 60-second Dead Cells run: 60/60 native 3840x2160 frames, 17 distinct animated loading states
- focused poisoned-output/null-output regression passes
- full CTest: 85/85 passed
- Messenger snapshot: 24,318 colors >= 5,000

Retained logs, images, and one core are local under `C:\Users\matti\Downloads\ps5ys-deadcells-539`.

Fixes #539