### PR TITLE
tools(renderer): add lightweight target timing

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -188,10 +188,11 @@ lines at renderer submit N, so boot textures do not consume the cap before the s
 line identifies local reuse, persistent hit/miss/invalidation, RTT sourcing, or an uncached decode. The
 aggregate output also reports retained RTT bytes, decode-scratch capacity, and validation-scratch capacity;
 use those figures before treating a process-memory increase as an unbounded cache.
-Combine timing with `PROSPER_RTTLOG=1` to print one `[rtt-timing]` line per rendered target group. It includes
-the submit number, target address, dimensions, draw count, and that target's exact Vulkan phase breakdown.
-Use `PROSPER_RTTLOG_MIN_SUBMIT=N` and `PROSPER_RTTLOG_MAX_SUBMIT=N` to bound the diagnostic window; unrestricted
-logging can materially slow a title and perturb wall-clock input routes.
+Set `PROSPER_RTT_TIMING=1` with timing enabled to print one lightweight `[rtt-timing]` line per rendered target
+group. It includes the submit number, target address, dimensions, draw count, and that target's exact Vulkan
+phase breakdown without scanning pixels or printing every draw. `PROSPER_RTTLOG=1` includes the same line plus
+the more expensive visual RTT diagnostics. Use `PROSPER_RTTLOG_MIN_SUBMIT=N` and
+`PROSPER_RTTLOG_MAX_SUBMIT=N` to bound either mode; unrestricted output can still perturb wall-clock routes.
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -345,11 +345,12 @@ wall-time counters. The new `backend-submit` lines report calls and draws per su
 setup, record/upload, fence wait, readback, cleanup, and the shader/fixed/resource/pipeline draw-setup split.
 They also print the frontend-measured backend duration, the detailed phase sum, and the unattributed remainder.
 This is the authoritative view for choosing the next backend optimization; the legacy per-call lines remain
-useful for spotting an individually slow render target. Combining `PROSPER_RENDER_TIMING=1` with
-`PROSPER_RTTLOG=1` adds a `[rtt-timing]` record for each target group with its submit, address, dimensions,
-draw count, and exact phase costs, allowing dependency logs and backend costs to be correlated directly. Bound
-verbose output with `PROSPER_RTTLOG_MIN_SUBMIT` and `PROSPER_RTTLOG_MAX_SUBMIT`; an unrestricted Dead Cells run
-dropped the title loop from about 20 FPS to 13-14 FPS and caused its wall-clock input route to miss the menu.
+useful for spotting an individually slow render target. `PROSPER_RTT_TIMING=1` adds a lightweight
+`[rtt-timing]` record for each target group with its submit, address, dimensions, draw count, and exact phase
+costs. `PROSPER_RTTLOG=1` retains its visual pixel/draw diagnostics and also emits the timing record. Bound both
+modes with `PROSPER_RTTLOG_MIN_SUBMIT` and `PROSPER_RTTLOG_MAX_SUBMIT`. The full visual mode scans rendered
+pixels and dropped one Dead Cells title loop from about 20 FPS to 13-14 FPS, causing its wall-clock input route
+to miss the menu; use the lightweight mode for performance attribution.
 
 A 180-second native Windows fresh-save Dead Cells run reached the post-parse workload with 373 draws, eight
 dispatches, and four graphics spans. Those spans rendered ten target groups per submit. The aligned backend

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -210,8 +210,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 ? std::max(0, atoi(getenv("PROSPER_RTTLOG_MIN_SUBMIT"))) : 0;
             static const int g_rttlog_max_submit = getenv("PROSPER_RTTLOG_MAX_SUBMIT")
                 ? std::max(0, atoi(getenv("PROSPER_RTTLOG_MAX_SUBMIT"))) : INT_MAX;
-            const bool rtt_log = getenv("PROSPER_RTTLOG") &&
+            const bool rtt_log_in_range =
                 g_this_submit >= g_rttlog_min_submit && g_this_submit <= g_rttlog_max_submit;
+            const bool rtt_log = getenv("PROSPER_RTTLOG") && rtt_log_in_range;
             using RenderClock = std::chrono::steady_clock;
             struct RenderTiming {
                 uint64_t callbacks = 0;
@@ -231,6 +232,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             };
             static thread_local RenderTiming pending_timing;
             const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+            const bool rtt_timing_log = timing_enabled && rtt_log_in_range &&
+                (rtt_log || getenv("PROSPER_RTT_TIMING"));
             if (timing_enabled && phase.first_span) pending_timing = {};
             const auto callback_timing_start = timing_enabled
                 ? RenderClock::now() : RenderClock::time_point{};
@@ -1527,6 +1530,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
+                    if (rtt_timing_log)
+                        fprintf(stderr,
+                                "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
+                                "total=%.2f target_setup=%.2f draw_setup=%.2f record_upload=%.2f "
+                                "gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                                g_this_submit, (unsigned long long)base, gw, gh, pass.size(),
+                                backend_call_timing.total_ms(), backend_call_timing.target_ms,
+                                backend_call_timing.draw_setup_ms,
+                                backend_call_timing.record_upload_ms,
+                                backend_call_timing.gpu_wait_ms, backend_call_timing.readback_ms,
+                                backend_call_timing.cleanup_ms);
                     if (rtt_log) {
                         size_t nz = 0, rgb_nz = 0;
                         for (uint8_t b : rendered_pixels) nz += (b != 0);
@@ -1537,17 +1551,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 "px_nonzero=%zu rgb_nonblack=%zu cache_size=%zu%s%s\n",
                                 (unsigned long long)base, gw, gh, native_w, native_h, pass.size(), nz, rgb_nz, g_rtt.size(),
                                 is_vo ? " SCANOUT" : "", base && base == front_va ? " FRONT" : "");
-                        if (timing_enabled)
-                            fprintf(stderr,
-                                    "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
-                                    "total=%.2f target_setup=%.2f draw_setup=%.2f record_upload=%.2f "
-                                    "gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
-                                    g_this_submit, (unsigned long long)base, gw, gh, pass.size(),
-                                    backend_call_timing.total_ms(), backend_call_timing.target_ms,
-                                    backend_call_timing.draw_setup_ms,
-                                    backend_call_timing.record_upload_ms,
-                                    backend_call_timing.gpu_wait_ms, backend_call_timing.readback_ms,
-                                    backend_call_timing.cleanup_ms);
                     }
                     // PROSPER_DUMP_DRAWSTEPS: for a pass targeting a SCANOUT buffer, re-render the pass
                     // draw-by-draw (prefix 1, prefix 2, ...) and dump each cumulative result — a one-boot


### PR DESCRIPTION
## Summary\n- add PROSPER_RTT_TIMING=1 for per-target Vulkan timing without visual RTT pixel scans or per-draw logs\n- retain PROSPER_RTTLOG=1 as the full visual diagnostic\n- apply the existing submit-range bounds to both modes\n- document the performance-perturbation caveat and recommended workflow\n\n## Why\nFull PROSPER_RTTLOG materially perturbed Dead Cells: its pixel scans and verbose output dropped the title loop from about 20 FPS to 13-14 FPS and caused a wall-clock pad route to miss the menu. In the heavy scene, per-target phase sums were roughly twice the non-RTT submit-aligned window, so those absolute values were not trustworthy.\n\n## Validation\n- native Windows prosper-app build\n- WSL/Linux prosper_live_renderer build\n- native Windows five-frame smoke with bounds 3..3: exit 0, exactly one [rtt-timing] line, zero visual [rtt] lines\n\nNo rendering behavior changes.\n\nAdvances #702.