### PR TITLE
GPU capture: retain failed operation diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The animation-sensitive exact splash guard (#573) remains separate.
 
 The current tooling frontier is deterministic offline capture rather than longer live-render windows.
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
-immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-6 `.prgcap` (#594).
+immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-7 `.prgcap` (#594).
 `gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
 full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 5 resolves those leaves against bounded
 same-run target history. Ordered `.prgbundle` windows now capture producer-time submits with content-defined
@@ -146,9 +146,13 @@ stage-specific proof: every VOPC input must be scalar/inline/literal or have a n
 definition from an unmodified uniform VOP1 move/conversion. Only then can the wave-empty VCC test lower to a
 per-invocation structured loop; varying bounds and compute remain fail-visible. `shader_inspect` decodes raw
 `PROSPER_SHADER_DUMP` files with exact dword PCs and branch targets. Current live gameplay samples realize all
-semantic draws; #618 tracks retaining the failed shader/state in future capsules.
+semantic draws. Capture v7 (#618) retains a failed stage fault-safely through `s_endpgm` or a 64 KiB cap,
+content-deduplicates it, and records exact coverage/opcode/PC, decoded pipeline/launch state, and
+resource/descriptor summaries. Start with `gpu_replay --inspect-only`; extract a raw stage with
+`--dump-failed-shader FAILURE:STAGE PATH` instead of rerunning the title.
 Do not treat `--bundle-final-capsule` as an exact DS checkpoint: it snapshots color RTT state, not live Vulkan
-depth/stencil images (#569). Capture v6 and timeline v5 remain backward-compatible with old local artifacts.
+depth/stencil images (#569). Capture v7 reads v1-v6 artifacts (failed-operation diagnostics report unavailable);
+timeline v5 remains backward-compatible with old local artifacts.
 Addresses and operation ordinals are run-local. The #608 `90 draws + 738x420 at draw 79..81` conjunction is
 also historical: a fresh 2026-07-13 route reached sustained 90-91-draw gameplay submits but did not match it.
 Recalibrate the semantic selector under #594 before a new exact capture. The Dead Cells splash guard alternates

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -36,7 +36,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   submit/present indexes can select one exact submit before renderer sampling and materialize immutable,
   content-deduplicated graphics/compute state plus mixed operation order for offline replay (#594).
   Offline dependency graphs resolve in-submit resource versions and identify deduplicated prior-submit
-  leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595).
+  leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595). Capture v7 retains
+  bounded, content-addressed raw RDNA2 and exact opcode/PC/state diagnostics for unrealized draws/dispatches;
+  `gpu_replay` can inspect and extract the failed stage without rerunning the title (#618).
 - ✅ **Dead Cells reaches gameplay reproducibly:** a deterministic input route passes the splash and menus
   into the first playable scene. The persistent-depth rejection is fixed: timeline-v5 backing hashes and
   compute writer provenance identify Unity's 32 KiB HTILE fill as the per-frame fast clear, and overlapping
@@ -46,7 +48,7 @@ possible without console keys. Dumps are user-supplied and gitignored.
   structurizer now accepts that shape only when each compare operand has a proved wave-uniform reaching
   definition; varying bounds and the compute wave-mask form still reject. Current routed gameplay submits
   realize every semantic draw (#615).
-  Version-6 GPU captures seed temporal render targets, retain complete depth-surface programming, and keep
+  Version-7 GPU captures seed temporal render targets, retain complete depth-surface programming, and keep
   content-addressed resource versions for
   faithful offline isolation (#568/#594); one residual
   live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
@@ -63,8 +65,7 @@ possible without console keys. Dumps are user-supplied and gitignored.
   The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
   failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written
   HTILE metadata instead; #611 implements that missing cache boundary. #569 still tracks exact depth/stencil
-  checkpoint serialization. #618 tracks capture-side failed-operation diagnostics so the next unsupported
-  shader can be reduced offline without another live title run. The nondeterministic exact-frame Dead Cells
+  checkpoint serialization. The nondeterministic exact-frame Dead Cells
   snapshot guard is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -50,10 +50,12 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   writer, and guest GPU writes now invalidate overlapping persistent DS cache entries (#611). A routed live A/B
   restores the layers rejected without that boundary.
   The four remaining fragment failures were uniform VCCZ-exit light loops; narrowly proved vertex/fragment
-  structurization now restores them while varying and compute-wave forms still reject (#615).
+  structurization now restores them while varying and compute-wave forms still reject (#615). Capture v7 now
+  records bounded raw stages, exact rejection opcode/PC, decoded state, and resource/descriptor summaries for
+  every observed realization failure, so the next unsupported shader can be reduced offline (#618).
 - **Immediate milestone:** refresh the now-stale Dead Cells semantic checkpoint under #594, resolve exact
-  depth/stencil checkpointing (#569), retain bounded failed-operation diagnostics in captures (#618), and replace
-  the nondeterministic animation-sensitive exact snapshot (#596/#573). Keep extending the workflow across Unity
+  depth/stencil checkpointing (#569), and replace the nondeterministic animation-sensitive exact snapshot
+  (#596/#573). Keep extending the workflow across Unity
   and Unreal targets rather than returning to long unstructured live traces.
 
 ## Historical status (2026-07-05) - retained for the milestone log

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -7,6 +7,7 @@
 #include "gpu_capture.hpp"
 
 #include "bc_decode.hpp"
+#include "rdna2_decode.hpp"
 #include "tile.hpp"
 
 #include <algorithm>
@@ -18,8 +19,11 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <limits>
 #include <map>
+#include <set>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 
@@ -32,7 +36,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 6;
+constexpr uint32_t kVersion = 7;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -42,6 +46,8 @@ constexpr uint32_t kMaxComputes = 65536;
 constexpr uint32_t kMaxOperations = 131072;
 constexpr uint32_t kMaxResources = 65536;
 constexpr uint32_t kMaxShaderWords = 16u << 20;
+constexpr uint32_t kMaxRawShaderWords = 0x4000; // 64 KiB per failed stage
+constexpr uint32_t kMaxFailureStages = 3;
 constexpr uint32_t kMaxStringBytes = 1u << 20;
 constexpr uint64_t kMaxTotalRttSeedBytes = 1ull << 30;
 
@@ -116,10 +122,16 @@ struct Reader {
         if (n > kMaxStringBytes || n > left) { if (error) *error = "invalid string length"; return false; }
         s.assign(reinterpret_cast<const char*>(p), n); p += n; left -= n; return true;
     }
-    bool words(std::vector<uint32_t>& v) {
+    bool words_bounded(std::vector<uint32_t>& v, uint32_t maximum, const char* length_error) {
         uint32_t n; if (!u32(n)) return false;
-        if (n > kMaxShaderWords || uint64_t(n) * 4 > left) { if (error) *error = "invalid word-vector length"; return false; }
+        if (n > maximum || uint64_t(n) * 4 > left) {
+            if (error) *error = length_error;
+            return false;
+        }
         v.resize(n); for (auto& x : v) if (!u32(x)) return false; return true;
+    }
+    bool words(std::vector<uint32_t>& v) {
+        return words_bounded(v, kMaxShaderWords, "invalid word-vector length");
     }
     bool bytes(std::vector<uint8_t>& v) {
         uint64_t n; if (!u64(n)) return false;
@@ -367,12 +379,223 @@ uint32_t shader_version_index(const std::vector<GpuCaptureShaderVersion>& versio
     return it == versions.end() ? 0xFFFFFFFFu : static_cast<uint32_t>(it - versions.begin());
 }
 
+using OperationIdentity = std::tuple<uint8_t, uint64_t, uint64_t>;
+
+OperationIdentity operation_identity(SubmitOperationKind kind, uint64_t source_index,
+                                     uint64_t command_order) {
+    return {static_cast<uint8_t>(kind), source_index, command_order};
+}
+
+bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& error) {
+    if (capture.raw_shader_versions.size() > kMaxResources ||
+        capture.failure_diagnostics.size() > kMaxOperations) {
+        error = "invalid failed-operation diagnostic count";
+        return false;
+    }
+    uint64_t raw_words = 0;
+    for (const auto& shader : capture.raw_shader_versions) {
+        if (shader.words.empty() || shader.words.size() > kMaxRawShaderWords ||
+            raw_words > kMaxShaderWords - shader.words.size()) {
+            error = "failed-operation raw shader data exceeds its bounded limit";
+            return false;
+        }
+        if (shader.content_hash != shader_hash(shader.words)) {
+            error = "failed-operation raw shader content hash mismatch";
+            return false;
+        }
+        raw_words += shader.words.size();
+    }
+
+    std::set<OperationIdentity> diagnosed;
+    std::vector<bool> raw_referenced(capture.raw_shader_versions.size(), false);
+    for (const auto& diagnostic : capture.failure_diagnostics) {
+        if (diagnostic.kind > SubmitOperationKind::Dispatch ||
+            diagnostic.reason <= RealizationFailureReason::None ||
+            diagnostic.reason > RealizationFailureReason::Filtered ||
+            diagnostic.stages.size() > kMaxFailureStages) {
+            error = "invalid failed-operation diagnostic metadata";
+            return false;
+        }
+        const OperationIdentity identity = operation_identity(
+            diagnostic.kind, diagnostic.source_index, diagnostic.command_order);
+        const auto operation = std::find_if(capture.operations.begin(), capture.operations.end(),
+            [&](const auto& candidate) {
+                return operation_identity(candidate.kind, candidate.source_index,
+                                          candidate.command_order) == identity;
+            });
+        if (operation == capture.operations.end() || operation->realized) {
+            error = "failed-operation diagnostic does not match an unrealized operation";
+            return false;
+        }
+        if (!diagnosed.insert(identity).second) {
+            error = "duplicate failed-operation diagnostic";
+            return false;
+        }
+        std::set<uint8_t> stage_kinds;
+        for (const auto& stage : diagnostic.stages) {
+            if (stage.stage > ShaderProgramStage::Compute ||
+                (stage.raw_shader_index != 0xFFFFFFFFu &&
+                 stage.raw_shader_index >= capture.raw_shader_versions.size()) ||
+                stage.resource_count > kMaxResources ||
+                stage.coverage.total > kMaxRawShaderWords ||
+                stage.coverage.alu > stage.coverage.total ||
+                stage.coverage.exports > stage.coverage.total ||
+                stage.coverage.table_dependent > stage.coverage.total ||
+                stage.coverage.unsupported > stage.coverage.total ||
+                (!stage.resource_table_present && stage.resource_count != 0) ||
+                (!stage.program_addr && stage.raw_shader_index != 0xFFFFFFFFu) ||
+                !stage_kinds.insert(static_cast<uint8_t>(stage.stage)).second) {
+                error = "invalid failed-stage diagnostic metadata";
+                return false;
+            }
+            if (stage.raw_shader_index != 0xFFFFFFFFu)
+                raw_referenced[stage.raw_shader_index] = true;
+            const uint32_t max_issue = static_cast<uint32_t>(DescriptorIssueCode::UnusedRuntimeBinding);
+            if ((!stage.descriptor_issue_count && stage.first_descriptor_issue != 0xFFFFFFFFu) ||
+                (stage.descriptor_issue_count && stage.first_descriptor_issue > max_issue)) {
+                error = "invalid failed-stage descriptor diagnostic";
+                return false;
+            }
+        }
+    }
+    for (const auto& operation : capture.operations) {
+        if (!operation.realized && diagnosed.count(operation_identity(
+                operation.kind, operation.source_index, operation.command_order)) == 0) {
+            error = "unrealized operation is missing its failure diagnostic";
+            return false;
+        }
+    }
+    if (std::find(raw_referenced.begin(), raw_referenced.end(), false) != raw_referenced.end()) {
+        error = "failed-operation raw shader is not referenced";
+        return false;
+    }
+    return true;
+}
+
+bool capture_failure_diagnostics(
+    const std::vector<OperationRealizationFailure>& failures,
+    const CaptureMemoryReader& reader, GpuCaptureFile& capture, std::string& error) {
+    if (failures.size() > kMaxOperations) {
+        error = "invalid failed-operation diagnostic count";
+        return false;
+    }
+    uint64_t raw_words = 0;
+    auto capture_raw_shader = [&](uint64_t addr, uint32_t& index) -> bool {
+        index = 0xFFFFFFFFu;
+        if (!addr) return true;
+        std::vector<uint32_t> words(kMaxRawShaderWords);
+        const size_t bytes_read = std::min<size_t>(
+            reader(addr, reinterpret_cast<uint8_t*>(words.data()), words.size() * sizeof(uint32_t)),
+            words.size() * sizeof(uint32_t));
+        words.resize(bytes_read / sizeof(uint32_t));
+        if (words.empty()) return true;
+        std::vector<Rdna2Inst> instructions;
+        const size_t consumed = rdna2_walk(words.data(), words.size(), instructions);
+        if (consumed && consumed < words.size()) words.resize(consumed);
+        const bool has_endpgm = !instructions.empty() && instructions.back().is_end;
+        const uint64_t hash = shader_hash(words);
+        auto existing = std::find_if(capture.raw_shader_versions.begin(),
+                                     capture.raw_shader_versions.end(), [&](const auto& candidate) {
+            return candidate.content_hash == hash && candidate.words == words;
+        });
+        if (existing != capture.raw_shader_versions.end()) {
+            index = static_cast<uint32_t>(existing - capture.raw_shader_versions.begin());
+            return true;
+        }
+        if (capture.raw_shader_versions.size() >= kMaxResources ||
+            raw_words > kMaxShaderWords - words.size()) {
+            error = "failed-operation raw shader data exceeds its bounded limit";
+            return false;
+        }
+        index = static_cast<uint32_t>(capture.raw_shader_versions.size());
+        raw_words += words.size();
+        capture.raw_shader_versions.push_back({hash, has_endpgm, std::move(words)});
+        return true;
+    };
+
+    for (const auto& failure : failures) {
+        GpuCapturedOperationFailure diagnostic;
+        diagnostic.kind = failure.kind;
+        diagnostic.source_index = failure.index;
+        diagnostic.command_order = failure.command_order;
+        diagnostic.reason = failure.reason;
+        diagnostic.pipeline_present = failure.pipeline_present;
+        diagnostic.pipeline = failure.pipeline;
+        diagnostic.color0_base = failure.color0_base;
+        diagnostic.color0_width = failure.color0_width;
+        diagnostic.color0_height = failure.color0_height;
+        diagnostic.vertex_count = failure.vertex_count;
+        diagnostic.compute_launch = failure.compute_launch;
+        for (const auto& runtime_stage : failure.stages) {
+            GpuCapturedStageDiagnostic stage;
+            stage.stage = runtime_stage.stage;
+            stage.program_addr = runtime_stage.program_addr;
+            stage.recompiled = runtime_stage.recompiled;
+            stage.resource_table_present = runtime_stage.resources != nullptr;
+            stage.resource_count = runtime_stage.resources
+                ? static_cast<uint32_t>(runtime_stage.resources->resources.size()) : 0;
+            stage.coverage = runtime_stage.coverage;
+            stage.descriptor_issue_count = runtime_stage.descriptor_issue_count;
+            stage.first_descriptor_issue = runtime_stage.first_descriptor_issue;
+            if (!capture_raw_shader(stage.program_addr, stage.raw_shader_index)) return false;
+            if (stage.raw_shader_index < capture.raw_shader_versions.size()) {
+                const auto& raw = capture.raw_shader_versions[stage.raw_shader_index].words;
+                stage.coverage = recompile_coverage(raw.data(), raw.size());
+            }
+            diagnostic.stages.push_back(std::move(stage));
+        }
+        capture.failure_diagnostics.push_back(std::move(diagnostic));
+    }
+    for (const auto& operation : capture.operations) {
+        if (operation.realized) continue;
+        const auto existing = std::find_if(capture.failure_diagnostics.begin(),
+                                           capture.failure_diagnostics.end(), [&](const auto& candidate) {
+            return operation_identity(candidate.kind, candidate.source_index,
+                                      candidate.command_order) ==
+                   operation_identity(operation.kind, operation.source_index,
+                                      operation.command_order);
+        });
+        if (existing == capture.failure_diagnostics.end()) {
+            GpuCapturedOperationFailure unknown;
+            unknown.kind = operation.kind;
+            unknown.source_index = operation.source_index;
+            unknown.command_order = operation.command_order;
+            unknown.reason = RealizationFailureReason::Unknown;
+            capture.failure_diagnostics.push_back(std::move(unknown));
+        }
+    }
+    return validate_failure_diagnostics(capture, error);
+}
+
 } // namespace
 
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
     uint64_t h = 1469598103934665603ull;
     for (size_t i = 0; i < size; ++i) { h ^= data[i]; h *= 1099511628211ull; }
     return h;
+}
+
+const char* shader_program_stage_name(ShaderProgramStage stage) {
+    switch (stage) {
+        case ShaderProgramStage::Vertex: return "vertex";
+        case ShaderProgramStage::Fragment: return "fragment";
+        case ShaderProgramStage::Compute: return "compute";
+    }
+    return "unknown";
+}
+
+const char* realization_failure_reason_name(RealizationFailureReason reason) {
+    switch (reason) {
+        case RealizationFailureReason::None: return "none";
+        case RealizationFailureReason::Unknown: return "unknown";
+        case RealizationFailureReason::MissingProgram: return "missing-program";
+        case RealizationFailureReason::ShaderRecompile: return "shader-recompile";
+        case RealizationFailureReason::DescriptorContract: return "descriptor-contract";
+        case RealizationFailureReason::NoEffect: return "no-effect";
+        case RealizationFailureReason::ZeroVertices: return "zero-vertices";
+        case RealizationFailureReason::Filtered: return "filtered";
+    }
+    return "unknown";
 }
 
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
@@ -392,8 +615,10 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           const std::vector<SubmitOperation>& operations,
                           const GpuCaptureMetadata& metadata,
                           const CaptureMemoryReader& reader, GpuCaptureFile& out,
-                          std::string& error, const CaptureRttSeedReader& rtt_reader) {
+                          std::string& error, const CaptureRttSeedReader& rtt_reader,
+                          const std::vector<OperationRealizationFailure>& failures) {
     error.clear(); out = {}; out.metadata = metadata;
+    out.failure_diagnostics_available = true;
     if (draws.size() > kMaxDraws || computes.size() > kMaxComputes ||
         operations.size() > kMaxOperations) {
         error = "capture item or operation count is invalid";
@@ -444,6 +669,7 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
             : realized_computes.count(operation.index) != 0;
         out.operations.push_back({operation.kind, operation.index, operation.command_order, realized});
     }
+    if (!capture_failure_diagnostics(failures, reader, out, error)) return false;
     collect_shader_versions(out);
     if (rtt_reader) {
         std::vector<uint64_t> candidates;
@@ -479,14 +705,17 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
                              GpuCaptureFile& out, std::string& error) {
-    std::vector<DrawItem> draws = realize_gpustate_draws(state);
-    std::vector<ComputeItem> computes = realize_compute_dispatches(state, submit_no);
+    std::vector<OperationRealizationFailure> failures, compute_failures;
+    std::vector<DrawItem> draws = realize_gpustate_draws(state, 0x10000, 1.0f, 1.0f, &failures);
+    std::vector<ComputeItem> computes = realize_compute_dispatches(state, submit_no, &compute_failures);
+    failures.insert(failures.end(), std::make_move_iterator(compute_failures.begin()),
+                    std::make_move_iterator(compute_failures.end()));
     GpuCaptureMetadata actual = metadata;
     actual.width = width;
     actual.height = height;
     actual.submit_index = submit_no;
     return capture_submit_items(draws, computes, plan_submit_operations(state), actual,
-                                read_capture_guest_memory, out, error, g_rtt_seed_reader);
+                                read_capture_guest_memory, out, error, g_rtt_seed_reader, failures);
 }
 
 bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
@@ -584,6 +813,36 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u8(static_cast<uint8_t>(operation.kind)); w.u64(operation.source_index);
         w.u64(operation.command_order); w.u8(operation.realized);
     }
+    if (!validate_failure_diagnostics(c, error)) return false;
+    w.u32(static_cast<uint32_t>(c.raw_shader_versions.size()));
+    for (const auto& shader : c.raw_shader_versions) {
+        w.u64(shader.content_hash); w.u8(shader.has_endpgm); w.words(shader.words);
+    }
+    w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
+    for (const auto& diagnostic : c.failure_diagnostics) {
+        w.u8(static_cast<uint8_t>(diagnostic.kind)); w.u64(diagnostic.source_index);
+        w.u64(diagnostic.command_order); w.u8(static_cast<uint8_t>(diagnostic.reason));
+        w.u8(diagnostic.pipeline_present);
+        if (diagnostic.pipeline_present) write_pipeline(w, diagnostic.pipeline);
+        w.u64(diagnostic.color0_base); w.u32(diagnostic.color0_width);
+        w.u32(diagnostic.color0_height); w.u32(diagnostic.vertex_count);
+        const auto& launch = diagnostic.compute_launch;
+        w.u32(launch.threads_x); w.u32(launch.threads_y); w.u32(launch.threads_z);
+        w.u32(launch.local_x); w.u32(launch.local_y); w.u32(launch.local_z);
+        w.u32(launch.groups_x); w.u32(launch.groups_y); w.u32(launch.groups_z);
+        w.u32(static_cast<uint32_t>(diagnostic.stages.size()));
+        for (const auto& stage : diagnostic.stages) {
+            w.u8(static_cast<uint8_t>(stage.stage)); w.u64(stage.program_addr);
+            w.u32(stage.raw_shader_index); w.u8(stage.recompiled);
+            w.u8(stage.resource_table_present); w.u32(stage.resource_count);
+            w.u32(stage.coverage.total); w.u32(stage.coverage.alu);
+            w.u32(stage.coverage.exports); w.u32(stage.coverage.unsupported);
+            w.u32(stage.coverage.table_dependent);
+            w.u32(static_cast<uint32_t>(stage.coverage.first_bad_fmt));
+            w.u32(stage.coverage.first_bad_op); w.u32(stage.coverage.first_bad_pc);
+            w.u32(stage.descriptor_issue_count); w.u32(stage.first_descriptor_issue);
+        }
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -617,8 +876,15 @@ bool read_gpu_capture(const std::string& path, GpuCaptureFile& c, std::string& e
 bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& c, std::string& error) {
     error.clear(); c = {};
     Reader r{bytes.data(), bytes.size(), &error}; char magic[8]; uint32_t version, endian;
-    if (!r.take(magic, 8) || std::memcmp(magic, kMagic, 8) || !r.u32(version) || version < 1 || version > kVersion ||
-        !r.u32(endian) || endian != kEndian) { error = "unsupported capture header"; return false; }
+    if (!r.take(magic, 8)) { error = "truncated capture header"; return false; }
+    if (std::memcmp(magic, kMagic, 8)) { error = "invalid capture magic"; return false; }
+    if (!r.u32(version)) { error = "truncated capture version"; return false; }
+    if (version < 1 || version > kVersion) {
+        error = "unsupported capture version " + std::to_string(version);
+        return false;
+    }
+    if (!r.u32(endian)) { error = "truncated capture byte-order marker"; return false; }
+    if (endian != kEndian) { error = "unsupported capture byte order"; return false; }
     auto& m = c.metadata;
     if (!r.u32(m.width) || !r.u32(m.height) || !r.u64(m.submit_index) || !r.string(m.revision) ||
         !r.string(m.title_id) || !r.string(m.input_route) || !r.string(m.savedata_dir)) return false;
@@ -718,12 +984,87 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             c.operations.push_back({SubmitOperationKind::Draw, i, c.draws[i].command_order, true});
         }
     }
+    if (version >= 7) {
+        c.failure_diagnostics_available = true;
+        uint32_t raw_count = 0;
+        if (!r.u32(raw_count) || raw_count > kMaxResources) {
+            error = "invalid failed-operation raw shader count";
+            return false;
+        }
+        c.raw_shader_versions.resize(raw_count);
+        uint64_t raw_words = 0;
+        for (auto& shader : c.raw_shader_versions) {
+            uint8_t has_endpgm = 0;
+            if (!r.u64(shader.content_hash) || !r.u8(has_endpgm) ||
+                !r.words_bounded(shader.words, kMaxRawShaderWords,
+                                 "invalid failed-operation raw shader length")) return false;
+            shader.has_endpgm = has_endpgm != 0;
+            if (shader.words.empty() || raw_words > kMaxShaderWords - shader.words.size()) {
+                error = "failed-operation raw shader data exceeds its bounded limit";
+                return false;
+            }
+            raw_words += shader.words.size();
+        }
+        uint32_t diagnostic_count = 0;
+        if (!r.u32(diagnostic_count) || diagnostic_count > kMaxOperations) {
+            error = "invalid failed-operation diagnostic count";
+            return false;
+        }
+        c.failure_diagnostics.resize(diagnostic_count);
+        for (auto& diagnostic : c.failure_diagnostics) {
+            uint8_t kind = 0, reason = 0, pipeline_present = 0;
+            if (!r.u8(kind) || kind > static_cast<uint8_t>(SubmitOperationKind::Dispatch) ||
+                !r.u64(diagnostic.source_index) || !r.u64(diagnostic.command_order) ||
+                !r.u8(reason) || reason <= static_cast<uint8_t>(RealizationFailureReason::None) ||
+                reason > static_cast<uint8_t>(RealizationFailureReason::Filtered) ||
+                !r.u8(pipeline_present)) {
+                error = "invalid failed-operation diagnostic metadata";
+                return false;
+            }
+            diagnostic.kind = static_cast<SubmitOperationKind>(kind);
+            diagnostic.reason = static_cast<RealizationFailureReason>(reason);
+            diagnostic.pipeline_present = pipeline_present != 0;
+            if (diagnostic.pipeline_present && !read_pipeline(r, diagnostic.pipeline, version)) return false;
+            if (!r.u64(diagnostic.color0_base) || !r.u32(diagnostic.color0_width) ||
+                !r.u32(diagnostic.color0_height) || !r.u32(diagnostic.vertex_count)) return false;
+            auto& launch = diagnostic.compute_launch;
+            if (!r.u32(launch.threads_x) || !r.u32(launch.threads_y) || !r.u32(launch.threads_z) ||
+                !r.u32(launch.local_x) || !r.u32(launch.local_y) || !r.u32(launch.local_z) ||
+                !r.u32(launch.groups_x) || !r.u32(launch.groups_y) || !r.u32(launch.groups_z)) return false;
+            uint32_t stage_count = 0;
+            if (!r.u32(stage_count) || stage_count > kMaxFailureStages) {
+                error = "invalid failed-stage diagnostic count";
+                return false;
+            }
+            diagnostic.stages.resize(stage_count);
+            for (auto& stage : diagnostic.stages) {
+                uint8_t stage_kind = 0, recompiled = 0, table_present = 0;
+                uint32_t first_bad_fmt = 0;
+                if (!r.u8(stage_kind) || stage_kind > static_cast<uint8_t>(ShaderProgramStage::Compute) ||
+                    !r.u64(stage.program_addr) || !r.u32(stage.raw_shader_index) ||
+                    !r.u8(recompiled) || !r.u8(table_present) || !r.u32(stage.resource_count) ||
+                    !r.u32(stage.coverage.total) || !r.u32(stage.coverage.alu) ||
+                    !r.u32(stage.coverage.exports) || !r.u32(stage.coverage.unsupported) ||
+                    !r.u32(stage.coverage.table_dependent) || !r.u32(first_bad_fmt) ||
+                    !r.u32(stage.coverage.first_bad_op) || !r.u32(stage.coverage.first_bad_pc) ||
+                    !r.u32(stage.descriptor_issue_count) || !r.u32(stage.first_descriptor_issue)) return false;
+                stage.stage = static_cast<ShaderProgramStage>(stage_kind);
+                stage.recompiled = recompiled != 0;
+                stage.resource_table_present = table_present != 0;
+                stage.coverage.first_bad_fmt = static_cast<int32_t>(first_bad_fmt);
+            }
+        }
+        if (!validate_failure_diagnostics(c, error)) return false;
+    }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
 }
 
 bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::string& error) {
     error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs; out.rtt_seeds = c.rtt_seeds;
+    out.raw_shader_versions = c.raw_shader_versions;
+    out.failure_diagnostics = c.failure_diagnostics;
+    out.failure_diagnostics_available = c.failure_diagnostics_available;
     out.expected_output_valid = c.expected_output_valid;
     out.expected_output_hash = c.expected_output_hash; out.expected_output_bytes = c.expected_output_bytes;
     size_t resource_reference_count = 0;

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -35,6 +35,14 @@ struct GpuCaptureShaderVersion {
     std::vector<uint32_t> words;
 };
 
+// Raw RDNA2 retained only for failed operations. Each version is capped at 64 KiB and ends at the
+// first decoded s_endpgm/unknown instruction or that cap. Equal byte streams share one version.
+struct GpuCaptureRawShaderVersion {
+    uint64_t content_hash = 0;
+    bool has_endpgm = false;
+    std::vector<uint32_t> words;
+};
+
 struct GpuCapturedResource {
     ShaderResource resource;
     uint32_t blob_index = 0xFFFFFFFFu;
@@ -77,6 +85,33 @@ struct GpuCapturedOperation {
     bool realized = false;
 };
 
+struct GpuCapturedStageDiagnostic {
+    ShaderProgramStage stage = ShaderProgramStage::Vertex;
+    uint64_t program_addr = 0;
+    uint32_t raw_shader_index = 0xFFFFFFFFu;
+    bool recompiled = false;
+    bool resource_table_present = false;
+    uint32_t resource_count = 0;
+    RecompileCoverage coverage;
+    uint32_t descriptor_issue_count = 0;
+    uint32_t first_descriptor_issue = 0xFFFFFFFFu;
+};
+
+struct GpuCapturedOperationFailure {
+    SubmitOperationKind kind = SubmitOperationKind::Draw;
+    uint64_t source_index = 0;
+    uint64_t command_order = 0;
+    RealizationFailureReason reason = RealizationFailureReason::None;
+    bool pipeline_present = false;
+    ResolvedPipelineState pipeline;
+    uint64_t color0_base = 0;
+    uint32_t color0_width = 0;
+    uint32_t color0_height = 0;
+    uint32_t vertex_count = 0;
+    ComputeLaunchDimensions compute_launch;
+    std::vector<GpuCapturedStageDiagnostic> stages;
+};
+
 // Host-rendered pixels retained across submits. The HLE renderer does not write these pixels back to
 // guest memory, so a standalone replay must seed its RTT cache explicitly to reproduce consumers whose
 // producer was in an earlier submit.
@@ -91,10 +126,13 @@ struct GpuCaptureFile {
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
     std::vector<GpuCaptureShaderVersion> shader_versions;
+    std::vector<GpuCaptureRawShaderVersion> raw_shader_versions;
     std::vector<GpuCaptureRttSeed> rtt_seeds;
     std::vector<GpuCapturedDraw> draws;
     std::vector<GpuCapturedCompute> computes;
     std::vector<GpuCapturedOperation> operations;
+    std::vector<GpuCapturedOperationFailure> failure_diagnostics;
+    bool failure_diagnostics_available = false;
     bool expected_output_valid = false;
     uint64_t expected_output_hash = 0;
     uint64_t expected_output_bytes = 0;
@@ -115,7 +153,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           const std::vector<SubmitOperation>& operations,
                           const GpuCaptureMetadata& metadata,
                           const CaptureMemoryReader& reader, GpuCaptureFile& out,
-                          std::string& error, const CaptureRttSeedReader& rtt_reader = {});
+                          std::string& error, const CaptureRttSeedReader& rtt_reader = {},
+                          const std::vector<OperationRealizationFailure>& failures = {});
 bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
@@ -145,6 +184,9 @@ struct GpuReplayFrame {
     std::vector<DrawItem> items;
     std::vector<ComputeItem> computes;
     std::vector<GpuCapturedOperation> operations;
+    std::vector<GpuCaptureRawShaderVersion> raw_shader_versions;
+    std::vector<GpuCapturedOperationFailure> failure_diagnostics;
+    bool failure_diagnostics_available = false;
     bool expected_output_valid = false;
     uint64_t expected_output_hash = 0;
     uint64_t expected_output_bytes = 0;
@@ -166,6 +208,8 @@ uint64_t gpu_capture_hash(const uint8_t* data, size_t size);
 inline uint64_t gpu_capture_hash(const std::vector<uint8_t>& data) {
     return gpu_capture_hash(data.data(), data.size());
 }
+const char* shader_program_stage_name(ShaderProgramStage stage);
+const char* realization_failure_reason_name(RealizationFailureReason reason);
 
 // Runtime hook used by execute_and_present. PROSPER_GPU_CAPTURE=<path> captures exactly one realized
 // submit. MIN_DRAWS/MAX_DRAWS select a semantic candidate class; PROSPER_GPU_CAPTURE_AT=N then selects

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -164,9 +164,11 @@ GpuCaptureFile make_capture_manifest(const GpuCaptureFile& capture) {
     manifest.expected_output_valid = capture.expected_output_valid;
     manifest.rtt_seeds = capture.rtt_seeds;
     manifest.shader_versions = capture.shader_versions;
+    manifest.raw_shader_versions = capture.raw_shader_versions;
     manifest.draws = capture.draws;
     manifest.computes = capture.computes;
     manifest.operations = capture.operations;
+    manifest.failure_diagnostics = capture.failure_diagnostics;
     manifest.blobs.resize(capture.blobs.size());
     const uint64_t empty_hash = gpu_capture_hash(nullptr, 0);
     for (size_t i = 0; i < capture.blobs.size(); ++i) {

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -13,6 +13,7 @@
 #include "rdna2_to_spirv.hpp"      // recompile_vertex / recompile_fragment
 #include "shader_resources.hpp"    // ShaderResourceTable
 #include "agc_shader_layout.hpp"   // DecodedBufferDescriptor (DynFetch)
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdio>
@@ -148,6 +149,52 @@ struct ComputeItem {
     uint64_t command_order = 0;
 };
 
+enum class SubmitOperationKind : uint8_t { Draw, Dispatch };
+struct SubmitOperation {
+    SubmitOperationKind kind = SubmitOperationKind::Draw;
+    size_t index = 0;
+    uint64_t command_order = 0;
+};
+
+enum class ShaderProgramStage : uint8_t { Vertex, Fragment, Compute };
+enum class RealizationFailureReason : uint8_t {
+    None,
+    Unknown,
+    MissingProgram,
+    ShaderRecompile,
+    DescriptorContract,
+    NoEffect,
+    ZeroVertices,
+    Filtered,
+};
+
+// Capture-facing facts collected at the exact point an operation is dropped. These contain no raw
+// shader bytes; gpu_capture reads those through its fault-safe, size-bounded memory reader.
+struct ShaderRealizationDiagnostic {
+    ShaderProgramStage stage = ShaderProgramStage::Vertex;
+    uint64_t program_addr = 0;
+    std::shared_ptr<ShaderResourceTable> resources;
+    RecompileCoverage coverage;
+    bool recompiled = false;
+    uint32_t descriptor_issue_count = 0;
+    uint32_t first_descriptor_issue = 0xFFFFFFFFu;
+};
+
+struct OperationRealizationFailure {
+    SubmitOperationKind kind = SubmitOperationKind::Draw;
+    size_t index = 0;
+    uint64_t command_order = 0;
+    RealizationFailureReason reason = RealizationFailureReason::None;
+    bool pipeline_present = false;
+    ResolvedPipelineState pipeline;
+    uint64_t color0_base = 0;
+    uint32_t color0_width = 0;
+    uint32_t color0_height = 0;
+    uint32_t vertex_count = 0;
+    ComputeLaunchDimensions compute_launch;
+    std::vector<ShaderRealizationDiagnostic> stages;
+};
+
 using LiveComputeFn = std::function<bool(const std::vector<ComputeItem>& items)>;
 
 // Guest GPU writes can change backing memory represented by a persistent host-side image. Backends
@@ -162,15 +209,9 @@ void notify_guest_gpu_write(uint64_t addr, uint64_t size);
 void set_submit_compute(LiveComputeFn fn);
 bool have_submit_compute();
 std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st,
-                                                     uint64_t submit_no = 0);
+                                                     uint64_t submit_no = 0,
+                                                     std::vector<OperationRealizationFailure>* failures = nullptr);
 bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no = 0);
-
-enum class SubmitOperationKind : uint8_t { Draw, Dispatch };
-struct SubmitOperation {
-    SubmitOperationKind kind = SubmitOperationKind::Draw;
-    size_t index = 0;
-    uint64_t command_order = 0;
-};
 std::vector<SubmitOperation> plan_submit_operations(const GpuState& st);
 
 // PROSPER_PROVENANCE_DIM=WxH: inspect sampled images of that size and report overlapping
@@ -226,9 +267,49 @@ inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_
 // the draw is a no-op (no PGM bound, recompile failed, or no color/depth/stencil effect). Shared by the default
 // (folded-state, one item) and PROSPER_PERDRAW (per-draw) paths so their per-draw handling is identical.
 inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, uint32_t vcount_hint,
-                              uint32_t max_shader_dwords, bool log, DrawItem& out) {
+                              uint32_t max_shader_dwords, bool log, DrawItem& out,
+                              OperationRealizationFailure* failure = nullptr) {
     RenderState rs = extract_render_state(ds);
+    if (failure) {
+        *failure = {};
+        failure->kind = SubmitOperationKind::Draw;
+        failure->pipeline_present = true;
+        failure->pipeline = resolve_pipeline_state(rs);
+        failure->color0_base = rs.color0_base;
+        failure->color0_width = rs.color0_width;
+        failure->color0_height = rs.color0_height;
+        failure->vertex_count = vcount_hint;
+    }
+    auto add_stage_diagnostic = [&](ShaderProgramStage stage, uint64_t addr,
+                                    const std::shared_ptr<ShaderResourceTable>& resources,
+                                    const std::vector<uint32_t>& spirv) {
+        if (!failure) return;
+        ShaderRealizationDiagnostic diagnostic;
+        diagnostic.stage = stage;
+        diagnostic.program_addr = addr;
+        diagnostic.resources = resources;
+        diagnostic.recompiled = !spirv.empty();
+        if (!spirv.empty()) {
+            const uint32_t expected_set = stage == ShaderProgramStage::Vertex ? 0u : 1u;
+            const SpirvShaderStage expected_stage = stage == ShaderProgramStage::Vertex
+                ? SpirvShaderStage::Vertex : SpirvShaderStage::Fragment;
+            const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+                spirv, resources.get(), expected_set, expected_stage, true);
+            diagnostic.descriptor_issue_count = static_cast<uint32_t>(report.issues.size());
+            auto issue = std::find_if(report.issues.begin(), report.issues.end(),
+                                      [](const auto& candidate) { return candidate.error; });
+            if (issue == report.issues.end() && !report.issues.empty()) issue = report.issues.begin();
+            if (issue != report.issues.end())
+                diagnostic.first_descriptor_issue = static_cast<uint32_t>(issue->code);
+        }
+        failure->stages.push_back(std::move(diagnostic));
+    };
     if (!rs.es_addr || !rs.ps_addr) {
+        if (failure) {
+            failure->reason = RealizationFailureReason::MissingProgram;
+            add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, {}, {});
+            add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, {}, {});
+        }
         if (log) fprintf(stderr, "[exec] skip draw: no PGM bound (es=0x%llx ps=0x%llx)\n",
                          (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
         return false;
@@ -251,6 +332,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     std::vector<uint32_t> vs = recompile_vertex((const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());
     std::vector<uint32_t> fs = recompile_fragment((const uint32_t*)(uintptr_t)rs.ps_addr, max_shader_dwords, prt.get());
+    add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, vrt, vs);
+    add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, prt, fs);
     if (const char* dd = getenv("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection
         static int nd = 0;
         if (nd < 3 && !vs.empty()) {
@@ -266,6 +349,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
     }
     if (vs.empty() || fs.empty()) {
+        if (failure) failure->reason = RealizationFailureReason::ShaderRecompile;
         // PROSPER_DYNTRACE_FAIL=1: replay the FAILED vertex stage's resource build with the
         // dynamic-fetch walk trace + user-data block dump forced on (once per distinct VS), so the
         // failing draw's exact seeding/s_load chain is captured without knowing its address up front.
@@ -323,6 +407,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     if (!validate_runtime_descriptor_contract("VS", vs, vrt.get(), 0, SpirvShaderStage::Vertex) ||
         !validate_runtime_descriptor_contract("PS", fs, prt.get(), 1, SpirvShaderStage::Fragment)) {
+        if (failure) failure->reason = RealizationFailureReason::DescriptorContract;
         if (log) fprintf(stderr, "[exec] skip draw: strict descriptor contract failed "
                                 "(es=0x%llx ps=0x%llx color0=0x%llx)\n",
                          (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
@@ -336,6 +421,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // be produced (#520). Skip only when the draw has no observable color OR depth/stencil effect.
     const bool ds_effect = has_depth_stencil_side_effect(ps);
     if (ps.color_write_mask == 0 && !ds_effect && !getenv("PROSPER_FORCE_COLORWRITE")) {
+        if (failure) failure->reason = RealizationFailureReason::NoEffect;
         if (log) fprintf(stderr, "[exec] skip draw: no color/depth/stencil effect cb_target_mask=0x%x cb_color_control=0x%x color0_fmt=%u\n",
                          rs.cb_target_mask, rs.cb_color_control, ps.color0_format);
         return false;
@@ -446,6 +532,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // full-VB draw of stale geometry composited into the frame (#400). The vb_entries "truer count"
     // override exists to correct a LOW/stale count, never to synthesize one for a zero-count draw.
     if (vcount_hint == 0 && out.indices.empty()) {
+        if (failure) failure->reason = RealizationFailureReason::ZeroVertices;
         if (log) fprintf(stderr, "[exec] skip draw: zero vertex count (no-op draw)\n");
         return false;
     }
@@ -477,13 +564,19 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         bool sa = false;
         if (prt) for (const auto& r : prt->resources)
             if (r.cls == ResourceClass::Texture && r.width == 2048 && r.height == 1024) sa = true;
-        if (!sa) return false;
+        if (!sa) {
+            if (failure) failure->reason = RealizationFailureReason::Filtered;
+            return false;
+        }
         // PROSPER_ONLY_IC=<n>: further restrict to draws whose index count == n (isolate one atlas mesh,
         // e.g. the main glyph batch idx=1566 vs a fullscreen atlas draw).
         if (const char* ic_s = getenv("PROSPER_ONLY_IC")) {
             uint32_t want = (uint32_t)atoi(ic_s);
             uint32_t ic = (draw && draw->indexed) ? draw->index_count : vcount_hint;
-            if (ic != want) return false;
+            if (ic != want) {
+                if (failure) failure->reason = RealizationFailureReason::Filtered;
+                return false;
+            }
         }
     }
     if (getenv("PROSPER_CAPTION_DIAG") && prt) {
@@ -562,7 +655,9 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
 inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
                                                     uint32_t max_shader_dwords = 0x10000,
                                                     float vp_scale_x = 1.0f,
-                                                    float vp_scale_y = 1.0f) {
+                                                    float vp_scale_y = 1.0f,
+                                                    std::vector<OperationRealizationFailure>* failures = nullptr) {
+    if (failures) failures->clear();
     if (st.draws.empty()) return {};
     // PROSPER_EXECLOG: just the per-draw bail-point/skip logs, without PROSPER_GFXLOG's per-packet
     // firehose (which is GBs over a minutes-long run) — for "which draws skip and why" surveys (#319).
@@ -583,21 +678,47 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
     if (perdraw) {
         for (size_t i = 0; i < st.draws.size(); i++) {
             DrawItem it;
+            OperationRealizationFailure failure;
             if (realize_draw_item(st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
-                                  max_shader_dwords, log, it)) {
+                                  max_shader_dwords, log, it, failures ? &failure : nullptr)) {
                 it.draw_index = i;
                 it.command_order = st.draws[i].command_order;
                 items.push_back(std::move(it));
+            } else if (failures) {
+                failure.index = i;
+                failure.command_order = st.draws[i].command_order;
+                failures->push_back(std::move(failure));
             }
         }
     } else {
+        // A forced folded capture still needs an explanation for every earlier semantic draw that
+        // the execution policy omits. Diagnose those draws without adding them to the realized list.
+        if (failures && st.draws.size() > 1) {
+            for (size_t i = 0; i + 1 < st.draws.size(); ++i) {
+                DrawItem ignored;
+                OperationRealizationFailure failure;
+                const bool would_realize = realize_draw_item(
+                    st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
+                    max_shader_dwords, log, ignored, &failure);
+                if (would_realize) failure.reason = RealizationFailureReason::Filtered;
+                failure.index = i;
+                failure.command_order = st.draws[i].command_order;
+                failures->push_back(std::move(failure));
+            }
+        }
         // Default: render the submit's last draw from the folded end state as a single item.
         DrawItem it;
         const GpuState::Draw& last = st.draws.back();
-        if (realize_draw_item(st, &last, last.index_count, max_shader_dwords, log, it)) {
+        OperationRealizationFailure failure;
+        if (realize_draw_item(st, &last, last.index_count, max_shader_dwords, log, it,
+                              failures ? &failure : nullptr)) {
             it.draw_index = st.draws.size() - 1;
             it.command_order = last.command_order;
             items.push_back(std::move(it));
+        } else if (failures) {
+            failure.index = st.draws.size() - 1;
+            failure.command_order = last.command_order;
+            failures->push_back(std::move(failure));
         }
     }
     if (getenv("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu perdraw=%d -> %zu item(s): raw index_counts=[",

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -873,7 +873,10 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     return out;
 }
 
-std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st, uint64_t submit_no) {
+std::vector<ComputeItem> realize_compute_dispatches(
+    const GpuState& st, uint64_t submit_no,
+    std::vector<OperationRealizationFailure>* failures) {
+    if (failures) failures->clear();
     if (st.dispatches.empty()) return {};
     namespace P = prosper::agc::Pm4;
     auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
@@ -888,9 +891,42 @@ std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st, uint64_t
         const GpuState& ds = dispatch.state ? *dispatch.state : st;
         const uint64_t code_addr = (static_cast<uint64_t>(rd(ds.sh, P::COMPUTE_PGM_LO)) << 8) |
                                    (static_cast<uint64_t>(rd(ds.sh, P::COMPUTE_PGM_HI) & 0xffu) << 40);
+        OperationRealizationFailure failure;
+        failure.kind = SubmitOperationKind::Dispatch;
+        failure.index = dispatch_index;
+        failure.command_order = dispatch.command_order;
+        failure.compute_launch = resolve_compute_launch(dispatch);
+        auto record_failure = [&](RealizationFailureReason reason,
+                                  const std::shared_ptr<ShaderResourceTable>& resources,
+                                  const std::vector<uint32_t>& spirv) {
+            if (!failures) return;
+            failure.reason = reason;
+            ShaderRealizationDiagnostic stage;
+            stage.stage = ShaderProgramStage::Compute;
+            stage.program_addr = code_addr;
+            stage.resources = resources;
+            stage.recompiled = !spirv.empty();
+            if (!spirv.empty()) {
+                const DescriptorValidationReport diagnostic_report =
+                    validate_spirv_descriptor_interface(spirv, resources.get(), 0,
+                                                        SpirvShaderStage::Compute, true);
+                stage.descriptor_issue_count =
+                    static_cast<uint32_t>(diagnostic_report.issues.size());
+                auto issue = std::find_if(diagnostic_report.issues.begin(),
+                                          diagnostic_report.issues.end(),
+                                          [](const auto& candidate) { return candidate.error; });
+                if (issue == diagnostic_report.issues.end() && !diagnostic_report.issues.empty())
+                    issue = diagnostic_report.issues.begin();
+                if (issue != diagnostic_report.issues.end())
+                    stage.first_descriptor_issue = static_cast<uint32_t>(issue->code);
+            }
+            failure.stages.push_back(std::move(stage));
+            failures->push_back(std::move(failure));
+        };
         const auto* header = static_cast<const AgcShaderHeader*>(
             prosper_agc_shader_header_for_code(code_addr));
         if (!header || !code_addr || !guest_readable(code_addr, sizeof(uint32_t))) {
+            record_failure(RealizationFailureReason::MissingProgram, {}, {});
             static std::set<uint64_t> logged;
             if (logged.insert(code_addr).second)
                 std::fprintf(stderr, "[compute] skip unregistered/unreadable program 0x%llx\n",
@@ -944,6 +980,7 @@ std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st, uint64_t
         item.submit_no = submit_no;
         item.command_order = dispatch.command_order;
         if (item.spirv.empty()) {
+            record_failure(RealizationFailureReason::ShaderRecompile, item.resources, item.spirv);
             // PROSPER_DYNTRACE_FAIL=1: replay the FAILED compute program's resource build with the
             // const-fold walk trace + user-data dump forced on (once per distinct program) — the
             // compute analog of the graphics VS/PS fail-replay (gpu_execute.hpp). Compute dispatches
@@ -984,6 +1021,7 @@ std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st, uint64_t
         const DescriptorValidationReport report = validate_spirv_descriptor_interface(
             item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
         if (!report.ok()) {
+            record_failure(RealizationFailureReason::DescriptorContract, item.resources, item.spirv);
             static std::set<uint64_t> logged;
             if (logged.insert(code_addr).second)
                 std::fprintf(stderr, "[compute] skip invalid descriptor contract for program 0x%llx\n",

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4075,7 +4075,11 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
         else if (table_dependent(in)) { cov.table_dependent++; }
         else {
             cov.unsupported++;
-            if (cov.first_bad_fmt < 0) { cov.first_bad_fmt = (int)in.fmt; cov.first_bad_op = in.opcode; }
+            if (cov.first_bad_fmt < 0) {
+                cov.first_bad_fmt = (int)in.fmt;
+                cov.first_bad_op = in.opcode;
+                cov.first_bad_pc = in.pc;
+            }
         }
     }
     return cov;

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -72,6 +72,7 @@ struct RecompileCoverage {
     uint32_t table_dependent = 0;
     int      first_bad_fmt = -1;   // Rdna2Format of the first TRULY-unsupported instruction (-1 if none)
     uint32_t first_bad_op  = 0;
+    uint32_t first_bad_pc  = 0xFFFFFFFFu; // dword offset of that instruction (-1 if none)
 };
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords);
 

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1,4 +1,5 @@
 #include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/pm4_registers.hpp"
 
 #include <cstdio>
 #include <cstring>
@@ -6,6 +7,24 @@
 #include <fstream>
 
 using namespace prosper::gpu;
+namespace P = prosper::agc::Pm4;
+
+alignas(256) static const uint32_t kDiagnosticVs[] = {
+    0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u, 0x7E0C02F2u,
+    0x10020B01u, 0x08020D01u, 0x10040B02u, 0x08040D02u, 0x7E060280u, 0x7E0802F2u,
+    0xF80008CFu, 0x04030201u, 0xBF810000u,
+};
+// Forward VCCZ branch is deliberately not invocation-safe and must remain fail-visible.
+alignas(256) static const uint32_t kDiagnosticBadPs[] = {
+    0x7da80300u, 0xbf860001u, 0x4a060300u, 0xBF810000u,
+};
+
+static void set_pgm(GpuState& state, uint32_t lo_register, uint32_t hi_register,
+                    const void* program) {
+    const uint64_t addr = reinterpret_cast<uint64_t>(program);
+    state.sh[lo_register] = static_cast<uint32_t>(addr >> 8);
+    state.sh[hi_register] = static_cast<uint32_t>((addr >> 40) & 0xffu);
+}
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
@@ -152,6 +171,9 @@ int main() {
     CHECK(mixed.operations.size() == 3 && mixed.operations[0].realized &&
           mixed.operations[1].realized && !mixed.operations[2].realized,
           "mixed operation plan explicitly retains unrealized work");
+    CHECK(mixed.failure_diagnostics_available && mixed.failure_diagnostics.size() == 1 &&
+          mixed.failure_diagnostics[0].reason == RealizationFailureReason::Unknown,
+          "pre-realized capture inputs label an unexplained omission explicitly");
     const auto mixed_path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_mixed_test.prgcap";
     CHECK(write_gpu_capture(mixed_path.string(), mixed, error), "mixed versioned capture writes");
     GpuCaptureFile mixed_loaded;
@@ -172,6 +194,90 @@ int main() {
     mixed_compute_bytes[0] ^= 0xff;
     CHECK(mixed_draw_bytes[0] == repeated[0],
           "compute copy-on-write cannot create a false alias between equal resource versions");
+
+    GpuState failed_state;
+    set_pgm(failed_state, P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, kDiagnosticVs);
+    set_pgm(failed_state, P::SPI_SHADER_PGM_LO_PS, P::SPI_SHADER_PGM_HI_PS, kDiagnosticBadPs);
+    failed_state.uc[P::VGT_PRIMITIVE_TYPE] = 4;
+    failed_state.cx[P::CB_TARGET_MASK] = 0xf;
+    failed_state.cx[P::CB_COLOR0_BASE] = 0x1234;
+    failed_state.draws.push_back({3});
+    failed_state.draws.back().command_order = 777;
+    GpuCaptureFile failed_capture;
+    CHECK(capture_gpustate_submit(failed_state, 99, 640, 360, meta, failed_capture, error),
+          "actual realization path captures a deliberately failed synthetic draw");
+    CHECK(failed_capture.draws.empty() && failed_capture.operations.size() == 1 &&
+          !failed_capture.operations[0].realized && failed_capture.failure_diagnostics_available &&
+          failed_capture.failure_diagnostics.size() == 1,
+          "unrealized operation retains one explicit v7 failure diagnostic");
+    const auto& failed = failed_capture.failure_diagnostics[0];
+    const auto failed_stage = std::find_if(failed.stages.begin(), failed.stages.end(), [](const auto& stage) {
+        return stage.stage == ShaderProgramStage::Fragment;
+    });
+    CHECK(failed.reason == RealizationFailureReason::ShaderRecompile && failed.pipeline_present &&
+          failed.pipeline.color_write_mask == 0xf && failed.vertex_count == 3 &&
+          failed_stage != failed.stages.end(),
+          "diagnostic distinguishes shader rejection and retains decoded draw state");
+    CHECK(failed_stage != failed.stages.end() && !failed_stage->recompiled &&
+          failed_stage->coverage.unsupported == 1 && failed_stage->coverage.first_bad_pc == 1 &&
+          failed_stage->coverage.first_bad_op == 0x06,
+          "failed fragment stage retains the exact rejection opcode and dword PC");
+    const GpuCaptureRawShaderVersion* failed_raw =
+        failed_stage != failed.stages.end() &&
+        failed_stage->raw_shader_index < failed_capture.raw_shader_versions.size()
+            ? &failed_capture.raw_shader_versions[failed_stage->raw_shader_index] : nullptr;
+    CHECK(failed_raw && failed_raw->has_endpgm &&
+          failed_raw->words == std::vector<uint32_t>(std::begin(kDiagnosticBadPs), std::end(kDiagnosticBadPs)) &&
+          failed_raw->content_hash == gpu_capture_hash(
+              reinterpret_cast<const uint8_t*>(kDiagnosticBadPs), sizeof(kDiagnosticBadPs)),
+          "failed stage retains the exact content-addressed raw stream through s_endpgm");
+
+    const auto failed_path = std::filesystem::temp_directory_path() /
+        "prosper_gpu_capture_failed_diagnostic_test.prgcap";
+    CHECK(write_gpu_capture(failed_path.string(), failed_capture, error),
+          "failed-operation diagnostic capture writes");
+    GpuCaptureFile failed_loaded;
+    CHECK(read_gpu_capture(failed_path.string(), failed_loaded, error) &&
+          failed_loaded.failure_diagnostics_available && failed_loaded.failure_diagnostics.size() == 1 &&
+          failed_loaded.raw_shader_versions.size() == failed_capture.raw_shader_versions.size() &&
+          failed_loaded.failure_diagnostics[0].stages[1].coverage.first_bad_pc == 1,
+          "failed stage state, coverage, and raw shader versions round-trip offline");
+
+    GpuCaptureFile stale_raw = failed_capture;
+    stale_raw.raw_shader_versions[0].content_hash ^= 1;
+    CHECK(!serialize_gpu_capture(stale_raw, repeated, error) &&
+          error == "failed-operation raw shader content hash mismatch",
+          "writer rejects stale failed-shader content identity");
+    GpuCaptureFile bad_raw_index = failed_capture;
+    bad_raw_index.failure_diagnostics[0].stages[0].raw_shader_index = 0xfffffffeu;
+    CHECK(!serialize_gpu_capture(bad_raw_index, repeated, error) &&
+          error == "invalid failed-stage diagnostic metadata",
+          "writer rejects an out-of-range failed-shader reference");
+    GpuCaptureFile oversized_raw = failed_capture;
+    oversized_raw.raw_shader_versions[0].words.resize(0x4001, 0xbf810000u);
+    oversized_raw.raw_shader_versions[0].content_hash = gpu_capture_hash(
+        reinterpret_cast<const uint8_t*>(oversized_raw.raw_shader_versions[0].words.data()),
+        oversized_raw.raw_shader_versions[0].words.size() * sizeof(uint32_t));
+    CHECK(!serialize_gpu_capture(oversized_raw, repeated, error) &&
+          error == "failed-operation raw shader data exceeds its bounded limit",
+          "writer enforces the documented 64 KiB per-stage raw bound");
+
+    std::vector<uint8_t> legacy_bytes;
+    CHECK(serialize_gpu_capture(captured, legacy_bytes, error) && legacy_bytes.size() >= 20,
+          "created a diagnostic-free v7 payload for the legacy-reader fixture");
+    if (legacy_bytes.size() >= 20) {
+        legacy_bytes[8] = 6; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
+        legacy_bytes.resize(legacy_bytes.size() - 8); // remove v7 raw-shader/diagnostic zero counts
+    }
+    GpuCaptureFile legacy_loaded;
+    CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
+          !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
+          "v6 capture reopens with failed-operation diagnostics reported unavailable");
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 8;
+    CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
+          error == "unsupported capture version 8",
+          "future capture versions fail with a concrete version error");
+
     GpuCaptureFile bad_hash = mixed;
     bad_hash.blobs[0].content_hash ^= 1;
     CHECK(!write_gpu_capture(mixed_path.string(), bad_hash, error) &&
@@ -215,6 +321,7 @@ int main() {
     GpuCaptureFile bad;
     CHECK(!read_gpu_capture(truncated.string(), bad, error) && !error.empty(), "truncated capture fails loudly");
     std::filesystem::remove(path); std::filesystem::remove(truncated); std::filesystem::remove(mixed_path);
+    std::filesystem::remove(failed_path);
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -32,6 +32,30 @@ int main() {
     }
     blob.content_hash = gpu_capture_hash(blob.bytes);
     first.blobs.push_back(blob);
+    first.operations.push_back({SubmitOperationKind::Draw, 5, 900, false});
+    GpuCaptureRawShaderVersion failed_shader;
+    failed_shader.words = {0xbf860001u, 0xbf810000u};
+    failed_shader.has_endpgm = true;
+    failed_shader.content_hash = gpu_capture_hash(
+        reinterpret_cast<const uint8_t*>(failed_shader.words.data()), failed_shader.words.size() * 4);
+    first.raw_shader_versions.push_back(failed_shader);
+    GpuCapturedOperationFailure failed_operation;
+    failed_operation.kind = SubmitOperationKind::Draw;
+    failed_operation.source_index = 5;
+    failed_operation.command_order = 900;
+    failed_operation.reason = RealizationFailureReason::ShaderRecompile;
+    GpuCapturedStageDiagnostic failed_stage;
+    failed_stage.stage = ShaderProgramStage::Fragment;
+    failed_stage.program_addr = 0x400000;
+    failed_stage.raw_shader_index = 0;
+    failed_stage.coverage.total = 1;
+    failed_stage.coverage.unsupported = 1;
+    failed_stage.coverage.first_bad_fmt = 2;
+    failed_stage.coverage.first_bad_op = 6;
+    failed_stage.coverage.first_bad_pc = 0;
+    failed_operation.stages.push_back(failed_stage);
+    first.failure_diagnostics.push_back(failed_operation);
+    first.failure_diagnostics_available = true;
     GpuCaptureFile second = first;
     second.metadata.submit_index = 42;
     second.metadata.input_route = "shift-the-serialized-blob-boundary";
@@ -82,7 +106,9 @@ int main() {
     CHECK(materialize_gpu_capture_bundle_submit(loaded, 0, restored_first, error) &&
           materialize_gpu_capture_bundle_submit(loaded, 1, restored_second, error) &&
           restored_second.metadata.submit_index == 42 && restored_second.blobs.size() == 1 &&
-          restored_second.blobs[0].guest_addr == 0x200000 && restored_second.blobs[0].bytes == blob.bytes,
+          restored_second.blobs[0].guest_addr == 0x200000 && restored_second.blobs[0].bytes == blob.bytes &&
+          restored_second.failure_diagnostics_available && restored_second.failure_diagnostics.size() == 1 &&
+          restored_second.raw_shader_versions[0].words == failed_shader.words,
           "bundle reconstructs an exact validated capture");
     CHECK(materialize_gpu_capture_bundle_manifest(loaded, 1, second_manifest, error) &&
           second_manifest.metadata.submit_index == 42 && second_manifest.blobs.size() == 1 &&

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -32,8 +32,9 @@ int main() {
     // the skipped block even when VCC says to branch, so the recompiler must reject it for now.
     const uint32_t vcc_branch[] = { 0x7da80300u, 0xbf860001u, 0x4a060300u, 0xBF810000u };
     RecompileCoverage c = recompile_coverage(vcc_branch, sizeof(vcc_branch)/sizeof(vcc_branch[0]));
-    CHECK(c.unsupported == 1 && c.first_bad_fmt >= 0 && c.first_bad_op == 0x06,
-          "a forward s_cbranch_vccz is rejected instead of linearized as a no-op");
+    CHECK(c.unsupported == 1 && c.first_bad_fmt >= 0 && c.first_bad_op == 0x06 &&
+          c.first_bad_pc == 1,
+          "a forward s_cbranch_vccz reports its exact rejection PC instead of becoming a no-op");
     CHECK(recompile_valu(vcc_branch, sizeof(vcc_branch)/sizeof(vcc_branch[0]), 2, 3).empty(),
           "the production recompiler rejects the unsafe forward VCC branch");
 

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -76,8 +76,10 @@ VideoOut flip. `gpu_timeline <path> [--records]` inspects the checksummed index 
 independent of `PROSPER_RENDER_EVERY`. To materialize one exact indexed submit without rendering the
 warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
-version-6 capsules deduplicate content-addressed shader/resource versions, retain complete raw depth-surface
-programming, and preserve mixed draw/dispatch order plus explicit unrealized operations. Selection is
+version-7 capsules deduplicate content-addressed shader/resource versions, retain complete raw depth-surface
+programming, and preserve mixed draw/dispatch order plus explicit unrealized operations. Failed operations
+also retain bounded raw stages and exact rejection/state summaries; inspect them with `gpu_replay --inspect-only`
+and extract one with `--dump-failed-shader FAILURE:STAGE PATH`. Selection is
 intentionally bounded to the consumer and an optional
 immediate predecessor. Explicit-depth `.prgbundle` capture provides bounded recursive cross-submit closure;
 automatic present-to-producer selection remains #595.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -62,7 +62,23 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute-resource 0:2 /tmp/storage.bin /tmp/submit.prgcap
+./build-linux/gpu_replay --dump-failed-shader 0:1 /tmp/failed-fragment.bin /tmp/submit.prgcap
 ```
+
+### Failed operations
+
+Capture v7 retains bounded diagnostics for draws and dispatches that semantic PM4 ordering contains but the
+executor cannot realize. `--inspect-only` prints the failure reason, decoded target/pipeline or compute-launch
+state, every referenced stage address, resource-table presence/count, descriptor issues, recompile coverage,
+and the first rejected opcode/format at its exact dword PC. It also prints the raw RDNA2 content hash, byte
+count, and whether the retained stream reached `s_endpgm`.
+
+`--dump-failed-shader FAILURE:STAGE PATH` writes that raw stream for `shader_inspect` or a focused recompiler
+fixture. Both indices are the zero-based values printed by `--inspect-only`; they are not draw indices. Each raw
+stage is fault-safely read once, content-deduplicated, capped at 64 KiB, and stopped at the first decoded
+`s_endpgm`/unknown instruction or the cap. Total failed-stage data is capped at 64 MiB, diagnostics cannot
+outnumber semantic operations, and every reference/hash is validated while reading. Captures v1-v6 remain
+readable and print `failure-diagnostics: unavailable (capture predates v7)` rather than inventing evidence.
 
 Compute selectors use the realized compute index printed by `--inspect-only`. The resource selector is
 `COMPUTE:BINDING`; it writes the captured pre-dispatch storage-buffer bytes, while `--dump-compute` writes
@@ -87,7 +103,7 @@ restored. The tool rejects a predecessor whose submit number is not earlier. A c
 consumer sampled the retained producer output, but it does not prove faithful closure: graph the predecessor
 and continue if it also has temporal leaves.
 
-`--bundle` reconstructs each captured submit through the normal version-6 validator, executes them in
+`--bundle` reconstructs each captured submit through the normal version-7 validator, executes them in
 ascending order through one renderer instance, and releases each materialized submit before the next.
 The summary reports logical versus unique bytes, per-submit output hashes, and every temporal image leaf:
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -41,6 +41,7 @@ void usage(const char* argv0) {
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
+                         "[--dump-failed-shader FAILURE:STAGE PATH] "
                          "[--dump-compute-resource N:BINDING PATH] "
                          "[--legacy-htile-before-stencil] "
                          "<capture.prgcap> [output.bmp]\n", argv0);
@@ -259,6 +260,66 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     static_cast<unsigned long long>(operation.source_index),
                     static_cast<unsigned long long>(operation.command_order),
                     operation.realized ? "yes" : "no");
+    }
+    if (!replay.failure_diagnostics_available) {
+        std::printf("failure-diagnostics: unavailable (capture predates v7)\n");
+    } else if (replay.failure_diagnostics.empty()) {
+        std::printf("failure-diagnostics: none\n");
+    }
+    for (size_t i = 0; i < replay.failure_diagnostics.size(); ++i) {
+        const auto& failure = replay.failure_diagnostics[i];
+        std::printf("failure[%zu] %s source=%llu order=%llu reason=%s stages=%zu\n", i,
+                    failure.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                    static_cast<unsigned long long>(failure.source_index),
+                    static_cast<unsigned long long>(failure.command_order),
+                    prosper::gpu::realization_failure_reason_name(failure.reason),
+                    failure.stages.size());
+        if (failure.kind == prosper::gpu::SubmitOperationKind::Draw) {
+            std::printf("  target=%016llx extent=%ux%u vertices=%u pipeline=%s",
+                        static_cast<unsigned long long>(failure.color0_base),
+                        failure.color0_width, failure.color0_height, failure.vertex_count,
+                        failure.pipeline_present ? "yes" : "no");
+            if (failure.pipeline_present)
+                std::printf(" fmt=%u cwm=%x depth=%d/%d/%u stencil=%d blend=%d",
+                            failure.pipeline.color0_format, failure.pipeline.color_write_mask,
+                            failure.pipeline.depth_test_enable, failure.pipeline.depth_write_enable,
+                            failure.pipeline.depth_compare_op, failure.pipeline.stencil_enable,
+                            failure.pipeline.blend_enable);
+            std::printf("\n");
+        } else {
+            const auto& launch = failure.compute_launch;
+            std::printf("  threads=%ux%ux%u local=%ux%ux%u groups=%ux%ux%u\n",
+                        launch.threads_x, launch.threads_y, launch.threads_z,
+                        launch.local_x, launch.local_y, launch.local_z,
+                        launch.groups_x, launch.groups_y, launch.groups_z);
+        }
+        for (const auto& stage : failure.stages) {
+            const prosper::gpu::GpuCaptureRawShaderVersion* raw = nullptr;
+            if (stage.raw_shader_index < replay.raw_shader_versions.size())
+                raw = &replay.raw_shader_versions[stage.raw_shader_index];
+            std::printf("  %s program=%016llx raw=%s",
+                        prosper::gpu::shader_program_stage_name(stage.stage),
+                        static_cast<unsigned long long>(stage.program_addr), raw ? "yes" : "no");
+            if (raw)
+                std::printf(" words=%zu bytes=%zu hash=%016llx endpgm=%s",
+                            raw->words.size(), raw->words.size() * sizeof(uint32_t),
+                            static_cast<unsigned long long>(raw->content_hash),
+                            raw->has_endpgm ? "yes" : "no");
+            std::printf(" recompiled=%s resources=%s/%u descriptors=%u",
+                        stage.recompiled ? "yes" : "no",
+                        stage.resource_table_present ? "present" : "absent",
+                        stage.resource_count, stage.descriptor_issue_count);
+            if (stage.first_descriptor_issue != 0xFFFFFFFFu)
+                std::printf(" first-descriptor=%s", prosper::gpu::descriptor_issue_name(
+                    static_cast<prosper::gpu::DescriptorIssueCode>(stage.first_descriptor_issue)));
+            std::printf("\n    coverage total=%u alu=%u exports=%u table-dependent=%u unsupported=%u",
+                        stage.coverage.total, stage.coverage.alu, stage.coverage.exports,
+                        stage.coverage.table_dependent, stage.coverage.unsupported);
+            if (stage.coverage.first_bad_fmt >= 0)
+                std::printf(" first-reject pc=%u fmt=%d op=0x%x", stage.coverage.first_bad_pc,
+                            stage.coverage.first_bad_fmt, stage.coverage.first_bad_op);
+            std::printf("\n");
+        }
     }
 }
 
