### PR TITLE
gpu: support capture-safe layered compute images

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 namespace prosper::frontend {
@@ -27,6 +28,7 @@ struct VulkanComputeContext {
     VkQueue queue = VK_NULL_HANDLE;
     uint32_t queue_family = UINT32_MAX;
     VkPhysicalDeviceMemoryProperties memory{};
+    VkPhysicalDeviceProperties properties{};
     // Storage-image support (#590): the recompiler's storage path declares the
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
@@ -51,6 +53,7 @@ struct VulkanComputeContext {
         std::vector<VkPhysicalDevice> devices(device_count);
         vkEnumeratePhysicalDevices(instance, &device_count, devices.data());
         physical = devices[0];
+        vkGetPhysicalDeviceProperties(physical, &properties);
 
         uint32_t family_count = 0;
         vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, nullptr);
@@ -124,7 +127,71 @@ struct BoundImage {
     VkImageView view = VK_NULL_HANDLE;
     VkSampler sampler = VK_NULL_HANDLE; // combined image sampler only
     VkDeviceSize row_pitch = 0;         // LINEAR-tiling row pitch (bytes), from vkGetImageSubresourceLayout
+    VkImageType image_type = VK_IMAGE_TYPE_2D;
+    VkImageViewType view_type = VK_IMAGE_VIEW_TYPE_2D;
+    VkExtent3D extent{1, 1, 1};
+    uint32_t array_layers = 1;
+    uint32_t slices = 1;
 };
+
+bool checked_mul_u64(uint64_t a, uint64_t b, uint64_t& out) {
+    if (a && b > std::numeric_limits<uint64_t>::max() / a) return false;
+    out = a * b;
+    return true;
+}
+
+bool compute_image_shape(const prosper::gpu::ShaderResource& r, bool storage,
+                         const VkPhysicalDeviceLimits& limits, BoundImage& out,
+                         const char*& why) {
+    if (!r.depth || r.depth > 8192u) { why = "invalid depth/layer count"; return false; }
+    if (!storage && r.img_dim != 1u) { why = "non-2D sampled texture"; return false; }
+    out.slices = 1;
+    switch (r.img_dim) {
+        case 0: // 1D
+            if (r.height != 1 || r.depth != 1) { why = "1D image has non-unit height/depth"; return false; }
+            out.image_type = VK_IMAGE_TYPE_1D; out.view_type = VK_IMAGE_VIEW_TYPE_1D;
+            out.extent = {r.width, 1, 1};
+            if (r.width > limits.maxImageDimension1D) { why = "1D extent exceeds device limit"; return false; }
+            break;
+        case 1: // 2D
+            if (r.depth != 1) { why = "2D image has non-unit depth"; return false; }
+            out.extent = {r.width, r.height, 1};
+            if (r.width > limits.maxImageDimension2D || r.height > limits.maxImageDimension2D) {
+                why = "2D extent exceeds device limit"; return false;
+            }
+            break;
+        case 2: // 3D
+            if (!storage) { why = "non-2D sampled texture"; return false; }
+            out.image_type = VK_IMAGE_TYPE_3D; out.view_type = VK_IMAGE_VIEW_TYPE_3D;
+            out.extent = {r.width, r.height, r.depth}; out.slices = r.depth;
+            if (r.width > limits.maxImageDimension3D || r.height > limits.maxImageDimension3D ||
+                r.depth > limits.maxImageDimension3D) {
+                why = "3D extent exceeds device limit"; return false;
+            }
+            break;
+        case 4: // 1D_ARRAY
+            if (!storage) { why = "non-2D sampled texture"; return false; }
+            if (r.height != 1) { why = "1D array has non-unit height"; return false; }
+            out.image_type = VK_IMAGE_TYPE_1D; out.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+            out.extent = {r.width, 1, 1}; out.array_layers = r.depth; out.slices = r.depth;
+            if (r.width > limits.maxImageDimension1D || r.depth > limits.maxImageArrayLayers) {
+                why = "1D-array extent exceeds device limit"; return false;
+            }
+            break;
+        case 5: // 2D_ARRAY
+            if (!storage) { why = "non-2D sampled texture"; return false; }
+            out.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+            out.extent = {r.width, r.height, 1}; out.array_layers = r.depth; out.slices = r.depth;
+            if (r.width > limits.maxImageDimension2D || r.height > limits.maxImageDimension2D ||
+                r.depth > limits.maxImageArrayLayers) {
+                why = "2D-array extent exceeds device limit"; return false;
+            }
+            break;
+        default:
+            why = "cube/MSAA image unsupported"; return false;
+    }
+    return true;
+}
 
 // --- Storage-image channel model (#590) -------------------------------------------------------------
 // The recompiler moves image texels as RAW 32-bit VGPR channel values (uvec4 per texel; the VkImage is
@@ -347,7 +414,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u fmt=%u: %s -> "
                                      "dispatch skipped (#590)\n",
                              (unsigned long long)item.code_addr, (unsigned long long)key,
-                             r ? r->width : 0, r ? r->height : 0, 1u,
+                             r ? r->width : 0, r ? r->height : 0, r ? r->depth : 0,
                              r ? (unsigned)r->format : 0u, why);
             }
             images_ready = false;
@@ -362,16 +429,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // A surface whose CURRENT pixels live in the renderer's RTT cache must not be read from
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
             if (is_live_render_target(r->gpu_addr)) { skip_image(r, "renderer-owned RTT surface"); break; }
