### PR TITLE
feat(gpu): capture temporal RTT replay seeds

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3,6 +3,7 @@
 #include "live_renderer.hpp"
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
+#include "gpu/gpu_capture.hpp"          // temporal RTT capture/replay seeds
 #include "gpu/tile.hpp"                 // detile_surface / tiled_surface_bytes / detile_elements
 #include "gpu/bc_decode.hpp"            // BC1/2/3 block decompression -> RGBA8 (#121)
 #include "gpu/shader_resources.hpp"     // ShaderResourceTable / ResourceClass
@@ -51,6 +52,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     }
     static std::atomic<int> frame_no{0};
     static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
+    if (getenv("PROSPER_GPU_CAPTURE"))
+        prosper::gpu::set_gpu_capture_rtt_seed_reader([](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {
+            auto it = g_rtt.find(addr); if (it == g_rtt.end()) return false;
+            seed.guest_addr = addr; seed.width = it->second.w; seed.height = it->second.h;
+            seed.rgba = it->second.rgba; return true;
+        });
+    if (getenv("PROSPER_GPU_REPLAY_RTT_SEEDS"))
+        prosper::gpu::set_gpu_replay_rtt_seed_writer([](const prosper::gpu::GpuCaptureRttSeed& seed, std::string& error) {
+            const uint64_t expected = static_cast<uint64_t>(seed.width) * seed.height * 4;
+            if (!seed.guest_addr || !seed.width || !seed.height || expected != seed.rgba.size()) {
+                error = "invalid temporal RTT seed"; return false;
+            }
+            RttSurf& surface = g_rtt[seed.guest_addr];
+            surface.w = seed.width; surface.h = seed.height; surface.rgba = seed.rgba;
+            return true;
+        });
     // A real command stream renders each CB_COLOR0_BASE into its own surface. Keep the old flattened
     // compositor only as a diagnostic fallback; it cannot preserve post chains or target extents.
     static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr ||

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -13,13 +13,14 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <unordered_set>
 #include <utility>
 
 namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 3;
+constexpr uint32_t kVersion = 4;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -28,6 +29,10 @@ constexpr uint32_t kMaxDraws = 65536;
 constexpr uint32_t kMaxResources = 65536;
 constexpr uint32_t kMaxShaderWords = 16u << 20;
 constexpr uint32_t kMaxStringBytes = 1u << 20;
+constexpr uint64_t kMaxTotalRttSeedBytes = 1ull << 30;
+
+CaptureRttSeedReader g_rtt_seed_reader;
+ReplayRttSeedWriter g_rtt_seed_writer;
 
 struct Writer {
     std::vector<uint8_t> data;
@@ -262,6 +267,18 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
 
 const char* env_or_empty(const char* name) { const char* v = std::getenv(name); return v ? v : ""; }
 
+bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
+    if (!seed.guest_addr || !seed.width || !seed.height) {
+        error = "RTT seed has an invalid address or extent"; return false;
+    }
+    const uint64_t pixels = checked_mul(seed.width, seed.height);
+    const uint64_t bytes = checked_mul(pixels, 4);
+    if (bytes > kMaxBlobBytes || bytes != seed.rgba.size()) {
+        error = "RTT seed byte count does not match its RGBA extent"; return false;
+    }
+    return true;
+}
+
 } // namespace
 
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
@@ -271,7 +288,8 @@ uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
 }
 
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
-                        const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error) {
+                        const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error,
+                        const CaptureRttSeedReader& rtt_reader) {
     error.clear(); out = {}; out.metadata = metadata;
     if (items.empty() || items.size() > kMaxDraws) { error = "capture must contain 1..65536 draws"; return false; }
     if (!reader) { error = "capture memory reader is missing"; return false; }
@@ -289,6 +307,32 @@ bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMeta
         if (!capture_table(d.vrt.get(), intervals, c.vrt, error) || !capture_table(d.prt.get(), intervals, c.prt, error)) return false;
         out.draws.push_back(std::move(c));
     }
