### PR TITLE
gpu: scale exact temporal capture bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,12 @@ all 30 internal temporal edges in submits 18735..18750 while storing 2.883 GiB l
 the earliest submit still has two unseeded 642x362 leaves. Full-run aggregation places their first observed
 graphics writers around submit 17,400 and records roughly 1,200-1,350 writes before the selected submit (#604).
 A transparent-zero boundary A/B yields the exact unseeded hash, so zero initialization is not the missing state.
-Target-extent filtering still captures about 150 MiB per submit because large static textures repeat. Build
-exact shared-resource reuse for long bundles instead of brute-forcing depth or adding a dimension fallback.
+Bundle v2 (#606) now uses fault-safe bulk guest reads plus an exact shared-resource chunk dictionary: a fixed
+1,200-submit full-state run folded 122.97 GiB into 301.1 MiB in 169.4 seconds. Semantic endpoints, rolling
+windows, successful-only exit, final compaction, and `gpu_replay --bundle-tail` prevent timing drift and replay
+holes. A compact two-submit closure resolves both 642x362 edges with no bounded leaves, but its 80-draw endpoint
+is the opening vignette rather than gameplay. Define a stable playable checkpoint and isolate the first bad
+composition under #608 instead of guessing another submit ordinal.
 Addresses and operation ordinals are run-local. The stale exact Dead Cells snapshot baseline is
 tracked separately in #596 and must not be silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with

--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ accepts scripted gamepad input, and renders the first level.
 - 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
   first playable scene. Graphics and compute now execute by retained PM4 order (#584), fixing a proven
   future-read. The formerly overbright screenshot was traced to a diagnostic warmup skipping temporal RTT
-  producers; producer-preserving runs render real opening geometry, with a practical late checkpoint next (#586).
+  producers. Versioned offline bundles now retain long, exact cross-submit resource history and replay a
+  minimized closure; a stable semantic checkpoint for the first playable composition remains #608.
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **87 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **91 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -44,12 +44,11 @@ possible without console keys. Dumps are user-supplied and gitignored.
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Active frontiers:** retain the long history for Dead Cells' two temporal 642×362 surfaces
-  (#595/#586/#604). Timeline-v4 aggregation places their first observed graphics writers around submit 17,400,
-  roughly 1,200-1,350 writes before the selected gameplay submit. A transparent-zero lower-bound A/B produces
-  the exact unseeded replay hash, ruling out stale backing versus zero initialization in the depth-16 window.
-  Extent-filtered captures still cost about 150 MiB per submit due to repeated large static textures, so the
-  next tooling boundary is exact shared-resource reuse across a long bundle rather than brute-force capture.
+- 🚧 **Active frontiers:** bundle v2 makes long Dead Cells history practical with exact shared-resource
+  chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
+  run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal
+  642×362 edges without bounded leaves, but the first 80-draw semantic endpoint is the opening vignette rather
+  than playable gameplay. #608 tracks a stable playable checkpoint and the first bad world-composition draw.
   The stale exact Dead Cells
   snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -16,6 +16,9 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
   roots on current master and reaches the controllable Jump tutorial. The
   route is wall-clock anchored because Dead Cells submits tens of thousands of
   loading flips before the menu.
+- `reach-first-gameplay-capture.pad`: uses the same menu input but holds Circle from
+  28 through 300 seconds. Use it when synchronous timeline/bundle capture begins during
+  level loading; the ordinary six-second hold can expire while capture stalls GPU progress.
 
 The long renderer warmup makes this route practical under llvmpipe, but it can
 skip temporal GPU producers. The former post-warmup fullscreen-white image was

--- a/prosper/scripts/dead-cells/reach-first-gameplay-capture.pad
+++ b/prosper/scripts/dead-cells/reach-first-gameplay-capture.pad
@@ -1,0 +1,7 @@
+# Dead Cells (PPSA15552): capture-safe variant of reach-first-gameplay.pad.
+# Long synchronous GPU bundle captures begin during level loading, so keep Circle
+# held until after the capture window instead of relying on the normal 28-34s hold.
+11:cross
+14:cross
+17:cross
+28-300:circle

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1,3 +1,9 @@
+#ifndef _WIN32
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#endif
+
 #include "gpu_capture.hpp"
 
 #include "bc_decode.hpp"
@@ -16,6 +22,11 @@
 #include <map>
 #include <unordered_set>
 #include <utility>
+
+#ifdef __linux__
+#include <sys/uio.h>
+#include <unistd.h>
+#endif
 
 namespace prosper::gpu {
 namespace {
@@ -36,6 +47,31 @@ constexpr uint64_t kMaxTotalRttSeedBytes = 1ull << 30;
 
 CaptureRttSeedReader g_rtt_seed_reader;
 ReplayRttSeedWriter g_rtt_seed_writer;
+
+size_t read_capture_guest_memory(uint64_t addr, uint8_t* dst, size_t bytes) {
+#ifdef __linux__
+    size_t done = 0;
+    while (done < bytes) {
+        iovec local{dst + done, bytes - done};
+        iovec remote{reinterpret_cast<void*>(static_cast<uintptr_t>(addr + done)), bytes - done};
+        const ssize_t read = process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
+        if (read < 0 && errno == EINTR) continue;
+        if (read <= 0) break;
+        done += static_cast<size_t>(read);
+    }
+    return done;
+#else
+    size_t done = 0;
+    constexpr size_t chunk_max = 0x10000;
+    while (done < bytes) {
+        const size_t n = std::min(bytes - done, chunk_max);
+        if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
+        std::memcpy(dst + done, reinterpret_cast<const void*>(static_cast<uintptr_t>(addr + done)), n);
+        done += n;
+    }
+    return done;
+#endif
+}
 
 struct Writer {
     std::vector<uint8_t> data;
@@ -433,23 +469,12 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              GpuCaptureFile& out, std::string& error) {
     std::vector<DrawItem> draws = realize_gpustate_draws(state);
     std::vector<ComputeItem> computes = realize_compute_dispatches(state, submit_no);
-    auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
-        size_t done = 0;
-        constexpr size_t chunk_max = 0x10000;
-        while (done < bytes) {
-            const size_t n = std::min(bytes - done, chunk_max);
-            if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
-            std::memcpy(dst + done, reinterpret_cast<const void*>(uintptr_t(addr + done)), n);
-            done += n;
-        }
-        return done;
-    };
     GpuCaptureMetadata actual = metadata;
     actual.width = width;
     actual.height = height;
     actual.submit_index = submit_no;
     return capture_submit_items(draws, computes, plan_submit_operations(state), actual,
-                                reader, out, error, g_rtt_seed_reader);
+                                read_capture_guest_memory, out, error, g_rtt_seed_reader);
 }
 
 bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
@@ -466,20 +491,10 @@ bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
     for (const auto& draw : draws)
         operations.push_back({SubmitOperationKind::Draw, static_cast<size_t>(draw.draw_index),
                               draw.command_order});
-    auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
-        size_t done = 0;
-        constexpr size_t chunk_max = 0x10000;
-        while (done < bytes) {
-            const size_t n = std::min(bytes - done, chunk_max);
-            if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
-            std::memcpy(dst + done, reinterpret_cast<const void*>(uintptr_t(addr + done)), n);
-            done += n;
-        }
-        return done;
-    };
     GpuCaptureMetadata actual = metadata;
     actual.width = width; actual.height = height; actual.submit_index = submit_no;
-    return capture_submit_items(draws, {}, operations, actual, reader, out, error, g_rtt_seed_reader);
+    return capture_submit_items(draws, {}, operations, actual, read_capture_guest_memory,
+                                out, error, g_rtt_seed_reader);
 }
 
 bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes, std::string& error) {
@@ -807,17 +822,9 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
         "PROSPER_TESTLUT", "PROSPER_TESTLUT32"
     };
     for (const char* name : render_env) if (const char* value = std::getenv(name)) m.renderer_env.emplace_back(name, value);
-    auto reader = [](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
-        size_t done = 0; constexpr size_t chunk_max = 0x10000;
-        while (done < bytes) {
-            size_t n = std::min(bytes - done, chunk_max);
-            if (!guest_readable(addr + done, static_cast<uint32_t>(n))) break;
-            std::memcpy(dst + done, reinterpret_cast<const void*>(uintptr_t(addr + done)), n); done += n;
-        }
-        return done;
-    };
     std::string error;
-    if (!capture_draw_items(items, m, reader, pending->capture, error, g_rtt_seed_reader)) {
+    if (!capture_draw_items(items, m, read_capture_guest_memory,
+                            pending->capture, error, g_rtt_seed_reader)) {
         std::fprintf(stderr, "[gpucap] capture failed: %s\n", error.c_str()); return {};
     }
     std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu blobs, %zu RTT seeds -> %s\n",

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -6,20 +6,22 @@
 #include <fstream>
 #include <limits>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace prosper::gpu {
 namespace {
 
 constexpr uint8_t kMagic[8] = {'P', 'R', 'G', 'B', 'N', 'D', 'L', '\0'};
-constexpr uint32_t kVersion = 1;
+constexpr uint32_t kVersion = 2;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxChunks = 1u << 20;
-constexpr uint32_t kMaxSubmits = 2048;
+constexpr uint32_t kMaxSubmits = 4096;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 
 struct Writer {
     std::vector<uint8_t> data;
     void raw(const void* p, size_t n) {
+        if (!n) return;
         const auto* b = static_cast<const uint8_t*>(p); data.insert(data.end(), b, b + n);
     }
     void u32(uint32_t v) {
@@ -85,12 +87,130 @@ size_t content_chunk_size(const std::vector<uint8_t>& bytes, size_t offset, size
     return available;
 }
 
+bool append_chunks(GpuCaptureBundle& bundle, const std::vector<uint8_t>& bytes,
+                   std::vector<uint32_t>& indices, std::string& error) {
+    auto& by_hash = bundle.chunk_indices_by_hash;
+    if (by_hash.empty() && !bundle.chunks.empty()) {
+        by_hash.reserve(bundle.chunks.size());
+        for (uint32_t i = 0; i < bundle.chunks.size(); ++i)
+            by_hash[bundle.chunk_hashes[i]].push_back(i);
+    }
+    for (size_t offset = 0; offset < bytes.size();) {
+        const size_t size = content_chunk_size(bytes, offset, bundle.chunk_bytes);
+        std::vector<uint8_t> chunk(bytes.begin() + offset, bytes.begin() + offset + size);
+        const uint64_t hash = gpu_capture_hash(chunk);
+        uint32_t index = UINT32_MAX;
+        auto found = by_hash.find(hash);
+        if (found != by_hash.end())
+            for (uint32_t candidate : found->second)
+                if (candidate < bundle.chunks.size() && bundle.chunks[candidate] == chunk) {
+                    index = candidate;
+                    break;
+                }
+        if (index == UINT32_MAX) {
+            if (bundle.chunks.size() >= kMaxChunks) {
+                error = "bundle chunk count exceeds limit";
+                return false;
+            }
+            index = static_cast<uint32_t>(bundle.chunks.size());
+            bundle.chunk_hashes.push_back(hash);
+            bundle.chunks.push_back(std::move(chunk));
+            by_hash[hash].push_back(index);
+        }
+        indices.push_back(index);
+        offset += size;
+    }
+    return true;
+}
+
+bool resource_equals(const GpuCaptureBundle& bundle, const GpuCaptureBundleResource& resource,
+                     const std::vector<uint8_t>& bytes) {
+    if (resource.logical_bytes != bytes.size()) return false;
+    size_t offset = 0;
+    for (uint32_t index : resource.chunk_indices) {
+        if (index >= bundle.chunks.size() || bundle.chunks[index].size() > bytes.size() - offset ||
+            !std::equal(bundle.chunks[index].begin(), bundle.chunks[index].end(), bytes.begin() + offset))
+            return false;
+        offset += bundle.chunks[index].size();
+    }
+    return offset == bytes.size();
+}
+
+uint64_t resource_hash(const GpuCaptureBundle& bundle,
+                       const GpuCaptureBundleResource& resource, bool& valid) {
+    uint64_t hash = 1469598103934665603ull;
+    uint64_t bytes = 0;
+    valid = true;
+    for (uint32_t index : resource.chunk_indices) {
+        if (index >= bundle.chunks.size() || bytes > UINT64_MAX - bundle.chunks[index].size()) {
+            valid = false;
+            return 0;
+        }
+        for (uint8_t byte : bundle.chunks[index]) {
+            hash ^= byte;
+            hash *= 1099511628211ull;
+        }
+        bytes += bundle.chunks[index].size();
+    }
+    valid = bytes == resource.logical_bytes;
+    return hash;
+}
+
+GpuCaptureFile make_capture_manifest(const GpuCaptureFile& capture) {
+    GpuCaptureFile manifest;
+    manifest.metadata = capture.metadata;
+    manifest.expected_output_hash = capture.expected_output_hash;
+    manifest.expected_output_bytes = capture.expected_output_bytes;
+    manifest.expected_output_valid = capture.expected_output_valid;
+    manifest.rtt_seeds = capture.rtt_seeds;
+    manifest.shader_versions = capture.shader_versions;
+    manifest.draws = capture.draws;
+    manifest.computes = capture.computes;
+    manifest.operations = capture.operations;
+    manifest.blobs.resize(capture.blobs.size());
+    const uint64_t empty_hash = gpu_capture_hash(nullptr, 0);
+    for (size_t i = 0; i < capture.blobs.size(); ++i) {
+        manifest.blobs[i].guest_addr = capture.blobs[i].guest_addr;
+        manifest.blobs[i].content_hash = empty_hash;
+    }
+    return manifest;
+}
+
 } // namespace
 
 uint64_t gpu_capture_bundle_unique_bytes(const GpuCaptureBundle& bundle) {
     uint64_t total = 0;
-    for (const auto& chunk : bundle.chunks) total += chunk.size();
+    for (const auto& chunk : bundle.chunks) {
+        if (total > UINT64_MAX - chunk.size()) return UINT64_MAX;
+        total += chunk.size();
+    }
     return total;
+}
+
+GpuCaptureBundleStats gpu_capture_bundle_stats(const GpuCaptureBundle& bundle) {
+    GpuCaptureBundleStats stats;
+    std::unordered_set<uint32_t> manifest_chunks, referenced_resources, resource_chunks;
+    for (const auto& submit : bundle.submits) {
+        manifest_chunks.insert(submit.chunk_indices.begin(), submit.chunk_indices.end());
+        referenced_resources.insert(submit.blob_resource_indices.begin(),
+                                    submit.blob_resource_indices.end());
+    }
+    for (uint32_t index : referenced_resources)
+        if (index < bundle.resources.size())
+            resource_chunks.insert(bundle.resources[index].chunk_indices.begin(),
+                                   bundle.resources[index].chunk_indices.end());
+    for (uint32_t index : manifest_chunks)
+        if (index < bundle.chunks.size()) stats.manifest_unique_bytes += bundle.chunks[index].size();
+    for (uint32_t index : resource_chunks)
+        if (index < bundle.chunks.size()) stats.resource_unique_bytes += bundle.chunks[index].size();
+    for (const auto& submit : bundle.submits) {
+        stats.resource_reference_count += submit.blob_resource_indices.size();
+        for (uint32_t index : submit.blob_resource_indices)
+            if (index < bundle.resources.size()) stats.resource_logical_bytes += bundle.resources[index].logical_bytes;
+    }
+    stats.exact_reuse_count = stats.resource_reference_count > referenced_resources.size()
+        ? stats.resource_reference_count - referenced_resources.size() : 0;
+    return stats;
 }
 
 bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& capture,
@@ -102,34 +222,111 @@ bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& c
     if (!bundle.submits.empty() && capture.metadata.submit_index <= bundle.submits.back().submit_index) {
         error = "bundle submits must be appended in increasing order"; return false;
     }
-    std::vector<uint8_t> bytes;
-    if (!serialize_gpu_capture(capture, bytes, error)) return false;
+    if (bundle.version != kVersion) {
+        error = "cannot append to a legacy capture bundle";
+        return false;
+    }
+    struct Rollback {
+        GpuCaptureBundle& bundle;
+        size_t chunks;
+        size_t hashes;
+        size_t resources;
+        size_t submits;
+        uint64_t logical_bytes;
+        bool committed = false;
+        ~Rollback() {
+            if (committed) return;
+            bundle.chunks.resize(chunks);
+            bundle.chunk_hashes.resize(hashes);
+            bundle.resources.resize(resources);
+            bundle.submits.resize(submits);
+            bundle.logical_bytes = logical_bytes;
+            bundle.chunk_indices_by_hash.clear();
+            for (uint32_t i = 0; i < bundle.chunks.size(); ++i)
+                bundle.chunk_indices_by_hash[bundle.chunk_hashes[i]].push_back(i);
+            bundle.resource_indices_by_hash.clear();
+            for (uint32_t i = 0; i < bundle.resources.size(); ++i)
+                bundle.resource_indices_by_hash[bundle.resources[i].content_hash].push_back(i);
+        }
+    } rollback{bundle, bundle.chunks.size(), bundle.chunk_hashes.size(), bundle.resources.size(),
+               bundle.submits.size(), bundle.logical_bytes};
     GpuCaptureBundleSubmit submit;
     submit.submit_index = capture.metadata.submit_index;
-    submit.logical_bytes = bytes.size();
-    std::unordered_map<uint64_t, std::vector<uint32_t>> by_hash;
-    by_hash.reserve(bundle.chunks.size());
-    for (uint32_t i = 0; i < bundle.chunks.size(); ++i) by_hash[bundle.chunk_hashes[i]].push_back(i);
-    for (size_t offset = 0; offset < bytes.size();) {
-        const size_t size = content_chunk_size(bytes, offset, bundle.chunk_bytes);
-        std::vector<uint8_t> chunk(bytes.begin() + offset, bytes.begin() + offset + size);
-        const uint64_t hash = gpu_capture_hash(chunk);
-        uint32_t index = UINT32_MAX;
-        auto found = by_hash.find(hash);
-        if (found != by_hash.end())
-            for (uint32_t candidate : found->second)
-                if (bundle.chunks[candidate] == chunk) { index = candidate; break; }
-        if (index == UINT32_MAX) {
-            if (bundle.chunks.size() >= kMaxChunks) { error = "bundle chunk count exceeds limit"; return false; }
-            index = static_cast<uint32_t>(bundle.chunks.size());
-            bundle.chunk_hashes.push_back(hash); bundle.chunks.push_back(std::move(chunk));
-            by_hash[hash].push_back(index);
-        }
-        submit.chunk_indices.push_back(index);
-        offset += size;
+    auto& resources_by_hash = bundle.resource_indices_by_hash;
+    if (resources_by_hash.empty() && !bundle.resources.empty()) {
+        resources_by_hash.reserve(bundle.resources.size());
+        for (uint32_t i = 0; i < bundle.resources.size(); ++i)
+            resources_by_hash[bundle.resources[i].content_hash].push_back(i);
     }
-    bundle.logical_bytes += bytes.size();
+    uint64_t resource_bytes = 0;
+    for (const auto& blob : capture.blobs) {
+        if (blob.bytes_read > blob.bytes.size()) {
+            error = "capture blob readable bytes exceed its content";
+            return false;
+        }
+        uint64_t hash = blob.content_hash;
+        uint32_t index = UINT32_MAX;
+        auto found = resources_by_hash.find(hash);
+        if (found != resources_by_hash.end())
+            for (uint32_t candidate : found->second)
+                if (resource_equals(bundle, bundle.resources[candidate], blob.bytes)) {
+                    index = candidate;
+                    break;
+                }
+        if (index == UINT32_MAX) {
+            const uint64_t actual_hash = gpu_capture_hash(blob.bytes);
+            if (hash && hash != actual_hash) {
+                error = "capture blob content hash mismatch";
+                return false;
+            }
+            hash = actual_hash;
+            found = resources_by_hash.find(hash);
+            if (found != resources_by_hash.end())
+                for (uint32_t candidate : found->second)
+                    if (resource_equals(bundle, bundle.resources[candidate], blob.bytes)) {
+                        index = candidate;
+                        break;
+                    }
+            if (index == UINT32_MAX) {
+                if (bundle.resources.size() >= kMaxChunks) {
+                    error = "bundle resource count exceeds limit";
+                    return false;
+                }
+                index = static_cast<uint32_t>(bundle.resources.size());
+                GpuCaptureBundleResource resource;
+                resource.content_hash = hash;
+                resource.logical_bytes = blob.bytes.size();
+                if (!append_chunks(bundle, blob.bytes, resource.chunk_indices, error)) return false;
+                bundle.resources.push_back(std::move(resource));
+                resources_by_hash[hash].push_back(index);
+            }
+        }
+        submit.blob_resource_indices.push_back(index);
+        submit.blob_bytes_read.push_back(blob.bytes_read);
+        if (resource_bytes > UINT64_MAX - blob.bytes.size()) {
+            error = "bundle submit resource size overflow";
+            return false;
+        }
+        resource_bytes += blob.bytes.size();
+    }
+
+    GpuCaptureFile manifest = make_capture_manifest(capture);
+    std::vector<uint8_t> bytes;
+    if (!serialize_gpu_capture(manifest, bytes, error)) return false;
+    submit.manifest_bytes = bytes.size();
+    if (submit.manifest_bytes > UINT64_MAX - resource_bytes) {
+        error = "bundle submit logical size overflow";
+        return false;
+    }
+    submit.logical_bytes = submit.manifest_bytes + resource_bytes;
+    if (!append_chunks(bundle, bytes, submit.chunk_indices, error)) return false;
+    if (bundle.logical_bytes > UINT64_MAX - submit.logical_bytes) {
+        error = "bundle logical size overflow";
+        return false;
+    }
+    bundle.logical_bytes += submit.logical_bytes;
     bundle.submits.push_back(std::move(submit));
+    rollback.committed = true;
     return true;
 }
 
@@ -138,22 +335,141 @@ bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_
     error.clear();
     if (submit_index >= bundle.submits.size()) { error = "bundle submit index is out of range"; return false; }
     const auto& submit = bundle.submits[submit_index];
-    if (submit.logical_bytes > std::numeric_limits<size_t>::max()) {
+    const uint64_t serialized_bytes = bundle.version >= 2 ? submit.manifest_bytes : submit.logical_bytes;
+    if (serialized_bytes > std::numeric_limits<size_t>::max()) {
         error = "bundle submit is too large"; return false;
     }
-    std::vector<uint8_t> bytes; bytes.reserve(static_cast<size_t>(submit.logical_bytes));
+    std::vector<uint8_t> bytes; bytes.reserve(static_cast<size_t>(serialized_bytes));
     for (uint32_t index : submit.chunk_indices) {
         if (index >= bundle.chunks.size()) { error = "bundle references an invalid chunk"; return false; }
-        if (bundle.chunks[index].size() > submit.logical_bytes - bytes.size()) {
+        if (bundle.chunks[index].size() > serialized_bytes - bytes.size()) {
             error = "bundle submit chunk sizes exceed the manifest"; return false;
         }
         bytes.insert(bytes.end(), bundle.chunks[index].begin(), bundle.chunks[index].end());
     }
-    if (bytes.size() != submit.logical_bytes) { error = "bundle submit is truncated"; return false; }
+    if (bytes.size() != serialized_bytes) { error = "bundle submit is truncated"; return false; }
     if (!deserialize_gpu_capture(bytes, capture, error)) return false;
+    if (bundle.version >= 2) {
+        if (capture.blobs.size() != submit.blob_resource_indices.size() ||
+            capture.blobs.size() != submit.blob_bytes_read.size()) {
+            error = "bundle submit resource manifest mismatch";
+            return false;
+        }
+        uint64_t logical_bytes = submit.manifest_bytes;
+        for (size_t i = 0; i < capture.blobs.size(); ++i) {
+            const uint32_t resource_index = submit.blob_resource_indices[i];
+            if (resource_index >= bundle.resources.size()) {
+                error = "bundle references an invalid resource";
+                return false;
+            }
+            const auto& resource = bundle.resources[resource_index];
+            if (submit.blob_bytes_read[i] > resource.logical_bytes ||
+                resource.logical_bytes > std::numeric_limits<size_t>::max() ||
+                logical_bytes > UINT64_MAX - resource.logical_bytes) {
+                error = "bundle resource metadata is invalid";
+                return false;
+            }
+            capture.blobs[i].bytes.clear();
+            capture.blobs[i].bytes.reserve(static_cast<size_t>(resource.logical_bytes));
+            for (uint32_t index : resource.chunk_indices) {
+                if (index >= bundle.chunks.size() || bundle.chunks[index].size() >
+                        resource.logical_bytes - capture.blobs[i].bytes.size()) {
+                    error = "bundle resource chunks are invalid";
+                    return false;
+                }
+                capture.blobs[i].bytes.insert(capture.blobs[i].bytes.end(),
+                                              bundle.chunks[index].begin(),
+                                              bundle.chunks[index].end());
+            }
+            if (capture.blobs[i].bytes.size() != resource.logical_bytes ||
+                gpu_capture_hash(capture.blobs[i].bytes) != resource.content_hash) {
+                error = "bundle resource content mismatch";
+                return false;
+            }
+            capture.blobs[i].bytes_read = submit.blob_bytes_read[i];
+            capture.blobs[i].content_hash = resource.content_hash;
+            logical_bytes += resource.logical_bytes;
+        }
+        if (logical_bytes != submit.logical_bytes) {
+            error = "bundle submit logical size mismatch";
+            return false;
+        }
+    }
     if (capture.metadata.submit_index != submit.submit_index) {
         error = "bundle submit identity mismatch"; return false;
     }
+    return true;
+}
+
+bool compact_gpu_capture_bundle(GpuCaptureBundle& bundle, std::string& error) {
+    error.clear();
+    if (bundle.chunk_hashes.size() != bundle.chunks.size()) {
+        error = "bundle chunk hash count mismatch";
+        return false;
+    }
+    std::vector<uint8_t> resource_used(bundle.resources.size(), 0);
+    for (const auto& submit : bundle.submits) {
+        for (uint32_t index : submit.chunk_indices)
+            if (index >= bundle.chunks.size()) {
+                error = "bundle submit references an invalid chunk";
+                return false;
+            }
+        for (uint32_t index : submit.blob_resource_indices) {
+            if (index >= bundle.resources.size()) {
+                error = "bundle submit references an invalid resource";
+                return false;
+            }
+            resource_used[index] = 1;
+        }
+    }
+    for (const auto& resource : bundle.resources)
+        for (uint32_t index : resource.chunk_indices)
+            if (index >= bundle.chunks.size()) {
+                error = "bundle resource references an invalid chunk";
+                return false;
+            }
+
+    std::vector<uint32_t> resource_map(bundle.resources.size(), UINT32_MAX);
+    std::vector<GpuCaptureBundleResource> resources;
+    resources.reserve(std::count(resource_used.begin(), resource_used.end(), uint8_t{1}));
+    for (uint32_t i = 0; i < bundle.resources.size(); ++i) {
+        if (!resource_used[i]) continue;
+        resource_map[i] = static_cast<uint32_t>(resources.size());
+        resources.push_back(std::move(bundle.resources[i]));
+    }
+    for (auto& submit : bundle.submits)
+        for (auto& index : submit.blob_resource_indices) index = resource_map[index];
+
+    std::vector<uint8_t> chunk_used(bundle.chunks.size(), 0);
+    for (const auto& submit : bundle.submits)
+        for (uint32_t index : submit.chunk_indices) chunk_used[index] = 1;
+    for (const auto& resource : resources)
+        for (uint32_t index : resource.chunk_indices) chunk_used[index] = 1;
+    std::vector<uint32_t> chunk_map(bundle.chunks.size(), UINT32_MAX);
+    std::vector<std::vector<uint8_t>> chunks;
+    std::vector<uint64_t> hashes;
+    chunks.reserve(std::count(chunk_used.begin(), chunk_used.end(), uint8_t{1}));
+    hashes.reserve(chunks.capacity());
+    for (uint32_t i = 0; i < bundle.chunks.size(); ++i) {
+        if (!chunk_used[i]) continue;
+        chunk_map[i] = static_cast<uint32_t>(chunks.size());
+        chunks.push_back(std::move(bundle.chunks[i]));
+        hashes.push_back(bundle.chunk_hashes[i]);
+    }
+    for (auto& submit : bundle.submits)
+        for (auto& index : submit.chunk_indices) index = chunk_map[index];
+    for (auto& resource : resources)
+        for (auto& index : resource.chunk_indices) index = chunk_map[index];
+
+    bundle.resources = std::move(resources);
+    bundle.chunks = std::move(chunks);
+    bundle.chunk_hashes = std::move(hashes);
+    bundle.chunk_indices_by_hash.clear();
+    for (uint32_t i = 0; i < bundle.chunks.size(); ++i)
+        bundle.chunk_indices_by_hash[bundle.chunk_hashes[i]].push_back(i);
+    bundle.resource_indices_by_hash.clear();
+    for (uint32_t i = 0; i < bundle.resources.size(); ++i)
+        bundle.resource_indices_by_hash[bundle.resources[i].content_hash].push_back(i);
     return true;
 }
 
@@ -161,10 +477,11 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
                               std::string& error) {
     error.clear();
     if (bundle.chunk_hashes.size() != bundle.chunks.size() || bundle.chunks.size() > kMaxChunks ||
-        bundle.submits.empty() || bundle.submits.size() > kMaxSubmits) {
+        bundle.resources.size() > kMaxChunks || bundle.submits.empty() ||
+        bundle.submits.size() > kMaxSubmits || bundle.version < 1 || bundle.version > kVersion) {
         error = "invalid bundle structure"; return false;
     }
-    Writer writer; writer.raw(kMagic, sizeof(kMagic)); writer.u32(kVersion); writer.u32(kEndian);
+    Writer writer; writer.raw(kMagic, sizeof(kMagic)); writer.u32(bundle.version); writer.u32(kEndian);
     writer.u32(bundle.chunk_bytes); writer.u64(bundle.logical_bytes);
     writer.u32(static_cast<uint32_t>(bundle.chunks.size()));
     for (size_t i = 0; i < bundle.chunks.size(); ++i) {
@@ -172,13 +489,76 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
         if (bundle.chunk_hashes[i] != hash) { error = "bundle chunk hash mismatch"; return false; }
         writer.u64(hash); writer.bytes(bundle.chunks[i]);
     }
+    if (bundle.version >= 2) {
+        writer.u32(static_cast<uint32_t>(bundle.resources.size()));
+        for (const auto& resource : bundle.resources) {
+            bool valid = false;
+            const uint64_t hash = resource_hash(bundle, resource, valid);
+            if (!valid || resource.content_hash != hash) {
+                error = "bundle resource hash mismatch";
+                return false;
+            }
+            writer.u64(hash);
+            writer.u64(resource.logical_bytes);
+            writer.u32(static_cast<uint32_t>(resource.chunk_indices.size()));
+            for (uint32_t index : resource.chunk_indices) {
+                if (index >= bundle.chunks.size()) {
+                    error = "bundle resource references an invalid chunk";
+                    return false;
+                }
+                writer.u32(index);
+            }
+        }
+    }
     writer.u32(static_cast<uint32_t>(bundle.submits.size()));
     for (const auto& submit : bundle.submits) {
+        uint64_t reconstructed_bytes = 0;
+        for (uint32_t index : submit.chunk_indices) {
+            if (index >= bundle.chunks.size() ||
+                reconstructed_bytes > UINT64_MAX - bundle.chunks[index].size()) {
+                error = "bundle references an invalid chunk";
+                return false;
+            }
+            reconstructed_bytes += bundle.chunks[index].size();
+        }
+        const uint64_t expected_manifest_bytes = bundle.version >= 2
+            ? submit.manifest_bytes : submit.logical_bytes;
+        if (reconstructed_bytes != expected_manifest_bytes) {
+            error = "bundle submit manifest size mismatch";
+            return false;
+        }
         writer.u64(submit.submit_index); writer.u64(submit.logical_bytes);
+        if (bundle.version >= 2) writer.u64(submit.manifest_bytes);
         writer.u32(static_cast<uint32_t>(submit.chunk_indices.size()));
         for (uint32_t index : submit.chunk_indices) {
             if (index >= bundle.chunks.size()) { error = "bundle references an invalid chunk"; return false; }
             writer.u32(index);
+        }
+        if (bundle.version >= 2) {
+            if (submit.blob_resource_indices.size() != submit.blob_bytes_read.size()) {
+                error = "bundle resource reference count mismatch";
+                return false;
+            }
+            writer.u32(static_cast<uint32_t>(submit.blob_resource_indices.size()));
+            for (size_t i = 0; i < submit.blob_resource_indices.size(); ++i) {
+                if (submit.blob_resource_indices[i] >= bundle.resources.size()) {
+                    error = "bundle references an invalid resource";
+                    return false;
+                }
+                writer.u32(submit.blob_resource_indices[i]);
+                writer.u64(submit.blob_bytes_read[i]);
+                if (reconstructed_bytes > UINT64_MAX -
+                        bundle.resources[submit.blob_resource_indices[i]].logical_bytes) {
+                    error = "bundle submit logical size overflow";
+                    return false;
+                }
+                reconstructed_bytes +=
+                    bundle.resources[submit.blob_resource_indices[i]].logical_bytes;
+            }
+        }
+        if (reconstructed_bytes != submit.logical_bytes) {
+            error = "bundle submit logical size mismatch";
+            return false;
         }
     }
     const uint64_t manifest_hash = gpu_capture_hash(writer.data);
@@ -206,7 +586,7 @@ bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,
     }
     Reader reader{bytes.data(), bytes.size() - 8}; uint8_t magic[8]; uint32_t version = 0, endian = 0;
     if (!reader.take(magic, 8) || std::memcmp(magic, kMagic, 8) || !reader.u32(version) ||
-        version != kVersion || !reader.u32(endian) || endian != kEndian ||
+        version < 1 || version > kVersion || !reader.u32(endian) || endian != kEndian ||
         !reader.u32(bundle.chunk_bytes) || !bundle.chunk_bytes || bundle.chunk_bytes > (16u << 20) ||
         !reader.u64(bundle.logical_bytes)) {
         error = "unsupported bundle header"; return false;
@@ -221,6 +601,36 @@ bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,
             gpu_capture_hash(bundle.chunks[i]) != bundle.chunk_hashes[i]) {
             error = "invalid bundle chunk"; return false;
         }
+        bundle.chunk_indices_by_hash[bundle.chunk_hashes[i]].push_back(i);
+    }
+    if (version >= 2) {
+        uint32_t resource_count = 0;
+        if (!reader.u32(resource_count) || resource_count > kMaxChunks) {
+            error = "invalid bundle resource count";
+            return false;
+        }
+        bundle.resources.resize(resource_count);
+        for (uint32_t resource_index = 0; resource_index < bundle.resources.size(); ++resource_index) {
+            auto& resource = bundle.resources[resource_index];
+            uint32_t refs = 0;
+            if (!reader.u64(resource.content_hash) || !reader.u64(resource.logical_bytes) ||
+                !reader.u32(refs) || refs > kMaxChunks) {
+                error = "invalid bundle resource";
+                return false;
+            }
+            resource.chunk_indices.resize(refs);
+            for (auto& index : resource.chunk_indices)
+                if (!reader.u32(index) || index >= bundle.chunks.size()) {
+                    error = "invalid bundle resource chunk reference";
+                    return false;
+                }
+            bool valid = false;
+            if (resource_hash(bundle, resource, valid) != resource.content_hash || !valid) {
+                error = "invalid bundle resource content";
+                return false;
+            }
+            bundle.resource_indices_by_hash[resource.content_hash].push_back(resource_index);
+        }
     }
     uint32_t submit_count = 0;
     if (!reader.u32(submit_count) || !submit_count || submit_count > kMaxSubmits) {
@@ -230,10 +640,55 @@ bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,
     for (auto& submit : bundle.submits) {
         uint32_t refs = 0;
         if (!reader.u64(submit.submit_index) || !reader.u64(submit.logical_bytes) ||
+            (version >= 2 && !reader.u64(submit.manifest_bytes)) ||
             !reader.u32(refs) || refs > kMaxChunks) { error = "invalid bundle submit"; return false; }
+        if (version < 2) submit.manifest_bytes = submit.logical_bytes;
         submit.chunk_indices.resize(refs);
         for (auto& index : submit.chunk_indices)
             if (!reader.u32(index) || index >= chunk_count) { error = "invalid bundle chunk reference"; return false; }
+        if (version >= 2) {
+            uint32_t resource_refs = 0;
+            if (!reader.u32(resource_refs) || resource_refs > kMaxChunks) {
+                error = "invalid bundle resource reference count";
+                return false;
+            }
+            submit.blob_resource_indices.resize(resource_refs);
+            submit.blob_bytes_read.resize(resource_refs);
+            for (uint32_t i = 0; i < resource_refs; ++i)
+                if (!reader.u32(submit.blob_resource_indices[i]) ||
+                    submit.blob_resource_indices[i] >= bundle.resources.size() ||
+                    !reader.u64(submit.blob_bytes_read[i]) ||
+                    submit.blob_bytes_read[i] >
+                        bundle.resources[submit.blob_resource_indices[i]].logical_bytes) {
+                    error = "invalid bundle resource reference";
+                    return false;
+                }
+        }
+        uint64_t reconstructed_bytes = 0;
+        for (uint32_t index : submit.chunk_indices) {
+            if (reconstructed_bytes > UINT64_MAX - bundle.chunks[index].size()) {
+                error = "bundle submit manifest size overflow";
+                return false;
+            }
+            reconstructed_bytes += bundle.chunks[index].size();
+        }
+        if (reconstructed_bytes != submit.manifest_bytes) {
+            error = "bundle submit manifest size mismatch";
+            return false;
+        }
+        if (version >= 2) {
+            for (uint32_t index : submit.blob_resource_indices) {
+                if (reconstructed_bytes > UINT64_MAX - bundle.resources[index].logical_bytes) {
+                    error = "bundle submit logical size overflow";
+                    return false;
+                }
+                reconstructed_bytes += bundle.resources[index].logical_bytes;
+            }
+        }
+        if (reconstructed_bytes != submit.logical_bytes) {
+            error = "bundle submit logical size mismatch";
+            return false;
+        }
         if (submit.submit_index <= prior_submit) { error = "bundle submits are not ordered"; return false; }
         prior_submit = submit.submit_index;
         if (logical_total > UINT64_MAX - submit.logical_bytes) { error = "bundle logical size overflow"; return false; }

--- a/prosper/src/gpu/gpu_capture_bundle.hpp
+++ b/prosper/src/gpu/gpu_capture_bundle.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace prosper::gpu {
@@ -12,26 +13,49 @@ namespace prosper::gpu {
 struct GpuCaptureBundleSubmit {
     uint64_t submit_index = 0;
     uint64_t logical_bytes = 0;
+    uint64_t manifest_bytes = 0;
+    std::vector<uint32_t> chunk_indices;
+    std::vector<uint32_t> blob_resource_indices;
+    std::vector<uint64_t> blob_bytes_read;
+};
+
+struct GpuCaptureBundleResource {
+    uint64_t content_hash = 0;
+    uint64_t logical_bytes = 0;
     std::vector<uint32_t> chunk_indices;
 };
 
 struct GpuCaptureBundle {
-    uint32_t version = 1;
+    uint32_t version = 2;
     uint32_t chunk_bytes = 256 * 1024;
     uint64_t logical_bytes = 0;
     std::vector<uint64_t> chunk_hashes;
     std::vector<std::vector<uint8_t>> chunks;
+    std::vector<GpuCaptureBundleResource> resources;
     std::vector<GpuCaptureBundleSubmit> submits;
+    // Runtime append indexes. They are rebuilt on read and are not serialized.
+    std::unordered_map<uint64_t, std::vector<uint32_t>> chunk_indices_by_hash;
+    std::unordered_map<uint64_t, std::vector<uint32_t>> resource_indices_by_hash;
+};
+
+struct GpuCaptureBundleStats {
+    uint64_t manifest_unique_bytes = 0;
+    uint64_t resource_unique_bytes = 0;
+    uint64_t resource_logical_bytes = 0;
+    uint64_t resource_reference_count = 0;
+    uint64_t exact_reuse_count = 0;
 };
 
 bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& capture,
                                std::string& error);
 bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
                                            GpuCaptureFile& capture, std::string& error);
+bool compact_gpu_capture_bundle(GpuCaptureBundle& bundle, std::string& error);
 bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& bundle,
                               std::string& error);
 bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,
                              std::string& error);
 uint64_t gpu_capture_bundle_unique_bytes(const GpuCaptureBundle& bundle);
+GpuCaptureBundleStats gpu_capture_bundle_stats(const GpuCaptureBundle& bundle);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -217,6 +217,10 @@ struct RuntimeDetailRequest {
     uint64_t bundle_max_unique_bytes = 1ull << 30;
     uint32_t bundle_target_width = 0;
     uint32_t bundle_target_height = 0;
+    uint32_t select_target_width = 0;
+    uint32_t select_target_height = 0;
+    uint32_t select_min_draws = 0;
+    bool exit_after_capture = false;
     uint64_t submit_no = 0;
     bool valid = false;
     std::atomic<bool> claimed{false};
@@ -247,8 +251,8 @@ struct RuntimeDetailRequest {
             if (const char* depth = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH")) {
                 char* depth_end = nullptr;
                 const uint64_t value = std::strtoull(depth, &depth_end, 0);
-                if (!depth_end || *depth_end || value < 2 || value > 2048) {
-                    std::fprintf(stderr, "[timeline] capture bundle depth must be 2..2048\n");
+                if (!depth_end || *depth_end || value < 2 || value > 4096) {
+                    std::fprintf(stderr, "[timeline] capture bundle depth must be 2..4096\n");
                     bundle_path.clear(); bundle_depth = 0;
                 } else {
                     bundle_depth = static_cast<uint32_t>(value);
@@ -275,8 +279,34 @@ struct RuntimeDetailRequest {
                 }
             }
         }
+        if (const char* dimensions = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM")) {
+            unsigned width = 0, height = 0; char tail = 0;
+            if (std::sscanf(dimensions, "%ux%u%c", &width, &height, &tail) != 2 ||
+                !width || !height) {
+                std::fprintf(stderr, "[timeline] capture endpoint target dimension must be WxH\n");
+                return;
+            }
+            select_target_width = width;
+            select_target_height = height;
+        }
+        if (const char* min_draws = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS")) {
+            char* min_end = nullptr;
+            const uint64_t value = std::strtoull(min_draws, &min_end, 0);
+            if (!min_end || *min_end || value > UINT32_MAX) {
+                std::fprintf(stderr, "[timeline] capture minimum draws must be 0..4294967295\n");
+                return;
+            }
+            select_min_draws = static_cast<uint32_t>(value);
+        }
+        if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE"))
+            exit_after_capture = *value && std::strcmp(value, "0") && std::strcmp(value, "off");
         submit_no = parsed;
         valid = true;
+        if (select_target_width)
+            std::fprintf(stderr, "[timeline] semantic capture endpoint submit>=%llu "
+                                 "target=%ux%u min-draws=%u\n",
+                         static_cast<unsigned long long>(submit_no), select_target_width,
+                         select_target_height, select_min_draws);
     }
 };
 
@@ -434,11 +464,36 @@ struct RuntimeCaptureBundle {
     GpuCaptureBundle bundle;
     bool budget_exhausted = false;
     bool failed = false;
+    bool started = false;
+    std::chrono::steady_clock::time_point started_at;
+    uint64_t captured_resource_bytes = 0;
 };
 
 RuntimeCaptureBundle& runtime_capture_bundle() {
     static RuntimeCaptureBundle state;
     return state;
+}
+
+bool runtime_capture_endpoint_matches(const RuntimeDetailRequest& request,
+                                      const GpuState& state, uint64_t submit_no) {
+    if (submit_no < request.submit_no) return false;
+    if (!request.select_target_width)
+        return submit_no == request.submit_no;
+    if (state.draws.size() < request.select_min_draws) return false;
+    for (size_t i = 0; i < state.draws.size(); ++i) {
+        const RenderState rs = extract_render_state(state.state_at_draw(i));
+        if (rs.color0_width == request.select_target_width &&
+            rs.color0_height == request.select_target_height)
+            return true;
+    }
+    return false;
+}
+
+void begin_runtime_capture_bundle() {
+    RuntimeCaptureBundle& state = runtime_capture_bundle();
+    if (state.started) return;
+    state.started = true;
+    state.started_at = std::chrono::steady_clock::now();
 }
 
 bool append_runtime_capture_bundle(const GpuCaptureFile& capture, uint64_t max_unique_bytes,
@@ -447,15 +502,30 @@ bool append_runtime_capture_bundle(const GpuCaptureFile& capture, uint64_t max_u
     if (state.budget_exhausted) { error = "capture bundle unique-byte budget was already exhausted"; return false; }
     const size_t chunks = state.bundle.chunks.size();
     const size_t hashes = state.bundle.chunk_hashes.size();
+    const size_t resources = state.bundle.resources.size();
     const size_t submits = state.bundle.submits.size();
     const uint64_t logical = state.bundle.logical_bytes;
     if (!append_gpu_capture_bundle(state.bundle, capture, error)) return false;
-    if (gpu_capture_bundle_unique_bytes(state.bundle) <= max_unique_bytes) return true;
+    if (gpu_capture_bundle_unique_bytes(state.bundle) <= max_unique_bytes) {
+        for (const auto& blob : capture.blobs) state.captured_resource_bytes += blob.bytes.size();
+        return true;
+    }
     state.bundle.chunks.resize(chunks); state.bundle.chunk_hashes.resize(hashes);
+    state.bundle.resources.resize(resources);
     state.bundle.submits.resize(submits); state.bundle.logical_bytes = logical;
+    state.bundle.chunk_indices_by_hash.clear();
+    state.bundle.resource_indices_by_hash.clear();
     state.budget_exhausted = true;
     error = "capture bundle exceeded its unique-byte budget";
     return false;
+}
+
+void trim_runtime_capture_bundle(size_t max_submits) {
+    GpuCaptureBundle& bundle = runtime_capture_bundle().bundle;
+    while (bundle.submits.size() > max_submits) {
+        bundle.logical_bytes -= bundle.submits.front().logical_bytes;
+        bundle.submits.erase(bundle.submits.begin());
+    }
 }
 
 GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
@@ -901,12 +971,15 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
     RuntimeDetailRequest& request = runtime_detail_request();
     RuntimeProducerHistory& history = runtime_producer_history();
+    const bool capture_endpoint = request.valid &&
+        runtime_capture_endpoint_matches(request, state, submit_no);
     const uint64_t bundle_first = request.bundle_depth > request.submit_no
         ? 1 : request.submit_no - request.bundle_depth + 1;
     if (request.valid && !request.bundle_path.empty() &&
         !runtime_capture_bundle().budget_exhausted && !runtime_capture_bundle().failed &&
         submit_no >= bundle_first &&
-        submit_no < request.submit_no) {
+        !capture_endpoint) {
+        begin_runtime_capture_bundle();
         GpuCaptureFile predecessor;
         const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
         const bool captured = request.bundle_target_width
@@ -921,6 +994,8 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             std::fprintf(stderr, "[timeline] bundle submit %llu capture failed: %s\n",
                          static_cast<unsigned long long>(submit_no), error.c_str());
         } else {
+            if (request.select_target_width)
+                trim_runtime_capture_bundle(request.bundle_depth - 1);
             const std::string identity = request.bundle_path + "#submit=" + std::to_string(submit_no);
             const GpuTimelineDetail detail = capture_detail(submit, identity, predecessor);
             if (!writer->append_detail(detail, error)) {
@@ -930,11 +1005,12 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             }
             const uint64_t offset = submit_no - bundle_first;
             if (request.bundle_depth <= 64 || !offset || !(offset % 100) ||
-                submit_no + 1 == request.submit_no)
+                (!request.select_target_width && submit_no + 1 == request.submit_no))
                 log_capture_detail(detail);
         }
     }
-    if (request.valid && !request.predecessor_path.empty() && request.submit_no > 1 &&
+    if (request.valid && !request.select_target_width && !request.predecessor_path.empty() &&
+        request.submit_no > 1 &&
         submit_no == request.submit_no - 1 && !request.predecessor_claimed.exchange(true)) {
         GpuCaptureFile predecessor;
         const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
@@ -953,13 +1029,14 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             log_capture_detail(detail);
         }
     }
-    if (!request.valid || request.submit_no != submit_no || request.claimed.exchange(true)) {
+    if (!capture_endpoint || request.claimed.exchange(true)) {
         history.remember(state, submit_no);
         return;
     }
     const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
 
     GpuCaptureFile capture;
+    if (!request.bundle_path.empty()) begin_runtime_capture_bundle();
     if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
                                  metadata, capture, error) ||
         !write_gpu_capture(request.path, capture, error)) {
@@ -1052,6 +1129,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                      static_cast<unsigned long long>(submit_no), error.c_str());
         error.clear();
     }
+    bool requested_artifacts_written = true;
     if (!request.bundle_path.empty()) {
         RuntimeCaptureBundle& state = runtime_capture_bundle();
         GpuCaptureBundle& bundle = state.bundle;
@@ -1062,15 +1140,31 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         }
         if (state.failed || state.budget_exhausted || !append_runtime_capture_bundle(
                 capture, request.bundle_max_unique_bytes, error) ||
+            !compact_gpu_capture_bundle(bundle, error) ||
             !write_gpu_capture_bundle(request.bundle_path, bundle, error)) {
+            requested_artifacts_written = false;
             std::fprintf(stderr, "[timeline] capture bundle write failed: %s\n", error.c_str());
         } else {
             const uint64_t unique_bytes = gpu_capture_bundle_unique_bytes(bundle);
+            const GpuCaptureBundleStats stats = gpu_capture_bundle_stats(bundle);
+            const uint64_t capture_ms = state.started ? static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - state.started_at).count()) : 0;
             std::fprintf(stderr, "[timeline] capture bundle submits=%zu logical=%llu unique=%llu "
-                                 "ratio=%.3f -> %s\n",
+                                 "ratio=%.3f resources=%zu refs=%llu exact-reuse=%llu "
+                                 "resource-logical=%llu resource-unique=%llu manifest-unique=%llu "
+                                 "guest-copied=%llu capture-ms=%llu -> %s\n",
                          bundle.submits.size(), static_cast<unsigned long long>(bundle.logical_bytes),
                          static_cast<unsigned long long>(unique_bytes),
                          bundle.logical_bytes ? static_cast<double>(unique_bytes) / bundle.logical_bytes : 0.0,
+                         bundle.resources.size(),
+                         static_cast<unsigned long long>(stats.resource_reference_count),
+                         static_cast<unsigned long long>(stats.exact_reuse_count),
+                         static_cast<unsigned long long>(stats.resource_logical_bytes),
+                         static_cast<unsigned long long>(stats.resource_unique_bytes),
+                         static_cast<unsigned long long>(stats.manifest_unique_bytes),
+                         static_cast<unsigned long long>(state.captured_resource_bytes),
+                         static_cast<unsigned long long>(capture_ms),
                          request.bundle_path.c_str());
         }
     }
