### PR TITLE
feat(tool): add screenshot render warmup

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -11,6 +11,7 @@
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
 
 #include <atomic>
+#include <chrono>
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
@@ -65,6 +66,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // reach a post-loading-screen scene.
             static std::atomic<int> g_submit_idx{0};
             static int g_render_first = getenv("PROSPER_RENDER_FIRST") ? atoi(getenv("PROSPER_RENDER_FIRST")) : 0;
+            // PROSPER_RENDER_DELAY_MS=<N>: wall-clock warmup for titles whose useful scene begins after
+            // a variable number of submits. The guest and command decoder keep running at native speed;
+            // only the synchronous Vulkan work is skipped. The clock starts at the first GPU submit.
+            static const int64_t g_render_delay_ms = getenv("PROSPER_RENDER_DELAY_MS")
+                ? std::max<int64_t>(0, atoll(getenv("PROSPER_RENDER_DELAY_MS"))) : 0;
+            static const auto g_render_delay_start = std::chrono::steady_clock::now();
+            static std::atomic<bool> g_render_delay_announced{false};
             // PROSPER_RENDER_LAST=<N>: stop rendering after submit N (default: unbounded). Bounds the render
             // window so a diagnostic slice at a late stall (RENDER_FIRST..RENDER_LAST) does not accumulate
             // unbounded RTT/GPU resources across tens of thousands of submits (which OOM-kills the process).
@@ -107,9 +115,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
             }
             // A one-time offscreen producer may occur before a much later consumer render window.