+    if (rtt_reader) {
+        std::vector<uint64_t> candidates;
+        auto add_table = [&](const ShaderResourceTable* table) {
+            if (!table) return;
+            for (const auto& r : table->resources)
+                if ((r.cls == ResourceClass::Texture || r.cls == ResourceClass::StorageImage) && r.gpu_addr)
+                    candidates.push_back(r.gpu_addr);
+        };
+        for (const auto& item : items) {
+            add_table(item.vrt.get()); add_table(item.prt.get());
+            if (item.color0_base) candidates.push_back(item.color0_base);
+        }
+        std::sort(candidates.begin(), candidates.end());
+        candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
+        uint64_t total = 0;
+        for (uint64_t addr : candidates) {
+            GpuCaptureRttSeed seed;
+            if (!rtt_reader(addr, seed)) continue;
+            if (seed.guest_addr != addr) { error = "RTT seed reader returned the wrong guest address"; return false; }
+            if (!validate_rtt_seed(seed, error)) return false;
+            if (total > kMaxTotalRttSeedBytes - seed.rgba.size()) {
+                error = "capture RTT seed data exceeds 1 GiB"; return false;
+            }
+            total += seed.rgba.size(); out.rtt_seeds.push_back(std::move(seed));
+        }
+    }
     return true;
 }
 
@@ -301,6 +345,18 @@ bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::st
     w.u64(c.expected_output_hash); w.u64(c.expected_output_bytes);
     w.u32(static_cast<uint32_t>(c.blobs.size()));
     for (const auto& b : c.blobs) { w.u64(b.guest_addr); w.u64(b.bytes_read); w.bytes(b.bytes); }
+    if (c.rtt_seeds.size() > kMaxResources) { error = "invalid RTT seed count"; return false; }
+    uint64_t seed_total = 0; std::unordered_set<uint64_t> seed_addresses;
+    w.u32(static_cast<uint32_t>(c.rtt_seeds.size()));
+    for (const auto& seed : c.rtt_seeds) {
+        if (!validate_rtt_seed(seed, error)) return false;
+        if (!seed_addresses.insert(seed.guest_addr).second) { error = "duplicate RTT seed address"; return false; }
+        if (seed_total > kMaxTotalRttSeedBytes - seed.rgba.size()) {
+            error = "capture RTT seed data exceeds 1 GiB"; return false;
+        }
+        seed_total += seed.rgba.size();
+        w.u64(seed.guest_addr); w.u32(seed.width); w.u32(seed.height); w.bytes(seed.rgba);
+    }
     w.u32(static_cast<uint32_t>(c.draws.size()));
     for (const auto& d : c.draws) {
         w.words(d.vs); w.words(d.fs); write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
@@ -344,6 +400,20 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
         if (b.bytes_read > b.bytes.size() || total > kMaxTotalBlobBytes - b.bytes.size()) { error = "invalid blob metadata"; return false; }
         total += b.bytes.size();
     }
+    if (version >= 4) {
+        uint32_t ns; if (!r.u32(ns) || ns > kMaxResources) { error = "invalid RTT seed count"; return false; }
+        uint64_t seed_total = 0; c.rtt_seeds.resize(ns);
+        std::unordered_set<uint64_t> addresses;
+        for (auto& seed : c.rtt_seeds) {
+            if (!r.u64(seed.guest_addr) || !r.u32(seed.width) || !r.u32(seed.height) || !r.bytes(seed.rgba)) return false;
+            if (!validate_rtt_seed(seed, error)) return false;
+            if (!addresses.insert(seed.guest_addr).second) { error = "duplicate RTT seed address"; return false; }
+            if (seed_total > kMaxTotalRttSeedBytes - seed.rgba.size()) {
+                error = "capture RTT seed data exceeds 1 GiB"; return false;
+            }
+            seed_total += seed.rgba.size();
+        }
+    }
     uint32_t nd; if (!r.u32(nd) || !nd || nd > kMaxDraws) { error = "invalid draw count"; return false; }
     c.draws.resize(nd);
     for (auto& d : c.draws) {
@@ -356,7 +426,7 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
 }
 
 bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::string& error) {
-    error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs;
+    error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs; out.rtt_seeds = c.rtt_seeds;
     out.expected_output_hash = c.expected_output_hash; out.expected_output_bytes = c.expected_output_bytes;
     auto table = [&](const GpuCapturedTable& src, std::shared_ptr<ShaderResourceTable>& dst) -> bool {
         if (!src.present) { dst.reset(); return src.resources.empty(); }
@@ -383,6 +453,18 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         d.color0_width = x.color0_width; d.color0_height = x.color0_height;
         if (!table(x.vrt, d.vrt) || !table(x.prt, d.prt)) return false;
         out.items.push_back(std::move(d));
+    }
+    return true;
+}
+
+void set_gpu_capture_rtt_seed_reader(CaptureRttSeedReader reader) { g_rtt_seed_reader = std::move(reader); }
+void set_gpu_replay_rtt_seed_writer(ReplayRttSeedWriter writer) { g_rtt_seed_writer = std::move(writer); }
+
+bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, std::string& error) {
+    error.clear();
+    if (!seeds.empty() && !g_rtt_seed_writer) { error = "live renderer has no RTT seed writer"; return false; }
+    for (const auto& seed : seeds) {
+        if (!validate_rtt_seed(seed, error) || !g_rtt_seed_writer(seed, error)) return false;
     }
     return true;
 }
