### PR TITLE
fix(hle): return a valid guest process id

### DIFF
--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -289,6 +289,10 @@ HLE(k_usleep)   { uint64_t us = a0; struct timespec ts{ (time_t)(us / 1000000), 
 // infinite busy-sleep. We always sleep the full duration, so return 0 (Kyty KernelSleep returns OK/0).
 HLE(k_sleep_s)  { struct timespec ts{ (time_t)a0, 0 }; nanosleep(&ts, nullptr); return 0; }
 HLE(k_nanosleep){ if (a0) nanosleep((const struct timespec*)P(a0), a1 ? (struct timespec*)P(a1) : nullptr); return 0; }
+// Guest-visible process id. Keep it stable across host runs and distinct from the kernel's
+// special pid 0; shadPS4 uses the same 0xBAD1 compatibility pid. Returning generic-stub success
+// (zero) violates POSIX and can collapse per-process paths/ownership keys. CONFIDENCE: HIGH.
+HLE(k_getpid)   { return 0xbad1; }
 
 // sceKernelGettimezone(struct timezone* tz) = { int tz_minuteswest; int tz_dsttime }. Was MISSING -> the
 // generic stub left the out-struct uninitialized (the #82/#190 uninit-out class). We present a UTC clock
@@ -1066,6 +1070,7 @@ void register_kernel_time_hle() {
     R("sceKernelUsleep", k_usleep);   R("usleep", k_usleep);
     R("sceKernelSleep", k_sleep_s);   R("sleep", k_sleep_s);
     R("sceKernelNanosleep", k_nanosleep);  R("nanosleep", k_nanosleep);  R("_nanosleep", k_nanosleep);
+    R("getpid", k_getpid);
     R("sceKernelGettimezone", k_gettimezone);   // was MISSING -> uninitialized tz out-struct
     R("sceKernelClockGetres", k_clock_getres);  R("clock_getres", k_clock_getres);
     R("clock_settime", k_ok);   R("sceKernelClockSettime", k_ok);   // guest clock is read-only here

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -31,6 +31,7 @@ int main() {
         "sceKernelIsStack", "scePthreadGetschedparam",
         // time / event queues
         "sceKernelClockGettime", "sceKernelUsleep", "sceKernelCreateEqueue", "sceKernelWaitEqueue",
+        "getpid",
         // services / dialogs
         "sceUserServiceGetInitialUser", "scePadOpen", "sceMsgDialogUpdateStatus",
         "sceSystemServiceHideSplashScreen",
@@ -50,6 +51,11 @@ int main() {
         uint64_t v = fn(0, 0, 0, 0, 0, 0);
         if (v != 1) { printf("  [FAIL] __ctype_get_mb_cur_max returned %llu, want 1 (the value, not a pointer)\n", (unsigned long long)v); fails++; }
     } else { printf("  [FAIL] not registered: __ctype_get_mb_cur_max\n"); fails++; }
+
+    if (HleFn fn = Hle::lookup(nid_hash("getpid"))) {
+        uint64_t v = fn(0, 0, 0, 0, 0, 0);
+        if (v == 0) { printf("  [FAIL] getpid returned kernel-special pid 0\n"); fails++; }
+    } else { printf("  [FAIL] not registered: getpid\n"); fails++; }
 
     if (fails) { printf("== FAIL: %d function(s) not registered ==\n", fails); return 1; }
     printf("== PASS: all %zu checked HLE functions registered ==\n", sizeof(names)/sizeof(names[0]) + 1);


### PR DESCRIPTION
## Summary

- register `libScePosix::getpid` instead of falling through to generic success
- return a stable nonzero guest PID (`0xBAD1`, matching shadPS4's compatibility model)
- guard both registration and nonzero behavior in `test_hle_registered`

## Verification

- `test_hle_registered` passes (56 checked functions)
- Dead Cells A/B confirmed `getpid` was not the loading-screen cause; #545 is separately classified as synchronous llvmpipe slowdown

Fixes #551