### PR TITLE
port(win): Windows guest boots multi-threaded into the frame loop (lazy-commit + worker-thread ABI/TLS)

### DIFF
--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -338,19 +338,31 @@ fault per kernel-transition boundary, not per access; a loop guard only re-appli
 actually changed). `PROSPER_NO_GUEST_FS=1` reverts to the old wall, confirming this is the enabler.
 Result: boot advances far past the wall into deep guest code.
 
-### The Windows frontier: a deep, nondeterministic guest crash
+### Guest allocator + worker threads — SOLVED (lazy-commit + worker trampoline)
 
-With `%fs` TLS in, boot reaches a much deeper guest crash — `eboot+0x17968cd`, a 9-frame guest
-backtrace, faulting on a **high mapped guest address** (not null), and it is **nondeterministic**
-(some runs `RUN ENDED` cleanly, some hard-fault / trip the Windows heap check). Prime suspects, in
-order: (1) the **deferred phys-aliasing** in the memory HLE — the guest may map one phys offset at two
-VAs expecting shared bytes, but Win32 gives it two private `VirtualAlloc` buffers, so writes through
-one VA aren't seen through the other; (2) **ASLR** — guest `VirtualAlloc` bases vary per run, so a
-guest assumption about layout would fault differently each time (a fixed-base reservation would make
-runs reproducible); (3) an HLE behavior only now reached. Next step: make the guest mapping
-deterministic (fixed base) to get a reproducible crash, then decide whether phys-aliasing must be
-implemented (the 64 KiB-granularity `CreateFileMapping`/`MapViewOfFile3` section approach) for this
-title.
+The deep crash after `%fs` TLS was two more Linux-parity gaps (fixed on `port/windows-boot-2`, PR #628):
+- **Lazy-commit.** The guest's binned allocator writes into pages inside a range it RESERVED but never
+  explicitly committed. Linux's SIGSEGV handler lazily backs these on first touch; the Windows VEH did
+  not, so allocator init faulted at a reserved page (diagnosed with a `[memclass]` fault classifier that
+  showed the fault address as reserved-but-uncommitted). The VEH now `VirtualAlloc(MEM_COMMIT)`s the
+  64 KiB page on a tracked-reserved fault and retries.
+- **Worker-thread ABI + TLS.** The Windows `pthread_create` path called the guest entry directly via
+  winpthreads: MS-x64 ABI (arg in rcx, guest reads rdi) and no `guest_tls_activate_thread()`. The first
+  worker got a garbage arg and no guest TCB and crashed on a null-derived deref (`mov 0x38(%rbx)`,
+  rbx=0) on an unrecoverable thread. A `win_thread_trampoline` now marshals the SysV entry through
+  `prosper_call_guest_sysv` and activates the worker's guest `%fs` TCB.
+
+### The Windows frontier: wire the renderer (guest reaches the frame loop and idle-waits)
+
+The Windows guest now **boots fully multi-threaded into the running frame loop and idle-waits** (0%
+CPU across 4 threads, zero unimplemented Sony calls, no crash) — the same state the Linux *headless*
+`boot_trace` reaches: alive, waiting for the GPU/present side to make progress. `boot_trace` wires no
+Vulkan on Windows, so the next step to a rendered frame is bringing up the live Vulkan renderer +
+present path on Windows (the `frontends/shared/live_renderer` used by `prosper-app`), analogous to
+`PROSPER_RENDER=1` on Linux. Deferred, lower-priority items surfaced along the way: phys-offset
+aliasing in the memory HLE (needed by UE4 MallocBinned3, not this Unity title — `CreateFileMapping`/
+`MapViewOfFile3`, 64 KiB granularity); honoring reserve alignment > 64 KiB (over-reserve + trim);
+worker-thread stack registration for GC bounds; and `PROSPER_CRASHPEEK` guards.
 
 **What is done (compiles + links, in CI):**
 - **`exec_image_win.cpp`** — the Win32 sibling of `exec_image_linux.cpp` implementing the full
@@ -373,21 +385,22 @@ title.
   `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **The deep nondeterministic guest crash — the current blocker.** See "The Windows frontier" above:
-   make guest mappings deterministic (fixed base) for a reproducible crash, then likely implement
-   phys-aliasing in the memory HLE (`CreateFileMapping`/`MapViewOfFile3`, 64 KiB granularity).
-2. ~~Port the direct/flexible-memory HLE~~ — **DONE** (private-`VirtualAlloc` port; phys-aliasing
-   deferred — now a prime suspect for item 1).
-3. ~~Guest `%fs` TLS~~ — **DONE** (FSGSBASE + VEH re-apply; see above).
-4. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
+1. **Wire the Vulkan renderer on Windows — the current frontier.** The guest boots into the frame loop
+   and idle-waits for the GPU/present side (see above). Bring up `frontends/shared/live_renderer` +
+   present on Windows (the `PROSPER_RENDER=1` analogue) to drive past the wait toward a rendered frame.
+2. ~~Port the direct/flexible-memory HLE~~ — **DONE** (private-`VirtualAlloc`; phys-aliasing deferred,
+   only needed by UE4 MallocBinned3, not this Unity title).
+3. ~~Guest `%fs` TLS~~ — **DONE** (FSGSBASE + VEH re-apply).
+4. ~~Guest allocator (reserved-page lazy commit) + worker-thread ABI/%fs TLS~~ — **DONE** (PR #628).
+5. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
    and now runtime-exercised through init; **XMM/float args are still not converted** (e.g. some libc
    formatters / `printf`-family) — add float-arg conversion when a title needs it.
-5. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
+6. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
    current stack; a true stack-overflow fault still needs a guard-page/dedicated-stack story (Linux
    uses `sigaltstack`). The `__builtin_longjmp` change fixed the cross-frame-unwind crash; this is the
    separate genuine-overflow case. Also: `PROSPER_CRASHPEEK` faults on Windows (the IL2CPP klass
    walker needs the same `guest_readable` guards the Linux path has).
-6. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
+7. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
    and so route correctly through the trampoline, but confirm none are raw host functions relying on
    host-ABI arg passing.
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -486,6 +486,25 @@ void* thread_trampoline(void* p) {
     return rv;
 }
 }
+#elif defined(_WIN32)
+namespace {
+// Windows guest-thread trampoline. The bare `pthread_create(entry, arg)` the Windows path used
+// before had two fatal bugs: (1) winpthreads calls `entry(arg)` with the MS x64 ABI (arg in rcx),
+// but the guest entry is System V (reads rdi) — so the worker got a garbage arg and crashed on a
+// null-derived pointer; (2) it never ran guest_tls_activate_thread(), so the worker had no guest
+// %fs TCB and its initial-exec TLS was wrong. This trampoline fixes both: activate the guest %fs
+// TCB, then call the guest entry through the SysV marshalling shim, and purge DTV on exit.
+struct WinThreadStart { uint64_t entry; void* arg; };
+extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
+void* win_thread_trampoline(void* p) {
+    auto* ts = (WinThreadStart*)p;
+    uint64_t entry = ts->entry; void* arg = ts->arg; free(ts);   // host libc: run on host %fs (before activate)
+    guest_tls_activate_thread();   // this worker's guest %fs TCB (FSGSBASE); no-op if the gate is off
+    void* rv = entry ? (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0) : nullptr;
+    tls_dtv_purge_current_thread();
+    return rv;
+}
+}
 #endif
 
 HLE(k_pthread_create) {
@@ -522,9 +541,14 @@ HLE(k_pthread_create) {
     pthread_attr_destroy(&la);
     if (r) { free(ts); return (uint64_t)r; }
 #else
+    // Windows: route through win_thread_trampoline so the guest entry is called with the SysV ABI and
+    // gets its guest %fs TCB — a bare pthread_create(entry, arg) mis-passes the arg (MS x64 vs SysV) and
+    // skips TLS activation, crashing the worker on a null-derived pointer.
     pthread_attr_t* at = (a1 && *(void**)a1) ? (pthread_attr_t*)*(void**)a1 : nullptr;
-    int r = pthread_create(&tid, at, entry, arg);
-    if (r) return (uint64_t)r;
+    auto* ts = (WinThreadStart*)malloc(sizeof(WinThreadStart));
+    ts->entry = (uint64_t)(uintptr_t)entry; ts->arg = arg;
+    int r = pthread_create(&tid, at, win_thread_trampoline, ts);
+    if (r) { free(ts); return (uint64_t)r; }
 #endif
     if (a0) *(uint64_t*)a0 = (uint64_t)tid;
     return 0;

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -233,11 +233,30 @@ namespace {
 
     __attribute__((noinline)) void veh_recover() { __builtin_longjmp(t_jb, 1); }   // runs on the faulting thread
 
+    // Tracked-mapping state probe for the lazy-commit fault path (defined in hle_kernel_mem.cpp):
+    // 0 = untracked/gap, 1 = reserved-but-uncommitted, 2 = committed.
+    extern "C" int prosper_reserved_range_state(uint64_t addr);
+
     LONG CALLBACK veh(EXCEPTION_POINTERS* ep) {
         CONTEXT* c = ep->ContextRecord;
         DWORD code = ep->ExceptionRecord->ExceptionCode;
         if (code == EXCEPTION_ILLEGAL_INSTRUCTION && try_emulate_sse4a(c))
             return EXCEPTION_CONTINUE_EXECUTION;
+        // Lazy-commit inside a guest-RESERVED range — parity with the Linux SIGSEGV handler. The guest
+        // reserves a virtual range then touches pages it believes committed (its binned allocator relies
+        // on a commit protocol real HW satisfies but our HLE doesn't fully replicate). If the faulting
+        // read/write address is one the memory HLE tracks as reserved-but-uncommitted, commit the 64 KiB
+        // page and retry. Gated to tracked-reserved addresses (state 1) and non-execute accesses
+        // (ExceptionInformation[0]!=8) so a genuine wild access / bad instruction fetch still faults.
+        if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2 &&
+            ep->ExceptionRecord->ExceptionInformation[0] != 8) {
+            uint64_t a = (uint64_t)ep->ExceptionRecord->ExceptionInformation[1];
+            if (a >= 0x1000000000ull && prosper_reserved_range_state(a) == 1) {
+                void* page = (void*)(uintptr_t)(a & ~(uint64_t)0xffff);
+                if (VirtualAlloc(page, 0x10000, MEM_COMMIT, PAGE_READWRITE))
+                    return EXCEPTION_CONTINUE_EXECUTION;   // re-execute against the now-committed page
+            }
+        }
         // Guest %fs base drift: Windows zeroes the user FS base on every kernel transition, so a
         // guest fs-relative TLS access can fault at a low linear address after a context switch /
         // syscall even though the guest TCB is fine. If the faulting instruction is fs-relative and
@@ -250,6 +269,15 @@ namespace {
             code != EXCEPTION_IN_PAGE_ERROR && code != EXCEPTION_PRIV_INSTRUCTION &&
             code != EXCEPTION_DATATYPE_MISALIGNMENT)
             return EXCEPTION_CONTINUE_SEARCH;   // not a guest fault we own
+        // PROSPER_VEHLOG: surface a fault we're about to decline (unarmed thread → the process will die
+        // without a RUN ENDED report). This is the only visibility into a guest worker-thread crash.
+        if (getenv("PROSPER_VEHLOG")) {
+            uint64_t fa = (ep->ExceptionRecord->NumberParameters >= 2)
+                        ? (uint64_t)ep->ExceptionRecord->ExceptionInformation[1] : 0;
+            fprintf(stderr, "[veh] tid=%lu code=0x%lx rip=0x%llx addr=0x%llx armed=%d rstate=%d\n",
+                    (unsigned long)cur_tid(), (unsigned long)code, (unsigned long long)c->Rip,
+                    (unsigned long long)fa, (int)t_armed, prosper_reserved_range_state(fa));
+        }
         if (!t_armed) return EXCEPTION_CONTINUE_SEARCH;   // worker thread with no recovery point
 
         g_trap_kind = (code == EXCEPTION_ILLEGAL_INSTRUCTION) ? 3 : 2;

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -8,6 +8,8 @@
 #include "hle/dispatch.hpp"
 #include <cstdio>
 #include <string>
+#include <cstdint>
+extern "C" int prosper_reserved_range_state(uint64_t);   // memory-HLE mapping classifier (diagnostic)
 #ifdef PROSPER_AUDIO_SDL3
 #include "audio_sdl3.hpp"                 // optional SDL3 audio frontend (-DPROSPER_AUDIO_SDL3=ON)
 #endif
@@ -208,6 +210,16 @@ int main(int argc, char** argv) {
            (unsigned long long)r.rdx, (unsigned long long)r.rbp, (unsigned long long)r.rsp);
     printf("  backtrace (%zu frames):\n", r.backtrace.size());
     for (uint64_t a : r.backtrace) printf("    %-12s +0x%llx\n", cls(a), (unsigned long long)bof(a));
+    // Classify the fault address vs our tracked guest mappings (0=untracked/gap, 1=reserved-uncommitted,
+    // 2=committed). A write at a page boundary whose predecessor byte is committed but which is itself
+    // reserved/untracked pinpoints a guest run-off-the-end-of-a-region (Windows memory-model diagnosis).
+    if (r.kind == 2 && r.fault_addr) {
+        auto st = [](int s){ return s==2?"committed":s==1?"reserved":"untracked/gap"; };
+        printf("  [memclass] fault_addr=%s  fault_addr-8=%s  fault_addr-0x1000=%s\n",
+               st(prosper_reserved_range_state(r.fault_addr)),
+               st(prosper_reserved_range_state(r.fault_addr - 8)),
+               st(prosper_reserved_range_state(r.fault_addr - 0x1000)));
+    }
     // PROSPER_CRASHPEEK: after a recovered main-thread fault, dump guest memory at the fault registers
     // (still 1:1-mapped) so a null-source deref (e.g. an IL2CPP memcpy from a null field) can be traced
     // to the object + field that is null. Reads are bounded by guest_readable (never re-faults).


### PR DESCRIPTION
Follow-up to the merged Windows substrate (#624). Takes the Windows boot from a
crash during allocator init to a **multi-threaded guest that runs without crashing**,
reaching the same running-frame-loop depth as the Linux *headless* boot_trace (no GPU
is wired in boot_trace on Windows, so it then waits/runs rather than rendering).

Two runtime fixes, both Linux-parity:

**1. Lazy-commit guest-reserved pages in the VEH.** The guest's binned allocator
writes into pages inside a range it reserved but never explicitly committed (a commit
protocol real HW satisfies). Linux's SIGSEGV handler lazily backs these; the Windows
VEH did not, so allocator init faulted fatally at a reserved page. The VEH now commits
the 64 KiB page on a tracked-reserved fault and retries (gated, non-execute only).
Also adds a `[memclass]` fault classifier to boot_trace and a `PROSPER_VEHLOG` decline
log — the diagnostics that pinpointed both bugs here.

**2. Guest worker threads get the SysV ABI + %fs TLS.** The Windows pthread_create
path called the guest entry directly via winpthreads — MS-x64 ABI (arg in rcx, guest
reads rdi) and no `guest_tls_activate_thread()` — so the first worker got a garbage arg
and no guest TCB, crashing on a null-derived deref. A `win_thread_trampoline` now
activates the worker's guest %fs TCB and calls the entry through the SysV shim, then
purges its DTV — the Windows analogue of the Linux thread_trampoline.

Scope: all `#ifdef _WIN32` except the boot_trace classifier (calls the existing
cross-platform `prosper_reserved_range_state`). Linux + macOS unaffected; verified with
a local WSL `prosper_core`/`boot_trace` rebuild. CI covers all four platforms.

Next frontier (docs/PORTING.md): characterize the running state (spin vs. sync-wait)
and wire the Vulkan renderer on Windows to drive past the frame-loop wait.
