### PR TITLE
port(win): Windows guest-execution substrate foundation (compile+link, boot not yet verified)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -397,6 +397,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_writer_provenance PRIVATE prosper_core)
   add_test(NAME writer_provenance_ranges COMMAND test_writer_provenance)
 
+  # Windows guest-execution substrate (exec_image_win.cpp): build boot_trace so the whole boot path
+  # links (proves the substrate + SysV-ABI HLE boundary resolve). No evdev/Vulkan here. The guest boot
+  # itself is not yet verified on Windows — see docs/PORTING.md "Windows".
+  if(WIN32)
+    add_executable(boot_trace tools/boot_trace/boot_trace.cpp)
+    target_link_libraries(boot_trace PRIVATE prosper_core)
+  endif()
+
   # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux + macOS/Rosetta).
   if(UNIX)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -296,12 +296,50 @@ This is exactly the hard sub-problem flagged above for both Windows and macOS. P
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
 trap-and-emulate of `%fs:` operands is in-house technology.
 
-## Windows port status (2026-07-13) — foundation landed on `port/windows-core`, boot NOT yet verified
+## Windows port status (2026-07-13) — the guest now BOOTS through module init into guest code
 
-Developed and compile-verified from the macOS machine via the MinGW-w64 cross-compiler (same GCC
-family CI uses), so every compile/link error is caught locally; **runtime is unverified** — no
-Windows machine and no game dump in CI. This is deliberately a *foundation + handoff*, per the plan's
-"native Windows port" step. A Windows-based agent should pick up from the runtime items below.
+The foundation (below) was compile-verified via MinGW-w64; since then a **Windows host has
+runtime-verified the boot**. The guest now links its modules, runs its module-init functions,
+reaches the real entry point, and executes deep guest code — stopping only at the confirmed
+**guest `%fs` TLS wall** (details below). `boot_trace.exe` goes from "crash at the first init fn"
+to a full `RUN ENDED` report. Three runtime bugs were fixed to get here (commits on
+`port/windows-core`):
+
+- **Direct/flexible-memory HLE ported to Win32** (`hle_kernel_mem.cpp` `#else` block). The pool
+  bookkeeping + VA tracker are copied verbatim from POSIX; mappings are backed by private
+  `VirtualAlloc`/`VirtualProtect`/`VirtualFree`. Phys-offset aliasing is NOT preserved (Win32 view
+  granularity is 64 KiB vs the guest's 16 KiB) — fine for Unity/IL2CPP (Messenger), a follow-up for
+  UE4 MallocBinned3. The guest now allocates + maps its pools.
+- **Host→guest SysV call trampoline** (`prosper_call_guest_sysv`). `run_guest_inits` called the guest
+  init fns with a plain C call, which on Windows uses the MS x64 ABI (args in rcx/rdx) while the guest
+  reads SysV (rdi/rsi) — the `module_start` got a garbage `argp` and jumped wild. The asm shim marshals
+  argc→rdi/argp→rsi and preserves the MS callee-saved regs the SysV callee may clobber (rsi/rdi/xmm6-15).
+- **VEH recovery uses `__builtin_setjmp`/`__builtin_longjmp`, not the CRT pair.** The CRT `longjmp`
+  does a full SEH unwind (`RtlUnwindEx`) from the fault site back to `setjmp`, which cannot traverse
+  the guest frame or the hand-written trampoline (no `.pdata`/`.xdata`) → `STATUS_STACK_OVERFLOW`
+  instead of recovery. The `__builtin_*` pair restores rsp/rbp/rip with no unwind (matching Linux).
+  Also: `run_entry` now points `NT_TIB.StackBase/StackLimit` at the switched guest stack during guest
+  execution so exception dispatch on that stack doesn't spuriously report stack exhaustion.
+
+### The Windows frontier: guest `%fs` TLS (confirmed + de-risked)
+
+Boot stops at `eboot+0x808f35`: `mov %fs:0x0,%rax` (a TLS self-pointer load) faulting at
+`addr=0x0`, with **zero Sony imports called yet** — the classic uninitialized-TLS signature. Guest
+`%fs` base is 0 on Windows, so `fs:`-relative reads resolve to low linear addresses.
+
+An FS-base persistence probe (spike 1b) settled the strategy: **user-mode `rdfsbase`/`wrfsbase` work**
+(CR4.FSGSBASE is enabled on Win10 1709+), and immediately after `wrfsbase` the guest TCB reads back
+correctly — **but Windows resets the FS base to 0 across any kernel transition** (a `Sleep(50)` in the
+probe zeroed it). It restores the per-thread FS base from a kernel-saved value on every context
+switch/syscall, and `wrfsbase` doesn't update that saved copy, so "set once and leave it" is unviable.
+
+Viable design (no per-HLE-call swap needed — the *host* uses `%gs`, only the *guest* uses `%fs`, so
+they don't collide, unlike Linux): **set the guest TCB via `wrfsbase` on each guest entry/thread
+start, and in the VEH re-apply `wrfsbase(guest_tcb)` and retry (CONTINUE_EXECUTION, no rip advance)
+whenever an `fs`-prefixed instruction faults with the base reset.** That costs one fault only after a
+kernel transition that lands between two guest `fs` accesses — not per access — so it's cheap. Needs:
+per-thread guest-TCB tracking, a Windows `guest_tls.cpp` TCB setup path, entry `wrfsbase`, and an
+fs-prefix decoder in the VEH (a guard against re-fault loops on genuine null derefs).
 
 **What is done (compiles + links, in CI):**
 - **`exec_image_win.cpp`** — the Win32 sibling of `exec_image_linux.cpp` implementing the full
@@ -322,20 +360,20 @@ Windows machine and no game dump in CI. This is deliberately a *foundation + han
 - `guest_tls.cpp` Windows path (guest `%fs` TLS hard-disabled), `boot_program.cpp` enabled on Windows,
   `boot_trace` built on Windows (no evdev/Vulkan), CI `Windows MinGW` job builds the whole boot path.
 
-**What is left (runtime work, needs a Windows host):**
-1. **Validate/repair the ABI trampoline at runtime.** Integer args are converted; **XMM/float args are
-   not** (e.g. some libc formatters, `printf`-family) — add float-arg conversion if a title needs it.
-   Confirm the shadow-space/alignment and callee-saved handling against real guest→HLE calls.
-2. **Port the direct/flexible-memory HLE.** `hle_kernel_mem.cpp` is still `__linux__`/`__APPLE__`-only
-   (mmap/memfd/futex); Windows gets only the tiny fallback `register_kernel_mem_hle`. The guest's
-   `sceKernelMapDirectMemory`/`MapFlexibleMemory`/`Mprotect` need `VirtualAlloc`/`VirtualProtect` +
-   `CreateFileMapping`/`MapViewOfFile3` for the CPU/GPU-aliased dmem dual mapping. This is the biggest
-   remaining chunk and is required before the guest can allocate memory.
-3. **Guest `%fs` TLS** — the same wall as macOS (see above). Windows gives user mode no reliable FS
-   base; trap/patch the guest `%fs:` accesses (shadPS4 precedent). Until then guest initial-exec TLS
-   reads the host TEB and is wrong.
-4. **VEH recovery hardening** — recovery resumes `longjmp` on the faulting thread's current stack; a
-   stack-overflow fault needs a guard-page/dedicated-stack story (Linux uses `sigaltstack`).
+**What is left (runtime work, on a Windows host):**
+1. **Guest `%fs` TLS — the current blocker.** See "The Windows frontier" above: implement the
+   entry-`wrfsbase` + VEH-retry design. This is the one thing between here and the same
+   HLE-completeness boot depth as Linux.
+2. ~~Port the direct/flexible-memory HLE~~ — **DONE** (private-`VirtualAlloc` port; phys-aliasing
+   deferred for UE4).
+3. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
+   and now runtime-exercised through init; **XMM/float args are still not converted** (e.g. some libc
+   formatters / `printf`-family) — add float-arg conversion when a title needs it.
+4. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
+   current stack; a true stack-overflow fault still needs a guard-page/dedicated-stack story (Linux
+   uses `sigaltstack`). The `__builtin_longjmp` change fixed the cross-frame-unwind crash; this is the
+   separate genuine-overflow case. Also: `PROSPER_CRASHPEEK` faults on Windows (the IL2CPP klass
+   walker needs the same `guest_readable` guards the Linux path has).
 5. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
    and so route correctly through the trampoline, but confirm none are raw host functions relying on
    host-ABI arg passing.

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -296,6 +296,56 @@ This is exactly the hard sub-problem flagged above for both Windows and macOS. P
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
 trap-and-emulate of `%fs:` operands is in-house technology.
 
+## Windows port status (2026-07-13) — foundation landed on `port/windows-core`, boot NOT yet verified
+
+Developed and compile-verified from the macOS machine via the MinGW-w64 cross-compiler (same GCC
+family CI uses), so every compile/link error is caught locally; **runtime is unverified** — no
+Windows machine and no game dump in CI. This is deliberately a *foundation + handoff*, per the plan's
+"native Windows port" step. A Windows-based agent should pick up from the runtime items below.
+
+**What is done (compiles + links, in CI):**
+- **`exec_image_win.cpp`** — the Win32 sibling of `exec_image_linux.cpp` implementing the full
+  `exec_image.hpp` contract: fixed-address guest mapping (`VirtualAlloc` at the guest bases), import
+  stub region, a **Vectored Exception Handler** (VEH) fault handler with SSE4a `INSERTQ`/`EXTRQ`
+  emulation over `CONTEXT.Xmm*`, lazy-ish recovery via a Rip-redirect to a `longjmp` trampoline,
+  `run_entry` (SysV crt0 stack + `jmp`), `run_guest_inits`, the thread-stack registry, and
+  `VirtualQuery`-based region classification. Linux-only diagnostics (perf_event HWBP/HWWATCH, int3
+  `PROSPER_BP`, PEEK/DUMPAT) are intentionally absent.
+- **The SysV⇄MS-x64 ABI boundary** is done in the emitted stub trampoline, NOT via
+  `__attribute__((sysv_abi))` on handlers. The attribute route was tried and **abandoned**: on MinGW
+  it conflicts with SEH-based C++ exception unwinding (`.seh_handlerdata used outside of .seh_proc
+  block`) and cannot be applied to 537 STL-using handlers. Instead `emit_impl` emits a trampoline that
+  converts the guest's SysV integer args (`rdi rsi rdx rcx r8 r9`) to MS x64 (`rcx rdx r8 r9`,
+  `[rsp+0x20]`, `[rsp+0x28]`, +32B shadow, 16-aligned call) before calling the handler, which stays a
+  plain MS-x64 C++ function. Byte encoding disassembly-verified; the register-move ordering is
+  clobber-safe by construction. `PROSPER_SYSV_ABI` (dispatch.hpp) is now an empty documented marker.
+- `guest_tls.cpp` Windows path (guest `%fs` TLS hard-disabled), `boot_program.cpp` enabled on Windows,
+  `boot_trace` built on Windows (no evdev/Vulkan), CI `Windows MinGW` job builds the whole boot path.
+
+**What is left (runtime work, needs a Windows host):**
+1. **Validate/repair the ABI trampoline at runtime.** Integer args are converted; **XMM/float args are
+   not** (e.g. some libc formatters, `printf`-family) — add float-arg conversion if a title needs it.
+   Confirm the shadow-space/alignment and callee-saved handling against real guest→HLE calls.
+2. **Port the direct/flexible-memory HLE.** `hle_kernel_mem.cpp` is still `__linux__`/`__APPLE__`-only
+   (mmap/memfd/futex); Windows gets only the tiny fallback `register_kernel_mem_hle`. The guest's
+   `sceKernelMapDirectMemory`/`MapFlexibleMemory`/`Mprotect` need `VirtualAlloc`/`VirtualProtect` +
+   `CreateFileMapping`/`MapViewOfFile3` for the CPU/GPU-aliased dmem dual mapping. This is the biggest
+   remaining chunk and is required before the guest can allocate memory.
+3. **Guest `%fs` TLS** — the same wall as macOS (see above). Windows gives user mode no reliable FS
+   base; trap/patch the guest `%fs:` accesses (shadPS4 precedent). Until then guest initial-exec TLS
+   reads the host TEB and is wrong.
+4. **VEH recovery hardening** — recovery resumes `longjmp` on the faulting thread's current stack; a
+   stack-overflow fault needs a guard-page/dedicated-stack story (Linux uses `sigaltstack`).
+5. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
+   and so route correctly through the trampoline, but confirm none are raw host functions relying on
+   host-ABI arg passing.
+
+**Reproducing the local compile loop (macOS → Windows):** `brew install mingw-w64`, then
+`cmake -S prosper -B build-win -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
+-DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows
+-DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE` and `cmake --build build-win`. A Windows agent builds
+natively under MSYS2/UCRT64 exactly as the CI `Windows MinGW` job does.
+
 ## Proposed sequence
 
 1. **Spikes (hours each, no commitment):**

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -321,25 +321,36 @@ to a full `RUN ENDED` report. Three runtime bugs were fixed to get here (commits
   Also: `run_entry` now points `NT_TIB.StackBase/StackLimit` at the switched guest stack during guest
   execution so exception dispatch on that stack doesn't spuriously report stack exhaustion.
 
-### The Windows frontier: guest `%fs` TLS (confirmed + de-risked)
+### Guest `%fs` TLS — SOLVED (FSGSBASE + VEH re-apply)
 
-Boot stops at `eboot+0x808f35`: `mov %fs:0x0,%rax` (a TLS self-pointer load) faulting at
-`addr=0x0`, with **zero Sony imports called yet** — the classic uninitialized-TLS signature. Guest
-`%fs` base is 0 on Windows, so `fs:`-relative reads resolve to low linear addresses.
+Was: boot stopped at `eboot+0x808f35` (`mov %fs:0x0,%rax` faulting at `addr=0x0`, zero Sony imports
+called) — uninitialized guest initial-exec TLS, guest `%fs` base 0 on Windows. An FS-base probe
+settled the strategy: **user-mode `rdfsbase`/`wrfsbase` work** (CR4.FSGSBASE, Win10 1709+), but
+**Windows resets the user FS base to 0 on every kernel transition** (a `Sleep()` zeroed it; it
+restores the thread's kernel-saved base and `wrfsbase` doesn't update that copy), so "set once" is
+impossible. Unlike Linux, the *host* uses `%gs` and only the *guest* uses `%fs`, so no per-HLE-call
+swap is needed.
 
-An FS-base persistence probe (spike 1b) settled the strategy: **user-mode `rdfsbase`/`wrfsbase` work**
-(CR4.FSGSBASE is enabled on Win10 1709+), and immediately after `wrfsbase` the guest TCB reads back
-correctly — **but Windows resets the FS base to 0 across any kernel transition** (a `Sleep(50)` in the
-probe zeroed it). It restores the per-thread FS base from a kernel-saved value on every context
-switch/syscall, and `wrfsbase` doesn't update that saved copy, so "set once and leave it" is unviable.
+Implemented: a real Windows `guest_tls.cpp` TCB (Variant-II layout, `VirtualAlloc`-backed, self-ptr +
+magic + guest canary), `wrfsbase(TP)` on each guest entry/thread start, and a VEH hook that re-applies
+`wrfsbase(TP)` and retries whenever an `fs`-prefixed instruction faults with the base drifted (one
+fault per kernel-transition boundary, not per access; a loop guard only re-applies when the base
+actually changed). `PROSPER_NO_GUEST_FS=1` reverts to the old wall, confirming this is the enabler.
+Result: boot advances far past the wall into deep guest code.
 
-Viable design (no per-HLE-call swap needed — the *host* uses `%gs`, only the *guest* uses `%fs`, so
-they don't collide, unlike Linux): **set the guest TCB via `wrfsbase` on each guest entry/thread
-start, and in the VEH re-apply `wrfsbase(guest_tcb)` and retry (CONTINUE_EXECUTION, no rip advance)
-whenever an `fs`-prefixed instruction faults with the base reset.** That costs one fault only after a
-kernel transition that lands between two guest `fs` accesses — not per access — so it's cheap. Needs:
-per-thread guest-TCB tracking, a Windows `guest_tls.cpp` TCB setup path, entry `wrfsbase`, and an
-fs-prefix decoder in the VEH (a guard against re-fault loops on genuine null derefs).
+### The Windows frontier: a deep, nondeterministic guest crash
+
+With `%fs` TLS in, boot reaches a much deeper guest crash — `eboot+0x17968cd`, a 9-frame guest
+backtrace, faulting on a **high mapped guest address** (not null), and it is **nondeterministic**
+(some runs `RUN ENDED` cleanly, some hard-fault / trip the Windows heap check). Prime suspects, in
+order: (1) the **deferred phys-aliasing** in the memory HLE — the guest may map one phys offset at two
+VAs expecting shared bytes, but Win32 gives it two private `VirtualAlloc` buffers, so writes through
+one VA aren't seen through the other; (2) **ASLR** — guest `VirtualAlloc` bases vary per run, so a
+guest assumption about layout would fault differently each time (a fixed-base reservation would make
+runs reproducible); (3) an HLE behavior only now reached. Next step: make the guest mapping
+deterministic (fixed base) to get a reproducible crash, then decide whether phys-aliasing must be
+implemented (the 64 KiB-granularity `CreateFileMapping`/`MapViewOfFile3` section approach) for this
+title.
 
 **What is done (compiles + links, in CI):**
 - **`exec_image_win.cpp`** — the Win32 sibling of `exec_image_linux.cpp` implementing the full
@@ -357,24 +368,26 @@ fs-prefix decoder in the VEH (a guard against re-fault loops on genuine null der
   `[rsp+0x20]`, `[rsp+0x28]`, +32B shadow, 16-aligned call) before calling the handler, which stays a
   plain MS-x64 C++ function. Byte encoding disassembly-verified; the register-move ordering is
   clobber-safe by construction. `PROSPER_SYSV_ABI` (dispatch.hpp) is now an empty documented marker.
-- `guest_tls.cpp` Windows path (guest `%fs` TLS hard-disabled), `boot_program.cpp` enabled on Windows,
-  `boot_trace` built on Windows (no evdev/Vulkan), CI `Windows MinGW` job builds the whole boot path.
+- `guest_tls.cpp` Windows path (guest `%fs` TLS now IMPLEMENTED via FSGSBASE — see above),
+  `boot_program.cpp` enabled on Windows, `boot_trace` built on Windows (no evdev/Vulkan), CI
+  `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **Guest `%fs` TLS — the current blocker.** See "The Windows frontier" above: implement the
-   entry-`wrfsbase` + VEH-retry design. This is the one thing between here and the same
-   HLE-completeness boot depth as Linux.
+1. **The deep nondeterministic guest crash — the current blocker.** See "The Windows frontier" above:
+   make guest mappings deterministic (fixed base) for a reproducible crash, then likely implement
+   phys-aliasing in the memory HLE (`CreateFileMapping`/`MapViewOfFile3`, 64 KiB granularity).
 2. ~~Port the direct/flexible-memory HLE~~ — **DONE** (private-`VirtualAlloc` port; phys-aliasing
-   deferred for UE4).
-3. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
+   deferred — now a prime suspect for item 1).
+3. ~~Guest `%fs` TLS~~ — **DONE** (FSGSBASE + VEH re-apply; see above).
+4. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
    and now runtime-exercised through init; **XMM/float args are still not converted** (e.g. some libc
    formatters / `printf`-family) — add float-arg conversion when a title needs it.
-4. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
+5. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
    current stack; a true stack-overflow fault still needs a guard-page/dedicated-stack story (Linux
    uses `sigaltstack`). The `__builtin_longjmp` change fixed the cross-frame-unwind crash; this is the
    separate genuine-overflow case. Also: `PROSPER_CRASHPEEK` faults on Windows (the IL2CPP klass
    walker needs the same `guest_readable` guards the Linux path has).
-5. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
+6. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
    and so route correctly through the trampoline, but confirm none are raw host functions relying on
    host-ABI arg passing.
 

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -142,6 +142,14 @@ uint64_t guest_tls_activate_thread();   // per guest thread at entry; returns gu
 void guest_fs_enter_host_for_signal();  // crash-signal-handler entry: swap guest %fs -> host %fs (no-op if not guest TCB)
 uint64_t guest_fs_to_host_scoped();     // diagnostic handler (returns to guest): swap to host %fs, return prev fs
 void guest_fs_restore_scoped(uint64_t prev_fs);  // restore the fs returned by guest_fs_to_host_scoped
+// This thread's guest TP (0 if guest-fs not active on it). On Windows the fault handler queries this
+// to detect a drifted FS base (Windows zeroes the user FS base on every kernel transition).
+uint64_t guest_fs_current_tp();
+// If guest-fs is active on this thread and the live FS base has drifted from the guest TP, re-apply
+// wrfsbase(guest TP) and return true; else false. The Windows VEH calls this to transparently retry a
+// faulting guest %fs access after the OS reset the base. Returns false when the base is already
+// correct (so a genuine fault at an fs-relative insn is NOT retried forever). No-op → false on Linux.
+bool guest_fs_reapply();
 // Diagnostic (test): the Variant II static-TLS distance below the thread pointer for module id
 // `modid`, and the total below TP — verifies the per-module PT_TLS p_align layout (#143). Linux-only.
 uint64_t guest_tls_module_below(uint32_t modid);

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -13,8 +13,23 @@
 
 namespace prosper {
 
+// Guest↔host calling-convention boundary. The guest is always System V AMD64 (PS5/FreeBSD ABI).
+// On Linux/macOS the host is *also* SysV, so an HLE handler is a plain C function the guest calls
+// directly. On Windows the host ABI is Microsoft x64, so every function the guest calls directly —
+// the HLE handlers and any host callback the guest invokes — MUST be tagged SysV, or the six
+// integer args (guest: rdi/rsi/rdx/rcx/r8/r9) are read from the wrong registers (MS: rcx/rdx/r8/r9
+// + stack). PROSPER_SYSV_ABI is that tag: `__attribute__((sysv_abi))` on Windows, empty elsewhere.
+// See docs/PORTING.md "Windows". NOTE: we do NOT tag handlers `__attribute__((sysv_abi))` on
+// Windows — that conflicts with SEH-based C++ exception unwinding in MinGW ("`.seh_handlerdata`
+// used outside of `.seh_proc` block"), and 537 STL-using handlers can't all drop exceptions.
+// Instead the guest↔host ABI conversion is done in the emitted import-stub trampoline
+// (exec_image_win.cpp emit_impl/emit_unimpl), so every handler stays a plain host function.
+// PROSPER_SYSV_ABI is therefore empty on all platforms today; it is kept as the single documented
+// marker of the boundary in case a future toolchain makes the attribute viable.
+#define PROSPER_SYSV_ABI
+
 // Generic HLE handler signature (up to 6 integer/pointer args, SysV).
-using HleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+using HleFn = PROSPER_SYSV_ABI uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 
 // One unresolved import across the whole linked program (deduped by NID). Its index
 // is the stub slot number; the trap logger names calls via this table.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -45,7 +45,7 @@ extern "C" void prosper_label_hist_wait_built(uint64_t addr, uint64_t cb);
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 
 namespace {

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -23,7 +23,7 @@
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define P(x) ((void*)(uintptr_t)(x))
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -33,7 +33,7 @@
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define P(x) ((void*)(uintptr_t)(x))
 #define CS(x) ((const char*)(uintptr_t)(x))

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -27,7 +27,7 @@
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 
 namespace {
@@ -567,7 +567,7 @@ uint64_t glog_impl(const char* nid, void* ra,
     return 0;
 }
 template <size_t I>
-__attribute__((noinline)) uint64_t glog_thunk(uint64_t a0, uint64_t a1, uint64_t a2,
+__attribute__((noinline)) PROSPER_SYSV_ABI uint64_t glog_thunk(uint64_t a0, uint64_t a1, uint64_t a2,
                                               uint64_t a3, uint64_t a4, uint64_t a5) {
     return glog_impl(kAgcNids[I], __builtin_return_address(0), a0, a1, a2, a3, a4, a5);
 }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -49,7 +49,7 @@ namespace { bool sclog() { static int v = getenv("PROSPER_SYNCLOG") ? 1 : 0; ret
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 
 // --- mutex attributes (opaque; we back with host pthread_mutexattr_t) ---

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -33,7 +33,7 @@
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 
 namespace {
@@ -1147,7 +1147,7 @@ void register_kernel_mem_hle() {
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 
 namespace {

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1137,18 +1137,405 @@ void register_kernel_mem_hle() {
 } // namespace prosper
 
 #else
+// ============================================================================================
+// Windows backing (Win32 VirtualAlloc/VirtualProtect). Sibling of the POSIX impl above.
+//
+// PS5 memory model (identical to the Linux path): reserve a virtual range, allocate "direct"
+// (physical) memory as an opaque pool offset, then map it — or flexible memory — into VA. The
+// direct-memory POOL BOOKKEEPING (dmem_take / g_dmem) and the VA TRACKER (g_maps) are pure
+// logic COPIED VERBATIM from the Linux path so VirtualQuery/DirectMemoryQuery stay truthful and
+// the allocator's first-fit/window semantics match byte-for-byte.
+//
+// What DIFFERS: the OS primitives. Linux uses mmap over a shared memfd so a phys offset can be
+// mapped at two VAs that ALIAS the same bytes (unified-physical-memory contract, needed by UE4
+// PPSA17942 MallocBinned3). Win32 file-mapping views are hard-limited to 64 KiB granularity for
+// both base address and file offset, but the guest maps at 16 KiB — so a faithful section-based
+// alias is a larger follow-up (tracked separately, area:ue4). Here we back every mapping with
+// PRIVATE committed VirtualAlloc memory: aliasing is NOT preserved, but the Messenger (Unity/
+// IL2CPP) never re-aliases a phys offset, so this unblocks its Windows boot. VirtualAlloc
+// zero-fills committed pages, so the console's fresh-pages-read-zero contract holds for free
+// (no dmem_zero needed). CONFIDENCE: HIGH for private-memory correctness on non-aliasing guests;
+// the aliasing gap is documented and will break MallocBinned3 on Windows until the section port.
+// ============================================================================================
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #include <atomic>
 #include <chrono>
 #include <climits>
 #include <condition_variable>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <mutex>
+#include <vector>
 
 namespace prosper {
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
+
+namespace {
+    bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
+    #define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
+
+    // --- VA tracker + direct-memory pool: PURE logic, copied verbatim from the Linux path -----
+    struct Mapping { uint64_t base, size; int prot; bool committed; char name[32]; };
+    std::mutex g_mx;
+    std::vector<Mapping> g_maps;
+    constexpr uint64_t kDmemBase  = 0x10000000;
+    constexpr uint64_t kDmemTotal = 8ull * 1024 * 1024 * 1024;   // 8 GiB pool
+    struct DMem { uint64_t start, end; int type; };
+    std::mutex g_dmx;
+    std::vector<DMem> g_dmem;
+
+    // First-fit claim of `sz` bytes at `align` within [lo,hi) — identical to the Linux allocator.
+    bool dmem_take(uint64_t sz, uint64_t align, int type, uint64_t& off_out,
+                   uint64_t lo = 0, uint64_t hi = ~0ull) {
+        if (!align) align = 0x4000;
+        if (lo < kDmemBase) lo = kDmemBase;
+        if (hi > kDmemBase + kDmemTotal) hi = kDmemBase + kDmemTotal;
+        if (lo >= hi) return false;
+        std::lock_guard<std::mutex> lk(g_dmx);
+        uint64_t cursor = kDmemBase;
+        size_t insert_at = 0;
+        for (size_t i = 0; i <= g_dmem.size(); i++) {
+            uint64_t gap_beg = cursor;
+            uint64_t gap_end = (i < g_dmem.size()) ? g_dmem[i].start : kDmemBase + kDmemTotal;
+            uint64_t beg = gap_beg < lo ? lo : gap_beg;
+            uint64_t end = gap_end > hi ? hi : gap_end;
+            uint64_t off = (beg + align - 1) & ~(align - 1);
+            if (off + sz <= end) { insert_at = i; off_out = off; goto found; }
+            if (i < g_dmem.size()) cursor = g_dmem[i].end;
+        }
+        return false;
+    found:
+        g_dmem.insert(g_dmem.begin() + insert_at, { off_out, off_out + sz, type });
+        return true;
+    }
+    void dmem_largest_free(uint64_t lo, uint64_t hi, uint64_t align, uint64_t& off_out, uint64_t& size_out) {
+        if (!align) align = 0x4000;
+        if (lo < kDmemBase) lo = kDmemBase;
+        if (hi > kDmemBase + kDmemTotal) hi = kDmemBase + kDmemTotal;
+        off_out = 0; size_out = 0;
+        std::lock_guard<std::mutex> lk(g_dmx);
+        uint64_t cursor = kDmemBase;
+        for (size_t i = 0; i <= g_dmem.size(); i++) {
+            uint64_t gap_beg = cursor;
+            uint64_t gap_end = (i < g_dmem.size()) ? g_dmem[i].start : kDmemBase + kDmemTotal;
+            uint64_t beg = gap_beg < lo ? lo : gap_beg;
+            uint64_t end = gap_end > hi ? hi : gap_end;
+            uint64_t aligned = (beg + align - 1) & ~(align - 1);
+            if (end > aligned && end - aligned > size_out) { off_out = aligned; size_out = end - aligned; }
+            if (i < g_dmem.size()) cursor = g_dmem[i].end;
+        }
+    }
+    void dmem_release(uint64_t start, uint64_t len) {
+        uint64_t end = start + len;
+        std::lock_guard<std::mutex> lk(g_dmx);
+        std::vector<DMem> out;
+        out.reserve(g_dmem.size());
+        for (auto& d : g_dmem) {
+            if (d.end <= start || d.start >= end) { out.push_back(d); continue; }
+            if (d.start < start) out.push_back({ d.start, start, d.type });
+            if (d.end > end)     out.push_back({ end, d.end, d.type });
+        }
+        g_dmem.swap(out);
+    }
+    void track(uint64_t base, uint64_t size, int prot, bool committed, const char* nm) {
+        std::lock_guard<std::mutex> lk(g_mx);
+        Mapping m{ base, size, prot, committed, {0} };
+        if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
+        g_maps.push_back(m);
+    }
+    void untrack(uint64_t base, uint64_t len) {
+        if (!len) return;
+        uint64_t end = base + len;
+        std::lock_guard<std::mutex> lk(g_mx);
+        std::vector<Mapping> out;
+        out.reserve(g_maps.size() + 1);
+        for (auto& m : g_maps) {
+            uint64_t me = m.base + m.size;
+            if (me <= base || m.base >= end) { out.push_back(m); continue; }
+            if (m.base < base) { Mapping lo = m; lo.size = base - m.base; out.push_back(lo); }
+            if (me > end)      { Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi); }
+        }
+        g_maps.swap(out);
+    }
+    void retrack_prot(uint64_t base, uint64_t len, int prot, const char* nm) {
+        if (!len) return;
+        untrack(base, len);
+        track(base, len, prot, true, nm);
+    }
+    const Mapping* find(uint64_t addr) {
+        std::lock_guard<std::mutex> lk(g_mx);
+        const Mapping* best = nullptr;
+        for (auto& m : g_maps)
+            if (addr >= m.base && addr < m.base + m.size)
+                if (!best || m.base > best->base) best = &m;
+        return best;
+    }
+    uint64_t next_base(uint64_t addr) {
+        std::lock_guard<std::mutex> lk(g_mx);
+        uint64_t n = 0;
+        for (auto& m : g_maps)
+            if (m.base > addr && (n == 0 || m.base < n)) n = m.base;
+        return n;
+    }
+    uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
+
+    // Guest Orbis protection bits (READ=1, WRITE=2 [implies read], EXEC=4). WRITE implies READ,
+    // and prot 0 is a legitimate no-access guard page (matches the Linux host_prot #342 fix).
+    enum { HP_R = 1, HP_W = 2, HP_X = 4 };
+    int host_prot(uint64_t p) {
+        int hp = 0;
+        if (p & 0x1) hp |= HP_R;
+        if (p & 0x2) hp |= HP_R | HP_W;
+        if (p & 0x4) hp |= HP_X;
+        return hp;   // p == 0 -> no access
+    }
+    // --- Win32 OS primitives (the platform-specific half) -------------------------------------
+    DWORD win_page_prot(int hp) {
+        bool w = hp & HP_W, r = hp & HP_R, x = hp & HP_X;
+        if (x) return w ? PAGE_EXECUTE_READWRITE : (r ? PAGE_EXECUTE_READ : PAGE_EXECUTE);
+        if (w) return PAGE_READWRITE;
+        if (r) return PAGE_READONLY;
+        return PAGE_NOACCESS;
+    }
+    // Commit `len` at `hint` (0 = OS chooses). Handles BOTH the guest's reserve-then-commit flow
+    // (ReserveVirtualRange did MEM_RESERVE; commit within it) AND a fresh map, by trying MEM_COMMIT
+    // first (succeeds only over an existing reservation) then MEM_RESERVE|MEM_COMMIT.
+    void* win_commit(uint64_t hint, uint64_t len, int hp) {
+        DWORD pp = win_page_prot(hp);
+        if (!hint) return VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
+        if (void* p = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_COMMIT, pp)) return p;
+        return VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
+    }
+    // Reserve (no commit). VirtualAlloc reservations are 64 KiB-aligned, satisfying guest aligns
+    // up to 64 KiB; larger alignment is logged and left to the OS base (follow-up).
+    void* win_reserve(uint64_t hint, uint64_t len, bool fixed, uint64_t align) {
+        if (align > 0x10000)
+            MLOG("reserve align=0x%llx > 64KiB not honored on Win32 (OS 64KiB base)\n",
+                 (unsigned long long)align);
+        if (hint) {
+            if (void* p = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE, PAGE_NOACCESS)) return p;
+            if (fixed) return nullptr;   // SCE_KERNEL_MAP_FIXED: must be exactly this address
+        }
+        return VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE, PAGE_NOACCESS);
+    }
+    bool win_protect(uint64_t addr, uint64_t len, int hp) {
+        DWORD old = 0;
+        return VirtualProtect((void*)addr, (SIZE_T)len, win_page_prot(hp), &old) != 0;
+    }
+    // Decommit (partial-safe; keeps any surrounding reservation). A full MEM_RELEASE needs the
+    // exact allocation base with size 0, which we don't track, so decommit is the safe general op.
+    void win_unmap(uint64_t addr, uint64_t len) {
+        if (addr && len) VirtualFree((void*)addr, (SIZE_T)len, MEM_DECOMMIT);
+    }
+} // namespace
+
+// Fault-handler lazy-commit probe parity (Linux exports this for its SIGSEGV handler). We commit
+// eagerly on Win32 so the VEH handler never needs lazy commit, but expose the symbol identically
+// in case the shared fault path references it: 0 = untracked, 1 = reserved, 2 = committed.
+extern "C" int prosper_reserved_range_state(uint64_t addr) {
+    std::lock_guard<std::mutex> lk(g_mx);
+    const Mapping* best = nullptr;
+    for (auto& m : g_maps)
+        if (addr >= m.base && addr < m.base + m.size)
+            if (!best || m.base > best->base) best = &m;
+    return best ? (best->committed ? 2 : 1) : 0;
+}
+
+// --- Handlers: Win32 versions of the Linux memory HLE, same Sony contracts -------------------
+
+// sceKernelReserveVirtualRange(void** addrInOut, size_t len, int flags, size_t align)
+HLE(k_reserve_vrange) {
+    uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
+    uint64_t align = a3 ? a3 : 0x4000;
+    const bool fixed = (a2 & 0x10) != 0;   // SCE_KERNEL_MAP_FIXED
+    if (!a1) return 0x80020016ull;         // EINVAL (len 0)
+    // Idempotent re-reserve of our own uncommitted range (Linux #115 parity).
+    if (hint) {
+        bool ours = false;
+        { std::lock_guard<std::mutex> lk(g_mx);
+          for (auto& m : g_maps)
+              if (!m.committed && hint >= m.base && hint < m.base + m.size) { ours = true; break; } }
+        if (ours) { if (a0) *(uint64_t*)a0 = hint;
+                    MLOG("reserve hint=0x%llx re-reserve-of-own-range -> OK\n", (unsigned long long)hint);
+                    return 0; }
+    }
+    void* p = win_reserve(hint, a1, fixed, align);
+    if (!p) { MLOG("reserve hint=0x%llx len=0x%llx FAILED\n",
+                   (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
+    if (a0) *(uint64_t*)a0 = (uint64_t)p;
+    track((uint64_t)p, a1, 0, false, "reserved");
+    MLOG("reserve -> 0x%llx len=0x%llx flags=0x%llx align=0x%llx\n",
+         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a2, (unsigned long long)align);
+    return 0;
+}
+
+// sceKernelMapNamedFlexibleMemory(void** addrInOut, size_t len, int prot, int flags, const char* name)
+HLE(k_map_flexible) {
+    uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
+    void* p = win_commit(hint, a1, host_prot(a2));
+    if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n",
+                   (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; }
+    if (a0) *(uint64_t*)a0 = (uint64_t)p;
+    track((uint64_t)p, a1, host_prot(a2), true, a4 ? (const char*)a4 : "flexible");
+    MLOG("mapflexible -> 0x%llx len=0x%llx prot=0x%llx\n",
+         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a2);
+    return 0;
+}
+HLE(k_map_flexible_noname) { return k_map_flexible(a0, a1, a2, a3, 0, 0); }
+
+// sceKernelAvailableFlexibleMemorySize(size_t* sizeOut) — 512 MiB budget (shadPS4 parity).
+HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0 = 512ull * 1024 * 1024; return 0; }
+
+// sceKernelAllocateDirectMemory(start, end, len, align, memType, off_t* physOut)
+HLE(k_alloc_dmem) {
+    uint64_t align = a3 ? a3 : 0x4000;
+    uint64_t sz = align_up(a2, align);
+    uint64_t off;
+    if (!dmem_take(sz, align, (int)a4, off, a0, a1 ? a1 : ~0ull)) {
+        MLOG("alloc_dmem len=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
+             (unsigned long long)a2, (unsigned long long)a0, (unsigned long long)a1);
+        return 0x8002000Cull;
+    }
+    if (a5 > 0xffff) *(uint64_t*)a5 = off;
+    MLOG("alloc_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a2, (unsigned long long)off);
+    return 0;
+}
+// sceKernelAllocateMainDirectMemory(len, align, memType, off_t* physOut) — physOut at arg3.
+HLE(k_alloc_main_dmem) {
+    uint64_t align = a1 ? a1 : 0x4000;
+    uint64_t sz = align_up(a0, align);
+    uint64_t off;
+    if (!dmem_take(sz, align, (int)a2, off)) {
+        MLOG("alloc_main_dmem len=0x%llx -> ENOMEM\n", (unsigned long long)a0);
+        return 0x8002000Cull;
+    }
+    if (a3 > 0xffff) *(uint64_t*)a3 = off;
+    MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
+    return 0;
+}
+
+// sceKernelDirectMemoryQuery(off_t offset, int flags, info*, size_t infoSize)
+HLE(k_direct_memory_query) {
+    if (!a2) return 0x80020016ull;
+    uint8_t* info = (uint8_t*)a2;
+    uint64_t sz = a3 ? (a3 > 0x18 ? 0x18 : a3) : 0x18;
+    memset(info, 0, sz);
+    std::lock_guard<std::mutex> lk(g_dmx);
+    const DMem* hit = nullptr; const DMem* next = nullptr;
+    for (auto& d : g_dmem) {
+        if (a0 >= d.start && a0 < d.end) { if (!hit || d.start > hit->start) hit = &d; }
+        if (d.start > a0 && (!next || d.start < next->start)) next = &d;
+    }
+    const DMem* r = hit ? hit : ((a1 & 1) ? next : nullptr);
+    if (!r) return 0x8002000eull;
+    if (sz >= 0x08) *(uint64_t*)(info + 0x00) = r->start;
+    if (sz >= 0x10) *(uint64_t*)(info + 0x08) = r->end;
+    if (sz >= 0x14) *(int32_t*)(info + 0x10) = r->type;
+    return 0;
+}
+
+// sceKernelMapDirectMemory(void** addrInOut, len, prot, flags, off_t phys, size_t align)
+HLE(k_map_dmem) {
+    uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
+    void* p = win_commit(hint, a1, host_prot(a2));   // private memory: phys (a4) not aliased (see banner)
+    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n",
+                   (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; }
+    if (a0) *(uint64_t*)a0 = (uint64_t)p;
+    track((uint64_t)p, a1, host_prot(a2), true, "direct");
+    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx\n",
+         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4);
+    return 0;
+}
+
+HLE(k_munmap)   { if (!a1) return 0x80020016ull;
+                  if (a0) { win_unmap(a0, a1); untrack(a0, a1); } return 0; }
+HLE(k_mprotect) { if (a0) { win_protect(a0, a1, host_prot(a2)); retrack_prot(a0, a1, host_prot(a2), "mprotect"); } return 0; }
+HLE(k_mtypeprotect) { if (a0) { win_protect(a0, a1, host_prot(a3)); retrack_prot(a0, a1, host_prot(a3), "mtypeprotect"); } return 0; }
+HLE(k_dmem_size){ return kDmemTotal; }
+// sceKernelAvailableDirectMemorySize(searchStart, searchEnd, align, off_t* physOut, size_t* sizeOut)
+HLE(k_avail_dmem) {
+    if (!a3 || !a4) return 0x80020016ull;
+    uint64_t off = 0, size = 0;
+    dmem_largest_free(a0, a1 ? a1 : (kDmemBase + kDmemTotal), a2, off, size);
+    if (!size) return 0x8002000Cull;
+    *(uint64_t*)(uintptr_t)a3 = off;
+    *(uint64_t*)(uintptr_t)a4 = size;
+    return 0;
+}
+HLE(k_release_dmem) { dmem_release(a0, a1); return 0; }
+
+// sceKernelBatchMap(entries, num, int* numOut) — entry 0x20 bytes: start@0, phys@8, len@0x10,
+// prot@0x18(char), type@0x19, op@0x1c. Ops: 0=MAP_DIRECT 1=UNMAP 2=PROTECT 3=MAP_FLEXIBLE 4=TYPE_PROTECT.
+HLE(k_batch_map) {
+    const uint8_t* e = (const uint8_t*)(uintptr_t)a0;
+    int n = (int)(int64_t)a1, done = 0;
+    if (!e || n < 0) return 0x80020016ull;
+    uint64_t ret = 0;
+    for (int i = 0; i < n; i++, e += 0x20) {
+        uint64_t start = *(const uint64_t*)(e + 0x00);
+        uint64_t len   = *(const uint64_t*)(e + 0x10);
+        uint8_t  prot  = e[0x18];
+        int32_t  op    = *(const int32_t*)(e + 0x1c);
+        bool ok = true;
+        switch (op) {
+            case 0: case 3: {                       // MAP_DIRECT / MAP_FLEXIBLE (private-backed on Win32)
+                void* p = win_commit(start, len, host_prot(prot));
+                ok = (p != nullptr);
+                if (ok) track((uint64_t)p, len, host_prot(prot), true, op == 0 ? "batch-direct" : "batch-flex");
+                break;
+            }
+            case 1: if (start) { win_unmap(start, len); untrack(start, len); } break;   // UNMAP
+            case 2: case 4:                                                              // PROTECT / TYPE_PROTECT
+                if (start) { win_protect(start, len, host_prot(prot));
+                             retrack_prot(start, len, host_prot(prot), "batch-prot"); } break;
+            default: ok = false; ret = 0x80020016ull; break;
+        }
+        if (!ok) { if (!ret) ret = 0x8002000Cull; break; }
+        done++;
+    }
+    if (a2) *(int32_t*)(uintptr_t)a2 = done;
+    MLOG("batchmap n=%d done=%d -> 0x%llx\n", n, done, (unsigned long long)ret);
+    return ret;
+}
+
+// sceKernelVirtualQuery(addr, flags, info*, infoSize): 0x00 start;0x08 end;0x18 i32 prot;0x20 u32 flags;0x24 name[32]
+HLE(k_virtual_query) {
+    if (!a2) return 0x80020016ull;
+    uint8_t* info = (uint8_t*)a2;
+    uint64_t sz = a3 ? (a3 > 0x48 ? 0x48 : a3) : 0x48;
+    memset(info, 0, sz);
+    const Mapping* m = find(a0);
+    uint64_t start, end; int prot; uint32_t flags;
+    if (m) {
+        start = m->base; end = m->base + m->size;
+        prot = m->committed ? 0x3 : 0x0; flags = m->committed ? 0x10 : 0x0;
+    } else {
+        uint64_t nb = next_base(a0);
+        if (!nb) return 0x8002000eull;
+        start = a0 & ~(uint64_t)0x3fff; end = nb; prot = 0; flags = 0;
+    }
+    if (sz >= 0x08) *(uint64_t*)(info + 0x00) = start;
+    if (sz >= 0x10) *(uint64_t*)(info + 0x08) = end;
+    if (sz >= 0x1c) *(int32_t*)(info + 0x18) = prot;
+    if (sz >= 0x24) *(uint32_t*)(info + 0x20) = flags;
+    if (sz >= 0x44 && m && m->name[0]) memcpy(info + 0x24, m->name, 32);
+    return 0;
+}
+
+// libSceAmpr / APR command-buffer trio + teardown. These commit UE4 (PPSA17942, area:ue4)
+// allocator pages; that title does not boot on Windows yet, so no-op stubs are correct here
+// (the Linux path models them). Registered by raw NID for parity.
+HLE(k_ampr_ok) { return 0; }
 
 namespace {
 std::mutex g_sync_mx;
@@ -1192,8 +1579,44 @@ HLE(k_wake_by_address) {
 }
 
 void register_kernel_mem_hle() {
+    #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
+    R("sceKernelReserveVirtualRange", k_reserve_vrange);
+    R("sceKernelMapNamedFlexibleMemory", k_map_flexible);
+    R("sceKernelMapFlexibleMemory", k_map_flexible_noname);
+    Hle::register_fn("4h6F1LLbTiw", (HleFn)k_map_flexible_noname, "sceKernelMapFlexibleMemoryInternal");
+    R("sceKernelAvailableFlexibleMemorySize", k_avail_flexible);
+    R("sceKernelAllocateDirectMemory", k_alloc_dmem);
+    R("sceKernelAllocateMainDirectMemory", k_alloc_main_dmem);
+    R("sceKernelMapDirectMemory", k_map_dmem);
+    R("sceKernelMapNamedDirectMemory", k_map_dmem);
+    R("sceKernelMunmap", k_munmap);
+    R("sceKernelReleaseFlexibleMemory", k_munmap);
+    R("sceKernelMprotect", k_mprotect);
+    R("sceKernelMtypeprotect", k_mtypeprotect);
+    R("sceKernelReleaseDirectMemory", k_release_dmem);
+    R("sceKernelCheckedReleaseDirectMemory", k_release_dmem);
+    R("sceKernelBatchMap", k_batch_map);
+    R("sceKernelBatchMap2", k_batch_map);
+    R("sceKernelVirtualQuery", k_virtual_query);
+    R("sceKernelDirectMemoryQuery", k_direct_memory_query);
+    R("sceKernelGetDirectMemorySize", k_dmem_size);
+    R("sceKernelAvailableDirectMemorySize", k_avail_dmem);
+    #undef R
     Hle::register_fn("Hc4CaR6JBL0", (HleFn)k_wait_on_address, "sceKernelWaitOnAddress?");
     Hle::register_fn("q2y-wDIVWZA", (HleFn)k_wake_by_address, "sceKernelWakeByAddress?");
+    // libSceAmpr / APR command-buffer trio + teardown — no-op stubs on Windows (area:ue4).
+    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_ok, "sceAmprCommandBufferConstructor");
+    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferConstructor");
+    Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_ok, "sceAmprCommandBufferSetBuffer");
+    Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_ok, "sceAmprCommandBufferReset");
+    Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_ok, "sceAmprCommandBufferClearBuffer");
+    Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_ok, "sceAmprCommandBufferGetSize");
+    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferDestructor");
+    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_ok, "sceAmprCommandBufferDestructor");
+    Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_ok, "AprSetEventQueue?");
+    Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_ok, "AprCbSetEventQueue?");
+    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_ok, "AprSubmitCommandBuffer?");
+    Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_ok, "AmprUnknown3");
 }
 
 } // namespace prosper

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -27,7 +27,7 @@
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define P(x) ((void*)(uintptr_t)(x))
 

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -88,7 +88,7 @@ static void* aligned_alloc_portable(size_t align, size_t size) {
 namespace prosper {
 
 // All handlers use the full 6-arg HLE signature; extras are ignored (SysV-safe).
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define P(x) ((void*)(uintptr_t)(x))
 #define CP(x) ((const void*)(uintptr_t)(x))

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -33,7 +33,7 @@ namespace prosper {
 
 using namespace prosper::input;
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define PW(x) ((void*)(uintptr_t)(x))
 

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -28,7 +28,7 @@
 
 namespace prosper {
 
-#define HLE(name) static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define PW(x) ((void*)(uintptr_t)(x))
 

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -1,8 +1,9 @@
 // boot_program.cpp — see boot_program.hpp. Extracted verbatim from boot_trace's boot sequence
-// (behavior-preserving); the guest-execution substrate is Linux-only, so guard the whole body.
+// (behavior-preserving); backed by whichever exec_image_<os> substrate the platform provides
+// (Linux/macOS: exec_image_linux.cpp; Windows: exec_image_win.cpp).
 #include "boot_program.hpp"
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
 #include "host/exec_image.hpp"
 #include "hle/dispatch.hpp"
 #include "self/module.hpp"     // PT_SCE_PROCPARAM
@@ -103,10 +104,10 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
 
 } // namespace prosper
 
-#else  // non-Linux: the guest-execution substrate doesn't exist.
+#else  // no guest-execution substrate for this platform.
 namespace prosper {
 bool boot_program(const std::string&, Program&, std::string* err, const std::function<void()>&) {
-    if (err) *err = "boot_program is Linux-only"; return false;
+    if (err) *err = "boot_program: no guest-execution substrate for this platform"; return false;
 }
 } // namespace prosper
 #endif

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -30,6 +30,58 @@
 #include <string>
 #include <vector>
 
+// Host→guest SysV call trampoline. The guest is System V AMD64; the host is Microsoft x64. On
+// Linux/macOS a GuestInitFn is tagged __attribute__((sysv_abi)) so the compiler marshals the call,
+// but on Windows that attribute breaks MinGW SEH unwinding and PROSPER_SYSV_ABI is empty — so a
+// plain C call `((GuestInitFn)f)(argc, argp)` passes args in the MS x64 registers (rcx/rdx) while
+// the guest reads the SysV registers (rdi/rsi). The guest then acts on garbage argc/argp and jumps
+// wild (observed: a module_start crash landing in host data). This shim moves argc→rdi, argp→rsi
+// (SysV) and calls the guest, saving the MS x64 callee-saved registers the SysV callee is free to
+// clobber (rsi, rdi, and xmm6–xmm15); rbx/rbp/r12–r15 are callee-saved in both ABIs. Returns the
+// guest's rax. run_entry does the equivalent inline (it jmp's and never returns); this is the
+// call-and-return path used for the init/module_start functions.
+extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t argc, uint64_t argp);
+__asm__(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_call_guest_sysv\n"
+    "prosper_call_guest_sysv:\n"
+    "    pushq %rbp\n"
+    "    movq  %rsp, %rbp\n"
+    "    pushq %rsi\n"
+    "    pushq %rdi\n"
+    "    subq  $176, %rsp\n"           // 10*16 for xmm6-15 (+16 slack); keeps rsp 16-aligned at the call
+    "    movaps %xmm6,    0(%rsp)\n"
+    "    movaps %xmm7,   16(%rsp)\n"
+    "    movaps %xmm8,   32(%rsp)\n"
+    "    movaps %xmm9,   48(%rsp)\n"
+    "    movaps %xmm10,  64(%rsp)\n"
+    "    movaps %xmm11,  80(%rsp)\n"
+    "    movaps %xmm12,  96(%rsp)\n"
+    "    movaps %xmm13, 112(%rsp)\n"
+    "    movaps %xmm14, 128(%rsp)\n"
+    "    movaps %xmm15, 144(%rsp)\n"
+    "    movq  %rcx, %rax\n"           // MS x64: rcx=fn, rdx=argc, r8=argp
+    "    movq  %rdx, %rdi\n"           // argc -> SysV arg0
+    "    movq  %r8,  %rsi\n"           // argp -> SysV arg1
+    "    callq *%rax\n"
+    "    movaps    0(%rsp), %xmm6\n"
+    "    movaps   16(%rsp), %xmm7\n"
+    "    movaps   32(%rsp), %xmm8\n"
+    "    movaps   48(%rsp), %xmm9\n"
+    "    movaps   64(%rsp), %xmm10\n"
+    "    movaps   80(%rsp), %xmm11\n"
+    "    movaps   96(%rsp), %xmm12\n"
+    "    movaps  112(%rsp), %xmm13\n"
+    "    movaps  128(%rsp), %xmm14\n"
+    "    movaps  144(%rsp), %xmm15\n"
+    "    addq  $176, %rsp\n"
+    "    popq  %rdi\n"
+    "    popq  %rsi\n"
+    "    popq  %rbp\n"
+    "    retq\n"
+);
+
 namespace prosper {
 
 // A guest function pointer: called by host code (init arrays, entry) but obeys the guest's SysV ABI.
@@ -43,7 +95,16 @@ namespace {
     // run_entry / run_guest_inits (see the VEH). thread_local is correct: the VEH runs on the
     // faulting thread. Keyed implicitly by being thread_local (no tid needed, unlike the Linux path
     // which must dodge a guest %fs — Windows has no guest %fs swap).
-    thread_local jmp_buf     t_jb;
+    //
+    // We use __builtin_setjmp/__builtin_longjmp, NOT the CRT setjmp/longjmp. On Windows x64 the CRT
+    // longjmp performs a full SEH stack UNWIND (RtlUnwindEx) from the longjmp site back to the setjmp
+    // frame. Our recovery longjmps ACROSS a guest frame and the hand-written prosper_call_guest_sysv
+    // trampoline — neither has Windows .pdata/.xdata unwind info — so RtlUnwindEx walks into frames it
+    // cannot describe and blows the stack (STATUS_STACK_OVERFLOW 0xC00000FD) instead of recovering.
+    // The __builtin_* pair restores only rsp/rbp/rip (no unwind), which is exactly right for crossing
+    // foreign frames — the same simple-register-restore behavior the Linux longjmp has. The buffer is
+    // GCC's fixed 5-word layout.
+    thread_local void*       t_jb[5];
     thread_local volatile int t_armed = 0;
 
     // Fault state latched by the VEH for the BootResult / init-fault report (single-threaded boot use).
@@ -156,7 +217,7 @@ namespace {
         return true;
     }
 
-    __attribute__((noinline)) void veh_recover() { longjmp(t_jb, 1); }   // runs on the faulting thread
+    __attribute__((noinline)) void veh_recover() { __builtin_longjmp(t_jb, 1); }   // runs on the faulting thread
 
     LONG CALLBACK veh(EXCEPTION_POINTERS* ep) {
         CONTEXT* c = ep->ContextRecord;
@@ -267,7 +328,7 @@ size_t run_guest_inits(const std::vector<uint64_t>& fns) {
         uint64_t argc = 0, argp = 0;
         for (auto& r : g_modstart_param_ranges)
             if (f >= r.first && f < r.second) { argc = 0x10; argp = (uint64_t)&g_modstart_desc; break; }
-        if (setjmp(t_jb) == 0) { ((GuestInitFn)(uintptr_t)f)(argc, argp); ok++; }
+        if (__builtin_setjmp(t_jb) == 0) { prosper_call_guest_sysv(f, argc, argp); ok++; }
         t_armed = 0;
         if (g_trap_kind) {
             fprintf(stderr, "[prosper] init fn 0x%llx faulted (%s); continuing\n",
@@ -334,8 +395,21 @@ BootResult run_entry(const LoadedImage& img) {
     memcpy((void*)(uintptr_t)top, vecv.data(), vecsz);
     uint64_t sp = top, rdi = sp, rsi = 0;
 
+    // Describe the switched guest stack in the TEB. We `mov %rsp` to `stk` below, but Windows still
+    // thinks the thread's stack is the original host-thread stack (NT_TIB.StackBase/StackLimit). When
+    // a guest fault (e.g. the SSE4a INSERTQ/EXTRQ trap) dispatches, ntdll's KiUserExceptionDispatcher
+    // compares the (guest) rsp against the (host) StackLimit, decides the stack is exhausted, and
+    // raises STATUS_STACK_OVERFLOW (0xC00000FD) instead of delivering the exception to our VEH — so the
+    // very first trap after boot killed the process. Point the TEB at the real guest stack for the
+    // duration of guest execution; restore it on the recovery path (back on the host stack). This is
+    // the standard requirement for running on a manually-allocated stack on Windows.
+    NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+    void* teb_save_base = tib->StackBase, *teb_save_limit = tib->StackLimit;
+
     g_trap_kind = 0; g_fault_addr = 0; g_fault_rip = 0; t_armed = 1;
-    if (setjmp(t_jb) == 0) {
+    if (__builtin_setjmp(t_jb) == 0) {
+        tib->StackBase  = (void*)((uintptr_t)stk + STK);   // high end (grows down toward StackLimit)
+        tib->StackLimit = stk;                             // low end of the committed guest stack
         register uint64_t e  asm("rax") = img.entry;
         register uint64_t s  asm("r8")  = sp;
         register uint64_t d  asm("r9")  = rdi;
@@ -346,12 +420,13 @@ BootResult run_entry(const LoadedImage& img) {
             : : "r"(e), "r"(s), "r"(d), "r"(si) : "memory");
         r.kind = 0; r.detail = "entry returned";
     } else {
+        tib->StackBase = teb_save_base; tib->StackLimit = teb_save_limit;   // back on the host stack
         r.kind = g_trap_kind; r.detail = trap_detail();
         r.fault_addr = g_fault_addr; r.fault_rip = g_fault_rip;
         r.rbp = g_rbp; r.rsp = g_rsp; r.rax = g_rax; r.rdi = g_rdi;
         r.rsi = g_rsi; r.rdx = g_rdx; r.rbx = g_rbx;
         t_armed = 1;
-        if (setjmp(t_jb) == 0) {
+        if (__builtin_setjmp(t_jb) == 0) {
             uint64_t bp = g_rbp;
             for (int i = 0; i < 24 && bp > 0x10000; i++) {
                 if (!addr_readable(bp) || !addr_readable(bp + 8)) break;

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1,0 +1,371 @@
+// exec_image_win.cpp — Windows host backing for the guest-execution substrate.
+//
+// The Windows sibling of exec_image_linux.cpp. It implements the same exec_image.hpp contract with
+// Win32 primitives instead of POSIX: VirtualAlloc for fixed-address guest mappings, a Vectored
+// Exception Handler (VEH) instead of a SIGSEGV/SIGILL handler, and CONTEXT register access instead
+// of ucontext. The guest is System V AMD64; the host is Microsoft x64 — the guest↔HLE boundary is
+// bridged by PROSPER_SYSV_ABI (dispatch.hpp), and host→guest calls here go through SysV-typed
+// function pointers.
+//
+// STATUS (2026-07-13): compile/link-complete and CI-built, but the guest boot is NOT yet verified on
+// Windows. Known remaining work is tracked in docs/PORTING.md "Windows": the direct/flexible memory
+// HLE (hle_kernel_mem.cpp) is still POSIX-only, guest %fs TLS is unsolved (same wall as macOS), the
+// (HleFn)-cast handler ABI audit, and runtime validation of VEH recovery. Diagnostics that depend on
+// Linux perf_event / ptrace (PROSPER_HWBP/HWWATCH/BP/PEEK/DUMPAT) are intentionally absent here.
+#ifdef _WIN32
+
+#include "exec_image.hpp"
+#include "sse4a.hpp"
+#include "../hle/nid.hpp"
+#include "../hle/dispatch.hpp"
+
+#include <windows.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <csetjmp>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace prosper {
+
+// A guest function pointer: called by host code (init arrays, entry) but obeys the guest's SysV ABI.
+using GuestInitFn = PROSPER_SYSV_ABI void (*)(uint64_t argc, uint64_t argp);
+
+namespace {
+    uint64_t g_base = 0, g_stub_base = 0, g_stub_size = 0, g_nstubs = 0;
+    NidDb*   g_nid_db = nullptr;
+
+    // Per-thread recovery point. A guest fault on the armed thread is turned into a longjmp back to
+    // run_entry / run_guest_inits (see the VEH). thread_local is correct: the VEH runs on the
+    // faulting thread. Keyed implicitly by being thread_local (no tid needed, unlike the Linux path
+    // which must dodge a guest %fs — Windows has no guest %fs swap).
+    thread_local jmp_buf     t_jb;
+    thread_local volatile int t_armed = 0;
+
+    // Fault state latched by the VEH for the BootResult / init-fault report (single-threaded boot use).
+    volatile int g_trap_kind = 0;   // 0 none, 2 access-violation, 3 illegal-instruction
+    uint64_t g_fault_addr = 0, g_fault_rip = 0;
+    uint64_t g_rax=0,g_rbx=0,g_rcx=0,g_rdx=0,g_rsi=0,g_rdi=0,g_rbp=0,g_rsp=0;
+    uint64_t g_r8=0,g_r9=0,g_r10=0,g_r11=0,g_r12=0,g_r13=0,g_r14=0,g_r15=0;
+
+    // Thread-stack registry (portable; mirrors the Linux one) so GC/thread code gets real bounds.
+    std::map<uint64_t, std::pair<uint64_t, uint64_t>> g_stacks;
+    std::mutex g_smx;
+
+    std::vector<std::pair<uint64_t, uint64_t>> g_modstart_param_ranges;
+    struct ModStartDesc { uint64_t a, b, c; } g_modstart_desc = { 0x10, 0x200, 0 };
+
+    inline uint64_t cur_tid() { return (uint64_t)GetCurrentThreadId(); }
+    inline uint64_t page_up(uint64_t v) { return (v + 0xfffull) & ~0xfffull; }
+
+    // Import-stub machine code. Unlike Linux (where host ABI == guest SysV, so the stub is a bare
+    // tail-jump with args intact), Windows handlers are Microsoft x64, so the stub is a TRAMPOLINE
+    // that converts the guest's SysV integer-arg registers to MS x64 before calling the handler:
+    //   SysV in:  rdi rsi rdx rcx r8 r9        (args a0..a5)
+    //   MS out:   rcx rdx r8  r9  [rsp+0x20] [rsp+0x28]  (+32B shadow space, 16-byte aligned call)
+    // Return value is rax in both ABIs. This handles integer/pointer args (the whole HleFn surface);
+    // XMM/float args (e.g. some libc formatters) are NOT converted yet — see docs/PORTING.md.
+    // The move ordering is chosen so no source register is clobbered before it is read (verified by
+    // hand). CONFIDENCE: MED (design verified on paper; not yet runtime-tested on Windows).
+    size_t emit_sysv_to_ms_prologue(uint8_t* p) {
+        static const uint8_t seq[] = {
+            0x48,0x83,0xEC,0x38,              // sub rsp,0x38   (0x20 shadow + a4/a5 + align: call rsp%16==0)
+            0x4C,0x89,0x44,0x24,0x20,         // mov [rsp+0x20],r8    ; MS 5th arg = a4
+            0x4C,0x89,0x4C,0x24,0x28,         // mov [rsp+0x28],r9    ; MS 6th arg = a5
+            0x49,0x89,0xC9,                   // mov r9,rcx           ; MS 4th = a3  (save before rcx clobbered)
+            0x49,0x89,0xD0,                   // mov r8,rdx           ; MS 3rd = a2  (save before rdx clobbered)
+            0x48,0x89,0xF2,                   // mov rdx,rsi          ; MS 2nd = a1
+            0x48,0x89,0xF9,                   // mov rcx,rdi          ; MS 1st = a0
+        };
+        memcpy(p, seq, sizeof seq); return sizeof seq;
+    }
+    void emit_impl(uint8_t* p, uint64_t fn) {
+        size_t o = emit_sysv_to_ms_prologue(p);
+        p[o++] = 0x48; p[o++] = 0xB8; memcpy(p + o, &fn, 8); o += 8;   // movabs rax,fn
+        p[o++] = 0xFF; p[o++] = 0xD0;                                  // call rax
+        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x38;    // add rsp,0x38
+        p[o++] = 0xC3;                                                 // ret
+    }
+    void emit_unimpl(uint8_t* p, uint32_t idx, uint64_t fn) {
+        size_t o = 0;
+        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xEC; p[o++] = 0x28;    // sub rsp,0x28 (shadow + align)
+        p[o++] = 0xB9; memcpy(p + o, &idx, 4); o += 4;                 // mov ecx,idx  (MS 1st arg)
+        p[o++] = 0x48; p[o++] = 0xB8; memcpy(p + o, &fn, 8); o += 8;   // movabs rax,fn
+        p[o++] = 0xFF; p[o++] = 0xD0;                                  // call rax  (prosper_on_unimpl)
+        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x28;    // add rsp,0x28
+        p[o++] = 0xC3;                                                 // ret
+    }
+
+    // Is [addr] readable right now? VirtualQuery-based, so the fault reporter never nests a fault.
+    bool addr_readable(uint64_t addr) {
+        MEMORY_BASIC_INFORMATION mbi;
+        if (!VirtualQuery((LPCVOID)(uintptr_t)addr, &mbi, sizeof mbi)) return false;
+        if (mbi.State != MEM_COMMIT) return false;
+        DWORD ok = PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE
+                 | PAGE_WRITECOPY | PAGE_EXECUTE_WRITECOPY;
+        return (mbi.Protect & ok) != 0 && !(mbi.Protect & PAGE_GUARD);
+    }
+    void dump_fault_bytes(uint64_t start, int n) {
+        for (int i = 0; i < n; i++) {
+            uint64_t a = start + i;
+            if (addr_readable(a)) fprintf(stderr, " %02x", *(const uint8_t*)(uintptr_t)a);
+            else { fprintf(stderr, " (unmapped@0x%llx)", (unsigned long long)a); return; }
+        }
+    }
+    std::string trap_detail() {
+        char b[160];
+        snprintf(b, sizeof b, "%s at addr=0x%llx  rip=0x%llx (image+0x%llx)",
+                 g_trap_kind == 3 ? "ILLEGAL-INSN" : "ACCESS-VIOLATION",
+                 (unsigned long long)g_fault_addr, (unsigned long long)g_fault_rip,
+                 (unsigned long long)(g_base && g_fault_rip >= g_base ? g_fault_rip - g_base : g_fault_rip));
+        return b;
+    }
+
+    // AMD SSE4a INSERTQ/EXTRQ emulation (Zen2-only; #UD on the Intel ISA Rosetta/native Intel expose,
+    // and generally on the host). Decode from Rip, mutate the xmm regs in CONTEXT, advance Rip.
+    // Mirrors the Linux try_emulate_sse4a but reads/writes CONTEXT.Xmm* instead of fpregs.
+    bool try_emulate_sse4a(CONTEXT* c) {
+        const uint8_t* p = (const uint8_t*)(uintptr_t)c->Rip;
+        if (!addr_readable(c->Rip)) return false;
+        size_t i = 0; uint8_t pfx = 0, rex = 0;
+        if (p[i] == 0x66 || p[i] == 0xF2) pfx = p[i++];
+        if ((p[i] & 0xF0) == 0x40) rex = p[i++];
+        if (p[i++] != 0x0F) return false;
+        uint8_t op = p[i++];
+        if (op != 0x78 && op != 0x79) return false;
+        uint8_t modrm = p[i++];
+        if ((modrm >> 6) != 3) return false;
+        int reg = ((modrm >> 3) & 7) | ((rex & 4) ? 8 : 0);
+        int rm  = (modrm & 7)       | ((rex & 1) ? 8 : 0);
+        M128A* xmm = &c->FltSave.XmmRegisters[0];   // 16 x {Low, High}
+        auto lo  = [&](int n) { return (uint64_t)xmm[n].Low; };
+        auto set = [&](int n, uint64_t v) { xmm[n].Low = (ULONGLONG)v; };
+        bool insertq = (pfx == 0xF2);
+        uint32_t len, idx;
+        if (op == 0x78)   { len = p[i++]; idx = p[i++]; }
+        else if (insertq) { uint64_t cc = (uint64_t)xmm[rm].High; len = (uint32_t)(cc & 0x3f); idx = (uint32_t)((cc >> 8) & 0x3f); }
+        else              { uint64_t cc = (uint64_t)xmm[rm].Low;  len = (uint32_t)(cc & 0x3f); idx = (uint32_t)((cc >> 8) & 0x3f); }
+        len &= 0x3f; idx &= 0x3f;
+        if (insertq) set(reg, sse4a_insertq(lo(reg), lo(rm), len, idx));
+        else { int dr = (op == 0x78) ? rm : reg; set(dr, sse4a_extrq(lo(dr), len, idx)); }
+        c->Rip += i;
+        return true;
+    }
+
+    __attribute__((noinline)) void veh_recover() { longjmp(t_jb, 1); }   // runs on the faulting thread
+
+    LONG CALLBACK veh(EXCEPTION_POINTERS* ep) {
+        CONTEXT* c = ep->ContextRecord;
+        DWORD code = ep->ExceptionRecord->ExceptionCode;
+        if (code == EXCEPTION_ILLEGAL_INSTRUCTION && try_emulate_sse4a(c))
+            return EXCEPTION_CONTINUE_EXECUTION;
+        if (code != EXCEPTION_ACCESS_VIOLATION && code != EXCEPTION_ILLEGAL_INSTRUCTION &&
+            code != EXCEPTION_IN_PAGE_ERROR && code != EXCEPTION_PRIV_INSTRUCTION &&
+            code != EXCEPTION_DATATYPE_MISALIGNMENT)
+            return EXCEPTION_CONTINUE_SEARCH;   // not a guest fault we own
+        if (!t_armed) return EXCEPTION_CONTINUE_SEARCH;   // worker thread with no recovery point
+
+        g_trap_kind = (code == EXCEPTION_ILLEGAL_INSTRUCTION) ? 3 : 2;
+        g_fault_rip = c->Rip;
+        g_fault_addr = (ep->ExceptionRecord->NumberParameters >= 2)
+                     ? (uint64_t)ep->ExceptionRecord->ExceptionInformation[1] : 0;
+        g_rax=c->Rax; g_rbx=c->Rbx; g_rcx=c->Rcx; g_rdx=c->Rdx; g_rsi=c->Rsi; g_rdi=c->Rdi;
+        g_rbp=c->Rbp; g_rsp=c->Rsp; g_r8=c->R8; g_r9=c->R9; g_r10=c->R10; g_r11=c->R11;
+        g_r12=c->R12; g_r13=c->R13; g_r14=c->R14; g_r15=c->R15;
+        // Redirect execution to veh_recover (which longjmps): calling longjmp directly out of a VEH
+        // is unsafe, so resume the thread at veh_recover on its current stack. 16-align the stack for
+        // the ABI. CONFIDENCE: MED — validated design, unverified at runtime on Windows.
+        c->Rsp &= ~(uint64_t)0xf;
+        c->Rip = (DWORD64)(uintptr_t)&veh_recover;
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+} // namespace
+
+bool map_image(const LoadedImage& img, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    void* want = (void*)(uintptr_t)(img.base + img.min_vaddr);
+    size_t sz  = img.mem.size();
+    void* got = VirtualAlloc(want, sz, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    if (!got || got != want) return fail("VirtualAlloc image at guest base failed");
+    memcpy(got, img.mem.data(), sz);
+    if (!g_base) g_base = img.base;
+    return true;
+}
+
+bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
+                   uint64_t stub_size, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (stub_size < 24) return fail("stub_size too small (need >= 24)");
+    if (!g_nid_db) g_nid_db = new NidDb();
+    dispatch_init(&slots, g_nid_db);
+
+    uint64_t n = slots.size();
+    if (n == 0) { g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = 0; return true; }
+    uint64_t region = page_up(n * stub_size);
+    void* got = VirtualAlloc((void*)(uintptr_t)stub_base, region, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    if (!got || got != (void*)(uintptr_t)stub_base) return fail("VirtualAlloc stub region failed");
+
+    uint8_t* base = (uint8_t*)got;
+    for (uint64_t i = 0; i < n; i++) {
+        uint8_t* slot = base + i * stub_size;
+        HleFn fn = Hle::lookup(slots[i].nid);
+        if (fn) emit_impl(slot, (uint64_t)fn);
+        else    emit_unimpl(slot, (uint32_t)i, (uint64_t)&prosper_on_unimpl);
+    }
+    g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = n;
+    return true;
+}
+
+void install_sigaltstack() {}   // Windows delivers exceptions on the runtime's own guard stack
+
+void install_trap_handler() {
+    static bool installed = false;
+    if (installed) return;
+    installed = true;
+    AddVectoredExceptionHandler(1 /*first*/, veh);
+}
+
+// Diagnostics that need Linux perf_event / int3 patching are unavailable on Windows.
+void arm_hwbp_this_thread() {}
+
+uint64_t stub_addr(uint64_t idx) { return g_stub_base + idx * g_stub_size; }
+uint64_t invoke_stub(uint64_t idx) {
+    if (idx >= g_nstubs) return 0;
+    return ((HleFn)(uintptr_t)stub_addr(idx))(0, 0, 0, 0, 0, 0);
+}
+
+void register_thread_stack(uint64_t tid, void* base, uint64_t size) {
+    std::lock_guard<std::mutex> lk(g_smx); g_stacks[tid] = { (uint64_t)base, size };
+}
+void unregister_thread_stack(uint64_t tid) {
+    std::lock_guard<std::mutex> lk(g_smx); g_stacks.erase(tid);
+}
+bool guest_stack_for_thread(uint64_t tid, void** base, size_t* size) {
+    std::lock_guard<std::mutex> lk(g_smx);
+    auto it = g_stacks.find(tid);
+    if (it == g_stacks.end()) return false;
+    if (base) *base = (void*)(uintptr_t)it->second.first;
+    if (size) *size = (size_t)it->second.second;
+    return true;
+}
+bool guest_stack_for_current_thread(void** base, size_t* size) {
+    return guest_stack_for_thread(cur_tid(), base, size);
+}
+
+void set_module_start_param_ranges(const std::vector<std::pair<uint64_t, uint64_t>>& ranges) {
+    g_modstart_param_ranges = ranges;
+}
+
+size_t run_guest_inits(const std::vector<uint64_t>& fns) {
+    size_t ok = 0;
+    for (uint64_t f : fns) {
+        g_trap_kind = 0; t_armed = 1;
+        uint64_t argc = 0, argp = 0;
+        for (auto& r : g_modstart_param_ranges)
+            if (f >= r.first && f < r.second) { argc = 0x10; argp = (uint64_t)&g_modstart_desc; break; }
+        if (setjmp(t_jb) == 0) { ((GuestInitFn)(uintptr_t)f)(argc, argp); ok++; }
+        t_armed = 0;
+        if (g_trap_kind) {
+            fprintf(stderr, "[prosper] init fn 0x%llx faulted (%s); continuing\n",
+                    (unsigned long long)f, trap_detail().c_str());
+            fprintf(stderr, "[prosper]   rax=%016llx rbx=%016llx rcx=%016llx rdx=%016llx\n"
+                            "[prosper]   rsi=%016llx rdi=%016llx rbp=%016llx rsp=%016llx\n"
+                            "[prosper]   r8 =%016llx r9 =%016llx r10=%016llx r11=%016llx\n"
+                            "[prosper]   r12=%016llx r13=%016llx r14=%016llx r15=%016llx\n",
+                    (unsigned long long)g_rax,(unsigned long long)g_rbx,(unsigned long long)g_rcx,
+                    (unsigned long long)g_rdx,(unsigned long long)g_rsi,(unsigned long long)g_rdi,
+                    (unsigned long long)g_rbp,(unsigned long long)g_rsp,(unsigned long long)g_r8,
+                    (unsigned long long)g_r9,(unsigned long long)g_r10,(unsigned long long)g_r11,
+                    (unsigned long long)g_r12,(unsigned long long)g_r13,(unsigned long long)g_r14,
+                    (unsigned long long)g_r15);
+            fprintf(stderr, "[prosper]   bytes@rip-8:"); dump_fault_bytes(g_fault_rip - 8, 24);
+            fprintf(stderr, "  (rip=0x%llx)\n", (unsigned long long)g_fault_rip);
+            fprintf(stderr, "[prosper]   bytes@entry:"); dump_fault_bytes(f, 24);
+            fprintf(stderr, "  (entry=0x%llx)\n", (unsigned long long)f);
+        }
+    }
+    return ok;
+}
+
+BootResult run_entry(const LoadedImage& img) {
+    const size_t STK = 16 * 1024 * 1024;
+    void* stk = VirtualAlloc(nullptr, STK, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+    BootResult r;
+    if (!stk) { r.kind = 2; r.detail = "guest stack VirtualAlloc failed"; return r; }
+    register_thread_stack(cur_tid(), stk, STK);
+
+    uint64_t top = ((uint64_t)(uintptr_t)stk + STK) & ~(uint64_t)0xf;
+    std::vector<std::string> args = { "/app0/eboot.bin" };
+    if (const char* extra = getenv("PROSPER_GUEST_ARGS")) {
+        const char* p = extra;
+        while (*p) { while (*p == ' ') p++; if (!*p) break; const char* s = p;
+                     while (*p && *p != ' ') p++; args.emplace_back(s, (size_t)(p - s)); }
+    }
+    std::vector<uint64_t> argptrs;
+    for (const auto& a : args) { size_t n = a.size() + 1; top -= n; memcpy((void*)(uintptr_t)top, a.c_str(), n); argptrs.push_back(top); }
+    std::vector<uint64_t> envptrs;
+    if (const char* ge = getenv("PROSPER_GUEST_ENV")) {
+        std::string s(ge); size_t i = 0;
+        while (i < s.size()) {
+            size_t j = s.find(';', i);
+            std::string kv = s.substr(i, j == std::string::npos ? std::string::npos : j - i);
+            if (!kv.empty()) { size_t n = kv.size() + 1; top -= n; memcpy((void*)(uintptr_t)top, kv.c_str(), n); envptrs.push_back(top); }
+            if (j == std::string::npos) break; i = j + 1;
+        }
+        top &= ~(uint64_t)0xf;
+    }
+    top &= ~(uint64_t)0xf;
+    // crt0 vector: argc, argv[], NULL, envp[], NULL, auxv AT_NULL(0,0). rsp ≡ 8 (mod 16) at entry.
+    std::vector<uint64_t> vecv;
+    vecv.push_back(args.size());
+    for (uint64_t pp : argptrs) vecv.push_back(pp);
+    vecv.push_back(0);
+    for (uint64_t pp : envptrs) vecv.push_back(pp);
+    vecv.push_back(0);
+    vecv.push_back(0); vecv.push_back(0);
+    if (vecv.size() & 1) vecv.push_back(0);
+    size_t vecsz = vecv.size() * sizeof(uint64_t);
+    top -= vecsz; top &= ~(uint64_t)0xf;
+    top -= 8;
+    memcpy((void*)(uintptr_t)top, vecv.data(), vecsz);
+    uint64_t sp = top, rdi = sp, rsi = 0;
+
+    g_trap_kind = 0; g_fault_addr = 0; g_fault_rip = 0; t_armed = 1;
+    if (setjmp(t_jb) == 0) {
+        register uint64_t e  asm("rax") = img.entry;
+        register uint64_t s  asm("r8")  = sp;
+        register uint64_t d  asm("r9")  = rdi;
+        register uint64_t si asm("r10") = rsi;
+        __asm__ volatile(
+            "mov %%r8, %%rsp\n\t" "mov %%r9, %%rdi\n\t" "mov %%r10, %%rsi\n\t"
+            "xor %%rbp, %%rbp\n\t" "jmp *%%rax\n\t"
+            : : "r"(e), "r"(s), "r"(d), "r"(si) : "memory");
+        r.kind = 0; r.detail = "entry returned";
+    } else {
+        r.kind = g_trap_kind; r.detail = trap_detail();
+        r.fault_addr = g_fault_addr; r.fault_rip = g_fault_rip;
+        r.rbp = g_rbp; r.rsp = g_rsp; r.rax = g_rax; r.rdi = g_rdi;
+        r.rsi = g_rsi; r.rdx = g_rdx; r.rbx = g_rbx;
+        t_armed = 1;
+        if (setjmp(t_jb) == 0) {
+            uint64_t bp = g_rbp;
+            for (int i = 0; i < 24 && bp > 0x10000; i++) {
+                if (!addr_readable(bp) || !addr_readable(bp + 8)) break;
+                uint64_t ret = *(uint64_t*)(uintptr_t)(bp + 8);
+                if (ret) r.backtrace.push_back(ret);
+                uint64_t nbp = *(uint64_t*)(uintptr_t)bp;
+                if (nbp <= bp) break;
+                bp = nbp;
+            }
+        }
+        t_armed = 0;
+    }
+    return r;
+}
+
+} // namespace prosper
+#endif // _WIN32

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -170,6 +170,20 @@ namespace {
                  | PAGE_WRITECOPY | PAGE_EXECUTE_WRITECOPY;
         return (mbi.Protect & ok) != 0 && !(mbi.Protect & PAGE_GUARD);
     }
+    // Does the instruction at p carry an %fs segment-override prefix (0x64)? Scans the legacy
+    // prefixes and REX; stops at the opcode. Used to tell a drifted-guest-%fs fault (Windows zeroed
+    // the FS base at a kernel transition) apart from a genuine fault, so we only retry fs accesses.
+    bool insn_is_fs_relative(const uint8_t* p) {
+        for (int i = 0; i < 8; i++) {
+            uint8_t b = p[i];
+            if (b == 0x64) return true;                               // fs override
+            if (b==0x66||b==0x67||b==0xF0||b==0xF2||b==0xF3||         // opnd/addr size, lock, rep
+                b==0x2E||b==0x36||b==0x3E||b==0x26||b==0x65) continue; // other segment overrides
+            if ((b & 0xF0) == 0x40) continue;                        // REX
+            return false;                                            // opcode reached; no fs prefix
+        }
+        return false;
+    }
     void dump_fault_bytes(uint64_t start, int n) {
         for (int i = 0; i < n; i++) {
             uint64_t a = start + i;
@@ -223,6 +237,14 @@ namespace {
         CONTEXT* c = ep->ContextRecord;
         DWORD code = ep->ExceptionRecord->ExceptionCode;
         if (code == EXCEPTION_ILLEGAL_INSTRUCTION && try_emulate_sse4a(c))
+            return EXCEPTION_CONTINUE_EXECUTION;
+        // Guest %fs base drift: Windows zeroes the user FS base on every kernel transition, so a
+        // guest fs-relative TLS access can fault at a low linear address after a context switch /
+        // syscall even though the guest TCB is fine. If the faulting instruction is fs-relative and
+        // our guest TP just needs re-applying, do so and retry — costing one fault per kernel-transition
+        // boundary, not per access. Runs BEFORE the t_armed gate so guest worker threads get it too.
+        if (code == EXCEPTION_ACCESS_VIOLATION && addr_readable(c->Rip) &&
+            insn_is_fs_relative((const uint8_t*)(uintptr_t)c->Rip) && guest_fs_reapply())
             return EXCEPTION_CONTINUE_EXECUTION;
         if (code != EXCEPTION_ACCESS_VIOLATION && code != EXCEPTION_ILLEGAL_INSTRUCTION &&
             code != EXCEPTION_IN_PAGE_ERROR && code != EXCEPTION_PRIV_INSTRUCTION &&
@@ -322,6 +344,7 @@ void set_module_start_param_ranges(const std::vector<std::pair<uint64_t, uint64_
 }
 
 size_t run_guest_inits(const std::vector<uint64_t>& fns) {
+    guest_tls_activate_thread();   // give this (main) thread its guest %fs TCB before running guest code
     size_t ok = 0;
     for (uint64_t f : fns) {
         g_trap_kind = 0; t_armed = 1;
@@ -410,6 +433,8 @@ BootResult run_entry(const LoadedImage& img) {
     if (__builtin_setjmp(t_jb) == 0) {
         tib->StackBase  = (void*)((uintptr_t)stk + STK);   // high end (grows down toward StackLimit)
         tib->StackLimit = stk;                             // low end of the committed guest stack
+        guest_tls_activate_thread();   // (re-)apply this thread's guest %fs base immediately before entry
+                                       // (idempotent; no syscall on the re-apply path, so fs survives to the jmp)
         register uint64_t e  asm("rax") = img.entry;
         register uint64_t s  asm("r8")  = sp;
         register uint64_t d  asm("r9")  = rdi;

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -154,4 +154,23 @@ uint64_t guest_tls_module_below(uint32_t modid) { return modid < g_below.size() 
 uint64_t guest_tls_total_below() { return g_total_below; }
 
 } // namespace prosper
+
+#elif defined(_WIN32)
+// Windows: guest initial-exec %fs TLS is unsupported (no fsbase API; a separate frontier tracked in
+// docs/PORTING.md). The gate is hard-off, so these are no-ops that keep boot_program/hle_kernel
+// linking. Guest %fs-relative static TLS therefore reads the host TEB — wrong, and the same class of
+// wall as macOS; solving it (trap/patch %fs) is the next Windows step.
+#include "../hle/dispatch.hpp"
+#include <cstdint>
+#include <cstddef>
+namespace prosper {
+void guest_tls_set_templates(const TlsModuleDesc*, size_t) {}
+bool guest_tls_enabled() { return false; }
+uint64_t guest_tls_activate_thread() { return 0; }
+void guest_fs_enter_host_for_signal() {}
+uint64_t guest_fs_to_host_scoped() { return 0; }
+void guest_fs_restore_scoped(uint64_t) {}
+uint64_t guest_tls_module_below(uint32_t) { return 0; }
+uint64_t guest_tls_total_below() { return 0; }
+} // namespace prosper
 #endif

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -146,6 +146,20 @@ uint64_t guest_fs_to_host_scoped() {
 }
 void guest_fs_restore_scoped(uint64_t prev_fs) { if (prev_fs) wr_fsbase(prev_fs); }
 
+// This thread's guest TP if it is running on our guest TCB, else 0. (Linux/macOS query the live
+// %fs; the magic marks it as ours.) Used by the Windows fault handler; harmless on Linux.
+uint64_t guest_fs_current_tp() {
+    if (!guest_tls_enabled()) return 0;
+#ifdef __APPLE__
+    return 0;   // guest-fs force-disabled; rd_fsbase SIGILLs under Rosetta
+#else
+    uint64_t fs = rd_fsbase();
+    return (fs && *(volatile uint32_t*)(fs + MAGIC_OFF) == TCB_MAGIC) ? fs : 0;
+#endif
+}
+// Linux/macOS preserve the FS base across kernel transitions, so there is never drift to correct.
+bool guest_fs_reapply() { return false; }
+
 // Diagnostic/test accessors for the Variant II static-TLS layout (#143): the distance below the
 // thread pointer at which module `modid`'s block starts (0 if out of range), and the total static
 // TLS below TP. Computed by guest_tls_set_templates regardless of the PROSPER_GUEST_FS gate, so a
@@ -156,21 +170,105 @@ uint64_t guest_tls_total_below() { return g_total_below; }
 } // namespace prosper
 
 #elif defined(_WIN32)
-// Windows: guest initial-exec %fs TLS is unsupported (no fsbase API; a separate frontier tracked in
-// docs/PORTING.md). The gate is hard-off, so these are no-ops that keep boot_program/hle_kernel
-// linking. Guest %fs-relative static TLS therefore reads the host TEB — wrong, and the same class of
-// wall as macOS; solving it (trap/patch %fs) is the next Windows step.
+// Windows: guest initial-exec %fs TLS, via user-mode FSGSBASE (rdfsbase/wrfsbase, enabled on
+// Win10 1709+). This differs from the Linux path in two ways that together make it SIMPLER here:
+//   (1) The HOST uses %gs (TEB) and only the GUEST uses %fs, so there is NO per-HLE-call %fs swap —
+//       host handlers and guest code never collide on %fs (the Linux stub swap dance is unneeded).
+//   (2) But Windows RESETS the user %fs base to 0 on every kernel transition (context switch /
+//       syscall) — it restores the thread's kernel-saved FS base (0), and wrfsbase updates only the
+//       live register. So "set once and leave it" is impossible. We set the base on guest entry and
+//       the VEH (exec_image_win.cpp) re-applies it and retries whenever a guest %fs access faults
+//       because the base drifted (guest_fs_reapply). One fault per kernel-transition boundary, not
+//       per access. See docs/PORTING.md "The Windows frontier: guest %fs TLS".
+// Because host-%fs aliasing (the Linux default fallback) cannot work here, guest-fs is enabled
+// whenever templates are configured (opt out with PROSPER_NO_GUEST_FS for bisection).
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include "../hle/dispatch.hpp"
+#include <windows.h>
 #include <cstdint>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
 namespace prosper {
-void guest_tls_set_templates(const TlsModuleDesc*, size_t) {}
-bool guest_tls_enabled() { return false; }
-uint64_t guest_tls_activate_thread() { return 0; }
+namespace {
+    std::vector<TlsModuleDesc> g_mods;
+    std::vector<uint64_t> g_below;
+    uint64_t g_total_below = 0;
+    bool g_enabled = false, g_configured = false;
+    thread_local uint64_t t_guest_tp = 0;
+
+    inline uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
+    inline uint64_t rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
+    inline void     wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
+}
+
+static constexpr uint64_t TCB_SIZE  = 0x200;
+static constexpr uint64_t MAGIC_OFF = 0x108;
+static constexpr uint32_t TCB_MAGIC = 0x50524F53u;   // "PROS"
+
+void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
+    g_enabled = getenv("PROSPER_NO_GUEST_FS") == nullptr;
+    g_mods.assign(descs, descs + count);
+    // x86-64 Variant II static-TLS layout (same math as the Linux path): each module's block sits
+    // BELOW the thread pointer at a distance rounded to its PT_TLS p_align, so a symbol at byte X
+    // reads at %fs:(X - off[i]) — exactly the tpoff the guest static linker baked in.
+    g_below.assign(g_mods.size(), 0);
+    uint64_t off = 0, max_align = 16;
+    for (size_t i = 1; i < g_mods.size(); i++) {
+        uint64_t a = g_mods[i].align ? g_mods[i].align : 16;
+        if (a > max_align) max_align = a;
+        off = align_up(off + g_mods[i].memsz, a);
+        g_below[i] = off;
+    }
+    g_total_below = align_up(off, max_align < 64 ? 64 : max_align);
+    g_configured = true;
+    if (getenv("PROSPER_TLSLOG"))
+        fprintf(stderr, "[tls] guest-fs %s (win/fsgsbase); static TLS below TP = 0x%llx bytes\n",
+                g_enabled ? "ENABLED" : "disabled", (unsigned long long)g_total_below);
+}
+
+bool guest_tls_enabled() { return g_enabled && g_configured; }
+
+uint64_t guest_tls_activate_thread() {
+    if (!guest_tls_enabled()) return 0;
+    if (t_guest_tp) { wr_fsbase(t_guest_tp); return t_guest_tp; }   // idempotent: re-apply, never re-alloc
+    size_t total = (size_t)g_total_below + TCB_SIZE;
+    uint8_t* block = (uint8_t*)VirtualAlloc(nullptr, total, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+    if (!block) return 0;
+    memset(block, 0, total);
+    uint64_t tp = (uint64_t)block + g_total_below;
+    for (size_t i = 1; i < g_mods.size(); i++)
+        if (g_mods[i].filesz && g_mods[i].init_va)
+            memcpy((void*)(tp - g_below[i]), (const void*)(uintptr_t)g_mods[i].init_va, g_mods[i].filesz);
+    *(uint64_t*)(tp + 0)         = tp;            // TCB self-pointer (the `mov %fs:0x0` idiom)
+    *(uint32_t*)(tp + MAGIC_OFF) = TCB_MAGIC;     // marks OUR guest TCB
+    // Guest stack-guard canary at %fs:0x28: a fixed non-zero value (the guest checks it for
+    // self-consistency; MinGW's host protector uses a global __stack_chk_guard, not %fs, so there
+    // is no host canary to mirror here — unlike the Linux path).
+    *(uint64_t*)(tp + 0x28) = 0x00000aff0c2b1d5eull;
+    t_guest_tp = tp;
+    wr_fsbase(tp);   // MUST be last — an intervening syscall (e.g. VirtualAlloc) resets the FS base
+    return tp;
+}
+
+uint64_t guest_fs_current_tp() { return t_guest_tp; }
+bool guest_fs_reapply() {
+    if (!t_guest_tp) return false;
+    if (rd_fsbase() == t_guest_tp) return false;   // already correct -> genuine fault, don't loop
+    wr_fsbase(t_guest_tp);
+    return true;
+}
+
+// Host uses %gs on Windows, so no guest<->host %fs swap is ever needed.
 void guest_fs_enter_host_for_signal() {}
 uint64_t guest_fs_to_host_scoped() { return 0; }
 void guest_fs_restore_scoped(uint64_t) {}
-uint64_t guest_tls_module_below(uint32_t) { return 0; }
-uint64_t guest_tls_total_below() { return 0; }
+uint64_t guest_tls_module_below(uint32_t modid) { return modid < g_below.size() ? g_below[modid] : 0; }
+uint64_t guest_tls_total_below() { return g_total_below; }
 } // namespace prosper
 #endif

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -140,6 +140,7 @@ int main(int argc, char** argv) {
     // this lets the REAL cutscene render past the crash while the engine-level "create the Stopwatch"
     // fix is developed. `len` = number of whole prologue bytes to relocate (>=5). Requires an executable
     // guest-adjacent cave within +/-2GB so a 5-byte jmp rel32 reaches it.
+#ifndef _WIN32   // PROSPER_NULLGUARD is a Messenger-specific mmap+patch diagnostic; not ported to Windows yet.
     if (const char* ng = getenv("PROSPER_NULLGUARD")) {
         char* e1 = nullptr; uint64_t addr = strtoull(ng, &e1, 0);
         long len = (e1 && *e1 == ',') ? strtol(e1 + 1, nullptr, 0) : 13;
@@ -184,6 +185,7 @@ int main(int argc, char** argv) {
             }
         }
     }
+#endif  // !_WIN32 (PROSPER_NULLGUARD)
 
 #ifdef PROSPER_HAVE_VULKAN
     // Compute is part of command submission even when frame rendering/dumping is disabled.


### PR DESCRIPTION
As much of the Windows port as is reliably achievable from a macOS machine: the full boot path now **compiles and links** on Windows (verified via MinGW-w64 cross-compile locally and in CI), with the SysV⇄MS-x64 ABI boundary implemented. The guest **boot itself is not yet runtime-verified** — I have no Windows host and CI has no game dump — so this is explicitly a *foundation + handoff* for a Windows-based agent to continue. Full detail in `docs/PORTING.md` → "Windows port status".

## What's done (compiles + links, in CI)

- **`src/host/exec_image_win.cpp`** — Win32 sibling of `exec_image_linux.cpp` implementing the whole `exec_image.hpp` contract: fixed-address guest mapping (`VirtualAlloc` at the guest bases), the import-stub region, a **VEH** fault handler with SSE4a `INSERTQ`/`EXTRQ` emulation over `CONTEXT.Xmm*` and recovery via a Rip-redirect `longjmp` trampoline, `run_entry` (SysV crt0 stack + `jmp`), `run_guest_inits`, the thread-stack registry, and `VirtualQuery` classification. Linux-only perf/int3 diagnostics are intentionally omitted.
- **SysV⇄MS-x64 ABI in the emitted stub trampoline**, not `__attribute__((sysv_abi))`. The attribute route was tried and abandoned: on MinGW it collides with SEH C++ exception unwinding (`.seh_handlerdata used outside of .seh_proc block`) and can't be applied to 537 STL-using handlers. `emit_impl` converts the guest's SysV integer args to MS x64 (regs + 32B shadow + 16-align) before calling the handler, which stays a plain MS-x64 function. **Byte encoding disassembly-verified**; register-move ordering is clobber-safe by construction.
- `guest_tls.cpp` Windows path (guest `%fs` TLS hard-disabled), `boot_program.cpp` enabled on Windows, `boot_trace` built on Windows. The existing `Windows MinGW` CI job now builds the whole boot path.

## What's left (needs a Windows host)

1. Runtime-validate/repair the ABI trampoline; **float/XMM args are not yet converted** (only integer/pointer).
2. **Port the direct/flexible-memory HLE** (`hle_kernel_mem.cpp` is still POSIX-only) to `VirtualAlloc`/`VirtualProtect` + `MapViewOfFile3` — the biggest remaining chunk; required before the guest can allocate memory.
3. **Guest `%fs` TLS** — same wall as macOS; trap/patch guest `%fs:` accesses (shadPS4 precedent).
4. VEH recovery hardening (dedicated/guard stack for stack-overflow faults).
5. Audit the 103 `(HleFn)`-cast handlers (almost all are `HLE()`-defined and route correctly; confirm none are raw host functions).

## Safety / regressions

All Windows code is `#ifdef _WIN32` or an empty macro on other platforms. macOS **67/67 ctest** still green; the `PROSPER_SYSV_ABI` marker is empty everywhere so Linux/macOS codegen is unchanged. Relies on the CI Linux/macOS jobs to confirm no regression.