### PR TITLE
perf(gpu): remove live renderer CPU bottlenecks

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -374,6 +374,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_recompile_coverage PRIVATE prosper_core)
   add_test(NAME recompile_coverage COMMAND test_recompile_coverage)
 
+  # Bounded graphics-shader cache: cached modules must match the direct recompiler byte-for-byte.
+  add_executable(test_shader_recompile_cache tests/test_shader_recompile_cache.cpp)
+  target_link_libraries(test_shader_recompile_cache PRIVATE prosper_core)
+  add_test(NAME shader_recompile_cache COMMAND test_shader_recompile_cache)
+
   # RDNA2 shader instruction-stream walker (first stage of the RDNA2->SPIR-V recompiler).
   add_executable(test_rdna2_decode tests/test_rdna2_decode.cpp)
   target_link_libraries(test_rdna2_decode PRIVATE prosper_core)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -95,11 +95,14 @@ The core keeps its existing headless render device. Frames cross the boundary as
   the renderer, no `#ifdef`, headless + CI identical.
 - The seam already emits CPU pixels, so the frontend is a pure consumer — the cleanest boundary, and
   the same seam becomes a shared-memory frame ring if the two are ever split into separate processes.
-- Cost = one readback + one upload per frame. The Messenger is 2D at 1080p (~8 MB/frame) — negligible.
+- Cost = one readback + one upload per frame. The Messenger is 2D at 1080p (~8 MB/frame), but native
+  Windows measurements showed that memory-type selection matters: uncached host-visible readback cost
+  roughly 570 ms per frame on an RTX 4090, versus about 1.8 ms with `HOST_CACHED` memory.
 
-**When to revisit:** only if a future 3D-heavy title makes the per-frame copy a real bottleneck. Then
-unify on a single frontend-provided device and share the render target via `VK_KHR_external_memory`
-(zero-copy) — but keep `present_readback` as the abstraction so headless still works. Not now.
+**When to revisit:** direct image presentation remains worthwhile after the renderer stops rebuilding
+pipelines and image/buffer objects per batch. At that point, unify on a single frontend-provided device
+or share the render target via `VK_KHR_external_memory` (zero-copy), while retaining `present_readback`
+for headless tests and screenshot tooling.
 
 ## Present loop (sketch)
 
@@ -166,15 +169,51 @@ $env:PROSPER_RENDER_TIMING = '1'
 
 The output separates guest-state realization, ordered graphics/compute execution, CPU resource
 decode/detile, Vulkan target and pipeline setup, upload/recording, GPU fence wait, readback, cleanup,
-and frontend publication. Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture
-decodes taking at least 0.5 ms (capped at 250 lines). The instrumentation does not take clock samples
-when the variable is unset. This is the first tool to use when the window presents correctly but a title
-is not interactive; do not infer a GPU bottleneck from low FPS without the stage breakdown.
+and frontend publication. Cumulative `[render-timing]` lines show the whole run; `[render-window]`
+lines show only the latest 25 submits/calls so a scene transition is immediately visible. The core
+window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
+Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture decodes taking at least
+0.5 ms (capped at 250 lines). The instrumentation does not take clock samples when the variable is
+unset. This is the first tool to use when the window presents correctly but a title is not interactive;
+do not infer a GPU bottleneck from low FPS without the stage breakdown.
+
+Transient Vulkan memory uses a bounded, exact-requirements pool because every backend call waits for its
+fence before cleanup. Timing output includes `memory_pool` hits, misses, cached allocation count/bytes,
+and budget-driven discards. The default budget is 512 MiB; override it with
+`PROSPER_MEMORY_POOL_MB=<MiB>`, or set `PROSPER_NO_MEMORY_POOL=1` for an A/B run against direct
+`vkAllocateMemory`/`vkFreeMemory`. The pool retains only allocation objects: images, buffers, views,
+descriptors, and their layout/content rules keep their existing per-call lifetimes.
+
+The persistent compute device has the same exact-requirements allocation pool with a separate 256 MiB
+default budget (`PROSPER_COMPUTE_MEMORY_POOL_MB=<MiB>`). `PROSPER_NO_MEMORY_POOL=1` disables both
+graphics and compute pools. Decoded texture scratch vectors are also retained across callbacks; they
+are storage only, and every partial decode/read explicitly clears its unwritten tail.
+
+Within one renderer callback, repeated guest-backed texture descriptions reuse the first decoded
+pixel buffer. This is intentionally callback-local because ordered compute splits graphics into new
+callbacks where guest memory may have changed. Live render-to-texture inputs are never reused through
+this map because an earlier pass can replace their pixels. The rolling frontend timing reports both
+`textures` (texture resource uses) and `reused` (decodes avoided); performed decodes are their
+difference.
+
+Graphics RDNA2-to-SPIR-V results use a process-wide bounded cache (4096 entries and 128 MiB by
+default). Its key contains the shader bytes and only the resource-table fields consumed by compilation;
+current guest addresses and backing data remain on each draw and are never cached. Use
+`PROSPER_NO_SHADER_CACHE=1` for a direct-recompiler A/B run or
+`PROSPER_SHADER_CACHE_MB=<MiB>` to change the byte budget. `test_shader_recompile_cache` compares
+every tested miss byte-for-byte with the direct recompiler and verifies that runtime-only resource
+changes hit while descriptor-interface changes miss.
+
+Do not cache `build_stage_table` results using only shader addresses and user-SGPR values. Descriptor
+tables are reached through guest pointers, and their memory can change while every pointer/register
+value remains identical. That experiment caused Messenger to remain on its initial loading screen and
+was removed after an enabled/disabled A/B test. A future table cache needs explicit guest-memory
+versioning or equivalent invalidation; the `tables=` timing bucket measures this work without caching it.
 
 The current renderer remains a deterministic readback-based implementation. It retains CPU-visible pixels
 for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702
 tracks persistent Vulkan resource/pipeline caching and direct image presentation beyond the initial
