### PR TITLE
gpu: execute compute dispatches with image bindings (#590)

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -18,6 +18,8 @@
 namespace prosper::frontend {
 namespace {
 
+constexpr VkDeviceSize kMaxComputeImageBytes = 256ull << 20;
+
 struct VulkanComputeContext {
     VkInstance instance = VK_NULL_HANDLE;
     VkPhysicalDevice physical = VK_NULL_HANDLE;
@@ -160,6 +162,7 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: { float v; std::memcpy(&v, &in[c], 4);
+                               if (std::isnan(v)) v = 0.f;
                                v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
                                dst[c] = (uint8_t)std::lround(v * 255.0f); break; }
             default: std::memcpy(dst + c * 4, &in[c], 4); break;    // 32-bit raw
@@ -225,7 +228,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
     }
     if (descriptors.empty() && image_descriptors.empty()) return false;
-    if (!image_descriptors.empty() && !ctx.image_support) {
+    const bool has_storage_images = std::any_of(
+        image_descriptors.begin(), image_descriptors.end(), [](const auto& descriptor) {
+            return descriptor.kind == SpirvDescriptorKind::StorageImage;
+        });
+    if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
         if (!warned) { warned = true;
             std::fprintf(stderr, "[compute] device lacks shaderStorageImageRead/WriteWithoutFormat; "
@@ -340,7 +347,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u fmt=%u: %s -> "
                                      "dispatch skipped (#590)\n",
                              (unsigned long long)item.code_addr, (unsigned long long)key,
-                             r ? r->width : 0, r ? r->height : 0, r ? r->depth : 0,
+                             r ? r->width : 0, r ? r->height : 0, 1u,
                              r ? (unsigned)r->format : 0u, why);
             }
             images_ready = false;
@@ -355,11 +362,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // A surface whose CURRENT pixels live in the renderer's RTT cache must not be read from
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
             if (is_live_render_target(r->gpu_addr)) { skip_image(r, "renderer-owned RTT surface"); break; }
-            const uint32_t slices = r->depth ? r->depth : 1;
-            const bool dim_1d = r->img_dim == 0, dim_3d = r->img_dim == 2, dim_array = r->img_dim == 5;
-            if (!dim_1d && !dim_3d && !dim_array && r->img_dim != 1) { skip_image(r, "unsupported image dim"); break; }
+            const bool dim_1d = r->img_dim == 0;
+            if (!dim_1d && r->img_dim != 1) {
+                skip_image(r, "layered/3D image deferred to #657"); break;
+            }
+            if (dim_1d && r->height != 1) { skip_image(r, "1D image has non-unit height"); break; }
             const uint32_t texel_bytes = bi.storage ? 16u : 4u;   // uvec4 raw channels / RGBA8
-            const VkDeviceSize sbytes = (VkDeviceSize)r->width * r->height * slices * texel_bytes;
+            const VkDeviceSize sbytes = static_cast<VkDeviceSize>(r->width) * r->height * texel_bytes;
+            if (!sbytes || sbytes > kMaxComputeImageBytes) {
+                skip_image(r, "expanded image exceeds the 256 MiB backend bound"); break;
+            }
             staging_bytes[i] = sbytes;
 
             // Fill the upload staging bytes.
@@ -371,30 +383,39 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
                 const size_t guest_texel = (size_t)cb * nc;
-                const size_t texels = (size_t)r->width * r->height * slices;
+                const size_t texels = (size_t)r->width * r->height;
+                const uint64_t guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
+                if (!guest_bytes || guest_bytes > UINT32_MAX || guest_bytes > r->size) {
+                    skip_image(r, "storage backing size is invalid"); break;
+                }
                 const uint8_t* src = resource_bytes(r);
-                const bool readable = (r->host_data && r->host_data_size >= texels * guest_texel) ||
-                                      guest_readable(r->gpu_addr, (uint32_t)(texels * guest_texel));
-                // Unreadable source = a fresh store-only allocation: seed zeros (the kernel writes it).
-                if (readable)
-                    for (size_t t = 0; t < texels; t++)
-                        storage_unpack_texel(src + t * guest_texel, r->format, nc,
-                                             reinterpret_cast<uint32_t*>(upload.data()) + t * 4);
+                const bool readable = (r->host_data && r->host_data_size >= guest_bytes) ||
+                                      guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
+                if (!readable) { skip_image(r, "storage backing unreadable"); break; }
+                for (size_t t = 0; t < texels; t++)
+                    storage_unpack_texel(src + t * guest_texel, r->format, nc,
+                                         reinterpret_cast<uint32_t*>(upload.data()) + t * 4);
             } else {
                 if (r->img_dim != 1) { skip_image(r, "non-2D sampled texture"); break; }
                 const uint32_t bpb = bc_block_bytes(r->format);
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
+                const bool rgba8 = r->format == DataFormat::Unorm8 && nc == 4;
+                const bool r8 = r->format == DataFormat::Unorm8 && nc == 1;
+                const bool f16 = r->format == DataFormat::Float16 && nc >= 1 && nc <= 4;
                 size_t need;                                       // guest bytes the decode reads
                 if (bpb) {
                     const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
                     need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
                                         : (size_t)bw * bh * bpb;
-                } else if (cb * nc == 4 || cb * nc == 1 || (r->format == DataFormat::Float16 && nc == 4)) {
+                } else if (rgba8 || r8 || f16) {
                     const uint32_t bpt = cb * nc;
                     need = r->tile_mode ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt)
                                         : (size_t)r->width * r->height * bpt;
                 } else { skip_image(r, "sampled format not decodable yet"); break; }
+                if (!need || need > kMaxComputeImageBytes || need > UINT32_MAX) {
+                    skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
+                }
                 const uint8_t* src = resource_bytes(r);
                 const bool readable = (r->host_data && r->host_data_size >= need) ||
                                       guest_readable(r->gpu_addr, (uint32_t)need);
@@ -417,20 +438,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     else
                         std::memcpy(lin.data(), src, lin.size());
                     const size_t texels = (size_t)r->width * r->height;
-                    if (bpt == 4) {                                 // RGBA8-class: direct
+                    if (rgba8) {                                    // RGBA8: direct
                         std::memcpy(upload.data(), lin.data(), lin.size());
-                    } else if (bpt == 1) {                          // R8: broadcast coverage to RGBA
+                    } else if (r8) {                                // R8: broadcast coverage to RGBA
                         for (size_t t = 0; t < texels; t++) {
                             const uint8_t v = lin[t];
                             upload[t * 4 + 0] = v; upload[t * 4 + 1] = v;
                             upload[t * 4 + 2] = v; upload[t * 4 + 3] = v;
                         }
-                    } else {                                        // Float16 x4: half -> UNORM8 clamp
+                    } else {                                        // Float16: half -> UNORM8 + default fill
                         const uint16_t* hp = reinterpret_cast<const uint16_t*>(lin.data());
-                        for (size_t t = 0; t < texels * 4; t++) {
-                            float v = half_to_float(hp[t]);
-                            v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
-                            upload[t] = (uint8_t)std::lround(v * 255.0f);
+                        for (size_t t = 0; t < texels; t++) {
+                            for (uint32_t c = 0; c < 4; c++) {
+                                if (c >= nc) {
+                                    upload[t * 4 + c] = c == 3 ? 255 : 0;
+                                    continue;
+                                }
+                                float v = half_to_float(hp[t * nc + c]);
+                                if (std::isnan(v)) v = 0.f;
+                                v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
+                                upload[t * 4 + c] = (uint8_t)std::lround(v * 255.0f);
+                            }
                         }
                     }
                 }
@@ -458,11 +486,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-            ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
+            ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : VK_IMAGE_TYPE_2D;
             ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT : VK_FORMAT_R8G8B8A8_UNORM;
-            ici.extent = {r->width, r->height, dim_3d ? slices : 1u};
+            ici.extent = {r->width, r->height, 1};
             ici.mipLevels = 1;
-            ici.arrayLayers = dim_array ? slices : 1u;
+            ici.arrayLayers = 1;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
             ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
@@ -481,8 +509,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 images_ready = false; break; }
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             vci.image = bi.image;
-            vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D : dim_3d ? VK_IMAGE_VIEW_TYPE_3D
-                         : dim_array ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D;
+            vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D : VK_IMAGE_VIEW_TYPE_2D;
             vci.format = ici.format;
             if (!bi.storage) {
                 // T# DST_SEL channel routing (SQ_SEL: 0=0, 1=1, 4=R, 5=G, 6=B, 7=A) — same mapping
@@ -620,8 +647,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             const ShaderResource* r = bi.resource;
-            const uint32_t slices = r->depth ? r->depth : 1;
-            const bool dim_1d = r->img_dim == 0, dim_3d = r->img_dim == 2, dim_array = r->img_dim == 5;
             VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_dst.srcAccessMask = 0;
             to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -629,13 +654,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             to_dst.srcQueueFamilyIndex = to_dst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             to_dst.image = bi.image;
-            to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0,
-                                       dim_array ? slices : 1u};
+            to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
             vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
             VkBufferImageCopy region{};
-            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, dim_array ? slices : 1u};
-            region.imageExtent = {r->width, r->height, dim_3d ? slices : 1u};
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            region.imageExtent = {r->width, r->height, 1};
             vkCmdCopyBufferToImage(command, staging[i], bi.image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
             VkImageMemoryBarrier to_general = to_dst;
@@ -657,8 +681,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const BoundImage& bi = images[i];
             if (!bi.storage) continue;
             const ShaderResource* r = bi.resource;
-            const uint32_t slices = r->depth ? r->depth : 1;
-            const bool dim_1d = r->img_dim == 0, dim_3d = r->img_dim == 2, dim_array = r->img_dim == 5;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
             to_src.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
@@ -666,13 +688,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             to_src.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             to_src.srcQueueFamilyIndex = to_src.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             to_src.image = bi.image;
-            to_src.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0,
-                                       dim_array ? slices : 1u};
+            to_src.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
             vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_src);
             VkBufferImageCopy region{};
-            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, dim_array ? slices : 1u};
-            region.imageExtent = {r->width, r->height, dim_3d ? slices : 1u};
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            region.imageExtent = {r->width, r->height, 1};
             vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    staging[i], 1, &region);
         }
