### PR TITLE
fix(hle): recover callback guest FS from saved stub slot

### DIFF
--- a/prosper/src/hle/callback_fs.hpp
+++ b/prosper/src/hle/callback_fs.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace prosper {
+
+// Recover the guest %fs saved by exec_image_linux.cpp's guest import-stub path. The entry shim
+// passes the HLE entry %rsp here: return-to-stub at +0, forwarded args7/8/9 at +8/+0x10/+0x18,
+// an alignment pad at +0x20, saved r11 (guest %fs) at +0x28, and the guest return address at +0x30.
+// Host-context tail calls have no such frame and return 0.
+inline uint64_t callback_guest_fs_from_entry_stack(uint64_t entry_rsp) {
+    uint64_t shim_ret = entry_rsp ? *(const uint64_t*)(uintptr_t)entry_rsp : 0;
+    if (shim_ret < 0x600000000ull || shim_ret >= 0x700000000ull) return 0;
+
+    uint64_t fs = *(const uint64_t*)(uintptr_t)(entry_rsp + 0x28);
+    // Match the import stub's TCB check before installing the value as %fs. This makes a malformed
+    // frame fail closed instead of interpreting a forwarded argument as a thread pointer.
+    if (fs < 0x10000 || (fs & 0xfull) || *(const uint64_t*)(uintptr_t)fs != fs ||
+        *(const uint32_t*)(uintptr_t)(fs + 0x108) != 0x50524F53u)
+        return 0;
+    return fs;
+}
+
+} // namespace prosper

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -5,6 +5,7 @@
 // (Game-controller input — libScePad — moved to hle_pad.cpp with a real host backend.)
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "callback_fs.hpp"
 #include "platform_ui.hpp"
 #include "video_backend.hpp"   // sceAvPlayer -> host hardware-decode backend (#705)
 #include "../host/posix_shim.hpp"   // PROSPER_ASM_TRAMPOLINE (Mach-O/ELF global-asm portability)
