### PR TITLE
gpu: execute UE4 volume-lighting compute chain

### DIFF
--- a/prosper/docs/GFX10_SW_64KB_TILING.md
+++ b/prosper/docs/GFX10_SW_64KB_TILING.md
@@ -74,6 +74,24 @@ Default: **16 pipes** — PS5's Oberon is Navi10-class (36-40 CU, 256-bit GDDR6,
 and Navi10's `GB_ADDR_CONFIG` is 16 pipes. Override with `PROSPER_RX_PIPES=<1|2|4|8|16|32|64>`
 for live A/B. `pipeBankXor` is assumed 0. CONFIDENCE: MED.
 
+### SW_64KB_R_X 3D volumes
+
+DOLL's UE4 lighting pipeline also uses mode-27 thin 3D images (not array textures), including
+`120x68x32` Float16 volumes. Mesa AddrLib's 16-pipe 3D pattern adds `z3,z2,z1,z0` to byte-offset
+bits 8..11 respectively. Each Z slice owns its own padded grid of 64KB 2D blocks, while those Z
+bits still participate in the XOR inside the slice:
+
+```
+addr(x, y, z) = z * blocksPerSlice * 65536
+              + block2D(x, y) * 65536
+              + patternOffset(x, y, z)
+```
+
+`tiled_volume_bytes`, `detile_volume`, and `tile_volume` implement this layout for mode 27 at
+1/2/4/8/16 bytes per texel. Unit tests cover exact round-trips at every size plus golden Z-bit
+positions derived from AddrLib. Capture v9 retains each resource's base-level depth so standalone
+replay uses the same volume footprint. CONFIDENCE: HIGH for the observed 16-pipe PS5 layout.
+
 ## Validation (agentic, offline)
 
 1. `PROSPER_DUMP_TILERAW=1 PROSPER_FRAME_DIR=<dir>` dumps every sampled tiled texture's raw guest

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -262,8 +262,8 @@ struct BoundBuffer {
     uint64_t changed_bytes = 0;
 };
 
-// One image binding (#590): a sampled texture (combined image sampler, decoded to RGBA8 exactly like
-// the live renderer's texture uploads) or a storage image (VK_FORMAT_R32G32B32A32_UINT raw-channel
+// One image binding (#590): a sampled texture (usually RGBA8, with native UINT8x4 and R11G11B10F
+// views where shader-visible numeric semantics require them) or a storage image (R32G32B32A32_UINT
 // texels — the recompiler's format-free contract, exec-diff proven by tests/image_compute_runner.h).
 struct BoundImage {
     const prosper::gpu::ShaderResource* resource = nullptr;
@@ -274,6 +274,10 @@ struct BoundImage {
     VkImageView view = VK_NULL_HANDLE;
     VkSampler sampler = VK_NULL_HANDLE; // combined image sampler only
     VkDeviceSize row_pitch = 0;         // LINEAR-tiling row pitch (bytes), from vkGetImageSubresourceLayout
+    size_t guest_bytes = 0;             // real linear/tiled guest backing footprint
+    size_t alias_of = SIZE_MAX;         // identical storage binding sharing an earlier image/view
+    uint64_t before_hash = 0, after_hash = 0; // trace-only storage-image writeback evidence
+    uint64_t nonzero_channels = 0;
 };
 
 // --- Storage-image channel model (#590) -------------------------------------------------------------
@@ -281,7 +285,7 @@ struct BoundImage {
 // R32G32B32A32_UINT with format-free reads/writes). Real hardware format-converts per the T#, so the
 // guest surface's bytes must be UNPACKED to channel dwords on upload and PACKED back on writeback:
 //   Unorm8  -> float(b/255) bits         <- clamp(bitcast float,0,1)*255 rounded
-//   Float16 -> half->float bits          <- (store pack deliberately unsupported in v0: no half encode)
+//   Float16 -> half->float bits          <- round-to-nearest-even float->half
 //   Float32/Uint32/Sint32 -> raw 4-byte move both ways.
 // Missing channels read the hardware default (0,0,0,1.0f). Anything else is unsupported -> the caller
 // skips the dispatch loudly (never a silent wrong-layout write — correctness-first).
@@ -291,7 +295,8 @@ bool storage_unpack_supported(prosper::gpu::DataFormat f) {
 }
 bool storage_pack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
-    return f == DF::Unorm8 || f == DF::Float32 || f == DF::Uint32 || f == DF::Sint32;
+    return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 ||
+           f == DF::Uint32 || f == DF::Sint32;
 }
 void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32_t ncomp, uint32_t out[4]) {
     using DF = prosper::gpu::DataFormat;
@@ -315,6 +320,10 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
                                if (std::isnan(v)) v = 0.f;
                                v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
                                dst[c] = (uint8_t)std::lround(v * 255.0f); break; }
+            case DF::Float16: { float v; std::memcpy(&v, &in[c], 4);
+                                const uint16_t h = prosper::gpu::float_to_half(v);
+                                dst[c * 2] = static_cast<uint8_t>(h);
+                                dst[c * 2 + 1] = static_cast<uint8_t>(h >> 8); break; }
             default: std::memcpy(dst + c * 4, &in[c], 4); break;    // 32-bit raw
         }
     }
@@ -410,6 +419,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     VkCommandPool command_pool = VK_NULL_HANDLE;
     VkFence fence = VK_NULL_HANDLE;
     bool ok = false;
+    auto vk_ok = [&](VkResult result, const char* stage) {
+        if (result == VK_SUCCESS) return true;
+        if (trace) std::fprintf(stderr, "[compute]   Vulkan failure stage=%s result=%d\n",
+                                stage, static_cast<int>(result));
+        return false;
+    };
+    auto vk_handle_ok = [&](auto handle, const char* stage) {
+        if (handle != VK_NULL_HANDLE) return true;
+        if (trace) std::fprintf(stderr, "[compute]   Vulkan failure stage=%s result=null-handle\n", stage);
+        return false;
+    };
 
     auto cleanup = [&] {
         if (fence) vkDestroyFence(ctx.device, fence, nullptr);
@@ -424,6 +444,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (buffer.memory) ctx.release_memory(buffer.memory);
         }
         for (size_t i = 0; i < images.size(); i++) {
+            if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
             if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
             if (images[i].image) vkDestroyImage(ctx.device, images[i].image, nullptr);
@@ -434,6 +455,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     };
     auto resource_bytes = [](const ShaderResource* resource) -> uint8_t* {
         if (resource->host_data && resource->host_data_size >= resource->size)
+            return resource->host_data;
+        return reinterpret_cast<uint8_t*>(uintptr_t(resource->gpu_addr));
+    };
+    auto resource_bytes_for = [](const ShaderResource* resource, size_t required) -> uint8_t* {
+        if (resource->host_data && resource->host_data_size >= required)
             return resource->host_data;
         return reinterpret_cast<uint8_t*>(uintptr_t(resource->gpu_addr));
     };
@@ -473,8 +499,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (const auto& buffer : buffers) buffers_ready &= buffer.resource && buffer.memory;
         if (!buffers_ready) break;
 
-        // --- Image bindings (#590): sampled textures decode to RGBA8 (the live renderer's proven
-        // model); storage images are R32G32B32A32_UINT raw-channel texels (the recompiler's
+        // --- Image bindings (#590): sampled textures use RGBA8 unless integer/packed-float semantics
+        // require a native view; storage images are R32G32B32A32_UINT raw-channel texels (the recompiler's
         // format-free contract, exec-diff proven by tests/image_compute_runner.h) with per-format
         // pack/unpack against the guest surface. Everything not provably correct skips LOUDLY. ---
         bool images_ready = !ctx.device ? false : true;
@@ -495,7 +521,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u fmt=%u: %s -> "
                                      "dispatch skipped (#590)\n",
                              (unsigned long long)item.code_addr, (unsigned long long)key,
-                             r ? r->width : 0, r ? r->height : 0, 1u,
+                             r ? r->width : 0, r ? r->height : 0, r ? r->depth : 0,
                              r ? (unsigned)r->format : 0u, why);
             }
             images_ready = false;
@@ -511,12 +537,45 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
             if (is_live_render_target(r->gpu_addr)) { skip_image(r, "renderer-owned RTT surface"); break; }
             const bool dim_1d = r->img_dim == 0;
-            if (!dim_1d && r->img_dim != 1) {
-                skip_image(r, "layered/3D image deferred to #657"); break;
+            const bool dim_3d = r->img_dim == 2;
+            if (!dim_1d && r->img_dim != 1 && !dim_3d) {
+                skip_image(r, "layered image deferred to #657"); break;
             }
             if (dim_1d && r->height != 1) { skip_image(r, "1D image has non-unit height"); break; }
+            if (!r->depth || (!dim_3d && r->depth != 1)) {
+                skip_image(r, "image depth does not match its dimensionality"); break;
+            }
+            if (dim_3d && r->depth > 1 && r->tile_mode &&
+                !tile_mode_supports_volume(r->tile_mode)) {
+                skip_image(r, "3D tile mode has no volume address pattern"); break;
+            }
+            // Multiple U# bindings may intentionally name the same guest surface (read/modify/write
+            // views of one UE4 volume). They must see one Vulkan image and produce one guest
+            // writeback; independent images let an unwritten alias clobber the written result.
+            if (bi.storage) {
+                for (size_t j = 0; j < i; j++) {
+                    const BoundImage& prior = images[j];
+                    const ShaderResource* p = prior.resource;
+                    if (!prior.storage || !p || p->gpu_addr != r->gpu_addr ||
+                        p->width != r->width || p->height != r->height || p->depth != r->depth ||
+                        p->format != r->format || p->num_components != r->num_components ||
+                        p->tile_mode != r->tile_mode || p->img_dim != r->img_dim)
+                        continue;
+                    bi.alias_of = prior.alias_of == SIZE_MAX ? j : prior.alias_of;
+                    const BoundImage& owner = images[bi.alias_of];
+                    bi.image = owner.image; bi.memory = owner.memory; bi.view = owner.view;
+                    bi.guest_bytes = owner.guest_bytes;
+                    staging_bytes[i] = staging_bytes[bi.alias_of];
+                    if (trace)
+                        std::fprintf(stderr, "[compute]   image-alias binding=%u -> binding=%u addr=0x%llx\n",
+                                     bi.binding, owner.binding, (unsigned long long)r->gpu_addr);
+                    break;
+                }
+                if (bi.alias_of != SIZE_MAX) continue;
+            }
+            const VkDeviceSize volume_texels = static_cast<VkDeviceSize>(r->width) * r->height * r->depth;
             const uint32_t texel_bytes = bi.storage ? 16u : 4u;   // uvec4 raw channels / RGBA8
-            const VkDeviceSize sbytes = static_cast<VkDeviceSize>(r->width) * r->height * texel_bytes;
+            const VkDeviceSize sbytes = volume_texels * texel_bytes;
             if (!sbytes || sbytes > kMaxComputeImageBytes) {
                 skip_image(r, "expanded image exceeds the 256 MiB backend bound"); break;
             }
@@ -525,46 +584,78 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Fill the upload staging bytes.
             std::vector<uint8_t> upload((size_t)sbytes, 0);
             if (bi.storage) {
-                if (r->tile_mode) { skip_image(r, "tiled storage surface (writeback would corrupt)"); break; }
+                if (r->tile_mode && !dim_3d) {
+                    skip_image(r, "tiled 1D/2D storage writeback deferred"); break;
+                }
                 if (!storage_unpack_supported(r->format) || !storage_pack_supported(r->format)) {
                     skip_image(r, "storage format has no channel pack/unpack yet"); break; }
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
                 const size_t guest_texel = (size_t)cb * nc;
-                const size_t texels = (size_t)r->width * r->height;
-                const uint64_t guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
-                if (!guest_bytes || guest_bytes > UINT32_MAX || guest_bytes > r->size) {
+                const size_t texels = (size_t)volume_texels;
+                const uint64_t linear_guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
+                const size_t guest_bytes = r->tile_mode
+                    ? (r->depth > 1
+                           ? tiled_volume_bytes(r->width, r->height, r->depth, r->tile_mode,
+                                                static_cast<uint32_t>(guest_texel))
+                           : tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
+                                                 static_cast<uint32_t>(guest_texel)))
+                    : static_cast<size_t>(linear_guest_bytes);
+                if (!linear_guest_bytes || linear_guest_bytes > SIZE_MAX || !guest_bytes ||
+                    guest_bytes > UINT32_MAX || (!r->tile_mode && guest_bytes > r->size)) {
                     skip_image(r, "storage backing size is invalid"); break;
                 }
-                const uint8_t* src = resource_bytes(r);
+                bi.guest_bytes = guest_bytes;
+                const uint8_t* src = resource_bytes_for(r, guest_bytes);
                 const bool readable = (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
+                if (trace) bi.before_hash = fnv1a(src, guest_bytes);
+                std::vector<uint8_t> linear((size_t)linear_guest_bytes, 0);
+                if (r->tile_mode && r->depth > 1) {
+                    if (!detile_volume(linear.data(), src, guest_bytes, r->width, r->height,
+                                       r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                        skip_image(r, "storage volume detile failed"); break;
+                    }
+                } else if (r->tile_mode) {
+                    detile_surface(linear.data(), src, r->width, r->height, r->tile_mode, 0,
+                                   static_cast<uint32_t>(guest_texel));
+                } else {
+                    std::memcpy(linear.data(), src, linear.size());
+                }
                 for (size_t t = 0; t < texels; t++)
-                    storage_unpack_texel(src + t * guest_texel, r->format, nc,
+                    storage_unpack_texel(linear.data() + t * guest_texel, r->format, nc,
                                          reinterpret_cast<uint32_t*>(upload.data()) + t * 4);
             } else {
-                if (r->img_dim != 1) { skip_image(r, "non-2D sampled texture"); break; }
                 const uint32_t bpb = bc_block_bytes(r->format);
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
                 const bool rgba8 = r->format == DataFormat::Unorm8 && nc == 4;
+                const bool uint8 = r->format == DataFormat::Uint8 && nc == 4;
                 const bool r8 = r->format == DataFormat::Unorm8 && nc == 1;
                 const bool f16 = r->format == DataFormat::Float16 && nc >= 1 && nc <= 4;
+                const bool r11g11b10 = r->format == DataFormat::Float10_11_11 && nc == 3;
                 size_t need;                                       // guest bytes the decode reads
-                if (bpb) {
+                if (bpb && dim_3d) {
+                    skip_image(r, "block-compressed 3D texture deferred"); break;
+                } else if (bpb) {
                     const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
                     need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
                                         : (size_t)bw * bh * bpb;
-                } else if (rgba8 || r8 || f16) {
-                    const uint32_t bpt = cb * nc;
-                    need = r->tile_mode ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt)
-                                        : (size_t)r->width * r->height * bpt;
+                } else if (rgba8 || uint8 || r8 || f16 || r11g11b10) {
+                    const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
+                    need = r->tile_mode
+                        ? (dim_3d && r->depth > 1
+                               ? tiled_volume_bytes(r->width, r->height, r->depth,
+                                                    r->tile_mode, bpt)
+                                  : tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt))
+                        : (size_t)volume_texels * bpt;
                 } else { skip_image(r, "sampled format not decodable yet"); break; }
                 if (!need || need > kMaxComputeImageBytes || need > UINT32_MAX) {
                     skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
                 }
-                const uint8_t* src = resource_bytes(r);
+                bi.guest_bytes = need;
+                const uint8_t* src = resource_bytes_for(r, need);
                 const bool readable = (r->host_data && r->host_data_size >= need) ||
                                       guest_readable(r->gpu_addr, (uint32_t)need);
                 if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
@@ -579,14 +670,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                            r->width, r->height, r->format)) {
                         skip_image(r, "BC decode unsupported"); break; }
                 } else {
-                    const uint32_t bpt = cb * nc;
-                    std::vector<uint8_t> lin((size_t)r->width * r->height * bpt, 0);
-                    if (r->tile_mode)
+                    const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
+                    std::vector<uint8_t> lin((size_t)volume_texels * bpt, 0);
+                    if (r->tile_mode && dim_3d && r->depth > 1) {
+                        if (!detile_volume(lin.data(), src, need, r->width, r->height, r->depth,
+                                           r->tile_mode, bpt)) {
+                            skip_image(r, "sampled volume detile failed"); break;
+                        }
+                    } else if (r->tile_mode) {
                         detile_surface(lin.data(), src, r->width, r->height, r->tile_mode, 0, bpt);
-                    else
+                    } else {
                         std::memcpy(lin.data(), src, lin.size());
-                    const size_t texels = (size_t)r->width * r->height;
-                    if (rgba8) {                                    // RGBA8: direct
+                    }
+                    const size_t texels = (size_t)volume_texels;
+                    if (rgba8 || uint8 || r11g11b10) {              // Native 4-byte sampled texels
                         std::memcpy(upload.data(), lin.data(), lin.size());
                     } else if (r8) {                                // R8: broadcast coverage to RGBA
                         for (size_t t = 0; t < texels; t++) {
@@ -616,25 +713,36 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
             sci.size = sbytes;
             sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-            if (vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]) != VK_SUCCESS) { images_ready = false; break; }
+            if (!vk_ok(vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]),
+                       "image-staging-buffer")) { images_ready = false; break; }
             VkMemoryRequirements sreq{};
             vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
             const uint32_t staging_memory_type = ctx.host_memory_type(sreq.memoryTypeBits);
             staging_memory[i] = ctx.allocate_memory(sreq.size, staging_memory_type);
-            if (!staging_memory[i] ||
-                vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0) != VK_SUCCESS) {
+            if (!vk_handle_ok(staging_memory[i], "image-staging-memory") ||
+                !vk_ok(vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0),
+                       "image-staging-bind")) {
                 images_ready = false; break; }
             { void* mapped = nullptr;
-              if (vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped) != VK_SUCCESS) {
+              if (!vk_ok(vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped),
+                         "image-staging-map")) {
                   images_ready = false; break; }
               std::memcpy(mapped, upload.data(), (size_t)sbytes);
               vkUnmapMemory(ctx.device, staging_memory[i]); }
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-            ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : VK_IMAGE_TYPE_2D;
-            ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT : VK_FORMAT_R8G8B8A8_UNORM;
-            ici.extent = {r->width, r->height, 1};
+            ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : (dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D);
+            const bool sampled_uint8 = !bi.storage && r->format == DataFormat::Uint8 &&
+                                       (r->num_components ? r->num_components : 1) == 4;
+            const bool sampled_r11g11b10 = !bi.storage &&
+                r->format == DataFormat::Float10_11_11 &&
+                (r->num_components ? r->num_components : 1) == 3;
+            ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT
+                                    : (sampled_uint8 ? VK_FORMAT_R8G8B8A8_UINT
+                                       : sampled_r11g11b10 ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                                                           : VK_FORMAT_R8G8B8A8_UNORM);
+            ici.extent = {r->width, r->height, r->depth};
             ici.mipLevels = 1;
             ici.arrayLayers = 1;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -643,17 +751,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                     : VK_IMAGE_USAGE_SAMPLED_BIT) |
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT;
             ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            if (vkCreateImage(ctx.device, &ici, nullptr, &bi.image) != VK_SUCCESS) { images_ready = false; break; }
+            if (!vk_ok(vkCreateImage(ctx.device, &ici, nullptr, &bi.image),
+                       "image-create")) { images_ready = false; break; }
             VkMemoryRequirements ireq{};
             vkGetImageMemoryRequirements(ctx.device, bi.image, &ireq);
             const uint32_t image_memory_type = device_memory_type(ireq.memoryTypeBits);
             bi.memory = ctx.allocate_memory(ireq.size, image_memory_type);
-            if (!bi.memory ||
-                vkBindImageMemory(ctx.device, bi.image, bi.memory, 0) != VK_SUCCESS) {
+            if (!vk_handle_ok(bi.memory, "image-memory") ||
+                !vk_ok(vkBindImageMemory(ctx.device, bi.image, bi.memory, 0), "image-bind")) {
                 images_ready = false; break; }
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             vci.image = bi.image;
-            vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D : VK_IMAGE_VIEW_TYPE_2D;
+            vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D
+                                  : (dim_3d ? VK_IMAGE_VIEW_TYPE_3D : VK_IMAGE_VIEW_TYPE_2D);
             vci.format = ici.format;
             if (!bi.storage) {
                 // T# DST_SEL channel routing (SQ_SEL: 0=0, 1=1, 4=R, 5=G, 6=B, 7=A) — same mapping
@@ -673,7 +783,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                   sel(r->swizzle[2]), sel(r->swizzle[3])};
             }
             vci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, ici.arrayLayers};
-            if (vkCreateImageView(ctx.device, &vci, nullptr, &bi.view) != VK_SUCCESS) { images_ready = false; break; }
+            if (!vk_ok(vkCreateImageView(ctx.device, &vci, nullptr, &bi.view),
+                       "image-view")) { images_ready = false; break; }
             if (!bi.storage) {
                 // Sampler from the decoded S# (mag/min filter, SQ_TEX CLAMP wrap enums) — the same
                 // fields the renderer honors; defaults reproduce LINEAR/clamp.
@@ -686,14 +797,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 };
                 VkSamplerCreateInfo smci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
