### PR TITLE
fix(renderer): bound viewport-derived depth extents

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1158,12 +1158,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const uint32_t present_w = prosper::gpu::present_width();
                     const uint32_t present_h = prosper::gpu::present_height();
                     // A depth prepass may bind a tiny/dummy color target with CB_TARGET_MASK=0 while
-                    // rasterizing the full-size guest depth surface. Keying and allocating persistent
-                    // DS from that irrelevant color extent creates (for DOLL) a 512x256 depth image;
-                    // the following 3840x2160 EQUAL lighting pass then gets a separate blank image and
-                    // rejects every fragment. For a wholly color-disabled DS pass, recover the native
-                    // attachment extent from its viewport (undoing execute_gpustate's render scale).
-                    // Mixed/color-writing passes retain the authoritative CB_COLOR extent.
+                    // rasterizing the full-size guest depth surface. Keying persistent DS from that
+                    // irrelevant color extent creates a small depth image that the later lighting pass
+                    // cannot reuse. Recover the attachment extent from the viewport, but only when the
+                    // complete inferred extent fits the known presentation surface. Viewport coordinates
+                    // position rasterization and are not allocation metadata; accepting translated or
+                    // otherwise oversized coordinates here previously created persistent images as large
+                    // as 16384x16384 and exhausted the host while Dead Cells loaded its first level.
                     const bool color_disabled = !pass.empty() && std::all_of(
                         pass.begin(), pass.end(), [](const auto* draw) {
                             return draw->ps.color_write_mask == 0;
@@ -1186,16 +1187,26 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (std::isfinite(y1) && std::isfinite(y2))
                                 viewport_y = std::max(viewport_y, std::max(std::fabs(y1), std::fabs(y2)));
                         }
-                        const uint32_t scale_w = present_w ? present_w : w;
-                        const uint32_t scale_h = present_h ? present_h : h;
+                        const uint32_t max_native_w = present_w ? present_w : w;
+                        const uint32_t max_native_h = present_h ? present_h : h;
                         const uint64_t viewport_native_w = static_cast<uint64_t>(
-                            std::ceil(viewport_x * static_cast<float>(scale_w) / w));
+                            std::ceil(viewport_x * static_cast<float>(max_native_w) / w));
                         const uint64_t viewport_native_h = static_cast<uint64_t>(
-                            std::ceil(viewport_y * static_cast<float>(scale_h) / h));
-                        if (viewport_native_w && viewport_native_w <= 16384)
+                            std::ceil(viewport_y * static_cast<float>(max_native_h) / h));
+                        const bool viewport_extent_valid = viewport_native_w && viewport_native_h &&
+                            viewport_native_w <= max_native_w && viewport_native_h <= max_native_h;
+                        if (getenv("PROSPER_DSLOG") && (viewport_native_w || viewport_native_h)) {
+                            fprintf(stderr,
+                                    "[ds] viewport-derived extent %llux%llu (presentation %ux%u) -> %s\n",
+                                    (unsigned long long)viewport_native_w,
+                                    (unsigned long long)viewport_native_h,
+                                    max_native_w, max_native_h,
+                                    viewport_extent_valid ? "accept" : "reject");
+                        }
+                        if (viewport_extent_valid) {
                             native_w = std::max(native_w, static_cast<uint32_t>(viewport_native_w));
-                        if (viewport_native_h && viewport_native_h <= 16384)
                             native_h = std::max(native_h, static_cast<uint32_t>(viewport_native_h));
+                        }
                     }
                     if (native_w && native_h) {
                         uint64_t native_pixels = (uint64_t)native_w * native_h;

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -149,6 +149,29 @@ int main() {
               "EQUAL lighting reuses viewport-sized depth written behind the tiny color attachment");
     }
 
+    // A translated viewport is raster state, not proof that the attachment itself is larger than the
+    // presentation surface. Promoting its far edge used to allocate and retain enormous depth images
+    // (up to 16384x16384) during Dead Cells level loading. Keep this deliberately out-of-bounds
+    // prepass on its declared dummy extent; the full-size EQUAL pass must not find invented depth.
+    DrawItem translated_prepass = depth_prepass;
+    translated_prepass.color0_base = 0x950000;
+    translated_prepass.ps.viewport_x = static_cast<float>(W * 2);
+    translated_prepass.ps.depth_read_base = translated_prepass.ps.depth_write_base = 0x960000;
+    translated_prepass.ps.htile_data_base = 0x970000;
+    DrawItem translated_lighting = equal_lighting;
+    translated_lighting.color0_base = 0x980000;
+    translated_lighting.ps.depth_read_base = translated_lighting.ps.depth_write_base = 0x960000;
+    translated_lighting.ps.htile_data_base = 0x970000;
+    std::vector<uint8_t> translated = render_submit_items(
+        {translated_prepass, translated_lighting}, W, H);
+    CHECK(translated.size() == static_cast<size_t>(W) * H * 4,
+          "oversized viewport does not inflate the persistent depth attachment");
+    if (translated.size() == static_cast<size_t>(W) * H * 4) {
+        const uint8_t* center = &translated[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+        CHECK(center[0] < 0x40,
+              "lighting does not reuse depth invented from a translated viewport far edge");
+    }
+
     // A captured consumer may depend on a producer from an earlier submit. Restore its serialized
     // host RTT surface before replaying draw zero; guest memory has no copy of these rendered pixels.
     GpuCaptureRttSeed temporal_seed;


### PR DESCRIPTION
## Summary

- bound viewport-derived depth-prepass extents to the known presentation surface
- validate width and height as one attachment extent instead of promoting either axis independently up to 16384
- retain the DOLL dummy-color/full-depth prepass behavior while rejecting translated viewport far edges
- add a Vulkan regression test for both the valid full-screen prepass and the oversized translated case

## Root cause

#718 recovers a full-size persistent depth attachment from a color-disabled pass's viewport because DOLL binds a tiny dummy color target during its 3840x2160 depth prepass. The original rule treated the maximum absolute viewport coordinate as allocation metadata and accepted each axis independently up to 16384.

Dead Cells exercises translated/partial viewport state during first-level rendering. The inferred far edge could therefore create enormous persistent depth images, retained by the DS cache until WSL exceeded its 32 GiB limit and the entire VM terminated. With rendering disabled, the title always reached `PrisonStart`, which is why this looked like a progression regression.

Viewport coordinates position rasterization; they are not authoritative attachment dimensions. The inferred extent is now accepted only as a complete nonzero pair that fits the known presentation surface. DOLL's valid 3840x2160 prepass remains accepted.

## Cross-title triage

- Dead Cells: before fix, WSL terminated shortly after the 20-second renderer warmup; reversing #718 survived 70 seconds at 4.38 GiB RSS. Current master plus this fix reaches `PrisonStart`, completes `PARSEALL` in 3.98 seconds, survives the full 70-second run, and peaks at 4.15 GiB.
- Blasphemous 2: current master completed the documented 420-frame route. Inspected late frames show the playable first room, moving player, HUD, world, lighting, and foreground layers.
- Alex Kidd: current master loads through `level7`; its black gameplay world is the pre-existing #320 backlog, not this regression.
- The Messenger remained the known passing title.

## Validation

- full Linux build
- 101/101 CTest tests pass
- focused `gpu_capture_render_replay` test covers accepted and rejected viewport-derived depth extents
- real Dead Cells fresh-save route and peak-RSS A/B above

Fixes #726.