@@ -436,12 +518,12 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
         return done;
     };
     std::string error;
-    if (!capture_draw_items(items, m, reader, pending->capture, error)) {
+    if (!capture_draw_items(items, m, reader, pending->capture, error, g_rtt_seed_reader)) {
         std::fprintf(stderr, "[gpucap] capture failed: %s\n", error.c_str()); return {};
     }
-    std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu blobs -> %s\n",
+    std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu blobs, %zu RTT seeds -> %s\n",
                  static_cast<unsigned long long>(current), static_cast<unsigned long long>(invocation),
-                 items.size(), pending->capture.blobs.size(), path);
+                 items.size(), pending->capture.blobs.size(), pending->capture.rtt_seeds.size(), path);
     return pending;
 }
 

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -52,9 +52,20 @@ struct GpuCapturedDraw {
     uint32_t color0_width = 0, color0_height = 0;
 };
 
+// Host-rendered pixels retained across submits. The HLE renderer does not write these pixels back to
+// guest memory, so a standalone replay must seed its RTT cache explicitly to reproduce consumers whose
+// producer was in an earlier submit.
+struct GpuCaptureRttSeed {
+    uint64_t guest_addr = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    std::vector<uint8_t> rgba;
+};
+
 struct GpuCaptureFile {
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
+    std::vector<GpuCaptureRttSeed> rtt_seeds;
     std::vector<GpuCapturedDraw> draws;
     uint64_t expected_output_hash = 0;
     uint64_t expected_output_bytes = 0;
@@ -63,21 +74,32 @@ struct GpuCaptureFile {
 // Reader returns the number of bytes copied. The capture zero-fills the unread suffix, matching the
 // live renderer's guarded-copy behavior for partially committed guest resources.
 using CaptureMemoryReader = std::function<size_t(uint64_t guest_addr, uint8_t* dst, size_t bytes)>;
+using CaptureRttSeedReader = std::function<bool(uint64_t guest_addr, GpuCaptureRttSeed& seed)>;
 
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
-                        const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error);
+                        const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error,
+                        const CaptureRttSeedReader& rtt_reader = {});
 bool write_gpu_capture(const std::string& path, const GpuCaptureFile& capture, std::string& error);
 bool read_gpu_capture(const std::string& path, GpuCaptureFile& capture, std::string& error);
 
 struct GpuReplayFrame {
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
+    std::vector<GpuCaptureRttSeed> rtt_seeds;
     std::vector<DrawItem> items;
     uint64_t expected_output_hash = 0;
     uint64_t expected_output_bytes = 0;
 };
 
 bool materialize_gpu_replay(const GpuCaptureFile& capture, GpuReplayFrame& replay, std::string& error);
