### PR TITLE
fix(gpu_replay): read shared ordered frame

### DIFF
--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -69,7 +69,7 @@ std::vector<uint8_t> execute_frame(const prosper::gpu::GpuReplayFrame& replay,
         },
         [](const auto& items) { return prosper::gpu::execute_compute_items(items); },
         replay.metadata.width, replay.metadata.height);
-    return std::move(result.pixels);
+    return result.frame.bytes();
 }
 
 const char* class_name(prosper::gpu::ResourceClass c);


### PR DESCRIPTION
## Summary
- adapt `gpu_replay` to the shared immutable ordered-frame result introduced by #741
- keep the replay helper's existing owning-vector return contract by copying only at that offline tool boundary

## Verification
- `cmake --build . --target gpu_replay test_present test_gpu_execute test_gpu_capture_render -j8`
- `ctest --output-on-failure -R present`
- `ctest --output-on-failure -R gpu_execute`
- `ctest --output-on-failure -R gpu_capture_render`

Fixes #744