### PR TITLE
tools(renderer): align backend timing to submits

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -177,14 +177,21 @@ $env:PROSPER_RENDER_TIMING = '1'
 The output separates guest-state realization, ordered graphics/compute execution, CPU resource
 decode/detile, Vulkan target and pipeline setup, upload/recording, GPU fence wait, readback, cleanup,
 and frontend publication. Cumulative `[render-timing]` lines show the whole run; `[render-window]`
-lines show only the latest 25 submits/calls so a scene transition is immediately visible. The core
-window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
+lines show only the latest 25 submits/calls so a scene transition is immediately visible. The
+`backend-submit` lines sum every Vulkan call made by those exact ordered submits, rather than mixing
+an independent 25-call backend window across submit boundaries. Compare `measured` with `detail` and
+its `other` remainder to verify that the subphase attribution covers the frontend's backend wall time.
+The core window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
 Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture decodes taking at least
 0.5 ms (capped at 250 lines). Set `PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT=N` to begin those detail
 lines at renderer submit N, so boot textures do not consume the cap before the scene under study. Each
 line identifies local reuse, persistent hit/miss/invalidation, RTT sourcing, or an uncached decode. The
 aggregate output also reports retained RTT bytes, decode-scratch capacity, and validation-scratch capacity;
 use those figures before treating a process-memory increase as an unbounded cache.
+Combine timing with `PROSPER_RTTLOG=1` to print one `[rtt-timing]` line per rendered target group. It includes
+the submit number, target address, dimensions, draw count, and that target's exact Vulkan phase breakdown.
+Use `PROSPER_RTTLOG_MIN_SUBMIT=N` and `PROSPER_RTTLOG_MAX_SUBMIT=N` to bound the diagnostic window; unrestricted
+logging can materially slow a title and perturb wall-clock input routes.
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -335,6 +335,46 @@ than the dominant remaining renderer cost. The optimized run ended stable near 1
 working set. The next large performance work remains persistent Vulkan object reuse and fewer synchronous
 graphics/compute/readback boundaries.
 
+## Submit-aligned Vulkan timing
+
+The original backend timing window averaged every 25 calls independently. Dead Cells currently makes four
+graphics callbacks in an ordered submit, and each callback can render multiple targets, so those backend
+windows could straddle scene and submit boundaries. The frontend now records the structured timing result of
+every completed `render_draws_rgba` call and sums it into the same 25-submit window used by its resource and
+wall-time counters. The new `backend-submit` lines report calls and draws per submit plus target setup, draw
+setup, record/upload, fence wait, readback, cleanup, and the shader/fixed/resource/pipeline draw-setup split.
+They also print the frontend-measured backend duration, the detailed phase sum, and the unattributed remainder.
+This is the authoritative view for choosing the next backend optimization; the legacy per-call lines remain
+useful for spotting an individually slow render target. Combining `PROSPER_RENDER_TIMING=1` with
+`PROSPER_RTTLOG=1` adds a `[rtt-timing]` record for each target group with its submit, address, dimensions,
+draw count, and exact phase costs, allowing dependency logs and backend costs to be correlated directly. Bound
+verbose output with `PROSPER_RTTLOG_MIN_SUBMIT` and `PROSPER_RTTLOG_MAX_SUBMIT`; an unrestricted Dead Cells run
+dropped the title loop from about 20 FPS to 13-14 FPS and caused its wall-clock input route to miss the menu.
+
+A 180-second native Windows fresh-save Dead Cells run reached the post-parse workload with 373 draws, eight
+dispatches, and four graphics spans. Those spans rendered ten target groups per submit. The aligned backend
+window was:
+
+| Vulkan work per submit | Time |
+|---|---:|
+| Frontend-measured backend wall time | 90.09 ms |
+| Detailed phase sum | 75.28 ms |
+| Fence waits | 33.12 ms |
+| Draw setup | 26.54 ms |
+| Pipeline creation (inside draw setup) | 12.89 ms |
+| Descriptor/resources (inside draw setup) | 8.46 ms |
+| Readback | 9.43 ms |
+| Record/upload | 4.59 ms |
+| Target setup + cleanup | 1.59 ms |
+| Unattributed backend wrapper time | 14.81 ms |
+
+The whole ordered submit remained about 201 ms: 36 ms draw realization and 165 ms backend execution. Private
+memory stepped up with the workload, then stayed near 1.81 GiB through the end; working set stayed near
+3.78 GiB. This rules out unbounded growth in that window and shows that no single small setup cache can make
+the workload playable. The next investigation must identify the true dependencies among the ten target calls;
+persisting pipelines addresses about 13 ms, while removing unnecessary synchronous wait/readback boundaries
+has the larger ceiling but requires preserving graphics/compute and RTT producer-consumer order.
+
 ## Current frame budget
 
 After shared publication, the Dead Cells post-parse loading workload is the most useful current budget:

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -206,10 +206,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             static thread_local int g_this_submit = -1;
             if (phase.first_span || g_this_submit < 0) g_this_submit = g_submit_idx++;
             if (g_this_submit > g_render_last) return {};
