### PR TITLE
docs(gpu): tag blend-factor decode (#320)

### DIFF
--- a/prosper/src/gpu/vk_translate.cpp
+++ b/prosper/src/gpu/vk_translate.cpp
@@ -146,6 +146,11 @@ VkFormat vk_color_format(uint32_t format, uint32_t number_type, uint32_t comp_sw
 
 uint32_t vk_blend_factor(uint32_t f) {
     // RDNA2 blend factor -> VkBlendFactor value (Kyty GraphicsRender.cpp).
+    // CONFIDENCE: HIGH — cross-checked against SharpEmu @ 85cc2b9
+    // (src/SharpEmu.Libs/VideoOut/VulkanVideoPresenter.cs ToVkBlendFactor + AgcExports.cs
+    // CB_BLEND0_CONTROL 0x1E0 decode): same register/bit-fields (COLOR_SRCBLEND[4:0],
+    // COLOR_DESTBLEND[12:8], COLOR_COMB_FCN[7:5], ENABLE[30]) and same enum (4->SrcAlpha,
+    // 5->OneMinusSrcAlpha). The two emulators decode blend identically.
     switch (f) {
         case 0x00: return 0;   // Zero              -> ZERO
         case 0x01: return 1;   // One               -> ONE


### PR DESCRIPTION
While localizing the PPSA02664 black gameplay scene (#320), the scene's sprite draws use `SRC_ALPHA`/`ONE_MINUS_SRC_ALPHA` blend with vertex-color alpha=0, so I needed to rule out a blend-factor **decode** error before concluding the alpha-0 is genuine.

Verified prosper's `vk_blend_factor` against **SharpEmu @ `85cc2b9`** (latest):
- Same register: `CB_BLEND0_CONTROL` (0x1E0).
- Same bit-fields: `COLOR_SRCBLEND[4:0]`, `COLOR_DESTBLEND[12:8]`, `COLOR_COMB_FCN[7:5]`, `ENABLE[30]`, separate-alpha `[16:20]/[24:28]/[21:23]/[29]`.
- Same enum mapping: `4→SrcAlpha`, `5→OneMinusSrcAlpha`, … (SharpEmu `ToVkBlendFactor`).

The two emulators decode blend **identically**. This PR only adds a `CONFIDENCE: HIGH` comment recording that cross-check at `vk_blend_factor`, so blend decode is not re-investigated. No behavior change.

Refs #320.