### PR TITLE
feat(gpu): graph captured resource dependencies

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -366,6 +366,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_timeline PRIVATE prosper_core)
   add_test(NAME gpu_timeline_roundtrip COMMAND test_gpu_timeline)
 
+  add_executable(test_gpu_dependency_graph tests/test_gpu_dependency_graph.cpp)
+  target_link_libraries(test_gpu_dependency_graph PRIVATE prosper_core)
+  add_test(NAME gpu_dependency_graph COMMAND test_gpu_dependency_graph)
+
   add_executable(gpu_timeline tools/gpu_timeline/gpu_timeline.cpp)
   target_link_libraries(gpu_timeline PRIVATE prosper_core)
 

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -35,6 +35,8 @@ possible without console keys. Dumps are user-supplied and gitignored.
   provenance, normal screenshot capture, and a local content-metric snapshot guard. Native-speed `.prgtl`
   submit/present indexes can select one exact submit before renderer sampling and materialize immutable,
   content-deduplicated graphics/compute state plus mixed operation order for offline replay (#594).
+  Offline dependency graphs resolve in-submit resource versions and identify deduplicated prior-submit
+  leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595).
 - ✅ **Dead Cells reaches gameplay reproducibly:** a deterministic input route passes the splash and menus
   into the first playable scene. HUD and some composition render, but the world is mostly white (#566).
   Version-5 GPU captures seed temporal render targets and retain content-addressed resource versions for
@@ -77,7 +79,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # 89 self-checking tests
+ctest --test-dir build          # 90 self-checking tests
 ```
 Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```

--- a/prosper/src/gpu/gpu_dependency_graph.cpp
+++ b/prosper/src/gpu/gpu_dependency_graph.cpp
@@ -1,0 +1,119 @@
+#include "gpu_dependency_graph.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <unordered_map>
+
+namespace prosper::gpu {
+namespace {
+
+struct Writer {
+    uint32_t operation = 0;
+    uint64_t addr = 0;
+    uint64_t size = 0;
+};
+
+uint64_t span_end(uint64_t addr, uint64_t size) {
+    return size > std::numeric_limits<uint64_t>::max() - addr
+        ? std::numeric_limits<uint64_t>::max() : addr + size;
+}
+
+bool overlaps(uint64_t a_addr, uint64_t a_size, uint64_t b_addr, uint64_t b_size) {
+    return a_addr < span_end(b_addr, b_size) && b_addr < span_end(a_addr, a_size);
+}
+
+uint64_t resource_size(const ShaderResource& resource) {
+    if (resource.host_data_size) return resource.host_data_size;
+    if (resource.size) return resource.size;
+    if (resource.width && resource.height)
+        return static_cast<uint64_t>(resource.width) * resource.height * 4;
+    return 0;
+}
+
+void append_accesses(const ShaderResourceTable* table, const char* stage,
+                     std::vector<GpuDependencyAccess>& accesses) {
+    if (!table) return;
+    for (const auto& resource : table->resources) {
+        const uint64_t size = resource_size(resource);
+        if (!resource.gpu_addr || !size || resource.cls == ResourceClass::Sampler) continue;
+        accesses.push_back({resource.gpu_addr, size, resource.width, resource.height,
+                            resource.binding, resource.cls, stage});
+    }
+}
+
+} // namespace
+
+bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
+                                GpuDependencyGraph& graph, std::string& error) {
+    graph = {};
+    error.clear();
+    std::unordered_map<uint64_t, const DrawItem*> draws;
+    std::unordered_map<uint64_t, const ComputeItem*> computes;
+    for (const auto& draw : replay.items) draws.emplace(draw.draw_index, &draw);
+    for (const auto& compute : replay.computes) computes.emplace(compute.dispatch_index, &compute);
+
+    std::vector<Writer> writers;
+    graph.nodes.reserve(replay.operations.size());
+    for (size_t operation_index = 0; operation_index < replay.operations.size(); ++operation_index) {
+        const auto& operation = replay.operations[operation_index];
+        graph.nodes.push_back({static_cast<uint32_t>(operation_index), operation.kind,
+                               operation.source_index, operation.command_order, operation.realized});
+        if (!operation.realized) continue;
+
+        std::vector<GpuDependencyAccess> reads;
+        std::vector<std::pair<uint64_t, uint64_t>> writes;
+        if (operation.kind == SubmitOperationKind::Draw) {
+            auto it = draws.find(operation.source_index);
+            if (it == draws.end()) {
+                error = "realized draw operation has no materialized item";
+                return false;
+            }
+            const DrawItem& draw = *it->second;
+            append_accesses(draw.vrt.get(), "vs", reads);
+            append_accesses(draw.prt.get(), "ps", reads);
+            if (draw.color0_base && draw.color0_width && draw.color0_height)
+                writes.push_back({draw.color0_base,
+                                  static_cast<uint64_t>(draw.color0_width) * draw.color0_height * 4});
+        } else {
+            auto it = computes.find(operation.source_index);
+            if (it == computes.end()) {
+                error = "realized dispatch operation has no materialized item";
+                return false;
+            }
+            append_accesses(it->second->resources.get(), "cs", reads);
+            for (const auto& access : reads) writes.push_back({access.addr, access.size});
+        }
+
+        for (const auto& access : reads) {
+            auto producer = std::find_if(writers.rbegin(), writers.rend(), [&](const Writer& writer) {
+                return overlaps(access.addr, access.size, writer.addr, writer.size);
+            });
+            if (producer == writers.rend()) {
+                auto leaf = std::find_if(graph.external_leaves.begin(), graph.external_leaves.end(),
+                    [&](const GpuDependencyLeaf& candidate) {
+                        return candidate.access.addr == access.addr && candidate.access.size == access.size;
+                    });
+                if (leaf == graph.external_leaves.end())
+                    graph.external_leaves.push_back({access, {static_cast<uint32_t>(operation_index)}, UINT32_MAX});
+                else if (leaf->consumer_operations.empty() ||
+                         leaf->consumer_operations.back() != operation_index)
+                    leaf->consumer_operations.push_back(static_cast<uint32_t>(operation_index));
+            } else
+                graph.edges.push_back({producer->operation, static_cast<uint32_t>(operation_index), access});
+        }
+        for (const auto& write : writes)
+            if (write.first && write.second)
+                writers.push_back({static_cast<uint32_t>(operation_index), write.first, write.second});
+    }
+    for (auto& leaf : graph.external_leaves) {
+        const uint32_t first_consumer = leaf.consumer_operations.front();
+        auto future = std::find_if(writers.begin(), writers.end(), [&](const Writer& writer) {
+            return writer.operation >= first_consumer &&
+                   overlaps(leaf.access.addr, leaf.access.size, writer.addr, writer.size);
+        });
+        if (future != writers.end()) leaf.first_future_writer = future->operation;
+    }
+    return true;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_dependency_graph.hpp
+++ b/prosper/src/gpu/gpu_dependency_graph.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "gpu_capture.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace prosper::gpu {
+
+struct GpuDependencyAccess {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t binding = 0;
+    ResourceClass resource_class = ResourceClass::ConstantBuffer;
+    std::string stage;
+};
+
+struct GpuDependencyNode {
+    uint32_t operation_index = 0;
+    SubmitOperationKind kind = SubmitOperationKind::Draw;
+    uint64_t source_index = 0;
+    uint64_t command_order = 0;
+    bool realized = false;
+};
+
+struct GpuDependencyEdge {
+    uint32_t producer_operation = 0;
+    uint32_t consumer_operation = 0;
+    GpuDependencyAccess access;
+};
+
+struct GpuDependencyLeaf {
+    GpuDependencyAccess access;
+    std::vector<uint32_t> consumer_operations;
+    uint32_t first_future_writer = UINT32_MAX;
+};
+
+struct GpuDependencyGraph {
+    std::vector<GpuDependencyNode> nodes;
+    std::vector<GpuDependencyEdge> edges;
+    std::vector<GpuDependencyLeaf> external_leaves;
+};
+
+bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
+                                GpuDependencyGraph& graph, std::string& error);
+
+} // namespace prosper::gpu

