### PR TITLE
gpu(recompiler): materialize small u64 constants via OpUConvert (MoltenVK vertex-shader fix, #693)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -238,7 +238,18 @@ struct SpirvCompute {
                        t_u64_cache = id(); put(types, Op_TypeInt, {t_u64_cache, 64, 0}); } return t_u64_cache; }
     // A 64-bit uint constant needs two value words. Shift amounts MUST be u64 here: a u32 shift operand on
     // a u64 base is mishandled by some drivers (llvmpipe), silently dropping the high half.
-    uint32_t uconst64(uint64_t v) { uint32_t c = id(); put(types, Op_Constant, {t_u64(), c, (uint32_t)v, (uint32_t)(v >> 32)}); return c; }
+    uint32_t uconst64(uint64_t v) {
+        // For values that fit in 32 bits (all current uses are shift amounts of 32), materialize the
+        // u64 by widening a 32-bit constant in the body rather than emitting a 2-word 64-bit OpConstant
+        // literal. Two reasons, both satisfied by this form: (1) MoltenVK's bundled SPIRV-Cross
+        // mis-parses 64-bit OpConstant literals (reads the high value word as a zero Id -> "Cannot
+        // resolve expression type", failing the whole shader) — a u32->u64 OpUConvert has no 2-word
+        // literal; (2) the result is still u64-typed, so llvmpipe's requirement that a u64 shift amount
+        // be u64 (a u32 shift operand drops the high half there) is preserved. Semantically identical on
+        // every driver. A genuine >32-bit constant still needs the 2-word form (not currently emitted).
+        if (v <= 0xffffffffull) { uint32_t r = id(); put(code, Op_UConvert, {t_u64(), r, uconst((uint32_t)v)}); return r; }
+        uint32_t c = id(); put(types, Op_Constant, {t_u64(), c, (uint32_t)v, (uint32_t)(v >> 32)}); return c;
+    }
     uint32_t u64_from_lohi(uint32_t lo, uint32_t hi) {   // (u64)hi<<32 | (u64)lo  — combine an SGPR pair
         uint32_t l = id(); put(code, Op_UConvert, {t_u64(), l, lo});
         uint32_t h = id(); put(code, Op_UConvert, {t_u64(), h, hi});


### PR DESCRIPTION
Partially fixes #693 (macOS/MoltenVK vertex shaders failing MSL compilation) — the primary blocker.

## Root cause

The recompiler's `uconst64()` emitted 64-bit constants as a 2-word `OpConstant` literal. MoltenVK's *bundled* SPIRV-Cross mis-parses those — it reads the high value word as a zero Id (`SPIR-V error … Id is 0` → `Cannot resolve expression type`) and fails the whole shader. I confirmed the SPIR-V is valid (`spirv-val` passes) and that the *current* standalone SPIRV-Cross converts it fine, so this is a bug in the older SPIRV-Cross inside MoltenVK, not our SPIR-V.

Every guest shader using a u64 constant hit this — the vertex-fetch V# descriptor decode (shift-by-32 in `u64_from_lohi`/`bfe_u64`/`u64_hi`), which is most vertex shaders.

## Fix

All current callers pass small values (32), so materialize the u64 by widening a 32-bit constant with `OpUConvert` instead of a 2-word literal. The result stays u64-typed, so llvmpipe's requirement that a u64 shift amount be u64 is preserved (a u32 operand drops the high half there). Semantically identical on every driver; a genuine >32-bit constant still uses the 2-word form (not currently emitted).

## Effect

On macOS/MoltenVK, shaders that failed on the 64-bit-constant parse bug now compile, and Blasphemous 2 renders in `prosper-app` at ~30 fps (before, the vertex shader failed hard and nothing rendered).

## Residual (keeps #693 open)

One int64-*arithmetic*-heavy shader (appears later in the boot) still trips the same old SPIRV-Cross on the int64 ops themselves, even without the 64-bit constant. The complete fix needs a newer SPIRV-Cross in MoltenVK (the current standalone handles it) or a recompiler int64→uvec2 lowering. Documented on #693.

## Safety

Cross-platform: rendered output is pixel-identical (only the constant's encoding changes), so Linux golden guards are unaffected. macOS ctest 92/93 (the one failure is the pre-existing MoltenVK `v_cvt_i32_f32` gap #686). CI covers Linux/Windows.