### PR TITLE
Improve guest binary reference tooling

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -43,6 +43,11 @@ endif()
 
 # --- tests (agentic-first: self-checking, exit-code = truth) -------------
 enable_testing()
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_Interpreter_FOUND)
+  add_test(NAME re_xref_decoder
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
+endif()
 # Path to the (gitignored) local game dump; override with -DGAME_DUMP=...
 set(GAME_DUMP "${CMAKE_SOURCE_DIR}/../PPSA24651-app0" CACHE PATH "Local PS5 game dump root")
 set(HAVE_GAME_DUMP OFF)

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -15,8 +15,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   for slow software rendering,
   and the pixel-distinct/pixel-stale assertions when visible progression matters. Source publication
   counts alone do not prove that the image changed; see `screenshot/README.md`.
-- **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map
-  (find file offsets for offline disassembly).
+- **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map, import NIDs, and
+  export RVAs. Use `--find-symbol NID` for a focused import/export query.
+- **`re/xref.py`** — find relative data pointers, direct references, runtime function-table
+  writers, and indirect callers in a flattened guest module. See `re/README.md`.
 - **`shader_histo/`** — histogram RDNA2 opcodes across a title's shaders.
 - **`shader_inspect/`** — decode one raw `PROSPER_SHADER_DUMP` binary offline. It prints bounded
   instruction PCs, operands, raw words, signed branch immediates, and resolved branch targets so a

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -1,0 +1,39 @@
+# Guest binary reference workflow
+
+Use these tools to map an unsymbolicated guest address without running a debugger. All addresses printed
+by the tools are image-relative; add the module's load base only when comparing them with a live trace.
+
+## Find an exported function
+
+PS5 dynamic symbols use NIDs rather than plaintext names. Once a name has been hashed with
+`prosper::nid_hash` (or obtained from a runtime lookup), query its module directly:
+
+```bash
+./build-linux/self_dump /path/to/module.prx --find-symbol vXRp9zVGPzU
+```
+
+The result distinguishes imports from exports and prints the export RVA. `--symbols` prints every import
+NID and every defined export with its RVA, size, module, and library context.
+
+## Find readers and writers of a slot
+
+Flatten the SELF/PRX first, then query the address with `xref.py`:
+
+```bash
+python3 tools/il2cpp/prx_to_elf.py /path/to/eboot.bin /tmp/eboot.elf
+python3 tools/re/xref.py /tmp/eboot.elf to 0x2031d10
+```
+
+The `to` query reports Sony relative-relocation data pointers, direct calls, RIP-relative loads/stores,
+and indirect calls/jumps through the requested slot. `from ADDRESS` lists references made by the function
+window containing that address; `reloc ADDRESS` restricts output to relative data relocations.
+
+For The Messenger, the example above identifies both sides of Unity's runtime IL2CPP API table:
+
+```text
+store at eboot+0x148276c   # writes dlsym("il2cpp_init")
+call* at eboot+0x1473a6f  # invokes the populated slot
+```
+
+This slot is zero in the flat image and has no ELF relocation. Treating every indirect RIP-relative call
+as a static GOT import would send the investigation to the wrong layer.

--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Synthetic decoder regression for xref.py's supported x86-64 reference forms."""
+
+import importlib.util
+import os
+import struct
+import sys
+import tempfile
+
+
+sys.dont_write_bytecode = True
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("prosper_xref", os.path.join(HERE, "xref.py"))
+XREF = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(XREF)
+
+
+def rel32(site, insn_size, target):
+    return struct.pack("<i", target - (site + insn_size))
+
+
+def main():
+    raw = bytearray(0x200)
+    raw[:4] = b"\x7fELF"
+    struct.pack_into("<Q", raw, 0x20, 0x40)       # e_phoff
+    struct.pack_into("<HH", raw, 0x36, 56, 1)    # e_phentsize, e_phnum
+    struct.pack_into("<IIQQQQQQ", raw, 0x40,
+                     1, 5, 0x100, 0x1000, 0, 0x100, 0x100, 0x1000)
+
+    slot = 0x1200
+    direct_target = 0x1080
+    code = bytearray()
+    site = 0x1000
+    code += b"\xe8" + rel32(site, 5, direct_target)
+    site += 5
+    code += b"\x48\x8d\x05" + rel32(site, 7, slot)
+    site += 7
+    code += b"\x48\x8b\x05" + rel32(site, 7, slot)
+    site += 7
+    code += b"\x48\x89\x05" + rel32(site, 7, slot)
+    site += 7
+    code += b"\xff\x15" + rel32(site, 6, slot)
+    site += 6
+    code += b"\xff\x25" + rel32(site, 6, slot)
+    raw[0x100:0x100 + len(code)] = code
+
+    path = ""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+            f.write(raw)
+        module = XREF.Module(path)
+        expected = {
+            (0x1005, "lea"),
+            (0x100c, "load"),
+            (0x1013, "store"),
+            (0x101a, "call*"),
+            (0x1020, "jmp*"),
+        }
+        actual = set(module.code_xref[slot])
+        assert actual == expected, (actual, expected)
+        assert module.code_xref[direct_target] == [(0x1000, "call")]
+    finally:
+        if path:
+            os.unlink(path)
+
+    print("xref decoder: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -3,7 +3,8 @@
 #
 # PS5 eboot/PRX code is position-independent: internal references appear as
 #   - direct calls          e8 <rel32>
-#   - rip-relative lea/mov   REX.W/REX.WR  8d|8b  modrm(rip)  <disp32>
+#   - rip-relative load/store REX.W/REX.WR 8d|8b|89 modrm(rip) <disp32>
+#   - indirect call/jump     ff /2|/4 modrm(rip) <disp32>
 #   - data pointers          absolute pointers stored in data, emitted as
 #                            R_X86_64_RELATIVE relocations (DT_RELA / DT_SCE_RELA)
 # so "grep for who references address X" is not a text search — it needs all three
@@ -69,7 +70,7 @@ class Module:
     def _build(self):
         raw = self.raw
         self.data_xref = defaultdict(list)   # target VA -> [site VAs] (relocated data pointers)
-        self.code_xref = defaultdict(list)   # target VA -> [(site VA, kind)]  kind in {call, lea, mov}
+        self.code_xref = defaultdict(list)   # target VA -> [(site VA, kind)]
         # --- relocations (standard DT_RELA + Sony DT_SCE_RELA) ---
         if self.dyn_va:
             o = self.foff(self.dyn_va)
@@ -86,7 +87,7 @@ class Module:
                         r_off, r_info, r_add = struct.unpack_from('<QQq', raw, base + i * 24)
                         if (r_info & 0xffffffff) == 8:   # R_X86_64_RELATIVE: target VA = addend
                             self.data_xref[r_add].append(r_off)
-        # --- code scan: rip-relative lea/mov (REX.W 0x48 and REX.WR 0x4c) + e8 calls ---
+        # --- code scan: direct calls, RIP-relative data accesses, and calls/jumps through slots ---
         for v, o, fs, fl in self.segs:
             if not (fl & 1):
                 continue
@@ -94,10 +95,17 @@ class Module:
             n = len(d)
             for i in range(n - 7):
                 b = d[i]
-                if b in (0x48, 0x4c) and d[i + 1] in (0x8d, 0x8b) and d[i + 2] in MODRM_RIP:
+                if b in (0x48, 0x4c) and d[i + 1] in (0x8d, 0x8b, 0x89) and d[i + 2] in MODRM_RIP:
                     disp = struct.unpack_from('<i', d, i + 3)[0]
                     site = v + i
-                    self.code_xref[site + 7 + disp].append((site, 'lea' if d[i + 1] == 0x8d else 'mov'))
+                    kind = {0x8d: 'lea', 0x8b: 'load', 0x89: 'store'}[d[i + 1]]
+                    self.code_xref[site + 7 + disp].append((site, kind))
+                elif b == 0xff and i + 5 < n and (d[i + 1] & 0xc7) == 0x05:
+                    reg = (d[i + 1] >> 3) & 7
+                    if reg in (2, 4):
+                        disp = struct.unpack_from('<i', d, i + 2)[0]
+                        site = v + i
+                        self.code_xref[site + 6 + disp].append((site, 'call*' if reg == 2 else 'jmp*'))
                 elif b == 0xe8:
                     disp = struct.unpack_from('<i', d, i + 1)[0]
                     site = v + i

--- a/prosper/tools/self_dump/self_dump.cpp
+++ b/prosper/tools/self_dump/self_dump.cpp
@@ -13,7 +13,7 @@
 // module/function set defines the entire HLE surface we must implement.
 //
 // Build: g++ -O2 -std=c++20 self_dump.cpp -o self_dump
-// Usage: self_dump <file.self|eboot.bin|*.prx> [--symbols]
+// Usage: self_dump <file.self|eboot.bin|*.prx> [--symbols] [--find-symbol NID]
 
 #include <cstdio>
 #include <cstdint>
@@ -150,8 +150,22 @@ static const char* dtag_name(int64_t t) {
 }
 
 int main(int argc, char** argv) {
-    if (argc < 2) { fprintf(stderr, "usage: %s <file> [--symbols]\n", argv[0]); return 1; }
-    bool dump_syms = (argc >= 3 && strcmp(argv[2], "--symbols") == 0);
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <file> [--symbols] [--find-symbol NID]\n", argv[0]);
+        return 1;
+    }
+    bool dump_syms = false;
+    std::string find_symbol;
+    for (int i = 2; i < argc; ++i) {
+        if (strcmp(argv[i], "--symbols") == 0) {
+            dump_syms = true;
+        } else if (strcmp(argv[i], "--find-symbol") == 0 && i + 1 < argc) {
+            find_symbol = argv[++i];
+        } else {
+            fprintf(stderr, "usage: %s <file> [--symbols] [--find-symbol NID]\n", argv[0]);
+            return 1;
+        }
+    }
     auto b = read_file(argv[1]);
 
     // -- SELF header --
@@ -321,7 +335,13 @@ int main(int argc, char** argv) {
     auto b64val = [&](const std::string& s) -> int {
         int v = 0; for (char c : s) { const char* p = strchr(B64, c); if (!p) return -1; v = v * 64 + (int)(p - B64); } return v;
     };
-    std::map<std::string, std::set<std::string>> by_lib; // libname -> set of NIDs
+    struct SymbolRec {
+        std::string nid, libname, modname;
+        uint64_t value = 0, size = 0;
+        bool is_import = false;
+    };
+    std::vector<SymbolRec> symbol_recs;
+    std::map<std::string, std::set<std::string>> by_lib; // libname -> set of import NIDs
     size_t nsym = syment ? symtabsz / syment : 0, n_import = 0, n_export = 0;
     for (size_t i = 0; i < nsym && symtab_foff >= 0; i++) {
         auto sym = rd<Elf64_Sym>(b, (size_t)symtab_foff + i * syment);
@@ -332,10 +352,20 @@ int main(int argc, char** argv) {
         auto h2 = s.find('#', h1 + 1);
         std::string nid = s.substr(0, h1);
         std::string libid = (h2 == std::string::npos) ? "" : s.substr(h1 + 1, h2 - h1 - 1);
+        std::string modid = (h2 == std::string::npos) ? "" : s.substr(h2 + 1);
         int lid = b64val(libid);
-        std::string libname = import_libs.count(lid) ? import_libs[lid].name
-                              : export_libs.count(lid) ? export_libs[lid].name : ("lib#" + libid);
         bool is_import = (sym.st_shndx == 0 && sym.st_value == 0);
+        std::string libname;
+        if (is_import && import_libs.count(lid)) libname = import_libs[lid].name;
+        else if (!is_import && export_libs.count(lid)) libname = export_libs[lid].name;
+        else if (import_libs.count(lid)) libname = import_libs[lid].name;
+        else if (export_libs.count(lid)) libname = export_libs[lid].name;
+        else libname = "lib#" + libid;
+        int mid = b64val(modid);
+        std::string modname = !is_import && export_libs.count(lid) ? export_libs[lid].name
+                              : needed_mods.count(mid) ? needed_mods[mid].name
+                              : ("mod#" + modid);
+        symbol_recs.push_back({nid, libname, modname, sym.st_value, sym.st_size, is_import});
         if (is_import) { n_import++; by_lib[libname].insert(nid); }
         else n_export++;
     }
@@ -344,6 +374,33 @@ int main(int argc, char** argv) {
     for (auto& [lib, nids] : by_lib) {
         printf("  %-32s %zu functions\n", lib.c_str(), nids.size());
         if (dump_syms) for (auto& n : nids) printf("       %s\n", n.c_str());
+    }
+
+    if (dump_syms) {
+        printf("\n[EXPORTS]\n");
+        for (const auto& sym : symbol_recs) {
+            if (sym.is_import) continue;
+            printf("  0x%09llx size=0x%-8llx %-11s  %s::%s\n",
+                   (unsigned long long)sym.value, (unsigned long long)sym.size,
+                   sym.nid.c_str(), sym.modname.c_str(), sym.libname.c_str());
+        }
+    }
+
+    if (!find_symbol.empty()) {
+        size_t found = 0;
+        printf("\n[SYMBOL QUERY] %s\n", find_symbol.c_str());
+        for (const auto& sym : symbol_recs) {
+            if (sym.nid != find_symbol) continue;
+            ++found;
+            printf("  %-6s value=0x%09llx size=0x%llx  %s::%s\n",
+                   sym.is_import ? "IMPORT" : "EXPORT",
+                   (unsigned long long)sym.value, (unsigned long long)sym.size,
+                   sym.modname.c_str(), sym.libname.c_str());
+        }
+        if (!found) {
+            printf("  not found\n");
+            return 2;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add focused `self_dump --find-symbol NID` queries and export RVA/context output
- teach `xref.py` to identify RIP-relative stores plus indirect calls/jumps through runtime-populated function tables
- document the offline workflow and add a synthetic x86-64 decoder regression

## Messenger result
The tools now establish that eboot `+0x2031d10` has no ELF relocation, is written at `+0x148276c`, and is invoked at `+0x1473a6f`. `il2cpp_init` (`vXRp9zVGPzU`) exports at `Il2cpp+0x107730`; its wrapper calls the real init body at `Il2cpp+0x169780`.

## Tests
- Windows standalone `self_dump` compile with `-Wall -Wextra -Werror`
- Linux CMake `self_dump` build
- `re_xref_decoder` CTest
- live dump queries against The Messenger eboot and Il2cppUserAssemblies

Closes #676
Supports #673