-            const bool dim_1d = r->img_dim == 0;
-            if (!dim_1d && r->img_dim != 1) {
-                skip_image(r, "layered/3D image deferred to #657"); break;
+            const char* shape_error = nullptr;
+            if (!compute_image_shape(*r, bi.storage, ctx.properties.limits, bi, shape_error)) {
+                skip_image(r, shape_error); break;
             }
-            if (dim_1d && r->height != 1) { skip_image(r, "1D image has non-unit height"); break; }
             const uint32_t texel_bytes = bi.storage ? 16u : 4u;   // uvec4 raw channels / RGBA8
-            const VkDeviceSize sbytes = static_cast<VkDeviceSize>(r->width) * r->height * texel_bytes;
-            if (!sbytes || sbytes > kMaxComputeImageBytes) {
+            uint64_t texels64 = 0, plane_texels = 0, expanded_bytes = 0;
+            if (!checked_mul_u64(r->width, r->height, plane_texels) ||
+                !checked_mul_u64(plane_texels, bi.slices, texels64) ||
+                !checked_mul_u64(texels64, texel_bytes, expanded_bytes) ||
+                !expanded_bytes || expanded_bytes > kMaxComputeImageBytes) {
                 skip_image(r, "expanded image exceeds the 256 MiB backend bound"); break;
             }
+            const VkDeviceSize sbytes = expanded_bytes;
+            const size_t texels = static_cast<size_t>(texels64);
             staging_bytes[i] = sbytes;
 
             // Fill the upload staging bytes.
@@ -383,9 +454,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
                 const size_t guest_texel = (size_t)cb * nc;
-                const size_t texels = (size_t)r->width * r->height;
-                const uint64_t guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
-                if (!guest_bytes || guest_bytes > UINT32_MAX || guest_bytes > r->size) {
+                uint64_t guest_bytes = 0;
+                if (!checked_mul_u64(texels64, guest_texel, guest_bytes) ||
+                    !guest_bytes || guest_bytes > UINT32_MAX || guest_bytes > r->size) {
                     skip_image(r, "storage backing size is invalid"); break;
                 }
                 const uint8_t* src = resource_bytes(r);
@@ -396,7 +467,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     storage_unpack_texel(src + t * guest_texel, r->format, nc,
                                          reinterpret_cast<uint32_t*>(upload.data()) + t * 4);
             } else {
-                if (r->img_dim != 1) { skip_image(r, "non-2D sampled texture"); break; }
                 const uint32_t bpb = bc_block_bytes(r->format);
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
@@ -486,11 +556,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-            ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : VK_IMAGE_TYPE_2D;
+            ici.imageType = bi.image_type;
             ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT : VK_FORMAT_R8G8B8A8_UNORM;
-            ici.extent = {r->width, r->height, 1};
+            ici.extent = bi.extent;
             ici.mipLevels = 1;
-            ici.arrayLayers = 1;
+            ici.arrayLayers = bi.array_layers;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
             ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
@@ -509,7 +579,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 images_ready = false; break; }
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             vci.image = bi.image;
-            vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D : VK_IMAGE_VIEW_TYPE_2D;
+            vci.viewType = bi.view_type;
             vci.format = ici.format;
             if (!bi.storage) {
                 // T# DST_SEL channel routing (SQ_SEL: 0=0, 1=1, 4=R, 5=G, 6=B, 7=A) — same mapping
@@ -646,7 +716,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // Upload every image: UNDEFINED -> TRANSFER_DST, copy the staged texels in, -> GENERAL.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
-            const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_dst.srcAccessMask = 0;
             to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -654,12 +723,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             to_dst.srcQueueFamilyIndex = to_dst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             to_dst.image = bi.image;
-            to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, bi.array_layers};
             vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
             VkBufferImageCopy region{};
-            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            region.imageExtent = {r->width, r->height, 1};
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, bi.array_layers};
+            region.imageExtent = bi.extent;
             vkCmdCopyBufferToImage(command, staging[i], bi.image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
             VkImageMemoryBarrier to_general = to_dst;
@@ -680,7 +749,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (!bi.storage) continue;
-            const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
             to_src.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
@@ -688,12 +756,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             to_src.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             to_src.srcQueueFamilyIndex = to_src.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             to_src.image = bi.image;
-            to_src.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            to_src.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, bi.array_layers};
             vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_src);
             VkBufferImageCopy region{};
-            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            region.imageExtent = {r->width, r->height, 1};
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, bi.array_layers};
+            region.imageExtent = bi.extent;
             vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    staging[i], 1, &region);
         }
@@ -745,15 +813,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const uint32_t cb = data_format_bytes(r->format);
             const uint32_t nc = r->num_components ? r->num_components : 1;
             const size_t guest_texel = (size_t)cb * nc;
-            const size_t texels = (size_t)r->width * r->height;
+            uint64_t plane_texels = 0, texels64 = 0, guest_bytes = 0;
+            if (!checked_mul_u64(r->width, r->height, plane_texels) ||
+                !checked_mul_u64(plane_texels, bi.slices, texels64) ||
+                !checked_mul_u64(texels64, guest_texel, guest_bytes) ||
+                guest_bytes > UINT32_MAX || guest_bytes > r->size) {
+                vkUnmapMemory(ctx.device, staging_memory[i]); readback_ok = false; break;
+            }
+            const size_t texels = static_cast<size_t>(texels64);
             uint8_t* destination = resource_bytes(r);
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
             for (size_t t = 0; t < texels; t++)
                 storage_pack_texel(channels + t * 4, r->format, nc, destination + t * guest_texel);
