### PR TITLE
Forward guest stack arguments through HLE import bridge

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -414,6 +414,21 @@ if(TARGET prosper_core)
   target_link_libraries(test_initfault_dump PRIVATE prosper_core)
   add_test(NAME initfault_dump_survives COMMAND test_initfault_dump)
 
+  # Generated guest->host import boundary: preserve all register args, stack args 7-9, return value,
+  # and ABI stack alignment. Windows exercises SysV->Microsoft-x64; Linux also drives the FS-swap path.
+  add_executable(test_hle_stack_args tests/test_hle_stack_args.cpp)
+  target_link_libraries(test_hle_stack_args PRIVATE prosper_core)
+  add_test(NAME hle_stack_args COMMAND test_hle_stack_args)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_test(NAME hle_stack_args_guest_fs COMMAND test_hle_stack_args --guest-fs)
+  endif()
+
+  # End-to-end AGC submit plus fixed args 7-9 in ReleaseMem/WaitRegMem. This is cross-platform so
+  # Windows validates the real fence builders behind the generated import-ABI conformance test.
+  add_executable(test_agc_submit tests/test_agc_submit.cpp)
+  target_link_libraries(test_agc_submit PRIVATE prosper_core)
+  add_test(NAME agc_submit_to_gpustate COMMAND test_agc_submit)
+
   # Windows guest-execution substrate (exec_image_win.cpp): build boot_trace so the whole boot path
   # links (proves the substrate + SysV-ABI HLE boundary resolve). No evdev/Vulkan here. The guest boot
   # itself is not yet verified on Windows — see docs/PORTING.md "Windows".
@@ -494,12 +509,6 @@ if(TARGET prosper_core)
     add_executable(test_agc_dcb tests/test_agc_dcb.cpp)
     target_link_libraries(test_agc_dcb PRIVATE prosper_core)
     add_test(NAME agc_dcb_pm4 COMMAND test_agc_dcb)
-
-    # End-to-end AGC submit: build a Dcb via the HLE fns -> sceAgcDriverSubmitDcb -> CommandProcessor
-    # folds it into a GpuState. Locks in the "first real command buffer executes" milestone.
-    add_executable(test_agc_submit tests/test_agc_submit.cpp)
-    target_link_libraries(test_agc_submit PRIVATE prosper_core)
-    add_test(NAME agc_submit_to_gpustate COMMAND test_agc_submit)
 
     # libSceVideoOut: query/config functions return real 1080p60 values + swapchain-scaffolding
     # display-buffer registry records the game's registered framebuffers.

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -296,14 +296,14 @@ This is exactly the hard sub-problem flagged above for both Windows and macOS. P
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
 trap-and-emulate of `%fs:` operands is in-house technology.
 
-## Windows port status (2026-07-13) — the guest now BOOTS through module init into guest code
+## Windows port status (2026-07-14) — first GPU fence fixed; IL2CPP init parity is next
 
-The foundation (below) was compile-verified via MinGW-w64; since then a **Windows host has
-runtime-verified the boot**. The guest now links its modules, runs its module-init functions,
-reaches the real entry point, and executes deep guest code — stopping only at the confirmed
-**guest `%fs` TLS wall** (details below). `boot_trace.exe` goes from "crash at the first init fn"
-to a full `RUN ENDED` report. Three runtime bugs were fixed to get here (commits on
-`port/windows-core`):
+The native MinGW build now links and initializes the live Vulkan renderer, boots The Messenger through
+Unity asset loading, emits a correct first GPU fence, and completes SubmitDcb #1. The guest `%fs`,
+threading, positioned-I/O, WaitOnAddress, VEH, and integer ABI foundations below are runtime-verified.
+The current blocker is #673: Windows `il2cpp_init("IL2CPP Root Domain")` returns false, leaving an
+Il2CppClass global null; once the corrected fence releases the render thread, generated code faults on
+that null before SubmitDcb #2. Linux initializes the same path and reaches repeated draw submissions.
 
 - **Direct/flexible-memory HLE ported to Win32** (`hle_kernel_mem.cpp` `#else` block). The pool
   bookkeeping + VA tracker are copied verbatim from POSIX; mappings are backed by private
