### PR TITLE
perf(frontend): share rendered frame ownership

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -23,7 +23,7 @@ and routed screenshot validation commands.
 ```
 prosper_core   (static lib — ZERO windowing/surface/OS-device deps; headless; CI-tested)
      ▲ links
-     │      audio_set_sink() · pad_set_backend() · present_* readback · run/request_stop()
+     │      audio_set_sink() · pad_set_backend() · present frame lease · run/request_stop()
 frontends/prosper-app   (new binary — owns ALL OS integration, via SDL3)
 ```
 
@@ -59,17 +59,21 @@ void pad_set_backend(PadBackend*);   // nullptr restores the neutral (no-device)
 Frontend supplies an **SDL3 `GameController` backend**, mapping SDL buttons/axes → `HostPadState`.
 The pad header already documents frontends installing this from the harness.
 
-### 3. Video — the present readback (exists, `src/gpu/videoout_present.hpp`)
+### 3. Video — rendered-frame ownership (exists, `src/gpu/videoout_present.hpp`)
 ```cpp
-bool     present_has_frame();
-uint32_t present_width();  uint32_t present_height();
-uint64_t present_count();                 // total flips presented (advances on guest flip)
-size_t   present_readback(void* dst, size_t dst_cap);   // copy the presented frame's pixels (w*h*4)
+struct PresentFrameLease {
+    uint64_t frame_seq;
+    uint32_t width, height;
+    std::shared_ptr<const std::vector<uint8_t>> rgba;
+};
+bool present_acquire_rendered_frame(PresentFrameLease& out);
+size_t present_readback(void* dst, size_t dst_cap); // compatibility/capture copy
 ```
-On each guest flip the renderer writes the finished frame into the scanout buffer; `present_readback`
-hands out those **CPU pixels**. The frontend polls `present_count()` for a new frame and blits the
-readback into its swapchain. This is the whole video boundary — the frontend is a pure *consumer* of
-finished frames.
+The renderer's selected scanout, the present layer, and `prosper-app` share one immutable CPU-pixel
+allocation. Acquiring a lease does not copy the image, and its storage stays valid if the renderer
+publishes a newer frame while the app uploads the old one. Screenshot, capture, replay, and legacy
+readback APIs deliberately retain copying semantics. The frontend remains a pure *consumer* of finished
+frames and polls `present_count()` for guest flip pacing.
 
 ### 4. Lifecycle — stop request exists; guest consumption remains
 The frontend has the minimal, headless-agnostic control:
