### PR TITLE
perf(win): cache committed sparse direct pages

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -179,6 +179,13 @@ The instrumentation does not take clock samples when the variable is unset. This
 to use when the window presents correctly but a title is not interactive; do not infer a GPU
 bottleneck from low FPS without the stage breakdown.
 
+On native Windows, large aligned direct-memory views are demand-paged. Their committed 16 KiB pages
+are retained in a mapping-generation-invalidated bitmap so repeated GPU resource reads do not repeat
+the same `VirtualQuery` calls. Set `PROSPER_NO_SPARSE_DMEM_PAGE_CACHE=1` for a control run when
+investigating this path; it is expected to be substantially slower in resource-heavy scenes. A
+thread-local positive HLE mapping lookup can be disabled separately with
+`PROSPER_NO_SPARSE_DMEM_ACCESS_CACHE=1`.
+
 When the `tables=` bucket is unexpectedly large, set `PROSPER_STAGE_FOLD_PROFILE=1`. It ranks the
 shader address and user-SGPR base pairs responsible for scalar table folding, including average and
 maximum time, decoded instructions, dynamic fetches, SRT uses, guest readability checks, and the

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -576,6 +576,12 @@ edge cases are tracked separately in #697.
    `MapViewOfFile3`, and commit 16 KiB pages on first CPU/GPU access. Guest `VirtualQuery` still reports the
    direct mapping as committed; untouched host pages carry no commit charge. Dead Cells' 3 GiB, 2 MiB-
    aligned arena therefore remains physically aliased without one 3 GiB eager private allocation.
+   A per-view bitmap remembers which 16 KiB host pages have been materialized, so repeated renderer
+   reads do not issue `VirtualQuery` for every resource reference. Any tracked map, unmap, or protection
+   change invalidates the bitmap through the guest-mapping generation; set
+   `PROSPER_NO_SPARSE_DMEM_PAGE_CACHE=1` only for an A/B against the query-per-access path. The same
+   generation guards a thread-local positive HLE mapping lookup; disable it independently with
+   `PROSPER_NO_SPARSE_DMEM_ACCESS_CACHE=1`.
    Exact fixed maps whose virtual and physical 64 KiB deltas differ still use the private fallback, and
    partial unmap needs a section-aware implementation.
 3. **Validate/repair the guest→HLE ABI trampoline for XMM/float args.** Integer args 1-9 are converted

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -192,6 +192,53 @@ spent about 40 ms in resource construction, and presented at roughly 8-10 FPS. I
 repeated scans or materialization of untouched resource tails is follow-up renderer work, not a reason to
 restore the eager 3 GiB private allocation.
 
+## Windows sparse page-state cache (2026-07-15)
+
+Demand paging removed the 3 GiB private commit, but the renderer still called `VirtualQuery` for every
+resource reference on every submit to prove that its sparse direct-memory pages were committed. Dead
+Cells' buffers made the cost clear: a matched 170-draw scene referenced about 680 buffers containing
+only 0.4 MiB in total, yet their guards took about 40 ms per submit. The bytes and copies were not the
+bottleneck; repeated kernel page-state queries were.
+
+Each sparse Windows direct-memory view now retains a compact bitmap of host-committed 16 KiB pages.
+The existing HLE mapping generation invalidates the bitmap after any tracked map, unmap, or protection
+change. A miss still commits the exact guest pages with the current tracked protection and falls back to
+`VirtualQuery` if the commit call fails; a hit skips the OS query. The 3 GiB Dead Cells view needs only
+24 KiB for this metadata. A thread-local positive mapping lookup, guarded by the same generation,
+also avoids rescanning the HLE mapping vector for every resource. Set
+`PROSPER_NO_SPARSE_DMEM_PAGE_CACHE=1` or `PROSPER_NO_SPARSE_DMEM_ACCESS_CACHE=1` to disable the
+corresponding layer for controlled comparison.
+
+Native Windows / RTX 4090, the same RelWithDebInfo binary, fresh processes without pad input,
+115-second runs, and the last 20 matched 168-176-draw title/menu windows:
+
+| Measurement | Page cache disabled | Page cache enabled |
+|---|---:|---:|
+| Frontend callback | 91.70 ms | 46.09 ms |
+| Resource construction | 60.28 ms | 13.12 ms |
+| Texture resource time | 18.12 ms | 9.82 ms |
+| Buffer resource time | 39.53 ms | 1.04 ms |
+| Late app rate | 8.75 FPS | 14.7 FPS |
+
+The enabled run's final ten process samples averaged 1584 MiB private memory and 2034 MiB working set;
+both decreased slightly over that sample rather than growing. `dmem_available` exercises first-touch
+commit, a far untouched page, physical aliases, read-only rejection, and generation invalidation when a
+materialized page becomes writable. The full native Windows suite passed 70 of 71 tests; the remaining
+`module_loads_eboot` failure was the expected fixture mismatch because this profiling build was configured
+against Dead Cells while that test pins The Messenger's import counts.
+
+A separate 160-second presented-screenshot run used the correctly file-prefixed
+`PROSPER_PAD_SCRIPT=@.../reach-first-gameplay-full-render.pad` route. It reached
+`Loading level PrisonStart` and saved 32 normal 3840x2160 screenshots; all 32 had distinct source and
+pixel identities. Inspected samples showed the title, update/menu flow, Prisoners' Quarters loading art,
+and the later loading fade without a blank-frame collapse. In the late 54-draw scene, buffer guards took
+0.40-0.43 ms, resource construction 9.56-12.27 ms, and total submits 45.21-48.06 ms. The run remained
+in the existing level-loading state at 160 seconds, so this is routed output evidence rather than a new
+gameplay progression proof. A matching 165-second app run sustained an 18.95 FPS median over its last
+ten reports. Its last ten process samples averaged 1619 MiB private memory with a +1.1 MiB change;
+working set averaged 2733 MiB and gained 119 MiB as the repeated texture scans continued making shared
+pages resident.
+
 ## Current frame budget
 
 After the above changes, a representative renderer submit remains about 36-38 ms. Approximate costs

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1342,6 +1342,8 @@ namespace {
         void* view_base;
         uint64_t view_size;
         bool sparse;
+        uint64_t page_cache_generation = 0;
+        std::vector<uint64_t> committed_pages;
     };
     std::mutex g_dview_mx;
     std::vector<DmemView> g_dviews;
