### PR TITLE
Fix PC-keyed scalar buffers in UE scene color

### DIFF
--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -3,6 +3,7 @@
 #include "gpu_capture.hpp"
 #include "gpu_capture_bundle.hpp"
 #include "gpu_dependency_graph.hpp"
+#include "pm4_registers.hpp"
 #include "render_state.hpp"
 #include "videoout_present.hpp"
 #include "writer_provenance.hpp"
@@ -1200,6 +1201,95 @@ bool gpu_timeline_submit_matches(const GpuTimelineSubmit& submit,
     return false;
 }
 
+// PROSPER_GPU_TIMELINE_MRT_SUBMIT=N, or the MRT_{MIN,MAX}_{DRAWS,DISPATCHES} predicates: print the
+// complete raw color-target programming for every semantic draw in one selected submit. Timeline
+// target spans intentionally retain only MRT0's extent, which is enough for scene selection but
+// cannot prove whether a sampled GPU-only surface was produced through MRT1..7. This bounded
+// diagnostic reads the draw-time register snapshots and never realizes shaders, copies resources,
+// or invokes Vulkan. Semantic predicates select only their first match so a title loop stays bounded.
+bool select_timeline_mrt_submit(const GpuState& state, uint64_t submit_no) {
+    struct Config {
+        uint64_t exact = 0;
+        size_t min_draws = 0, max_draws = std::numeric_limits<size_t>::max();
+        size_t min_dispatches = 0, max_dispatches = std::numeric_limits<size_t>::max();
+        bool semantic = false;
+    };
+    static const Config config = [] {
+        Config out;
+        auto read = [&](const char* name, size_t& field) {
+            const char* value = std::getenv(name);
+            if (!value || !*value) return;
+            field = static_cast<size_t>(std::strtoull(value, nullptr, 0));
+            out.semantic = true;
+        };
+        if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_MRT_SUBMIT"); value && *value)
+            out.exact = std::strtoull(value, nullptr, 0);
+        read("PROSPER_GPU_TIMELINE_MRT_MIN_DRAWS", out.min_draws);
+        read("PROSPER_GPU_TIMELINE_MRT_MAX_DRAWS", out.max_draws);
+        read("PROSPER_GPU_TIMELINE_MRT_MIN_DISPATCHES", out.min_dispatches);
+        read("PROSPER_GPU_TIMELINE_MRT_MAX_DISPATCHES", out.max_dispatches);
+        return out;
+    }();
+    if (config.exact) return submit_no == config.exact;
+    if (!config.semantic || state.draws.size() < config.min_draws ||
+        state.draws.size() > config.max_draws ||
+        state.dispatches.size() < config.min_dispatches ||
+        state.dispatches.size() > config.max_dispatches)
+        return false;
+    static std::atomic<uint64_t> selected{0};
+    uint64_t expected = 0;
+    selected.compare_exchange_strong(expected, submit_no, std::memory_order_relaxed);
+    return selected.load(std::memory_order_relaxed) == submit_no;
+}
+
+void log_timeline_mrt_draw(const GpuState& draw_state, uint64_t submit_no,
+                           size_t draw_index, uint64_t command_order, bool selected) {
+    if (!selected) return;
+    namespace P = prosper::agc::Pm4;
+    auto read = [&](uint32_t reg) {
+        const auto found = draw_state.cx.find(reg);
+        return found == draw_state.cx.end() ? 0u : found->second;
+    };
+    const bool has_target_mask = draw_state.cx.count(P::CB_TARGET_MASK) != 0;
+    const bool has_shader_mask = draw_state.cx.count(P::CB_SHADER_MASK) != 0;
+    const uint32_t target_mask = has_target_mask ? read(P::CB_TARGET_MASK) : 0xffffffffu;
+    const uint32_t shader_mask = read(P::CB_SHADER_MASK);
+
+    std::fprintf(stderr,
+                 "[timeline-mrt] submit=%llu draw=%zu order=%llu target-mask=%08x%s "
+                 "shader-mask=%08x%s",
+                 static_cast<unsigned long long>(submit_no), draw_index,
+                 static_cast<unsigned long long>(command_order), target_mask,
+                 has_target_mask ? "" : "(default)", shader_mask,
+                 has_shader_mask ? "" : "(absent)");
+    for (uint32_t slot = 0; slot < 8; ++slot) {
+        constexpr uint32_t kColorRegisterStride = 0xf;
+        const uint32_t base_reg = P::CB_COLOR0_BASE + slot * kColorRegisterStride;
+        const uint32_t info_reg = P::CB_COLOR0_INFO + slot * kColorRegisterStride;
+        const uint32_t attrib2_reg = P::CB_COLOR0_ATTRIB2 + slot;
+        const uint32_t base = read(base_reg);
+        const uint32_t base_ext = read(P::CB_COLOR0_BASE_EXT + slot);
+        const uint32_t info = read(info_reg);
+        const auto attrib2 = draw_state.cx.find(attrib2_reg);
+        const uint32_t write_mask = (target_mask >> (slot * 4)) & 0xfu;
+        const uint32_t export_mask = (shader_mask >> (slot * 4)) & 0xfu;
+        // An absent CB_TARGET_MASK defaults to all ones, but that does not bind seven zero-address
+        // targets. Report only a programmed surface or shader export, while still showing its mask.
+        if (!base && !base_ext && !info && !export_mask) continue;
+        const uint64_t address = (static_cast<uint64_t>(base) << 8) |
+                                 (static_cast<uint64_t>(base_ext & 0xffu) << 40);
+        const uint32_t format = PM4_FIELD(info, CB_COLOR0_INFO, FORMAT);
+        std::fprintf(stderr, " c%u=0x%llx/f%u/w%x/e%x", slot,
+                     static_cast<unsigned long long>(address), format, write_mask, export_mask);
+        if (attrib2 != draw_state.cx.end()) {
+            const uint32_t width = PM4_FIELD(attrib2->second, CB_COLOR0_ATTRIB2, MIP0_WIDTH) + 1u;
+            const uint32_t height = PM4_FIELD(attrib2->second, CB_COLOR0_ATTRIB2, MIP0_HEIGHT) + 1u;
+            std::fprintf(stderr, "/%ux%u", width, height);
+        }
+    }
+    std::fputc('\n', stderr);
+}
+
 void begin_gpu_timeline_submit(uint64_t submit_no) {
     static const bool requested = [] {
         const char* path = std::getenv("PROSPER_GPU_TIMELINE");
@@ -1222,11 +1312,14 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     submit.draw_count = static_cast<uint32_t>(std::min<size_t>(state.draws.size(), UINT32_MAX));
     submit.dispatch_count = static_cast<uint32_t>(std::min<size_t>(state.dispatches.size(), UINT32_MAX));
     submit.first_command_order = std::numeric_limits<uint64_t>::max();
+    const bool log_mrt = select_timeline_mrt_submit(state, submit_no);
     for (size_t draw_index = 0; draw_index < state.draws.size(); ++draw_index) {
         const auto& draw = state.draws[draw_index];
         submit.first_command_order = std::min(submit.first_command_order, draw.command_order);
         submit.last_command_order = std::max(submit.last_command_order, draw.command_order);
-        const RenderState rs = extract_render_state(draw.state ? *draw.state : state);
+        const GpuState& draw_state = draw.state ? *draw.state : state;
+        log_timeline_mrt_draw(draw_state, submit_no, draw_index, draw.command_order, log_mrt);
+        const RenderState rs = extract_render_state(draw_state);
         if (!submit.target_spans_truncated) {
             if (draw_index > UINT32_MAX) {
                 submit.target_spans_truncated = true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2939,15 +2939,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // user-data SGPR index (the V# was placed in SGPRs by the driver). Default binding 2.
             uint32_t binding = 2; bool cbuf_resolved = false;
             if (rt) { const ShaderResource* res = nullptr;
+                // Descriptor-table folding emits pc-only entries when a V# has no stable SRT key
+                // (or that key collides). Exact per-use provenance must win, as it does for MUBUF/MIMG.
+                res = rt->by_fetch_pc(in.pc);
+                if (res && res->cls != ResourceClass::ConstantBuffer) res = nullptr;
                 auto it = rs.sreg_srt.find(in.src[0].value);
-                if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
+                if (!res && it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
                 // A scalar buffer load reads a CONSTANT buffer — resolve the SBASE SGPR to a constant
                 // buffer specifically (the same SGPR may also hold a vertex-buffer V# elsewhere).
                 if (!res) res = rt->by_sgpr_base_cls(in.src[0].value, ResourceClass::ConstantBuffer);
                 if (res) { binding = res->binding; cbuf_resolved = true; } }
             if (getenv("PROSPER_CBUFLOG"))
-                fprintf(stderr, "[cbuf] s_buffer_load x%u src0=s%d off=0x%x(dw%u) dyn=%d -> binding=%u %s\n",
-                        n, in.src[0].value, in.literal, base_idx, (int)soff_dyn, binding,
+                fprintf(stderr, "[cbuf] pc=%u s_buffer_load x%u src0=s%d off=0x%x(dw%u) dyn=%d -> binding=%u %s\n",
+                        in.pc, n, in.src[0].value, in.literal, base_idx, (int)soff_dyn, binding,
                         cbuf_resolved ? "resolved" : "DEFAULT-2");
             // Immediate s_load_dwordx4/x8 is the same descriptor-table fetch as the dynamic form
             // handled above. When the front-half table already decoded that V#/T#/S#, its raw words

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -472,6 +472,26 @@ int main() {
     CHECK(!spv22hi.empty() && !has2 && has32 && has33,
           "#515: decoded descriptor fetches add no dead binding-2 contract; data loads use 32/33");
 
+    // #319: key-less/collided descriptor-table V#s carry exact consuming-PC provenance. Scalar
+    // loads must consult it; otherwise the real resource is present while generated code reads b2.
+    const uint32_t code22pc[] = {
+        0xf4200002u, 0xfa000004u, 0x7e000c00u, 0xbf810000u,
+    };
+    ShaderResourceTable rt22pc;
+    { ShaderResource cb{}; cb.cls = ResourceClass::ConstantBuffer; cb.format = DataFormat::Uint32;
+      cb.num_components = 1; cb.binding = 3; cb.fetch_pc = 0; rt22pc.resources.push_back(cb); }
+    std::vector<uint32_t> spv22pc = recompile_valu(
+        code22pc, sizeof(code22pc)/sizeof(code22pc[0]), 1, 0, &rt22pc);
+    std::vector<uint32_t> cbuf22pc0(4, 0u), cbuf22pc1(4, 0u);
+    cbuf22pc0[1] = 20u; cbuf22pc1[1] = 300u;
+    std::vector<float> got22pc = prosper::test::run_compute(
+        spv22pc, in22, N, N, cbuf22pc0, cbuf22pc1);
+    uint32_t bad22pc = 0;
+    for (uint32_t i = 0; i < N && got22pc.size() == N; i++)
+        if (std::fabs(got22pc[i] - 300.0f) > 1e-3f) bad22pc++;
+    CHECK(!spv22pc.empty() && got22pc.size() == N && bad22pc == 0,
+          "#319: pc-only cbuf provenance routes s_buffer_load off fallback binding 2");
+
     // Kernel 23: buffer_load_format_x FLOAT32 VERTEX FETCH (stage 2 — the real-VS mechanism). v0=(uint)
     // gid (element index); buffer_load_format_x v1, v0, s[8:11] idxen fetches vbuf[gid]; out=v1. The V#
     // descriptor is DIRECT (in user-data SGPR s8) -> resolved via sgpr_base -> VertexBuffer binding 3,

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -83,6 +83,16 @@ realized draw/dispatch counts, missing operations, unique shader/resource versio
 Run metadata includes the revision, title, and input route when the corresponding capture environment
 variables are set.
 
+When MRT0-only target spans are insufficient, set `PROSPER_GPU_TIMELINE_MRT_SUBMIT=N` on a second
+native-speed run. For timing-sensitive routes, use the semantic
+`PROSPER_GPU_TIMELINE_MRT_MIN_DRAWS`, `MAX_DRAWS`, `MIN_DISPATCHES`, and `MAX_DISPATCHES` predicates
+instead; only their first matching submit is logged. For every semantic draw in the selected submit,
+the recorder prints all eight raw `CB_COLOR` addresses, formats, extents, target write masks, and
+shader export masks. Use this to prove whether a GPU-only input was produced through MRT1..7 before
+proposing multi-attachment renderer work. The diagnostic does not realize shaders, copy resource
+bytes, or invoke Vulkan. Exact submit numbers are run-local, so prefer predicates derived from prior
+positive and nearby negative `.prgtl` samples when timing can move the endpoint.
+
 ## Format contract
 
 - Explicit little-endian versioned header; C++ struct layout is never serialized.


### PR DESCRIPTION
## Summary
- resolve scalar `s_buffer_load` resources by exact consuming-instruction PC before SRT/SGPR fallbacks
- add a Vulkan regression proving a PC-only constant buffer no longer reads fallback binding 2
- add a bounded GPU-timeline MRT diagnostic to prove whether sampled surfaces were produced through MRT1..7

## DOLL / issue #319 evidence
A metadata capsule of the first 3840x2160 scene-color submit shows the first four full-viewport material draws reject descriptor validation because their fragment SPIR-V statically reads set 1/binding 2. Their runtime tables already contain the correct constant buffers at bindings 32+ with exact `fetch_pc` provenance (for example binding 38 at PC 0x236). MUBUF and MIMG consume this provenance; SMEM did not, and silently fell back to binding 2.

The MRT diagnostic also disproved the previous direct-MRT hypothesis: the black intermediate 0x207e5e0000 and scene color 0x2075350000 are programmed as MRT0. True MRT0+MRT1 writes occur earlier but are not the direct missing input.

## Validation
- full Linux build
- ctest: 92/92 passed
- focused `test_rdna2_to_spirv`: passed, including Vulkan execution of the new PC-only cbuf case
- Messenger snapshot: 24,318 colors (minimum 5,000)
- Dead Cells snapshot: 1,705 colors (minimum 1,500)

## Live caveat
Post-fix DOLL capture attempts are currently dying before graphics initialization in the known issue #312 MallocBinned3/GPU-label write-after-free. The patch is therefore draft until a clean DOLL run confirms the four scene-color shaders no longer declare binding 2 and provides a visual A/B.

Advances #319.