### PR TITLE
feat(win): validate native frontend through Messenger gameplay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ prosper/
   src/self/        SELF/ELF parsing -> relocatable module image
   src/loader/      multi-module linker + global NID export table
   src/hle/         reimplemented Sony libraries (libc, libkernel, AGC/graphics), NID hashing
-  src/host/        host execution: image mapping, import stubs, fault handling (Linux)
+  src/host/        host execution: per-platform image mapping, ABI stubs, fault handling
   src/gpu/         AGC->Vulkan: PM4 decode, command processor, render state, vk_translate,
                    resource layer, RDNA2->SPIR-V recompiler
   tools/           self_dump, boot_trace, shader_histo, imgdump, spv_validate,
@@ -72,12 +72,18 @@ renderer is wired in; the game's **real pixel shader recompiles to valid SPIR-V*
 **bindless-dynamic vertex-fetch resolution** for the vertex shader — fully specified in
 `prosper/docs/NEXT_STEP_VERTEX_FETCH.md`. This paragraph is historical only.
 
-## Current frontier (2026-07-13)
+## Current frontier (2026-07-14)
 
 The game now **boots through IL2CPP, renders its intro/title/menu, and reaches gameplay with real GPU
 draws.** The old bindless vertex-fetch frontier is complete: both shader stages recompile and dynamic
 V#/T#/S# resources resolve on current master. Do **not** start from `NEXT_STEP_VERTEX_FETCH.md`; it is
 retained as a historical bring-up record.