--- a/prosper/tests/test_gpu_dependency_graph.cpp
+++ b/prosper/tests/test_gpu_dependency_graph.cpp
@@ -1,0 +1,94 @@
+#include "../src/gpu/gpu_dependency_graph.hpp"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+static ShaderResource resource(uint64_t addr, uint64_t bytes, uint32_t binding,
+                               ResourceClass cls = ResourceClass::Texture) {
+    ShaderResource result;
+    result.gpu_addr = addr;
+    result.size = static_cast<uint32_t>(bytes);
+    result.host_data_size = bytes;
+    result.binding = binding;
+    result.cls = cls;
+    return result;
+}
+
+int main() {
+    std::printf("== test_gpu_dependency_graph ==\n");
+    GpuReplayFrame replay;
+
+    DrawItem producer;
+    producer.draw_index = 0;
+    producer.command_order = 10;
+    producer.color0_base = 0x2000;
+    producer.color0_width = 8;
+    producer.color0_height = 8;
+    producer.prt = std::make_shared<ShaderResourceTable>();
+    producer.prt->resources.push_back(resource(0x1000, 0x100, 4));
+
+    ComputeItem compute;
+    compute.dispatch_index = 2;
+    compute.command_order = 20;
+    compute.resources = std::make_shared<ShaderResourceTable>();
+    compute.resources->resources.push_back(resource(0x3000, 0x80, 2, ResourceClass::ConstantBuffer));
+
+    DrawItem consumer;
+    consumer.draw_index = 1;
+    consumer.command_order = 30;
+    consumer.color0_base = 0x5000;
+    consumer.color0_width = 8;
+    consumer.color0_height = 8;
+    consumer.prt = std::make_shared<ShaderResourceTable>();
+    consumer.prt->resources = {
+        resource(0x2000, 0x100, 4),
+        resource(0x3040, 0x20, 5, ResourceClass::ConstantBuffer),
+        resource(0x4000, 0x40, 6),
+    };
+
+    replay.items = {producer, consumer};
+    replay.computes = {compute};
+    replay.operations = {
+        {SubmitOperationKind::Draw, 0, 10, true},
+        {SubmitOperationKind::Dispatch, 2, 20, true},
+        {SubmitOperationKind::Draw, 1, 30, true},
+        {SubmitOperationKind::Draw, 9, 40, false},
+    };
+
+    GpuDependencyGraph graph;
+    std::string error;
+    CHECK(build_gpu_dependency_graph(replay, graph, error), "mixed operation graph builds");
+    CHECK(graph.nodes.size() == 4 && !graph.nodes[3].realized,
+          "all semantic operations remain visible, including missing work");
+    CHECK(graph.edges.size() == 2 && graph.edges[0].producer_operation == 0 &&
+          graph.edges[0].consumer_operation == 2 && graph.edges[1].producer_operation == 1 &&
+          graph.edges[1].consumer_operation == 2,
+          "consumer resolves latest overlapping draw and compute writers");
+    CHECK(graph.external_leaves.size() == 3,
+          "resources with no earlier in-capsule writer remain explicit external leaves");
+    CHECK(graph.external_leaves[0].access.addr == 0x1000 &&
+          graph.external_leaves[1].access.addr == 0x3000 &&
+          graph.external_leaves[2].access.addr == 0x4000 &&
+          graph.external_leaves[0].consumer_operations[0] == 0,
+          "external leaf identities preserve operation order");
+    CHECK(graph.external_leaves[0].first_future_writer == UINT32_MAX &&
+          graph.external_leaves[1].first_future_writer == 1,
+          "read-before-write leaves identify the first in-capsule future writer");
+
+    replay.operations[3].realized = true;
+    CHECK(!build_gpu_dependency_graph(replay, graph, error) &&
+          error.find("no materialized item") != std::string::npos,
+          "graph rejects a falsely realized operation");
+
+    if (fails) return 1;
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -81,6 +81,11 @@ offscreen target dimensions.
 
 Use `gpu_replay --inspect-only` to print fixed-function state, native color-target dimensions, resource
 hashes, explicit clear intent, guest depth/stencil surface identities, and raw stencil-op provenance.
+Use `gpu_replay --graph <capture.prgcap>` to resolve captured resource reads to the latest overlapping
+earlier draw/dispatch writer in mixed PM4 order. External versions are deduplicated by logical range and
+list every consumer; `future-writer=N` identifies a temporal read-before-write whose prior-submit version
+is required. `--graph-json <path> <capture.prgcap>` emits the same closure frontier as structured JSON.
+The graph is selected-submit scope: external leaves still require cross-submit producer capture (#595).
 Version-4+ capsules also print and restore temporal RTT seeds: exact host-rendered surfaces sampled by the
 captured submit whose producer ran in an earlier submit. This keeps replay from silently substituting stale
 guest-memory bytes for renderer-owned history; older capsules remain readable and report zero seeds.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1,4 +1,5 @@
 #include "gpu/gpu_capture.hpp"
+#include "gpu/gpu_dependency_graph.hpp"
 #include "gpu/gpu_execute.hpp"
 #include "live_renderer.hpp"
 #include "render_runner.h"
@@ -21,10 +22,84 @@ bool set_environment(const std::string& name, const std::string& value) {
 }
 
 void usage(const char* argv0) {
-    std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate] [--draw N[:M]] "
+    std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
+                         "[--graph-json PATH] [--draw N[:M]] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-shader DRAW:vs|fs PATH] "
                          "<capture.prgcap> [output.bmp]\n", argv0);
+}
+
+const char* class_name(prosper::gpu::ResourceClass c);
+
+void print_graph(const prosper::gpu::GpuDependencyGraph& graph) {
+    std::printf("dependency-graph operations=%zu edges=%zu external-leaves=%zu\n",
+                graph.nodes.size(), graph.edges.size(), graph.external_leaves.size());
+    for (const auto& node : graph.nodes)
+        if (!node.realized)
+            std::printf("missing operation=%u kind=%s source=%llu order=%llu\n",
+                        node.operation_index,
+                        node.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                        static_cast<unsigned long long>(node.source_index),
+                        static_cast<unsigned long long>(node.command_order));
+    for (const auto& edge : graph.edges)
+        std::printf("edge producer=%u consumer=%u stage=%s binding=%u addr=%016llx bytes=%llu dims=%ux%u\n",
+                    edge.producer_operation, edge.consumer_operation, edge.access.stage.c_str(),
+                    edge.access.binding, static_cast<unsigned long long>(edge.access.addr),
+                    static_cast<unsigned long long>(edge.access.size), edge.access.width, edge.access.height);
+    for (const auto& leaf : graph.external_leaves)
+        std::printf("external consumers=%zu first=%u future-writer=%lld stage=%s binding=%u class=%s "
+                    "addr=%016llx bytes=%llu dims=%ux%u\n",
+                    leaf.consumer_operations.size(), leaf.consumer_operations.front(),
+                    leaf.first_future_writer == UINT32_MAX ? -1ll : static_cast<long long>(leaf.first_future_writer),
+                    leaf.access.stage.c_str(), leaf.access.binding,
+                    class_name(leaf.access.resource_class),
+                    static_cast<unsigned long long>(leaf.access.addr),
+                    static_cast<unsigned long long>(leaf.access.size), leaf.access.width, leaf.access.height);
+}
+
+bool write_graph_json(const std::string& path, const prosper::gpu::GpuDependencyGraph& graph) {
+    FILE* file = std::fopen(path.c_str(), "wb");
+    if (!file) return false;
+    std::fprintf(file, "{\n  \"operation_count\": %zu,\n  \"nodes\": [\n", graph.nodes.size());
+    for (size_t i = 0; i < graph.nodes.size(); ++i) {
+        const auto& node = graph.nodes[i];
+        std::fprintf(file, "    {\"operation\":%u,\"kind\":\"%s\",\"source\":%llu,"
+                           "\"order\":%llu,\"realized\":%s}%s\n",
+                     node.operation_index,
+                     node.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                     static_cast<unsigned long long>(node.source_index),
+                     static_cast<unsigned long long>(node.command_order),
+                     node.realized ? "true" : "false", i + 1 == graph.nodes.size() ? "" : ",");
+    }
+    std::fprintf(file, "  ],\n  \"edges\": [\n");
+    for (size_t i = 0; i < graph.edges.size(); ++i) {
+        const auto& edge = graph.edges[i];
+        std::fprintf(file, "    {\"producer\":%u,\"consumer\":%u,\"stage\":\"%s\","
+                           "\"binding\":%u,\"addr\":%llu,\"bytes\":%llu,\"width\":%u,\"height\":%u}%s\n",
+                     edge.producer_operation, edge.consumer_operation, edge.access.stage.c_str(),
+                     edge.access.binding, static_cast<unsigned long long>(edge.access.addr),
+                     static_cast<unsigned long long>(edge.access.size), edge.access.width,
+                     edge.access.height, i + 1 == graph.edges.size() ? "" : ",");
+    }
+    std::fprintf(file, "  ],\n  \"external_leaves\": [\n");
+    for (size_t i = 0; i < graph.external_leaves.size(); ++i) {
+        const auto& leaf = graph.external_leaves[i];
+        std::fprintf(file, "    {\"consumers\":[");
+        for (size_t c = 0; c < leaf.consumer_operations.size(); ++c)
+            std::fprintf(file, "%s%u", c ? "," : "", leaf.consumer_operations[c]);
+        if (leaf.first_future_writer == UINT32_MAX) std::fprintf(file, "],\"future_writer\":null");
+        else std::fprintf(file, "],\"future_writer\":%u", leaf.first_future_writer);
+        std::fprintf(file, ",\"stage\":\"%s\",\"binding\":%u,"
+                           "\"class\":\"%s\",\"addr\":%llu,\"bytes\":%llu,"
+                           "\"width\":%u,\"height\":%u}%s\n",
+                     leaf.access.stage.c_str(), leaf.access.binding,
+                     class_name(leaf.access.resource_class),
+                     static_cast<unsigned long long>(leaf.access.addr),
+                     static_cast<unsigned long long>(leaf.access.size), leaf.access.width,
+                     leaf.access.height, i + 1 == graph.external_leaves.size() ? "" : ",");
+    }
+    std::fprintf(file, "  ]\n}\n");
+    return std::fclose(file) == 0;
 }
 
 const char* class_name(prosper::gpu::ResourceClass c) {
@@ -182,13 +257,18 @@ bool validate_frame(const prosper::gpu::GpuReplayFrame& replay) {
 
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
+    bool graph_only = false;
     int draw_first = -1, draw_last = -1;
-    std::string dump_spec, dump_path, shader_spec, shader_path;
+    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
         else if (std::string(argv[i]) == "--inspect-only") inspect = inspect_only = true;
         else if (std::string(argv[i]) == "--validate") validate_only = true;
+        else if (std::string(argv[i]) == "--graph") graph_only = true;
+        else if (std::string(argv[i]) == "--graph-json" && i + 1 < argc) {
+            graph_only = true; graph_json_path = argv[++i];
+        }
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
             std::string range = argv[++i]; size_t colon = range.find(':');
@@ -218,6 +298,17 @@ int main(int argc, char** argv) {
     prosper::gpu::GpuReplayFrame replay;
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    if (graph_only) {
+        prosper::gpu::GpuDependencyGraph graph;
+        if (!prosper::gpu::build_gpu_dependency_graph(replay, graph, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot build dependency graph: %s\n", error.c_str()); return 2;
+        }
+        if (graph_json_path.empty()) print_graph(graph);
+        else if (!write_graph_json(graph_json_path, graph)) {
+            std::fprintf(stderr, "gpu_replay: cannot write graph JSON %s\n", graph_json_path.c_str()); return 2;
+        }
+        return 0;
     }
     if (!dump_spec.empty()) {
         size_t c1 = dump_spec.find(':'), c2 = c1 == std::string::npos ? c1 : dump_spec.find(':', c1 + 1);

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -27,6 +27,8 @@ PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
 
 ./build-linux/gpu_timeline /tmp/dead-cells-detail.prgtl --records
 ./build-linux/gpu_replay --inspect-only /tmp/dead-cells-submit-18420.prgcap
+./build-linux/gpu_replay --graph /tmp/dead-cells-submit-18420.prgcap
+./build-linux/gpu_replay --graph-json /tmp/dead-cells-graph.json /tmp/dead-cells-submit-18420.prgcap
 ./build-linux/gpu_replay /tmp/dead-cells-submit-18420.prgcap /tmp/replay.bmp
 ```
 
@@ -60,3 +62,6 @@ produced one; replay reports `oracle=no` and renders without pretending an expec
 The capture is selected by exact submit number, not yet by route checkpoint or present. It contains the
 selected submit and temporal RTT surfaces currently resident in the renderer, but does not automatically
 pull earlier producer submits. Automatic present-to-producer dependency closure is tracked by #595.
+`gpu_replay --graph` resolves dependencies inside the selected submit and reports the remaining external
+versions; a `future-writer` on an external leaf is the characteristic temporal read-before-write case that
+needs the earlier version of the same logical surface.


### PR DESCRIPTION
## Summary
- derive a deterministic resource dependency graph from v5 captured mixed PM4 operation order
- resolve draw/dispatch reads to the latest overlapping earlier writer and retain unrealized operations explicitly
- deduplicate external versions by logical range, list all consumers, and identify temporal read-before-write leaves with their first future writer
- expose human-readable and structured JSON graph output from gpu_replay

Part of #595. The next slice uses the exact external leaves to capture prior-submit producers recursively.

## Dead Cells evidence
- 100 operations, including 5 explicit unrealized nodes
- 12 in-submit producer edges and 320 unique external versions
- exact temporal 642x362 leaves reduced to two addresses:
  - 0x7f9b78890000, consumed by operations 19-25/27/28, first in-submit writer operation 28
  - 0x7f9b789b0000, consumed by operation 48, first in-submit writer operation 49
- JSON artifact parses as 100 nodes / 12 edges / 320 leaves / 5 missing nodes

## Verification
- 90/90 ctest --output-on-failure
- focused graph test covers overlap resolution, external leaves, read-before-write detection, and malformed realized operations
- graph text and JSON generated from the 180 MB Dead Cells gameplay capsule without Vulkan