### PR TITLE
Fix Windows GC exception delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ accepts scripted gamepad input, and renders the first level.
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **92 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **96 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
@@ -115,7 +115,7 @@ Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the g
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # 92 self-checking tests
+ctest --test-dir build-linux          # 96 self-checking tests
 ```
 
 Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). A

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -253,6 +253,16 @@ if(TARGET prosper_core)
   target_link_libraries(test_file_binary PRIVATE prosper_core)
   add_test(NAME file_binary_roundtrip COMMAND test_file_binary)
 
+  if(WIN32)
+    add_executable(test_win_exception_delivery tests/test_win_exception_delivery.cpp)
+    target_link_libraries(test_win_exception_delivery PRIVATE prosper_core)
+    add_test(NAME win_exception_delivery COMMAND test_win_exception_delivery)
+
+    add_executable(test_win_kernel_is_stack tests/test_win_kernel_is_stack.cpp)
+    target_link_libraries(test_win_kernel_is_stack PRIVATE prosper_core)
+    add_test(NAME win_kernel_is_stack COMMAND test_win_kernel_is_stack)
+  endif()
+
   # APR container registry + size-keyed read matching (issue #62): stable ids, path dedup, and
   # the ambiguity/chunk-read refusal the read-submit path relies on. Pure, no game dump needed.
   add_executable(test_apr_registry tests/test_apr_registry.cpp)

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -296,14 +296,14 @@ This is exactly the hard sub-problem flagged above for both Windows and macOS. P
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
 trap-and-emulate of `%fs:` operands is in-house technology.
 
-## Windows port status (2026-07-14) — IL2CPP metadata fixed; GC exception delivery is next
+## Windows port status (2026-07-14) — Messenger presents frames after GC delivery fix
 
 The native MinGW build now links and initializes the live Vulkan renderer, boots The Messenger through
-Unity asset loading, reads and initializes IL2CPP metadata, emits a correct first GPU fence, and completes
-SubmitDcb #1. The guest `%fs`, threading, positioned-I/O, WaitOnAddress, VEH, and integer ABI foundations
-below are runtime-verified. The current blocker is #678: the Windows `sceKernelRaiseException` path still
-returns success without asynchronously running the installed handler on the target thread. IL2CPP's GC
-therefore waits forever for a stop-the-world suspension acknowledgement before later graphics submissions.
+Unity asset loading and IL2CPP initialization, completes repeated GC stop-the-world cycles, and presents
+real 1920x1080 frames. The guest `%fs`, threading, positioned-I/O, WaitOnAddress, VEH, integer ABI, and
+targeted exception-delivery foundations below are runtime-verified. A 60-second run reached SubmitDcb #28
+with up to 11 draws per submission and no guest fatal. The next work is frontend/gameplay acceptance and
+the remaining portability gaps, not another boot-time IL2CPP investigation.
 
 - **Direct/flexible-memory HLE ported to Win32** (`hle_kernel_mem.cpp` `#else` block). The pool
   bookkeeping + VA tracker are copied verbatim from POSIX; mappings are backed by private
@@ -390,7 +390,7 @@ Windows runs then fail consistently at `Il2cpp+0x17d64b` because `il2cpp_init` h
 and an Il2CppClass global at `Il2cpp+0x268c878` is null. That distinct initialization-parity problem was
 tracked and solved in #673; do not reopen the solved fence-field investigation.
 
-### IL2CPP metadata read — SOLVED (#673); current frontier: GC exception delivery (#678)
+### IL2CPP metadata read — SOLVED (#673)
 
 Windows opened and fstat'd `Media/Metadata/global-metadata.dat` correctly, but the low-level guest fd
 path omitted `O_BINARY`. The Windows CRT consequently treated the first `0x1a` byte as text EOF: a
@@ -401,10 +401,30 @@ now records host open results, fd-to-path associations, fstat sizes, and read/pr
 made this failure visible without debugger stepping.
 
 Native validation reads all 10,743,608 bytes, no longer prints `unable to initialize il2cpp`, and shows
