### PR TITLE
perf(renderer): transfer persistent decode ownership

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -181,7 +181,10 @@ lines show only the latest 25 submits/calls so a scene transition is immediately
 window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
 Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture decodes taking at least
 0.5 ms (capped at 250 lines). Set `PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT=N` to begin those detail
-lines at renderer submit N, so boot textures do not consume the cap before the scene under study.
+lines at renderer submit N, so boot textures do not consume the cap before the scene under study. Each
+line identifies local reuse, persistent hit/miss/invalidation, RTT sourcing, or an uncached decode. The
+aggregate output also reports retained RTT bytes, decode-scratch capacity, and validation-scratch capacity;
+use those figures before treating a process-memory increase as an unbounded cache.
 The instrumentation does not take clock samples when the variable is unset. This is the first tool
 to use when the window presents correctly but a title is not interactive; do not infer a GPU
 bottleneck from low FPS without the stage breakdown.

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -276,6 +276,34 @@ compute pools remained bounded at 355 MiB and 47 MiB. The workload nevertheless 
 persistent textures per submit window and performs repeated uploads, so resource versioning and residency
 are the next memory/performance investigation rather than further publication lookup tuning.
 
+## Persistent decode ownership and cache accounting (2026-07-15)
+
+The persistent decoded-texture cache previously copied each newly decoded image out of a reusable scratch
+vector. The scratch vector retained its allocation even though all future uses referenced the persistent
+copy. Successful cache insertion now moves that allocation into the cache. Uncached and mutable resources
+still retain reusable scratch storage so steady rendering does not allocate every frame.
+
+Native Windows cache accounting shows the result:
+
+| Measurement | Copy insertion | Ownership transfer |
+|---|---:|---:|
+| Loading-loop decode scratch | 141-160 MiB | 0 MiB |
+| Post-parse decode scratch | 160 MiB | 49.8 MiB |
+| Loading-loop private memory | about 1.58 GiB | about 1.42 GiB |
+| Post-parse private memory | about 1.89 GiB | about 1.84 GiB |
+
+The smaller post-parse process delta includes variation in the workload's other bounded caches: the later
+run held 27 decoded textures, 15 RTT surfaces, a 359 MiB graphics pool, and a 49 MiB compute pool. Its final
+45 seconds stayed near 1.84 GiB private and 3.82 GiB working set. RTT retention is not the leak hypothesis:
+it stabilized at 101.8 MiB. `PROSPER_RENDER_TIMING=1` now reports RTT, decode-scratch, and validation-scratch
+storage so later titles can distinguish cache growth from an unbounded process.
+
+Detailed timing also identifies why resource construction remains expensive. Exact validation of unchanged
+linear atlases costs about 7.3 ms for one 4096x4096 image, 1.8-2.1 ms for one 2048x2048 image, and about 1 ms
+for one 1024x2048 image on every graphics span. `PROSPER_RENDER_TIMING=detail` labels each slow texture as a
+local reuse, persistent hit/miss/invalidation, RTT source, or uncached decode. Replacing exact validation
+requires write-aware invalidation; probabilistic sampling is not an acceptable correctness shortcut.
+
 ## Current frame budget
 
 After shared publication, the Dead Cells post-parse loading workload is the most useful current budget:

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -364,6 +364,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const auto resource_timing_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     bool resource_rtt_hit = false;
+                    bool resource_local_reuse = false;
+                    bool resource_persistent_hit = false;
+                    bool resource_persistent_miss = false;
+                    bool resource_persistent_invalidation = false;
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     // Captured replays preserve the logical guest address for RT identity but provide
                     // owned bytes here. Production resources leave host_data null and use guest memory.
@@ -420,6 +424,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         DecodedTexture persistent_reuse;
                         const DecodedTexture* decoded_reuse = reused != decoded_textures.end()
                             ? &reused->second : nullptr;
+                        resource_local_reuse = decoded_reuse != nullptr;
                         if (!decoded_reuse && persistent_cache_eligible) {
                             auto cached = persistent_decoded_textures.find(decode_key);
                             if (cached != persistent_decoded_textures.end() &&
@@ -450,11 +455,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                                         cached->second.narrow,
                                                         cached->second.persistent_id};
                                     decoded_reuse = &persistent_reuse;
+                                    resource_persistent_hit = true;
                                     if (timing_enabled) pending_timing.persistent_hits++;
                                 } else if (timing_enabled) {
+                                    resource_persistent_invalidation = true;
                                     pending_timing.persistent_invalidations++;
                                 }
                             } else if (timing_enabled) {
+                                resource_persistent_miss = true;
                                 pending_timing.persistent_misses++;
                             }
                         }
