### PR TITLE
perf(gpu): retain validated guest mapping ranges

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -409,6 +409,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_dynfetch_fold PRIVATE prosper_core)
   add_test(NAME dynfetch_fold COMMAND test_dynfetch_fold)
 
+  # Cross-submit readability reuse is valid only while the HLE mapping generation is unchanged.
+  add_executable(test_guest_memory_map tests/test_guest_memory_map.cpp)
+  target_link_libraries(test_guest_memory_map PRIVATE prosper_core)
+  add_test(NAME guest_memory_map COMMAND test_guest_memory_map)
+
   # Unannounced-32-bit index-buffer fingerprint (#304 — DOLL's Slate/UMG quads). No Vulkan needed.
   add_executable(test_index_size_detect tests/test_index_size_detect.cpp)
   target_link_libraries(test_index_size_detect PRIVATE prosper_core)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -179,6 +179,13 @@ The instrumentation does not take clock samples when the variable is unset. This
 to use when the window presents correctly but a title is not interactive; do not infer a GPU
 bottleneck from low FPS without the stage breakdown.
 
+When the `tables=` bucket is unexpectedly large, set `PROSPER_STAGE_FOLD_PROFILE=1`. It ranks the
+shader address and user-SGPR base pairs responsible for scalar table folding, including average and
+maximum time, decoded instructions, dynamic fetches, SRT uses, guest readability checks, and the
+decode/probe/interpreter split. It prints every 4096 folds by default; set
+`PROSPER_STAGE_FOLD_PROFILE_CALLS=<N>` to change that window. The profiler is intended for short
+diagnostic runs and takes no timing samples when disabled.
+
 Transient Vulkan memory uses a bounded, exact-requirements pool because every backend call waits for its
 fence before cleanup. Timing output includes `memory_pool` hits, misses, cached allocation count/bytes,
 and budget-driven discards. The default budget is 512 MiB; override it with
@@ -226,6 +233,15 @@ tables are reached through guest pointers, and their memory can change while eve
 value remains identical. That experiment caused Messenger to remain on its initial loading screen and
 was removed after an enabled/disabled A/B test. A future table cache needs explicit guest-memory
 versioning or equivalent invalidation; the `tables=` timing bucket measures this work without caching it.
+
+Windows readability checks retain positive results across synchronous submits only for explicitly
+tracked, currently readable kernel-HLE mappings. This is mapping-topology reuse, not a table or
+guest-content cache: HLE map, unmap, and protection operations advance a process generation and
+discard all retained ranges before the next submit. Host-managed guest stacks, diagnostic mappings,
+and other untracked regions are reused only within one submit. Guest bytes are still interpreted on
+every fold. Set `PROSPER_NO_GUEST_READ_CACHE=1` for the uncached A/B path. The contract assumes memory
+referenced by a synchronous GPU submit remains mapped until that submit returns, which was already
+required before the cross-submit reuse was added.
 
 The current renderer remains a deterministic readback-based implementation. It retains CPU-visible pixels
 for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -136,6 +136,46 @@ with `PROSPER_BACKEND_TEXTURE_CACHE_MB`.
 `test_texture_sample_render` verifies the initial miss/upload, a cross-callback hit with zero upload,
 byte-identical forced-upload output, and a new content version that cannot reuse the prior image.
 
