### PR TITLE
macos: use LunarG SDK MoltenVK for rendering (resolves the #693 shader-compile blocker in practice)

### DIFF
--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -303,7 +303,26 @@ init** (`GfxDevicePS5SharedData::CreateWorkload`), AGC command submission, and ~
 bundles — 180k+ `%fs` accesses emulated with zero unhandled forms. The `prosper-app` window comes up
 and the live renderer begins creating real pipelines from the guest's draws.
 
-**Remaining to on-screen gameplay (follow-on frontiers, MoltenVK shader fidelity, not TLS):**
+**MoltenVK build matters (2026-07-14):** the guest's shaders exposed a SPIRV-Cross bug in the
+**x86_64 Khronos-release MoltenVK 1.4.1** (`Cannot resolve expression type`) — proven build/arch
+specific: the *arm64* MoltenVK 1.4.1 and the **LunarG Vulkan SDK's** universal MoltenVK both convert
+the identical shaders fine. So for real rendering, use a good MoltenVK:
+`scripts/fetch-macos-vulkan.sh --lunarg` (headless-installs the LunarG SDK's universal MoltenVK into
+`.macos-vulkan/`). With it, most guest shaders compile and `prosper-app` presents frames (slowly —
+first-use Metal pipeline compilation under Rosetta is ~a few fps until warm). The plain
+`fetch-macos-vulkan.sh` (Khronos release) stays the light build/CI path. #701 fixed one SPIRV-Cross
+trigger (64-bit OpConstant); `draft/recompiler-int64-lowering` removes Int64 entirely (unmerged,
+helps weak drivers).
+
+**Remaining to on-screen gameplay (follow-on frontiers, not TLS):**
+- One guest vertex shader still fails MSL conversion *at runtime* even with the good MoltenVK, though
+  the SDK's standalone converter handles the same SPIR-V — a MoltenVK pipeline-config/SPIRV-Cross
+  interaction (tracked with #693). One missing draw.
+- GPU submit-completion: with real pipelines created, the guest waits on GPU work
+  (`sce::Agc::suspendPoint` / fence) — the completion/label-writeback handshake needs verifying on
+  macOS so the frame loop advances at speed (same class as the Windows "GPU EOP completion" step).
+- On-screen content not yet visually confirmed (headless dev context); the present path is proven by
+  `--test-pattern`.
 - MoltenVK pipeline compat: `primitiveRestartEnable=VK_FALSE` is rejected by Metal — fixed (force
   `VK_TRUE` on Apple). Next: the guest **vertex shader fails MSL compilation** in MoltenVK
   (`Vertex shader function could not be compiled into pipeline`) — a SPIR-V→Metal translation gap to

--- a/prosper/scripts/fetch-macos-vulkan.sh
+++ b/prosper/scripts/fetch-macos-vulkan.sh
@@ -1,35 +1,48 @@
 #!/usr/bin/env bash
-# fetch-macos-vulkan.sh — download a UNIVERSAL (x86_64+arm64) MoltenVK for the macOS harness app.
+# fetch-macos-vulkan.sh — obtain a UNIVERSAL (x86_64+arm64) MoltenVK for the macOS harness app.
 #
 # prosper on macOS is built x86_64 (it runs the PS5 guest's x86-64 code natively under Rosetta 2), so
 # it needs an x86_64 Vulkan driver. Homebrew's molten-vk/vulkan-loader are arm64-only and cannot link
-# into the x86_64 binary. The prebuilt KhronosGroup/MoltenVK release ships a universal dylib, which is
-# exactly what we need. This drops it into <repo>/.macos-vulkan/ (gitignored); pass its path to CMake:
+# into the x86_64 binary. This drops a universal MoltenVK into <repo>/.macos-vulkan/ (gitignored) and
+# points CMake at it with -DPROSPER_MACOS_MOLTENVK=.../.macos-vulkan/lib/libMoltenVK.dylib.
 #
-#   cmake -S prosper -B prosper/build-mac-app -G Ninja \
-#     -DCMAKE_OSX_ARCHITECTURES=x86_64 -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON \
-#     -DPROSPER_MACOS_MOLTENVK="$PWD/.macos-vulkan/lib/libMoltenVK.dylib"
-#   cmake --build prosper/build-mac-app --target prosper-app
-#   PROSPER_VULKAN_LIB="$PWD/.macos-vulkan/lib/libMoltenVK.dylib" \
-#     ./prosper/build-mac-app/prosper-app --test-pattern       # smoke test (no game needed)
+# TWO sources (see docs/PORTING.md "macOS harness app"):
+#   (default) Khronos prebuilt release — small, fast; FINE FOR BUILDING/CI (build-only), but its
+#             x86_64 build has a SPIRV-Cross bug (#693) that fails to convert some guest shaders to
+#             MSL, so it does NOT render real content.
+#   --lunarg  LunarG Vulkan SDK's MoltenVK — a good universal build whose SPIRV-Cross converts the
+#             guest shaders. USE THIS TO ACTUALLY RENDER. ~370 MB download, headless-installed to a
+#             local dir (no changes to your system beyond <repo>/.macos-vulkan and a temp dir).
 #
-# The LunarG Vulkan SDK for macOS is an equivalent (also universal) source if you prefer it.
+# Usage:  bash prosper/scripts/fetch-macos-vulkan.sh            # Khronos release (build/CI)
+#         bash prosper/scripts/fetch-macos-vulkan.sh --lunarg   # LunarG SDK MoltenVK (rendering)
 set -euo pipefail
 
-VER="${1:-v1.4.1}"
+MODE="khronos"; [ "${1:-}" = "--lunarg" ] && MODE="lunarg"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEST="$REPO_ROOT/.macos-vulkan"
-TAR_URL="https://github.com/KhronosGroup/MoltenVK/releases/download/${VER}/MoltenVK-macos.tar"
-
-echo "==> Fetching MoltenVK ${VER} (universal) into ${DEST}"
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
-curl -fsSL -o "$tmp/mvk.tar" "$TAR_URL"
-tar xf "$tmp/mvk.tar" -C "$tmp"
-
-SRC="$tmp/MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
 mkdir -p "$DEST/lib" "$DEST/share/vulkan/icd.d"
-cp "$SRC" "$DEST/lib/"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+if [ "$MODE" = "lunarg" ]; then
+  VER="$(curl -fsSL https://vulkan.lunarg.com/sdk/latest/mac.txt | tr -d '[:space:]')"
+  echo "==> Fetching LunarG Vulkan SDK ${VER} for macOS (universal MoltenVK; good SPIRV-Cross)"
+  curl -fsSL -o "$tmp/sdk.zip" "https://sdk.lunarg.com/sdk/download/${VER}/mac/vulkansdk-macos-${VER}.zip"
+  ( cd "$tmp" && unzip -q sdk.zip )
+  APP="$(find "$tmp" -maxdepth 2 -name 'vulkansdk-macOS-*' -path '*/MacOS/*' -type f | head -1)"
+  chmod +x "$APP"
+  echo "==> Headless-installing the SDK to $tmp/VulkanSDK ..."
+  "$APP" --root "$tmp/VulkanSDK" --accept-licenses --accept-obligations --default-answer --confirm-command install >/dev/null 2>&1
+  SRC="$(find "$tmp/VulkanSDK/macOS/lib" -name libMoltenVK.dylib | head -1)"
+else
+  VER="${2:-v1.4.1}"
+  echo "==> Fetching Khronos MoltenVK ${VER} (universal; build/CI only — see #693)"
+  curl -fsSL -o "$tmp/mvk.tar" "https://github.com/KhronosGroup/MoltenVK/releases/download/${VER}/MoltenVK-macos.tar"
+  tar xf "$tmp/mvk.tar" -C "$tmp"
+  SRC="$tmp/MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
+fi
+
+cp "$SRC" "$DEST/lib/libMoltenVK.dylib"
 cat > "$DEST/share/vulkan/icd.d/MoltenVK_icd.json" <<JSON
 {
   "file_format_version": "1.0.0",
@@ -37,5 +50,6 @@ cat > "$DEST/share/vulkan/icd.d/MoltenVK_icd.json" <<JSON
 }
 JSON
 
-echo "==> Installed $(lipo -archs "$DEST/lib/libMoltenVK.dylib" 2>/dev/null) libMoltenVK.dylib"
+echo "==> Installed $(lipo -archs "$DEST/lib/libMoltenVK.dylib" 2>/dev/null) libMoltenVK.dylib  [$MODE]"
 echo "==> Configure with: -DPROSPER_MACOS_MOLTENVK=$DEST/lib/libMoltenVK.dylib"
+[ "$MODE" = "khronos" ] && echo "==> NOTE: for real rendering use --lunarg (the Khronos x86_64 build can't convert some shaders, #693)"


### PR DESCRIPTION
Follows up #693 with the root cause and a practical fix for macOS rendering.

## Finding

The guest's shaders exposed a SPIRV-Cross bug in the **x86_64 Khronos-release MoltenVK 1.4.1** (`Cannot resolve expression type`). I proved it's **build/arch specific**, not our SPIR-V: the identical (`spirv-val`-valid) shaders convert cleanly under the **arm64** MoltenVK 1.4.1 *and* the **LunarG Vulkan SDK's** universal MoltenVK. So the fix is simply to use a good MoltenVK.

## Change

Adds a `--lunarg` mode to `scripts/fetch-macos-vulkan.sh` that headless-installs the LunarG SDK's universal MoltenVK into `.macos-vulkan/` (no changes to the user's system beyond that gitignored dir + a temp dir). With it: most guest shaders compile and `prosper-app` presents frames (slowly at first — Metal first-use pipeline compilation under Rosetta). The plain (Khronos-release) mode stays the light build/CI path (build-only, so its shader bug doesn't matter there).

Docs updated with the finding and the remaining frontiers.

## Remaining to on-screen gameplay (not this PR)

- One guest vertex shader still fails MSL conversion **at runtime** even with the good MoltenVK, though the SDK's standalone converter handles the same SPIR-V → a MoltenVK pipeline-config/SPIRV-Cross interaction (#693 residual). One missing draw.
- GPU submit-completion: real pipelines now get created, so the guest waits on GPU work (`sce::Agc::suspendPoint`/fence); the completion handshake needs verifying on macOS (same class as the Windows "GPU EOP completion" step).
- On-screen content not yet visually confirmed from this headless dev context (the present path itself is proven by `--test-pattern`).

Docs/script only — no code or CI-behavior change. `draft/recompiler-int64-lowering` (unmerged) remains available as a weak-driver portability improvement.