### PR TITLE
perf(renderer): retain exact-validated texture images

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -192,14 +192,26 @@ graphics and compute pools. Decoded texture scratch vectors are also retained ac
 are storage only, and every partial decode/read explicitly clears its unwritten tail.
 
 Within one renderer callback, repeated guest-backed texture descriptions reuse the first decoded
-pixel buffer. A bounded process-wide cache also covers guest-backed tiled `Unorm8x4` sampled textures,
-the common sprite-atlas case. Every cross-submit lookup copies and compares the complete padded tiled
-source bytes before reusing decoded pixels; changed bytes, a changed mapping extent, or an address
-reuse invalidates the entry. Live render targets, storage images, and other formats remain excluded.
-The default budget is 256 MiB; use `PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change it or
+pixel buffer. A bounded process-wide cache also covers guest-backed linear and tiled `Unorm8x4`
+sampled textures, the common sprite-atlas cases. Every cross-submit lookup compares the complete guest
+source before reusing decoded pixels; the linear path compares directly against its decoded copy while
+the tiled path retains and compares the padded tiled source. Changed bytes, a changed mapping extent,
+or address reuse invalidates the entry and creates a new content-version ID. Live render targets,
+storage images, captured host backing, and other formats remain excluded. The default budget is
+256 MiB; use `PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change it or
 `PROSPER_NO_TEXTURE_DECODE_CACHE=1` for an A/B run. Timing reports cross-submit `texture_cache`
 hits/misses/invalidations separately from `textures` (all texture uses) and `reused` (both local and
 persistent decodes avoided).
+
+The Vulkan backend may retain an optimal sampled image only when that exact frontend validation
+supplies a nonzero content-version ID. Cache hits skip image allocation, staging allocation, pixel
+copy, transfer commands, and upload barriers; per-draw views, swizzles, and samplers remain callback
+local. The cache is bounded to 256 MiB and 1024 allocations by default. Set
+`PROSPER_BACKEND_TEXTURE_CACHE_MB=<MiB>` to change the byte budget or
+`PROSPER_NO_BACKEND_PERSISTENT_TEXTURES=1` for a forced-upload A/B. Backend timing reports
+`persistent=hits/misses` and the current cache bytes. The frontend decoded-pixel budget and backend
+device-image budget are separate: a hot immutable atlas can occupy space in both, trading bounded
+residency for lower frame time.
 
 Graphics RDNA2-to-SPIR-V results use a process-wide bounded cache (4096 entries and 128 MiB by
 default). Its key contains the shader bytes and only the resource-table fields consumed by compilation;

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -98,6 +98,44 @@ The Vulkan regression test compares sharing on/off byte-for-byte while using sep
 views. It also renders a two-slice 3D texture twice, verifies the selected depth slice, and requires one
 depth-accounted upload. This protects the general 2D and 3D paths rather than only the Dead Cells shape.
 