@@ -1082,6 +1176,12 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     }
     log_capture_detail(detail);
     history.remember(state, submit_no);
+    if (request.exit_after_capture && requested_artifacts_written) {
+        std::fprintf(stderr, "[timeline] selected capture complete; exiting as requested\n");
+        close_gpu_timeline();
+        std::fflush(nullptr);
+        std::exit(0);
+    }
 }
 
 void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -30,27 +30,89 @@ int main() {
         random ^= random << 13; random ^= random >> 17; random ^= random << 5;
         byte = static_cast<uint8_t>(random);
     }
+    blob.content_hash = gpu_capture_hash(blob.bytes);
     first.blobs.push_back(blob);
     GpuCaptureFile second = first;
     second.metadata.submit_index = 42;
     second.metadata.input_route = "shift-the-serialized-blob-boundary";
+    second.blobs[0].guest_addr = 0x200000;
+
+    GpuCaptureFile stale = second;
+    stale.metadata.submit_index = 43;
+    stale.blobs[0].bytes[17] ^= 0x80;
 
     GpuCaptureBundle bundle;
     std::string error;
     CHECK(append_gpu_capture_bundle(bundle, first, error), "first submit appends to bundle");
     CHECK(append_gpu_capture_bundle(bundle, second, error), "second submit appends in order");