-readback-memory, detile, and compute-context fixes.
+readback-memory, detile, compute-context, transient-memory-pool, scratch-reuse, and shader-cache fixes.
 
 WSLg remains a useful alternate path for running the Linux build:
 

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -155,6 +155,27 @@ For native Windows, configure MinGW with `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=
 
 The complete manual PowerShell recipe is in `WINDOWS_PORT_HANDOFF.md`.
 
+### Live renderer performance diagnostics
+
+Set `PROSPER_RENDER_TIMING=1` before launching to print aggregate timings every 25 operations:
+
+```powershell
+$env:PROSPER_RENDER_TIMING = '1'
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0 -NoBuild
+```
+
+The output separates guest-state realization, ordered graphics/compute execution, CPU resource
+decode/detile, Vulkan target and pipeline setup, upload/recording, GPU fence wait, readback, cleanup,
+and frontend publication. Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture
+decodes taking at least 0.5 ms (capped at 250 lines). The instrumentation does not take clock samples
+when the variable is unset. This is the first tool to use when the window presents correctly but a title
+is not interactive; do not infer a GPU bottleneck from low FPS without the stage breakdown.
+
+The current renderer remains a deterministic readback-based implementation. It retains CPU-visible pixels
+for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702
+tracks persistent Vulkan resource/pipeline caching and direct image presentation beyond the initial
+readback-memory, detile, and compute-context fixes.
+
 WSLg remains a useful alternate path for running the Linux build:
 
 1. Prereq check: `vulkaninfo` in the WSL shell confirms a usable Vulkan device (vendor WSL ICD, else

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -182,7 +182,19 @@ PROSPER_GFXLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 
 Performance diagnostics: set `PROSPER_RENDER_TIMING=1` for aggregate graphics/compute stage timings, or
 `PROSPER_RENDER_TIMING=detail` to include slow individual texture decodes. The output and bucket definitions
-are documented in `FRONTEND_APP.md`.
+are documented in `FRONTEND_APP.md`; rolling `[render-window]` lines cover the latest 25 operations rather
+than averaging away the current scene. Backend output also reports transient Vulkan memory-pool statistics;
+use `PROSPER_NO_MEMORY_POOL=1` for a direct allocate/free A/B run, or `PROSPER_MEMORY_POOL_MB=<MiB>` to
+override the default 512 MiB graphics budget. Compute allocations use a separate 256 MiB default budget,
+overridable with `PROSPER_COMPUTE_MEMORY_POOL_MB=<MiB>`. Graphics shader translation is cached by shader
+bytes plus descriptor-interface semantics; `PROSPER_NO_SHADER_CACHE=1` disables it for comparison and
+`PROSPER_SHADER_CACHE_MB=<MiB>` overrides its 128 MiB budget. Timing windows report shader hits/misses and
+miss compilation time. Run `test_shader_recompile_cache` after changing the key or recompiler contract.
+Frontend windows also report texture resource uses as `textures` and callback-local duplicate decodes
+avoided as `reused`; their difference is the number of performed decodes. Do not infer descriptor-table
+identity from shader/user-SGPR values alone:
+pointed-to guest memory is mutable, and that cache experiment stalled Messenger at its loading screen.
+See `FRONTEND_APP.md` for the invalidation requirement.
 
 Diagnostics (env, all off by default): `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode + the `NOT satisfied`
 fence log), `PROSPER_EVLOG` (`[ev]` equeue/flip/EOP), `PROSPER_SYNCLOG` (`[sync]` WaitOnAddress/Wake with

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -180,6 +180,10 @@ PROSPER_GFXLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   PROSPER_FRAME_DIR=/some/dir ./boot_trace.exe /c/Users/matti/repos/ps5ys/PPSA24651-app0
 ```
 
+Performance diagnostics: set `PROSPER_RENDER_TIMING=1` for aggregate graphics/compute stage timings, or
+`PROSPER_RENDER_TIMING=detail` to include slow individual texture decodes. The output and bucket definitions
+are documented in `FRONTEND_APP.md`.
+
 Diagnostics (env, all off by default): `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode + the `NOT satisfied`
 fence log), `PROSPER_EVLOG` (`[ev]` equeue/flip/EOP), `PROSPER_SYNCLOG` (`[sync]` WaitOnAddress/Wake with
 tid + validated guest caller, `[sync2]` cond/sema/EventFlag), `PROSPER_EXCLOG` (GC exception

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -14,12 +14,64 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <functional>
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 
 namespace prosper::frontend {
 namespace {
 
 constexpr VkDeviceSize kMaxComputeImageBytes = 256ull << 20;
+
+struct ComputeMemoryKey {
+    VkDeviceSize bytes = 0;
+    uint32_t memory_type = UINT32_MAX;
+    bool operator==(const ComputeMemoryKey& other) const {
+        return bytes == other.bytes && memory_type == other.memory_type;
+    }
+};
+
+struct ComputeMemoryKeyHash {
+    size_t operator()(const ComputeMemoryKey& key) const {
+        return std::hash<uint64_t>{}(static_cast<uint64_t>(key.bytes)) ^
+               (std::hash<uint32_t>{}(key.memory_type) << 1);
+    }
+};
+
+struct ComputeMemoryPool {
+    std::mutex mutex;
+    std::unordered_map<ComputeMemoryKey, std::vector<VkDeviceMemory>, ComputeMemoryKeyHash> available;
+    std::unordered_map<VkDeviceMemory, ComputeMemoryKey> active;
+    VkDeviceSize cached_bytes = 0;
+    size_t cached_allocations = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t discarded = 0;
+};
+
+struct ComputeMemoryPoolStats {
+    VkDeviceSize cached_bytes = 0;
+    size_t cached_allocations = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t discarded = 0;
+};
+
+bool compute_memory_pool_enabled() {
+    static const bool enabled = std::getenv("PROSPER_NO_MEMORY_POOL") == nullptr;
+    return enabled;
+}
+
+VkDeviceSize compute_memory_pool_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = std::getenv("PROSPER_COMPUTE_MEMORY_POOL_MB");
+        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 256ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
 
 struct VulkanComputeContext {
     VkInstance instance = VK_NULL_HANDLE;
@@ -28,6 +80,7 @@ struct VulkanComputeContext {
     VkQueue queue = VK_NULL_HANDLE;
     uint32_t queue_family = UINT32_MAX;
     VkPhysicalDeviceMemoryProperties memory{};
+    ComputeMemoryPool memory_pool;
     // Storage-image support (#590): the recompiler's storage path declares the
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
@@ -35,8 +88,93 @@ struct VulkanComputeContext {
     bool image_support = false;
 
     ~VulkanComputeContext() {
+        release_cached_memory();
         if (device) vkDestroyDevice(device, nullptr);
         if (instance) vkDestroyInstance(instance, nullptr);
+    }
+
+    VkDeviceMemory allocate_memory(VkDeviceSize bytes, uint32_t memory_type) {
+        if (memory_type == UINT32_MAX) return VK_NULL_HANDLE;
+        const ComputeMemoryKey key{bytes, memory_type};
+        if (compute_memory_pool_enabled()) {
+            std::lock_guard<std::mutex> lock(memory_pool.mutex);
+            auto found = memory_pool.available.find(key);
+            if (found != memory_pool.available.end() && !found->second.empty()) {
+                const VkDeviceMemory allocation = found->second.back();
+                found->second.pop_back();
+                if (found->second.empty()) memory_pool.available.erase(found);
+                memory_pool.cached_bytes -= bytes;
+                --memory_pool.cached_allocations;
+                ++memory_pool.hits;
+                memory_pool.active.emplace(allocation, key);
+                return allocation;
+            }
+            ++memory_pool.misses;
+        }
+
+        VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        allocation.allocationSize = bytes;
+        allocation.memoryTypeIndex = memory_type;
+        VkDeviceMemory result = VK_NULL_HANDLE;
+        if (vkAllocateMemory(device, &allocation, nullptr, &result) != VK_SUCCESS)
+            return VK_NULL_HANDLE;
+        if (compute_memory_pool_enabled()) {
+            std::lock_guard<std::mutex> lock(memory_pool.mutex);
+            memory_pool.active.emplace(result, key);
+        }
+        return result;
+    }
+
+    void release_memory(VkDeviceMemory allocation) {
+        if (!allocation) return;
+        if (!compute_memory_pool_enabled()) {
+            vkFreeMemory(device, allocation, nullptr);
+            return;
+        }
+        std::lock_guard<std::mutex> lock(memory_pool.mutex);
+        auto found = memory_pool.active.find(allocation);
+        if (found == memory_pool.active.end()) {
+            vkFreeMemory(device, allocation, nullptr);
+            return;
+        }
+        const ComputeMemoryKey key = found->second;
+        memory_pool.active.erase(found);
+        constexpr size_t max_cached_allocations = 2048;
+        const VkDeviceSize limit = compute_memory_pool_limit();
+        const VkDeviceSize remaining = memory_pool.cached_bytes < limit
+            ? limit - memory_pool.cached_bytes : 0;
+        if (memory_pool.cached_allocations >= max_cached_allocations || key.bytes > remaining) {
+            ++memory_pool.discarded;
+            vkFreeMemory(device, allocation, nullptr);
+            return;
+        }
+        memory_pool.available[key].push_back(allocation);
+        memory_pool.cached_bytes += key.bytes;
+        ++memory_pool.cached_allocations;
+    }
+
+    ComputeMemoryPoolStats memory_pool_stats() {
+        std::lock_guard<std::mutex> lock(memory_pool.mutex);
+        return {memory_pool.cached_bytes, memory_pool.cached_allocations, memory_pool.hits,
+                memory_pool.misses, memory_pool.discarded};
+    }
+
+    void release_cached_memory() {
+        if (!device) return;
+        std::lock_guard<std::mutex> lock(memory_pool.mutex);
+        for (const auto& [key, allocations] : memory_pool.available) {
+            (void)key;
+            for (VkDeviceMemory allocation : allocations)
+                vkFreeMemory(device, allocation, nullptr);
+        }
+        for (const auto& [allocation, key] : memory_pool.active) {
+            (void)key;
+            vkFreeMemory(device, allocation, nullptr);
+        }
+        memory_pool.available.clear();
+        memory_pool.active.clear();
+        memory_pool.cached_bytes = 0;
+        memory_pool.cached_allocations = 0;
     }
 
     bool init() {
@@ -283,15 +421,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (descriptor_layout) vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
         for (auto& buffer : buffers) {
             if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
-            if (buffer.memory) vkFreeMemory(ctx.device, buffer.memory, nullptr);
+            if (buffer.memory) ctx.release_memory(buffer.memory);
         }
         for (size_t i = 0; i < images.size(); i++) {
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
             if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
             if (images[i].image) vkDestroyImage(ctx.device, images[i].image, nullptr);
-            if (images[i].memory) vkFreeMemory(ctx.device, images[i].memory, nullptr);
+            if (images[i].memory) ctx.release_memory(images[i].memory);
             if (staging[i]) vkDestroyBuffer(ctx.device, staging[i], nullptr);
-            if (staging_memory[i]) vkFreeMemory(ctx.device, staging_memory[i], nullptr);
+            if (staging_memory[i]) ctx.release_memory(staging_memory[i]);
         }
     };
     auto resource_bytes = [](const ShaderResource* resource) -> uint8_t* {
@@ -316,10 +454,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
             const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
             if (memory_type == UINT32_MAX) break;
-            VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-            mai.allocationSize = requirements.size;
-            mai.memoryTypeIndex = memory_type;
-            if (vkAllocateMemory(ctx.device, &mai, nullptr, &buffers[i].memory) != VK_SUCCESS) break;
+            buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type);
+            if (!buffers[i].memory) break;
             if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
             void* mapped = nullptr;
             if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
@@ -483,11 +619,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]) != VK_SUCCESS) { images_ready = false; break; }
             VkMemoryRequirements sreq{};
             vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
-            VkMemoryAllocateInfo smai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-            smai.allocationSize = sreq.size;
-            smai.memoryTypeIndex = ctx.host_memory_type(sreq.memoryTypeBits);
-            if (smai.memoryTypeIndex == UINT32_MAX ||
-                vkAllocateMemory(ctx.device, &smai, nullptr, &staging_memory[i]) != VK_SUCCESS ||
+            const uint32_t staging_memory_type = ctx.host_memory_type(sreq.memoryTypeBits);
+            staging_memory[i] = ctx.allocate_memory(sreq.size, staging_memory_type);
+            if (!staging_memory[i] ||
                 vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0) != VK_SUCCESS) {
                 images_ready = false; break; }
             { void* mapped = nullptr;
@@ -512,11 +646,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (vkCreateImage(ctx.device, &ici, nullptr, &bi.image) != VK_SUCCESS) { images_ready = false; break; }
             VkMemoryRequirements ireq{};
             vkGetImageMemoryRequirements(ctx.device, bi.image, &ireq);
-            VkMemoryAllocateInfo imai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-            imai.allocationSize = ireq.size;
-            imai.memoryTypeIndex = device_memory_type(ireq.memoryTypeBits);
-            if (imai.memoryTypeIndex == UINT32_MAX ||
-                vkAllocateMemory(ctx.device, &imai, nullptr, &bi.memory) != VK_SUCCESS ||
+            const uint32_t image_memory_type = device_memory_type(ireq.memoryTypeBits);
+            bi.memory = ctx.allocate_memory(ireq.size, image_memory_type);
+            if (!bi.memory ||
                 vkBindImageMemory(ctx.device, bi.image, bi.memory, 0) != VK_SUCCESS) {
                 images_ready = false; break; }
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
@@ -824,16 +956,36 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     if (timing_enabled) {
         struct TimingTotals { uint64_t calls = 0, dispatches = 0; double milliseconds = 0; };
         static TimingTotals totals;
-        totals.calls++;
-        totals.dispatches += items.size();
-        totals.milliseconds += std::chrono::duration<double, std::milli>(
+        static TimingTotals window;
+        const double elapsed = std::chrono::duration<double, std::milli>(
             std::chrono::steady_clock::now() - timing_start).count();
+        auto accumulate = [&](TimingTotals& timing) {
+            timing.calls++;
+            timing.dispatches += items.size();
+            timing.milliseconds += elapsed;
+        };
+        accumulate(totals);
+        accumulate(window);
         if (totals.calls % 25 == 0) {
             std::fprintf(stderr,
                          "[render-timing] compute calls=%llu dispatches=%llu avg_ms=%.2f\n",
                          (unsigned long long)totals.calls,
                          (unsigned long long)totals.dispatches,
                          totals.milliseconds / static_cast<double>(totals.calls));
+            const ComputeMemoryPoolStats pool = context.memory_pool_stats();
+            std::fprintf(stderr,
+                         "[render-timing] compute_memory_pool hits=%llu misses=%llu cached=%zu "
+                         "%.1f MiB discarded=%llu\n",
+                         (unsigned long long)pool.hits, (unsigned long long)pool.misses,
+                         pool.cached_allocations,
+                         static_cast<double>(pool.cached_bytes) / (1024.0 * 1024.0),
+                         (unsigned long long)pool.discarded);
+            std::fprintf(stderr,
+                         "[render-window] compute calls=%llu dispatches=%.1f avg_ms=%.2f\n",
+                         (unsigned long long)window.calls,
+                         window.dispatches / static_cast<double>(window.calls),
+                         window.milliseconds / static_cast<double>(window.calls));
+            window = {};
         }
     }
     return all_ok;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -9,6 +9,7 @@
 #include <vulkan/vulkan.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <cstdio>
@@ -802,17 +803,39 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 } // namespace
 
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items) {
-    VulkanComputeContext context;
-    if (!context.init()) {
+    // Keep the Vulkan device alive across dispatch spans. Constructing an instance, device, and queue for
+    // every callback cost roughly 25 ms/frame on the native Windows frontend before any kernel work ran.
+    // Function-local static initialization is thread-safe; AGC submit execution serializes subsequent use.
+    static VulkanComputeContext context;
+    static const bool context_ready = context.init();
+    if (!context_ready) {
         std::fprintf(stderr, "[compute] Vulkan initialization failed\n");
         return false;
     }
+    const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const auto timing_start = timing_enabled
+        ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     // Dispatches are independent PM4-order operations: one item failing (e.g. an image shape the
     // backend can't bind yet, #590) must not abort the rest of the batch — that would regress
     // dispatches that executed before image bindings existed. Run all; report all-succeeded.
     bool all_ok = true;
     for (const auto& item : items)
         all_ok &= execute_item(context, item);
+    if (timing_enabled) {
+        struct TimingTotals { uint64_t calls = 0, dispatches = 0; double milliseconds = 0; };
+        static TimingTotals totals;
+        totals.calls++;
+        totals.dispatches += items.size();
+        totals.milliseconds += std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - timing_start).count();
+        if (totals.calls % 25 == 0) {
+            std::fprintf(stderr,
+                         "[render-timing] compute calls=%llu dispatches=%llu avg_ms=%.2f\n",
+                         (unsigned long long)totals.calls,
+                         (unsigned long long)totals.dispatches,
+                         totals.milliseconds / static_cast<double>(totals.calls));
+        }
+    }
     return all_ok;
 }
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -39,7 +39,49 @@ namespace prosper::frontend {
 // composite pass. Guest memory at that address is never populated on our (CPU-read) side, so without
 // this the composite samples zeros and the frame is black. We cache each submit's rendered pixels under
 // its render-target base and inject them when a subsequent draw samples a texture at a matching base.
-namespace { struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; }; }
+namespace {
+struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; };
+
+// Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
+// to one renderer callback: graphics spans are split at compute operations, so guest texture bytes
+// cannot change within its lifetime. Live RTT inputs are excluded separately because an earlier pass
+// in the same callback can replace their pixels.
+struct TextureDecodeKey {
+    uint64_t gpu_addr = 0;
+    uint64_t host_data = 0;
+    uint64_t host_data_size = 0;
+    uint32_t size = 0;
+    uint32_t cls = 0;
+    uint32_t format = 0;
+    uint32_t num_components = 0;
+    uint32_t width = 0, height = 0;
+    uint32_t tile_mode = 0;
+    uint32_t img_dim = 0;
+    bool operator==(const TextureDecodeKey&) const = default;
+};
+
+struct TextureDecodeKeyHash {
+    size_t operator()(const TextureDecodeKey& key) const {
+        size_t hash = 1469598103934665603ull;
+        auto mix = [&](uint64_t value) {
+            hash ^= static_cast<size_t>(value);
+            hash *= 1099511628211ull;
+            hash ^= static_cast<size_t>(value >> 32);
+            hash *= 1099511628211ull;
+        };
+        mix(key.gpu_addr); mix(key.host_data); mix(key.host_data_size); mix(key.size);
+        mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height);
+        mix(key.tile_mode); mix(key.img_dim);
+        return hash;
+    }
+};
+
+struct DecodedTexture {
+    const uint8_t* pixels = nullptr;
+    uint32_t output_height = 0;
+    bool narrow = false;
+};
+}
 
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     register_live_compute();
@@ -140,7 +182,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             struct RenderTiming {
                 uint64_t callbacks = 0;
                 double total_ms = 0, build_resources_ms = 0, backend_ms = 0;
-                uint64_t textures = 0, buffers = 0, texture_bytes = 0, buffer_bytes = 0;
+                uint64_t textures = 0, texture_reuses = 0, buffers = 0;
+                uint64_t texture_bytes = 0, buffer_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
             };
             static thread_local RenderTiming pending_timing;
@@ -220,8 +263,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 return done;
             };
-            static std::vector<std::vector<uint8_t>> texstore;  // keep every item's texture bytes alive
-            texstore.clear();
+            // Keep decoded texture storage alive across callbacks. The old clear()+emplace(size, 0)
+            // released and zero-filled tens of MiB every submit even though the decode paths overwrite
+            // all pixels. Reusing same-sized slots avoids both costs; short guest reads explicitly clear
+            // their uncovered tail below so stale scratch bytes can never become sampled pixels.
+            static std::vector<std::vector<uint8_t>> texstore;
+            size_t texstore_used = 0;
+            std::unordered_map<TextureDecodeKey, DecodedTexture, TextureDecodeKeyHash> decoded_textures;
             uint32_t resource_hash_w = 0, resource_hash_h = 0;
             if (const char* dim = getenv("PROSPER_RESOURCE_HASH_DIM"))
                 if (sscanf(dim, "%ux%u", &resource_hash_w, &resource_hash_h) != 2)
@@ -259,9 +307,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     };
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
+                        const TextureDecodeKey decode_key{
+                            r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
+                            r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
+                            static_cast<uint32_t>(r.format), r.num_components, tw, th,
+                            r.tile_mode, r.img_dim,
+                        };
+                        auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
+                        const bool has_live_rtt = live_rtt != g_rtt.end() && live_rtt->second.w &&
+                            live_rtt->second.h && !live_rtt->second.rgba.empty();
+                        bool narrow_done = false;
+                        auto reused = has_live_rtt ? decoded_textures.end()
+                                                   : decoded_textures.find(decode_key);
+                        if (reused != decoded_textures.end()) {
+                            fr.tex_rgba = reused->second.pixels;
+                            fr.tw = tw;
+                            fr.th = reused->second.output_height;
+                            narrow_done = reused->second.narrow;
+                            if (timing_enabled) pending_timing.texture_reuses++;
+                        } else {
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         size_t nb = (size_t)tw * th * 4 * (is_cube ? 6u : 1u);
-                        texstore.emplace_back(nb, 0x00);
+                        if (texstore_used == texstore.size()) texstore.emplace_back();
+                        std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
+                        texture_pixels.resize(nb);
                         // PROSPER_TEXCOMMIT: log, once per texture base, how much of the sampled surface is
                         // COMMITTED guest memory (the same reserved_range_state safe_copy stops at). If the
                         // level's backgrounds read ~0% committed, they're GPU-DMA'd pages the CPU never
@@ -301,7 +370,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool f16 = r.format == prosper::gpu::DataFormat::Float16 &&
                                          (bpt == 2 || bpt == 4 || bpt == 8);
                         if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
-                        bool narrow_done = false;
                         bool f16_done = false;
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
@@ -311,12 +379,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 const RttSurf& s = rit->second;
                                 const size_t expected = static_cast<size_t>(tw) * th * 4;
                                 if (s.w == tw && s.h == th && s.rgba.size() == expected) {
-                                    std::memcpy(texstore.back().data(), s.rgba.data(), expected);
+                                    std::memcpy(texture_pixels.data(), s.rgba.data(), expected);
                                 } else {
+                                    std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
                                     for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
                                         uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
                                         size_t si = ((size_t)sy * s.w + sx) * 4;
-                                        if (si + 4 <= s.rgba.size()) std::memcpy(&texstore.back()[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
+                                        if (si + 4 <= s.rgba.size()) std::memcpy(&texture_pixels[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
                                     }
                                 }
                                 rtt_hit = true;
@@ -339,7 +408,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             const uint32_t cb = prosper::gpu::bc_block_bytes(r.format);
                             const bool ctiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                             for (uint32_t fface = 0; fface < 6; fface++) {
-                                uint8_t* slice = texstore.back().data() + (size_t)fface * tw * th * 4;
+                                uint8_t* slice = texture_pixels.data() + (size_t)fface * tw * th * 4;
                                 if (cb) {
                                     uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
                                     size_t comp = (size_t)bw * bh * cb;
@@ -360,7 +429,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         std::vector<uint8_t> traw(stride, 0);
                                         copy_resource(traw.data(), r.gpu_addr + (uint64_t)fface * stride, stride);
                                         prosper::gpu::detile_surface(slice, traw.data(), tw, th, r.tile_mode, 0);
-                                    } else copy_resource(slice, r.gpu_addr + (uint64_t)fface * stride, fb);
+                                    } else {
+                                        const size_t got = copy_resource(
+                                            slice, r.gpu_addr + (uint64_t)fface * stride, fb);
+                                        if (got < fb) std::fill(slice + got, slice + fb, 0);
+                                    }
                                 }
                             }
                             cube_done = true;
@@ -386,7 +459,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             } else {
                                 copy_resource(lin.data(), r.gpu_addr, comp_bytes);
                             }
-                            prosper::gpu::bc_decode_surface(texstore.back().data(), lin.data(), lin.size(), tw, th, r.format);
+                            if (!prosper::gpu::bc_decode_surface(
+                                    texture_pixels.data(), lin.data(), lin.size(), tw, th, r.format))
+                                std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
                         } else if (f16) {
                             // fp16 texture (#290 wall 1): read at the REAL bytes-per-texel and detile
                             // with the REAL element size — the old clamp read an 8-B/texel Float16x4
@@ -412,7 +487,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 copy_resource(hlin.data(), r.gpu_addr, hlin.size());
                             }
                             for (size_t t = 0; t < (size_t)tw * th; t++) {
-                                uint8_t* p = &texstore.back()[t * 4];
+                                uint8_t* p = &texture_pixels[t * 4];
                                 for (uint32_t c = 0; c < 4; c++) {
                                     if (c < nc) {
                                         uint16_t hv; std::memcpy(&hv, &hlin[t * bpt + c * 2], 2);
@@ -453,22 +528,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             for (size_t t = 0; t < (size_t)tw * th; t++) {
                                 uint8_t v = nlin[t * bpt];   // first (coverage) channel
-                                uint8_t* p = &texstore.back()[t * 4];
+                                uint8_t* p = &texture_pixels[t * 4];
                                 p[0] = p[1] = p[2] = p[3] = v;
                             }
                             narrow_done = true;   // already detiled+expanded; skip the 32-bpp auto-detile below
                         } else {
-                            copy_resource(texstore.back().data(), r.gpu_addr, nb);
+                            const size_t got = copy_resource(texture_pixels.data(), r.gpu_addr, nb);
+                            if (got < nb)
+                                std::fill(texture_pixels.begin() + got, texture_pixels.end(), 0);
                         }
                         // PROSPER_DUMP_RAWTEX: write the raw tiled RGBA bytes (pre-detile) to a .bin for
                         // offline swizzle experimentation.
-                        if (getenv("PROSPER_DUMP_RAWTEX") && !texstore.back().empty()) {
+                        if (getenv("PROSPER_DUMP_RAWTEX") && !texture_pixels.empty()) {
                             std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
                             char fn[512]; snprintf(fn, sizeof fn, "%s/rawtex_%ux%u.bin", d.c_str(), tw, th);
-                            if (FILE* f = fopen(fn, "wb")) { fwrite(texstore.back().data(), 1, nb, f); fclose(f);
+                            if (FILE* f = fopen(fn, "wb")) { fwrite(texture_pixels.data(), 1, nb, f); fclose(f);
                                 fprintf(stderr, "[render] dumped raw tiled bytes -> %s (%zu)\n", fn, nb); fflush(stderr); }
                         }
-                        if (getenv("PROSPER_GFXLOG")) { const uint8_t* b = texstore.back().data();
+                        if (getenv("PROSPER_GFXLOG")) { const uint8_t* b = texture_pixels.data();
                             size_t nz = 0; for (size_t i = 0; i < nb && i < (1u<<16); i++) nz += (b[i] != 0);
                             fprintf(stderr, "[render] tex binding=%u %ux%u first64k-nonzero=%zu\n", r.binding, tw, th, nz); }
                         // AUTO-DETILE: de-swizzle a GPU-tiled sampled surface into the linear texstore,
@@ -486,7 +563,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 // The padded tiled buffer's tail (th rounded to whole 32-row tiles) runs past
                                 // the real backing: fall back to the width*height linear bytes copied above
                                 // rather than an all-zero buffer (which would BLANK the texture).
-                                std::memcpy(tiled.data(), texstore.back().data(), std::min(nb, tiled_bytes));
+                                std::memcpy(tiled.data(), texture_pixels.data(), std::min(nb, tiled_bytes));
                             // PROSPER_DUMP_RAWTILE: write the EXACT padded tiled bytes to a .bin (no lossy BMP
                             // round-trip) so the de-swizzle can be reversed offline against a known image (#101).
                             if (getenv("PROSPER_DUMP_RAWTILE") && (frame_no < 200 || (tw <= 2048 && th <= 1024))) {
@@ -502,14 +579,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     if (FILE* bf = fopen(bn, "wb")) { fwrite(tiled.data(), 1, tiled.size(), bf); fclose(bf); }
                                 }
                             }
-                            prosper::gpu::detile_surface(texstore.back().data(), tiled.data(), tw, th, tmode, pitch);
+                            prosper::gpu::detile_surface(texture_pixels.data(), tiled.data(), tw, th, tmode, pitch);
                         }
                         // Packed R11G11B10F (Gen5 IMG_FMT 36 -> DataFormat::Float10_11_11, #294): UE4's
                         // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
                         // above already produced linear packed words; unpack each to RGBA8 in place with
                         // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
                         if (!rtt_hit && r.format == prosper::gpu::DataFormat::Float10_11_11) {
-                            uint8_t* tp = texstore.back().data();
+                            uint8_t* tp = texture_pixels.data();
                             for (size_t t = 0; t < (size_t)tw * th; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);
                                 const float fc[3] = { prosper::gpu::f11_to_float((uint16_t)(v & 0x7FFu)),
@@ -538,7 +615,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 return hash;
                             };
                             const uint64_t raw_hash = fnv(raw.data(), raw_got);
-                            const uint64_t sample_hash = fnv(texstore.back().data(), texstore.back().size());
+                            const uint64_t sample_hash = fnv(texture_pixels.data(), texture_pixels.size());
                             const auto writer = prosper::gpu::last_guest_write_overlap(
                                 r.gpu_addr, raw_size);
                             fprintf(stderr,
@@ -552,7 +629,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     set, r.binding, (unsigned long long)r.gpu_addr, tw, th,
                                     (unsigned)r.cls, (unsigned)r.format, r.tile_mode, (int)rtt_hit,
                                     raw_got, raw_size, (unsigned long long)raw_hash,
-                                    texstore.back().size(), (unsigned long long)sample_hash,
+                                    texture_pixels.size(), (unsigned long long)sample_hash,
                                     writer ? prosper::gpu::guest_writer_kind_name(writer->kind) : "none",
                                     (unsigned long long)(writer ? writer->submit : 0),
                                     (unsigned long long)(writer ? writer->item : 0),
@@ -566,7 +643,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             uint64_t hash = 1469598103934665603ull;
                             size_t rgb_nonblack = 0;
                             for (size_t t = 0; t < (size_t)tw * th; ++t) {
-                                const uint8_t* p = &texstore.back()[t * 4];
+                                const uint8_t* p = &texture_pixels[t * 4];
                                 rgb_nonblack += (p[0] != 0 || p[1] != 0 || p[2] != 0);
                                 for (unsigned c = 0; c < 4; ++c) {
                                     hash ^= p[c]; hash *= 1099511628211ull;
@@ -581,7 +658,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // sampling diagnosis (#522).
                         if (getenv("PROSPER_TESTTEX")) {
                             for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
-                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
+                                uint8_t* p = &texture_pixels[((size_t)y * tw + x) * 4];
                                 bool ck = ((x / 64) ^ (y / 64)) & 1;
                                 p[0] = (uint8_t)(255 * x / tw); p[1] = (uint8_t)(255 * y / th);
                                 p[2] = ck ? 200 : 40; p[3] = 255;
@@ -593,7 +670,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // source/geometry/sample path (#522).
                         if (getenv("PROSPER_TESTLUT") && tw == 256 && th == 16) {
                             for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
-                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
+                                uint8_t* p = &texture_pixels[((size_t)y * tw + x) * 4];
                                 p[0] = (uint8_t)((x % 16) * 255 / 15);
                                 p[1] = (uint8_t)((15 - y) * 255 / 15);
                                 p[2] = (uint8_t)((x / 16) * 255 / 15);
@@ -605,7 +682,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // from the persistent post shader and its healthy scene input (#522).
                         if (getenv("PROSPER_TESTLUT32") && tw == 1024 && th == 32) {
                             for (uint32_t y = 0; y < th; ++y) for (uint32_t x = 0; x < tw; ++x) {
-                                uint8_t* p = &texstore.back()[((size_t)y * tw + x) * 4];
+                                uint8_t* p = &texture_pixels[((size_t)y * tw + x) * 4];
                                 p[0] = (uint8_t)((x % 32) * 255 / 31);
                                 p[1] = (uint8_t)(y * 255 / 31);
                                 p[2] = (uint8_t)((x / 32) * 255 / 31);
@@ -614,24 +691,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         // PROSPER_DUMP_TEX: write the RAW texture memory (interpreted linearly) to a BMP,
                         // bypassing the shader — reveals whether the render target is tiled or linear.
-                        if (getenv("PROSPER_DUMP_TEX") && !texstore.back().empty() && frame_no < 200) {
+                        if (getenv("PROSPER_DUMP_TEX") && !texture_pixels.empty() && frame_no < 200) {
                             std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
                             char fn[512]; snprintf(fn, sizeof fn, "%s/rawtex_f%04d_b%u.bmp", d.c_str(), (int)frame_no, r.binding);
-                            prosper::test::dump_bmp(fn, texstore.back(), tw, th);
+                            prosper::test::dump_bmp(fn, texture_pixels, tw, th);
                             fprintf(stderr, "[render] dumped raw texture -> %s\n", fn); fflush(stderr);
                         }
                         // PROSPER_DUMP_ATLAS: dump each SMALL sampled texture once per ADDRESS (find the caption
                         // font among same-size UI textures). Capped.
-                        if (getenv("PROSPER_DUMP_ATLAS") && !texstore.back().empty() && tw <= 2048 && th <= 1024) {
+                        if (getenv("PROSPER_DUMP_ATLAS") && !texture_pixels.empty() && tw <= 2048 && th <= 1024) {
                             static std::unordered_map<uint64_t,int> seen; static int ndumped = 0;
                             if (seen[r.gpu_addr]++ == 0 && ndumped++ < 60) {
                                 std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
                                 char fn[512]; snprintf(fn, sizeof fn, "%s/tex_%ux%u_%llx_c%u.bmp", d.c_str(), tw, th,
                                                        (unsigned long long)r.gpu_addr, r.num_components);
-                                prosper::test::dump_bmp(fn, texstore.back(), tw, th);
+                                prosper::test::dump_bmp(fn, texture_pixels, tw, th);
                             }
                         }
-                        fr.tex_rgba = texstore.back().data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
+                        fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
+                        if (!resource_rtt_hit && !has_live_rtt)
+                            decoded_textures.emplace(
+                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done});
+                        }
                         // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
@@ -973,7 +1054,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         for (size_t k = 1; k <= render_pass.size(); ++k) {
                             std::vector<const prosper::gpu::DrawItem*> prefix(
                                 render_pass.begin(), render_pass.begin() + k);
-                            texstore.clear();
+                            texstore_used = 0;
+                            decoded_textures.clear();
                             std::vector<uint8_t> step = prosper::test::render_draws_rgba(
                                 build_bds(prefix), gw, gh, seed, clear_for(prefix), true);
                             uint64_t hash = 1469598103934665603ull;
@@ -1146,21 +1228,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 struct TimingTotals {
                     uint64_t submits = 0, callbacks = 0;
                     double total_ms = 0, build_resources_ms = 0, backend_ms = 0;
-                    uint64_t textures = 0, buffers = 0, texture_bytes = 0, buffer_bytes = 0;
+                    uint64_t textures = 0, texture_reuses = 0, buffers = 0;
+                    uint64_t texture_bytes = 0, buffer_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                 };
                 static TimingTotals totals;
-                totals.submits++;
-                totals.callbacks += pending_timing.callbacks;
-                totals.total_ms += pending_timing.total_ms;
-                totals.build_resources_ms += pending_timing.build_resources_ms;
-                totals.backend_ms += pending_timing.backend_ms;
-                totals.textures += pending_timing.textures;
-                totals.buffers += pending_timing.buffers;
-                totals.texture_bytes += pending_timing.texture_bytes;
-                totals.buffer_bytes += pending_timing.buffer_bytes;
-                totals.texture_ms += pending_timing.texture_ms;
-                totals.buffer_ms += pending_timing.buffer_ms;
+                static TimingTotals window;
+                auto accumulate = [&](TimingTotals& timing) {
+                    timing.submits++;
+                    timing.callbacks += pending_timing.callbacks;
+                    timing.total_ms += pending_timing.total_ms;
+                    timing.build_resources_ms += pending_timing.build_resources_ms;
+                    timing.backend_ms += pending_timing.backend_ms;
+                    timing.textures += pending_timing.textures;
+                    timing.texture_reuses += pending_timing.texture_reuses;
+                    timing.buffers += pending_timing.buffers;
+                    timing.texture_bytes += pending_timing.texture_bytes;
+                    timing.buffer_bytes += pending_timing.buffer_bytes;
+                    timing.texture_ms += pending_timing.texture_ms;
+                    timing.buffer_ms += pending_timing.buffer_ms;
+                };
+                accumulate(totals);
+                accumulate(window);
                 if (totals.submits % 25 == 0) {
                     const double nsub = static_cast<double>(totals.submits);
                     const double other = totals.total_ms - totals.build_resources_ms - totals.backend_ms;
@@ -1171,12 +1260,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.total_ms / nsub, totals.build_resources_ms / nsub,
                             totals.backend_ms / nsub, other / nsub);
                     fprintf(stderr,
-                            "[render-timing] resources textures=%llu %.1f MiB %.2f ms/submit; "
+                            "[render-timing] resources textures=%llu reused=%llu %.1f MiB %.2f ms/submit; "
                             "buffers=%llu %.1f MiB %.2f ms/submit\n",
                             (unsigned long long)totals.textures,
+                            (unsigned long long)totals.texture_reuses,
                             totals.texture_bytes / (1024.0 * 1024.0), totals.texture_ms / nsub,
                             (unsigned long long)totals.buffers,
                             totals.buffer_bytes / (1024.0 * 1024.0), totals.buffer_ms / nsub);
+                    const double wn = static_cast<double>(window.submits);
+                    const double window_other = window.total_ms - window.build_resources_ms -
+                                                window.backend_ms;
+                    fprintf(stderr,
+                            "[render-window] frontend submits=%llu callbacks=%.1f avg_ms: total=%.2f "
+                            "build_resources=%.2f backend=%.2f other=%.2f; resources textures=%.1f "
+                            "reused=%.1f %.1f MiB %.2f ms buffers=%.1f %.1f MiB %.2f ms\n",
+                            (unsigned long long)window.submits, window.callbacks / wn,
+                            window.total_ms / wn, window.build_resources_ms / wn,
+                            window.backend_ms / wn, window_other / wn, window.textures / wn,
+                            window.texture_reuses / wn,
+                            window.texture_bytes / (wn * 1024.0 * 1024.0), window.texture_ms / wn,
+                            window.buffers / wn, window.buffer_bytes / (wn * 1024.0 * 1024.0),
+                            window.buffer_ms / wn);
+                    window = {};
                 }
             }
             return px;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -136,6 +136,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             static thread_local int g_this_submit = -1;
             if (phase.first_span || g_this_submit < 0) g_this_submit = g_submit_idx++;
             if (g_this_submit > g_render_last) return {};
+            using RenderClock = std::chrono::steady_clock;
+            struct RenderTiming {
+                uint64_t callbacks = 0;
+                double total_ms = 0, build_resources_ms = 0, backend_ms = 0;
+                uint64_t textures = 0, buffers = 0, texture_bytes = 0, buffer_bytes = 0;
+                double texture_ms = 0, buffer_ms = 0;
+            };
+            static thread_local RenderTiming pending_timing;
+            const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+            if (timing_enabled && phase.first_span) pending_timing = {};
+            const auto callback_timing_start = timing_enabled
+                ? RenderClock::now() : RenderClock::time_point{};
             // PROSPER_SUBMITLOG: print the GPU-submit index periodically (at native speed, before the slow
             // render) so it can be correlated with guest-side log lines (e.g. a MsgDialog wait) to find the
             // exact submit at which a scene appears — for aiming PROSPER_RENDER_FIRST at it.
@@ -230,6 +242,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
               auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set){
                 if (!t) return;
                 for (auto& r : t->resources) {
+                    const auto resource_timing_start = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
+                    bool resource_rtt_hit = false;
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     // Captured replays preserve the logical guest address for RT identity but provide
                     // owned bytes here. Production resources leave host_data null and use guest memory.
@@ -294,12 +309,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (rtt_on) { auto rit = g_rtt.find(r.gpu_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && !rit->second.rgba.empty()) {
                                 const RttSurf& s = rit->second;
-                                for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
-                                    uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
-                                    size_t si = ((size_t)sy * s.w + sx) * 4;
-                                    if (si + 4 <= s.rgba.size()) std::memcpy(&texstore.back()[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
+                                const size_t expected = static_cast<size_t>(tw) * th * 4;
+                                if (s.w == tw && s.h == th && s.rgba.size() == expected) {
+                                    std::memcpy(texstore.back().data(), s.rgba.data(), expected);
+                                } else {
+                                    for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
+                                        uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
+                                        size_t si = ((size_t)sy * s.w + sx) * 4;
+                                        if (si + 4 <= s.rgba.size()) std::memcpy(&texstore.back()[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
+                                    }
                                 }
                                 rtt_hit = true;
+                                resource_rtt_hit = true;
                             }
                             if (getenv("PROSPER_RTTLOG"))
                                 fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",
@@ -656,6 +677,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                         }
                     }
+                    if (timing_enabled) {
+                        const double elapsed = std::chrono::duration<double, std::milli>(
+                            RenderClock::now() - resource_timing_start).count();
+                        if (fr.is_texture()) {
+                            pending_timing.textures++;
+                            pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * 4;
+                            pending_timing.texture_ms += elapsed;
+                            if (const char* mode = getenv("PROSPER_RENDER_TIMING");
+                                mode && strcmp(mode, "detail") == 0 && elapsed >= 0.5) {
+                                static uint64_t detail_lines = 0;
+                                if (detail_lines++ < 250) {
+                                    fprintf(stderr,
+                                            "[render-timing] texture addr=0x%llx %ux%u out=%ux%u "
+                                            "fmt=%u comps=%u tile=%u rtt=%d %.2f ms\n",
+                                            (unsigned long long)r.gpu_addr, r.width, r.height,
+                                            fr.tw, fr.th, (unsigned)r.format, r.num_components,
+                                            r.tile_mode, (int)resource_rtt_hit, elapsed);
+                                }
+                            }
+                        } else {
+                            pending_timing.buffers++;
+                            pending_timing.buffer_bytes += static_cast<uint64_t>(fr.dwords.size()) * 4;
+                            pending_timing.buffer_ms += elapsed;
+                        }
+                    }
                     R.push_back(std::move(fr));
                 }
               };
@@ -881,8 +927,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
                         if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
                             sit->second.rgba.size() == (size_t)gw * gh * 4) seed = sit->second.rgba.data(); }
+                    const auto build_start = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
+                    auto backend_draws = build_bds(render_pass);
+                    const auto build_done = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
-                        build_bds(render_pass), gw, gh, seed, clear_for(render_pass), true);
+                        backend_draws, gw, gh, seed, clear_for(render_pass), true);
+                    const auto backend_done = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
+                    if (timing_enabled) {
+                        pending_timing.build_resources_ms +=
+                            std::chrono::duration<double, std::milli>(build_done - build_start).count();
+                        pending_timing.backend_ms +=
+                            std::chrono::duration<double, std::milli>(backend_done - build_done).count();
+                    }
                     if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = gw; s.h = gh; }
                     if (native_w == resource_hash_w && native_h == resource_hash_h && !gpx.empty()) {
                         uint64_t hash = 1469598103934665603ull;
@@ -1013,7 +1072,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // Single-framebuffer path: render_draws_rgba composites every draw into ONE framebuffer.
                 std::vector<const prosper::gpu::DrawItem*> all; all.reserve(items.size());
                 for (const auto& it : items) all.push_back(&it);
-                px = prosper::test::render_draws_rgba(build_bds(all), w, h, nullptr, clear_for(all), true);
+                const auto build_start = timing_enabled
+                    ? RenderClock::now() : RenderClock::time_point{};
+                auto backend_draws = build_bds(all);
+                const auto build_done = timing_enabled
+                    ? RenderClock::now() : RenderClock::time_point{};
+                px = prosper::test::render_draws_rgba(backend_draws, w, h, nullptr, clear_for(all), true);
+                const auto backend_done = timing_enabled
+                    ? RenderClock::now() : RenderClock::time_point{};
+                if (timing_enabled) {
+                    pending_timing.build_resources_ms +=
+                        std::chrono::duration<double, std::milli>(build_done - build_start).count();
+                    pending_timing.backend_ms +=
+                        std::chrono::duration<double, std::milli>(backend_done - build_done).count();
+                }
                 // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
                 // composite pass that samples that address gets the scene we drew (not empty guest memory).
                 if (rtt_on && !px.empty()) {
@@ -1046,7 +1118,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 if (scanout) px = scanout->rgba;
             }
-            if (!phase.final_span) return px;
+            if (!phase.final_span) {
+                if (timing_enabled) {
+                    pending_timing.callbacks++;
+                    pending_timing.total_ms += std::chrono::duration<double, std::milli>(
+                        RenderClock::now() - callback_timing_start).count();
+                }
+                return px;
+            }
             int n = frame_no++;
             // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
             // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.
@@ -1059,6 +1138,46 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 char fn[512]; snprintf(fn, sizeof fn, "%s/frame_%04d.bmp", frame_dir.c_str(), n);
                 prosper::test::dump_bmp(fn, px, w, h);
                 fprintf(stderr, "[render] frame %d rendered (%ux%u) nz=%zu -> %s\n", n, w, h, px_nz, fn);
+            }
+            if (timing_enabled) {
+                pending_timing.callbacks++;
+                pending_timing.total_ms += std::chrono::duration<double, std::milli>(
+                    RenderClock::now() - callback_timing_start).count();
+                struct TimingTotals {
+                    uint64_t submits = 0, callbacks = 0;
+                    double total_ms = 0, build_resources_ms = 0, backend_ms = 0;
+                    uint64_t textures = 0, buffers = 0, texture_bytes = 0, buffer_bytes = 0;
+                    double texture_ms = 0, buffer_ms = 0;
+                };
+                static TimingTotals totals;
+                totals.submits++;
+                totals.callbacks += pending_timing.callbacks;
+                totals.total_ms += pending_timing.total_ms;
+                totals.build_resources_ms += pending_timing.build_resources_ms;
+                totals.backend_ms += pending_timing.backend_ms;
+                totals.textures += pending_timing.textures;
+                totals.buffers += pending_timing.buffers;
+                totals.texture_bytes += pending_timing.texture_bytes;
+                totals.buffer_bytes += pending_timing.buffer_bytes;
+                totals.texture_ms += pending_timing.texture_ms;
+                totals.buffer_ms += pending_timing.buffer_ms;
+                if (totals.submits % 25 == 0) {
+                    const double nsub = static_cast<double>(totals.submits);
+                    const double other = totals.total_ms - totals.build_resources_ms - totals.backend_ms;
+                    fprintf(stderr,
+                            "[render-timing] frontend submits=%llu callbacks=%llu avg_ms: total=%.2f "
+                            "build_resources=%.2f backend=%.2f other=%.2f\n",
+                            (unsigned long long)totals.submits, (unsigned long long)totals.callbacks,
+                            totals.total_ms / nsub, totals.build_resources_ms / nsub,
+                            totals.backend_ms / nsub, other / nsub);
+                    fprintf(stderr,
+                            "[render-timing] resources textures=%llu %.1f MiB %.2f ms/submit; "
+                            "buffers=%llu %.1f MiB %.2f ms/submit\n",
+                            (unsigned long long)totals.textures,
+                            totals.texture_bytes / (1024.0 * 1024.0), totals.texture_ms / nsub,
+                            (unsigned long long)totals.buffers,
+                            totals.buffer_bytes / (1024.0 * 1024.0), totals.buffer_ms / nsub);
+                }
             }
             return px;
         });

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -16,6 +16,7 @@
 #include "agc_shader_layout.hpp"   // DecodedBufferDescriptor (DynFetch)
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -162,6 +163,35 @@ struct SubmitOperation {
 };
 
 enum class ShaderProgramStage : uint8_t { Vertex, Fragment, Compute };
+
+// Graphics shaders are commonly submitted dozens of times per frame with different guest backing
+// addresses but the same code and descriptor interface. Cache the deterministic RDNA2 -> SPIR-V
+// result by shader bytes plus the resource fields the recompiler actually consumes. Runtime resource
+// state (addresses, sizes, dimensions, sampler state, and host backing) deliberately stays out of the
+// key; the backend reads it from each draw's current ShaderResourceTable.
+struct ShaderRecompileCacheStats {
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t bypasses = 0;
+    uint64_t evictions = 0;
+    uint64_t entries = 0;
+    uint64_t bytes = 0;
+    double compile_ms = 0.0;
+};
+std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
+                                                       const uint32_t* code, size_t dwords,
+                                                       const ShaderResourceTable* resources = nullptr);
+ShaderRecompileCacheStats shader_recompile_cache_stats();
+void clear_shader_recompile_cache();
+
+struct DrawRealizationPhaseStats {
+    uint64_t draws = 0;
+    double table_ms = 0.0;
+    double shader_ms = 0.0;
+};
+void record_draw_realization_phases(double table_ms, double shader_ms);
+DrawRealizationPhaseStats draw_realization_phase_stats();
+
 enum class RealizationFailureReason : uint8_t {
     None,
     Unknown,
@@ -336,8 +366,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                          (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
         return false;
     }
+    const bool phase_timing = getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const auto table_start = phase_timing
+        ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(ds, rs.es_addr, false);
     std::shared_ptr<ShaderResourceTable> prt = build_stage_table(ds, rs.ps_addr, true);
+    const auto table_done = phase_timing
+        ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     // PROSPER_RTLOG: correlate this draw's render-target address (CB_COLOR0_BASE) with the addresses of
     // the textures it SAMPLES. If a sampled texture's base equals some draw's color0_base, that surface is
     // a GPU render target (the game renders into it then samples it) -> render-to-texture (#83/#101).
@@ -352,8 +387,16 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 fprintf(stderr, " vtex=0x%llx(%ux%u f%u)", (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
         fprintf(stderr, "\n");
     }
-    std::vector<uint32_t> vs = recompile_vertex((const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());
-    std::vector<uint32_t> fs = recompile_fragment((const uint32_t*)(uintptr_t)rs.ps_addr, max_shader_dwords, prt.get());
+    std::vector<uint32_t> vs = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());
+    std::vector<uint32_t> fs = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr, max_shader_dwords, prt.get());
+    if (phase_timing) {
+        const auto shader_done = std::chrono::steady_clock::now();
+        record_draw_realization_phases(
+            std::chrono::duration<double, std::milli>(table_done - table_start).count(),
+            std::chrono::duration<double, std::milli>(shader_done - table_done).count());
+    }
     add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, vrt, vs);
     add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, prt, fs);
     if (const char* dd = getenv("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -12,6 +12,7 @@
 #include "rdna2_decode.hpp"       // rdna2_walk (for the vertex-fetch const-eval)
 #include "rdna2_to_spirv.hpp"     // recompile_compute
 #include "writer_provenance.hpp"
+#include <chrono>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -1541,16 +1542,24 @@ bool execute_compute_items(const std::vector<ComputeItem>& items) {
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
                                  uint64_t submit_no) {
     if ((!g_live && !g_compute) || (st.draws.empty() && st.dispatches.empty())) return false;
+    using TimingClock = std::chrono::steady_clock;
+    const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
     std::vector<DrawItem> draws = g_live && width && height
         ? realize_gpustate_draws(st, 0x10000, sx, sy) : std::vector<DrawItem>{};
+    const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<ComputeItem> computes = g_compute
         ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
+    const auto timing_compute_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
 
+    auto operations = plan_submit_operations(st);
+    const auto timing_plan_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     OrderedSubmitResult result = execute_ordered_items(
-        plan_submit_operations(st), draws, computes, g_live, g_compute, width, height);
+        operations, draws, computes, g_live, g_compute, width, height);
+    const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<uint8_t>& px = result.pixels;
 
     if (!draws.empty()) {
@@ -1561,9 +1570,40 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                 std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
         }
     }
-    if (px.size() != static_cast<size_t>(width) * height * 4) return false;
-    present_write_frame(px.data(), width, height);
-    return true;
+    const bool presented = px.size() == static_cast<size_t>(width) * height * 4;
+    if (presented) present_write_frame(px.data(), width, height);
+    if (timing_enabled) {
+        const auto timing_done = TimingClock::now();
+        auto ms = [](auto begin, auto end) {
+            return std::chrono::duration<double, std::milli>(end - begin).count();
+        };
+        struct TimingTotals {
+            uint64_t submits = 0, draws = 0, dispatches = 0;
+            double realize_draws = 0, realize_compute = 0, plan = 0, backend = 0, publish = 0;
+        };
+        static TimingTotals totals;
+        totals.submits++;
+        totals.draws += draws.size();
+        totals.dispatches += computes.size();
+        totals.realize_draws += ms(timing_start, timing_draws_ready);
+        totals.realize_compute += ms(timing_draws_ready, timing_compute_ready);
+        totals.plan += ms(timing_compute_ready, timing_plan_ready);
+        totals.backend += ms(timing_plan_ready, timing_backend_done);
+        totals.publish += ms(timing_backend_done, timing_done);
+        if (totals.submits % 25 == 0) {
+            const double n = static_cast<double>(totals.submits);
+            const double total = totals.realize_draws + totals.realize_compute + totals.plan +
+                                 totals.backend + totals.publish;
+            std::fprintf(stderr,
+                         "[render-timing] submits=%llu draws=%llu dispatches=%llu avg_ms: total=%.2f "
+                         "realize_draws=%.2f realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f\n",
+                         (unsigned long long)totals.submits, (unsigned long long)totals.draws,
+                         (unsigned long long)totals.dispatches, total / n, totals.realize_draws / n,
+                         totals.realize_compute / n, totals.plan / n, totals.backend / n,
+                         totals.publish / n);
+        }
+    }
+    return presented;
 }
 
 bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -17,6 +17,8 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <iterator>
+#include <mutex>
 #include <set>
 #include <vector>
 #include <unordered_map>
@@ -54,6 +56,213 @@ void read_user_sgprs(const std::unordered_map<uint32_t, uint32_t>& sh, uint32_t 
 // envs. Set (and cleared) by realize_draw_item's failure replay — the submit path is serialized
 // by the HLE submit mutex, so a plain global is safe there.
 bool g_dyntrace_force = false;
+
+namespace {
+
+struct ShaderResourceCompileKey {
+    uint32_t cls = 0;
+    uint32_t format = 0;
+    uint32_t num_components = 0;
+    uint32_t binding = 0;
+    uint32_t stride = 0;
+    uint32_t srt_offset = 0;
+    uint32_t sgpr_base = 0;
+    uint32_t fetch_pc = 0;
+
+    bool operator==(const ShaderResourceCompileKey&) const = default;
+};
+
+struct ShaderCompileKey {
+    ShaderProgramStage stage = ShaderProgramStage::Vertex;
+    bool has_resource_table = false;
+    bool force_position_w = false;
+    std::vector<uint32_t> code;
+    std::vector<ShaderResourceCompileKey> resources;
+
+    bool operator==(const ShaderCompileKey&) const = default;
+};
+
+static uint64_t hash_mix(uint64_t hash, uint64_t value) {
+    // FNV-1a over fixed-width values. Equality still compares the full key, so collisions are benign.
+    for (unsigned i = 0; i < 8; ++i) {
+        hash ^= static_cast<uint8_t>(value >> (i * 8));
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+struct ShaderCompileKeyHash {
+    size_t operator()(const ShaderCompileKey& key) const {
+        uint64_t hash = 1469598103934665603ull;
+        hash = hash_mix(hash, static_cast<uint32_t>(key.stage));
+        hash = hash_mix(hash, key.has_resource_table);
+        hash = hash_mix(hash, key.force_position_w);
+        hash = hash_mix(hash, key.code.size());
+        for (uint32_t word : key.code) hash = hash_mix(hash, word);
+        hash = hash_mix(hash, key.resources.size());
+        for (const auto& resource : key.resources) {
+            hash = hash_mix(hash, resource.cls);
+            hash = hash_mix(hash, resource.format);
+            hash = hash_mix(hash, resource.num_components);
+            hash = hash_mix(hash, resource.binding);
+            hash = hash_mix(hash, resource.stride);
+            hash = hash_mix(hash, resource.srt_offset);
+            hash = hash_mix(hash, resource.sgpr_base);
+            hash = hash_mix(hash, resource.fetch_pc);
+        }
+        return static_cast<size_t>(hash);
+    }
+};
+
+struct CachedShader {
+    std::vector<uint32_t> spirv;
+    uint64_t last_use = 0;
+    uint64_t bytes = 0;
+};
+
+struct ShaderCache {
+    std::mutex mutex;
+    std::unordered_map<ShaderCompileKey, CachedShader, ShaderCompileKeyHash> entries;
+    ShaderRecompileCacheStats stats;
+    uint64_t use_counter = 0;
+};
+
+ShaderCache& shader_cache() {
+    static ShaderCache cache;
+    return cache;
+}
+
+uint64_t shader_cache_limit_bytes() {
+    constexpr uint64_t default_bytes = 128ull * 1024 * 1024;
+    const char* value = getenv("PROSPER_SHADER_CACHE_MB");
+    if (!value || !*value) return default_bytes;
+    char* end = nullptr;
+    const unsigned long long mib = strtoull(value, &end, 10);
+    if (end == value || *end != '\0') return default_bytes;
+    return std::min<uint64_t>(mib, 4096ull) * 1024 * 1024;
+}
+
+uint64_t shader_cache_entry_bytes(const ShaderCompileKey& key, const std::vector<uint32_t>& spirv) {
+    return static_cast<uint64_t>(key.code.size()) * sizeof(uint32_t) +
+           static_cast<uint64_t>(key.resources.size()) * sizeof(ShaderResourceCompileKey) +
+           static_cast<uint64_t>(spirv.size()) * sizeof(uint32_t);
+}
+
+ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_t* code, size_t dwords,
+                                         const ShaderResourceTable* resources) {
+    ShaderCompileKey key;
+    key.stage = stage;
+    key.has_resource_table = resources != nullptr;
+    key.force_position_w = getenv("PROSPER_FORCE_W") != nullptr;
+    if (code && dwords) {
+        std::vector<Rdna2Inst> instructions;
+        const size_t consumed = rdna2_walk(code, dwords, instructions);
+        key.code.assign(code, code + consumed);
+    }
+    if (resources) {
+        key.resources.reserve(resources->resources.size());
+        for (const auto& resource : resources->resources) {
+            key.resources.push_back({
+                static_cast<uint32_t>(resource.cls), static_cast<uint32_t>(resource.format),
+                resource.num_components, resource.binding, resource.stride,
+                resource.srt_offset, resource.sgpr_base, resource.fetch_pc,
+            });
+        }
+    }
+    return key;
+}
+
+std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const ShaderCompileKey& key,
+                                              const ShaderResourceTable* resources) {
+    const uint32_t* code = key.code.empty() ? nullptr : key.code.data();
+    if (stage == ShaderProgramStage::Vertex)
+        return recompile_vertex(code, key.code.size(), resources);
+    if (stage == ShaderProgramStage::Fragment)
+        return recompile_fragment(code, key.code.size(), resources);
+    return {};
+}
+
+} // namespace
+
+std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
+                                                       const uint32_t* code, size_t dwords,
+                                                       const ShaderResourceTable* resources) {
+    ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources);
+    if (getenv("PROSPER_NO_SHADER_CACHE")) {
+        auto& cache = shader_cache();
+        {
+            std::lock_guard lock(cache.mutex);
+            ++cache.stats.bypasses;
+        }
+        return compile_graphics_shader(stage, key, resources);
+    }
+
+    auto& cache = shader_cache();
+    std::lock_guard lock(cache.mutex);
+    auto found = cache.entries.find(key);
+    if (found != cache.entries.end()) {
+        ++cache.stats.hits;
+        found->second.last_use = ++cache.use_counter;
+        return found->second.spirv;
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    std::vector<uint32_t> spirv = compile_graphics_shader(stage, key, resources);
+    const auto end = std::chrono::steady_clock::now();
+    ++cache.stats.misses;
+    cache.stats.compile_ms += std::chrono::duration<double, std::milli>(end - start).count();
+
+    constexpr size_t max_entries = 4096;
+    const uint64_t bytes = shader_cache_entry_bytes(key, spirv);
+    const uint64_t limit = shader_cache_limit_bytes();
+    while (!cache.entries.empty() &&
+           (cache.entries.size() >= max_entries || cache.stats.bytes + bytes > limit)) {
+        auto oldest = cache.entries.begin();
+        for (auto it = std::next(cache.entries.begin()); it != cache.entries.end(); ++it)
+            if (it->second.last_use < oldest->second.last_use) oldest = it;
+        cache.stats.bytes -= oldest->second.bytes;
+        cache.entries.erase(oldest);
+        ++cache.stats.evictions;
+    }
+    if (bytes <= limit && max_entries != 0) {
+        CachedShader value;
+        value.spirv = spirv;
+        value.last_use = ++cache.use_counter;
+        value.bytes = bytes;
+        cache.stats.bytes += bytes;
+        cache.entries.emplace(std::move(key), std::move(value));
+    }
+    cache.stats.entries = cache.entries.size();
+    return spirv;
+}
+
+ShaderRecompileCacheStats shader_recompile_cache_stats() {
+    auto& cache = shader_cache();
+    std::lock_guard lock(cache.mutex);
+    ShaderRecompileCacheStats result = cache.stats;
+    result.entries = cache.entries.size();
+    return result;
+}
+
+void clear_shader_recompile_cache() {
+    auto& cache = shader_cache();
+    std::lock_guard lock(cache.mutex);
+    cache.entries.clear();
+    cache.stats = {};
+    cache.use_counter = 0;
+}
+
+thread_local DrawRealizationPhaseStats g_draw_realization_phases;
+
+void record_draw_realization_phases(double table_ms, double shader_ms) {
+    ++g_draw_realization_phases.draws;
+    g_draw_realization_phases.table_ms += table_ms;
+    g_draw_realization_phases.shader_ms += shader_ms;
+}
+
+DrawRealizationPhaseStats draw_realization_phase_stats() {
+    return g_draw_realization_phases;
+}
 
 // Readability probe (guest memory is 1:1-mapped, but a mis-decoded address could be unmapped),
 // so guarded derefs on the render/submit thread don't risk a SIGSEGV. NOTE: /dev/null does NOT
@@ -612,7 +821,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
         // shader's s[8:11]/s[24:25] descriptor pointers to the register file at GS_0+offset).
-        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 8, &srt_uses);
+        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+                                       sgprs, kUserSgprs, 8, &srt_uses);
         if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_RESDUMP")) {
             fprintf(stderr, "[dynvb] VS resolved %zu dynamic vertex-fetch descriptor(s):\n", dyn_vb.size());
             for (auto& kv : dyn_vb) {
@@ -1545,11 +1755,19 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+    const ShaderRecompileCacheStats shader_before = timing_enabled
+        ? shader_recompile_cache_stats() : ShaderRecompileCacheStats{};
+    const DrawRealizationPhaseStats phases_before = timing_enabled
+        ? draw_realization_phase_stats() : DrawRealizationPhaseStats{};
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
     std::vector<DrawItem> draws = g_live && width && height
         ? realize_gpustate_draws(st, 0x10000, sx, sy) : std::vector<DrawItem>{};
+    const ShaderRecompileCacheStats shader_after = timing_enabled
+        ? shader_recompile_cache_stats() : ShaderRecompileCacheStats{};
+    const DrawRealizationPhaseStats phases_after = timing_enabled
+        ? draw_realization_phase_stats() : DrawRealizationPhaseStats{};
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<ComputeItem> computes = g_compute
         ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
@@ -1578,29 +1796,63 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
             return std::chrono::duration<double, std::milli>(end - begin).count();
         };
         struct TimingTotals {
-            uint64_t submits = 0, draws = 0, dispatches = 0;
+            uint64_t submits = 0, draws = 0, dispatches = 0, render_spans = 0;
+            uint64_t shader_hits = 0, shader_misses = 0, shader_bypasses = 0;
             double realize_draws = 0, realize_compute = 0, plan = 0, backend = 0, publish = 0;
+            double table_build = 0, shader_lookup = 0, shader_compile = 0;
         };
         static TimingTotals totals;
