### PR TITLE
fix(hle/pad): headless default presents one connected controller (Fixes #680)

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -311,11 +311,11 @@ void pad_record(int64_t frame, uint32_t buttons) {
 }
 
 // Snapshot the controller for a given pad handle via the installed backend. With no host frontend
-// installed, prosper_core's default backend reports a neutral, disconnected pad (fully-formed
-// struct). PROSPER_PAD_PRESS overrides with a synthetic connected pad (CROSS held); PROSPER_PAD_SCRIPT
-// overrides with a timed button sequence — both are device-independent end-to-end test drivers.
+// installed, prosper_core's default backend reports ONE connected controller with neutral input (a PS5
+// title can gate progression on a pad being present, so dev/testing needs one). PROSPER_PAD_PRESS adds
+// a synthetic CROSS; PROSPER_PAD_SCRIPT adds a timed button sequence — device-independent test drivers.
 HostPadState snapshot(int /*handle*/, const char* what) {
-    HostPadState s;   // neutral, disconnected by default
+    HostPadState s;   // filled by the backend below (default: one connected, neutral controller)
     pad_backend()->poll(0, s);
     if (getenv("PROSPER_PAD_PRESS")) {
         s.connected = true;

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -76,10 +76,15 @@ void pad_fill_data(ScePadData* out, const HostPadState& s, uint64_t timestamp, u
 
 // --- pluggable backend: default neutral (headless), plus the injector -----------------------------
 namespace {
-// The built-in backend: no host device. Reports a neutral, disconnected pad so the HLE contract is
-// fully defined with zero dependencies. A frontend replaces this via pad_set_backend().
+// The built-in backend: no host device, but reports ONE connected controller with neutral input.
+// A PS5 title legitimately gates progression on a pad being present (e.g. PPSA02664 loops a
+// "Please, connect a controller to continue." message dialog forever while none is connected), so the
+// headless/dev-testing default must present one — otherwise the game never reaches its title/gameplay.
+// Input stays neutral (no buttons); PROSPER_PAD_PRESS / PROSPER_PAD_SCRIPT drive actual presses on top.
+// A real frontend (SDL3 / evdev) replaces this via pad_set_backend(); the harness app will manage the
+// connected-controller count there. CONFIDENCE: HIGH (controller-presence gate is live-observed).
 struct NeutralPadBackend : PadBackend {
-    bool poll(int /*index*/, HostPadState& out) override { out = HostPadState{}; return false; }
+    bool poll(int /*index*/, HostPadState& out) override { out = HostPadState{}; out.connected = true; return true; }
 };
 NeutralPadBackend        g_neutral;
 std::atomic<PadBackend*> g_backend{&g_neutral};   // a frontend may install from another thread

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -101,7 +101,8 @@ int main() {
         CHECK(ci.stick_dead_zone_left == ci.stick_dead_zone_right, "info: symmetric dead zone");
     }
 
-    // (6) HLE registration + full-struct fill (no PROSPER_PAD -> neutral, but complete + connected=0).
+    // (6) HLE registration + full-struct fill (no PROSPER_PAD -> neutral input, but ONE controller is
+    // connected by default: the built-in NeutralPadBackend now presents a connected pad for dev/testing).
     {
         register_builtin_hle();
         HleFn read_state = Hle::lookup(nid_hash("scePadReadState"));
@@ -118,7 +119,7 @@ int main() {
             uint64_t r = read_state(1, (uint64_t)(uintptr_t)&d, 0, 0, 0, 0);
             CHECK(r == 0, "scePadReadState -> 0 (OK)");
             // The struct's TAIL (bytes the old 48-byte stub never touched) must now be written:
-            CHECK(d.connected == 0, "readstate: connected written (was uninit in old stub)");
+            CHECK(d.connected == 1, "readstate: one controller connected by default (dev/testing default)");
             CHECK(d.left_stick_x == 0x80, "readstate: sticks centered");
             CHECK(d.orientation_w == 1.0f, "readstate: identity orientation");
         }


### PR DESCRIPTION
Makes the built-in headless pad backend present ONE connected controller (neutral input) so controller-gated PS5 titles boot in dev/testing. PPSA02664 (Alex Kidd) otherwise loops a "Please, connect a controller to continue." message dialog forever and never reaches its title/gameplay.

Real frontends (SDL3/evdev) still override via `pad_set_backend()`; the harness app will manage the connected-controller count. `PROSPER_PAD_PRESS`/`PROSPER_PAD_SCRIPT` still drive presses on top.

## Validation
- PPSA02664 clears the dialog and renders its intro credits with no pad env (dialog-loop count 0).
- Messenger snapshot guard OK (24318 colors), Dead Cells splash OK (1672 colors) — no #238-class connected-controller crash.
- Full ctest green (updated test_pad readstate expectation to the new default).

Fixes #680