+## Dead Cells cross-callback texture residency (2026-07-15)
+
+Per-call sharing removed duplicate uploads within one graphics span, but the same large immutable
+linear atlases were still copied from guest memory and uploaded again on every callback. The steady
+Dead Cells loading submit referenced 54 textures. Eleven distinct uploads remained and transferred
+96.3 MiB per callback, including unchanged 64 MiB, 32 MiB, and 8 MiB linear RGBA atlases.
+
+The frontend cache now exact-validates linear `Unorm8x4` sources as well as tiled sources. A validated
+content version receives a monotonic ID; any source-byte or readable-prefix change creates a new ID.
+The Vulkan backend retains only images with such an ID, under a 256 MiB / 1024-entry default bound.
+Render targets, storage images, captured host backing, and unvalidated formats never receive an ID.
+Per-call views and samplers remain independent, so descriptor swizzles and filtering are unchanged.
+
+Native Windows / RTX 4090, same RelWithDebInfo binary, fresh saves, documented full-render route, and
+matched 110-second samples:
+
+| Measurement | Forced upload | Persistent images |
+|---|---:|---:|
+| Late app rate | about 10.9 FPS | 13.7-14.4 FPS |
+| Late backend call | 36.8-37.9 ms | 17.7-19.0 ms |
+| Backend resource setup | 5.8-6.1 ms | 0.42-0.44 ms |
+| GPU fence wait | 21.8-22.6 ms | 8.1-9.5 ms |
+| Steady texture upload | 96.3 MiB/call | 0 |
+| Transient allocation pool | 375.3 MiB | 232.0 MiB |
+| Peak process working set | 2.20 GiB | 2.29 GiB |
+| Peak process private memory | 4.54 GiB | 4.60 GiB |
+
+Both runs reached `Loading level PrisonStart`; neither cleared the separately tracked loading
+starvation within the sample. The enabled run retained 15 frontend versions / 192.9 MiB and the same
+192.9 MiB of backend images, with zero invalidations and zero transient-pool discards. Private memory
+plateaued rather than growing without bound. The small residency increase is therefore the explicit
+cache tradeoff, not a return of the earlier multi-gigabyte per-draw allocation growth. Disable the
+backend half with `PROSPER_NO_BACKEND_PERSISTENT_TEXTURES=1`, or change its independent byte budget
+with `PROSPER_BACKEND_TEXTURE_CACHE_MB`.
+
+`test_texture_sample_render` verifies the initial miss/upload, a cross-callback hit with zero upload,
+byte-identical forced-upload output, and a new content version that cannot reuse the prior image.
+
 ## Current frame budget
 
 After the above changes, a representative renderer submit remains about 36-38 ms. Approximate costs

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -81,15 +81,19 @@ struct DecodedTexture {
     const uint8_t* pixels = nullptr;
     uint32_t output_height = 0;
     bool narrow = false;
+    uint64_t persistent_id = 0;
 };
 
 struct PersistentDecodedTexture {
     size_t source_size = 0;
+    size_t source_prefix_size = 0;
+    bool source_matches_pixels = false;
     std::vector<uint8_t> source_prefix;
     std::vector<uint8_t> pixels;
     uint32_t output_height = 0;
     bool narrow = false;
     uint64_t last_use = 0;
+    uint64_t persistent_id = 0;
 
     size_t bytes() const { return source_prefix.size() + pixels.size(); }
 };
@@ -276,6 +280,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 return done;
             };
+            auto safe_equal = [](const uint8_t* expected, uint64_t a, size_t n,
+                                 size_t& compared) -> bool {
+                const size_t PG = 0x10000;
+                compared = 0;
+                while (compared < n) {
+                    const uint64_t cur = a + compared;
+                    if (cur < 0x1000 || prosper_reserved_range_state(cur) == 0) return true;
+                    const size_t chunk = std::min(
+                        n - compared, PG - static_cast<size_t>(cur & (PG - 1)));
+                    if (std::memcmp(expected + compared,
+                                    reinterpret_cast<const void*>(static_cast<uintptr_t>(cur)),
+                                    chunk)) return false;
+                    compared += chunk;
+                }
+                return true;
+            };
             // Keep decoded texture storage alive across callbacks. The old clear()+emplace(size, 0)
             // released and zero-filled tens of MiB every submit even though the decode paths overwrite
             // all pixels. Reusing same-sized slots avoids both costs; short guest reads explicitly clear
@@ -288,6 +308,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             static size_t persistent_decoded_texture_bytes = 0;
             static uint64_t persistent_decode_generation = 0;
             const uint64_t decode_generation = ++persistent_decode_generation;
+            static uint64_t persistent_texture_id = 0;
             static std::vector<uint8_t> persistent_validation_scratch;
             const size_t persistent_decode_limit = [] {
                 const char* value = getenv("PROSPER_TEXTURE_DECODE_CACHE_MB");
@@ -345,13 +366,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
+                        const bool persistent_rgba_texture =
+                            !has_live_rtt && !r.host_data && r.img_dim == 1u &&
+                            r.cls == RC::Texture &&
+                            r.format == prosper::gpu::DataFormat::Unorm8 &&
+                            r.num_components == 4;
+                        const bool persistent_source_is_tiled =
+                            persistent_rgba_texture && !getenv("PROSPER_NODETILE") &&
+                            prosper::gpu::tile_mode_is_tiled(r.tile_mode);
+                        const bool persistent_source_matches_pixels =
+                            persistent_rgba_texture &&
+                            !prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
+                            (!getenv("PROSPER_DETILE") || atoi(getenv("PROSPER_DETILE")) == 0);
                         const bool persistent_cache_eligible =
-                            !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") && persistent_decode_limit &&
-                            !has_live_rtt && r.img_dim == 1u && r.cls == RC::Texture &&
-                            r.format == prosper::gpu::DataFormat::Unorm8 && r.num_components == 4 &&
-                            !getenv("PROSPER_NODETILE") && prosper::gpu::tile_mode_is_tiled(r.tile_mode);
-                        const size_t persistent_source_size = persistent_cache_eligible
-                            ? prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, persistent_pitch) : 0;
+                            !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
+                            persistent_decode_limit &&
+                            (persistent_source_is_tiled || persistent_source_matches_pixels);
+                        const size_t persistent_source_size = persistent_source_matches_pixels
+                            ? static_cast<size_t>(tw) * th * 4
+                            : (persistent_source_is_tiled
+                                ? prosper::gpu::tiled_surface_bytes(
+                                      tw, th, r.tile_mode, persistent_pitch)
+                                : 0);
                         bool narrow_done = false;
                         auto reused = has_live_rtt ? decoded_textures.end()
                                                    : decoded_textures.find(decode_key);
