### PR TITLE
feat(checkpoint): add Messenger story route

### DIFF
--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -7,8 +7,9 @@
 > between flips. Realtime/RTC clocks remain tied to host time. `PROSPER_PAD_SCRIPT=@path` loads newline-
 > separated routes with comments and explicit time/flip ranges. `PROSPER_PAD_RECORD=path` records the
 > final button stream on that same flip axis; `prosper-app --record path` exposes it interactively.
-> Checked-in verified scripts and pad-read screenshot checkpoints remain open in #302. The original
-> design follows.
+> The first checked-in route, `scripts/messenger/reach-intro-story.pad`, repeatedly reaches the opening
+> story but still has small narration-phase drift. Deeper routes and a precise pad-read screenshot
+> checkpoint axis remain open in #302. The original design follows.
 
 ## The problem
 
@@ -50,6 +51,9 @@ Good bones. Two gaps for reaching deep states reliably: the clock is **wall-time
 ### 3. Checkpoint library + agent docs
 - `prosper/scripts/<title>/reach-*.pad` — **tiny text files, no game imagery, safe to commit** (unlike golden frames). Named by the state they reach: `reach-title-menu.pad`, `reach-level1.pad`, …
 - An `AGENTS.md` note: *"to reproduce a bug at state X, prefix your tool with `PROSPER_PAD_SCRIPT=@scripts/<title>/reach-X.pad`."* A bug report then just cites the checkpoint.
+
+The library is seeded with `scripts/messenger/reach-intro-story.pad`. It is a coarse route: repeated
+runs reach the named story state, while exact narration-frame verification remains step 4 work.
 
 ## The crux: determinism
 

--- a/prosper/scripts/messenger/README.md
+++ b/prosper/scripts/messenger/README.md
@@ -1,0 +1,21 @@
+# The Messenger Routes
+
+Reusable `PROSPER_PAD_SCRIPT` routes for The Messenger (`PPSA24651`). Run tools
+from `prosper/` so the relative paths below resolve:
+
+```bash
+PROSPER_PAD_SCRIPT=@scripts/messenger/reach-intro-story.pad \
+  ./build-linux/screenshot /path/PPSA24651-app0 --seconds 1 --count 10 --out shots
+```
+
+## Routes
+
+- `reach-intro-story.pad`: presses Options at flips 10-14 after the first pad
+  poll. The interval was produced by `PROSPER_PAD_RECORD` and verified twice on
+  current master at `PROSPER_RENDER_SCALE=4`; both runs reached the opening map
+  narration. The exact narration phase still drifts by a few rendered frames,
+  so this is a coarse state route, not an exact visual checkpoint.
+
+Create another route with `prosper-app --record <path>` or
+`PROSPER_PAD_RECORD=<path>`, replay it with `PROSPER_PAD_SCRIPT=@path`, and only
+commit it after repeated current-master runs reach the state named by the file.

--- a/prosper/scripts/messenger/reach-intro-story.pad
+++ b/prosper/scripts/messenger/reach-intro-story.pad
@@ -1,0 +1,3 @@
+# The Messenger (PPSA24651): advance the title prompt into the opening story.
+# The interval was recorded on current master at 1/4 render scale.
+f10-14:options


### PR DESCRIPTION
## Summary
- seed `scripts/messenger` with a current-master-verified route
- use the recorder-produced `f10-14:options` interval
- document usage, provenance, and the remaining exact-frame drift

## Validation
- two independent flip-route runs at `PROSPER_RENDER_SCALE=4` reached the opening story
- both runs showed the opening map narration by ten seconds
- exact narration phase differed slightly, so the route is explicitly classified as coarse rather than hash-stable

Artifacts:
- `C:\Users\matti\Downloads\ps5ys-messenger-route-story-flip-run1`
- `C:\Users\matti\Downloads\ps5ys-messenger-route-story-flip-run2`

Refs #302