### PR TITLE
fix(win): wake GPU-label waiters via native WakeByAddress (GPU->CPU futex wake was a no-op)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1606,6 +1606,10 @@ HLE(k_wait_on_address) {
         deadline = GetTickCount64() + ms;
     }
     volatile uint32_t* wa = (volatile uint32_t*)(uintptr_t)a0;
+    // Register as a futex waiter so the GPU command processor's RELEASE_MEM/EOP wake (wake_label_waiters,
+    // which only fires when g_waiters>0) reaches this thread. RAII so every return path unregisters.
+    futex_wait_enter();
+    struct WaiterGuard { ~WaiterGuard() { futex_wait_exit(); } } _waiter_guard;
     while (*wa == expected) {
         DWORD wait_ms = INFINITE;
         if (deadline) {

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -6,6 +6,14 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include "../host/posix_shim.hpp"
+#elif defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00   // WakeByAddressAll needs >= 0x0602 (Win8)
+#endif
+#include <windows.h>   // native futex: WakeByAddressAll (pairs with WaitOnAddress in hle_kernel_mem.cpp)
 #endif
 
 namespace prosper {
@@ -18,6 +26,14 @@ void futex_wake(uint64_t addr, int n) {
 #if defined(__linux__) || defined(__APPLE__)
     if (!addr) return;
     prosper_futex_wake((uint32_t*)(uintptr_t)addr, n > 1);
+#elif defined(_WIN32)
+    // Native Win32 futex wake, pairing with sceKernelWaitOnAddress's WaitOnAddress (hle_kernel_mem.cpp).
+    // The GPU command processor calls this from RELEASE_MEM/EOP to wake a guest render/producer thread
+    // parked on the label the GPU just wrote — without it the guest's WaitOnAddress never wakes on
+    // Windows and rendering wedges after the first submit. Wake ALL (n is a hint; label waiters are few).
+    if (!addr) return;
+    (void)n;
+    WakeByAddressAll((PVOID)(uintptr_t)addr);
 #else
     (void)addr; (void)n;
 #endif


### PR DESCRIPTION
`futex_wake()` — called by the GPU command processor's `RELEASE_MEM`/EOP (`wake_label_waiters`) to wake a guest render/producer thread parked on the label the GPU just wrote — was a **no-op on Windows** (`#else (void)addr;`). With `sceKernelWaitOnAddress` now on the native Win32 futex (#663), the GPU-side wake must use the native `WakeByAddressAll` on the same address, or a guest thread waiting on a GPU-written label never wakes and rendering wedges after submit.

Implements it (native `WakeByAddressAll`), and registers the native `k_wait_on_address` as a futex waiter (`futex_wait_enter/exit`, RAII) so `wake_label_waiters`' `g_waiters>0` guard doesn't skip the wake.

Necessary correctness fix for the GPU→CPU sync path on Windows (currently the guest reaches shader setup + first submit; the remaining pre-draw wall is a separate GPU-fence dependency being chased). Windows-only; Linux/macOS unchanged (verified WSL rebuild). Refs #624.