-    CHECK(bundle.submits.size() == 2 &&
+    CHECK(bundle.version == 2 && bundle.resources.size() == 1 &&
+          bundle.submits[0].blob_resource_indices == bundle.submits[1].blob_resource_indices,
+          "same content at different addresses reuses one exact resource");
+    CHECK(!append_gpu_capture_bundle(bundle, stale, error) &&
+          error.find("content hash mismatch") != std::string::npos &&
+          bundle.resources.size() == 1 && bundle.submits.size() == 2,
+          "failed append rolls back and cannot reuse a stale same-address resource");
+    stale.blobs[0].content_hash = gpu_capture_hash(stale.blobs[0].bytes);
+    CHECK(append_gpu_capture_bundle(bundle, stale, error) && bundle.resources.size() == 2 &&
+          bundle.submits[2].blob_resource_indices[0] != bundle.submits[1].blob_resource_indices[0],
+          "changed content at the same address creates a distinct resource version");
+    CHECK(bundle.submits.size() == 3 &&
           gpu_capture_bundle_unique_bytes(bundle) * 10 < bundle.logical_bytes * 7,
-          "content-defined chunks resynchronize and deduplicate after shifted metadata");
+          "resource dictionary and manifest chunks reduce physical bytes");
+    const GpuCaptureBundleStats stats = gpu_capture_bundle_stats(bundle);
+    CHECK(stats.resource_reference_count == 3 && stats.exact_reuse_count == 1 &&
+          stats.resource_logical_bytes == blob.bytes.size() * 3,
+          "bundle statistics distinguish logical references from exact reuse");
+    GpuCaptureBundle rolling = bundle;
+    rolling.submits.erase(rolling.submits.begin(), rolling.submits.begin() + 2);
+    rolling.logical_bytes = rolling.submits[0].logical_bytes;
+    const uint64_t rolling_before = gpu_capture_bundle_unique_bytes(rolling);
+    GpuCaptureFile rolling_restored;
+    CHECK(compact_gpu_capture_bundle(rolling, error) && rolling.resources.size() == 1 &&
+          gpu_capture_bundle_unique_bytes(rolling) < rolling_before &&
+          materialize_gpu_capture_bundle_submit(rolling, 0, rolling_restored, error) &&
+          rolling_restored.blobs[0].bytes == stale.blobs[0].bytes,
+          "rolling-window compaction removes unreachable resources and chunks");
     CHECK(write_gpu_capture_bundle(path.string(), bundle, error), "bundle writes atomically");
 
     GpuCaptureBundle loaded;
     CHECK(read_gpu_capture_bundle(path.string(), loaded, error), "checksummed bundle reads");
