### PR TITLE
feat(gpu): execute buffer compute dispatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,10 @@ Dead Cells now has a deterministic route through splash/menu into gameplay. HUD 
 but the world is mostly white (#566). Version-4 `.prgcap` captures seed temporal RTT inputs (#568) and isolate the
 first bad composition at draw 18; one 642x362 input has no prior color-target writer. The kernel-derived dispatch
 thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574)
-recover a real compute program and buffer resource. The immediate frontier is actual compute execution (#576):
-dispatches are still retained for diagnostics only, so compute-produced memory/images remain stale. Use writer
-provenance to prove ownership of the missing surface rather than assuming compute is causal. The residual seeded
-replay mismatch (#569) and the animation-sensitive exact splash guard (#573) remain separate tooling issues.
+now execute the real fill kernel against guest buffers before submit completion (#576). The gameplay route remains
+mostly white, proving this buffer compute was not the missing 642x362 producer. The immediate frontier is writer
+provenance and storage-image compute, without assuming compute owns that surface (#566). The residual seeded replay
+mismatch (#569) and the animation-sensitive exact splash guard (#573) remain separate tooling issues.
 `PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` are landed capabilities from #515.
 Do not restart the superseded
 Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.
@@ -136,7 +136,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 85/85 expected green on Linux
+  cmake --build . -j8 && ctest        # 86/86 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ accepts scripted gamepad input, and renders the first level.
   A scripted gamepad route produced a full-resolution sequence that was confirmed against PS5 hardware.
 - 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
   first playable scene. HUD and some composition are alive, but the world is mostly white. Capture/replay
-  isolated the first bad composition input; compute program and resource binding now resolve, while actual
-  `DispatchDirect` shader execution remains missing (#566, #576).
+  isolated the first bad composition input. Its real buffer compute kernel now executes in stream order and
+  writes guest memory, but this does not recover the missing 642x362 scene input (#566, #576).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **85 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **86 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
@@ -103,7 +103,7 @@ Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the g
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # 85 self-checking tests
+ctest --test-dir build-linux          # 86 self-checking tests
 ```
 
 Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). A

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -454,7 +454,8 @@ if(TARGET prosper_core)
       # Shared live renderer (frontends/shared): the DrawItem->Vulkan compositor, factored out of
       # boot_trace so BOTH boot_trace and prosper-app register the SAME renderer instead of
       # duplicating it. Needs render_runner.h (tests/) and refvs.inc (tools/boot_trace/).
-      add_library(prosper_live_renderer STATIC frontends/shared/live_renderer.cpp)
+      add_library(prosper_live_renderer STATIC frontends/shared/live_renderer.cpp
+                                               frontends/shared/live_compute.cpp)
       target_include_directories(prosper_live_renderer PRIVATE src tests tools/boot_trace)
       target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
@@ -499,6 +500,11 @@ if(TARGET prosper_core)
       add_executable(test_compute_exec tests/test_compute_exec.cpp)
       target_link_libraries(test_compute_exec PRIVATE Vulkan::Vulkan)
       add_test(NAME compute_exec_differential COMMAND test_compute_exec)
+
+      # Execute a real game kernel with its user/system-register ABI and resource table.
+      add_executable(test_game_compute tests/test_game_compute.cpp)
+      target_link_libraries(test_game_compute PRIVATE prosper_live_renderer)
+      add_test(NAME game_compute_exec COMMAND test_game_compute)
 
       # Prove our own SPIR-V emitter produces valid, correct, runnable SPIR-V (execution-differential).
       add_executable(test_spirv_builder tests/test_spirv_builder.cpp)

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -37,10 +37,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   into the first playable scene. HUD and some composition render, but the world is mostly white (#566).
   Version-4 GPU captures seed temporal render targets for faithful offline isolation (#568); one residual
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
-  compute program binding, and the title's direct type-1 buffer resource now decode correctly (#580/#574).
-- 🚧 **Active frontiers:** execute retained compute dispatches in stream order (#576), then use compute
-  writer provenance to determine whether the missing 642x362 Dead Cells composition input is compute-owned.
-  Stabilize the animation-sensitive exact splash guard (#573) and continue cross-title capture/replay and
+  compute program binding, and the title's direct type-1 buffer resource now execute correctly (#580/#576).
+- 🚧 **Active frontiers:** identify the actual producer of Dead Cells' missing 642x362 composition input;
+  buffer compute execution does not recover it (#566). Add storage-image compute and compute-writer provenance,
+  stabilize the animation-sensitive exact splash guard (#573), and continue cross-title capture/replay and
   descriptor-validation work. UE4's measured GPU boundary remains tracked separately under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
@@ -72,7 +72,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # 85 self-checking tests
+ctest --test-dir build          # 86 self-checking tests
 ```
 Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -39,12 +39,12 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   render, but the world is mostly white (#566). Version-4 captures seed temporal render targets (#568) and isolate
   the first bad composition at draw 18; its missing 642x362 input has no prior color-target writer. The corrected
   dispatch thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V#
-  decoding (#574) now recover a valid registered program and one real buffer resource for every exercised
-  startup dispatch.
-- **Immediate milestone:** execute retained compute dispatches and order their writes before downstream consumers
-  (#576), then extend provenance to identify compute/DMA/CPU writers and test whether Dead Cells' missing surface
-  is compute-produced. Separately, resolve the seeded replay hash mismatch (#569) and animation-sensitive splash
-  snapshot (#573), while continuing the same capture/replay workflow across Unity and Unreal targets.
+  decoding (#574) now execute a valid registered fill program against real guest buffers before submit completion
+  (#576). The deterministic gameplay route remains mostly white, so this does not own the missing scene input.
+- **Immediate milestone:** extend provenance to identify compute/DMA/CPU writers, add storage-image compute, and
+  locate the actual producer of Dead Cells' missing surface (#566). Separately, resolve the seeded replay hash
+  mismatch (#569) and animation-sensitive splash snapshot (#573), while continuing the same capture/replay
+  workflow across Unity and Unreal targets.
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,0 +1,327 @@
+#include "live_compute.hpp"
+
+#include "gpu/gpu_execute.hpp"
+#include "gpu/shader_resources.hpp"
+
+#include <vulkan/vulkan.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace prosper::frontend {
+namespace {
+
+struct VulkanComputeContext {
+    VkInstance instance = VK_NULL_HANDLE;
+    VkPhysicalDevice physical = VK_NULL_HANDLE;
+    VkDevice device = VK_NULL_HANDLE;
+    VkQueue queue = VK_NULL_HANDLE;
+    uint32_t queue_family = UINT32_MAX;
+    VkPhysicalDeviceMemoryProperties memory{};
+
+    ~VulkanComputeContext() {
+        if (device) vkDestroyDevice(device, nullptr);
+        if (instance) vkDestroyInstance(instance, nullptr);
+    }
+
+    bool init() {
+        VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+        app.apiVersion = VK_API_VERSION_1_1;
+        VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+        ici.pApplicationInfo = &app;
+        if (vkCreateInstance(&ici, nullptr, &instance) != VK_SUCCESS) return false;
+
+        uint32_t device_count = 0;
+        vkEnumeratePhysicalDevices(instance, &device_count, nullptr);
+        if (!device_count) return false;
+        std::vector<VkPhysicalDevice> devices(device_count);
+        vkEnumeratePhysicalDevices(instance, &device_count, devices.data());
+        physical = devices[0];
+
+        uint32_t family_count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, nullptr);
+        std::vector<VkQueueFamilyProperties> families(family_count);
+        vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, families.data());
+        for (uint32_t i = 0; i < family_count; i++) {
+            if (families[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
+                queue_family = i;
+                break;
+            }
+        }
+        if (queue_family == UINT32_MAX) return false;
+
+        float priority = 1.0f;
+        VkDeviceQueueCreateInfo qci{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
+        qci.queueFamilyIndex = queue_family;
+        qci.queueCount = 1;
+        qci.pQueuePriorities = &priority;
+        VkPhysicalDeviceFeatures supported{};
+        vkGetPhysicalDeviceFeatures(physical, &supported);
+        if (!supported.robustBufferAccess) {
+            std::fprintf(stderr, "[compute] device lacks robustBufferAccess\n");
+            return false;
+        }
+        VkPhysicalDeviceFeatures enabled{};
+        enabled.robustBufferAccess = VK_TRUE;
+        VkDeviceCreateInfo dci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
+        dci.queueCreateInfoCount = 1;
+        dci.pQueueCreateInfos = &qci;
+        dci.pEnabledFeatures = &enabled;
+        if (vkCreateDevice(physical, &dci, nullptr, &device) != VK_SUCCESS) return false;
+        vkGetDeviceQueue(device, queue_family, 0, &queue);
+        vkGetPhysicalDeviceMemoryProperties(physical, &memory);
+        return true;
+    }
+
+    uint32_t host_memory_type(uint32_t bits) const {
+        const VkMemoryPropertyFlags wanted = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                             VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        for (uint32_t i = 0; i < memory.memoryTypeCount; i++)
+            if ((bits & (1u << i)) && (memory.memoryTypes[i].propertyFlags & wanted) == wanted)
+                return i;
+        return UINT32_MAX;
+    }
+};
+
+struct BoundBuffer {
+    const prosper::gpu::ShaderResource* resource = nullptr;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    uint64_t before_hash = 0, after_hash = 0;
+    uint64_t changed_bytes = 0;
+};
+
+uint64_t fnv1a(const void* data, size_t size) {
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    uint64_t hash = 1469598103934665603ull;
+    for (size_t i = 0; i < size; i++) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
+    using namespace prosper::gpu;
+    const bool trace = std::getenv("PROSPER_COMPUTELOG") != nullptr;
+    auto report = validate_spirv_descriptor_interface(
+        item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
+    if (!report.ok()) return false;
+
+    std::vector<SpirvDescriptorBinding> descriptors;
+    for (const auto& descriptor : report.descriptors) {
+        if (descriptor.kind != SpirvDescriptorKind::StorageBuffer) {
+            std::fprintf(stderr, "[compute] program 0x%llx uses unsupported %s binding %u\n",
+                         (unsigned long long)item.code_addr,
+                         spirv_descriptor_kind_name(descriptor.kind), descriptor.binding);
+            return false;
+        }
+        descriptors.push_back(descriptor);
+    }
+    if (descriptors.empty()) return false;
+    std::sort(descriptors.begin(), descriptors.end(), [](const auto& a, const auto& b) {
+        return a.binding < b.binding;
+    });
+
+    std::vector<BoundBuffer> buffers(descriptors.size());
+    VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
+    VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
+    VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
+    VkShaderModule shader = VK_NULL_HANDLE;
+    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    VkCommandPool command_pool = VK_NULL_HANDLE;
+    VkFence fence = VK_NULL_HANDLE;
+    bool ok = false;
+
+    auto cleanup = [&] {
+        if (fence) vkDestroyFence(ctx.device, fence, nullptr);
+        if (command_pool) vkDestroyCommandPool(ctx.device, command_pool, nullptr);
+        if (pipeline) vkDestroyPipeline(ctx.device, pipeline, nullptr);
+        if (pipeline_layout) vkDestroyPipelineLayout(ctx.device, pipeline_layout, nullptr);
+        if (shader) vkDestroyShaderModule(ctx.device, shader, nullptr);
+        if (descriptor_pool) vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
+        if (descriptor_layout) vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
+        for (auto& buffer : buffers) {
+            if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
+            if (buffer.memory) vkFreeMemory(ctx.device, buffer.memory, nullptr);
+        }
+    };
+
+    do {
+        std::vector<VkDescriptorSetLayoutBinding> layout_bindings(descriptors.size());
+        for (size_t i = 0; i < descriptors.size(); i++) {
+            const ShaderResource* resource = item.resources->by_binding(descriptors[i].binding);
+            if (!resource || !resource->size ||
+                !guest_readable(resource->gpu_addr, resource->size)) break;
+            buffers[i].resource = resource;
+            VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+            bci.size = resource->size;
+            bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+            if (vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer) != VK_SUCCESS) break;
+            VkMemoryRequirements requirements{};
+            vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
+            const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
+            if (memory_type == UINT32_MAX) break;
+            VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+            mai.allocationSize = requirements.size;
+            mai.memoryTypeIndex = memory_type;
+            if (vkAllocateMemory(ctx.device, &mai, nullptr, &buffers[i].memory) != VK_SUCCESS) break;
+            if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
+            void* mapped = nullptr;
+            if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
+            const void* guest = (const void*)(uintptr_t)resource->gpu_addr;
+            if (trace) buffers[i].before_hash = fnv1a(guest, resource->size);
+            std::memcpy(mapped, guest, resource->size);
+            vkUnmapMemory(ctx.device, buffers[i].memory);
+
+            layout_bindings[i].binding = descriptors[i].binding;
+            layout_bindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            layout_bindings[i].descriptorCount = 1;
+            layout_bindings[i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        }
+        bool buffers_ready = true;
+        for (const auto& buffer : buffers) buffers_ready &= buffer.resource && buffer.memory;
+        if (!buffers_ready) break;
+
+        VkDescriptorSetLayoutCreateInfo dlci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+        dlci.bindingCount = static_cast<uint32_t>(layout_bindings.size());
+        dlci.pBindings = layout_bindings.data();
+        if (vkCreateDescriptorSetLayout(ctx.device, &dlci, nullptr, &descriptor_layout) != VK_SUCCESS) break;
+        VkDescriptorPoolSize pool_size{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                                       static_cast<uint32_t>(buffers.size())};
+        VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+        dpci.maxSets = 1;
+        dpci.poolSizeCount = 1;
+        dpci.pPoolSizes = &pool_size;
+        if (vkCreateDescriptorPool(ctx.device, &dpci, nullptr, &descriptor_pool) != VK_SUCCESS) break;
+        VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+        dsai.descriptorPool = descriptor_pool;
+        dsai.descriptorSetCount = 1;
+        dsai.pSetLayouts = &descriptor_layout;
+        if (vkAllocateDescriptorSets(ctx.device, &dsai, &descriptor_set) != VK_SUCCESS) break;
+
+        std::vector<VkDescriptorBufferInfo> buffer_infos(buffers.size());
+        std::vector<VkWriteDescriptorSet> writes(buffers.size());
+        for (size_t i = 0; i < buffers.size(); i++) {
+            buffer_infos[i] = {buffers[i].buffer, 0, buffers[i].resource->size};
+            writes[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+            writes[i].dstSet = descriptor_set;
+            writes[i].dstBinding = descriptors[i].binding;
+            writes[i].descriptorCount = 1;
+            writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[i].pBufferInfo = &buffer_infos[i];
+        }
+        vkUpdateDescriptorSets(ctx.device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+
+        VkShaderModuleCreateInfo smci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+        smci.codeSize = item.spirv.size() * sizeof(uint32_t);
+        smci.pCode = item.spirv.data();
+        if (vkCreateShaderModule(ctx.device, &smci, nullptr, &shader) != VK_SUCCESS) break;
+        VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+        plci.setLayoutCount = 1;
+        plci.pSetLayouts = &descriptor_layout;
+        if (vkCreatePipelineLayout(ctx.device, &plci, nullptr, &pipeline_layout) != VK_SUCCESS) break;
+        VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+        cpci.stage = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+        cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        cpci.stage.module = shader;
+        cpci.stage.pName = "main";
+        cpci.layout = pipeline_layout;
+        if (vkCreateComputePipelines(ctx.device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipeline) != VK_SUCCESS) break;
+
+        VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+        pci.queueFamilyIndex = ctx.queue_family;
+        if (vkCreateCommandPool(ctx.device, &pci, nullptr, &command_pool) != VK_SUCCESS) break;
+        VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+        cbai.commandPool = command_pool;
+        cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cbai.commandBufferCount = 1;
+        VkCommandBuffer command = VK_NULL_HANDLE;
+        if (vkAllocateCommandBuffers(ctx.device, &cbai, &command) != VK_SUCCESS) break;
+        VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+        begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        if (vkBeginCommandBuffer(command, &begin) != VK_SUCCESS) break;
+        vkCmdBindPipeline(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+        vkCmdBindDescriptorSets(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout,
+                                0, 1, &descriptor_set, 0, nullptr);
+        vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+        if (vkEndCommandBuffer(command) != VK_SUCCESS) break;
+        VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+        if (vkCreateFence(ctx.device, &fci, nullptr, &fence) != VK_SUCCESS) break;
+        VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+        submit.commandBufferCount = 1;
+        submit.pCommandBuffers = &command;
+        if (vkQueueSubmit(ctx.queue, 1, &submit, fence) != VK_SUCCESS) break;
+        if (vkWaitForFences(ctx.device, 1, &fence, VK_TRUE, 30ull * 1000 * 1000 * 1000) != VK_SUCCESS) break;
+
+        bool readback_ok = true;
+        for (auto& buffer : buffers) {
+            void* mapped = nullptr;
+            if (vkMapMemory(ctx.device, buffer.memory, 0, buffer.resource->size, 0, &mapped) != VK_SUCCESS) {
+                readback_ok = false;
+                break;
+            }
+            auto* guest = (uint8_t*)(uintptr_t)buffer.resource->gpu_addr;
+            const auto* result = static_cast<const uint8_t*>(mapped);
+            if (trace) {
+                buffer.after_hash = fnv1a(result, buffer.resource->size);
+                for (uint32_t i = 0; i < buffer.resource->size; i++)
+                    buffer.changed_bytes += guest[i] != result[i];
+            }
+            std::memcpy(guest, result, buffer.resource->size);
+            vkUnmapMemory(ctx.device, buffer.memory);
+        }
+        if (!readback_ok) break;
+        ok = true;
+    } while (false);
+
+    if (trace)
+        std::fprintf(stderr, "[compute] execute code=0x%llx groups=%ux%ux%u buffers=%zu result=%s\n",
+                     (unsigned long long)item.code_addr, item.launch.groups_x, item.launch.groups_y,
+                     item.launch.groups_z, buffers.size(), ok ? "ok" : "failed");
+    if (trace) {
+        for (const auto& buffer : buffers) {
+            if (!buffer.resource) continue;
+            std::fprintf(stderr,
+                         "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
+                         "hash=%016llx->%016llx\n",
+                         buffer.resource->binding, (unsigned long long)buffer.resource->gpu_addr,
+                         buffer.resource->size, (unsigned long long)buffer.changed_bytes,
+                         (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash);
+        }
+    }
+    cleanup();
+    return ok;
+}
+
+} // namespace
+
+bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items) {
+    VulkanComputeContext context;
+    if (!context.init()) {
+        std::fprintf(stderr, "[compute] Vulkan initialization failed\n");
+        return false;
+    }
+    for (const auto& item : items)
+        if (!execute_item(context, item)) return false;
+    return true;
+}
+
+void register_live_compute() {
+    static bool attempted = false;
+    if (attempted) return;
+    attempted = true;
+    const char* enabled = std::getenv("PROSPER_COMPUTE");
+    if (enabled && (!std::strcmp(enabled, "0") || !std::strcmp(enabled, "off"))) {
+        std::fprintf(stderr, "[compute] live execution disabled by PROSPER_COMPUTE=%s\n", enabled);
+        return;
+    }
+    prosper::gpu::set_submit_compute(execute_live_compute_items);
+    std::fprintf(stderr, "[compute] live Vulkan compute backend registered\n");
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "gpu/gpu_execute.hpp"
+
+#include <vector>
+
+namespace prosper::frontend {
+
+// Execute already-realized compute items synchronously. Exposed for the production-backend test.
+bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items);
+
+// Register the synchronous Vulkan compute backend used by AGC submit processing.
+void register_live_compute();
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1,6 +1,7 @@
 // live_renderer.cpp — see live_renderer.hpp. Extracted from boot_trace's PROSPER_RENDER lambda
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "live_renderer.hpp"
+#include "live_compute.hpp"
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
 #include "gpu/gpu_capture.hpp"          // temporal RTT capture/replay seeds
@@ -40,6 +41,7 @@ namespace prosper::frontend {
 namespace { struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; }; }
 
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
+    register_live_compute();
     // Resource tables are built before the submit reaches this callback. Publish the renderer's
     // default mode now so unmapped render-target descriptors remain available for RTT injection.
     // Outside a registered renderer, resource decoding retains its strict unknown-format policy.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1363,11 +1363,9 @@ void GpuState::apply(const Pm4Command& c) {
             }
             break;
         case K::DispatchDirect:
-            // Compute dispatch (issue #213 — DOLL's UE4 compute prologue). Recorded for stats/
-            // diagnostics only: prosper has no compute execution path yet. The fence cluster the
-            // guest builds around each dispatch (label init + EOP write + wait) completes at fold
-            // time independently of the dispatch itself, so skipping the shader work cannot hang
-            // the stream — it only leaves compute-written buffers stale (surfaced by the counter).
+            // Retain the dispatch and its exact register snapshot. The submit executor recompiles
+            // supported compute programs and runs them in this vector's stream order before exposing
+            // completion; unsupported programs remain visible in diagnostics (#576).
             if (state_dirty_ || !last_snapshot_) {
                 auto snap = std::make_shared<GpuState>();
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -136,6 +136,21 @@ struct ComputeLaunchDimensions {
 // to one so malformed/incomplete state never divides by zero.
 ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& dispatch);
 
+struct ComputeItem {
+    std::vector<uint32_t> spirv;
+    std::shared_ptr<ShaderResourceTable> resources;
+    ComputeLaunchDimensions launch;
+    uint64_t code_addr = 0;
+};
+
+using LiveComputeFn = std::function<bool(const std::vector<ComputeItem>& items)>;
+
+// Register the synchronous live compute backend. execute_compute_dispatches realizes every retained
+// dispatch from its state snapshot and invokes the backend in stream order.
+void set_submit_compute(LiveComputeFn fn);
+bool have_submit_compute();
+bool execute_compute_dispatches(const GpuState& st);
+
 // PROSPER_PROVENANCE_DIM=WxH: retain color-target address history across submits, then inspect
 // sampled images of that size and report the most recent draw that wrote the same guest address.
 // PROSPER_PROVENANCE_MIN_DRAWS=N limits expensive descriptor resolution to large target submits.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -10,6 +10,7 @@
 #include "agc_shader_layout.hpp"  // AgcShaderHeader + build_shader_resources
 #include "pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
 #include "rdna2_decode.hpp"       // rdna2_walk (for the vertex-fetch const-eval)
+#include "rdna2_to_spirv.hpp"     // recompile_compute
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -29,6 +30,7 @@ extern "C" const void* prosper_agc_shader_header_for_code(uint64_t code_addr);
 namespace prosper::gpu {
 namespace {
 LiveRenderFn g_live;   // empty until the runtime/test registers a device-backed renderer
+LiveComputeFn g_compute;   // synchronous compute backend, registered with the live Vulkan frontend
 
 // Read a 32-dword user-data SGPR block from a stage's register file. `base` = the stage's
 // SPI_SHADER_USER_DATA_*_0 register offset; absent registers read as 0. 32 (not 16) because NGG merged
@@ -868,6 +870,94 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     return out;
 }
 
+bool execute_compute_dispatches(const GpuState& st) {
+    if (!g_compute || st.dispatches.empty()) return false;
+    namespace P = prosper::agc::Pm4;
+    auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
+        auto it = regs.find(off);
+        return it == regs.end() ? 0u : it->second;
+    };
+
+    std::vector<ComputeItem> items;
+    items.reserve(st.dispatches.size());
+    for (const auto& dispatch : st.dispatches) {
+        const GpuState& ds = dispatch.state ? *dispatch.state : st;
+        const uint64_t code_addr = (static_cast<uint64_t>(rd(ds.sh, P::COMPUTE_PGM_LO)) << 8) |
+                                   (static_cast<uint64_t>(rd(ds.sh, P::COMPUTE_PGM_HI) & 0xffu) << 40);
+        const auto* header = static_cast<const AgcShaderHeader*>(
+            prosper_agc_shader_header_for_code(code_addr));
+        if (!header || !code_addr || !guest_readable(code_addr, sizeof(uint32_t))) {
+            static std::set<uint64_t> logged;
+            if (logged.insert(code_addr).second)
+                std::fprintf(stderr, "[compute] skip unregistered/unreadable program 0x%llx\n",
+                             (unsigned long long)code_addr);
+            continue;
+        }
+
+        uint32_t range_start = 0;
+        if (header->specials && guest_readable((uint64_t)(uintptr_t)header->specials,
+                                               sizeof(AgcShaderSpecials))) {
+            const uint32_t start = header->specials->user_data_range_start;
+            const uint32_t end = header->specials->user_data_range_end;
+            if (start < kUserSgprs && end > start && end <= 2 * kUserSgprs) range_start = start;
+        }
+        uint32_t sgprs[kUserSgprs] = {};
+        read_user_sgprs(ds.sh, P::COMPUTE_USER_DATA_0 + range_start, sgprs);
+        auto table = std::make_shared<ShaderResourceTable>(
+            build_shader_resources(*header, sgprs, kUserSgprs, 0));
+        assign_convention_bindings(*table, 2);
+
+        const uint32_t rsrc2 = rd(ds.sh, P::COMPUTE_PGM_RSRC2);
+        auto field = [&](uint32_t shift, uint32_t mask) { return (rsrc2 >> shift) & mask; };
+        ComputeShaderConfig config;
+        const uint32_t user_count = field(P::COMPUTE_PGM_RSRC2_USER_SGPR_SHIFT,
+                                          P::COMPUTE_PGM_RSRC2_USER_SGPR_MASK);
+        config.user_sgprs.assign(sgprs, sgprs + std::min(user_count, kUserSgprs));
+        const ComputeLaunchDimensions launch = resolve_compute_launch(dispatch);
+        config.local_x = launch.local_x;
+        config.local_y = launch.local_y;
+        config.local_z = launch.local_z;
+        config.tgid_x_en = field(P::COMPUTE_PGM_RSRC2_TGID_X_EN_SHIFT,
+                                 P::COMPUTE_PGM_RSRC2_TGID_X_EN_MASK) != 0;
+        config.tgid_y_en = field(P::COMPUTE_PGM_RSRC2_TGID_Y_EN_SHIFT,
+                                 P::COMPUTE_PGM_RSRC2_TGID_Y_EN_MASK) != 0;
+        config.tgid_z_en = field(P::COMPUTE_PGM_RSRC2_TGID_Z_EN_SHIFT,
+                                 P::COMPUTE_PGM_RSRC2_TGID_Z_EN_MASK) != 0;
+        config.tg_size_en = field(P::COMPUTE_PGM_RSRC2_TG_SIZE_EN_SHIFT,
+                                  P::COMPUTE_PGM_RSRC2_TG_SIZE_EN_MASK) != 0;
+        config.tidig_comp_cnt = field(P::COMPUTE_PGM_RSRC2_TIDIG_COMP_CNT_SHIFT,
+                                      P::COMPUTE_PGM_RSRC2_TIDIG_COMP_CNT_MASK);
+        config.lds_bytes = field(P::COMPUTE_PGM_RSRC2_LDS_SIZE_SHIFT,
+                                 P::COMPUTE_PGM_RSRC2_LDS_SIZE_MASK) * 512u;
+
+        ComputeItem item;
+        item.spirv = recompile_compute((const uint32_t*)(uintptr_t)code_addr, 0x10000,
+                                       table.get(), config);
+        item.resources = std::move(table);
+        item.launch = launch;
+        item.code_addr = code_addr;
+        if (item.spirv.empty()) {
+            static std::set<uint64_t> logged;
+            if (logged.insert(code_addr).second)
+                std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",
+                             (unsigned long long)code_addr);
+            continue;
+        }
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
+        if (!report.ok()) {
+            static std::set<uint64_t> logged;
+            if (logged.insert(code_addr).second)
+                std::fprintf(stderr, "[compute] skip invalid descriptor contract for program 0x%llx\n",
+                             (unsigned long long)code_addr);
+            continue;
+        }
+        items.push_back(std::move(item));
+    }
+    if (items.empty()) return false;
+    return g_compute(items);
+}
+
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     const char* enabled = getenv("PROSPER_COMPUTELOG");
     const char* dim_env = getenv("PROSPER_COMPUTELOG_DIM");
@@ -1081,6 +1171,8 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
 
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
 bool have_submit_renderer()               { return static_cast<bool>(g_live); }
+void set_submit_compute(LiveComputeFn fn) { g_compute = std::move(fn); }
+bool have_submit_compute()                { return static_cast<bool>(g_compute); }
 std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
                                          uint32_t width, uint32_t height) {
     return g_live ? g_live(items, width, height) : std::vector<uint8_t>{};

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -66,7 +66,8 @@ enum : uint32_t {
     SC_Workgroup=4, Scope_Workgroup=2, MemSem_WGAcqRel=0x108,   // LDS: Workgroup storage + barrier scope/semantics
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_Flat=14, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
-    BI_Position=0, BI_FragCoord=15, BI_LocalInvocationId=27, BI_GlobalInvocationId=28, BI_VertexIndex=42,
+    BI_Position=0, BI_FragCoord=15, BI_WorkgroupId=26, BI_LocalInvocationId=27,
+    BI_GlobalInvocationId=28, BI_VertexIndex=42,
 };
 
 uint32_t fbits(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
@@ -80,7 +81,8 @@ struct SpirvCompute {
     uint32_t stride = 1;
     // fixed ids (set in begin()):
     uint32_t t_void=0, t_fn=0, t_f32=0, t_u32=0, t_i32=0, t_v3u=0, t_bool=0, t_ptr_sb_f32=0;
-    uint32_t v_gid=0, v_in=0, v_out=0, gidx=0, f_main=0, glsl=0, bconst_false=0;
+    uint32_t v_gid=0, v_groupid=0, v_in=0, v_out=0, gidx=0, f_main=0, glsl=0, bconst_false=0;
+    uint32_t groupid[3] = {0, 0, 0}, localid_comp[3] = {0, 0, 0};
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
@@ -740,11 +742,12 @@ struct SpirvCompute {
     uint32_t land(uint32_t a, uint32_t b_) { uint32_t r = id(); put(code, Op_LogicalAnd, {t_bool, r, a, b_}); return r; }
     uint32_t lor(uint32_t a, uint32_t b_)  { uint32_t r = id(); put(code, Op_LogicalOr,  {t_bool, r, a, b_}); return r; }
 
-    void begin(uint32_t input_stride, const ShaderResourceTable* rt = nullptr) {
+    void begin(uint32_t input_stride, const ShaderResourceTable* rt = nullptr,
+               uint32_t local_x = 64, uint32_t local_y = 1, uint32_t local_z = 1) {
         stride = input_stride;
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_v3u = id(); t_bool = id();
         t_v4f = id();   // vec4<float>: needed by the sampled-texture path (image_sample) in a compute shader
-        uint32_t t_ptr_in_v3u = id(); v_gid = id(); v_localid = id();
+        uint32_t t_ptr_in_v3u = id(); v_gid = id(); v_groupid = id(); v_localid = id();
         uint32_t t_rta = id(), t_struct = id(), t_ptr_sb_struct = id();
         v_in = id(); v_out = id(); t_ptr_sb_f32 = id();
         f_main = id(); uint32_t lbl = id(); glsl = id();
@@ -753,9 +756,10 @@ struct SpirvCompute {
         { std::vector<uint32_t> o{glsl}; pstr(o, "GLSL.std.450"); putv(extimp, Op_ExtInstImport, o); }
         put(mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
         is_compute = true;
-        exec_model = Exec_GLCompute; iface = {v_gid, v_localid};   // EntryPoint deferred to finish()
-        put(exec, Op_ExecutionMode, {f_main, EM_LocalSize, 64, 1, 1});
+        exec_model = Exec_GLCompute; iface = {v_gid, v_groupid, v_localid};   // EntryPoint deferred to finish()
+        put(exec, Op_ExecutionMode, {f_main, EM_LocalSize, local_x, local_y, local_z});
         put(deco, Op_Decorate, {v_gid, Dec_BuiltIn, BI_GlobalInvocationId});
+        put(deco, Op_Decorate, {v_groupid, Dec_BuiltIn, BI_WorkgroupId});
         put(deco, Op_Decorate, {v_localid, Dec_BuiltIn, BI_LocalInvocationId});   // wave lane index (.x)
         put(deco, Op_Decorate, {t_rta, Dec_ArrayStride, 4});
         put(deco, Op_MemberDecorate, {t_struct, 0, Dec_Offset, 0});
@@ -772,6 +776,7 @@ struct SpirvCompute {
         put(types, Op_TypeBool, {t_bool});
         put(types, Op_TypePointer, {t_ptr_in_v3u, SC_Input, t_v3u});
         put(types, Op_Variable, {t_ptr_in_v3u, v_gid, SC_Input});
+        put(types, Op_Variable, {t_ptr_in_v3u, v_groupid, SC_Input});
         put(types, Op_Variable, {t_ptr_in_v3u, v_localid, SC_Input});
         put(types, Op_TypeRuntimeArray, {t_rta, t_f32});
         put(types, Op_TypeStruct, {t_struct, t_rta});
@@ -785,7 +790,16 @@ struct SpirvCompute {
         uint32_t ld = id(); put(code, Op_Load, {t_v3u, ld, v_gid});
         gidx = id(); put(code, Op_CompositeExtract, {t_u32, gidx, ld, 0});
         uint32_t ldl = id(); put(code, Op_Load, {t_v3u, ldl, v_localid});
-        localid = id(); put(code, Op_CompositeExtract, {t_u32, localid, ldl, 0});   // wave lane index
+        for (uint32_t c = 0; c < 3; c++) {
+            localid_comp[c] = id();
+            put(code, Op_CompositeExtract, {t_u32, localid_comp[c], ldl, c});
+        }
+        localid = localid_comp[0];   // wave lane index
+        uint32_t ldg = id(); put(code, Op_Load, {t_v3u, ldg, v_groupid});
+        for (uint32_t c = 0; c < 3; c++) {
+            groupid[c] = id();
+            put(code, Op_CompositeExtract, {t_u32, groupid[c], ldg, c});
+        }
     }
     // --- Fragment-shader shell: a location-0 vec4 color output; EXP MRT0 stores to it. ---
     uint32_t t_v4f = 0, v_color = 0;
@@ -3835,6 +3849,61 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     // value; if it was restored to all-lanes-on, every lane stores.
     if (!rs.exec_narrowed) b.store_output(outbits);
     else                   b.store_output_pred(outbits, rs.exec);
+    return b.finish();
+}
+
+std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
+                                        const ShaderResourceTable* rt,
+                                        const ComputeShaderConfig& config) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    SpirvCompute b;
+    if (config.lds_bytes) {
+        uint32_t dw = (config.lds_bytes + 3) / 4;
+        b.lds_dwords = std::min(16384u, std::max(1u, dw));
+    }
+    const uint32_t local_x = std::max(1u, config.local_x);
+    const uint32_t local_y = std::max(1u, config.local_y);
+    const uint32_t local_z = std::max(1u, config.local_z);
+    b.begin(1, rt, local_x, local_y, local_z);
+
+    RegState rs;
+    rs.vcc = b.bfalse();
+    rs.scc = b.bfalse();
+    rs.exec = b.btrue();
+    // Inline descriptors are represented by the resource table, not scalar SSA values. Leaving
+    // their SGPR range absent also preserves the existing direct-provenance rule: a format MUBUF may
+    // fall back to by_sgpr_base only while its SRSRC has not been overwritten by shader code.
+    std::set<uint32_t> descriptor_sgprs;
+    if (rt) {
+        for (const auto& resource : rt->resources) {
+            if (resource.srt_offset != 0xFFFFFFFFu || resource.sgpr_base == 0xFFFFFFFFu) continue;
+            uint32_t words = (resource.cls == ResourceClass::Texture ||
+                              resource.cls == ResourceClass::StorageImage) ? 8u : 4u;
+            for (uint32_t word = 0; word < words; word++)
+                descriptor_sgprs.insert(resource.sgpr_base + word);
+        }
+    }
+    for (size_t i = 0; i < config.user_sgprs.size(); i++)
+        if (!descriptor_sgprs.count(static_cast<uint32_t>(i)))
+            rs.sreg[static_cast<int>(i)] = b.uconst(config.user_sgprs[i]);
+
+    rs.vreg[0] = b.localid_comp[0];
+    if (config.tidig_comp_cnt >= 1) rs.vreg[1] = b.localid_comp[1];
+    if (config.tidig_comp_cnt >= 2) rs.vreg[2] = b.localid_comp[2];
+
+    int system_sgpr = static_cast<int>(config.user_sgprs.size());
+    if (config.tgid_x_en) rs.sreg[system_sgpr++] = b.groupid[0];
+    if (config.tgid_y_en) rs.sreg[system_sgpr++] = b.groupid[1];
+    if (config.tgid_z_en) rs.sreg[system_sgpr++] = b.groupid[2];
+    if (config.tg_size_en)
+        rs.sreg[system_sgpr] = b.uconst(local_x * local_y * local_z);
+
+    auto safe_branches = safe_execz_branches(ins);
+    for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);
+    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true,
+                   /*allow_smem*/true, [](const Rdna2Inst&) { return false; }, code, dwords))
+        return {};
     return b.finish();
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -29,6 +29,24 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      uint32_t num_inputs, uint32_t out_vgpr,
                                      const ShaderResourceTable* rt = nullptr, uint32_t lds_bytes = 0);
 
+// Register and launch state for a real compute program. User SGPR values are baked into the module
+// for one retained dispatch; enabled system SGPRs follow them in hardware order. TIDIG_COMP_CNT
+// controls whether local IDs seed v0 only (0), v0-v1 (1), or v0-v2 (2+).
+struct ComputeShaderConfig {
+    std::vector<uint32_t> user_sgprs;
+    uint32_t local_x = 64, local_y = 1, local_z = 1;
+    uint32_t tidig_comp_cnt = 0;
+    bool tgid_x_en = false, tgid_y_en = false, tgid_z_en = false;
+    bool tg_size_en = false;
+    uint32_t lds_bytes = 0;
+};
+
+// Translate a game compute program without the synthetic binding-0 input / binding-1 output used by
+// recompile_valu. Memory effects come only from the program's actual resource operations.
+std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
+                                        const ShaderResourceTable* rt,
+                                        const ComputeShaderConfig& config);
+
 // Recompile a pixel/fragment shader to a fragment SPIR-V module: run the VALU, and on EXP to an MRT
 // target write vec4(src0..3) to the location-0 color output. Returns {} if unsupported / no export.
 // An optional ShaderResourceTable enables memory ops (SMEM/MUBUF) with resolved bindings.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1063,6 +1063,10 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
     gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
+    if (gpu::have_submit_compute() && !agc_gpu_state().dispatches.empty() &&
+        !gpu::execute_compute_dispatches(agc_gpu_state()) && getenv("PROSPER_COMPUTELOG"))
+        fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
+                (unsigned long long)g_submit_count);
     // #312 EOP visibility contract: the pulse fires immediately only when no gated writes are
     // pending; otherwise it is OWED and delivered when the tail drains (the guest's completion
     // scan must never observe a half-retired frame — see command_processor.cpp). The flip and the
@@ -1182,6 +1186,10 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
     gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
+    if (gpu::have_submit_compute() && !agc_gpu_state().dispatches.empty() &&
+        !gpu::execute_compute_dispatches(agc_gpu_state()) && getenv("PROSPER_COMPUTELOG"))
+        fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
+                (unsigned long long)g_submit_count);
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
     // #312 EOP visibility contract: pulse only when no gated writes are pending, else owed until
@@ -1310,10 +1318,8 @@ HLE(agc_driver_get_resource_registration_max_name_length) {
 // modifier. Preserve thread counts here; the executor derives ceil(threads/local_size) groups
 // from the retained register snapshot (#580). Kyty's Gen4 GraphicsDispatchDirect is a differently
 // named API and is not an oracle for this Gen5 builder. DOLL's first real frame issues ~535 of
-// these (UE4's compute
-// prologue: GPUScene build, clears, culling) before any graphics draw. Appending the packet keeps
-// the stream faithful; the CommandProcessor records it (no compute execution yet — that is a later
-// milestone; the fence cluster around each dispatch completes at fold time regardless).
+// these (UE4's compute prologue: GPUScene build, clears, culling) before any graphics draw. Appending
+// the packet keeps the stream faithful; the CommandProcessor retains it for ordered submit execution.
 // CONFIDENCE: HIGH (PS5 symbol table + live kernel disassembly, register state, and descriptor sizes).
 HLE(agc_cb_dispatch) {  // (buf, thread_count_x, thread_count_y, thread_count_z, dispatch_modifier)
     uint32_t* cmd; if (!begin_packet(a0, 6, IT_NOP, R_DISPATCH_DIRECT, &cmd)) return 0;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1,0 +1,96 @@
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include "live_compute.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
+
+int main() {
+    // Dead Cells' bound startup fill kernel, copied verbatim from eboot.elf at runtime address
+    // 0x401aec200. It stores s4-s7 to record `(TGID_X << 6) + local_id_x` through the V# in s0-s3.
+    static const uint32_t code[] = {
+        0xd7460004, 0x04010c08, 0x7e000204, 0x7e020205, 0x7e040206,
+        0x7e060207, 0xe01c2000, 0x80000004, 0xbf810000,
+    };
+
+    constexpr uint32_t records = 130;
+    std::vector<uint32_t> result(records * 4, 0xcccccccc);
+    ShaderResourceTable rt;
+    ShaderResource buffer;
+    // Runtime metadata classifies compute direct type-1 V#s as ConstantBuffer even though MUBUF
+    // format stores use them; both classes lower to storage buffers.
+    buffer.cls = ResourceClass::ConstantBuffer;
+    buffer.format = DataFormat::Uint32;
+    buffer.num_components = 4;
+    buffer.binding = 2;
+    buffer.gpu_addr = (uint64_t)(uintptr_t)result.data();
+    buffer.size = records * 4 * sizeof(uint32_t);
+    buffer.stride = 4 * sizeof(uint32_t);
+    buffer.sgpr_base = 0;
+    rt.resources.push_back(buffer);
+
+    ComputeShaderConfig config;
+    config.user_sgprs = {
+        0, 0, 0, 0,
+        0x11223344, 0x55667788, 0x99aabbcc, 0xddeeff00,
+    };
+    config.local_x = 64;
+    config.tidig_comp_cnt = 0;
+    config.tgid_x_en = true;
+
+    std::vector<uint32_t> spirv = recompile_compute(
+        code, sizeof(code) / sizeof(code[0]), &rt, config);
+    CHECK(!spirv.empty(), "real Dead Cells compute kernel recompiles");
+    if (spirv.empty()) return 1;
+
+    auto report = validate_spirv_descriptor_interface(
+        spirv, &rt, 0, SpirvShaderStage::Compute);
+    for (const auto& issue : report.issues) {
+        if (issue.error)
+            std::printf("descriptor error: %s binding=%u expected=%s actual=%s\n",
+                        descriptor_issue_name(issue.code), issue.binding,
+                        spirv_descriptor_kind_name(issue.expected),
+                        spirv_descriptor_kind_name(issue.actual));
+    }
+    CHECK(report.ok(), "real compute descriptor interface validates");
+
+    ComputeItem item;
+    item.spirv = spirv;
+    item.resources = std::make_shared<ShaderResourceTable>(rt);
+    item.launch.threads_x = records;
+    item.launch.local_x = 64;
+    item.launch.groups_x = 3;
+    item.launch.local_y = item.launch.local_z = 1;
+    item.launch.groups_y = item.launch.groups_z = 1;
+    item.code_addr = 0x401aec200;
+    CHECK(prosper::frontend::execute_live_compute_items({item}),
+          "production live backend executes the game kernel");
+    CHECK(result.size() == records * 4, "compute resource retains its declared size");
+    const uint32_t expected[4] = {0x11223344, 0x55667788, 0x99aabbcc, 0xddeeff00};
+    bool all_filled = result.size() == records * 4;
+    for (uint32_t record = 0; record < records; record++) {
+        for (uint32_t component = 0; component < 4; component++) {
+            if (result[record * 4 + component] != expected[component]) {
+                std::printf("FAIL: record %u component %u = %08x, expected %08x\n",
+                            record, component, result[record * 4 + component], expected[component]);
+                all_filled = false;
+                break;
+            }
+        }
+        if (!all_filled) break;
+    }
+    CHECK(all_filled, "all 130 records are filled across three workgroups");
+
+    if (fails) {
+        std::printf("== FAIL: %d ==\n", fails);
+        return 1;
+    }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -26,6 +26,7 @@
 #include "gpu/rdna2_to_spirv.hpp"         // recompile_fragment (diagnostic solid-color PS)
 #include "../../tests/render_runner.h"   // offscreen Vulkan backend (render_triangle_rgba) + dump_bmp
 #include "../../frontends/shared/live_renderer.hpp"   // shared live renderer (also used by prosper-app)
+#include "../../frontends/shared/live_compute.hpp"    // synchronous AGC compute execution
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
@@ -185,6 +186,8 @@ int main(int argc, char** argv) {
     }
 
 #ifdef PROSPER_HAVE_VULKAN
+    // Compute is part of command submission even when frame rendering/dumping is disabled.
+    prosper::frontend::register_live_compute();
     // PROSPER_RENDER=1: register the live Vulkan renderer (shared with prosper-app via
     // frontends/shared/live_renderer) so execute_and_present composites every submitted Dcb with
     // draws and hands the frame to the present path; periodic BMP screenshots go to PROSPER_FRAME_DIR


### PR DESCRIPTION
Fixes #576.

## What changed
- add a production compute recompiler shell with real user SGPR values, local invocation IDs, enabled workgroup IDs, local size, and LDS sizing
- realize retained dispatch snapshots into validated `ComputeItem`s and execute them in stream order before submit completion becomes visible
- add a synchronous Vulkan storage-buffer backend with guarded guest upload, dispatch, fence wait, and guest-memory readback
- register compute independently of frame rendering; `PROSPER_COMPUTE=0` remains an explicit diagnostic escape hatch
- add before/after buffer hashes and changed-byte counts under `PROSPER_COMPUTELOG`
- update compatibility docs and the configured test count

This first execution slice intentionally rejects storage images and unsupported descriptor kinds instead of guessing their layout.

## Real-game proof
Dead Cells' exact nine-dword fill kernel executes at `0x401aec200` with the #580 launch contract. On the first live submit:
- 33,423,360-byte buffer: 8,355,840 bytes changed, FNV `33e3d65949850383 -> 6f02a4a1bd090383`
- 655,360-byte buffer: all 655,360 bytes changed, FNV `66fb17eebe150383 -> 2bb8dbdc63790383`
- repeated fills report zero changes once the target already contains the fill value

Execution evidence is in `C:\Users\matti\Downloads\ps5ys-deadcells-route\compute-execution\run.log`.

The deterministic gameplay route still reaches the Jump tutorial and remains mostly white. This rules out the exercised buffer fill kernel as the missing 642x362 producer; #566 has the screenshots and next investigation boundary.

## Verification
- 86/86 configured Linux tests pass
- new production-backend test recompiles and executes the exact Dead Cells kernel over 130 records / three 64-thread workgroups, including robust tail lanes
- Messenger guard passes at 24,318 colors
- Dead Cells same-binary A/B: `PROSPER_COMPUTE=0` matches the exact stored splash hash; default compute consistently selects a visually correct earlier Evil Empire animation frame (`891a80fc...`) because the guard uses a wall-clock warmup. Tracked in #573; baseline unchanged
- five post-warmup Dead Cells gameplay screenshots captured under `C:\Users\matti\Downloads\ps5ys-deadcells-route\compute-gameplay`