### PR TITLE
docs: refresh Dead Cells status after composition fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ prosper/
 Key docs to orient: `prosper/README.md` (status), `prosper/docs/ROADMAP.md`, `prosper/docs/GRAPHICS.md`,
 `prosper/docs/RENDER_LOOP.md` (the historical render bring-up log), and
 `prosper/docs/MESSENGER_BLACK_RENDER.md` (the revisioned Messenger investigation status). The current
-Dead Cells graphics handoff and exact reproduction recipe are in `prosper/docs/DEAD_CELLS_STATUS.md`.
+Dead Cells graphics status and exact regression recipe are in `prosper/docs/DEAD_CELLS_STATUS.md`.
 
 ## Historical frontier (superseded 2026-07-11)
 
@@ -72,7 +72,7 @@ renderer is wired in; the game's **real pixel shader recompiles to valid SPIR-V*
 **bindless-dynamic vertex-fetch resolution** for the vertex shader — fully specified in
 `prosper/docs/NEXT_STEP_VERTEX_FETCH.md`. This paragraph is historical only.
 
-## Current frontier (2026-07-12)
+## Current frontier (2026-07-13)
 
 The game now **boots through IL2CPP, renders its intro/title/menu, and reaches gameplay with real GPU
 draws.** The old bindless vertex-fetch frontier is complete: both shader stages recompile and dynamic
@@ -98,9 +98,9 @@ exercised NGS2 lifecycle returns initialized sizes/handles/state and silent outp
 window reaches the Evil Empire splash. #545 was software-render throughput, not a guest deadlock: synchronous
 3840×2160 llvmpipe rendering stretches its ~13,000-submit startup into minutes.
 