@@ -724,22 +745,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const uint32_t cb = data_format_bytes(r->format);
             const uint32_t nc = r->num_components ? r->num_components : 1;
             const size_t guest_texel = (size_t)cb * nc;
-            const uint32_t slices = r->depth ? r->depth : 1;
-            const size_t texels = (size_t)r->width * r->height * slices;
+            const size_t texels = (size_t)r->width * r->height;
             uint8_t* destination = resource_bytes(r);
-            const bool writable = (r->host_data && r->host_data_size >= texels * guest_texel) ||
-                                  guest_readable(r->gpu_addr, (uint32_t)(texels * guest_texel));
-            if (writable) {
-                const uint32_t* channels = static_cast<const uint32_t*>(mapped);
-                for (size_t t = 0; t < texels; t++)
-                    storage_pack_texel(channels + t * 4, r->format, nc, destination + t * guest_texel);
-                notify_guest_gpu_write(r->gpu_addr, texels * guest_texel);
-                if (!r->host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       r->gpu_addr, texels * guest_texel,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-            }
+            const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+            for (size_t t = 0; t < texels; t++)
+                storage_pack_texel(channels + t * 4, r->format, nc, destination + t * guest_texel);
+            notify_guest_gpu_write(r->gpu_addr, texels * guest_texel);
+            if (!r->host_data && writer_provenance_enabled())
+                record_guest_write(GuestWriterKind::ComputeBuffer,
+                                   r->gpu_addr, texels * guest_texel,
+                                   item.submit_no, item.dispatch_index,
+                                   item.command_order, item.code_addr);
             vkUnmapMemory(ctx.device, staging_memory[i]);
         }
         if (!readback_ok) break;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,12 +1,15 @@
 #include "live_compute.hpp"
 
+#include "gpu/bc_decode.hpp"
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"
+#include "gpu/tile.hpp"
 #include "gpu/writer_provenance.hpp"
 
 #include <vulkan/vulkan.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -22,6 +25,11 @@ struct VulkanComputeContext {
     VkQueue queue = VK_NULL_HANDLE;
     uint32_t queue_family = UINT32_MAX;
     VkPhysicalDeviceMemoryProperties memory{};
