### PR TITLE
Fix recycled UE fence generations beyond thread caches

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -454,6 +454,41 @@ static bool mb3_freelist_guard() {
                                return !e || strtol(e, nullptr, 0) != 0; }();
     return v;
 }
+// A consumed-marker label is intentionally uninitialized when its DmaData packet is built. The
+// packet-exact snapshot distinguishes that harmless residue from a target whose 0x20-byte block was
+// freed and reused before this old packet executed. Content alone cannot do that: a reused block may
+// also begin with 0/1, while a live uninitialized label may contain an arbitrary pointer residue.
+static bool dma_build_pre_changed(const Pm4Command& c, uint64_t pre, uint64_t* build_pre) {
+    if (!c.dd_build_pre_valid || c.dd_build_pre == pre) return false;
+    if (build_pre) *build_pre = c.dd_build_pre;
+    return true;
+}
+static void stale_dma_change_report(uint64_t addr, uint64_t build_pre, uint64_t pre, uint64_t pkt) {
+    static std::atomic<uint32_t> n{0};
+    if (n.fetch_add(1, std::memory_order_relaxed) < 256)
+        fprintf(stderr, "[agc] DMA-GENERATION-CHANGED-STALE-SUPPRESS [0x%llx] build-pre=0x%llx "
+                        "exec-pre=0x%llx pkt=0x%llx t=%llums\n",
+                (unsigned long long)addr, (unsigned long long)build_pre,
+                (unsigned long long)pre, (unsigned long long)pkt,
+                (unsigned long long)now_ms());
+}
+static bool stale_release_generation(const Pm4Command& c, uint64_t pre) {
+    if (!c.rel_build_pre_valid || c.rel_data_sel != 1 || c.rel_value != 1 ||
+        !label_is_consumed_marker(c.rel_addr)) return false;
+    uint64_t initialized = c.rel_build_pre & 0xffffffff00000000ull;
+    uint64_t signaled = initialized | 1ull;
+    if (pre == initialized || pre == signaled) return false;
+    static std::atomic<uint32_t> n{0};
+    if (n.fetch_add(1, std::memory_order_relaxed) < 256)
+        fprintf(stderr, "[agc] REL-GENERATION-CHANGED-STALE-SUPPRESS [0x%llx] "
+                        "build-pre=0x%llx expected-init=0x%llx exec-pre=0x%llx "
+                        "pkt=0x%llx t=%llums\n",
+                (unsigned long long)c.rel_addr, (unsigned long long)c.rel_build_pre,
+                (unsigned long long)initialized, (unsigned long long)pre,
+                (unsigned long long)pkt_addr(c), (unsigned long long)now_ms());
+    label_hist_rel_free(c.rel_addr, 0);
+    return true;
+}
 static void mb3_freelist_report(const char* kind, uint64_t addr, uint64_t pre,
                                 const Mb3FreelistMatch* match, bool debt) {
     static std::atomic<uint32_t> n{0};
@@ -564,6 +599,7 @@ static void honor_eop_write(const Pm4Command& c) {
                   // target-region trigger caught only benign fences and burned the report cap.
                   // Trigger on pointer-like PRE-CONTENT only.)
                   uint64_t pre = 0; memcpy(&pre, dst, sizeof pre);
+                  if (stale_release_generation(c, pre)) return;
                   // #312 — label free-state write-after-free guard (default OFF; A/B instrumentation,
                   // see waf_guard). Keys on tracked lifecycle state; suppresses genuine WAFs but does
                   // NOT close the gate (the dominant residual is GPU-side-undetectable — see waf_guard).
@@ -734,20 +770,28 @@ static void honor_dma_data(const Pm4Command& c) {
     }
     uint32_t v32 = (uint32_t)c.dd_src;
     uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;
+    uint64_t pre_dma = peek_qword(c.dd_dst);   // #312: pre-content for generation/membership checks
     // The exact consumed-marker initializer is a 4-byte immediate zero. Test allocator membership
     // BEFORE touching it: memset(0) would erase a free node's NextFreeBlock and make the later fence
     // indistinguishable from a live initialized label (the session-11 residual).
     if (mb3_freelist_guard() && c.dd_bytes == 4 && v32 == 0 &&
         label_is_consumed_marker(c.dd_dst)) {
+        uint64_t build_pre = 0;
+        bool generation_changed = dma_build_pre_changed(c, pre_dma, &build_pre);
+        if (generation_changed) {
+            // Pair a debt with the skipped init so its following ReleaseMem cannot overwrite the
+            // new owner either. This is the allocated/reused sibling of a free-membership hit.
+            label_hist_dma_free(c.dd_dst, 0);
+            stale_dma_change_report(c.dd_dst, build_pre, pre_dma, pkt_addr(c));
+            return;
+        }
         Mb3FreelistMatch match{};
         if (mb3_freelist_contains_stable(c.dd_dst, &match)) {
-            uint64_t pre = peek_qword(c.dd_dst);
             label_hist_dma_free(c.dd_dst, match.pool_base);
-            mb3_freelist_report("DMA", c.dd_dst, pre, &match, false);
+            mb3_freelist_report("DMA", c.dd_dst, pre_dma, &match, false);
             return;
         }
     }
-    uint64_t pre_dma = peek_qword(c.dd_dst);   // #312: pre-content for the label event ring
     forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, pkt_addr(c));   // #312 session-10 tripwire (log-only)
     if (v32 == 0) {
         memset(dst, 0, c.dd_bytes);

--- a/prosper/src/gpu/mb3_freelist.cpp
+++ b/prosper/src/gpu/mb3_freelist.cpp
@@ -21,8 +21,15 @@ namespace {
 // the pthread TLS hot path; an overflow only reduces guard coverage and cannot change guest state.
 constexpr uint32_t kMaxPoolCandidates = 256;
 constexpr uint32_t kMaxChainHops = 4096;
+constexpr uint64_t kMb3PageSize = 0x10000;
+constexpr uint32_t kMb3BlockSize = 0x20;
+// FFreeBlock { uint16 BlockSizeShifted; uint8 PoolIndex; uint8 Canary; ... } for pool idx=1.
+// DOLL's UE build uses 0xe3 (confirmed at eboot+0x230ca5c); newer UE sources use 0xe7.
+constexpr uint32_t kMb3Idx1FreeTagE3 = 0xe3010002;
+constexpr uint32_t kMb3Idx1FreeTagE7 = 0xe7010002;
 std::atomic<uint64_t> g_pool_candidates[kMaxPoolCandidates];
 std::atomic<uint32_t> g_pool_candidate_count{0};
+std::atomic<uint64_t> g_global_recycler_bin{0};
 
 bool safe_read(uint64_t addr, void* out, uint32_t bytes) {
 #if defined(__linux__)
@@ -65,6 +72,84 @@ bool scan_chain(uint64_t head, uint64_t block, uint8_t list, uint64_t pool_base,
     return false;
 }
 
+bool central_scan_enabled() {
+    static const bool enabled = [] {
+        const char* e = getenv("PROSPER_MB3_CENTRAL_SCAN");
+        return !e || strtol(e, nullptr, 0) != 0;
+    }();
+    return enabled;
+}
+
+bool scan_central_run(uint64_t block, Mb3FreelistMatch* match) {
+    // A central FFreeBlock is an in-place header at the low end of a contiguous free run. Scanning
+    // one 64 KiB MB3 page avoids depending on the title's FPoolInfoSmall table address/layout. The
+    // exact pool/canary tag and the bounded run containing `block` make unrelated data an extremely
+    // unlikely match. safe_read keeps a concurrent decommit from faulting the GPU worker.
+    const uint64_t page_base = block & ~(kMb3PageSize - 1);
+    const uint32_t block_off = (uint32_t)(block - page_base);
+    alignas(64) static thread_local uint8_t page[kMb3PageSize];
+    if (!safe_read(page_base, page, sizeof page)) return false;
+
+    for (uint32_t off = 0; off <= kMb3PageSize - 12; off += kMb3BlockSize) {
+        uint32_t tag = 0, num_free = 0;
+        memcpy(&tag, page + off, sizeof tag);
+        if (tag != kMb3Idx1FreeTagE3 && tag != kMb3Idx1FreeTagE7) continue;
+        memcpy(&num_free, page + off + 4, sizeof num_free);
+        const uint32_t max_run = (uint32_t)((kMb3PageSize - off) / kMb3BlockSize);
+        if (!num_free || num_free > max_run) continue;
+        const uint32_t run_end = off + num_free * kMb3BlockSize;
+        if (block_off >= off && block_off < run_end) {
+            if (match) *match = {page_base, page_base + off,
+                                 (block_off - off) / kMb3BlockSize, 11};
+            return true;
+        }
+    }
+    return false;
+}
+
+uint64_t discover_global_recycler_bin() {
+    // UE's compiled bundle-spill path scales PoolIndex by 0x40 immediately before a RIP-relative
+    // LEA of the eight-slot recycler table. Locate that instruction shape once instead of baking in
+    // DOLL's eboot address. The signature includes the following per-thread count transfer and slot
+    // probe; the displacement itself is the only wildcard.
+    static const uint64_t discovered = [] {
+        constexpr uint64_t kImageBase = 0x400000000ull;
+        constexpr uint64_t kScanBytes = 0x04000000ull;
+        constexpr uint32_t kChunk = 0x10000;
+        constexpr uint32_t kOverlap = 0x40;
+        static const uint8_t prefix[] = {0xc1, 0xe0, 0x06, 0x4c, 0x8d, 0x0d};
+        static const uint8_t suffix[] = {
+            0x41, 0xc1, 0xe0, 0x05, 0x4a, 0x8d, 0x74, 0x01, 0x18,
+            0x46, 0x8b, 0x44, 0x01, 0x18, 0x44, 0x89, 0x47, 0x08,
+            0x4d, 0x8d, 0x04, 0x01, 0x4a, 0x83, 0x3c, 0x08, 0x00,
+        };
+        alignas(64) static uint8_t code[kChunk];
+        for (uint64_t chunk_addr = kImageBase;
+             chunk_addr < kImageBase + kScanBytes; chunk_addr += kChunk - kOverlap) {
+            if (!safe_read(chunk_addr, code, sizeof code)) break;
+            constexpr uint32_t kPatternBytes = sizeof prefix + 4 + sizeof suffix;
+            for (uint32_t off = 0; off + kPatternBytes <= kChunk; ++off) {
+                if (memcmp(code + off, prefix, sizeof prefix) ||
+                    memcmp(code + off + sizeof prefix + 4, suffix, sizeof suffix)) continue;
+                int32_t disp = 0;
+                memcpy(&disp, code + off + sizeof prefix, sizeof disp);
+                uint64_t signature = chunk_addr + off;
+                uint64_t table = signature + sizeof prefix + 4 + (int64_t)disp;
+                uint8_t slots[64] = {};
+                if (table < kImageBase || table >= 0x4c0000000ull || (table & 0x3full) ||
+                    !safe_read(table + 0x40, slots, sizeof slots)) continue;
+                fprintf(stderr, "[agc] MB3 global recycler discovered: table=0x%llx "
+                                "idx1=0x%llx signature=0x%llx\n",
+                        (unsigned long long)table, (unsigned long long)(table + 0x40),
+                        (unsigned long long)signature);
+                return (uint64_t)(table + 0x40); // size-class idx=1 (Malloc(0x20))
+            }
+        }
+        return uint64_t{0};
+    }();
+    return discovered;
+}
+
 bool scan_once(uint64_t block, Mb3FreelistMatch* match) {
     if (!plausible_node(block)) return false;
     uint32_t count = g_pool_candidate_count.load(std::memory_order_acquire);
@@ -80,6 +165,27 @@ bool scan_once(uint64_t block, Mb3FreelistMatch* match) {
         if (scan_chain(bin[0], block, 1, base, match) ||
             scan_chain(bin[2], block, 2, base, match)) return true;
     }
+
+    uint64_t recycler = g_global_recycler_bin.load(std::memory_order_acquire);
+    if (!recycler) {
+        // Diagnostic override used to validate a newly recovered allocator layout before making
+        // automatic discovery production behavior. The value is the exact idx=1 eight-slot bin,
+        // not the beginning of the all-size-class recycler table.
+        static const uint64_t env_recycler = [] {
+            const char* e = getenv("PROSPER_MB3_GLOBAL_BIN");
+            return e ? strtoull(e, nullptr, 0) : 0ull;
+        }();
+        recycler = env_recycler;
+    }
+    if (!recycler) recycler = discover_global_recycler_bin();
+    if (recycler >= 0x10000 && !(recycler & 7ull)) {
+        for (uint8_t slot = 0; slot < 8; ++slot) {
+            uint64_t head = 0;
+            if (!safe_read(recycler + (uint64_t)slot * 8, &head, sizeof head)) break;
+            if (scan_chain(head, block, (uint8_t)(3 + slot), recycler, match)) return true;
+        }
+    }
+    if (central_scan_enabled() && scan_central_run(block, match)) return true;
     return false;
 }
 
@@ -107,6 +213,11 @@ void mb3_note_tls_pool_candidate(uint64_t base) {
         g_pool_candidates[slot].store(base, std::memory_order_release);
 }
 
+void mb3_note_global_recycler_bin(uint64_t base) {
+    if (base < 0x10000 || (base & 7ull)) return;
+    g_global_recycler_bin.store(base, std::memory_order_release);
+}
+
 bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match) {
     Mb3FreelistMatch first{};
     if (!scan_once(block, &first)) return false;
@@ -120,6 +231,7 @@ bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match) {
 void mb3_reset_pool_candidates_for_test() {
     for (auto& base : g_pool_candidates) base.store(0, std::memory_order_relaxed);
     g_pool_candidate_count.store(0, std::memory_order_release);
+    g_global_recycler_bin.store(0, std::memory_order_release);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/mb3_freelist.hpp
+++ b/prosper/src/gpu/mb3_freelist.hpp
@@ -9,7 +9,7 @@ struct Mb3FreelistMatch {
     uint64_t pool_base = 0;
     uint64_t head = 0;
     uint32_t hops = 0;
-    uint8_t list = 0;          // 1 = primary head, 2 = secondary head
+    uint8_t list = 0;          // 1/2 = TLS; 3..10 = global recycler; 11 = central free run
 };
 
 // MallocBinned3 keeps one 64 KiB-aligned per-thread pool-array in pthread TLS. The libkernel HLE
@@ -18,9 +18,14 @@ struct Mb3FreelistMatch {
 void mb3_note_tls_pool_candidate(uint64_t base);
 bool mb3_tls_tracking_enabled();
 
-// Is `block` currently linked into size-class idx=1 (Malloc(0x20)) in any learned per-thread cache?
-// A positive result is observed twice so a concurrent allocator pop cannot turn a stale first read
-// into a false "free" verdict. False negatives merely leave the existing #505/#510 guards in place.
+// A full per-thread bundle is transferred into one of eight lock-free global recycler slots. The
+// bin address is learned from the guest allocator code; registering it extends membership beyond
+// the two per-thread roots without trapping the allocator's hot free path.
+void mb3_note_global_recycler_bin(uint64_t base);
+
+// Is `block` currently free in size-class idx=1 (Malloc(0x20))? This checks the learned per-thread
+// and global bundle chains plus the allocator's in-page central FFreeBlock runs. A positive result is
+// observed twice so a concurrent allocator pop cannot turn a stale first read into a false verdict.
 bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match = nullptr);
 
 // Test isolation for the process-global candidate registry.

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -100,6 +100,10 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     if (npl >= 2) c.rel_addr = lo_hi(pl);
                     if (npl >= 3) c.rel_data_sel = pl[2];
                     if (npl >= 5) { c.rel_value = (uint64_t)pl[3] | ((uint64_t)pl[4] << 32); c.rel_value_valid = true; }
+                    if (npl >= 8) {
+                        c.rel_build_pre = lo_hi(pl + 6);
+                        c.rel_build_pre_valid = true;
+                    }
                     break;
                 case R_FLIP:
                     c.kind = K::Flip;
@@ -162,7 +166,7 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     break;
                 case R_DMA_DATA:
                     // sceAgcDcbDmaData / sceAgcAcbDmaData (#312): CP-DMA. payload: [0..1]=dst lo/hi,
-                    // [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels (see agc_dcb_dma_data).
+                    // [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels, [6..7]=build-time dst qword.
                     c.kind = K::DmaData;
                     if (npl >= 6) {
                         c.dd_dst   = lo_hi(pl);
@@ -170,6 +174,10 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                         c.dd_bytes = pl[4];
                         c.dd_sels  = pl[5];
                         c.dd_valid = true;
+                    }
+                    if (npl >= 8) {
+                        c.dd_build_pre = lo_hi(pl + 6);
+                        c.dd_build_pre_valid = true;
                     }
                     break;
                 case R_SET_PRED:

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -112,6 +112,8 @@ struct Pm4Command {
     uint32_t rel_data_sel = 0;           // ReleaseMem: DATA_SEL (1/2/3)
     uint64_t rel_value = 0;              // ReleaseMem: 64-bit fence value (for data_sel 1/2)
     bool rel_value_valid = false;        // ReleaseMem: packet was long enough to carry rel_value
+    uint64_t rel_build_pre = 0;          // ReleaseMem: destination qword when this packet was built
+    bool rel_build_pre_valid = false;    // ReleaseMem: extended packet carried the build snapshot
 
     // WaitRegMem — laid out by hle_agc.cpp agc_dcb_wait_reg_mem per sceAgcDcbWaitRegMem(buf, size,
     // compare_func, op, cache_policy, address, reference, mask, poll_cycles) (Kyty
@@ -156,12 +158,15 @@ struct Pm4Command {
     // stack arg9 = byte count. DOLL's RHI translate loop emits DmaData(src=0, dst=<per-chunk fence
     // label>, 4 bytes) per segment — the GPU-side label INIT (label := 0) of the consumed-marker
     // protocol whose completion leg is ReleaseMem(label <- 1). Packet payload:
-    // [0..1]=dst lo/hi, [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels (a2 | a3<<8).
+    // [0..1]=dst lo/hi, [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels (a2 | a3<<8),
+    // [6..7]=the destination qword captured at build time (stale-generation identity, #312).
     uint64_t dd_dst = 0;                 // DmaData: destination address
     uint64_t dd_src = 0;                 // DmaData: source address OR immediate value
     uint32_t dd_bytes = 0;               // DmaData: byte count (0 = unrecovered -> not executed)
     uint32_t dd_sels = 0;                // DmaData: raw selector args (a2 | a3<<8)
     bool     dd_valid = false;           // DmaData: payload carried the full operand set
+    uint64_t dd_build_pre = 0;           // DmaData: destination qword when this exact packet was built
+    bool     dd_build_pre_valid = false; // DmaData: extended packet carried the build snapshot
 
     uint32_t flip_handle = 0;            // Flip: sceVideoOut handle
     int32_t  flip_bufidx = -1;           // Flip: display buffer index (-1 = not decoded)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -361,9 +361,17 @@ HLE(agc_cb_nop) {  // (dcb, num_dwords, ...)
 //    "free an unrecognized block 0x1000000001" / 0x20015f00 freelist-pop fatals.
 // numBytes is stack arg9. The import ABI bridge forwards args 7-9 as normal fixed parameters on
 // Windows and on Linux's guest-FS path; no compiler-frame decoding is involved (#672).
-// Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=srcOrImm lo/hi, [5]=numBytes, [6]=sels.
+// Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=srcOrImm lo/hi, [5]=numBytes, [6]=sels,
+// [7..8]=the destination qword when this exact packet was built (#312 generation identity).
 // CONFIDENCE: HIGH on a4=dst/a1=srcOrImm (malloc-destination callsite + patcher names + protocol);
 // MED on the selector args (recorded raw; the executor only honors the small-immediate form).
+static uint64_t label_build_pre(uint64_t dst, uint64_t num_bytes) {
+    uint64_t pre = 0;
+    if (num_bytes <= 8 && dst >= 0x10000 && !(dst & 3) && gpu::guest_readable(dst, sizeof pre))
+        memcpy(&pre, (const void*)(uintptr_t)dst, sizeof pre);
+    return pre;
+}
+
 HLE9(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, ..., stack9=numBytes)
     uint64_t num_bytes = a8 <= 0x10000000ull ? a8 : 0;
     static std::atomic<uint64_t> g_dma_n{0};
@@ -374,12 +382,16 @@ HLE9(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, 
                     (unsigned long long)k, (unsigned long long)a4, (unsigned long long)a1,
                     (unsigned long long)num_bytes, (unsigned long long)a2, (unsigned long long)a3);
     }
-    uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DMA_DATA, &cmd)) return 0;
+    uint32_t* cmd; if (!begin_packet(a0, 9, IT_NOP, R_DMA_DATA, &cmd)) return 0;
     cmd[1] = (uint32_t)(a4 & 0xffffffffu); cmd[2] = (uint32_t)(a4 >> 32u);
     cmd[3] = (uint32_t)(a1 & 0xffffffffu); cmd[4] = (uint32_t)(a1 >> 32u);
     cmd[5] = (uint32_t)num_bytes;
     cmd[6] = (uint32_t)((a2 & 0xffu) | ((a3 & 0xffu) << 8));
-    if (num_bytes <= 8) prosper_label_hist_dma_built(a4, a0, (uint32_t)a1, 1);   // #312 (label-init form)
+    uint64_t build_pre = label_build_pre(a4, num_bytes);
+    cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
+    if (num_bytes <= 8) {
+        prosper_label_hist_dma_built(a4, a0, (uint32_t)a1, 1);                  // #312 label-init form
+    }
     return (uint64_t)(uintptr_t)cmd;
 }
 // sceAgcAcbDmaData (-RnpfpxIhec) — the async-compute-queue sibling. Same operation, shifted ABI
@@ -390,12 +402,16 @@ HLE9(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, 
 HLE9(agc_acb_dma_data) {  // (acb, srcSel?, dstSel?, dst, ?, ?, stack7=srcOrImm, stack8=numBytes)
     uint64_t src_imm = a6, num_bytes = a7;
     if (num_bytes > 0x10000000ull) num_bytes = 0;
-    uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_DMA_DATA, &cmd)) return 0;
+    uint32_t* cmd; if (!begin_packet(a0, 9, IT_NOP, R_DMA_DATA, &cmd)) return 0;
     cmd[1] = (uint32_t)(a3 & 0xffffffffu); cmd[2] = (uint32_t)(a3 >> 32u);
     cmd[3] = (uint32_t)(src_imm & 0xffffffffu); cmd[4] = (uint32_t)(src_imm >> 32u);
     cmd[5] = (uint32_t)num_bytes;
     cmd[6] = (uint32_t)((a1 & 0xffu) | ((a2 & 0xffu) << 8));
-    if (num_bytes <= 8) prosper_label_hist_dma_built(a3, a0, (uint32_t)src_imm, 2);   // #312
+    uint64_t build_pre = label_build_pre(a3, num_bytes);
+    cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
+    if (num_bytes <= 8) {
+        prosper_label_hist_dma_built(a3, a0, (uint32_t)src_imm, 2);              // #312
+    }
     return (uint64_t)(uintptr_t)cmd;
 }
 // sceAgcDmaDataPatchSetDstAddressOrOffset (IxYiarKlXxM) / ...SetSrcAddressOrOffsetOrImmediate
@@ -405,6 +421,11 @@ HLE(agc_patch_dma_data_dst) {  // (cmd, address)
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     if (!patch_check(cmd, R_DMA_DATA, "DmaDataPatchSetDst")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    uint32_t len = ((cmd[0] >> 16) & 0x3fffu) + 2;
+    if (len >= 9) {
+        uint64_t build_pre = label_build_pre(a1, cmd[5]);
+        cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
+    }
     return 0;
 }
 HLE(agc_patch_dma_data_src) {  // (cmd, addressOrImmediate)
@@ -496,11 +517,13 @@ HLE9(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, ca
     // into the packet so the CommandProcessor performs the completion write at SUBMIT time (correct
     // end-of-pipe timing — our GPU folds synchronously, so submit == pipe drain). CONFIDENCE: HIGH — the
     // arg positions are fixed by the AGC ABI; a5-as-label was independently confirmed (WaitRegMem polls it).
-    uint32_t* cmd; if (!begin_packet(a0, 7, IT_NOP, R_RELEASE_MEM, &cmd)) return 0;
+    uint32_t* cmd; if (!begin_packet(a0, 9, IT_NOP, R_RELEASE_MEM, &cmd)) return 0;
     cmd[1] = (uint32_t)(a5 & 0xffffffffu); cmd[2] = (uint32_t)(a5 >> 32u);
     cmd[3] = (uint32_t)data_sel;
     cmd[4] = (uint32_t)(data & 0xffffffffu); cmd[5] = (uint32_t)(data >> 32u);
     cmd[6] = (uint32_t)a1;
+    uint64_t build_pre = label_build_pre(a5, data_sel == 1 ? 4 : 8);
+    cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
     if (data_sel == 1) {
         prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a5);   // #312 discriminator
         prosper_label_hist_rel_built(a5, a0);                         // #312 protocol history
@@ -1281,6 +1304,11 @@ HLE(agc_patch_release_mem_addr) {  // 0fWWK5uG9rQ (cmd, address): ReleaseMem pay
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
     if (!patch_check(cmd, R_RELEASE_MEM, "ReleaseMemPatchAddress")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+    uint32_t len = ((cmd[0] >> 16) & 0x3fffu) + 2;
+    if (len >= 9) {
+        uint64_t build_pre = label_build_pre(a1, cmd[3] == 1 ? 4 : 8);
+        cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
+    }
     prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build
     return 0;
 }

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -125,10 +125,10 @@ int main() {
         release(S, 0x28, 0, 1, 0, A, 2, 1, 0);
         waitmem(S, 8, 3, 0, 0, A, 1, 0xffffffffu, 0x20);
 
-        CHECK(sync.cursor_up - sync_buffer == 16, "ReleaseMem + WaitRegMem emitted 7 + 9 dwords");
+        CHECK(sync.cursor_up - sync_buffer == 18, "ReleaseMem + WaitRegMem emitted 9 + 9 dwords");
         CHECK(sync_buffer[3] == 2 && sync_buffer[4] == 1 && sync_buffer[5] == 0,
               "ReleaseMem encoded stack args data_sel=2 and data=1");
-        const uint32_t* wait = sync_buffer + 7;
+        const uint32_t* wait = sync_buffer + 9;
         CHECK(wait[3] == 0xffffffffu && wait[4] == 0 && wait[5] == 1 && wait[6] == 0,
               "WaitRegMem encoded stack args mask=0xffffffff and reference=1");
         CHECK(wait[7] == 3 && wait[8] == 0x20,

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -184,6 +184,90 @@ int main() {
     CHECK(!mb3_freelist_contains_stable((uint64_t)(uintptr_t)&live_label, nullptr),
           "an allocated block absent from both freelists is not classified free");
 
+    // Full bundles leave the per-thread secondary root and move into one of eight lock-free global
+    // recycler slots. Membership must continue to see those nodes until the slot is popped.
+    static uint64_t global_slots[8] = {};
+    static FreeNode global_label{}, global_tail{};
+    global_label.next = (uint64_t)(uintptr_t)&global_tail;
+    global_tail.next = 0;
+    global_slots[5] = (uint64_t)(uintptr_t)&global_label;
+    mb3_note_global_recycler_bin((uint64_t)(uintptr_t)global_slots);
+    CHECK(mb3_freelist_contains_stable((uint64_t)(uintptr_t)&global_tail, &match) &&
+          match.list == 8 && match.hops == 1,
+          "MB3 membership walks a bundle held in a global recycler slot");
+    global_slots[5] = 0;
+    CHECK(!mb3_freelist_contains_stable((uint64_t)(uintptr_t)&global_tail, nullptr),
+          "a bundle removed from the global recycler is no longer classified free");
+
+    // Once all eight global recycler slots are occupied, MB3 returns a bundle to the central page
+    // structure. FFreeBlock is an in-place header at the low end of its contiguous free run. Detect
+    // an interior 0x20-byte block without knowing the title-specific FPoolInfoSmall table address.
+    static uint8_t central_backing[0x20000] = {};
+    uint8_t* central_page =
+        (uint8_t*)(((uintptr_t)central_backing + 0xffffull) & ~0xffffull);
+    uint32_t* central_header = (uint32_t*)(central_page + 0x2000);
+    central_header[0] = 0xe3010002; // DOLL: BlockSizeShifted=2, PoolIndex=1, Canary=0xe3
+    central_header[1] = 4;          // four free blocks in [header, header + 4*0x20)
+    central_header[2] = ~0u;        // end of the central free-run index chain
+    uint64_t central_free = (uint64_t)(uintptr_t)(central_page + 0x2040);
+    CHECK(mb3_freelist_contains_stable(central_free, &match) &&
+          match.list == 11 && match.pool_base == (uint64_t)(uintptr_t)central_page &&
+          match.head == (uint64_t)(uintptr_t)(central_page + 0x2000) && match.hops == 2,
+          "MB3 membership detects an interior block in a central in-page free run");
+    CHECK(!mb3_freelist_contains_stable((uint64_t)(uintptr_t)(central_page + 0x2080), nullptr),
+          "a block immediately outside a central free run is not classified free");
+    central_header[0] = 0xe2010002;
+    CHECK(!mb3_freelist_contains_stable(central_free, nullptr),
+          "a central-run lookalike with the wrong MB3 canary is rejected");
+    central_header[0] = 0xe7010002;
+    CHECK(mb3_freelist_contains_stable(central_free, nullptr),
+          "MB3 membership accepts the newer UE central-run canary");
+
+    // A command packet can outlive the 0x20-byte label generation it captured. If that block was
+    // reused, executing the stale DmaData(0) would overwrite its new owner's first dword (observed
+    // live as a C++ vtable becoming 0x400000000). Key the build snapshot by the exact packet.
+    {
+        struct alignas(0x20) ReusedLabel { uint64_t value; uint64_t pad[3]; } reused{};
+        reused.value = 0x1020304050607080ull;
+        uint64_t addr = (uint64_t)(uintptr_t)&reused;
+        prosper_label_hist_dma_built(addr, 0x3000, 0, 1);
+        uint32_t dma[9] = {};
+        dma[0] = PM4(9, IT_NOP, R_DMA_DATA);
+        dma[1] = (uint32_t)addr; dma[2] = (uint32_t)(addr >> 32);
+        dma[5] = 4; dma[6] = 0x303;
+        dma[7] = (uint32_t)reused.value; dma[8] = (uint32_t)(reused.value >> 32);
+        reused.value = 0x409123458ull; // a different owner replaced the build-time label residue
+        GpuState st; run_cb(dma, 9, st);
+        CHECK(reused.value == 0x409123458ull,
+              "stale DmaData does not overwrite a label block reused after packet build");
+
+        uint32_t rel[7] = {};
+        rel[0] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        rel[1] = (uint32_t)addr; rel[2] = (uint32_t)(addr >> 32);
+        rel[3] = 1; rel[4] = 1; rel[6] = 4;
+        run_cb(rel, 7, st);
+        CHECK(reused.value == 0x409123458ull,
+              "the paired stale ReleaseMem does not overwrite the reused block either");
+    }
+
+    // ReleaseMem also carries its own build snapshot. Cover that guard without a preceding
+    // suppressed DmaData (and therefore without relying on the one-generation suppression debt).
+    {
+        struct alignas(0x20) ReusedLabel { uint64_t value; uint64_t pad[3]; } reused{};
+        reused.value = 0x1020304050607080ull;
+        uint64_t addr = (uint64_t)(uintptr_t)&reused;
+        prosper_label_hist_dma_built(addr, 0x4000, 0, 1);
+        uint32_t rel[9] = {};
+        rel[0] = PM4(9, IT_NOP, R_RELEASE_MEM);
+        rel[1] = (uint32_t)addr; rel[2] = (uint32_t)(addr >> 32);
+        rel[3] = 1; rel[4] = 1; rel[6] = 4;
+        rel[7] = (uint32_t)reused.value; rel[8] = (uint32_t)(reused.value >> 32);
+        reused.value = 0x409abcdefull;
+        GpuState st; run_cb(rel, 9, st);
+        CHECK(reused.value == 0x409abcdefull,
+              "packet-local ReleaseMem identity protects a reused label without DmaData debt");
+    }
+
     // The free label's DmaData(:=0) must be skipped before it erases NextFreeBlock. Then simulate an
     // allocator pop/reuse before ReleaseMem(<-1): the one-generation debt must still suppress that
     // old fence even though direct membership has become false.


### PR DESCRIPTION
## Summary
- extend UE MallocBinned3 size-class-1 free-membership checks from per-thread caches to all eight global recycler slots and central in-page `FFreeBlock` runs
- discover DOLL's global recycler table from the allocator spill-path instruction signature instead of hard-coding an eboot address
- carry packet-local destination snapshots in Prosper's custom DmaData and ReleaseMem packets so stale command-buffer generations cannot overwrite a recycled 0x20-byte label block
- keep the original 7-dword packet decoding compatible

Refs #312

## Tests
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure -j$(nproc)` — 96/96 passed
- `test_eop_write` — 25 focused checks, including TLS/global/central membership, stale DmaData, independent stale ReleaseMem, and the normal live-label sequence
- `git diff --check`

## Live validation
DOLL ran to the full 60-second cap with the normal guard set and no MallocBinned3 fatal or worker-thread fault. It rendered 32 captured frames; frames 31–32 contain recognizable `SYSTEM_SaveDataCheck_Message_CreateNewSaveData` UI. The previous dominant failure was an allocator abort around 8 seconds.

## Scope / remaining work
This is a heap-stability improvement, not the shaded-output fix. Live output still has incorrect composition and intermittent black frames, and fence scheduling diagnostics still report unsatisfied fold-time dependencies. Issue #312 should remain open while those residual races are investigated.