### PR TITLE
fix(agc): confirm type-0 data packet payload

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -817,26 +817,23 @@ static_assert(offsetof(AgcShaderSpecialRegs, vgt_gs_out_prim_type) == 0x20, "spe
 // sceAgcGetDataPacketPayloadAddress (V++UgBtQhn0) — called from INSIDE eboot's static AGC code
 // (register-bank prepare, eboot+0x3af040 path, callsite +0x3af170): resolve a data packet built in
 // the Dcb to its payload address, which becomes the register bank the guest reads/writes through.
-// Kyty only reverse-engineered the TYPE-1 data packet: payload at cmd+2 (a 2-dword header). This
-// title also builds TYPE-0 data packets whose header size / payload offset were NEVER RE'd, so
-// cmd+2 is a best-effort guess for them — a wrong offset makes the returned bank alias the wrong
-// dwords and silently corrupts the register set (#140). Until the type-0 header is confirmed (RE the
-// eboot packet builder), surface any non-type-1 packet LOUDLY — once per type, UNCONDITIONALLY (not
-// GFXLOG-gated as before) — while keeping the cmd+2 best-effort so the register-bank prepare still
-// gets a usable pointer (erroring here would fail the eboot's static AGC init).
+// Both exercised data-packet types have two non-payload dwords (#140). Type 1 is SET_UCONFIG_REG:
+// cmd[0] is its PM4 header and cmd[1] the register offset. Type 0 is a NOP data packet: cmd[0] is
+// its PM4 header and cmd[1] the data-packet metadata/tag. In both cases the caller-visible payload
+// begins at cmd+2. A live Dead Cells A/B confirmed the type-0 metadata role: returning cmd+1 shifts
+// the caller's writes over that slot and immediately triggers its texture-memory fatal; cmd+2 boots.
 HLE(agc_get_data_packet_payload) {  // (uint32_t** addr, uint32_t* cmd, int type)
     auto** addr = (uint32_t**)(uintptr_t)a0;
     auto*  cmd  = (uint32_t*)(uintptr_t)a1;
     if (!addr || !cmd) return kAgcErrInvalidArg;
-    if (a2 != 1) {
+    if (a2 == 0 || a2 == 1) { *addr = cmd + 2; return 0; }
+    {
         static std::atomic<uint32_t> logged_mask{0};
         uint32_t bit = ((int)a2 >= 0 && (int)a2 < 31) ? (1u << (uint32_t)a2) : (1u << 31);
         if (!(logged_mask.fetch_or(bit, std::memory_order_relaxed) & bit))
-            fprintf(stderr, "[agc] GetDataPacketPayloadAddress: UNCONFIRMED packet type=%d — payload "
-                    "offset assumed cmd+2 (only type-1 is RE'd; type-0 header unknown, #140)\n", (int)a2);
+            fprintf(stderr, "[agc] GetDataPacketPayloadAddress: unsupported packet type=%d\n", (int)a2);
     }
-    *addr = cmd + 2;
-    return 0;
+    return kAgcErrInvalidArg;
 }
 
 // sceAgcCbSetShRegisterRangeDirect (n2fD4A+pb+g) — append an IT_SET_SH_REG packet covering

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -68,8 +68,8 @@ int main() {
     CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu, "PatchSetAddress rewrote cmd[2]/cmd[3]");
 
     // sceAgcGetDataPacketPayloadAddress (#140): resolves a data packet to its register-bank payload.
-    // Type 1 is the RE'd case (payload at cmd+2); type 0 is unconfirmed and returns cmd+2 best-effort
-    // (loud-once, not silent). Null out-ptr / null cmd -> invalid-arg. Verify the *addr contract.
+    // Type 0 is NOP header + metadata; type 1 is register header + offset. Both payloads start +2.
+    // Null pointers and unknown packet types are invalid. Verify the exact *addr contract.
     auto getpayload = Hle::lookup("V++UgBtQhn0");
     CHECK(getpayload != nullptr, "GetDataPacketPayloadAddress registered");
     if (getpayload) {
@@ -78,7 +78,10 @@ int main() {
               out == pkt + 2, "type 1: *addr = cmd+2, rc 0");
         out = nullptr;
         CHECK(getpayload((uint64_t)(uintptr_t)&out, (uint64_t)(uintptr_t)pkt, /*type*/0, 0, 0, 0) == 0 &&
-              out == pkt + 2, "type 0 (unconfirmed): *addr = cmd+2 best-effort, rc 0 (not aborted)");
+              out == pkt + 2, "type 0: *addr = cmd+2, rc 0");
+        out = nullptr;
+        CHECK(getpayload((uint64_t)(uintptr_t)&out, (uint64_t)(uintptr_t)pkt, /*type*/2, 0, 0, 0) != 0 &&
+              out == nullptr, "unknown type: invalid-arg and out pointer remains untouched");
         CHECK(getpayload(0, (uint64_t)(uintptr_t)pkt, 1, 0, 0, 0) != 0, "null out-ptr -> invalid-arg");
         CHECK(getpayload((uint64_t)(uintptr_t)&out, 0, 1, 0, 0, 0) != 0, "null cmd -> invalid-arg");
     }


### PR DESCRIPTION
## Summary

- document the live-captured type-0 and type-1 AGC data-packet layouts
- preserve the confirmed `cmd + 2` payload address for both exercised types
- reject unknown packet types instead of silently applying the type-1 offset
- remove the stale warning that incorrectly described type 0 as unconfirmed

## Evidence

Dead Cells debugger capture showed:

- type 0: NOP header, metadata/tag, then register-bank payload
- type 1: register header, register offset, then register-bank payload

An A/B using `cmd + 1` for type 0 corrupted the bank and could trigger `Maximum texture memory reached`. The original `cmd + 2` behavior is therefore correct for both observed types, for different structural reasons. This disproves the suspected connection between #140 and the still-empty compute program/resource state tracked in #574.

## Verification

- 85/85 Linux tests pass
- `messenger-scene`: OK, richest frame 24,318 colors
- `dead-cells-splash`: exact image hash OK

Fixes #140