### PR TITLE
feat(gpu): trace live resource versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,16 @@ first bad composition at draw 18; one 642x362 input has no prior color-target wr
 thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574)
 now execute the real fill kernel against guest buffers before submit completion (#576). Range provenance proved
 draw 19 consumes one backing, dispatch 5 fills it, then draw 31 consumes it again in one submit. Graphics spans and
-compute now execute by retained PM4 order (#584), fixing that future-read and changing the first gameplay frame;
-the scene still settles to the overbright composition tracked by #586. The residual seeded replay mismatch (#569)
-and animation-sensitive exact splash guard (#573) remain separate tooling issues.
+compute now execute by retained PM4 order (#584), fixing that future-read. The later overbright screenshot was a
+warmup artifact: the 35-second render delay skipped a 642x362 RTT producer, then a replace-copy sampled dispatch
+4's raw all-`0xFF` backing and cached it indefinitely. `PROSPER_RENDER_TARGET_DIM=642x362` preserves the real
+opening vignette/level geometry; #586 now tracks a practical late checkpoint with that history intact. The
+residual seeded replay mismatch (#569) and animation-sensitive exact splash guard (#573) remain separate issues.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.
+`PROSPER_RESOURCE_HASH_DIM=WxH` correlates raw and sampled hashes with those writers at each live draw;
+`PROSPER_TARGET_STEP_HASH_DIM=WxH` plus `PROSPER_TARGET_STEP_HASH_MIN_DRAWS=N` prefix-bisects a target
+pass using content metrics without writing per-draw images.
 `PROSPER_DESCRIPTOR_VALIDATE=strict|poison` and `gpu_replay --validate` are landed capabilities from #515.
 Do not restart the superseded
 Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without contradictory new evidence.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ accepts scripted gamepad input, and renders the first level.
   water, structures, and foreground composition render through the first level at native 1920x1080.
   A scripted gamepad route produced a full-resolution sequence that was confirmed against PS5 hardware.
 - 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
-  first playable scene. HUD and some composition are alive, but the world is mostly white. Capture/replay
-  isolated the first bad composition input. Graphics and compute now execute by retained PM4 order (#584),
-  fixing a proven future-read; the settled overbright composition remains under investigation (#566, #586).
+  first playable scene. Graphics and compute now execute by retained PM4 order (#584), fixing a proven
+  future-read. The formerly overbright screenshot was traced to a diagnostic warmup skipping temporal RTT
+  producers; producer-preserving runs render real opening geometry, with a practical late checkpoint next (#586).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -39,7 +39,7 @@ possible without console keys. Dumps are user-supplied and gitignored.
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** diagnose Dead Cells' settled overbright composition after the ordering fix (#586),
+- 🚧 **Active frontiers:** build a practical producer-preserving Dead Cells gameplay checkpoint (#586),
   stabilize the animation-sensitive exact splash guard (#573), and continue cross-title capture/replay and
   descriptor-validation work. UE4's measured GPU boundary remains tracked separately under its area issues.
 

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -41,10 +41,11 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   dispatch thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V#
   decoding (#574) now execute a valid registered fill program against real guest buffers before submit completion
   (#576). Range provenance proved one submit orders a 642x362 consumer, dispatch 5's fill, then another consumer.
-  Graphics spans and compute now execute by that retained PM4 order (#584); the first gameplay frame changes, but
-  subsequent frames still settle to the prior overbright composition.
-- **Immediate milestone:** isolate the remaining settled Dead Cells composition defect (#586), including live
-  per-consumer resource versions and dark/overbright captures. Separately, resolve the seeded replay hash
+  Graphics spans and compute now execute by that retained PM4 order (#584). Per-consumer hashes and target-prefix
+  metrics proved the later overbright screenshot was a warmup artifact: a skipped temporal RTT fell back to an
+  all-`0xFF` compute backing, then the bad copy persisted. Preserving the 642x362 producers renders real geometry.
+- **Immediate milestone:** build a practical late Dead Cells checkpoint with required RTT history intact (#586).
+  Separately, resolve the seeded replay hash
   mismatch (#569) and animation-sensitive splash
   snapshot (#573), while continuing the same capture/replay workflow across Unity and Unreal targets.
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4,6 +4,7 @@
 #include "live_compute.hpp"
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
+#include "gpu/writer_provenance.hpp"
 #include "gpu/gpu_capture.hpp"          // temporal RTT capture/replay seeds
 #include "gpu/tile.hpp"                 // detile_surface / tiled_surface_bytes / detile_elements
 #include "gpu/bc_decode.hpp"            // BC1/2/3 block decompression -> RGBA8 (#121)
@@ -174,10 +175,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             };
             static std::vector<std::vector<uint8_t>> texstore;  // keep every item's texture bytes alive
             texstore.clear();
+            uint32_t resource_hash_w = 0, resource_hash_h = 0;
+            if (const char* dim = getenv("PROSPER_RESOURCE_HASH_DIM"))
+                if (sscanf(dim, "%ux%u", &resource_hash_w, &resource_hash_h) != 2)
+                    resource_hash_w = resource_hash_h = 0;
+            uint32_t target_step_w = 0, target_step_h = 0;
+            if (const char* dim = getenv("PROSPER_TARGET_STEP_HASH_DIM"))
+                if (sscanf(dim, "%ux%u", &target_step_w, &target_step_h) != 2)
+                    target_step_w = target_step_h = 0;
+            const size_t target_step_min_draws = getenv("PROSPER_TARGET_STEP_HASH_MIN_DRAWS")
+                ? std::max<long>(2, atol(getenv("PROSPER_TARGET_STEP_HASH_MIN_DRAWS"))) : 2;
             // Build one draw's set-tagged resources from its VS (set 0) + PS (set 1) tables — read the
             // bytes from 1:1-mapped guest memory, detile textures. (Each constant/vertex buffer + texture
             // gets its own binding; the recompiler declared a storage buffer / image sampler at each.)
-            auto build_R = [&](const prosper::gpu::ShaderResourceTable* vrt, const prosper::gpu::ShaderResourceTable* prt) {
+            auto build_R = [&](const prosper::gpu::DrawItem& draw,
+                               const prosper::gpu::ShaderResourceTable* vrt,
+                               const prosper::gpu::ShaderResourceTable* prt) {
               std::vector<prosper::test::FrameResource> R;
               auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set){
                 if (!t) return;
@@ -452,6 +465,44 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 tp[t * 4 + 3] = 255;
                             }
                         }
+                        // Focused per-consumer version probe (#586). Hash both the raw guest backing
+                        // and the final decoded/RTT-injected pixels so a live draw identifies whether
+                        // divergence precedes format conversion or enters through renderer-owned state.
+                        if (resource_hash_w == tw && resource_hash_h == th) {
+                            const size_t raw_size = std::min<size_t>(
+                                r.size ? r.size : (size_t)tw * th * 4, 64u << 20);
+                            std::vector<uint8_t> raw(raw_size, 0);
+                            const size_t raw_got = copy_resource(raw.data(), r.gpu_addr, raw.size());
+                            auto fnv = [](const uint8_t* data, size_t size) {
+                                uint64_t hash = 1469598103934665603ull;
+                                for (size_t i = 0; i < size; ++i) {
+                                    hash ^= data[i];
+                                    hash *= 1099511628211ull;
+                                }
+                                return hash;
+                            };
+                            const uint64_t raw_hash = fnv(raw.data(), raw_got);
+                            const uint64_t sample_hash = fnv(texstore.back().data(), texstore.back().size());
+                            const auto writer = prosper::gpu::last_guest_write_overlap(
+                                r.gpu_addr, raw_size);
+                            fprintf(stderr,
+                                    "[resource-version] render-submit=%llu draw=%llu order=%llu set=%u bind=%u "
+                                    "addr=0x%llx dims=%ux%u class=%u fmt=%u tile=%u rtt=%d "
+                                    "raw=%zu/%zu:%016llx sample=%zu:%016llx "
+                                    "writer=%s/%llu/%llu/%llu/0x%llx\n",
+                                    (unsigned long long)g_this_submit,
+                                    (unsigned long long)draw.draw_index,
+                                    (unsigned long long)draw.command_order,
+                                    set, r.binding, (unsigned long long)r.gpu_addr, tw, th,
+                                    (unsigned)r.cls, (unsigned)r.format, r.tile_mode, (int)rtt_hit,
+                                    raw_got, raw_size, (unsigned long long)raw_hash,
+                                    texstore.back().size(), (unsigned long long)sample_hash,
+                                    writer ? prosper::gpu::guest_writer_kind_name(writer->kind) : "none",
+                                    (unsigned long long)(writer ? writer->submit : 0),
+                                    (unsigned long long)(writer ? writer->item : 0),
+                                    (unsigned long long)(writer ? writer->order : 0),
+                                    (unsigned long long)(writer ? writer->identity : 0));
+                        }
                         // PROSPER_PALETTELOG: compact identity/provenance trace for Unity's 256x16
                         // palette textures. Unlike GFXLOG this is cheap enough for a focused render
                         // window and reveals both descriptor-address and decoded-content changes.
@@ -663,7 +714,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bd.fs     = ps_override.empty() ? it.fs : ps_override;
                     bd.vcount = refvs ? 3u : it.vertex_count;
                     bd.ps     = nops ? nullptr : &it.ps;
-                    bd.R      = build_R(it.vrt.get(), it.prt.get());
+                    bd.R      = build_R(it, it.vrt.get(), it.prt.get());
                     if (!prosper::gpu::validate_runtime_descriptor_contract(
                             "VS/backend", bd.vs, it.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex) ||
                         !prosper::gpu::validate_runtime_descriptor_contract(
@@ -798,6 +849,80 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
                         build_bds(render_pass), gw, gh, seed, clear_for(render_pass), true);
                     if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = gw; s.h = gh; }
+                    if (native_w == resource_hash_w && native_h == resource_hash_h && !gpx.empty()) {
+                        uint64_t hash = 1469598103934665603ull;
+                        for (uint8_t byte : gpx) {
+                            hash ^= byte;
+                            hash *= 1099511628211ull;
+                        }
+                        const auto* first = render_pass.empty() ? nullptr : render_pass.front();
+                        const auto* last = render_pass.empty() ? nullptr : render_pass.back();
+                        fprintf(stderr,
+                                "[target-version] render-submit=%llu target=0x%llx dims=%ux%u "
+                                "draws=%llu-%llu orders=%llu-%llu seed=%d clear=%d "
+                                "rgba=%.3f,%.3f,%.3f,%.3f hash=%016llx\n",
+                                (unsigned long long)g_this_submit,
+                                (unsigned long long)base, native_w, native_h,
+                                (unsigned long long)(first ? first->draw_index : 0),
+                                (unsigned long long)(last ? last->draw_index : 0),
+                                (unsigned long long)(first ? first->command_order : 0),
+                                (unsigned long long)(last ? last->command_order : 0),
+                                seed != nullptr, first ? (int)first->ps.has_clear_color : 0,
+                                first ? first->ps.clear_color[0] : 0.0f,
+                                first ? first->ps.clear_color[1] : 0.0f,
+                                first ? first->ps.clear_color[2] : 0.0f,
+                                first ? first->ps.clear_color[3] : 0.0f,
+                                (unsigned long long)hash);
+                    }
+                    if (native_w == target_step_w && native_h == target_step_h &&
+                        render_pass.size() >= target_step_min_draws) {
+                        for (size_t k = 1; k <= render_pass.size(); ++k) {
+                            std::vector<const prosper::gpu::DrawItem*> prefix(
+                                render_pass.begin(), render_pass.begin() + k);
+                            texstore.clear();
+                            std::vector<uint8_t> step = prosper::test::render_draws_rgba(
+                                build_bds(prefix), gw, gh, seed, clear_for(prefix), true);
+                            uint64_t hash = 1469598103934665603ull;
+                            for (uint8_t byte : step) {
+                                hash ^= byte;
+                                hash *= 1099511628211ull;
+                            }
+                            size_t dark = 0, near_white = 0;
+                            uint64_t rgb_sum = 0;
+                            for (size_t p = 0; p + 3 < step.size(); p += 4) {
+                                const uint8_t r = step[p], g = step[p + 1], b = step[p + 2];
+                                dark += std::max({r, g, b}) < 64;
+                                near_white += std::min({r, g, b}) > 240;
+                                rgb_sum += r + g + b;
+                            }
+                            const double mean_rgb = step.empty() ? 0.0 :
+                                (double)rgb_sum / ((step.size() / 4) * 3);
+                            const auto* draw = prefix.back();
+                            auto spirv_hash = [](const std::vector<uint32_t>& words) {
+                                uint64_t hash = 1469598103934665603ull;
+                                const uint8_t* bytes = reinterpret_cast<const uint8_t*>(words.data());
+                                for (size_t i = 0; i < words.size() * sizeof(uint32_t); ++i) {
+                                    hash ^= bytes[i];
+                                    hash *= 1099511628211ull;
+                                }
+                                return hash;
+                            };
+                            fprintf(stderr,
+                                    "[target-step] render-submit=%llu target=0x%llx step=%zu/%zu "
+                                    "draw=%llu order=%llu vs=%016llx ps=%016llx mask=0x%x "
+                                    "blend=%d/%u/%u hash=%016llx dark=%zu white=%zu mean=%.2f\n",
+                                    (unsigned long long)g_this_submit,
+                                    (unsigned long long)base, k, render_pass.size(),
+                                    (unsigned long long)draw->draw_index,
+                                    (unsigned long long)draw->command_order,
+                                    (unsigned long long)spirv_hash(draw->vs),
+                                    (unsigned long long)spirv_hash(draw->fs),
+                                    draw->ps.color_write_mask, (int)draw->ps.blend_enable,
+                                    draw->ps.src_color_blend_factor,
+                                    draw->ps.dst_color_blend_factor,
+                                    (unsigned long long)hash, dark, near_white, mean_rgb);
+                        }
+                    }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
                     if (getenv("PROSPER_RTTLOG")) {

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -18,6 +18,8 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
   loading flips before the menu.
 
 The long renderer warmup makes this route practical under llvmpipe, but it can
-skip one-time GPU producers. The current post-warmup gameplay image is tracked
-in issues #566/#586 and must not be used as a golden visual checkpoint until
-the warmup artifact has been separated from genuine renderer behavior.
+skip temporal GPU producers. The former post-warmup fullscreen-white image was
+caused by that skip and is not normal renderer output (#586). For graphics
+investigation, add `PROSPER_RENDER_TARGET_DIM=642x362` to preserve the level's
+RTT chain; this is much slower and currently remains in the opening vignette at
+the 35-second checkpoint. Do not use the fast route as a visual golden guard.

--- a/prosper/src/gpu/writer_provenance.cpp
+++ b/prosper/src/gpu/writer_provenance.cpp
@@ -37,10 +37,12 @@ uint64_t span_end(uint64_t addr, uint64_t size) {
 bool writer_provenance_enabled() {
     const char* explicit_mode = std::getenv("PROSPER_WRITER_PROVENANCE");
     const char* dimension_mode = std::getenv("PROSPER_PROVENANCE_DIM");
+    const char* resource_hash_mode = std::getenv("PROSPER_RESOURCE_HASH_DIM");
     const bool explicitly_on = explicit_mode && *explicit_mode &&
                                std::strcmp(explicit_mode, "0") &&
                                std::strcmp(explicit_mode, "off");
-    return explicitly_on || (dimension_mode && *dimension_mode);
+    return explicitly_on || (dimension_mode && *dimension_mode) ||
+           (resource_hash_mode && *resource_hash_mode);
 }
 
 const char* guest_writer_kind_name(GuestWriterKind kind) {

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -56,6 +56,10 @@ This preserves a one-time producer in the RTT cache while still skipping an expe
 late consumer.
 `PROSPER_RENDER_RESOURCE_DIM=WxH` likewise executes submits that sample a matching image, allowing a
 producer/consumer A/B without rendering every unrelated submit between them.
+`PROSPER_RESOURCE_HASH_DIM=WxH` logs each matching sampled resource's raw guest hash, decoded/sample
+hash, RTT-hit state, last compute/DMA writer, draw index, and PM4 order. `PROSPER_TARGET_STEP_HASH_DIM`
+rerenders matching target passes by prefix and logs per-draw hashes plus dark/white/mean metrics;
+`PROSPER_TARGET_STEP_HASH_MIN_DRAWS=N` bounds that intentionally expensive bisect.
 `PROSPER_RENDER_DELAY_MS=N` skips synchronous Vulkan work for N milliseconds from the first submit while
 the guest and command decoder advance. The `screenshot` frontend exposes this as `--warmup-seconds`, plus
 `--warmup-submits` for `PROSPER_RENDER_FIRST`; use wall-clock warmup for progression captures and the exact

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -42,9 +42,10 @@ Only the game is required; everything else has a sane default.
 Directory-creation and PNG write failures include the failing path and operating-system error.
 
 Warmup is useful when llvmpipe makes a frame-counted startup take minutes. The guest and GPU command
-decoder continue at native speed while Vulkan work is skipped; normal screenshots begin once rendering
-does. During warmup, the raw-scanout fallback is suppressed so the output folder does not fill with
-misleading loading frames. The two warmup gates are additive when both are supplied. `--timeout` covers
+decoder continue at native speed while Vulkan work is skipped; normal screenshots begin once warmup
+ends. During warmup, both rendered frames and the raw-scanout fallback are suppressed from capture, so
+diagnostic target/resource overrides can preserve producers without saving early frames (#588). The two
+warmup gates are additive when both are supplied. `--timeout` covers
 the entire run, including warmup.
 
 **"Frames" = rendered frames** (composited images handed to the present layer), *not* guest flips —

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -222,7 +222,7 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[shot] %s: %d screenshots, every %d frames -> %s/%s_%s_*.png\n",
                 code.c_str(), count, every, out.c_str(), code.c_str(), ts);
     if (warming_up)
-        fprintf(stderr, "[shot] warmup: %lld ms, %d submits; raw scanout suppressed until rendering begins\n",
+        fprintf(stderr, "[shot] warmup: %lld ms, %d submits; capture suppressed until warmup ends\n",
                 (long long)render_delay_ms, render_first);
 
     std::vector<uint8_t> buf;
@@ -241,9 +241,12 @@ int main(int argc, char** argv) {
         bool due = time_mode ? (std::chrono::duration<double>(now - last_cap).count() >= seconds)
                              : (gpu::present_frame_seq() >= next);
         const bool rendered = gpu::present_has_frame();
-        const bool raw_scanout = !warming_up && gpu::present_front_index() >= 0 &&
+        const bool wall_warmup_done = el * 1000.0 >= (double)render_delay_ms;
+        const bool rendered_capture = rendered && wall_warmup_done;
+        const bool raw_scanout = wall_warmup_done && render_first == 0 &&
+                                 gpu::present_front_index() >= 0 &&
                                  gpu::present_width() > 0 && gpu::present_height() > 0;
-        if ((rendered || raw_scanout) && due) {
+        if ((rendered_capture || raw_scanout) && due) {
             uint64_t at = gpu::present_frame_seq();
             // Size the buffer from the RENDERED frame's dims, not the guest display dims: under
             // PROSPER_RENDER_SCALE the frame is smaller, and present_readback returns g_frame.size()


### PR DESCRIPTION
﻿## Summary
- add `PROSPER_RESOURCE_HASH_DIM=WxH` for per-consumer raw/sample hashes, RTT-hit state, writer identity, draw index, and PM4 order
- add `PROSPER_TARGET_STEP_HASH_DIM=WxH` plus a minimum-draw filter for bounded prefix rerenders with stable shader hashes and dark/white/mean metrics
- make resource hashing automatically retain compute/DMA writer provenance
- keep rendered PNG capture suppressed until wall warmup ends even when diagnostic target/resource overrides force producers to render
- update current-status and Dead Cells route docs with the measured warmup artifact

## Dead Cells finding
The 35-second fast route skipped a temporal 642x362 RTT producer. On the first rendered submit, a fullscreen replace-copy sampled dispatch 4's raw all-`0xFF` backing. Prefix metrics measured the target changing from 89,329 dark / 0 near-white pixels to 0 dark / 89,329 near-white pixels at that draw; the poisoned RTT then fed back on later frames. Preserving 642x362 producers renders the real opening vignette/level geometry instead. #586 remains open for a practical late producer-preserving checkpoint.

## Screenshot fix
With `PROSPER_RENDER_TARGET_DIM=642x362 --warmup-seconds 35`, forced producers rendered before warmup but the first PNG was saved at exactly 35.0 seconds (frame 11), rather than 25-27 seconds.

## Verification
- `ctest --output-on-failure`: 87/87 passed
- targeted `gpu_execute`, `writer_provenance_ranges`, and `boot_reaches_first_syscall` pass
- forced-producer warmup capture: first PNG at 35.0s
- producer-preserving Dead Cells capture contains real vignette geometry

Fixes #588
Updates #586
