### PR TITLE
feat(macos): guest %fs TLS via trap-and-emulate — boots into Unity GPU init

### DIFF
--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -280,24 +280,36 @@ The macOS x86_64/Rosetta path is now real, not theoretical:
   fingerprint (#304) read the same bytes through `uint16_t*` and `uint32_t*` — strict-aliasing UB
   that Apple Clang 21 compiled into `ud2`. Now `memcpy` loads.
 
-### The macOS frontier: guest `%fs` TLS
+### The macOS frontier: guest `%fs` TLS — SOLVED (2026-07-14, trap-and-emulate)
 
-Boot stalls a few frames into libc init: a guest function does `call *rax` where `rax` resolved to
-a stack address, faulting (caught cleanly now, thanks to a mandatory alt stack on Darwin). The root
-cause is the predicted one — **guest initial-exec `%fs` TLS**. The Messenger needed
-`PROSPER_GUEST_FS` on Linux for correct TLS (see `guest_tls.cpp`: without it, guest `%fs:`-relative
-reads alias the host glibc TCB and return garbage). On macOS that gate is *force-disabled* because it
-is implemented with `wrfsbase`, which Rosetta SIGILLs on — and Darwin's `%fs` base is 0 (macOS uses
-`%gs` for TLS), so the guest's TLS reads resolve to garbage/stack values immediately, deeper and
-earlier than on Linux.
+Was: boot died a few frames into libc init on guest initial-exec `%fs` TLS. Rosetta rejects
+`wrfsbase`/`rdfsbase` (SIGILL) and Darwin's `%fs` base is 0 (macOS uses `%gs`), so we can't give the
+CPU a real guest fs base the way Linux (`wrfsbase`) and Windows (FSGSBASE + VEH re-apply) do.
 
-This is exactly the hard sub-problem flagged above for both Windows and macOS. Path forward
-(unchanged): find Rosetta's segment-base mechanism, or **patch/trap the guest `%fs`-relative
-accesses** — the fault handler already decodes instructions at fault sites (SSE4a), so
-trap-and-emulate of `%fs:` operands is in-house technology. NOTE (2026-07-14): the Windows port
-SOLVED its equivalent `%fs` TLS wall (FSGSBASE + VEH re-apply, see the Windows section) — but that
-relies on native FSGSBASE, which Rosetta does not expose (`wrfsbase` SIGILLs), so macOS still needs
-the trap/patch route rather than a direct port of the Windows fix.
+Solved by **trap-and-emulate**, settled by a spike: under Rosetta a guest `%fs:disp` access faults at
+linear address == the raw offset (fs base is 0), so the real target is simply `guest_TP + fault_addr`
+— no addressing-mode decode needed. Implementation:
+- `guest_tls.cpp` macOS "trap mode" (same `PROSPER_GUEST_FS` gate): build the per-thread Variant-II
+  guest TCB and store its thread pointer in host (`%gs`) TLS, but **do not** touch the CPU fs base.
+- `exec_image_linux.cpp` `try_emulate_fs_access`: in the SIGSEGV/SIGBUS handler, if the faulting
+  instruction carries an `%fs` prefix and trap-mode TLS is active, redirect the access to
+  `guest_TP + fault_addr`, emulate it (mov family — load/store all sizes, movzx/movsx, imm store),
+  advance RIP, and resume. Unknown instruction forms log and fall through (none seen so far).
+- The Linux `%fs` swap stubs are disabled on macOS (they use `wrfsbase`); handlers run on host `%gs`
+  TLS so no per-HLE-call swap is needed. TLS is activated before `.init_array` too (Apple-only).
+
+Result: Blasphemous 2 boots from the old libc-init death **all the way into Unity's PS5 GPU device
+init** (`GfxDevicePS5SharedData::CreateWorkload`), AGC command submission, and ~500 StreamingAssets
+bundles — 180k+ `%fs` accesses emulated with zero unhandled forms. The `prosper-app` window comes up
+and the live renderer begins creating real pipelines from the guest's draws.
+
+**Remaining to on-screen gameplay (follow-on frontiers, MoltenVK shader fidelity, not TLS):**
+- MoltenVK pipeline compat: `primitiveRestartEnable=VK_FALSE` is rejected by Metal — fixed (force
+  `VK_TRUE` on Apple). Next: the guest **vertex shader fails MSL compilation** in MoltenVK
+  (`Vertex shader function could not be compiled into pipeline`) — a SPIR-V→Metal translation gap to
+  isolate (same class as the `v_cvt_i32_f32` issue #686).
+- A guest **worker-thread fault** (`ret` to `0x0` at a host address) during asset load — a separate
+  HLE issue to diagnose.
 
 ### The macOS harness app (prosper-app) — WORKS (2026-07-14)
 

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -141,6 +141,9 @@ size_t tls_dtv_thread_count();
 void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count);
 bool guest_tls_enabled();
 uint64_t guest_tls_activate_thread();   // per guest thread at entry; returns guest TP (0 if disabled)
