### PR TITLE
Improve renderer throughput and publish the Windows app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches: [master]
+    tags: ['v*']
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Configure
         shell: msys2 {0}
-        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
 
       - name: Build
         shell: msys2 {0}
@@ -87,6 +87,88 @@ jobs:
       - name: Test
         shell: msys2 {0}
         run: ctest --test-dir prosper/build-ci --output-on-failure
+
+  windows-app:
+    name: Windows App
+    runs-on: windows-latest
+
+    # Build-only for the Vulkan window itself: hosted Windows runners do not expose a reliable GPU
+    # or interactive desktop. The SDL audio/pad seams still run through their dummy-driver tests.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-vulkan-headers
+            mingw-w64-ucrt-x86_64-vulkan-loader
+
+      - name: Configure frontend
+        shell: msys2 {0}
+        run: >-
+          cmake -S prosper -B prosper/build-windows-app -G Ninja
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DPROSPER_APP=ON
+          -DPROSPER_AUDIO_SDL3=ON
+          -DPROSPER_PAD_SDL3=ON
+
+      - name: Build frontend and seam tests
+        shell: msys2 {0}
+        run: >-
+          cmake --build prosper/build-windows-app
+          --target prosper-app test_prosper_app_pad_overlay test_audio_sdl3 test_pad_sdl3
+
+      - name: Test SDL audio and input seams
+        shell: msys2 {0}
+        run: >-
+          ctest --test-dir prosper/build-windows-app --output-on-failure
+          -R '^(prosper_app_pad_overlay|audio_sdl3|pad_sdl3)$'
+
+      - name: Verify portable runtime imports
+        shell: msys2 {0}
+        run: |
+          deps="$(objdump -p prosper/build-windows-app/prosper-app.exe | sed -n 's/.*DLL Name: //p')"
+          printf '%s\n' "$deps"
+          if grep -Eiq 'lib(gcc|stdc\+\+|winpthread)|SDL3' <<<"$deps"; then
+            echo 'prosper-app unexpectedly depends on a MinGW or SDL runtime DLL' >&2
+            exit 1
+          fi
+
+      - name: Package Windows app
+        shell: pwsh
+        run: |
+          $stage = Join-Path $env:RUNNER_TEMP 'prosper-windows-x64'
+          $zip = Join-Path $env:GITHUB_WORKSPACE 'prosper-windows-x64.zip'
+          New-Item -ItemType Directory -Path $stage -Force | Out-Null
+          Copy-Item 'prosper/build-windows-app/prosper-app.exe' $stage
+          Copy-Item 'prosper/scripts/start-prosper.ps1' $stage
+          Copy-Item 'prosper/docs/WINDOWS_RELEASE.md' (Join-Path $stage 'README.md')
+          @(
+            'prosper Windows x64'
+            "commit: $env:GITHUB_SHA"
+            "workflow: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          ) | Set-Content (Join-Path $stage 'BUILD.txt') -Encoding ascii
+          Compress-Archive -Path "$stage/*" -DestinationPath $zip -Force
+          $hash = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  prosper-windows-x64.zip" | Set-Content "$zip.sha256" -Encoding ascii
+
+      - name: Upload Windows app
+        uses: actions/upload-artifact@v4
+        with:
+          name: prosper-windows-x64
+          path: |
+            prosper-windows-x64.zip
+            prosper-windows-x64.zip.sha256
+          if-no-files-found: error
+          retention-days: 14
 
   macos:
     name: macOS (x86_64 / Rosetta 2)
@@ -145,3 +227,31 @@ jobs:
 
       - name: Build prosper-app
         run: cmake --build prosper/build-app --target prosper-app
+
+  release:
+    name: Publish Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [linux, linux-app, windows-mingw, windows-app, macos, macos-app]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Windows archive
+        uses: actions/download-artifact@v4
+        with:
+          name: prosper-windows-x64
+          path: release-assets
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" release-assets/* \
+              --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" release-assets/* \
+              --repo "$GITHUB_REPOSITORY" --verify-tag --generate-notes \
+              --title "prosper $GITHUB_REF_NAME"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,13 @@ exposed a stale Windows `guest_readable` stub in dynamic-fetch folding; a `Virtu
 fixes the resulting loading-time host access violation (#688). Start Windows work from
 `docs/WINDOWS_PORT_HANDOFF.md`, not the historical pre-render fence investigation.
 
+The July native-renderer performance pass and its stop decision are documented in
+`docs/RENDERER_PERFORMANCE_2026_07.md`. Exact-byte texture decode reuse, per-submit readable-range
+reuse, output-copy removal, and corrected mixed-operation capture improve Messenger's first level
+from roughly 12 to 24 FPS. The remaining synchronous graphics/compute boundaries must be evaluated
+against a 3D workload; do not resume Messenger-specific cache work toward 60 FPS first. Windows
+release users start from `docs/WINDOWS_RELEASE.md`; build/debug work stays in the port handoff.
+
 The save-game list is visible (#299 closed), and retaining color-disabled depth/stencil passes (#520) recovers
 the first level's source scene. The black gameplay root cause was fixed on master by #528 (`e5fce22`):
 the direct 1024x32 RGBA16F grading-LUT producer was skipped because the recompiler lacked
@@ -236,7 +243,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 92/92 expected green on Linux
+  cmake --build . -j8 && ctest        # 93/93 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ audio, and graphics stack. See [Game compatibility](COMPATIBILITY.md) for exact 
 evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
 headless `boot_trace`.
 
-Development is **agentic-first**: correctness is verified programmatically — **92 self-checking tests**
+Development is **agentic-first**: correctness is verified programmatically — **93 self-checking tests**
 under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
 numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
 that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
@@ -90,7 +90,9 @@ Windows/MinGW), structured logs, and purpose-built tracing tooling — never by 
 - This is an independent interoperability / preservation research project, not affiliated with or
   endorsed by Sony Interactive Entertainment.
 
-## Building (Linux)
+## Building
+
+### Linux
 
 Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the graphics tests
 (the CI/headless path uses the `llvmpipe` software ICD).
@@ -99,19 +101,72 @@ Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the g
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # 92 self-checking tests
+ctest --test-dir build-linux          # 93 self-checking tests
 ```
 
-Add `-DPROSPER_APP=ON` to also build the windowed `prosper-app` frontend (fetches SDL3). Native
-Windows/MinGW now boots and renders the primary title through the same live Vulkan renderer; its
-current build, run, screenshot, and diagnostic recipe is maintained in
-[`prosper/docs/WINDOWS_PORT_HANDOFF.md`](prosper/docs/WINDOWS_PORT_HANDOFF.md).
+Add `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` to build the windowed frontend
+with audio and controller support. CMake fetches SDL3 when it is not installed.
 
-On Windows, the full graphics + WASAPI audio + controller/keyboard frontend is one command:
+### Windows core
+
+The supported Windows toolchain is 64-bit MinGW-w64 UCRT. In an MSYS2 UCRT64 shell:
+
+```sh
+pacman -S --needed git mingw-w64-ucrt-x86_64-gcc \
+  mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja
+cmake -S prosper -B prosper/build-windows-core -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+cmake --build prosper/build-windows-core
+ctest --test-dir prosper/build-windows-core --output-on-failure
+```
+
+This builds and tests the headless core without SDL or Vulkan. GitHub Actions runs the same UCRT64
+path on every push and pull request.
+
+### Windows app
+
+Install the Vulkan development packages in the same UCRT64 shell, then enable the app and its SDL3
+backends:
+
+```sh
+pacman -S --needed mingw-w64-ucrt-x86_64-vulkan-headers \
+  mingw-w64-ucrt-x86_64-vulkan-loader
+cmake -S prosper -B prosper/build-windows-app -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPROSPER_APP=ON \
+  -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
+cmake --build prosper/build-windows-app --target prosper-app
+./prosper/build-windows-app/prosper-app.exe --test-pattern --frames 120
+```
+
+From native PowerShell, the repository launcher supports WinLibs or MSYS2 MinGW plus an installed
+Vulkan SDK and performs configure, build, and launch in one command:
 
 ```powershell
 .\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
 ```
+
+The detailed native build, screenshot, and diagnostic recipe is in
+[`WINDOWS_PORT_HANDOFF.md`](prosper/docs/WINDOWS_PORT_HANDOFF.md).
+
+## Windows download and use
+
+Every CI run publishes a `prosper-windows-x64` artifact. A `v*` tag publishes the same
+`prosper-windows-x64.zip` on the repository's [GitHub Releases page](https://github.com/mattias800/ps5ys/releases).
+The archive contains
+`prosper-app.exe`, a one-command PowerShell launcher, and its usage guide; it never contains games,
+firmware, or keys.
+
+After extracting the archive, launch an unpacked `app0` directory:
+
+```powershell
+./start-prosper.ps1 'D:/PS5/PPSA24651-app0'
+```
+
+There is no game-picker or settings UI yet. The launcher supplies the required guest environment,
+creates local save data, and enables the Vulkan window, audio, physical controller, and keyboard
+overlay. Use `./start-prosper.ps1 -TestPattern -Frames 120` to test the frontend without a game.
+See [`WINDOWS_RELEASE.md`](prosper/docs/WINDOWS_RELEASE.md) for requirements, direct-executable use,
+save-data selection, the complete keyboard mapping, recordings, and troubleshooting.
 
 ## Repository layout
 
@@ -128,6 +183,10 @@ prosper/
   tests/          unit + boot + Vulkan-execution tests (run under ctest)
   docs/           ARCHITECTURE, ROADMAP, GRAPHICS, RENDER_LOOP, VERIFICATION, and per-frontier logs
 ```
+
+The July 2026 renderer profiling results, correctness constraints, rejected experiments, and next
+architecture step are recorded in
+[`RENDERER_PERFORMANCE_2026_07.md`](prosper/docs/RENDERER_PERFORMANCE_2026_07.md).
 
 ## License
 

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -173,9 +173,11 @@ and frontend publication. Cumulative `[render-timing]` lines show the whole run;
 lines show only the latest 25 submits/calls so a scene transition is immediately visible. The core
 window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
 Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture decodes taking at least
-0.5 ms (capped at 250 lines). The instrumentation does not take clock samples when the variable is
-unset. This is the first tool to use when the window presents correctly but a title is not interactive;
-do not infer a GPU bottleneck from low FPS without the stage breakdown.
+0.5 ms (capped at 250 lines). Set `PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT=N` to begin those detail
+lines at renderer submit N, so boot textures do not consume the cap before the scene under study.
+The instrumentation does not take clock samples when the variable is unset. This is the first tool
+to use when the window presents correctly but a title is not interactive; do not infer a GPU
+bottleneck from low FPS without the stage breakdown.
 
 Transient Vulkan memory uses a bounded, exact-requirements pool because every backend call waits for its
 fence before cleanup. Timing output includes `memory_pool` hits, misses, cached allocation count/bytes,
@@ -190,11 +192,14 @@ graphics and compute pools. Decoded texture scratch vectors are also retained ac
 are storage only, and every partial decode/read explicitly clears its unwritten tail.
 
 Within one renderer callback, repeated guest-backed texture descriptions reuse the first decoded
-pixel buffer. This is intentionally callback-local because ordered compute splits graphics into new
-callbacks where guest memory may have changed. Live render-to-texture inputs are never reused through
-this map because an earlier pass can replace their pixels. The rolling frontend timing reports both
-`textures` (texture resource uses) and `reused` (decodes avoided); performed decodes are their
-difference.
+pixel buffer. A bounded process-wide cache also covers guest-backed tiled `Unorm8x4` sampled textures,
+the common sprite-atlas case. Every cross-submit lookup copies and compares the complete padded tiled
+source bytes before reusing decoded pixels; changed bytes, a changed mapping extent, or an address
+reuse invalidates the entry. Live render targets, storage images, and other formats remain excluded.
+The default budget is 256 MiB; use `PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change it or
+`PROSPER_NO_TEXTURE_DECODE_CACHE=1` for an A/B run. Timing reports cross-submit `texture_cache`
+hits/misses/invalidations separately from `textures` (all texture uses) and `reused` (both local and
+persistent decodes avoided).
 
 Graphics RDNA2-to-SPIR-V results use a process-wide bounded cache (4096 entries and 128 MiB by
 default). Its key contains the shader bytes and only the resource-table fields consumed by compilation;
@@ -214,6 +219,14 @@ The current renderer remains a deterministic readback-based implementation. It r
 for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702
 tracks persistent Vulkan resource/pipeline caching and direct image presentation beyond the initial
 readback-memory, detile, compute-context, transient-memory-pool, scratch-reuse, and shader-cache fixes.
+On the native Windows Messenger first level, the exact-byte texture cache improved the same-binary
+workload from about 20 FPS to 24 FPS (resource construction 10.1-10.5 ms to about 3.9 ms). The remaining
+roughly 36-38 ms submit time is primarily ordered graphics/compute backend work: four graphics spans,
+four compute dispatches, synchronous fence waits/readbacks, and transient Vulkan pipelines/resources.
+Further work should be validated against a 3D title and converge graphics/compute resource ownership;
+title-specific 2D cache additions are not the current priority.
+The complete A/B table, heavy-frame budget, corrected capture graph, rejected experiments, and handoff
+decision are preserved in `RENDERER_PERFORMANCE_2026_07.md`.
 
 WSLg remains a useful alternate path for running the Linux build:
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1,0 +1,126 @@
+# Renderer performance and tooling findings (2026-07-14)
+
+This is the handoff for the native Windows performance work tracked in
+[#702](https://github.com/mattias800/ps5ys/issues/702). It records measured results, rejected
+experiments, capture-tool corrections, and the remaining architectural work. Use it with
+`FRONTEND_APP.md` for the environment-variable reference and `tools/AGENTS.md` for capture/replay.
+
+## Scope and decision
+
+The Messenger's first level is visually correct on the native Windows frontend. The work here was
+therefore profiling and general renderer improvement, not another graphics-correctness workaround.
+The representative heavy frame has four compute dispatches interleaved with four graphics spans.
+
+The current build runs that scene at roughly 24 FPS on the measured host, up from approximately
+12 FPS at the start of this pass. Further Messenger-only work toward 60 FPS is deliberately paused.
+The remaining cost is structural, and the next renderer changes must be tested against a 3D title
+before choosing a resource-lifetime or scheduling architecture.
+
+## Measurement method
+
+Use a `RelWithDebInfo` native Windows build, a fresh process for each A/B, the same input route and
+save data, and wait until the same first-level scene is stable. Enable rolling stage timings:
+
+```powershell
+$env:PROSPER_RENDER_TIMING = '1'
+./prosper/scripts/run-windows.ps1 ./PPSA24651-app0 -NoBuild
+```
+
+For slow resource attribution, use `detail` and defer detail output until the scene under study:
+
+```powershell
+$env:PROSPER_RENDER_TIMING = 'detail'
+$env:PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT = '5000'
+```
+
+Compare rolling `[render-window]` lines, not whole-run cumulative values. App FPS is useful as the
+outcome, but the stage buckets determine which subsystem actually changed.
+
+## Results
+
+| Change | Before | After | Main evidence |
+|---|---:|---:|---|
+| Avoid intermediate framebuffer copies and move final callback output | about 12.3 FPS | about 15.3 FPS | unclassified/output work fell from about 12.4 ms to 1.1 ms |
+| Per-submit readable-range cache | about 15 FPS | about 21 FPS | realization fell from 15-17 ms to 3.3 ms; table/fold work from 11.6-13 ms to 1.7 ms |
+| Exact-byte persistent texture decode cache | about 20 FPS | 23.7-24.8 FPS | resource construction fell from 10.1-10.5 ms to about 3.9 ms |
+
+The readability cache is scoped to one synchronous submit and caches only whether a guest range is
+mapped. It does not cache guest bytes. A representative heavy submit served about 940 of 962 checks
+from the local cache and needed only about 22 `VirtualQuery` probes.
+
+The shader fold cache retains only the scalar/resource instructions needed by dynamic descriptor
+resolution. Its key includes a copy of the decoded shader bytes, so same-address guest mutation is
+detected. It is bounded to 64 MiB by default and can be disabled with
+`PROSPER_NO_SHADER_DECODE_CACHE=1`.
+
+The persistent texture cache covers only guest-backed tiled `Unorm8x4` sampled textures. It excludes
+render targets, storage images, and unsupported formats. Every hit copies and compares the complete
+padded source before reusing decoded pixels, so address reuse and in-place mutation invalidate the
+entry. In the measured scene it produced 42 persistent hits and 14 callback-local hits out of 57
+texture uses, retained 101 entries / about 75 MiB, and observed no invalidation. Disable it with
+`PROSPER_NO_TEXTURE_DECODE_CACHE=1`; its default 256 MiB budget is controlled by
+`PROSPER_TEXTURE_DECODE_CACHE_MB`.
+
+## Current frame budget
+
+After the above changes, a representative renderer submit remains about 36-38 ms. Approximate costs
+per frame are:
+
+| Area | Approximate cost |
+|---|---:|
+| Four graphics GPU waits | 10-11 ms |
+| Four graphics readbacks | 4-5 ms |
+| Graphics pipeline creation/setup | about 3 ms |
+| Backend resource/descriptor setup | about 2 ms |
+| Graphics record/upload | about 2 ms |
+| Four compute dispatches | about 3 ms |
+| Remaining realization, publication, and overhead | remainder |
+
+These numbers explain why another small CPU lookup cache is not a credible path to 60 FPS. The
+renderer currently creates transient Vulkan objects, waits, and reads back at each ordered backend
+boundary. A durable improvement needs persistent resources and coordinated graphics/compute
+ownership, then direct presentation where screenshots/captures do not require CPU pixels.
+
+## Capture correction and dependency evidence
+
+Direct `PROSPER_GPU_CAPTURE` used to snapshot only draw items after execution. On a known Messenger
+submit this silently produced `draws=56 computes=0 operations=56`, losing the mixed PM4 order. The
+fix tracked in [#714](https://github.com/mattias800/ps5ys/issues/714) snapshots draws, computes, and
+the original ordered operation list before execution, then attaches final pixels and the oracle hash
+after execution.
+
+The corrected capture reports `draws=56 computes=4 operations=60`. Its operation order is:
+
+```text
+C0, draw 0, C1, draws 1..47, C2, draws 48..54, C3, draw 55
+```
+
+`gpu_replay --graph` found four concrete edges: C0 to C1 through a 196608-byte buffer, C1 to the
+first large graphics span through fragment binding 32, C1 to C2 through that buffer, and C2 to C3.
+This disproves a safe blind "run all compute first" optimization. Some later graphics spans have no
+captured overlap with the following dispatch, but exploiting that requires explicit dependency and
+resource-ownership scheduling rather than reordering by operation type.
+
+## Rejected experiments
+
+- Caching `build_stage_table` from shader address and user SGPRs is incorrect. Pointed-to descriptor
+  memory can mutate while those values remain unchanged. The experiment stalled Messenger on its
+  initial loading screen and was removed.
+- A driver `VkPipelineCache` alone made no measurable difference. The backend still creates transient
+  render passes and layouts, so stable application-level pipeline keys/lifetimes are needed first.
+- Reordering compute and graphics by type is not valid. The corrected capture graph proves real
+  producer/consumer edges in the representative frame.
+
+## Separate unresolved risk
+
+Native Windows boot can still intermittently stop after exactly 75 submits while asset loading and
+GC suspension continue. The same binary and route can pass on a retry. This is tracked separately in
+[#712](https://github.com/mattias800/ps5ys/issues/712); do not misclassify it as a renderer-cache
+regression without checking the submit count and suspend logs.
+
+## Next renderer step
+
+Bring up a representative Unreal/3D workload and collect the same stage timings plus a corrected
+mixed-operation capture. Then design one cross-engine persistent-resource change around measured
+resource identities and dependencies. Keep the exact-byte and disable-switch A/B discipline used
+here, and preserve screenshot/capture correctness while reducing the synchronous boundaries.

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -1,5 +1,8 @@
 # Windows native port — handoff (2026-07-14)
 
+For users of the prebuilt archive, start with `WINDOWS_RELEASE.md`. This document is the engineering
+build, validation, and debugging handoff.
+
 The Windows native core boots The Messenger (`PPSA24651`) through IL2CPP and repeated GC
 stop-the-world cycles, drives real GPU draws, and presents 1920x1080 frames. The fence-field,
 binary-file-read, and asynchronous-GC blockers were fixed in #672, #673, and #678 respectively.
@@ -183,7 +186,8 @@ PROSPER_GFXLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 Performance diagnostics: set `PROSPER_RENDER_TIMING=1` for aggregate graphics/compute stage timings, or
 `PROSPER_RENDER_TIMING=detail` to include slow individual texture decodes. The output and bucket definitions
 are documented in `FRONTEND_APP.md`; rolling `[render-window]` lines cover the latest 25 operations rather
-than averaging away the current scene. Backend output also reports transient Vulkan memory-pool statistics;
+than averaging away the current scene. Use `PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT=N` to defer detailed
+texture lines until the scene being profiled. Backend output also reports transient Vulkan memory-pool statistics;
 use `PROSPER_NO_MEMORY_POOL=1` for a direct allocate/free A/B run, or `PROSPER_MEMORY_POOL_MB=<MiB>` to
 override the default 512 MiB graphics budget. Compute allocations use a separate 256 MiB default budget,
 overridable with `PROSPER_COMPUTE_MEMORY_POOL_MB=<MiB>`. Graphics shader translation is cached by shader
@@ -191,7 +195,10 @@ bytes plus descriptor-interface semantics; `PROSPER_NO_SHADER_CACHE=1` disables 
 `PROSPER_SHADER_CACHE_MB=<MiB>` overrides its 128 MiB budget. Timing windows report shader hits/misses and
 miss compilation time. Run `test_shader_recompile_cache` after changing the key or recompiler contract.
 Frontend windows also report texture resource uses as `textures` and callback-local duplicate decodes
-avoided as `reused`; their difference is the number of performed decodes. Do not infer descriptor-table
+avoided as `reused`, plus exact-byte cross-submit `texture_cache` hits/misses/invalidations. The persistent
+cache is limited to guest-backed tiled `Unorm8x4` sampled textures and defaults to 256 MiB; use
+`PROSPER_NO_TEXTURE_DECODE_CACHE=1` for an A/B or `PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change the
+budget. Do not infer descriptor-table
 identity from shader/user-SGPR values alone:
 pointed-to guest memory is mutable, and that cache experiment stalled Messenger at its loading screen.
 See `FRONTEND_APP.md` for the invalidation requirement.

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -1,0 +1,95 @@
+# Using the Windows release
+
+The Windows archive contains the native `prosper-app` frontend: a Vulkan window with audio and
+controller/keyboard input. It does not contain PS5 software, firmware, keys, or a game picker. Supply
+your own legally obtained dump whose module segments are already unencrypted.
+
+## Requirements
+
+- 64-bit Windows 10 or Windows 11 on an x86-64 CPU.
+- A Vulkan 1.1-capable graphics driver. Update the AMD, Intel, or NVIDIA driver if Windows cannot
+  load `vulkan-1.dll` or the app reports that no Vulkan device is available.
+- An unpacked title directory conventionally named `<TITLE_ID>-app0`, containing `eboot.bin` and the
+  title's other files.
+
+The archive is portable: MinGW, C++, and SDL3 runtimes are statically linked. Extract the complete
+archive to a writable directory. Keep `start-prosper.ps1` beside `prosper-app.exe`.
+
+## Start a title
+
+Open PowerShell in the extracted directory and pass the title's `app0` directory:
+
+```powershell
+./start-prosper.ps1 'D:/PS5/PPSA24651-app0'
+```
+
+The launcher creates a `savedata` directory beside the executable. Use a separate location when
+testing a fresh save or keeping titles isolated:
+
+```powershell
+./start-prosper.ps1 'D:/PS5/PPSA24651-app0' -SavedataDir 'D:/prosper-saves/PPSA24651'
+```
+
+If PowerShell blocks the unsigned local script, use this process-local policy; it does not change the
+machine policy:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ./start-prosper.ps1 'D:/PS5/PPSA24651-app0'
+```
+
+The direct executable form is also supported. The environment is currently required because there
+is no settings UI:
+
+```powershell
+$env:PROSPER_GUEST_FS = '1'
+$env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
+$env:PROSPER_SAVEDATA_DIR = "$PWD/savedata"
+./prosper-app.exe --dump 'D:/PS5/PPSA24651-app0'
+```
+
+`-force-gfx-direct` is the current Unity default. For a title that must not receive it, launch with
+`-GuestArgs ''`.
+
+## Input and exit
+
+SDL3 automatically uses a connected controller as pad 0. Keyboard input is composed over it:
+
+| Host input | Guest control |
+|---|---|
+| WASD or arrows | D-pad and left stick |
+| J or Space | Cross |
+| K | Square |
+| L | Circle |
+| I | Triangle |
+| U / O | L1 / R1 |
+| Y / H | L2 / R2 |
+| Enter | Options |
+| Escape | Exit |
+
+Closing the window also exits. Shutdown currently terminates the process after flushing logs because
+cooperative guest-thread teardown is not implemented yet.
+
+## Smoke test and recordings
+
+Test the window, Vulkan swapchain, and presentation path without a game:
+
+```powershell
+./start-prosper.ps1 -TestPattern -Frames 120
+```
+
+Record controller/keyboard input as a replay route while playing:
+
+```powershell
+./start-prosper.ps1 'D:/PS5/PPSA24651-app0' -Record "$PWD/routes/session.pad"
+```
+
+Release the final held button before exiting so its interval can be written. Runtime logs are printed
+to the PowerShell console; include those logs, the title ID, GPU/driver, and the release version when
+reporting a problem.
+
+## Compatibility
+
+prosper is an experimental compatibility layer, not a general-purpose PS5 runner. Titles reach
+different milestones and regressions are possible. See the repository's
+[`COMPATIBILITY.md`](https://github.com/mattias800/ps5ys/blob/master/COMPATIBILITY.md) for the tested
+state of each title. No compatibility is implied merely because a dump boots.

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -38,6 +38,8 @@ CMake, Ninja, and MinGW-w64 UCRT are required; the launcher discovers the standa
 installation automatically.
 
 WSLg remains an alternate way to run the Linux build, but it is no longer the primary Windows path.
+Prebuilt Windows archives include `start-prosper.ps1`; see `prosper/docs/WINDOWS_RELEASE.md` for the
+no-UI launch command, save-data selection, keyboard map, and runtime requirements.
 
 ## Run
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -81,6 +81,17 @@ struct DecodedTexture {
     uint32_t output_height = 0;
     bool narrow = false;
 };
+
+struct PersistentDecodedTexture {
+    size_t source_size = 0;
+    std::vector<uint8_t> source_prefix;
+    std::vector<uint8_t> pixels;
+    uint32_t output_height = 0;
+    bool narrow = false;
+    uint64_t last_use = 0;
+
+    size_t bytes() const { return source_prefix.size() + pixels.size(); }
+};
 }
 
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
@@ -181,8 +192,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             using RenderClock = std::chrono::steady_clock;
             struct RenderTiming {
                 uint64_t callbacks = 0;
-                double total_ms = 0, build_resources_ms = 0, backend_ms = 0;
+                double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
                 uint64_t textures = 0, texture_reuses = 0, buffers = 0;
+                uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                 uint64_t texture_bytes = 0, buffer_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
             };
@@ -270,6 +282,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             static std::vector<std::vector<uint8_t>> texstore;
             size_t texstore_used = 0;
             std::unordered_map<TextureDecodeKey, DecodedTexture, TextureDecodeKeyHash> decoded_textures;
+            static std::unordered_map<TextureDecodeKey, PersistentDecodedTexture, TextureDecodeKeyHash>
+                persistent_decoded_textures;
+            static size_t persistent_decoded_texture_bytes = 0;
+            static uint64_t persistent_decode_generation = 0;
+            const uint64_t decode_generation = ++persistent_decode_generation;
+            static std::vector<uint8_t> persistent_validation_scratch;
+            const size_t persistent_decode_limit = [] {
+                const char* value = getenv("PROSPER_TEXTURE_DECODE_CACHE_MB");
+                const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
+                return static_cast<size_t>(std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull))) *
+                       1024ull * 1024ull;
+            }();
             uint32_t resource_hash_w = 0, resource_hash_h = 0;
             if (const char* dim = getenv("PROSPER_RESOURCE_HASH_DIM"))
                 if (sscanf(dim, "%ux%u", &resource_hash_w, &resource_hash_h) != 2)
@@ -316,17 +340,55 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
                         const bool has_live_rtt = live_rtt != g_rtt.end() && live_rtt->second.w &&
                             live_rtt->second.h && !live_rtt->second.rgba.empty();
+                        const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
+                        const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
+                            ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
+                        const bool persistent_cache_eligible =
+                            !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") && persistent_decode_limit &&
+                            !has_live_rtt && !is_cube && r.cls == RC::Texture &&
+                            r.format == prosper::gpu::DataFormat::Unorm8 && r.num_components == 4 &&
+                            !getenv("PROSPER_NODETILE") && prosper::gpu::tile_mode_is_tiled(r.tile_mode);
+                        const size_t persistent_source_size = persistent_cache_eligible
+                            ? prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, persistent_pitch) : 0;
                         bool narrow_done = false;
                         auto reused = has_live_rtt ? decoded_textures.end()
                                                    : decoded_textures.find(decode_key);
-                        if (reused != decoded_textures.end()) {
-                            fr.tex_rgba = reused->second.pixels;
+                        DecodedTexture persistent_reuse;
+                        const DecodedTexture* decoded_reuse = reused != decoded_textures.end()
+                            ? &reused->second : nullptr;
+                        if (!decoded_reuse && persistent_cache_eligible) {
+                            auto cached = persistent_decoded_textures.find(decode_key);
+                            if (cached != persistent_decoded_textures.end() &&
+                                cached->second.source_size == persistent_source_size) {
+                                persistent_validation_scratch.resize(persistent_source_size);
+                                const size_t got = copy_resource(
+                                    persistent_validation_scratch.data(), r.gpu_addr,
+                                    persistent_source_size);
+                                if (got == cached->second.source_prefix.size() &&
+                                    (got == 0 || !std::memcmp(persistent_validation_scratch.data(),
+                                                              cached->second.source_prefix.data(), got))) {
+                                    cached->second.last_use = decode_generation;
+                                    persistent_reuse = {cached->second.pixels.data(),
+                                                        cached->second.output_height,
+                                                        cached->second.narrow};
+                                    decoded_reuse = &persistent_reuse;
+                                    if (timing_enabled) pending_timing.persistent_hits++;
+                                } else if (timing_enabled) {
+                                    pending_timing.persistent_invalidations++;
+                                }
+                            } else if (timing_enabled) {
+                                pending_timing.persistent_misses++;
+                            }
+                        }
+                        if (decoded_reuse) {
+                            fr.tex_rgba = decoded_reuse->pixels;
                             fr.tw = tw;
-                            fr.th = reused->second.output_height;
-                            narrow_done = reused->second.narrow;
+                            fr.th = decoded_reuse->output_height;
+                            narrow_done = decoded_reuse->narrow;
+                            decoded_textures.emplace(
+                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done});
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
-                        const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         size_t nb = (size_t)tw * th * 4 * (is_cube ? 6u : 1u);
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
@@ -709,6 +771,52 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                         }
                         fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
+                        if (persistent_cache_eligible) {
+                            persistent_validation_scratch.resize(persistent_source_size);
+                            const size_t got = copy_resource(
+                                persistent_validation_scratch.data(), r.gpu_addr,
+                                persistent_source_size);
+                            auto old = persistent_decoded_textures.find(decode_key);
+                            const bool can_replace = old == persistent_decoded_textures.end() ||
+                                old->second.last_use != decode_generation;
+                            if (old != persistent_decoded_textures.end() && can_replace) {
+                                persistent_decoded_texture_bytes -= old->second.bytes();
+                                persistent_decoded_textures.erase(old);
+                            }
+                            const size_t required = got + texture_pixels.size();
+                            while (required <= persistent_decode_limit &&
+                                   persistent_decoded_texture_bytes > persistent_decode_limit - required) {
+                                auto victim = persistent_decoded_textures.end();
+                                for (auto it = persistent_decoded_textures.begin();
+                                     it != persistent_decoded_textures.end(); ++it) {
+                                    if (it->second.last_use == decode_generation) continue;
+                                    if (victim == persistent_decoded_textures.end() ||
+                                        it->second.last_use < victim->second.last_use) victim = it;
+                                }
+                                if (victim == persistent_decoded_textures.end()) break;
+                                persistent_decoded_texture_bytes -= victim->second.bytes();
+                                persistent_decoded_textures.erase(victim);
+                            }
+                            if (can_replace &&
+                                required <= persistent_decode_limit &&
+                                persistent_decoded_texture_bytes <= persistent_decode_limit - required) {
+                                PersistentDecodedTexture cached;
+                                cached.source_size = persistent_source_size;
+                                cached.source_prefix.assign(
+                                    persistent_validation_scratch.begin(),
+                                    persistent_validation_scratch.begin() + got);
+                                cached.pixels = texture_pixels;
+                                cached.output_height = fr.th;
+                                cached.narrow = narrow_done;
+                                cached.last_use = decode_generation;
+                                auto [inserted, ok] = persistent_decoded_textures.emplace(
+                                    decode_key, std::move(cached));
+                                if (ok) {
+                                    persistent_decoded_texture_bytes += inserted->second.bytes();
+                                    fr.tex_rgba = inserted->second.pixels.data();
+                                }
+                            }
+                        }
                         if (!resource_rtt_hit && !has_live_rtt)
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done});
@@ -765,8 +873,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             pending_timing.textures++;
                             pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * 4;
                             pending_timing.texture_ms += elapsed;
+                            const uint64_t detail_min_submit = getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT")
+                                ? strtoull(getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT"), nullptr, 0) : 0;
                             if (const char* mode = getenv("PROSPER_RENDER_TIMING");
-                                mode && strcmp(mode, "detail") == 0 && elapsed >= 0.5) {
+                                mode && strcmp(mode, "detail") == 0 &&
+                                static_cast<uint64_t>(g_this_submit) >= detail_min_submit && elapsed >= 0.5) {
                                 static uint64_t detail_lines = 0;
                                 if (detail_lines++ < 250) {
                                     fprintf(stderr,
@@ -921,6 +1032,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 return g.empty() ? nullptr : g.front()->ps.clear_color;
             };
             std::vector<uint8_t> px;
+            const std::vector<uint8_t>* selected_pixels = nullptr;
             if (pertarget) {
                 // PER-TARGET RTT: a real frame is a sequence of passes, each rendering into a specific
                 // color target (CB_COLOR0_BASE), and a final composite pass SAMPLES the earlier targets.
@@ -953,7 +1065,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fprintf(stderr, " [%d]=0x%llx", i, (unsigned long long)prosper_vo_buffer_addr(i));
                     fprintf(stderr, "\n");
                 }
-                std::vector<uint8_t> px_front, px_vo;   // flip-matched / any-scanout-matched candidates
+                const std::vector<uint8_t>* px_front = nullptr;
+                const std::vector<uint8_t>* px_vo = nullptr;
+                const std::vector<uint8_t>* px_last = nullptr;
                 // Render-target persistence (default on; PROSPER_RTT_NOSEED reverts to per-pass blue
                 // clear): seed each group's framebuffer with the pixels last rendered into that SAME
                 // target VA, so a pass that draws into an already-written target (UE4's UI pass onto
@@ -1023,10 +1137,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         pending_timing.backend_ms +=
                             std::chrono::duration<double, std::milli>(backend_done - build_done).count();
                     }
-                    if (base && !gpx.empty()) { RttSurf& s = g_rtt[base]; s.rgba = gpx; s.w = gw; s.h = gh; }
-                    if (native_w == resource_hash_w && native_h == resource_hash_h && !gpx.empty()) {
+                    const std::vector<uint8_t>* pass_pixels = &gpx;
+                    if (base && !gpx.empty()) {
+                        RttSurf& surface = g_rtt[base];
+                        surface.rgba = std::move(gpx);
+                        surface.w = gw;
+                        surface.h = gh;
+                        pass_pixels = &surface.rgba;
+                    }
+                    const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
+                    if (native_w == resource_hash_w && native_h == resource_hash_h &&
+                        !rendered_pixels.empty()) {
                         uint64_t hash = 1469598103934665603ull;
-                        for (uint8_t byte : gpx) {
+                        for (uint8_t byte : rendered_pixels) {
                             hash ^= byte;
                             hash *= 1099511628211ull;
                         }
@@ -1103,9 +1226,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
                     if (getenv("PROSPER_RTTLOG")) {
                         size_t nz = 0, rgb_nz = 0;
-                        for (uint8_t b : gpx) nz += (b != 0);
-                        for (size_t p = 0; p + 3 < gpx.size(); p += 4)
-                            rgb_nz += (gpx[p] != 0 || gpx[p + 1] != 0 || gpx[p + 2] != 0);
+                        for (uint8_t b : rendered_pixels) nz += (b != 0);
+                        for (size_t p = 0; p + 3 < rendered_pixels.size(); p += 4)
+                            rgb_nz += (rendered_pixels[p] != 0 || rendered_pixels[p + 1] != 0 ||
+                                       rendered_pixels[p + 2] != 0);
                         fprintf(stderr, "[rtt] pass target=0x%llx extent=%ux%u native=%ux%u (%zu draws) "
                                 "px_nonzero=%zu rgb_nonblack=%zu cache_size=%zu%s%s\n",
                                 (unsigned long long)base, gw, gh, native_w, native_h, pass.size(), nz, rgb_nz, g_rtt.size(),
@@ -1131,25 +1255,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes>: dump each per-target group's rendered
                     // pixels (rtgrp_<base>_<frame>.bmp in PROSPER_FRAME_DIR) — to inspect an intermediate
                     // pass (e.g. the UI/banner RT) instead of only the presented composite. Diagnostic.
-                    if (const char* rg = getenv("PROSPER_DUMP_RTGROUPS"); rg && !gpx.empty()) {
-                        size_t nz = 0; for (uint8_t b : gpx) nz += (b != 0);
+                    if (const char* rg = getenv("PROSPER_DUMP_RTGROUPS"); rg && !rendered_pixels.empty()) {
+                        size_t nz = 0; for (uint8_t b : rendered_pixels) nz += (b != 0);
                         if (nz >= (size_t)atol(rg)) {
                             const char* dd = getenv("PROSPER_FRAME_DIR");
                             char fn[512]; snprintf(fn, sizeof fn, "%s/rtgrp_%llx_%04d.bmp",
                                                    dd ? dd : ".", (unsigned long long)base, frame_no.load());
-                            prosper::test::dump_bmp(fn, gpx, gw, gh);
+                            prosper::test::dump_bmp(fn, rendered_pixels, gw, gh);
                         }
                     }
-                    if (!gpx.empty()) {
-                        if (base && base == front_va) px_front = gpx;                   // the flipped buffer
-                        if (is_vo)                    px_vo    = gpx;                   // any registered scanout
-                        px = std::move(gpx);                                            // last non-empty (fallback)
+                    if (!rendered_pixels.empty()) {
+                        if (base && base == front_va) px_front = pass_pixels;  // the flipped buffer
+                        if (is_vo)                    px_vo = pass_pixels;     // any registered scanout
+                        px_last = pass_pixels;                                  // last non-empty (fallback)
                     }
                 }
                 // Present priority: the flipped front buffer > any registered scanout target > the
                 // legacy "last group" fallback (unchanged behavior when no group targets a VO buffer).
-                if (!px_front.empty())   px = std::move(px_front);
-                else if (!px_vo.empty()) px = std::move(px_vo);
+                selected_pixels = px_front ? px_front : (px_vo ? px_vo : px_last);
             } else {
                 // Single-framebuffer path: render_draws_rgba composites every draw into ONE framebuffer.
                 std::vector<const prosper::gpu::DrawItem*> all; all.reserve(items.size());
@@ -1198,7 +1321,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     for (int i = 0; i < prosper_vo_buffer_count(); ++i)
                         if ((scanout = cached_scanout(prosper_vo_buffer_addr(i)))) break;
                 }
-                if (scanout) px = scanout->rgba;
+                if (scanout) selected_pixels = &scanout->rgba;
+            }
+            if (phase.final_span && selected_pixels) {
+                const auto copy_start = timing_enabled
+                    ? RenderClock::now() : RenderClock::time_point{};
+                px.assign(selected_pixels->begin(), selected_pixels->end());
+                if (timing_enabled)
+                    pending_timing.output_copy_ms += std::chrono::duration<double, std::milli>(
+                        RenderClock::now() - copy_start).count();
             }
             if (!phase.final_span) {
                 if (timing_enabled) {
@@ -1227,8 +1358,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     RenderClock::now() - callback_timing_start).count();
                 struct TimingTotals {
                     uint64_t submits = 0, callbacks = 0;
-                    double total_ms = 0, build_resources_ms = 0, backend_ms = 0;
+                    double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
                     uint64_t textures = 0, texture_reuses = 0, buffers = 0;
+                    uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                     uint64_t texture_bytes = 0, buffer_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                 };
@@ -1240,8 +1372,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.total_ms += pending_timing.total_ms;
                     timing.build_resources_ms += pending_timing.build_resources_ms;
                     timing.backend_ms += pending_timing.backend_ms;
+                    timing.output_copy_ms += pending_timing.output_copy_ms;
                     timing.textures += pending_timing.textures;
                     timing.texture_reuses += pending_timing.texture_reuses;
+                    timing.persistent_hits += pending_timing.persistent_hits;
+                    timing.persistent_misses += pending_timing.persistent_misses;
+                    timing.persistent_invalidations += pending_timing.persistent_invalidations;
                     timing.buffers += pending_timing.buffers;
                     timing.texture_bytes += pending_timing.texture_bytes;
                     timing.buffer_bytes += pending_timing.buffer_bytes;
@@ -1252,13 +1388,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 accumulate(window);
                 if (totals.submits % 25 == 0) {
                     const double nsub = static_cast<double>(totals.submits);
-                    const double other = totals.total_ms - totals.build_resources_ms - totals.backend_ms;
+                    const double other = totals.total_ms - totals.build_resources_ms - totals.backend_ms -
+                                         totals.output_copy_ms;
                     fprintf(stderr,
                             "[render-timing] frontend submits=%llu callbacks=%llu avg_ms: total=%.2f "
-                            "build_resources=%.2f backend=%.2f other=%.2f\n",
+                            "build_resources=%.2f backend=%.2f output_copy=%.2f other=%.2f\n",
                             (unsigned long long)totals.submits, (unsigned long long)totals.callbacks,
                             totals.total_ms / nsub, totals.build_resources_ms / nsub,
-                            totals.backend_ms / nsub, other / nsub);
+                            totals.backend_ms / nsub, totals.output_copy_ms / nsub, other / nsub);
                     fprintf(stderr,
                             "[render-timing] resources textures=%llu reused=%llu %.1f MiB %.2f ms/submit; "
                             "buffers=%llu %.1f MiB %.2f ms/submit\n",
@@ -1267,20 +1404,33 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.texture_bytes / (1024.0 * 1024.0), totals.texture_ms / nsub,
                             (unsigned long long)totals.buffers,
                             totals.buffer_bytes / (1024.0 * 1024.0), totals.buffer_ms / nsub);
+                    fprintf(stderr,
+                            "[render-timing] texture_cache hits=%llu misses=%llu invalid=%llu entries=%zu %.1f MiB\n",
+                            (unsigned long long)totals.persistent_hits,
+                            (unsigned long long)totals.persistent_misses,
+                            (unsigned long long)totals.persistent_invalidations,
+                            persistent_decoded_textures.size(),
+                            persistent_decoded_texture_bytes / (1024.0 * 1024.0));
                     const double wn = static_cast<double>(window.submits);
                     const double window_other = window.total_ms - window.build_resources_ms -
-                                                window.backend_ms;
+                                                window.backend_ms - window.output_copy_ms;
                     fprintf(stderr,
                             "[render-window] frontend submits=%llu callbacks=%.1f avg_ms: total=%.2f "
-                            "build_resources=%.2f backend=%.2f other=%.2f; resources textures=%.1f "
+                            "build_resources=%.2f backend=%.2f output_copy=%.2f other=%.2f; "
+                            "resources textures=%.1f "
                             "reused=%.1f %.1f MiB %.2f ms buffers=%.1f %.1f MiB %.2f ms\n",
                             (unsigned long long)window.submits, window.callbacks / wn,
                             window.total_ms / wn, window.build_resources_ms / wn,
-                            window.backend_ms / wn, window_other / wn, window.textures / wn,
+                            window.backend_ms / wn, window.output_copy_ms / wn, window_other / wn,
+                            window.textures / wn,
                             window.texture_reuses / wn,
                             window.texture_bytes / (wn * 1024.0 * 1024.0), window.texture_ms / wn,
                             window.buffers / wn, window.buffer_bytes / (wn * 1024.0 * 1024.0),
                             window.buffer_ms / wn);
+                    fprintf(stderr,
+                            "[render-window] texture_cache hits=%.1f misses=%.1f invalid=%.1f\n",
+                            window.persistent_hits / wn, window.persistent_misses / wn,
+                            window.persistent_invalidations / wn);
                     window = {};
                 }
             }

--- a/prosper/scripts/start-prosper.ps1
+++ b/prosper/scripts/start-prosper.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Dump,
+
+    [string]$SavedataDir = (Join-Path $PSScriptRoot 'savedata'),
+    [string]$GuestArgs = '-force-gfx-direct',
+    [string]$Record,
+    [int]$Frames = 0,
+    [switch]$TestPattern
+)
+
+$ErrorActionPreference = 'Stop'
+$app = Join-Path $PSScriptRoot 'prosper-app.exe'
+
+if (-not (Test-Path -LiteralPath $app -PathType Leaf)) {
+    throw "prosper-app.exe must be beside this script: $app"
+}
+
+$runArgs = @()
+if ($TestPattern) {
+    $runArgs += '--test-pattern'
+} else {
+    if (-not $Dump) { throw 'Pass an app0 dump directory, or use -TestPattern.' }
+    $Dump = (Resolve-Path -LiteralPath $Dump).Path
+    if (-not (Test-Path -LiteralPath $Dump -PathType Container)) {
+        throw "Dump is not a directory: $Dump"
+    }
+
+    $SavedataDir = [IO.Path]::GetFullPath($SavedataDir)
+    New-Item -ItemType Directory -Path $SavedataDir -Force | Out-Null
+    $env:PROSPER_GUEST_FS = '1'
+    $env:PROSPER_GUEST_ARGS = $GuestArgs
+    $env:PROSPER_SAVEDATA_DIR = $SavedataDir
+    $runArgs += @('--dump', $Dump)
+}
+
+if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
+if ($Record) {
+    $recordPath = [IO.Path]::GetFullPath($Record)
+    $recordParent = Split-Path -Parent $recordPath
+    if ($recordParent) { New-Item -ItemType Directory -Path $recordParent -Force | Out-Null }
+    $runArgs += @('--record', $recordPath)
+}
+
+& $app @runArgs
+if ($LASTEXITCODE -ne 0) { throw "prosper-app exited with code $LASTEXITCODE" }

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1361,8 +1361,9 @@ bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std
     return true;
 }
 
-std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector<DrawItem>& items,
-                                                               uint32_t width, uint32_t height) {
+std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
+    const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
+    const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height) {
     const char* path = std::getenv("PROSPER_GPU_CAPTURE"); if (!path || !*path) return {};
     static std::atomic<uint64_t> invocation_sequence{0};
     const uint64_t invocation = invocation_sequence.fetch_add(1);
@@ -1372,7 +1373,7 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
     uint64_t min_draws = 0, max_draws = std::numeric_limits<uint64_t>::max();
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MIN_DRAWS")) min_draws = std::strtoull(v, nullptr, 0);
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MAX_DRAWS")) max_draws = std::strtoull(v, nullptr, 0);
-    if (items.size() < min_draws || items.size() > max_draws) return {};
+    if (draws.size() < min_draws || draws.size() > max_draws) return {};
     static std::atomic<uint64_t> sequence{0}; static std::atomic<bool> claimed{false};
     uint64_t current = sequence.fetch_add(1), wanted = 0;
     if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);
@@ -1401,13 +1402,15 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector
     };
     for (const char* name : render_env) if (const char* value = std::getenv(name)) m.renderer_env.emplace_back(name, value);
     std::string error;
-    if (!capture_draw_items(items, m, read_capture_guest_memory,
-                            pending->capture, error, g_rtt_seed_reader)) {
+    if (!capture_submit_items(draws, computes, operations, m, read_capture_guest_memory,
+                              pending->capture, error, g_rtt_seed_reader)) {
         std::fprintf(stderr, "[gpucap] capture failed: %s\n", error.c_str()); return {};
     }
-    std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu blobs, %zu RTT seeds -> %s\n",
+    std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu computes, "
+                         "%zu operations, %zu blobs, %zu RTT seeds -> %s\n",
                  static_cast<unsigned long long>(current), static_cast<unsigned long long>(invocation),
-                 items.size(), pending->capture.blobs.size(), pending->capture.rtt_seeds.size(), path);
+                 draws.size(), computes.size(), operations.size(), pending->capture.blobs.size(),
+                 pending->capture.rtt_seeds.size(), path);
     return pending;
 }
 

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -254,8 +254,9 @@ struct PendingGpuCapture {
     std::string path;
     GpuCaptureFile capture;
 };
-std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(const std::vector<DrawItem>& items,
-                                                               uint32_t width, uint32_t height);
+std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
+    const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
+    const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height);
 bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
                                   const std::vector<uint8_t>& output, std::string& error);
 

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -111,6 +111,21 @@ std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             uint32_t user_sgpr_base,
                                             std::vector<SrtUse>* srt_uses = nullptr);
 
+// The dynamic descriptor fold and shader-cache key builder both walk immutable shader instructions
+// on every draw. Cache only the decoded instructions, validating the complete consumed byte range on
+// every hit. Concrete SGPR values and descriptor-table memory remain per-draw inputs to the fold.
+struct ShaderDecodeCacheStats {
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t bypasses = 0;
+    uint64_t invalidations = 0;
+    uint64_t evictions = 0;
+    uint64_t entries = 0;
+    uint64_t bytes = 0;
+};
+ShaderDecodeCacheStats shader_decode_cache_stats();
+void clear_shader_decode_cache();
+
 // PROSPER_DYNTRACE_FAIL support (gpu_executor.cpp): while true, resolve_dynamic_fetch traces its
 // walk and build_stage_table dumps the user-data SGPR blocks. realize_draw_item sets it around a
 // replay of a FAILED vertex-stage resource build, so the diagnostic captures exactly the failing
@@ -191,6 +206,15 @@ struct DrawRealizationPhaseStats {
 };
 void record_draw_realization_phases(double table_ms, double shader_ms);
 DrawRealizationPhaseStats draw_realization_phase_stats();
+
+struct StageTablePhaseStats {
+    uint64_t calls = 0;
+    double metadata_ms = 0.0;
+    double dynamic_fold_ms = 0.0;
+    double resources_ms = 0.0;
+};
+void record_stage_table_phases(double metadata_ms, double dynamic_fold_ms, double resources_ms);
+StageTablePhaseStats stage_table_phase_stats();
 
 enum class RealizationFailureReason : uint8_t {
     None,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <bitset>
 #include <iterator>
 #include <mutex>
 #include <set>
@@ -132,6 +133,126 @@ ShaderCache& shader_cache() {
     return cache;
 }
 
+struct DecodedShader {
+    std::vector<uint32_t> code;
+    std::vector<Rdna2Inst> instructions;
+    size_t source_dwords = 0;
+    bool terminated = false;
+    uint64_t bytes = 0;
+};
+
+struct DecodedShaderEntry {
+    std::shared_ptr<const DecodedShader> shader;
+    uint64_t last_use = 0;
+};
+
+struct ShaderDecodeCache {
+    std::mutex mutex;
+    std::unordered_map<uintptr_t, DecodedShaderEntry> entries;
+    ShaderDecodeCacheStats stats;
+    uint64_t use_counter = 0;
+};
+
+ShaderDecodeCache& shader_decode_cache() {
+    static ShaderDecodeCache cache;
+    return cache;
+}
+
+uint64_t shader_decode_cache_limit_bytes() {
+    constexpr uint64_t default_bytes = 64ull * 1024 * 1024;
+    const char* value = getenv("PROSPER_SHADER_DECODE_CACHE_MB");
+    if (!value || !*value) return default_bytes;
+    char* end = nullptr;
+    const unsigned long long mib = strtoull(value, &end, 10);
+    if (end == value || *end != '\0') return default_bytes;
+    return std::min<uint64_t>(mib, 1024ull) * 1024 * 1024;
+}
+
+std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, size_t dwords) {
+    auto decode = [&] {
+        auto result = std::make_shared<DecodedShader>();
+        result->source_dwords = dwords;
+        std::vector<Rdna2Inst> decoded;
+        const size_t consumed = rdna2_walk(code, dwords, decoded);
+        result->code.assign(code, code + consumed);
+        if (!decoded.empty()) {
+            const Rdna2Inst& last = decoded.back();
+            result->terminated = last.is_end || last.fmt == Rdna2Format::Unknown ||
+                                 last.len_dwords == 0;
+        }
+        // The fold ignores vector/control/export instructions unless the decoder reports an SGPR
+        // destination (the conservative unknown-value invalidation). Retain only instructions that can
+        // affect its state or emit a descriptor use, preserving their original order and PCs.
+        result->instructions.reserve(decoded.size());
+        for (const Rdna2Inst& instruction : decoded) {
+            if (instruction.is_end) break;
+            const bool fold_format = instruction.fmt == Rdna2Format::SOP1 ||
+                                     instruction.fmt == Rdna2Format::SOP2 ||
+                                     instruction.fmt == Rdna2Format::SOPC ||
+                                     instruction.fmt == Rdna2Format::SOPK ||
+                                     instruction.fmt == Rdna2Format::SMEM ||
+                                     instruction.fmt == Rdna2Format::MIMG ||
+                                     instruction.fmt == Rdna2Format::MUBUF;
+            if (fold_format || instruction.dst.kind == OperandKind::SGPR)
+                result->instructions.push_back(instruction);
+        }
+        result->bytes = static_cast<uint64_t>(result->code.size()) * sizeof(uint32_t) +
+                        static_cast<uint64_t>(result->instructions.size()) * sizeof(Rdna2Inst);
+        return result;
+    };
+
+    if (!code || !dwords) return decode();
+    auto& cache = shader_decode_cache();
+    if (getenv("PROSPER_NO_SHADER_DECODE_CACHE")) {
+        std::lock_guard lock(cache.mutex);
+        ++cache.stats.bypasses;
+        return decode();
+    }
+
+    const uintptr_t address = reinterpret_cast<uintptr_t>(code);
+    {
+        std::lock_guard lock(cache.mutex);
+        auto found = cache.entries.find(address);
+        if (found != cache.entries.end()) {
+            const auto& cached = found->second.shader;
+            const bool compatible_length = cached->terminated || cached->source_dwords == dwords;
+            const uint64_t code_bytes = static_cast<uint64_t>(cached->code.size()) * sizeof(uint32_t);
+            const bool readable = code_bytes == 0 ||
+                                  (code_bytes <= UINT32_MAX && guest_readable(address, (uint32_t)code_bytes));
+            if (compatible_length && cached->code.size() <= dwords && readable &&
+                (code_bytes == 0 || memcmp(code, cached->code.data(), (size_t)code_bytes) == 0)) {
+                ++cache.stats.hits;
+                found->second.last_use = ++cache.use_counter;
+                return cached;
+            }
+            cache.stats.bytes -= cached->bytes;
+            cache.entries.erase(found);
+            ++cache.stats.invalidations;
+        }
+        ++cache.stats.misses;
+    }
+
+    auto decoded = decode();
+    std::lock_guard lock(cache.mutex);
+    constexpr size_t max_entries = 4096;
+    const uint64_t limit = shader_decode_cache_limit_bytes();
+    while (!cache.entries.empty() &&
+           (cache.entries.size() >= max_entries || cache.stats.bytes + decoded->bytes > limit)) {
+        auto oldest = cache.entries.begin();
+        for (auto it = std::next(cache.entries.begin()); it != cache.entries.end(); ++it)
+            if (it->second.last_use < oldest->second.last_use) oldest = it;
+        cache.stats.bytes -= oldest->second.shader->bytes;
+        cache.entries.erase(oldest);
+        ++cache.stats.evictions;
+    }
+    if (decoded->bytes <= limit && max_entries != 0) {
+        cache.entries[address] = {decoded, ++cache.use_counter};
+        cache.stats.bytes += decoded->bytes;
+    }
+    cache.stats.entries = cache.entries.size();
+    return decoded;
+}
+
 uint64_t shader_cache_limit_bytes() {
     constexpr uint64_t default_bytes = 128ull * 1024 * 1024;
     const char* value = getenv("PROSPER_SHADER_CACHE_MB");
@@ -183,6 +304,22 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
 }
 
 } // namespace
+
+ShaderDecodeCacheStats shader_decode_cache_stats() {
+    auto& cache = shader_decode_cache();
+    std::lock_guard lock(cache.mutex);
+    ShaderDecodeCacheStats stats = cache.stats;
+    stats.entries = cache.entries.size();
+    return stats;
+}
+
+void clear_shader_decode_cache() {
+    auto& cache = shader_decode_cache();
+    std::lock_guard lock(cache.mutex);
+    cache.entries.clear();
+    cache.stats = {};
+    cache.use_counter = 0;
+}
 
 std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
@@ -264,6 +401,65 @@ DrawRealizationPhaseStats draw_realization_phase_stats() {
     return g_draw_realization_phases;
 }
 
+thread_local StageTablePhaseStats g_stage_table_phases;
+
+void record_stage_table_phases(double metadata_ms, double dynamic_fold_ms, double resources_ms) {
+    ++g_stage_table_phases.calls;
+    g_stage_table_phases.metadata_ms += metadata_ms;
+    g_stage_table_phases.dynamic_fold_ms += dynamic_fold_ms;
+    g_stage_table_phases.resources_ms += resources_ms;
+}
+
+StageTablePhaseStats stage_table_phase_stats() {
+    return g_stage_table_phases;
+}
+
+namespace {
+
+struct GuestReadableRange { uint64_t begin = 0, end = 0; };
+struct GuestReadableCacheState {
+    bool active = false;
+    std::vector<GuestReadableRange> ranges;
+    uint64_t calls = 0, hits = 0, os_probes = 0;
+};
+thread_local GuestReadableCacheState g_guest_readable_cache;
+
+bool guest_range_cache_hit(uint64_t begin, uint64_t end) {
+    if (!g_guest_readable_cache.active) return false;
+    ++g_guest_readable_cache.calls;
+    for (const auto& range : g_guest_readable_cache.ranges) {
+        if (begin >= range.begin && end <= range.end) {
+            ++g_guest_readable_cache.hits;
+            return true;
+        }
+    }
+    return false;
+}
+
+void cache_guest_readable_range(uint64_t begin, uint64_t end) {
+    if (!g_guest_readable_cache.active || begin >= end) return;
+    for (auto it = g_guest_readable_cache.ranges.begin(); it != g_guest_readable_cache.ranges.end();) {
+        if (end < it->begin || begin > it->end) { ++it; continue; }
+        begin = std::min(begin, it->begin);
+        end = std::max(end, it->end);
+        it = g_guest_readable_cache.ranges.erase(it);
+    }
+    g_guest_readable_cache.ranges.push_back({begin, end});
+}
+
+struct GuestReadableSubmitScope {
+    GuestReadableSubmitScope() {
+        g_guest_readable_cache = {};
+        g_guest_readable_cache.active = getenv("PROSPER_NO_GUEST_READ_CACHE") == nullptr;
+    }
+    ~GuestReadableSubmitScope() {
+        g_guest_readable_cache.active = false;
+        g_guest_readable_cache.ranges.clear();
+    }
+};
+
+} // namespace
+
 // Readability probe (guest memory is 1:1-mapped, but a mis-decoded address could be unmapped),
 // so guarded derefs on the render/submit thread don't risk a SIGSEGV. NOTE: /dev/null does NOT
 // work for this — the kernel's null_write returns count without ever touching the source buffer,
@@ -304,19 +500,26 @@ static bool probe_byte(uint64_t a) {
 bool guest_readable(uint64_t a, uint32_t n) {
     if (a < 0x1000 || n == 0) return false;
     if (a + n < a) return false;   // wrap
+    const uint64_t end = a + n;
+    if (guest_range_cache_hit(a, end)) return true;
     if (!probe_pipe_ok()) return false;
     uint64_t last_page = (a + n - 1) & ~0xfffull;
-    for (uint64_t p = a & ~0xfffull; p <= last_page; p += 0x1000)
+    for (uint64_t p = a & ~0xfffull; p <= last_page; p += 0x1000) {
+        if (g_guest_readable_cache.active) ++g_guest_readable_cache.os_probes;
         if (!probe_byte(p < a ? a : p)) return false;
+    }
+    cache_guest_readable_range(a & ~0xfffull, last_page + 0x1000);
     return true;
 }
 #else
 bool guest_readable(uint64_t a, uint32_t n) {
     if (a < 0x1000 || n == 0 || a + n < a) return false;
     const uint64_t end = a + n;
+    if (guest_range_cache_hit(a, end)) return true;
     uint64_t cursor = a;
     while (cursor < end) {
         MEMORY_BASIC_INFORMATION mbi{};
+        if (g_guest_readable_cache.active) ++g_guest_readable_cache.os_probes;
         if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
         const DWORD blocked = PAGE_NOACCESS | PAGE_GUARD;
         if (mbi.State != MEM_COMMIT || (mbi.Protect & blocked)) return false;
@@ -325,6 +528,7 @@ bool guest_readable(uint64_t a, uint32_t n) {
         if (!(mbi.Protect & readable)) return false;
         const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
         if (region_end <= cursor) return false;
+        cache_guest_readable_range((uint64_t)(uintptr_t)mbi.BaseAddress, region_end);
         cursor = std::min(end, region_end);
     }
     return true;
@@ -347,8 +551,8 @@ std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
                       uint32_t user_sgpr_base, std::vector<SrtUse>* srt_uses) {
     std::vector<DynFetch> out;
-    std::vector<Rdna2Inst> ins;
-    rdna2_walk(code, dwords, ins);
+    const auto decoded = decode_shader_cached(code, dwords);
+    const auto& ins = decoded->instructions;
 
     // PROSPER_DYNTRACE traces the whole const-fold walk; PROSPER_DYNTRACE_ADDR=<hex code addr>
     // narrows it to ONE shader (a full run otherwise traces every draw's walk — unusable volume).
@@ -358,24 +562,42 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     if (trc && !g_dyntrace_force)
         if (const char* fa = getenv("PROSPER_DYNTRACE_ADDR"))
             trc = strtoull(fa, nullptr, 16) == (uint64_t)(uintptr_t)code;
-    std::unordered_map<int, uint32_t> val;                 // known concrete SGPR values (by SHADER SGPR #)
-    std::unordered_map<int, std::array<uint32_t, 4>> descr; // SGPR -> the 4-dword V# it holds (load-time snapshot)
+    // Scalar operands encode at most 128 SGPRs. Fixed register files avoid hundreds of tiny hash/tree
+    // allocations per submit while retaining exactly the same known/unknown state model.
+    constexpr size_t kFoldSgprs = 128;
+    std::array<uint32_t, kFoldSgprs> val{};                 // concrete SGPR values
+    std::bitset<kFoldSgprs> val_known;
+    std::array<std::array<uint32_t, 4>, kFoldSgprs> descr{}; // load-time V# snapshots by base SGPR
+    std::bitset<kFoldSgprs> descr_known;
     // Descriptor-TABLE provenance (#294): for each snapshotted 4/8-dword s_load, the load's IMMEDIATE
     // byte offset — the recompiler's sreg_srt/by_srt_offset key. 0xFFFFFFFF = not provenance-usable
     // (register-SOFFSET or negative-immediate load, which emit_alu doesn't tag).
-    std::unordered_map<int, uint32_t> descr_key;
-    std::unordered_map<int, std::array<uint32_t, 8>> descr8;  // SGPR -> 8-dword T# (load-time snapshot)
-    std::unordered_map<int, uint32_t> descr8_key;
+    std::array<uint32_t, kFoldSgprs> descr_key{};
+    std::bitset<kFoldSgprs> descr_key_known;
+    std::array<std::array<uint32_t, 8>, kFoldSgprs> descr8{};  // load-time T# snapshots by base SGPR
+    std::bitset<kFoldSgprs> descr8_known;
+    std::array<uint32_t, kFoldSgprs> descr8_key{};
+    std::bitset<kFoldSgprs> descr8_key_known;
     // SGPRs overwritten by an s_load since seeding — the seed-V# MUBUF fallback below must not use a
     // stale user-data snapshot once the register was RELOADED from memory (ALU patches deliberately
     // don't count: descriptor snapshots are load-time semantics, pre-patch, like `descr`).
-    std::set<int> reloaded;
+    std::bitset<kFoldSgprs> reloaded;
     int scc = -1;   // tracked SCC (-1 unknown): set by s_cmp_*, consumed by s_cselect (the format patch's tail)
     // The SPI loads the user-data block starting at shader SGPR `user_sgpr_base` (s0..s7 are NGG system
     // SGPRs). So user-data block index k lands in shader SGPR (user_sgpr_base + k).
-    for (uint32_t i = 0; i < nsgpr; i++) val[(int)(user_sgpr_base + i)] = user_sgprs[i];
+    auto valid_reg = [](int r) { return r >= 0 && r < (int)kFoldSgprs; };
+    auto set_value = [&](int r, uint32_t v) {
+        if (valid_reg(r)) { val[(size_t)r] = v; val_known.set((size_t)r); }
+    };
+    auto forget = [&](int r) { if (valid_reg(r)) val_known.reset((size_t)r); };
+    for (uint32_t i = 0; i < nsgpr; i++)
+        set_value((int)(user_sgpr_base + i), user_sgprs[i]);
 
-    auto known = [&](int r, uint32_t& v) { auto it = val.find(r); if (it == val.end()) return false; v = it->second; return true; };
+    auto known = [&](int r, uint32_t& v) {
+        if (!valid_reg(r) || !val_known.test((size_t)r)) return false;
+        v = val[(size_t)r];
+        return true;
+    };
     // Resolve an ALU source operand to a concrete value (SGPR / inline int / literal / a vcc Special).
     // vcc_lo/hi (106/107) are written by ALU dsts as SGPR 106/107 but read back as Special operands with
     // the same field value, so map them onto the same val[] keys. Other Specials (EXEC/M0/...) stay unknown.
@@ -396,8 +618,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 if (in.opcode == 0x03) {                        // s_mov_b32
                     uint32_t v;
                     if (in.src[0].kind == OperandKind::Literal ? (v = in.literal, true) : srcval(in.src[0], v))
-                        val[in.dst.value] = v;
-                    else val.erase(in.dst.value);
+                        set_value(in.dst.value, v);
+                    else forget(in.dst.value);
                 } else if (in.dst.kind == OperandKind::SGPR) {
                     // Not the modeled s_mov_b32 -> the dest is unknown. Erase the PAIR: 64-bit SOP1 ops
                     // (s_mov_b64, s_getpc_b64, s_and/or/xor/not_b64, s_*_saveexec_b64, …) write
@@ -405,8 +627,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     // confidently-wrong 64-bit base/offset -> a wrong V#/T# read from the wrong guest
                     // address (#460). Over-erasing dst+1 for a 32-bit SOP1 only loses a fold opportunity
                     // (never fabricates a value) — matching the SOP2 s_bfe_u64 pair-erase.
-                    val.erase(in.dst.value);
-                    val.erase(in.dst.value + 1);
+                    forget(in.dst.value);
+                    forget(in.dst.value + 1);
                 }
                 // Several SOP1 ops write SCC (s_abs_i32, s_not_b32, s_and_saveexec_*, …). Only the moves
                 // (s_mov_b32 0x03 / s_mov_b64 0x04) are known not to — anything else invalidates the
@@ -461,10 +683,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // Every SOP2 ALU op except s_cselect writes SCC to a value we don't track here — invalidate so a
                 // later s_cselect only trusts SCC set by an immediately-preceding s_cmp.
                 if (in.opcode != 0x0A) scc = -1;
-                if (ok) { val[d] = r; if (wrote_pair) val[d + 1] = hi64; }
+                if (ok) { set_value(d, r); if (wrote_pair) set_value(d + 1, hi64); }
                 // A 64-bit-dst op (s_bfe_u64) invalidates BOTH dwords even when its sources were
                 // unknown (the opcode switch never ran, so wrote_pair may still be false).
-                else    { val.erase(d); if (wrote_pair || in.opcode == 0x29) val.erase(d + 1); }
+                else    { forget(d); if (wrote_pair || in.opcode == 0x29) forget(d + 1); }
                 break;
             }
             case Rdna2Format::SOPC: {   // scalar compare -> SCC (feeds the format patch's s_cselect)
@@ -512,13 +734,16 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // immediate (matching the recompiler's sreg_srt tag). Recorded BEFORE the dest write
                 // below (SBASE and SDST ranges may overlap).
                 if (srt_uses && is_buffer) {
-                    auto dit = descr.find(sbase); auto kit = descr_key.find(sbase);
-                    if (dit != descr.end() && kit != descr_key.end() && kit->second != 0xFFFFFFFFu) {
-                        SrtUse u; u.kind = 1; u.key = kit->second; u.v4 = dit->second;
+                    if (valid_reg(sbase) && descr_known.test((size_t)sbase) &&
+                        descr_key_known.test((size_t)sbase) &&
+                        descr_key[(size_t)sbase] != 0xFFFFFFFFu) {
+                        SrtUse u; u.kind = 1; u.key = descr_key[(size_t)sbase];
+                        u.v4 = descr[(size_t)sbase];
                         srt_uses->push_back(u);
                     }
                 }
-                for (uint32_t k = 0; k < n; k++) reloaded.insert(sdst + (int)k);   // dest now holds memory data
+                for (uint32_t k = 0; k < n; k++)
+                    if (valid_reg(sdst + (int)k)) reloaded.set((size_t)(sdst + (int)k));
                 uint64_t base = 0; bool base_ok;
                 if (is_buffer) { uint32_t b0, b1; base_ok = known(sbase, b0) && known(sbase + 1, b1);
                                  base = ((uint64_t)b0 | ((uint64_t)b1 << 32)) & 0xFFFFFFFFFFFFull; }   // V#.Base48
@@ -528,14 +753,17 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                  "soff_field=%u soff_val=0x%x soff_ok=%d imm=0x%x n=%u\n", in.opcode,
                                  is_buffer ? "bufload" : "load", sdst, sbase, (unsigned long long)base, base_ok,
                                  soff_field, soff_val, soff_ok, in.literal, n);
-                if (n == 0 || !base_ok || !soff_ok) { for (uint32_t k = 0; k < n; k++) val.erase(sdst + (int)k); break; }
+                if (n == 0 || !base_ok || !soff_ok) {
+                    for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k);
+                    break;
+                }
                 // in.literal is the SIGN-EXTENDED 21-bit immediate (#149) — add it as signed so a
                 // negative offset subtracts from the base instead of wrapping to a huge address.
                 uint64_t addr = base + (uint64_t)(int64_t)(int32_t)in.literal + soff_val;
                 if (!guest_readable(addr, n * 4)) { if (trc) fprintf(stderr, "[dyntrace]   addr 0x%llx unreadable\n", (unsigned long long)addr);
-                                                    for (uint32_t k = 0; k < n; k++) val.erase(sdst + (int)k); break; }
+                                                    for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k); break; }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
-                for (uint32_t k = 0; k < n; k++) val[sdst + (int)k] = mem[k];
+                for (uint32_t k = 0; k < n; k++) set_value(sdst + (int)k, mem[k]);
                 // Provenance key: the recompiler tags an IMMEDIATE-only descriptor load's dest SGPRs
                 // with the load immediate (sreg_srt = in.literal); register-SOFFSET / negative loads
                 // are not tagged, so mark those snapshots key-less.
@@ -543,11 +771,22 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // A 4-dword load is a V# candidate — snapshot it now (before any later stride patch) so a
                 // vertex fetch using these SGPRs resolves to the descriptor as loaded. An 8-dword load is
                 // a T# candidate (image_sample SRSRC), snapshotted the same way (#294).
-                if (n == 4) { descr[sdst] = { mem[0], mem[1], mem[2], mem[3] };
+                if (n == 4 && valid_reg(sdst)) {
+                              descr[(size_t)sdst] = { mem[0], mem[1], mem[2], mem[3] };
+                              descr_known.set((size_t)sdst);
                               // only s_load (not s_buffer_load) dests get the recompiler's sreg_srt tag
-                              descr_key[sdst] = (imm_only && !is_buffer) ? in.literal : 0xFFFFFFFFu; }
-                if (n == 8) { descr8[sdst] = { mem[0], mem[1], mem[2], mem[3], mem[4], mem[5], mem[6], mem[7] };
-                              descr8_key[sdst] = (imm_only && !is_buffer) ? in.literal : 0xFFFFFFFFu; }
+                              descr_key[(size_t)sdst] = (imm_only && !is_buffer)
+                                  ? in.literal : 0xFFFFFFFFu;
+                              descr_key_known.set((size_t)sdst);
+                }
+                if (n == 8 && valid_reg(sdst)) {
+                              descr8[(size_t)sdst] = {
+                                  mem[0], mem[1], mem[2], mem[3], mem[4], mem[5], mem[6], mem[7] };
+                              descr8_known.set((size_t)sdst);
+                              descr8_key[(size_t)sdst] = (imm_only && !is_buffer)
+                                  ? in.literal : 0xFFFFFFFFu;
+                              descr8_key_known.set((size_t)sdst);
+                }
                 break;
             }
             case Rdna2Format::MIMG: {
@@ -558,18 +797,23 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // its instruction pc, which the recompiler resolves via ShaderResource::fetch_pc when
                 // the immediate-key model fails or collides.
                 if (srt_uses) {
-                    auto tit = descr8.find(in.src[1].value); auto kit = descr8_key.find(in.src[1].value);
+                    const int tbase = in.src[1].value;
+                    const int samp_base = in.src[2].value;
+                    const bool have_t8 = valid_reg(tbase) && descr8_known.test((size_t)tbase);
+                    const bool have_key = valid_reg(tbase) && descr8_key_known.test((size_t)tbase);
                     if (trc) fprintf(stderr, "[dyntrace] MIMG pc=%u srsrc=s%d ssamp=s%d have_t8=%d key=0x%x t8[0]=0x%x\n",
-                                     in.pc, in.src[1].value, in.src[2].value, tit != descr8.end(),
-                                     kit != descr8_key.end() ? kit->second : 0xEEEEEEEEu,
-                                     tit != descr8.end() ? tit->second[0] : 0u);
-                    if (tit != descr8.end()) {
-                        SrtUse u; u.kind = 0; u.t8 = tit->second;
-                        u.key = kit != descr8_key.end() ? kit->second : 0xFFFFFFFFu;
+                                     in.pc, tbase, samp_base, have_t8,
+                                     have_key ? descr8_key[(size_t)tbase] : 0xEEEEEEEEu,
+                                     have_t8 ? descr8[(size_t)tbase][0] : 0u);
+                    if (have_t8) {
+                        SrtUse u; u.kind = 0; u.t8 = descr8[(size_t)tbase];
+                        u.key = have_key ? descr8_key[(size_t)tbase] : 0xFFFFFFFFu;
                         u.use_pc = in.pc;
                         u.is_store = in.opcode == 0x08;   // image_store: a STORAGE-image use (#590)
-                        auto sit = descr.find(in.src[2].value);
-                        if (sit != descr.end()) { u.has_samp = true; u.s4 = sit->second; }
+                        if (valid_reg(samp_base) && descr_known.test((size_t)samp_base)) {
+                            u.has_samp = true;
+                            u.s4 = descr[(size_t)samp_base];
+                        }
                         srt_uses->push_back(u);
                     }
                 }
@@ -583,14 +827,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // use. (The VS vertex-fetch path below is unchanged: by_fetch_pc still wins there.)
                 if (srt_uses && (in.opcode <= 3 || (in.opcode >= 0x0C && in.opcode <= 0x0F))) {
                     int srsrc = in.src[1].value;
-                    auto dit = descr.find(srsrc); auto kit = descr_key.find(srsrc);
-                    if (dit != descr.end()) {
+                    if (valid_reg(srsrc) && descr_known.test((size_t)srsrc)) {
                         // Key-less snapshots (an s_buffer_load-fetched V# — a structured-buffer
                         // descriptor stored INSIDE a constant buffer, DOLL's title post PSes) carry
                         // the consuming instruction's pc instead; the recompiler resolves those via
                         // ShaderResource::fetch_pc with the faithful (non-vertex-index) address path.
-                        SrtUse u; u.kind = 1; u.v4 = dit->second;
-                        u.key = kit != descr_key.end() ? kit->second : 0xFFFFFFFFu;
+                        SrtUse u; u.kind = 1; u.v4 = descr[(size_t)srsrc];
+                        u.key = descr_key_known.test((size_t)srsrc)
+                            ? descr_key[(size_t)srsrc] : 0xFFFFFFFFu;
                         u.use_pc = in.pc;
                         srt_uses->push_back(u);
                     }
@@ -607,7 +851,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     uint32_t vv[4]; bool k0 = known(srsrc, vv[0]), k1 = known(srsrc + 1, vv[1]),
                                          k2 = known(srsrc + 2, vv[2]), k3 = known(srsrc + 3, vv[3]);
                     bool patched = k0 && k1 && k2 && k3;
-                    auto it = descr.find(srsrc);
+                    const bool have_descr = valid_reg(srsrc) && descr_known.test((size_t)srsrc);
                     // Fold the fetch's CONSTANT byte offset into the emitted V# base (#273 item 1, the
                     // "solid banner" bug): the recompiler's per-fetch (by_fetch_pc) address model is
                     // exactly gl_VertexIndex*stride from the resolved base — it assumes the attribute's
@@ -637,7 +881,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         return d;
                     };
                     if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x soff_known=%d\n",
-                                     in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3, k3 ? vv[3] : 0, it != descr.end(), fetch_off, (int)soff_known);
+                                     in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3,
+                                     k3 ? vv[3] : 0, have_descr, fetch_off, (int)soff_known);
                     // A real (non-NULL) SOFFSET the fold cannot resolve would silently collapse fetch_off's
                     // in-record component to 0 — every attribute reads base+inst_off (the "solid banner"
                     // collapse this fold was written to fix) or a wrong descriptor address. Leave the fetch
@@ -650,11 +895,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     // per vertex attribute — position, uv, color…). Keyed by the fetch's pc so the recompiler
                     // resolves each buffer_load_format to the descriptor as loaded at that instruction.
                     if (patched)          out.push_back({ in.pc, srsrc, with_off(decode_buffer_descriptor(vv)), vv[3] });
-                    else if (it != descr.end())
-                        out.push_back({ in.pc, srsrc, with_off(decode_buffer_descriptor(it->second.data())), it->second[3] });
+                    else if (have_descr)
+                        out.push_back({ in.pc, srsrc,
+                                        with_off(decode_buffer_descriptor(descr[(size_t)srsrc].data())),
+                                        descr[(size_t)srsrc][3] });
                     else if (srsrc >= (int)user_sgpr_base && srsrc + 4 <= (int)(user_sgpr_base + nsgpr) &&
-                             !reloaded.count(srsrc) && !reloaded.count(srsrc + 1) &&
-                             !reloaded.count(srsrc + 2) && !reloaded.count(srsrc + 3)) {
+                             valid_reg(srsrc + 3) && !reloaded.test((size_t)srsrc) &&
+                             !reloaded.test((size_t)(srsrc + 1)) &&
+                             !reloaded.test((size_t)(srsrc + 2)) &&
+                             !reloaded.test((size_t)(srsrc + 3))) {
                         // SEED fallback (#294): the SRSRC V# was placed directly in the user-data SGPRs
                         // by the driver (never s_loaded — so no `descr` snapshot) and the shader's
                         // stride/format patch left the CURRENT dwords partially unknown (its s_cselect
@@ -683,11 +932,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // interpreter doesn't model SOPK, so ANY SOPK conservatively invalidates the tracked SCC —
                 // a stale SCC consumed by a later s_cselect would fabricate a confidently-wrong V# patch.
                 scc = -1;
-                if (in.dst.kind == OperandKind::SGPR) val.erase(in.dst.value);
+                if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);
                 break;
             default:
                 // Remaining formats (SOPP, VALU, memory, …) don't write SCC, so the tracked SCC survives.
-                if (in.dst.kind == OperandKind::SGPR) val.erase(in.dst.value);   // unmodeled scalar write -> unknown
+                if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);   // unmodeled scalar write -> unknown
                 break;
         }
     }
@@ -726,6 +975,9 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     if (!code_addr) return nullptr;
     const auto* hdr = (const AgcShaderHeader*)prosper_agc_shader_header_for_code(code_addr);
     if (!hdr) return nullptr;
+    using StageClock = std::chrono::steady_clock;
+    const bool phase_timing = getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const auto metadata_start = phase_timing ? StageClock::now() : StageClock::time_point{};
     namespace P = prosper::agc::Pm4;
     const bool log = getenv("PROSPER_GFXLOG") != nullptr;
 
@@ -814,6 +1066,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     // becomes the resource's srt_offset (the recompiler's by_srt_offset provenance).
     std::vector<DynFetch> dyn_vb;
     std::vector<SrtUse> srt_uses;
+    const auto metadata_done = phase_timing ? StageClock::now() : StageClock::time_point{};
     if (is_ps) {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
         resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 0, &srt_uses);
@@ -846,6 +1099,16 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             }
         }
     }
+
+    const auto fold_done = phase_timing ? StageClock::now() : StageClock::time_point{};
+    auto record_phases = [&] {
+        if (!phase_timing) return;
+        const auto resources_done = StageClock::now();
+        record_stage_table_phases(
+            std::chrono::duration<double, std::milli>(metadata_done - metadata_start).count(),
+            std::chrono::duration<double, std::milli>(fold_done - metadata_done).count(),
+            std::chrono::duration<double, std::milli>(resources_done - fold_done).count());
+    };
 
     // NGG VS/GS loads user data at shader s8 (s0..s7 = system SGPRs); PS at s0. The resource sgpr_base
     // (an s_buffer_load/image_sample's SBASE/SRSRC register) is in that shader-SGPR space.
@@ -1029,10 +1292,13 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                 }
             }
         }
-        return std::make_shared<ShaderResourceTable>(std::move(t));
+        auto result = std::make_shared<ShaderResourceTable>(std::move(t));
+        record_phases();
+        return result;
     }
     if (log) fprintf(stderr, "[restab] %s code=0x%llx -> no resources in any user-data base\n",
                      is_ps ? "PS" : "VS", (unsigned long long)code_addr);
+    record_phases();
     return nullptr;
 }
 
@@ -1752,13 +2018,21 @@ bool execute_compute_items(const std::vector<ComputeItem>& items) {
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
                                  uint64_t submit_no) {
     if ((!g_live && !g_compute) || (st.draws.empty() && st.dispatches.empty())) return false;
+    // Guest allocations referenced by a GPU submit must remain mapped until that submit completes.
+    // Reuse positive page/VirtualQuery results only inside this synchronous execution window; the
+    // scope is discarded before guest code can submit a later mapping generation.
+    GuestReadableSubmitScope guest_readable_scope;
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     const ShaderRecompileCacheStats shader_before = timing_enabled
         ? shader_recompile_cache_stats() : ShaderRecompileCacheStats{};
+    const ShaderDecodeCacheStats decode_before = timing_enabled
+        ? shader_decode_cache_stats() : ShaderDecodeCacheStats{};
     const DrawRealizationPhaseStats phases_before = timing_enabled
         ? draw_realization_phase_stats() : DrawRealizationPhaseStats{};
+    const StageTablePhaseStats table_phases_before = timing_enabled
+        ? stage_table_phase_stats() : StageTablePhaseStats{};
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
@@ -1766,8 +2040,12 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
         ? realize_gpustate_draws(st, 0x10000, sx, sy) : std::vector<DrawItem>{};
     const ShaderRecompileCacheStats shader_after = timing_enabled
         ? shader_recompile_cache_stats() : ShaderRecompileCacheStats{};
+    const ShaderDecodeCacheStats decode_after = timing_enabled
+        ? shader_decode_cache_stats() : ShaderDecodeCacheStats{};
     const DrawRealizationPhaseStats phases_after = timing_enabled
         ? draw_realization_phase_stats() : DrawRealizationPhaseStats{};
+    const StageTablePhaseStats table_phases_after = timing_enabled
+        ? stage_table_phase_stats() : StageTablePhaseStats{};
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<ComputeItem> computes = g_compute
         ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
@@ -1775,18 +2053,17 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
 
     auto operations = plan_submit_operations(st);
     const auto timing_plan_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+    auto pending_capture = begin_requested_gpu_capture(
+        draws, computes, operations, width, height);
     OrderedSubmitResult result = execute_ordered_items(
         operations, draws, computes, g_live, g_compute, width, height);
     const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<uint8_t>& px = result.pixels;
 
-    if (!draws.empty()) {
-        auto pending = begin_requested_gpu_capture(draws, width, height);
-        if (pending) {
-            std::string error;
-            if (!finish_requested_gpu_capture(std::move(pending), px, error))
-                std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
-        }
+    if (pending_capture) {
+        std::string error;
+        if (!finish_requested_gpu_capture(std::move(pending_capture), px, error))
+            std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
     }
     const bool presented = px.size() == static_cast<size_t>(width) * height * 4;
     if (presented) present_write_frame(px.data(), width, height);
@@ -1798,8 +2075,11 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
         struct TimingTotals {
             uint64_t submits = 0, draws = 0, dispatches = 0, render_spans = 0;
             uint64_t shader_hits = 0, shader_misses = 0, shader_bypasses = 0;
+            uint64_t decode_hits = 0, decode_misses = 0, decode_invalidations = 0;
+            uint64_t readable_calls = 0, readable_hits = 0, readable_os_probes = 0;
             double realize_draws = 0, realize_compute = 0, plan = 0, backend = 0, publish = 0;
             double table_build = 0, shader_lookup = 0, shader_compile = 0;
+            double table_metadata = 0, table_dynamic_fold = 0, table_resources = 0;
         };
         static TimingTotals totals;
         static TimingTotals window;
@@ -1811,12 +2091,22 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
             timing.shader_hits += shader_after.hits - shader_before.hits;
             timing.shader_misses += shader_after.misses - shader_before.misses;
             timing.shader_bypasses += shader_after.bypasses - shader_before.bypasses;
+            timing.decode_hits += decode_after.hits - decode_before.hits;
+            timing.decode_misses += decode_after.misses - decode_before.misses;
+            timing.decode_invalidations += decode_after.invalidations - decode_before.invalidations;
+            timing.readable_calls += g_guest_readable_cache.calls;
+            timing.readable_hits += g_guest_readable_cache.hits;
+            timing.readable_os_probes += g_guest_readable_cache.os_probes;
             timing.realize_draws += ms(timing_start, timing_draws_ready);
             timing.realize_compute += ms(timing_draws_ready, timing_compute_ready);
             timing.plan += ms(timing_compute_ready, timing_plan_ready);
             timing.backend += ms(timing_plan_ready, timing_backend_done);
             timing.publish += ms(timing_backend_done, timing_done);
             timing.table_build += phases_after.table_ms - phases_before.table_ms;
+            timing.table_metadata += table_phases_after.metadata_ms - table_phases_before.metadata_ms;
+            timing.table_dynamic_fold += table_phases_after.dynamic_fold_ms -
+                                         table_phases_before.dynamic_fold_ms;
+            timing.table_resources += table_phases_after.resources_ms - table_phases_before.resources_ms;
             timing.shader_lookup += phases_after.shader_ms - phases_before.shader_ms;
             timing.shader_compile += shader_after.compile_ms - shader_before.compile_ms;
         };
@@ -1841,15 +2131,22 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
             std::fprintf(stderr,
                          "[render-window] submits=%llu avg_items: draws=%.1f dispatches=%.1f "
                          "spans=%.1f shaders: hit=%.1f miss=%.1f bypass=%.1f "
+                         "decode: hit=%.1f miss=%.1f invalid=%.1f "
+                         "readable: hit=%.1f/%.1f os=%.1f "
                          "avg_ms: total=%.2f realize_draws=%.2f tables=%.2f shader_lookup=%.2f "
-                         "shader_compile=%.2f "
+                         "shader_compile=%.2f table_parts: metadata=%.2f fold=%.2f resources=%.2f "
                          "realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f\n",
                          (unsigned long long)window.submits, window.draws / wn,
                          window.dispatches / wn, window.render_spans / wn,
                          window.shader_hits / wn, window.shader_misses / wn,
-                         window.shader_bypasses / wn, window_total / wn,
+                         window.shader_bypasses / wn, window.decode_hits / wn,
+                         window.decode_misses / wn, window.decode_invalidations / wn,
+                         window.readable_hits / wn, window.readable_calls / wn,
+                         window.readable_os_probes / wn, window_total / wn,
                          window.realize_draws / wn, window.table_build / wn,
                          window.shader_lookup / wn, window.shader_compile / wn,
+                         window.table_metadata / wn, window.table_dynamic_fold / wn,
+                         window.table_resources / wn,
                          window.realize_compute / wn, window.plan / wn, window.backend / wn,
                          window.publish / wn);
             window = {};
@@ -1870,7 +2167,12 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
     float sy = fh ? (float)height / (float)fh : 1.0f;
     std::vector<uint8_t> px = execute_gpustate(st,
         [&](const std::vector<DrawItem>& items) {
-            auto pending = begin_requested_gpu_capture(items, width, height);
+            std::vector<SubmitOperation> operations;
+            operations.reserve(items.size());
+            for (const auto& item : items)
+                operations.push_back({SubmitOperationKind::Draw,
+                                      static_cast<size_t>(item.draw_index), item.command_order});
+            auto pending = begin_requested_gpu_capture(items, {}, operations, width, height);
             std::vector<uint8_t> rendered = g_live(items, width, height);
             if (pending) {
                 std::string error;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -866,11 +866,21 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         uint32_t n_sets = 1, vcount = 3, icount = 0; bool use_desc = false, ok = false;
     };
     std::vector<DV> dv(draws.size());
+    double setup_shader_ms = 0.0;
+    double setup_fixed_ms = 0.0;
+    double setup_resources_ms = 0.0;
+    double setup_pipeline_ms = 0.0;
+    auto setup_elapsed_ms = [](auto begin, auto end) {
+        return std::chrono::duration<double, std::milli>(end - begin).count();
+    };
     // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
     for (size_t di = 0; di < draws.size(); di++) {
+        const auto setup_begin = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         const BackendDraw& bd = draws[di];
         DV& v = dv[di];
         v.vs = mkmod(bd.vs); v.fs = mkmod(bd.fs);
+        const auto setup_shaders_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) setup_shader_ms += setup_elapsed_ms(setup_begin, setup_shaders_ready);
         if (!v.vs || !v.fs) continue;   // rejected SPIR-V -> skip this draw
         const prosper::gpu::ResolvedPipelineState* ps = bd.ps;
         v.vcount = bd.vcount;
@@ -984,6 +994,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         ps->stencil_fail_op[0], ps->stencil_pass_op[0], ps->stencil_depth_fail_op[0], dss.front.reference, (int)ps->depth_test_enable);
         }
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
+        const auto setup_fixed_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) setup_fixed_ms += setup_elapsed_ms(setup_shaders_ready, setup_fixed_ready);
         v.R = bd.R; auto& R = v.R;
         v.use_desc = !R.empty();
         for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
@@ -1145,6 +1157,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             for (size_t i = 0; i < R.size(); i++) wr[i].dstSet = v.dsets[R[i].set];
             vkUpdateDescriptorSets(dev, (uint32_t)wr.size(), wr.data(), 0, nullptr);
         }
+        const auto setup_resources_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) setup_resources_ms += setup_elapsed_ms(setup_fixed_ready, setup_resources_ready);
         VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
         if (v.use_desc) { plci.setLayoutCount = v.n_sets; plci.pSetLayouts = v.dsls.data(); }
         vkCreatePipelineLayout(dev, &plci, nullptr, &v.layout);
@@ -1154,6 +1168,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         gp.pColorBlendState = &cb; gp.layout = v.layout; gp.renderPass = rp; gp.subpass = 0;
         if (ps && (ps->depth_test_enable || ps->stencil_enable)) gp.pDepthStencilState = &dss;
         if (vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) v.ok = true;
+        const auto setup_pipeline_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) setup_pipeline_ms += setup_elapsed_ms(setup_resources_ready, setup_pipeline_ready);
     }
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -1414,6 +1430,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         struct TimingTotals {
             uint64_t calls = 0, draws = 0;
             double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
+            double setup_shader = 0, setup_fixed = 0, setup_resources = 0, setup_pipeline = 0;
         };
         static TimingTotals totals;
         static TimingTotals window;
@@ -1426,6 +1443,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             timing.gpu_wait += ms(timing_recorded, timing_gpu_done);
             timing.readback += ms(timing_gpu_done, timing_readback_done);
             timing.cleanup += ms(timing_readback_done, timing_done);
+            timing.setup_shader += setup_shader_ms;
+            timing.setup_fixed += setup_fixed_ms;
+            timing.setup_resources += setup_resources_ms;
+            timing.setup_pipeline += setup_pipeline_ms;
         };
         accumulate(totals);
         accumulate(window);
@@ -1439,6 +1460,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     (unsigned long long)totals.calls, (unsigned long long)totals.draws, total / n,
                     totals.target / n, totals.draw_setup / n, totals.record / n,
                     totals.gpu_wait / n, totals.readback / n, totals.cleanup / n);
+            fprintf(stderr,
+                    "[render-timing] draw_setup avg_ms: shaders=%.2f fixed=%.2f resources=%.2f pipeline=%.2f\n",
+                    totals.setup_shader / n, totals.setup_fixed / n,
+                    totals.setup_resources / n, totals.setup_pipeline / n);
             const RenderMemoryPoolStats pool = render_memory_pool_stats();
             fprintf(stderr,
                     "[render-timing] memory_pool hits=%llu misses=%llu cached=%zu %.1f MiB "
@@ -1456,6 +1481,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     (unsigned long long)window.calls, window.draws / wn, window_total / wn,
                     window.target / wn, window.draw_setup / wn, window.record / wn,
                     window.gpu_wait / wn, window.readback / wn, window.cleanup / wn);
+            fprintf(stderr,
+                    "[render-window] draw_setup avg_ms: shaders=%.2f fixed=%.2f resources=%.2f pipeline=%.2f\n",
+                    window.setup_shader / wn, window.setup_fixed / wn,
+                    window.setup_resources / wn, window.setup_pipeline / wn);
             window = {};
         }
     }

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -156,6 +156,25 @@ int main() {
     for (const auto& u : uses_m0) if (u.kind == 0 && u.key == 0x40) have_tex_m0 = true;
     CHECK(!have_tex_m0, "#398: m0-SOFFSET s_load marks the T# UNKNOWN (no descriptor fabricated from soffset 0)");
 
+    // The instruction cache must reuse an unchanged shader but invalidate when code at the same guest
+    // address changes. The second case is important for games that recycle or patch shader allocations:
+    // stale decoded literals would resolve a confidently wrong descriptor.
+    clear_shader_decode_cache();
+    std::vector<uint32_t> mutable_code(k1, k1 + sizeof(k1) / sizeof(k1[0]));
+    auto cached_first = resolve_dynamic_fetch(mutable_code.data(), mutable_code.size(), nullptr, 0, 0);
+    auto cached_second = resolve_dynamic_fetch(mutable_code.data(), mutable_code.size(), nullptr, 0, 0);
+    ShaderDecodeCacheStats cache_stats = shader_decode_cache_stats();
+    CHECK(cache_stats.misses == 1 && cache_stats.hits == 1,
+          "unchanged shader bytes reuse the decoded-instruction cache");
+    mutable_code[1] = 0x00002000u;  // same address, change s_mov_b32 literal: V# base 0x1000 -> 0x2000
+    auto patched = resolve_dynamic_fetch(mutable_code.data(), mutable_code.size(), nullptr, 0, 0);
+    cache_stats = shader_decode_cache_stats();
+    CHECK(cache_stats.invalidations == 1 && cache_stats.misses == 2,
+          "same-address shader mutation invalidates the decoded instructions");
+    CHECK(cached_first.size() == 1 && cached_second.size() == 1 && patched.size() == 1 &&
+              cached_first[0].desc.base == 0x1000u && patched[0].desc.base == 0x2000u,
+          "cache invalidation preserves the real fold result after a shader literal changes");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -63,6 +63,10 @@ PROSPER_GPU_CAPTURE=/tmp/messenger-level.prgcap PROSPER_GPU_CAPTURE_AT=0 \
 `PROSPER_GPU_CAPTURE_MIN_DRAWS`/`MAX_DRAWS` filter by realized item count; `PROSPER_GPU_CAPTURE_AT`
 counts matching invocations that reach the registered renderer, after the normal `RENDER_EVERY`
 sampling. Aim the live run near the target first; the capture itself writes once.
+The live hook snapshots realized draws, compute dispatches, and the original mixed PM4 operation order
+before executing the selected submit, then attaches the rendered pixel oracle afterward. An inspected
+mixed capsule must report the same draw/compute/operation counts as the live timing line; `computes=0`
+for a known mixed submit indicates an obsolete capture build, not proof that the barriers are unnecessary.
 `PROSPER_GPU_CAPTURE_AFTER=N` ignores the first `N` renderer invocations before applying the draw-count
 filters and `AT` counter. Pair it with `PROSPER_SUBMITLOG`/`PROSPER_RENDER_FIRST` when several early
 scenes share the same draw count as a late target.


### PR DESCRIPTION
## What changed

- removes redundant renderer framebuffer copies and adds bounded, correctness-validated caches for guest readability, dynamic shader folding, and static tiled texture decode
- fixes direct GPU capture so mixed draw/compute PM4 order is preserved before execution and the final pixel oracle is attached afterward
- records the complete Messenger A/B results, remaining frame budget, rejected experiments, capture graph, boot-race caveat, and the decision to validate the next architecture change against 3D
- adds Windows core and full frontend build instructions, a portable release launcher, and no-UI binary usage documentation
- builds the UCRT64 SDL3/Vulkan frontend in CI, checks that MinGW/SDL runtime DLLs are not required, uploads a Windows zip and checksum, and publishes them for `v*` tags

## Impact

The measured Messenger first-level workload improves from roughly 12 FPS at the start of the pass to 23.7-24.8 FPS. The remaining 36-38 ms renderer submit is dominated by synchronous graphics/compute boundaries, so this PR documents the stopping point instead of adding title-specific caches.

A release archive contains `prosper-app.exe`, `start-prosper.ps1`, a usage guide, and build revision metadata. It never contains title data, firmware, or keys.

## Validation

- native Windows MinGW full build
- native Windows CTest: 68/68 passed
- Linux/WSL Vulkan CTest: 93/93 passed
- `actionlint` on `.github/workflows/ci.yml`
- packaged launcher: 3/3 Vulkan test-pattern frames presented on native Windows
- archive content, SHA-256 generation, and PE runtime imports inspected
- corrected live capture: 56 draws, 4 computes, 60 ordered operations

Closes #714.
Closes #715.
Advances #702.
Related to #712.