### PR TITLE
gpu: replay an exact predecessor capsule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,11 @@ Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact
 immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-5 `.prgcap` (#594).
 `gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
 full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 3 resolves those leaves against bounded
-same-run target history. The Dead Cells submit-18750 run found both 642x362 producers in submit 18749, at draws
-45 and 41 (PM4 orders 9436927 and 9436871). Addresses are run-local. Snapshot those producer-time bytes and
-recurse rather than adding a dimension override (#595/#586). The stale exact Dead Cells snapshot baseline is
+same-run target history. A same-run producer-time capsule for Dead Cells submit 18749 can now be prepended to
+submit 18750. It changes the expected overbright regions to black, proving the consumer uses those outputs, but
+the producer graph reads the same two 642x362 temporal versions before rewriting them. Implement an ordered
+recursive predecessor window rather than adding a dimension override (#595/#586). Addresses and operation
+ordinals are run-local. The stale exact Dead Cells snapshot baseline is
 tracked separately in #596 and must not be silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -44,9 +44,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** retain and replay producer-time state/bytes from Dead Cells submit 18749 for the
-  two temporal 642×362 versions consumed by submit 18750 (#595/#586). Exact-submit capture, selected-submit
-  graphing, and same-run producer identity are complete; recursive capsule closure is not. The stale exact Dead Cells
+- 🚧 **Active frontiers:** extend the proven one-level Dead Cells producer/consumer replay into an ordered
+  recursive predecessor window for the two temporal 642×362 versions (#595/#586). Exact-submit capture,
+  graphing, same-run producer identity, and producer-time `N-1` replay are complete; recursive closure is not.
+  The stale exact Dead Cells
   snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -209,9 +209,11 @@ RuntimeRecorder& runtime_recorder() {
 
 struct RuntimeDetailRequest {
     std::string path;
+    std::string predecessor_path;
     uint64_t submit_no = 0;
     bool valid = false;
     std::atomic<bool> claimed{false};
+    std::atomic<bool> predecessor_claimed{false};
 
     RuntimeDetailRequest() {
         const char* path_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
@@ -230,6 +232,8 @@ struct RuntimeDetailRequest {
             return;
         }
         path = path_env;
+        if (const char* predecessor = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR"))
+            predecessor_path = predecessor;
         submit_no = parsed;
         valid = true;
     }
@@ -294,6 +298,52 @@ struct RuntimeProducerHistory {
 RuntimeProducerHistory& runtime_producer_history() {
     static RuntimeProducerHistory history;
     return history;
+}
+
+GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
+    GpuCaptureMetadata metadata;
+    metadata.width = present_width();
+    metadata.height = present_height();
+    metadata.submit_index = submit_no;
+#ifdef PROSPER_GIT_REVISION
+    metadata.revision = PROSPER_GIT_REVISION;
+#else
+    metadata.revision = "unknown";
+#endif
+    if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) metadata.revision = revision;
+    metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
+    metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
+    metadata.savedata_dir = env_or_empty("PROSPER_SAVEDATA_DIR");
+    return metadata;
+}
+
+GpuTimelineDetail capture_detail(const GpuTimelineSubmit& submit, const std::string& path,
+                                 const GpuCaptureFile& capture) {
+    GpuTimelineDetail detail;
+    detail.submit_no = submit.submit_no;
+    detail.capture_path = path;
+    detail.semantic_draw_count = submit.draw_count;
+    detail.semantic_dispatch_count = submit.dispatch_count;
+    detail.realized_draw_count = static_cast<uint32_t>(capture.draws.size());
+    detail.realized_dispatch_count = static_cast<uint32_t>(capture.computes.size());
+    detail.operation_count = static_cast<uint32_t>(capture.operations.size());
+    detail.missing_operation_count = static_cast<uint32_t>(std::count_if(
+        capture.operations.begin(), capture.operations.end(),
+        [](const auto& operation) { return !operation.realized; }));
+    detail.shader_version_count = static_cast<uint32_t>(capture.shader_versions.size());
+    detail.resource_version_count = static_cast<uint32_t>(capture.blobs.size());
+    for (const auto& blob : capture.blobs) detail.resource_bytes += blob.bytes.size();
+    return detail;
+}
+
+void log_capture_detail(const GpuTimelineDetail& detail) {
+    std::fprintf(stderr, "[timeline] captured submit %llu: draws=%u/%u dispatches=%u/%u "
+                         "versions=%u shaders/%u resources (%llu bytes) -> %s\n",
+                 static_cast<unsigned long long>(detail.submit_no), detail.realized_draw_count,
+                 detail.semantic_draw_count, detail.realized_dispatch_count,
+                 detail.semantic_dispatch_count, detail.shader_version_count,
+                 detail.resource_version_count, static_cast<unsigned long long>(detail.resource_bytes),
+                 detail.capture_path.c_str());
 }
 
 } // namespace
@@ -654,23 +704,30 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
     RuntimeDetailRequest& request = runtime_detail_request();
     RuntimeProducerHistory& history = runtime_producer_history();
+    if (request.valid && !request.predecessor_path.empty() && request.submit_no > 1 &&
+        submit_no == request.submit_no - 1 && !request.predecessor_claimed.exchange(true)) {
+        GpuCaptureFile predecessor;
+        const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
+        if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
+                                     metadata, predecessor, error) ||
+            !write_gpu_capture(request.predecessor_path, predecessor, error)) {
+            std::fprintf(stderr, "[timeline] predecessor submit %llu capture failed: %s\n",
+                         static_cast<unsigned long long>(submit_no), error.c_str());
+        } else {
+            const GpuTimelineDetail detail = capture_detail(submit, request.predecessor_path, predecessor);
+            if (!writer->append_detail(detail, error)) {
+                runtime_recorder().mark_failed(error);
+                history.remember(state, submit_no);
+                return;
+            }
+            log_capture_detail(detail);
+        }
+    }
     if (!request.valid || request.submit_no != submit_no || request.claimed.exchange(true)) {
         history.remember(state, submit_no);
         return;
     }
-    GpuCaptureMetadata metadata;
-    metadata.width = present_width();
-    metadata.height = present_height();
-    metadata.submit_index = submit_no;
-#ifdef PROSPER_GIT_REVISION
-    metadata.revision = PROSPER_GIT_REVISION;
-#else
-    metadata.revision = "unknown";
-#endif
-    if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) metadata.revision = revision;
-    metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
-    metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
-    metadata.savedata_dir = env_or_empty("PROSPER_SAVEDATA_DIR");
+    const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
 
     GpuCaptureFile capture;
     if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
@@ -729,32 +786,13 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                      static_cast<unsigned long long>(submit_no), error.c_str());
         error.clear();
     }
-    GpuTimelineDetail detail;
-    detail.submit_no = submit_no;
-    detail.capture_path = request.path;
-    detail.semantic_draw_count = submit.draw_count;
-    detail.semantic_dispatch_count = submit.dispatch_count;
-    detail.realized_draw_count = static_cast<uint32_t>(capture.draws.size());
-    detail.realized_dispatch_count = static_cast<uint32_t>(capture.computes.size());
-    detail.operation_count = static_cast<uint32_t>(capture.operations.size());
-    detail.missing_operation_count = static_cast<uint32_t>(std::count_if(
-        capture.operations.begin(), capture.operations.end(),
-        [](const auto& operation) { return !operation.realized; }));
-    detail.shader_version_count = static_cast<uint32_t>(capture.shader_versions.size());
-    detail.resource_version_count = static_cast<uint32_t>(capture.blobs.size());
-    for (const auto& blob : capture.blobs) detail.resource_bytes += blob.bytes.size();
+    const GpuTimelineDetail detail = capture_detail(submit, request.path, capture);
     if (!writer->append_detail(detail, error)) {
         runtime_recorder().mark_failed(error);
         history.remember(state, submit_no);
         return;
     }
-    std::fprintf(stderr, "[timeline] captured submit %llu: draws=%u/%u dispatches=%u/%u "
-                         "versions=%u shaders/%u resources (%llu bytes) -> %s\n",
-                 static_cast<unsigned long long>(submit_no), detail.realized_draw_count,
-                 detail.semantic_draw_count, detail.realized_dispatch_count,
-                 detail.semantic_dispatch_count, detail.shader_version_count,
-                 detail.resource_version_count, static_cast<unsigned long long>(detail.resource_bytes),
-                 request.path.c_str());
+    log_capture_detail(detail);
     history.remember(state, submit_no);
 }
 

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -101,6 +101,16 @@ int main() {
               "later pass samples pixels cached from the 32x2 producer target");
     }
 
+    render_submit_items({producer}, W, H);
+    std::vector<uint8_t> cross_submit = render_submit_items({consumer}, W, H);
+    CHECK(cross_submit.size() == static_cast<size_t>(16) * 16 * 4,
+          "renderer retains a producer target across separate replay submits");
+    if (cross_submit.size() == static_cast<size_t>(16) * 16 * 4) {
+        const uint8_t* center = &cross_submit[(8u * 16u + 8u) * 4];
+        CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
+              "later replay submit samples the retained producer target");
+    }
+
     // A captured consumer may depend on a producer from an earlier submit. Restore its serialized
     // host RTT surface before replaying draw zero; guest memory has no copy of these rendered pixels.
     GpuCaptureRttSeed temporal_seed;

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -113,17 +113,24 @@ int main() {
 
     const auto runtime = base.string() + "-runtime.prgtl";
     const auto runtime_capture = base.string() + "-submit-42.prgcap";
+    const auto predecessor_capture = base.string() + "-submit-41.prgcap";
 #ifdef _WIN32
     _putenv_s("PROSPER_GPU_TIMELINE", runtime.c_str());
     _putenv_s("PROSPER_CAPTURE_TITLE", "runtime-title");
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE", runtime_capture.c_str());
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "42");
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", predecessor_capture.c_str());
 #else
     setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
     setenv("PROSPER_CAPTURE_TITLE", "runtime-title", 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE", runtime_capture.c_str(), 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "42", 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", predecessor_capture.c_str(), 1);
 #endif
+    GpuState predecessor_state;
+    predecessor_state.command_order = 120;
+    begin_gpu_timeline_submit(41);
+    record_gpu_timeline_submit(predecessor_state, 41);
     begin_gpu_timeline_submit(42);
     record_gpu_timeline_present(9, 1, 77, 1920, 1080); // a PM4 flip can precede submit completion
     GpuState runtime_state;
@@ -132,13 +139,15 @@ int main() {
     close_gpu_timeline();
     GpuTimelineFile runtime_timeline;
     CHECK(read_gpu_timeline(runtime, runtime_timeline, error), "runtime hooks produce an inspectable timeline");
-    CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 1 &&
+    CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 2 &&
           runtime_timeline.presents[0].latest_submit_no == 42,
           "a flip during folding is associated with its active submit");
-    CHECK(runtime_timeline.details.size() == 1 && runtime_timeline.details[0].submit_no == 42 &&
-          runtime_timeline.details[0].capture_path == runtime_capture &&
-          std::filesystem::exists(runtime_capture),
-          "exact submit selection writes and links one bounded detail capsule");
+    CHECK(runtime_timeline.details.size() == 2 && runtime_timeline.details[0].submit_no == 41 &&
+          runtime_timeline.details[0].capture_path == predecessor_capture &&
+          runtime_timeline.details[1].submit_no == 42 &&
+          runtime_timeline.details[1].capture_path == runtime_capture &&
+          std::filesystem::exists(predecessor_capture) && std::filesystem::exists(runtime_capture),
+          "exact submit selection writes and links producer-time predecessor and consumer capsules");
 
     const auto compat_v2 = base.string() + "-compat-v2.prgtl";
     GpuTimelineWriter compat_writer;
@@ -161,6 +170,7 @@ int main() {
     std::filesystem::remove(corrupt, ec);
     std::filesystem::remove(runtime, ec);
     std::filesystem::remove(runtime_capture, ec);
+    std::filesystem::remove(predecessor_capture, ec);
     std::filesystem::remove(compat_v2, ec);
     std::filesystem::remove(version1, ec);
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -74,12 +74,15 @@ independent of `PROSPER_RENDER_EVERY`. To materialize one exact indexed submit w
 warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
 version-5 capsules deduplicate content-addressed shader/resource versions and retain mixed draw/dispatch
-order plus explicit unrealized operations. Selection is intentionally bounded to one submit; automatic
-cross-submit producer closure remains #595.
+order plus explicit unrealized operations. Selection is intentionally bounded to the consumer and an optional
+immediate predecessor; automatic recursive cross-submit producer closure remains #595.
 Timeline version 3 retains lightweight graphics-target summaries for the previous 64 submits when a
 detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises that bounded window to at most
 4096. Producer records resolve temporal image leaves to the latest overlapping prior submit/draw/PM4
 order, or state `unresolved`; they intentionally do not retain delayed pointers to mutable guest bytes.
+Set `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>.prgcap` to snapshot exact submit `N-1` at producer
+time alongside selected submit `N`. Replay the pair with `gpu_replay --prepend producer consumer output`.
+This is a one-level probe; graph the producer and recurse when it also reads a temporal version.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -19,6 +19,7 @@ Create a capsule with the native-speed workflow in
 ./build-linux/gpu_replay --graph /tmp/submit.prgcap
 ./build-linux/gpu_replay --graph-json /tmp/graph.json /tmp/submit.prgcap
 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/replay.bmp
+./build-linux/gpu_replay --prepend /tmp/producer.prgcap /tmp/consumer.prgcap /tmp/closure.bmp
 ```
 
 ## Reading graph output
@@ -54,9 +55,20 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 interchangeable when dispatches or unrealized operations are present. Replay restores serialized render-target
 seeds before operation zero and uses owned resource memory; it must not dereference original guest mappings.
 
+`--prepend` materializes and executes one earlier capsule in the same renderer instance before the consumer.
+Its rendered targets take precedence over consumer RTT seeds at matching addresses; unrelated seeds are still
+restored. The tool rejects a predecessor whose submit number is not earlier. A changed image proves that the
+consumer sampled the retained producer output, but it does not prove faithful closure: graph the predecessor
+and continue if it also has temporal leaves.
+
 ## Current Dead Cells reference
 
 The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. A timeline-v3
 run resolved both to submit 18,749: draw 45 / PM4 order 9,436,927 and draw 41 / PM4 order 9,436,871. The
 resource addresses and even semantic operation ordinals are run-local observations, not title constants.
 Recompute them from each new capsule and timeline; never hardcode them into renderer behavior.
+
+A same-run producer/consumer capture showed that prepending submit 18,749 changes the overbright consumer in
+the expected regions, but those regions become black. Submit 18,749 has the same two temporal read-before-write
+leaves, so this is positive closure evidence rather than a final image fix. Recursive predecessor capture is
+the next #595 step.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace {
@@ -24,9 +25,30 @@ bool set_environment(const std::string& name, const std::string& value) {
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] "
+                         "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-shader DRAW:vs|fs PATH] "
                          "<capture.prgcap> [output.bmp]\n", argv0);
