### PR TITLE
feat(input): add Dead Cells gameplay route

### DIFF
--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -1,0 +1,23 @@
+# Dead Cells Routes
+
+Reusable `PROSPER_PAD_SCRIPT` routes for Dead Cells (`PPSA15552`). Run tools
+from `prosper/` so the relative paths below resolve:
+
+```bash
+PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
+  ./build-linux/screenshot /path/PPSA15552-app0 \
+  --warmup-seconds 35 --seconds 1 --count 5 --timeout 65 --out shots
+```
+
+## Routes
+
+- `reach-first-gameplay.pad`: selects Play/slot 1, starts `PrisonStart`, and
+  holds Circle through the skippable opening. It was verified from fresh save
+  roots on current master and reaches the controllable Jump tutorial. The
+  route is wall-clock anchored because Dead Cells submits tens of thousands of
+  loading flips before the menu.
+
+The long renderer warmup makes this route practical under llvmpipe, but it can
+skip one-time GPU producers. The current post-warmup gameplay image is tracked
+in issue #566 and must not be used as a golden visual checkpoint until that
+warmup artifact has been separated from genuine renderer behavior.

--- a/prosper/scripts/dead-cells/reach-first-gameplay.pad
+++ b/prosper/scripts/dead-cells/reach-first-gameplay.pad
@@ -1,0 +1,7 @@
+# Dead Cells (PPSA15552): start slot 1 and skip the Prisoners' Quarters opening.
+# Seconds are measured from the first pad poll. Repeated Cross presses tolerate
+# first-boot/save-load timing; holding Circle skips the opening once it appears.
+11:cross
+14:cross
+17:cross
+28-34:circle


### PR DESCRIPTION
﻿Closes #565.

## What changed

- add `scripts/dead-cells/reach-first-gameplay.pad`
- select Play/slot 1 and skip the Prisoners' Quarters opening
- document llvmpipe warmup usage and the current #566 visual caveat

## Verification

- fresh save root: reaches `Loading level PrisonStart`
- level parser completes
- skip route reaches the controllable Jump tutorial
- checked-in `@scripts/dead-cells/reach-first-gameplay.pad` path loads successfully from `prosper/`

No visual checkpoint is added yet because the long warmup may skip one-time GPU producers; #566 tracks that investigation.