+// macOS trap mode only: the calling thread's guest thread-pointer, or 0. The SIGSEGV handler uses it
+// to relocate a faulting guest `%fs:`-relative access to guest_TP + offset (Rosetta can't set fs base).
+uint64_t guest_tls_tp();
 void guest_fs_enter_host_for_signal();  // crash-signal-handler entry: swap guest %fs -> host %fs (no-op if not guest TCB)
 uint64_t guest_fs_to_host_scoped();     // diagnostic handler (returns to guest): swap to host %fs, return prev fs
 void guest_fs_restore_scoped(uint64_t prev_fs);  // restore the fs returned by guest_fs_to_host_scoped

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -701,6 +701,109 @@ namespace {
     // source xmm (EXTRQ: rm[13:0]; INSERTQ: rm[77:64]).  len==0 means 64. CONFIDENCE: HIGH (Intel SDM).
     volatile unsigned long g_sse4a_emulated = 0;
     const bool g_sse4a_stat = getenv("PROSPER_SSE4A_STAT") != nullptr;
+#ifdef __APPLE__
+    // macOS/Rosetta guest %fs TLS emulation. Rosetta keeps the CPU fs base at 0 and rejects wrfsbase,
+    // so every guest `%fs:disp` access faults at linear address == the raw offset. With the per-thread
+    // guest TCB (guest_tls trap mode), the real target is guest_TP + fault_addr. Decode the fs-prefixed
+    // instruction, perform the access against the TCB, advance RIP, and resume. Handles the mov family
+    // (the overwhelming majority of TLS touches: self-ptr read, IE-var load/store, imm store, and
+    // movzx/movsx); logs+bails on any other form so it can be extended from real boot evidence.
+    volatile unsigned long g_fs_emulated = 0;
+    const bool g_fslog = getenv("PROSPER_FSLOG") != nullptr;
+    // x86 register number (rax=0..r15=15) -> Darwin greg view index.
+    static const int kX86ToReg[16] = { REG_RAX,REG_RCX,REG_RDX,REG_RBX,REG_RSP,REG_RBP,REG_RSI,REG_RDI,
+                                       REG_R8,REG_R9,REG_R10,REG_R11,REG_R12,REG_R13,REG_R14,REG_R15 };
+    bool try_emulate_fs_access(ucontext_t* uc, uint64_t fault_addr) {
+        uint64_t tp = guest_tls_tp();
+        if (!tp) return false;
+        auto g = PROSPER_GREGS(uc);
+        const uint8_t* p = (const uint8_t*)(uintptr_t)g[REG_RIP];
+        size_t i = 0;
+        bool fs = false, opsz16 = false;
+        for (;; i++) {              // legacy prefixes
+            uint8_t b = p[i];
+            if (b == 0x64) { fs = true; continue; }                 // %fs override — the one we want
+            if (b == 0x66) { opsz16 = true; continue; }
+            if (b==0xF2||b==0xF3||b==0x2E||b==0x36||b==0x3E||b==0x26||b==0x65||b==0x67) continue;
+            break;
+        }
+        if (!fs) return false;      // no fs prefix -> a genuine fault, not guest TLS
+        uint8_t rex = 0;
+        if ((p[i] & 0xF0) == 0x40) rex = p[i++];
+        bool w = rex & 8; bool rexR = rex & 4;
+        uint8_t op = p[i++];
+        bool two = (op == 0x0F);
+        if (two) op = p[i++];
+        uint8_t modrm = p[i++];
+        int mod = modrm >> 6;
+        int reg = ((modrm >> 3) & 7) | (rexR ? 8 : 0);
+        int rm  = modrm & 7;
+        if (mod == 3) return false;                 // register operand: not an fs memory access
+        size_t sib_off = i;
+        if (rm == 4) i++;                            // SIB byte present
+        if (mod == 0) {
+            if (rm == 5) i += 4;                     // disp32 (no base)
+            else if (rm == 4 && (p[sib_off] & 7) == 5) i += 4;
+        } else if (mod == 1) i += 1;
+        else i += 4;                                 // mod == 2
+        // Safety: only touch the guest TCB window [TP - total_below, TP + 0x200). A mis-decode with a
+        // wild offset is treated as a real fault (bail) rather than corrupting/reading random memory.
+        int64_t off = (int64_t)fault_addr;
+        if (off < -(int64_t)guest_tls_total_below() || off >= 0x200) return false;
+        volatile uint8_t* mem = (volatile uint8_t*)(uintptr_t)(tp + fault_addr);
+
+        auto wr_reg = [&](int xr, uint64_t v, int sz) {   // write a value into a reg with x86 width rules
+            uint64_t& r = g[kX86ToReg[xr]];
+            if (sz == 8)      r = v;
+            else if (sz == 4) r = (uint32_t)v;                    // 32-bit dest zero-extends to 64
+            else if (sz == 2) r = (r & ~0xffffull) | (v & 0xffff);
+            else              r = (r & ~0xffull)   | (v & 0xff);
+        };
+        auto rd_mem = [&](int sz) -> uint64_t {
+            uint64_t v = 0; for (int k = 0; k < sz; k++) v |= (uint64_t)mem[k] << (8*k); return v;
+        };
+        auto wr_mem = [&](uint64_t v, int sz) { for (int k = 0; k < sz; k++) mem[k] = (uint8_t)(v >> (8*k)); };
+
+        int sz = w ? 8 : (opsz16 ? 2 : 4);
+        bool handled = false;
+        if (!two) {
+            switch (op) {
+                case 0x8B: wr_reg(reg, rd_mem(sz), sz); handled = true; break;            // mov r, [fs:m]
+                case 0x8A: wr_reg(reg, rd_mem(1), 1);  handled = true; break;            // mov r8, [fs:m8]
+                case 0x89: wr_mem(g[kX86ToReg[reg]], sz); handled = true; break;         // mov [fs:m], r
+                case 0x88: wr_mem(g[kX86ToReg[reg]], 1);  handled = true; break;         // mov [fs:m8], r8
+                case 0xC7: { int isz = opsz16 ? 2 : 4; int32_t im = 0; memcpy(&im, p + i, isz); i += isz;
+                             wr_mem(w ? (uint64_t)(int64_t)im : (uint64_t)(uint32_t)im, sz); handled = true; break; } // mov [fs:m], imm
+                case 0xC6: { uint8_t imm = p[i++]; wr_mem(imm, 1); handled = true; break; }  // mov [fs:m8], imm8
+                default: break;
+            }
+        } else {
+            switch (op) {
+                case 0xB6: wr_reg(reg, rd_mem(1), w?8:4); handled = true; break;          // movzx r, m8
+                case 0xB7: wr_reg(reg, rd_mem(2), w?8:4); handled = true; break;          // movzx r, m16
+                case 0xBE: wr_reg(reg, (uint64_t)(int64_t)(int8_t)rd_mem(1), w?8:4);  handled = true; break;  // movsx m8
+                case 0xBF: wr_reg(reg, (uint64_t)(int64_t)(int16_t)rd_mem(2), w?8:4); handled = true; break;  // movsx m16
+                default: break;
+            }
+        }
+        if (!handled) {
+            char b[128]; int n = snprintf(b, sizeof b,
+                "[fs-emu] UNHANDLED fs insn rip=0x%llx off=%lld bytes: %02x %02x %02x %02x %02x %02x %02x %02x\n",
+                (unsigned long long)g[REG_RIP], (long long)off,
+                p[0],p[1],p[2],p[3],p[4],p[5],p[6],p[7]);
+            ssize_t wr = write(2, b, (size_t)(n>0?n:0)); (void)wr;
+            return false;   // fall through to the normal (fatal) fault path so the form is visible
+        }
+        g[REG_RIP] = (greg_t)(uintptr_t)(p + i);   // advance past the emulated instruction
+        g_fs_emulated++;
+        if (g_fslog && (g_fs_emulated & 0x3FFF) == 0) {
+            char b[64]; int n = snprintf(b, sizeof b, "[fs-emu] %lu accesses\n", g_fs_emulated);
+            ssize_t wr = write(2, b, (size_t)(n>0?n:0)); (void)wr;
+        }
+        return true;
+    }
+#endif  // __APPLE__
+
     bool try_emulate_sse4a(ucontext_t* uc) {
         auto g = PROSPER_GREGS(uc);
         uint64_t rip = (uint64_t)g[REG_RIP];
@@ -765,6 +868,13 @@ namespace {
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
         // Emulate AMD-only SSE4a bitfield ops (insertq/extrq) that #UD on Intel hosts, then resume.
         if (sig == SIGILL && try_emulate_sse4a((ucontext_t*)uctx)) return;
+#ifdef __APPLE__
+        // macOS/Rosetta: a guest `%fs:`-relative TLS access faults (fs base is 0). Redirect it to the
+        // guest TCB (guest_TP + offset) and resume. Only fires when trap-mode TLS is active and the
+        // faulting instruction actually carries an fs prefix; otherwise falls through to the real path.
+        if ((sig == SIGSEGV || sig == SIGBUS) && try_emulate_fs_access((ucontext_t*)uctx, (uint64_t)si->si_addr))
+            return;
+#endif
         // A SIGILL we did NOT emulate: log the faulting instruction bytes so the offending opcode can be
         // identified (another AMD-only ISA extension, or a decode miss in try_emulate_sse4a). #163-progress.
         if (sig == SIGILL) {
@@ -1715,7 +1825,14 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (got == MAP_FAILED || got != want) return fail("mmap stub region failed");
 
+#ifdef __APPLE__
+    // macOS trap mode NEVER swaps %fs: the CPU fs base stays 0 and HLE handlers run on the host's own
+    // (%gs) TLS, so the plain tail-jump stub is correct. (The swap stub uses rdfsbase/wrfsbase, which
+    // SIGILL on Rosetta — emitting it here made every guest import call trap.)
+    bool swap = false;
+#else
     bool swap = guest_tls_enabled();   // gated: emit the %fs swap stubs so HLE handlers run on the host TCB
+#endif
     if (swap && stub_size < 96) return fail("stub_size too small for guest-%fs swap stub (need >= 96)");
     uint8_t* base = (uint8_t*)got;
     for (uint64_t i = 0; i < n; i++) {
@@ -2101,6 +2218,14 @@ static void dump_fault_bytes(uint64_t start, int n) {
 }
 
 size_t run_guest_inits(const std::vector<uint64_t>& fns) {
+#ifdef __APPLE__
+    // macOS only: the module .init_array ctors touch guest %fs TLS and run on this (main) thread BEFORE
+    // run_entry, so activate the guest TCB now to give the %fs emulator its per-thread guest_TP
+    // (idempotent — run_entry's later call reuses the same TP). On Linux the inits run under the host
+    // glibc %fs (a valid TCB) and activation stays in run_entry, so this is deliberately NOT done there
+    // to avoid perturbing the tuned Messenger/PROSPER_GUEST_FS boot ordering.
+    guest_tls_activate_thread();
+#endif
     size_t ok = 0;
     for (uint64_t f : fns) {
         g_trap_kind = 0; g_armed_tid = cur_tid();

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -43,14 +43,13 @@ static constexpr uint32_t TCB_MAGIC       = 0x50524F53u;  // "PROS" — marks OU
 void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
     g_enabled = getenv("PROSPER_GUEST_FS") != nullptr;
 #ifdef __APPLE__
-    // Rosetta 2 does not implement rdfsbase/wrfsbase (verified: SIGILL on an M2, macOS 26) and
-    // Darwin has no fsbase API, so guest initial-exec %fs TLS cannot be enabled on this host yet.
-    // The default (host-%fs-aliasing) boot path is unaffected. See docs/PORTING.md.
-    if (g_enabled) {
-        fprintf(stderr, "[guest-tls] PROSPER_GUEST_FS is not supported on macOS (Rosetta lacks "
-                        "wrfsbase); continuing with it DISABLED\n");
-        g_enabled = false;
-    }
+    // Rosetta 2 does not implement rdfsbase/wrfsbase (verified: SIGILL on an M2) and Darwin has no
+    // fsbase API, so we cannot give the CPU a real guest %fs base. Instead run in TRAP mode: build
+    // the guest TCB, leave the hardware fs base at Rosetta's 0, and emulate each `%fs:`-prefixed
+    // access in the SIGSEGV handler (the fault address is exactly the guest's offset, since base==0,
+    // so the real target is guest_TP + fault_addr). Enabled by the same PROSPER_GUEST_FS gate.
+    // See exec_image_linux.cpp try_emulate_fs_access and docs/PORTING.md "macOS harness app".
+    if (g_enabled) fprintf(stderr, "[guest-tls] macOS TRAP mode: %%fs accesses emulated (no wrfsbase)\n");
 #endif
     g_mods.assign(descs, descs + count);
     // x86-64 Variant II static-TLS layout (glibc _dl_determine_tlsoffset, TLS_TCB_AT_TP): each
@@ -84,6 +83,33 @@ bool guest_tls_enabled() { return g_enabled && g_configured; }
 // Allocate + initialize this thread's guest TLS block and switch %fs to the guest TP. Returns the guest
 // TP (fs base), or 0 if disabled. Idempotent-ish: always makes a fresh block (called once per guest thread
 // at its entry). The block is intentionally leaked for the thread's lifetime (freed by process exit).
+#ifdef __APPLE__
+// The current thread's guest thread-pointer (0 if this isn't a guest thread / trap mode off). Lives
+// in host TLS (%gs on Darwin — host libc's own TLS, untouched by the guest %fs emulation), so the
+// SIGSEGV handler can read it to relocate a faulting `%fs:` access to guest_TP + offset.
+static thread_local uint64_t t_guest_tp = 0;
+uint64_t guest_tls_tp() { return t_guest_tp; }
+
+uint64_t guest_tls_activate_thread() {
+    if (!guest_tls_enabled()) return 0;
+    if (t_guest_tp) return t_guest_tp;   // idempotent: one TCB per thread, shared across inits + entry
+    size_t total = (size_t)g_total_below + TCB_SIZE;
+    uint8_t* block = (uint8_t*)mmap(nullptr, total, PROT_READ | PROT_WRITE,
+                                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (block == MAP_FAILED) return 0;
+    memset(block, 0, total);
+    uint64_t tp = (uint64_t)block + g_total_below;
+    for (size_t i = 1; i < g_mods.size(); i++)
+        if (g_mods[i].filesz && g_mods[i].init_va)
+            memcpy((void*)(tp - g_below[i]), (const void*)(uintptr_t)g_mods[i].init_va, g_mods[i].filesz);
+    *(uint64_t*)(tp + 0)         = tp;          // TCB self-pointer (the `mov %fs:0x0,rax` idiom)
+    *(uint32_t*)(tp + MAGIC_OFF) = TCB_MAGIC;   // marks OUR guest TCB
+    // No host-canary copy: Darwin's host canary is %gs-relative, and the guest seeds its own
+    // %fs:0x28 canary during crt init. HOSTFS_OFF is unused in trap mode (no per-call swap).
+    t_guest_tp = tp;
+    return tp;   // NB: hardware fs base stays 0; accesses are trapped+emulated (try_emulate_fs_access)
+}
+#else
 uint64_t guest_tls_activate_thread() {
     if (!guest_tls_enabled()) return 0;
     uint64_t host_fs = rd_fsbase();
@@ -113,6 +139,7 @@ uint64_t guest_tls_activate_thread() {
     wr_fsbase(tp);
     return tp;
 }
+#endif  // __APPLE__ (trap-mode activation) vs else (wrfsbase activation)
 
 // Called at the entry of the CRASH signal handler (fault_handler). If the faulting thread is running on
 // OUR guest %fs, switch to the stashed host %fs so the handler's host-libc calls (snprintf/write) and any

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -756,6 +756,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkPipelineVertexInputStateCreateInfo vin{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
         VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
         ia.topology = ps ? (VkPrimitiveTopology)ps->topology : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+#ifdef __APPLE__
+        // Metal always has primitive restart enabled and MoltenVK rejects primitiveRestartEnable=VK_FALSE
+        // with VK_ERROR_FEATURE_NOT_PRESENT. Force it on; harmless here because these draws don't use the
+        // strip-restart sentinel index (0xFFFF/0xFFFFFFFF), and it has no effect on list topologies.
+        ia.primitiveRestartEnable = VK_TRUE;
+#endif
         // Default: full-target viewport. When the resolved state carries the guest's PA_CL_VPORT transform,
         // honor it — a guest yscale < 0 arrives as a negative viewport_h (Vulkan core-1.1 flipped viewport),
         // reproducing the hardware's Y orientation (#38; each draw item keeps its own resolved viewport).


### PR DESCRIPTION
Solves the macOS "gameplay frontier": guest initial-exec `%fs` TLS, which had been blocking every macOS boot a few frames into libc init.

## The problem

Rosetta rejects `wrfsbase`/`rdfsbase` (SIGILL) and Darwin's `%fs` base is 0 (macOS uses `%gs`), so — unlike Linux (`wrfsbase`) and Windows (FSGSBASE + VEH re-apply) — we can't give the CPU a real guest fs base.

## The solution: trap-and-emulate

A spike settled it: under Rosetta a guest `%fs:disp` access faults at linear address **== the raw offset** (fs base is 0), so the real target is just `guest_TP + fault_addr` — no addressing-mode decode needed.

- **`guest_tls.cpp`** macOS TRAP mode (same `PROSPER_GUEST_FS` gate): build the per-thread Variant-II guest TCB, store its thread pointer in host (`%gs`) TLS, leave the CPU fs base at 0. Idempotent so `.init_array` + entry share one TP.
- **`exec_image_linux.cpp` `try_emulate_fs_access`:** in the SIGSEGV/SIGBUS handler, redirect an `%fs`-prefixed access to `guest_TP + fault_addr` and emulate it (mov family: load/store all sizes, movzx/movsx, imm store), advance RIP, resume. Unknown forms log + fall through (none seen). The Linux `%fs` swap stubs are disabled on macOS (they use `wrfsbase`); handlers run on host `%gs` TLS so no per-call swap is needed.
- **`render_runner.h`:** force `primitiveRestartEnable=VK_TRUE` on Apple (Metal can't disable it; MoltenVK rejected `VK_FALSE`).

## Result (Apple M2)

Blasphemous 2 boots from the old libc-init death **into Unity's PS5 GPU device init** (`GfxDevicePS5SharedData::CreateWorkload`), AGC command submission, and ~500 StreamingAssets bundles — **180k+ `%fs` accesses emulated, 0 unhandled forms**. `prosper-app`'s window comes up and the live renderer starts creating real pipelines from the guest's draws.

## Remaining to on-screen gameplay (follow-on frontiers, filed separately)

- MoltenVK **vertex-shader MSL compilation** gap (`Vertex shader function could not be compiled into pipeline`) — SPIR-V→Metal fidelity, same class as #686.
- A guest **worker-thread fault** (`ret` to `0x0`) during asset load — a separate HLE issue.

## Safety

All new code is `#ifdef __APPLE__`; Linux and Windows paths are unchanged (the Linux `PROSPER_GUEST_FS` boot ordering is deliberately preserved). macOS ctest 92/93 — the one failure is the pre-existing MoltenVK `v_cvt_i32_f32` gap (#686), not a regression. CI verifies Linux/Windows/macOS.