### PR TITLE
docs: refresh current compatibility frontier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,14 @@ exercised NGS2 lifecycle returns initialized sizes/handles/state and silent outp
 window reaches the Evil Empire splash. #545 was software-render throughput, not a guest deadlock: synchronous
 3840×2160 llvmpipe rendering stretches its ~13,000-submit startup into minutes.
 
-The immediate frontier is repeatable, practical progression tooling: address the software-render capture policy
-(#549), finish input checkpoints and multi-title snapshots (#302/#248), complete the newly reached offline
-service contracts (#552), then apply `.prgcap` replay and strict descriptor validation to existing 3D Unity/Unreal
-workloads.
+Dead Cells now has a deterministic route through splash/menu into gameplay. HUD and partial composition render,
+but the world is mostly white (#566). Version-4 `.prgcap` captures seed temporal RTT inputs (#568) and isolate the
+first bad composition at draw 18; one 642x362 input has no prior color-target writer. The dispatch ABI (#571),
+`sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574) recover a real compute program and
+buffer resource. The immediate frontier is actual compute execution (#576): dispatches are still retained for
+diagnostics only, so compute-produced memory/images remain stale. Use writer provenance to prove ownership of the
+missing surface rather than assuming compute is causal. The residual seeded replay mismatch (#569) and the
+animation-sensitive exact splash guard (#573) remain separate tooling issues.
 `PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` are landed capabilities from #515.
 Do not restart the superseded
 Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 runs PS5 (Prospero) game binaries on Linux (primary) and Windows (secondary) by reimplementing the
 console's OS, ABI, and GPU stack on the host — **not** by emulating a CPU.
 
-> ⚠️ **Experimental research project.** It is not a playable game runner yet, but it now boots real
-> retail titles deep into their engine's frame loop and **renders real frames** to a live Vulkan
-> backend. See [Status](#status) for exactly how far it gets today.
+> ⚠️ **Experimental research project.** It is not a general-purpose game runner yet. The primary
+> title now reaches a hardware-verified first level, while other retail titles expose substantial
+> compatibility gaps. See [Status](#status) for exactly how far each target gets today.
 
 ## Why no CPU emulation?
 
@@ -28,8 +28,8 @@ natural primary target and the long-term dream is running on that hardware.
 
 prosper boots **multiple real retail titles** across two engine families — Unity 2022 / IL2CPP
 (*The Messenger*, `PPSA24651`, the primary target) and Unreal Engine (`PPSA17942`) — from a
-user-supplied, **unencrypted-segment** dump. For the primary title it now boots *through* the engine
-and draws real geometry.
+user-supplied, **unencrypted-segment** dump. For the primary title it now boots *through* the engine,
+accepts scripted gamepad input, and renders the first level.
 
 **Boot & runtime (host-side OS / ABI / HLE):**
 - ✅ Parses `SELF`/`ELF`, builds a relocatable image, resolves Sony **NID**-hashed imports, links the
@@ -65,16 +65,19 @@ and draws real geometry.
   `resolve_pipeline_state` → real `VkGraphicsPipeline`s, with topology, blend (incl. separate-alpha),
   depth, stencil, per-MRT color-write-mask, the game's real fast-clear color, and a render-to-texture
   cache for multi-pass composites — all driven from the decoded registers and pixel-verified.
-- ✅ **The Messenger renders:** it plays its intro **cutscene** (dozens of distinct animating frames),
-  draws its **title screen with readable text**, accepts **gamepad input**, and progresses through
-  New-Game into **gameplay level loading**. Frames are asserted by a golden-image regression guard, not
-  eyeballed.
+- ✅ **The Messenger reaches gameplay:** intro, title, menus, save list, dialogue, player, terrain,
+  water, structures, and foreground composition render through the first level at native 1920x1080.
+  A scripted gamepad route produced a full-resolution sequence that was confirmed against PS5 hardware.
+- 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
+  first playable scene. HUD and some composition are alive, but the world is mostly white. Capture/replay
+  isolated the first bad composition input; compute program and resource binding now resolve, while actual
+  `DispatchDirect` shader execution remains missing (#566, #576).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **84 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **85 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
@@ -100,7 +103,7 @@ Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the g
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # 84 self-checking tests
+ctest --test-dir build-linux          # 85 self-checking tests
 ```
 
 Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). A

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -33,15 +33,15 @@ possible without console keys. Dumps are user-supplied and gitignored.
 - ✅ **Graphics investigation tooling:** versioned live GPU capture/replay (`.prgcap`), per-draw/resource
   inspection and isolation, strict reflected SPIR-V/runtime descriptor validation, render-target producer
   provenance, normal screenshot capture, and a local content-metric snapshot guard.
-- ✅ **Dead Cells reaches its publisher splash:** the intermittent AGC startup crash is fixed (#544),
-  repeated startup is stable, and its exercised NGS2 audio lifecycle now returns real sizes, handles,
-  state, and silent output (#554). A late render-window capture reaches the Evil Empire splash; the earlier
-  apparent loading stall was synchronous 4K llvmpipe slowdown (#545), not a guest deadlock.
-- 🚧 **Active frontiers:** make progression capture practical on software Vulkan (#549), finish reusable
-  input checkpoints and multi-title snapshots (#302/#248), complete newly reached offline service contracts
-  (#552), then apply capture/replay and descriptor validation to existing Unity and Unreal 3D workloads.
-  UE4's first measured GPU blocker is unresolved image/vertex descriptor provenance (#485), not an assumed
-  missing instruction class.
+- ✅ **Dead Cells reaches gameplay reproducibly:** a deterministic input route passes the splash and menus
+  into the first playable scene. HUD and some composition render, but the world is mostly white (#566).
+  Version-4 GPU captures seed temporal render targets for faithful offline isolation (#568); one residual
+  live/replay hash mismatch remains (#569). Dispatch dimensions, compute program binding, and the title's
+  direct type-1 buffer resource now decode correctly (#571/#574).
+- 🚧 **Active frontiers:** execute retained compute dispatches in stream order (#576), then use compute
+  writer provenance to determine whether the missing 642x362 Dead Cells composition input is compute-owned.
+  Stabilize the animation-sensitive exact splash guard (#573) and continue cross-title capture/replay and
+  descriptor-validation work. UE4's measured GPU boundary remains tracked separately under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
 [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -24,7 +24,7 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
 
 ---
 
-## Current status (2026-07-11) - at a glance
+## Current status (2026-07-12) - at a glance
 
 - **Messenger reaches and renders the first level:** intro, title, menus, save list, dialogue, player,
   background, foreground tree/terrain, water, and structures render at native 1920×1080. The causal fixes
@@ -35,15 +35,15 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   live/replay hashes and per-draw/resource isolation; #515 provides reflected SPIR-V/runtime descriptor
   validation in live and offline replay paths. Producer provenance, normal screenshot capture, and the local
   content-metric snapshot guard complete the current first-bad-contract workflow.
-- **Dead Cells cross-title milestone:** #544 fixes the poisoned AGC resource-name limit that caused intermittent
-  startup stack exhaustion; 30/30 repeated starts pass. Its exercised NGS2 lifecycle now supplies initialized
-  sizes, handles, voice state, geometry state, and silent PCM (#554), and POSIX `getpid` is nonzero (#553).
-  A revision-locked late render window reaches the Evil Empire splash. #545 is closed: rendering every 4K
-  submit synchronously through llvmpipe made a ~13,000-submit startup look stalled for minutes.
-- **Immediate milestone:** make progression capture/checkpointing practical without hand-guessing submit windows
-  (#549/#302), expand multi-title snapshot coverage (#248), and implement the newly reached honest-offline NP and
-  SaveData contracts (#552). Then use the same capture/replay and descriptor-validation workflow on existing
-  Unity/Unreal 3D workloads. UE4's measured shader rejection boundary remains descriptor provenance (#485).
+- **Dead Cells cross-title milestone:** deterministic routing now reaches gameplay. HUD and partial composition
+  render, but the world is mostly white (#566). Version-4 captures seed temporal render targets (#568) and isolate
+  the first bad composition at draw 18; its missing 642x362 input has no prior color-target writer. The corrected
+  dispatch ABI (#571), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# decoding (#574) now recover a
+  valid registered program and one real buffer resource for every exercised startup dispatch.
+- **Immediate milestone:** execute retained compute dispatches and order their writes before downstream consumers
+  (#576), then extend provenance to identify compute/DMA/CPU writers and test whether Dead Cells' missing surface
+  is compute-produced. Separately, resolve the seeded replay hash mismatch (#569) and animation-sensitive splash
+  snapshot (#573), while continuing the same capture/replay workflow across Unity and Unreal targets.
 
 ## Historical status (2026-07-05) - retained for the milestone log
 


### PR DESCRIPTION
﻿## Summary

Refresh the current-status sections in the repository charter and public docs after the July 11-12 graphics work:

- record The Messenger's hardware-confirmed first-level render
- record Dead Cells' deterministic route to gameplay and mostly-white world
- capture the v4 temporal RTT replay, corrected dispatch ABI, and recovered compute program/resource binding
- state the remaining boundary honestly: `DispatchDirect` work is retained but not executed (#576)
- update the configured suite count from 84 to 85

Historical milestone logs remain unchanged.

Fixes #577
