### PR TITLE
Initialize RDNA2 fragment position inputs

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -198,7 +198,8 @@ struct ShaderRecompileCacheStats {
 std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
                                                        const ShaderResourceTable* resources = nullptr,
-                                                       const PixelInputMapping* pixel_inputs = nullptr);
+                                                       const PixelInputMapping* pixel_inputs = nullptr,
+                                                       const PixelSystemInputMapping* system_inputs = nullptr);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -431,22 +432,25 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
     }
     if (getenv("PROSPER_INTERPLOG")) {
-        fprintf(stderr, "[interp] es=0x%llx ps=0x%llx source=%s valid=%08x",
+        fprintf(stderr, "[interp] es=0x%llx ps=0x%llx source=%s valid=%08x ena=%08x addr=%08x",
                 (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
                 interpolants_from_metadata ? "metadata" : "registers",
-                pixel_inputs.valid_mask);
+                pixel_inputs.valid_mask, rs.ps_input_ena, rs.ps_input_addr);
         for (uint32_t i = 0; i < pixel_inputs.controls.size(); ++i)
             if (pixel_inputs.valid_mask & (1u << i))
                 fprintf(stderr, " i%u=%08x", i, pixel_inputs.controls[i]);
         fprintf(stderr, "\n");
     }
     const PixelInputMapping* pixel_input_ptr = pixel_inputs.valid_mask ? &pixel_inputs : nullptr;
+    PixelSystemInputMapping system_inputs{rs.ps_input_ena, rs.ps_input_addr};
+    const PixelSystemInputMapping* system_input_ptr =
+        (system_inputs.ena || system_inputs.addr) ? &system_inputs : nullptr;
     std::vector<uint32_t> vs = recompile_graphics_shader_cached(
         ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
         max_shader_dwords, vrt.get(), pixel_input_ptr);
     std::vector<uint32_t> fs = recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
-        max_shader_dwords, prt.get());
+        max_shader_dwords, prt.get(), nullptr, system_input_ptr);
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();
         record_draw_realization_phases(

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -79,6 +79,8 @@ struct ShaderCompileKey {
     bool force_position_w = false;
     bool has_pixel_inputs = false;
     PixelInputMapping pixel_inputs{};
+    bool has_system_inputs = false;
+    PixelSystemInputMapping system_inputs{};
     std::vector<uint32_t> code;
     std::vector<ShaderResourceCompileKey> resources;
 
@@ -105,6 +107,11 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, key.pixel_inputs.valid_mask);
             for (uint32_t control : key.pixel_inputs.controls)
                 hash = hash_mix(hash, control);
+        }
+        hash = hash_mix(hash, key.has_system_inputs);
+        if (key.has_system_inputs) {
+            hash = hash_mix(hash, key.system_inputs.ena);
+            hash = hash_mix(hash, key.system_inputs.addr);
         }
         hash = hash_mix(hash, key.code.size());
         for (uint32_t word : key.code) hash = hash_mix(hash, word);
@@ -275,18 +282,22 @@ uint64_t shader_cache_entry_bytes(const ShaderCompileKey& key, const std::vector
     return static_cast<uint64_t>(key.code.size()) * sizeof(uint32_t) +
            static_cast<uint64_t>(key.resources.size()) * sizeof(ShaderResourceCompileKey) +
            (key.has_pixel_inputs ? sizeof(PixelInputMapping) : 0u) +
+           (key.has_system_inputs ? sizeof(PixelSystemInputMapping) : 0u) +
            static_cast<uint64_t>(spirv.size()) * sizeof(uint32_t);
 }
 
 ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* resources,
