### PR TITLE
port: run prosper core on macOS (x86_64 under Rosetta 2), boot Blasphemous 2 into guest code

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -98,7 +98,7 @@ if(TARGET prosper_core)
 
   # Guest static-TLS Variant II layout uses each module's real PT_TLS p_align (#143). The layout
   # code is Linux-only (guest %fs), so gate the test on it too.
-  if(UNIX AND NOT APPLE)
+  if(UNIX)
     add_executable(test_guest_tls_align tests/test_guest_tls_align.cpp)
     target_link_libraries(test_guest_tls_align PRIVATE prosper_core)
     add_test(NAME guest_tls_align COMMAND test_guest_tls_align)
@@ -247,7 +247,7 @@ if(TARGET prosper_core)
 
   # Hinted map must not clobber a live mapping (#137): MAP_FIXED_NOREPLACE unless the hint is our
   # own uncommitted reservation. Drives the real map HLE handlers. Linux-only (mmap semantics).
-  if(UNIX AND NOT APPLE)
+  if(UNIX)
     add_executable(test_map_noreplace tests/test_map_noreplace.cpp)
     target_link_libraries(test_map_noreplace PRIVATE prosper_core)
     add_test(NAME map_noreplace COMMAND test_map_noreplace)
@@ -393,18 +393,20 @@ if(TARGET prosper_core)
   target_link_libraries(test_writer_provenance PRIVATE prosper_core)
   add_test(NAME writer_provenance_ranges COMMAND test_writer_provenance)
 
-  # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux only).
-  if(UNIX AND NOT APPLE)
+  # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux + macOS/Rosetta).
+  if(UNIX)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)
     target_link_libraries(boot_trace PRIVATE prosper_core)
 
-    # Zero-dependency Linux evdev gamepad frontend (outside prosper_core). Always available on Linux;
-    # boot_trace installs it (gated by PROSPER_PAD) when the SDL3 gamepad frontend isn't built.
-    add_library(prosper_pad_evdev STATIC frontends/pad_evdev/pad_evdev.cpp)
-    target_include_directories(prosper_pad_evdev PUBLIC frontends/pad_evdev src)
-    target_link_libraries(prosper_pad_evdev PUBLIC prosper_core)
-    target_link_libraries(boot_trace PRIVATE prosper_pad_evdev)
-    target_compile_definitions(boot_trace PRIVATE PROSPER_PAD_EVDEV=1)
+    if(NOT APPLE)
+      # Zero-dependency Linux evdev gamepad frontend (outside prosper_core). Always available on Linux;
+      # boot_trace installs it (gated by PROSPER_PAD) when the SDL3 gamepad frontend isn't built.
+      add_library(prosper_pad_evdev STATIC frontends/pad_evdev/pad_evdev.cpp)
+      target_include_directories(prosper_pad_evdev PUBLIC frontends/pad_evdev src)
+      target_link_libraries(prosper_pad_evdev PUBLIC prosper_core)
+      target_link_libraries(boot_trace PRIVATE prosper_pad_evdev)
+      target_compile_definitions(boot_trace PRIVATE PROSPER_PAD_EVDEV=1)
+    endif()
 
     add_executable(imgdump tools/imgdump/imgdump.cpp)
     target_link_libraries(imgdump PRIVATE prosper_core)

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -23,9 +23,10 @@
 #include <unordered_set>
 #include <utility>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <sys/uio.h>
 #include <unistd.h>
