### PR TITLE
tools: add stable gameplay timeline selectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,9 @@ The current tooling frontier is deterministic offline capture rather than longer
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
 immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-7 `.prgcap` (#594).
 `gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
-full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 5 resolves those leaves against bounded
-same-run target history. Ordered `.prgbundle` windows now capture producer-time submits with content-defined
+full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 6 retains the version-5 bounded same-run
+target/depth history and adds compact per-draw target spans for offline scene selection. Ordered `.prgbundle`
+windows now capture producer-time submits with content-defined
 cross-submit deduplication and replay them through one persistent renderer (#603). Dead Cells depth 16 resolves
 all 30 internal temporal edges in submits 18735..18750 while storing 2.883 GiB logical data in 166.3 MiB, but
 the earliest submit still has two unseeded 642x362 leaves. Full-run aggregation places their first observed
@@ -129,10 +130,11 @@ Bundle v2 (#606) now uses fault-safe bulk guest reads plus an exact shared-resou
 1,200-submit full-state run folded 122.97 GiB into 301.1 MiB in 169.4 seconds. Semantic endpoints, rolling
 windows, successful-only exit, final compaction, and `gpu_replay --bundle-tail` prevent timing drift and replay
 holes. A compact two-submit closure resolves both 642x362 edges with no bounded leaves, but its 80-draw endpoint
-is the opening vignette rather than gameplay. #608 now identifies the controllable Jump tutorial without a
-submit ordinal: require exactly 90 semantic draws and the 738x420 target at semantic draw index 79..81. Target
-extent or total draw count alone also selects cinematic/transition frames and must not be used as the oracle.
-Use this checkpoint to isolate the first bad composition.
+is the opening vignette rather than gameplay. The preserved #608 playable bundle used exactly 90 semantic draws
+and the 738x420 target at draw 79..81. Current routes use 91..93 draws, exactly 8 dispatches, and the 738x420
+target at draw 80..82; two independent timelines selected only sustained gameplay from about 29.5 seconds onward.
+Target extent or total draw count alone also selects cinematic/transition frames and must not be used as the
+oracle. Use this checkpoint to isolate the first bad composition.
 The faithful playable bundle spans submits 18,165..19,047, stores 158.94 GiB logical state in 739 MiB, resolves
 all 1,764 temporal image dependencies, and renders hash `5759c125812154dc`. A fresh-depth final replay instead
 renders `71b84bdfae53933c`; `gpu_replay --bundle-find-ds ADDR` scans manifest-only DS use in seconds and proves
@@ -154,10 +156,9 @@ resource/descriptor summaries. Start with `gpu_replay --inspect-only`; extract a
 `--dump-failed-shader FAILURE:STAGE PATH` instead of rerunning the title.
 Do not treat `--bundle-final-capsule` as an exact DS checkpoint: it snapshots color RTT state, not live Vulkan
 depth/stencil images (#569). Capture v7 reads v1-v6 artifacts (failed-operation diagnostics report unavailable);
-timeline v5 remains backward-compatible with old local artifacts.
-Addresses and operation ordinals are run-local. The #608 `90 draws + 738x420 at draw 79..81` conjunction is
-also historical: a fresh 2026-07-13 route reached sustained 90-91-draw gameplay submits but did not match it.
-Recalibrate the semantic selector under #594 before a new exact capture. The Dead Cells splash guard deliberately
+timeline v6 reads timeline v1-v5 artifacts. Addresses and operation ordinals are run-local. Use
+`gpu_timeline FILE --signatures DRAWS DISPATCHES` to discover target spans and `--select` to validate the exact
+live-capture predicate before recording another detailed bundle. The Dead Cells splash guard deliberately
 uses `min_colors=1500` rather than an exact hash: unchanged builds select multiple valid animation states with
 1,650-1,698 distinct colors, while observed partial transitions contain only about 325-339.
 `PROSPER_PROVENANCE_DIM=WxH` reports overlapping color, compute, DMA_DATA, and WRITE_DATA writers with

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ accepts scripted gamepad input, and renders the first level.
   first playable scene. Graphics and compute now execute by retained PM4 order (#584), fixing a proven
   future-read. The formerly overbright screenshot was traced to a diagnostic warmup skipping temporal RTT
   producers. Versioned offline bundles now retain long, exact cross-submit resource history and replay a
-  minimized closure. #608 preserved a run-local semantic checkpoint for the controllable Jump tutorial:
-  exactly 90 semantic draws with the 738x420 pass at draw index 79..81. That conjunction is historical and
-  no longer matches current fresh routes; route-independent selector refresh remains under #594. Its faithful
-  883-submit replay isolated the missing-world symptom to a persistent 642x362 depth surface. Timeline-v5 backing hashes and
+  minimized closure. The preserved #608 bundle used exactly 90 semantic draws with the 738x420 pass at draw
+  79..81. Current routes use 91..93 draws, exactly 8 dispatches, and that pass at draw 80..82. Timeline v6
+  discovers and validates this checkpoint offline without depending on run-local submit ordinals (#594). The
+  faithful 883-submit replay isolated the missing-world symptom to a persistent 642x362 depth surface.
+  Timeline-v5 backing hashes and
   writer provenance then found the real clear boundary: a supported compute kernel fills the surface's
   32 KiB HTILE allocation with `0xfffffff0` before drawing. Guest GPU writes now invalidate overlapping
   cached Vulkan depth images, restoring the rejected gameplay layers in a routed live A/B (#611). The four

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -33,8 +33,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
 - ✅ **Graphics investigation tooling:** versioned live GPU capture/replay (`.prgcap`), per-draw/resource
   inspection and isolation, strict reflected SPIR-V/runtime descriptor validation, render-target producer
   provenance, normal screenshot capture, and a local content-metric snapshot guard. Native-speed `.prgtl`
-  submit/present indexes can select one exact submit before renderer sampling and materialize immutable,
-  content-deduplicated graphics/compute state plus mixed operation order for offline replay (#594).
+  submit/present indexes can select an exact submit or semantic route checkpoint before renderer sampling and
+  materialize immutable, content-deduplicated graphics/compute state plus mixed operation order for offline
+  replay (#594).
   Offline dependency graphs resolve in-submit resource versions and identify deduplicated prior-submit
   leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595). Capture v7 retains
   bounded, content-addressed raw RDNA2 and exact opcode/PC/state diagnostics for unrealized draws/dispatches;
@@ -58,10 +59,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal
   642×362 edges without bounded leaves, but the first 80-draw semantic endpoint is the opening vignette rather
-  than playable gameplay. #608 selected the controllable Jump tutorial by combining an exact 90-draw submit
-  with the 738x420 pass at semantic draw 79..81, and tracked its exact history and first bad composition. That
-  exact conjunction is now a preserved-capture recipe: current fresh routes reach sustained gameplay but no
-  longer match it, so selector recalibration remains under #594.
+  than playable gameplay. The preserved #608 bundle selected the Jump tutorial with exactly 90 draws and the
+  738x420 pass at draw 79..81. Current routes are selected without submit ordinals by combining 91..93 semantic
+  draws, exactly 8 dispatches, and that pass at draw 80..82. Timeline v6 records compact target spans so the
+  predicate can be discovered and validated offline before an expensive detailed capture (#594).
   The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
   failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written
   HTILE metadata instead; #611 implements that missing cache boundary. #569 still tracks exact depth/stencil

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -53,10 +53,10 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   structurization now restores them while varying and compute-wave forms still reject (#615). Capture v7 now
   records bounded raw stages, exact rejection opcode/PC, decoded state, and resource/descriptor summaries for
   every observed realization failure, so the next unsupported shader can be reduced offline (#618).
-- **Immediate milestone:** refresh the now-stale Dead Cells semantic checkpoint under #594 and resolve exact
-  depth/stencil checkpointing (#569). Keep extending the workflow across Unity and Unreal targets rather than
-  returning to long unstructured live traces. The Dead Cells splash regression guard now uses a measured run-level
-  content threshold instead of the historical animation-sensitive exact frame (#596/#573).
+- **Immediate milestone:** resolve exact depth/stencil checkpointing (#569). Keep extending the workflow across
+  Unity and Unreal targets rather than returning to long unstructured live traces. Timeline v6 closes the stale
+  Dead Cells checkpoint problem with offline target-span discovery and a two-route semantic selector (#594), and
+  the splash guard uses a measured run-level content threshold (#596/#573).
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -27,7 +27,9 @@ investigation, add `PROSPER_RENDER_TARGET_DIM=642x362` to preserve the level's
 RTT chain; this is much slower and currently remains in the opening vignette at
 the 35-second checkpoint. Do not use the fast route as a visual golden guard.
 
-## Historical playable semantic checkpoint (#608)
+## Playable Semantic Checkpoints
+
+### Historical #608 bundle
 
 Do not select the first 738x420 target: it also occurs in the skippable opening. The preserved #608
 Jump-tutorial capture used all of these predicates:
@@ -43,12 +45,32 @@ The draw index is zero-based in the raw semantic sequence. Those #608 runs selec
 but replayed the same controllable scene with 86 realized draws, seven realized dispatches, the Jump prompt,
 and the full HUD. Nearby cinematic and transition captures were outside this conjunction.
 
-This is no longer a guaranteed current selector. A 2026-07-13 fresh route after #611 reached sustained
-gameplay submits with 90-91 semantic draws, eight dispatches, and the 642x362 scene-depth family, but did not
-match `738x420 @ draw 79..81` plus exactly 90 draws during a bounded 90-second run. Treat the conjunction as
-a preserved-capture recipe only. Record a native-speed `.prgtl`, confirm gameplay from its submit/depth
-sequence, and derive a new exact conjunction before starting an expensive capsule or bundle. Refreshing that
-route-independent checkpoint remains under #594.
+Treat that conjunction as a preserved-capture recipe only.
+
+### Current timeline-v6 checkpoint (#594)
+
+Two independent 90-second native-speed routes selected sustained gameplay from about 29.5 seconds onward with
+this conjunction, despite different submit ordinals:
+
+```bash
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=80:82 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=91 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=93 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8
+```
+
+Timeline v6 retains compact target spans, so calibrate and validate the endpoint offline before starting a
+large capsule or bundle:
+
+```bash
+./build-linux/gpu_timeline run.prgtl --signatures 91:93 8
+./build-linux/gpu_timeline run.prgtl --select 738x420 80:82 91:93 8
+```
+
+The adjacent target indices 79 and 83, exact 90-draw count, and dispatch counts 7 and 9 all produced zero
+matches. The live selector reproduced the offline result and installed a gameplay capsule at its first match.
 
 The faithful playable reference on #608 retained 883 submits and renders hash
 `5759c125812154dc`. A final-submit replay with fresh depth renders `71b84bdfae53933c` instead. Use
@@ -59,6 +81,7 @@ compute: program `0x401aec200` fills the 32 KiB HTILE block with `0xfffffff0` be
 invalidates overlapping persistent Vulkan depth/stencil images on guest GPU writes, restoring the rejected
 layers. Dead Cells' four repeated fragment failures were uniform VCCZ-exit light loops; #615 adds a narrowly
 proved fragment/vertex structurization path and current gameplay submits realize every semantic draw. Use
-`shader_inspect` for raw `PROSPER_SHADER_DUMP` binaries; capture-side retention of unrealized shader diagnostics
-is tracked in #618. The 35-second screenshot warmup still skips color RTT history and therefore remains an
+`shader_inspect` for raw `PROSPER_SHADER_DUMP` binaries; capture v7 retains bounded raw stages and exact
+failure diagnostics for unrealized operations (#618). The 35-second screenshot warmup still skips color RTT
+history and therefore remains an
 overbright progression diagnostic, not a color-correct gameplay oracle.

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -35,10 +35,11 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 5;
+constexpr uint32_t kVersion = 6;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
+constexpr uint32_t kMaxTargetSpans = 16384;
 
 enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3, Detail = 4, Producer = 5 };
 
@@ -100,6 +101,17 @@ uint64_t hash_bytes(const uint8_t* data, size_t size) {
         hash *= 1099511628211ull;
     }
     return hash;
+}
+
+bool valid_target_spans(const GpuTimelineSubmit& submit) {
+    if (submit.target_spans.empty()) return true;
+    uint64_t expected_first = 0;
+    for (const auto& span : submit.target_spans) {
+        if (!span.draw_count || span.first_draw != expected_first) return false;
+        expected_first += span.draw_count;
+        if (expected_first > submit.draw_count) return false;
+    }
+    return submit.target_spans_truncated || expected_first == submit.draw_count;
 }
 
 bool write_all(FILE* file, const void* data, size_t bytes, std::string& error) {
@@ -233,6 +245,8 @@ struct RuntimeDetailRequest {
     uint32_t select_target_max_index = UINT32_MAX;
     uint32_t select_min_draws = 0;
     uint32_t select_max_draws = UINT32_MAX;
+    uint32_t select_min_dispatches = 0;
+    uint32_t select_max_dispatches = UINT32_MAX;
     bool exit_after_capture = false;
     uint64_t submit_no = 0;
     bool valid = false;
@@ -347,16 +361,45 @@ struct RuntimeDetailRequest {
             std::fprintf(stderr, "[timeline] capture minimum draws exceeds maximum draws\n");
             return;
         }
+        if (const char* min_dispatches = std::getenv(
+                "PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES")) {
+            char* min_end = nullptr;
+            const uint64_t value = std::strtoull(min_dispatches, &min_end, 0);
+            if (!min_end || *min_end || value > UINT32_MAX) {
+                std::fprintf(stderr,
+                             "[timeline] capture minimum dispatches must be 0..4294967295\n");
+                return;
+            }
+            select_min_dispatches = static_cast<uint32_t>(value);
+        }
+        if (const char* max_dispatches = std::getenv(
+                "PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES")) {
+            char* max_end = nullptr;
+            const uint64_t value = std::strtoull(max_dispatches, &max_end, 0);
+            if (!max_end || *max_end || value > UINT32_MAX) {
+                std::fprintf(stderr,
+                             "[timeline] capture maximum dispatches must be 0..4294967295\n");
+                return;
+            }
+            select_max_dispatches = static_cast<uint32_t>(value);
+        }
+        if (select_min_dispatches > select_max_dispatches) {
+            std::fprintf(stderr,
+                         "[timeline] capture minimum dispatches exceeds maximum dispatches\n");
+            return;
+        }
         if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE"))
             exit_after_capture = *value && std::strcmp(value, "0") && std::strcmp(value, "off");
         submit_no = parsed;
         valid = true;
         if (select_target_width)
             std::fprintf(stderr, "[timeline] semantic capture endpoint submit>=%llu "
-                                 "target=%ux%u target-index=%u..%u draws=%u..%u\n",
+                                 "target=%ux%u target-index=%u..%u draws=%u..%u "
+                                 "dispatches=%u..%u\n",
                          static_cast<unsigned long long>(submit_no), select_target_width,
                          select_target_height, select_target_min_index,
-                         select_target_max_index, select_min_draws, select_max_draws);
+                         select_target_max_index, select_min_draws, select_max_draws,
+                         select_min_dispatches, select_max_dispatches);
     }
 };
 
@@ -525,24 +568,25 @@ RuntimeCaptureBundle& runtime_capture_bundle() {
 }
 
 bool runtime_capture_endpoint_matches(const RuntimeDetailRequest& request,
-                                      const GpuState& state, uint64_t submit_no) {
+                                      const GpuTimelineSubmit& submit) {
+    const uint64_t submit_no = submit.submit_no;
     if (submit_no < request.submit_no) return false;
     if (!request.select_target_width)
         return submit_no == request.submit_no;
-    if (state.draws.size() < request.select_min_draws ||
-        state.draws.size() > request.select_max_draws) return false;
-    for (size_t i = request.select_target_min_index;
-         i < state.draws.size() && i <= request.select_target_max_index; ++i) {
-        const RenderState rs = extract_render_state(state.state_at_draw(i));
-        if (rs.color0_width == request.select_target_width &&
-            rs.color0_height == request.select_target_height) {
-            std::fprintf(stderr,
-                         "[timeline] semantic capture endpoint matched submit=%llu target-draw=%zu\n",
-                         static_cast<unsigned long long>(submit_no), i);
-            return true;
-        }
-    }
-    return false;
+    GpuTimelineSelector selector;
+    selector.min_submit_no = request.submit_no;
+    selector.target_width = request.select_target_width;
+    selector.target_height = request.select_target_height;
+    selector.target_min_draw = request.select_target_min_index;
+    selector.target_max_draw = request.select_target_max_index;
+    selector.min_draws = request.select_min_draws;
+    selector.max_draws = request.select_max_draws;
+    selector.min_dispatches = request.select_min_dispatches;
+    selector.max_dispatches = request.select_max_dispatches;
+    if (!gpu_timeline_submit_matches(submit, selector)) return false;
+    std::fprintf(stderr, "[timeline] semantic capture endpoint matched submit=%llu\n",
+                 static_cast<unsigned long long>(submit_no));
+    return true;
 }
 
 bool same_depth_surface(const GpuTimelineDepthSurface& a, const GpuTimelineDepthSurface& b) {
@@ -757,6 +801,14 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
         error = "timeline submit has too many depth surfaces";
         return false;
     }
+    if (submit.target_spans.size() > kMaxTargetSpans) {
+        error = "timeline submit has too many target spans";
+        return false;
+    }
+    if (!valid_target_spans(submit)) {
+        error = "timeline submit has invalid target spans";
+        return false;
+    }
     Bytes payload;
     payload.u64(submit.submit_no);
     payload.u64(submit.process_command_order);
@@ -767,9 +819,10 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
     payload.u32(submit.dispatch_count);
     payload.u32(submit.color0_width);
     payload.u32(submit.color0_height);
-    // Keep an empty v5 submit byte-identical to v1-v4 so small compatibility fixtures and producers
-    // that do not use depth remain simple. A non-empty tail is explicitly version-gated on read.
-    if (!submit.depth_surfaces.empty()) {
+    // Keep a metadata-free v6 submit byte-identical to v1-v4 for compatibility fixtures. Any v6
+    // tail carries both collection counts so the depth and target-span sections are unambiguous.
+    if (!submit.depth_surfaces.empty() || !submit.target_spans.empty() ||
+        submit.target_spans_truncated) {
         payload.u32(static_cast<uint32_t>(submit.depth_surfaces.size()));
         for (const auto& ds : submit.depth_surfaces) {
             payload.u64(ds.depth_read_base); payload.u64(ds.depth_write_base);
@@ -791,6 +844,12 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
             payload.u64(ds.backing_writer_addr); payload.u64(ds.backing_writer_size);
             payload.u64(ds.backing_writer_order); payload.u64(ds.backing_writer_identity);
         }
+        payload.u32(static_cast<uint32_t>(submit.target_spans.size()));
+        for (const auto& span : submit.target_spans) {
+            payload.u32(span.first_draw); payload.u32(span.draw_count);
+            payload.u32(span.width); payload.u32(span.height);
+        }
+        payload.u32(submit.target_spans_truncated ? 1u : 0u);
     }
     return impl_->append(RecordType::Submit, payload, error);
 }
@@ -978,7 +1037,8 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
                 error = "invalid timeline submit record";
                 return false;
             }
-            if (version >= 5 && p.left) {
+            const bool have_submit_tail = p.left != 0;
+            if (version >= 5 && have_submit_tail) {
                 uint32_t surface_count = 0;
                 if (!p.u32(surface_count) || surface_count > 65536) {
                     error = "invalid timeline depth-surface count";
@@ -1006,6 +1066,30 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
                         error = "invalid timeline depth-surface record";
                         return false;
                     }
+                }
+            }
+            if (version >= 6 && have_submit_tail) {
+                uint32_t span_count = 0, truncated = 0;
+                if (!p.u32(span_count) || span_count > kMaxTargetSpans) {
+                    error = "invalid timeline target-span count";
+                    return false;
+                }
+                submit.target_spans.resize(span_count);
+                for (auto& span : submit.target_spans) {
+                    if (!p.u32(span.first_draw) || !p.u32(span.draw_count) ||
+                        !p.u32(span.width) || !p.u32(span.height) || !span.draw_count) {
+                        error = "invalid timeline target-span record";
+                        return false;
+                    }
+                }
+                if (!p.u32(truncated) || truncated > 1) {
+                    error = "invalid timeline target-span truncation flag";
+                    return false;
+                }
+                submit.target_spans_truncated = truncated != 0;
+                if (!valid_target_spans(submit)) {
+                    error = "invalid timeline target-span coverage";
+                    return false;
                 }
             }
             if (p.left) {
@@ -1095,6 +1179,27 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
     return true;
 }
 
+bool gpu_timeline_submit_matches(const GpuTimelineSubmit& submit,
+                                 const GpuTimelineSelector& selector) {
+    if (submit.submit_no < selector.min_submit_no ||
+        submit.draw_count < selector.min_draws || submit.draw_count > selector.max_draws ||
+        submit.dispatch_count < selector.min_dispatches ||
+        submit.dispatch_count > selector.max_dispatches)
+        return false;
+    if (!selector.target_width) return true;
+    if (!selector.target_height || submit.target_spans_truncated) return false;
+    for (const auto& span : submit.target_spans) {
+        if (span.width != selector.target_width || span.height != selector.target_height ||
+            !span.draw_count)
+            continue;
+        const uint64_t first = span.first_draw;
+        const uint64_t last = first + span.draw_count - 1;
+        if (last >= selector.target_min_draw && first <= selector.target_max_draw)
+            return true;
+    }
+    return false;
+}
+
 void begin_gpu_timeline_submit(uint64_t submit_no) {
     static const bool requested = [] {
         const char* path = std::getenv("PROSPER_GPU_TIMELINE");
@@ -1117,10 +1222,26 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     submit.draw_count = static_cast<uint32_t>(std::min<size_t>(state.draws.size(), UINT32_MAX));
     submit.dispatch_count = static_cast<uint32_t>(std::min<size_t>(state.dispatches.size(), UINT32_MAX));
     submit.first_command_order = std::numeric_limits<uint64_t>::max();
-    for (const auto& draw : state.draws) {
+    for (size_t draw_index = 0; draw_index < state.draws.size(); ++draw_index) {
+        const auto& draw = state.draws[draw_index];
         submit.first_command_order = std::min(submit.first_command_order, draw.command_order);
         submit.last_command_order = std::max(submit.last_command_order, draw.command_order);
         const RenderState rs = extract_render_state(draw.state ? *draw.state : state);
+        if (!submit.target_spans_truncated) {
+            if (draw_index > UINT32_MAX) {
+                submit.target_spans_truncated = true;
+            } else if (!submit.target_spans.empty() &&
+                submit.target_spans.back().draw_count < UINT32_MAX &&
+                submit.target_spans.back().width == rs.color0_width &&
+                submit.target_spans.back().height == rs.color0_height) {
+                ++submit.target_spans.back().draw_count;
+            } else if (submit.target_spans.size() < kMaxTargetSpans) {
+                submit.target_spans.push_back({static_cast<uint32_t>(draw_index), 1,
+                                               rs.color0_width, rs.color0_height});
+            } else {
+                submit.target_spans_truncated = true;
+            }
+        }
         if (!rs.z_enable && !rs.z_write_enable && !rs.stencil_enable &&
             !rs.depth_clear_enable && !rs.stencil_clear_enable)
             continue;
@@ -1225,7 +1346,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                      request.bundle_start_target_width, request.bundle_start_target_height);
     }
     const bool capture_endpoint = request.valid &&
-        runtime_capture_endpoint_matches(request, state, submit_no);
+        runtime_capture_endpoint_matches(request, submit);
     const uint64_t bundle_first = request.bundle_depth > request.submit_no
         ? 1 : request.submit_no - request.bundle_depth + 1;
     if (request.valid && !request.bundle_path.empty() &&

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -40,6 +40,15 @@ struct GpuTimelineDepthSurface {
     uint64_t backing_writer_order = 0, backing_writer_identity = 0;
 };
 
+// Consecutive semantic draws that use the same color-target extent. Addresses are deliberately
+// excluded: they are run-local, while the extent/order signature is useful across routed boots.
+struct GpuTimelineTargetSpan {
+    uint32_t first_draw = 0;
+    uint32_t draw_count = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
+
 struct GpuTimelineSubmit {
     uint64_t sequence = 0;
     uint64_t elapsed_ns = 0;
@@ -53,6 +62,22 @@ struct GpuTimelineSubmit {
     uint32_t color0_width = 0;
     uint32_t color0_height = 0;
     std::vector<GpuTimelineDepthSurface> depth_surfaces;
+    std::vector<GpuTimelineTargetSpan> target_spans;
+    bool target_spans_truncated = false;
+};
+
+// Shared by live detailed-capture selection and offline timeline inspection. A zero target extent
+// disables target matching; all numeric ranges are inclusive.
+struct GpuTimelineSelector {
+    uint64_t min_submit_no = 1;
+    uint32_t target_width = 0;
+    uint32_t target_height = 0;
+    uint32_t target_min_draw = 0;
+    uint32_t target_max_draw = UINT32_MAX;
+    uint32_t min_draws = 0;
+    uint32_t max_draws = UINT32_MAX;
+    uint32_t min_dispatches = 0;
+    uint32_t max_dispatches = UINT32_MAX;
 };
 
 struct GpuTimelinePresent {
@@ -156,6 +181,8 @@ private:
 };
 
 bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::string& error);
+bool gpu_timeline_submit_matches(const GpuTimelineSubmit& submit,
+                                 const GpuTimelineSelector& selector);
 
 // Runtime hooks. Inert unless PROSPER_GPU_TIMELINE=<path> is set. They record folded semantic state
 // before renderer sampling and never realize shaders, copy resources, or invoke Vulkan.

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -40,6 +40,14 @@ int main() {
     first.submit_no = 10; first.process_command_order = 400; first.first_command_order = 390;
     first.last_command_order = 400; first.color0_base = 0x12340000; first.draw_count = 3;
     first.dispatch_count = 1; first.color0_width = 642; first.color0_height = 362;
+    first.target_spans.push_back({0, 1, 642, 362});
+    first.target_spans.push_back({1, 2, 738, 420});
+    GpuTimelineSubmit invalid_spans = first;
+    invalid_spans.target_spans[1].first_draw = 2;
+    CHECK(!writer.append_submit(invalid_spans, error) &&
+          error.find("invalid target spans") != std::string::npos,
+          "writer rejects noncontiguous target-span coverage");
+    error.clear();
     GpuTimelineDepthSurface first_depth;
     first_depth.depth_read_base = first_depth.depth_write_base = 0x700000;
     first_depth.stencil_read_base = first_depth.stencil_write_base = 0x830000;
@@ -87,6 +95,7 @@ int main() {
     CHECK(writer.append_producer(producer, error), "writer appends a prior-producer identity");
     GpuTimelineSubmit second = first;
     second.submit_no = 11; second.draw_count = 4; second.dispatch_count = 0;
+    second.target_spans[1].draw_count = 3;
     CHECK(writer.append_submit(second, error), "writer appends a second submit record");
     CHECK(writer.flush(error), "writer flushes explicitly");
     writer.close();
@@ -97,7 +106,7 @@ int main() {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.version == 5 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+    CHECK(timeline.version == 6 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
           timeline.details.size() == 1 && timeline.producers.size() == 1,
           "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
@@ -116,6 +125,31 @@ int main() {
           timeline.submits[0].depth_surfaces[0].backing_writer_sequence == 9 &&
           timeline.submits[0].depth_surfaces[0].backing_writer_identity == 0xabcdef,
           "native timeline depth identity, HTILE programming, and use counts round-trip");
+    CHECK(timeline.submits[0].target_spans.size() == 2 &&
+          timeline.submits[0].target_spans[1].first_draw == 1 &&
+          timeline.submits[0].target_spans[1].draw_count == 2 &&
+          timeline.submits[0].target_spans[1].width == 738 &&
+          !timeline.submits[0].target_spans_truncated,
+          "target-extent spans round-trip without run-local addresses");
+    GpuTimelineSelector selector;
+    selector.min_submit_no = 1; selector.target_width = 738; selector.target_height = 420;
+    selector.target_min_draw = 1; selector.target_max_draw = 2;
+    selector.min_draws = selector.max_draws = 3;
+    selector.min_dispatches = selector.max_dispatches = 1;
+    CHECK(gpu_timeline_submit_matches(timeline.submits[0], selector),
+          "shared selector matches target position plus draw/dispatch counts");
+    selector.target_min_draw = selector.target_max_draw = 0;
+    CHECK(!gpu_timeline_submit_matches(timeline.submits[0], selector),
+          "shared selector rejects a target outside the requested draw range");
+    selector.target_min_draw = 1; selector.target_max_draw = 2;
+    selector.min_dispatches = selector.max_dispatches = 2;
+    CHECK(!gpu_timeline_submit_matches(timeline.submits[0], selector),
+          "shared selector rejects an otherwise identical dispatch-count mismatch");
+    selector.min_dispatches = selector.max_dispatches = 1;
+    timeline.submits[0].target_spans_truncated = true;
+    CHECK(!gpu_timeline_submit_matches(timeline.submits[0], selector),
+          "shared selector refuses an incomplete target signature");
+    timeline.submits[0].target_spans_truncated = false;
     CHECK(timeline.presents[0].buffer_index == 2 && timeline.presents[0].flip_arg == -5,
           "signed present fields round-trip");
     CHECK(timeline.details[0].submit_no == 10 && timeline.details[0].missing_operation_count == 1 &&
@@ -207,6 +241,12 @@ int main() {
           runtime_timeline.submits[1].depth_surfaces[0].htile_data_base == 0x820000 &&
           runtime_timeline.submits[1].depth_surfaces[0].depth_test_count == 1,
           "runtime timeline extracts compact DS programming without realizing resources");
+    CHECK(runtime_timeline.submits[1].target_spans.size() == 1 &&
+          runtime_timeline.submits[1].target_spans[0].first_draw == 0 &&
+          runtime_timeline.submits[1].target_spans[0].draw_count == 1 &&
+          runtime_timeline.submits[1].target_spans[0].width == 642 &&
+          runtime_timeline.submits[1].target_spans[0].height == 362,
+          "runtime timeline records compact semantic target spans");
     CHECK(runtime_timeline.details.size() == 3 && runtime_timeline.details[0].submit_no == 41 &&
           runtime_timeline.details[0].capture_path.find(bundle_capture + "#submit=41") == 0 &&
           runtime_timeline.details[1].capture_path == predecessor_capture &&
@@ -224,7 +264,8 @@ int main() {
 
     const auto compat_v2 = base.string() + "-compat-v2.prgtl";
     GpuTimelineWriter compat_writer;
-    GpuTimelineSubmit legacy_first = first; legacy_first.depth_surfaces.clear();
+    GpuTimelineSubmit legacy_first = first;
+    legacy_first.depth_surfaces.clear(); legacy_first.target_spans.clear();
     CHECK(compat_writer.open(compat_v2, metadata, error) && compat_writer.append_submit(legacy_first, error),
           "created a detail-free compatibility timeline");
     compat_writer.close();

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -72,7 +72,9 @@ the guest and command decoder advance. The `screenshot` frontend exposes this as
 `--warmup-submits` for `PROSPER_RENDER_FIRST`; use wall-clock warmup for progression captures and the exact
 submit gate for repeatable renderer investigations.
 `PROSPER_GPU_TIMELINE=<path>.prgtl` records every folded submit before renderer sampling plus every
-VideoOut flip. `gpu_timeline <path> [--records]` inspects the checksummed index offline. Recording is
+VideoOut flip. `gpu_timeline <path> [--records]` inspects the checksummed index offline. Version 6 also records
+compact target-extent spans; use `--signatures DRAWS DISPATCHES` to discover scene shapes and
+`--select WxH DRAW_INDEX DRAWS DISPATCHES` to validate the live predicate. Recording is
 independent of `PROSPER_RENDER_EVERY`. To materialize one exact indexed submit without rendering the
 warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
@@ -83,14 +85,14 @@ and extract one with `--dump-failed-shader FAILURE:STAGE PATH`. Selection is
 intentionally bounded to the consumer and an optional
 immediate predecessor. Explicit-depth `.prgbundle` capture provides bounded recursive cross-submit closure;
 automatic present-to-producer selection remains #595.
-Timeline version 5 retains a sliding graphics-target window plus full-run aggregate lifetime metadata when a
-detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises the sliding window to at most 65536.
+Timeline version 6 retains the version-5 sliding graphics-target window plus full-run aggregate lifetime metadata
+when a detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises the window to at most 65536.
 Producer records identify the latest overlapping prior submit/draw/PM4 order, earliest observed graphics
 writer, write/submit counts, truncation, and raw first-writer clear/target state. Raw clear registers are
 provenance, not proof of an implicit hardware clear. The timeline intentionally retains no delayed pointers
 to mutable guest bytes.
-Every v5 submit also records distinct DS plane/HTILE identities, raw view/format/size programming, target
-extents, and test/write/clear counts. `gpu_timeline FILE --depth-summary [WxH]` groups their full lifetimes.
+Every current submit also records the v5 distinct DS plane/HTILE identities, raw view/format/size programming,
+target extents, and test/write/clear counts. `gpu_timeline FILE --depth-summary [WxH]` groups their full lifetimes.
 For a focused run, `PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM=WxH` adds guest depth/stencil/HTILE hashes and latest
 overlapping writer provenance without realizing general resources; use it before attempting a full bundle.
 Set `PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR=<path>.prgcap` to snapshot exact submit `N-1` at producer
@@ -130,7 +132,9 @@ For timing-sensitive routes, `PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=WxH` 
 submit at or after `CAPTURE_SUBMIT`; `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=N` bound semantic complexity to reject loading or cinematic passes.
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=MIN:MAX` narrows where the selected target may occur in the
-raw semantic draw sequence; derive it from repeated positives and nearby negative samples.
+raw semantic draw sequence. `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=N` and
+`PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=N` add dispatch-count bounds. Derive the full conjunction from
+repeated positives and nearby negative samples with the offline v6 selector.
 When the endpoint moves, predecessor manifests roll forward so the final bundle retains the latest requested
 depth; dictionary bytes observed by evicted manifests still count against the unique-byte budget.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -165,7 +165,7 @@ faithful replacement for the missing producer history.
 
 ## Current Dead Cells reference
 
-The #608 playable closure selects exactly 90 semantic draws with the 738x420 pass at draw 79..81. Its retained
+The preserved #608 playable closure selects exactly 90 semantic draws with the 738x420 pass at draw 79..81. Its retained
 submits 18,165..19,047 represent 158.94 GiB logically and 739 MiB uniquely. Replay resolves 1,764 temporal image
 dependencies with zero bounded/unresolved leaves and renders hash `5759c125812154dc`. A complete-color-cache
 final capsule renders `71b84bdfae53933c` because it begins with fresh depth. Manifest scanning shows the same
@@ -175,6 +175,10 @@ clear. Timeline-v5 backing hashes and writer provenance resolve the missing boun
 backend now invalidates overlapping persistent DS entries on guest GPU writeback (#611); a routed A/B restores
 the layers that stayed black with invalidation disabled. #569 remains the exact DS checkpoint gap, not another
 color RTT producer.
+
+For new routed captures, timeline v6 replaces that historical endpoint with 91..93 semantic draws, exactly
+8 dispatches, and the 738x420 pass at draw 80..82. `gpu_timeline --signatures` derived the conjunction from two
+independent routes, and `--select` proves it has no splash/menu/loading or adjacent-index matches before capture.
 
 The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. Timeline-v4
 full-run aggregation shows that both surfaces begin around submit 17,400 in current runs and are rewritten

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -17,6 +17,8 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl --records
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl --depth-summary 642x362
+./build-linux/gpu_timeline /tmp/dead-cells.prgtl --signatures 91:93 8
+./build-linux/gpu_timeline /tmp/dead-cells.prgtl --select 738x420 80:82 91:93 8
 ```
 
 Capture a selected submit and, optionally, its immediate predecessor from the same run:
@@ -49,9 +51,11 @@ PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=1000 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
 PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=642x362 \
 PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
-PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=79:81 \
-PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=90 \
-PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=90 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=80:82 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=91 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=93 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
   ./build-linux/boot_trace /path/to/PPSA15552-app0
 
@@ -64,7 +68,11 @@ semantics, draw isolation, resource/shader extraction, and the distinction betwe
 
 The summary reports duration, submit/present/draw/dispatch counts, rates, target extents, and whether
 an incomplete final record was discarded. `--records` prints the globally ordered submit/present
-index. Version-2+ detail records link the selected submit to its `.prgcap` and report semantic versus
+index plus v6 target spans. `--signatures DRAWS DISPATCHES` groups target-span sequences for candidate
+submit-count ranges; each range accepts `N` or `MIN:MAX`. `--select WxH DRAW_INDEX DRAWS DISPATCHES` applies
+the same semantic predicate as live capture, reports its first/last match and total, and exits nonzero when no
+submit matches. It reports an inconclusive error instead of treating a truncated target signature as a negative.
+Version-2+ detail records link the selected submit to its `.prgcap` and report semantic versus
 realized draw/dispatch counts, missing operations, unique shader/resource versions, and resource bytes.
 Run metadata includes the revision, title, and input route when the corresponding capture environment
 variables are set.
@@ -82,11 +90,15 @@ variables are set.
 
 ## Current boundary
 
-Version 5 remains backward-compatible with version-1 through version-4 indexes. Every submit now retains a
-compact manifest of distinct depth/stencil surfaces without realizing shaders or copying general resources:
-plane and HTILE bases, raw view/format/size/override programming, target extent, draw/test/write/clear counts,
-and compare-op coverage. `gpu_timeline FILE --depth-summary [WxH]` groups complete lifetimes and reports raw
-programming transitions. This is the fast first check for a stale persistent DS cache identity.
+Version 6 reads version-1 through version-5 indexes. It adds run-length encoded color-target extent spans over
+the semantic draw sequence, excluding run-local addresses, so scene predicates can be discovered and tested
+offline before a detailed rerun. Span storage is bounded and an incomplete signature is marked truncated.
+
+Version 5 added a compact per-submit manifest of distinct depth/stencil surfaces without realizing shaders or
+copying general resources: plane and HTILE bases, raw view/format/size/override programming, target extent,
+draw/test/write/clear counts, and compare-op coverage. `gpu_timeline FILE --depth-summary [WxH]` groups
+complete lifetimes and reports raw programming transitions. This is the fast first check for a stale persistent
+DS cache identity.
 
 Set `PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM=WxH` only for a focused native run. Matching submits hash the readable
 guest depth, stencil, and padded HTILE spans and record the latest overlapping graphics/compute/DMA/WRITE_DATA
@@ -116,8 +128,10 @@ stage coverage, first rejected opcode/PC, decoded state, and failure reason. Ins
 submit as complete. A timeline-selected capsule has no live-output hash oracle unless the renderer also
 produced one; replay reports `oracle=no` and renders without pretending an expected pixel hash exists.
 
-The capture is selected by exact submit number, not yet by route checkpoint or present. It contains the
-selected submit and temporal RTT surfaces currently resident in the renderer, but does not automatically
+Without a semantic endpoint predicate, capture uses the exact configured submit. With target/draw/dispatch
+conditions, that submit becomes a lower bound and the first matching route checkpoint is selected. Present
+selection is not implemented. A capsule contains the selected submit and temporal RTT surfaces currently
+resident in the renderer, but does not automatically
 pull earlier producer submits. Automatic present-to-producer dependency closure is tracked by #595.
 `gpu_replay --graph` resolves dependencies inside the selected submit and reports the remaining external
 versions; a `future-writer` on an external leaf is the characteristic temporal read-before-write case that
@@ -165,3 +179,5 @@ compacts unreachable dictionary entries before installing the bundle.
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=MIN:MAX` restricts the matching target to a zero-based
 semantic draw-index window. Establish the range across multiple desired captures and nearby negative samples;
 realized replay indices can differ when earlier semantic draws are unrealized.
+`PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=N` and
+`PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=N` restrict the same checkpoint by semantic dispatch count.

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <map>
 #include <set>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -149,9 +150,60 @@ int print_depth_summary(const GpuTimelineFile& timeline, uint32_t filter_width,
     return totals.empty() ? 1 : 0;
 }
 
+bool parse_u32_range(const char* text, uint32_t& first, uint32_t& last) {
+    const std::string value(text ? text : "");
+    const size_t colon = value.find(':');
+    auto parse_one = [](const std::string& part, uint32_t& out) {
+        if (part.empty()) return false;
+        char* end = nullptr;
+        const unsigned long long parsed = std::strtoull(part.c_str(), &end, 0);
+        if (!end || *end || parsed > UINT32_MAX) return false;
+        out = static_cast<uint32_t>(parsed);
+        return true;
+    };
+    if (colon == std::string::npos) {
+        if (!parse_one(value, first)) return false;
+        last = first;
+        return true;
+    }
+    if (value.find(':', colon + 1) != std::string::npos ||
+        !parse_one(value.substr(0, colon), first) ||
+        !parse_one(value.substr(colon + 1), last))
+        return false;
+    return first <= last;
+}
+
+bool parse_dimensions(const char* text, uint32_t& width, uint32_t& height) {
+    unsigned parsed_width = 0, parsed_height = 0;
+    char tail = 0;
+    if (!text || std::sscanf(text, "%ux%u%c", &parsed_width, &parsed_height, &tail) != 2 ||
+        !parsed_width || !parsed_height)
+        return false;
+    width = parsed_width;
+    height = parsed_height;
+    return true;
+}
+
+std::string target_signature(const GpuTimelineSubmit& submit) {
+    std::ostringstream out;
+    if (submit.target_spans.empty()) out << "unavailable";
+    for (size_t i = 0; i < submit.target_spans.size(); ++i) {
+        const auto& span = submit.target_spans[i];
+        if (i) out << ',';
+        out << span.first_draw;
+        if (span.draw_count > 1) out << '-' << (uint64_t{span.first_draw} + span.draw_count - 1);
+        out << ':' << span.width << 'x' << span.height;
+    }
+    if (submit.target_spans_truncated) out << ",truncated";
+    return out.str();
+}
+
 int main(int argc, char** argv) {
     const bool records = argc == 3 && std::string(argv[2]) == "--records";
-    const bool depth_summary = argc >= 3 && std::string(argv[2]) == "--depth-summary";
+    const bool depth_summary = (argc == 3 || argc == 4) &&
+                               std::string(argv[2]) == "--depth-summary";
+    const bool signatures = argc == 5 && std::string(argv[2]) == "--signatures";
+    const bool select = argc == 7 && std::string(argv[2]) == "--select";
     uint32_t depth_width = 0, depth_height = 0;
     if (depth_summary && argc == 4) {
         unsigned width = 0, height = 0; char tail = 0;
@@ -159,9 +211,26 @@ int main(int argc, char** argv) {
             depth_width = width; depth_height = height;
         }
     }
-    if (argc < 2 || argc > 4 || (argc == 3 && !records && !depth_summary) ||
-        (argc == 4 && (!depth_summary || !depth_width))) {
-        std::fprintf(stderr, "usage: gpu_timeline <capture.prgtl> [--records|--depth-summary [WxH]]\n");
+    uint32_t filter_min_draws = 0, filter_max_draws = 0;
+    uint32_t filter_min_dispatches = 0, filter_max_dispatches = 0;
+    uint32_t select_width = 0, select_height = 0;
+    uint32_t select_min_draw = 0, select_max_draw = 0;
+    const bool filter_ok = !signatures ||
+        (parse_u32_range(argv[3], filter_min_draws, filter_max_draws) &&
+         parse_u32_range(argv[4], filter_min_dispatches, filter_max_dispatches));
+    const bool select_ok = !select ||
+        (parse_dimensions(argv[3], select_width, select_height) &&
+         parse_u32_range(argv[4], select_min_draw, select_max_draw) &&
+         parse_u32_range(argv[5], filter_min_draws, filter_max_draws) &&
+         parse_u32_range(argv[6], filter_min_dispatches, filter_max_dispatches));
+    const bool basic = argc == 2;
+    if (argc < 2 || (!basic && !records && !depth_summary && !signatures && !select) ||
+        (depth_summary && argc == 4 && !depth_width) || !filter_ok || !select_ok) {
+        std::fprintf(stderr,
+            "usage: gpu_timeline <capture.prgtl> [--records|--depth-summary [WxH]]\n"
+            "       gpu_timeline <capture.prgtl> --signatures DRAWS DISPATCHES\n"
+            "       gpu_timeline <capture.prgtl> --select WxH DRAW_INDEX DRAWS DISPATCHES\n"
+            "ranges accept N or MIN:MAX\n");
         return 2;
     }
     GpuTimelineFile timeline;
@@ -171,6 +240,82 @@ int main(int argc, char** argv) {
         return 1;
     }
     if (depth_summary) return print_depth_summary(timeline, depth_width, depth_height);
+    if (signatures || select) {
+        if (timeline.version < 6) {
+            std::fprintf(stderr,
+                         "gpu_timeline: target signatures require timeline version 6 (file is v%u)\n",
+                         timeline.version);
+            return 1;
+        }
+        if (signatures) {
+            struct Stats { uint64_t count = 0, first = UINT64_MAX, last = 0; };
+            std::map<std::string, Stats> grouped;
+            for (const auto& submit : timeline.submits) {
+                if (submit.draw_count < filter_min_draws || submit.draw_count > filter_max_draws ||
+                    submit.dispatch_count < filter_min_dispatches ||
+                    submit.dispatch_count > filter_max_dispatches)
+                    continue;
+                const std::string signature = "draws=" + std::to_string(submit.draw_count) +
+                    " dispatches=" + std::to_string(submit.dispatch_count) +
+                    " targets=" + target_signature(submit);
+                Stats& stats = grouped[signature];
+                ++stats.count;
+                stats.first = std::min(stats.first, submit.submit_no);
+                stats.last = std::max(stats.last, submit.submit_no);
+            }
+            for (const auto& [signature, stats] : grouped)
+                std::printf("signature submits=%llu first=%llu last=%llu %s\n",
+                            static_cast<unsigned long long>(stats.count),
+                            static_cast<unsigned long long>(stats.first),
+                            static_cast<unsigned long long>(stats.last), signature.c_str());
+            std::fprintf(stderr, "gpu_timeline: signatures=%zu\n", grouped.size());
+            return grouped.empty() ? 1 : 0;
+        }
+        GpuTimelineSelector selector;
+        selector.target_width = select_width;
+        selector.target_height = select_height;
+        selector.target_min_draw = select_min_draw;
+        selector.target_max_draw = select_max_draw;
+        selector.min_draws = filter_min_draws;
+        selector.max_draws = filter_max_draws;
+        selector.min_dispatches = filter_min_dispatches;
+        selector.max_dispatches = filter_max_dispatches;
+        uint64_t matches = 0;
+        uint64_t incomplete_candidates = 0;
+        const GpuTimelineSubmit* first_match = nullptr;
+        const GpuTimelineSubmit* last_match = nullptr;
+        for (const auto& submit : timeline.submits) {
+            if (submit.target_spans_truncated &&
+                submit.draw_count >= selector.min_draws && submit.draw_count <= selector.max_draws &&
+                submit.dispatch_count >= selector.min_dispatches &&
+                submit.dispatch_count <= selector.max_dispatches)
+                ++incomplete_candidates;
+            if (!gpu_timeline_submit_matches(submit, selector)) continue;
+            if (!first_match) first_match = &submit;
+            last_match = &submit;
+            ++matches;
+        }
+        auto print_match = [](const char* label, const GpuTimelineSubmit& submit) {
+            std::printf("%s submit=%llu t=%.6f draws=%u dispatches=%u targets=%s\n", label,
+                        static_cast<unsigned long long>(submit.submit_no), submit.elapsed_ns / 1e9,
+                        submit.draw_count, submit.dispatch_count, target_signature(submit).c_str());
+        };
+        if (first_match) {
+            print_match("first-match", *first_match);
+            if (last_match != first_match) print_match("last-match", *last_match);
+        }
+        std::fprintf(stderr, "gpu_timeline: matches=%llu%s\n",
+                     static_cast<unsigned long long>(matches),
+                     matches ? " (capture selects first match)" : "");
+        if (incomplete_candidates) {
+            std::fprintf(stderr,
+                         "gpu_timeline: selector is inconclusive: %llu count-matching submits have "
+                         "truncated target spans\n",
+                         static_cast<unsigned long long>(incomplete_candidates));
+            return 2;
+        }
+        return matches ? 0 : 1;
+    }
 
     uint64_t last_ns = 0, draws = 0, dispatches = 0;
     std::map<std::pair<uint32_t, uint32_t>, uint64_t> target_extents;
@@ -285,6 +430,14 @@ int main(int argc, char** argv) {
                                     static_cast<unsigned long long>(depth.backing_writer_size),
                                     static_cast<unsigned long long>(depth.backing_writer_order),
                                     static_cast<unsigned long long>(depth.backing_writer_identity));
+                for (const auto& span : s.target_spans)
+                    std::printf("  target-span draws=%u..%llu target=%ux%u\n",
+                                span.first_draw,
+                                static_cast<unsigned long long>(
+                                    uint64_t{span.first_draw} + span.draw_count - 1),
+                                span.width, span.height);
+                if (s.target_spans_truncated)
+                    std::printf("  target-spans truncated=yes\n");
             } else if (ps <= ds && ps <= xs) {
                 const auto& p = timeline.presents[pi++];
                 std::printf("%llu %.6f present=%llu latest-submit=%llu buffer=%d flip-arg=%lld extent=%ux%u\n",


### PR DESCRIPTION
## Summary
- add timeline v6 compact target-extent spans while preserving v1-v5 reads and bounded/truncation-safe storage
- share one semantic selector between live capture and offline inspection, including dispatch-count bounds
- add `gpu_timeline --signatures` for scene-shape discovery and `--select` for exact predicate validation
- replace stale current-route documentation with the measured Dead Cells gameplay checkpoint while retaining the #608 recipe as historical

## Dead Cells evidence
Two independent 90-second native-speed routes selected sustained gameplay with `91:93 draws + 8 dispatches + 738x420 at draw 80:82`:

- run 1: 2,492 matches, first at 29.532616 s / submit 17,862
- run 2: 2,473 matches, first at 29.509543 s / submit 17,836
- target indices 79 and 83: zero matches
- exact 90 draws: zero matches
- dispatch counts 7 and 9: zero matches

A third live-selector route claimed its first match at 29.203997 s / submit 17,699, exited successfully after installing a 269 MiB capsule, and recorded 93/93 realized draws. `gpu_replay --validate` accepted the realized descriptor contracts.

## Validation
- full native build
- `ctest --output-on-failure` (91/91 passed)
- focused timeline round-trip, malformed-span, selector-positive, positional-negative, dispatch-negative, and truncation tests
- preserved v4 and v5 Dead Cells timelines remain readable
- two fresh v6 route timelines plus one live selected capture
- `git diff --check`

Fixes #594