### PR TITLE
Fix Windows binary file reads

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -249,6 +249,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_stat PRIVATE prosper_core)
   add_test(NAME sce_stat_layout COMMAND test_stat)
 
+  add_executable(test_file_binary tests/test_file_binary.cpp)
+  target_link_libraries(test_file_binary PRIVATE prosper_core)
+  add_test(NAME file_binary_roundtrip COMMAND test_file_binary)
+
   # APR container registry + size-keyed read matching (issue #62): stable ids, path dedup, and
   # the ambiguity/chunk-read refusal the read-submit path relies on. Pure, no game dump needed.
   add_executable(test_apr_registry tests/test_apr_registry.cpp)

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -296,14 +296,14 @@ This is exactly the hard sub-problem flagged above for both Windows and macOS. P
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
 trap-and-emulate of `%fs:` operands is in-house technology.
 
-## Windows port status (2026-07-14) — first GPU fence fixed; IL2CPP init parity is next
+## Windows port status (2026-07-14) — IL2CPP metadata fixed; GC exception delivery is next
 
 The native MinGW build now links and initializes the live Vulkan renderer, boots The Messenger through
-Unity asset loading, emits a correct first GPU fence, and completes SubmitDcb #1. The guest `%fs`,
-threading, positioned-I/O, WaitOnAddress, VEH, and integer ABI foundations below are runtime-verified.
-The current blocker is #673: Windows `il2cpp_init("IL2CPP Root Domain")` returns false, leaving an
-Il2CppClass global null; once the corrected fence releases the render thread, generated code faults on
-that null before SubmitDcb #2. Linux initializes the same path and reaches repeated draw submissions.
+Unity asset loading, reads and initializes IL2CPP metadata, emits a correct first GPU fence, and completes
+SubmitDcb #1. The guest `%fs`, threading, positioned-I/O, WaitOnAddress, VEH, and integer ABI foundations
+below are runtime-verified. The current blocker is #678: the Windows `sceKernelRaiseException` path still
+returns success without asynchronously running the installed handler on the target thread. IL2CPP's GC
+therefore waits forever for a stop-the-world suspension acknowledgement before later graphics submissions.
 
 - **Direct/flexible-memory HLE ported to Win32** (`hle_kernel_mem.cpp` `#else` block). The pool
   bookkeeping + VA tracker are copied verbatim from POSIX; mappings are backed by private
