### PR TITLE
feat(gpu): record native submit and present timelines (#594)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.self
 eboot.bin
 *.prgcap
+*.prgtl
 
 # ---- Build output ----
 /prosper/build/

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -360,6 +360,15 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_capture PRIVATE prosper_core)
   add_test(NAME gpu_capture_roundtrip COMMAND test_gpu_capture)
 
+  # Native-speed append-only submit/present timeline: portable framing, checksums, and truncated-tail
+  # recovery are pure and must not depend on Vulkan or a game dump.
+  add_executable(test_gpu_timeline tests/test_gpu_timeline.cpp)
+  target_link_libraries(test_gpu_timeline PRIVATE prosper_core)
+  add_test(NAME gpu_timeline_roundtrip COMMAND test_gpu_timeline)
+
+  add_executable(gpu_timeline tools/gpu_timeline/gpu_timeline.cpp)
+  target_link_libraries(gpu_timeline PRIVATE prosper_core)
+
   # Front-half resource-table builder + V# descriptor decode (agc_shader_layout.cpp): shader user_data
   # + user-data SGPRs -> ShaderResourceTable (constant buffers, stage 1). Pure/cross-platform.
   add_executable(test_build_shader_resources tests/test_build_shader_resources.cpp)

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1,0 +1,531 @@
+#include "gpu_timeline.hpp"
+
+#include "render_state.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <bit>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <utility>
+
+namespace prosper::gpu {
+namespace {
+
+constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
+constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
+constexpr uint32_t kVersion = 1;
+constexpr uint32_t kEndian = 0x01020304u;
+constexpr uint32_t kMaxPayloadBytes = 1u << 20;
+constexpr uint32_t kFlushInterval = 256;
+
+enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3 };
+
+struct Bytes {
+    std::vector<uint8_t> data;
+    void raw(const void* src, size_t bytes) {
+        const auto* p = static_cast<const uint8_t*>(src);
+        data.insert(data.end(), p, p + bytes);
+    }
+    void u32(uint32_t value) {
+        for (unsigned i = 0; i < 4; ++i) data.push_back(static_cast<uint8_t>(value >> (i * 8)));
+    }
+    void u64(uint64_t value) {
+        for (unsigned i = 0; i < 8; ++i) data.push_back(static_cast<uint8_t>(value >> (i * 8)));
+    }
+    void string(const std::string& value) {
+        u32(static_cast<uint32_t>(value.size()));
+        raw(value.data(), value.size());
+    }
+};
+
+struct Cursor {
+    const uint8_t* data = nullptr;
+    size_t left = 0;
+    bool take(void* dst, size_t bytes) {
+        if (bytes > left) return false;
+        if (bytes) std::memcpy(dst, data, bytes);
+        data += bytes;
+        left -= bytes;
+        return true;
+    }
+    bool u32(uint32_t& value) {
+        uint8_t b[4];
+        if (!take(b, sizeof b)) return false;
+        value = uint32_t(b[0]) | uint32_t(b[1]) << 8 | uint32_t(b[2]) << 16 | uint32_t(b[3]) << 24;
+        return true;
+    }
+    bool u64(uint64_t& value) {
+        uint8_t b[8];
+        if (!take(b, sizeof b)) return false;
+        value = 0;
+        for (unsigned i = 0; i < 8; ++i) value |= uint64_t(b[i]) << (i * 8);
+        return true;
+    }
+    bool string(std::string& value) {
+        uint32_t size = 0;
+        if (!u32(size) || size > left) return false;
+        value.assign(reinterpret_cast<const char*>(data), size);
+        data += size;
+        left -= size;
+        return true;
+    }
+};
+
+uint64_t hash_bytes(const uint8_t* data, size_t size) {
+    uint64_t hash = 1469598103934665603ull;
+    for (size_t i = 0; i < size; ++i) {
+        hash ^= data[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+bool write_all(FILE* file, const void* data, size_t bytes, std::string& error) {
+    if (!bytes) return true;
+    if (std::fwrite(data, 1, bytes, file) == bytes) return true;
+    error = std::string("timeline write failed: ") + std::strerror(errno);
+    return false;
+}
+
+bool append_record(FILE* file, RecordType type, uint64_t sequence, uint64_t elapsed_ns,
+                   const Bytes& payload, std::string& error) {
+    if (payload.data.size() > kMaxPayloadBytes) {
+        error = "timeline record payload exceeds 1 MiB";
+        return false;
+    }
+    Bytes body;
+    body.u32(static_cast<uint32_t>(type));
+    body.u32(static_cast<uint32_t>(payload.data.size()));
+    body.u64(sequence);
+    body.u64(elapsed_ns);
+    body.raw(payload.data.data(), payload.data.size());
+    const uint64_t checksum = hash_bytes(body.data.data(), body.data.size());
+    Bytes trailer;
+    trailer.u64(checksum);
+    return write_all(file, kRecordMagic, sizeof kRecordMagic, error) &&
+           write_all(file, body.data.data(), body.data.size(), error) &&
+           write_all(file, trailer.data.data(), trailer.data.size(), error);
+}
+
+bool read_exact(std::ifstream& file, void* dst, size_t bytes, bool& clean_eof) {
+    clean_eof = false;
+    file.read(static_cast<char*>(dst), static_cast<std::streamsize>(bytes));
+    if (file.gcount() == static_cast<std::streamsize>(bytes)) return true;
+    clean_eof = file.gcount() == 0 && file.eof();
+    return false;
+}
+
+const char* env_or_empty(const char* name) {
+    const char* value = std::getenv(name);
+    return value ? value : "";
+}
+
+std::atomic<uint64_t> g_active_submit_no{0};
+
+struct RuntimeRecorder {
+    std::mutex mutex;
+    std::unique_ptr<GpuTimelineWriter> writer;
+    std::atomic<GpuTimelineWriter*> fast_writer{nullptr};
+    std::atomic<uint8_t> state{0}; // 0 uninitialized, 1 active, 2 disabled/failed
+    bool failed = false;
+
+    GpuTimelineWriter* get() {
+        if (GpuTimelineWriter* active = fast_writer.load(std::memory_order_acquire)) return active;
+        if (state.load(std::memory_order_acquire) == 2) return nullptr;
+        std::lock_guard<std::mutex> lock(mutex);
+        if (writer && !failed) return writer.get();
+        if (state.load(std::memory_order_relaxed) == 2) return nullptr;
+        const char* path = std::getenv("PROSPER_GPU_TIMELINE");
+        if (!path || !*path) {
+            state.store(2, std::memory_order_release);
+            return nullptr;
+        }
+        std::error_code ec;
+        const std::filesystem::path output(path);
+        if (output.has_parent_path()) std::filesystem::create_directories(output.parent_path(), ec);
+        if (ec) {
+            std::fprintf(stderr, "[timeline] cannot create '%s': %s\n", path, ec.message().c_str());
+            failed = true;
+            state.store(2, std::memory_order_release);
+            return nullptr;
+        }
+        GpuTimelineMetadata metadata;
+#ifdef PROSPER_GIT_REVISION
+        metadata.revision = PROSPER_GIT_REVISION;
+#else
+        metadata.revision = "unknown";
+#endif
+        if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) metadata.revision = revision;
+        metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
+        metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
+        writer = std::make_unique<GpuTimelineWriter>();
+        std::string error;
+        if (!writer->open(path, metadata, error)) {
+            std::fprintf(stderr, "[timeline] open failed: %s\n", error.c_str());
+            writer.reset();
+            failed = true;
+            state.store(2, std::memory_order_release);
+            return nullptr;
+        }
+        std::fprintf(stderr, "[timeline] recording native submit/present index -> %s\n", path);
+        GpuTimelineWriter* active = writer.get();
+        fast_writer.store(active, std::memory_order_release);
+        state.store(1, std::memory_order_release);
+        return active;
+    }
+
+    void mark_failed(const std::string& error) {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!failed) std::fprintf(stderr, "[timeline] recording failed: %s\n", error.c_str());
+        failed = true;
+        fast_writer.store(nullptr, std::memory_order_release);
+        state.store(2, std::memory_order_release);
+    }
+
+    void close() {
+        std::lock_guard<std::mutex> lock(mutex);
+        fast_writer.store(nullptr, std::memory_order_release);
+        if (writer) writer->close();
+        state.store(2, std::memory_order_release);
+    }
+};
+
+RuntimeRecorder& runtime_recorder() {
+    static RuntimeRecorder recorder;
+    return recorder;
+}
+
+} // namespace
+
+struct GpuTimelineWriter::Impl {
+    FILE* file = nullptr;
+    std::mutex mutex;
+    uint64_t next_sequence = 0;
+    uint32_t records_since_flush = 0;
+    std::chrono::steady_clock::time_point start;
+
+    uint64_t elapsed_ns() const {
+        return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - start).count());
+    }
+
+    bool append(RecordType type, const Bytes& payload, std::string& error) {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!file) {
+            error = "timeline writer is not open";
+            return false;
+        }
+        if (!append_record(file, type, next_sequence++, elapsed_ns(), payload, error)) return false;
+        if (++records_since_flush >= kFlushInterval) {
+            if (std::fflush(file) != 0) {
+                error = std::string("timeline flush failed: ") + std::strerror(errno);
+                return false;
+            }
+            records_since_flush = 0;
+        }
+        return true;
+    }
+};
+
+GpuTimelineWriter::GpuTimelineWriter() : impl_(std::make_unique<Impl>()) {}
+GpuTimelineWriter::~GpuTimelineWriter() { close(); }
+
+bool GpuTimelineWriter::open(const std::string& path, const GpuTimelineMetadata& metadata,
+                             std::string& error) {
+    close();
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->file = std::fopen(path.c_str(), "wb");
+    if (!impl_->file) {
+        error = std::string("cannot open timeline: ") + std::strerror(errno);
+        return false;
+    }
+    std::setvbuf(impl_->file, nullptr, _IOFBF, 1u << 20);
+    impl_->start = std::chrono::steady_clock::now();
+    impl_->next_sequence = 0;
+    impl_->records_since_flush = 0;
+    Bytes header;
+    header.raw(kFileMagic, sizeof kFileMagic);
+    header.u32(kVersion);
+    header.u32(kEndian);
+    if (!write_all(impl_->file, header.data.data(), header.data.size(), error)) {
+        std::fclose(impl_->file);
+        impl_->file = nullptr;
+        return false;
+    }
+    Bytes payload;
+    payload.string(metadata.revision);
+    payload.string(metadata.title_id);
+    payload.string(metadata.input_route);
+    if (!append_record(impl_->file, RecordType::Metadata, impl_->next_sequence++, 0, payload, error) ||
+        std::fflush(impl_->file) != 0) {
+        if (error.empty()) error = std::string("timeline header flush failed: ") + std::strerror(errno);
+        std::fclose(impl_->file);
+        impl_->file = nullptr;
+        return false;
+    }
+    return true;
+}
+
+bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::string& error) {
+    Bytes payload;
+    payload.u64(submit.submit_no);
+    payload.u64(submit.process_command_order);
+    payload.u64(submit.first_command_order);
+    payload.u64(submit.last_command_order);
+    payload.u64(submit.color0_base);
+    payload.u32(submit.draw_count);
+    payload.u32(submit.dispatch_count);
+    payload.u32(submit.color0_width);
+    payload.u32(submit.color0_height);
+    return impl_->append(RecordType::Submit, payload, error);
+}
+
+bool GpuTimelineWriter::append_present(const GpuTimelinePresent& present, std::string& error) {
+    Bytes payload;
+    payload.u64(present.present_count);
+    payload.u64(present.latest_submit_no);
+    payload.u32(std::bit_cast<uint32_t>(present.buffer_index));
+    payload.u64(std::bit_cast<uint64_t>(present.flip_arg));
+    payload.u32(present.width);
+    payload.u32(present.height);
+    return impl_->append(RecordType::Present, payload, error);
+}
+
+bool GpuTimelineWriter::flush(std::string& error) {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    if (!impl_->file) return true;
+    if (std::fflush(impl_->file) == 0) {
+        impl_->records_since_flush = 0;
+        return true;
+    }
+    error = std::string("timeline flush failed: ") + std::strerror(errno);
+    return false;
+}
+
+void GpuTimelineWriter::close() {
+    if (!impl_) return;
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    if (!impl_->file) return;
+    std::fflush(impl_->file);
+    std::fclose(impl_->file);
+    impl_->file = nullptr;
+}
+
+bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::string& error) {
+    timeline = {};
+    error.clear();
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        error = "cannot open timeline";
+        return false;
+    }
+    uint8_t file_header[16];
+    bool clean_eof = false;
+    if (!read_exact(file, file_header, sizeof file_header, clean_eof)) {
+        error = "truncated timeline header";
+        return false;
+    }
+    Cursor header{file_header, sizeof file_header};
+    uint8_t magic[8];
+    uint32_t version = 0, endian = 0;
+    if (!header.take(magic, sizeof magic) || std::memcmp(magic, kFileMagic, sizeof magic) != 0 ||
+        !header.u32(version) || !header.u32(endian)) {
+        error = "invalid timeline header";
+        return false;
+    }
+    if (version != kVersion) {
+        error = "unsupported timeline version " + std::to_string(version);
+        return false;
+    }
+    if (endian != kEndian) {
+        error = "timeline endian marker mismatch";
+        return false;
+    }
+
+    bool have_metadata = false;
+    uint64_t expected_sequence = 0;
+    for (;;) {
+        uint8_t magic_record[4];
+        if (!read_exact(file, magic_record, sizeof magic_record, clean_eof)) {
+            if (clean_eof) break;
+            timeline.truncated_tail = true;
+            break;
+        }
+        if (std::memcmp(magic_record, kRecordMagic, sizeof magic_record) != 0) {
+            error = "invalid timeline record magic";
+            return false;
+        }
+        uint8_t record_header[24];
+        if (!read_exact(file, record_header, sizeof record_header, clean_eof)) {
+            timeline.truncated_tail = true;
+            break;
+        }
+        Cursor rc{record_header, sizeof record_header};
+        uint32_t type_raw = 0, payload_size = 0;
+        uint64_t sequence = 0, elapsed_ns = 0;
+        if (!rc.u32(type_raw) || !rc.u32(payload_size) || !rc.u64(sequence) || !rc.u64(elapsed_ns) ||
+            payload_size > kMaxPayloadBytes) {
+            error = "invalid timeline record header";
+            return false;
+        }
+        if (sequence != expected_sequence++) {
+            error = "non-contiguous timeline record sequence";
+            return false;
+        }
+        std::vector<uint8_t> payload(payload_size);
+        uint8_t checksum_bytes[8];
+        if (!read_exact(file, payload.data(), payload.size(), clean_eof) ||
+            !read_exact(file, checksum_bytes, sizeof checksum_bytes, clean_eof)) {
+            timeline.truncated_tail = true;
+            break;
+        }
+        Cursor checksum_cursor{checksum_bytes, sizeof checksum_bytes};
+        uint64_t stored_checksum = 0;
+        checksum_cursor.u64(stored_checksum);
+        Bytes body;
+        body.raw(record_header, sizeof record_header);
+        body.raw(payload.data(), payload.size());
+        if (hash_bytes(body.data.data(), body.data.size()) != stored_checksum) {
+            error = "timeline record checksum mismatch at sequence " + std::to_string(sequence);
+            return false;
+        }
+
+        Cursor p{payload.data(), payload.size()};
+        const RecordType type = static_cast<RecordType>(type_raw);
+        if (type == RecordType::Metadata) {
+            if (have_metadata || sequence != 0 || !p.string(timeline.metadata.revision) ||
+                !p.string(timeline.metadata.title_id) || !p.string(timeline.metadata.input_route) || p.left) {
+                error = "invalid timeline metadata record";
+                return false;
+            }
+            have_metadata = true;
+        } else if (type == RecordType::Submit) {
+            GpuTimelineSubmit submit;
+            submit.sequence = sequence;
+            submit.elapsed_ns = elapsed_ns;
+            if (!p.u64(submit.submit_no) || !p.u64(submit.process_command_order) ||
+                !p.u64(submit.first_command_order) || !p.u64(submit.last_command_order) ||
+                !p.u64(submit.color0_base) || !p.u32(submit.draw_count) ||
+                !p.u32(submit.dispatch_count) || !p.u32(submit.color0_width) ||
+                !p.u32(submit.color0_height) || p.left) {
+                error = "invalid timeline submit record";
+                return false;
+            }
+            timeline.submits.push_back(submit);
+        } else if (type == RecordType::Present) {
+            GpuTimelinePresent present;
+            present.sequence = sequence;
+            present.elapsed_ns = elapsed_ns;
+            uint32_t buffer_index = 0;
+            uint64_t flip_arg = 0;
+            if (!p.u64(present.present_count) || !p.u64(present.latest_submit_no) ||
+                !p.u32(buffer_index) || !p.u64(flip_arg) || !p.u32(present.width) ||
+                !p.u32(present.height) || p.left) {
+                error = "invalid timeline present record";
+                return false;
+            }
+            present.buffer_index = std::bit_cast<int32_t>(buffer_index);
+            present.flip_arg = std::bit_cast<int64_t>(flip_arg);
+            timeline.presents.push_back(present);
+        } else {
+            error = "unknown timeline record type " + std::to_string(type_raw);
+            return false;
+        }
+    }
+    if (!have_metadata) {
+        error = "timeline has no metadata record";
+        return false;
+    }
+    return true;
+}
+
+void begin_gpu_timeline_submit(uint64_t submit_no) {
+    static const bool requested = [] {
+        const char* path = std::getenv("PROSPER_GPU_TIMELINE");
+        return path && *path;
+    }();
+    if (requested) g_active_submit_no.store(submit_no, std::memory_order_release);
+}
+
+void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
+    static const bool requested = [] {
+        const char* path = std::getenv("PROSPER_GPU_TIMELINE");
+        return path && *path;
+    }();
+    if (!requested) return;
+    GpuTimelineWriter* writer = runtime_recorder().get();
+    if (!writer) return;
+    GpuTimelineSubmit submit;
+    submit.submit_no = submit_no;
+    submit.process_command_order = state.command_order;
+    submit.draw_count = static_cast<uint32_t>(std::min<size_t>(state.draws.size(), UINT32_MAX));
+    submit.dispatch_count = static_cast<uint32_t>(std::min<size_t>(state.dispatches.size(), UINT32_MAX));
+    submit.first_command_order = std::numeric_limits<uint64_t>::max();
+    for (const auto& draw : state.draws) {
+        submit.first_command_order = std::min(submit.first_command_order, draw.command_order);
+        submit.last_command_order = std::max(submit.last_command_order, draw.command_order);
+    }
+    for (const auto& dispatch : state.dispatches) {
+        submit.first_command_order = std::min(submit.first_command_order, dispatch.command_order);
+        submit.last_command_order = std::max(submit.last_command_order, dispatch.command_order);
+    }
+    if (submit.first_command_order == std::numeric_limits<uint64_t>::max())
+        submit.first_command_order = submit.last_command_order = 0;
+    if (!state.draws.empty()) {
+        const RenderState rs = extract_render_state(state.state_at_draw(state.draws.size() - 1));
+        submit.color0_base = rs.color0_base;
+        submit.color0_width = rs.color0_width;
+        submit.color0_height = rs.color0_height;
+    }
+    std::string error;
+    if (!writer->append_submit(submit, error)) runtime_recorder().mark_failed(error);
+}
+
+void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,
+                                 uint32_t width, uint32_t height) {
+    static const bool requested = [] {
+        const char* path = std::getenv("PROSPER_GPU_TIMELINE");
+        return path && *path;
+    }();
+    if (!requested) return;
+    GpuTimelineWriter* writer = runtime_recorder().get();
+    if (!writer) return;
+    GpuTimelinePresent present;
+    present.present_count = present_count;
+    present.latest_submit_no = g_active_submit_no.load(std::memory_order_acquire);
+    present.buffer_index = buffer_index;
+    present.flip_arg = flip_arg;
+    present.width = width;
+    present.height = height;
+    std::string error;
+    if (!writer->append_present(present, error)) runtime_recorder().mark_failed(error);
+}
+
+void flush_gpu_timeline() {
+    static const bool requested = [] {
+        const char* path = std::getenv("PROSPER_GPU_TIMELINE");
+        return path && *path;
+    }();
+    if (!requested) return;
+    GpuTimelineWriter* writer = runtime_recorder().get();
+    if (!writer) return;
+    std::string error;
+    if (!writer->flush(error)) runtime_recorder().mark_failed(error);
+}
+
+void close_gpu_timeline() {
+    static const bool requested = [] {
+        const char* path = std::getenv("PROSPER_GPU_TIMELINE");
+        return path && *path;
+    }();
+    if (requested) runtime_recorder().close();
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -1,0 +1,80 @@
+// gpu_timeline.hpp - native-speed semantic submit/present timeline recording.
+#pragma once
+
+#include "command_processor.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace prosper::gpu {
+
+struct GpuTimelineMetadata {
+    std::string revision;
+    std::string title_id;
+    std::string input_route;
+};
+
+struct GpuTimelineSubmit {
+    uint64_t sequence = 0;
+    uint64_t elapsed_ns = 0;
+    uint64_t submit_no = 0;
+    uint64_t process_command_order = 0;
+    uint64_t first_command_order = 0;
+    uint64_t last_command_order = 0;
+    uint64_t color0_base = 0;
+    uint32_t draw_count = 0;
+    uint32_t dispatch_count = 0;
+    uint32_t color0_width = 0;
+    uint32_t color0_height = 0;
+};
+
+struct GpuTimelinePresent {
+    uint64_t sequence = 0;
+    uint64_t elapsed_ns = 0;
+    uint64_t present_count = 0;
+    uint64_t latest_submit_no = 0;
+    int32_t buffer_index = -1;
+    int64_t flip_arg = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
+
+struct GpuTimelineFile {
+    GpuTimelineMetadata metadata;
+    std::vector<GpuTimelineSubmit> submits;
+    std::vector<GpuTimelinePresent> presents;
+    bool truncated_tail = false;
+};
+
+class GpuTimelineWriter {
+public:
+    GpuTimelineWriter();
+    ~GpuTimelineWriter();
+    GpuTimelineWriter(const GpuTimelineWriter&) = delete;
+    GpuTimelineWriter& operator=(const GpuTimelineWriter&) = delete;
+
+    bool open(const std::string& path, const GpuTimelineMetadata& metadata, std::string& error);
+    bool append_submit(const GpuTimelineSubmit& submit, std::string& error);
+    bool append_present(const GpuTimelinePresent& present, std::string& error);
+    bool flush(std::string& error);
+    void close();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::string& error);
+
+// Runtime hooks. Inert unless PROSPER_GPU_TIMELINE=<path> is set. They record folded semantic state
+// before renderer sampling and never realize shaders, copy resources, or invoke Vulkan.
+void begin_gpu_timeline_submit(uint64_t submit_no);
+void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no);
+void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,
+                                 uint32_t width, uint32_t height);
+void flush_gpu_timeline();
+void close_gpu_timeline();
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -1,5 +1,6 @@
 // videoout_present.cpp — see videoout_present.hpp.
 #include "videoout_present.hpp"
