### PR TITLE
perf(win): demand-page aligned direct memory

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -243,6 +243,13 @@ every fold. Set `PROSPER_NO_GUEST_READ_CACHE=1` for the uncached A/B path. The c
 referenced by a synchronous GPU submit remains mapped until that submit returns, which was already
 required before the cross-submit reuse was added.
 
+Large-alignment Windows direct-memory views can be sparse section mappings. They are deliberately
+excluded from cross-submit readability reuse because guest-visible committed pages may still be host-
+reserved until first access. CPU faults, GPU readability guards, and the live renderer materialize the
+required 16 KiB pages through the memory HLE, which validates the complete guest mapping and its current
+protection first. This preserves untouched-zero and alias behavior without eagerly committing a title's
+entire arena. `PROSPER_MEMLOG=1` reports `map_dmem sparse aligned view` when this path is active.
+
 The current renderer remains a deterministic readback-based implementation. It retains CPU-visible pixels
 for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702
 tracks persistent Vulkan resource/pipeline caching and direct image presentation beyond the initial

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -569,11 +569,15 @@ edge cases are tracked separately in #697.
 1. **Extend native scripted gameplay coverage beyond The Messenger (#683/#688).** The frontend,
    controller composition, WIC screenshot path, and routed first-level acceptance now work. Add
    checkpoint automation for more titles as the Windows substrate is exercised more broadly.
-2. **Complete the remaining 16 KiB section-view edge cases (#697).** Direct memory now uses one sparse
+2. **Complete the remaining 16 KiB section-view edge cases (#697).** Direct memory uses one sparse
    paging-file section, so zero-hint and 64 KiB-congruent mappings alias correctly and Dead Cells no
-   longer corrupts the host heap during physical-range churn (#691). Exact fixed maps whose virtual and
-   physical 64 KiB deltas differ still use the private fallback, and partial unmap needs a section-aware
-   implementation. These likely require placeholder APIs (`VirtualAlloc2`/`MapViewOfFile3`).
+   longer corrupts the host heap during physical-range churn (#691). Large-alignment zero-hint maps now
+   reserve an explicitly aligned placeholder with `VirtualAlloc2`, replace it with the shared section via
+   `MapViewOfFile3`, and commit 16 KiB pages on first CPU/GPU access. Guest `VirtualQuery` still reports the
+   direct mapping as committed; untouched host pages carry no commit charge. Dead Cells' 3 GiB, 2 MiB-
+   aligned arena therefore remains physically aliased without one 3 GiB eager private allocation.
+   Exact fixed maps whose virtual and physical 64 KiB deltas differ still use the private fallback, and
+   partial unmap needs a section-aware implementation.
 3. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args 1-9 are converted
    and now runtime-exercised through init; **XMM/float args are still not converted** (e.g. some libc
    formatters / `printf`-family) — add float-arg conversion when a title needs it.

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -169,12 +169,28 @@ stability evidence, not a new progression proof.
 
 The large process baseline has a separate source. Dead Cells explicitly allocates and maps a
 `0xc0000000` (3 GiB) direct-memory arena at 2 MiB alignment. On Windows, the shared-section view
-currently falls back to one eagerly committed `MEM_PRIVATE` allocation. A `VirtualQueryEx` census at
+previously fell back to one eagerly committed `MEM_PRIVATE` allocation. A `VirtualQueryEx` census at
 35 seconds attributed exactly 3072 MiB of roughly 4638 MiB private commit to this arena; measured
 renderer persistent images and transient pools together accounted for about 441 MiB. Placeholder,
 aligned shared-view, or sparse-realization work belongs to
 [#697](https://github.com/mattias800/ps5ys/issues/697) because it must preserve guest query semantics,
 untouched zero-page reads, aliases, and partial unmaps.
+
+The Windows sparse large-alignment path now uses `VirtualAlloc2` address requirements plus
+`MapViewOfFile3(MEM_REPLACE_PLACEHOLDER)` and commits shared 16 KiB pages on demand. The focused test
+checks 2 MiB placement, guest query state, an untouched far page, GPU-read materialization, alias
+coherence, protection changes before and after first touch, and exact whole-view unmap. The modern APIs
+are resolved dynamically; systems without them retain the old mapping path.
+
+A five-minute fresh-save Dead Cells run removed the 3072 MiB private fallback and had no sparse commit
+failure. In the late 54-draw loading scene, private commit averaged 1604 MiB over the final minute and
+changed by about +1 MiB. Working set was 2815 MiB at exit and still gaining about 190 MiB over that
+minute: repeated renderer reads were making the shared section resident even though they no longer
+charged private commit. That run repeatedly scanned about 460 MiB of declared texture ranges per submit,
+spent about 40 ms in resource construction, and presented at roughly 8-10 FPS. It did not reach the
+`PrisonStart` marker, so it is memory/fault stability evidence rather than a progression proof. Avoiding
+repeated scans or materialization of untouched resource tails is follow-up renderer work, not a reason to
+restore the eager 3 GiB private allocation.
 
 ## Current frame budget
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -27,6 +27,9 @@
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
 extern "C" int prosper_reserved_range_state(uint64_t addr);
+#ifdef _WIN32
+extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
+#endif
 // VideoOut scanout registry (hle_graphics.cpp) — which guest buffer the game most recently FLIPPED
 // to screen. The flip fires during the Dcb fold (agc_dcb_set_flip -> prosper_vo_flip_from_gpu),
 // BEFORE the submit's execute_and_present, so at render time these identify this frame's scanout VA.
@@ -270,6 +273,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // short copy just leaves a transparent/black tail (only the missing region degrades).
             auto safe_copy = [](uint8_t* dst, uint64_t a, size_t n) -> size_t {
                 const size_t PG = 0x10000;   // lazy-commit granularity (64 KB)
+#ifdef _WIN32
+                // Prepare a complete sparse direct-memory resource once. The per-chunk mapping
+                // checks below still stop an over-declared resource at its real guest boundary.
+                if (prosper_try_commit_dmem(a, n, 0)) {
+                    std::memcpy(dst, (const void*)(uintptr_t)a, n);
+                    return n;
+                }
+#endif
                 size_t done = 0;
                 while (done < n) {
                     uint64_t cur = a + done;
@@ -283,6 +294,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             auto safe_equal = [](const uint8_t* expected, uint64_t a, size_t n,
                                  size_t& compared) -> bool {
                 const size_t PG = 0x10000;
+#ifdef _WIN32
+                if (prosper_try_commit_dmem(a, n, 0)) {
+                    compared = n;
+                    return std::memcmp(expected, (const void*)(uintptr_t)a, n) == 0;
+                }
+#endif
                 compared = 0;
                 while (compared < n) {
                     const uint64_t cur = a + compared;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -635,6 +635,8 @@ bool guest_readable(uint64_t a, uint32_t n) {
     return true;
 }
 #else
+extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
+
 bool guest_readable(uint64_t a, uint32_t n) {
     if (a < 0x1000 || n == 0 || a + n < a) return false;
     const uint64_t end = a + n;
@@ -645,6 +647,11 @@ bool guest_readable(uint64_t a, uint32_t n) {
         if (g_guest_readable_cache.active) ++g_guest_readable_cache.os_probes;
         if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
         const DWORD blocked = PAGE_NOACCESS | PAGE_GUARD;
+        if (mbi.State != MEM_COMMIT) {
+            if (!prosper_try_commit_dmem(cursor, end - cursor, 0)) return false;
+            if (g_guest_readable_cache.active) ++g_guest_readable_cache.os_probes;
+            if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
+        }
         if (mbi.State != MEM_COMMIT || (mbi.Protect & blocked)) return false;
         const DWORD readable = PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
                                PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1192,6 +1192,7 @@ namespace {
     struct Mapping { uint64_t base, size; int prot; bool committed; char name[32]; };
     std::mutex g_mx;
     std::vector<Mapping> g_maps;
+    bool sparse_dmem_view_overlaps(uint64_t begin, uint64_t end);
     constexpr uint64_t kDmemBase  = 0x10000000;
     constexpr uint64_t kDmemTotal = 8ull * 1024 * 1024 * 1024;   // 8 GiB pool
     struct DMem { uint64_t start, end; int type; };
@@ -1251,12 +1252,14 @@ namespace {
         }
         g_dmem.swap(out);
     }
-    void track(uint64_t base, uint64_t size, int prot, bool committed, const char* nm) {
+    void track(uint64_t base, uint64_t size, int prot, bool committed, const char* nm,
+               bool host_readable = true) {
         std::lock_guard<std::mutex> lk(g_mx);
         Mapping m{ base, size, prot, committed, {0} };
         if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
         g_maps.push_back(m);
-        host::notify_guest_mapping_added(base, size, committed && (prot & 0x1));
+        host::notify_guest_mapping_added(base, size,
+                                         committed && host_readable && (prot & 0x1));
     }
     void untrack(uint64_t base, uint64_t len) {
         if (!len) return;
@@ -1276,7 +1279,10 @@ namespace {
     void retrack_prot(uint64_t base, uint64_t len, int prot, const char* nm) {
         if (!len) return;
         untrack(base, len);
-        track(base, len, prot, true, nm);
+        // Sparse protection overlays remain submit-local; fully committed mappings retain the
+        // generation-guarded cross-submit readability optimization from #737.
+        track(base, len, prot, true, nm,
+              base <= UINT64_MAX - len && !sparse_dmem_view_overlaps(base, base + len));
     }
     const Mapping* find(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);
@@ -1335,9 +1341,65 @@ namespace {
         uint64_t phys;
         void* view_base;
         uint64_t view_size;
+        bool sparse;
     };
     std::mutex g_dview_mx;
     std::vector<DmemView> g_dviews;
+
+    using VirtualAlloc2Fn = PVOID (WINAPI*)(HANDLE, PVOID, SIZE_T, ULONG, ULONG,
+                                            MEM_EXTENDED_PARAMETER*, ULONG);
+    using MapViewOfFile3Fn = PVOID (WINAPI*)(HANDLE, HANDLE, PVOID, ULONG64, SIZE_T,
+                                             ULONG, ULONG, MEM_EXTENDED_PARAMETER*, ULONG);
+
+    struct PlaceholderApis {
+        VirtualAlloc2Fn virtual_alloc2 = nullptr;
+        MapViewOfFile3Fn map_view_of_file3 = nullptr;
+    };
+
+    const PlaceholderApis& placeholder_apis() {
+        static const PlaceholderApis apis = [] {
+            HMODULE module = GetModuleHandleW(L"kernelbase.dll");
+            if (!module) module = GetModuleHandleW(L"kernel32.dll");
+            PlaceholderApis out;
+            if (module) {
+                out.virtual_alloc2 = reinterpret_cast<VirtualAlloc2Fn>(
+                    GetProcAddress(module, "VirtualAlloc2"));
+                out.map_view_of_file3 = reinterpret_cast<MapViewOfFile3Fn>(
+                    GetProcAddress(module, "MapViewOfFile3"));
+            }
+            return out;
+        }();
+        return apis;
+    }
+
+    void* map_sparse_aligned_section_view(HANDLE section, uint64_t file_off,
+                                          uint64_t view_size, uint64_t align) {
+        const PlaceholderApis& apis = placeholder_apis();
+        if (!apis.virtual_alloc2 || !apis.map_view_of_file3 ||
+            align < kWinAllocationGranularity || (align & (align - 1))) return nullptr;
+
+        MEM_ADDRESS_REQUIREMENTS requirements{};
+        requirements.Alignment = static_cast<SIZE_T>(align);
+        MEM_EXTENDED_PARAMETER parameter{};
+        parameter.Type = MemExtendedParameterAddressRequirements;
+        parameter.Pointer = &requirements;
+        void* placeholder = apis.virtual_alloc2(
+            GetCurrentProcess(), nullptr, static_cast<SIZE_T>(view_size),
+            MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, &parameter, 1);
+        if (!placeholder) return nullptr;
+
+        void* view = apis.map_view_of_file3(
+            section, GetCurrentProcess(), placeholder, file_off,
+            static_cast<SIZE_T>(view_size), MEM_REPLACE_PLACEHOLDER,
+            PAGE_READWRITE, nullptr, 0);
+        if (!view) {
+            const DWORD error = GetLastError();
+            VirtualFree(placeholder, 0, MEM_RELEASE);
+            SetLastError(error);
+            return nullptr;
+        }
+        return view;
+    }
 
     void* map_section_view(uint64_t hint, uint64_t len, int hp, uint64_t phys, uint64_t align) {
         HANDLE section = dmem_section();
@@ -1359,26 +1421,38 @@ namespace {
             requested = (void*)(uintptr_t)(hint - delta);
         }
 
-        void* view = MapViewOfFileEx(section, FILE_MAP_ALL_ACCESS,
-                                     (DWORD)(file_off >> 32), (DWORD)(file_off & 0xffffffffu),
-                                     (SIZE_T)view_size, requested);
+        const uint64_t requested_align = align ? align : 0x4000;
+        bool sparse = false;
+        void* view = nullptr;
+        // MapViewOfFileEx only chooses a 64 KiB-aligned base. A zero-hint title requesting a
+        // larger alignment needs a placeholder reservation with explicit address requirements.
+        // Keep the SEC_RESERVE pages uncommitted here; first CPU/GPU access materializes 16 KiB.
+        if (!hint && requested_align > kWinAllocationGranularity &&
+            (delta & (requested_align - 1)) == 0) {
+            view = map_sparse_aligned_section_view(section, file_off, view_size, requested_align);
+            sparse = view != nullptr;
+        }
+        if (!view) {
+            view = MapViewOfFileEx(section, FILE_MAP_ALL_ACCESS,
+                                   (DWORD)(file_off >> 32), (DWORD)(file_off & 0xffffffffu),
+                                   (SIZE_T)view_size, requested);
+        }
         if (!view) return nullptr;
         uint8_t* guest = (uint8_t*)view + delta;
 
-        const uint64_t requested_align = align ? align : 0x4000;
         if (!hint && requested_align &&
             ((uint64_t)(uintptr_t)guest & (requested_align - 1)) != 0) {
             UnmapViewOfFile(view);
             return nullptr;
         }
-        if (!VirtualAlloc(guest, (SIZE_T)len, MEM_COMMIT, PAGE_READWRITE)) {
+        if (!sparse && !VirtualAlloc(guest, (SIZE_T)len, MEM_COMMIT, PAGE_READWRITE)) {
             MLOG("section commit va=0x%llx len=0x%llx failed error=%lu\n",
                  (unsigned long long)(uintptr_t)guest, (unsigned long long)len, GetLastError());
             UnmapViewOfFile(view);
             return nullptr;
         }
         DWORD old = 0;
-        if (!VirtualProtect(guest, (SIZE_T)len, win_page_prot(hp), &old)) {
+        if (!sparse && !VirtualProtect(guest, (SIZE_T)len, win_page_prot(hp), &old)) {
             MLOG("section protect va=0x%llx len=0x%llx failed error=%lu\n",
                  (unsigned long long)(uintptr_t)guest, (unsigned long long)len, GetLastError());
             UnmapViewOfFile(view);
@@ -1386,9 +1460,95 @@ namespace {
         }
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
-            g_dviews.push_back({ (uint64_t)(uintptr_t)guest, len, phys, view, view_size });
+            g_dviews.push_back({ (uint64_t)(uintptr_t)guest, len, phys, view, view_size, sparse });
         }
+        if (sparse)
+            MLOG("map_dmem sparse aligned view va=0x%llx len=0x%llx phys=0x%llx align=0x%llx\n",
+                 (unsigned long long)(uintptr_t)guest, (unsigned long long)len,
+                 (unsigned long long)phys, (unsigned long long)requested_align);
         return guest;
+    }
+
+    bool sparse_dmem_view_contains(uint64_t begin, uint64_t end, DmemView* out = nullptr) {
+        if (begin >= end) return false;
+        std::lock_guard<std::mutex> lk(g_dview_mx);
+        for (const DmemView& view : g_dviews) {
+            if (!view.sparse || begin < view.guest_base ||
+                end > view.guest_base + view.guest_size) continue;
+            if (out) *out = view;
+            return true;
+        }
+        return false;
+    }
+
+    bool sparse_dmem_view_overlaps(uint64_t begin, uint64_t end) {
+        if (begin >= end) return false;
+        std::lock_guard<std::mutex> lk(g_dview_mx);
+        for (const DmemView& view : g_dviews)
+            if (view.sparse && begin < view.guest_base + view.guest_size &&
+                end > view.guest_base) return true;
+        return false;
+    }
+
+    bool tracked_mapping_access(uint64_t begin, uint64_t end, bool write, int& hp) {
+        if (begin >= end) return false;
+        std::lock_guard<std::mutex> lk(g_mx);
+        const Mapping* best = nullptr;
+        for (const Mapping& mapping : g_maps) {
+            if (!mapping.committed || begin < mapping.base ||
+                begin >= mapping.base + mapping.size) continue;
+            if (!best || mapping.base > best->base) best = &mapping;
+        }
+        if (!best || end > best->base + best->size || !(best->prot & HP_R) ||
+            (write && !(best->prot & HP_W))) return false;
+        hp = best->prot;
+        return true;
+    }
+
+    int commit_sparse_dmem(uint64_t addr, uint64_t len, bool write) {
+        if (!len || addr > UINT64_MAX - len ||
+            !sparse_dmem_view_contains(addr, addr + len)) return 0;
+        int hp = 0;
+        if (!tracked_mapping_access(addr, addr + len, write, hp)) return 0;
+        const uint64_t first = addr & ~0x3fffull;
+        const uint64_t last = (addr + len - 1) & ~0x3fffull;
+        uint64_t page = first;
+        for (;;) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery((const void*)(uintptr_t)page, &mbi, sizeof(mbi))) return 0;
+            if (mbi.State != MEM_COMMIT) {
+                if (!VirtualAlloc((void*)(uintptr_t)page, 0x4000, MEM_COMMIT,
+                                  win_page_prot(hp))) {
+                    MLOG("sparse dmem commit va=0x%llx failed error=%lu\n",
+                         (unsigned long long)page, GetLastError());
+                    return 0;
+                }
+            } else {
+                const DWORD blocked = PAGE_NOACCESS | PAGE_GUARD;
+                const DWORD readable = PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+                                       PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE |
+                                       PAGE_EXECUTE_WRITECOPY;
+                const DWORD writable = PAGE_READWRITE | PAGE_WRITECOPY |
+                                       PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+                if ((mbi.Protect & blocked) || !(mbi.Protect & readable) ||
+                    (write && !(mbi.Protect & writable))) return 0;
+                const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+                if (region_end > last) break;
+                if (region_end <= page) return 0;
+                page = (region_end + 0x3fff) & ~0x3fffull;
+                continue;
+            }
+            if (page == last) break;
+            page += 0x4000;
+        }
+        return 1;
+    }
+
+    bool sparse_dmem_page_uncommitted(uint64_t addr) {
+        if (!sparse_dmem_view_contains(addr, addr + 1)) return false;
+        MEMORY_BASIC_INFORMATION mbi{};
+        return VirtualQuery((const void*)(uintptr_t)addr, &mbi, sizeof(mbi)) &&
+               mbi.State != MEM_COMMIT;
     }
 
     // A released physical range can be allocated again while old virtual aliases still exist.
@@ -1494,6 +1654,25 @@ namespace {
         return (void*)(((uint64_t)raw + (align - 1)) & ~(align - 1));
     }
     bool win_protect(uint64_t addr, uint64_t len, int hp) {
+        if (len && addr <= UINT64_MAX - len && sparse_dmem_view_overlaps(addr, addr + len)) {
+            const uint64_t end = addr + len;
+            uint64_t cursor = addr;
+            while (cursor < end) {
+                MEMORY_BASIC_INFORMATION mbi{};
+                if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
+                const uint64_t region_end = std::min<uint64_t>(
+                    end, (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize);
+                if (region_end <= cursor || mbi.State == MEM_FREE) return false;
+                if (mbi.State == MEM_COMMIT) {
+                    DWORD old = 0;
+                    if (!VirtualProtect((void*)(uintptr_t)cursor,
+                                        (SIZE_T)(region_end - cursor),
+                                        win_page_prot(hp), &old)) return false;
+                }
+                cursor = region_end;
+            }
+            return true;
+        }
         DWORD old = 0;
         return VirtualProtect((void*)addr, (SIZE_T)len, win_page_prot(hp), &old) != 0;
     }
@@ -1520,15 +1699,30 @@ namespace {
     }
 } // namespace
 
+// Materialize untouched zero pages in a sparse direct-memory view before a host-side read/write.
+// Returns 0 for an unrelated, inaccessible, or invalid range so callers retain their normal guard.
+extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write) {
+    return commit_sparse_dmem(addr, len, write != 0);
+}
+
 // Fault-handler lazy-commit probe parity (Linux exports this for its SIGSEGV handler). The Windows
-// VEH uses this to back reserved guest pages on first touch: 0 = untracked, 1 = reserved, 2 = committed.
+// VEH uses this to back reserved guest pages on first touch: 0 = untracked, 1 = reserved,
+// 2 = committed, 3 = guest-committed sparse direct page awaiting host commitment.
 extern "C" int prosper_reserved_range_state(uint64_t addr) {
-    std::lock_guard<std::mutex> lk(g_mx);
-    const Mapping* best = nullptr;
-    for (auto& m : g_maps)
-        if (addr >= m.base && addr < m.base + m.size)
-            if (!best || m.base > best->base) best = &m;
-    return best ? (best->committed ? 2 : 1) : 0;
+    bool tracked = false;
+    bool committed = false;
+    {
+        std::lock_guard<std::mutex> lk(g_mx);
+        const Mapping* best = nullptr;
+        for (auto& m : g_maps)
+            if (addr >= m.base && addr < m.base + m.size)
+                if (!best || m.base > best->base) best = &m;
+        tracked = best != nullptr;
+        committed = best && best->committed;
+    }
+    if (!tracked) return 0;
+    if (!committed) return 1;
+    return addr != UINT64_MAX && sparse_dmem_page_uncommitted(addr) ? 3 : 2;
 }
 
 // --- Handlers: Win32 versions of the Linux memory HLE, same Sony contracts -------------------
@@ -1634,7 +1828,8 @@ HLE(k_map_dmem) {
     if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n",
                    (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; }
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
-    track((uint64_t)p, a1, host_prot(a2), true, "direct");
+    const bool sparse = sparse_dmem_view_contains((uint64_t)p, (uint64_t)p + a1);
+    track((uint64_t)p, a1, host_prot(a2), true, "direct", !sparse);
     MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
          (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4,
          (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)a5);
@@ -1679,7 +1874,12 @@ HLE(k_batch_map) {
             case 0: {                               // MAP_DIRECT: shared physical backing
                 void* p = win_map_phys(start, len, host_prot(prot), phys, 0, start != 0);
                 ok = (p != nullptr);
-                if (ok) track((uint64_t)p, len, host_prot(prot), true, "batch-direct");
+                if (ok) {
+                    const bool sparse = sparse_dmem_view_contains(
+                        (uint64_t)p, (uint64_t)p + len);
+                    track((uint64_t)p, len, host_prot(prot), true,
+                          "batch-direct", !sparse);
+                }
                 break;
             }
             case 3: {                               // MAP_FLEXIBLE: anonymous/private

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -263,8 +263,9 @@ namespace {
     );
 
     // Tracked-mapping state probe for the lazy-commit fault path (defined in hle_kernel_mem.cpp):
-    // 0 = untracked/gap, 1 = reserved-but-uncommitted, 2 = committed.
+    // 0 = untracked/gap, 1 = reserved, 2 = committed, 3 = sparse direct-memory page.
     extern "C" int prosper_reserved_range_state(uint64_t addr);
+    extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
 
     LONG CALLBACK veh(EXCEPTION_POINTERS* ep) {
         CONTEXT* c = ep->ContextRecord;
@@ -282,6 +283,10 @@ namespace {
         if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2 &&
             ep->ExceptionRecord->ExceptionInformation[0] != 8) {
             uint64_t a = (uint64_t)ep->ExceptionRecord->ExceptionInformation[1];
+            if (a >= 0x1000000000ull &&
+                prosper_try_commit_dmem(
+                    a, 1, ep->ExceptionRecord->ExceptionInformation[0] == 1))
+                return EXCEPTION_CONTINUE_EXECUTION;
             if (a >= 0x1000000000ull && prosper_reserved_range_state(a) == 1) {
                 void* page = (void*)(uintptr_t)(a & ~(uint64_t)0x3fff);
                 if (VirtualAlloc(page, 0x4000, MEM_COMMIT, PAGE_READWRITE))

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -8,6 +8,10 @@
 #include "../src/hle/nid.hpp"
 #ifdef _WIN32
 #include "../src/host/exec_image.hpp"
+#include "../src/host/guest_memory_map.hpp"
+#include "../src/gpu/gpu_execute.hpp"
+#include <windows.h>
+extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
 #endif
 #include <cstdio>
 #include <cstdint>
@@ -36,8 +40,11 @@ int main() {
     auto unmap   = Hle::lookup(nid_hash("sceKernelMunmap"));
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
     auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
+    auto protect = Hle::lookup(nid_hash("sceKernelMprotect"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
-    CHECK(reserve && unmap && alloc && map && release, "memory HLE functions registered");
+    auto query   = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
+    CHECK(reserve && unmap && alloc && map && protect && release && query,
+          "memory HLE functions registered");
     if (fails) return 1;
 
     constexpr uint64_t len = 0x4000;
@@ -93,6 +100,92 @@ int main() {
     if (va3) CHECK(unmap(va3, dlen, 0, 0, 0, 0) == 0, "unmap reused direct-memory view");
     if (hinted) CHECK(unmap(hinted, dlen, 0, 0, 0, 0) == 0, "unmap relocated direct-memory view");
     if (reused_phys) release(reused_phys, dlen, 0, 0, 0, 0);
+
+    // Large zero-hint alignments use a placeholder-backed SEC_RESERVE view. Dead Cells requests
+    // one 3 GiB mapping at 2 MiB alignment; committing that whole range made private memory exceed
+    // 4.5 GiB. Prove that placement is aligned, untouched pages remain sparse, host GPU reads
+    // materialize exactly their range, and a second VA still aliases the same physical bytes.
+    constexpr uint64_t sparse_len = 0x02000000;
+    constexpr uint64_t sparse_align = 0x00200000;
+    constexpr uint64_t sparse_window = kBase + 0x10000000;
+    uint64_t sparse_phys = 0, sparse_va1 = 0, sparse_va2 = 0;
+    CHECK(alloc(sparse_window, sparse_window + sparse_len, sparse_len, sparse_align, 0,
+                (uint64_t)(uintptr_t)&sparse_phys) == 0 && sparse_phys == sparse_window,
+          "allocate a virgin 32 MiB sparse direct-memory range");
+    CHECK(map((uint64_t)(uintptr_t)&sparse_va1, sparse_len, 0x2, 0,
+              sparse_phys, sparse_align) == 0 && sparse_va1 &&
+              (sparse_va1 & (sparse_align - 1)) == 0,
+          "large-alignment direct view uses a 2 MiB-aligned address");
+    MEMORY_BASIC_INFORMATION near_before{}, far_before{};
+    if (sparse_va1) {
+        uint8_t guest_query[0x48]{};
+        CHECK(query(sparse_va1 + 0x01000000, 0,
+                    (uint64_t)(uintptr_t)guest_query, sizeof(guest_query), 0, 0) == 0 &&
+                  *(uint32_t*)(guest_query + 0x20) == 0x10,
+              "guest VirtualQuery reports the sparse direct view as committed");
+        host::GuestReadableRange persistent_range{};
+        CHECK(!host::guest_readable_mapping_containing(
+                  sparse_va1 + 0x4000, sparse_va1 + 0x8000, persistent_range),
+              "sparse view is excluded from cross-submit host-readability reuse");
+        VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x4000), &near_before,
+                     sizeof(near_before));
+        VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x01000000), &far_before,
+                     sizeof(far_before));
+        CHECK(near_before.State == MEM_RESERVE && far_before.State == MEM_RESERVE,
+              "untouched sparse direct pages carry no host commit");
+        CHECK(gpu::guest_readable(sparse_va1 + 0x4000, 0x4000),
+              "GPU guest-read guard materializes an untouched zero page");
+        MEMORY_BASIC_INFORMATION near_after{}, far_after{};
+        VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x4000), &near_after,
+                     sizeof(near_after));
+        VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x01000000), &far_after,
+                     sizeof(far_after));
+        CHECK(near_after.State == MEM_COMMIT && far_after.State == MEM_RESERVE,
+              "host read commits only the requested 16 KiB guest page");
+        CHECK(*(volatile uint32_t*)(uintptr_t)(sparse_va1 + 0x4120) == 0,
+              "virgin sparse direct-memory page reads as zero");
+
+        const uint64_t protected_page = sparse_va1 + 0x01000000;
+        CHECK(protect(protected_page, 0x4000, 0x1, 0, 0, 0) == 0,
+              "mprotect accepts an untouched sparse page");
+        MEMORY_BASIC_INFORMATION protected_before{};
+        VirtualQuery((void*)(uintptr_t)protected_page, &protected_before,
+                     sizeof(protected_before));
+        CHECK(protected_before.State == MEM_RESERVE,
+              "mprotect does not materialize an untouched sparse page");
+        CHECK(!prosper_try_commit_dmem(protected_page, 0x4000, 1),
+              "read-only sparse mapping rejects host write materialization");
+        CHECK(prosper_try_commit_dmem(protected_page, 0x4000, 0),
+              "read-only sparse mapping permits host read materialization");
+        MEMORY_BASIC_INFORMATION protected_after{};
+        VirtualQuery((void*)(uintptr_t)protected_page, &protected_after,
+                     sizeof(protected_after));
+        CHECK(protected_after.State == MEM_COMMIT &&
+                  (protected_after.Protect & 0xff) == PAGE_READONLY,
+              "first touch applies the tracked read-only protection");
+        CHECK(protect(protected_page, 0x4000, 0x2, 0, 0, 0) == 0,
+              "mprotect restores read/write on a materialized sparse page");
+        MEMORY_BASIC_INFORMATION writable_after{};
+        VirtualQuery((void*)(uintptr_t)protected_page, &writable_after,
+                     sizeof(writable_after));
+        CHECK(writable_after.State == MEM_COMMIT &&
+                  (writable_after.Protect & 0xff) == PAGE_READWRITE,
+              "mprotect updates an existing sparse host page");
+    }
+    CHECK(map((uint64_t)(uintptr_t)&sparse_va2, sparse_len, 0x2, 0,
+              sparse_phys, sparse_align) == 0 && sparse_va2 && sparse_va2 != sparse_va1,
+          "map a second sparse view of the same physical range");
+    if (sparse_va1 && sparse_va2) {
+        *(volatile uint64_t*)(uintptr_t)(sparse_va1 + 0x5120) = 0x5A17C0DE6310CAFEull;
+        CHECK(*(volatile uint64_t*)(uintptr_t)(sparse_va2 + 0x5120) ==
+                  0x5A17C0DE6310CAFEull,
+              "sparse views retain physical alias coherence");
+    }
+    if (sparse_va1) CHECK(unmap(sparse_va1, sparse_len, 0, 0, 0, 0) == 0,
+                          "unmap first sparse direct-memory view");
+    if (sparse_va2) CHECK(unmap(sparse_va2, sparse_len, 0, 0, 0, 0) == 0,
+                          "unmap second sparse direct-memory view");
+    if (sparse_phys) release(sparse_phys, sparse_len, 0, 0, 0, 0);
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary

- maps zero-hint Windows direct-memory arenas with alignment above 64 KiB through an explicitly aligned placeholder and the existing shared `SEC_RESERVE` section
- commits 16 KiB host pages on first CPU/GPU/renderer access while preserving guest committed-query semantics and current protection
- keeps physical aliases coherent and excludes not-yet-materialized sparse views from retained host-readability ranges
- documents the measured Dead Cells memory reduction and the remaining working-set/performance limitation

## Root cause

Dead Cells requests one `0xc0000000` (3 GiB) direct-memory arena at 2 MiB alignment. `MapViewOfFileEx` could not choose a base with that alignment, so the Windows HLE rejected the shared view and fell back to an eagerly committed private allocation. That one fallback accounted for exactly 3072 MiB of the process's roughly 4638 MiB private commit.

## Implementation

`VirtualAlloc2(MEM_RESERVE_PLACEHOLDER)` supplies the requested alignment and `MapViewOfFile3(MEM_REPLACE_PLACEHOLDER)` installs the paging-file section without committing it. The APIs are resolved dynamically. The VEH and host GPU guards materialize validated 16 KiB pages on demand. Protection changes update already committed pages and are retained in HLE tracking for future first touches.

## Evidence

| Measurement | Before | This branch |
|---|---:|---:|
| Dead Cells private commit baseline | about 4638 MiB | about 1604 MiB in late loading |
| Exact eager arena charge | 3072 MiB | 0 MiB |

The five-minute run had no sparse commit failure; final-minute private commit changed about +1 MiB. Working set reached 2815 MiB and was still rising by about 190 MiB over the final minute because the loading renderer scans roughly 460 MiB of declared texture ranges per submit. Early scenes presented around 21-23 FPS, while the later 54-draw loading scene presented around 8-10 FPS. These are observational scene rates, not a matched FPS A/B. The route did not reach `PrisonStart`, so this is not progression evidence. The resource-scan/residency problem remains #702 work.

## Validation

- Windows MinGW: 70/70 applicable tests pass; the excluded `module_loads_eboot` fixture expects Messenger import counts while this build is configured with Dead Cells
- Linux/WSL: 102/102 tests pass
- focused Windows test covers 2 MiB placement, guest `VirtualQuery`, untouched far pages, GPU read materialization, zero fill, alias coherence, pre/post-touch protection, retained-range exclusion, and exact whole-view unmap
- Messenger native screenshot smoke: 10 images, seven pixel-distinct, intact title and intro; several 1 MiB-aligned sparse views exercised
- Blasphemous 2 branch/control A/B: both remain at the same known black two-present startup state for more than 90 seconds; clean `origin/master` control has the same CRC and does not implicate this change

Partially addresses #697. Incompatible fixed VA/physical 64 KiB deltas and partial section-view unmap remain open.