### PR TITLE
perf(renderer): reuse same-submit texture validation

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -185,6 +185,15 @@ lines at renderer submit N, so boot textures do not consume the cap before the s
 line identifies local reuse, persistent hit/miss/invalidation, RTT sourcing, or an uncached decode. The
 aggregate output also reports retained RTT bytes, decode-scratch capacity, and validation-scratch capacity;
 use those figures before treating a process-memory increase as an unbounded cache.
+
+Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
+compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated
+full-byte scan when no later write overlaps it. Timing output reports these as `persistent-submit` details and
+`submit_reuse` aggregates, alongside the remaining exact validation count and bytes. Cross-submit reuse still
+uses exact comparison because guest CPU writes are not yet tracked. Set
+`PROSPER_NO_SUBMIT_TEXTURE_VALIDATION_REUSE=1` for the exact-validation A/B control. Set
+`PROSPER_AUDIT_SUBMIT_TEXTURE_VALIDATION_REUSE=1` to keep every comparison while checking and logging any
+disagreement with the journal's unchanged decision; use that audit before extending writer coverage.
 The instrumentation does not take clock samples when the variable is unset. This is the first tool
 to use when the window presents correctly but a title is not interactive; do not infer a GPU
 bottleneck from low FPS without the stage breakdown.

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -304,6 +304,37 @@ for one 1024x2048 image on every graphics span. `PROSPER_RENDER_TIMING=detail` l
 local reuse, persistent hit/miss/invalidation, RTT source, or uncached decode. Replacing exact validation
 requires write-aware invalidation; probabilistic sampling is not an acceptable correctness shortcut.
 
+## Same-submit write-aware validation (2026-07-15)
+
+Ordered execution now opens a backend-neutral, bounded journal for each synchronous submit. Compute buffer
+and storage-image writeback already reports exact guest ranges through `notify_guest_gpu_write`; later
+graphics spans query only events after the cache entry's last successful validation. An unrelated write proves
+the source unchanged, an overlap forces an exact comparison, and a different submit, inactive scope, nested
+execution, or 4,096-event overflow also falls back to exact comparison. DMA_DATA and WRITE_DATA currently
+execute during command-buffer folding before ordered backend execution, so the first graphics span's exact
+comparison observes them; they are not silently treated as between-span events.
+
+Cross-submit validation is intentionally unchanged. Guest CPU writes need authoritative dirty-page tracking
+before the exact comparison can be removed there. `PROSPER_NO_SUBMIT_TEXTURE_VALIDATION_REUSE=1` disables the
+same-submit shortcut. `PROSPER_AUDIT_SUBMIT_TEXTURE_VALIDATION_REUSE=1` exercises every proposed shortcut but
+still performs the old exact comparison. A 180-second native Windows Dead Cells audit reached `PrisonStart`,
+completed `PARSEALL`, exercised 1,196 cumulative shortcuts, and reported zero disagreements.
+
+The fully rendered route is animated and the compared four-span windows contained different draw counts, so
+whole-submit figures are directional rather than a strict benchmark. The resource-specific reduction is
+directly counted:
+
+| Four-span window | Exact validations/submit | Validated bytes/submit | Texture resource time | Resource build |
+|---|---:|---:|---:|---:|
+| Audit, exact comparisons retained | 28 | 275.8 MiB | 40.2-40.4 ms | 49.9-50.3 ms |
+| Write-aware shortcut enabled | 22 | 145.1 MiB | 30.5-30.7 ms | 40.8-41.2 ms |
+
+The audit window's whole submit was about 202 ms with 348 draws; the optimized window was 196-199 ms with
+386 draws. Reported app rate remained about 4.3 FPS, confirming this is a bounded frontend improvement rather
+than the dominant remaining renderer cost. The optimized run ended stable near 1.81 GiB private and 3.79 GiB
+working set. The next large performance work remains persistent Vulkan object reuse and fewer synchronous
+graphics/compute/readback boundaries.
+
 ## Current frame budget
 
 After shared publication, the Dead Cells post-parse loading workload is the most useful current budget:

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -101,6 +101,7 @@ struct PersistentDecodedTexture {
     bool narrow = false;
     uint64_t last_use = 0;
     uint64_t persistent_id = 0;
+    prosper::gpu::GuestGpuWriteSnapshot validation_snapshot;
 
     size_t bytes() const { return source_prefix.size() + pixels.size(); }
 };
