### PR TITLE
feat(input): record replayable pad routes

### DIFF
--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -1,12 +1,14 @@
 # Input replay & checkpoints — reaching a game state to reproduce a bug
 
-> **Status (2026-07-12): frame anchoring, file-loaded routes, and the opt-in deterministic clock have landed.**
+> **Status (2026-07-12): frame anchoring, route loading/recording, and the opt-in deterministic clock have landed.**
 > Current master supports inline `PROSPER_PAD_SCRIPT` entries anchored as `fN:`/`fA-B:` and
 > `PROSPER_DET_CLOCK=1` (fixed `1/PROSPER_DET_FPS`, default 60, per flip). Before the first flip the
 > monotonic clock follows host time so initialization can progress; afterward it intentionally pauses
 > between flips. Realtime/RTC clocks remain tied to host time. `PROSPER_PAD_SCRIPT=@path` loads newline-
-> separated routes with comments and explicit time/flip ranges. Recording, checked-in verified scripts,
-> and pad-read screenshot checkpoints remain open in #302. The original design follows.
+> separated routes with comments and explicit time/flip ranges. `PROSPER_PAD_RECORD=path` records the
+> final button stream on that same flip axis; `prosper-app --record path` exposes it interactively.
+> Checked-in verified scripts and pad-read screenshot checkpoints remain open in #302. The original
+> design follows.
 
 ## The problem
 
@@ -42,7 +44,7 @@ Good bones. Two gaps for reaching deep states reliably: the clock is **wall-time
 - **Load from a file.** `PROSPER_PAD_SCRIPT=@path` reads a multi-line script file, so long routes live in the repo, not an env string.
 - **Richer input.** Per-entry hold length, analog stick directions, not just a 300 ms button tap.
 