-            notify_guest_gpu_write(r->gpu_addr, texels * guest_texel);
+            notify_guest_gpu_write(r->gpu_addr, static_cast<size_t>(guest_bytes));
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
-                                   r->gpu_addr, texels * guest_texel,
+                                   r->gpu_addr, static_cast<size_t>(guest_bytes),
                                    item.submit_no, item.dispatch_index,
                                    item.command_order, item.code_addr);
             vkUnmapMemory(ctx.device, staging_memory[i]);

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -140,6 +140,7 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.base      = (((uint64_t)t[0] | ((uint64_t)t[1] << 32)) & 0xFFFFFFFFFFull) << 8;             // Base40
     d.width     = (uint32_t)(((t[1] >> 30) & 0x3u) | (((t[2] >> 0) & 0xFFFu) << 2)) + 1;          // Width5
     d.height    = (uint32_t)((t[2] >> 14) & 0x3FFFu) + 1;                                          // Height5
+    d.depth     = (uint32_t)(t[4] & 0x1FFFu) + 1;                                                   // Depth
     d.format    = (t[1] >> 20) & 0x1FFu;                                                           // Format
     d.tile_mode = (t[3] >> 20) & 0x1Fu;                                                            // TileMode (SW_MODE)
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
@@ -152,6 +153,13 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
 
 uint32_t image_type_to_dim(uint8_t type) {
     return type >= 8 && type <= 15 ? static_cast<uint32_t>(type - 8) : 1u;
+}
+
+uint32_t image_slice_count(uint32_t img_dim, uint32_t depth) {
+    if (img_dim == 3u) return 6u;
+    if (img_dim == 2u || img_dim == 4u || img_dim == 5u || img_dim == 7u)
+        return depth ? depth : 1u;
+    return 1u;
 }
 
 ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
@@ -350,13 +358,18 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // 12=1D_ARRAY, 13=2D_ARRAY). A CUBE resource (img_dim 3) uploads as six faces stacked
             // vertically in one 2D image (#273); everything else keeps the 2D default.
             r.img_dim       = image_type_to_dim(d.type);
+            r.depth         = image_slice_count(r.img_dim, d.depth);
             r.srgb          = fi.srgb;              // gamma-encoded surface: sample with sRGB->linear (#263)
             if (fi.srgb && getenv("PROSPER_GFXLOG"))
                 fprintf(stderr, "[t#] SRGB texture fmt=%u %ux%u (binding %u)\n", d.format, d.width, d.height, r.binding);
             // Backing byte size: block-compressed surfaces store one bytes_per_block unit per 4x4 block
             // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
-            r.size          = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
-                                     : (d.width * d.height * fi.bytes_per_block);
+            const uint64_t slice_bytes = is_bcn
+                ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block
+                : static_cast<uint64_t>(d.width) * d.height * fi.bytes_per_block;
+            const uint64_t backing_bytes = slice_bytes * r.depth;
+            if (!backing_bytes || backing_bytes > UINT32_MAX) continue;
+            r.size          = static_cast<uint32_t>(backing_bytes);
             // SGPR-resident T#: DIRECT provenance (image_sample SRSRC SGPR). EUD-resident T#: INDIRECT
             // (the s_load immediate = tsrt), and sgpr_base must be invalid so a stray by_sgpr_base for an
             // unrelated op reading that (bogus, out-of-file) SGPR number can't spuriously match it (#382).

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -77,6 +77,9 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 struct DecodedImageDescriptor {
     uint64_t base = 0;
     uint32_t width = 0, height = 0;
+    // WORD4 DEPTH is depth-1 for 3D images and last-array-slice for array resources. Consumers
+    // normalize it back to 1 for non-layered image types. Layout is SQ_IMG_RSRC_WORD4.DEPTH[12:0].
+    uint32_t depth = 1;
     uint32_t format = 0;      // Gen5 surface-format enum (fields[1] bits 20..28)
     uint32_t tile_mode = 0;   // 0 = linear
     uint8_t  type = 0;        // SQ_RSRC_IMG dim (GFX10: 8=1D, 9=2D, 10=3D, 11=CUBE, 12=1D_ARRAY, 13=2D_ARRAY).
@@ -92,6 +95,10 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]);
 // Convert SQ_RSRC_IMG TYPE (8..15) to the MIMG dim convention (0..7). Unknown values retain the
 // long-standing 2D fallback.
 uint32_t image_type_to_dim(uint8_t type);