+#include "../host/posix_shim.hpp"
 #endif
 
 namespace prosper::gpu {
@@ -49,7 +50,7 @@ CaptureRttSeedReader g_rtt_seed_reader;
 ReplayRttSeedWriter g_rtt_seed_writer;
 
 size_t read_capture_guest_memory(uint64_t addr, uint8_t* dst, size_t bytes) {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     size_t done = 0;
     while (done < bytes) {
         iovec local{dst + done, bytes - done};

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -10,6 +10,7 @@
 #pragma once
 #include "command_processor.hpp"   // GpuState
 #include "render_state.hpp"        // extract_render_state / resolve_pipeline_state / ResolvedPipelineState
+#include <cstring>                 // memcpy: aliasing-safe index-buffer fingerprint loads
 #include "rdna2_to_spirv.hpp"      // recompile_vertex / recompile_fragment
 #include "shader_resources.hpp"    // ShaderResourceTable
 #include "agc_shader_layout.hpp"   // DecodedBufferDescriptor (DynFetch)
@@ -204,10 +205,19 @@ inline uint32_t index_elem_bytes(uint32_t index_type) {
 inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_t* p32, uint32_t n) {
     if (n < 2) return false;                         // need at least one odd word to test
     bool odd_zero = true, all_small = true, any_nonzero = false, has_odd = false;
+    // memcpy loads, NOT typed derefs: p16/p32 view the SAME guest bytes, and reading one object
+    // through both element types is strict-aliasing UB — Apple Clang 21 at -O2 proved it and
+    // compiled the caller into ud2 (found by the macOS port; Linux GCC happened to tolerate it).
+    // Fixed-size memcpy compiles to the same single loads without the aliasing assumption.
     for (uint32_t i = 0; i < n; i++) {
-        if (i & 1) { has_odd = true; if (p16[i] != 0) odd_zero = false; }
-        if (p32[i] >= 0x10000u) all_small = false;
-        if (p32[i] != 0) any_nonzero = true;
+        if (i & 1) {
+            has_odd = true;
+            uint16_t w; memcpy(&w, (const char*)p16 + 2u * i, 2);
+            if (w != 0) odd_zero = false;
+        }
+        uint32_t d; memcpy(&d, (const char*)p32 + 4u * i, 4);
+        if (d >= 0x10000u) all_small = false;
+        if (d != 0) any_nonzero = true;
     }
     return has_odd && odd_zero && all_small && any_nonzero;
 }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -66,8 +66,20 @@ static int g_probe_pipe[2] = {-1, -1};
 // the multi-threaded HLE pointer probes: an unguarded `if (fd < 0) pipe2(...)` lazy init let two
 // first-callers each pipe2 into the array — a torn pair (write-end of pipe B, read-end of pipe A)
 // never drains, fills, and EAGAINs: VALID memory reported unreadable, silently. (PR #61 review.)
+static bool make_probe_pipe() {
+#ifdef __linux__
+    return pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) == 0;
+#else   // Darwin/BSD: no pipe2 — pipe + fcntl (still inside the once-only magic static, so no race)
+    if (pipe(g_probe_pipe) != 0) return false;
+    for (int fd : g_probe_pipe) {
+        if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) return false;
+        if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0) return false;
+    }
+    return true;
+#endif
+}
 static bool probe_pipe_ok() {
-    static const bool ok = pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) == 0;
+    static const bool ok = make_probe_pipe();
     return ok;
 }
 static bool probe_byte(uint64_t a) {

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -19,6 +19,7 @@
 #include <sys/uio.h>
 #include <unistd.h>
 #endif
+#include "../host/posix_shim.hpp"   // Darwin: process_vm_readv/writev
 
 namespace prosper {
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -29,6 +29,7 @@
 #include <direct.h>
 #include <io.h>
 #endif
+#include "../host/posix_shim.hpp"   // Darwin: process_vm_*, pthread_getattr_np, st_*tim, prosper_mincore
 
 namespace prosper {
 
@@ -569,6 +570,42 @@ HLE(f_rmdir) { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::rm
 // enumerates its pak directory with this during IO-stack init.
 HLE(f_getdents) {
     if (!a1 || a2 < 32) return 0x80020016ull;   // EINVAL
+#ifdef __APPLE__
+    // Darwin has no getdents-on-fd (getdirentries is unavailable with 64-bit inodes). Keep the
+    // per-fd kernel cursor by caching one DIR* per directory fd (fdopendir owns a dup, so the
+    // guest's fd number stays valid); seekdir puts back the first entry that doesn't fit.
+    // CONFIDENCE: MED — a guest that closes the fd and gets the number reused for a different
+    // directory would see a stale cursor; not exercised by current titles.
+    static std::mutex dirmx; static std::map<int, DIR*> dirs;
+    DIR* dp = nullptr;
+    { std::lock_guard<std::mutex> lk(dirmx);
+      auto it = dirs.find((int)a0);
+      if (it != dirs.end()) dp = it->second;
+      else {
+          int d2 = dup((int)a0);
+          dp = d2 >= 0 ? fdopendir(d2) : nullptr;
+          if (!dp) { if (d2 >= 0) ::close(d2); return 0x80020000ull | (uint64_t)(errno & 0xff); }
+          dirs[(int)a0] = dp;
+      } }
+    uint8_t* out = (uint8_t*)P(a1);
+    size_t w = 0;
+    for (;;) {
+        long pos = telldir(dp);
+        struct dirent* d = readdir(dp);
+        if (!d) break;
+        size_t namlen = d->d_namlen;
+        size_t rec = (8 + namlen + 1 + 3) & ~(size_t)3;   // 4-byte header + name + NUL, 4-aligned
+        if (w + rec > a2) { seekdir(dp, pos); break; }    // didn't fit: rewind so nothing is lost
+        uint8_t* r = out + w;
+        *(uint32_t*)(r + 0) = (uint32_t)d->d_ino;
+        *(uint16_t*)(r + 4) = (uint16_t)rec;
+        r[6] = d->d_type;
+        r[7] = (uint8_t)namlen;
+        memcpy(r + 8, d->d_name, namlen + 1);
+        w += rec;
+    }
+    return (uint64_t)w;
+#else
     struct LinuxDirent64 { uint64_t ino; int64_t off; uint16_t reclen; uint8_t type; char name[]; };
     uint8_t tmp[4096];
     size_t want = a2 < sizeof tmp ? (size_t)a2 : sizeof tmp;
@@ -592,6 +629,7 @@ HLE(f_getdents) {
         o += d->reclen;
     }
     return (uint64_t)w;
+#endif
 }
 // sceKernelGetdirentries(fd, buf, nbytes, long* basep): like getdents but also writes the pre-call
 // directory offset to *basep. Was MISSING -> returned 0 = "empty directory". Delegate to f_getdents and
@@ -781,15 +819,7 @@ extern "C" int prosper_reserved_range_state(uint64_t addr);
 extern "C" uint64_t f_apr_read_submit_c(uint64_t a0, uint64_t a1, uint64_t a2,
                                         uint64_t a3, uint64_t a4, uint64_t a5,
                                         uint64_t entry_rsp);
-asm(".text\n"
-    ".globl f_apr_read_submit_entry\n"
-    ".type f_apr_read_submit_entry,@function\n"
-    "f_apr_read_submit_entry:\n"
-    "  movq %rsp, %rax\n"
-    "  pushq %rax\n"
-    "  call f_apr_read_submit_c\n"
-    "  addq $8, %rsp\n"
-    "  ret\n");
+PROSPER_ASM_TRAMPOLINE(f_apr_read_submit_entry, f_apr_read_submit_c)
 extern "C" void f_apr_read_submit_entry();
 // Fetch the Nth stack argument (0-based: arg7 is n=0) of the in-flight ReadFile call.
 // Both stub paths land the forwarded/natural stack args at [entry_rsp+8] (layout note above).
@@ -831,7 +861,7 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     bool committed = false;
     for (uint64_t p = dst & ~0xffffull; p < dst + size; p += 0x10000) {
         unsigned char vec;
-        if (mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
+        if (prosper_mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
             prosper_reserved_range_state(p) == 1 &&
             mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,
                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == (void*)(uintptr_t)p)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -10,6 +10,7 @@
 #include "../host/exec_image.hpp"
 #include <pthread.h>
 #include <semaphore.h>   // scePthreadSem* -> host sem_t
+#include "../host/posix_shim.hpp"   // Darwin: sem/barrier/timedlock/getattr_np/sigqueue compat
 #include <cerrno>
 #include <cctype>
 #include <cstdio>
@@ -21,19 +22,21 @@
 #include <thread>
 #include <atomic>
 #include <condition_variable>
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <sys/mman.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <signal.h>
+#ifdef __linux__
 #include <ucontext.h>
+#endif
 #endif
 
 namespace prosper {
 namespace { bool sclog() { static int v = getenv("PROSPER_SYNCLOG") ? 1 : 0; return v; }
     long sctid() {
-#ifdef __linux__
-        return (long)syscall(SYS_gettid);
+#if defined(__linux__) || defined(__APPLE__)
+        return (long)prosper_gettid();
 #else
         return 0;
 #endif
@@ -365,7 +368,7 @@ HLE(k_attr_get) {
     // thread's attributes. a0 = thread handle (== the host pthread_t we store), a1 = attr handle.
     // (Bug fixed: the attr is arg1, not arg0 — reading arg0 left the real attr empty, so the GC's
     // GC_get_stack_base got a 0 stack base -> "Bad stack base in GC_register_my_thread".)
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     if (a1 && *(void**)a1) {
         auto* at = (pthread_attr_t*)*(void**)a1;
         void* base = nullptr; size_t sz = 0;
@@ -434,7 +437,7 @@ HLE(k_getprio)            { // scePthreadGetprio(thread, int* prio)
 // 8 MiB per exited thread. The trampoline still TRACKS the bounds (via pthread_getattr_np, keyed
 // by our tid) so GC/thread-stack queries stay accurate, and unregisters them on exit — pthread
 // ids are recycled, so a stale entry would serve the next thread the dead thread's bounds.
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 namespace {
 struct ThreadStart { void* (*entry)(void*); void* arg; char name[16]; };
 // Runs first on the new thread: register our own stack (keyed by our tid) BEFORE any guest code,
@@ -456,7 +459,11 @@ void* thread_trampoline(void* p) {
     // thread name so debugger/procfs views (gdb, /proc/PID/task/*/comm) show the engine's own
     // role names (GameThread, RenderThread, RHIThread, ...) instead of the binary name. Kernel
     // limit is 15 chars + NUL; host libc call, so it must run on the host %fs (we are).
+#ifdef __APPLE__
+    if (ts->name[0]) pthread_setname_np(ts->name);   // Darwin can only name the CURRENT thread (which this is)
+#else
     if (ts->name[0]) pthread_setname_np(pthread_self(), ts->name);
+#endif
     auto entry = ts->entry; void* arg = ts->arg; free(ts);   // all host libc — MUST run on the host %fs
     // gated (PROSPER_GUEST_FS): give this guest worker its own guest TCB + static TLS and switch %fs to it
     // as the LAST host action before entering guest code (so guest initial-exec TLS — incl. libc.prx's
@@ -488,7 +495,7 @@ HLE(k_pthread_create) {
         fprintf(stderr, "[thread] create entry=0x%llx arg=0x%llx name=%s\n",
                 (unsigned long long)a2, (unsigned long long)a3, a4 ? (const char*)(uintptr_t)a4 : "");
     pthread_t tid;
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     // Stack size: honor the guest attr's stacksize (previously ignored — everything got a fixed
     // 8 MiB), floored at 1 MiB because our HLE + host libc frames run deeper than Sony's runtime
     // would on the same stack. No attr (or no explicit size) keeps the 8 MiB default.
@@ -536,7 +543,7 @@ HLE(k_pthread_exit)   {
     // registration (#138 — pthread ids recycle). HLE handlers run under the HOST %fs (the import
     // stubs swap), so the host libc below is safe. No-op for threads that never touched either.
     tls_dtv_purge_current_thread();
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     unregister_thread_stack((uint64_t)pthread_self());
 #endif
     pthread_exit((void*)(uintptr_t)a0);
@@ -843,17 +850,42 @@ bool g_exc_log = false;               // set once (outside signal ctx) from PROS
 // PROSPER_SYNCLOG. Read once (getenv is not signal-safe).
 bool g_exc_log2 = false;
 volatile int* g_exc_counter = nullptr; // optional fork-safe raise counter (tests)
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 int  g_exc_sig = -1;
+#ifdef __APPLE__
+// Darwin has no pthread_sigqueue / RT-signal payload, so the exception TYPE travels through a
+// small async-signal-safe pending table keyed by the target pthread instead of si_value. A raise
+// claims a slot with CAS before pthread_kill; the handler (on the target thread) takes it back.
+// GC suspend/resume raises are sequential per target, so 16 slots is generous.
+struct ExcPending { std::atomic<uint64_t> tid{0}; std::atomic<int> type{0}; };
+ExcPending g_exc_pending[16];
+bool exc_pending_put(uint64_t tid, int type) {
+    for (auto& s : g_exc_pending) {
+        uint64_t z = 0;
+        if (s.tid.compare_exchange_strong(z, tid)) { s.type.store(type); return true; }
+    }
+    return false;
+}
+int exc_pending_take(uint64_t tid) {
+    for (auto& s : g_exc_pending)
+        if (s.tid.load() == tid) { int t = s.type.load(); s.tid.store(0); return t; }
+    return -1;
+}
+#endif
 void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
+#ifdef __APPLE__
+    (void)si;
+    int type = exc_pending_take((uint64_t)pthread_self());   // pthread_self reads %gs TSD, never %fs
+#else
     int type = si->si_value.sival_int;
+#endif
     if (type < 0 || type >= 128 || !g_exc_handlers[type]) {
         if (g_exc_log2) {   // a suspend request that silently does NOTHING = an unstopped thread
             // %fs-safe: this handler can interrupt guest code running on the GUEST %fs, where host
             // libc TLS (locale, stack canary) reads garbage — swap to host %fs for the logging.
             uint64_t sfs = guest_fs_to_host_scoped();
             char b[96]; int n = snprintf(b, sizeof b, "[exc2] DROPPED type=%d tid=%ld (no handler)\n",
-                                         type, (long)syscall(SYS_gettid));
+                                         type, (long)prosper_gettid());
             (void)!write(2, b, n);
             guest_fs_restore_scoped(sfs);
         }
@@ -862,27 +894,27 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
     if (g_exc_log2) {
         // Log the interrupted context: rip (classified guest module+off / host) and whether the
         // thread was on the guest or host %fs at interrupt time. %fs-safe (scoped host swap).
-        uint64_t irip = (uint64_t)((ucontext_t*)uc_)->uc_mcontext.gregs[REG_RIP];
+        uint64_t irip = (uint64_t)PROSPER_GREGS((ucontext_t*)uc_)[REG_RIP];
         uint64_t sfs = guest_fs_to_host_scoped();
         const char* fss = sfs ? "guest" : "host";
         char b[160]; int n;
         if (irip >= 0x400000000ull && irip < 0x420000000ull)
             n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=eboot+0x%llx\n",
-                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)(irip - 0x400000000ull));
+                         (long)prosper_gettid(), type, fss, (unsigned long long)(irip - 0x400000000ull));
         else if (irip >= 0x440000000ull && irip < 0x443000000ull)
             n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=il2cpp+0x%llx\n",
-                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)(irip - 0x440000000ull));
+                         (long)prosper_gettid(), type, fss, (unsigned long long)(irip - 0x440000000ull));
         else if (irip >= 0x500000000ull && irip < 0x501000000ull)
             n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=libc+0x%llx\n",
-                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)(irip - 0x500000000ull));
+                         (long)prosper_gettid(), type, fss, (unsigned long long)(irip - 0x500000000ull));
         else
             n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=host:0x%llx\n",
-                         (long)syscall(SYS_gettid), type, fss, (unsigned long long)irip);
+                         (long)prosper_gettid(), type, fss, (unsigned long long)irip);
         (void)!write(2, b, n);
         guest_fs_restore_scoped(sfs);
     }
     auto* uc = (ucontext_t*)uc_;
-    greg_t* g = uc->uc_mcontext.gregs;
+    auto g = PROSPER_GREGS(uc);
     // FreeBSD amd64 mcontext_t: rdi@0x08 rsi@0x10 rdx@0x18 rcx@0x20 r8@0x28 r9@0x30 rax@0x38
     // rbx@0x40 rbp@0x48 r10@0x50 r11@0x58 r12@0x60 r13@0x68 r14@0x70 r15@0x78 rip@0xA0 rsp@0xB8
     // NOT `static __thread`: guest threads run under a GUEST %fs, so a host thread_local resolves into
@@ -913,7 +945,7 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
     if (g_exc_log2) {
         uint64_t sfs = guest_fs_to_host_scoped();   // %fs-safe logging (see ENTER)
         char b[96]; int n = snprintf(b, sizeof b, "[exc2] RESUME tid=%ld type=%d\n",
-                                     (long)syscall(SYS_gettid), type);
+                                     (long)prosper_gettid(), type);
         (void)!write(2, b, n);
         guest_fs_restore_scoped(sfs);
     }
@@ -922,7 +954,11 @@ void ensure_exc_sig() {
     if (g_exc_sig != -1) return;
     g_exc_log = getenv("PROSPER_SYNCLOG") != nullptr;
     g_exc_log2 = getenv("PROSPER_EXCLOG") != nullptr;
+#ifdef __APPLE__
+    g_exc_sig = SIGUSR2;                         // no RT signals on Darwin; SIGUSR2 is otherwise unused here
+#else
     g_exc_sig = SIGRTMIN + 4;                    // free RT signal (not our SIGSEGV/ILL/BUS)
+#endif
     struct sigaction sa; memset(&sa, 0, sizeof sa);
     sa.sa_sigaction = exc_delivery_handler;
     // SA_ONSTACK: run on the per-thread sigaltstack (installed for the main thread and every worker in
@@ -955,10 +991,15 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
     if (getenv("PROSPER_SYNCLOG"))
         fprintf(stderr, "[exc] T%ld raise target=0x%llx type=0x%llx\n",
                 sctid(), (unsigned long long)a0, (unsigned long long)a1);
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     if (a0 && a1 < 128 && g_exc_handlers[a1]) {
+#ifdef __APPLE__
+        int qr = exc_pending_put((uint64_t)a0, (int)a1) ? pthread_kill((pthread_t)a0, g_exc_sig)
+                                                        : EAGAIN;   // pending table full
+#else
         union sigval sv; sv.sival_int = (int)a1;
         int qr = pthread_sigqueue((pthread_t)a0, g_exc_sig, sv);
+#endif
         if (g_exc_log2)
             fprintf(stderr, "[exc2] RAISE by tid=%ld target=0x%llx type=0x%llx sigqueue=%d\n",
                     sctid(), (unsigned long long)a0, (unsigned long long)a1, qr);
@@ -974,7 +1015,7 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
 void set_exc_raise_counter(volatile int* counter) { g_exc_counter = counter; }
 
 HLE(k_is_stack) {   // sceKernelIsStack(void* addr): is addr within the current thread's stack?
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     void* base = nullptr; size_t sz = 0;
     if (guest_stack_for_current_thread(&base, &sz) &&
         a0 >= (uint64_t)(uintptr_t)base && a0 < (uint64_t)(uintptr_t)base + sz)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -7,13 +7,16 @@
 #include "nid.hpp"
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
+#include "../host/posix_shim.hpp"
 #include <sys/mman.h>
 #include <sys/syscall.h>
-#include <linux/futex.h>
 #include <unistd.h>
-#include <fcntl.h>          // fallocate
+#include <fcntl.h>
+#ifdef __linux__
+#include <linux/futex.h>
 #include <linux/falloc.h>  // FALLOC_FL_PUNCH_HOLE / FALLOC_FL_KEEP_SIZE
+#endif
 #include <climits>
 #include <cerrno>
 #include <ctime>
@@ -222,7 +225,7 @@ namespace {
         // is already there; only if the occupant is entirely our own uncommitted reservation do we
         // replace it with MAP_FIXED (the guest is committing a range it reserved). A hint that
         // overlaps a committed mapping or an untracked host mapping fails instead of destroying it.
-        void* p = mmap((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+        void* p = prosper_mmap_noreplace((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (p != MAP_FAILED) return p;
         if (range_is_free_reservation(hint, len)) {
             p = mmap((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
@@ -239,7 +242,7 @@ namespace {
     // the file is sparse, so unused ranges cost nothing.
     int dmem_fd() {
         static int fd = [] {
-            int f = (int)syscall(SYS_memfd_create, "prosper-dmem", 1 /*MFD_CLOEXEC*/);
+            int f = prosper_memfd_create("prosper-dmem");
             if (f >= 0 && ftruncate(f, (off_t)(kDmemBase + kDmemTotal)) != 0) { close(f); f = -1; }
             return f;
         }();
@@ -253,8 +256,15 @@ namespace {
     // the console's fresh-page-zeroed semantics).
     void dmem_zero(uint64_t phys, uint64_t sz) {
         int fd = dmem_fd();
-        if (fd >= 0 && phys < kDmemBase + kDmemTotal && sz)
-            fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, (off_t)phys, (off_t)sz);
+        if (fd < 0 || phys >= kDmemBase + kDmemTotal || !sz) return;
+#ifdef __linux__
+        fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, (off_t)phys, (off_t)sz);
+#else
+        // Darwin shm has no hole punching; zero the range through a scratch mapping. Loses
+        // sparseness but preserves the guest-visible fresh-pages-read-zero contract.
+        void* z = mmap(nullptr, sz, PROT_WRITE, MAP_SHARED, fd, (off_t)phys);
+        if (z != MAP_FAILED) { memset(z, 0, sz); munmap(z, sz); }
+#endif
     }
     // Reserve an anonymous span whose returned base satisfies `align`. Linux mmap only promises
     // host-page alignment, while Orbis direct-memory callers can require larger alignment.
@@ -289,7 +299,7 @@ namespace {
                 // Same no-clobber discipline as map_at (#137): NOREPLACE first, MAP_FIXED replace
                 // only over our own uncommitted reservation, else refuse rather than destroy a live
                 // (committed / untracked) mapping — the exact clobber class of issues #88 / #107.
-                void* p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED_NOREPLACE, fd, (off_t)phys);
+                void* p = prosper_mmap_noreplace((void*)hint, len, prot, MAP_SHARED, fd, (off_t)phys);
                 if (p != MAP_FAILED) return p;
                 if (range_is_free_reservation(hint, len)) {
                     p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
@@ -336,7 +346,7 @@ HLE(k_reserve_vrange) {
          (unsigned long long)a3);
     if (!a1) return 0x80020016ull;         // SCE_KERNEL_ERROR_EINVAL (len 0; shadPS4 rejects too)
     if (hint && fixed) {
-        void* p = mmap((void*)hint, a1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+        void* p = prosper_mmap_noreplace((void*)hint, a1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (p == MAP_FAILED) {
             // The FIXED hint region is already mapped. If it's ALREADY one of OUR reservations
             // (uncommitted), the guest is re-claiming its own recorded range — idempotent success
@@ -366,7 +376,7 @@ HLE(k_reserve_vrange) {
         uint64_t cand = align_up(hint, align);
         const uint64_t kSearchLimit = 0x40000000000ull;   // 4 TiB — far above any guest range
         while (cand < kSearchLimit) {
-            void* p = mmap((void*)cand, a1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+            void* p = prosper_mmap_noreplace((void*)cand, a1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             if (p != MAP_FAILED) {
                 if (a0) *(uint64_t*)a0 = (uint64_t)p;
                 track((uint64_t)p, a1, 0, false, "reserved");
@@ -579,15 +589,15 @@ HLE(k_wait_on_address) {
         ts.tv_sec = punch_secs; ts.tv_nsec = 0; pts = &ts;   // bound this otherwise-infinite wait
     }
     if (synclog()) fprintf(stderr, "[sync] T%ld WAIT.enter  addr=0x%llx *addr=0x%x exp=0x%llx timo_us=%lld caller=eboot+0x%llx\n",
-                           (long)syscall(SYS_gettid), (unsigned long long)a0, *(uint32_t*)a0,
+                           (long)prosper_gettid(), (unsigned long long)a0, *(uint32_t*)a0,
                            (unsigned long long)a1, pts ? (long long)(ts.tv_sec*1000000 + ts.tv_nsec/1000) : -1,
                            (unsigned long long)goff);
     futex_wait_enter();   // registers this waiter so GPU-side label wakes know someone is blocked
-    long r = syscall(SYS_futex, (uint32_t*)a0, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, (uint32_t)a1, pts, nullptr, 0);
+    long r = prosper_futex_wait((uint32_t*)a0, (uint32_t)a1, pts);
     int e = errno;
     futex_wait_exit();
     if (synclog()) fprintf(stderr, "[sync] T%ld WAIT.exit   addr=0x%llx r=%ld errno=%d\n",
-                           (long)syscall(SYS_gettid), (unsigned long long)a0, r, r < 0 ? e : 0);
+                           (long)prosper_gettid(), (unsigned long long)a0, r, r < 0 ? e : 0);
     // Return the RIGHT status to the guest. Previously we always returned 0 (=woken/success), so on a
     // timeout the guest believed its semaphore was signaled → it consumed a resource that was never
     // produced → phantom item → crash in the exception unwinder. On a futex timeout, report the Sony
@@ -601,7 +611,7 @@ HLE(k_wait_on_address) {
             *(volatile uint32_t*)(uintptr_t)a0 = (uint32_t)a1 + 1;
             futex_wake(a0, INT_MAX);
             fprintf(stderr, "[punch] T%ld addr=0x%llx exp=0x%llx -> fabricated signal (ra=eboot+0x%llx, budget=%d)\n",
-                    (long)syscall(SYS_gettid), (unsigned long long)a0, (unsigned long long)a1,
+                    (long)prosper_gettid(), (unsigned long long)a0, (unsigned long long)a1,
                     (unsigned long long)(gra - 0x400000000ull), punch_budget.load());
             return 0;
         }
@@ -616,7 +626,7 @@ HLE(k_wake_by_address) {
     if (synclog()) {
         uint64_t wgoff = ((uint64_t*)__builtin_frame_address(0))[1] - 0x400000000ull;
         fprintf(stderr, "[sync] T%ld WAKE       addr=0x%llx *addr=0x%x n=%d caller=eboot+0x%llx\n",
-                (long)syscall(SYS_gettid), (unsigned long long)a0, *(uint32_t*)a0, n, (unsigned long long)wgoff);
+                (long)prosper_gettid(), (unsigned long long)a0, *(uint32_t*)a0, n, (unsigned long long)wgoff);
     }
     return 0;
 }
@@ -968,7 +978,7 @@ HLE(k_ampr_push_map) {
             // proven by MEMLOG: page 0x11e0df0000 appears as both [lazy-commit] heap and ampr
             // mirror; the mirror map is strictly later, so it clobbers the live page).
             unsigned char vec;
-            bool mirror_live = (mincore((void*)(uintptr_t)mirror, 1, &vec) == 0);
+            bool mirror_live = (prosper_mincore((void*)(uintptr_t)mirror, 1, &vec) == 0);
             void* q = nullptr;
             if (mirror_live) {
                 MLOG("ampr push-map va=0x%llx mirror=0x%llx SKIPPED (target is live guest memory — "

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -26,13 +26,19 @@
 // are exactly the guest caller's), setjmp entered here sees the caller's true context. We
 // save only the SysV callee-saved set + rsp + return address (64 bytes) — well within the
 // guest's FreeBSD jmp_buf — and never touch the signal mask (matched pair, self-consistent).
-#if defined(__linux__) && defined(__x86_64__)
+#if (defined(__linux__) || defined(__APPLE__)) && defined(__x86_64__)
 extern "C" uint64_t prosper_setjmp(void*);
 extern "C" void     prosper_longjmp(void*, uint64_t);
+// Mach-O C symbols carry a leading underscore; ELF ones don't.
+#ifdef __APPLE__
+#define PSJ(x) "_" x
+#else
+#define PSJ(x) x
+#endif
 __asm__(
     ".text\n"
-    ".globl prosper_setjmp\n.p2align 4\n"
-    "prosper_setjmp:\n"
+    ".globl " PSJ("prosper_setjmp") "\n.p2align 4\n"
+    PSJ("prosper_setjmp") ":\n"
     "    movq (%rsp), %rax\n"        // guest return address (stub jmp'd here, so [rsp]=caller ret)
     "    movq %rbx,  0(%rdi)\n"
     "    movq %rbp,  8(%rdi)\n"
@@ -45,8 +51,8 @@ __asm__(
     "    movq %rax, 56(%rdi)\n"
     "    xorl %eax, %eax\n"           // first return: 0
     "    ret\n"
-    ".globl prosper_longjmp\n.p2align 4\n"
-    "prosper_longjmp:\n"
+    ".globl " PSJ("prosper_longjmp") "\n.p2align 4\n"
+    PSJ("prosper_longjmp") ":\n"
     "    movq  0(%rdi), %rbx\n"
     "    movq  8(%rdi), %rbp\n"
     "    movq 16(%rdi), %r12\n"

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -6,6 +6,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "platform_ui.hpp"
+#include "../host/posix_shim.hpp"   // PROSPER_ASM_TRAMPOLINE (Mach-O/ELF global-asm portability)
 #include <cstdint>
 #include <cstring>
 #include <cstdio>
@@ -856,15 +857,7 @@ HLE(s_netctl_getstate) {
 extern "C" uint64_t s_netctl_check_cb_c(uint64_t a0, uint64_t a1, uint64_t a2,
                                         uint64_t a3, uint64_t a4, uint64_t a5,
                                         uint64_t entry_rsp);
-asm(".text\n"
-    ".globl s_netctl_check_cb_entry\n"
-    ".type s_netctl_check_cb_entry,@function\n"
-    "s_netctl_check_cb_entry:\n"
-    "  movq %rsp, %rax\n"
-    "  pushq %rax\n"
-    "  call s_netctl_check_cb_c\n"
-    "  addq $8, %rsp\n"
-    "  ret\n");
+PROSPER_ASM_TRAMPOLINE(s_netctl_check_cb_entry, s_netctl_check_cb_c)
 extern "C" void s_netctl_check_cb_entry();
 extern "C" uint64_t s_netctl_check_cb_c(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
                                         uint64_t entry_rsp) {
@@ -920,15 +913,7 @@ HLE(s_np_register_state_cbA) {   // (SceNpStateCallbackA func, void* userdata) -
 extern "C" uint64_t s_np_check_cb_c(uint64_t a0, uint64_t a1, uint64_t a2,
                                     uint64_t a3, uint64_t a4, uint64_t a5,
                                     uint64_t entry_rsp);
-asm(".text\n"
-    ".globl s_np_check_cb_entry\n"
-    ".type s_np_check_cb_entry,@function\n"
-    "s_np_check_cb_entry:\n"
-    "  movq %rsp, %rax\n"
-    "  pushq %rax\n"
-    "  call s_np_check_cb_c\n"
-    "  addq $8, %rsp\n"
-    "  ret\n");
+PROSPER_ASM_TRAMPOLINE(s_np_check_cb_entry, s_np_check_cb_c)
 extern "C" void s_np_check_cb_entry();
 extern "C" uint64_t s_np_check_cb_c(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
                                     uint64_t entry_rsp) {

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -2,10 +2,10 @@
 #include "sync_futex.hpp"
 #include <atomic>
 #include <climits>
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <unistd.h>
 #include <sys/syscall.h>
-#include <linux/futex.h>
+#include "../host/posix_shim.hpp"
 #endif
 
 namespace prosper {
@@ -15,9 +15,9 @@ void futex_wait_enter() { g_waiters.fetch_add(1, std::memory_order_seq_cst); }
 void futex_wait_exit()  { g_waiters.fetch_sub(1, std::memory_order_seq_cst); }
 
 void futex_wake(uint64_t addr, int n) {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
     if (!addr) return;
-    syscall(SYS_futex, (uint32_t*)(uintptr_t)addr, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, n, nullptr, nullptr, 0);
+    prosper_futex_wake((uint32_t*)(uintptr_t)addr, n > 1);
 #else
     (void)addr; (void)n;
 #endif

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -2,7 +2,7 @@
 // (behavior-preserving); the guest-execution substrate is Linux-only, so guard the whole body.
 #include "boot_program.hpp"
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include "host/exec_image.hpp"
 #include "hle/dispatch.hpp"
 #include "self/module.hpp"     // PT_SCE_PROCPARAM

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1914,6 +1914,15 @@ void install_trap_handler() {
     // exact "fatal signal 11, no output" we see mid-load). On the alt stack the worker-thread fault
     // path (which does NOT siglongjmp) can print the faulting RIP. Gated so the default boot's
     // main-thread siglongjmp recovery is unchanged. CONFIDENCE: HIGH (mechanism).
+    // On macOS the alt stack is MANDATORY, not diagnostic: a guest fault whose access is on the
+    // faulting thread's own stack (a bad indirect branch into the stack, a stack overflow) cannot
+    // push a signal frame onto that same stack, so without SA_ONSTACK the kernel force-kills the
+    // process with no handler entry (the "SIGSEGV, no output" we first saw). The Darwin recovery
+    // path siglongjmps out of the handler, which is safe from the alt stack (no glibc
+    // %fs-guarded ____longjmp_chk to trip, unlike Linux — that is why it stays opt-in there).
+#ifdef __APPLE__
+    sa.sa_flags |= SA_ONSTACK;
+#endif
     if (getenv("PROSPER_FAULT_ONSTACK")) sa.sa_flags |= SA_ONSTACK;
     sigemptyset(&sa.sa_mask);
     sigaction(SIGSEGV, &sa, nullptr);

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -5,7 +5,8 @@
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
+#include "posix_shim.hpp"
 #include <sys/mman.h>
 #include <signal.h>
 #include <setjmp.h>
@@ -14,8 +15,10 @@
 #include <sys/syscall.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
+#ifdef __linux__
 #include <linux/perf_event.h>
 #include <linux/hw_breakpoint.h>
+#endif
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -24,6 +27,27 @@
 #include <map>
 #include <mutex>
 #include <atomic>
+
+// Darwin mcontext/perf compatibility (PROSPER_GREGS / PROSPER_REG_ERR / PROSPER_SI_FD, the
+// HW_BREAKPOINT_*/F_SETSIG constants, and mach headers) lives in posix_shim.hpp — shared with the
+// guest-exception delivery handler in hle_kernel.cpp.
+#ifdef __APPLE__
+// Hardware break/watchpoints are a Linux perf_event capability with no Darwin userland
+// equivalent (and Rosetta exposes no x86 debug registers anyway). perf_bp_open below returns
+// -1/ENOTSUP, so every PROSPER_HWBP/HWWATCH arm attempt takes its existing "arm FAILED" path and
+// the software-watch (mprotect) + int3 diagnostics remain the macOS toolset. These constants only
+// keep the never-reached call sites compiling; the fds involved are always -1 here.
+enum { HW_BREAKPOINT_X = 4, HW_BREAKPOINT_W = 2, HW_BREAKPOINT_LEN_8 = 8 };
+enum { PERF_EVENT_IOC_ENABLE = 0x2400, PERF_EVENT_IOC_DISABLE = 0x2401 };
+enum { F_OWNER_TID = 0 };
+struct f_owner_ex { int type; pid_t pid; };
+#ifndef F_SETSIG
+#define F_SETSIG    -1000   // unknown fcntl cmd -> EINVAL; only ever issued on fd=-1 (EBADF)
+#endif
+#ifndef F_SETOWN_EX
+#define F_SETOWN_EX -1001
+#endif
+#endif
 
 namespace prosper {
 
@@ -44,7 +68,7 @@ namespace {
     // Plain globals + gettid sidestep %fs entirely.
     sigjmp_buf g_jb;
     volatile long g_armed_tid = 0;               // kernel tid that armed g_jb, 0 = none
-    inline long cur_tid() { return (long)syscall(SYS_gettid); }
+    inline long cur_tid() { return (long)prosper_gettid(); }
     volatile sig_atomic_t g_trap_kind = 0;   // 0 none, 2 SEGV/BUS, 3 ILL
     volatile int          g_trap_sig = 0;
     void*    g_fault_addr = nullptr;
@@ -68,8 +92,18 @@ namespace {
     // pattern could tear the fd pair under two concurrent first-calls (PR #61 review). Called
     // only from install-time paths (never from the signal handler itself), so the guard's
     // internal locking is safe here.
+    bool make_probe_pipe() {
+#ifdef __linux__
+        return pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) == 0;
+#else   // Darwin: no pipe2; pipe + fcntl inside the same once-only guard, so no torn-pair race
+        if (pipe(g_probe_pipe) != 0) return false;
+        for (int fd : g_probe_pipe)
+            if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0 || fcntl(fd, F_SETFL, O_NONBLOCK) != 0) return false;
+        return true;
+#endif
+    }
     void ensure_probe_pipe() {
-        static const bool ok = pipe2(g_probe_pipe, O_CLOEXEC | O_NONBLOCK) == 0;
+        static const bool ok = make_probe_pipe();
         if (!ok) g_probe_pipe[0] = g_probe_pipe[1] = -1;
     }
     // DIAGNOSTIC (PROSPER_SKIP_NULL_COMPANION, default off): at the Unity GfxDevice pipeline reader
@@ -262,16 +296,42 @@ namespace {
     uint64_t g_hwwatch_addr = 0;
     volatile sig_atomic_t g_hwwatch_count = 0;
     long perf_bp_open(uint64_t addr, uint32_t bp_type) {
+#ifdef __linux__
         struct perf_event_attr pe; memset(&pe, 0, sizeof pe);
         pe.type = PERF_TYPE_BREAKPOINT; pe.size = sizeof pe;
         pe.bp_type = bp_type; pe.bp_addr = addr;
         pe.bp_len = (bp_type == HW_BREAKPOINT_X) ? sizeof(long) : (uint64_t)HW_BREAKPOINT_LEN_8;
         pe.sample_period = 1; pe.disabled = 1; pe.exclude_kernel = 1; pe.exclude_hv = 1;
         return syscall(SYS_perf_event_open, &pe, 0, -1, -1, 0UL);
+#else
+        (void)addr; (void)bp_type; errno = ENOTSUP; return -1;   // see the Darwin compat note above
+#endif
     }
     // Async-safe-ish: write the /proc/self/maps line containing `addr` to stderr (identifies the module
     // that a writer RIP belongs to). Fixed buffers, no malloc; open/read/write are signal-safe.
     void classify_addr(uint64_t addr) {
+#ifdef __APPLE__
+        // No /proc on Darwin: report the containing mach VM region (bounds + prot). mach_vm_region
+        // is a plain trap — no malloc, async-safe enough for this diagnostic path.
+        mach_vm_address_t ra = addr; mach_vm_size_t rs = 0;
+        vm_region_basic_info_data_64_t info; mach_msg_type_number_t cnt = VM_REGION_BASIC_INFO_COUNT_64;
+        mach_port_t obj = MACH_PORT_NULL;
+        char b[160]; int n;
+        if (mach_vm_region(mach_task_self(), &ra, &rs, VM_REGION_BASIC_INFO_64,
+                           (vm_region_info_t)&info, &cnt, &obj) == KERN_SUCCESS && addr >= ra) {
+            if (obj != MACH_PORT_NULL) mach_port_deallocate(mach_task_self(), obj);
+            n = snprintf(b, sizeof b, "[hwwatch]   writer 0x%llx is in: 0x%llx-0x%llx %c%c%c\n",
+                         (unsigned long long)addr, (unsigned long long)ra, (unsigned long long)(ra + rs),
+                         (info.protection & VM_PROT_READ) ? 'r' : '-',
+                         (info.protection & VM_PROT_WRITE) ? 'w' : '-',
+                         (info.protection & VM_PROT_EXECUTE) ? 'x' : '-');
+        } else {
+            n = snprintf(b, sizeof b, "[hwwatch]   writer 0x%llx: no containing region\n",
+                         (unsigned long long)addr);
+        }
+        if (n > 0) { ssize_t w = write(2, b, (size_t)n); (void)w; }
+        return;
+#else
         int fd = open("/proc/self/maps", O_RDONLY | O_CLOEXEC);
         if (fd < 0) return;
         char buf[8192]; ssize_t got; char line[512]; size_t li = 0;
@@ -293,6 +353,7 @@ namespace {
             }
         }
         close(fd);
+#endif
     }
     // Dump the HWBP ring (oldest->newest) once. Prints reader fields (cur/[cur]/rax) for anom traces and
     // typetree-node fields (r8/[r8+8]/[r8+0x10]/r14) for node traces. Signal-safe (fixed buffers, write()).
@@ -345,7 +406,7 @@ namespace {
         g_hwwatch_fd = (int)fd; g_hwwatch_addr = addr;
         fcntl(g_hwwatch_fd, F_SETFL, O_ASYNC);
         fcntl(g_hwwatch_fd, F_SETSIG, SIGTRAP);
-        struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
+        struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)prosper_gettid();
         fcntl(g_hwwatch_fd, F_SETOWN_EX, &ow);
         ioctl(g_hwwatch_fd, PERF_EVENT_IOC_ENABLE, 0);
         int n = snprintf(b, sizeof b, "[hwwatch] armed W-watch at 0x%llx (fd=%d)\n",
@@ -392,7 +453,7 @@ namespace {
                 syscall(SYS_write, 2, b, (size_t)k); continue; }
             fcntl((int)fd, F_SETFL, O_ASYNC);
             fcntl((int)fd, F_SETSIG, SIGTRAP);
-            struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
+            struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)prosper_gettid();
             fcntl((int)fd, F_SETOWN_EX, &ow);
             ioctl((int)fd, PERF_EVENT_IOC_ENABLE, 0);
             int slot = g_mb3w_cnt.fetch_add(1, std::memory_order_acq_rel);
@@ -527,7 +588,7 @@ namespace {
                          p[0],p[1],p[2],p[3],p[4],p[5],p[6],p[7],p[8],p[9],p[10],p[11],p[12],p[13],p[14],p[15]);
             syscall(SYS_write, 2, b, (size_t)n);
         }
-        auto& g = uc->uc_mcontext.gregs;
+        auto g = PROSPER_GREGS(uc);
         const struct { const char* nm; uint64_t v; } regs[] = {
             {"rax", (uint64_t)g[REG_RAX]}, {"rbx", (uint64_t)g[REG_RBX]},
             {"rcx", (uint64_t)g[REG_RCX]}, {"rdx", (uint64_t)g[REG_RDX]},
@@ -641,7 +702,7 @@ namespace {
     volatile unsigned long g_sse4a_emulated = 0;
     const bool g_sse4a_stat = getenv("PROSPER_SSE4A_STAT") != nullptr;
     bool try_emulate_sse4a(ucontext_t* uc) {
-        auto& g = uc->uc_mcontext.gregs;
+        auto g = PROSPER_GREGS(uc);
         uint64_t rip = (uint64_t)g[REG_RIP];
         const uint8_t* p = (const uint8_t*)rip;
         size_t i = 0;
@@ -657,11 +718,19 @@ namespace {
         if ((modrm >> 6) != 3) return false;            // register operands only
         int reg = ((modrm >> 3) & 7) | ((rex & 4) ? 8 : 0);
         int rm  = (modrm & 7)       | ((rex & 1) ? 8 : 0);
+#ifdef __APPLE__
+        // Darwin keeps the xmm registers as 16 contiguous _STRUCT_XMM_REG fields in the mcontext's
+        // float state; index off __fpu_xmm0.
+        if (!uc->uc_mcontext) return false;
+        auto xmm = [&](int n) { return (uint32_t*)(&uc->uc_mcontext->__fs.__fpu_xmm0 + n); };
+#else
         auto* fp = uc->uc_mcontext.fpregs;
         if (!fp) return false;
-        auto lo  = [&](int n) { const uint32_t* e = fp->_xmm[n].element; return (uint64_t)e[0] | ((uint64_t)e[1] << 32); };
-        auto hi  = [&](int n) { const uint32_t* e = fp->_xmm[n].element; return (uint64_t)e[2] | ((uint64_t)e[3] << 32); };
-        auto set = [&](int n, uint64_t v) { uint32_t* e = fp->_xmm[n].element; e[0] = (uint32_t)v; e[1] = (uint32_t)(v >> 32); };
+        auto xmm = [&](int n) { return (uint32_t*)fp->_xmm[n].element; };
+#endif
+        auto lo  = [&](int n) { const uint32_t* e = xmm(n); return (uint64_t)e[0] | ((uint64_t)e[1] << 32); };
+        auto hi  = [&](int n) { const uint32_t* e = xmm(n); return (uint64_t)e[2] | ((uint64_t)e[3] << 32); };
+        auto set = [&](int n, uint64_t v) { uint32_t* e = xmm(n); e[0] = (uint32_t)v; e[1] = (uint32_t)(v >> 32); };
         bool insertq = (pfx == 0xF2);
         uint32_t len, idx;
         if (op == 0x78)       { len = p[i++]; idx = p[i++]; }
@@ -699,7 +768,7 @@ namespace {
         // A SIGILL we did NOT emulate: log the faulting instruction bytes so the offending opcode can be
         // identified (another AMD-only ISA extension, or a decode miss in try_emulate_sse4a). #163-progress.
         if (sig == SIGILL) {
-            uint64_t rip = (uint64_t)((ucontext_t*)uctx)->uc_mcontext.gregs[REG_RIP];
+            uint64_t rip = (uint64_t)PROSPER_GREGS((ucontext_t*)uctx)[REG_RIP];
             const uint8_t* p = (const uint8_t*)rip;
             char b[96]; int n = snprintf(b, sizeof b, "[sigill] rip=0x%llx bytes:", (unsigned long long)rip);
             for (int k = 0; k < 16 && n < (int)sizeof b - 4; k++) n += snprintf(b + n, sizeof b - n, " %02x", p[k]);
@@ -713,9 +782,9 @@ namespace {
         // dump its full register + guest-stack context. Raw syscalls only (may run on a guest-%fs
         // worker); globals + fd table, no thread_local.
         if (sig == SIGTRAP && g_mb3w_cnt.load(std::memory_order_acquire) > 0) {
-            int mi = mb3w_match(si->si_fd);
+            int mi = mb3w_match(PROSPER_SI_FD(si));
             if (mi >= 0) {
-                auto& gr2 = ((ucontext_t*)uctx)->uc_mcontext.gregs;
+                auto gr2 = PROSPER_GREGS((ucontext_t*)uctx);
                 uint64_t addr = g_mb3w[mi].addr;
                 unsigned long long v = *(volatile uint64_t*)addr;
                 uint64_t wr = (uint64_t)gr2[REG_RIP];
@@ -777,7 +846,7 @@ namespace {
             // Step-window: continuous single-step from driver hit N to the next driver hit. On each step,
             // find the live read cursor (a GP reg pointing inside [base,end]) and ring-log advances.
             if (g_stepwin_active && si->si_code == TRAP_TRACE) {
-                auto& gs = uc->uc_mcontext.gregs;
+                auto gs = PROSPER_GREGS(uc);
                 uint64_t rip = (uint64_t)gs[REG_RIP];
                 g_stepwin_steps++;
                 static const int idx[] = { REG_RAX,REG_RBX,REG_RCX,REG_RDX,REG_RSI,REG_RDI,REG_R8,
@@ -810,15 +879,15 @@ namespace {
             if ((hwbp_state && hwbp_state->stepping) || g_hwbp_stepping) {
                 const int fd = hwbp_state ? hwbp_state->fd : g_hwbp_fd;
                 ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
-                uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;
+                PROSPER_GREGS(uc)[REG_EFL] &= ~0x100ll;
                 if (hwbp_state) hwbp_state->stepping = 0;
                 g_hwbp_stepping = false;
                 return;
             }
             // Chained DATA write-watchpoint hit (a write to the watched slot completed): log the writer
             // RIP + the value just stored. Write-watchpoints trap AFTER the store, so no step is needed.
-            if (g_hwwatch_fd >= 0 && si->si_fd == g_hwwatch_fd) {
-                auto& gr2 = uc->uc_mcontext.gregs;
+            if (g_hwwatch_fd >= 0 && PROSPER_SI_FD(si) == g_hwwatch_fd) {
+                auto gr2 = PROSPER_GREGS(uc);
                 unsigned long long v = 0; { auto p=(volatile uint64_t*)g_hwwatch_addr; v=*p; }
                 // Always log an ANOMALOUS store (not a plausible guest heap pointer 0x1000000000..
                 // 0x1720000000, and nonzero) even past the count cap — this is how a corrupt value
@@ -837,7 +906,7 @@ namespace {
                 }
                 return;
             }
-            auto& gr = uc->uc_mcontext.gregs;
+            auto gr = PROSPER_GREGS(uc);
             uint64_t rdi = (uint64_t)gr[REG_RDI], rsi = (uint64_t)gr[REG_RSI];
             uint64_t rax = (uint64_t)gr[REG_RAX], r14 = (uint64_t)gr[REG_R14], r15 = (uint64_t)gr[REG_R15];
             // This handler returns to the guest, which may be on the guest %fs — swap to host %fs for the
@@ -1093,7 +1162,7 @@ namespace {
                 arm_hwwatch(base + (uint64_t)g_hwwatch_delta);
             }
             const int hit_fd = hwbp_state ? hwbp_state->fd :
-                               (si->si_fd >= 0 ? si->si_fd : g_hwbp_fd);
+                               (PROSPER_SI_FD(si) >= 0 ? PROSPER_SI_FD(si) : g_hwbp_fd);
             ioctl(hit_fd, PERF_EVENT_IOC_DISABLE, 0);   // disable so we can step off the bp address
             // Step-window ENTRY: on the Nth driver hit, begin continuous single-stepping (bp stays disabled;
             // the window ends when we single-step back to the driver = next hit). Buffer range is [base,
@@ -1110,14 +1179,14 @@ namespace {
                     (int)g_hwbp_count, (unsigned long long)g_stepwin_base, (unsigned long long)g_stepwin_prevcur,
                     (unsigned long long)(g_stepwin_prevcur - g_stepwin_base));
                 syscall(SYS_write, 2,sb, sn);
-                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // start single-stepping
+                PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // start single-stepping
                 guest_fs_restore_scoped(saved_fs);
                 return;
             }
             // Stay armed while logging OR while the anomaly-ring trace is still hunting (PROSPER_HWBP_MAX
             // can be 0 to suppress the per-hit log yet keep the bp live feeding the ring until it dumps).
             if (g_hwbp_count < g_hwbp_max || ((g_hwbp_anom_on || g_hwbp_node_on) && !g_hwbp_ring_dumped)) {
-                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;
+                PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;
                 if (hwbp_state) hwbp_state->stepping = 1; else g_hwbp_stepping = true;
             }                                              // else: leave disabled (one-and-done at the cap)
             guest_fs_restore_scoped(saved_fs);             // back to guest %fs before returning to guest code
@@ -1131,14 +1200,14 @@ namespace {
             auto* uc = (ucontext_t*)uctx;
             if (g_bp_stepping) {
                 bp_write_byte(g_bp_addr, 0xCC);
-                uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;   // clear TF
+                PROSPER_GREGS(uc)[REG_EFL] &= ~0x100ll;   // clear TF
                 g_bp_stepping = false;
                 return;
             }
-            uint64_t rip = (uint64_t)uc->uc_mcontext.gregs[REG_RIP];
+            uint64_t rip = (uint64_t)PROSPER_GREGS(uc)[REG_RIP];
             if (rip == g_bp_addr + 1) {
-                uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
-                auto& gr0 = uc->uc_mcontext.gregs;
+                uint64_t r15 = (uint64_t)PROSPER_GREGS(uc)[REG_R15];
+                auto gr0 = PROSPER_GREGS(uc);
                 // PROSPER_BP_SHIFT=1 (#312): only log when the store source rsi is a byte-shifted pool
                 // pointer (the primary corruptor's value). Filters the freelist push/pop hot path down
                 // to just the corrupting event, so timing is barely perturbed and the log is decisive.
@@ -1152,7 +1221,7 @@ namespace {
                     g_bp_count = g_bp_count + 1;
                     auto rd = [](uint64_t a) -> unsigned long long {
                         return probe_readable(a) ? (unsigned long long)*(const uint64_t*)a : 0xBADBADull; };
-                    auto& gr = uc->uc_mcontext.gregs;
+                    auto gr = PROSPER_GREGS(uc);
                     uint64_t rdi = (uint64_t)gr[REG_RDI], rsi = (uint64_t)gr[REG_RSI];
                     uint64_t rax = (uint64_t)gr[REG_RAX], r14 = (uint64_t)gr[REG_R14];
                     uint64_t rcx = (uint64_t)gr[REG_RCX];
@@ -1183,8 +1252,8 @@ namespace {
                     syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
                 }
                 bp_write_byte(g_bp_addr, g_bp_orig);              // restore real instruction
-                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_bp_addr;  // re-execute it
-                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;        // single-step (TF)
+                PROSPER_GREGS(uc)[REG_RIP] = (greg_t)g_bp_addr;  // re-execute it
+                PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;        // single-step (TF)
                 g_bp_stepping = true;
                 return;
             }
@@ -1193,7 +1262,7 @@ namespace {
         // log the slot's post-write value, re-protect, keep watching.
         if (sig == SIGTRAP && g_lwatch_stepping) {
             auto* uc = (ucontext_t*)uctx;
-            uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;   // clear TF
+            PROSPER_GREGS(uc)[REG_EFL] &= ~0x100ll;   // clear TF
             if (g_lwatch_shift) {
                 // Value-triggered: only report if the just-completed store left a byte-shifted pool
                 // pointer at the faulting address (the primary #312 corruptor). Silent otherwise.
@@ -1241,8 +1310,8 @@ namespace {
         if (g_lwatch_armed && sig == SIGSEGV && si->si_addr) {
             uint64_t fa = (uint64_t)si->si_addr;
             auto* uc = (ucontext_t*)uctx;
-            if ((fa & ~(uint64_t)0xfff) == g_lwatch_page && (uc->uc_mcontext.gregs[REG_ERR] & 2)) {
-                uint64_t rip = (uint64_t)uc->uc_mcontext.gregs[REG_RIP];
+            if ((fa & ~(uint64_t)0xfff) == g_lwatch_page && (PROSPER_REG_ERR(uc) & 2)) {
+                uint64_t rip = (uint64_t)PROSPER_GREGS(uc)[REG_RIP];
                 g_lwatch_step_rip = 0;
                 if (g_lwatch_shift) {
                     // Value-triggered: capture writer + stack silently now, decide at SIGTRAP whether
@@ -1250,7 +1319,7 @@ namespace {
                     // write) so the corruptor is caught wherever in the FPoolInfo page it lands.
                     g_lwatch_fa = fa;
                     g_lwatch_step_rip = rip;
-                    uint64_t rsp = (uint64_t)uc->uc_mcontext.gregs[REG_RSP];
+                    uint64_t rsp = (uint64_t)PROSPER_GREGS(uc)[REG_RSP];
                     g_lwatch_stkn = 0;
                     for (uint64_t o = 0; o < 0x400 && g_lwatch_stkn < 8; o += 8) {
                         if (!probe_readable(rsp + o)) break;
@@ -1258,7 +1327,7 @@ namespace {
                         if (v >= 0x400000000ull && v < 0x40a000000ull) g_lwatch_stk[g_lwatch_stkn++] = v;
                     }
                     mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
-                    uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // TF -> single-step the write
+                    PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // TF -> single-step the write
                     g_lwatch_stepping = true;
                     return;
                 }
@@ -1277,7 +1346,7 @@ namespace {
                     // addresses (up to 8), so the guest free/alloc path above the raw write is
                     // identifiable (async-signal-safe: bounded reads of the faulting thread's
                     // own stack).
-                    uint64_t rsp = (uint64_t)uc->uc_mcontext.gregs[REG_RSP];
+                    uint64_t rsp = (uint64_t)PROSPER_GREGS(uc)[REG_RSP];
                     int found = 0;
                     for (uint64_t o = 0; o < 0x400 && found < 8 && n < (int)sizeof b - 24; o += 8) {
                         if (!probe_readable(rsp + o)) break;
@@ -1298,7 +1367,7 @@ namespace {
                     }
                 }
                 mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
-                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // TF -> single-step the write
+                PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // TF -> single-step the write
                 g_lwatch_stepping = true;
                 return;
             }
@@ -1307,7 +1376,7 @@ namespace {
         // re-arm (re-protect read-only) and clear the trap flag so we keep watching.
         if (sig == SIGTRAP && g_watch_stepping) {
             auto* uc = (ucontext_t*)uctx;
-            uc->uc_mcontext.gregs[REG_EFL] &= ~0x100ll;   // clear TF
+            PROSPER_GREGS(uc)[REG_EFL] &= ~0x100ll;   // clear TF
             // Post-write: log the slot's new value + the object's type tag [r15+0] (0x2b if it's still
             // the same live object; changed => the memory was freed and reused, so the write is churn).
             unsigned long long slot = *(const uint64_t*)g_watch_addr;
@@ -1322,8 +1391,8 @@ namespace {
         // Arm the watchpoint on the first companion read (rip == the reader deref, slot still null).
         if (g_watch_companion && sig == SIGSEGV && !g_watch_armed) {
             auto* uc = (ucontext_t*)uctx;
-            if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
-                uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
+            if ((uint64_t)PROSPER_GREGS(uc)[REG_RIP] == g_skip_rip) {
+                uint64_t r15 = (uint64_t)PROSPER_GREGS(uc)[REG_R15];
                 g_watch_addr = r15 + 0x140;
                 g_watch_page = g_watch_addr & ~(uint64_t)0xfff;
                 if (mprotect((void*)g_watch_page, 0x1000, PROT_READ) == 0) {
@@ -1334,7 +1403,7 @@ namespace {
                     syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
                 }
                 // Skip this (null) read so the boot proceeds; the slot's page is now watched.
-                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                PROSPER_GREGS(uc)[REG_RIP] = (greg_t)g_skip_target;
                 return;
             }
         }
@@ -1343,18 +1412,18 @@ namespace {
         if (g_watch_armed && sig == SIGSEGV && si->si_addr) {
             uint64_t fa = (uint64_t)si->si_addr;
             auto* uc = (ucontext_t*)uctx;
-            if ((fa & ~(uint64_t)0xfff) == g_watch_page && (uc->uc_mcontext.gregs[REG_ERR] & 2)) {
+            if ((fa & ~(uint64_t)0xfff) == g_watch_page && (PROSPER_REG_ERR(uc) & 2)) {
                 if (fa >= g_watch_addr && fa < g_watch_addr + 8) {
                     g_watch_hits = g_watch_hits + 1;
                     char b[160];
                     int n = snprintf(b, sizeof b, "[watch] WRITE to companion slot 0x%llx from rip=0x%llx writer-tid=%ld (hit #%d)\n",
                                      (unsigned long long)fa,
-                                     (unsigned long long)uc->uc_mcontext.gregs[REG_RIP], cur_tid(),
+                                     (unsigned long long)PROSPER_GREGS(uc)[REG_RIP], cur_tid(),
                                      (int)g_watch_hits);
                     syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
                 }
                 mprotect((void*)g_watch_page, 0x1000, PROT_READ | PROT_WRITE);
-                uc->uc_mcontext.gregs[REG_EFL] |= 0x100ll;   // set TF -> single-step the write
+                PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // set TF -> single-step the write
                 g_watch_stepping = true;
                 return;
             }
@@ -1362,8 +1431,8 @@ namespace {
         // Repeated companion reads (later reader passes): skip them too so the boot keeps running.
         if (g_watch_armed && sig == SIGSEGV) {
             auto* uc = (ucontext_t*)uctx;
-            if ((uint64_t)uc->uc_mcontext.gregs[REG_RIP] == g_skip_rip) {
-                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+            if ((uint64_t)PROSPER_GREGS(uc)[REG_RIP] == g_skip_rip) {
+                PROSPER_GREGS(uc)[REG_RIP] = (greg_t)g_skip_target;
                 return;
             }
         }
@@ -1383,7 +1452,7 @@ namespace {
                 char b[128]; auto* uc2 = (ucontext_t*)uctx;
                 int n = snprintf(b, sizeof b, "[lazy-commit] %s page=0x%llx rip=0x%llx\n",
                                  ok ? "mapped" : "MMAP-FAILED", (unsigned long long)(uint64_t)(uintptr_t)page,
-                                 (unsigned long long)uc2->uc_mcontext.gregs[REG_RIP]);
+                                 (unsigned long long)PROSPER_GREGS(uc2)[REG_RIP]);
                 // RAW syscall, NOT glibc write(): this handler can run on a thread whose %fs is the
                 // GUEST TCB (PROSPER_GUEST_FS), and glibc write()'s cancellation prologue reads the
                 // TCB through %fs — a nested SIGSEGV inside the handler killed the process (the UE4
@@ -1404,7 +1473,7 @@ namespace {
         //    same address forever (infinite fault loop) instead of a clean fault report.
         if (sig == SIGSEGV && si->si_addr && si->si_code == SEGV_MAPERR) {
             uint64_t a = (uint64_t)si->si_addr;
-            uint64_t rip = (uint64_t)((ucontext_t*)uctx)->uc_mcontext.gregs[REG_RIP];
+            uint64_t rip = (uint64_t)PROSPER_GREGS((ucontext_t*)uctx)[REG_RIP];
             if (a >= GPU_VA_LO && a < GPU_VA_HI && a != rip) {
                 void* page = (void*)(a & ~(uint64_t)0xfff);
                 bool ok = mmap(page, 0x1000, PROT_READ | PROT_WRITE,
@@ -1428,7 +1497,7 @@ namespace {
         if (g_null_page && sig == SIGSEGV) {
             uint64_t a = (uint64_t)si->si_addr;
             auto* uc = (ucontext_t*)uctx;
-            uint64_t rip = (uint64_t)uc->uc_mcontext.gregs[REG_RIP];
+            uint64_t rip = (uint64_t)PROSPER_GREGS(uc)[REG_RIP];
             // Only a DATA READ from low memory is backable. An instruction fetch at null (a==rip, i.e.
             // a call/jmp through a null pointer) or a fault on an already-backed page (a null WRITE)
             // must NOT be re-backed — those are the real chain endpoints; let them terminate + report.
@@ -1452,9 +1521,9 @@ namespace {
         // the null [obj+0x140] deref to its own skip label, logging each object's state.
         if (g_skip_null_companion && sig == SIGSEGV) {
             auto* uc = (ucontext_t*)uctx;
-            uint64_t rip = (uint64_t)uc->uc_mcontext.gregs[REG_RIP];
+            uint64_t rip = (uint64_t)PROSPER_GREGS(uc)[REG_RIP];
             if (rip == g_skip_rip) {
-                uint64_t r15 = (uint64_t)uc->uc_mcontext.gregs[REG_R15];
+                uint64_t r15 = (uint64_t)PROSPER_GREGS(uc)[REG_R15];
                 g_skip_count = g_skip_count + 1;
                 auto rd = [](uint64_t a) -> unsigned long long {
                     return probe_readable(a) ? (unsigned long long)*(const uint64_t*)a : 0xBADBADull;
@@ -1466,7 +1535,7 @@ namespace {
                     (int)g_skip_count, (unsigned long long)r15, rd(r15+0xc0), rd(r15+0xe0),
                     rd(r15+0x138), rd(r15+0x140), rd(r15+0x1a0), (unsigned long long)g_skip_target);
                 syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
-                uc->uc_mcontext.gregs[REG_RIP] = (greg_t)g_skip_target;
+                PROSPER_GREGS(uc)[REG_RIP] = (greg_t)g_skip_target;
                 return;   // re-execute from the reader's skip label
             }
         }
@@ -1478,13 +1547,13 @@ namespace {
         if (g_faultlog) {
             char b[128]; auto* uc = (ucontext_t*)uctx;
             int n = snprintf(b, sizeof b, "[fault] sig=%d addr=%p rip=0x%llx armed=%d tid=%ld\n",
-                             sig, si->si_addr, (unsigned long long)uc->uc_mcontext.gregs[REG_RIP],
+                             sig, si->si_addr, (unsigned long long)PROSPER_GREGS(uc)[REG_RIP],
                              (int)(g_armed_tid && cur_tid() == g_armed_tid), cur_tid());
             syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
         }
         g_fault_addr = si->si_addr;
         auto* uc = (ucontext_t*)uctx;
-        auto& g = uc->uc_mcontext.gregs;
+        auto g = PROSPER_GREGS(uc);
         g_fault_rip = (uint64_t)g[REG_RIP];
         g_rbp = (uint64_t)g[REG_RBP]; g_rsp = (uint64_t)g[REG_RSP];
         g_rax = (uint64_t)g[REG_RAX]; g_rdi = (uint64_t)g[REG_RDI];
@@ -1621,8 +1690,8 @@ bool map_image(const LoadedImage& img, std::string* err) {
     void* want = (void*)(img.base + img.min_vaddr);
     size_t sz  = img.mem.size();
     // RWX for bring-up; per-segment W^X is a later refinement (shared LOAD pages).
-    void* got = mmap(want, sz, PROT_READ | PROT_WRITE | PROT_EXEC,
-                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+    void* got = prosper_mmap_noreplace(want, sz, PROT_READ | PROT_WRITE | PROT_EXEC,
+                                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (got == MAP_FAILED || got != want) return fail("mmap image at guest base failed");
     memcpy(got, img.mem.data(), sz);
     if (!g_base) g_base = img.base;   // main image, for fault-offset reporting
@@ -1643,8 +1712,8 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
     if (n == 0) { g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = 0; return true; }
     uint64_t region = page_up(n * stub_size);
     void* want = (void*)stub_base;
-    void* got = mmap(want, region, PROT_READ | PROT_WRITE | PROT_EXEC,
-                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+    void* got = prosper_mmap_noreplace(want, region, PROT_READ | PROT_WRITE | PROT_EXEC,
+                                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (got == MAP_FAILED || got != want) return fail("mmap stub region failed");
 
     bool swap = guest_tls_enabled();   // gated: emit the %fs swap stubs so HLE handlers run on the host TCB
@@ -1882,7 +1951,7 @@ void arm_hwbp() {
     g_hwbp_fd = (int)fd;
     fcntl(g_hwbp_fd, F_SETFL, O_ASYNC);
     fcntl(g_hwbp_fd, F_SETSIG, SIGTRAP);
-    struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
+    struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)prosper_gettid();
     fcntl(g_hwbp_fd, F_SETOWN_EX, &ow);
     if (!hwbp_register_thread(ow.pid, g_hwbp_fd)) {
         int n = snprintf(b, sizeof b, "[hwbp] thread-state table full for tid=%ld - HW bp disabled\n",
@@ -1893,7 +1962,7 @@ void arm_hwbp() {
     ioctl(g_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     t_hwbp_fd = g_hwbp_fd;   // main thread uses the same fd for its per-thread stepping state
     int n = snprintf(b, sizeof b, "[hwbp] armed HW execute bp at eboot+0x%llx (fd=%d tid=%ld)\n",
-                     (unsigned long long)(g_hwbp_addr - 0x400000000ull), g_hwbp_fd, (long)syscall(SYS_gettid));
+                     (unsigned long long)(g_hwbp_addr - 0x400000000ull), g_hwbp_fd, (long)prosper_gettid());
     syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
 }
 
@@ -1901,16 +1970,16 @@ void arm_hwbp() {
 // owns its own perf fd + SIGTRAP delivery, so off-main-thread execution of the target is observed too.
 void arm_hwbp_this_thread() {
     if (getenv("PROSPER_HWBP_ARMLOG")) { char b[128]; int n = snprintf(b, sizeof b,
-        "[hwbp] arm_this_thread tid=%ld on=%d all=%d addr=0x%llx tfd=%d\n", (long)syscall(SYS_gettid),
+        "[hwbp] arm_this_thread tid=%ld on=%d all=%d addr=0x%llx tfd=%d\n", (long)prosper_gettid(),
         g_hwbp_on, g_hwbp_allthreads, (unsigned long long)g_hwbp_addr, t_hwbp_fd); syscall(SYS_write, 2,b, n); }
     if (!g_hwbp_on || !g_hwbp_allthreads || !g_hwbp_addr || t_hwbp_fd >= 0) return;
     long fd = perf_bp_open(g_hwbp_addr, HW_BREAKPOINT_X);
     if (fd < 0) { char b[96]; int n = snprintf(b, sizeof b, "[hwbp] worker-arm FAILED tid=%ld errno=%d\n",
-        (long)syscall(SYS_gettid), errno); syscall(SYS_write, 2,b, n); return; }
+        (long)prosper_gettid(), errno); syscall(SYS_write, 2,b, n); return; }
     t_hwbp_fd = (int)fd;
     fcntl(t_hwbp_fd, F_SETFL, O_ASYNC);
     fcntl(t_hwbp_fd, F_SETSIG, SIGTRAP);
-    struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)syscall(SYS_gettid);
+    struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)prosper_gettid();
     fcntl(t_hwbp_fd, F_SETOWN_EX, &ow);
     if (!hwbp_register_thread(ow.pid, t_hwbp_fd)) {
         char b[112]; int n = snprintf(b, sizeof b,
@@ -1920,7 +1989,7 @@ void arm_hwbp_this_thread() {
     }
     ioctl(t_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     char b[128]; int n = snprintf(b, sizeof b, "[hwbp] armed on worker tid=%ld (fd=%d) for eboot+0x%llx\n",
-        (long)syscall(SYS_gettid), t_hwbp_fd, (unsigned long long)(g_hwbp_addr - 0x400000000ull));
+        (long)prosper_gettid(), t_hwbp_fd, (unsigned long long)(g_hwbp_addr - 0x400000000ull));
     syscall(SYS_write, 2,b, n);
 }
 
@@ -1965,6 +2034,22 @@ void set_module_start_param_ranges(const std::vector<std::pair<uint64_t, uint64_
 
 // Find the /proc/self/maps region containing `addr`: [s,e) and its "rwxp" perms. False if unmapped.
 static bool region_of(uint64_t addr, uint64_t& s, uint64_t& e, char perms[5]) {
+#ifdef __APPLE__
+    // mach_vm_region: first region at or after `addr` (containing it when mapped).
+    mach_vm_address_t ra = addr; mach_vm_size_t rs = 0;
+    vm_region_basic_info_data_64_t info; mach_msg_type_number_t cnt = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t obj = MACH_PORT_NULL;
+    if (mach_vm_region(mach_task_self(), &ra, &rs, VM_REGION_BASIC_INFO_64,
+                       (vm_region_info_t)&info, &cnt, &obj) != KERN_SUCCESS) return false;
+    if (obj != MACH_PORT_NULL) mach_port_deallocate(mach_task_self(), obj);
+    if (addr < ra || addr >= ra + rs) return false;   // gap: addr itself is unmapped
+    s = ra; e = ra + rs;
+    perms[0] = (info.protection & VM_PROT_READ)    ? 'r' : '-';
+    perms[1] = (info.protection & VM_PROT_WRITE)   ? 'w' : '-';
+    perms[2] = (info.protection & VM_PROT_EXECUTE) ? 'x' : '-';
+    perms[3] = 'p'; perms[4] = 0;
+    return true;
+#else
     FILE* mf = fopen("/proc/self/maps", "re");
     if (!mf) return false;
     char line[512];
@@ -1975,6 +2060,7 @@ static bool region_of(uint64_t addr, uint64_t& s, uint64_t& e, char perms[5]) {
     }
     fclose(mf);
     return false;
+#endif
 }
 
 // Print the `n` bytes at [start, start+n) for the init-fault report WITHOUT risking a second,

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -10,7 +10,7 @@
 // pointer per Variant II, and run guest code with %fs = guest TP. HLE handlers (which use host libc/TLS)
 // swap %fs back to the host TCB for the duration of the call — done in the emitted import stubs
 // (exec_image_linux.cpp), which read the stashed host %fs from [guestTP + GUEST_TCB_HOSTFS_OFF].
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include "../hle/dispatch.hpp"
 #include <cstdint>
 #include <cstdlib>
@@ -42,6 +42,16 @@ static constexpr uint32_t TCB_MAGIC       = 0x50524F53u;  // "PROS" — marks OU
 
 void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
     g_enabled = getenv("PROSPER_GUEST_FS") != nullptr;
+#ifdef __APPLE__
+    // Rosetta 2 does not implement rdfsbase/wrfsbase (verified: SIGILL on an M2, macOS 26) and
+    // Darwin has no fsbase API, so guest initial-exec %fs TLS cannot be enabled on this host yet.
+    // The default (host-%fs-aliasing) boot path is unaffected. See docs/PORTING.md.
+    if (g_enabled) {
+        fprintf(stderr, "[guest-tls] PROSPER_GUEST_FS is not supported on macOS (Rosetta lacks "
+                        "wrfsbase); continuing with it DISABLED\n");
+        g_enabled = false;
+    }
+#endif
     g_mods.assign(descs, descs + count);
     // x86-64 Variant II static-TLS layout (glibc _dl_determine_tlsoffset, TLS_TCB_AT_TP): each
     // module's block sits BELOW the thread pointer at a distance rounded to that module's REAL
@@ -112,6 +122,9 @@ uint64_t guest_tls_activate_thread() {
 // area) and simply won't match the magic. NOT used by the GC RT-signal handler, which must KEEP the guest
 // %fs to run the guest's own exception handler. Safe to call unconditionally.
 void guest_fs_enter_host_for_signal() {
+#ifdef __APPLE__
+    return;   // guest-fs is force-disabled on Darwin, and rdfsbase itself SIGILLs under Rosetta
+#endif
     uint64_t fs = rd_fsbase();
     if (fs && *(volatile uint32_t*)(fs + MAGIC_OFF) == TCB_MAGIC)
         wr_fsbase(*(volatile uint64_t*)(fs + HOSTFS_OFF));
@@ -121,6 +134,9 @@ void guest_fs_enter_host_for_signal() {
 // host %fs for the handler's host-libc calls and return the previous (guest) fs so the caller can restore
 // it before returning to guest code. Returns 0 if not on a guest TCB (nothing to restore).
 uint64_t guest_fs_to_host_scoped() {
+#ifdef __APPLE__
+    return 0;   // see guest_fs_enter_host_for_signal
+#endif
     uint64_t fs = rd_fsbase();
     if (fs && *(volatile uint32_t*)(fs + MAGIC_OFF) == TCB_MAGIC) {
         wr_fsbase(*(volatile uint64_t*)(fs + HOSTFS_OFF));

--- a/prosper/src/host/posix_shim.hpp
+++ b/prosper/src/host/posix_shim.hpp
@@ -1,0 +1,373 @@
+#pragma once
+// Darwin (macOS) compatibility for the small set of Linux/glibc-specific APIs the emulator uses.
+// Everything here is a REAL implementation (these back actual guest synchronization and fault-safe
+// memory access), not a stub — correctness-first per the project charter. Included by the HLE TUs
+// that use these APIs; a no-op on Linux/Windows.
+//
+// Provided on __APPLE__:
+//   - process_vm_readv / process_vm_writev  (same-process only) via mach_vm_read_overwrite/mach_vm_write
+//   - pthread_getattr_np                    via pthread_get_stackaddr_np/pthread_get_stacksize_np
+//   - pthread_mutex_timedlock, pthread_rwlock_timedrdlock/timedwrlock   (trylock + sleep loop)
+//   - sem_*        remapped to a mutex+cond counting semaphore (Darwin's unnamed sem_init is ENOSYS)
+//   - pthread_barrier_*  remapped to a generation-counted mutex+cond barrier
+//   - pthread_sigqueue   degraded to pthread_kill (sigval payload dropped — warns once; see note)
+//   - prosper_mincore    signature-portable mincore wrapper (Darwin takes char*, Linux unsigned char*)
+
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+// Global-asm portability: Mach-O prepends '_' to C symbols and has no ELF .type directive.
+// PROSPER_ASM_TRAMPOLINE emits the shared "pass entry rsp as the 7th argument" shim used by the
+// HLE callback/APR paths (see hle_file.cpp f_apr_read_submit_entry for the alignment rationale).
+#ifdef __APPLE__
+#define PROSPER_ASM_TRAMPOLINE(entry, target) \
+    asm(".text\n" \
+        ".globl _" #entry "\n" \
+        "_" #entry ":\n" \
+        "  movq %rsp, %rax\n" \
+        "  pushq %rax\n" \
+        "  call _" #target "\n" \
+        "  addq $8, %rsp\n" \
+        "  ret\n");
+#else
+#define PROSPER_ASM_TRAMPOLINE(entry, target) \
+    asm(".text\n" \
+        ".globl " #entry "\n" \
+        ".type " #entry ",@function\n" \
+        #entry ":\n" \
+        "  movq %rsp, %rax\n" \
+        "  pushq %rax\n" \
+        "  call " #target "\n" \
+        "  addq $8, %rsp\n" \
+        "  ret\n");
+#endif
+
+#ifndef __APPLE__
+
+static inline int prosper_mincore(const void* addr, size_t len, unsigned char* vec) {
+#ifdef _WIN32
+    (void)addr; (void)len; (void)vec; return -1;
+#else
+    return mincore(const_cast<void*>(addr), len, vec);
+#endif
+}
+
+#else  // __APPLE__
+
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <pthread.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstdio>
+#include <ctime>
+#include <csignal>
+
+static inline int prosper_mincore(const void* addr, size_t len, unsigned char* vec) {
+    return mincore(const_cast<void*>(addr), len, reinterpret_cast<char*>(vec));
+}
+
+// ---- fault-safe same-process memory copy (Linux: process_vm_readv/writev) ----------------------
+// The HLE uses these as an EFAULT-safe memcpy against possibly-unmapped guest addresses (pid is
+// always getpid()). mach_vm_read_overwrite/mach_vm_write give the same guarantee on Darwin. The
+// mach calls fail wholesale rather than partially; callers treat any short result as unreadable,
+// which is the same failure class. Only the 1-iovec form the HLE uses is supported.
+static inline ssize_t process_vm_readv(pid_t /*pid: self*/,
+                                       const struct iovec* local, unsigned long liovcnt,
+                                       const struct iovec* remote, unsigned long riovcnt,
+                                       unsigned long /*flags*/) {
+    if (liovcnt != 1 || riovcnt != 1 || local->iov_len != remote->iov_len) { errno = EINVAL; return -1; }
+    mach_vm_size_t got = 0;
+    kern_return_t kr = mach_vm_read_overwrite(mach_task_self(),
+                                              (mach_vm_address_t)remote->iov_base,
+                                              (mach_vm_size_t)remote->iov_len,
+                                              (mach_vm_address_t)local->iov_base, &got);
+    if (kr != KERN_SUCCESS) { errno = EFAULT; return -1; }
+    return (ssize_t)got;
+}
+static inline ssize_t process_vm_writev(pid_t /*pid: self*/,
+                                        const struct iovec* local, unsigned long liovcnt,
+                                        const struct iovec* remote, unsigned long riovcnt,
+                                        unsigned long /*flags*/) {
+    if (liovcnt != 1 || riovcnt != 1 || local->iov_len != remote->iov_len) { errno = EINVAL; return -1; }
+    kern_return_t kr = mach_vm_write(mach_task_self(),
+                                     (mach_vm_address_t)remote->iov_base,
+                                     (vm_offset_t)local->iov_base,
+                                     (mach_msg_type_number_t)local->iov_len);
+    if (kr != KERN_SUCCESS) { errno = EFAULT; return -1; }
+    return (ssize_t)local->iov_len;
+}
+
+// ---- struct stat nanosecond timestamp field names ----------------------------------------------
+#ifndef st_atim
+#define st_atim st_atimespec
+#define st_mtim st_mtimespec
+#define st_ctim st_ctimespec
+#endif
+
+// ---- pthread_getattr_np ------------------------------------------------------------------------
+// Darwin exposes the running thread's stack directly; repackage it into a pthread_attr_t so the
+// existing pthread_attr_getstack() consumers work unchanged. Note pthread_get_stackaddr_np returns
+// the stack TOP (highest address); POSIX attr carries the lowest address.
+static inline int pthread_getattr_np(pthread_t t, pthread_attr_t* attr) {
+    if (pthread_attr_init(attr) != 0) return EINVAL;
+    void*  top = pthread_get_stackaddr_np(t);
+    size_t sz  = pthread_get_stacksize_np(t);
+    if (!top || !sz) return EINVAL;
+    return pthread_attr_setstack(attr, (char*)top - sz, sz);
+}
+
+// ---- timed lock acquisition ----------------------------------------------------------------------
+// Darwin has no pthread_*_timedlock family. A trylock + 500µs sleep loop against the CLOCK_REALTIME
+// deadline preserves the guest-visible contract (0 only when actually locked, ETIMEDOUT on expiry);
+// wake latency is up to ~0.5ms coarser than a kernel timedlock. CONFIDENCE: MED (granularity only).
+static inline bool prosper_deadline_passed(const struct timespec* dl) {
+    struct timespec now; clock_gettime(CLOCK_REALTIME, &now);
+    return now.tv_sec > dl->tv_sec || (now.tv_sec == dl->tv_sec && now.tv_nsec >= dl->tv_nsec);
+}
+static inline int pthread_mutex_timedlock(pthread_mutex_t* m, const struct timespec* dl) {
+    for (;;) {
+        int rc = pthread_mutex_trylock(m);
+        if (rc != EBUSY) return rc;
+        if (prosper_deadline_passed(dl)) return ETIMEDOUT;
+        usleep(500);
+    }
+}
+static inline int pthread_rwlock_timedrdlock(pthread_rwlock_t* rw, const struct timespec* dl) {
+    for (;;) {
+        int rc = pthread_rwlock_tryrdlock(rw);
+        if (rc != EBUSY) return rc;
+        if (prosper_deadline_passed(dl)) return ETIMEDOUT;
+        usleep(500);
+    }
+}
+static inline int pthread_rwlock_timedwrlock(pthread_rwlock_t* rw, const struct timespec* dl) {
+    for (;;) {
+        int rc = pthread_rwlock_trywrlock(rw);
+        if (rc != EBUSY) return rc;
+        if (prosper_deadline_passed(dl)) return ETIMEDOUT;
+        usleep(500);
+    }
+}
+
+// ---- counting semaphore (Darwin sem_init is ENOSYS: unnamed POSIX semaphores unsupported) -------
+struct prosper_sem_t {
+    pthread_mutex_t m;
+    pthread_cond_t  c;
+    int             count;
+};
+static inline int prosper_sem_init(prosper_sem_t* s, int /*pshared*/, unsigned value) {
+    pthread_mutex_init(&s->m, nullptr); pthread_cond_init(&s->c, nullptr);
+    s->count = (int)value; return 0;
+}
+static inline int prosper_sem_wait(prosper_sem_t* s) {
+    pthread_mutex_lock(&s->m);
+    while (s->count <= 0) pthread_cond_wait(&s->c, &s->m);
+    s->count--; pthread_mutex_unlock(&s->m); return 0;
+}
+static inline int prosper_sem_trywait(prosper_sem_t* s) {
+    pthread_mutex_lock(&s->m);
+    if (s->count <= 0) { pthread_mutex_unlock(&s->m); errno = EAGAIN; return -1; }
+    s->count--; pthread_mutex_unlock(&s->m); return 0;
+}
+static inline int prosper_sem_timedwait(prosper_sem_t* s, const struct timespec* dl) {
+    pthread_mutex_lock(&s->m);
+    while (s->count <= 0) {
+        int rc = pthread_cond_timedwait(&s->c, &s->m, dl);
+        if (rc == ETIMEDOUT) { pthread_mutex_unlock(&s->m); errno = ETIMEDOUT; return -1; }
+    }
+    s->count--; pthread_mutex_unlock(&s->m); return 0;
+}
+static inline int prosper_sem_post(prosper_sem_t* s) {
+    pthread_mutex_lock(&s->m);
+    s->count++; pthread_cond_signal(&s->c); pthread_mutex_unlock(&s->m); return 0;
+}
+static inline int prosper_sem_getvalue(prosper_sem_t* s, int* out) {
+    pthread_mutex_lock(&s->m); *out = s->count; pthread_mutex_unlock(&s->m); return 0;
+}
+static inline int prosper_sem_destroy(prosper_sem_t* s) {
+    pthread_mutex_destroy(&s->m); pthread_cond_destroy(&s->c); return 0;
+}
+#define sem_t         prosper_sem_t
+#define sem_init      prosper_sem_init
+#define sem_wait      prosper_sem_wait
+#define sem_trywait   prosper_sem_trywait
+#define sem_timedwait prosper_sem_timedwait
+#define sem_post      prosper_sem_post
+#define sem_getvalue  prosper_sem_getvalue
+#define sem_destroy   prosper_sem_destroy
+
+// ---- barrier (Darwin has no pthread_barrier_t) ---------------------------------------------------
+struct prosper_barrier_t {
+    pthread_mutex_t m;
+    pthread_cond_t  c;
+    unsigned        threshold, waiting, generation;
+};
+#ifndef PTHREAD_BARRIER_SERIAL_THREAD
+#define PTHREAD_BARRIER_SERIAL_THREAD (-1)
+#endif
+static inline int prosper_barrier_init(prosper_barrier_t* b, const void* /*attr*/, unsigned count) {
+    if (!count) return EINVAL;
+    pthread_mutex_init(&b->m, nullptr); pthread_cond_init(&b->c, nullptr);
+    b->threshold = count; b->waiting = 0; b->generation = 0; return 0;
+}
+static inline int prosper_barrier_wait(prosper_barrier_t* b) {
+    pthread_mutex_lock(&b->m);
+    unsigned gen = b->generation;
+    if (++b->waiting == b->threshold) {
+        b->generation++; b->waiting = 0;
+        pthread_cond_broadcast(&b->c);
+        pthread_mutex_unlock(&b->m);
+        return PTHREAD_BARRIER_SERIAL_THREAD;
+    }
+    while (gen == b->generation) pthread_cond_wait(&b->c, &b->m);
+    pthread_mutex_unlock(&b->m);
+    return 0;
+}
+static inline int prosper_barrier_destroy(prosper_barrier_t* b) {
+    pthread_mutex_destroy(&b->m); pthread_cond_destroy(&b->c); return 0;
+}
+#define pthread_barrier_t       prosper_barrier_t
+#define pthread_barrier_init    prosper_barrier_init
+#define pthread_barrier_wait    prosper_barrier_wait
+#define pthread_barrier_destroy prosper_barrier_destroy
+
+// ---- pthread_sigqueue ----------------------------------------------------------------------------
+// Darwin cannot queue a realtime signal with a payload to a specific thread. pthread_kill delivers
+// the signal but DROPS the sigval; the exception-injection path that reads si_value will see zero.
+// CONFIDENCE: LOW for that diagnostic path (warns once when first exercised) — acceptable for boot
+// bring-up; revisit with a side-channel map if a title exercises guest exception injection on macOS.
+static inline int pthread_sigqueue(pthread_t t, int sig, const union sigval /*value*/) {
+    static bool warned = false;
+    if (!warned) { warned = true; fprintf(stderr, "[shim] pthread_sigqueue: sigval dropped on Darwin (pthread_kill)\n"); }
+    return pthread_kill(t, sig);
+}
+
+#endif // __APPLE__
+
+// ---- signal-context register access (shared by exec_image and the exception delivery HLE) -------
+// Linux exposes the interrupted registers as an indexable gregs[] array; Darwin as named fields in
+// __ss. PROSPER_GREGS gives handler code one indexable view of both; writes through it mutate the
+// mcontext exactly like the Linux array (sigreturn applies them on resume).
+#ifdef __APPLE__
+#include <signal.h>
+#include <sys/ucontext.h>
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"   // syscall(2): raw traps stay async-signal-safe
+enum { REG_R8 = 0, REG_R9, REG_R10, REG_R11, REG_R12, REG_R13, REG_R14, REG_R15,
+       REG_RDI, REG_RSI, REG_RBP, REG_RBX, REG_RDX, REG_RAX, REG_RCX, REG_RSP,
+       REG_RIP, REG_EFL };
+using greg_t = int64_t;
+struct prosper_gregs_view {
+    ucontext_t* uc;
+    uint64_t& operator[](int r) const {
+        auto& ss = uc->uc_mcontext->__ss;
+        switch (r) {
+            case REG_R8:  return (uint64_t&)ss.__r8;   case REG_R9:  return (uint64_t&)ss.__r9;
+            case REG_R10: return (uint64_t&)ss.__r10;  case REG_R11: return (uint64_t&)ss.__r11;
+            case REG_R12: return (uint64_t&)ss.__r12;  case REG_R13: return (uint64_t&)ss.__r13;
+            case REG_R14: return (uint64_t&)ss.__r14;  case REG_R15: return (uint64_t&)ss.__r15;
+            case REG_RDI: return (uint64_t&)ss.__rdi;  case REG_RSI: return (uint64_t&)ss.__rsi;
+            case REG_RBP: return (uint64_t&)ss.__rbp;  case REG_RBX: return (uint64_t&)ss.__rbx;
+            case REG_RDX: return (uint64_t&)ss.__rdx;  case REG_RAX: return (uint64_t&)ss.__rax;
+            case REG_RCX: return (uint64_t&)ss.__rcx;  case REG_RSP: return (uint64_t&)ss.__rsp;
+            case REG_RIP: return (uint64_t&)ss.__rip;  default:      return (uint64_t&)ss.__rflags;
+        }
+    }
+};
+#define PROSPER_GREGS(u)   (prosper_gregs_view{(u)})
+#define PROSPER_REG_ERR(u) ((uint64_t)(u)->uc_mcontext->__es.__err)
+// si_fd (which perf fd fired) is Linux-only siginfo; on Darwin no perf fd ever exists, so -1
+// routes the never-reached HWBP dispatch to its "not one of ours" paths.
+#define PROSPER_SI_FD(si) (-1)
+#elif defined(__linux__)
+#define PROSPER_GREGS(u)   ((u)->uc_mcontext.gregs)
+#define PROSPER_REG_ERR(u) ((uint64_t)(u)->uc_mcontext.gregs[REG_ERR])
+#define PROSPER_SI_FD(si)  ((si)->si_fd)
+#endif
+
+// ---- substrate primitives shared by exec_image / hle_kernel_mem / sync_futex --------------------
+// Real host thread id (async-signal-safe on both platforms; must NOT read %fs-based TLS because
+// guest threads may run with a guest %fs — see the g_jb comment in exec_image_linux.cpp).
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+static inline uint64_t prosper_gettid() {
+    uint64_t tid = 0; pthread_threadid_np(nullptr, &tid);   // reads %gs-based TSD, never %fs
+    return tid;
+}
+#elif defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+static inline uint64_t prosper_gettid() { return (uint64_t)syscall(SYS_gettid); }
+#endif
+
+#ifndef _WIN32
+// mmap that claims `addr` only if the range is entirely free (Linux MAP_FIXED_NOREPLACE).
+// Darwin lacks the flag: pass the address as a hint (Darwin honors free hints) and back out if the
+// kernel placed the mapping elsewhere. Not atomic against a concurrent mapper, but all in-process
+// fixed-address allocation goes through the HLE/loader paths. CONFIDENCE: MED (race window only).
+static inline void* prosper_mmap_noreplace(void* addr, size_t len, int prot, int flags, int fd, off_t off) {
+#ifdef __linux__
+    return mmap(addr, len, prot, flags | MAP_FIXED_NOREPLACE, fd, off);
+#else
+    void* p = mmap(addr, len, prot, flags & ~MAP_FIXED, fd, off);
+    if (p == MAP_FAILED) return p;
+    if (p != addr) { munmap(p, len); errno = EEXIST; return MAP_FAILED; }
+    return p;
+#endif
+}
+
+// Anonymous shared-memory fd usable for multi-mapping one physical range (Linux memfd_create).
+// Darwin: a POSIX shm object, unlinked immediately so the fd is the only reference.
+static inline int prosper_memfd_create(const char* name) {
+#ifdef __linux__
+    return (int)syscall(SYS_memfd_create, name, 1 /*MFD_CLOEXEC*/);
+#else
+    char nm[64];
+    for (unsigned i = 0; i < 64; i++) {
+        snprintf(nm, sizeof nm, "/%s-%d-%u", name, (int)getpid(), i);
+        int fd = shm_open(nm, O_RDWR | O_CREAT | O_EXCL, 0600);
+        if (fd >= 0) { shm_unlink(nm); return fd; }
+        if (errno != EEXIST) break;
+    }
+    return -1;
+#endif
+}
+
+// futex(FUTEX_WAIT/WAKE)-shaped wait-on-address. Darwin: os_sync_wait_on_address (macOS 14.4+).
+// Semantics preserved for the HLE callers: wait returns 0 on wake, -1/ETIMEDOUT on expiry,
+// -1/EAGAIN when *addr != expect at entry; wake returns without error when no one waits.
+#ifdef __APPLE__
+extern "C" int os_sync_wait_on_address(void* addr, uint64_t value, size_t size, uint32_t flags);
+extern "C" int os_sync_wait_on_address_with_timeout(void* addr, uint64_t value, size_t size,
+                                                    uint32_t flags, uint32_t clockid, uint64_t timeout_ns);
+extern "C" int os_sync_wake_by_address_any(void* addr, size_t size, uint32_t flags);
+extern "C" int os_sync_wake_by_address_all(void* addr, size_t size, uint32_t flags);
+static inline int prosper_futex_wait(uint32_t* addr, uint32_t expect, const struct timespec* rel) {
+    if (__atomic_load_n(addr, __ATOMIC_SEQ_CST) != expect) { errno = EAGAIN; return -1; }
+    int r;
+    if (rel) {
+        uint64_t ns = (uint64_t)rel->tv_sec * 1000000000ull + (uint64_t)rel->tv_nsec;
+        r = os_sync_wait_on_address_with_timeout(addr, expect, 4, 0, 32 /*OS_CLOCK_MACH_ABSOLUTE_TIME*/, ns);
+    } else {
+        r = os_sync_wait_on_address(addr, expect, 4, 0);
+    }
+    return r < 0 ? -1 : 0;   // errno already ETIMEDOUT on expiry
+}
+static inline void prosper_futex_wake(uint32_t* addr, bool all) {
+    if (all) os_sync_wake_by_address_all(addr, 4, 0);
+    else     os_sync_wake_by_address_any(addr, 4, 0);
+}
+#elif defined(__linux__)
+#include <linux/futex.h>
+static inline int prosper_futex_wait(uint32_t* addr, uint32_t expect, const struct timespec* rel) {
+    return (int)syscall(SYS_futex, addr, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, expect, rel, nullptr, 0);
+}
+static inline void prosper_futex_wake(uint32_t* addr, bool all) {
+    syscall(SYS_futex, addr, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, all ? INT32_MAX : 1, nullptr, nullptr, 0);
+}
+#endif
+#endif // !_WIN32

--- a/prosper/src/host/posix_shim.hpp
+++ b/prosper/src/host/posix_shim.hpp
@@ -12,6 +12,12 @@
 //   - pthread_barrier_*  remapped to a generation-counted mutex+cond barrier
 //   - pthread_sigqueue   degraded to pthread_kill (sigval payload dropped — warns once; see note)
 //   - prosper_mincore    signature-portable mincore wrapper (Darwin takes char*, Linux unsigned char*)
+//
+// Windows has no guest-execution substrate yet, and every symbol here is consumed only from
+// POSIX-guarded code (exec_image_linux.cpp is __linux__/__APPLE__-only; hle_file.cpp's
+// prosper_mincore use is inside #ifndef _WIN32). The whole header is therefore POSIX-only — on
+// Windows it must expand to nothing, since <sys/mman.h> does not exist under MinGW.
+#ifndef _WIN32
 
 #include <sys/mman.h>
 #include <fcntl.h>
@@ -370,4 +376,6 @@ static inline void prosper_futex_wake(uint32_t* addr, bool all) {
     syscall(SYS_futex, addr, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, all ? INT32_MAX : 1, nullptr, nullptr, 0);
 }
 #endif
-#endif // !_WIN32
+#endif // !_WIN32 (substrate primitives)
+
+#endif // !_WIN32 (whole header: POSIX-only, no-op under MinGW)

--- a/prosper/tests/test_boot_linux.cpp
+++ b/prosper/tests/test_boot_linux.cpp
@@ -13,6 +13,7 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <signal.h>   // kill(): not pulled in transitively on Darwin
 #include <ctime>
 
 using namespace prosper;

--- a/prosper/tests/test_prot_none.cpp
+++ b/prosper/tests/test_prot_none.cpp
@@ -21,13 +21,17 @@ static sigjmp_buf g_jmp;
 static volatile sig_atomic_t g_faulted;
 static void on_segv(int) { g_faulted = 1; siglongjmp(g_jmp, 1); }
 
-// Returns true if READING *p faulted (i.e. the page is not readable).
+// Returns true if READING *p faulted (i.e. the page is not readable). Catch SIGBUS alongside
+// SIGSEGV: Darwin delivers PROT_NONE access as SIGBUS where Linux uses SIGSEGV (the emulator's
+// real fault handler likewise registers both).
 static bool read_faults(const volatile uint32_t* p) {
-    struct sigaction sa{}, old{}; sa.sa_handler = on_segv; sigemptyset(&sa.sa_mask);
-    sigaction(SIGSEGV, &sa, &old);
+    struct sigaction sa{}, old_segv{}, old_bus{}; sa.sa_handler = on_segv; sigemptyset(&sa.sa_mask);
+    sigaction(SIGSEGV, &sa, &old_segv);
+    sigaction(SIGBUS, &sa, &old_bus);
     g_faulted = 0;
     if (sigsetjmp(g_jmp, 1) == 0) { volatile uint32_t v = *p; (void)v; }
-    sigaction(SIGSEGV, &old, nullptr);
+    sigaction(SIGSEGV, &old_segv, nullptr);
+    sigaction(SIGBUS, &old_bus, nullptr);
     return g_faulted != 0;
 }
 


### PR DESCRIPTION
Executes the macOS milestone of the porting plan (#610): build the core as x86_64 Darwin and run it under Rosetta 2, targeting a fresh title (Blasphemous 2, PPSA13579 — Unity/IL2CPP, same module family as The Messenger).

## Result

- **67/67 ctest green** on an Apple M2 under Rosetta 2 (up from the 55-test pure subset — the substrate tests trap/boot/setjmp/stack/AGC/videoout/prot_none now run on Darwin too).
- **`boot_trace PPSA13579-app0` links all 7 modules, resolves 3554 imports (408 cross-module), dispatches every `.init_array`, and executes real guest x86-64 code**, reaching the C runtime's first constructor running libc initialization.

## What's here

- `src/host/posix_shim.hpp`: Darwin equivalents of the ~15 Linux/glibc primitives the emulator uses — mach `process_vm_readv/writev`, `os_sync_wait_on_address` futex, unlinked-`shm_open` memfd, `MAP_FIXED_NOREPLACE` emulation, `gettid`, `pthread_getattr_np`, timed mutex/rwlock, a real counting semaphore + barrier (Darwin lacks unnamed `sem_t`/`pthread_barrier_t`), an indexable mcontext register view over `__ss`, and Mach-O/ELF global-asm portability.
- Darwin variants in the guest-exec substrate: SSE4a xmm emulation over Darwin's float state, `mach_vm_region` replacing `/proc/self/maps`, perf-event HWBP gracefully unsupported (software-watch + int3 remain), exception delivery via SIGUSR2 + an async-signal-safe pending-type table (no `pthread_sigqueue`), and `PROSPER_GUEST_FS` force-disabled (Rosetta SIGILLs on `wrfsbase`).
- The fault handler runs on the sigaltstack by default on macOS (mandatory there — otherwise a stack-region fault force-kills the process with no handler entry).
- Correctness fix exposed by the port (all platforms): the unannounced-32-bit index-buffer fingerprint (#304) read the same bytes through `uint16_t*` and `uint32_t*` — strict-aliasing UB that Apple Clang 21 compiled into `ud2`. Now uses `memcpy` loads.
- CMake: the three `UNIX AND NOT APPLE` gates opened to `UNIX` (evdev pad stays Linux-only).

## Known frontier (tracked separately)

Boot stalls a few frames into libc init on **guest `%fs` TLS** — the hard sub-problem the plan flagged. Rosetta doesn't implement `wrfsbase` and Darwin's `%fs` base is 0 (macOS uses `%gs`), so guest initial-exec TLS reads resolve to garbage immediately. The fix is to trap/patch guest `%fs`-relative accesses (the fault handler already decodes instructions there). Filed as an issue.

No Linux behavior changes (all Darwin code is `#ifdef __APPLE__`; the index-buffer fix is a pure correctness improvement).