### PR TITLE
gpu: structure proven-uniform VCC control flow (loops + forward ifs) in the compute shell (#590)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1025,9 +1025,28 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 }
             }
             static std::set<uint64_t> logged;
-            if (logged.insert(code_addr).second)
+            if (logged.insert(code_addr).second) {
                 std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",
                              (unsigned long long)code_addr);
+                // PROSPER_SHADER_DUMP=<dir>: write the failed COMPUTE program's raw bytes for offline
+                // shader_inspect, mirroring the graphics VS/PS dump (gpu_execute.hpp). The graphics
+                // path was the only dumper, so a failing dispatch's CFG could not be mapped offline.
+                // Bounded like the graphics dump (64 KB covers the largest observed shaders); shrink
+                // to the readable prefix instead of faulting on a short final mapping.
+                if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
+                    size_t n = 0x10000;
+                    while (n >= 0x1000 && !guest_readable(code_addr, (uint32_t)n)) n >>= 1;
+                    if (n >= 0x1000) {
+                        char fn[512];
+                        snprintf(fn, sizeof fn, "%s/exec_cs_%llx.bin", dd,
+                                 (unsigned long long)code_addr);
+                        if (FILE* f = fopen(fn, "wb")) {
+                            fwrite((const void*)(uintptr_t)code_addr, 1, n, f);
+                            fclose(f);
+                        }
+                    }
+                }
+            }
             continue;
         }
         const DescriptorValidationReport report = validate_spirv_descriptor_interface(

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3695,7 +3695,37 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // (OpLoopMerge + header OpPhi per carried register/mask) whose per-lane condition is THIS
         // lane's EXEC bool after the header's exec recompute. The IF machinery is unchanged and
         // recurses INTO loop bodies (their nested forward-execz regions).
-        if (!b.is_compute) Ls = detect_divergent_loops(ins, safe);
+        Ls = detect_divergent_loops(ins, safe);
+        if (b.is_compute) {
+            // Compute VCC-exit loops (#590, extending #615): the fragment-stage uniformity proof is
+            // data-provenance-based, not stage-based — vcc_exit_is_wave_uniform accepts a compare only
+            // when every input is scalar/inline/literal or a VGPR whose nearest definition is an
+            // unmodified uniform VOP1 move from a scalar. With that proven, every lane's compare bool
+            // is identical, so the wave-empty vccz exit lowers to THIS invocation's !cond exactly as
+            // in the fragment shell (tid-derived/varying inputs fail the proof and keep rejecting).
+            // Two compute-specific guards, both conservative:
+            //   * accept ONLY Condition::Vcc loops (the detector sets it only under the uniform proof;
+            //     per-lane Exec-condition loops stay graphics-only until a compute case is observed);
+            //   * the body must be barrier/LDS/cross-lane-free — the proof is per-WAVE, and a barrier
+            //     inside a loop whose trip count could differ across the workgroup's waves would be
+            //     workgroup-divergent control flow (UB). DOLL's blocked light/fill kernels are
+            //     straight-line bodies, so nothing observed is lost. CONFIDENCE: MED-HIGH (shared
+            //     emit machinery; spirv-val + coverage tests + Messenger guard gate it).
+            bool compute_ok = !Ls.empty();
+            for (const auto& L : Ls) {
+                if (!compute_ok) break;
+                if (L.condition != DivLoop::Condition::Vcc) { compute_ok = false; break; }
+                for (const auto& in : ins) {
+                    if (in.is_end || in.pc >= L.exit_pc) break;
+                    if (in.pc < L.header_pc) continue;
+                    if (in.fmt == Rdna2Format::DS ||
+                        (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
+                        (in.fmt == Rdna2Format::VOP3 &&
+                         (in.opcode == 0x365 || in.opcode == 0x366))) { compute_ok = false; break; }
+                }
+            }
+            if (!compute_ok) Ls.clear();   // unchanged behavior: the branch reaches emit_alu -> loud reject
+        }
         bool cf_rejected = false;
         const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe,
                                                              Ls.empty() ? nullptr : &Ls, &cf_rejected);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1403,13 +1403,52 @@ bool instruction_may_change_exec(const Rdna2Inst& in) {
 //   v_cvt_i32_f32 vBOUND, sBOUND; ...; v_cmp_* vcc, sCOUNTER, vBOUND; s_cbranch_vccz EXIT
 // so every active lane makes the same comparison. Keep the proof deliberately local and reject a
 // varying/unresolved VGPR bound rather than silently changing wave semantics.
+// True when `in` provably cannot overwrite VCC — used by vcc_exit_is_wave_uniform's compare-finding
+// walk (#590) to look past instructions scheduled between the VOPC and its consuming branch (real
+// UE4 compute kernels hoist ~15 unrelated ALU ops in between). Anything not provably safe stops the
+// walk conservatively: VOPC itself (the implicit dst), the VOP2 carry-chain ops (v_*_co_ci_u32,
+// 0x28-0x2a), VOP3 windows that may carry a scalar dest (VOPC-as-VOP3 sdst at 0x000-0x13f, VOP3B
+// carry-out / v_readlane at 0x300+ — the decoder does not expose their sdst), and any scalar or
+// SMEM write whose dest range could cover SGPR 106/107 (the shaders use s106/s107 as scratch).
+static bool cannot_write_vcc(const Rdna2Inst& in) {
+    auto sgpr_dst_misses_vcc = [&](uint32_t n_dwords) {
+        if (in.dst.kind != OperandKind::SGPR && in.dst.kind != OperandKind::Special) return true;
+        const int lo = in.dst.value, hi = in.dst.value + (int)n_dwords - 1;
+        return hi < 106 || lo > 107;
+    };
+    switch (in.fmt) {
+        case Rdna2Format::VOP1:
+        case Rdna2Format::VINTRP:
+        case Rdna2Format::MUBUF: case Rdna2Format::MTBUF: case Rdna2Format::MIMG:
+        case Rdna2Format::DS:    case Rdna2Format::FLAT:
+        case Rdna2Format::EXP:                                     // VGPR/memory dsts only
+        case Rdna2Format::SOPP:                                    // branches/hints/waitcnt: no dst
+        case Rdna2Format::SOPC:  return true;                      // writes SCC only
+        case Rdna2Format::VOP2:  return in.opcode < 0x28 || in.opcode > 0x2a;
+        case Rdna2Format::VOP3P: return true;                      // packed VALU: VGPR dst, no carry
+        case Rdna2Format::VOP3:  return in.opcode >= 0x140 && in.opcode < 0x300 &&
+                                        sgpr_dst_misses_vcc(1);    // plain-VALU window only
+        case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPK:
+            return sgpr_dst_misses_vcc(2);                         // conservative 64-bit pair
+        case Rdna2Format::SMEM: {
+            uint32_t n = 0;
+            switch (in.opcode & 7) { case 0: n = 1; break; case 1: n = 2; break; case 2: n = 4; break;
+                                     case 3: n = 8; break; case 4: n = 16; break; default: return false; }
+            return sgpr_dst_misses_vcc(n);
+        }
+        default: return false;                                     // VOPC / unknown: stops the walk
+    }
+}
+
 bool vcc_exit_is_wave_uniform(const std::vector<Rdna2Inst>& ins, uint32_t branch_pc) {
     const Rdna2Inst* compare = nullptr;
     for (auto it = ins.rbegin(); it != ins.rend(); ++it) {
         if (it->pc >= branch_pc) continue;
         if (sopp_is_noop(*it)) continue;
-        compare = &*it;
-        break;
+        if (it->fmt == Rdna2Format::VOPC) { compare = &*it; break; }
+        if (cannot_write_vcc(*it)) continue;   // (#590) look past provably-VCC-preserving instrs —
+        break;                                 // VCC's value is frozen at the compare; only a real
+                                               // rewrite between compare and branch invalidates it
     }
     if (!compare || compare->fmt != Rdna2Format::VOPC || vopc_is_cmpx(compare->opcode)) return false;
 
@@ -1642,7 +1681,8 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                                           const uint32_t* code, size_t dwords,
                                           const std::unordered_set<uint32_t>* skip = nullptr,
                                           const std::vector<DivLoop>* loops = nullptr,
-                                          bool* rejected = nullptr) {
+                                          bool* rejected = nullptr,
+                                          bool uniform_vcc_compute = false) {
     std::vector<ForwardIf> out;
     if (rejected) *rejected = false;
     auto reject = [&]() -> std::vector<ForwardIf> { if (rejected) *rejected = true; return {}; };
@@ -1661,6 +1701,9 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt != Rdna2Format::SOPP) continue;
+        // Set when a compute vccz/vccnz if is accepted via the #590 uniformity proof — its region is
+        // then required to be barrier/LDS/cross-lane free (checked after the target/merge is known).
+        bool compute_uniform_vcc = false;
         switch (in.opcode) {
             case 0x02: continue;                                     // s_branch: validated in pass 2
             case 0x09:                                               // execnz: only as a loop back-edge
@@ -1674,7 +1717,16 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                                                                      // stages only — compute has wave VCC/EXEC)
             case 0x06: case 0x07:                                    // vccz / vccnz
                 if (loop_exit(in.pc)) continue;                      // canonical loop condition: loop emitter owns it
-                if (!allow_vcc) return reject();
+                if (!allow_vcc) {
+                    // Compute (#590, extending #615): accept the forward VCC if ONLY under the same
+                    // uniformity proof as the VCC-exit loops — every compare input scalar/inline or a
+                    // uniform-VOP1-from-scalar VGPR, and no possible VCC rewrite between compare and
+                    // branch (cannot_write_vcc walk). Every lane's bool is then identical, so the
+                    // wave-empty vccz test lowers to this invocation's bool. Varying compares keep
+                    // rejecting loudly (per-invocation lowering of a varying wave test is wrong).
+                    if (!uniform_vcc_compute || !vcc_exit_is_wave_uniform(ins, in.pc)) return reject();
+                    compute_uniform_vcc = true;
+                }
                 break;
             case 0x04: case 0x05:                                    // scc0 / scc1
                 if (skip && skip->count(in.pc)) continue;            // kill-mask branch: linearized, not an if
@@ -1683,6 +1735,9 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
         }
         // A loop BREAK (validated vccz/execz -> exit_pc inside an execnz-back-edge loop): a plain
         // forward if skipping the REST of the body — the exec-governed continue then exits the lane.
+        // A compute-uniform-accepted vcc branch can never be a break (compute loops require the
+        // s_branch back-edge Vcc shape, which has no breaks) — reject the combination defensively.
+        if (compute_uniform_vcc && loop_break(in.pc)) return reject();
         if (const DivLoop* L = loop_break(in.pc)) {
             ForwardIf F;
             F.found = true; F.branch_pc = in.pc; F.target_pc = L->backedge_pc;
@@ -1727,6 +1782,21 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 if (lm <= tgt || lm > end_pc) return reject();       // merge must be forward, in-stream
                 F.has_else = true; F.sb_pc = sb.pc; F.merge_pc = lm;
                 break;
+            }
+        }
+        if (compute_uniform_vcc) {
+            // (#590) the uniformity proof is per-WAVE: reject when the guarded region contains a
+            // barrier / LDS / cross-lane op (mirroring the compute loop-body guard — a barrier under
+            // control flow whose condition could differ across the workgroup's waves would be
+            // workgroup-divergent, UB).
+            const uint32_t region_end = F.has_else ? F.merge_pc : F.target_pc;
+            for (const auto& r : ins) {
+                if (r.is_end || r.pc >= region_end) break;
+                if (r.pc <= in.pc) continue;
+                if (r.fmt == Rdna2Format::DS ||
+                    (r.fmt == Rdna2Format::SOPP && r.opcode == 0x0a) ||
+                    (r.fmt == Rdna2Format::VOP3 &&
+                     (r.opcode == 0x365 || r.opcode == 0x366))) return reject();
             }
         }
         out.push_back(F);
@@ -3728,7 +3798,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         }
         bool cf_rejected = false;
         const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe,
