### PR TITLE
fix(tool): list content-metric snapshots

### DIFF
--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -273,8 +273,12 @@ def select(m, names):
 
 def cmd_list(m, names):
     for s in m["snapshots"]:
-        print(f"  {s['name']:<28} dump={s['dump']} frame={s['frame']} "
-              f"hash={'set' if s.get('hash') else 'MISSING'}")
+        if "min_colors" in s:
+            mode = f"min_colors={s['min_colors']}"
+        else:
+            mode = (f"frame={s.get('frame', 'MISSING')} "
+                    f"hash={'set' if s.get('hash') else 'MISSING'}")
+        print(f"  {s['name']:<28} dump={s['dump']} {mode}")
 
 
 def cmd_update(m, names):


### PR DESCRIPTION
## Summary
- make `snapshot.py list` distinguish run-level `min_colors` guards from exact frame/hash entries
- avoid indexing a missing `frame` field for the current Messenger manifest

## Validation
- `python3 -m py_compile prosper/tools/snapshot/snapshot.py`
- `python3 prosper/tools/snapshot/snapshot.py list` reports `messenger-scene ... min_colors=5000`

Fixes #558