### PR TITLE
feat(win): add one-command native frontend launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Windows/MinGW now boots and renders the primary title through the same live Vulk
 current build, run, screenshot, and diagnostic recipe is maintained in
 [`prosper/docs/WINDOWS_PORT_HANDOFF.md`](prosper/docs/WINDOWS_PORT_HANDOFF.md).
 
+On Windows, the full graphics + WASAPI audio + controller/keyboard frontend is one command:
+
+```powershell
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+```
+
 ## Repository layout
 
 ```

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -122,6 +122,13 @@ g++ -O2 -std=c++20 tools/self_dump/self_dump.cpp -o self_dump
 ./self_dump ../PPSA24651-app0/eboot.bin [--symbols]
 ```
 
+From the parent repository root, native Windows builds and runs the full graphics + WASAPI audio +
+controller/keyboard frontend with:
+
+```powershell
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+```
+
 ## Legal / scope
 Interoperability & preservation research on legally-owned titles. `prosper` ships **no** Sony code,
 firmware, or keys — it reimplements published library interfaces clean-room style. It only operates on

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -71,17 +71,19 @@ hands out those **CPU pixels**. The frontend polls `present_count()` for a new f
 readback into its swapchain. This is the whole video boundary — the frontend is a pure *consumer* of
 finished frames.
 
-### 4. Lifecycle — run/stop (the ONE new core hook)
-Today `boot_trace` runs the guest to a fixed frame budget. An app needs the guest loop to live with
-the window. Add a minimal, headless-agnostic control:
+### 4. Lifecycle — stop request exists; guest consumption remains
+The frontend has the minimal, headless-agnostic control:
 ```cpp
 // in the run harness / a small host lifecycle header
 void prosper_request_stop();     // idempotent; sets a flag the guest run-loop checks
 bool prosper_stop_requested();
 ```