+            static const int g_rttlog_min_submit = getenv("PROSPER_RTTLOG_MIN_SUBMIT")
+                ? std::max(0, atoi(getenv("PROSPER_RTTLOG_MIN_SUBMIT"))) : 0;
+            static const int g_rttlog_max_submit = getenv("PROSPER_RTTLOG_MAX_SUBMIT")
+                ? std::max(0, atoi(getenv("PROSPER_RTTLOG_MAX_SUBMIT"))) : INT_MAX;
+            const bool rtt_log = getenv("PROSPER_RTTLOG") &&
+                g_this_submit >= g_rttlog_min_submit && g_this_submit <= g_rttlog_max_submit;
             using RenderClock = std::chrono::steady_clock;
             struct RenderTiming {
                 uint64_t callbacks = 0;
                 double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
+                uint64_t backend_calls = 0, backend_draws = 0;
+                double backend_target_ms = 0, backend_draw_setup_ms = 0;
+                double backend_record_upload_ms = 0, backend_gpu_wait_ms = 0;
+                double backend_readback_ms = 0, backend_cleanup_ms = 0;
+                double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
+                double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                 uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                 uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                 uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
@@ -222,6 +234,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             if (timing_enabled && phase.first_span) pending_timing = {};
             const auto callback_timing_start = timing_enabled
                 ? RenderClock::now() : RenderClock::time_point{};
+            auto record_backend_timing = [&](const prosper::test::BackendRenderTimingStats& backend) {
+                pending_timing.backend_calls += backend.calls;
+                pending_timing.backend_draws += backend.draws;
+                pending_timing.backend_target_ms += backend.target_ms;
+                pending_timing.backend_draw_setup_ms += backend.draw_setup_ms;
+                pending_timing.backend_record_upload_ms += backend.record_upload_ms;
+                pending_timing.backend_gpu_wait_ms += backend.gpu_wait_ms;
+                pending_timing.backend_readback_ms += backend.readback_ms;
+                pending_timing.backend_cleanup_ms += backend.cleanup_ms;
+                pending_timing.backend_setup_shader_ms += backend.setup_shader_ms;
+                pending_timing.backend_setup_fixed_ms += backend.setup_fixed_ms;
+                pending_timing.backend_setup_resources_ms += backend.setup_resources_ms;
+                pending_timing.backend_setup_pipeline_ms += backend.setup_pipeline_ms;
+            };
             // PROSPER_SUBMITLOG: print the GPU-submit index periodically (at native speed, before the slow
             // render) so it can be correlated with guest-side log lines (e.g. a MsgDialog wait) to find the
             // exact submit at which a scene appears — for aiming PROSPER_RENDER_FIRST at it.
@@ -608,7 +634,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     }
                                 }
                             }