-                                         const PixelInputMapping* pixel_inputs) {
+                                         const PixelInputMapping* pixel_inputs,
+                                         const PixelSystemInputMapping* system_inputs) {
     ShaderCompileKey key;
     key.stage = stage;
     key.has_resource_table = resources != nullptr;
     key.force_position_w = getenv("PROSPER_FORCE_W") != nullptr;
     key.has_pixel_inputs = stage == ShaderProgramStage::Vertex && pixel_inputs != nullptr;
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
+    key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
+    if (key.has_system_inputs) key.system_inputs = *system_inputs;
     if (code && dwords) {
         std::vector<Rdna2Inst> instructions;
         const size_t consumed = rdna2_walk(code, dwords, instructions);
@@ -312,7 +323,8 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
         return recompile_vertex(code, key.code.size(), resources,
                                 key.has_pixel_inputs ? &key.pixel_inputs : nullptr);
     if (stage == ShaderProgramStage::Fragment)
-        return recompile_fragment(code, key.code.size(), resources);
+        return recompile_fragment(code, key.code.size(), resources,
+                                  key.has_system_inputs ? &key.system_inputs : nullptr);
     return {};
 }
 
@@ -337,8 +349,10 @@ void clear_shader_decode_cache() {
 std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
                                                        const ShaderResourceTable* resources,
-                                                       const PixelInputMapping* pixel_inputs) {
-    ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs);
+                                                       const PixelInputMapping* pixel_inputs,
+                                                       const PixelSystemInputMapping* system_inputs) {
+    ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs,
+                                                   system_inputs);
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
         auto& cache = shader_cache();
         {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -990,6 +990,11 @@ struct SpirvCompute {
         put(deco, Op_Decorate, {v_fragcoord, Dec_BuiltIn, BI_FragCoord});
         iface.push_back(v_fragcoord); return v_fragcoord;
     }
+    uint32_t fragcoord_component(uint32_t component) {
+        uint32_t value = id(); put(code, Op_Load, {t_v4f, value, fragcoord_var()});
+        uint32_t scalar = id(); put(code, Op_CompositeExtract, {t_f32, scalar, value, component});
+        return bcu(scalar);
+    }
     // DPP16 quad_perm (#273 — DOLL's manual ddx/ddy in its sharpen/AA PSs): the value of `x` at quad
     // lane t = QP[my_lane] is reconstructed as x + (tx-px)·dPdx(x) + (ty-py)·dPdy(x), where (px,py) =
     // (int(gl_FragCoord.xy) & 1) is this invocation's quad position and (tx,ty) = (t&1, t>>1). Exact
@@ -4758,7 +4763,9 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     return cov;
 }
 
-std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, const ShaderResourceTable* rt) {
+std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
+                                         const ShaderResourceTable* rt,
+                                         const PixelSystemInputMapping* system_inputs) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
 
@@ -4779,6 +4786,20 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords, co
       for (uint32_t a : b.flat_attrs) if (smooth_attr.count(a)) return {};   // mixed smooth+flat: reject
     }
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
+    if (system_inputs) {
+        // RDNA2 PS system values are packed in field order. ADDR reserves each field's documented
+        // width even when ENA is clear, allowing a driver to keep later VGPR numbers stable. Vulkan
+        // exposes the four floating-point position terms directly as FragCoord.xyzw.
+        static constexpr uint8_t widths[16] = {2, 2, 2, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        uint32_t vgpr = 0;
+        for (uint32_t field = 0; field < 16; ++field) {
+            const uint32_t bit = 1u << field;
+            if (!(system_inputs->addr & bit)) continue;
+            if ((system_inputs->ena & bit) && field >= 8 && field <= 11)
+                rs.vreg[(int)vgpr] = b.fragcoord_component(field - 8);
+            vgpr += widths[field];
+        }
+    }
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);   // readfirstlane waterfalls (#273)
     // FRAGMENT-only: also linearize alpha-test / clip() kill-mask s_cbranch_scc0/scc1 early-outs (Unity

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -31,6 +31,18 @@ struct PixelInputMapping {
     bool operator==(const PixelInputMapping&) const = default;
 };
 