-                smci.magFilter = r->mag_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
-                smci.minFilter = r->min_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
+                // Integer sampled formats cannot be linearly filtered in Vulkan. DOLL's UINT8x4
+                // volume is consumed by image_load (texel fetch), so the sampler is unused there;
+                // nearest also preserves integer semantics if a shader samples such a descriptor.
+                smci.magFilter = sampled_uint8 ? VK_FILTER_NEAREST
+                                               : (r->mag_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
+                smci.minFilter = sampled_uint8 ? VK_FILTER_NEAREST
+                                               : (r->min_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
                 smci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
                 smci.addressModeU = wrap(r->addr_uvw[0]);
                 smci.addressModeV = wrap(r->addr_uvw[1]);
                 smci.addressModeW = wrap(r->addr_uvw[2]);
                 smci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-                if (vkCreateSampler(ctx.device, &smci, nullptr, &bi.sampler) != VK_SUCCESS) {
+                if (!vk_ok(vkCreateSampler(ctx.device, &smci, nullptr, &bi.sampler), "image-sampler")) {
                     images_ready = false; break; }
             }
         }
@@ -712,7 +828,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkDescriptorSetLayoutCreateInfo dlci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
         dlci.bindingCount = static_cast<uint32_t>(layout_bindings.size());
         dlci.pBindings = layout_bindings.data();
-        if (vkCreateDescriptorSetLayout(ctx.device, &dlci, nullptr, &descriptor_layout) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreateDescriptorSetLayout(ctx.device, &dlci, nullptr, &descriptor_layout),
+                   "descriptor-layout")) break;
         uint32_t sampled_count = 0, storage_image_count = 0;
         for (const auto& im : images) (im.storage ? storage_image_count : sampled_count)++;
         VkDescriptorPoolSize pool_sizes[3]; uint32_t pool_size_count = 0;
@@ -727,12 +844,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         dpci.maxSets = 1;
         dpci.poolSizeCount = pool_size_count;
         dpci.pPoolSizes = pool_sizes;
-        if (vkCreateDescriptorPool(ctx.device, &dpci, nullptr, &descriptor_pool) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreateDescriptorPool(ctx.device, &dpci, nullptr, &descriptor_pool),
+                   "descriptor-pool")) break;
         VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
         dsai.descriptorPool = descriptor_pool;
         dsai.descriptorSetCount = 1;
         dsai.pSetLayouts = &descriptor_layout;
-        if (vkAllocateDescriptorSets(ctx.device, &dsai, &descriptor_set) != VK_SUCCESS) break;
+        if (!vk_ok(vkAllocateDescriptorSets(ctx.device, &dsai, &descriptor_set),
+                   "descriptor-set")) break;
 
         std::vector<VkDescriptorBufferInfo> buffer_infos(buffers.size());
         std::vector<VkDescriptorImageInfo> image_infos(images.size());
@@ -762,34 +881,37 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkShaderModuleCreateInfo smci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
         smci.codeSize = item.spirv.size() * sizeof(uint32_t);
         smci.pCode = item.spirv.data();
-        if (vkCreateShaderModule(ctx.device, &smci, nullptr, &shader) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreateShaderModule(ctx.device, &smci, nullptr, &shader), "shader-module")) break;
         VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
         plci.setLayoutCount = 1;
         plci.pSetLayouts = &descriptor_layout;
-        if (vkCreatePipelineLayout(ctx.device, &plci, nullptr, &pipeline_layout) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreatePipelineLayout(ctx.device, &plci, nullptr, &pipeline_layout),
+                   "pipeline-layout")) break;
         VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
         cpci.stage = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
         cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
         cpci.stage.module = shader;
         cpci.stage.pName = "main";
         cpci.layout = pipeline_layout;
-        if (vkCreateComputePipelines(ctx.device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipeline) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreateComputePipelines(ctx.device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipeline),
+                   "compute-pipeline")) break;
 
         VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
         pci.queueFamilyIndex = ctx.queue_family;
-        if (vkCreateCommandPool(ctx.device, &pci, nullptr, &command_pool) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreateCommandPool(ctx.device, &pci, nullptr, &command_pool), "command-pool")) break;
         VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
         cbai.commandPool = command_pool;
         cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         cbai.commandBufferCount = 1;
         VkCommandBuffer command = VK_NULL_HANDLE;
-        if (vkAllocateCommandBuffers(ctx.device, &cbai, &command) != VK_SUCCESS) break;
+        if (!vk_ok(vkAllocateCommandBuffers(ctx.device, &cbai, &command), "command-buffer")) break;
         VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-        if (vkBeginCommandBuffer(command, &begin) != VK_SUCCESS) break;
+        if (!vk_ok(vkBeginCommandBuffer(command, &begin), "command-begin")) break;
         // Upload every image: UNDEFINED -> TRANSFER_DST, copy the staged texels in, -> GENERAL.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
+            if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_dst.srcAccessMask = 0;
@@ -803,7 +925,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
             VkBufferImageCopy region{};
             region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            region.imageExtent = {r->width, r->height, 1};
+            region.imageExtent = {r->width, r->height, r->depth};
             vkCmdCopyBufferToImage(command, staging[i], bi.image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
             VkImageMemoryBarrier to_general = to_dst;
@@ -823,7 +945,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
-            if (!bi.storage) continue;
+            if (!bi.storage || bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -837,18 +959,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_src);
             VkBufferImageCopy region{};
             region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            region.imageExtent = {r->width, r->height, 1};
+            region.imageExtent = {r->width, r->height, r->depth};
             vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    staging[i], 1, &region);
         }
-        if (vkEndCommandBuffer(command) != VK_SUCCESS) break;
+        if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
         VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
-        if (vkCreateFence(ctx.device, &fci, nullptr, &fence) != VK_SUCCESS) break;
+        if (!vk_ok(vkCreateFence(ctx.device, &fci, nullptr, &fence), "fence")) break;
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &command;
-        if (vkQueueSubmit(ctx.queue, 1, &submit, fence) != VK_SUCCESS) break;
-        if (vkWaitForFences(ctx.device, 1, &fence, VK_TRUE, 30ull * 1000 * 1000 * 1000) != VK_SUCCESS) break;
+        if (!vk_ok(vkQueueSubmit(ctx.queue, 1, &submit, fence), "queue-submit")) break;
+        if (!vk_ok(vkWaitForFences(ctx.device, 1, &fence, VK_TRUE,
+                                   30ull * 1000 * 1000 * 1000), "queue-wait")) break;
 
         bool readback_ok = true;
         for (auto& buffer : buffers) {
@@ -875,11 +998,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         if (!readback_ok) break;
         // Storage-image writeback (#590): pack the kernel's raw uvec4 channel texels back into the
-        // guest surface's real format (tile_mode==0 was enforced at creation, so linear rows are the
-        // correct layout) and notify the render side exactly like the buffer path.
+        // guest surface's real format, then restore its linear or 3D tiled address layout and notify
+        // the render side exactly like the buffer path.
         for (size_t i = 0; i < images.size() && readback_ok; i++) {
-            const BoundImage& bi = images[i];
-            if (!bi.storage) continue;
+            BoundImage& bi = images[i];
+            if (!bi.storage || bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
             void* mapped = nullptr;
             if (vkMapMemory(ctx.device, staging_memory[i], 0, staging_bytes[i], 0, &mapped) != VK_SUCCESS) {
@@ -889,15 +1012,36 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const uint32_t cb = data_format_bytes(r->format);
             const uint32_t nc = r->num_components ? r->num_components : 1;
             const size_t guest_texel = (size_t)cb * nc;
-            const size_t texels = (size_t)r->width * r->height;
-            uint8_t* destination = resource_bytes(r);
+            const size_t texels = (size_t)r->width * r->height * r->depth;
+            std::vector<uint8_t> linear(texels * guest_texel, 0);
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+            if (trace) {
+                for (size_t t = 0; t < texels; t++)
+                    for (uint32_t c = 0; c < 4; c++)
+                        bi.nonzero_channels += channels[t * 4 + c] != 0;
+            }
             for (size_t t = 0; t < texels; t++)
-                storage_pack_texel(channels + t * 4, r->format, nc, destination + t * guest_texel);
-            notify_guest_gpu_write(r->gpu_addr, texels * guest_texel);
+                storage_pack_texel(channels + t * 4, r->format, nc,
+                                   linear.data() + t * guest_texel);
+            uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+            if (r->tile_mode && r->depth > 1) {
+                if (!tile_volume(destination, bi.guest_bytes, linear.data(), r->width, r->height,
+                                 r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                    readback_ok = false;
+                    vkUnmapMemory(ctx.device, staging_memory[i]);
+                    break;
+                }
+            } else if (r->tile_mode) {
+                tile_surface(destination, linear.data(), r->width, r->height, r->tile_mode, 0,
+                             static_cast<uint32_t>(guest_texel));
+            } else {
+                std::memcpy(destination, linear.data(), linear.size());
+            }
+            if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
+            notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
-                                   r->gpu_addr, texels * guest_texel,
+                                   r->gpu_addr, bi.guest_bytes,
                                    item.submit_no, item.dispatch_index,
                                    item.command_order, item.code_addr);
             vkUnmapMemory(ctx.device, staging_memory[i]);
@@ -930,6 +1074,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                          buffer.resource->size >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
                          buffer.resource->size >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
                          buffer.resource->size >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
+        }
+        for (const auto& image : images) {
+            if (!image.storage || !image.resource || image.alias_of != SIZE_MAX) continue;
+            const uint8_t* bytes = resource_bytes_for(image.resource, image.guest_bytes);
+            std::fprintf(stderr,
+                         "[compute]   image-writeback binding=%u addr=0x%llx size=%zu "
+                         "hash=%016llx->%016llx nonzero-ch=%llu "
+                         "first=%08x,%08x,%08x,%08x\n",
+                         image.binding, (unsigned long long)image.resource->gpu_addr,
+                         image.guest_bytes, (unsigned long long)image.before_hash,
+                         (unsigned long long)image.after_hash,
+                         (unsigned long long)image.nonzero_channels,
+                         image.guest_bytes >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
+                         image.guest_bytes >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
+                         image.guest_bytes >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
+                         image.guest_bytes >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
         }
     }
     cleanup();

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -55,7 +55,7 @@ struct TextureDecodeKey {
     uint32_t cls = 0;
     uint32_t format = 0;
     uint32_t num_components = 0;
-    uint32_t width = 0, height = 0;
+    uint32_t width = 0, height = 0, depth = 1;
     uint32_t tile_mode = 0;
     uint32_t img_dim = 0;
     bool operator==(const TextureDecodeKey&) const = default;
@@ -71,7 +71,7 @@ struct TextureDecodeKeyHash {
             hash *= 1099511628211ull;
         };
         mix(key.gpu_addr); mix(key.host_data); mix(key.host_data_size); mix(key.size);
-        mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height);
+        mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height); mix(key.depth);
         mix(key.tile_mode); mix(key.img_dim);
         return hash;
     }
@@ -335,18 +335,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const TextureDecodeKey decode_key{
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
                             r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
-                            static_cast<uint32_t>(r.format), r.num_components, tw, th,
+                            static_cast<uint32_t>(r.format), r.num_components, tw, th, r.depth,
                             r.tile_mode, r.img_dim,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
-                        const bool has_live_rtt = live_rtt != g_rtt.end() && live_rtt->second.w &&
+                        const bool has_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() && live_rtt->second.w &&
                             live_rtt->second.h && !live_rtt->second.rgba.empty();
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
+                        const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
                         const bool persistent_cache_eligible =
                             !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") && persistent_decode_limit &&
-                            !has_live_rtt && !is_cube && r.cls == RC::Texture &&
+                            !has_live_rtt && r.img_dim == 1u && r.cls == RC::Texture &&
                             r.format == prosper::gpu::DataFormat::Unorm8 && r.num_components == 4 &&
                             !getenv("PROSPER_NODETILE") && prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const size_t persistent_source_size = persistent_cache_eligible
@@ -385,12 +386,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.tex_rgba = decoded_reuse->pixels;
                             fr.tw = tw;
                             fr.th = decoded_reuse->output_height;
+                            fr.td = is_volume ? r.depth : 1u;
+                            fr.img_dim = r.img_dim;
                             narrow_done = decoded_reuse->narrow;
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done});
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
-                        size_t nb = (size_t)tw * th * 4 * (is_cube ? 6u : 1u);
+                        const size_t volume_texels = (size_t)tw * th * (is_volume ? r.depth : 1u);
+                        size_t nb = volume_texels * 4 * (is_cube ? 6u : 1u);
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
                         texture_pixels.resize(nb);