+    // Storage-image support (#590): the recompiler's storage path declares the
+    // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
+    // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
+    // the features, image-binding dispatches are skipped loudly instead of creating an invalid device.
+    bool image_support = false;
 
     ~VulkanComputeContext() {
         if (device) vkDestroyDevice(device, nullptr);
@@ -67,6 +75,13 @@ struct VulkanComputeContext {
         }
         VkPhysicalDeviceFeatures enabled{};
         enabled.robustBufferAccess = VK_TRUE;
+        // Image bindings (#590): enable the format-free storage-image features when available.
+        image_support = supported.shaderStorageImageReadWithoutFormat &&
+                        supported.shaderStorageImageWriteWithoutFormat;
+        if (image_support) {
+            enabled.shaderStorageImageReadWithoutFormat = VK_TRUE;
+            enabled.shaderStorageImageWriteWithoutFormat = VK_TRUE;
+        }
         VkDeviceCreateInfo dci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
         dci.queueCreateInfoCount = 1;
         dci.pQueueCreateInfos = &qci;
@@ -94,6 +109,63 @@ struct BoundBuffer {
     uint64_t before_hash = 0, after_hash = 0;
     uint64_t changed_bytes = 0;
 };
+
+// One image binding (#590): a sampled texture (combined image sampler, decoded to RGBA8 exactly like
+// the live renderer's texture uploads) or a storage image (VK_FORMAT_R32G32B32A32_UINT raw-channel
+// texels — the recompiler's format-free contract, exec-diff proven by tests/image_compute_runner.h).
+struct BoundImage {
+    const prosper::gpu::ShaderResource* resource = nullptr;
+    uint32_t binding = 0;
+    bool storage = false;               // storage image: read back + pack to guest after the dispatch
+    VkImage image = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkImageView view = VK_NULL_HANDLE;
+    VkSampler sampler = VK_NULL_HANDLE; // combined image sampler only
+    VkDeviceSize row_pitch = 0;         // LINEAR-tiling row pitch (bytes), from vkGetImageSubresourceLayout
+};
+
+// --- Storage-image channel model (#590) -------------------------------------------------------------
+// The recompiler moves image texels as RAW 32-bit VGPR channel values (uvec4 per texel; the VkImage is
+// R32G32B32A32_UINT with format-free reads/writes). Real hardware format-converts per the T#, so the
+// guest surface's bytes must be UNPACKED to channel dwords on upload and PACKED back on writeback:
+//   Unorm8  -> float(b/255) bits         <- clamp(bitcast float,0,1)*255 rounded
+//   Float16 -> half->float bits          <- (store pack deliberately unsupported in v0: no half encode)
+//   Float32/Uint32/Sint32 -> raw 4-byte move both ways.
+// Missing channels read the hardware default (0,0,0,1.0f). Anything else is unsupported -> the caller
+// skips the dispatch loudly (never a silent wrong-layout write — correctness-first).
+bool storage_unpack_supported(prosper::gpu::DataFormat f) {
+    using DF = prosper::gpu::DataFormat;
+    return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 || f == DF::Uint32 || f == DF::Sint32;
+}
+bool storage_pack_supported(prosper::gpu::DataFormat f) {
+    using DF = prosper::gpu::DataFormat;
+    return f == DF::Unorm8 || f == DF::Float32 || f == DF::Uint32 || f == DF::Sint32;
+}
+void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32_t ncomp, uint32_t out[4]) {
+    using DF = prosper::gpu::DataFormat;
+    const uint32_t one_f32 = 0x3f800000u;                 // hardware default: missing channels = (0,0,0,1.0f)
+    out[0] = out[1] = out[2] = 0; out[3] = one_f32;
+    for (uint32_t c = 0; c < ncomp && c < 4; c++) {
+        switch (f) {
+            case DF::Unorm8: { float v = src[c] / 255.0f; std::memcpy(&out[c], &v, 4); break; }
+            case DF::Float16: { float v = prosper::gpu::half_to_float(
+                                    (uint16_t)(src[c * 2] | (src[c * 2 + 1] << 8)));
+                                std::memcpy(&out[c], &v, 4); break; }
+            default: std::memcpy(&out[c], src + c * 4, 4); break;   // 32-bit raw
+        }
+    }
+}
+void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32_t ncomp, uint8_t* dst) {
+    using DF = prosper::gpu::DataFormat;
+    for (uint32_t c = 0; c < ncomp && c < 4; c++) {
+        switch (f) {
+            case DF::Unorm8: { float v; std::memcpy(&v, &in[c], 4);
+                               v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
+                               dst[c] = (uint8_t)std::lround(v * 255.0f); break; }
+            default: std::memcpy(dst + c * 4, &in[c], 4); break;    // 32-bit raw
+        }
+    }
+}
 
 uint64_t fnv1a(const void* data, size_t size) {
     const auto* bytes = static_cast<const uint8_t*>(data);
@@ -134,22 +206,44 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
     if (!report.ok()) return false;
 
-    std::vector<SpirvDescriptorBinding> descriptors;
+    std::vector<SpirvDescriptorBinding> descriptors;       // storage buffers
+    std::vector<SpirvDescriptorBinding> image_descriptors; // sampled + storage images (#590)
     for (const auto& descriptor : report.descriptors) {
-        if (descriptor.kind != SpirvDescriptorKind::StorageBuffer) {
-            std::fprintf(stderr, "[compute] program 0x%llx uses unsupported %s binding %u\n",
-                         (unsigned long long)item.code_addr,
-                         spirv_descriptor_kind_name(descriptor.kind), descriptor.binding);
-            return false;
+        switch (descriptor.kind) {
+            case SpirvDescriptorKind::StorageBuffer:
+                descriptors.push_back(descriptor);
+                break;
+            case SpirvDescriptorKind::CombinedImageSampler:
+            case SpirvDescriptorKind::StorageImage:
+                image_descriptors.push_back(descriptor);
+                break;
+            default:
+                std::fprintf(stderr, "[compute] program 0x%llx uses unsupported %s binding %u\n",
+                             (unsigned long long)item.code_addr,
+                             spirv_descriptor_kind_name(descriptor.kind), descriptor.binding);
+                return false;
         }
-        descriptors.push_back(descriptor);
     }
-    if (descriptors.empty()) return false;
+    if (descriptors.empty() && image_descriptors.empty()) return false;
+    if (!image_descriptors.empty() && !ctx.image_support) {
+        static bool warned = false;
+        if (!warned) { warned = true;
+            std::fprintf(stderr, "[compute] device lacks shaderStorageImageRead/WriteWithoutFormat; "
+                                 "image-binding dispatches are skipped\n"); }
+        return false;
+    }
     std::sort(descriptors.begin(), descriptors.end(), [](const auto& a, const auto& b) {
+        return a.binding < b.binding;
+    });
+    std::sort(image_descriptors.begin(), image_descriptors.end(), [](const auto& a, const auto& b) {
         return a.binding < b.binding;
     });
 
     std::vector<BoundBuffer> buffers(descriptors.size());
+    std::vector<BoundImage> images(image_descriptors.size());
+    std::vector<VkBuffer> staging(image_descriptors.size(), VK_NULL_HANDLE);          // upload/readback
+    std::vector<VkDeviceMemory> staging_memory(image_descriptors.size(), VK_NULL_HANDLE);
+    std::vector<VkDeviceSize> staging_bytes(image_descriptors.size(), 0);
     VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
     VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
@@ -171,6 +265,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (auto& buffer : buffers) {
             if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
             if (buffer.memory) vkFreeMemory(ctx.device, buffer.memory, nullptr);
+        }
+        for (size_t i = 0; i < images.size(); i++) {
+            if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
+            if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
+            if (images[i].image) vkDestroyImage(ctx.device, images[i].image, nullptr);
+            if (images[i].memory) vkFreeMemory(ctx.device, images[i].memory, nullptr);
+            if (staging[i]) vkDestroyBuffer(ctx.device, staging[i], nullptr);
+            if (staging_memory[i]) vkFreeMemory(ctx.device, staging_memory[i], nullptr);
         }
     };
     auto resource_bytes = [](const ShaderResource* resource) -> uint8_t* {
@@ -216,16 +318,244 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (const auto& buffer : buffers) buffers_ready &= buffer.resource && buffer.memory;
         if (!buffers_ready) break;
 
+        // --- Image bindings (#590): sampled textures decode to RGBA8 (the live renderer's proven
+        // model); storage images are R32G32B32A32_UINT raw-channel texels (the recompiler's
+        // format-free contract, exec-diff proven by tests/image_compute_runner.h) with per-format
+        // pack/unpack against the guest surface. Everything not provably correct skips LOUDLY. ---
+        bool images_ready = !ctx.device ? false : true;
+        auto device_memory_type = [&](uint32_t bits) -> uint32_t {
+            for (uint32_t i = 0; i < ctx.memory.memoryTypeCount; i++)
+                if ((bits & (1u << i)) &&
+                    (ctx.memory.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+                    return i;
+            for (uint32_t i = 0; i < ctx.memory.memoryTypeCount; i++)
+                if (bits & (1u << i)) return i;
+            return UINT32_MAX;
+        };
+        auto skip_image = [&](const prosper::gpu::ShaderResource* r, const char* why) {
+            static std::vector<uint64_t> warned;
+            const uint64_t key = r ? r->gpu_addr : 0;
+            if (std::find(warned.begin(), warned.end(), key) == warned.end()) {
+                warned.push_back(key);
+                std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u fmt=%u: %s -> "
+                                     "dispatch skipped (#590)\n",
+                             (unsigned long long)item.code_addr, (unsigned long long)key,
+                             r ? r->width : 0, r ? r->height : 0, r ? r->depth : 0,
+                             r ? (unsigned)r->format : 0u, why);
+            }
+            images_ready = false;
+        };
+        for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
+            const ShaderResource* r = item.resources->by_binding(image_descriptors[i].binding);
+            if (!r || !r->width || !r->height) { skip_image(r, "no/degenerate resource"); break; }
+            BoundImage& bi = images[i];
+            bi.resource = r;
+            bi.binding = image_descriptors[i].binding;
+            bi.storage = image_descriptors[i].kind == SpirvDescriptorKind::StorageImage;
+            // A surface whose CURRENT pixels live in the renderer's RTT cache must not be read from
+            // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
+            if (is_live_render_target(r->gpu_addr)) { skip_image(r, "renderer-owned RTT surface"); break; }
+            const uint32_t slices = r->depth ? r->depth : 1;
+            const bool dim_1d = r->img_dim == 0, dim_3d = r->img_dim == 2, dim_array = r->img_dim == 5;
+            if (!dim_1d && !dim_3d && !dim_array && r->img_dim != 1) { skip_image(r, "unsupported image dim"); break; }
+            const uint32_t texel_bytes = bi.storage ? 16u : 4u;   // uvec4 raw channels / RGBA8
+            const VkDeviceSize sbytes = (VkDeviceSize)r->width * r->height * slices * texel_bytes;
+            staging_bytes[i] = sbytes;
+
+            // Fill the upload staging bytes.
+            std::vector<uint8_t> upload((size_t)sbytes, 0);
+            if (bi.storage) {
+                if (r->tile_mode) { skip_image(r, "tiled storage surface (writeback would corrupt)"); break; }
+                if (!storage_unpack_supported(r->format) || !storage_pack_supported(r->format)) {
+                    skip_image(r, "storage format has no channel pack/unpack yet"); break; }
+                const uint32_t cb = data_format_bytes(r->format);
+                const uint32_t nc = r->num_components ? r->num_components : 1;
+                const size_t guest_texel = (size_t)cb * nc;
+                const size_t texels = (size_t)r->width * r->height * slices;
+                const uint8_t* src = resource_bytes(r);
+                const bool readable = (r->host_data && r->host_data_size >= texels * guest_texel) ||
+                                      guest_readable(r->gpu_addr, (uint32_t)(texels * guest_texel));
+                // Unreadable source = a fresh store-only allocation: seed zeros (the kernel writes it).
+                if (readable)
+                    for (size_t t = 0; t < texels; t++)
+                        storage_unpack_texel(src + t * guest_texel, r->format, nc,
+                                             reinterpret_cast<uint32_t*>(upload.data()) + t * 4);
+            } else {
+                if (r->img_dim != 1) { skip_image(r, "non-2D sampled texture"); break; }
+                const uint32_t bpb = bc_block_bytes(r->format);
+                const uint32_t cb = data_format_bytes(r->format);
+                const uint32_t nc = r->num_components ? r->num_components : 1;
+                size_t need;                                       // guest bytes the decode reads
+                if (bpb) {
+                    const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
+                    need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
+                                        : (size_t)bw * bh * bpb;
+                } else if (cb * nc == 4 || cb * nc == 1 || (r->format == DataFormat::Float16 && nc == 4)) {
+                    const uint32_t bpt = cb * nc;
+                    need = r->tile_mode ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt)
+                                        : (size_t)r->width * r->height * bpt;
+                } else { skip_image(r, "sampled format not decodable yet"); break; }
+                const uint8_t* src = resource_bytes(r);
+                const bool readable = (r->host_data && r->host_data_size >= need) ||
+                                      guest_readable(r->gpu_addr, (uint32_t)need);
+                if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
+                if (bpb) {                                          // BCn: (block-detile ->) decode
+                    const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
+                    std::vector<uint8_t> lin((size_t)bw * bh * bpb, 0);
+                    if (r->tile_mode)
+                        detile_elements(lin.data(), src, need, bw, bh, bpb, r->tile_mode);
+                    else
+                        std::memcpy(lin.data(), src, lin.size());
+                    if (!bc_decode_surface(upload.data(), lin.data(), lin.size(),
+                                           r->width, r->height, r->format)) {
+                        skip_image(r, "BC decode unsupported"); break; }
+                } else {
+                    const uint32_t bpt = cb * nc;
+                    std::vector<uint8_t> lin((size_t)r->width * r->height * bpt, 0);
+                    if (r->tile_mode)
+                        detile_surface(lin.data(), src, r->width, r->height, r->tile_mode, 0, bpt);
+                    else
+                        std::memcpy(lin.data(), src, lin.size());
+                    const size_t texels = (size_t)r->width * r->height;
+                    if (bpt == 4) {                                 // RGBA8-class: direct
+                        std::memcpy(upload.data(), lin.data(), lin.size());
+                    } else if (bpt == 1) {                          // R8: broadcast coverage to RGBA
+                        for (size_t t = 0; t < texels; t++) {
+                            const uint8_t v = lin[t];
+                            upload[t * 4 + 0] = v; upload[t * 4 + 1] = v;
+                            upload[t * 4 + 2] = v; upload[t * 4 + 3] = v;
+                        }
+                    } else {                                        // Float16 x4: half -> UNORM8 clamp
+                        const uint16_t* hp = reinterpret_cast<const uint16_t*>(lin.data());
+                        for (size_t t = 0; t < texels * 4; t++) {
+                            float v = half_to_float(hp[t]);
+                            v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
+                            upload[t] = (uint8_t)std::lround(v * 255.0f);
+                        }
+                    }
+                }
+            }
+
+            // Staging buffer (host-visible) holding the upload bytes; reused for storage readback.
+            VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+            sci.size = sbytes;
+            sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            if (vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]) != VK_SUCCESS) { images_ready = false; break; }
+            VkMemoryRequirements sreq{};
+            vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
+            VkMemoryAllocateInfo smai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+            smai.allocationSize = sreq.size;
+            smai.memoryTypeIndex = ctx.host_memory_type(sreq.memoryTypeBits);
+            if (smai.memoryTypeIndex == UINT32_MAX ||
+                vkAllocateMemory(ctx.device, &smai, nullptr, &staging_memory[i]) != VK_SUCCESS ||
+                vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0) != VK_SUCCESS) {
+                images_ready = false; break; }
+            { void* mapped = nullptr;
+              if (vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped) != VK_SUCCESS) {
+                  images_ready = false; break; }
+              std::memcpy(mapped, upload.data(), (size_t)sbytes);
+              vkUnmapMemory(ctx.device, staging_memory[i]); }
+
+            // Device-local image.
+            VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+            ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
+            ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT : VK_FORMAT_R8G8B8A8_UNORM;
+            ici.extent = {r->width, r->height, dim_3d ? slices : 1u};
+            ici.mipLevels = 1;
+            ici.arrayLayers = dim_array ? slices : 1u;
+            ici.samples = VK_SAMPLE_COUNT_1_BIT;
+            ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+            ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+                                    : VK_IMAGE_USAGE_SAMPLED_BIT) |
+                        VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            if (vkCreateImage(ctx.device, &ici, nullptr, &bi.image) != VK_SUCCESS) { images_ready = false; break; }
+            VkMemoryRequirements ireq{};
+            vkGetImageMemoryRequirements(ctx.device, bi.image, &ireq);
+            VkMemoryAllocateInfo imai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+            imai.allocationSize = ireq.size;
+            imai.memoryTypeIndex = device_memory_type(ireq.memoryTypeBits);
+            if (imai.memoryTypeIndex == UINT32_MAX ||
+                vkAllocateMemory(ctx.device, &imai, nullptr, &bi.memory) != VK_SUCCESS ||
+                vkBindImageMemory(ctx.device, bi.image, bi.memory, 0) != VK_SUCCESS) {
+                images_ready = false; break; }
+            VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+            vci.image = bi.image;
+            vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D : dim_3d ? VK_IMAGE_VIEW_TYPE_3D
+                         : dim_array ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D;
+            vci.format = ici.format;
+            if (!bi.storage) {
+                // T# DST_SEL channel routing (SQ_SEL: 0=0, 1=1, 4=R, 5=G, 6=B, 7=A) — same mapping
+                // the renderer applies on its sampled views.
+                auto sel = [&](uint32_t s) {
+                    switch (s) {
+                        case 0: return VK_COMPONENT_SWIZZLE_ZERO;
+                        case 1: return VK_COMPONENT_SWIZZLE_ONE;
+                        case 4: return VK_COMPONENT_SWIZZLE_R;
+                        case 5: return VK_COMPONENT_SWIZZLE_G;
+                        case 6: return VK_COMPONENT_SWIZZLE_B;
+                        case 7: return VK_COMPONENT_SWIZZLE_A;
+                        default: return VK_COMPONENT_SWIZZLE_IDENTITY;
+                    }
+                };
+                vci.components = {sel(r->swizzle[0]), sel(r->swizzle[1]),
+                                  sel(r->swizzle[2]), sel(r->swizzle[3])};
+            }
+            vci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, ici.arrayLayers};
+            if (vkCreateImageView(ctx.device, &vci, nullptr, &bi.view) != VK_SUCCESS) { images_ready = false; break; }
+            if (!bi.storage) {
+                // Sampler from the decoded S# (mag/min filter, SQ_TEX CLAMP wrap enums) — the same
+                // fields the renderer honors; defaults reproduce LINEAR/clamp.
+                auto wrap = [&](uint32_t m) {
+                    switch (m) {
+                        case 0: return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+                        case 1: return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+                        case 6: case 7: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+                        default: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+                    }
+                };
+                VkSamplerCreateInfo smci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
+                smci.magFilter = r->mag_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
+                smci.minFilter = r->min_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
+                smci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+                smci.addressModeU = wrap(r->addr_uvw[0]);
+                smci.addressModeV = wrap(r->addr_uvw[1]);
+                smci.addressModeW = wrap(r->addr_uvw[2]);
+                smci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+                if (vkCreateSampler(ctx.device, &smci, nullptr, &bi.sampler) != VK_SUCCESS) {
+                    images_ready = false; break; }
+            }
+        }
+        if (!images_ready) break;
+
+        // Layout: the buffer bindings (filled above) + one entry per image binding (#590).
+        for (size_t i = 0; i < images.size(); i++) {
+            VkDescriptorSetLayoutBinding b{};
+            b.binding = images[i].binding;
+            b.descriptorType = images[i].storage ? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+                                                 : VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            b.descriptorCount = 1;
+            b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+            layout_bindings.push_back(b);
+        }
         VkDescriptorSetLayoutCreateInfo dlci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
         dlci.bindingCount = static_cast<uint32_t>(layout_bindings.size());
         dlci.pBindings = layout_bindings.data();
         if (vkCreateDescriptorSetLayout(ctx.device, &dlci, nullptr, &descriptor_layout) != VK_SUCCESS) break;
