### PR TITLE
fix(gpu): preserve mixed submit order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,12 +101,13 @@ Dead Cells now has a deterministic route through splash/menu into gameplay. HUD 
 but the world is mostly white (#566). Version-4 `.prgcap` captures seed temporal RTT inputs (#568) and isolate the
 first bad composition at draw 18; one 642x362 input has no prior color-target writer. The kernel-derived dispatch
 thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574)
-now execute the real fill kernel against guest buffers before submit completion (#576). The gameplay route remains
-mostly white, but range provenance proves the missing 642x362 color target is backed by dispatch 5 of that compute
-fill. PM4 order is decisive: draw 19 consumes it, dispatch 5 fills it, then draw 31 consumes it again in one submit;
-prosper incorrectly batches compute before both draws (#584). The residual seeded replay mismatch (#569) and
-animation-sensitive exact splash guard (#573) remain separate tooling issues. `PROSPER_PROVENANCE_DIM=WxH` reports
-overlapping color, compute, DMA_DATA, and WRITE_DATA writers with submit/item/PM4 ordinals.
+now execute the real fill kernel against guest buffers before submit completion (#576). Range provenance proved
+draw 19 consumes one backing, dispatch 5 fills it, then draw 31 consumes it again in one submit. Graphics spans and
+compute now execute by retained PM4 order (#584), fixing that future-read and changing the first gameplay frame;
+the scene still settles to the overbright composition tracked by #586. The residual seeded replay mismatch (#569)
+and animation-sensitive exact splash guard (#573) remain separate tooling issues.
+`PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
+submit/item/PM4 ordinals.
 `PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` are landed capabilities from #515.
 Do not restart the superseded
 Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ accepts scripted gamepad input, and renders the first level.
   A scripted gamepad route produced a full-resolution sequence that was confirmed against PS5 hardware.
 - 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
   first playable scene. HUD and some composition are alive, but the world is mostly white. Capture/replay
-  isolated the first bad composition input. Range provenance now identifies its 642x362 backing as a real
-  compute-filled buffer and exposes a draw-compute-draw ordering violation in the executor (#566, #584).
+  isolated the first bad composition input. Graphics and compute now execute by retained PM4 order (#584),
+  fixing a proven future-read; the settled overbright composition remains under investigation (#566, #586).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -37,9 +37,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   into the first playable scene. HUD and some composition render, but the world is mostly white (#566).
   Version-4 GPU captures seed temporal render targets for faithful offline isolation (#568); one residual
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
-  compute program binding, and the title's direct type-1 buffer resource now execute correctly (#580/#576).
-- 🚧 **Active frontiers:** range provenance identifies Dead Cells' missing 642x362 color writer as a
-  compute-buffer fill between two consumers. Interleave compute and graphics by retained PM4 order (#584),
+  compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
+  (#580/#576/#584).
+- 🚧 **Active frontiers:** diagnose Dead Cells' settled overbright composition after the ordering fix (#586),
   stabilize the animation-sensitive exact splash guard (#573), and continue cross-title capture/replay and
   descriptor-validation work. UE4's measured GPU boundary remains tracked separately under its area issues.
 

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -40,10 +40,12 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   the first bad composition at draw 18; its missing 642x362 input has no prior color-target writer. The corrected
   dispatch thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V#
   decoding (#574) now execute a valid registered fill program against real guest buffers before submit completion
-  (#576). Range provenance proves one submit orders a 642x362 consumer, dispatch 5's fill, then another consumer;
-  prosper currently batches the fill before both draws.
-- **Immediate milestone:** interleave compute and graphics by retained PM4 order (#584), then rerun the Dead Cells
-  route/capsule (#566). Separately, resolve the seeded replay hash mismatch (#569) and animation-sensitive splash
+  (#576). Range provenance proved one submit orders a 642x362 consumer, dispatch 5's fill, then another consumer.
+  Graphics spans and compute now execute by that retained PM4 order (#584); the first gameplay frame changes, but
+  subsequent frames still settle to the prior overbright composition.
+- **Immediate milestone:** isolate the remaining settled Dead Cells composition defect (#586), including live
+  per-consumer resource versions and dark/overbright captures. Separately, resolve the seeded replay hash
+  mismatch (#569) and animation-sensitive splash
   snapshot (#573), while continuing the same capture/replay workflow across Unity and Unreal targets.
 
 ## Historical status (2026-07-05) - retained for the milestone log

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -78,6 +78,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     prosper::gpu::set_submit_renderer(
         [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
             using RC = prosper::gpu::ResourceClass;
+            const prosper::gpu::LiveRenderPhase phase = prosper::gpu::live_render_phase();
             // PROSPER_RENDER_FIRST=<N>: skip the slow (~400x) Vulkan render for the first N GPU submits, so
             // the game reaches a LATE scene (e.g. the level1 cutscene, which only starts submitting after
             // ~5000 title-loop submits) at native speed before we begin rendering/dumping. Returning {}
@@ -96,12 +97,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // window so a diagnostic slice at a late stall (RENDER_FIRST..RENDER_LAST) does not accumulate
             // unbounded RTT/GPU resources across tens of thousands of submits (which OOM-kills the process).
             static int g_render_last = getenv("PROSPER_RENDER_LAST") ? atoi(getenv("PROSPER_RENDER_LAST")) : INT_MAX;
-            int g_this_submit = g_submit_idx++;
+            static thread_local int g_this_submit = -1;
+            if (phase.first_span || g_this_submit < 0) g_this_submit = g_submit_idx++;
             if (g_this_submit > g_render_last) return {};
             // PROSPER_SUBMITLOG: print the GPU-submit index periodically (at native speed, before the slow
             // render) so it can be correlated with guest-side log lines (e.g. a MsgDialog wait) to find the
             // exact submit at which a scene appears — for aiming PROSPER_RENDER_FIRST at it.
-            if (getenv("PROSPER_SUBMITLOG") && (g_this_submit % 1000 == 0))
+            if (phase.first_span && getenv("PROSPER_SUBMITLOG") && (g_this_submit % 1000 == 0))
                 fprintf(stderr, "[submit] index=%d (%zu draw items)\n", g_this_submit, items.size());
             if (const char* sd = getenv("PROSPER_SUBMITLOG_DIM")) {
                 uint32_t sw = 0, sh = 0;
@@ -864,6 +866,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fprintf(stderr, ") px_nonzero=%zu cache_size=%zu\n", nz, g_rtt.size()); }
                 }
             }
+            // Ordered submits may invoke this callback for several graphics spans separated by
+            // compute dispatches. Intermediate spans only update g_rtt. At the final span, recover
+            // the flipped scanout from that persistent cache even when it was rendered earlier in
+            // the transaction, and advance frame/dump state exactly once.
+            if (phase.final_span && pertarget) {
+                auto cached_scanout = [&](uint64_t addr) -> const RttSurf* {
+                    auto it = g_rtt.find(addr);
+                    if (it == g_rtt.end() || it->second.w != w || it->second.h != h ||
+                        it->second.rgba.size() != (size_t)w * h * 4) return nullptr;
+                    return &it->second;
+                };
+                const int front = prosper::gpu::present_front_index();
+                const RttSurf* scanout = front >= 0
+                    ? cached_scanout(prosper_vo_buffer_addr(front)) : nullptr;
+                if (!scanout) {
+                    for (int i = 0; i < prosper_vo_buffer_count(); ++i)
+                        if ((scanout = cached_scanout(prosper_vo_buffer_addr(i)))) break;
+                }
+                if (scanout) px = scanout->rgba;
+            }
+            if (!phase.final_span) return px;
             int n = frame_no++;
             // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
             // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -19,5 +19,5 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
 
 The long renderer warmup makes this route practical under llvmpipe, but it can
 skip one-time GPU producers. The current post-warmup gameplay image is tracked
-in issue #566 and must not be used as a golden visual checkpoint until that
-warmup artifact has been separated from genuine renderer behavior.
+in issues #566/#586 and must not be used as a golden visual checkpoint until
+the warmup artifact has been separated from genuine renderer behavior.

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -50,6 +50,8 @@ struct DrawItem {
     // memory — the scene RT is never populated on the CPU side — and the frame is a black composite).
     uint64_t color0_base = 0;
     uint32_t color0_width = 0, color0_height = 0;
+    uint64_t draw_index = 0;
+    uint64_t command_order = 0;
 };
 
 // The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8
@@ -152,7 +154,17 @@ using LiveComputeFn = std::function<bool(const std::vector<ComputeItem>& items)>
 // dispatch from its state snapshot and invokes the backend in stream order.
 void set_submit_compute(LiveComputeFn fn);
 bool have_submit_compute();
+std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st,
+                                                     uint64_t submit_no = 0);
 bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no = 0);
+
+enum class SubmitOperationKind : uint8_t { Draw, Dispatch };
+struct SubmitOperation {
+    SubmitOperationKind kind = SubmitOperationKind::Draw;
+    size_t index = 0;
+    uint64_t command_order = 0;
+};
+std::vector<SubmitOperation> plan_submit_operations(const GpuState& st);
 
 // PROSPER_PROVENANCE_DIM=WxH: inspect sampled images of that size and report overlapping
 // color, compute, DMA_DATA, and WRITE_DATA events with both observation and PM4 ordering.
@@ -528,10 +540,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
 // full present-resolution pixels; when we render into a reduced-resolution framebuffer (PROSPER_RENDER_SCALE)
 // the viewport must shrink by the same ratio, or a full-res viewport into a small framebuffer clips the
 // image to its bottom-left corner. Default 1.0 (full-res / tests: no change).
-inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
-                                             uint32_t max_shader_dwords = 0x10000,
-                                             float vp_scale_x = 1.0f, float vp_scale_y = 1.0f) {
-    if (st.draws.empty() || !render) return {};              // nothing to render (e.g. a state-only submit)
+inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
+                                                    uint32_t max_shader_dwords = 0x10000,
+                                                    float vp_scale_x = 1.0f,
+                                                    float vp_scale_y = 1.0f) {
+    if (st.draws.empty()) return {};
     // PROSPER_EXECLOG: just the per-draw bail-point/skip logs, without PROSPER_GFXLOG's per-packet
     // firehose (which is GBs over a minutes-long run) — for "which draws skip and why" surveys (#319).
     const bool log = getenv("PROSPER_GFXLOG") != nullptr ||
@@ -545,21 +558,28 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
     // CONFIDENCE: MED — verified multi-draw scenes render their content per-draw vs. a blank clear folded.
     static const bool force_perdraw = getenv("PROSPER_PERDRAW") != nullptr;
     static const bool force_folded  = getenv("PROSPER_FOLDED") != nullptr;
-    const bool perdraw = force_perdraw || (!force_folded && st.draws.size() > 1);
+    const bool perdraw = force_perdraw ||
+                         (!force_folded && (st.draws.size() > 1 || !st.dispatches.empty()));
     std::vector<DrawItem> items;
     if (perdraw) {
         for (size_t i = 0; i < st.draws.size(); i++) {
             DrawItem it;
             if (realize_draw_item(st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
-                                  max_shader_dwords, log, it))
+                                  max_shader_dwords, log, it)) {
+                it.draw_index = i;
+                it.command_order = st.draws[i].command_order;
                 items.push_back(std::move(it));
+            }
         }
     } else {
         // Default: render the submit's last draw from the folded end state as a single item.
         DrawItem it;
         const GpuState::Draw& last = st.draws.back();
-        if (realize_draw_item(st, &last, last.index_count, max_shader_dwords, log, it))
+        if (realize_draw_item(st, &last, last.index_count, max_shader_dwords, log, it)) {
+            it.draw_index = st.draws.size() - 1;
+            it.command_order = last.command_order;
             items.push_back(std::move(it));
+        }
     }
     if (getenv("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu perdraw=%d -> %zu item(s): raw index_counts=[",
         st.draws.size(), (int)perdraw, items.size());
@@ -579,6 +599,16 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
                 it.ps.viewport_y *= vp_scale_y; it.ps.viewport_h *= vp_scale_y;
             }
     if (log) fprintf(stderr, "[exec] rendering %zu draw item(s) (of %zu draws)\n", items.size(), st.draws.size());
+    return items;
+}
+
+inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn& render,
+                                             uint32_t max_shader_dwords = 0x10000,
+                                             float vp_scale_x = 1.0f, float vp_scale_y = 1.0f) {
+    if (!render) return {};
+    std::vector<DrawItem> items = realize_gpustate_draws(
+        st, max_shader_dwords, vp_scale_x, vp_scale_y);
+    if (items.empty()) return {};
     return render(items);
 }
 
@@ -590,9 +620,27 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
 using LiveRenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawItem>& items,
                                                         uint32_t width, uint32_t height)>;
 
+struct OrderedSubmitResult {
+    std::vector<uint8_t> pixels;
+    size_t render_spans = 0;
+    bool compute_executed = false;
+};
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height);
+
 // Register (or clear, with {}) the live render backend that agc_driver_submit_dcb uses on each submit.
 void set_submit_renderer(LiveRenderFn fn);
 bool have_submit_renderer();
+
+struct LiveRenderPhase {
+    bool first_span = true;
+    bool final_span = true;
+};
+LiveRenderPhase live_render_phase();
 
 // Invoke the registered live backend directly with already-realized draws. Used by the local capture
 // replayer; normal guest execution enters through execute_and_present(). Returns {} when unregistered.
@@ -604,5 +652,10 @@ std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
 // returning false when there is no renderer registered or the state has no draws — so it is inert on the
 // game path until the runtime wires a device, yet fully exercised by tests. Stage A of GPU_EXECUTOR_DESIGN.
 bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height);
+
+// Execute retained graphics and compute work in PM4 order. Graphics spans share the frontend's
+// persistent render-target cache, and only the final span is handed to the present path.
+bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
+                                 uint64_t submit_no = 0);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -32,6 +32,7 @@ namespace prosper::gpu {
 namespace {
 LiveRenderFn g_live;   // empty until the runtime/test registers a device-backed renderer
 LiveComputeFn g_compute;   // synchronous compute backend, registered with the live Vulkan frontend
+thread_local LiveRenderPhase g_live_phase;
 
 // Read a 32-dword user-data SGPR block from a stage's register file. `base` = the stage's
 // SPI_SHADER_USER_DATA_*_0 register offset; absent registers read as 0. 32 (not 16) because NGG merged
@@ -871,8 +872,8 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     return out;
 }
 
-bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no) {
-    if (!g_compute || st.dispatches.empty()) return false;
+std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st, uint64_t submit_no) {
+    if (st.dispatches.empty()) return {};
     namespace P = prosper::agc::Pm4;
     auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
         auto it = regs.find(off);
@@ -959,8 +960,13 @@ bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no) {
         }
         items.push_back(std::move(item));
     }
-    if (items.empty()) return false;
-    return g_compute(items);
+    return items;
+}
+
+bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no) {
+    if (!g_compute) return false;
+    std::vector<ComputeItem> items = realize_compute_dispatches(st, submit_no);
+    return !items.empty() && g_compute(items);
 }
 
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
@@ -1214,13 +1220,113 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
     }
 }
 
+std::vector<SubmitOperation> plan_submit_operations(const GpuState& st) {
+    std::vector<SubmitOperation> operations;
+    operations.reserve(st.draws.size() + st.dispatches.size());
+    for (size_t i = 0; i < st.draws.size(); ++i)
+        operations.push_back({SubmitOperationKind::Draw, i, st.draws[i].command_order});
+    for (size_t i = 0; i < st.dispatches.size(); ++i)
+        operations.push_back({SubmitOperationKind::Dispatch, i, st.dispatches[i].command_order});
+    std::stable_sort(operations.begin(), operations.end(), [](const auto& a, const auto& b) {
+        return a.command_order < b.command_order;
+    });
+    return operations;
+}
+
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height) {
+    std::unordered_map<size_t, size_t> draw_by_index, compute_by_index;
+    for (size_t i = 0; i < draws.size(); ++i) draw_by_index[draws[i].draw_index] = i;
+    for (size_t i = 0; i < computes.size(); ++i)
+        compute_by_index[static_cast<size_t>(computes[i].dispatch_index)] = i;
+
+    struct ExecutableOperation { SubmitOperationKind kind; size_t item; };
+    std::vector<ExecutableOperation> executable;
+    for (const auto& operation : operations) {
+        if (operation.kind == SubmitOperationKind::Draw) {
+            auto it = draw_by_index.find(operation.index);
+            if (it != draw_by_index.end()) executable.push_back({operation.kind, it->second});
+        } else {
+            auto it = compute_by_index.find(operation.index);
+            if (it != compute_by_index.end()) executable.push_back({operation.kind, it->second});
+        }
+    }
+
+    size_t total_spans = 0;
+    bool in_draw_span = false;
+    for (const auto& operation : executable) {
+        if (operation.kind == SubmitOperationKind::Draw) {
+            if (!in_draw_span) ++total_spans;
+            in_draw_span = true;
+        } else {
+            in_draw_span = false;
+        }
+    }
+
+    OrderedSubmitResult result;
+    std::vector<DrawItem> span;
+    auto flush_span = [&] {
+        if (span.empty() || !render) return;
+        LiveRenderPhase saved = g_live_phase;
+        g_live_phase = {result.render_spans == 0, result.render_spans + 1 == total_spans};
+        std::vector<uint8_t> rendered = render(span, width, height);
+        g_live_phase = saved;
+        if (!rendered.empty()) result.pixels = std::move(rendered);
+        span.clear();
+        ++result.render_spans;
+    };
+    for (const auto& operation : executable) {
+        if (operation.kind == SubmitOperationKind::Draw) {
+            span.push_back(draws[operation.item]);
+        } else {
+            flush_span();
+            result.compute_executed |= compute && compute({computes[operation.item]});
+        }
+    }
+    flush_span();
+    return result;
+}
+
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
 bool have_submit_renderer()               { return static_cast<bool>(g_live); }
 void set_submit_compute(LiveComputeFn fn) { g_compute = std::move(fn); }
 bool have_submit_compute()                { return static_cast<bool>(g_compute); }
+LiveRenderPhase live_render_phase()       { return g_live_phase; }
 std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
                                          uint32_t width, uint32_t height) {
     return g_live ? g_live(items, width, height) : std::vector<uint8_t>{};
+}
+
+bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
+                                 uint64_t submit_no) {
+    if ((!g_live && !g_compute) || (st.draws.empty() && st.dispatches.empty())) return false;
+    uint32_t fw = present_width(), fh = present_height();
+    float sx = fw ? (float)width / (float)fw : 1.0f;
+    float sy = fh ? (float)height / (float)fh : 1.0f;
+    std::vector<DrawItem> draws = g_live && width && height
+        ? realize_gpustate_draws(st, 0x10000, sx, sy) : std::vector<DrawItem>{};
+    std::vector<ComputeItem> computes = g_compute
+        ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
+
+    OrderedSubmitResult result = execute_ordered_items(
+        plan_submit_operations(st), draws, computes, g_live, g_compute, width, height);
+    std::vector<uint8_t>& px = result.pixels;
+
+    if (!draws.empty()) {
+        auto pending = begin_requested_gpu_capture(draws, width, height);
+        if (pending) {
+            std::string error;
+            if (!finish_requested_gpu_capture(std::move(pending), px, error))
+                std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
+        }
+    }
+    if (px.size() != static_cast<size_t>(width) * height * 4) return false;
+    present_write_frame(px.data(), width, height);
+    return true;
 }
 
 bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1045,6 +1045,46 @@ void start_defer_watchdog() {
 }
 }
 
+static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned& draw_submits) {
+    static const unsigned render_every = [] {
+        const char* e = getenv("PROSPER_RENDER_EVERY");
+        long v = e ? atol(e) : 1;
+        return v > 0 ? (unsigned)v : 1u;
+    }();
+    const bool render = gpu::have_submit_renderer() && !st.draws.empty() &&
+                        (draw_submits++ % render_every) == 0;
+    if (!render) {
+        if (gpu::have_submit_compute() && !st.dispatches.empty() &&
+            !gpu::execute_compute_dispatches(st, submit_no) && getenv("PROSPER_COMPUTELOG"))
+            fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
+                    (unsigned long long)submit_no);
+        return false;
+    }
+
+    uint32_t w = gpu::present_width(), h = gpu::present_height();
+    static const uint32_t scale = [] {
+        const char* e = getenv("PROSPER_RENDER_SCALE");
+        long v = e ? atol(e) : 1;
+        return v > 0 ? (uint32_t)v : 1u;
+    }();
+    if (scale > 1) {
+        w = (w / scale) & ~1u;
+        h = (h / scale) & ~1u;
+        if (!w) w = 2;
+        if (!h) h = 2;
+    }
+    // Draw spans and dispatches are synchronous. Drain packet writes before the renderer reads guest
+    // resources, then retire completion only after the ordered mixed timeline has finished.
+    gpu::flush_deferred_streams();
+    prosper_gpu_drain_completion_writes();
+    const bool presented = gpu::execute_ordered_and_present(st, w, h, submit_no);
+    if (presented) g_presents_cum++;
+    if (presented && getenv("PROSPER_GFXLOG"))
+        fprintf(stderr, "[agc] SubmitDcb #%llu: executed %zu draws -> presented %ux%u frame\n",
+                (unsigned long long)submit_no, st.draws.size(), w, h);
+    return presented;
+}
+
 // Fold one raw Dcb dword stream through the CommandProcessor, fire the GPU EOP completion events, and
 // (if a live renderer is wired and the submit produced draws) execute+present. Shared by the primary
 // submit path (sceAgcDriverSubmitDcb) and the DOLL warmup-submit variant (w1KFAHVqpaU) below.
@@ -1062,10 +1102,8 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
-    if (gpu::have_submit_compute() && !agc_gpu_state().dispatches.empty() &&
-        !gpu::execute_compute_dispatches(agc_gpu_state(), g_submit_count) && getenv("PROSPER_COMPUTELOG"))
-        fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
-                (unsigned long long)g_submit_count);
+    static unsigned draw_submits2 = 0;
+    execute_submit_work(agc_gpu_state(), g_submit_count, draw_submits2);
     gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     // #312 EOP visibility contract: the pulse fires immediately only when no gated writes are
     // pending; otherwise it is OWED and delivered when the tail drains (the guest's completion
@@ -1078,17 +1116,6 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     // Watchdog keys off PENDING streams, not just this fold: streams can outlive their fold (and
     // the Jump-recursion flag reset once hid a deferring fold entirely — the wedge class).
     if (gpu::deferred_pending()) start_defer_watchdog();
-    static const unsigned render_every2 = [] {
-        const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
-    static unsigned draw_submits2 = 0;
-    if (gpu::have_submit_renderer() && !agc_gpu_state().draws.empty() && (draw_submits2++ % render_every2) == 0) {
-        uint32_t w = gpu::present_width(), h = gpu::present_height();
-        static const uint32_t scale = [] {
-            const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
-        if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
-        prosper_gpu_drain_completion_writes();   // renderer reads WRITE_DATA-uploaded guest memory (#312)
-        if (gpu::execute_and_present(agc_gpu_state(), w, h)) g_presents_cum++;
-    }
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc] %s #%llu: %u dwords (walk=%u) -> %zu packets applied (draws: %zu, dispatches: %llu)\n",
                 who, (unsigned long long)g_submit_count, dw_num, walk, applied,
@@ -1185,10 +1212,8 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
-    if (gpu::have_submit_compute() && !agc_gpu_state().dispatches.empty() &&
-        !gpu::execute_compute_dispatches(agc_gpu_state(), g_submit_count) && getenv("PROSPER_COMPUTELOG"))
-        fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
-                (unsigned long long)g_submit_count);
+    static unsigned draw_submits = 0;
+    execute_submit_work(agc_gpu_state(), g_submit_count, draw_submits);
     gpu::diagnose_resource_provenance(agc_gpu_state(), g_submit_count);
     // The submit has "completed" (synchronous fold): fire any registered GPU EOP events. Inert unless the
     // game called sceGnmAddEqEvent (b0xyllnVY-I); the RELEASE_MEM label write already happened in apply().
@@ -1197,33 +1222,6 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     gpu::flush_deferred_streams();
     gpu::submit_completion_pulse();
     if (gpu::deferred_pending()) start_defer_watchdog();
-    // Stage A: if a live renderer has been registered (runtime binary wires a Vulkan device) and this
-    // submit accumulated draws, execute the folded GpuState and present the frame. Inert (returns false)
-    // on the pure-HLE path until a device is registered, so it never perturbs the existing boot behavior.
-    // PROSPER_RENDER_EVERY=K: render only every Kth draw-carrying submit (default 1). Under llvmpipe a
-    // 1080p render is ~10-20 s and execute_and_present is SYNCHRONOUS here, throttling the frame loop to
-    // a crawl — so a distant scene (the cutscene, thousands of frames in) would take hours. Sampling
-    // keeps the game running near full speed while still producing periodic frames of the live scene.
-    static const unsigned render_every = [] {
-        const char* e = getenv("PROSPER_RENDER_EVERY"); long v = e ? atol(e) : 1; return v > 0 ? (unsigned)v : 1u; }();
-    static unsigned draw_submits = 0;
-    if (gpu::have_submit_renderer() && !agc_gpu_state().draws.empty() && (draw_submits++ % render_every) == 0) {
-        uint32_t w = gpu::present_width(), h = gpu::present_height();
-        // PROSPER_RENDER_SCALE=N: render at 1/N resolution. execute_and_present is SYNCHRONOUS on the
-        // guest submit thread; a full 1080p llvmpipe render blocks it ~15 s, and while it is blocked in
-        // host Vulkan the guest GC's stop-the-world can't get its ack -> the collection races and aborts
-        // ("Unexpected state"), so the game crashes long before reaching a distant scene. A 1/4 render
-        // (~1 s) shrinks that window enough to run deep into the cutscene while still capturing a frame.
-        static const uint32_t scale = [] {
-            const char* e = getenv("PROSPER_RENDER_SCALE"); long v = e ? atol(e) : 1; return v > 0 ? (uint32_t)v : 1u; }();
-        if (scale > 1) { w = (w / scale) & ~1u; h = (h / scale) & ~1u; if (!w) w = 2; if (!h) h = 2; }
-        prosper_gpu_drain_completion_writes();   // renderer reads WRITE_DATA-uploaded guest memory (#312)
-        bool presented = gpu::execute_and_present(agc_gpu_state(), w, h);
-        if (presented) g_presents_cum++;
-        if (presented && getenv("PROSPER_GFXLOG"))
-            fprintf(stderr, "[agc] SubmitDcb #%llu: executed %zu draws -> presented %ux%u frame\n",
-                    (unsigned long long)g_submit_count, agc_gpu_state().draws.size(), w, h);
-    }
     if (getenv("PROSPER_GFXLOG")) {
         fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu, dispatches total: %llu)\n",
                 (unsigned long long)g_submit_count, p->dw_num, applied, agc_gpu_state().draws.size(),

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -77,6 +77,51 @@ int main() {
     GpuState empty; empty.draws.clear();
     CHECK(execute_gpustate(empty, backend).empty(), "a draw-less GpuState renders no frame (state-only submit)");
 
+    // #584: graphics and compute are one PM4 timeline. The planner must retain the asymmetric
+    // draw-before-dispatch-before-draw dependency that exposed Dead Cells' future buffer read.
+    {
+        GpuState mixed;
+        GpuState::Draw before, after;
+        before.command_order = 100;
+        after.command_order = 300;
+        mixed.draws = {before, after};
+        GpuState::Dispatch dispatch;
+        dispatch.command_order = 200;
+        mixed.dispatches.push_back(dispatch);
+        auto operations = plan_submit_operations(mixed);
+        CHECK(operations.size() == 3 &&
+              operations[0].kind == SubmitOperationKind::Draw && operations[0].index == 0 &&
+              operations[1].kind == SubmitOperationKind::Dispatch && operations[1].index == 0 &&
+              operations[2].kind == SubmitOperationKind::Draw && operations[2].index == 1,
+              "mixed submit planner retains draw-compute-draw PM4 order");
+
+        uint32_t aliased_value = 7;
+        std::vector<uint32_t> observed;
+        std::vector<LiveRenderPhase> phases;
+        DrawItem first, second;
+        first.draw_index = 0;
+        second.draw_index = 1;
+        ComputeItem fill;
+        fill.dispatch_index = 0;
+        LiveRenderFn observe = [&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            for (size_t i = 0; i < items.size(); ++i) observed.push_back(aliased_value);
+            phases.push_back(live_render_phase());
+            return std::vector<uint8_t>(4, static_cast<uint8_t>(aliased_value));
+        };
+        LiveComputeFn mutate = [&](const std::vector<ComputeItem>&) {
+            aliased_value = 9;
+            return true;
+        };
+        OrderedSubmitResult ordered = execute_ordered_items(
+            operations, {first, second}, {fill}, observe, mutate, 1, 1);
+        CHECK(observed == std::vector<uint32_t>({7, 9}),
+              "ordered executor exposes pre-compute bytes to draw 0 and post-compute bytes to draw 1");
+        CHECK(ordered.compute_executed && ordered.render_spans == 2 && phases.size() == 2 &&
+              phases[0].first_span && !phases[0].final_span &&
+              !phases[1].first_span && phases[1].final_span,
+              "ordered executor brackets one submit across two graphics spans");
+    }
+
     // --- Indexed draws through the executor (issue #64) -------------------------------------------------
     // realize_draw_item fetches a REAL 16-bit guest index buffer (index_type 0, the SetIndexType reset
     // default this title relies on) and the backend renders it with vkCmdDrawIndexed — gl_VertexIndex is


### PR DESCRIPTION
## Summary
- merge retained draws and dispatches by their process-lifetime PM4 ordinals
- separate compute realization from execution and flush graphics spans at dispatch boundaries
- keep the live renderer's RTT cache across spans while advancing submit/frame/present state once
- retire submit completion only after the synchronous mixed graphics/compute timeline finishes
- update current-status docs and split the remaining Dead Cells overbright composition to #586

## Regression
A synthetic aliased resource is read by draw 0 as value 7, changed by compute to 9, then read by draw 1 as 9. The test also proves the two renderer callbacks are one first/non-final span and one non-first/final span.

## Live result
At 960x540, Dead Cells' deterministic gameplay route now produces a new dark-blue first composition for two screenshots (1,238 colors, 510,049 dark pixels), then settles to the prior overbright composition (~1,168 colors, ~36,657 dark pixels). The ordering bug is behaviorally fixed but was not the only defect; #586 owns the residual.

Artifacts: `C:\Users\matti\Downloads\ps5ys-deadcells-route\ordered-submit-scale4c\`.

## Verification
- `ctest --output-on-failure`: 87/87 passed
- Messenger guard: 24,318 colors (minimum 5,000)
- Dead Cells with `PROSPER_COMPUTE=0`: exact `8429fedd...` splash baseline
- Dead Cells default compute: known `891a80fc...` animation frame tracked by #573
- deterministic gameplay route: 5 PNGs at 960x540

Fixes #584