### PR TITLE
gpu: structure uniform VCC exit loops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,19 @@ provenance, which found compute program `0x401aec200` filling the exact 32 KiB H
 DS entries become invalid so the next use follows the existing compare-derived clear path. A routed live A/B
 restores the foreground/platform/HUD layers that remain black with invalidation disabled. The explicit
 `--legacy-htile-before-stencil` switch supplies the omitted HTILE identity only for the preserved pre-v6 bundle.
+The four repeated Dead Cells fragment failures were canonical VCCZ-exit light-accumulation loops. #615 adds a
+stage-specific proof: every VOPC input must be scalar/inline/literal or have a nearest overlapping VGPR
+definition from an unmodified uniform VOP1 move/conversion. Only then can the wave-empty VCC test lower to a
+per-invocation structured loop; varying bounds and compute remain fail-visible. `shader_inspect` decodes raw
+`PROSPER_SHADER_DUMP` files with exact dword PCs and branch targets. Current live gameplay samples realize all
+semantic draws; #618 tracks retaining the failed shader/state in future capsules.
 Do not treat `--bundle-final-capsule` as an exact DS checkpoint: it snapshots color RTT state, not live Vulkan
 depth/stencil images (#569). Capture v6 and timeline v5 remain backward-compatible with old local artifacts.
-Addresses and operation ordinals are run-local. The stale exact Dead Cells snapshot baseline is
-tracked separately in #596 and must not be silently updated.
+Addresses and operation ordinals are run-local. The #608 `90 draws + 738x420 at draw 79..81` conjunction is
+also historical: a fresh 2026-07-13 route reached sustained 90-91-draw gameplay submits but did not match it.
+Recalibrate the semantic selector under #594 before a new exact capture. The Dead Cells splash guard alternates
+between hashes `8429fedd427b...` and `891a80fc9178...` on one unchanged build; replace that nondeterministic
+exact-frame contract under #596 rather than silently choosing or re-blessing either hash.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.
 `PROSPER_RESOURCE_HASH_DIM=WxH` correlates raw and sampled hashes with those writers at each live draw;

--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ accepts scripted gamepad input, and renders the first level.
   first playable scene. Graphics and compute now execute by retained PM4 order (#584), fixing a proven
   future-read. The formerly overbright screenshot was traced to a diagnostic warmup skipping temporal RTT
   producers. Versioned offline bundles now retain long, exact cross-submit resource history and replay a
-  minimized closure. #608 now defines a run-local semantic checkpoint for the controllable Jump tutorial:
-  exactly 90 semantic draws with the 738x420 pass at draw index 79..81. Its faithful 883-submit replay
-  isolated the missing-world symptom to a persistent 642x362 depth surface. Timeline-v5 backing hashes and
+  minimized closure. #608 preserved a run-local semantic checkpoint for the controllable Jump tutorial:
+  exactly 90 semantic draws with the 738x420 pass at draw index 79..81. That conjunction is historical and
+  no longer matches current fresh routes; route-independent selector refresh remains under #594. Its faithful
+  883-submit replay isolated the missing-world symptom to a persistent 642x362 depth surface. Timeline-v5 backing hashes and
   writer provenance then found the real clear boundary: a supported compute kernel fills the surface's
   32 KiB HTILE allocation with `0xfffffff0` before drawing. Guest GPU writes now invalidate overlapping
-  cached Vulkan depth images, restoring the rejected gameplay layers in a routed live A/B (#611).
+  cached Vulkan depth images, restoring the rejected gameplay layers in a routed live A/B (#611). The four
+  remaining scene draws used uniform VCCZ-exit light loops; the fragment/vertex recompiler now proves that
+  narrow wave-uniform shape, emits structured loops, and realizes every sampled gameplay draw (#615).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -335,6 +335,10 @@ if(TARGET prosper_core)
   add_executable(shader_histo tools/shader_histo/shader_histo.cpp)
   target_link_libraries(shader_histo PRIVATE prosper_core)
 
+  # shader_inspect: bounded offline decode/CFG listing for raw PROSPER_SHADER_DUMP binaries.
+  add_executable(shader_inspect tools/shader_inspect/shader_inspect.cpp)
+  target_link_libraries(shader_inspect PRIVATE prosper_core)
+
   # spv_validate: recompile one shader from every path and run spirv-val on each — a strict-validation
   # gate (the render tests only prove llvmpipe accepts them; llvmpipe is lenient). No Vulkan needed;
   # skips validation gracefully if spirv-val is not on PATH (still checks recompilation succeeds).

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -42,6 +42,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   compute writer provenance identify Unity's 32 KiB HTILE fill as the per-frame fast clear, and overlapping
   guest GPU writes now invalidate the detached Vulkan depth cache (#611). A routed live A/B restores the
   foreground/platform/HUD layers that remained black without invalidation.
+  Four repeated fragment failures were uniform VCCZ-exit light-accumulation loops. The stage-specific
+  structurizer now accepts that shape only when each compare operand has a proved wave-uniform reaching
+  definition; varying bounds and the compute wave-mask form still reject. Current routed gameplay submits
+  realize every semantic draw (#615).
   Version-6 GPU captures seed temporal render targets, retain complete depth-surface programming, and keep
   content-addressed resource versions for
   faithful offline isolation (#568/#594); one residual
@@ -52,14 +56,16 @@ possible without console keys. Dumps are user-supplied and gitignored.
   chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal
   642×362 edges without bounded leaves, but the first 80-draw semantic endpoint is the opening vignette rather
-  than playable gameplay. #608 now selects the controllable Jump tutorial by combining an exact 90-draw submit
-  with the 738x420 pass at semantic draw 79..81, and tracks its exact history and first bad composition.
+  than playable gameplay. #608 selected the controllable Jump tutorial by combining an exact 90-draw submit
+  with the 738x420 pass at semantic draw 79..81, and tracked its exact history and first bad composition. That
+  exact conjunction is now a preserved-capture recipe: current fresh routes reach sustained gameplay but no
+  longer match it, so selector recalibration remains under #594.
   The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
   failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written
   HTILE metadata instead; #611 implements that missing cache boundary. #569 still tracks exact depth/stencil
-  checkpoint serialization, and #615 tracks four fragment control-flow failures at the playable endpoint.
-  The stale exact Dead Cells
-  snapshot baseline is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
+  checkpoint serialization. #618 tracks capture-side failed-operation diagnostics so the next unsupported
+  shader can be reduced offline without another live title run. The nondeterministic exact-frame Dead Cells
+  snapshot guard is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
 [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -49,10 +49,12 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   with `0xfffffff0` before every scene pass. Timeline-v5 depth backing hashes/writer provenance found the exact
   writer, and guest GPU writes now invalidate overlapping persistent DS cache entries (#611). A routed live A/B
   restores the layers rejected without that boundary.
-- **Immediate milestone:** finish the remaining Dead Cells composition gaps using the same semantic checkpoint.
-  Implement the four repeated fragment control-flow failures (#615), resolve exact depth/stencil checkpointing (#569),
-  and refresh the stale animation-sensitive snapshot (#596/#573). Keep extending the workflow across Unity and
-  Unreal targets rather than returning to long unstructured live traces.
+  The four remaining fragment failures were uniform VCCZ-exit light loops; narrowly proved vertex/fragment
+  structurization now restores them while varying and compute-wave forms still reject (#615).
+- **Immediate milestone:** refresh the now-stale Dead Cells semantic checkpoint under #594, resolve exact
+  depth/stencil checkpointing (#569), retain bounded failed-operation diagnostics in captures (#618), and replace
+  the nondeterministic animation-sensitive exact snapshot (#596/#573). Keep extending the workflow across Unity
+  and Unreal targets rather than returning to long unstructured live traces.
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -27,10 +27,10 @@ investigation, add `PROSPER_RENDER_TARGET_DIM=642x362` to preserve the level's
 RTT chain; this is much slower and currently remains in the opening vignette at
 the 35-second checkpoint. Do not use the fast route as a visual golden guard.
 
-## Playable semantic checkpoint
+## Historical playable semantic checkpoint (#608)
 
-Do not select the first 738x420 target: it also occurs in the skippable opening. The validated Jump-tutorial
-endpoint combines all of these predicates:
+Do not select the first 738x420 target: it also occurs in the skippable opening. The preserved #608
+Jump-tutorial capture used all of these predicates:
 
 ```bash
 PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
@@ -39,9 +39,16 @@ PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=90 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=90
 ```
 
-The draw index is zero-based in the raw semantic sequence. Fresh native-speed runs selected different submit
-numbers but replayed the same controllable scene with 86 realized draws, seven realized dispatches, the Jump
-prompt, and the full HUD. Nearby cinematic and transition captures are explicitly outside this conjunction.
+The draw index is zero-based in the raw semantic sequence. Those #608 runs selected different submit numbers
+but replayed the same controllable scene with 86 realized draws, seven realized dispatches, the Jump prompt,
+and the full HUD. Nearby cinematic and transition captures were outside this conjunction.
+
+This is no longer a guaranteed current selector. A 2026-07-13 fresh route after #611 reached sustained
+gameplay submits with 90-91 semantic draws, eight dispatches, and the 642x362 scene-depth family, but did not
+match `738x420 @ draw 79..81` plus exactly 90 draws during a bounded 90-second run. Treat the conjunction as
+a preserved-capture recipe only. Record a native-speed `.prgtl`, confirm gameplay from its submit/depth
+sequence, and derive a new exact conjunction before starting an expensive capsule or bundle. Refreshing that
+route-independent checkpoint remains under #594.
 
 The faithful playable reference on #608 retained 883 submits and renders hash
 `5759c125812154dc`. A final-submit replay with fresh depth renders `71b84bdfae53933c` instead. Use
@@ -50,5 +57,8 @@ reconstructing resource payloads or invoking Vulkan. Timeline-v5 `--depth-summar
 capture with `PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM=642x362`, found that the stable surface backing changed via
 compute: program `0x401aec200` fills the 32 KiB HTILE block with `0xfffffff0` before the scene draws. #611 now
 invalidates overlapping persistent Vulkan depth/stencil images on guest GPU writes, restoring the rejected
-layers. The 35-second screenshot warmup still skips color RTT history and therefore remains an overbright
-progression diagnostic, not a color-correct gameplay oracle.
+layers. Dead Cells' four repeated fragment failures were uniform VCCZ-exit light loops; #615 adds a narrowly
+proved fragment/vertex structurization path and current gameplay submits realize every semantic draw. Use
+`shader_inspect` for raw `PROSPER_SHADER_DUMP` binaries; capture-side retention of unrealized shader diagnostics
+is tracked in #618. The 35-second screenshot warmup still skips color RTT history and therefore remains an
+overbright progression diagnostic, not a color-correct gameplay oracle.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1320,7 +1320,7 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
     return L;
 }
 
-// DIVERGENT EXECZ-EXIT LOOPS (#273 — DOLL's post-process accumulation PSes, the title-composite
+// DIVERGENT EXEC/VCC-EXIT LOOPS (#273/#615 — post-process and light-accumulation PSes, the title-composite
 // content producers). The compiled shape:
 //     header: <exec recompute: v_cmpx_.. counter,bound  |  v_cmp..;s_andn2_b64 exec,exec,vcc>
 //             s_cbranch_execz EXIT                      ; leave when no lane remains
@@ -1343,12 +1343,109 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
 // mirrors the exec recompute), so the next header check exits it — we REQUIRE the execnz back-edge
 // (exec-governed continue) for any loop carrying breaks, which makes that reasoning structural.
 struct DivLoop {
+    enum class Condition : uint8_t { Exec, Vcc };
     uint32_t header_pc = 0;        // back-edge target; condition region = [header_pc, exit_branch_pc)
-    uint32_t exit_branch_pc = 0;   // the canonical forward s_cbranch_execz whose target is exit_pc
+    uint32_t exit_branch_pc = 0;   // canonical forward execz/vccz branch whose target is exit_pc
     uint32_t backedge_pc = 0;      // backward s_branch (unconditional) or s_cbranch_execnz
     uint32_t exit_pc = 0;          // backedge_pc + its length (first pc after the loop)
     std::vector<uint32_t> break_pcs;   // extra forward vccz/execz -> exit_pc (lowered as body ifs)
+    Condition condition = Condition::Exec;
 };
+
+// Number of consecutive VGPRs an instruction writes, starting at dst. This is intentionally an
+// over-approximation for memory operations: treating a store's VDATA as clobbered can only make the
+// uniformity proof below reject, while missing a multi-register load could make it accept stale data.
+uint32_t vgpr_write_count(const Rdna2Inst& in) {
+    if (in.dst.kind != OperandKind::VGPR) return 0;
+    switch (in.fmt) {
+        case Rdna2Format::VOP1:
+            return in.opcode == 0x02 ? 0 : 1;                   // v_readfirstlane writes an SGPR
+        case Rdna2Format::VOP2: case Rdna2Format::VOP3: case Rdna2Format::VOP3P:
+            return 1;
+        case Rdna2Format::DS:
+            return in.opcode == 0x36 || in.opcode == 0xb1 ? 1 : 0;
+        case Rdna2Format::MUBUF:
+            switch (in.opcode) {
+                case 0x1: case 0x5: case 0xD: return 2;
+                case 0x2: case 0x6: case 0xF: return 3;
+                case 0x3: case 0x7: case 0xE: return 4;
+                default: return 1;
+            }
+        case Rdna2Format::MIMG: {
+            if (in.opcode == 0x47 || in.opcode == 0x57) return 4;  // gather4 always returns four texels
+            uint32_t n = 0;
+            for (uint32_t c = 0; c < 4; ++c) n += (in.mimg_dmask >> c) & 1u;
+            return n ? n : 4;                                     // unknown/empty mask: reject conservatively
+        }
+        default:
+            return 0;
+    }
+}
+
+bool vopc_is_cmpx(uint32_t opcode) {
+    return (opcode >= 0x10 && opcode <= 0x1f) ||
+           (opcode >= 0x90 && opcode <= 0x9f) ||
+           (opcode >= 0xd0 && opcode <= 0xdf);
+}
+
+bool instruction_may_change_exec(const Rdna2Inst& in) {
+    if (in.fmt == Rdna2Format::VOPC && vopc_is_cmpx(in.opcode)) return true;
+    auto is_exec = [](const Operand& operand) {
+        return (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special) &&
+               (operand.value == 126 || operand.value == 127);
+    };
+    return is_exec(in.dst) || is_exec(in.sdst);
+}
+
+// A scalar VCCZ branch tests whether ANY active lane set VCC, not this lane's bit. Lowering that
+// branch as per-invocation structured control flow is exact only when the VCC producer is provably
+// uniform across the wave. Dead Cells' light loops use the narrow compiler shape
+//   v_cvt_i32_f32 vBOUND, sBOUND; ...; v_cmp_* vcc, sCOUNTER, vBOUND; s_cbranch_vccz EXIT
+// so every active lane makes the same comparison. Keep the proof deliberately local and reject a
+// varying/unresolved VGPR bound rather than silently changing wave semantics.
+bool vcc_exit_is_wave_uniform(const std::vector<Rdna2Inst>& ins, uint32_t branch_pc) {
+    const Rdna2Inst* compare = nullptr;
+    for (auto it = ins.rbegin(); it != ins.rend(); ++it) {
+        if (it->pc >= branch_pc) continue;
+        if (sopp_is_noop(*it)) continue;
+        compare = &*it;
+        break;
+    }
+    if (!compare || compare->fmt != Rdna2Format::VOPC || vopc_is_cmpx(compare->opcode)) return false;
+
+    auto uniform_operand = [&](const Operand& operand) -> bool {
+        if (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::InlineInt ||
+            operand.kind == OperandKind::InlineFloat || operand.kind == OperandKind::Literal)
+            return true;
+        if (operand.kind != OperandKind::VGPR) return false;
+        for (auto it = ins.rbegin(); it != ins.rend(); ++it) {
+            if (it->pc >= compare->pc) continue;
+            const uint32_t writes = vgpr_write_count(*it);
+            if (!writes || operand.value < it->dst.value ||
+                operand.value >= it->dst.value + (int32_t)writes) continue;
+            const bool uniform_unary = it->fmt == Rdna2Format::VOP1 &&
+                (it->opcode == 0x01 || (it->opcode >= 0x05 && it->opcode <= 0x08));
+            const bool uniform_definition = it->dst.value == operand.value && uniform_unary &&
+                !it->has_modifier && !it->has_dpp && it->sdwa_dst_sel == 6 &&
+                it->sdwa_src0_sel == 6 && it->n_src == 1 &&
+                (it->src[0].kind == OperandKind::SGPR ||
+                 it->src[0].kind == OperandKind::InlineInt ||
+                 it->src[0].kind == OperandKind::InlineFloat ||
+                 it->src[0].kind == OperandKind::Literal);
+            if (!uniform_definition) return false;
+            // The write makes every currently active lane uniform. It remains so only while EXEC is
+            // unchanged; a later widen could reactivate lanes that retained an older varying value.
+            for (const auto& between : ins)
+                if (between.pc > it->pc && between.pc < compare->pc &&
+                    instruction_may_change_exec(between)) return false;
+            return true;
+        }
+        return false;
+    };
+    for (uint32_t i = 0; i < compare->n_src; ++i)
+        if (!uniform_operand(compare->src[i])) return false;
+    return compare->n_src != 0;
+}
 
 // Returns the loops in header-pc order, or {} when any backward branch doesn't fit the shape (the
 // caller then rejects the stream loudly, exactly as before this feature). `safe` carries the
@@ -1402,7 +1499,17 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
             if (tgt > L.exit_pc) return {};                     // conditional jumping past the loop
             if (tgt == L.exit_pc) {                             // an exit test
                 if (!L.exit_branch_pc) {                        // first one = the canonical exit
-                    if (in.opcode != 0x08) return {};           // must be execz -> EXIT
+                    if (in.opcode == 0x08) {                    // execz -> EXIT
+                        L.condition = DivLoop::Condition::Exec;
+                    } else if (in.opcode == 0x06 && !execnz &&
+                               vcc_exit_is_wave_uniform(ins, in.pc)) {
+                        // The compare is uniform, so VCC is either set for every active lane or empty.
+                        // Compute still never calls this detector; its general VCC contract remains a
+                        // wave mask requiring a reduction (#590).
+                        L.condition = DivLoop::Condition::Vcc;
+                    } else {
+                        return {};
+                    }
                     L.exit_branch_pc = in.pc;
                 } else {                                        // later ones = breaks
                     if (in.opcode != 0x06 && in.opcode != 0x08) return {};  // vccz/execz only
@@ -1566,6 +1673,7 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 break;                                               // DIVERGENT-REGION if (per-invocation
                                                                      // stages only — compute has wave VCC/EXEC)
             case 0x06: case 0x07:                                    // vccz / vccnz
+                if (loop_exit(in.pc)) continue;                      // canonical loop condition: loop emitter owns it
                 if (!allow_vcc) return reject();
                 break;
             case 0x04: case 0x05:                                    // scc0 / scc1
@@ -1682,15 +1790,10 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 else vregs.insert(in.dst.value); break;                   // (writelane: slots, not SSA)
             case Rdna2Format::DS:                                          // ds_read writes one VGPR
                 if (in.opcode == 0x36 || in.opcode == 0xb1) vregs.insert(in.dst.value); break;
-            case Rdna2Format::MUBUF: {                                     // load_format/load: N consecutive VGPRs
-                uint32_t n = 1; switch (in.opcode) { case 0x1: case 0x5: case 0xD: n=2; break;
-                    case 0x2: case 0x6: case 0xF: n=3; break; case 0x3: case 0x7: case 0xE: n=4; break; }
-                for (uint32_t k = 0; k < n; k++) vregs.insert(in.dst.value + (int)k); break;
-            }
-            case Rdna2Format::MIMG: {                                      // image_load: one VGPR per dmask bit
-                int w = 0; for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) vregs.insert(in.dst.value + w++);
+            case Rdna2Format::MUBUF: case Rdna2Format::MIMG:
+                for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
+                    vregs.insert(in.dst.value + (int)k);
                 break;
-            }
             case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPK:
                 sregs.insert(in.dst.value); break;
             case Rdna2Format::SMEM: {                                      // s_load/s_buffer_load: N consecutive SGPRs
@@ -2343,8 +2446,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // v_cmpx_* shares each type's compare set at base+0x10 (f32 0x10-0x1f, i32 0x90-0x9f,
             // u32 0xd0-0xdf); it writes EXEC in addition to VCC. Map to the base compare, then narrow.
             uint32_t op = in.opcode;
-            bool is_cmpx = (op >= 0x10 && op <= 0x1f) || (op >= 0x90 && op <= 0x9f) ||
-                           (op >= 0xd0 && op <= 0xdf);
+            bool is_cmpx = vopc_is_cmpx(op);
             if (is_cmpx && !allow_exec_update) { ok = false; return true; }
             uint32_t eff = is_cmpx ? op - 0x10 : op;
             uint32_t cmp = 0;
@@ -3587,7 +3689,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // 7. Post-loop body.
         if (!emit_range(L.exit_pc, UINT32_MAX)) return false;
     } else if (std::vector<DivLoop> Ls; true) {
-        // DIVERGENT execz-exit loops (#273) + structured uniform/divergent IFs. Loops are detected
+        // Per-invocation EXEC/VCC-exit loops (#273/#615) + structured uniform/divergent IFs. Loops are detected
         // for the per-invocation stages only (fragment/vertex — the compute shell keeps its
         // wave-level VCC/EXEC contract); each is emitted as a real structured SPIR-V loop
         // (OpLoopMerge + header OpPhi per carried register/mask) whose per-lane condition is THIS
@@ -3624,7 +3726,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // CONFIDENCE: MED — per-invocation lowering of wave-level branches; spirv-val + exec-diff
         // kernels + the live-boot A/B gate it.
         std::function<bool(uint32_t, uint32_t, uint32_t)> emit_structured;
-        // Emit one DIVERGENT execz-exit loop (#273) as a structured SPIR-V loop. Same block shape as
+        // Emit one per-invocation EXEC/VCC-exit loop (#273/#615) as structured SPIR-V. Same block shape as
         // the counted-loop path (hdr -> chk -> body -> cont -> hdr, exit chk->merge) with three
         // differences: (1) the loop condition is THIS lane's EXEC bool after the header's exec
         // recompute (v_cmpx / s_andn2 exec) — continue while set, exit at execz; (2) the body is
@@ -3637,6 +3739,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // emitting invalid SPIR-V). CONFIDENCE: MED (per-invocation lowering of a wave-level loop;
         // spirv-val + execution kernels + the live-boot A/B gate it).
         std::function<bool(const DivLoop&)> emit_divloop = [&](const DivLoop& L) -> bool {
+            const bool entry_exec_narrowed = rs.exec_narrowed;
             std::set<int> cv, cs, condv, conds;
             loop_written_regs(ins, L.header_pc, L.backedge_pc, cv, cs);
             loop_written_regs(ins, L.header_pc, L.exit_branch_pc, condv, conds);
@@ -3655,8 +3758,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             std::sort(mask_keys.begin(), mask_keys.end());     // deterministic emission order
             for (int k : mask_keys) { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.sreg_bool[k], preheader, p); rs.sreg_bool[k] = ph; phis.push_back({k, 5, ph, p}); }
             b.emit_loopmerge(merge, cont); b.emit_branch(chk); b.emit_label(chk);
-            // Inside the loop EXEC is the per-lane loop condition — vector writes must predicate.
-            rs.exec_narrowed = true;
+            // An EXEC-governed loop predicates vector writes. A VCC-governed loop branches on this
+            // invocation's VCC bit but does not itself change EXEC, matching the hardware loop body.
+            if (L.condition == DivLoop::Condition::Exec) rs.exec_narrowed = true;
             // Condition region [header, exit_branch): branch-free (validated), straight-line.
             if (!emit_range(L.header_pc, L.exit_branch_pc)) return false;
             // chk-end snapshots: the exit path flows THROUGH this block, so these dominate the merge.
@@ -3665,12 +3769,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             for (int r : conds) conds_val[r] = sget(r);
             const uint32_t exec_chk = rs.exec, vcc_chk = rs.vcc, scc_chk = rs.scc;
             const std::unordered_map<int, uint32_t> bool_chk = rs.sreg_bool;
-            b.emit_condbranch(rs.exec, body, merge);           // execz exit: continue while EXEC bit set
+            const uint32_t loop_cond = L.condition == DivLoop::Condition::Exec ? rs.exec : rs.vcc;
+            b.emit_condbranch(loop_cond, body, merge);         // execz/vccz exit: continue while bit set
             while (idx < ins.size() && ins[idx].pc < L.exit_branch_pc) ++idx;
             if (idx < ins.size() && ins[idx].pc == L.exit_branch_pc) ++idx;   // consume the exit branch
             b.emit_label(body);
             // Body (recursive: nested if regions + breaks); ends just before the back-edge.
             if (!emit_structured(L.exit_branch_pc + 1, L.backedge_pc, L.backedge_pc)) return false;
+            const bool body_exec_narrowed = rs.exec_narrowed;
             if (idx < ins.size() && ins[idx].pc == L.backedge_pc) ++idx;      // consume the back-edge
             b.emit_branch(cont); b.emit_label(cont);
             for (auto& pr : phis) {
@@ -3700,9 +3806,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     it = rs.sreg_bool.erase(it);
                 } else ++it;
             }
-            // Post-loop, this lane's EXEC bool is the (false) chk value until the compiled restore
-            // (`s_mov_b64 exec, <saved>`) — keep writes predicated.
-            rs.exec_narrowed = true;
+            // An execz exit leaves this lane inactive until the compiled restore. A vccz exit leaves
+            // EXEC unchanged; preserve any narrowing that existed on entry or occurred in the body.
+            rs.exec_narrowed = L.condition == DivLoop::Condition::Exec
+                ? true : (entry_exec_narrowed || body_exec_narrowed);
             return true;
         };
         emit_structured =

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -37,6 +37,15 @@ int main() {
     CHECK(recompile_valu(vcc_branch, sizeof(vcc_branch)/sizeof(vcc_branch[0]), 2, 3).empty(),
           "the production recompiler rejects the unsafe forward VCC branch");
 
+    // A VCCZ-exit loop is valid in vertex/fragment stages where one SPIR-V invocation models one
+    // hardware lane (#615), but not in the 64-lane compute shell: compute VCC needs a wave reduction.
+    const uint32_t compute_vcc_loop[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBF860004u,
+        0x060000FFu, 0x3E800000u, 0x81008100u, 0xBF82FFFAu, 0xBF810000u,
+    };
+    CHECK(recompile_valu(compute_vcc_loop, sizeof(compute_vcc_loop)/sizeof(compute_vcc_loop[0]), 0, 0).empty(),
+          "a VCCZ-exit loop remains rejected by the compute shell (wave-mask condition)");
+
     // A forward s_cbranch_execz that REJOINS LIVE CODE is only safe to linearize when its skipped block
     // is EXEC-predicated VGPR writes. Here the block is a scalar write (s_mov_b32 s0,1) and the branch
     // target is a live use of s0 (v_mov_b32 v0,s0) — the scalar write is NOT dead, so linearizing would

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -6,8 +6,10 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "render_runner.h"
 #include "spirv_triangle.h"     // kTriVertSpv: placeholder vertex shader (positions)
+#include <algorithm>
 #include <cstdio>
 #include <cstdint>
+#include <iterator>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -126,6 +128,45 @@ int main() {
                       "divergent loop: 4 iterations, nested if 2 -> (0.5, 1.0, 0.5)");
             }
         }
+    }
+
+    // VCCZ-EXIT LOOP (#615 - Dead Cells' per-pixel light accumulation shape).
+    // VCC is this fragment invocation's loop predicate: for (s0=0; s0<v1=4; ++s0) v0 += 0.25.
+    // The hardware branch exits when the wave VCC mask is empty. Here the bound is a constant moved
+    // into every lane, so VCC is provably uniform and the per-invocation branch is exact. The
+    // unconditional back-edge and carried scalar/vector values lower through OpLoopMerge + OpPhi.
+    {
+        const uint32_t ps[] = {
+            0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7E0602F2u,
+            0x7D020200u, 0xBF860004u, 0x060000FFu, 0x3E800000u,
+            0x81008100u, 0xBF82FFFAu, 0x7E020300u, 0x7E040300u,
+            0xF800080Fu, 0x03020100u, 0xBF810000u,
+        };
+        std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+        CHECK(!frg.empty(), "recompiled VCCZ-exit light-accumulation LOOP PS -> SPIR-V");
+        if (!frg.empty()) {
+            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
+            CHECK(px2.size() == (size_t)W*H*4, "rendered the VCCZ-exit loop PS");
+            if (px2.size() == (size_t)W*H*4) {
+                const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
+                printf("  vccz loop center=(%u,%u,%u,%u) expect white\n", cc[0],cc[1],cc[2],cc[3]);
+                CHECK(cc[0] > 0xF0 && cc[1] > 0xF0 && cc[2] > 0xF0,
+                      "VCCZ loop: exactly 4 iterations of 0.25 -> 1.0 white");
+            }
+        }
+
+        uint32_t varying_ps[sizeof(ps)/sizeof(ps[0])];
+        std::copy(std::begin(ps), std::end(ps), varying_ps);
+        varying_ps[2] = 0x7E020302u;  // v_mov_b32 v1,v2: a lane-varying/unproven loop bound
+        CHECK(recompile_fragment(varying_ps, sizeof(varying_ps)/sizeof(varying_ps[0])).empty(),
+              "a varying-VCC loop remains rejected (wave-empty branch is not lane-local)");
+
+        uint32_t exec_mutating_ps[sizeof(ps)/sizeof(ps[0])];
+        std::copy(std::begin(ps), std::end(ps), exec_mutating_ps);
+        exec_mutating_ps[3] = 0xBEFE04C1u;  // s_mov_b64 exec,-1 between the bound definition and compare
+        CHECK(recompile_fragment(exec_mutating_ps,
+                                 sizeof(exec_mutating_ps)/sizeof(exec_mutating_ps[0])).empty(),
+              "a VCC loop with intervening EXEC mutation remains rejected");
     }
 
     // EXECNZ-back-edge loop with a mid-body vccz BREAK (#273 — DOLL's scalar-indexed unroll shape):

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -13,6 +13,9 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map
   (find file offsets for offline disassembly).
 - **`shader_histo/`** — histogram RDNA2 opcodes across a title's shaders.
+- **`shader_inspect/`** — decode one raw `PROSPER_SHADER_DUMP` binary offline. It prints bounded
+  instruction PCs, operands, raw words, signed branch immediates, and resolved branch targets so a
+  failed shader's CFG can be mapped without hand-counting variable-length instructions.
 - **`imgdump/`** — decode/dump a guest texture to an image for inspection.
 - **`gpu_replay/`** — replay a local `PROSPER_GPU_CAPTURE` realized-submit capsule through the same
   Vulkan backend without booting the guest. Capsules include game shaders/resources, use `.prgcap`,

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -1,0 +1,17 @@
+# Shader inspect
+
+`shader_inspect` decodes one raw RDNA2 shader captured with `PROSPER_SHADER_DUMP`. It is the fast
+offline path for mapping a failed shader's control flow before changing the recompiler.
+
+```bash
+cmake --build build-linux -j8 --target shader_inspect
+./build-linux/shader_inspect /tmp/shaders/exec_ps_7f123400.bin
+```
+
+Each instruction row includes its dword PC, encoded length, format/opcode, exact raw words, decoded
+operands, and, for SOPP branches, the signed immediate and resolved target PC. The header also prints
+the stage-agnostic `recompile_coverage` result. That coverage is intentionally compute-safe; a VCC
+control-flow shape may remain listed there even when the vertex/fragment structurizer accepts it.
+
+The input is bounded to 16 MiB and decoding stops at the first `s_endpgm` or unknown instruction.
+Raw dumps contain title-derived code, are local-only, and must not be committed.

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -1,0 +1,116 @@
+// shader_inspect - print the decoded RDNA2 stream and resolved control-flow targets from a raw dump.
+#include "../../src/gpu/rdna2_decode.hpp"
+#include "../../src/gpu/rdna2_to_spirv.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+
+namespace {
+
+const char* format_name(Rdna2Format format) {
+    static const char* names[] = {
+        "SOP2", "SOP1", "SOPK", "SOPC", "SOPP", "SMEM", "VOP2", "VOP1", "VOPC",
+        "VOP3", "VINTRP", "DS", "MUBUF", "MTBUF", "MIMG", "FLAT", "EXP", "VOP3P",
+        "Unknown",
+    };
+    const size_t index = static_cast<size_t>(format);
+    return index < std::size(names) ? names[index] : "Invalid";
+}
+
+const char* operand_kind_name(OperandKind kind) {
+    static const char* names[] = {
+        "none", "sgpr", "vgpr", "inline-int", "inline-float", "literal", "special",
+    };
+    const size_t index = static_cast<size_t>(kind);
+    return index < std::size(names) ? names[index] : "invalid";
+}
+
+bool is_branch(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 && in.opcode <= 0x09 &&
+           in.opcode != 0x03;
+}
+
+void print_operand(const char* label, const Operand& operand) {
+    if (operand.kind == OperandKind::None) return;
+    std::printf(" %s=%s:%d", label, operand_kind_name(operand.kind), operand.value);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: %s <raw-rdna2.bin>\n", argv[0]);
+        return 2;
+    }
+
+    std::ifstream input(argv[1], std::ios::binary);
+    if (!input) {
+        std::fprintf(stderr, "shader_inspect: cannot open %s\n", argv[1]);
+        return 2;
+    }
+    constexpr size_t kMaxBytes = 16u << 20;
+    input.seekg(0, std::ios::end);
+    const std::streamoff input_size = input.tellg();
+    if (input_size <= 0 || input_size % sizeof(uint32_t)) {
+        std::fprintf(stderr, "shader_inspect: input must contain a non-empty whole number of dwords\n");
+        return 2;
+    }
+    if (input_size > static_cast<std::streamoff>(kMaxBytes)) {
+        std::fprintf(stderr, "shader_inspect: input exceeds the 16 MiB diagnostic bound\n");
+        return 2;
+    }
+    input.seekg(0, std::ios::beg);
+    std::vector<uint8_t> bytes(static_cast<size_t>(input_size));
+    if (!input.read(reinterpret_cast<char*>(bytes.data()), input_size)) {
+        std::fprintf(stderr, "shader_inspect: failed to read %s\n", argv[1]);
+        return 2;
+    }
+
+    std::vector<uint32_t> words(bytes.size() / sizeof(uint32_t));
+    std::memcpy(words.data(), bytes.data(), bytes.size());
+    std::vector<Rdna2Inst> instructions;
+    const size_t consumed = rdna2_walk(words.data(), words.size(), instructions);
+    const RecompileCoverage coverage = recompile_coverage(words.data(), words.size());
+    const bool ended = !instructions.empty() && instructions.back().is_end;
+    std::printf("file=%s bytes=%zu dwords=%zu consumed=%zu instructions=%zu endpgm=%d\n",
+                argv[1], bytes.size(), words.size(), consumed, instructions.size(), ended);
+    std::printf("generic-coverage total=%u alu=%u exp=%u table=%u unsupported=%u first=%s/0x%x\n",
+                coverage.total, coverage.alu, coverage.exports, coverage.table_dependent,
+                coverage.unsupported,
+                coverage.first_bad_fmt < 0 ? "none" : format_name(static_cast<Rdna2Format>(coverage.first_bad_fmt)),
+                coverage.first_bad_op);
+
+    for (const auto& in : instructions) {
+        std::printf("pc=%04u len=%u fmt=%-7s op=0x%03x words=", in.pc, in.len_dwords,
+                    format_name(in.fmt), in.opcode);
+        const uint32_t available = static_cast<uint32_t>(words.size() - in.pc);
+        const uint32_t count = std::min(in.len_dwords, available);
+        for (uint32_t i = 0; i < count; ++i)
+            std::printf("%s%08x", i ? "," : "", words[in.pc + i]);
+        print_operand("dst", in.dst);
+        for (uint32_t i = 0; i < in.n_src; ++i) {
+            char label[8];
+            std::snprintf(label, sizeof(label), "src%u", i);
+            print_operand(label, in.src[i]);
+        }
+        if (in.sdst.kind != OperandKind::None) print_operand("sdst", in.sdst);
+        if (is_branch(in)) {
+            const int64_t target = static_cast<int64_t>(in.pc) + in.len_dwords + in.simm16;
+            std::printf(" simm=%d target=%lld", in.simm16, static_cast<long long>(target));
+        } else if (in.fmt == Rdna2Format::SOPK) {
+            std::printf(" simm=%d", in.simm16);
+        }
+        if (in.is_end) std::printf(" endpgm");
+        std::printf("\n");
+    }
+
+    return ended ? 0 : 1;
+}

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -156,6 +156,12 @@ int main(int argc, char** argv) {
                             0x060404FFu,0x3E800000u,0xBEFE0404u,0x060606FFu,0x3E800000u,0x81008100u,
                             0xBF82FFF4u,0xBEFE0402u,0xF800180Fu,0x05020302u,0xBF810000u};
       dump(dir, "fragment_divergent_loop", recompile_fragment(c, sizeof(c)/4, nullptr)); }
+    // Fragment: uniform VCCZ-exit light-accumulation loop (#615, Dead Cells). The compare's VGPR
+    // bound is moved from an inline uniform value, making the wave-empty VCC branch structurizable.
+    { const uint32_t c[] = {0xBE800380u,0x7E000280u,0x7E020284u,0x7E0602F2u,0x7D020200u,
+                            0xBF860004u,0x060000FFu,0x3E800000u,0x81008100u,0xBF82FFFAu,
+                            0x7E020300u,0x7E040300u,0xF800080Fu,0x03020100u,0xBF810000u};
+      dump(dir, "fragment_uniform_vcc_loop", recompile_fragment(c, sizeof(c)/4, nullptr)); }
     // Fragment: EXECNZ-back-edge loop with a mid-body vccz break (#273 — the scalar-indexed unroll).
     { const uint32_t c[] = {0xBE82047Eu,0xBE800380u,0xBE810383u,0x7E040280u,0x7E0A02F2u,0xBF880009u,
                             0xBF0A0100u,0x8584807Eu,0xBEEA0404u,0xBEFE0404u,0xBF860004u,0x060404FFu,


### PR DESCRIPTION
## Summary

- structurize canonical fragment/vertex `s_cbranch_vccz` exit loops when the VOPC inputs have a narrowly proved wave-uniform reaching definition
- keep varying bounds, intervening EXEC mutations, CMPX producers, and compute wave-mask control flow fail-visible
- add executed fragment, negative proof-boundary, compute-rejection, and strict SPIR-V validation coverage
- add bounded `shader_inspect` output for raw RDNA2 dumps, including exact PCs, operands, words, signed branch immediates, and resolved targets
- update the Dead Cells route/status docs: the #608 exact selector is historical and needs #594 recalibration; failed-operation payload retention is tracked in #618

## Root cause

The four missing Dead Cells scene draws use one compiler shape: a scalar light counter is compared with a VGPR bound produced by an unmodified move/conversion from a scalar value, followed by a forward `s_cbranch_vccz` loop exit and an unconditional backward branch. Existing divergent-loop ownership supported EXECZ but rejected VCCZ.

A VCCZ test is wave-wide, so treating it as one SPIR-V invocation's condition is exact only when every active lane has the same compare result. This PR proves that local shape rather than accepting arbitrary VCC loops.

## Validation

- full Linux build
- CTest: 91/91
- strict `spv_validate`, including the new structured loop module
- fragment execution: four `0.25` iterations render white
- negative cases: varying bound and intervening EXEC mutation reject
- compute-shell form rejects
- final Dead Cells gameplay route: zero recompile failures; sampled submits `94/94`, `99/99`, sustained `98/98`; screenshots `distinct=2`, status `ok`; no `exec_ps_*` failure dump
- Messenger snapshot guard: 24,318 colors >= 5,000
- Dead Cells exact snapshot check can pass, but two-capture verify alternates between the two known hashes; not re-blessed, tracked in #596
- `shader_inspect` accepts the preserved 64 KiB stream and rejects a 17 MiB input before allocation

Fixes #615
Refs #594
Refs #596
Refs #618