+}
+
+std::vector<uint8_t> execute_frame(const prosper::gpu::GpuReplayFrame& replay,
+                                   bool draws_only = false) {
+    std::vector<prosper::gpu::SubmitOperation> operations;
+    for (const auto& operation : replay.operations)
+        if (operation.realized)
+            operations.push_back({operation.kind, static_cast<size_t>(operation.source_index),
+                                  operation.command_order});
+    if (operations.empty() || draws_only)
+        return prosper::gpu::render_submit_items(
+            replay.items, replay.metadata.width, replay.metadata.height);
+    auto result = prosper::gpu::execute_ordered_items(
+        operations, replay.items, replay.computes,
+        [](const auto& items, uint32_t width, uint32_t height) {
+            return prosper::gpu::render_submit_items(items, width, height);
+        },
+        [](const auto& items) { return prosper::gpu::execute_compute_items(items); },
+        replay.metadata.width, replay.metadata.height);
+    return std::move(result.pixels);
 }
 
 const char* class_name(prosper::gpu::ResourceClass c);
@@ -259,7 +281,7 @@ int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool graph_only = false;
     int draw_first = -1, draw_last = -1;
-    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path;
+    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
@@ -270,6 +292,7 @@ int main(int argc, char** argv) {
             graph_only = true; graph_json_path = argv[++i];
         }
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
+        else if (std::string(argv[i]) == "--prepend" && i + 1 < argc) prepend_path = argv[++i];
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
             std::string range = argv[++i]; size_t colon = range.find(':');
             draw_first = std::atoi(range.c_str());