-Dead Cells now has a deterministic route through splash/menu into gameplay. HUD and partial composition render.
-Version-4 `.prgcap` captures seed temporal RTT inputs (#568) and isolates the
-first bad composition at draw 18; one 642x362 input has no prior color-target writer. The kernel-derived dispatch
+Dead Cells now has a deterministic route through splash/menu into full-color gameplay.
+Version-4 `.prgcap` captures seeded temporal RTT inputs (#568) historically isolated the earlier warmup artifact
+at draw 18; one 642x362 input had no prior color-target writer. The kernel-derived dispatch
 thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V# binding (#574)
 now execute the real fill kernel against guest buffers before submit completion (#576). Range provenance proved
 draw 19 consumes one backing, dispatch 5 fills it, then draw 31 consumes it again in one submit. Graphics spans and
@@ -135,7 +135,7 @@ is the opening vignette rather than gameplay. The preserved #608 playable bundle
 and the 738x420 target at draw 79..81. Current routes use 91..93 draws, exactly 8 dispatches, and the 738x420
 target at draw 80..82; two independent timelines selected only sustained gameplay from about 29.5 seconds onward.
 Target extent or total draw count alone also selects cinematic/transition frames and must not be used as the
-oracle. Use this checkpoint to isolate the first bad composition.
+oracle. This checkpoint established the stable offline baseline used to isolate the composition defects.
 The faithful playable bundle spans submits 18,165..19,047, stores 158.94 GiB logical state in 739 MiB, and
 resolves all 1,764 temporal image dependencies. Its pre-#611/#615 historical hash was `5759c125812154dc`; do
 not use that old absolute hash as a current renderer oracle. A two-submit color-bounded replay remains
@@ -161,6 +161,14 @@ semantic draws. Capture v7 (#618) retains a failed stage fault-safely through `s
 content-deduplicates it, and records exact coverage/opcode/PC, decoded pipeline/launch state, and
 resource/descriptor summaries. Start with `gpu_replay --inspect-only`; extract a raw stage with
 `--dump-failed-shader FAILURE:STAGE PATH` instead of rerunning the title.
+
+The remaining Dead Cells color defect was fixed by #626. Its world shaders emit color exports in descending
+MRT3..MRT0 order; the single-attachment recompiler incorrectly used the first export, presenting a grayscale
+G-buffer plane as color0. Selecting MRT0 restores the full-color Prisoners' Quarters composition. The same PR
+also exposes the directly placed destination V# for a format-copy compute shader, taking the current checkpoint
+from seven to eight realized dispatches. #566 is closed. Use `prosper/docs/DEAD_CELLS_STATUS.md` for the current
+route and regression workflow rather than restarting the completed composition localization.
+
 `--bundle-final-capsule` snapshots both color RTT state and exact valid planes from persistent Vulkan
 depth/stencil images into capture v8 (#569). Capture v8 reads v1-v7 artifacts; pre-v7 failed-operation diagnostics
 report unavailable and pre-v8 captures contain no invented DS seeds. Timeline v6 reads timeline v1-v5

--- a/README.md
+++ b/README.md
@@ -68,23 +68,15 @@ accepts scripted gamepad input, and renders the first level.
 - ✅ **The Messenger reaches gameplay:** intro, title, menus, save list, dialogue, player, terrain,
   water, structures, and foreground composition render through the first level at native 1920x1080.
   A scripted gamepad route produced a full-resolution sequence that was confirmed against PS5 hardware.
-- 🚧 **Dead Cells reaches gameplay:** deterministic input routing passes its splash and menus into the
-  first playable scene. Graphics and compute now execute by retained PM4 order (#584), fixing a proven
-  future-read. The formerly overbright screenshot was traced to a diagnostic warmup skipping temporal RTT
-  producers. Versioned offline bundles now retain long, exact cross-submit resource history and replay a
-  minimized closure. The preserved #608 bundle used exactly 90 semantic draws with the 738x420 pass at draw
-  79..81. Current routes use 91..93 draws, exactly 8 dispatches, and that pass at draw 80..82. Timeline v6
-  discovers and validates this checkpoint offline without depending on run-local submit ordinals (#594). The
-  faithful 883-submit replay isolated the missing-world symptom to a persistent 642x362 depth surface.
-  Timeline-v5 backing hashes and
-  writer provenance then found the real clear boundary: a supported compute kernel fills the surface's
-  32 KiB HTILE allocation with `0xfffffff0` before drawing. Guest GPU writes now invalidate overlapping
-  cached Vulkan depth images, restoring the rejected gameplay layers in a routed live A/B (#611). The four
-  remaining scene draws used uniform VCCZ-exit light loops; the fragment/vertex recompiler now proves that
-  narrow wave-uniform shape, emits structured loops, and realizes every sampled gameplay draw (#615).
-  Capture v8 snapshots exact persistent Vulkan depth/stencil planes alongside temporal color targets, turning
-  the final composition into a standalone, hash-checked replay checkpoint (#569). The current evidence boundary,
-  reproduction recipe, and remaining work are in [`prosper/docs/DEAD_CELLS_STATUS.md`](prosper/docs/DEAD_CELLS_STATUS.md).
+- ✅ **Dead Cells reaches full-color gameplay:** deterministic input routing passes the splash and menus into
+  the controllable Prisoners' Quarters scene. Graphics and compute execute in retained PM4 order (#584), guest
+  compute writes invalidate overlapping depth-cache state (#611), and the remaining lighting loops recompile
+  through a narrowly proved wave-uniform form (#615). The final grayscale-world defect was MRT selection: the
+  shaders export MRT3..MRT0, while the single-attachment backend previously used the first export. MRT0 now feeds
+  color attachment 0 (#626), restoring the colored atlas, lighting, player, terrain, effects, and HUD. Capture v8
+  preserves the complete color/depth checkpoint and source-image oracle for fast standalone regression replay
+  (#569). The exact route and reproduction workflow are in
+  [`prosper/docs/DEAD_CELLS_STATUS.md`](prosper/docs/DEAD_CELLS_STATUS.md).
 
 **Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -1,17 +1,20 @@
-# Dead Cells graphics status
+# Dead Cells graphics status and regression workflow
 
 Last updated: 2026-07-13
 
-This is the handoff for the remaining *Dead Cells* gameplay-composition work. The operational route and
-selector reference is [`../scripts/dead-cells/README.md`](../scripts/dead-cells/README.md). The active bug is
-[#566](https://github.com/mattias800/ps5ys/issues/566).
+The operational route and selector reference is
+[`../scripts/dead-cells/README.md`](../scripts/dead-cells/README.md). The gameplay-composition bug
+[#566](https://github.com/mattias800/ps5ys/issues/566) was fixed by #626; this document retains the exact
+checkpoint recipe as a regression and future-investigation workflow.
 
 ## Current state
 
 *Dead Cells* boots, passes the splash and menus, loads `PrisonStart`, and reaches the controllable Jump tutorial.
-Scene geometry, smoke, silhouettes, the player, the tutorial prompt, and the HUD render. The remaining output is
-visibly wrong compared with the game: the world composition is largely grayscale and overexposed instead of the
-colored, lit scene.
+The scene renders in full color, including geometry, lighting, smoke, silhouettes, the player, terrain, effects,
+the tutorial prompt, and the HUD. The final grayscale-world root cause was the fragment recompiler selecting the
+first color export from shaders that emit MRT3..MRT0; MRT0 now feeds the backend's single color attachment (#626).
+The same change set recovers a separately dropped format-copy dispatch by resolving its directly placed
+destination buffer descriptor at s4.
 
 The original mostly-white repeated-block image is not the current bug. It was caused by beginning diagnostic
 rendering after a required 642x362 temporal render-target producer had already run (#586). Do not use a
@@ -24,10 +27,12 @@ The important fixes already on `master` are:
 - four uniform VCCZ-exit fragment-lighting loops recompile through a narrowly proved structured form (#615);
 - failed operations retain bounded raw shaders and exact rejection diagnostics in capture v7 (#618);
 - capture v8 checkpoints complete color RTT state and persistent depth/stencil planes, including a source-output
-  hash oracle (#569).
+  hash oracle (#569);
+- directly placed compute buffer destinations resolve, so the current scene realizes all eight dispatches (#626);
+- MRT0, rather than the first-emitted non-color G-buffer plane, supplies the visible fragment output (#626).
 
-Current live gameplay submits after #615 realize all semantic draws. Descriptor validation has not identified a
-missing or undersized binding in the exercised frame.
+The producer-complete post-#626 checkpoint realizes every semantic draw and all eight dispatches. Descriptor
+validation has not identified a missing or undersized binding in the exercised frame.
 
 ## Evidence boundary
 
@@ -41,10 +46,11 @@ invalidation deliberately disabled, both produce `535256588b67a536`. This exact 
 the checkpoint implementation, but the image still reflects the old capture's missing operations. Do not use it
 to conclude which pass is wrong in a post-#615 live submit.
 
-A fresh producer-complete current bundle is therefore the required starting point. Title-derived `.prgtl`,
+A fresh producer-complete current bundle is the required starting point for any new regression or deeper-scene
+investigation. Title-derived `.prgtl`,
 `.prgcap`, `.prgbundle`, shader, and image artifacts are local and gitignored; none belong in a commit.
 
-## Recreate the current checkpoint
+## Recreate the regression checkpoint
 
 Build in WSL from the repository root. Adjust the dump path if needed:
 
@@ -107,27 +113,21 @@ cmp /tmp/dead-cells-current-source.bmp \
     /tmp/dead-cells-current-standalone.bmp
 ```
 
-Do not begin isolation until `cmp` succeeds and standalone replay reports that its embedded oracle passed. Also
-require `gpu_replay --inspect-only` to report zero failed operations for the current endpoint.
+Do not use a checkpoint as an oracle until `cmp` succeeds and standalone replay reports that its embedded oracle
+passed. Also require `gpu_replay --inspect-only` to report zero failed operations for the current endpoint.
 
 ## What remains
 
-1. Produce the fresh current bundle and hash-checked v8 capsule above. This removes the five legacy operation
-   holes from the debugging baseline.
-2. Obtain a hardware/reference capture of the same controllable frame and route state. The image currently
-   attached to #566 is from the preceding opening vignette, so it is a qualitative color reference rather than
-   a pixel-aligned oracle.
-3. Use `gpu_replay --through-operation N --allow-mismatch` to locate the operation where the 642x362 scene first
-   loses the expected material/color information. Preserve mixed graphics/compute order; `--draw` is not a
-   substitute for a semantic prefix.
-4. For the first suspect operation, record its draw/dispatch source, PM4 order, target, shader hashes, resource
-   hashes, blend/depth state, and before/after output. Dump only the relevant shader/resource inputs.
-5. Implement the missing generic GPU contract, add a synthetic regression, run all CTests and both Messenger and
-   Dead Cells snapshot guards, then repeat the source/capsule equality check.
+1. Keep the deterministic gameplay route and source/capsule equality check green as shared GPU work lands.
+2. Extend routed playability and checkpoint coverage beyond the first tutorial scene and into later rooms.
+3. Obtain a pixel-aligned hardware capture when exact visual comparison is needed; the #566 reference is from the
+   preceding opening vignette and remains a qualitative rather than pixel-exact oracle.
+4. For any new visual regression, use semantic operation prefixes to name the first divergent pass before changing
+   the renderer. Record its draw/dispatch source, PM4 order, target, shader and resource hashes, and fixed-function
+   state, then add a synthetic contract test for the generic fix.
 
-The likely fault domain is now a scene color/light composition contract, but shader execution, resource decode,
-format conversion, and blending remain hypotheses until the current producer-complete prefix identifies the
-first bad pass.
+There is no known remaining #566 composition defect in the exercised checkpoint. Generic GPU limitations and
+tooling follow-ups should be tracked as separate issues rather than reopening the completed grayscale investigation.
 
 ## Tooling note
 

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -24,7 +24,7 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
 
 ---
 
-## Current status (2026-07-12) - at a glance
+## Current status (2026-07-13) - at a glance
 
 - **Messenger reaches and renders the first level:** intro, title, menus, save list, dialogue, player,
   background, foreground tree/terrain, water, and structures render at native 1920×1080. The causal fixes
@@ -35,31 +35,16 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   live/replay hashes and per-draw/resource isolation; #515 provides reflected SPIR-V/runtime descriptor
   validation in live and offline replay paths. Producer provenance, normal screenshot capture, and the local
   content-metric snapshot guard complete the current first-bad-contract workflow.
-- **Dead Cells cross-title milestone:** deterministic routing now reaches gameplay. The initial mostly-white world
-  in #566 was a diagnostic warmup artifact, not the current renderer output. Version-4 captures seeded temporal
-  render targets (#568) and originally isolated that artifact at draw 18, where a 642x362 input lacked its prior
-  renderer-owned color-target version. The corrected
-  dispatch thread/local/group contract (#580), `sceAgcCbSetShRegistersDirect`, and compute direct type-1 V#
-  decoding (#574) now execute a valid registered fill program against real guest buffers before submit completion
-  (#576). Range provenance proved one submit orders a 642x362 consumer, dispatch 5's fill, then another consumer.
-  Graphics spans and compute now execute by that retained PM4 order (#584). Per-consumer hashes and target-prefix
-  metrics proved the later overbright screenshot was a warmup artifact: a skipped temporal RTT fell back to an
-  all-`0xFF` compute backing, then the bad copy persisted. Preserving the 642x362 producers renders real geometry.
-  The faithful playable closure subsequently isolated a second lifetime bug: one detached Vulkan depth image
-  accumulated across 883 submits even though a supported compute kernel filled its 32 KiB HTILE allocation
-  with `0xfffffff0` before every scene pass. Timeline-v5 depth backing hashes/writer provenance found the exact
-  writer, and guest GPU writes now invalidate overlapping persistent DS cache entries (#611). A routed live A/B
-  restores the layers rejected without that boundary.
-  The four remaining fragment failures were uniform VCCZ-exit light loops; narrowly proved vertex/fragment
-  structurization now restores them while varying and compute-wave forms still reject (#615). Capture v7 now
-  records bounded raw stages, exact rejection opcode/PC, decoded state, and resource/descriptor summaries for
-  every observed realization failure, so the next unsupported shader can be reduced offline (#618).
-- **Immediate milestone:** use the exact capture-v8 final checkpoint to bisect remaining Dead Cells composition
-  contracts without replaying 883 submits. #569 now preserves complete persistent DS identity, independent valid
-  planes, effective lifetime settings, and the source output oracle; source and standalone BMPs are byte-identical.
-  Keep extending this workflow across Unity and Unreal targets rather than returning to long unstructured live
-  traces. Timeline v6 supplies offline target-span discovery and a two-route semantic selector (#594), and the
-  splash guard uses a measured run-level content threshold (#596/#573).
+- **Dead Cells cross-title milestone:** deterministic routing now reaches the controllable Prisoners' Quarters
+  scene with full-color geometry, lighting, player, effects, and HUD. Retained PM4 graphics/compute order (#584),
+  guest-write depth-cache invalidation (#611), and narrowly proved uniform VCCZ lighting loops (#615) restore the
+  producer and depth layers. #626 fixes the last grayscale composition error: multi-target world shaders export
+  MRT3..MRT0, so the single-attachment recompiler must select MRT0 rather than the first emitted G-buffer plane.
+  It also realizes the eighth scene dispatch by resolving its directly placed destination V#. #566 is closed.
+- **Immediate milestone:** extend the capture-first workflow to later Dead Cells rooms and additional 3D titles.
+  Capture v8 preserves complete persistent color/depth state and embeds a source-output oracle (#569), while
+  Timeline v6 supplies offline target-span discovery and a semantic scene selector (#594). Keep reducing new
+  failures through standalone checkpoints and synthetic contracts rather than long unstructured live traces.
 
 ## Historical status (2026-07-05) - retained for the milestone log
 


### PR DESCRIPTION
## Summary

- update README, CLAUDE.md, and the roadmap to record the full-color Dead Cells gameplay result from #626
- turn the stale pre-fix handoff into a current regression workflow
- preserve the exact v8 capture/replay recipe while replacing completed composition-localization steps with the actual remaining coverage work

## Root cause

PR #626 added its handoff document before its later commits fixed the grayscale composition and closed #566. The merged current-status docs therefore still described the fixed output and investigation as active work.

## Validation

- `git diff --check`
- fresh WSL Release build against `PPSA24651-app0`
- `ctest --test-dir prosper/build-review-linux --output-on-failure`: 91/91 passed

Fixes #634