-        VkDescriptorPoolSize pool_size{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                                       static_cast<uint32_t>(buffers.size())};
+        uint32_t sampled_count = 0, storage_image_count = 0;
+        for (const auto& im : images) (im.storage ? storage_image_count : sampled_count)++;
+        VkDescriptorPoolSize pool_sizes[3]; uint32_t pool_size_count = 0;
+        if (!buffers.empty())
+            pool_sizes[pool_size_count++] = {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                                             static_cast<uint32_t>(buffers.size())};
+        if (sampled_count)
+            pool_sizes[pool_size_count++] = {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, sampled_count};
+        if (storage_image_count)
+            pool_sizes[pool_size_count++] = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, storage_image_count};
         VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
         dpci.maxSets = 1;
-        dpci.poolSizeCount = 1;
-        dpci.pPoolSizes = &pool_size;
+        dpci.poolSizeCount = pool_size_count;
+        dpci.pPoolSizes = pool_sizes;
         if (vkCreateDescriptorPool(ctx.device, &dpci, nullptr, &descriptor_pool) != VK_SUCCESS) break;
         VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
         dsai.descriptorPool = descriptor_pool;
@@ -234,7 +564,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (vkAllocateDescriptorSets(ctx.device, &dsai, &descriptor_set) != VK_SUCCESS) break;
 
         std::vector<VkDescriptorBufferInfo> buffer_infos(buffers.size());