@@ -211,6 +212,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
                 uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                 uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
+                uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
+                uint64_t persistent_validation_bytes = 0;
                 uint64_t texture_bytes = 0, buffer_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
             };
@@ -366,6 +369,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bool resource_rtt_hit = false;
                     bool resource_local_reuse = false;
                     bool resource_persistent_hit = false;
+                    bool resource_persistent_submit_reuse = false;
                     bool resource_persistent_miss = false;
                     bool resource_persistent_invalidation = false;
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
@@ -429,27 +433,62 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             auto cached = persistent_decoded_textures.find(decode_key);
                             if (cached != persistent_decoded_textures.end() &&
                                 cached->second.source_size == persistent_source_size) {
+                                auto validate_exact = [&] {
+                                    bool matches = false;
+                                    size_t validated_bytes = 0;
+                                    if (cached->second.source_matches_pixels) {
+                                        matches = safe_equal(
+                                            cached->second.pixels.data(), r.gpu_addr,
+                                            persistent_source_size, validated_bytes) &&
+                                            validated_bytes == cached->second.source_prefix_size;
+                                    } else {
+                                        persistent_validation_scratch.resize(persistent_source_size);
+                                        validated_bytes = copy_resource(
+                                            persistent_validation_scratch.data(), r.gpu_addr,
+                                            persistent_source_size);
+                                        matches =
+                                            validated_bytes == cached->second.source_prefix_size &&
+                                            validated_bytes == cached->second.source_prefix.size() &&
+                                            (validated_bytes == 0 || !std::memcmp(
+                                                persistent_validation_scratch.data(),
+                                                cached->second.source_prefix.data(), validated_bytes));
+                                    }
+                                    if (timing_enabled) {
+                                        pending_timing.persistent_validations++;
+                                        pending_timing.persistent_validation_bytes += validated_bytes;
+                                    }
+                                    return matches;
+                                };
+                                static const bool submit_reuse_enabled =
+                                    !getenv("PROSPER_NO_SUBMIT_TEXTURE_VALIDATION_REUSE");
+                                static const bool audit_submit_reuse =
+                                    getenv("PROSPER_AUDIT_SUBMIT_TEXTURE_VALIDATION_REUSE") != nullptr;
+                                const bool submit_unchanged = submit_reuse_enabled &&
+                                    prosper::gpu::guest_gpu_writes_since(
+                                        cached->second.validation_snapshot, r.gpu_addr,
+                                        persistent_source_size) ==
+                                        prosper::gpu::GuestGpuWriteQuery::Unchanged;
                                 bool content_matches = false;
-                                if (cached->second.source_matches_pixels) {
-                                    size_t compared = 0;
-                                    content_matches = safe_equal(
-                                        cached->second.pixels.data(), r.gpu_addr,
-                                        persistent_source_size, compared) &&
-                                        compared == cached->second.source_prefix_size;
+                                if (submit_unchanged) {
+                                    content_matches = audit_submit_reuse ? validate_exact() : true;
+                                    if (!content_matches) {
+                                        fprintf(stderr,
+                                                "[render] in-submit texture validation audit failed "
+                                                "addr=0x%llx bytes=%zu\n",
+                                                (unsigned long long)r.gpu_addr,
+                                                persistent_source_size);
+                                    } else {
+                                        resource_persistent_submit_reuse = true;
+                                        if (timing_enabled)
+                                            pending_timing.persistent_submit_reuses++;
+                                    }
                                 } else {
-                                    persistent_validation_scratch.resize(persistent_source_size);
-                                    const size_t got = copy_resource(
-                                        persistent_validation_scratch.data(), r.gpu_addr,
-                                        persistent_source_size);
-                                    content_matches =
-                                        got == cached->second.source_prefix_size &&
-                                        got == cached->second.source_prefix.size() &&
-                                        (got == 0 || !std::memcmp(
-                                            persistent_validation_scratch.data(),
-                                            cached->second.source_prefix.data(), got));
+                                    content_matches = validate_exact();
                                 }
                                 if (content_matches) {
                                     cached->second.last_use = decode_generation;
+                                    cached->second.validation_snapshot =
+                                        prosper::gpu::guest_gpu_write_snapshot();
                                     persistent_reuse = {cached->second.pixels.data(),
                                                         cached->second.output_height,
                                                         cached->second.narrow,
@@ -980,6 +1019,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 cached.persistent_id = ++persistent_texture_id;
                                 if (!cached.persistent_id)
                                     cached.persistent_id = ++persistent_texture_id;
+                                cached.validation_snapshot =
+                                    prosper::gpu::guest_gpu_write_snapshot();
                                 auto [inserted, ok] = persistent_decoded_textures.emplace(
                                     decode_key, std::move(cached));
                                 if (ok) {
@@ -1056,9 +1097,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     detail_lines++ < 250) {
                                     const char* cache_state = resource_rtt_hit ? "rtt" :
                                         (resource_local_reuse ? "local" :
+                                        (resource_persistent_submit_reuse ? "persistent-submit" :
                                         (resource_persistent_hit ? "persistent-hit" :
                                         (resource_persistent_invalidation ? "persistent-invalid" :
-                                        (resource_persistent_miss ? "persistent-miss" : "uncached"))));
+                                        (resource_persistent_miss ? "persistent-miss" : "uncached")))));
                                     fprintf(stderr,
                                             "[render-timing] texture addr=0x%llx %ux%u out=%ux%u "
                                             "fmt=%u comps=%u tile=%u cache=%s id=%llu %.2f ms\n",
@@ -1590,6 +1632,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
                     uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                     uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
+                    uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
+                    uint64_t persistent_validation_bytes = 0;
                     uint64_t texture_bytes = 0, buffer_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                 };
@@ -1607,6 +1651,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.persistent_hits += pending_timing.persistent_hits;
                     timing.persistent_misses += pending_timing.persistent_misses;
                     timing.persistent_invalidations += pending_timing.persistent_invalidations;
+                    timing.persistent_submit_reuses += pending_timing.persistent_submit_reuses;
+                    timing.persistent_validations += pending_timing.persistent_validations;
+                    timing.persistent_validation_bytes += pending_timing.persistent_validation_bytes;
                     timing.buffers += pending_timing.buffers;
                     timing.texture_bytes += pending_timing.texture_bytes;
                     timing.buffer_bytes += pending_timing.buffer_bytes;
@@ -1634,10 +1681,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (unsigned long long)totals.buffers,
                             totals.buffer_bytes / (1024.0 * 1024.0), totals.buffer_ms / nsub);
                     fprintf(stderr,
-                            "[render-timing] texture_cache hits=%llu misses=%llu invalid=%llu entries=%zu %.1f MiB\n",
+                            "[render-timing] texture_cache hits=%llu submit_reuse=%llu misses=%llu "
+                            "invalid=%llu validations=%llu %.1f GiB entries=%zu %.1f MiB\n",
                             (unsigned long long)totals.persistent_hits,
+                            (unsigned long long)totals.persistent_submit_reuses,
                             (unsigned long long)totals.persistent_misses,
                             (unsigned long long)totals.persistent_invalidations,
+                            (unsigned long long)totals.persistent_validations,
+                            totals.persistent_validation_bytes / (1024.0 * 1024.0 * 1024.0),
                             persistent_decoded_textures.size(),
                             persistent_decoded_texture_bytes / (1024.0 * 1024.0));
                     size_t rtt_bytes = 0;
@@ -1671,9 +1722,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.buffers / wn, window.buffer_bytes / (wn * 1024.0 * 1024.0),
                             window.buffer_ms / wn);
                     fprintf(stderr,
-                            "[render-window] texture_cache hits=%.1f misses=%.1f invalid=%.1f\n",
-                            window.persistent_hits / wn, window.persistent_misses / wn,
-                            window.persistent_invalidations / wn);
+                            "[render-window] texture_cache hits=%.1f submit_reuse=%.1f misses=%.1f "
+                            "invalid=%.1f validations=%.1f %.1f MiB\n",
+                            window.persistent_hits / wn, window.persistent_submit_reuses / wn,
+                            window.persistent_misses / wn, window.persistent_invalidations / wn,
+                            window.persistent_validations / wn,
+                            window.persistent_validation_bytes / (wn * 1024.0 * 1024.0));
                     window = {};
                 }
             }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -267,6 +267,23 @@ using GuestGpuWriteObserver = std::function<void(uint64_t addr, uint64_t size)>;
 void set_guest_gpu_write_observer(GuestGpuWriteObserver observer);
 void notify_guest_gpu_write(uint64_t addr, uint64_t size);
 
