### PR TITLE
fix(kernel): leave host FS active on thread return

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,10 @@ and the user confirmed the first-level graphics match the hardware reference. #5
 
 *Blasphemous 2* now passes FMOD initialization (#638/#640), renders its logos/title/EULA after the corrected
 AGC marker implementation (#641), and passes the post-EULA telemetry parser after `sceHttpUriParse` gained its
-two-pass caller-pool contract (#642). The route loads gameplay scenes and assets; the next boundary is the
-normal-return guest pthread TLS cleanup bug tracked by #644. Use `scripts/blasphemous2/README.md` for the route.
+two-pass caller-pool contract (#642). Normal-return guest pthreads also leave host `%fs` active before glibc
+thread cleanup (#644), so the route loads gameplay scenes/assets without the old host crash and renders the
+opening cinematic. Poll-safe native-resolution input delivery remains tracked by #646; do not claim a verified
+gameplay screenshot until that route is stable. Use `scripts/blasphemous2/README.md` for the current recipe.
 
 Cross-title breadth has advanced: *Dead Cells* now starts reliably after the AGC resource-name fix (#544), its
 exercised NGS2 lifecycle returns initialized sizes/handles/state and silent output (#554), and a late render

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -461,8 +461,8 @@ if(TARGET prosper_core)
     target_link_libraries(test_rwlock_once PRIVATE prosper_core)
     add_test(NAME rwlock_once_semantics COMMAND test_rwlock_once)
 
-    # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68):
-    # a recycled pthread id must get fresh zero/tdata-initialized TLS, never a dead thread's bytes.
+    # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
+    # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).
     add_executable(test_tls_dtv_purge tests/test_tls_dtv_purge.cpp)
     target_link_libraries(test_tls_dtv_purge PRIVATE prosper_core)
     add_test(NAME tls_dtv_purge_on_thread_exit COMMAND test_tls_dtv_purge)

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -60,8 +60,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   constructor modeled by the old workaround (#641). A dedicated two-pass `sceHttpUriParse` implementation
   replaces the success-with-stale-output stub that crashed the title's telemetry worker (#642). The routed
   run continues through its Http2 calls and loads gameplay scenes, UI, enemies, bosses, audio banks, and
-  cutscene assets. Its current boundary is a normal-return guest pthread restoring guest `%fs` before glibc
-  performs host TLS cleanup (#644).
+  cutscene assets. Normal-return guest pthreads now leave host `%fs` active before glibc performs its own
+  thread cleanup (#644), removing the next host crash. Native-resolution captures reach the opening
+  cinematic; reliable boot-to-gameplay input delivery under slow synchronous rendering is tracked by #646.
 - 🚧 **Active frontiers:** bundle v2 makes long Dead Cells history practical with exact shared-resource
   chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -162,6 +162,10 @@ Turn the file into a resident, relocated guest image in host memory.
 - [x] `sceHttpUriParse` implements its two-pass caller-pool contract and initializes the public URI
       element layout (#642). This removes Blasphemous 2's post-EULA stale-pointer crash and advances
       its route to the guest pthread exit boundary tracked by #644.
+- [x] A normally returning guest pthread leaves host `%fs` active before returning into glibc's
+      `start_thread` cleanup (#644). The regression enables real guest FS, returns a sentinel from a
+      guest worker, and joins it; restoring guest FS at that boundary previously crashed in
+      `__res_thread_freeres` before the join completed.
 - [x] Dependent-module `init_array` (C++ global ctors) now run before entry — the key
       unlock that let IL2CPP's runtime initialize.
 - [x] locale/ctype tables; `sync_on_address` futex (Linux `futex(2)`); C++ new/delete; stdio.

--- a/prosper/scripts/blasphemous2/README.md
+++ b/prosper/scripts/blasphemous2/README.md
@@ -8,8 +8,10 @@ from `prosper/` so relative script paths resolve.
 `reach-first-gameplay.pad` is an exploratory Cross-tap route anchored to the
 first pad poll. It passes the studio logos, title, and EULA. With the local URI
 parser from #642, it also passes the title's telemetry calls and loads gameplay
-scenes and assets. The current run stops at the normal-return pthread/TLS cleanup
-boundary tracked by #644, before a gameplay screenshot is confirmed.
+scenes and assets. The normal-return pthread/TLS cleanup crash is fixed by #644,
+and native-resolution captures render the opening cinematic. A gameplay screenshot
+is not yet confirmed because this exploratory route's 250 ms input windows can be
+missed by the slower synchronous renderer; #646 tracks the poll-safe route/tooling fix.
 
 Capture one full-resolution PNG per second with:
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -476,13 +476,14 @@ void* thread_trampoline(void* p) {
     // Normal-return exit path: purge this thread's __tls_get_addr DTV entries and free the blocks
     // (#68 — glibc recycles pthread ids, so a stale entry would hand the NEXT thread on this id the
     // dead thread's dirty TLS). The guest entry can return with %fs still = the guest TP
-    // (PROSPER_GUEST_FS), and the purge is host libc (mutex/free), so run it under the host %fs
-    // (scoped swap; both calls are no-ops when the gate is off / not on a guest TCB). Threads that
-    // exit via scePthreadExit never get here — k_pthread_exit purges before host pthread_exit.
-    uint64_t sfs = guest_fs_to_host_scoped();
+    // (PROSPER_GUEST_FS), and the purge is host libc (mutex/free), so switch permanently to host
+    // %fs before cleanup. This is a terminal guest boundary: restoring guest %fs before returning
+    // makes glibc's start_thread cleanup read its TLS through the guest TCB (#644). Threads that
+    // exit via scePthreadExit never get here — its import gate already restored host %fs and
+    // k_pthread_exit purges before host pthread_exit.
+    (void)guest_fs_to_host_scoped();
     tls_dtv_purge_current_thread();
     unregister_thread_stack((uint64_t)pthread_self());   // ids recycle; stale bounds = wrong bounds (#138)
-    guest_fs_restore_scoped(sfs);
     return rv;
 }
 }

--- a/prosper/tests/test_tls_dtv_purge.cpp
+++ b/prosper/tests/test_tls_dtv_purge.cpp
@@ -6,10 +6,12 @@
 // Covers: (1) fresh zero+tdata init of a new block, (2) purge-then-refetch returns fresh state on
 // the same thread (the recycled-id scenario, simulated deterministically), (3) the trampoline
 // normal-return exit path purges, (4) the scePthreadExit path (host pthread_exit — never returns
-// through the trampoline) purges, (5) main/host threads with no DTV entries purge as a no-op.
+// through the trampoline) purges, (5) main/host threads with no DTV entries purge as a no-op,
+// (6) a normal-return thread leaves guest %fs before returning to the host pthread runtime (#644).
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <cstdio>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 
@@ -52,6 +54,9 @@ static void* worker_exit(void* p) {     // exit path 2: scePthreadExit (host pth
     tls_touch_and_dirty((WorkerResult*)p);
     EXITF(0, 0, 0, 0, 0, 0);
     return (void*)0xdead;               // not reached
+}
+static void* worker_guest_fs_return(void*) {
+    return (void*)0x644;
 }
 
 int main() {
@@ -105,6 +110,28 @@ int main() {
         snprintf(msg, sizeof msg, "iter %d (%s): DTV entry purged on thread exit", i, via_exit ? "scePthreadExit" : "return");
         CHECK(tls_dtv_thread_count() == 0, msg);
     }
+
+#ifdef __linux__
+    // (6) The guest entry returns with guest %fs active. The trampoline must switch permanently
+    // back to host %fs before it returns into glibc's start_thread cleanup. Restoring guest %fs at
+    // that terminal boundary makes __res_thread_freeres read glibc TLS through the guest TCB and
+    // fault at null+0x10 (#644). Index zero is reserved; no static TLS module is needed here.
+    setenv("PROSPER_GUEST_FS", "1", 1);
+    TlsModuleDesc reserved{};
+    guest_tls_set_templates(&reserved, 1);
+    CHECK(guest_tls_enabled(), "guest FS enabled for normal-return boundary test");
+
+    uint64_t tid = 0;
+    void* result = nullptr;
+    uint64_t rc = CREATE((uint64_t)(uintptr_t)&tid, 0,
+                         (uint64_t)(uintptr_t)worker_guest_fs_return, 0, 0, 0);
+    CHECK(rc == 0, "guest-FS worker created");
+    if (rc == 0) {
+        JOIN(tid, (uint64_t)(uintptr_t)&result, 0, 0, 0, 0);
+        CHECK(result == (void*)0x644,
+              "normal-return worker reaches host pthread cleanup and preserves its result");
+    }
+#endif
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## What changed

- treat normal guest pthread return as a terminal guest-TLS boundary
- switch to host `%fs` for prosper cleanup and leave it active while returning into the host pthread runtime
- extend the existing TLS/DTV exit test to enable real `PROSPER_GUEST_FS`, return a sentinel from a guest worker, join it, and verify the result
- update current Blasphemous 2 status and route documentation

## Root cause

The Linux guest-thread trampoline correctly switched from the guest TCB back to host `%fs` before running prosper's mutex/free/stack cleanup. It then restored guest `%fs` immediately before returning. glibc's `start_thread` subsequently ran its own TLS cleanup through the guest TCB and crashed in `__res_thread_freeres` at null+0x10.

The `scePthreadExit` path was already safe because the import gate restores host `%fs` and `pthread_exit` never returns through the guest trampoline.

## Validation

- regression before fix: reaches `guest-FS worker created`, then dumps core before `pthread_join`
- regression after fix: joins successfully and preserves return value `0x644`
- `ctest --test-dir build-linux --output-on-failure`: 92/92 passed
- routed Blasphemous 2 `boot_trace`: survives 120 seconds without the old ~50-second glibc fault and loads gameplay scenes/in-game assets
- native 1920x1080 screenshot runs render the opening cinematic; poll-safe route delivery is tracked separately by #646

This PR is stacked on #645 -> #643 -> #640.

Fixes #644