-        std::vector<VkWriteDescriptorSet> writes(buffers.size());
+        std::vector<VkDescriptorImageInfo> image_infos(images.size());
+        std::vector<VkWriteDescriptorSet> writes(buffers.size() + images.size());
         for (size_t i = 0; i < buffers.size(); i++) {
             buffer_infos[i] = {buffers[i].buffer, 0, buffers[i].resource->size};
             writes[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
@@ -243,6 +574,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             writes[i].descriptorCount = 1;
             writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             writes[i].pBufferInfo = &buffer_infos[i];
+        }
+        for (size_t i = 0; i < images.size(); i++) {
+            image_infos[i] = {images[i].sampler, images[i].view, VK_IMAGE_LAYOUT_GENERAL};
+            VkWriteDescriptorSet& w = writes[buffers.size() + i];
+            w = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+            w.dstSet = descriptor_set;
+            w.dstBinding = images[i].binding;
+            w.descriptorCount = 1;
+            w.descriptorType = images[i].storage ? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+                                                 : VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            w.pImageInfo = &image_infos[i];
         }
         vkUpdateDescriptorSets(ctx.device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
@@ -274,10 +616,66 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         if (vkBeginCommandBuffer(command, &begin) != VK_SUCCESS) break;
+        // Upload every image: UNDEFINED -> TRANSFER_DST, copy the staged texels in, -> GENERAL.
+        for (size_t i = 0; i < images.size(); i++) {
+            const BoundImage& bi = images[i];
+            const ShaderResource* r = bi.resource;
+            const uint32_t slices = r->depth ? r->depth : 1;
+            const bool dim_1d = r->img_dim == 0, dim_3d = r->img_dim == 2, dim_array = r->img_dim == 5;
+            VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            to_dst.srcAccessMask = 0;
+            to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            to_dst.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            to_dst.srcQueueFamilyIndex = to_dst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            to_dst.image = bi.image;
+            to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0,
+                                       dim_array ? slices : 1u};
+            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
+            VkBufferImageCopy region{};
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, dim_array ? slices : 1u};
+            region.imageExtent = {r->width, r->height, dim_3d ? slices : 1u};
+            vkCmdCopyBufferToImage(command, staging[i], bi.image,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+            VkImageMemoryBarrier to_general = to_dst;
+            to_general.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                       (bi.storage ? VK_ACCESS_SHADER_WRITE_BIT : 0u);
+            to_general.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
+                                 1, &to_general);
+        }
         vkCmdBindPipeline(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
         vkCmdBindDescriptorSets(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout,
                                 0, 1, &descriptor_set, 0, nullptr);
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+        // Storage images: copy the written texels back into the staging buffer for guest writeback.
+        for (size_t i = 0; i < images.size(); i++) {
+            const BoundImage& bi = images[i];
+            if (!bi.storage) continue;
+            const ShaderResource* r = bi.resource;
+            const uint32_t slices = r->depth ? r->depth : 1;
+            const bool dim_1d = r->img_dim == 0, dim_3d = r->img_dim == 2, dim_array = r->img_dim == 5;
+            VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+            to_src.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            to_src.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            to_src.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            to_src.srcQueueFamilyIndex = to_src.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            to_src.image = bi.image;
+            to_src.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0,
+                                       dim_array ? slices : 1u};
+            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_src);
+            VkBufferImageCopy region{};
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, dim_array ? slices : 1u};
+            region.imageExtent = {r->width, r->height, dim_3d ? slices : 1u};
+            vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                   staging[i], 1, &region);
+        }
         if (vkEndCommandBuffer(command) != VK_SUCCESS) break;
         VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
         if (vkCreateFence(ctx.device, &fci, nullptr, &fence) != VK_SUCCESS) break;
@@ -311,15 +709,49 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                    item.command_order, item.code_addr);
         }
         if (!readback_ok) break;
+        // Storage-image writeback (#590): pack the kernel's raw uvec4 channel texels back into the
+        // guest surface's real format (tile_mode==0 was enforced at creation, so linear rows are the
+        // correct layout) and notify the render side exactly like the buffer path.
+        for (size_t i = 0; i < images.size() && readback_ok; i++) {
+            const BoundImage& bi = images[i];
+            if (!bi.storage) continue;
+            const ShaderResource* r = bi.resource;
+            void* mapped = nullptr;
+            if (vkMapMemory(ctx.device, staging_memory[i], 0, staging_bytes[i], 0, &mapped) != VK_SUCCESS) {
+                readback_ok = false;
+                break;
+            }
+            const uint32_t cb = data_format_bytes(r->format);
+            const uint32_t nc = r->num_components ? r->num_components : 1;
+            const size_t guest_texel = (size_t)cb * nc;
+            const uint32_t slices = r->depth ? r->depth : 1;
+            const size_t texels = (size_t)r->width * r->height * slices;
+            uint8_t* destination = resource_bytes(r);
+            const bool writable = (r->host_data && r->host_data_size >= texels * guest_texel) ||
+                                  guest_readable(r->gpu_addr, (uint32_t)(texels * guest_texel));
+            if (writable) {
+                const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+                for (size_t t = 0; t < texels; t++)
+                    storage_pack_texel(channels + t * 4, r->format, nc, destination + t * guest_texel);
+                notify_guest_gpu_write(r->gpu_addr, texels * guest_texel);
+                if (!r->host_data && writer_provenance_enabled())
+                    record_guest_write(GuestWriterKind::ComputeBuffer,
+                                       r->gpu_addr, texels * guest_texel,
+                                       item.submit_no, item.dispatch_index,
+                                       item.command_order, item.code_addr);
+            }
+            vkUnmapMemory(ctx.device, staging_memory[i]);
+        }
+        if (!readback_ok) break;
         ok = true;
     } while (false);
 
     if (trace)
         std::fprintf(stderr, "[compute] execute submit=%llu dispatch=%llu code=0x%llx "
-                     "groups=%ux%ux%u buffers=%zu result=%s\n",
+                     "groups=%ux%ux%u buffers=%zu images=%zu result=%s\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
                      (unsigned long long)item.code_addr, item.launch.groups_x, item.launch.groups_y,
-                     item.launch.groups_z, buffers.size(), ok ? "ok" : "failed");
+                     item.launch.groups_z, buffers.size(), images.size(), ok ? "ok" : "failed");
     if (trace) {
         for (const auto& buffer : buffers) {
             if (!buffer.resource) continue;
@@ -348,9 +780,13 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         std::fprintf(stderr, "[compute] Vulkan initialization failed\n");
         return false;
     }
+    // Dispatches are independent PM4-order operations: one item failing (e.g. an image shape the
+    // backend can't bind yet, #590) must not abort the rest of the batch — that would regress
+    // dispatches that executed before image bindings existed. Run all; report all-succeeded.
+    bool all_ok = true;
     for (const auto& item : items)
-        if (!execute_item(context, item)) return false;
-    return true;
+        all_ok &= execute_item(context, item);
+    return all_ok;
 }
 
 void register_live_compute() {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -81,6 +81,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 return true;
             });
     }
