### PR TITLE
tools(renderer): filter target timing by workload

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -193,6 +193,10 @@ group. It includes the submit number, target address, dimensions, draw count, an
 phase breakdown without scanning pixels or printing every draw. `PROSPER_RTTLOG=1` includes the same line plus
 the more expensive visual RTT diagnostics. Use `PROSPER_RTTLOG_MIN_SUBMIT=N` and
 `PROSPER_RTTLOG_MAX_SUBMIT=N` to bound either mode; unrestricted output can still perturb wall-clock routes.
+For scene selection that is stable across runs, set `PROSPER_RTT_TIMING_MIN_DRAWS=N`. Lightweight records are
+buffered for one ordered submit and emitted together only when its total backend draw count reaches N, so all
+target calls are retained without logging the boot/menu workloads. For example, 300 selects the current
+Dead Cells post-parse workload while excluding its 54-56-draw loading loop.
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -352,6 +352,12 @@ modes with `PROSPER_RTTLOG_MIN_SUBMIT` and `PROSPER_RTTLOG_MAX_SUBMIT`. The full
 pixels and dropped one Dead Cells title loop from about 20 FPS to 13-14 FPS, causing its wall-clock input route
 to miss the menu; use the lightweight mode for performance attribution.
 
+Submit ordinals also varied enough across fresh runs that preselected ranges repeatedly missed the transition.
+`PROSPER_RTT_TIMING_MIN_DRAWS=N` therefore buffers lightweight target records until the final graphics span and
+emits the complete submit only when its total backend draw count reaches N. A value of 300 selects the current
+357-373-draw Dead Cells workload while producing no output for the earlier 54-56-draw loop. The buffer contains
+only target metadata and timing scalars; rendered pixels and backend execution are unchanged.
+
 A 180-second native Windows fresh-save Dead Cells run reached the post-parse workload with 373 draws, eight
 dispatches, and four graphics spans. Those spans rendered ten target groups per submit. The aligned backend
 window was:

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -230,11 +230,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t texture_bytes = 0, buffer_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
             };
+            struct RttTimingRecord {
+                int submit = 0;
+                uint64_t target = 0;
+                uint32_t width = 0, height = 0;
+                size_t draws = 0;
+                prosper::test::BackendRenderTimingStats timing;
+            };
             static thread_local RenderTiming pending_timing;
+            static thread_local std::vector<RttTimingRecord> pending_rtt_timing;
             const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
-            const bool rtt_timing_log = timing_enabled && rtt_log_in_range &&
-                (rtt_log || getenv("PROSPER_RTT_TIMING"));
-            if (timing_enabled && phase.first_span) pending_timing = {};
+            const bool lightweight_rtt_timing = timing_enabled && getenv("PROSPER_RTT_TIMING");
+            static const uint64_t rtt_timing_min_draws = getenv("PROSPER_RTT_TIMING_MIN_DRAWS")
+                ? strtoull(getenv("PROSPER_RTT_TIMING_MIN_DRAWS"), nullptr, 0) : 0;
+            if (timing_enabled && phase.first_span) {
+                pending_timing = {};
+                pending_rtt_timing.clear();
+            }
             const auto callback_timing_start = timing_enabled
                 ? RenderClock::now() : RenderClock::time_point{};
             auto record_backend_timing = [&](const prosper::test::BackendRenderTimingStats& backend) {
@@ -250,6 +262,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_setup_fixed_ms += backend.setup_fixed_ms;
                 pending_timing.backend_setup_resources_ms += backend.setup_resources_ms;
                 pending_timing.backend_setup_pipeline_ms += backend.setup_pipeline_ms;
+            };
+            auto print_rtt_timing = [](const RttTimingRecord& record) {
+                const prosper::test::BackendRenderTimingStats& timing = record.timing;
+                fprintf(stderr,
+                        "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
+                        "total=%.2f target_setup=%.2f draw_setup=%.2f record_upload=%.2f "
+                        "gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                        record.submit, (unsigned long long)record.target,
+                        record.width, record.height, record.draws, timing.total_ms(),
+                        timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
+                        timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms);
             };
             // PROSPER_SUBMITLOG: print the GPU-submit index periodically (at native speed, before the slow
             // render) so it can be correlated with guest-side log lines (e.g. a MsgDialog wait) to find the
@@ -1530,17 +1553,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
-                    if (rtt_timing_log)
-                        fprintf(stderr,
-                                "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
-                                "total=%.2f target_setup=%.2f draw_setup=%.2f record_upload=%.2f "
-                                "gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
-                                g_this_submit, (unsigned long long)base, gw, gh, pass.size(),
-                                backend_call_timing.total_ms(), backend_call_timing.target_ms,
-                                backend_call_timing.draw_setup_ms,
-                                backend_call_timing.record_upload_ms,
-                                backend_call_timing.gpu_wait_ms, backend_call_timing.readback_ms,
-                                backend_call_timing.cleanup_ms);
+                    const RttTimingRecord rtt_timing_record{
+                        g_this_submit, base, gw, gh, pass.size(), backend_call_timing};
+                    if (lightweight_rtt_timing) pending_rtt_timing.push_back(rtt_timing_record);
+                    else if (timing_enabled && rtt_log) print_rtt_timing(rtt_timing_record);
                     if (rtt_log) {
                         size_t nz = 0, rgb_nz = 0;
                         for (uint8_t b : rendered_pixels) nz += (b != 0);
@@ -1649,6 +1665,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 if (scanout) selected_pixels = scanout->rgba;
             }
+            if (phase.final_span && lightweight_rtt_timing && rtt_log_in_range &&
+                pending_timing.backend_draws >= rtt_timing_min_draws)
+                for (const RttTimingRecord& record : pending_rtt_timing) print_rtt_timing(record);
             if (!phase.final_span) {
                 if (timing_enabled) {
                     pending_timing.callbacks++;


### PR DESCRIPTION
## Summary\n- buffer lightweight target-timing records for one ordered submit\n- add PROSPER_RTT_TIMING_MIN_DRAWS=N to emit the complete submit only when its backend draw count reaches N\n- retain optional submit-range bounds and the full visual RTT mode\n- document a stable Dead Cells recipe: min draws 300 excludes the 54-56-draw loop and selects the current 357-373-draw workload\n\n## Why\nFresh-run scene transitions varied enough that ordinal ranges repeatedly missed the heavy workload. Widening the range produced enough output to slow progression. A workload predicate keeps boot/menu output at zero and still retains every target call from the selected submit.\n\n## Validation\n- native Windows prosper-app build\n- WSL/Linux prosper_live_renderer build\n- five-frame native Windows threshold smoke:\n  - min draws 3: zero records for the two-draw submit\n  - min draws 2 with submit bounds 3..3: exactly one complete record\n- both processes exited 0\n\nNo rendering behavior changes.\n\nAdvances #702.