@@ -865,6 +926,7 @@ int main(int argc, char** argv) {
     std::string dump_spec, dump_path, shader_spec, shader_path;
     std::string compute_shader_spec, compute_shader_path;
     std::string compute_resource_spec, compute_resource_path;
+    std::string failed_shader_spec, failed_shader_path;
     std::string graph_json_path, prepend_path;
     std::string bundle_path, bundle_compact_path;
     std::string bundle_final_capsule_path;
@@ -938,6 +1000,9 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-compute-resource" && i + 2 < argc) {
             compute_resource_spec = argv[++i]; compute_resource_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--dump-failed-shader" && i + 2 < argc) {
+            failed_shader_spec = argv[++i]; failed_shader_path = argv[++i];
+        }
         else positional.push_back(argv[i]);
     }
     if (legacy_htile_before_stencil)
@@ -947,7 +1012,7 @@ int main(int argc, char** argv) {
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
             draw_first >= 0 || through_operation >= 0 || !dump_spec.empty() ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
-            !compute_resource_spec.empty() || !prepend_path.empty()) {
+            !compute_resource_spec.empty() || !failed_shader_spec.empty() || !prepend_path.empty()) {
             usage(argv[0]); return 2;
         }
         return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
@@ -1045,6 +1110,42 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[gpureplay] dumped %s (%zu bytes) to %s\n", shader_spec.c_str(), bytes,
                      shader_path.c_str());
     }