@@ -437,7 +441,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
-                        if (rtt_on) { auto rit = g_rtt.find(r.gpu_addr);
+                        if (rtt_on && !is_volume) { auto rit = g_rtt.find(r.gpu_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && !rit->second.rgba.empty()) {
                                 const RttSurf& s = rit->second;
                                 const size_t expected = static_cast<size_t>(tw) * th * 4;
@@ -538,18 +542,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // unit-tested, but the [0,1] clamp loses >1.0 bloom energy (native
                             // VK_FORMAT_R16G16B16A16_SFLOAT upload is the documented follow-up).
                             const uint32_t nc = bpt / 2;                    // fp16 components per texel
-                            std::vector<uint8_t> hlin((size_t)tw * th * bpt, 0);
+                            std::vector<uint8_t> hlin(volume_texels * bpt, 0);
                             bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                             if (tiled) {
-                                size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
+                                size_t tbytes = is_volume
+                                    ? prosper::gpu::tiled_volume_bytes(tw, th, r.depth, r.tile_mode, bpt)
+                                    : prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
                                 size_t got = copy_resource(traw.data(), r.gpu_addr, tbytes);
                                 if (got < hlin.size()) copy_resource(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
-                                else prosper::gpu::detile_surface(hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                                else if (is_volume) prosper::gpu::detile_volume(
+                                    hlin.data(), traw.data(), got, tw, th, r.depth, r.tile_mode, bpt);
+                                else prosper::gpu::detile_surface(
+                                    hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
                                 copy_resource(hlin.data(), r.gpu_addr, hlin.size());
                             }
-                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                            for (size_t t = 0; t < volume_texels; t++) {
                                 uint8_t* p = &texture_pixels[t * 4];
                                 for (uint32_t c = 0; c < 4; c++) {
                                     if (c < nc) {
@@ -566,10 +575,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // with the matching bpe geometry (1 B -> 64x64 micro-tiles, #119), then expand
                             // each texel to grayscale RGBA8 (replicate to R,G,B,A) so the sampling shader
                             // reads the coverage in ANY channel it uses (.r for a font atlas, .a for a mask).
-                            std::vector<uint8_t> nlin((size_t)tw * th * bpt, 0);
+                            std::vector<uint8_t> nlin(volume_texels * bpt, 0);
                             bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                             if (tiled) {
-                                size_t tbytes = prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
+                                size_t tbytes = is_volume
+                                    ? prosper::gpu::tiled_volume_bytes(tw, th, r.depth, r.tile_mode, bpt)
+                                    : prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
                                 size_t got = copy_resource(traw.data(), r.gpu_addr, tbytes);
                                 // PROSPER_DUMP_RAWTILE (narrow path): the single/dual-channel RAW TILED bytes,
@@ -585,11 +596,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     }
                                 }
                                 if (got < nlin.size()) copy_resource(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
-                                else prosper::gpu::detile_surface(nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                                else if (is_volume) prosper::gpu::detile_volume(
+                                    nlin.data(), traw.data(), got, tw, th, r.depth, r.tile_mode, bpt);
+                                else prosper::gpu::detile_surface(
+                                    nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
                                 copy_resource(nlin.data(), r.gpu_addr, nlin.size());
                             }
-                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                            for (size_t t = 0; t < volume_texels; t++) {
                                 uint8_t v = nlin[t * bpt];   // first (coverage) channel
                                 uint8_t* p = &texture_pixels[t * 4];
                                 p[0] = p[1] = p[2] = p[3] = v;
@@ -616,10 +630,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!rtt_hit && !cube_done && !bcb && !narrow_done && !f16_done && !getenv("PROSPER_NODETILE") && (auto_tiled || (dt && atoi(dt) != 0))) {
+                        if (!rtt_hit && !cube_done && !bcb && !narrow_done && !f16_done &&
+                            !getenv("PROSPER_NODETILE") &&
+                            (auto_tiled || (!is_volume && dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
                             const uint32_t pitch = getenv("PROSPER_PITCH") ? (uint32_t)atoi(getenv("PROSPER_PITCH")) : 0;
-                            size_t tiled_bytes = prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
+                            size_t tiled_bytes = is_volume
+                                ? prosper::gpu::tiled_volume_bytes(tw, th, r.depth, tmode, 4)
+                                : prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
                             std::vector<uint8_t> tiled(tiled_bytes, 0);
                             size_t got = copy_resource(tiled.data(), r.gpu_addr, tiled_bytes);
                             if (got < nb)
@@ -642,7 +660,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     if (FILE* bf = fopen(bn, "wb")) { fwrite(tiled.data(), 1, tiled.size(), bf); fclose(bf); }
                                 }
                             }
-                            prosper::gpu::detile_surface(texture_pixels.data(), tiled.data(), tw, th, tmode, pitch);
+                            if (is_volume) prosper::gpu::detile_volume(
+                                texture_pixels.data(), tiled.data(), got, tw, th, r.depth, tmode, 4);
+                            else prosper::gpu::detile_surface(
+                                texture_pixels.data(), tiled.data(), tw, th, tmode, pitch);
                         }
                         // Packed R11G11B10F (Gen5 IMG_FMT 36 -> DataFormat::Float10_11_11, #294): UE4's
                         // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
@@ -650,7 +671,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
                         if (!rtt_hit && r.format == prosper::gpu::DataFormat::Float10_11_11) {
                             uint8_t* tp = texture_pixels.data();
-                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                            for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);
                                 const float fc[3] = { prosper::gpu::f11_to_float((uint16_t)(v & 0x7FFu)),
                                                       prosper::gpu::f11_to_float((uint16_t)((v >> 11) & 0x7FFu)),
@@ -666,7 +687,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // field to the RGBA8 image format used by this renderer before sampling.
                         if (!rtt_hit && r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
                             uint8_t* tp = texstore.back().data();
-                            for (size_t t = 0; t < (size_t)tw * th; t++) {
+                            for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);
                                 prosper::gpu::unorm2_10_10_10_to_rgba8(v, tp + t * 4);
                             }
@@ -676,7 +697,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // divergence precedes format conversion or enters through renderer-owned state.
                         if (resource_hash_w == tw && resource_hash_h == th) {
                             const size_t raw_size = std::min<size_t>(
-                                r.size ? r.size : (size_t)tw * th * 4, 64u << 20);
+                                r.size ? r.size : volume_texels * 4, 64u << 20);
                             std::vector<uint8_t> raw(raw_size, 0);
                             const size_t raw_got = copy_resource(raw.data(), r.gpu_addr, raw.size());
                             auto fnv = [](const uint8_t* data, size_t size) {
@@ -729,13 +750,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Apply the synthetic texture after every decode/conversion step. Applying it before
                         // auto-detile let the real tiled bytes overwrite the checker, producing a false-negative
                         // sampling diagnosis (#522).
-                        if (getenv("PROSPER_TESTTEX")) {
-                            for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
-                                uint8_t* p = &texture_pixels[((size_t)y * tw + x) * 4];
-                                bool ck = ((x / 64) ^ (y / 64)) & 1;
-                                p[0] = (uint8_t)(255 * x / tw); p[1] = (uint8_t)(255 * y / th);
-                                p[2] = ck ? 200 : 40; p[3] = 255;
-                            }
+                        const char* test_texture = getenv("PROSPER_TESTTEX");
+                        const char* test_texture_binding = getenv("PROSPER_TESTTEX_BINDING");
+                        const bool test_this_texture = test_texture &&
+                            (!test_texture_binding ||
+                             strtoul(test_texture_binding, nullptr, 0) == r.binding);
+                        if (test_this_texture) {
+                            const uint32_t slices = is_volume ? std::max(r.depth, 1u) : 1u;
+                            for (uint32_t z = 0; z < slices; ++z)
+                                for (uint32_t y = 0; y < th; ++y)
+                                    for (uint32_t x = 0; x < tw; ++x) {
+                                        uint8_t* p = &texture_pixels[
+                                            (((size_t)z * th + y) * tw + x) * 4];
+                                        bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
+                                        p[0] = (uint8_t)(255 * x / tw);
+                                        p[1] = (uint8_t)(255 * y / th);
+                                        p[2] = ck ? 200 : 40;
+                                        p[3] = 255;
+                                    }
                         }
                         // This 256x16 sparse palette is addressed like 16 blue slices, each 16 texels wide.
                         // The identity probe preserves source color through shaders using
@@ -782,6 +814,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                         }
                         fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
+                        fr.td = is_volume ? r.depth : 1u;
+                        fr.img_dim = r.img_dim;
                         if (persistent_cache_eligible) {
                             persistent_validation_scratch.resize(persistent_source_size);
                             const size_t got = copy_resource(
@@ -882,7 +916,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             RenderClock::now() - resource_timing_start).count();
                         if (fr.is_texture()) {
                             pending_timing.textures++;
-                            pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * 4;
+                            pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * fr.td * 4;
                             pending_timing.texture_ms += elapsed;
                             const uint64_t detail_min_submit = getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT")
                                 ? strtoull(getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT"), nullptr, 0) : 0;
@@ -937,7 +971,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     for (const auto& r : resources) if (r.set == set && r.binding == d.binding) ++count;
                     const bool wants_buffer = d.kind == prosper::gpu::SpirvDescriptorKind::StorageBuffer;
                     const uint64_t available = first == resources.end() ? 0 :
-                        (first->is_texture() ? (uint64_t)first->tw * first->th * 4 : first->dwords.size() * 4);
+                        (first->is_texture() ? (uint64_t)first->tw * first->th * first->td * 4
+                                             : first->dwords.size() * 4);
                     const bool wrong_type = first != resources.end() && (first->is_texture() == wants_buffer);
                     const bool undersized = wants_buffer && available < std::max<uint64_t>(d.required_bytes, 4);
                     resources.erase(std::remove_if(resources.begin(), resources.end(), [&](const auto& r) {

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -1,6 +1,7 @@
 // agc_shader_layout.cpp — see agc_shader_layout.hpp. V# decode + the front-half resource-table build.
 #include "agc_shader_layout.hpp"
 #include <algorithm>
+#include <climits>
 #include <cstdio>
 #include <cstdlib>
 
@@ -189,6 +190,7 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.format    = (t[1] >> 20) & 0x1FFu;                                                           // Format
     d.tile_mode = (t[3] >> 20) & 0x1Fu;                                                            // TileMode (SW_MODE)
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
+    d.depth     = d.type == 10 ? ((t[4] & 0x1FFFu) + 1u) : 1u;                                     // DEPTH (3D)
     d.dst_sel[0] = (uint8_t)((t[3] >> 0) & 0x7u);   // DST_SEL_X (WORD3 [2:0])
     d.dst_sel[1] = (uint8_t)((t[3] >> 3) & 0x7u);   // DST_SEL_Y ([5:3])
     d.dst_sel[2] = (uint8_t)((t[3] >> 6) & 0x7u);   // DST_SEL_Z ([8:6])
@@ -407,6 +409,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.gpu_addr      = d.base;
             r.width         = d.width;
             r.height        = d.height;
+            r.depth         = d.depth;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
             r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
             r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];   // T# DST_SEL channel remap (#261)
@@ -419,8 +422,11 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 fprintf(stderr, "[t#] SRGB texture fmt=%u %ux%u (binding %u)\n", d.format, d.width, d.height, r.binding);
             // Backing byte size: block-compressed surfaces store one bytes_per_block unit per 4x4 block
             // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
-            r.size          = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
-                                     : (d.width * d.height * fi.bytes_per_block);
+            const uint64_t backing_bytes = is_bcn
+                ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * d.depth * fi.bytes_per_block
+                : static_cast<uint64_t>(d.width) * d.height * d.depth * fi.bytes_per_block;
+            if (!backing_bytes || backing_bytes > UINT32_MAX) continue;
+            r.size = static_cast<uint32_t>(backing_bytes);
             // SGPR-resident T#: DIRECT provenance (image_sample SRSRC SGPR). EUD-resident T#: INDIRECT
             // (the s_load immediate = tsrt), and sgpr_base must be invalid so a stray by_sgpr_base for an
             // unrelated op reading that (bogus, out-of-file) SGPR number can't spuriously match it (#382).

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -115,7 +115,7 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 // in unified guest memory. `tile_mode` 0 = linear (no detiling needed); non-zero = GPU-tiled.
 struct DecodedImageDescriptor {
     uint64_t base = 0;
-    uint32_t width = 0, height = 0;
+    uint32_t width = 0, height = 0, depth = 1;
     uint32_t format = 0;      // Gen5 surface-format enum (fields[1] bits 20..28)
     uint32_t tile_mode = 0;   // 0 = linear
     uint8_t  type = 0;        // SQ_RSRC_IMG dim (GFX10: 8=1D, 9=2D, 10=3D, 11=CUBE, 12=1D_ARRAY, 13=2D_ARRAY).

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 8;
+constexpr uint32_t kVersion = 9;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -264,7 +264,7 @@ uint64_t checked_mul(uint64_t a, uint64_t b) {
 uint64_t resource_footprint(const ShaderResource& r) {
     uint64_t result = r.size;
     if (r.cls != ResourceClass::Texture && r.cls != ResourceClass::StorageImage) return result;
-    const uint64_t faces = r.img_dim == 3u ? 6u : 1u;
+    const uint64_t layers = r.img_dim == 3u ? 6u : (r.img_dim == 2u ? std::max(r.depth, 1u) : 1u);
     uint32_t w = r.width ? r.width : 4, h = r.height ? r.height : 4;
     const uint32_t bc = bc_block_bytes(r.format);
     uint64_t decoded = 0;
@@ -279,7 +279,7 @@ uint64_t resource_footprint(const ShaderResource& r) {
         decoded = tile_mode_is_tiled(r.tile_mode) ? tiled_surface_bytes(w, h, r.tile_mode, 0, bpt)
                                                   : checked_mul(checked_mul(w, h), bpt);
     }
-    decoded = checked_mul(decoded, faces);
+    decoded = checked_mul(decoded, layers);
     return std::max(result, decoded);
 }
 
@@ -956,6 +956,20 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u8(seed.depth_valid); w.u8(seed.stencil_valid);
         w.bytes(seed.depth); w.bytes(seed.stencil);
     }
+    // v9 extends the resource contract with the base-level depth of 3D images. Keep the resource
+    // record itself byte-compatible with v1-v8 and append depths in deterministic table order, so old
+    // captures remain readable without duplicating every legacy table parser.
+    uint64_t resource_depth_count = 0;
+    for (const auto& draw : c.draws)
+        resource_depth_count += draw.vrt.resources.size() + draw.prt.resources.size();
+    for (const auto& compute : c.computes) resource_depth_count += compute.resources.resources.size();
+    if (resource_depth_count > UINT32_MAX) { error = "invalid resource depth count"; return false; }
+    w.u32(static_cast<uint32_t>(resource_depth_count));
+    auto write_depths = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources) w.u32(captured.resource.depth);
+    };
+    for (const auto& draw : c.draws) { write_depths(draw.vrt); write_depths(draw.prt); }
+    for (const auto& compute : c.computes) write_depths(compute.resources);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1202,6 +1216,30 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             }
             seed_total += plane_bytes;
         }
+    }
+    if (version >= 9) {
+        uint64_t expected_depths = 0;
+        for (const auto& draw : c.draws)
+            expected_depths += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected_depths += compute.resources.resources.size();
+        uint32_t depth_count = 0;
+        if (!r.u32(depth_count) || depth_count != expected_depths) {
+            error = "invalid resource depth count"; return false;
+        }
+        auto read_depths = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources)
+                if (!r.u32(captured.resource.depth) || !captured.resource.depth ||
+                    captured.resource.depth > 8192u) {
+                    error = "invalid resource depth";
+                    return false;
+                }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_depths(draw.vrt) || !read_depths(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_depths(compute.resources)) return false;
     }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1297,7 +1297,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         bool mapped = false;
                         for (auto& r0 : t.resources)
                             if (r0.cls == ResourceClass::Texture && r0.gpu_addr == d.base &&
-                                r0.width == d.width && r0.height == d.height) {
+                                r0.width == d.width && r0.height == d.height && r0.depth == d.depth) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
                                 if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
                             }
@@ -1318,15 +1318,18 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     ShaderResource r;
                     r.cls = ResourceClass::Texture;
                     r.format = fi.format; r.num_components = fi.num_components;
-                    r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
+                    r.gpu_addr = d.base; r.width = d.width; r.height = d.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
                     // T# TYPE -> MIMG dim (GFX10: 9=2D, 10=3D, 11=CUBE, 13=2D_ARRAY); a cube
                     // uploads as six vertically-stacked faces (#273 — see agc_shader_layout).
                     r.img_dim = image_type_to_dim(d.type);
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
-                    r.size = is_bcn ? (((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block)
-                                    : (d.width * d.height * fi.bytes_per_block);
+                    const uint64_t backing_bytes = is_bcn
+                        ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * d.depth * fi.bytes_per_block
+                        : static_cast<uint64_t>(d.width) * d.height * d.depth * fi.bytes_per_block;
+                    if (!backing_bytes || backing_bytes > UINT32_MAX) continue;
+                    r.size = static_cast<uint32_t>(backing_bytes);
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;   // ambiguous/absent key: pc-only provenance
                     r.fetch_pc   = u.use_pc;                       // per-instruction provenance (#273)
                     if (u.has_samp) {                     // paired S# (same SQ_IMG_SAMP decode as the sharp path)
@@ -1600,7 +1603,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                                                : ResourceClass::Texture;
                         for (auto& r0 : table->resources)
                             if (r0.cls == wanted &&
-                                r0.gpu_addr == d.base && r0.width == d.width && r0.height == d.height) {
+                                r0.gpu_addr == d.base && r0.width == d.width && r0.height == d.height &&
+                                r0.depth == d.depth) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
                                 if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
                             }
@@ -1619,18 +1623,18 @@ std::vector<ComputeItem> realize_compute_dispatches(
                         r.format = fi.format; r.num_components = fi.num_components;
                         const bool is_bcn = fi.block_width > 1;
                         const uint64_t bytes = is_bcn
-                            ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * fi.bytes_per_block
-                            : static_cast<uint64_t>(d.width) * d.height * fi.bytes_per_block;
+                            ? static_cast<uint64_t>((d.width + 3) / 4) * ((d.height + 3) / 4) * d.depth * fi.bytes_per_block
+                            : static_cast<uint64_t>(d.width) * d.height * d.depth * fi.bytes_per_block;
                         if (!bytes || bytes > UINT32_MAX) continue;
                         r.size = static_cast<uint32_t>(bytes);
                         r.srgb = fi.srgb;
                     } else {
-                        const uint64_t bytes = static_cast<uint64_t>(d.width) * d.height * 4;
+                        const uint64_t bytes = static_cast<uint64_t>(d.width) * d.height * d.depth * 4;
                         if (!bytes || bytes > UINT32_MAX) continue;
                         r.format = DataFormat::Unknown; r.num_components = 4;
                         r.size = static_cast<uint32_t>(bytes);
                     }
-                    r.gpu_addr = d.base; r.width = d.width; r.height = d.height;
+                    r.gpu_addr = d.base; r.width = d.width; r.height = d.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode;
                     r.img_dim = image_type_to_dim(d.type);
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
@@ -1639,6 +1643,27 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     r.fetch_pc = u.use_pc;               // per-use pc provenance (the image op)
                     table->resources.push_back(r);
                 }
+            }
+        }
+        // A direct compute "constant buffer" can actually be an SRT address pair consumed by
+        // s_load_dword[xN]. Its adjacent SGPRs are not V# NUM_RECORDS/format words, so decoding them
+        // as a four-dword V# can produce a nonsense one-byte bound. Size these pointer-backed tables
+        // from the shader's immediate s_load accesses, but only when that exact guest range is mapped.
+        for (auto& resource : table->resources) {
+            if (resource.cls != ResourceClass::ConstantBuffer ||
+                resource.sgpr_base == 0xFFFFFFFFu || !resource.gpu_addr)
+                continue;
+            const uint32_t required = rdna2_sload_required_bytes(
+                reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+                0x4000, resource.sgpr_base);
+            if (required > resource.size && required <= 0x10000000u &&
+                guest_readable(resource.gpu_addr, required)) {
+                if (std::getenv("PROSPER_DBG"))
+                    std::fprintf(stderr,
+                                 "[compute-sload-range] s%u addr=0x%llx decoded=%u inferred=%u\n",
+                                 resource.sgpr_base, (unsigned long long)resource.gpu_addr,
+                                 resource.size, required);
+                resource.size = required;
             }
         }
         assign_convention_bindings(*table, 2);
@@ -1738,9 +1763,30 @@ std::vector<ComputeItem> realize_compute_dispatches(
         if (!report.ok()) {
             record_failure(RealizationFailureReason::DescriptorContract, item.resources, item.spirv);
             static std::set<uint64_t> logged;
-            if (logged.insert(code_addr).second)
+            if (logged.insert(code_addr).second) {
                 std::fprintf(stderr, "[compute] skip invalid descriptor contract for program 0x%llx\n",
                              (unsigned long long)code_addr);
+                if (std::getenv("PROSPER_DBG")) for (const auto& issue : report.issues) {
+                    std::fprintf(stderr,
+                                 "[compute-descriptor] %s binding=%u expected=%s actual=%s required=%llu available=%llu error=%d\n",
+                                 descriptor_issue_name(issue.code), issue.binding,
+                                 spirv_descriptor_kind_name(issue.expected),
+                                 spirv_descriptor_kind_name(issue.actual),
+                                 (unsigned long long)issue.required_bytes,
+                                 (unsigned long long)issue.available_bytes, issue.error ? 1 : 0);
+                    if (item.resources) for (const auto& resource : item.resources->resources)
+                        if (resource.binding == issue.binding)
+                            std::fprintf(stderr,
+                                         "[compute-resource] binding=%u class=%u addr=0x%llx size=%llu host=%zu stride=%u fmt=%u comps=%u dims=%ux%ux%u srt=0x%x sgpr=%u pc=%u\n",
+                                         resource.binding, static_cast<unsigned>(resource.cls),
+                                         (unsigned long long)resource.gpu_addr,
+                                         (unsigned long long)resource.size, resource.host_data_size,
+                                         resource.stride, static_cast<unsigned>(resource.format),
+                                         resource.num_components, resource.width, resource.height,
+                                         resource.depth, resource.srt_offset, resource.sgpr_base,
+                                         resource.fetch_pc);
+                }
+            }
             continue;
         }
         // Image bindings (sampled textures + storage images) execute through the live backend's

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -1,6 +1,8 @@
 // rdna2_decode.cpp — see rdna2_decode.hpp.
 #include "rdna2_decode.hpp"
 
+#include <algorithm>
+
 namespace prosper::gpu {
 
 namespace {
@@ -146,6 +148,21 @@ void decode_operands(Rdna2Inst& i) {
                 if (((sd >> 16) & 7u) == 6u && ((sd >> 24) & 7u) == 6u &&
                     !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u))
                     i.has_modifier = false;
+                // f16 VOPC may select either 16-bit half. UE4 uses WORD_1 for packed visibility
+                // values (`v_cmpx_gt_f16_sdwa ..., v7, 0 src0_sel:WORD_1`). Preserve the selects so
+                // the recompiler can unpack the chosen half; other sub-dword compare forms reject.
+                else {
+                    const uint32_t eff = i.opcode >= 0xD9u && i.opcode <= 0xDEu
+                                           ? i.opcode - 0x10u : i.opcode;
+                    const uint32_t s0sel = (sd >> 16) & 7u, s1sel = (sd >> 24) & 7u;
+                    if (eff >= 0xC9u && eff <= 0xCEu &&
+                        s0sel >= 4u && s0sel <= 6u && s1sel >= 4u && s1sel <= 6u &&
+                        !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u)) {
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.sdwa_src1_sel = static_cast<uint8_t>(s1sel);
+                        i.has_modifier = false;
+                    }
+                }
             } else { i.src[0] = decode_src_field(w & 0x1FFu); i.src[1] = vgpr(w >> 9); i.n_src = 2; }
             break;
         case Rdna2Format::VOP3: {
@@ -434,6 +451,27 @@ size_t rdna2_walk(const uint32_t* code, size_t dwords, std::vector<Rdna2Inst>& o
         if (i.is_end || i.fmt == Rdna2Format::Unknown) break;
     }
     return pc;
+}
+
+uint32_t rdna2_sload_required_bytes(const uint32_t* code, size_t dwords, uint32_t sgpr_base) {
+    std::vector<Rdna2Inst> instructions;
+    rdna2_walk(code, dwords, instructions);
+    uint64_t required = 0;
+    for (const auto& in : instructions) {
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::SMEM || in.opcode > 0x04u ||
+            in.src[0].value != static_cast<int32_t>(sgpr_base) ||
+            in.src[1].kind != OperandKind::Special || in.src[1].value != 125 ||
+            static_cast<int32_t>(in.literal) < 0)
+            continue;
+        uint32_t words = 1;
+        if (in.opcode == 0x01u) words = 2;
+        else if (in.opcode == 0x02u) words = 4;
+        else if (in.opcode == 0x03u) words = 8;
+        else if (in.opcode == 0x04u) words = 16;
+        required = std::max<uint64_t>(required, static_cast<uint64_t>(in.literal) + words * 4u);
+    }
+    return required > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(required);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -122,4 +122,9 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords);
 // encoding, or the end of the buffer. Returns the number of dwords consumed.
 size_t rdna2_walk(const uint32_t* code, size_t dwords, std::vector<Rdna2Inst>& out);
 
+// Minimum byte range touched by immediate s_load_dword[xN] operations whose 64-bit SBASE begins at
+// `sgpr_base`. Unlike s_buffer_load, s_load consumes an address pair rather than a bounded V#; callers
+// use this to size pointer-backed user-data tables from the shader's actual accesses.
+uint32_t rdna2_sload_required_bytes(const uint32_t* code, size_t dwords, uint32_t sgpr_base);
+
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -21,7 +21,7 @@ enum : uint32_t {
     Op_Capability=17, Op_TypeVoid=19, Op_TypeBool=20, Op_TypeInt=21, Op_TypeFloat=22, Op_TypeVector=23,
     Op_TypeRuntimeArray=29, Op_TypeStruct=30, Op_TypePointer=32, Op_TypeFunction=33,
     Op_ConstantTrue=41, Op_ConstantFalse=42, Op_Constant=43, Op_Function=54, Op_FunctionEnd=56, Op_Variable=59,
-    Op_LogicalOr=166, Op_LogicalAnd=167, Op_Select=169, Op_FOrdEqual=180, Op_FOrdNotEqual=182, Op_FOrdLessThan=184, Op_FOrdGreaterThan=186,
+    Op_LogicalOr=166, Op_LogicalAnd=167, Op_LogicalNot=168, Op_Select=169, Op_FOrdEqual=180, Op_FOrdNotEqual=182, Op_FOrdLessThan=184, Op_FOrdGreaterThan=186,
     Op_FOrdLessThanEqual=188, Op_FOrdGreaterThanEqual=190,
     Op_FUnordEqual=181, Op_FUnordNotEqual=183, Op_FUnordLessThan=185, Op_FUnordGreaterThan=187,   // NaN-inclusive ("n"-prefix) compares
     Op_FUnordLessThanEqual=189, Op_FUnordGreaterThanEqual=191,
@@ -37,11 +37,12 @@ enum : uint32_t {
     Op_BitReverse=204, Op_UConvert=113,
     Op_TypeImage=25, Op_TypeSampledImage=27, Op_SampledImage=86,
     Op_ImageSampleImplicitLod=87, Op_ImageSampleExplicitLod=88, Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
-    Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103,
+    Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQueryLevels=106,
     Op_TypeArray=28, Op_ControlBarrier=224,
     Op_DPdx=207, Op_DPdy=208,   // screen-space derivatives (Fragment; plain Shader capability)
     Op_Phi=245, Op_LoopMerge=246,
-    Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Kill=252, Op_Return=253,
+    Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
+    Op_Kill=252, Op_Return=253, Op_GroupNonUniformAny=335,
 };
 // GLSL.std.450 extended-instruction numbers.
 enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Glsl_Ceil=9, Glsl_Fract=10, Glsl_Sin=13, Glsl_Cos=14,
@@ -49,9 +50,10 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_Sqrt=31, Glsl_InverseSqrt=32, Glsl_FMin=37, Glsl_UMin=38, Glsl_SMin=39, Glsl_FMax=40,
                   Glsl_UMax=41, Glsl_SMax=42, Glsl_PackHalf2x16=58, Glsl_UnpackHalf2x16=62 };
 enum : uint32_t {
-    Cap_Shader=1, Cap_Int64=11, Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Fragment=4, Exec_GLCompute=5,
+    Cap_Shader=1, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
+    Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_LocalSize=17,
-    SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_StorageBuffer=12, FC_None=0,
+    SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_StorageBuffer=12, FC_None=0,
     Dim_1D=0, Dim_2D=1, Dim_3D=2,   // SPIR-V Dim. (2D coincides with the SQ_RSRC 2D dim value, but distinct.)
     Cap_Sampled1D=43, Cap_Image1D=44,   // Dim=1D needs Sampled1D; a 1D STORAGE image (read/write) also needs Image1D
     Cap_StorageImageMultisample=27,      // MS=1 storage image (read/write a multisampled image)
@@ -63,7 +65,7 @@ enum : uint32_t {
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Sample=0x40,   // ImageOperands bits: LOD bias / explicit LOD / MSAA Sample index.
-    SC_Workgroup=4, Scope_Workgroup=2, MemSem_WGAcqRel=0x108,   // LDS: Workgroup storage + barrier scope/semantics
+    SC_Workgroup=4, Scope_Workgroup=2, Scope_Subgroup=3, MemSem_WGAcqRel=0x108,   // LDS: Workgroup storage + barrier scope/semantics
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_Flat=14, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
     BI_Position=0, BI_FragCoord=15, BI_WorkgroupId=26, BI_LocalInvocationId=27,
@@ -93,6 +95,7 @@ struct SpirvCompute {
     // geometry). Each stage owns its own set: VS=set 0, PS=set 1 (mirrors the PS5's per-stage resource
     // tables). Set in begin_fragment(); the host binds one descriptor set per stage.
     uint32_t desc_set=0;
+    size_t function_var_insert = 0;                   // first-function-block OpVariable insertion point
     uint32_t exec_model=0;                           // deferred EntryPoint (emitted in finish() so lazily-
     std::vector<uint32_t> iface;                     // declared I/O varyings can join the interface list)
 
@@ -174,6 +177,34 @@ struct SpirvCompute {
     }
     void patch_phi(size_t patch_off, uint32_t v1, uint32_t l1) { code[patch_off] = v1; code[patch_off + 1] = l1; }
     void emit_selmerge(uint32_t m) { put(code, Op_SelectionMerge, {m, 0}); }   // structured if (before condbranch)
+    void emit_switch(uint32_t selector, uint32_t fallback,
+                     const std::vector<std::pair<uint32_t, uint32_t>>& cases) {
+        std::vector<uint32_t> operands{selector, fallback};
+        for (const auto& c : cases) { operands.push_back(c.first); operands.push_back(c.second); }
+        putv(code, Op_Switch, operands);
+    }
+    uint32_t function_var(uint32_t type, uint32_t& ptr_type) {
+        if (!ptr_type) { ptr_type = id(); put(types, Op_TypePointer, {ptr_type, SC_Function, type}); }
+        uint32_t var = id();
+        std::vector<uint32_t> decl;
+        put(decl, Op_Variable, {ptr_type, var, SC_Function});
+        code.insert(code.begin() + static_cast<std::ptrdiff_t>(function_var_insert),
+                    decl.begin(), decl.end());
+        function_var_insert += decl.size();
+        return var;
+    }
+    uint32_t load_function(uint32_t type, uint32_t var) {
+        uint32_t value = id(); put(code, Op_Load, {type, value, var}); return value;
+    }
+    void store_function(uint32_t var, uint32_t value) { put(code, Op_Store, {var, value}); }
+    uint32_t logical_not(uint32_t value) {
+        uint32_t result = id(); put(code, Op_LogicalNot, {t_bool, result, value}); return result;
+    }
+    uint32_t subgroup_any(uint32_t value) {
+        uint32_t result = id();
+        put(code, Op_GroupNonUniformAny, {t_bool, result, uconst(Scope_Subgroup), value});
+        return result;
+    }
     // Fragment discard: OpKill any lane where `alive` is false, survivors fall through to `mergeL`. Used to
     // lower an EXP done under a narrowed EXEC (an alpha-test / WQM discard — the surviving lanes are the
     // ones that pass the kill test) to a real per-invocation discard. OpKill is a block terminator, so the
@@ -321,102 +352,115 @@ struct SpirvCompute {
         return ibin(Op_BitwiseAnd, pack_half2x16(fbits, bcu(fconstf(0.0f))), uconst(0xFFFFu));
     }
 
-    // Combined image+sampler support (MIMG image_sample). One float OpTypeImage/OpTypeSampledImage PER DIM
-    // (2D/3D) is shared; each texture is a COMBINED_IMAGE_SAMPLER UniformConstant at its binding.
-    uint32_t t_image = 0, t_sampled_image = 0;            // 2D (the common case; kept for existing callers)
+    // Combined image+sampler support (MIMG image_sample/image_load). Float and unsigned-integer
+    // textures need distinct SPIR-V image types even at the same dimension: normalized/float T#s
+    // return float bits, while UINT T#s return raw integer channel values. Each texture is still a
+    // COMBINED_IMAGE_SAMPLER UniformConstant at its binding.
     std::unordered_map<uint32_t, uint32_t> tex_var;       // binding -> combined-sampler OpVariable id
-    std::unordered_map<uint32_t, uint32_t> tex_simg_dim;  // SPIR-V Dim -> OpTypeSampledImage id
-    std::unordered_map<uint32_t, uint32_t> tex_img_dim;   // SPIR-V Dim -> its OpTypeImage id (OpImage results)
+    std::unordered_map<uint32_t, uint32_t> tex_simg_type; // (Dim | UINT flag) -> OpTypeSampledImage id
+    std::unordered_map<uint32_t, uint32_t> tex_img_type;  // same key -> its OpTypeImage id
+    std::unordered_map<uint32_t, uint32_t> tex_binding_simg;
+    std::unordered_map<uint32_t, uint32_t> tex_binding_img;
+    std::unordered_map<uint32_t, bool> tex_binding_uint;
     uint32_t t_v3f_cache = 0;
     uint32_t t_v3f() { if (!t_v3f_cache) { t_v3f_cache = id(); put(types, Op_TypeVector, {t_v3f_cache, t_f32, 3}); } return t_v3f_cache; }
-    uint32_t sampled_image_type(uint32_t dim) {
-        auto it = tex_simg_dim.find(dim); if (it != tex_simg_dim.end()) return it->second;
-        uint32_t ti = id(); put(types, Op_TypeImage, {ti, t_f32, dim, 0, 0, 0, 1, 0});  // sampled f32, Sampled=1
+    uint32_t t_v3i_cache = 0;
+    uint32_t t_v3i() { if (!t_v3i_cache) { t_v3i_cache = id(); put(types, Op_TypeVector, {t_v3i_cache, t_i32, 3}); } return t_v3i_cache; }
+    static uint32_t sampled_image_key(uint32_t dim, bool is_uint) {
+        return dim | (is_uint ? 0x100u : 0u);
+    }
+    uint32_t sampled_image_type(uint32_t dim, bool is_uint = false) {
+        const uint32_t key = sampled_image_key(dim, is_uint);
+        auto it = tex_simg_type.find(key); if (it != tex_simg_type.end()) return it->second;
+        uint32_t ti = id(); put(types, Op_TypeImage, {ti, is_uint ? t_u32 : t_f32,
+                                                      dim, 0, 0, 0, 1, 0});  // sampled, Sampled=1
         uint32_t si = id(); put(types, Op_TypeSampledImage, {si, ti});
-        if (dim == Dim_2D) { t_image = ti; t_sampled_image = si; }
-        tex_simg_dim[dim] = si; tex_img_dim[dim] = ti; return si;
+        tex_simg_type[key] = si; tex_img_type[key] = ti; return si;
     }
     // Declare (idempotently) a combined image+sampler of SPIR-V `dim` at descriptor-set 0, `binding`.
-    void declare_texture(uint32_t binding, uint32_t dim = Dim_2D) {
-        uint32_t simg = sampled_image_type(dim);
+    void declare_texture(uint32_t binding, uint32_t dim = Dim_2D, bool is_uint = false) {
+        const uint32_t key = sampled_image_key(dim, is_uint);
+        uint32_t simg = sampled_image_type(dim, is_uint);
         if (tex_var.count(binding)) return;
         uint32_t t_ptr = id(); put(types, Op_TypePointer, {t_ptr, SC_UniformConstant, simg});
         uint32_t v = id();     put(types, Op_Variable,    {t_ptr, v, SC_UniformConstant});
         put(deco, Op_Decorate, {v, Dec_DescriptorSet, desc_set});
         put(deco, Op_Decorate, {v, Dec_Binding, binding});
         tex_var[binding] = v;
+        tex_binding_simg[binding] = simg;
+        tex_binding_img[binding] = tex_img_type[key];
+        tex_binding_uint[binding] = is_uint;
+    }
+    uint32_t texture_vec4(uint32_t binding) {
+        return tex_binding_uint[binding] ? t_v4u() : t_v4f;
+    }
+    void unpack_texture_result(uint32_t binding, uint32_t result, uint32_t out[4]) {
+        const bool is_uint = tex_binding_uint[binding];
+        const uint32_t scalar_type = is_uint ? t_u32 : t_f32;
+        for (uint32_t c = 0; c < 4; c++) {
+            uint32_t e = id(); put(code, Op_CompositeExtract, {scalar_type, e, result, c});
+            out[c] = is_uint ? e : bcu(e);
+        }
     }
     // image_sample 2D: sample the combined sampler at `binding` with (u,v) float-BITS coords; fills
     // out[0..3] with the RGBA result components as raw VGPR bits. Implicit LOD is only legal in the
     // Fragment execution model (#151) — the compute/vertex shells have no derivatives, so there we
     // sample at explicit LOD 0 (what a non-pixel-shader image_sample resolves to without gradients).
     void image_sample_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t out[4]) {
-        uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
         uint32_t res   = id();
-        if (is_fragment) put(code, Op_ImageSampleImplicitLod, {t_v4f, res, si, coord});
-        else             put(code, Op_ImageSampleExplicitLod, {t_v4f, res, si, coord, ImgOp_Lod, fconstf(0.0f)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        if (is_fragment) put(code, Op_ImageSampleImplicitLod, {texture_vec4(binding), res, si, coord});
+        else             put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, fconstf(0.0f)});
+        unpack_texture_result(binding, res, out);
     }
     // image_sample 3D: (u,v,w) float-BITS coords -> RGBA. Uses the Dim_3D sampled image; same
     // implicit-LOD-only-in-Fragment rule as image_sample_2d.
     void image_sample_3d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t w_bits, uint32_t out[4]) {
-        uint32_t simg  = sampled_image_type(Dim_3D);
+        uint32_t simg  = tex_binding_simg[binding];
         uint32_t si    = id(); put(code, Op_Load, {simg, si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(w_bits)});
         uint32_t res   = id();
-        if (is_fragment) put(code, Op_ImageSampleImplicitLod, {t_v4f, res, si, coord});
-        else             put(code, Op_ImageSampleExplicitLod, {t_v4f, res, si, coord, ImgOp_Lod, fconstf(0.0f)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        if (is_fragment) put(code, Op_ImageSampleImplicitLod, {texture_vec4(binding), res, si, coord});
+        else             put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, fconstf(0.0f)});
+        unpack_texture_result(binding, res, out);
     }
     // image_sample_l / _lz: sample with an EXPLICIT LOD (lod_bits float). Stage-agnostic (no derivatives).
     void image_sample_lod_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t lod_bits, uint32_t out[4]) {
-        uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
-        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod, {t_v4f, res, si, coord, ImgOp_Lod, bcf(lod_bits)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, bcf(lod_bits)});
+        unpack_texture_result(binding, res, out);
     }
     // image_sample_lz from a 3D texture: explicit LOD (usually 0) on a (u,v,w) coord. Stage-agnostic.
     void image_sample_lod_3d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t w_bits,
                              uint32_t lod_bits, uint32_t out[4]) {
-        uint32_t simg  = sampled_image_type(Dim_3D);
+        uint32_t simg  = tex_binding_simg[binding];
         uint32_t si    = id(); put(code, Op_Load, {simg, si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(w_bits)});
-        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod, {t_v4f, res, si, coord, ImgOp_Lod, bcf(lod_bits)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, bcf(lod_bits)});
+        unpack_texture_result(binding, res, out);
     }
     // image_sample_b 2D: implicit-LOD sample with an LOD BIAS (bias_bits float). Bias only means
     // anything with implicit LOD (fragment derivatives); outside the fragment stage the op resolves
     // like the other samples there — explicit LOD 0 (bias dropped, matching image_sample_2d's rule).
     void image_sample_bias_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t bias_bits, uint32_t out[4]) {
-        uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
         uint32_t res   = id();
-        if (is_fragment) put(code, Op_ImageSampleImplicitLod, {t_v4f, res, si, coord, ImgOp_Bias, bcf(bias_bits)});
-        else             put(code, Op_ImageSampleExplicitLod, {t_v4f, res, si, coord, ImgOp_Lod, fconstf(0.0f)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        if (is_fragment) put(code, Op_ImageSampleImplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Bias, bcf(bias_bits)});
+        else             put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, fconstf(0.0f)});
+        unpack_texture_result(binding, res, out);
     }
     // image_gather4_lz 2D: OpImageGather of component `comp` (0..3) — the 2x2 footprint's four texels
     // of one channel, in the DX/GL gather order ((0,1),(1,1),(1,0),(0,0)), which the AMD gather4
     // result order matches. Gather always samples the base level (== the _lz behavior). out[0..3] =
     // the four gathered values as raw bits.
     void image_gather_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t comp, uint32_t out[4]) {
-        uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
-        uint32_t res   = id(); put(code, Op_ImageGather, {t_v4f, res, si, coord, uconst(comp)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        uint32_t res   = id(); put(code, Op_ImageGather, {texture_vec4(binding), res, si, coord, uconst(comp)});
+        unpack_texture_result(binding, res, out);
     }
     // image_gather4_lz_o 2D: gather with the MIMG _o per-pixel OFFSET operand. The offset VGPR packs
     // signed 6-bit TEXEL offsets (x = bits[5:0], y = bits[13:8] — AMD RDNA2 ISA "offset" packing, the
@@ -429,17 +473,15 @@ struct SpirvCompute {
     void image_gather_offset_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t comp,
                                 uint32_t off_bits, uint32_t out[4]) {
         if (!declared_gather_ext) { put(caps, Op_Capability, {Cap_ImageGatherExtended}); declared_gather_ext = true; }
-        uint32_t si    = id(); put(code, Op_Load, {t_sampled_image, si, tex_var[binding]});
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
         // signed 6-bit texel offsets. NOTE: bfe_s takes SPIR-V IDs — raw integers here (the #296
         // original) emitted OpBitFieldSExtract with invalid operand IDs; never caught live because
         // the only gather4_lz_o user (DOLL's FXAA PS) still rejected upstream on its execz region.
         uint32_t ox    = bfe_s(off_bits, uconst(0), uconst(6)), oy = bfe_s(off_bits, uconst(8), uconst(6));
         uint32_t offv  = id(); put(code, Op_CompositeConstruct, {t_v2i(), offv, bcs(ox), bcs(oy)});
-        uint32_t res   = id(); put(code, Op_ImageGather, {t_v4f, res, si, coord, uconst(comp), ImgOp_Offset, offv});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        uint32_t res   = id(); put(code, Op_ImageGather, {texture_vec4(binding), res, si, coord, uconst(comp), ImgOp_Offset, offv});
+        unpack_texture_result(binding, res, out);
     }
     // image_sample_lz_o 2D: explicit-LOD-0 sample with the MIMG _o packed texel offset (x = bits[5:0],
     // y = bits[13:8], signed 6-bit — same packing as gather4_lz_o). Vulkan forbids the dynamic Offset
@@ -451,8 +493,8 @@ struct SpirvCompute {
     void image_sample_lz_offset_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
                                    uint32_t off_bits, uint32_t out[4]) {
         if (!declared_image_query) { put(caps, Op_Capability, {Cap_ImageQuery}); declared_image_query = true; }
-        uint32_t si   = id(); put(code, Op_Load,  {t_sampled_image, si, tex_var[binding]});
-        uint32_t img  = id(); put(code, Op_Image, {t_image, img, si});
+        uint32_t si   = id(); put(code, Op_Load,  {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t img  = id(); put(code, Op_Image, {tex_binding_img[binding], img, si});
         uint32_t size = id(); put(code, Op_ImageQuerySizeLod, {t_v2i(), size, img, uconst(0)});
         uint32_t w_i  = id(); put(code, Op_CompositeExtract, {t_i32, w_i, size, 0});
         uint32_t h_i  = id(); put(code, Op_CompositeExtract, {t_i32, h_i, size, 1});
@@ -461,35 +503,60 @@ struct SpirvCompute {
         uint32_t dv = fbin(Op_FDiv, cvt_i2f(oy), cvt_i2f(i2u(h_i)));
         image_sample_lod_2d(binding, fbin(Op_FAdd, u_bits, du), fbin(Op_FAdd, v_bits, dv), uconst(0), out);
     }
+    // image_get_resinfo: query a sampled image's dimensions at the integer LOD carried in VADDR.
+    // RDNA returns {width,height,depth-or-layers,mip-levels}; absent spatial axes are 1. The result is
+    // integer data in ordinary VGPRs, so the signed SPIR-V query result is bitcast back to raw u32.
+    void image_get_resinfo(uint32_t binding, uint32_t dim, uint32_t lod_bits, uint32_t out[4]) {
+        if (!declared_image_query) { put(caps, Op_Capability, {Cap_ImageQuery}); declared_image_query = true; }
+        const uint32_t simg = tex_binding_simg[binding];
+        const uint32_t image_type = tex_binding_img[binding];
+        uint32_t si = id();  put(code, Op_Load,  {simg, si, tex_var[binding]});
+        uint32_t img = id(); put(code, Op_Image, {image_type, img, si});
+        out[0] = out[1] = out[2] = uconst(1);
+        if (dim == Dim_1D) {
+            uint32_t size = id(); put(code, Op_ImageQuerySizeLod, {t_i32, size, img, bcs(lod_bits)});
+            out[0] = i2u(size);
+        } else {
+            const uint32_t size_type = dim == Dim_2D ? t_v2i() : t_v3i();
+            uint32_t size = id(); put(code, Op_ImageQuerySizeLod, {size_type, size, img, bcs(lod_bits)});
+            const uint32_t components = dim == Dim_2D ? 2u : 3u;
+            for (uint32_t c = 0; c < components; c++) {
+                uint32_t value = id(); put(code, Op_CompositeExtract, {t_i32, value, size, c});
+                out[c] = i2u(value);
+            }
+        }
+        uint32_t levels = id(); put(code, Op_ImageQueryLevels, {t_i32, levels, img});
+        out[3] = i2u(levels);
+    }
     // 2-component uint vector (integer texel coordinates for OpImageFetch).
     uint32_t t_v2u_cache = 0;
     uint32_t t_v2u() { if (!t_v2u_cache) { t_v2u_cache = id(); put(types, Op_TypeVector, {t_v2u_cache, t_u32, 2}); } return t_v2u_cache; }
     // image_load 2D (image_load): texelFetch the image at the combined sampler's `binding` with INTEGER
     // (x,y) coords (raw VGPR bits). OpImage strips the sampler; OpImageFetch at explicit LOD 0.
     void image_fetch_2d(uint32_t binding, uint32_t x_bits, uint32_t y_bits, uint32_t out[4]) {
-        uint32_t si    = id(); put(code, Op_Load,  {t_sampled_image, si, tex_var[binding]});
-        uint32_t img   = id(); put(code, Op_Image, {t_image, img, si});
+        uint32_t si    = id(); put(code, Op_Load,  {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t img   = id(); put(code, Op_Image, {tex_binding_img[binding], img, si});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2u(), coord, x_bits, y_bits});
-        uint32_t res   = id(); put(code, Op_ImageFetch, {t_v4f, res, img, coord, ImgOp_Lod, uconst(0)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        uint32_t res   = id(); put(code, Op_ImageFetch, {texture_vec4(binding), res, img, coord, ImgOp_Lod, uconst(0)});
+        unpack_texture_result(binding, res, out);
     }
 
     // image_load from a 3D texture (integer texel fetch through the combined sampler — DOLL's
     // color-grade LUT, #273): OpImage strips the sampler; OpImageFetch with (x,y,z) integer coords.
     uint32_t t_v3u_cache2 = 0;
-    uint32_t t_v3u_fetch() { if (!t_v3u_cache2) { t_v3u_cache2 = id(); put(types, Op_TypeVector, {t_v3u_cache2, t_u32, 3}); } return t_v3u_cache2; }
+    uint32_t t_v3u_fetch() {
+        if (t_v3u) return t_v3u;   // compute/vertex shells already declare a uvec3 for built-ins
+        if (!t_v3u_cache2) { t_v3u_cache2 = id(); put(types, Op_TypeVector, {t_v3u_cache2, t_u32, 3}); }
+        return t_v3u_cache2;
+    }
     void image_fetch_3d(uint32_t binding, uint32_t x_bits, uint32_t y_bits, uint32_t z_bits, uint32_t out[4]) {
-        uint32_t simg  = sampled_image_type(Dim_3D);
-        uint32_t t_img3 = tex_img_dim[Dim_3D];   // OpImage's result type must be the pair's Image type
+        uint32_t simg  = tex_binding_simg[binding];
+        uint32_t t_img3 = tex_binding_img[binding];   // OpImage's result type must be the pair's Image type
         uint32_t si    = id(); put(code, Op_Load,  {simg, si, tex_var[binding]});
         uint32_t img   = id(); put(code, Op_Image, {t_img3, img, si});
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v3u_fetch(), coord, x_bits, y_bits, z_bits});
-        uint32_t res   = id(); put(code, Op_ImageFetch, {t_v4f, res, img, coord, ImgOp_Lod, uconst(0)});
-        for (uint32_t c = 0; c < 4; c++) {
-            uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, res, c}); out[c] = bcu(e);
-        }
+        uint32_t res   = id(); put(code, Op_ImageFetch, {texture_vec4(binding), res, img, coord, ImgOp_Lod, uconst(0)});
+        unpack_texture_result(binding, res, out);
     }
 
     // --- STORAGE images (MIMG image_load / image_store WITHOUT a sampler; compute copy/blit) ---
@@ -798,6 +865,7 @@ struct SpirvCompute {
         declare_cbufs(rt); // scalar-memory buffers, including table-assigned bindings beyond 2/3
         put(code, Op_Function, {t_void, f_main, FC_None, t_fn});
         put(code, Op_Label, {lbl}); cur_block = lbl;
+        function_var_insert = code.size();
         uint32_t ld = id(); put(code, Op_Load, {t_v3u, ld, v_gid});
         gidx = id(); put(code, Op_CompositeExtract, {t_u32, gidx, ld, 0});
         uint32_t ldl = id(); put(code, Op_Load, {t_v3u, ldl, v_localid});
@@ -1003,6 +1071,8 @@ struct RegState {
     // scalar: vgpr -> lane -> SSA id. A vgpr used as a spill array must never be read as ordinary
     // per-lane data — operand_bits rejects that (fail-visible), keeping the model honest.
     std::unordered_map<int, std::unordered_map<int, uint32_t>> vgpr_lane_slots;
+    // EXEC/VCC/saved-mask spills use the same fixed lanes but remain bool-domain values.
+    std::unordered_map<int, std::unordered_map<int, uint32_t>> vgpr_lane_mask_slots;
     // LDS ADDTID per-lane spill slots (#273 — DOLL's title post PSes): `s_movk m0, K;
     // ds_write_addtid_b32 vN` spills THIS lane's vN to LDS[M0 + offset + tid*4], and the matching
     // `ds_read_addtid_b32` reloads it. Per-invocation the slot is one value, keyed by the M0 SSA id
@@ -1020,6 +1090,7 @@ inline void predicate_write(SpirvCompute& b, RegState& rs, int idx, uint32_t old
     // rather than rejecting it as a stale cross-lane spill. Blasphemous 2 does exactly this after
     // an image_sample overwrites the shader's early scalar-spill v11 (#652).
     rs.vgpr_lane_slots.erase(idx);
+    rs.vgpr_lane_mask_slots.erase(idx);
 }
 inline uint32_t vreg_old(SpirvCompute& b, RegState& rs, int idx) {
     auto it = rs.vreg.find(idx); return it == rs.vreg.end() ? b.uconst(0) : it->second;
@@ -1442,8 +1513,15 @@ static bool cannot_write_vcc(const Rdna2Inst& in) {
         case Rdna2Format::SOPC:  return true;                      // writes SCC only
         case Rdna2Format::VOP2:  return in.opcode < 0x28 || in.opcode > 0x2a;
         case Rdna2Format::VOP3P: return true;                      // packed VALU: VGPR dst, no carry
-        case Rdna2Format::VOP3:  return in.opcode >= 0x140 && in.opcode < 0x300 &&
-                                        sgpr_dst_misses_vcc(1);    // plain-VALU window only
+        case Rdna2Format::VOP3:
+            // gfx10 v_writelane_b32 writes only its VGPR lane slot. v_readlane_b32 writes the
+            // scalar destination encoded in the decoder's dst field, so it is VCC-preserving as
+            // long as that destination does not overlap s106:s107. UE4 schedules long scalar-spill
+            // sequences of these two ops between a uniform VOPC and its s_cbranch_vccz.
+            if (in.opcode == 0x361) return true;
+            if (in.opcode == 0x360) return sgpr_dst_misses_vcc(1);
+            return in.opcode >= 0x140 && in.opcode < 0x300 &&
+                   sgpr_dst_misses_vcc(1);                         // plain-VALU window only
         case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPK:
             return sgpr_dst_misses_vcc(2);                         // conservative 64-bit pair
         case Rdna2Format::SMEM: {
@@ -1895,14 +1973,17 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
 // Resolve an operand to its raw 32-bit value (bits). Float ops bitcast these to float.
 // `ok`: cleared when the operand's VALUE is not representable — a Special operand read as ALU DATA
 // (VCC/EXEC live as per-lane bools in rs.vcc/rs.exec; their 32-bit wave-mask value does not exist
-// in the per-invocation model, and M0/SCC/ttmp aren't modeled at all). Only SGPR_NULL (field 125)
-// has a defined value, 0. Previously every Special silently read as 0 and the shader computed
+// in the per-invocation model, and untracked M0/ttmp aren't modeled). SGPR_NULL (field 125) is 0;
+// SCC (field 253) is a scalar 0/1 and therefore is representable exactly. Previously other
+// untracked Specials silently read as 0 and the shader computed
 // garbage (#134); now it rejects, matching the SDWA/DPP reject-rather-than-miscompute discipline.
 uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const Operand& o, bool* ok = nullptr) {
     switch (o.kind) {
         case OperandKind::VGPR: {
             // A scalar-spill vgpr (v_writelane slots) has no per-lane data value — reject, don't read 0.
-            if (rs.vgpr_lane_slots.count(o.value)) { if (ok) *ok = false; return b.uconst(0); }
+            if (rs.vgpr_lane_slots.count(o.value) || rs.vgpr_lane_mask_slots.count(o.value)) {
+                if (ok) *ok = false; return b.uconst(0);
+            }
             auto it = rs.vreg.find(o.value); return it == rs.vreg.end() ? b.uconst(0) : it->second; }
         case OperandKind::SGPR: { auto it = rs.sreg.find(o.value); return it == rs.sreg.end() ? b.uconst(0) : it->second; }
         case OperandKind::InlineInt:   return b.uconst((uint32_t)o.value);
@@ -1910,6 +1991,7 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
         case OperandKind::Literal:     return b.uconst(in.literal);
         case OperandKind::Special:
             if (o.value == 125) return b.uconst(0);   // SGPR_NULL: the one Special whose data value IS 0
+            if (o.value == 253) return b.sel(rs.scc, b.uconst(1), b.uconst(0)); // SCC scalar source
             // VCC_LO/HI (106/107), ttmp0..15 (108..123) and M0 (124) double as plain scalar SCRATCH
             // in compiled code — the NGG preamble does `s_bfe_u32 vcc_lo, s3, ...` then reads vcc
             // back as data, and DOLL's skinned VS round-trips M0 (`s_mov m0, s4 … s_mov s36, m0`,
@@ -2105,9 +2187,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 else { rs.sreg_bool[in.dst.value] = r; rs.sreg_bool_narrowed[in.dst.value] = true; }  // conservative flag
                 return true;
             }
-            if (in.opcode == 0x0f || in.opcode == 0x11 || in.opcode == 0x13 || in.opcode == 0x15) {
-                // 64-bit wave-mask LOGICAL ops on per-lane bools: s_and_b64(0x0f)/s_or_b64(0x11)/
-                // s_xor_b64(0x13)/s_andn2_b64(0x15, = m0 AND NOT m1). Used for lane-mask arithmetic around
+            if (in.opcode == 0x0f || in.opcode == 0x11 || in.opcode == 0x13 || in.opcode == 0x15 ||
+                in.opcode == 0x17 || in.opcode == 0x19 || in.opcode == 0x1b || in.opcode == 0x1d) {
+                // 64-bit wave-mask LOGICAL ops on per-lane bools: AND/OR/XOR/ANDN2 plus the
+                // complementary ORN2/NAND/NOR/XNOR family. Used for lane-mask arithmetic around
                 // divergent control flow / ballot. SCC=(result!=0) is a cross-lane reduction we can't form
                 // per-lane, so (like every mask op) we don't write SCC. Same mask-resolution as s_cselect_b64.
                 auto is_exec = [](const Operand& o){ return o.value == 126 || o.value == 127; };
@@ -2122,10 +2205,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 };
                 uint32_t m0 = mask(in.src[0]), m1 = mask(in.src[1]);
                 if (!m0 || !m1) { ok = false; return true; }
-                uint32_t r = in.opcode == 0x0f ? b.land(m0, m1)
-                           : in.opcode == 0x11 ? b.lor(m0, m1)
-                           : in.opcode == 0x13 ? b.bsel(m0, b.bsel(m1, b.bfalse(), b.btrue()), m1)   // xor = m0?!m1:m1
-                           : b.land(m0, b.bsel(m1, b.bfalse(), b.btrue()));                            // andn2 = m0 & !m1
+                const uint32_t n0 = b.logical_not(m0), n1 = b.logical_not(m1);
+                const uint32_t x = b.bsel(m0, n1, m1);               // xor = m0 ? !m1 : m1
+                uint32_t r = in.opcode == 0x0f ? b.land(m0, m1)      // and
+                           : in.opcode == 0x11 ? b.lor(m0, m1)       // or
+                           : in.opcode == 0x13 ? x                    // xor
+                           : in.opcode == 0x15 ? b.land(m0, n1)      // andn2
+                           : in.opcode == 0x17 ? b.lor(m0, n1)       // orn2
+                           : in.opcode == 0x19 ? b.lor(n0, n1)       // nand
+                           : in.opcode == 0x1b ? b.land(n0, n1)      // nor
+                           : b.logical_not(x);                        // xnor
                 if (is_exec(in.dst)) { rs.exec = r; rs.exec_narrowed = true; }
                 else if (in.dst.value == 106 || in.dst.value == 107) { rs.vcc = r; rs.sreg_bool_narrowed[in.dst.value] = true; }
                 else { rs.sreg_bool[in.dst.value] = r; rs.sreg_bool_narrowed[in.dst.value] = true; }
@@ -2601,7 +2690,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         uint32_t v = (in.src[k].kind == OperandKind::InlineFloat ||
                                       in.src[k].kind == OperandKind::InlineInt)
                                          ? raw                       // inline: already a full-width value
-                                         : b.unpack_half(raw, 0);    // register/literal: f16 in the low half
+                                         : b.unpack_half(raw, in.sdwa_src0_sel == 5u && k == 0 ? 1u :
+                                                              in.sdwa_src1_sel == 5u && k == 1 ? 1u : 0u);
                         if (in.src_abs[k]) v = b.fext1(Glsl_FAbs, v);
                         if (in.src_neg[k]) v = b.fbin(Op_FSub, b.uconst(0), v);
                         return v;
@@ -2648,20 +2738,58 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
                     ok = false; return true;
                 }
-                auto [slots, inserted] = rs.vgpr_lane_slots.try_emplace(in.dst.value);
-                if (inserted) rs.vreg.erase(in.dst.value);             // new spill-array lifetime
-                slots->second[in.src[1].value] = val(in.src[0]);
+                const int lane = in.src[1].value;
+                uint32_t mask_value = 0;
+                bool mask_source = false;
+                if (in.src[0].value == 126 || in.src[0].value == 127) {
+                    mask_value = rs.exec; mask_source = true;
+                } else if ((in.src[0].value == 106 || in.src[0].value == 107) &&
+                           !rs.sreg.count(in.src[0].value)) {
+                    mask_value = rs.vcc; mask_source = true;
+                } else if (in.src[0].kind == OperandKind::SGPR) {
+                    auto saved = rs.sreg_bool.find(in.src[0].value);
+                    if (saved != rs.sreg_bool.end()) { mask_value = saved->second; mask_source = true; }
+                }
+                rs.vreg.erase(in.dst.value);                            // spill-array lifetime
+                if (mask_source) {
+                    rs.vgpr_lane_mask_slots[in.dst.value][lane] = mask_value;
+                    auto data = rs.vgpr_lane_slots.find(in.dst.value);
+                    if (data != rs.vgpr_lane_slots.end()) {
+                        data->second.erase(lane);
+                        if (data->second.empty()) rs.vgpr_lane_slots.erase(data);
+                    }
+                } else {
+                    rs.vgpr_lane_slots[in.dst.value][lane] = val(in.src[0]);
+                    auto masks = rs.vgpr_lane_mask_slots.find(in.dst.value);
+                    if (masks != rs.vgpr_lane_mask_slots.end()) {
+                        masks->second.erase(lane);
+                        if (masks->second.empty()) rs.vgpr_lane_mask_slots.erase(masks);
+                    }
+                }
                 return true;
             }
             if (in.opcode == 0x360) {                                 // v_readlane_b32 sDST, vSRC, lane
                 if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
                     ok = false; return true;
                 }
+                auto mit = rs.vgpr_lane_mask_slots.find(in.src[0].value);
+                if (mit != rs.vgpr_lane_mask_slots.end()) {
+                    auto sit = mit->second.find(in.src[1].value);
+                    if (sit != mit->second.end()) {
+                        rs.sreg_bool[in.dst.value] = sit->second;
+                        rs.sreg_bool_narrowed[in.dst.value] = true;
+                        rs.sreg.erase(in.dst.value);
+                        rs.sreg_srt.erase(in.dst.value);
+                        return true;
+                    }
+                }
                 auto vit = rs.vgpr_lane_slots.find(in.src[0].value);
                 if (vit == rs.vgpr_lane_slots.end()) { ok = false; return true; }   // not a spill array
                 auto sit = vit->second.find(in.src[1].value);
                 if (sit == vit->second.end()) { ok = false; return true; }          // slot never written
                 rs.sreg[in.dst.value] = sit->second;   // dst field is the SGPR number (like readfirstlane)
+                rs.sreg_bool.erase(in.dst.value);
+                rs.sreg_bool_narrowed.erase(in.dst.value);
                 rs.sreg_srt.erase(in.dst.value);
                 return true;
             }
@@ -3363,7 +3491,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // Exact per-use provenance wins over table keys. A sample and store may consume the same
             // T# through a colliding offset but require different Vulkan descriptor classes.
             if ((in.opcode == 0x08 && res && res->cls != ResourceClass::StorageImage) ||
-                (in.opcode != 0x00 && in.opcode != 0x08 && res && res->cls != ResourceClass::Texture))
+                (in.opcode != 0x00 && in.opcode != 0x08 && in.opcode != 0x0e &&
+                 res && res->cls != ResourceClass::Texture))
                 res = nullptr;
             if ((!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage))
                 && getenv("PROSPER_DBG")) {
@@ -3379,6 +3508,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         rt->resources.size());
             }
             if (!res) { ok = false; return true; }
+            const bool uint_texture = res->format == DataFormat::Uint8 ||
+                                      res->format == DataFormat::Uint16 ||
+                                      res->format == DataFormat::Uint32;
 
             // --- Storage-image path: image_load (0x00) / image_store (0x08), no sampler, any dim ---
             if (res->cls == ResourceClass::StorageImage) {
@@ -3425,6 +3557,27 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     int vd = in.dst.value, w = 0;
                     for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) { vals[c] = vread(vd + w); w++; }
                     b.image_write(res->binding, dim, arrayed, ncoord, coords, vals, rs.exec_narrowed, rs.exec);
+                }
+                return true;
+            }
+
+            // image_get_resinfo (0x0e): sampled-image dimensions at the integer LOD in VADDR. The
+            // DOLL UE4 volume initializer uses dim:3D, dmask:xyz to bounds-check its 8x8x8 dispatch
+            // before loading and writing the volume. Array/cube queries remain deferred with their
+            // corresponding sampled-image representations.
+            if (in.opcode == 0x0e) {
+                uint32_t dim;
+                if (in.mimg_dim == 0u) dim = Dim_1D;
+                else if (in.mimg_dim == 1u) dim = Dim_2D;
+                else if (in.mimg_dim == 2u) dim = Dim_3D;
+                else { ok = false; return true; }
+                if (res->cls != ResourceClass::Texture) { ok = false; return true; }
+                b.declare_texture(res->binding, dim, uint_texture);
+                uint32_t out[4]; b.image_get_resinfo(res->binding, dim, vread(in.src[0].value), out);
+                int vd = in.dst.value, w = 0;
+                for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) {
+                    uint32_t old = vreg_old(b, rs, vd + w); rs.vreg[vd + w] = out[c];
+                    predicate_write(b, rs, vd + w, old); w++;
                 }
                 return true;
             }
@@ -3487,13 +3640,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t layer = b.fext1(Glsl_RoundEven,
                                      b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, fid, b.uconst(fbits(5.0f))), zero));
                 uint32_t v6 = b.fbin(Op_FMul, b.fbin(Op_FAdd, layer, vf), b.uconst(fbits(1.0f / 6.0f)));
-                b.declare_texture(res->binding, Dim_2D);
+                b.declare_texture(res->binding, Dim_2D, uint_texture);
                 b.image_sample_lod_2d(res->binding, uf, v6, b.uconst(0), out);
             } else if (dim3d) {
                 // 3D: implicit-LOD / LOD-0 sample, or an integer texel FETCH (image_load — DOLL's
                 // color-grade 3D LUT, #273).
                 if (!is_sample && !is_sample_lz && !is_load) { ok = false; return true; }
-                b.declare_texture(res->binding, Dim_3D);
+                b.declare_texture(res->binding, Dim_3D, uint_texture);
                 if (is_sample)      b.image_sample_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
                 else if (is_load)   b.image_fetch_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
                 else                b.image_sample_lod_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)),
@@ -3504,7 +3657,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t dm = in.mimg_dmask;
                 if (dm != 1u && dm != 2u && dm != 4u && dm != 8u) { ok = false; return true; }
                 uint32_t comp = dm == 1u ? 0u : dm == 2u ? 1u : dm == 4u ? 2u : 3u;
-                b.declare_texture(res->binding, Dim_2D);
+                b.declare_texture(res->binding, Dim_2D, uint_texture);
                 if (is_gather_lz_o)   // vaddr order for _o: [packed offset, u, v]
                     b.image_gather_offset_2d(res->binding, vread(cvg(1)), vread(cvg(2)), comp, vread(cvg(0)), out);
                 else
@@ -3517,7 +3670,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             } else {
-                b.declare_texture(res->binding, Dim_2D);
+                b.declare_texture(res->binding, Dim_2D, uint_texture);
                 if (is_sample_b) {      // vaddr order for _b: [bias, u, v]
                     b.image_sample_bias_2d(res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(0)), out);
                 } else if (is_sample_lz_o) {   // vaddr order for _o: [packed offset, u, v]
@@ -3723,6 +3876,324 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
     return out;
 }
 
+// Arbitrary compute CFG fallback. Some UE4 volume-lighting kernels contain nested EXEC loops plus
+// a small backward VCC vote loop. They are valid reducible machine CFGs, but deliberately exceed the
+// narrow pattern structurizer below. Lower them as a structured dispatcher loop: one switch case per
+// basic block, with the emulated register file persisted in Function variables between iterations.
+// VCCZ/EXECZ test subgroup-wide Any, matching the hardware branch's wave-mask reduction instead of
+// treating one invocation's bit as the whole mask. The fallback is gated by emit_body to complex,
+// barrier/LDS-free compute CFGs; simple or unsafe shaders retain the existing conservative path.
+bool emit_compute_cfg_state_machine(
+    SpirvCompute& b, RegState& initial, const std::vector<Rdna2Inst>& ins,
+    const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
+    bool allow_exec_update, bool allow_smem,
+    const std::function<bool(const Rdna2Inst&)>& exp_fn) {
+    if (!b.is_compute || ins.empty()) return false;
+
+    uint32_t end_pc = UINT32_MAX;
+    for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
+    if (end_pc == UINT32_MAX) return false;
+
+    // Split at every branch target and fallthrough. Case values are dense block indices, not guest PCs.
+    std::set<uint32_t> start_set{ins.front().pc};
+    for (size_t i = 0; i < ins.size(); ++i) {
+        const auto& in = ins[i];
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::SOPP || in.opcode < 0x02 || in.opcode > 0x09 ||
+            in.opcode == 0x03) continue;
+        const uint32_t target = branch_target(in);
+        if (target <= end_pc) start_set.insert(target);
+        if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc) start_set.insert(ins[i + 1].pc);
+    }
+    start_set.insert(end_pc);
+    std::vector<uint32_t> starts(start_set.begin(), start_set.end());
+    if (starts.empty() || starts.front() != ins.front().pc) return false;
+    std::unordered_map<uint32_t, uint32_t> block_for_pc;
+    for (uint32_t i = 0; i < starts.size(); ++i) block_for_pc[starts[i]] = i;
+
+    // Persist only registers that the stream reads or writes, plus the caller's initialized inputs.
+    std::set<int> vregs, sregs;
+    loop_written_regs(ins, 0, end_pc, vregs, sregs);
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        for (uint32_t k = 0; k < in.n_src; ++k) {
+            const Operand& src = in.src[k];
+            if (src.kind == OperandKind::VGPR) vregs.insert(src.value);
+            else if (src.kind == OperandKind::SGPR ||
+                     (src.kind == OperandKind::Special && src.value >= 106 && src.value <= 124))
+                sregs.insert(src.value);
+        }
+    }
+    for (const auto& kv : initial.vreg) vregs.insert(kv.first);
+    for (const auto& kv : initial.sreg) sregs.insert(kv.first);
+
+    // Direct user-data descriptors are deliberately absent from the initial scalar SSA map: their
+    // identity lives in the resource table, and presence in sreg means shader code overwrote them.
+    // The dispatcher persists every referenced SGPR in a Function variable, so recover that
+    // distinction per block until the first static write; otherwise a direct V# such as UE4's s[8:11]
+    // looks rewritten merely because the dispatcher loaded its zero-initialized backing variable.
+    std::set<int> direct_descriptor_sregs;
+    if (rt) {
+        for (const auto& resource : rt->resources) {
+            if (resource.srt_offset != 0xFFFFFFFFu || resource.sgpr_base == 0xFFFFFFFFu) continue;
+            const uint32_t words = (resource.cls == ResourceClass::Texture ||
+                                    resource.cls == ResourceClass::StorageImage) ? 8u : 4u;
+            for (uint32_t word = 0; word < words; ++word)
+                direct_descriptor_sregs.insert(static_cast<int>(resource.sgpr_base + word));
+        }
+    }
+
+    // Saved mask pairs and scalar-spill lane slots have their own value domains.
+    std::set<int> mask_keys;
+    for (const auto& kv : initial.sreg_bool) mask_keys.insert(kv.first);
+    std::set<std::pair<int, int>> lane_slots, mask_lane_slots;
+    // Discover every mask-valued SGPR first. A lane spill can precede another static definition of
+    // that mask in a back-edge block, so classifying spills in the same pass would be order-dependent.
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt == Rdna2Format::SOP1 &&
+            (in.opcode == 0x04 || in.opcode == 0x0a || in.opcode == 0x24 || in.opcode == 0x25) &&
+            in.dst.value != 126 && in.dst.value != 127)
+            mask_keys.insert(in.dst.value);
+        if (in.fmt == Rdna2Format::SOP2 &&
+            (in.opcode == 0x0b || in.opcode == 0x0f || in.opcode == 0x11 ||
+             in.opcode == 0x13 || in.opcode == 0x15 || in.opcode == 0x17 ||
+             in.opcode == 0x19 || in.opcode == 0x1b || in.opcode == 0x1d) &&
+            in.dst.value != 106 && in.dst.value != 107 && in.dst.value != 126 && in.dst.value != 127)
+            mask_keys.insert(in.dst.value);
+        if (in.fmt == Rdna2Format::VOPC && in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
+            mask_keys.insert(in.dst.value);
+    }
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt == Rdna2Format::VOP3 && in.opcode == 0x361 &&
+            in.src[1].kind == OperandKind::InlineInt && in.src[1].value >= 0 && in.src[1].value <= 63) {
+            const std::pair<int, int> slot{in.dst.value, in.src[1].value};
+            const bool is_mask = in.src[0].value == 106 || in.src[0].value == 107 ||
+                                 in.src[0].value == 126 || in.src[0].value == 127 ||
+                                 (in.src[0].kind == OperandKind::SGPR && mask_keys.count(in.src[0].value));
+            (is_mask ? mask_lane_slots : lane_slots).insert(slot);
+        }
+    }
+    for (const auto& vg : initial.vgpr_lane_slots)
+        for (const auto& slot : vg.second) lane_slots.emplace(vg.first, slot.first);
+    for (const auto& vg : initial.vgpr_lane_mask_slots)
+        for (const auto& slot : vg.second) mask_lane_slots.emplace(vg.first, slot.first);
+    // The dispatcher has separate persisted value domains for scalar data and lane masks. If one
+    // physical spill slot changes domain across paths, rejecting is safer than reloading both and
+    // letting v_readlane choose an arbitrary representation.
+    for (const auto& slot : lane_slots)
+        if (mask_lane_slots.count(slot)) return false;
+
+    uint32_t ptr_u32 = 0, ptr_bool = 0;
+    std::map<int, uint32_t> vv, sv, mv;
+    std::map<std::pair<int, int>, uint32_t> lv, lmv;
+    for (int r : vregs) vv[r] = b.function_var(b.t_u32, ptr_u32);
+    for (int r : sregs) sv[r] = b.function_var(b.t_u32, ptr_u32);
+    for (int r : mask_keys) mv[r] = b.function_var(b.t_bool, ptr_bool);
+    for (const auto& slot : lane_slots) lv[slot] = b.function_var(b.t_u32, ptr_u32);
+    for (const auto& slot : mask_lane_slots) lmv[slot] = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t scc_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t vcc_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t exec_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t pc_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t active_var = b.function_var(b.t_bool, ptr_bool);
+
+    const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
+    for (const auto& kv : vv) {
+        auto it = initial.vreg.find(kv.first);
+        b.store_function(kv.second, it == initial.vreg.end() ? zero : it->second);
+    }
+    for (const auto& kv : sv) {
+        auto it = initial.sreg.find(kv.first);
+        b.store_function(kv.second, it == initial.sreg.end() ? zero : it->second);
+    }
+    for (const auto& kv : mv) {
+        auto it = initial.sreg_bool.find(kv.first);
+        b.store_function(kv.second, it == initial.sreg_bool.end() ? no : it->second);
+    }
+    for (const auto& kv : lv) {
+        uint32_t value = zero;
+        auto vg = initial.vgpr_lane_slots.find(kv.first.first);
+        if (vg != initial.vgpr_lane_slots.end()) {
+            auto slot = vg->second.find(kv.first.second);
+            if (slot != vg->second.end()) value = slot->second;
+        }
+        b.store_function(kv.second, value);
+    }
+    for (const auto& kv : lmv) {
+        uint32_t value = no;
+        auto vg = initial.vgpr_lane_mask_slots.find(kv.first.first);
+        if (vg != initial.vgpr_lane_mask_slots.end()) {
+            auto slot = vg->second.find(kv.first.second);
+            if (slot != vg->second.end()) value = slot->second;
+        }
+        b.store_function(kv.second, value);
+    }
+    b.store_function(scc_var, initial.scc);
+    b.store_function(vcc_var, initial.vcc);
+    b.store_function(exec_var, initial.exec);
+    b.store_function(pc_var, b.uconst(0));
+    b.store_function(active_var, yes);
+
+    auto load_state = [&]() {
+        RegState state;
+        for (const auto& kv : vv) state.vreg[kv.first] = b.load_function(b.t_u32, kv.second);
+        for (const auto& kv : sv) state.sreg[kv.first] = b.load_function(b.t_u32, kv.second);
+        for (const auto& kv : mv) {
+            state.sreg_bool[kv.first] = b.load_function(b.t_bool, kv.second);
+            state.sreg_bool_narrowed[kv.first] = true;
+        }
+        for (const auto& kv : lv)
+            state.vgpr_lane_slots[kv.first.first][kv.first.second] =
+                b.load_function(b.t_u32, kv.second);
+        for (const auto& kv : lmv)
+            state.vgpr_lane_mask_slots[kv.first.first][kv.first.second] =
+                b.load_function(b.t_bool, kv.second);
+        state.scc = b.load_function(b.t_bool, scc_var);
+        state.vcc = b.load_function(b.t_bool, vcc_var);
+        state.exec = b.load_function(b.t_bool, exec_var);
+        state.exec_narrowed = true; // state-machine joins may carry a narrowed EXEC edge
+        state.mubuf_pcrel_tables = initial.mubuf_pcrel_tables;
+        return state;
+    };
+    auto save_state = [&](const RegState& state) {
+        for (const auto& kv : vv) {
+            auto it = state.vreg.find(kv.first);
+            b.store_function(kv.second, it == state.vreg.end() ? zero : it->second);
+        }
+        for (const auto& kv : sv) {
+            auto it = state.sreg.find(kv.first);
+            b.store_function(kv.second, it == state.sreg.end() ? zero : it->second);
+        }
+        for (const auto& kv : mv) {
+            auto it = state.sreg_bool.find(kv.first);
+            b.store_function(kv.second, it == state.sreg_bool.end() ? no : it->second);
+        }
+        for (const auto& kv : lv) {
+            uint32_t value = zero;
+            auto vg = state.vgpr_lane_slots.find(kv.first.first);
+            if (vg != state.vgpr_lane_slots.end()) {
+                auto slot = vg->second.find(kv.first.second);
+                if (slot != vg->second.end()) value = slot->second;
+            }
+            b.store_function(kv.second, value);
+        }
+        for (const auto& kv : lmv) {
+            uint32_t value = no;
+            auto vg = state.vgpr_lane_mask_slots.find(kv.first.first);
+            if (vg != state.vgpr_lane_mask_slots.end()) {
+                auto slot = vg->second.find(kv.first.second);
+                if (slot != vg->second.end()) value = slot->second;
+            }
+            b.store_function(kv.second, value);
+        }
+        b.store_function(scc_var, state.scc);
+        b.store_function(vcc_var, state.vcc);
+        b.store_function(exec_var, state.exec);
+    };
+
+    // Subgroup votes are required only by this fallback and therefore add no capability to the
+    // normal shader path.
+    SpirvCompute::put(b.caps, Op_Capability, {Cap_GroupNonUniform});
+    SpirvCompute::put(b.caps, Op_Capability, {Cap_GroupNonUniformVote});
+
+    const uint32_t loop_header = b.id(), switch_header = b.id(), switch_merge = b.id();
+    const uint32_t loop_continue = b.id(), loop_merge = b.id(), fallback = b.id();
+    std::vector<uint32_t> labels(starts.size());
+    std::vector<std::pair<uint32_t, uint32_t>> switch_cases;
+    for (uint32_t i = 0; i < starts.size(); ++i) {
+        labels[i] = b.id();
+        switch_cases.emplace_back(i, labels[i]);
+    }
+    b.emit_branch(loop_header);
+    b.emit_label(loop_header);
+    b.emit_loopmerge(loop_merge, loop_continue);
+    b.emit_branch(switch_header);
+    b.emit_label(switch_header);
+    const uint32_t selector = b.load_function(b.t_u32, pc_var);
+    b.emit_selmerge(switch_merge);
+    b.emit_switch(selector, fallback, switch_cases);
+
+    auto set_next = [&](uint32_t pc) {
+        auto found = block_for_pc.find(pc);
+        if (pc > end_pc || found == block_for_pc.end()) b.store_function(active_var, no);
+        else b.store_function(pc_var, b.uconst(found->second));
+    };
+    for (uint32_t block = 0; block < starts.size(); ++block) {
+        const uint32_t lo = starts[block];
+        const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
+        b.emit_label(labels[block]);
+        RegState state = load_state();
+        if (!direct_descriptor_sregs.empty()) {
+            std::set<int> written_vregs, written_sregs;
+            loop_written_regs(ins, 0, lo, written_vregs, written_sregs);
+            for (int reg : direct_descriptor_sregs)
+                if (!written_sregs.count(reg)) state.sreg.erase(reg);
+        }
+        const Rdna2Inst* terminator = nullptr;
+        for (const auto& in : ins) {
+            if (in.pc < lo || in.pc >= hi) continue;
+            if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
+                              in.opcode <= 0x09 && in.opcode != 0x03)) {
+                terminator = &in;
+                break;
+            }
+            if (in.fmt == Rdna2Format::EXP) {
+                if (!exp_fn(in)) return false;
+                continue;
+            }
+            bool ok = true;
+            if (!emit_alu(b, state, in, ok, allow_exec_update, &safe, allow_smem, rt,
+                          /*allow_wave*/false) || !ok) {
+                if (getenv("PROSPER_DBG"))
+                    std::fprintf(stderr, "[cfg-recompile-reject] pc=%u fmt=%d op=0x%x\n",
+                                 in.pc, static_cast<int>(in.fmt), in.opcode);
+                return false;
+            }
+        }
+        save_state(state);
+        if (!terminator) {
+            set_next(hi);
+        } else if (terminator->is_end) {
+            b.store_function(active_var, no);
+        } else if (terminator->opcode == 0x02) {
+            set_next(branch_target(*terminator));
+        } else {
+            uint32_t condition = 0;
+            switch (terminator->opcode) {
+                case 0x04: condition = b.logical_not(state.scc); break; // s_cbranch_scc0
+                case 0x05: condition = state.scc; break;
+                case 0x06: condition = b.logical_not(b.subgroup_any(state.vcc)); break;
+                case 0x07: condition = b.subgroup_any(state.vcc); break;
+                case 0x08: condition = b.logical_not(b.subgroup_any(state.exec)); break;
+                case 0x09: condition = b.subgroup_any(state.exec); break;
+                default: return false;
+            }
+            const uint32_t target = branch_target(*terminator);
+            const uint32_t fallthrough = terminator->pc + terminator->len_dwords;
+            auto taken = block_for_pc.find(target), next = block_for_pc.find(fallthrough);
+            if (taken == block_for_pc.end() || next == block_for_pc.end()) return false;
+            b.store_function(pc_var,
+                b.sel(condition, b.uconst(taken->second), b.uconst(next->second)));
+        }
+        b.emit_branch(switch_merge);
+    }
+    b.emit_label(fallback);
+    b.store_function(active_var, no);
+    b.emit_branch(switch_merge);
+    b.emit_label(switch_merge);
+    b.emit_branch(loop_continue);
+    b.emit_label(loop_continue);
+    b.emit_condbranch(b.load_function(b.t_bool, active_var), loop_header, loop_merge);
+    b.emit_label(loop_merge);
+
+    // Expose the final emulated state to the caller (compute currently consumes no register output,
+    // but keeping it coherent makes the helper reusable and avoids surprising post-body state).
+    initial = load_state();
+    return true;
+}
+
 // Emit the instruction body (shared by every stage). Handles a single recognized COUNTED loop as a real
 // structured SPIR-V loop (OpLoopMerge + OpPhi for loop-carried registers); loop-FREE streams walk straight
 // through, byte-identical to the pre-loop-feature behavior. `exp_fn` handles an EXP instruction per stage