@@ -362,17 +398,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             auto cached = persistent_decoded_textures.find(decode_key);
                             if (cached != persistent_decoded_textures.end() &&
                                 cached->second.source_size == persistent_source_size) {
-                                persistent_validation_scratch.resize(persistent_source_size);
-                                const size_t got = copy_resource(
-                                    persistent_validation_scratch.data(), r.gpu_addr,
-                                    persistent_source_size);
-                                if (got == cached->second.source_prefix.size() &&
-                                    (got == 0 || !std::memcmp(persistent_validation_scratch.data(),
-                                                              cached->second.source_prefix.data(), got))) {
+                                bool content_matches = false;
+                                if (cached->second.source_matches_pixels) {
+                                    size_t compared = 0;
+                                    content_matches = safe_equal(
+                                        cached->second.pixels.data(), r.gpu_addr,
+                                        persistent_source_size, compared) &&
+                                        compared == cached->second.source_prefix_size;
+                                } else {
+                                    persistent_validation_scratch.resize(persistent_source_size);
+                                    const size_t got = copy_resource(
+                                        persistent_validation_scratch.data(), r.gpu_addr,
+                                        persistent_source_size);
+                                    content_matches =
+                                        got == cached->second.source_prefix_size &&
+                                        got == cached->second.source_prefix.size() &&
+                                        (got == 0 || !std::memcmp(
+                                            persistent_validation_scratch.data(),
+                                            cached->second.source_prefix.data(), got));
+                                }
+                                if (content_matches) {
                                     cached->second.last_use = decode_generation;
                                     persistent_reuse = {cached->second.pixels.data(),
                                                         cached->second.output_height,
-                                                        cached->second.narrow};
+                                                        cached->second.narrow,
+                                                        cached->second.persistent_id};
                                     decoded_reuse = &persistent_reuse;
                                     if (timing_enabled) pending_timing.persistent_hits++;
                                 } else if (timing_enabled) {
@@ -389,12 +439,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.td = is_volume ? r.depth : 1u;
                             fr.img_dim = r.img_dim;
                             narrow_done = decoded_reuse->narrow;
+                            fr.persistent_texture_id = decoded_reuse->persistent_id;
                             decoded_textures.emplace(
-                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done});
+                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
+                                                          fr.persistent_texture_id});
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
                         const size_t volume_texels = (size_t)tw * th * (is_volume ? r.depth : 1u);
                         size_t nb = volume_texels * 4 * (is_cube ? 6u : 1u);
+                        size_t linear_source_prefix_size = 0;
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
                         texture_pixels.resize(nb);
@@ -632,6 +685,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             narrow_done = true;   // already detiled+expanded; skip the 32-bpp auto-detile below
                         } else {
                             const size_t got = copy_resource(texture_pixels.data(), r.gpu_addr, nb);
+                            linear_source_prefix_size = got;
                             if (got < nb)
                                 std::fill(texture_pixels.begin() + got, texture_pixels.end(), 0);
                         }
@@ -838,10 +892,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fr.td = is_volume ? r.depth : 1u;
                         fr.img_dim = r.img_dim;
                         if (persistent_cache_eligible) {
-                            persistent_validation_scratch.resize(persistent_source_size);
-                            const size_t got = copy_resource(
-                                persistent_validation_scratch.data(), r.gpu_addr,
-                                persistent_source_size);
+                            size_t source_prefix_size = linear_source_prefix_size;
+                            if (!persistent_source_matches_pixels) {
+                                persistent_validation_scratch.resize(persistent_source_size);
+                                source_prefix_size = copy_resource(
+                                    persistent_validation_scratch.data(), r.gpu_addr,
+                                    persistent_source_size);
+                            }
                             auto old = persistent_decoded_textures.find(decode_key);
                             const bool can_replace = old == persistent_decoded_textures.end() ||
                                 old->second.last_use != decode_generation;
@@ -849,7 +906,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 persistent_decoded_texture_bytes -= old->second.bytes();
                                 persistent_decoded_textures.erase(old);
                             }