-    GpuCaptureFile restored;
-    CHECK(materialize_gpu_capture_bundle_submit(loaded, 1, restored, error) &&
-          restored.metadata.submit_index == 42 && restored.blobs.size() == 1 &&
-          restored.blobs[0].bytes == blob.bytes,
+    GpuCaptureFile restored_first, restored_second;
+    CHECK(materialize_gpu_capture_bundle_submit(loaded, 0, restored_first, error) &&
+          materialize_gpu_capture_bundle_submit(loaded, 1, restored_second, error) &&
+          restored_second.metadata.submit_index == 42 && restored_second.blobs.size() == 1 &&
+          restored_second.blobs[0].guest_addr == 0x200000 && restored_second.blobs[0].bytes == blob.bytes,
           "bundle reconstructs an exact validated capture");
+    restored_first.blobs[0].bytes[0] ^= 0xff;
+    CHECK(restored_second.blobs[0].bytes == blob.bytes,
+          "materialized submits own independent mutable resource bytes");
+
+    GpuCaptureBundle malformed = loaded;
+    malformed.submits[0].blob_resource_indices[0] =
+        static_cast<uint32_t>(malformed.resources.size());
+    GpuCaptureFile rejected_capture;
+    CHECK(!materialize_gpu_capture_bundle_submit(malformed, 0, rejected_capture, error) &&
+          error.find("invalid resource") != std::string::npos,
+          "materialization rejects an out-of-range resource reference");
+
+    const auto v1_path = path.string() + ".v1";
+    std::vector<uint8_t> first_bytes;
+    CHECK(serialize_gpu_capture(first, first_bytes, error), "created a legacy capture payload");
+    GpuCaptureBundle legacy;
+    legacy.version = 1; legacy.chunk_bytes = 16u << 20;
+    legacy.logical_bytes = first_bytes.size();
+    legacy.chunks.push_back(first_bytes); legacy.chunk_hashes.push_back(gpu_capture_hash(first_bytes));
+    GpuCaptureBundleSubmit legacy_submit;
+    legacy_submit.submit_index = first.metadata.submit_index;
+    legacy_submit.logical_bytes = legacy_submit.manifest_bytes = first_bytes.size();
+    legacy_submit.chunk_indices.push_back(0); legacy.submits.push_back(legacy_submit);
+    CHECK(write_gpu_capture_bundle(v1_path, legacy, error), "writer preserves the legacy v1 layout");
+    GpuCaptureBundle loaded_legacy;
+    GpuCaptureFile restored_legacy;
+    CHECK(read_gpu_capture_bundle(v1_path, loaded_legacy, error) && loaded_legacy.version == 1 &&
+          materialize_gpu_capture_bundle_submit(loaded_legacy, 0, restored_legacy, error) &&
+          restored_legacy.blobs[0].bytes == blob.bytes,
+          "reader and materializer remain compatible with v1 bundles");
 
     std::ifstream input(path, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
@@ -64,6 +126,7 @@ int main() {
           "bundle rejects manifest corruption");
 
     std::error_code ec; std::filesystem::remove(path, ec); std::filesystem::remove(corrupt_path, ec);
+    std::filesystem::remove(v1_path, ec);
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;
 }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -87,13 +87,23 @@ Set `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>.prgcap` to snapshot exact s
 time alongside selected submit `N`. Replay the pair with `gpu_replay --prepend producer consumer output`.
 This is a one-level probe; graph the producer and recurse when it also reads a temporal version.
 For bounded recursion, add `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>.prgbundle`,
-`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=2..2048`, and optionally
+`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=2..4096`, and optionally
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=64..4096` (default 1024). `gpu_replay --bundle bundle output`
 executes the ordered window and classifies each temporal frontier as included, seeded, or depth-bounded.
 Bundles use content-defined chunks so shifted capture metadata does not defeat cross-submit deduplication.
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM=WxH` restricts predecessor captures to draws targeting that extent;
 it is a size diagnostic, not a dependency proof. `gpu_replay --bundle-zero-boundary` supplies transparent
 pixels to the oldest unseeded temporal leaves for an explicit A/B test and labels the synthetic seeds.
+`gpu_replay --bundle-tail N` skips older manifests without changing dictionary content; use it only when
+lifetime evidence proves the suffix contains the target's beginning, then inspect its lower-bound frontier.
+`gpu_replay --bundle-compact PATH` removes dictionary resources/chunks unreachable from retained rolling
+manifests and exits without Vulkan when no image output path is supplied.
+Set `PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1` for long unattended runs; it exits only after the selected
+capsule and requested bundle are installed, never on capture failure or budget exhaustion.
+For timing-sensitive routes, `PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=WxH` selects the first matching
+submit at or after `CAPTURE_SUBMIT`; `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N` can reject loading passes.
+When the endpoint moves, predecessor manifests roll forward so the final bundle retains the latest requested
+depth; dictionary bytes observed by evicted manifests still count against the unique-byte budget.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
 single-framebuffer compositor only for diagnostic comparison; it cannot represent real post chains or
 offscreen target dimensions.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -21,6 +21,8 @@ Create a capsule with the native-speed workflow in
 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/replay.bmp
 ./build-linux/gpu_replay --prepend /tmp/producer.prgcap /tmp/consumer.prgcap /tmp/closure.bmp
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle /tmp/closure.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-tail 2 /tmp/tail.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-compact /tmp/compact.prgbundle
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-zero-boundary /tmp/zero-ab.bmp
 ```
 
@@ -76,6 +78,14 @@ The summary reports logical versus unique bytes, per-submit output hashes, and e
 A successful replay with `configured-bound` is an explicitly partial closure, not a faithful pixel oracle.
 Bundle files use `.prgbundle`, contain title-derived data, are gitignored, and must not be committed.
 
+`--bundle-tail N` replays only the latest `N` manifests while retaining the bundle's exact shared resource
+dictionary. Use it when lifetime evidence proves that earlier submits cannot be target producers; the first
+replayed submit becomes the explicit configured boundary and its graph must still be inspected for leaves.
+
+`--bundle-compact PATH` writes a validated copy containing only resources and chunks reachable from retained
+submit manifests. It is useful after a rolling semantic capture; with no image output argument, compaction
+exits without initializing Vulkan. Combine it with `--bundle-tail N` to write a compact suffix bundle.
+
 `--bundle-zero-boundary` is an A/B diagnostic. It supplies transparent RGBA pixels for unseeded temporal
 image leaves at the oldest bundled submit, labels them `diagnostic-zero-seed`, and leaves the bundle unchanged.
 It can disprove stale guest backing versus zero initialization as the cause of a mismatch, but it is not a
@@ -97,7 +107,13 @@ between the dark and overbright failure. Supplying transparent zero to those two
 the same final hash (`62a46f15efa52a26`) as unseeded replay, so stale guest backing versus transparent
 initialization is not the cause in this window.
 
-Capturing only 642x362-target predecessor draws still costs about 150 MiB per submit because repeated static
-fragment resources include 64, 32, and 16 MiB textures. A 1,200-submit brute-force bundle is therefore not a
-practical next step. The next tooling boundary is an exact shared-resource dictionary or equivalently proven
-unchanged-resource reuse across submits; mutable versions must never be reused from address identity alone.
+Bundle v2 stores exact resource versions in a global content-defined chunk dictionary. On a fixed 1,200-submit
+full-state run it folded 122.97 GiB of logical capture data into 301.1 MiB in 169.4 seconds. Reuse is proven by
+hash plus byte equality; mutable versions are never reused from address identity. Linux capture reads use
+fault-safe `process_vm_readv` rather than per-page pipe probes.
+
+A timing-independent semantic run retained a rolling 1,400-submit window and selected run-local submit 23,350.
+The two 642x362 surfaces first appear one submit earlier. Compacting to that exact two-submit suffix stores
+142.6 MiB; replay resolves both temporal edges with zero seeded, bounded, or unresolved leaves and finishes at
+hash `112e7db0001791cc`. The image is the dark opening vignette with `HOLD Skip`, not playable gameplay, so
+extent plus 80 draws is still too broad. #608 tracks a stable playable checkpoint and first bad composition.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -26,7 +26,8 @@ bool set_environment(const std::string& name, const std::string& value) {
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] "
-                         "[--bundle capture.prgbundle] [--bundle-zero-boundary] "
+                         "[--bundle capture.prgbundle] [--bundle-tail N] [--bundle-compact PATH] "
+                         "[--bundle-zero-boundary] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-shader DRAW:vs|fs PATH] "
@@ -291,18 +292,55 @@ bool ranges_overlap(uint64_t a, uint64_t as, uint64_t b, uint64_t bs) {
     return a < range_end(b, bs) && b < range_end(a, as);
 }
 
-int replay_bundle(const std::string& path, const char* output_path, bool zero_boundary) {
+int replay_bundle(const std::string& path, const char* output_path, bool zero_boundary,
+                  size_t tail_count, const std::string& compact_path) {
     prosper::gpu::GpuCaptureBundle bundle;
     std::string error;
     if (!prosper::gpu::read_gpu_capture_bundle(path, bundle, error)) {
         std::fprintf(stderr, "gpu_replay: cannot read bundle: %s\n", error.c_str()); return 2;
     }
     const uint64_t unique_bytes = prosper::gpu::gpu_capture_bundle_unique_bytes(bundle);
-    std::fprintf(stderr, "[gpureplay] bundle submits=%zu logical=%llu unique=%llu ratio=%.3f chunks=%zu\n",
+    const auto stats = prosper::gpu::gpu_capture_bundle_stats(bundle);
+    size_t first_submit_index = tail_count && tail_count < bundle.submits.size()
+        ? bundle.submits.size() - tail_count : 0;
+    std::fprintf(stderr, "[gpureplay] bundle v%u submits=%zu logical=%llu unique=%llu ratio=%.3f "
+                         "chunks=%zu resources=%zu refs=%llu exact-reuse=%llu "
+                         "resource-logical=%llu resource-unique=%llu manifest-unique=%llu\n",
+                 bundle.version,
                  bundle.submits.size(), static_cast<unsigned long long>(bundle.logical_bytes),
                  static_cast<unsigned long long>(unique_bytes),
                  bundle.logical_bytes ? static_cast<double>(unique_bytes) / bundle.logical_bytes : 0.0,
-                 bundle.chunks.size());
+                 bundle.chunks.size(), bundle.resources.size(),
+                 static_cast<unsigned long long>(stats.resource_reference_count),
+                 static_cast<unsigned long long>(stats.exact_reuse_count),
+                 static_cast<unsigned long long>(stats.resource_logical_bytes),
+                 static_cast<unsigned long long>(stats.resource_unique_bytes),
+                 static_cast<unsigned long long>(stats.manifest_unique_bytes));
+    if (first_submit_index)
+        std::fprintf(stderr, "[gpureplay] replaying tail submits=%zu range=%llu..%llu\n",
+                     bundle.submits.size() - first_submit_index,
+                     static_cast<unsigned long long>(bundle.submits[first_submit_index].submit_index),
+                     static_cast<unsigned long long>(bundle.submits.back().submit_index));
+    if (!compact_path.empty()) {
+        const uint64_t before = prosper::gpu::gpu_capture_bundle_unique_bytes(bundle);
+        if (first_submit_index) {
+            bundle.submits.erase(bundle.submits.begin(), bundle.submits.begin() + first_submit_index);
+            bundle.logical_bytes = 0;
+            for (const auto& submit : bundle.submits) bundle.logical_bytes += submit.logical_bytes;
+            first_submit_index = 0;
+        }
+        if (!prosper::gpu::compact_gpu_capture_bundle(bundle, error) ||
+            !prosper::gpu::write_gpu_capture_bundle(compact_path, bundle, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot compact bundle: %s\n", error.c_str());
+            return 2;
+        }
+        const uint64_t after = prosper::gpu::gpu_capture_bundle_unique_bytes(bundle);
+        std::fprintf(stderr, "[gpureplay] compacted unique=%llu -> %llu resources=%zu chunks=%zu -> %s\n",
+                     static_cast<unsigned long long>(before),
+                     static_cast<unsigned long long>(after), bundle.resources.size(),
+                     bundle.chunks.size(), compact_path.c_str());
+        if (!output_path) return 0;
+    }
 
     prosper::gpu::GpuCaptureFile final_capture;
     if (!prosper::gpu::materialize_gpu_capture_bundle_submit(
@@ -326,7 +364,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
     std::vector<BundleTarget> prior_targets;
     std::vector<uint8_t> final_pixels;
     uint64_t temporal_resolved = 0, temporal_seeded = 0, temporal_bounded = 0, temporal_unresolved = 0;
-    for (size_t i = 0; i < bundle.submits.size(); ++i) {
+    for (size_t i = first_submit_index; i < bundle.submits.size(); ++i) {
         prosper::gpu::GpuCaptureFile capture;
         if (!prosper::gpu::materialize_gpu_capture_bundle_submit(bundle, i, capture, error)) {
             std::fprintf(stderr, "gpu_replay: cannot reconstruct bundle submit %zu: %s\n",
@@ -345,7 +383,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             return 2;
         }
         std::vector<uint64_t> diagnostic_zero_seeds;
-        if (i == 0 && zero_boundary) {
+        if (i == first_submit_index && zero_boundary) {
             for (const auto& leaf : graph.external_leaves) {
                 if (leaf.first_future_writer == UINT32_MAX || !leaf.access.addr ||
                     !leaf.access.width || !leaf.access.height ||
@@ -384,7 +422,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                 [&](const auto& target) {
                     return ranges_overlap(leaf.access.addr, leaf.access.size, target.addr, target.size);
                 });
-            const char* stop = i == 0 ? "configured-bound" : "unresolved-producer";
+            const char* stop = i == first_submit_index ? "configured-bound" : "unresolved-producer";
             uint64_t producer_submit = 0;
             if (producer != prior_targets.rend()) {
                 stop = "included-producer"; producer_submit = producer->submit; ++temporal_resolved;
@@ -394,7 +432,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                     ? "diagnostic-zero-seed" : "initialized-seed";
                 ++temporal_seeded;
             } else {
-                if (i == 0) ++temporal_bounded;
+                if (i == first_submit_index) ++temporal_bounded;
                 else ++temporal_unresolved;
             }
             std::fprintf(stderr, "[gpureplay] frontier submit=%llu op=%u addr=%016llx dims=%ux%u "
@@ -450,8 +488,10 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool graph_only = false, bundle_zero_boundary = false;
+    size_t bundle_tail = 0;
     int draw_first = -1, draw_last = -1;
-    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path, bundle_path;
+    std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path;
+    std::string bundle_path, bundle_compact_path;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
@@ -464,6 +504,14 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
         else if (std::string(argv[i]) == "--bundle" && i + 1 < argc) bundle_path = argv[++i];
         else if (std::string(argv[i]) == "--bundle-zero-boundary") bundle_zero_boundary = true;
+        else if (std::string(argv[i]) == "--bundle-compact" && i + 1 < argc)
+            bundle_compact_path = argv[++i];
+        else if (std::string(argv[i]) == "--bundle-tail" && i + 1 < argc) {
+            char* end = nullptr;
+            const unsigned long long value = std::strtoull(argv[++i], &end, 0);
+            if (!end || *end || !value || value > SIZE_MAX) { usage(argv[0]); return 2; }
+            bundle_tail = static_cast<size_t>(value);
+        }
         else if (std::string(argv[i]) == "--prepend" && i + 1 < argc) prepend_path = argv[++i];
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
             std::string range = argv[++i]; size_t colon = range.find(':');
@@ -484,9 +532,11 @@ int main(int argc, char** argv) {
             usage(argv[0]); return 2;
         }
         return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
-                             bundle_zero_boundary);
+                             bundle_zero_boundary, bundle_tail, bundle_compact_path);
     }
-    if (bundle_zero_boundary) { usage(argv[0]); return 2; }
+    if (bundle_zero_boundary || bundle_tail || !bundle_compact_path.empty()) {
+        usage(argv[0]); return 2;
+    }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
     prosper::gpu::GpuCaptureFile capture; std::string error;
     if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -44,6 +44,9 @@ PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
 PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-depth16.prgbundle \
 PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=16 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=642x362 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=80 \
+PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
   ./build-linux/boot_trace /path/to/PPSA15552-app0
 
 ./build-linux/gpu_replay --bundle /tmp/dead-cells-depth16.prgbundle /tmp/closure.bmp
@@ -106,9 +109,11 @@ producer time in the same run and links both capsules with ordinary detail recor
 one-level closure probe; if the predecessor graph has temporal leaves, capture must recurse further.
 
 For a recursive probe, `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>` captures the selected submit and
-`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=N` contiguous submits ending there (2..2048). Captures are serialized at
-producer time and folded immediately into content-defined, checksummed chunks; no retained `GpuState` or
-standalone predecessor files are used. `PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=N` bounds unique chunk
+`PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=N` contiguous submits ending there (2..4096). Bundle v2 captures at
+producer time and stores small submit manifests plus exact resource versions in a global content-defined,
+checksummed chunk dictionary; no retained `GpuState` or standalone predecessor files are used. Equal content
+is reused only after byte comparison, never from guest address identity. Version-1 bundles remain readable.
+`PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=N` bounds unique chunk
 data to 64..4096 MiB (default 1024) and aborts bundle installation if exhausted. The selected standalone
 `.prgcap` remains the graph/oracle reference and is currently required with the bundle.
 
@@ -116,3 +121,16 @@ data to 64..4096 MiB (default 1024) and aborts bundle installation if exhausted.
 matching target extents while leaving the selected consumer complete. This is a capture-volume diagnostic,
 not renderer substitution. It may still be expensive when relevant passes reference large shared assets;
 unique-byte budget enforcement remains authoritative.
+
+`PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1` terminates the process only after the selected standalone
+capsule and any requested bundle have been installed successfully. Use it for long captures instead of a
+wall-clock timeout; capture failure or budget exhaustion leaves the process running for diagnostics.
+
+`PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=WxH` changes the configured submit into a lower endpoint
+bound: the first later submit with a draw targeting that extent is selected. Optionally require a semantic
+draw count with `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N`. This keeps a long synchronous capture from
+selecting the wrong scene when it perturbs wall-clock pacing. A requested bundle still begins at
+`CAPTURE_SUBMIT - CAPTURE_DEPTH + 1`; if the endpoint moves beyond that window, predecessor manifests roll
+forward so the final bundle contains exactly the latest requested depth. The dictionary may retain content
+seen by evicted manifests during capture, and the unique-byte budget remains authoritative. Finalization
+compacts unreachable dictionary entries before installing the bundle.


### PR DESCRIPTION
## Summary

- add `.prgbundle` v2 with exact content-defined resource chunks, persistent append indexes, rolling semantic windows, and final reachability compaction
- replace per-page capture probes with fault-safe Linux `process_vm_readv`
- add timing-independent capture endpoints, successful-artifact exit, bundle suffix replay, and offline bundle compaction
- retain v1 bundle read/replay compatibility and independently owned materialized resource versions
- add a capture-safe Dead Cells route and update the project/tool documentation

## Measured result

A fixed 1,200-submit full-state Dead Cells capture folded 122.97 GiB logical data into 301.1 MiB in 169.4 seconds, with 72,907 exact whole-resource reuses.

A rolling semantic run selected run-local submit 23,350; timeline v4 placed both 642x362 first writers at submit 23,349. `--bundle-tail 2 --bundle-compact` reduced the retained closure to 142.6 MiB. Replay reports 2 included temporal producers, 0 seeded, 0 bounded, and 0 unresolved leaves:

- submit 23,349: `26ed8b6191338383`
- submit 23,350: `112e7db0001791cc`

The selected frame is the opening vignette rather than playable gameplay, so #608 owns the stronger checkpoint and first bad composition.

## Safety contracts

- reuse requires hash lookup plus byte equality; guest address is never reuse proof
- same-address changed content creates a new version
- v2 reconstruction copies dictionary content into independent mutable blob ownership
- unique-byte limits remain authoritative, including content observed before rolling eviction
- exit-after-capture triggers only after the selected capsule and requested bundle install successfully

## Validation

- standard Messenger fixture: 91/91 tests passed
- tests cover exact reuse, mutation, failed-append rollback, independent ownership, malformed references, rolling compaction, stats, and v1 compatibility
- existing v1 Dead Cells depth-16 bundle retains final hash `62a46f15efa52a26`
- compact v2 two-submit suffix retains both original per-submit hashes

Closes #606
Follow-up: #608