+
+// The Vulkan frontend owns the RTT cache and registers these hooks when its renderer is installed.
+// Capture queries only addresses referenced by the selected submit; replay restores the serialized
+// surfaces before draw zero.
+using ReplayRttSeedWriter = std::function<bool(const GpuCaptureRttSeed& seed, std::string& error)>;
+void set_gpu_capture_rtt_seed_reader(CaptureRttSeedReader reader);
+void set_gpu_replay_rtt_seed_writer(ReplayRttSeedWriter writer);
+bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, std::string& error);
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size);
 inline uint64_t gpu_capture_hash(const std::vector<uint8_t>& data) {
     return gpu_capture_hash(data.data(), data.size());

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -43,16 +43,30 @@ int main() {
     meta.savedata_dir = "/tmp/prosper-test-save";
     meta.renderer_env = {{"PROSPER_RTT_PERTARGET", "1"}, {"PROSPER_NO_CULL", "1"}};
     GpuCaptureFile captured; std::string error;
-    CHECK(capture_draw_items({draw}, meta, reader, captured, error), "capture realized draw succeeds");
+    const std::vector<uint8_t> temporal_rgba = {
+        255, 0, 0, 255, 0, 255, 0, 255,
+        0, 0, 255, 255, 255, 255, 255, 255,
+    };
+    auto rtt_reader = [&](uint64_t addr, GpuCaptureRttSeed& seed) {
+        if (addr != draw.color0_base) return false;
+        seed.guest_addr = addr; seed.width = 2; seed.height = 2; seed.rgba = temporal_rgba; return true;
+    };
+    CHECK(capture_draw_items({draw}, meta, reader, captured, error, rtt_reader), "capture realized draw succeeds");
     CHECK(captured.blobs.size() == 1 && captured.blobs[0].guest_addr == 0x1000 && captured.blobs[0].bytes.size() == 24,
           "overlapping resource ranges merge into one alias-preserving blob");
     CHECK(captured.blobs[0].bytes_read == 24 && captured.blobs[0].bytes[8] == memory[8],
           "capture records readable byte count and resource contents");
     CHECK(captured.draws[0].vrt.resources[0].blob_index == captured.draws[0].vrt.resources[1].blob_index &&
           captured.draws[0].vrt.resources[1].blob_offset == 8, "resource references preserve overlap offsets");
+    CHECK(captured.rtt_seeds.size() == 1 && captured.rtt_seeds[0].guest_addr == draw.color0_base &&
+          captured.rtt_seeds[0].rgba == temporal_rgba,
+          "capture stores referenced temporal RTT pixels separately from guest memory");
     captured.expected_output_hash = 0x1122334455667788ull; captured.expected_output_bytes = 480ull * 270 * 4;
 
     auto path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_test.prgcap";
+    GpuCaptureFile duplicate_seed = captured; duplicate_seed.rtt_seeds.push_back(captured.rtt_seeds[0]);
+    CHECK(!write_gpu_capture(path.string(), duplicate_seed, error) && error == "duplicate RTT seed address",
+          "writer rejects duplicate temporal RTT seed addresses");
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
@@ -63,6 +77,8 @@ int main() {
           "fixed-function pipeline state round-trips explicitly");
     CHECK(loaded.draws[0].color0_width == 1024 && loaded.draws[0].color0_height == 32,
           "per-target extent round-trips");
+    CHECK(loaded.rtt_seeds.size() == 1 && loaded.rtt_seeds[0].width == 2 &&
+          loaded.rtt_seeds[0].rgba == temporal_rgba, "temporal RTT seed round-trips");
     CHECK(loaded.draws[0].ps.db_render_control == 2 && loaded.draws[0].ps.stencil_clear_enable &&
           loaded.draws[0].ps.has_stencil_clear && loaded.draws[0].ps.stencil_clear_value == 3 &&
           loaded.draws[0].ps.stencil_read_base == 0x12345000 &&
@@ -77,6 +93,8 @@ int main() {
     CHECK(rr[0].host_data && rr[1].host_data == rr[0].host_data + 8 && rr[1].host_data[0] == memory[8],
           "replay resources point into shared owned backing at captured offsets");
     CHECK(replay.expected_output_hash == captured.expected_output_hash, "expected render hash round-trips");
+    CHECK(replay.rtt_seeds.size() == 1 && replay.rtt_seeds[0].guest_addr == draw.color0_base,
+          "materialized replay owns temporal RTT seed pixels");
 
     auto truncated = path; truncated += ".truncated";
     std::filesystem::copy_file(path, truncated, std::filesystem::copy_options::overwrite_existing);

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -59,6 +59,11 @@ int main() {
           replay.items[0].prt->resources[0].host_data_size == texture.size(),
           "replay keeps logical VA and exposes exact host backing size");
 
+#ifdef _WIN32
+    _putenv_s("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
+#else
+    setenv("PROSPER_GPU_REPLAY_RTT_SEEDS", "1", 1);
+#endif
     prosper::frontend::register_live_renderer(".", false);
     std::vector<uint8_t> pixels = render_submit_items(replay.items, W, H);
     CHECK(pixels.size() == static_cast<size_t>(W) * H * 4, "replayed draw renders through live backend");
@@ -94,6 +99,34 @@ int main() {
         const uint8_t* center = &chained[(8u * 16u + 8u) * 4];
         CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
               "later pass samples pixels cached from the 32x2 producer target");
+    }
+
+    // A captured consumer may depend on a producer from an earlier submit. Restore its serialized
+    // host RTT surface before replaying draw zero; guest memory has no copy of these rendered pixels.
+    GpuCaptureRttSeed temporal_seed;
+    temporal_seed.guest_addr = 0x600000; temporal_seed.width = 2; temporal_seed.height = 2;
+    temporal_seed.rgba = {
+        255, 0, 0, 255, 255, 0, 0, 255,
+        255, 0, 0, 255, 255, 0, 0, 255,
+    };
+    CHECK(restore_gpu_replay_rtt_seeds({temporal_seed}, error),
+          "replay restores a producer surface captured from an earlier submit");
+    DrawItem temporal_consumer = replay.items[0];
+    temporal_consumer.color0_base = 0x700000;
+    temporal_consumer.color0_width = 8; temporal_consumer.color0_height = 8;
+    auto temporal_rt = std::make_shared<ShaderResourceTable>(*temporal_consumer.prt);
+    temporal_rt->resources[0].gpu_addr = temporal_seed.guest_addr;
+    temporal_rt->resources[0].width = temporal_seed.width;
+    temporal_rt->resources[0].height = temporal_seed.height;
+    temporal_rt->resources[0].host_data = nullptr;
+    temporal_rt->resources[0].host_data_size = 0;
+    temporal_consumer.prt = std::move(temporal_rt);
+    std::vector<uint8_t> temporal = render_submit_items({temporal_consumer}, W, H);
+    CHECK(temporal.size() == 8u * 8u * 4u, "temporal consumer renders at its native target extent");
+    if (temporal.size() == 8u * 8u * 4u) {
+        const uint8_t* center = &temporal[(4u * 8u + 4u) * 4];
+        CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
+              "temporal consumer samples restored host RTT pixels, not guest-memory fallback");
     }
 
     DrawItem missing_texture = replay.items[0];

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -66,6 +66,9 @@ offscreen target dimensions.
 
 Use `gpu_replay --inspect-only` to print fixed-function state, native color-target dimensions, resource
 hashes, explicit clear intent, guest depth/stencil surface identities, and raw stencil-op provenance.
+Version-4 capsules also print and restore temporal RTT seeds: exact host-rendered surfaces sampled by the
+captured submit whose producer ran in an earlier submit. This keeps replay from silently substituting stale
+guest-memory bytes for renderer-owned history; older capsules remain readable and report zero seeds.
 The draw header also reports raster state as `raster=cull/front-face/polygon-mode`, using Vulkan enum
 values. `PROSPER_NO_CULL=1` disables culling; `PROSPER_FLIP_FRONT_FACE=1` preserves the cull mode and
 toggles only the resolved winding convention. The latter is useful for isolating `PA_SU_SC_MODE_CNTL`

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -3,6 +3,7 @@
 #include "live_renderer.hpp"
 #include "render_runner.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -35,7 +36,8 @@ const char* class_name(prosper::gpu::ResourceClass c) {
     return "?";
 }
 
-void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* table) {
+void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* table,
+                   const std::vector<prosper::gpu::GpuCaptureRttSeed>& seeds) {
     if (!table) { std::printf("  %s: none\n", stage); return; }
     for (const auto& r : table->resources) {
         size_t nz = 0; uint32_t first = 0;
@@ -44,16 +46,19 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
             if (r.host_data_size >= 4) std::memcpy(&first, r.host_data, 4);
         }
         uint64_t hash = r.host_data ? prosper::gpu::gpu_capture_hash(r.host_data, static_cast<size_t>(r.host_data_size)) : 0;
+        const bool temporal_seed = std::any_of(seeds.begin(), seeds.end(), [&](const auto& seed) {
+            return seed.guest_addr == r.gpu_addr;
+        });
         std::printf("  %s %-7s b=%u addr=%016llx bytes=%llu nz=%zu hash=%016llx first=%08x "
                     "fmt=%u nc=%u stride=%u %ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
-                    "srt=%08x sgpr=%08x pc=%08x\n",
+                    "srt=%08x sgpr=%08x pc=%08x%s\n",
                     stage, class_name(r.cls), r.binding, static_cast<unsigned long long>(r.gpu_addr),
                     static_cast<unsigned long long>(r.host_data_size), nz, static_cast<unsigned long long>(hash), first,
                     static_cast<unsigned>(r.format), r.num_components, r.stride, r.width, r.height, r.tile_mode,
                     r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2],
                     r.swizzle[0], r.swizzle[1], r.swizzle[2], r.swizzle[3],
                     r.mag_filter, r.min_filter, r.mip_filter,
-                    r.srt_offset, r.sgpr_base, r.fetch_pc);
+                    r.srt_offset, r.sgpr_base, r.fetch_pc, temporal_seed ? " temporal-RTT-seed" : "");
         if (r.host_data && r.host_data_size >= 16 &&
             (r.cls == prosper::gpu::ResourceClass::ConstantBuffer ||
              r.cls == prosper::gpu::ResourceClass::VertexBuffer)) {
@@ -65,6 +70,12 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
 }
 
 void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