+// Fixed-function per-pixel VGPR loads selected by SPI_PS_INPUT_ENA / SPI_PS_INPUT_ADDR. ENA says
+// which values hardware computes and loads; ADDR also reserves VGPR slots for disabled values, so it
+// participates in the destination-register mapping. The fragment shell currently materializes the
+// four floating-point position terms through SPIR-V FragCoord; the remaining enabled terms still
+// reserve their documented slots for faithful position placement.
+struct PixelSystemInputMapping {
+    uint32_t ena = 0;
+    uint32_t addr = 0;
+
+    bool operator==(const PixelSystemInputMapping&) const = default;
+};
+
 // Translate a straight-line float-VALU RDNA2 stream to a compute-shader SPIR-V module.
 // Returns {} if the stream contains an opcode/format this stage does not yet handle. An optional
 // ShaderResourceTable routes SMEM constant-buffer loads to distinct bindings via descriptor provenance.
@@ -63,7 +75,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 // target write vec4(src0..3) to the location-0 color output. Returns {} if unsupported / no export.
 // An optional ShaderResourceTable enables memory ops (SMEM/MUBUF) with resolved bindings.
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
-                                         const ShaderResourceTable* rt = nullptr);
+                                         const ShaderResourceTable* rt = nullptr,
+                                         const PixelSystemInputMapping* system_inputs = nullptr);
 
 // Recompile a vertex shader to a vertex SPIR-V module: v0 = gl_VertexIndex, run the VALU, and on EXP
 // to a POS target write vec4(src0..3) to gl_Position. Returns {} if unsupported / no position export.

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -77,6 +77,8 @@ RenderState extract_render_state(const GpuState& st) {
         rs.ps_input_cntl[i] = it->second;
         rs.ps_input_cntl_valid_mask |= 1u << i;
     }