-                            const size_t required = got + texture_pixels.size();
+                            const size_t required =
+                                (persistent_source_matches_pixels ? 0 : source_prefix_size) +
+                                texture_pixels.size();
                             while (required <= persistent_decode_limit &&
                                    persistent_decoded_texture_bytes > persistent_decode_limit - required) {
                                 auto victim = persistent_decoded_textures.end();
@@ -868,24 +927,32 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 persistent_decoded_texture_bytes <= persistent_decode_limit - required) {
                                 PersistentDecodedTexture cached;
                                 cached.source_size = persistent_source_size;
-                                cached.source_prefix.assign(
-                                    persistent_validation_scratch.begin(),
-                                    persistent_validation_scratch.begin() + got);
+                                cached.source_prefix_size = source_prefix_size;
+                                cached.source_matches_pixels = persistent_source_matches_pixels;
+                                if (!persistent_source_matches_pixels)
+                                    cached.source_prefix.assign(
+                                        persistent_validation_scratch.begin(),
+                                        persistent_validation_scratch.begin() + source_prefix_size);
                                 cached.pixels = texture_pixels;
                                 cached.output_height = fr.th;
                                 cached.narrow = narrow_done;
                                 cached.last_use = decode_generation;
+                                cached.persistent_id = ++persistent_texture_id;
+                                if (!cached.persistent_id)
+                                    cached.persistent_id = ++persistent_texture_id;
                                 auto [inserted, ok] = persistent_decoded_textures.emplace(
                                     decode_key, std::move(cached));
                                 if (ok) {
                                     persistent_decoded_texture_bytes += inserted->second.bytes();
                                     fr.tex_rgba = inserted->second.pixels.data();
+                                    fr.persistent_texture_id = inserted->second.persistent_id;
                                 }
                             }
                         }
                         if (!resource_rtt_hit && !has_live_rtt)
                             decoded_textures.emplace(
-                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done});
+                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
+                                                          fr.persistent_texture_id});
                         }
                         // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -85,6 +85,10 @@ struct FrameResource {
     // T# DST_SEL channel swizzle (SQ_SEL per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Default = identity
     // (R,G,B,A) == a no-op VkComponentMapping, so tests that build FrameResources directly are unchanged.
     uint32_t swizzle[4] = {4, 5, 6, 7};
+    // Non-zero only when the frontend has revalidated the complete guest source backing and can
+    // prove these decoded pixels are the same content version as a prior callback. The Vulkan
+    // backend may retain an uploaded image under this ID; zero remains callback-local/transient.
+    uint64_t persistent_texture_id = 0;
     bool is_texture() const { return tex_rgba != nullptr; }
 };
 
@@ -120,6 +124,9 @@ struct BackendTextureUploadStats {
     size_t references = 0;
     size_t unique_uploads = 0;
     uint64_t upload_bytes = 0;
+    size_t persistent_hits = 0;
+    size_t persistent_misses = 0;
+    uint64_t persistent_cached_bytes = 0;
 };
 
 inline BackendTextureUploadStats& backend_texture_upload_stats_storage() {
@@ -907,12 +914,53 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkDeviceMemory memory = VK_NULL_HANDLE;
         VkBuffer staging = VK_NULL_HANDLE;
         VkDeviceMemory staging_memory = VK_NULL_HANDLE;
+        uint64_t persistent_id = 0;
+        VkDeviceSize image_bytes = 0;
+        bool persistent_hit = false;
+        bool direct_memory = false;
     };