+    for (const auto& seed : replay.rtt_seeds) {
+        const uint64_t hash = prosper::gpu::gpu_capture_hash(seed.rgba);
+        std::printf("rtt-seed addr=%016llx extent=%ux%u bytes=%zu hash=%016llx\n",
+                    static_cast<unsigned long long>(seed.guest_addr), seed.width, seed.height,
+                    seed.rgba.size(), static_cast<unsigned long long>(hash));
+    }
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
         std::printf("draw[%zu] target=%016llx extent=%ux%u vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
@@ -100,7 +111,8 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.raw_stencil_op[1][0], d.ps.raw_stencil_op[1][1], d.ps.raw_stencil_op[1][2],
                     d.ps.db_shader_control, d.ps.stencil_test_val_export_enable,
                     d.ps.stencil_op_val_export_enable);
-        inspect_table("VS", d.vrt.get()); inspect_table("PS", d.prt.get());
+        inspect_table("VS", d.vrt.get(), replay.rtt_seeds);
+        inspect_table("PS", d.prt.get(), replay.rtt_seeds);
     }
 }
 
@@ -236,13 +248,17 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[gpureplay] selected original draws %d:%d\n", draw_first, draw_last);
     }
     const auto& m = replay.metadata;
-    std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu blobs=%zu\n",
+    std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu blobs=%zu RTT-seeds=%zu\n",
                  m.revision.c_str(), m.title_id.c_str(), static_cast<unsigned long long>(m.submit_index),
