### PR TITLE
feat(input): load reusable pad routes

### DIFF
--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -1,11 +1,12 @@
 # Input replay & checkpoints — reaching a game state to reproduce a bug
 
-> **Status (2026-07-11): inline frame anchoring and the opt-in deterministic clock have landed.**
+> **Status (2026-07-12): frame anchoring, file-loaded routes, and the opt-in deterministic clock have landed.**
 > Current master supports inline `PROSPER_PAD_SCRIPT` entries anchored as `fN:`/`fA-B:` and
 > `PROSPER_DET_CLOCK=1` (fixed `1/PROSPER_DET_FPS`, default 60, per flip). Before the first flip the
 > monotonic clock follows host time so initialization can progress; afterward it intentionally pauses
-> between flips. Realtime/RTC clocks remain tied to host time. File-loaded routes, recording, checked-in
-> scripts, and pad-read screenshot checkpoints remain open in #302. The original design follows.
+> between flips. Realtime/RTC clocks remain tied to host time. `PROSPER_PAD_SCRIPT=@path` loads newline-
+> separated routes with comments and explicit time/flip ranges. Recording, checked-in verified scripts,
+> and pad-read screenshot checkpoints remain open in #302. The original design follows.
 
 ## The problem
 
@@ -36,9 +37,9 @@ Good bones. Two gaps for reaching deep states reliably: the clock is **wall-time
 
 ## Design
 
-### 1. Frame-anchored, file-loadable scripts (core)
+### 1. Frame-anchored, file-loadable scripts (core) - implemented
 - **Anchor to game frames, not wall-time.** Keep the "first pad poll" origin (robust to load time), but measure progress in **flips since first poll** (game logic frames), not elapsed seconds. The Messenger is a fixed-timestep platformer, so wall-time drifts vs game frames on slow llvmpipe vs a fast GPU — frame anchoring makes `f300:cross` reproduce everywhere. Add an `f<frame>:` entry syntax alongside the existing `<seconds>:` (kept for back-compat).