-        totals.submits++;
-        totals.draws += draws.size();
-        totals.dispatches += computes.size();
-        totals.realize_draws += ms(timing_start, timing_draws_ready);
-        totals.realize_compute += ms(timing_draws_ready, timing_compute_ready);
-        totals.plan += ms(timing_compute_ready, timing_plan_ready);
-        totals.backend += ms(timing_plan_ready, timing_backend_done);
-        totals.publish += ms(timing_backend_done, timing_done);
+        static TimingTotals window;
+        auto accumulate = [&](TimingTotals& timing) {
+            timing.submits++;
+            timing.draws += draws.size();
+            timing.dispatches += computes.size();
+            timing.render_spans += result.render_spans;
+            timing.shader_hits += shader_after.hits - shader_before.hits;
+            timing.shader_misses += shader_after.misses - shader_before.misses;
+            timing.shader_bypasses += shader_after.bypasses - shader_before.bypasses;
+            timing.realize_draws += ms(timing_start, timing_draws_ready);
+            timing.realize_compute += ms(timing_draws_ready, timing_compute_ready);
+            timing.plan += ms(timing_compute_ready, timing_plan_ready);
+            timing.backend += ms(timing_plan_ready, timing_backend_done);
+            timing.publish += ms(timing_backend_done, timing_done);
+            timing.table_build += phases_after.table_ms - phases_before.table_ms;
+            timing.shader_lookup += phases_after.shader_ms - phases_before.shader_ms;
+            timing.shader_compile += shader_after.compile_ms - shader_before.compile_ms;
+        };
+        accumulate(totals);
+        accumulate(window);
         if (totals.submits % 25 == 0) {
             const double n = static_cast<double>(totals.submits);
             const double total = totals.realize_draws + totals.realize_compute + totals.plan +
                                  totals.backend + totals.publish;
             std::fprintf(stderr,
-                         "[render-timing] submits=%llu draws=%llu dispatches=%llu avg_ms: total=%.2f "
+                         "[render-timing] submits=%llu draws=%llu dispatches=%llu spans=%llu "
+                         "avg_ms: total=%.2f "
                          "realize_draws=%.2f realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f\n",
                          (unsigned long long)totals.submits, (unsigned long long)totals.draws,
-                         (unsigned long long)totals.dispatches, total / n, totals.realize_draws / n,
-                         totals.realize_compute / n, totals.plan / n, totals.backend / n,
-                         totals.publish / n);
+                         (unsigned long long)totals.dispatches,
+                         (unsigned long long)totals.render_spans, total / n,
+                         totals.realize_draws / n, totals.realize_compute / n, totals.plan / n,
+                         totals.backend / n, totals.publish / n);
+            const double wn = static_cast<double>(window.submits);
+            const double window_total = window.realize_draws + window.realize_compute + window.plan +
+                                        window.backend + window.publish;
+            std::fprintf(stderr,
+                         "[render-window] submits=%llu avg_items: draws=%.1f dispatches=%.1f "
+                         "spans=%.1f shaders: hit=%.1f miss=%.1f bypass=%.1f "
+                         "avg_ms: total=%.2f realize_draws=%.2f tables=%.2f shader_lookup=%.2f "
+                         "shader_compile=%.2f "
+                         "realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f\n",
+                         (unsigned long long)window.submits, window.draws / wn,
+                         window.dispatches / wn, window.render_spans / wn,
+                         window.shader_hits / wn, window.shader_misses / wn,
+                         window.shader_bypasses / wn, window_total / wn,
+                         window.realize_draws / wn, window.table_build / wn,
+                         window.shader_lookup / wn, window.shader_compile / wn,
+                         window.realize_compute / wn, window.plan / wn, window.backend / wn,
+                         window.publish / wn);
+            window = {};
         }
     }
     return presented;

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -86,12 +86,39 @@ inline uint32_t sw4kb_morton(uint32_t ix, uint32_t iy, uint32_t bx, uint32_t by)
     }
     return m;
 }