-the formerly-null global at `Il2cpp+0x268c878` initialized. That exposes the distinct #678 stop-the-world
-blocker: `sceKernelRaiseException(target, 0x1e)` is implemented with targeted signals on Linux/macOS but
-is a success no-op on Windows, so the raiser blocks on `SuspendSemaphore` while the target never runs the
-installed handler.
+the formerly-null global at `Il2cpp+0x268c878` initialized. That exposed the distinct #678 stop-the-world
+blocker described below.
+
+### GC target-thread exception delivery — SOLVED (#678)
+
+IL2CPP installs exception type `0x1e`, then raises it on each target thread to stop the world for GC.
+Windows had returned success without delivery, leaving the raiser blocked on `SuspendSemaphore` forever.
+The native path now suspends the requested winpthreads thread, captures its Windows `CONTEXT`, redirects
+it through a small aligned thunk, synthesizes the FreeBSD mcontext layout expected by the guest handler,
+runs that handler on the requested thread, and resumes the exact interrupted context with
+`RtlRestoreContext`.
+
+A redirected context is not dispatched until a blocked `WaitOnAddress` returns. The futex layer therefore
+tracks each Windows waiter's guest address and wakes that exact address after the target's suspend count is
+dropped. The injection leaves the guest SysV red zone intact. `PROSPER_EXCLOG=1` records the target-thread
+handler enter/exit cycles without enabling the much noisier synchronization trace.
+
+The first live delivery exposed two more Windows success-no-ops: `sceKernelIsStack` always returned false,
+and `scePthreadAttrGet` never copied the registered worker-stack bounds. The latter made BDWGC abort with
+`Bad stack base in GC_register_my_thread`. Both now use the existing cross-platform stack registry.
+`win_exception_delivery` tests real delivery while the worker is blocked in the HLE WaitOnAddress path;
+`win_kernel_is_stack` covers both the direct query and IL2CPP's AttrGet/Getstackaddr/Getstacksize sequence.
+The live Messenger acceptance run completed many GC cycles and reached SubmitDcb #28 with repeated
+1920x1080 presentations.
 
 (Historical, pre-fix diagnosis retained below for context.)
 
@@ -471,14 +491,13 @@ granularity); and `PROSPER_CRASHPEEK` guards.
   plain MS-x64 C++ function. `test_hle_stack_args` executes the generated stub and verifies every arg,
   the return value, and handler-entry alignment; `test_agc_submit` pins the real first-fence fields.
 - `guest_tls.cpp` Windows path (guest `%fs` TLS now IMPLEMENTED via FSGSBASE — see above),
-  `boot_program.cpp` enabled on Windows, `boot_trace` built on Windows (no evdev/Vulkan), CI
-  `Windows MinGW` job builds the whole boot path.
+  `boot_program.cpp` enabled on Windows, and the Vulkan-backed `boot_trace` built and runtime-validated
+  on Windows. CI's `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **Port asynchronous GC exception delivery (#678), the current frontier.** Windows must interrupt
-   the requested `pthread_t`, synthesize the same FreeBSD mcontext used by the POSIX path, run the
-   installed guest handler on that target thread, and resume the interrupted context after the handler
-   returns. Do not fake the `SuspendSemaphore` acknowledgement.
+1. **Validate the user-facing frontend through scripted gameplay.** The headless renderer now presents
+   real frames; run the same deterministic input/screenshot acceptance route used on Linux and repair any
+   Windows-specific SDL/present/input gaps it exposes.
 2. **Preserve physical-offset aliasing in the Windows memory HLE.** Private `VirtualAlloc` is sufficient
    for Unity, but UE4 MallocBinned3 needs shared backing (`CreateFileMapping`/`MapViewOfFile3`) while
    respecting Windows' 64 KiB allocation granularity.

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -1,9 +1,10 @@
 # Windows native port — handoff (2026-07-14)
 
-The Windows native core boots The Messenger (`PPSA24651`) through the OS/runtime/asset/sync layer and
-drives the GPU pipeline. The GPU-fence field bug documented below was fixed in #672: native validation
-now matches Linux and SubmitDcb #1 completes. The newly exposed blocker is #673: `il2cpp_init` returns
-false on Windows, leaving a generated-code class global null before SubmitDcb #2. Companion:
+The Windows native core boots The Messenger (`PPSA24651`) through IL2CPP and repeated GC
+stop-the-world cycles, then drives real GPU draws and presents 1920x1080 frames. The fence-field,
+metadata-read, and asynchronous-GC blockers were fixed in #672, #673, and #678 respectively. A
+60-second native validation reached SubmitDcb #28 (up to 11 draws per submit) without a guest fatal;
+the next frontier is user-facing frontend/gameplay validation and the remaining portability gaps in
 `docs/PORTING.md` ("Windows").
 
 ## What works today (merged to master)
