### PR TITLE
gpu: capture deduplicated submit closure bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ renderer is wired in; the game's **real pixel shader recompiles to valid SPIR-V*
 **bindless-dynamic vertex-fetch resolution** for the vertex shader — fully specified in
 `prosper/docs/NEXT_STEP_VERTEX_FETCH.md`. This paragraph is historical only.
 
-## Current frontier (2026-07-11)
+## Current frontier (2026-07-12)
 
 The game now **boots through IL2CPP, renders its intro/title/menu, and reaches gameplay with real GPU
 draws.** The old bindless vertex-fetch frontier is complete: both shader stages recompile and dynamic
@@ -114,11 +114,12 @@ Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact
 immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-5 `.prgcap` (#594).
 `gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
 full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 3 resolves those leaves against bounded
-same-run target history. A same-run producer-time capsule for Dead Cells submit 18749 can now be prepended to
-submit 18750. It changes the expected overbright regions to black, proving the consumer uses those outputs, but
-the producer graph reads the same two 642x362 temporal versions before rewriting them. Implement an ordered
-recursive predecessor window rather than adding a dimension override (#595/#586). Addresses and operation
-ordinals are run-local. The stale exact Dead Cells snapshot baseline is
+same-run target history. Ordered `.prgbundle` windows now capture producer-time submits with content-defined
+cross-submit deduplication and replay them through one persistent renderer (#603). Dead Cells depth 16 resolves
+all 30 internal temporal edges in submits 18735..18750 while storing 2.883 GiB logical data in 166.3 MiB, but
+the earliest submit still has two unseeded 642x362 leaves. Find/capture their initialization version rather than
+increasing depth blindly or adding a dimension fallback (#595/#586). Addresses and operation ordinals are
+run-local. The stale exact Dead Cells snapshot baseline is
 tracked separately in #596 and must not be silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.
@@ -156,7 +157,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 87/87 expected green on Linux
+  cmake --build . -j8 && ctest        # 91/91 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -360,6 +360,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_capture PRIVATE prosper_core)
   add_test(NAME gpu_capture_roundtrip COMMAND test_gpu_capture)
 
+  add_executable(test_gpu_capture_bundle tests/test_gpu_capture_bundle.cpp)
+  target_link_libraries(test_gpu_capture_bundle PRIVATE prosper_core)
+  add_test(NAME gpu_capture_bundle_roundtrip COMMAND test_gpu_capture_bundle)
+
   # Native-speed append-only submit/present timeline: portable framing, checksums, and truncated-tail
   # recovery are pure and must not depend on Vulkan or a game dump.
   add_executable(test_gpu_timeline tests/test_gpu_timeline.cpp)

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -44,9 +44,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** extend the proven one-level Dead Cells producer/consumer replay into an ordered
-  recursive predecessor window for the two temporal 642×362 versions (#595/#586). Exact-submit capture,
-  graphing, same-run producer identity, and producer-time `N-1` replay are complete; recursive closure is not.
+- 🚧 **Active frontiers:** locate and retain the initialization version for Dead Cells' two temporal 642×362
+  surfaces (#595/#586). Ordered depth-16 bundles now resolve every later producer edge with 94.2% cross-submit
+  deduplication (#603), but the earliest included submit remains explicitly depth-bounded with no RTT seed.
   The stale exact Dead Cells
   snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -452,7 +452,7 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                                 reader, out, error, g_rtt_seed_reader);
 }
 
-bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::string& error) {
+bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes, std::string& error) {
     error.clear(); Writer w; w.raw(kMagic, sizeof(kMagic)); w.u32(kVersion); w.u32(kEndian);
     w.u32(c.metadata.width); w.u32(c.metadata.height); w.u64(c.metadata.submit_index);
     w.string(c.metadata.revision); w.string(c.metadata.title_id); w.string(c.metadata.input_route); w.string(c.metadata.savedata_dir);
@@ -528,10 +528,17 @@ bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::st
         w.u64(operation.command_order); w.u8(operation.realized);
     }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
+    bytes = std::move(w.data);
+    return true;
+}
+
+bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::string& error) {
+    std::vector<uint8_t> bytes;
+    if (!serialize_gpu_capture(c, bytes, error)) return false;
     std::filesystem::path target(path), temp = target; temp += ".tmp";
     std::error_code ec; if (target.has_parent_path()) std::filesystem::create_directories(target.parent_path(), ec);
     std::ofstream f(temp, std::ios::binary | std::ios::trunc);
-    if (!f || !f.write(reinterpret_cast<const char*>(w.data.data()), static_cast<std::streamsize>(w.data.size()))) {
+    if (!f || !f.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()))) {
         error = "cannot write capture temporary file"; return false;
     }
     f.close(); std::filesystem::rename(temp, target, ec);
@@ -541,12 +548,17 @@ bool write_gpu_capture(const std::string& path, const GpuCaptureFile& c, std::st
 }
 
 bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& error) {
-    error.clear(); c = {}; std::error_code ec; uint64_t size = std::filesystem::file_size(path, ec);
+    error.clear(); std::error_code ec; uint64_t size = std::filesystem::file_size(path, ec);
     if (ec || size > kMaxFileBytes || size > std::numeric_limits<size_t>::max()) { error = "invalid capture file size"; return false; }
     std::vector<uint8_t> bytes(static_cast<size_t>(size)); std::ifstream f(path, std::ios::binary);
     if (!f || !f.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()))) {
         error = "cannot read capture file"; return false;
     }
+    return deserialize_gpu_capture(bytes, c, error);
+}
+
+bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& c, std::string& error) {
+    error.clear(); c = {};
     Reader r{bytes.data(), bytes.size(), &error}; char magic[8]; uint32_t version, endian;
     if (!r.take(magic, 8) || std::memcmp(magic, kMagic, 8) || !r.u32(version) || version < 1 || version > kVersion ||
         !r.u32(endian) || endian != kEndian) { error = "unsupported capture header"; return false; }

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -118,6 +118,10 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
                              GpuCaptureFile& out, std::string& error);
+bool serialize_gpu_capture(const GpuCaptureFile& capture, std::vector<uint8_t>& bytes,
+                           std::string& error);
+bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& capture,
+                             std::string& error);
 bool write_gpu_capture(const std::string& path, const GpuCaptureFile& capture, std::string& error);
 bool read_gpu_capture(const std::string& path, GpuCaptureFile& capture, std::string& error);
 

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -1,0 +1,248 @@
+#include "gpu_capture_bundle.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <unordered_map>
+
+namespace prosper::gpu {
+namespace {
+
+constexpr uint8_t kMagic[8] = {'P', 'R', 'G', 'B', 'N', 'D', 'L', '\0'};
+constexpr uint32_t kVersion = 1;
+constexpr uint32_t kEndian = 0x01020304u;
+constexpr uint32_t kMaxChunks = 1u << 20;
+constexpr uint32_t kMaxSubmits = 64;
+constexpr uint64_t kMaxFileBytes = 4ull << 30;
+
+struct Writer {
+    std::vector<uint8_t> data;
+    void raw(const void* p, size_t n) {
+        const auto* b = static_cast<const uint8_t*>(p); data.insert(data.end(), b, b + n);
+    }
+    void u32(uint32_t v) {
+        uint8_t b[4]; for (int i = 0; i < 4; ++i) b[i] = static_cast<uint8_t>(v >> (i * 8)); raw(b, 4);
+    }
+    void u64(uint64_t v) {
+        uint8_t b[8]; for (int i = 0; i < 8; ++i) b[i] = static_cast<uint8_t>(v >> (i * 8)); raw(b, 8);
+    }
+    void bytes(const std::vector<uint8_t>& v) { u32(static_cast<uint32_t>(v.size())); raw(v.data(), v.size()); }
+};
+
+struct Reader {
+    const uint8_t* p = nullptr;
+    size_t left = 0;
+    bool take(void* dst, size_t n) {
+        if (n > left) return false; std::memcpy(dst, p, n); p += n; left -= n; return true;
+    }
+    bool u32(uint32_t& v) {
+        uint8_t b[4]; if (!take(b, 4)) return false; v = 0;
+        for (int i = 0; i < 4; ++i) v |= static_cast<uint32_t>(b[i]) << (i * 8); return true;
+    }
+    bool u64(uint64_t& v) {
+        uint8_t b[8]; if (!take(b, 8)) return false; v = 0;
+        for (int i = 0; i < 8; ++i) v |= static_cast<uint64_t>(b[i]) << (i * 8); return true;
+    }
+    bool bytes(std::vector<uint8_t>& v) {
+        uint32_t n = 0; if (!u32(n) || n > left) return false; v.resize(n); return take(v.data(), n);
+    }
+};
+
+bool install_file(const std::string& path, const std::vector<uint8_t>& bytes, std::string& error) {
+    std::filesystem::path target(path), temp = target; temp += ".tmp";
+    std::error_code ec;
+    if (target.has_parent_path()) std::filesystem::create_directories(target.parent_path(), ec);
+    std::ofstream file(temp, std::ios::binary | std::ios::trunc);
+    if (!file || !file.write(reinterpret_cast<const char*>(bytes.data()),
+                             static_cast<std::streamsize>(bytes.size()))) {
+        error = "cannot write bundle temporary file"; return false;
+    }
+    file.close(); std::filesystem::rename(temp, target, ec);
+    if (ec) { std::filesystem::remove(target, ec); ec.clear(); std::filesystem::rename(temp, target, ec); }
+    if (ec) { error = "cannot install bundle: " + ec.message(); return false; }
+    return true;
+}
+
+uint64_t gear_value(uint8_t byte) {
+    uint64_t value = static_cast<uint64_t>(byte) + 0x9e3779b97f4a7c15ull;
+    value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ull;
+    value = (value ^ (value >> 27)) * 0x94d049bb133111ebull;
+    return value ^ (value >> 31);
+}
+
+size_t content_chunk_size(const std::vector<uint8_t>& bytes, size_t offset, size_t maximum) {
+    constexpr size_t minimum = 16 * 1024;
+    constexpr uint64_t average_mask = (64 * 1024) - 1;
+    const size_t available = std::min(maximum, bytes.size() - offset);
+    if (available <= minimum) return available;
+    uint64_t rolling = 0;
+    for (size_t size = 1; size <= available; ++size) {
+        rolling = (rolling << 1) + gear_value(bytes[offset + size - 1]);
+        if (size >= minimum && (!(rolling & average_mask) || size == available)) return size;
+    }
+    return available;
+}
+
+} // namespace
+
+uint64_t gpu_capture_bundle_unique_bytes(const GpuCaptureBundle& bundle) {
+    uint64_t total = 0;
+    for (const auto& chunk : bundle.chunks) total += chunk.size();
+    return total;
+}
+
+bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& capture,
+                               std::string& error) {
+    error.clear();
+    if (!bundle.chunk_bytes || bundle.chunk_bytes > (16u << 20) || bundle.submits.size() >= kMaxSubmits) {
+        error = "invalid bundle bounds"; return false;
+    }
+    if (!bundle.submits.empty() && capture.metadata.submit_index <= bundle.submits.back().submit_index) {
+        error = "bundle submits must be appended in increasing order"; return false;
+    }
+    std::vector<uint8_t> bytes;
+    if (!serialize_gpu_capture(capture, bytes, error)) return false;
+    GpuCaptureBundleSubmit submit;
+    submit.submit_index = capture.metadata.submit_index;
+    submit.logical_bytes = bytes.size();
+    std::unordered_map<uint64_t, std::vector<uint32_t>> by_hash;
+    by_hash.reserve(bundle.chunks.size());
+    for (uint32_t i = 0; i < bundle.chunks.size(); ++i) by_hash[bundle.chunk_hashes[i]].push_back(i);
+    for (size_t offset = 0; offset < bytes.size();) {
+        const size_t size = content_chunk_size(bytes, offset, bundle.chunk_bytes);
+        std::vector<uint8_t> chunk(bytes.begin() + offset, bytes.begin() + offset + size);
+        const uint64_t hash = gpu_capture_hash(chunk);
+        uint32_t index = UINT32_MAX;
+        auto found = by_hash.find(hash);
+        if (found != by_hash.end())
+            for (uint32_t candidate : found->second)
+                if (bundle.chunks[candidate] == chunk) { index = candidate; break; }
+        if (index == UINT32_MAX) {
+            if (bundle.chunks.size() >= kMaxChunks) { error = "bundle chunk count exceeds limit"; return false; }
+            index = static_cast<uint32_t>(bundle.chunks.size());
+            bundle.chunk_hashes.push_back(hash); bundle.chunks.push_back(std::move(chunk));
+            by_hash[hash].push_back(index);
+        }
+        submit.chunk_indices.push_back(index);
+        offset += size;
+    }
+    bundle.logical_bytes += bytes.size();
+    bundle.submits.push_back(std::move(submit));
+    return true;
+}
+
+bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
+                                           GpuCaptureFile& capture, std::string& error) {
+    error.clear();
+    if (submit_index >= bundle.submits.size()) { error = "bundle submit index is out of range"; return false; }
+    const auto& submit = bundle.submits[submit_index];
+    if (submit.logical_bytes > std::numeric_limits<size_t>::max()) {
+        error = "bundle submit is too large"; return false;
+    }
+    std::vector<uint8_t> bytes; bytes.reserve(static_cast<size_t>(submit.logical_bytes));
+    for (uint32_t index : submit.chunk_indices) {
+        if (index >= bundle.chunks.size()) { error = "bundle references an invalid chunk"; return false; }
+        if (bundle.chunks[index].size() > submit.logical_bytes - bytes.size()) {
+            error = "bundle submit chunk sizes exceed the manifest"; return false;
+        }
+        bytes.insert(bytes.end(), bundle.chunks[index].begin(), bundle.chunks[index].end());
+    }
+    if (bytes.size() != submit.logical_bytes) { error = "bundle submit is truncated"; return false; }
+    if (!deserialize_gpu_capture(bytes, capture, error)) return false;
+    if (capture.metadata.submit_index != submit.submit_index) {
+        error = "bundle submit identity mismatch"; return false;
+    }
+    return true;
+}
+
+bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& bundle,
+                              std::string& error) {
+    error.clear();
+    if (bundle.chunk_hashes.size() != bundle.chunks.size() || bundle.chunks.size() > kMaxChunks ||
+        bundle.submits.empty() || bundle.submits.size() > kMaxSubmits) {
+        error = "invalid bundle structure"; return false;
+    }
+    Writer writer; writer.raw(kMagic, sizeof(kMagic)); writer.u32(kVersion); writer.u32(kEndian);
+    writer.u32(bundle.chunk_bytes); writer.u64(bundle.logical_bytes);
+    writer.u32(static_cast<uint32_t>(bundle.chunks.size()));
+    for (size_t i = 0; i < bundle.chunks.size(); ++i) {
+        const uint64_t hash = gpu_capture_hash(bundle.chunks[i]);
+        if (bundle.chunk_hashes[i] != hash) { error = "bundle chunk hash mismatch"; return false; }
+        writer.u64(hash); writer.bytes(bundle.chunks[i]);
+    }
+    writer.u32(static_cast<uint32_t>(bundle.submits.size()));
+    for (const auto& submit : bundle.submits) {
+        writer.u64(submit.submit_index); writer.u64(submit.logical_bytes);
+        writer.u32(static_cast<uint32_t>(submit.chunk_indices.size()));
+        for (uint32_t index : submit.chunk_indices) {
+            if (index >= bundle.chunks.size()) { error = "bundle references an invalid chunk"; return false; }
+            writer.u32(index);
+        }
+    }
+    const uint64_t manifest_hash = gpu_capture_hash(writer.data);
+    writer.u64(manifest_hash);
+    if (writer.data.size() > kMaxFileBytes) { error = "bundle exceeds 4 GiB"; return false; }
+    return install_file(path, writer.data, error);
+}
+
+bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,
+                             std::string& error) {
+    error.clear(); bundle = {};
+    std::error_code ec; const uint64_t file_size = std::filesystem::file_size(path, ec);
+    if (ec || file_size < 32 || file_size > kMaxFileBytes || file_size > std::numeric_limits<size_t>::max()) {
+        error = "invalid bundle file size"; return false;
+    }
+    std::vector<uint8_t> bytes(static_cast<size_t>(file_size));
+    std::ifstream file(path, std::ios::binary);
+    if (!file || !file.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()))) {
+        error = "cannot read bundle"; return false;
+    }
+    uint64_t stored_hash = 0;
+    Reader tail{bytes.data() + bytes.size() - 8, 8}; tail.u64(stored_hash);
+    if (gpu_capture_hash(bytes.data(), bytes.size() - 8) != stored_hash) {
+        error = "bundle manifest checksum mismatch"; return false;
+    }
+    Reader reader{bytes.data(), bytes.size() - 8}; uint8_t magic[8]; uint32_t version = 0, endian = 0;
+    if (!reader.take(magic, 8) || std::memcmp(magic, kMagic, 8) || !reader.u32(version) ||
+        version != kVersion || !reader.u32(endian) || endian != kEndian ||
+        !reader.u32(bundle.chunk_bytes) || !bundle.chunk_bytes || bundle.chunk_bytes > (16u << 20) ||
+        !reader.u64(bundle.logical_bytes)) {
+        error = "unsupported bundle header"; return false;
+    }
+    bundle.version = version;
+    uint32_t chunk_count = 0;
+    if (!reader.u32(chunk_count) || chunk_count > kMaxChunks) { error = "invalid bundle chunk count"; return false; }
+    bundle.chunks.resize(chunk_count); bundle.chunk_hashes.resize(chunk_count);
+    for (uint32_t i = 0; i < chunk_count; ++i) {
+        if (!reader.u64(bundle.chunk_hashes[i]) || !reader.bytes(bundle.chunks[i]) ||
+            bundle.chunks[i].size() > bundle.chunk_bytes ||
+            gpu_capture_hash(bundle.chunks[i]) != bundle.chunk_hashes[i]) {
+            error = "invalid bundle chunk"; return false;
+        }
+    }
+    uint32_t submit_count = 0;
+    if (!reader.u32(submit_count) || !submit_count || submit_count > kMaxSubmits) {
+        error = "invalid bundle submit count"; return false;
+    }
+    uint64_t logical_total = 0, prior_submit = 0; bundle.submits.resize(submit_count);
+    for (auto& submit : bundle.submits) {
+        uint32_t refs = 0;
+        if (!reader.u64(submit.submit_index) || !reader.u64(submit.logical_bytes) ||
+            !reader.u32(refs) || refs > kMaxChunks) { error = "invalid bundle submit"; return false; }
+        submit.chunk_indices.resize(refs);
+        for (auto& index : submit.chunk_indices)
+            if (!reader.u32(index) || index >= chunk_count) { error = "invalid bundle chunk reference"; return false; }
+        if (submit.submit_index <= prior_submit) { error = "bundle submits are not ordered"; return false; }
+        prior_submit = submit.submit_index;
+        if (logical_total > UINT64_MAX - submit.logical_bytes) { error = "bundle logical size overflow"; return false; }
+        logical_total += submit.logical_bytes;
+    }
+    if (reader.left || logical_total != bundle.logical_bytes) {
+        error = "bundle manifest size mismatch"; return false;
+    }
+    return true;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_capture_bundle.hpp
+++ b/prosper/src/gpu/gpu_capture_bundle.hpp
@@ -1,0 +1,37 @@
+// gpu_capture_bundle.hpp - content-deduplicated ordered submit captures.
+#pragma once
+
+#include "gpu_capture.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace prosper::gpu {
+
+struct GpuCaptureBundleSubmit {
+    uint64_t submit_index = 0;
+    uint64_t logical_bytes = 0;
+    std::vector<uint32_t> chunk_indices;
+};
+
+struct GpuCaptureBundle {
+    uint32_t version = 1;
+    uint32_t chunk_bytes = 256 * 1024;
+    uint64_t logical_bytes = 0;
+    std::vector<uint64_t> chunk_hashes;
+    std::vector<std::vector<uint8_t>> chunks;
+    std::vector<GpuCaptureBundleSubmit> submits;
+};
+
+bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& capture,
+                               std::string& error);
+bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
+                                           GpuCaptureFile& capture, std::string& error);
+bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& bundle,
+                              std::string& error);
+bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,
+                             std::string& error);
+uint64_t gpu_capture_bundle_unique_bytes(const GpuCaptureBundle& bundle);
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1,6 +1,7 @@
 #include "gpu_timeline.hpp"
 
 #include "gpu_capture.hpp"
+#include "gpu_capture_bundle.hpp"
 #include "gpu_dependency_graph.hpp"
 #include "render_state.hpp"
 #include "videoout_present.hpp"
@@ -210,6 +211,9 @@ RuntimeRecorder& runtime_recorder() {
 struct RuntimeDetailRequest {
     std::string path;
     std::string predecessor_path;
+    std::string bundle_path;
+    uint32_t bundle_depth = 0;
+    uint64_t bundle_max_unique_bytes = 1ull << 30;
     uint64_t submit_no = 0;
     bool valid = false;
     std::atomic<bool> claimed{false};
@@ -234,6 +238,30 @@ struct RuntimeDetailRequest {
         path = path_env;
         if (const char* predecessor = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR"))
             predecessor_path = predecessor;
+        if (const char* bundle = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE")) {
+            bundle_path = bundle;
+            bundle_depth = 2;
+            if (const char* depth = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH")) {
+                char* depth_end = nullptr;
+                const uint64_t value = std::strtoull(depth, &depth_end, 0);
+                if (!depth_end || *depth_end || value < 2 || value > 16) {
+                    std::fprintf(stderr, "[timeline] capture bundle depth must be 2..16\n");
+                    bundle_path.clear(); bundle_depth = 0;
+                } else {
+                    bundle_depth = static_cast<uint32_t>(value);
+                }
+            }
+            if (const char* budget = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB")) {
+                char* budget_end = nullptr;
+                const uint64_t value = std::strtoull(budget, &budget_end, 0);
+                if (!budget_end || *budget_end || value < 64 || value > 4096) {
+                    std::fprintf(stderr, "[timeline] capture bundle budget must be 64..4096 MiB\n");
+                    bundle_path.clear(); bundle_depth = 0;
+                } else {
+                    bundle_max_unique_bytes = value << 20;
+                }
+            }
+        }
         submit_no = parsed;
         valid = true;
     }
@@ -298,6 +326,34 @@ struct RuntimeProducerHistory {
 RuntimeProducerHistory& runtime_producer_history() {
     static RuntimeProducerHistory history;
     return history;
+}
+
+struct RuntimeCaptureBundle {
+    GpuCaptureBundle bundle;
+    bool budget_exhausted = false;
+    bool failed = false;
+};
+
+RuntimeCaptureBundle& runtime_capture_bundle() {
+    static RuntimeCaptureBundle state;
+    return state;
+}
+
+bool append_runtime_capture_bundle(const GpuCaptureFile& capture, uint64_t max_unique_bytes,
+                                   std::string& error) {
+    RuntimeCaptureBundle& state = runtime_capture_bundle();
+    if (state.budget_exhausted) { error = "capture bundle unique-byte budget was already exhausted"; return false; }
+    const size_t chunks = state.bundle.chunks.size();
+    const size_t hashes = state.bundle.chunk_hashes.size();
+    const size_t submits = state.bundle.submits.size();
+    const uint64_t logical = state.bundle.logical_bytes;
+    if (!append_gpu_capture_bundle(state.bundle, capture, error)) return false;
+    if (gpu_capture_bundle_unique_bytes(state.bundle) <= max_unique_bytes) return true;
+    state.bundle.chunks.resize(chunks); state.bundle.chunk_hashes.resize(hashes);
+    state.bundle.submits.resize(submits); state.bundle.logical_bytes = logical;
+    state.budget_exhausted = true;
+    error = "capture bundle exceeded its unique-byte budget";
+    return false;
 }
 
 GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
@@ -704,6 +760,31 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
     RuntimeDetailRequest& request = runtime_detail_request();
     RuntimeProducerHistory& history = runtime_producer_history();
+    const uint64_t bundle_first = request.bundle_depth > request.submit_no
+        ? 1 : request.submit_no - request.bundle_depth + 1;
+    if (request.valid && !request.bundle_path.empty() &&
+        !runtime_capture_bundle().budget_exhausted && !runtime_capture_bundle().failed &&
+        submit_no >= bundle_first &&
+        submit_no < request.submit_no) {
+        GpuCaptureFile predecessor;
+        const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
+        if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
+                                     metadata, predecessor, error) ||
+            !append_runtime_capture_bundle(predecessor, request.bundle_max_unique_bytes, error)) {
+            runtime_capture_bundle().failed = !runtime_capture_bundle().budget_exhausted;
+            std::fprintf(stderr, "[timeline] bundle submit %llu capture failed: %s\n",
+                         static_cast<unsigned long long>(submit_no), error.c_str());
+        } else {
+            const std::string identity = request.bundle_path + "#submit=" + std::to_string(submit_no);
+            const GpuTimelineDetail detail = capture_detail(submit, identity, predecessor);
+            if (!writer->append_detail(detail, error)) {
+                runtime_recorder().mark_failed(error);
+                history.remember(state, submit_no);
+                return;
+            }
+            log_capture_detail(detail);
+        }
+    }
     if (request.valid && !request.predecessor_path.empty() && request.submit_no > 1 &&
         submit_no == request.submit_no - 1 && !request.predecessor_claimed.exchange(true)) {
         GpuCaptureFile predecessor;
@@ -785,6 +866,28 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         std::fprintf(stderr, "[timeline] dependency graph failed for submit %llu: %s\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
         error.clear();
+    }
+    if (!request.bundle_path.empty()) {
+        RuntimeCaptureBundle& state = runtime_capture_bundle();
+        GpuCaptureBundle& bundle = state.bundle;
+        if (state.failed) {
+            error = "capture bundle has a failed or missing predecessor submit";
+        } else if (state.budget_exhausted) {
+            error = "capture bundle unique-byte budget was exhausted before the selected submit";
+        }
+        if (state.failed || state.budget_exhausted || !append_runtime_capture_bundle(
+                capture, request.bundle_max_unique_bytes, error) ||
+            !write_gpu_capture_bundle(request.bundle_path, bundle, error)) {
+            std::fprintf(stderr, "[timeline] capture bundle write failed: %s\n", error.c_str());
+        } else {
+            const uint64_t unique_bytes = gpu_capture_bundle_unique_bytes(bundle);
+            std::fprintf(stderr, "[timeline] capture bundle submits=%zu logical=%llu unique=%llu "
+                                 "ratio=%.3f -> %s\n",
+                         bundle.submits.size(), static_cast<unsigned long long>(bundle.logical_bytes),
+                         static_cast<unsigned long long>(unique_bytes),
+                         bundle.logical_bytes ? static_cast<double>(unique_bytes) / bundle.logical_bytes : 0.0,
+                         request.bundle_path.c_str());
+        }
     }
     const GpuTimelineDetail detail = capture_detail(submit, request.path, capture);
     if (!writer->append_detail(detail, error)) {

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -1,0 +1,69 @@
+#include "../src/gpu/gpu_capture_bundle.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_capture_bundle ==\n");
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto path = std::filesystem::temp_directory_path() /
+        ("prosper-gpu-bundle-" + std::to_string(nonce) + ".prgbundle");
+    const auto corrupt_path = path.string() + ".corrupt";
+
+    GpuCaptureFile first;
+    first.metadata.width = 64; first.metadata.height = 64;
+    first.metadata.submit_index = 41; first.metadata.revision = "bundle-test";
+    GpuCaptureBlob blob;
+    blob.guest_addr = 0x100000; blob.bytes_read = 256 * 1024;
+    blob.bytes.resize(static_cast<size_t>(blob.bytes_read));
+    uint32_t random = 0x12345678u;
+    for (auto& byte : blob.bytes) {
+        random ^= random << 13; random ^= random >> 17; random ^= random << 5;
+        byte = static_cast<uint8_t>(random);
+    }
+    first.blobs.push_back(blob);
+    GpuCaptureFile second = first;
+    second.metadata.submit_index = 42;
+    second.metadata.input_route = "shift-the-serialized-blob-boundary";
+
+    GpuCaptureBundle bundle;
+    std::string error;
+    CHECK(append_gpu_capture_bundle(bundle, first, error), "first submit appends to bundle");
+    CHECK(append_gpu_capture_bundle(bundle, second, error), "second submit appends in order");
+    CHECK(bundle.submits.size() == 2 &&
+          gpu_capture_bundle_unique_bytes(bundle) * 10 < bundle.logical_bytes * 7,
+          "content-defined chunks resynchronize and deduplicate after shifted metadata");
+    CHECK(write_gpu_capture_bundle(path.string(), bundle, error), "bundle writes atomically");
+
+    GpuCaptureBundle loaded;
+    CHECK(read_gpu_capture_bundle(path.string(), loaded, error), "checksummed bundle reads");
+    GpuCaptureFile restored;
+    CHECK(materialize_gpu_capture_bundle_submit(loaded, 1, restored, error) &&
+          restored.metadata.submit_index == 42 && restored.blobs.size() == 1 &&
+          restored.blobs[0].bytes == blob.bytes,
+          "bundle reconstructs an exact validated capture");
+
+    std::ifstream input(path, std::ios::binary);
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
+    if (!bytes.empty()) bytes.back() ^= 0x80;
+    std::ofstream corrupt(corrupt_path, std::ios::binary);
+    corrupt.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    corrupt.close();
+    GpuCaptureBundle rejected;
+    CHECK(!read_gpu_capture_bundle(corrupt_path, rejected, error) &&
+          error.find("checksum") != std::string::npos,
+          "bundle rejects manifest corruption");
+
+    std::error_code ec; std::filesystem::remove(path, ec); std::filesystem::remove(corrupt_path, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n"); return 0;
+}

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -1,4 +1,5 @@
 #include "../src/gpu/gpu_timeline.hpp"
+#include "../src/gpu/gpu_capture_bundle.hpp"
 
 #include <chrono>
 #include <cstdio>
@@ -114,18 +115,23 @@ int main() {
     const auto runtime = base.string() + "-runtime.prgtl";
     const auto runtime_capture = base.string() + "-submit-42.prgcap";
     const auto predecessor_capture = base.string() + "-submit-41.prgcap";
+    const auto bundle_capture = base.string() + "-submits-41-42.prgbundle";
 #ifdef _WIN32
     _putenv_s("PROSPER_GPU_TIMELINE", runtime.c_str());
     _putenv_s("PROSPER_CAPTURE_TITLE", "runtime-title");
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE", runtime_capture.c_str());
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "42");
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", predecessor_capture.c_str());
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str());
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2");
 #else
     setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
     setenv("PROSPER_CAPTURE_TITLE", "runtime-title", 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE", runtime_capture.c_str(), 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "42", 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", predecessor_capture.c_str(), 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str(), 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2", 1);
 #endif
     GpuState predecessor_state;
     predecessor_state.command_order = 120;
@@ -142,12 +148,18 @@ int main() {
     CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 2 &&
           runtime_timeline.presents[0].latest_submit_no == 42,
           "a flip during folding is associated with its active submit");
-    CHECK(runtime_timeline.details.size() == 2 && runtime_timeline.details[0].submit_no == 41 &&
-          runtime_timeline.details[0].capture_path == predecessor_capture &&
-          runtime_timeline.details[1].submit_no == 42 &&
-          runtime_timeline.details[1].capture_path == runtime_capture &&
+    CHECK(runtime_timeline.details.size() == 3 && runtime_timeline.details[0].submit_no == 41 &&
+          runtime_timeline.details[0].capture_path.find(bundle_capture + "#submit=41") == 0 &&
+          runtime_timeline.details[1].capture_path == predecessor_capture &&
+          runtime_timeline.details[2].submit_no == 42 &&
+          runtime_timeline.details[2].capture_path == runtime_capture &&
           std::filesystem::exists(predecessor_capture) && std::filesystem::exists(runtime_capture),
           "exact submit selection writes and links producer-time predecessor and consumer capsules");
+    GpuCaptureBundle runtime_bundle;
+    CHECK(read_gpu_capture_bundle(bundle_capture, runtime_bundle, error) &&
+          runtime_bundle.submits.size() == 2 && runtime_bundle.submits[0].submit_index == 41 &&
+          runtime_bundle.submits[1].submit_index == 42,
+          "exact submit selection writes an ordered same-run capture bundle");
 
     const auto compat_v2 = base.string() + "-compat-v2.prgtl";
     GpuTimelineWriter compat_writer;
@@ -171,6 +183,7 @@ int main() {
     std::filesystem::remove(runtime, ec);
     std::filesystem::remove(runtime_capture, ec);
     std::filesystem::remove(predecessor_capture, ec);
+    std::filesystem::remove(bundle_capture, ec);
     std::filesystem::remove(compat_v2, ec);
     std::filesystem::remove(version1, ec);
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -83,6 +83,11 @@ order, or state `unresolved`; they intentionally do not retain delayed pointers 
 Set `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>.prgcap` to snapshot exact submit `N-1` at producer
 time alongside selected submit `N`. Replay the pair with `gpu_replay --prepend producer consumer output`.
 This is a one-level probe; graph the producer and recurse when it also reads a temporal version.
+For bounded recursion, add `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>.prgbundle`,
+`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=2..16`, and optionally
+`PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=64..4096` (default 1024). `gpu_replay --bundle bundle output`
+executes the ordered window and classifies each temporal frontier as included, seeded, or depth-bounded.
+Bundles use content-defined chunks so shifted capture metadata does not defeat cross-submit deduplication.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -20,6 +20,7 @@ Create a capsule with the native-speed workflow in
 ./build-linux/gpu_replay --graph-json /tmp/graph.json /tmp/submit.prgcap
 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/replay.bmp
 ./build-linux/gpu_replay --prepend /tmp/producer.prgcap /tmp/consumer.prgcap /tmp/closure.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle /tmp/closure.bmp
 ```
 
 ## Reading graph output
@@ -61,6 +62,19 @@ restored. The tool rejects a predecessor whose submit number is not earlier. A c
 consumer sampled the retained producer output, but it does not prove faithful closure: graph the predecessor
 and continue if it also has temporal leaves.
 
+`--bundle` reconstructs each captured submit through the normal version-5 validator, executes them in
+ascending order through one renderer instance, and releases each materialized submit before the next.
+The summary reports logical versus unique bytes, per-submit output hashes, and every temporal image leaf:
+
+- `stop=included-producer` names the earlier bundled submit whose target overlaps the leaf.
+- `stop=initialized-seed` means serialized RTT pixels establish the version without another submit.
+- `stop=configured-bound` means the earliest bundled submit still needs older history.
+- `stop=unresolved-producer` means a later submit has no overlapping earlier bundled target; a contiguous
+  bundle should not produce this and the capture/replay evidence is incomplete.
+
+A successful replay with `configured-bound` is an explicitly partial closure, not a faithful pixel oracle.
+Bundle files use `.prgbundle`, contain title-derived data, are gitignored, and must not be committed.
+
 ## Current Dead Cells reference
 
 The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. A timeline-v3
@@ -68,7 +82,8 @@ run resolved both to submit 18,749: draw 45 / PM4 order 9,436,927 and draw 41 / 
 resource addresses and even semantic operation ordinals are run-local observations, not title constants.
 Recompute them from each new capsule and timeline; never hardcode them into renderer behavior.
 
-A same-run producer/consumer capture showed that prepending submit 18,749 changes the overbright consumer in
-the expected regions, but those regions become black. Submit 18,749 has the same two temporal read-before-write
-leaves, so this is positive closure evidence rather than a final image fix. Recursive predecessor capture is
-the next #595 step.
+A same-run depth-16 bundle for submits 18,735..18,750 resolved all 30 internal temporal edges and reported
+exactly two 642x362 leaves at the configured lower bound. Content-defined dedup stored 2.883 GiB of logical
+capsules in 166.3 MiB (5.8%). No initialized RTT seed appeared in that window, and even/odd depths alternate
+between the dark and overbright failure. The tool is working; faithful Dead Cells closure still requires the
+earlier initialization version rather than an arbitrary depth or title-specific fallback.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1,4 +1,5 @@
 #include "gpu/gpu_capture.hpp"
+#include "gpu/gpu_capture_bundle.hpp"
 #include "gpu/gpu_dependency_graph.hpp"
 #include "gpu/gpu_execute.hpp"
 #include "live_renderer.hpp"
@@ -25,6 +26,7 @@ bool set_environment(const std::string& name, const std::string& value) {
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] "
+                         "[--bundle capture.prgbundle] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-shader DRAW:vs|fs PATH] "
@@ -275,13 +277,148 @@ bool validate_frame(const prosper::gpu::GpuReplayFrame& replay) {
     return valid;
 }
 
+struct BundleTarget {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    uint64_t submit = 0;
+};
+
+uint64_t range_end(uint64_t addr, uint64_t size) {
+    return size > UINT64_MAX - addr ? UINT64_MAX : addr + size;
+}
+
+bool ranges_overlap(uint64_t a, uint64_t as, uint64_t b, uint64_t bs) {
+    return a < range_end(b, bs) && b < range_end(a, as);
+}
+
+int replay_bundle(const std::string& path, const char* output_path) {
+    prosper::gpu::GpuCaptureBundle bundle;
+    std::string error;
+    if (!prosper::gpu::read_gpu_capture_bundle(path, bundle, error)) {
+        std::fprintf(stderr, "gpu_replay: cannot read bundle: %s\n", error.c_str()); return 2;
+    }
+    const uint64_t unique_bytes = prosper::gpu::gpu_capture_bundle_unique_bytes(bundle);
+    std::fprintf(stderr, "[gpureplay] bundle submits=%zu logical=%llu unique=%llu ratio=%.3f chunks=%zu\n",
+                 bundle.submits.size(), static_cast<unsigned long long>(bundle.logical_bytes),
+                 static_cast<unsigned long long>(unique_bytes),
+                 bundle.logical_bytes ? static_cast<double>(unique_bytes) / bundle.logical_bytes : 0.0,
+                 bundle.chunks.size());
+
+    prosper::gpu::GpuCaptureFile final_capture;
+    if (!prosper::gpu::materialize_gpu_capture_bundle_submit(
+            bundle, bundle.submits.size() - 1, final_capture, error)) {
+        std::fprintf(stderr, "gpu_replay: cannot reconstruct final submit: %s\n", error.c_str()); return 2;
+    }
+    const prosper::gpu::GpuCaptureMetadata final_metadata = final_capture.metadata;
+    const bool expected_output_valid = final_capture.expected_output_valid;
+    const uint64_t expected_output_bytes = final_capture.expected_output_bytes;
+    const uint64_t expected_output_hash = final_capture.expected_output_hash;
+    for (const auto& [name, value] : final_capture.metadata.renderer_env)
+        if (!set_environment(name, value)) {
+            std::fprintf(stderr, "gpu_replay: cannot set %s\n", name.c_str()); return 2;
+        }
+    set_environment("PROSPER_RENDER_FIRST", "0");
+    set_environment("PROSPER_RENDER_LAST", "2147483647");
+    set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
+    prosper::frontend::register_live_renderer(".", false);
+    final_capture = {};
+
+    std::vector<BundleTarget> prior_targets;
+    std::vector<uint8_t> final_pixels;
+    uint64_t temporal_resolved = 0, temporal_seeded = 0, temporal_bounded = 0, temporal_unresolved = 0;
+    for (size_t i = 0; i < bundle.submits.size(); ++i) {
+        prosper::gpu::GpuCaptureFile capture;
+        if (!prosper::gpu::materialize_gpu_capture_bundle_submit(bundle, i, capture, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot reconstruct bundle submit %zu: %s\n",
+                         i, error.c_str()); return 2;
+        }
+        prosper::gpu::GpuReplayFrame replay;
+        if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot materialize bundle submit %llu: %s\n",
+                         static_cast<unsigned long long>(capture.metadata.submit_index), error.c_str());
+            return 2;
+        }
+        prosper::gpu::GpuDependencyGraph graph;
+        if (!prosper::gpu::build_gpu_dependency_graph(replay, graph, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot graph bundle submit %llu: %s\n",
+                         static_cast<unsigned long long>(capture.metadata.submit_index), error.c_str());
+            return 2;
+        }
+        for (const auto& leaf : graph.external_leaves) {
+            if (leaf.first_future_writer == UINT32_MAX ||
+                (leaf.access.resource_class != prosper::gpu::ResourceClass::Texture &&
+                 leaf.access.resource_class != prosper::gpu::ResourceClass::StorageImage)) continue;
+            auto seed = std::find_if(replay.rtt_seeds.begin(), replay.rtt_seeds.end(),
+                [&](const auto& candidate) { return candidate.guest_addr == leaf.access.addr; });
+            auto producer = std::find_if(prior_targets.rbegin(), prior_targets.rend(),
+                [&](const auto& target) {
+                    return ranges_overlap(leaf.access.addr, leaf.access.size, target.addr, target.size);
+                });
+            const char* stop = i == 0 ? "configured-bound" : "unresolved-producer";
+            uint64_t producer_submit = 0;
+            if (producer != prior_targets.rend()) {
+                stop = "included-producer"; producer_submit = producer->submit; ++temporal_resolved;
+            } else if (seed != replay.rtt_seeds.end()) {
+                stop = "initialized-seed"; ++temporal_seeded;
+            } else {
+                if (i == 0) ++temporal_bounded;
+                else ++temporal_unresolved;
+            }
+            std::fprintf(stderr, "[gpureplay] frontier submit=%llu op=%u addr=%016llx dims=%ux%u "
+                                 "stop=%s producer=%llu\n",
+                         static_cast<unsigned long long>(capture.metadata.submit_index),
+                         leaf.consumer_operations.front(),
+                         static_cast<unsigned long long>(leaf.access.addr),
+                         leaf.access.width, leaf.access.height, stop,
+                         static_cast<unsigned long long>(producer_submit));
+        }
+
+        std::vector<prosper::gpu::GpuCaptureRttSeed> seeds;
+        for (const auto& seed : replay.rtt_seeds)
+            if (std::none_of(prior_targets.begin(), prior_targets.end(), [&](const auto& target) {
+                    return target.addr == seed.guest_addr;
+                })) seeds.push_back(seed);
+        if (!prosper::gpu::restore_gpu_replay_rtt_seeds(seeds, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot restore bundle RTT seeds: %s\n", error.c_str());
+            return 2;
+        }
+        final_pixels = execute_frame(replay);
+        for (const auto& draw : replay.items)
+            if (draw.color0_base && draw.color0_width && draw.color0_height)
+                prior_targets.push_back({draw.color0_base,
+                    static_cast<uint64_t>(draw.color0_width) * draw.color0_height * 4,
+                    capture.metadata.submit_index});
+        std::fprintf(stderr, "[gpureplay] bundle-submit=%llu operations=%zu output_bytes=%zu hash=%016llx\n",
+                     static_cast<unsigned long long>(capture.metadata.submit_index),
+                     replay.operations.size(), final_pixels.size(),
+                     static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(final_pixels)));
+    }
+    std::fprintf(stderr, "[gpureplay] closure temporal-resolved=%llu seeded=%llu bounded=%llu "
+                         "unresolved=%llu\n",
+                 static_cast<unsigned long long>(temporal_resolved),
+                 static_cast<unsigned long long>(temporal_seeded),
+                 static_cast<unsigned long long>(temporal_bounded),
+                 static_cast<unsigned long long>(temporal_unresolved));
+    if (output_path && !final_pixels.empty() &&
+        !prosper::test::dump_bmp(output_path, final_pixels,
+                                 final_metadata.width, final_metadata.height)) {
+        std::fprintf(stderr, "gpu_replay: cannot write %s\n", output_path); return 2;
+    }
+    if (expected_output_valid &&
+        (final_pixels.size() != expected_output_bytes ||
+         prosper::gpu::gpu_capture_hash(final_pixels) != expected_output_hash)) {
+        std::fprintf(stderr, "gpu_replay: bundle output mismatch\n"); return 1;
+    }
+    return 0;
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool graph_only = false;
     int draw_first = -1, draw_last = -1;
