### PR TITLE
Fix Windows VEH recovery entry ABI

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -408,6 +408,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_writer_provenance PRIVATE prosper_core)
   add_test(NAME writer_provenance_ranges COMMAND test_writer_provenance)
 
+  # The init-fault report must survive a wild/null faulting RIP (#128). On Windows this also drives
+  # the VEH recovery thunk and asserts its compiled-helper call obeys the Microsoft-x64 ABI (#633).
+  add_executable(test_initfault_dump tests/test_initfault_dump.cpp)
+  target_link_libraries(test_initfault_dump PRIVATE prosper_core)
+  add_test(NAME initfault_dump_survives COMMAND test_initfault_dump)
+
   # Windows guest-execution substrate (exec_image_win.cpp): build boot_trace so the whole boot path
   # links (proves the substrate + SysV-ABI HLE boundary resolve). No evdev/Vulkan here. The guest boot
   # itself is not yet verified on Windows — see docs/PORTING.md "Windows".
@@ -458,11 +464,6 @@ if(TARGET prosper_core)
       add_test(NAME trap_identifies_imports
                COMMAND test_trap_linux "${GAME_DUMP}")
     endif()
-
-    # The init-fault report must survive a wild/null faulting rip (#128). No game dump needed.
-    add_executable(test_initfault_dump tests/test_initfault_dump.cpp)
-    target_link_libraries(test_initfault_dump PRIVATE prosper_core)
-    add_test(NAME initfault_dump_survives COMMAND test_initfault_dump)
 
     add_executable(test_boot_linux tests/test_boot_linux.cpp)
     target_link_libraries(test_boot_linux PRIVATE prosper_core)

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -25,6 +25,12 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
 // Install the fault handler for genuine guest faults during a run.
 void install_trap_handler();
 
+#ifdef _WIN32
+// Test diagnostic: RSP&15 immediately before the recovery thunk calls its compiled MS-x64 helper.
+// A valid Microsoft-x64 call site is 0; -1 means the thunk has not run yet.
+int recovery_thunk_call_rsp_mod16();
+#endif
+
 // Install a per-thread alternate signal stack (so the fault handler survives a guest stack overflow).
 // The main thread gets one via install_trap_handler(); worker threads call this in their trampoline.
 void install_sigaltstack();

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -229,7 +229,32 @@ namespace {
         return true;
     }
 
-    __attribute__((noinline)) void veh_recover() { __builtin_longjmp(t_jb, 1); }   // runs on the faulting thread
+    // The VEH resumes at this assembly thunk instead of entering a compiled function directly. Its
+    // entry contract is deliberately not a normal call frame: RSP is 16-byte aligned and there is no
+    // return address. The thunk allocates the Microsoft-x64 32-byte home area, then makes a normal,
+    // aligned call into the compiled helper. __builtin_longjmp never returns across the foreign guest
+    // frames, so the missing caller frame is immaterial. The recorded alignment makes the contract
+    // regression-testable on Windows rather than relying on current compiler tolerance (#633).
+    extern "C" {
+        volatile uint64_t prosper_veh_recover_call_rsp_mod16 = ~uint64_t{0};
+        void prosper_veh_recover_thunk();
+    }
+    extern "C" __attribute__((noinline, noreturn)) void prosper_veh_recover_longjmp() {
+        __builtin_longjmp(t_jb, 1);
+        __builtin_unreachable();
+    }
+    __asm__(
+        ".text\n"
+        ".p2align 4\n"
+        ".globl prosper_veh_recover_thunk\n"
+        "prosper_veh_recover_thunk:\n"
+        "    subq $32, %rsp\n"       // MS-x64 shadow space; preserves 16-byte call-site alignment
+        "    movq %rsp, %rax\n"
+        "    andq $15, %rax\n"
+        "    movq %rax, prosper_veh_recover_call_rsp_mod16(%rip)\n"
+        "    callq prosper_veh_recover_longjmp\n"
+        "    ud2\n"
+    );
 
     // Tracked-mapping state probe for the lazy-commit fault path (defined in hle_kernel_mem.cpp):
     // 0 = untracked/gap, 1 = reserved-but-uncommitted, 2 = committed.
@@ -287,11 +312,10 @@ namespace {
         g_rax=c->Rax; g_rbx=c->Rbx; g_rcx=c->Rcx; g_rdx=c->Rdx; g_rsi=c->Rsi; g_rdi=c->Rdi;
         g_rbp=c->Rbp; g_rsp=c->Rsp; g_r8=c->R8; g_r9=c->R9; g_r10=c->R10; g_r11=c->R11;
         g_r12=c->R12; g_r13=c->R13; g_r14=c->R14; g_r15=c->R15;
-        // Redirect execution to veh_recover (which longjmps): calling longjmp directly out of a VEH
-        // is unsafe, so resume the thread at veh_recover on its current stack. 16-align the stack for
-        // the ABI. CONFIDENCE: MED — validated design, unverified at runtime on Windows.
+        // Resume at the explicit recovery thunk. Its entry contract is RSP%16==0; it creates the
+        // MS-x64 shadow space and a normal call frame before entering compiled code.
         c->Rsp &= ~(uint64_t)0xf;
-        c->Rip = (DWORD64)(uintptr_t)&veh_recover;
+        c->Rip = (DWORD64)(uintptr_t)&prosper_veh_recover_thunk;
         return EXCEPTION_CONTINUE_EXECUTION;
     }
 } // namespace
@@ -338,6 +362,11 @@ void install_trap_handler() {
     if (installed) return;
     installed = true;
     AddVectoredExceptionHandler(1 /*first*/, veh);
+}
+
+int recovery_thunk_call_rsp_mod16() {
+    return prosper_veh_recover_call_rsp_mod16 == ~uint64_t{0}
+         ? -1 : (int)prosper_veh_recover_call_rsp_mod16;
 }
 
 // Diagnostics that need Linux perf_event / int3 patching are unavailable on Windows.

--- a/prosper/tests/test_initfault_dump.cpp
+++ b/prosper/tests/test_initfault_dump.cpp
@@ -18,6 +18,15 @@ int main() {
         printf("  [FAIL] wild init fns were counted as succeeded (ok=%zu)\n", ok);
         return 1;
     }
+#ifdef _WIN32
+    int call_alignment = prosper::recovery_thunk_call_rsp_mod16();
+    if (call_alignment != 0) {
+        printf("  [FAIL] recovery thunk called compiled code with RSP%%16=%d (expected 0)\n",
+               call_alignment);
+        return 1;
+    }
+    printf("  [ok]   recovery thunk provided aligned MS-x64 shadow-space call frame\n");
+#endif
     printf("  [ok]   wild + null init fns tolerated; the fault report did not kill the process\n");
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## What changed

- resume Windows VEH recovery through an explicit assembly thunk
- allocate the Microsoft x64 32-byte shadow space and preserve call-site alignment before entering compiled code
- expose a narrow alignment diagnostic and run the existing init-fault recovery test on Windows

## Root cause

The VEH previously redirected `RIP` directly into a compiled C++ function after forcing `RSP` to 16-byte alignment. A normal Microsoft x64 function entry instead expects a return-address-adjusted stack (`RSP % 16 == 8`) and caller-provided shadow space. The old path therefore depended on compiler tolerance and could corrupt recovery state.

## Validation

- Windows MinGW Debug full build
- Windows CTest: 59/59 passed
- Linux Release full build
- Linux CTest: 92/92 passed
- inspected generated thunk disassembly to verify the 32-byte allocation and normal `call`

Fixes #633