-                                                             Ls.empty() ? nullptr : &Ls, &cf_rejected);
+                                                             Ls.empty() ? nullptr : &Ls, &cf_rejected,
+                                                             /*uniform_vcc_compute*/b.is_compute);
         if (cf_rejected) Ls.clear();   // unmodeled CF somewhere: fall through to straight-line (loud reject)
         if (Fs.empty() && Ls.empty()) {
             wave_ok = true;   // straight-line: barriers are wave-uniform, so cross-lane mbcnt is safe here
@@ -4058,7 +4129,9 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     // back-edge + exit, and the forward-if branch) as handled, so coverage matches what actually recompiles
     // (previously the MSAA-resolve loop shaders 031-034 were mis-flagged "blocked" at their s_cbranch_scc0).
     const CountedLoop cL = detect_counted_loop(ins);
-    const std::vector<ForwardIf> cFs = detect_forward_ifs(ins, /*allow_vcc*/false, code, dwords);   // conservative diagnostic (compute-safe)
+    const std::vector<ForwardIf> cFs = detect_forward_ifs(ins, /*allow_vcc*/false, code, dwords,
+                                                          nullptr, nullptr, nullptr,
+                                                          /*uniform_vcc_compute*/true);   // matches the compute shell (#590)
     auto cf_reconstructed = [&](const Rdna2Inst& i) {
         if (cL.found && (i.pc == cL.backedge_pc || i.pc == cL.exit_branch_pc)) return true;
         for (const auto& F : cFs) if (i.pc == F.branch_pc) return true;

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -38,14 +38,38 @@ int main() {
     CHECK(recompile_valu(vcc_branch, sizeof(vcc_branch)/sizeof(vcc_branch[0]), 2, 3).empty(),
           "the production recompiler rejects the unsafe forward VCC branch");
 
-    // A VCCZ-exit loop is valid in vertex/fragment stages where one SPIR-V invocation models one
-    // hardware lane (#615), but not in the 64-lane compute shell: compute VCC needs a wave reduction.
+    // A PROVEN-UNIFORM VCCZ-exit loop now structurizes in the compute shell too (#590, extending
+    // #615): the uniformity proof is data-provenance-based — the compare reads s0 (scalar) and v1,
+    // whose nearest definition is `v_mov_b32 v1, 4` (an unmodified uniform VOP1 move from an inline
+    // scalar) — so every lane's compare bool is identical and the wave-empty vccz exit lowers to
+    // this invocation's bool, exactly as in the fragment shell. Body must be barrier/LDS/cross-lane
+    // free (guards below).
     const uint32_t compute_vcc_loop[] = {
         0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBF860004u,
         0x060000FFu, 0x3E800000u, 0x81008100u, 0xBF82FFFAu, 0xBF810000u,
     };
-    CHECK(recompile_valu(compute_vcc_loop, sizeof(compute_vcc_loop)/sizeof(compute_vcc_loop[0]), 0, 0).empty(),
-          "a VCCZ-exit loop remains rejected by the compute shell (wave-mask condition)");
+    CHECK(!recompile_valu(compute_vcc_loop, sizeof(compute_vcc_loop)/sizeof(compute_vcc_loop[0]), 0, 0).empty(),
+          "a proven-uniform VCCZ-exit loop structurizes in the compute shell (#590)");
+    // The SAME loop with v1 defined from a VGPR (`v_mov_b32 v1, v0`) fails the uniform-VOP1-from-
+    // scalar proof clause: the compare can no longer be proven wave-uniform, so compute still
+    // rejects it loudly (a varying trip count needs a real wave reduction).
+    const uint32_t compute_vcc_loop_varying[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020300u, 0x7D020200u, 0xBF860004u,
+        0x060000FFu, 0x3E800000u, 0x81008100u, 0xBF82FFFAu, 0xBF810000u,
+    };
+    CHECK(recompile_valu(compute_vcc_loop_varying,
+                         sizeof(compute_vcc_loop_varying)/sizeof(compute_vcc_loop_varying[0]), 0, 0).empty(),
+          "a VCCZ-exit loop whose compare reads a varying VGPR still rejects in the compute shell");
+    // An s_barrier INSIDE the loop body also rejects: the uniformity proof is per-WAVE, and a
+    // barrier inside a loop whose trip count could differ across the workgroup's waves would be
+    // workgroup-divergent control flow (UB).
+    const uint32_t compute_vcc_loop_barrier[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBF860005u,
+        0x060000FFu, 0x3E800000u, 0x81008100u, 0xBF8A0000u, 0xBF82FFF9u, 0xBF810000u,
+    };
+    CHECK(recompile_valu(compute_vcc_loop_barrier,
+                         sizeof(compute_vcc_loop_barrier)/sizeof(compute_vcc_loop_barrier[0]), 0, 0).empty(),
+          "a uniform VCCZ-exit loop containing s_barrier still rejects in the compute shell");
 
     // A forward s_cbranch_execz that REJOINS LIVE CODE is only safe to linearize when its skipped block
     // is EXEC-predicated VGPR writes. Here the block is a scalar write (s_mov_b32 s0,1) and the branch

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -71,6 +71,50 @@ int main() {
                          sizeof(compute_vcc_loop_barrier)/sizeof(compute_vcc_loop_barrier[0]), 0, 0).empty(),
           "a uniform VCCZ-exit loop containing s_barrier still rejects in the compute shell");
 
+    // A FORWARD vccz if with the same proven-uniform compare also structurizes in compute (#590 —
+    // DOLL's blocked lighting/fill kernels are forward vccz if/else trees, not loops). Same shape as
+    // the loop fixture minus the back-edge: compare, skip-two-dwords vccz to s_endpgm (early-out).
+    const uint32_t compute_vcc_if[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBF860002u,
+        0x060000FFu, 0x3E800000u, 0xBF810000u,
+    };
+    CHECK(!recompile_valu(compute_vcc_if, sizeof(compute_vcc_if)/sizeof(compute_vcc_if[0]), 0, 0).empty(),
+          "a proven-uniform forward vccz if structurizes in the compute shell (#590)");
+    // Varying compare (v1 <- v_mov from a VGPR): still rejects.
+    const uint32_t compute_vcc_if_varying[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020300u, 0x7D020200u, 0xBF860002u,
+        0x060000FFu, 0x3E800000u, 0xBF810000u,
+    };
+    CHECK(recompile_valu(compute_vcc_if_varying,
+                         sizeof(compute_vcc_if_varying)/sizeof(compute_vcc_if_varying[0]), 0, 0).empty(),
+          "a forward vccz if with a varying compare still rejects in the compute shell");
+    // s_barrier inside the guarded region: still rejects (workgroup-divergence hazard).
+    const uint32_t compute_vcc_if_barrier[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBF860003u,
+        0x060000FFu, 0x3E800000u, 0xBF8A0000u, 0xBF810000u,
+    };
+    CHECK(recompile_valu(compute_vcc_if_barrier,
+                         sizeof(compute_vcc_if_barrier)/sizeof(compute_vcc_if_barrier[0]), 0, 0).empty(),
+          "a uniform forward vccz if containing s_barrier still rejects in the compute shell");
+    // The compare-finding walk looks past instructions that provably cannot rewrite VCC (real UE4
+    // kernels schedule unrelated ALU between compare and branch): same uniform if with two plain
+    // VALU ops (v_mov v2,1 ; v_mov v3,2) hoisted between the compare and the branch.
+    const uint32_t compute_vcc_if_hoisted[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0x7E040281u, 0x7E060282u,
+        0xBF860002u, 0x060000FFu, 0x3E800000u, 0xBF810000u,
+    };
+    CHECK(!recompile_valu(compute_vcc_if_hoisted,
+                          sizeof(compute_vcc_if_hoisted)/sizeof(compute_vcc_if_hoisted[0]), 0, 0).empty(),
+          "the uniformity proof looks past VCC-preserving instructions between compare and branch");
+    // But an intervening write that COULD hit VCC (s_mov_b32 s106, 0) stops the walk: reject.
+    const uint32_t compute_vcc_if_clobber[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBEEA0380u,
+        0xBF860002u, 0x060000FFu, 0x3E800000u, 0xBF810000u,
+    };
+    CHECK(recompile_valu(compute_vcc_if_clobber,
+                         sizeof(compute_vcc_if_clobber)/sizeof(compute_vcc_if_clobber[0]), 0, 0).empty(),
+          "an intervening write to s106 (VCC) between compare and branch stops the proof");
+
     // A forward s_cbranch_execz that REJOINS LIVE CODE is only safe to linearize when its skipped block
     // is EXEC-predicated VGPR writes. Here the block is a scalar write (s_mov_b32 s0,1) and the branch
     // target is a live use of s0 (v_mov_b32 v0,s0) — the scalar write is NOT dead, so linearizing would


### PR DESCRIPTION
## What

Extends #615's proven-uniform VCC structurization to the **compute shell** — both shapes:

1. **VCC-exit loops** (commit 1): accept `DivLoop::Condition::Vcc` loops in compute under the same
   data-provenance uniformity proof as fragment (every compare input scalar/inline/literal or a
   uniform-VOP1-from-scalar VGPR → every lane's bool identical → the wave-empty vccz exit lowers to
   this invocation's bool). Conservative guards: Vcc-condition only, and the body must be
   barrier/LDS/cross-lane free (the proof is per-wave; a barrier under possibly-wave-divergent CF
   would be workgroup-divergent UB).
2. **Forward VCC ifs** (commit 2): DOLL's actually-blocked compute kernels are forward vccz if/else
   trees, not loops (`shader_inspect` on the new `exec_cs` dumps). Accept them under the same proof +
   region guard. Real kernels hoist ~15 unrelated ALU ops between the compare and its branch, so the
   proof's compare-finding walk now looks past instructions that **provably cannot rewrite VCC**
   (`cannot_write_vcc`); any possible VCC writer that is not a plain VOPC stops the walk
   conservatively. Sound because VCC's value is frozen at the compare.

Plus: failed **compute** programs now dump raw bytes under `PROSPER_SHADER_DUMP`
(`exec_cs_<addr>.bin`, fault-safe, bounded 64 KB), mirroring the graphics VS/PS dump — this is what
made the offline CFG mapping of the blocked kernels possible.

## Measured effect (DOLL PPSA17942, 200 s boot, PROSPER_DBG)

- `s_cbranch_vccz` rejects **136 → 111**; `image_store` rejects **57 → 97**: the blocked kernels'
  first-bad site moves PAST their branches to the storage-image op — the CF half of #590 works on the
  real shaders. No program fully compiles yet: the next blocker is compute storage-image/descriptor
  resolution (#590 items 1-3, the follow-up).
- Messenger: 0 rejects before and after; `messenger_recompile_guard` green.
- Snapshot guard green and identical: messenger-scene 24318 colors, dead-cells-splash 1684.

## Tests

8 new contract cases in `test_recompile_coverage`: uniform loop + uniform forward if compile in the
compute shell; varying compare, `s_barrier` in loop body, `s_barrier` in if region, and an intervening
`s_mov_b32 s106` (VCC clobber) all still reject; the hoisted-ALU shape proves the walk generalization.
86/86 ctest on Linux.

Part of #590 (control-flow half). The storage-image resolution + `live_compute` binding half follows.
