### PR TITLE
fix(win): native Win32 futex for sceKernelWaitOnAddress (fixes lost-wakeup boot wedge) + sync diagnostics

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -34,6 +34,11 @@ if(PROSPER_SRC)
   target_compile_definitions(prosper_core PRIVATE PROSPER_GIT_REVISION="${PROSPER_GIT_REVISION}")
   find_package(Threads REQUIRED)
   target_link_libraries(prosper_core PUBLIC Threads::Threads)
+  # Windows: the guest futex HLE (sceKernelWaitOnAddress/WakeByAddress) is backed by the native Win32
+  # WaitOnAddress/WakeByAddressSingle/All, which live in the Synchronization import lib (not kernel32).
+  if(WIN32)
+    target_link_libraries(prosper_core PUBLIC synchronization)
+  endif()
 endif()
 
 # --- tests (agentic-first: self-checking, exit-code = truth) -------------

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -352,13 +352,32 @@ The deep crash after `%fs` TLS was two more Linux-parity gaps (fixed on `port/wi
   rbx=0) on an unrecoverable thread. A `win_thread_trampoline` now marshals the SysV entry through
   `prosper_call_guest_sysv` and activates the worker's guest `%fs` TCB.
 
-### Renderer wired on Windows (#655); the Windows frontier: the Unity GC-helper init handshake
+### Renderer wired (#655); WaitOnAddress lost-wakeup FIXED; frontier: draw submission after VideoOut setup
 
-The live Vulkan renderer now builds + initializes on Windows (#655): the whole GPU/Vulkan translation
+**SOLVED — the pre-render wedge was a lost wakeup in the Windows `sceKernelWaitOnAddress`.** It had been
+backed by ONE global `std::condition_variable` shared across every waited address, so a guest
+`WakeByAddress(n=1)` → `notify_one()` could wake a waiter parked on a DIFFERENT address (it re-checked its
+own word, found it unchanged, re-slept) while the intended waiter was never woken. That randomly lost
+Unity's job/thread startup handshakes → the boot nondeterministically wedged (2 vs ~45 threads, or a
+worker fault). Re-implemented on the **native Win32 futex** (`WaitOnAddress` / `WakeByAddressSingle` /
+`WakeByAddressAll`, needs `-lsynchronization`), a true per-address wait exactly like the Linux
+`FUTEX_WAIT` path — correct `n=1` semantics, no thundering herd. The boot is now **deterministic** and
+goes far deeper: it spawns the full Unity thread ecosystem (13 `AssetGarbageCollectorHelper`,
+`Job.Worker 0-12`, `Background Job.Worker 0-15`, `Loading.AsyncRead`, `BatchDeleteObjects`) and reaches
+**VideoOut display setup** — `RegisterBuffers2`, "display surface: 1920x1080, 3 buffers registered",
+`ConfigureOutput`, `GetOutputStatus`.
+
+Current frontier: from VideoOut setup to actual draw submission + flip. Immediate next blocker seen: an
+unimplemented `libSceSystemService::mPpPxv5CZt4` (returning 0) right after `GetOutputStatus`; implement
+it (and any siblings) and re-check whether the guest starts submitting Dcbs to the now-wired renderer.
+
+(Historical, pre-fix diagnosis retained below for context.)
+
+The live Vulkan renderer builds + initializes on Windows (#655): the whole GPU/Vulkan translation
 layer + `prosper_live_renderer` compile under MinGW (the Vulkan SDK is found via `VULKAN_SDK`), and at
 runtime the live compute + submit renderers register cleanly. With the renderer wired and
 `PROSPER_RENDER=1`, the guest boots into Unity engine init (allocates its pools, spawns
-`AssetGarbageCollectorHelper` threads) and then **idle-waits** (0% CPU) — it does NOT yet submit draws.
+`AssetGarbageCollectorHelper` threads) and (before the fix above) **idle-waited** (0% CPU).
 
 Diagnosis (via `PROSPER_SYNCLOG` WaitOnAddress logging + `PROSPER_GUEST_ARGS=-force-gfx-direct
 PROSPER_RENDER=1` + gdb thread inventory). **A thread-inventory diff vs Linux localizes the stall

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -372,10 +372,23 @@ precisely — it is NOT the later job-dispatch loop, it is the very first GC-hel
   total wakes then silence. None of `Job.Worker*`/`PreloadManager`/`AsyncRead`/`GfxFlipThread` is ever
   created.
 
-So the `AssetGarbageCollectorHelper` thread (guest entry `eboot+0xbfbac0`) now RUNS on Windows (the
-worker-thread ABI + `%fs` TLS fixes stopped it crashing at `mov 0x38(%rbx)`), but it **fails to complete
-its init handshake / signal the main thread it is ready**, so the main thread never advances to spawn
-the rest of Unity's threads. Next step: trace what that helper does on Windows vs Linux — which
+**Update — the stall is a RACE, and it wedges on a custom semaphore.** With a validated guest-caller +
+thread-id sync log (the `[sync] T<tid> ... caller=0x...` fields), the stuck waits resolve to a
+Unity/Sony **custom counting semaphore**: `mov $-1,%eax; lock xadd %eax,0x8(%rdi); test %eax,%eax; jle
+<slow>` — decrement a job-count at `[obj+8]`, and if it went ≤0 take the `sceKernelWaitOnAddress` slow
+path (sites `eboot+0x18ab088` job-pool and `eboot+0xae1463`). So workers block acquiring jobs the
+producer never releases. Crucially the boot is **nondeterministic**: different runs reach very different
+depths — sometimes only 2 `AssetGarbageCollectorHelper` threads then wedge, sometimes ~45 guest threads
+(much of the Unity set) then wedge, and sometimes a worker hard-faults (exit 139). That variability
+means a **startup race** in the sync/thread path, not a fixed missing tick. The global-`std::condition_variable`
+`WaitOnAddress` is logically correct under its mutex (no lost wakeup even with the 45-thread thundering
+herd), so suspicion falls on thread-startup ordering / the guest's timing assumptions under our slower
+per-call sync. Linux (real per-address futex) never exhibits this and renders 330 frames.
+
+(Historical framing, still true of the early-wedge runs:) the `AssetGarbageCollectorHelper` thread
+(guest entry `eboot+0xbfbac0`) RUNS on Windows (the worker-thread ABI + `%fs` TLS fixes stopped it
+crashing at `mov 0x38(%rbx)`) but on an early-wedge run never signals main ready. Next step: trace what
+that helper does on Windows vs Linux — which
 `WaitOnAddress`/wake or HLE call it diverges on (its own TLS-derived state, or a wake it should send to
 main that never fires). The coarse Windows `WaitOnAddress` (one global `std::condition_variable`; any
 wake re-checks all waiters) is correct under its mutex (no lost-wakeup) but is a candidate to revisit.

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1163,6 +1163,9 @@ void register_kernel_mem_hle() {
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00   // Win10: WaitOnAddress/WakeByAddress* need >= 0x0602 (Win8)
+#endif
 #include <windows.h>
 #include <atomic>
 #include <chrono>
@@ -1587,30 +1590,42 @@ HLE(k_wait_on_address) {
                             (unsigned long)GetCurrentThreadId(),
                             (unsigned long long)a0, (unsigned)addr.load(std::memory_order_acquire),
                             (unsigned)expected, (unsigned long long)a2, (unsigned long long)sync_guest_caller());
-    // Honor the guest timeout by default (#142) — the same fix the Linux futex path got (#139).
-    // Previously this global-cv fallback IGNORED the timeout arg and blocked FOREVER while
-    // *addr == expected, returning 0 (=signaled), so a Windows-build timed wait could never take its
-    // timeout branch. Parse *a2 as uint32 microseconds, wait to that deadline, and return SCE
-    // ETIMEDOUT on expiry. PROSPER_NO_WAIT_TIMEOUT restores infinite waits (parity with Linux).
-    // The 32-bit compare is a shared limitation with the Linux FUTEX_WAIT path (WaitOnAddress can
-    // wait on 1/2/4/8-byte values; only 4 is modeled) — unchanged here.
+    // Back this with the NATIVE Win32 futex (WaitOnAddress/WakeByAddress*, Win8+): a true PER-ADDRESS
+    // wait, exactly like the Linux FUTEX_WAIT path. The previous global-`condition_variable` shared one
+    // cv across every waited address, so WakeByAddress(n=1) -> notify_one() could wake a waiter parked
+    // on a DIFFERENT address (it re-checks its own word, finds it unchanged, re-sleeps) while the
+    // intended waiter was never woken — a lost wakeup that made the boot nondeterministically deadlock.
+    // Native WaitOnAddress blocks while *addr == compare and is woken only by WakeByAddress* on THIS
+    // addr, so n=1 semantics are correct and there is no thundering herd. The 32-bit compare is a
+    // shared limitation with the Linux path (WaitOnAddress supports 1/2/4/8-byte; only 4 is modeled).
     static const bool honor_timeout = getenv("PROSPER_NO_WAIT_TIMEOUT") == nullptr;
-    std::unique_lock<std::mutex> lk(g_sync_mx);
+    ULONGLONG deadline = 0;   // 0 = infinite
     if (a2 && honor_timeout) {
         uint32_t us = *(volatile uint32_t*)(uintptr_t)a2;
-        if (us == 0) us = 1;   // 0 == "poll" -> a minimal wait so we re-check
-        auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(us);
-        while (addr.load(std::memory_order_acquire) == expected)
-            if (g_sync_cv.wait_until(lk, deadline) == std::cv_status::timeout &&
-                addr.load(std::memory_order_acquire) == expected) {
+        ULONGLONG ms = us == 0 ? 1 : (ULONGLONG)((us + 999) / 1000);   // us -> ms, round up; 0 == poll
+        deadline = GetTickCount64() + ms;
+    }
+    volatile uint32_t* wa = (volatile uint32_t*)(uintptr_t)a0;
+    while (*wa == expected) {
+        DWORD wait_ms = INFINITE;
+        if (deadline) {
+            ULONGLONG now = GetTickCount64();
+            if (now >= deadline) {
                 if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx TIMEOUT\n", (unsigned long long)a0);
                 return 0x80020060ull;   // SCE_KERNEL_ERROR_ETIMEDOUT
             }
-        if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx woke\n", (unsigned long long)a0);
-        return 0;
+            wait_ms = (DWORD)(deadline - now);
+        }
+        uint32_t cmp = expected;
+        if (!WaitOnAddress(wa, &cmp, sizeof(cmp), wait_ms) && GetLastError() == ERROR_TIMEOUT) {
+            if (*wa == expected) {
+                if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx TIMEOUT\n", (unsigned long long)a0);
+                return 0x80020060ull;
+            }
+        }
+        // else: woken or spurious — loop re-checks *addr
     }
-    while (addr.load(std::memory_order_acquire) == expected) g_sync_cv.wait(lk);
-    if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx woke (untimed)\n", (unsigned long long)a0);
+    if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx woke\n", (unsigned long long)a0);
     return 0;
 }
 
@@ -1619,10 +1634,12 @@ HLE(k_wake_by_address) {
                             (unsigned long)GetCurrentThreadId(),
                             (unsigned long long)a0, a0 ? *(uint32_t*)(uintptr_t)a0 : 0, (long long)a1,
                             (unsigned long long)sync_guest_caller());
-    std::lock_guard<std::mutex> lk(g_sync_mx);
-    int n = a1 ? (int)a1 : INT_MAX;
-    if (n == 1) g_sync_cv.notify_one();
-    else        g_sync_cv.notify_all();
+    if (!a0) return 0;
+    // Native per-address wake: n==1 wakes ONE waiter on THIS address (correct semaphore-release
+    // semantics), otherwise wake all. No lost wakeup and no global thundering herd (unlike the old
+    // single shared condition_variable).
+    if (a1 == 1) WakeByAddressSingle((PVOID)(uintptr_t)a0);
+    else         WakeByAddressAll((PVOID)(uintptr_t)a0);
     return 0;
 }
 

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1548,6 +1548,34 @@ namespace {
 std::mutex g_sync_mx;
 std::condition_variable g_sync_cv;
 bool wsynclog() { static int v = getenv("PROSPER_SYNCLOG") ? 1 : 0; return v; }
+// Best-effort guest call site of the current HLE call. The Windows import stub `call`s the handler
+// (no frame pointer), so an [rbp+8] walk misses the guest return address; instead scan our stack for
+// the first value in the guest code range (eboot..libc = [0x400000000, 0x700000000)). The guest's
+// `call <stub>` pushed its return address just below, so the first in-range hit is the caller. Coarse
+// (a stack data word could coincidentally look like a guest PC), but good enough to name a wait site.
+uint64_t sync_guest_caller() {
+    uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
+    for (int i = 0; i < 160; i++) {
+        uint64_t v = sp[i];
+        if (v < 0x400000000ull || v >= 0x600000000ull) continue;   // guest MODULES only (exclude 0x6.. import stubs)
+        if ((v & 0xfff) < 8) continue;                             // keep the 6-byte look-back on v's page
+        // A stack word in the guest range may be data, not a return address, and could point at an
+        // UNMAPPED gap between modules — so confirm the page is committed+readable before dereferencing
+        // (this scan runs on every logged wait; an unguarded read faulted intermittently).
+        MEMORY_BASIC_INFORMATION mbi;
+        if (!VirtualQuery((LPCVOID)(uintptr_t)v, &mbi, sizeof mbi) || mbi.State != MEM_COMMIT) continue;
+        const DWORD rd = PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE
+                       | PAGE_WRITECOPY | PAGE_EXECUTE_WRITECOPY;
+        if (!(mbi.Protect & rd) || (mbi.Protect & PAGE_GUARD)) continue;
+        const uint8_t* p = (const uint8_t*)(uintptr_t)v;
+        // Accept only a real return address: the preceding instruction must be a CALL.
+        if (p[-5] == 0xE8) return v;                                        // call rel32
+        if (p[-2] == 0xFF && ((p[-1] >> 3) & 7) == 2) return v;             // call r/m (2-byte)
+        if (p[-3] == 0xFF && ((p[-2] >> 3) & 7) == 2) return v;             // call r/m (3-byte, modrm+sib/disp8)
+        if (p[-6] == 0xFF && ((p[-5] >> 3) & 7) == 2) return v;             // call r/m (rip-rel disp32)
+    }
+    return 0;
+}
 }
 
 HLE(k_wait_on_address) {
@@ -1555,9 +1583,10 @@ HLE(k_wait_on_address) {
     auto& raw = *(uint32_t*)(uintptr_t)a0;
     std::atomic_ref<uint32_t> addr(raw);
     uint32_t expected = (uint32_t)a1;
-    if (wsynclog()) fprintf(stderr, "[sync] WAIT.enter addr=0x%llx *addr=0x%x exp=0x%x timo_ptr=0x%llx\n",
+    if (wsynclog()) fprintf(stderr, "[sync] T%lu WAIT.enter addr=0x%llx *addr=0x%x exp=0x%x timo_ptr=0x%llx caller=0x%llx\n",
+                            (unsigned long)GetCurrentThreadId(),
                             (unsigned long long)a0, (unsigned)addr.load(std::memory_order_acquire),
-                            (unsigned)expected, (unsigned long long)a2);
+                            (unsigned)expected, (unsigned long long)a2, (unsigned long long)sync_guest_caller());
     // Honor the guest timeout by default (#142) — the same fix the Linux futex path got (#139).
     // Previously this global-cv fallback IGNORED the timeout arg and blocked FOREVER while
     // *addr == expected, returning 0 (=signaled), so a Windows-build timed wait could never take its
@@ -1586,8 +1615,10 @@ HLE(k_wait_on_address) {
 }
 
 HLE(k_wake_by_address) {
-    if (wsynclog()) fprintf(stderr, "[sync] WAKE       addr=0x%llx *addr=0x%x n=%lld\n",
-                            (unsigned long long)a0, a0 ? *(uint32_t*)(uintptr_t)a0 : 0, (long long)a1);
+    if (wsynclog()) fprintf(stderr, "[sync] T%lu WAKE       addr=0x%llx *addr=0x%x n=%lld caller=0x%llx\n",
+                            (unsigned long)GetCurrentThreadId(),
+                            (unsigned long long)a0, a0 ? *(uint32_t*)(uintptr_t)a0 : 0, (long long)a1,
+                            (unsigned long long)sync_guest_caller());
     std::lock_guard<std::mutex> lk(g_sync_mx);
     int n = a1 ? (int)a1 : INT_MAX;
     if (n == 1) g_sync_cv.notify_one();


### PR DESCRIPTION
The Windows `sceKernelWaitOnAddress`/`WakeByAddress` HLE was backed by ONE global `std::condition_variable` shared across every waited address, so a guest `WakeByAddress(n=1)` → `notify_one()` could wake a waiter parked on a **different** address (which re-checks its own unchanged word and re-sleeps) while the intended waiter is never woken — a lost wakeup that made the Windows boot **nondeterministically deadlock** (2 vs ~45 guest threads, or a worker fault).

**Fix:** re-implement on the **native Win32 futex** — `WaitOnAddress` / `WakeByAddressSingle` / `WakeByAddressAll` (needs `-lsynchronization`), a true per-address wait exactly like the Linux `FUTEX_WAIT` path (correct n=1 semantics, no thundering herd).

**Result:** the Windows boot is now **deterministic** and reaches far deeper — it spawns the full Unity thread ecosystem (13 AssetGC helpers, Job.Worker 0–12, Background Job.Worker 0–15, Loading.AsyncRead, BatchDeleteObjects) and reaches **VideoOut display setup** (`RegisterBuffers2`, "display surface: 1920x1080, 3 buffers registered", `ConfigureOutput`). Next blocker: an unimplemented `libSceSystemService` function on the path to draw submission.

Also lands the diagnostics that found it: `PROSPER_SYNCLOG` WaitOnAddress/WakeByAddress logging with thread-id + a VirtualQuery-guarded validated guest caller. Windows-only (`#else` block + WIN32 CMake); Linux/macOS unaffected (verified WSL rebuild). Refs #624.