+## Dead Cells cross-submit mapping topology cache (2026-07-15)
+
+After persistent texture residency, Dead Cells still spent 38-44 ms per large submit in the
+`tables=` phase. `PROSPER_STAGE_FOLD_PROFILE=1` showed that the scalar interpreter body took about
+0.003 ms per call and shader decode validation about 0.002 ms. The dominant cost was the Windows
+readability guard: the same mapped descriptor regions were checked thousands of times, but the
+positive `VirtualQuery` results were discarded at the end of every synchronous submit.
+
+Positive readable ranges from explicitly tracked kernel-HLE mappings now survive across submits while
+the HLE guest-mapping generation remains unchanged. Every tracked map, unmap, or protection change
+advances that generation and clears the ranges before reuse. Host-managed guest stacks, diagnostic
+mappings, and other regions whose lifetime does not pass through the memory HLE remain submit-local.
+The cache stores only OS mapping topology; it never stores descriptor bytes, shader fold results, or
+resource tables. The existing contract that a synchronous GPU submit's guest allocations remain
+mapped until the submit returns is unchanged. Use `PROSPER_NO_GUEST_READ_CACHE=1` for a control run.
+
+Native Windows / RTX 4090, same RelWithDebInfo binary and matched 169-175-draw Dead Cells scene:
+
+| Measurement | Submit-local ranges | Generation-retained ranges |
+|---|---:|---:|
+| Actual `VirtualQuery` calls per submit | about 31 | 0-2 |
+| Table-fold phase | 38-44 ms | 2-5 ms |
+| Total submit | 99-103 ms | 63-66 ms |
+| App rate | about 9.1 FPS | 13.5-14.2 FPS |
+
+A separate 300-second run remained stable and sustained about 17-18 FPS in a later 56-draw scene.
+Its final 60 seconds averaged 4705 MiB private memory and 3681 MiB working set, with changes of about
++31 MiB and +34 MiB respectively rather than continuing multi-gigabyte growth. The fresh-save scripted
+route did not reach the PrisonStart progression marker in that run, so this is renderer and memory
+stability evidence, not a new progression proof.
+
+The large process baseline has a separate source. Dead Cells explicitly allocates and maps a
+`0xc0000000` (3 GiB) direct-memory arena at 2 MiB alignment. On Windows, the shared-section view
+currently falls back to one eagerly committed `MEM_PRIVATE` allocation. A `VirtualQueryEx` census at
+35 seconds attributed exactly 3072 MiB of roughly 4638 MiB private commit to this arena; measured
+renderer persistent images and transient pools together accounted for about 441 MiB. Placeholder,
+aligned shared-view, or sparse-realization work belongs to
+[#697](https://github.com/mattias800/ps5ys/issues/697) because it must preserve guest query semantics,
+untouched zero-page reads, aliases, and partial unmaps.
+
 ## Current frame budget
 
 After the above changes, a representative renderer submit remains about 36-38 ms. Approximate costs

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -12,6 +12,7 @@
 #include "rdna2_decode.hpp"       // rdna2_walk (for the vertex-fetch const-eval)
 #include "rdna2_to_spirv.hpp"     // recompile_compute
 #include "writer_provenance.hpp"
+#include "../host/guest_memory_map.hpp"
 #include <chrono>
 #include <cstdlib>
 #include <cstdio>
@@ -167,6 +168,100 @@ struct ShaderDecodeCache {
     ShaderDecodeCacheStats stats;
     uint64_t use_counter = 0;
 };
+
+struct StageFoldProfileEntry {
+    uint64_t code = 0;
+    uint32_t user_base = 0;
+    uint64_t calls = 0;
+    uint64_t instructions = 0;
+    uint64_t dynamic_fetches = 0;
+    uint64_t srt_uses = 0;
+    uint64_t code_dwords = 0;
+    uint64_t guest_probes = 0;
+    double total_ms = 0.0;
+    double decode_ms = 0.0;
+    double guest_probe_ms = 0.0;
+    double max_ms = 0.0;
+};
+
+struct StageFoldProfileKey {
+    uint64_t code = 0;
+    uint32_t user_base = 0;
+    bool operator==(const StageFoldProfileKey&) const = default;
+};
+
+struct StageFoldProfileKeyHash {
+    size_t operator()(const StageFoldProfileKey& key) const {
+        const uint64_t mixed = key.code ^ (static_cast<uint64_t>(key.user_base) << 48);
+        return static_cast<size_t>(mixed ^ (mixed >> 32));
+    }
+};
+
+struct StageFoldProfiler {
+    std::mutex mutex;
+    std::unordered_map<StageFoldProfileKey, StageFoldProfileEntry,
+                       StageFoldProfileKeyHash> window;
+    uint64_t calls = 0;
+};
+
+StageFoldProfiler& stage_fold_profiler() {
+    static StageFoldProfiler profiler;
+    return profiler;
+}
+
+void record_stage_fold_profile(uint64_t code, uint32_t user_base, size_t code_dwords,
+                               size_t instructions, size_t dynamic_fetches, size_t srt_uses,
+                               uint64_t guest_probes, double elapsed_ms, double decode_ms,
+                               double guest_probe_ms) {
+    static const uint64_t interval = [] {
+        const char* value = std::getenv("PROSPER_STAGE_FOLD_PROFILE_CALLS");
+        if (!value || !*value) return 4096ull;
+        char* end = nullptr;
+        const unsigned long long parsed = std::strtoull(value, &end, 10);
+        return end != value && parsed > 0 ? parsed : 4096ull;
+    }();
+    StageFoldProfiler& profiler = stage_fold_profiler();
+    std::lock_guard lock(profiler.mutex);
+    StageFoldProfileEntry& entry = profiler.window[{code, user_base}];
+    entry.code = code;
+    entry.user_base = user_base;
+    ++entry.calls;
+    entry.instructions += instructions;
+    entry.dynamic_fetches += dynamic_fetches;
+    entry.srt_uses += srt_uses;
+    entry.code_dwords += code_dwords;
+    entry.guest_probes += guest_probes;
+    entry.total_ms += elapsed_ms;
+    entry.decode_ms += decode_ms;
+    entry.guest_probe_ms += guest_probe_ms;
+    entry.max_ms = std::max(entry.max_ms, elapsed_ms);
+    if (++profiler.calls < interval) return;
+
+    std::vector<StageFoldProfileEntry> ranked;
+    ranked.reserve(profiler.window.size());
+    for (const auto& item : profiler.window) ranked.push_back(item.second);
+    std::sort(ranked.begin(), ranked.end(), [](const auto& a, const auto& b) {
+        return a.total_ms > b.total_ms;
+    });
+    std::fprintf(stderr, "[stage-fold-profile] calls=%llu shaders=%zu top-by-total-ms:\n",
+                 (unsigned long long)profiler.calls, ranked.size());
+    for (size_t i = 0; i < std::min<size_t>(ranked.size(), 12); ++i) {
+        const StageFoldProfileEntry& item = ranked[i];
+        const double calls = static_cast<double>(item.calls);
+        std::fprintf(stderr,
+                     "[stage-fold-profile] code=0x%llx base=%u calls=%llu total=%.3f avg=%.3f "
+                     "max=%.3f decode=%.3f probe=%.3f body=%.3f dw/call=%.1f ins/call=%.1f "
+                     "probes/call=%.1f dyn/call=%.1f srt/call=%.1f\n",
+                     (unsigned long long)item.code, item.user_base,
+                     (unsigned long long)item.calls, item.total_ms, item.total_ms / calls,
+                     item.max_ms, item.decode_ms / calls, item.guest_probe_ms / calls,
+                     (item.total_ms - item.decode_ms - item.guest_probe_ms) / calls,
+                     item.code_dwords / calls, item.instructions / calls,
+                     item.guest_probes / calls, item.dynamic_fetches / calls, item.srt_uses / calls);
+    }
+    profiler.window.clear();
+    profiler.calls = 0;
+}
 
 ShaderDecodeCache& shader_decode_cache() {
     static ShaderDecodeCache cache;
@@ -444,10 +539,10 @@ StageTablePhaseStats stage_table_phase_stats() {
 
 namespace {
 
-struct GuestReadableRange { uint64_t begin = 0, end = 0; };
 struct GuestReadableCacheState {
     bool active = false;
-    std::vector<GuestReadableRange> ranges;
+    host::GuestReadableRangeCache persistent_ranges;
+    host::GuestReadableRangeCache submit_ranges;
     uint64_t calls = 0, hits = 0, os_probes = 0;
 };
 thread_local GuestReadableCacheState g_guest_readable_cache;
@@ -455,34 +550,34 @@ thread_local GuestReadableCacheState g_guest_readable_cache;
 bool guest_range_cache_hit(uint64_t begin, uint64_t end) {
     if (!g_guest_readable_cache.active) return false;
     ++g_guest_readable_cache.calls;
-    for (const auto& range : g_guest_readable_cache.ranges) {
-        if (begin >= range.begin && end <= range.end) {
-            ++g_guest_readable_cache.hits;
-            return true;
-        }
-    }
-    return false;
+    const bool hit = g_guest_readable_cache.persistent_ranges.contains(begin, end) ||
+                     g_guest_readable_cache.submit_ranges.contains(begin, end);
+    if (hit) ++g_guest_readable_cache.hits;
+    return hit;
 }
 
-void cache_guest_readable_range(uint64_t begin, uint64_t end) {
+void cache_guest_readable_range(uint64_t begin, uint64_t end,
+                                uint64_t query_begin, uint64_t query_end) {
     if (!g_guest_readable_cache.active || begin >= end) return;
-    for (auto it = g_guest_readable_cache.ranges.begin(); it != g_guest_readable_cache.ranges.end();) {
-        if (end < it->begin || begin > it->end) { ++it; continue; }
-        begin = std::min(begin, it->begin);
-        end = std::max(end, it->end);
-        it = g_guest_readable_cache.ranges.erase(it);
-    }
-    g_guest_readable_cache.ranges.push_back({begin, end});
+    g_guest_readable_cache.submit_ranges.insert(begin, end);
+    host::GuestReadableRange mapping{};
+    if (host::guest_readable_mapping_containing(query_begin, query_end, mapping))
+        g_guest_readable_cache.persistent_ranges.insert(mapping.begin, mapping.end);
 }
 
 struct GuestReadableSubmitScope {
     GuestReadableSubmitScope() {
-        g_guest_readable_cache = {};
         g_guest_readable_cache.active = getenv("PROSPER_NO_GUEST_READ_CACHE") == nullptr;
+        g_guest_readable_cache.calls = 0;
+        g_guest_readable_cache.hits = 0;
+        g_guest_readable_cache.os_probes = 0;
+        g_guest_readable_cache.submit_ranges.clear();
+        if (g_guest_readable_cache.active)
+            g_guest_readable_cache.persistent_ranges.sync_generation(
+                host::guest_mapping_generation());
     }
     ~GuestReadableSubmitScope() {
         g_guest_readable_cache.active = false;
-        g_guest_readable_cache.ranges.clear();
     }
 };
 
@@ -536,7 +631,7 @@ bool guest_readable(uint64_t a, uint32_t n) {
         if (g_guest_readable_cache.active) ++g_guest_readable_cache.os_probes;
         if (!probe_byte(p < a ? a : p)) return false;
     }
-    cache_guest_readable_range(a & ~0xfffull, last_page + 0x1000);
+    cache_guest_readable_range(a & ~0xfffull, last_page + 0x1000, a, end);
     return true;
 }
 #else
@@ -556,8 +651,10 @@ bool guest_readable(uint64_t a, uint32_t n) {
         if (!(mbi.Protect & readable)) return false;
         const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
         if (region_end <= cursor) return false;
-        cache_guest_readable_range((uint64_t)(uintptr_t)mbi.BaseAddress, region_end);
-        cursor = std::min(end, region_end);
+        const uint64_t query_end = std::min(end, region_end);
+        cache_guest_readable_range((uint64_t)(uintptr_t)mbi.BaseAddress, region_end,
+                                   cursor, query_end);
+        cursor = query_end;
     }
     return true;
 }
@@ -578,9 +675,26 @@ bool guest_readable(uint64_t a, uint32_t n) {
 std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
                       uint32_t user_sgpr_base, std::vector<SrtUse>* srt_uses) {
+    using FoldClock = std::chrono::steady_clock;
+    static const bool profile_fold = std::getenv("PROSPER_STAGE_FOLD_PROFILE") != nullptr;
+    const auto fold_start = profile_fold ? FoldClock::now() : FoldClock::time_point{};
+    const size_t srt_before = srt_uses ? srt_uses->size() : 0;
+    uint64_t guest_probe_calls = 0;
+    double guest_probe_ms = 0.0;
     std::vector<DynFetch> out;
     const auto decoded = decode_shader_cached(code, dwords);
+    const auto decode_done = profile_fold ? FoldClock::now() : FoldClock::time_point{};
     const auto& ins = decoded->instructions;
+
+    auto readable = [&](uint64_t addr, uint32_t bytes) {
+        if (!profile_fold) return guest_readable(addr, bytes);
+        const auto start = FoldClock::now();
+        const bool result = guest_readable(addr, bytes);
+        guest_probe_ms += std::chrono::duration<double, std::milli>(
+            FoldClock::now() - start).count();
+        ++guest_probe_calls;
+        return result;
+    };
 
     // PROSPER_DYNTRACE traces the whole const-fold walk; PROSPER_DYNTRACE_ADDR=<hex code addr>
     // narrows it to ONE shader (a full run otherwise traces every draw's walk — unusable volume).
@@ -808,20 +922,23 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // aperture. Every candidate must be mapped for the complete load, so this never turns
                 // an unreadable pointer into an unchecked dereference. The 4-byte alignment matches
                 // scalar-memory dword addressing (SharpEmu's evaluator applies the same alignment).
-                if (!is_buffer && !guest_readable(addr, n * 4)) {
+                bool addr_readable = is_buffer ? false : readable(addr, n * 4);
+                if (!is_buffer && !addr_readable) {
                     for (uint64_t mask : {0xFFFFFFFFFFFFull, 0xFFFFFFFFFFull}) {
                         const uint64_t candidate = (((base & mask) + (uint64_t)byte_off) & ~3ull);
-                        if (candidate != addr && guest_readable(candidate, n * 4)) {
+                        if (candidate != addr && readable(candidate, n * 4)) {
                             if (trc) fprintf(stderr, "[dyntrace]   canonical S_LOAD addr 0x%llx -> 0x%llx (mask=0x%llx)\n",
                                              (unsigned long long)addr, (unsigned long long)candidate,
                                              (unsigned long long)mask);
                             addr = candidate;
+                            addr_readable = true;
                             break;
                         }
                     }
                 }
-                if (!guest_readable(addr, n * 4)) { if (trc) fprintf(stderr, "[dyntrace]   addr 0x%llx unreadable\n", (unsigned long long)addr);
-                                                    for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k); break; }
+                if (is_buffer) addr_readable = readable(addr, n * 4);
+                if (!addr_readable) { if (trc) fprintf(stderr, "[dyntrace]   addr 0x%llx unreadable\n", (unsigned long long)addr);
+                                      for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k); break; }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
                 for (uint32_t k = 0; k < n; k++) set_value(sdst + (int)k, mem[k]);
                 // Provenance key: the recompiler tags an IMMEDIATE-only descriptor load's dest SGPRs
@@ -1044,6 +1161,13 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 break;
         }
     }
+    if (profile_fold)
+        record_stage_fold_profile(
+            (uint64_t)(uintptr_t)code, user_sgpr_base, decoded->code.size(), ins.size(), out.size(),
+            srt_uses ? srt_uses->size() - srt_before : 0, guest_probe_calls,
+            std::chrono::duration<double, std::milli>(FoldClock::now() - fold_start).count(),
+            std::chrono::duration<double, std::milli>(decode_done - fold_start).count(),
+            guest_probe_ms);
     return out;
 }
 

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -6,6 +6,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
+#include "../host/guest_memory_map.hpp"
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "../host/posix_shim.hpp"
@@ -133,6 +134,7 @@ namespace {
         Mapping m{ base, size, prot, committed, {0} };
         if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
         g_maps.push_back(m);
+        host::notify_guest_mapping_added(base, size, committed && (prot & 0x1));
     }
     // Trim/split tracked mappings overlapping [base, base+len). munmap/BatchMap-UNMAP must remove
     // their tracking (this never happened before — g_maps only ever grew): stale "committed"
@@ -153,6 +155,7 @@ namespace {
             if (me > end)      { Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi); }
         }
         g_maps.swap(out);