@@ -1005,8 +1006,9 @@ HLE(s_npent_addcont_info) {
 // import swap-stub switched), so the guest callback must run with the GUEST %fs restored or its
 // TLS accesses (UE MallocBinned caches!) read host TLS garbage. The swap-stub saves the guest fs
 // base in its frame (push r11), so an asm entry shim (the f_apr_read_submit_entry pattern) hands
-// the handler its entry %rsp: [rsp]=ret-to-stub, [+8/+0x10]=re-pushed args7/8, [+0x18]=guest fs,
-// [+0x20]=guest RA. A [rsp] outside the stub region [0x6_0000_0000,0x7_0000_0000) means the
+// the handler its entry %rsp. The guest swap path re-pushes args7/8/9, an alignment pad, then the
+// saved r11: [rsp]=ret-to-stub, args at +8/+0x10/+0x18, pad at +0x20, guest fs at +0x28, and guest
+// RA at +0x30. A [rsp] outside the stub region [0x6_0000_0000,0x7_0000_0000) means the
 // host-context tail-jmp path (no swap happened) — call the callback on the current fs.
 // Mechanism proven live by the PROSPER_NETCTL_CB experiment (run 7/9: delivered + consumed
 // cleanly, no crash). CONFIDENCE: HIGH.
@@ -1014,13 +1016,6 @@ HLE(s_npent_addcont_info) {
 namespace {
 inline uint64_t cb_rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
 inline void     cb_wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
-// The guest %fs base saved by the import swap-stub, or 0 if the call came in on a host context.
-inline uint64_t cb_guest_fs(uint64_t entry_rsp) {
-    uint64_t shim_ret = entry_rsp ? *(uint64_t*)entry_rsp : 0;
-    if (shim_ret >= 0x600000000ull && shim_ret < 0x700000000ull)
-        return *(uint64_t*)(entry_rsp + 0x18);                // the swap-stub's saved r11
-    return 0;
-}
 // RAII: run the enclosed guest callback on the guest %fs (no-op when guest_fs==0).
 struct CbGuestFsScope {
     uint64_t saved = 0, active = 0;
@@ -1072,7 +1067,7 @@ extern "C" uint64_t s_netctl_check_cb_c(uint64_t, uint64_t, uint64_t, uint64_t, 
                                         uint64_t entry_rsp) {
     uint64_t fn = g_netctl_cb_fn.load();
     if (!fn || g_netctl_cb_delivered.exchange(1)) return 0;   // deliver the initial state exactly once
-    uint64_t gfs = cb_guest_fs(entry_rsp);
+    uint64_t gfs = callback_guest_fs_from_entry_stack(entry_rsp);
     {
         CbGuestFsScope fs(gfs);
         ((void (*)(int, void*))(uintptr_t)fn)(1 /*SCE_NET_CTL_EVENT_TYPE_DISCONNECTED*/,
@@ -1127,7 +1122,7 @@ extern "C" void s_np_check_cb_entry();
 extern "C" uint64_t s_np_check_cb_c(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
                                     uint64_t entry_rsp) {
     int n = g_np_state_cb_n.load(); if (n > 4) n = 4;
-    uint64_t gfs = cb_guest_fs(entry_rsp);
+    uint64_t gfs = callback_guest_fs_from_entry_stack(entry_rsp);
     for (int i = 0; i < n; i++) {
         uint64_t fn = g_np_state_cbs[i].fn.load();
         if (!fn || g_np_state_cbs[i].delivered.exchange(1)) continue;

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -5,6 +5,7 @@
 // NID, so this looks them up by NID and exercises the output contract.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "../src/hle/callback_fs.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
@@ -26,6 +27,30 @@ static int32_t call_int_getter(HleFn fn, int32_t sentinel) {
 int main() {
     printf("== test_service_getters ==\n");
     register_builtin_hle();
+
+#ifndef _WIN32
+    // Guest callback shims must recover saved r11 from the import stub's real +0x28 slot. +0x18 is
+    // forwarded arg9 and can legitimately contain an eboot pointer; treating it as %fs crashes the
+    // next host-libc call on executable memory.
+    {
+        struct alignas(16) FakeTcb { uint8_t bytes[0x110]; } tcb{};
+        uint64_t tp = (uint64_t)(uintptr_t)&tcb;
+        *(uint64_t*)(tcb.bytes + 0x00) = tp;
+        *(uint32_t*)(tcb.bytes + 0x108) = 0x50524F53u;
+        uint64_t frame[7] = {};
+        frame[0] = 0x600001000ull;    // return into an import swap stub
+        frame[3] = 0x400000000ull;    // arg9 decoy: the old +0x18 bug selected this as %fs
+        frame[5] = tp;                // +0x28: saved r11 / real guest %fs
+        CHECK(callback_guest_fs_from_entry_stack((uint64_t)(uintptr_t)frame) == tp,
+              "callback shim recovers guest fs from saved-r11 +0x28, not arg9 +0x18");
+        *(uint32_t*)(tcb.bytes + 0x108) = 0;
+        CHECK(callback_guest_fs_from_entry_stack((uint64_t)(uintptr_t)frame) == 0,
+              "callback shim rejects a value without the guest-TCB magic");
+        frame[0] = 0x400001000ull;
+        CHECK(callback_guest_fs_from_entry_stack((uint64_t)(uintptr_t)frame) == 0,
+              "host-context callback entry does not invent a guest fs frame");
+    }
+#endif
 
     // UserService getters: age level -> adult (18), accessibility -> off (0). Must WRITE the output.
     struct { const char* nid; int32_t want; const char* what; } getters[] = {


### PR DESCRIPTION
## Summary

- recover the guest `%fs` base from the import swap stub's saved-`r11` slot at `entry_rsp + 0x28`
- reject malformed or host-context frames before installing a thread pointer
- add regression coverage for the exact DOLL failure shape, where forwarded arg9 is `0x400000000`

## Root cause

The callback entry helper treated `entry_rsp + 0x18` as saved `r11`. That slot is actually forwarded argument 9; the saved guest thread pointer is at `+0x28`, after args 7/8/9 and the alignment pad. DOLL supplied its eboot base in arg9, so callback delivery installed `%fs = 0x400000000` and the next host-libc TLS access crashed.

## Impact

NetCtl and NP callbacks now execute with the correct guest TCB. In a live DOLL boot both callbacks reported `guest_fs=1`, the deterministic host-libc crash disappeared, and execution continued to the separate known MallocBinned3 presentation fault.

## Validation

- Linux build succeeds
- CTest: 96/96 passed
- live DOLL boot with `PROSPER_GUEST_FS=1` and the default allocator forge guard:
  - NetCtl callback delivered with `guest_fs=1`
  - NP callback delivered with `guest_fs=1`
  - no host crash recorded in `dmesg`