### PR TITLE
feat(hle): add a silent NGS2 lifecycle

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -498,6 +498,230 @@ HLE(ajm_batch_start) {
 HLE(ajm_batch_wait)       { return a0 ? 0 : AJM_ERR_INVALID_CONTEXT; }   // batch completed
 HLE(ajm_batch_errordump)  { return 0; }
 
+// --- libSceNgs2 silent lifecycle ---------------------------------------------------------------
+// Dead Cells is the first title to exercise NGS2. PROSPER_NGS2_TRACE preserves and logs all six
+// guest arguments for this PS5 surface; normal execution uses the same handlers without logging.
+namespace {
+
+bool ngs2_trace_enabled() {
+    const char* e = getenv("PROSPER_NGS2_TRACE");
+    return e && *e && *e != '0';
+}
+
+void ngs2_trace_call(const char* name, std::atomic<uint64_t>& calls,
+                     uint64_t a0, uint64_t a1, uint64_t a2,
+                     uint64_t a3, uint64_t a4, uint64_t a5) {
+    const uint64_t n = calls.fetch_add(1) + 1;
+    if (ngs2_trace_enabled() && (n <= 8 || (n & (n - 1)) == 0)) {
+        fprintf(stderr, "[ngs2] %s #%llu (0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx)\n",
+                name, (unsigned long long)n,
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+    }
+}
+
+constexpr uint64_t kNgs2SystemTag = 0x4e47533253000000ull; // "NGS2S"
+constexpr uint64_t kNgs2RackTag   = 0x4e47533252000000ull; // "NGS2R"
+constexpr uint64_t kNgs2VoiceTag  = 0x4e47533256000000ull; // "NGS2V"
+constexpr uint64_t kNgs2TagMask   = 0xffffffffffffff00ull;
+constexpr uint64_t kNgs2VoiceMask = 0xffffffffff000000ull;
+constexpr uint64_t kNgs2ErrInvalidOut    = (uint64_t)(int64_t)(int32_t)0x804a0053;
+constexpr uint64_t kNgs2ErrInvalidSystem = (uint64_t)(int64_t)(int32_t)0x804a0230;
+constexpr uint64_t kNgs2ErrInvalidRack   = (uint64_t)(int64_t)(int32_t)0x804a0261;
+constexpr uint64_t kNgs2ErrInvalidVoice  = (uint64_t)(int64_t)(int32_t)0x804a0302;
+
+struct Ngs2RackState {
+    bool used = false;
+    uint64_t system = 0;
+    uint32_t rack_id = 0;
+    uint32_t max_voices = 64;
+};
+
+std::mutex g_ngs2_mx;
+bool g_ngs2_systems[4]{};
+Ngs2RackState g_ngs2_racks[32];
+std::mutex g_ngs2_zero_mx;
+std::vector<uint8_t> g_ngs2_zeros;
+
+bool ngs2_read_u32(uint64_t src, uint32_t& value) {
+#ifndef _WIN32
+    struct iovec l { &value, sizeof value }, r { (void*)(uintptr_t)src, sizeof value };
+    return src && process_vm_readv(getpid(), &l, 1, &r, 1, 0) == (ssize_t)sizeof value;
+#else
+    if (!src) return false;
+    value = *(const uint32_t*)(uintptr_t)src;
+    return true;
+#endif
+}
+
+bool ngs2_read_bytes(uint64_t src, void* dst, size_t size) {
+#ifndef _WIN32
+    struct iovec l { dst, size }, r { (void*)(uintptr_t)src, size };
+    return src && process_vm_readv(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+#else
+    if (!src) return false;
+    memcpy(dst, (const void*)(uintptr_t)src, size);
+    return true;
+#endif
+}
+
+bool ngs2_zero_bytes(uint64_t dst, size_t size) {
+#ifndef _WIN32
+    // Do not use thread_local here: guest execution swaps %fs, and adding host TLS to prosper_core
+    // perturbs Messenger before its first syscall. Process-global zero storage is sufficient because
+    // NGS2 rendering is serialized by its audio thread; the lock also makes that contract explicit.
+    std::lock_guard<std::mutex> lock(g_ngs2_zero_mx);
+    if (g_ngs2_zeros.size() < size) g_ngs2_zeros.resize(size, 0);
+    struct iovec l { g_ngs2_zeros.data(), size }, r { (void*)(uintptr_t)dst, size };
+    return dst && process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
+#else
+    if (!dst) return false;
+    memset((void*)(uintptr_t)dst, 0, size);
+    return true;
+#endif
+}
+
+uint32_t ngs2_max_voices(uint64_t option) {
+    uint32_t voices = 0;
+    // SceNgs2RackOption: size[8], name[16], flags, maxGrainSamples, maxVoices.
+    if (option) ngs2_read_u32(option + 0x20, voices);
+    return voices ? voices : 64;
+}
+
+bool ngs2_valid_system(uint64_t handle) {
+    const uint64_t slot = handle & 0xff;
+    return (handle & kNgs2TagMask) == kNgs2SystemTag && slot >= 1 && slot <= 4 &&
+           g_ngs2_systems[slot - 1];
+}
+
+Ngs2RackState* ngs2_rack(uint64_t handle) {
+    const uint64_t slot = handle & 0xff;
+    if ((handle & kNgs2TagMask) != kNgs2RackTag || slot < 1 || slot > 32) return nullptr;
+    Ngs2RackState& rack = g_ngs2_racks[slot - 1];
+    return rack.used ? &rack : nullptr;
+}
+
+} // namespace
+
+#define NGS2_LOG(label) do { static std::atomic<uint64_t> calls{0}; \
+    ngs2_trace_call(label, calls, a0, a1, a2, a3, a4, a5); } while (0)
+
+// NGS2 is implemented as a silent backend: the guest still receives real buffer requirements and
+// opaque lifecycle handles, while SystemRender produces silence. Layouts/prototypes agree between
+// the 3.20 export table, Kyty, shadPS4, and the Dead Cells live trace above. CONFIDENCE: HIGH on
+// argument/output positions and handle flow; MED on the deliberately private work-buffer sizes.
+HLE(ngs2_system_query_buffer) {
+    NGS2_LOG("sceNgs2SystemQueryBufferSize");
+    if (!a1 || !a2_store_zeros(a1, 0x40) || !a2_store_u64(a1 + 8, 0x1000))
+        return kNgs2ErrInvalidOut;
+    return 0;
+}
+
+HLE(ngs2_system_create) {
+    NGS2_LOG("sceNgs2SystemCreate");
+    if (!a1 || !a2) return kNgs2ErrInvalidOut;
+    std::lock_guard<std::mutex> lock(g_ngs2_mx);
+    for (uint64_t i = 0; i < 4; ++i) {
+        if (g_ngs2_systems[i]) continue;
+        g_ngs2_systems[i] = true;
+        if (!a2_store_u64(a2, kNgs2SystemTag | (i + 1))) {
+            g_ngs2_systems[i] = false;
+            return kNgs2ErrInvalidOut;
+        }
+        return 0;
+    }
+    return kNgs2ErrInvalidSystem;
+}
+
+HLE(ngs2_rack_query_buffer) {
+    NGS2_LOG("sceNgs2RackQueryBufferSize");
+    const uint64_t size = 0x1000ull + (uint64_t)ngs2_max_voices(a1) * 0x40ull;
+    if (!a2 || !a2_store_zeros(a2, 0x40) || !a2_store_u64(a2 + 8, size))
+        return kNgs2ErrInvalidOut;
+    return 0;
+}
+
+HLE(ngs2_rack_create) {
+    NGS2_LOG("sceNgs2RackCreate");
+    if (!a3 || !a4) return kNgs2ErrInvalidOut;
+    std::lock_guard<std::mutex> lock(g_ngs2_mx);
+    if (!ngs2_valid_system(a0)) return kNgs2ErrInvalidSystem;
+    for (uint64_t i = 0; i < 32; ++i) {
+        if (g_ngs2_racks[i].used) continue;
+        g_ngs2_racks[i] = {true, a0, (uint32_t)a1, ngs2_max_voices(a2)};
+        if (!a2_store_u64(a4, kNgs2RackTag | (i + 1))) {
+            g_ngs2_racks[i] = {};
+            return kNgs2ErrInvalidOut;
+        }
+        return 0;
+    }
+    return kNgs2ErrInvalidRack;
+}
+
+HLE(ngs2_rack_get_voice) {
+    NGS2_LOG("sceNgs2RackGetVoiceHandle");
+    if (!a2) return kNgs2ErrInvalidOut;
+    std::lock_guard<std::mutex> lock(g_ngs2_mx);
+    Ngs2RackState* rack = ngs2_rack(a0);
+    if (!rack) return kNgs2ErrInvalidRack;
+    if (a1 >= rack->max_voices || a1 > 0xff) return kNgs2ErrInvalidVoice;
+    const uint64_t rack_slot = a0 & 0xff;
+    return a2_store_u64(a2, kNgs2VoiceTag | (rack_slot << 8) | a1) ? 0 : kNgs2ErrInvalidOut;
+}
+
+HLE(ngs2_voice_control) {
+    NGS2_LOG("sceNgs2VoiceControl");
+    return (a0 & kNgs2VoiceMask) == kNgs2VoiceTag ? 0 : kNgs2ErrInvalidVoice;
+}
+
+HLE(ngs2_voice_run_commands) {
+    NGS2_LOG("sceNgs2VoiceRunCommands");
+    return (a0 & kNgs2VoiceMask) == kNgs2VoiceTag ? 0 : kNgs2ErrInvalidVoice;
+}
+
+HLE(ngs2_voice_get_state) {
+    NGS2_LOG("sceNgs2VoiceGetState");
+    if ((a0 & kNgs2VoiceMask) != kNgs2VoiceTag) return kNgs2ErrInvalidVoice;
+    // An inert backend has no active decoder: zero stateFlags means Empty. Dead Cells requests the
+    // sampler extension, so clear the caller-declared payload as Kyty does before filling it.
+    if (!a1 || !a2 || a2 > 0x1000 || !a2_store_zeros(a1, (size_t)a2)) return kNgs2ErrInvalidOut;
+    return 0;
+}
+
+HLE(ngs2_geom_reset_source) {
+    NGS2_LOG("sceNgs2GeomResetSourceParam");
+    return a0 && a2_store_zeros(a0, 0xa8) ? 0 : kNgs2ErrInvalidOut;
+}
+
+HLE(ngs2_system_render) {
+    NGS2_LOG("sceNgs2SystemRender");
+    {
+        std::lock_guard<std::mutex> lock(g_ngs2_mx);
+        if (!ngs2_valid_system(a0)) return kNgs2ErrInvalidSystem;
+    }
+    struct RenderBufferInfo { uint64_t buffer, size; uint32_t waveform_type, channels; };
+    if (!a1 || a2 == 0 || a2 > 16) return kNgs2ErrInvalidOut;
+    for (uint64_t i = 0; i < a2; ++i) {
+        RenderBufferInfo info{};
+        if (!ngs2_read_bytes(a1 + i * sizeof(info), &info, sizeof(info)) ||
+            !info.buffer || info.size > 64ull * 1024 * 1024 || !ngs2_zero_bytes(info.buffer, (size_t)info.size))
+            return kNgs2ErrInvalidOut;
+    }
+    return 0;
+}
+
+HLE(ngs2_geom_reset_listener) {
+    NGS2_LOG("sceNgs2GeomResetListenerParam");
+    return a0 && a2_store_zeros(a0, 0xa0) ? 0 : kNgs2ErrInvalidOut;
+}
+
+HLE(ngs2_geom_calc_listener) {
+    NGS2_LOG("sceNgs2GeomCalcListener");
+    return a0 && a1 && a2_store_zeros(a1, 0x60) ? 0 : kNgs2ErrInvalidOut;
+}
+
+#undef NGS2_LOG
+
 void register_audio_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("sceAudioOutInit", audio_init);
@@ -538,6 +762,18 @@ void register_audio_hle() {
     R("sceAjmInstanceCreate", ajm_instance_create);   R("sceAjmInstanceDestroy", ajm_instance_destroy);
     R("sceAjmBatchStartBuffer", ajm_batch_start);     R("sceAjmBatchWait", ajm_batch_wait);
     R("sceAjmBatchErrorDump", ajm_batch_errordump);
+    Hle::register_fn("pgFAiLR5qT4", ngs2_system_query_buffer, "sceNgs2SystemQueryBufferSize");
+    Hle::register_fn("koBbCMvOKWw", ngs2_system_create, "sceNgs2SystemCreate");
+    Hle::register_fn("0eFLVCfWVds", ngs2_rack_query_buffer, "sceNgs2RackQueryBufferSize");
+    Hle::register_fn("cLV4aiT9JpA", ngs2_rack_create, "sceNgs2RackCreate");
+    Hle::register_fn("MwmHz8pAdAo", ngs2_rack_get_voice, "sceNgs2RackGetVoiceHandle");
+    Hle::register_fn("uu94irFOGpA", ngs2_voice_control, "sceNgs2VoiceControl");
+    Hle::register_fn("AbYvTOZ8Pts", ngs2_voice_run_commands, "sceNgs2VoiceRunCommands");
+    Hle::register_fn("-TOuuAQ-buE", ngs2_voice_get_state, "sceNgs2VoiceGetState");
+    Hle::register_fn("0lbbayqDNoE", ngs2_geom_reset_source, "sceNgs2GeomResetSourceParam");
+    Hle::register_fn("i0VnXM-C9fc", ngs2_system_render, "sceNgs2SystemRender");
+    Hle::register_fn("7Lcfo8SmpsU", ngs2_geom_reset_listener, "sceNgs2GeomResetListenerParam");
+    Hle::register_fn("1WsleK-MTkE", ngs2_geom_calc_listener, "sceNgs2GeomCalcListener");
     #undef R
 }
 

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -1,4 +1,4 @@
-// test_audio — behavioral test for the sceAudioOut HLE (hle_audio.cpp) via a capturing sink.
+// test_audio — behavioral tests for the sceAudioOut and NGS2 HLEs in hle_audio.cpp.
 //
 // Agentic-first: no device, no PATH/DLL setup. Installs a fake AudioSink, drives the real HLE
 // entrypoints through the dispatch table (so registration + arg decoding + forwarding are all
@@ -49,6 +49,12 @@ static int64_t call(const char* n, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2
                     uint64_t a3 = 0, uint64_t a4 = 0, uint64_t a5 = 0) {
     HleFn f = FN(n);
     if (!f) { printf("  [FAIL] not registered: %s\n", n); fails++; return -999; }
+    return (int64_t)f(a0, a1, a2, a3, a4, a5);
+}
+static int64_t call_raw(const char* nid, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0,
+                        uint64_t a3 = 0, uint64_t a4 = 0, uint64_t a5 = 0) {
+    HleFn f = Hle::lookup(nid);
+    if (!f) { printf("  [FAIL] raw NID not registered: %s\n", nid); fails++; return -999; }
     return (int64_t)f(a0, a1, a2, a3, a4, a5);
 }
 static uint64_t PTR(const void* p) { return (uint64_t)(uintptr_t)p; }
@@ -157,10 +163,67 @@ int main() {
                                                           // ports (Kyty/shadPS4 both return a single grain)
     CHECK(sink.outs.size() == 2);                         // ...but both valid entries are still forwarded
 
+    // --- 10. libSceNgs2 silent lifecycle: sizes, handles, state, and render output -------------
+    struct BufferInfo { uint64_t host_buffer, host_buffer_size, reserved[5], user_data; };
+    struct RackOption {
+        uint64_t size; char name[16]; uint32_t flags, max_grain, max_voices,
+            max_delay, max_matrices, max_ports, reserved[20];
+    };
+    struct RenderInfo { uint64_t buffer, size; uint32_t waveform_type, channels; };
+
+    BufferInfo sys_info; memset(&sys_info, 0xEE, sizeof sys_info);
+    CHECK(call_raw("pgFAiLR5qT4", 0, PTR(&sys_info)) == 0); // SystemQueryBufferSize
+    CHECK(sys_info.host_buffer == 0);
+    CHECK(sys_info.host_buffer_size == 0x1000);
+    CHECK(sys_info.reserved[0] == 0 && sys_info.user_data == 0);
+    std::vector<uint8_t> sys_work(sys_info.host_buffer_size, 0);
+    sys_info.host_buffer = PTR(sys_work.data());
+    uint64_t system = 0xDEADBEEFDEADBEEFull;
+    CHECK(call_raw("koBbCMvOKWw", 0, PTR(&sys_info), PTR(&system)) == 0); // SystemCreate
+    CHECK(system != 0 && system != 0xDEADBEEFDEADBEEFull);
+
+    RackOption rack_opt{}; rack_opt.size = sizeof rack_opt; rack_opt.max_voices = 2;
+    memcpy(rack_opt.name, "test", 5);
+    BufferInfo rack_info; memset(&rack_info, 0xDD, sizeof rack_info);
+    CHECK(call_raw("0eFLVCfWVds", 0x2001, PTR(&rack_opt), PTR(&rack_info)) == 0);
+    CHECK(rack_info.host_buffer == 0 && rack_info.host_buffer_size >= 0x1000);
+    std::vector<uint8_t> rack_work(rack_info.host_buffer_size, 0);
+    rack_info.host_buffer = PTR(rack_work.data());
+    uint64_t rack = 0xDEADBEEFDEADBEEFull;
+    CHECK(call_raw("cLV4aiT9JpA", system, 0x2001, PTR(&rack_opt), PTR(&rack_info), PTR(&rack)) == 0);
+    CHECK(rack != 0 && rack != 0xDEADBEEFDEADBEEFull);
+
+    uint64_t voice = 0xDEADBEEFDEADBEEFull;
+    CHECK(call_raw("MwmHz8pAdAo", rack, 1, PTR(&voice)) == 0);
+    CHECK(voice != 0 && voice != 0xDEADBEEFDEADBEEFull);
+    uint64_t invalid_voice = 0xDEADBEEFDEADBEEFull;
+    CHECK((int32_t)call_raw("MwmHz8pAdAo", rack, 2, PTR(&invalid_voice)) == (int32_t)0x804A0302);
+    CHECK(invalid_voice == 0xDEADBEEFDEADBEEFull);
+
+    uint8_t voice_state[0x30]; memset(voice_state, 0xCC, sizeof voice_state);
+    CHECK(call_raw("-TOuuAQ-buE", voice, PTR(voice_state), sizeof voice_state) == 0);
+    for (uint8_t b : voice_state) CHECK(b == 0);           // inert voice = Empty
+
+    uint8_t ngs_pcm[256]; memset(ngs_pcm, 0xA5, sizeof ngs_pcm);
+    RenderInfo render{PTR(ngs_pcm), sizeof ngs_pcm, 0, 2};
+    CHECK(call_raw("i0VnXM-C9fc", system, PTR(&render), 1) == 0);
+    for (uint8_t b : ngs_pcm) CHECK(b == 0);               // silent backend produces silence
+    CHECK((int32_t)call_raw("i0VnXM-C9fc", 0, PTR(&render), 1) == (int32_t)0x804A0230);
+
+    uint8_t source[0xA8], listener[0xA0], listener_work[0x60];
+    memset(source, 0xBB, sizeof source); memset(listener, 0xBB, sizeof listener);
+    memset(listener_work, 0xBB, sizeof listener_work);
+    CHECK(call_raw("0lbbayqDNoE", PTR(source)) == 0);
+    CHECK(call_raw("7Lcfo8SmpsU", PTR(listener)) == 0);
+    CHECK(call_raw("1WsleK-MTkE", PTR(listener), PTR(listener_work), 0) == 0);
+    for (uint8_t b : source) CHECK(b == 0);
+    for (uint8_t b : listener) CHECK(b == 0);
+    for (uint8_t b : listener_work) CHECK(b == 0);
+
     // --- restore the default sink so we don't dangle a stack pointer -------------------------
     audio_reset();
 
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
-    printf("== PASS: sceAudioOut HLE (format/open/output/volume/state/close/batch/errors) ==\n");
+    printf("== PASS: sceAudioOut + NGS2 HLE lifecycle/output/error contracts ==\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

- implement Dead Cells' exercised libSceNgs2 system/rack/voice lifecycle
- return deterministic nonzero work-buffer sizes and opaque validated handles
- initialize sampler voice state and geometry outputs instead of success-with-garbage
- produce zero-filled PCM through a silent `SystemRender` backend
- retain optional rate-limited `PROSPER_NGS2_TRACE=1` argument tracing
- extend `test_audio` with poisoned-output, handle, error, geometry, and silent-render coverage

## Evidence

Live prototypes/argument positions were captured from Dead Cells under #545 and cross-checked against the PS5 3.20 export table, Kyty, and shadPS4.

## Verification

- full Linux CTest: 85/85
- Messenger boot regression: 3 consecutive passes
- `snapshot.py check messenger-scene`: 24,318 colors, threshold 5,000
- default NGS2 path, no trace gate: Dead Cells reaches submit 20,000 and renders the Evil Empire splash; evidence retained at `C:\Users\matti\Downloads\ps5ys-deadcells-550-default`

Fixes #550