### PR TITLE
feat(gpu): materialize selected timeline submits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,13 @@ warmup artifact: the 35-second render delay skipped a 642x362 RTT producer, then
 4's raw all-`0xFF` backing and cached it indefinitely. `PROSPER_RENDER_TARGET_DIM=642x362` preserves the real
 opening vignette/level geometry; #586 now tracks a practical late checkpoint with that history intact. The
 residual seeded replay mismatch (#569) and animation-sensitive exact splash guard (#573) remain separate issues.
+
+The current tooling frontier is deterministic offline capture rather than longer live-render windows.
+Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
+immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-5 `.prgcap` (#594).
+Use that path to isolate the Dead Cells gameplay consumer, then implement automatic earlier-producer dependency
+closure (#595/#586). The stale exact Dead Cells snapshot baseline is tracked separately in #596 and must not be
+silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.
 `PROSPER_RESOURCE_HASH_DIM=WxH` correlates raw and sampled hashes with those writers at each live draw;

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -32,16 +32,20 @@ possible without console keys. Dumps are user-supplied and gitignored.
   tests and the real-game snapshot guard.
 - ✅ **Graphics investigation tooling:** versioned live GPU capture/replay (`.prgcap`), per-draw/resource
   inspection and isolation, strict reflected SPIR-V/runtime descriptor validation, render-target producer
-  provenance, normal screenshot capture, and a local content-metric snapshot guard.
+  provenance, normal screenshot capture, and a local content-metric snapshot guard. Native-speed `.prgtl`
+  submit/present indexes can select one exact submit before renderer sampling and materialize immutable,
+  content-deduplicated graphics/compute state plus mixed operation order for offline replay (#594).
 - ✅ **Dead Cells reaches gameplay reproducibly:** a deterministic input route passes the splash and menus
   into the first playable scene. HUD and some composition render, but the world is mostly white (#566).
-  Version-4 GPU captures seed temporal render targets for faithful offline isolation (#568); one residual
+  Version-5 GPU captures seed temporal render targets and retain content-addressed resource versions for
+  faithful offline isolation (#568/#594); one residual
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** build a practical producer-preserving Dead Cells gameplay checkpoint (#586),
-  stabilize the animation-sensitive exact splash guard (#573), and continue cross-title capture/replay and
-  descriptor-validation work. UE4's measured GPU boundary remains tracked separately under its area issues.
+- 🚧 **Active frontiers:** use the selected-submit timeline/capsule path to prove the Dead Cells gameplay
+  consumer offline (#594), then derive its earlier 642×362 producer dependency automatically (#595/#586).
+  The stale exact Dead Cells snapshot baseline is tracked separately in #596. UE4's measured GPU boundary
+  remains tracked under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
 [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub
@@ -63,7 +67,8 @@ prosper/
   src/gpu/         AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
                    texture tiling + BC decode, RDNA2→SPIR-V recompiler
   frontends/       shared boot+render core, windowed prosper-app, SDL3 audio/dialog, controllers
-  tools/           self_dump, boot_trace, shader_histo, screenshot, snapshot, gpu_replay, spv_validate
+  tools/           self_dump, boot_trace, shader_histo, screenshot, snapshot, gpu_timeline, gpu_replay,
+                   spv_validate
   tests/           unit + boot + Vulkan-execution tests (ctest)
   CMakeLists.txt
 ```
@@ -72,7 +77,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # 87 self-checking tests
+ctest --test-dir build          # 89 self-checking tests
 ```
 Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -185,10 +185,11 @@ Turn the file into a resident, relocated guest image in host memory.
   exception handler, thread-stack queries, `setjmp`, `dlsym`.
 - [x] GC thread-stack queries (`scePthreadAttrGet`/`Getstackaddr`/`Getstacksize`) via
       `pthread_getattr_np` (real bounds for IL2CPP's GC root scanning).
-- [ ] **Current frontier — graphics required.** IL2CPP aborts during internal-call resolution
+- [x] **Historical 2025 frontier — graphics required.** IL2CPP aborted during internal-call resolution
       on `UnityEngine.GL::Internal_SetRTSimple_Injected` (SetRenderTarget) at `Il2cpp+0x110ea`.
       The rendering icalls are registered when the engine's **graphics device initializes**, so
-      the boot now genuinely needs the GPU path. This is the transition to M4/M5.
+      this established that the boot genuinely needed the GPU path. M4 now runs through gameplay;
+      see the status summary in `README.md` and current GitHub issues for the active frontier.
 ### M3.5 — Threading correctness (in progress)
 - [x] **GC "unknown thread" fixed**: `pthread_equal` was unregistered (POSIX name) so the GC's
       thread-table search never matched. Root cause found via gdb (empty thread table → the

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -151,13 +151,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (buffer.memory) vkFreeMemory(ctx.device, buffer.memory, nullptr);
         }
     };
+    auto resource_bytes = [](const ShaderResource* resource) -> uint8_t* {
+        if (resource->host_data && resource->host_data_size >= resource->size)
+            return resource->host_data;
+        return reinterpret_cast<uint8_t*>(uintptr_t(resource->gpu_addr));
+    };
 
     do {
         std::vector<VkDescriptorSetLayoutBinding> layout_bindings(descriptors.size());
         for (size_t i = 0; i < descriptors.size(); i++) {
             const ShaderResource* resource = item.resources->by_binding(descriptors[i].binding);
             if (!resource || !resource->size ||
-                !guest_readable(resource->gpu_addr, resource->size)) break;
+                ((!resource->host_data || resource->host_data_size < resource->size) &&
+                 !guest_readable(resource->gpu_addr, resource->size))) break;
             buffers[i].resource = resource;
             VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
             bci.size = resource->size;
@@ -174,9 +180,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
             void* mapped = nullptr;
             if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
-            const void* guest = (const void*)(uintptr_t)resource->gpu_addr;
-            if (trace) buffers[i].before_hash = fnv1a(guest, resource->size);
-            std::memcpy(mapped, guest, resource->size);
+            const uint8_t* source = resource_bytes(resource);
+            if (trace) buffers[i].before_hash = fnv1a(source, resource->size);
+            std::memcpy(mapped, source, resource->size);
             vkUnmapMemory(ctx.device, buffers[i].memory);
 
             layout_bindings[i].binding = descriptors[i].binding;
@@ -266,16 +272,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 readback_ok = false;
                 break;
             }
-            auto* guest = (uint8_t*)(uintptr_t)buffer.resource->gpu_addr;
+            uint8_t* destination = resource_bytes(buffer.resource);
             const auto* result = static_cast<const uint8_t*>(mapped);
             if (trace) {
                 buffer.after_hash = fnv1a(result, buffer.resource->size);
                 for (uint32_t i = 0; i < buffer.resource->size; i++)
-                    buffer.changed_bytes += guest[i] != result[i];
+                    buffer.changed_bytes += destination[i] != result[i];
             }
-            std::memcpy(guest, result, buffer.resource->size);
+            std::memcpy(destination, result, buffer.resource->size);
             vkUnmapMemory(ctx.device, buffer.memory);
-            if (writer_provenance_enabled())
+            if (!buffer.resource->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    buffer.resource->gpu_addr, buffer.resource->size,
                                    item.submit_no, item.dispatch_index,
@@ -294,16 +300,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     if (trace) {
         for (const auto& buffer : buffers) {
             if (!buffer.resource) continue;
+            const uint8_t* bytes = resource_bytes(buffer.resource);
             std::fprintf(stderr,
                          "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
                          "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x\n",
                          buffer.resource->binding, (unsigned long long)buffer.resource->gpu_addr,
                          buffer.resource->size, (unsigned long long)buffer.changed_bytes,
                          (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash,
-                         buffer.resource->size >= 4 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[0] : 0,
-                         buffer.resource->size >= 8 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[1] : 0,
-                         buffer.resource->size >= 12 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[2] : 0,
-                         buffer.resource->size >= 16 ? ((const uint32_t*)(uintptr_t)buffer.resource->gpu_addr)[3] : 0);
+                         buffer.resource->size >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
+                         buffer.resource->size >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
+                         buffer.resource->size >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
+                         buffer.resource->size >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
         }
     }
     cleanup();

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -55,7 +55,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     }
     static std::atomic<int> frame_no{0};
     static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
-    if (getenv("PROSPER_GPU_CAPTURE"))
+    if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE"))
         prosper::gpu::set_gpu_capture_rtt_seed_reader([](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {
             auto it = g_rtt.find(addr); if (it == g_rtt.end()) return false;
             seed.guest_addr = addr; seed.width = it->second.w; seed.height = it->second.h;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <map>
 #include <unordered_set>
 #include <utility>
 
@@ -20,12 +21,14 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 4;
+constexpr uint32_t kVersion = 5;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
 constexpr uint64_t kMaxTotalBlobBytes = 3ull << 30;
 constexpr uint32_t kMaxDraws = 65536;
+constexpr uint32_t kMaxComputes = 65536;
+constexpr uint32_t kMaxOperations = 131072;
 constexpr uint32_t kMaxResources = 65536;
 constexpr uint32_t kMaxShaderWords = 16u << 20;
 constexpr uint32_t kMaxStringBytes = 1u << 20;
@@ -215,9 +218,15 @@ uint64_t resource_footprint(const ShaderResource& r) {
     return std::max(result, decoded);
 }
 
-struct Interval { uint64_t begin, end; };
+struct Interval {
+    uint64_t begin = 0;
+    uint64_t end = 0;
+    uint32_t blob_index = 0xFFFFFFFFu;
+};
 
-bool collect_intervals(const std::vector<DrawItem>& items, std::vector<Interval>& intervals, std::string& error) {
+bool collect_intervals(const std::vector<DrawItem>& draws,
+                       const std::vector<ComputeItem>& computes,
+                       std::vector<Interval>& intervals, std::string& error) {
     uint64_t total = 0;
     auto add_table = [&](const ShaderResourceTable* t) -> bool {
         if (!t) return true;
@@ -231,7 +240,8 @@ bool collect_intervals(const std::vector<DrawItem>& items, std::vector<Interval>
         }
         return true;
     };
-    for (const auto& d : items) if (!add_table(d.vrt.get()) || !add_table(d.prt.get())) return false;
+    for (const auto& d : draws) if (!add_table(d.vrt.get()) || !add_table(d.prt.get())) return false;
+    for (const auto& c : computes) if (!add_table(c.resources.get())) return false;
     std::sort(intervals.begin(), intervals.end(), [](auto a, auto b) { return a.begin < b.begin; });
     std::vector<Interval> merged;
     for (auto x : intervals) {
@@ -258,7 +268,7 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
                 return x.begin <= r.gpu_addr && r.gpu_addr + n <= x.end;
             });
             if (it == intervals.end()) { error = "resource was not assigned to a capture blob"; return false; }
-            c.blob_index = static_cast<uint32_t>(it - intervals.begin()); c.blob_offset = r.gpu_addr - it->begin;
+            c.blob_index = it->blob_index; c.blob_offset = r.gpu_addr - it->begin;
         }
         dst.resources.push_back(std::move(c));
     }
@@ -279,6 +289,36 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
     return true;
 }
 
+uint64_t shader_hash(const std::vector<uint32_t>& words) {
+    return gpu_capture_hash(reinterpret_cast<const uint8_t*>(words.data()),
+                            words.size() * sizeof(uint32_t));
+}
+
+void collect_shader_versions(GpuCaptureFile& capture) {
+    capture.shader_versions.clear();
+    auto add = [&](const std::vector<uint32_t>& words) {
+        const uint64_t hash = shader_hash(words);
+        auto it = std::find_if(capture.shader_versions.begin(), capture.shader_versions.end(),
+            [&](const auto& version) { return version.content_hash == hash && version.words == words; });
+        if (it == capture.shader_versions.end())
+            capture.shader_versions.push_back({hash, words});
+    };
+    for (const auto& draw : capture.draws) {
+        add(draw.vs);
+        add(draw.fs);
+    }
+    for (const auto& compute : capture.computes) add(compute.spirv);
+}
+
+uint32_t shader_version_index(const std::vector<GpuCaptureShaderVersion>& versions,
+                              const std::vector<uint32_t>& words) {
+    const uint64_t hash = shader_hash(words);
+    auto it = std::find_if(versions.begin(), versions.end(), [&](const auto& version) {
+        return version.content_hash == hash && version.words == words;
+    });
+    return it == versions.end() ? 0xFFFFFFFFu : static_cast<uint32_t>(it - versions.begin());
+}
+
 } // namespace
 
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
@@ -290,23 +330,73 @@ uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
                         const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error,
                         const CaptureRttSeedReader& rtt_reader) {
+    if (items.empty()) { error = "capture must contain at least one draw"; return false; }
+    std::vector<SubmitOperation> operations;
+    operations.reserve(items.size());
+    for (size_t i = 0; i < items.size(); ++i)
+        operations.push_back({SubmitOperationKind::Draw, static_cast<size_t>(items[i].draw_index),
+                              items[i].command_order});
+    return capture_submit_items(items, {}, operations, metadata, reader, out, error, rtt_reader);
+}
+
+bool capture_submit_items(const std::vector<DrawItem>& draws,
+                          const std::vector<ComputeItem>& computes,
+                          const std::vector<SubmitOperation>& operations,
+                          const GpuCaptureMetadata& metadata,
+                          const CaptureMemoryReader& reader, GpuCaptureFile& out,
+                          std::string& error, const CaptureRttSeedReader& rtt_reader) {
     error.clear(); out = {}; out.metadata = metadata;
-    if (items.empty() || items.size() > kMaxDraws) { error = "capture must contain 1..65536 draws"; return false; }
+    if (draws.size() > kMaxDraws || computes.size() > kMaxComputes ||
+        operations.size() > kMaxOperations) {
+        error = "capture item or operation count is invalid";
+        return false;
+    }
     if (!reader) { error = "capture memory reader is missing"; return false; }
     std::vector<Interval> intervals;
-    if (!collect_intervals(items, intervals, error)) return false;
-    for (auto x : intervals) {
+    if (!collect_intervals(draws, computes, intervals, error)) return false;
+    for (auto& x : intervals) {
         GpuCaptureBlob b; b.guest_addr = x.begin; b.bytes.resize(static_cast<size_t>(x.end - x.begin), 0);
         b.bytes_read = std::min<uint64_t>(reader(x.begin, b.bytes.data(), b.bytes.size()), b.bytes.size());
-        out.blobs.push_back(std::move(b));
+        b.content_hash = gpu_capture_hash(b.bytes);
+        auto existing = std::find_if(out.blobs.begin(), out.blobs.end(), [&](const auto& candidate) {
+            return candidate.content_hash == b.content_hash && candidate.bytes == b.bytes;
+        });
+        if (existing == out.blobs.end()) {
+            x.blob_index = static_cast<uint32_t>(out.blobs.size());
+            out.blobs.push_back(std::move(b));
+        } else {
+            x.blob_index = static_cast<uint32_t>(existing - out.blobs.begin());
+        }
     }
-    for (const auto& d : items) {
+    for (const auto& d : draws) {
         GpuCapturedDraw c; c.vs = d.vs; c.fs = d.fs; c.ps = d.ps; c.vertex_count = d.vertex_count;
         c.indices = d.indices; c.color0_base = d.color0_base;
         c.color0_width = d.color0_width; c.color0_height = d.color0_height;
+        c.draw_index = d.draw_index; c.command_order = d.command_order;
         if (!capture_table(d.vrt.get(), intervals, c.vrt, error) || !capture_table(d.prt.get(), intervals, c.prt, error)) return false;
         out.draws.push_back(std::move(c));
     }
+    for (const auto& compute : computes) {
+        GpuCapturedCompute c;
+        c.spirv = compute.spirv;
+        c.launch = compute.launch;
+        c.code_addr = compute.code_addr;
+        c.dispatch_index = compute.dispatch_index;
+        c.submit_no = compute.submit_no;
+        c.command_order = compute.command_order;
+        if (!capture_table(compute.resources.get(), intervals, c.resources, error)) return false;
+        out.computes.push_back(std::move(c));
+    }
+    std::unordered_set<uint64_t> realized_draws, realized_computes;
+    for (const auto& draw : out.draws) realized_draws.insert(draw.draw_index);
+    for (const auto& compute : out.computes) realized_computes.insert(compute.dispatch_index);
+    for (const auto& operation : operations) {
+        const bool realized = operation.kind == SubmitOperationKind::Draw
+            ? realized_draws.count(operation.index) != 0
+            : realized_computes.count(operation.index) != 0;
+        out.operations.push_back({operation.kind, operation.index, operation.command_order, realized});
+    }
+    collect_shader_versions(out);
     if (rtt_reader) {
         std::vector<uint64_t> candidates;
         auto add_table = [&](const ShaderResourceTable* table) {
@@ -315,10 +405,11 @@ bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMeta
                 if ((r.cls == ResourceClass::Texture || r.cls == ResourceClass::StorageImage) && r.gpu_addr)
                     candidates.push_back(r.gpu_addr);
         };
-        for (const auto& item : items) {
+        for (const auto& item : draws) {
             add_table(item.vrt.get()); add_table(item.prt.get());
             if (item.color0_base) candidates.push_back(item.color0_base);
         }
+        for (const auto& item : computes) add_table(item.resources.get());
         std::sort(candidates.begin(), candidates.end());
         candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
         uint64_t total = 0;
@@ -336,15 +427,44 @@ bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMeta
     return true;
 }
 
+bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
+                             uint32_t width, uint32_t height,
+                             const GpuCaptureMetadata& metadata,
+                             GpuCaptureFile& out, std::string& error) {
+    std::vector<DrawItem> draws = realize_gpustate_draws(state);
+    std::vector<ComputeItem> computes = realize_compute_dispatches(state, submit_no);
+    auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
+        size_t done = 0;
+        constexpr size_t chunk_max = 0x10000;
+        while (done < bytes) {
+            const size_t n = std::min(bytes - done, chunk_max);
+            if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
+            std::memcpy(dst + done, reinterpret_cast<const void*>(uintptr_t(addr + done)), n);
+            done += n;
+        }
+        return done;
+    };
+    GpuCaptureMetadata actual = metadata;
+    actual.width = width;
+    actual.height = height;
+    actual.submit_index = submit_no;
+    return capture_submit_items(draws, computes, plan_submit_operations(state), actual,
+                                reader, out, error, g_rtt_seed_reader);
+}
+
 bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::string& error) {
     error.clear(); Writer w; w.raw(kMagic, sizeof(kMagic)); w.u32(kVersion); w.u32(kEndian);
     w.u32(c.metadata.width); w.u32(c.metadata.height); w.u64(c.metadata.submit_index);
     w.string(c.metadata.revision); w.string(c.metadata.title_id); w.string(c.metadata.input_route); w.string(c.metadata.savedata_dir);
     w.u32(static_cast<uint32_t>(c.metadata.renderer_env.size()));
     for (const auto& [name, value] : c.metadata.renderer_env) { w.string(name); w.string(value); }
-    w.u64(c.expected_output_hash); w.u64(c.expected_output_bytes);
+    w.u8(c.expected_output_valid); w.u64(c.expected_output_hash); w.u64(c.expected_output_bytes);
     w.u32(static_cast<uint32_t>(c.blobs.size()));
-    for (const auto& b : c.blobs) { w.u64(b.guest_addr); w.u64(b.bytes_read); w.bytes(b.bytes); }
+    for (const auto& b : c.blobs) {
+        const uint64_t hash = gpu_capture_hash(b.bytes);
+        if (b.content_hash && b.content_hash != hash) { error = "capture blob content hash mismatch"; return false; }
+        w.u64(b.guest_addr); w.u64(b.bytes_read); w.u64(hash); w.bytes(b.bytes);
+    }
     if (c.rtt_seeds.size() > kMaxResources) { error = "invalid RTT seed count"; return false; }
     uint64_t seed_total = 0; std::unordered_set<uint64_t> seed_addresses;
     w.u32(static_cast<uint32_t>(c.rtt_seeds.size()));
@@ -357,11 +477,55 @@ bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::st
         seed_total += seed.rgba.size();
         w.u64(seed.guest_addr); w.u32(seed.width); w.u32(seed.height); w.bytes(seed.rgba);
     }
+    std::vector<GpuCaptureShaderVersion> versions = c.shader_versions;
+    auto add_shader = [&](const std::vector<uint32_t>& words) {
+        const uint64_t hash = shader_hash(words);
+        auto it = std::find_if(versions.begin(), versions.end(), [&](const auto& version) {
+            return version.content_hash == hash && version.words == words;
+        });
+        if (it == versions.end()) versions.push_back({hash, words});
+    };
+    for (const auto& d : c.draws) { add_shader(d.vs); add_shader(d.fs); }
+    for (const auto& compute : c.computes) add_shader(compute.spirv);
+    if (versions.size() > kMaxResources) { error = "invalid shader-version count"; return false; }
+    w.u32(static_cast<uint32_t>(versions.size()));
+    for (const auto& version : versions) {
+        const uint64_t hash = shader_hash(version.words);
+        if (version.content_hash && version.content_hash != hash) {
+            error = "capture shader content hash mismatch"; return false;
+        }
+        w.u64(hash); w.words(version.words);
+    }
+    if (c.draws.size() > kMaxDraws) { error = "invalid draw count"; return false; }
     w.u32(static_cast<uint32_t>(c.draws.size()));
     for (const auto& d : c.draws) {
-        w.words(d.vs); w.words(d.fs); write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
+        const uint32_t vs_index = shader_version_index(versions, d.vs);
+        const uint32_t fs_index = shader_version_index(versions, d.fs);
+        if (vs_index == 0xFFFFFFFFu || fs_index == 0xFFFFFFFFu) {
+            error = "draw shader is missing from the version table"; return false;
+        }
+        w.u32(vs_index); w.u32(fs_index); write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
         w.u32(d.vertex_count); w.words(d.indices); w.u64(d.color0_base);
         w.u32(d.color0_width); w.u32(d.color0_height);
+        w.u64(d.draw_index); w.u64(d.command_order);
+    }
+    if (c.computes.size() > kMaxComputes) { error = "invalid compute count"; return false; }
+    w.u32(static_cast<uint32_t>(c.computes.size()));
+    for (const auto& compute : c.computes) {
+        const uint32_t shader_index = shader_version_index(versions, compute.spirv);
+        if (shader_index == 0xFFFFFFFFu) { error = "compute shader is missing from the version table"; return false; }
+        w.u32(shader_index); write_table(w, compute.resources);
+        w.u32(compute.launch.threads_x); w.u32(compute.launch.threads_y); w.u32(compute.launch.threads_z);
+        w.u32(compute.launch.local_x); w.u32(compute.launch.local_y); w.u32(compute.launch.local_z);
+        w.u32(compute.launch.groups_x); w.u32(compute.launch.groups_y); w.u32(compute.launch.groups_z);
+        w.u64(compute.code_addr); w.u64(compute.dispatch_index); w.u64(compute.submit_no);
+        w.u64(compute.command_order);
+    }
+    if (c.operations.size() > kMaxOperations) { error = "invalid operation count"; return false; }
+    w.u32(static_cast<uint32_t>(c.operations.size()));
+    for (const auto& operation : c.operations) {
+        w.u8(static_cast<uint8_t>(operation.kind)); w.u64(operation.source_index);
+        w.u64(operation.command_order); w.u8(operation.realized);
     }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     std::filesystem::path target(path), temp = target; temp += ".tmp";
@@ -392,12 +556,23 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
     uint32_t ne; if (!r.u32(ne) || ne > 256) { error = "invalid renderer environment count"; return false; }
     m.renderer_env.resize(ne);
     for (auto& [name, value] : m.renderer_env) if (!r.string(name) || !r.string(value)) return false;
+    if (version >= 5) {
+        uint8_t valid = 0;
+        if (!r.u8(valid)) return false;
+        c.expected_output_valid = valid != 0;
+    } else {
+        c.expected_output_valid = true;
+    }
     if (!r.u64(c.expected_output_hash) || !r.u64(c.expected_output_bytes)) return false;
     uint32_t nb; if (!r.u32(nb) || nb > kMaxResources) { error = "invalid blob count"; return false; }
     uint64_t total = 0; c.blobs.resize(nb);
     for (auto& b : c.blobs) {
-        if (!r.u64(b.guest_addr) || !r.u64(b.bytes_read) || !r.bytes(b.bytes)) return false;
+        if (!r.u64(b.guest_addr) || !r.u64(b.bytes_read) ||
+            (version >= 5 && !r.u64(b.content_hash)) || !r.bytes(b.bytes)) return false;
         if (b.bytes_read > b.bytes.size() || total > kMaxTotalBlobBytes - b.bytes.size()) { error = "invalid blob metadata"; return false; }
+        const uint64_t actual_hash = gpu_capture_hash(b.bytes);
+        if (version >= 5 && b.content_hash != actual_hash) { error = "capture blob content hash mismatch"; return false; }
+        b.content_hash = actual_hash;
         total += b.bytes.size();
     }
     if (version >= 4) {
@@ -414,12 +589,65 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
             seed_total += seed.rgba.size();
         }
     }
-    uint32_t nd; if (!r.u32(nd) || !nd || nd > kMaxDraws) { error = "invalid draw count"; return false; }
+    if (version >= 5) {
+        uint32_t ns = 0;
+        if (!r.u32(ns) || ns > kMaxResources) { error = "invalid shader-version count"; return false; }
+        c.shader_versions.resize(ns);
+        for (auto& shader : c.shader_versions) {
+            if (!r.u64(shader.content_hash) || !r.words(shader.words)) return false;
+            if (shader.content_hash != shader_hash(shader.words)) {
+                error = "capture shader content hash mismatch"; return false;
+            }
+        }
+    }
+    uint32_t nd; if (!r.u32(nd) || nd > kMaxDraws || (version < 5 && !nd)) { error = "invalid draw count"; return false; }
     c.draws.resize(nd);
     for (auto& d : c.draws) {
-        if (!r.words(d.vs) || !r.words(d.fs) || !read_pipeline(r, d.ps, version) || !read_table(r, d.vrt) ||
+        if (version >= 5) {
+            uint32_t vs_index = 0, fs_index = 0;
+            if (!r.u32(vs_index) || !r.u32(fs_index) || vs_index >= c.shader_versions.size() ||
+                fs_index >= c.shader_versions.size()) { error = "invalid draw shader-version index"; return false; }
+            d.vs = c.shader_versions[vs_index].words;
+            d.fs = c.shader_versions[fs_index].words;
+        } else if (!r.words(d.vs) || !r.words(d.fs)) return false;
+        if (!read_pipeline(r, d.ps, version) || !read_table(r, d.vrt) ||
             !read_table(r, d.prt) || !r.u32(d.vertex_count) || !r.words(d.indices) || !r.u64(d.color0_base)) return false;
         if (version >= 3 && (!r.u32(d.color0_width) || !r.u32(d.color0_height))) return false;
+        if (version >= 5 && (!r.u64(d.draw_index) || !r.u64(d.command_order))) return false;
+    }
+    if (version >= 5) {
+        uint32_t nc = 0;
+        if (!r.u32(nc) || nc > kMaxComputes) { error = "invalid compute count"; return false; }
+        c.computes.resize(nc);
+        for (auto& compute : c.computes) {
+            uint32_t shader_index = 0;
+            if (!r.u32(shader_index) || shader_index >= c.shader_versions.size()) {
+                error = "invalid compute shader-version index"; return false;
+            }
+            compute.spirv = c.shader_versions[shader_index].words;
+            if (!read_table(r, compute.resources) ||
+                !r.u32(compute.launch.threads_x) || !r.u32(compute.launch.threads_y) || !r.u32(compute.launch.threads_z) ||
+                !r.u32(compute.launch.local_x) || !r.u32(compute.launch.local_y) || !r.u32(compute.launch.local_z) ||
+                !r.u32(compute.launch.groups_x) || !r.u32(compute.launch.groups_y) || !r.u32(compute.launch.groups_z) ||
+                !r.u64(compute.code_addr) || !r.u64(compute.dispatch_index) || !r.u64(compute.submit_no) ||
+                !r.u64(compute.command_order)) return false;
+        }
+        uint32_t no = 0;
+        if (!r.u32(no) || no > kMaxOperations) { error = "invalid operation count"; return false; }
+        c.operations.resize(no);
+        for (auto& operation : c.operations) {
+            uint8_t kind = 0, realized = 0;
+            if (!r.u8(kind) || kind > static_cast<uint8_t>(SubmitOperationKind::Dispatch) ||
+                !r.u64(operation.source_index) || !r.u64(operation.command_order) || !r.u8(realized)) return false;
+            operation.kind = static_cast<SubmitOperationKind>(kind);
+            operation.realized = realized != 0;
+        }
+    } else {
+        collect_shader_versions(c);
+        for (size_t i = 0; i < c.draws.size(); ++i) {
+            c.draws[i].draw_index = i;
+            c.operations.push_back({SubmitOperationKind::Draw, i, c.draws[i].command_order, true});
+        }
     }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -427,7 +655,15 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
 
 bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::string& error) {
     error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs; out.rtt_seeds = c.rtt_seeds;
+    out.expected_output_valid = c.expected_output_valid;
     out.expected_output_hash = c.expected_output_hash; out.expected_output_bytes = c.expected_output_bytes;
+    size_t resource_reference_count = 0;
+    for (const auto& draw : c.draws)
+        resource_reference_count += draw.vrt.resources.size() + draw.prt.resources.size();
+    for (const auto& compute : c.computes)
+        resource_reference_count += compute.resources.resources.size();
+    out.resource_instances.reserve(resource_reference_count);
+    std::map<std::pair<uint32_t, uint64_t>, size_t> instance_by_version_and_base;
     auto table = [&](const GpuCapturedTable& src, std::shared_ptr<ShaderResourceTable>& dst) -> bool {
         if (!src.present) { dst.reset(); return src.resources.empty(); }
         dst = std::make_shared<ShaderResourceTable>();
@@ -437,10 +673,17 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
                 if (x.blob_index >= out.blobs.size() || x.blob_offset > out.blobs[x.blob_index].bytes.size()) {
                     error = "resource references an invalid capture blob"; return false;
                 }
-                auto& b = out.blobs[x.blob_index].bytes;
+                const auto& b = out.blobs[x.blob_index].bytes;
                 uint64_t need = resource_footprint(r);
                 if (need > b.size() - x.blob_offset) { error = "resource footprint exceeds capture blob"; return false; }
-                r.host_data = b.data() + x.blob_offset; r.host_data_size = need;
+                if (x.blob_offset > r.gpu_addr) { error = "resource blob offset exceeds its logical address"; return false; }
+                const uint64_t logical_base = r.gpu_addr - x.blob_offset;
+                const auto key = std::make_pair(x.blob_index, logical_base);
+                auto [it, inserted] = instance_by_version_and_base.emplace(key, out.resource_instances.size());
+                if (inserted)
+                    out.resource_instances.push_back({logical_base, x.blob_index, b});
+                auto& instance = out.resource_instances[it->second].bytes;
+                r.host_data = instance.data() + x.blob_offset; r.host_data_size = need;
             }
             dst->resources.push_back(r);
         }
@@ -451,9 +694,23 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         DrawItem d; d.vs = x.vs; d.fs = x.fs; d.ps = x.ps; d.vertex_count = x.vertex_count;
         d.indices = x.indices; d.color0_base = x.color0_base;
         d.color0_width = x.color0_width; d.color0_height = x.color0_height;
+        d.draw_index = x.draw_index; d.command_order = x.command_order;
         if (!table(x.vrt, d.vrt) || !table(x.prt, d.prt)) return false;
         out.items.push_back(std::move(d));
     }
+    out.computes.reserve(c.computes.size());
+    for (const auto& x : c.computes) {
+        ComputeItem compute;
+        compute.spirv = x.spirv;
+        compute.launch = x.launch;
+        compute.code_addr = x.code_addr;
+        compute.dispatch_index = x.dispatch_index;
+        compute.submit_no = x.submit_no;
+        compute.command_order = x.command_order;
+        if (!table(x.resources, compute.resources)) return false;
+        out.computes.push_back(std::move(compute));
+    }
+    out.operations = c.operations;
     return true;
 }
 
@@ -530,6 +787,7 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
 bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
                                   const std::vector<uint8_t>& output, std::string& error) {
     if (!pending) return true;
+    pending->capture.expected_output_valid = true;
     pending->capture.expected_output_bytes = output.size(); pending->capture.expected_output_hash = gpu_capture_hash(output);
     if (!write_gpu_capture(pending->path, pending->capture, error)) return false;
     std::fprintf(stderr, "[gpucap] wrote %s output_bytes=%zu hash=%016llx\n", pending->path.c_str(), output.size(),

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -26,7 +26,13 @@ struct GpuCaptureMetadata {
 struct GpuCaptureBlob {
     uint64_t guest_addr = 0;
     uint64_t bytes_read = 0;
+    uint64_t content_hash = 0;
     std::vector<uint8_t> bytes;
+};
+
+struct GpuCaptureShaderVersion {
+    uint64_t content_hash = 0;
+    std::vector<uint32_t> words;
 };
 
 struct GpuCapturedResource {
@@ -50,6 +56,25 @@ struct GpuCapturedDraw {
     std::vector<uint32_t> indices;
     uint64_t color0_base = 0;
     uint32_t color0_width = 0, color0_height = 0;
+    uint64_t draw_index = 0;
+    uint64_t command_order = 0;
+};
+
+struct GpuCapturedCompute {
+    std::vector<uint32_t> spirv;
+    GpuCapturedTable resources;
+    ComputeLaunchDimensions launch;
+    uint64_t code_addr = 0;
+    uint64_t dispatch_index = 0;
+    uint64_t submit_no = 0;
+    uint64_t command_order = 0;
+};
+
+struct GpuCapturedOperation {
+    SubmitOperationKind kind = SubmitOperationKind::Draw;
+    uint64_t source_index = 0;
+    uint64_t command_order = 0;
+    bool realized = false;
 };
 
 // Host-rendered pixels retained across submits. The HLE renderer does not write these pixels back to
@@ -65,8 +90,12 @@ struct GpuCaptureRttSeed {
 struct GpuCaptureFile {
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
+    std::vector<GpuCaptureShaderVersion> shader_versions;
     std::vector<GpuCaptureRttSeed> rtt_seeds;
     std::vector<GpuCapturedDraw> draws;
+    std::vector<GpuCapturedCompute> computes;
+    std::vector<GpuCapturedOperation> operations;
+    bool expected_output_valid = false;
     uint64_t expected_output_hash = 0;
     uint64_t expected_output_bytes = 0;
 };
@@ -79,14 +108,33 @@ using CaptureRttSeedReader = std::function<bool(uint64_t guest_addr, GpuCaptureR
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
                         const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error,
                         const CaptureRttSeedReader& rtt_reader = {});
+bool capture_submit_items(const std::vector<DrawItem>& draws,
+                          const std::vector<ComputeItem>& computes,
+                          const std::vector<SubmitOperation>& operations,
+                          const GpuCaptureMetadata& metadata,
+                          const CaptureMemoryReader& reader, GpuCaptureFile& out,
+                          std::string& error, const CaptureRttSeedReader& rtt_reader = {});
+bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
+                             uint32_t width, uint32_t height,
+                             const GpuCaptureMetadata& metadata,
+                             GpuCaptureFile& out, std::string& error);
 bool write_gpu_capture(const std::string& path, const GpuCaptureFile& capture, std::string& error);
 bool read_gpu_capture(const std::string& path, GpuCaptureFile& capture, std::string& error);
 
 struct GpuReplayFrame {
+    struct ResourceInstance {
+        uint64_t guest_addr = 0;
+        uint32_t blob_index = 0xFFFFFFFFu;
+        std::vector<uint8_t> bytes;
+    };
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
+    std::vector<ResourceInstance> resource_instances;
     std::vector<GpuCaptureRttSeed> rtt_seeds;
     std::vector<DrawItem> items;
+    std::vector<ComputeItem> computes;
+    std::vector<GpuCapturedOperation> operations;
+    bool expected_output_valid = false;
     uint64_t expected_output_hash = 0;
     uint64_t expected_output_bytes = 0;
 };

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -646,6 +646,7 @@ LiveRenderPhase live_render_phase();
 // replayer; normal guest execution enters through execute_and_present(). Returns {} when unregistered.
 std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
                                          uint32_t width, uint32_t height);
+bool execute_compute_items(const std::vector<ComputeItem>& items);
 
 // Render a folded GpuState at (width,height) via the registered live renderer and hand the frame to the
 // present path (present_write_frame). Returns true iff a frame was produced and presented. A no-op

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1331,6 +1331,9 @@ std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
                                          uint32_t width, uint32_t height) {
     return g_live ? g_live(items, width, height) : std::vector<uint8_t>{};
 }
+bool execute_compute_items(const std::vector<ComputeItem>& items) {
+    return g_compute && !items.empty() && g_compute(items);
+}
 
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
                                  uint64_t submit_no) {

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1,10 +1,13 @@
 #include "gpu_timeline.hpp"
 
+#include "gpu_capture.hpp"
 #include "render_state.hpp"
+#include "videoout_present.hpp"
 
 #include <algorithm>
 #include <atomic>
 #include <bit>
+#include <cerrno>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -20,12 +23,12 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 1;
+constexpr uint32_t kVersion = 2;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
 
-enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3 };
+enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3, Detail = 4 };
 
 struct Bytes {
     std::vector<uint8_t> data;
@@ -202,6 +205,39 @@ RuntimeRecorder& runtime_recorder() {
     return recorder;
 }
 
+struct RuntimeDetailRequest {
+    std::string path;
+    uint64_t submit_no = 0;
+    bool valid = false;
+    std::atomic<bool> claimed{false};
+
+    RuntimeDetailRequest() {
+        const char* path_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
+        const char* submit_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
+        if ((!path_env || !*path_env) && (!submit_env || !*submit_env)) return;
+        if (!path_env || !*path_env || !submit_env || !*submit_env) {
+            std::fprintf(stderr, "[timeline] detailed capture requires both "
+                         "PROSPER_GPU_TIMELINE_CAPTURE and PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT\n");
+            return;
+        }
+        char* end = nullptr;
+        errno = 0;
+        const uint64_t parsed = std::strtoull(submit_env, &end, 0);
+        if (errno || !end || *end || !parsed) {
+            std::fprintf(stderr, "[timeline] invalid detailed-capture submit '%s'\n", submit_env);
+            return;
+        }
+        path = path_env;
+        submit_no = parsed;
+        valid = true;
+    }
+};
+
+RuntimeDetailRequest& runtime_detail_request() {
+    static RuntimeDetailRequest request;
+    return request;
+}
+
 } // namespace
 
 struct GpuTimelineWriter::Impl {
@@ -298,6 +334,22 @@ bool GpuTimelineWriter::append_present(const GpuTimelinePresent& present, std::s
     return impl_->append(RecordType::Present, payload, error);
 }
 
+bool GpuTimelineWriter::append_detail(const GpuTimelineDetail& detail, std::string& error) {
+    Bytes payload;
+    payload.u64(detail.submit_no);
+    payload.string(detail.capture_path);
+    payload.u32(detail.semantic_draw_count);
+    payload.u32(detail.semantic_dispatch_count);
+    payload.u32(detail.realized_draw_count);
+    payload.u32(detail.realized_dispatch_count);
+    payload.u32(detail.operation_count);
+    payload.u32(detail.missing_operation_count);
+    payload.u32(detail.shader_version_count);
+    payload.u32(detail.resource_version_count);
+    payload.u64(detail.resource_bytes);
+    return impl_->append(RecordType::Detail, payload, error);
+}
+
 bool GpuTimelineWriter::flush(std::string& error) {
     std::lock_guard<std::mutex> lock(impl_->mutex);
     if (!impl_->file) return true;
@@ -340,10 +392,11 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
         error = "invalid timeline header";
         return false;
     }
-    if (version != kVersion) {
+    if (version < 1 || version > kVersion) {
         error = "unsupported timeline version " + std::to_string(version);
         return false;
     }
+    timeline.version = version;
     if (endian != kEndian) {
         error = "timeline endian marker mismatch";
         return false;
@@ -434,6 +487,20 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
             present.buffer_index = std::bit_cast<int32_t>(buffer_index);
             present.flip_arg = std::bit_cast<int64_t>(flip_arg);
             timeline.presents.push_back(present);
+        } else if (type == RecordType::Detail && version >= 2) {
+            GpuTimelineDetail detail;
+            detail.sequence = sequence;
+            detail.elapsed_ns = elapsed_ns;
+            if (!p.u64(detail.submit_no) || !p.string(detail.capture_path) ||
+                !p.u32(detail.semantic_draw_count) || !p.u32(detail.semantic_dispatch_count) ||
+                !p.u32(detail.realized_draw_count) || !p.u32(detail.realized_dispatch_count) ||
+                !p.u32(detail.operation_count) || !p.u32(detail.missing_operation_count) ||
+                !p.u32(detail.shader_version_count) || !p.u32(detail.resource_version_count) ||
+                !p.u64(detail.resource_bytes) || p.left) {
+                error = "invalid timeline detail record";
+                return false;
+            }
+            timeline.details.push_back(std::move(detail));
         } else {
             error = "unknown timeline record type " + std::to_string(type_raw);
             return false;
@@ -485,7 +552,60 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         submit.color0_height = rs.color0_height;
     }
     std::string error;
-    if (!writer->append_submit(submit, error)) runtime_recorder().mark_failed(error);
+    if (!writer->append_submit(submit, error)) {
+        runtime_recorder().mark_failed(error);
+        return;
+    }
+
+    RuntimeDetailRequest& request = runtime_detail_request();
+    if (!request.valid || request.submit_no != submit_no || request.claimed.exchange(true)) return;
+    GpuCaptureMetadata metadata;
+    metadata.width = present_width();
+    metadata.height = present_height();
+    metadata.submit_index = submit_no;
+#ifdef PROSPER_GIT_REVISION
+    metadata.revision = PROSPER_GIT_REVISION;
+#else
+    metadata.revision = "unknown";
+#endif
+    if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) metadata.revision = revision;
+    metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
+    metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
+    metadata.savedata_dir = env_or_empty("PROSPER_SAVEDATA_DIR");
+
+    GpuCaptureFile capture;
+    if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
+                                 metadata, capture, error) ||
+        !write_gpu_capture(request.path, capture, error)) {
+        std::fprintf(stderr, "[timeline] submit %llu detailed capture failed: %s\n",
+                     static_cast<unsigned long long>(submit_no), error.c_str());
+        return;
+    }
+    GpuTimelineDetail detail;
+    detail.submit_no = submit_no;
+    detail.capture_path = request.path;
+    detail.semantic_draw_count = submit.draw_count;
+    detail.semantic_dispatch_count = submit.dispatch_count;
+    detail.realized_draw_count = static_cast<uint32_t>(capture.draws.size());
+    detail.realized_dispatch_count = static_cast<uint32_t>(capture.computes.size());
+    detail.operation_count = static_cast<uint32_t>(capture.operations.size());
+    detail.missing_operation_count = static_cast<uint32_t>(std::count_if(
+        capture.operations.begin(), capture.operations.end(),
+        [](const auto& operation) { return !operation.realized; }));
+    detail.shader_version_count = static_cast<uint32_t>(capture.shader_versions.size());
+    detail.resource_version_count = static_cast<uint32_t>(capture.blobs.size());
+    for (const auto& blob : capture.blobs) detail.resource_bytes += blob.bytes.size();
+    if (!writer->append_detail(detail, error)) {
+        runtime_recorder().mark_failed(error);
+        return;
+    }
+    std::fprintf(stderr, "[timeline] captured submit %llu: draws=%u/%u dispatches=%u/%u "
+                         "versions=%u shaders/%u resources (%llu bytes) -> %s\n",
+                 static_cast<unsigned long long>(submit_no), detail.realized_draw_count,
+                 detail.semantic_draw_count, detail.realized_dispatch_count,
+                 detail.semantic_dispatch_count, detail.shader_version_count,
+                 detail.resource_version_count, static_cast<unsigned long long>(detail.resource_bytes),
+                 request.path.c_str());
 }
 
 void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -41,10 +41,28 @@ struct GpuTimelinePresent {
     uint32_t height = 0;
 };
 
+struct GpuTimelineDetail {
+    uint64_t sequence = 0;
+    uint64_t elapsed_ns = 0;
+    uint64_t submit_no = 0;
+    std::string capture_path;
+    uint32_t semantic_draw_count = 0;
+    uint32_t semantic_dispatch_count = 0;
+    uint32_t realized_draw_count = 0;
+    uint32_t realized_dispatch_count = 0;
+    uint32_t operation_count = 0;
+    uint32_t missing_operation_count = 0;
+    uint32_t shader_version_count = 0;
+    uint32_t resource_version_count = 0;
+    uint64_t resource_bytes = 0;
+};
+
 struct GpuTimelineFile {
+    uint32_t version = 0;
     GpuTimelineMetadata metadata;
     std::vector<GpuTimelineSubmit> submits;
     std::vector<GpuTimelinePresent> presents;
+    std::vector<GpuTimelineDetail> details;
     bool truncated_tail = false;
 };
 
@@ -58,6 +76,7 @@ public:
     bool open(const std::string& path, const GpuTimelineMetadata& metadata, std::string& error);
     bool append_submit(const GpuTimelineSubmit& submit, std::string& error);
     bool append_present(const GpuTimelinePresent& present, std::string& error);
+    bool append_detail(const GpuTimelineDetail& detail, std::string& error);
     bool flush(std::string& error);
     void close();
 

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -152,10 +152,10 @@ struct ShaderResource {
     // path (that already broadcasts coverage to every channel).
     uint32_t      swizzle[4]        = {4, 5, 6, 7};
 
-    // Replay-only backing. `gpu_addr` remains the captured logical guest address so render-target
-    // identity/alias checks stay faithful; the live renderer reads from host_data when non-null.
-    // Production resource tables leave both fields zero and continue reading 1:1 guest memory.
-    const uint8_t* host_data        = nullptr;
+    // Replay-only owned backing. `gpu_addr` remains the captured logical guest address so render-target
+    // identity/alias checks stay faithful. Graphics reads from host_data; compute may update it before a
+    // later operation consumes the same version. Production tables leave both fields zero and use guest memory.
+    uint8_t*       host_data        = nullptr;
     uint64_t       host_data_size   = 0;
 };
 

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -90,6 +90,21 @@ int main() {
     }
     CHECK(all_filled, "all 130 records are filled across three workgroups");
 
+    std::vector<uint32_t> replay_owned(records * 4, 0xdddddddd);
+    ShaderResource replay_buffer = buffer;
+    replay_buffer.gpu_addr = 1; // Deliberately unreadable: replay must never dereference this identity.
+    replay_buffer.host_data = reinterpret_cast<uint8_t*>(replay_owned.data());
+    replay_buffer.host_data_size = replay_owned.size() * sizeof(uint32_t);
+    item.resources = std::make_shared<ShaderResourceTable>();
+    item.resources->resources.push_back(replay_buffer);
+    CHECK(prosper::frontend::execute_live_compute_items({item}),
+          "production compute backend executes against replay-owned bytes");
+    bool replay_filled = true;
+    for (uint32_t record = 0; record < records && replay_filled; ++record)
+        for (uint32_t component = 0; component < 4; ++component)
+            replay_filled &= replay_owned[record * 4 + component] == expected[component];
+    CHECK(replay_filled, "compute writeback updates owned backing for a later replay operation");
+
     if (fails) {
         std::printf("== FAIL: %d ==\n", fails);
         return 1;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -31,6 +31,7 @@ int main() {
     DrawItem draw; draw.vs = {0x07230203, 1, 2}; draw.fs = {0x07230203, 3}; draw.vrt = table;
     draw.vertex_count = 6; draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
     draw.color0_width = 1024; draw.color0_height = 32;
+    draw.draw_index = 7; draw.command_order = 123;
     draw.ps.topology = 3; draw.ps.color0_format = 37; draw.ps.blend_enable = true;
     draw.ps.has_viewport = true; draw.ps.viewport_w = 1920; draw.ps.viewport_h = -1080;
     draw.ps.db_render_control = 2; draw.ps.stencil_clear_enable = true;
@@ -56,11 +57,17 @@ int main() {
           "overlapping resource ranges merge into one alias-preserving blob");
     CHECK(captured.blobs[0].bytes_read == 24 && captured.blobs[0].bytes[8] == memory[8],
           "capture records readable byte count and resource contents");
+    CHECK(captured.blobs[0].content_hash == gpu_capture_hash(captured.blobs[0].bytes),
+          "resource bytes receive an immutable content identity");
     CHECK(captured.draws[0].vrt.resources[0].blob_index == captured.draws[0].vrt.resources[1].blob_index &&
           captured.draws[0].vrt.resources[1].blob_offset == 8, "resource references preserve overlap offsets");
     CHECK(captured.rtt_seeds.size() == 1 && captured.rtt_seeds[0].guest_addr == draw.color0_base &&
           captured.rtt_seeds[0].rgba == temporal_rgba,
           "capture stores referenced temporal RTT pixels separately from guest memory");
+    CHECK(captured.shader_versions.size() == 2 && captured.operations.size() == 1 &&
+          captured.operations[0].source_index == 7 && captured.operations[0].realized,
+          "capture indexes unique shaders and retains operation provenance");
+    captured.expected_output_valid = true;
     captured.expected_output_hash = 0x1122334455667788ull; captured.expected_output_bytes = 480ull * 270 * 4;
 
     auto path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_test.prgcap";
@@ -77,6 +84,9 @@ int main() {
           "fixed-function pipeline state round-trips explicitly");
     CHECK(loaded.draws[0].color0_width == 1024 && loaded.draws[0].color0_height == 32,
           "per-target extent round-trips");
+    CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
+          loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
+          "content versions and draw operation identity round-trip");
     CHECK(loaded.rtt_seeds.size() == 1 && loaded.rtt_seeds[0].width == 2 &&
           loaded.rtt_seeds[0].rgba == temporal_rgba, "temporal RTT seed round-trips");
     CHECK(loaded.draws[0].ps.db_render_control == 2 && loaded.draws[0].ps.stencil_clear_enable &&
@@ -92,16 +102,79 @@ int main() {
     CHECK(rr[0].gpu_addr == 0x1000 && rr[1].gpu_addr == 0x1008, "replay retains logical guest addresses");
     CHECK(rr[0].host_data && rr[1].host_data == rr[0].host_data + 8 && rr[1].host_data[0] == memory[8],
           "replay resources point into shared owned backing at captured offsets");
-    CHECK(replay.expected_output_hash == captured.expected_output_hash, "expected render hash round-trips");
+    CHECK(replay.expected_output_valid && replay.expected_output_hash == captured.expected_output_hash,
+          "expected render oracle round-trips");
+    CHECK(replay.items[0].draw_index == 7 && replay.items[0].command_order == 123,
+          "materialized draw retains its source operation identity");
     CHECK(replay.rtt_seeds.size() == 1 && replay.rtt_seeds[0].guest_addr == draw.color0_base,
           "materialized replay owns temporal RTT seed pixels");
+
+    std::vector<uint8_t> repeated(48);
+    for (size_t i = 0; i < 16; ++i) repeated[i] = repeated[i + 32] = static_cast<uint8_t>(i * 3 + 1);
+    auto repeated_reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr < 0x3000 || addr >= 0x3000 + repeated.size()) return 0;
+        const size_t offset = static_cast<size_t>(addr - 0x3000);
+        const size_t take = std::min(n, repeated.size() - offset);
+        std::memcpy(dst, repeated.data() + offset, take);
+        return take;
+    };
+    auto draw_table = std::make_shared<ShaderResourceTable>();
+    ShaderResource draw_resource{}; draw_resource.gpu_addr = 0x3000; draw_resource.size = 16;
+    draw_resource.binding = 2; draw_table->resources = {draw_resource};
+    auto compute_table = std::make_shared<ShaderResourceTable>();
+    ShaderResource compute_resource = draw_resource; compute_resource.gpu_addr = 0x3020;
+    compute_table->resources = {compute_resource};
+    DrawItem mixed_draw; mixed_draw.vs = {0x07230203, 11}; mixed_draw.fs = {0x07230203, 22};
+    mixed_draw.vrt = draw_table; mixed_draw.draw_index = 4; mixed_draw.command_order = 100;
+    ComputeItem mixed_compute; mixed_compute.spirv = mixed_draw.fs; mixed_compute.resources = compute_table;
+    mixed_compute.dispatch_index = 9; mixed_compute.submit_no = 88; mixed_compute.command_order = 101;
+    mixed_compute.launch.groups_x = 8; mixed_compute.launch.local_x = 64;
+    std::vector<SubmitOperation> mixed_operations = {
+        {SubmitOperationKind::Draw, 4, 100},
+        {SubmitOperationKind::Dispatch, 9, 101},
+        {SubmitOperationKind::Draw, 5, 102},
+    };
+    GpuCaptureFile mixed;
+    CHECK(capture_submit_items({mixed_draw}, {mixed_compute}, mixed_operations, meta,
+                               repeated_reader, mixed, error),
+          "mixed graphics/compute submit captures without a renderer");
+    CHECK(mixed.blobs.size() == 1 && mixed.shader_versions.size() == 2,
+          "identical address-distinct resources and shared shaders deduplicate by content");
+    CHECK(mixed.operations.size() == 3 && mixed.operations[0].realized &&
+          mixed.operations[1].realized && !mixed.operations[2].realized,
+          "mixed operation plan explicitly retains unrealized work");
+    const auto mixed_path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_mixed_test.prgcap";
+    CHECK(write_gpu_capture(mixed_path.string(), mixed, error), "mixed versioned capture writes");
+    GpuCaptureFile mixed_loaded;
+    CHECK(read_gpu_capture(mixed_path.string(), mixed_loaded, error) &&
+          mixed_loaded.computes.size() == 1 && mixed_loaded.operations.size() == 3 &&
+          !mixed_loaded.expected_output_valid,
+          "mixed items, operation order, and absent output oracle round-trip");
+    GpuReplayFrame mixed_replay;
+    CHECK(materialize_gpu_replay(mixed_loaded, mixed_replay, error) &&
+          mixed_replay.computes.size() == 1 && mixed_replay.computes[0].dispatch_index == 9 &&
+          mixed_replay.computes[0].resources->resources[0].host_data[0] == repeated[32],
+          "offline materialization owns compute resources without guest pointers");
+    uint8_t* mixed_draw_bytes = mixed_replay.items[0].vrt->resources[0].host_data;
+    uint8_t* mixed_compute_bytes = mixed_replay.computes[0].resources->resources[0].host_data;
+    CHECK(mixed_draw_bytes != mixed_compute_bytes &&
+          mixed_replay.resource_instances.size() == 2,
+          "address-distinct users of one content version receive independent mutable instances");
+    mixed_compute_bytes[0] ^= 0xff;
+    CHECK(mixed_draw_bytes[0] == repeated[0],
+          "compute copy-on-write cannot create a false alias between equal resource versions");
+    GpuCaptureFile bad_hash = mixed;
+    bad_hash.blobs[0].content_hash ^= 1;
+    CHECK(!write_gpu_capture(mixed_path.string(), bad_hash, error) &&
+          error == "capture blob content hash mismatch",
+          "writer rejects a resource version whose content identity is stale");
 
     auto truncated = path; truncated += ".truncated";
     std::filesystem::copy_file(path, truncated, std::filesystem::copy_options::overwrite_existing);
     std::filesystem::resize_file(truncated, std::filesystem::file_size(truncated) - 5);
     GpuCaptureFile bad;
     CHECK(!read_gpu_capture(truncated.string(), bad, error) && !error.empty(), "truncated capture fails loudly");
-    std::filesystem::remove(path); std::filesystem::remove(truncated);
+    std::filesystem::remove(path); std::filesystem::remove(truncated); std::filesystem::remove(mixed_path);
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -43,6 +43,13 @@ int main() {
     present.present_count = 7; present.latest_submit_no = 10; present.buffer_index = 2;
     present.flip_arg = -5; present.width = 1920; present.height = 1080;
     CHECK(writer.append_present(present, error), "writer appends a present record");
+    GpuTimelineDetail detail;
+    detail.submit_no = 10; detail.capture_path = "/tmp/dead-cells-submit-10.prgcap";
+    detail.semantic_draw_count = 3; detail.semantic_dispatch_count = 1;
+    detail.realized_draw_count = 2; detail.realized_dispatch_count = 1;
+    detail.operation_count = 4; detail.missing_operation_count = 1;
+    detail.shader_version_count = 5; detail.resource_version_count = 3; detail.resource_bytes = 4096;
+    CHECK(writer.append_detail(detail, error), "writer appends a detailed-capture link");
     GpuTimelineSubmit second = first;
     second.submit_no = 11; second.draw_count = 4; second.dispatch_count = 0;
     CHECK(writer.append_submit(second, error), "writer appends a second submit record");
@@ -55,15 +62,19 @@ int main() {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.submits.size() == 2 && timeline.presents.size() == 1,
-          "submit and present counts round-trip");
+    CHECK(timeline.version == 2 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+          timeline.details.size() == 1, "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
-          timeline.submits[1].sequence == 3, "global record ordering round-trips");
+          timeline.details[0].sequence == 3 && timeline.submits[1].sequence == 4,
+          "global record ordering round-trips");
     CHECK(timeline.submits[0].color0_base == 0x12340000 &&
           timeline.submits[0].color0_width == 642 && timeline.submits[0].color0_height == 362,
           "target identity and extent round-trip");
     CHECK(timeline.presents[0].buffer_index == 2 && timeline.presents[0].flip_arg == -5,
           "signed present fields round-trip");
+    CHECK(timeline.details[0].submit_no == 10 && timeline.details[0].missing_operation_count == 1 &&
+          timeline.details[0].shader_version_count == 5 && timeline.details[0].resource_bytes == 4096,
+          "detailed-capture identity and version statistics round-trip");
 
     std::ifstream input(good, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
@@ -72,7 +83,8 @@ int main() {
     CHECK(write_bytes(truncated, truncated_bytes), "created a truncated-tail fixture");
     GpuTimelineFile partial;
     CHECK(read_gpu_timeline(truncated, partial, error), "reader recovers complete records from a truncated tail");
-    CHECK(partial.truncated_tail && partial.submits.size() == 1 && partial.presents.size() == 1,
+    CHECK(partial.truncated_tail && partial.submits.size() == 1 && partial.presents.size() == 1 &&
+          partial.details.size() == 1,
           "truncated final submit is ignored explicitly");
 
     std::vector<uint8_t> corrupt_bytes = bytes;
@@ -84,12 +96,17 @@ int main() {
           "reader rejects corruption instead of treating it as truncation");
 
     const auto runtime = base.string() + "-runtime.prgtl";
+    const auto runtime_capture = base.string() + "-submit-42.prgcap";
 #ifdef _WIN32
     _putenv_s("PROSPER_GPU_TIMELINE", runtime.c_str());
     _putenv_s("PROSPER_CAPTURE_TITLE", "runtime-title");
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE", runtime_capture.c_str());
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "42");
 #else
     setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
     setenv("PROSPER_CAPTURE_TITLE", "runtime-title", 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE", runtime_capture.c_str(), 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "42", 1);
 #endif
     begin_gpu_timeline_submit(42);
     record_gpu_timeline_present(9, 1, 77, 1920, 1080); // a PM4 flip can precede submit completion
@@ -102,12 +119,34 @@ int main() {
     CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 1 &&
           runtime_timeline.presents[0].latest_submit_no == 42,
           "a flip during folding is associated with its active submit");
+    CHECK(runtime_timeline.details.size() == 1 && runtime_timeline.details[0].submit_no == 42 &&
+          runtime_timeline.details[0].capture_path == runtime_capture &&
+          std::filesystem::exists(runtime_capture),
+          "exact submit selection writes and links one bounded detail capsule");
+
+    const auto compat_v2 = base.string() + "-compat-v2.prgtl";
+    GpuTimelineWriter compat_writer;
+    CHECK(compat_writer.open(compat_v2, metadata, error) && compat_writer.append_submit(first, error),
+          "created a detail-free compatibility timeline");
+    compat_writer.close();
+    std::ifstream compat_input(compat_v2, std::ios::binary);
+    std::vector<uint8_t> version1_bytes((std::istreambuf_iterator<char>(compat_input)), {});
+    version1_bytes[8] = 1; version1_bytes[9] = version1_bytes[10] = version1_bytes[11] = 0;
+    const auto version1 = base.string() + "-version1.prgtl";
+    CHECK(write_bytes(version1, version1_bytes), "created a version-1 compatibility fixture");
+    GpuTimelineFile version1_timeline;
+    CHECK(read_gpu_timeline(version1, version1_timeline, error) && version1_timeline.version == 1 &&
+          version1_timeline.submits.size() == 1,
+          "reader remains backward-compatible with version-1 semantic timelines");
 
     std::error_code ec;
     std::filesystem::remove(good, ec);
     std::filesystem::remove(truncated, ec);
     std::filesystem::remove(corrupt, ec);
     std::filesystem::remove(runtime, ec);
+    std::filesystem::remove(runtime_capture, ec);
+    std::filesystem::remove(compat_v2, ec);
+    std::filesystem::remove(version1, ec);
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -69,14 +69,19 @@ the guest and command decoder advance. The `screenshot` frontend exposes this as
 submit gate for repeatable renderer investigations.
 `PROSPER_GPU_TIMELINE=<path>.prgtl` records every folded submit before renderer sampling plus every
 VideoOut flip. `gpu_timeline <path> [--records]` inspects the checksummed index offline. Recording is
-independent of `PROSPER_RENDER_EVERY`; version 1 is semantic metadata, not yet a renderable resource capture.
+independent of `PROSPER_RENDER_EVERY`. To materialize one exact indexed submit without rendering the
+warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
+`PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
+version-5 capsules deduplicate content-addressed shader/resource versions and retain mixed draw/dispatch
+order plus explicit unrealized operations. Selection is intentionally bounded to one submit; automatic
+cross-submit producer closure remains #595.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.
 
 Use `gpu_replay --inspect-only` to print fixed-function state, native color-target dimensions, resource
 hashes, explicit clear intent, guest depth/stencil surface identities, and raw stencil-op provenance.
-Version-4 capsules also print and restore temporal RTT seeds: exact host-rendered surfaces sampled by the
+Version-4+ capsules also print and restore temporal RTT seeds: exact host-rendered surfaces sampled by the
 captured submit whose producer ran in an earlier submit. This keeps replay from silently substituting stale
 guest-memory bytes for renderer-owned history; older capsules remain readable and report zero seeds.
 The draw header also reports raster state as `raster=cull/front-face/polygon-mode`, using Vulkan enum

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -114,6 +114,27 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
         inspect_table("VS", d.vrt.get(), replay.rtt_seeds);
         inspect_table("PS", d.prt.get(), replay.rtt_seeds);
     }
+    for (size_t i = 0; i < replay.computes.size(); ++i) {
+        const auto& c = replay.computes[i];
+        std::printf("compute[%zu] source=%llu order=%llu code=%016llx groups=%ux%ux%u local=%ux%ux%u "
+                    "shader=%zu/%016llx\n",
+                    i, static_cast<unsigned long long>(c.dispatch_index),
+                    static_cast<unsigned long long>(c.command_order),
+                    static_cast<unsigned long long>(c.code_addr), c.launch.groups_x,
+                    c.launch.groups_y, c.launch.groups_z, c.launch.local_x, c.launch.local_y,
+                    c.launch.local_z, c.spirv.size(),
+                    static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
+                        reinterpret_cast<const uint8_t*>(c.spirv.data()), c.spirv.size() * 4)));
+        inspect_table("CS", c.resources.get(), replay.rtt_seeds);
+    }
+    for (size_t i = 0; i < replay.operations.size(); ++i) {
+        const auto& operation = replay.operations[i];
+        std::printf("operation[%zu] %s source=%llu order=%llu realized=%s\n", i,
+                    operation.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                    static_cast<unsigned long long>(operation.source_index),
+                    static_cast<unsigned long long>(operation.command_order),
+                    operation.realized ? "yes" : "no");
+    }
 }
 
 bool validate_frame(const prosper::gpu::GpuReplayFrame& replay) {
@@ -248,9 +269,12 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[gpureplay] selected original draws %d:%d\n", draw_first, draw_last);
     }
     const auto& m = replay.metadata;
-    std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu blobs=%zu RTT-seeds=%zu\n",
+    std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu computes=%zu "
+                         "operations=%zu shaders=%zu blobs=%zu RTT-seeds=%zu oracle=%s\n",
                  m.revision.c_str(), m.title_id.c_str(), static_cast<unsigned long long>(m.submit_index),
-                 m.width, m.height, replay.items.size(), replay.blobs.size(), replay.rtt_seeds.size());
+                 m.width, m.height, replay.items.size(), replay.computes.size(), replay.operations.size(),
+                 capture.shader_versions.size(), replay.blobs.size(), replay.rtt_seeds.size(),
+                 replay.expected_output_valid ? "yes" : "no");
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;
@@ -259,7 +283,24 @@ int main(int argc, char** argv) {
     if (!prosper::gpu::restore_gpu_replay_rtt_seeds(replay.rtt_seeds, error)) {
         std::fprintf(stderr, "gpu_replay: cannot restore RTT seeds: %s\n", error.c_str()); return 2;
     }
-    std::vector<uint8_t> pixels = prosper::gpu::render_submit_items(replay.items, m.width, m.height);
+    std::vector<prosper::gpu::SubmitOperation> operations;
+    for (const auto& operation : replay.operations)
+        if (operation.realized)
+            operations.push_back({operation.kind, static_cast<size_t>(operation.source_index),
+                                  operation.command_order});
+    std::vector<uint8_t> pixels;
+    if (operations.empty() || draw_first >= 0) {
+        pixels = prosper::gpu::render_submit_items(replay.items, m.width, m.height);
+    } else {
+        auto result = prosper::gpu::execute_ordered_items(
+            operations, replay.items, replay.computes,
+            [](const auto& items, uint32_t width, uint32_t height) {
+                return prosper::gpu::render_submit_items(items, width, height);
+            },
+            [](const auto& items) { return prosper::gpu::execute_compute_items(items); },
+            m.width, m.height);
+        pixels = std::move(result.pixels);
+    }
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
     std::fprintf(stderr, "[gpureplay] output_bytes=%zu hash=%016llx expected_bytes=%llu expected_hash=%016llx\n",
                  pixels.size(), static_cast<unsigned long long>(hash),
@@ -268,7 +309,8 @@ int main(int argc, char** argv) {
     if (positional.size() == 2 && !pixels.empty() && !prosper::test::dump_bmp(positional[1], pixels, m.width, m.height)) {
         std::fprintf(stderr, "gpu_replay: cannot write %s\n", positional[1]); return 2;
     }
-    if (!allow_mismatch && (pixels.size() != replay.expected_output_bytes || hash != replay.expected_output_hash)) {
+    if (!allow_mismatch && replay.expected_output_valid &&
+        (pixels.size() != replay.expected_output_bytes || hash != replay.expected_output_hash)) {
         std::fprintf(stderr, "gpu_replay: output mismatch\n"); return 1;
     }
     return 0;

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -1,9 +1,9 @@
 # GPU timeline
 
 `PROSPER_GPU_TIMELINE=<path>.prgtl` records the guest's folded GPU-submit and VideoOut-present
-boundaries without registering or invoking the Vulkan renderer. The initial semantic index is meant
-for native-speed progression analysis and as the stable identity layer for later resource-version and
-dependency-complete replay work (#594/#595).
+boundaries without registering or invoking the Vulkan renderer. Use the cheap semantic index to find
+the exact submit of interest, then select that stable submit number in a second run to create one
+immutable replay capsule. Vulkan warmup and renderer sampling do not control the selection.
 
 ```bash
 PROSPER_GUEST_FS=1 \
@@ -17,10 +17,25 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl --records
 ```
 
+Capture one submit found in that index:
+
+```bash
+PROSPER_GPU_TIMELINE=/tmp/dead-cells-detail.prgtl \
+PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=18420 \
+PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
+  ./build-linux/boot_trace /path/to/PPSA15552-app0
+
+./build-linux/gpu_timeline /tmp/dead-cells-detail.prgtl --records
+./build-linux/gpu_replay --inspect-only /tmp/dead-cells-submit-18420.prgcap
+./build-linux/gpu_replay /tmp/dead-cells-submit-18420.prgcap /tmp/replay.bmp
+```
+
 The summary reports duration, submit/present/draw/dispatch counts, rates, target extents, and whether
 an incomplete final record was discarded. `--records` prints the globally ordered submit/present
-index. Run metadata includes the revision, title, and input route when the corresponding capture
-environment variables are set.
+index. Version-2 detail records link the selected submit to its `.prgcap` and report semantic versus
+realized draw/dispatch counts, missing operations, unique shader/resource versions, and resource bytes.
+Run metadata includes the revision, title, and input route when the corresponding capture environment
+variables are set.
 
 ## Format contract
 
@@ -35,7 +50,13 @@ environment variables are set.
 
 ## Current boundary
 
-Version 1 is a semantic index: submit numbers, PM4 order ranges, draw/dispatch counts, final color
-target identity/extent, and flip boundaries. It does **not** yet contain shader/resource bytes or
-enough state to render offline. The next #594 slice adds deduplicated immutable resource versions;
-#595 uses those versions to build the selected present's producer dependency closure.
+Version 2 retains backward support for version-1 semantic indexes and adds exactly one bounded detailed
+submit per run. The linked version-5 `.prgcap` contains content-hashed/deduplicated shaders and resource
+bytes, graphics and compute items, and the original mixed PM4 operation order. An operation whose shader
+cannot be realized stays in the manifest with `realized=no`; inspection never silently treats a partial
+submit as complete. A timeline-selected capsule has no live-output hash oracle unless the renderer also
+produced one; replay reports `oracle=no` and renders without pretending an expected pixel hash exists.
+
+The capture is selected by exact submit number, not yet by route checkpoint or present. It contains the
+selected submit and temporal RTT surfaces currently resident in the renderer, but does not automatically
+pull earlier producer submits. Automatic present-to-producer dependency closure is tracked by #595.

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -32,11 +32,11 @@ int main(int argc, char** argv) {
     }
     for (const auto& present : timeline.presents) last_ns = std::max(last_ns, present.elapsed_ns);
     const double seconds = static_cast<double>(last_ns) / 1e9;
-    std::printf("timeline version=1 revision=%s title=%s route=%s\n",
-                timeline.metadata.revision.c_str(), timeline.metadata.title_id.c_str(),
+    std::printf("timeline version=%u revision=%s title=%s route=%s\n",
+                timeline.version, timeline.metadata.revision.c_str(), timeline.metadata.title_id.c_str(),
                 timeline.metadata.input_route.c_str());
-    std::printf("duration=%.3fs submits=%zu presents=%zu draws=%llu dispatches=%llu truncated_tail=%s\n",
-                seconds, timeline.submits.size(), timeline.presents.size(),
+    std::printf("duration=%.3fs submits=%zu presents=%zu details=%zu draws=%llu dispatches=%llu truncated_tail=%s\n",
+                seconds, timeline.submits.size(), timeline.presents.size(), timeline.details.size(),
                 static_cast<unsigned long long>(draws), static_cast<unsigned long long>(dispatches),
                 timeline.truncated_tail ? "yes" : "no");
     if (seconds > 0)
@@ -45,14 +45,23 @@ int main(int argc, char** argv) {
     for (const auto& [extent, count] : target_extents)
         std::printf("target %ux%u submits=%llu\n", extent.first, extent.second,
                     static_cast<unsigned long long>(count));
+    for (const auto& detail : timeline.details)
+        std::printf("detail submit=%llu realized=%u/%u draws %u/%u dispatches operations=%u missing=%u "
+                    "versions=%u shaders/%u resources bytes=%llu capture=%s\n",
+                    static_cast<unsigned long long>(detail.submit_no), detail.realized_draw_count,
+                    detail.semantic_draw_count, detail.realized_dispatch_count,
+                    detail.semantic_dispatch_count, detail.operation_count,
+                    detail.missing_operation_count, detail.shader_version_count,
+                    detail.resource_version_count, static_cast<unsigned long long>(detail.resource_bytes),
+                    detail.capture_path.c_str());
 
     if (argc == 3) {
-        size_t si = 0, pi = 0;
-        while (si < timeline.submits.size() || pi < timeline.presents.size()) {
-            const bool take_submit = pi == timeline.presents.size() ||
-                (si < timeline.submits.size() &&
-                 timeline.submits[si].sequence < timeline.presents[pi].sequence);
-            if (take_submit) {
+        size_t si = 0, pi = 0, di = 0;
+        while (si < timeline.submits.size() || pi < timeline.presents.size() || di < timeline.details.size()) {
+            const uint64_t ss = si < timeline.submits.size() ? timeline.submits[si].sequence : UINT64_MAX;
+            const uint64_t ps = pi < timeline.presents.size() ? timeline.presents[pi].sequence : UINT64_MAX;
+            const uint64_t ds = di < timeline.details.size() ? timeline.details[di].sequence : UINT64_MAX;
+            if (ss <= ps && ss <= ds) {
                 const auto& s = timeline.submits[si++];
                 std::printf("%llu %.6f submit=%llu draws=%u dispatches=%u order=%llu..%llu "
                             "target=%016llx/%ux%u\n",
@@ -62,13 +71,23 @@ int main(int argc, char** argv) {
                             static_cast<unsigned long long>(s.last_command_order),
                             static_cast<unsigned long long>(s.color0_base),
                             s.color0_width, s.color0_height);
-            } else {
+            } else if (ps <= ds) {
                 const auto& p = timeline.presents[pi++];
                 std::printf("%llu %.6f present=%llu latest-submit=%llu buffer=%d flip-arg=%lld extent=%ux%u\n",
                             static_cast<unsigned long long>(p.sequence), p.elapsed_ns / 1e9,
                             static_cast<unsigned long long>(p.present_count),
                             static_cast<unsigned long long>(p.latest_submit_no), p.buffer_index,
                             static_cast<long long>(p.flip_arg), p.width, p.height);
+            } else {
+                const auto& d = timeline.details[di++];
+                std::printf("%llu %.6f detail-submit=%llu realized=%u/%u+%u/%u operations=%u missing=%u "
+                            "versions=%u/%u bytes=%llu capture=%s\n",
+                            static_cast<unsigned long long>(d.sequence), d.elapsed_ns / 1e9,
+                            static_cast<unsigned long long>(d.submit_no), d.realized_draw_count,
+                            d.semantic_draw_count, d.realized_dispatch_count, d.semantic_dispatch_count,
+                            d.operation_count, d.missing_operation_count, d.shader_version_count,
+                            d.resource_version_count, static_cast<unsigned long long>(d.resource_bytes),
+                            d.capture_path.c_str());
             }
         }
     }


### PR DESCRIPTION
## Summary
- select one exact semantic timeline submit before renderer sampling and link its capsule from .prgtl v2
- serialize .prgcap v5 content-addressed shader/resource versions, graphics+compute items, and explicit mixed PM4 operation order
- materialize replay-owned mutable resource instances without guest pointers or false aliasing between address-distinct equal versions
- execute captured compute writeback and ordered graphics spans offline; distinguish capsules with and without a live pixel oracle
- update current tooling/frontier documentation and retain version-1 timeline plus version-1..4 capsule compatibility

Part of #594. Remaining work is route/checkpoint selection across nondeterministic runs; automatic prior-producer closure is tracked by #595.

## Verification
- 89/89 ctest --output-on-failure
- Messenger snapshot: 24,318 colors (minimum 5,000)
- Dead Cells native index reached Loading level PrisonStart
- selected submit 18,750: 92 draws + 8 dispatches; 88 + 7 realized, 5 explicit missing operations
- 31 shader versions, 144 resource versions, 179,314,092 resource bytes; capture work about 1.089 s
- offline gpu_replay --validate accepts all realized graphics descriptor contracts
- offline 3840x2160 replay with no guest mappings: 7 computes executed, output hash f438db1e3ce61da3 in 5.8 s