### PR TITLE
gpu: advance UE scene resource and interpolant semantics

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -908,10 +908,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
     if (trace)
         std::fprintf(stderr, "[compute] execute submit=%llu dispatch=%llu code=0x%llx "
-                     "groups=%ux%ux%u buffers=%zu images=%zu result=%s\n",
+                     "threads=%ux%ux%u local=%ux%ux%u groups=%ux%ux%u "
+                     "buffers=%zu images=%zu result=%s\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
-                     (unsigned long long)item.code_addr, item.launch.groups_x, item.launch.groups_y,
-                     item.launch.groups_z, buffers.size(), images.size(), ok ? "ok" : "failed");
+                     (unsigned long long)item.code_addr, item.launch.threads_x,
+                     item.launch.threads_y, item.launch.threads_z, item.launch.local_x,
+                     item.launch.local_y, item.launch.local_z, item.launch.groups_x,
+                     item.launch.groups_y, item.launch.groups_z, buffers.size(), images.size(),
+                     ok ? "ok" : "failed");
     if (trace) {
         for (const auto& buffer : buffers) {
             if (!buffer.resource) continue;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <chrono>
 #include <climits>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -660,6 +661,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 tp[t * 4 + 3] = 255;
                             }
                         }
+                        // Packed R10G10B10A2 UNORM (GFX10 IMG_FMT 50 / "2_10_10_10_UNORM"):
+                        // the generic 4-B read and detile above preserve packed texels; normalize each
+                        // field to the RGBA8 image format used by this renderer before sampling.
+                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
+                            uint8_t* tp = texstore.back().data();
+                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                                uint32_t v; std::memcpy(&v, tp + t * 4, 4);
+                                prosper::gpu::unorm2_10_10_10_to_rgba8(v, tp + t * 4);
+                            }
+                        }
                         // Focused per-consumer version probe (#586). Hash both the raw guest backing
                         // and the final decoded/RTT-injected pixels so a live draw identifies whether
                         // divergence precedes format conversion or enters through renderer-owned state.
@@ -1090,6 +1101,46 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint32_t gw = w, gh = h;
                     const uint32_t present_w = prosper::gpu::present_width();
                     const uint32_t present_h = prosper::gpu::present_height();