@@ -16,6 +17,8 @@ The guest, on Windows (MinGW, native), reproducibly:
   registers flip/vblank/EOP equeues, and does an initial `GpuFlip` of buffer 0.
 - Compiles 36 real shaders and submits GPU command buffers; the executor decodes real PM4
   (`WriteData`/`ReleaseMem`/`WaitRegMem`) and delivers flip/vblank/EOP events.
+- Delivers IL2CPP's exception-type `0x1e` asynchronously on the requested target thread, allowing
+  repeated GC stop-the-world suspend/resume cycles to complete.
 
 Merged PRs that got it here (all `#ifdef _WIN32` — Linux/macOS unaffected, CI green on all 4 platforms):
 - **#624** substrate: `exec_image_win.cpp` (VirtualAlloc mapping, VEH fault handler, SysV↔MS-x64 stub
@@ -88,8 +91,8 @@ generated stub with nine sentinels and checks alignment/return value; `test_agc_
 ReleaseMem/WaitRegMem packet fields.
 
 Native runtime validation: `data_sel=2 data=1`, `ref=1 mask=ffffffff`, no `NOT satisfied`, SubmitDcb #1
-completes. Five repeat runs then expose #673 at `Il2cpp+0x17d64b` before SubmitDcb #2; the next work is
-initialization parity, not further fence decoding.
+completes. The later #673 metadata and #678 GC-delivery blockers are also resolved; do not reopen the
+solved fence investigation when diagnosing a later Windows failure.
 
 ## Build + run + diagnose (native Windows, MinGW)
 
@@ -115,9 +118,9 @@ PROSPER_GFXLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 
 Diagnostics (env, all off by default): `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode + the `NOT satisfied`
 fence log), `PROSPER_EVLOG` (`[ev]` equeue/flip/EOP), `PROSPER_SYNCLOG` (`[sync]` WaitOnAddress/Wake with
-tid + validated guest caller, `[sync2]` cond/sema/EventFlag), `PROSPER_MEMLOG`, `PROSPER_VEHLOG`,
-boot_trace `[memclass]`. The Messenger renders on **Linux** (`build-linux`, `PROSPER_GUEST_FS=1 …`) —
-use it as the oracle: `SubmitDcb #2: executed 3 draws -> presented 1920x1080 frame`.
+tid + validated guest caller, `[sync2]` cond/sema/EventFlag), `PROSPER_EXCLOG` (GC exception
+raise/deliver/resume), `PROSPER_MEMLOG`, `PROSPER_VEHLOG`, boot_trace `[memclass]`. The Messenger renders
+on **Linux** (`build-linux`, `PROSPER_GUEST_FS=1 …`) — use it as the oracle.
 
 ## Gotchas learned (so the next agent doesn't relearn them)
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "sync_futex.hpp"
 #include "../host/exec_image.hpp"
 #include <pthread.h>
 #include <semaphore.h>   // scePthreadSem* -> host sem_t
@@ -29,6 +30,7 @@
 #include <thread>
 #include <atomic>
 #include <condition_variable>
+#include <new>
 #ifdef _WIN32
 #include <windows.h>   // GetCurrentThreadStackLimits/GetCurrentThreadId for the guest-thread trampoline
 #endif