+    // The compute backend must not sample a surface whose CURRENT pixels live in this renderer's
+    // RTT cache (raw guest memory is then empty/stale — the Dead Cells 642x362 lesson): publish the
+    // exact-match target query it skips on (#590). Same keying as the RTT injection below.
+    prosper::gpu::set_live_target_query([](uint64_t addr) { return g_rtt.count(addr) != 0; });
     if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
         getenv("PROSPER_GPU_REPLAY_EXPORT_DS"))
         prosper::gpu::set_gpu_capture_ds_seed_snapshot_reader(

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -140,7 +140,6 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.base      = (((uint64_t)t[0] | ((uint64_t)t[1] << 32)) & 0xFFFFFFFFFFull) << 8;             // Base40
     d.width     = (uint32_t)(((t[1] >> 30) & 0x3u) | (((t[2] >> 0) & 0xFFFu) << 2)) + 1;          // Width5
     d.height    = (uint32_t)((t[2] >> 14) & 0x3FFFu) + 1;                                          // Height5
-    d.depth     = (uint32_t)(t[4] & 0x1FFFu) + 1;                                                  // Depth (WORD4[12:0])
     d.format    = (t[1] >> 20) & 0x1FFu;                                                           // Format
     d.tile_mode = (t[3] >> 20) & 0x1Fu;                                                            // TileMode (SW_MODE)
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
@@ -149,6 +148,10 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.dst_sel[2] = (uint8_t)((t[3] >> 6) & 0x7u);   // DST_SEL_Z ([8:6])
     d.dst_sel[3] = (uint8_t)((t[3] >> 9) & 0x7u);   // DST_SEL_W ([11:9])
     return d;
+}
+
+uint32_t image_type_to_dim(uint8_t type) {
+    return type >= 8 && type <= 15 ? static_cast<uint32_t>(type - 8) : 1u;
 }
 
 ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
@@ -346,7 +349,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // T# TYPE -> the MIMG dim convention (GFX10 SQ_RSRC_IMG: 8=1D, 9=2D, 10=3D, 11=CUBE,
             // 12=1D_ARRAY, 13=2D_ARRAY). A CUBE resource (img_dim 3) uploads as six faces stacked
             // vertically in one 2D image (#273); everything else keeps the 2D default.
-            r.img_dim       = d.type == 11 ? 3u : d.type == 10 ? 2u : d.type == 13 ? 5u : 1u;
+            r.img_dim       = image_type_to_dim(d.type);
             r.srgb          = fi.srgb;              // gamma-encoded surface: sample with sRGB->linear (#263)
             if (fi.srgb && getenv("PROSPER_GFXLOG"))
                 fprintf(stderr, "[t#] SRGB texture fmt=%u %ux%u (binding %u)\n", d.format, d.width, d.height, r.binding);

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -140,6 +140,7 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.base      = (((uint64_t)t[0] | ((uint64_t)t[1] << 32)) & 0xFFFFFFFFFFull) << 8;             // Base40
     d.width     = (uint32_t)(((t[1] >> 30) & 0x3u) | (((t[2] >> 0) & 0xFFFu) << 2)) + 1;          // Width5
     d.height    = (uint32_t)((t[2] >> 14) & 0x3FFFu) + 1;                                          // Height5
+    d.depth     = (uint32_t)(t[4] & 0x1FFFu) + 1;                                                  // Depth (WORD4[12:0])
     d.format    = (t[1] >> 20) & 0x1FFu;                                                           // Format
     d.tile_mode = (t[3] >> 20) & 0x1Fu;                                                            // TileMode (SW_MODE)
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -77,11 +77,6 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 struct DecodedImageDescriptor {
     uint64_t base = 0;
     uint32_t width = 0, height = 0;
-    // DEPTH+1 (3D) / last-array-slice+1 (arrays) from WORD4 bits [12:0], per the same AMD GFX10
-    // register DB the fields above cite (SQ_IMG_RSRC_WORD4.DEPTH). 1 for plain 2D. Consumed by the
-    // compute storage-image path (#590) to size 3D/array images. CONFIDENCE: MED (DB-derived, no
-    // live cross-check yet — a wrong value mis-sizes the bound image; reads stay bounds-checked).
-    uint32_t depth = 1;
     uint32_t format = 0;      // Gen5 surface-format enum (fields[1] bits 20..28)
     uint32_t tile_mode = 0;   // 0 = linear
     uint8_t  type = 0;        // SQ_RSRC_IMG dim (GFX10: 8=1D, 9=2D, 10=3D, 11=CUBE, 12=1D_ARRAY, 13=2D_ARRAY).
@@ -93,6 +88,10 @@ struct DecodedImageDescriptor {
 };
 // Decode an 8-dword T# (RDNA2/Gen5 image resource). Pure; exposed for reuse + testing.
 DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]);
+
+// Convert SQ_RSRC_IMG TYPE (8..15) to the MIMG dim convention (0..7). Unknown values retain the
+// long-standing 2D fallback.
+uint32_t image_type_to_dim(uint8_t type);
 
 // A Gen5/GFX10 T# IMG_FMT (the 9-bit combined format field) decoded to sizing + conversion info.
 // bytes_per_block is the byte size of one block_width x block_height texel block — for uncompressed

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -77,6 +77,11 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 struct DecodedImageDescriptor {
     uint64_t base = 0;
     uint32_t width = 0, height = 0;
+    // DEPTH+1 (3D) / last-array-slice+1 (arrays) from WORD4 bits [12:0], per the same AMD GFX10
+    // register DB the fields above cite (SQ_IMG_RSRC_WORD4.DEPTH). 1 for plain 2D. Consumed by the
+    // compute storage-image path (#590) to size 3D/array images. CONFIDENCE: MED (DB-derived, no
+    // live cross-check yet — a wrong value mis-sizes the bound image; reads stay bounds-checked).
+    uint32_t depth = 1;
     uint32_t format = 0;      // Gen5 surface-format enum (fields[1] bits 20..28)
     uint32_t tile_mode = 0;   // 0 = linear
     uint8_t  type = 0;        // SQ_RSRC_IMG dim (GFX10: 8=1D, 9=2D, 10=3D, 11=CUBE, 12=1D_ARRAY, 13=2D_ARRAY).

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -213,6 +213,14 @@ void notify_guest_gpu_write(uint64_t addr, uint64_t size);
 // dispatch from its state snapshot and invokes the backend in stream order.
 void set_submit_compute(LiveComputeFn fn);
 bool have_submit_compute();
+
+// Live render-target query (#590): the compute backend must not read a sampled input from raw guest
+// memory when the LIVE RENDERER owns that surface's current pixels (an RTT color target — raw memory
+// is then empty/stale, the Dead Cells 642x362 lesson). The live renderer registers this; the compute
+// backend skips such dispatches loudly. Cross-device RTT sharing is the follow-up.
+using LiveTargetQueryFn = std::function<bool(uint64_t gpu_addr)>;
+void set_live_target_query(LiveTargetQueryFn fn);
+bool is_live_render_target(uint64_t gpu_addr);
 std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st,
                                                      uint64_t submit_no = 0,
                                                      std::vector<OperationRealizationFailure>* failures = nullptr);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1027,17 +1027,23 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     if (mapped_fmt && fi.block_width > 1 && fi.snorm) continue;   // signed BCn: not wired
                     ShaderResource r;
                     r.cls = u.is_store ? ResourceClass::StorageImage : ResourceClass::Texture;
+                    // 3D / 2D_ARRAY surfaces (SQ_RSRC_IMG type 10 / 13) carry their slice count in
+                    // the T#'s WORD4 DEPTH field — the storage-image path sizes the bound image and
+                    // its guest writeback with it (#590). Plain 2D keeps depth 1.
+                    const uint32_t slices = (d.type == 10 || d.type == 13)
+                                                ? (d.depth ? d.depth : 1u) : 1u;
                     if (mapped_fmt) {
                         r.format = fi.format; r.num_components = fi.num_components;
                         const bool is_bcn = fi.block_width > 1;
                         r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
-                                        : (d.width * d.height * fi.bytes_per_block);
+                                        : (d.width * d.height * fi.bytes_per_block * slices);
                         r.srgb = fi.srgb;
                     } else {
                         r.format = DataFormat::Unorm8; r.num_components = 4;
-                        r.size = d.width * d.height * 4;
+                        r.size = d.width * d.height * 4 * slices;
                     }
                     r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
+                    r.depth = slices;
                     r.tile_mode = d.tile_mode;
                     r.img_dim = d.type == 11 ? 3u : d.type == 10 ? 2u : d.type == 13 ? 5u : 1u;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
@@ -1150,28 +1156,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
                              (unsigned long long)code_addr);
             continue;
         }