@@ -1460,7 +1462,15 @@ namespace {
         }
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
-            g_dviews.push_back({ (uint64_t)(uintptr_t)guest, len, phys, view, view_size, sparse });
+            DmemView tracked{
+                (uint64_t)(uintptr_t)guest, len, phys, view, view_size, sparse
+            };
+            if (sparse) {
+                const uint64_t pages = (len + 0x3fff) / 0x4000;
+                tracked.committed_pages.resize((pages + 63) / 64);
+                tracked.page_cache_generation = host::guest_mapping_generation();
+            }
+            g_dviews.push_back(std::move(tracked));
         }
         if (sparse)
             MLOG("map_dmem sparse aligned view va=0x%llx len=0x%llx phys=0x%llx align=0x%llx\n",
@@ -1492,6 +1502,21 @@ namespace {
 
     bool tracked_mapping_access(uint64_t begin, uint64_t end, bool write, int& hp) {
         if (begin >= end) return false;
+        struct AccessCache {
+            uint64_t generation = 0;
+            uint64_t begin = 0;
+            uint64_t end = 0;
+            int prot = 0;
+        };
+        static thread_local AccessCache cache;
+        static const bool cache_disabled = getenv("PROSPER_NO_SPARSE_DMEM_ACCESS_CACHE") != nullptr;
+        const uint64_t generation = host::guest_mapping_generation();
+        if (!cache_disabled && cache.generation == generation &&
+            begin >= cache.begin && end <= cache.end) {
+            if (!(cache.prot & HP_R) || (write && !(cache.prot & HP_W))) return false;
+            hp = cache.prot;
+            return true;
+        }
         std::lock_guard<std::mutex> lk(g_mx);
         const Mapping* best = nullptr;
         for (const Mapping& mapping : g_maps) {
@@ -1502,6 +1527,12 @@ namespace {
         if (!best || end > best->base + best->size || !(best->prot & HP_R) ||
             (write && !(best->prot & HP_W))) return false;
         hp = best->prot;
+        if (!cache_disabled) {
+            cache.generation = host::guest_mapping_generation();
+            cache.begin = best->base;
+            cache.end = best->base + best->size;
+            cache.prot = best->prot;
+        }
         return true;
     }
 
@@ -1512,6 +1543,50 @@ namespace {
         if (!tracked_mapping_access(addr, addr + len, write, hp)) return 0;
         const uint64_t first = addr & ~0x3fffull;
         const uint64_t last = (addr + len - 1) & ~0x3fffull;
+        static const bool page_cache_disabled =
+            getenv("PROSPER_NO_SPARSE_DMEM_PAGE_CACHE") != nullptr;
+        if (!page_cache_disabled) {
+            std::lock_guard<std::mutex> lk(g_dview_mx);
+            DmemView* selected = nullptr;
+            for (DmemView& view : g_dviews) {
+                if (!view.sparse || addr < view.guest_base ||
+                    addr + len > view.guest_base + view.guest_size) continue;
+                selected = &view;
+                break;
+            }
+            if (!selected) return 0;
+            const uint64_t generation = host::guest_mapping_generation();
+            if (selected->page_cache_generation != generation) {
+                std::fill(selected->committed_pages.begin(),
+                          selected->committed_pages.end(), 0);
+                selected->page_cache_generation = generation;
+            }
+            const uint64_t view_first = selected->guest_base & ~0x3fffull;
+            for (uint64_t page = first;; page += 0x4000) {
+                const uint64_t index = (page - view_first) / 0x4000;
+                if (index / 64 >= selected->committed_pages.size()) return 0;
+                const uint64_t mask = 1ull << (index & 63);
+                if (!(selected->committed_pages[index / 64] & mask)) {
+                    if (!VirtualAlloc((void*)(uintptr_t)page, 0x4000, MEM_COMMIT,
+                                      win_page_prot(hp))) {
+                        MEMORY_BASIC_INFORMATION mbi{};
+                        if (!VirtualQuery((const void*)(uintptr_t)page, &mbi, sizeof(mbi)) ||
+                            mbi.State != MEM_COMMIT) return 0;
+                        const DWORD blocked = PAGE_NOACCESS | PAGE_GUARD;
+                        const DWORD readable = PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+                                               PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE |
+                                               PAGE_EXECUTE_WRITECOPY;
+                        const DWORD writable = PAGE_READWRITE | PAGE_WRITECOPY |
+                                               PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+                        if ((mbi.Protect & blocked) || !(mbi.Protect & readable) ||
+                            (write && !(mbi.Protect & writable))) return 0;
+                    }
+                    selected->committed_pages[index / 64] |= mask;
+                }
+                if (page == last) break;
+            }
+            return 1;
+        }
         uint64_t page = first;
         for (;;) {
             MEMORY_BASIC_INFORMATION mbi{};

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -165,6 +165,8 @@ int main() {
               "first touch applies the tracked read-only protection");
         CHECK(protect(protected_page, 0x4000, 0x2, 0, 0, 0) == 0,
               "mprotect restores read/write on a materialized sparse page");
+        CHECK(prosper_try_commit_dmem(protected_page, 0x4000, 1),
+              "mapping-generation invalidation permits a cached sparse-page write");
         MEMORY_BASIC_INFORMATION writable_after{};
         VirtualQuery((void*)(uintptr_t)protected_page, &writable_after,
                      sizeof(writable_after));


### PR DESCRIPTION
## What changed

- retain a compact committed-16-KiB-page bitmap for each sparse Windows direct-memory view
- invalidate page and positive mapping caches through the existing HLE map/unmap/protection generation
- preserve exact-page commit, tracked protection checks, physical aliases, and a `VirtualQuery` fallback
- add an mprotect-generation regression check and document both A/B switches

## Why

After #738 removed Dead Cells' eager 3 GiB private allocation, each renderer resource still repeated Windows page-state queries. A matched 170-draw scene had about 680 buffers totaling only 0.4 MiB, but their guards cost about 40 ms per submit.

## Measured impact

Native Windows, RelWithDebInfo, fresh processes without pad input, 115-second runs, last 20 matched 168-176-draw title/menu windows:

| Measurement | Disabled | Enabled |
|---|---:|---:|
| Frontend callback | 91.70 ms | 46.09 ms |
| Resource construction | 60.28 ms | 13.12 ms |
| Texture resource time | 18.12 ms | 9.82 ms |
| Buffer resource time | 39.53 ms | 1.04 ms |
| Late app rate | 8.75 FPS | 14.7 FPS |

The 3 GiB view uses 24 KiB of bitmap metadata. Late enabled-run memory averaged 1584 MiB private / 2034 MiB working set and was not climbing.

## Routed output validation

A separate 160-second run used the correctly file-prefixed `PROSPER_PAD_SCRIPT=@.../reach-first-gameplay-full-render.pad` route. It reached `Loading level PrisonStart` and saved 32 normal 3840x2160 screenshots; all 32 were source- and pixel-distinct. Inspected frames showed the title, update/menu flow, Prisoners' Quarters loading art, and later loading fade intact. Late 54-draw submits took 45.21-48.06 ms, with buffer guards at 0.40-0.43 ms. A matching app run sustained an 18.95 FPS late median; private memory averaged 1619 MiB with only a +1.1 MiB final-sample change.

The title remained in the existing level-loading state at 160 seconds, so this is visual/regression evidence rather than a gameplay completion claim.

## Validation

- `ctest --test-dir prosper/build-mingw-app -R '^dmem_available$' --output-on-failure`
- full native Windows suite: 70/71 pass; `module_loads_eboot` is the expected fixture mismatch because the profiling build is configured against Dead Cells while that test pins The Messenger import counts
- six-platform core/app GitHub CI passed on the implementation commit; the documentation correction triggers the same matrix again
- controlled page-cache A/B plus the routed 32-frame presented-screenshot run

Tracking: #702, #697