### PR TITLE
fix(agc): bind Dead Cells compute programs

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -415,9 +415,15 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
     // buffer, 10 = vertex attrib; direct_resource_offset is indexed by usage type and the value is the
     // SGPR index where that V# sits (0xffff = absent). We emit a VertexBuffer keyed by sgpr_base so
     // the recompiler resolves each buffer_load_format_*'s SRSRC directly (no in-shader s_load).
+    // Dead Cells compute shaders use direct type 1 for an inline V# at COMPUTE_USER_DATA_0
+    // (live descriptor: 16-byte stride, 0x1fe000 records, plausible Base48). Model it as a
+    // ConstantBuffer-class resource: both that class and VertexBuffer lower to a Vulkan storage
+    // buffer, while ConstantBuffer also lets scalar buffer loads resolve by their direct SBASE.
+    // Restrict this Gen5 observation to compute shaders; other stages have no exercised contract.
     if (const uint16_t* dro = ud->direct_resource_offset) {
         for (uint16_t type = 0; type < ud->direct_resource_count; type++) {
-            if (type != 8 && type != 10) continue;              // vertex buffer / vertex attrib
+            const bool compute_buffer = shdr.type == 0 && type == 1;
+            if (!compute_buffer && type != 8 && type != 10) continue;
             uint32_t reg = dro[type];
             if (reg == 0xffff) continue;
             if ((uint64_t)reg + 4 > num_user_sgprs) continue;   // V# (4 dwords) must fit in the block
@@ -430,8 +436,8 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // for shaders that DO place the V# inline.)
             if (d.base == 0 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
             ShaderResource r;
-            r.cls            = ResourceClass::VertexBuffer;
-            r.format         = d.format;          // Float32 for this game (dfmt {4,11,13,14}, nfmt 7)
+            r.cls            = compute_buffer ? ResourceClass::ConstantBuffer : ResourceClass::VertexBuffer;
+            r.format         = d.format;
             r.num_components  = d.num_components;
             r.binding        = binding++;
             r.gpu_addr       = d.base;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -879,11 +879,48 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
         }
 
         ShaderResourceTable table;
+        uint32_t sgprs[kUserSgprs] = {};
         if (hdr) {
-            uint32_t sgprs[kUserSgprs];
             read_user_sgprs(ds.sh, P::COMPUTE_USER_DATA_0 + range_start, sgprs);
             table = build_shader_resources(*hdr, sgprs, kUserSgprs, 0);
             assign_convention_bindings(table, 2);
+        }
+
+        // A compute shader can carry only an inline direct type-1 V# and no sharp descriptors. Dump
+        // its metadata and bound SGPRs once per program if resource decoding still returns empty.
+        // This turns the next unsupported layout into a reproducible decode problem instead of
+        // another blind `resources=0` investigation.
+        if (hdr && table.resources.empty() && enabled && *enabled) {
+            static std::set<uint64_t> logged_empty;
+            if (logged_empty.insert(code_addr).second) {
+                const AgcShaderUserData* ud = hdr->user_data;
+                fprintf(stderr, "[compute] empty-resource metadata code=0x%llx type=%u ud=%p",
+                        (unsigned long long)code_addr, hdr->type, (const void*)ud);
+                if (ud) {
+                    fprintf(stderr, " eud=%u srt=%u direct_count=%u sharp={%u,%u,%u,%u}",
+                            ud->eud_size_dw, ud->srt_size_dw, ud->direct_resource_count,
+                            ud->sharp_resource_count[0], ud->sharp_resource_count[1],
+                            ud->sharp_resource_count[2], ud->sharp_resource_count[3]);
+                }
+                fprintf(stderr, "\n[compute]   user_sgprs:");
+                for (uint32_t s = 0; s < kUserSgprs; ++s) fprintf(stderr, " %08x", sgprs[s]);
+                fprintf(stderr, "\n");
+
+                if (ud && ud->direct_resource_offset && ud->direct_resource_count) {
+                    fprintf(stderr, "[compute]   direct offsets:");
+                    for (uint16_t t = 0; t < ud->direct_resource_count && t < 16; ++t)
+                        fprintf(stderr, " [%u]=%u", t, ud->direct_resource_offset[t]);
+                    fprintf(stderr, "\n");
+                    const uint32_t reg = ud->direct_resource_count > 1 ? ud->direct_resource_offset[1] : 0xffffu;
+                    if (reg != 0xffffu && reg + 4 <= kUserSgprs) {
+                        const DecodedBufferDescriptor d = decode_buffer_descriptor(&sgprs[reg]);
+                        fprintf(stderr, "[compute]   type1 V# reg=%u base=0x%llx stride=%u records=%u "
+                                        "size=%u fmt=%u comps=%u\n",
+                                reg, (unsigned long long)d.base, d.stride, d.num_records, d.size_bytes,
+                                (unsigned)d.format, d.num_components);
+                    }
+                }
+            }
         }
 
         bool dim_match = !want_w || !want_h;

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -852,6 +852,46 @@ HLE(agc_cb_set_sh_register_range_direct) {  // (buf, offset, values, num_values)
     return (uint64_t)(uintptr_t)cmd;
 }
 
+// sceAgcCbSetShRegistersDirect (UZbQjYAwwXM) -- append a set of non-contiguous SH registers.
+// Live Dead Cells imports this immediately before its compute dispatch stream; dropping the call
+// leaves COMPUTE_PGM_* and compute user-data at zero. The ABI is (Dcb*, ShaderRegister*, count),
+// where each entry is {offset,value}. Preserve caller order and combine only adjacent consecutive
+// offsets, so duplicate/out-of-order writes retain their original semantics.
+HLE(agc_cb_set_sh_registers_direct) {
+    auto* regs = (const AgcShaderRegister*)(uintptr_t)a1;
+    const uint32_t count = (uint32_t)a2;
+    if (!a0 || !regs || !count || count > 4096) return 0;
+
+    if (getenv("PROSPER_GFXLOG")) {
+        static std::atomic<uint32_t> logged{0};
+        const uint32_t n = logged.fetch_add(1, std::memory_order_relaxed);
+        if (n < 16) {
+            fprintf(stderr, "[agc] SetShRegistersDirect dcb=0x%llx regs=%p count=%u:",
+                    (unsigned long long)a0, (const void*)regs, count);
+            for (uint32_t i = 0; i < count && i < 24; ++i)
+                fprintf(stderr, " (off=0x%x val=0x%x)", regs[i].offset, regs[i].value);
+            if (count > 24) fprintf(stderr, " ...");
+            fprintf(stderr, "\n");
+        }
+    }
+
+    uint32_t* first = nullptr;
+    uint32_t start = 0;
+    while (start < count) {
+        uint32_t end = start + 1;
+        while (end < count && regs[end].offset == regs[end - 1].offset + 1) ++end;
+
+        const uint32_t run_count = end - start;
+        uint32_t* cmd = nullptr;
+        if (!begin_packet(a0, run_count + 2, IT_SET_SH_REG, 0, &cmd)) return 0;
+        if (!first) first = cmd;
+        cmd[1] = regs[start].offset;
+        for (uint32_t i = 0; i < run_count; ++i) cmd[2 + i] = regs[start + i].value;
+        start = end;
+    }
+    return (uint64_t)(uintptr_t)first;
+}
+
 // sceAgcCreatePrimState (D9sr1xGUriE) — derive the primitive-pipeline registers from the bound
 // geometry shader's "specials" block. Kyty hard-asserts hs==null and exact register offsets; we
 // copy the specials through and log deviations instead (tessellation would arrive via hs).
@@ -1286,6 +1326,7 @@ void register_agc_hle() {
     RN("uJziRsODk1c", agc_driver_get_resource_registration_max_name_length);
     RN("V++UgBtQhn0", agc_get_data_packet_payload);          // data packet -> register-bank payload
     RN("n2fD4A+pb+g", agc_cb_set_sh_register_range_direct);  // SET_SH_REG range packet
+    RN("UZbQjYAwwXM", agc_cb_set_sh_registers_direct);       // non-contiguous SET_SH_REG packets
     RN("D9sr1xGUriE", agc_create_prim_state);                // prim registers from gs specials
     RN("HV4j+E0MBHE", agc_create_interpolant_mapping);       // SPI_PS_INPUT_CNTL_* wiring
     RN("TRO721eVt4g", agc_dcb_reset_queue);

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -24,7 +24,9 @@ struct Dcb {
 static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & 0x3fu) << 2u);
 }
-constexpr uint32_t IT_NOP = 0x10, R_DRAW_RESET = 0x05, R_CX_REGS_INDIRECT = 0x12;
+constexpr uint32_t IT_NOP = 0x10, IT_SET_SH_REG = 0x76, R_DRAW_RESET = 0x05, R_CX_REGS_INDIRECT = 0x12;
+
+struct ShaderRegister { uint32_t offset, value; };
 
 int main() {
     printf("== test_agc_dcb ==\n");
@@ -84,6 +86,40 @@ int main() {
               out == nullptr, "unknown type: invalid-arg and out pointer remains untouched");
         CHECK(getpayload(0, (uint64_t)(uintptr_t)pkt, 1, 0, 0, 0) != 0, "null out-ptr -> invalid-arg");
         CHECK(getpayload((uint64_t)(uintptr_t)&out, 0, 1, 0, 0, 0) != 0, "null cmd -> invalid-arg");
+    }
+
+    // sceAgcCbSetShRegistersDirect (#574): group adjacent offsets, but preserve caller order and
+    // split gaps into separate packets so every {offset,value} pair reaches the SH register file.
+    auto setshdirect = Hle::lookup("UZbQjYAwwXM");
+    CHECK(setshdirect != nullptr, "SetShRegistersDirect registered");
+    if (setshdirect) {
+        ShaderRegister sh[] = {
+            {0x20c, 0x11111111u}, {0x20d, 0x22222222u},
+            {0x212, 0x33333333u}, {0x100, 0x44444444u}, {0x101, 0x55555555u},
+        };
+        uint32_t* before = dcb.cursor_up;
+        uint64_t first_addr = setshdirect(D, (uint64_t)(uintptr_t)sh, 5, 0, 0, 0);
+        auto* first = (uint32_t*)(uintptr_t)first_addr;
+        CHECK(first == before, "SetShRegistersDirect returns the first emitted packet");
+        CHECK(first[0] == PM4(4, IT_SET_SH_REG, 0) && first[1] == 0x20c &&
+              first[2] == 0x11111111u && first[3] == 0x22222222u,
+              "first consecutive SH-register run emitted as one packet");
+        auto* second = first + 4;
+        CHECK(second[0] == PM4(3, IT_SET_SH_REG, 0) && second[1] == 0x212 &&
+              second[2] == 0x33333333u, "register gap starts a new SH packet");
+        auto* third = second + 3;
+        CHECK(third[0] == PM4(4, IT_SET_SH_REG, 0) && third[1] == 0x100 &&
+              third[2] == 0x44444444u && third[3] == 0x55555555u,
+              "out-of-order consecutive run preserves caller order");
+        CHECK(dcb.cursor_up == before + 11, "SetShRegistersDirect advances by all packet dwords");
+
+        before = dcb.cursor_up;
+        CHECK(setshdirect(D, 0, 5, 0, 0, 0) == 0 && dcb.cursor_up == before,
+              "null register array rejected without allocating");
+        CHECK(setshdirect(D, (uint64_t)(uintptr_t)sh, 0, 0, 0, 0) == 0 && dcb.cursor_up == before,
+              "zero register count rejected without allocating");
+        CHECK(setshdirect(D, (uint64_t)(uintptr_t)sh, 4097, 0, 0, 0) == 0 && dcb.cursor_up == before,
+              "oversized register count rejected without allocating");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -184,6 +184,29 @@ int main() {
     CHECK(t3.by_sgpr_base(4) != nullptr, "constant buffers still present alongside vertex buffers");
     CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
 
+    // --- Dead Cells compute direct resource: type 1 points at an inline V# in user SGPRs (#574). --
+    {
+        uint32_t csgprs[32]; memset(csgprs, 0, sizeof csgprs);
+        make_vsharp(&csgprs[0], 0x74B4A8240000ull, 16, 0x1fe000, /*fmt*/75);
+        uint16_t cdro[11]; for (auto& x : cdro) x = 0xffff;
+        cdro[1] = 0;
+        AgcShaderUserData cud; memset(&cud, 0, sizeof cud);
+        cud.direct_resource_offset = cdro; cud.direct_resource_count = 11; cud.srt_size_dw = 8;
+        AgcShaderHeader csh; memset(&csh, 0, sizeof csh);
+        csh.file_header = 0x34333231u; csh.version = 0x18; csh.type = 0; csh.user_data = &cud;
+
+        ShaderResourceTable ct = build_shader_resources(csh, csgprs, 32);
+        const ShaderResource* cb = ct.by_sgpr_base(0);
+        CHECK(cb && cb->cls == ResourceClass::ConstantBuffer,
+              "compute type-1 direct V# emitted as a storage-buffer-backed resource");
+        CHECK(cb && cb->gpu_addr == 0x74B4A8240000ull && cb->stride == 16 &&
+              cb->size == 0x1fe0000, "compute direct V# base/stride/size decoded from live-shaped data");
+
+        csh.type = 1;
+        CHECK(build_shader_resources(csh, csgprs, 32).resources.empty(),
+              "type-1 direct resource is not guessed for unobserved non-compute stages");
+    }
+
     // --- textures: sharp[0] T#s carry their real format + byte size; BC1/2/3 are bound (decoded to RGBA8
     // on upload, #121); BC4-7 + unmapped formats are still skipped (#65) ---
     {


### PR DESCRIPTION
﻿## Summary

- implement `sceAgcCbSetShRegistersDirect` from live Dead Cells ABI evidence
- preserve non-contiguous and duplicate register writes while grouping consecutive runs into `IT_SET_SH_REG`
- decode the title's compute-only direct type-1 inline V# as a storage-buffer-backed resource
- extend `PROSPER_COMPUTELOG` to dump unresolved compute metadata and bound SGPRs once per program

## Live evidence

Before this branch, every startup dispatch reported:

```
code=0x0 header=no resources=0
```

The live builder call is `(Dcb*, ShaderRegister*, count=10)` and includes `COMPUTE_PGM_LO/HI`, `COMPUTE_PGM_RSRC*`, and thread dimensions. After packet emission:

```
code=0x401aec200 header=yes resources=0
```

The shader has no sharps; it declares direct usage type 1 at SGPR 0. Its bound dwords decode as a real V# (Base48, stride 16, Uint32x4, size matching the dispatch modifier). With compute type-1 decoding:

```
code=0x401aec200 header=yes resources=1
binding=2 addr=<guest buffer> size=33423360 fmt=Uint32x4 sgpr=0
```

All six startup dispatches now resolve the correct per-dispatch buffer. Actual compute execution remains separate work in #576; the command processor still records dispatches without executing them.

## Verification

- 85/85 Linux tests pass
- `messenger-scene`: OK, richest frame 24,318 colors
- aggregate Dead Cells guard selected known alternate animation hash `e4f49b4d...` (#573)
- standalone `dead-cells-splash`: exact baseline OK, 960x540
- live Dead Cells dispatch trace: valid program/header and one bound resource on every startup dispatch

Fixes #574