+// A validation snapshot is meaningful only inside one synchronous execute_ordered_items call.
+// It lets a backend prove that no retained GPU operation wrote a resource between graphics spans;
+// CPU writes and later submits deliberately remain outside this proof and must use exact validation.
+constexpr size_t kGuestGpuWriteJournalCapacity = 4096;
+struct GuestGpuWriteSnapshot {
+    uint64_t submit_serial = 0;
+    size_t write_count = 0;
+};
+enum class GuestGpuWriteQuery {
+    Unchanged,
+    Overlap,
+    Unknown,
+};
+GuestGpuWriteSnapshot guest_gpu_write_snapshot();
+GuestGpuWriteQuery guest_gpu_writes_since(const GuestGpuWriteSnapshot& snapshot,
+                                           uint64_t addr, uint64_t size);
+
 // Register the synchronous live compute backend. execute_compute_dispatches realizes every retained
 // dispatch from its state snapshot and invokes the backend in stream order.
 void set_submit_compute(LiveComputeFn fn);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <atomic>
 #include <bitset>
 #include <iterator>
 #include <mutex>
@@ -41,6 +42,48 @@ LiveRenderFn g_live;   // empty until the runtime/test registers a device-backed
 LiveComputeFn g_compute;   // synchronous compute backend, registered with the live Vulkan frontend
 GuestGpuWriteObserver g_guest_gpu_write_observer;
 thread_local LiveRenderPhase g_live_phase;