-`boot_trace` keeps its fixed-budget behavior for CI; the frontend calls `prosper_request_stop()` on
-window close, and the run-loop (guest driver) exits, threads join, teardown runs. **This is the only
-change inside the core-adjacent code, and it touches the run harness — coordinate (see Risks).**
+`boot_trace` keeps its fixed-budget behavior for CI and the frontend calls `prosper_request_stop()`
+on window close. `run_entry` does not consume the flag yet, so the current app cannot safely join a
+booted guest. It flushes logs and calls `std::_Exit` instead; returning from `main` after detaching the
+guest caused a reproducible Windows access violation when static teardown raced live guest threads.
+The remaining lifecycle work is a guest flip-boundary check followed by a real join and normal
+teardown (#352).
 
 ## The Vulkan-context decision: two contexts, frames cross as CPU pixels
 
@@ -114,7 +116,8 @@ frame: SDL_PollEvent → on SDL_QUIT / window-close: prosper_request_stop(); bre
            upload staging → VkImage; blit/scale VkImage → acquired swapchain image; vkQueuePresentKHR;
        else: small sleep / wait on a frame condvar to avoid spinning.
 
-quit:  prosper_request_stop(); join guest thread; destroy swapchain/device/window; SDL_Quit().
+quit target: prosper_request_stop(); join guest thread; destroy swapchain/device/window; SDL_Quit().
+quit today:  prosper_request_stop(); flush logs; direct process exit while the guest is still live.
 ```
 Handle swapchain resize (`present_width/height` change or window resize → recreate). Vsync via
 `VK_PRESENT_MODE_FIFO`.
@@ -127,9 +130,9 @@ Handle swapchain resize (`present_width/height` change or window resize → recr
 - Audio/pad callbacks run on whatever thread the core calls them from; the SDL sink/backend must be
   thread-safe (the pad header already requires it).
 
-Shutdown ordering: `request_stop` → guest thread observes the flag at its loop boundary and returns →
-join → tear down GPU/window. No teardown races because the frontend owns the window/device and only
-destroys them after the guest thread has joined.
+Target shutdown ordering: `request_stop` → guest thread observes the flag at its loop boundary and
+returns → join → tear down GPU/window. Until that check exists, direct process exit deliberately
+skips frontend/HLE static teardown so it cannot race the detached guest.
 
 ## Target / build layout
 
@@ -144,7 +147,13 @@ destroys them after the guest thread has joined.
 
 For native Windows, configure MinGW with `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON
 -DPROSPER_PAD_SDL3=ON`, build `prosper-app.exe`, and verify the window/swapchain first with
-`--test-pattern --frames 120`. The complete PowerShell recipe is in `WINDOWS_PORT_HANDOFF.md`.
+`--test-pattern --frames 120`. `scripts/run-windows.ps1` performs that full configure/build/run path:
+
+```powershell
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+```
+
+The complete manual PowerShell recipe is in `WINDOWS_PORT_HANDOFF.md`.
 
 WSLg remains a useful alternate path for running the Linux build:
 
@@ -195,19 +204,19 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
   shows the composited game (verified `--dump … --frames 3`).
 - **P1 — audio** ✅ **done**: `prosper-app` installs the SDL3 `AudioSink` (`sceAudioOut` → host).
 - **P2 — controllers** ✅ **done**: installs the SDL3 `PadBackend` (host gamepad → `libScePad`).
-- **P3 — polish** (in progress): resize/fullscreen, pause/quit UX, present-mode/latency tuning,
-  packaging (WSLg launcher). Cooperative guest-stop at a flip boundary is a follow-up (today the
+- **P3 — polish** (in progress): resize/fullscreen, pause/quit UX, and present-mode/latency tuning.
+  Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
+  at a flip boundary is a follow-up (today the
   guest thread is detached at window-close and reclaimed by process exit).
-- **P1 — audio**: land the SDL3 `AudioSink` (from `feat/audio-sdl3`). Result: sound.
-- **P2 — controllers**: SDL3 `GameController` `PadBackend`. Result: play it.
-- **P3 — polish**: resize, fullscreen, pause/quit UX, present-mode/latency tuning, packaging.
 
 ## Risks & open questions
 
-- **Vulkan-in-WSL ICD** — the single external unknown; verify with `vulkaninfo` before P0.
+- **Vulkan availability** — native Windows needs the Vulkan SDK at build time and a working host
+  driver at runtime. WSLg additionally needs a usable WSL Vulkan ICD.
 - **The run/stop hook touches the run harness** (`boot_trace`/how the guest loop is driven), which the
   render-frontier and audio workstreams also use — coordinate; keep the fixed-budget CI path intact.
 - **`feat/audio-sdl3` overlap** — P1 must build on that branch, not fork it.
-- **Present latency/vsync** under WSLg is decent, not native — acceptable for a smoke/dev view.
+- **Present latency/vsync** is intentionally FIFO today; low-latency present-mode selection remains
+  P3 work.
 - **Later zero-copy** (`external_memory`) is deliberately deferred; the readback seam is the v1 answer.
 - **area:** shared/host infrastructure — needs an `area:` decision and coordination before build.

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -99,6 +99,17 @@ solved fence investigation when diagnosing a later Windows failure.
 
 ## Full frontend build and validation (native Windows, MinGW)
 
+The normal interactive path is now one command from the repository root. It configures the full
+SDL3 video/audio/controller build when needed and then launches the title in the native window:
+
+```powershell
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+```
+
+Use `-TestPattern -Frames 120` for a no-game swapchain smoke, or `-NoBuild` after the first build.
+The explicit commands below remain the diagnostic recipe when compiler or CMake configuration needs
+to be controlled directly.
+
 Required tools are WinLibs MinGW-w64 UCRT `gcc/g++.exe`, Ninja, CMake, and a Vulkan SDK with
 `VULKAN_SDK` set. Configure the window, SDL3 audio/controller, live renderer, and screenshot tool
 directly from PowerShell:

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -4,7 +4,8 @@ The OS-integration frontend: an SDL3 window + Vulkan swapchain that runs a PS5 t
 rendering, audio out, and controller in. See `prosper/docs/FRONTEND_APP.md` for the design and issue
 #164 for the plan.
 
-**Status:** boots and displays the game, with audio and controllers. `--dump <app0>` boots a title
+**Status:** boots and displays the game natively on Linux, Windows, and macOS, with audio and
+controllers. `--dump <app0>` boots a title
 via the shared `boot_program()` path, composites its GPU submits with the shared live renderer, and
 presents them to the window; `sceAudioOut` is routed to the host and a host gamepad drives
 `libScePad`. `--test-pattern` verifies the window + swapchain without a dump.
@@ -21,9 +22,22 @@ cmake --build build-app -j8 --target prosper-app
 
 (`-DPROSPER_APP=ON` alone builds a video-only app — no audio/controllers.)
 
-On Windows this builds/runs under WSL2; the window appears on the Windows desktop via WSLg, audio via
-WSLg's PulseAudio. A real GPU needs your vendor's WSL Vulkan driver (else it falls back to the
-`llvmpipe` software rasterizer — correct but slow). Confirm your device with `vulkaninfo`.
+### Native Windows
+
+From the repository root, the launcher configures a MinGW/Ninja build with video, WASAPI audio, and
+SDL3 controller support, then starts the supplied title:
+
+```powershell
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+```
+
+It reuses `prosper/build-mingw-app` on later runs. Use `-NoBuild` to skip the configure/build check,
+`-TestPattern -Frames 120` to smoke-test the real window and Vulkan swapchain without a game, and
+`-GuestArgs ''` when a title must not receive Unity's `-force-gfx-direct` argument. A Vulkan SDK,
+CMake, Ninja, and MinGW-w64 UCRT are required; the launcher discovers the standard winget WinLibs
+installation automatically.
+
+WSLg remains an alternate way to run the Linux build, but it is no longer the primary Windows path.
 
 ## Run
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -4,8 +4,9 @@
 //
 // P0a scope (this file): the whole present half, decoupled from the guest boot. It pulls finished
 // frames from prosper_core's present layer (present_readback) and blits them to a real swapchain,
-// and closes on SDL_QUIT/Esc via the cooperative stop signal (prosper_request_stop). To verify the
-// pipeline without a game dump it can also FEED the present layer a synthetic animated pattern
+// and handles SDL_QUIT/Esc via the shared stop request. run_entry does not consume that request yet,
+// so a booted guest uses direct process exit after the present loop (issue #352). To verify the
+// pipeline without a game dump the app can FEED the present layer a synthetic animated pattern
 // (--test-pattern): frame -> present_write_frame -> present_readback -> swapchain, exactly the path
 // a real guest frame takes. P0b wires the actual guest boot in front of this (the same present
 // path, no changes here).
@@ -502,10 +503,20 @@ int main(int argc, char** argv) {
 
     prosper_request_stop();   // signal the guest run-loop to wind down at its next boundary
     fprintf(stderr, "[app] shutting down after %llu presented frame(s)\n", (unsigned long long)shown);
+    const int exitCode = (exitAfter && (int)shown < exitAfter) ? 1 : 0;
+
+    // run_entry does not yet observe the frontend stop flag, so a booted guest cannot be joined.
+    // Returning from main after detaching it is unsafe: C++ static teardown destroys HLE/renderer
+    // state while guest threads still use it (a short --frames run reliably ended in 0xC0000005 on
+    // Windows). Until the flip-boundary cooperative stop is implemented, terminate directly and
+    // let the OS reclaim process state without running destructors under the live guest.
+    if (guestThread.joinable()) {
+        guestThread.detach();
+        fflush(nullptr);
+        std::_Exit(exitCode);
+    }
+
     vkDeviceWaitIdle(vk.device);
-    // The guest runs guest code with no cooperative yield point yet (a flip-boundary stop check is a
-    // refinement), so we detach and let process exit reclaim it rather than block on a join.
-    if (guestThread.joinable()) guestThread.detach();
     SDL_DestroyWindow(win); SDL_Quit();
-    return (exitAfter && (int)shown < exitAfter) ? 1 : 0;
+    return exitCode;
 }

--- a/prosper/scripts/run-windows.ps1
+++ b/prosper/scripts/run-windows.ps1
@@ -1,0 +1,115 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Dump,
+
+    [string]$BuildDir,
+    [string]$GuestArgs = '-force-gfx-direct',
+    [string]$SavedataDir,
+    [string]$Record,
+    [int]$Frames = 0,
+    [int]$Jobs = 8,
+    [switch]$TestPattern,
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Checked {
+    param([string]$Program, [string[]]$Arguments)
+    & $Program @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE`: $Program $($Arguments -join ' ')"
+    }
+}
+
+function Find-WinLibsTool {
+    param([string]$Name)
+
+    $onPath = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($onPath) { return $onPath.Source }
+
+    $candidates = @()
+    if ($env:LOCALAPPDATA) {
+        $wingetRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+        if (Test-Path -LiteralPath $wingetRoot) {
+            $packages = Get-ChildItem -LiteralPath $wingetRoot -Directory -Filter 'BrechtSanders.WinLibs*' |
+                Sort-Object LastWriteTime -Descending
+            foreach ($package in $packages) {
+                $candidates += Join-Path $package.FullName "mingw64\bin\$Name"
+            }
+        }
+    }
+    $candidates += "C:\msys64\ucrt64\bin\$Name"
+    $candidates += "C:\msys64\mingw64\bin\$Name"
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate) { return $candidate }
+    }
+    return $null
+}
+
+if (-not $IsWindows -and $PSVersionTable.PSEdition -eq 'Core') {
+    throw 'run-windows.ps1 must be run from native Windows PowerShell, not WSL/Linux.'
+}
+
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$sourceDir = Join-Path $repoRoot 'prosper'
+if (-not $BuildDir) { $BuildDir = Join-Path $sourceDir 'build-mingw-app' }
+$BuildDir = [IO.Path]::GetFullPath($BuildDir)
+
+if (-not $TestPattern) {
+    if (-not $Dump) { throw 'Pass an app0 dump directory, or use -TestPattern.' }
+    $Dump = (Resolve-Path -LiteralPath $Dump).Path
+    if (-not (Test-Path -LiteralPath $Dump -PathType Container)) {
+        throw "Dump is not a directory: $Dump"
+    }
+}
+
+$cmake = (Get-Command cmake -ErrorAction Stop).Source
+$cache = Join-Path $BuildDir 'CMakeCache.txt'
+$app = Join-Path $BuildDir 'prosper-app.exe'
+
+if (-not $NoBuild) {
+    $configure = @(
+        '-S', $sourceDir,
+        '-B', $BuildDir,
+        '-G', 'Ninja',
+        '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
+        '-DPROSPER_APP=ON',
+        '-DPROSPER_AUDIO_SDL3=ON',
+        '-DPROSPER_PAD_SDL3=ON'
+    )
+    if (-not (Test-Path -LiteralPath $cache)) {
+        $cxx = Find-WinLibsTool 'g++.exe'
+        $cc = if ($cxx) { Join-Path (Split-Path -Parent $cxx) 'gcc.exe' } else { $null }
+        if (-not $cxx -or -not (Test-Path -LiteralPath $cc)) {
+            throw 'MinGW-w64 UCRT gcc/g++ were not found. Install WinLibs with winget, or add its mingw64\bin directory to PATH.'
+        }
+        $configure += "-DCMAKE_C_COMPILER=$cc"
+        $configure += "-DCMAKE_CXX_COMPILER=$cxx"
+    }
+    Invoke-Checked $cmake $configure
+    Invoke-Checked $cmake @('--build', $BuildDir, '--target', 'prosper-app', '--parallel', "$Jobs")
+}
+
+if (-not (Test-Path -LiteralPath $app -PathType Leaf)) {
+    throw "prosper-app.exe was not built at $app. Check the Vulkan SDK and rerun without -NoBuild."
+}
+
+$runArgs = @()
+if ($TestPattern) {
+    $runArgs += '--test-pattern'
+} else {
+    $env:PROSPER_GUEST_FS = '1'
+    $env:PROSPER_GUEST_ARGS = $GuestArgs
+    if ($SavedataDir) { $env:PROSPER_SAVEDATA_DIR = [IO.Path]::GetFullPath($SavedataDir) }
+    $runArgs += @('--dump', $Dump)
+}
+if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
+if ($Record) { $runArgs += @('--record', [IO.Path]::GetFullPath($Record)) }
+
+Write-Host "Starting $app"
+& $app @runArgs
+if ($LASTEXITCODE -ne 0) { throw "prosper-app exited with code $LASTEXITCODE" }
+


### PR DESCRIPTION
## Summary

- add a one-command native PowerShell launcher for the full Vulkan + WASAPI + SDL3 gamepad/keyboard frontend
- support build reuse, test-pattern smoke, frame-limited runs, guest args, save roots, and input recording
- avoid C++ static teardown while detached guest threads are still live
- replace stale WSLg-primary instructions across the frontend and Windows docs

## Validation

- fresh native MinGW configure/build of `prosper-app` with all SDL3 backends
- test pattern: 5 frames on NVIDIA RTX 4090, exit 0
- Messenger: live renderer + audio + pad + keyboard + dialogs, 3 guest frames, exit 0
- Windows MinGW ctest: 67/67

Refs #352