+
+The native Windows/MinGW substrate now runs the same SDL3/Vulkan frontend and normal PNG screenshot
+workflow through a routed Messenger fresh save and a fully lit first-level frame (#683). The route
+exposed a stale Windows `guest_readable` stub in dynamic-fetch folding; a `VirtualQuery` range guard
+fixes the resulting loading-time host access violation (#688). Start Windows work from
+`docs/WINDOWS_PORT_HANDOFF.md`, not the historical pre-render fence investigation.
 
 The save-game list is visible (#299 closed), and retaining color-disabled depth/stencil passes (#520) recovers
 the first level's source scene. The black gameplay root cause was fixed on master by #528 (`e5fce22`):
@@ -230,7 +236,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 91/91 expected green on Linux
+  cmake --build . -j8 && ctest        # 92/92 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ accepts scripted gamepad input, and renders the first level.
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **96 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **92 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
@@ -115,11 +115,13 @@ Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the g
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # 96 self-checking tests
+ctest --test-dir build-linux          # 92 self-checking tests
 ```
 
-Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). A
-static-linked Windows (MinGW) build covers the host-agnostic parts as well.
+Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). Native
+Windows/MinGW now boots and renders the primary title through the same live Vulkan renderer; its
+current build, run, screenshot, and diagnostic recipe is maintained in
+[`prosper/docs/WINDOWS_PORT_HANDOFF.md`](prosper/docs/WINDOWS_PORT_HANDOFF.md).
 
 ## Repository layout
 
@@ -128,7 +130,7 @@ prosper/
   src/self/       SELF/ELF parsing → relocatable module image
   src/loader/     multi-module linker + global export table
   src/hle/        HLE of Sony libraries (libc, libkernel, AGC/graphics, services), NID hashing
-  src/host/       host execution: image mapping, stubs, fault handling (Linux)
+  src/host/       host execution: per-platform image mapping, ABI stubs, fault handling
   src/gpu/        AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
                   texture tiling + BC decode, and the RDNA2→SPIR-V shader recompiler
   frontends/      shared boot+render core, the windowed prosper-app, SDL3 audio/dialog, controllers

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -216,6 +216,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_pad PRIVATE prosper_core)
   add_test(NAME pad_input COMMAND test_pad)
 
+  add_executable(test_prosper_app_pad_overlay frontends/prosper-app/test_pad_overlay.cpp)
+  target_include_directories(test_prosper_app_pad_overlay PRIVATE src frontends/prosper-app)
+  target_link_libraries(test_prosper_app_pad_overlay PRIVATE prosper_core)
+  add_test(NAME prosper_app_pad_overlay COMMAND test_prosper_app_pad_overlay)
+
   add_executable(test_sync_on_address tests/test_sync_on_address.cpp)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)
@@ -573,18 +578,6 @@ if(TARGET prosper_core)
       target_link_libraries(test_gpu_capture_render PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
       add_test(NAME gpu_capture_render_replay COMMAND test_gpu_capture_render)
 
-      # screenshot: run a game and capture a PNG every N frames (default 60) until M shots (default
-      # 30). Reuses boot_program + the shared live renderer; writes zlib-compressed PNGs (needs zlib).
-      find_package(ZLIB QUIET)
-      if(ZLIB_FOUND)
-        add_executable(screenshot tools/screenshot/screenshot.cpp
-                                  tools/screenshot/capture_manifest.cpp)
-        target_include_directories(screenshot PRIVATE src tools/screenshot)
-        target_link_libraries(screenshot PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan ZLIB::ZLIB)
-      else()
-        message(STATUS "zlib not found — skipping the screenshot tool")
-      endif()
-
       add_executable(test_vulkan_offscreen tests/test_vulkan_offscreen.cpp)
       target_link_libraries(test_vulkan_offscreen PRIVATE Vulkan::Vulkan)
       add_test(NAME vulkan_offscreen_clear COMMAND test_vulkan_offscreen)
@@ -692,6 +685,28 @@ if(TARGET prosper_core)
       message(STATUS "Vulkan found (${Vulkan_LIBRARY}) — offscreen graphics harness enabled")
     else()
       message(STATUS "Vulkan not found — skipping offscreen graphics harness")
+    endif()
+  endif()
+endif()
+
+# Normal sampled-render capture on every host with the live renderer. Unix writes PNG through zlib;
+# Windows uses its built-in WIC PNG encoder so the native tool needs no extra package.
+if(TARGET prosper_live_renderer AND TARGET Vulkan::Vulkan)
+  if(WIN32)
+    add_executable(screenshot tools/screenshot/screenshot.cpp
+                              tools/screenshot/capture_manifest.cpp)
+    target_include_directories(screenshot PRIVATE src tools/screenshot)
+    target_link_libraries(screenshot PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan
+                                              windowscodecs ole32)
+  else()
+    find_package(ZLIB QUIET)
+    if(ZLIB_FOUND)
+      add_executable(screenshot tools/screenshot/screenshot.cpp
+                                tools/screenshot/capture_manifest.cpp)
+      target_include_directories(screenshot PRIVATE src tools/screenshot)
+      target_link_libraries(screenshot PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan ZLIB::ZLIB)
+    else()
+      message(STATUS "zlib not found — skipping the screenshot tool")
     endif()
   endif()
 endif()

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -100,7 +100,7 @@ prosper/
   src/self/        SELF/ELF parsing → relocatable module image
   src/loader/      multi-module linker + global export table
   src/hle/         HLE of Sony libraries (libc, libkernel, AGC/graphics, services), NID hashing
-  src/host/        host execution: image mapping, stubs, fault handling (Linux)
+  src/host/        host execution: per-platform image mapping, ABI stubs, fault handling
   src/gpu/         AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
                    texture tiling + BC decode, RDNA2→SPIR-V recompiler
   frontends/       shared boot+render core, windowed prosper-app, SDL3 audio/dialog, controllers

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -13,10 +13,10 @@ desktop app: a window showing the game, audio out, controller in, and close-to-q
 we can watch prosper run on a real GPU with sound — a human-perspective smoke test — **without
 compromising the headless-first core**, which stays the source of truth for agentic/CI verification.
 
-On Windows this runs under WSL2: Windows 11's **WSLg** already provides a Wayland/X11 compositor
-+ PulseAudio + (vendor-ICD) Vulkan, so a Linux GUI app's window appears on the Windows desktop
-(taskbar + Start-menu entry), plays audio through Windows, and quits when the window closes. The
-frontend is an ordinary Linux SDL app; WSLg is the whole "Windows app" story. See *Deployment*.
+The frontend runs both as a Linux application (including through WSLg) and as a native MinGW Windows
+application. Native Windows uses SDL3's Win32/WASAPI/XInput-HIDAPI backends and a Vulkan SDK; it boots
+the same guest and renderer directly, without WSL. See `WINDOWS_PORT_HANDOFF.md` for the current build
+and routed screenshot validation commands.
 
 ## First principle: the dependency arrow points one way
 
@@ -134,13 +134,19 @@ destroys them after the guest thread has joined.
 ## Target / build layout
 
 - New dir `frontends/prosper-app/` with its own `main.cpp` + the SDL sink/backend.
-- Its own CMake target linking `prosper_core`, gated `if(BUILD_FRONTEND_APP)` (**default OFF**), and
+- Its own CMake target linking `prosper_core`, gated by `-DPROSPER_APP=ON` (**default OFF**), and
   on `find_package(SDL3)` + `find_package(Vulkan)` being present. The core and all existing tests
   build and pass with the frontend absent — never a core/CI dependency.
 - SDL3 unifies window + audio + gamepad in one dep, matching the existing SDL3 direction
   (`feat/audio-sdl3`, the gamepad frontend).
 
-## Deployment on Windows (WSLg)
+## Deployment on Windows
+
+For native Windows, configure MinGW with `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON
+-DPROSPER_PAD_SDL3=ON`, build `prosper-app.exe`, and verify the window/swapchain first with
+`--test-pattern --frames 120`. The complete PowerShell recipe is in `WINDOWS_PORT_HANDOFF.md`.
+
+WSLg remains a useful alternate path for running the Linux build:
 
 1. Prereq check: `vulkaninfo` in the WSL shell confirms a usable Vulkan device (vendor WSL ICD, else
    Mesa Dozen over D3D12). This is the one external dependency worth verifying up front.
@@ -161,7 +167,7 @@ Vulkan device + display, which CI may lack).
 The chosen path was **(b): extract a shared `boot_program()` helper** both `boot_trace` and the
 frontend call, rather than duplicate the boot glue.
 
-- `src/host/boot_program.hpp/.cpp` (in `prosper_core`, Linux-only body): links the fixed module set
+- `src/host/boot_program.hpp/.cpp` (in `prosper_core`, Linux and Windows): links the fixed module set
   (honoring `PROSPER_NO_PSN`, dropping absent modules), registers the built-in HLE, maps images, sets
   up TLS/unwind/procparam, installs the import stubs + trap handler, registers the PSN/SaveData
   module-start ranges, and runs the dependent-module init_arrays. An `after_hle_registered` hook lets

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -296,14 +296,17 @@ This is exactly the hard sub-problem flagged above for both Windows and macOS. P
 accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
 trap-and-emulate of `%fs:` operands is in-house technology.
 
-## Windows port status (2026-07-14) — Messenger presents frames after GC delivery fix
+## Windows port status (2026-07-14) — Messenger reaches the first level natively
 
-The native MinGW build now links and initializes the live Vulkan renderer, boots The Messenger through
+The native MinGW build links and initializes the live Vulkan renderer, boots The Messenger through
 Unity asset loading and IL2CPP initialization, completes repeated GC stop-the-world cycles, and presents
-real 1920x1080 frames. The guest `%fs`, threading, positioned-I/O, WaitOnAddress, VEH, integer ABI, and
-targeted exception-delivery foundations below are runtime-verified. A 60-second run reached SubmitDcb #28
-with up to 11 draws per submission and no guest fatal. The next work is frontend/gameplay acceptance and
-the remaining portability gaps, not another boot-time IL2CPP investigation.
+real 1920x1080 frames. The SDL3 window, WASAPI audio, XInput/HIDAPI pad, keyboard overlay, and normal WIC
+PNG screenshot path now build and run under #683. The guest `%fs`, threading, positioned-I/O,
+WaitOnAddress, VEH, integer ABI, and targeted exception-delivery foundations below are runtime-verified.
+Fresh-save routing now reaches a fully lit first-level frame and exits cleanly. #688 fixed the final
+Windows-only crash found by that route: an always-true `guest_readable` stub let a null dynamic-fetch
+table reach a host dereference. The 360-second acceptance produced 36/36 compact sampled captures,
+36 distinct source frames, and 23 distinct pixel frames at 1920x1080.
 
 - **Direct/flexible-memory HLE ported to Win32** (`hle_kernel_mem.cpp` `#else` block). The pool
   bookkeeping + VA tracker are copied verbatim from POSIX; mappings are backed by private
@@ -352,7 +355,7 @@ The deep crash after `%fs` TLS was two more Linux-parity gaps (fixed on `port/wi
   rbx=0) on an unrecoverable thread. A `win_thread_trampoline` now marshals the SysV entry through
   `prosper_call_guest_sysv` and activates the worker's guest `%fs` TCB.
 
-### Renderer wired (#655); WaitOnAddress (#663) + positioned IO (#665) FIXED; frontier: GPU EOP completion
+### Renderer, WaitOnAddress, positioned I/O, and GPU completion — SOLVED
 
 **SOLVED — the pre-render wedge was a lost wakeup in the Windows `sceKernelWaitOnAddress`.** It had been
 backed by ONE global `std::condition_variable` shared across every waited address, so a guest
@@ -495,9 +498,9 @@ granularity); and `PROSPER_CRASHPEEK` guards.
   on Windows. CI's `Windows MinGW` job builds the whole boot path.
 
 **What is left (runtime work, on a Windows host):**
-1. **Validate the user-facing frontend through scripted gameplay.** The headless renderer now presents
-   real frames; run the same deterministic input/screenshot acceptance route used on Linux and repair any
-   Windows-specific SDL/present/input gaps it exposes.
+1. **Extend native scripted gameplay coverage beyond The Messenger (#683/#688).** The frontend,
+   controller composition, WIC screenshot path, and routed first-level acceptance now work. Add
+   checkpoint automation for more titles as the Windows substrate is exercised more broadly.
 2. **Preserve physical-offset aliasing in the Windows memory HLE.** Private `VirtualAlloc` is sufficient
    for Unity, but UE4 MallocBinned3 needs shared backing (`CreateFileMapping`/`MapViewOfFile3`) while
    respecting Windows' 64 KiB allocation granularity.
@@ -532,8 +535,8 @@ natively under MSYS2/UCRT64 exactly as the CI `Windows MinGW` job does.
    make `hle_kernel_mem.cpp`/`hle_kernel.cpp` use the shims.
 3. **macOS port:** `exec_image_darwin.cpp`, x86_64 preset, MoltenVK + SDL3 frontend. Exit
    criterion: the pure test suite + a dump-gated boot test green under Rosetta on this laptop.
-4. **Windows native port:** `exec_image_win.cpp`, `sysv_abi` boundary, FS strategy per spike
-   result. WSL2 remains the supported Windows path meanwhile.
+4. **Windows native hardening:** keep extending gameplay coverage beyond the completed substrate,
+   then address physical-memory aliasing, XMM import arguments, and remaining VEH edge cases.
 5. **Android packaging:** Box64 + rootfs + Turnip APK, Kotlin shell. After macOS/Windows ship.
 6. **Hedge track (background):** validate the Linux-VM-on-macOS route (Rosetta-for-Linux or
    FEX/muvm + Venus) before macOS 28 removes general Rosetta.

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -1,13 +1,14 @@
 # Windows native port — handoff (2026-07-14)
 
 The Windows native core boots The Messenger (`PPSA24651`) through IL2CPP and repeated GC
-stop-the-world cycles, then drives real GPU draws and presents 1920x1080 frames. The fence-field,
-metadata-read, and asynchronous-GC blockers were fixed in #672, #673, and #678 respectively. A
-60-second native validation reached SubmitDcb #28 (up to 11 draws per submit) without a guest fatal;
-the next frontier is user-facing frontend/gameplay validation and the remaining portability gaps in
-`docs/PORTING.md` ("Windows").
+stop-the-world cycles, drives real GPU draws, and presents 1920x1080 frames. The fence-field,
+binary-file-read, and asynchronous-GC blockers were fixed in #672, #673, and #678 respectively.
+Issue #683 adds and validates the SDL3/Vulkan window, audio and controller frontends plus the normal
+sampled screenshot tool. Its native fresh-save route now reaches a fully lit first-level frame at
+1920x1080 and exits cleanly. During that acceptance run, #688 exposed and fixed a stale Windows
+readability stub that allowed a null dynamic-fetch table to reach a host dereference.
 
-## What works today (merged to master)
+## What works today
 
 The guest, on Windows (MinGW, native), reproducibly:
 - Boots through SELF/ELF load → multi-module link → `module_start` init → guest `%fs` TLS.
@@ -19,6 +20,8 @@ The guest, on Windows (MinGW, native), reproducibly:
   (`WriteData`/`ReleaseMem`/`WaitRegMem`) and delivers flip/vblank/EOP events.
 - Delivers IL2CPP's exception-type `0x1e` asynchronously on the requested target thread, allowing
   repeated GC stop-the-world suspend/resume cycles to complete.
+- Runs the shared live Vulkan renderer and normal 1920x1080 present/readback path on an NVIDIA host.
+- Builds SDL3 with native Win32 video, WASAPI audio, XInput/HIDAPI controllers, and Vulkan support.
 
 Merged PRs that got it here (all `#ifdef _WIN32` — Linux/macOS unaffected, CI green on all 4 platforms):
 - **#624** substrate: `exec_image_win.cpp` (VirtualAlloc mapping, VEH fault handler, SysV↔MS-x64 stub
@@ -94,10 +97,60 @@ Native runtime validation: `data_sel=2 data=1`, `ref=1 mask=ffffffff`, no `NOT s
 completes. The later #673 metadata and #678 GC-delivery blockers are also resolved; do not reopen the
 solved fence investigation when diagnosing a later Windows failure.
 
-## Build + run + diagnose (native Windows, MinGW)
+## Full frontend build and validation (native Windows, MinGW)
 
-Toolchain on PATH: WinLibs MinGW-w64 UCRT `gcc/g++.exe` + Ninja; CMake; Vulkan SDK (`VULKAN_SDK` set).
-Git via PowerShell; build/run via Git Bash. Configure a Vulkan-enabled build dir once:
+Required tools are WinLibs MinGW-w64 UCRT `gcc/g++.exe`, Ninja, CMake, and a Vulkan SDK with
+`VULKAN_SDK` set. Configure the window, SDL3 audio/controller, live renderer, and screenshot tool
+directly from PowerShell:
+
+```powershell
+$wlb = "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\BrechtSanders.WinLibs.POSIX.UCRT_Microsoft.Winget.Source_8wekyb3d8bbwe\mingw64\bin"
+cmake -S prosper -B prosper/build-mingw-app -G Ninja `
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+  -DCMAKE_C_COMPILER="$wlb\gcc.exe" -DCMAKE_CXX_COMPILER="$wlb\g++.exe" `
+  -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON `
+  -DGAME_DUMP=C:/Users/matti/repos/ps5ys/PPSA24651-app0
+cmake --build prosper/build-mingw-app -j 8
+```
+
+Smoke-test the actual SDL window and Vulkan swapchain without a game, then run the game frontend:
+
+```powershell
+prosper/build-mingw-app/prosper-app.exe --test-pattern --frames 120
+$env:PROSPER_GUEST_FS = '1'
+$env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
+prosper/build-mingw-app/prosper-app.exe --dump C:/Users/matti/repos/ps5ys/PPSA24651-app0
+```
+
+For unattended evidence, `screenshot.exe` uses Windows Imaging Component to write normal PNGs and
+creates missing output directories. The following is the measured fresh-save acceptance route. It
+samples every ten seconds to keep the evidence compact while retaining boot, menu, loading, fade, and
+fully lit first-level milestones:
+
+```powershell
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$env:PROSPER_PAD_SCRIPT = '@C:/Users/matti/repos/ps5ys/prosper/scripts/messenger/reach-first-level-windows.pad'
+$env:PROSPER_PAD_SCRIPT_LOG = '1'
+$env:PROSPER_SAVEDATA_DIR = "$env:TEMP/prosper-messenger-$stamp"
+prosper/build-mingw-app/screenshot.exe C:/Users/matti/repos/ps5ys/PPSA24651-app0 `
+  --seconds 10 --count 36 --out "$env:USERPROFILE/Downloads/messenger-windows-$stamp" `
+  --min-distinct-frames 25 --min-pixel-distinct-frames 10 --require-composited-frame
+```
+
+Use `--seconds 1 --count 360` when a complete one-frame-per-second sequence is more useful than a
+compact acceptance sample. The validated 2026-07-14 run completed 36/36 captures at 360.3 seconds,
+reported 36 distinct source frames and 23 distinct pixel frames, and showed the fully lit level in
+the final PNG with process exit 0.
+
+Use a new `PROSPER_SAVEDATA_DIR` for every fresh-save route validation. The manifest and PNG count
+prove capture health; inspect the final PNGs too, because delivered input does not prove that the
+intended game state was reached. Wall-time routes are renderer-speed sensitive, so use the dedicated
+Windows route for native full rendering and keep `PROSPER_PAD_SCRIPT_LOG=1` enabled.
+
+## Core diagnostics build
+
+This smaller Git Bash recipe remains useful when only `boot_trace` and verbose core diagnostics are
+needed. It shares the same compiler and Vulkan SDK prerequisites as the full build above:
 
 ```bash
 WLB="/c/Users/matti/AppData/Local/Microsoft/WinGet/Packages/BrechtSanders.WinLibs.POSIX.UCRT_Microsoft.Winget.Source_8wekyb3d8bbwe/mingw64/bin"
@@ -108,7 +161,7 @@ cmake -S prosper -B prosper/build-mingw-vk -G Ninja -DCMAKE_BUILD_TYPE=Debug \
 cmake --build prosper/build-mingw-vk --target boot_trace -j8
 ```
 
-Run (Git Bash — PowerShell redirection writes UTF-16). Guest-fs is default-on on Windows:
+Run from Git Bash (guest-fs is default-on on Windows):
 
 ```bash
 cd prosper/build-mingw-vk
@@ -119,8 +172,8 @@ PROSPER_GFXLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 Diagnostics (env, all off by default): `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode + the `NOT satisfied`
 fence log), `PROSPER_EVLOG` (`[ev]` equeue/flip/EOP), `PROSPER_SYNCLOG` (`[sync]` WaitOnAddress/Wake with
 tid + validated guest caller, `[sync2]` cond/sema/EventFlag), `PROSPER_EXCLOG` (GC exception
-raise/deliver/resume), `PROSPER_MEMLOG`, `PROSPER_VEHLOG`, boot_trace `[memclass]`. The Messenger renders
-on **Linux** (`build-linux`, `PROSPER_GUEST_FS=1 …`) — use it as the oracle.
+raise/deliver/resume), `PROSPER_MEMLOG`, `PROSPER_VEHLOG`, and boot_trace `[memclass]`. Compare with a
+known-good Linux capture when separating cross-platform frontend faults from shared renderer faults.
 
 ## Gotchas learned (so the next agent doesn't relearn them)
 
@@ -130,5 +183,9 @@ on **Linux** (`build-linux`, `PROSPER_GUEST_FS=1 …`) — use it as the oracle.
 - MinGW `longjmp` does an SEH unwind that can't cross guest/asm frames → use `__builtin_setjmp/longjmp`.
 - `boot_trace` on Windows is nondeterministic-crash-prone ONLY if a diagnostic reads raw stack words —
   the sync-caller scanner is `VirtualQuery`-guarded now; keep any new stack-walk guarded.
-- The intermittent `exit 139` on some runs is a residual worker-thread edge; runs mostly reach the
-  fence stall deterministically.
+- Windows file descriptors must use binary mode for guest assets. Text-mode reads can translate
+  bytes and corrupt metadata even when the same path works on Linux (#673).
+- Asynchronous GC delivery must wake a target blocked in `WaitOnAddress`; rewriting its context alone
+  is insufficient because it may never return to guest code (#678).
+- Dynamic-fetch constant folding must reject unreadable guest ranges on every host. The native
+  renderer exercises this path; an unconditional Windows readability stub caused #688.

--- a/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
@@ -27,7 +27,13 @@ int main() {
     printf("== test_audio_sdl3 ==\n");
     register_builtin_hle();
     // Force the dummy driver so this runs on headless CI with no sound hardware.
-    if (!getenv("SDL_AUDIO_DRIVER")) setenv("SDL_AUDIO_DRIVER", "dummy", 1);
+    if (!getenv("SDL_AUDIO_DRIVER")) {
+#ifdef _WIN32
+        _putenv_s("SDL_AUDIO_DRIVER", "dummy");
+#else
+        setenv("SDL_AUDIO_DRIVER", "dummy", 1);
+#endif
+    }
 
     bool ok = install_sdl3_audio_sink();
     CHECK(ok);

--- a/prosper/frontends/pad_sdl3/pad_sdl3.hpp
+++ b/prosper/frontends/pad_sdl3/pad_sdl3.hpp
@@ -10,8 +10,8 @@
 namespace prosper {
 
 // Initialise SDL gamepad and install the SDL3 PadBackend as the active backend. Idempotent.
-// Returns true on success; false (leaving the core's neutral default active) if SDL gamepad could
-// not be initialised. Call once at startup after register_builtin_hle().
+// Returns true on success; false (leaving the core's connected-neutral default active) if SDL
+// gamepad could not be initialised. Call once at startup after register_builtin_hle().
 bool install_sdl3_pad_backend();
 
 // Uninstall the SDL3 backend (restores the neutral default) and shut SDL gamepad down.

--- a/prosper/frontends/pad_sdl3/test_pad_sdl3.cpp
+++ b/prosper/frontends/pad_sdl3/test_pad_sdl3.cpp
@@ -21,7 +21,7 @@ int main() {
     if (!installed) {
         // If SDL gamepad can't init in this environment, the core default must remain active and safe.
         HostPadState s; bool present = pad_backend()->poll(0, s);
-        CHECK(!present && !s.connected, "fallback: neutral default backend still safe");
+        CHECK(present && s.connected, "fallback: connected neutral default backend restored");
         printf(fails ? "== FAIL ==\n" : "== PASS (SDL unavailable, safe fallback) ==\n");
         return fails ? 1 : 0;
     }
@@ -40,9 +40,10 @@ int main() {
     CHECK(d.connected == 0 && d.orientation_w == 1.0f, "mapping: disconnected + identity orientation");
 
     shutdown_sdl3_pad_backend();
-    // After shutdown the neutral core default is restored.
+    // After shutdown the connected-neutral core default (#680) is restored.
     HostPadState s2; bool p2 = pad_backend()->poll(0, s2);
-    CHECK(!p2 && !s2.connected, "after shutdown: neutral default restored");
+    CHECK(p2 && s2.connected && s2.buttons == 0,
+          "after shutdown: connected neutral default restored");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -18,6 +18,7 @@
 #include "host/exec_image.hpp"         // run_entry
 #include "loader/linker.hpp"           // Program
 #include "input/pad.hpp"               // keyboard -> libScePad (HostPadState / PadBackend)
+#include "pad_overlay.hpp"              // keyboard pad 0 composed over the physical controller backend
 #ifdef PROSPER_HAVE_LIVE_RENDERER
 #include "live_renderer.hpp"           // shared DrawItem->Vulkan compositor (register_live_renderer)
 #endif
@@ -44,11 +45,18 @@
 #include <cmath>
 #include <chrono>
 #include <thread>
-#include <mutex>
 
 using namespace prosper;
 
 namespace {
+
+bool set_environment(const char* name, const char* value) {
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, 1) == 0;
+#endif
+}
 
 // ---- tiny Vulkan error helper -----------------------------------------------------------------
 #define VKCHECK(x, msg) do { VkResult _r = (x); if (_r != VK_SUCCESS) { \
@@ -276,22 +284,11 @@ void feed_test_pattern(uint32_t w, uint32_t h, uint64_t frame) {
 
 // ---- keyboard -> virtual DualSense (pad 0) ----------------------------------------------------
 // A controller over WSL passthrough is flaky, so the app maps the keyboard onto the same
-// HostPadState the SDL gamepad backend fills. The event loop snapshots the current key state into
-// g_kb_state (main thread); the guest's scePadReadState reads it through this backend (guest thread).
-std::mutex g_kb_mx;
-prosper::input::HostPadState g_kb_state;
+// HostPadState the SDL gamepad backend fills. The event loop updates g_keyboard_pad on the main
+// thread; the guest's scePadReadState reads the composed keyboard/physical state on a guest thread.
+prosper::frontend::KeyboardPadOverlay g_keyboard_pad;
 
-struct KeyboardPad : prosper::input::PadBackend {
-    bool poll(int index, prosper::input::HostPadState& out) override {
-        if (index != 0) return false;                 // single virtual pad
-        std::lock_guard<std::mutex> lk(g_kb_mx);
-        out = g_kb_state;
-        return true;
-    }
-};
-KeyboardPad g_keyboard_pad;
-
-// Snapshot the current keyboard into g_kb_state. Call from the thread that pumps SDL events.
+// Snapshot the current keyboard into the overlay. Call from the thread that pumps SDL events.
 void poll_keyboard() {
     using namespace prosper::input;
     const bool* k = SDL_GetKeyboardState(nullptr);
@@ -321,8 +318,7 @@ void poll_keyboard() {
     st.l2 = d(SDL_SCANCODE_Y) ? 255 : 0;
     st.r2 = d(SDL_SCANCODE_H) ? 255 : 0;
     st.connected = true;
-    std::lock_guard<std::mutex> lk(g_kb_mx);
-    g_kb_state = st;
+    g_keyboard_pad.set_keyboard_state(st);
 }
 
 } // namespace
@@ -335,7 +331,12 @@ int main(int argc, char** argv) {
         if (a == "--test-pattern") testPattern = true;
         else if (a == "--frames" && i + 1 < argc) exitAfter = atoi(argv[++i]);   // present N frames then exit (CI/smoke)
         else if (a == "--dump" && i + 1 < argc) dump = argv[++i];                // boot the game at this app0 dir
-        else if (a == "--record" && i + 1 < argc) setenv("PROSPER_PAD_RECORD", argv[++i], 1);
+        else if (a == "--record" && i + 1 < argc) {
+            if (!set_environment("PROSPER_PAD_RECORD", argv[++i])) {
+                fprintf(stderr, "prosper-app: failed to set PROSPER_PAD_RECORD\n");
+                return 2;
+            }
+        }
         else if (a[0] != '-' && dump.empty()) dump = a;                          // positional dump path
     }
 
@@ -360,7 +361,10 @@ int main(int argc, char** argv) {
             prosper::install_sdl3_audio_sink();
 #endif
 #ifdef PROSPER_PAD_SDL3
-            if (prosper::install_sdl3_pad_backend()) fprintf(stderr, "[app] controller backend installed.\n");
+            if (prosper::install_sdl3_pad_backend()) {
+                g_keyboard_pad.set_fallback(prosper::input::pad_backend());
+                fprintf(stderr, "[app] controller backend installed.\n");
+            }
 #endif
 #ifdef PROSPER_HAVE_DIALOG_SDL3
             prosper::install_sdl3_platform_ui();   // real SDL message boxes for MsgDialog/ErrorDialog (#347)
@@ -403,7 +407,7 @@ int main(int argc, char** argv) {
     fprintf(stderr, "[app] window up (%s). Close the window or press Esc to quit.\n",
             testPattern ? "test-pattern" : "waiting for guest frames");
 
-    // Keyboard controls (installed last, so it's the active pad even if the SDL gamepad backend ran).
+    // Keyboard controls augment SDL pad 0; the fallback keeps physical pads and their analog state.
     prosper::input::pad_set_backend(&g_keyboard_pad);
     fprintf(stderr, "[app] keyboard: WASD/Arrows=move  J/Space=Cross(jump)  K=Square(attack)  L=Circle  "
                     "I=Triangle  U/O=L1/R1  Y/H=L2/R2  Enter=Options  Esc=quit\n");

--- a/prosper/frontends/prosper-app/pad_overlay.hpp
+++ b/prosper/frontends/prosper-app/pad_overlay.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "input/pad.hpp"
+
+#include <mutex>
+
+namespace prosper::frontend {
+
+// Adds a keyboard-backed virtual pad 0 without hiding an installed physical-pad backend.
+class KeyboardPadOverlay final : public input::PadBackend {
+public:
+    void set_fallback(input::PadBackend* backend) { fallback_ = backend; }
+
+    void set_keyboard_state(const input::HostPadState& state) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        keyboard_ = state;
+    }
+
+    bool poll(int index, input::HostPadState& out) override {
+        const bool physical = fallback_ && fallback_ != this && fallback_->poll(index, out);
+        if (index != 0) return physical;
+
+        input::HostPadState keyboard;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            keyboard = keyboard_;
+        }
+        if (!physical) out = {};
+        out.buttons |= keyboard.buttons;
+        if (keyboard.left_x != 0x80) out.left_x = keyboard.left_x;
+        if (keyboard.left_y != 0x80) out.left_y = keyboard.left_y;
+        if (keyboard.l2 > out.l2) out.l2 = keyboard.l2;
+        if (keyboard.r2 > out.r2) out.r2 = keyboard.r2;
+        out.connected = true;
+        return true;
+    }
+
+private:
+    std::mutex mutex_;
+    input::HostPadState keyboard_;
+    input::PadBackend* fallback_ = nullptr;
+};
+
+} // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/test_pad_overlay.cpp
+++ b/prosper/frontends/prosper-app/test_pad_overlay.cpp
@@ -1,0 +1,56 @@
+#include "pad_overlay.hpp"
+
+#include <cstdio>
+
+using namespace prosper::input;
+
+namespace {
+
+int failures = 0;
+#define CHECK(expr) do { if (!(expr)) { std::printf("FAIL line %d: %s\n", __LINE__, #expr); ++failures; } } while (0)
+
+struct PhysicalPads final : PadBackend {
+    bool poll(int index, HostPadState& out) override {
+        if (index > 1) return false;
+        out = {};
+        out.connected = true;
+        out.buttons = index == 0 ? SCE_PAD_BUTTON_SQUARE : SCE_PAD_BUTTON_CIRCLE;
+        out.left_x = 0x90;
+        out.right_x = 0x22;
+        out.l2 = 80;
+        return true;
+    }
+};
+
+} // namespace
+
+int main() {
+    prosper::frontend::KeyboardPadOverlay overlay;
+
+    HostPadState state;
+    CHECK(overlay.poll(0, state));
+    CHECK(state.connected && state.buttons == 0 && state.left_x == 0x80);
+    CHECK(!overlay.poll(1, state));
+
+    PhysicalPads physical;
+    overlay.set_fallback(&physical);
+    HostPadState keyboard;
+    keyboard.buttons = SCE_PAD_BUTTON_CROSS;
+    keyboard.left_x = 0;
+    keyboard.r2 = 120;
+    overlay.set_keyboard_state(keyboard);
+
+    CHECK(overlay.poll(0, state));
+    CHECK(state.connected);
+    CHECK(state.buttons == (SCE_PAD_BUTTON_SQUARE | SCE_PAD_BUTTON_CROSS));
+    CHECK(state.left_x == 0 && state.right_x == 0x22);
+    CHECK(state.l2 == 80 && state.r2 == 120);
+
+    CHECK(overlay.poll(1, state));
+    CHECK(state.buttons == SCE_PAD_BUTTON_CIRCLE && state.left_x == 0x90);
+    CHECK(!overlay.poll(2, state));
+
+    if (failures) std::printf("FAIL: %d\n", failures);
+    else std::printf("PASS\n");
+    return failures ? 1 : 0;
+}

--- a/prosper/scripts/messenger/README.md
+++ b/prosper/scripts/messenger/README.md
@@ -15,6 +15,16 @@ PROSPER_PAD_SCRIPT=@scripts/messenger/reach-intro-story.pad \
   current master at `PROSPER_RENDER_SCALE=4`; both runs reached the opening map
   narration. The exact narration phase still drifts by a few rendered frames,
   so this is a coarse state route, not an exact visual checkpoint.
+- `reach-first-level.pad`: the wall-time route used for the final fresh-save
+  validation on issue #522. It crosses the title, story choices, and dialogue
+  into the first playable level. The route is intentionally time-anchored to
+  preserve the hardware-oracle validation sequence; use one-second screenshot
+  sampling and allow at least 180 seconds.
+- `reach-first-level-windows.pad`: native Windows full-render variant. Explicit
+  1.5-second input windows survive sparse pad polling and its delayed tail waits
+  for save-slot and name-entry transitions. The validated native run reached a
+  fully lit first-level frame at 360 seconds. Use a fresh `PROSPER_SAVEDATA_DIR`
+  and keep `PROSPER_PAD_SCRIPT_LOG=1` enabled.
 
 Create another route with `prosper-app --record <path>` or
 `PROSPER_PAD_RECORD=<path>`, replay it with `PROSPER_PAD_SCRIPT=@path`, and only

--- a/prosper/scripts/messenger/reach-first-level-windows.pad
+++ b/prosper/scripts/messenger/reach-first-level-windows.pad
@@ -1,0 +1,40 @@
+# The Messenger (PPSA24651): fresh-save route for native Windows full rendering.
+# Explicit windows survive the roughly one-second pad poll interval. The final tail waits
+# for save-slot and name-entry transitions which complete later than in the Linux renderer.
+3-4.5:options
+7-8.5:options
+13-14.5:cross
+20-21.5:cross
+26-27.5:cross
+28-29.5:options
+33-34.5:up
+35-36.5:cross
+45-46.5:cross
+55-56.5:cross
+70-71.5:cross
+85-86.5:options
+100-101.5:up
+112-113.5:cross
+
+# Select a fresh slot and enter the name screen.
+120-121.5:up
+122-123.5:cross
+124-125.5:cross
+128-129.5:up
+130-131.5:cross
+132-133.5:cross
+136-137.5:up
+138-139.5:cross
+140-141.5:cross
+
+# Enter "AA", submit it, select Yes, and confirm.
+185-186.5:cross
+200-201.5:cross
+215-216.5:options
+230-231.5:up
+245-246.5:cross
+
+# Redundant confirmations around the long save/load boundary; presses are ignored while the game
+# suspends pad polling, but cover timing drift after confirmation without changing menu selections.
+270-271.5:cross
+285-286.5:cross

--- a/prosper/scripts/messenger/reach-first-level.pad
+++ b/prosper/scripts/messenger/reach-first-level.pad
@@ -1,0 +1,25 @@
+# The Messenger (PPSA24651): fresh-save route through menus/story into first-level dialogue.
+# Recovered from the final clean-build validation on issue #522.
+3:options
+7:options
+13:cross
+20:cross
+26:cross
+28:options
+33:up
+35:cross
+45:cross
+55:cross
+70:cross
+85:options
+100:up
+112:cross
+120:up
+122:cross
+124:cross
+128:up
+130:cross
+132:cross
+136:up
+138:cross
+140:cross

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -19,7 +19,9 @@
 #include <set>
 #include <vector>
 #include <unordered_map>
-#ifndef _WIN32
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <unistd.h>
 #endif
@@ -58,9 +60,10 @@ bool g_dyntrace_force = false;
 // so the old probe reported EVERY address >= 0x1000 "readable" and all guards built on it were
 // no-ops (verified empirically on this project's WSL kernel). A pipe write actually imports the
 // user pages and returns EFAULT for unmapped memory. Readability is page-granular: probe one byte
-// in each page the range touches, draining after every write so the pipe can never fill. Always-
-// true on Windows (the const-eval only runs on the live-render path, which is Linux; tests never
-// pass wild addresses).
+// in each page the range touches, draining after every write so the pipe can never fill. Windows
+// uses VirtualQuery for the same guard. Dynamic fetch resolution now runs in the native
+// live renderer too, so an always-true probe turns a guest null descriptor-table pointer into a
+// host access violation (#688).
 #ifndef _WIN32
 static int g_probe_pipe[2] = {-1, -1};
 // One-time pipe creation via a C++11 magic static (thread-safe). guest_readable is shared with
@@ -98,7 +101,24 @@ bool guest_readable(uint64_t a, uint32_t n) {
     return true;
 }
 #else
-bool guest_readable(uint64_t, uint32_t) { return true; }
+bool guest_readable(uint64_t a, uint32_t n) {
+    if (a < 0x1000 || n == 0 || a + n < a) return false;
+    const uint64_t end = a + n;
+    uint64_t cursor = a;
+    while (cursor < end) {
+        MEMORY_BASIC_INFORMATION mbi{};
+        if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
+        const DWORD blocked = PAGE_NOACCESS | PAGE_GUARD;
+        if (mbi.State != MEM_COMMIT || (mbi.Protect & blocked)) return false;
+        const DWORD readable = PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+                               PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+        if (!(mbi.Protect & readable)) return false;
+        const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+        if (region_end <= cursor) return false;
+        cursor = std::min(end, region_end);
+    }
+    return true;
+}
 #endif
 
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -6,10 +6,10 @@
 // of ucontext. The guest is System V AMD64; the host is Microsoft x64. Emitted import stubs marshal
 // guest calls into the host ABI, and prosper_call_guest_sysv marshals host calls into the guest ABI.
 //
-// STATUS (2026-07-13): runtime-verified through a multi-threaded headless frame-loop boot. Remaining
-// work is tracked in docs/PORTING.md "Windows": wire the Vulkan renderer, preserve physical-memory
-// aliasing, cover float/XMM import arguments, and harden VEH recovery. Diagnostics that depend on
-// Linux perf_event / ptrace (PROSPER_HWBP/HWWATCH/BP/PEEK/DUMPAT) are intentionally absent here.
+// STATUS (2026-07-14): runtime-verified through repeated GC cycles and the native live Vulkan
+// renderer. Remaining work is tracked in docs/PORTING.md "Windows", including physical-memory
+// alias fidelity, float/XMM import arguments, and deeper frontend/gameplay validation. Diagnostics
+// that depend on Linux perf_event / ptrace (PROSPER_HWBP/HWWATCH/BP/PEEK/DUMPAT) remain absent.
 #ifdef _WIN32
 
 #include "exec_image.hpp"

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -178,8 +178,9 @@ uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double
 
 // ---- Pluggable host backend (mirrors AudioSink / audio_set_sink) -------------------------------
 //
-// prosper_core is HEADLESS: it ships a default backend that reports a neutral, disconnected pad, so
-// the HLE contract is fully defined with no dependencies and is unit-testable. A concrete host
+// prosper_core is HEADLESS: it ships a default backend that reports one connected neutral pad, so
+// titles with a controller-presence gate can progress and the HLE contract remains dependency-free
+// and unit-testable. A concrete host
 // backend (SDL3 gamepad, or the zero-dep Linux evdev reader) lives OUTSIDE prosper_core, under
 // frontends/, and installs itself via pad_set_backend() from the harness (boot_trace). This keeps
 // prosper_core free of any host-input / device code, and makes a future libretro core trivial — it
@@ -192,7 +193,7 @@ struct PadBackend {
     virtual bool poll(int index, HostPadState& out) = 0;
 };
 
-// Install a backend. Non-owning; pass nullptr to restore the built-in neutral/disconnected default.
+// Install a backend. Non-owning; pass nullptr to restore the built-in connected-neutral default.
 void pad_set_backend(PadBackend* backend);
 // The active backend (never null — the neutral default is returned when none is installed).
 PadBackend* pad_backend();

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -22,6 +22,11 @@ static int fails = 0;
 int main() {
     printf("== test_dynfetch_fold ==\n");
 
+    uint32_t readable_probe = 0;
+    CHECK(!guest_readable(0, sizeof(uint32_t)), "null guest address is not readable");
+    CHECK(guest_readable((uint64_t)(uintptr_t)&readable_probe, sizeof(readable_probe)),
+          "mapped host/guest address is readable");
+
     // Kernel 1: negative INLINE INT src0 sign-extends to 64 bits.
     //   s_mov_b32 s8, 0x1000 | s_mov_b32 s9, 0 | s_mov_b32 s10, 64
     //   s_bfe_u64 s[12:13], -1, 0x80028      ; bits [47:40] of 0xFFFF..FF = 0xFF (hi dword all-ones)

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -13,12 +13,16 @@ partial early output instead of waiting indefinitely for a Vulkan draw.
 
 ## Build
 
-Built automatically wherever Vulkan + zlib are available (same block as `boot_trace`):
+Built automatically with the live Vulkan renderer. Unix uses zlib; native Windows uses the built-in
+Windows Imaging Component PNG encoder and needs no zlib package:
 
 ```bash
 cmake -S prosper -B build -DPROSPER_APP=ON      # or any config that finds Vulkan
 cmake --build build --target screenshot
 ```
+
+The executable is `screenshot.exe` in a native Windows build. Commands and environment variables are
+otherwise identical in PowerShell; use `$env:NAME = 'value'` to set each variable.
 
 ## Usage
 

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -20,7 +20,7 @@
 // Reaching a rendering frame loop needs the guest switches the render frontier documents; this tool
 // defaults PROSPER_GUEST_FS=1 and PROSPER_GUEST_ARGS=-force-gfx-direct (Unity/Messenger recipe) if
 // they aren't already set. For other titles, set the appropriate env before running (e.g. a UE4
-// title: PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1). Linux-only (the guest substrate is).
+// title: PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1).
 #include "loader/linker.hpp"          // Program
 #include "host/boot_program.hpp"       // boot_program
 #include "host/exec_image.hpp"         // run_entry
@@ -29,7 +29,14 @@
 #include "live_renderer.hpp"           // register_live_renderer (frontends/shared)
 #include "capture_manifest.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <wincodec.h>
+#include <objbase.h>
+#else
 #include <zlib.h>
+#include <unistd.h>
+#endif
 #include <algorithm>
 #include <climits>
 #include <cmath>
@@ -47,11 +54,30 @@
 #include <thread>
 #include <chrono>
 #include <ctime>
-#include <unistd.h>
 
 using namespace prosper;
 
 namespace {
+
+bool set_environment(const char* name, const char* value, bool overwrite) {
+    if (!overwrite && getenv(name)) return true;
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, overwrite ? 1 : 0) == 0;
+#endif
+}
+
+uint32_t crc32_bytes(const void* data, size_t len, uint32_t seed = 0) {
+    uint32_t crc = ~seed;
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= bytes[i];
+        for (int bit = 0; bit < 8; ++bit)
+            crc = (crc >> 1) ^ (0xedb88320u & (0u - (crc & 1u)));
+    }
+    return ~crc;
+}
 
 bool parse_nonnegative_double(const char* text, double& value) {
     char* end = nullptr;
@@ -85,15 +111,92 @@ void put_chunk(FILE* f, const char* type, const uint8_t* data, size_t len) {
     fwrite(hdr, 1, 4, f);
     fwrite(type, 1, 4, f);
     if (len) fwrite(data, 1, len, f);
-    uint32_t crc = crc32(0, (const Bytef*)type, 4);
-    if (len) crc = crc32(crc, (const Bytef*)data, (uInt)len);
+    uint32_t crc = crc32_bytes(type, 4);
+    if (len) crc = crc32_bytes(data, len, crc);
     uint8_t crcb[4] = { (uint8_t)(crc >> 24), (uint8_t)(crc >> 16), (uint8_t)(crc >> 8), (uint8_t)crc };
     fwrite(crcb, 1, 4, f);
 }
 
-// Write w*h RGBA8 as an 8-bit RGBA PNG (filter None per row, zlib-compressed IDAT).
+// Write w*h RGBA8 as an 8-bit RGBA PNG.
 bool write_png(const char* path, const uint8_t* rgba, uint32_t w, uint32_t h,
                std::string& error) {
+#ifdef _WIN32
+    const HRESULT init_hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    const bool uninitialize = SUCCEEDED(init_hr);
+    if (FAILED(init_hr) && init_hr != RPC_E_CHANGED_MODE) {
+        char detail[64];
+        snprintf(detail, sizeof detail, "COM init failed (0x%08lx)", (unsigned long)init_hr);
+        error = detail;
+        return false;
+    }
+
+    IWICImagingFactory* factory = nullptr;
+    IWICStream* stream = nullptr;
+    IWICBitmapEncoder* encoder = nullptr;
+    IWICBitmapFrameEncode* frame = nullptr;
+    IPropertyBag2* properties = nullptr;
+    HRESULT hr = S_OK;
+    bool ok = false;
+    do {
+        hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&factory));
+        if (FAILED(hr)) break;
+        hr = factory->CreateStream(&stream);
+        if (FAILED(hr)) break;
+        const std::wstring wide_path = std::filesystem::path(path).wstring();
+        hr = stream->InitializeFromFilename(wide_path.c_str(), GENERIC_WRITE);
+        if (FAILED(hr)) break;
+        hr = factory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder);
+        if (FAILED(hr)) break;
+        hr = encoder->Initialize(stream, WICBitmapEncoderNoCache);
+        if (FAILED(hr)) break;
+        hr = encoder->CreateNewFrame(&frame, &properties);
+        if (FAILED(hr)) break;
+        hr = frame->Initialize(properties);
+        if (FAILED(hr)) break;
+        hr = frame->SetSize(w, h);
+        if (FAILED(hr)) break;
+        WICPixelFormatGUID format = GUID_WICPixelFormat32bppBGRA;
+        hr = frame->SetPixelFormat(&format);
+        if (FAILED(hr) || !IsEqualGUID(format, GUID_WICPixelFormat32bppBGRA)) {
+            if (SUCCEEDED(hr)) hr = WINCODEC_ERR_UNSUPPORTEDPIXELFORMAT;
+            break;
+        }
+        if (w == 0 || h == 0 || w > UINT32_MAX / 4) { hr = E_INVALIDARG; break; }
+        const UINT stride = w * 4;
+        if (h > UINT32_MAX / stride) { hr = E_INVALIDARG; break; }
+        const UINT byte_count = stride * h;
+        std::vector<uint8_t> bgra(byte_count);
+        for (size_t i = 0; i < byte_count; i += 4) {
+            bgra[i + 0] = rgba[i + 2];
+            bgra[i + 1] = rgba[i + 1];
+            bgra[i + 2] = rgba[i + 0];
+            bgra[i + 3] = rgba[i + 3];
+        }
+        hr = frame->WritePixels(h, stride, byte_count, bgra.data());
+        if (FAILED(hr)) break;
+        hr = frame->Commit();
+        if (FAILED(hr)) break;
+        hr = encoder->Commit();
+        if (FAILED(hr)) break;
+        ok = true;
+    } while (false);
+
+    if (properties) properties->Release();
+    if (frame) frame->Release();
+    if (encoder) encoder->Release();
+    if (stream) stream->Release();
+    if (factory) factory->Release();
+    if (uninitialize) CoUninitialize();
+    if (!ok) {
+        char detail[64];
+        snprintf(detail, sizeof detail, "WIC PNG encode failed (0x%08lx)", (unsigned long)hr);
+        error = detail;
+        std::error_code remove_error;
+        std::filesystem::remove(path, remove_error);
+    }
+    return ok;
+#else
     std::vector<uint8_t> raw;
     raw.reserve((size_t)h * (1 + (size_t)w * 4));
     for (uint32_t y = 0; y < h; y++) {
@@ -127,13 +230,18 @@ bool write_png(const char* path, const uint8_t* rgba, uint32_t w, uint32_t h,
     if (ferror(f)) {
         error = std::string("write failed: ") + strerror(errno);
         fclose(f);
+        std::error_code remove_error;
+        std::filesystem::remove(path, remove_error);
         return false;
     }
     if (fclose(f) != 0) {
         error = std::string("close failed: ") + strerror(errno);
+        std::error_code remove_error;
+        std::filesystem::remove(path, remove_error);
         return false;
     }
     return true;
+#endif
 }
 
 } // namespace
@@ -259,35 +367,41 @@ int main(int argc, char** argv) {
 
     // Run-start timestamp shared by every screenshot in this run, so a run groups when sorted.
     char ts[32];
-    { time_t t = time(nullptr); struct tm tmv; localtime_r(&t, &tmv); strftime(ts, sizeof ts, "%Y%m%d-%H%M%S", &tmv); }
+    { time_t t = time(nullptr); struct tm tmv;
+#ifdef _WIN32
+      localtime_s(&tmv, &t);
+#else
+      localtime_r(&t, &tmv);
+#endif
+      strftime(ts, sizeof ts, "%Y%m%d-%H%M%S", &tmv); }
 
     // Zero-pad the index to the width of the largest index (min 2), for correct lexical sort.
     int pad = 2; for (int m = count - 1, d = 1; ; m /= 10, d++) { if (m < 10) { if (d > pad) pad = d; break; } }
 
     // Sane render-frontier defaults (don't override if the caller set them for another title).
-    setenv("PROSPER_GUEST_FS",   "1", 0);
-    setenv("PROSPER_GUEST_ARGS", "-force-gfx-direct", 0);
+    set_environment("PROSPER_GUEST_FS",   "1", false);
+    set_environment("PROSPER_GUEST_ARGS", "-force-gfx-direct", false);
     if (warmup_seconds_set) {
         char delay_ms[32];
         snprintf(delay_ms, sizeof delay_ms, "%lld",
                  (long long)(warmup_seconds * 1000.0 + 0.5));
-        setenv("PROSPER_RENDER_DELAY_MS", delay_ms, 1);
+        set_environment("PROSPER_RENDER_DELAY_MS", delay_ms, true);
     }
     if (warmup_submits_set) {
         char first_submit[32];
         snprintf(first_submit, sizeof first_submit, "%d", warmup_submits);
-        setenv("PROSPER_RENDER_FIRST", first_submit, 1);
+        set_environment("PROSPER_RENDER_FIRST", first_submit, true);
     }
     if (render_every_arg > 0) {
         char cadence[32];
         snprintf(cadence, sizeof cadence, "%d", render_every_arg);
-        setenv("PROSPER_RENDER_EVERY", cadence, 1);
+        set_environment("PROSPER_RENDER_EVERY", cadence, true);
     }
     if (render_every_for_seconds > 0) {
         char duration_ms[32];
         snprintf(duration_ms, sizeof duration_ms, "%lld",
                  (long long)(render_every_for_seconds * 1000.0 + 0.5));
-        setenv("PROSPER_RENDER_EVERY_FOR_MS", duration_ms, 1);
+        set_environment("PROSPER_RENDER_EVERY_FOR_MS", duration_ms, true);
     }
 
     const int64_t render_delay_ms = getenv("PROSPER_RENDER_DELAY_MS")
@@ -427,9 +541,7 @@ int main(int argc, char** argv) {
                     const std::string fn = filename.str();
                     std::string png_error;
                     if (write_png(fn.c_str(), snap.rgba.data(), snap.width, snap.height, png_error)) {
-                        const uint32_t pixel_crc = static_cast<uint32_t>(crc32(
-                            0, reinterpret_cast<const Bytef*>(snap.rgba.data()),
-                            static_cast<uInt>(snap.rgba.size())));
+                        const uint32_t pixel_crc = crc32_bytes(snap.rgba.data(), snap.rgba.size());
                         screenshot::CaptureObservation observation;
                         observation.source = snap_rendered ? screenshot::CaptureSource::Rendered
                                                            : screenshot::CaptureSource::RawScanout;


### PR DESCRIPTION
## Summary

- build and validate the complete native MinGW `prosper-app` path with SDL3 Win32/WASAPI/XInput-HIDAPI and Vulkan
- make the normal sampled screenshot tool cross-platform, using WIC PNG encoding on Windows with output-directory creation, actionable write errors, and partial-file cleanup
- compose the keyboard virtual pad over the SDL physical-controller backend instead of replacing it
- add poll-safe Messenger fresh-save routes and document the exact native build/run/capture workflow
- guard dynamic-fetch constant folding with `VirtualQuery` on Windows, fixing the loading-time host access violation found by the gameplay route
- refresh README, porting, frontend, and agent handoff status

## Native acceptance

A `RelWithDebInfo` MinGW run used `reach-first-level-windows.pad`, a fresh save root, the live Vulkan renderer, and WIC readback:

- exit 0 after 360.7 seconds
- 36/36 normal 1920x1080 PNGs sampled every 10 seconds
- 36 distinct source frames, 23 distinct pixel frames
- boot/title/save/name/loading/fade milestones and a fully lit first-level frame
- no recurrence of the #688 `resolve_dynamic_fetch` access violation

Local evidence: `C:\Users\matti\Downloads\ps5ys-windows-messenger-acceptance-20260714-165047`

## Verification

- native Windows MinGW: 67/67 tests pass
- native Windows focused `RelWithDebInfo`: dynamic fetch, pad overlay, SDL audio, SDL pad pass
- Linux: 92/92 tests pass
- golden image guards:
  - Messenger: 24,318 colors >= 5,000
  - Dead Cells: 1,672 colors >= 1,500
- native and Linux screenshot targets build; WIC and zlib PNG paths both live-smoked

Fixes #683
Fixes #688