+
+struct GuestGpuWriteRange {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+};
+struct GuestGpuWriteJournal {
+    bool active = false;
+    bool overflowed = false;
+    uint64_t submit_serial = 0;
+    std::vector<GuestGpuWriteRange> writes;
+};
+thread_local GuestGpuWriteJournal g_guest_gpu_writes;
+std::atomic<uint64_t> g_next_guest_gpu_submit_serial{0};
+
+bool ranges_overlap(uint64_t a, uint64_t a_size, uint64_t b, uint64_t b_size) {
+    if (!a_size || !b_size) return false;
+    return a <= b ? b - a < a_size : a - b < b_size;
+}
+
+class GuestGpuWriteSubmitScope {
+public:
+    GuestGpuWriteSubmitScope() {
+        // Ordered execution is synchronous and non-recursive. If that contract is ever broken,
+        // force conservative validation rather than silently losing the outer write history.
+        if (g_guest_gpu_writes.active) {
+            nested_ = true;
+            g_guest_gpu_writes.overflowed = true;
+            return;
+        }
+        g_guest_gpu_writes.active = true;
+        g_guest_gpu_writes.overflowed = false;
+        g_guest_gpu_writes.submit_serial =
+            g_next_guest_gpu_submit_serial.fetch_add(1, std::memory_order_relaxed) + 1;
+        g_guest_gpu_writes.writes.clear();
+    }
+    ~GuestGpuWriteSubmitScope() {
+        if (!nested_) g_guest_gpu_writes.active = false;
+    }
+
+private:
+    bool nested_ = false;
+};
 
 // Read a 32-dword user-data SGPR block from a stage's register file. `base` = the stage's
 // SPI_SHADER_USER_DATA_*_0 register offset; absent registers read as 0. 32 (not 16) because NGG merged