+    if (!failed_shader_spec.empty()) {
+        const size_t colon = failed_shader_spec.find(':');
+        char* failure_end = nullptr;
+        const long failure_index = std::strtol(failed_shader_spec.c_str(), &failure_end, 0);
+        char* stage_end = nullptr;
+        const long stage_index = colon == std::string::npos ? -1 :
+            std::strtol(failed_shader_spec.c_str() + colon + 1, &stage_end, 0);
+        if (colon == std::string::npos || failure_end != failed_shader_spec.c_str() + colon ||
+            !stage_end || *stage_end || failure_index < 0 || stage_index < 0 ||
+            static_cast<size_t>(failure_index) >= replay.failure_diagnostics.size() ||
+            static_cast<size_t>(stage_index) >=
+                replay.failure_diagnostics[static_cast<size_t>(failure_index)].stages.size()) {
+            std::fprintf(stderr, "gpu_replay: invalid failed-shader selector %s\n",
+                         failed_shader_spec.c_str());
+            return 2;
+        }
+        const auto& stage = replay.failure_diagnostics[static_cast<size_t>(failure_index)]
+                                .stages[static_cast<size_t>(stage_index)];
+        if (stage.raw_shader_index >= replay.raw_shader_versions.size()) {
+            std::fprintf(stderr, "gpu_replay: failed shader %s has no captured raw stream\n",
+                         failed_shader_spec.c_str());
+            return 2;
+        }
+        const auto& words = replay.raw_shader_versions[stage.raw_shader_index].words;
+        FILE* f = std::fopen(failed_shader_path.c_str(), "wb");
+        const size_t bytes = words.size() * sizeof(uint32_t);
+        if (!f || std::fwrite(words.data(), 1, bytes, f) != bytes) {
+            if (f) std::fclose(f);
+            std::fprintf(stderr, "gpu_replay: cannot write %s\n", failed_shader_path.c_str());
+            return 2;
+        }
+        std::fclose(f);
+        std::fprintf(stderr, "[gpureplay] dumped failed shader %s (%zu bytes) to %s\n",
+                     failed_shader_spec.c_str(), bytes, failed_shader_path.c_str());
+        if (positional.size() == 1 && !inspect) return 0;
+    }
     if (!compute_shader_spec.empty()) {
         char* end = nullptr;
         const long index = std::strtol(compute_shader_spec.c_str(), &end, 0);
@@ -1124,10 +1225,12 @@ int main(int argc, char** argv) {
     }
     const auto& m = replay.metadata;
     std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu computes=%zu "
-                         "operations=%zu shaders=%zu blobs=%zu RTT-seeds=%zu oracle=%s\n",
+                         "operations=%zu shaders=%zu failed=%zu raw-failed-shaders=%zu blobs=%zu "
+                         "RTT-seeds=%zu oracle=%s\n",
                  m.revision.c_str(), m.title_id.c_str(), static_cast<unsigned long long>(m.submit_index),
                  m.width, m.height, replay.items.size(), replay.computes.size(), replay.operations.size(),
-                 capture.shader_versions.size(), replay.blobs.size(), replay.rtt_seeds.size(),
+                 capture.shader_versions.size(), replay.failure_diagnostics.size(),
+                 replay.raw_shader_versions.size(), replay.blobs.size(), replay.rtt_seeds.size(),
                  replay.expected_output_valid ? "yes" : "no");
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -107,11 +107,12 @@ latest same-run writer identity for every temporal image leaf in the selected ca
 the consumer submit/operation/range, the in-submit future writer, and either the matched prior graphics
 submit/draw/PM4 order/target extent or an explicit unresolved result.
 