-// Element (x,y) -> its linear element INDEX in the tiled surface: tiles laid out row-major over the
-// padded pitch, sw4kb_morton within a tile.
-inline uint64_t sw4kb_index(uint32_t x, uint32_t y, uint32_t tiles_per_row, uint32_t bx, uint32_t by) {
-    uint32_t tw = 1u << bx, th = 1u << by;
-    uint32_t tx = x >> bx, ty = y >> by, ix = x & (tw - 1), iy = y & (th - 1);
-    return (uint64_t)(ty * tiles_per_row + tx) * ((uint64_t)tw * th) + sw4kb_morton(ix, iy, bx, by);
+
+struct Sw4kbLookup {
+    uint32_t bx = 0, by = 0, tw = 0, th = 0;
+    std::vector<uint16_t> byte_offsets;
+};
+
+Sw4kbLookup make_sw4kb_lookup(uint32_t bpe) {
+    Sw4kbLookup lookup;
+    sw4kb_dims(bpe, lookup.bx, lookup.by);
+    lookup.tw = 1u << lookup.bx;
+    lookup.th = 1u << lookup.by;
+    lookup.byte_offsets.resize(static_cast<size_t>(lookup.tw) * lookup.th);
+    for (uint32_t y = 0; y < lookup.th; ++y)
+        for (uint32_t x = 0; x < lookup.tw; ++x)
+            lookup.byte_offsets[static_cast<size_t>(y) * lookup.tw + x] =
+                static_cast<uint16_t>(sw4kb_morton(x, y, lookup.bx, lookup.by) * bpe);
+    return lookup;
+}
+
+const Sw4kbLookup& sw4kb_lookup(uint32_t bpe) {
+    static const Sw4kbLookup b1 = make_sw4kb_lookup(1);
+    static const Sw4kbLookup b2 = make_sw4kb_lookup(2);
+    static const Sw4kbLookup b4 = make_sw4kb_lookup(4);
+    static const Sw4kbLookup b8 = make_sw4kb_lookup(8);
+    static const Sw4kbLookup b16 = make_sw4kb_lookup(16);
+    switch (bpe) {
+        case 1: return b1;
+        case 2: return b2;
+        case 4: return b4;
+        case 8: return b8;
+        case 16: return b16;
+        default: return b1;
+    }
 }
 
 // The single tiled<->linear walk every public function shares: per element, the tiled offset
@@ -101,17 +128,35 @@ inline uint64_t sw4kb_index(uint32_t x, uint32_t y, uint32_t tiles_per_row, uint
 template <bool ToTiled>
 void sw4kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uint32_t pitch,
                 uint32_t bpe, size_t tiled_bytes) {
-    uint32_t bx = 0, by = 0; sw4kb_dims(bpe, bx, by);
+    const Sw4kbLookup& lookup = sw4kb_lookup(bpe);
     uint32_t pw = pitch ? pitch : ew;
-    uint32_t tiles_per_row = (pw + (1u << bx) - 1) >> bx;
-    for (uint32_t y = 0; y < eh; y++)
-        for (uint32_t x = 0; x < ew; x++) {
-            uint64_t t = sw4kb_index(x, y, tiles_per_row, bx, by) * bpe;   // tiled offset
-            size_t   l = ((size_t)y * ew + x) * bpe;                       // linear offset
-            if (ToTiled) { if (t + bpe <= tiled_bytes) std::memcpy(dst + t, src + l, bpe); }
-            else         { if (t + bpe <= tiled_bytes) std::memcpy(dst + l, src + t, bpe);
-                           else                        std::memset(dst + l, 0, bpe); }
+    uint32_t tiles_per_row = (pw + lookup.tw - 1) / lookup.tw;
+    uint32_t surface_tile_rows = (eh + lookup.th - 1) / lookup.th;
+    uint32_t surface_tile_cols = (ew + lookup.tw - 1) / lookup.tw;
+    for (uint32_t ty = 0; ty < surface_tile_rows; ++ty) {
+        const uint32_t rows = std::min(lookup.th, eh - ty * lookup.th);
+        for (uint32_t tx = 0; tx < surface_tile_cols; ++tx) {
+            const uint32_t columns = std::min(lookup.tw, ew - tx * lookup.tw);
+            const size_t tile_base = static_cast<size_t>(ty * tiles_per_row + tx) * 4096;
+            for (uint32_t iy = 0; iy < rows; ++iy) {
+                const size_t linear_base =
+                    (static_cast<size_t>(ty * lookup.th + iy) * ew + tx * lookup.tw) * bpe;
+                const uint16_t* offsets =
+                    lookup.byte_offsets.data() + static_cast<size_t>(iy) * lookup.tw;
+                for (uint32_t ix = 0; ix < columns; ++ix) {
+                    const size_t tiled = tile_base + offsets[ix];
+                    const size_t linear = linear_base + static_cast<size_t>(ix) * bpe;
+                    if (ToTiled) {
+                        if (tiled + bpe <= tiled_bytes) std::memcpy(dst + tiled, src + linear, bpe);
+                    } else if (tiled + bpe <= tiled_bytes) {
+                        std::memcpy(dst + linear, src + tiled, bpe);
+                    } else {
+                        std::memset(dst + linear, 0, bpe);
+                    }
+                }
+            }
         }
+    }
 }
 
 size_t sw4kb_tiled_bytes(uint32_t ew, uint32_t eh, uint32_t pitch, uint32_t bpe) {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -11,6 +11,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -192,6 +194,133 @@ inline const RenderVkCtx& render_vk_ctx() {
         return r;
     }();
     return c;
+}
+
+// Each call waits for its fence before cleanup, so transient allocations can be safely recycled by
+// exact Vulkan memory requirements. Keeping only the memory object avoids changing image layouts or
+// descriptor lifetimes while removing the driver's expensive allocate/free churn between batches.
+struct RenderMemoryKey {
+    VkDeviceSize bytes = 0;
+    uint32_t memory_type = UINT32_MAX;
+    bool operator==(const RenderMemoryKey& other) const {
+        return bytes == other.bytes && memory_type == other.memory_type;
+    }
+};
+
+struct RenderMemoryKeyHash {
+    size_t operator()(const RenderMemoryKey& key) const {
+        return std::hash<uint64_t>{}(static_cast<uint64_t>(key.bytes)) ^
+               (std::hash<uint32_t>{}(key.memory_type) << 1);
+    }
+};
+
+struct RenderMemoryPool {
+    std::mutex mutex;
+    std::unordered_map<RenderMemoryKey, std::vector<VkDeviceMemory>, RenderMemoryKeyHash> available;
+    std::unordered_map<VkDeviceMemory, RenderMemoryKey> active;
+    VkDeviceSize cached_bytes = 0;
+    size_t cached_allocations = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t discarded = 0;
+};
+
+struct RenderMemoryPoolStats {
+    VkDeviceSize cached_bytes = 0;
+    size_t cached_allocations = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t discarded = 0;
+};
+
+inline RenderMemoryPool& render_memory_pool() {
+    static RenderMemoryPool pool;
+    return pool;
+}
+
+inline bool render_memory_pool_enabled() {
+    static const bool enabled = getenv("PROSPER_NO_MEMORY_POOL") == nullptr;
+    return enabled;
+}
+
+inline VkDeviceSize render_memory_pool_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = getenv("PROSPER_MEMORY_POOL_MB");
+        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 512ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
+
+inline VkDeviceMemory allocate_transient_render_memory(VkDevice device, VkDeviceSize bytes,
+                                                       uint32_t memory_type) {
+    if (memory_type == UINT32_MAX) return VK_NULL_HANDLE;
+    RenderMemoryKey key{bytes, memory_type};
+    if (render_memory_pool_enabled()) {
+        RenderMemoryPool& pool = render_memory_pool();
+        std::lock_guard<std::mutex> lock(pool.mutex);
+        auto found = pool.available.find(key);
+        if (found != pool.available.end() && !found->second.empty()) {
+            VkDeviceMemory memory = found->second.back();
+            found->second.pop_back();
+            if (found->second.empty()) pool.available.erase(found);
+            pool.cached_bytes -= bytes;
+            --pool.cached_allocations;
+            ++pool.hits;
+            pool.active.emplace(memory, key);
+            return memory;
+        }
+        ++pool.misses;
+    }
+
+    VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    allocation.allocationSize = bytes;
+    allocation.memoryTypeIndex = memory_type;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    if (vkAllocateMemory(device, &allocation, nullptr, &memory) != VK_SUCCESS) return VK_NULL_HANDLE;
+    if (render_memory_pool_enabled()) {
+        RenderMemoryPool& pool = render_memory_pool();
+        std::lock_guard<std::mutex> lock(pool.mutex);
+        pool.active.emplace(memory, key);
+    }
+    return memory;
+}
+
+inline void release_transient_render_memory(VkDevice device, VkDeviceMemory memory) {
+    if (!memory) return;
+    if (!render_memory_pool_enabled()) {
+        vkFreeMemory(device, memory, nullptr);
+        return;
+    }
+
+    RenderMemoryPool& pool = render_memory_pool();
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    auto found = pool.active.find(memory);
+    if (found == pool.active.end()) {
+        vkFreeMemory(device, memory, nullptr);
+        return;
+    }
+    const RenderMemoryKey key = found->second;
+    pool.active.erase(found);
+    constexpr size_t max_cached_allocations = 4096;
+    const VkDeviceSize limit = render_memory_pool_limit();
+    const VkDeviceSize remaining = pool.cached_bytes < limit ? limit - pool.cached_bytes : 0;
+    if (pool.cached_allocations >= max_cached_allocations ||
+        key.bytes > remaining) {
+        ++pool.discarded;
+        vkFreeMemory(device, memory, nullptr);
+        return;
+    }
+    pool.available[key].push_back(memory);
+    pool.cached_bytes += key.bytes;
+    ++pool.cached_allocations;
+}
+
+inline RenderMemoryPoolStats render_memory_pool_stats() {
+    RenderMemoryPool& pool = render_memory_pool();
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    return {pool.cached_bytes, pool.cached_allocations, pool.hits, pool.misses, pool.discarded};
 }
 
 inline uint32_t render_memory_type(VkPhysicalDevice phys, uint32_t bits,
@@ -650,7 +779,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkMemoryRequirements ir; vkGetImageMemoryRequirements(dev, img, &ir);
     VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
     iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
-    VkDeviceMemory imem; vkAllocateMemory(dev, &iai, nullptr, &imem); vkBindImageMemory(dev, img, imem, 0);
+    VkDeviceMemory imem = allocate_transient_render_memory(dev, iai.allocationSize,
+                                                            iai.memoryTypeIndex);
+    vkBindImageMemory(dev, img, imem, 0);
     VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
     ivci.image = img; ivci.viewType = VK_IMAGE_VIEW_TYPE_2D; ivci.format = FMT;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -667,7 +798,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkMemoryRequirements dr; vkGetImageMemoryRequirements(dev, dimg, &dr);
         VkMemoryAllocateInfo dai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
         dai.allocationSize = dr.size; dai.memoryTypeIndex = pick(dr.memoryTypeBits, 0);
-        vkAllocateMemory(dev, &dai, nullptr, &dmem); vkBindImageMemory(dev, dimg, dmem, 0);
+        if (cached_ds) vkAllocateMemory(dev, &dai, nullptr, &dmem);
+        else dmem = allocate_transient_render_memory(dev, dai.allocationSize,
+                                                      dai.memoryTypeIndex);
+        vkBindImageMemory(dev, dimg, dmem, 0);
         VkImageViewCreateInfo dvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         dvci.image = dimg; dvci.viewType = VK_IMAGE_VIEW_TYPE_2D; dvci.format = DFMT;
         dvci.subresourceRange = {DASPECT, 0, 1, 0, 1};
@@ -750,7 +884,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             VkMemoryRequirements imr; vkGetBufferMemoryRequirements(dev, v.ibuf, &imr);
             VkMemoryAllocateInfo imai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; imai.allocationSize = imr.size;
             imai.memoryTypeIndex = pick(imr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-            vkAllocateMemory(dev, &imai, nullptr, &v.ibmem); vkBindBufferMemory(dev, v.ibuf, v.ibmem, 0);
+            v.ibmem = allocate_transient_render_memory(dev, imai.allocationSize,
+                                                        imai.memoryTypeIndex);
+            vkBindBufferMemory(dev, v.ibuf, v.ibmem, 0);
             void* ip = nullptr; vkMapMemory(dev, v.ibmem, 0, isz, 0, &ip);
             std::memcpy(ip, bd.indices.data(), (size_t)isz); vkUnmapMemory(dev, v.ibmem);
             v.icount = (uint32_t)bd.indices.size();
@@ -882,7 +1018,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     vkCreateImage(dev, &tci, nullptr, &v.timg[i]);
                     VkMemoryRequirements tr; vkGetImageMemoryRequirements(dev, v.timg[i], &tr);
                     VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; tai.allocationSize = tr.size;
-                    tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0); vkAllocateMemory(dev, &tai, nullptr, &v.tmem[i]);
+                    tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0);
+                    v.tmem[i] = allocate_transient_render_memory(dev, tai.allocationSize,
+                                                                  tai.memoryTypeIndex);
                     vkBindImageMemory(dev, v.timg[i], v.tmem[i], 0);
                     VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
                     // NOTE(#263): r.srgb carries whether the T# is a gamma-encoded (sRGB) surface, but we
@@ -962,7 +1100,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, v.tstage[i], &sr);
                     VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; sai.allocationSize = sr.size;
                     sai.memoryTypeIndex = pick(sr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                    vkAllocateMemory(dev, &sai, nullptr, &v.tstagemem[i]); vkBindBufferMemory(dev, v.tstage[i], v.tstagemem[i], 0);
+                    v.tstagemem[i] = allocate_transient_render_memory(dev, sai.allocationSize,
+                                                                      sai.memoryTypeIndex);
+                    vkBindBufferMemory(dev, v.tstage[i], v.tstagemem[i], 0);
                     void* sp = nullptr; vkMapMemory(dev, v.tstagemem[i], 0, tbytes, 0, &sp);
                     std::memcpy(sp, r.tex_rgba, (size_t)tbytes); vkUnmapMemory(dev, v.tstagemem[i]);
                     dii[i] = {v.tsamp[i], v.tview[i], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
@@ -977,7 +1117,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     VkMemoryRequirements mr; vkGetBufferMemoryRequirements(dev, v.sbuf[i], &mr);
                     VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; mai.allocationSize = mr.size;
                     mai.memoryTypeIndex = pick(mr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                    vkAllocateMemory(dev, &mai, nullptr, &v.sbmem[i]); vkBindBufferMemory(dev, v.sbuf[i], v.sbmem[i], 0);
+                    v.sbmem[i] = allocate_transient_render_memory(dev, mai.allocationSize,
+                                                                  mai.memoryTypeIndex);
+                    vkBindBufferMemory(dev, v.sbuf[i], v.sbmem[i], 0);
                     void* p = nullptr; vkMapMemory(dev, v.sbmem[i], 0, sz, 0, &p);
                     if (r.dwords.empty()) ((uint32_t*)p)[0] = 0; else std::memcpy(p, r.dwords.data(), r.dwords.size() * 4);
                     vkUnmapMemory(dev, v.sbmem[i]);
@@ -1030,7 +1172,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
     if (bai.memoryTypeIndex == UINT32_MAX)
         bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent);
-    VkDeviceMemory bmem; vkAllocateMemory(dev, &bai, nullptr, &bmem); vkBindBufferMemory(dev, rb, bmem, 0);
+    VkDeviceMemory bmem = allocate_transient_render_memory(dev, bai.allocationSize,
+                                                            bai.memoryTypeIndex);
+    vkBindBufferMemory(dev, rb, bmem, 0);
 
     VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO}; pci.queueFamilyIndex = qfi;
     VkCommandPool pool; vkCreateCommandPool(dev, &pci, nullptr, &pool);
@@ -1049,7 +1193,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, seedbuf, &sr);
         VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; sai.allocationSize = sr.size;
         sai.memoryTypeIndex = pick(sr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-        vkAllocateMemory(dev, &sai, nullptr, &seedmem); vkBindBufferMemory(dev, seedbuf, seedmem, 0);
+        seedmem = allocate_transient_render_memory(dev, sai.allocationSize,
+                                                    sai.memoryTypeIndex);
+        vkBindBufferMemory(dev, seedbuf, seedmem, 0);
         void* sp = nullptr; vkMapMemory(dev, seedmem, 0, bytes, 0, &sp);
         memcpy(sp, seed_rgba, (size_t)bytes); vkUnmapMemory(dev, seedmem);
         VkImageMemoryBarrier s0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
@@ -1143,9 +1289,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         cached_ds->stencil_valid |= use_stencil;
     }
 
-    out.resize(bytes);
     void* mp = nullptr; vkMapMemory(dev, bmem, 0, bytes, 0, &mp);
-    std::memcpy(out.data(), mp, static_cast<size_t>(bytes));
+    const auto* readback = static_cast<const uint8_t*>(mp);
+    // A range assignment constructs directly from the mapped pixels. resize()+memcpy first zeroed the
+    // entire 8.3 MiB 1080p vector even though every byte was immediately overwritten.
+    out.assign(readback, readback + static_cast<size_t>(bytes));
     vkUnmapMemory(dev, bmem);
     const auto timing_readback_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
 
@@ -1233,29 +1381,30 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (v.pipe)   vkDestroyPipeline(dev, v.pipe, nullptr);
         if (v.layout) vkDestroyPipelineLayout(dev, v.layout, nullptr);
         if (v.ibuf)   vkDestroyBuffer(dev, v.ibuf, nullptr);
-        if (v.ibmem)  vkFreeMemory(dev, v.ibmem, nullptr);
+        if (v.ibmem)  release_transient_render_memory(dev, v.ibmem);
         if (v.vs)     vkDestroyShaderModule(dev, v.vs, nullptr);
         if (v.fs)     vkDestroyShaderModule(dev, v.fs, nullptr);
         if (v.dpool)  vkDestroyDescriptorPool(dev, v.dpool, nullptr);
         for (auto d : v.dsls) if (d) vkDestroyDescriptorSetLayout(dev, d, nullptr);
         for (size_t i = 0; i < v.R.size(); i++) {
             if (v.sbuf[i])     vkDestroyBuffer(dev, v.sbuf[i], nullptr);
-            if (v.sbmem[i])    vkFreeMemory(dev, v.sbmem[i], nullptr);
+            if (v.sbmem[i])    release_transient_render_memory(dev, v.sbmem[i]);
             if (v.tsamp[i])    vkDestroySampler(dev, v.tsamp[i], nullptr);
             if (v.tview[i])    vkDestroyImageView(dev, v.tview[i], nullptr);
             if (v.timg[i])     vkDestroyImage(dev, v.timg[i], nullptr);
-            if (v.tmem[i])     vkFreeMemory(dev, v.tmem[i], nullptr);
+            if (v.tmem[i])     release_transient_render_memory(dev, v.tmem[i]);
             if (v.tstage[i])   vkDestroyBuffer(dev, v.tstage[i], nullptr);
-            if (v.tstagemem[i])vkFreeMemory(dev, v.tstagemem[i], nullptr);
+            if (v.tstagemem[i])release_transient_render_memory(dev, v.tstagemem[i]);
         }
     }
     if (seedbuf) vkDestroyBuffer(dev, seedbuf, nullptr);
