### PR TITLE
feat(macos): realtime harness app (prosper-app) on macOS via SDL3 + MoltenVK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,31 @@ jobs:
 
       - name: Test
         run: ctest --test-dir prosper/build-ci --output-on-failure
+
+  macos-app:
+    name: macOS App (SDL3 + MoltenVK)
+    runs-on: macos-latest
+
+    # Builds the realtime window frontend (prosper-app) x86_64 against a UNIVERSAL MoltenVK, so the
+    # SDL3-window/MoltenVK-present glue and the frontends stay compiling on a real macOS toolchain.
+    # Build-only: the window needs a display and headless Metal is flaky on CI runners, so it isn't
+    # run here (locally on an M2, --test-pattern presents fine and the offscreen GPU tests pass 90/91
+    # -- see docs/PORTING.md "The macOS harness app"). Mirrors the Linux App job.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install ninja vulkan-headers
+          softwareupdate --install-rosetta --agree-to-license
+
+      - name: Fetch universal MoltenVK
+        # Homebrew's MoltenVK is arm64-only; the x86_64 app needs a universal driver.
+        run: bash prosper/scripts/fetch-macos-vulkan.sh
+
+      - name: Configure
+        run: cmake -S prosper -B prosper/build-app -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=x86_64 -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON -DPROSPER_MACOS_MOLTENVK=${{ github.workspace }}/.macos-vulkan/lib/libMoltenVK.dylib
+
+      - name: Build prosper-app
+        run: cmake --build prosper/build-app --target prosper-app

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ prosper/screenshots/
 *.spv
 *.bmp
 frame_*.png