@@ -298,6 +321,18 @@ int main(int argc, char** argv) {
     prosper::gpu::GpuReplayFrame replay;
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    prosper::gpu::GpuCaptureFile prepend_capture;
+    prosper::gpu::GpuReplayFrame prepend;
+    if (!prepend_path.empty() &&
+        (!prosper::gpu::read_gpu_capture(prepend_path, prepend_capture, error) ||
+         !prosper::gpu::materialize_gpu_replay(prepend_capture, prepend, error))) {
+        std::fprintf(stderr, "gpu_replay: cannot load predecessor %s: %s\n",
+                     prepend_path.c_str(), error.c_str()); return 2;
+    }
+    if (!prepend_path.empty() && prepend.metadata.submit_index >= replay.metadata.submit_index) {
+        std::fprintf(stderr, "gpu_replay: predecessor submit must be earlier than consumer submit\n");
+        return 2;
     }
     if (graph_only) {
         prosper::gpu::GpuDependencyGraph graph;
@@ -369,29 +404,32 @@ int main(int argc, char** argv) {
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;
-    if (!replay.rtt_seeds.empty()) set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
+    if (!replay.rtt_seeds.empty() || !prepend.rtt_seeds.empty())
+        set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
     prosper::frontend::register_live_renderer(".", false);
-    if (!prosper::gpu::restore_gpu_replay_rtt_seeds(replay.rtt_seeds, error)) {
+    std::unordered_set<uint64_t> predecessor_targets;
+    if (!prepend_path.empty()) {
+        if (!prosper::gpu::restore_gpu_replay_rtt_seeds(prepend.rtt_seeds, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot restore predecessor RTT seeds: %s\n",
+                         error.c_str());
+            return 2;
+        }
+        std::vector<uint8_t> predecessor_pixels = execute_frame(prepend);
+        for (const auto& draw : prepend.items)
+            if (draw.color0_base) predecessor_targets.insert(draw.color0_base);
+        std::fprintf(stderr, "[gpureplay] prepended submit=%llu operations=%zu targets=%zu "
+                             "output_bytes=%zu hash=%016llx\n",
+                     static_cast<unsigned long long>(prepend.metadata.submit_index),
+                     prepend.operations.size(), predecessor_targets.size(), predecessor_pixels.size(),
+                     static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(predecessor_pixels)));
+    }
+    std::vector<prosper::gpu::GpuCaptureRttSeed> consumer_seeds;
+    for (const auto& seed : replay.rtt_seeds)
+        if (!predecessor_targets.count(seed.guest_addr)) consumer_seeds.push_back(seed);
+    if (!prosper::gpu::restore_gpu_replay_rtt_seeds(consumer_seeds, error)) {
         std::fprintf(stderr, "gpu_replay: cannot restore RTT seeds: %s\n", error.c_str()); return 2;
     }
-    std::vector<prosper::gpu::SubmitOperation> operations;
-    for (const auto& operation : replay.operations)
-        if (operation.realized)
-            operations.push_back({operation.kind, static_cast<size_t>(operation.source_index),
-                                  operation.command_order});
-    std::vector<uint8_t> pixels;
-    if (operations.empty() || draw_first >= 0) {
-        pixels = prosper::gpu::render_submit_items(replay.items, m.width, m.height);
-    } else {
-        auto result = prosper::gpu::execute_ordered_items(
-            operations, replay.items, replay.computes,
-            [](const auto& items, uint32_t width, uint32_t height) {
-                return prosper::gpu::render_submit_items(items, width, height);
-            },
-            [](const auto& items) { return prosper::gpu::execute_compute_items(items); },
-            m.width, m.height);
-        pixels = std::move(result.pixels);
-    }
+    std::vector<uint8_t> pixels = execute_frame(replay, draw_first >= 0);
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
     std::fprintf(stderr, "[gpureplay] output_bytes=%zu hash=%016llx expected_bytes=%llu expected_hash=%016llx\n",
                  pixels.size(), static_cast<unsigned long long>(hash),

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -17,12 +17,13 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl --records
 ```
 
-Capture one submit found in that index:
+Capture a selected submit and, optionally, its immediate predecessor from the same run:
 
 ```bash
 PROSPER_GPU_TIMELINE=/tmp/dead-cells-detail.prgtl \
 PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=18420 \
 PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
+PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=/tmp/dead-cells-submit-18419.prgcap \
   ./build-linux/boot_trace /path/to/PPSA15552-app0
 
 ./build-linux/gpu_timeline /tmp/dead-cells-detail.prgtl --records
@@ -30,6 +31,8 @@ PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
 ./build-linux/gpu_replay --graph /tmp/dead-cells-submit-18420.prgcap
 ./build-linux/gpu_replay --graph-json /tmp/dead-cells-graph.json /tmp/dead-cells-submit-18420.prgcap
 ./build-linux/gpu_replay /tmp/dead-cells-submit-18420.prgcap /tmp/replay.bmp
+./build-linux/gpu_replay --prepend /tmp/dead-cells-submit-18419.prgcap \
+  /tmp/dead-cells-submit-18420.prgcap /tmp/replay-with-producer.bmp
 ```
 
 See [`../gpu_replay/README.md`](../gpu_replay/README.md) for graph interpretation, pixel-oracle
@@ -78,4 +81,6 @@ needs the earlier version of the same logical surface.
 
 Producer identity records do not contain producer-time resource bytes. Retaining an old `GpuState` and
 materializing it after the selected submit would read mutable guest memory too late and create false
-evidence; bounded producer-time snapshotting remains the next #595 step.
+evidence. `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>` instead captures exactly submit `N-1` at
+producer time in the same run and links both capsules with ordinary detail records. It is deliberately a
+one-level closure probe; if the predecessor graph has temporal leaves, capture must recurse further.


### PR DESCRIPTION
## Summary
- capture selected submit `N-1` at producer time as an optional same-run predecessor capsule
- add `gpu_replay --prepend` to execute producer and consumer in one persistent renderer
- preserve explicit producer targets over colliding consumer RTT seeds
- document the one-level closure workflow and recursive boundary

## Dead Cells evidence
Fresh same-run capsules for submits 18749 and 18750 resolve both 642x362 temporal leaves to 18749. The consumer-alone hash is `100f9c4b83246165`; prepending 18749 changes it to `62bc6813c12fdf55` in the expected regions. Those regions become black because 18749 itself reads the same temporal surfaces before rewriting them. This proves cross-submit dataflow and establishes recursive predecessor capture as the next step; it does not claim a faithful final image.

## Verification
- `ctest --test-dir prosper/build-linux --output-on-failure` (90/90)
- live scripted `PPSA15552` producer/consumer capture
- full-resolution offline A/B replay

Advances #595; does not close it.