### PR TITLE
feat(gpu): trace guest writer provenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,11 @@ but the world is mostly white (#566). Version-4 `.prgcap` captures seed temporal
 first bad composition at draw 18; one 642x362 input has no prior color-target writer. The kernel-derived dispatch
 thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574)
 now execute the real fill kernel against guest buffers before submit completion (#576). The gameplay route remains
-mostly white, proving this buffer compute was not the missing 642x362 producer. The immediate frontier is writer
-provenance and storage-image compute, without assuming compute owns that surface (#566). The residual seeded replay
-mismatch (#569) and the animation-sensitive exact splash guard (#573) remain separate tooling issues.
+mostly white, but range provenance proves the missing 642x362 color target is backed by dispatch 5 of that compute
+fill. PM4 order is decisive: draw 19 consumes it, dispatch 5 fills it, then draw 31 consumes it again in one submit;
+prosper incorrectly batches compute before both draws (#584). The residual seeded replay mismatch (#569) and
+animation-sensitive exact splash guard (#573) remain separate tooling issues. `PROSPER_PROVENANCE_DIM=WxH` reports
+overlapping color, compute, DMA_DATA, and WRITE_DATA writers with submit/item/PM4 ordinals.
 `PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` are landed capabilities from #515.
 Do not restart the superseded
 Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.
@@ -136,7 +138,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 86/86 expected green on Linux
+  cmake --build . -j8 && ctest        # 87/87 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ accepts scripted gamepad input, and renders the first level.
   A scripted gamepad route produced a full-resolution sequence that was confirmed against PS5 hardware.
 - 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
   first playable scene. HUD and some composition are alive, but the world is mostly white. Capture/replay
-  isolated the first bad composition input. Its real buffer compute kernel now executes in stream order and
-  writes guest memory, but this does not recover the missing 642x362 scene input (#566, #576).
+  isolated the first bad composition input. Range provenance now identifies its 642x362 backing as a real
+  compute-filled buffer and exposes a draw-compute-draw ordering violation in the executor (#566, #584).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **86 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **87 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
@@ -103,7 +103,7 @@ Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the g
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # 86 self-checking tests
+ctest --test-dir build-linux          # 87 self-checking tests
 ```
 
 Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). A

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -366,6 +366,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_convention_bindings PRIVATE prosper_core)
   add_test(NAME convention_bindings COMMAND test_convention_bindings)
 
+  add_executable(test_writer_provenance tests/test_writer_provenance.cpp)
+  target_link_libraries(test_writer_provenance PRIVATE prosper_core)
+  add_test(NAME writer_provenance_ranges COMMAND test_writer_provenance)
+
   # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux only).
   if(UNIX AND NOT APPLE)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -38,8 +38,8 @@ possible without console keys. Dumps are user-supplied and gitignored.
   Version-4 GPU captures seed temporal render targets for faithful offline isolation (#568); one residual
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, and the title's direct type-1 buffer resource now execute correctly (#580/#576).
-- 🚧 **Active frontiers:** identify the actual producer of Dead Cells' missing 642x362 composition input;
-  buffer compute execution does not recover it (#566). Add storage-image compute and compute-writer provenance,
+- 🚧 **Active frontiers:** range provenance identifies Dead Cells' missing 642x362 color writer as a
+  compute-buffer fill between two consumers. Interleave compute and graphics by retained PM4 order (#584),
   stabilize the animation-sensitive exact splash guard (#573), and continue cross-title capture/replay and
   descriptor-validation work. UE4's measured GPU boundary remains tracked separately under its area issues.
 
@@ -72,7 +72,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # 86 self-checking tests
+ctest --test-dir build          # 87 self-checking tests
 ```
 Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -40,11 +40,11 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   the first bad composition at draw 18; its missing 642x362 input has no prior color-target writer. The corrected
   dispatch thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V#
   decoding (#574) now execute a valid registered fill program against real guest buffers before submit completion
-  (#576). The deterministic gameplay route remains mostly white, so this does not own the missing scene input.
-- **Immediate milestone:** extend provenance to identify compute/DMA/CPU writers, add storage-image compute, and
-  locate the actual producer of Dead Cells' missing surface (#566). Separately, resolve the seeded replay hash
-  mismatch (#569) and animation-sensitive splash snapshot (#573), while continuing the same capture/replay
-  workflow across Unity and Unreal targets.
+  (#576). Range provenance proves one submit orders a 642x362 consumer, dispatch 5's fill, then another consumer;
+  prosper currently batches the fill before both draws.
+- **Immediate milestone:** interleave compute and graphics by retained PM4 order (#584), then rerun the Dead Cells
+  route/capsule (#566). Separately, resolve the seeded replay hash mismatch (#569) and animation-sensitive splash
+  snapshot (#573), while continuing the same capture/replay workflow across Unity and Unreal targets.
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2,6 +2,7 @@
 
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"
+#include "gpu/writer_provenance.hpp"
 
 #include <vulkan/vulkan.h>
 
@@ -274,13 +275,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             std::memcpy(guest, result, buffer.resource->size);
             vkUnmapMemory(ctx.device, buffer.memory);
+            if (writer_provenance_enabled())
+                record_guest_write(GuestWriterKind::ComputeBuffer,
+                                   buffer.resource->gpu_addr, buffer.resource->size,
+                                   item.submit_no, item.dispatch_index,
+                                   item.command_order, item.code_addr);
         }
         if (!readback_ok) break;
         ok = true;
     } while (false);
 
     if (trace)
-        std::fprintf(stderr, "[compute] execute code=0x%llx groups=%ux%ux%u buffers=%zu result=%s\n",
+        std::fprintf(stderr, "[compute] execute submit=%llu dispatch=%llu code=0x%llx "
+                     "groups=%ux%ux%u buffers=%zu result=%s\n",
+                     (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
                      (unsigned long long)item.code_addr, item.launch.groups_x, item.launch.groups_y,
                      item.launch.groups_z, buffers.size(), ok ? "ok" : "failed");
     if (trace) {
@@ -288,10 +296,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (!buffer.resource) continue;
             std::fprintf(stderr,
                          "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
-                         "hash=%016llx->%016llx\n",
+                         "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x\n",
                          buffer.resource->binding, (unsigned long long)buffer.resource->gpu_addr,
                          buffer.resource->size, (unsigned long long)buffer.changed_bytes,
-                         (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash);
+                         (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash,
+                         buffer.resource->size >= 4 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[0] : 0,
+                         buffer.resource->size >= 8 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[1] : 0,
+                         buffer.resource->size >= 12 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[2] : 0,
+                         buffer.resource->size >= 16 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[3] : 0);
         }
     }
     cleanup();

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1,5 +1,6 @@
 // command_processor.cpp — see command_processor.hpp.
 #include "command_processor.hpp"
+#include "writer_provenance.hpp"
 #include "hle/sync_futex.hpp"   // wake_label_waiters (shared with sceKernelWaitOnAddress's futex)
 
 // hle_graphics.cpp: perform the videoout flip for an in-stream SetFlip packet — advances the flip
@@ -667,6 +668,9 @@ static void honor_dma_data(const Pm4Command& c) {
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   DmaData [0x%llx] := 0x%x (%u bytes)\n",
                 (unsigned long long)c.dd_dst, v32, c.dd_bytes);
+    if (writer_provenance_enabled() && c.dd_bytes >= 256)
+        record_guest_write(GuestWriterKind::DmaData, c.dd_dst, c.dd_bytes,
+                           0, 0, c.stream_order, pkt_addr(c));
     wake_on_label(c.dd_dst);
 }
 
@@ -687,6 +691,10 @@ static void honor_write_data(const Pm4Command& c) {
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   WriteData [0x%llx] %u dwords (first=0x%08x)\n",
                 (unsigned long long)c.wd_addr, c.wd_num, c.wd_data[0]);
+    if (writer_provenance_enabled() && c.wd_num >= 64)
+        record_guest_write(GuestWriterKind::WriteData, c.wd_addr,
+                           static_cast<uint64_t>(c.wd_num) * 4, 0, 0,
+                           c.stream_order, pkt_addr(c));
     wake_on_label(c.wd_addr);   // wake any sync_on_address futex waiter on this written label
 }
 
@@ -1177,6 +1185,7 @@ int flush_deferred_streams() {
 
 void GpuState::apply(const Pm4Command& c) {
     using K = Pm4Command::Kind;
+    command_order = c.stream_order ? c.stream_order : command_order + 1;
     switch (c.kind) {
         case K::SetRegsIndirect: {
             if (c.regs_vaddr == 0 || c.num_regs == 0 || c.num_regs > kMaxRegsPerPacket) return;
@@ -1256,6 +1265,7 @@ void GpuState::apply(const Pm4Command& c) {
                 d.from_offset = true;
             }
             draws.push_back(std::move(d));
+            draws.back().command_order = command_order;
             break;
         }
         case K::DrawIndexAuto:
@@ -1281,6 +1291,7 @@ void GpuState::apply(const Pm4Command& c) {
                 d.modifier = c.di_modifier;
             }
             draws.push_back(std::move(d));
+            draws.back().command_order = command_order;
             break;
         }
         case K::ReleaseMem:
@@ -1372,7 +1383,8 @@ void GpuState::apply(const Pm4Command& c) {
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
-            dispatches.push_back({c.threads_x, c.threads_y, c.threads_z, c.dispatch_modifier, last_snapshot_});
+            dispatches.push_back({c.threads_x, c.threads_y, c.threads_z,
+                                  c.dispatch_modifier, last_snapshot_, command_order});
             dispatch_count++;
             break;
         case K::SetPredication:
@@ -1457,7 +1469,10 @@ size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
     }
     std::vector<Pm4Command> ops;
     decode_pm4(buf, dwords, ops);
-    for (const auto& c : ops) st.apply(c);
+    for (auto& c : ops) {
+        c.stream_order = st.command_order + 1;
+        st.apply(c);
+    }
     return ops.size();
 }
 

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -56,6 +56,7 @@ struct GpuState {
         uint64_t index_base   = 0;
         uint32_t index_offset = 0;
         bool     from_offset  = false;
+        uint64_t command_order = 0;
     };
     std::vector<Draw> draws;                             // one per DrawIndexAuto / DrawIndex
     // Compute dispatch + register state AT the packet. Compute is not executed yet, but retaining
@@ -65,9 +66,11 @@ struct GpuState {
         uint32_t threads_x = 0, threads_y = 0, threads_z = 0;
         uint64_t modifier = 0;
         std::shared_ptr<const GpuState> state;
+        uint64_t command_order = 0;
     };
     std::vector<Dispatch> dispatches;                     // current submit's DispatchDirect packets
     uint64_t dispatch_count = 0;                          // process-lifetime DispatchDirect count
+    uint64_t command_order = 0;                           // process-lifetime applied PM4 ordinal
 
     // GPU predication window (#319): the 64-bit condition address the last SetPredication opened
     // (0 = no window). A packet-predicated Jump inside the window is executed/skipped on the

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -141,6 +141,9 @@ struct ComputeItem {
     std::shared_ptr<ShaderResourceTable> resources;
     ComputeLaunchDimensions launch;
     uint64_t code_addr = 0;
+    uint64_t dispatch_index = 0;
+    uint64_t submit_no = 0;
+    uint64_t command_order = 0;
 };
 
 using LiveComputeFn = std::function<bool(const std::vector<ComputeItem>& items)>;
@@ -149,10 +152,10 @@ using LiveComputeFn = std::function<bool(const std::vector<ComputeItem>& items)>
 // dispatch from its state snapshot and invokes the backend in stream order.
 void set_submit_compute(LiveComputeFn fn);
 bool have_submit_compute();
-bool execute_compute_dispatches(const GpuState& st);
+bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no = 0);
 
-// PROSPER_PROVENANCE_DIM=WxH: retain color-target address history across submits, then inspect
-// sampled images of that size and report the most recent draw that wrote the same guest address.
+// PROSPER_PROVENANCE_DIM=WxH: inspect sampled images of that size and report overlapping
+// color, compute, DMA_DATA, and WRITE_DATA events with both observation and PM4 ordering.
 // PROSPER_PROVENANCE_MIN_DRAWS=N limits expensive descriptor resolution to large target submits.
 void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no);
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -11,6 +11,7 @@
 #include "pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
 #include "rdna2_decode.hpp"       // rdna2_walk (for the vertex-fetch const-eval)
 #include "rdna2_to_spirv.hpp"     // recompile_compute
+#include "writer_provenance.hpp"
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -870,7 +871,7 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     return out;
 }
 
-bool execute_compute_dispatches(const GpuState& st) {
+bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     if (!g_compute || st.dispatches.empty()) return false;
     namespace P = prosper::agc::Pm4;
     auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
@@ -880,7 +881,8 @@ bool execute_compute_dispatches(const GpuState& st) {
 
     std::vector<ComputeItem> items;
     items.reserve(st.dispatches.size());
-    for (const auto& dispatch : st.dispatches) {
+    for (size_t dispatch_index = 0; dispatch_index < st.dispatches.size(); dispatch_index++) {
+        const auto& dispatch = st.dispatches[dispatch_index];
         const GpuState& ds = dispatch.state ? *dispatch.state : st;
         const uint64_t code_addr = (static_cast<uint64_t>(rd(ds.sh, P::COMPUTE_PGM_LO)) << 8) |
                                    (static_cast<uint64_t>(rd(ds.sh, P::COMPUTE_PGM_HI) & 0xffu) << 40);
@@ -936,6 +938,9 @@ bool execute_compute_dispatches(const GpuState& st) {
         item.resources = std::move(table);
         item.launch = launch;
         item.code_addr = code_addr;
+        item.dispatch_index = dispatch_index;
+        item.submit_no = submit_no;
+        item.command_order = dispatch.command_order;
         if (item.spirv.empty()) {
             static std::set<uint64_t> logged;
             if (logged.insert(code_addr).second)
@@ -1111,6 +1116,7 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
         GpuState::Draw draw_record{};
     };
     static std::unordered_map<uint64_t, ColorWrite> last_color_write;
+    static std::set<uint64_t> recorded_color_ranges;
     static uint64_t draw_submit_ordinal = 0;
     const uint64_t this_draw_submit = st.draws.empty() ? draw_submit_ordinal : draw_submit_ordinal++;
 
@@ -1125,24 +1131,53 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
             auto prt = build_stage_table(ds, rs.ps_addr, true);
             if (prt) for (const auto& r : prt->resources) {
                 if (r.width != want_w || r.height != want_h) continue;
+                const uint64_t resource_size = r.size ? r.size :
+                    static_cast<uint64_t>(r.width) * r.height * 4;
+                auto writer = last_guest_write_overlap(r.gpu_addr, resource_size);
+                if (writer) {
+                    fprintf(stderr,
+                            "[provenance]   latest-recorded-overlap kind=%s seq=%llu "
+                            "range=[0x%llx,+0x%llx) "
+                            "submit=%llu item=%llu order=%llu identity=0x%llx dims=%ux%u\n",
+                            guest_writer_kind_name(writer->kind),
+                            (unsigned long long)writer->sequence,
+                            (unsigned long long)writer->addr,
+                            (unsigned long long)writer->size,
+                            (unsigned long long)writer->submit,
+                            (unsigned long long)writer->item,
+                            (unsigned long long)writer->order,
+                            (unsigned long long)writer->identity,
+                            writer->width, writer->height);
+                } else {
+                    fprintf(stderr,
+                            "[provenance]   no recorded color/compute/DMA/WRITE_DATA overlap for "
+                            "[0x%llx,+0x%llx)\n",
+                            (unsigned long long)r.gpu_addr,
+                            (unsigned long long)resource_size);
+                }
                 auto it = last_color_write.find(r.gpu_addr);
                 if (it == last_color_write.end()) {
                     fprintf(stderr,
                             "[provenance] consumer submit=%llu draw=%zu ps=0x%llx samples "
-                            "addr=0x%llx dims=%ux%u draw_submit=%llu: no prior color-target write\n",
+                            "addr=0x%llx dims=%ux%u draw_submit=%llu order=%llu: "
+                            "no prior color-target write\n",
                             (unsigned long long)submit_no, i, (unsigned long long)rs.ps_addr,
                             (unsigned long long)r.gpu_addr, r.width, r.height,
-                            (unsigned long long)this_draw_submit);
+                            (unsigned long long)this_draw_submit,
+                            (unsigned long long)st.draws[i].command_order);
                 } else {
                     const ColorWrite& w = it->second;
                     fprintf(stderr,
                             "[provenance] consumer submit=%llu draw=%zu ps=0x%llx samples "
-                            "addr=0x%llx dims=%ux%u draw_submit=%llu: last color write submit=%llu "
+                            "addr=0x%llx dims=%ux%u draw_submit=%llu order=%llu: "
+                            "last color write submit=%llu "
                             "draw_submit=%llu draw=%zu target_extent=%ux%u "
                             "vs=0x%llx ps=0x%llx\n",
                             (unsigned long long)submit_no, i, (unsigned long long)rs.ps_addr,
                             (unsigned long long)r.gpu_addr, r.width, r.height,
-                            (unsigned long long)this_draw_submit, (unsigned long long)w.submit,
+                            (unsigned long long)this_draw_submit,
+                            (unsigned long long)st.draws[i].command_order,
+                            (unsigned long long)w.submit,
                             (unsigned long long)w.draw_submit, w.draw, w.width, w.height,
                             (unsigned long long)w.vs, (unsigned long long)w.ps);
                     static std::set<uint64_t> probed;
@@ -1161,11 +1196,21 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
             }
         }
 
-        if (rs.color0_base)
+        if (rs.color0_base) {
             last_color_write[rs.color0_base] = {
                 submit_no, this_draw_submit, i, rs.es_addr, rs.ps_addr,
                 rs.color0_width, rs.color0_height, st.draws[i]
             };
+            // The exact-address map above retains every latest color writer. The generic overlap
+            // history needs only one representative event per target range; recording every draw
+            // adds millions of mutex/hash operations during Dead Cells' submit-heavy startup.
+            if (recorded_color_ranges.insert(rs.color0_base).second) {
+                const uint64_t bytes = static_cast<uint64_t>(rs.color0_width) * rs.color0_height * 4;
+                record_guest_write(GuestWriterKind::ColorTarget, rs.color0_base, bytes,
+                                   submit_no, i, st.draws[i].command_order, rs.ps_addr,
+                                   rs.color0_width, rs.color0_height);
+            }
+        }
     }
 }
 

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -52,6 +52,7 @@ struct Pm4Command {
         DmaData, Unknown,
     } kind = Kind::Unknown;
 
+    uint64_t stream_order = 0;          // assigned before apply and retained by deferred effects
     uint32_t        header = 0;
     uint32_t        op = 0, r = 0, len = 0;   // op, sub-op, total dwords (incl. header)
     const uint32_t* payload = nullptr;        // points at header+1 (len-1 dwords)

--- a/prosper/src/gpu/writer_provenance.cpp
+++ b/prosper/src/gpu/writer_provenance.cpp
@@ -1,0 +1,105 @@
+#include "writer_provenance.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <cstdlib>
+#include <limits>
+#include <mutex>
+#include <unordered_map>
+
+namespace prosper::gpu {
+namespace {
+
+constexpr size_t kMaxEvents = 65536;
+std::mutex g_mutex;
+struct EventKey {
+    GuestWriterKind kind;
+    uint64_t addr;
+    bool operator==(const EventKey& other) const { return kind == other.kind && addr == other.addr; }
+};
+struct EventKeyHash {
+    size_t operator()(const EventKey& key) const {
+        return (static_cast<size_t>(key.kind) << 61) ^
+               static_cast<size_t>(key.addr ^ (key.addr >> 32));
+    }
+};
+std::unordered_map<EventKey, GuestWriteEvent, EventKeyHash> g_events;
+std::atomic<uint64_t> g_sequence{0};
+
+uint64_t span_end(uint64_t addr, uint64_t size) {
+    if (size > std::numeric_limits<uint64_t>::max() - addr)
+        return std::numeric_limits<uint64_t>::max();
+    return addr + size;
+}
+
+} // namespace
+
+bool writer_provenance_enabled() {
+    const char* explicit_mode = std::getenv("PROSPER_WRITER_PROVENANCE");
+    const char* dimension_mode = std::getenv("PROSPER_PROVENANCE_DIM");
+    const bool explicitly_on = explicit_mode && *explicit_mode &&
+                               std::strcmp(explicit_mode, "0") &&
+                               std::strcmp(explicit_mode, "off");
+    return explicitly_on || (dimension_mode && *dimension_mode);
+}
+
+const char* guest_writer_kind_name(GuestWriterKind kind) {
+    switch (kind) {
+        case GuestWriterKind::ColorTarget: return "color";
+        case GuestWriterKind::ComputeBuffer: return "compute-buffer";
+        case GuestWriterKind::DmaData: return "dma-data";
+        case GuestWriterKind::WriteData: return "write-data";
+    }
+    return "unknown";
+}
+
+uint64_t record_guest_write(GuestWriterKind kind, uint64_t addr, uint64_t size,
+                            uint64_t submit, uint64_t item, uint64_t order, uint64_t identity,
+                            uint32_t width, uint32_t height) {
+    if (!addr || !size) return 0;
+    GuestWriteEvent event;
+    event.sequence = g_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    event.kind = kind;
+    event.addr = addr;
+    event.size = size;
+    event.submit = submit;
+    event.item = item;
+    event.order = order;
+    event.identity = identity;
+    event.width = width;
+    event.height = height;
+    std::lock_guard<std::mutex> lock(g_mutex);
+    EventKey key{kind, addr};
+    if (g_events.size() == kMaxEvents && !g_events.count(key)) {
+        auto oldest = g_events.begin();
+        for (auto it = g_events.begin(); it != g_events.end(); ++it)
+            if (it->second.sequence < oldest->second.sequence) oldest = it;
+        g_events.erase(oldest);
+    }
+    g_events[key] = event;
+    return event.sequence;
+}
+
+std::optional<GuestWriteEvent> last_guest_write_overlap(uint64_t addr, uint64_t size,
+                                                        uint64_t before_sequence) {
+    if (!addr || !size) return std::nullopt;
+    const uint64_t end = span_end(addr, size);
+    std::lock_guard<std::mutex> lock(g_mutex);
+    std::optional<GuestWriteEvent> latest;
+    for (const auto& pair : g_events) {
+        const GuestWriteEvent& event = pair.second;
+        if (event.sequence >= before_sequence) continue;
+        if (addr < span_end(event.addr, event.size) && event.addr < end &&
+            (!latest || event.sequence > latest->sequence))
+            latest = event;
+    }
+    return latest;
+}
+
+void reset_guest_write_history_for_test() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_events.clear();
+    g_sequence.store(0, std::memory_order_relaxed);
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/writer_provenance.hpp
+++ b/prosper/src/gpu/writer_provenance.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace prosper::gpu {
+
+enum class GuestWriterKind : uint8_t {
+    ColorTarget,
+    ComputeBuffer,
+    DmaData,
+    WriteData,
+};
+
+struct GuestWriteEvent {
+    uint64_t sequence = 0;
+    GuestWriterKind kind = GuestWriterKind::ColorTarget;
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    uint64_t submit = 0;
+    uint64_t item = 0;
+    uint64_t order = 0;
+    uint64_t identity = 0;
+    uint32_t width = 0, height = 0;
+};
+
+// The opt-in live history is enabled by either the existing dimension probe or its explicit alias.
+bool writer_provenance_enabled();
+const char* guest_writer_kind_name(GuestWriterKind kind);
+
+uint64_t record_guest_write(GuestWriterKind kind, uint64_t addr, uint64_t size,
+                            uint64_t submit = 0, uint64_t item = 0, uint64_t order = 0,
+                            uint64_t identity = 0,
+                            uint32_t width = 0, uint32_t height = 0);
+std::optional<GuestWriteEvent> last_guest_write_overlap(uint64_t addr, uint64_t size,
+                                                        uint64_t before_sequence = UINT64_MAX);
+
+// Test-only reset for the process-global bounded history.
+void reset_guest_write_history_for_test();
+
+} // namespace prosper::gpu

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1062,11 +1062,11 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
-    gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     if (gpu::have_submit_compute() && !agc_gpu_state().dispatches.empty() &&
-        !gpu::execute_compute_dispatches(agc_gpu_state()) && getenv("PROSPER_COMPUTELOG"))
+        !gpu::execute_compute_dispatches(agc_gpu_state(), g_submit_count) && getenv("PROSPER_COMPUTELOG"))
         fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
                 (unsigned long long)g_submit_count);
+    gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     // #312 EOP visibility contract: the pulse fires immediately only when no gated writes are
     // pending; otherwise it is OWED and delivered when the tail drains (the guest's completion
     // scan must never observe a half-retired frame — see command_processor.cpp). The flip and the
@@ -1185,11 +1185,11 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
-    gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     if (gpu::have_submit_compute() && !agc_gpu_state().dispatches.empty() &&
-        !gpu::execute_compute_dispatches(agc_gpu_state()) && getenv("PROSPER_COMPUTELOG"))
+        !gpu::execute_compute_dispatches(agc_gpu_state(), g_submit_count) && getenv("PROSPER_COMPUTELOG"))
         fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
                 (unsigned long long)g_submit_count);
+    gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
     // #312 EOP visibility contract: pulse only when no gated writes are pending, else owed until

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -226,6 +226,9 @@ int main() {
                   "dispatch 1 snapshot retains updated compute user data");
             CHECK(cs.dispatches[1].threads_x == 8 && cs.dispatches[1].threads_y == 2 &&
                   cs.dispatches[1].threads_z == 3, "dispatch 1 asymmetric thread counts retained");
+            CHECK(cs.dispatches[0].command_order > 0 &&
+                  cs.dispatches[0].command_order < cs.dispatches[1].command_order,
+                  "dispatches retain monotonic PM4 stream order");
         }
     }
 

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -69,6 +69,9 @@ int main() {
     item.launch.local_y = item.launch.local_z = 1;
     item.launch.groups_y = item.launch.groups_z = 1;
     item.code_addr = 0x401aec200;
+    item.dispatch_index = 7;
+    item.submit_no = 11;
+    item.command_order = 70;
     CHECK(prosper::frontend::execute_live_compute_items({item}),
           "production live backend executes the game kernel");
     CHECK(result.size() == records * 4, "compute resource retains its declared size");

--- a/prosper/tests/test_writer_provenance.cpp
+++ b/prosper/tests/test_writer_provenance.cpp
@@ -1,0 +1,38 @@
+#include "../src/gpu/writer_provenance.hpp"
+
+#include <cstdio>
+#include <string>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
+
+int main() {
+    reset_guest_write_history_for_test();
+    const uint64_t first = record_guest_write(
+        GuestWriterKind::DmaData, 0x1000, 0x100, 4, 7, 40, 0xaaa);
+    const uint64_t second = record_guest_write(
+        GuestWriterKind::ComputeBuffer, 0x1080, 0x80, 5, 2, 50, 0xbbb);
+    record_guest_write(GuestWriterKind::WriteData, UINT64_MAX - 7, 16, 6, 1, 60, 0xccc);
+
+    auto latest = last_guest_write_overlap(0x10f0, 0x40);
+    CHECK(latest && latest->kind == GuestWriterKind::ComputeBuffer && latest->sequence == second,
+          "latest overlapping writer wins");
+    CHECK(latest && latest->submit == 5 && latest->item == 2 && latest->order == 50 &&
+          latest->identity == 0xbbb,
+          "writer metadata survives the range history");
+    auto earlier = last_guest_write_overlap(0x10f0, 0x40, second);
+    CHECK(earlier && earlier->kind == GuestWriterKind::DmaData && earlier->sequence == first,
+          "before-sequence query returns the preceding writer");
+    CHECK(!last_guest_write_overlap(0x2000, 0x20), "disjoint ranges do not match");
+    auto wrapped = last_guest_write_overlap(UINT64_MAX - 3, 4);
+    CHECK(wrapped && wrapped->kind == GuestWriterKind::WriteData,
+          "overflowing address spans clamp and still overlap safely");
+    CHECK(std::string(guest_writer_kind_name(GuestWriterKind::ColorTarget)) == "color",
+          "writer kind has a stable diagnostic name");
+
+    if (fails) return 1;
+    std::printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a bounded, thread-safe guest writer range history for color targets, compute readbacks, DMA_DATA, and WRITE_DATA
- retain process-lifetime PM4 ordinals on draws, dispatches, deferred memory effects, and compute work
- report overlapping writers for `PROSPER_PROVENANCE_DIM=WxH` with executor-observed and PM4 ordering metadata
- update the project docs with the concrete Dead Cells draw-compute-draw violation and #584 as the next executor milestone

## Dead Cells finding
The 642x362 sampled backing range is consumed at PM4 order 2109858, filled by dispatch 5 (`0x401aec200`) at 2109892, and consumed again at 2110017 in submit 27040. Prosper currently executes all compute before all graphics, so the first draw observes a future fill. The behavior fix is tracked separately in #584.

## Verification
- `cmake --build . -j8`
- `ctest --output-on-failure`: 87/87 passed
- Messenger snapshot guard: 24,318 colors
- Dead Cells `PROSPER_COMPUTE=0`: exact golden baseline
- Dead Cells default compute: known earlier animation frame tracked by #573

Fixes #583