### PR TITLE
gpu: trace full temporal target lifetimes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,13 +113,16 @@ The current tooling frontier is deterministic offline capture rather than longer
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
 immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-5 `.prgcap` (#594).
 `gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
-full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 3 resolves those leaves against bounded
+full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 4 resolves those leaves against bounded
 same-run target history. Ordered `.prgbundle` windows now capture producer-time submits with content-defined
 cross-submit deduplication and replay them through one persistent renderer (#603). Dead Cells depth 16 resolves
 all 30 internal temporal edges in submits 18735..18750 while storing 2.883 GiB logical data in 166.3 MiB, but
-the earliest submit still has two unseeded 642x362 leaves. Find/capture their initialization version rather than
-increasing depth blindly or adding a dimension fallback (#595/#586). Addresses and operation ordinals are
-run-local. The stale exact Dead Cells snapshot baseline is
+the earliest submit still has two unseeded 642x362 leaves. Full-run aggregation places their first observed
+graphics writers around submit 17,400 and records roughly 1,200-1,350 writes before the selected submit (#604).
+A transparent-zero boundary A/B yields the exact unseeded hash, so zero initialization is not the missing state.
+Target-extent filtering still captures about 150 MiB per submit because large static textures repeat. Build
+exact shared-resource reuse for long bundles instead of brute-forcing depth or adding a dimension fallback.
+Addresses and operation ordinals are run-local. The stale exact Dead Cells snapshot baseline is
 tracked separately in #596 and must not be silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -44,9 +44,12 @@ possible without console keys. Dumps are user-supplied and gitignored.
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** locate and retain the initialization version for Dead Cells' two temporal 642×362
-  surfaces (#595/#586). Ordered depth-16 bundles now resolve every later producer edge with 94.2% cross-submit
-  deduplication (#603), but the earliest included submit remains explicitly depth-bounded with no RTT seed.
+- 🚧 **Active frontiers:** retain the long history for Dead Cells' two temporal 642×362 surfaces
+  (#595/#586/#604). Timeline-v4 aggregation places their first observed graphics writers around submit 17,400,
+  roughly 1,200-1,350 writes before the selected gameplay submit. A transparent-zero lower-bound A/B produces
+  the exact unseeded replay hash, ruling out stale backing versus zero initialization in the depth-16 window.
+  Extent-filtered captures still cost about 150 MiB per submit due to repeated large static textures, so the
+  next tooling boundary is exact shared-resource reuse across a long bundle rather than brute-force capture.
   The stale exact Dead Cells
   snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -452,6 +452,36 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                                 reader, out, error, g_rtt_seed_reader);
 }
 
+bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
+                                    uint32_t width, uint32_t height,
+                                    uint32_t target_width, uint32_t target_height,
+                                    const GpuCaptureMetadata& metadata,
+                                    GpuCaptureFile& out, std::string& error) {
+    std::vector<DrawItem> draws = realize_gpustate_draws(state);
+    draws.erase(std::remove_if(draws.begin(), draws.end(), [&](const DrawItem& draw) {
+        return draw.color0_width != target_width || draw.color0_height != target_height;
+    }), draws.end());
+    std::vector<SubmitOperation> operations;
+    operations.reserve(draws.size());
+    for (const auto& draw : draws)
+        operations.push_back({SubmitOperationKind::Draw, static_cast<size_t>(draw.draw_index),
+                              draw.command_order});
+    auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
+        size_t done = 0;
+        constexpr size_t chunk_max = 0x10000;
+        while (done < bytes) {
+            const size_t n = std::min(bytes - done, chunk_max);
+            if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
+            std::memcpy(dst + done, reinterpret_cast<const void*>(uintptr_t(addr + done)), n);
+            done += n;
+        }
+        return done;
+    };
+    GpuCaptureMetadata actual = metadata;
+    actual.width = width; actual.height = height; actual.submit_index = submit_no;
+    return capture_submit_items(draws, {}, operations, actual, reader, out, error, g_rtt_seed_reader);
+}
+
 bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes, std::string& error) {
     error.clear(); Writer w; w.raw(kMagic, sizeof(kMagic)); w.u32(kVersion); w.u32(kEndian);
     w.u32(c.metadata.width); w.u32(c.metadata.height); w.u64(c.metadata.submit_index);

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -118,6 +118,11 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
                              GpuCaptureFile& out, std::string& error);
+bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
+                                    uint32_t width, uint32_t height,
+                                    uint32_t target_width, uint32_t target_height,
+                                    const GpuCaptureMetadata& metadata,
+                                    GpuCaptureFile& out, std::string& error);
 bool serialize_gpu_capture(const GpuCaptureFile& capture, std::vector<uint8_t>& bytes,
                            std::string& error);
 bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& capture,

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -14,7 +14,7 @@ constexpr uint8_t kMagic[8] = {'P', 'R', 'G', 'B', 'N', 'D', 'L', '\0'};
 constexpr uint32_t kVersion = 1;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxChunks = 1u << 20;
-constexpr uint32_t kMaxSubmits = 64;
+constexpr uint32_t kMaxSubmits = 2048;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 
 struct Writer {

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <limits>
 #include <mutex>
+#include <unordered_map>
 #include <utility>
 
 namespace prosper::gpu {
@@ -26,7 +27,7 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 3;
+constexpr uint32_t kVersion = 4;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
@@ -214,6 +215,8 @@ struct RuntimeDetailRequest {
     std::string bundle_path;
     uint32_t bundle_depth = 0;
     uint64_t bundle_max_unique_bytes = 1ull << 30;
+    uint32_t bundle_target_width = 0;
+    uint32_t bundle_target_height = 0;
     uint64_t submit_no = 0;
     bool valid = false;
     std::atomic<bool> claimed{false};
@@ -244,8 +247,8 @@ struct RuntimeDetailRequest {
             if (const char* depth = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH")) {
                 char* depth_end = nullptr;
                 const uint64_t value = std::strtoull(depth, &depth_end, 0);
-                if (!depth_end || *depth_end || value < 2 || value > 16) {
-                    std::fprintf(stderr, "[timeline] capture bundle depth must be 2..16\n");
+                if (!depth_end || *depth_end || value < 2 || value > 2048) {
+                    std::fprintf(stderr, "[timeline] capture bundle depth must be 2..2048\n");
                     bundle_path.clear(); bundle_depth = 0;
                 } else {
                     bundle_depth = static_cast<uint32_t>(value);
@@ -259,6 +262,16 @@ struct RuntimeDetailRequest {
                     bundle_path.clear(); bundle_depth = 0;
                 } else {
                     bundle_max_unique_bytes = value << 20;
+                }
+            }
+            if (const char* dimensions = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM")) {
+                unsigned width = 0, height = 0; char tail = 0;
+                if (std::sscanf(dimensions, "%ux%u%c", &width, &height, &tail) != 2 ||
+                    !width || !height) {
+                    std::fprintf(stderr, "[timeline] capture target dimension must be WxH\n");
+                    bundle_path.clear(); bundle_depth = 0;
+                } else {
+                    bundle_target_width = width; bundle_target_height = height;
                 }
             }
         }
@@ -280,24 +293,64 @@ struct RuntimeTargetWrite {
     uint64_t size = 0;
     uint32_t width = 0;
     uint32_t height = 0;
+    bool color_has_clear = false;
+    uint32_t color_clear_word0 = 0;
+    uint32_t color_clear_word1 = 0;
+    uint32_t color_control = 0;
+    uint32_t target_mask = 0;
+    uint32_t color_format = 0;
+};
+
+struct RuntimeTargetLifetime {
+    const RuntimeTargetWrite* first = nullptr;
+    const RuntimeTargetWrite* last = nullptr;
+    uint64_t write_count = 0;
+    uint64_t submit_count = 0;
+};
+
+struct RuntimeTargetKey {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    bool operator==(const RuntimeTargetKey& other) const {
+        return addr == other.addr && size == other.size;
+    }
+};
+
+struct RuntimeTargetKeyHash {
+    size_t operator()(const RuntimeTargetKey& key) const {
+        return static_cast<size_t>(key.addr ^ (key.addr >> 32) ^ key.size ^ (key.size >> 32));
+    }
+};
+
+struct RuntimeTargetAggregate {
+    RuntimeTargetWrite first;
+    RuntimeTargetWrite last;
+    uint64_t write_count = 0;
+    uint64_t submit_count = 0;
+    uint64_t last_counted_submit = 0;
 };
 
 struct RuntimeProducerHistory {
     std::deque<std::vector<RuntimeTargetWrite>> submits;
     size_t capacity = 64;
     bool enabled = false;
+    uint64_t first_submit_no = 0;
+    uint64_t dropped_submits = 0;
+    std::unordered_map<RuntimeTargetKey, RuntimeTargetAggregate, RuntimeTargetKeyHash> lifetimes;
+    bool lifetime_truncated = false;
 
     RuntimeProducerHistory() {
         enabled = runtime_detail_request().valid;
         if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_HISTORY")) {
             char* end = nullptr;
             const uint64_t parsed = std::strtoull(value, &end, 0);
-            if (end && !*end && parsed) capacity = static_cast<size_t>(std::min<uint64_t>(parsed, 4096));
+            if (end && !*end && parsed) capacity = static_cast<size_t>(std::min<uint64_t>(parsed, 65536));
         }
     }
 
     void remember(const GpuState& state, uint64_t submit_no) {
         if (!enabled) return;
+        if (!first_submit_no) first_submit_no = submit_no;
         std::vector<RuntimeTargetWrite> writes;
         writes.reserve(state.draws.size());
         for (size_t i = 0; i < state.draws.size(); ++i) {
@@ -305,10 +358,34 @@ struct RuntimeProducerHistory {
             if (!rs.color0_base || !rs.color0_width || !rs.color0_height) continue;
             writes.push_back({submit_no, i, state.draws[i].command_order, rs.color0_base,
                               static_cast<uint64_t>(rs.color0_width) * rs.color0_height * 4,
-                              rs.color0_width, rs.color0_height});
+                              rs.color0_width, rs.color0_height, rs.color0_has_clear,
+                              rs.color0_clear_word0, rs.color0_clear_word1, rs.cb_color_control,
+                              rs.cb_target_mask, rs.color0_format});
+            const RuntimeTargetWrite& write = writes.back();
+            const RuntimeTargetKey key{write.addr, write.size};
+            auto found = lifetimes.find(key);
+            if (found == lifetimes.end()) {
+                if (lifetimes.size() >= 65536) {
+                    lifetime_truncated = true;
+                } else {
+                    RuntimeTargetAggregate aggregate;
+                    aggregate.first = aggregate.last = write;
+                    aggregate.write_count = aggregate.submit_count = 1;
+                    aggregate.last_counted_submit = submit_no;
+                    lifetimes.emplace(key, std::move(aggregate));
+                }
+            } else {
+                RuntimeTargetAggregate& aggregate = found->second;
+                aggregate.last = write;
+                ++aggregate.write_count;
+                if (aggregate.last_counted_submit != submit_no) {
+                    ++aggregate.submit_count;
+                    aggregate.last_counted_submit = submit_no;
+                }
+            }
         }
         submits.push_back(std::move(writes));
-        while (submits.size() > capacity) submits.pop_front();
+        while (submits.size() > capacity) { submits.pop_front(); ++dropped_submits; }
     }
 
     const RuntimeTargetWrite* latest_overlap(uint64_t addr, uint64_t size) const {
@@ -320,6 +397,31 @@ struct RuntimeProducerHistory {
                 if (addr < end(write->addr, write->size) && write->addr < end(addr, size))
                     return &*write;
         return nullptr;
+    }
+
+    RuntimeTargetLifetime lifetime_overlap(uint64_t addr, uint64_t size) const {
+        auto end = [](uint64_t base, uint64_t bytes) {
+            return bytes > UINT64_MAX - base ? UINT64_MAX : base + bytes;
+        };
+        RuntimeTargetLifetime lifetime;
+        for (const auto& [key, aggregate] : lifetimes) {
+            if (addr >= end(key.addr, key.size) || key.addr >= end(addr, size)) continue;
+            if (!lifetime.first || aggregate.first.submit_no < lifetime.first->submit_no ||
+                (aggregate.first.submit_no == lifetime.first->submit_no &&
+                 aggregate.first.command_order < lifetime.first->command_order))
+                lifetime.first = &aggregate.first;
+            if (!lifetime.last || aggregate.last.submit_no > lifetime.last->submit_no ||
+                (aggregate.last.submit_no == lifetime.last->submit_no &&
+                 aggregate.last.command_order > lifetime.last->command_order))
+                lifetime.last = &aggregate.last;
+            lifetime.write_count += aggregate.write_count;
+            lifetime.submit_count += aggregate.submit_count;
+        }
+        return lifetime;
+    }
+
+    uint64_t window_first_submit_no() const {
+        return first_submit_no ? first_submit_no + dropped_submits : 0;
     }
 };
 
@@ -530,6 +632,22 @@ bool GpuTimelineWriter::append_producer(const GpuTimelineProducer& producer, std
     payload.u64(producer.producer_target_addr);
     payload.u32(producer.producer_width);
     payload.u32(producer.producer_height);
+    payload.u32(static_cast<uint32_t>(producer.first_writer_kind));
+    payload.u64(producer.history_first_submit_no);
+    payload.u64(producer.history_first_draw_index);
+    payload.u64(producer.history_first_command_order);
+    payload.u64(producer.history_write_count);
+    payload.u64(producer.history_submit_count);
+    payload.u64(producer.history_window_first_submit_no);
+    payload.u32(producer.lifetime_truncated ? 1u : 0u);
+    payload.u32(producer.history_window_truncated ? 1u : 0u);
+    payload.u32(producer.first_color_has_clear ? 1u : 0u);
+    payload.u32(producer.first_color_clear_word0);
+    payload.u32(producer.first_color_clear_word1);
+    payload.u32(producer.first_color_control);
+    payload.u32(producer.first_color_control_mode);
+    payload.u32(producer.first_target_mask);
+    payload.u32(producer.first_color_format);
     return impl_->append(RecordType::Producer, payload, error);
 }
 
@@ -688,19 +806,42 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
             GpuTimelineProducer producer;
             producer.sequence = sequence;
             producer.elapsed_ns = elapsed_ns;
-            uint32_t resolved = 0;
+            uint32_t resolved = 0, writer_kind = 0, lifetime_truncated = 0;
+            uint32_t window_truncated = 0, has_clear = 0;
             if (!p.u64(producer.consumer_submit_no) || !p.u32(producer.consumer_operation) ||
                 !p.u32(producer.future_writer_operation) || !p.u64(producer.resource_addr) ||
                 !p.u64(producer.resource_size) || !p.u32(producer.resource_width) ||
                 !p.u32(producer.resource_height) || !p.u32(resolved) ||
                 !p.u64(producer.producer_submit_no) || !p.u64(producer.producer_draw_index) ||
                 !p.u64(producer.producer_command_order) || !p.u64(producer.producer_target_addr) ||
-                !p.u32(producer.producer_width) || !p.u32(producer.producer_height) || p.left ||
+                !p.u32(producer.producer_width) || !p.u32(producer.producer_height) ||
                 resolved > 1) {
                 error = "invalid timeline producer record";
                 return false;
             }
             producer.resolved = resolved != 0;
+            if (version >= 4) {
+                if (!p.u32(writer_kind) || writer_kind > static_cast<uint32_t>(GpuTimelineWriterKind::WriteData) ||
+                    !p.u64(producer.history_first_submit_no) ||
+                    !p.u64(producer.history_first_draw_index) ||
+                    !p.u64(producer.history_first_command_order) ||
+                    !p.u64(producer.history_write_count) || !p.u64(producer.history_submit_count) ||
+                    !p.u64(producer.history_window_first_submit_no) || !p.u32(lifetime_truncated) ||
+                    !p.u32(window_truncated) ||
+                    !p.u32(has_clear) || !p.u32(producer.first_color_clear_word0) ||
+                    !p.u32(producer.first_color_clear_word1) || !p.u32(producer.first_color_control) ||
+                    !p.u32(producer.first_color_control_mode) || !p.u32(producer.first_target_mask) ||
+                    !p.u32(producer.first_color_format) || lifetime_truncated > 1 ||
+                    window_truncated > 1 || has_clear > 1) {
+                    error = "invalid timeline producer lifetime record";
+                    return false;
+                }
+                producer.first_writer_kind = static_cast<GpuTimelineWriterKind>(writer_kind);
+                producer.lifetime_truncated = lifetime_truncated != 0;
+                producer.history_window_truncated = window_truncated != 0;
+                producer.first_color_has_clear = has_clear != 0;
+            }
+            if (p.left) { error = "invalid timeline producer record size"; return false; }
             timeline.producers.push_back(std::move(producer));
         } else {
             error = "unknown timeline record type " + std::to_string(type_raw);
@@ -768,8 +909,13 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         submit_no < request.submit_no) {
         GpuCaptureFile predecessor;
         const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
-        if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
-                                     metadata, predecessor, error) ||
+        const bool captured = request.bundle_target_width
+            ? capture_gpustate_target_submit(state, submit_no, metadata.width, metadata.height,
+                                             request.bundle_target_width, request.bundle_target_height,
+                                             metadata, predecessor, error)
+            : capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
+                                      metadata, predecessor, error);
+        if (!captured ||
             !append_runtime_capture_bundle(predecessor, request.bundle_max_unique_bytes, error)) {
             runtime_capture_bundle().failed = !runtime_capture_bundle().budget_exhausted;
             std::fprintf(stderr, "[timeline] bundle submit %llu capture failed: %s\n",
@@ -782,7 +928,10 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                 history.remember(state, submit_no);
                 return;
             }
-            log_capture_detail(detail);
+            const uint64_t offset = submit_no - bundle_first;
+            if (request.bundle_depth <= 64 || !offset || !(offset % 100) ||
+                submit_no + 1 == request.submit_no)
+                log_capture_detail(detail);
         }
     }
     if (request.valid && !request.predecessor_path.empty() && request.submit_no > 1 &&
@@ -835,7 +984,30 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             producer.resource_size = leaf.access.size;
             producer.resource_width = leaf.access.width;
             producer.resource_height = leaf.access.height;
-            if (const RuntimeTargetWrite* match = history.latest_overlap(leaf.access.addr, leaf.access.size)) {
+            const RuntimeTargetLifetime lifetime = history.lifetime_overlap(
+                leaf.access.addr, leaf.access.size);
+            producer.history_window_first_submit_no = history.window_first_submit_no();
+            producer.lifetime_truncated = history.lifetime_truncated;
+            producer.history_window_truncated = history.dropped_submits != 0;
+            producer.history_write_count = lifetime.write_count;
+            producer.history_submit_count = lifetime.submit_count;
+            if (lifetime.first) {
+                producer.first_writer_kind = GpuTimelineWriterKind::Graphics;
+                producer.history_first_submit_no = lifetime.first->submit_no;
+                producer.history_first_draw_index = lifetime.first->draw_index;
+                producer.history_first_command_order = lifetime.first->command_order;
+                producer.first_color_has_clear = lifetime.first->color_has_clear;
+                producer.first_color_clear_word0 = lifetime.first->color_clear_word0;
+                producer.first_color_clear_word1 = lifetime.first->color_clear_word1;
+                producer.first_color_control = lifetime.first->color_control;
+                producer.first_color_control_mode =
+                    (lifetime.first->color_control >> 4) & 0x7u;
+                producer.first_target_mask = lifetime.first->target_mask;
+                producer.first_color_format = lifetime.first->color_format;
+            }
+            const RuntimeTargetWrite* match = lifetime.last
+                ? lifetime.last : history.latest_overlap(leaf.access.addr, leaf.access.size);
+            if (match) {
                 producer.resolved = true;
                 producer.producer_submit_no = match->submit_no;
                 producer.producer_draw_index = match->draw_index;
@@ -860,6 +1032,19 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                              static_cast<unsigned long long>(producer.producer_command_order),
                              static_cast<unsigned long long>(producer.producer_target_addr),
                              producer.producer_width, producer.producer_height);
+            if (lifetime.first)
+                std::fprintf(stderr, " lifetime=%llu..%llu submits=%llu writes=%llu "
+                                     "lifetime-truncated=%s window-truncated=%s "
+                                     "first-clear=%s mode=%u mask=0x%x fmt=%u",
+                             static_cast<unsigned long long>(producer.history_first_submit_no),
+                             static_cast<unsigned long long>(producer.producer_submit_no),
+                             static_cast<unsigned long long>(producer.history_submit_count),
+                             static_cast<unsigned long long>(producer.history_write_count),
+                             producer.lifetime_truncated ? "yes" : "no",
+                             producer.history_window_truncated ? "yes" : "no",
+                             producer.first_color_has_clear ? "programmed" : "absent",
+                             producer.first_color_control_mode, producer.first_target_mask,
+                             producer.first_color_format);
             std::fprintf(stderr, "\n");
         }
     } else {

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -57,6 +57,14 @@ struct GpuTimelineDetail {
     uint64_t resource_bytes = 0;
 };
 
+enum class GpuTimelineWriterKind : uint32_t {
+    Unknown = 0,
+    Graphics = 1,
+    Compute = 2,
+    DmaData = 3,
+    WriteData = 4,
+};
+
 struct GpuTimelineProducer {
     uint64_t sequence = 0;
     uint64_t elapsed_ns = 0;
@@ -74,6 +82,22 @@ struct GpuTimelineProducer {
     uint64_t producer_target_addr = 0;
     uint32_t producer_width = 0;
     uint32_t producer_height = 0;
+    GpuTimelineWriterKind first_writer_kind = GpuTimelineWriterKind::Unknown;
+    uint64_t history_first_submit_no = 0;
+    uint64_t history_first_draw_index = 0;
+    uint64_t history_first_command_order = 0;
+    uint64_t history_write_count = 0;
+    uint64_t history_submit_count = 0;
+    uint64_t history_window_first_submit_no = 0;
+    bool lifetime_truncated = false;
+    bool history_window_truncated = false;
+    bool first_color_has_clear = false;
+    uint32_t first_color_clear_word0 = 0;
+    uint32_t first_color_clear_word1 = 0;
+    uint32_t first_color_control = 0;
+    uint32_t first_color_control_mode = 0;
+    uint32_t first_target_mask = 0;
+    uint32_t first_color_format = 0;
 };
 
 struct GpuTimelineFile {

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -59,6 +59,15 @@ int main() {
     producer.producer_submit_no = 9; producer.producer_draw_index = 13;
     producer.producer_command_order = 380; producer.producer_target_addr = 0x700000;
     producer.producer_width = 642; producer.producer_height = 362;
+    producer.first_writer_kind = GpuTimelineWriterKind::Graphics;
+    producer.history_first_submit_no = 2; producer.history_first_draw_index = 7;
+    producer.history_first_command_order = 80; producer.history_write_count = 31;
+    producer.history_submit_count = 8; producer.history_window_first_submit_no = 1;
+    producer.lifetime_truncated = true; producer.history_window_truncated = true;
+    producer.first_color_has_clear = true; producer.first_color_clear_word0 = 0x11223344;
+    producer.first_color_clear_word1 = 0x55667788; producer.first_color_control = 0x60;
+    producer.first_color_control_mode = 6; producer.first_target_mask = 0xf;
+    producer.first_color_format = 10;
     CHECK(writer.append_producer(producer, error), "writer appends a prior-producer identity");
     GpuTimelineSubmit second = first;
     second.submit_no = 11; second.draw_count = 4; second.dispatch_count = 0;
@@ -72,7 +81,7 @@ int main() {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.version == 3 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+    CHECK(timeline.version == 4 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
           timeline.details.size() == 1 && timeline.producers.size() == 1,
           "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
@@ -90,7 +99,14 @@ int main() {
     CHECK(timeline.producers[0].resolved && timeline.producers[0].consumer_operation == 19 &&
           timeline.producers[0].producer_submit_no == 9 &&
           timeline.producers[0].producer_command_order == 380 &&
-          timeline.producers[0].resource_width == 642,
+          timeline.producers[0].resource_width == 642 &&
+          timeline.producers[0].history_first_submit_no == 2 &&
+          timeline.producers[0].history_write_count == 31 &&
+          timeline.producers[0].first_writer_kind == GpuTimelineWriterKind::Graphics &&
+          timeline.producers[0].lifetime_truncated &&
+          timeline.producers[0].history_window_truncated &&
+          timeline.producers[0].first_color_has_clear &&
+          timeline.producers[0].first_color_clear_word1 == 0x55667788,
           "prior-producer resource and writer identities round-trip");
 
     std::ifstream input(good, std::ios::binary);

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -75,19 +75,25 @@ warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
 version-5 capsules deduplicate content-addressed shader/resource versions and retain mixed draw/dispatch
 order plus explicit unrealized operations. Selection is intentionally bounded to the consumer and an optional
-immediate predecessor; automatic recursive cross-submit producer closure remains #595.
-Timeline version 3 retains lightweight graphics-target summaries for the previous 64 submits when a
-detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises that bounded window to at most
-4096. Producer records resolve temporal image leaves to the latest overlapping prior submit/draw/PM4
-order, or state `unresolved`; they intentionally do not retain delayed pointers to mutable guest bytes.
+immediate predecessor. Explicit-depth `.prgbundle` capture provides bounded recursive cross-submit closure;
+automatic present-to-producer selection remains #595.
+Timeline version 4 retains a sliding graphics-target window plus full-run aggregate lifetime metadata when a
+detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises the sliding window to at most 65536.
+Producer records identify the latest overlapping prior submit/draw/PM4 order, earliest observed graphics
+writer, write/submit counts, truncation, and raw first-writer clear/target state. Raw clear registers are
+provenance, not proof of an implicit hardware clear. The timeline intentionally retains no delayed pointers
+to mutable guest bytes.
 Set `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>.prgcap` to snapshot exact submit `N-1` at producer
 time alongside selected submit `N`. Replay the pair with `gpu_replay --prepend producer consumer output`.
 This is a one-level probe; graph the producer and recurse when it also reads a temporal version.
 For bounded recursion, add `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>.prgbundle`,
-`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=2..16`, and optionally
+`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=2..2048`, and optionally
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=64..4096` (default 1024). `gpu_replay --bundle bundle output`
 executes the ordered window and classifies each temporal frontier as included, seeded, or depth-bounded.
 Bundles use content-defined chunks so shifted capture metadata does not defeat cross-submit deduplication.
+`PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM=WxH` restricts predecessor captures to draws targeting that extent;
+it is a size diagnostic, not a dependency proof. `gpu_replay --bundle-zero-boundary` supplies transparent
+pixels to the oldest unseeded temporal leaves for an explicit A/B test and labels the synthetic seeds.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -21,6 +21,7 @@ Create a capsule with the native-speed workflow in
 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/replay.bmp
 ./build-linux/gpu_replay --prepend /tmp/producer.prgcap /tmp/consumer.prgcap /tmp/closure.bmp
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle /tmp/closure.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-zero-boundary /tmp/zero-ab.bmp
 ```
 
 ## Reading graph output
@@ -75,15 +76,28 @@ The summary reports logical versus unique bytes, per-submit output hashes, and e
 A successful replay with `configured-bound` is an explicitly partial closure, not a faithful pixel oracle.
 Bundle files use `.prgbundle`, contain title-derived data, are gitignored, and must not be committed.
 
+`--bundle-zero-boundary` is an A/B diagnostic. It supplies transparent RGBA pixels for unseeded temporal
+image leaves at the oldest bundled submit, labels them `diagnostic-zero-seed`, and leaves the bundle unchanged.
+It can disprove stale guest backing versus zero initialization as the cause of a mismatch, but it is not a
+faithful replacement for the missing producer history.
+
 ## Current Dead Cells reference
 
-The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. A timeline-v3
-run resolved both to submit 18,749: draw 45 / PM4 order 9,436,927 and draw 41 / PM4 order 9,436,871. The
-resource addresses and even semantic operation ordinals are run-local observations, not title constants.
-Recompute them from each new capsule and timeline; never hardcode them into renderer behavior.
+The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. Timeline-v4
+full-run aggregation shows that both surfaces begin around submit 17,400 in current runs and are rewritten
+about 1,200-1,350 times before the selected submit. Their first observed graphics writers have programmed
+clear state, color mode 0, target mask `0xf`, and color format 10. These are raw register observations, not
+proof that hardware performed an implicit clear. Resource addresses, submit numbers, and semantic operation
+ordinals vary between runs; recompute them and never hardcode them into renderer behavior.
 
 A same-run depth-16 bundle for submits 18,735..18,750 resolved all 30 internal temporal edges and reported
 exactly two 642x362 leaves at the configured lower bound. Content-defined dedup stored 2.883 GiB of logical
 capsules in 166.3 MiB (5.8%). No initialized RTT seed appeared in that window, and even/odd depths alternate
-between the dark and overbright failure. The tool is working; faithful Dead Cells closure still requires the
-earlier initialization version rather than an arbitrary depth or title-specific fallback.
+between the dark and overbright failure. Supplying transparent zero to those two lower-bound leaves produces
+the same final hash (`62a46f15efa52a26`) as unseeded replay, so stale guest backing versus transparent
+initialization is not the cause in this window.
+
+Capturing only 642x362-target predecessor draws still costs about 150 MiB per submit because repeated static
+fragment resources include 64, 32, and 16 MiB textures. A 1,200-submit brute-force bundle is therefore not a
+practical next step. The next tooling boundary is an exact shared-resource dictionary or equivalently proven
+unchanged-resource reuse across submits; mutable versions must never be reused from address identity alone.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -26,7 +26,7 @@ bool set_environment(const std::string& name, const std::string& value) {
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] "
-                         "[--bundle capture.prgbundle] "
+                         "[--bundle capture.prgbundle] [--bundle-zero-boundary] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-shader DRAW:vs|fs PATH] "
@@ -291,7 +291,7 @@ bool ranges_overlap(uint64_t a, uint64_t as, uint64_t b, uint64_t bs) {
     return a < range_end(b, bs) && b < range_end(a, as);
 }
 
-int replay_bundle(const std::string& path, const char* output_path) {
+int replay_bundle(const std::string& path, const char* output_path, bool zero_boundary) {
     prosper::gpu::GpuCaptureBundle bundle;
     std::string error;
     if (!prosper::gpu::read_gpu_capture_bundle(path, bundle, error)) {
@@ -344,6 +344,36 @@ int replay_bundle(const std::string& path, const char* output_path) {
                          static_cast<unsigned long long>(capture.metadata.submit_index), error.c_str());
             return 2;
         }
+        std::vector<uint64_t> diagnostic_zero_seeds;
+        if (i == 0 && zero_boundary) {
+            for (const auto& leaf : graph.external_leaves) {
+                if (leaf.first_future_writer == UINT32_MAX || !leaf.access.addr ||
+                    !leaf.access.width || !leaf.access.height ||
+                    (leaf.access.resource_class != prosper::gpu::ResourceClass::Texture &&
+                     leaf.access.resource_class != prosper::gpu::ResourceClass::StorageImage) ||
+                    std::any_of(replay.rtt_seeds.begin(), replay.rtt_seeds.end(), [&](const auto& seed) {
+                        return seed.guest_addr == leaf.access.addr;
+                    })) continue;
+                prosper::gpu::GpuCaptureRttSeed seed;
+                seed.guest_addr = leaf.access.addr;
+                seed.width = leaf.access.width; seed.height = leaf.access.height;
+                const uint64_t seed_bytes = static_cast<uint64_t>(seed.width) * seed.height * 4;
+                constexpr uint64_t kMaxDiagnosticSeedBytes = 1ull << 30;
+                if (seed_bytes > kMaxDiagnosticSeedBytes || seed_bytes > SIZE_MAX) {
+                    std::fprintf(stderr,
+                                 "[gpureplay] skip oversized diagnostic zero seed addr=%016llx "
+                                 "dims=%ux%u bytes=%llu\n",
+                                 static_cast<unsigned long long>(seed.guest_addr), seed.width, seed.height,
+                                 static_cast<unsigned long long>(seed_bytes));
+                    continue;
+                }
+                seed.rgba.resize(static_cast<size_t>(seed_bytes), 0);
+                replay.rtt_seeds.push_back(std::move(seed));
+                diagnostic_zero_seeds.push_back(leaf.access.addr);
+            }
+            std::fprintf(stderr, "[gpureplay] diagnostic zero-boundary seeds=%zu\n",
+                         diagnostic_zero_seeds.size());
+        }
         for (const auto& leaf : graph.external_leaves) {
             if (leaf.first_future_writer == UINT32_MAX ||
                 (leaf.access.resource_class != prosper::gpu::ResourceClass::Texture &&
@@ -359,7 +389,10 @@ int replay_bundle(const std::string& path, const char* output_path) {
             if (producer != prior_targets.rend()) {
                 stop = "included-producer"; producer_submit = producer->submit; ++temporal_resolved;
             } else if (seed != replay.rtt_seeds.end()) {
-                stop = "initialized-seed"; ++temporal_seeded;
+                stop = std::find(diagnostic_zero_seeds.begin(), diagnostic_zero_seeds.end(),
+                                 leaf.access.addr) != diagnostic_zero_seeds.end()
+                    ? "diagnostic-zero-seed" : "initialized-seed";
+                ++temporal_seeded;
             } else {
                 if (i == 0) ++temporal_bounded;
                 else ++temporal_unresolved;
@@ -416,7 +449,7 @@ int replay_bundle(const std::string& path, const char* output_path) {
 
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
-    bool graph_only = false;
+    bool graph_only = false, bundle_zero_boundary = false;
     int draw_first = -1, draw_last = -1;
     std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path, bundle_path;
     std::vector<const char*> positional;
@@ -430,6 +463,7 @@ int main(int argc, char** argv) {
         }
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
         else if (std::string(argv[i]) == "--bundle" && i + 1 < argc) bundle_path = argv[++i];
+        else if (std::string(argv[i]) == "--bundle-zero-boundary") bundle_zero_boundary = true;
         else if (std::string(argv[i]) == "--prepend" && i + 1 < argc) prepend_path = argv[++i];
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
             std::string range = argv[++i]; size_t colon = range.find(':');
@@ -449,8 +483,10 @@ int main(int argc, char** argv) {
             draw_first >= 0 || !dump_spec.empty() || !shader_spec.empty() || !prepend_path.empty()) {
             usage(argv[0]); return 2;
         }
-        return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0]);
+        return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
+                             bundle_zero_boundary);
     }
+    if (bundle_zero_boundary) { usage(argv[0]); return 2; }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
     prosper::gpu::GpuCaptureFile capture; std::string error;
     if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -72,10 +72,16 @@ variables are set.
 
 ## Current boundary
 
-Version 3 remains backward-compatible with version-1 and version-2 indexes. When detailed capture is
+Version 4 remains backward-compatible with version-1 through version-3 indexes. For every selected temporal
+image leaf it adds an online full-run target lifetime: earliest/latest graphics writer, matching writes and
+submits, retained-window start, independent lifetime/window truncation flags, and the earliest writer's raw
+clear words, color-control mode, target mask, and format. Lifetime aggregation is keyed by target range, so
+memory scales with distinct surfaces rather than draw count.
+
+Version 3 added bounded latest-writer history. When detailed capture is
 enabled, it retains lightweight target-writer summaries for the previous 64 submits and records the
 latest same-run writer identity for every temporal image leaf in the selected capsule. Set
-`PROSPER_GPU_TIMELINE_HISTORY=N` to change that bounded window (maximum 4096). A producer record includes
+`PROSPER_GPU_TIMELINE_HISTORY=N` to change that bounded window (maximum 65536). A producer record includes
 the consumer submit/operation/range, the in-submit future writer, and either the matched prior graphics
 submit/draw/PM4 order/target extent or an explicit unresolved result.
 
@@ -100,8 +106,13 @@ producer time in the same run and links both capsules with ordinary detail recor
 one-level closure probe; if the predecessor graph has temporal leaves, capture must recurse further.
 
 For a recursive probe, `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>` captures the selected submit and
-`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=N` contiguous submits ending there (2..16). Captures are serialized at
+`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=N` contiguous submits ending there (2..2048). Captures are serialized at
 producer time and folded immediately into content-defined, checksummed chunks; no retained `GpuState` or
 standalone predecessor files are used. `PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=N` bounds unique chunk
 data to 64..4096 MiB (default 1024) and aborts bundle installation if exhausted. The selected standalone
 `.prgcap` remains the graph/oracle reference and is currently required with the bundle.
+
+`PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM=WxH` restricts predecessor bundle submits to graphics draws for
+matching target extents while leaving the selected consumer complete. This is a capture-volume diagnostic,
+not renderer substitution. It may still be expensive when relevant passes reference large shared assets;
+unique-byte budget enforcement remains authoritative.

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -9,6 +9,16 @@
 
 using namespace prosper::gpu;
 
+const char* writer_kind_name(GpuTimelineWriterKind kind) {
+    switch (kind) {
+        case GpuTimelineWriterKind::Graphics: return "graphics";
+        case GpuTimelineWriterKind::Compute: return "compute";
+        case GpuTimelineWriterKind::DmaData: return "dma-data";
+        case GpuTimelineWriterKind::WriteData: return "write-data";
+        default: return "unknown";
+    }
+}
+
 int main(int argc, char** argv) {
     if (argc < 2 || argc > 3 || (argc == 3 && std::string(argv[2]) != "--records")) {
         std::fprintf(stderr, "usage: gpu_timeline <capture.prgtl> [--records]\n");
@@ -58,7 +68,11 @@ int main(int argc, char** argv) {
                     detail.capture_path.c_str());
     for (const auto& producer : timeline.producers)
         std::printf("producer consumer=%llu/op%u resource=%016llx/%ux%u -> %s"
-                    " submit=%llu draw=%llu order=%llu target=%016llx/%ux%u\n",
+                    " submit=%llu draw=%llu order=%llu target=%016llx/%ux%u "
+                    "lifetime=%llu..%llu submits=%llu writes=%llu window-first=%llu "
+                    "lifetime-truncated=%s window-truncated=%s "
+                    "first-kind=%s first-draw=%llu first-order=%llu clear=%s/%08x:%08x "
+                    "mode=%u mask=%x format=%u\n",
                     static_cast<unsigned long long>(producer.consumer_submit_no),
                     producer.consumer_operation,
                     static_cast<unsigned long long>(producer.resource_addr),
@@ -68,7 +82,21 @@ int main(int argc, char** argv) {
                     static_cast<unsigned long long>(producer.producer_draw_index),
                     static_cast<unsigned long long>(producer.producer_command_order),
                     static_cast<unsigned long long>(producer.producer_target_addr),
-                    producer.producer_width, producer.producer_height);
+                    producer.producer_width, producer.producer_height,
+                    static_cast<unsigned long long>(producer.history_first_submit_no),
+                    static_cast<unsigned long long>(producer.producer_submit_no),
+                    static_cast<unsigned long long>(producer.history_submit_count),
+                    static_cast<unsigned long long>(producer.history_write_count),
+                    static_cast<unsigned long long>(producer.history_window_first_submit_no),
+                    producer.lifetime_truncated ? "yes" : "no",
+                    producer.history_window_truncated ? "yes" : "no",
+                    writer_kind_name(producer.first_writer_kind),
+                    static_cast<unsigned long long>(producer.history_first_draw_index),
+                    static_cast<unsigned long long>(producer.history_first_command_order),
+                    producer.first_color_has_clear ? "programmed" : "absent",
+                    producer.first_color_clear_word0, producer.first_color_clear_word1,
+                    producer.first_color_control_mode, producer.first_target_mask,
+                    producer.first_color_format);
 
     if (argc == 3) {
         size_t si = 0, pi = 0, di = 0, xi = 0;
@@ -108,14 +136,24 @@ int main(int argc, char** argv) {
             } else {
                 const auto& x = timeline.producers[xi++];
                 std::printf("%llu %.6f producer consumer=%llu/op%u resource=%016llx/%ux%u "
-                            "future=%u resolved=%s submit=%llu draw=%llu order=%llu\n",
+                            "future=%u resolved=%s submit=%llu draw=%llu order=%llu "
+                            "lifetime=%llu..%llu/%llu writes=%llu window=%llu "
+                            "lifetime-truncated=%s window-truncated=%s kind=%s\n",
                             static_cast<unsigned long long>(x.sequence), x.elapsed_ns / 1e9,
                             static_cast<unsigned long long>(x.consumer_submit_no), x.consumer_operation,
                             static_cast<unsigned long long>(x.resource_addr), x.resource_width,
                             x.resource_height, x.future_writer_operation, x.resolved ? "yes" : "no",
                             static_cast<unsigned long long>(x.producer_submit_no),
                             static_cast<unsigned long long>(x.producer_draw_index),
-                            static_cast<unsigned long long>(x.producer_command_order));
+                            static_cast<unsigned long long>(x.producer_command_order),
+                            static_cast<unsigned long long>(x.history_first_submit_no),
+                            static_cast<unsigned long long>(x.producer_submit_no),
+                            static_cast<unsigned long long>(x.history_submit_count),
+                            static_cast<unsigned long long>(x.history_write_count),
+                            static_cast<unsigned long long>(x.history_window_first_submit_no),
+                            x.lifetime_truncated ? "yes" : "no",
+                            x.history_window_truncated ? "yes" : "no",
+                            writer_kind_name(x.first_writer_kind));
             }
         }
     }


### PR DESCRIPTION
## Summary

- bump GPU timelines to v4 with full-run target lifetime aggregates, earliest/latest graphics-writer identities, write counts, truncation state, and raw first-writer clear/target registers
- add target-extent predecessor bundle capture and raise the explicit bundle depth limit to 2048
- add `gpu_replay --bundle-zero-boundary` for transparent lower-bound A/B diagnostics
- document the Dead Cells lifetime and capture-volume evidence across the project/tool guides

## Dead Cells result

The two persistent 642x362 surfaces begin around submit 17,400 in current runs and accumulate roughly 1,200-1,350 writes before gameplay submit 18,750. Transparent zero at the depth-16 lower bound produces the exact unseeded final hash (`62a46f15efa52a26`), so a simple clear value is not the missing state.

Target-extent capture still costs about 150 MiB per predecessor because large static fragment resources repeat. #606 tracks exact shared-resource reuse needed to retain the complete rendered history without a hundreds-of-GiB capture.

## Validation

- full Linux build
- `ctest --output-on-failure -j8`: 91/91 passed
- current depth-16 Dead Cells bundle replayed with two diagnostic zero seeds; 30 temporal edges resolved and final hash `62a46f15efa52a26`

Closes #604
Follow-up: #606