### PR TITLE
test(snapshot): add Dead Cells splash guard

### DIFF
--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -4,9 +4,10 @@ Real-game rendering regression guard. Run this whenever a change can affect
 rendered output: RDNA2-to-SPIR-V recompilation, AGC/PM4 decoding, render state,
 texture detiling, or executor/present behavior.
 
-The current Messenger guard records the richest frame's distinct-color count
-across the boot. This catches a render collapsed to a clear while tolerating the
-title's run-to-run frame variance.
+The Messenger guard records the richest frame's distinct-color count across the
+boot. The Dead Cells guard uses an exact first-frame hash after a wall-clock
+renderer warmup. Together they exercise both supported guard modes across two
+titles.
 
 ## Run It
 
@@ -14,6 +15,7 @@ title's run-to-run frame variance.
 # From prosper/, with build-linux/boot_trace built for the change.
 python3 tools/snapshot/snapshot.py check
 python3 tools/snapshot/snapshot.py check messenger-scene
+python3 tools/snapshot/snapshot.py check dead-cells-splash
 ```
 
 On failure, the screenshot and boot log are written to

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -13,6 +13,7 @@ CI. Only hashes or content thresholds live in `snapshots.json`.
 # From prosper/, after building build-linux/boot_trace.
 python3 tools/snapshot/snapshot.py check
 python3 tools/snapshot/snapshot.py check messenger-scene
+python3 tools/snapshot/snapshot.py check dead-cells-splash
 ```
 
 On failure, `check` writes the screenshot and boot log to
@@ -25,6 +26,14 @@ On failure, `check` writes the screenshot and boot log to
   guard uses this mode and tolerates frame timing variance.
 - `frame` plus `hash`: compare one targeted draw-submit frame exactly. Run
   `verify <name>` before establishing its baseline with `update <name>`.
+
+## Current Matrix
+
+- `messenger-scene`: run-level content guard because the threaded boot does not
+  choose a stable exact frame.
+- `dead-cells-splash`: exact first frame after a three-second renderer warmup.
+  The warmup advances the submit-heavy startup without synchronous llvmpipe
+  rendering; repeated captures are pixel-identical at 960x540.
 
 ## Adding A Snapshot
 

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -8,6 +8,21 @@
       "env": {},
       "min_colors": 5000,
       "_note": "Content-metric guard (min_colors): The Messenger's boot render isn't pixel-deterministic across runs (exact hashing AND a single settled frame both flake — the stable screen varies run-to-run). So `check` runs the whole boot and takes the RICHEST frame's distinct-color count — robust to per-frame variance, but still catches the regression that matters: a rejected/dropped shader (the #199/#201/#239 class) collapses every frame to the debug clear (~1 color), while a real render peaks in the tens of thousands (observed ~34k-137k once the scene/cutscene renders). 5000 is a wide margin below that and far above any blue-clear."
+    },
+    {
+      "name": "dead-cells-splash",
+      "dump": "PPSA15552-app0",
+      "scale": 4,
+      "timeout": 20,
+      "frame": 0,
+      "env": {
+        "PROSPER_RENDER_DELAY_MS": "3000"
+      },
+      "hash": "8429fedd427b63d9330e6dc2357699a3d22fd1c0a7b664f873c83955cb8420d0",
+      "dims": [
+        960,
+        540
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Dead Cells as the second title in the local rendering snapshot matrix
- use a 3-second renderer warmup, then hash the first rendered Evil Empire splash at 960x540
- document the current exact-hash and content-metric guards

## Determinism evidence
- `snapshot.py verify`: two identical captures, `8429fedd427b...`
- `snapshot.py update`: two additional identical captures before blessing the hash
- two subsequent `snapshot.py check` runs passed
- six independent runs total matched the same pixel hash

## Other validation
- `snapshot.py list` reports both guard modes after #559
- `python3 -m py_compile prosper/tools/snapshot/snapshot.py`

Fixes #248