+
+# Local universal MoltenVK for the macOS (Rosetta/x86_64) app build — not committed
+/.macos-vulkan/

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -15,6 +15,34 @@ if(MINGW OR (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
   add_link_options(-static -static-libgcc -static-libstdc++)
 endif()
 
+# --- macOS Vulkan (MoltenVK) override ------------------------------------
+# prosper on macOS is built x86_64 (to run the guest under Rosetta), but Homebrew's MoltenVK/loader
+# are arm64-only, so find_package(Vulkan) would hand back an unlinkable arm64 lib. Point the build at
+# a UNIVERSAL (x86_64+arm64) MoltenVK instead — either the LunarG Vulkan SDK, or the prebuilt
+# KhronosGroup/MoltenVK release (`MoltenVK-macos.tar`, universal). Pass:
+#   -DPROSPER_MACOS_MOLTENVK=/path/to/libMoltenVK.dylib   (universal)
+#   -DPROSPER_MACOS_VULKAN_INCLUDE=/path/to/vulkan/headers (dir containing vulkan/vulkan.h)
+# When set we pre-create the Vulkan::Vulkan imported target from it, so every later
+# find_package(Vulkan) is skipped (guarded on `NOT TARGET Vulkan::Vulkan`). Headers are
+# architecture-independent, so Homebrew's vulkan-headers work for the include dir.
+if(APPLE AND PROSPER_MACOS_MOLTENVK)
+  if(NOT PROSPER_MACOS_VULKAN_INCLUDE)
+    set(PROSPER_MACOS_VULKAN_INCLUDE "/opt/homebrew/include")   # Homebrew vulkan-headers (arch-independent)
+  endif()
+  add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
+  set_target_properties(Vulkan::Vulkan PROPERTIES
+    IMPORTED_LOCATION "${PROSPER_MACOS_MOLTENVK}"
+    INTERFACE_INCLUDE_DIRECTORIES "${PROSPER_MACOS_VULKAN_INCLUDE}")
+  set(Vulkan_FOUND TRUE)
+  set(Vulkan_LIBRARY "${PROSPER_MACOS_MOLTENVK}")
+  set(Vulkan_INCLUDE_DIR "${PROSPER_MACOS_VULKAN_INCLUDE}")
+  # The app dlopen's / links MoltenVK by leaf name; add its dir to the executables' rpath so
+  # SDL_Vulkan_LoadLibrary("libMoltenVK.dylib") and the direct link both resolve at runtime.
+  get_filename_component(_mvk_dir "${PROSPER_MACOS_MOLTENVK}" DIRECTORY)
+  set(CMAKE_BUILD_RPATH "${_mvk_dir}")
+  message(STATUS "macOS Vulkan: using universal MoltenVK ${PROSPER_MACOS_MOLTENVK}")
+endif()
+
 # --- tools ---------------------------------------------------------------
 # self_dump: SELF/ELF inspector and NID import extractor (M0).
 add_executable(self_dump tools/self_dump/self_dump.cpp)
@@ -445,7 +473,9 @@ if(TARGET prosper_core)
     # shared DrawItem->Vulkan compositor boot_trace uses on Linux so the guest's SubmitDcb draws
     # execute + present + dump frames. Mirrors the UNIX block below (boot_trace + prosper_live_renderer
     # only; the extra replay/screenshot tools stay Linux-first for now). See docs/PORTING.md "Windows".
-    find_package(Vulkan QUIET)
+    if(NOT TARGET Vulkan::Vulkan)
+      find_package(Vulkan QUIET)
+    endif()
     if(Vulkan_FOUND)
       target_link_libraries(boot_trace PRIVATE Vulkan::Vulkan)
       target_compile_definitions(boot_trace PRIVATE PROSPER_HAVE_VULKAN=1)
@@ -529,7 +559,9 @@ if(TARGET prosper_core)
 
     # Graphics-phase foundation + agentic-first verification harness: headless offscreen Vulkan
     # (render/clear -> readback -> pixel/CRC assert). Only built if Vulkan dev files are present.
-    find_package(Vulkan QUIET)
+    if(NOT TARGET Vulkan::Vulkan)
+      find_package(Vulkan QUIET)
+    endif()
     if(Vulkan_FOUND)
       # Live game rendering: with Vulkan available, boot_trace can register the live submit renderer
       # (PROSPER_RENDER=1) so the game's SubmitDcb draws execute + present + dump frames to disk.
@@ -693,7 +725,11 @@ option(PROSPER_AUDIO_SDL3 "Build the optional SDL3 audio frontend"   OFF)
 option(PROSPER_PAD_SDL3   "Build the optional SDL3 gamepad frontend" OFF)
 option(PROSPER_APP        "Build the prosper-app frontend (SDL3 window + Vulkan present)" OFF)
 if((PROSPER_AUDIO_SDL3 OR PROSPER_PAD_SDL3 OR PROSPER_APP) AND TARGET prosper_core AND NOT TARGET SDL3::SDL3)
-  find_package(SDL3 QUIET CONFIG)
+  # On macOS the build is x86_64 (Rosetta), but a system SDL3 (e.g. Homebrew) is arm64-only and won't
+  # link — so skip discovery there and always FetchContent+build SDL3 for the requested architecture.
+  if(NOT APPLE)
+    find_package(SDL3 QUIET CONFIG)
+  endif()
   if(NOT SDL3_FOUND)
     message(STATUS "SDL3 not found — fetching release-3.2.30 (audio=${PROSPER_AUDIO_SDL3} pad=${PROSPER_PAD_SDL3} app=${PROSPER_APP})")
     include(FetchContent)
@@ -709,8 +745,12 @@ if((PROSPER_AUDIO_SDL3 OR PROSPER_PAD_SDL3 OR PROSPER_APP) AND TARGET prosper_co
     if(PROSPER_APP)
       set(SDL_UNIX_CONSOLE_BUILD OFF CACHE BOOL "" FORCE)
       set(SDL_VIDEO   ON CACHE BOOL "" FORCE)
-      set(SDL_WAYLAND ON CACHE BOOL "" FORCE)
-      set(SDL_X11     ON CACHE BOOL "" FORCE)
+      # Wayland/X11 are the Linux window backends; on macOS SDL uses Cocoa (forcing X11/Wayland ON
+      # there makes SDL hunt for X11/Wayland dev headers that don't exist). Only request them on Linux.
+      if(NOT APPLE)
+        set(SDL_WAYLAND ON CACHE BOOL "" FORCE)
+        set(SDL_X11     ON CACHE BOOL "" FORCE)
+      endif()
     else()
       set(SDL_UNIX_CONSOLE_BUILD ON CACHE BOOL "" FORCE)
       set(SDL_VIDEO   OFF CACHE BOOL "" FORCE)
@@ -747,7 +787,9 @@ endif()
 # window. A SEPARATE Vulkan context from the core's headless render device (docs/FRONTEND_APP.md);
 # frames cross as CPU pixels. Entirely outside prosper_core. Default OFF; needs SDL3 (video) + Vulkan.
 if(PROSPER_APP AND TARGET SDL3::SDL3)
-  find_package(Vulkan QUIET)
+  if(NOT TARGET Vulkan::Vulkan)
+    find_package(Vulkan QUIET)
+  endif()
   if(Vulkan_FOUND)
     add_executable(prosper-app frontends/prosper-app/main.cpp)
     target_include_directories(prosper-app PRIVATE src)

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -294,7 +294,43 @@ earlier than on Linux.
 This is exactly the hard sub-problem flagged above for both Windows and macOS. Path forward
 (unchanged): find Rosetta's segment-base mechanism, or **patch/trap the guest `%fs`-relative
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
-trap-and-emulate of `%fs:` operands is in-house technology.
+trap-and-emulate of `%fs:` operands is in-house technology. NOTE (2026-07-14): the Windows port
+SOLVED its equivalent `%fs` TLS wall (FSGSBASE + VEH re-apply, see the Windows section) — but that
+relies on native FSGSBASE, which Rosetta does not expose (`wrfsbase` SIGILLs), so macOS still needs
+the trap/patch route rather than a direct port of the Windows fix.
+
+### The macOS harness app (prosper-app) — WORKS (2026-07-14)
+
+The realtime window frontend (the Linux `prosper-app`: SDL3 window + Vulkan present, so you watch
+the game live instead of dumping screenshots) now **builds and runs on macOS** under Rosetta 2:
+
+- **Built x86_64** (links the guest-running core) against a **universal MoltenVK** (Homebrew's is
+  arm64-only; `scripts/fetch-macos-vulkan.sh` drops the universal Khronos release into
+  `.macos-vulkan/`). SDL3 is FetchContent-built for x86_64 (a system arm64 SDL3 is skipped on Apple);
+  SDL uses Cocoa (Wayland/X11 are Linux-only now). MoltenVK is linked **directly** (no Khronos
+  loader), so `SDL_Vulkan_LoadLibrary` points at it and the SDL-injected
+  `VK_KHR_portability_enumeration` instance extension is stripped (a loader-only extension MoltenVK
+  rejects in direct-link mode); the device enables the spec-mandated `VK_KHR_portability_subset`.
+- **Verified on an M2:** `prosper-app --test-pattern` opens a Cocoa window, creates the MoltenVK
+  swapchain, and presents animated frames (exit 0). Against the Blasphemous 2 dump the guest boots on
+  its worker thread, the window comes up and waits for guest frames, and the boot hits the **same
+  `%fs` TLS wall** as `boot_trace` — so the harness is complete and will show live gameplay the moment
+  that frontier is solved, exactly like the Linux app.
+- **MoltenVK renders correctly**, not just presents: with `PROSPER_MACOS_MOLTENVK` set, the offscreen
+  GPU tests run on macOS and **90/91 pass** (SPIR-V recompile → MoltenVK → readback → CRC). The one
+  failure, `rdna2_to_spirv_exec`, is a genuine Metal semantics gap — `v_cvt_i32_f32` NaN→0 /
+  INT_MIN/MAX saturation differs from Vulkan/RDNA2 (Metal's out-of-range float→int is undefined). All
+  compute values match (`mismatches=0`); only that saturation subcase diverges. Tracked as an issue.
+
+Build recipe (see the CMake `PROSPER_MACOS_MOLTENVK` override and `scripts/fetch-macos-vulkan.sh`):
+```bash
+bash prosper/scripts/fetch-macos-vulkan.sh
+cmake -S prosper -B prosper/build-mac-app -G Ninja -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+  -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON \
+  -DPROSPER_MACOS_MOLTENVK="$PWD/.macos-vulkan/lib/libMoltenVK.dylib"
+cmake --build prosper/build-mac-app --target prosper-app
+PROSPER_VULKAN_LIB="$PWD/.macos-vulkan/lib/libMoltenVK.dylib" ./prosper/build-mac-app/prosper-app --test-pattern
+```
 
 ## Windows port status (2026-07-14) — first GPU fence fixed; IL2CPP init parity is next
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -41,6 +41,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <algorithm>
 #include <cmath>
 #include <chrono>
 #include <thread>
@@ -96,6 +97,17 @@ bool create_instance(Vk& vk, SDL_Window* win) {
     if (!sdlExts) { fprintf(stderr, "[app] SDL_Vulkan_GetInstanceExtensions: %s\n", SDL_GetError()); return false; }
     std::vector<const char*> exts(sdlExts, sdlExts + extCount);
 
+    // macOS: SDL adds VK_KHR_portability_enumeration to its required extensions because it assumes
+    // the Khronos loader. This build links MoltenVK DIRECTLY (no loader), where MoltenVK is the sole
+    // driver — no enumeration is needed and MoltenVK rejects the extension with
+    // VK_ERROR_EXTENSION_NOT_PRESENT. Strip it (and never set the enumerate flag). The device-level
+    // VK_KHR_portability_subset (below) is the piece that actually matters. If a future build routes
+    // through the loader, keep SDL's extension and add the ENUMERATE_PORTABILITY flag instead.
+#ifdef __APPLE__
+    exts.erase(std::remove_if(exts.begin(), exts.end(),
+                   [](const char* e){ return std::strcmp(e, "VK_KHR_portability_enumeration") == 0; }),
+               exts.end());
+#endif
     VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
     app.pApplicationName = "prosper-app"; app.apiVersion = VK_API_VERSION_1_1;
     VkInstanceCreateInfo ci{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
@@ -128,10 +140,19 @@ bool pick_device(Vk& vk) {
     float pr = 1.0f;
     VkDeviceQueueCreateInfo qi{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
     qi.queueFamilyIndex = vk.qfamily; qi.queueCount = 1; qi.pQueuePriorities = &pr;
-    const char* devExts[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+    std::vector<const char*> devExts = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+#ifdef __APPLE__
+    // The Vulkan spec requires enabling VK_KHR_portability_subset on any device that advertises it
+    // (all MoltenVK devices do), or vkCreateDevice fails with VK_ERROR_EXTENSION_NOT_PRESENT.
+    { uint32_t n = 0; vkEnumerateDeviceExtensionProperties(vk.phys, nullptr, &n, nullptr);
+      std::vector<VkExtensionProperties> dp(n);
+      vkEnumerateDeviceExtensionProperties(vk.phys, nullptr, &n, dp.data());
+      for (auto& e : dp) if (!strcmp(e.extensionName, "VK_KHR_portability_subset")) {
+          devExts.push_back("VK_KHR_portability_subset"); break; } }
+#endif
     VkDeviceCreateInfo di{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
     di.queueCreateInfoCount = 1; di.pQueueCreateInfos = &qi;
-    di.enabledExtensionCount = 1; di.ppEnabledExtensionNames = devExts;
+    di.enabledExtensionCount = (uint32_t)devExts.size(); di.ppEnabledExtensionNames = devExts.data();
     VKCHECK(vkCreateDevice(vk.phys, &di, nullptr, &vk.device), "vkCreateDevice");
     vkGetDeviceQueue(vk.device, vk.qfamily, 0, &vk.queue);
 
@@ -375,6 +396,16 @@ int main(int argc, char** argv) {
     }
 
     if (!SDL_Init(SDL_INIT_VIDEO)) { fprintf(stderr, "[app] SDL_Init: %s\n", SDL_GetError()); return 1; }
+#ifdef __APPLE__
+    // There is no system Vulkan loader on macOS; point SDL at MoltenVK so SDL_Vulkan_* uses the same
+    // driver this binary links. PROSPER_VULKAN_LIB overrides the path; default resolves via the
+    // executable's rpath (CMake links MoltenVK with an rpath, so the dylib sits beside/near the app).
+    if (!SDL_Vulkan_LoadLibrary(getenv("PROSPER_VULKAN_LIB") ? getenv("PROSPER_VULKAN_LIB") : "libMoltenVK.dylib")) {
+        fprintf(stderr, "[app] SDL_Vulkan_LoadLibrary(MoltenVK): %s\n", SDL_GetError());
+        fprintf(stderr, "[app] set PROSPER_VULKAN_LIB=/path/to/libMoltenVK.dylib\n");
+        return 1;
+    }
+#endif
     // Title: "prosper — <app0 basename>" for a booted game, else a plain label.
     std::string title = "prosper";
     if (!dump.empty()) { auto sl = dump.find_last_of("/\\"); title += " — " + (sl == std::string::npos ? dump : dump.substr(sl + 1)); }

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -88,6 +88,17 @@ struct VulkanComputeContext {
         dci.queueCreateInfoCount = 1;
         dci.pQueueCreateInfos = &qci;
         dci.pEnabledFeatures = &enabled;
+        std::vector<const char*> dev_exts;
+#ifdef __APPLE__
+        // Spec-mandated on MoltenVK: enable VK_KHR_portability_subset when advertised (always is).
+        { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
+          std::vector<VkExtensionProperties> de(ne);
+          vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
+          for (auto& e : de) if (!std::strcmp(e.extensionName, "VK_KHR_portability_subset")) {
+              dev_exts.push_back("VK_KHR_portability_subset"); break; } }
+        dci.enabledExtensionCount = (uint32_t)dev_exts.size();
+        dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
+#endif
         if (vkCreateDevice(physical, &dci, nullptr, &device) != VK_SUCCESS) return false;
         vkGetDeviceQueue(device, queue_family, 0, &queue);
         vkGetPhysicalDeviceMemoryProperties(physical, &memory);

--- a/prosper/scripts/fetch-macos-vulkan.sh
+++ b/prosper/scripts/fetch-macos-vulkan.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# fetch-macos-vulkan.sh — download a UNIVERSAL (x86_64+arm64) MoltenVK for the macOS harness app.
+#
+# prosper on macOS is built x86_64 (it runs the PS5 guest's x86-64 code natively under Rosetta 2), so
+# it needs an x86_64 Vulkan driver. Homebrew's molten-vk/vulkan-loader are arm64-only and cannot link
+# into the x86_64 binary. The prebuilt KhronosGroup/MoltenVK release ships a universal dylib, which is
+# exactly what we need. This drops it into <repo>/.macos-vulkan/ (gitignored); pass its path to CMake:
+#
+#   cmake -S prosper -B prosper/build-mac-app -G Ninja \
+#     -DCMAKE_OSX_ARCHITECTURES=x86_64 -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON \
+#     -DPROSPER_MACOS_MOLTENVK="$PWD/.macos-vulkan/lib/libMoltenVK.dylib"
+#   cmake --build prosper/build-mac-app --target prosper-app
+#   PROSPER_VULKAN_LIB="$PWD/.macos-vulkan/lib/libMoltenVK.dylib" \
+#     ./prosper/build-mac-app/prosper-app --test-pattern       # smoke test (no game needed)
+#
+# The LunarG Vulkan SDK for macOS is an equivalent (also universal) source if you prefer it.
+set -euo pipefail
+
+VER="${1:-v1.4.1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEST="$REPO_ROOT/.macos-vulkan"
+TAR_URL="https://github.com/KhronosGroup/MoltenVK/releases/download/${VER}/MoltenVK-macos.tar"
+
+echo "==> Fetching MoltenVK ${VER} (universal) into ${DEST}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL -o "$tmp/mvk.tar" "$TAR_URL"
+tar xf "$tmp/mvk.tar" -C "$tmp"
+
+SRC="$tmp/MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
+mkdir -p "$DEST/lib" "$DEST/share/vulkan/icd.d"
+cp "$SRC" "$DEST/lib/"
+cat > "$DEST/share/vulkan/icd.d/MoltenVK_icd.json" <<JSON
+{
+  "file_format_version": "1.0.0",
+  "ICD": { "library_path": "../../../lib/libMoltenVK.dylib", "api_version": "1.4.0", "is_portability_driver": true }
+}
+JSON
+
+echo "==> Installed $(lipo -archs "$DEST/lib/libMoltenVK.dylib" 2>/dev/null) libMoltenVK.dylib"
+echo "==> Configure with: -DPROSPER_MACOS_MOLTENVK=$DEST/lib/libMoltenVK.dylib"

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -139,6 +139,8 @@ inline const RenderVkCtx& render_vk_ctx() {
         RenderVkCtx r;
         VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO}; app.apiVersion = VK_API_VERSION_1_1;
         VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; ici.pApplicationInfo = &app;
+        // macOS: MoltenVK is linked directly, so VK_KHR_portability_enumeration is neither needed nor
+        // accepted here (see prosper-app main.cpp). Only the device-level portability_subset matters.
         if (vkCreateInstance(&ici, nullptr, &r.inst) != VK_SUCCESS || !r.inst) return r;
         uint32_t nd = 0; vkEnumeratePhysicalDevices(r.inst, &nd, nullptr);
         if (!nd) return r;
@@ -163,18 +165,26 @@ inline const RenderVkCtx& render_vk_ctx() {
         r.max_aniso_limit = phys_props.limits.maxSamplerAnisotropy;
         if (r.aniso_enabled) feats.samplerAnisotropy = VK_TRUE;
         // robustImageAccess (VK_EXT_image_robustness): OpImageRead OOB must return zero (#131). Guarded.
+        // Device extensions accumulate into a vector so the (optional) image-robustness and (macOS)
+        // portability-subset extensions coexist.
+        std::vector<const char*> dev_exts;
         VkPhysicalDeviceImageRobustnessFeaturesEXT irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT};
-        const char* img_robust_ext[] = { "VK_EXT_image_robustness" };
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, de.data());
-          for (uint32_t i = 0; i < ne; i++) if (!strcmp(de[i].extensionName, "VK_EXT_image_robustness")) {
-              VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-              f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-              if (irf.robustImageAccess) { dci.pNext = &irf;
-                  dci.enabledExtensionCount = 1; dci.ppEnabledExtensionNames = img_robust_ext; }
-              break;
+          for (uint32_t i = 0; i < ne; i++) {
+              if (!strcmp(de[i].extensionName, "VK_EXT_image_robustness")) {
+                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+                  f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+                  if (irf.robustImageAccess) { dci.pNext = &irf; dev_exts.push_back("VK_EXT_image_robustness"); }
+              }
+#ifdef __APPLE__
+              // Spec-mandated: must be enabled when advertised (MoltenVK always advertises it).
+              if (!strcmp(de[i].extensionName, "VK_KHR_portability_subset")) dev_exts.push_back("VK_KHR_portability_subset");
+#endif
           } }
+        dci.enabledExtensionCount = (uint32_t)dev_exts.size();
+        dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
         if (vkCreateDevice(r.phys, &dci, nullptr, &r.dev) != VK_SUCCESS || !r.dev) return r;
         vkGetDeviceQueue(r.dev, r.qfi, 0, &r.queue);
         r.ok = true;


### PR DESCRIPTION
Brings the realtime window frontend to macOS, so a game can be watched live on a Mac instead of only screenshotted — the same `prosper-app` that exists for Linux.

## Result (verified on an Apple M2)

- `prosper-app` **builds x86_64** (it links the guest-running core, so it must match the Rosetta arch) against a **universal MoltenVK**, with SDL3 built from source for x86_64.
- **`--test-pattern` opens a Cocoa window and presents animated frames through the MoltenVK swapchain** (exit 0) — the full SDL3 + MoltenVK present path works under Rosetta.
- Against the Blasphemous 2 dump: the guest boots on its worker thread, the window comes up and **waits for guest frames**, and boot hits the *same* guest-`%fs` TLS wall as `boot_trace`. So the harness is complete and will show live gameplay the moment that frontier lands — identical to the Linux app today.
- **MoltenVK renders, not just presents:** with the MoltenVK override the offscreen GPU tests run on macOS and **90/91 pass** (SPIR-V → MoltenVK → readback → CRC). The one failure is a genuine Metal semantics gap (`v_cvt_i32_f32` NaN→0 / INT saturation differs from Vulkan/RDNA2); all compute values match. Filed as an issue.

## How it works

- **CMake:** Homebrew's MoltenVK/loader are arm64-only, so a `PROSPER_MACOS_MOLTENVK` override pre-creates the `Vulkan::Vulkan` target from a universal MoltenVK (`scripts/fetch-macos-vulkan.sh` fetches the Khronos release into gitignored `.macos-vulkan/`), and every `find_package(Vulkan)` is guarded behind it. System SDL3 is skipped on Apple (arm64) and FetchContent-built x86_64; Wayland/X11 are requested only on Linux (Cocoa on mac).
- **Frontend:** MoltenVK is linked directly (no Khronos loader) — `SDL_Vulkan_LoadLibrary` points at it; SDL's loader-only `VK_KHR_portability_enumeration` instance extension is stripped (MoltenVK rejects it in direct-link mode); the device enables the spec-mandated `VK_KHR_portability_subset`. The same portability wiring is added to the shared offscreen renderer (`render_runner.h`) and compute (`live_compute.cpp`).
- **CI:** a build-only `macOS App` job (fetch MoltenVK → configure → build `prosper-app`), mirroring `Linux App`.

## Safety

All new code is `#ifdef __APPLE__` or Apple-only CMake; Linux and Windows are unchanged. Relies on the existing Linux/Windows/macOS-core CI jobs to confirm no regression.