@@ -378,7 +380,6 @@ HLE(k_attr_get) {
     // thread's attributes. a0 = thread handle (== the host pthread_t we store), a1 = attr handle.
     // (Bug fixed: the attr is arg1, not arg0 — reading arg0 left the real attr empty, so the GC's
     // GC_get_stack_base got a 0 stack base -> "Bad stack base in GC_register_my_thread".)
-#if defined(__linux__) || defined(__APPLE__)
     if (a1 && *(void**)a1) {
         auto* at = (pthread_attr_t*)*(void**)a1;
         void* base = nullptr; size_t sz = 0;
@@ -387,7 +388,6 @@ HLE(k_attr_get) {
         if (ok) pthread_attr_setstack(at, base, sz);   // real, tracked stack for that thread
         // else: leave the attr as-is (avoid the fragile pthread_getattr_np)
     }
-#endif
     return 0;
 }
 // scePthreadAttrGetstackaddr(attr, void** addr) — Sony reports the stack *base* (low addr).
@@ -888,10 +888,10 @@ void set_unwind_modules(const UnwindModuleDesc* d, size_t c) {
 // then to stop the world it calls sceKernelRaiseException(thread, 0x1e) on each thread. On
 // real hardware that asynchronously interrupts the target thread and runs its handler ON that
 // thread; the handler captures the thread's registers (for GC root scanning) and blocks until
-// resumed. We reproduce this exactly with a real-time signal: pthread_sigqueue delivers it to
-// the target thread, and our SA_SIGINFO handler synthesises a FreeBSD amd64 mcontext from the
-// interrupted ucontext (so the guest handler sees the real registers) and runs the guest
-// handler on that thread. A stubbed RaiseException left every thread un-acked -> deadlock.
+// resumed. POSIX hosts use a targeted signal. Windows suspends the target, redirects its CONTEXT
+// through a small aligned thunk, and restores the interrupted CONTEXT after the guest handler
+// returns. Both paths synthesize the same FreeBSD amd64 mcontext and run the real guest handler
+// on the target thread. A stubbed RaiseException left every thread un-acked -> deadlock.
 namespace {
 uint64_t g_exc_handlers[128] = {0};   // guest handler fn ptr, indexed by exception type
 bool g_exc_log = false;               // set once (outside signal ctx) from PROSPER_SYNCLOG
@@ -1022,6 +1022,132 @@ void ensure_exc_sig() {
     sigemptyset(&sa.sa_mask);
     sigaction(g_exc_sig, &sa, nullptr);
 }
+#elif defined(_WIN32)
+struct WinExcDelivery {
+    CONTEXT saved{};
+    uint64_t type = 0;
+    uint64_t handler = 0;
+};
+using RtlRestoreContextFn = VOID (WINAPI*)(PCONTEXT, PEXCEPTION_RECORD);
+RtlRestoreContextFn g_rtl_restore_context = nullptr;
+
+extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
+extern "C" __attribute__((noreturn)) void prosper_win_exc_delivery(WinExcDelivery* delivery);
+extern "C" void prosper_win_exc_thunk();
+
+// SetThreadContext reliably redirects RIP/RSP, but Windows may rewrite volatile integer registers
+// while resuming a suspended syscall. Pass the delivery pointer on the target stack, not in RCX.
+// Entry RSP is 8 mod 16; pop makes it call-site aligned, and the 32-byte subtraction supplies the
+// Microsoft-x64 home area before the compiled helper call. The injected RSP is placed below the
+// guest SysV red zone so an asynchronous delivery cannot overwrite a leaf function's live locals.
+__asm__(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_win_exc_thunk\n"
+    "prosper_win_exc_thunk:\n"
+    "    popq %rcx\n"
+    "    subq $32, %rsp\n"
+    "    call prosper_win_exc_delivery\n"
+    "    ud2\n"
+);
+
+void win_exc_log(const char* msg) {
+    if (!g_exc_log && !g_exc_log2) return;
+    DWORD written = 0;
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), msg, (DWORD)strlen(msg), &written, nullptr);
+}
+
+extern "C" __attribute__((noinline, noreturn))
+void prosper_win_exc_delivery(WinExcDelivery* delivery) {
+    CONTEXT saved = delivery->saved;
+    uint64_t type = delivery->type;
+    uint64_t handler = delivery->handler;
+
+    // FreeBSD amd64 mcontext layout; keep in lockstep with the POSIX signal path above.
+    alignas(16) uint8_t ctx[0x400]{};
+    auto WQ = [&](int off, uint64_t v) { *(uint64_t*)(ctx + off) = v; };
+    WQ(0x08, saved.Rdi); WQ(0x10, saved.Rsi); WQ(0x18, saved.Rdx); WQ(0x20, saved.Rcx);
+    WQ(0x28, saved.R8);  WQ(0x30, saved.R9);  WQ(0x38, saved.Rax); WQ(0x40, saved.Rbx);
+    WQ(0x48, saved.Rbp); WQ(0x50, saved.R10); WQ(0x58, saved.R11); WQ(0x60, saved.R12);
+    WQ(0x68, saved.R13); WQ(0x70, saved.R14); WQ(0x78, saved.R15);
+    WQ(0xA0, saved.Rip); WQ(0xB8, saved.Rsp); WQ(0xF8, saved.Rsp);
+
+    win_exc_log("[exc] handler ENTER on Windows target\n");
+    prosper_call_guest_sysv(handler, type, (uint64_t)(uintptr_t)ctx);
+    win_exc_log("[exc] handler EXIT on Windows target (resumed)\n");
+
+    delete delivery;
+    g_rtl_restore_context(&saved, nullptr);
+    TerminateProcess(GetCurrentProcess(), ERROR_INVALID_STATE);   // RtlRestoreContext never returns
+    __builtin_unreachable();
+}
+
+uint64_t win_raise_exception(uint64_t target, uint64_t type) {
+    if (!target || type >= 128 || !g_exc_handlers[type]) return 0;
+    if (pthread_equal((pthread_t)target, pthread_self())) return 0x80020023ull; // EDEADLK-ish
+    if (!g_rtl_restore_context) return 0x80020026ull;                         // ENOSYS-ish
+
+    HANDLE thread = (HANDLE)pthread_gethandle((pthread_t)target);
+    if (!thread || thread == INVALID_HANDLE_VALUE) return 0x80020003ull;       // ESRCH
+
+    // Allocate before suspending: the target could currently own the process heap lock.
+    auto* delivery = new (std::nothrow) WinExcDelivery;
+    if (!delivery) return 0x8002000cull;                                      // ENOMEM
+    delivery->type = type;
+    delivery->handler = g_exc_handlers[type];
+
+    DWORD previous_suspend = SuspendThread(thread);
+    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); delete delivery; return 0x80020000ull | (e & 0xffff); }
+    if (previous_suspend != 0) {
+        ResumeThread(thread);
+        delete delivery;
+        return 0x80020010ull;                                                 // EBUSY
+    }
+
+    delivery->saved.ContextFlags = CONTEXT_ALL;
+    if (!GetThreadContext(thread, &delivery->saved)) {
+        DWORD e = GetLastError(); ResumeThread(thread); delete delivery;
+        return 0x80020000ull | (e & 0xffff);
+    }
+
+    CONTEXT injected = delivery->saved;
+    injected.ContextFlags = CONTEXT_FULL;
+    injected.Rip = (DWORD64)(uintptr_t)&prosper_win_exc_thunk;
+    constexpr DWORD64 kGuestRedZone = 128;
+    injected.Rsp = (injected.Rsp & ~(DWORD64)0xf) - kGuestRedZone - 8;
+    DWORD64 delivery_ptr = (DWORD64)(uintptr_t)delivery;
+    SIZE_T written = 0;
+    if (!WriteProcessMemory(GetCurrentProcess(), (void*)(uintptr_t)injected.Rsp,
+                            &delivery_ptr, sizeof(delivery_ptr), &written) ||
+        written != sizeof(delivery_ptr)) {
+        DWORD e = GetLastError(); ResumeThread(thread); delete delivery;
+        return 0x80020000ull | (e & 0xffff);
+    }
+    if (!SetThreadContext(thread, &injected)) {
+        DWORD e = GetLastError(); ResumeThread(thread); delete delivery;
+        return 0x80020000ull | (e & 0xffff);
+    }
+    if (ResumeThread(thread) == (DWORD)-1) {
+        DWORD e = GetLastError();
+        bool restored = SetThreadContext(thread, &delivery->saved) != FALSE;
+        if (restored && ResumeThread(thread) != (DWORD)-1) delete delivery;
+        return 0x80020000ull | (e & 0xffff);
+    }
+    // A redirected Windows CONTEXT is not dispatched until a blocking syscall returns. Current
+    // IL2CPP targets commonly sit in our infinite WaitOnAddress HLE; wake its registered address
+    // after dropping the suspend count so the target enters prosper_win_exc_thunk immediately.
+    interrupt_futex_wait(target);
+    return 0;
+}
+
+void ensure_exc_sig() {
+    if (g_rtl_restore_context) return;
+    g_exc_log = getenv("PROSPER_SYNCLOG") != nullptr;
+    g_exc_log2 = getenv("PROSPER_EXCLOG") != nullptr;
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    g_rtl_restore_context = ntdll
+        ? (RtlRestoreContextFn)GetProcAddress(ntdll, "RtlRestoreContext") : nullptr;
+}
 #else
 void ensure_exc_sig() {}
 #endif