-                            if (getenv("PROSPER_RTTLOG"))
+                            if (rtt_log)
                                 fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",
                                         (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
                                         rtt_hit ? "HIT" : "miss", g_rtt.size());
@@ -1228,7 +1254,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // RTTLOG per-draw detail (render-window-only, unlike the GFXLOG firehose): enough
                     // state to diagnose a pass whose inputs HIT the RTT cache yet outputs nothing —
                     // blend factors, write mask, viewport, and each PS-sampled texture address (#319).
-                    if (getenv("PROSPER_RTTLOG")) {
+                    if (rtt_log) {
                         fprintf(stderr, "[rtt]   draw tgt=0x%llx vcount=%u nidx=%zu topo=%u mask=0x%x "
                                 "blend=%d(src=%u dst=%u) vp=%d(%.2f,%.2f %.2fx%.2f) z=%d zw=%d ps=",
                                 (unsigned long long)it.color0_base, bd.vcount, bd.indices.size(),
@@ -1280,7 +1306,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 const int      vo_n     = prosper_vo_buffer_count();
                 const int      vo_front = prosper::gpu::present_front_index();
                 const uint64_t front_va = vo_front >= 0 ? prosper_vo_buffer_addr(vo_front) : 0;
-                if (getenv("PROSPER_RTTLOG")) {
+                if (rtt_log) {
                     fprintf(stderr, "[rtt] flip state: front=%d va=0x%llx of %d registered:",
                             vo_front, (unsigned long long)front_va, vo_n);
                     for (int i = 0; i < vo_n && i < 8; i++)
@@ -1405,11 +1431,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         backend_draws, gw, gh, seed, clear_for(render_pass), true);
                     const auto backend_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
+                    const prosper::test::BackendRenderTimingStats backend_call_timing = timing_enabled
+                        ? prosper::test::backend_render_timing_stats()
+                        : prosper::test::BackendRenderTimingStats{};
                     if (timing_enabled) {
                         pending_timing.build_resources_ms +=
                             std::chrono::duration<double, std::milli>(build_done - build_start).count();
                         pending_timing.backend_ms +=
                             std::chrono::duration<double, std::milli>(backend_done - build_done).count();
+                        record_backend_timing(backend_call_timing);
                     }
                     auto pass_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(gpx));
                     if (base && !pass_pixels->empty()) {
@@ -1497,7 +1527,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
-                    if (getenv("PROSPER_RTTLOG")) {
+                    if (rtt_log) {
                         size_t nz = 0, rgb_nz = 0;
                         for (uint8_t b : rendered_pixels) nz += (b != 0);
                         for (size_t p = 0; p + 3 < rendered_pixels.size(); p += 4)
@@ -1506,7 +1536,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fprintf(stderr, "[rtt] pass target=0x%llx extent=%ux%u native=%ux%u (%zu draws) "
                                 "px_nonzero=%zu rgb_nonblack=%zu cache_size=%zu%s%s\n",
                                 (unsigned long long)base, gw, gh, native_w, native_h, pass.size(), nz, rgb_nz, g_rtt.size(),
-                                is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : ""); }
+                                is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : "");
+                        if (timing_enabled)
+                            fprintf(stderr,
+                                    "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
+                                    "total=%.2f target_setup=%.2f draw_setup=%.2f record_upload=%.2f "
+                                    "gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                                    g_this_submit, (unsigned long long)base, gw, gh, pass.size(),
+                                    backend_call_timing.total_ms(), backend_call_timing.target_ms,
+                                    backend_call_timing.draw_setup_ms,
+                                    backend_call_timing.record_upload_ms,
+                                    backend_call_timing.gpu_wait_ms, backend_call_timing.readback_ms,
+                                    backend_call_timing.cleanup_ms);
+                    }
                     // PROSPER_DUMP_DRAWSTEPS: for a pass targeting a SCANOUT buffer, re-render the pass
                     // draw-by-draw (prefix 1, prefix 2, ...) and dump each cumulative result — a one-boot
                     // bisect for "which draw of the final composite blacks the screen" (#319). Diagnostic.
@@ -1559,11 +1601,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     backend_draws, w, h, nullptr, clear_for(all), true);
                 const auto backend_done = timing_enabled
                     ? RenderClock::now() : RenderClock::time_point{};
+                const prosper::test::BackendRenderTimingStats backend_call_timing = timing_enabled
+                    ? prosper::test::backend_render_timing_stats()
+                    : prosper::test::BackendRenderTimingStats{};
                 if (timing_enabled) {
                     pending_timing.build_resources_ms +=
                         std::chrono::duration<double, std::milli>(build_done - build_start).count();
                     pending_timing.backend_ms +=
                         std::chrono::duration<double, std::milli>(backend_done - build_done).count();
+                    record_backend_timing(backend_call_timing);
                 }
                 // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
                 // composite pass that samples that address gets the scene we drew (not empty guest memory).
@@ -1572,7 +1618,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint64_t tgt = 0;
                     for (const auto& it : items) if (it.color0_base) { tgt = it.color0_base; break; }
                     if (tgt) { RttSurf& s = g_rtt[tgt]; s.rgba = selected_pixels; s.w = w; s.h = h; }
-                    if (getenv("PROSPER_RTTLOG")) { size_t nz=0;
+                    if (rtt_log) { size_t nz=0;
                         for (uint8_t byte : *selected_pixels) nz += byte != 0;
                         fprintf(stderr, "[rtt] store target=0x%llx (%zu items, color0s:", (unsigned long long)tgt, items.size());
                         for (const auto& it : items) fprintf(stderr, " 0x%llx", (unsigned long long)it.color0_base);
@@ -1630,6 +1676,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 struct TimingTotals {
                     uint64_t submits = 0, callbacks = 0;
                     double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
+                    uint64_t backend_calls = 0, backend_draws = 0;
+                    double backend_target_ms = 0, backend_draw_setup_ms = 0;
+                    double backend_record_upload_ms = 0, backend_gpu_wait_ms = 0;
+                    double backend_readback_ms = 0, backend_cleanup_ms = 0;
+                    double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
+                    double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                     uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                     uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                     uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
@@ -1646,6 +1698,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.build_resources_ms += pending_timing.build_resources_ms;
                     timing.backend_ms += pending_timing.backend_ms;
                     timing.output_copy_ms += pending_timing.output_copy_ms;
+                    timing.backend_calls += pending_timing.backend_calls;
+                    timing.backend_draws += pending_timing.backend_draws;
+                    timing.backend_target_ms += pending_timing.backend_target_ms;
+                    timing.backend_draw_setup_ms += pending_timing.backend_draw_setup_ms;
+                    timing.backend_record_upload_ms += pending_timing.backend_record_upload_ms;
+                    timing.backend_gpu_wait_ms += pending_timing.backend_gpu_wait_ms;
+                    timing.backend_readback_ms += pending_timing.backend_readback_ms;
+                    timing.backend_cleanup_ms += pending_timing.backend_cleanup_ms;
+                    timing.backend_setup_shader_ms += pending_timing.backend_setup_shader_ms;
+                    timing.backend_setup_fixed_ms += pending_timing.backend_setup_fixed_ms;
+                    timing.backend_setup_resources_ms += pending_timing.backend_setup_resources_ms;
+                    timing.backend_setup_pipeline_ms += pending_timing.backend_setup_pipeline_ms;
                     timing.textures += pending_timing.textures;
                     timing.texture_reuses += pending_timing.texture_reuses;
                     timing.persistent_hits += pending_timing.persistent_hits;
@@ -1672,6 +1736,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (unsigned long long)totals.submits, (unsigned long long)totals.callbacks,
                             totals.total_ms / nsub, totals.build_resources_ms / nsub,
                             totals.backend_ms / nsub, totals.output_copy_ms / nsub, other / nsub);
+                    const double backend_detail_ms = totals.backend_target_ms +
+                        totals.backend_draw_setup_ms + totals.backend_record_upload_ms +
+                        totals.backend_gpu_wait_ms + totals.backend_readback_ms +
+                        totals.backend_cleanup_ms;
+                    fprintf(stderr,
+                            "[render-timing] backend-submit calls=%.2f draws=%.1f avg_ms: measured=%.2f "
+                            "detail=%.2f target=%.2f draw_setup=%.2f record_upload=%.2f "
+                            "gpu_wait=%.2f readback=%.2f cleanup=%.2f other=%.2f\n",
+                            totals.backend_calls / nsub, totals.backend_draws / nsub,
+                            totals.backend_ms / nsub, backend_detail_ms / nsub,
+                            totals.backend_target_ms / nsub, totals.backend_draw_setup_ms / nsub,
+                            totals.backend_record_upload_ms / nsub, totals.backend_gpu_wait_ms / nsub,
+                            totals.backend_readback_ms / nsub, totals.backend_cleanup_ms / nsub,
+                            (totals.backend_ms - backend_detail_ms) / nsub);
+                    fprintf(stderr,
+                            "[render-timing] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
+                            "resources=%.2f pipeline=%.2f\n",
+                            totals.backend_setup_shader_ms / nsub,
+                            totals.backend_setup_fixed_ms / nsub,
+                            totals.backend_setup_resources_ms / nsub,
+                            totals.backend_setup_pipeline_ms / nsub);
                     fprintf(stderr,
                             "[render-timing] resources textures=%llu reused=%llu %.1f MiB %.2f ms/submit; "
                             "buffers=%llu %.1f MiB %.2f ms/submit\n",
@@ -1721,6 +1806,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.texture_bytes / (wn * 1024.0 * 1024.0), window.texture_ms / wn,
                             window.buffers / wn, window.buffer_bytes / (wn * 1024.0 * 1024.0),
                             window.buffer_ms / wn);
+                    const double window_backend_detail_ms = window.backend_target_ms +
+                        window.backend_draw_setup_ms + window.backend_record_upload_ms +
+                        window.backend_gpu_wait_ms + window.backend_readback_ms +
+                        window.backend_cleanup_ms;
+                    fprintf(stderr,
+                            "[render-window] backend-submit calls=%.2f draws=%.1f avg_ms: measured=%.2f "
+                            "detail=%.2f target=%.2f draw_setup=%.2f record_upload=%.2f "
+                            "gpu_wait=%.2f readback=%.2f cleanup=%.2f other=%.2f\n",
+                            window.backend_calls / wn, window.backend_draws / wn,
+                            window.backend_ms / wn, window_backend_detail_ms / wn,
+                            window.backend_target_ms / wn, window.backend_draw_setup_ms / wn,
+                            window.backend_record_upload_ms / wn, window.backend_gpu_wait_ms / wn,
+                            window.backend_readback_ms / wn, window.backend_cleanup_ms / wn,
+                            (window.backend_ms - window_backend_detail_ms) / wn);
+                    fprintf(stderr,
+                            "[render-window] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
+                            "resources=%.2f pipeline=%.2f\n",
+                            window.backend_setup_shader_ms / wn,
+                            window.backend_setup_fixed_ms / wn,
+                            window.backend_setup_resources_ms / wn,
+                            window.backend_setup_pipeline_ms / wn);
                     fprintf(stderr,
                             "[render-window] texture_cache hits=%.1f submit_reuse=%.1f misses=%.1f "
                             "invalid=%.1f validations=%.1f %.1f MiB\n",

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -138,6 +138,34 @@ inline BackendTextureUploadStats backend_texture_upload_stats() {
     return backend_texture_upload_stats_storage();
 }
 
+struct BackendRenderTimingStats {
+    uint64_t calls = 0;
+    uint64_t draws = 0;
+    double target_ms = 0;
+    double draw_setup_ms = 0;
+    double record_upload_ms = 0;
+    double gpu_wait_ms = 0;
+    double readback_ms = 0;
+    double cleanup_ms = 0;
+    double setup_shader_ms = 0;
+    double setup_fixed_ms = 0;
+    double setup_resources_ms = 0;
+    double setup_pipeline_ms = 0;
+
+    double total_ms() const {
+        return target_ms + draw_setup_ms + record_upload_ms + gpu_wait_ms + readback_ms + cleanup_ms;
+    }
+};
+
+inline BackendRenderTimingStats& backend_render_timing_stats_storage() {
+    static thread_local BackendRenderTimingStats stats;
+    return stats;
+}
+
+inline BackendRenderTimingStats backend_render_timing_stats() {
+    return backend_render_timing_stats_storage();
+}
+
 // `seed_rgba` (optional): W*H*4 RGBA8 pixels to PRELOAD the color attachment with before the draws
 // run (loadOp LOAD instead of the blue clear). This is real render-target memory semantics: a game
 // pass that draws into a target it (or an earlier submit) already rendered composites OVER that
@@ -662,6 +690,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+    if (timing_enabled) backend_render_timing_stats_storage() = {};
     std::vector<uint8_t> out;
     if (draws.empty()) return out;
     const RenderVkCtx& ctx = render_vk_ctx();
@@ -1641,6 +1670,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         auto ms = [](auto begin, auto end) {
             return std::chrono::duration<double, std::milli>(end - begin).count();
         };
+        BackendRenderTimingStats& call_timing = backend_render_timing_stats_storage();
+        call_timing.calls = 1;
+        call_timing.draws = draws.size();
+        call_timing.target_ms = ms(timing_start, timing_target_ready);
+        call_timing.draw_setup_ms = ms(timing_target_ready, timing_draws_ready);
+        call_timing.record_upload_ms = ms(timing_draws_ready, timing_recorded);
+        call_timing.gpu_wait_ms = ms(timing_recorded, timing_gpu_done);
+        call_timing.readback_ms = ms(timing_gpu_done, timing_readback_done);
+        call_timing.cleanup_ms = ms(timing_readback_done, timing_done);
+        call_timing.setup_shader_ms = setup_shader_ms;
+        call_timing.setup_fixed_ms = setup_fixed_ms;
+        call_timing.setup_resources_ms = setup_resources_ms;
+        call_timing.setup_pipeline_ms = setup_pipeline_ms;
         struct TimingTotals {
             uint64_t calls = 0, draws = 0;
             uint64_t texture_references = 0, texture_uploads = 0, texture_upload_bytes = 0;
@@ -1659,16 +1701,16 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             timing.persistent_hits += texture_stats.persistent_hits;
             timing.persistent_misses += texture_stats.persistent_misses;
             timing.persistent_cached_bytes = texture_stats.persistent_cached_bytes;
-            timing.target += ms(timing_start, timing_target_ready);
-            timing.draw_setup += ms(timing_target_ready, timing_draws_ready);
-            timing.record += ms(timing_draws_ready, timing_recorded);
-            timing.gpu_wait += ms(timing_recorded, timing_gpu_done);
-            timing.readback += ms(timing_gpu_done, timing_readback_done);
-            timing.cleanup += ms(timing_readback_done, timing_done);
-            timing.setup_shader += setup_shader_ms;
-            timing.setup_fixed += setup_fixed_ms;
-            timing.setup_resources += setup_resources_ms;
-            timing.setup_pipeline += setup_pipeline_ms;
+            timing.target += call_timing.target_ms;
+            timing.draw_setup += call_timing.draw_setup_ms;
+            timing.record += call_timing.record_upload_ms;
+            timing.gpu_wait += call_timing.gpu_wait_ms;
+            timing.readback += call_timing.readback_ms;
+            timing.cleanup += call_timing.cleanup_ms;
+            timing.setup_shader += call_timing.setup_shader_ms;
+            timing.setup_fixed += call_timing.setup_fixed_ms;
+            timing.setup_resources += call_timing.setup_resources_ms;
+            timing.setup_pipeline += call_timing.setup_pipeline_ms;
         };
         accumulate(totals);
         accumulate(window);

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -8,6 +8,7 @@
 #include "../src/gpu/render_state.hpp"
 #include "render_runner.h"
 #include <cstdio>
+#include <cstdlib>
 #include <cstdint>
 #include <vector>
 
@@ -19,6 +20,11 @@ static int fails = 0;
 
 int main() {
     printf("== test_multidraw_render ==\n");
+#ifdef _WIN32
+    _putenv_s("PROSPER_RENDER_TIMING", "1");
+#else
+    setenv("PROSPER_RENDER_TIMING", "1", 1);
+#endif
     const uint32_t W = 64, H = 64;
 
     // Known-good fullscreen-triangle vertex shader (SPIR-V), shared by both draws.
@@ -65,6 +71,15 @@ int main() {
             CHECK(c[0] > 0xC0 && c[1] > 0xC0 && c[2] < 0x40,
                   "two draws composite into ONE cleared-once framebuffer -> YELLOW center (red+green)");
         }
+        const prosper::test::BackendRenderTimingStats timing =
+            prosper::test::backend_render_timing_stats();
+        CHECK(timing.calls == 1 && timing.draws == 2,
+              "backend timing publishes the completed call and draw count");
+        CHECK(timing.total_ms() > 0 && timing.draw_setup_ms > 0,
+              "backend timing publishes a non-empty phase breakdown");
+        CHECK(timing.draw_setup_ms + 0.001 >= timing.setup_shader_ms + timing.setup_fixed_ms +
+                  timing.setup_resources_ms + timing.setup_pipeline_ms,
+              "draw-setup subphases fit inside the backend draw-setup phase");
     }
 
     // A guest depth/stencil surface survives renderer calls. The first call writes stencil=2 with no


### PR DESCRIPTION
## Summary\n- publish a structured timing record for each completed Vulkan backend call\n- aggregate every target render into the frontend's exact ordered-submit window\n- report submit-aligned target, draw setup, upload/record, fence wait, readback, cleanup, and draw-setup subphases\n- add per-target phase costs to the existing PROSPER_RTTLOG diagnostic\n- document the tool and the measured Dead Cells post-parse frame budget\n\n## Dead Cells evidence\nA 180-second native Windows fresh-save/full-render route reached the 373-draw, 8-dispatch, 4-span workload. Its four callbacks render 10 target groups per submit:\n\n- frontend Vulkan wall time: 90.09 ms\n- detailed phase sum: 75.28 ms\n- fence wait: 33.12 ms\n- draw setup: 26.54 ms (pipeline 12.89 ms; descriptor/resources 8.46 ms)\n- readback: 9.43 ms\n- record/upload: 4.59 ms\n- target setup + cleanup: 1.59 ms\n- remaining wrapper time: 14.81 ms\n\nMemory remained bounded near 1.81 GiB private / 3.78 GiB working set after the heavy transition. A native Windows five-frame PROSPER_RTTLOG=1 smoke verified target address/dimensions/draws and phase costs are emitted together.\n\n## Validation\n- native Windows prosper-app build\n- native Windows 180-second Dead Cells route\n- native Windows five-frame per-target timing smoke\n- Linux/Vulkan: 97/97 tests\n- 	est_multidraw_render asserts the published call/draw count and phase structure\n\nNo rendering behavior changes, so screenshot baselines are unaffected.\n\nAdvances #702.