### PR TITLE
port(win): reserve-alignment + worker-stack registration + sync diagnostics (job-system stall pinpointed)

### DIFF
--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -352,17 +352,29 @@ The deep crash after `%fs` TLS was two more Linux-parity gaps (fixed on `port/wi
   rbx=0) on an unrecoverable thread. A `win_thread_trampoline` now marshals the SysV entry through
   `prosper_call_guest_sysv` and activates the worker's guest `%fs` TCB.
 
-### The Windows frontier: wire the renderer (guest reaches the frame loop and idle-waits)
+### Renderer wired on Windows (#655); the Windows frontier: the Unity job-system pre-render stall
 
-The Windows guest now **boots fully multi-threaded into the running frame loop and idle-waits** (0%
-CPU across 4 threads, zero unimplemented Sony calls, no crash) — the same state the Linux *headless*
-`boot_trace` reaches: alive, waiting for the GPU/present side to make progress. `boot_trace` wires no
-Vulkan on Windows, so the next step to a rendered frame is bringing up the live Vulkan renderer +
-present path on Windows (the `frontends/shared/live_renderer` used by `prosper-app`), analogous to
-`PROSPER_RENDER=1` on Linux. Deferred, lower-priority items surfaced along the way: phys-offset
-aliasing in the memory HLE (needed by UE4 MallocBinned3, not this Unity title — `CreateFileMapping`/
-`MapViewOfFile3`, 64 KiB granularity); honoring reserve alignment > 64 KiB (over-reserve + trim);
-worker-thread stack registration for GC bounds; and `PROSPER_CRASHPEEK` guards.
+The live Vulkan renderer now builds + initializes on Windows (#655): the whole GPU/Vulkan translation
+layer + `prosper_live_renderer` compile under MinGW (the Vulkan SDK is found via `VULKAN_SDK`), and at
+runtime the live compute + submit renderers register cleanly. With the renderer wired and
+`PROSPER_RENDER=1`, the guest boots into Unity engine init (allocates its pools, spawns
+`AssetGarbageCollectorHelper` threads) and then **idle-waits** (0% CPU) — it does NOT yet submit draws.
+
+Diagnosis (via the new `PROSPER_SYNCLOG` WaitOnAddress logging): the guest's **Unity job-system worker
+threads park in `sceKernelWaitOnAddress`** on a contiguous array of per-worker words (observed ~44
+stuck waits, `*addr==expected==0`, no timeout), waiting for jobs the dispatcher never posts because the
+**main/dispatch thread is itself blocked** after an init burst (24 `scePthreadCondBroadcast`s). This is
+the same producer/consumer class as the Linux pre-render stall. Next step: identify what the dispatch
+thread is blocked on (likely a resource-load / async / GPU-or-VideoOut completion that must tick to
+release it), using the sync + EventFlag logs; the Linux bring-up (worker pool via PSN.prx, EOP
+completions, scene activation) is the reference. Note the coarse Windows `WaitOnAddress` uses one global
+`std::condition_variable` (any wake re-checks all waiters) — correct but worth revisiting if the wake
+path proves to be the gap.
+
+Deferred, lower-priority items (some now done): ~~honor reserve alignment > 64 KiB~~ (done, #658);
+~~worker-thread stack registration for GC bounds~~ (done, #658); phys-offset aliasing in the memory HLE
+(needed by UE4 MallocBinned3, not this Unity title — `CreateFileMapping`/`MapViewOfFile3`, 64 KiB
+granularity); and `PROSPER_CRASHPEEK` guards.
 
 **What is done (compiles + links, in CI):**
 - **`exec_image_win.cpp`** — the Win32 sibling of `exec_image_linux.cpp` implementing the full
@@ -385,22 +397,25 @@ worker-thread stack registration for GC bounds; and `PROSPER_CRASHPEEK` guards.
   `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **Wire the Vulkan renderer on Windows — the current frontier.** The guest boots into the frame loop
-   and idle-waits for the GPU/present side (see above). Bring up `frontends/shared/live_renderer` +
-   present on Windows (the `PROSPER_RENDER=1` analogue) to drive past the wait toward a rendered frame.
+1. **The Unity job-system pre-render stall — the current frontier.** The renderer is wired (#655) but
+   the guest idle-waits in engine init: job workers park in `sceKernelWaitOnAddress` for jobs the
+   blocked dispatch thread never posts (see above). Find what blocks the dispatch thread (sync/EventFlag
+   logs are in place) so draws start flowing to the now-wired renderer.
 2. ~~Port the direct/flexible-memory HLE~~ — **DONE** (private-`VirtualAlloc`; phys-aliasing deferred,
    only needed by UE4 MallocBinned3, not this Unity title).
 3. ~~Guest `%fs` TLS~~ — **DONE** (FSGSBASE + VEH re-apply).
-4. ~~Guest allocator (reserved-page lazy commit) + worker-thread ABI/%fs TLS~~ — **DONE** (PR #628).
-5. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
+4. ~~Guest allocator lazy-commit + worker-thread ABI/%fs TLS~~ — **DONE** (#628).
+5. ~~Wire the Vulkan renderer on Windows~~ — **DONE** (#655: builds + initializes).
+6. ~~Reserve alignment > 64 KiB + worker-thread stack registration~~ — **DONE** (#658).
+7. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
    and now runtime-exercised through init; **XMM/float args are still not converted** (e.g. some libc
    formatters / `printf`-family) — add float-arg conversion when a title needs it.
-6. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
+8. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
    current stack; a true stack-overflow fault still needs a guard-page/dedicated-stack story (Linux
    uses `sigaltstack`). The `__builtin_longjmp` change fixed the cross-frame-unwind crash; this is the
    separate genuine-overflow case. Also: `PROSPER_CRASHPEEK` faults on Windows (the IL2CPP klass
    walker needs the same `guest_readable` guards the Linux path has).
-7. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
+9. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
    and so route correctly through the trampoline, but confirm none are raw host functions relying on
    host-ABI arg passing.
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -5,6 +5,13 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE   // pthread_getattr_np
 #endif
+#ifdef _WIN32
+// Must precede any header that transitively includes windows.h (e.g. winpthreads <pthread.h>) so
+// GetCurrentThreadStackLimits (needs _WIN32_WINNT >= 0x0602 / Win8) is declared.
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00
+#endif
+#endif
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "../host/exec_image.hpp"
@@ -22,6 +29,9 @@
 #include <thread>
 #include <atomic>
 #include <condition_variable>
+#ifdef _WIN32
+#include <windows.h>   // GetCurrentThreadStackLimits/GetCurrentThreadId for the guest-thread trampoline
+#endif
 #if defined(__linux__) || defined(__APPLE__)
 #include <sys/mman.h>
 #include <sys/syscall.h>
@@ -500,9 +510,19 @@ extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a
 void* win_thread_trampoline(void* p) {
     auto* ts = (WinThreadStart*)p;
     uint64_t entry = ts->entry; void* arg = ts->arg; free(ts);   // host libc: run on host %fs (before activate)
+    // Register this worker's stack bounds FIRST, keyed by the Windows thread id (== exec_image_win's
+    // cur_tid) so a guest GC that queries its own stack base (GC_register_my_thread / stack scanning —
+    // e.g. Unity's AssetGarbageCollectorHelper) finds real bounds instead of wedging on "Bad stack
+    // base". Mirrors the Linux thread_trampoline's register-first ordering. GetCurrentThreadStackLimits
+    // gives the committed stack range (Win8+).
+    ULONG_PTR stk_lo = 0, stk_hi = 0;
+    GetCurrentThreadStackLimits(&stk_lo, &stk_hi);
+    if (stk_lo && stk_hi > stk_lo)
+        register_thread_stack((uint64_t)GetCurrentThreadId(), (void*)stk_lo, (uint64_t)(stk_hi - stk_lo));
     guest_tls_activate_thread();   // this worker's guest %fs TCB (FSGSBASE); no-op if the gate is off
     void* rv = entry ? (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0) : nullptr;
     tls_dtv_purge_current_thread();
+    unregister_thread_stack((uint64_t)GetCurrentThreadId());   // ids recycle; stale bounds = wrong bounds
     return rv;
 }
 }
@@ -627,7 +647,7 @@ HLE(k_ef_delete)  {
     if (!has_waiters) ef_destroy(e);               // none parked -> free now; else the last waiter frees
     return 0;
 }
-HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits |= a1; pthread_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
+HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; if (sclog()) fprintf(stderr, "[sync2] T%ld EF.set       ef=0x%llx bits|=0x%llx\n", sctid(), (unsigned long long)a0, (unsigned long long)a1); pthread_mutex_lock(&e->m); e->bits |= a1; pthread_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
 HLE(k_ef_clear)   { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits &= a1; pthread_mutex_unlock(&e->m); return 0; }
 // Absolute CLOCK_REALTIME deadline `usec` microseconds from now (for pthread_cond_timedwait
 // on default-attr condvars, which time against CLOCK_REALTIME).
@@ -699,6 +719,9 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
     // expiry returns KERNEL_ERROR_ETIMEDOUT (Kyty EventFlag.cpp / Errno.h 0x8002003C).
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
     uint64_t ret = 0;
+    if (sclog()) fprintf(stderr, "[sync2] T%ld EF.wait.ent  ef=0x%llx pat=0x%llx mode=0x%llx bits=0x%llx\n",
+                         sctid(), (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                         (unsigned long long)e->bits);
     pthread_mutex_lock(&e->m);
     e->waiters++;
     if (a4) {
@@ -725,6 +748,8 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
     pthread_mutex_unlock(&e->m);
     if (last) ef_destroy(e);                        // safe: `res` was copied before the free
     if (a3) *(uint64_t*)(uintptr_t)a3 = res;
+    if (sclog()) fprintf(stderr, "[sync2] T%ld EF.wait.exit ef=0x%llx res=0x%llx ret=0x%llx\n",
+                         sctid(), (unsigned long long)a0, (unsigned long long)res, (unsigned long long)ret);
     return ret;
 }
 HLE(k_ef_poll)    { // (ef, pattern, waitMode, resultPat*)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1319,14 +1319,22 @@ namespace {
     // Reserve (no commit). VirtualAlloc reservations are 64 KiB-aligned, satisfying guest aligns
     // up to 64 KiB; larger alignment is logged and left to the OS base (follow-up).
     void* win_reserve(uint64_t hint, uint64_t len, bool fixed, uint64_t align) {
-        if (align > 0x10000)
-            MLOG("reserve align=0x%llx > 64KiB not honored on Win32 (OS 64KiB base)\n",
-                 (unsigned long long)align);
         if (hint) {
             if (void* p = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE, PAGE_NOACCESS)) return p;
             if (fixed) return nullptr;   // SCE_KERNEL_MAP_FIXED: must be exactly this address
         }
-        return VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE, PAGE_NOACCESS);
+        // VirtualAlloc only guarantees 64 KiB (allocation-granularity) base alignment. Guest allocators
+        // reserve with LARGER alignment (e.g. 0x40000 = 256 KiB) and then compute chunk/metadata offsets
+        // by rounding a pointer DOWN to that alignment — so a base that is 64 KiB- but not 256 KiB-aligned
+        // makes those computations land below the reservation and corrupt/wedge the allocator. Honor a
+        // >64 KiB request by over-reserving len+align and returning the aligned sub-base; commits within
+        // it still succeed (it is one reserved region) and the slack stays reserved (only wasted address
+        // space — trimming a reservation would race a concurrent reserve). CONFIDENCE: HIGH.
+        if (align <= 0x10000)
+            return VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE, PAGE_NOACCESS);
+        void* raw = VirtualAlloc(nullptr, (SIZE_T)(len + align), MEM_RESERVE, PAGE_NOACCESS);
+        if (!raw) return nullptr;
+        return (void*)(((uint64_t)raw + (align - 1)) & ~(align - 1));
     }
     bool win_protect(uint64_t addr, uint64_t len, int hp) {
         DWORD old = 0;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1547,6 +1547,7 @@ HLE(k_ampr_ok) { return 0; }
 namespace {
 std::mutex g_sync_mx;
 std::condition_variable g_sync_cv;
+bool wsynclog() { static int v = getenv("PROSPER_SYNCLOG") ? 1 : 0; return v; }
 }
 
 HLE(k_wait_on_address) {
@@ -1554,6 +1555,9 @@ HLE(k_wait_on_address) {
     auto& raw = *(uint32_t*)(uintptr_t)a0;
     std::atomic_ref<uint32_t> addr(raw);
     uint32_t expected = (uint32_t)a1;
+    if (wsynclog()) fprintf(stderr, "[sync] WAIT.enter addr=0x%llx *addr=0x%x exp=0x%x timo_ptr=0x%llx\n",
+                            (unsigned long long)a0, (unsigned)addr.load(std::memory_order_acquire),
+                            (unsigned)expected, (unsigned long long)a2);
     // Honor the guest timeout by default (#142) — the same fix the Linux futex path got (#139).
     // Previously this global-cv fallback IGNORED the timeout arg and blocked FOREVER while
     // *addr == expected, returning 0 (=signaled), so a Windows-build timed wait could never take its
@@ -1569,15 +1573,21 @@ HLE(k_wait_on_address) {
         auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(us);
         while (addr.load(std::memory_order_acquire) == expected)
             if (g_sync_cv.wait_until(lk, deadline) == std::cv_status::timeout &&
-                addr.load(std::memory_order_acquire) == expected)
+                addr.load(std::memory_order_acquire) == expected) {
+                if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx TIMEOUT\n", (unsigned long long)a0);
                 return 0x80020060ull;   // SCE_KERNEL_ERROR_ETIMEDOUT
+            }
+        if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx woke\n", (unsigned long long)a0);
         return 0;
     }
     while (addr.load(std::memory_order_acquire) == expected) g_sync_cv.wait(lk);
+    if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx woke (untimed)\n", (unsigned long long)a0);
     return 0;
 }
 
 HLE(k_wake_by_address) {
+    if (wsynclog()) fprintf(stderr, "[sync] WAKE       addr=0x%llx *addr=0x%x n=%lld\n",
+                            (unsigned long long)a0, a0 ? *(uint32_t*)(uintptr_t)a0 : 0, (long long)a1);
     std::lock_guard<std::mutex> lk(g_sync_mx);
     int n = a1 ? (int)a1 : INT_MAX;
     if (n == 1) g_sync_cv.notify_one();


### PR DESCRIPTION
Follow-up to the merged Windows renderer wiring (#655). Three Windows-port correctness +
diagnostic changes made while chasing the guest's pre-render stall, plus the stall diagnosis
itself.

1. **Honor guest reserve alignment > 64 KiB.** `sceKernelReserveVirtualRange` callers reserve with
   e.g. 0x40000 (256 KiB) alignment and round pointers down to it for chunk/metadata math; VirtualAlloc
   only guarantees 64 KiB base alignment. Over-reserve `len+align` and return the aligned sub-base
   (commits within the one reserved region still succeed; slack stays reserved). Was a warning before.

2. **Register guest worker-thread stacks + EventFlag logging.** The Windows guest-thread trampoline now
   registers each worker's stack bounds (GetCurrentThreadStackLimits, keyed by GetCurrentThreadId to
   match exec_image_win's cur_tid) before running guest code, so a guest GC that queries its own stack
   base (Unity's AssetGarbageCollectorHelper) finds real bounds — mirroring the Linux thread_trampoline.
   Adds PROSPER_SYNCLOG EventFlag wait/set logging.

3. **Log sceKernelWaitOnAddress waits/wakes.** The Windows WaitOnAddress/WakeByAddress HLE (global
   std::condition_variable) had no logging, so PROSPER_SYNCLOG showed nothing on Windows.

Together (3) revealed the current frontier: with the renderer wired, the Windows guest boots into
Unity engine init and **its job-system worker threads park in sceKernelWaitOnAddress on an array of
per-worker words (44 stuck waits, *addr==exp==0, no timeout) waiting for jobs the blocked dispatcher
never posts** — the same producer/consumer class as the Linux pre-render stall. That deeper bring-up
is the next step; this PR lands the correctness fixes + the diagnostics that pinpoint it.

Scope: all #ifdef _WIN32 / Windows-branch. Linux + macOS unaffected; verified with a local WSL
prosper_core/boot_trace rebuild. CI covers all four platforms. Refs #624.
