### PR TITLE
Handoff: B2 macOS crash = render-path stray write to host g_eq_mx (latent on Linux) + diagnostics

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -244,9 +244,23 @@ namespace { inline uint64_t fbsd_errno(int host) {
     return (uint64_t)(unsigned)host;
 } }
 HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
-HLE(k_mutex_lock)    { auto* m = ensure_mutex(a0); return m ? fbsd_errno(pthread_mutex_lock(m))    : 0x16; }
-HLE(k_mutex_trylock) { auto* m = ensure_mutex(a0); return m ? fbsd_errno(pthread_mutex_trylock(m)) : 0x16; }
-HLE(k_mutex_unlock)  { auto* m = ensure_mutex(a0); return m ? fbsd_errno(pthread_mutex_unlock(m))  : 0x16; }
+// PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
+// with the guest slot address and the host object it resolved to. Diagnostic for the macOS
+// guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
+// a FreeBSD EINVAL(0x16) to the guest's libc++, which throws and terminates. This pinpoints the
+// exact slot/host-pointer producing the bad lock without needing a debugger (unusable under Rosetta).
+namespace {
+    inline uint64_t mtx_report(const char* op, uint64_t slot, pthread_mutex_t* m, int host) {
+        static const bool on = getenv("PROSPER_MUTEX_FAILLOG") != nullptr;
+        if (on && host != 0)
+            fprintf(stderr, "[mtx-fail] %s slot=0x%llx host_m=%p rc=%d(%s)\n", op,
+                    (unsigned long long)slot, (void*)m, host, strerror(host));
+        return fbsd_errno(host);
+    }
+}
+HLE(k_mutex_lock)    { auto* m = ensure_mutex(a0); return m ? mtx_report("lock",    a0, m, pthread_mutex_lock(m))    : 0x16; }
+HLE(k_mutex_trylock) { auto* m = ensure_mutex(a0); return m ? mtx_report("trylock", a0, m, pthread_mutex_trylock(m)) : 0x16; }
+HLE(k_mutex_unlock)  { auto* m = ensure_mutex(a0); return m ? mtx_report("unlock",  a0, m, pthread_mutex_unlock(m))  : 0x16; }
 
 // --- condition variables ---
 HLE(k_condattr_init)    { if (a0) { auto* c = (pthread_condattr_t*)calloc(1, sizeof(pthread_condattr_t)); pthread_condattr_init(c); *(void**)a0 = c; } return 0; }

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -100,10 +100,15 @@ int main(int argc, char** argv) {
                 catch (const std::exception& ex) { fprintf(stderr, "  what(): %s\n", ex.what()); }
                 catch (...) { fprintf(stderr, "  (non-std exception)\n"); }
             }
+#ifndef _WIN32
             void* frames[64];
             int n = backtrace(frames, 64);
             char** syms = backtrace_symbols(frames, n);
             for (int i = 0; i < n; ++i) fprintf(stderr, "  #%02d %s\n", i, syms ? syms[i] : "?");
+#else
+            // No execinfo on MinGW; the exception message above is still the useful part.
+            fprintf(stderr, "  (host backtrace unavailable on this platform)\n");
+#endif
             fflush(stderr);
             _Exit(42);
         });

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -9,6 +9,10 @@
 #include <cstdio>
 #include <string>
 #include <cstdint>
+#include <exception>          // std::set_terminate / std::current_exception (PROSPER_TERM_BT)
+#ifndef _WIN32
+#include <execinfo.h>         // backtrace / backtrace_symbols (host crash backtrace)
+#endif
 extern "C" int prosper_reserved_range_state(uint64_t);   // memory-HLE mapping classifier (diagnostic)
 #ifdef PROSPER_AUDIO_SDL3
 #include "audio_sdl3.hpp"                 // optional SDL3 audio frontend (-DPROSPER_AUDIO_SDL3=ON)