+
+// Number of tightly-packed 2D/1D slices in an image backing. 3D and array resources use the
+// descriptor's depth/layer count, cube resources have six faces, and ordinary/MSAA images use one.
+uint32_t image_slice_count(uint32_t img_dim, uint32_t depth);
 
 // A Gen5/GFX10 T# IMG_FMT (the 9-bit combined format field) decoded to sizing + conversion info.
 // bytes_per_block is the byte size of one block_width x block_height texel block — for uncompressed

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 8;
+constexpr uint32_t kVersion = 9;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -264,7 +264,7 @@ uint64_t checked_mul(uint64_t a, uint64_t b) {
 uint64_t resource_footprint(const ShaderResource& r) {
     uint64_t result = r.size;
     if (r.cls != ResourceClass::Texture && r.cls != ResourceClass::StorageImage) return result;
-    const uint64_t faces = r.img_dim == 3u ? 6u : 1u;
+    const uint64_t slices = image_slice_count(r.img_dim, r.depth);
     uint32_t w = r.width ? r.width : 4, h = r.height ? r.height : 4;
     const uint32_t bc = bc_block_bytes(r.format);
     uint64_t decoded = 0;
@@ -279,7 +279,7 @@ uint64_t resource_footprint(const ShaderResource& r) {
         decoded = tile_mode_is_tiled(r.tile_mode) ? tiled_surface_bytes(w, h, r.tile_mode, 0, bpt)
                                                   : checked_mul(checked_mul(w, h), bpt);
     }
-    decoded = checked_mul(decoded, faces);
+    decoded = checked_mul(decoded, slices);
     return std::max(result, decoded);
 }
 
@@ -950,6 +950,32 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u8(seed.depth_valid); w.u8(seed.stencil_valid);
         w.bytes(seed.depth); w.bytes(seed.stencil);
     }
+    // v9: image depth/array-layer metadata is a tail sidecar. Keeping the v1-v8 resource record
+    // byte-for-byte stable makes old captures directly readable; their resources retain depth=1.
+    // References are visited in the same deterministic order as their tables above.
+    size_t resource_reference_count = 0;
+    for (const auto& draw : c.draws)
+        resource_reference_count += draw.vrt.resources.size() + draw.prt.resources.size();
+    for (const auto& compute : c.computes)
+        resource_reference_count += compute.resources.resources.size();
+    if (resource_reference_count > UINT32_MAX) {
+        error = "capture has too many resource references for image-shape metadata"; return false;
+    }
+    w.u32(static_cast<uint32_t>(resource_reference_count));
+    auto write_depths = [&](const GpuCapturedTable& table) -> bool {
+        for (const auto& captured : table.resources) {
+            const uint32_t depth = captured.resource.depth;
+            if (!depth || depth > 8192u) {
+                error = "resource image depth/layer count is outside the T# range"; return false;
+            }
+            w.u32(depth);
+        }
+        return true;
+    };
+    for (const auto& draw : c.draws)
+        if (!write_depths(draw.vrt) || !write_depths(draw.prt)) return false;
+    for (const auto& compute : c.computes)
+        if (!write_depths(compute.resources)) return false;
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1196,6 +1222,30 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             }
             seed_total += plane_bytes;
         }
