### PR TITLE
tooling: add reviewed multi-frame gameplay guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,14 +243,17 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
-  cmake --build . -j8 && ctest        # 93/93 expected green on Linux
+  cmake --build . -j8 && ctest        # 99/99 expected green on Linux
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
-  shaders are `spirv-val`-gated; rendered frames are pixel/CRC-asserted or dumped to BMP. No manual
-  eyeballing is required to know a change works. **After any change that can affect rendered output**
-  (recompiler, AGC decode, render state, detile, executor/present), run the golden-image guard
-  `python3 tools/snapshot/snapshot.py check` (local-only, boots a real game and pixel-hashes an exact
-  frame vs a stored baseline — see `tools/snapshot/AGENTS.md`).
+  shaders are `spirv-val`-gated; rendered frames are asserted by pixels, hashes, or routed content
+  metrics. **After any change that can affect rendered output** (recompiler, AGC decode, render state,
+  detile, executor/present), run `python3 tools/snapshot/snapshot.py check` (local-only). Gameplay
+  guards inspect multiple frames in route-specific windows and use SSIM over compact luminance
+  signatures from several reviewed states, looking for major collapse without rejecting subtle pixel improvements.
+  Every new or materially changed baseline requires `snapshot.py verify`,
+  inspection of all retained images from both runs, and a factual `review` note. See
+  `tools/snapshot/AGENTS.md`.
 - **Build tools — don't avoid them.** This project is a long reverse-engineering effort, and getting
   progressively more complicated games running will keep demanding new instrumentation. When you hit a
   question the existing tools can't answer — "who references this address in the unsymbolicated eboot?",

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -75,6 +75,8 @@ find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND)
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
+  add_test(NAME snapshot_guard_logic
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/snapshot/test_snapshot.py")
 endif()
 # Path to the (gitignored) local game dump; override with -DGAME_DUMP=...
 set(GAME_DUMP "${CMAKE_SOURCE_DIR}/../PPSA24651-app0" CACHE PATH "Local PS5 game dump root")

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -114,7 +114,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # 92 self-checking tests
+ctest --test-dir build          # 99 self-checking tests
 ```
 Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
 ```

--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -1,8 +1,9 @@
-# Verification strategy (agentic-first — no manual eyeballing)
+# Verification strategy (automated gates, reviewed baselines)
 
-Every milestone is gated by a self-checking test whose **exit code is the truth**. Nobody looks at a
-window; nobody diffs an image by hand. This keeps a long project cheap to run — `ctest` is the only
-verification step. The graphics path is verified in layers, cheapest first.
+Every milestone is gated by a self-checking test whose **exit code is the truth**. Routine checks do
+not require a person to operate a game window or compare images. Baselines are different: a new or
+changed real-game baseline must be visually inspected once so an automated check cannot bless a black
+frame, logo, menu, or wrong scene. The graphics path is verified in layers, cheapest first.
 
 ## 1. Structural assertions (no GPU) — the bulk of correctness
 
@@ -60,11 +61,24 @@ coverage % + the top first-unsupported opcodes. This turns "what to build next" 
 ~67% of instructions; the dominant remaining blocker is `SMEM`), and is regression-tested pure
 (`test_recompile_coverage`).
 
-## 5. Frame-CRC golden for the real game (once it boots)
+## 5. Routed multi-frame guards for real games
 
-When the completion-event fix lets the residency pass run and real draws flow through the spine,
-capture the per-frame command-stream / framebuffer CRC once, then assert it thereafter. The game's
-early frames are deterministic, so this detects any rendering regression frame-by-frame without review.
+`tools/snapshot/snapshot.py` boots local game dumps through the normal presented-screenshot frontend,
+can replay a title-specific input route from a fresh temporary save, and evaluates several composited
+frames from a gameplay-only time window. Threaded games rarely select one deterministic frame, and subtle pixel changes may be
+valid improvements, so gameplay guards use coarse contracts: multiple frames must exceed a reviewed
+scene-richness threshold, several frames must meet an SSIM threshold against visually reviewed 16x9
+luminance reference states, non-black coverage and dimensions must remain correct, and moving routes can require visible pixel
+changes. This catches black output, missing major layers, stalled routes, and presentation collapse
+without making every pixel part of the API. Exact CRCs identify samples for debugging but do not reject
+subtle changes in timing-sensitive gameplay.
+
+Exact frame hashes remain available for checkpoints proven deterministic by two independent captures.
+For either mode, `snapshot.py verify NAME` retains images from two runs under
+`tools/snapshot/review/NAME/`. A person must inspect every retained image and confirm the intended state,
+layers, and progression before recording a new hash or threshold. Routine `snapshot.py check` runs are
+then automated. Dumps and evidence images are local and gitignored, so real-game guards do not run in CI.
+See `tools/snapshot/README.md` for the complete approval workflow.
 
 ## CI
 
@@ -76,5 +90,6 @@ game dump is absent.
 ## Rule of thumb
 
 Prefer the cheapest layer that can catch a given bug: pure structural asserts for translation logic,
-pixel/region + golden-hash for the raster path, execution-differential for shader semantics. Only the
-final integrated frame needs the GPU; everything upstream is verified on the CPU.
+pixel/region plus golden hashes for deterministic raster tests, execution-differential checks for shader
+semantics, and routed multi-frame guards for integrated games. Only the final integrated scene needs a
+game dump and the GPU; everything upstream is verified on the CPU.

--- a/prosper/scripts/blasphemous2/README.md
+++ b/prosper/scripts/blasphemous2/README.md
@@ -52,6 +52,19 @@ manifest records the renderer policy and reports source and pixel progression
 separately. The #654 validation produced all 420 requested 1920x1080 PNGs, with
 315 pixel-distinct samples and moving full-screen gameplay through the final frame.
 
+For the routine renderer regression gate, run:
+
+```bash
+python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
+```
+
+That guard starts from an isolated fresh save, replays this route, and evaluates
+multiple changing frames only after the first-playable-room movement begins. It
+uses a coarse content threshold rather than exact hashes so subtle pixel changes
+do not fail the check. Any new or changed threshold must first be generated with
+`snapshot.py verify blasphemous2-gameplay` and accepted only after every retained
+image from both runs is inspected; see `tools/snapshot/README.md`.
+
 The title's optional `libfmodstudio.prx` and `libfmod.prx` must be prelinked as
 described by #638/#640. A run that stops before the first studio logo has not
 reached the #641 marker fix; a run that faults at guest `eboot+0x11f79d0` has not

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -16,6 +16,11 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
   roots on current master and reaches the controllable Jump tutorial. The
   route is wall-clock anchored because Dead Cells submits tens of thousands of
   loading flips before the menu.
+- `reach-first-gameplay-full-render.pad`: performs the same route with input
+  delayed until the title appears when every submit is rendered. Use this for
+  presented-image regression investigation; it does not depend on a renderer
+  warmup. WSL llvmpipe runs have not yet cleared Prisoners' Quarters loading
+  repeatably by 180 seconds, so the gameplay baseline remains pending.
 - `reach-first-gameplay-capture.pad`: uses the same menu input but holds Circle from
   28 through 300 seconds. Use it when synchronous timeline/bundle capture begins during
   level loading; the ordinary six-second hold can expire while capture stalls GPU progress.