-    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path;
+    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path, bundle_path;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
@@ -292,6 +429,7 @@ int main(int argc, char** argv) {
             graph_only = true; graph_json_path = argv[++i];
         }
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
+        else if (std::string(argv[i]) == "--bundle" && i + 1 < argc) bundle_path = argv[++i];
         else if (std::string(argv[i]) == "--prepend" && i + 1 < argc) prepend_path = argv[++i];
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
             std::string range = argv[++i]; size_t colon = range.find(':');
@@ -305,6 +443,13 @@ int main(int argc, char** argv) {
             shader_spec = argv[++i]; shader_path = argv[++i];
         }
         else positional.push_back(argv[i]);
+    }
+    if (!bundle_path.empty()) {
+        if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
+            draw_first >= 0 || !dump_spec.empty() || !shader_spec.empty() || !prepend_path.empty()) {
+            usage(argv[0]); return 2;
+        }
+        return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0]);
     }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
     prosper::gpu::GpuCaptureFile capture; std::string error;

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -35,6 +35,20 @@ PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=/tmp/dead-cells-submit-18419.prgcap \
   /tmp/dead-cells-submit-18420.prgcap /tmp/replay-with-producer.bmp
 ```
 
+Capture a bounded ordered window directly into one deduplicated bundle:
+
+```bash
+PROSPER_GPU_TIMELINE=/tmp/dead-cells-bundle.prgtl \
+PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=18420 \
+PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
+PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-depth16.prgbundle \
+PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=16 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
+  ./build-linux/boot_trace /path/to/PPSA15552-app0
+
+./build-linux/gpu_replay --bundle /tmp/dead-cells-depth16.prgbundle /tmp/closure.bmp
+```
+
 See [`../gpu_replay/README.md`](../gpu_replay/README.md) for graph interpretation, pixel-oracle
 semantics, draw isolation, resource/shader extraction, and the distinction between draw and operation indices.
 
@@ -84,3 +98,10 @@ materializing it after the selected submit would read mutable guest memory too l
 evidence. `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>` instead captures exactly submit `N-1` at
 producer time in the same run and links both capsules with ordinary detail records. It is deliberately a
 one-level closure probe; if the predecessor graph has temporal leaves, capture must recurse further.
+
+For a recursive probe, `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>` captures the selected submit and
+`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=N` contiguous submits ending there (2..16). Captures are serialized at
+producer time and folded immediately into content-defined, checksummed chunks; no retained `GpuState` or
+standalone predecessor files are used. `PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=N` bounds unique chunk
+data to 64..4096 MiB (default 1024) and aborts bundle installation if exhausted. The selected standalone
+`.prgcap` remains the graph/oracle reference and is currently required with the bundle.


### PR DESCRIPTION
## Summary
- add checksummed, content-defined `.prgbundle` storage for ordered v5 submit captures
- capture bounded producer-time windows with explicit depth and unique-byte budgets
- replay bundle submits chronologically through one persistent renderer
- classify temporal leaves as included, seeded, depth-bounded, or unresolved
- document the workflow and current Dead Cells initialization frontier

## Storage and correctness
- exact captures reconstruct through the existing v5 validator
- no retained guest pointers or second GPU-state schema
- shifted-metadata regression proves content-defined chunks resynchronize
- failed middle captures and exhausted byte budgets prevent bundle installation

## Dead Cells evidence
Depth 16 captured submits 18735..18750:
- 2,882,703,952 logical bytes
- 166,338,347 unique bytes (5.8%; 94.2% deduplicated)
- 30 internal temporal edges resolved
- 2 lower-bound 642x362 leaves
- 0 initialized seeds and 0 unresolved later producers
- final hash `62a46f15efa52a26`

The remaining initialization investigation is tracked in #604. This PR advances #603/#595 without claiming faithful final pixels.

## Verification
- `ctest --test-dir prosper/build-linux --output-on-failure` (91/91)
- scripted Dead Cells depth 3, 4, and 16 captures
- full-resolution chronological bundle replays