-    if (seedmem) vkFreeMemory(dev, seedmem, nullptr);
-    vkDestroyBuffer(dev, rb, nullptr); vkFreeMemory(dev, bmem, nullptr);
+    if (seedmem) release_transient_render_memory(dev, seedmem);
+    vkDestroyBuffer(dev, rb, nullptr); release_transient_render_memory(dev, bmem);
     vkDestroyFramebuffer(dev, fb, nullptr); vkDestroyRenderPass(dev, rp, nullptr); vkDestroyImageView(dev, view, nullptr);
-    vkDestroyImage(dev, img, nullptr); vkFreeMemory(dev, imem, nullptr);
+    vkDestroyImage(dev, img, nullptr); release_transient_render_memory(dev, imem);
     if (use_ds && !cached_ds) {
-        vkDestroyImageView(dev, dview, nullptr); vkDestroyImage(dev, dimg, nullptr); vkFreeMemory(dev, dmem, nullptr);
+        vkDestroyImageView(dev, dview, nullptr); vkDestroyImage(dev, dimg, nullptr);
+        release_transient_render_memory(dev, dmem);
     }
     if (timing_enabled) {
         const auto timing_done = TimingClock::now();
@@ -1267,14 +1416,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
         };
         static TimingTotals totals;
-        totals.calls++;
-        totals.draws += draws.size();
-        totals.target += ms(timing_start, timing_target_ready);
-        totals.draw_setup += ms(timing_target_ready, timing_draws_ready);
-        totals.record += ms(timing_draws_ready, timing_recorded);
-        totals.gpu_wait += ms(timing_recorded, timing_gpu_done);
-        totals.readback += ms(timing_gpu_done, timing_readback_done);
-        totals.cleanup += ms(timing_readback_done, timing_done);
+        static TimingTotals window;
+        auto accumulate = [&](TimingTotals& timing) {
+            timing.calls++;
+            timing.draws += draws.size();
+            timing.target += ms(timing_start, timing_target_ready);
+            timing.draw_setup += ms(timing_target_ready, timing_draws_ready);
+            timing.record += ms(timing_draws_ready, timing_recorded);
+            timing.gpu_wait += ms(timing_recorded, timing_gpu_done);
+            timing.readback += ms(timing_gpu_done, timing_readback_done);
+            timing.cleanup += ms(timing_readback_done, timing_done);
+        };
+        accumulate(totals);
+        accumulate(window);
         if (totals.calls % 25 == 0) {
             const double n = static_cast<double>(totals.calls);
             const double total = totals.target + totals.draw_setup + totals.record +
@@ -1285,6 +1439,24 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     (unsigned long long)totals.calls, (unsigned long long)totals.draws, total / n,
                     totals.target / n, totals.draw_setup / n, totals.record / n,
                     totals.gpu_wait / n, totals.readback / n, totals.cleanup / n);