+#include "gpu_timeline.hpp"
 #include <atomic>
 #include <cstring>
 #include <cstdio>
@@ -44,12 +45,14 @@ uint64_t present_frame_seq() { return g_frame_seq.load(std::memory_order_relaxed
 
 bool present_has_frame() { return g_have_frame.load(std::memory_order_acquire); }
 
-void present_flip(int buffer_index, int64_t /*flip_arg*/) {
+void present_flip(int buffer_index, int64_t flip_arg) {
     // Only accept a buffer the game actually registered; otherwise leave the front unchanged (an
     // invalid index shouldn't corrupt scanout state).
     if (buffer_index >= 0 && buffer_index < prosper_vo_buffer_count())
         g_front.store(buffer_index, std::memory_order_relaxed);
     uint64_t n = g_present_count.fetch_add(1, std::memory_order_relaxed);
+    record_gpu_timeline_present(n + 1, buffer_index, flip_arg,
+                                prosper_vo_display_width(), prosper_vo_display_height());
     // PROSPER_DUMP_SCANOUT=<dir>: dump the RAW guest display buffer the game just flipped (what the game
     // actually puts on screen — vs our execute_and_present composite render). First 8 flips + every 60th.
     // Written as raw w*h*4 bytes; convert offline. This reveals whether the game's real display holds the

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -13,6 +13,7 @@
 #include "gpu/command_processor.hpp"
 #include "gpu/pm4_decode.hpp"
 #include "gpu/gpu_execute.hpp"
+#include "gpu/gpu_timeline.hpp"
 #include "gpu/videoout_present.hpp"
 #include <cstdint>
 #include <cstdio>
@@ -1046,6 +1047,9 @@ void start_defer_watchdog() {
 }
 
 static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned& draw_submits) {
+    // Native-speed semantic capture happens before renderer sampling. PROSPER_RENDER_EVERY and
+    // warmup may skip Vulkan work, but must not erase submit/present history from the timeline.
+    gpu::record_gpu_timeline_submit(st, submit_no);
     static const unsigned render_every = [] {
         const char* e = getenv("PROSPER_RENDER_EVERY");
         long v = e ? atol(e) : 1;
@@ -1099,6 +1103,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
+    gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);
@@ -1209,6 +1214,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
+    gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;
     gpu::diagnose_compute_dispatches(agc_gpu_state(), g_submit_count);

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -1,0 +1,114 @@
+#include "../src/gpu/gpu_timeline.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+static bool write_bytes(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+    std::ofstream out(path, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    return static_cast<bool>(out);
+}
+
+int main() {
+    std::printf("== test_gpu_timeline ==\n");
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto base = std::filesystem::temp_directory_path() /
+        ("prosper-gpu-timeline-" + std::to_string(nonce));
+    const auto good = base.string() + ".prgtl";
+    const auto truncated = base.string() + "-truncated.prgtl";
+    const auto corrupt = base.string() + "-corrupt.prgtl";
+
+    GpuTimelineWriter writer;
+    GpuTimelineMetadata metadata{"revision-1", "PPSA15552", "@scripts/dead-cells/route.pad"};
+    std::string error;
+    CHECK(writer.open(good, metadata, error), "writer creates a versioned timeline");
+    GpuTimelineSubmit first;
+    first.submit_no = 10; first.process_command_order = 400; first.first_command_order = 390;
+    first.last_command_order = 400; first.color0_base = 0x12340000; first.draw_count = 3;
+    first.dispatch_count = 1; first.color0_width = 642; first.color0_height = 362;
+    CHECK(writer.append_submit(first, error), "writer appends a submit record");
+    GpuTimelinePresent present;
+    present.present_count = 7; present.latest_submit_no = 10; present.buffer_index = 2;
+    present.flip_arg = -5; present.width = 1920; present.height = 1080;
+    CHECK(writer.append_present(present, error), "writer appends a present record");
+    GpuTimelineSubmit second = first;
+    second.submit_no = 11; second.draw_count = 4; second.dispatch_count = 0;
+    CHECK(writer.append_submit(second, error), "writer appends a second submit record");
+    CHECK(writer.flush(error), "writer flushes explicitly");
+    writer.close();
+
+    GpuTimelineFile timeline;
+    CHECK(read_gpu_timeline(good, timeline, error), "reader accepts a complete timeline");
+    CHECK(timeline.metadata.revision == metadata.revision &&
+          timeline.metadata.title_id == metadata.title_id &&
+          timeline.metadata.input_route == metadata.input_route,
+          "metadata round-trips");
+    CHECK(timeline.submits.size() == 2 && timeline.presents.size() == 1,
+          "submit and present counts round-trip");
+    CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
+          timeline.submits[1].sequence == 3, "global record ordering round-trips");
+    CHECK(timeline.submits[0].color0_base == 0x12340000 &&
+          timeline.submits[0].color0_width == 642 && timeline.submits[0].color0_height == 362,
+          "target identity and extent round-trip");
+    CHECK(timeline.presents[0].buffer_index == 2 && timeline.presents[0].flip_arg == -5,
+          "signed present fields round-trip");
+
+    std::ifstream input(good, std::ios::binary);
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
+    CHECK(bytes.size() > 16, "test timeline has framed records");
+    std::vector<uint8_t> truncated_bytes(bytes.begin(), bytes.end() - 5);
+    CHECK(write_bytes(truncated, truncated_bytes), "created a truncated-tail fixture");
+    GpuTimelineFile partial;
+    CHECK(read_gpu_timeline(truncated, partial, error), "reader recovers complete records from a truncated tail");
+    CHECK(partial.truncated_tail && partial.submits.size() == 1 && partial.presents.size() == 1,
+          "truncated final submit is ignored explicitly");
+
+    std::vector<uint8_t> corrupt_bytes = bytes;
+    corrupt_bytes[corrupt_bytes.size() - 12] ^= 0x80;
+    CHECK(write_bytes(corrupt, corrupt_bytes), "created a checksum-corrupt fixture");
+    GpuTimelineFile rejected;
+    CHECK(!read_gpu_timeline(corrupt, rejected, error) &&
+          error.find("checksum mismatch") != std::string::npos,
+          "reader rejects corruption instead of treating it as truncation");
+
+    const auto runtime = base.string() + "-runtime.prgtl";
+#ifdef _WIN32
+    _putenv_s("PROSPER_GPU_TIMELINE", runtime.c_str());
+    _putenv_s("PROSPER_CAPTURE_TITLE", "runtime-title");
+#else
+    setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
+    setenv("PROSPER_CAPTURE_TITLE", "runtime-title", 1);
+#endif
+    begin_gpu_timeline_submit(42);
+    record_gpu_timeline_present(9, 1, 77, 1920, 1080); // a PM4 flip can precede submit completion
+    GpuState runtime_state;
+    runtime_state.command_order = 123;
+    record_gpu_timeline_submit(runtime_state, 42);
+    close_gpu_timeline();
+    GpuTimelineFile runtime_timeline;
+    CHECK(read_gpu_timeline(runtime, runtime_timeline, error), "runtime hooks produce an inspectable timeline");
+    CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 1 &&
+          runtime_timeline.presents[0].latest_submit_no == 42,
+          "a flip during folding is associated with its active submit");
+
+    std::error_code ec;
+    std::filesystem::remove(good, ec);
+    std::filesystem::remove(truncated, ec);
+    std::filesystem::remove(corrupt, ec);
+    std::filesystem::remove(runtime, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -17,6 +17,9 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`gpu_replay/`** — replay a local `PROSPER_GPU_CAPTURE` realized-submit capsule through the same
   Vulkan backend without booting the guest. Capsules include game shaders/resources, use `.prgcap`,
   are gitignored, and must never be committed. The tool exits non-zero on output-hash mismatch.
+- **`gpu_timeline/`** — inspect a native-speed `.prgtl` submit/present index recorded with
+  `PROSPER_GPU_TIMELINE=<path>`. It does not invoke Vulkan; use it to locate progression and producer
+  windows before making an expensive realized `.prgcap`. Timeline files are gitignored and local-only.
 - **`spv_validate/`** — `spirv-val` wrapper for recompiled SPIR-V.
 - **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
 
@@ -64,6 +67,9 @@ rerenders matching target passes by prefix and logs per-draw hashes plus dark/wh
 the guest and command decoder advance. The `screenshot` frontend exposes this as `--warmup-seconds`, plus
 `--warmup-submits` for `PROSPER_RENDER_FIRST`; use wall-clock warmup for progression captures and the exact
 submit gate for repeatable renderer investigations.
+`PROSPER_GPU_TIMELINE=<path>.prgtl` records every folded submit before renderer sampling plus every
+VideoOut flip. `gpu_timeline <path> [--records]` inspects the checksummed index offline. Recording is
+independent of `PROSPER_RENDER_EVERY`; version 1 is semantic metadata, not yet a renderable resource capture.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -1,0 +1,41 @@
+# GPU timeline
+
+`PROSPER_GPU_TIMELINE=<path>.prgtl` records the guest's folded GPU-submit and VideoOut-present
+boundaries without registering or invoking the Vulkan renderer. The initial semantic index is meant
+for native-speed progression analysis and as the stable identity layer for later resource-version and
+dependency-complete replay work (#594/#595).
+
+```bash
+PROSPER_GUEST_FS=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_GPU_TIMELINE=/tmp/dead-cells.prgtl \
+PROSPER_CAPTURE_TITLE=PPSA15552 \
+PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
+  ./build-linux/boot_trace /path/to/PPSA15552-app0
+
+./build-linux/gpu_timeline /tmp/dead-cells.prgtl
+./build-linux/gpu_timeline /tmp/dead-cells.prgtl --records
+```
+
+The summary reports duration, submit/present/draw/dispatch counts, rates, target extents, and whether
+an incomplete final record was discarded. `--records` prints the globally ordered submit/present
+index. Run metadata includes the revision, title, and input route when the corresponding capture
+environment variables are set.
+
+## Format contract
+
+- Explicit little-endian versioned header; C++ struct layout is never serialized.
+- Every record has a global sequence, monotonic timestamp, bounded payload, and FNV-1a checksum.
+- The writer buffers output and flushes every 256 records. Normal process teardown closes it; a killed
+  process can lose only its buffered tail.
+- The reader recovers all complete records if the final record is truncated. A checksum error or bad
+  framing in a complete record is corruption and fails inspection.
+- Captures are local, may contain title-derived addresses/state, use the gitignored `.prgtl` suffix,
+  and must never be committed.
+
+## Current boundary
+
+Version 1 is a semantic index: submit numbers, PM4 order ranges, draw/dispatch counts, final color
+target identity/extent, and flip boundaries. It does **not** yet contain shader/resource bytes or
+enough state to render offline. The next #594 slice adds deduplicated immutable resource versions;
+#595 uses those versions to build the selected present's producer dependency closure.

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -1,0 +1,78 @@
+#include "gpu/gpu_timeline.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <string>
+#include <utility>
+
+using namespace prosper::gpu;
+
+int main(int argc, char** argv) {
+    if (argc < 2 || argc > 3 || (argc == 3 && std::string(argv[2]) != "--records")) {
+        std::fprintf(stderr, "usage: gpu_timeline <capture.prgtl> [--records]\n");
+        return 2;
+    }
+    GpuTimelineFile timeline;
+    std::string error;
+    if (!read_gpu_timeline(argv[1], timeline, error)) {
+        std::fprintf(stderr, "gpu_timeline: %s: %s\n", argv[1], error.c_str());
+        return 1;
+    }
+
+    uint64_t last_ns = 0, draws = 0, dispatches = 0;
+    std::map<std::pair<uint32_t, uint32_t>, uint64_t> target_extents;
+    for (const auto& submit : timeline.submits) {
+        last_ns = std::max(last_ns, submit.elapsed_ns);
+        draws += submit.draw_count;
+        dispatches += submit.dispatch_count;
+        if (submit.color0_width && submit.color0_height)
+            target_extents[{submit.color0_width, submit.color0_height}]++;
+    }
+    for (const auto& present : timeline.presents) last_ns = std::max(last_ns, present.elapsed_ns);
+    const double seconds = static_cast<double>(last_ns) / 1e9;
+    std::printf("timeline version=1 revision=%s title=%s route=%s\n",
+                timeline.metadata.revision.c_str(), timeline.metadata.title_id.c_str(),
+                timeline.metadata.input_route.c_str());
+    std::printf("duration=%.3fs submits=%zu presents=%zu draws=%llu dispatches=%llu truncated_tail=%s\n",
+                seconds, timeline.submits.size(), timeline.presents.size(),
+                static_cast<unsigned long long>(draws), static_cast<unsigned long long>(dispatches),
+                timeline.truncated_tail ? "yes" : "no");
+    if (seconds > 0)
+        std::printf("rates submits=%.1f/s presents=%.1f/s\n",
+                    timeline.submits.size() / seconds, timeline.presents.size() / seconds);
+    for (const auto& [extent, count] : target_extents)
+        std::printf("target %ux%u submits=%llu\n", extent.first, extent.second,
+                    static_cast<unsigned long long>(count));
+
+    if (argc == 3) {
+        size_t si = 0, pi = 0;
+        while (si < timeline.submits.size() || pi < timeline.presents.size()) {
+            const bool take_submit = pi == timeline.presents.size() ||
+                (si < timeline.submits.size() &&
+                 timeline.submits[si].sequence < timeline.presents[pi].sequence);
+            if (take_submit) {
+                const auto& s = timeline.submits[si++];
+                std::printf("%llu %.6f submit=%llu draws=%u dispatches=%u order=%llu..%llu "
+                            "target=%016llx/%ux%u\n",
+                            static_cast<unsigned long long>(s.sequence), s.elapsed_ns / 1e9,
+                            static_cast<unsigned long long>(s.submit_no), s.draw_count, s.dispatch_count,
+                            static_cast<unsigned long long>(s.first_command_order),
+                            static_cast<unsigned long long>(s.last_command_order),
+                            static_cast<unsigned long long>(s.color0_base),
+                            s.color0_width, s.color0_height);
+            } else {
+                const auto& p = timeline.presents[pi++];
+                std::printf("%llu %.6f present=%llu latest-submit=%llu buffer=%d flip-arg=%lld extent=%ux%u\n",
+                            static_cast<unsigned long long>(p.sequence), p.elapsed_ns / 1e9,
+                            static_cast<unsigned long long>(p.present_count),
+                            static_cast<unsigned long long>(p.latest_submit_no), p.buffer_index,
+                            static_cast<long long>(p.flip_arg), p.width, p.height);
+            }
+        }
+    }
+    if (timeline.truncated_tail)
+        std::fprintf(stderr, "gpu_timeline: warning: ignored a truncated final record\n");
+    return 0;
+}

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -25,6 +25,7 @@
 #include "host/boot_program.hpp"       // boot_program
 #include "host/exec_image.hpp"         // run_entry
 #include "gpu/videoout_present.hpp"    // present_count / present_readback / present_width/height
+#include "gpu/gpu_timeline.hpp"
 #include "live_renderer.hpp"           // register_live_renderer (frontends/shared)
 #include "capture_manifest.hpp"
 
@@ -457,5 +458,6 @@ int main(int argc, char** argv) {
     fprintf(stderr, "[shot] done: %d screenshot(s) in %s; distinct=%llu max-stale=%.1fs status=%s\n",
             saved, out.c_str(), (unsigned long long)tracker.distinct_source_frames(),
             tracker.max_stale_seconds(), exit_code ? "FAILED" : "ok");
+    gpu::close_gpu_timeline();
     _exit(exit_code);   // the guest thread is detached and running guest code; don't block on teardown
 }


### PR DESCRIPTION
## Summary

- add an opt-in native-speed `.prgtl` submit/present semantic recorder before renderer sampling
- add checksummed, versioned framing with partial-tail recovery and corruption rejection
- add an offline `gpu_timeline` inspector that requires neither guest boot nor Vulkan
- associate PM4 flips with their active submit and close timelines before screenshot's `_exit`
- document the local-only format and add round-trip/runtime/truncation tests

## Dead Cells evidence

A no-render route recorded 18,843 submits, 18,842 presents, 1,295,405 draws, and 2,618 dispatches over 28.899 seconds before the known later guest fault. The 3.1 MB file inspects cleanly offline.

A forced five-second termination retained 9,291 submits and 9,290 presents, explicitly reporting `truncated_tail=yes`.

Matched 14-second heartbeat:
- control: 17,871 submits
- capture: 17,431 submits
- observed single-run overhead: 2.46%

## Verification

- Linux build
- 89/89 ctest
- Messenger snapshot guard: 24,318 colors >= 5,000

Part of #594 and #592. This does not close #594; immutable resource versions and offline realization remain.