@@ -962,7 +970,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     cached.source_prefix.assign(
                                         persistent_validation_scratch.begin(),
                                         persistent_validation_scratch.begin() + source_prefix_size);
-                                cached.pixels = texture_pixels;
+                                // A successful persistent insertion owns the decoded allocation from
+                                // now on. Moving it avoids retaining the same large atlas in both the
+                                // process-wide cache and a reusable scratch slot.
+                                cached.pixels = std::move(texture_pixels);
                                 cached.output_height = fr.th;
                                 cached.narrow = narrow_done;
                                 cached.last_use = decode_generation;
@@ -1039,15 +1050,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 ? strtoull(getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT"), nullptr, 0) : 0;
                             if (const char* mode = getenv("PROSPER_RENDER_TIMING");
                                 mode && strcmp(mode, "detail") == 0 &&
-                                static_cast<uint64_t>(g_this_submit) >= detail_min_submit && elapsed >= 0.5) {
+                                static_cast<uint64_t>(g_this_submit) >= detail_min_submit) {
                                 static uint64_t detail_lines = 0;
-                                if (detail_lines++ < 250) {
+                                if ((elapsed >= 0.5 || resource_persistent_invalidation) &&
+                                    detail_lines++ < 250) {
+                                    const char* cache_state = resource_rtt_hit ? "rtt" :
+                                        (resource_local_reuse ? "local" :
+                                        (resource_persistent_hit ? "persistent-hit" :
+                                        (resource_persistent_invalidation ? "persistent-invalid" :
+                                        (resource_persistent_miss ? "persistent-miss" : "uncached"))));
                                     fprintf(stderr,
                                             "[render-timing] texture addr=0x%llx %ux%u out=%ux%u "
-                                            "fmt=%u comps=%u tile=%u rtt=%d %.2f ms\n",
+                                            "fmt=%u comps=%u tile=%u cache=%s id=%llu %.2f ms\n",
                                             (unsigned long long)r.gpu_addr, r.width, r.height,
                                             fr.tw, fr.th, (unsigned)r.format, r.num_components,
-                                            r.tile_mode, (int)resource_rtt_hit, elapsed);
+                                            r.tile_mode, cache_state,
+                                            (unsigned long long)fr.persistent_texture_id, elapsed);
                                 }
                             }
                         } else {
@@ -1622,6 +1640,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (unsigned long long)totals.persistent_invalidations,
                             persistent_decoded_textures.size(),
                             persistent_decoded_texture_bytes / (1024.0 * 1024.0));
+                    size_t rtt_bytes = 0;
+                    for (const auto& [addr, surface] : g_rtt) {
+                        (void)addr;
+                        if (surface.rgba) rtt_bytes += surface.rgba->size();
+                    }
+                    size_t scratch_bytes = 0;
+                    for (const auto& scratch : texstore)
+                        scratch_bytes += scratch.capacity();
+                    fprintf(stderr,
+                            "[render-timing] host_cache rtt=%zu %.1f MiB decode_scratch=%zu %.1f MiB "
+                            "validation=%.1f MiB\n",
+                            g_rtt.size(), rtt_bytes / (1024.0 * 1024.0),
+                            texstore.size(), scratch_bytes / (1024.0 * 1024.0),
+                            persistent_validation_scratch.capacity() / (1024.0 * 1024.0));
                     const double wn = static_cast<double>(window.submits);
                     const double window_other = window.total_ms - window.build_resources_ms -
                                                 window.backend_ms - window.output_copy_ms;


### PR DESCRIPTION
## Summary
- transfer decoded pixel-vector ownership into the persistent cache instead of retaining a duplicate scratch allocation
- label detailed texture timing with the exact cache outcome
- report retained RTT, decode-scratch, and validation-scratch capacity in the timing window
- document the measured Dead Cells cache/memory budget and the remaining validation bottleneck

## Dead Cells measurements

| Metric | Before | After |
|---|---:|---:|
| loading decode scratch | 141-160 MiB | 0 MiB |
| loading private memory | ~1.58 GiB | ~1.42 GiB |
| post-parse decode scratch | 160.1 MiB | 49.8 MiB |
| post-parse private memory | ~1.89 GiB | ~1.84 GiB |

The final 45 seconds of the post-parse run stayed near 1.84 GiB private / 3.82 GiB working set. This fixes duplicate ownership; it deliberately does not claim an FPS gain. Detailed timing identifies full exact validation of unchanged 4096x4096 and smaller atlases as the next cost tracked by #743.

## Verification
- complete WSL build, including `gpu_replay`
- WSL `ctest -j8 --output-on-failure`: 97/97 passed
- Windows `prosper-app`, `screenshot`, and `boot_trace` builds
- two native Dead Cells memory/timing runs through `PARSEALL`, including a 45-second stable post-parse window

Fixes #742