-- **Load from a file.** `PROSPER_PAD_SCRIPT=@path` (or `PROSPER_PAD_SCRIPT_FILE=path`) reads a multi-line script file, so long routes live in the repo, not an env string.
+- **Load from a file.** `PROSPER_PAD_SCRIPT=@path` reads a multi-line script file, so long routes live in the repo, not an env string.
 - **Richer input.** Per-entry hold length, analog stick directions, not just a 300 ms button tap.
 
 ### 2. Record mode in `prosper-app`

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -57,8 +57,10 @@ uint64_t now_us() {
 // --- PROSPER_PAD_SCRIPT: hardware-free timed button sequence -------------------------------------
 // Drives a scripted controller so a headless run can navigate menus (e.g. the title→menu→save→name
 // flow in issue #163) with no host device. Format: a ';'-separated list of "<seconds>:<button>[+..]"
-// entries, e.g. "3:start;9:start;16:cross;24:cross;31:up+cross". Each entry presses its button(s)
-// for PROSPER_PAD_HOLD ms (default 300) starting at <seconds>. When a script is set the pad reports
+// entries, e.g. "3:start;9:start;16:cross;24:cross;31:up+cross". Prefix with '@' to load a route
+// file; files may use newlines, comments, and explicit ranges such as "f300-340:cross". Time points
+// use PROSPER_PAD_HOLD ms (default 300); flip points use PROSPER_PAD_FRAME_HOLD (default 8). When a
+// script is set the pad reports
 // CONNECTED for the whole run (a menu that gates on a controller sees one).
 //
 // Timing is anchored to the FIRST input poll, not process start: the game only reads the pad once it
@@ -68,7 +70,11 @@ uint64_t now_us() {
 const std::vector<PadScriptEntry>& pad_script() {
     static const std::vector<PadScriptEntry> script = [] {
         const char* env = getenv("PROSPER_PAD_SCRIPT");
-        return env ? parse_pad_script(env) : std::vector<PadScriptEntry>{};
+        if (!env) return std::vector<PadScriptEntry>{};
+        std::string error;
+        auto loaded = load_pad_script(env, &error);
+        if (!error.empty()) fprintf(stderr, "[pad] PROSPER_PAD_SCRIPT: %s\n", error.c_str());
+        return loaded;
     }();
     return script;
 }

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -7,6 +7,9 @@
 #include <cstring>
 #include <cstdlib>
 #include <atomic>
+#include <cmath>
+#include <fstream>
+#include <sstream>
 
 namespace prosper::input {
 
@@ -123,27 +126,66 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
     std::vector<PadScriptEntry> v;
     size_t i = 0;
     while (i < spec.size()) {
-        size_t semi = spec.find(';', i);
-        std::string tok = spec.substr(i, semi == std::string::npos ? std::string::npos : semi - i);
-        i = (semi == std::string::npos) ? spec.size() : semi + 1;
+        size_t sep = spec.find_first_of(";\n", i);
+        std::string tok = spec.substr(i, sep == std::string::npos ? std::string::npos : sep - i);
+        i = (sep == std::string::npos) ? spec.size() : sep + 1;
+        if (size_t comment = tok.find('#'); comment != std::string::npos) tok.erase(comment);
+        auto trim = [](std::string s) {
+            const size_t first = s.find_first_not_of(" \t\r\f\v");
+            if (first == std::string::npos) return std::string{};
+            return s.substr(first, s.find_last_not_of(" \t\r\f\v") - first + 1);
+        };
+        tok = trim(tok);
+        if (tok.empty()) continue;
         size_t colon = tok.find(':');
         if (colon == std::string::npos) continue;
-        std::string head = tok.substr(0, colon);
+        std::string head = trim(tok.substr(0, colon));
         // A leading 'f' marks a FRAME-anchored entry ("f300:cross" -> flip 300); else it's seconds.
         bool frame_anchored = (!head.empty() && (head[0] == 'f' || head[0] == 'F'));
-        double t = atof(frame_anchored ? head.c_str() + 1 : head.c_str());
+        std::string window = frame_anchored ? head.substr(1) : head;
+        size_t dash = window.find('-', 1);
+        auto parse_number = [](const std::string& text, double& out) {
+            char* end = nullptr;
+            const double value = strtod(text.c_str(), &end);
+            if (end == text.c_str() || *end != '\0' || value < 0.0 || !std::isfinite(value)) return false;
+            out = value;
+            return true;
+        };
+        double start = 0.0, end = 0.0;
+        if (!parse_number(trim(window.substr(0, dash)), start)) continue;
+        if (dash != std::string::npos) {
+            if (!parse_number(trim(window.substr(dash + 1)), end) || end <= start) continue;
+        }
         std::string btns = tok.substr(colon + 1);
         uint32_t mask = 0;
         size_t j = 0;
         while (j < btns.size()) {                       // '+'-separated buttons pressed together
             size_t plus = btns.find('+', j);
-            std::string one = btns.substr(j, plus == std::string::npos ? std::string::npos : plus - j);
+            std::string one = trim(btns.substr(j, plus == std::string::npos ? std::string::npos : plus - j));
             j = (plus == std::string::npos) ? btns.size() : plus + 1;
             mask |= pad_button_by_name(one);
         }
-        if (mask) v.push_back({t, mask, frame_anchored});
+        if (mask) v.push_back({start, mask, frame_anchored, end});
     }
     return v;
+}
+
+std::vector<PadScriptEntry> load_pad_script(const std::string& source, std::string* error) {
+    if (error) error->clear();
+    if (source.empty() || source[0] != '@') return parse_pad_script(source);
+    const std::string path = source.substr(1);
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        if (error) *error = path.empty() ? "route path is empty" : "cannot open route file: " + path;
+        return {};
+    }
+    std::ostringstream contents;
+    contents << file.rdbuf();
+    if (file.bad()) {
+        if (error) *error = "cannot read route file: " + path;
+        return {};
+    }
+    return parse_pad_script(contents.str());
 }
 
 uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs,
@@ -152,9 +194,11 @@ uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double
     for (const auto& e : script) {
         if (e.frame_anchored) {
             int64_t f = (int64_t)e.t_secs;   // frame number lives in t_secs for frame-anchored entries
-            if (frame_count >= 0 && frame_count >= f && frame_count < f + frame_hold) mask |= e.button_mask;
+            int64_t end = e.end > e.t_secs ? (int64_t)e.end : f + frame_hold;
+            if (frame_count >= 0 && frame_count >= f && frame_count < end) mask |= e.button_mask;
         } else {
-            if (elapsed_secs >= e.t_secs && elapsed_secs < e.t_secs + hold_secs) mask |= e.button_mask;
+            double end = e.end > e.t_secs ? e.end : e.t_secs + hold_secs;
+            if (elapsed_secs >= e.t_secs && elapsed_secs < end) mask |= e.button_mask;
         }
     }
     return mask;

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -144,20 +144,31 @@ uint32_t pad_trigger_buttons(uint8_t l2, uint8_t r2);
 // first poll). Frame-anchoring is boot-speed-invariant: `f300:cross` fires at the same game state on a
 // fast GPU and slow llvmpipe, where a wall-clock `10:cross` would drift — essential for deterministic
 // menu-reach across builds (bisect/regression repro). See #302.
-struct PadScriptEntry { double t_secs; uint32_t button_mask; bool frame_anchored = false; };
+struct PadScriptEntry {
+    double t_secs;
+    uint32_t button_mask;
+    bool frame_anchored = false;
+    double end = 0.0;  // exclusive explicit range end; 0 uses the configured default hold
+};
 
 // Map a button name ("start"/"options"/"cross"/"x"/"up"/... case as written) to its SCE_PAD_BUTTON_*
 // bit; 0 if unknown. "start" and "options" both mean the PS5 Options button (the "Start" equivalent).
 uint32_t pad_button_by_name(const std::string& name);
 
-// Parse "<secs>:<btn>[+<btn>...][;...]" into entries (e.g. "3:start;9:cross+up"). An entry whose time
-// token starts with 'f' is FRAME-anchored: "f300:cross" fires at flip 300 since the first poll. Entries
-// with no recognized button are dropped. Whitespace-tolerant only where the spec has none by design.
+// Parse ';'- or newline-separated entries. An entry whose time token starts with 'f' is
+// FRAME-anchored: "f300:cross" fires at flip 300 since the first poll. Both anchors accept explicit
+// ranges ("3-4.5:cross", "f300-340:cross"); '#' starts a comment. Malformed entries and entries with
+// no recognized button are dropped.
 std::vector<PadScriptEntry> parse_pad_script(const std::string& spec);
+
+// Parse an inline script, or load and parse one from disk when `source` starts with '@'. Relative
+// paths use the process working directory. Returns an empty vector and describes file I/O errors.
+std::vector<PadScriptEntry> load_pad_script(const std::string& source, std::string* error = nullptr);
 
 // Buttons held now: OR of every entry whose window contains the current time. A seconds-anchored entry
 // matches [t, t+hold_secs) against `elapsed_secs`; a frame-anchored entry matches [f, f+frame_hold)
 // against `frame_count` (pass -1 when no frame count is available -> frame entries never fire).
+// An explicit range uses its exclusive `end`; point entries use hold_secs/frame_hold.
 uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs,
                                int64_t frame_count = -1, int64_t frame_hold = 8);
 

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -10,6 +10,9 @@
 #include <cstdint>
 #include <cstring>
 #include <cstddef>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 
 using namespace prosper;
 using namespace prosper::input;