+    struct PersistentTextureKey {
+        uint64_t id = 0;
+        uint32_t width = 0, height = 0, depth = 1, img_dim = 1;
+        bool operator==(const PersistentTextureKey&) const = default;
+    };
+    struct PersistentTextureKeyHash {
+        size_t operator()(const PersistentTextureKey& key) const {
+            size_t h = std::hash<uint64_t>{}(key.id);
+            auto mix = [&](uint32_t value) {
+                h ^= static_cast<size_t>(value) + 0x9e3779b9u + (h << 6) + (h >> 2);
+            };
+            mix(key.width); mix(key.height); mix(key.depth); mix(key.img_dim);
+            return h;
+        }
+    };
+    struct PersistentTextureImage {
+        VkImage image = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkDeviceSize bytes = 0;
+        uint64_t last_use = 0;
+    };
+    static std::unordered_map<PersistentTextureKey, PersistentTextureImage,
+                              PersistentTextureKeyHash> persistent_texture_images;
+    static VkDeviceSize persistent_texture_bytes = 0;
+    static uint64_t persistent_texture_generation = 0;
+    constexpr size_t persistent_texture_max_entries = 1024;
+    const uint64_t texture_generation = ++persistent_texture_generation;
+    const bool persistent_textures_enabled =
+        getenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES") == nullptr;
+    const VkDeviceSize persistent_texture_limit = []() -> VkDeviceSize {
+        const char* value = getenv("PROSPER_BACKEND_TEXTURE_CACHE_MB");
+        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
     std::vector<DV> dv(draws.size());
     std::vector<SharedTextureUpload> texture_uploads;
     std::unordered_map<TextureUploadKey, size_t, TextureUploadKeyHash> texture_upload_indices;
     const bool share_texture_uploads = getenv("PROSPER_NO_BACKEND_TEXTURE_SHARE") == nullptr;
     size_t texture_references = 0;
+    size_t persistent_texture_hits = 0;
+    size_t persistent_texture_misses = 0;
     double setup_shader_ms = 0.0;
     double setup_fixed_ms = 0.0;
     double setup_resources_ms = 0.0;
@@ -1084,39 +1132,69 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         upload.key = texture_key;
                         if (share_texture_uploads) texture_upload_indices.emplace(texture_key, upload_index);
 
-                        VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-                        const bool texture_3d = r.img_dim == 2;
-                        tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
-                        tci.format = VK_FORMAT_R8G8B8A8_UNORM;
-                        tci.extent = {r.tw, r.th, r.td};
-                        tci.mipLevels = 1; tci.arrayLayers = 1; tci.samples = VK_SAMPLE_COUNT_1_BIT;
-                        tci.tiling = VK_IMAGE_TILING_OPTIMAL;
-                        tci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-                        vkCreateImage(dev, &tci, nullptr, &upload.image);
-                        VkMemoryRequirements tr; vkGetImageMemoryRequirements(dev, upload.image, &tr);
-                        VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-                        tai.allocationSize = tr.size; tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0);
-                        upload.memory = allocate_transient_render_memory(dev, tai.allocationSize,
-                                                                         tai.memoryTypeIndex);
-                        vkBindImageMemory(dev, upload.image, upload.memory, 0);
+                        upload.persistent_id = r.persistent_texture_id;
+                        const PersistentTextureKey persistent_key{
+                            r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim};
+                        if (persistent_textures_enabled && r.persistent_texture_id) {
+                            auto cached = persistent_texture_images.find(persistent_key);
+                            if (cached != persistent_texture_images.end()) {
+                                cached->second.last_use = texture_generation;
+                                upload.image = cached->second.image;
+                                upload.image_bytes = cached->second.bytes;
+                                upload.persistent_hit = true;
+                                ++persistent_texture_hits;
+                            } else {
+                                ++persistent_texture_misses;
+                            }
+                        }
 
-                        const VkDeviceSize tbytes =
-                            static_cast<VkDeviceSize>(r.tw) * r.th * r.td * 4;
-                        VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                        stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-                        vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
-                        VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, upload.staging, &sr);
-                        VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-                        sai.allocationSize = sr.size;
-                        sai.memoryTypeIndex = pick(sr.memoryTypeBits,
-                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                                   VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                        upload.staging_memory = allocate_transient_render_memory(
-                            dev, sai.allocationSize, sai.memoryTypeIndex);
-                        vkBindBufferMemory(dev, upload.staging, upload.staging_memory, 0);
-                        void* sp = nullptr; vkMapMemory(dev, upload.staging_memory, 0, tbytes, 0, &sp);
-                        std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
-                        vkUnmapMemory(dev, upload.staging_memory);
+                        if (!upload.persistent_hit) {
+                            VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+                            const bool texture_3d = r.img_dim == 2;
+                            tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
+                            tci.format = VK_FORMAT_R8G8B8A8_UNORM;
+                            tci.extent = {r.tw, r.th, r.td};
+                            tci.mipLevels = 1; tci.arrayLayers = 1;
+                            tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
+                            tci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                            vkCreateImage(dev, &tci, nullptr, &upload.image);
+                            VkMemoryRequirements tr;
+                            vkGetImageMemoryRequirements(dev, upload.image, &tr);
+                            upload.image_bytes = tr.size;
+                            VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+                            tai.allocationSize = tr.size;
+                            tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0);
+                            const bool retain = persistent_textures_enabled && upload.persistent_id &&
+                                                tr.size <= persistent_texture_limit;
+                            if (retain && vkAllocateMemory(dev, &tai, nullptr, &upload.memory) == VK_SUCCESS)
+                                upload.direct_memory = true;
+                            if (!upload.memory) {
+                                upload.persistent_id = 0;
+                                upload.memory = allocate_transient_render_memory(
+                                    dev, tai.allocationSize, tai.memoryTypeIndex);
+                            }
+                            vkBindImageMemory(dev, upload.image, upload.memory, 0);
+
+                            const VkDeviceSize tbytes =
+                                static_cast<VkDeviceSize>(r.tw) * r.th * r.td * 4;
+                            VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                            stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+                            vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
+                            VkMemoryRequirements sr;
+                            vkGetBufferMemoryRequirements(dev, upload.staging, &sr);
+                            VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+                            sai.allocationSize = sr.size;
+                            sai.memoryTypeIndex = pick(sr.memoryTypeBits,
+                                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                                       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                            upload.staging_memory = allocate_transient_render_memory(
+                                dev, sai.allocationSize, sai.memoryTypeIndex);
+                            vkBindBufferMemory(dev, upload.staging, upload.staging_memory, 0);
+                            void* sp = nullptr;
+                            vkMapMemory(dev, upload.staging_memory, 0, tbytes, 0, &sp);
+                            std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
+                            vkUnmapMemory(dev, upload.staging_memory);
+                        }
                     }
                     v.texture_upload[i] = upload_index;
                     const SharedTextureUpload& upload = texture_uploads[upload_index];