@@ -25,7 +30,9 @@ skip temporal GPU producers. The former post-warmup fullscreen-white image was
 caused by that skip and is not normal renderer output (#586). For graphics
 investigation, add `PROSPER_RENDER_TARGET_DIM=642x362` to preserve the level's
 RTT chain; this is much slower and currently remains in the opening vignette at
-the 35-second checkpoint. Do not use the fast route as a visual golden guard.
+the 35-second checkpoint. Do not use the warmup-based fast route as a visual
+golden guard. The snapshot matrix uses the full-render route and requires
+inspected multi-frame evidence.
 
 ## Playable Semantic Checkpoints
 

--- a/prosper/scripts/dead-cells/reach-first-gameplay-full-render.pad
+++ b/prosper/scripts/dead-cells/reach-first-gameplay-full-render.pad
@@ -1,0 +1,10 @@
+# Dead Cells (PPSA15552): full-render fresh-save route to first gameplay.
+# Unlike reach-first-gameplay.pad, this does not depend on a renderer warmup making
+# guest startup run ahead. Full rendering can reduce pad polls below 1 Hz, so
+# every menu action is held across several polls with a release gap between it
+# and the next action. Circle remains held through the skippable opening.
+40-48:cross
+52-60:cross
+64-72:cross
+76-84:cross
+88-115:circle

--- a/prosper/tests/test_capture_manifest.cpp
+++ b/prosper/tests/test_capture_manifest.cpp
@@ -26,6 +26,11 @@ int main() {
           "same source identity is classified stale");
 
     auto c = b; c.source_seq = c.frame_seq = 11; c.pixel_crc32 = 0x87654321; c.elapsed_seconds = 4.0;
+    c.distinct_rgb_colors = 37;
+    c.nonblack_rgb_pixels = 101;
+    c.average_hash = 0x0123456789abcdef;
+    c.difference_hash = 0xfedcba9876543210;
+    c.luma16x9.fill(0x7f);
     pixels[0] = 0x22;
     auto cc = tracker.observe(c, pixels);
     CHECK(cc.source_advanced && !cc.pixel_identical && cc.stale_seconds == 0,
@@ -46,6 +51,37 @@ int main() {
     CHECK(line.find("@route\\nname") != std::string::npos, "manifest JSON escapes route text");
     CHECK(line.find("\"source\":\"composited\"") != std::string::npos,
           "manifest names the capture source");
+    CHECK(line.find("\"distinct_rgb_colors\":37") != std::string::npos,
+          "manifest records a coarse content metric for presented pixels");
+    CHECK(line.find("\"nonblack_rgb_pixels\":101") != std::string::npos,
+          "manifest records black-frame coverage");
+    CHECK(line.find("\"average_hash\":\"0123456789abcdef\"") != std::string::npos &&
+          line.find("\"difference_hash\":\"fedcba9876543210\"") != std::string::npos,
+          "manifest records tolerant perceptual fingerprints");
+    CHECK(line.find("\"luma16x9\":\"7f7f7f7f") != std::string::npos,
+          "manifest records a structural luminance signature");
+
+    std::vector<uint8_t> gradient(9 * 8 * 4, 255);
+    for (uint32_t y = 0; y < 8; ++y) for (uint32_t x = 0; x < 9; ++x) {
+        const size_t offset = (y * 9 + x) * 4;
+        gradient[offset] = gradient[offset + 1] = gradient[offset + 2] = static_cast<uint8_t>(x * 28);
+    }
+    const auto increasing = perceptual_hashes_rgba(gradient, 9, 8);
+    CHECK(increasing.difference == 0, "difference hash follows the standard left-greater-than-right rule");
+    for (uint32_t y = 0; y < 8; ++y) for (uint32_t x = 0; x < 9; ++x) {
+        const size_t offset = (y * 9 + x) * 4;
+        gradient[offset] = gradient[offset + 1] = gradient[offset + 2] = static_cast<uint8_t>((8 - x) * 28);
+    }
+    const auto decreasing = perceptual_hashes_rgba(gradient, 9, 8);
+    CHECK(decreasing.difference == UINT64_MAX,
+          "difference hash detects the opposite horizontal structure in all 64 cells");
+    const auto luma = perceptual_luma16x9_rgba(gradient, 9, 8);
+    CHECK(luma.size() == kPerceptualLumaCells && luma.front() > luma.back(),
+          "16x9 luminance signature preserves broad spatial structure");
+    for (size_t i = 3; i < gradient.size(); i += 4) gradient[i] = 0;
+    const auto transparent_luma = perceptual_luma16x9_rgba(gradient, 9, 8);
+    CHECK(transparent_luma.front() == 0 && transparent_luma.back() == 0,
+          "structural signature ignores invisible RGB beneath zero alpha");
     const std::string long_route(4096, 'x');
     const std::string long_line = manifest_sample_json(3, "long.png", c, cc, long_route);
     CHECK(long_line.size() > long_route.size() && long_line.find(long_route) != std::string::npos,

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -3,10 +3,12 @@
 Developer/agent tooling. These are debugging and verification aids, not part of
 the shipped runtime. Build them from `build-linux/` like everything else.
 
-- **`snapshot/`** — golden-image **rendering regression guard**. Run
-  `python3 tools/snapshot/snapshot.py check` before/after any change that can
-  affect rendered output (recompiler, AGC decode, render state, detile, present).
-  See `snapshot/AGENTS.md`. **Run this after touching the render path.**
+- **`snapshot/`** - routed, multi-frame **rendering regression guard**. Run
+  `python3 tools/snapshot/snapshot.py check` after any change that can affect
+  rendered output (recompiler, AGC decode, render state, detile, present). It
+  catches major scene collapse without treating subtle pixel changes as
+  regressions. New or changed baselines require two-run image inspection; see
+  `snapshot/AGENTS.md`. **Run this after touching the render path.**
 - **`boot_trace/`** — boots a SELF/ELF game image through the loader + HLE and
   runs it, with the fault handler, GPU executor, and (under `PROSPER_RENDER`) the
   live Vulkan renderer. The main harness for exercising a real title headlessly.

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -64,8 +64,12 @@ Only the game is required; everything else has a sane default.
 Directory-creation and PNG write failures include the failing path and operating-system error.
 
 Every normal run writes a JSONL manifest beside its PNGs. Each sample records the atomic present-source
-identity, guest flip count, rendered-frame sequence, dimensions, CRC32, capture source, elapsed time,
-input route, and whether the source advanced or was stale. A final summary records distinct-frame and
+identity, guest flip count, rendered-frame sequence, dimensions, CRC32, distinct RGB color count,
+non-black pixel count, a 16x9 luminance signature, and standard 64-bit average/difference hashes,
+capture source, elapsed time, input route, and whether the source advanced or was stale. The color
+count and signatures are computed from the visible presented RGBA result (including alpha) and support scene-collapse,
+coverage, and SSIM likeness guards without decoding the PNG again. The hashes and CRC32 remain useful
+diagnostics, but are not sufficient likeness oracles by themselves. A final summary records distinct-frame and
 maximum-stale metrics plus the exit status. Manifests flush after every sample so a killed run retains
 usable evidence. `--no-manifest` preserves the old PNG-only behavior.
 

--- a/prosper/tools/screenshot/capture_manifest.cpp
+++ b/prosper/tools/screenshot/capture_manifest.cpp
@@ -7,6 +7,71 @@
 
 namespace prosper::screenshot {
 
+namespace {
+uint8_t cell_luma(const std::vector<uint8_t>& pixels, uint32_t width, uint32_t height,
+                  uint32_t cell_x, uint32_t cell_y, uint32_t grid_width, uint32_t grid_height) {
+    const uint32_t x0 = cell_x * width / grid_width;
+    const uint32_t x1 = std::max(x0 + 1, (cell_x + 1) * width / grid_width);
+    const uint32_t y0 = cell_y * height / grid_height;
+    const uint32_t y1 = std::max(y0 + 1, (cell_y + 1) * height / grid_height);
+    uint64_t sum = 0;
+    uint64_t count = 0;
+    for (uint32_t y = y0; y < std::min(y1, height); ++y) {
+        for (uint32_t x = x0; x < std::min(x1, width); ++x) {
+            const size_t offset = (static_cast<size_t>(y) * width + x) * 4;
+            // Integer Rec. 601 luma after compositing the presented RGBA over black. Some
+            // renderer failures preserve stale RGB under zero alpha, which is not visible output.
+            const uint32_t luma = 299u * pixels[offset] + 587u * pixels[offset + 1] +
+                                  114u * pixels[offset + 2];
+            sum += (luma * pixels[offset + 3] + 127) / 255;
+            ++count;
+        }
+    }
+    return count ? static_cast<uint8_t>((sum / count + 500) / 1000) : 0;
+}
+} // namespace
+
+PerceptualHashes perceptual_hashes_rgba(const std::vector<uint8_t>& pixels,
+                                        uint32_t width, uint32_t height) {
+    PerceptualHashes result;
+    if (!width || !height || pixels.size() < static_cast<size_t>(width) * height * 4)
+        return result;
+
+    uint8_t average_cells[64]{};
+    uint32_t sum = 0;
+    for (uint32_t y = 0; y < 8; ++y) {
+        for (uint32_t x = 0; x < 8; ++x) {
+            const uint8_t value = cell_luma(pixels, width, height, x, y, 8, 8);
+            average_cells[y * 8 + x] = value;
+            sum += value;
+        }
+    }
+    const uint32_t mean = sum / 64;
+    for (uint32_t i = 0; i < 64; ++i)
+        if (average_cells[i] > mean) result.average |= uint64_t{1} << i;
+
+    for (uint32_t y = 0; y < 8; ++y) {
+        uint8_t row[9]{};
+        for (uint32_t x = 0; x < 9; ++x)
+            row[x] = cell_luma(pixels, width, height, x, y, 9, 8);
+        for (uint32_t x = 0; x < 8; ++x)
+            if (row[x] > row[x + 1]) result.difference |= uint64_t{1} << (y * 8 + x);
+    }
+    return result;
+}
+
+std::array<uint8_t, kPerceptualLumaCells>
+perceptual_luma16x9_rgba(const std::vector<uint8_t>& pixels,
+                         uint32_t width, uint32_t height) {
+    std::array<uint8_t, kPerceptualLumaCells> result{};
+    if (!width || !height || pixels.size() < static_cast<size_t>(width) * height * 4)
+        return result;
+    for (uint32_t y = 0; y < 9; ++y)
+        for (uint32_t x = 0; x < 16; ++x)
+            result[y * 16 + x] = cell_luma(pixels, width, height, x, y, 16, 9);
+    return result;
+}
+
 CaptureClassification CaptureTracker::observe(const CaptureObservation& observation,
                                                const std::vector<uint8_t>& pixels) {
     CaptureClassification result;
@@ -122,6 +187,15 @@ std::string manifest_sample_json(int index, const std::string& png_path,
          << ",\"width\":" << o.width << ",\"height\":" << o.height
          << ",\"pixel_crc32\":\"" << std::hex << std::setw(8) << std::setfill('0')
          << o.pixel_crc32 << std::dec << "\""
+         << ",\"distinct_rgb_colors\":" << o.distinct_rgb_colors
+         << ",\"nonblack_rgb_pixels\":" << o.nonblack_rgb_pixels
+         << ",\"average_hash\":\"" << std::hex << std::setw(16) << std::setfill('0')
+         << o.average_hash << "\""
+         << ",\"difference_hash\":\"" << std::setw(16) << o.difference_hash << "\""
+         << ",\"luma16x9\":\"";
+    for (const uint8_t value : o.luma16x9)
+        line << std::setw(2) << static_cast<unsigned>(value);
+    line << std::dec << "\""
          << ",\"source_advanced\":" << (c.source_advanced ? "true" : "false")
          << ",\"pixel_identical\":" << (c.pixel_identical ? "true" : "false")
          << ",\"stale_seconds\":" << std::fixed << std::setprecision(6) << c.stale_seconds

--- a/prosper/tools/screenshot/capture_manifest.hpp
+++ b/prosper/tools/screenshot/capture_manifest.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
 
 namespace prosper::screenshot {
+
+constexpr size_t kPerceptualLumaCells = 16 * 9;
 
 enum class CaptureSource : uint8_t { Rendered, RawScanout };
 
@@ -18,7 +22,28 @@ struct CaptureObservation {
     uint32_t height = 0;
     uint32_t pixel_crc32 = 0;
     double elapsed_seconds = 0;
+    uint32_t distinct_rgb_colors = 0;
+    uint64_t nonblack_rgb_pixels = 0;
+    uint64_t average_hash = 0;
+    uint64_t difference_hash = 0;
+    std::array<uint8_t, kPerceptualLumaCells> luma16x9{};
 };
+
+struct PerceptualHashes {
+    uint64_t average = 0;
+    uint64_t difference = 0;
+};
+
+// Standard 8x8 average hash plus 9x8 horizontal difference hash. These intentionally discard
+// fine pixel detail so small raster changes remain close while missing layers alter the signature.
+PerceptualHashes perceptual_hashes_rgba(const std::vector<uint8_t>& pixels,
+                                        uint32_t width, uint32_t height);
+
+// A small spatial luminance signature suitable for SSIM comparisons. Unlike aHash/dHash,
+// it preserves the magnitude and location of large missing layers.
+std::array<uint8_t, kPerceptualLumaCells>
+perceptual_luma16x9_rgba(const std::vector<uint8_t>& pixels,
+                         uint32_t width, uint32_t height);
 
 struct CaptureClassification {
     bool source_advanced = true;

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -50,6 +50,7 @@
 #include <sstream>
 #include <string>
 #include <system_error>
+#include <unordered_set>
 #include <vector>
 #include <thread>
 #include <chrono>
@@ -58,6 +59,27 @@
 using namespace prosper;
 
 namespace {
+
+struct PixelContentMetrics {
+    uint32_t distinct_colors = 0;
+    uint64_t nonblack_pixels = 0;
+};
+
+PixelContentMetrics measure_pixel_content(const std::vector<uint8_t>& rgba) {
+    std::unordered_set<uint32_t> colors;
+    colors.reserve(std::min<size_t>(rgba.size() / 4, 65536));
+    uint64_t nonblack = 0;
+    for (size_t i = 0; i + 3 < rgba.size(); i += 4) {
+        const uint32_t alpha = rgba[i + 3];
+        const uint32_t red = (static_cast<uint32_t>(rgba[i]) * alpha + 127) / 255;
+        const uint32_t green = (static_cast<uint32_t>(rgba[i + 1]) * alpha + 127) / 255;
+        const uint32_t blue = (static_cast<uint32_t>(rgba[i + 2]) * alpha + 127) / 255;
+        const uint32_t rgb = (red << 16) | (green << 8) | blue;
+        colors.insert(rgb);
+        nonblack += rgb != 0;
+    }
+    return {static_cast<uint32_t>(colors.size()), nonblack};
+}
 
 bool set_environment(const char* name, const char* value, bool overwrite) {
     if (!overwrite && getenv(name)) return true;
@@ -553,6 +575,15 @@ int main(int argc, char** argv) {
                         observation.height = snap.height;
                         observation.pixel_crc32 = pixel_crc;
                         observation.elapsed_seconds = el;
+                        const auto content = measure_pixel_content(snap.rgba);
+                        observation.distinct_rgb_colors = content.distinct_colors;
+                        observation.nonblack_rgb_pixels = content.nonblack_pixels;
+                        const auto perceptual = screenshot::perceptual_hashes_rgba(
+                            snap.rgba, snap.width, snap.height);
+                        observation.average_hash = perceptual.average;
+                        observation.difference_hash = perceptual.difference;
+                        observation.luma16x9 = screenshot::perceptual_luma16x9_rgba(
+                            snap.rgba, snap.width, snap.height);
                         const auto classification = tracker.observe(observation, snap.rgba);
                         required_crc32_seen |= required_crc32_set && pixel_crc == required_crc32;
                         fprintf(stderr, "[shot] %d/%d  %s  (frame %llu, %.1fs%s, crc=%08x)\n",

--- a/prosper/tools/snapshot/.gitignore
+++ b/prosper/tools/snapshot/.gitignore
@@ -1,4 +1,6 @@
 failures/
+review/
 *.bmp
 *.png
 snap_*/
+__pycache__/

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -1,59 +1,58 @@
 # AGENTS.md - rendering snapshot tests
 
-Real-game rendering regression guard. Run this whenever a change can affect
-rendered output: RDNA2-to-SPIR-V recompilation, AGC/PM4 decoding, render state,
-texture detiling, or executor/present behavior.
-
-The Messenger and Dead Cells guards record the richest frame's distinct-color
-count across their configured windows. Both titles have threaded/timing-sensitive
-boots whose exact rendered frame is not a stable contract.
-
-## Run It
+This is the required local real-game rendering gate. Run the affected title
+guards after any change that can affect output: RDNA2-to-SPIR-V recompilation,
+AGC/PM4 decoding, render state, texture decode/detiling, executor behavior, or
+presentation.
 
 ```bash
-# From prosper/, with build-linux/boot_trace built for the change.
+# From prosper/, with build-linux/boot_trace built from the change.
 python3 tools/snapshot/snapshot.py check
 python3 tools/snapshot/snapshot.py check messenger-scene
 python3 tools/snapshot/snapshot.py check dead-cells-splash
+python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 ```
 
-On failure, the screenshot and boot log are written to
-`tools/snapshot/failures/<name>.{bmp,log}`. Convert a BMP for inspection with:
+## Contract
 
-```bash
-python3 -c 'from PIL import Image; Image.open("x.bmp").save("x.png")'
-```
+- Local only. Game dumps and captured imagery must never be committed.
+- Gameplay guards are deliberately coarse. Subtle pixel changes may be valid or
+  improvements; use tolerant average/difference hashes to detect major collapse,
+  missing layers, lost progression, and wrong dimensions without freezing every pixel.
+- A content guard examines all frames in a gameplay-only evidence window and
+  requires multiple qualifying frames. Do not treat one richest frame, a logo,
+  a menu, or a static screen as proof of gameplay.
+- `check` is fully automated. On failure, inspect the representative PNGs and
+  log under `tools/snapshot/failures/` before changing code or thresholds.
+- Do not lower a threshold merely to pass. Explain intentional contract changes
+  and repeat the baseline-review workflow below.
 
-## Non-Negotiables
+## New Or Changed Baselines
 
-- Local only, never CI. Game dumps and captured imagery must not be committed.
-- Only thresholds or pixel hashes live in `snapshots.json`.
-- Do not lower `min_colors` merely to make a failing check pass. Investigate the
-  regression, or explain an intentional baseline change in the PR.
+Baseline evidence requires visual review even though routine regression runs do
+not. This prevents checksums or thresholds from blessing black output or the
+wrong scene.
 
-## Guard Modes
+1. Set `review` to `pending` and run `snapshot.py verify NAME`.
+2. Inspect every image retained from both independent runs in
+   `tools/snapshot/review/NAME/`. Confirm the intended gameplay state, expected
+   layers, and progression across multiple timestamps.
+   Use the adjacent `runN-evidence.json` when a bad frame needs correlation
+   with its flip count, front-buffer index, or renderer publication.
+3. For content mode, choose a conservative `min_colors`, require at least two
+   qualifying frames, and add `min_pixel_changes` for moving routes.
+4. Run `snapshot.py update NAME --reviewed` only after every image is accepted.
+   Content mode records reviewed luminance references for SSIM plus a
+   conservative non-black coverage floor; exact mode records the identical
+   pixel hash. Never use exact hashes for threaded gameplay merely because one
+   run happened to be stable.
+5. Run `snapshot.py check NAME` after approval.
 
-- `min_colors`: run the full configured timeout, inspect every dumped frame,
-  and require the richest frame to meet the threshold. `messenger-scene` uses
-  this because exact frame hashes are not stable across threaded boots. The
-  Dead Cells splash uses the same mode because one unchanged build selects
-  multiple valid static/animated splash hashes after its renderer warmup. Use
-  `verify <name>` to require two full runs to meet the threshold at equal
-  dimensions.
-- `frame` plus `hash`: target one draw-submit frame. Use `verify <name>` before
-  trusting a new exact baseline, then `update <name>` after an intentional pixel
-  change.
-
-`RENDER_SCALE` shrinks the framebuffer. Keep `scale` fixed for either mode.
-
-## Adding A Snapshot
-
-Add `name`, `dump`, `scale`, `timeout`, optional `env`, and either:
-
-- a justified `min_colors` threshold for a run-level content guard; or
-- `frame` plus an exact `hash`, established with `verify` then `update`.
+See `README.md` for every manifest field and the current title matrix.
 
 ## Environment
 
 - `PROSPER_GAME_ROOT`: directory holding `*-app0` dumps; defaults to the repo.
-- `PROSPER_BOOT_TRACE`: boot_trace path; defaults to `build-linux/boot_trace`.
+- `PROSPER_BOOT_TRACE`: `boot_trace` path; defaults to `build-linux/boot_trace`.
+- `PROSPER_SCREENSHOT`: presented-capture frontend; defaults to
+  `build-linux/screenshot`.

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -1,49 +1,125 @@
 # Rendering Regression Snapshots
 
-This local tool catches real-game rendering regressions. A snapshot can use an
-exact frame hash, or a run-level content metric for titles whose threaded boots
-do not land on a deterministic frame.
+This local tool boots real game dumps and catches major rendering failures. It is
+deliberately not a pixel-perfection gate for timing-sensitive gameplay: small
+pixel differences may be valid or improved output. Content guards instead check
+several frames from a routed gameplay window for scene richness, structural
+likeness to reviewed references, stable dimensions, non-black coverage, and optional visible progression.
 
-Game dumps and screenshots are local and gitignored, so this does not run in
-CI. Only hashes or content thresholds live in `snapshots.json`.
+Game dumps and captured images are local and gitignored, so this cannot run in
+CI. Only reviewed 16x9 luminance signatures, diagnostic hashes, coarse content
+thresholds, routes, and review notes live in `snapshots.json`.
 
 ## Run
 
+Build `build-linux/boot_trace`, then run from `prosper/`:
+
 ```bash
-# From prosper/, after building build-linux/boot_trace.
+# Run the whole real-game matrix, or one affected title.
 python3 tools/snapshot/snapshot.py check
 python3 tools/snapshot/snapshot.py check messenger-scene
-python3 tools/snapshot/snapshot.py check dead-cells-splash
+python3 tools/snapshot/snapshot.py check dead-cells-gameplay
+python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 ```
 
-On failure, `check` writes the screenshot and boot log to
-`tools/snapshot/failures/<name>.{bmp,log}` and exits nonzero.
+Run the relevant checks after changes to shader recompilation, AGC/PM4 decode,
+render state, texture decode/detiling, executor behavior, or presentation.
+`check` is automated and nonzero on failure. A content failure retains several
+representative presented PNGs, the boot log, and structured per-frame evidence
+in `tools/snapshot/failures/`.
 
 ## Guard Modes
 
-- `min_colors`: run for the configured timeout and require the richest rendered
-  frame to reach a distinct-color threshold. `verify <name>` repeats the full
-  capture and requires both runs to meet the threshold at the same dimensions.
-- `frame` plus `hash`: compare one targeted draw-submit frame exactly. Run
-  `verify <name>` before establishing its baseline with `update <name>`.
+### Routed content guard
+
+This is the default for gameplay and other timing-sensitive scenes. A manifest
+entry can define:
+
+- `pad_script`: input route relative to `prosper/`.
+- `savedata_policy`: `fresh` for an isolated temporary save, or `preserve`.
+- `capture_after_seconds` / `capture_before_seconds`: evidence window. Put this
+  after the route reaches the state being protected; logos and menus are not
+  gameplay evidence.
+- `min_colors`: coarse per-frame richness floor.
+- `min_qualifying_frames`: number of frames that must meet that floor; defaults
+  to two, so one lucky frame cannot pass the guard.
+- `min_pixel_changes`: required changes between consecutive captured frames.
+  Use this when movement or animation is part of the route.
+- `structural_references`: 16x9 luminance signatures generated only from
+  visually approved evidence. Average/difference hashes are retained beside
+  them for diagnostics, but do not decide pass/fail.
+- `min_structural_similarity`: minimum SSIM against the closest reviewed
+  signature; `0.85` is the conservative default. SSIM preserves broad spatial
+  structure while ignoring exact raster detail.
+- `min_structural_matches`: number of current frames that must resemble a
+  reviewed reference.
+- `min_content_match_ratio`: fraction of all evidence-window frames that must
+  meet both structural and non-black contracts; defaults to `0.75`. This keeps
+  a few good frames from hiding an intermittently broken renderer.
+- `min_nonblack_ratio`: conservative coverage floor generated during baseline
+  approval at half the lowest reviewed coverage. It rejects blank output
+  without requiring a normally dark game to be bright.
+- `min_nonblack_matches`: number of frames that must meet that coverage floor;
+  defaults to `min_qualifying_frames`.
+- `dims`: expected scaled framebuffer dimensions.
+- `review`: factual record of the evidence that a person inspected when the
+  guard was introduced or materially changed.
+
+The checker measures every complete frame in the evidence window. It does not
+compare exact pixels. It computes the established Structural Similarity Index
+(SSIM) over a downsampled luminance grid, so it tolerates subtle raster changes
+while still detecting black output, missing scene layers that alter broad
+layout, a route that no longer progresses, or wrong framebuffer dimensions.
+CRC32 and perceptual hashes identify samples for diagnostics but are not the
+content guard's pass/fail oracle.
+
+### Exact frame guard
+
+An entry with `frame` and `hash` compares one targeted draw-submit frame. Use
+this only when two independent captures prove that the frame is deterministic.
+Exact mode is appropriate for stable synthetic or static checkpoints, not
+threaded gameplay.
+
+## Baseline Review Is Mandatory
+
+A checksum or color threshold is not trustworthy merely because it passes. A
+logo, menu, or detailed error screen can have many colors; an exact hash can
+faithfully preserve a black frame. Every new or changed baseline must be tied to
+inspected image evidence:
+
+1. Add or change the candidate entry with `"review": "pending"`.
+2. Run `python3 tools/snapshot/snapshot.py verify NAME`. It performs two
+   independent full captures and retains eight temporally spread images per run under
+   `tools/snapshot/review/NAME/`. Each run also retains an evidence JSON file
+   with every sample's flip count, renderer sequence, front-buffer index, CRC,
+   coverage, and structural signature.
+3. Inspect every retained image from both runs. Confirm the intended scene,
+   expected world layers/HUD/player, and progression across multiple moments.
+4. For a content guard, confirm the threshold has a conservative margin below
+   the observed valid range. Never lower a threshold just to make a failure pass.
+5. After inspecting every image, run
+   `python3 tools/snapshot/snapshot.py update NAME --reviewed`. Content mode
+   records the reviewed structural references and a conservative non-black
+   floor; exact mode records the verified pixel hash. `update` refuses stale,
+   incomplete, or unverified candidates.
+6. Run `check NAME` once more. Commit only the manifest and route, never the
+   local review/failure images or game data.
+
+Repeat this review when the route, evidence window, expected scene, dimensions,
+hash, or threshold changes materially. Ordinary `check` runs need no manual
+inspection unless they fail.
 
 ## Current Matrix
 
-- `messenger-scene`: run-level content guard because the threaded boot does not
-  choose a stable exact frame.
-- `dead-cells-splash`: run-level content guard after a three-second renderer
-  warmup. The warmup advances the submit-heavy startup without synchronous
-  llvmpipe rendering; the richest startup frame must contain at least 1,500
-  colors. Exact hashes are intentionally not used because an unchanged build
-  selects multiple valid splash animation states at 960x540.
-
-## Adding A Snapshot
-
-Add an entry to `snapshots.json` with `name`, `dump`, `scale`, `timeout`, optional
-per-title `env`, and either a justified `min_colors` threshold or a verified
-`frame`/`hash` baseline.
+- `messenger-scene`: broad content guard for a timing-sensitive rendered scene.
+- `dead-cells-gameplay`: provisional full-render route toward the controllable
+  Jump tutorial. Baseline approval is blocked on repeatably clearing level loading.
+- `blasphemous2-gameplay`: native-resolution fresh-save routed guard for
+  multiple moving frames in the first playable room.
 
 ## Environment
 
 - `PROSPER_GAME_ROOT`: directory holding `*-app0` dumps; defaults to the repo.
-- `PROSPER_BOOT_TRACE`: boot_trace path; defaults to `build-linux/boot_trace`.
+- `PROSPER_BOOT_TRACE`: `boot_trace` path; defaults to `build-linux/boot_trace`.
+- `PROSPER_SCREENSHOT`: presented-capture frontend; defaults to
+  `build-linux/screenshot`.

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -1,37 +1,41 @@
 #!/usr/bin/env python3
 """Local snapshot tester for prosper's game rendering.
 
-Runs a game through boot_trace and checks either an exact rendered-frame hash or
-a run-level content threshold. On a mismatch it saves the offending screenshot
+Runs a game through the presented-screenshot frontend for content guards, or
+through boot_trace for a targeted exact rendered-frame hash. On a mismatch it saves the evidence
 and exits non-zero — snapshot testing for the renderer, so
 any agent can catch a rendering regression (e.g. a recompiler change that blanks
 a title) before it ships.
 
 The game dumps are NOT in the repo (gitignored) and MUST NOT be committed, so
-this runs LOCALLY, never in CI. Only the small pixel HASHES live in the repo
-(snapshots.json) — a hash is a checksum, not game imagery.
+this runs LOCALLY, never in CI. Only small structural luminance signatures and
+diagnostic hashes live in the repo (snapshots.json), never game imagery.
 
 Usage:
   snapshot.py check  [name ...]   # compare captures to baselines; exit 1 on any diff/error
-  snapshot.py update [name ...]   # (re)capture and store/overwrite baseline hashes
-  snapshot.py verify [name ...]   # capture twice each; report whether the frame is deterministic
+  snapshot.py verify [name ...]   # capture twice and retain multiple local review images
+  snapshot.py update NAME --reviewed  # approve an inspected exact-hash candidate
   snapshot.py list
 
 Env overrides:
   PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: /mnt/c/Users/matti/repos/ps5ys)
   PROSPER_BOOT_TRACE  path to the boot_trace binary    (default: <prosper>/build-linux/boot_trace)
+  PROSPER_SCREENSHOT  path to the screenshot binary    (default: <prosper>/build-linux/screenshot)
 
 Exact mode targets a frame with RENDER_EVERY=1 plus `frame`=F, so frame_<F>.bmp
 is the F-th draw submit's render. Pick F in a stable-content window and use
-`verify` before trusting a baseline. Content mode uses `min_colors` and checks the
-richest frame over the complete configured window when threaded timing makes no
-single frame a stable contract.
+`verify` before trusting a baseline. Content mode can restrict evidence to a gameplay-only time
+window of normal composited screenshots, requires multiple frames to meet `min_colors`, and can
+require visible pixel changes. Its pass/fail contract uses SSIM and content coverage to catch major
+collapse without rejecting subtle pixel improvements.
 """
-import sys, os, json, time, hashlib, struct, subprocess, tempfile, shutil, signal
+import sys, os, json, time, hashlib, math, struct, subprocess, tempfile, shutil, signal
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+PROSPER_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
 MANIFEST = os.path.join(HERE, "snapshots.json")
 FAIL_DIR = os.path.join(HERE, "failures")
+REVIEW_DIR = os.path.join(HERE, "review")
 GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT", "/mnt/c/Users/matti/repos/ps5ys")
 
 
@@ -41,6 +45,13 @@ def boot_trace_path():
         return p
     # <prosper>/tools/snapshot/ -> <prosper>/build-linux/boot_trace
     return os.path.normpath(os.path.join(HERE, "..", "..", "build-linux", "boot_trace"))
+
+
+def screenshot_path():
+    p = os.environ.get("PROSPER_SCREENSHOT")
+    if p:
+        return p
+    return os.path.normpath(os.path.join(HERE, "..", "..", "build-linux", "screenshot"))
 
 
 def load_manifest():
@@ -94,6 +105,356 @@ def resolve_dump(entry):
     return dump if os.path.isabs(dump) else os.path.join(GAME_ROOT, dump)
 
 
+def apply_entry_env(env, entry, tmp):
+    """Apply route/save policy after generic renderer defaults.
+
+    Routes are manifest data rather than shell working-directory assumptions. A fresh save lives in
+    the capture temp directory and disappears with the run, so two verification runs start from the
+    same console state without touching a developer's normal save.
+    """
+    env.update(entry.get("env", {}))
+    route = entry.get("pad_script")
+    if route:
+        route = route if os.path.isabs(route) else os.path.join(PROSPER_ROOT, route)
+        if not os.path.isfile(route):
+            raise RuntimeError(f"pad script not found: {route}")
+        env["PROSPER_PAD_SCRIPT"] = "@" + route
+        env.setdefault("PROSPER_PAD_SCRIPT_LOG", "1")
+    save_policy = entry.get("savedata_policy")
+    if save_policy == "fresh":
+        save_dir = os.path.join(tmp, "savedata")
+        os.makedirs(save_dir, exist_ok=True)
+        env["PROSPER_SAVEDATA_DIR"] = save_dir
+    elif save_policy not in (None, "preserve"):
+        raise RuntimeError(f"unknown savedata_policy={save_policy!r}; use fresh or preserve")
+
+
+def decode_luma16x9(value):
+    """Decode the screenshot manifest's fixed 16x9 8-bit luminance signature."""
+    if not isinstance(value, str) or len(value) != 16 * 9 * 2:
+        raise ValueError("luma16x9 must be 288 hexadecimal characters")
+    try:
+        return tuple(bytes.fromhex(value))
+    except ValueError as exc:
+        raise ValueError("luma16x9 is not valid hexadecimal") from exc
+
+
+def structural_similarity(left, right):
+    """Return the SSIM index for two equally sized luminance signatures.
+
+    This is the standard SSIM luminance/contrast/structure equation over a fixed spatial thumbnail.
+    It preserves large layer placement while deliberately discarding exact raster detail.
+    """
+    if len(left) != len(right) or not left:
+        raise ValueError("SSIM inputs must have the same non-zero length")
+    count = len(left)
+    mean_left = sum(left) / count
+    mean_right = sum(right) / count
+    variance_left = sum((value - mean_left) ** 2 for value in left) / count
+    variance_right = sum((value - mean_right) ** 2 for value in right) / count
+    covariance = sum((a - mean_left) * (b - mean_right)
+                     for a, b in zip(left, right)) / count
+    c1 = (0.01 * 255) ** 2
+    c2 = (0.03 * 255) ** 2
+    denominator = ((mean_left ** 2 + mean_right ** 2 + c1) *
+                   (variance_left + variance_right + c2))
+    if denominator == 0:
+        return 1.0
+    return max(-1.0, min(1.0,
+        ((2 * mean_left * mean_right + c1) * (2 * covariance + c2)) / denominator))
+
+
+def analyze_content_manifest(tmp, entry):
+    """Measure presented screenshots in the configured evidence window."""
+    after = float(entry.get("capture_after_seconds", 0))
+    before = entry.get("capture_before_seconds")
+    before = float(before) if before is not None else None
+    manifest = os.path.join(tmp, "capture.jsonl")
+    if not os.path.isfile(manifest):
+        raise RuntimeError("screenshot frontend did not write capture.jsonl")
+    events = []
+    with open(manifest) as f:
+        for number, line in enumerate(f, 1):
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(f"invalid screenshot manifest line {number}: {exc}") from exc
+    final = next((e for e in reversed(events) if e.get("type") == "summary"), None)
+    if not final or final.get("exit_code") != 0 or final.get("saved") != final.get("requested"):
+        raise RuntimeError(f"screenshot run did not complete successfully: {final or 'no summary'}")
+
+    required_source = entry.get("capture_source", "composited")
+    records = []
+    for sample in (e for e in events if e.get("type") == "sample"):
+        elapsed = float(sample.get("elapsed_seconds", -1))
+        if elapsed < after or (before is not None and elapsed > before):
+            continue
+        if required_source and sample.get("source") != required_source:
+            continue
+        if "distinct_rgb_colors" not in sample:
+            raise RuntimeError("screenshot manifest lacks distinct_rgb_colors; rebuild the screenshot tool")
+        required_metrics = ("luma16x9", "nonblack_rgb_pixels", "average_hash", "difference_hash")
+        if any(metric not in sample for metric in required_metrics):
+            raise RuntimeError("screenshot manifest lacks structural metrics; rebuild the screenshot tool")
+        path = sample.get("png", "")
+        if not os.path.isabs(path):
+            path = os.path.join(tmp, path)
+        if not os.path.isfile(path) or os.path.getsize(path) <= 0:
+            raise RuntimeError(f"manifest screenshot is missing or empty: {path}")
+        dims = (int(sample["width"]), int(sample["height"]))
+        if dims[0] <= 0 or dims[1] <= 0:
+            raise RuntimeError(f"manifest screenshot has invalid dimensions: {dims}")
+        records.append({
+            "index": int(sample.get("index", len(records))),
+            "path": path, "filename": os.path.basename(path), "elapsed": elapsed,
+            "colors": int(sample["distinct_rgb_colors"]), "dims": dims,
+            "hash": str(sample["pixel_crc32"]), "source": sample.get("source"),
+            "source_seq": int(sample.get("source_seq", 0)),
+            "frame_seq": int(sample.get("frame_seq", 0)),
+            "present_count": int(sample.get("present_count", 0)),
+            "front_index": int(sample.get("front_index", -1)),
+            "average_hash": int(sample["average_hash"], 16),
+            "difference_hash": int(sample["difference_hash"], 16),
+            "luma16x9": decode_luma16x9(sample["luma16x9"]),
+            "nonblack_ratio": int(sample["nonblack_rgb_pixels"]) / (dims[0] * dims[1]),
+            "best_structural_similarity": None,
+        })
+    if not records:
+        window = f"after {after:g}s" + (f" and before {before:g}s" if before is not None else "")
+        raise RuntimeError(f"no {required_source or 'presented'} screenshots in evidence window ({window})")
+
+    threshold = int(entry["min_colors"])
+    qualifying = [r for r in records if r["colors"] >= threshold]
+    pixel_changes = sum(a["hash"] != b["hash"] for a, b in zip(records, records[1:]))
+    richest = max(records, key=lambda r: r["colors"])
+    dims = {r["dims"] for r in records}
+    references = entry.get("structural_references", [])
+    similarities = []
+    if references:
+        parsed = [decode_luma16x9(reference["luma16x9"]) for reference in references]
+        for record in records:
+            similarity = max(structural_similarity(record["luma16x9"], reference)
+                             for reference in parsed)
+            record["best_structural_similarity"] = similarity
+            similarities.append(similarity)
+    minimum_similarity = float(entry.get("min_structural_similarity", 0.85))
+    minimum_coverage = float(entry.get("min_nonblack_ratio", 0))
+    return {
+        "records": records,
+        "qualifying": qualifying,
+        "richest": richest,
+        "dims": richest["dims"],
+        "dimensions_consistent": len(dims) == 1,
+        "pixel_changes": pixel_changes,
+        "structural_similarities": similarities,
+        "structural_matches": sum(value >= minimum_similarity for value in similarities),
+        "nonblack_matches": sum(record["nonblack_ratio"] >= minimum_coverage
+                                for record in records),
+    }
+
+
+def choose_review_records(summary, count=8):
+    """Choose temporally spread window evidence, always including the richest frame."""
+    pool = summary["records"]
+    count = max(2, int(count))
+    if len(pool) <= count:
+        return pool
+    indices = {0, len(pool) - 1}
+    for i in range(1, count - 1):
+        indices.add(round(i * (len(pool) - 1) / (count - 1)))
+    richest = summary["richest"]
+    selected = [pool[i] for i in sorted(indices)]
+    if richest not in selected:
+        selected[-2 if len(selected) > 1 else 0] = richest
+    return sorted({r["path"]: r for r in selected}.values(), key=lambda r: r["elapsed"])
+
+
+def content_result(entry, summary, include_structural=True):
+    required_frames = int(entry.get("min_qualifying_frames", 2))
+    required_changes = int(entry.get("min_pixel_changes", 0))
+    match_ratio = float(entry.get("min_content_match_ratio", 0.75))
+    expected_dims = tuple(entry["dims"]) if entry.get("dims") else None
+    failures = []
+    if not 0 <= match_ratio <= 1:
+        failures.append(f"min_content_match_ratio {match_ratio} is outside [0, 1]")
+    if len(summary["qualifying"]) < required_frames:
+        failures.append(f"qualifying frames {len(summary['qualifying'])} < {required_frames}")
+    if summary["pixel_changes"] < required_changes:
+        failures.append(f"pixel changes {summary['pixel_changes']} < {required_changes}")
+    if not summary["dimensions_consistent"]:
+        failures.append("frame dimensions changed within evidence window")
+    if expected_dims and summary["dims"] != expected_dims:
+        failures.append(f"dimensions {summary['dims']} != {expected_dims}")
+    references = entry.get("structural_references", [])
+    if include_structural and references:
+        required_matches = max(int(entry.get("min_structural_matches", required_frames)),
+                               math.ceil(len(summary["records"]) * match_ratio))
+        if summary["structural_matches"] < required_matches:
+            failures.append(
+                f"structural matches {summary['structural_matches']} < {required_matches} "
+                f"(minimum SSIM {entry.get('min_structural_similarity', 0.85)})")
+    if entry.get("min_nonblack_ratio") is not None:
+        required_nonblack = max(int(entry.get("min_nonblack_matches", required_frames)),
+                                math.ceil(len(summary["records"]) * match_ratio))
+        if summary["nonblack_matches"] < required_nonblack:
+            failures.append(
+                f"non-black coverage matches {summary['nonblack_matches']} < {required_nonblack} "
+                f"(minimum ratio {entry['min_nonblack_ratio']})")
+    return not failures, failures
+
+
+def save_content_evidence(name, run_number, summary):
+    out_dir = os.path.join(REVIEW_DIR, name)
+    os.makedirs(out_dir, exist_ok=True)
+    saved = []
+    selected = choose_review_records(summary)
+    review_names = {}
+    for index, record in enumerate(selected):
+        stem, extension = os.path.splitext(record["filename"])
+        leaf = f"run{run_number}_{index:02d}_{stem}_{record['colors']}colors{extension}"
+        dst = os.path.join(out_dir, leaf)
+        shutil.copyfile(record["path"], dst)
+        saved.append(dst)
+        review_names[record["path"]] = leaf
+    save_content_metadata(os.path.join(out_dir, f"run{run_number}-evidence.json"),
+                          summary, review_names)
+    return saved
+
+
+def save_content_metadata(path, summary, review_names=None):
+    """Persist enough presentation identity to investigate every retained or rejected frame."""
+    review_names = review_names or {}
+    records = []
+    for record in summary["records"]:
+        records.append({
+            "index": record["index"], "elapsed_seconds": record["elapsed"],
+            "source": record["source"], "source_seq": record["source_seq"],
+            "frame_seq": record["frame_seq"], "present_count": record["present_count"],
+            "front_index": record["front_index"], "width": record["dims"][0],
+            "height": record["dims"][1], "pixel_crc32": record["hash"],
+            "distinct_rgb_colors": record["colors"],
+            "nonblack_ratio": round(record["nonblack_ratio"], 8),
+            "average_hash": f"{record['average_hash']:016x}",
+            "difference_hash": f"{record['difference_hash']:016x}",
+            "luma16x9": bytes(record["luma16x9"]).hex(),
+            "best_structural_similarity": record["best_structural_similarity"],
+            "review_png": review_names.get(record["path"]),
+        })
+    with open(path, "w") as f:
+        json.dump({
+            "schema": 1, "records": records,
+            "qualifying_frames": len(summary["qualifying"]),
+            "pixel_changes": summary["pixel_changes"],
+        }, f, indent=2)
+        f.write("\n")
+
+
+def reset_review_evidence(name):
+    out_dir = os.path.join(REVIEW_DIR, name)
+    shutil.rmtree(out_dir, ignore_errors=True)
+    os.makedirs(out_dir, exist_ok=True)
+    return out_dir
+
+
+def entry_fingerprint(entry):
+    stable = {k: v for k, v in entry.items()
+              if k not in ("hash", "dims", "review", "structural_references",
+                           "perceptual_references", "min_nonblack_ratio")}
+    raw = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def save_exact_candidate(entry, first, second, pixel_digest, dims):
+    out_dir = reset_review_evidence(entry["name"])
+    first_out = os.path.join(out_dir, "run1.bmp")
+    second_out = os.path.join(out_dir, "run2.bmp")
+    shutil.copyfile(first, first_out)
+    shutil.copyfile(second, second_out)
+    candidate = {
+        "mode": "exact", "name": entry["name"], "hash": pixel_digest, "dims": list(dims),
+        "entry_fingerprint": entry_fingerprint(entry),
+    }
+    with open(os.path.join(out_dir, "candidate.json"), "w") as f:
+        json.dump(candidate, f, indent=2)
+        f.write("\n")
+    return first_out, second_out
+
+
+def approve_exact_candidate(entry):
+    path = os.path.join(REVIEW_DIR, entry["name"], "candidate.json")
+    if not os.path.isfile(path):
+        raise RuntimeError(f"no reviewed candidate at {path}; run verify first")
+    with open(path) as f:
+        candidate = json.load(f)
+    if candidate.get("mode") != "exact":
+        raise RuntimeError("review candidate is not an exact-frame capture")
+    if candidate.get("entry_fingerprint") != entry_fingerprint(entry):
+        raise RuntimeError("snapshot configuration changed after verify; regenerate review evidence")
+    entry["hash"] = candidate["hash"]
+    entry["dims"] = candidate["dims"]
+    entry["review"] = (f"Pixel evidence approved with snapshot.py update --reviewed on "
+                       f"{time.strftime('%Y-%m-%d')}")
+
+
+def save_content_candidate(entry, summaries):
+    out_dir = os.path.join(REVIEW_DIR, entry["name"])
+    records = []
+    for summary in summaries:
+        records.extend(choose_review_records(summary))
+    references = []
+    seen = set()
+    for record in records:
+        signature = bytes(record["luma16x9"]).hex()
+        if signature in seen:
+            continue
+        seen.add(signature)
+        references.append({
+            "luma16x9": signature,
+            "average_hash": f"{record['average_hash']:016x}",
+            "difference_hash": f"{record['difference_hash']:016x}",
+        })
+    minimum_reviewed_coverage = min(record["nonblack_ratio"] for record in records)
+    candidate = {
+        "mode": "content", "name": entry["name"],
+        "structural_references": references,
+        "suggested_min_nonblack_ratio": round(minimum_reviewed_coverage * 0.5, 6),
+        "evidence_count": len(records),
+        "evidence_files": sorted(
+            filename for filename in os.listdir(out_dir)
+            if filename.startswith("run") and filename.lower().endswith((".png", ".bmp"))),
+        "dims": list(summaries[0]["dims"]),
+        "entry_fingerprint": entry_fingerprint(entry),
+    }
+    with open(os.path.join(out_dir, "candidate.json"), "w") as f:
+        json.dump(candidate, f, indent=2)
+        f.write("\n")
+
+
+def approve_content_candidate(entry):
+    path = os.path.join(REVIEW_DIR, entry["name"], "candidate.json")
+    if not os.path.isfile(path):
+        raise RuntimeError(f"no reviewed candidate at {path}; run verify first")
+    with open(path) as f:
+        candidate = json.load(f)
+    if candidate.get("mode") != "content":
+        raise RuntimeError("review candidate is not a content capture")
+    if candidate.get("entry_fingerprint") != entry_fingerprint(entry):
+        raise RuntimeError("snapshot configuration changed after verify; regenerate review evidence")
+    if candidate.get("evidence_count", 0) < 4 or not candidate.get("structural_references"):
+        raise RuntimeError("candidate does not contain enough multi-frame review evidence")
+    evidence_files = candidate.get("evidence_files", [])
+    if len(evidence_files) != candidate["evidence_count"] or any(
+            not os.path.isfile(os.path.join(os.path.dirname(path), filename))
+            for filename in evidence_files):
+        raise RuntimeError("review evidence is incomplete; run verify again")
+    entry["structural_references"] = candidate["structural_references"]
+    entry.setdefault("min_nonblack_ratio", candidate["suggested_min_nonblack_ratio"])
+    entry["dims"] = candidate["dims"]
+    entry["review"] = (
+        f"Approved {candidate['evidence_count']} composited images from two independent runs on "
+        f"{time.strftime('%Y-%m-%d')}; intended scene, layers, and progression visually confirmed.")
+
+
 def capture(entry, run_log=None):
     """Boot the game, wait for frame_<F>.bmp, return (bmp_bytes_path_copy, (w,h)).
     Raises RuntimeError on timeout / crash-before-frame."""
@@ -120,9 +481,8 @@ def capture(entry, run_log=None):
         "PROSPER_RENDER_SCALE": str(scale),
         "PROSPER_FAULT_ONSTACK": "1",    # a guest-thread fault is reported, not a silent kill
     })
-    env.update(entry.get("env", {}))
-
     tmp = tempfile.mkdtemp(prefix="snap_")
+    apply_entry_env(env, entry, tmp)
     env["PROSPER_FRAME_DIR"] = tmp
     target = os.path.join(tmp, "frame_%04d.bmp" % frame)
     # Run a UNIQUELY-NAMED copy of the binary: this repo is worked by several agents at once, and a
@@ -130,8 +490,11 @@ def capture(entry, run_log=None):
     bt_run = os.path.join(tmp, "bt_snap")
     shutil.copyfile(bt, bt_run)
     os.chmod(bt_run, 0o755)
-    logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
+    proc = None
+    logf = None
+    failed = False
     try:
+        logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
         proc = subprocess.Popen([bt_run, dump], env=env, stdout=logf, stderr=subprocess.STDOUT,
                                 preexec_fn=os.setsid)
         deadline = time.time() + timeout
@@ -183,72 +546,82 @@ def capture(entry, run_log=None):
             time.sleep(0.3)
         raise RuntimeError(f"timeout after {timeout}s waiting for frame {frame} "
                            f"(reached: {_last_frame(tmp)})")
+    except Exception:
+        failed = True
+        raise
     finally:
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            if proc is not None:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except Exception:
             pass
-        if run_log:
+        if run_log and logf is not None:
             logf.close()
+        if failed:
+            _cleanup(tmp)
 
 
-def capture_richest(entry, run_log=None):
-    """Run the whole boot and return the RICHEST frame it produced: (best_bmp_path, max_colors, dims, tmp).
-    For a threaded boot whose per-frame output isn't reproducible, neither an exact hash nor a single
-    settled frame is stable (the settled screen — a blank loading flicker vs real content — varies). The
-    MAX distinct-color count OVER THE WHOLE RUN is robust: a working render always produces some rich
-    frame; a rejected/dropped shader collapses every frame to the debug clear (~1 color). Powers the
-    `min_colors` guard (see distinct_colors)."""
-    bt = boot_trace_path()
-    if not os.path.exists(bt):
-        raise RuntimeError(f"boot_trace not found at {bt} (build it, or set PROSPER_BOOT_TRACE)")
+def capture_content(entry, run_log=None):
+    """Run the title and measure normal composited screenshots, never renderer intermediates."""
+    frontend = screenshot_path()
+    if not os.path.exists(frontend):
+        raise RuntimeError(f"screenshot not found at {frontend} (build it, or set PROSPER_SCREENSHOT)")
     dump = resolve_dump(entry)
     if not os.path.exists(dump):
         raise RuntimeError(f"game dump not found: {dump} (set PROSPER_GAME_ROOT)")
     scale = int(entry.get("scale", 4))
     timeout = int(entry.get("timeout", 240))
+    sample_seconds = float(entry.get("sample_seconds", 1))
+    if sample_seconds <= 0:
+        raise RuntimeError("sample_seconds must be positive")
     env = dict(os.environ)
     env.update({
         "PROSPER_GUEST_FS": "1", "PROSPER_GUEST_ARGS": "-force-gfx-direct",
         "PROSPER_RENDER": "1", "PROSPER_RENDER_EVERY": "1", "PROSPER_RENDER_FIRST": "0",
         "PROSPER_RENDER_SCALE": str(scale), "PROSPER_FAULT_ONSTACK": "1",
     })
-    env.update(entry.get("env", {}))
     tmp = tempfile.mkdtemp(prefix="snap_")
-    env["PROSPER_FRAME_DIR"] = tmp
-    bt_run = os.path.join(tmp, "bt_snap")
-    shutil.copyfile(bt, bt_run); os.chmod(bt_run, 0o755)
-    logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
+    proc = None
+    logf = None
+    failed = False
     try:
-        proc = subprocess.Popen([bt_run, dump], env=env, stdout=logf, stderr=subprocess.STDOUT,
+        apply_entry_env(env, entry, tmp)
+        frontend_run = os.path.join(tmp, "screenshot_snap")
+        shutil.copyfile(frontend, frontend_run)
+        os.chmod(frontend_run, 0o755)
+        capture_end = float(entry.get("capture_before_seconds", timeout))
+        count = max(2, int(math.ceil(capture_end / sample_seconds)) + 1)
+        runner_timeout = max(timeout, int(math.ceil(capture_end))) + 30
+        command = [
+            frontend_run, dump, "--seconds", str(sample_seconds), "--count", str(count),
+            "--out", tmp, "--manifest", os.path.join(tmp, "capture.jsonl"),
+            "--timeout", str(runner_timeout), "--require-composited-frame",
+        ]
+        logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
+        proc = subprocess.Popen(command, env=env, stdout=logf, stderr=subprocess.STDOUT,
                                 preexec_fn=os.setsid)
-        deadline = time.time() + timeout
+        deadline = time.time() + runner_timeout + 15
         while time.time() < deadline and proc.poll() is None:
             time.sleep(1.0)
+        if proc.poll() is None:
+            raise RuntimeError(f"screenshot frontend exceeded {runner_timeout + 15}s")
+        if proc.returncode != 0:
+            raise RuntimeError(f"screenshot frontend exited with code {proc.returncode}")
+        summary = analyze_content_manifest(tmp, entry)
+        return summary["richest"]["path"], summary, tmp
+    except Exception:
+        failed = True
+        raise
     finally:
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            if proc is not None:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except Exception:
             pass
-        if run_log:
+        if run_log and logf is not None:
             logf.close()
-    frames = sorted(f for f in os.listdir(tmp) if f.startswith("frame_") and f.endswith(".bmp"))
-    if not frames:
-        raise RuntimeError(f"no frames rendered in {timeout}s")
-    best_p, best_n, best_dims = None, -1, (0, 0)
-    for f in frames:
-        p = os.path.join(tmp, f)
-        try:
-            if os.path.getsize(p) <= 0:
-                continue
-            n, dims = distinct_colors(p)
-        except (OSError, ValueError):
-            continue
-        if n > best_n:
-            best_p, best_n, best_dims = p, n, dims
-    dst = os.path.join(tmp, "captured.bmp")
-    shutil.copyfile(best_p, dst)
-    return dst, best_n, best_dims, tmp
+        if failed:
+            _cleanup(tmp)
 
 
 def _last_frame(tmp):
@@ -275,7 +648,10 @@ def select(m, names):
 def cmd_list(m, names):
     for s in m["snapshots"]:
         if "min_colors" in s:
-            mode = f"min_colors={s['min_colors']}"
+            mode = (f"min_colors={s['min_colors']} "
+                    f"min_frames={s.get('min_qualifying_frames', 2)} "
+                    f"min_changes={s.get('min_pixel_changes', 0)} "
+                    f"references={len(s.get('structural_references', []))}")
         else:
             mode = (f"frame={s.get('frame', 'MISSING')} "
                     f"hash={'set' if s.get('hash') else 'MISSING'}")
@@ -283,38 +659,30 @@ def cmd_list(m, names):
 
 
 def cmd_update(m, names):
-    # Bless a NEW baseline hash — but only if the target is DETERMINISTIC. Capture twice and refuse to
-    # write the hash unless both captures agree; a baseline that isn't reproducible is worse than none
-    # (it fails `check` for every other agent/machine and trains people to ignore the guard). A target
-    # like "the N-th draw submit" (PROSPER_RENDER_EVERY=1) is inherently timing/threading-dependent on a
-    # threaded boot, so it will (correctly) be rejected here until the entry targets a settled/stable
-    # capture point. `--force` blesses a single capture anyway (escape hatch; not recommended).
-    force = "--force" in names
-    names = [n for n in names if n != "--force"]
+    # Exact hashes require two identical verify captures plus explicit review of the saved images.
+    reviewed = "--reviewed" in names
+    names = [n for n in names if n != "--reviewed"]
     rc = 0
     for s in select(m, names):
         try:
-            if s.get("min_colors"):     # content-metric entry: nothing to bless; report the margin
-                b, nc, dims, t = capture_richest(s); _cleanup(t)
-                ok = nc >= int(s["min_colors"])
-                print(f"[update] {s['name']}: {dims[0]}x{dims[1]}, richest frame {nc} distinct colors "
-                      f"(threshold min_colors={s['min_colors']}, {'OK' if ok else 'BELOW'})")
-                if not ok:
+            if s.get("min_colors"):
+                if not reviewed:
+                    print(f"[update] {s['name']}: REFUSED — run verify, inspect every image from "
+                          f"both runs, then rerun update {s['name']} --reviewed", file=sys.stderr)
                     rc = 1
+                    continue
+                approve_content_candidate(s)
+                print(f"[update] {s['name']}: approved "
+                      f"{len(s['structural_references'])} structural references")
                 continue
-            b1, t1 = capture(s); h1, dims = pixel_hash(b1); _cleanup(t1)
-            if force:
-                s["hash"] = h1; s["dims"] = list(dims)
-                print(f"[update] {s['name']}: {dims[0]}x{dims[1]} hash={h1[:16]}… (FORCED, unverified)")
-                continue
-            b2, t2 = capture(s); h2, _ = pixel_hash(b2); _cleanup(t2)
-            if h1 != h2:
-                print(f"[update] {s['name']}: REFUSED — non-deterministic ({h1[:12]} vs {h2[:12]}); "
-                      f"target a settled/stable frame (or --force to override)", file=sys.stderr)
+            if not reviewed:
+                print(f"[update] {s['name']}: REFUSED — run verify, inspect both review images, "
+                      f"then rerun update {s['name']} --reviewed", file=sys.stderr)
                 rc = 1
                 continue
-            s["hash"] = h1; s["dims"] = list(dims)
-            print(f"[update] {s['name']}: {dims[0]}x{dims[1]} hash={h1[:16]}… (verified deterministic)")
+            approve_exact_candidate(s)
+            print(f"[update] {s['name']}: approved {s['dims'][0]}x{s['dims'][1]} "
+                  f"hash={s['hash'][:16]}…")
         except Exception as e:
             print(f"[update] {s['name']}: ERROR {e}", file=sys.stderr)
             rc = 1
@@ -325,26 +693,49 @@ def cmd_update(m, names):
 def cmd_verify(m, names):
     rc = 0
     for s in select(m, names):
+        temps = []
         try:
             if s.get("min_colors"):
-                threshold = int(s["min_colors"])
-                b1, n1, dims1, t1 = capture_richest(s); _cleanup(t1)
-                b2, n2, dims2, t2 = capture_richest(s); _cleanup(t2)
-                ok = n1 >= threshold and n2 >= threshold and dims1 == dims2
+                out_dir = reset_review_evidence(s["name"])
+                _, summary1, t1 = capture_content(s, run_log=os.path.join(out_dir, "run1.log"))
+                temps.append(t1)
+                saved1 = save_content_evidence(s["name"], 1, summary1)
+                _cleanup(t1)
+                _, summary2, t2 = capture_content(s, run_log=os.path.join(out_dir, "run2.log"))
+                temps.append(t2)
+                saved2 = save_content_evidence(s["name"], 2, summary2)
+                _cleanup(t2)
+                ok1, why1 = content_result(s, summary1, include_structural=False)
+                ok2, why2 = content_result(s, summary2, include_structural=False)
+                ok = ok1 and ok2 and summary1["dims"] == summary2["dims"]
+                if ok:
+                    save_content_candidate(s, (summary1, summary2))
                 print(f"[verify] {s['name']}: {'CONTENT-STABLE' if ok else 'UNSTABLE'} "
-                      f"({n1} vs {n2} colors, min={threshold}, "
-                      f"dims={dims1[0]}x{dims1[1]}/{dims2[0]}x{dims2[1]})")
+                      f"(richest={summary1['richest']['colors']}/{summary2['richest']['colors']}, "
+                      f"qualifying={len(summary1['qualifying'])}/{len(summary2['qualifying'])}, "
+                      f"changes={summary1['pixel_changes']}/{summary2['pixel_changes']}, "
+                      f"dims={summary1['dims'][0]}x{summary1['dims'][1]}/"
+                      f"{summary2['dims'][0]}x{summary2['dims'][1]})")
+                if why1 or why2:
+                    print(f"         failures: run1={why1 or 'none'} run2={why2 or 'none'}")
+                print(f"         REVIEW REQUIRED: inspect {len(saved1) + len(saved2)} images in {out_dir}")
                 if not ok:
                     rc = 1
                 continue
-            b1, t1 = capture(s); h1, _ = pixel_hash(b1); _cleanup(t1)
-            b2, t2 = capture(s); h2, _ = pixel_hash(b2); _cleanup(t2)
-            ok = h1 == h2
+            b1, t1 = capture(s); temps.append(t1); h1, dims1 = pixel_hash(b1)
+            b2, t2 = capture(s); temps.append(t2); h2, dims2 = pixel_hash(b2)
+            ok = h1 == h2 and dims1 == dims2
             print(f"[verify] {s['name']}: {'DETERMINISTIC' if ok else 'NON-DETERMINISTIC'} "
                   f"({h1[:12]} vs {h2[:12]})")
+            if ok:
+                first, second = save_exact_candidate(s, b1, b2, h1, dims1)
+                print(f"         REVIEW REQUIRED: inspect {first} and {second}")
+            _cleanup(t1); _cleanup(t2)
             if not ok:
                 rc = 1
         except Exception as e:
+            for tmp in temps:
+                _cleanup(tmp)
             print(f"[verify] {s['name']}: ERROR {e}", file=sys.stderr)
             rc = 1
     return rc
@@ -354,25 +745,49 @@ def cmd_check(m, names):
     os.makedirs(FAIL_DIR, exist_ok=True)
     rc = 0
     for s in select(m, names):
+        tmp = None
         min_colors = s.get("min_colors")
         base = s.get("hash")
         if not min_colors and not base:
-            print(f"[check] {s['name']}: NO BASELINE — run `snapshot.py update {s['name']}`", file=sys.stderr)
+            print(f"[check] {s['name']}: NO BASELINE — run verify, inspect its review images, then "
+                  f"run `snapshot.py update {s['name']} --reviewed`", file=sys.stderr)
+            rc = 1
+            continue
+        if base and (not s.get("review") or str(s["review"]).lower() == "pending"):
+            print(f"[check] {s['name']}: baseline lacks a completed visual-review note", file=sys.stderr)
             rc = 1
             continue
         log = os.path.join(FAIL_DIR, f"{s['name']}.log")
         try:
             if min_colors:                                  # content-metric mode (robust to pixel variance)
-                bmp, nc, dims, tmp = capture_richest(s, run_log=log)
-                if nc >= int(min_colors):
-                    print(f"[check] {s['name']}: OK ({dims[0]}x{dims[1]}, richest {nc} colors >= {min_colors})")
+                if not s.get("review") or str(s["review"]).lower() == "pending":
+                    raise RuntimeError("content guard lacks a completed visual-review note")
+                if not s.get("structural_references"):
+                    raise RuntimeError("content guard lacks reviewed structural references")
+                _, summary, tmp = capture_content(s, run_log=log)
+                ok, failures = content_result(s, summary)
+                if ok:
+                    print(f"[check] {s['name']}: OK ({summary['dims'][0]}x{summary['dims'][1]}, "
+                          f"frames={len(summary['records'])}, qualifying={len(summary['qualifying'])}, "
+                          f"richest={summary['richest']['colors']} colors, "
+                          f"pixel_changes={summary['pixel_changes']}, "
+                          f"structural_matches={summary['structural_matches']}, "
+                          f"nonblack_matches={summary['nonblack_matches']})")
                     os.remove(log) if os.path.exists(log) else None
                 else:
-                    out = os.path.join(FAIL_DIR, f"{s['name']}.bmp")
-                    shutil.copyfile(bmp, out)
-                    print(f"[check] {s['name']}: FAIL — richest frame only {nc} distinct colors < min "
-                          f"{min_colors} (render collapsed to the debug clear?)")
-                    print(f"         screenshot: {out}")
+                    failure_paths = []
+                    review_names = {}
+                    for i, record in enumerate(choose_review_records(summary)):
+                        extension = os.path.splitext(record["path"])[1]
+                        out = os.path.join(FAIL_DIR, f"{s['name']}-{i:02d}{extension}")
+                        shutil.copyfile(record["path"], out)
+                        failure_paths.append(out)
+                        review_names[record["path"]] = os.path.basename(out)
+                    metadata = os.path.join(FAIL_DIR, f"{s['name']}-evidence.json")
+                    save_content_metadata(metadata, summary, review_names)
+                    print(f"[check] {s['name']}: FAIL — {'; '.join(failures)}")
+                    print(f"         screenshots: {', '.join(failure_paths)}")
+                    print(f"         metadata:    {metadata}")
                     print(f"         boot log:   {log}")
                     rc = 1
                 _cleanup(tmp)
@@ -391,6 +806,8 @@ def cmd_check(m, names):
                 rc = 1
             _cleanup(tmp)
         except Exception as e:
+            if tmp:
+                _cleanup(tmp)
             print(f"[check] {s['name']}: ERROR {e}  (log: {log})", file=sys.stderr)
             rc = 1
     return rc

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -5,20 +5,63 @@
       "dump": "PPSA24651-app0",
       "scale": 4,
       "timeout": 200,
+      "capture_after_seconds": 150,
+      "capture_before_seconds": 199,
+      "pad_script": "scripts/messenger/reach-first-level.pad",
+      "savedata_policy": "fresh",
       "env": {},
-      "min_colors": 5000,
-      "_note": "Content-metric guard (min_colors): The Messenger's boot render isn't pixel-deterministic across runs (exact hashing AND a single settled frame both flake — the stable screen varies run-to-run). So `check` runs the whole boot and takes the RICHEST frame's distinct-color count — robust to per-frame variance, but still catches the regression that matters: a rejected/dropped shader (the #199/#201/#239 class) collapses every frame to the debug clear (~1 color), while a real render peaks in the tens of thousands (observed ~34k-137k once the scene/cutscene renders). 5000 is a wide margin below that and far above any blue-clear."
+      "min_colors": 20,
+      "min_qualifying_frames": 4,
+      "min_pixel_changes": 3,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 4,
+      "min_content_match_ratio": 0.75,
+      "dims": [480, 270],
+      "review": "pending",
+      "_note": "Provisional presented-frame guard for The Messenger's first-level scene. Valid palette-rendered screenshots contain only 27-39 visible RGB colors, proving the previous 5000-color threshold measured the wrong source. Baseline approval is blocked because inspected runs also contain cyclic incomplete compositions tracked by #720."
     },
     {
-      "name": "dead-cells-splash",
+      "name": "dead-cells-gameplay",
       "dump": "PPSA15552-app0",
       "scale": 4,
-      "timeout": 20,
+      "timeout": 180,
+      "capture_after_seconds": 130,
+      "capture_before_seconds": 179,
+      "pad_script": "scripts/dead-cells/reach-first-gameplay-full-render.pad",
+      "savedata_policy": "fresh",
+      "env": {},
+      "min_colors": 5000,
+      "min_qualifying_frames": 4,
+      "min_pixel_changes": 3,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 4,
+      "min_content_match_ratio": 0.75,
+      "dims": [960, 540],
+      "review": "pending",
+      "_note": "Provisional full-render route toward the controllable Jump tutorial. Two inspected WSL runs diverged in Prisoners' Quarters loading and did not reach gameplay by 180 seconds, so this remains pending. Approve it only after both runs show the intended gameplay, full scene layers/HUD, and progression."
+    },
+    {
+      "name": "blasphemous2-gameplay",
+      "dump": "PPSA13579-app0",
+      "scale": 1,
+      "timeout": 420,
+      "capture_after_seconds": 318,
+      "capture_before_seconds": 419,
+      "pad_script": "scripts/blasphemous2/reach-first-gameplay.pad",
+      "savedata_policy": "fresh",
       "env": {
-        "PROSPER_RENDER_DELAY_MS": "3000"
+        "PROSPER_RENDER_EVERY": "30",
+        "PROSPER_RENDER_EVERY_FOR_MS": "230000"
       },
-      "min_colors": 1500,
-      "_note": "Run-level splash content guard. Frame 0 after the 3-second render delay is timing-dependent: unchanged builds select multiple valid static/animated states (including hashes 8429fedd..., 891a80fc..., and a9e41a6b...). Preserved failures and three fresh runs show valid rich states at 1650-1698 distinct colors, while later transition frames are only about 325-339. Requiring the richest startup frame to reach 1500 accepts all observed valid splash phases without blessing one animation frame, while still rejecting partial transitions and clear-only rendering."
+      "min_colors": 1000,
+      "min_qualifying_frames": 4,
+      "min_pixel_changes": 3,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 4,
+      "min_content_match_ratio": 0.75,
+      "dims": [1920, 1080],
+      "review": "pending",
+      "_note": "Route-aware provisional guard for the first playable room. Only frames written after movement begins are evidence; multiple rich frames and pixel changes reject boot logos, static menus, and black-world output. Run verify and visually inspect its retained review images before replacing the pending review note or adjusting thresholds."
     }
   ]
 }

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -18,7 +18,7 @@
       "min_content_match_ratio": 0.75,
       "dims": [480, 270],
       "review": "pending",
-      "_note": "Provisional presented-frame guard for The Messenger's first-level scene. Valid palette-rendered screenshots contain only 27-39 visible RGB colors, proving the previous 5000-color threshold measured the wrong source. Baseline approval is blocked because inspected runs also contain cyclic incomplete compositions tracked by #720."
+      "_note": "Provisional presented-frame guard for The Messenger's first-level scene. Valid palette-rendered screenshots contain only 27-39 visible RGB colors, proving the previous 5000-color threshold measured the wrong source. The retained dialog samples are visually complete, but the baseline remains pending until the route evidence is deliberately reviewed and approved."
     },
     {
       "name": "dead-cells-gameplay",

--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("prosper_snapshot", os.path.join(HERE, "snapshot.py"))
+SNAPSHOT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SNAPSHOT)
+
+
+class SnapshotContentTests(unittest.TestCase):
+    def test_content_window_requires_multiple_frames_and_progression(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            samples = [
+                (1, 1, "a", "raw_scanout", 0, 0, 100, 2),
+                (5, 2, "b", "composited", 0, 0, 100, 2),
+                (6, 2, "c", "composited", 1, 0, 100, 2),
+                (7, 2, "c", "composited", 1, 0, 101, 2),
+                (8, 1, "d", "composited", 0xffffffffffffffff, 0xffffffffffffffff, 0, 0),
+            ]
+            events = [{"type": "run"}]
+            for index, (elapsed, colors, crc, source, ahash, dhash, luma, nonblack) in enumerate(samples):
+                path = os.path.join(tmp, f"shot_{index:02d}.png")
+                with open(path, "wb") as f:
+                    f.write(b"png evidence")
+                events.append({
+                    "type": "sample", "elapsed_seconds": elapsed, "source": source,
+                    "png": path, "width": 2, "height": 1,
+                    "distinct_rgb_colors": colors, "pixel_crc32": crc,
+                    "average_hash": f"{ahash:016x}",
+                    "difference_hash": f"{dhash:016x}",
+                    "luma16x9": f"{luma:02x}" * (16 * 9),
+                    "nonblack_rgb_pixels": nonblack,
+                })
+            events.append({
+                "type": "summary", "exit_code": 0,
+                "saved": len(samples), "requested": len(samples),
+            })
+            with open(os.path.join(tmp, "capture.jsonl"), "w") as f:
+                for event in events:
+                    f.write(json.dumps(event) + "\n")
+
+            entry = {
+                "min_colors": 2, "min_qualifying_frames": 3, "min_pixel_changes": 2,
+                "capture_after_seconds": 4, "capture_before_seconds": 9, "dims": [2, 1],
+                "structural_references": [
+                    {"luma16x9": "64" * (16 * 9)},
+                ],
+                "min_structural_similarity": 0.99, "min_structural_matches": 3,
+                "min_nonblack_ratio": 0.5, "min_nonblack_matches": 3,
+                "min_content_match_ratio": 0.75,
+            }
+            summary = SNAPSHOT.analyze_content_manifest(tmp, entry)
+            ok, failures = SNAPSHOT.content_result(entry, summary)
+
+            self.assertTrue(ok, failures)
+            self.assertEqual(4, len(summary["records"]))
+            self.assertEqual(3, len(summary["qualifying"]))
+            self.assertEqual(2, summary["pixel_changes"])
+            self.assertEqual(3, summary["structural_matches"])
+            self.assertEqual(3, summary["nonblack_matches"])
+            self.assertEqual(4, len(SNAPSHOT.choose_review_records(summary)))
+            metadata_path = os.path.join(tmp, "evidence.json")
+            SNAPSHOT.save_content_metadata(metadata_path, summary)
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+            self.assertEqual(4, len(metadata["records"]))
+            self.assertEqual("composited", metadata["records"][0]["source"])
+
+    def test_content_manifest_rejects_incomplete_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "capture.jsonl"), "w") as f:
+                f.write(json.dumps({
+                    "type": "summary", "exit_code": 1, "saved": 2, "requested": 3,
+                }) + "\n")
+            with self.assertRaisesRegex(RuntimeError, "did not complete"):
+                SNAPSHOT.analyze_content_manifest(tmp, {"min_colors": 1})
+
+    def test_content_result_reports_each_failed_contract(self):
+        summary = {
+            "qualifying": [{}], "pixel_changes": 0, "dimensions_consistent": True,
+            "dims": (2, 1),
+        }
+        entry = {
+            "min_qualifying_frames": 2, "min_pixel_changes": 1, "dims": [3, 1],
+        }
+        ok, failures = SNAPSHOT.content_result(entry, summary)
+        self.assertFalse(ok)
+        self.assertEqual(3, len(failures))
+
+    def test_entry_env_resolves_route_and_uses_fresh_save(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            route = os.path.join(tmp, "route.pad")
+            with open(route, "w") as f:
+                f.write("1-2:cross\n")
+            env = {}
+            SNAPSHOT.apply_entry_env(env, {
+                "pad_script": route, "savedata_policy": "fresh", "env": {"EXTRA": "yes"},
+            }, tmp)
+            self.assertEqual("@" + route, env["PROSPER_PAD_SCRIPT"])
+            self.assertEqual("1", env["PROSPER_PAD_SCRIPT_LOG"])
+            self.assertEqual("yes", env["EXTRA"])
+            self.assertTrue(os.path.isdir(env["PROSPER_SAVEDATA_DIR"]))
+
+    def test_structural_similarity_tolerates_small_changes_but_rejects_missing_layer(self):
+        reference = (100,) * (16 * 9)
+        subtle_change = (101,) * (16 * 9)
+        missing_half = (0,) * (16 * 4) + (100,) * (16 * 5)
+        self.assertGreater(SNAPSHOT.structural_similarity(reference, subtle_change), 0.99)
+        self.assertLess(SNAPSHOT.structural_similarity(reference, missing_half), 0.1)
+
+    def test_candidate_fingerprint_ignores_baseline_and_review_only(self):
+        base = {"name": "x", "frame": 7, "hash": "old", "dims": [1, 1], "review": "old"}
+        changed_baseline = dict(base, hash="new", dims=[2, 2], review="new",
+                                structural_references=[{"luma16x9": "00" * (16 * 9)}])
+        changed_contract = dict(base, frame=8)
+        self.assertEqual(SNAPSHOT.entry_fingerprint(base), SNAPSHOT.entry_fingerprint(changed_baseline))
+        self.assertNotEqual(SNAPSHOT.entry_fingerprint(base), SNAPSHOT.entry_fingerprint(changed_contract))
+
+    def test_content_candidate_requires_complete_review_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_review = SNAPSHOT.REVIEW_DIR
+            SNAPSHOT.REVIEW_DIR = tmp
+            try:
+                entry = {"name": "gameplay", "min_colors": 10,
+                         "min_structural_similarity": 0.85}
+                records = []
+                for run in (1, 2):
+                    run_records = []
+                    for index in range(2):
+                        path = os.path.join(tmp, "gameplay", f"run{run}_{index:02d}.png")
+                        os.makedirs(os.path.dirname(path), exist_ok=True)
+                        with open(path, "wb") as f:
+                            f.write(b"reviewed image")
+                        run_records.append({
+                            "path": path, "elapsed": run * 10 + index, "colors": 20,
+                            "dims": (4, 3), "average_hash": run * 10 + index,
+                            "difference_hash": run * 20 + index,
+                            "luma16x9": (run * 10 + index,) * (16 * 9),
+                            "nonblack_ratio": 0.8,
+                        })
+                    records.append({
+                        "records": run_records, "qualifying": run_records,
+                        "richest": run_records[0], "dims": (4, 3),
+                    })
+                SNAPSHOT.save_content_candidate(entry, records)
+                SNAPSHOT.approve_content_candidate(entry)
+                self.assertEqual(4, len(entry["structural_references"]))
+                self.assertEqual(0.4, entry["min_nonblack_ratio"])
+                self.assertIn("4 composited images", entry["review"])
+
+                os.remove(os.path.join(tmp, "gameplay", "run2_01.png"))
+                entry.pop("structural_references")
+                entry["review"] = "pending"
+                with self.assertRaisesRegex(RuntimeError, "incomplete"):
+                    SNAPSHOT.approve_content_candidate(entry)
+            finally:
+                SNAPSHOT.REVIEW_DIR = old_review
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- route content guards through the normal presented-screenshot frontend instead of renderer-invocation BMP dumps
- evaluate every composited frame in a configured gameplay window and retain eight spread images from each of two independent runs
- add alpha-aware color/coverage metrics, diagnostic hashes/CRC, and a 16x9 luminance signature to screenshot manifests
- compare reviewed references with SSIM and require a configurable majority of the evidence window to match
- require explicit visual approval before recording a baseline; reject pending, stale, or incomplete candidates
- retain per-frame flip, renderer, front-buffer, CRC, coverage, and structural metadata beside review/failure PNGs
- add provisional Messenger, Dead Cells, and Blasphemous 2 routes plus comprehensive workflow documentation

## Why

The previous guards could bless one renderer intermediate, a logo, or a black/wrong scene. Exact checksums also reject harmless pixel changes, while the 8x8 perceptual hashes tested here were too coarse to distinguish Blasphemous 2's missing sky/HUD frame. The new workflow uses reviewed multi-frame evidence and structural similarity to catch major collapse without freezing exact pixels.

## Validation

- full Linux build succeeds after rebasing on current `master`
- `ctest`: 99/99 passing
- snapshot logic: 7/7 passing
- inspected two-run captures for Messenger and Dead Cells
- historical Blasphemous 2 complete/incomplete pair scores SSIM `0.761892`, below the `0.85` gate

## Known blockers

No new title reference is approved in this PR. Dead Cells' full-render route diverges during Prisoners' Quarters loading and still needs a repeatable gameplay checkpoint. The historical Blasphemous 2 sample still needs reproducible current-run evidence. Messenger's retained dialog samples are visually complete; an earlier missing-layer report was retracted after direct PNG pixel comparison showed that the samples differ only in the dialog region. The manifest entries remain `review: pending` deliberately.

Progresses #661.