@@ -376,19 +376,19 @@ thread-safe on a shared fd, full-read loop for the PS5 full-count contract) — 
 also loop now. (`libSceSystemService::mPpPxv5CZt4` = `sceSystemServiceGetHdrToneMapLuminance` is a benign
 HDR stub returning 0, tracked in #664 — not a blocker.)
 
-### Current frontier: the GPU EOP-completion handshake (first rendered frame)
+### GPU stack-argument fence fields — SOLVED (#672); current frontier: IL2CPP initialization (#673)
 
-With #663 + #665 the guest now **streams assets and drives the GPU command stream**: it builds AGC
-command buffers and submits, and the executor decodes real PM4 — including `WriteData`, **`ReleaseMem`
-(EOP label write)** and **`WaitRegMem` (wait-for-memory)**. It then plateaus (no `[render] frame N` yet):
-the guest submits a Dcb and waits (CPU-side `WaitOnAddress`) for that submission's **GPU end-of-pipe
-completion** before building the next frame. Getting the first frame is now a GPU-executor question:
-confirm the Windows executor folds the submitted Dcb and DELIVERS the EOP completion (the label write +
-waking the guest's waiter / the flip-completion equeue event) — the same lost-semaphore/EOP-delivery
-class Linux solved in #236 ("deliver every GPU EOP completion, coalesce=false"). The EOP + vblank pump
-threads are cross-platform `std::thread`s, so the machinery exists; verify it actually fires on Windows
-for the guest's submitted work. Diagnostics: `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode), `PROSPER_EVLOG`
-(`[ev]` equeue/flip/EOP events), `PROSPER_SYNCLOG`.
+The EOP machinery was working; the Windows import trampoline dropped guest stack arguments 7-9. AGC's
+ReleaseMem/WaitRegMem handlers then decoded compiler shadow-space garbage as `data_sel`, `data`,
+`reference`, and `mask`, making the first fence impossible to satisfy. The trampoline now forwards those
+arguments into the standard Microsoft-x64 call slots, Linux's guest-FS stub forwards the same three args,
+and fixed-arity AGC handlers use explicit parameters instead of `__builtin_frame_address` offsets.
+
+Native validation now matches Linux exactly: `ReleaseMem data_sel=2 data=1`, followed by
+`WaitRegMem ref=1 mask=ffffffff`; the `NOT satisfied` message is gone and SubmitDcb #1 completes. Five
+Windows runs then fail consistently at `Il2cpp+0x17d64b` because `il2cpp_init` had already returned false
+and an Il2CppClass global at `Il2cpp+0x268c878` is null. That distinct initialization-parity problem is
+tracked in #673; do not mask the null or reopen the solved fence-field investigation.
 
 (Historical, pre-fix diagnosis retained below for context.)
 
@@ -450,35 +450,28 @@ granularity); and `PROSPER_CRASHPEEK` guards.
   `__attribute__((sysv_abi))` on handlers. The attribute route was tried and **abandoned**: on MinGW
   it conflicts with SEH-based C++ exception unwinding (`.seh_handlerdata used outside of .seh_proc
   block`) and cannot be applied to 537 STL-using handlers. Instead `emit_impl` emits a trampoline that
-  converts the guest's SysV integer args (`rdi rsi rdx rcx r8 r9`) to MS x64 (`rcx rdx r8 r9`,
-  `[rsp+0x20]`, `[rsp+0x28]`, +32B shadow, 16-aligned call) before calling the handler, which stays a
-  plain MS-x64 C++ function. Byte encoding disassembly-verified; the register-move ordering is
-  clobber-safe by construction. `PROSPER_SYSV_ABI` (dispatch.hpp) is now an empty documented marker.
+  converts guest SysV args 1-9 (`rdi rsi rdx rcx r8 r9` plus three guest-stack words) to MS x64
+  (`rcx rdx r8 r9`, stack args 5-9, +32B shadow, aligned call) before calling the handler, which stays a
+  plain MS-x64 C++ function. `test_hle_stack_args` executes the generated stub and verifies every arg,
+  the return value, and handler-entry alignment; `test_agc_submit` pins the real first-fence fields.
 - `guest_tls.cpp` Windows path (guest `%fs` TLS now IMPLEMENTED via FSGSBASE — see above),
   `boot_program.cpp` enabled on Windows, `boot_trace` built on Windows (no evdev/Vulkan), CI
   `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **The Unity GC-helper init handshake — the current frontier.** The renderer is wired (#655) but the
-   guest deadlocks EARLY: it creates only 2 `AssetGarbageCollectorHelper` threads (Linux creates 40+ incl.
-   Job.Workers/PreloadManager/GfxFlipThread and renders 330 frames), then all 3 guest threads park in
-   `sceKernelWaitOnAddress`. The helper (`eboot+0xbfbac0`) runs but never signals the main thread ready.
-   Trace the helper's Windows-vs-Linux divergence (see "the Windows frontier" above) so main advances.
-2. ~~Port the direct/flexible-memory HLE~~ — **DONE** (private-`VirtualAlloc`; phys-aliasing deferred,
-   only needed by UE4 MallocBinned3, not this Unity title).
-3. ~~Guest `%fs` TLS~~ — **DONE** (FSGSBASE + VEH re-apply).
-4. ~~Guest allocator lazy-commit + worker-thread ABI/%fs TLS~~ — **DONE** (#628).
-5. ~~Wire the Vulkan renderer on Windows~~ — **DONE** (#655: builds + initializes).
-6. ~~Reserve alignment > 64 KiB + worker-thread stack registration~~ — **DONE** (#658).
-7. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args are converted
+1. **Restore IL2CPP initialization parity (#673), the current frontier.** Identify the cross-module
+   `il2cpp_init` binding at eboot GOT `+0x2031d10`, compare its return path and required globals with
+   Linux, and make `Il2cpp+0x268c878` valid before use. Do not patch around the null class.
+2. **Preserve physical-offset aliasing in the Windows memory HLE.** Private `VirtualAlloc` is sufficient
+   for Unity, but UE4 MallocBinned3 needs shared backing (`CreateFileMapping`/`MapViewOfFile3`) while
+   respecting Windows' 64 KiB allocation granularity.
+3. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args 1-9 are converted
    and now runtime-exercised through init; **XMM/float args are still not converted** (e.g. some libc
    formatters / `printf`-family) — add float-arg conversion when a title needs it.
-8. **VEH recovery hardening for stack-overflow faults** — recovery resumes on the faulting thread's
-   current stack; a true stack-overflow fault still needs a guard-page/dedicated-stack story (Linux
-   uses `sigaltstack`). The `__builtin_longjmp` change fixed the cross-frame-unwind crash; this is the
-   separate genuine-overflow case. Also: `PROSPER_CRASHPEEK` faults on Windows (the IL2CPP klass
-   walker needs the same `guest_readable` guards the Linux path has).
-9. **Audit the 103 `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
+4. **VEH recovery hardening for genuine stack-overflow faults.** #633 added a tested assembly recovery
+   entry with valid Microsoft-x64 shadow space/alignment, but a truly exhausted guest stack still needs
+   a guard-page/dedicated-stack story (Linux uses `sigaltstack`).
+5. **Audit the `(HleFn)`-cast handlers** — almost all cast targets are `HLE()`-defined handlers
    and so route correctly through the trampoline, but confirm none are raw host functions relying on
    host-ABI arg passing.
 

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -1,9 +1,10 @@
 # Windows native port — handoff (2026-07-14)
 
-The Windows native core boots The Messenger (`PPSA24651`) through the entire OS/runtime/asset/sync
-layer and drives the GPU pipeline; it wedges just before the **first draw command buffer** on a
-**GPU-fence field-decode bug**. This doc hands off that exact next step, with the evidence, a strong
-root-cause lead, and the full build/run/diagnose recipe. Companion: `docs/PORTING.md` ("Windows").
+The Windows native core boots The Messenger (`PPSA24651`) through the OS/runtime/asset/sync layer and
+drives the GPU pipeline. The GPU-fence field bug documented below was fixed in #672: native validation
+now matches Linux and SubmitDcb #1 completes. The newly exposed blocker is #673: `il2cpp_init` returns
+false on Windows, leaving a generated-code class global null before SubmitDcb #2. Companion:
+`docs/PORTING.md` ("Windows").
 
 ## What works today (merged to master)
 
