### PR TITLE
tools: stabilize Dead Cells splash guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ opening vignette/level geometry; #586 established a practical late checkpoint wi
 residual seeded replay mismatch (#569) exposed persistent depth/stencil state outside color RTT seeds. The
 faithful closure reuses one 642x362 depth identity, but timeline-v5 backing provenance proves compute fills its
 HTILE allocation before drawing; #611 now invalidates the detached Vulkan DS cache on that guest GPU write.
-The animation-sensitive exact splash guard (#573) remains separate.
+The Dead Cells splash regression guard is now a run-level content check: after a three-second renderer warmup,
+the richest frame in a 20-second window must contain at least 1,500 distinct colors. This replaces the historical
+animation-sensitive exact-frame contract from #573/#596.
 
 The current tooling frontier is deterministic offline capture rather than longer live-render windows.
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
@@ -155,9 +157,9 @@ depth/stencil images (#569). Capture v7 reads v1-v6 artifacts (failed-operation 
 timeline v5 remains backward-compatible with old local artifacts.
 Addresses and operation ordinals are run-local. The #608 `90 draws + 738x420 at draw 79..81` conjunction is
 also historical: a fresh 2026-07-13 route reached sustained 90-91-draw gameplay submits but did not match it.
-Recalibrate the semantic selector under #594 before a new exact capture. The Dead Cells splash guard alternates
-between hashes `8429fedd427b...` and `891a80fc9178...` on one unchanged build; replace that nondeterministic
-exact-frame contract under #596 rather than silently choosing or re-blessing either hash.
+Recalibrate the semantic selector under #594 before a new exact capture. The Dead Cells splash guard deliberately
+uses `min_colors=1500` rather than an exact hash: unchanged builds select multiple valid animation states with
+1,650-1,698 distinct colors, while observed partial transitions contain only about 325-339.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with
 submit/item/PM4 ordinals.
 `PROSPER_RESOURCE_HASH_DIM=WxH` correlates raw and sampled hashes with those writers at each live draw;

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -65,8 +65,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
   failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written
   HTILE metadata instead; #611 implements that missing cache boundary. #569 still tracks exact depth/stencil
-  checkpoint serialization. The nondeterministic exact-frame Dead Cells
-  snapshot guard is tracked separately in #596. UE4's measured GPU boundary remains under its area issues.
+  checkpoint serialization. The Dead Cells splash guard now checks the richest frame in its startup window against
+  a measured content threshold, avoiding its nondeterministic animation frame. UE4's measured GPU boundary remains
+  under its area issues.
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
 [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -53,10 +53,10 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   structurization now restores them while varying and compute-wave forms still reject (#615). Capture v7 now
   records bounded raw stages, exact rejection opcode/PC, decoded state, and resource/descriptor summaries for
   every observed realization failure, so the next unsupported shader can be reduced offline (#618).
-- **Immediate milestone:** refresh the now-stale Dead Cells semantic checkpoint under #594, resolve exact
-  depth/stencil checkpointing (#569), and replace the nondeterministic animation-sensitive exact snapshot
-  (#596/#573). Keep extending the workflow across Unity
-  and Unreal targets rather than returning to long unstructured live traces.
+- **Immediate milestone:** refresh the now-stale Dead Cells semantic checkpoint under #594 and resolve exact
+  depth/stencil checkpointing (#569). Keep extending the workflow across Unity and Unreal targets rather than
+  returning to long unstructured live traces. The Dead Cells splash regression guard now uses a measured run-level
+  content threshold instead of the historical animation-sensitive exact frame (#596/#573).
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -4,10 +4,9 @@ Real-game rendering regression guard. Run this whenever a change can affect
 rendered output: RDNA2-to-SPIR-V recompilation, AGC/PM4 decoding, render state,
 texture detiling, or executor/present behavior.
 
-The Messenger guard records the richest frame's distinct-color count across the
-boot. The Dead Cells guard uses an exact first-frame hash after a wall-clock
-renderer warmup. Together they exercise both supported guard modes across two
-titles.
+The Messenger and Dead Cells guards record the richest frame's distinct-color
+count across their configured windows. Both titles have threaded/timing-sensitive
+boots whose exact rendered frame is not a stable contract.
 
 ## Run It
 
@@ -36,7 +35,11 @@ python3 -c 'from PIL import Image; Image.open("x.bmp").save("x.png")'
 
 - `min_colors`: run the full configured timeout, inspect every dumped frame,
   and require the richest frame to meet the threshold. `messenger-scene` uses
-  this because exact frame hashes are not stable across threaded boots.
+  this because exact frame hashes are not stable across threaded boots. The
+  Dead Cells splash uses the same mode because one unchanged build selects
+  multiple valid static/animated splash hashes after its renderer warmup. Use
+  `verify <name>` to require two full runs to meet the threshold at equal
+  dimensions.
 - `frame` plus `hash`: target one draw-submit frame. Use `verify <name>` before
   trusting a new exact baseline, then `update <name>` after an intentional pixel
   change.

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -22,8 +22,8 @@ On failure, `check` writes the screenshot and boot log to
 ## Guard Modes
 
 - `min_colors`: run for the configured timeout and require the richest rendered
-  frame to reach a distinct-color threshold. The current `messenger-scene`
-  guard uses this mode and tolerates frame timing variance.
+  frame to reach a distinct-color threshold. `verify <name>` repeats the full
+  capture and requires both runs to meet the threshold at the same dimensions.
 - `frame` plus `hash`: compare one targeted draw-submit frame exactly. Run
   `verify <name>` before establishing its baseline with `update <name>`.
 
@@ -31,9 +31,11 @@ On failure, `check` writes the screenshot and boot log to
 
 - `messenger-scene`: run-level content guard because the threaded boot does not
   choose a stable exact frame.
-- `dead-cells-splash`: exact first frame after a three-second renderer warmup.
-  The warmup advances the submit-heavy startup without synchronous llvmpipe
-  rendering; repeated captures are pixel-identical at 960x540.
+- `dead-cells-splash`: run-level content guard after a three-second renderer
+  warmup. The warmup advances the submit-heavy startup without synchronous
+  llvmpipe rendering; the richest startup frame must contain at least 1,500
+  colors. Exact hashes are intentionally not used because an unchanged build
+  selects multiple valid splash animation states at 960x540.
 
 ## Adding A Snapshot
 

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Golden-image snapshot tester for prosper's game rendering.
+"""Local snapshot tester for prosper's game rendering.
 
-Runs a game through boot_trace, captures an EXACT rendered frame, hashes its
-pixels, and compares against a stored baseline. On a mismatch it saves the
-offending screenshot and exits non-zero — snapshot testing for the renderer, so
+Runs a game through boot_trace and checks either an exact rendered-frame hash or
+a run-level content threshold. On a mismatch it saves the offending screenshot
+and exits non-zero — snapshot testing for the renderer, so
 any agent can catch a rendering regression (e.g. a recompiler change that blanks
 a title) before it ships.
 
@@ -21,10 +21,11 @@ Env overrides:
   PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: /mnt/c/Users/matti/repos/ps5ys)
   PROSPER_BOOT_TRACE  path to the boot_trace binary    (default: <prosper>/build-linux/boot_trace)
 
-A frame is targeted by RENDER_EVERY=1 (render every draw submit) + `frame`=F, so
-frame_<F>.bmp is the F-th draw submit's render. Pick F in a STABLE-content window
-(a static title/menu loop renders the same composite every submit → same hash);
-use `verify` to confirm F is deterministic before trusting a baseline.
+Exact mode targets a frame with RENDER_EVERY=1 plus `frame`=F, so frame_<F>.bmp
+is the F-th draw submit's render. Pick F in a stable-content window and use
+`verify` before trusting a baseline. Content mode uses `min_colors` and checks the
+richest frame over the complete configured window when threaded timing makes no
+single frame a stable contract.
 """
 import sys, os, json, time, hashlib, struct, subprocess, tempfile, shutil, signal
 
@@ -325,6 +326,17 @@ def cmd_verify(m, names):
     rc = 0
     for s in select(m, names):
         try:
+            if s.get("min_colors"):
+                threshold = int(s["min_colors"])
+                b1, n1, dims1, t1 = capture_richest(s); _cleanup(t1)
+                b2, n2, dims2, t2 = capture_richest(s); _cleanup(t2)
+                ok = n1 >= threshold and n2 >= threshold and dims1 == dims2
+                print(f"[verify] {s['name']}: {'CONTENT-STABLE' if ok else 'UNSTABLE'} "
+                      f"({n1} vs {n2} colors, min={threshold}, "
+                      f"dims={dims1[0]}x{dims1[1]}/{dims2[0]}x{dims2[1]})")
+                if not ok:
+                    rc = 1
+                continue
             b1, t1 = capture(s); h1, _ = pixel_hash(b1); _cleanup(t1)
             b2, t2 = capture(s); h2, _ = pixel_hash(b2); _cleanup(t2)
             ok = h1 == h2

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -14,15 +14,11 @@
       "dump": "PPSA15552-app0",
       "scale": 4,
       "timeout": 20,
-      "frame": 0,
       "env": {
         "PROSPER_RENDER_DELAY_MS": "3000"
       },
-      "hash": "8429fedd427b63d9330e6dc2357699a3d22fd1c0a7b664f873c83955cb8420d0",
-      "dims": [
-        960,
-        540
-      ]
+      "min_colors": 1500,
+      "_note": "Run-level splash content guard. Frame 0 after the 3-second render delay is timing-dependent: unchanged builds select multiple valid static/animated states (including hashes 8429fedd..., 891a80fc..., and a9e41a6b...). Preserved failures and three fresh runs show valid rich states at 1650-1698 distinct colors, while later transition frames are only about 325-339. Requiring the richest startup frame to reach 1500 accepts all observed valid splash phases without blessing one animation frame, while still rejecting partial transitions and clear-only rendering."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the timing-dependent Dead Cells exact splash hash with a measured run-level content guard
- teach `snapshot.py verify` to validate content guards across two complete captures and equal dimensions
- update the snapshot guide, agent notes, README, CLAUDE.md, and roadmap to describe the current contract

## Evidence
On one unchanged build, valid splash states selected several hashes and contained 1,650-1,698 distinct colors. Observed transition frames contained only about 325-339 colors. The new threshold is 1,500 after the existing 3-second renderer warmup and over the existing 20-second window.

## Validation
- `python3 tools/snapshot/snapshot.py verify dead-cells-splash` (1,662 vs 1,698 colors, content-stable)
- `python3 tools/snapshot/snapshot.py check` (Messenger 24,318/5,000; Dead Cells 1,672/1,500)
- `cmake --build . -j8`
- `ctest --output-on-failure` (91/91 passed)
- `python3 -m py_compile tools/snapshot/snapshot.py`
- `git diff --check`

Fixes #596