### PR TITLE
Fix intermittent Dead Cells texture-memory crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,9 @@ indices 0..3 to all four clip-space corners while the guest submits count 3. #65
 Vulkan strip and invokes the fourth procedural vertex for the observed no-VB form. A 420-frame native run
 then showed full-screen moving gameplay with no accumulated tutorial glyphs.
 
-Cross-title breadth has advanced: *Dead Cells* now starts reliably after the AGC resource-name fix (#544), its
+Cross-title breadth has advanced: *Dead Cells* now starts reliably after both AGC resource-registration output
+queries were implemented (#544, #660). The old success stubs left stack data in the max-name and required-memory
+outputs, causing intermittent multi-gigabyte stack or texture-pool allocations. Its
 exercised NGS2 lifecycle returns initialized sizes/handles/state and silent output (#554), and a late render
 window reaches the Evil Empire splash. #545 was software-render throughput, not a guest deadlock: synchronous
 3840×2160 llvmpipe rendering stretches its ~13,000-submit startup into minutes.

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -1,6 +1,6 @@
 # Dead Cells graphics status and regression workflow
 
-Last updated: 2026-07-13
+Last updated: 2026-07-14
 
 The operational route and selector reference is
 [`../scripts/dead-cells/README.md`](../scripts/dead-cells/README.md). The gameplay-composition bug
@@ -16,6 +16,12 @@ first color export from shaders that emit MRT3..MRT0; MRT0 now feeds the backend
 The same change set recovers a separately dropped format-copy dispatch by resolving its directly placed
 destination buffer descriptor at s4.
 
+Startup and progression are stable after implementing both AGC resource-registration output queries. The former
+success-only `QueryResourceRegistrationUserMemoryRequirements` stub left Dead Cells' stack value untouched and
+occasionally requested a multi-gigabyte texture-pool allocation (#660). A native-speed fresh-save matrix improved
+from 7/10 gameplay matches, two texture-memory crashes, and one timeout to 20/20 gameplay matches with no crash or
+timeout. The issue's 120-second live-render screenshot route also completes without the former lavapipe fault.
+
 The original mostly-white repeated-block image is not the current bug. It was caused by beginning diagnostic
 rendering after a required 642x362 temporal render-target producer had already run (#586). Do not use a
 35-second sparse-render screenshot as a color oracle.
@@ -29,7 +35,9 @@ The important fixes already on `master` are:
 - capture v8 checkpoints complete color RTT state and persistent depth/stencil planes, including a source-output
   hash oracle (#569);
 - directly placed compute buffer destinations resolve, so the current scene realizes all eight dispatches (#626);
-- MRT0, rather than the first-emitted non-color G-buffer plane, supplies the visible fragment output (#626).
+- MRT0, rather than the first-emitted non-color G-buffer plane, supplies the visible fragment output (#626);
+- AGC resource-registration memory requirements always initialize their output instead of leaking stack data into
+  the game's texture-pool allocation size (#660).
 
 The producer-complete post-#626 checkpoint realizes every semantic draw and all eight dispatches. Descriptor
 validation has not identified a missing or undersized binding in the exercised frame.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1355,6 +1355,27 @@ HLE(agc_driver_get_resource_registration_max_name_length) {
     return 0;
 }
 
+// sceAgcDriverQueryResourceRegistrationUserMemoryRequirements. The API returns the opaque backing
+// store required by ResourceRegistration::init for the requested resource and owner capacities.
+// Prosper keeps the registry on the host and does not consume this guest block, so use a stable,
+// conservative layout estimate rather than exposing host implementation details. Most importantly,
+// always initialize the size_t output: the former success stub left Dead Cells' stack poison in it,
+// intermittently turning this allocation into a multi-gigabyte texture-pool request (#660).
+// CONFIDENCE: HIGH on ABI/output/error; MED on opaque record sizes (irrelevant until init consumes it).
+HLE(agc_driver_query_resource_registration_user_memory_requirements) {
+    if (!a0)
+        return (uint64_t)(int64_t)(int32_t)0x80D19005u;
+
+    constexpr uint64_t kHeaderBytes = 0x100;
+    constexpr uint64_t kResourceBytes = 0x40;
+    constexpr uint64_t kOwnerBytes = 0x20;
+    constexpr uint64_t kAlignment = 0x40;
+    const uint64_t required = kHeaderBytes + (uint32_t)a1 * kResourceBytes
+                            + (uint32_t)a2 * kOwnerBytes;
+    *(uint64_t*)(uintptr_t)a0 = (required + kAlignment - 1) & ~(kAlignment - 1);
+    return 0;
+}
+
 // sceAgcCbDispatch (NID k3GhuSNmBLU) — compute dispatch.
 // The authoritative PS5 3.20 export name is sceAgcCbDispatch, and its ABI is
 // (dcb, thread_count_x, thread_count_y, thread_count_z, dispatch_modifier). Dead Cells' bound
@@ -1376,6 +1397,7 @@ HLE(agc_cb_dispatch) {  // (buf, thread_count_x, thread_count_y, thread_count_z,
 void register_agc_hle() {
     #define RN(nid, fn) Hle::register_fn(nid, (HleFn)(fn), nid)
     RN("f3dg2CSgRKY", agc_create_shader);   // sceAgcCreateShader — populates the shader registry
+    RN("AOLcoIkQDgM", agc_driver_query_resource_registration_user_memory_requirements);
     RN("uJziRsODk1c", agc_driver_get_resource_registration_max_name_length);
     RN("V++UgBtQhn0", agc_get_data_packet_payload);          // data packet -> register-bank payload
     RN("n2fD4A+pb+g", agc_cb_set_sh_register_range_direct);  // SET_SH_REG range packet

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -349,7 +349,7 @@ const char* const kAgcNids[] = {
     "IxYiarKlXxM",   // sceAgcDmaDataPatchSetDstAddressOrOffset — observe-only (packet now gets valid ptrs, #117)
     // Dead Cells resource-registration startup path (#539). These trace entries preserve the original
     // six arguments, which the generic unimplemented stub cannot do because it replaces a0 with the
-    // import index. The max-name-length query is overridden by its real handler in hle_agc.
+    // import index. The two output queries are overridden by real handlers in hle_agc.
     "AOLcoIkQDgM",   // sceAgcDriverQueryResourceRegistrationUserMemoryRequirements
     "F0Y42t-3e18",   // sceAgcDriverInitResourceRegistration
     "U9ueyEhSkF4",   // sceAgcDriverRegisterDefaultOwner (shadPS4 symbol map)

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -37,10 +37,21 @@ int main() {
     auto setidx = Hle::lookup("GIIW2J37e70");   // GraphicsDcbSetIndexSize
     auto draw   = Hle::lookup("Yw0jKSqop+E");   // GraphicsDcbDrawIndexAuto
     auto submit = Hle::lookup("UglJIZjGssM");   // GraphicsDriverSubmitDcb
+    auto regmem = Hle::lookup("AOLcoIkQDgM");   // QueryResourceRegistrationUserMemoryRequirements
     auto maxname = Hle::lookup("uJziRsODk1c");   // sceAgcDriverGetResourceRegistrationMaxNameLength
-    CHECK(reset && setcx && setidx && draw && submit && maxname,
+    CHECK(reset && setcx && setidx && draw && submit && regmem && maxname,
           "AGC Dcb, submit, and resource-registration functions registered");
-    if (!(reset && setcx && setidx && draw && submit && maxname)) { printf("== FAIL ==\n"); return 1; }
+    if (!(reset && setcx && setidx && draw && submit && regmem && maxname)) { printf("== FAIL ==\n"); return 1; }
+
+    uint64_t registration_bytes = 0x7a2a67fe6900ull;
+    CHECK(regmem((uint64_t)(uintptr_t)&registration_bytes, 0x2000, 0x38, 0, 0, 0) == 0,
+          "resource-registration memory query returned OK");
+    CHECK(registration_bytes == 0x80800,
+          "resource-registration memory query replaced the poisoned size deterministically");
+    CHECK((registration_bytes & 0x3f) == 0 && registration_bytes < 0x100000,
+          "resource-registration memory requirement is aligned and bounded");
+    CHECK((int64_t)regmem(0, 0x2000, 0x38, 0, 0, 0) < 0,
+          "resource-registration memory query rejects a null output");
 
     uint32_t max_name_length = 0xdeadbeefu;
     CHECK(maxname((uint64_t)(uintptr_t)&max_name_length, 0, 0, 0, 0, 0) == 0,


### PR DESCRIPTION
## Summary

- implement `sceAgcDriverQueryResourceRegistrationUserMemoryRequirements` instead of returning success with an untouched output
- return a deterministic, aligned compatibility backing size derived from resource/owner capacities
- add a poisoned-output raw-NID regression and update Dead Cells stability documentation

## Root cause

Dead Cells passes an uninitialized stack slot to `AOLcoIkQDgM`, then immediately uses the returned `size_t` as a texture-pool allocation size. The generic success stub did not write the output.

In the captured failure the untouched slot was `0x7a2a67fe6900`; the game's allocator used its low 32 bits and requested `0x67fe6900` bytes (about 1.74 GiB), producing the intermittent `Maximum texture memory reached` error and subsequent libc null fault.

## Validation

- native-speed fresh-save gameplay route: 20/20 matched in 30-31 seconds
- pre-fix baseline: 7/10 gameplay, 2/10 texture-memory crash, 1/10 timeout
- exact #660 live-screenshot route: 120/120 screenshots, 39 pixel-distinct frames, no texture error or lavapipe fault
- `ctest --test-dir prosper/build-linux --output-on-failure`: 92/92 passed
- snapshot guard:
  - Messenger: 24,318 colors >= 5,000
  - Dead Cells: 1,701 colors >= 1,500

The synchronous llvmpipe route still delays wall-clock menu inputs and finishes this 120-second sample at the main menu; input/checkpoint robustness under slow rendering remains tracked by #302.

Fixes #660