### PR TITLE
gpu: record prior producer identities in timelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,9 +112,12 @@ residual seeded replay mismatch (#569) and animation-sensitive exact splash guar
 The current tooling frontier is deterministic offline capture rather than longer live-render windows.
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
 immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-5 `.prgcap` (#594).
-Use that path to isolate the Dead Cells gameplay consumer, then implement automatic earlier-producer dependency
-closure (#595/#586). The stale exact Dead Cells snapshot baseline is tracked separately in #596 and must not be
-silently updated.
+`gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
+full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 3 resolves those leaves against bounded
+same-run target history. The Dead Cells submit-18750 run found both 642x362 producers in submit 18749, at draws
+45 and 41 (PM4 orders 9436927 and 9436871). Addresses are run-local. Snapshot those producer-time bytes and
+recurse rather than adding a dimension override (#595/#586). The stale exact Dead Cells snapshot baseline is
+tracked separately in #596 and must not be silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.
 `PROSPER_RESOURCE_HASH_DIM=WxH` correlates raw and sampled hashes with those writers at each live draw;

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -44,10 +44,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** use the selected-submit timeline/capsule path to prove the Dead Cells gameplay
-  consumer offline (#594), then derive its earlier 642×362 producer dependency automatically (#595/#586).
-  The stale exact Dead Cells snapshot baseline is tracked separately in #596. UE4's measured GPU boundary
-  remains tracked under its area issues.
+- 🚧 **Active frontiers:** retain and replay producer-time state/bytes from Dead Cells submit 18749 for the
+  two temporal 642×362 versions consumed by submit 18750 (#595/#586). Exact-submit capture, selected-submit
+  graphing, and same-run producer identity are complete; recursive capsule closure is not. The stale exact Dead Cells
+  snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
 [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1,6 +1,7 @@
 #include "gpu_timeline.hpp"
 
 #include "gpu_capture.hpp"
+#include "gpu_dependency_graph.hpp"
 #include "render_state.hpp"
 #include "videoout_present.hpp"
 
@@ -12,6 +13,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -23,12 +25,12 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 2;
+constexpr uint32_t kVersion = 3;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
 
-enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3, Detail = 4 };
+enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3, Detail = 4, Producer = 5 };
 
 struct Bytes {
     std::vector<uint8_t> data;
@@ -238,6 +240,62 @@ RuntimeDetailRequest& runtime_detail_request() {
     return request;
 }
 
+struct RuntimeTargetWrite {
+    uint64_t submit_no = 0;
+    uint64_t draw_index = 0;
+    uint64_t command_order = 0;
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
+
+struct RuntimeProducerHistory {
+    std::deque<std::vector<RuntimeTargetWrite>> submits;
+    size_t capacity = 64;
+    bool enabled = false;
+
+    RuntimeProducerHistory() {
+        enabled = runtime_detail_request().valid;
+        if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_HISTORY")) {
+            char* end = nullptr;
+            const uint64_t parsed = std::strtoull(value, &end, 0);
+            if (end && !*end && parsed) capacity = static_cast<size_t>(std::min<uint64_t>(parsed, 4096));
+        }
+    }
+
+    void remember(const GpuState& state, uint64_t submit_no) {
+        if (!enabled) return;
+        std::vector<RuntimeTargetWrite> writes;
+        writes.reserve(state.draws.size());
+        for (size_t i = 0; i < state.draws.size(); ++i) {
+            const RenderState rs = extract_render_state(state.state_at_draw(i));
+            if (!rs.color0_base || !rs.color0_width || !rs.color0_height) continue;
+            writes.push_back({submit_no, i, state.draws[i].command_order, rs.color0_base,
+                              static_cast<uint64_t>(rs.color0_width) * rs.color0_height * 4,
+                              rs.color0_width, rs.color0_height});
+        }
+        submits.push_back(std::move(writes));
+        while (submits.size() > capacity) submits.pop_front();
+    }
+
+    const RuntimeTargetWrite* latest_overlap(uint64_t addr, uint64_t size) const {
+        auto end = [](uint64_t base, uint64_t bytes) {
+            return bytes > UINT64_MAX - base ? UINT64_MAX : base + bytes;
+        };
+        for (auto submit = submits.rbegin(); submit != submits.rend(); ++submit)
+            for (auto write = submit->rbegin(); write != submit->rend(); ++write)
+                if (addr < end(write->addr, write->size) && write->addr < end(addr, size))
+                    return &*write;
+        return nullptr;
+    }
+};
+
+RuntimeProducerHistory& runtime_producer_history() {
+    static RuntimeProducerHistory history;
+    return history;
+}
+
 } // namespace
 
 struct GpuTimelineWriter::Impl {
@@ -348,6 +406,25 @@ bool GpuTimelineWriter::append_detail(const GpuTimelineDetail& detail, std::stri
     payload.u32(detail.resource_version_count);
     payload.u64(detail.resource_bytes);
     return impl_->append(RecordType::Detail, payload, error);
+}
+
+bool GpuTimelineWriter::append_producer(const GpuTimelineProducer& producer, std::string& error) {
+    Bytes payload;
+    payload.u64(producer.consumer_submit_no);
+    payload.u32(producer.consumer_operation);
+    payload.u32(producer.future_writer_operation);
+    payload.u64(producer.resource_addr);
+    payload.u64(producer.resource_size);
+    payload.u32(producer.resource_width);
+    payload.u32(producer.resource_height);
+    payload.u32(producer.resolved ? 1u : 0u);
+    payload.u64(producer.producer_submit_no);
+    payload.u64(producer.producer_draw_index);
+    payload.u64(producer.producer_command_order);
+    payload.u64(producer.producer_target_addr);
+    payload.u32(producer.producer_width);
+    payload.u32(producer.producer_height);
+    return impl_->append(RecordType::Producer, payload, error);
 }
 
 bool GpuTimelineWriter::flush(std::string& error) {
@@ -501,6 +578,24 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
                 return false;
             }
             timeline.details.push_back(std::move(detail));
+        } else if (type == RecordType::Producer && version >= 3) {
+            GpuTimelineProducer producer;
+            producer.sequence = sequence;
+            producer.elapsed_ns = elapsed_ns;
+            uint32_t resolved = 0;
+            if (!p.u64(producer.consumer_submit_no) || !p.u32(producer.consumer_operation) ||
+                !p.u32(producer.future_writer_operation) || !p.u64(producer.resource_addr) ||
+                !p.u64(producer.resource_size) || !p.u32(producer.resource_width) ||
+                !p.u32(producer.resource_height) || !p.u32(resolved) ||
+                !p.u64(producer.producer_submit_no) || !p.u64(producer.producer_draw_index) ||
+                !p.u64(producer.producer_command_order) || !p.u64(producer.producer_target_addr) ||
+                !p.u32(producer.producer_width) || !p.u32(producer.producer_height) || p.left ||
+                resolved > 1) {
+                error = "invalid timeline producer record";
+                return false;
+            }
+            producer.resolved = resolved != 0;
+            timeline.producers.push_back(std::move(producer));
         } else {
             error = "unknown timeline record type " + std::to_string(type_raw);
             return false;
@@ -558,7 +653,11 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     }
 
     RuntimeDetailRequest& request = runtime_detail_request();
-    if (!request.valid || request.submit_no != submit_no || request.claimed.exchange(true)) return;
+    RuntimeProducerHistory& history = runtime_producer_history();
+    if (!request.valid || request.submit_no != submit_no || request.claimed.exchange(true)) {
+        history.remember(state, submit_no);
+        return;
+    }
     GpuCaptureMetadata metadata;
     metadata.width = present_width();
     metadata.height = present_height();
@@ -579,7 +678,56 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         !write_gpu_capture(request.path, capture, error)) {
         std::fprintf(stderr, "[timeline] submit %llu detailed capture failed: %s\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
+        history.remember(state, submit_no);
         return;
+    }
+    GpuReplayFrame replay;
+    GpuDependencyGraph graph;
+    if (materialize_gpu_replay(capture, replay, error) &&
+        build_gpu_dependency_graph(replay, graph, error)) {
+        for (const auto& leaf : graph.external_leaves) {
+            if (leaf.first_future_writer == UINT32_MAX) continue;
+            if (leaf.access.resource_class != ResourceClass::Texture &&
+                leaf.access.resource_class != ResourceClass::StorageImage) continue;
+            GpuTimelineProducer producer;
+            producer.consumer_submit_no = submit_no;
+            producer.consumer_operation = leaf.consumer_operations.front();
+            producer.future_writer_operation = leaf.first_future_writer;
+            producer.resource_addr = leaf.access.addr;
+            producer.resource_size = leaf.access.size;
+            producer.resource_width = leaf.access.width;
+            producer.resource_height = leaf.access.height;
+            if (const RuntimeTargetWrite* match = history.latest_overlap(leaf.access.addr, leaf.access.size)) {
+                producer.resolved = true;
+                producer.producer_submit_no = match->submit_no;
+                producer.producer_draw_index = match->draw_index;
+                producer.producer_command_order = match->command_order;
+                producer.producer_target_addr = match->addr;
+                producer.producer_width = match->width;
+                producer.producer_height = match->height;
+            }
+            if (!writer->append_producer(producer, error)) {
+                runtime_recorder().mark_failed(error);
+                history.remember(state, submit_no);
+                return;
+            }
+            std::fprintf(stderr, "[timeline] temporal resource 0x%llx/%ux%u op=%u -> %s",
+                         static_cast<unsigned long long>(producer.resource_addr),
+                         producer.resource_width, producer.resource_height,
+                         producer.consumer_operation, producer.resolved ? "producer" : "unresolved");
+            if (producer.resolved)
+                std::fprintf(stderr, " submit=%llu draw=%llu order=%llu target=0x%llx/%ux%u",
+                             static_cast<unsigned long long>(producer.producer_submit_no),
+                             static_cast<unsigned long long>(producer.producer_draw_index),
+                             static_cast<unsigned long long>(producer.producer_command_order),
+                             static_cast<unsigned long long>(producer.producer_target_addr),
+                             producer.producer_width, producer.producer_height);
+            std::fprintf(stderr, "\n");
+        }
+    } else {
+        std::fprintf(stderr, "[timeline] dependency graph failed for submit %llu: %s\n",
+                     static_cast<unsigned long long>(submit_no), error.c_str());
+        error.clear();
     }
     GpuTimelineDetail detail;
     detail.submit_no = submit_no;
@@ -597,6 +745,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     for (const auto& blob : capture.blobs) detail.resource_bytes += blob.bytes.size();
     if (!writer->append_detail(detail, error)) {
         runtime_recorder().mark_failed(error);
+        history.remember(state, submit_no);
         return;
     }
     std::fprintf(stderr, "[timeline] captured submit %llu: draws=%u/%u dispatches=%u/%u "
@@ -606,6 +755,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                  detail.semantic_dispatch_count, detail.shader_version_count,
                  detail.resource_version_count, static_cast<unsigned long long>(detail.resource_bytes),
                  request.path.c_str());
+    history.remember(state, submit_no);
 }
 
 void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -57,12 +57,32 @@ struct GpuTimelineDetail {
     uint64_t resource_bytes = 0;
 };
 
+struct GpuTimelineProducer {
+    uint64_t sequence = 0;
+    uint64_t elapsed_ns = 0;
+    uint64_t consumer_submit_no = 0;
+    uint32_t consumer_operation = 0;
+    uint32_t future_writer_operation = UINT32_MAX;
+    uint64_t resource_addr = 0;
+    uint64_t resource_size = 0;
+    uint32_t resource_width = 0;
+    uint32_t resource_height = 0;
+    bool resolved = false;
+    uint64_t producer_submit_no = 0;
+    uint64_t producer_draw_index = 0;
+    uint64_t producer_command_order = 0;
+    uint64_t producer_target_addr = 0;
+    uint32_t producer_width = 0;
+    uint32_t producer_height = 0;
+};
+
 struct GpuTimelineFile {
     uint32_t version = 0;
     GpuTimelineMetadata metadata;
     std::vector<GpuTimelineSubmit> submits;
     std::vector<GpuTimelinePresent> presents;
     std::vector<GpuTimelineDetail> details;
+    std::vector<GpuTimelineProducer> producers;
     bool truncated_tail = false;
 };
 
@@ -77,6 +97,7 @@ public:
     bool append_submit(const GpuTimelineSubmit& submit, std::string& error);
     bool append_present(const GpuTimelinePresent& present, std::string& error);
     bool append_detail(const GpuTimelineDetail& detail, std::string& error);
+    bool append_producer(const GpuTimelineProducer& producer, std::string& error);
     bool flush(std::string& error);
     void close();
 

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -50,6 +50,15 @@ int main() {
     detail.operation_count = 4; detail.missing_operation_count = 1;
     detail.shader_version_count = 5; detail.resource_version_count = 3; detail.resource_bytes = 4096;
     CHECK(writer.append_detail(detail, error), "writer appends a detailed-capture link");
+    GpuTimelineProducer producer;
+    producer.consumer_submit_no = 10; producer.consumer_operation = 19;
+    producer.future_writer_operation = 28; producer.resource_addr = 0x700000;
+    producer.resource_size = 642ull * 362 * 4; producer.resource_width = 642;
+    producer.resource_height = 362; producer.resolved = true;
+    producer.producer_submit_no = 9; producer.producer_draw_index = 13;
+    producer.producer_command_order = 380; producer.producer_target_addr = 0x700000;
+    producer.producer_width = 642; producer.producer_height = 362;
+    CHECK(writer.append_producer(producer, error), "writer appends a prior-producer identity");
     GpuTimelineSubmit second = first;
     second.submit_no = 11; second.draw_count = 4; second.dispatch_count = 0;
     CHECK(writer.append_submit(second, error), "writer appends a second submit record");
@@ -62,10 +71,12 @@ int main() {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.version == 2 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
-          timeline.details.size() == 1, "version and record counts round-trip");
+    CHECK(timeline.version == 3 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+          timeline.details.size() == 1 && timeline.producers.size() == 1,
+          "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
-          timeline.details[0].sequence == 3 && timeline.submits[1].sequence == 4,
+          timeline.details[0].sequence == 3 && timeline.producers[0].sequence == 4 &&
+          timeline.submits[1].sequence == 5,
           "global record ordering round-trips");
     CHECK(timeline.submits[0].color0_base == 0x12340000 &&
           timeline.submits[0].color0_width == 642 && timeline.submits[0].color0_height == 362,
@@ -75,6 +86,11 @@ int main() {
     CHECK(timeline.details[0].submit_no == 10 && timeline.details[0].missing_operation_count == 1 &&
           timeline.details[0].shader_version_count == 5 && timeline.details[0].resource_bytes == 4096,
           "detailed-capture identity and version statistics round-trip");
+    CHECK(timeline.producers[0].resolved && timeline.producers[0].consumer_operation == 19 &&
+          timeline.producers[0].producer_submit_no == 9 &&
+          timeline.producers[0].producer_command_order == 380 &&
+          timeline.producers[0].resource_width == 642,
+          "prior-producer resource and writer identities round-trip");
 
     std::ifstream input(good, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
@@ -84,7 +100,7 @@ int main() {
     GpuTimelineFile partial;
     CHECK(read_gpu_timeline(truncated, partial, error), "reader recovers complete records from a truncated tail");
     CHECK(partial.truncated_tail && partial.submits.size() == 1 && partial.presents.size() == 1 &&
-          partial.details.size() == 1,
+          partial.details.size() == 1 && partial.producers.size() == 1,
           "truncated final submit is ignored explicitly");
 
     std::vector<uint8_t> corrupt_bytes = bytes;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -17,6 +17,7 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`gpu_replay/`** — replay a local `PROSPER_GPU_CAPTURE` realized-submit capsule through the same
   Vulkan backend without booting the guest. Capsules include game shaders/resources, use `.prgcap`,
   are gitignored, and must never be committed. The tool exits non-zero on output-hash mismatch.
+  See `gpu_replay/README.md` for inspection, validation, dependency graphs, oracle semantics, and extraction.
 - **`gpu_timeline/`** — inspect a native-speed `.prgtl` submit/present index recorded with
   `PROSPER_GPU_TIMELINE=<path>`. It does not invoke Vulkan; use it to locate progression and producer
   windows before making an expensive realized `.prgcap`. Timeline files are gitignored and local-only.
@@ -75,6 +76,10 @@ warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 version-5 capsules deduplicate content-addressed shader/resource versions and retain mixed draw/dispatch
 order plus explicit unrealized operations. Selection is intentionally bounded to one submit; automatic
 cross-submit producer closure remains #595.
+Timeline version 3 retains lightweight graphics-target summaries for the previous 64 submits when a
+detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises that bounded window to at most
+4096. Producer records resolve temporal image leaves to the latest overlapping prior submit/draw/PM4
+order, or state `unresolved`; they intentionally do not retain delayed pointers to mutable guest bytes.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -1,0 +1,62 @@
+# GPU replay
+
+`gpu_replay` inspects, validates, graphs, and renders a local `.prgcap` without booting the guest.
+Capsules contain title-derived shaders, resource bytes, addresses, and optional rendered RTT pixels.
+They are gitignored local artifacts and must never be committed or shared as project fixtures.
+
+Build from `prosper/`, using the worktree-local Linux build:
+
+```bash
+cmake --build build-linux -j8 --target gpu_replay
+```
+
+Create a capsule with the native-speed workflow in
+[`../gpu_timeline/README.md`](../gpu_timeline/README.md). Then use:
+
+```bash
+./build-linux/gpu_replay --inspect-only /tmp/submit.prgcap
+./build-linux/gpu_replay --validate /tmp/submit.prgcap
+./build-linux/gpu_replay --graph /tmp/submit.prgcap
+./build-linux/gpu_replay --graph-json /tmp/graph.json /tmp/submit.prgcap
+./build-linux/gpu_replay /tmp/submit.prgcap /tmp/replay.bmp
+```
+
+## Reading graph output
+
+- `edge producer=P consumer=C` means operation `C` reads a range last written by earlier operation `P`.
+- `external` means no earlier writer exists inside this capsule. Static assets are normally external.
+- `consumers=N first=C` deduplicates one external address/range used by multiple operations.
+- `future-writer=N` means the selected submit reads the range before rewriting it. This is a temporal
+  version and the strongest signal that an earlier submit must join the replay closure.
+- `future-writer=-1` means this capsule never writes the range. It may be static/CPU data or have a producer
+  further back in GPU history. Cross-submit resolution is tracked by #595.
+- `missing operation` is semantic work whose shader/resource contract could not be realized. A graph or replay
+  containing one is explicitly partial; do not treat its rendered image as a faithful oracle.
+
+The JSON contains `nodes`, `edges`, and deduplicated `external_leaves` with the same operation indices,
+logical addresses, byte ranges, dimensions, bindings, stages, and future-writer identities.
+
+## Pixel oracles
+
+Renderer-invocation captures record an expected byte count/hash and replay exits nonzero on mismatch.
+Timeline-selected captures occur before Vulkan and report `oracle=no`; they render normally but do not invent an
+expected hash. `--allow-mismatch` is for an intentional differential such as `--draw N:M`.
+
+## Isolation and extraction
+
+```bash
+./build-linux/gpu_replay --draw 12:18 /tmp/submit.prgcap /tmp/pass.bmp
+./build-linux/gpu_replay --dump-resource 18:ps:34 /tmp/texture.bin /tmp/submit.prgcap
+./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
+```
+
+`--draw` uses realized draw indices, while graphs use mixed semantic operation indices. They are not
+interchangeable when dispatches or unrealized operations are present. Replay restores serialized render-target
+seeds before operation zero and uses owned resource memory; it must not dereference original guest mappings.
+
+## Current Dead Cells reference
+
+The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. A timeline-v3
+run resolved both to submit 18,749: draw 45 / PM4 order 9,436,927 and draw 41 / PM4 order 9,436,871. The
+resource addresses and even semantic operation ordinals are run-local observations, not title constants.
+Recompute them from each new capsule and timeline; never hardcode them into renderer behavior.

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -32,9 +32,12 @@ PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
 ./build-linux/gpu_replay /tmp/dead-cells-submit-18420.prgcap /tmp/replay.bmp
 ```
 
+See [`../gpu_replay/README.md`](../gpu_replay/README.md) for graph interpretation, pixel-oracle
+semantics, draw isolation, resource/shader extraction, and the distinction between draw and operation indices.
+
 The summary reports duration, submit/present/draw/dispatch counts, rates, target extents, and whether
 an incomplete final record was discarded. `--records` prints the globally ordered submit/present
-index. Version-2 detail records link the selected submit to its `.prgcap` and report semantic versus
+index. Version-2+ detail records link the selected submit to its `.prgcap` and report semantic versus
 realized draw/dispatch counts, missing operations, unique shader/resource versions, and resource bytes.
 Run metadata includes the revision, title, and input route when the corresponding capture environment
 variables are set.
@@ -52,8 +55,15 @@ variables are set.
 
 ## Current boundary
 
-Version 2 retains backward support for version-1 semantic indexes and adds exactly one bounded detailed
-submit per run. The linked version-5 `.prgcap` contains content-hashed/deduplicated shaders and resource
+Version 3 remains backward-compatible with version-1 and version-2 indexes. When detailed capture is
+enabled, it retains lightweight target-writer summaries for the previous 64 submits and records the
+latest same-run writer identity for every temporal image leaf in the selected capsule. Set
+`PROSPER_GPU_TIMELINE_HISTORY=N` to change that bounded window (maximum 4096). A producer record includes
+the consumer submit/operation/range, the in-submit future writer, and either the matched prior graphics
+submit/draw/PM4 order/target extent or an explicit unresolved result.
+
+Version 2 added exactly one bounded detailed submit per run. The linked version-5 `.prgcap` contains
+content-hashed/deduplicated shaders and resource
 bytes, graphics and compute items, and the original mixed PM4 operation order. An operation whose shader
 cannot be realized stays in the manifest with `realized=no`; inspection never silently treats a partial
 submit as complete. A timeline-selected capsule has no live-output hash oracle unless the renderer also
@@ -65,3 +75,7 @@ pull earlier producer submits. Automatic present-to-producer dependency closure 
 `gpu_replay --graph` resolves dependencies inside the selected submit and reports the remaining external
 versions; a `future-writer` on an external leaf is the characteristic temporal read-before-write case that
 needs the earlier version of the same logical surface.
+
+Producer identity records do not contain producer-time resource bytes. Retaining an old `GpuState` and
+materializing it after the selected submit would read mutable guest memory too late and create false
+evidence; bounded producer-time snapshotting remains the next #595 step.

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -35,8 +35,10 @@ int main(int argc, char** argv) {
     std::printf("timeline version=%u revision=%s title=%s route=%s\n",
                 timeline.version, timeline.metadata.revision.c_str(), timeline.metadata.title_id.c_str(),
                 timeline.metadata.input_route.c_str());
-    std::printf("duration=%.3fs submits=%zu presents=%zu details=%zu draws=%llu dispatches=%llu truncated_tail=%s\n",
+    std::printf("duration=%.3fs submits=%zu presents=%zu details=%zu producers=%zu "
+                "draws=%llu dispatches=%llu truncated_tail=%s\n",
                 seconds, timeline.submits.size(), timeline.presents.size(), timeline.details.size(),
+                timeline.producers.size(),
                 static_cast<unsigned long long>(draws), static_cast<unsigned long long>(dispatches),
                 timeline.truncated_tail ? "yes" : "no");
     if (seconds > 0)
@@ -54,14 +56,29 @@ int main(int argc, char** argv) {
                     detail.missing_operation_count, detail.shader_version_count,
                     detail.resource_version_count, static_cast<unsigned long long>(detail.resource_bytes),
                     detail.capture_path.c_str());
+    for (const auto& producer : timeline.producers)
+        std::printf("producer consumer=%llu/op%u resource=%016llx/%ux%u -> %s"
+                    " submit=%llu draw=%llu order=%llu target=%016llx/%ux%u\n",
+                    static_cast<unsigned long long>(producer.consumer_submit_no),
+                    producer.consumer_operation,
+                    static_cast<unsigned long long>(producer.resource_addr),
+                    producer.resource_width, producer.resource_height,
+                    producer.resolved ? "resolved" : "unresolved",
+                    static_cast<unsigned long long>(producer.producer_submit_no),
+                    static_cast<unsigned long long>(producer.producer_draw_index),
+                    static_cast<unsigned long long>(producer.producer_command_order),
+                    static_cast<unsigned long long>(producer.producer_target_addr),
+                    producer.producer_width, producer.producer_height);
 
     if (argc == 3) {
-        size_t si = 0, pi = 0, di = 0;
-        while (si < timeline.submits.size() || pi < timeline.presents.size() || di < timeline.details.size()) {
+        size_t si = 0, pi = 0, di = 0, xi = 0;
+        while (si < timeline.submits.size() || pi < timeline.presents.size() ||
+               di < timeline.details.size() || xi < timeline.producers.size()) {
             const uint64_t ss = si < timeline.submits.size() ? timeline.submits[si].sequence : UINT64_MAX;
             const uint64_t ps = pi < timeline.presents.size() ? timeline.presents[pi].sequence : UINT64_MAX;
             const uint64_t ds = di < timeline.details.size() ? timeline.details[di].sequence : UINT64_MAX;
-            if (ss <= ps && ss <= ds) {
+            const uint64_t xs = xi < timeline.producers.size() ? timeline.producers[xi].sequence : UINT64_MAX;
+            if (ss <= ps && ss <= ds && ss <= xs) {
                 const auto& s = timeline.submits[si++];
                 std::printf("%llu %.6f submit=%llu draws=%u dispatches=%u order=%llu..%llu "
                             "target=%016llx/%ux%u\n",
@@ -71,14 +88,14 @@ int main(int argc, char** argv) {
                             static_cast<unsigned long long>(s.last_command_order),
                             static_cast<unsigned long long>(s.color0_base),
                             s.color0_width, s.color0_height);
-            } else if (ps <= ds) {
+            } else if (ps <= ds && ps <= xs) {
                 const auto& p = timeline.presents[pi++];
                 std::printf("%llu %.6f present=%llu latest-submit=%llu buffer=%d flip-arg=%lld extent=%ux%u\n",
                             static_cast<unsigned long long>(p.sequence), p.elapsed_ns / 1e9,
                             static_cast<unsigned long long>(p.present_count),
                             static_cast<unsigned long long>(p.latest_submit_no), p.buffer_index,
                             static_cast<long long>(p.flip_arg), p.width, p.height);
-            } else {
+            } else if (ds <= xs) {
                 const auto& d = timeline.details[di++];
                 std::printf("%llu %.6f detail-submit=%llu realized=%u/%u+%u/%u operations=%u missing=%u "
                             "versions=%u/%u bytes=%llu capture=%s\n",
@@ -88,6 +105,17 @@ int main(int argc, char** argv) {
                             d.operation_count, d.missing_operation_count, d.shader_version_count,
                             d.resource_version_count, static_cast<unsigned long long>(d.resource_bytes),
                             d.capture_path.c_str());
+            } else {
+                const auto& x = timeline.producers[xi++];
+                std::printf("%llu %.6f producer consumer=%llu/op%u resource=%016llx/%ux%u "
+                            "future=%u resolved=%s submit=%llu draw=%llu order=%llu\n",
+                            static_cast<unsigned long long>(x.sequence), x.elapsed_ns / 1e9,
+                            static_cast<unsigned long long>(x.consumer_submit_no), x.consumer_operation,
+                            static_cast<unsigned long long>(x.resource_addr), x.resource_width,
+                            x.resource_height, x.future_writer_operation, x.resolved ? "yes" : "no",
+                            static_cast<unsigned long long>(x.producer_submit_no),
+                            static_cast<unsigned long long>(x.producer_draw_index),
+                            static_cast<unsigned long long>(x.producer_command_order));
             }
         }
     }


### PR DESCRIPTION
## Summary
- add timeline v3 producer records for temporal image dependencies
- retain a bounded same-run graphics-target identity history during exact-submit capture
- document the complete timeline/replay workflow and current Dead Cells frontier

## Dead Cells evidence
A scripted gameplay run selected submit 18750 and resolved both external 642x362 temporal leaves to submit 18749:
- draw 45, PM4 order 9436927
- draw 41, PM4 order 9436871

Addresses and semantic operation ordinals are intentionally treated as run-local. This PR records identities only; producer-time byte retention follows separately so mutable guest memory is never captured late.

## Verification
- `ctest --test-dir prosper/build-linux --output-on-failure` (90/90)
- live `PPSA15552` scripted route, 19,377 indexed submits, two resolved producer records

Closes no issue; advances #595.