@@ -1058,6 +1184,8 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
         fprintf(stderr, "[exc2] RAISE-NOOP by tid=%ld target=0x%llx type=0x%llx (no handler)\n",
                 sctid(), (unsigned long long)a0, (unsigned long long)a1);
     }
+#elif defined(_WIN32)
+    return win_raise_exception(a0, a1);
 #endif
     return 0;
 }
@@ -1065,12 +1193,10 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
 void set_exc_raise_counter(volatile int* counter) { g_exc_counter = counter; }
 
 HLE(k_is_stack) {   // sceKernelIsStack(void* addr): is addr within the current thread's stack?
-#if defined(__linux__) || defined(__APPLE__)
     void* base = nullptr; size_t sz = 0;
     if (guest_stack_for_current_thread(&base, &sz) &&
         a0 >= (uint64_t)(uintptr_t)base && a0 < (uint64_t)(uintptr_t)base + sz)
         return 1;
-#endif
     return 0;
 }
 // Global export table (NID -> guest addr) registered by the loader, so dlsym can resolve

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -592,7 +592,7 @@ HLE(k_wait_on_address) {
                            (long)prosper_gettid(), (unsigned long long)a0, *(uint32_t*)a0,
                            (unsigned long long)a1, pts ? (long long)(ts.tv_sec*1000000 + ts.tv_nsec/1000) : -1,
                            (unsigned long long)goff);