+    rs.ps_input_ena = rd(st.cx, P::SPI_PS_INPUT_ENA);
+    rs.ps_input_addr = rd(st.cx, P::SPI_PS_INPUT_ADDR);
 
     // Color MRT 0 (context register file).
     rs.color0_base            = addr_of(rd(st.cx, P::CB_COLOR0_BASE), rd(st.cx, P::CB_COLOR0_BASE_EXT));

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -28,6 +28,12 @@ struct RenderState {
     std::array<uint32_t, 32> ps_input_cntl{};
     uint32_t ps_input_cntl_valid_mask = 0;
 
+    // Hardware-provided PS VGPR inputs (barycentrics, floating-point position, face/sample data).
+    // INPUT_ADDR controls slot reservation even for terms disabled in INPUT_ENA, so both raw words
+    // are retained for the fragment recompiler.
+    uint32_t ps_input_ena = 0;
+    uint32_t ps_input_addr = 0;
+
     // Color MRT 0. format/number_type/comp_swap together select the VkFormat (see vk_translate).
     uint64_t color0_base        = 0;   // byte address (CB_COLOR0_BASE + BASE_EXT)
     uint32_t color0_format      = 0;   // CB_COLOR0_INFO.FORMAT       (surface format)

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -97,6 +97,20 @@ bool has_decoration(const std::vector<uint32_t>& spv, uint32_t decoration) {
     return false;
 }
 
+bool has_builtin(const std::vector<uint32_t>& spv, uint32_t builtin) {
+    enum : uint32_t { OpDecorateL = 71, DecBuiltIn = 11 };
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        uint32_t word = spv[i];
+        uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == OpDecorateL && wc >= 4 && spv[i + 2] == DecBuiltIn && spv[i + 3] == builtin)
+            return true;
+        i += wc;
+    }
+    return false;
+}
+
 // The largest OpTypeArray length (resolved through its OpConstant) in the module — for LDS sizing
 // (#130), the Workgroup LDS array is the biggest array the compute shell declares.
 uint32_t max_array_length(const std::vector<uint32_t>& spv) {
@@ -366,6 +380,25 @@ int main() {
         return 1;
     }
     printf("  [ok]   mixed flat+smooth read of one attribute is rejected\n");
+
+    // Pixel-system VGPR initialization: with perspective sample/center enabled, disabled
+    // centroid/pull-model slots reserved by ADDR, and position X/Y enabled, the packed destinations
+    // are v12/v13. The fragment shell must source those values from gl_FragCoord rather than the
+    // old undefined-register zero. Encodings: exp mrt0 v12,v13,0,1; s_endpgm. BuiltIn FragCoord=15.
+    const uint32_t ps_position[] = {
+        0x7e1c0280u, 0x7e1e02f2u, // v_mov v14,0; v_mov v15,1
+        0xf800000fu, 0x0f0e0d0cu, 0xbf810000u,
+    };
+    PixelSystemInputMapping sys{};
+    sys.ena = (1u << 0) | (1u << 1) | (1u << 8) | (1u << 9);
+    sys.addr = sys.ena | (1u << 2) | (1u << 3) | (1u << 6) | (1u << 7);
+    std::vector<uint32_t> position_spv = recompile_fragment(
+        ps_position, sizeof(ps_position)/sizeof(ps_position[0]), nullptr, &sys);
+    if (position_spv.empty() || !has_builtin(position_spv, 15)) {
+        printf("  [FAIL] enabled POS_X/Y_FLOAT system VGPRs do not materialize gl_FragCoord\n");
+        return 1;
+    }
+    printf("  [ok]   packed POS_X/Y_FLOAT system VGPRs source gl_FragCoord\n");
 
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -41,6 +41,30 @@ int main() {
     CHECK(c[1] > 0x80 && c[0] < 0x40 && c[2] < 0x40, "center pixel is GREEN (from the recompiled shader)");
     CHECK(k[2] > 0x80 && k[0] < 0x40 && k[1] < 0x40, "corner pixel is the BLUE clear");
 
+    // DOLL's volume-sampling PS uses ENA=ADDR=0x702: perspective-center occupies v0:v1 and
+    // POS_X/Y/Z_FLOAT occupy v2:v4. Export v2 as red; a real FragCoord.x saturates the UNORM target
+    // while the old undefined-register fallback exported zero and left the triangle black.
+    const uint32_t position_ps[] = {
+        0x7E060280u, 0x7E080280u, 0x7E0A02F2u, // v3=0, v4=0, v5=1
+        0xF800180Fu, 0x05040302u, 0xBF810000u, // exp mrt0 v2,v3,v4,v5; s_endpgm
+    };
+    PixelSystemInputMapping doll_inputs{0x00000702u, 0x00000702u};
+    std::vector<uint32_t> position_frag = recompile_fragment(
+        position_ps, std::size(position_ps), nullptr, &doll_inputs);
+    CHECK(!position_frag.empty(), "recompiled DOLL's packed perspective-center + position inputs");
+    if (!position_frag.empty()) {
+        std::vector<uint8_t> position_px = prosper::test::render_triangle_rgba(
+            vert, position_frag, W, H);
+        CHECK(position_px.size() == (size_t)W * H * 4,
+              "rendered a fragment shader consuming the hardware position VGPR");
+        if (position_px.size() == (size_t)W * H * 4) {
+            const uint8_t* pc = &position_px[((size_t)(H/2) * W + W/2) * 4];
+            printf("  system-position center=(%u,%u,%u,%u)\n", pc[0],pc[1],pc[2],pc[3]);
+            CHECK(pc[0] > 0x80 && pc[1] < 0x40 && pc[2] < 0x40,
+                  "DOLL layout: v2 receives FragCoord.x and renders RED");
+        }
+    }
+
     // VCC kill-mask early-out (#273 — DOLL's alpha-cull PS): `v_cmp; s_andn2_b64 vcc, exec, vcc;
     // s_cbranch_scc0 <null-export>; s_mov_b64 exec, vcc; export`. The kill mask lives in VCC itself
     // (not a saved SGPR pair); mask_test_branches must recognize it so the branch linearizes and the

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -75,6 +75,8 @@ int main() {
         { P::CB_COLOR0_ATTRIB2, ((1024u - 1u) << 14) | (32u - 1u) },
         { P::SPI_PS_INPUT_CNTL_0, 0x00000401u }, // PS input 0 <- PARAM1, flat
         { P::SPI_PS_INPUT_CNTL_0 + 1u, 0x00000320u }, // PS input 1 <- DEFAULT_VAL 1111
+        { P::SPI_PS_INPUT_ENA, 0x00000303u }, // perspective sample/center + float position X/Y
+        { P::SPI_PS_INPUT_ADDR, 0x000003CFu }, // reserve disabled centroid/pull-model slots
     };
     // Shader-stage program addresses.
     ShaderReg sh_regs[] = {
@@ -100,6 +102,8 @@ int main() {
     CHECK(rs.ps_input_cntl_valid_mask == 0x3u &&
           rs.ps_input_cntl[0] == 0x00000401u && rs.ps_input_cntl[1] == 0x00000320u,
           "programmed SPI_PS_INPUT_CNTL words and presence mask are retained");
+    CHECK(rs.ps_input_ena == 0x00000303u && rs.ps_input_addr == 0x000003CFu,
+          "SPI_PS_INPUT_ENA/ADDR system-value VGPR controls are retained");
 
     CHECK(rs.color0_base == rdna2_addr(0x00100000u, 0x12u), "color0_base = (BASE<<8)|(EXT<<40)");
     CHECK(rs.color0_format == 0x0Au, "color0_format = 0x0A (FORMAT field)");

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -107,6 +107,22 @@ int main() {
               stats.misses == mapping_misses + 2 && stats.hits == mapping_hits + 1,
           "pixel-input mappings participate in the vertex shader cache key");
 
+    // Fragment system-input placement changes SPIR-V declarations and the initial VGPR values.
+    // Both ENA and ADDR therefore belong to the cache key.
+    const uint64_t system_misses = stats.misses;
+    PixelSystemInputMapping system_inputs{0x00000303u, 0x00000303u};
+    const auto system_once = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr, nullptr, &system_inputs);
+    const auto system_again = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr, nullptr, &system_inputs);
+    system_inputs.addr |= 1u << 2;
+    const auto system_remapped = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr, nullptr, &system_inputs);
+    stats = shader_recompile_cache_stats();
+    CHECK(!system_once.empty() && system_again == system_once && !system_remapped.empty() &&
+              stats.misses == system_misses + 2,
+          "pixel-system ENA/ADDR mappings participate in the fragment shader cache key");
+
     clear_shader_recompile_cache();
     stats = shader_recompile_cache_stats();
     CHECK(stats.entries == 0 && stats.hits == 0 && stats.misses == 0 && stats.bytes == 0,


### PR DESCRIPTION
## Summary

- retain `SPI_PS_INPUT_ENA` and `SPI_PS_INPUT_ADDR` in render state
- pack RDNA2 pixel-system VGPR slots and materialize enabled position X/Y/Z/W values from SPIR-V `FragCoord`
- include the system-input mapping in fragment shader cache identity
- cover state extraction, packed slot placement, cache separation, and DOLL's exact `ENA=ADDR=0x702` layout

## Root cause

The fragment recompiler initialized interpolated varyings but not fixed-function pixel-system VGPRs. DOLL reads hardware position values from v2-v4 to reconstruct its volume-sampling coordinates. Those registers previously fell back to literal zero, producing infinities/NaNs in the reconstruction and black texture samples.

`INPUT_ADDR` also participates in destination placement: it reserves each documented field width even when the corresponding `INPUT_ENA` bit is clear. The recompiler now preserves that packing and maps enabled floating-point position fields to `FragCoord.xyzw`.

## Impact

This lets DOLL consume the nonzero lighting-volume backing added by #725. In a controlled 3840x2160 live boot, the active shader reported `ENA=ADDR=0x702` and the Square Enix and HexaDrive splash frames rendered correctly instead of remaining black.

The remaining non-position system inputs are not synthesized yet; their slots are reserved so later position fields land in the correct VGPRs.

## Validation

- full Linux build
- `ctest --test-dir build-linux --output-on-failure -j 8`: 94/94 passed
- executable Vulkan regression: DOLL layout maps `FragCoord.x` to v2 and renders the expected red pixel
- controlled live DOLL capture: 75 draws, 22 computes, 127 ordered operations
- standalone replay matched the 33,177,600-byte live oracle exactly: `7359aa8c2962258f`
- `snapshot.py check` was attempted, but current `master` preflights all three snapshot entries as `review: pending` before executing them

The controlled boot used a temporary opt-in NP callback only to bypass an unrelated nondeterministic startup stall; that hook was removed before this commit.

Continues #719.