-        // The live compute backend binds STORAGE BUFFERS only (live_compute.cpp). A program whose
-        // reflected interface needs a storage image / sampled texture now RECOMPILES (the #590 fold
-        // above resolves its descriptors), but executing it would fail at bind time — and one failing
-        // item aborts the whole batch in execute_live_compute_items, skipping dispatches that ran
-        // before this change. Gate it here, loudly and once per program, until the backend grows the
-        // STORAGE_IMAGE path; this line is the measure of exactly what that backend work unblocks.
-        {
-            bool backend_bindable = true;
-            SpirvDescriptorKind blocked = SpirvDescriptorKind::Unknown;
-            for (const auto& d : report.descriptors)
-                if (d.kind != SpirvDescriptorKind::StorageBuffer) {
-                    backend_bindable = false; blocked = d.kind; break;
-                }
-            if (!backend_bindable) {
-                static std::set<uint64_t> logged;
-                if (logged.insert(code_addr).second)
-                    std::fprintf(stderr, "[compute] program 0x%llx recompiles but needs a %s binding "
-                                         "the backend cannot execute yet (#590)\n",
-                                 (unsigned long long)code_addr, spirv_descriptor_kind_name(blocked));
-                continue;
-            }
-        }
+        // Image bindings (sampled textures + storage images) execute through the live backend's
+        // image paths (#590, live_compute.cpp); shapes it cannot bind correctly are skipped there,
+        // loudly and per-item, without aborting the rest of the batch.
         items.push_back(std::move(item));
     }
     return items;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1509,6 +1509,13 @@ void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
 bool have_submit_renderer()               { return static_cast<bool>(g_live); }
 void set_submit_compute(LiveComputeFn fn) { g_compute = std::move(fn); }
 bool have_submit_compute()                { return static_cast<bool>(g_compute); }
+
+static LiveTargetQueryFn g_live_target_query;   // registered by the live renderer (#590)
+void set_live_target_query(LiveTargetQueryFn fn) { g_live_target_query = std::move(fn); }
+bool is_live_render_target(uint64_t gpu_addr) {
+    return g_live_target_query && g_live_target_query(gpu_addr);
+}
+
 void set_guest_gpu_write_observer(GuestGpuWriteObserver observer) {
     g_guest_gpu_write_observer = std::move(observer);
 }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -738,7 +738,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
                     // T# TYPE -> MIMG dim (GFX10: 9=2D, 10=3D, 11=CUBE, 13=2D_ARRAY); a cube
                     // uploads as six vertically-stacked faces (#273 — see agc_shader_layout).
-                    r.img_dim = d.type == 11 ? 3u : d.type == 10 ? 2u : d.type == 13 ? 5u : 1u;
+                    r.img_dim = image_type_to_dim(d.type);
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
@@ -1009,8 +1009,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
                         d.width > 16384 || d.height > 16384) continue;   // garbage/degenerate T#
                     {
                         bool mapped = false;
+                        const ResourceClass wanted = u.is_store ? ResourceClass::StorageImage
+                                                               : ResourceClass::Texture;
                         for (auto& r0 : table->resources)
-                            if ((r0.cls == ResourceClass::Texture || r0.cls == ResourceClass::StorageImage) &&
+                            if (r0.cls == wanted &&
                                 r0.gpu_addr == d.base && r0.width == d.width && r0.height == d.height) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
                                 if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
@@ -1019,33 +1021,31 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     }
                     Gen5ImageFormatInfo fi;
                     const bool mapped_fmt = gen5_image_format(d.format, &fi);
-                    // Storage images move texels bit-exact (uint view; format lives in the T#), so an
-                    // unmapped IMG_FMT is acceptable THERE with a 4-byte-texel assumption only when the
-                    // format is genuinely unknown; sampled textures keep the strict policy (skip when
-                    // unmapped — a wrong RGBA8 read samples garbage).
+                    // Unknown sampled formats cannot be decoded. Unknown storage formats may still
+                    // recompile (format-free SPIR-V), but remain explicitly Unknown so the live backend
+                    // rejects them instead of silently treating arbitrary bytes as RGBA8.
                     if (!mapped_fmt && !u.is_store) continue;
                     if (mapped_fmt && fi.block_width > 1 && fi.snorm) continue;   // signed BCn: not wired
                     ShaderResource r;
                     r.cls = u.is_store ? ResourceClass::StorageImage : ResourceClass::Texture;
-                    // 3D / 2D_ARRAY surfaces (SQ_RSRC_IMG type 10 / 13) carry their slice count in
-                    // the T#'s WORD4 DEPTH field — the storage-image path sizes the bound image and
-                    // its guest writeback with it (#590). Plain 2D keeps depth 1.
-                    const uint32_t slices = (d.type == 10 || d.type == 13)
-                                                ? (d.depth ? d.depth : 1u) : 1u;
                     if (mapped_fmt) {
                         r.format = fi.format; r.num_components = fi.num_components;
                         const bool is_bcn = fi.block_width > 1;
-                        r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
-                                        : (d.width * d.height * fi.bytes_per_block * slices);
+                        const uint64_t bytes = is_bcn
+                            ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block
+                            : static_cast<uint64_t>(d.width) * d.height * fi.bytes_per_block;
+                        if (!bytes || bytes > UINT32_MAX) continue;
+                        r.size = static_cast<uint32_t>(bytes);
                         r.srgb = fi.srgb;
                     } else {
-                        r.format = DataFormat::Unorm8; r.num_components = 4;
-                        r.size = d.width * d.height * 4 * slices;
+                        const uint64_t bytes = static_cast<uint64_t>(d.width) * d.height * 4;
+                        if (!bytes || bytes > UINT32_MAX) continue;
+                        r.format = DataFormat::Unknown; r.num_components = 4;
+                        r.size = static_cast<uint32_t>(bytes);
                     }
                     r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
-                    r.depth = slices;
                     r.tile_mode = d.tile_mode;
-                    r.img_dim = d.type == 11 ? 3u : d.type == 10 ? 2u : d.type == 13 ? 5u : 1u;
+                    r.img_dim = image_type_to_dim(d.type);
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3294,20 +3294,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const uint32_t SQ_DIM_2D = 1u;
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
             // Resolve the T#/U# via SRSRC (src[1]) provenance: s_load tag (indirect) else user-data SGPR.
-            const ShaderResource* res = nullptr;
-            { auto it = rs.sreg_srt.find(in.src[1].value);
-              if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
-              if (!res) res = rt->by_sgpr_base(in.src[1].value); }
-            // PER-USE pc provenance fallback (#273 — DOLL's title-composite image_sample_b): the
-            // executor's const-fold walk snapshots the T# each image op consumes and keys it by the
-            // INSTRUCTION pc (ShaderResource::fetch_pc). Used when the key/SGPR chains found nothing,
-            // or found a NON-image resource — the load-immediate key model collides when two different
-            // tables reuse one immediate (a key-0 EUD sharp vs the key-0 table T# here).
+            const ShaderResource* res = rt->by_fetch_pc(in.pc);
             if (!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage)) {
-                if (const ShaderResource* pr = rt->by_fetch_pc(in.pc);
-                    pr && (pr->cls == ResourceClass::Texture || pr->cls == ResourceClass::StorageImage))
-                    res = pr;
+                res = nullptr;
+                auto it = rs.sreg_srt.find(in.src[1].value);
+                if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
+                if (!res) res = rt->by_sgpr_base(in.src[1].value);
             }