@@ -31,7 +32,7 @@ Merged PRs that got it here (all `#ifdef _WIN32` — Linux/macOS unaffected, CI 
   (was a no-op on Windows) + native wait registers `futex_wait_enter/exit`.
 - **#664** HDR support tracking issue (benign `sceSystemServiceGetHdrToneMapLuminance` stub).
 
-## The current blocker: GPU fence fields are garbage on Windows
+## Resolved blocker (#672): GPU fence fields were garbage on Windows
 
 The guest submits SubmitDcb #1 (a **sync-only** Dcb, 0 draws) and then wedges before submitting the
 first **draw** Dcb. The executor logs:
@@ -54,7 +55,7 @@ On Linux `data_sel=0x2, data=0x1, mask=0xffffffff` (a normal "write 1, wait for 
 writes the wrong value / the wait can never be satisfied → the guest's render thread never proceeds to
 draws. **Rendering is gated entirely on decoding these fence fields correctly.**
 
-### Strong root-cause lead: stack-argument ABI in HLE handlers (args 7+)
+### Confirmed root cause: stack-argument ABI in HLE handlers (args 7+)
 
 The fence builders read their high arguments off the stack via `__builtin_frame_address(0)`:
 
@@ -78,24 +79,17 @@ entry), but for the **guest→host** direction and specifically for **stack-pass
 registers**. The 6 register args are converted correctly by the stub (that's why everything else works);
 only handlers that reach past arg 6 into the guest stack are affected.
 
-### Suggested fix directions (pick one; verify against the Linux field values above)
+### Implemented fix and validation
 
-1. **Forward the guest stack args in the stub, at a known offset.** Extend `emit_sysv_to_ms_prologue`/
-   `emit_impl` so the guest's stack args 7,8 (at the guest `[rsp+8]`,`[rsp+16]` on entry to the stub) are
-   copied to a fixed, handler-discoverable location, and give the `_WIN32` handlers a small accessor
-   (e.g. `guest_stack_arg(n)`) that reads them from there instead of `__builtin_frame_address`. Cleanest;
-   fixes all such handlers at once.
-2. **Windows-specific `fp[]` offset** in each affected handler: work out the constant delta the stub
-   frame adds (stub does `sub rsp,0x38` then `call` pushes 8 → the guest return address sits at a fixed
-   offset above the handler frame; the guest stack args are `+8`/`+16` from there). Add
-   `#ifdef _WIN32` offsets to `agc_cb_release_mem`, `agc_acb_dma_data`, and any WaitRegMem builder.
-   Quicker but per-handler and brittle.
-3. Confirm which handler builds the WaitRegMem `mask`/`func`/`ref` (grep `R_WAIT_REG_MEM` / the
-   `WaitRegMem` builder in `hle_agc.cpp`) and check whether IT also reads stack args.
+`emit_impl` now copies guest stack args 7-9 into the standard Microsoft-x64 outgoing argument slots;
+Linux's guest-FS swap stub re-pushes the same three arguments with valid SysV alignment. Fixed-arity AGC
+handlers take explicit args 7-9 instead of decoding compiler frames. `test_hle_stack_args` calls a real
+generated stub with nine sentinels and checks alignment/return value; `test_agc_submit` checks the actual
+ReleaseMem/WaitRegMem packet fields.
 
-Validation: with any fix, the Windows first fence pair must read `data_sel=0x2 data=0x1 mask=0xffffffff`
-(matching Linux), the `NOT satisfied` log must disappear, and `SubmitDcb #2: executed N draws ->
-presented 1920x1080 frame` should appear (with BMPs in `PROSPER_FRAME_DIR`).
+Native runtime validation: `data_sel=2 data=1`, `ref=1 mask=ffffffff`, no `NOT satisfied`, SubmitDcb #1
+completes. Five repeat runs then expose #673 at `Il2cpp+0x17d64b` before SubmitDcb #2; the next work is
+initialization parity, not further fence decoding.
 
 ## Build + run + diagnose (native Windows, MinGW)
 

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -47,6 +47,9 @@ namespace prosper {
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
+#define HLE9(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6, \
+                                       uint64_t a7, uint64_t a8)
 
 namespace {
 
@@ -356,21 +359,13 @@ HLE(agc_cb_nop) {  // (dcb, num_dwords, ...)
 //    this generation's fence packets are still in flight, and our (faithful) value-1 fence writes
 //    then land in freed MallocBinned3 memory — the #312 "Canary was 0x3, should be 0x1" /
 //    "free an unrecognized block 0x1000000001" / 0x20015f00 freelist-pop fatals.
-// numBytes is stack arg9 — beyond the swap stub's 2-arg re-push window, recovered from the intact
-// original guest frame exactly like agc_driver_submit_dcb_variant's arg9 (validated: the re-pushed
-// args must match the originals and the return address must be guest text; on mismatch numBytes
-// stays 0 and the CommandProcessor skips the packet with a loud log — the pre-fix behavior).
+// numBytes is stack arg9. The import ABI bridge forwards args 7-9 as normal fixed parameters on
+// Windows and on Linux's guest-FS path; no compiler-frame decoding is involved (#672).
 // Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=srcOrImm lo/hi, [5]=numBytes, [6]=sels.
 // CONFIDENCE: HIGH on a4=dst/a1=srcOrImm (malloc-destination callsite + patcher names + protocol);
 // MED on the selector args (recorded raw; the executor only honors the small-immediate form).
-HLE(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, ..., stack9=numBytes)
-    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
-    uint64_t num_bytes = 0;
-    if (fp[6] == fp[2] && fp[7] == fp[3] &&
-        fp[5] >= 0x400000000ull && fp[5] < 0x500000000ull) {
-        uint64_t n = fp[8];                       // original stack arg9 = byte count
-        if (n && n <= 0x10000000ull) num_bytes = n;
-    }
+HLE9(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, ..., stack9=numBytes)
+    uint64_t num_bytes = a8 <= 0x10000000ull ? a8 : 0;
     static std::atomic<uint64_t> g_dma_n{0};
     if (getenv("PROSPER_PREDLOG") || getenv("PROSPER_GFXLOG")) {
         uint64_t k = g_dma_n.fetch_add(1);
@@ -390,11 +385,10 @@ HLE(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, .
 // sceAgcAcbDmaData (-RnpfpxIhec) — the async-compute-queue sibling. Same operation, shifted ABI
 // (RE'd from the Acb consumed-marker emitter at eboot+0x220d31e, which pairs it with the same
 // sceAgcCbReleaseMem(label<-1): (acb, srcSel?=3, dstSel?=3, dst=label, 2, 3, stack7=srcOrImm=0,
-// stack8=numBytes=4). srcOrImm/numBytes are stack args 7/8 = fp[2]/fp[3], INSIDE the swap stub's
-// forwarded window. CONFIDENCE: MED (single callsite; the executor gate limits the blast radius).
-HLE(agc_acb_dma_data) {  // (acb, srcSel?, dstSel?, dst, ?, ?, stack7=srcOrImm, stack8=numBytes)
-    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
-    uint64_t src_imm = fp[2], num_bytes = fp[3];
+// stack8=numBytes=4). srcOrImm/numBytes are explicit stack args 7/8 after the import bridge.
+// CONFIDENCE: MED (single callsite; the executor gate limits the blast radius).
+HLE9(agc_acb_dma_data) {  // (acb, srcSel?, dstSel?, dst, ?, ?, stack7=srcOrImm, stack8=numBytes)
+    uint64_t src_imm = a6, num_bytes = a7;
     if (num_bytes > 0x10000000ull) num_bytes = 0;
     uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DMA_DATA, &cmd)) return 0;
     cmd[1] = (uint32_t)(a3 & 0xffffffffu); cmd[2] = (uint32_t)(a3 >> 32u);
@@ -435,14 +429,10 @@ HLE(agc_dcb_acquire_mem) {  // (buf, engine, cb_db_op, gcr_cntl, ...) — 8 dw
     cmd[1] = (uint32_t)a2; cmd[2] = cmd[3] = cmd[4] = cmd[5] = cmd[6] = 0; cmd[7] = (uint32_t)a3;
     return (uint64_t)(uintptr_t)cmd;
 }
-HLE(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address, data_sel, data, …)
+HLE9(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address, data_sel, data, …)
     // ABI pinned to Kyty GraphicsCbReleaseMem (Graphics.cpp:1763): a5=label address, then the two stack
-    // args are data_sel (7th) and the 64-bit fence value (8th). SysV: fp[1]=ret, fp[2]=data_sel, fp[3]=data.
-    // Valid under BOTH stub shapes: the guest-%fs swap stub forwards the first two stack args
-    // (exec_image_linux.cpp emit_swap_stub) — previously fp[2]/fp[3] were the saved guest-fs base and
-    // guest return address there, so every fence under PROSPER_GUEST_FS was written with garbage.
-    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
-    uint64_t data_sel = fp[2], data = fp[3];
+    // args are data_sel (7th) and the 64-bit fence value (8th), forwarded as a6/a7 by the import bridge.
+    uint64_t data_sel = a6, data = a7;
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc] ReleaseMem action=0x%llx dst=0x%llx addr=0x%llx data_sel=0x%llx data=0x%llx\n",
             (unsigned long long)a1,(unsigned long long)a3,(unsigned long long)a5,
@@ -478,9 +468,11 @@ HLE(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cac
 #endif
         static std::atomic<int> seen_n{0};
         static uint64_t seen_ra[16];
+        // Diagnostic-only stack scan for guest callsite attribution. ABI arguments never come from it.
+        volatile uint64_t* stack_scan = (uint64_t*)__builtin_frame_address(0);
         uint64_t ra = 0, ra2 = 0, ra3 = 0;
         for (int i = 1; i < 96; i++) {
-            uint64_t v = fp[i];
+            uint64_t v = stack_scan[i];
             if (v >= 0x400000000ull && v < 0x4c0000000ull) {
                 if (!ra) ra = v; else if (!ra2) ra2 = v; else { ra3 = v; break; }
             }
@@ -544,16 +536,14 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     if (num <= 4) prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a3);   // #312 discriminator
     return (uint64_t)(uintptr_t)cmd;
 }
-HLE(agc_dcb_wait_reg_mem) {  // sceAgcDcbWaitRegMem(buf, size, compare_func, op, cache_policy, address, reference, mask, poll_cycles)
+HLE9(agc_dcb_wait_reg_mem) {  // sceAgcDcbWaitRegMem(buf, size, compare_func, op, cache_policy, address, reference, mask, poll_cycles)
     // ABI pinned to Kyty GraphicsDcbWaitRegMem (Graphics.cpp:2096): a5 = label address; the 7th/8th
-    // args (reference, mask) are STACK args, readable at fp[2]/fp[3] under both stub shapes (the
-    // guest-%fs swap stub forwards two stack args). poll_cycles (9th) is beyond the forwarded
-    // window and is only a poll-interval hint — encode 0. The payload previously ZEROED every
+    // stack args reference, mask, and poll_cycles are forwarded as a6/a7/a8 by the import bridge.
+    // The payload previously ZEROED every
     // wait parameter at build time (address/ref/mask/function destroyed — the wait could never be
     // honored downstream); now it mirrors Kyty's layout exactly:
     // [1..2]=addr lo/hi, [3..4]=mask lo/hi, [5..6]=reference lo/hi, [7]=compare_function, [8]=interval.
-    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
-    uint64_t reference = fp[2], mask = fp[3];
+    uint64_t reference = a6, mask = a7;
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc] WaitRegMem size=%llu func=%llu op=%llu addr=0x%llx ref=0x%llx mask=0x%llx\n",
             (unsigned long long)a1,(unsigned long long)a2,(unsigned long long)a3,
@@ -563,7 +553,7 @@ HLE(agc_dcb_wait_reg_mem) {  // sceAgcDcbWaitRegMem(buf, size, compare_func, op,
     cmd[3] = (uint32_t)(mask & 0xffffffffu);      cmd[4] = (uint32_t)(mask >> 32u);
     cmd[5] = (uint32_t)(reference & 0xffffffffu); cmd[6] = (uint32_t)(reference >> 32u);
     cmd[7] = (uint32_t)a2;                        // compare_function
-    cmd[8] = 0;                                   // poll interval hint (arg9 not forwarded; unused by our fold)
+    cmd[8] = (uint32_t)a8;                        // poll interval hint
     prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a5);   // #312 discriminator (wait leg)
     prosper_label_hist_wait_built(a5, a0);                        // #312 protocol history
     return (uint64_t)(uintptr_t)cmd;
@@ -1181,19 +1171,9 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
 //
 // ABI (RE'd from the compiler-generated adapter thunk at eboot+0x58df3f0, which marshals DOLL's
 // internal call at eboot+0x220aace into the Sony import): the raw Dcb dword-stream address arrives as
-// stack arg8, which the guest-%fs swap stub forwards to fp[3] (the same slot ReleaseMem/WaitRegMem read
-// their 8th arg from). The dword COUNT is stack arg9: the callsite loads the buffer-array entry
+// stack arg8, forwarded as a7 by the import ABI bridge. The dword COUNT is stack arg9: the callsite loads the buffer-array entry
 // {addr @+0x00, dw_count32 @+0x10} (`mov 0x10(%rax,%r12,1),%r10d`) and the adapter pushes it as the
 // import's 9th arg (32-bit, matching Packet.dw_num on the primary UglJIZjGssM path).
-//
-// arg9 is beyond the swap stub's 2-arg re-push window, but the ORIGINAL guest stack frame is still
-// intact above the stub's pushes. Guest-path stub frame at handler entry ([rsp] up):
-//   ret-to-stub, arg7-copy, arg8-copy, saved-r11(guest fs), ret-to-guest, orig-arg7, orig-arg8, orig-arg9
-// i.e. with the handler's rbp frame: fp[2]=arg7, fp[3]=arg8, fp[4]=saved r11, fp[5]=ret-to-guest,
-// fp[6]=orig arg7, fp[7]=orig arg8, fp[8]=orig arg9. We take arg9 from fp[8] ONLY after validating the
-// frame shape (fp[7]==fp[3] — the re-pushed arg8 must equal the original — and fp[5] must return into
-// guest code): a mismatch means a different stub layout (host path / future stub change), and we fall
-// back to the self-terminating fold rather than trust a garbage count.
 //
 // WHY the exact count matters (#241 and the boot crash-zoo): the Dcb is carved from a live ring whose
 // STALE tail is still valid type-3 PM4 from previous frames. An unknown-length fold does not stop at
@@ -1202,15 +1182,14 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
 // into live allocator state (the deterministic 0x20015f00 free-list node of issue #241, the libc.prx
 // logger stack-smash) — intermittent because it depends on what got reallocated under the stale fences.
 // CONFIDENCE: HIGH on the arg9=count ABI (callsite + adapter disassembly agree, and the count matches
-// the primary path's Packet.dw_num field offset); the validated-frame walk falls back safely.
-HLE(agc_driver_submit_dcb_variant) {
+// the primary path's Packet.dw_num field offset).
+HLE9(agc_driver_submit_dcb_variant) {
     auto is_pm4 = [](uint64_t p) -> bool {
         if (p < 0x10000 || (p & 3)) return false;
         uint32_t h = *(const volatile uint32_t*)(uintptr_t)p;
         return (h & 0xC0000000u) == 0xC0000000u;
     };
-    volatile uint64_t* fp = (uint64_t*)__builtin_frame_address(0);
-    uint64_t cand = fp[3];                                  // arg8 = the Dcb stream address (adapter ABI)
+    uint64_t cand = a7;                                     // arg8 = the Dcb stream address (adapter ABI)
     if (!is_pm4(cand)) {                                    // fallback: scan the register args
         const uint64_t regs[6] = { a0, a1, a2, a3, a4, a5 };
         cand = 0;
@@ -1219,24 +1198,16 @@ HLE(agc_driver_submit_dcb_variant) {
     if (!cand) {
         static std::atomic<int> logged{0};
         if (logged.fetch_add(1) < 4)
-            fprintf(stderr, "[agc] w1KFAHVqpaU: no PM4 stream found (fp[3]=0x%llx a0=0x%llx a1=0x%llx) — submit refused\n",
-                    (unsigned long long)fp[3], (unsigned long long)a0, (unsigned long long)a1);
+            fprintf(stderr, "[agc] w1KFAHVqpaU: no PM4 stream found (arg8=0x%llx a0=0x%llx a1=0x%llx) — submit refused\n",
+                    (unsigned long long)a7, (unsigned long long)a0, (unsigned long long)a1);
         return 0;
     }
-    // Recover the true dword count (arg9) from the original guest frame, validated as described above.
-    // Guest code range for the return-address check: main image at 0x400000000 (see classify_addr).
-    uint32_t dw_num = 0;
-    if (cand == fp[3] && fp[7] == fp[3] &&
-        fp[5] >= 0x400000000ull && fp[5] < 0x500000000ull) {
-        uint64_t n = fp[8];
-        if (n && n <= 0x400000ull)                          // plausible: bounded by any real ring size
-            dw_num = (uint32_t)n;
-    }
+    uint32_t dw_num = a8 && a8 <= 0x400000ull ? (uint32_t)a8 : 0;
     if (!dw_num) {
         static std::atomic<int> logged9{0};
         if (logged9.fetch_add(1) < 4)
-            fprintf(stderr, "[agc] w1KFAHVqpaU: arg9 count unavailable (fp[5]=0x%llx fp[7]=0x%llx fp[8]=0x%llx) — self-terminating fold\n",
-                    (unsigned long long)fp[5], (unsigned long long)fp[7], (unsigned long long)fp[8]);
+            fprintf(stderr, "[agc] w1KFAHVqpaU: invalid arg9 count 0x%llx — self-terminating fold\n",
+                    (unsigned long long)a8);
     }
     return submit_dcb_stream((const uint32_t*)(uintptr_t)cand, dw_num, "SubmitDcbFinal");
 }

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1643,14 +1643,11 @@ namespace {
     // handler on the current fs — exactly the old behavior. Uses FSGSBASE. Clobbers only rax/r11 (never
     // the arg regs rdi..r9).
     //
-    // STACK-ARG FORWARDING: the guest path interposes `push r11` + `call` between the guest caller and
-    // the handler, which shifts the caller's STACK args (args 7+) by two qwords — a handler reading its
-    // 7th arg at the SysV frame slot fp[2] silently got the saved guest-fs base instead (ReleaseMem read
-    // a TCB pointer as data_sel and the guest return address as the 64-bit fence value). The stub now
-    // re-pushes the first TWO stack args before the call, so handlers see the documented SysV layout
-    // (fp[2]=arg7, fp[3]=arg8) on BOTH paths. Alignment: entry rsp≡8 (caller's call), +3 pushes ≡0,
-    // call ≡8 at handler entry — the SysV contract. Handlers needing >2 stack args would need this
-    // widened. Keep 0x108/0x100/magic in sync with guest_tls.cpp (MAGIC_OFF/HOSTFS_OFF/TCB_MAGIC).
+    // STACK-ARG FORWARDING: the guest path interposes a call between the guest caller and handler.
+    // Re-push args 9,8,7 so fixed-arity handlers receive the normal SysV layout ([rsp+8]=arg7,
+    // [rsp+16]=arg8, [rsp+24]=arg9). The saved r11 plus an 8-byte pad remain behind those arguments.
+    // Alignment: entry rsp is 8 mod 16; five qwords of storage make the call site 0 mod 16 and the
+    // handler entry 8 mod 16. Keep offsets/magic in sync with guest_tls.cpp.
     void emit_swap_stub(uint8_t* p, uint32_t idx, uint64_t fn, bool unimpl) {
         uint8_t* s = p;
         auto mid = [&](uint8_t*& q) {   // per-variant: unimpl loads its slot index into edi first
@@ -1662,16 +1659,18 @@ namespace {
         *p++=0x41; *p++=0x81; *p++=0xBB; uint32_t mo=0x108; memcpy(p,&mo,4); p+=4;
         uint32_t magic=0x50524F53u; memcpy(p,&magic,4); p+=4;
         *p++=0x75; uint8_t* jne_rel = p++;                                  // jne rel8 (patched below)
-        // .guest: push r11 ; push [rsp+0x18] (arg8) ; push [rsp+0x18] (arg7) ; mov rax,[r11+0x100] ;
-        //         wrfsbase rax ; <mid> ; call rax ; add rsp,0x10 ; pop r11 ; wrfsbase r11 ; ret
+        // .guest: push r11 ; sub rsp,8 ; push [rsp+0x28] (arg9/8/7) x3 ; mov rax,[r11+0x100] ;
+        //         wrfsbase rax ; <mid> ; call rax ; add rsp,0x20 ; pop r11 ; wrfsbase r11 ; ret
         *p++=0x41; *p++=0x53;
-        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x18;                         // push qword [rsp+0x18] = arg8
-        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x18;                         // push qword [rsp+0x18] = arg7
+        *p++=0x48; *p++=0x83; *p++=0xEC; *p++=0x08;                         // sub rsp,8 (alignment pad)
+        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg9
+        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg8
+        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg7
         *p++=0x49; *p++=0x8B; *p++=0x83; uint32_t ho=0x100; memcpy(p,&ho,4); p+=4;
         *p++=0xF3; *p++=0x48; *p++=0x0F; *p++=0xAE; *p++=0xD0;
         mid(p);
         *p++=0xFF; *p++=0xD0;                                               // call rax
-        *p++=0x48; *p++=0x83; *p++=0xC4; *p++=0x10;                         // add rsp, 0x10
+        *p++=0x48; *p++=0x83; *p++=0xC4; *p++=0x20;                         // discard arg copies + pad
         *p++=0x41; *p++=0x5B;                                               // pop r11
         *p++=0xF3; *p++=0x49; *p++=0x0F; *p++=0xAE; *p++=0xD3;              // wrfsbase r11
         *p++=0xC3;                                                          // ret

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -123,16 +123,22 @@ namespace {
 
     // Import-stub machine code. Unlike Linux (where host ABI == guest SysV, so the stub is a bare
     // tail-jump with args intact), Windows handlers are Microsoft x64, so the stub is a TRAMPOLINE
-    // that converts the guest's SysV integer-arg registers to MS x64 before calling the handler:
-    //   SysV in:  rdi rsi rdx rcx r8 r9        (args a0..a5)
-    //   MS out:   rcx rdx r8  r9  [rsp+0x20] [rsp+0x28]  (+32B shadow space, 16-byte aligned call)
+    // that converts the guest's SysV integer arguments to MS x64 before calling the handler:
+    //   SysV in: rdi rsi rdx rcx r8 r9 [guest rsp+8] [guest rsp+16] [guest rsp+24] (a0..a8)
+    //   MS out:  rcx rdx r8 r9 [rsp+20]...[rsp+40] (+32B shadow, stack args a4..a8)
     // Return value is rax in both ABIs. This handles integer/pointer args (the whole HleFn surface);
     // XMM/float args (e.g. some libc formatters) are NOT converted yet — see docs/PORTING.md.
-    // The move ordering is chosen so no source register is clobbered before it is read (verified by
-    // hand). CONFIDENCE: MED (design verified on paper; not yet runtime-tested on Windows).
+    // The 0x48-byte outgoing area is 8 mod 16, so a normally-entered stub (RSP%16==8) has the required
+    // RSP%16==0 at its handler call site. The ABI conformance test verifies args 1-9 and alignment.
     size_t emit_sysv_to_ms_prologue(uint8_t* p) {
         static const uint8_t seq[] = {
-            0x48,0x83,0xEC,0x38,              // sub rsp,0x38   (0x20 shadow + a4/a5 + align: call rsp%16==0)
+            0x48,0x83,0xEC,0x48,              // sub rsp,0x48   (shadow + a4..a8; call rsp%16==0)
+            0x48,0x8B,0x44,0x24,0x50,         // mov rax,[rsp+0x50]   ; guest a6 at original rsp+8
+            0x48,0x89,0x44,0x24,0x30,         // mov [rsp+0x30],rax  ; MS 7th arg = a6
+            0x48,0x8B,0x44,0x24,0x58,         // mov rax,[rsp+0x58]   ; guest a7 at original rsp+16
+            0x48,0x89,0x44,0x24,0x38,         // mov [rsp+0x38],rax  ; MS 8th arg = a7
+            0x48,0x8B,0x44,0x24,0x60,         // mov rax,[rsp+0x60]   ; guest a8 at original rsp+24
+            0x48,0x89,0x44,0x24,0x40,         // mov [rsp+0x40],rax  ; MS 9th arg = a8
             0x4C,0x89,0x44,0x24,0x20,         // mov [rsp+0x20],r8    ; MS 5th arg = a4
             0x4C,0x89,0x4C,0x24,0x28,         // mov [rsp+0x28],r9    ; MS 6th arg = a5
             0x49,0x89,0xC9,                   // mov r9,rcx           ; MS 4th = a3  (save before rcx clobbered)
@@ -146,7 +152,7 @@ namespace {
         size_t o = emit_sysv_to_ms_prologue(p);
         p[o++] = 0x48; p[o++] = 0xB8; memcpy(p + o, &fn, 8); o += 8;   // movabs rax,fn
         p[o++] = 0xFF; p[o++] = 0xD0;                                  // call rax
-        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x38;    // add rsp,0x38
+        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x48;    // add rsp,0x48
         p[o++] = 0xC3;                                                 // ret
     }
     void emit_unimpl(uint8_t* p, uint32_t idx, uint64_t fn) {
@@ -334,7 +340,7 @@ bool map_image(const LoadedImage& img, std::string* err) {
 bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                    uint64_t stub_size, std::string* err) {
     auto fail = [&](const char* s){ if (err) *err = s; return false; };
-    if (stub_size < 24) return fail("stub_size too small (need >= 24)");
+    if (stub_size < 80) return fail("stub_size too small for Windows ABI bridge (need >= 80)");
     if (!g_nid_db) g_nid_db = new NidDb();
     dispatch_init(&slots, g_nid_db);
 

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -27,7 +27,7 @@ struct Program {
     std::vector<uint64_t>                init_fns; // dependent-module init fns, in call order
     std::vector<TlsTemplate>             tls_templates; // indexed by module TLS id (0 = unused)
     uint64_t entry = 0;                            // main module entry
-    uint64_t stub_base = 0, stub_size = 96;   // 96 leaves room for the gated guest-%fs swap stub (~74 bytes)
+    uint64_t stub_base = 0, stub_size = 96;   // 96 contains the largest guest-%fs swap stub (94 bytes)
 
     // Global export table: NID -> absolute guest address (first definition wins). Retained so the
     // HLE can serve sceKernelDlsym by name (nid_hash(name)) against loaded modules — e.g. resolve

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -27,6 +27,8 @@ struct Dcb {
 };
 // The AgcDriver submit descriptor (Kyty Gen5Driver::Packet).
 struct Packet { uint32_t* addr; uint32_t dw_num; uint8_t pad[4]; };
+using HostHle9 = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                              uint64_t, uint64_t, uint64_t, uint64_t);
 
 int main() {
     printf("== test_agc_submit ==\n");
@@ -39,9 +41,13 @@ int main() {
     auto submit = Hle::lookup("UglJIZjGssM");   // GraphicsDriverSubmitDcb
     auto regmem = Hle::lookup("AOLcoIkQDgM");   // QueryResourceRegistrationUserMemoryRequirements
     auto maxname = Hle::lookup("uJziRsODk1c");   // sceAgcDriverGetResourceRegistrationMaxNameLength
-    CHECK(reset && setcx && setidx && draw && submit && regmem && maxname,
+    auto release = reinterpret_cast<HostHle9>(Hle::lookup("wr23dPKyWc0")); // GraphicsCbReleaseMem
+    auto waitmem = reinterpret_cast<HostHle9>(Hle::lookup("VmW0Tdpy420")); // GraphicsDcbWaitRegMem
+    CHECK(reset && setcx && setidx && draw && submit && regmem && maxname && release && waitmem,
           "AGC Dcb, submit, and resource-registration functions registered");
-    if (!(reset && setcx && setidx && draw && submit && regmem && maxname)) { printf("== FAIL ==\n"); return 1; }
+    if (!(reset && setcx && setidx && draw && submit && regmem && maxname && release && waitmem)) {
+        printf("== FAIL ==\n"); return 1;
+    }
 
     uint64_t registration_bytes = 0x7a2a67fe6900ull;
     CHECK(regmem((uint64_t)(uintptr_t)&registration_bytes, 0x2000, 0x38, 0, 0, 0) == 0,
@@ -104,6 +110,29 @@ int main() {
         CHECK(st.index_type == 1, "folded the index type");
         CHECK(st.draws.size() == 1 && st.draws[0].index_count == 42,
               "recorded one DrawIndexAuto with index_count=42");
+    }
+
+    // Fixed args 7-9 must be real function parameters, not compiler-frame offsets. This is the exact
+    // first-fence field pattern whose missing Windows stack forwarding blocked the render thread (#672).
+    {
+        uint32_t sync_buffer[64] = {};
+        Dcb sync{};
+        sync.bottom = sync_buffer; sync.top = sync_buffer + 64;
+        sync.cursor_up = sync_buffer; sync.cursor_down = sync_buffer + 64;
+        uint64_t label = 0;
+        const uint64_t S = (uint64_t)(uintptr_t)&sync;
+        const uint64_t A = (uint64_t)(uintptr_t)&label;
+        release(S, 0x28, 0, 1, 0, A, 2, 1, 0);
+        waitmem(S, 8, 3, 0, 0, A, 1, 0xffffffffu, 0x20);
+
+        CHECK(sync.cursor_up - sync_buffer == 16, "ReleaseMem + WaitRegMem emitted 7 + 9 dwords");
+        CHECK(sync_buffer[3] == 2 && sync_buffer[4] == 1 && sync_buffer[5] == 0,
+              "ReleaseMem encoded stack args data_sel=2 and data=1");
+        const uint32_t* wait = sync_buffer + 7;
+        CHECK(wait[3] == 0xffffffffu && wait[4] == 0 && wait[5] == 1 && wait[6] == 0,
+              "WaitRegMem encoded stack args mask=0xffffffff and reference=1");
+        CHECK(wait[7] == 3 && wait[8] == 0x20,
+              "WaitRegMem encoded compare function and arg9 poll interval");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_hle_stack_args.cpp
+++ b/prosper/tests/test_hle_stack_args.cpp
@@ -1,0 +1,134 @@
+// test_hle_stack_args - the generated import stub must preserve the guest's complete fixed-arity
+// SysV call across the host ABI boundary. Windows needs a SysV->Microsoft-x64 conversion; Linux's
+// guest-FS path interposes a call while swapping FS. Both paths must forward stack args 7-9.
+#include "../src/host/exec_image.hpp"
+#include "../src/hle/dispatch.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace prosper;
+
+namespace {
+
+constexpr uint64_t kArgs[9] = {
+    0x1111111111111111ull, 0x2222222222222222ull, 0x3333333333333333ull,
+    0x4444444444444444ull, 0x5555555555555555ull, 0x6666666666666666ull,
+    0x7777777777777777ull, 0x8888888888888888ull, 0x9999999999999999ull,
+};
+constexpr uint64_t kReturn = 0xabcddcba01234567ull;
+uint64_t g_seen[9] = {};
+extern "C" {
+uint64_t prosper_test_hle_entry_rsp_mod16 = ~uint64_t{0};
+}
+
+extern "C" uint64_t prosper_test_hle9_handler(
+    uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4,
+    uint64_t a5, uint64_t a6, uint64_t a7, uint64_t a8) {
+    const uint64_t args[9] = {a0, a1, a2, a3, a4, a5, a6, a7, a8};
+    for (int i = 0; i < 9; ++i) g_seen[i] = args[i];
+    return kReturn;
+}
+
+extern "C" void prosper_test_hle9_entry();
+
+#define PROSPER_STRINGIFY_INNER(x) #x
+#define PROSPER_STRINGIFY(x) PROSPER_STRINGIFY_INNER(x)
+#ifdef __APPLE__
+#define PROSPER_ASM_SYMBOL(x) "_" PROSPER_STRINGIFY(x)
+#else
+#define PROSPER_ASM_SYMBOL(x) PROSPER_STRINGIFY(x)
+#endif
+
+// Record RSP before any compiler prologue, then tail-jump to the real host-ABI handler. A valid
+// SysV or Microsoft-x64 callee enters with RSP%16==8.
+__asm__(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl " PROSPER_ASM_SYMBOL(prosper_test_hle9_entry) "\n"
+    PROSPER_ASM_SYMBOL(prosper_test_hle9_entry) ":\n"
+    "    movq %rsp, %r10\n"
+    "    andq $15, %r10\n"
+    "    movq %r10, " PROSPER_ASM_SYMBOL(prosper_test_hle_entry_rsp_mod16) "(%rip)\n"
+    "    jmp " PROSPER_ASM_SYMBOL(prosper_test_hle9_handler) "\n"
+);
+
+#ifdef _WIN32
+using GuestHle9 = uint64_t (__attribute__((sysv_abi)) *)(
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t, uint64_t, uint64_t);
+#else
+using GuestHle9 = uint64_t (*)(
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t, uint64_t, uint64_t);
+#endif
+
+int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::printf("== test_hle_stack_args ==\n");
+
+#if defined(__linux__)
+    const bool guest_fs = argc > 1 && std::string(argv[1]) == "--guest-fs";
+    if (guest_fs) {
+        setenv("PROSPER_GUEST_FS", "1", 1);
+        TlsModuleDesc empty_module{};
+        guest_tls_set_templates(&empty_module, 1);
+        CHECK(guest_tls_enabled(), "Linux guest-FS import path enabled");
+    }
+#else
+    (void)argc;
+    (void)argv;
+    const bool guest_fs = false;
+#endif
+
+    constexpr const char* kNid = "test.hle.stack.args";
+    Hle::register_fn(kNid, reinterpret_cast<HleFn>(&prosper_test_hle9_entry),
+                     "prosper_test_hle9_entry");
+    const std::vector<ImportSlot> slots = {{"test", kNid}};
+    std::string err;
+    CHECK(install_stubs(slots, 0x710000000ull, 96, &err), "generated one executable import stub");
+    if (fails) {
+        if (!err.empty()) std::printf("  install error: %s\n", err.c_str());
+        return 1;
+    }
+
+    bool guest_fs_active = false;
+#if defined(__linux__)
+    // Do not call libc between activation and the import: the test thread is deliberately running
+    // with a guest TCB until the generated stub and the explicit restore below return it to host FS.
+    if (guest_fs) guest_fs_active = guest_tls_activate_thread() != 0;
+#endif
+
+    auto call = reinterpret_cast<GuestHle9>(static_cast<uintptr_t>(stub_addr(0)));
+    const uint64_t result = call(kArgs[0], kArgs[1], kArgs[2], kArgs[3], kArgs[4],
+                                 kArgs[5], kArgs[6], kArgs[7], kArgs[8]);
+
+#if defined(__linux__)
+    if (guest_fs_active) guest_fs_enter_host_for_signal();
+#endif
+
+    CHECK(!guest_fs || guest_fs_active, "activated a guest FS base for the call");
+    CHECK(result == kReturn, "return value crossed the import ABI bridge");
+    CHECK(prosper_test_hle_entry_rsp_mod16 == 8, "host handler entered with RSP%16 == 8");
+    for (int i = 0; i < 9; ++i) {
+        char what[96];
+        std::snprintf(what, sizeof what, "argument %d preserved (0x%016llx)", i + 1,
+                      static_cast<unsigned long long>(kArgs[i]));
+        CHECK(g_seen[i] == kArgs[i], what);
+    }
+
+    if (fails) {
+        std::printf("== FAIL: %d ==\n", fails);
+        return 1;
+    }
+    std::printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- forward guest SysV stack arguments 7-9 through the generated Windows Microsoft-x64 import trampoline
- preserve the same arguments through Linux guest-`%fs` swap stubs and replace fragile AGC compiler-frame decoding with explicit fixed parameters
- add generated-bridge ABI conformance coverage, cross-platform first-fence field tests, and update the Windows port handoff

## Runtime validation
Five native Windows Messenger runs now agree with Linux at the first fence:
- `ReleaseMem data_sel=2 data=1`
- `WaitRegMem ref=1 mask=ffffffff`
- no `NOT satisfied`
- SubmitDcb #1 completes

This exposes the separate pre-existing IL2CPP initialization failure tracked in #673 before SubmitDcb #2.

## Tests
- Windows native: `61/61` CTest tests passed
- Linux: `94/94` CTest tests passed, including ordinary and guest-`%fs` bridge paths and all Vulkan execution tests

Fixes #672