@@ -3864,6 +4335,34 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe,
                                                              Ls.empty() ? nullptr : &Ls, &cf_rejected,
                                                              /*uniform_vcc_compute*/b.is_compute);
+
+        // UE4's volume-lighting kernels combine nested EXEC loops with a backward VCC vote loop.
+        // That shape is intentionally outside the narrow pattern structurizer above. Use the
+        // dispatcher fallback only when there is unmistakably complex compute control flow and the
+        // body is free of operations whose workgroup-uniform placement the dispatcher cannot prove.
+        // Existing straight-line, single-if, and recognized single-loop shaders keep their old path.
+        size_t cfg_branches = 0;
+        bool cfg_has_backedge = false, cfg_dispatch_safe = b.is_compute;
+        for (const auto& in : ins) {
+            if (in.is_end) break;
+            if (in.fmt == Rdna2Format::DS ||
+                (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
+                (in.fmt == Rdna2Format::VOP3 &&
+                 (in.opcode == 0x365 || in.opcode == 0x366)))
+                cfg_dispatch_safe = false;
+            if (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 && in.opcode <= 0x09 &&
+                in.opcode != 0x03) {
+                ++cfg_branches;
+                if (branch_target(in) <= in.pc) cfg_has_backedge = true;
+            }
+        }
+        // A lone exit + back-edge is the ordinary single-loop shape. Keep rejecting it when its
+        // wave-uniformity proof fails; the dispatcher is reserved for genuinely nested/multi-branch CFGs.
+        const bool complex_compute_cfg = cfg_dispatch_safe && cfg_branches > 2 && cfg_has_backedge;
+        if (complex_compute_cfg && (cf_rejected || Ls.empty()) &&
+            emit_compute_cfg_state_machine(b, rs, ins, safe, rt,
+                                           allow_exec_update, allow_smem, exp_fn))
+            return true;
         if (cf_rejected) Ls.clear();   // unmodeled CF somewhere: fall through to straight-line (loud reject)
         if (Fs.empty() && Ls.empty()) {
             wave_ok = true;   // straight-line: barriers are wave-uniform, so cross-lane mbcnt is safe here
@@ -4026,14 +4525,13 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     // Narrowed-ness is sticky (either edge narrowed → post-merge writes stay predicated).
                     if (then_exec != pre_exec) rs.exec = b.emit_phi_2way(b.t_bool, pre_exec, preblock, then_exec, thenEnd);
                     rs.exec_narrowed = pre_narrowed || then_narrowed;
-                    // A saved MASK (sreg_bool) whose value CHANGED inside the block would not dominate the
-                    // merge — phi it like SCC/VCC (a mask newly CREATED inside the block is left as-is,
-                    // matching the previous single-if behavior; its post-merge use, if any, was already
-                    // undominated before this path existed).
+                    // A saved MASK (sreg_bool) created or changed inside the block must dominate both
+                    // merge predecessors. A newly-created per-lane mask is false on the skipped edge.
                     for (auto& kv : rs.sreg_bool) {
                         auto p = pre_bool.find(kv.first);
-                        if (p != pre_bool.end() && p->second != kv.second) {
-                            kv.second = b.emit_phi_2way(b.t_bool, p->second, preblock, kv.second, thenEnd);
+                        const uint32_t before = p != pre_bool.end() ? p->second : b.bfalse();
+                        if (before != kv.second) {
+                            kv.second = b.emit_phi_2way(b.t_bool, before, preblock, kv.second, thenEnd);
                             rs.sreg_bool_narrowed[kv.first] = true;   // conservative: provenance now mixed
                         }
                     }
@@ -4078,12 +4576,19 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     if (then_vcc != rs.vcc) rs.vcc = b.emit_phi_2way(b.t_bool, then_vcc, thenEnd, rs.vcc, elseEnd);
                     if (then_exec != rs.exec) rs.exec = b.emit_phi_2way(b.t_bool, then_exec, thenEnd, rs.exec, elseEnd);
                     rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
-                    for (auto& kv : rs.sreg_bool) {         // masks changed differently per arm -> phi
-                        auto t = then_bool.find(kv.first);
-                        if (t != then_bool.end() && t->second != kv.second) {
-                            kv.second = b.emit_phi_2way(b.t_bool, t->second, thenEnd, kv.second, elseEnd);
-                            rs.sreg_bool_narrowed[kv.first] = true;
-                        }
+                    // Merge the UNION of mask keys. A mask created in only one arm is false in the
+                    // other arm; leaving that arm-local SSA id live after the merge is invalid SPIR-V.
+                    std::set<int> bool_keys;
+                    for (const auto& kv : then_bool) bool_keys.insert(kv.first);
+                    for (const auto& kv : rs.sreg_bool) bool_keys.insert(kv.first);
+                    for (int key : bool_keys) {
+                        auto t = then_bool.find(key);
+                        auto e = rs.sreg_bool.find(key);
+                        const uint32_t tv = t != then_bool.end() ? t->second : b.bfalse();
+                        const uint32_t ev = e != rs.sreg_bool.end() ? e->second : b.bfalse();
+                        rs.sreg_bool[key] = tv == ev ? tv
+                            : b.emit_phi_2way(b.t_bool, tv, thenEnd, ev, elseEnd);
+                        if (tv != ev) rs.sreg_bool_narrowed[key] = true;
                     }
                     lo = else_hi;   // continue after the merge (== hi for the escaping-cascade shape)
                 }
@@ -4224,6 +4729,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     const bool st_dim = i.mimg_dim <= 2u || i.mimg_dim == 4u || i.mimg_dim == 5u;
                     if (i.opcode == 0x00u) return st_dim || i.mimg_dim == 6u || i.mimg_dim == 7u;   // image_load (+ 2D_MSAA[_ARRAY])
                     if (i.opcode == 0x08u) return st_dim;                       // image_store (no per-sample MSAA store)
+                    if (i.opcode == 0x0eu) return i.mimg_dim <= 2u;             // image_get_resinfo 1D/2D/3D
                     // sample*: 2D (NSA ok); plus implicit-LOD image_sample (0x20) / LOD-0 image_sample_lz
                     // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D. 2D_ARRAY (dim 5)
                     // is accepted for all sample paths and handled as its base 2D slice (array index dropped,

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -2,6 +2,7 @@
 #include "shader_resources.hpp"
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <set>
@@ -42,6 +43,38 @@ float half_to_float(uint16_t h) {
     static_assert(sizeof(f) == sizeof(bits), "float is 32-bit");
     __builtin_memcpy(&f, &bits, sizeof f);
     return f;
+}
+
+uint16_t float_to_half(float f) {
+    uint32_t bits = 0;
+    std::memcpy(&bits, &f, sizeof(bits));
+    const uint16_t sign = static_cast<uint16_t>((bits >> 16) & 0x8000u);
+    const uint32_t exponent = (bits >> 23) & 0xffu;
+    uint32_t mantissa = bits & 0x7fffffu;
+    if (exponent == 0xffu) {
+        if (!mantissa) return static_cast<uint16_t>(sign | 0x7c00u);
+        uint16_t payload = static_cast<uint16_t>(mantissa >> 13);
+        if (!payload) payload = 1;
+        return static_cast<uint16_t>(sign | 0x7c00u | payload);
+    }
+
+    const int32_t half_exponent = static_cast<int32_t>(exponent) - 127 + 15;
+    if (half_exponent >= 31) return static_cast<uint16_t>(sign | 0x7c00u);
+    if (half_exponent <= 0) {
+        if (half_exponent < -10) return sign;
+        mantissa |= 0x800000u;
+        const uint32_t shift = static_cast<uint32_t>(14 - half_exponent);
+        uint32_t rounded = mantissa >> shift;
+        const uint32_t remainder = mantissa & ((1u << shift) - 1u);
+        const uint32_t halfway = 1u << (shift - 1u);
+        if (remainder > halfway || (remainder == halfway && (rounded & 1u))) rounded++;
+        return static_cast<uint16_t>(sign | rounded);
+    }
+
+    uint32_t rounded = mantissa >> 13;
+    const uint32_t remainder = mantissa & 0x1fffu;
+    if (remainder > 0x1000u || (remainder == 0x1000u && (rounded & 1u))) rounded++;
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(half_exponent) << 10) | rounded);
 }
 
 float f11_to_float(uint16_t v) {

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -52,6 +52,10 @@ uint32_t data_format_bytes(DataFormat f);
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
 float half_to_float(uint16_t h);
 
+// IEEE-754 binary32 -> binary16, round-to-nearest-even. This is the inverse conversion needed when
+// a format-free storage-image write targets an R16_FLOAT/R16G16B16A16_FLOAT guest surface.
+uint16_t float_to_half(float f);
+
 // Unsigned small-float components of a packed Float10_11_11 texel (#294). Both share binary16's
 // 5-bit exponent (bias 15) with a shortened mantissa (6 bits for the 11-bit R/G, 5 for the 10-bit B)
 // and NO sign bit — so a left-shift of the mantissa into a half's 10-bit field is an exact
@@ -106,13 +110,14 @@ struct ShaderResource {
     uint32_t      fetch_pc      = 0xFFFFFFFFu;
 
     // Texture-only (cls == Texture). img_dim mirrors the MIMG dim field (1D=0, 2D=1, 3D=2, ...).
-    // width/height are for image_load/texelFetch + unnormalized addressing (unused by normalized
-    // image_sample). sampler_sgpr_base = the paired sampler's S# base SGPR (SSAMP); with a Vulkan
+    // width/height/depth are the complete base-level extent (depth is >1 for 3D only), used by image
+    // queries, uploads, and image_load/texelFetch. sampler_sgpr_base = the paired sampler's S# base SGPR (SSAMP); with a Vulkan
     // COMBINED_IMAGE_SAMPLER the sampler is baked into the same `binding`, so this is provenance for a
     // future image/sampler split.
     uint32_t      img_dim           = 1;
     uint32_t      width             = 0;
     uint32_t      height            = 0;
+    uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -342,6 +342,73 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
 inline bool is_64kb_mode(uint32_t tile_mode) {
     return tile_mode == (uint32_t)TileMode::Sw64KbS || tile_mode == (uint32_t)TileMode::Sw64KbRX;
 }
+
+// For the PS5/default 16-pipe GFX10_SW_64K_R_X_1xaa pattern, AddrLib nibble2[74]
+// contributes z3,z2,z1,z0 to byte-offset bits 8..11 respectively. The X/Y portions are the
+// existing kSw64kRX[4] table above. Keeping this separate makes the previously 2D-only table's
+// intentional z==0 projection explicit.
+constexpr uint16_t kSw64kbRXVolumeZ[16] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0x0008, 0x0004, 0x0002, 0x0001, 0, 0, 0, 0
+};
+
+size_t sw64kb_volume_bytes(uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+    const uint32_t el = sw64kb_elem_log2(bpe);
+    if (el == UINT32_MAX) return 0;
+    const size_t slice = sw64kb_tiled_bytes(width, height, 0, bpe);
+    if (!slice || depth > SIZE_MAX / slice) return 0;
+    return slice * depth;
+}
+
+template <bool ToTiled>
+bool sw64kb_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
+                        uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+    const uint32_t el = sw64kb_elem_log2(bpe);
+    if (el == UINT32_MAX || sw64kb_rx_pipes_log2() != 4) return false;
+    uint32_t bw = 0, bh = 0;
+    sw64kb_dims(el, bw, bh);
+    const uint64_t blocks_x = (static_cast<uint64_t>(width) + bw - 1) / bw;
+    const uint64_t blocks_y = (static_cast<uint64_t>(height) + bh - 1) / bh;
+    const PatBit* pat = kSw64kRX[4][el];
+    std::vector<uint16_t> fx(width), fy(height), fz(depth);
+    for (uint32_t x = 0; x < width; x++) {
+        uint32_t v = 0;
+        for (uint32_t i = el; i < 16; i++)
+            v |= static_cast<uint32_t>(__builtin_popcount(x & pat[i].x) & 1) << i;
+        fx[x] = static_cast<uint16_t>(v);
+    }
+    for (uint32_t y = 0; y < height; y++) {
+        uint32_t v = 0;
+        for (uint32_t i = el; i < 16; i++)
+            v |= static_cast<uint32_t>(__builtin_popcount(y & pat[i].y) & 1) << i;
+        fy[y] = static_cast<uint16_t>(v);
+    }
+    for (uint32_t z = 0; z < depth; z++) {
+        uint32_t v = 0;
+        for (uint32_t i = el; i < 16; i++)
+            v |= static_cast<uint32_t>(__builtin_popcount(z & kSw64kbRXVolumeZ[i]) & 1) << i;
+        fz[z] = static_cast<uint16_t>(v);
+    }
+    for (uint32_t z = 0; z < depth; z++) {
+        const uint64_t slab = static_cast<uint64_t>(z) * blocks_y * blocks_x;
+        for (uint32_t y = 0; y < height; y++) {
+            const uint64_t row = slab + static_cast<uint64_t>(y / bh) * blocks_x;
+            for (uint32_t x = 0; x < width; x++) {
+                const uint64_t block = row + x / bw;
+                const uint64_t tiled = (block << 16) | static_cast<uint32_t>(fx[x] ^ fy[y] ^ fz[z]);
+                const size_t linear =
+                    ((static_cast<size_t>(z) * height + y) * width + x) * bpe;
+                if (ToTiled) {
+                    if (tiled + bpe <= tiled_bytes) std::memcpy(dst + tiled, src + linear, bpe);
+                } else if (tiled + bpe <= tiled_bytes) {
+                    std::memcpy(dst + linear, src + tiled, bpe);
+                } else {
+                    std::memset(dst + linear, 0, bpe);
+                }
+            }
+        }
+    }
+    return true;
+}
 } // namespace
 
 size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, uint32_t pitch,