+            // Exact per-use provenance wins over table keys. A sample and store may consume the same
+            // T# through a colliding offset but require different Vulkan descriptor classes.
+            if ((in.opcode == 0x08 && res && res->cls != ResourceClass::StorageImage) ||
+                (in.opcode != 0x00 && in.opcode != 0x08 && res && res->cls != ResourceClass::Texture))
+                res = nullptr;
             if ((!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage))
                 && getenv("PROSPER_DBG")) {
                 // Resolution-failure diagnostic: which provenance step failed for this image op.

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -107,9 +107,6 @@ struct ShaderResource {
     uint32_t      img_dim           = 1;
     uint32_t      width             = 0;
     uint32_t      height            = 0;
-    // 3D depth / array-layer count from the T#'s WORD4 DEPTH field (#590); 1 for plain 2D. Used by
-    // the compute storage-image path to size 3D/2D_ARRAY images and their guest writeback.
-    uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -107,6 +107,9 @@ struct ShaderResource {
     uint32_t      img_dim           = 1;
     uint32_t      width             = 0;
     uint32_t      height            = 0;
+    // 3D depth / array-layer count from the T#'s WORD4 DEPTH field (#590); 1 for plain 2D. Used by
+    // the compute storage-image path to size 3D/2D_ARRAY images and their guest writeback.
+    uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -78,6 +78,13 @@ int main() {
         CHECK(!gen5_image_format(44, &fi), "IMG_FMT 44 (10_10_10_2) unmapped -> false");
         CHECK(!gen5_image_format(157, &fi), "IMG_FMT 157 (FMASK) unmapped -> false");
         CHECK(!gen5_image_format(511, &fi), "IMG_FMT 511 out-of-table -> false");
+        CHECK(image_type_to_dim(8) == 0 && image_type_to_dim(9) == 1 &&
+              image_type_to_dim(10) == 2 && image_type_to_dim(11) == 3,
+              "T# TYPE 1D/2D/3D/CUBE maps to MIMG dims 0..3");
+        CHECK(image_type_to_dim(12) == 4 && image_type_to_dim(13) == 5 &&
+              image_type_to_dim(14) == 6 && image_type_to_dim(15) == 7,
+              "T# TYPE array/MSAA variants map to MIMG dims 4..7");
+        CHECK(image_type_to_dim(0) == 1, "unknown T# TYPE keeps the conservative 2D fallback");
     }
 
     // --- V# decode in isolation ---------------------------------------------------------------

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -105,6 +105,71 @@ int main() {
             replay_filled &= replay_owned[record * 4 + component] == expected[component];
     CHECK(replay_filled, "compute writeback updates owned backing for a later replay operation");
 
+    // --- #590: the live backend's storage-IMAGE path. The same 1D image-copy kernel that
+    // test_storage_image_copy proves against the raw harness, executed through the PRODUCTION
+    // backend with Unorm8x4 guest-style backing — exercising the full chain: channel unpack
+    // (bytes -> float-bit uvec4 texels), the R32G32B32A32_UINT image contract, and the pack-back
+    // writeback (float bits -> clamped bytes). Unorm8 pack(unpack(b)) == b exactly, so a bit-exact
+    // dst==src is the correctness assertion.
+    static const uint32_t image_copy[] = {
+        0x7E080300u, 0xF0000F00u, 0x00000004u, 0xBF8C3F70u, 0xF0200F00u, 0x00020004u, 0xBF810000u,
+    };
+    const uint32_t W = 64;
+    std::vector<uint32_t> lane_index(W);
+    for (uint32_t i = 0; i < W; i++) lane_index[i] = i;      // shell input: v0 = input[gid] = gid
+    std::vector<uint32_t> dummy(4, 0);
+    std::vector<uint8_t> img_src(W * 4), img_dst(W * 4, 0xEE);
+    for (uint32_t i = 0; i < W * 4; i++) img_src[i] = (uint8_t)(i * 37 + 5);
+    ShaderResourceTable irt;
+    auto add_buffer = [&](uint32_t binding, void* data, uint32_t size) {
+        ShaderResource b{};
+        b.cls = ResourceClass::ConstantBuffer;
+        b.binding = binding;
+        b.gpu_addr = (uint64_t)(uintptr_t)data;
+        b.size = size;
+        irt.resources.push_back(b);
+    };
+    add_buffer(0, lane_index.data(), W * sizeof(uint32_t));
+    add_buffer(1, dummy.data(), 16);
+    add_buffer(2, dummy.data(), 16);
+    add_buffer(3, dummy.data(), 16);
+    auto add_image = [&](uint32_t binding, uint32_t sgpr, void* data, uint32_t size) {
+        ShaderResource im{};
+        im.cls = ResourceClass::StorageImage;
+        im.img_dim = 0;                     // 1D
+        im.binding = binding;
+        im.sgpr_base = sgpr;
+        im.format = DataFormat::Unorm8;
+        im.num_components = 4;
+        im.width = W; im.height = 1; im.depth = 1;
+        im.gpu_addr = (uint64_t)(uintptr_t)data;
+        im.size = size;
+        irt.resources.push_back(im);
+    };
+    add_image(4, 0, img_src.data(), W * 4);
+    add_image(5, 8, img_dst.data(), W * 4);
+    std::vector<uint32_t> image_spirv = recompile_valu(
+        image_copy, sizeof(image_copy) / sizeof(image_copy[0]), 1, 0, &irt);
+    CHECK(!image_spirv.empty(), "storage-image copy kernel recompiles against the game-style table");
+    if (!image_spirv.empty()) {
+        ComputeItem image_item;
+        image_item.spirv = image_spirv;
+        image_item.resources = std::make_shared<ShaderResourceTable>(irt);
+        image_item.launch.threads_x = W;
+        image_item.launch.local_x = 64;
+        image_item.launch.groups_x = 1;
+        image_item.launch.local_y = image_item.launch.local_z = 1;
+        image_item.launch.groups_y = image_item.launch.groups_z = 1;
+        image_item.code_addr = 0x590590;
+        CHECK(prosper::frontend::execute_live_compute_items({image_item}),
+              "live backend executes the storage-image copy dispatch (#590)");
+        uint32_t bad = 0;
+        for (uint32_t i = 0; i < W * 4; i++) bad += img_dst[i] != img_src[i];
+        if (bad) std::printf("  image copy mismatched bytes = %u/%u (b0 src=%02x dst=%02x)\n",
+                             bad, W * 4, img_src[0], img_dst[0]);
+        CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
+    }
+
     if (fails) {
         std::printf("== FAIL: %d ==\n", fails);
         return 1;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -141,7 +141,7 @@ int main() {
         im.sgpr_base = sgpr;
         im.format = DataFormat::Unorm8;
         im.num_components = 4;
-        im.width = W; im.height = 1; im.depth = 1;
+        im.width = W; im.height = 1;
         im.gpu_addr = (uint64_t)(uintptr_t)data;
         im.size = size;
         irt.resources.push_back(im);


### PR DESCRIPTION
## What

Completes the backend half of #590. The live compute backend was storage-buffer-only, so kernels whose resolved descriptors included sampled textures or storage images were skipped. This PR adds:

- **Sampled textures:** 2D combined-image-sampler bindings; guest decode to RGBA8 via the renderer's detile/BC/half helpers; T# swizzle and decoded S# sampler state.
- **Storage images:** capture-safe 1D/2D `R32G32B32A32_UINT` raw-channel images with per-`DataFormat` pack/unpack and guest writeback notification.
- **Compute descriptor fold:** exact per-instruction image provenance; opcode-specific Texture vs StorageImage class resolution; direct/keyed cross-class collisions cannot mask the correct binding.
- **RTT alias guard:** a live renderer target is never sampled from stale raw guest memory.
- **Hard bounds:** reject unknown storage formats, unreadable/undersized backing, unsupported sampled formats, tiled storage writes, invalid 1D extents, and expanded images over 256 MiB instead of guessing.
- **Per-item failure isolation:** an unsupported image item does not abort unrelated dispatches in the same batch.

3D and array bindings are deliberately **not** claimed here. The current capture/resource schema does not persist their depth/layer metadata safely; those shapes skip loudly and are tracked in #657.

## Measured

Original pre-hardening DOLL (`PPSA17942`) 200-second census on this PR stack:

- 1,127 compute dispatches executed (previously 0 for the image-gated family), four program variants, zero backend failures;
- total recompile rejects 1,522 -> 288 (-81%); compute skips 16 -> 12.

Exact hardened-head DOLL reruns were interrupted by the known intermittent #241 worker/free-list fault before reaching an image-bearing kernel. The longer attempt executed 20,567 ordinary compute dispatches with zero backend failures before that unrelated guest fault. The supported image path is therefore validated on the exact head by the production backend test below, while the older DOLL count is retained as stack-level evidence rather than relabeled as a fresh census.

## Validation

Exact pushed head `c320aa8`:

- 92/92 local CTests pass after rebase to current master.
- Fresh GitHub CI passes: Linux, Linux App, Windows MinGW, macOS.
- `game_compute_exec`: production backend executes the proven 1D Unorm8 storage-image copy byte-exact through unpack -> Vulkan image copy -> pack/writeback.
- `storage_image_copy`: Vulkan execution differential remains bit-exact, including non-workgroup-multiple OOB tail lanes.
- Snapshot guards: Messenger 24,318 colours; Dead Cells splash 1,684 colours.
- Current-master gameplay capsule parity:
  - Dead Cells: `9981d8c587b37c78` before and after.
  - Blasphemous 2: `501bd2223a3c11a5` before and after.
- `messenger_recompile_guard` and descriptor/resource contract tests pass.

Completes the first executable compute-image arc: #627 -> #629 -> this PR. Remaining shader classes and layered-image capture support stay in #590/#657.