### PR TITLE
feat(gpu): deterministic playable closure debugging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ exercised NGS2 lifecycle returns initialized sizes/handles/state and silent outp
 window reaches the Evil Empire splash. #545 was software-render throughput, not a guest deadlock: synchronous
 3840×2160 llvmpipe rendering stretches its ~13,000-submit startup into minutes.
 
-Dead Cells now has a deterministic route through splash/menu into gameplay. HUD and partial composition render,
-but the world is mostly white (#566). Version-4 `.prgcap` captures seed temporal RTT inputs (#568) and isolate the
+Dead Cells now has a deterministic route through splash/menu into gameplay. HUD and partial composition render.
+Version-4 `.prgcap` captures seed temporal RTT inputs (#568) and isolates the
 first bad composition at draw 18; one 642x362 input has no prior color-target writer. The kernel-derived dispatch
 thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574)
 now execute the real fill kernel against guest buffers before submit completion (#576). Range provenance proved
@@ -107,7 +107,10 @@ compute now execute by retained PM4 order (#584), fixing that future-read. The l
 warmup artifact: the 35-second render delay skipped a 642x362 RTT producer, then a replace-copy sampled dispatch
 4's raw all-`0xFF` backing and cached it indefinitely. `PROSPER_RENDER_TARGET_DIM=642x362` preserves the real
 opening vignette/level geometry; #586 now tracks a practical late checkpoint with that history intact. The
-residual seeded replay mismatch (#569) and animation-sensitive exact splash guard (#573) remain separate issues.
+residual seeded replay mismatch (#569) is persistent depth/stencil state outside color RTT seeds: the faithful
+playable closure reuses one 642x362 depth surface across all 883 submits with LESS_OR_EQUAL writes/tests and no
+captured clears, so stale depth rejects most world geometry (#611). The animation-sensitive exact splash guard
+(#573) remains separate.
 
 The current tooling frontier is deterministic offline capture rather than longer live-render windows.
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
@@ -124,8 +127,15 @@ Bundle v2 (#606) now uses fault-safe bulk guest reads plus an exact shared-resou
 1,200-submit full-state run folded 122.97 GiB into 301.1 MiB in 169.4 seconds. Semantic endpoints, rolling
 windows, successful-only exit, final compaction, and `gpu_replay --bundle-tail` prevent timing drift and replay
 holes. A compact two-submit closure resolves both 642x362 edges with no bounded leaves, but its 80-draw endpoint
-is the opening vignette rather than gameplay. Define a stable playable checkpoint and isolate the first bad
-composition under #608 instead of guessing another submit ordinal.
+is the opening vignette rather than gameplay. #608 now identifies the controllable Jump tutorial without a
+submit ordinal: require exactly 90 semantic draws and the 738x420 target at semantic draw index 79..81. Target
+extent or total draw count alone also selects cinematic/transition frames and must not be used as the oracle.
+Use this checkpoint to isolate the first bad composition.
+The faithful playable bundle spans submits 18,165..19,047, stores 158.94 GiB logical state in 739 MiB, resolves
+all 1,764 temporal image dependencies, and renders hash `5759c125812154dc`. A fresh-depth final replay instead
+renders `71b84bdfae53933c`; `gpu_replay --bundle-find-ds ADDR` scans manifest-only DS use in seconds and proves
+the shared surface has no clear intent. Do not treat `--bundle-final-capsule` as exact until its standalone hash
+matches: it snapshots color RTT state, not live Vulkan depth/stencil images.
 Addresses and operation ordinals are run-local. The stale exact Dead Cells snapshot baseline is
 tracked separately in #596 and must not be silently updated.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ accepts scripted gamepad input, and renders the first level.
   first playable scene. Graphics and compute now execute by retained PM4 order (#584), fixing a proven
   future-read. The formerly overbright screenshot was traced to a diagnostic warmup skipping temporal RTT
   producers. Versioned offline bundles now retain long, exact cross-submit resource history and replay a
-  minimized closure; a stable semantic checkpoint for the first playable composition remains #608.
+  minimized closure. #608 now defines a run-local semantic checkpoint for the controllable Jump tutorial:
+  exactly 90 semantic draws with the 738x420 pass at draw index 79..81. Its faithful 883-submit replay
+  isolates the remaining missing-world symptom to a persistent 642x362 depth surface that is never cleared
+  in the captured draw/register stream (#611), rather than another missing color RTT.
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -38,7 +38,8 @@ possible without console keys. Dumps are user-supplied and gitignored.
   Offline dependency graphs resolve in-submit resource versions and identify deduplicated prior-submit
   leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595).
 - ✅ **Dead Cells reaches gameplay reproducibly:** a deterministic input route passes the splash and menus
-  into the first playable scene. HUD and some composition render, but the world is mostly white (#566).
+  into the first playable scene. HUD and some composition render, but most world geometry is rejected after
+  a long history (#611).
   Version-5 GPU captures seed temporal render targets and retain content-addressed resource versions for
   faithful offline isolation (#568/#594); one residual
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
@@ -48,7 +49,11 @@ possible without console keys. Dumps are user-supplied and gitignored.
   chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal
   642×362 edges without bounded leaves, but the first 80-draw semantic endpoint is the opening vignette rather
-  than playable gameplay. #608 tracks a stable playable checkpoint and the first bad world-composition draw.
+  than playable gameplay. #608 now selects the controllable Jump tutorial by combining an exact 90-draw submit
+  with the 738x420 pass at semantic draw 79..81, and tracks its exact history and first bad composition.
+  The faithful 883-submit closure resolves 1,764 temporal image dependencies but reuses one 642x362 depth
+  surface with LESS_OR_EQUAL writes and zero clears across every retained submit; #611 tracks the missing
+  clear/lifetime boundary and #569 tracks depth/stencil checkpoint serialization.
   The stale exact Dead Cells
   snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -55,12 +55,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     }
     static std::atomic<int> frame_no{0};
     static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
-    if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE"))
+    if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
+        getenv("PROSPER_GPU_REPLAY_EXPORT_RTT")) {
         prosper::gpu::set_gpu_capture_rtt_seed_reader([](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {
             auto it = g_rtt.find(addr); if (it == g_rtt.end()) return false;
             seed.guest_addr = addr; seed.width = it->second.w; seed.height = it->second.h;
             seed.rgba = it->second.rgba; return true;
         });
+        prosper::gpu::set_gpu_capture_rtt_seed_snapshot_reader(
+            [](std::vector<prosper::gpu::GpuCaptureRttSeed>& seeds, std::string&) {
+                seeds.reserve(g_rtt.size());
+                for (const auto& [addr, surface] : g_rtt) {
+                    prosper::gpu::GpuCaptureRttSeed seed;
+                    seed.guest_addr = addr; seed.width = surface.w; seed.height = surface.h;
+                    seed.rgba = surface.rgba; seeds.push_back(std::move(seed));
+                }
+                return true;
+            });
+    }
     if (getenv("PROSPER_GPU_REPLAY_RTT_SEEDS"))
         prosper::gpu::set_gpu_replay_rtt_seed_writer([](const prosper::gpu::GpuCaptureRttSeed& seed, std::string& error) {
             const uint64_t expected = static_cast<uint64_t>(seed.width) * seed.height * 4;

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -26,3 +26,25 @@ caused by that skip and is not normal renderer output (#586). For graphics
 investigation, add `PROSPER_RENDER_TARGET_DIM=642x362` to preserve the level's
 RTT chain; this is much slower and currently remains in the opening vignette at
 the 35-second checkpoint. Do not use the fast route as a visual golden guard.
+
+## Playable semantic checkpoint
+
+Do not select the first 738x420 target: it also occurs in the skippable opening. The validated Jump-tutorial
+endpoint combines all of these predicates:
+
+```bash
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=79:81 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=90 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=90
+```
+
+The draw index is zero-based in the raw semantic sequence. Fresh native-speed runs selected different submit
+numbers but replayed the same controllable scene with 86 realized draws, seven realized dispatches, the Jump
+prompt, and the full HUD. Nearby cinematic and transition captures are explicitly outside this conjunction.
+
+The faithful playable reference on #608 retained 883 submits and renders hash
+`5759c125812154dc`. A final-submit replay with fresh depth renders `71b84bdfae53933c` instead. Use
+`gpu_replay --bundle-find-ds ADDR` to scan a bundle's depth/stencil identity, tests, writes, clears, and
+target extents without reconstructing resource payloads or invoking Vulkan. #611 tracks the observed
+642x362 depth surface reused throughout the closure with no captured clear.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1,5 +1,6 @@
 // command_processor.cpp — see command_processor.hpp.
 #include "command_processor.hpp"
+#include "pm4_registers.hpp"
 #include "writer_provenance.hpp"
 #include "hle/sync_futex.hpp"   // wake_label_waiters (shared with sceKernelWaitOnAddress's futex)
 
@@ -1200,7 +1201,17 @@ void GpuState::apply(const Pm4Command& c) {
                     fprintf(stderr, " (off=0x%x val=0x%x)", regs[i].offset, regs[i].value);
                 fprintf(stderr, "\n");
             }
-            for (uint32_t i = 0; i < c.num_regs; i++) file[regs[i].offset] = regs[i].value;
+            for (uint32_t i = 0; i < c.num_regs; i++) {
+                file[regs[i].offset] = regs[i].value;
+                if (c.reg_class == RegClass::Cx &&
+                    regs[i].offset == prosper::agc::Pm4::DB_RENDER_CONTROL &&
+                    (regs[i].value & 0x3u) &&
+                    getenv("PROSPER_DS_CLEARLOG"))
+                    fprintf(stderr,
+                            "[ds-clear-reg] order=%llu value=%08x depth=%u stencil=%u\n",
+                            (unsigned long long)command_order, regs[i].value,
+                            regs[i].value & 1u, (regs[i].value >> 1) & 1u);
+            }
             state_dirty_ = true;   // register state changed -> the next draw needs a fresh snapshot
             break;
         }

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -46,6 +46,7 @@ constexpr uint32_t kMaxStringBytes = 1u << 20;
 constexpr uint64_t kMaxTotalRttSeedBytes = 1ull << 30;
 
 CaptureRttSeedReader g_rtt_seed_reader;
+CaptureRttSeedSnapshotReader g_rtt_seed_snapshot_reader;
 ReplayRttSeedWriter g_rtt_seed_writer;
 
 size_t read_capture_guest_memory(uint64_t addr, uint8_t* dst, size_t bytes) {
@@ -772,6 +773,39 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
 }
 
 void set_gpu_capture_rtt_seed_reader(CaptureRttSeedReader reader) { g_rtt_seed_reader = std::move(reader); }
+bool read_gpu_capture_rtt_seed(uint64_t guest_addr, GpuCaptureRttSeed& seed, std::string& error) {
+    error.clear();
+    if (!g_rtt_seed_reader) { error = "live renderer has no RTT seed reader"; return false; }
+    if (!g_rtt_seed_reader(guest_addr, seed)) { error = "render target is absent from live cache"; return false; }
+    return validate_rtt_seed(seed, error);
+}
+void set_gpu_capture_rtt_seed_snapshot_reader(CaptureRttSeedSnapshotReader reader) {
+    g_rtt_seed_snapshot_reader = std::move(reader);
+}
+bool read_all_gpu_capture_rtt_seeds(std::vector<GpuCaptureRttSeed>& seeds, std::string& error) {
+    error.clear(); seeds.clear();
+    if (!g_rtt_seed_snapshot_reader) {
+        error = "live renderer has no RTT seed snapshot reader"; return false;
+    }
+    if (!g_rtt_seed_snapshot_reader(seeds, error)) return false;
+    if (seeds.size() > kMaxResources) { error = "invalid RTT seed count"; return false; }
+    uint64_t total = 0;
+    std::unordered_set<uint64_t> addresses;
+    for (const auto& seed : seeds) {
+        if (!validate_rtt_seed(seed, error)) return false;
+        if (!addresses.insert(seed.guest_addr).second) {
+            error = "duplicate RTT seed address"; return false;
+        }
+        if (seed.rgba.size() > kMaxTotalRttSeedBytes - total) {
+            error = "RTT seed bytes exceed limit"; return false;
+        }
+        total += seed.rgba.size();
+    }
+    std::sort(seeds.begin(), seeds.end(), [](const auto& a, const auto& b) {
+        return a.guest_addr < b.guest_addr;
+    });
+    return true;
+}
 void set_gpu_replay_rtt_seed_writer(ReplayRttSeedWriter writer) { g_rtt_seed_writer = std::move(writer); }
 
 bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, std::string& error) {

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -104,6 +104,8 @@ struct GpuCaptureFile {
 // live renderer's guarded-copy behavior for partially committed guest resources.
 using CaptureMemoryReader = std::function<size_t(uint64_t guest_addr, uint8_t* dst, size_t bytes)>;
 using CaptureRttSeedReader = std::function<bool(uint64_t guest_addr, GpuCaptureRttSeed& seed)>;
+using CaptureRttSeedSnapshotReader =
+    std::function<bool(std::vector<GpuCaptureRttSeed>& seeds, std::string& error)>;
 
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
                         const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error,
@@ -155,6 +157,9 @@ bool materialize_gpu_replay(const GpuCaptureFile& capture, GpuReplayFrame& repla
 // surfaces before draw zero.
 using ReplayRttSeedWriter = std::function<bool(const GpuCaptureRttSeed& seed, std::string& error)>;
 void set_gpu_capture_rtt_seed_reader(CaptureRttSeedReader reader);
+bool read_gpu_capture_rtt_seed(uint64_t guest_addr, GpuCaptureRttSeed& seed, std::string& error);
+void set_gpu_capture_rtt_seed_snapshot_reader(CaptureRttSeedSnapshotReader reader);
+bool read_all_gpu_capture_rtt_seeds(std::vector<GpuCaptureRttSeed>& seeds, std::string& error);
 void set_gpu_replay_rtt_seed_writer(ReplayRttSeedWriter writer);
 bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, std::string& error);
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size);

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -330,8 +330,8 @@ bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& c
     return true;
 }
 
-bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
-                                           GpuCaptureFile& capture, std::string& error) {
+bool materialize_gpu_capture_bundle_manifest(const GpuCaptureBundle& bundle, size_t submit_index,
+                                             GpuCaptureFile& capture, std::string& error) {
     error.clear();
     if (submit_index >= bundle.submits.size()) { error = "bundle submit index is out of range"; return false; }
     const auto& submit = bundle.submits[submit_index];
@@ -349,6 +349,16 @@ bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_
     }
     if (bytes.size() != serialized_bytes) { error = "bundle submit is truncated"; return false; }
     if (!deserialize_gpu_capture(bytes, capture, error)) return false;
+    if (capture.metadata.submit_index != submit.submit_index) {
+        error = "bundle submit identity mismatch"; return false;
+    }
+    return true;
+}
+
+bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
+                                           GpuCaptureFile& capture, std::string& error) {
+    if (!materialize_gpu_capture_bundle_manifest(bundle, submit_index, capture, error)) return false;
+    const auto& submit = bundle.submits[submit_index];
     if (bundle.version >= 2) {
         if (capture.blobs.size() != submit.blob_resource_indices.size() ||
             capture.blobs.size() != submit.blob_bytes_read.size()) {
@@ -394,9 +404,6 @@ bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_
             error = "bundle submit logical size mismatch";
             return false;
         }
-    }
-    if (capture.metadata.submit_index != submit.submit_index) {
-        error = "bundle submit identity mismatch"; return false;
     }
     return true;
 }

--- a/prosper/src/gpu/gpu_capture_bundle.hpp
+++ b/prosper/src/gpu/gpu_capture_bundle.hpp
@@ -48,6 +48,8 @@ struct GpuCaptureBundleStats {
 
 bool append_gpu_capture_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& capture,
                                std::string& error);
+bool materialize_gpu_capture_bundle_manifest(const GpuCaptureBundle& bundle, size_t submit_index,
+                                             GpuCaptureFile& capture, std::string& error);
 bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
                                            GpuCaptureFile& capture, std::string& error);
 bool compact_gpu_capture_bundle(GpuCaptureBundle& bundle, std::string& error);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -284,9 +284,21 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
         if (log) {
-            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; es=0x%llx ps=0x%llx color0=0x%llx)\n",
-                    vs.size(), fs.size(), (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
-                    (unsigned long long)rs.color0_base);
+            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; order=%llu "
+                            "es=0x%llx ps=0x%llx color0=0x%llx/%ux%u "
+                            "depth=%d/%d/op%u clear=%d/%g base=0x%llx/0x%llx "
+                            "stencil=%d clear=%d/%u base=0x%llx/0x%llx)\n",
+                    vs.size(), fs.size(),
+                    (unsigned long long)(draw ? draw->command_order : 0),
+                    (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                    (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
+                    (int)rs.z_enable, (int)rs.z_write_enable, rs.zfunc,
+                    (int)rs.depth_clear_enable, rs.depth_clear_value,
+                    (unsigned long long)rs.depth_read_base,
+                    (unsigned long long)rs.depth_write_base,
+                    (int)rs.stencil_enable, (int)rs.stencil_clear_enable, rs.stencil_clear_value,
+                    (unsigned long long)rs.stencil_read_base,
+                    (unsigned long long)rs.stencil_write_base);
             for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
                 RecompileCoverage c = recompile_coverage((const uint32_t*)(uintptr_t)addr, max_shader_dwords);
                 fprintf(stderr, "[exec]   %s coverage: total=%u alu=%u exp=%u tabledep=%u unsupported=%u "

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -217,14 +217,20 @@ struct RuntimeDetailRequest {
     uint64_t bundle_max_unique_bytes = 1ull << 30;
     uint32_t bundle_target_width = 0;
     uint32_t bundle_target_height = 0;
+    uint32_t bundle_start_target_width = 0;
+    uint32_t bundle_start_target_height = 0;
     uint32_t select_target_width = 0;
     uint32_t select_target_height = 0;
+    uint32_t select_target_min_index = 0;
+    uint32_t select_target_max_index = UINT32_MAX;
     uint32_t select_min_draws = 0;
+    uint32_t select_max_draws = UINT32_MAX;
     bool exit_after_capture = false;
     uint64_t submit_no = 0;
     bool valid = false;
     std::atomic<bool> claimed{false};
     std::atomic<bool> predecessor_claimed{false};
+    bool bundle_start_reached = false;
 
     RuntimeDetailRequest() {
         const char* path_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
@@ -278,6 +284,18 @@ struct RuntimeDetailRequest {
                     bundle_target_width = width; bundle_target_height = height;
                 }
             }
+            if (const char* dimensions = std::getenv(
+                    "PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM")) {
+                unsigned width = 0, height = 0; char tail = 0;
+                if (std::sscanf(dimensions, "%ux%u%c", &width, &height, &tail) != 2 ||
+                    !width || !height) {
+                    std::fprintf(stderr, "[timeline] capture start target dimension must be WxH\n");
+                    bundle_path.clear(); bundle_depth = 0;
+                } else {
+                    bundle_start_target_width = width;
+                    bundle_start_target_height = height;
+                }
+            }
         }
         if (const char* dimensions = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM")) {
             unsigned width = 0, height = 0; char tail = 0;
@@ -289,6 +307,16 @@ struct RuntimeDetailRequest {
             select_target_width = width;
             select_target_height = height;
         }
+        if (const char* range = std::getenv(
+                "PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX")) {
+            unsigned first = 0, last = 0; char tail = 0;
+            if (std::sscanf(range, "%u:%u%c", &first, &last, &tail) != 2 || first > last) {
+                std::fprintf(stderr, "[timeline] target draw index must be MIN:MAX\n");
+                return;
+            }
+            select_target_min_index = first;
+            select_target_max_index = last;
+        }
         if (const char* min_draws = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS")) {
             char* min_end = nullptr;
             const uint64_t value = std::strtoull(min_draws, &min_end, 0);
@@ -298,15 +326,29 @@ struct RuntimeDetailRequest {
             }
             select_min_draws = static_cast<uint32_t>(value);
         }
+        if (const char* max_draws = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS")) {
+            char* max_end = nullptr;
+            const uint64_t value = std::strtoull(max_draws, &max_end, 0);
+            if (!max_end || *max_end || value > UINT32_MAX) {
+                std::fprintf(stderr, "[timeline] capture maximum draws must be 0..4294967295\n");
+                return;
+            }
+            select_max_draws = static_cast<uint32_t>(value);
+        }
+        if (select_min_draws > select_max_draws) {
+            std::fprintf(stderr, "[timeline] capture minimum draws exceeds maximum draws\n");
+            return;
+        }
         if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE"))
             exit_after_capture = *value && std::strcmp(value, "0") && std::strcmp(value, "off");
         submit_no = parsed;
         valid = true;
         if (select_target_width)
             std::fprintf(stderr, "[timeline] semantic capture endpoint submit>=%llu "
-                                 "target=%ux%u min-draws=%u\n",
+                                 "target=%ux%u target-index=%u..%u draws=%u..%u\n",
                          static_cast<unsigned long long>(submit_no), select_target_width,
-                         select_target_height, select_min_draws);
+                         select_target_height, select_target_min_index,
+                         select_target_max_index, select_min_draws, select_max_draws);
     }
 };
 
@@ -479,12 +521,27 @@ bool runtime_capture_endpoint_matches(const RuntimeDetailRequest& request,
     if (submit_no < request.submit_no) return false;
     if (!request.select_target_width)
         return submit_no == request.submit_no;
-    if (state.draws.size() < request.select_min_draws) return false;
-    for (size_t i = 0; i < state.draws.size(); ++i) {
+    if (state.draws.size() < request.select_min_draws ||
+        state.draws.size() > request.select_max_draws) return false;
+    for (size_t i = request.select_target_min_index;
+         i < state.draws.size() && i <= request.select_target_max_index; ++i) {
         const RenderState rs = extract_render_state(state.state_at_draw(i));
         if (rs.color0_width == request.select_target_width &&
-            rs.color0_height == request.select_target_height)
+            rs.color0_height == request.select_target_height) {
+            std::fprintf(stderr,
+                         "[timeline] semantic capture endpoint matched submit=%llu target-draw=%zu\n",
+                         static_cast<unsigned long long>(submit_no), i);
             return true;
+        }
+    }
+    return false;
+}
+
+bool runtime_submit_has_target(const GpuState& state, uint32_t width, uint32_t height) {
+    if (!width || !height) return false;
+    for (size_t i = 0; i < state.draws.size(); ++i) {
+        const RenderState rs = extract_render_state(state.state_at_draw(i));
+        if (rs.color0_width == width && rs.color0_height == height) return true;
     }
     return false;
 }
@@ -971,6 +1028,14 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
     RuntimeDetailRequest& request = runtime_detail_request();
     RuntimeProducerHistory& history = runtime_producer_history();
+    if (request.valid && request.bundle_start_target_width && !request.bundle_start_reached &&
+        runtime_submit_has_target(state, request.bundle_start_target_width,
+                                  request.bundle_start_target_height)) {
+        request.bundle_start_reached = true;
+        std::fprintf(stderr, "[timeline] capture bundle start reached submit=%llu target=%ux%u\n",
+                     static_cast<unsigned long long>(submit_no),
+                     request.bundle_start_target_width, request.bundle_start_target_height);
+    }
     const bool capture_endpoint = request.valid &&
         runtime_capture_endpoint_matches(request, state, submit_no);
     const uint64_t bundle_first = request.bundle_depth > request.submit_no
@@ -978,6 +1043,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     if (request.valid && !request.bundle_path.empty() &&
         !runtime_capture_bundle().budget_exhausted && !runtime_capture_bundle().failed &&
         submit_no >= bundle_first &&
+        (!request.bundle_start_target_width || request.bundle_start_reached) &&
         !capture_endpoint) {
         begin_runtime_capture_bundle();
         GpuCaptureFile predecessor;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -169,6 +169,37 @@ int main() {
           error == "capture blob content hash mismatch",
           "writer rejects a resource version whose content identity is stale");
 
+    set_gpu_capture_rtt_seed_reader([](uint64_t addr, GpuCaptureRttSeed& seed) {
+        if (addr != 0x9000) return false;
+        seed.guest_addr = addr; seed.width = 2; seed.height = 2;
+        seed.rgba.assign(16, 0x5a);
+        return true;
+    });
+    GpuCaptureRttSeed exported_seed;
+    CHECK(read_gpu_capture_rtt_seed(0x9000, exported_seed, error) &&
+          exported_seed.guest_addr == 0x9000 && exported_seed.rgba.size() == 16 &&
+          exported_seed.rgba[0] == 0x5a,
+          "registered RTT reader exports a validated temporal seed");
+    set_gpu_capture_rtt_seed_snapshot_reader([](std::vector<GpuCaptureRttSeed>& seeds, std::string&) {
+        GpuCaptureRttSeed high, low;
+        high.guest_addr = 0xa000; high.width = 1; high.height = 1; high.rgba.assign(4, 0xa0);
+        low.guest_addr = 0x8000; low.width = 1; low.height = 1; low.rgba.assign(4, 0x80);
+        seeds.push_back(std::move(high)); seeds.push_back(std::move(low));
+        return true;
+    });
+    std::vector<GpuCaptureRttSeed> exported_seeds;
+    CHECK(read_all_gpu_capture_rtt_seeds(exported_seeds, error) && exported_seeds.size() == 2 &&
+          exported_seeds[0].guest_addr == 0x8000 && exported_seeds[1].guest_addr == 0xa000,
+          "registered RTT snapshot reader exports and sorts the complete live cache");
+    set_gpu_capture_rtt_seed_snapshot_reader({});
+    CHECK(!read_all_gpu_capture_rtt_seeds(exported_seeds, error) &&
+          error == "live renderer has no RTT seed snapshot reader",
+          "RTT snapshot export fails explicitly without a registered renderer reader");
+    set_gpu_capture_rtt_seed_reader({});
+    CHECK(!read_gpu_capture_rtt_seed(0x9000, exported_seed, error) &&
+          error == "live renderer has no RTT seed reader",
+          "RTT export fails explicitly without a registered renderer reader");
+
     auto truncated = path; truncated += ".truncated";
     std::filesystem::copy_file(path, truncated, std::filesystem::copy_options::overwrite_existing);
     std::filesystem::resize_file(truncated, std::filesystem::file_size(truncated) - 5);

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -78,11 +78,16 @@ int main() {
     GpuCaptureBundle loaded;
     CHECK(read_gpu_capture_bundle(path.string(), loaded, error), "checksummed bundle reads");
     GpuCaptureFile restored_first, restored_second;
+    GpuCaptureFile second_manifest;
     CHECK(materialize_gpu_capture_bundle_submit(loaded, 0, restored_first, error) &&
           materialize_gpu_capture_bundle_submit(loaded, 1, restored_second, error) &&
           restored_second.metadata.submit_index == 42 && restored_second.blobs.size() == 1 &&
           restored_second.blobs[0].guest_addr == 0x200000 && restored_second.blobs[0].bytes == blob.bytes,
           "bundle reconstructs an exact validated capture");
+    CHECK(materialize_gpu_capture_bundle_manifest(loaded, 1, second_manifest, error) &&
+          second_manifest.metadata.submit_index == 42 && second_manifest.blobs.size() == 1 &&
+          second_manifest.blobs[0].bytes.empty() && second_manifest.draws.size() == restored_second.draws.size(),
+          "manifest-only materialization exposes submit state without resource payload reconstruction");
     restored_first.blobs[0].bytes[0] ^= 0xff;
     CHECK(restored_second.blobs[0].bytes == blob.bytes,
           "materialized submits own independent mutable resource bytes");

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -1,5 +1,6 @@
 #include "../src/gpu/gpu_timeline.hpp"
 #include "../src/gpu/gpu_capture_bundle.hpp"
+#include "../src/gpu/pm4_registers.hpp"
 
 #include <chrono>
 #include <cstdio>
@@ -140,6 +141,7 @@ int main() {
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", predecessor_capture.c_str());
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str());
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2");
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362");
 #else
     setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
     setenv("PROSPER_CAPTURE_TITLE", "runtime-title", 1);
@@ -148,8 +150,15 @@ int main() {
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", predecessor_capture.c_str(), 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str(), 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2", 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362", 1);
 #endif
+    GpuState prestart_state;
+    begin_gpu_timeline_submit(40);
+    record_gpu_timeline_submit(prestart_state, 40);
     GpuState predecessor_state;
+    predecessor_state.cx[prosper::agc::Pm4::CB_COLOR0_ATTRIB2] =
+        ((642u - 1u) << 14) | (362u - 1u);
+    predecessor_state.draws.push_back({3});
     predecessor_state.command_order = 120;
     begin_gpu_timeline_submit(41);
     record_gpu_timeline_submit(predecessor_state, 41);
@@ -161,7 +170,7 @@ int main() {
     close_gpu_timeline();
     GpuTimelineFile runtime_timeline;
     CHECK(read_gpu_timeline(runtime, runtime_timeline, error), "runtime hooks produce an inspectable timeline");
-    CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 2 &&
+    CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 3 &&
           runtime_timeline.presents[0].latest_submit_no == 42,
           "a flip during folding is associated with its active submit");
     CHECK(runtime_timeline.details.size() == 3 && runtime_timeline.details[0].submit_no == 41 &&
@@ -176,6 +185,8 @@ int main() {
           runtime_bundle.submits.size() == 2 && runtime_bundle.submits[0].submit_index == 41 &&
           runtime_bundle.submits[1].submit_index == 42,
           "exact submit selection writes an ordered same-run capture bundle");
+    CHECK(runtime_bundle.submits.front().submit_index == 41,
+          "bundle start target excludes earlier nonmatching submits and includes the first writer");
 
     const auto compat_v2 = base.string() + "-compat-v2.prgtl";
     GpuTimelineWriter compat_writer;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -94,14 +94,30 @@ Bundles use content-defined chunks so shifted capture metadata does not defeat c
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM=WxH` restricts predecessor captures to draws targeting that extent;
 it is a size diagnostic, not a dependency proof. `gpu_replay --bundle-zero-boundary` supplies transparent
 pixels to the oldest unseeded temporal leaves for an explicit A/B test and labels the synthetic seeds.
+`PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=WxH` delays bundle capture until the first matching target
+writer while timeline/lifetime recording continues, avoiding progression distortion from irrelevant submits.
 `gpu_replay --bundle-tail N` skips older manifests without changing dictionary content; use it only when
 lifetime evidence proves the suffix contains the target's beginning, then inspect its lower-bound frontier.
+`gpu_replay --bundle-intermediate-through-target WxH` omits later passes from non-final submits only when
+dependency evidence proves that the named target family is the sole temporal image frontier.
+`gpu_replay --bundle-final-capsule PATH` exports the complete live color RTT cache; verify its standalone output
+hash against the bundle before using it for rapid final-submit isolation. Persistent Vulkan depth/stencil images
+are not serialized yet (#569/#611), so complete color seeds do not guarantee equality.
+`gpu_replay --bundle-extract-submit N PATH` materializes one exact manifest for normal inspect/graph/validate
+work without replaying the bundle.
+`gpu_replay --bundle-find-ds ADDR` scans compact manifests for guest depth/stencil use, writes, clears, compare
+ops, and target extents without reconstructing resource payloads or invoking Vulkan.
+`gpu_replay --through-operation N` preserves the inclusive mixed graphics/compute prefix and is the preferred
+final-composition bisect after a seeded capsule has matched the full bundle hash.
 `gpu_replay --bundle-compact PATH` removes dictionary resources/chunks unreachable from retained rolling
 manifests and exits without Vulkan when no image output path is supplied.
 Set `PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1` for long unattended runs; it exits only after the selected
 capsule and requested bundle are installed, never on capture failure or budget exhaustion.
 For timing-sensitive routes, `PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=WxH` selects the first matching
-submit at or after `CAPTURE_SUBMIT`; `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N` can reject loading passes.
+submit at or after `CAPTURE_SUBMIT`; `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N` and
+`PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=N` bound semantic complexity to reject loading or cinematic passes.
+`PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=MIN:MAX` narrows where the selected target may occur in the
+raw semantic draw sequence; derive it from repeated positives and nearby negative samples.
 When the endpoint moves, predecessor manifests roll forward so the final bundle retains the latest requested
 depth; dictionary bytes observed by evicted manifests still count against the unique-byte budget.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened
@@ -122,6 +138,9 @@ The draw header also reports raster state as `raster=cull/front-face/polygon-mod
 values. `PROSPER_NO_CULL=1` disables culling; `PROSPER_FLIP_FRONT_FACE=1` preserves the cull mode and
 toggles only the resolved winding convention. The latter is useful for isolating `PA_SU_SC_MODE_CNTL`
 translation without the overdraw introduced by disabling culling entirely.
+`PROSPER_EXECLOG=1` includes command order, target extent, depth/stencil identity, compare/write state, and clear
+intent on recompile failures. `PROSPER_DS_CLEARLOG=1` logs only nonzero fold-time `DB_RENDER_CONTROL` clear-enable
+writes, which is suitable for detecting transient clear pulses without `PROSPER_GFXLOG` packet volume.
 Use `gpu_replay --validate` to reflect every draw's statically used VS/PS descriptor interface and validate it
 against the captured runtime resource tables without initializing Vulkan. It exits nonzero for malformed SPIR-V,
 stage/set mismatches, missing or duplicate bindings, wrong descriptor classes, or statically provable undersized

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -22,6 +22,12 @@ Create a capsule with the native-speed workflow in
 ./build-linux/gpu_replay --prepend /tmp/producer.prgcap /tmp/consumer.prgcap /tmp/closure.bmp
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle /tmp/closure.bmp
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-tail 2 /tmp/tail.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle \
+  --bundle-intermediate-through-target 642x362 /tmp/closure.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle \
+  --bundle-final-capsule /tmp/final-seeded.prgcap /tmp/closure.bmp
+./build-linux/gpu_replay --bundle /tmp/window.prgbundle \
+  --bundle-extract-submit 19046 /tmp/submit-19046.prgcap
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-compact /tmp/compact.prgbundle
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-zero-boundary /tmp/zero-ab.bmp
 ```
@@ -51,6 +57,7 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 
 ```bash
 ./build-linux/gpu_replay --draw 12:18 /tmp/submit.prgcap /tmp/pass.bmp
+./build-linux/gpu_replay --through-operation 52 /tmp/submit.prgcap /tmp/prefix.bmp
 ./build-linux/gpu_replay --dump-resource 18:ps:34 /tmp/texture.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
 ```
@@ -58,6 +65,13 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 `--draw` uses realized draw indices, while graphs use mixed semantic operation indices. They are not
 interchangeable when dispatches or unrealized operations are present. Replay restores serialized render-target
 seeds before operation zero and uses owned resource memory; it must not dereference original guest mappings.
+Bundle operation sources are semantic draw IDs and may contain holes; tooling must resolve them through each
+realized item's `draw_index`, never treat them as offsets into the compact draw vector.
+
+`--through-operation N` executes the inclusive mixed graphics/compute prefix `0..N`, preserving operation
+order and all earlier work. Prefix output uses the last executed draw target's native dimensions. Use it with
+a hash-verified seeded final capsule for fast composition bisection; unlike `--draw`, it does not discard
+compute dispatches or earlier draws.
 
 `--prepend` materializes and executes one earlier capsule in the same renderer instance before the consumer.
 Its rendered targets take precedence over consumer RTT seeds at matching addresses; unrelated seeds are still
@@ -82,6 +96,27 @@ Bundle files use `.prgbundle`, contain title-derived data, are gitignored, and m
 dictionary. Use it when lifetime evidence proves that earlier submits cannot be target producers; the first
 replayed submit becomes the explicit configured boundary and its graph must still be inspected for leaves.
 
+`--bundle-intermediate-through-target WxH` stops each non-final submit after its last realized draw to that
+target extent. It avoids rendering later presentation/UI passes when timeline and dependency evidence proves
+that only the named target family crosses submit boundaries. The final submit remains complete. Replay aborts
+if an included temporal image leaf has another extent or an intermediate submit has no matching draw. This is
+an evidence-gated optimization, not automatic dependency closure.
+
+`--bundle-final-capsule PATH` snapshots the complete live color RTT cache before executing the final submit
+and writes it as seeds in a standalone capsule. Its standalone output must match the bundle's final hash before
+using it for fast `--draw`, resource, or shader experiments. Export validates every surface and fails when a
+required temporal surface is absent; it never substitutes zero pixels. The capsule does not yet serialize live
+Vulkan depth/stencil images (#569/#611), so a hash mismatch can remain even when every color seed is exact.
+
+`--bundle-extract-submit N PATH` materializes one run-local submit manifest as a normal capsule and exits
+without Vulkan when no image output is requested. Use it to inspect, graph, or validate the exact predecessor
+whose frontier or cache behavior is in question.
+
+`--bundle-find-ds ADDR` scans only the compact submit manifests and reports every submit whose depth/stencil
+read or write bases match `ADDR`, including draw range, target extent, depth-test/write counts, clear count,
+and compare-op bitmask. It does not reconstruct resource payloads or initialize Vulkan. Use it to establish a
+guest DS surface's lifetime before expanding a replay window or changing cache behavior.
+
 `--bundle-compact PATH` writes a validated copy containing only resources and chunks reachable from retained
 submit manifests. It is useful after a rolling semantic capture; with no image output argument, compaction
 exits without initializing Vulkan. Combine it with `--bundle-tail N` to write a compact suffix bundle.
@@ -92,6 +127,13 @@ It can disprove stale guest backing versus zero initialization as the cause of a
 faithful replacement for the missing producer history.
 
 ## Current Dead Cells reference
+
+The #608 playable closure selects exactly 90 semantic draws with the 738x420 pass at draw 79..81. Its retained
+submits 18,165..19,047 represent 158.94 GiB logically and 739 MiB uniquely. Replay resolves 1,764 temporal image
+dependencies with zero bounded/unresolved leaves and renders hash `5759c125812154dc`. A complete-color-cache
+final capsule renders `71b84bdfae53933c` because it begins with fresh depth. Manifest scanning shows the same
+642x362 depth address in all 883 submits, always with LESS_OR_EQUAL tests/writes and never a clear. This is the
+#611 depth-lifetime bug and #569 checkpoint gap; it is not evidence for another color RTT producer.
 
 The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. Timeline-v4
 full-run aggregation shows that both surfaces begin around submit 17,400 in current runs and are rewritten

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -26,7 +27,12 @@ bool set_environment(const std::string& name, const std::string& value) {
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] "
+                         "[--through-operation N] "
                          "[--bundle capture.prgbundle] [--bundle-tail N] [--bundle-compact PATH] "
+                         "[--bundle-intermediate-through-target WxH] "
+                         "[--bundle-final-capsule PATH] "
+                         "[--bundle-extract-submit N PATH] "
+                         "[--bundle-find-ds ADDR] "
                          "[--bundle-zero-boundary] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
@@ -35,15 +41,20 @@ void usage(const char* argv0) {
 }
 
 std::vector<uint8_t> execute_frame(const prosper::gpu::GpuReplayFrame& replay,
-                                   bool draws_only = false) {
+                                   bool draws_only = false,
+                                   size_t operation_limit = SIZE_MAX) {
     std::vector<prosper::gpu::SubmitOperation> operations;
-    for (const auto& operation : replay.operations)
+    const size_t count = std::min(operation_limit, replay.operations.size());
+    for (size_t i = 0; i < count; ++i) {
+        const auto& operation = replay.operations[i];
         if (operation.realized)
             operations.push_back({operation.kind, static_cast<size_t>(operation.source_index),
                                   operation.command_order});
-    if (operations.empty() || draws_only)
+    }
+    if (draws_only || replay.operations.empty())
         return prosper::gpu::render_submit_items(
             replay.items, replay.metadata.width, replay.metadata.height);
+    if (operations.empty()) return {};
     auto result = prosper::gpu::execute_ordered_items(
         operations, replay.items, replay.computes,
         [](const auto& items, uint32_t width, uint32_t height) {
@@ -293,7 +304,11 @@ bool ranges_overlap(uint64_t a, uint64_t as, uint64_t b, uint64_t bs) {
 }
 
 int replay_bundle(const std::string& path, const char* output_path, bool zero_boundary,
-                  size_t tail_count, const std::string& compact_path) {
+                  size_t tail_count, const std::string& compact_path,
+                  uint32_t intermediate_target_width, uint32_t intermediate_target_height,
+                  const std::string& final_capsule_path,
+                  uint64_t extract_submit_no, const std::string& extract_submit_path,
+                  uint64_t find_ds_addr) {
     prosper::gpu::GpuCaptureBundle bundle;
     std::string error;
     if (!prosper::gpu::read_gpu_capture_bundle(path, bundle, error)) {
@@ -316,6 +331,48 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                  static_cast<unsigned long long>(stats.resource_logical_bytes),
                  static_cast<unsigned long long>(stats.resource_unique_bytes),
                  static_cast<unsigned long long>(stats.manifest_unique_bytes));
+    if (find_ds_addr) {
+        size_t matching_submits = 0;
+        for (size_t i = first_submit_index; i < bundle.submits.size(); ++i) {
+            prosper::gpu::GpuCaptureFile manifest;
+            if (!prosper::gpu::materialize_gpu_capture_bundle_manifest(bundle, i, manifest, error)) {
+                std::fprintf(stderr, "gpu_replay: cannot reconstruct bundle manifest %zu: %s\n",
+                             i, error.c_str());
+                return 2;
+            }
+            size_t matches = 0, tests = 0, writes = 0, clears = 0;
+            uint32_t compare_mask = 0, width = 0, height = 0;
+            uint64_t first_draw = UINT64_MAX, last_draw = 0;
+            for (const auto& draw : manifest.draws) {
+                const auto& ps = draw.ps;
+                if (ps.depth_read_base != find_ds_addr && ps.depth_write_base != find_ds_addr &&
+                    ps.stencil_read_base != find_ds_addr && ps.stencil_write_base != find_ds_addr)
+                    continue;
+                ++matches;
+                tests += ps.depth_test_enable;
+                writes += ps.depth_write_enable;
+                clears += ps.depth_clear_enable || ps.stencil_clear_enable;
+                if (ps.depth_test_enable && ps.depth_compare_op < 32)
+                    compare_mask |= 1u << ps.depth_compare_op;
+                if (first_draw == UINT64_MAX) {
+                    first_draw = draw.draw_index; width = draw.color0_width; height = draw.color0_height;
+                }
+                last_draw = draw.draw_index;
+            }
+            if (!matches) continue;
+            ++matching_submits;
+            std::printf("ds-submit=%llu draws=%zu first=%llu last=%llu target=%ux%u "
+                        "tests=%zu writes=%zu clears=%zu compare-mask=%08x\n",
+                        static_cast<unsigned long long>(manifest.metadata.submit_index), matches,
+                        static_cast<unsigned long long>(first_draw),
+                        static_cast<unsigned long long>(last_draw), width, height,
+                        tests, writes, clears, compare_mask);
+        }
+        std::fprintf(stderr, "[gpureplay] DS address %016llx matched %zu/%zu submits\n",
+                     static_cast<unsigned long long>(find_ds_addr), matching_submits,
+                     bundle.submits.size() - first_submit_index);
+        return matching_submits ? 0 : 1;
+    }
     if (first_submit_index)
         std::fprintf(stderr, "[gpureplay] replaying tail submits=%zu range=%llu..%llu\n",
                      bundle.submits.size() - first_submit_index,
@@ -339,7 +396,26 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                      static_cast<unsigned long long>(before),
                      static_cast<unsigned long long>(after), bundle.resources.size(),
                      bundle.chunks.size(), compact_path.c_str());
-        if (!output_path) return 0;
+        if (!output_path && final_capsule_path.empty() && extract_submit_path.empty()) return 0;
+    }
+    if (!extract_submit_path.empty()) {
+        const auto manifest = std::find_if(bundle.submits.begin(), bundle.submits.end(),
+            [&](const auto& submit) { return submit.submit_index == extract_submit_no; });
+        if (manifest == bundle.submits.end()) {
+            std::fprintf(stderr, "gpu_replay: bundle has no submit %llu\n",
+                         static_cast<unsigned long long>(extract_submit_no));
+            return 2;
+        }
+        prosper::gpu::GpuCaptureFile extracted;
+        const size_t index = static_cast<size_t>(manifest - bundle.submits.begin());
+        if (!prosper::gpu::materialize_gpu_capture_bundle_submit(bundle, index, extracted, error) ||
+            !prosper::gpu::write_gpu_capture(extract_submit_path, extracted, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot extract bundle submit: %s\n", error.c_str());
+            return 2;
+        }
+        std::fprintf(stderr, "[gpureplay] extracted submit=%llu -> %s\n",
+                     static_cast<unsigned long long>(extract_submit_no), extract_submit_path.c_str());
+        if (!output_path && final_capsule_path.empty()) return 0;
     }
 
     prosper::gpu::GpuCaptureFile final_capture;
@@ -358,6 +434,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
     set_environment("PROSPER_RENDER_FIRST", "0");
     set_environment("PROSPER_RENDER_LAST", "2147483647");
     set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
+    if (!final_capsule_path.empty()) set_environment("PROSPER_GPU_REPLAY_EXPORT_RTT", "1");
     prosper::frontend::register_live_renderer(".", false);
     final_capture = {};
 
@@ -381,6 +458,47 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             std::fprintf(stderr, "gpu_replay: cannot graph bundle submit %llu: %s\n",
                          static_cast<unsigned long long>(capture.metadata.submit_index), error.c_str());
             return 2;
+        }
+        // Operation sources are semantic draw IDs; unrealized draws leave holes in the compact item vector.
+        std::unordered_map<uint64_t, size_t> draw_item_by_index;
+        for (size_t item_index = 0; item_index < replay.items.size(); ++item_index)
+            draw_item_by_index[replay.items[item_index].draw_index] = item_index;
+        size_t operation_limit = replay.operations.size();
+        if (i + 1 < bundle.submits.size() && intermediate_target_width) {
+            operation_limit = 0;
+            for (size_t operation_index = 0; operation_index < replay.operations.size(); ++operation_index) {
+                const auto& operation = replay.operations[operation_index];
+                if (!operation.realized ||
+                    operation.kind != prosper::gpu::SubmitOperationKind::Draw) continue;
+                const auto item = draw_item_by_index.find(operation.source_index);
+                if (item == draw_item_by_index.end()) continue;
+                const auto& draw = replay.items[item->second];
+                if (draw.color0_width == intermediate_target_width &&
+                    draw.color0_height == intermediate_target_height)
+                    operation_limit = operation_index + 1;
+            }
+            if (!operation_limit) {
+                std::fprintf(stderr,
+                             "gpu_replay: bundle submit %llu has no realized %ux%u target\n",
+                             static_cast<unsigned long long>(capture.metadata.submit_index),
+                             intermediate_target_width, intermediate_target_height);
+                return 2;
+            }
+            for (const auto& leaf : graph.external_leaves) {
+                if (leaf.first_future_writer == UINT32_MAX ||
+                    leaf.consumer_operations.front() >= operation_limit ||
+                    (leaf.access.resource_class != prosper::gpu::ResourceClass::Texture &&
+                     leaf.access.resource_class != prosper::gpu::ResourceClass::StorageImage) ||
+                    (leaf.access.width == intermediate_target_width &&
+                     leaf.access.height == intermediate_target_height)) continue;
+                std::fprintf(stderr,
+                             "gpu_replay: refusing intermediate truncation at submit %llu: "
+                             "temporal leaf op=%u is %ux%u, not %ux%u\n",
+                             static_cast<unsigned long long>(capture.metadata.submit_index),
+                             leaf.consumer_operations.front(), leaf.access.width, leaf.access.height,
+                             intermediate_target_width, intermediate_target_height);
+                return 2;
+            }
         }
         std::vector<uint64_t> diagnostic_zero_seeds;
         if (i == first_submit_index && zero_boundary) {
@@ -449,19 +567,72 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             if (std::none_of(prior_targets.begin(), prior_targets.end(), [&](const auto& target) {
                     return target.addr == seed.guest_addr;
                 })) seeds.push_back(seed);
+        if (i + 1 == bundle.submits.size() && !final_capsule_path.empty()) {
+            std::unordered_set<uint64_t> required;
+            for (const auto& leaf : graph.external_leaves) {
+                if (leaf.first_future_writer == UINT32_MAX ||
+                    (leaf.access.resource_class != prosper::gpu::ResourceClass::Texture &&
+                     leaf.access.resource_class != prosper::gpu::ResourceClass::StorageImage)) continue;
+                required.insert(leaf.access.addr);
+            }
+            std::vector<prosper::gpu::GpuCaptureRttSeed> snapshot;
+            if (!prosper::gpu::read_all_gpu_capture_rtt_seeds(snapshot, error)) {
+                std::fprintf(stderr, "gpu_replay: cannot snapshot final RTT cache: %s\n",
+                             error.c_str());
+                return 2;
+            }
+            size_t exported = 0, refreshed = 0;
+            for (auto& seed : snapshot) {
+                const uint64_t addr = seed.guest_addr;
+                auto existing = std::find_if(capture.rtt_seeds.begin(), capture.rtt_seeds.end(),
+                    [&](const auto& candidate) { return candidate.guest_addr == addr; });
+                if (existing == capture.rtt_seeds.end()) {
+                    capture.rtt_seeds.push_back(std::move(seed));
+                    ++exported;
+                } else {
+                    *existing = std::move(seed);
+                    ++refreshed;
+                }
+            }
+            for (uint64_t addr : required)
+                if (std::none_of(capture.rtt_seeds.begin(), capture.rtt_seeds.end(),
+                    [&](const auto& seed) { return seed.guest_addr == addr; })) {
+                    std::fprintf(stderr,
+                                 "gpu_replay: final RTT snapshot lacks required temporal seed %016llx\n",
+                                 static_cast<unsigned long long>(addr));
+                    return 2;
+                }
+            if (!prosper::gpu::write_gpu_capture(final_capsule_path, capture, error)) {
+                std::fprintf(stderr, "gpu_replay: cannot write final seeded capsule: %s\n",
+                             error.c_str());
+                return 2;
+            }
+            std::fprintf(stderr,
+                         "[gpureplay] exported final seeded capsule cache-surfaces=%zu required=%zu "
+                         "new-seeds=%zu refreshed=%zu total-seeds=%zu -> %s\n",
+                         snapshot.size(), required.size(), exported, refreshed, capture.rtt_seeds.size(),
+                         final_capsule_path.c_str());
+        }
         if (!prosper::gpu::restore_gpu_replay_rtt_seeds(seeds, error)) {
             std::fprintf(stderr, "gpu_replay: cannot restore bundle RTT seeds: %s\n", error.c_str());
             return 2;
         }
-        final_pixels = execute_frame(replay);
-        for (const auto& draw : replay.items)
+        final_pixels = execute_frame(replay, false, operation_limit);
+        for (size_t operation_index = 0; operation_index < operation_limit; ++operation_index) {
+            const auto& operation = replay.operations[operation_index];
+            if (!operation.realized ||
+                operation.kind != prosper::gpu::SubmitOperationKind::Draw) continue;
+            const auto item = draw_item_by_index.find(operation.source_index);
+            if (item == draw_item_by_index.end()) continue;
+            const auto& draw = replay.items[item->second];
             if (draw.color0_base && draw.color0_width && draw.color0_height)
                 prior_targets.push_back({draw.color0_base,
                     static_cast<uint64_t>(draw.color0_width) * draw.color0_height * 4,
                     capture.metadata.submit_index});
-        std::fprintf(stderr, "[gpureplay] bundle-submit=%llu operations=%zu output_bytes=%zu hash=%016llx\n",
+        }
+        std::fprintf(stderr, "[gpureplay] bundle-submit=%llu operations=%zu/%zu output_bytes=%zu hash=%016llx\n",
                      static_cast<unsigned long long>(capture.metadata.submit_index),
-                     replay.operations.size(), final_pixels.size(),
+                     operation_limit, replay.operations.size(), final_pixels.size(),
                      static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(final_pixels)));
     }
     std::fprintf(stderr, "[gpureplay] closure temporal-resolved=%llu seeded=%llu bounded=%llu "
@@ -489,9 +660,15 @@ int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool graph_only = false, bundle_zero_boundary = false;
     size_t bundle_tail = 0;
+    uint32_t bundle_intermediate_target_width = 0, bundle_intermediate_target_height = 0;
     int draw_first = -1, draw_last = -1;
+    int through_operation = -1;
     std::string dump_spec, dump_path, shader_spec, shader_path, graph_json_path, prepend_path;
     std::string bundle_path, bundle_compact_path;
+    std::string bundle_final_capsule_path;
+    std::string bundle_extract_submit_path;
+    uint64_t bundle_extract_submit_no = 0;
+    uint64_t bundle_find_ds_addr = 0;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
@@ -512,11 +689,37 @@ int main(int argc, char** argv) {
             if (!end || *end || !value || value > SIZE_MAX) { usage(argv[0]); return 2; }
             bundle_tail = static_cast<size_t>(value);
         }
+        else if (std::string(argv[i]) == "--bundle-intermediate-through-target" && i + 1 < argc) {
+            unsigned width = 0, height = 0; char tail = 0;
+            if (std::sscanf(argv[++i], "%ux%u%c", &width, &height, &tail) != 2 ||
+                !width || !height) { usage(argv[0]); return 2; }
+            bundle_intermediate_target_width = width;
+            bundle_intermediate_target_height = height;
+        }
+        else if (std::string(argv[i]) == "--bundle-final-capsule" && i + 1 < argc)
+            bundle_final_capsule_path = argv[++i];
+        else if (std::string(argv[i]) == "--bundle-extract-submit" && i + 2 < argc) {
+            char* end = nullptr;
+            bundle_extract_submit_no = std::strtoull(argv[++i], &end, 0);
+            if (!end || *end || !bundle_extract_submit_no) { usage(argv[0]); return 2; }
+            bundle_extract_submit_path = argv[++i];
+        }
+        else if (std::string(argv[i]) == "--bundle-find-ds" && i + 1 < argc) {
+            char* end = nullptr;
+            bundle_find_ds_addr = std::strtoull(argv[++i], &end, 0);
+            if (!end || *end || !bundle_find_ds_addr) { usage(argv[0]); return 2; }
+        }
         else if (std::string(argv[i]) == "--prepend" && i + 1 < argc) prepend_path = argv[++i];
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
             std::string range = argv[++i]; size_t colon = range.find(':');
             draw_first = std::atoi(range.c_str());
             draw_last = colon == std::string::npos ? draw_first : std::atoi(range.c_str() + colon + 1);
+        }
+        else if (std::string(argv[i]) == "--through-operation" && i + 1 < argc) {
+            char* end = nullptr;
+            const long value = std::strtol(argv[++i], &end, 0);
+            if (!end || *end || value < 0 || value > INT_MAX) { usage(argv[0]); return 2; }
+            through_operation = static_cast<int>(value);
         }
         else if (std::string(argv[i]) == "--dump-resource" && i + 2 < argc) {
             dump_spec = argv[++i]; dump_path = argv[++i];
@@ -528,16 +731,26 @@ int main(int argc, char** argv) {
     }
     if (!bundle_path.empty()) {
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
-            draw_first >= 0 || !dump_spec.empty() || !shader_spec.empty() || !prepend_path.empty()) {
+            draw_first >= 0 || through_operation >= 0 || !dump_spec.empty() ||
+            !shader_spec.empty() || !prepend_path.empty()) {
             usage(argv[0]); return 2;
         }
         return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
-                             bundle_zero_boundary, bundle_tail, bundle_compact_path);
+                             bundle_zero_boundary, bundle_tail, bundle_compact_path,
+                             bundle_intermediate_target_width,
+                             bundle_intermediate_target_height,
+                             bundle_final_capsule_path,
+                             bundle_extract_submit_no,
+                             bundle_extract_submit_path,
+                             bundle_find_ds_addr);
     }
-    if (bundle_zero_boundary || bundle_tail || !bundle_compact_path.empty()) {
+    if (bundle_zero_boundary || bundle_tail || !bundle_compact_path.empty() ||
+        bundle_intermediate_target_width || !bundle_final_capsule_path.empty() ||
+        !bundle_extract_submit_path.empty() || bundle_find_ds_addr) {
         usage(argv[0]); return 2;
     }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
+    if (draw_first >= 0 && through_operation >= 0) { usage(argv[0]); return 2; }
     prosper::gpu::GpuCaptureFile capture; std::string error;
     if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {
         std::fprintf(stderr, "gpu_replay: %s: %s\n", positional[0], error.c_str()); return 2;
@@ -625,6 +838,14 @@ int main(int argc, char** argv) {
         replay.items = std::move(selected); allow_mismatch = true;
         std::fprintf(stderr, "[gpureplay] selected original draws %d:%d\n", draw_first, draw_last);
     }
+    if (through_operation >= 0) {
+        if (static_cast<size_t>(through_operation) >= replay.operations.size()) {
+            std::fprintf(stderr, "gpu_replay: operation %d is out of range\n", through_operation);
+            return 2;
+        }
+        allow_mismatch = true;
+        std::fprintf(stderr, "[gpureplay] executing through mixed operation %d\n", through_operation);
+    }
     const auto& m = replay.metadata;
     std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu computes=%zu "
                          "operations=%zu shaders=%zu blobs=%zu RTT-seeds=%zu oracle=%s\n",
@@ -660,13 +881,32 @@ int main(int argc, char** argv) {
     if (!prosper::gpu::restore_gpu_replay_rtt_seeds(consumer_seeds, error)) {
         std::fprintf(stderr, "gpu_replay: cannot restore RTT seeds: %s\n", error.c_str()); return 2;
     }
-    std::vector<uint8_t> pixels = execute_frame(replay, draw_first >= 0);
+    const size_t operation_limit = through_operation >= 0
+        ? static_cast<size_t>(through_operation) + 1 : SIZE_MAX;
+    std::vector<uint8_t> pixels = execute_frame(replay, draw_first >= 0, operation_limit);
+    uint32_t output_width = m.width, output_height = m.height;
+    if (through_operation >= 0) {
+        for (size_t operation_index = 0; operation_index < operation_limit; ++operation_index) {
+            const auto& operation = replay.operations[operation_index];
+            if (!operation.realized ||
+                operation.kind != prosper::gpu::SubmitOperationKind::Draw) continue;
+            const auto item = std::find_if(replay.items.begin(), replay.items.end(),
+                [&](const auto& draw) { return draw.draw_index == operation.source_index; });
+            if (item != replay.items.end() && item->color0_width && item->color0_height) {
+                output_width = item->color0_width;
+                output_height = item->color0_height;
+            }
+        }
+    }
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
-    std::fprintf(stderr, "[gpureplay] output_bytes=%zu hash=%016llx expected_bytes=%llu expected_hash=%016llx\n",
-                 pixels.size(), static_cast<unsigned long long>(hash),
+    std::fprintf(stderr, "[gpureplay] output=%ux%u bytes=%zu hash=%016llx "
+                         "expected_bytes=%llu expected_hash=%016llx\n",
+                 output_width, output_height, pixels.size(), static_cast<unsigned long long>(hash),
                  static_cast<unsigned long long>(replay.expected_output_bytes),
                  static_cast<unsigned long long>(replay.expected_output_hash));
-    if (positional.size() == 2 && !pixels.empty() && !prosper::test::dump_bmp(positional[1], pixels, m.width, m.height)) {
+    if (positional.size() == 2 && !pixels.empty() &&
+        (pixels.size() != static_cast<size_t>(output_width) * output_height * 4 ||
+         !prosper::test::dump_bmp(positional[1], pixels, output_width, output_height))) {
         std::fprintf(stderr, "gpu_replay: cannot write %s\n", positional[1]); return 2;
     }
     if (!allow_mismatch && replay.expected_output_valid &&

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -2,8 +2,9 @@
 
 `PROSPER_GPU_TIMELINE=<path>.prgtl` records the guest's folded GPU-submit and VideoOut-present
 boundaries without registering or invoking the Vulkan renderer. Use the cheap semantic index to find
-the exact submit of interest, then select that stable submit number in a second run to create one
-immutable replay capsule. Vulkan warmup and renderer sampling do not control the selection.
+the scene shape of interest, then select it with target, draw-count, and draw-index predicates to create one
+immutable replay capsule. Submit numbers are run-local. Vulkan warmup and renderer sampling do not control
+the selection.
 
 ```bash
 PROSPER_GUEST_FS=1 \
@@ -38,18 +39,23 @@ PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=/tmp/dead-cells-submit-18419.prgcap \
 Capture a bounded ordered window directly into one deduplicated bundle:
 
 ```bash
-PROSPER_GPU_TIMELINE=/tmp/dead-cells-bundle.prgtl \
-PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=18420 \
-PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-submit-18420.prgcap \
-PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-depth16.prgbundle \
-PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=16 \
+PROSPER_GPU_TIMELINE=/tmp/dead-cells-gameplay.prgtl \
+PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay-capture.pad \
+PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=1 \
+PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-gameplay.prgcap \
+PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-gameplay.prgbundle \
+PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=1000 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
-PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=642x362 \
-PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=80 \
+PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=642x362 \
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=79:81 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=90 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=90 \
 PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
   ./build-linux/boot_trace /path/to/PPSA15552-app0
 
-./build-linux/gpu_replay --bundle /tmp/dead-cells-depth16.prgbundle /tmp/closure.bmp
+./build-linux/gpu_replay --bundle /tmp/dead-cells-gameplay.prgbundle \
+  --bundle-intermediate-through-target 642x362 /tmp/closure.bmp
 ```
 
 See [`../gpu_replay/README.md`](../gpu_replay/README.md) for graph interpretation, pixel-oracle
@@ -122,15 +128,25 @@ matching target extents while leaving the selected consumer complete. This is a 
 not renderer substitution. It may still be expensive when relevant passes reference large shared assets;
 unique-byte budget enforcement remains authoritative.
 
+`PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=WxH` delays predecessor bundle capture until the first submit
+that writes a target with that extent. Use it when native-speed lifetime evidence identifies the beginning of
+the relevant surface family; earlier submits remain in the timeline but do not perturb progression or consume
+bundle budget. The matching start submit is included.
+
 `PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1` terminates the process only after the selected standalone
 capsule and any requested bundle have been installed successfully. Use it for long captures instead of a
 wall-clock timeout; capture failure or budget exhaustion leaves the process running for diagnostics.
 
 `PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=WxH` changes the configured submit into a lower endpoint
 bound: the first later submit with a draw targeting that extent is selected. Optionally require a semantic
-draw count with `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N`. This keeps a long synchronous capture from
+draw-count window with `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N` and
+`PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=N`. This keeps a long synchronous capture from
 selecting the wrong scene when it perturbs wall-clock pacing. A requested bundle still begins at
 `CAPTURE_SUBMIT - CAPTURE_DEPTH + 1`; if the endpoint moves beyond that window, predecessor manifests roll
 forward so the final bundle contains exactly the latest requested depth. The dictionary may retain content
 seen by evicted manifests during capture, and the unique-byte budget remains authoritative. Finalization
 compacts unreachable dictionary entries before installing the bundle.
+
+`PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=MIN:MAX` restricts the matching target to a zero-based
+semantic draw-index window. Establish the range across multiple desired captures and nearby negative samples;
+realized replay indices can differ when earlier semantic draws are unrealized.


### PR DESCRIPTION
## Summary\n\n- add stable semantic timeline selection for the Dead Cells Jump tutorial:\n  - target extent\n  - target draw-index range\n  - minimum/maximum semantic draw count\n  - delayed bundle start at the first relevant target family\n- add evidence-gated bundle replay tools:\n  - intermediate execution through the last matching target\n  - exact submit extraction\n  - complete live color-RTT cache export\n  - inclusive mixed graphics/compute operation prefixes\n  - manifest-only depth/stencil lifetime scans\n- fix bundle replay's semantic draw-ID lookup when unrealized draws leave holes\n- enrich recompile-failure and transient DS-clear diagnostics\n- update stale root/tool/route documentation with the faithful playable checkpoint\n\n## Dead Cells result\n\nStable endpoint:\n- exactly 90 semantic draws\n- 738x420 target at semantic draw 79..81\n- 86 realized draws, 7 realized dispatches in validated captures\n\nFaithful closure:\n- submits 18165..19047 (883)\n- 158.94 GiB logical, 739 MiB unique\n- 1,764 temporal image dependencies resolved\n- 0 bounded/unresolved\n- final hash 5759c125812154dc\n\nA complete-color-cache final capsule replays to 71b84bdfae53933c, not the long-history hash. The new manifest-only scanner identifies the missing state in 4.4 seconds: the same 642x362 depth surface is used by all 883 submits with LESS_OR_EQUAL writes/tests and zero captured clears. Persistent DS state rejects most later world geometry. This is tracked in #611; DS checkpoint serialization remains #569.\n\nFocused native endpoint tracing also proves the four unrealized draws are fragment control-flow recompiler failures with ordinary depth writes, not hidden clear operations.\n\n## Verification\n\n- full build\n- ctest --test-dir prosper/build-linux --output-on-failure: 91/91 passed\n- tail-2 color checkpoint: bundled and standalone hashes both 71b84bdfae53933c\n- tail-2 BMP SHA-256 matches byte-for-byte\n- --bundle-find-ds full scan: 883/883 submits\n- --bundle-find-ds --bundle-tail 2: 2/2 submits\n\nRefs #569\nRefs #608\nRefs #611