@@ -376,7 +376,7 @@ thread-safe on a shared fd, full-read loop for the PS5 full-count contract) — 
 also loop now. (`libSceSystemService::mPpPxv5CZt4` = `sceSystemServiceGetHdrToneMapLuminance` is a benign
 HDR stub returning 0, tracked in #664 — not a blocker.)
 
-### GPU stack-argument fence fields — SOLVED (#672); current frontier: IL2CPP initialization (#673)
+### GPU stack-argument fence fields — SOLVED (#672)
 
 The EOP machinery was working; the Windows import trampoline dropped guest stack arguments 7-9. AGC's
 ReleaseMem/WaitRegMem handlers then decoded compiler shadow-space garbage as `data_sel`, `data`,
@@ -387,8 +387,24 @@ and fixed-arity AGC handlers use explicit parameters instead of `__builtin_frame
 Native validation now matches Linux exactly: `ReleaseMem data_sel=2 data=1`, followed by
 `WaitRegMem ref=1 mask=ffffffff`; the `NOT satisfied` message is gone and SubmitDcb #1 completes. Five
 Windows runs then fail consistently at `Il2cpp+0x17d64b` because `il2cpp_init` had already returned false
-and an Il2CppClass global at `Il2cpp+0x268c878` is null. That distinct initialization-parity problem is
-tracked in #673; do not mask the null or reopen the solved fence-field investigation.
+and an Il2CppClass global at `Il2cpp+0x268c878` is null. That distinct initialization-parity problem was
+tracked and solved in #673; do not reopen the solved fence-field investigation.
+
+### IL2CPP metadata read — SOLVED (#673); current frontier: GC exception delivery (#678)
+
+Windows opened and fstat'd `Media/Metadata/global-metadata.dat` correctly, but the low-level guest fd
+path omitted `O_BINARY`. The Windows CRT consequently treated the first `0x1a` byte as text EOF: a
+10,743,608-byte read returned exactly 440 bytes, the real file's first `0x1a` offset, and
+`il2cpp_init` rejected the truncated metadata. Windows `host_open_flags` now always includes `O_BINARY`;
+a cross-platform HLE regression test reads through embedded `0x1a` and CRLF bytes. `PROSPER_FILELOG=1`
+now records host open results, fd-to-path associations, fstat sizes, and read/pread return counts, which
+made this failure visible without debugger stepping.
+
+Native validation reads all 10,743,608 bytes, no longer prints `unable to initialize il2cpp`, and shows
+the formerly-null global at `Il2cpp+0x268c878` initialized. That exposes the distinct #678 stop-the-world
+blocker: `sceKernelRaiseException(target, 0x1e)` is implemented with targeted signals on Linux/macOS but
+is a success no-op on Windows, so the raiser blocks on `SuspendSemaphore` while the target never runs the
+installed handler.
 
 (Historical, pre-fix diagnosis retained below for context.)
 
@@ -459,9 +475,10 @@ granularity); and `PROSPER_CRASHPEEK` guards.
   `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **Restore IL2CPP initialization parity (#673), the current frontier.** Identify the cross-module
-   `il2cpp_init` binding at eboot GOT `+0x2031d10`, compare its return path and required globals with
-   Linux, and make `Il2cpp+0x268c878` valid before use. Do not patch around the null class.
+1. **Port asynchronous GC exception delivery (#678), the current frontier.** Windows must interrupt
+   the requested `pthread_t`, synthesize the same FreeBSD mcontext used by the POSIX path, run the
+   installed guest handler on that target thread, and resume the interrupted context after the handler
+   returns. Do not fake the `SuspendSemaphore` acknowledgement.
 2. **Preserve physical-offset aliasing in the Windows memory HLE.** Private `VirtualAlloc` is sufficient
    for Unity, but UE4 MallocBinned3 needs shared backing (`CreateFileMapping`/`MapViewOfFile3`) while
    respecting Windows' 64 KiB allocation granularity.

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -48,6 +48,45 @@ namespace prosper {
 namespace {
     std::string g_app0;   // host directory backing guest "/app0"
     bool filelog() { static int v = getenv("PROSPER_FILELOG") ? 1 : 0; return v; }
+    std::mutex g_filelog_fd_mx;
+    std::map<int, std::string> g_filelog_fd_paths;
+
+    void filelog_remember_fd(int fd, const std::string& path) {
+        if (!filelog() || fd < 0) return;
+        std::lock_guard<std::mutex> lk(g_filelog_fd_mx);
+        g_filelog_fd_paths[fd] = path;
+    }
+
+    std::string filelog_fd_path(int fd) {
+        if (!filelog()) return {};
+        std::lock_guard<std::mutex> lk(g_filelog_fd_mx);
+        auto it = g_filelog_fd_paths.find(fd);
+        return it == g_filelog_fd_paths.end() ? std::string() : it->second;
+    }
+
+    void filelog_forget_fd(int fd) {
+        if (!filelog()) return;
+        std::lock_guard<std::mutex> lk(g_filelog_fd_mx);
+        g_filelog_fd_paths.erase(fd);
+    }
+
+    void filelog_fd_io(const char* op, int fd, int64_t off, uint64_t count,
+                       int64_t result, int err) {
+        if (!filelog()) return;
+        std::string path = filelog_fd_path(fd);
+        fprintf(stderr,
+                "[file] %s fd=%d path='%s' off=0x%llx count=0x%llx -> %lld error=%d\n",
+                op, fd, path.empty() ? "?" : path.c_str(),
+                (unsigned long long)off, (unsigned long long)count,
+                (long long)result, err);
+    }
+
+    void filelog_fd_stat(int fd, int result, int err, int64_t size) {
+        if (!filelog()) return;
+        std::string path = filelog_fd_path(fd);
+        fprintf(stderr, "[file] fstat fd=%d path='%s' -> %d size=%lld error=%d\n",
+                fd, path.empty() ? "?" : path.c_str(), result, (long long)size, err);
+    }
     // Host directory backing guest "/temp0" — the app temp-data area that
     // sceAppContentTemporaryDataMount2 (hle_service.cpp) reports to the game. Created on first
     // use; override with PROSPER_TEMP0. A scratch dir outside the dump keeps the game's writes
@@ -350,7 +389,12 @@ static int host_open_flags(uint64_t f) {
     if (f & 0x0200) h |= O_CREAT;
     if (f & 0x0400) h |= O_TRUNC;
     if (f & 0x0800) h |= O_EXCL;
-#ifndef _WIN32
+#ifdef _WIN32
+    // Game content is binary. Without O_BINARY, the Windows CRT treats 0x1a as EOF and
+    // translates CRLF during _read; global-metadata.dat's first 0x1a is at byte 440, so
+    // IL2CPP received 440 bytes from a valid 10.7 MiB file and rejected initialization.
+    h |= O_BINARY;
+#else
     if (f & 0x0004) h |= O_NONBLOCK;
     if (f & 0x0080) h |= O_SYNC;                // FreeBSD O_FSYNC
     if (f & 0x0100) h |= O_NOFOLLOW;
@@ -358,13 +402,23 @@ static int host_open_flags(uint64_t f) {
 #endif
     return h;
 }
-HLE(f_open)  { std::string h = translate(CS(a0)); int fd = (int)::open(h.c_str(), host_open_flags(a1), (mode_t)a2);
+HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_flags(a1);
+               int fd = (int)::open(h.c_str(), host_flags, (mode_t)a2);
 #ifndef _WIN32
                while (fd >= 0 && fd < 3) { int nfd = fcntl(fd, F_DUPFD, 3); ::close(fd); fd = nfd; }
 #endif
+               int err = fd < 0 ? errno : 0;
+               filelog_remember_fd(fd, h);
+               if (filelog()) fprintf(stderr,
+                   "[file] open-result host='%s' guest-flags=0x%llx host-flags=0x%x -> fd=%d error=%d\n",
+                   h.c_str(), (unsigned long long)a1, host_flags, fd, err);
                if (fd >= 0) preadlog("open", (uint64_t)fd, 0, 0); return (uint64_t)(int64_t)fd; }
 HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
-               preadlog("close", a0, 0, 0); return (uint64_t)(int64_t)::close((int)a0); }
+               preadlog("close", a0, 0, 0);
+               int fd = (int)a0; int r = ::close(fd); int err = r < 0 ? errno : 0;
+               filelog_fd_io("close", fd, 0, 0, r, err);
+               if (r == 0) filelog_forget_fd(fd);
+               return (uint64_t)(int64_t)r; }
 // dup/dup2 were MISSING -> the return-0 stub handed back fd 0 (a valid-looking descriptor that is actually
 // stdin), so the guest read/closed stdin thinking it was its duplicate -> the fd-0 hazard this file guards
 // against elsewhere. Back with host dup/dup2; dup keeps the result above fd 2 (same as f_open).
@@ -411,9 +465,15 @@ static int64_t write_full(int fd, const void* buf, size_t count, bool positioned
     return (int64_t)done;
 }
 #endif
-HLE(f_read)  { if (fdlog_on()) preadlog("read", a0, (uint64_t)::lseek((int)a0, 0, SEEK_CUR), a2);
+HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
+               if (filelog() || fdlog_on()) off = (int64_t)::lseek(fd, 0, SEEK_CUR);
+               if (fdlog_on()) preadlog("read", a0, (uint64_t)off, a2);
+               auto logged_return = [&](int64_t r) -> uint64_t {
+                   filelog_fd_io("read", fd, off, a2, r, r < 0 ? errno : 0);
+                   return (uint64_t)r;
+               };
 #ifndef _WIN32
-               return (uint64_t)read_full((int)a0, P(a1), (size_t)a2, false, 0);
+               return logged_return(read_full(fd, P(a1), (size_t)a2, false, 0));
 #else
                // Full sequential read (loop) — same full-count contract as read_full: a short ::read
                // would leave Unity's asset cache block partially filled and deserialize corrupt data.
@@ -421,11 +481,11 @@ HLE(f_read)  { if (fdlog_on()) preadlog("read", a0, (uint64_t)::lseek((int)a0, 0
                  while (done < cnt) {
                      unsigned want = (cnt - done) > 0x40000000u ? 0x40000000u : (unsigned)(cnt - done);
                      int r = ::read((int)a0, b + done, want);
-                     if (r < 0) return done ? (uint64_t)done : (uint64_t)-1;
+                     if (r < 0) return logged_return(done ? (int64_t)done : (int64_t)-1);
                      if (r == 0) break;   // EOF
                      done += (size_t)r;
                  }
-                 return (uint64_t)done; }
+                 return logged_return((int64_t)done); }
 #endif
              }
 HLE(f_write) {
@@ -438,7 +498,8 @@ HLE(f_write) {
 HLE(f_lseek) { if (fdlog_on() && ((int)a2 != SEEK_CUR || a1 != 0)) preadlog("lseek", a0, a1, (uint64_t)a2);
                return (uint64_t)(int64_t)::lseek((int)a0, (off_t)a1, (int)a2); }
 #ifndef _WIN32
-HLE(f_pread)  { preadlog("pread", a0, a3, a2); return (uint64_t)read_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3); }
+HLE(f_pread)  { preadlog("pread", a0, a3, a2); int64_t r = read_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3);
+                filelog_fd_io("pread", (int)a0, (int64_t)a3, a2, r, r < 0 ? errno : 0); return (uint64_t)r; }
 HLE(f_pwrite) { return (uint64_t)write_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3); }
 // Vectored IO — OrbisKernelIovec == host iovec { void* iov_base; size_t iov_len }, and guest pointers are
 // identity-mapped, so the guest iovec array and its buffers pass straight to host (p)readv/(p)writev.
@@ -481,7 +542,9 @@ int64_t win_pio(int fd, void* buf, size_t count, uint64_t off, bool write) {
 // Guest OrbisKernelIovec == host layout { void* base; size_t len }.
 struct GIovec { void* base; size_t len; };
 } // namespace
-HLE(f_pread)  { return (uint64_t)win_pio((int)a0, P(a1), (size_t)a2, (uint64_t)a3, false); }
+HLE(f_pread)  { int64_t r = win_pio((int)a0, P(a1), (size_t)a2, (uint64_t)a3, false);
+                int err = r < 0 ? (int)GetLastError() : 0;
+                filelog_fd_io("pread", (int)a0, (int64_t)a3, a2, r, err); return (uint64_t)r; }
 HLE(f_pwrite) { return (uint64_t)win_pio((int)a0, P(a1), (size_t)a2, (uint64_t)a3, true); }
 HLE(f_readv)  { auto* v = (GIovec*)P(a1); int nc = (int)a2; int64_t tot = 0;
                 for (int i = 0; i < nc; i++) { int64_t r = (int64_t)(int)::read((int)a0, v[i].base, (unsigned)v[i].len);
@@ -600,7 +663,9 @@ HLE(k_aio_cancel) {  // (id, s32* state): nothing is in flight to cancel — rep
 
 #ifndef _WIN32
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct stat st; int r = ::stat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
-HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); int err = r < 0 ? errno : 0;
+               if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1));
+               filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1); return (uint64_t)(int64_t)r; }
 // lstat: was MISSING -> the return-0 stub reported success while leaving the caller's stat buffer as
 // uninitialized garbage (wrong file type/size). We have no symlinks in the dump, so ::lstat == ::stat, but
 // the key fix is WRITING the buffer. fsync: was fake-success; flush for real save durability.
@@ -608,7 +673,9 @@ HLE(f_lstat) { std::string h = translate(CS(a0)); struct stat st; int r = ::lsta
 HLE(f_fsync) { return (uint64_t)(int64_t)::fsync((int)a0); }
 #else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
-HLE(f_fstat) { struct _stat64 st; int r = ::_fstat64((int)a0, &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+HLE(f_fstat) { struct _stat64 st; int r = ::_fstat64((int)a0, &st); int err = r < 0 ? errno : 0;
+               if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1));
+               filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1); return (uint64_t)(int64_t)r; }
 HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
 HLE(f_fsync) { return 0; }
 #endif

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -1,0 +1,54 @@
+// Guest fd I/O must preserve every byte of binary game content on every host.
+// In particular, Windows CRT text mode treats 0x1a as EOF and translates CRLF.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { std::printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    std::printf("== test_file_binary ==\n");
+    const char* path = "prosper-test-file-binary.tmp";
+    std::array<uint8_t, 512> expected{};
+    for (size_t i = 0; i < expected.size(); ++i) expected[i] = (uint8_t)(i * 37u + 11u);
+    expected[7] = 0x1a;
+    expected[8] = '\r';
+    expected[9] = '\n';
+
+    FILE* out = std::fopen(path, "wb");
+    CHECK(out != nullptr, "create binary fixture");
+    if (out) {
+        CHECK(std::fwrite(expected.data(), 1, expected.size(), out) == expected.size(),
+              "write binary fixture");
+        std::fclose(out);
+    }
+
+    register_file_hle();
+    HleFn open_fn = Hle::lookup(nid_hash("sceKernelOpen"));
+    HleFn read_fn = Hle::lookup(nid_hash("sceKernelRead"));
+    HleFn close_fn = Hle::lookup(nid_hash("sceKernelClose"));
+    CHECK(open_fn && read_fn && close_fn, "file HLE functions registered");
+
+    std::array<uint8_t, 512> actual{};
+    int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;
+    CHECK(fd >= 0, "open fixture through guest fd HLE");
+    int64_t n = fd >= 0 && read_fn
+        ? (int64_t)read_fn((uint64_t)fd, (uint64_t)(uintptr_t)actual.data(), actual.size(), 0, 0, 0)
+        : -1;
+    CHECK(n == (int64_t)expected.size(), "read continues through embedded 0x1a");
+    CHECK(n == (int64_t)expected.size() && actual == expected,
+          "read preserves binary bytes including CRLF");
+    if (fd >= 0 && close_fn) close_fn((uint64_t)fd, 0, 0, 0, 0, 0);
+    std::remove(path);
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- open low-level guest files with `O_BINARY` on Windows
- extend `PROSPER_FILELOG` with open/fd/stat/read outcomes and host paths
- add a binary HLE regression test and update the Windows port handoff

## Root cause

Windows successfully opened and fstat'd `global-metadata.dat` at 10,743,608 bytes, but `sceKernelRead` returned exactly 440 bytes. The file's first `0x1a` is at offset 440: the CRT fd was in text mode and interpreted that byte as EOF. IL2CPP therefore rejected truncated metadata and left its class global null.

With `O_BINARY`, the same request returns all 10,743,608 bytes, `unable to initialize il2cpp` is absent, and `Il2cpp+0x268c878` is nonzero. Initialization then reaches the distinct Windows GC exception-delivery gap tracked in #678.

## Validation

- Windows MinGW: 62/62 tests pass
- Linux Vulkan: 96/96 tests pass
- native Windows Messenger trace: full metadata read, no IL2CPP failure, initialized class global

Fixes #673
Refs #678