@@ -173,6 +176,32 @@ int main() {
               "frame: at window end (exclusive) -> released");
         CHECK(pad_script_buttons_at(fs, 5.1, hold, /*no frame info*/-1, fhold) == SCE_PAD_BUTTON_OPTIONS,
               "frame: seconds entry still fires with frame_count=-1; frame entry does not");
+
+        // File syntax: newlines/comments, explicit time/frame ranges, and @path loading.
+        auto ranges = parse_pad_script("# checkpoint\n f10-20:cross # hold\n3-4.5:up+cross\n");
+        CHECK(ranges.size() == 2, "route: comments/newlines parse two entries");
+        CHECK(ranges[0].frame_anchored && ranges[0].t_secs == 10.0 && ranges[0].end == 20.0,
+              "route: frame range preserves exclusive end");
+        CHECK(!ranges[1].frame_anchored && ranges[1].t_secs == 3.0 && ranges[1].end == 4.5,
+              "route: time range preserves exclusive end");
+        CHECK(pad_script_buttons_at(ranges, 0.0, hold, 19, fhold) == SCE_PAD_BUTTON_CROSS,
+              "route: frame range active before explicit end");
+        CHECK(pad_script_buttons_at(ranges, 0.0, hold, 20, fhold) == 0,
+              "route: frame range ends exclusively");
+        CHECK(pad_script_buttons_at(ranges, 4.4, hold, -1, fhold) ==
+              (SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS), "route: time range active");
+
+        const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+        const auto route_path = std::filesystem::temp_directory_path() /
+                                ("prosper_test_pad_route_" + std::to_string(unique) + ".pad");
+        { std::ofstream route(route_path); route << "# loaded route\nf7-12:options\n"; }
+        std::string route_error;
+        auto loaded = load_pad_script("@" + route_path.string(), &route_error);
+        CHECK(route_error.empty() && loaded.size() == 1 && loaded[0].frame_anchored && loaded[0].end == 12.0,
+              "route: @path loads and parses a file");
+        std::filesystem::remove(route_path);
+        auto missing = load_pad_script("@/this/prosper/route/does/not/exist.pad", &route_error);
+        CHECK(missing.empty() && !route_error.empty(), "route: missing @path reports an error");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -23,6 +23,11 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 Verification here is agentic-first (see `docs/VERIFICATION.md`): prefer a
 programmatic check (ctest exit code, `spirv-val`, a snapshot hash) over eyeballing.
 
+To drive any runner through a longer input route, set
+`PROSPER_PAD_SCRIPT=@scripts/<title>/reach-<state>.pad`. Route files use the same
+seconds/flip syntax as inline scripts, accept one entry per line, `#` comments,
+and explicit ranges such as `f300-340:cross`. See `docs/INPUT_REPLAY.md`.
+
 Capture one draw-carrying renderer invocation with:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `PROSPER_PAD_SCRIPT=@path` loading to the core pad backend
- accept newline-separated entries, `#` comments, and inline comments
- support explicit time and flip ranges such as `3-4.5:cross` and `f300-340:cross`
- preserve current inline and `fN` display-flip semantics
- document the recovered #302 capability

## Validation
- focused `test_pad` covers parsing, exclusive range evaluation, @file loading, and missing-file errors
- Linux ctest: 85/85
- live Messenger run loaded an @file route, reported connected=1, and returned routed Options `buttons=0x8` through 15,000+ pad reads

Refs #302