+            const RenderMemoryPoolStats pool = render_memory_pool_stats();
+            fprintf(stderr,
+                    "[render-timing] memory_pool hits=%llu misses=%llu cached=%zu %.1f MiB "
+                    "discarded=%llu\n",
+                    (unsigned long long)pool.hits, (unsigned long long)pool.misses,
+                    pool.cached_allocations,
+                    static_cast<double>(pool.cached_bytes) / (1024.0 * 1024.0),
+                    (unsigned long long)pool.discarded);
+            const double wn = static_cast<double>(window.calls);
+            const double window_total = window.target + window.draw_setup + window.record +
+                                        window.gpu_wait + window.readback + window.cleanup;
+            fprintf(stderr,
+                    "[render-window] backend calls=%llu draws=%.1f avg_ms: total=%.2f target=%.2f "
+                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                    (unsigned long long)window.calls, window.draws / wn, window_total / wn,
+                    window.target / wn, window.draw_setup / wn, window.record / wn,
+                    window.gpu_wait / wn, window.readback / wn, window.cleanup / wn);
+            window = {};
         }
     }
     // NB: dev/instance are the persistent RenderVkCtx — do NOT destroy them here (reused across calls).

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.h>
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/render_state.hpp"
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -506,6 +507,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                                               const uint8_t* seed_rgba = nullptr,
                                               const float* clear_rgba = nullptr,
                                               bool persist_depth_stencil = false) {
+    using TimingClock = std::chrono::steady_clock;
+    const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<uint8_t> out;
     if (draws.empty()) return out;
     const RenderVkCtx& ctx = render_vk_ctx();
@@ -715,6 +719,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         s.codeSize = c.size() * 4; s.pCode = c.data(); VkShaderModule m = VK_NULL_HANDLE;
         vkCreateShaderModule(dev, &s, nullptr, &m); return m; };
     // Per-draw Vulkan objects — kept alive until after the queue submit, freed at the end.