+    }
+    if (version >= 9) {
+        size_t expected = 0;
+        for (const auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "image-shape resource count does not match capture tables"; return false;
+        }
+        auto read_depths = [&](GpuCapturedTable& table) -> bool {
+            for (auto& captured : table.resources) {
+                if (!r.u32(captured.resource.depth) || !captured.resource.depth ||
+                    captured.resource.depth > 8192u) {
+                    error = "invalid resource image depth/layer count"; return false;
+                }
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_depths(draw.vrt) || !read_depths(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_depths(compute.resources)) return false;
     }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1012,8 +1012,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
                         const ResourceClass wanted = u.is_store ? ResourceClass::StorageImage
                                                                : ResourceClass::Texture;
                         for (auto& r0 : table->resources)
-                            if (r0.cls == wanted &&
-                                r0.gpu_addr == d.base && r0.width == d.width && r0.height == d.height) {
+                            if (r0.cls == wanted && r0.gpu_addr == d.base &&
+                                r0.width == d.width && r0.height == d.height &&
+                                r0.img_dim == image_type_to_dim(d.type) &&
+                                r0.depth == image_slice_count(r0.img_dim, d.depth)) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
                                 if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
                             }
@@ -1028,24 +1030,26 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     if (mapped_fmt && fi.block_width > 1 && fi.snorm) continue;   // signed BCn: not wired
                     ShaderResource r;
                     r.cls = u.is_store ? ResourceClass::StorageImage : ResourceClass::Texture;
+                    r.img_dim = image_type_to_dim(d.type);
+                    r.depth = image_slice_count(r.img_dim, d.depth);
                     if (mapped_fmt) {
                         r.format = fi.format; r.num_components = fi.num_components;
                         const bool is_bcn = fi.block_width > 1;
-                        const uint64_t bytes = is_bcn
+                        const uint64_t slice_bytes = is_bcn
                             ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block
                             : static_cast<uint64_t>(d.width) * d.height * fi.bytes_per_block;
+                        const uint64_t bytes = slice_bytes * r.depth;
                         if (!bytes || bytes > UINT32_MAX) continue;
                         r.size = static_cast<uint32_t>(bytes);
                         r.srgb = fi.srgb;
                     } else {
-                        const uint64_t bytes = static_cast<uint64_t>(d.width) * d.height * 4;
+                        const uint64_t bytes = static_cast<uint64_t>(d.width) * d.height * r.depth * 4;
                         if (!bytes || bytes > UINT32_MAX) continue;
                         r.format = DataFormat::Unknown; r.num_components = 4;
                         r.size = static_cast<uint32_t>(bytes);
                     }
                     r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
                     r.tile_mode = d.tile_mode;
-                    r.img_dim = image_type_to_dim(d.type);
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -99,7 +99,9 @@ struct ShaderResource {
     //     vertex fetch by its instruction pc first (exact), falling back to sgpr_base. 0xFFFFFFFF = unset.
     uint32_t      fetch_pc      = 0xFFFFFFFFu;
 
-    // Texture-only (cls == Texture). img_dim mirrors the MIMG dim field (1D=0, 2D=1, 3D=2, ...).
+    // Image-only (cls == Texture or StorageImage). img_dim mirrors the MIMG dim field
+    // (1D=0, 2D=1, 3D=2, CUBE=3, 1D_ARRAY=4, 2D_ARRAY=5, ...). `depth` is the 3D depth or
+    // array-layer count decoded from SQ_IMG_RSRC_WORD4.DEPTH; it is 1 for non-layered images.
     // width/height are for image_load/texelFetch + unnormalized addressing (unused by normalized
     // image_sample). sampler_sgpr_base = the paired sampler's S# base SGPR (SSAMP); with a Vulkan
     // COMBINED_IMAGE_SAMPLER the sampler is baked into the same `binding`, so this is provenance for a
@@ -107,6 +109,7 @@ struct ShaderResource {
     uint32_t      img_dim           = 1;
     uint32_t      width             = 0;
     uint32_t      height            = 0;
+    uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -28,13 +28,14 @@ static void make_vsharp(uint32_t v[4], uint64_t base, uint32_t stride, uint32_t 
 // Width5-1 split over word1[31:30] (lo) + word2[11:0] (hi), Height5-1 @word2[27:14], TileMode
 // @word3[24:20], Type @word3[31:28]. Mirrors decode_image_descriptor / Kyty's Gen5 getters.
 static void make_tsharp(uint32_t t[8], uint64_t base, uint32_t w, uint32_t h, uint32_t fmt,
-                        uint32_t tile_mode, uint32_t type) {
+                         uint32_t tile_mode, uint32_t type, uint32_t depth = 1) {
     memset(t, 0, 8 * sizeof(uint32_t));
     uint64_t b = base >> 8;                       // 256-byte-aligned base, stored >>8
     t[0] = (uint32_t)(b & 0xffffffffu);
     t[1] = (uint32_t)((b >> 32) & 0xffu) | ((fmt & 0x1ffu) << 20) | (((w - 1) & 0x3u) << 30);
     t[2] = (((w - 1) >> 2) & 0xfffu) | (((h - 1) & 0x3fffu) << 14);
     t[3] = ((tile_mode & 0x1fu) << 20) | ((type & 0xfu) << 28);
+    t[4] = ((depth ? depth : 1) - 1) & 0x1fffu;
 }
 
 int main() {
@@ -294,6 +295,41 @@ int main() {
         CHECK(t2 && t2->size == ((256u + 3) / 4) * ((256u + 3) / 4) * 8u,
               "BC1 size = ceil(w/4)*ceil(h/4)*8 (compressed block bytes, not w*h*4)");
         CHECK(tt.by_sgpr_base(24) == nullptr, "unmapped IMG_FMT T# skipped (no silent RGBA8)");
+    }
+
+    // #657: WORD4 DEPTH is persisted as 3D depth / array-layer count, and the backing size covers
+    // every slice. These resources go through the real T# front half (not hand-filled img_dim fields).
+    {
+        uint32_t layered_sgprs[32]; memset(layered_sgprs, 0, sizeof layered_sgprs);
+        make_tsharp(&layered_sgprs[0],  0xD1000000ull, 16, 4, /*fmt*/56, /*linear*/0,
+                    /*3D*/10, /*depth*/3);
+        make_tsharp(&layered_sgprs[8],  0xD2000000ull, 32, 1, /*fmt*/56, /*linear*/0,
+                    /*1D_ARRAY*/12, /*layers*/4);
+        make_tsharp(&layered_sgprs[16], 0xD3000000ull, 8, 4, /*fmt*/56, /*linear*/0,
+                    /*2D_ARRAY*/13, /*layers*/5);
+        make_tsharp(&layered_sgprs[24], 0xD4000000ull, 16384, 16384, /*RGBA16F*/71, /*linear*/0,
+                    /*3D*/10, /*depth*/8192); // valid fields, impossible uint32 backing -> rejected
+        AgcShaderSharp sharps[4];
+        for (int i = 0; i < 4; ++i) sharps[i].bits = static_cast<uint16_t>(i * 8);
+        AgcShaderUserData lud; memset(&lud, 0, sizeof lud);
+        lud.sharp_resource_offset[0] = sharps; lud.sharp_resource_count[0] = 4;
+        AgcShaderHeader lsh; memset(&lsh, 0, sizeof lsh);
+        lsh.file_header = 0x34333231u; lsh.version = 0x18; lsh.type = 1; lsh.user_data = &lud;
+
+        DecodedImageDescriptor decoded = decode_image_descriptor(&layered_sgprs[0]);
+        CHECK(decoded.depth == 3, "T# WORD4 DEPTH decodes as depth-minus-one + 1");
+        ShaderResourceTable layered = build_shader_resources(lsh, layered_sgprs, 32);
+        CHECK(layered.resources.size() == 3,
+              "3D/array T#s emit; a layered backing beyond uint32 is rejected before probing");
+        const ShaderResource* image3d = layered.by_sgpr_base(0);
+        const ShaderResource* image1da = layered.by_sgpr_base(8);
+        const ShaderResource* image2da = layered.by_sgpr_base(16);
+        CHECK(image3d && image3d->img_dim == 2 && image3d->depth == 3 && image3d->size == 16u * 4 * 3 * 4,
+              "3D descriptor carries depth and all-slice backing size");
+        CHECK(image1da && image1da->img_dim == 4 && image1da->depth == 4 && image1da->size == 32u * 4 * 4,
+              "1D-array descriptor carries layer count and all-layer backing size");
+        CHECK(image2da && image2da->img_dim == 5 && image2da->depth == 5 && image2da->size == 8u * 4 * 5 * 4,
+              "2D-array descriptor carries layer count and all-layer backing size");
     }
 
     // #382: an EUD-resident texture (T# spilled beyond the user-SGPR block) must be emitted, mirroring

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1,15 +1,51 @@
+#include "../src/gpu/agc_shader_layout.hpp"
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include "live_compute.hpp"
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 using namespace prosper::gpu;
 
 static int fails = 0;
 #define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
+
+static void make_tsharp(uint32_t t[8], uint64_t base, uint32_t width, uint32_t height,
+                        uint32_t type, uint32_t depth) {
+    std::memset(t, 0, 8 * sizeof(uint32_t));
+    const uint64_t encoded_base = base >> 8;
+    t[0] = static_cast<uint32_t>(encoded_base);
+    t[1] = static_cast<uint32_t>((encoded_base >> 32) & 0xffu) |
+           (56u << 20) | (((width - 1) & 0x3u) << 30); // IMG_FMT 56 = Unorm8x4
+    t[2] = (((width - 1) >> 2) & 0xfffu) | (((height - 1) & 0x3fffu) << 14);
+    t[3] = (type & 0xfu) << 28; // linear tile mode + real SQ_RSRC_IMG TYPE
+    t[4] = (depth - 1) & 0x1fffu;
+}
+
+static bool build_storage_image_resource(ShaderResource& out, uint8_t* data,
+                                         uint32_t width, uint32_t height,
+                                         uint32_t type, uint32_t depth,
+                                         uint32_t binding, uint32_t sgpr_base) {
+    uint32_t sgprs[8];
+    make_tsharp(sgprs, reinterpret_cast<uint64_t>(data), width, height, type, depth);
+    AgcShaderSharp sharp[1]; sharp[0].bits = 0;
+    AgcShaderUserData user_data{};
+    user_data.sharp_resource_offset[0] = sharp;
+    user_data.sharp_resource_count[0] = 1;
+    AgcShaderHeader header{};
+    header.file_header = 0x34333231u; header.version = 0x18; header.type = 1;
+    header.user_data = &user_data;
+    ShaderResourceTable decoded = build_shader_resources(header, sgprs, 8);
+    if (decoded.resources.size() != 1) return false;
+    out = decoded.resources.front();
+    out.cls = ResourceClass::StorageImage; // image_store consumer selects this class in gpu_executor.
+    out.binding = binding;
+    out.sgpr_base = sgpr_base;
+    return true;
+}
 
 int main() {
     // Dead Cells' bound startup fill kernel, copied verbatim from eboot.elf at runtime address
@@ -169,6 +205,85 @@ int main() {
                              bad, W * 4, img_src[0], img_dst[0]);
         CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
     }
+
+    // #657: production-backend copies for every newly enabled layered shape. Unlike the old 1D
+    // fixture, image metadata here is decoded from real 8-dword T#s via build_shader_resources.
+    static const uint32_t copy_3d[] = {
+        0x361000bfu, 0x7e120280u, 0x2c140086u,
+        0xf0000f10u, 0x00000008u, 0xbf8c3f70u,
+        0xf0200f10u, 0x00020008u, 0xbf810000u,
+    };
+    static const uint32_t copy_1d_array[] = {
+        0x361000bfu, 0x2c120086u,
+        0xf0000f20u, 0x00000008u, 0xbf8c3f70u,
+        0xf0200f20u, 0x00020008u, 0xbf810000u,
+    };
+    static const uint32_t copy_2d_array[] = {
+        0x361000bfu, 0x7e120280u, 0x2c140086u,
+        0xf0000f28u, 0x00000008u, 0xbf8c3f70u,
+        0xf0200f28u, 0x00020008u, 0xbf810000u,
+    };
+    auto run_layered_copy = [&](const uint32_t* code_words, size_t word_count,
+                                uint32_t tsharp_type, uint32_t expected_dim,
+                                const char* shape_name) {
+        constexpr uint32_t width = 64, height = 1, slices = 3;
+        constexpr size_t image_bytes = static_cast<size_t>(width) * height * slices * 4;
+        std::vector<uint8_t> backing(image_bytes * 2 + 512);
+        const uintptr_t first = (reinterpret_cast<uintptr_t>(backing.data()) + 255u) & ~uintptr_t(255u);
+        uint8_t* layered_src = reinterpret_cast<uint8_t*>(first);
+        uint8_t* layered_dst = layered_src + image_bytes; // image_bytes is 256-byte aligned.
+        for (size_t i = 0; i < image_bytes; ++i) layered_src[i] = static_cast<uint8_t>(i * 29 + 11);
+        std::memset(layered_dst, 0xee, image_bytes);
+
+        const uint32_t threads = width * height * slices;
+        std::vector<uint32_t> indices(threads);
+        for (uint32_t i = 0; i < threads; ++i) indices[i] = i;
+        std::vector<uint32_t> scratch(4, 0);
+        ShaderResourceTable layered_table;
+        auto add_layered_buffer = [&](uint32_t binding, void* ptr, uint32_t bytes) {
+            ShaderResource resource{};
+            resource.cls = ResourceClass::ConstantBuffer; resource.binding = binding;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(ptr); resource.size = bytes;
+            layered_table.resources.push_back(resource);
+        };
+        add_layered_buffer(0, indices.data(), threads * sizeof(uint32_t));
+        add_layered_buffer(1, scratch.data(), 16);
+        add_layered_buffer(2, scratch.data(), 16);
+        add_layered_buffer(3, scratch.data(), 16);
+        ShaderResource src_image{}, dst_image{};
+        const bool src_built = build_storage_image_resource(
+            src_image, layered_src, width, height, tsharp_type, slices, 4, 0);
+        const bool dst_built = build_storage_image_resource(
+            dst_image, layered_dst, width, height, tsharp_type, slices, 5, 8);
+        CHECK(src_built && dst_built, "layered storage images decode from real T# descriptors");
+        CHECK(src_built && src_image.img_dim == expected_dim && src_image.depth == slices &&
+              src_image.size == image_bytes,
+              "layered T# carries the expected dimension, slice count, and backing size");
+        if (!src_built || !dst_built) return;
+        layered_table.resources.push_back(src_image);
+        layered_table.resources.push_back(dst_image);
+
+        std::vector<uint32_t> layered_spirv = recompile_valu(
+            code_words, word_count, 1, 0, &layered_table);
+        CHECK(!layered_spirv.empty(), "layered storage-image copy kernel recompiles");
+        if (layered_spirv.empty()) return;
+        ComputeItem layered_item;
+        layered_item.spirv = std::move(layered_spirv);
+        layered_item.resources = std::make_shared<ShaderResourceTable>(layered_table);
+        layered_item.launch.threads_x = threads; layered_item.launch.local_x = 64;
+        layered_item.launch.groups_x = threads / 64;
+        layered_item.launch.local_y = layered_item.launch.local_z = 1;
+        layered_item.launch.groups_y = layered_item.launch.groups_z = 1;
+        layered_item.code_addr = 0x657000 + expected_dim;
+        const bool executed = prosper::frontend::execute_live_compute_items({layered_item});
+        if (!executed) std::printf("  layered backend rejected %s\n", shape_name);
+        CHECK(executed, "production backend executes layered storage-image dispatch");
+        CHECK(std::memcmp(layered_src, layered_dst, image_bytes) == 0,
+              "layered upload -> copy -> writeback is byte-exact across every slice");
+    };
+    run_layered_copy(copy_3d, sizeof(copy_3d) / sizeof(copy_3d[0]), 10, 2, "3D");
+    run_layered_copy(copy_1d_array, sizeof(copy_1d_array) / sizeof(copy_1d_array[0]), 12, 4, "1D_ARRAY");
+    run_layered_copy(copy_2d_array, sizeof(copy_2d_array) / sizeof(copy_2d_array[0]), 13, 5, "2D_ARRAY");
 
     if (fails) {
         std::printf("== FAIL: %d ==\n", fails);

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -106,6 +106,13 @@ int main() {
     large_resource.size = 2u << 20;
     CHECK(gpu_capture_resource_footprint(large_resource) == (2u << 20),
           "public capture footprint reports the planner's declared buffer range");
+    ShaderResource layered_footprint{};
+    layered_footprint.cls = ResourceClass::StorageImage;
+    layered_footprint.format = DataFormat::Unorm8; layered_footprint.num_components = 4;
+    layered_footprint.img_dim = 2; layered_footprint.width = 2; layered_footprint.height = 3;
+    layered_footprint.depth = 4;
+    CHECK(gpu_capture_resource_footprint(layered_footprint) == 2u * 3 * 4 * 4,
+          "capture footprint includes every 3D slice");
     large_table->resources = {large_resource};
     DrawItem large_draw = draw;
     large_draw.vrt = large_table;
@@ -156,7 +163,7 @@ int main() {
           deserialize_gpu_capture(stencil_only_bytes, stencil_only_loaded, error) &&
           !stencil_only_loaded.ds_seeds[0].depth_valid &&
           stencil_only_loaded.ds_seeds[0].stencil_valid,
-          "stencil-only validity survives capture v8 independently of depth");
+          "stencil-only validity survives capture v9 independently of depth");
     GpuCaptureFile invalid_stencil_format = stencil_only;
     invalid_stencil_format.ds_seeds[0].format = GpuCaptureDsFormat::D32Float;
     CHECK(!serialize_gpu_capture(invalid_stencil_format, stencil_only_bytes, error) &&
@@ -238,6 +245,23 @@ int main() {
           "mixed graphics/compute submit captures without a renderer");
     CHECK(mixed.blobs.size() == 1 && mixed.shader_versions.size() == 2,
           "identical address-distinct resources and shared shaders deduplicate by content");
+    GpuCaptureFile layered_capture = mixed;
+    GpuCapturedResource layered_ref;
+    layered_ref.resource = layered_footprint;
+    layered_ref.resource.binding = 6; layered_ref.resource.gpu_addr = 0x4000;
+    layered_ref.resource.size = 2u * 3 * 4 * 4;
+    layered_capture.computes[0].resources.resources.push_back(layered_ref);
+    std::vector<uint8_t> layered_bytes;
+    GpuCaptureFile layered_loaded;
+    CHECK(serialize_gpu_capture(layered_capture, layered_bytes, error) &&
+          deserialize_gpu_capture(layered_bytes, layered_loaded, error) &&
+          layered_loaded.computes[0].resources.resources.back().resource.depth == 4,
+          "capture v9 round-trips image depth/array-layer metadata");
+    GpuCaptureFile invalid_layered = layered_capture;
+    invalid_layered.computes[0].resources.resources.back().resource.depth = 0;
+    CHECK(!serialize_gpu_capture(invalid_layered, layered_bytes, error) &&
+          error == "resource image depth/layer count is outside the T# range",
+          "capture writer rejects an invalid zero layer count");
     CHECK(mixed.operations.size() == 3 && mixed.operations[0].realized &&
           mixed.operations[1].realized && !mixed.operations[2].realized,
           "mixed operation plan explicitly retains unrealized work");
@@ -335,12 +359,24 @@ int main() {
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 24,
-          "created a diagnostic-free v8 payload for legacy-reader fixtures");
+          "created a diagnostic-free v9 payload for legacy-reader fixtures");
     if (legacy_bytes.size() >= 24) {
+        size_t legacy_resource_count = 0;
+        for (const auto& draw_ref : legacy_source.draws)
+            legacy_resource_count += draw_ref.vrt.resources.size() + draw_ref.prt.resources.size();
+        for (const auto& compute_ref : legacy_source.computes)
+            legacy_resource_count += compute_ref.resources.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 4 - legacy_resource_count * 4); // remove v9 shape sidecar
+        legacy_bytes[8] = 8; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
+    }
+    GpuCaptureFile legacy_loaded;
+    CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
+          legacy_loaded.draws[0].vrt.resources[0].resource.depth == 1,
+          "v8 capture reopens with legacy image depth defaulted to one");
+    if (legacy_bytes.size() >= 16) {
         legacy_bytes.resize(legacy_bytes.size() - 4); // remove v8 DS-seed zero count
         legacy_bytes[8] = 7; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
     }
-    GpuCaptureFile legacy_loaded;
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           legacy_loaded.failure_diagnostics_available && legacy_loaded.ds_seeds.empty(),
           "v7 capture reopens without persistent DS checkpoint data");
@@ -351,9 +387,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 9;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 10;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 9",
+          error == "unsupported capture version 10",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -94,8 +94,9 @@ compact target-extent spans; use `--signatures DRAWS DISPATCHES` to discover sce
 independent of `PROSPER_RENDER_EVERY`. To materialize one exact indexed submit without rendering the
 warmup, set `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE=<path>.prgcap` on a second run. Version-2 detail records link the capsule;
-version-8 capsules deduplicate content-addressed shader/resource versions, retain complete raw depth-surface
-programming, and preserve mixed draw/dispatch order plus explicit unrealized operations. Failed operations
+version-9 capsules deduplicate content-addressed shader/resource versions, retain complete raw depth-surface
+programming plus layered-image depth/layer counts, and preserve mixed draw/dispatch order plus explicit
+unrealized operations. Failed operations
 also retain bounded raw stages and exact rejection/state summaries; inspect them with `gpu_replay --inspect-only`
 and extract one with `--dump-failed-shader FAILURE:STAGE PATH`. Selection is
 intentionally bounded to the consumer and an optional
@@ -129,7 +130,7 @@ lifetime evidence proves the suffix contains the target's beginning, then inspec
 `gpu_replay --bundle-intermediate-through-target WxH` omits later passes from non-final submits only when
 dependency evidence proves that the named target family is the sole temporal image frontier.
 `gpu_replay --bundle-final-capsule PATH` exports the complete live color RTT cache plus exact valid planes from
-the persistent Vulkan depth/stencil cache into a capture-v8 capsule. Verify its standalone output hash against
+the persistent Vulkan depth/stencil cache into a capture-v9 capsule. Verify its standalone output hash against
 the bundle before using it for rapid final-submit isolation. `--inspect-only` prints each DS seed's full cache
 identity, format, independent validity flags, byte counts, and hashes. Captures v1-v7 remain readable without
 invented DS state.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -142,7 +142,7 @@ if an included temporal image leaf has another extent or an intermediate submit 
 an evidence-gated optimization, not automatic dependency closure.
 
 `--bundle-final-capsule PATH` snapshots the complete live color RTT and persistent Vulkan depth/stencil caches
-before executing the final submit and writes them as seeds in a standalone capture-v8 capsule. Its standalone
+before executing the final submit and writes them as seeds in a standalone capture-v9 capsule. Its standalone
 output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or
 shader experiments. Export validates every surface and fails when a required temporal color surface is absent;
 it never substitutes zero pixels. The file is installed only after the source final submit renders, and embeds


### PR DESCRIPTION
Fixes #657.

## What changed

- Persist SQ image depth/array-layer metadata through resource realization and capture v9.
- Size 3D and array image backing across every slice with checked bounds.
- Add Vulkan storage-image support for 3D, 1D-array, and 2D-array views, uploads, copies, and readback.
- Preserve capture v1-v8 compatibility by storing the new metadata in a deterministic v9 sidecar.
- Add real T# descriptor fixtures and byte-exact production-backend copies for all newly supported shapes.

## Why

The compute backend previously deferred layered and 3D storage images because their depth/layer metadata was not capture-safe. DOLL can emit these descriptors, so silently flattening or executing them as 2D would corrupt capture/replay and guest writeback.

## Validation

- Full post-rebase suite: 92/92 tests passed.
- Messenger and Dead Cells rendering snapshot guards passed.
- Bounded DOLL smoke reached 713 compute submissions with no execution failures; no layered image-bound dispatch occurred during that window.