-                 m.width, m.height, replay.items.size(), replay.blobs.size());
+                 m.width, m.height, replay.items.size(), replay.blobs.size(), replay.rtt_seeds.size());
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;
+    if (!replay.rtt_seeds.empty()) set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
     prosper::frontend::register_live_renderer(".", false);
+    if (!prosper::gpu::restore_gpu_replay_rtt_seeds(replay.rtt_seeds, error)) {
+        std::fprintf(stderr, "gpu_replay: cannot restore RTT seeds: %s\n", error.c_str()); return 2;
+    }
     std::vector<uint8_t> pixels = prosper::gpu::render_submit_items(replay.items, m.width, m.height);
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
     std::fprintf(stderr, "[gpureplay] output_bytes=%zu hash=%016llx expected_bytes=%llu expected_hash=%016llx\n",


### PR DESCRIPTION
## Summary

- bump .prgcap to version 4 and serialize referenced host-side temporal RTT surfaces
- restore those surfaces before replay draw zero and mark their consumers in --inspect-only
- preserve v1-v3 reading and reject malformed/duplicate/oversized seed tables
- add round-trip and cross-submit Vulkan coverage

## Validation

- ctest --output-on-failure: 85/85 passed
- messenger-scene: 24,318 colors >= 5,000
- dead-cells-splash: exact 960x540 baseline passed
- live Dead Cells v4 capsule: 86 draws, 137 blobs, 9 temporal RTT seeds

A remaining whole-frame hash mismatch after color seed restoration is tracked separately in #569; the color temporal state and consumer provenance implemented here are independently covered.

Fixes #568