+    const auto timing_target_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     struct DV {
         VkShaderModule vs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
         std::vector<FrameResource> R;
@@ -1009,12 +1014,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) v.ok = true;
     }
 
+    const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     VkDeviceSize bytes = (VkDeviceSize)W * H * 4;
     VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; bci.size = bytes; bci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     VkBuffer rb; vkCreateBuffer(dev, &bci, nullptr, &rb);
     VkMemoryRequirements br; vkGetBufferMemoryRequirements(dev, rb, &br);
     VkMemoryAllocateInfo bai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; bai.allocationSize = br.size;
-    bai.memoryTypeIndex = pick(br.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    // Prefer cached host memory for GPU -> CPU readback. Discrete NVIDIA exposes an earlier coherent,
+    // write-combined BAR type and a later HOST_CACHED type; the generic first-match selector chose the
+    // former, making an 8 MiB 1080p read take roughly 570 ms on Windows. Upload buffers deliberately keep
+    // the write-combined type. Integrated GPUs and portability drivers may not expose HOST_CACHED, so fall
+    // back to the original required flags.
+    constexpr VkMemoryPropertyFlags host_coherent =
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+    if (bai.memoryTypeIndex == UINT32_MAX)
+        bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent);
     VkDeviceMemory bmem; vkAllocateMemory(dev, &bai, nullptr, &bmem); vkBindBufferMemory(dev, rb, bmem, 0);
 
     VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO}; pci.queueFamilyIndex = qfi;