@@ -1252,10 +1330,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     BackendTextureUploadStats& texture_stats = backend_texture_upload_stats_storage();
     texture_stats = {};
     texture_stats.references = texture_references;
-    texture_stats.unique_uploads = texture_uploads.size();
-    for (const auto& upload : texture_uploads)
+    texture_stats.persistent_hits = persistent_texture_hits;
+    texture_stats.persistent_misses = persistent_texture_misses;
+    for (const auto& upload : texture_uploads) {
+        if (!upload.staging) continue;
+        ++texture_stats.unique_uploads;
         texture_stats.upload_bytes += static_cast<uint64_t>(upload.key.width) * upload.key.height *
                                       upload.key.depth * 4;
+    }
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     VkDeviceSize bytes = (VkDeviceSize)W * H * 4;
@@ -1316,6 +1398,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // Upload each distinct texture once. Draw descriptors may use separate views/samplers over the
     // same image, preserving per-binding swizzle and sampler state without duplicating pixel storage.
     for (const auto& upload : texture_uploads) {
+        if (!upload.staging) continue;  // exact-validated persistent image already has shader-read layout
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         b0.image = upload.image; b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -1496,9 +1579,50 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             if (v.tview[i])    vkDestroyImageView(dev, v.tview[i], nullptr);
         }
     }
