### PR TITLE
feat(gpu): checkpoint persistent depth stencil state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ animation-sensitive exact-frame contract from #573/#596.
 
 The current tooling frontier is deterministic offline capture rather than longer live-render windows.
 Native-speed `.prgtl` indexes retain every submit/present boundary, and an exact-submit selector can materialize
-immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-7 `.prgcap` (#594).
+immutable, content-deduplicated graphics/compute state plus mixed PM4 order into a version-8 `.prgcap` (#594/#569).
 `gpu_replay --graph` / `--graph-json` now resolve in-submit versions and temporal read-before-write leaves (#600;
 full workflow: `prosper/tools/gpu_replay/README.md`). Timeline version 6 retains the version-5 bounded same-run
 target/depth history and adds compact per-draw target spans for offline scene selection. Ordered `.prgbundle`
@@ -135,9 +135,10 @@ and the 738x420 target at draw 79..81. Current routes use 91..93 draws, exactly 
 target at draw 80..82; two independent timelines selected only sustained gameplay from about 29.5 seconds onward.
 Target extent or total draw count alone also selects cinematic/transition frames and must not be used as the
 oracle. Use this checkpoint to isolate the first bad composition.
-The faithful playable bundle spans submits 18,165..19,047, stores 158.94 GiB logical state in 739 MiB, resolves
-all 1,764 temporal image dependencies, and renders hash `5759c125812154dc`. A fresh-depth final replay instead
-renders `71b84bdfae53933c`; `gpu_replay --bundle-find-ds ADDR` scans manifest-only DS use in seconds and proves
+The faithful playable bundle spans submits 18,165..19,047, stores 158.94 GiB logical state in 739 MiB, and
+resolves all 1,764 temporal image dependencies. Its pre-#611/#615 historical hash was `5759c125812154dc`; do
+not use that old absolute hash as a current renderer oracle. A two-submit color-bounded replay remains
+`71b84bdfae53933c`; `gpu_replay --bundle-find-ds ADDR` scans manifest-only DS use in seconds and proves
 the shared surface has no draw/register clear intent. The missing hardware boundary is now identified and
 implemented (#611): timeline-v5 retains complete raw DS programming plus optional guest backing hashes/writer
 provenance, which found compute program `0x401aec200` filling the exact 32 KiB HTILE allocation with
@@ -145,6 +146,11 @@ provenance, which found compute program `0x401aec200` filling the exact 32 KiB H
 DS entries become invalid so the next use follows the existing compare-derived clear path. A routed live A/B
 restores the foreground/platform/HUD layers that remain black with invalidation disabled. The explicit
 `--legacy-htile-before-stencil` switch supplies the omitted HTILE identity only for the preserved pre-v6 bundle.
+Capture v8 closes the exact offline boundary (#569). Current #611-enabled full-bundle and standalone output are
+both `fac9ca4cbbba8196`. An invalidation-disabled stale-depth A/B is `535256588b67a536` in both paths with
+byte-identical BMPs; the self-contained capsule carries 12 RTT surfaces, one 929,616-byte 642x362 D32S8 depth
+plane, effective DS lifetime/legacy settings, and the 33,177,600-byte source oracle. Standalone replay takes
+about 3.3 seconds instead of roughly 24 minutes.
 The four repeated Dead Cells fragment failures were canonical VCCZ-exit light-accumulation loops. #615 adds a
 stage-specific proof: every VOPC input must be scalar/inline/literal or have a nearest overlapping VGPR
 definition from an unmodified uniform VOP1 move/conversion. Only then can the wave-empty VCC test lower to a
@@ -154,9 +160,10 @@ semantic draws. Capture v7 (#618) retains a failed stage fault-safely through `s
 content-deduplicates it, and records exact coverage/opcode/PC, decoded pipeline/launch state, and
 resource/descriptor summaries. Start with `gpu_replay --inspect-only`; extract a raw stage with
 `--dump-failed-shader FAILURE:STAGE PATH` instead of rerunning the title.
-Do not treat `--bundle-final-capsule` as an exact DS checkpoint: it snapshots color RTT state, not live Vulkan
-depth/stencil images (#569). Capture v7 reads v1-v6 artifacts (failed-operation diagnostics report unavailable);
-timeline v6 reads timeline v1-v5 artifacts. Addresses and operation ordinals are run-local. Use
+`--bundle-final-capsule` snapshots both color RTT state and exact valid planes from persistent Vulkan
+depth/stencil images into capture v8 (#569). Capture v8 reads v1-v7 artifacts; pre-v7 failed-operation diagnostics
+report unavailable and pre-v8 captures contain no invented DS seeds. Timeline v6 reads timeline v1-v5
+artifacts. Addresses and operation ordinals are run-local. Use
 `gpu_timeline FILE --signatures DRAWS DISPATCHES` to discover target spans and `--select` to validate the exact
 live-capture predicate before recording another detailed bundle. The Dead Cells splash guard deliberately
 uses `min_colors=1500` rather than an exact hash: unchanged builds select multiple valid animation states with

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ accepts scripted gamepad input, and renders the first level.
   cached Vulkan depth images, restoring the rejected gameplay layers in a routed live A/B (#611). The four
   remaining scene draws used uniform VCCZ-exit light loops; the fragment/vertex recompiler now proves that
   narrow wave-uniform shape, emits structured loops, and realizes every sampled gameplay draw (#615).
+  Capture v8 snapshots exact persistent Vulkan depth/stencil planes alongside temporal color targets, turning
+  the final composition into a standalone, hash-checked replay checkpoint (#569).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -49,10 +49,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   structurizer now accepts that shape only when each compare operand has a proved wave-uniform reaching
   definition; varying bounds and the compute wave-mask form still reject. Current routed gameplay submits
   realize every semantic draw (#615).
-  Version-7 GPU captures seed temporal render targets, retain complete depth-surface programming, and keep
-  content-addressed resource versions for
-  faithful offline isolation (#568/#594); one residual
-  live/replay hash mismatch remains (#569). Dispatch thread counts and derived workgroup dimensions,
+  Version-8 GPU captures seed temporal render targets, retain complete depth-surface programming, preserve
+  exact persistent Vulkan depth/stencil checkpoint planes, and keep content-addressed resource versions for
+  faithful offline isolation (#568/#594/#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
 - 🚧 **Active frontiers:** bundle v2 makes long Dead Cells history practical with exact shared-resource
@@ -65,8 +64,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   predicate can be discovered and validated offline before an expensive detailed capture (#594).
   The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
   failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written
-  HTILE metadata instead; #611 implements that missing cache boundary. #569 still tracks exact depth/stencil
-  checkpoint serialization. The Dead Cells splash guard now checks the richest frame in its startup window against
+  HTILE metadata instead; #611 implements that missing cache boundary. Capture v8 now snapshots exact valid
+  depth/stencil planes with their complete cache identity and embeds the source bundle output oracle. Both the
+  normal production path and an invalidation-disabled stale-depth A/B replay byte-identically from one final
+  capsule in about 3.3 seconds (#569). The Dead Cells splash guard checks the richest frame in its startup window against
   a measured content threshold, avoiding its nondeterministic animation frame. UE4's measured GPU boundary remains
   under its area issues.
 

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -53,10 +53,12 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   structurization now restores them while varying and compute-wave forms still reject (#615). Capture v7 now
   records bounded raw stages, exact rejection opcode/PC, decoded state, and resource/descriptor summaries for
   every observed realization failure, so the next unsupported shader can be reduced offline (#618).
-- **Immediate milestone:** resolve exact depth/stencil checkpointing (#569). Keep extending the workflow across
-  Unity and Unreal targets rather than returning to long unstructured live traces. Timeline v6 closes the stale
-  Dead Cells checkpoint problem with offline target-span discovery and a two-route semantic selector (#594), and
-  the splash guard uses a measured run-level content threshold (#596/#573).
+- **Immediate milestone:** use the exact capture-v8 final checkpoint to bisect remaining Dead Cells composition
+  contracts without replaying 883 submits. #569 now preserves complete persistent DS identity, independent valid
+  planes, effective lifetime settings, and the source output oracle; source and standalone BMPs are byte-identical.
+  Keep extending this workflow across Unity and Unreal targets rather than returning to long unstructured live
+  traces. Timeline v6 supplies offline target-span discovery and a two-route semantic selector (#594), and the
+  splash guard uses a measured run-level content threshold (#596/#573).
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -81,6 +81,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 return true;
             });
     }
+    if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
+        getenv("PROSPER_GPU_REPLAY_EXPORT_DS"))
+        prosper::gpu::set_gpu_capture_ds_seed_snapshot_reader(
+            [](std::vector<prosper::gpu::GpuCaptureDsSeed>& seeds, std::string& error) {
+                return prosper::test::snapshot_persistent_ds_images(seeds, error);
+            });
     if (getenv("PROSPER_GPU_REPLAY_RTT_SEEDS"))
         prosper::gpu::set_gpu_replay_rtt_seed_writer([](const prosper::gpu::GpuCaptureRttSeed& seed, std::string& error) {
             const uint64_t expected = static_cast<uint64_t>(seed.width) * seed.height * 4;
@@ -91,6 +97,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             surface.w = seed.width; surface.h = seed.height; surface.rgba = seed.rgba;
             return true;
         });
+    if (getenv("PROSPER_GPU_REPLAY_DS_SEEDS"))
+        prosper::gpu::set_gpu_replay_ds_seed_writer(
+            [](const prosper::gpu::GpuCaptureDsSeed& seed, std::string& error) {
+                return prosper::test::restore_persistent_ds_image(seed, error);
+            });
     // A real command stream renders each CB_COLOR0_BASE into its own surface. Keep the old flattened
     // compositor only as a diagnostic fallback; it cannot preserve post chains or target extents.
     static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr ||

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -72,8 +72,8 @@ large capsule or bundle:
 The adjacent target indices 79 and 83, exact 90-draw count, and dispatch counts 7 and 9 all produced zero
 matches. The live selector reproduced the offline result and installed a gameplay capsule at its first match.
 
-The faithful playable reference on #608 retained 883 submits and renders hash
-`5759c125812154dc`. A final-submit replay with fresh depth renders `71b84bdfae53933c` instead. Use
+The faithful playable reference on #608 retained 883 submits; its `5759c125812154dc` hash is historical to the
+pre-#611/#615 renderer. A two-submit color-bounded replay still renders `71b84bdfae53933c`. Use
 `gpu_replay --bundle-ds-summary` to scan every depth/stencil identity and raw programming variant without
 reconstructing resource payloads or invoking Vulkan. Timeline-v5 `--depth-summary 642x362`, enabled during
 capture with `PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM=642x362`, found that the stable surface backing changed via
@@ -82,6 +82,10 @@ invalidates overlapping persistent Vulkan depth/stencil images on guest GPU writ
 layers. Dead Cells' four repeated fragment failures were uniform VCCZ-exit light loops; #615 adds a narrowly
 proved fragment/vertex structurization path and current gameplay submits realize every semantic draw. Use
 `shader_inspect` for raw `PROSPER_SHADER_DUMP` binaries; capture v7 retains bounded raw stages and exact
-failure diagnostics for unrealized operations (#618). The 35-second screenshot warmup still skips color RTT
-history and therefore remains an
-overbright progression diagnostic, not a color-correct gameplay oracle.
+failure diagnostics for unrealized operations (#618). Capture v8 additionally snapshots exact persistent
+Vulkan depth/stencil planes at final-submit entry; export it with `--bundle-final-capsule`, then require its
+standalone hash to equal the source bundle before using fast operation-prefix experiments (#569). The
+current invalidation-disabled stale-depth A/B is `535256588b67a536` in both the 883-submit source and a
+self-contained v8 capsule, with byte-identical BMPs and a 3.3-second standalone replay. The
+35-second screenshot warmup still skips color RTT
+history and therefore remains an overbright progression diagnostic, not a color-correct gameplay oracle.

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 7;
+constexpr uint32_t kVersion = 8;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -51,10 +51,13 @@ constexpr uint32_t kMaxRawShaderWords = 0x4000; // 64 KiB per failed stage
 constexpr uint32_t kMaxFailureStages = 3;
 constexpr uint32_t kMaxStringBytes = 1u << 20;
 constexpr uint64_t kMaxTotalRttSeedBytes = 1ull << 30;
+constexpr uint64_t kMaxTotalDsSeedBytes = 1ull << 30;
 
 CaptureRttSeedReader g_rtt_seed_reader;
 CaptureRttSeedSnapshotReader g_rtt_seed_snapshot_reader;
 ReplayRttSeedWriter g_rtt_seed_writer;
+CaptureDsSeedSnapshotReader g_ds_seed_snapshot_reader;
+ReplayDsSeedWriter g_ds_seed_writer;
 
 size_t read_capture_guest_memory(uint64_t addr, uint8_t* dst, size_t bytes) {
 #if defined(__linux__) || defined(__APPLE__)
@@ -346,6 +349,41 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
     const uint64_t bytes = checked_mul(pixels, 4);
     if (bytes > kMaxBlobBytes || bytes != seed.rgba.size()) {
         error = "RTT seed byte count does not match its RGBA extent"; return false;
+    }
+    return true;
+}
+
+auto ds_seed_key(const GpuCaptureDsSeed& seed) {
+    return std::tuple(seed.depth_read_base, seed.depth_write_base,
+                      seed.stencil_read_base, seed.stencil_write_base,
+                      seed.htile_data_base, seed.width, seed.height,
+                      static_cast<uint32_t>(seed.format));
+}
+
+bool validate_ds_seed(const GpuCaptureDsSeed& seed, std::string& error) {
+    if ((!seed.depth_read_base && !seed.depth_write_base && !seed.stencil_read_base &&
+         !seed.stencil_write_base && !seed.htile_data_base) || !seed.width || !seed.height) {
+        error = "DS seed has an invalid identity or extent"; return false;
+    }
+    if (seed.format != GpuCaptureDsFormat::D32Float &&
+        seed.format != GpuCaptureDsFormat::D32FloatS8) {
+        error = "DS seed has an unsupported format"; return false;
+    }
+    if (!seed.depth_valid && !seed.stencil_valid) {
+        error = "DS seed has no valid plane"; return false;
+    }
+    const uint64_t pixels = checked_mul(seed.width, seed.height);
+    const uint64_t depth_bytes = checked_mul(pixels, 4);
+    if ((seed.depth_valid && (depth_bytes > kMaxBlobBytes || depth_bytes != seed.depth.size())) ||
+        (!seed.depth_valid && !seed.depth.empty())) {
+        error = "DS seed depth byte count does not match its extent and validity"; return false;
+    }
+    if ((seed.stencil_valid &&
+         (seed.format != GpuCaptureDsFormat::D32FloatS8 || pixels > kMaxBlobBytes ||
+          pixels != seed.stencil.size())) ||
+        (!seed.stencil_valid && !seed.stencil.empty())) {
+        error = "DS seed stencil byte count does not match its extent, format, and validity";
+        return false;
     }
     return true;
 }
@@ -844,6 +882,28 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
             w.u32(stage.descriptor_issue_count); w.u32(stage.first_descriptor_issue);
         }
     }
+    if (c.ds_seeds.size() > kMaxResources) { error = "invalid DS seed count"; return false; }
+    uint64_t ds_seed_total = 0;
+    std::set<decltype(ds_seed_key(GpuCaptureDsSeed{}))> ds_seed_keys;
+    w.u32(static_cast<uint32_t>(c.ds_seeds.size()));
+    for (const auto& seed : c.ds_seeds) {
+        if (!validate_ds_seed(seed, error)) return false;
+        if (!ds_seed_keys.insert(ds_seed_key(seed)).second) {
+            error = "duplicate DS seed identity"; return false;
+        }
+        const uint64_t plane_bytes = seed.depth.size() + seed.stencil.size();
+        if (plane_bytes > kMaxTotalDsSeedBytes ||
+            ds_seed_total > kMaxTotalDsSeedBytes - plane_bytes) {
+            error = "capture DS seed data exceeds 1 GiB"; return false;
+        }
+        ds_seed_total += plane_bytes;
+        w.u64(seed.depth_read_base); w.u64(seed.depth_write_base);
+        w.u64(seed.stencil_read_base); w.u64(seed.stencil_write_base);
+        w.u64(seed.htile_data_base); w.u32(seed.width); w.u32(seed.height);
+        w.u32(static_cast<uint32_t>(seed.format));
+        w.u8(seed.depth_valid); w.u8(seed.stencil_valid);
+        w.bytes(seed.depth); w.bytes(seed.stencil);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1057,12 +1117,47 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         }
         if (!validate_failure_diagnostics(c, error)) return false;
     }
+    if (version >= 8) {
+        uint32_t seed_count = 0;
+        if (!r.u32(seed_count) || seed_count > kMaxResources) {
+            error = "invalid DS seed count"; return false;
+        }
+        c.ds_seeds.resize(seed_count);
+        uint64_t seed_total = 0;
+        std::set<decltype(ds_seed_key(GpuCaptureDsSeed{}))> keys;
+        for (auto& seed : c.ds_seeds) {
+            uint32_t format = 0;
+            uint8_t depth_valid = 0, stencil_valid = 0;
+            if (!r.u64(seed.depth_read_base) || !r.u64(seed.depth_write_base) ||
+                !r.u64(seed.stencil_read_base) || !r.u64(seed.stencil_write_base) ||
+                !r.u64(seed.htile_data_base) || !r.u32(seed.width) || !r.u32(seed.height) ||
+                !r.u32(format) || !r.u8(depth_valid) || !r.u8(stencil_valid) ||
+                !r.bytes(seed.depth) || !r.bytes(seed.stencil)) return false;
+            if (depth_valid > 1 || stencil_valid > 1) {
+                error = "invalid DS seed plane validity"; return false;
+            }
+            seed.format = static_cast<GpuCaptureDsFormat>(format);
+            seed.depth_valid = depth_valid != 0;
+            seed.stencil_valid = stencil_valid != 0;
+            if (!validate_ds_seed(seed, error)) return false;
+            if (!keys.insert(ds_seed_key(seed)).second) {
+                error = "duplicate DS seed identity"; return false;
+            }
+            const uint64_t plane_bytes = seed.depth.size() + seed.stencil.size();
+            if (plane_bytes > kMaxTotalDsSeedBytes ||
+                seed_total > kMaxTotalDsSeedBytes - plane_bytes) {
+                error = "capture DS seed data exceeds 1 GiB"; return false;
+            }
+            seed_total += plane_bytes;
+        }
+    }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
 }
 
 bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::string& error) {
-    error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs; out.rtt_seeds = c.rtt_seeds;
+    error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs;
+    out.rtt_seeds = c.rtt_seeds; out.ds_seeds = c.ds_seeds;
     out.raw_shader_versions = c.raw_shader_versions;
     out.failure_diagnostics = c.failure_diagnostics;
     out.failure_diagnostics_available = c.failure_diagnostics_available;
@@ -1166,6 +1261,56 @@ bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, s
     if (!seeds.empty() && !g_rtt_seed_writer) { error = "live renderer has no RTT seed writer"; return false; }
     for (const auto& seed : seeds) {
         if (!validate_rtt_seed(seed, error) || !g_rtt_seed_writer(seed, error)) return false;
+    }
+    return true;
+}
+
+void set_gpu_capture_ds_seed_snapshot_reader(CaptureDsSeedSnapshotReader reader) {
+    g_ds_seed_snapshot_reader = std::move(reader);
+}
+
+bool read_all_gpu_capture_ds_seeds(std::vector<GpuCaptureDsSeed>& seeds, std::string& error) {
+    error.clear(); seeds.clear();
+    if (!g_ds_seed_snapshot_reader) {
+        error = "live renderer has no DS seed snapshot reader"; return false;
+    }
+    if (!g_ds_seed_snapshot_reader(seeds, error)) return false;
+    if (seeds.size() > kMaxResources) { error = "invalid DS seed count"; return false; }
+    uint64_t total = 0;
+    std::set<decltype(ds_seed_key(GpuCaptureDsSeed{}))> keys;
+    for (const auto& seed : seeds) {
+        if (!validate_ds_seed(seed, error)) return false;
+        if (!keys.insert(ds_seed_key(seed)).second) {
+            error = "duplicate DS seed identity"; return false;
+        }
+        const uint64_t plane_bytes = seed.depth.size() + seed.stencil.size();
+        if (plane_bytes > kMaxTotalDsSeedBytes || total > kMaxTotalDsSeedBytes - plane_bytes) {
+            error = "DS seed bytes exceed limit"; return false;
+        }
+        total += plane_bytes;
+    }
+    std::sort(seeds.begin(), seeds.end(), [](const auto& a, const auto& b) {
+        return ds_seed_key(a) < ds_seed_key(b);
+    });
+    return true;
+}
+
+void set_gpu_replay_ds_seed_writer(ReplayDsSeedWriter writer) {
+    g_ds_seed_writer = std::move(writer);
+}
+
+bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std::string& error) {
+    error.clear();
+    if (!seeds.empty() && !g_ds_seed_writer) {
+        error = "live renderer has no DS seed writer"; return false;
+    }
+    std::set<decltype(ds_seed_key(GpuCaptureDsSeed{}))> keys;
+    for (const auto& seed : seeds) {
+        if (!validate_ds_seed(seed, error)) return false;
+        if (!keys.insert(ds_seed_key(seed)).second) {
+            error = "duplicate DS seed identity"; return false;
+        }
+        if (!g_ds_seed_writer(seed, error)) return false;
     }
     return true;
 }

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -122,12 +122,36 @@ struct GpuCaptureRttSeed {
     std::vector<uint8_t> rgba;
 };
 
+enum class GpuCaptureDsFormat : uint32_t {
+    D32Float = 1,
+    D32FloatS8 = 2,
+};
+
+// Exact host depth/stencil attachment contents retained across submits. These planes are detached
+// from guest tiled memory, just like RTT pixels, so a final-submit capsule needs an explicit copy of
+// every valid plane selected by the persistent renderer cache.
+struct GpuCaptureDsSeed {
+    uint64_t depth_read_base = 0;
+    uint64_t depth_write_base = 0;
+    uint64_t stencil_read_base = 0;
+    uint64_t stencil_write_base = 0;
+    uint64_t htile_data_base = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    GpuCaptureDsFormat format = GpuCaptureDsFormat::D32Float;
+    bool depth_valid = false;
+    bool stencil_valid = false;
+    std::vector<uint8_t> depth;
+    std::vector<uint8_t> stencil;
+};
+
 struct GpuCaptureFile {
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
     std::vector<GpuCaptureShaderVersion> shader_versions;
     std::vector<GpuCaptureRawShaderVersion> raw_shader_versions;
     std::vector<GpuCaptureRttSeed> rtt_seeds;
+    std::vector<GpuCaptureDsSeed> ds_seeds;
     std::vector<GpuCapturedDraw> draws;
     std::vector<GpuCapturedCompute> computes;
     std::vector<GpuCapturedOperation> operations;
@@ -144,6 +168,8 @@ using CaptureMemoryReader = std::function<size_t(uint64_t guest_addr, uint8_t* d
 using CaptureRttSeedReader = std::function<bool(uint64_t guest_addr, GpuCaptureRttSeed& seed)>;
 using CaptureRttSeedSnapshotReader =
     std::function<bool(std::vector<GpuCaptureRttSeed>& seeds, std::string& error)>;
+using CaptureDsSeedSnapshotReader =
+    std::function<bool(std::vector<GpuCaptureDsSeed>& seeds, std::string& error)>;
 
 bool capture_draw_items(const std::vector<DrawItem>& items, const GpuCaptureMetadata& metadata,
                         const CaptureMemoryReader& reader, GpuCaptureFile& out, std::string& error,
@@ -181,6 +207,7 @@ struct GpuReplayFrame {
     std::vector<GpuCaptureBlob> blobs;
     std::vector<ResourceInstance> resource_instances;
     std::vector<GpuCaptureRttSeed> rtt_seeds;
+    std::vector<GpuCaptureDsSeed> ds_seeds;
     std::vector<DrawItem> items;
     std::vector<ComputeItem> computes;
     std::vector<GpuCapturedOperation> operations;
@@ -194,16 +221,21 @@ struct GpuReplayFrame {
 
 bool materialize_gpu_replay(const GpuCaptureFile& capture, GpuReplayFrame& replay, std::string& error);
 
-// The Vulkan frontend owns the RTT cache and registers these hooks when its renderer is installed.
-// Capture queries only addresses referenced by the selected submit; replay restores the serialized
-// surfaces before draw zero.
+// The Vulkan frontend owns the RTT and persistent DS caches and registers these hooks when its renderer
+// is installed. Normal capture queries only RTT addresses referenced by the selected submit; final bundle
+// export snapshots both complete caches. Replay restores serialized surfaces before draw zero.
 using ReplayRttSeedWriter = std::function<bool(const GpuCaptureRttSeed& seed, std::string& error)>;
+using ReplayDsSeedWriter = std::function<bool(const GpuCaptureDsSeed& seed, std::string& error)>;
 void set_gpu_capture_rtt_seed_reader(CaptureRttSeedReader reader);
 bool read_gpu_capture_rtt_seed(uint64_t guest_addr, GpuCaptureRttSeed& seed, std::string& error);
 void set_gpu_capture_rtt_seed_snapshot_reader(CaptureRttSeedSnapshotReader reader);
 bool read_all_gpu_capture_rtt_seeds(std::vector<GpuCaptureRttSeed>& seeds, std::string& error);
 void set_gpu_replay_rtt_seed_writer(ReplayRttSeedWriter writer);
 bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, std::string& error);
+void set_gpu_capture_ds_seed_snapshot_reader(CaptureDsSeedSnapshotReader reader);
+bool read_all_gpu_capture_ds_seeds(std::vector<GpuCaptureDsSeed>& seeds, std::string& error);
+void set_gpu_replay_ds_seed_writer(ReplayDsSeedWriter writer);
+bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std::string& error);
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size);
 inline uint64_t gpu_capture_hash(const std::vector<uint8_t>& data) {
     return gpu_capture_hash(data.data(), data.size());

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -163,6 +163,7 @@ GpuCaptureFile make_capture_manifest(const GpuCaptureFile& capture) {
     manifest.expected_output_bytes = capture.expected_output_bytes;
     manifest.expected_output_valid = capture.expected_output_valid;
     manifest.rtt_seeds = capture.rtt_seeds;
+    manifest.ds_seeds = capture.ds_seeds;
     manifest.shader_versions = capture.shader_versions;
     manifest.raw_shader_versions = capture.raw_shader_versions;
     manifest.draws = capture.draws;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4,11 +4,13 @@
 // including test links Vulkan::Vulkan.
 #pragma once
 #include <vulkan/vulkan.h>
+#include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/render_state.hpp"
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -181,6 +183,16 @@ inline const RenderVkCtx& render_vk_ctx() {
     return c;
 }
 
+inline uint32_t render_memory_type(VkPhysicalDevice phys, uint32_t bits,
+                                   VkMemoryPropertyFlags wanted) {
+    VkPhysicalDeviceMemoryProperties properties{};
+    vkGetPhysicalDeviceMemoryProperties(phys, &properties);
+    for (uint32_t i = 0; i < properties.memoryTypeCount; ++i)
+        if ((bits & (1u << i)) &&
+            (properties.memoryTypes[i].propertyFlags & wanted) == wanted) return i;
+    return UINT32_MAX;
+}
+
 struct PersistentDsKey {
     uint64_t dr = 0, dw = 0, sr = 0, sw = 0, htile = 0;
     uint32_t w = 0, h = 0, fmt = 0;
@@ -246,6 +258,238 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
         fprintf(stderr, "[ds] guest-write addr=%llx size=%llu invalidated=%zu\n",
                 (unsigned long long)addr, (unsigned long long)size, invalidated);
     return invalidated;
+}
+
+inline bool persistent_ds_transfer_buffer(const RenderVkCtx& ctx, VkDeviceSize bytes,
+                                          VkBufferUsageFlags usage, VkBuffer& buffer,
+                                          VkDeviceMemory& memory, std::string& error) {
+    VkBufferCreateInfo info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    info.size = bytes; info.usage = usage;
+    if (vkCreateBuffer(ctx.dev, &info, nullptr, &buffer) != VK_SUCCESS) {
+        error = "cannot create persistent DS transfer buffer"; return false;
+    }
+    VkMemoryRequirements requirements{};
+    vkGetBufferMemoryRequirements(ctx.dev, buffer, &requirements);
+    VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    allocation.allocationSize = requirements.size;
+    allocation.memoryTypeIndex = render_memory_type(
+        ctx.phys, requirements.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (allocation.memoryTypeIndex == UINT32_MAX ||
+        vkAllocateMemory(ctx.dev, &allocation, nullptr, &memory) != VK_SUCCESS ||
+        vkBindBufferMemory(ctx.dev, buffer, memory, 0) != VK_SUCCESS) {
+        if (memory) vkFreeMemory(ctx.dev, memory, nullptr);
+        vkDestroyBuffer(ctx.dev, buffer, nullptr); buffer = VK_NULL_HANDLE; memory = VK_NULL_HANDLE;
+        error = "cannot allocate persistent DS transfer buffer"; return false;
+    }
+    return true;
+}
+
+inline bool submit_persistent_ds_transfer(const RenderVkCtx& ctx, VkImage image,
+                                          VkImageAspectFlags aspects, VkImageLayout old_layout,
+                                          VkImageLayout transfer_layout, VkBuffer buffer,
+                                          uint32_t width, uint32_t height,
+                                          bool copy_depth, bool copy_stencil,
+                                          bool upload, std::string& error) {
+    VkCommandPool pool = VK_NULL_HANDLE;
+    VkCommandBuffer command = VK_NULL_HANDLE;
+    VkFence fence = VK_NULL_HANDLE;
+    VkCommandPoolCreateInfo pool_info{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+    pool_info.queueFamilyIndex = ctx.qfi;
+    if (vkCreateCommandPool(ctx.dev, &pool_info, nullptr, &pool) != VK_SUCCESS) {
+        error = "cannot create persistent DS transfer command pool"; return false;
+    }
+    VkCommandBufferAllocateInfo command_info{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+    command_info.commandPool = pool; command_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    command_info.commandBufferCount = 1;
+    VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    if (vkAllocateCommandBuffers(ctx.dev, &command_info, &command) != VK_SUCCESS ||
+        vkBeginCommandBuffer(command, &begin) != VK_SUCCESS) {
+        vkDestroyCommandPool(ctx.dev, pool, nullptr);
+        error = "cannot begin persistent DS transfer command"; return false;
+    }
+    VkImageMemoryBarrier barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    barrier.oldLayout = old_layout; barrier.newLayout = transfer_layout;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = image;
+    barrier.subresourceRange = {aspects, 0, 1, 0, 1};
+    barrier.srcAccessMask = old_layout == VK_IMAGE_LAYOUT_UNDEFINED ? 0 :
+        (VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+         VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+    barrier.dstAccessMask = upload ? VK_ACCESS_TRANSFER_WRITE_BIT : VK_ACCESS_TRANSFER_READ_BIT;
+    const VkPipelineStageFlags source_stage = old_layout == VK_IMAGE_LAYOUT_UNDEFINED
+        ? VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT
+        : VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    vkCmdPipelineBarrier(command, source_stage, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                         0, nullptr, 0, nullptr, 1, &barrier);
+
+    VkDeviceSize offset = 0;
+    auto copy_plane = [&](VkImageAspectFlagBits aspect, VkDeviceSize bytes) {
+        VkBufferImageCopy copy{};
+        copy.bufferOffset = offset;
+        copy.imageSubresource = {static_cast<VkImageAspectFlags>(aspect), 0, 0, 1};
+        copy.imageExtent = {width, height, 1};
+        if (upload)
+            vkCmdCopyBufferToImage(command, buffer, image, transfer_layout, 1, &copy);
+        else
+            vkCmdCopyImageToBuffer(command, image, transfer_layout, buffer, 1, &copy);
+        offset += bytes;
+    };
+    if (copy_depth) copy_plane(VK_IMAGE_ASPECT_DEPTH_BIT,
+                               static_cast<VkDeviceSize>(width) * height * 4);
+    if (copy_stencil) copy_plane(VK_IMAGE_ASPECT_STENCIL_BIT,
+                                 static_cast<VkDeviceSize>(width) * height);
+
+    barrier.oldLayout = transfer_layout;
+    barrier.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    barrier.srcAccessMask = upload ? VK_ACCESS_TRANSFER_WRITE_BIT : VK_ACCESS_TRANSFER_READ_BIT;
+    barrier.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                            VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                         VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                         0, 0, nullptr, 0, nullptr, 1, &barrier);
+    VkFenceCreateInfo fence_info{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    const bool recorded = vkEndCommandBuffer(command) == VK_SUCCESS;
+    const bool fenced = recorded &&
+        vkCreateFence(ctx.dev, &fence_info, nullptr, &fence) == VK_SUCCESS;
+    VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    submit.commandBufferCount = 1; submit.pCommandBuffers = &command;
+    const bool submitted = fenced && vkQueueSubmit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
+    bool finished = submitted &&
+        vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000) == VK_SUCCESS;
+    if (submitted && !finished) finished = vkQueueWaitIdle(ctx.queue) == VK_SUCCESS;
+    if (fence) vkDestroyFence(ctx.dev, fence, nullptr);
+    vkDestroyCommandPool(ctx.dev, pool, nullptr);
+    if (!finished) { error = "persistent DS transfer did not complete"; return false; }
+    return true;
+}
+
+inline bool snapshot_persistent_ds_images(std::vector<prosper::gpu::GpuCaptureDsSeed>& seeds,
+                                          std::string& error) {
+    error.clear(); seeds.clear();
+    const RenderVkCtx& ctx = render_vk_ctx();
+    if (!ctx.ok) { error = "Vulkan renderer is unavailable"; return false; }
+    for (const auto& [key, image] : persistent_ds_cache()) {
+        if (!image.depth_valid && !image.stencil_valid) continue;
+        if (!image.image || !image.layout_initialized) {
+            error = "valid persistent DS cache entry has no initialized image"; return false;
+        }
+        prosper::gpu::GpuCaptureDsSeed seed;
+        seed.depth_read_base = key.dr; seed.depth_write_base = key.dw;
+        seed.stencil_read_base = key.sr; seed.stencil_write_base = key.sw;
+        seed.htile_data_base = key.htile; seed.width = key.w; seed.height = key.h;
+        if (key.fmt == static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT))
+            seed.format = prosper::gpu::GpuCaptureDsFormat::D32Float;
+        else if (key.fmt == static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT_S8_UINT))
+            seed.format = prosper::gpu::GpuCaptureDsFormat::D32FloatS8;
+        else {
+            error = "persistent DS cache uses an unsupported capture format"; return false;
+        }
+        seed.depth_valid = image.depth_valid;
+        seed.stencil_valid = image.stencil_valid;
+        const size_t depth_bytes = seed.depth_valid ? static_cast<size_t>(key.w) * key.h * 4 : 0;
+        const size_t stencil_bytes = seed.stencil_valid ? static_cast<size_t>(key.w) * key.h : 0;
+        VkBuffer buffer = VK_NULL_HANDLE; VkDeviceMemory memory = VK_NULL_HANDLE;
+        if (!persistent_ds_transfer_buffer(ctx, depth_bytes + stencil_bytes,
+                                           VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                           buffer, memory, error)) return false;
+        const VkImageAspectFlags aspects = VK_IMAGE_ASPECT_DEPTH_BIT |
+            (key.fmt == static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT_S8_UINT)
+                 ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
+        const bool copied = submit_persistent_ds_transfer(
+            ctx, image.image, aspects, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer, key.w, key.h,
+            seed.depth_valid, seed.stencil_valid, false, error);
+        void* mapped = nullptr;
+        const bool mapped_ok = copied &&
+            vkMapMemory(ctx.dev, memory, 0, depth_bytes + stencil_bytes, 0, &mapped) == VK_SUCCESS;
+        if (mapped_ok) {
+            const auto* bytes = static_cast<const uint8_t*>(mapped);
+            seed.depth.assign(bytes, bytes + depth_bytes);
+            seed.stencil.assign(bytes + depth_bytes, bytes + depth_bytes + stencil_bytes);
+            vkUnmapMemory(ctx.dev, memory);
+        }
+        vkDestroyBuffer(ctx.dev, buffer, nullptr); vkFreeMemory(ctx.dev, memory, nullptr);
+        if (!mapped_ok) {
+            if (error.empty()) error = "cannot map persistent DS readback";
+            return false;
+        }
+        seeds.push_back(std::move(seed));
+    }
+    return true;
+}
+
+inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& seed,
+                                        std::string& error) {
+    error.clear();
+    const RenderVkCtx& ctx = render_vk_ctx();
+    if (!ctx.ok) { error = "Vulkan renderer is unavailable"; return false; }
+    const VkFormat format = seed.format == prosper::gpu::GpuCaptureDsFormat::D32Float
+        ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D32_SFLOAT_S8_UINT;
+    const VkImageAspectFlags aspects = VK_IMAGE_ASPECT_DEPTH_BIT |
+        (format == VK_FORMAT_D32_SFLOAT_S8_UINT ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
+    PersistentDsKey key{seed.depth_read_base, seed.depth_write_base,
+                        seed.stencil_read_base, seed.stencil_write_base,
+                        seed.htile_data_base, seed.width, seed.height,
+                        static_cast<uint32_t>(format)};
+    PersistentDsImage& image = persistent_ds_cache()[key];
+    if (!image.image) {
+        VkImageCreateInfo info{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+        info.imageType = VK_IMAGE_TYPE_2D; info.format = format;
+        info.extent = {seed.width, seed.height, 1};
+        info.mipLevels = 1; info.arrayLayers = 1; info.samples = VK_SAMPLE_COUNT_1_BIT;
+        info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        if (vkCreateImage(ctx.dev, &info, nullptr, &image.image) != VK_SUCCESS) {
+            error = "cannot create restored persistent DS image"; return false;
+        }
+        VkMemoryRequirements requirements{};
+        vkGetImageMemoryRequirements(ctx.dev, image.image, &requirements);
+        VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        allocation.allocationSize = requirements.size;
+        allocation.memoryTypeIndex = render_memory_type(ctx.phys, requirements.memoryTypeBits, 0);
+        VkImageViewCreateInfo view_info{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+        view_info.image = image.image; view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        view_info.format = format; view_info.subresourceRange = {aspects, 0, 1, 0, 1};
+        if (allocation.memoryTypeIndex == UINT32_MAX ||
+            vkAllocateMemory(ctx.dev, &allocation, nullptr, &image.memory) != VK_SUCCESS ||
+            vkBindImageMemory(ctx.dev, image.image, image.memory, 0) != VK_SUCCESS ||
+            vkCreateImageView(ctx.dev, &view_info, nullptr, &image.view) != VK_SUCCESS) {
+            if (image.view) vkDestroyImageView(ctx.dev, image.view, nullptr);
+            vkDestroyImage(ctx.dev, image.image, nullptr);
+            if (image.memory) vkFreeMemory(ctx.dev, image.memory, nullptr);
+            image = {};
+            error = "cannot allocate restored persistent DS image"; return false;
+        }
+    }
+    const size_t transfer_bytes = seed.depth.size() + seed.stencil.size();
+    VkBuffer buffer = VK_NULL_HANDLE; VkDeviceMemory memory = VK_NULL_HANDLE;
+    if (!persistent_ds_transfer_buffer(ctx, transfer_bytes, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                                       buffer, memory, error)) return false;
+    void* mapped = nullptr;
+    if (vkMapMemory(ctx.dev, memory, 0, transfer_bytes, 0, &mapped) != VK_SUCCESS) {
+        vkDestroyBuffer(ctx.dev, buffer, nullptr); vkFreeMemory(ctx.dev, memory, nullptr);
+        error = "cannot map persistent DS upload"; return false;
+    }
+    if (!seed.depth.empty()) std::memcpy(mapped, seed.depth.data(), seed.depth.size());
+    if (!seed.stencil.empty())
+        std::memcpy(static_cast<uint8_t*>(mapped) + seed.depth.size(),
+                    seed.stencil.data(), seed.stencil.size());
+    vkUnmapMemory(ctx.dev, memory);
+    const VkImageLayout old_layout = image.layout_initialized
+        ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+    const bool copied = submit_persistent_ds_transfer(
+        ctx, image.image, aspects, old_layout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        buffer, seed.width, seed.height, seed.depth_valid, seed.stencil_valid, true, error);
+    vkDestroyBuffer(ctx.dev, buffer, nullptr); vkFreeMemory(ctx.dev, memory, nullptr);
+    if (!copied) return false;
+    image.layout_initialized = true;
+    image.depth_valid = seed.depth_valid; image.stencil_valid = seed.stencil_valid;
+    return true;
 }
 
 inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H,
@@ -402,7 +646,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkImageCreateInfo dci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
         dci.imageType = VK_IMAGE_TYPE_2D; dci.format = DFMT; dci.extent = {W, H, 1};
         dci.mipLevels = 1; dci.arrayLayers = 1; dci.samples = VK_SAMPLE_COUNT_1_BIT;
-        dci.tiling = VK_IMAGE_TILING_OPTIMAL; dci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+        dci.tiling = VK_IMAGE_TILING_OPTIMAL;
+        dci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                    VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         vkCreateImage(dev, &dci, nullptr, &dimg);
         VkMemoryRequirements dr; vkGetImageMemoryRequirements(dev, dimg, &dr);
         VkMemoryAllocateInfo dai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -93,11 +93,36 @@ int main() {
           "capture indexes unique shaders and retains operation provenance");
     captured.expected_output_valid = true;
     captured.expected_output_hash = 0x1122334455667788ull; captured.expected_output_bytes = 480ull * 270 * 4;
+    GpuCaptureDsSeed ds_seed;
+    ds_seed.depth_read_base = 0x810000; ds_seed.depth_write_base = 0x810000;
+    ds_seed.stencil_read_base = 0x820000; ds_seed.stencil_write_base = 0x820000;
+    ds_seed.htile_data_base = 0x800000; ds_seed.width = 2; ds_seed.height = 2;
+    ds_seed.format = GpuCaptureDsFormat::D32FloatS8;
+    ds_seed.depth_valid = true; ds_seed.stencil_valid = true;
+    ds_seed.depth.assign(16, 0x31); ds_seed.stencil = {1, 2, 3, 4};
+    captured.ds_seeds.push_back(ds_seed);
 
     auto path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_test.prgcap";
     GpuCaptureFile duplicate_seed = captured; duplicate_seed.rtt_seeds.push_back(captured.rtt_seeds[0]);
     CHECK(!write_gpu_capture(path.string(), duplicate_seed, error) && error == "duplicate RTT seed address",
           "writer rejects duplicate temporal RTT seed addresses");
+    GpuCaptureFile duplicate_ds = captured; duplicate_ds.ds_seeds.push_back(ds_seed);
+    CHECK(!write_gpu_capture(path.string(), duplicate_ds, error) && error == "duplicate DS seed identity",
+          "writer rejects duplicate persistent DS seed identities");
+    GpuCaptureFile stencil_only = captured;
+    stencil_only.ds_seeds[0].depth_valid = false; stencil_only.ds_seeds[0].depth.clear();
+    std::vector<uint8_t> stencil_only_bytes;
+    GpuCaptureFile stencil_only_loaded;
+    CHECK(serialize_gpu_capture(stencil_only, stencil_only_bytes, error) &&
+          deserialize_gpu_capture(stencil_only_bytes, stencil_only_loaded, error) &&
+          !stencil_only_loaded.ds_seeds[0].depth_valid &&
+          stencil_only_loaded.ds_seeds[0].stencil_valid,
+          "stencil-only validity survives capture v8 independently of depth");
+    GpuCaptureFile invalid_stencil_format = stencil_only;
+    invalid_stencil_format.ds_seeds[0].format = GpuCaptureDsFormat::D32Float;
+    CHECK(!serialize_gpu_capture(invalid_stencil_format, stencil_only_bytes, error) &&
+          error == "DS seed stencil byte count does not match its extent, format, and validity",
+          "writer rejects stencil bytes for a depth-only format");
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
@@ -113,6 +138,10 @@ int main() {
           "content versions and draw operation identity round-trip");
     CHECK(loaded.rtt_seeds.size() == 1 && loaded.rtt_seeds[0].width == 2 &&
           loaded.rtt_seeds[0].rgba == temporal_rgba, "temporal RTT seed round-trips");
+    CHECK(loaded.ds_seeds.size() == 1 && loaded.ds_seeds[0].depth == ds_seed.depth &&
+          loaded.ds_seeds[0].stencil == ds_seed.stencil && loaded.ds_seeds[0].depth_valid &&
+          loaded.ds_seeds[0].stencil_valid,
+          "persistent depth and stencil planes round-trip independently");
     CHECK(loaded.draws[0].ps.db_render_control == 2 && loaded.draws[0].ps.stencil_clear_enable &&
           loaded.draws[0].ps.has_stencil_clear && loaded.draws[0].ps.stencil_clear_value == 3 &&
           loaded.draws[0].ps.stencil_read_base == 0x12345000 &&
@@ -136,6 +165,8 @@ int main() {
           "materialized draw retains its source operation identity");
     CHECK(replay.rtt_seeds.size() == 1 && replay.rtt_seeds[0].guest_addr == draw.color0_base,
           "materialized replay owns temporal RTT seed pixels");
+    CHECK(replay.ds_seeds.size() == 1 && replay.ds_seeds[0].htile_data_base == 0x800000,
+          "materialized replay owns persistent DS checkpoint bytes");
 
     std::vector<uint8_t> repeated(48);
     for (size_t i = 0; i < 16; ++i) repeated[i] = repeated[i + 32] = static_cast<uint8_t>(i * 3 + 1);
@@ -262,20 +293,28 @@ int main() {
           error == "failed-operation raw shader data exceeds its bounded limit",
           "writer enforces the documented 64 KiB per-stage raw bound");
 
+    GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
-    CHECK(serialize_gpu_capture(captured, legacy_bytes, error) && legacy_bytes.size() >= 20,
-          "created a diagnostic-free v7 payload for the legacy-reader fixture");
-    if (legacy_bytes.size() >= 20) {
-        legacy_bytes[8] = 6; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
-        legacy_bytes.resize(legacy_bytes.size() - 8); // remove v7 raw-shader/diagnostic zero counts
+    CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 24,
+          "created a diagnostic-free v8 payload for legacy-reader fixtures");
+    if (legacy_bytes.size() >= 24) {
+        legacy_bytes.resize(legacy_bytes.size() - 4); // remove v8 DS-seed zero count
+        legacy_bytes[8] = 7; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
     }
     GpuCaptureFile legacy_loaded;
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
+          legacy_loaded.failure_diagnostics_available && legacy_loaded.ds_seeds.empty(),
+          "v7 capture reopens without persistent DS checkpoint data");
+    if (legacy_bytes.size() >= 20) {
+        legacy_bytes.resize(legacy_bytes.size() - 8); // remove v7 raw-shader/diagnostic zero counts
+        legacy_bytes[8] = 6;
+    }
+    CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 8;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 9;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 8",
+          error == "unsupported capture version 9",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;
@@ -314,6 +353,35 @@ int main() {
     CHECK(!read_gpu_capture_rtt_seed(0x9000, exported_seed, error) &&
           error == "live renderer has no RTT seed reader",
           "RTT export fails explicitly without a registered renderer reader");
+
+    set_gpu_capture_ds_seed_snapshot_reader(
+        [&](std::vector<GpuCaptureDsSeed>& seeds, std::string&) {
+            GpuCaptureDsSeed high = ds_seed, low = ds_seed;
+            high.depth_read_base = high.depth_write_base = 0xa10000;
+            low.depth_read_base = low.depth_write_base = 0x710000;
+            seeds.push_back(std::move(high)); seeds.push_back(std::move(low));
+            return true;
+        });
+    std::vector<GpuCaptureDsSeed> exported_ds;
+    CHECK(read_all_gpu_capture_ds_seeds(exported_ds, error) && exported_ds.size() == 2 &&
+          exported_ds[0].depth_read_base == 0x710000 &&
+          exported_ds[1].depth_read_base == 0xa10000,
+          "registered DS snapshot reader validates and sorts the complete live cache");
+    GpuCaptureDsSeed restored_ds;
+    set_gpu_replay_ds_seed_writer([&](const GpuCaptureDsSeed& seed, std::string&) {
+        restored_ds = seed; return true;
+    });
+    CHECK(restore_gpu_replay_ds_seeds({ds_seed}, error) && restored_ds.depth == ds_seed.depth &&
+          restored_ds.stencil == ds_seed.stencil,
+          "registered DS writer receives exact validated checkpoint planes");
+    set_gpu_capture_ds_seed_snapshot_reader({});
+    CHECK(!read_all_gpu_capture_ds_seeds(exported_ds, error) &&
+          error == "live renderer has no DS seed snapshot reader",
+          "DS snapshot export fails explicitly without a registered renderer reader");
+    set_gpu_replay_ds_seed_writer({});
+    CHECK(!restore_gpu_replay_ds_seeds({ds_seed}, error) &&
+          error == "live renderer has no DS seed writer",
+          "DS restore fails explicitly without a registered renderer writer");
 
     auto truncated = path; truncated += ".truncated";
     std::filesystem::copy_file(path, truncated, std::filesystem::copy_options::overwrite_existing);

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -56,6 +56,12 @@ int main() {
     failed_operation.stages.push_back(failed_stage);
     first.failure_diagnostics.push_back(failed_operation);
     first.failure_diagnostics_available = true;
+    GpuCaptureDsSeed ds_seed;
+    ds_seed.depth_read_base = ds_seed.depth_write_base = 0x310000;
+    ds_seed.htile_data_base = 0x300000; ds_seed.width = 2; ds_seed.height = 2;
+    ds_seed.format = GpuCaptureDsFormat::D32Float;
+    ds_seed.depth_valid = true; ds_seed.depth.assign(16, 0x5a);
+    first.ds_seeds.push_back(ds_seed);
     GpuCaptureFile second = first;
     second.metadata.submit_index = 42;
     second.metadata.input_route = "shift-the-serialized-blob-boundary";
@@ -108,11 +114,13 @@ int main() {
           restored_second.metadata.submit_index == 42 && restored_second.blobs.size() == 1 &&
           restored_second.blobs[0].guest_addr == 0x200000 && restored_second.blobs[0].bytes == blob.bytes &&
           restored_second.failure_diagnostics_available && restored_second.failure_diagnostics.size() == 1 &&
-          restored_second.raw_shader_versions[0].words == failed_shader.words,
+          restored_second.raw_shader_versions[0].words == failed_shader.words &&
+          restored_second.ds_seeds.size() == 1 && restored_second.ds_seeds[0].depth == ds_seed.depth,
           "bundle reconstructs an exact validated capture");
     CHECK(materialize_gpu_capture_bundle_manifest(loaded, 1, second_manifest, error) &&
           second_manifest.metadata.submit_index == 42 && second_manifest.blobs.size() == 1 &&
-          second_manifest.blobs[0].bytes.empty() && second_manifest.draws.size() == restored_second.draws.size(),
+          second_manifest.blobs[0].bytes.empty() && second_manifest.draws.size() == restored_second.draws.size() &&
+          second_manifest.ds_seeds.size() == 1 && second_manifest.ds_seeds[0].depth == ds_seed.depth,
           "manifest-only materialization exposes submit state without resource payload reconstruction");
     restored_first.blobs[0].bytes[0] ^= 0xff;
     CHECK(restored_second.blobs[0].bytes == blob.bytes,

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -2,6 +2,7 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../frontends/shared/live_renderer.hpp"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -61,8 +62,12 @@ int main() {
 
 #ifdef _WIN32
     _putenv_s("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
+    _putenv_s("PROSPER_GPU_REPLAY_DS_SEEDS", "1");
+    _putenv_s("PROSPER_GPU_REPLAY_EXPORT_DS", "1");
 #else
     setenv("PROSPER_GPU_REPLAY_RTT_SEEDS", "1", 1);
+    setenv("PROSPER_GPU_REPLAY_DS_SEEDS", "1", 1);
+    setenv("PROSPER_GPU_REPLAY_EXPORT_DS", "1", 1);
 #endif
     prosper::frontend::register_live_renderer(".", false);
     std::vector<uint8_t> pixels = render_submit_items(replay.items, W, H);
@@ -138,6 +143,31 @@ int main() {
         CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
               "temporal consumer samples restored host RTT pixels, not guest-memory fallback");
     }
+
+    GpuCaptureDsSeed ds_seed;
+    ds_seed.depth_read_base = ds_seed.depth_write_base = 0x810000;
+    ds_seed.stencil_read_base = ds_seed.stencil_write_base = 0x820000;
+    ds_seed.htile_data_base = 0x800000;
+    ds_seed.width = 4; ds_seed.height = 3;
+    ds_seed.format = GpuCaptureDsFormat::D32FloatS8;
+    ds_seed.depth_valid = true; ds_seed.stencil_valid = true;
+    ds_seed.depth.resize(4u * 3u * 4u);
+    ds_seed.stencil.resize(4u * 3u);
+    for (size_t i = 0; i < ds_seed.depth.size(); ++i)
+        ds_seed.depth[i] = static_cast<uint8_t>(i * 17u + 3u);
+    for (size_t i = 0; i < ds_seed.stencil.size(); ++i)
+        ds_seed.stencil[i] = static_cast<uint8_t>(i * 11u + 1u);
+    CHECK(restore_gpu_replay_ds_seeds({ds_seed}, error),
+          "replay uploads exact persistent Vulkan depth and stencil planes");
+    std::vector<GpuCaptureDsSeed> ds_snapshot;
+    const bool ds_read = read_all_gpu_capture_ds_seeds(ds_snapshot, error);
+    const auto restored = std::find_if(ds_snapshot.begin(), ds_snapshot.end(), [&](const auto& seed) {
+        return seed.depth_read_base == ds_seed.depth_read_base &&
+               seed.stencil_read_base == ds_seed.stencil_read_base;
+    });
+    CHECK(ds_read && restored != ds_snapshot.end() && restored->depth == ds_seed.depth &&
+          restored->stencil == ds_seed.stencil && restored->depth_valid && restored->stencil_valid,
+          "persistent Vulkan DS snapshot reads back byte-exact checkpoint contents");
 
     DrawItem missing_texture = replay.items[0];
     missing_texture.prt = std::make_shared<ShaderResourceTable>();

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -78,7 +78,7 @@ compact target-extent spans; use `--signatures DRAWS DISPATCHES` to discover sce
 independent of `PROSPER_RENDER_EVERY`. To materialize one exact indexed submit without rendering the
 warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
-version-7 capsules deduplicate content-addressed shader/resource versions, retain complete raw depth-surface
+version-8 capsules deduplicate content-addressed shader/resource versions, retain complete raw depth-surface
 programming, and preserve mixed draw/dispatch order plus explicit unrealized operations. Failed operations
 also retain bounded raw stages and exact rejection/state summaries; inspect them with `gpu_replay --inspect-only`
 and extract one with `--dump-failed-shader FAILURE:STAGE PATH`. Selection is
@@ -112,9 +112,11 @@ writer while timeline/lifetime recording continues, avoiding progression distort
 lifetime evidence proves the suffix contains the target's beginning, then inspect its lower-bound frontier.
 `gpu_replay --bundle-intermediate-through-target WxH` omits later passes from non-final submits only when
 dependency evidence proves that the named target family is the sole temporal image frontier.
-`gpu_replay --bundle-final-capsule PATH` exports the complete live color RTT cache; verify its standalone output
-hash against the bundle before using it for rapid final-submit isolation. Persistent Vulkan depth/stencil images
-are not serialized yet (#569/#611), so complete color seeds do not guarantee equality.
+`gpu_replay --bundle-final-capsule PATH` exports the complete live color RTT cache plus exact valid planes from
+the persistent Vulkan depth/stencil cache into a capture-v8 capsule. Verify its standalone output hash against
+the bundle before using it for rapid final-submit isolation. `--inspect-only` prints each DS seed's full cache
+identity, format, independent validity flags, byte counts, and hashes. Captures v1-v7 remain readable without
+invented DS state.
 `gpu_replay --bundle-extract-submit N PATH` materializes one exact manifest for normal inspect/graph/validate
 work without replaying the bundle.
 `gpu_replay --bundle-find-ds ADDR` scans compact manifests for guest depth/stencil use, writes, clears, compare

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -1,7 +1,8 @@
 # GPU replay
 
 `gpu_replay` inspects, validates, graphs, and renders a local `.prgcap` without booting the guest.
-Capsules contain title-derived shaders, resource bytes, addresses, and optional rendered RTT pixels.
+Capsules contain title-derived shaders, resource bytes, addresses, optional rendered RTT pixels, and optional
+exact persistent Vulkan depth/stencil checkpoint planes.
 They are gitignored local artifacts and must never be committed or shared as project fixtures.
 
 Build from `prosper/`, using the worktree-local Linux build:
@@ -67,7 +68,7 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 
 ### Failed operations
 
-Capture v7 retains bounded diagnostics for draws and dispatches that semantic PM4 ordering contains but the
+Capture v7 and later retain bounded diagnostics for draws and dispatches that semantic PM4 ordering contains but the
 executor cannot realize. `--inspect-only` prints the failure reason, decoded target/pipeline or compute-launch
 state, every referenced stage address, resource-table presence/count, descriptor issues, recompile coverage,
 and the first rejected opcode/format at its exact dword PC. It also prints the raw RDNA2 content hash, byte
@@ -79,6 +80,12 @@ stage is fault-safely read once, content-deduplicated, capped at 64 KiB, and sto
 `s_endpgm`/unknown instruction or the cap. Total failed-stage data is capped at 64 MiB, diagnostics cannot
 outnumber semantic operations, and every reference/hash is validated while reading. Captures v1-v6 remain
 readable and print `failure-diagnostics: unavailable (capture predates v7)` rather than inventing evidence.
+
+Capture v8 adds persistent depth/stencil checkpoints. Each seed stores the renderer's complete guest cache
+identity (depth/stencil read/write bases, HTILE base, extent, and D32/D32S8 format), independent depth/stencil
+validity, and raw valid-plane bytes. Counts, extents, formats, duplicate identities, per-plane lengths, and a
+1 GiB total are validated before allocation or Vulkan upload. Captures v1-v7 remain readable with zero DS
+seeds. `--inspect-only` prints every seed's identity, validity, byte counts, and content hashes.
 
 Compute selectors use the realized compute index printed by `--inspect-only`. The resource selector is
 `COMPUTE:BINDING`; it writes the captured pre-dispatch storage-buffer bytes, while `--dump-compute` writes
@@ -103,7 +110,7 @@ restored. The tool rejects a predecessor whose submit number is not earlier. A c
 consumer sampled the retained producer output, but it does not prove faithful closure: graph the predecessor
 and continue if it also has temporal leaves.
 
-`--bundle` reconstructs each captured submit through the normal version-7 validator, executes them in
+`--bundle` reconstructs each captured submit through the normal versioned validator, executes them in
 ascending order through one renderer instance, and releases each materialized submit before the next.
 The summary reports logical versus unique bytes, per-submit output hashes, and every temporal image leaf:
 
@@ -126,11 +133,15 @@ that only the named target family crosses submit boundaries. The final submit re
 if an included temporal image leaf has another extent or an intermediate submit has no matching draw. This is
 an evidence-gated optimization, not automatic dependency closure.
 
-`--bundle-final-capsule PATH` snapshots the complete live color RTT cache before executing the final submit
-and writes it as seeds in a standalone capsule. Its standalone output must match the bundle's final hash before
-using it for fast `--draw`, resource, or shader experiments. Export validates every surface and fails when a
-required temporal surface is absent; it never substitutes zero pixels. The capsule does not yet serialize live
-Vulkan depth/stencil images (#569/#611), so a hash mismatch can remain even when every color seed is exact.
+`--bundle-final-capsule PATH` snapshots the complete live color RTT and persistent Vulkan depth/stencil caches
+before executing the final submit and writes them as seeds in a standalone capture-v8 capsule. Its standalone
+output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or
+shader experiments. Export validates every surface and fails when a required temporal color surface is absent;
+it never substitutes zero pixels. The file is installed only after the source final submit renders, and embeds
+that output byte count/hash as its replay oracle. A legacy pre-v7 manifest with unrealized operations is migrated explicitly to
+`Unknown` failure diagnostics with the original operation kind/source/order, so the v8 writer remains strict.
+The DS snapshot uses transfer barriers to return every image to depth/stencil-attachment layout before the final
+bundle submit executes; equality therefore also checks that readback did not perturb the source run.
 
 `--bundle-extract-submit N PATH` materializes one run-local submit manifest as a normal capsule and exits
 without Vulkan when no image output is requested. Use it to inspect, graph, or validate the exact predecessor
@@ -165,16 +176,25 @@ faithful replacement for the missing producer history.
 
 ## Current Dead Cells reference
 
-The preserved #608 playable closure selects exactly 90 semantic draws with the 738x420 pass at draw 79..81. Its retained
-submits 18,165..19,047 represent 158.94 GiB logically and 739 MiB uniquely. Replay resolves 1,764 temporal image
-dependencies with zero bounded/unresolved leaves and renders hash `5759c125812154dc`. A complete-color-cache
-final capsule renders `71b84bdfae53933c` because it begins with fresh depth. Manifest scanning shows the same
-642x362 depth address in all 883 submits, always with LESS_OR_EQUAL tests/writes and never a draw/register
-clear. Timeline-v5 backing hashes and writer provenance resolve the missing boundary: supported compute program
-`0x401aec200` fills the exact 32 KiB HTILE allocation with `0xfffffff0` before the scene draw span. The live
-backend now invalidates overlapping persistent DS entries on guest GPU writeback (#611); a routed A/B restores
-the layers that stayed black with invalidation disabled. #569 remains the exact DS checkpoint gap, not another
-color RTT producer.
+The preserved #608 playable closure selects exactly 90 semantic draws with the 738x420 pass at draw 79..81. Its
+retained submits 18,165..19,047 represent 158.94 GiB logically and 739 MiB uniquely, resolving all 1,764 temporal
+image dependencies. Its original pre-#611/#615 replay hash was `5759c125812154dc`; absolute hashes from that old
+renderer revision are historical, while source/capsule equality remains the checkpoint invariant.
+
+On current code, normal #611 invalidation produces `fac9ca4cbbba8196` from both the full bundle and standalone
+v8 capsule. With `PROSPER_DS_GUEST_WRITE_INVALIDATE=0`, the exact stale-depth A/B produces
+`535256588b67a536` from both paths and byte-identical BMPs. The self-contained capsule holds 12 RTT surfaces,
+one valid 642x362 D32S8 depth plane (929,616 bytes), the effective invalidation/legacy-HTILE settings, and its
+33,177,600-byte output oracle; standalone replay takes about 3.3 seconds instead of roughly 24 minutes. A
+tail-two negative control remains `71b84bdfae53933c` in both bundle and capsule because its two color frontiers
+are explicitly bounded. This closes #569 without hiding an incomplete history boundary.
+
+Manifest scanning shows the same 642x362 depth address in all 883 submits, always with LESS_OR_EQUAL
+tests/writes and never a draw/register clear. Timeline-v5 backing hashes and writer provenance resolved the
+hardware boundary: supported compute program `0x401aec200` fills the exact 32 KiB HTILE allocation with
+`0xfffffff0` before the scene draw span. The live backend invalidates overlapping persistent DS entries on guest
+GPU writeback (#611); capture v8 preserves the state exactly when an investigation deliberately disables that
+invalidation.
 
 For new routed captures, timeline v6 replaces that historical endpoint with 91..93 semantic draws, exactly
 8 dispatches, and the 738x420 pass at draw 80..82. `gpu_timeline --signatures` derived the conjunction from two

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -194,6 +194,21 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     static_cast<unsigned long long>(seed.guest_addr), seed.width, seed.height,
                     seed.rgba.size(), static_cast<unsigned long long>(hash));
     }
+    for (const auto& seed : replay.ds_seeds) {
+        const uint64_t depth_hash = prosper::gpu::gpu_capture_hash(seed.depth);
+        const uint64_t stencil_hash = prosper::gpu::gpu_capture_hash(seed.stencil);
+        std::printf("ds-seed base-z=%016llx/%016llx base-s=%016llx/%016llx htile=%016llx "
+                    "extent=%ux%u format=%s valid=%d/%d depth=%zu/%016llx stencil=%zu/%016llx\n",
+                    static_cast<unsigned long long>(seed.depth_read_base),
+                    static_cast<unsigned long long>(seed.depth_write_base),
+                    static_cast<unsigned long long>(seed.stencil_read_base),
+                    static_cast<unsigned long long>(seed.stencil_write_base),
+                    static_cast<unsigned long long>(seed.htile_data_base), seed.width, seed.height,
+                    seed.format == prosper::gpu::GpuCaptureDsFormat::D32FloatS8 ? "D32S8" : "D32",
+                    seed.depth_valid, seed.stencil_valid, seed.depth.size(),
+                    static_cast<unsigned long long>(depth_hash), seed.stencil.size(),
+                    static_cast<unsigned long long>(stencil_hash));
+    }
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
         std::printf("draw[%zu] target=%016llx extent=%ux%u vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
@@ -693,7 +708,11 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
     set_environment("PROSPER_RENDER_FIRST", "0");
     set_environment("PROSPER_RENDER_LAST", "2147483647");
     set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
-    if (!final_capsule_path.empty()) set_environment("PROSPER_GPU_REPLAY_EXPORT_RTT", "1");
+    set_environment("PROSPER_GPU_REPLAY_DS_SEEDS", "1");
+    if (!final_capsule_path.empty()) {
+        set_environment("PROSPER_GPU_REPLAY_EXPORT_RTT", "1");
+        set_environment("PROSPER_GPU_REPLAY_EXPORT_DS", "1");
+    }
     prosper::frontend::register_live_renderer(".", false);
     final_capture = {};
 
@@ -826,6 +845,14 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             if (std::none_of(prior_targets.begin(), prior_targets.end(), [&](const auto& target) {
                     return target.addr == seed.guest_addr;
                 })) seeds.push_back(seed);
+        if (!prosper::gpu::restore_gpu_replay_ds_seeds(replay.ds_seeds, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot restore bundle DS seeds: %s\n", error.c_str());
+            return 2;
+        }
+        bool final_capsule_prepared = false;
+        size_t final_cache_surfaces = 0, final_required = 0;
+        size_t final_exported = 0, final_refreshed = 0, final_migrated_failures = 0;
+        uint64_t final_ds_snapshot_bytes = 0;
         if (i + 1 == bundle.submits.size() && !final_capsule_path.empty()) {
             std::unordered_set<uint64_t> required;
             for (const auto& leaf : graph.external_leaves) {
@@ -840,17 +867,16 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                              error.c_str());
                 return 2;
             }
-            size_t exported = 0, refreshed = 0;
             for (auto& seed : snapshot) {
                 const uint64_t addr = seed.guest_addr;
                 auto existing = std::find_if(capture.rtt_seeds.begin(), capture.rtt_seeds.end(),
                     [&](const auto& candidate) { return candidate.guest_addr == addr; });
                 if (existing == capture.rtt_seeds.end()) {
                     capture.rtt_seeds.push_back(std::move(seed));
-                    ++exported;
+                    ++final_exported;
                 } else {
                     *existing = std::move(seed);
-                    ++refreshed;
+                    ++final_refreshed;
                 }
             }
             for (uint64_t addr : required)
@@ -861,6 +887,56 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                                  static_cast<unsigned long long>(addr));
                     return 2;
                 }
+            std::vector<prosper::gpu::GpuCaptureDsSeed> ds_snapshot;
+            if (!prosper::gpu::read_all_gpu_capture_ds_seeds(ds_snapshot, error)) {
+                std::fprintf(stderr, "gpu_replay: cannot snapshot final DS cache: %s\n",
+                             error.c_str());
+                return 2;
+            }
+            for (const auto& seed : ds_snapshot)
+                final_ds_snapshot_bytes += seed.depth.size() + seed.stencil.size();
+            capture.ds_seeds = std::move(ds_snapshot);
+            if (!capture.failure_diagnostics_available) {
+                for (const auto& operation : capture.operations) {
+                    if (operation.realized) continue;
+                    prosper::gpu::GpuCapturedOperationFailure failure;
+                    failure.kind = operation.kind;
+                    failure.source_index = operation.source_index;
+                    failure.command_order = operation.command_order;
+                    failure.reason = prosper::gpu::RealizationFailureReason::Unknown;
+                    capture.failure_diagnostics.push_back(std::move(failure));
+                    ++final_migrated_failures;
+                }
+                capture.failure_diagnostics_available = true;
+            }
+            for (const char* name : {"PROSPER_DS_GUEST_WRITE_INVALIDATE",
+                                     "PROSPER_GPU_REPLAY_LEGACY_HTILE_BEFORE_STENCIL"}) {
+                const char* value = std::getenv(name);
+                if (!value) continue;
+                auto existing = std::find_if(capture.metadata.renderer_env.begin(),
+                                             capture.metadata.renderer_env.end(),
+                    [&](const auto& entry) { return entry.first == name; });
+                if (existing == capture.metadata.renderer_env.end())
+                    capture.metadata.renderer_env.emplace_back(name, value);
+                else
+                    existing->second = value;
+            }
+            final_cache_surfaces = snapshot.size(); final_required = required.size();
+            final_capsule_prepared = true;
+        }
+        if (!prosper::gpu::restore_gpu_replay_rtt_seeds(seeds, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot restore bundle RTT seeds: %s\n", error.c_str());
+            return 2;
+        }
+        final_pixels = execute_frame(replay, false, operation_limit);
+        if (final_capsule_prepared) {
+            if (final_pixels.empty()) {
+                std::fprintf(stderr, "gpu_replay: final submit produced no checkpoint oracle\n");
+                return 2;
+            }
+            capture.expected_output_valid = true;
+            capture.expected_output_bytes = final_pixels.size();
+            capture.expected_output_hash = prosper::gpu::gpu_capture_hash(final_pixels);
             if (!prosper::gpu::write_gpu_capture(final_capsule_path, capture, error)) {
                 std::fprintf(stderr, "gpu_replay: cannot write final seeded capsule: %s\n",
                              error.c_str());
@@ -868,15 +944,16 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             }
             std::fprintf(stderr,
                          "[gpureplay] exported final seeded capsule cache-surfaces=%zu required=%zu "
-                         "new-seeds=%zu refreshed=%zu total-seeds=%zu -> %s\n",
-                         snapshot.size(), required.size(), exported, refreshed, capture.rtt_seeds.size(),
+                         "new-seeds=%zu refreshed=%zu total-seeds=%zu DS-seeds=%zu DS-bytes=%llu "
+                         "migrated-failures=%zu oracle=%016llx/%llu -> %s\n",
+                         final_cache_surfaces, final_required, final_exported, final_refreshed,
+                         capture.rtt_seeds.size(), capture.ds_seeds.size(),
+                         static_cast<unsigned long long>(final_ds_snapshot_bytes),
+                         final_migrated_failures,
+                         static_cast<unsigned long long>(capture.expected_output_hash),
+                         static_cast<unsigned long long>(capture.expected_output_bytes),
                          final_capsule_path.c_str());
         }
-        if (!prosper::gpu::restore_gpu_replay_rtt_seeds(seeds, error)) {
-            std::fprintf(stderr, "gpu_replay: cannot restore bundle RTT seeds: %s\n", error.c_str());
-            return 2;
-        }
-        final_pixels = execute_frame(replay, false, operation_limit);
         for (size_t operation_index = 0; operation_index < operation_limit; ++operation_index) {
             const auto& operation = replay.operations[operation_index];
             if (!operation.realized ||
@@ -1226,22 +1303,30 @@ int main(int argc, char** argv) {
     const auto& m = replay.metadata;
     std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu computes=%zu "
                          "operations=%zu shaders=%zu failed=%zu raw-failed-shaders=%zu blobs=%zu "
-                         "RTT-seeds=%zu oracle=%s\n",
+                         "RTT-seeds=%zu DS-seeds=%zu oracle=%s\n",
                  m.revision.c_str(), m.title_id.c_str(), static_cast<unsigned long long>(m.submit_index),
                  m.width, m.height, replay.items.size(), replay.computes.size(), replay.operations.size(),
                  capture.shader_versions.size(), replay.failure_diagnostics.size(),
                  replay.raw_shader_versions.size(), replay.blobs.size(), replay.rtt_seeds.size(),
+                 replay.ds_seeds.size(),
                  replay.expected_output_valid ? "yes" : "no");
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;
     if (!replay.rtt_seeds.empty() || !prepend.rtt_seeds.empty())
         set_environment("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
+    if (!replay.ds_seeds.empty() || !prepend.ds_seeds.empty())
+        set_environment("PROSPER_GPU_REPLAY_DS_SEEDS", "1");
     prosper::frontend::register_live_renderer(".", false);
     std::unordered_set<uint64_t> predecessor_targets;
     if (!prepend_path.empty()) {
         if (!prosper::gpu::restore_gpu_replay_rtt_seeds(prepend.rtt_seeds, error)) {
             std::fprintf(stderr, "gpu_replay: cannot restore predecessor RTT seeds: %s\n",
+                         error.c_str());
+            return 2;
+        }
+        if (!prosper::gpu::restore_gpu_replay_ds_seeds(prepend.ds_seeds, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot restore predecessor DS seeds: %s\n",
                          error.c_str());
             return 2;
         }
@@ -1259,6 +1344,9 @@ int main(int argc, char** argv) {
         if (!predecessor_targets.count(seed.guest_addr)) consumer_seeds.push_back(seed);
     if (!prosper::gpu::restore_gpu_replay_rtt_seeds(consumer_seeds, error)) {
         std::fprintf(stderr, "gpu_replay: cannot restore RTT seeds: %s\n", error.c_str()); return 2;
+    }
+    if (!prosper::gpu::restore_gpu_replay_ds_seeds(replay.ds_seeds, error)) {
+        std::fprintf(stderr, "gpu_replay: cannot restore DS seeds: %s\n", error.c_str()); return 2;
     }
     const size_t operation_limit = through_operation >= 0
         ? static_cast<size_t>(through_operation) + 1 : SIZE_MAX;

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -119,7 +119,7 @@ latest same-run writer identity for every temporal image leaf in the selected ca
 the consumer submit/operation/range, the in-submit future writer, and either the matched prior graphics
 submit/draw/PM4 order/target extent or an explicit unresolved result.
 
-Version 2 added exactly one bounded detailed submit per run. The linked version-7 `.prgcap` contains
+Version 2 added exactly one bounded detailed submit per run. The linked version-8 `.prgcap` contains
 content-hashed/deduplicated shaders and resource
 bytes, graphics and compute items, complete raw depth-surface programming, and the original mixed PM4 operation
 order. An operation whose shader


### PR DESCRIPTION
﻿## Summary

- add capture v8 persistent depth/stencil seeds with complete cache identity, independent plane validity, strict bounded validation, and v1-v7 compatibility
- snapshot/restore exact Vulkan D32 and D32S8 planes around the final-submit boundary
- make `--bundle-final-capsule` self-contained and self-verifying with RTT+DS caches, effective DS settings, migrated legacy failure diagnostics, and the source output oracle
- document and regression-test the complete workflow

## Dead Cells evidence

Production #611 path:
- 883-submit bundle: `fac9ca4cbbba8196`
- standalone v8 capsule: `fac9ca4cbbba8196`

Invalidation-disabled stale-depth A/B:
- 883-submit source: `535256588b67a536`
- standalone v8 capsule: `535256588b67a536`
- BMPs byte-identical
- capsule: 12 RTT surfaces, one 642x362 D32S8 depth plane (929,616 bytes), source oracle
- standalone runtime: 3.3 seconds versus roughly 24 minutes

The old `5759c125812154dc` value predates #611/#615 and is retained in docs only as historical evidence. Current acceptance is exact source/capsule equality.

## Validation

- full Linux build
- CTest: 91/91 passed
- `gpu_capture_roundtrip`, `gpu_capture_bundle_roundtrip`, `gpu_capture_render_replay`
- byte-exact Vulkan D32S8 upload/readback
- snapshot suite:
  - Messenger: 24,318 colors >= 5,000
  - Dead Cells: 1,684 colors >= 1,500

Closes #569
