### PR TITLE
fix(http): implement local URI parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,11 @@ Two later fixes complete the hardware-oracle composition and restore boot progre
 cannot poison the intro's reverse-Z depth plane. A clean scripted route produced 180 native 1920×1080 frames,
 and the user confirmed the first-level graphics match the hardware reference. #530 and #540 are closed.
 
+*Blasphemous 2* now passes FMOD initialization (#638/#640), renders its logos/title/EULA after the corrected
+AGC marker implementation (#641), and passes the post-EULA telemetry parser after `sceHttpUriParse` gained its
+two-pass caller-pool contract (#642). The route loads gameplay scenes and assets; the next boundary is the
+normal-return guest pthread TLS cleanup bug tracked by #644. Use `scripts/blasphemous2/README.md` for the route.
+
 Cross-title breadth has advanced: *Dead Cells* now starts reliably after the AGC resource-name fix (#544), its
 exercised NGS2 lifecycle returns initialized sizes/handles/state and silent output (#554), and a late render
 window reaches the Evil Empire splash. #545 was software-render throughput, not a guest deadlock: synchronous

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -165,6 +165,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_service_getters PRIVATE prosper_core)
   add_test(NAME service_getters COMMAND test_service_getters)
 
+  # libSceHttp local URI parser (#642): two-pass caller pool sizing, public URI layout, and
+  # deterministic error paths. Pure and offline; it never contacts a network.
+  add_executable(test_http tests/test_http.cpp)
+  target_link_libraries(test_http PRIVATE prosper_core)
+  add_test(NAME http_hle COMMAND test_http)
+
   # PlatformUi hook (#347): the app frontend can service the guest's ImeDialog with real UI; with no
   # backend registered the headless auto-complete default is unchanged. Pure, no game dump.
   add_executable(test_platform_ui tests/test_platform_ui.cpp)

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -54,11 +54,14 @@ possible without console keys. Dumps are user-supplied and gitignored.
   faithful offline isolation (#568/#594/#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
-- 🚧 **Blasphemous 2 reaches its title and EULA:** prelinking the title's optional FMOD core/studio
+- 🚧 **Blasphemous 2 passes its EULA and loads gameplay content:** prelinking the title's optional FMOD core/studio
   plugins lets IL2CPP P/Invoke complete `FMODAudioBanksManager` initialization (#638/#640). The later AGC
   fault was prosper corrupting live DCB state: `+kSrjIVxKFE` is `sceAgcDcbPushMarker`, not the context
-  constructor modeled by the old workaround (#641). The current routed boundary is the offline HTTP path
-  after accepting the EULA, where success-returning Http2 stubs leave invalid handles/outputs (#642).
+  constructor modeled by the old workaround (#641). A dedicated two-pass `sceHttpUriParse` implementation
+  replaces the success-with-stale-output stub that crashed the title's telemetry worker (#642). The routed
+  run continues through its Http2 calls and loads gameplay scenes, UI, enemies, bosses, audio banks, and
+  cutscene assets. Its current boundary is a normal-return guest pthread restoring guest `%fs` before glibc
+  performs host TLS cleanup (#644).
 - 🚧 **Active frontiers:** bundle v2 makes long Dead Cells history practical with exact shared-resource
   chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -159,6 +159,9 @@ Turn the file into a resident, relocated guest image in host memory.
       `+kSrjIVxKFE` as `sceAgcDcbPushMarker`. The temporary context-init workaround was also wrong
       and was removed by #641 after it was shown to clear live DCB state. See `docs/AGC_TRACE.md` and
       the correction in `docs/GRAPHICS.md` rather than restarting the locale/context theory.
+- [x] `sceHttpUriParse` implements its two-pass caller-pool contract and initializes the public URI
+      element layout (#642). This removes Blasphemous 2's post-EULA stale-pointer crash and advances
+      its route to the guest pthread exit boundary tracked by #644.
 - [x] Dependent-module `init_array` (C++ global ctors) now run before entry — the key
       unlock that let IL2CPP's runtime initialize.
 - [x] locale/ctype tables; `sync_on_address` futex (Linux `futex(2)`); C++ new/delete; stdio.

--- a/prosper/scripts/blasphemous2/README.md
+++ b/prosper/scripts/blasphemous2/README.md
@@ -6,9 +6,10 @@ from `prosper/` so relative script paths resolve.
 ## Current Route
 
 `reach-first-gameplay.pad` is an exploratory Cross-tap route anchored to the
-first pad poll. On #641 stacked over #640 it passes the studio logos, title, and
-EULA, then reaches the offline HTTP boundary tracked by #642. It does not yet
-reach gameplay; tighten the taps only after that service boundary is fixed.
+first pad poll. It passes the studio logos, title, and EULA. With the local URI
+parser from #642, it also passes the title's telemetry calls and loads gameplay
+scenes and assets. The current run stops at the normal-return pthread/TLS cleanup
+boundary tracked by #644, before a gameplay screenshot is confirmed.
 
 Capture one full-resolution PNG per second with:
 
@@ -22,4 +23,5 @@ PROSPER_PAD_SCRIPT=@scripts/blasphemous2/reach-first-gameplay.pad \
 
 The title's optional `libfmodstudio.prx` and `libfmod.prx` must be prelinked as
 described by #638/#640. A run that stops before the first studio logo has not
-reached the #641/#642 frontier.
+reached the #641 marker fix; a run that faults at guest `eboot+0x11f79d0` has not
+picked up the #642 URI parser.

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -81,6 +81,8 @@ void savedata0_umount();
 std::vector<std::string> savedata0_list_dirs();   // existing save dirs under the host save root (#299)
 // PS5 system services (user/NP/mouse/appcontent/dialog); called by register_builtin_hle().
 void register_service_hle();
+// libSceHttp local URI helpers; called by register_builtin_hle().
+void register_http_hle();
 // libScePad game-controller input (real host controller via input/pad.cpp); called by register_builtin_hle().
 void register_pad_hle();
 // Headless graphics bring-up (libSceAgc/libSceVideoOut placeholders); see hle_graphics.cpp.

--- a/prosper/src/hle/hle_http.cpp
+++ b/prosper/src/hle/hle_http.cpp
@@ -1,0 +1,178 @@
+// libSceHttp URI helpers. Network requests remain offline, but parsing is local and deterministic:
+// returning success without filling this structure makes callers dereference stale pointer fields.
+#include "hle_http.hpp"
+#include "dispatch.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+namespace prosper {
+
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                                        uint64_t a3, uint64_t a4, uint64_t a5)
+
+namespace {
+
+using http::SceHttpUriElement;
+constexpr size_t kMaxUriBytes = 64 * 1024;
+
+struct ParsedUri {
+    bool opaque = true;
+    std::string scheme, username, password, hostname, path, query, fragment;
+    uint16_t port = 0;
+};
+
+bool ascii_ieq(std::string_view a, std::string_view b) {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        auto ca = static_cast<unsigned char>(a[i]);
+        auto cb = static_cast<unsigned char>(b[i]);
+        if (std::tolower(ca) != std::tolower(cb)) return false;
+    }
+    return true;
+}
+
+bool valid_scheme(std::string_view value) {
+    if (value.empty() || !std::isalpha(static_cast<unsigned char>(value[0]))) return false;
+    return std::all_of(value.begin() + 1, value.end(), [](char c) {
+        auto u = static_cast<unsigned char>(c);
+        return std::isalnum(u) || c == '+' || c == '-' || c == '.';
+    });
+}
+
+bool parse_port(std::string_view text, uint16_t& out) {
+    if (text.empty() || text.size() > 5) return false;
+    uint32_t value = 0;
+    for (char c : text) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) return false;
+        value = value * 10u + static_cast<uint32_t>(c - '0');
+    }
+    if (value > 65535u) return false;
+    out = static_cast<uint16_t>(value);
+    return true;
+}
+
+bool parse_uri(std::string_view input, ParsedUri& out) {
+    size_t pos = 0;
+    const size_t colon = input.find(':');
+    const size_t first_delim = input.find_first_of("/?#");
+    if (colon != std::string_view::npos &&
+        (first_delim == std::string_view::npos || colon < first_delim)) {
+        if (!valid_scheme(input.substr(0, colon))) return false;
+        out.scheme.assign(input.substr(0, colon));
+        pos = colon + 1;
+    }
+
+    const bool has_authority = input.substr(pos, 2) == "//";
+    out.opaque = !has_authority;
+    if (has_authority) {
+        pos += 2;
+        size_t end = input.find_first_of("/?#", pos);
+        if (end == std::string_view::npos) end = input.size();
+        std::string_view authority = input.substr(pos, end - pos);
+        pos = end;
+
+        const size_t at = authority.rfind('@');
+        if (at != std::string_view::npos) {
+            std::string_view userinfo = authority.substr(0, at);
+            authority.remove_prefix(at + 1);
+            const size_t sep = userinfo.find(':');
+            out.username.assign(userinfo.substr(0, sep));
+            if (sep != std::string_view::npos) out.password.assign(userinfo.substr(sep + 1));
+        }
+
+        if (!authority.empty() && authority.front() == '[') {
+            const size_t close = authority.find(']');
+            if (close == std::string_view::npos) return false;
+            out.hostname.assign(authority.substr(1, close - 1));
+            if (close + 1 < authority.size()) {
+                if (authority[close + 1] != ':' ||
+                    !parse_port(authority.substr(close + 2), out.port)) return false;
+            }
+        } else {
+            const size_t port_sep = authority.rfind(':');
+            if (port_sep != std::string_view::npos) {
+                out.hostname.assign(authority.substr(0, port_sep));
+                if (!parse_port(authority.substr(port_sep + 1), out.port)) return false;
+            } else {
+                out.hostname.assign(authority);
+            }
+        }
+    }
+
+    size_t path_end = input.find_first_of("?#", pos);
+    if (path_end == std::string_view::npos) path_end = input.size();
+    out.path.assign(input.substr(pos, path_end - pos));
+    pos = path_end;
+
+    if (pos < input.size() && input[pos] == '?') {
+        size_t query_end = input.find('#', pos);
+        if (query_end == std::string_view::npos) query_end = input.size();
+        out.query.assign(input.substr(pos, query_end - pos));
+        pos = query_end;
+    }
+    if (pos < input.size() && input[pos] == '#') out.fragment.assign(input.substr(pos));
+
+    if (out.port == 0) {
+        if (ascii_ieq(out.scheme, "http")) out.port = 80;
+        else if (ascii_ieq(out.scheme, "https")) out.port = 443;
+    }
+    return true;
+}
+
+size_t pool_requirement(const ParsedUri& uri) {
+    return uri.scheme.size() + uri.username.size() + uri.password.size() + uri.hostname.size() +
+           uri.path.size() + uri.query.size() + uri.fragment.size() + 7;
+}
+
+char* copy_component(char*& cursor, const std::string& value) {
+    char* result = cursor;
+    std::memcpy(cursor, value.c_str(), value.size() + 1);
+    cursor += value.size() + 1;
+    return result;
+}
+
+HLE(h_http_uri_parse) { // (out, src_uri, pool, required_size, pool_size)
+    (void)a5;
+    const char* src = reinterpret_cast<const char*>(a1);
+    if (!src) return http::kErrorInvalidUrl;
+    const size_t length = strnlen(src, kMaxUriBytes);
+    if (length == kMaxUriBytes) return http::kErrorInvalidUrl;
+
+    ParsedUri parsed;
+    if (!parse_uri(std::string_view(src, length), parsed)) return http::kErrorInvalidUrl;
+    const size_t required = pool_requirement(parsed);
+    auto* required_out = reinterpret_cast<uint64_t*>(a3);
+    if (required_out) *required_out = required;
+
+    auto* out = reinterpret_cast<SceHttpUriElement*>(a0);
+    auto* pool = reinterpret_cast<char*>(a2);
+    const bool write_output = out && pool;
+    if (!write_output) return required_out ? 0 : http::kErrorInvalidValue;
+    if (a4 < required) return http::kErrorOutOfMemory;
+
+    std::memset(out, 0, sizeof(*out));
+    char* cursor = pool;
+    out->opaque = parsed.opaque;
+    out->scheme = copy_component(cursor, parsed.scheme);
+    out->username = copy_component(cursor, parsed.username);
+    out->password = copy_component(cursor, parsed.password);
+    out->hostname = copy_component(cursor, parsed.hostname);
+    out->path = copy_component(cursor, parsed.path);
+    out->query = copy_component(cursor, parsed.query);
+    out->fragment = copy_component(cursor, parsed.fragment);
+    out->port = parsed.port;
+    return 0;
+}
+
+} // namespace
+
+void register_http_hle() {
+    Hle::register_fn("IWalAn-guFs", (HleFn)h_http_uri_parse, "sceHttpUriParse");
+}
+
+} // namespace prosper

--- a/prosper/src/hle/hle_http.hpp
+++ b/prosper/src/hle/hle_http.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::http {
+
+// PS4 and PS5 use the same public URI element ABI. Strings point into the caller-provided pool.
+struct SceHttpUriElement {
+    bool opaque;
+    uint8_t align[7];
+    char* scheme;
+    char* username;
+    char* password;
+    char* hostname;
+    char* path;
+    char* query;
+    char* fragment;
+    uint16_t port;
+    uint8_t reserved[10];
+};
+
+static_assert(sizeof(SceHttpUriElement) == 80);
+static_assert(offsetof(SceHttpUriElement, scheme) == 8);
+static_assert(offsetof(SceHttpUriElement, hostname) == 32);
+
+constexpr uint32_t kErrorOutOfMemory = 0x80431022u;
+constexpr uint32_t kErrorInvalidValue = 0x804311feu;
+constexpr uint32_t kErrorInvalidUrl = 0x80433060u;
+
+} // namespace prosper::http

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -505,6 +505,7 @@ void register_builtin_hle() {
     #undef R
     register_file_hle();     // file I/O (stdio + POSIX, /app0 translation)
     register_service_hle();  // PS5 system services (user/NP/mouse/appcontent/dialog)
+    register_http_hle();     // libSceHttp local URI parsing
     register_pad_hle();      // libScePad: real game-controller input (input/pad.cpp)
     register_audio_hle();    // libSceAudioOut backed by a headless/pluggable AudioSink
     register_graphics_hle(); // headless libSceAgc/libSceVideoOut placeholders (bring-up)

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -35,6 +35,8 @@ int main() {
         // services / dialogs
         "sceUserServiceGetInitialUser", "scePadOpen", "sceMsgDialogUpdateStatus",
         "sceSystemServiceHideSplashScreen",
+        // HTTP helpers
+        "sceHttpUriParse",
         // graphics (headless bring-up)
         "sceVideoOutOpen", "sceVideoOutSubmitFlip", "sceVideoOutGetFlipStatus",
         // audio (headless / pluggable backend)

--- a/prosper/tests/test_http.cpp
+++ b/prosper/tests/test_http.cpp
@@ -1,0 +1,66 @@
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/hle_http.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_http ==\n");
+    register_builtin_hle();
+    HleFn parse = Hle::lookup("IWalAn-guFs");
+    CHECK(parse && std::strcmp(Hle::name_of("IWalAn-guFs"), "sceHttpUriParse") == 0,
+          "sceHttpUriParse registered by its PS5 NID");
+    if (!parse) return 1;
+
+    const char* url = "https://events.backtrace.io/api/unique-events/submit?token=abc&universe=nimble";
+    uint64_t required = 0;
+    CHECK(parse(0, (uint64_t)url, 0, (uint64_t)&required, 0, 0) == 0 && required > 32,
+          "size-query mode reports a nonzero caller-pool requirement");
+
+    std::array<char, 512> pool{};
+    http::SceHttpUriElement uri{};
+    CHECK(parse((uint64_t)&uri, (uint64_t)url, (uint64_t)pool.data(), 0, required, 0) == 0,
+          "fill mode succeeds without requiring a second size output");
+    CHECK(!uri.opaque && std::strcmp(uri.scheme, "https") == 0 && uri.port == 443,
+          "HTTPS scheme and default port parsed");
+    CHECK(std::strcmp(uri.hostname, "events.backtrace.io") == 0,
+          "Blasphemous 2 telemetry hostname parsed");
+    CHECK(std::strcmp(uri.path, "/api/unique-events/submit") == 0 &&
+          std::strcmp(uri.query, "?token=abc&universe=nimble") == 0,
+          "path and leading-question-mark query parsed");
+    CHECK(uri.scheme >= pool.data() && uri.fragment < pool.data() + required,
+          "all URI strings live in the caller-provided pool");
+
+    const char* complex = "http://alice:secret@[2001:db8::1]:8080/x#frag";
+    required = 0;
+    parse(0, (uint64_t)complex, 0, (uint64_t)&required, 0, 0);
+    std::memset(&uri, 0, sizeof(uri));
+    CHECK(parse((uint64_t)&uri, (uint64_t)complex, (uint64_t)pool.data(),
+                (uint64_t)&required, pool.size(), 0) == 0,
+          "userinfo, IPv6, explicit-port URI parsed");
+    CHECK(std::strcmp(uri.username, "alice") == 0 && std::strcmp(uri.password, "secret") == 0 &&
+          std::strcmp(uri.hostname, "2001:db8::1") == 0 && uri.port == 8080 &&
+          std::strcmp(uri.fragment, "#frag") == 0,
+          "userinfo, bracketless IPv6 output, port, and fragment match ABI");
+
+    uint64_t need = 0;
+    parse(0, (uint64_t)url, 0, (uint64_t)&need, 0, 0);
+    CHECK(parse((uint64_t)&uri, (uint64_t)url, (uint64_t)pool.data(),
+                (uint64_t)&required, need - 1, 0) == http::kErrorOutOfMemory,
+          "undersized caller pool returns SCE_HTTP_ERROR_OUT_OF_MEMORY");
+    CHECK(parse(0, 0, 0, (uint64_t)&required, 0, 0) == http::kErrorInvalidUrl,
+          "null source returns SCE_HTTP_ERROR_INVALID_URL");
+    CHECK(parse(0, (uint64_t)url, 0, 0, 0, 0) == http::kErrorInvalidValue,
+          "size query without required-size output returns INVALID_VALUE");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## What changed

- add a dedicated `sceHttpUriParse` HLE registered by its authoritative PS5 NID
- implement the public 80-byte URI element ABI and two-pass caller-pool sizing/fill contract
- parse scheme, userinfo, host, bracketed IPv6, port, path, query, and fragment with bounded input
- return deterministic invalid-value/URL and out-of-memory errors instead of success with stale outputs
- add syscall-level tests and builtin-registration coverage
- update project and Blasphemous 2 route docs to the next observed boundary

## Root cause

Blasphemous 2 first calls `sceHttpUriParse` with null output/pool to obtain the required pool size, allocates that pool, then calls it again to fill `SceHttpUriElement`. The generic dispatcher returned success for both calls without writing either output. The game later read stale `scheme=0x63` and faulted at `eboot+0x11f79d0` while comparing it with `file`.

With this implementation the old guest fault is gone. The routed title passes the exercised Http2 calls, loads gameplay scenes/assets, and reaches a separate normal-return pthread/TLS cleanup fault tracked by #644.

## Validation

- `ctest --test-dir build-linux --output-on-failure`: 92/92 passed with the primary Messenger dump configured
- routed Blasphemous 2 `boot_trace`: old URI fault removed; about 50 seconds of progression and gameplay-asset loading before #644

This PR is stacked on #643, which is stacked on #640.

Fixes #642