+    auto evict_persistent_texture = [&]() {
+        auto victim = persistent_texture_images.end();
+        for (auto it = persistent_texture_images.begin();
+             it != persistent_texture_images.end(); ++it) {
+            if (it->second.last_use == texture_generation) continue;
+            if (victim == persistent_texture_images.end() ||
+                it->second.last_use < victim->second.last_use) victim = it;
+        }
+        if (victim == persistent_texture_images.end()) return false;
+        vkDestroyImage(dev, victim->second.image, nullptr);
+        vkFreeMemory(dev, victim->second.memory, nullptr);
+        persistent_texture_bytes -= victim->second.bytes;
+        persistent_texture_images.erase(victim);
+        return true;
+    };
     for (auto& upload : texture_uploads) {
-        if (upload.image) vkDestroyImage(dev, upload.image, nullptr);
-        if (upload.memory) release_transient_render_memory(dev, upload.memory);
+        if (!upload.direct_memory || !upload.persistent_id || upload.persistent_hit) continue;
+        const PersistentTextureKey key{upload.persistent_id, upload.key.width, upload.key.height,
+                                       upload.key.depth, upload.key.img_dim};
+        while ((persistent_texture_images.size() >= persistent_texture_max_entries ||
+                (upload.image_bytes <= persistent_texture_limit &&
+                 persistent_texture_bytes > persistent_texture_limit - upload.image_bytes)) &&
+               evict_persistent_texture()) {}
+        if (upload.image_bytes <= persistent_texture_limit &&
+            persistent_texture_images.size() < persistent_texture_max_entries &&
+            persistent_texture_bytes <= persistent_texture_limit - upload.image_bytes) {
+            auto [cached, inserted] = persistent_texture_images.emplace(
+                key, PersistentTextureImage{upload.image, upload.memory, upload.image_bytes,
+                                            texture_generation});
+            if (inserted) {
+                persistent_texture_bytes += upload.image_bytes;
+                upload.image = VK_NULL_HANDLE;
+                upload.memory = VK_NULL_HANDLE;
+            }
+        }
+    }
+    while (persistent_texture_bytes > persistent_texture_limit && evict_persistent_texture()) {}
+    texture_stats.persistent_cached_bytes = persistent_texture_bytes;
+    for (auto& upload : texture_uploads) {
+        if (upload.image && !upload.persistent_hit) vkDestroyImage(dev, upload.image, nullptr);
+        if (upload.memory) {
+            if (upload.direct_memory) vkFreeMemory(dev, upload.memory, nullptr);
+            else release_transient_render_memory(dev, upload.memory);
+        }
         if (upload.staging) vkDestroyBuffer(dev, upload.staging, nullptr);
         if (upload.staging_memory)
             release_transient_render_memory(dev, upload.staging_memory);
@@ -1520,6 +1644,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         struct TimingTotals {
             uint64_t calls = 0, draws = 0;
             uint64_t texture_references = 0, texture_uploads = 0, texture_upload_bytes = 0;
+            uint64_t persistent_hits = 0, persistent_misses = 0, persistent_cached_bytes = 0;
             double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
             double setup_shader = 0, setup_fixed = 0, setup_resources = 0, setup_pipeline = 0;
         };
@@ -1531,6 +1656,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             timing.texture_references += texture_stats.references;
             timing.texture_uploads += texture_stats.unique_uploads;
             timing.texture_upload_bytes += texture_stats.upload_bytes;
+            timing.persistent_hits += texture_stats.persistent_hits;
+            timing.persistent_misses += texture_stats.persistent_misses;
+            timing.persistent_cached_bytes = texture_stats.persistent_cached_bytes;
             timing.target += ms(timing_start, timing_target_ready);
             timing.draw_setup += ms(timing_target_ready, timing_draws_ready);
             timing.record += ms(timing_draws_ready, timing_recorded);
@@ -1559,10 +1687,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     totals.setup_shader / n, totals.setup_fixed / n,
                     totals.setup_resources / n, totals.setup_pipeline / n);
             fprintf(stderr,
-                    "[render-timing] backend textures refs=%llu uploads=%llu %.1f MiB\n",
+                    "[render-timing] backend textures refs=%llu uploads=%llu %.1f MiB "
+                    "persistent=%llu/%llu cache=%.1f MiB\n",
                     (unsigned long long)totals.texture_references,
                     (unsigned long long)totals.texture_uploads,
-                    totals.texture_upload_bytes / (1024.0 * 1024.0));
+                    totals.texture_upload_bytes / (1024.0 * 1024.0),
+                    (unsigned long long)totals.persistent_hits,
+                    (unsigned long long)totals.persistent_misses,
+                    totals.persistent_cached_bytes / (1024.0 * 1024.0));
             const RenderMemoryPoolStats pool = render_memory_pool_stats();
             fprintf(stderr,
                     "[render-timing] memory_pool hits=%llu misses=%llu cached=%zu %.1f MiB "
@@ -1585,9 +1717,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     window.setup_shader / wn, window.setup_fixed / wn,
                     window.setup_resources / wn, window.setup_pipeline / wn);
             fprintf(stderr,
-                    "[render-window] backend textures refs=%.1f uploads=%.1f %.1f MiB\n",
+                    "[render-window] backend textures refs=%.1f uploads=%.1f %.1f MiB "
+                    "persistent=%.1f/%.1f cache=%.1f MiB\n",
                     window.texture_references / wn, window.texture_uploads / wn,
-                    window.texture_upload_bytes / (wn * 1024.0 * 1024.0));
+                    window.texture_upload_bytes / (wn * 1024.0 * 1024.0),
+                    window.persistent_hits / wn, window.persistent_misses / wn,
+                    window.persistent_cached_bytes / (1024.0 * 1024.0));
             window = {};
         }
     }

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -121,6 +121,63 @@ int main() {
               "shared and legacy uploads with distinct view swizzles render byte-identically");
     }
 