-Version 2 added exactly one bounded detailed submit per run. The linked version-6 `.prgcap` contains
+Version 2 added exactly one bounded detailed submit per run. The linked version-7 `.prgcap` contains
 content-hashed/deduplicated shaders and resource
 bytes, graphics and compute items, complete raw depth-surface programming, and the original mixed PM4 operation
 order. An operation whose shader
-cannot be realized stays in the manifest with `realized=no`; inspection never silently treats a partial
+cannot be realized stays in the manifest with `realized=no`; capture v7 also retains its bounded raw shader,
+stage coverage, first rejected opcode/PC, decoded state, and failure reason. Inspection never silently treats a partial
 submit as complete. A timeline-selected capsule has no live-output hash oracle unless the renderer also
 produced one; replay reports `oracle=no` and renders without pretending an expected pixel hash exists.
 


### PR DESCRIPTION
## Summary
- append backward-readable `.prgcap` v7 diagnostics for every unrealized draw/dispatch
- retain bounded, content-addressed raw RDNA2 plus exact failure reason, opcode/PC coverage, decoded state, and resource/descriptor summaries
- inspect and extract failed stages offline with `gpu_replay`, including through bundle manifests
- update the capture/replay documentation and current project status

## Format and safety
- 64 KiB maximum per failed stage; 64 MiB total raw failed-stage data
- fault-safe capture reads, `s_endpgm`/unknown termination, hash and reference validation
- explicit operation/stage/count bounds and concrete version/truncation errors
- v1-v6 capsules remain readable and report diagnostics unavailable
- synthetic fixtures only; no title bytes or local capsules committed

## Verification
- synthetic `GpuState -> failed realization -> capture -> reopen` reports fragment `s_cbranch_vccz` at dword PC 1, opcode `0x6`, hash `219a49824aa3a22e`, and a 16-byte stream through `s_endpgm`
- `gpu_replay --dump-failed-shader 0:1` reproduces `7da80300 bf860001 4a060300 bf810000`
- bundle diagnostic round-trip, stale hash, invalid reference, oversize, truncation, future-version, and v6 compatibility coverage
- full Linux build succeeds
- `ctest --output-on-failure`: 91/91 passed

Fixes #618
Refs #594
Refs #615