### PR TITLE
feat(screenshot): add capture manifests and assertions (#593)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -78,6 +78,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_lifecycle PRIVATE prosper_core)
   add_test(NAME lifecycle_stop_signal COMMAND test_lifecycle)
 
+  # Screenshot evidence classification/JSON is pure and must remain testable without Vulkan or a dump.
+  add_executable(test_capture_manifest tests/test_capture_manifest.cpp
+                                       tools/screenshot/capture_manifest.cpp)
+  target_include_directories(test_capture_manifest PRIVATE tools/screenshot)
+  add_test(NAME capture_manifest COMMAND test_capture_manifest)
+
   # va2foff resolution order (issue #113): DYNAMIC/PROCPARAM/TLS must never shadow
   # the PT_LOAD that truly maps a VA. Pure unit test — no game dump required.
   add_executable(test_va2foff tests/test_va2foff.cpp)
@@ -482,8 +488,9 @@ if(TARGET prosper_core)
       # 30). Reuses boot_program + the shared live renderer; writes zlib-compressed PNGs (needs zlib).
       find_package(ZLIB QUIET)
       if(ZLIB_FOUND)
-        add_executable(screenshot tools/screenshot/screenshot.cpp)
-        target_include_directories(screenshot PRIVATE src)
+        add_executable(screenshot tools/screenshot/screenshot.cpp
+                                  tools/screenshot/capture_manifest.cpp)
+        target_include_directories(screenshot PRIVATE src tools/screenshot)
         target_link_libraries(screenshot PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan ZLIB::ZLIB)
       else()
         message(STATUS "zlib not found — skipping the screenshot tool")

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -100,6 +100,42 @@ size_t present_readback(void* dst, size_t dst_cap) {
     return bytes;
 }
 
+bool present_snapshot(PresentSnapshot& out) {
+    out = {};
+    // frame_seq is incremented while holding this mutex, after the pixels and dimensions are
+    // installed, so the copied bytes and identity describe the same renderer publication.
+    if (g_have_frame.load(std::memory_order_acquire)) {
+        std::lock_guard<std::mutex> lk(g_frame_mx);
+        if (g_frame.empty() || !g_frame_w || !g_frame_h) return false;
+        out.source = PresentSource::Rendered;
+        out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
+        out.source_seq = out.frame_seq;
+        out.present_count = g_present_count.load(std::memory_order_relaxed);
+        out.front_index = g_front.load(std::memory_order_relaxed);
+        out.width = g_frame_w;
+        out.height = g_frame_h;
+        out.rgba = g_frame;
+        return true;
+    }
+
+    const int front = g_front.load(std::memory_order_relaxed);
+    if (front < 0) return false;
+    const uint64_t addr = prosper_vo_buffer_addr(front);
+    const uint32_t w = prosper_vo_display_width(), h = prosper_vo_display_height();
+    if (!addr || !w || !h) return false;
+    const size_t bytes = static_cast<size_t>(w) * h * 4;
+    out.source = PresentSource::RawScanout;
+    out.present_count = g_present_count.load(std::memory_order_relaxed);
+    out.source_seq = out.present_count;
+    out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
+    out.front_index = front;
+    out.width = w;
+    out.height = h;
+    out.rgba.resize(bytes);
+    std::memcpy(out.rgba.data(), reinterpret_cast<const void*>(static_cast<uintptr_t>(addr)), bytes);
+    return true;
+}
+
 void present_reset() {
     g_front.store(-1, std::memory_order_relaxed);
     g_present_count.store(0, std::memory_order_relaxed);

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -13,8 +13,25 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
+#include <vector>
 
 namespace prosper::gpu {
+
+enum class PresentSource : uint8_t { None, Rendered, RawScanout };
+
+// One internally consistent readback plus the counters that identify it. The older query/readback
+// calls remain for lightweight consumers, but tools that persist evidence should use this snapshot:
+// querying frame_seq and pixels separately can race a renderer write and mislabel the saved image.
+struct PresentSnapshot {
+    PresentSource source = PresentSource::None;
+    uint64_t source_seq = 0;      // rendered-frame sequence, or guest flip count for raw scanout
+    uint64_t frame_seq = 0;
+    uint64_t present_count = 0;
+    int front_index = -1;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    std::vector<uint8_t> rgba;
+};
 
 // Present the display buffer `buffer_index` (from sceVideoOutSubmitFlip). Records it as the front
 // buffer and bumps the present counter. `flip_arg` is the guest's flip label (echoed in flip status).
@@ -43,6 +60,10 @@ uint32_t present_frame_height();
 // Copy the presented frame's pixels (width*height, 4 bytes/pixel) from the front buffer's guest
 // memory into `dst`. Returns bytes written, or 0 if there is no surface / no flip yet / dst too small.
 size_t present_readback(void* dst, size_t dst_cap);
+
+// Copy the best available frame and its identity as one observation. Prefers a rendered frame and
+// falls back to the raw guest scanout. Returns false before either source is available.
+bool present_snapshot(PresentSnapshot& out);
 
 void present_reset();             // tests: clear front/count
 

--- a/prosper/tests/test_capture_manifest.cpp
+++ b/prosper/tests/test_capture_manifest.cpp
@@ -1,0 +1,73 @@
+#include "../tools/screenshot/capture_manifest.hpp"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace prosper::screenshot;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    std::printf("== test_capture_manifest ==\n");
+    CaptureTracker tracker;
+    std::vector<uint8_t> pixels(16 * 8 * 4, 0x11);
+    CaptureObservation a{CaptureSource::Rendered, 10, 10, 100, 1, 16, 8, 0x12345678, 1.0};
+    auto ca = tracker.observe(a, pixels);
+    CHECK(ca.source_advanced && !ca.pixel_identical && ca.stale_seconds == 0,
+          "first sample is a new source frame");
+
+    auto b = a; b.elapsed_seconds = 3.5;
+    auto cb = tracker.observe(b, pixels);
+    CHECK(!cb.source_advanced && cb.pixel_identical && cb.stale_seconds == 2.5,
+          "same source identity is classified stale");
+
+    auto c = b; c.source_seq = c.frame_seq = 11; c.pixel_crc32 = 0x87654321; c.elapsed_seconds = 4.0;
+    pixels[0] = 0x22;
+    auto cc = tracker.observe(c, pixels);
+    CHECK(cc.source_advanced && !cc.pixel_identical && cc.stale_seconds == 0,
+          "new renderer publication resets stale duration");
+    CHECK(tracker.distinct_source_frames() == 2 && tracker.rendered_samples() == 3,
+          "tracker reports distinct and composited counts");
+    CHECK(tracker.max_stale_seconds() == 2.5 && tracker.max_frame_seq() == 11 &&
+          tracker.max_present_count() == 100, "tracker preserves assertion maxima");
+
+    const std::string line = manifest_sample_json(2, "a\\b\"c.png", c, cc, "@route\nname");
+    CHECK(line.find("a\\\\b\\\"c.png") != std::string::npos, "manifest JSON escapes paths");
+    CHECK(line.find("@route\\nname") != std::string::npos, "manifest JSON escapes route text");
+    CHECK(line.find("\"source\":\"composited\"") != std::string::npos,
+          "manifest names the capture source");
+    const std::string long_route(4096, 'x');
+    const std::string long_line = manifest_sample_json(3, "long.png", c, cc, long_route);
+    CHECK(long_line.size() > long_route.size() && long_line.find(long_route) != std::string::npos,
+          "manifest serialization does not truncate long routes");
+
+    CaptureRunConfig config;
+    config.title = "PPSA15552";
+    config.input_route = "@scripts/dead-cells/route.pad";
+    config.time_mode = true;
+    config.seconds = 1;
+    config.requested = 120;
+    config.render_every = "1000";
+    config.min_distinct_frames = 10;
+    config.require_composited_frame = true;
+    config.required_crc32_set = true;
+    config.required_crc32 = 0x1234abcd;
+    const std::string run = manifest_run_json(config);
+    CHECK(run.find("\"capture_mode\":\"wall_seconds\"") != std::string::npos &&
+          run.find("\"render_every\":\"1000\"") != std::string::npos,
+          "run header records cadence and renderer policy");
+    CHECK(run.find("\"required_crc32\":\"1234abcd\"") != std::string::npos,
+          "run header records checkpoint assertions");
+
+    const std::string summary = manifest_summary_json(3, 5, true, tracker, 1);
+    CHECK(summary.find("\"timed_out\":true") != std::string::npos &&
+          summary.find("\"exit_code\":1") != std::string::npos,
+          "summary records incomplete failure");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -67,6 +67,11 @@ int main() {
     flip(0x1001, 2, 0, 0, 0, 0);
     gpu::present_readback(out.data(), out.size());
     CHECK(out[0] == 0x44 && out[100] == 0x44, "readback reflects updated framebuffer memory");
+    gpu::PresentSnapshot raw_snap;
+    CHECK(gpu::present_snapshot(raw_snap), "raw present snapshot is available before rendering");
+    CHECK(raw_snap.source == gpu::PresentSource::RawScanout && raw_snap.front_index == 2 &&
+          raw_snap.width == W && raw_snap.height == H && raw_snap.rgba[0] == 0x44,
+          "raw snapshot identifies and copies the selected guest scanout");
 
     // Out-of-range flip index leaves the front buffer unchanged (but still counts as a flip).
     flip(0x1001, 99, 0, 0, 0, 0);
@@ -83,6 +88,12 @@ int main() {
     size_t rb = gpu::present_readback(out.data(), out.size());
     CHECK(rb == FB_BYTES, "readback returns the rendered frame size");
     CHECK(memcmp(out.data(), rendered.data(), FB_BYTES) == 0, "readback returns the exact rendered pixels");
+    gpu::PresentSnapshot snap;
+    CHECK(gpu::present_snapshot(snap), "atomic present snapshot is available");
+    CHECK(snap.source == gpu::PresentSource::Rendered && snap.source_seq == gpu::present_frame_seq(),
+          "snapshot identifies the rendered publication");
+    CHECK(snap.width == W && snap.height == H && snap.rgba == rendered,
+          "snapshot metadata and pixels describe the same frame");
     // The rendered frame wins over the raw guest buffer even across flips.
     flip(0x1001, 0, 0, 0, 0, 0);
     gpu::present_readback(out.data(), out.size());

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -25,6 +25,10 @@ cmake --build build --target screenshot
 ```
 screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
            [--warmup-seconds S] [--warmup-submits N]
+           [--manifest PATH | --no-manifest]
+           [--min-distinct-frames N] [--max-stale-seconds S]
+           [--require-composited-frame] [--min-present-count N]
+           [--min-frame-seq N] [--require-crc32 N]
 ```
 
 | Option | Default | Meaning |
@@ -37,9 +41,27 @@ screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
 | `--timeout S` | 900 | Give up after S seconds if the game isn't rendering enough (0 = no limit) |
 | `--warmup-seconds S` | 0 | Advance the guest for S seconds without synchronous Vulkan rendering |
 | `--warmup-submits N` | 0 | Advance without rendering until GPU submit N |
+| `--manifest PATH` | `<out>/<run>.jsonl` | Write the machine-readable capture manifest here |
+| `--no-manifest` | off | Disable the default JSONL sidecar |
+| `--min-distinct-frames N` | 0 | Fail unless at least N distinct source publications were captured |
+| `--max-stale-seconds S` | unset | Fail if one source publication is reused longer than S seconds |
+| `--require-composited-frame` | off | Fail if every PNG came from raw guest scanout fallback |
+| `--min-present-count N` | 0 | Fail unless a captured sample reaches guest flip N |
+| `--min-frame-seq N` | 0 | Fail unless a captured sample reaches rendered-frame N |
+| `--require-crc32 N` | unset | Fail unless a sample has this RGBA CRC32 (decimal or `0xHEX`) |
 
 Only the game is required; everything else has a sane default.
 Directory-creation and PNG write failures include the failing path and operating-system error.
+
+Every normal run writes a JSONL manifest beside its PNGs. Each sample records the atomic present-source
+identity, guest flip count, rendered-frame sequence, dimensions, CRC32, capture source, elapsed time,
+input route, and whether the source advanced or was stale. A final summary records distinct-frame and
+maximum-stale metrics plus the exit status. Manifests flush after every sample so a killed run retains
+usable evidence. `--no-manifest` preserves the old PNG-only behavior.
+
+Assertions preserve every PNG and the manifest, print the concrete failed condition, and exit nonzero.
+This lets an automated progression run distinguish "120 files written" from "120 advancing frames" or
+"the requested checkpoint was reached." A timeout or incomplete screenshot count is also a failure.
 
 Warmup is useful when llvmpipe makes a frame-counted startup take minutes. The guest and GPU command
 decoder continue at native speed while Vulkan work is skipped; normal screenshots begin once warmup

--- a/prosper/tools/screenshot/capture_manifest.cpp
+++ b/prosper/tools/screenshot/capture_manifest.cpp
@@ -1,0 +1,135 @@
+#include "capture_manifest.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <iomanip>
+#include <sstream>
+
+namespace prosper::screenshot {
+
+CaptureClassification CaptureTracker::observe(const CaptureObservation& observation,
+                                               const std::vector<uint8_t>& pixels) {
+    CaptureClassification result;
+    if (have_previous_) {
+        result.source_advanced = observation.source != previous_.source ||
+                                 observation.source_seq != previous_.source_seq;
+        result.pixel_identical = observation.width == previous_.width &&
+                                 observation.height == previous_.height &&
+                                 pixels == previous_pixels_;
+        if (!result.source_advanced)
+            result.stale_seconds = std::max(0.0, observation.elapsed_seconds - last_advance_seconds_);
+    }
+    if (!have_previous_ || result.source_advanced) {
+        distinct_source_frames_++;
+        last_advance_seconds_ = observation.elapsed_seconds;
+    }
+    if (observation.source == CaptureSource::Rendered) rendered_samples_++;
+    max_stale_seconds_ = std::max(max_stale_seconds_, result.stale_seconds);
+    max_frame_seq_ = std::max(max_frame_seq_, observation.frame_seq);
+    max_present_count_ = std::max(max_present_count_, observation.present_count);
+    previous_ = observation;
+    previous_pixels_ = pixels;
+    have_previous_ = true;
+    return result;
+}
+
+std::string json_escape(const std::string& value) {
+    std::string out;
+    out.reserve(value.size() + 8);
+    for (const unsigned char c : value) {
+        switch (c) {
+        case '"': out += "\\\""; break;
+        case '\\': out += "\\\\"; break;
+        case '\b': out += "\\b"; break;
+        case '\f': out += "\\f"; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        case '\t': out += "\\t"; break;
+        default:
+            if (c < 0x20) {
+                char escaped[7];
+                std::snprintf(escaped, sizeof escaped, "\\u%04x", static_cast<unsigned>(c));
+                out += escaped;
+            } else {
+                out += static_cast<char>(c);
+            }
+        }
+    }
+    return out;
+}
+
+const char* capture_source_name(CaptureSource source) {
+    return source == CaptureSource::Rendered ? "composited" : "raw_scanout";
+}
+
+std::string manifest_run_json(const CaptureRunConfig& c) {
+    std::ostringstream line;
+    line << "{\"type\":\"run\",\"schema\":1"
+         << ",\"title\":\"" << json_escape(c.title) << "\""
+         << ",\"timestamp\":\"" << json_escape(c.timestamp) << "\""
+         << ",\"output_dir\":\"" << json_escape(c.output_dir) << "\""
+         << ",\"input_route\":\"" << json_escape(c.input_route) << "\""
+         << ",\"capture_mode\":\"" << (c.time_mode ? "wall_seconds" : "rendered_frames") << "\""
+         << ",\"seconds\":" << std::fixed << std::setprecision(6) << c.seconds
+         << ",\"every\":" << c.every << ",\"requested\":" << c.requested
+         << ",\"warmup_ms\":" << c.warmup_ms
+         << ",\"warmup_submits\":" << c.warmup_submits
+         << ",\"render_every\":\"" << json_escape(c.render_every) << "\""
+         << ",\"render_scale\":\"" << json_escape(c.render_scale) << "\""
+         << ",\"render_target_dim\":\"" << json_escape(c.render_target_dim) << "\""
+         << ",\"render_resource_dim\":\"" << json_escape(c.render_resource_dim) << "\""
+         << ",\"assertions\":{\"min_distinct_frames\":" << c.min_distinct_frames
+         << ",\"max_stale_seconds\":" << std::fixed << std::setprecision(6) << c.max_stale_seconds
+         << ",\"require_composited_frame\":" << (c.require_composited_frame ? "true" : "false")
+         << ",\"min_present_count\":" << c.min_present_count
+         << ",\"min_frame_seq\":" << c.min_frame_seq
+         << ",\"required_crc32\":";
+    if (c.required_crc32_set)
+        line << "\"" << std::hex << std::setw(8) << std::setfill('0') << c.required_crc32
+             << std::dec << "\"";
+    else
+        line << "null";
+    line << "}}";
+    return line.str();
+}
+
+std::string manifest_sample_json(int index, const std::string& png_path,
+                                 const CaptureObservation& o,
+                                 const CaptureClassification& c,
+                                 const std::string& input_route) {
+    std::ostringstream line;
+    line << "{\"type\":\"sample\",\"schema\":1,\"index\":" << index
+         << ",\"png\":\"" << json_escape(png_path) << "\""
+         << ",\"elapsed_seconds\":" << std::fixed << std::setprecision(6) << o.elapsed_seconds
+         << ",\"source\":\"" << capture_source_name(o.source) << "\""
+         << ",\"source_seq\":" << o.source_seq
+         << ",\"frame_seq\":" << o.frame_seq
+         << ",\"present_count\":" << o.present_count
+         << ",\"front_index\":" << o.front_index
+         << ",\"width\":" << o.width << ",\"height\":" << o.height
+         << ",\"pixel_crc32\":\"" << std::hex << std::setw(8) << std::setfill('0')
+         << o.pixel_crc32 << std::dec << "\""
+         << ",\"source_advanced\":" << (c.source_advanced ? "true" : "false")
+         << ",\"pixel_identical\":" << (c.pixel_identical ? "true" : "false")
+         << ",\"stale_seconds\":" << std::fixed << std::setprecision(6) << c.stale_seconds
+         << ",\"input_route\":\"" << json_escape(input_route) << "\"}";
+    return line.str();
+}
+
+std::string manifest_summary_json(int saved, int requested, bool timed_out,
+                                  const CaptureTracker& tracker, int exit_code) {
+    std::ostringstream line;
+    line << "{\"type\":\"summary\",\"schema\":1,\"saved\":" << saved
+         << ",\"requested\":" << requested
+         << ",\"timed_out\":" << (timed_out ? "true" : "false")
+         << ",\"distinct_source_frames\":" << tracker.distinct_source_frames()
+         << ",\"rendered_samples\":" << tracker.rendered_samples()
+         << ",\"max_stale_seconds\":" << std::fixed << std::setprecision(6)
+         << tracker.max_stale_seconds()
+         << ",\"max_frame_seq\":" << tracker.max_frame_seq()
+         << ",\"max_present_count\":" << tracker.max_present_count()
+         << ",\"exit_code\":" << exit_code << "}";
+    return line.str();
+}
+
+} // namespace prosper::screenshot

--- a/prosper/tools/screenshot/capture_manifest.hpp
+++ b/prosper/tools/screenshot/capture_manifest.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace prosper::screenshot {
+
+enum class CaptureSource : uint8_t { Rendered, RawScanout };
+
+struct CaptureObservation {
+    CaptureSource source = CaptureSource::Rendered;
+    uint64_t source_seq = 0;
+    uint64_t frame_seq = 0;
+    uint64_t present_count = 0;
+    int front_index = -1;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t pixel_crc32 = 0;
+    double elapsed_seconds = 0;
+};
+
+struct CaptureClassification {
+    bool source_advanced = true;
+    bool pixel_identical = false;
+    double stale_seconds = 0;
+};
+
+struct CaptureRunConfig {
+    std::string title;
+    std::string timestamp;
+    std::string output_dir;
+    std::string input_route;
+    std::string render_every;
+    std::string render_scale;
+    std::string render_target_dim;
+    std::string render_resource_dim;
+    bool time_mode = false;
+    double seconds = 0;
+    int every = 0;
+    int requested = 0;
+    int64_t warmup_ms = 0;
+    int warmup_submits = 0;
+    int min_distinct_frames = 0;
+    double max_stale_seconds = -1;
+    bool require_composited_frame = false;
+    uint64_t min_present_count = 0;
+    uint64_t min_frame_seq = 0;
+    bool required_crc32_set = false;
+    uint32_t required_crc32 = 0;
+};
+
+class CaptureTracker {
+public:
+    CaptureClassification observe(const CaptureObservation& observation,
+                                  const std::vector<uint8_t>& pixels);
+    uint64_t distinct_source_frames() const { return distinct_source_frames_; }
+    uint64_t rendered_samples() const { return rendered_samples_; }
+    double max_stale_seconds() const { return max_stale_seconds_; }
+    uint64_t max_frame_seq() const { return max_frame_seq_; }
+    uint64_t max_present_count() const { return max_present_count_; }
+
+private:
+    bool have_previous_ = false;
+    CaptureObservation previous_{};
+    std::vector<uint8_t> previous_pixels_;
+    double last_advance_seconds_ = 0;
+    uint64_t distinct_source_frames_ = 0;
+    uint64_t rendered_samples_ = 0;
+    double max_stale_seconds_ = 0;
+    uint64_t max_frame_seq_ = 0;
+    uint64_t max_present_count_ = 0;
+};
+
+std::string json_escape(const std::string& value);
+const char* capture_source_name(CaptureSource source);
+std::string manifest_run_json(const CaptureRunConfig& config);
+std::string manifest_sample_json(int index, const std::string& png_path,
+                                 const CaptureObservation& observation,
+                                 const CaptureClassification& classification,
+                                 const std::string& input_route);
+std::string manifest_summary_json(int saved, int requested, bool timed_out,
+                                  const CaptureTracker& tracker, int exit_code);
+
+} // namespace prosper::screenshot

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -7,7 +7,7 @@
 // one run shares a prefix and sorts together in a folder of many runs.
 //
 //   screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
-//              [--warmup-seconds S] [--warmup-submits N]
+//              [--warmup-seconds S] [--warmup-submits N] [manifest/assertion options]
 //     <app0-dir>   REQUIRED. The game dump root (e.g. .../PPSA24651-app0). Title code = its basename
 //                  with a trailing "-app0" stripped.
 //     --every N    rendered frames between screenshots       (default 60)
@@ -26,6 +26,7 @@
 #include "host/exec_image.hpp"         // run_entry
 #include "gpu/videoout_present.hpp"    // present_count / present_readback / present_width/height
 #include "live_renderer.hpp"           // register_live_renderer (frontends/shared)
+#include "capture_manifest.hpp"
 
 #include <zlib.h>
 #include <algorithm>
@@ -37,6 +38,8 @@
 #include <cstdint>
 #include <cerrno>
 #include <filesystem>
+#include <iomanip>
+#include <sstream>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -64,6 +67,15 @@ bool parse_nonnegative_int(const char* text, int& value) {
     const long parsed = strtol(text, &end, 10);
     if (errno || end == text || *end != '\0' || parsed < 0 || parsed > INT_MAX) return false;
     value = static_cast<int>(parsed);
+    return true;
+}
+
+bool parse_nonnegative_u64(const char* text, uint64_t& value) {
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long long parsed = strtoull(text, &end, 0);
+    if (errno || end == text || *end != '\0' || text[0] == '-') return false;
+    value = static_cast<uint64_t>(parsed);
     return true;
 }
 
@@ -126,11 +138,15 @@ bool write_png(const char* path, const uint8_t* rgba, uint32_t w, uint32_t h,
 } // namespace
 
 int main(int argc, char** argv) {
-    std::string dump, out = ".";
+    std::string dump, out = ".", manifest_path;
     int every = 60, count = 30, timeout = 900;
     double seconds = 0.0;   // >0 => capture every N wall-clock seconds instead of every N rendered frames
     double warmup_seconds = -1.0;  // <0 => preserve the environment; explicit values override it
+    double max_stale_seconds = -1.0;
     int warmup_submits = -1;
+    int min_distinct_frames = 0;
+    uint64_t min_present_count = 0, min_frame_seq = 0, required_crc32 = 0;
+    bool manifest_disabled = false, require_composited_frame = false, required_crc32_set = false;
     bool warmup_seconds_set = false, warmup_submits_set = false;
     for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
@@ -138,7 +154,42 @@ int main(int argc, char** argv) {
         else if (a == "--seconds" && i + 1 < argc) seconds = atof(argv[++i]);
         else if (a == "--count"   && i + 1 < argc) count = atoi(argv[++i]);
         else if (a == "--out"     && i + 1 < argc) out   = argv[++i];
+        else if (a == "--manifest" && i + 1 < argc) manifest_path = argv[++i];
+        else if (a == "--no-manifest") manifest_disabled = true;
         else if (a == "--timeout" && i + 1 < argc) timeout = atoi(argv[++i]);
+        else if (a == "--min-distinct-frames" && i + 1 < argc) {
+            if (!parse_nonnegative_int(argv[++i], min_distinct_frames)) {
+                fprintf(stderr, "screenshot: --min-distinct-frames requires a non-negative integer\n");
+                return 2;
+            }
+        }
+        else if (a == "--max-stale-seconds" && i + 1 < argc) {
+            if (!parse_nonnegative_double(argv[++i], max_stale_seconds)) {
+                fprintf(stderr, "screenshot: --max-stale-seconds requires a non-negative number\n");
+                return 2;
+            }
+        }
+        else if (a == "--min-present-count" && i + 1 < argc) {
+            if (!parse_nonnegative_u64(argv[++i], min_present_count)) {
+                fprintf(stderr, "screenshot: --min-present-count requires a non-negative integer\n");
+                return 2;
+            }
+        }
+        else if (a == "--min-frame-seq" && i + 1 < argc) {
+            if (!parse_nonnegative_u64(argv[++i], min_frame_seq)) {
+                fprintf(stderr, "screenshot: --min-frame-seq requires a non-negative integer\n");
+                return 2;
+            }
+        }
+        else if (a == "--require-crc32" && i + 1 < argc) {
+            required_crc32_set = parse_nonnegative_u64(argv[++i], required_crc32) &&
+                                 required_crc32 <= UINT32_MAX;
+            if (!required_crc32_set) {
+                fprintf(stderr, "screenshot: --require-crc32 requires a 32-bit integer (decimal or 0xHEX)\n");
+                return 2;
+            }
+        }
+        else if (a == "--require-composited-frame") require_composited_frame = true;
         else if (a == "--warmup-seconds" && i + 1 < argc) {
             warmup_seconds_set = true;
             if (!parse_nonnegative_double(argv[++i], warmup_seconds)) {
@@ -157,7 +208,11 @@ int main(int argc, char** argv) {
         else { fprintf(stderr, "screenshot: unknown/duplicate arg '%s'\n", a.c_str()); return 2; }
     }
     if (dump.empty()) {
-        fprintf(stderr, "usage: screenshot <app0-dir> [--every N=60 | --seconds S] [--count M=30] [--out DIR] [--timeout SECS] [--warmup-seconds S] [--warmup-submits N]\n");
+        fprintf(stderr, "usage: screenshot <app0-dir> [--every N=60 | --seconds S] [--count M=30] "
+                        "[--out DIR] [--manifest PATH | --no-manifest] [--timeout SECS] "
+                        "[--warmup-seconds S] [--warmup-submits N] [--min-distinct-frames N] "
+                        "[--max-stale-seconds S] [--require-composited-frame] "
+                        "[--min-present-count N] [--min-frame-seq N] [--require-crc32 N]\n");
         return 2;
     }
     if (every < 1) every = 1;
@@ -197,6 +252,7 @@ int main(int argc, char** argv) {
     const int render_first = getenv("PROSPER_RENDER_FIRST")
         ? std::max(0, atoi(getenv("PROSPER_RENDER_FIRST"))) : 0;
     const bool warming_up = render_delay_ms > 0 || render_first > 0;
+    const std::string input_route = getenv("PROSPER_PAD_SCRIPT") ? getenv("PROSPER_PAD_SCRIPT") : "";
 
     std::error_code out_ec;
     std::filesystem::create_directories(out, out_ec);
@@ -204,6 +260,61 @@ int main(int argc, char** argv) {
         fprintf(stderr, "screenshot: cannot create output directory '%s': %s\n",
                 out.c_str(), out_ec.message().c_str());
         return 1;
+    }
+
+    if (!manifest_disabled && manifest_path.empty())
+        manifest_path = out + "/" + code + "_" + ts + ".jsonl";
+    FILE* manifest = nullptr;
+    if (!manifest_disabled) {
+        const std::filesystem::path mp(manifest_path);
+        if (mp.has_parent_path()) {
+            std::error_code manifest_dir_ec;
+            std::filesystem::create_directories(mp.parent_path(), manifest_dir_ec);
+            if (manifest_dir_ec) {
+                fprintf(stderr, "screenshot: cannot create manifest directory '%s': %s\n",
+                        mp.parent_path().string().c_str(), manifest_dir_ec.message().c_str());
+                return 1;
+            }
+        }
+        manifest = fopen(manifest_path.c_str(), "wb");
+        if (!manifest) {
+            fprintf(stderr, "screenshot: cannot open manifest '%s': %s\n",
+                    manifest_path.c_str(), strerror(errno));
+            return 1;
+        }
+        auto env_string = [](const char* name) {
+            const char* value = getenv(name);
+            return value ? std::string(value) : std::string();
+        };
+        screenshot::CaptureRunConfig run_config;
+        run_config.title = code;
+        run_config.timestamp = ts;
+        run_config.output_dir = out;
+        run_config.input_route = input_route;
+        run_config.render_every = env_string("PROSPER_RENDER_EVERY");
+        run_config.render_scale = env_string("PROSPER_RENDER_SCALE");
+        run_config.render_target_dim = env_string("PROSPER_RENDER_TARGET_DIM");
+        run_config.render_resource_dim = env_string("PROSPER_RENDER_RESOURCE_DIM");
+        run_config.time_mode = seconds > 0;
+        run_config.seconds = seconds;
+        run_config.every = every;
+        run_config.requested = count;
+        run_config.warmup_ms = render_delay_ms;
+        run_config.warmup_submits = render_first;
+        run_config.min_distinct_frames = min_distinct_frames;
+        run_config.max_stale_seconds = max_stale_seconds;
+        run_config.require_composited_frame = require_composited_frame;
+        run_config.min_present_count = min_present_count;
+        run_config.min_frame_seq = min_frame_seq;
+        run_config.required_crc32_set = required_crc32_set;
+        run_config.required_crc32 = static_cast<uint32_t>(required_crc32);
+        const std::string run_line = screenshot::manifest_run_json(run_config);
+        if (fprintf(manifest, "%s\n", run_line.c_str()) < 0 || fflush(manifest) != 0) {
+            fprintf(stderr, "screenshot: cannot write manifest header '%s': %s\n",
+                    manifest_path.c_str(), strerror(errno));
+            fclose(manifest);
+            return 1;
+        }
     }
 
     // Register the shared live renderer (feeds the present layer; no BMP spam), then boot + run the
@@ -224,9 +335,12 @@ int main(int argc, char** argv) {
     if (warming_up)
         fprintf(stderr, "[shot] warmup: %lld ms, %d submits; capture suppressed until warmup ends\n",
                 (long long)render_delay_ms, render_first);
+    if (manifest)
+        fprintf(stderr, "[shot] manifest: %s\n", manifest_path.c_str());
 
-    std::vector<uint8_t> buf;
     int saved = 0;
+    bool timed_out = false, manifest_failed = false, required_crc32_seen = false;
+    screenshot::CaptureTracker tracker;
     uint64_t next = (uint64_t)every;   // frame-mode: rendered-frame # for the next shot
     auto t0 = std::chrono::steady_clock::now();
     auto last_cap = t0;                // time-mode: wall-clock of the previous shot
@@ -236,6 +350,7 @@ int main(int argc, char** argv) {
         if (timeout > 0 && el > timeout) {
             fprintf(stderr, "[shot] timeout after %.0fs with %d/%d saved — game not rendering enough "
                             "(wrong guest env for this title? see the README)\n", el, saved, count);
+            timed_out = true;
             break;
         }
         bool due = time_mode ? (std::chrono::duration<double>(now - last_cap).count() >= seconds)
@@ -247,35 +362,100 @@ int main(int argc, char** argv) {
                                  gpu::present_front_index() >= 0 &&
                                  gpu::present_width() > 0 && gpu::present_height() > 0;
         if ((rendered_capture || raw_scanout) && due) {
-            uint64_t at = gpu::present_frame_seq();
-            // Size the buffer from the RENDERED frame's dims, not the guest display dims: under
-            // PROSPER_RENDER_SCALE the frame is smaller, and present_readback returns g_frame.size()
-            // (scaled). Using the display dims made buf.size() != readback bytes, so the exact-size
-            // guard below dropped EVERY screenshot silently (#399). Fall back to display dims only when
-            // no rendered frame is present (the raw-scanout path).
-            uint32_t fw = rendered ? gpu::present_frame_width() : 0;
-            uint32_t fh = rendered ? gpu::present_frame_height() : 0;
-            uint32_t w = fw ? fw : gpu::present_width(), h = fh ? fh : gpu::present_height();
-            if (w && h) {
-                buf.resize((size_t)w * h * 4);
-                if (gpu::present_readback(buf.data(), buf.size()) == buf.size()) {
-                    char fn[1024];
-                    snprintf(fn, sizeof fn, "%s/%s_%s_%0*d.png", out.c_str(), code.c_str(), ts, pad, saved);
+            gpu::PresentSnapshot snap;
+            if (gpu::present_snapshot(snap)) {
+                const bool snap_rendered = snap.source == gpu::PresentSource::Rendered;
+                const bool source_allowed = snap_rendered ? rendered_capture : raw_scanout;
+                if (source_allowed && snap.width && snap.height && !snap.rgba.empty()) {
+                    std::ostringstream filename;
+                    filename << out << "/" << code << "_" << ts << "_"
+                             << std::setw(pad) << std::setfill('0') << saved << ".png";
+                    const std::string fn = filename.str();
                     std::string png_error;
-                    if (write_png(fn, buf.data(), w, h, png_error)) {
-                        fprintf(stderr, "[shot] %d/%d  %s  (frame %llu, %.1fs)\n",
-                                saved + 1, count, fn, (unsigned long long)at, el);
+                    if (write_png(fn.c_str(), snap.rgba.data(), snap.width, snap.height, png_error)) {
+                        const uint32_t pixel_crc = static_cast<uint32_t>(crc32(
+                            0, reinterpret_cast<const Bytef*>(snap.rgba.data()),
+                            static_cast<uInt>(snap.rgba.size())));
+                        screenshot::CaptureObservation observation;
+                        observation.source = snap_rendered ? screenshot::CaptureSource::Rendered
+                                                           : screenshot::CaptureSource::RawScanout;
+                        observation.source_seq = snap.source_seq;
+                        observation.frame_seq = snap.frame_seq;
+                        observation.present_count = snap.present_count;
+                        observation.front_index = snap.front_index;
+                        observation.width = snap.width;
+                        observation.height = snap.height;
+                        observation.pixel_crc32 = pixel_crc;
+                        observation.elapsed_seconds = el;
+                        const auto classification = tracker.observe(observation, snap.rgba);
+                        required_crc32_seen |= required_crc32_set && pixel_crc == required_crc32;
+                        fprintf(stderr, "[shot] %d/%d  %s  (frame %llu, %.1fs%s, crc=%08x)\n",
+                                saved + 1, count, fn.c_str(), (unsigned long long)snap.frame_seq, el,
+                                classification.source_advanced ? "" : ", STALE",
+                                pixel_crc);
+                        if (manifest) {
+                            const std::string line = screenshot::manifest_sample_json(
+                                saved, fn, observation, classification, input_route);
+                            if (fprintf(manifest, "%s\n", line.c_str()) < 0 || fflush(manifest) != 0) {
+                                fprintf(stderr, "[shot] manifest write failed: %s: %s\n",
+                                        manifest_path.c_str(), strerror(errno));
+                                manifest_failed = true;
+                            }
+                        }
                         saved++;
                     } else {
-                        fprintf(stderr, "[shot] PNG write failed: %s: %s\n", fn, png_error.c_str());
+                        fprintf(stderr, "[shot] PNG write failed: %s: %s\n",
+                                fn.c_str(), png_error.c_str());
                     }
-                    if (time_mode) last_cap = now; else next = at + (uint64_t)every;
+                    if (time_mode) last_cap = now; else next = snap.frame_seq + (uint64_t)every;
                 }
             }
         } else {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }
     }
-    fprintf(stderr, "[shot] done: %d screenshot(s) in %s\n", saved, out.c_str());
-    _exit(0);   // the guest thread is detached and running guest code; don't block on teardown
+    int exit_code = 0;
+    auto assertion_failed = [&](const char* format, auto... args) {
+        fprintf(stderr, "[shot] assertion failed: ");
+        fprintf(stderr, format, args...);
+        fputc('\n', stderr);
+        exit_code = 1;
+    };
+    if (saved != count)
+        assertion_failed("saved %d/%d requested screenshots", saved, count);
+    if (manifest_failed)
+        assertion_failed("%s", "manifest could not be written completely");
+    if (tracker.distinct_source_frames() < static_cast<uint64_t>(min_distinct_frames))
+        assertion_failed("distinct source frames %llu < required %d",
+                         (unsigned long long)tracker.distinct_source_frames(), min_distinct_frames);
+    if (max_stale_seconds >= 0 && tracker.max_stale_seconds() > max_stale_seconds)
+        assertion_failed("maximum stale duration %.3fs > allowed %.3fs",
+                         tracker.max_stale_seconds(), max_stale_seconds);
+    if (require_composited_frame && tracker.rendered_samples() == 0)
+        assertion_failed("%s", "no composited renderer frame was captured");
+    if (tracker.max_present_count() < min_present_count)
+        assertion_failed("present count %llu < required %llu",
+                         (unsigned long long)tracker.max_present_count(),
+                         (unsigned long long)min_present_count);
+    if (tracker.max_frame_seq() < min_frame_seq)
+        assertion_failed("rendered frame sequence %llu < required %llu",
+                         (unsigned long long)tracker.max_frame_seq(),
+                         (unsigned long long)min_frame_seq);
+    if (required_crc32_set && !required_crc32_seen)
+        assertion_failed("required pixel CRC32 %08llx was not captured",
+                         (unsigned long long)required_crc32);
+
+    if (manifest) {
+        const std::string summary = screenshot::manifest_summary_json(
+            saved, count, timed_out, tracker, exit_code);
+        if (fprintf(manifest, "%s\n", summary.c_str()) < 0 || fclose(manifest) != 0) {
+            fprintf(stderr, "[shot] manifest close failed: %s: %s\n",
+                    manifest_path.c_str(), strerror(errno));
+            exit_code = 1;
+        }
+    }
+    fprintf(stderr, "[shot] done: %d screenshot(s) in %s; distinct=%llu max-stale=%.1fs status=%s\n",
+            saved, out.c_str(), (unsigned long long)tracker.distinct_source_frames(),
+            tracker.max_stale_seconds(), exit_code ? "FAILED" : "ok");
+    _exit(exit_code);   // the guest thread is detached and running guest code; don't block on teardown
 }


### PR DESCRIPTION
## Summary

- add a default JSONL run/sample/summary manifest to `screenshot`
- capture pixels and present identity atomically, with explicit composited/raw source metadata
- classify stale source publications and exact byte-identical pixels
- add machine-checkable progression assertions with nonzero failure status
- document the contract and add pure/unit coverage

## Why

A Dead Cells progression run wrote 120 one-per-second PNGs while representing only 20 renderer publications. It also had no machine-readable proof that gameplay was reached. This change makes those conditions explicit and prevents artifact-count success from being mistaken for progression success.

## Validation

- Linux build
- 88/88 ctest
- live dense Dead Cells control: 2 distinct composited publications, exit 0
- live sparse negative control: five PNGs but one raw publication/four stale samples; assertions exit 1 and preserve evidence
- Messenger snapshot guard: pass, 24,318 colors >= 5,000
- Dead Cells splash snapshot: pre-existing current-master mismatch reproduced on untouched `dd03bc3`, tracked in #596

Fixes #593
Part of #592.