@@ -415,6 +482,49 @@ void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
         return;
     }
     sw4kb_copy<false>(dst, src, ew, eh, /*pitch*/0, bpe, src_bytes);
+}
+
+bool tile_mode_supports_volume(uint32_t tile_mode) {
+    return tile_mode == (uint32_t)TileMode::Linear ||
+           (tile_mode == (uint32_t)TileMode::Sw64KbRX && sw64kb_rx_pipes_log2() == 4);
+}
+
+size_t tiled_volume_bytes(uint32_t width, uint32_t height, uint32_t depth,
+                          uint32_t tile_mode, uint32_t bytes_per_texel) {
+    if (!width || !height || !depth || !bytes_per_texel) return 0;
+    if (tile_mode == (uint32_t)TileMode::Linear) {
+        const uint64_t texels = static_cast<uint64_t>(width) * height * depth;
+        if (texels > SIZE_MAX / bytes_per_texel) return 0;
+        return static_cast<size_t>(texels * bytes_per_texel);
+    }
+    if (!tile_mode_supports_volume(tile_mode)) return 0;
+    return sw64kb_volume_bytes(width, height, depth, bytes_per_texel);
+}
+
+bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                   uint32_t width, uint32_t height, uint32_t depth,
+                   uint32_t tile_mode, uint32_t bytes_per_texel) {
+    const size_t linear_bytes = static_cast<size_t>(width) * height * depth * bytes_per_texel;
+    if (tile_mode == (uint32_t)TileMode::Linear) {
+        if (src_bytes < linear_bytes) return false;
+        std::memcpy(dst, src, linear_bytes);
+        return true;
+    }
+    if (!tile_mode_supports_volume(tile_mode)) return false;
+    return sw64kb_volume_copy<false>(dst, src, src_bytes, width, height, depth, bytes_per_texel);
+}
+
+bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
+                 uint32_t width, uint32_t height, uint32_t depth,
+                 uint32_t tile_mode, uint32_t bytes_per_texel) {
+    const size_t need = tiled_volume_bytes(width, height, depth, tile_mode, bytes_per_texel);
+    if (!need || dst_bytes < need) return false;
+    if (tile_mode == (uint32_t)TileMode::Linear) {
+        std::memcpy(dst, src, need);
+        return true;
+    }
+    std::memset(dst, 0, need);
+    return sw64kb_volume_copy<true>(dst, src, need, width, height, depth, bytes_per_texel);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -57,4 +57,18 @@ void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 // must read at least this many bytes of tiled source before detiling.
 size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode);
 