+                    // A depth prepass may bind a tiny/dummy color target with CB_TARGET_MASK=0 while
+                    // rasterizing the full-size guest depth surface. Keying and allocating persistent
+                    // DS from that irrelevant color extent creates (for DOLL) a 512x256 depth image;
+                    // the following 3840x2160 EQUAL lighting pass then gets a separate blank image and
+                    // rejects every fragment. For a wholly color-disabled DS pass, recover the native
+                    // attachment extent from its viewport (undoing execute_gpustate's render scale).
+                    // Mixed/color-writing passes retain the authoritative CB_COLOR extent.
+                    const bool color_disabled = !pass.empty() && std::all_of(
+                        pass.begin(), pass.end(), [](const auto* draw) {
+                            return draw->ps.color_write_mask == 0;
+                        });
+                    const bool uses_ds = std::any_of(pass.begin(), pass.end(), [](const auto* draw) {
+                        return draw->ps.depth_test_enable || draw->ps.depth_write_enable ||
+                               draw->ps.depth_clear_enable || draw->ps.stencil_enable ||
+                               draw->ps.stencil_clear_enable;
+                    });
+                    if (color_disabled && uses_ds && w && h) {
+                        float viewport_x = 0.0f, viewport_y = 0.0f;
+                        for (const auto* draw : pass) {
+                            if (!draw->ps.has_viewport) continue;
+                            const float x1 = draw->ps.viewport_x;
+                            const float x2 = x1 + draw->ps.viewport_w;
+                            const float y1 = draw->ps.viewport_y;
+                            const float y2 = y1 + draw->ps.viewport_h;
+                            if (std::isfinite(x1) && std::isfinite(x2))
+                                viewport_x = std::max(viewport_x, std::max(std::fabs(x1), std::fabs(x2)));
+                            if (std::isfinite(y1) && std::isfinite(y2))
+                                viewport_y = std::max(viewport_y, std::max(std::fabs(y1), std::fabs(y2)));
+                        }
+                        const uint32_t scale_w = present_w ? present_w : w;
+                        const uint32_t scale_h = present_h ? present_h : h;
+                        const uint64_t viewport_native_w = static_cast<uint64_t>(
+                            std::ceil(viewport_x * static_cast<float>(scale_w) / w));
+                        const uint64_t viewport_native_h = static_cast<uint64_t>(
+                            std::ceil(viewport_y * static_cast<float>(scale_h) / h));
+                        if (viewport_native_w && viewport_native_w <= 16384)
+                            native_w = std::max(native_w, static_cast<uint32_t>(viewport_native_w));
+                        if (viewport_native_h && viewport_native_h <= 16384)
+                            native_h = std::max(native_h, static_cast<uint32_t>(viewport_native_h));
+                    }
                     if (native_w && native_h) {
                         uint64_t native_pixels = (uint64_t)native_w * native_h;
                         uint64_t global_pixels = (uint64_t)w * h;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -1,5 +1,6 @@
 // agc_shader_layout.cpp — see agc_shader_layout.hpp. V# decode + the front-half resource-table build.
 #include "agc_shader_layout.hpp"
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 
@@ -8,6 +9,45 @@ namespace prosper::gpu {
 // Guest-memory readability probe (defined in gpu_executor.cpp, same lib) — used by the gated
 // PROSPER_DUMP_TILERAW diagnostic to avoid a SIGSEGV on a mis-decoded texture base.
 bool guest_readable(uint64_t addr, uint32_t bytes);
+
+AgcPixelInputControls derive_agc_pixel_input_controls(const AgcShaderHeader* producer,
+                                                      const AgcShaderHeader* pixel) {
+    AgcPixelInputControls out;
+    const uint32_t producer_count = producer && producer->output_semantics &&
+                                    producer->num_output_semantics <= 64
+        ? producer->num_output_semantics : 0u;
+
+    // The no-PS form used by sceAgcCreateInterpolantMapping maps the producer's declared outputs
+    // directly. Normal rendering always supplies a PS and takes the semantic-matching path below.
+    if (!pixel) {
+        const uint32_t n = std::min<uint32_t>(producer_count, 32u);
+        for (uint32_t i = 0; i < n; ++i) {
+            const AgcShaderSemantic& semantic = producer->output_semantics[i];
+            const uint32_t slot = semantic.hardware_mapping() < 32u
+                ? semantic.hardware_mapping() : i;
+            out.controls[i] = slot | (semantic.is_flat_shaded() ? 0x400u : 0u);
+            out.valid_mask |= 1u << i;
+        }
+        return out;
+    }
+
+    if (!pixel->input_semantics || pixel->num_input_semantics > 32u) return out;
+    for (uint32_t i = 0; i < pixel->num_input_semantics; ++i) {
+        const AgcShaderSemantic& input = pixel->input_semantics[i];
+        uint32_t control = 0x20u | (input.default_value() << 8); // constant if no output matches
+        for (uint32_t j = 0; j < producer_count; ++j) {
+            const AgcShaderSemantic& output = producer->output_semantics[j];
+            if (output.semantic() == input.semantic() && output.hardware_mapping() < 32u) {
+                control = output.hardware_mapping();
+                break;
+            }
+        }
+        if (input.is_flat_shaded()) control |= 0x400u;
+        out.controls[i] = control;
+        out.valid_mask |= 1u << i;
+    }
+    return out;
+}
 
 // RDNA2 (GFX10/PS5) V# dword3 carries a COMBINED 7-bit FORMAT at bits[18:12] — NOT the separate GCN/PS4
 // NFMT[14:12]/DFMT[18:15] split (reading that on a PS5 V# yields garbage fields, so every descriptor came
@@ -106,6 +146,12 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
         // format must keep falling back rather than mis-convert. CONFIDENCE: HIGH (value from
         // AMD's GFX10 register DB; live DOLL T#s confirmed fmt=36 at scene-color dimensions).
         fi.format = DataFormat::Float10_11_11; fi.num_components = 3; fi.bytes_per_block = 4;
+    } else if (fmt == 50) {
+        // GFX10_FORMAT_2_10_10_10_UNORM — Mesa maps a logical R10G10B10A2 format to this enum.
+        // DOLL's final composite PS samples a live 32x32 T# in this format; leaving it unmapped drops
+        // the binding and rejects the entire scene-color writer. It is one packed 4-byte texel and the
+        // live renderer expands it to RGBA8 before upload. CONFIDENCE: HIGH (Mesa DB + live T#).
+        fi.format = DataFormat::Unorm2_10_10_10; fi.num_components = 4; fi.bytes_per_block = 4;
     } else if (fmt >= 1 && fmt <= 77) {          // shared with the V# buffer-format numbering
         DataFormat f = DataFormat::Unknown; uint32_t n = 0;
         rdna2_buffer_format(fmt, &f, &n);
@@ -458,7 +504,13 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // non-descriptor SGPRs -> a garbage decode (e.g. size ~1.4 GB). Skip those rather than emit
             // a bogus binding. (When the dynamic-fetch path is implemented, this direct case still holds
             // for shaders that DO place the V# inline.)
-            if (d.base == 0 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+            // The metadata slot can name ordinary user data when the real V# is bindless. A mapped
+            // buffer FORMAT is part of the direct-sharp contract and provides a stronger discriminator
+            // than the size ceiling alone: DOLL has a live false positive just below 256 MiB whose four
+            // pointer/data dwords decode with FORMAT=0. Dynamic descriptors whose format is patched by
+            // shader ALU are recovered by resolve_dynamic_fetch instead of this metadata-only path.
+            if (d.base == 0 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
+                d.format == DataFormat::Unknown || !d.num_components) continue;
             ShaderResource r;
             r.cls            = compute_buffer ? ResourceClass::ConstantBuffer : ResourceClass::VertexBuffer;
             r.format         = d.format;
@@ -500,7 +552,8 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 if (e.sgpr_base == sgpr) { covered = true; break; }
             if (covered) continue;
             DecodedBufferDescriptor d = decode_buffer_descriptor(&user_sgprs[reg]);
-            if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+            if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
+                d.format == DataFormat::Unknown || !d.num_components) continue;
             ShaderResource r;
             r.cls            = ResourceClass::ConstantBuffer;   // storage buffer (readable + writable)
             r.format         = d.format;

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -8,6 +8,8 @@
 // Stride[16:29], NumRecords=word2, Nfmt[12:14], Dfmt[15:18]).
 #pragma once
 #include "shader_resources.hpp"
+#include <array>
+#include <cstddef>
 #include <cstdint>
 
 namespace prosper::gpu {
@@ -44,6 +46,18 @@ struct AgcShaderSpecials {
     uint16_t user_data_range_end;     // +0x16
 };
 
+// One packed shader input/output semantic (Kyty Shader.h:958). Keep the storage as a raw dword:
+// C++ bitfield allocation is implementation-defined, while these accessors describe the SDK ABI.
+struct AgcShaderSemantic {
+    uint32_t bits = 0;
+    uint32_t semantic()         const { return  bits        & 0xffu; }
+    uint32_t hardware_mapping() const { return (bits >>  8) & 0xffu; }
+    bool     is_flat_shaded()   const { return ((bits >> 22) & 1u) != 0; }
+    uint32_t default_value()    const { return (bits >> 28) & 0x3u; }
+    uint32_t default_value_hi() const { return (bits >> 30) & 0x3u; }
+};
+static_assert(sizeof(AgcShaderSemantic) == 4, "AGC semantic is one dword");
+
 // The SDK shader header (Kyty Shader.h:974) — only the fields the resource builder needs.
 struct AgcShaderHeader {
     uint32_t           file_header;   // +0x00 '1234'
@@ -53,9 +67,34 @@ struct AgcShaderHeader {
     const void*        cx_registers;  // +0x18
     const void*        sh_registers;  // +0x20
     const AgcShaderSpecials* specials;// +0x28
-    uint8_t            pad[0x5a - 0x30];
+    const AgcShaderSemantic* input_semantics;  // +0x30
+    const AgcShaderSemantic* output_semantics; // +0x38
+    uint32_t           header_size;             // +0x40
+    uint32_t           shader_size;             // +0x44
+    uint32_t           embedded_constant_buffer_size_dqw; // +0x48
+    uint32_t           target;                  // +0x4c
+    uint32_t           num_input_semantics;     // +0x50
+    uint16_t           scratch_size_dw_per_thread; // +0x54
+    uint16_t           num_output_semantics;    // +0x56
+    uint16_t           special_sizes_bytes;     // +0x58
     uint8_t            type;          // +0x5a (2=VS/ES, 1=PS, 0=CS)
+    uint8_t            num_cx_registers; // +0x5b
+    uint8_t            num_sh_registers; // +0x5c
 };
+static_assert(offsetof(AgcShaderHeader, input_semantics) == 0x30 &&
+              offsetof(AgcShaderHeader, num_input_semantics) == 0x50 &&
+              offsetof(AgcShaderHeader, type) == 0x5a,
+              "AgcShaderHeader must match the SDK blob layout");
+
+// Hardware SPI_PS_INPUT_CNTL values derived from an ES/GS producer and a PS consumer's semantic
+// metadata. Each valid control maps one logical PS input either to the matching producer PARAM slot
+// or to OFFSET=0x20 + DEFAULT_VAL when the producer does not export that semantic.
+struct AgcPixelInputControls {
+    std::array<uint32_t, 32> controls{};
+    uint32_t valid_mask = 0;
+};
+AgcPixelInputControls derive_agc_pixel_input_controls(const AgcShaderHeader* producer,
+                                                      const AgcShaderHeader* pixel);
 
 // A decoded buffer resource descriptor (V#, 4 dwords). base/stride/num_records per Kyty's getters;
 // format+num_components from the (dfmt,nfmt) split. `size_bytes` is the backing region size.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1,5 +1,6 @@
 // command_processor.cpp — see command_processor.hpp.
 #include "command_processor.hpp"
+#include "mb3_freelist.hpp"
 #include "pm4_registers.hpp"
 #include "writer_provenance.hpp"
 #include "hle/sync_futex.hpp"   // wake_label_waiters (shared with sceKernelWaitOnAddress's futex)
@@ -149,7 +150,8 @@ extern "C" int prosper_fence_journal_lookup(uint64_t pkt, uint64_t* addr, uint64
 namespace {
 // Event types for the per-label ring. Build events fire in the AGC builder HLEs (guest thread);
 // exec events fire in the honor_* paths (fold thread / pend worker).
-enum : uint8_t { LE_DMA_BUILT = 1, LE_REL_BUILT, LE_WAIT_BUILT, LE_DMA_EXEC, LE_REL_EXEC, LE_DMA_SKIP };
+enum : uint8_t { LE_DMA_BUILT = 1, LE_REL_BUILT, LE_WAIT_BUILT, LE_DMA_EXEC, LE_REL_EXEC, LE_DMA_SKIP,
+                 LE_DMA_FREE, LE_REL_FREE };
 struct LabelEvent {
     uint8_t  type;
     uint32_t fold;        // g_fold_seq at event time (exec events; builds carry it too for context)
@@ -160,6 +162,7 @@ struct LabelHist {
     uint64_t addr;
     std::atomic<uint32_t> n;              // total events (ring index)
     std::atomic<uint32_t> dma_built_n, dma_exec_n, rel_built_n, rel_exec_n;   // overlap counters
+    std::atomic<uint32_t> mb3_dma_suppressed_n, mb3_rel_debt_consumed_n;
     LabelEvent ev[16];                    // last 16 events
 };
 constexpr uint32_t kLabelHistSize = 16384;            // power of two
@@ -170,6 +173,7 @@ inline LabelHist& label_hist_slot(uint64_t addr) {
     if (h.addr != addr) {                              // collision/new: reset (diagnostic-grade)
         h.addr = addr; h.n.store(0, std::memory_order_relaxed);
         h.dma_built_n = h.dma_exec_n = h.rel_built_n = h.rel_exec_n = 0;
+        h.mb3_dma_suppressed_n = h.mb3_rel_debt_consumed_n = 0;
         memset(h.ev, 0, sizeof h.ev);
     }
     return h;
@@ -212,6 +216,23 @@ void label_hist_dma_skip(uint64_t addr)               { label_hist_event(addr, L
 void label_hist_rel_exec(uint64_t addr, uint64_t pre) {
     label_hist_slot(addr).rel_exec_n.fetch_add(1, std::memory_order_relaxed);
     label_hist_event(addr, LE_REL_EXEC, pre);
+}
+void label_hist_dma_free(uint64_t addr, uint64_t pool_base) {
+    label_hist_slot(addr).mb3_dma_suppressed_n.fetch_add(1, std::memory_order_relaxed);
+    label_hist_event(addr, LE_DMA_FREE, pool_base);
+}
+bool label_hist_take_dma_free_debt(uint64_t addr) {
+    LabelHist& h = label_hist_slot(addr);
+    uint32_t used = h.mb3_rel_debt_consumed_n.load(std::memory_order_relaxed);
+    for (;;) {
+        uint32_t made = h.mb3_dma_suppressed_n.load(std::memory_order_acquire);
+        if (used >= made) return false;
+        if (h.mb3_rel_debt_consumed_n.compare_exchange_weak(
+                used, used + 1, std::memory_order_acq_rel, std::memory_order_relaxed)) return true;
+    }
+}
+void label_hist_rel_free(uint64_t addr, uint64_t pool_base) {
+    label_hist_event(addr, LE_REL_FREE, pool_base);
 }
 // #312 in-flight-overlap probe: at REL1 exec time, a SECOND init/fence pair already built for the
 // same label (built-execed >= 2 pending, counting this one) means two fence generations were in
@@ -284,7 +305,8 @@ int label_freed_marker_kind(uint64_t addr, uint64_t pre, uint64_t value) {
 }
 // Format the event ring for a suspect report, oldest first. b=built x=exec, aux in hex.
 void label_hist_report(uint64_t addr, char* out, size_t cap) {
-    static const char* nm[] = {"?", "dmaB", "relB", "waitB", "dmaX", "relX", "dmaSKIP"};
+    static const char* nm[] = {"?", "dmaB", "relB", "waitB", "dmaX", "relX", "dmaSKIP",
+                               "dmaFREE", "relFREE"};
     const LabelHist& h = label_hist_slot(addr);
     uint32_t n = h.n.load(std::memory_order_relaxed);
     uint32_t first = n > 16 ? n - 16 : 0;
@@ -292,7 +314,7 @@ void label_hist_report(uint64_t addr, char* out, size_t cap) {
     for (uint32_t i = first; i < n && off + 48 < cap; i++) {
         const LabelEvent& e = h.ev[i & 15];
         int m = snprintf(out + off, cap - off, " %s@%llu/f%u:0x%llx",
-                         e.type <= 6 ? nm[e.type] : "?", (unsigned long long)e.t_ms, e.fold,
+                         e.type <= 8 ? nm[e.type] : "?", (unsigned long long)e.t_ms, e.fold,
                          (unsigned long long)e.aux);
         if (m > 0) off += (size_t)m;
     }
@@ -424,6 +446,44 @@ static void waf_report(const char* kind, uint64_t addr, uint64_t pre, uint64_t v
                 kind, catname[cat & 3], (unsigned long long)addr, (unsigned long long)pre,
                 (unsigned long long)value, (unsigned long long)now_ms());
 }
+// #312 close: direct, non-trapping membership in the guest allocator's Malloc(0x20) freelists.
+// Unlike content/counter inference, this remains truthful before our DmaData init has overwritten a
+// freed node's NextFreeBlock with 0. Default ON; PROSPER_MB3_FREELIST_GUARD=0 is the live A/B escape.
+static bool mb3_freelist_guard() {
+    static const bool v = [] { const char* e = getenv("PROSPER_MB3_FREELIST_GUARD");
+                               return !e || strtol(e, nullptr, 0) != 0; }();
+    return v;
+}
+static void mb3_freelist_report(const char* kind, uint64_t addr, uint64_t pre,
+                                const Mb3FreelistMatch* match, bool debt) {
+    static std::atomic<uint32_t> n{0};
+    uint32_t i = n.fetch_add(1, std::memory_order_relaxed);
+    if (i < 64 || (i & 4095u) == 0)
+        fprintf(stderr, "[agc] MB3-FREE-SUPPRESS kind=%s [0x%llx] pre=0x%llx via=%s "
+                        "pool=0x%llx list=%u head=0x%llx hops=%u t=%llums\n",
+                kind, (unsigned long long)addr, (unsigned long long)pre,
+                debt ? "dma-debt" : "membership",
+                (unsigned long long)(match ? match->pool_base : 0), match ? match->list : 0,
+                (unsigned long long)(match ? match->head : 0), match ? match->hops : 0,
+                (unsigned long long)now_ms());
+}
+// If an init was suppressed while its target was free, its paired ReleaseMem must stay suppressed
+// even when the allocator pops/reuses the block between the two packets. Otherwise direct membership
+// would correctly turn false but the old generation's fence would corrupt the block's new owner.
+static bool mb3_suppress_release(uint64_t addr, uint64_t value, const char* kind) {
+    if (!mb3_freelist_guard() || value != 1 || !label_is_consumed_marker(addr)) return false;
+    uint64_t pre = peek_qword(addr);
+    if (label_hist_take_dma_free_debt(addr)) {
+        label_hist_rel_free(addr, 0);
+        mb3_freelist_report(kind, addr, pre, nullptr, true);
+        return true;
+    }
+    Mb3FreelistMatch match{};
+    if (!mb3_freelist_contains_stable(addr, &match)) return false;
+    label_hist_rel_free(addr, match.pool_base);
+    mb3_freelist_report(kind, addr, pre, &match, false);
+    return true;
+}
 // #312: report one suspicious fence write with its build-journal verdict. kindtag: "REL1" etc.
 //
 // RUN-2026-07-10 FINDING (this instrumentation's own history): the historical "~96 pointer-valued
@@ -482,6 +542,7 @@ static void honor_eop_write(const Pm4Command& c) {
         // packet's rel_value is a fabricated 0 that could move a satisfied fence label BACKWARDS
         // (re-blocking a `*label >= expected` poll).
         case 1: { if (!c.rel_value_valid) return;
+                  if (mb3_suppress_release(c.rel_addr, c.rel_value, "REL1")) return;
                   // #312 stomp-catcher: a live fence label holds small ints/timestamps; a freed
                   // MallocBinned3 FFreeBlock header holds heap POINTERS. Pointer-like pre-content
                   // means this fence write is landing in freed (or reused) memory — log it in the
@@ -562,6 +623,7 @@ static void honor_eop_write(const Pm4Command& c) {
                   poolshift_check("REL1", c.rel_addr, 4, c.rel_value, pkt_addr(c));
                   label_hist_rel_exec(c.rel_addr, pre); break; }
         case 2: { if (!c.rel_value_valid) return;
+                  if (mb3_suppress_release(c.rel_addr, c.rel_value, "REL2")) return;
                   // #312: the same freelist-stomp guard as the 32-bit path. An 8-byte value-1 fence
                   // over a live consumed-marker freelist node overwrites BOTH the next-pointer dwords
                   // (observed live: 8-byte kind=1 writes to a hot recycled label preceding a canary
@@ -654,6 +716,19 @@ static void honor_dma_data(const Pm4Command& c) {
     }
     uint32_t v32 = (uint32_t)c.dd_src;
     uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;
+    // The exact consumed-marker initializer is a 4-byte immediate zero. Test allocator membership
+    // BEFORE touching it: memset(0) would erase a free node's NextFreeBlock and make the later fence
+    // indistinguishable from a live initialized label (the session-11 residual).
+    if (mb3_freelist_guard() && c.dd_bytes == 4 && v32 == 0 &&
+        label_is_consumed_marker(c.dd_dst)) {
+        Mb3FreelistMatch match{};
+        if (mb3_freelist_contains_stable(c.dd_dst, &match)) {
+            uint64_t pre = peek_qword(c.dd_dst);
+            label_hist_dma_free(c.dd_dst, match.pool_base);
+            mb3_freelist_report("DMA", c.dd_dst, pre, &match, false);
+            return;
+        }
+    }
     uint64_t pre_dma = peek_qword(c.dd_dst);   // #312: pre-content for the label event ring
     forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, pkt_addr(c));   // #312 session-10 tripwire (log-only)
     if (v32 == 0) {

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -231,7 +231,7 @@ void write_resource(Writer& w, const GpuCapturedResource& c) {
 bool read_resource(Reader& rd, GpuCapturedResource& c) {
     auto& r = c.resource; uint32_t cls, fmt; uint8_t b;
     if (!rd.u32(cls) || cls > static_cast<uint32_t>(ResourceClass::StorageImage) ||
-        !rd.u32(fmt) || fmt > static_cast<uint32_t>(DataFormat::Float10_11_11)) return false;
+        !rd.u32(fmt) || fmt > static_cast<uint32_t>(DataFormat::Unorm2_10_10_10)) return false;
     r.cls = static_cast<ResourceClass>(cls); r.format = static_cast<DataFormat>(fmt);
     if (!rd.u32(r.num_components) || !rd.u32(r.binding) || !rd.u64(r.gpu_addr) || !rd.u32(r.size) ||
         !rd.u32(r.stride) || !rd.u32(r.srt_offset) || !rd.u32(r.sgpr_base) || !rd.u32(r.fetch_pc) ||

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -25,6 +25,8 @@
 #include <vector>
 #include <set>
 
+extern "C" const void* prosper_agc_shader_header_for_code(uint64_t code_addr);
+
 namespace prosper::gpu {
 
 struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backend so it can bind resources
@@ -195,7 +197,8 @@ struct ShaderRecompileCacheStats {
 };
 std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
-                                                       const ShaderResourceTable* resources = nullptr);
+                                                       const ShaderResourceTable* resources = nullptr,
+                                                       const PixelInputMapping* pixel_inputs = nullptr);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -411,10 +414,39 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 fprintf(stderr, " vtex=0x%llx(%ux%u f%u)", (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
         fprintf(stderr, "\n");
     }
+    PixelInputMapping pixel_inputs;
+    pixel_inputs.controls = rs.ps_input_cntl;
+    pixel_inputs.valid_mask = rs.ps_input_cntl_valid_mask;
+    bool interpolants_from_metadata = false;
+    if (!pixel_inputs.valid_mask) {
+        const auto* producer = static_cast<const AgcShaderHeader*>(
+            prosper_agc_shader_header_for_code(rs.es_addr));
+        const auto* pixel = static_cast<const AgcShaderHeader*>(
+            prosper_agc_shader_header_for_code(rs.ps_addr));
+        const AgcPixelInputControls derived = derive_agc_pixel_input_controls(producer, pixel);
+        if (derived.valid_mask) {
+            pixel_inputs.controls = derived.controls;
+            pixel_inputs.valid_mask = derived.valid_mask;
+            interpolants_from_metadata = true;
+        }
+    }
+    if (getenv("PROSPER_INTERPLOG")) {
+        fprintf(stderr, "[interp] es=0x%llx ps=0x%llx source=%s valid=%08x",
+                (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                interpolants_from_metadata ? "metadata" : "registers",
+                pixel_inputs.valid_mask);
+        for (uint32_t i = 0; i < pixel_inputs.controls.size(); ++i)
+            if (pixel_inputs.valid_mask & (1u << i))
+                fprintf(stderr, " i%u=%08x", i, pixel_inputs.controls[i]);
+        fprintf(stderr, "\n");
+    }
+    const PixelInputMapping* pixel_input_ptr = pixel_inputs.valid_mask ? &pixel_inputs : nullptr;
     std::vector<uint32_t> vs = recompile_graphics_shader_cached(
-        ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr, max_shader_dwords, vrt.get());
+        ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
+        max_shader_dwords, vrt.get(), pixel_input_ptr);
     std::vector<uint32_t> fs = recompile_graphics_shader_cached(
-        ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr, max_shader_dwords, prt.get());
+        ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
+        max_shader_dwords, prt.get());
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();
         record_draw_realization_phases(

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -77,6 +77,8 @@ struct ShaderCompileKey {
     ShaderProgramStage stage = ShaderProgramStage::Vertex;
     bool has_resource_table = false;
     bool force_position_w = false;
+    bool has_pixel_inputs = false;
+    PixelInputMapping pixel_inputs{};
     std::vector<uint32_t> code;
     std::vector<ShaderResourceCompileKey> resources;
 
@@ -98,6 +100,12 @@ struct ShaderCompileKeyHash {
         hash = hash_mix(hash, static_cast<uint32_t>(key.stage));
         hash = hash_mix(hash, key.has_resource_table);
         hash = hash_mix(hash, key.force_position_w);
+        hash = hash_mix(hash, key.has_pixel_inputs);
+        if (key.has_pixel_inputs) {
+            hash = hash_mix(hash, key.pixel_inputs.valid_mask);
+            for (uint32_t control : key.pixel_inputs.controls)
+                hash = hash_mix(hash, control);
+        }
         hash = hash_mix(hash, key.code.size());
         for (uint32_t word : key.code) hash = hash_mix(hash, word);
         hash = hash_mix(hash, key.resources.size());
@@ -266,15 +274,19 @@ uint64_t shader_cache_limit_bytes() {
 uint64_t shader_cache_entry_bytes(const ShaderCompileKey& key, const std::vector<uint32_t>& spirv) {
     return static_cast<uint64_t>(key.code.size()) * sizeof(uint32_t) +
            static_cast<uint64_t>(key.resources.size()) * sizeof(ShaderResourceCompileKey) +
+           (key.has_pixel_inputs ? sizeof(PixelInputMapping) : 0u) +
            static_cast<uint64_t>(spirv.size()) * sizeof(uint32_t);
 }
 
 ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_t* code, size_t dwords,
-                                         const ShaderResourceTable* resources) {
+                                         const ShaderResourceTable* resources,
+                                         const PixelInputMapping* pixel_inputs) {
     ShaderCompileKey key;
     key.stage = stage;
     key.has_resource_table = resources != nullptr;
     key.force_position_w = getenv("PROSPER_FORCE_W") != nullptr;
+    key.has_pixel_inputs = stage == ShaderProgramStage::Vertex && pixel_inputs != nullptr;
+    if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
     if (code && dwords) {
         std::vector<Rdna2Inst> instructions;
         const size_t consumed = rdna2_walk(code, dwords, instructions);
@@ -297,7 +309,8 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
                                               const ShaderResourceTable* resources) {
     const uint32_t* code = key.code.empty() ? nullptr : key.code.data();
     if (stage == ShaderProgramStage::Vertex)
-        return recompile_vertex(code, key.code.size(), resources);
+        return recompile_vertex(code, key.code.size(), resources,
+                                key.has_pixel_inputs ? &key.pixel_inputs : nullptr);
     if (stage == ShaderProgramStage::Fragment)
         return recompile_fragment(code, key.code.size(), resources);
     return {};
@@ -323,8 +336,9 @@ void clear_shader_decode_cache() {
 
 std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
-                                                       const ShaderResourceTable* resources) {
-    ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources);
+                                                       const ShaderResourceTable* resources,
+                                                       const PixelInputMapping* pixel_inputs) {
+    ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs);
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
         auto& cache = shader_cache();
         {
@@ -593,6 +607,18 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     for (uint32_t i = 0; i < nsgpr; i++)
         set_value((int)(user_sgpr_base + i), user_sgprs[i]);
 
+    // A direct sharp lives in the initial user-data SGPR block rather than arriving through an
+    // s_load. It remains a usable load-time descriptor only while none of its SGPRs has subsequently
+    // been reloaded from memory. ALU descriptor patches deliberately retain the same pre-patch
+    // snapshot semantics as `descr`/`descr8` and the seed-V# fallback below.
+    auto untouched_seed_range = [&](int first, int count) {
+        if (!user_sgprs || first < (int)user_sgpr_base ||
+            first + count > (int)(user_sgpr_base + nsgpr)) return false;
+        for (int r = first; r < first + count; r++)
+            if (!valid_reg(r) || reloaded.test((size_t)r)) return false;
+        return true;
+    };
+
     auto known = [&](int r, uint32_t& v) {
         if (!valid_reg(r) || !val_known.test((size_t)r)) return false;
         v = val[(size_t)r];
@@ -759,7 +785,27 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 }
                 // in.literal is the SIGN-EXTENDED 21-bit immediate (#149) — add it as signed so a
                 // negative offset subtracts from the base instead of wrapping to a huge address.
-                uint64_t addr = base + (uint64_t)(int64_t)(int32_t)in.literal + soff_val;
+                const int64_t byte_off = (int64_t)(int32_t)in.literal + (int64_t)soff_val;
+                uint64_t addr = (base + (uint64_t)byte_off) & ~3ull;
+                // AGC scalar-pointer user data can carry aperture/tag bits above the title's usable
+                // GPU VA. Real GFX10 S_LOAD addresses are canonicalized by the memory system; a raw
+                // host dereference is not. Prefer the exact 64-bit address, then (only when it is
+                // unreadable) try the architectural Base48 and the PS5 process' exercised 40-bit VA
+                // aperture. Every candidate must be mapped for the complete load, so this never turns
+                // an unreadable pointer into an unchecked dereference. The 4-byte alignment matches
+                // scalar-memory dword addressing (SharpEmu's evaluator applies the same alignment).
+                if (!is_buffer && !guest_readable(addr, n * 4)) {
+                    for (uint64_t mask : {0xFFFFFFFFFFFFull, 0xFFFFFFFFFFull}) {
+                        const uint64_t candidate = (((base & mask) + (uint64_t)byte_off) & ~3ull);
+                        if (candidate != addr && guest_readable(candidate, n * 4)) {
+                            if (trc) fprintf(stderr, "[dyntrace]   canonical S_LOAD addr 0x%llx -> 0x%llx (mask=0x%llx)\n",
+                                             (unsigned long long)addr, (unsigned long long)candidate,
+                                             (unsigned long long)mask);
+                            addr = candidate;
+                            break;
+                        }
+                    }
+                }
                 if (!guest_readable(addr, n * 4)) { if (trc) fprintf(stderr, "[dyntrace]   addr 0x%llx unreadable\n", (unsigned long long)addr);
                                                     for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k); break; }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
@@ -801,18 +847,43 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     const int samp_base = in.src[2].value;
                     const bool have_t8 = valid_reg(tbase) && descr8_known.test((size_t)tbase);
                     const bool have_key = valid_reg(tbase) && descr8_key_known.test((size_t)tbase);
-                    if (trc) fprintf(stderr, "[dyntrace] MIMG pc=%u srsrc=s%d ssamp=s%d have_t8=%d key=0x%x t8[0]=0x%x\n",
-                                     in.pc, tbase, samp_base, have_t8,
-                                     have_key ? descr8_key[(size_t)tbase] : 0xEEEEEEEEu,
-                                     have_t8 ? descr8[(size_t)tbase][0] : 0u);
-                    if (have_t8) {
-                        SrtUse u; u.kind = 0; u.t8 = descr8[(size_t)tbase];
-                        u.key = have_key ? descr8_key[(size_t)tbase] : 0xFFFFFFFFu;
+                    const std::array<uint32_t, 8>* t8 = have_t8
+                        ? &descr8[(size_t)tbase] : nullptr;
+                    std::array<uint32_t, 8> seed_t8{};
+                    const uint32_t tkey = have_key
+                        ? descr8_key[(size_t)tbase] : 0xFFFFFFFFu;
+                    bool from_seed = false;
+                    if (!t8 && untouched_seed_range(tbase, 8)) {
+                        for (int k = 0; k < 8; k++)
+                            seed_t8[k] = user_sgprs[tbase - (int)user_sgpr_base + k];
+                        DecodedImageDescriptor d = decode_image_descriptor(seed_t8.data());
+                        // A direct T# has no s_load provenance key, so it is resolved by this MIMG's
+                        // exact pc. Reject obviously non-image user data before creating that mapping.
+                        if (d.base > 0x10000 && d.width && d.height &&
+                            d.width <= 16384 && d.height <= 16384 &&
+                            d.type >= 8 && d.type <= 15) {
+                            t8 = &seed_t8;
+                            from_seed = true;
+                        }
+                    }
+                    if (trc) fprintf(stderr, "[dyntrace] MIMG pc=%u srsrc=s%d ssamp=s%d have_t8=%d seed_t8=%d key=0x%x t8[0]=0x%x\n",
+                                     in.pc, tbase, samp_base, have_t8, from_seed,
+                                     tkey, t8 ? (*t8)[0] : 0u);
+                    if (t8) {
+                        SrtUse u; u.kind = 0; u.t8 = *t8;
+                        u.key = tkey;
                         u.use_pc = in.pc;
                         u.is_store = in.opcode == 0x08;   // image_store: a STORAGE-image use (#590)
                         if (valid_reg(samp_base) && descr_known.test((size_t)samp_base)) {
                             u.has_samp = true;
                             u.s4 = descr[(size_t)samp_base];
+                        } else if (untouched_seed_range(samp_base, 4)) {
+                            // Direct S# paired with the direct/table T#. Samplers have no address or
+                            // extent field to validate; block membership plus reload invalidation is
+                            // the conservative provenance check.
+                            for (int k = 0; k < 4; k++)
+                                u.s4[k] = user_sgprs[samp_base - (int)user_sgpr_base + k];
+                            u.has_samp = true;
                         }
                         srt_uses->push_back(u);
                     }
@@ -837,6 +908,25 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             ? descr_key[(size_t)srsrc] : 0xFFFFFFFFu;
                         u.use_pc = in.pc;
                         srt_uses->push_back(u);
+                    } else if (in.opcode >= 0x0C && untouched_seed_range(srsrc, 4)) {
+                        // Direct RAW V#: an untyped MUBUF can consume a V# placed in the initial
+                        // user-data SGPRs without any preceding s_load. This is not a vertex-format
+                        // fetch, so the dyn_vb path below never reports it. Preserve the exact V# as
+                        // a pc-keyed buffer view; treating the same eight SGPRs as a plausible T# can
+                        // otherwise make raw MUBUF resolve to a texture (stride 0), dropping idxen.
+                        SrtUse u; u.kind = 1; u.key = 0xFFFFFFFFu; u.use_pc = in.pc;
+                        for (int k = 0; k < 4; ++k)
+                            u.v4[k] = user_sgprs[srsrc - (int)user_sgpr_base + k];
+                        DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                        if (d.base > 0x10000 && d.size_bytes != 0 &&
+                            d.size_bytes <= 0x10000000u && d.stride != 0) {
+                            if (trc) fprintf(stderr,
+                                             "[dyntrace] raw MUBUF pc=%u direct V# s%d base=0x%llx "
+                                             "stride=%u size=%u\n",
+                                             in.pc, srsrc, (unsigned long long)d.base,
+                                             d.stride, d.size_bytes);
+                            srt_uses->push_back(u);
+                        }
                     }
                 }
                 // buffer_load_format_* (vertex fetch): opcodes 0..3. Resolve the SRSRC (src[1]) SGPR to the
@@ -1173,7 +1263,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         bool piggybacked = false;
                         for (auto& r0 : t.resources)
                             if ((r0.cls == ResourceClass::ConstantBuffer || r0.cls == ResourceClass::VertexBuffer) &&
-                                r0.gpu_addr == d.base && r0.size == d.size_bytes) {
+                                r0.gpu_addr == d.base && r0.size == d.size_bytes && r0.stride == d.stride) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu && r0.cls == ResourceClass::ConstantBuffer)
                                     r0.fetch_pc = u.use_pc;
                                 piggybacked = r0.fetch_pc == u.use_pc || r0.cls == ResourceClass::VertexBuffer;

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -240,6 +240,7 @@ struct RuntimeDetailRequest {
     uint32_t bundle_target_height = 0;
     uint32_t bundle_start_target_width = 0;
     uint32_t bundle_start_target_height = 0;
+    uint32_t bundle_checkpoint_interval = 0;
     uint32_t select_target_width = 0;
     uint32_t select_target_height = 0;
     uint32_t select_target_min_index = 0;
@@ -317,6 +318,18 @@ struct RuntimeDetailRequest {
                 } else {
                     bundle_start_target_width = width;
                     bundle_start_target_height = height;
+                }
+            }
+            if (const char* interval = std::getenv(
+                    "PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY")) {
+                char* interval_end = nullptr;
+                const uint64_t value = std::strtoull(interval, &interval_end, 0);
+                if (!interval_end || *interval_end || value < 1 || value > 4096) {
+                    std::fprintf(stderr,
+                                 "[timeline] capture bundle checkpoint interval must be 1..4096\n");
+                    bundle_path.clear(); bundle_depth = 0;
+                } else {
+                    bundle_checkpoint_interval = static_cast<uint32_t>(value);
                 }
             }
         }
@@ -561,6 +574,7 @@ struct RuntimeCaptureBundle {
     bool started = false;
     std::chrono::steady_clock::time_point started_at;
     uint64_t captured_resource_bytes = 0;
+    uint64_t captured_submit_count = 0;
 };
 
 RuntimeCaptureBundle& runtime_capture_bundle() {
@@ -1464,6 +1478,23 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         } else {
             if (request.select_target_width)
                 trim_runtime_capture_bundle(request.bundle_depth - 1);
+            RuntimeCaptureBundle& bundle_state = runtime_capture_bundle();
+            ++bundle_state.captured_submit_count;
+            if (request.bundle_checkpoint_interval &&
+                !(bundle_state.captured_submit_count % request.bundle_checkpoint_interval)) {
+                if (!write_gpu_capture_bundle(request.bundle_path, bundle_state.bundle, error)) {
+                    std::fprintf(stderr,
+                                 "[timeline] capture bundle checkpoint at submit %llu failed: %s\n",
+                                 static_cast<unsigned long long>(submit_no), error.c_str());
+                    error.clear();
+                } else {
+                    std::fprintf(stderr,
+                                 "[timeline] checkpointed capture bundle submits=%zu through=%llu -> %s\n",
+                                 bundle_state.bundle.submits.size(),
+                                 static_cast<unsigned long long>(submit_no),
+                                 request.bundle_path.c_str());
+                }
+            }
             const std::string identity = request.bundle_path + "#submit=" + std::to_string(submit_no);
             const GpuTimelineDetail detail = capture_detail(submit, identity, predecessor);
             if (!writer->append_detail(detail, error)) {

--- a/prosper/src/gpu/mb3_freelist.cpp
+++ b/prosper/src/gpu/mb3_freelist.cpp
@@ -1,0 +1,125 @@
+#include "mb3_freelist.hpp"
+#include "gpu_execute.hpp"
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#if defined(__linux__)
+#include <sys/uio.h>
+#include <unistd.h>
+#elif defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+namespace prosper::gpu {
+namespace {
+
+// Session-10 captures found 21 caches/run. Keep ample fixed storage with no allocation or locks on
+// the pthread TLS hot path; an overflow only reduces guard coverage and cannot change guest state.
+constexpr uint32_t kMaxPoolCandidates = 256;
+constexpr uint32_t kMaxChainHops = 4096;
+std::atomic<uint64_t> g_pool_candidates[kMaxPoolCandidates];
+std::atomic<uint32_t> g_pool_candidate_count{0};
+
+bool safe_read(uint64_t addr, void* out, uint32_t bytes) {
+#if defined(__linux__)
+    // The allocator may decommit a candidate/node between a page-map probe and memcpy. Ask the
+    // kernel to copy from our own address space instead: process_vm_readv returns EFAULT for that
+    // race and never delivers SIGSEGV to the GPU worker.
+    struct iovec local { out, bytes };
+    struct iovec remote { (void*)(uintptr_t)addr, bytes };
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)bytes;
+#elif defined(_WIN32)
+    SIZE_T copied = 0;
+    return ReadProcessMemory(GetCurrentProcess(), (const void*)(uintptr_t)addr, out, bytes, &copied) &&
+           copied == bytes;
+#else
+    if (!guest_readable(addr, bytes)) return false;
+    memcpy(out, (const void*)(uintptr_t)addr, bytes);
+    return true;
+#endif
+}
+
+bool plausible_node(uint64_t addr) {
+    // MB3 0x20-byte blocks are naturally 0x20-aligned. Rejecting a corrupt/tagged pointer before
+    // dereference is both a traversal terminator and protection against the historic 0x...0001 node.
+    return addr >= 0x10000 && !(addr & 0x1full);
+}
+
+bool scan_chain(uint64_t head, uint64_t block, uint8_t list, uint64_t pool_base,
+                Mb3FreelistMatch* match) {
+    uint64_t node = head;
+    for (uint32_t hops = 0; node && hops < kMaxChainHops; ++hops) {
+        if (node == block) {
+            if (match) *match = {pool_base, head, hops, list};
+            return true;
+        }
+        if (!plausible_node(node)) return false;
+        uint64_t next = 0;
+        if (!safe_read(node, &next, sizeof next) || next == node) return false;
+        node = next;
+    }
+    return false;
+}
+
+bool scan_once(uint64_t block, Mb3FreelistMatch* match) {
+    if (!plausible_node(block)) return false;
+    uint32_t count = g_pool_candidate_count.load(std::memory_order_acquire);
+    if (count > kMaxPoolCandidates) count = kMaxPoolCandidates;
+    for (uint32_t i = 0; i < count; ++i) {
+        uint64_t base = g_pool_candidates[i].load(std::memory_order_acquire);
+        if (!base) continue;
+
+        // Per-size-class descriptor layout recovered at eboot+0x2316a20:
+        // {head,count,secondaryHead,secondaryCount}, 0x20 stride. idx=1 is Malloc(0x20).
+        uint64_t bin[4] = {};
+        if (!safe_read(base + 0x20, bin, sizeof bin)) continue;
+        if (scan_chain(bin[0], block, 1, base, match) ||
+            scan_chain(bin[2], block, 2, base, match)) return true;
+    }
+    return false;
+}
+
+} // namespace
+
+bool mb3_tls_tracking_enabled() {
+    static const bool enabled = [] {
+        const char* e = getenv("PROSPER_MB3_TRACK_TLS");
+        return !e || strtol(e, nullptr, 0) != 0;
+    }();
+    return enabled;
+}
+
+void mb3_note_tls_pool_candidate(uint64_t base) {
+    // The observed MB3 pool arrays are 64 KiB allocations. This cheap shape gate makes the usual
+    // pthread_getspecific traffic a no-op and keeps unrelated TLS pointers out of the scan set.
+    if (base < 0x10000 || (base & 0xffffull)) return;
+    uint32_t count = g_pool_candidate_count.load(std::memory_order_acquire);
+    if (count > kMaxPoolCandidates) count = kMaxPoolCandidates;
+    for (uint32_t i = 0; i < count; ++i)
+        if (g_pool_candidates[i].load(std::memory_order_acquire) == base) return;
+
+    uint32_t slot = g_pool_candidate_count.fetch_add(1, std::memory_order_acq_rel);
+    if (slot < kMaxPoolCandidates)
+        g_pool_candidates[slot].store(base, std::memory_order_release);
+}
+
+bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match) {
+    Mb3FreelistMatch first{};
+    if (!scan_once(block, &first)) return false;
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    Mb3FreelistMatch second{};
+    if (!scan_once(block, &second)) return false;
+    if (match) *match = second;
+    return true;
+}
+
+void mb3_reset_pool_candidates_for_test() {
+    for (auto& base : g_pool_candidates) base.store(0, std::memory_order_relaxed);
+    g_pool_candidate_count.store(0, std::memory_order_release);
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/mb3_freelist.hpp
+++ b/prosper/src/gpu/mb3_freelist.hpp
@@ -1,0 +1,29 @@
+// mb3_freelist.hpp -- non-trapping MallocBinned3 free-block membership (#312).
+#pragma once
+
+#include <cstdint>
+
+namespace prosper::gpu {
+
+struct Mb3FreelistMatch {
+    uint64_t pool_base = 0;
+    uint64_t head = 0;
+    uint32_t hops = 0;
+    uint8_t list = 0;          // 1 = primary head, 2 = secondary head
+};
+
+// MallocBinned3 keeps one 64 KiB-aligned per-thread pool-array in pthread TLS. The libkernel HLE
+// feeds every aligned TLS value here; exact freelist traversal later distinguishes the real pool
+// arrays from unrelated aligned TLS allocations without title-specific addresses.
+void mb3_note_tls_pool_candidate(uint64_t base);
+bool mb3_tls_tracking_enabled();
+
+// Is `block` currently linked into size-class idx=1 (Malloc(0x20)) in any learned per-thread cache?
+// A positive result is observed twice so a concurrent allocator pop cannot turn a stale first read
+// into a false "free" verdict. False negatives merely leave the existing #505/#510 guards in place.
+bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match = nullptr);
+
+// Test isolation for the process-global candidate registry.
+void mb3_reset_pool_candidates_for_test();
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2061,8 +2061,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             uint32_t a = val(in.src[0]); uint32_t& d = rs.sreg[in.dst.value];
             switch (in.opcode) {
-                case 0x03: d = a; break;                    // s_mov_b32
-                case 0x07: d = b.iun(Op_Not, a); break;     // s_not_b32
+                case 0x03: {                                // s_mov_b32
+                    d = a;
+                    // Descriptor provenance is part of the scalar value. Shader compilers commonly
+                    // load several V#s into separate SGPR ranges and copy the selected four words into
+                    // one reused SRSRC range before each MUBUF. Keeping that range's OLD tag makes all
+                    // subsequent buffer loads resolve to the first descriptor (DOLL scene VS: the four
+                    // transform rows became one row, degenerating every triangle).
+                    auto tag = rs.sreg_srt.find(in.src[0].value);
+                    if ((in.src[0].kind == OperandKind::SGPR ||
+                         (in.src[0].kind == OperandKind::Special && in.src[0].value >= 106 && in.src[0].value <= 123)) &&
+                        tag != rs.sreg_srt.end())
+                        rs.sreg_srt[in.dst.value] = tag->second;
+                    else
+                        rs.sreg_srt.erase(in.dst.value);
+                    break;
+                }
+                case 0x07:                                  // s_not_b32 changes the descriptor word
+                    d = b.iun(Op_Not, a); rs.sreg_srt.erase(in.dst.value); break;
                 default: ok = false;
             }
             return true;
@@ -2200,6 +2216,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 default: ok = false;
             }
+            // Every modeled SOP2 operation changes the scalar bits (including cselect unless both
+            // inputs happen to be identical). A previous descriptor tag on the destination is stale;
+            // retaining it can bind an unrelated later SRSRC to the old buffer.
+            if (ok) {
+                rs.sreg_srt.erase(in.dst.value);
+                if (in.opcode == 0x29) rs.sreg_srt.erase(in.dst.value + 1);
+            }
             return true;
         }
         case Rdna2Format::VOP3P: {
@@ -2271,7 +2294,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // 16-bit-immediate scalar ops. s_movk_i32 (0x00): dst = sign-extend(simm16). The decoder
             // already sign-extended simm16 to 32 bits. (s_cmovk/s_cmpk/s_addk/s_mulk deferred.)
             switch (in.opcode) {
-                case 0x00: rs.sreg[in.dst.value] = b.uconst((uint32_t)in.simm16); break;   // s_movk_i32
+                case 0x00:                                  // s_movk_i32
+                    rs.sreg[in.dst.value] = b.uconst((uint32_t)in.simm16);
+                    rs.sreg_srt.erase(in.dst.value);
+                    break;
                 // s_waitcnt_vscnt/vmcnt/expcnt/lgkmcnt: wait-for-counter — benign no-ops in our
                 // synchronous model (like SOPP s_waitcnt). These are SOPK on gfx10, NOT SOPP 0x7d
                 // as previously claimed (that case was unreachable dead code, and a real
@@ -2302,7 +2328,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // THIS lane's value. SPECULATIVE(confidence: med): exact only when src0 is wave-uniform —
                 // which is the standard use (reading a uniformly-computed VGPR into an SGPR, e.g. the
                 // integer-divide reciprocal in the game's shaders). Writes an SGPR, not a VGPR.
-                rs.sreg[in.dst.value] = a; return true;
+                rs.sreg[in.dst.value] = a;
+                rs.sreg_srt.erase(in.dst.value);
+                return true;
             }
             uint32_t& d = vreg[in.dst.value];
             // WORD-select v_mov_b32_sdwa (#273): extract the selected 16-bit source half and insert it
@@ -2993,8 +3021,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // A wide scalar load is a descriptor fetch — tag its dest SGPRs with the SRT offset so a
             // later buffer/image op using them resolves to the right resource (provenance). x4 = V#/S#
             // (buffers, samplers), x8 = T# (textures, 8 dwords).
-            if (rt && (in.opcode == 0x2 || in.opcode == 0x3))
+            if (rt && (in.opcode == 0x2 || in.opcode == 0x3)) {
                 for (uint32_t k = 0; k < n; k++) rs.sreg_srt[in.dst.value + (int)k] = in.literal;
+            } else {
+                // Scalar data loads overwrite the destination; they do not carry descriptor identity.
+                for (uint32_t k = 0; k < n; k++) rs.sreg_srt.erase(in.dst.value + (int)k);
+            }
             return true;
         }
         case Rdna2Format::MUBUF: {
@@ -3074,7 +3106,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // CONSTANT/structured buffer (a PS's per-lane table fetch, #273) keeps the faithful
                     // VADDR*stride+offset address below.
                     res = rt->by_fetch_pc(in.pc);
-                    if (res) dyn_vfetch = (res->cls == ResourceClass::VertexBuffer);
+                    // The NGG fetch-prologue shortcut applies to the conventional v0 element index
+                    // and to attributes whose SRSRC was rewritten by an in-shader descriptor load.
+                    // In the latter case the folded V# base already includes the attribute offset,
+                    // even when the incomplete prologue left a non-v0 VADDR. A pc-keyed VertexBuffer
+                    // can also be a directly supplied structured V# whose SRSRC was never rewritten;
+                    // DOLL skinning indexes those through computed v4/v5/v7/... values. Replacing
+                    // those addresses with gl_VertexIndex reads the wrong matrix row and collapses
+                    // the whole mesh, so preserve a non-v0 VADDR for untouched direct user data.
+                    if (res) {
+                        const bool srsrc_rewritten = rs.sreg.find(in.src[1].value) != rs.sreg.end();
+                        dyn_vfetch = res->cls == ResourceClass::VertexBuffer &&
+                                     (in.src[0].value == 0 || srsrc_rewritten);
+                    }
                     if (!res) res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
                     if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
                         if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
@@ -4283,7 +4327,9 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
     return b.finish();
 }
 
-std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords, const ShaderResourceTable* rt) {
+std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
+                                       const ShaderResourceTable* rt,
+                                       const PixelInputMapping* pixel_inputs) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
 
@@ -4314,14 +4360,42 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords, cons
             b.export_position(operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
                               operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
             exported = true;
-        } else if (in.exp_target >= 32) {                    // PARAM0.. -> Output varying (location N)
-            b.export_param(in.exp_target - 32, operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
-                           operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
+        } else if (in.exp_target >= 32) {                    // PARAM0.. -> remapped PS input varying
+            const uint32_t source = in.exp_target - 32;
+            const uint32_t x = operand_bits(b, rs, in, in.src[0], &eok);
+            const uint32_t y = operand_bits(b, rs, in, in.src[1], &eok);
+            const uint32_t z = operand_bits(b, rs, in, in.src[2], &eok);
+            const uint32_t w = operand_bits(b, rs, in, in.src[3], &eok);
+            if (!pixel_inputs || source >= 32 || !(pixel_inputs->valid_mask & (1u << source)))
+                b.export_param(source, x, y, z, w);           // absent control retains identity wiring
+            if (pixel_inputs) {
+                for (uint32_t ps_input = 0; ps_input < pixel_inputs->controls.size(); ++ps_input) {
+                    if (!(pixel_inputs->valid_mask & (1u << ps_input))) continue;
+                    const uint32_t offset = pixel_inputs->controls[ps_input] & 0x3Fu;
+                    if (offset == source) b.export_param(ps_input, x, y, z, w);
+                }
+            }
         }
         return eok;
     };
     if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) return {};
     if (!exported) return {};
+    // OFFSET=0x20 asks the interpolator to synthesize a constant instead of consuming a PARAM
+    // export. GFX10 DEFAULT_VAL encodes 0000, 0001, 1110, and 1111. Materialize those outputs in
+    // the Vulkan vertex stage, whose fixed-function interface has no equivalent default source.
+    if (pixel_inputs) {
+        for (uint32_t ps_input = 0; ps_input < pixel_inputs->controls.size(); ++ps_input) {
+            if (!(pixel_inputs->valid_mask & (1u << ps_input))) continue;
+            const uint32_t control = pixel_inputs->controls[ps_input];
+            if ((control & 0x3Fu) != 0x20u) continue;
+            const uint32_t one = b.uconst(0x3F800000u), zero = b.uconst(0u);
+            const uint32_t default_val = (control >> 8) & 0x3u;
+            const bool xyz_one = (default_val & 0x2u) != 0;
+            const bool w_one = (default_val & 0x1u) != 0;
+            b.export_param(ps_input, xyz_one ? one : zero, xyz_one ? one : zero,
+                           xyz_one ? one : zero, w_one ? one : zero);
+        }
+    }
     return b.finish();
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -11,6 +11,7 @@
 // floats per invocation from storage buffer 0 into v0..v(num_inputs-1)  (v[k] = a[gid*num_inputs+k]),
 // runs the translated ALU ops, then stores v[out_vgpr] to storage buffer 1 (b[gid]).
 #pragma once
+#include <array>
 #include <cstdint>
 #include <cstddef>
 #include <vector>
@@ -18,6 +19,17 @@
 namespace prosper::gpu {
 
 struct ShaderResourceTable;   // resource-binding contract (shader_resources.hpp); optional to recompile_valu
+
+// Fixed-function PS interpolant wiring captured from SPI_PS_INPUT_CNTL_0..31. A valid entry's
+// OFFSET selects the vertex PARAM export feeding that logical PS input; OFFSET=0x20 selects the
+// four hardware default vectors encoded by DEFAULT_VAL instead. Keeping this separate from
+// RenderState makes the recompiler independently unit-testable.
+struct PixelInputMapping {
+    std::array<uint32_t, 32> controls{};
+    uint32_t valid_mask = 0;
+
+    bool operator==(const PixelInputMapping&) const = default;
+};
 
 // Translate a straight-line float-VALU RDNA2 stream to a compute-shader SPIR-V module.
 // Returns {} if the stream contains an opcode/format this stage does not yet handle. An optional
@@ -57,7 +69,8 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
 // to a POS target write vec4(src0..3) to gl_Position. Returns {} if unsupported / no position export.
 // An optional ShaderResourceTable enables vertex fetch (buffer_load_format_*) + constant loads.
 std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
-                                       const ShaderResourceTable* rt = nullptr);
+                                       const ShaderResourceTable* rt = nullptr,
+                                       const PixelInputMapping* pixel_inputs = nullptr);
 
 // How much of a shader the recompiler currently covers (per-instruction), without requiring the
 // stream to be a complete vertex/fragment. `alu` = instructions emit_alu handles (VALU/scalar/

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -70,6 +70,13 @@ RenderState extract_render_state(const GpuState& st) {
     rs.gs_addr = addr_of(rd(st.sh, P::SPI_SHADER_PGM_LO_GS), rd(st.sh, P::SPI_SHADER_PGM_HI_GS));
     rs.es_addr = addr_of(rd(st.sh, P::SPI_SHADER_PGM_LO_ES), rd(st.sh, P::SPI_SHADER_PGM_HI_ES));
     rs.hs_addr = addr_of(rd(st.sh, P::SPI_SHADER_PGM_LO_HS), rd(st.sh, P::SPI_SHADER_PGM_HI_HS));
+    for (uint32_t i = 0; i < rs.ps_input_cntl.size(); ++i) {
+        const uint32_t reg = P::SPI_PS_INPUT_CNTL_0 + i;
+        auto it = st.cx.find(reg);
+        if (it == st.cx.end()) continue;
+        rs.ps_input_cntl[i] = it->second;
+        rs.ps_input_cntl_valid_mask |= 1u << i;
+    }
 
     // Color MRT 0 (context register file).
     rs.color0_base            = addr_of(rd(st.cx, P::CB_COLOR0_BASE), rd(st.cx, P::CB_COLOR0_BASE_EXT));

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -9,6 +9,7 @@
 // here is fabricated.
 #pragma once
 #include "command_processor.hpp"
+#include <array>
 #include <cstdint>
 
 namespace prosper::gpu {
@@ -19,6 +20,13 @@ struct RenderState {
     uint64_t gs_addr = 0;   // geometry (…_GS)
     uint64_t es_addr = 0;   // export/vertex (…_ES)
     uint64_t hs_addr = 0;   // hull/tess (…_HS)
+
+    // Pixel-input wiring (SPI_PS_INPUT_CNTL_0..31). Each programmed word maps a PS interpolant
+    // number to an ES/VS PARAM export slot, or selects one of the hardware constant defaults when
+    // OFFSET=0x20. Vulkan has no equivalent fixed-function remap/default stage, so the vertex
+    // recompiler materializes this contract in its output interface.
+    std::array<uint32_t, 32> ps_input_cntl{};
+    uint32_t ps_input_cntl_valid_mask = 0;
 
     // Color MRT 0. format/number_type/comp_swap together select the VkFormat (see vk_translate).
     uint64_t color0_base        = 0;   // byte address (CB_COLOR0_BASE + BASE_EXT)

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -55,6 +55,16 @@ float f10_to_float(uint16_t v) {
     return half_to_float((uint16_t)(((v & 0x3FFu) >> 5 << 10) | ((v & 0x1Fu) << 5)));
 }
 
+void unorm2_10_10_10_to_rgba8(uint32_t packed, uint8_t rgba[4]) {
+    // Mesa's GFX10 format table maps a logical R10G10B10A2 description to hardware IMG_FMT 50,
+    // whose name lists the packed fields high-to-low. Scale with integer rounding so both endpoints
+    // and intermediate UNORM values match a normalized hardware sample as closely as RGBA8 permits.
+    rgba[0] = (uint8_t)((((packed >>  0) & 0x3FFu) * 255u + 511u) / 1023u);
+    rgba[1] = (uint8_t)((((packed >> 10) & 0x3FFu) * 255u + 511u) / 1023u);
+    rgba[2] = (uint8_t)((((packed >> 20) & 0x3FFu) * 255u + 511u) / 1023u);
+    rgba[3] = (uint8_t)(((packed >> 30) & 0x3u) * 85u);
+}
+
 const ShaderResource* ShaderResourceTable::by_srt_offset(uint32_t srt_offset) const {
     if (srt_offset == 0xFFFFFFFFu) return nullptr;
     for (const auto& r : resources) if (r.srt_offset == srt_offset) return &r;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -39,7 +39,10 @@ enum class DataFormat : uint32_t {
     // format (#294). data_format_bytes() returns 0 (packed — per-component size is meaningless;
     // the texel is 4 bytes, carried by Gen5ImageFormatInfo::bytes_per_block).
     Float10_11_11,
-    // Other 10/11-bit packed formats are added as the target needs them.
+    // Packed 32-bit R10G10B10A2 UNORM. GFX10 names its high-to-low storage layout
+    // "2_10_10_10_UNORM" (IMG_FMT 50); logical R/G/B occupy the low/middle 10-bit fields and
+    // alpha occupies the high 2 bits. Sampled uploads unpack it to RGBA8.
+    Unorm2_10_10_10,
 };
 
 // How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).
@@ -55,6 +58,9 @@ float half_to_float(uint16_t h);
 // widening (subnormals scale identically, inf/NaN preserved). Pure + testable.
 float f11_to_float(uint16_t v);   // low 11 bits used
 float f10_to_float(uint16_t v);   // low 10 bits used
+
+// GFX10_FORMAT_2_10_10_10_UNORM packed texel -> RGBA8, with nearest UNORM scaling. Pure + testable.
+void unorm2_10_10_10_to_rgba8(uint32_t packed, uint8_t rgba[4]);
 
 enum class ResourceClass : uint32_t {
     ConstantBuffer,  // read by s_buffer_load_* (scalar, uniform across the wave)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -757,7 +757,6 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
                         "cx=%u sh=%u pgm_patched=%d\n",
                 agc_shaders().size(), (void*)h, (void*)code, h->type, h->target, h->shader_size,
                 h->num_cx_registers, h->num_sh_registers, (int)patched);
-
     // Semantic surfacing probe (PROSPER_PIPETRACE): logs the shader's input/output vertex semantics.
     // CORRECTION (2026-07-05, fresh 3-agent RE, ground-truth via eboot x86 disasm): an earlier theory
     // blamed the eboot+0xba6e08 GfxDevice fault on "empty semantics leaving the reflection table empty
@@ -803,22 +802,6 @@ HLE(agc_create_shader) {  // (Shader** dst, void* header, const void* code)
 // ([sub+0x10]/[sub+0x18]) at the packet payload. The leaf imports it needs are these four
 // (semantics per Kyty Graphics.cpp:1606-1762, generalized — see each note).
 namespace {
-
-struct AgcShaderSemantic {           // guest-visible 32-bit bitfield (Kyty Shader.h:958)
-    uint32_t semantic         : 8;
-    uint32_t hardware_mapping : 8;
-    uint32_t size_in_elements : 4;
-    uint32_t is_f16           : 2;
-    uint32_t is_flat_shaded   : 1;
-    uint32_t is_linear        : 1;
-    uint32_t is_custom        : 1;
-    uint32_t static_vb_index  : 1;
-    uint32_t static_attribute : 1;
-    uint32_t reserved         : 1;
-    uint32_t default_value    : 2;
-    uint32_t default_value_hi : 2;
-};
-static_assert(sizeof(AgcShaderSemantic) == 4, "semantic must be one dword");
 
 struct AgcShaderSpecialRegs {        // guest-visible (Kyty Shader.h:947); pointed to by Shader+0x28
     AgcShaderRegister ge_cntl;                  // +0x00
@@ -946,8 +929,6 @@ HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader
     auto* ps   = (const AgcShader*)(uintptr_t)a2;
     if (!regs || !gs) return kAgcErrInvalidArg;
     using namespace prosper::agc::Pm4;
-    const auto* gs_out = (const AgcShaderSemantic*)gs->output_semantics;
-    const auto* ps_in  = ps ? (const AgcShaderSemantic*)ps->input_semantics : nullptr;
     uint32_t n = ps ? ps->num_input_semantics : (uint32_t)gs->num_output_semantics;
     if (getenv("PROSPER_PIPETRACE"))
         fprintf(stderr, "  [interp] gs.num_out=%u ps=%p ps.num_in=%u -> mapping %u interpolants\n",
@@ -955,21 +936,12 @@ HLE(agc_create_interpolant_mapping) {  // (ShaderRegister regs[32], const Shader
                 ps ? ps->num_input_semantics : 0u, n);
     pipetrace_shader_user_data("CreateInterpolant.gs", gs);
     pipetrace_shader_user_data("CreateInterpolant.ps", ps);
+    const auto mapping = prosper::gpu::derive_agc_pixel_input_controls(
+        reinterpret_cast<const prosper::gpu::AgcShaderHeader*>(gs),
+        reinterpret_cast<const prosper::gpu::AgcShaderHeader*>(ps));
     for (uint32_t i = 0; i < 32; i++) {
         regs[i].offset = SPI_PS_INPUT_CNTL_0 + i;
-        uint32_t value = 0;
-        if (i < n) {
-            uint32_t slot = i; bool flat = false;
-            if (ps_in && gs_out) {
-                flat = ps_in[i].is_flat_shaded != 0;
-                for (uint32_t j = 0; j < gs->num_output_semantics; j++)
-                    if (gs_out[j].semantic == ps_in[i].semantic) { slot = gs_out[j].hardware_mapping; break; }
-            } else if (gs_out) {
-                slot = gs_out[i].hardware_mapping;
-            }
-            value = slot | (flat ? 0x400u : 0u);
-        }
-        regs[i].value = value;
+        regs[i].value = (mapping.valid_mask & (1u << i)) ? mapping.controls[i] : 0u;
     }
     return 0;
 }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -15,6 +15,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "sync_futex.hpp"
+#include "../gpu/mb3_freelist.hpp"
 #include "../host/exec_image.hpp"
 #include <pthread.h>
 #include <semaphore.h>   // scePthreadSem* -> host sem_t
@@ -607,6 +608,10 @@ HLE(k_key_create) {
 HLE(k_key_delete)    { pthread_key_delete((pthread_key_t)a0); return 0; }
 HLE(k_getspecific)   {
     uint64_t rv = (uint64_t)(uintptr_t)pthread_getspecific((pthread_key_t)a0);
+    // #312: learn the non-trapping MB3 pool-array address even when the hardware-watch diagnostic
+    // is off. Only 64 KiB-aligned values enter the bounded lock-free registry. Deliberately do not
+    // use host thread_local state here: guest threads own %fs between import-stub swaps.
+    if (gpu::mb3_tls_tracking_enabled()) gpu::mb3_note_tls_pool_candidate(rv);
     // #312: the MallocBinned3 per-thread free-block cache base is fetched via getspecific; arm a
     // per-thread head watch on it the moment this (owning) thread receives it (no-op unless armed).
     if (g_mb3_arm_hook && rv) g_mb3_arm_hook(rv);
@@ -616,7 +621,9 @@ HLE(k_setspecific)   {
     // #312: catch the cache the instant it is FIRST installed (base passed to setspecific), which is
     // right after allocation — before any head store — the earliest "descriptor established" moment.
     if (g_mb3_arm_hook && a1) g_mb3_arm_hook(a1);
-    return (uint64_t)(int64_t)pthread_setspecific((pthread_key_t)a0, (void*)(uintptr_t)a1);
+    int r = pthread_setspecific((pthread_key_t)a0, (void*)(uintptr_t)a1);
+    if (!r && gpu::mb3_tls_tracking_enabled()) gpu::mb3_note_tls_pool_candidate(a1);
+    return (uint64_t)(int64_t)r;
 }
 
 // --- event flags (SceKernelEventFlag): a bit pattern with wait/set/clear ---

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -73,6 +73,9 @@ int main() {
         CHECK(gen5_image_format(36, &fi) && fi.format == DataFormat::Float10_11_11 &&
               fi.num_components == 3 && fi.bytes_per_block == 4 && fi.block_width == 1 && !fi.srgb,
               "IMG_FMT 36 -> Float10_11_11 packed, 4 B/texel");
+        CHECK(gen5_image_format(50, &fi) && fi.format == DataFormat::Unorm2_10_10_10 &&
+              fi.num_components == 4 && fi.bytes_per_block == 4 && fi.block_width == 1 && !fi.srgb,
+              "IMG_FMT 50 -> R10G10B10A2 UNORM packed, 4 B/texel");
         CHECK(!gen5_image_format(0, &fi) && fi.format == DataFormat::Unknown, "IMG_FMT 0 (INVALID) unmapped");
         CHECK(!gen5_image_format(9, &fi), "IMG_FMT 9 (16_USCALED) unmapped -> false");
         CHECK(!gen5_image_format(44, &fi), "IMG_FMT 44 (10_10_10_2) unmapped -> false");
@@ -85,6 +88,39 @@ int main() {
               image_type_to_dim(14) == 6 && image_type_to_dim(15) == 7,
               "T# TYPE array/MSAA variants map to MIMG dims 4..7");
         CHECK(image_type_to_dim(0) == 1, "unknown T# TYPE keeps the conservative 2D fallback");
+    }
+
+    // --- AGC semantic metadata -> SPI_PS_INPUT_CNTL wiring ------------------------------------
+    // Live DOLL shape: the producer exports semantics 15..18 in PARAM0..3, while the PS consumes
+    // semantic 15 and semantic 18. Identity wiring would feed PS input 1 from PARAM1; semantic
+    // matching must instead select PARAM3. A missing producer semantic uses DEFAULT_VAL.
+    {
+        AgcShaderSemantic producer_out[] = {
+            {0x0000000fu}, {0x00000110u}, {0x00000211u}, {0x00000312u},
+        };
+        AgcShaderSemantic pixel_in[] = {{0x0000000fu}, {0x00000012u}};
+        AgcShaderHeader producer{};
+        producer.output_semantics = producer_out;
+        producer.num_output_semantics = 4;
+        AgcShaderHeader pixel{};
+        pixel.input_semantics = pixel_in;
+        pixel.num_input_semantics = 2;
+        AgcPixelInputControls mapping = derive_agc_pixel_input_controls(&producer, &pixel);
+        CHECK(mapping.valid_mask == 0x3u && mapping.controls[0] == 0u && mapping.controls[1] == 3u,
+              "DOLL semantics map PS inputs {15,18} to producer PARAM slots {0,3}");
+
+        producer.output_semantics = nullptr;
+        producer.num_output_semantics = 0;
+        mapping = derive_agc_pixel_input_controls(&producer, &pixel);
+        CHECK(mapping.valid_mask == 0x3u && mapping.controls[0] == 0x20u && mapping.controls[1] == 0x20u,
+              "procedural producer with no PARAM exports materializes PS input defaults");
+
+        AgcShaderSemantic default_flat[] = {{0x30400055u}}; // DEFAULT_VAL=3 + flat, no matching output
+        pixel.input_semantics = default_flat;
+        pixel.num_input_semantics = 1;
+        mapping = derive_agc_pixel_input_controls(&producer, &pixel);
+        CHECK(mapping.valid_mask == 1u && mapping.controls[0] == 0x720u,
+              "unmatched flat semantic preserves DEFAULT_VAL and FLAT_SHADE control bits");
     }
 
     // --- V# decode in isolation ---------------------------------------------------------------
@@ -175,8 +211,10 @@ int main() {
     // --- vertex buffers: direct resource usage type 8 (V# inline in the user-data SGPRs) ------------
     // A 16-entry direct_resource_offset table; type 8 (vertex buffer) points at a V# at SGPR dword 20.
     uint16_t dro[16]; for (auto& x : dro) x = 0xffff;
+    make_vsharp(&sgprs[16], 0xD0000000ull, 0, 0x0fe9c0c0u, /*fmt*/0); // user data: near-cap false V#
     make_vsharp(&sgprs[20], 0xC0000000ull, 12, 90, /*fmt*/74);  // 32_32_32 FLOAT, stride 12
     dro[8] = 20;                                                            // vertex buffer V# at sgpr 20
+    dro[10] = 16;                                                           // metadata can name non-V# data
     ud.direct_resource_offset = dro;
     ud.direct_resource_count  = 16;
     cbuf_sharps[1].bits = (uint16_t)(12 & 0x7fff);   // restore cbuf1 so we test cbuf + vbuf together
@@ -188,6 +226,8 @@ int main() {
     CHECK(vb && vb->format == DataFormat::Float32 && vb->num_components == 3, "vbuf format Float32 x3");
     CHECK(vb && vb->gpu_addr == 0xC0000000ull && vb->stride == 12 && vb->size == 90 * 12, "vbuf base/stride/size");
     CHECK(vb && vb->srt_offset == 0xFFFFFFFFu, "DIRECT vbuf leaves srt_offset unset");
+    CHECK(t3.by_sgpr_base(16) == nullptr,
+          "unknown-format user data just below the size cap is not guessed as a direct V#");
     CHECK(t3.by_sgpr_base(4) != nullptr, "constant buffers still present alongside vertex buffers");
     CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
 

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -139,6 +139,74 @@ int main() {
     CHECK(have_cbuf, "kernel 5 s_buffer_load reports a ConstantBuffer table-use keyed by the V# load imm");
     CHECK(cbuf_ok,   "kernel 5 V# dwords match the table as loaded");
 
+    // Kernel 5d: direct T#/S# sharps already occupy the initial PS user SGPRs, so no s_load creates
+    // descr8/descr snapshots. The MIMG use must still receive a pc-keyed texture and paired sampler.
+    const uint32_t k5d[] = {
+        0xF0800F08u, 0x00400000u,   // image_sample v[0:3], v[0:1], s[0:7], s[8:11] dmask:0xf 2D
+        0xBF810000u,                // s_endpgm
+    };
+    const uint32_t seed5d[12] = {
+        0x20753500u, 0xC2400000u, 0x021BC3BFu, 0x91B003ACu, // T#: 0x2075350000, 3840x2160, 2D
+        0x00000000u, 0x00700000u, 0x006B0000u, 0x00205072u,
+        0x00000092u, 0x00FFF000u, 0x06500000u, 0x00000000u, // S#
+    };
+    std::vector<SrtUse> direct_uses;
+    resolve_dynamic_fetch(k5d, sizeof(k5d)/sizeof(k5d[0]), seed5d, 12, 0, &direct_uses);
+    CHECK(direct_uses.size() == 1 && direct_uses[0].kind == 0 &&
+          direct_uses[0].key == 0xFFFFFFFFu && direct_uses[0].use_pc == 0,
+          "direct user-SGPR T# resolves the image_sample by exact pc");
+    CHECK(direct_uses.size() == 1 && direct_uses[0].t8[0] == seed5d[0] &&
+          direct_uses[0].t8[7] == seed5d[7] && direct_uses[0].has_samp &&
+          direct_uses[0].s4[0] == seed5d[8] && direct_uses[0].s4[3] == seed5d[11],
+          "direct user-SGPR T#/S# dwords are preserved");
+
+    // DOLL scene VS: an untyped buffer_load_dwordx3 uses a V# placed directly in user-data
+    // s[8:11]. There is no preceding s_load and it is not a format/vertex fetch, so it needs its
+    // own pc-keyed buffer use. The same eight seed SGPRs may also happen to decode as a plausible
+    // T#; the consuming MUBUF instruction is definitive that these first four words are a V#.
+    const uint32_t k5v[] = {
+        0xE03C2000u, 0x80020003u,   // buffer_load_dwordx3 v[0:2], v3, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    const uint32_t seed5v[4] = {
+        0x00020000u, 0x00040000u, 1480u, 75u << 12, // base=0x20000 stride=4 size=5920
+    };
+    std::vector<SrtUse> direct_v_uses;
+    resolve_dynamic_fetch(k5v, sizeof(k5v)/sizeof(k5v[0]), seed5v, 4, 8, &direct_v_uses);
+    CHECK(direct_v_uses.size() == 1 && direct_v_uses[0].kind == 1 &&
+          direct_v_uses[0].key == 0xFFFFFFFFu && direct_v_uses[0].use_pc == 0,
+          "direct user-SGPR V# resolves raw MUBUF by exact pc");
+    CHECK(direct_v_uses.size() == 1 && direct_v_uses[0].v4[0] == seed5v[0] &&
+          direct_v_uses[0].v4[1] == seed5v[1] && direct_v_uses[0].v4[2] == seed5v[2],
+          "direct raw-MUBUF V# preserves base/stride/record dwords");
+
+    // Kernel 5dr: once any T# SGPR is reloaded, the initial sharp is stale. An unresolved reload must
+    // not silently resurrect it and fabricate a texture mapping for the later image operation.
+    const uint32_t k5dr[] = {
+        0xF4000014u, 0xFA000000u,   // s_load_dword s0, s[40:41], 0x0 (unknown base -> reloaded+unknown)
+        0xF0800F08u, 0x00400000u,   // image_sample v[0:3], v[0:1], s[0:7], s[8:11]
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<SrtUse> direct_reloaded_uses;
+    resolve_dynamic_fetch(k5dr, sizeof(k5dr)/sizeof(k5dr[0]), seed5d, 12, 0, &direct_reloaded_uses);
+    CHECK(direct_reloaded_uses.empty(),
+          "reloaded direct T# SGPR blocks the stale seed fallback");
+
+    // Kernel 5t: AGC user data may carry non-address aperture/tag bits above Base48. A scalar load
+    // must canonicalize an otherwise-unreadable tagged pair before the host memory read; the exact
+    // same descriptor table should still resolve. (The untagged address is the real in-process table,
+    // so the full-range readability check also guards the fallback.)
+    uint32_t tagged_seed5[2] = { seed5[0], seed5[1] | 0xABCD0000u };
+    std::vector<SrtUse> tagged_uses;
+    resolve_dynamic_fetch(k5, sizeof(k5)/sizeof(k5[0]), tagged_seed5, 2, 8, &tagged_uses);
+    bool tagged_tex = false, tagged_cbuf = false;
+    for (const auto& u : tagged_uses) {
+        if (u.kind == 0 && u.key == 0x40 && u.t8[0] == table[16]) tagged_tex = true;
+        if (u.kind == 1 && u.key == 0x80 && u.v4[0] == table[32]) tagged_cbuf = true;
+    }
+    CHECK(tagged_tex && tagged_cbuf,
+          "tagged scalar Base48 pointer canonicalizes to the mapped descriptor table");
+
     // Kernel 5m (#398): same as k5 but the T# s_load uses m0 as SOFFSET (field 124), a special register
     // the fold does not track. It must NOT be folded to offset 0 and snapshotted — that would decode a T#
     // from base+0x40+0 (the wrong address in general) and report it as valid. The fix marks s[12:19]

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -5,6 +5,7 @@
 // builders themselves read SysV stack args via __builtin_frame_address, only valid under the loaded
 // game) and asserts run_command_buffer writes the right bytes to the target address.
 #include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/mb3_freelist.hpp"
 #include "../src/gpu/pm4_decode.hpp"
 #include <cstdio>
 #include <cstdint>
@@ -15,6 +16,7 @@ using namespace prosper::gpu;
 // The guest TSC clock the GPU EOP timestamp shares (hle_kernel_time.cpp) — same source as
 // sceKernelReadTsc, so a GPU fence timestamp and a CPU TSC read lie on one timeline (#156).
 extern "C" uint64_t prosper_guest_tsc_ns();
+extern "C" void prosper_label_hist_dma_built(uint64_t addr, uint64_t cb, uint32_t src, uint8_t builder);
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
@@ -151,6 +153,74 @@ int main() {
         size_t n = run_cb(buf, 4, st);    // must not fault / write anywhere
         CHECK(n == 1, "address-less EVENT_WRITE decodes and is a harmless no-op");
     }
+
+    // #312: learn a per-thread MB3 pool array from pthread TLS and detect a 0x20-byte block in both
+    // of size-class idx=1's freelists. The descriptor address is dynamic; no DOLL address is baked in.
+    alignas(0x10000) static uint8_t mb3_pool[0x10000] = {};
+    struct alignas(0x20) FreeNode { uint64_t next; uint64_t pad[3]; };
+    static FreeNode free_label{}, free_tail{}, secondary_label{}, live_label{};
+    uint64_t* bin = (uint64_t*)(mb3_pool + 0x20);
+    mb3_reset_pool_candidates_for_test();
+    mb3_note_tls_pool_candidate((uint64_t)(uintptr_t)mb3_pool);
+    free_label.next = (uint64_t)(uintptr_t)&free_tail;
+    free_tail.next = 0;
+    bin[0] = (uint64_t)(uintptr_t)&free_label; bin[1] = 2;
+    bin[2] = (uint64_t)(uintptr_t)&secondary_label; bin[3] = 1;
+    Mb3FreelistMatch match{};
+    CHECK(mb3_freelist_contains_stable((uint64_t)(uintptr_t)&free_tail, &match) &&
+          match.list == 1 && match.hops == 1,
+          "MB3 membership walks the dynamic primary size-class freelist");
+    CHECK(mb3_freelist_contains_stable((uint64_t)(uintptr_t)&secondary_label, &match) &&
+          match.list == 2,
+          "MB3 membership checks the secondary size-class freelist");
+    CHECK(!mb3_freelist_contains_stable((uint64_t)(uintptr_t)&live_label, nullptr),
+          "an allocated block absent from both freelists is not classified free");
+
+    // The free label's DmaData(:=0) must be skipped before it erases NextFreeBlock. Then simulate an
+    // allocator pop/reuse before ReleaseMem(<-1): the one-generation debt must still suppress that
+    // old fence even though direct membership has become false.
+    {
+        uint64_t addr = (uint64_t)(uintptr_t)&free_label;
+        prosper_label_hist_dma_built(addr, 0x1000, 0, 1);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = (uint32_t)addr; dma[2] = (uint32_t)(addr >> 32);
+        dma[3] = 0; dma[4] = 0; dma[5] = 4; dma[6] = 0x303;
+        uint64_t next_before = free_label.next;
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(free_label.next == next_before,
+              "DmaData zero-init does not overwrite a block currently on the MB3 freelist");
+
+        bin[0] = 0; bin[1] = 0;                    // allocator popped/reused it after the skipped init
+        free_label.next = 0x1122334455667788ull;   // observable data belonging to the new owner
+        uint32_t rel[7] = {};
+        rel[0] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        rel[1] = (uint32_t)addr; rel[2] = (uint32_t)(addr >> 32);
+        rel[3] = 1; rel[4] = 1; rel[5] = 0; rel[6] = 4;
+        run_cb(rel, 7, st);
+        CHECK(free_label.next == 0x1122334455667788ull,
+              "paired ReleaseMem remains suppressed after the free block is popped/reused");
+    }
+
+    // A normal consumed-marker label that is not on a freelist must retain the real protocol: init
+    // low dword to 0, then signal it to 1. This is the false-positive/liveness side of the guard.
+    {
+        bin[2] = 0; bin[3] = 0;
+        live_label.next = 0xAABBCCDDFFFFFFFFull;
+        uint64_t addr = (uint64_t)(uintptr_t)&live_label;
+        prosper_label_hist_dma_built(addr, 0x2000, 0, 1);
+        uint32_t stream[14] = {};
+        stream[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        stream[1] = (uint32_t)addr; stream[2] = (uint32_t)(addr >> 32);
+        stream[3] = 0; stream[4] = 0; stream[5] = 4; stream[6] = 0x303;
+        stream[7] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        stream[8] = (uint32_t)addr; stream[9] = (uint32_t)(addr >> 32);
+        stream[10] = 1; stream[11] = 1; stream[12] = 0; stream[13] = 4;
+        GpuState st; run_cb(stream, 14, st);
+        CHECK((uint32_t)live_label.next == 1,
+              "live consumed-marker labels still execute DmaData(0) then ReleaseMem(1)");
+    }
+    mb3_reset_pool_candidates_for_test();
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -156,7 +156,15 @@ int main() {
 
     // #312: learn a per-thread MB3 pool array from pthread TLS and detect a 0x20-byte block in both
     // of size-class idx=1's freelists. The descriptor address is dynamic; no DOLL address is baked in.
-    alignas(0x10000) static uint8_t mb3_pool[0x10000] = {};
+    // Real MB3 pool arrays are 64 KiB allocations, so mb3_note_tls_pool_candidate only accepts a
+    // 64-KiB-aligned base ((base & 0xffff) == 0). alignas(0x10000) on a STATIC can't guarantee that:
+    // linkers cap static alignment below 64 KiB (macOS reduces __bss to 4 KiB, MinGW rejects > 8 KiB),
+    // so the buffer may land off a 64-KiB boundary and the candidate is silently dropped — the four MB3
+    // membership subtests then fail on macOS/Windows while passing on Linux. Over-allocate and carve a
+    // 64-KiB-aligned 64-KiB window at runtime, which is honored everywhere. Production MB3 logic is
+    // unchanged; only the test's backing memory is.
+    static uint8_t mb3_pool_backing[0x20000] = {};
+    uint8_t* mb3_pool = (uint8_t*)(((uintptr_t)mb3_pool_backing + 0xffffull) & ~0xffffull);
     struct alignas(0x20) FreeNode { uint64_t next; uint64_t pad[3]; };
     static FreeNode free_label{}, free_tail{}, secondary_label{}, live_label{};
     uint64_t* bin = (uint64_t*)(mb3_pool + 0x20);

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -51,7 +51,7 @@ int main() {
 
     auto table = std::make_shared<ShaderResourceTable>();
     ShaderResource a{}; a.cls = ResourceClass::VertexBuffer; a.binding = 9; a.gpu_addr = 0x1000;
-    a.size = 16; a.stride = 4; a.format = DataFormat::Unorm8; a.num_components = 4; a.fetch_pc = 12;
+    a.size = 16; a.stride = 4; a.format = DataFormat::Unorm2_10_10_10; a.num_components = 4; a.fetch_pc = 12;
     ShaderResource b{}; b.cls = ResourceClass::ConstantBuffer; b.binding = 2; b.gpu_addr = 0x1008;
     b.size = 16; b.format = DataFormat::Float32; b.num_components = 4; b.srt_offset = 0x20;
     table->resources = {a, b};
@@ -172,6 +172,8 @@ int main() {
           "fixed-function pipeline state round-trips explicitly");
     CHECK(loaded.draws[0].color0_width == 1024 && loaded.draws[0].color0_height == 32,
           "per-target extent round-trips");
+    CHECK(loaded.draws[0].vrt.resources[0].resource.format == DataFormat::Unorm2_10_10_10,
+          "newest packed image format enum round-trips");
     CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -116,6 +116,39 @@ int main() {
               "later replay submit samples the retained producer target");
     }
 
+    // UE depth prepasses can use a tiny dummy color target with writes disabled while their viewport
+    // and depth surface are full-size. The lighting pass then changes color targets but keeps the exact
+    // DS identity and performs EQUAL testing. Persistent DS must follow the viewport extent, not the
+    // dummy color extent, or the lighting pass receives a fresh clear image and rejects every pixel.
+    DrawItem depth_prepass = replay.items[0];
+    depth_prepass.color0_base = 0x910000;
+    depth_prepass.color0_width = 8; depth_prepass.color0_height = 8;
+    depth_prepass.ps.color_write_mask = 0;
+    depth_prepass.ps.depth_test_enable = true;
+    depth_prepass.ps.depth_write_enable = true;
+    depth_prepass.ps.depth_compare_op = 7; // ALWAYS: populate the persistent surface
+    depth_prepass.ps.depth_clear_value = 1.0f;
+    depth_prepass.ps.has_viewport = true;
+    depth_prepass.ps.viewport_x = 0.0f; depth_prepass.ps.viewport_y = static_cast<float>(H);
+    depth_prepass.ps.viewport_w = static_cast<float>(W); depth_prepass.ps.viewport_h = -static_cast<float>(H);
+    depth_prepass.ps.depth_read_base = depth_prepass.ps.depth_write_base = 0x920000;
+    depth_prepass.ps.htile_data_base = 0x930000;
+
+    DrawItem equal_lighting = depth_prepass;
+    equal_lighting.color0_base = 0x940000;
+    equal_lighting.color0_width = W; equal_lighting.color0_height = H;
+    equal_lighting.ps.color_write_mask = 0xF;
+    equal_lighting.ps.depth_write_enable = false;
+    equal_lighting.ps.depth_compare_op = 2; // EQUAL: same VS depth must match the prepass
+    std::vector<uint8_t> depth_reused = render_submit_items({depth_prepass, equal_lighting}, W, H);
+    CHECK(depth_reused.size() == static_cast<size_t>(W) * H * 4,
+          "full-size lighting pass follows a dummy-color depth prepass");
+    if (depth_reused.size() == static_cast<size_t>(W) * H * 4) {
+        const uint8_t* center = &depth_reused[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+        CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
+              "EQUAL lighting reuses viewport-sized depth written behind the tiny color attachment");
+    }
+
     // A captured consumer may depend on a producer from an earlier submit. Restore its serialized
     // host RTT surface before replaying draw zero; guest memory has no copy of these rendered pixels.
     GpuCaptureRttSeed temporal_seed;

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -200,6 +200,7 @@ int main() {
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str());
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2");
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362");
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1");
 #else
     setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
     setenv("PROSPER_CAPTURE_TITLE", "runtime-title", 1);
@@ -209,6 +210,7 @@ int main() {
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str(), 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2", 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362", 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1", 1);
 #endif
     GpuState prestart_state;
     begin_gpu_timeline_submit(40);
@@ -225,6 +227,11 @@ int main() {
     predecessor_state.command_order = 120;
     begin_gpu_timeline_submit(41);
     record_gpu_timeline_submit(predecessor_state, 41);
+    GpuCaptureBundle checkpoint_bundle;
+    CHECK(read_gpu_capture_bundle(bundle_capture, checkpoint_bundle, error) &&
+          checkpoint_bundle.submits.size() == 1 &&
+          checkpoint_bundle.submits[0].submit_index == 41,
+          "bundle checkpoint preserves predecessor history before the endpoint exists");
     begin_gpu_timeline_submit(42);
     record_gpu_timeline_present(9, 1, 77, 1920, 1080); // a PM4 flip can precede submit completion
     GpuState runtime_state;

--- a/prosper/tests/test_interp_render.cpp
+++ b/prosper/tests/test_interp_render.cpp
@@ -9,6 +9,7 @@
 // and blue stay ~0, proving the output is the interpolated attribute, not garbage.
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "render_runner.h"
+#include <algorithm>
 #include <cstdio>
 #include <cstdint>
 #include <vector>
@@ -56,6 +57,53 @@ int main() {
     printf("  red range [%u..%u]  max(green,blue)=%u\n", rmin, rmax, max_gb);
     CHECK(rmax - rmin > 40, "the interpolated attribute forms a red GRADIENT across the viewport");
     CHECK(max_gb < 0x20, "green/blue stay ~0 (output is the interpolated attribute, not garbage)");
+
+    // DOLL's live linkage shape is non-identity: PS input 1 consumes producer PARAM3. Exercise the
+    // generic form here by moving this fixture's export from PARAM0 to PARAM3, then remapping logical
+    // PS input 0 back to source slot 3. The unchanged attr0 PS must still receive the gradient.
+    std::vector<uint32_t> param3_vs(vs, vs + sizeof(vs)/sizeof(vs[0]));
+    for (uint32_t& word : param3_vs) if (word == 0xf800020fu) word = 0xf800023fu;
+    PixelInputMapping remap;
+    remap.valid_mask = 1u;
+    remap.controls[0] = 3u;
+    std::vector<uint32_t> remapped_vert = recompile_vertex(
+        param3_vs.data(), param3_vs.size(), nullptr, &remap);
+    std::vector<uint8_t> remapped_px = prosper::test::render_triangle_rgba(
+        remapped_vert, frag, W, H);
+    CHECK(remapped_px.size() == (size_t)W * H * 4,
+          "SPI_PS_INPUT_CNTL remap links source PARAM3 to logical PS input 0");
+    if (remapped_px.size() == (size_t)W * H * 4) {
+        uint8_t remapped_min = 255, remapped_max = 0;
+        for (size_t i = 0; i < remapped_px.size(); i += 4) {
+            remapped_min = std::min(remapped_min, remapped_px[i]);
+            remapped_max = std::max(remapped_max, remapped_px[i]);
+        }
+        CHECK(remapped_max - remapped_min > 40,
+              "remapped PARAM3 preserves the interpolated gradient at PS input 0");
+    }
+
+    // GFX10 fixed-function interpolation can replace a missing PARAM export with one of four
+    // DEFAULT_VAL vectors. Vulkan has no matching pipeline state, so the vertex recompiler emits
+    // the selected constant at the logical PS input location. DEFAULT_VAL=3 is (1,1,1,1): the same
+    // PS that produced a gradient above must now see attr0.x=1 at every covered pixel.
+    PixelInputMapping default_input;
+    default_input.valid_mask = 1u;
+    default_input.controls[0] = 0x00000320u; // OFFSET=0x20, DEFAULT_VAL=3 (1111)
+    std::vector<uint32_t> default_vert = recompile_vertex(
+        vs, sizeof(vs)/sizeof(vs[0]), nullptr, &default_input);
+    std::vector<uint8_t> default_px = prosper::test::render_triangle_rgba(
+        default_vert, frag, W, H);
+    CHECK(default_px.size() == (size_t)W * H * 4,
+          "SPI_PS_INPUT_CNTL default produces a linkable VS/PS interface");
+    if (default_px.size() == (size_t)W * H * 4) {
+        uint8_t default_min = 255, default_max = 0;
+        for (size_t i = 0; i < default_px.size(); i += 4) {
+            if (default_px[i] < default_min) default_min = default_px[i];
+            if (default_px[i] > default_max) default_max = default_px[i];
+        }
+        CHECK(default_min == 255 && default_max == 255,
+              "DEFAULT_VAL=3 materializes attr0=(1,1,1,1), not an unwritten zero varying");
+    }
 
     // DPP quad_perm as screen-space derivatives (#273 — DOLL's manual ddx/ddy idiom). The attribute
     // attr0.x ramps linearly across the fullscreen triangle: PARAM0.x = vid with vertices

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -453,6 +453,34 @@ int main() {
     printf("  kernel22 mismatches=%u (out[0]=%g expect=320: cbuf0[1]=20 + cbuf1[1]=300)\n", bad22, got22.size()==N?got22[0]:-1);
     CHECK(got22.size()==N && bad22==0, "recompiled kernel 22 (provenance routes s_buffer_loads to bindings 2 & 3) correct");
 
+    // DOLL scene VS: the compiler loads several V# descriptors into separate SGPR ranges, then
+    // reuses one SRSRC range by copying a selected descriptor into it with s_mov_b32. Descriptor
+    // provenance must follow each scalar move. Keeping the destination's previous SRT tag routes
+    // every later raw MUBUF through the first constant buffer and collapses the scene triangles.
+    const uint32_t code22move[] = {
+        0xf4080200u, 0xfa000020u,                         // s_load_dwordx4 s[8:11],  s[0:1], 0x20
+        0xf4080300u, 0xfa000040u,                         // s_load_dwordx4 s[12:15], s[0:1], 0x40
+        0xbe88030cu, 0xbe89030du, 0xbe8a030eu, 0xbe8b030fu, // s_mov_b32 s[8:11], s[12:15]
+        0xe0300000u, 0x84020000u,                         // buffer_load_dword v0, off, s[8:11], 4
+        0x7e000d00u, 0xbf810000u,                         // v_cvt_f32_u32 v0,v0; s_endpgm
+    };
+    ShaderResourceTable rt22move;
+    rt22move.resources.push_back({ResourceClass::ConstantBuffer, DataFormat::Uint32, 1,
+                                  /*binding*/2, 0, 0, 0, /*srt*/0x20});
+    rt22move.resources.push_back({ResourceClass::ConstantBuffer, DataFormat::Uint32, 1,
+                                  /*binding*/3, 0, 0, 0, /*srt*/0x40});
+    std::vector<uint32_t> spv22move = recompile_valu(
+        code22move, sizeof(code22move) / sizeof(code22move[0]), 1, 0, &rt22move);
+    std::vector<uint32_t> decoy22move(4, 0u), wanted22move(4, 0u);
+    decoy22move[1] = 20u; wanted22move[1] = 300u;
+    std::vector<float> got22move = prosper::test::run_compute(
+        spv22move, in22, N, N, decoy22move, wanted22move);
+    uint32_t bad22move = 0;
+    for (uint32_t i = 0; i < N && got22move.size() == N; i++)
+        if (std::fabs(got22move[i] - 300.0f) > 1e-3f) bad22move++;
+    CHECK(!spv22move.empty() && got22move.size() == N && bad22move == 0,
+          "descriptor provenance follows s_mov_b32 when an SRSRC range is reused");
+
     // #515: a stage whose decoded resources start at 32/33 must not retain dead fallback-binding-2
     // loads for the preceding raw descriptor fetches. Those s_load_dwordx4 results are provenance;
     // the actual s_buffer_load data operations below resolve to the table's high bindings.
@@ -509,6 +537,69 @@ int main() {
     uint32_t bad23 = 0; for (uint32_t i=0;i<N&&got23.size()==N;i++) if (std::fabs(got23[i]-exp23[i])>1e-3f) bad23++;
     printf("  kernel23 mismatches=%u (out[5]=%g expect=6.5)\n", bad23, got23.size()==N?got23[5]:-1);
     CHECK(got23.size()==N && bad23==0, "recompiled kernel 23 (float32 vertex fetch via sgpr_base provenance) correct");
+
+    // A pc-keyed VertexBuffer is not necessarily the NGG v0 fetch prologue. DOLL's skinned scene
+    // shaders use a direct structured V# through computed VADDRs (v4/v5/v7/...); the old shortcut
+    // replaced all of them with gl_VertexIndex. Pin v1=1 and prove the fetch stays on record 1 for
+    // every lane even though exact per-PC provenance is present.
+    const uint32_t code23computed[] = {
+        0x7e020281u,                 // v_mov_b32 v1, 1
+        0xe0002000u, 0x80020201u,   // buffer_load_format_x v2, v1, s[8:11], 0 idxen
+        0xbf810000u,
+    };
+    ShaderResourceTable rt23computed;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
+      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8; vb.fetch_pc = 1;
+      rt23computed.resources.push_back(vb); }
+    std::vector<uint32_t> spv23computed = recompile_valu(
+        code23computed, sizeof(code23computed)/sizeof(code23computed[0]), 1, 2, &rt23computed);
+    std::vector<float> got23computed = prosper::test::run_compute(
+        spv23computed, in23, N, N, {}, vbuf23);
+    uint32_t bad23computed = 0;
+    for (uint32_t i = 0; i < N && got23computed.size() == N; ++i)
+        if (std::fabs(got23computed[i] - exp23[1]) > 1e-3f) ++bad23computed;
+    CHECK(!spv23computed.empty() && got23computed.size() == N && bad23computed == 0,
+          "pc-keyed structured vertex fetch preserves its computed non-v0 VADDR");
+
+    // Conversely, a descriptor-loaded attribute remains an NGG fetch-prologue use even when the
+    // incomplete prologue left its element index in a non-v0 register. The rewritten SRSRC is the
+    // discriminator: the vertex module must reload gl_VertexIndex for the fetch instead of reading
+    // record zero from v1. Count loads from the decorated built-in (one ABI seed + one fetch use).
+    const uint32_t code23rewritten[] = {
+        0xbe880380u,                 // s_mov_b32 s8, 0 (marks the SRSRC range rewritten)
+        0x7e020280u,                 // v_mov_b32 v1, 0
+        0xe0002000u, 0x80020201u,   // buffer_load_format_x v2, v1, s[8:11], 0 idxen
+        0x7e060280u, 0x7e0802f2u,   // v3=0, v4=1.0
+        0xf80008cfu, 0x04030201u,   // exp pos0 v[1:4]
+        0xbf810000u,
+    };
+    ShaderResourceTable rt23rewritten;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
+      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.fetch_pc = 2;
+      rt23rewritten.resources.push_back(vb); }
+    std::vector<uint32_t> spv23rewritten = recompile_vertex(
+        code23rewritten, sizeof(code23rewritten)/sizeof(code23rewritten[0]), &rt23rewritten);
+    uint32_t vertex_index_id = 0, vertex_index_loads = 0;
+    for (size_t word = 5; word < spv23rewritten.size(); ) {
+        const uint32_t count = spv23rewritten[word] >> 16;
+        const uint32_t opcode = spv23rewritten[word] & 0xffffu;
+        if (!count || word + count > spv23rewritten.size()) break;
+        // OpDecorate target BuiltIn VertexIndex (71, decoration 11, built-in 42).
+        if (opcode == 71 && count >= 4 && spv23rewritten[word + 2] == 11u &&
+            spv23rewritten[word + 3] == 42u)
+            vertex_index_id = spv23rewritten[word + 1];
+        word += count;
+    }
+    for (size_t word = 5; word < spv23rewritten.size(); ) {
+        const uint32_t count = spv23rewritten[word] >> 16;
+        const uint32_t opcode = spv23rewritten[word] & 0xffffu;
+        if (!count || word + count > spv23rewritten.size()) break;
+        if (opcode == 61 && count >= 4 && spv23rewritten[word + 3] == vertex_index_id)
+            ++vertex_index_loads; // OpLoad result-type result-id pointer
+        word += count;
+    }
+    CHECK(!spv23rewritten.empty() && vertex_index_id && vertex_index_loads == 2,
+          "pc-keyed rewritten SRSRC keeps vertex-index recovery for non-v0 attributes");
 
     // Kernel 24: UNORM8x4 vertex fetch (stage 3 — packed-format conversion). buffer_load_format_xyzw
     // unpacks a dword into 4 bytes, each normalized /255 into v1..v4. out = v1 + 2*v2 + 3*v3 + 4*v4

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -73,6 +73,8 @@ int main() {
         { P::CB_COLOR0_CLEAR_WORD0, 0x11223344u },
         { P::CB_COLOR0_CLEAR_WORD1, 0x00000000u },
         { P::CB_COLOR0_ATTRIB2, ((1024u - 1u) << 14) | (32u - 1u) },
+        { P::SPI_PS_INPUT_CNTL_0, 0x00000401u }, // PS input 0 <- PARAM1, flat
+        { P::SPI_PS_INPUT_CNTL_0 + 1u, 0x00000320u }, // PS input 1 <- DEFAULT_VAL 1111
     };
     // Shader-stage program addresses.
     ShaderReg sh_regs[] = {
@@ -95,6 +97,9 @@ int main() {
     CHECK(rs.ps_addr == rdna2_addr(0x00ABCDEFu, 0x12u), "PS shader addr = (LO<<8)|(HI<<40)");
     CHECK(rs.es_addr == rdna2_addr(0x00111111u, 0x34u), "ES shader addr = (LO<<8)|(HI<<40)");
     CHECK(rs.gs_addr == 0 && rs.hs_addr == 0, "unset GS/HS shader addrs are 0");
+    CHECK(rs.ps_input_cntl_valid_mask == 0x3u &&
+          rs.ps_input_cntl[0] == 0x00000401u && rs.ps_input_cntl[1] == 0x00000320u,
+          "programmed SPI_PS_INPUT_CNTL words and presence mask are retained");
 
     CHECK(rs.color0_base == rdna2_addr(0x00100000u, 0x12u), "color0_base = (BASE<<8)|(EXT<<40)");
     CHECK(rs.color0_format == 0x0Au, "color0_format = 0x0A (FORMAT field)");

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -87,6 +87,26 @@ int main() {
     CHECK(!direct_ps.empty() && cached_ps == direct_ps,
           "fragment cache output is byte-identical to the direct recompiler");
 
+    // Interpolant wiring changes vertex PARAM export locations/defaults, so it is part of the
+    // compile-time key even when the guest code and resource interface are otherwise identical.
+    stats = shader_recompile_cache_stats();
+    const uint64_t mapping_misses = stats.misses;
+    const uint64_t mapping_hits = stats.hits;
+    PixelInputMapping mapping;
+    mapping.valid_mask = 1;
+    mapping.controls[0] = 1;
+    const auto mapped_once = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, &mapping);
+    const auto mapped_again = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, &mapping);
+    mapping.controls[0] = 2;
+    const auto remapped = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, &mapping);
+    stats = shader_recompile_cache_stats();
+    CHECK(!mapped_once.empty() && mapped_again == mapped_once && !remapped.empty() &&
+              stats.misses == mapping_misses + 2 && stats.hits == mapping_hits + 1,
+          "pixel-input mappings participate in the vertex shader cache key");
+
     clear_shader_recompile_cache();
     stats = shader_recompile_cache_stats();
     CHECK(stats.entries == 0 && stats.hits == 0 && stats.misses == 0 && stats.bytes == 0,

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -137,6 +137,16 @@ int main() {
     { float nan = f10_to_float(0x3E1); CHECK(nan != nan, "f10 0x3E1 = NaN"); }
     CHECK(data_format_bytes(DataFormat::Float10_11_11) == 0,
           "Float10_11_11 is packed: per-component bytes = 0 (texel size lives in bytes_per_block)");
+    CHECK(data_format_bytes(DataFormat::Unorm2_10_10_10) == 0,
+          "Unorm2_10_10_10 is packed: per-component bytes = 0");
+
+    uint8_t rgba10[4] = {};
+    unorm2_10_10_10_to_rgba8(0xFFFFFFFFu, rgba10);
+    CHECK(rgba10[0] == 255 && rgba10[1] == 255 && rgba10[2] == 255 && rgba10[3] == 255,
+          "packed R10G10B10A2 all-ones maps to opaque white");
+    unorm2_10_10_10_to_rgba8((512u << 0) | (256u << 10) | (1u << 20) | (2u << 30), rgba10);
+    CHECK(rgba10[0] == 128 && rgba10[1] == 64 && rgba10[2] == 0 && rgba10[3] == 170,
+          "packed R10G10B10A2 fields normalize and round independently");
 
     const std::vector<uint32_t> spv = descriptor_test_spirv();
     ShaderResource good{}; good.cls = ResourceClass::VertexBuffer; good.binding = 9;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -125,6 +125,8 @@ For bounded recursion, add `PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=<path>.prgbundle
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=64..4096` (default 1024). `gpu_replay --bundle bundle output`
 executes the ordered window and classifies each temporal frontier as included, seeded, or depth-bounded.
 Bundles use content-defined chunks so shifted capture metadata does not defeat cross-submit deduplication.
+`PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY=N` atomically installs the rolling bundle every N captured
+predecessor submits, preserving the latest complete window if the guest crashes before the selected endpoint.
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM=WxH` restricts predecessor captures to draws targeting that extent;
 it is a size diagnostic, not a dependency proof. `gpu_replay --bundle-zero-boundary` supplies transparent
 pixels to the oldest unseeded temporal leaves for an explicit A/B test and labels the synthetic seeds.
@@ -141,6 +143,8 @@ identity, format, independent validity flags, byte counts, and hashes. Captures 
 invented DS state.
 `gpu_replay --bundle-extract-submit N PATH` materializes one exact manifest for normal inspect/graph/validate
 work without replaying the bundle.
+`gpu_replay --warmup-repeats N CAPTURE OUTPUT` executes the same capsule N times into the persistent RTT/DS
+caches before the measured replay, providing an explicit temporal-history convergence probe.
 `gpu_replay --bundle-find-ds ADDR` scans compact manifests for guest depth/stencil use, writes, clears, compare
 ops, and target extents without reconstructing resource payloads or invoking Vulkan.
 `gpu_replay --bundle-ds-summary` groups every DS-active draw by complete captured identity/programming and

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -66,7 +66,9 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 
 ```bash
 ./build-linux/gpu_replay --draw 12:18 /tmp/submit.prgcap /tmp/pass.bmp
+./build-linux/gpu_replay --draw 18 --draw-with-compute-prefix /tmp/submit.prgcap /tmp/draw.bmp
 ./build-linux/gpu_replay --through-operation 52 /tmp/submit.prgcap /tmp/prefix.bmp
+./build-linux/gpu_replay --warmup-repeats 2 /tmp/submit.prgcap /tmp/converged.bmp
 ./build-linux/gpu_replay --dump-resource 18:ps:34 /tmp/texture.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
@@ -106,6 +108,10 @@ interchangeable when dispatches or unrealized operations are present. Replay res
 seeds before operation zero and uses owned resource memory; it must not dereference original guest mappings.
 Bundle operation sources are semantic draw IDs and may contain holes; tooling must resolve them through each
 realized item's `draw_index`, never treat them as offsets into the compact draw vector.
+
+`--draw-with-compute-prefix` retains every compute operation before the selected draw while discarding the
+other graphics draws. This isolates geometry whose vertex/indirect buffers are produced earlier in the same
+submit without losing those producers. Plain `--draw` intentionally remains the cheaper graphics-only path.
 
 `--through-operation N` executes the inclusive mixed graphics/compute prefix `0..N`, preserving operation
 order and all earlier work. Prefix output uses the last executed draw target's native dimensions. Use it with

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -29,8 +29,8 @@ bool set_environment(const std::string& name, const std::string& value) {
 
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
-                         "[--graph-json PATH] [--draw N[:M]] "
-                         "[--through-operation N] "
+                         "[--graph-json PATH] [--draw N[:M]] [--draw-with-compute-prefix] "
+                         "[--through-operation N] [--warmup-repeats N] "
                          "[--bundle capture.prgbundle] [--bundle-tail N] [--bundle-compact PATH] "
                          "[--bundle-intermediate-through-target WxH] "
                          "[--bundle-final-capsule PATH] "
@@ -215,10 +215,11 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     }
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
-        std::printf("draw[%zu] target=%016llx extent=%ux%u vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
+        std::printf("draw[%zu] source=%llu target=%016llx extent=%ux%u vcount=%u indices=%zu topo=%u fmt=%u cwm=%x "
                     "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u viewport=%d %.1f,%.1f %.1fx%.1f "
                     "vs=%zu/%016llx fs=%zu/%016llx\n",
-                    i, static_cast<unsigned long long>(d.color0_base), d.color0_width, d.color0_height,
+                    i, static_cast<unsigned long long>(d.draw_index),
+                    static_cast<unsigned long long>(d.color0_base), d.color0_width, d.color0_height,
                     d.vertex_count, d.indices.size(),
                     d.ps.topology, d.ps.color0_format, d.ps.color_write_mask, d.ps.depth_test_enable,
                     d.ps.depth_write_enable, d.ps.depth_compare_op, d.ps.stencil_enable, d.ps.blend_enable,
@@ -256,6 +257,13 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.db_depth_size_xy, d.ps.db_depth_size, d.ps.db_depth_slice,
                     d.ps.db_depth_info, d.ps.db_z_info, d.ps.db_stencil_info,
                     d.ps.db_dfsm_control, d.ps.db_rmi_l2_cache_control);
+        if (!d.indices.empty()) {
+            const size_t preview_count = std::min<size_t>(d.indices.size(), 16);
+            std::printf("  indices first[%zu/%zu]=", preview_count, d.indices.size());
+            for (size_t index = 0; index < preview_count; ++index)
+                std::printf("%s%u", index ? "," : "", d.indices[index]);
+            std::printf("\n");
+        }
         inspect_table("VS", d.vrt.get(), replay.rtt_seeds);
         inspect_table("PS", d.prt.get(), replay.rtt_seeds);
     }
@@ -999,11 +1007,12 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool graph_only = false, bundle_zero_boundary = false, bundle_ds_summary = false;
-    bool legacy_htile_before_stencil = false;
+    bool legacy_htile_before_stencil = false, draw_with_compute_prefix = false;
     size_t bundle_tail = 0;
     uint32_t bundle_intermediate_target_width = 0, bundle_intermediate_target_height = 0;
     int draw_first = -1, draw_last = -1;
     int through_operation = -1;
+    uint32_t warmup_repeats = 0;
     std::string dump_spec, dump_path, shader_spec, shader_path;
     std::string compute_shader_spec, compute_shader_path;
     std::string compute_resource_spec, compute_resource_path;
@@ -1063,11 +1072,19 @@ int main(int argc, char** argv) {
             draw_first = std::atoi(range.c_str());
             draw_last = colon == std::string::npos ? draw_first : std::atoi(range.c_str() + colon + 1);
         }
+        else if (std::string(argv[i]) == "--draw-with-compute-prefix")
+            draw_with_compute_prefix = true;
         else if (std::string(argv[i]) == "--through-operation" && i + 1 < argc) {
             char* end = nullptr;
             const long value = std::strtol(argv[++i], &end, 0);
             if (!end || *end || value < 0 || value > INT_MAX) { usage(argv[0]); return 2; }
             through_operation = static_cast<int>(value);
+        }
+        else if (std::string(argv[i]) == "--warmup-repeats" && i + 1 < argc) {
+            char* end = nullptr;
+            const unsigned long value = std::strtoul(argv[++i], &end, 0);
+            if (!end || *end || !value || value > 1024) { usage(argv[0]); return 2; }
+            warmup_repeats = static_cast<uint32_t>(value);
         }
         else if (std::string(argv[i]) == "--dump-resource" && i + 2 < argc) {
             dump_spec = argv[++i]; dump_path = argv[++i];
@@ -1091,9 +1108,11 @@ int main(int argc, char** argv) {
     if (!bundle_path.empty()) {
         if (bundle_ds_summary && bundle_find_ds_addr) { usage(argv[0]); return 2; }
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
-            draw_first >= 0 || through_operation >= 0 || !dump_spec.empty() ||
+            draw_first >= 0 || draw_with_compute_prefix || through_operation >= 0 ||
+            warmup_repeats || !dump_spec.empty() ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
-            !compute_resource_spec.empty() || !failed_shader_spec.empty() || !prepend_path.empty()) {
+            !compute_resource_spec.empty() || !failed_shader_spec.empty() ||
+            !prepend_path.empty()) {
             usage(argv[0]); return 2;
         }
         return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
@@ -1113,6 +1132,7 @@ int main(int argc, char** argv) {
     }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
     if (draw_first >= 0 && through_operation >= 0) { usage(argv[0]); return 2; }
+    if (draw_with_compute_prefix && draw_first < 0) { usage(argv[0]); return 2; }
     prosper::gpu::GpuCaptureFile capture; std::string error;
     if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {
         std::fprintf(stderr, "gpu_replay: %s: %s\n", positional[0], error.c_str()); return 2;
@@ -1287,14 +1307,33 @@ int main(int argc, char** argv) {
                      static_cast<unsigned long long>(found->host_data_size),
                      compute_resource_path.c_str());
     }
+    size_t selected_operation_limit = SIZE_MAX;
     if (draw_first >= 0) {
         if (draw_last < draw_first || static_cast<size_t>(draw_last) >= replay.items.size()) {
             std::fprintf(stderr, "gpu_replay: draw range %d:%d is out of range\n", draw_first, draw_last); return 2;
         }
         std::vector<prosper::gpu::DrawItem> selected;
-        for (int i = draw_first; i <= draw_last; ++i) selected.push_back(std::move(replay.items[i]));
+        std::unordered_set<uint64_t> selected_draw_indexes;
+        for (int i = draw_first; i <= draw_last; ++i) {
+            selected_draw_indexes.insert(replay.items[i].draw_index);
+            selected.push_back(std::move(replay.items[i]));
+        }
+        if (draw_with_compute_prefix) {
+            for (size_t operation_index = 0; operation_index < replay.operations.size();
+                 ++operation_index) {
+                const auto& operation = replay.operations[operation_index];
+                if (operation.kind == prosper::gpu::SubmitOperationKind::Draw &&
+                    selected_draw_indexes.count(operation.source_index))
+                    selected_operation_limit = operation_index + 1;
+            }
+            if (selected_operation_limit == SIZE_MAX) {
+                std::fprintf(stderr, "gpu_replay: selected draw range has no submit operation\n");
+                return 2;
+            }
+        }
         replay.items = std::move(selected); allow_mismatch = true;
-        std::fprintf(stderr, "[gpureplay] selected original draws %d:%d\n", draw_first, draw_last);
+        std::fprintf(stderr, "[gpureplay] selected original draws %d:%d%s\n", draw_first,
+                     draw_last, draw_with_compute_prefix ? " with compute prefix" : "");
     }
     if (through_operation >= 0) {
         if (static_cast<size_t>(through_operation) >= replay.operations.size()) {
@@ -1363,9 +1402,17 @@ int main(int argc, char** argv) {
     if (!prosper::gpu::restore_gpu_replay_ds_seeds(replay.ds_seeds, error)) {
         std::fprintf(stderr, "gpu_replay: cannot restore DS seeds: %s\n", error.c_str()); return 2;
     }
+    for (uint32_t repeat = 0; repeat < warmup_repeats; ++repeat) {
+        std::vector<uint8_t> warmup_pixels = execute_frame(replay);
+        std::fprintf(stderr, "[gpureplay] warmup repeat=%u/%u output_bytes=%zu hash=%016llx\n",
+                     repeat + 1, warmup_repeats, warmup_pixels.size(),
+                     static_cast<unsigned long long>(
+                         prosper::gpu::gpu_capture_hash(warmup_pixels)));
+    }
     const size_t operation_limit = through_operation >= 0
-        ? static_cast<size_t>(through_operation) + 1 : SIZE_MAX;
-    std::vector<uint8_t> pixels = execute_frame(replay, draw_first >= 0, operation_limit);
+        ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
+    std::vector<uint8_t> pixels = execute_frame(
+        replay, draw_first >= 0 && !draw_with_compute_prefix, operation_limit);
     uint32_t output_width = m.width, output_height = m.height;
     if (through_operation >= 0) {
         for (size_t operation_index = 0; operation_index < operation_limit; ++operation_index) {

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -169,6 +169,10 @@ is reused only after byte comparison, never from guest address identity. Version
 data to 64..4096 MiB (default 1024) and aborts bundle installation if exhausted. The selected standalone
 `.prgcap` remains the graph/oracle reference and is currently required with the bundle.
 
+`PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY=N` atomically writes the current rolling bundle after every N
+captured predecessor submits (1..4096). Use it when the guest may crash before the semantic endpoint; the
+checkpoint remains replayable, while a later successful endpoint still compacts and replaces it normally.
+
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DIM=WxH` restricts predecessor bundle submits to graphics draws for
 matching target extents while leaving the selected consumer complete. This is a capture-volume diagnostic,
 not renderer substitution. It may still be expensive when relevant passes reference large shared assets;
@@ -193,6 +197,10 @@ selecting the wrong scene when it perturbs wall-clock pacing. A requested bundle
 forward so the final bundle contains exactly the latest requested depth. The dictionary may retain content
 seen by evicted manifests during capture, and the unique-byte budget remains authoritative. Finalization
 compacts unreachable dictionary entries before installing the bundle.
+
+For a standalone capsule that reads its own prior-frame targets, `gpu_replay --warmup-repeats N CAPTURE OUTPUT`
+executes N unmeasured copies into the persistent RTT/depth caches before the final replay. This is a temporal
+convergence diagnostic, not evidence that the first native frame contained those prior versions.
 
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=MIN:MAX` restricts the matching target to a zero-based
 semantic draw-index window. Establish the range across multiple desired captures and nearby negative samples;


### PR DESCRIPTION
## Summary

- suppress fences that target freed MallocBinned3 labels, keeping more UE capture runs alive
- resolve direct T#/S#/V# resources and preserve computed structured-buffer VADDR provenance instead of replacing it with `gl_VertexIndex`
- capture and derive AGC pixel-input mappings so vertex PARAM exports reach the fragment shader's intended interpolants and defaults
- add GFX10 `2_10_10_10_UNORM` image support and retain full-size depth attachments for color-disabled prepasses
- extend capture/replay diagnostics with checkpoints, compute-prefix replay, warmup repeats, source draw IDs, and index previews

## DOLL evidence

The existing full DOLL capture reaches the UE scene workload (80 draws, 101 recorded draw slots, and 293 compute dispatches). Before this change, representative scene draws collapsed to zero rasterized pixels with the real vertex shader. With direct descriptor provenance and computed VADDR preserved, the same real vertex shaders rasterize coherent on-screen silhouettes under a diagnostic pixel shader.

This is a meaningful geometry milestone, but not a claim that DOLL's shaded scene is finished: the real pixel-shader path for the inspected draw is still black. Fresh long captures also remain intermittently exposed to the broader label-lifetime race tracked in #312. Keeping this PR draft makes that remaining gap explicit.

The temporary experiment that interpreted AGC dispatch dimensions as workgroup counts was fully reverted. The branch retains the established API thread-count semantics and passes the existing compute regressions.

## Validation

- full RelWithDebInfo build
- 93/93 CTest tests pass serially, including Vulkan render/replay coverage
- Messenger snapshot: 24,318 distinct colors (threshold 5,000)
- Dead Cells splash snapshot: 1,705 distinct colors (threshold 1,500)
- focused direct-descriptor, dynamic-fetch, interpolant, format, depth-prepass, capture, timeline, and shader-cache tests

Advances #320. Related to #312.