@@ -85,17 +89,19 @@ guest caused a reproducible Windows access violation when static teardown raced 
 The remaining lifecycle work is a guest flip-boundary check followed by a real join and normal
 teardown (#352).
 
-## The Vulkan-context decision: two contexts, frames cross as CPU pixels
+## The Vulkan-context decision: two contexts, one shared CPU frame
 
 **The frontend owns its own Vulkan context (instance + device + swapchain on the window surface).
-The core keeps its existing headless render device. Frames cross the boundary as CPU pixels via
-`present_readback`.** Rationale:
+The core keeps its existing headless render device. Frames cross the boundary through immutable shared
+CPU storage acquired with `present_acquire_rendered_frame`.** Rationale:
 
 - The core's render device stays **surface-free and unchanged** — no swapchain dependency leaks into
   the renderer, no `#ifdef`, headless + CI identical.
 - The seam already emits CPU pixels, so the frontend is a pure consumer — the cleanest boundary, and
   the same seam becomes a shared-memory frame ring if the two are ever split into separate processes.
-- Cost = one readback + one upload per frame. The Messenger is 2D at 1080p (~8 MB/frame), but native
+- Cost = the renderer's required GPU readback plus one frontend upload per frame. There are no
+  renderer-cache-to-return, return-to-present, or present-to-app copies. The Messenger is 2D at 1080p
+  (~8 MB/frame), but native
   Windows measurements showed that memory-type selection matters: uncached host-visible readback cost
   roughly 570 ms per frame on an RTX 4090, versus about 1.8 ms with `HOST_CACHED` memory.
 
@@ -115,8 +121,8 @@ init:  SDL_Init(VIDEO|AUDIO|GAMECONTROLLER); create window;
 
 frame: SDL_PollEvent → on SDL_QUIT / window-close: prosper_request_stop(); break;
        if present_count() advanced since last shown:
-           n = present_readback(staging_mapped, cap);
-           upload staging → VkImage; blit/scale VkImage → acquired swapchain image; vkQueuePresentKHR;
+           lease = present_acquire_rendered_frame();
+           upload lease.rgba → VkImage; blit/scale VkImage → acquired swapchain image; vkQueuePresentKHR;
        else: small sleep / wait on a frame condvar to avoid spinning.
 
 quit target: prosper_request_stop(); join guest thread; destroy swapchain/device/window; SDL_Quit().
@@ -128,8 +134,9 @@ Handle swapchain resize (`present_width/height` change or window resize → recr
 ## Threading
 
 - **Guest run-loop thread**: drives the guest (as `boot_trace` does), renders into scanout on flip.
-- **Main/UI thread**: SDL event pump + swapchain present. It only *reads* via `present_readback`
-  (already mutex-guarded: renderer writes, present reads) — no new shared state.
+- **Main/UI thread**: SDL event pump + swapchain present. It holds an immutable shared frame lease
+  while copying to its Vulkan staging allocation; publication only swaps shared ownership under the
+  present mutex.
 - Audio/pad callbacks run on whatever thread the core calls them from; the SDL sink/backend must be
   thread-safe (the pad header already requires it).
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -239,25 +239,62 @@ ten reports. Its last ten process samples averaged 1619 MiB private memory with 
 working set averaged 2733 MiB and gained 119 MiB as the repeated texture scans continued making shared
 pages resident.
 
+## Shared rendered-frame publication (2026-07-15)
+
+The selected render target previously crossed three additional full-frame CPU copies after Vulkan
+readback: persistent RTT storage to the live-renderer return vector, that vector to the present layer,
+and `present_readback` to the app's scratch vector. At 3840x2160 RGBA8 each copy moved about 31.6 MiB.
+
+`RenderedFrame` now carries immutable shared ownership from the live renderer through the executor and
+present layer. `prosper-app` acquires a lifetime-safe `PresentFrameLease` and uploads directly from that
+storage. Compatibility readback, screenshots, captures, and replay still copy by design. Unit coverage
+asserts pointer identity across renderer-to-present publication and proves a lease survives replacement
+and `present_reset()`.
+
+On native Windows / RTX 4090, the fresh-save full-render Dead Cells route improved the matched 54-draw
+loading scene as follows:
+
+| Measurement | Before | Shared publication |
+|---|---:|---:|
+| Frontend callback | 36-38 ms | 31-34 ms |
+| Frontend output copy | 4.3-4.4 ms | 0.0 ms |
+| Core submit | 46-49 ms | 40-42 ms |
+| Core publication | 1.7 ms | 0.0 ms |
+| App present rate | about 19 FPS | about 21-22 FPS |
+
+The speedup was sufficient for the same 165-second route to finish Dead Cells' 71.6-second
+`PrisonStart` parse and enter the next loading workload instead of remaining in the 54-draw loop. That
+post-parse workload uses about 344 draws, eight dispatches, and four graphics spans per submit. It runs at about
+4.3 FPS, with about 202 ms core submit time: 32 ms realization, 20 ms table work, and 170 ms ordered
+backend execution. The frontend portion spends about 51 ms building resources and 89 ms in its Vulkan
+backend. Full-resolution screenshots at 150 seconds still show the Prisoners' Quarters loading art, so
+this is a later loading phase rather than confirmed gameplay. It is now the representative optimization target.
+
+Private memory rose once from about 1.59 GiB to about 1.90 GiB when that workload arrived, then fluctuated
+in a narrow band during the final 20 seconds. Working set settled around 3.82 GiB. Vulkan graphics and
+compute pools remained bounded at 355 MiB and 47 MiB. The workload nevertheless invalidates about two
+persistent textures per submit window and performs repeated uploads, so resource versioning and residency
+are the next memory/performance investigation rather than further publication lookup tuning.
+
 ## Current frame budget
 
-After the above changes, a representative renderer submit remains about 36-38 ms. Approximate costs
-per frame are:
+After shared publication, the Dead Cells post-parse loading workload is the most useful current budget:
 
 | Area | Approximate cost |
 |---|---:|
-| Four graphics GPU waits | 10-11 ms |
-| Four graphics readbacks | 4-5 ms |
-| Graphics pipeline creation/setup | about 3 ms |
-| Backend resource/descriptor setup | about 2 ms |
-| Graphics record/upload | about 2 ms |
-| Four compute dispatches | about 3 ms |
-| Remaining realization, publication, and overhead | remainder |
+| Draw realization | 32 ms |
+| Scalar table work (included above) | 20 ms |
+| Frontend resource construction | 51 ms |
+| Frontend Vulkan work | 89 ms |
+| Ordered backend total (graphics + compute) | 170 ms |
+| Frame publication | approximately 0 ms |
+| Whole submit | 201-203 ms |
 
 These numbers explain why another small CPU lookup cache is not a credible path to 60 FPS. The
 renderer currently creates transient Vulkan objects, waits, and reads back at each ordered backend
-boundary. A durable improvement needs persistent resources and coordinated graphics/compute
-ownership, then direct presentation where screenshots/captures do not require CPU pixels.
+boundary. A durable improvement needs persistent resources and coordinated graphics/compute ownership.
+Shared CPU publication is complete; direct GPU-image presentation remains a later step because the app
+and headless renderer still own separate Vulkan devices.
 
 ## Capture correction and dependency evidence
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1,19 +1,19 @@
 // prosper-app (P0a) — the OS-integration frontend: an SDL3 window + Vulkan swapchain that presents
-// the frame prosper's renderer hands to the present layer (present_readback). See
+// the frame prosper's renderer hands to the present layer. See
 // docs/FRONTEND_APP.md and issue #164.
 //
 // P0a scope (this file): the whole present half, decoupled from the guest boot. It pulls finished
-// frames from prosper_core's present layer (present_readback) and blits them to a real swapchain,
+// frames from prosper_core's present layer and blits them to a real swapchain,
 // and handles SDL_QUIT/Esc via the shared stop request. run_entry does not consume that request yet,
 // so a booted guest uses direct process exit after the present loop (issue #352). To verify the
 // pipeline without a game dump the app can FEED the present layer a synthetic animated pattern
-// (--test-pattern): frame -> present_write_frame -> present_readback -> swapchain, exactly the path
+// (--test-pattern): frame -> present_write_frame -> shared frame lease -> swapchain, exactly the path
 // a real guest frame takes. P0b wires the actual guest boot in front of this (the same present
 // path, no changes here).
 //
 // Two Vulkan contexts by design (docs/FRONTEND_APP.md): the core keeps its headless render device;
-// THIS is a separate presentation device, and frames cross as CPU pixels via present_readback.
-#include "gpu/videoout_present.hpp"   // present_readback / present_write_frame / present_width/height/count
+// THIS is a separate presentation device, and frames cross as shared immutable CPU pixels.
+#include "gpu/videoout_present.hpp"   // present_acquire_rendered_frame / present_write_frame
 #include "host/lifecycle.hpp"          // prosper_request_stop / prosper_stop_requested
 #include "host/boot_program.hpp"       // boot_program (shared guest-boot path, also used by boot_trace)
 #include "host/exec_image.hpp"         // run_entry
@@ -469,15 +469,13 @@ int main(int argc, char** argv) {
         // In normal use a frame is "new" when the guest flips (present_count advances); test-pattern
         // has no flips, so treat every iteration as new.
         bool newFrame = testPattern || (gpu::present_count() != lastCount);
-        if (gpu::present_has_frame() && newFrame) {
-            uint32_t w = testPattern ? kPatW : gpu::present_width();
-            uint32_t h = testPattern ? kPatH : gpu::present_height();
+        gpu::PresentFrameLease frame;
+        if (newFrame && gpu::present_acquire_rendered_frame(frame)) {
+            uint32_t w = frame.width;
+            uint32_t h = frame.height;
             if (w == 0 || h == 0) { std::this_thread::sleep_for(std::chrono::milliseconds(2)); continue; }
-            static std::vector<uint8_t> buf;
-            buf.resize((size_t)w * h * 4);
-            size_t n = gpu::present_readback(buf.data(), buf.size());
-            if (n == buf.size()) {
-                if (!present_frame(vk, buf.data(), w, h)) {
+            if (frame.rgba && frame.rgba->size() == (size_t)w * h * 4) {
+                if (!present_frame(vk, frame.rgba->data(), w, h)) {
                     // out-of-date / resize: recreate the swapchain and retry next iteration.
                     vkDeviceWaitIdle(vk.device);
                     vkDestroySwapchainKHR(vk.device, vk.swapchain, nullptr); vk.swapchain = VK_NULL_HANDLE;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
+#include <memory>
 #include <vector>
 #include <set>
 #include <unordered_map>
@@ -44,7 +45,10 @@ namespace prosper::frontend {
 // this the composite samples zeros and the frame is black. We cache each submit's rendered pixels under
 // its render-target base and inject them when a subsequent draw samples a texture at a matching base.
 namespace {
-struct RttSurf { std::vector<uint8_t> rgba; uint32_t w = 0, h = 0; };
+struct RttSurf {
+    std::shared_ptr<const std::vector<uint8_t>> rgba;
+    uint32_t w = 0, h = 0;
+};
 
 // Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
 // to one renderer callback: graphics spans are split at compute operations, so guest texture bytes
@@ -128,16 +132,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
         getenv("PROSPER_GPU_REPLAY_EXPORT_RTT")) {
         prosper::gpu::set_gpu_capture_rtt_seed_reader([](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {
             auto it = g_rtt.find(addr); if (it == g_rtt.end()) return false;
+            if (!it->second.rgba) return false;
             seed.guest_addr = addr; seed.width = it->second.w; seed.height = it->second.h;
-            seed.rgba = it->second.rgba; return true;
+            seed.rgba = *it->second.rgba; return true;
         });
         prosper::gpu::set_gpu_capture_rtt_seed_snapshot_reader(
             [](std::vector<prosper::gpu::GpuCaptureRttSeed>& seeds, std::string&) {
                 seeds.reserve(g_rtt.size());
                 for (const auto& [addr, surface] : g_rtt) {
+                    if (!surface.rgba) continue;
                     prosper::gpu::GpuCaptureRttSeed seed;
                     seed.guest_addr = addr; seed.width = surface.w; seed.height = surface.h;
-                    seed.rgba = surface.rgba; seeds.push_back(std::move(seed));
+                    seed.rgba = *surface.rgba; seeds.push_back(std::move(seed));
                 }
                 return true;
             });
@@ -159,7 +165,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 error = "invalid temporal RTT seed"; return false;
             }
             RttSurf& surface = g_rtt[seed.guest_addr];
-            surface.w = seed.width; surface.h = seed.height; surface.rgba = seed.rgba;
+            surface.w = seed.width; surface.h = seed.height;
+            surface.rgba = std::make_shared<const std::vector<uint8_t>>(seed.rgba);
             return true;
         });
     if (getenv("PROSPER_GPU_REPLAY_DS_SEEDS"))
@@ -173,7 +180,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                   getenv("PROSPER_RTT_SINGLE_TARGET") == nullptr;
     static const bool rtt_on = getenv("PROSPER_RTT") != nullptr || pertarget;
     prosper::gpu::set_submit_renderer(
-        [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
+        [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items,
+                               uint32_t w, uint32_t h) -> prosper::gpu::RenderedFrame {
             using RC = prosper::gpu::ResourceClass;
             const prosper::gpu::LiveRenderPhase phase = prosper::gpu::live_render_phase();
             // PROSPER_RENDER_FIRST=<N>: skip the slow (~400x) Vulkan render for the first N GPU submits, so
@@ -378,7 +386,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
                         const bool has_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() && live_rtt->second.w &&
-                            live_rtt->second.h && !live_rtt->second.rgba.empty();
+                            live_rtt->second.h && live_rtt->second.rgba &&
+                            !live_rtt->second.rgba->empty();
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
@@ -512,17 +521,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
                         if (rtt_on && !is_volume) { auto rit = g_rtt.find(r.gpu_addr);
-                            if (rit != g_rtt.end() && rit->second.w && rit->second.h && !rit->second.rgba.empty()) {
+                            if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&
+                                !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
                                 const size_t expected = static_cast<size_t>(tw) * th * 4;
-                                if (s.w == tw && s.h == th && s.rgba.size() == expected) {
-                                    std::memcpy(texture_pixels.data(), s.rgba.data(), expected);
+                                if (s.w == tw && s.h == th && s.rgba->size() == expected) {
+                                    std::memcpy(texture_pixels.data(), s.rgba->data(), expected);
                                 } else {
                                     std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
                                     for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
                                         uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
                                         size_t si = ((size_t)sy * s.w + sx) * 4;
-                                        if (si + 4 <= s.rgba.size()) std::memcpy(&texture_pixels[((size_t)y * tw + x) * 4], &s.rgba[si], 4);
+                                        if (si + 4 <= s.rgba->size())
+                                            std::memcpy(&texture_pixels[((size_t)y * tw + x) * 4],
+                                                        &(*s.rgba)[si], 4);
                                     }
                                 }
                                 rtt_hit = true;
@@ -1182,8 +1194,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             auto clear_for = [](const std::vector<const prosper::gpu::DrawItem*>& g) -> const float* {
                 return g.empty() ? nullptr : g.front()->ps.clear_color;
             };
-            std::vector<uint8_t> px;
-            const std::vector<uint8_t>* selected_pixels = nullptr;
+            std::shared_ptr<const std::vector<uint8_t>> selected_pixels;
             if (pertarget) {
                 // PER-TARGET RTT: a real frame is a sequence of passes, each rendering into a specific
                 // color target (CB_COLOR0_BASE), and a final composite pass SAMPLES the earlier targets.
@@ -1216,9 +1227,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fprintf(stderr, " [%d]=0x%llx", i, (unsigned long long)prosper_vo_buffer_addr(i));
                     fprintf(stderr, "\n");
                 }
-                const std::vector<uint8_t>* px_front = nullptr;
-                const std::vector<uint8_t>* px_vo = nullptr;
-                const std::vector<uint8_t>* px_last = nullptr;
+                std::shared_ptr<const std::vector<uint8_t>> px_front;
+                std::shared_ptr<const std::vector<uint8_t>> px_vo;
+                std::shared_ptr<const std::vector<uint8_t>> px_last;
                 // Render-target persistence (default on; PROSPER_RTT_NOSEED reverts to per-pass blue
                 // clear): seed each group's framebuffer with the pixels last rendered into that SAME
                 // target VA, so a pass that draws into an already-written target (UE4's UI pass onto
@@ -1323,7 +1334,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const uint8_t* seed = nullptr;
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
                         if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
-                            sit->second.rgba.size() == (size_t)gw * gh * 4) seed = sit->second.rgba.data(); }
+                            sit->second.rgba && sit->second.rgba->size() == (size_t)gw * gh * 4)
+                            seed = sit->second.rgba->data(); }
                     const auto build_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     auto backend_draws = build_bds(render_pass);
@@ -1339,13 +1351,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         pending_timing.backend_ms +=
                             std::chrono::duration<double, std::milli>(backend_done - build_done).count();
                     }
-                    const std::vector<uint8_t>* pass_pixels = &gpx;
-                    if (base && !gpx.empty()) {
+                    auto pass_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(gpx));
+                    if (base && !pass_pixels->empty()) {
                         RttSurf& surface = g_rtt[base];
-                        surface.rgba = std::move(gpx);
+                        surface.rgba = pass_pixels;
                         surface.w = gw;
                         surface.h = gh;
-                        pass_pixels = &surface.rgba;
                     }
                     const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
                     if (native_w == resource_hash_w && native_h == resource_hash_h &&
@@ -1484,7 +1495,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 auto backend_draws = build_bds(all);
                 const auto build_done = timing_enabled
                     ? RenderClock::now() : RenderClock::time_point{};
-                px = prosper::test::render_draws_rgba(backend_draws, w, h, nullptr, clear_for(all), true);
+                auto rendered = prosper::test::render_draws_rgba(
+                    backend_draws, w, h, nullptr, clear_for(all), true);
                 const auto backend_done = timing_enabled
                     ? RenderClock::now() : RenderClock::time_point{};
                 if (timing_enabled) {
@@ -1495,11 +1507,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
                 // composite pass that samples that address gets the scene we drew (not empty guest memory).
-                if (rtt_on && !px.empty()) {
+                selected_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(rendered));
+                if (rtt_on && !selected_pixels->empty()) {
                     uint64_t tgt = 0;
                     for (const auto& it : items) if (it.color0_base) { tgt = it.color0_base; break; }
-                    if (tgt) { RttSurf& s = g_rtt[tgt]; s.rgba = px; s.w = w; s.h = h; }
-                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0; for(size_t i=0;i<px.size();i++) nz+=(px[i]!=0);
+                    if (tgt) { RttSurf& s = g_rtt[tgt]; s.rgba = selected_pixels; s.w = w; s.h = h; }
+                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0;
+                        for (uint8_t byte : *selected_pixels) nz += byte != 0;
                         fprintf(stderr, "[rtt] store target=0x%llx (%zu items, color0s:", (unsigned long long)tgt, items.size());
                         for (const auto& it : items) fprintf(stderr, " 0x%llx", (unsigned long long)it.color0_base);
                         fprintf(stderr, ") px_nonzero=%zu cache_size=%zu\n", nz, g_rtt.size()); }
@@ -1513,7 +1527,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 auto cached_scanout = [&](uint64_t addr) -> const RttSurf* {
                     auto it = g_rtt.find(addr);
                     if (it == g_rtt.end() || it->second.w != w || it->second.h != h ||
-                        it->second.rgba.size() != (size_t)w * h * 4) return nullptr;
+                        !it->second.rgba || it->second.rgba->size() != (size_t)w * h * 4)
+                        return nullptr;
                     return &it->second;
                 };
                 const int front = prosper::gpu::present_front_index();
@@ -1523,15 +1538,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     for (int i = 0; i < prosper_vo_buffer_count(); ++i)
                         if ((scanout = cached_scanout(prosper_vo_buffer_addr(i)))) break;
                 }
-                if (scanout) selected_pixels = &scanout->rgba;
-            }
-            if (phase.final_span && selected_pixels) {
-                const auto copy_start = timing_enabled
-                    ? RenderClock::now() : RenderClock::time_point{};
-                px.assign(selected_pixels->begin(), selected_pixels->end());
-                if (timing_enabled)
-                    pending_timing.output_copy_ms += std::chrono::duration<double, std::milli>(
-                        RenderClock::now() - copy_start).count();
+                if (scanout) selected_pixels = scanout->rgba;
             }
             if (!phase.final_span) {
                 if (timing_enabled) {
@@ -1539,8 +1546,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     pending_timing.total_ms += std::chrono::duration<double, std::milli>(
                         RenderClock::now() - callback_timing_start).count();
                 }
-                return px;
+                return {};
             }
+            static const std::vector<uint8_t> empty_pixels;
+            const std::vector<uint8_t>& px = selected_pixels ? *selected_pixels : empty_pixels;
             int n = frame_no++;
             // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
             // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.
@@ -1636,7 +1645,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     window = {};
                 }
             }
-            return px;
+            return prosper::gpu::RenderedFrame(std::move(selected_pixels));
         });
     fprintf(stderr, "[render] live Vulkan submit renderer registered (dump=%d, frames -> %s)\n",
             (int)dump_bmps, frame_dir.c_str());

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -893,11 +893,29 @@ inline std::vector<uint8_t> execute_gpustate(const GpuState& st, const RenderFn&
 // attachments. Registered by whoever owns a persistent Vulkan device — the runtime binary at startup, or a
 // test — so prosper_core itself stays Vulkan-free (this just stores a std::function). Same DrawItem-list
 // shape as RenderFn, plus (w,h).
-using LiveRenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawItem>& items,
-                                                        uint32_t width, uint32_t height)>;
+struct RenderedFrame {
+    std::shared_ptr<const std::vector<uint8_t>> storage;
+
+    RenderedFrame() = default;
+    RenderedFrame(std::vector<uint8_t> pixels)
+        : storage(std::make_shared<const std::vector<uint8_t>>(std::move(pixels))) {}
+    explicit RenderedFrame(std::shared_ptr<const std::vector<uint8_t>> pixels)
+        : storage(std::move(pixels)) {}
+
+    bool empty() const { return !storage || storage->empty(); }
+    size_t size() const { return storage ? storage->size() : 0; }
+    const uint8_t* data() const { return storage ? storage->data() : nullptr; }
+    const std::vector<uint8_t>& bytes() const {
+        static const std::vector<uint8_t> empty;
+        return storage ? *storage : empty;
+    }
+};
+
+using LiveRenderFn = std::function<RenderedFrame(const std::vector<DrawItem>& items,
+                                                  uint32_t width, uint32_t height)>;
 
 struct OrderedSubmitResult {
-    std::vector<uint8_t> pixels;
+    RenderedFrame frame;
     size_t render_spans = 0;
     bool compute_executed = false;
 };

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2252,9 +2252,9 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
         if (span.empty() || !render) return;
         LiveRenderPhase saved = g_live_phase;
         g_live_phase = {result.render_spans == 0, result.render_spans + 1 == total_spans};
-        std::vector<uint8_t> rendered = render(span, width, height);
+        RenderedFrame rendered = render(span, width, height);
         g_live_phase = saved;
-        if (!rendered.empty()) result.pixels = std::move(rendered);
+        if (!rendered.empty()) result.frame = std::move(rendered);
         span.clear();
         ++result.render_spans;
     };
@@ -2290,7 +2290,9 @@ void notify_guest_gpu_write(uint64_t addr, uint64_t size) {
 LiveRenderPhase live_render_phase()       { return g_live_phase; }
 std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
                                          uint32_t width, uint32_t height) {
-    return g_live ? g_live(items, width, height) : std::vector<uint8_t>{};
+    if (!g_live) return {};
+    RenderedFrame frame = g_live(items, width, height);
+    return frame.storage ? *frame.storage : std::vector<uint8_t>{};
 }
 bool execute_compute_items(const std::vector<ComputeItem>& items) {
     return g_compute && !items.empty() && g_compute(items);
@@ -2339,7 +2341,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     OrderedSubmitResult result = execute_ordered_items(
         operations, draws, computes, g_live, g_compute, width, height);
     const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    std::vector<uint8_t>& px = result.pixels;
+    const std::vector<uint8_t>& px = result.frame.bytes();
 
     if (pending_capture) {
         std::string error;
@@ -2347,7 +2349,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
             std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
     }
     const bool presented = px.size() == static_cast<size_t>(width) * height * 4;
-    if (presented) present_write_frame(px.data(), width, height);
+    if (presented) present_write_frame(result.frame.storage, width, height);
     if (timing_enabled) {
         const auto timing_done = TimingClock::now();
         auto ms = [](auto begin, auto end) {
@@ -2446,25 +2448,22 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width  / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
-    std::vector<uint8_t> px = execute_gpustate(st,
-        [&](const std::vector<DrawItem>& items) {
-            std::vector<SubmitOperation> operations;
-            operations.reserve(items.size());
-            for (const auto& item : items)
-                operations.push_back({SubmitOperationKind::Draw,
-                                      static_cast<size_t>(item.draw_index), item.command_order});
-            auto pending = begin_requested_gpu_capture(items, {}, operations, width, height);
-            std::vector<uint8_t> rendered = g_live(items, width, height);
-            if (pending) {
-                std::string error;
-                if (!finish_requested_gpu_capture(std::move(pending), rendered, error))
-                    std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
-            }
-            return rendered;
-        },
-        0x10000, sx, sy);
-    if (px.size() != static_cast<size_t>(width) * height * 4) return false;   // recompile/render failed
-    present_write_frame(px.data(), width, height);
+    std::vector<DrawItem> items = realize_gpustate_draws(st, 0x10000, sx, sy);
+    if (items.empty()) return false;
+    std::vector<SubmitOperation> operations;
+    operations.reserve(items.size());
+    for (const auto& item : items)
+        operations.push_back({SubmitOperationKind::Draw,
+                              static_cast<size_t>(item.draw_index), item.command_order});
+    auto pending = begin_requested_gpu_capture(items, {}, operations, width, height);
+    RenderedFrame rendered = g_live(items, width, height);
+    if (pending) {
+        std::string error;
+        if (!finish_requested_gpu_capture(std::move(pending), rendered.bytes(), error))
+            std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
+    }
+    if (rendered.size() != static_cast<size_t>(width) * height * 4) return false;
+    present_write_frame(rendered.storage, width, height);
     return true;
 }
 

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -25,7 +25,7 @@ std::atomic<uint64_t> g_frame_seq{0};   // # of rendered frames handed in via pr
 // The rendered frame the back-half hands us (the "scanout" image). Guarded by a mutex because the
 // renderer thread writes it while guest threads / tests read it via present_readback.
 std::mutex           g_frame_mx;
-std::vector<uint8_t> g_frame;      // w*h*4 bytes when a frame is present
+std::shared_ptr<const std::vector<uint8_t>> g_frame; // w*h*4 bytes when a frame is present
 uint32_t             g_frame_w = 0, g_frame_h = 0;
 std::atomic<bool>    g_have_frame{false};
 }
@@ -33,9 +33,16 @@ std::atomic<bool>    g_have_frame{false};
 void present_write_frame(const void* pixels, uint32_t w, uint32_t h) {
     if (!pixels || !w || !h) return;
     size_t bytes = (size_t)w * h * 4;
+    auto owned = std::make_shared<std::vector<uint8_t>>(bytes);
+    std::memcpy(owned->data(), pixels, bytes);
+    present_write_frame(std::move(owned), w, h);
+}
+
+void present_write_frame(std::shared_ptr<const std::vector<uint8_t>> pixels,
+                         uint32_t w, uint32_t h) {
+    if (!pixels || !w || !h || pixels->size() != (size_t)w * h * 4) return;
     std::lock_guard<std::mutex> lk(g_frame_mx);
-    g_frame.resize(bytes);
-    std::memcpy(g_frame.data(), pixels, bytes);
+    g_frame = std::move(pixels);
     g_frame_w = w; g_frame_h = h;
     g_have_frame.store(true, std::memory_order_release);
     g_frame_seq.fetch_add(1, std::memory_order_relaxed);
@@ -85,9 +92,9 @@ size_t present_readback(void* dst, size_t dst_cap) {
     // Prefer the real rendered frame from the back-half, if one has been handed in.
     if (g_have_frame.load(std::memory_order_acquire)) {
         std::lock_guard<std::mutex> lk(g_frame_mx);
-        if (!g_frame.empty() && dst_cap >= g_frame.size()) {
-            std::memcpy(dst, g_frame.data(), g_frame.size());
-            return g_frame.size();
+        if (g_frame && !g_frame->empty() && dst_cap >= g_frame->size()) {
+            std::memcpy(dst, g_frame->data(), g_frame->size());
+            return g_frame->size();
         }
         return 0;
     }
@@ -103,13 +110,25 @@ size_t present_readback(void* dst, size_t dst_cap) {
     return bytes;
 }
 
+bool present_acquire_rendered_frame(PresentFrameLease& out) {
+    out = {};
+    if (!g_have_frame.load(std::memory_order_acquire)) return false;
+    std::lock_guard<std::mutex> lk(g_frame_mx);
+    if (!g_frame || g_frame->empty() || !g_frame_w || !g_frame_h) return false;
+    out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
+    out.width = g_frame_w;
+    out.height = g_frame_h;
+    out.rgba = g_frame;
+    return true;
+}
+
 bool present_snapshot(PresentSnapshot& out) {
     out = {};
     // frame_seq is incremented while holding this mutex, after the pixels and dimensions are
     // installed, so the copied bytes and identity describe the same renderer publication.
     if (g_have_frame.load(std::memory_order_acquire)) {
         std::lock_guard<std::mutex> lk(g_frame_mx);
-        if (g_frame.empty() || !g_frame_w || !g_frame_h) return false;
+        if (!g_frame || g_frame->empty() || !g_frame_w || !g_frame_h) return false;
         out.source = PresentSource::Rendered;
         out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
         out.source_seq = out.frame_seq;
@@ -117,7 +136,7 @@ bool present_snapshot(PresentSnapshot& out) {
         out.front_index = g_front.load(std::memory_order_relaxed);
         out.width = g_frame_w;
         out.height = g_frame_h;
-        out.rgba = g_frame;
+        out.rgba = *g_frame;
         return true;
     }
 
@@ -143,7 +162,7 @@ void present_reset() {
     g_front.store(-1, std::memory_order_relaxed);
     g_present_count.store(0, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(g_frame_mx);
-    g_frame.clear(); g_frame_w = g_frame_h = 0;
+    g_frame.reset(); g_frame_w = g_frame_h = 0;
     g_frame_seq.store(0, std::memory_order_relaxed);   // #399: reset the rendered-frame counter too
     g_have_frame.store(false, std::memory_order_release);
 }

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -13,6 +13,7 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 namespace prosper::gpu {
@@ -33,6 +34,15 @@ struct PresentSnapshot {
     std::vector<uint8_t> rgba;
 };
 
+// Lifetime-safe access to the current rendered frame without copying its pixels. The immutable
+// storage remains valid after a newer frame is published or present_reset() is called.
+struct PresentFrameLease {
+    uint64_t frame_seq = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    std::shared_ptr<const std::vector<uint8_t>> rgba;
+};
+
 // Present the display buffer `buffer_index` (from sceVideoOutSubmitFlip). Records it as the front
 // buffer and bumps the present counter. `flip_arg` is the guest's flip label (echoed in flip status).
 void present_flip(int buffer_index, int64_t flip_arg);
@@ -42,6 +52,8 @@ void present_flip(int buffer_index, int64_t flip_arg);
 // pixels — instead of the raw guest display buffer, closing the loop shader → render →
 // present_write_frame → present_readback. Thread-safe (renderer writes, present reads).
 void present_write_frame(const void* pixels, uint32_t w, uint32_t h);
+void present_write_frame(std::shared_ptr<const std::vector<uint8_t>> pixels,
+                         uint32_t w, uint32_t h);
 
 // True once a rendered frame has been handed in (readback returns rendered pixels, not the guest buffer).
 bool present_has_frame();
@@ -60,6 +72,10 @@ uint32_t present_frame_height();
 // Copy the presented frame's pixels (width*height, 4 bytes/pixel) from the front buffer's guest
 // memory into `dst`. Returns bytes written, or 0 if there is no surface / no flip yet / dst too small.
 size_t present_readback(void* dst, size_t dst_cap);
+
+// Acquire immutable shared ownership of the latest rendered frame. Unlike present_readback(), this
+// does not copy pixels and never falls back to raw guest scanout.
+bool present_acquire_rendered_frame(PresentFrameLease& out);
 
 // Copy the best available frame and its identity as one observation. Prefers a rendered frame and
 // falls back to the raw guest scanout. Returns false before either source is available.

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -9,6 +9,7 @@
 #include "render_runner.h"
 #include <cstdio>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -234,9 +235,12 @@ int main() {
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");
-    set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t w, uint32_t h) -> std::vector<uint8_t> {
+    std::shared_ptr<const std::vector<uint8_t>> live_storage;
+    set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t w, uint32_t h) -> RenderedFrame {
         if (items.empty()) return {};
-        return prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, w, h, &items[0].ps);
+        live_storage = std::make_shared<const std::vector<uint8_t>>(
+            prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, w, h, &items[0].ps));
+        return RenderedFrame(live_storage);
     });
     CHECK(have_submit_renderer(), "live renderer registered");
     prosper::gpu::present_reset();
@@ -245,6 +249,10 @@ int main() {
     std::vector<uint8_t> submit_scan((size_t)W * H * 4, 0);
     prosper::gpu::present_readback(submit_scan.data(), submit_scan.size());
     CHECK(submit_scan == px, "live-submit path presents the same GREEN frame as the direct executor");
+    prosper::gpu::PresentFrameLease submit_lease;
+    CHECK(prosper::gpu::present_acquire_rendered_frame(submit_lease) && submit_lease.rgba &&
+          submit_lease.rgba->data() == live_storage->data(),
+          "live-submit path publishes the renderer allocation without copying");
     CHECK(!execute_and_present(empty, W, H), "execute_and_present skips a draw-less submit even with a renderer");
     set_submit_renderer({});  // restore inert default
 

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 using namespace prosper;
@@ -94,14 +95,33 @@ int main() {
           "snapshot identifies the rendered publication");
     CHECK(snap.width == W && snap.height == H && snap.rgba == rendered,
           "snapshot metadata and pixels describe the same frame");
+
+    // The shared publication path must retain the renderer's exact immutable allocation. A lease
+    // keeps the old frame alive even after a newer frame replaces it or the present state resets.
+    auto shared_pixels = std::make_shared<const std::vector<uint8_t>>(rendered);
+    const uint8_t* shared_data = shared_pixels->data();
+    gpu::present_write_frame(shared_pixels, W, H);
+    gpu::PresentFrameLease lease;
+    CHECK(gpu::present_acquire_rendered_frame(lease) && lease.rgba &&
+          lease.rgba->data() == shared_data,
+          "shared rendered publication preserves allocation identity without copying");
+    const uint64_t leased_seq = lease.frame_seq;
+    std::vector<uint8_t> replacement(FB_BYTES, 0x5A);
+    gpu::present_write_frame(replacement.data(), W, H);
+    CHECK(lease.frame_seq == leased_seq && lease.rgba->data() == shared_data &&
+          *lease.rgba == rendered,
+          "rendered-frame lease remains valid after a newer publication");
     // The rendered frame wins over the raw guest buffer even across flips.
     flip(0x1001, 0, 0, 0, 0, 0);
     gpu::present_readback(out.data(), out.size());
-    CHECK(memcmp(out.data(), rendered.data(), FB_BYTES) == 0, "rendered frame takes precedence over the flipped guest buffer");
+    CHECK(memcmp(out.data(), replacement.data(), FB_BYTES) == 0,
+          "latest rendered frame takes precedence over the flipped guest buffer");
 
     // After reset, readback falls back to the guest buffer again.
     gpu::present_reset();
     CHECK(!gpu::present_has_frame(), "reset clears the rendered frame");
+    CHECK(lease.rgba->data() == shared_data && *lease.rgba == rendered,
+          "rendered-frame lease remains valid after present reset");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## What changed

- carry the selected renderer output as immutable shared storage through the live renderer, executor, and present layer
- let `prosper-app` acquire a lifetime-safe rendered-frame lease instead of copying through `present_readback`
- retain copying behavior for screenshots, captures, replay, snapshots, and the compatibility pointer API
- add pointer-identity and lease-lifetime tests
- document the ownership contract, measurements, and new Dead Cells post-parse loading bottleneck

## Why

At 3840x2160, the app moved about 31.6 MiB three additional times after the Vulkan readback. The copies cost about 6 ms inside the measured core path and another unmeasured app-side copy.

The shared ownership path removes those copies without changing capture or screenshot semantics. The same Dead Cells route now finishes `PrisonStart` parsing and reaches a later, heavier loading workload during the measurement window.

Closes #740.

## Validation

- Windows `prosper-app`, `screenshot`, and `boot_trace` build
- WSL `test_present`, `test_gpu_execute`, and `test_gpu_capture_render` pass
- Windows CTest: 70/71; only the known dump-specific `module_loads_eboot` fixture mismatch fails because this build points at Dead Cells
- native Windows Dead Cells routed A/B: matched 54-draw core submit improves from 46-49 ms to 40-42 ms; output copy and publication buckets fall to zero
- full-resolution screenshot run: 5/5 source-distinct and pixel-distinct PNGs; inspected title/menu/loading output is valid

The local snapshot matrix itself cannot run because all three manifest entries are still marked `review: pending`; no thresholds or review state were weakened in this PR.