+// GFX10 volume layout. PS5's observed 3D surfaces use SW_64KB_R_X (mode 27), which AddrLib defines
+// as a thin/view-as-2D volume: each Z slice owns a padded grid of 2D 64KB blocks, but Z still
+// participates in the pipe-XOR bits inside every block. These helpers return false/zero for tiled
+// modes whose 3D pattern is not implemented. `src_bytes` bounds detile reads.
+bool tile_mode_supports_volume(uint32_t tile_mode);
+size_t tiled_volume_bytes(uint32_t width, uint32_t height, uint32_t depth,
+                          uint32_t tile_mode, uint32_t bytes_per_texel);
+bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                   uint32_t width, uint32_t height, uint32_t depth,
+                   uint32_t tile_mode, uint32_t bytes_per_texel);
+bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
+                 uint32_t width, uint32_t height, uint32_t depth,
+                 uint32_t tile_mode, uint32_t bytes_per_texel);
+
 } // namespace prosper::gpu

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -67,7 +67,8 @@ struct FrameResource {
                                     // collide binding 2/3 between stages and make the layout invalid).
     std::vector<uint32_t> dwords;   // storage-buffer contents (empty -> a 1-dword zero buffer)
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
-    uint32_t tw = 0, th = 0;
+    uint32_t tw = 0, th = 0, td = 1;
+    uint32_t img_dim = 1;             // ShaderResource/MIMG dim (1=2D, 2=3D); depth-1 3D stays 3D
     // Sampler state (Texture only). Defaults = LINEAR + clamp-to-edge — the harness's prior fixed
     // sampler — so render tests that build FrameResources directly stay byte-identical. The live path
     // fills these from the decoded S# (shader_resources.hpp). filter: 0=nearest, 1=linear; addr = Gen5
@@ -1024,7 +1025,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
                         : VK_SHADER_STAGE_FRAGMENT_BIT;
                     VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-                    tci.imageType = VK_IMAGE_TYPE_2D; tci.format = VK_FORMAT_R8G8B8A8_UNORM; tci.extent = {r.tw, r.th, 1};
+                    const bool texture_3d = r.img_dim == 2;
+                    tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
+                    tci.format = VK_FORMAT_R8G8B8A8_UNORM; tci.extent = {r.tw, r.th, r.td};
                     tci.mipLevels = 1; tci.arrayLayers = 1; tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
                     tci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
                     vkCreateImage(dev, &tci, nullptr, &v.timg[i]);
@@ -1044,7 +1047,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     // matching encode on store -> linear values into a UNORM swapchain -> too dark. A
                     // correct sRGB fix is a coordinated linear-working-space + output-encode change (see the
                     // #263 discussion), NOT a per-view format flip. r.srgb is decoded now as groundwork.
-                    tvci.image = v.timg[i]; tvci.viewType = VK_IMAGE_VIEW_TYPE_2D; tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
+                    tvci.image = v.timg[i];
+                    tvci.viewType = texture_3d ? VK_IMAGE_VIEW_TYPE_3D : VK_IMAGE_VIEW_TYPE_2D;
+                    tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
                     // T# DST_SEL channel remap (#261): map each SQ_SEL to a VkComponentSwizzle. Identity
                     // (the default, and the narrow/font path) yields IDENTITY == a no-op. PROSPER_NO_SWIZZLE
                     // forces identity for A/B testing against the pre-swizzle behavior.
@@ -1106,7 +1111,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     }
                     sci.minLod = r.min_lod; sci.maxLod = r.max_lod; sci.mipLodBias = r.lod_bias;
                     vkCreateSampler(dev, &sci, nullptr, &v.tsamp[i]);