@@ -2218,6 +2261,7 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
                                           const LiveRenderFn& render,
                                           const LiveComputeFn& compute,
                                           uint32_t width, uint32_t height) {
+    GuestGpuWriteSubmitScope guest_gpu_write_scope;
     std::unordered_map<size_t, size_t> draw_by_index, compute_by_index;
     for (size_t i = 0; i < draws.size(); ++i) draw_by_index[draws[i].draw_index] = i;
     for (size_t i = 0; i < computes.size(); ++i)
@@ -2285,7 +2329,32 @@ void set_guest_gpu_write_observer(GuestGpuWriteObserver observer) {
     g_guest_gpu_write_observer = std::move(observer);
 }
 void notify_guest_gpu_write(uint64_t addr, uint64_t size) {
-    if (addr && size && g_guest_gpu_write_observer) g_guest_gpu_write_observer(addr, size);
+    if (!addr || !size) return;
+    if (g_guest_gpu_writes.active) {
+        if (g_guest_gpu_writes.writes.size() < kGuestGpuWriteJournalCapacity)
+            g_guest_gpu_writes.writes.push_back({addr, size});
+        else
+            g_guest_gpu_writes.overflowed = true;
+    }
+    if (g_guest_gpu_write_observer) g_guest_gpu_write_observer(addr, size);
+}
+GuestGpuWriteSnapshot guest_gpu_write_snapshot() {
+    if (!g_guest_gpu_writes.active || g_guest_gpu_writes.overflowed) return {};
+    return {g_guest_gpu_writes.submit_serial, g_guest_gpu_writes.writes.size()};
+}
+GuestGpuWriteQuery guest_gpu_writes_since(const GuestGpuWriteSnapshot& snapshot,
+                                           uint64_t addr, uint64_t size) {
+    if (!snapshot.submit_serial || !g_guest_gpu_writes.active ||
+        snapshot.submit_serial != g_guest_gpu_writes.submit_serial ||
+        g_guest_gpu_writes.overflowed ||
+        snapshot.write_count > g_guest_gpu_writes.writes.size())
+        return GuestGpuWriteQuery::Unknown;
+    for (size_t i = snapshot.write_count; i < g_guest_gpu_writes.writes.size(); ++i) {
+        const auto& write = g_guest_gpu_writes.writes[i];
+        if (ranges_overlap(addr, size, write.addr, write.size))
+            return GuestGpuWriteQuery::Overlap;
+    }
+    return GuestGpuWriteQuery::Unchanged;
 }
 LiveRenderPhase live_render_phase()       { return g_live_phase; }
 std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -100,6 +100,9 @@ int main() {
         uint32_t aliased_value = 7;
         std::vector<uint32_t> observed;
         std::vector<LiveRenderPhase> phases;
+        GuestGpuWriteSnapshot validation;
+        GuestGpuWriteQuery overlapping = GuestGpuWriteQuery::Unknown;
+        GuestGpuWriteQuery unrelated = GuestGpuWriteQuery::Unknown;
         DrawItem first, second;
         first.draw_index = 0;
         second.draw_index = 1;
@@ -108,10 +111,17 @@ int main() {
         LiveRenderFn observe = [&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
             for (size_t i = 0; i < items.size(); ++i) observed.push_back(aliased_value);
             phases.push_back(live_render_phase());
+            if (phases.size() == 1) {
+                validation = guest_gpu_write_snapshot();
+            } else {
+                overlapping = guest_gpu_writes_since(validation, 0x2080, 16);
+                unrelated = guest_gpu_writes_since(validation, 0x4000, 16);
+            }
             return std::vector<uint8_t>(4, static_cast<uint8_t>(aliased_value));
         };
         LiveComputeFn mutate = [&](const std::vector<ComputeItem>&) {
             aliased_value = 9;
+            notify_guest_gpu_write(0x2000, 0x100);
             return true;
         };
         OrderedSubmitResult ordered = execute_ordered_items(
@@ -122,6 +132,41 @@ int main() {
               phases[0].first_span && !phases[0].final_span &&
               !phases[1].first_span && phases[1].final_span,
               "ordered executor brackets one submit across two graphics spans");
+        CHECK(overlapping == GuestGpuWriteQuery::Overlap &&
+              unrelated == GuestGpuWriteQuery::Unchanged,
+              "write journal distinguishes overlapping and unrelated in-submit GPU writes");
+        CHECK(guest_gpu_writes_since(validation, 0x4000, 16) == GuestGpuWriteQuery::Unknown,
+              "write journal snapshots cannot suppress validation after submit completion");
+    }
+
+    // Overflow or otherwise incomplete write history must fall back to exact validation.
+    {
+        DrawItem first, second;
+        first.draw_index = 0;
+        second.draw_index = 1;
+        ComputeItem fill;
+        fill.dispatch_index = 0;
+        const std::vector<SubmitOperation> operations = {
+            {SubmitOperationKind::Draw, 0, 100},
+            {SubmitOperationKind::Dispatch, 0, 200},
+            {SubmitOperationKind::Draw, 1, 300},
+        };
+        GuestGpuWriteSnapshot validation;
+        GuestGpuWriteQuery after_overflow = GuestGpuWriteQuery::Unchanged;
+        size_t renders = 0;
+        LiveRenderFn observe = [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+            if (renders++ == 0) validation = guest_gpu_write_snapshot();
+            else after_overflow = guest_gpu_writes_since(validation, 0x8000, 16);
+            return std::vector<uint8_t>(4, 0);
+        };
+        LiveComputeFn overflow = [&](const std::vector<ComputeItem>&) {
+            for (size_t i = 0; i <= kGuestGpuWriteJournalCapacity; ++i)
+                notify_guest_gpu_write(0x100000 + i * 0x10, 1);
+            return true;
+        };
+        execute_ordered_items(operations, {first, second}, {fill}, observe, overflow, 1, 1);
+        CHECK(after_overflow == GuestGpuWriteQuery::Unknown,
+              "write journal overflow forces conservative validation");
     }
 
     // #611: a compute fast-clear writes HTILE guest memory between graphics spans. The detached


### PR DESCRIPTION
## Summary
- journal exact guest GPU write ranges for one synchronous ordered submit
- reuse persistent texture validation across graphics spans only when no later range overlaps
- retain exact validation for different submits, overlaps, inactive/incomplete history, recursion, and overflow
- add an audit mode, disable switch, validation byte counters, unit coverage, and performance documentation

## Dead Cells result

| Four-span window | Exact validations | Validated bytes | Texture resource time | Resource build |
|---|---:|---:|---:|---:|
| Audit with exact comparisons | 28/submit | 275.8 MiB/submit | 40.2-40.4 ms | 49.9-50.3 ms |
| Write-aware reuse | 22/submit | 145.1 MiB/submit | 30.5-30.7 ms | 40.8-41.2 ms |

A 180-second audit exercised 1,196 proposed shortcuts with zero disagreements. Whole-submit time improves directionally from ~202 ms to 196-199 ms, but animated windows had different draw counts and app rate remains ~4.3 FPS. Cross-submit CPU dirty tracking remains on #743.

## Verification
- complete WSL build and `ctest`: 97/97
- complete native Windows build and `ctest`: 69/69
- native 180-second Dead Cells exact/audit and optimized runs through `PARSEALL`
- native 18-frame normal composited screenshot sequence: 18 source-distinct, 18 pixel-distinct; title/menu/loading art visually inspected
- `snapshot.py check` correctly refuses the three still-pending unreviewed baselines; no threshold or review metadata was changed

Advances #743