### PR TITLE
fix(gpu/recompiler): Dead Cells gameplay composition — MRT0 color output + dropped compute dispatch (Fixes #566)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ prosper/
 
 Key docs to orient: `prosper/README.md` (status), `prosper/docs/ROADMAP.md`, `prosper/docs/GRAPHICS.md`,
 `prosper/docs/RENDER_LOOP.md` (the historical render bring-up log), and
-`prosper/docs/MESSENGER_BLACK_RENDER.md` (the current, revisioned Messenger investigation status).
+`prosper/docs/MESSENGER_BLACK_RENDER.md` (the revisioned Messenger investigation status). The current
+Dead Cells graphics handoff and exact reproduction recipe are in `prosper/docs/DEAD_CELLS_STATUS.md`.
 
 ## Historical frontier (superseded 2026-07-11)
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ accepts scripted gamepad input, and renders the first level.
   remaining scene draws used uniform VCCZ-exit light loops; the fragment/vertex recompiler now proves that
   narrow wave-uniform shape, emits structured loops, and realizes every sampled gameplay draw (#615).
   Capture v8 snapshots exact persistent Vulkan depth/stencil planes alongside temporal color targets, turning
-  the final composition into a standalone, hash-checked replay checkpoint (#569).
+  the final composition into a standalone, hash-checked replay checkpoint (#569). The current evidence boundary,
+  reproduction recipe, and remaining work are in [`prosper/docs/DEAD_CELLS_STATUS.md`](prosper/docs/DEAD_CELLS_STATUS.md).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -1,0 +1,138 @@
+# Dead Cells graphics status
+
+Last updated: 2026-07-13
+
+This is the handoff for the remaining *Dead Cells* gameplay-composition work. The operational route and
+selector reference is [`../scripts/dead-cells/README.md`](../scripts/dead-cells/README.md). The active bug is
+[#566](https://github.com/mattias800/ps5ys/issues/566).
+
+## Current state
+
+*Dead Cells* boots, passes the splash and menus, loads `PrisonStart`, and reaches the controllable Jump tutorial.
+Scene geometry, smoke, silhouettes, the player, the tutorial prompt, and the HUD render. The remaining output is
+visibly wrong compared with the game: the world composition is largely grayscale and overexposed instead of the
+colored, lit scene.
+
+The original mostly-white repeated-block image is not the current bug. It was caused by beginning diagnostic
+rendering after a required 642x362 temporal render-target producer had already run (#586). Do not use a
+35-second sparse-render screenshot as a color oracle.
+
+The important fixes already on `master` are:
+
+- mixed graphics/compute execution follows PM4 order (#584);
+- compute writes to a depth surface's HTILE allocation invalidate the detached Vulkan depth cache (#611);
+- four uniform VCCZ-exit fragment-lighting loops recompile through a narrowly proved structured form (#615);
+- failed operations retain bounded raw shaders and exact rejection diagnostics in capture v7 (#618);
+- capture v8 checkpoints complete color RTT state and persistent depth/stencil planes, including a source-output
+  hash oracle (#569).
+
+Current live gameplay submits after #615 realize all semantic draws. Descriptor validation has not identified a
+missing or undersized binding in the exercised frame.
+
+## Evidence boundary
+
+The preserved #608 bundle is useful historical evidence, but it is not a current live-frame oracle. It contains
+883 submits (`18165..19047`), resolves all 1,764 temporal image dependencies, and was captured before #615. Its
+final submit has four unrealized draws and one unrealized dispatch. Capture-v8 migration represents those five
+holes explicitly as `Unknown`; it cannot recover work that was absent from the old artifact.
+
+On the current renderer, that bundle and its exported v8 capsule both produce `fac9ca4cbbba8196`. With depth
+invalidation deliberately disabled, both produce `535256588b67a536`. This exact source/capsule equality proves
+the checkpoint implementation, but the image still reflects the old capture's missing operations. Do not use it
+to conclude which pass is wrong in a post-#615 live submit.
+
+A fresh producer-complete current bundle is therefore the required starting point. Title-derived `.prgtl`,
+`.prgcap`, `.prgbundle`, shader, and image artifacts are local and gitignored; none belong in a commit.
+
+## Recreate the current checkpoint
+
+Build in WSL from the repository root. Adjust the dump path if needed:
+
+```bash
+cd prosper
+cmake -S . -B build-linux \
+  -DGAME_DUMP=/mnt/c/Users/matti/repos/ps5ys/PPSA15552-app0
+cmake --build build-linux -j8 --target boot_trace gpu_timeline gpu_replay
+```
+
+Capture a rolling producer-time bundle. Let `boot_trace` exit through
+`PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE`; a wall-clock timeout can stop after level parsing but before the
+semantic endpoint is installed.
+
+```bash
+mkdir -p /tmp/dead-cells-current-save
+
+PROSPER_CAPTURE_TITLE=PPSA15552 \
+PROSPER_SAVEDATA_DIR=/tmp/dead-cells-current-save \
+PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay-capture.pad \
+PROSPER_GPU_TIMELINE=/tmp/dead-cells-current.prgtl \
+PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=1 \
+PROSPER_GPU_TIMELINE_CAPTURE=/tmp/dead-cells-current.prgcap \
+PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-current.prgbundle \
+PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=1000 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
+PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=642x362 \
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=80:82 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=91 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=93 \
+PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8 \
+PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
+  ./build-linux/boot_trace \
+  /mnt/c/Users/matti/repos/ps5ys/PPSA15552-app0 \
+  > /tmp/dead-cells-current.log 2>&1
+```
+
+Confirm the timeline selected the intended scene:
+
+```bash
+./build-linux/gpu_timeline /tmp/dead-cells-current.prgtl \
+  --select 738x420 80:82 91:93 8
+```
+
+Replay the complete source once and export the exact final checkpoint:
+
+```bash
+./build-linux/gpu_replay \
+  --bundle /tmp/dead-cells-current.prgbundle \
+  --bundle-final-capsule /tmp/dead-cells-current-v8.prgcap \
+  /tmp/dead-cells-current-source.bmp
+
+./build-linux/gpu_replay \
+  /tmp/dead-cells-current-v8.prgcap \
+  /tmp/dead-cells-current-standalone.bmp
+
+cmp /tmp/dead-cells-current-source.bmp \
+    /tmp/dead-cells-current-standalone.bmp
+```
+
+Do not begin isolation until `cmp` succeeds and standalone replay reports that its embedded oracle passed. Also
+require `gpu_replay --inspect-only` to report zero failed operations for the current endpoint.
+
+## What remains
+
+1. Produce the fresh current bundle and hash-checked v8 capsule above. This removes the five legacy operation
+   holes from the debugging baseline.
+2. Obtain a hardware/reference capture of the same controllable frame and route state. The image currently
+   attached to #566 is from the preceding opening vignette, so it is a qualitative color reference rather than
+   a pixel-aligned oracle.
+3. Use `gpu_replay --through-operation N --allow-mismatch` to locate the operation where the 642x362 scene first
+   loses the expected material/color information. Preserve mixed graphics/compute order; `--draw` is not a
+   substitute for a semantic prefix.
+4. For the first suspect operation, record its draw/dispatch source, PM4 order, target, shader hashes, resource
+   hashes, blend/depth state, and before/after output. Dump only the relevant shader/resource inputs.
+5. Implement the missing generic GPU contract, add a synthetic regression, run all CTests and both Messenger and
+   Dead Cells snapshot guards, then repeat the source/capsule equality check.
+
+The likely fault domain is now a scene color/light composition contract, but shader execution, resource decode,
+format conversion, and blending remain hypotheses until the current producer-complete prefix identifies the
+first bad pass.
+
+## Tooling note
+
+`--bundle-final-capsule` is currently the strict path: it snapshots the complete live RTT and depth/stencil cache
+at final-submit entry and embeds the source output oracle. A standalone capsule selected directly by the timeline
+is useful for state inspection, but it does not by itself prove complete renderer history or source-image
+equality. Prefer improving the capture/replay diagnostics when an investigation would otherwise require repeated
+full-title runs.

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -35,9 +35,10 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   live/replay hashes and per-draw/resource isolation; #515 provides reflected SPIR-V/runtime descriptor
   validation in live and offline replay paths. Producer provenance, normal screenshot capture, and the local
   content-metric snapshot guard complete the current first-bad-contract workflow.
-- **Dead Cells cross-title milestone:** deterministic routing now reaches gameplay. HUD and partial composition
-  render, but the world is mostly white (#566). Version-4 captures seed temporal render targets (#568) and isolate
-  the first bad composition at draw 18; its missing 642x362 input has no prior color-target writer. The corrected
+- **Dead Cells cross-title milestone:** deterministic routing now reaches gameplay. The initial mostly-white world
+  in #566 was a diagnostic warmup artifact, not the current renderer output. Version-4 captures seeded temporal
+  render targets (#568) and originally isolated that artifact at draw 18, where a 642x362 input lacked its prior
+  renderer-owned color-target version. The corrected
   dispatch thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V#
   decoding (#574) now execute a valid registered fill program against real guest buffers before submit completion
   (#576). Range provenance proved one submit orders a 642x362 consumer, dispatch 5's fill, then another consumer.

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -453,6 +453,43 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             table.resources.push_back(r);
         }
     }
+
+    // Additional directly-placed COMPUTE buffers (#566). Gen5 compute shaders put buffer V#s straight
+    // in the user-SGPR block and reference them by SRSRC, but the shader's resource-usage metadata only
+    // declares the FIRST (direct_resource_offset type 1 -> reg 0, handled above). A format-copy compute
+    // — Dead Cells: `buffer_load_format_xyzw v, vIDX, s[0:3]` then `buffer_store_format_xyzw v, vIDX,
+    // s[4:7]` — therefore had its STORE destination V# (at s4) absent from the table, so the store's
+    // SRSRC resolved to nothing and the whole shader was rejected (`[mubuf-unresolved] srsrc=s4`). Its
+    // dispatch was then dropped, losing the scene-composition pass. Expose every remaining 4-dword-
+    // aligned user-SGPR slot that decodes to a plausible buffer V#, keyed by sgpr_base, so the recompiler
+    // resolves the SRSRC via by_sgpr_base. The SAME plausibility guard used for the type-1/vertex buffers
+    // rejects leftover non-descriptor SGPRs: a real V# has a mapped base and a sane size, while stale
+    // registers decode as base 0 or the ~0xFFFFFFFF max size. In the exercised Dead Cells frame this
+    // emits ONLY the real copy destinations; every other compute shader's trailing slots are filtered.
+    // An unreferenced extra resource is harmless — the recompiler binds only the SRSRCs it actually uses.
+    // CONFIDENCE: HIGH (live-verified: dispatch 0x401aec800 realizes and the dropped pass returns).
+    if (shdr.type == 0) {
+        for (uint32_t reg = 0; reg + 4 <= num_user_sgprs; reg += 4) {
+            const uint32_t sgpr = user_sgpr_base + reg;
+            bool covered = false;
+            for (const ShaderResource& e : table.resources)
+                if (e.sgpr_base == sgpr) { covered = true; break; }
+            if (covered) continue;
+            DecodedBufferDescriptor d = decode_buffer_descriptor(&user_sgprs[reg]);
+            if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+            ShaderResource r;
+            r.cls            = ResourceClass::ConstantBuffer;   // storage buffer (readable + writable)
+            r.format         = d.format;
+            r.num_components  = d.num_components;
+            r.binding        = binding++;
+            r.gpu_addr       = d.base;
+            r.size           = d.size_bytes;
+            r.stride         = d.stride;
+            r.sgpr_base      = sgpr;
+            r.srt_offset     = 0xFFFFFFFFu;      // direct (not s_loaded)
+            table.resources.push_back(r);
+        }
+    }
     return table;
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4113,8 +4113,21 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
     // skips it; the block's EXEC narrow + the export's OpKill do the per-invocation discard (#102). This is
     // NOT added for the vertex/compute shells (their scc branches are real uniform-ifs / NGG culling).
     for (uint32_t pc : mask_test_branches(ins)) safe_branches.insert(pc);
+    // Which color MRT feeds Vulkan color attachment 0? By the hardware convention MRT0 -> color0, and
+    // prosper binds a single color attachment (color0), so the fragment's one Location-0 output must carry
+    // MRT0's export. Multi-render-target shaders (Dead Cells' world/G-buffer passes) emit their exports in
+    // DESCENDING target order (MRT3, MRT2, MRT1, MRT0), so the old "first EXP with target<=7 wins" wrote a
+    // non-color plane (MRT3) into color0 — the world rendered as that grayscale G-buffer channel instead of
+    // the colored albedo (#566, exact R=G=B / chroma 0). Select the LOWEST-numbered color MRT (MRT0 when
+    // present); single-MRT shaders (target 0 only) are unchanged.
+    uint32_t color_mrt = 0xFFFFFFFFu;
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt == Rdna2Format::EXP && in.exp_target <= 7 && in.exp_target < color_mrt)
+            color_mrt = in.exp_target;
+    }
     bool exported = false;
-    auto exp_fn = [&](const Rdna2Inst& in) -> bool {         // EXP MRT0..7 -> the color output
+    auto exp_fn = [&](const Rdna2Inst& in) -> bool {         // EXP MRTn -> the color0 output
         // An export while EXEC is narrowed (lanes killed by an alpha test / v_cmpx and not restored to
         // all-on) must not write the inactive lanes. Lower it to a real fragment discard: OpKill the lanes
         // whose EXEC bit is false, then export from the survivors under full EXEC. This is exactly the
@@ -4122,7 +4135,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
         // exec,saved -> shade -> export): the surviving lanes are the ones that passed the test. (When EXEC
         // was never narrowed this is a no-op — the common sRGB/tonemap restore-then-export path.)
         if (rs.exec_narrowed) { b.discard_unless(rs.exec); rs.exec = b.btrue(); rs.exec_narrowed = false; }
-        if (in.exp_target <= 7 && !exported) {
+        if (in.exp_target == color_mrt && !exported) {
             bool eok = true;   // a Special (wave-mask) source has no data value — reject, don't export 0 (#134)
             if (in.exp_compr) {
                 // COMPR: the 4 channels are two f16x2 pairs — src[0] holds (r,g), src[1] holds (b,a).

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -207,6 +207,43 @@ int main() {
               "type-1 direct resource is not guessed for unobserved non-compute stages");
     }
 
+    // --- #566: additional directly-placed compute buffers (store-destination V# not in metadata). ---
+    // A Gen5 format-copy compute (Dead Cells) places TWO buffer V#s straight in the user-SGPR block —
+    // load source at reg0, store destination at reg4 — but its resource-usage metadata declares only the
+    // FIRST (direct_resource_offset type 1 -> reg 0). The store's SRSRC (s4) therefore had no resource and
+    // the whole dispatch was rejected/dropped, losing a scene-composition pass. build_shader_resources
+    // now also exposes plausible buffer V#s found directly in the user-SGPR block (keyed by sgpr_base),
+    // while the same plausibility guard filters leftover non-descriptor SGPRs, and the scan is compute-only.
+    {
+        uint32_t csgprs[32]; memset(csgprs, 0, sizeof csgprs);
+        make_vsharp(&csgprs[0], 0x74BA456E0000ull, 4, 393216, /*fmt*/2);   // src (declared via type 1)
+        make_vsharp(&csgprs[4], 0x74BA2F3E0000ull, 4, 393216, /*fmt*/2);   // dst (NOT declared anywhere)
+        make_vsharp(&csgprs[12], 0x50000000ull,    4, 0x8000000, /*fmt*/2);// 512 MB -> implausible, filtered
+        // reg8 + reg16..28 stay zero -> base 0 -> filtered.
+        uint16_t cdro[11]; for (auto& x : cdro) x = 0xffff;
+        cdro[1] = 0;                                                       // declare ONLY reg0
+        AgcShaderUserData cud; memset(&cud, 0, sizeof cud);
+        cud.direct_resource_offset = cdro; cud.direct_resource_count = 11;
+        AgcShaderHeader csh; memset(&csh, 0, sizeof csh);
+        csh.file_header = 0x34333231u; csh.version = 0x18; csh.type = 0; csh.user_data = &cud;
+
+        ShaderResourceTable ct = build_shader_resources(csh, csgprs, 32);
+        const ShaderResource* src = ct.by_sgpr_base(0);
+        const ShaderResource* dst = ct.by_sgpr_base(4);
+        CHECK(src && src->gpu_addr == 0x74BA456E0000ull, "#566: declared compute source buffer at sgpr 0");
+        CHECK(dst && dst->cls == ResourceClass::ConstantBuffer && dst->gpu_addr == 0x74BA2F3E0000ull,
+              "#566: undeclared compute store-dest V# at sgpr 4 exposed (store SRSRC now resolves)");
+        CHECK(dst && dst->size == 393216u * 4u && dst->stride == 4, "#566: dest V# base/size/stride decoded");
+        CHECK(ct.by_sgpr_base(8) == nullptr, "#566: leftover base-0 SGPR slot not emitted");
+        CHECK(ct.by_sgpr_base(12) == nullptr, "#566: >256 MB implausible V# filtered (no stale-SGPR binding)");
+        int at0 = 0; for (const auto& r : ct.resources) if (r.sgpr_base == 0) at0++;
+        CHECK(at0 == 1, "#566: declared source buffer emitted exactly once (scan dedups the type-1 slot)");
+
+        csh.type = 1;   // PS: the additional-buffer scan is compute-only.
+        CHECK(build_shader_resources(csh, csgprs, 32).by_sgpr_base(4) == nullptr,
+              "#566: additional directly-placed-buffer scan does not run for non-compute stages");
+    }
+
     // --- textures: sharp[0] T#s carry their real format + byte size; BC1/2/3 are bound (decoded to RGBA8
     // on upload, #121); BC4-7 + unmapped formats are still skipped (#65) ---
     {

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -216,6 +216,34 @@ int main() {
         }
     }
 
+    // MULTI-RENDER-TARGET selection (#566 — Dead Cells world/G-buffer shaders). A 4-MRT shader emits its
+    // color exports in DESCENDING target order (MRT3..MRT0). Vulkan color attachment 0 must receive MRT0's
+    // data; the old "first EXP with target<=7 wins" wrote MRT3 (a non-albedo G-buffer plane) into color0,
+    // so the world rendered as that grayscale channel instead of the colored albedo. Here MRT3 exports RED
+    // and MRT0 exports BLUE (emitted MRT3-first); the triangle must be BLUE (MRT0 chosen), not RED (MRT3).
+    {
+        const uint32_t ps[] = {
+            0x7E0002F2u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u,   // v0=1.0,v1=0,v2=0,v3=1.0  -> RED
+            0xF800183Fu, 0x03020100u,                             // exp mrt3 v0,v1,v2,v3
+            0x7E080280u, 0x7E0A0280u, 0x7E0C02F2u, 0x7E0E02F2u,   // v4=0,v5=0,v6=1.0,v7=1.0  -> BLUE
+            0xF800180Fu, 0x07060504u,                             // exp mrt0 v4,v5,v6,v7
+            0xBF810000u,                                          // s_endpgm
+        };
+        std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+        CHECK(!frg.empty(), "#566: recompiled descending-order 4-MRT (MRT3 then MRT0) PS -> SPIR-V");
+        if (!frg.empty()) {
+            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
+            CHECK(px2.size() == (size_t)W*H*4, "rendered the MRT-order PS");
+            if (px2.size() == (size_t)W*H*4) {
+                const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
+                printf("  mrt-order center=(%u,%u,%u,%u) expect BLUE (MRT0), not RED (MRT3)\n",
+                       cc[0],cc[1],cc[2],cc[3]);
+                CHECK(cc[2] > 0x80 && cc[0] < 0x40,
+                      "#566: color0 receives MRT0 (BLUE), not the first-emitted MRT3 (RED)");
+            }
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## Summary

Fixes the Dead Cells (`PPSA15552`) gameplay world composition (#566). The controllable Prisoners'
Quarters now renders in full colour instead of grayscale/overexposed.

Two fixes land here (continued from the #626 hand-off doc):

1. **`fix(recompiler)` — fragment color output uses MRT0, not the first-emitted export** (the #566 fix).
   The world/G-buffer pixel shaders are multi-render-target and emit their exports in DESCENDING target
   order (MRT3→MRT0). `recompile_fragment` took the *first* EXP as the single color output, so it wrote
   MRT3 (a non-albedo, grayscale G-buffer plane) into Vulkan color attachment 0 — the whole world rendered
   as that channel (exact R=G=B, chroma 0). Now it selects the color target that maps to attachment 0
   (MRT0). Single-MRT shaders are unchanged.
2. **`fix(gpu)` — expose directly-placed compute buffer V#s so a store's SRSRC resolves** (`2dba57f`).
   A separate real bug found along the way: the scene-composition compute dispatch (`0x401aec800`, a
   format-copy) was dropped because its store destination V# wasn't in the resource table. Now realizes
   (`dispatches 7/8 → 8/8`). Necessary for a clean producer-complete baseline but not the color cause.

## Before / after

| Before (grayscale) | After (fixed) |
|---|---|
| ![before](https://raw.githubusercontent.com/mattias800/ps5ys/pr-assets/issue-566/before-grayscale.png) | ![after](https://raw.githubusercontent.com/mattias800/ps5ys/pr-assets/issue-566/after-color.png) |

## Validation

- Producer-complete bundle replay: chroma **maxchroma 0 → 255**, 96% colored pixels; source/capsule
  equality holds, 0 failed operations.
- Regression test in `test_recompiled_fragment`: a PS exporting RED to MRT3 then BLUE to MRT0 must render
  BLUE (color0 = MRT0) — fails under the old first-export-wins behavior.
- `test_build_shader_resources` regression for the compute buffer fix.
- **All 91 CTests pass**, no regressions (incl. the Messenger boot/render guards).

Fixes #566
