### PR TITLE
fix(win): commit one guest page on reserved first touch

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1339,9 +1339,8 @@ namespace {
     }
 } // namespace
 
-// Fault-handler lazy-commit probe parity (Linux exports this for its SIGSEGV handler). We commit
-// eagerly on Win32 so the VEH handler never needs lazy commit, but expose the symbol identically
-// in case the shared fault path references it: 0 = untracked, 1 = reserved, 2 = committed.
+// Fault-handler lazy-commit probe parity (Linux exports this for its SIGSEGV handler). The Windows
+// VEH uses this to back reserved guest pages on first touch: 0 = untracked, 1 = reserved, 2 = committed.
 extern "C" int prosper_reserved_range_state(uint64_t addr) {
     std::lock_guard<std::mutex> lk(g_mx);
     const Mapping* best = nullptr;

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -3,14 +3,12 @@
 // The Windows sibling of exec_image_linux.cpp. It implements the same exec_image.hpp contract with
 // Win32 primitives instead of POSIX: VirtualAlloc for fixed-address guest mappings, a Vectored
 // Exception Handler (VEH) instead of a SIGSEGV/SIGILL handler, and CONTEXT register access instead
-// of ucontext. The guest is System V AMD64; the host is Microsoft x64 — the guest↔HLE boundary is
-// bridged by PROSPER_SYSV_ABI (dispatch.hpp), and host→guest calls here go through SysV-typed
-// function pointers.
+// of ucontext. The guest is System V AMD64; the host is Microsoft x64. Emitted import stubs marshal
+// guest calls into the host ABI, and prosper_call_guest_sysv marshals host calls into the guest ABI.
 //
-// STATUS (2026-07-13): compile/link-complete and CI-built, but the guest boot is NOT yet verified on
-// Windows. Known remaining work is tracked in docs/PORTING.md "Windows": the direct/flexible memory
-// HLE (hle_kernel_mem.cpp) is still POSIX-only, guest %fs TLS is unsolved (same wall as macOS), the
-// (HleFn)-cast handler ABI audit, and runtime validation of VEH recovery. Diagnostics that depend on
+// STATUS (2026-07-13): runtime-verified through a multi-threaded headless frame-loop boot. Remaining
+// work is tracked in docs/PORTING.md "Windows": wire the Vulkan renderer, preserve physical-memory
+// aliasing, cover float/XMM import arguments, and harden VEH recovery. Diagnostics that depend on
 // Linux perf_event / ptrace (PROSPER_HWBP/HWWATCH/BP/PEEK/DUMPAT) are intentionally absent here.
 #ifdef _WIN32
 

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -245,15 +245,17 @@ namespace {
         // Lazy-commit inside a guest-RESERVED range — parity with the Linux SIGSEGV handler. The guest
         // reserves a virtual range then touches pages it believes committed (its binned allocator relies
         // on a commit protocol real HW satisfies but our HLE doesn't fully replicate). If the faulting
-        // read/write address is one the memory HLE tracks as reserved-but-uncommitted, commit the 64 KiB
-        // page and retry. Gated to tracked-reserved addresses (state 1) and non-execute accesses
+        // read/write address is one the memory HLE tracks as reserved-but-uncommitted, commit the 16 KiB
+        // guest page and retry. Windows reservations can be only one guest page long; committing a
+        // 64 KiB allocation-granularity span would cross that reservation and fail with ERROR_INVALID_ADDRESS.
+        // Gated to tracked-reserved addresses (state 1) and non-execute accesses
         // (ExceptionInformation[0]!=8) so a genuine wild access / bad instruction fetch still faults.
         if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2 &&
             ep->ExceptionRecord->ExceptionInformation[0] != 8) {
             uint64_t a = (uint64_t)ep->ExceptionRecord->ExceptionInformation[1];
             if (a >= 0x1000000000ull && prosper_reserved_range_state(a) == 1) {
-                void* page = (void*)(uintptr_t)(a & ~(uint64_t)0xffff);
-                if (VirtualAlloc(page, 0x10000, MEM_COMMIT, PAGE_READWRITE))
+                void* page = (void*)(uintptr_t)(a & ~(uint64_t)0x3fff);
+                if (VirtualAlloc(page, 0x4000, MEM_COMMIT, PAGE_READWRITE))
                     return EXCEPTION_CONTINUE_EXECUTION;   // re-execute against the now-committed page
             }
         }

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -6,6 +6,9 @@
 // own process, so the process-global direct-memory pool starts empty here.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#ifdef _WIN32
+#include "../src/host/exec_image.hpp"
+#endif
 #include <cstdio>
 #include <cstdint>
 #ifdef __linux__
@@ -25,10 +28,33 @@ static constexpr uint64_t kEnd   = kBase + kTotal;
 
 int main() {
     printf("== test_dmem ==\n");
-#ifndef __linux__
+#ifdef _WIN32
+    // Windows first-touch handling must commit one 16 KiB guest page, not a 64 KiB allocation-
+    // granularity span. The latter crosses this reservation and fails with ERROR_INVALID_ADDRESS.
+    register_builtin_hle();
+    auto reserve = Hle::lookup(nid_hash("sceKernelReserveVirtualRange"));
+    auto unmap   = Hle::lookup(nid_hash("sceKernelMunmap"));
+    CHECK(reserve && unmap, "reserve/unmap HLE functions registered");
+    if (fails) return 1;
+
+    constexpr uint64_t len = 0x4000;
+    uint64_t va = 0x30000000000ull;  // Fixed, 64 KiB-aligned, and above the VEH's heap threshold.
+    CHECK(reserve((uint64_t)(uintptr_t)&va, len, 0x10 /* MAP_FIXED */, len, 0, 0) == 0,
+          "ReserveVirtualRange creates an exact 16 KiB reservation");
+    if (fails) return 1;
+
+    install_trap_handler();
+    volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)va;
+    *cell = 0x6310CAFEu;
+    CHECK(*cell == 0x6310CAFEu, "first touch commits one guest page and preserves the write");
+    CHECK(unmap(va, len, 0, 0, 0, 0) == 0, "reserved page unmaps cleanly");
+
+    if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+#elif !defined(__linux__)
     // The direct-memory HLE (hle_kernel_mem.cpp) is #ifdef __linux__ — its functions aren't
-    // registered on other platforms (e.g. the Windows/MinGW CI build), so there is nothing to
-    // exercise here. Skip cleanly rather than fail on the absent registrations.
+    // registered on this platform, so there is nothing to exercise here. Skip cleanly.
     printf("  [skip] direct-memory HLE is Linux-only on this build\n== PASS ==\n");
     return 0;
 #else


### PR DESCRIPTION
## Summary

- commit the containing 16 KiB PS5 guest page in the Windows lazy-commit VEH instead of a 64 KiB allocation-granularity span
- extend the cross-platform direct-memory test with a native Windows reserve/first-touch regression
- refresh the stale Windows execution/memory status comments after #624/#628

A one-page `sceKernelReserveVirtualRange` reservation is valid on Windows. The previous 64 KiB commit crossed its end, so `VirtualAlloc(MEM_COMMIT)` failed with `ERROR_INVALID_ADDRESS` and the original access violation became fatal.

## Verification

- Windows MinGW build: clean
- Windows ctest: 57/57 passed
- Linux build: clean
- Linux ctest: 91/91 passed
- Native Windows regression: real HLE reserves exactly 16 KiB; the VEH commits it on first write and preserves the value

Fixes #631