-                    VkDeviceSize tbytes = (VkDeviceSize)r.tw * r.th * 4;
+                    VkDeviceSize tbytes = (VkDeviceSize)r.tw * r.th * r.td * 4;
                     VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
                     vkCreateBuffer(dev, &stci, nullptr, &v.tstage[i]);
                     VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, v.tstage[i], &sr);
@@ -1236,7 +1241,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         b0.image = v.timg[i]; b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         b0.srcAccessMask = 0; b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
-        VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; tc.imageExtent = {v.R[i].tw, v.R[i].th, 1};
+        VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        tc.imageExtent = {v.R[i].tw, v.R[i].th, v.R[i].td};
         vkCmdCopyBufferToImage(cmd, v.tstage[i], v.timg[i], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
         VkImageMemoryBarrier b1{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL; b1.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -28,13 +28,14 @@ static void make_vsharp(uint32_t v[4], uint64_t base, uint32_t stride, uint32_t 
 // Width5-1 split over word1[31:30] (lo) + word2[11:0] (hi), Height5-1 @word2[27:14], TileMode
 // @word3[24:20], Type @word3[31:28]. Mirrors decode_image_descriptor / Kyty's Gen5 getters.
 static void make_tsharp(uint32_t t[8], uint64_t base, uint32_t w, uint32_t h, uint32_t fmt,
-                        uint32_t tile_mode, uint32_t type) {
+                        uint32_t tile_mode, uint32_t type, uint32_t depth = 1) {
     memset(t, 0, 8 * sizeof(uint32_t));
     uint64_t b = base >> 8;                       // 256-byte-aligned base, stored >>8
     t[0] = (uint32_t)(b & 0xffffffffu);
     t[1] = (uint32_t)((b >> 32) & 0xffu) | ((fmt & 0x1ffu) << 20) | (((w - 1) & 0x3u) << 30);
     t[2] = (((w - 1) >> 2) & 0xfffu) | (((h - 1) & 0x3fffu) << 14);
     t[3] = ((tile_mode & 0x1fu) << 20) | ((type & 0xfu) << 28);
+    if (type == 10) t[4] = (depth - 1) & 0x1fffu;
 }
 
 int main() {
@@ -88,6 +89,11 @@ int main() {
               image_type_to_dim(14) == 6 && image_type_to_dim(15) == 7,
               "T# TYPE array/MSAA variants map to MIMG dims 4..7");
         CHECK(image_type_to_dim(0) == 1, "unknown T# TYPE keeps the conservative 2D fallback");
+        uint32_t t3d[8];
+        make_tsharp(t3d, 0x12000000ull, 32, 16, /*fmt*/56, /*tile*/0, /*type 3D*/10, /*depth*/8);
+        const DecodedImageDescriptor d3d = decode_image_descriptor(t3d);
+        CHECK(d3d.width == 32 && d3d.height == 16 && d3d.depth == 8,
+              "3D T# word4 DEPTH decodes as depth-minus-one");
     }
 
     // --- AGC semantic metadata -> SPI_PS_INPUT_CNTL wiring ------------------------------------

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -140,6 +140,7 @@ int main() {
     ds_seed.depth_valid = true; ds_seed.stencil_valid = true;
     ds_seed.depth.assign(16, 0x31); ds_seed.stencil = {1, 2, 3, 4};
     captured.ds_seeds.push_back(ds_seed);
+    captured.draws[0].vrt.resources[0].resource.depth = 7;
 
     auto path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_test.prgcap";
     GpuCaptureFile duplicate_seed = captured; duplicate_seed.rtt_seeds.push_back(captured.rtt_seeds[0]);
@@ -156,7 +157,7 @@ int main() {
           deserialize_gpu_capture(stencil_only_bytes, stencil_only_loaded, error) &&
           !stencil_only_loaded.ds_seeds[0].depth_valid &&
           stencil_only_loaded.ds_seeds[0].stencil_valid,
-          "stencil-only validity survives capture v8 independently of depth");
+          "stencil-only validity survives capture v9 independently of depth");
     GpuCaptureFile invalid_stencil_format = stencil_only;
     invalid_stencil_format.ds_seeds[0].format = GpuCaptureDsFormat::D32Float;
     CHECK(!serialize_gpu_capture(invalid_stencil_format, stencil_only_bytes, error) &&
@@ -174,6 +175,8 @@ int main() {
           "per-target extent round-trips");
     CHECK(loaded.draws[0].vrt.resources[0].resource.format == DataFormat::Unorm2_10_10_10,
           "newest packed image format enum round-trips");
+    CHECK(loaded.draws[0].vrt.resources[0].resource.depth == 7,
+          "v9 resource depth round-trips");
     CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");
@@ -336,10 +339,13 @@ int main() {
 
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
-    CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 24,
-          "created a diagnostic-free v8 payload for legacy-reader fixtures");
-    if (legacy_bytes.size() >= 24) {
-        legacy_bytes.resize(legacy_bytes.size() - 4); // remove v8 DS-seed zero count
+    CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 28,
+          "created a diagnostic-free v9 payload for legacy-reader fixtures");
+    if (legacy_bytes.size() >= 28) {
+        const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
+                                             legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 4 - 4 - 4 * legacy_resource_count);
+        // remove v9 depth section (count + values) and the v8 DS-seed zero count
         legacy_bytes[8] = 7; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
     }
     GpuCaptureFile legacy_loaded;
@@ -353,9 +359,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 9;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 10;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 9",
+          error == "unsupported capture version 10",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -110,6 +110,11 @@ int main() {
     Rdna2Inst sd = rdna2_decode_one(sdwa, 2);
     CHECK(sd.fmt == Rdna2Format::VOP2 && sd.len_dwords == 2 && sd.has_modifier,
           "VOP2 SDWA form is 2 dwords and flagged has_modifier");
+    const uint32_t f16cmp[] = { 0x7db900f9u, 0x86050007u };
+    Rdna2Inst fc = rdna2_decode_one(f16cmp, 2);
+    CHECK(fc.fmt == Rdna2Format::VOPC && fc.opcode == 0xDCu && !fc.has_modifier &&
+          fc.sdwa_src0_sel == 5u && fc.sdwa_src1_sel == 6u,
+          "VOPC f16 SDWA WORD_1 source select is decoded for recompilation");
     const uint32_t dpp16[] = { 0x4a0e0cfau, 0xff011106u };   // v_add_nc_u32_dpp v7, v6, v6 row_shr:1
     Rdna2Inst dp = rdna2_decode_one(dpp16, 2);
     CHECK(dp.fmt == Rdna2Format::VOP2 && dp.len_dwords == 2 && dp.has_modifier,
@@ -174,6 +179,14 @@ int main() {
     const uint32_t smem_neg[] = { 0xf4000002u, 0xfa1ffff8u };
     Rdna2Inst sn = rdna2_decode_one(smem_neg, 2);
     CHECK((int32_t)sn.literal == -8, "SMEM 21-bit immediate is sign-extended (0x1ffff8 -> -8)");
+
+    // s_load uses a 64-bit address pair, not V# bounds. UE4's root SRT at s[12:13] loads x4 at
+    // byte offset 0x250, requiring a 0x260-byte mapped range even when s14 happens to contain 1.
+    const uint32_t sload_range[] = { 0xf4080706u, 0xfa000250u, 0xbf810000u };
+    CHECK(rdna2_sload_required_bytes(sload_range, 3, 12) == 0x260u,
+          "immediate s_load range inference includes offset plus x4 width");
+    CHECK(rdna2_sload_required_bytes(sload_range, 3, 8) == 0u,
+          "s_load range inference ignores a different SBASE pair");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -241,7 +241,8 @@ int main() {
     // the Fragment execution model — the compute and vertex shells have no derivatives, so an
     // image_sample there must lower to OpImageSampleExplicitLod (LOD 0) or spirv-val rejects the
     // module and pipeline creation fails.
-    enum : uint32_t { OpImageSampleImplicitLod = 87, OpImageSampleExplicitLod = 88 };
+    enum : uint32_t { OpImageSampleImplicitLod = 87, OpImageSampleExplicitLod = 88,
+                      OpImageQuerySizeLod = 103, OpImageQueryLevels = 106 };
     ShaderResourceTable rt_tex;
     { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1; /*2D*/
       t.width = 2; t.height = 2; t.sgpr_base = 8; rt_tex.resources.push_back(t); }
@@ -283,6 +284,25 @@ int main() {
         return 1;
     }
     printf("  [ok]   fragment image_sample still uses OpImageSampleImplicitLod\n");
+
+    // UE4/DOLL volume initialization starts by querying a 3D T# with image_get_resinfo, then uses the
+    // xyz result for its dispatch bounds. This was the sole rejected opcode in that captured kernel.
+    ShaderResourceTable rt_3d;
+    { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 2;
+      t.width = 8; t.height = 8; t.sgpr_base = 0; rt_3d.resources.push_back(t); }
+    const uint32_t cs_resinfo[] = {
+        0x7e060280u,                         // v_mov_b32 v3, 0 (LOD)
+        0xf0380710u, 0x00000003u,           // image_get_resinfo v[0:2], v3, s[0:7] dmask:xyz dim:3D
+        0xbf810000u,
+    };
+    std::vector<uint32_t> resinfo_spv = recompile_valu(
+        cs_resinfo, sizeof(cs_resinfo)/sizeof(cs_resinfo[0]), 0, 0, &rt_3d);
+    if (resinfo_spv.empty() || !has_opcode(resinfo_spv, OpImageQuerySizeLod) ||
+        !has_opcode(resinfo_spv, OpImageQueryLevels)) {
+        printf("  [FAIL] image_get_resinfo 3D did not lower to SPIR-V image queries\n");
+        return 1;
+    }
+    printf("  [ok]   image_get_resinfo 3D lowers to size/level image queries\n");
 
     // LDS array is sized from the shader's real allocation (#130), not a hardcoded 16 KB. A compute
     // kernel that uses ds_write/ds_read declares a Workgroup array; its length must be 4096 dwords

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -2,6 +2,7 @@
 // requiring a complete vertex/fragment. Pure (no Vulkan), so it runs in CI. It also drives the
 // data-driven coverage report over the real game shaders (shader_histo).
 #include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
 #include <cstdio>
 #include <vector>
 
@@ -60,6 +61,37 @@ int main() {
     CHECK(recompile_valu(compute_vcc_loop_varying,
                          sizeof(compute_vcc_loop_varying)/sizeof(compute_vcc_loop_varying[0]), 0, 0).empty(),
           "a VCCZ-exit loop whose compare reads a varying VGPR still rejects in the compute shell");
+    // A genuinely nested/multi-branch compute CFG uses the subgroup-vote dispatcher fallback. This
+    // is the reduced shape of UE4's volume-lighting kernel: varying VCC exit, an inner scalar branch,
+    // and a backward loop edge. The simpler two-branch loop above deliberately remains rejected.
+    const uint32_t compute_cfg_dispatch[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020300u,
+        0xD7610013u, 0x00014A7Eu, 0xD7610013u, 0x0001507Fu,
+        0xD760000Eu, 0x00014B13u, 0xD760000Fu, 0x00015113u, 0xBEFE040Eu,
+        0xE00C2000u, 0x80020400u, 0x7DB900F9u, 0x86050007u,
+        0x7D020200u, 0xBF860006u, 0xBF0A8204u, 0x360000FDu, 0xBF840001u,
+        0x81008100u, 0x81008100u, 0xBF82FFF4u,
+        0xBF810000u,
+    };
+    ShaderResourceTable dispatch_rt;
+    ShaderResource dispatch_vb{}; dispatch_vb.cls = ResourceClass::VertexBuffer;
+    dispatch_vb.binding = 3; dispatch_vb.sgpr_base = 8; dispatch_vb.stride = 16;
+    dispatch_vb.format = DataFormat::Float32; dispatch_vb.num_components = 4;
+    dispatch_rt.resources.push_back(dispatch_vb);
+    CHECK(!recompile_valu(compute_cfg_dispatch,
+                          sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]), 0, 0,
+                          &dispatch_rt).empty(),
+          "a nested varying-VCC compute CFG preserves spilled EXEC and lowers through the dispatcher");
+    const uint32_t scc_data_source[] = {
+        0xBF060000u, 0x360000FDu, 0xBF810000u, // s_cmp_eq_u32 s0,s0; v_and_b32 v0,scc,v0
+    };
+    CHECK(!recompile_valu(scc_data_source, sizeof(scc_data_source)/sizeof(scc_data_source[0]), 0, 0).empty(),
+          "SCC is accepted as its architectural scalar 0/1 ALU source");
+    const uint32_t mask_nor[] = {
+        0x7C040CF9u, 0x06869880u, 0x8DEA6A18u, 0xBF810000u,
+    };
+    CHECK(!recompile_valu(mask_nor, sizeof(mask_nor)/sizeof(mask_nor[0]), 0, 0).empty(),
+          "s_nor_b64 combines a saved comparison mask with VCC in the bool domain");
     // An s_barrier INSIDE the loop body also rejects: the uniformity proof is per-WAVE, and a
     // barrier inside a loop whose trip count could differ across the workgroup's waves would be
     // workgroup-divergent control flow (UB).
@@ -106,6 +138,17 @@ int main() {
     CHECK(!recompile_valu(compute_vcc_if_hoisted,
                           sizeof(compute_vcc_if_hoisted)/sizeof(compute_vcc_if_hoisted[0]), 0, 0).empty(),
           "the uniformity proof looks past VCC-preserving instructions between compare and branch");
+    // UE4's scalar-spill lowering also schedules v_writelane_b32 between the uniform compare and
+    // its VCCZ branch. The op updates one lane of a VGPR and cannot clobber VCC, so it must not stop
+    // the same local proof. (Raw pair assembled and round-tripped with llvm-mc gfx1010.)
+    const uint32_t compute_vcc_if_writelane[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u,
+        0xD7610013u, 0x00012A1Bu, // v_writelane_b32 v19, s27, 21
+        0xBF860002u, 0x060000FFu, 0x3E800000u, 0xBF810000u,
+    };
+    CHECK(!recompile_valu(compute_vcc_if_writelane,
+                          sizeof(compute_vcc_if_writelane)/sizeof(compute_vcc_if_writelane[0]), 0, 0).empty(),
+          "the uniformity proof looks past VCC-preserving v_writelane scalar spills");
     // But an intervening write that COULD hit VCC (s_mov_b32 s106, 0) stops the walk: reject.
     const uint32_t compute_vcc_if_clobber[] = {
         0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBEEA0380u,

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -78,6 +78,15 @@ int main() {
           "8-bit formats are 1 byte");
     CHECK(data_format_bytes(DataFormat::Unknown) == 0, "Unknown format is 0 bytes");
 
+    CHECK(float_to_half(0.0f) == 0x0000u && float_to_half(-0.0f) == 0x8000u &&
+          float_to_half(1.0f) == 0x3c00u && float_to_half(-2.0f) == 0xc000u &&
+          float_to_half(65504.0f) == 0x7bffu,
+          "float32 -> float16 conversion preserves zero/sign and exact finite values");
+    CHECK(float_to_half(half_to_float(0x0001u)) == 0x0001u &&
+          float_to_half(half_to_float(0x3555u)) == 0x3555u &&
+          float_to_half(half_to_float(0x7bffu)) == 0x7bffu,
+          "float16 -> float32 -> float16 round-trip is bit exact for finite values");
+
     // A table as the front-half would build it: a float32×4 constant buffer (descriptor at SRT 0x20)
     // and a unorm8×4 vertex buffer (descriptor at SRT 0x40).
     ShaderResourceTable t;

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -454,6 +454,49 @@ int main() {
         CHECK(std::memcmp(&tiled[8704], at(16, 0), bpe) == 0, "64KB_R_X 4B golden: element (16,0) at byte 8704 (x4 -> bits 9+13)");
     }
 
+    // GFX10 thin/view-as-2D 3D SW_64KB_R_X. Each Z slice owns a padded 2D block grid, while Z
+    // participates in the pipe-XOR inside that slice; z0..z3 map to offset bits 11..8.
+    if (!getenv("PROSPER_RX_PIPES")) {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbRX;
+        CHECK(tile_mode_supports_volume(M), "SW_64KB_R_X has an explicit 3D pipe-XOR pattern");
+        CHECK(tiled_volume_bytes(120, 68, 32, M, 8) == (size_t)1 * 2 * 32 * 65536,
+              "120x68x32 @ 8 B uses 1x2 padded 2D blocks per Z slice");
+        auto rt_volume = [&](uint32_t bpe) {
+            static const uint32_t dims[5][2] = {
+                {256,256}, {256,128}, {128,128}, {128,64}, {64,64}
+            };
+            uint32_t el = 0; while ((1u << el) < bpe) el++;
+            const uint32_t w = dims[el][0] + 3, h = dims[el][1] + 2, d = 5;
+            std::vector<uint8_t> ref((size_t)w * h * d * bpe);
+            for (size_t i = 0; i < ref.size(); i++) ref[i] = (uint8_t)((i * 2246822519u) >> 13);
+            const size_t bytes = tiled_volume_bytes(w, h, d, M, bpe);
+            std::vector<uint8_t> tiled(bytes, 0), back(ref.size(), 0);
+            return tile_volume(tiled.data(), tiled.size(), ref.data(), w, h, d, M, bpe) &&
+                   detile_volume(back.data(), tiled.data(), tiled.size(), w, h, d, M, bpe) &&
+                   back == ref;
+        };
+        CHECK(rt_volume(1) && rt_volume(2) && rt_volume(4) && rt_volume(8) && rt_volume(16),
+              "SW_64KB_R_X 3D round-trip is exact at every supported texel size");
+
+        const uint32_t w = 128, h = 64, d = 16, bpe = 8;
+        std::vector<uint8_t> ref((size_t)w * h * d * bpe);
+        for (size_t i = 0; i < ref.size(); i++) ref[i] = (uint8_t)((i >> 3) * 43 + i);
+        std::vector<uint8_t> tiled((size_t)d * 65536, 0);
+        CHECK(tile_volume(tiled.data(), tiled.size(), ref.data(), w, h, d, M, bpe),
+              "one 128x64 8-B block per volume slice tiles successfully");
+        auto at3 = [&](uint32_t x, uint32_t y, uint32_t z) {
+            return &ref[(((size_t)z * h + y) * w + x) * bpe];
+        };
+        CHECK(std::memcmp(&tiled[(size_t)1 * 65536 + 2048], at3(0,0,1), bpe) == 0,
+              "64KB_R_X 3D golden: z0 maps to byte-offset bit 11");
+        CHECK(std::memcmp(&tiled[(size_t)2 * 65536 + 1024], at3(0,0,2), bpe) == 0,
+              "64KB_R_X 3D golden: z1 maps to byte-offset bit 10");
+        CHECK(std::memcmp(&tiled[(size_t)4 * 65536 + 512], at3(0,0,4), bpe) == 0,
+              "64KB_R_X 3D golden: z2 maps to byte-offset bit 9");
+        CHECK(std::memcmp(&tiled[(size_t)8 * 65536 + 256], at3(0,0,8), bpe) == 0,
+              "64KB_R_X 3D golden: z3 maps to byte-offset bit 8");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -137,9 +137,10 @@ lifetime evidence proves the suffix contains the target's beginning, then inspec
 `gpu_replay --bundle-intermediate-through-target WxH` omits later passes from non-final submits only when
 dependency evidence proves that the named target family is the sole temporal image frontier.
 `gpu_replay --bundle-final-capsule PATH` exports the complete live color RTT cache plus exact valid planes from
-the persistent Vulkan depth/stencil cache into a capture-v8 capsule. Verify its standalone output hash against
+the persistent Vulkan depth/stencil cache into a capture-v9 capsule, including base-level depth for 3D image
+resources. Verify its standalone output hash against
 the bundle before using it for rapid final-submit isolation. `--inspect-only` prints each DS seed's full cache
-identity, format, independent validity flags, byte counts, and hashes. Captures v1-v7 remain readable without
+identity, format, independent validity flags, byte counts, and hashes. Captures v1-v8 remain readable without
 invented DS state.
 `gpu_replay --bundle-extract-submit N PATH` materializes one exact manifest for normal inspect/graph/validate
 work without replaying the bundle.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -148,12 +148,13 @@ if an included temporal image leaf has another extent or an intermediate submit 
 an evidence-gated optimization, not automatic dependency closure.
 
 `--bundle-final-capsule PATH` snapshots the complete live color RTT and persistent Vulkan depth/stencil caches
-before executing the final submit and writes them as seeds in a standalone capture-v8 capsule. Its standalone
+before executing the final submit and writes them as seeds in a standalone capture-v9 capsule. Capture v9 also
+retains the base-level depth of every 3D image resource. Its standalone
 output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or
 shader experiments. Export validates every surface and fails when a required temporal color surface is absent;
 it never substitutes zero pixels. The file is installed only after the source final submit renders, and embeds
 that output byte count/hash as its replay oracle. A legacy pre-v7 manifest with unrealized operations is migrated explicitly to
-`Unknown` failure diagnostics with the original operation kind/source/order, so the v8 writer remains strict.
+`Unknown` failure diagnostics with the original operation kind/source/order, so the v9 writer remains strict.
 The DS snapshot uses transfer barriers to return every image to depth/stencil-attachment layout before the final
 bundle submit executes; equality therefore also checks that readback did not perturb the source run.
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -169,14 +169,15 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
         });
         std::printf("  %s %-7s b=%u addr=%016llx declared=%u footprint=%llu captured=%llu "
                     "nz=%zu hash=%016llx first=%08x "
-                    "fmt=%u nc=%u stride=%u %ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
+                    "fmt=%u nc=%u stride=%u %ux%ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
                     "srt=%08x sgpr=%08x pc=%08x%s\n",
                     stage, class_name(r.cls), r.binding, static_cast<unsigned long long>(r.gpu_addr),
                     r.size,
                     static_cast<unsigned long long>(prosper::gpu::gpu_capture_resource_footprint(r)),
                     static_cast<unsigned long long>(r.host_data_size), nz,
                     static_cast<unsigned long long>(hash), first,
-                    static_cast<unsigned>(r.format), r.num_components, r.stride, r.width, r.height, r.tile_mode,
+                    static_cast<unsigned>(r.format), r.num_components, r.stride,
+                    r.width, r.height, r.depth, r.tile_mode,
                     r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2],
                     r.swizzle[0], r.swizzle[1], r.swizzle[2], r.swizzle[3],
                     r.mag_filter, r.min_filter, r.mip_filter,

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -113,9 +113,42 @@ int main(int argc, char** argv) {
       ShaderResource s{};  s.cls=ResourceClass::StorageImage; s.binding=1; s.sgpr_base=16; rt.resources.push_back(s);
       const uint32_t c[] = {0x7E0002F0u,0x7E0202F0u,0xF09C0F08u,0x00400400u,0xBF8C3F70u,0xF0200108u,0x00040402u,0xBF810000u};
       dump(dir, "compute_sample_store", recompile_valu(c, sizeof(c)/4, 0, 0, &rt)); }
+    // Compute image_get_resinfo on a sampled 3D image (DOLL's volume-initializer bounds query).
+    { ShaderResourceTable rt;
+      ShaderResource t{}; t.cls=ResourceClass::Texture; t.binding=4; t.sgpr_base=0; t.img_dim=2; rt.resources.push_back(t);
+      const uint32_t c[] = {0x7E060280u,0xF0380710u,0x00000003u,0xBF810000u};
+      dump(dir, "compute_resinfo_3d", recompile_valu(c, sizeof(c)/4, 0, 0, &rt)); }
+    // Compute integer image_load from a UINT8x4 3D texture. The sampled image's scalar type and
+    // OpImageFetch result must be uint, matching the explicit v_cvt_f32_ubyte* sequence used by
+    // UE4's volumetric-lightmap indirection volume (DOLL producer pc 816).
+    { ShaderResourceTable rt;
+      ShaderResource t{}; t.cls=ResourceClass::Texture; t.format=DataFormat::Uint8;
+      t.num_components=4; t.binding=4; t.sgpr_base=0; t.img_dim=2;
+      t.width=32; t.height=32; t.depth=32; rt.resources.push_back(t);
+      const uint32_t c[] = {0x7E1E0280u,0x7E200280u,0x7E220280u,
+                            0xF0000F10u,0x0000000Fu,0xBF8C3F70u,
+                            0x7E000D00u,0x7E020D01u,0x7E040D02u,0x7E060D03u,
+                            0xBF810000u};
+      dump(dir, "compute_uint_load_3d", recompile_valu(c, sizeof(c)/4, 0, 0, &rt)); }
     // Compute mul_hi (high 32 bits via OpUMulExtended -> {lo,hi} struct extract).
     { const uint32_t c[] = {0x7E0202FFu,0x80000000u,0xD56A0002u,0x00020301u,0x7E000D02u,0xBF810000u};
       dump(dir, "compute_mul_hi", recompile_valu(c, sizeof(c)/4, 1, 0)); }
+    // Compute: saved VOPC mask combined with VCC by s_nor_b64 (UE4 visibility-mask shape).
+    { const uint32_t c[] = {0x7C040CF9u,0x06869880u,0x8DEA6A18u,0xBF810000u};
+      dump(dir, "compute_mask_nor", recompile_valu(c, sizeof(c)/4, 0, 0)); }
+    // Compute: nested/multi-branch CFG dispatcher (varying VCC exit + inner SCC branch + back-edge).
+    // Locks both structured switch-loop formation and the subgroup Any vote used for wave branches.
+    { const uint32_t c[] = {0xBE800380u,0x7E000280u,0x7E020300u,
+                            0xD7610013u,0x00014A7Eu,0xD7610013u,0x0001507Fu,
+                            0xD760000Eu,0x00014B13u,0xD760000Fu,0x00015113u,0xBEFE040Eu,
+                            0xE00C2000u,0x80020400u,0x7DB900F9u,0x86050007u,
+                            0x7D020200u,0xBF860006u,0xBF0A8204u,0x360000FDu,0xBF840001u,
+                            0x81008100u,0x81008100u,0xBF82FFF4u,
+                            0xBF810000u};
+      ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer;
+      vb.binding=3; vb.sgpr_base=8; vb.stride=16; vb.format=DataFormat::Float32;
+      vb.num_components=4; rt.resources.push_back(vb);
+      dump(dir, "compute_cfg_dispatch", recompile_valu(c, sizeof(c)/4, 0, 0, &rt)); }
 
     // --- #273 additions (DOLL recompiler frontier) ---
     // Fragment: 3D image_load (integer LUT fetch through the combined sampler; OpImage+OpImageFetch).
@@ -149,6 +182,11 @@ int main(int argc, char** argv) {
     { const uint32_t c[] = {0x7e020280u,0x7e0002f2u,0x7c2200f0u,0xbf880002u,0xbe8503f2u,0x7e020205u,
                             0x7e040205u,0xf800180fu,0x01010101u,0xbf810000u};
       dump(dir, "fragment_execz_if", recompile_fragment(c, sizeof(c)/4, nullptr)); }
+    // A saved lane mask first defined inside a forward if and consumed after its merge. The skipped
+    // edge contributes false; without that phi the arm-local definition does not dominate its use.
+    { const uint32_t c[] = {0x7E020280u,0x7E0002F2u,0x7C2200F0u,0xBF880001u,0xBE82047Eu,
+                            0xBEFE0402u,0x7E0202F2u,0xF800180Fu,0x01010101u,0xBF810000u};
+      dump(dir, "fragment_if_new_mask", recompile_fragment(c, sizeof(c)/4, nullptr)); }
     // Fragment: DIVERGENT execz-exit loop with a nested execz if in the body (#273 — the DOLL
     // title post-process accumulation shape; test_recompiled_fragment executes it).
     { const uint32_t c[] = {0x7E020284u,0xBE800380u,0x7E040280u,0x7E060280u,0x7E080282u,0x7E0A02F2u,


### PR DESCRIPTION
## Summary

- lower complex, barrier-free UE4 compute control flow through a structured SPIR-V dispatcher, including subgroup-correct VCCZ/EXECZ tests, saved-mask lane spills, f16 SDWA compares, and the missing scalar mask operations
- implement `image_get_resinfo` plus integer sampled-image semantics needed by the volume producer
- preserve 3D resource depth through descriptor decoding and capture v9, and add the GFX10 mode-27 thin-volume tile/detile path
- execute 3D Uint8x4 and R11G11B10F sampled inputs plus Float16 storage-image writeback
- make identical storage descriptors share one Vulkan image so an unwritten alias cannot clobber the written guest volume

## Root cause and impact

The black real-fragment path was not only a fragment-lowering problem. Its UE4 lighting resources depend on a compute producer chain that previously failed before dispatch: resource queries were unsupported, the main producer's nested/backward CFG could not be structured, 3D depth/layout was lost, and the final pass bound the same guest volume through two independent storage images.

With this change, the full 150,042-word producer validates and executes. The following pass shares its aliased storage views and persists a genuinely nonzero tiled Float16 volume back to guest memory.

This is meaningful producer-history progress, but it does **not** yet claim a recognizable final shaded DOLL scene; the first nonblank live frames inspected were still the early system/debug overlay. The remaining presentation/consumer investigation stays in #719.

## DOLL evidence

- exact producer dispatch 517: `15x9x32` threads, `8x8x1` local size, 14 images, result `ok`
- consumer dispatch 518: bindings 7 and 9 alias the same guest volume and execute against one Vulkan image
- final 4 MiB Float16 tiled writeback changes hash and contains 2,048 nonzero channels; the first written half value is `0x3c00` (1.0)
- standalone full-capsule replay retains its exact 3840x2160 output oracle: `26ed8b6191338383`
- a fresh live boot repeatedly executes the same producer/consumer chain with nonzero volume writeback

## Validation

- full Linux build
- 98/98 CTest tests pass, including strict SPIR-V validation and Vulkan execution coverage
- Messenger snapshot: 24,318 distinct colors (threshold 5,000)
- Dead Cells splash snapshot: 1,722 distinct colors (threshold 1,500)
- exact DOLL capsule replay and output-oracle match
- `git diff --check`

Advances #719. Builds on #718.
