### PR TITLE
fix(loader): preload optional Unity FMOD plugins

### DIFF
--- a/prosper/README.md
+++ b/prosper/README.md
@@ -54,6 +54,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   faithful offline isolation (#568/#594/#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
+- 🚧 **Blasphemous 2 reaches its first rendered studio logo:** prelinking the title's optional FMOD
+  core/studio native plugins lets IL2CPP P/Invoke complete `FMODAudioBanksManager` initialization instead of
+  abandoning the managed startup coroutine. The next reproducible boundary is a guest AGC null dereference
+  after the logo; its exact trace and follow-up work are tracked in #638.
 - 🚧 **Active frontiers:** bundle v2 makes long Dead Cells history practical with exact shared-resource
   chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -34,6 +34,12 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         // in the list => its init runs first (it's PSNCore's dependency). Absent-file titles skip these.
         { d + "/Media/Plugins/PSNCore.prx", BOOT_PSNCORE },
         { d + "/Media/Plugins/PSNCommon.prx", BOOT_PSNCOMMON },
+        // FMOD's C# integration resolves these through P/Invoke only when its RuntimeManager is first
+        // constructed. Until prosper has true runtime PRX loading (#639), link the optional pair up
+        // front so LoadStartModule returns a real module handle. Studio precedes core in this list
+        // because dependent-module init functions run in reverse order (core must initialize first).
+        { d + "/Media/Plugins/libfmodstudio.prx", BOOT_FMODSTUDIO },
+        { d + "/Media/Plugins/libfmod.prx", BOOT_FMOD },
         { d + "/sce_module/libc.prx", BOOT_LIBC },
     };
     if (getenv("PROSPER_NO_PSN"))

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -17,10 +17,12 @@ inline constexpr uint64_t BOOT_EBOOT    = 0x400000000ull;
 inline constexpr uint64_t BOOT_IL2CPP   = 0x440000000ull;
 inline constexpr uint64_t BOOT_PS5UTIL  = 0x4c0000000ull;
 inline constexpr uint64_t BOOT_PSNCORE  = 0x480000000ull;   // PPSA02664's Unity PSN native plugin
-inline constexpr uint64_t BOOT_PSNCOMMON= 0x4a0000000ull;   //   (PSNCore.prx + PSNCommon.prx)
+inline constexpr uint64_t BOOT_PSNCOMMON = 0x4a0000000ull;  //   (PSNCore.prx + PSNCommon.prx)
 inline constexpr uint64_t BOOT_PSN      = 0x4e0000000ull;
 inline constexpr uint64_t BOOT_SAVEDATA = 0x4f0000000ull;
 inline constexpr uint64_t BOOT_LIBC     = 0x500000000ull;
+inline constexpr uint64_t BOOT_FMODSTUDIO = 0x520000000ull; // optional Unity FMOD native plugins
+inline constexpr uint64_t BOOT_FMOD       = 0x540000000ull;
 inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 
 // Boot the title rooted at `dump_root` (the app0 directory): link the fixed module set (dropping any


### PR DESCRIPTION
## What changed
- preload optional `libfmodstudio.prx` and `libfmod.prx` modules when a title ships them
- preserve absent-file behavior for every other title
- record Blasphemous 2's new rendered-logo frontier in the README

## Root cause
Blasphemous 2 constructs `FMODUnity.RuntimeManager` late in its managed startup coroutine. IL2CPP then P/Invokes `libfmod.prx`, but prosper's current `sceKernelLoadStartModule` only recognizes the boot-time linked module set. The missing-module exception abandoned `Core.InitializeCoroutine`, leaving the title on its black loading scene indefinitely.

The general runtime PRX loader remains tracked in #639. This is the narrow, correct prelink needed for the shipped Unity plugin pair today.

## Validation
- full Linux build
- 91/91 ctest passed
- `messenger-scene` real-game snapshot guard passed: richest frame 24,318 colors (threshold 5,000)
- clean Blasphemous 2 run reaches `Core.Ready`, initializes native FMOD/audio threads, and renders The Game Kitchen logo at 1920x1080

Refs #638
Refs #639