### PR TITLE
port(win): build + initialize the live Vulkan renderer on Windows

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -409,6 +409,24 @@ if(TARGET prosper_core)
   if(WIN32)
     add_executable(boot_trace tools/boot_trace/boot_trace.cpp)
     target_link_libraries(boot_trace PRIVATE prosper_core)
+
+    # Live Vulkan renderer on Windows (PROSPER_RENDER=1): with the Vulkan SDK present, wire the same
+    # shared DrawItem->Vulkan compositor boot_trace uses on Linux so the guest's SubmitDcb draws
+    # execute + present + dump frames. Mirrors the UNIX block below (boot_trace + prosper_live_renderer
+    # only; the extra replay/screenshot tools stay Linux-first for now). See docs/PORTING.md "Windows".
+    find_package(Vulkan QUIET)
+    if(Vulkan_FOUND)
+      target_link_libraries(boot_trace PRIVATE Vulkan::Vulkan)
+      target_compile_definitions(boot_trace PRIVATE PROSPER_HAVE_VULKAN=1)
+      add_library(prosper_live_renderer STATIC frontends/shared/live_renderer.cpp
+                                               frontends/shared/live_compute.cpp)
+      target_include_directories(prosper_live_renderer PRIVATE src tests tools/boot_trace)
+      target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
+      target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
+      target_link_libraries(boot_trace PRIVATE prosper_live_renderer)
+    else()
+      message(STATUS "Vulkan not found — Windows boot_trace built without the live renderer")
+    endif()
   endif()
 
   # M2+: real memory mapping, trap, boot, and the boot-trace debug tool (Linux + macOS/Rosetta).

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -34,9 +34,11 @@ extern "C" int prosper_reserved_range_state(uint64_t);   // memory-HLE mapping c
 #include <cstring>
 #include <algorithm>
 #include <vector>
+#ifndef _WIN32
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#endif
 #endif
 
 // PROSPER_CRASHPEEK (below) needs these in every config — the gpu/*.hpp includes above are gated on


### PR DESCRIPTION
The Vulkan renderer + its find_package(Vulkan) lived only in the CMake `if(UNIX)` block, so the Windows build never got it. This mirrors the essential wiring into `if(WIN32)`: detect Vulkan (SDK found via VULKAN_SDK), link boot_trace against Vulkan::Vulkan, define PROSPER_HAVE_VULKAN, and build+link the shared `prosper_live_renderer`. Also guards the POSIX headers in boot_trace.cpp's PROSPER_HAVE_VULKAN block behind `#ifndef _WIN32`.

Result: the whole GPU/Vulkan translation layer + live renderer compile and link under MinGW (boot_trace.exe imports vulkan-1.dll), and at runtime the live Vulkan compute + submit renderers initialize cleanly. The guest then runs into the frame loop and idle-waits; getting it to submit draws is the next step (same pre-render stall class as the Linux headless boot).

Verified Linux boot_trace still builds — all changes are WIN32-gated or `#ifndef _WIN32`. Refs #624.