+    // A non-zero content ID is an exact-validation proof supplied by the frontend. The backend may
+    // retain that uploaded image across render callbacks, but the diagnostic switch must preserve
+    // rendered output while forcing the old upload path for controlled A/B runs.
+    {
+        std::vector<uint32_t> ps(ps_template, ps_template + sizeof(ps_template)/sizeof(ps_template[0]));
+        ps[1] = C075; ps[3] = C025;
+        std::vector<uint32_t> frag = recompile_fragment(ps.data(), ps.size(), &rt);
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.tex_rgba = texels; resource.tw = 2; resource.th = 2;
+        resource.persistent_texture_id = 0x7020000000000001ull;
+        prosper::test::BackendDraw draw;
+        draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
+
+        std::vector<uint8_t> first = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto first_stats = prosper::test::backend_texture_upload_stats();
+        std::vector<uint8_t> reused = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto reused_stats = prosper::test::backend_texture_upload_stats();
+        CHECK(first_stats.persistent_misses == 1 && first_stats.unique_uploads == 1,
+              "first exact-validated texture version is uploaded into the persistent cache");
+        CHECK(reused_stats.persistent_hits == 1 && reused_stats.unique_uploads == 0 &&
+                  reused_stats.upload_bytes == 0,
+              "same exact-validated texture version skips its next callback upload");
+        CHECK(!first.empty() && first == reused,
+              "persistent texture reuse renders byte-identically to its initial upload");
+
+#ifdef _WIN32
+        _putenv_s("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES", "1");
+#else
+        setenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES", "1", 1);
+#endif
+        std::vector<uint8_t> bypassed = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto bypassed_stats = prosper::test::backend_texture_upload_stats();
+#ifdef _WIN32
+        _putenv_s("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES", "");
+#else
+        unsetenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES");
+#endif
+        CHECK(bypassed_stats.persistent_hits == 0 && bypassed_stats.unique_uploads == 1,
+              "persistent texture disable switch restores an upload on every callback");
+        CHECK(reused == bypassed,
+              "persistent cache and forced-upload paths render byte-identically");
+
+        uint8_t changed_texels[sizeof(texels)];
+        std::memcpy(changed_texels, texels, sizeof(texels));
+        changed_texels[4] = 255;  // sampled top-right texel: green -> yellow
+        resource.tex_rgba = changed_texels;
+        resource.persistent_texture_id = 0x7020000000000002ull;
+        draw.R = {resource};
+        std::vector<uint8_t> changed = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto changed_stats = prosper::test::backend_texture_upload_stats();
+        CHECK(changed_stats.persistent_misses == 1 && changed_stats.unique_uploads == 1,
+              "a new exact-validated content version cannot hit the prior image");
+        CHECK(!changed.empty() && changed != reused,
+              "a new content version uploads and renders its changed pixels");
+    }
+
     // The backend upload key includes depth and image dimensionality. Exercise a real 3D image here
     // so depth-1 3D resources cannot accidentally regress to a 2D Vulkan image/view during sharing.
     {


### PR DESCRIPTION
## Summary
- extend the exact-byte frontend decode cache to linear RGBA atlases and issue a new content-version ID after any source/prefix change
- retain only exact-validated Vulkan sampled images across callbacks under independent 256 MiB / 1024-entry bounds
- preserve callback-local views/samplers, exclude RTT/storage/host-backed/unvalidated resources, and add disable/budget diagnostics
- document the implementation, memory tradeoff, and controlled Dead Cells measurements

## Dead Cells A/B
Native Windows / RTX 4090, same RelWithDebInfo binary, fresh saves, full-render route, matched 110 s runs:

| Measurement | forced upload | persistent images |
|---|---:|---:|
| late app rate | ~10.9 FPS | 13.7-14.4 FPS |
| late backend call | 36.8-37.9 ms | 17.7-19.0 ms |
| steady upload | 96.3 MiB/call | 0 |
| transient pool | 375.3 MiB | 232.0 MiB |
| peak WS / private | 2.20 / 4.54 GiB | 2.29 / 4.60 GiB |

Both runs reached `Loading level PrisonStart`; neither cleared the separately tracked #723 starvation in 110 seconds. The enabled run retained 15 versions / 192.9 MiB with zero invalidations and no pool discards. Private memory plateaued.

## Validation
- Windows CTest: 68/68
- Linux CTest: 97/97 applicable tests; four configured dump tests fail because this build points at Dead Cells while they assert Messenger-specific imports/assets
- focused Vulkan test: initial miss/upload, cross-callback zero-upload hit, forced-upload byte identity, changed content-version miss
- GPU capture/render integration test passes
- two-run Messenger presented-image verification in progress; first run visually contains complete world, player, dialog, portrait, and text layers

Refs #702. Does not close #723.