-    futex_wait_enter();   // registers this waiter so GPU-side label wakes know someone is blocked
+    futex_wait_enter(a0); // registers this waiter so GPU-side label wakes know someone is blocked
     long r = prosper_futex_wait((uint32_t*)a0, (uint32_t)a1, pts);
     int e = errno;
     futex_wait_exit();
@@ -1608,7 +1608,7 @@ HLE(k_wait_on_address) {
     volatile uint32_t* wa = (volatile uint32_t*)(uintptr_t)a0;
     // Register as a futex waiter so the GPU command processor's RELEASE_MEM/EOP wake (wake_label_waiters,
     // which only fires when g_waiters>0) reaches this thread. RAII so every return path unregisters.
-    futex_wait_enter();
+    futex_wait_enter(a0);
     struct WaiterGuard { ~WaiterGuard() { futex_wait_exit(); } } _waiter_guard;
     while (*wa == expected) {
         DWORD wait_ms = INFINITE;

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -14,13 +14,49 @@
 #define _WIN32_WINNT 0x0A00   // WakeByAddressAll needs >= 0x0602 (Win8)
 #endif
 #include <windows.h>   // native futex: WakeByAddressAll (pairs with WaitOnAddress in hle_kernel_mem.cpp)
+#include <pthread.h>
+#include <mutex>
+#include <unordered_map>
 #endif
 
 namespace prosper {
-namespace { std::atomic<int> g_waiters{0}; }
+namespace {
+std::atomic<int> g_waiters{0};
+#ifdef _WIN32
+std::mutex g_wait_mx;
+std::unordered_map<uint64_t, uint64_t> g_thread_waits;  // pthread_t -> guest wait address
+#endif
+}
 
-void futex_wait_enter() { g_waiters.fetch_add(1, std::memory_order_seq_cst); }
-void futex_wait_exit()  { g_waiters.fetch_sub(1, std::memory_order_seq_cst); }
+void futex_wait_enter(uint64_t addr) {
+#ifdef _WIN32
+    { std::lock_guard<std::mutex> lk(g_wait_mx); g_thread_waits[(uint64_t)pthread_self()] = addr; }
+#else
+    (void)addr;
+#endif
+    g_waiters.fetch_add(1, std::memory_order_seq_cst);
+}
+void futex_wait_exit() {
+    g_waiters.fetch_sub(1, std::memory_order_seq_cst);
+#ifdef _WIN32
+    std::lock_guard<std::mutex> lk(g_wait_mx);
+    g_thread_waits.erase((uint64_t)pthread_self());
+#endif
+}
+
+bool interrupt_futex_wait(uint64_t thread) {
+#ifdef _WIN32
+    uint64_t addr = 0;
+    { std::lock_guard<std::mutex> lk(g_wait_mx);
+      auto it = g_thread_waits.find(thread);
+      if (it != g_thread_waits.end()) addr = it->second; }
+    if (addr) WakeByAddressAll((PVOID)(uintptr_t)addr);
+    return addr != 0;
+#else
+    (void)thread;
+    return false;
+#endif
+}
 
 void futex_wake(uint64_t addr, int n) {
 #if defined(__linux__) || defined(__APPLE__)

--- a/prosper/src/hle/sync_futex.hpp
+++ b/prosper/src/hle/sync_futex.hpp
@@ -10,8 +10,13 @@ namespace prosper {
 
 // Bracket a blocking guest futex wait: enter before FUTEX_WAIT, exit after it returns. Lets
 // wake_label_waiters skip its wake syscalls entirely while no thread is blocked.
-void futex_wait_enter();
+void futex_wait_enter(uint64_t addr);
 void futex_wait_exit();
+
+// Windows applies SetThreadContext only after a blocked syscall returns. If `thread` is currently
+// inside the HLE WaitOnAddress path, wake that exact address so an asynchronous guest exception can
+// enter its redirected context. Returns true when a registered futex wait was woken.
+bool interrupt_futex_wait(uint64_t thread);
 
 // FUTEX_WAKE up to n waiters blocked on the 32-bit word at addr. No-op when addr==0 or non-Linux.
 void futex_wake(uint64_t addr, int n);

--- a/prosper/tests/test_win_exception_delivery.cpp
+++ b/prosper/tests/test_win_exception_delivery.cpp
@@ -1,0 +1,76 @@
+// Windows must run sceKernelRaiseException's guest handler on the requested target thread,
+// then restore the exact interrupted host context so that thread continues normally.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <pthread.h>
+#include <windows.h>
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+static volatile LONG delivered;
+static volatile LONG resumed;
+static volatile DWORD worker_tid;
+static volatile DWORD handler_tid;
+static volatile uint64_t context_rip;
+static volatile uint64_t context_rsp;
+static volatile uint32_t wait_word;
+static HleFn wait_on_address;
+static int fails;
+
+#define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { std::printf("  [ok]   %s\n", msg); } } while (0)
+
+extern "C" __attribute__((sysv_abi)) void guest_exception_handler(uint64_t type, void* raw_ctx) {
+    auto* ctx = (const uint8_t*)raw_ctx;
+    handler_tid = GetCurrentThreadId();
+    context_rip = *(const uint64_t*)(ctx + 0xa0);
+    context_rsp = *(const uint64_t*)(ctx + 0xf8);
+    if (type == 0x1e) {
+        wait_word = 1;
+        InterlockedExchange(&delivered, 1);
+    }
+}
+
+static void* worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    wait_on_address((uint64_t)(uintptr_t)&wait_word, 0, 0, 0, 0, 0);
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+int main() {
+    std::printf("== test_win_exception_delivery ==\n");
+    register_builtin_hle();
+    HleFn install = Hle::lookup(nid_hash("sceKernelInstallExceptionHandler"));
+    HleFn raise = Hle::lookup(nid_hash("sceKernelRaiseException"));
+    wait_on_address = Hle::lookup("Hc4CaR6JBL0");
+    CHECK(install && raise && wait_on_address, "exception and futex HLE functions registered");
+    if (!install || !raise || !wait_on_address) return 1;
+
+    CHECK(install(0x1e, (uint64_t)(uintptr_t)&guest_exception_handler, 0, 0, 0, 0) == 0,
+          "install guest exception handler");
+    pthread_t thread = 0;
+    CHECK(pthread_create(&thread, nullptr, worker, nullptr) == 0, "create target thread");
+    for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+    CHECK(worker_tid != 0, "target thread entered blocking HLE futex");
+
+    uint64_t result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "raise exception to target thread");
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) {
+        InterlockedExchange((volatile LONG*)&wait_word, 1);
+        WakeByAddressAll((void*)&wait_word);
+    }
+    pthread_join(thread, nullptr);
+
+    CHECK(delivered != 0, "guest handler executed");
+    CHECK(handler_tid == worker_tid, "guest handler executed on requested target");
+    CHECK(context_rip != 0 && context_rsp != 0, "interrupted RIP and GC stack pointer captured");
+    CHECK(resumed != 0, "target resumed its interrupted context after handler return");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_win_kernel_is_stack.cpp
+++ b/prosper/tests/test_win_kernel_is_stack.cpp
@@ -1,0 +1,54 @@
+#include "../src/host/exec_image.hpp"
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <windows.h>
+#include <pthread.h>
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+int main() {
+    register_builtin_hle();
+    auto is_stack = Hle::lookup(nid_hash("sceKernelIsStack"));
+    auto attr_init = Hle::lookup(nid_hash("scePthreadAttrInit"));
+    auto attr_get = Hle::lookup(nid_hash("scePthreadAttrGet"));
+    auto attr_getaddr = Hle::lookup(nid_hash("scePthreadAttrGetstackaddr"));
+    auto attr_getsize = Hle::lookup(nid_hash("scePthreadAttrGetstacksize"));
+    auto attr_destroy = Hle::lookup(nid_hash("scePthreadAttrDestroy"));
+    if (!is_stack || !attr_init || !attr_get || !attr_getaddr || !attr_getsize || !attr_destroy) {
+        std::fprintf(stderr, "required stack HLE is not registered\n");
+        return 1;
+    }
+
+    uint8_t local = 0;
+    uint64_t addr = (uint64_t)(uintptr_t)&local;
+    uint64_t base = addr - 0x1000;
+    register_thread_stack((uint64_t)GetCurrentThreadId(), (void*)(uintptr_t)base, 0x2000);
+
+    bool inside = is_stack(addr, 0, 0, 0, 0, 0) == 1;
+    bool below = is_stack(base - 1, 0, 0, 0, 0, 0) == 0;
+    bool at_end = is_stack(base + 0x2000, 0, 0, 0, 0, 0) == 0;
+
+    void* attr = nullptr;
+    void* reported_base = nullptr;
+    size_t reported_size = 0;
+    attr_init((uint64_t)(uintptr_t)&attr, 0, 0, 0, 0, 0);
+    attr_get((uint64_t)pthread_self(), (uint64_t)(uintptr_t)&attr, 0, 0, 0, 0);
+    attr_getaddr((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_base, 0, 0, 0, 0);
+    attr_getsize((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_size, 0, 0, 0, 0);
+    attr_destroy((uint64_t)(uintptr_t)&attr, 0, 0, 0, 0, 0);
+    bool attr_bounds = reported_base == (void*)(uintptr_t)base && reported_size == 0x2000;
+
+    unregister_thread_stack((uint64_t)GetCurrentThreadId());
+    bool unregistered = is_stack(addr, 0, 0, 0, 0, 0) == 0;
+
+    if (!inside || !below || !at_end || !attr_bounds || !unregistered) {
+        std::fprintf(stderr,
+                     "stack HLE mismatch: inside=%d below=%d at_end=%d attr_bounds=%d "
+                     "reported=%p/%zu unregistered=%d\n",
+                     inside, below, at_end, attr_bounds, reported_base, reported_size, unregistered);
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- implement native Windows target-thread delivery for `sceKernelRaiseException` using `SuspendThread`/`GetThreadContext`, an ABI-aligned thunk, a synthesized FreeBSD mcontext, and `RtlRestoreContext`
- wake targets blocked in the HLE `WaitOnAddress` path so redirected contexts are dispatched
- enable Windows `scePthreadAttrGet` and `sceKernelIsStack` stack-registry behavior, fixing BDWGC's `Bad stack base in GC_register_my_thread` abort
- add Windows exception-delivery and stack-query regression tests
- update README and Windows port/handoff documentation

## Runtime validation

Native Messenger (`PPSA24651`) was run for 75 seconds with Vulkan rendering and exception diagnostics enabled. It completed 109 matched GC handler enter/exit cycles, presented 30 real 1920x1080 DCB frames, and reached SubmitDcb #31 with 11 draws. No stack-base, unarmed VEH, or IL2CPP initialization fatal markers occurred.

## Tests

- Windows MinGW/Vulkan: 64/64 passed
- Linux/WSL Vulkan: 96/96 passed

Fixes #678
Follow-up: #683