@@ -1117,9 +1132,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {W, H, 1};
     vkCmdCopyImageToBuffer(cmd, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
     vkEndCommandBuffer(cmd);
+    const auto timing_recorded = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount = 1; si.pCommandBuffers = &cmd;
     VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev, &fci, nullptr, &fence);
     vkQueueSubmit(queue, 1, &si, fence); vkWaitForFences(dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+    const auto timing_gpu_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     if (cached_ds) {
         cached_ds->layout_initialized = true;
         cached_ds->depth_valid |= use_depth && depth_used_meaningfully;
@@ -1128,8 +1145,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
 
     out.resize(bytes);
     void* mp = nullptr; vkMapMemory(dev, bmem, 0, bytes, 0, &mp);
-    for (VkDeviceSize i = 0; i < bytes; i++) out[i] = ((const uint8_t*)mp)[i];
+    std::memcpy(out.data(), mp, static_cast<size_t>(bytes));
     vkUnmapMemory(dev, bmem);
+    const auto timing_readback_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
 
     // PROSPER_DRAW_ISO + PROSPER_ISO_AT="x,y": per-draw kill isolation (generalizes the #240 title harness
     // to any submit / any target pixel). On the FIRST submit whose rendered pixel at (x,y) is lit
@@ -1238,6 +1256,36 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     vkDestroyImage(dev, img, nullptr); vkFreeMemory(dev, imem, nullptr);
     if (use_ds && !cached_ds) {
         vkDestroyImageView(dev, dview, nullptr); vkDestroyImage(dev, dimg, nullptr); vkFreeMemory(dev, dmem, nullptr);
+    }
+    if (timing_enabled) {
+        const auto timing_done = TimingClock::now();
+        auto ms = [](auto begin, auto end) {
+            return std::chrono::duration<double, std::milli>(end - begin).count();
+        };
+        struct TimingTotals {
+            uint64_t calls = 0, draws = 0;
+            double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
+        };
+        static TimingTotals totals;
+        totals.calls++;
+        totals.draws += draws.size();
+        totals.target += ms(timing_start, timing_target_ready);
+        totals.draw_setup += ms(timing_target_ready, timing_draws_ready);
+        totals.record += ms(timing_draws_ready, timing_recorded);
+        totals.gpu_wait += ms(timing_recorded, timing_gpu_done);
+        totals.readback += ms(timing_gpu_done, timing_readback_done);
+        totals.cleanup += ms(timing_readback_done, timing_done);
+        if (totals.calls % 25 == 0) {
+            const double n = static_cast<double>(totals.calls);
+            const double total = totals.target + totals.draw_setup + totals.record +
+                                 totals.gpu_wait + totals.readback + totals.cleanup;
+            fprintf(stderr,
+                    "[render-timing] backend calls=%llu draws=%llu avg_ms: total=%.2f target=%.2f "
+                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                    (unsigned long long)totals.calls, (unsigned long long)totals.draws, total / n,
+                    totals.target / n, totals.draw_setup / n, totals.record / n,
+                    totals.gpu_wait / n, totals.readback / n, totals.cleanup / n);
+        }
     }
     // NB: dev/instance are the persistent RenderVkCtx — do NOT destroy them here (reused across calls).
     return out;

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1,0 +1,101 @@
+#include "../src/gpu/gpu_execute.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <iterator>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int failures = 0;
+#define CHECK(condition, message) do { \
+    if (condition) std::printf("  [ok]   %s\n", message); \
+    else { std::printf("  [FAIL] %s\n", message); ++failures; } \
+} while (0)
+
+// Fullscreen triangle and solid green shaders assembled for gfx1030. These are also used by the
+// end-to-end GPU executor tests, but this test needs no Vulkan device.
+static const uint32_t kVs[] = {
+    0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u,
+    0x7E0C02F2u, 0x10020B01u, 0x08020D01u, 0x10040B02u, 0x08040D02u,
+    0x7E060280u, 0x7E0802F2u, 0xF80008CFu, 0x04030201u, 0xBF810000u,
+};
+static const uint32_t kPs[] = {
+    0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,
+    0xF800180Fu, 0x03020100u, 0xBF810000u,
+};
+
+int main() {
+    std::printf("== test_shader_recompile_cache ==\n");
+    clear_shader_recompile_cache();
+
+    ShaderResource resource;
+    resource.cls = ResourceClass::VertexBuffer;
+    resource.format = DataFormat::Float32;
+    resource.num_components = 3;
+    resource.binding = 7;
+    resource.stride = 12;
+    resource.srt_offset = 0x20;
+    resource.sgpr_base = 8;
+    resource.fetch_pc = 4;
+    resource.gpu_addr = 0x100000;
+    resource.size = 4096;
+    ShaderResourceTable table;
+    table.resources.push_back(resource);
+
+    const auto direct_vs = recompile_vertex(kVs, std::size(kVs), &table);
+    const auto cached_vs = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table);
+    CHECK(!direct_vs.empty() && cached_vs == direct_vs,
+          "cache miss is byte-identical to the direct vertex recompiler");
+    auto stats = shader_recompile_cache_stats();
+    CHECK(stats.misses == 1 && stats.hits == 0 && stats.entries == 1,
+          "first shader realization records one cache miss");
+
+    const auto repeated_vs = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table);
+    stats = shader_recompile_cache_stats();
+    CHECK(repeated_vs == direct_vs && stats.hits == 1 && stats.misses == 1,
+          "identical code and descriptor semantics hit the cache");
+
+    // These fields are consumed by the runtime backend, not by the recompiler. Changing them must
+    // reuse SPIR-V while each DrawItem continues to carry the new table to descriptor upload.
+    table.resources[0].gpu_addr = 0x900000;
+    table.resources[0].size = 8192;
+    table.resources[0].width = 1024;
+    table.resources[0].height = 512;
+    table.resources[0].mag_filter = 0;
+    table.resources[0].host_data = reinterpret_cast<uint8_t*>(0x1234);
+    table.resources[0].host_data_size = 16;
+    const auto runtime_changed = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table);
+    stats = shader_recompile_cache_stats();
+    CHECK(runtime_changed == direct_vs && stats.hits == 2 && stats.misses == 1,
+          "runtime-only resource changes preserve the compiled shader cache entry");
+
+    // Binding participates in both descriptor declarations and memory-op lowering, so it must miss.
+    table.resources[0].binding = 9;
+    const auto direct_rebound = recompile_vertex(kVs, std::size(kVs), &table);
+    const auto cached_rebound = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table);
+    stats = shader_recompile_cache_stats();
+    CHECK(cached_rebound == direct_rebound && stats.misses == 2 && stats.entries == 2,
+          "compile-time resource changes miss and remain byte-identical to the oracle");
+
+    const auto direct_ps = recompile_fragment(kPs, std::size(kPs), nullptr);
+    const auto cached_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr);
+    CHECK(!direct_ps.empty() && cached_ps == direct_ps,
+          "fragment cache output is byte-identical to the direct recompiler");
+
+    clear_shader_recompile_cache();
+    stats = shader_recompile_cache_stats();
+    CHECK(stats.entries == 0 && stats.hits == 0 && stats.misses == 0 && stats.bytes == 0,
+          "cache reset clears entries and instrumentation");
+
+    if (failures) {
+        std::printf("== FAIL: %d ==\n", failures);
+        return 1;
+    }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -37,6 +37,63 @@ static bool roundtrip_ok(uint32_t w, uint32_t h) {
     return back == ref;
 }
 
+// Independent, deliberately slow SW_4KB_S oracle. These bit orders are the low-bit GFX10 addrlib
+// patterns documented by the hardware-derived golden tests below. This does not share production's
+// lookup table or indexing code, so it catches a fast-path error that a tile/detile round trip cannot.
+struct RefOrder {
+    const uint8_t* bits;
+    uint32_t count, tile_w, tile_h;
+};
+
+static RefOrder reference_order(uint32_t bpe) {
+    // 0..6 = x bit; 0x80..0x86 = y bit.
+    static const uint8_t b1[]  = {0,1,2,3, 0x80,0x81,0x82,0x83,0x84, 4,0x85,5};
+    static const uint8_t b2[]  = {0,1,2, 0x80,0x81,0x82, 3,0x83,4,0x84,5};
+    static const uint8_t b4[]  = {0,1, 0x80,0x81,0x82, 2,0x83,3,0x84,4};
+    static const uint8_t b8[]  = {0,0x80,0x81,1,2,0x82,3,0x83,4};
+    static const uint8_t b16[] = {0x80,0x81,0,1,0x82,2,0x83,3};
+    switch (bpe) {
+        case 1:  return {b1,  12, 64, 64};
+        case 2:  return {b2,  11, 64, 32};
+        case 4:  return {b4,  10, 32, 32};
+        case 8:  return {b8,   9, 32, 16};
+        case 16: return {b16,  8, 16, 16};
+        default: return {nullptr, 0, 0, 0};
+    }
+}
+
+static uint32_t reference_element_index(uint32_t x, uint32_t y, const RefOrder& order) {
+    uint32_t index = 0;
+    for (uint32_t out_bit = 0; out_bit < order.count; ++out_bit) {
+        const uint8_t source = order.bits[out_bit];
+        const uint32_t bit = source & 0x7fu;
+        const uint32_t value = source & 0x80u ? ((y >> bit) & 1u) : ((x >> bit) & 1u);
+        index |= value << out_bit;
+    }
+    return index;
+}
+
+template <bool ToTiled>
+static void reference_sw4kb_copy(uint8_t* dst, const uint8_t* src, uint32_t w, uint32_t h,
+                                 uint32_t pitch, uint32_t bpe, size_t tiled_bytes) {
+    const RefOrder order = reference_order(bpe);
+    const uint32_t tiles_per_row = ((pitch ? pitch : w) + order.tile_w - 1) / order.tile_w;
+    for (uint32_t y = 0; y < h; ++y) for (uint32_t x = 0; x < w; ++x) {
+        const uint32_t tx = x / order.tile_w, ty = y / order.tile_h;
+        const uint32_t ix = x % order.tile_w, iy = y % order.tile_h;
+        const size_t tiled = static_cast<size_t>(ty * tiles_per_row + tx) * 4096 +
+                             reference_element_index(ix, iy, order) * bpe;
+        const size_t linear = (static_cast<size_t>(y) * w + x) * bpe;
+        if (ToTiled) {
+            if (tiled + bpe <= tiled_bytes) std::memcpy(dst + tiled, src + linear, bpe);
+        } else if (tiled + bpe <= tiled_bytes) {
+            std::memcpy(dst + linear, src + tiled, bpe);
+        } else {
+            std::memset(dst + linear, 0, bpe);
+        }
+    }
+}
+
 int main() {
     printf("== test_tile ==\n");
 
@@ -127,6 +184,52 @@ int main() {
         CHECK(rt_bpe(96, 64, 4),   "round-trip 96x64 @ 4 B/texel (explicit-bpt path == default)");
         CHECK(rt_bpe(70, 40, 8),   "round-trip 70x40 @ 8 B/elem (32x16 tiles)");
         CHECK(rt_bpe(40, 40, 16),  "round-trip 40x40 @ 16 B/elem (16x16 tiles)");
+    }
+
+    // Compare the optimized tile-oriented implementation directly with the independent per-element
+    // oracle. Cover every element size, partial edge tiles, padded pitches, and bounded/truncated reads.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw4KbS;
+        struct Case { uint32_t w, h, pitch, bpe; };
+        const Case cases[] = {
+            {131, 70, 193, 1}, {131, 70, 191, 2}, {67, 45, 96, 4},
+            {70, 41, 97, 8}, {41, 39, 55, 16},
+        };
+        bool tile_matches = true, detile_matches = true, truncated_matches = true;
+        for (const Case& c : cases) {
+            std::vector<uint8_t> linear((size_t)c.w * c.h * c.bpe);
+            for (size_t i = 0; i < linear.size(); ++i)
+                linear[i] = (uint8_t)((i * 11400714819323198485ull) >> 37);
+            const size_t bytes = tiled_surface_bytes(c.w, c.h, M, c.pitch, c.bpe);
+            std::vector<uint8_t> expected(bytes, 0), actual(bytes, 0);
+            reference_sw4kb_copy<true>(expected.data(), linear.data(), c.w, c.h,
+                                       c.pitch, c.bpe, bytes);
+            tile_surface(actual.data(), linear.data(), c.w, c.h, M, c.pitch, c.bpe);
+            tile_matches &= actual == expected;
+
+            std::vector<uint8_t> expected_linear(linear.size(), 0), actual_linear(linear.size(), 0);
+            reference_sw4kb_copy<false>(expected_linear.data(), expected.data(), c.w, c.h,
+                                        c.pitch, c.bpe, bytes);
+            detile_surface(actual_linear.data(), expected.data(), c.w, c.h, M, c.pitch, c.bpe);
+            detile_matches &= actual_linear == expected_linear;
+
+            // detile_elements exposes an explicit source bound. Use pitch=width, as that API does.
+            const size_t unpitched_bytes = tiled_elements_bytes(c.w, c.h, c.bpe, M);
+            std::vector<uint8_t> unpitched(unpitched_bytes, 0);
+            reference_sw4kb_copy<true>(unpitched.data(), linear.data(), c.w, c.h,
+                                       0, c.bpe, unpitched_bytes);
+            const size_t available = unpitched_bytes > 123 ? unpitched_bytes - 123 : unpitched_bytes / 2;
+            std::fill(expected_linear.begin(), expected_linear.end(), 0);
+            std::fill(actual_linear.begin(), actual_linear.end(), 0);
+            reference_sw4kb_copy<false>(expected_linear.data(), unpitched.data(), c.w, c.h,
+                                        0, c.bpe, available);
+            detile_elements(actual_linear.data(), unpitched.data(), available,
+                            c.w, c.h, c.bpe, M);
+            truncated_matches &= actual_linear == expected_linear;
+        }
+        CHECK(tile_matches, "optimized SW_4KB_S tile matches independent addrlib-order oracle");
+        CHECK(detile_matches, "optimized SW_4KB_S detile matches oracle for padded pitches/edge tiles");
+        CHECK(truncated_matches, "optimized bounded detile matches oracle for truncated tiled buffers");
     }
 
     // Golden positions for the GFX10 SW_4KB_S element order (#118): the lowest four element bits are a


### PR DESCRIPTION
## Summary

- prefer cached host-visible Vulkan memory for framebuffer readback and bulk-copy pixels
- precompute `SW_4KB_S` detile offsets and verify them against an independent slow oracle
- retain the Vulkan compute context between dispatches
- pool exact-requirements transient graphics and compute `VkDeviceMemory` allocations
- retain decoded-texture scratch storage and avoid duplicate guest texture decodes within a graphics callback
- cache deterministic graphics RDNA2-to-SPIR-V results with a direct-recompiler oracle test
- add rolling render-stage, resource, shader-cache, and allocation-pool timing diagnostics

## Root cause and impact

The native Windows frontend was doing several expensive operations on every frame: reading an 8 MiB framebuffer through uncached host-visible memory, recomputing addrlib bit equations per detiled texel, recreating the Vulkan compute device/context, repeatedly allocating/freeing transient Vulkan memory, zero-filling texture/readback scratch that was immediately overwritten, and retranslating identical graphics shaders.

On the tested RTX 4090 system, the boot/frontend workload improved from **0.8 FPS** to **26.7 FPS** over 60 frames and **23.6 FPS** over 120 frames. Readback fell from about 572 ms to 1.8 ms, detiling from about 39 ms to 6.5 ms, and persistent compute callbacks are about 0.9 ms after pooling.

In Messenger's heavy first-level workload, the live app now sustains roughly **11-12 FPS** in the current no-input scene, compared with the earlier **3.8-5.1 FPS** baseline. A comparable rolling window avoided 12/55 texture decodes, reducing texture work from 13.84 ms to 7.81 ms and frontend resource construction from 15.36 ms to 9.24 ms. Shader-cache hits approach 100% after warmup; remaining draw realization is dominated by descriptor/resource-table construction (about 10.9 ms/submit), not shader compilation.

The detile, compute, pool, texture, and shader changes are shared by Linux and Windows. Cached host-visible readback uses standard Vulkan memory selection with the existing compatible fallback.

## Correctness boundary

An experimental per-submit `build_stage_table` cache was rejected and is **not** in this PR. Messenger stalled at its initial loading screen with it enabled and progressed immediately in an exact A/B relaunch with it disabled. User-SGPR values identify pointers, not the mutable guest memory behind them, so a future table cache needs explicit memory versioning/invalidation. The failed experiment and constraint are documented in the issue and frontend handoff docs.

## Validation

- Windows: 68/68 tests pass
- Linux/WSL: 93/93 tests pass, including the full Vulkan GPU execution spine
- `test_shader_recompile_cache` checks cached misses byte-for-byte against the direct recompiler, runtime-only resource changes as hits, and compile-time interface changes as misses
- independent `SW_4KB_S` oracle covers all supported bytes-per-element sizes, padded pitches, edge tiles, and truncated buffers
- The Messenger golden-scene guard: 24,318 colors (minimum 5,000)
- clean no-workaround Windows build progressed from boot into Messenger gameplay after the rejected cache was removed

Refs #702