+        host::notify_guest_mapping_removed(base, len);
     }
     // Re-tag [base, base+len) with a new protection (mprotect): replace the overlapped span so
     // VirtualQuery/the fault probe report the CURRENT prot, not the one from map time.
@@ -1253,6 +1256,7 @@ namespace {
         Mapping m{ base, size, prot, committed, {0} };
         if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
         g_maps.push_back(m);
+        host::notify_guest_mapping_added(base, size, committed && (prot & 0x1));
     }
     void untrack(uint64_t base, uint64_t len) {
         if (!len) return;
@@ -1267,6 +1271,7 @@ namespace {
             if (me > end)      { Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi); }
         }
         g_maps.swap(out);
+        host::notify_guest_mapping_removed(base, len);
     }
     void retrack_prot(uint64_t base, uint64_t len, int prot, const char* nm) {
         if (!len) return;

--- a/prosper/src/host/guest_memory_map.hpp
+++ b/prosper/src/host/guest_memory_map.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace prosper::host {
+
+struct GuestReadableRange {
+    uint64_t begin = 0;
+    uint64_t end = 0;
+};
+
+class GuestReadableRangeCache {
+public:
+    bool contains(uint64_t begin, uint64_t end) {
+        if (begin >= end) return false;
+        if (have_last_hit_ && begin >= last_hit_.begin && end <= last_hit_.end) return true;
+        auto candidate = std::upper_bound(
+            ranges_.begin(), ranges_.end(), begin,
+            [](uint64_t value, const GuestReadableRange& range) { return value < range.begin; });
+        if (candidate == ranges_.begin()) return false;
+        --candidate;
+        if (begin < candidate->begin || end > candidate->end) return false;
+        last_hit_ = *candidate;
+        have_last_hit_ = true;
+        return true;
+    }
+
+    bool containing_range(uint64_t begin, uint64_t end, GuestReadableRange& out) {
+        if (!contains(begin, end)) return false;
+        out = last_hit_;
+        return true;
+    }
+
+    void insert(uint64_t begin, uint64_t end) {
+        if (begin >= end) return;
+        size_t first = 0;
+        while (first < ranges_.size() && ranges_[first].end < begin) ++first;
+        size_t last = first;
+        while (last < ranges_.size() && ranges_[last].begin <= end) {
+            begin = std::min(begin, ranges_[last].begin);
+            end = std::max(end, ranges_[last].end);
+            ++last;
+        }
+        ranges_.erase(ranges_.begin() + first, ranges_.begin() + last);
+        ranges_.insert(ranges_.begin() + first, {begin, end});
+        last_hit_ = {begin, end};
+        have_last_hit_ = true;
+    }
+
+    void erase(uint64_t begin, uint64_t end) {
+        if (begin >= end) return;
+        std::vector<GuestReadableRange> kept;
+        kept.reserve(ranges_.size() + 1);
+        for (const GuestReadableRange& range : ranges_) {
+            if (range.end <= begin || range.begin >= end) {
+                kept.push_back(range);
+                continue;
+            }
+            if (range.begin < begin) kept.push_back({range.begin, begin});
+            if (range.end > end) kept.push_back({end, range.end});
+        }
+        ranges_.swap(kept);
+        last_hit_ = {};
+        have_last_hit_ = false;
+    }
+
+    void sync_generation(uint64_t generation) {
+        if (generation_ == generation) return;
+        clear();
+        generation_ = generation;
+    }
+
+    void clear() {
+        ranges_.clear();
+        last_hit_ = {};
+        have_last_hit_ = false;
+    }
+
+    size_t range_count() const { return ranges_.size(); }
+    uint64_t generation() const { return generation_; }
+
+private:
+    std::vector<GuestReadableRange> ranges_;
+    GuestReadableRange last_hit_;
+    uint64_t generation_ = 0;
+    bool have_last_hit_ = false;
+};
+
+// Only explicitly tracked, currently readable HLE mappings are eligible for cross-submit reuse.
+// Host-managed guest stacks and diagnostic mappings remain submit-local because their lifetime does
+// not pass through the kernel-memory HLE.
+namespace detail {
+inline std::atomic<uint64_t> guest_mapping_generation{1};
+inline std::mutex guest_mapping_mutex;
+inline GuestReadableRangeCache guest_readable_mappings;
+
+inline void advance_guest_mapping_generation() {
+    guest_mapping_generation.fetch_add(1, std::memory_order_release);
+}
+}
+
+inline uint64_t guest_mapping_generation() {
+    return detail::guest_mapping_generation.load(std::memory_order_acquire);
+}
+
+inline void notify_guest_mapping_added(uint64_t begin, uint64_t size, bool readable) {
+    if (!size) return;
+    {
+        std::lock_guard lock(detail::guest_mapping_mutex);
+        if (begin > UINT64_MAX - size) {
+            detail::guest_readable_mappings.clear();
+            detail::advance_guest_mapping_generation();
+            return;
+        }
+        const uint64_t end = begin + size;
+        detail::guest_readable_mappings.erase(begin, end);
+        if (readable) detail::guest_readable_mappings.insert(begin, end);
+    }
+    detail::advance_guest_mapping_generation();
+}
+
+inline void notify_guest_mapping_removed(uint64_t begin, uint64_t size) {
+    if (!size) return;
+    {
+        std::lock_guard lock(detail::guest_mapping_mutex);
+        if (begin > UINT64_MAX - size) {
+            detail::guest_readable_mappings.clear();
+            detail::advance_guest_mapping_generation();
+            return;
+        }
+        detail::guest_readable_mappings.erase(begin, begin + size);
+    }
+    detail::advance_guest_mapping_generation();
+}
+
+inline bool guest_readable_mapping_containing(uint64_t begin, uint64_t end,
+                                              GuestReadableRange& out) {
+    std::lock_guard lock(detail::guest_mapping_mutex);
+    return detail::guest_readable_mappings.containing_range(begin, end, out);
+}
+
+} // namespace prosper::host

--- a/prosper/tests/test_guest_memory_map.cpp
+++ b/prosper/tests/test_guest_memory_map.cpp
@@ -1,0 +1,60 @@
+#include "host/guest_memory_map.hpp"
+
+#include <cstdio>
+
+using prosper::host::GuestReadableRangeCache;
+
+int main() {
+    int failures = 0;
+    auto check = [&](bool condition, const char* name) {
+        std::printf("  [%s] %s\n", condition ? "ok" : "FAIL", name);
+        if (!condition) ++failures;
+    };
+
+    std::puts("== test_guest_memory_map ==");
+    GuestReadableRangeCache cache;
+    cache.sync_generation(10);
+    cache.insert(0x3000, 0x4000);
+    cache.insert(0x1000, 0x2000);
+    check(cache.contains(0x1000, 0x1800), "out-of-order disjoint insert remains searchable");
+    check(cache.contains(0x3000, 0x4000), "last inserted range remains searchable");
+    check(!cache.contains(0x1800, 0x3800), "query spanning an unmapped gap misses");
+
+    cache.insert(0x2000, 0x3000);
+    check(cache.range_count() == 1, "adjacent ranges merge into one interval");
+    check(cache.contains(0x1000, 0x4000), "merged interval covers its complete extent");
+
+    cache.erase(0x1800, 0x3800);
+    check(cache.contains(0x1000, 0x1800), "range removal preserves the lower fragment");
+    check(!cache.contains(0x1800, 0x3800), "range removal drops the overlapped span");
+    check(cache.contains(0x3800, 0x4000), "range removal preserves the upper fragment");
+    cache.insert(0x1800, 0x3800);
+
+    cache.sync_generation(10);
+    check(cache.contains(0x1800, 0x3800), "unchanged mapping generation preserves ranges");
+    cache.sync_generation(11);
+    check(cache.range_count() == 0, "mapping generation change clears cached ranges");
+    check(!cache.contains(0x1000, 0x1800), "cleared generation cannot return a stale hit");
+
+    const uint64_t generation = prosper::host::guest_mapping_generation();
+    prosper::host::notify_guest_mapping_added(0x10000, 0x4000, true);
+    check(prosper::host::guest_mapping_generation() != generation,
+          "mapping notification advances the process generation");
+    prosper::host::GuestReadableRange mapping{};
+    check(prosper::host::guest_readable_mapping_containing(0x11000, 0x12000, mapping) &&
+              mapping.begin == 0x10000 && mapping.end == 0x14000,
+          "readable HLE mapping exposes its stable containing extent");
+    prosper::host::notify_guest_mapping_added(0x11000, 0x1000, false);
+    check(!prosper::host::guest_readable_mapping_containing(0x11000, 0x12000, mapping),
+          "unreadable overlay is ineligible for cross-submit reuse");
+    prosper::host::notify_guest_mapping_removed(0x10000, 0x4000);
+    check(!prosper::host::guest_readable_mapping_containing(0x10000, 0x11000, mapping),
+          "removed HLE mapping cannot retain a positive readability result");
+    prosper::host::notify_guest_mapping_added(0x20000, 0x1000, true);
+    prosper::host::notify_guest_mapping_removed(UINT64_MAX - 1, 4);
+    check(!prosper::host::guest_readable_mapping_containing(0x20000, 0x21000, mapping),
+          "malformed mapping change conservatively clears readable extents");
+
+    std::puts(failures ? "== FAIL ==" : "== PASS ==");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- retain validated guest-readable mapping ranges across synchronous GPU submits only for explicitly tracked, currently readable kernel-HLE mappings
- invalidate retained ranges on every tracked map, unmap, or protection change while keeping host-managed stacks and untracked mappings submit-local
- add `PROSPER_STAGE_FOLD_PROFILE` diagnostics, the uncached `PROSPER_NO_GUEST_READ_CACHE` control, focused unit coverage, and performance documentation

## Root cause and impact

Dead Cells repeated thousands of guest-readability guards while folding dynamic shader tables. On Windows, positive `VirtualQuery` results were discarded after every submit even though the HLE mapping topology had not changed. The interpreter itself took about 0.003 ms per call; the OS mapping probes dominated the 38-44 ms table phase.

In a matched 169-175-draw native Windows scene:

| Metric | Submit-local ranges | Retained tracked ranges |
|---|---:|---:|
| Actual `VirtualQuery` calls / submit | about 31 | 0-2 |
| Table-fold phase | 38-44 ms | 2-5 ms |
| Total submit | 99-103 ms | 63-66 ms |
| App rate | about 9.1 FPS | 13.5-14.2 FPS |

The cache stores mapping topology only. Guest bytes, descriptor tables, and fold results are still read and computed every time. A 300-second control remained bounded; Dead Cells' separate 3 GiB Windows private-memory baseline is documented on #697 rather than changed here.

Partially addresses #702.

## Validation

- Windows CTest: 69/69 passed
- Linux CTest: 102/102 passed, including `boot_reaches_first_syscall`
- new range-cache tests cover merge, split, generation invalidation, readable/unreadable overlays, removal, and malformed-range fail-safe behavior
- two Messenger gameplay verifications were content-stable and all retained frames were inspected
- two Blasphemous 2 gameplay verifications reached the playable room; retained frames also reproduce the known intermittent layer loss from #720
- two Dead Cells verifier runs reproduced the existing loading-screen divergence from #723/#661; the final native performance route remained stable and exercised the tracked-only cache