-### 2. Record mode in `prosper-app`
+### 2. Record mode in `prosper-app` - implemented
 `prosper-app --dump <app0> --record <file>`: capture the human's keyboard/gamepad input **stamped by flip count**, writing a script file. This is how checkpoint scripts get *created* — play to the point once, get a reusable, committable route. (The app already snapshots keyboard state per frame; recording is writing that stream out, anchored to `present_count`.)
 
 ### 3. Checkpoint library + agent docs

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -43,6 +43,9 @@ Esc or closing the window quits.
 - `--dump <app0>` — boot and display the PS5 title at this app0 directory (positional path also works).
 - `--test-pattern` — feed a synthetic animated frame through the real present path (no guest).
 - `--frames N` — present N frames then exit 0 (non-interactive smoke; exit 1 if it couldn't).
+- `--record PATH` — record the final controller stream to a replayable `PROSPER_PAD_SCRIPT` route.
+  Missing parent directories are created; release the last held button before stopping so its interval
+  is closed and flushed.
 
 ## Notes
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -335,6 +335,7 @@ int main(int argc, char** argv) {
         if (a == "--test-pattern") testPattern = true;
         else if (a == "--frames" && i + 1 < argc) exitAfter = atoi(argv[++i]);   // present N frames then exit (CI/smoke)
         else if (a == "--dump" && i + 1 < argc) dump = argv[++i];                // boot the game at this app0 dir
+        else if (a == "--record" && i + 1 < argc) setenv("PROSPER_PAD_RECORD", argv[++i], 1);
         else if (a[0] != '-' && dump.empty()) dump = a;                          // positional dump path
     }
 

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -15,11 +15,17 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "../input/pad.hpp"
+#include <algorithm>
+#include <cerrno>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <cstdlib>
 #include <atomic>
 #include <chrono>
+#include <filesystem>
+#include <limits>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -94,16 +100,25 @@ std::atomic<uint64_t> g_pad_t0_us{0};
 // prosper_vo_flip_count() is the guest's presented-frame counter (hle_graphics.cpp), boot-speed-
 // invariant — unlike wall-clock it lands the same input on the same game state across builds (#302).
 extern "C" uint64_t prosper_vo_flip_count();
-std::atomic<uint64_t> g_pad_flip0{0};
-std::atomic<bool>     g_pad_flip0_set{false};
+std::atomic<uint64_t> g_pad_flip0{std::numeric_limits<uint64_t>::max()};
 
 int64_t pad_frame_hold() {   // how many flips to hold a frame-anchored press (default 8)
     static const int64_t h = [] { const char* e = getenv("PROSPER_PAD_FRAME_HOLD"); return e ? (int64_t)atoll(e) : 8; }();
     return h;
 }
 
+int64_t pad_frame_now() {
+    const uint64_t flips = prosper_vo_flip_count();
+    uint64_t base = g_pad_flip0.load(std::memory_order_relaxed);
+    if (base == std::numeric_limits<uint64_t>::max()) {
+        g_pad_flip0.compare_exchange_strong(base, flips, std::memory_order_relaxed);
+        base = g_pad_flip0.load(std::memory_order_relaxed);
+    }
+    return flips >= base ? (int64_t)(flips - base) : 0;
+}
+
 // Overlay any active scripted press onto `s`. Returns true if a script is driving the pad.
-bool apply_pad_script(HostPadState& s) {
+bool apply_pad_script(HostPadState& s, int64_t frame) {
     const auto& script = pad_script();
     if (script.empty()) return false;
     s.connected = true;                                     // a controller is present for the whole run
@@ -113,12 +128,54 @@ bool apply_pad_script(HostPadState& s) {
         if (g_pad_t0_us.compare_exchange_strong(expect, now)) t0 = now; else t0 = expect;
     }
     double elapsed = (now_us() - t0) / 1e6;
-    // Frame count = flips since the first poll (anchor the flip baseline on that same first poll).
-    uint64_t flips = prosper_vo_flip_count();
-    if (!g_pad_flip0_set.exchange(true)) g_pad_flip0.store(flips, std::memory_order_relaxed);
-    int64_t frame = (int64_t)(flips - g_pad_flip0.load(std::memory_order_relaxed));
     s.buttons |= pad_script_buttons_at(script, elapsed, pad_hold_secs(), frame, pad_frame_hold());
     return true;
+}
+
+// Record the final button stream as explicit flip ranges. Completed intervals are flushed immediately;
+// only a button still held when a process is force-killed can be absent from the route tail.
+void pad_record(int64_t frame, uint32_t buttons) {
+    static const char* output = getenv("PROSPER_PAD_RECORD");
+    if (!output || !*output) return;
+    struct Recorder {
+        std::mutex mutex;
+        bool initialized = false;
+        FILE* file = nullptr;
+        uint32_t previous = 0;
+        int64_t start = 0;
+    };
+    static Recorder recorder;
+    std::lock_guard<std::mutex> lock(recorder.mutex);
+    if (!recorder.initialized) {
+        recorder.initialized = true;
+        std::filesystem::path path(output);
+        std::error_code ec;
+        if (path.has_parent_path()) std::filesystem::create_directories(path.parent_path(), ec);
+        if (ec) {
+            fprintf(stderr, "[pad] PROSPER_PAD_RECORD: cannot create '%s': %s\n",
+                    path.parent_path().string().c_str(), ec.message().c_str());
+        } else if ((recorder.file = fopen(output, "w"))) {
+            fprintf(recorder.file,
+                    "# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll\n");
+            fflush(recorder.file);
+            fprintf(stderr, "[pad] recording input route -> %s\n", output);
+        } else {
+            fprintf(stderr, "[pad] PROSPER_PAD_RECORD: cannot open '%s': %s\n",
+                    output, strerror(errno));
+        }
+    }
+    if (!recorder.file || buttons == recorder.previous) return;
+    if (recorder.previous) {
+        const int64_t end = std::max(frame, recorder.start + 1);
+        const std::string names = pad_button_names(recorder.previous);
+        if (!names.empty()) {
+            fprintf(recorder.file, "f%lld-%lld:%s\n", (long long)recorder.start,
+                    (long long)end, names.c_str());
+            fflush(recorder.file);
+        }
+    }
+    recorder.previous = buttons;
+    recorder.start = frame;
 }
 
 // Snapshot the controller for a given pad handle via the installed backend. With no host frontend
@@ -132,7 +189,9 @@ HostPadState snapshot(int /*handle*/, const char* what) {
         s.connected = true;
         s.buttons  |= SCE_PAD_BUTTON_CROSS;
     }
-    apply_pad_script(s);
+    const int64_t frame = pad_frame_now();
+    apply_pad_script(s, frame);
+    pad_record(frame, s.buttons);
     padlog_once(what, &s);
     return s;
 }

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -122,6 +122,26 @@ uint32_t pad_button_by_name(const std::string& n) {
     return 0;
 }
 
+std::string pad_button_names(uint32_t mask) {
+    static constexpr struct { uint32_t bit; const char* name; } names[] = {
+        {SCE_PAD_BUTTON_UP, "up"}, {SCE_PAD_BUTTON_DOWN, "down"},
+        {SCE_PAD_BUTTON_LEFT, "left"}, {SCE_PAD_BUTTON_RIGHT, "right"},
+        {SCE_PAD_BUTTON_CROSS, "cross"}, {SCE_PAD_BUTTON_CIRCLE, "circle"},
+        {SCE_PAD_BUTTON_SQUARE, "square"}, {SCE_PAD_BUTTON_TRIANGLE, "triangle"},
+        {SCE_PAD_BUTTON_L1, "l1"}, {SCE_PAD_BUTTON_R1, "r1"},
+        {SCE_PAD_BUTTON_L2, "l2"}, {SCE_PAD_BUTTON_R2, "r2"},
+        {SCE_PAD_BUTTON_L3, "l3"}, {SCE_PAD_BUTTON_R3, "r3"},
+        {SCE_PAD_BUTTON_OPTIONS, "options"},
+    };
+    std::string result;
+    for (const auto& name : names) {
+        if (!(mask & name.bit)) continue;
+        if (!result.empty()) result += '+';
+        result += name.name;
+    }
+    return result;
+}
+
 std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
     std::vector<PadScriptEntry> v;
     size_t i = 0;

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -155,6 +155,10 @@ struct PadScriptEntry {
 // bit; 0 if unknown. "start" and "options" both mean the PS5 Options button (the "Start" equivalent).
 uint32_t pad_button_by_name(const std::string& name);
 
+// Canonical '+'-joined names for a button mask. The output round-trips through the parser and uses a
+// stable order so recorded routes have deterministic text.
+std::string pad_button_names(uint32_t mask);
+
 // Parse ';'- or newline-separated entries. An entry whose time token starts with 'f' is
 // FRAME-anchored: "f300:cross" fires at flip 300 since the first poll. Both anchors accept explicit
 // ranges ("3-4.5:cross", "f300-340:cross"); '#' starts a comment. Malformed entries and entries with

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -138,6 +138,15 @@ int main() {
         CHECK(pad_button_by_name("x")       == SCE_PAD_BUTTON_CROSS,   "name: x -> CROSS");
         CHECK(pad_button_by_name("up")      == SCE_PAD_BUTTON_UP,      "name: up -> UP");
         CHECK(pad_button_by_name("nonsense")== 0,                      "name: unknown -> 0");
+        CHECK(pad_button_names(SCE_PAD_BUTTON_OPTIONS) == "options", "names: options is canonical");
+        CHECK(pad_button_names(SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS) == "up+cross",
+              "names: stable combined-button order");
+        CHECK(pad_button_names(0).empty(), "names: neutral mask is empty");
+        auto round_trip = parse_pad_script("f0:" +
+            pad_button_names(SCE_PAD_BUTTON_LEFT | SCE_PAD_BUTTON_SQUARE | SCE_PAD_BUTTON_R1));
+        CHECK(round_trip.size() == 1 && round_trip[0].button_mask ==
+              (SCE_PAD_BUTTON_LEFT | SCE_PAD_BUTTON_SQUARE | SCE_PAD_BUTTON_R1),
+              "names: recorded text round-trips through parser");
 
         auto s = parse_pad_script("3:start;9.5:cross;16:up+cross");
         CHECK(s.size() == 3, "parse: 3 entries");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -27,6 +27,8 @@ To drive any runner through a longer input route, set
 `PROSPER_PAD_SCRIPT=@scripts/<title>/reach-<state>.pad`. Route files use the same
 seconds/flip syntax as inline scripts, accept one entry per line, `#` comments,
 and explicit ranges such as `f300-340:cross`. See `docs/INPUT_REPLAY.md`.
+Set `PROSPER_PAD_RECORD=<path>` on any runner, or use `prosper-app --record <path>`, to capture the
+final controller stream in that format. Completed button intervals are flushed immediately.
 
 Capture one draw-carrying renderer invocation with:
 


### PR DESCRIPTION
## Summary
- add `PROSPER_PAD_RECORD=<path>` to every runner
- add `prosper-app --record <path>` for interactive capture
- record the final physical/scripted button stream as explicit `fSTART-END` ranges
- share one display-flip origin between replay and recording
- create missing parent directories and flush completed intervals immediately
- add canonical button-name round-trip coverage and documentation

## Validation
- Linux ctest: 85/85
- video-only prosper-app + fetched SDL3 builds successfully
- controlled Messenger recording created a missing nested directory and emitted `f2563-5131:options`
- replaying the generated file reproduced connected=1 and Options `buttons=0x8`

Artifacts: `C:\Users\matti\Downloads\ps5ys-pad-record-20260712`

Refs #302