### PR TITLE
feat(gpu): compute-dispatch fail-trace for PROSPER_DYNTRACE_FAIL (#590)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -943,6 +943,37 @@ std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st, uint64_t
         item.submit_no = submit_no;
         item.command_order = dispatch.command_order;
         if (item.spirv.empty()) {
+            // PROSPER_DYNTRACE_FAIL=1: replay the FAILED compute program's resource build with the
+            // const-fold walk trace + user-data dump forced on (once per distinct program) — the
+            // compute analog of the graphics VS/PS fail-replay (gpu_execute.hpp). Compute dispatches
+            // only run build_shader_resources (the DIRECT front-half table) and NEVER the const-fold
+            // resolve_dynamic_fetch that graphics stages use, so a bindless storage-image U# / T#
+            // (image_store SRSRC, image_sample) can't be recovered by pc-provenance for a dispatch.
+            // This trace reveals whether the failing dispatch's descriptors ARE const-fold-resolvable
+            // (i.e. loaded via a foldable s_load chain) — the ground truth for #590 before extending
+            // the compute resource build. Read-only: it does not change what the executor binds.
+            if (getenv("PROSPER_DYNTRACE_FAIL")) {
+                static std::set<uint64_t> traced_cs;
+                if (traced_cs.insert(code_addr).second) {
+                    std::fprintf(stderr, "[dynfail] replaying COMPUTE 0x%llx resource build with trace:\n",
+                                 (unsigned long long)code_addr);
+                    std::fprintf(stderr, "[dynfail]   compute user-data SGPRs (s0..s%u):\n", kUserSgprs - 1);
+                    for (uint32_t i = 0; i < kUserSgprs; i += 4)
+                        std::fprintf(stderr, "[dynfail]     s%-2u: %08x %08x %08x %08x\n", i,
+                                     sgprs[i], sgprs[i + 1], sgprs[i + 2], sgprs[i + 3]);
+                    std::vector<SrtUse> cs_uses;
+                    g_dyntrace_force = true;
+                    resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+                                          sgprs, kUserSgprs, 0, &cs_uses);
+                    g_dyntrace_force = false;
+                    std::fprintf(stderr, "[dynfail]   const-fold recovered %zu descriptor use(s):\n",
+                                 cs_uses.size());
+                    for (const auto& u : cs_uses)
+                        std::fprintf(stderr, "[dynfail]     %s key=0x%x use_pc=%u dw0=0x%x\n",
+                                     u.kind == 0 ? "TEX/IMG(t8)" : "BUF(v4)", u.key, u.use_pc,
+                                     u.kind == 0 ? u.t8[0] : u.v4[0]);
+                }
+            }
             static std::set<uint64_t> logged;
             if (logged.insert(code_addr).second)
                 std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",


### PR DESCRIPTION
## What

Extends `PROSPER_DYNTRACE_FAIL` to **compute dispatches**. When a compute program fails to recompile
(`item.spirv.empty()` in `realize_compute_dispatches`), it dumps the compute user-data SGPR block and
replays `resolve_dynamic_fetch` with the const-fold trace forced on — the compute analog of the graphics
VS/PS fail-replay already in `gpu_execute.hpp`.

## Why

Investigating the DOLL (PPSA17942) shader-reject frontier (#590), the `image_store` compute rejects showed
`[mimg-unresolved] … pc_res=null` with no way to see how the storage-image U#/T# was set up — because
`PROSPER_DYNTRACE_FAIL` only covered graphics stages. This tool closed that gap and surfaced the root finding:

- `realize_compute_dispatches` (gpu_executor.cpp:909) builds its resource table with `build_shader_resources`
  **only**, and never calls the const-fold `resolve_dynamic_fetch` that graphics stages use via
  `build_stage_table` — so bindless provenance (`by_fetch_pc`/srt) is never populated for a dispatch.
- Yet the const-fold **does** snapshot many of these compute T#s when replayed (`MIMG … have_t8=1`,
  keyed s_loads). The follow-up PR wires the const-fold into the compute path (classifying `image_store` /
  sampler-less `image_load` uses as `StorageImage`).

Full trace evidence in #590.

## Risk

Read-only, env-gated (`getenv("PROSPER_DYNTRACE_FAIL")`) at a fail-only path — no change to what the
executor binds or recompiles by default. `messenger_recompile_guard` passes; ctest unchanged (the 3
dump-gated tests are pre-existing skips).

Part of #590.