-            // Render that target even before RENDER_FIRST so its RTT cache entry survives skipped
-            // intermediate submits (#526).
-            if (g_this_submit < g_render_first && !force_target) return {};
+            // Render that target even before the warmup ends so its RTT cache entry survives skipped
+            // intermediate submits (#526). Submit-count and wall-clock gates are additive.
+            const int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - g_render_delay_start).count();
+            const bool before_delay = elapsed_ms < g_render_delay_ms;
+            if (!before_delay && g_render_delay_ms > 0 &&
+                !g_render_delay_announced.exchange(true, std::memory_order_relaxed)) {
+                fprintf(stderr, "[render] wall-clock warmup complete after %lld ms at submit %d\n",
+                        (long long)elapsed_ms, g_this_submit);
+            }
+            if ((g_this_submit < g_render_first || before_delay) && !force_target) return {};
             // Dump the FIRST item's recompiled SPIR-V (diagnostic; survives a mid-render crash).
             if (getenv("PROSPER_SHADER_DUMP") && !items.empty()) {
                 std::string d = getenv("PROSPER_SHADER_DUMP");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -49,6 +49,10 @@ This preserves a one-time producer in the RTT cache while still skipping an expe
 late consumer.
 `PROSPER_RENDER_RESOURCE_DIM=WxH` likewise executes submits that sample a matching image, allowing a
 producer/consumer A/B without rendering every unrelated submit between them.
+`PROSPER_RENDER_DELAY_MS=N` skips synchronous Vulkan work for N milliseconds from the first submit while
+the guest and command decoder advance. The `screenshot` frontend exposes this as `--warmup-seconds`, plus
+`--warmup-submits` for `PROSPER_RENDER_FIRST`; use wall-clock warmup for progression captures and the exact
+submit gate for repeatable renderer investigations.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -24,6 +24,7 @@ cmake --build build --target screenshot
 
 ```
 screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
+           [--warmup-seconds S] [--warmup-submits N]
 ```
 
 | Option | Default | Meaning |
@@ -34,9 +35,17 @@ screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
 | `--count M` | 30 | Number of screenshots, then exit |
 | `--out DIR` | `.` | Output directory; missing directories and parents are created |
 | `--timeout S` | 900 | Give up after S seconds if the game isn't rendering enough (0 = no limit) |
+| `--warmup-seconds S` | 0 | Advance the guest for S seconds without synchronous Vulkan rendering |
+| `--warmup-submits N` | 0 | Advance without rendering until GPU submit N |
 
 Only the game is required; everything else has a sane default.
 Directory-creation and PNG write failures include the failing path and operating-system error.
+
+Warmup is useful when llvmpipe makes a frame-counted startup take minutes. The guest and GPU command
+decoder continue at native speed while Vulkan work is skipped; normal screenshots begin once rendering
+does. During warmup, the raw-scanout fallback is suppressed so the output folder does not fill with
+misleading loading frames. The two warmup gates are additive when both are supplied. `--timeout` covers
+the entire run, including warmup.
 
 **"Frames" = rendered frames** (composited images handed to the present layer), *not* guest flips —
 the guest flips far faster than llvmpipe renders, so counting flips would bunch every shot into the
@@ -66,4 +75,7 @@ PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1 screenshot /path/PPSA01885-app0
 ```bash
 # 30 shots, one every 60 rendered frames, into ./shots
 screenshot /mnt/c/.../PPSA24651-app0 --out shots
+
+# Skip Dead Cells' submit-heavy startup, then capture ten normal frames one second apart.
+screenshot /mnt/c/.../PPSA15552-app0 --warmup-seconds 3 --seconds 1 --count 10 --out shots
 ```

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -2,17 +2,20 @@
 //
 // Reuses the shared boot path (boot_program) and the shared live renderer (frontends/shared), so the
 // game boots and composites exactly as boot_trace / prosper-app do; this tool just samples the
-// present layer (present_readback) periodically and writes PNGs. Frames are counted as display flips
-// (present_count). Files are named <titleCode>_<runTimestamp>_<index>.png so every screenshot from
+// present layer (present_readback) periodically and writes PNGs. Frames are counted as rendered frames
+// (present_frame_seq). Files are named <titleCode>_<runTimestamp>_<index>.png so every screenshot from
 // one run shares a prefix and sorts together in a folder of many runs.
 //
 //   screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
+//              [--warmup-seconds S] [--warmup-submits N]
 //     <app0-dir>   REQUIRED. The game dump root (e.g. .../PPSA24651-app0). Title code = its basename
 //                  with a trailing "-app0" stripped.
-//     --every N    frames (flips) between screenshots        (default 60)
+//     --every N    rendered frames between screenshots       (default 60)
 //     --count M    number of screenshots to take, then exit  (default 30)
 //     --out DIR    output directory                          (default ".")
-//     --timeout S  give up after S seconds if the game isn't flipping enough (default 900; 0 = none)
+//     --timeout S  give up after S seconds if the game isn't rendering enough (default 900; 0 = none)
+//     --warmup-seconds S  skip Vulkan rendering for S seconds before capture
+//     --warmup-submits N  skip Vulkan rendering before submit N
 //
 // Reaching a rendering frame loop needs the guest switches the render frontier documents; this tool
 // defaults PROSPER_GUEST_FS=1 and PROSPER_GUEST_ARGS=-force-gfx-direct (Unity/Messenger recipe) if
@@ -25,6 +28,9 @@
 #include "live_renderer.hpp"           // register_live_renderer (frontends/shared)
 
 #include <zlib.h>
+#include <algorithm>
+#include <climits>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -42,6 +48,24 @@
 using namespace prosper;
 
 namespace {
+
+bool parse_nonnegative_double(const char* text, double& value) {
+    char* end = nullptr;
+    errno = 0;
+    const double parsed = strtod(text, &end);
+    if (errno || end == text || *end != '\0' || parsed < 0.0 || !std::isfinite(parsed)) return false;
+    value = parsed;
+    return true;
+}
+
+bool parse_nonnegative_int(const char* text, int& value) {
+    char* end = nullptr;
+    errno = 0;
+    const long parsed = strtol(text, &end, 10);
+    if (errno || end == text || *end != '\0' || parsed < 0 || parsed > INT_MAX) return false;
+    value = static_cast<int>(parsed);
+    return true;
+}
 
 void put_chunk(FILE* f, const char* type, const uint8_t* data, size_t len) {
     uint8_t hdr[4] = { (uint8_t)(len >> 24), (uint8_t)(len >> 16), (uint8_t)(len >> 8), (uint8_t)len };
@@ -105,6 +129,9 @@ int main(int argc, char** argv) {
     std::string dump, out = ".";
     int every = 60, count = 30, timeout = 900;
     double seconds = 0.0;   // >0 => capture every N wall-clock seconds instead of every N rendered frames
+    double warmup_seconds = -1.0;  // <0 => preserve the environment; explicit values override it
+    int warmup_submits = -1;
+    bool warmup_seconds_set = false, warmup_submits_set = false;
     for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
         if      (a == "--every"   && i + 1 < argc) every = atoi(argv[++i]);
@@ -112,11 +139,25 @@ int main(int argc, char** argv) {
         else if (a == "--count"   && i + 1 < argc) count = atoi(argv[++i]);
         else if (a == "--out"     && i + 1 < argc) out   = argv[++i];
         else if (a == "--timeout" && i + 1 < argc) timeout = atoi(argv[++i]);
+        else if (a == "--warmup-seconds" && i + 1 < argc) {
+            warmup_seconds_set = true;
+            if (!parse_nonnegative_double(argv[++i], warmup_seconds)) {
+                fprintf(stderr, "screenshot: --warmup-seconds requires a non-negative number\n");
+                return 2;
+            }
+        }
+        else if (a == "--warmup-submits" && i + 1 < argc) {
+            warmup_submits_set = true;
+            if (!parse_nonnegative_int(argv[++i], warmup_submits)) {
+                fprintf(stderr, "screenshot: --warmup-submits requires a non-negative integer\n");
+                return 2;
+            }
+        }
         else if (!a.empty() && a[0] != '-' && dump.empty()) dump = a;
         else { fprintf(stderr, "screenshot: unknown/duplicate arg '%s'\n", a.c_str()); return 2; }
     }
     if (dump.empty()) {
-        fprintf(stderr, "usage: screenshot <app0-dir> [--every N=60 | --seconds S] [--count M=30] [--out DIR] [--timeout SECS]\n");
+        fprintf(stderr, "usage: screenshot <app0-dir> [--every N=60 | --seconds S] [--count M=30] [--out DIR] [--timeout SECS] [--warmup-seconds S] [--warmup-submits N]\n");
         return 2;
     }
     if (every < 1) every = 1;
@@ -139,6 +180,23 @@ int main(int argc, char** argv) {
     // Sane render-frontier defaults (don't override if the caller set them for another title).
     setenv("PROSPER_GUEST_FS",   "1", 0);
     setenv("PROSPER_GUEST_ARGS", "-force-gfx-direct", 0);
+    if (warmup_seconds_set) {
+        char delay_ms[32];
+        snprintf(delay_ms, sizeof delay_ms, "%lld",
+                 (long long)(warmup_seconds * 1000.0 + 0.5));
+        setenv("PROSPER_RENDER_DELAY_MS", delay_ms, 1);
+    }
+    if (warmup_submits_set) {
+        char first_submit[32];
+        snprintf(first_submit, sizeof first_submit, "%d", warmup_submits);
+        setenv("PROSPER_RENDER_FIRST", first_submit, 1);
+    }
+
+    const int64_t render_delay_ms = getenv("PROSPER_RENDER_DELAY_MS")
+        ? std::max<int64_t>(0, atoll(getenv("PROSPER_RENDER_DELAY_MS"))) : 0;
+    const int render_first = getenv("PROSPER_RENDER_FIRST")
+        ? std::max(0, atoi(getenv("PROSPER_RENDER_FIRST"))) : 0;
+    const bool warming_up = render_delay_ms > 0 || render_first > 0;
 
     std::error_code out_ec;
     std::filesystem::create_directories(out, out_ec);
@@ -163,6 +221,9 @@ int main(int argc, char** argv) {
     else
         fprintf(stderr, "[shot] %s: %d screenshots, every %d frames -> %s/%s_%s_*.png\n",
                 code.c_str(), count, every, out.c_str(), code.c_str(), ts);
+    if (warming_up)
+        fprintf(stderr, "[shot] warmup: %lld ms, %d submits; raw scanout suppressed until rendering begins\n",
+                (long long)render_delay_ms, render_first);
 
     std::vector<uint8_t> buf;
     int saved = 0;
@@ -180,7 +241,7 @@ int main(int argc, char** argv) {
         bool due = time_mode ? (std::chrono::duration<double>(now - last_cap).count() >= seconds)
                              : (gpu::present_frame_seq() >= next);
         const bool rendered = gpu::present_has_frame();
-        const bool raw_scanout = gpu::present_front_index() >= 0 &&
+        const bool raw_scanout = !warming_up && gpu::present_front_index() >= 0 &&
                                  gpu::present_width() > 0 && gpu::present_height() > 0;
         if ((rendered || raw_scanout) && due) {
             uint64_t at = gpu::present_frame_seq();


### PR DESCRIPTION
## Summary
- add wall-clock and submit-count renderer warmup gates
- expose them as `screenshot --warmup-seconds` and `--warmup-submits`
- suppress raw-scanout screenshots while a warmup is active
- document timing, timeout, and Dead Cells usage

## Validation
- Dead Cells: 3-second warmup reached submit 19,758; 3 native 3840x2160 Evil Empire splash captures completed in 6.5 seconds
- Dead Cells: exact-submit warmup began rendering at submit 15,000
- output directories were absent before both runs and created automatically
- Linux: 85/85 ctest
- Messenger: `messenger-scene` snapshot passed, 24,318 colors >= 5,000

Fixes #549