@@ -84,6 +88,26 @@ static uint64_t bof(uint64_t a) {
 }
 
 int main(int argc, char** argv) {
+    // PROSPER_TERM_BT: install a std::terminate handler that dumps the HOST backtrace + exception
+    // message. Diagnostic for the macOS std::mutex EINVAL crash — the guest rbp-walker only shows
+    // guest frames, but an uncaught host C++ exception (e.g. a mutex lock throwing) terminates on
+    // the throwing thread, so backtrace() here captures the real host call chain to the bad lock.
+    if (getenv("PROSPER_TERM_BT")) {
+        std::set_terminate([]{
+            fprintf(stderr, "\n=== PROSPER_TERM_BT: std::terminate ===\n");
+            if (auto ep = std::current_exception()) {
+                try { std::rethrow_exception(ep); }
+                catch (const std::exception& ex) { fprintf(stderr, "  what(): %s\n", ex.what()); }
+                catch (...) { fprintf(stderr, "  (non-std exception)\n"); }
+            }
+            void* frames[64];
+            int n = backtrace(frames, 64);
+            char** syms = backtrace_symbols(frames, n);
+            for (int i = 0; i < n; ++i) fprintf(stderr, "  #%02d %s\n", i, syms ? syms[i] : "?");
+            fflush(stderr);
+            _Exit(42);
+        });
+    }
     std::string d = (argc >= 2) ? argv[1] : "../../PPSA24651-app0";
     Program p; std::string e;
     // Boot the title via the shared path (also used by prosper-app): link the fixed module set,


### PR DESCRIPTION
## Handoff: Blasphemous 2 crash is a render-path stray write to host global `g_eq_mx` (latent on Linux)

This PR lands two gated diagnostics and hands off a fully-characterized bug for a **Linux** agent to finish,
because the exact-instruction hunt is blocked on macOS/Rosetta but trivial on Linux. Refs #707.

**This is a handoff, not a fix** — the crash is not fixed yet. Read this whole description; it has everything
needed to land the fix in one Linux session.

---

### TL;DR for the Linux agent

Blasphemous 2 (PPSA13579) reaches in-level gameplay on Linux/Windows but **crashes on macOS**. Root cause: a
**stray write from the render/compute path corrupts the bytes of the file-scope global `std::mutex g_eq_mx`**
(the equeue lock in `src/hle/hle_kernel_time.cpp`). macOS `pthread_mutex_lock` validates the `pthread_mutex_t`
`__sig` word and throws `EINVAL`; **glibc does not validate the sig, so the identical write is latent on Linux**
(the lock silently proceeds). That's why Linux survives and macOS dies in `vblank_pump`.

**Your job:** the corruption is *latent but present* on Linux. Reproduce the B2 route on Linux with a watch on
`&g_eq_mx`; because it won't crash there, you get a repeatable signal and can use a **gdb hardware watchpoint**
(or valgrind) to name the exact writing instruction in seconds — then fix it. macOS blocks every tool that would
do this (see below).

---

### What this PR contains

Two diagnostics, both **no-ops unless their env var is set** (`prosper/src/hle/hle_kernel.cpp`,
`prosper/tools/boot_trace/boot_trace.cpp`):

- **`PROSPER_TERM_BT`** (boot_trace): a `std::set_terminate` handler that prints the uncaught exception's
  `what()` plus a symbolized **host** backtrace via `backtrace`/`backtrace_symbols`. An uncaught host C++
  exception terminates on the throwing thread, so this captures the real host call chain — which the guest
  rbp-walking fault backtrace cannot. This is what attributed the crash to `g_eq_mx` in `vblank_pump`.
- **`PROSPER_MUTEX_FAILLOG`** (hle_kernel): reports any guest pthread-mutex op that returns non-zero, with the
  guest slot + resolved host object, so a guest-side `mutex lock failed` can be traced without a debugger.

Both are generally useful and safe to merge regardless of the bug.

---

### The crash (macOS)

```
libc++abi: terminating due to uncaught exception of type std::__1::system_error:
           mutex lock failed: Invalid argument
```

`PROSPER_TERM_BT` host backtrace:

```
std::__throw_system_error (EINVAL)
std::mutex::lock
std::lock_guard<std::mutex>::lock_guard
prosper::(anonymous)::vblank_pump          <- hle_kernel_time.cpp:452, locks g_eq_mx
```

`g_eq_mx` is a global `std::mutex`; it can't be uninitialized at frame ~1000, so its bytes were **corrupted**.

### The old #707 diagnosis was wrong

It claimed a stall at ~frame 623 behind an online/NP/web-API handshake. **Superseded.** With #716's renderer
throughput work the game advances far past 623:
- input route + renderer: reaches guest frames **~1000–2261** (gameplay + FMOD-bank load) then dies;
- **rendering disabled** (`PROSPER_RENDER` unset): runs clean to **frame 4384+**, no crash.

So it was throughput-limited, and the blocker is a **render/compute-path bug**, not web-API.

### Precise characterization (what's known)

- **Victim:** `&g_eq_mx` (host `__DATA`; ASLR-relocated per run). Only **byte 0 of the sig** is overwritten with
  a small guest-ish value (observed `0x4D555458`→`0x4D55545A`, i.e. byte0 `0x58`→`0x5A`). A single small/byte
  write, not a wide splat.
- **Render/compute-triggered** (render-off is clean). Occurs as early as the **first compute-active submit**.
- **Cross-thread** from the compute submit thread; the writer **completes and parks immediately** (at detection,
  every other thread is idle in `__psynch_cvwait`/`semaphore_wait` — a fast transient).
- The write is **not** a `pthread_mutex_*` op — it's a raw store / `memcpy` / `memset` to `&g_eq_mx`.
- **Intermittent hang↔crash (~50/50):** the same corruption hits the mutex sig (→ EINVAL crash) on some runs, or
  other equeue/flip state (→ hang spinning `sceAgcSuspendPoint`) on others.

**Ruled OUT** via targeted overlap probes / synchronous canary checks (do not re-investigate these):
- GPU completion writes — `honor_eop_write` / `honor_event_write` / `honor_write_data` (RELEASE_MEM / EVENT_WRITE
  / WRITE_DATA) in `command_processor.cpp`;
- the compute buffer readback + storage-image writeback in `live_compute.cpp` `execute_item`;
- `execute_item` internals; the executor compute-prep `realize_compute_dispatches` (`gpu_executor.cpp`);
- the graphics-render phases (`live_renderer.cpp`: resource build, `build_bds`, `render_draws_rgba`).

The remaining unpinned surface is a raw write from *somewhere* in the render/compute path (a guest/worker thread).

---

### Reproduce (macOS recipe — for reference)

```
# LunarG MoltenVK (renders real content): bash prosper/scripts/fetch-macos-vulkan.sh --lunarg
export PROSPER_VULKAN_LIB=<repo>/.macos-vulkan/lib/libMoltenVK.dylib
PROSPER_TERM_BT=1 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
  PROSPER_RENDER_EVERY=20 \
  PROSPER_PAD_SCRIPT=@prosper/scripts/blasphemous2/reach-first-gameplay.pad PROSPER_PAD_SCRIPT_LOG=1 \
  ./boot_trace <path>/PPSA13579-app0
# ~50% of runs crash (EINVAL in vblank_pump); ~50% hang spinning suspendPoint. Re-run to get the crash.
```

### Reproduce + pin the writer (Linux — the recommended path)

The corruption is latent on glibc, so it does **not** crash — add a tiny watcher and let it run:

1. Drop a diagnostic that polls the first 8 bytes of `g_eq_mx` (its sig) and logs the instant it deviates from
   the known-good pthread sig values (glibc: check for its `__data.__kind`/lock-word invariants, or simply
   snapshot the sig after first lock and diff). It will fire **without crashing** — repeatable.
2. Then the decisive tool: `gdb -p <pid>` (or launch under gdb), `watch -l *(long*)&<g_eq_mx address>` — a
   **hardware watchpoint** stops exactly on the writing instruction with a full symbolized stack. Or run under
   `valgrind --tool=memcheck` for the write's origin. Either names the culprit in one shot.
3. Fix the stray write at its source; verify the macOS crash is gone (re-run the macOS recipe many times).

Route/pad script and full status: `prosper/scripts/blasphemous2/README.md`.

### Why not just do it on macOS

Rosetta blocks all three: **hardware watchpoints** (x86 debug regs aren't honored for translated code),
**lldb** (dies at the first guest `%fs` TLS trap — the trap-and-emulate SIGSEGV storm), and **ASan** (its shadow
reservations collide with the guest's fixed-address mmaps → the guest faults early at frame ~543). I built a
Mach all-thread `rip` sampler (works under Rosetta) but the writer parks faster than a 5µs poll, and a page-guard
(below) needs the crash-variant run + is fought by Heisenbug overhead.

### Proven macOS fallback if Linux is unavailable: the `g_eq_mx` page-guard catcher (technique)

Verified to arm correctly (despite ASLR) and catch writes to `g_eq_mx` (it caught `vblank_pump`'s own lock before
the leaf-filter was added). Not landed (needs a crash-variant run + cleanup); rebuild in minutes:

- `mprotect(PROT_READ)` the page holding `g_eq_mx` (compute base at runtime from `&g_eq_mx & ~(pgsz-1)`).
- In the macOS `fault_handler` (`exec_image_linux.cpp`), before the `%fs` emulation, on a write-fault whose addr
  is in that page: **RW-pass legit locks** — leaf symbol (`dladdr(rip).dli_sname`) contains `pthread_mutex`; the
  neighbor mutexes `g_apr_mx`/`g_guard_mx`/`g_det_clock` share the page and lock legitimately. Otherwise it's the
  **corruptor**: walk the faulting-context `rbp` chain, `dladdr` each frame, print, `_exit`.
- Re-arm per render phase (a 5µs re-arm stalls the run; per-phase works but only catches on the crash variant).

### Also worth hardening (separate correctness issue, NOT this bug)

`honor_eop_write` / `honor_event_write` / `honor_write_data` (`command_processor.cpp`) write to guest-PM4-supplied
label addresses **without** the `guest_readable()` guard that `honor_dma_data` already has — a mis-decoded packet
could stomp host memory. (Overlap-probed: not the g_eq_mx corruptor. Note `guest_readable` is permissive re: host
mappings on macOS, so prefer a strict guest-range check there.)
