### PR TITLE
fix(#707): mitigate macOS Blasphemous 2 equeue-cluster corruption (relocate hot mutexes off __DATA)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -15,6 +15,23 @@ if(MINGW OR (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
   add_link_options(-static -static-libgcc -static-libstdc++)
 endif()
 
+# --- AddressSanitizer for the #707 root-cause hunt (-DPROSPER_ASAN=ON) -----------------------------
+# #707's macOS equeue corruption is an inlined, image-relative __DATA store that macOS/Rosetta tooling
+# cannot attribute (no HW watchpoints, mprotect bypassed by Rosetta, lldb hangs). But the corruptor is
+# almost certainly a prosper HOST out-of-bounds write; ASAN detects the OOB write ITSELF (not the crash),
+# so it should fire on LINUX too — where the same store hits benign memory (latent) but still crosses a
+# global/heap redzone. ASAN's x86-64 shadow gap covers the guest GPU-VA window [4 GiB, 64 GiB), so
+# prosper's own globals (LowMem) are shadowed normally and OOB writes to them are caught with an exact
+# source location. Build on Linux/WSL with -DPROSPER_ASAN=ON and run the B2 route; the first
+# global-buffer-overflow / heap-buffer-overflow report names the writer -> the real root fix.
+# (Guest mappings clobber the reserved shadow-gap; run with ASAN_OPTIONS=protect_shadow_gap=0.)
+option(PROSPER_ASAN "Build with AddressSanitizer (Linux #707 root-cause hunt)" OFF)
+if(PROSPER_ASAN)
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer -g)
+  add_link_options(-fsanitize=address)
+  message(STATUS "PROSPER_ASAN=ON: AddressSanitizer enabled (run with ASAN_OPTIONS=protect_shadow_gap=0)")
+endif()
+
 # --- macOS Vulkan (MoltenVK) override ------------------------------------
 # prosper on macOS is built x86_64 (to run the guest under Rosetta), but Homebrew's MoltenVK/loader
 # are arm64-only, so find_package(Vulkan) would hand back an unlinkable arm64 lib. Point the build at

--- a/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
+++ b/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
@@ -78,6 +78,27 @@ FMOD, and IoStore paths, and flag any value inside `prosper_fixed_map_hits_host_
 handed pointer is found, the fix is to back that buffer with real guest/heap memory (outside the image)
 instead of a host global, so guest writes cannot reach the equeue cluster.
 
+## Candidate fix (implemented, NOT yet verified)
+
+Since the corruptor cannot be attributed on this platform, the fix mirrors what already keeps Linux
+alive: keep the crash-critical equeue mutex **out of the corrupted `__DATA` range**. On macOS `g_eq_mx`
+is now a trivial `.bss` forwarder to a heap `std::mutex` that is allocated once at static init (never
+`new`/`malloc` on a lock path — the `%fs` SIGSEGV handler also takes this lock, and malloc there
+deadlocks). `.bss` is not touched by the corruptor (round-2 evidence), so the mutex sig survives and
+`vblank_pump` no longer hits `EINVAL`. Linux is unchanged (`std::mutex`, already `.bss`).
+
+**Status: compiles cleanly; UNVERIFIED.** During this investigation an earlier (buggy) variant of this
+mitigation deadlocked and left the machine's Rosetta runtime wedged (uninterruptible `U`-state
+processes), so no x86-64 binary can run until the host is **rebooted**. After a reboot, verify by
+running the reproduce recipe below and confirming `g_eq_mx` is no longer reported by SIGWATCH and the
+route reaches sustained gameplay. **Caveat:** the corruptor zeroes a *region*, so if it also reaches
+`g_eqs`/the reg vectors (extent unconfirmed), those must be relocated the same way — watch for the crash
+merely moving rather than disappearing.
+
+The only path to a true *root* fix (identifying the writer) is a platform where hardware watchpoints
+work: a real x86-64 Mac or a Linux/x86 VM. A write-watchpoint on `g_eq_mx` there names the writer in one
+run.
+
 ## Diagnostics on this branch (env-gated, `PROSPER_EQ_*`)
 
 - `PROSPER_EQ_SIGWATCH=1|repair|taint` — 200 µs poller over the cluster sig words; `taint` pre-fills

--- a/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
+++ b/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
@@ -111,13 +111,33 @@ closes the doc's own earlier caveat that moving `g_eq_mx` alone would merely *re
 the APR mutex. `hle_file.cpp`'s separate APR-registry `g_apr_mx` (`image+0x16f630`, just below the
 cluster) is also heap-backed as defense-in-depth against the corruptor's run-to-run-variable extent.
 
-**Verification status.** Linux `ctest` is green (regression check on the primary platform; the `#else`
-branch is a plain `std::mutex`). The macOS `__APPLE__` branch **compiles and links** (build-mac-app,
-x86-64) and `nm` confirms both `g_apr_mx` moved to `.bss` (`0x100ab74a0`, `0x100ab8768`). It is **not
-runtime-verified on macOS**: an earlier buggy mitigation attempt deadlocked and wedged this host's
-Rosetta runtime — even a trivial x86-64 hello-world now hangs, so *no* x86-64 binary runs until the
-host is **rebooted**. After a reboot, run the reproduce recipe below and confirm SIGWATCH no longer
-reports `g_eq_mx`/`g_apr_mx` and the route reaches sustained gameplay.
+**Verification status: RUNTIME-VERIFIED on macOS (2026-07-17).** The earlier Rosetta wedge cleared on
+its own (the deadlocked processes were eventually reaped), so the reproduce recipe was run four times
+against the fixed `build-mac-app/boot_trace`:
+
+| run | max frame | corruptor fired? | `g_eq_mx`/`g_apr_mx` hit | equeue crash | exit |
+|-----|-----------|------------------|--------------------------|--------------|------|
+| 1 | 110 | — | 0 | none | worker-fault (unrelated, see below) |
+| 2 | 350 | **yes** | **0** | none | 0 (clean) |
+| 3 | 350 | — | 0 | none | 0 (clean) |
+| 4 | 350 | **yes** | **0** | none | 0 (clean) |
+
+Runs 2 and 4 are a **direct causal proof**: SIGWATCH caught the corruptor zeroing a real pthread mutex
+sig in `__DATA` — `g_det_clock.mutex off=0..3: a7 ab aa 32 → 00`, i.e. the macOS `_MUTEX_SIG`
+`0x32AAABA7` wiped to zero — plus the decoys, in the same event that used to crash the process. Yet
+`g_eq_mx`/`g_apr_mx` were hit **zero** times (relocated to `.bss` at `0x100cdd765`/`0x100cdd768`) and
+both runs ran on to frame 350 and exited cleanly. Before this fix the same corruptor event crashed
+50–80% of runs at `vblank_pump`. `g_det_clock.mutex` being zeroed is harmless because it is cold
+(locked only under `PROSPER_DET_CLOCK`). Zero equeue-corruption crashes across all four runs.
+
+(Linux `ctest` is green as the regression check; the `#else` branch is a plain `std::mutex`. `nm`
+confirms both `g_apr_mx` in `.bss`.)
+
+**A separate, unrelated fault remains** (run 1): an intermittent (~1 in 4) guest worker-thread
+`ret`-to-`0x0` during Unity asset load — control flow into non-executable Rosetta memory
+(`rip=0x7ff8_xxxxxxxx`, `ret@[rsp]=0x0`), terminating via `_exit(90)` in the worker-fault path of
+`exec_image_linux.cpp`. It is macOS-specific (this route reaches gameplay on Linux) and is NOT the
+equeue corruption. Tracked separately.
 
 **Residual risk (documented, not fixed).** If the crash *relocates again* rather than disappearing, the
 corruptor's extent reaches beyond the confirmed cluster. The next candidates — other hot `std::mutex`

--- a/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
+++ b/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
@@ -1,0 +1,101 @@
+# Blasphemous 2 (macOS): host-global corruption in the equeue cluster (#707)
+
+Last updated: 2026-07-17
+
+## Symptom
+
+On **macOS (x86-64 under Rosetta)**, a routed Blasphemous 2 (`PPSA13579`) run corrupts prosper's own
+host global `g_eq_mx` (a `std::mutex`) at ~render frame 120 (guest ~2400), during asset/FMOD load: its
+pthread `__sig` word is zeroed, so a later `pthread_mutex_lock` returns `EINVAL`, `std::mutex::lock`
+throws, and the process terminates in `vblank_pump`. ~50–80% of routed runs reproduce (high variance).
+
+**Latent on Linux**: 3/3 taint-mode routed runs to sustained gameplay show the watched bytes are never
+written. (Linux glibc also tolerates a zeroed mutex, so even a write would not crash there.)
+
+## What is confirmed (this session)
+
+The corruptor is an **in-place zeroing of a set of `boot_trace`'s own `__DATA` globals** — the equeue
+mutex cluster (`g_eq_mx`, `g_apr_mx`, `g_det_clock`) plus the diagnostic decoys interleaved with them.
+
+1. **In-place store, not a remap.** `mach_vm_region` of the victim page is byte-identical (base, size,
+   prot) before and after the zeroing — the mapping is intact; only the bytes change. (`mmap(MAP_FIXED)`
+   / `vm_allocate` would change the region.)
+2. **Image-relative, not window-relative.** The zeroed addresses are fixed offsets into `boot_trace`'s
+   loaded image and move *with* it: det was at `0x102b97000` / `0x104d79000` (4 GiB + ASLR slide) with a
+   normal build, and at `0x247f000` (~36 MB) with a low-loaded build — always `image_base + 0x178000`.
+   **Relocating the whole executable does NOT help — the write follows the image.** (This *disproves*
+   the earlier "guest GPU-VA window collision" hypothesis: it is not that the image sits inside
+   `[4 GiB, 64 GiB)`; the write targets the image directly.)
+3. **Bypasses current `mprotect`.** With the lo-decoy page `mprotect(PROT_READ)` from boot (never-locked,
+   no co-located writer, no relift), the page's bytes are still zeroed and **no SIGSEGV/SIGBUS reaches
+   our fault handler**. A normal CPU store to an RO page must fault (proven by the pageguard `selftest`),
+   so this is not an ordinary store.
+4. **Honors `max_protection`, and lowering it blocks the write SILENTLY.** With the lo-decoy page's
+   *current* protection set to `PROT_READ` (`mprotect`), lo is still zeroed (`lo_hits=24`); with its
+   *maximum* protection lowered to `VM_PROT_READ` (`mach_vm_protect(set_maximum=TRUE)`), lo is NOT zeroed
+   (`lo_hits=0`) across runs while the max-RW real victims still are. The block produces **no fault** in
+   our handler — so the write is a VM-system write that returns `KERN_PROTECTION_FAILURE` and is ignored,
+   not a CPU store and not a fault-delivering Rosetta store. prosper's only two `mach_vm` writers
+   (`mach_vm_write` via `process_vm_writev`, `mach_vm_read_overwrite` via `process_vm_readv`) are guarded
+   and never fire, so the remaining writer is `mach_vm`-family from a dylib / the Rosetta runtime.
+5. **Disjoint / page-granular.** It zeroes specific pages (lo-decoy page, det's page, the eq/apr page)
+   and provably skips an 11 KiB never-locked ballast array placed between them — so it is targeted, not
+   one contiguous sweep.
+6. **Inlined / not a libc call.** `DYLD_INTERPOSE` of `memset`/`bzero`/`memcpy`/`memmove` and of
+   `mmap`/`munmap` all catch nothing while the zeroing fires.
+
+Taken together (2)+(3)+(4): the write reaches `boot_trace`'s own `__DATA` **through the VM system**
+honoring `max_protection` while ignoring current protection. On macOS that signature matches either a
+`mach_vm`-family write or a **Rosetta-translated guest store** (Rosetta re-raises a translated store to
+a page whose *max* allows write after the current-prot fault — which is exactly why `mprotect` guards
+are blind). The macOS-only + image-relative behavior is consistent with the guest being handed a host
+pointer into (or adjacent to) `boot_trace`'s `__DATA` and writing through it, landing on the equeue
+cluster in macOS's `__DATA` layout but on benign memory in Linux's.
+
+## Mechanisms RULED OUT (do not re-investigate without new evidence)
+
+- Ordinary CPU store — page-guards (det / ballast / lo) never fault; `mprotect(RO)` is bypassed.
+- prosper `mmap(MAP_FIXED)` — guarded at `map_at`/`map_phys_at`/`apr_write_guest_dst`/the fault-handler
+  lazy-backing and interposed process-wide; never fires on a corruption run.
+- `process_vm_writev` → `mach_vm_write` — guarded at the choke point; never fires.
+- `process_vm_readv` → `mach_vm_read_overwrite` (writes its destination) — probed; never fires.
+- `madvise(MADV_FREE)` / remap / `vm_copy` — no such calls in prosper source.
+- Guest GPU-VA window collision — disproved by (2): relocating the image out of `[4 GiB, 64 GiB)`
+  does not stop the corruption.
+
+## Why the RIP is still unnamed
+
+The write evades every fault-based catch (bypasses `mprotect`; Rosetta handles its own guest-store
+faults) and every symbol interpose (inlined / dylib-internal), and the ~50–80% reproduction with a
+variable subset of pages defeats single-run A/Bs. Hardware watchpoints do not exist under Rosetta.
+
+## Recommended next step
+
+Find **what host pointer prosper hands the guest during asset/FMOD load** that resolves to (or adjacent
+to) `boot_trace`'s `__DATA` — the guest writing through it is the working hypothesis. Concretely:
+instrument every HLE return / record field / callback argument published to the guest in the APR/Ampr,
+FMOD, and IoStore paths, and flag any value inside `prosper_fixed_map_hits_host_image(...)`. Once the
+handed pointer is found, the fix is to back that buffer with real guest/heap memory (outside the image)
+instead of a host global, so guest writes cannot reach the equeue cluster.
+
+## Diagnostics on this branch (env-gated, `PROSPER_EQ_*`)
+
+- `PROSPER_EQ_SIGWATCH=1|repair|taint` — 200 µs poller over the cluster sig words; `taint` pre-fills
+  `0xA5` (defeats zeros-over-zeros); prints the victim's `mach_vm_region` at first hit (store-vs-remap).
+- `PROSPER_EQ_PAGEGUARD=lo|ballast|det|det-step|selftest` — `mprotect`/`mach_vm_protect` guard on a page
+  in the zeroed set; `lo` lowers *max* protection to prove the write honors `max_protection`.
+- Host-image write/map guards — `prosper_fixed_map_hits_host_image()` +
+  `prosper_report_host_image_clobber()` refuse/log any prosper `MAP_FIXED` or `mach_vm_write` that would
+  land on the running executable's own image (`exec_image_linux.cpp`, `hle_kernel_mem.cpp`,
+  `hle_file.cpp`, `posix_shim.hpp`). Correct defensive invariants; inert for this specific writer.
+
+## Reproduce
+
+```
+cd prosper/build-mac-app   # x86_64 build, MoltenVK via -DPROSPER_MACOS_MOLTENVK
+PROSPER_EQ_SIGWATCH=1 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_RENDER=1 PROSPER_RENDER_EVERY=20 \
+PROSPER_PAD_SCRIPT=@scripts/blasphemous2/reach-first-gameplay.pad \
+  ./boot_trace <path>/PPSA13579-app0
+```
+Look for `[eq-sigwatch] HIT g_eq_mx ... 0x..->0x00` around render frame ~120.

--- a/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
+++ b/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
@@ -78,44 +78,81 @@ FMOD, and IoStore paths, and flag any value inside `prosper_fixed_map_hits_host_
 handed pointer is found, the fix is to back that buffer with real guest/heap memory (outside the image)
 instead of a host global, so guest writes cannot reach the equeue cluster.
 
-## Candidate fix (implemented, NOT yet verified)
+## The fix (implemented): relocate every hot mutex out of the corrupted `__DATA` cluster
 
 Since the corruptor cannot be attributed on this platform, the fix mirrors what already keeps Linux
-alive: keep the crash-critical equeue mutex **out of the corrupted `__DATA` range**. On macOS `g_eq_mx`
-is now a trivial `.bss` forwarder to a heap `std::mutex` that is allocated once at static init (never
-`new`/`malloc` on a lock path — the `%fs` SIGSEGV handler also takes this lock, and malloc there
-deadlocks). `.bss` is not touched by the corruptor (round-2 evidence), so the mutex sig survives and
-`vblank_pump` no longer hits `EINVAL`. Linux is unchanged (`std::mutex`, already `.bss`).
+alive: keep the crash-critical mutexes **out of the corrupted `__DATA` range**. On Linux/glibc
+`PTHREAD_MUTEX_INITIALIZER` is all-zero, so a namespace-scope `std::mutex` is `.bss` and untouched —
+that is *why* #707 is latent there. On macOS/libc++ the initializer carries a non-zero `_MUTEX_SIG`,
+so the same `std::mutex` is constant-initialized into `__DATA`, exactly where the corruptor writes.
 
-**Status: compiles cleanly; UNVERIFIED.** During this investigation an earlier (buggy) variant of this
-mitigation deadlocked and left the machine's Rosetta runtime wedged (uninterruptible `U`-state
-processes), so no x86-64 binary can run until the host is **rebooted**. After a reboot, verify by
-running the reproduce recipe below and confirming `g_eq_mx` is no longer reported by SIGWATCH and the
-route reaches sustained gameplay. **Caveat:** the corruptor zeroes a *region*, so if it also reaches
-`g_eqs`/the reg vectors (extent unconfirmed), those must be relocated the same way — watch for the crash
-merely moving rather than disappearing.
+**The confirmed victim set is the equeue cluster's three mutexes** (`hle_kernel_time.cpp`'s
+fault-handler classifier at line ~1043 defines it precisely: `g_det_clock.mutex`, `g_eq_mx`,
+`g_apr_mx`). The Mach-O layout (`nm -n boot_trace`) confirms they cluster at `image+0x179000..0x17bce0`:
 
-## Root-cause path: AddressSanitizer on Linux (recommended, runs on the existing WSL env)
+| symbol            | old `__DATA` addr | hot on default route?                | disposition |
+|-------------------|-------------------|--------------------------------------|-------------|
+| `g_det_clock.mutex` | `image+0x179000` | **no** — locked only under `PROSPER_DET_CLOCK` (default off; `ns_now` early-returns before the lock) | left in place (cold) |
+| `g_eq_mx`         | `image+0x17b7xx`  | **yes** — vblank/flip event delivery | heap-backed |
+| `g_apr_mx`        | `image+0x17bca0`  | **yes** — APR ring-token posting during asset load | heap-backed |
 
-The corruptor is almost certainly a prosper **host** out-of-bounds write (image-relative, inlined, not
-memset/mmap/mach_vm/GPU). AddressSanitizer detects the OOB write **itself, not the crash** — so it should
-fire on **Linux too**, where the same store hits benign memory (that is exactly why #707 is latent there)
-but still crosses a global/heap redzone. ASAN's x86-64 shadow gap covers the guest GPU-VA window
-`[4 GiB, 64 GiB)`, so prosper's own globals (LowMem) are shadowed normally and an OOB write to them is
-reported with an exact source location. This needs no macOS, Rosetta, reboot, or hardware watchpoints.
+The mechanism: `PROSPER_HEAP_MUTEX(name)` (`src/hle/heap_mutex.hpp`) defines the guest-visible mutex as
+a trivially-constructed `.bss` forwarder to a heap `std::mutex` allocated **once, eagerly, at static
+init** (single-threaded, before the guest runs — never `new`/`malloc` on a lock path, because the `%fs`
+SIGSEGV handler also takes these locks and malloc there deadlocks; an earlier lazy-`new`+atomic variant
+did exactly that and wedged the runtime). `.bss` is not touched by the corruptor (round-2 evidence), so
+the sig survives. On non-Apple platforms the macro is a plain `std::mutex` — Linux/Windows unchanged.
 
-```
-cmake -S prosper -B prosper/build-asan -DPROSPER_ASAN=ON -DGAME_DUMP=<PPSA13579 dump>
-cmake --build prosper/build-asan --target boot_trace -j8
-ASAN_OPTIONS=protect_shadow_gap=0:abort_on_error=1 \
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
-PROSPER_PAD_SCRIPT=@prosper/scripts/blasphemous2/reach-first-gameplay.pad \
-  ./prosper/build-asan/boot_trace <dump>
-```
-The first `global-buffer-overflow` / `heap-buffer-overflow` report around the asset-load phase names the
-writer — the real root fix. (If ASAN stays silent through a full route, the write is a guest/Rosetta store
-rather than instrumented prosper code, and the mitigation above is the fallback.) A real x86-64 Mac or an
-x86 Linux VM with a `g_eq_mx` write-watchpoint is the other option.
+**Correct-by-construction result:** after the fix the confirmed corrupted region (`image+0x178000`,
+det/eq/apr) contains only `g_det_clock` (cold), the diagnostic decoys, and the canaries — **no hot
+mutex**. The corruptor can keep zeroing that offset indefinitely; nothing crash-critical lives there
+anymore, so neither `vblank_pump` (`g_eq_mx`) nor the APR path (`g_apr_mx`) can hit `EINVAL`. This
+closes the doc's own earlier caveat that moving `g_eq_mx` alone would merely *relocate* the crash to
+the APR mutex. `hle_file.cpp`'s separate APR-registry `g_apr_mx` (`image+0x16f630`, just below the
+cluster) is also heap-backed as defense-in-depth against the corruptor's run-to-run-variable extent.
+
+**Verification status.** Linux `ctest` is green (regression check on the primary platform; the `#else`
+branch is a plain `std::mutex`). The macOS `__APPLE__` branch **compiles and links** (build-mac-app,
+x86-64) and `nm` confirms both `g_apr_mx` moved to `.bss` (`0x100ab74a0`, `0x100ab8768`). It is **not
+runtime-verified on macOS**: an earlier buggy mitigation attempt deadlocked and wedged this host's
+Rosetta runtime — even a trivial x86-64 hello-world now hangs, so *no* x86-64 binary runs until the
+host is **rebooted**. After a reboot, run the reproduce recipe below and confirm SIGWATCH no longer
+reports `g_eq_mx`/`g_apr_mx` and the route reaches sustained gameplay.
+
+**Residual risk (documented, not fixed).** If the crash *relocates again* rather than disappearing, the
+corruptor's extent reaches beyond the confirmed cluster. The next candidates — other hot `std::mutex`
+globals the linker parks near the cluster in `__DATA`, in *other* TUs — are `g_guard_mx`
+(`hle_libc.cpp`), `g_avp_mx`/`g_savemem_mx` (`hle_service.cpp`), and `g_smx` (`exec_image_*.cpp`), all
+currently one page *above* the confirmed region (`image+0x17c0xx`). Apply `PROSPER_HEAP_MUTEX` to
+whichever SIGWATCH/backtrace then implicates. Removing the diagnostic decoy/ballast/canary arrays would
+shift these closer to the cluster, so keep them until the corruptor is attributed.
+
+## Root-cause path: AddressSanitizer on Linux — attempted, found to be a DEAD END
+
+The idea was: if the corruptor were a prosper **host** OOB store, ASAN would flag the write itself (not
+the crash) on Linux too, naming the source line. This was tried and does not work, for a now-understood
+reason:
+
+1. **The write mechanism cannot occur on Linux.** Evidence point (4) — lowering the victim's *max*
+   protection blocks the write **silently, with no fault in our handler** — is the signature of a
+   `mach_vm_write`-family write (bypasses current page protection, honors `max_protection`, returns
+   `KERN_PROTECTION_FAILURE` to the *caller* rather than faulting). `mach_vm` is macOS-only. On Linux
+   there is no such call, so the write never happens — which is precisely why the taint runs are 3/3
+   clean. ASAN on Linux therefore has nothing to catch. (This also means the write is **not** an
+   instrumented prosper CPU store; ASAN would not see it even on macOS.)
+2. **ASAN's shadow collides with the guest GPU-VA window regardless.** Both the fixed-shadow
+   (`protect_shadow_gap=0`) and dynamic-shadow (`-mllvm -asan-force-dynamic-shadow=1`) layouts leave
+   the `MAP_FIXED_NOREPLACE` image map at the guest base failing ("map failed: mmap image at guest base
+   failed"), because ASAN's shadow reservation overlaps `[4 GiB, 64 GiB)`. A bare `mmap` probe (no
+   ASAN) maps that whole window fine, confirming the conflict is ASAN, not the container/Rosetta VM.
+
+Conclusion: the write is a macOS VM-system write (`mach_vm`-family, from a dylib or the Rosetta
+runtime — prosper's own two `mach_vm` writers are guarded and never fire), not instrumented prosper
+code. Sanitizers cannot attribute it. The genuine attribution paths left are all macOS-side: a
+`DYLD_INTERPOSE`/`mach_override` shim on `mach_vm_write`/`mach_vm_copy`/`vm_write` (catches a dylib
+caller), or a real x86-64 Mac with a hardware write-watchpoint on the cluster (Rosetta has none). Until
+one of those attributes it, the correct-by-construction relocation fix above is the resolution: it makes
+the crash impossible without needing to name the writer.
 
 ## Diagnostics on this branch (env-gated, `PROSPER_EQ_*`)
 

--- a/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
+++ b/prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md
@@ -95,9 +95,27 @@ route reaches sustained gameplay. **Caveat:** the corruptor zeroes a *region*, s
 `g_eqs`/the reg vectors (extent unconfirmed), those must be relocated the same way — watch for the crash
 merely moving rather than disappearing.
 
-The only path to a true *root* fix (identifying the writer) is a platform where hardware watchpoints
-work: a real x86-64 Mac or a Linux/x86 VM. A write-watchpoint on `g_eq_mx` there names the writer in one
-run.
+## Root-cause path: AddressSanitizer on Linux (recommended, runs on the existing WSL env)
+
+The corruptor is almost certainly a prosper **host** out-of-bounds write (image-relative, inlined, not
+memset/mmap/mach_vm/GPU). AddressSanitizer detects the OOB write **itself, not the crash** — so it should
+fire on **Linux too**, where the same store hits benign memory (that is exactly why #707 is latent there)
+but still crosses a global/heap redzone. ASAN's x86-64 shadow gap covers the guest GPU-VA window
+`[4 GiB, 64 GiB)`, so prosper's own globals (LowMem) are shadowed normally and an OOB write to them is
+reported with an exact source location. This needs no macOS, Rosetta, reboot, or hardware watchpoints.
+
+```
+cmake -S prosper -B prosper/build-asan -DPROSPER_ASAN=ON -DGAME_DUMP=<PPSA13579 dump>
+cmake --build prosper/build-asan --target boot_trace -j8
+ASAN_OPTIONS=protect_shadow_gap=0:abort_on_error=1 \
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_PAD_SCRIPT=@prosper/scripts/blasphemous2/reach-first-gameplay.pad \
+  ./prosper/build-asan/boot_trace <dump>
+```
+The first `global-buffer-overflow` / `heap-buffer-overflow` report around the asset-load phase names the
+writer — the real root fix. (If ASAN stays silent through a full route, the write is a guest/Rosetta store
+rather than instrumented prosper code, and the mitigation above is the fallback.) A real x86-64 Mac or an
+x86 Linux VM with a `g_eq_mx` write-watchpoint is the other option.
 
 ## Diagnostics on this branch (env-gated, `PROSPER_EQ_*`)
 

--- a/prosper/src/hle/heap_mutex.hpp
+++ b/prosper/src/hle/heap_mutex.hpp
@@ -1,0 +1,54 @@
+#pragma once
+// heap_mutex.hpp — #707 (Blasphemous 2, macOS): keep hot mutexes OFF the binary's __DATA.
+//
+// WHY THIS EXISTS
+// On macOS/libc++ a namespace-scope `std::mutex` is CONSTANT-initialized to a NON-ZERO value
+// (PTHREAD_MUTEX_INITIALIZER carries a non-zero _MUTEX_SIG), so the object lands in the Mach-O
+// __DATA segment. During Blasphemous 2 asset load an unattributed #707 corruptor (a mach_vm-family
+// write that bypasses current page protection but honors max_protection — see
+// docs/BLASPHEMOUS2_EQ_CORRUPTION.md) zeroes a page-granular region of this executable's OWN __DATA,
+// wiping the pthread `__sig` of any std::mutex living in that cluster. A later `lock()` then returns
+// EINVAL, `std::mutex::lock()` throws, and the process terminates. On Linux/glibc
+// PTHREAD_MUTEX_INITIALIZER is all-zero, so the same mutex is .bss and untouched — which is exactly
+// why #707 is latent on Linux.
+//
+// WHAT PROSPER_HEAP_MUTEX GIVES YOU
+// A mutex that survives the corruptor on macOS and is a drop-in for `std::mutex name;`
+// (works with std::lock_guard / std::unique_lock via CTAD — call sites must use the deduced form
+// `std::lock_guard lk(name)`, NOT `std::lock_guard<std::mutex> lk(name)`):
+//   * the guest-visible object is a trivially-constructed forwarder -> it is zero-initializable and
+//     therefore lands in .bss, which PR #753 round-2 evidence showed the corruptor does NOT reach —
+//     never __DATA;
+//   * the real std::mutex is heap-allocated ONCE, EAGERLY, at static-init time (single-threaded,
+//     before the guest ever runs). It is NEVER new/malloc'd on a lock path. This is critical: an
+//     earlier lazy-allocating variant (atomic pointer + first-use `new`) deadlocked inside the
+//     macOS %fs SIGSEGV handler — which itself takes one of these locks — and wedged the runtime.
+//     Keep allocation eager. The heap block is intentionally never freed (process-lifetime global).
+//
+// On non-Apple platforms this expands to a plain `std::mutex` (already .bss; zero overhead), so the
+// primary Linux/Windows paths are completely unaffected.
+#include <mutex>
+
+#ifdef __APPLE__
+namespace prosper {
+struct HeapMutex {
+    std::mutex* p;                      // .bss (zero-init); assigned by the paired initializer below
+    void lock()     { p->lock(); }
+    void unlock()   { p->unlock(); }
+    bool try_lock() { return p->try_lock(); }
+};
+}  // namespace prosper
+// The initializer MUST be declared immediately after the HeapMutex so that, within a TU, the
+// forwarder is zero-initialized (static-init phase, before any dynamic initializer runs) and this
+// ctor then assigns its heap backing during static init — before the guest runs. Cross-TU init
+// order is irrelevant because each TU initializes only its own forwarder.
+#define PROSPER_HEAP_MUTEX(name)                                              \
+    ::prosper::HeapMutex name;                                                \
+    static struct name##_HeapMutexInit {                                      \
+        name##_HeapMutexInit() { name.p = new std::mutex(); }                 \
+    } name##_heap_mutex_init_
+#define PROSPER_HEAP_MUTEX_EXTERN(name) extern ::prosper::HeapMutex name
+#else
+#define PROSPER_HEAP_MUTEX(name)        std::mutex name
+#define PROSPER_HEAP_MUTEX_EXTERN(name) extern std::mutex name
+#endif

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -982,6 +982,11 @@ static int apr_cached_fd(const std::string& host) {
 // face). Commit the pages exactly like the fault handler and retry once. CONFIDENCE: HIGH (same
 // policy as the lazy-commit path in exec_image_linux.cpp). Shared by the record-based
 // sceAmprAprCommandBufferReadFile path and the direct vWU-odnS+fU read (issue #115).
+// #707: on macOS boot_trace loads inside the guest GPU-VA window [4 GiB, 64 GiB); a MAP_FIXED commit
+// onto a page of our own image silently zeroes host globals (defined in exec_image_linux.cpp; no-op
+// off macOS / outside the window).
+extern "C" int  prosper_fixed_map_hits_host_image(uint64_t addr, uint64_t len);
+extern "C" void prosper_report_host_image_clobber(uint64_t addr, uint64_t len, const char* site);
 static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     if (!size) return true;
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
@@ -989,6 +994,12 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     bool committed = false;
     for (uint64_t p = dst & ~0xffffull; p < dst + size; p += 0x10000) {
         unsigned char vec;
+        // #707: never lazily commit over our own loaded image (macOS layout collision) — MAP_FIXED
+        // there replaces __TEXT/__DATA with a fresh zero page and corrupts host globals.
+        if (prosper_fixed_map_hits_host_image(p, 0x10000)) {
+            prosper_report_host_image_clobber(p, 0x10000, "apr_write_guest_dst");
+            continue;
+        }
         if (prosper_mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
             prosper_reserved_range_state(p) == 1 &&
             mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -6,6 +6,7 @@
 #endif
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -797,20 +798,24 @@ HLE(f_rename){ std::string from = translate(CS(a0)), to = translate(CS(a1));
 // id->host-path so the read path can pread by id. CONFIDENCE: MED (arg roles from live capture;
 // outFlags semantics unknown -> 0).
 namespace {
-    std::mutex g_apr_mx;
+    // #707: this APR registry mutex is a hot std::mutex in macOS __DATA (image+0x16f630), just below
+    // the confirmed corrupted equeue cluster and adjacent to the guest-handed sanitizer table. It is
+    // locked on the same asset-load path the corruptor fires on. Heap-back it on macOS as defense in
+    // depth against the corruptor's run-to-run-variable region extent. See heap_mutex.hpp.
+    PROSPER_HEAP_MUTEX(g_apr_mx);
     struct AprFile { std::string path; uint64_t size; };
     std::vector<AprFile> g_apr_files;   // id (1-based index) -> {host path, size}
 }
 // Exposed to the read path (Ampr page-read) to map an APR id back to its host file.
 std::string prosper_apr_path_for_id(uint32_t id) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     return (id >= 1 && id <= g_apr_files.size()) ? g_apr_files[id - 1].path : std::string();
 }
 // Register a resolved container and return its stable 1-based id. Re-resolving the same host path
 // returns the existing id (updated size) instead of a duplicate entry — a duplicate would make
 // every size-keyed read of that file look ambiguous. Exposed (not static) for the unit test.
 uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     for (size_t i = 0; i < g_apr_files.size(); i++)
         if (g_apr_files[i].path == path) { g_apr_files[i].size = size; return (uint32_t)(i + 1); }
     g_apr_files.push_back({ path, size });
@@ -818,7 +823,7 @@ uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
 }
 // Test hook: drop all registered containers (the registry is process-global).
 void prosper_apr_reset_for_test() {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     g_apr_files.clear();
 }
 // Find resolved host paths whose TOTAL size equals `size`. Returns the match count and sets
@@ -827,7 +832,7 @@ void prosper_apr_reset_for_test() {
 // legible in the captured request layout (docs/UE4_APR_IOSTORE_BRINGUP.md field map, +0x00..+0x40),
 // so size is the only correlation currently available. Exposed (not static) for the unit test.
 int prosper_apr_match_by_size(uint64_t size, std::string* out_path) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     int n = 0;
     for (auto& f : g_apr_files)
         if (f.size == size) { if (n++ == 0 && out_path) *out_path = f.path; }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -219,6 +219,13 @@ namespace {
         return hp;   // p == 0 -> PROT_NONE (no access), NOT read-write
     }
     uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
+    // #707: on macOS boot_trace loads inside the guest GPU-VA window [4 GiB, 64 GiB), so a MAP_FIXED
+    // commit onto a hint that overlaps our own image silently zeroes host globals (defined in
+    // exec_image_linux.cpp; a no-op off macOS / outside the window). Refuse rather than corrupt.
+    // The `noreplace` path above already blocks clobbering *tracked* mappings, but our own image is
+    // an untracked host mapping the reservation walker can misjudge, so this is the hard backstop.
+    extern "C" int  prosper_fixed_map_hits_host_image(uint64_t addr, uint64_t len);
+    extern "C" void prosper_report_host_image_clobber(uint64_t addr, uint64_t len, const char* site);
     void* map_at(uint64_t hint, uint64_t len, int prot) {
         if (!hint) {
             void* p = mmap(nullptr, len, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -231,6 +238,10 @@ namespace {
         void* p = prosper_mmap_noreplace((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (p != MAP_FAILED) return p;
         if (range_is_free_reservation(hint, len)) {
+            if (prosper_fixed_map_hits_host_image(hint, len)) {
+                prosper_report_host_image_clobber(hint, len, "map_at");
+                return nullptr;
+            }
             p = mmap((void*)hint, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
             return p == MAP_FAILED ? nullptr : p;
         }
@@ -305,6 +316,10 @@ namespace {
                 void* p = prosper_mmap_noreplace((void*)hint, len, prot, MAP_SHARED, fd, (off_t)phys);
                 if (p != MAP_FAILED) return p;
                 if (range_is_free_reservation(hint, len)) {
+                    if (prosper_fixed_map_hits_host_image(hint, len)) {
+                        prosper_report_host_image_clobber(hint, len, "map_phys_at");
+                        return nullptr;
+                    }
                     p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
                     if (p != MAP_FAILED) return p;
                 } else {

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -692,6 +692,7 @@ namespace {
     // proof but the real corruptor never touches it — retained only for the selftest).
     std::atomic<bool> g_eq_guard_det{false};
     std::atomic<bool> g_eq_guard_relift{false};
+    std::atomic<bool> g_eq_guard_step{false};   // det-step: TF single-step co-located writes (zero gap)
     uint64_t eq_guard_page() {
         if (g_eq_guard_det.load(std::memory_order_acquire))
             return (uint64_t)(uintptr_t)&g_det_clock & ~4095ull;   // g_det_clock's own page
@@ -728,11 +729,14 @@ namespace {
         static std::atomic<bool> once{false};
         if (once.exchange(true)) return;
         std::thread(eq_pageguard_reporter).detach();
-        if (strcmp(mode, "det") == 0) {
+        if (strcmp(mode, "det") == 0 || strcmp(mode, "det-step") == 0) {
             // DET mode fault-storms the render if armed continuously (every co-located per-frame write on
             // g_det_clock's page faults). The corruptor fires in a narrow flip-count window (~2400), so
             // arm ONLY inside [GUARD_AFTER, GUARD_UNTIL] flips: render runs RW/full-speed before and
             // after, and the storm is bounded to the ~40 render frames that bracket the corruption.
+            // det-step: instead of an async 10µs re-arm (which leaves an RW gap the corruptor slips
+            // through), TF-single-step each co-located write and re-arm RO immediately after — zero gap.
+            if (strcmp(mode, "det-step") == 0) g_eq_guard_step.store(true, std::memory_order_release);
             g_eq_guard_det.store(true, std::memory_order_release);   // MUST precede eq_guard_page() below
             void* pg = (void*)(uintptr_t)eq_guard_page();            // now resolves to g_det_clock's page
             uint64_t after = getenv("PROSPER_EQ_GUARD_AFTER") ? strtoull(getenv("PROSPER_EQ_GUARD_AFTER"), 0, 0) : 2000;
@@ -857,13 +861,25 @@ extern "C" int prosper_eq_pageguard_classify(uint64_t addr) {
             uint64_t b = (uint64_t)(uintptr_t)mtx; return addr >= b && addr < b + 8;
         };
         bool victim = sig_hit(&g_det_clock) || sig_hit(&g_eq_mx) || sig_hit(&g_apr_mx);
-        g_eq_guard_relift.store(true, std::memory_order_release);
-        if (!victim) return 2;                                     // legit co-located write: silent
+        if (!g_eq_guard_step.load(std::memory_order_acquire))
+            g_eq_guard_relift.store(true, std::memory_order_release);   // async-relift mode only
+        if (!victim) return 2;                                     // legit co-located write (step: TF re-arm)
         g_eq_pageguard_armed.store(false, std::memory_order_release);
         return 1;                                                  // corruptor hit a victim: report
     }
     g_eq_pageguard_armed.store(false, std::memory_order_release);   // bigdecoy mode: one-shot
     return 1;
+}
+
+// det-step support (PR #753 round 8): the fault handler TF-single-steps a co-located write and then
+// re-arms the guard page RO immediately, so the RW window is one instruction wide (no async-relift gap
+// for the corruptor to slip through). Called only from the fault handler; one syscall, async-safe.
+extern "C" int  prosper_eq_guard_step_mode() { return g_eq_guard_step.load(std::memory_order_acquire) ? 1 : 0; }
+extern "C" void prosper_eq_guard_rearm() {
+#ifndef _WIN32
+    if (g_eq_pageguard_armed.load(std::memory_order_acquire))
+        mprotect((void*)(uintptr_t)eq_guard_page(), 4096, PROT_READ);
+#endif
 }
 
 // Exposed to hle_graphics.cpp (sceVideoOut* flip/vblank event registration).

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -410,7 +410,16 @@ namespace {
     // the state while k_eq_wait sat in cv.wait on it). Delete marks `deleted` and wakes waiters; the
     // object dies when the last reference drops.
     struct EqState { std::mutex m; std::condition_variable cv; std::deque<SceKEvent> ready; bool deleted = false; };
+    // #707 addressing-mode discriminator (PR #753): a mutex-sized DECOY declared immediately before
+    // g_eq_mx. On macOS both are initialized-sig mutexes sharing __DATA and the linker keeps the
+    // mutex cluster in declaration order, so the decoy takes g_eq_mx's former fixed offset and
+    // g_eq_mx shifts +64. If the corruptor targets the SLOT (binary_base + const, or one-past-
+    // g_det_clock), it now hits the decoy: the crash vanishes and the decoy's sig carries the
+    // payload (reported by the sig-watcher below). If it follows g_eq_mx by symbol, the crash
+    // persists at the new offset. Never locked — diagnostic layout ballast only.
+    std::mutex g_eq_decoy;
     std::mutex g_eq_mx;
+    extern std::mutex g_apr_mx;   // defined in the APR block below; sig-watched alongside g_eq_mx
     volatile uint8_t g_eq_canary_b[128] PROSPER_EQ_CANARY_INIT;   // #707 canary: immediately beside g_eq_mx/g_eqs in declaration order
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
@@ -459,6 +468,59 @@ namespace {
         static const bool on = getenv("PROSPER_EQ_CANARY") != nullptr;
         if (!on || g_eq_canary_started.exchange(true)) return;
         std::thread(eq_canary_thread).detach();
+    }
+
+    // --- #707 sig-watcher (PROSPER_EQ_SIGWATCH=1 or =repair; default off — see PR #753). A
+    // read-only poller over the stable head bytes of the cluster's mutexes. On macOS these are the
+    // pthread sig words: written once at image load, never by lock/unlock (legit locks touch
+    // offsets 24/32 only, verified on the issue), so ANY deviation from the armed baseline is the
+    // corruptor — reported as exact byte, old->new value, and time: the payload fingerprint the
+    // canaries cannot capture for a short targeted write. "repair" also restores the baseline
+    // byte, which on macOS suppresses the EINVAL crash so the run stays alive and every
+    // subsequent hit is captured too. On glibc the lock word [0,16) mutates legitimately, so the
+    // Linux build watches the stable __kind window instead — the diagnostic compiles and runs
+    // everywhere, but its target platform is macOS.
+    std::atomic<bool> g_eq_sigwatch_started{false};
+    void eq_sigwatch_thread(bool repair) {
+#ifdef __APPLE__
+        constexpr int kOff = 0, kLen = 16;    // pthread_mutex __sig + head: init-only on Darwin
+#else
+        constexpr int kOff = 16, kLen = 8;    // glibc __kind/__spins: never written for a plain mutex
+#endif
+        struct Target { const char* name; volatile uint8_t* p; uint8_t base[16]; };
+        static Target t[4] = {
+            { "g_eq_decoy",        (volatile uint8_t*)&g_eq_decoy,  {} },
+            { "g_eq_mx",           (volatile uint8_t*)&g_eq_mx,     {} },
+            { "g_det_clock.mutex", (volatile uint8_t*)&g_det_clock, {} },
+            { "g_apr_mx",          (volatile uint8_t*)&g_apr_mx,    {} },
+        };
+        for (auto& x : t) for (int i = 0; i < kLen; i++) x.base[i] = x.p[kOff + i];
+        fprintf(stderr, "[eq-sigwatch] armed repair=%d window=[%d,%d): decoy=%p eq_mx=%p det=%p apr=%p\n",
+                repair ? 1 : 0, kOff, kOff + kLen,
+                (void*)t[0].p, (void*)t[1].p, (void*)t[2].p, (void*)t[3].p);
+        auto ms = [] { struct timespec ts{}; clock_gettime(CLOCK_MONOTONIC, &ts);
+                       return (unsigned long long)ts.tv_sec * 1000ull + (unsigned long long)ts.tv_nsec / 1000000ull; };
+        uint64_t hits = 0;
+        for (;;) {
+            struct timespec ts{ 0, 200000 }; nanosleep(&ts, nullptr);   // 200 µs poll
+            for (auto& x : t)
+                for (int i = 0; i < kLen; i++) {
+                    uint8_t v = x.p[kOff + i];
+                    if (v == x.base[i]) continue;
+                    fprintf(stderr, "[eq-sigwatch] HIT %s off=%d 0x%02x->0x%02x addr=%p t=%llums%s\n",
+                            x.name, kOff + i, x.base[i], v, (void*)&x.p[kOff + i], ms(),
+                            repair ? " (repaired)" : "");
+                    if (repair) x.p[kOff + i] = x.base[i];
+                    else        x.base[i] = v;   // track the new state so further deltas keep reporting
+                    if (++hits >= 512) { fprintf(stderr, "[eq-sigwatch] report cap reached\n"); return; }
+                }
+        }
+    }
+    void eq_sigwatch_maybe_start() {
+        static const char* mode = getenv("PROSPER_EQ_SIGWATCH");
+        if (!mode || g_eq_sigwatch_started.exchange(true)) return;
+        bool repair = strcmp(mode, "repair") == 0;
+        std::thread(eq_sigwatch_thread, repair).detach();
     }
 
     std::shared_ptr<EqState> eq_find(uint64_t eq) {
@@ -518,7 +580,8 @@ namespace {
         }
     }
     void ensure_pump() {
-        eq_canary_maybe_start();   // #707 diagnostic; no-op unless PROSPER_EQ_CANARY is set
+        eq_canary_maybe_start();     // #707 diagnostics; no-ops unless their env vars are set
+        eq_sigwatch_maybe_start();
         if (!g_pump_started.exchange(true)) std::thread(vblank_pump).detach();
     }
 }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -881,13 +881,18 @@ namespace {
             // which mach_vm_write and other VM-system writes bypass (they honor max_protection). If the
             // corruptor respects max_prot, this BLOCKS the zeroing (SIGWATCH silent on lo) => a mach_vm
             // family write. If lo is STILL zeroed with max=RO => a physical alias / separate mapping.
+#ifdef __APPLE__
             kern_return_t kr = mach_vm_protect(mach_task_self(), (mach_vm_address_t)(uintptr_t)pg, 4096,
                                                TRUE /*set_maximum*/, VM_PROT_READ);
-            if (kr == KERN_SUCCESS) {
+            bool ok = (kr == KERN_SUCCESS);
+#else
+            bool ok = (mprotect(pg, 4096, PROT_READ) == 0);   // Linux: current-prot RO (mach max-prot is macOS-only)
+#endif
+            if (ok) {
                 g_eq_pageguard_armed.store(true, std::memory_order_release);
-                fprintf(stderr, "[eq-pageguard] armed LO(max=R): page %p (lo0=%p det=%p)\n",
+                fprintf(stderr, "[eq-pageguard] armed LO: page %p (lo0=%p det=%p)\n",
                         pg, (void*)&g_eq_decoy_lo0, (void*)&g_det_clock);
-            } else fprintf(stderr, "[eq-pageguard] mach_vm_protect(%p) FAILED kr=%d\n", pg, (int)kr);
+            } else fprintf(stderr, "[eq-pageguard] LO guard mprotect(%p) FAILED\n", pg);
             return;
         }
         if (strcmp(mode, "ballast") == 0) {

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -94,7 +94,14 @@ namespace {
     // no fault storm, no re-arm gap to race, and the FIRST fault on the page is the corruptor with
     // a clean rbp-chain. 72 mutexes = 4.5 KiB on Darwin; declaration order keeps it between det
     // and the hot cluster on macOS (verify with nm as usual).
-    std::mutex g_eq_ballast_hi[72];
+    // Enlarged to 176 (11 KiB) so it spans a FULL page-aligned page that is entirely ballast (round 9):
+    // the corruptor's region-zero was observed to engulf this array (both g_det_clock AND g_eq_mx —
+    // 0x12a0 apart across it — got zeroed), yet these mutexes are NEVER locked. So a page in the middle
+    // of the array is in the zeroed region AND has zero legit writers → guard it continuously from boot
+    // (PROSPER_EQ_PAGEGUARD=ballast): no det_clock-lock storm (unlike det's own page), no race, and the
+    // FIRST fault on it is the corruptor with a clean rbp-chain. det's page can't be used continuously
+    // because g_det_clock.mutex is locked by det_clock_now (the guest clock) — that IS a hot writer.
+    std::mutex g_eq_ballast_hi[176];
 
     uint64_t det_clock_fps() {
         static const uint64_t fps = [] {
@@ -702,7 +709,14 @@ namespace {
     std::atomic<bool> g_eq_guard_det{false};
     std::atomic<bool> g_eq_guard_relift{false};
     std::atomic<bool> g_eq_guard_step{false};   // det-step: TF single-step co-located writes (zero gap)
+    std::atomic<bool> g_eq_guard_ballast{false}; // ballast: guard a pure never-locked page in g_eq_ballast_hi
     uint64_t eq_guard_page() {
+        if (g_eq_guard_ballast.load(std::memory_order_acquire)) {
+            // First full page-aligned page at/above &g_eq_ballast_hi[0] (fully inside the 11 KiB array,
+            // never locked, in the corruptor's zeroed region). Closest full ballast page above det.
+            uint64_t base = (uint64_t)(uintptr_t)&g_eq_ballast_hi[0];
+            return (base + 4095) & ~4095ull;
+        }
         if (g_eq_guard_det.load(std::memory_order_acquire))
             return (uint64_t)(uintptr_t)&g_det_clock & ~4095ull;   // g_det_clock's own page
         uint64_t end = (uint64_t)(uintptr_t)&g_eq_bigdecoy[384];   // one-past-end of the 24 KiB array
@@ -738,6 +752,20 @@ namespace {
         static std::atomic<bool> once{false};
         if (once.exchange(true)) return;
         std::thread(eq_pageguard_reporter).detach();
+        if (strcmp(mode, "ballast") == 0) {
+            // BALLAST mode (round 9): guard a full page INSIDE g_eq_ballast_hi — never-locked mutexes in
+            // the corruptor's zeroed region. No legit writer touches it, so arm once from boot and stay
+            // armed; the FIRST fault is the corruptor. One-shot report path (like bigdecoy) but this page
+            // is actually in the zeroed run, so it triggers at runtime, not just teardown.
+            g_eq_guard_ballast.store(true, std::memory_order_release);   // before eq_guard_page()
+            void* pg = (void*)(uintptr_t)eq_guard_page();
+            if (mprotect(pg, 4096, PROT_READ) == 0) {
+                g_eq_pageguard_armed.store(true, std::memory_order_release);
+                fprintf(stderr, "[eq-pageguard] armed BALLAST: page %p PROT_READ (ballast_hi=%p..%p, det=%p)\n",
+                        pg, (void*)&g_eq_ballast_hi[0], (void*)&g_eq_ballast_hi[176], (void*)&g_det_clock);
+            } else fprintf(stderr, "[eq-pageguard] mprotect(%p) FAILED errno=%d\n", pg, errno);
+            return;
+        }
         if (strcmp(mode, "det") == 0 || strcmp(mode, "det-step") == 0) {
             // DET mode fault-storms the render if armed continuously (every co-located per-frame write on
             // g_det_clock's page faults). The corruptor fires in a narrow flip-count window (~2400), so

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -391,8 +391,18 @@ namespace {
     // an all-zeros range write that a value-conditional hardware watchpoint cannot even see —
     // is the stray write. The poller detects and localizes the hit bytes at native speed; the
     // armed addresses are printed so a second run can aim exact hardware watchpoints at them.
-    // The linker decides final .bss placement — verify adjacency with `nm --numeric-sort`.
-    volatile uint8_t g_eq_canary_a[128];
+    // The linker decides final placement — verify adjacency with `nm --numeric-sort`.
+    // SEGMENT MATCH (#707, macOS): the canaries must share g_eq_mx's segment to bracket it. On glibc
+    // g_eq_mx (std::mutex) is zero-init -> .bss, so UNINITIALIZED canaries co-locate (Linux: verified).
+    // On macOS the std::mutex PTHREAD_MUTEX_INITIALIZER sig is NON-ZERO -> g_eq_mx lands in __DATA, so an
+    // uninitialized canary goes to __bss (megabytes away, useless). Initialize the canaries on macOS so
+    // they land in __DATA beside g_eq_mx. (The arm step overwrites all 128 bytes with 0xA5 regardless.)
+#ifdef __APPLE__
+#define PROSPER_EQ_CANARY_INIT = {0xA5}
+#else
+#define PROSPER_EQ_CANARY_INIT
+#endif
+    volatile uint8_t g_eq_canary_a[128] PROSPER_EQ_CANARY_INIT;
     extern volatile uint8_t g_eq_canary_d[128];   // defined beside the APR ring arrays below
     // Equeue lifetime (#67): states are SHARED-ptr owned. eq_find hands out a reference that keeps
     // the object alive across the caller's wait, so sceKernelDeleteEqueue can never destroy a mutex/
@@ -401,7 +411,7 @@ namespace {
     // object dies when the last reference drops.
     struct EqState { std::mutex m; std::condition_variable cv; std::deque<SceKEvent> ready; bool deleted = false; };
     std::mutex g_eq_mx;
-    volatile uint8_t g_eq_canary_b[128];   // #707 canary: immediately beside g_eq_mx/g_eqs in declaration order
+    volatile uint8_t g_eq_canary_b[128] PROSPER_EQ_CANARY_INIT;   // #707 canary: immediately beside g_eq_mx/g_eqs in declaration order
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
     std::vector<FlipReg> g_flip_regs, g_vblank_regs;
@@ -422,7 +432,7 @@ namespace {
     struct TimerTok { std::shared_ptr<std::atomic<bool>> cancelled; };
     std::map<std::pair<uint64_t, int64_t>, TimerTok> g_timers;
     std::atomic<bool> g_pump_started{false};
-    volatile uint8_t g_eq_canary_c[128];   // #707 canary: tail side of the timer/registration block
+    volatile uint8_t g_eq_canary_c[128] PROSPER_EQ_CANARY_INIT;   // #707 canary: tail side of the timer/registration block
     std::atomic<bool> g_eq_canary_started{false};
     void eq_canary_thread() {
         volatile uint8_t* rows[4] = { g_eq_canary_a, g_eq_canary_b, g_eq_canary_c, g_eq_canary_d };
@@ -790,7 +800,7 @@ namespace {
     // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
     std::mutex g_apr_mx;
     std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
-    volatile uint8_t g_eq_canary_d[128];               // #707 canary (declared beside g_eq_mx above)
+    volatile uint8_t g_eq_canary_d[128] PROSPER_EQ_CANARY_INIT;   // #707 canary (declared beside g_eq_mx above)
     uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
     uint64_t g_apr_tag_hwm[64] = {};                   // per-ring highest tag counter posted (guarded)
     void apr_post(const AprEqReg& r, unsigned ring, uint64_t token) {   // no APR lock held

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -9,6 +9,10 @@
 #include <sys/syscall.h>
 #include <sys/uio.h>   // process_vm_readv (slot-echo scan, issue #180)
 #include <sys/mman.h>  // mprotect (the #707 decoy page guard, PR #753)
+#ifdef __APPLE__
+#include <mach/mach.h>       // #707: mach_vm_region probe — is the zeroing a store or a remap?
+#include <mach/mach_vm.h>
+#endif
 #endif
 #include <cstdint>
 #include <cstdlib>
@@ -529,6 +533,26 @@ namespace {
     // Linux build watches the stable __kind window instead — the diagnostic compiles and runs
     // everywhere, but its target platform is macOS.
     std::atomic<bool> g_eq_sigwatch_started{false};
+#ifdef __APPLE__
+    // #707: describe the mach VM region covering `addr` — base/size/prot/user_tag/share_mode. If the
+    // corruptor REPLACES the mapping (mmap/vm_allocate MAP_FIXED), the region at det changes (new base
+    // or tag); if it STORES in place, the region is unchanged and only the bytes differ. This settles
+    // store-vs-remap without catching the writer.
+    static void eq_region_desc(uint64_t addr, char* out, size_t cap) {
+        mach_vm_address_t ra = addr; mach_vm_size_t rs = 0;
+        vm_region_basic_info_data_64_t info{}; mach_msg_type_number_t cnt = VM_REGION_BASIC_INFO_COUNT_64;
+        mach_port_t obj = MACH_PORT_NULL;
+        kern_return_t kr = mach_vm_region(mach_task_self(), &ra, &rs, VM_REGION_BASIC_INFO_64,
+                                          (vm_region_info_t)&info, &cnt, &obj);
+        if (kr != KERN_SUCCESS) { snprintf(out, cap, "region: kr=%d (unmapped?)", (int)kr); return; }
+        snprintf(out, cap, "region base=0x%llx size=0x%llx prot=%c%c%c shared=%d resv=%d",
+                 (unsigned long long)ra, (unsigned long long)rs,
+                 (info.protection & VM_PROT_READ) ? 'r' : '-',
+                 (info.protection & VM_PROT_WRITE) ? 'w' : '-',
+                 (info.protection & VM_PROT_EXECUTE) ? 'x' : '-',
+                 (int)info.shared, (int)info.reserved);
+    }
+#endif
     void eq_sigwatch_thread(bool repair, bool taint) {
 #ifdef __APPLE__
         constexpr int kOff = 0, kLen = 16;    // pthread_mutex __sig + head: init-only on Darwin
@@ -568,6 +592,11 @@ namespace {
         fprintf(stderr, "[eq-sigwatch] armed repair=%d taint=%d: decoy=%p eq_mx=%p det=%p apr=%p\n",
                 repair ? 1 : 0, taint ? 1 : 0,
                 (void*)t[6].p, (void*)t[7].p, (void*)t[8].p, (void*)t[9].p);
+#ifdef __APPLE__
+        { char rd[160]; eq_region_desc((uint64_t)(uintptr_t)&g_det_clock, rd, sizeof rd);
+          fprintf(stderr, "[eq-sigwatch] BASELINE det %s\n", rd); }
+        bool region_probed = false;
+#endif
         auto ms = [] { struct timespec ts{}; clock_gettime(CLOCK_MONOTONIC, &ts);
                        return (unsigned long long)ts.tv_sec * 1000ull + (unsigned long long)ts.tv_nsec / 1000000ull; };
         uint64_t hits = 0;
@@ -580,6 +609,14 @@ namespace {
                     fprintf(stderr, "[eq-sigwatch] HIT %s off=%d 0x%02x->0x%02x addr=%p t=%llums%s\n",
                             x.name, x.off + i, x.base[i], v, (void*)&x.p[x.off + i], ms(),
                             repair ? " (repaired)" : "");
+#ifdef __APPLE__
+                    if (!region_probed) {
+                        region_probed = true;
+                        char rd[160]; eq_region_desc((uint64_t)(uintptr_t)x.p, rd, sizeof rd);
+                        fprintf(stderr, "[eq-sigwatch] AT-HIT %s %s  (store => region unchanged; remap => new base/prot)\n",
+                                x.name, rd);
+                    }
+#endif
                     if (repair) x.p[x.off + i] = x.base[i];
                     else        x.base[i] = v;   // track the new state so further deltas keep reporting
                     if (++hits >= 512) { fprintf(stderr, "[eq-sigwatch] report cap reached\n"); return; }
@@ -648,6 +685,41 @@ namespace {
         if (eq_in_cluster(d, n)) eq_report_cluster("memmove", d, n);
         return memmove(d, s, n);
     }
+    // #707: catch ANY mmap/munmap that lands on our OWN loaded image — the macOS guest-window
+    // collision (image at [4 GiB, ~4 GiB+11 MB] is inside [GPU_VA_LO, GPU_VA_HI)). A MAP_FIXED over
+    // our __TEXT/__DATA replaces the mapping with fresh zero pages and corrupts host globals with no
+    // page fault, so page-guards/watchpoints never see it. Always on (an overlap never happens
+    // legitimately), non-signal context. Call the real syscall directly: mmap/munmap are not
+    // compiler builtins, so calling mmap() here would re-enter this interposer (recursion).
+    extern "C" int prosper_fixed_map_hits_host_image(uint64_t addr, uint64_t len);
+    void eq_report_img(const char* fn, const void* target, size_t n, int flags) {
+        static std::atomic<int> seen{0};
+        int idx = seen.fetch_add(1); if (idx > 24) return;
+        struct timespec ts{}; clock_gettime(CLOCK_MONOTONIC, &ts);
+        unsigned long long ms = (unsigned long long)ts.tv_sec * 1000ull + ts.tv_nsec / 1000000ull;
+        void* bt[40]; int nb = backtrace(bt, 40);
+        fprintf(stderr, "[#707-img] #%d %s(%p,len=%zu,flags=0x%x) OVER HOST IMAGE t=%llums:\n",
+                idx, fn, target, n, flags, ms);
+        char** syms = backtrace_symbols(bt, nb);
+        for (int i = 0; i < nb; i++) fprintf(stderr, "[#707-img]   %s\n", syms ? syms[i] : "?");
+        free(syms); fflush(stderr);
+    }
+    extern "C" void* prosper_int_mmap(void* a, size_t n, int prot, int flags, int fd, off_t off) {
+        // RTLD_NEXT bypasses the interpose (a function-pointer call skips the rewritten binding),
+        // so this reaches libSystem's real mmap without recursing and without the 32-bit-truncating
+        // deprecated syscall().
+        static auto real = (void* (*)(void*, size_t, int, int, int, off_t))dlsym(RTLD_NEXT, "mmap");
+        void* r = real ? real(a, n, prot, flags, fd, off) : MAP_FAILED;
+        if (r != MAP_FAILED && prosper_fixed_map_hits_host_image((uint64_t)(uintptr_t)r, n))
+            eq_report_img("mmap", r, n, flags);
+        return r;
+    }
+    extern "C" int prosper_int_munmap(void* a, size_t n) {
+        static auto real = (int (*)(void*, size_t))dlsym(RTLD_NEXT, "munmap");
+        if (prosper_fixed_map_hits_host_image((uint64_t)(uintptr_t)a, n))
+            eq_report_img("munmap", a, n, 0);
+        return real ? real(a, n) : -1;
+    }
     #define PROSPER_DYLD_INTERPOSE(_repl,_orig) \
         __attribute__((used)) static struct { const void* r; const void* o; } \
         _interpose_##_orig __attribute__((section("__DATA,__interpose"))) = \
@@ -657,6 +729,8 @@ namespace {
     PROSPER_DYLD_INTERPOSE(prosper_int_memset, memset)
     PROSPER_DYLD_INTERPOSE(prosper_int_bzero, bzero)
     PROSPER_DYLD_INTERPOSE(prosper_int_memmove, memmove)
+    PROSPER_DYLD_INTERPOSE(prosper_int_mmap, mmap)
+    PROSPER_DYLD_INTERPOSE(prosper_int_munmap, munmap)
 #endif
 
     // #707 decoy-page guard arming (PR #753 round 5; no-op unless PROSPER_EQ_PAGEGUARD is set and
@@ -710,7 +784,13 @@ namespace {
     std::atomic<bool> g_eq_guard_relift{false};
     std::atomic<bool> g_eq_guard_step{false};   // det-step: TF single-step co-located writes (zero gap)
     std::atomic<bool> g_eq_guard_ballast{false}; // ballast: guard a pure never-locked page in g_eq_ballast_hi
+    std::atomic<bool> g_eq_guard_lo{false};      // lo: guard the page-aligned lo-decoy page (IN the zeroed set)
     uint64_t eq_guard_page() {
+        if (g_eq_guard_lo.load(std::memory_order_acquire))
+            // g_eq_decoy_lo0 is page-aligned and is the LOWEST address the corruptor zeroes (confirmed by
+            // SIGWATCH). The ballast page (above det) is NOT in the zeroed set, so it never faults; the lo
+            // page IS. Never-locked, so a continuous-from-boot RO guard has no co-located writer to race.
+            return (uint64_t)(uintptr_t)&g_eq_decoy_lo0 & ~4095ull;
         if (g_eq_guard_ballast.load(std::memory_order_acquire)) {
             // First full page-aligned page at/above &g_eq_ballast_hi[0] (fully inside the 11 KiB array,
             // never locked, in the corruptor's zeroed region). Closest full ballast page above det.
@@ -766,6 +846,27 @@ namespace {
         static std::atomic<bool> once{false};
         if (once.exchange(true)) return;
         std::thread(eq_pageguard_reporter).detach();
+        if (strcmp(mode, "lo") == 0) {
+            // LO mode: guard the page-aligned lo-decoy page — the LOWEST address the corruptor zeroes
+            // (SIGWATCH-confirmed) and the one the ballast page (above det) failed to cover. Never-locked
+            // page, armed once from boot, one-shot: the FIRST fault is the corruptor's store. If lo IS
+            // zeroed (SIGWATCH) while this page stays RO and NO fault fires, the store bypasses our
+            // SIGSEGV handler (Rosetta) — a decisive result either way.
+            g_eq_guard_lo.store(true, std::memory_order_release);   // before eq_guard_page()
+            void* pg = (void*)(uintptr_t)eq_guard_page();
+            // Lower the MAX protection to READ (not just current). mprotect() only sets current prot,
+            // which mach_vm_write and other VM-system writes bypass (they honor max_protection). If the
+            // corruptor respects max_prot, this BLOCKS the zeroing (SIGWATCH silent on lo) => a mach_vm
+            // family write. If lo is STILL zeroed with max=RO => a physical alias / separate mapping.
+            kern_return_t kr = mach_vm_protect(mach_task_self(), (mach_vm_address_t)(uintptr_t)pg, 4096,
+                                               TRUE /*set_maximum*/, VM_PROT_READ);
+            if (kr == KERN_SUCCESS) {
+                g_eq_pageguard_armed.store(true, std::memory_order_release);
+                fprintf(stderr, "[eq-pageguard] armed LO(max=R): page %p (lo0=%p det=%p)\n",
+                        pg, (void*)&g_eq_decoy_lo0, (void*)&g_det_clock);
+            } else fprintf(stderr, "[eq-pageguard] mach_vm_protect(%p) FAILED kr=%d\n", pg, (int)kr);
+            return;
+        }
         if (strcmp(mode, "ballast") == 0) {
             // BALLAST mode (round 9): guard a full page INSIDE g_eq_ballast_hi — never-locked mutexes in
             // the corruptor's zeroed region. No legit writer touches it, so arm once from boot and stay

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -722,6 +722,20 @@ namespace {
         uint64_t end = (uint64_t)(uintptr_t)&g_eq_bigdecoy[384];   // one-past-end of the 24 KiB array
         return (end & ~4095ull) - 4096;                            // last page fully inside the array
     }
+    // Exit-time false-positive suppressor (round 10): at process exit the guarded arrays' OWN static
+    // destructors (~mutex on each element -> pthread_mutex_destroy) fault the still-armed RO page and
+    // masquerade as the corruptor. This object is declared AFTER g_eq_bigdecoy/g_eq_ballast_hi, so its
+    // destructor runs BEFORE theirs (reverse construction order): it disarms the guard and lifts the
+    // page to RW, so the array dtors run harmlessly and only a RUNTIME fault can report.
+    struct EqGuardDisarmer {
+        ~EqGuardDisarmer() {
+#ifndef _WIN32
+            if (g_eq_pageguard_armed.exchange(false))
+                mprotect((void*)(uintptr_t)eq_guard_page(), 4096, PROT_READ | PROT_WRITE);
+#endif
+        }
+    };
+    EqGuardDisarmer g_eq_guard_disarmer;   // dtor runs before the ballast/bigdecoy array dtors
     // Continuous re-arm: keep g_det_clock's page RO except for the brief windows the handler lifts it
     // for a legitimate co-located write. Idempotent mprotect every ~25 µs, so the corruptor's store
     // (which lands on a victim offset) almost always hits an RO page and faults -> caught.

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -513,42 +513,58 @@ namespace {
     // Linux build watches the stable __kind window instead — the diagnostic compiles and runs
     // everywhere, but its target platform is macOS.
     std::atomic<bool> g_eq_sigwatch_started{false};
-    void eq_sigwatch_thread(bool repair) {
+    void eq_sigwatch_thread(bool repair, bool taint) {
 #ifdef __APPLE__
         constexpr int kOff = 0, kLen = 16;    // pthread_mutex __sig + head: init-only on Darwin
 #else
         constexpr int kOff = 16, kLen = 8;    // glibc __kind/__spins: never written for a plain mutex
 #endif
-        struct Target { const char* name; volatile uint8_t* p; uint8_t base[16]; };
+        struct Target { const char* name; volatile uint8_t* p; bool taintable; int off, len; uint8_t base[16]; };
+        // taintable = the mutex is NEVER locked in this configuration, so its head bytes are dead
+        // storage we may pre-fill. g_det_clock.mutex is only locked under PROSPER_DET_CLOCK (checked
+        // below); the decoys are never locked by construction. g_eq_mx/g_apr_mx are hot — never taint.
         static Target t[10] = {
-            { "g_eq_decoy_lo0",    (volatile uint8_t*)&g_eq_decoy_lo0, {} },
-            { "g_eq_decoy_lo1",    (volatile uint8_t*)&g_eq_decoy_lo1, {} },
-            { "g_eq_decoy_lo2",    (volatile uint8_t*)&g_eq_decoy_lo2, {} },
-            { "g_eq_decoy_lo3",    (volatile uint8_t*)&g_eq_decoy_lo3, {} },
-            { "g_eq_decoy_lo4",    (volatile uint8_t*)&g_eq_decoy_lo4, {} },
-            { "g_eq_decoy_lo5",    (volatile uint8_t*)&g_eq_decoy_lo5, {} },
-            { "g_eq_decoy",        (volatile uint8_t*)&g_eq_decoy,  {} },
-            { "g_eq_mx",           (volatile uint8_t*)&g_eq_mx,     {} },
-            { "g_det_clock.mutex", (volatile uint8_t*)&g_det_clock, {} },
-            { "g_apr_mx",          (volatile uint8_t*)&g_apr_mx,    {} },
+            { "g_eq_decoy_lo0",    (volatile uint8_t*)&g_eq_decoy_lo0, true,  0, 0, {} },
+            { "g_eq_decoy_lo1",    (volatile uint8_t*)&g_eq_decoy_lo1, true,  0, 0, {} },
+            { "g_eq_decoy_lo2",    (volatile uint8_t*)&g_eq_decoy_lo2, true,  0, 0, {} },
+            { "g_eq_decoy_lo3",    (volatile uint8_t*)&g_eq_decoy_lo3, true,  0, 0, {} },
+            { "g_eq_decoy_lo4",    (volatile uint8_t*)&g_eq_decoy_lo4, true,  0, 0, {} },
+            { "g_eq_decoy_lo5",    (volatile uint8_t*)&g_eq_decoy_lo5, true,  0, 0, {} },
+            { "g_eq_decoy",        (volatile uint8_t*)&g_eq_decoy,     true,  0, 0, {} },
+            { "g_eq_mx",           (volatile uint8_t*)&g_eq_mx,        false, 0, 0, {} },
+            { "g_det_clock.mutex", (volatile uint8_t*)&g_det_clock,    true,  0, 0, {} },
+            { "g_apr_mx",          (volatile uint8_t*)&g_apr_mx,       false, 0, 0, {} },
         };
-        for (auto& x : t) for (int i = 0; i < kLen; i++) x.base[i] = x.p[kOff + i];
-        fprintf(stderr, "[eq-sigwatch] armed repair=%d window=[%d,%d): decoy=%p eq_mx=%p det=%p apr=%p\n",
-                repair ? 1 : 0, kOff, kOff + kLen,
-                (void*)t[0].p, (void*)t[1].p, (void*)t[2].p, (void*)t[3].p);
+        // #707 round 7: an all-zeros store over all-zeros bytes is invisible to a baseline diff AND
+        // to hardware watchpoints (no value change). glibc mutexes are all-zero at rest, so on Linux
+        // a det-anchored zeroing (the round-6 macOS finding) slips through the default [16,24) kind
+        // window untainted. taint mode pre-fills the never-locked targets' head bytes with 0xA5 so
+        // the zeroing becomes a visible transition — for this poller and for a follow-up gdb
+        // hardware watchpoint on the same bytes. det is only tainted while PROSPER_DET_CLOCK is off.
+        const bool det_in_use = getenv("PROSPER_DET_CLOCK") != nullptr;
+        for (auto& x : t) {
+            bool tainted = taint && x.taintable && !(x.p == (volatile uint8_t*)&g_det_clock && det_in_use);
+            x.off = tainted ? 0 : kOff;
+            x.len = tainted ? 16 : kLen;
+            if (tainted) for (int i = 0; i < x.len; i++) x.p[x.off + i] = 0xA5;
+            for (int i = 0; i < x.len; i++) x.base[i] = x.p[x.off + i];
+        }
+        fprintf(stderr, "[eq-sigwatch] armed repair=%d taint=%d: decoy=%p eq_mx=%p det=%p apr=%p\n",
+                repair ? 1 : 0, taint ? 1 : 0,
+                (void*)t[6].p, (void*)t[7].p, (void*)t[8].p, (void*)t[9].p);
         auto ms = [] { struct timespec ts{}; clock_gettime(CLOCK_MONOTONIC, &ts);
                        return (unsigned long long)ts.tv_sec * 1000ull + (unsigned long long)ts.tv_nsec / 1000000ull; };
         uint64_t hits = 0;
         for (;;) {
             struct timespec ts{ 0, 200000 }; nanosleep(&ts, nullptr);   // 200 µs poll
             for (auto& x : t)
-                for (int i = 0; i < kLen; i++) {
-                    uint8_t v = x.p[kOff + i];
+                for (int i = 0; i < x.len; i++) {
+                    uint8_t v = x.p[x.off + i];
                     if (v == x.base[i]) continue;
                     fprintf(stderr, "[eq-sigwatch] HIT %s off=%d 0x%02x->0x%02x addr=%p t=%llums%s\n",
-                            x.name, kOff + i, x.base[i], v, (void*)&x.p[kOff + i], ms(),
+                            x.name, x.off + i, x.base[i], v, (void*)&x.p[x.off + i], ms(),
                             repair ? " (repaired)" : "");
-                    if (repair) x.p[kOff + i] = x.base[i];
+                    if (repair) x.p[x.off + i] = x.base[i];
                     else        x.base[i] = v;   // track the new state so further deltas keep reporting
                     if (++hits >= 512) { fprintf(stderr, "[eq-sigwatch] report cap reached\n"); return; }
                 }
@@ -558,7 +574,9 @@ namespace {
         static const char* mode = getenv("PROSPER_EQ_SIGWATCH");
         if (!mode || g_eq_sigwatch_started.exchange(true)) return;
         bool repair = strcmp(mode, "repair") == 0;
-        std::thread(eq_sigwatch_thread, repair).detach();
+        bool taint  = strcmp(mode, "taint") == 0 || strcmp(mode, "taint-repair") == 0;
+        if (strcmp(mode, "taint-repair") == 0) repair = true;
+        std::thread(eq_sigwatch_thread, repair, taint).detach();
     }
 
 #ifdef __APPLE__

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -470,7 +470,30 @@ namespace {
     // payload (reported by the sig-watcher below). If it follows g_eq_mx by symbol, the crash
     // persists at the new offset. Never locked — diagnostic layout ballast only.
     std::mutex g_eq_decoy;
+#ifdef __APPLE__
+    // #707 fix (macOS): the equeue-cluster corruptor zeroes a __DATA byte range; a std::mutex living
+    // there gets its pthread __sig zeroed and the next lock returns EINVAL, terminating vblank_pump.
+    // The corruptor is an inlined, image-relative CPU store that macOS/Rosetta tooling cannot attribute
+    // (no HW watchpoints; mprotect guards are bypassed by Rosetta-translated stores; the store is inlined
+    // past every memset/mmap/mach_vm interpose; GPU DMA is excluded) — but round-2 evidence (PR #753)
+    // showed it does NOT reach .bss. So keep the equeue mutex OFF __DATA: g_eq_mx_ptr is a plain .bss
+    // pointer (zero-init, no ctor), the real std::mutex is heap-allocated ONCE at static init (single-
+    // threaded, before the guest runs — never new/malloc on a lock path, which would deadlock the %fs
+    // SIGSEGV handler that also takes this lock), and EqMutex is a trivial 0-member forwarder so it too
+    // lands in .bss and std::lock_guard/std::unique_lock keep working unchanged (via CTAD). On Linux the
+    // std::mutex is already zero-init/.bss and unaffected, so this is macOS-only.
+    std::mutex* g_eq_mx_ptr;                                             // .bss
+    struct EqMxInit { EqMxInit() { g_eq_mx_ptr = new std::mutex(); } };  // ctor runs once at static init
+    EqMxInit g_eq_mx_init;
+    struct EqMutex {
+        void lock()     { g_eq_mx_ptr->lock(); }
+        void unlock()   { g_eq_mx_ptr->unlock(); }
+        bool try_lock() { return g_eq_mx_ptr->try_lock(); }
+    };
+    EqMutex g_eq_mx;   // trivial, 0-member -> .bss; forwards to the heap mutex
+#else
     std::mutex g_eq_mx;
+#endif
     extern std::mutex g_apr_mx;   // defined in the APR block below; sig-watched alongside g_eq_mx
     volatile uint8_t g_eq_canary_b[128] PROSPER_EQ_CANARY_INIT;   // #707 canary: immediately beside g_eq_mx/g_eqs in declaration order
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
@@ -928,7 +951,7 @@ namespace {
     }
 
     std::shared_ptr<EqState> eq_find(uint64_t eq) {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_eqs.find(eq);
         return it == g_eqs.end() ? nullptr : it->second;
     }
@@ -965,7 +988,7 @@ namespace {
             struct timespec ts{ 0, 16666667 }; nanosleep(&ts, nullptr);   // ~60 Hz
             frame++;
             std::vector<FlipReg> vr;
-            { std::lock_guard<std::mutex> lk(g_eq_mx); vr = g_vblank_regs; }
+            { std::lock_guard lk(g_eq_mx); vr = g_vblank_regs; }
             // Vblank ticks are periodic by nature — pump them. FLIP events are NOT pumped: a flip
             // event fires when a submitted flip completes (prosper_eq_trigger_flip below), carrying
             // that flip's flipArg in `data`. The old timer-driven flip event carried a frame counter
@@ -978,7 +1001,7 @@ namespace {
             // to signal work; if the producer path isn't reached, that thread starves and the game idles.
             // Firing it each vblank tests whether waking that consumer lets the game progress to real draws.
             if (getenv("PROSPER_PUMP_USEREV")) {
-                std::vector<UserReg> ur; { std::lock_guard<std::mutex> lk(g_eq_mx); ur = g_user_regs; }
+                std::vector<UserReg> ur; { std::lock_guard lk(g_eq_mx); ur = g_user_regs; }
                 for (auto& r : ur) { SceKEvent e{}; e.ident = r.id; e.filter = -11 /*EVFILT_USER*/; e.udata = r.udata; eq_post(r.eq, e); }
             }
         }
@@ -1036,7 +1059,7 @@ extern "C" void prosper_eq_guard_rearm() {
 
 // Exposed to hle_graphics.cpp (sceVideoOut* flip/vblank event registration).
 void prosper_eq_add_flip(uint64_t eq, int64_t ident, uint64_t udata) {
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_flip_regs.push_back({ eq, ident, udata }); }
+    { std::lock_guard lk(g_eq_mx); g_flip_regs.push_back({ eq, ident, udata }); }
     ensure_pump();
 }
 // Fire the flip-completion event on every registered flip equeue — called by BOTH flip paths
@@ -1044,7 +1067,7 @@ void prosper_eq_add_flip(uint64_t eq, int64_t ident, uint64_t udata) {
 // flip_event_trigger_func: ident=VIDEO_OUT_EVENT_FLIP, data=the completed flip's flipArg.
 void prosper_eq_trigger_flip(int64_t flip_arg) {
     std::vector<FlipReg> regs;
-    { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_flip_regs; }
+    { std::lock_guard lk(g_eq_mx); regs = g_flip_regs; }
     for (auto& r : regs) {
         SceKEvent e{}; e.ident = VIDEO_OUT_EVENT_FLIP; e.filter = EVFILT_VIDEO_OUT;
         e.fflags = 1; e.data = flip_arg; e.udata = r.udata;
@@ -1052,12 +1075,12 @@ void prosper_eq_trigger_flip(int64_t flip_arg) {
     }
 }
 void prosper_eq_add_vblank(uint64_t eq, int64_t ident, uint64_t udata) {
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_vblank_regs.push_back({ eq, ident, udata }); }
+    { std::lock_guard lk(g_eq_mx); g_vblank_regs.push_back({ eq, ident, udata }); }
     ensure_pump();
 }
 // Exposed to the AGC submit path (hle_agc.cpp). Register a GPU EOP event source (sceGnmAddEqEvent).
 void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
-    std::lock_guard<std::mutex> lk(g_eq_mx); g_eop_regs.push_back({ eq, id, udata });
+    std::lock_guard lk(g_eq_mx); g_eop_regs.push_back({ eq, id, udata });
 }
 // Fire the registered EOP events — called when a submit completes. Posts TriggerEvent(ident=id,
 // filter=GraphicsCore, data=id, udata) to each registered equeue, matching shadPS4's IRQ handler.
@@ -1080,7 +1103,7 @@ namespace {
         // is a discrete count, never a level. PROSPER_EOP_COALESCE restores the old behavior.
         static const bool coalesce = getenv("PROSPER_EOP_COALESCE") != nullptr;
         std::vector<FlipReg> regs;
-        { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_eop_regs; }
+        { std::lock_guard lk(g_eq_mx); regs = g_eop_regs; }
         for (auto& r : regs) {
             SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
             eq_post(r.eq, e, coalesce);
@@ -1140,7 +1163,7 @@ void prosper_eq_trigger_eop() {
 HLE(k_eq_create) {
     auto s = std::make_shared<EqState>();
     if (a0) *(void**)P(a0) = (void*)s.get();   // the guest's opaque SceKernelEqueue handle IS our state ptr
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_eqs[(uint64_t)(uintptr_t)s.get()] = s; }
+    { std::lock_guard lk(g_eq_mx); g_eqs[(uint64_t)(uintptr_t)s.get()] = s; }
     if (evlog()) fprintf(stderr, "[ev] CreateEqueue -> eq=%p name=%s\n", (void*)s.get(), a1 ? (const char*)P(a1) : "");
     return 0;
 }
@@ -1148,7 +1171,7 @@ HLE(k_eq_delete) {
     if (!a0) return 0;
     std::shared_ptr<EqState> s;
     {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_eqs.find(a0);
         if (it != g_eqs.end()) { s = std::move(it->second); g_eqs.erase(it); }
         // Purge every registration pointing at this queue (#67). Without this, a later heap
@@ -1445,14 +1468,14 @@ namespace {
     // (UserReg / g_user_regs are declared above, before the vblank pump.)
 }
 HLE(k_add_user_event) {   // (eq, id, udata?) — register a user event source on the equeue
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_user_regs.push_back({ a0, (int64_t)a1, a2 }); }
+    { std::lock_guard lk(g_eq_mx); g_user_regs.push_back({ a0, (int64_t)a1, a2 }); }
     if (evlog()) fprintf(stderr, "[ev] AddUserEvent eq=0x%llx id=%lld udata=0x%llx\n",
         (unsigned long long)a0, (long long)a1, (unsigned long long)a2);
     return 0;
 }
 HLE(k_trigger_user_event) {   // (eq, id, udata) — fire the user event: post it to the equeue
     uint64_t udata = a2;
-    { std::lock_guard<std::mutex> lk(g_eq_mx);
+    { std::lock_guard lk(g_eq_mx);
       for (auto& r : g_user_regs) if (r.eq == a0 && r.id == (int64_t)a1) { if (!udata) udata = r.udata; break; } }
     SceKEvent e{}; e.ident = (int64_t)a1; e.filter = EVFILT_USER; e.udata = udata;
     eq_post(a0, e);
@@ -1473,7 +1496,7 @@ HLE(k_trigger_user_event) {   // (eq, id, udata) — fire the user event: post i
 static void post_after(uint64_t eq, int64_t id, uint64_t udata, uint64_t usec, int16_t filter, bool periodic) {
     auto cancelled = std::make_shared<std::atomic<bool>>(false);
     {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto key = std::make_pair(eq, id);
         auto it = g_timers.find(key);
         if (it != g_timers.end()) it->second.cancelled->store(true);   // re-arm replaces the pending shot
@@ -1492,7 +1515,7 @@ static void post_after(uint64_t eq, int64_t id, uint64_t udata, uint64_t usec, i
             eq_post(eq, e);
         } while (periodic && !cancelled->load());
         // forget the registration once we stop firing (only if it is still OUR token, not a re-arm's)
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_timers.find(std::make_pair(eq, id));
         if (it != g_timers.end() && it->second.cancelled == cancelled) g_timers.erase(it);
     }).detach();
@@ -1501,7 +1524,7 @@ static void post_after(uint64_t eq, int64_t id, uint64_t udata, uint64_t usec, i
 HLE(k_del_timer_event) {   // (eq, id)
     bool cancelled = false;
     {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_timers.find(std::make_pair(a0, (int64_t)a1));
         if (it != g_timers.end()) { it->second.cancelled->store(true); g_timers.erase(it); cancelled = true; }
     }
@@ -1512,7 +1535,7 @@ HLE(k_del_timer_event) {   // (eq, id)
 // Remove a registered user-event source (previously a no-op: a deleted source kept receiving
 // TriggerUserEvent posts and diagnostic-pump heartbeats).
 HLE(k_del_user_event) {   // (eq, id)
-    std::lock_guard<std::mutex> lk(g_eq_mx);
+    std::lock_guard lk(g_eq_mx);
     g_user_regs.erase(std::remove_if(g_user_regs.begin(), g_user_regs.end(),
                       [&](const UserReg& r){ return r.eq == a0 && r.id == (int64_t)a1; }), g_user_regs.end());
     if (evlog()) fprintf(stderr, "[ev] DeleteUserEvent eq=0x%llx id=%lld\n", (unsigned long long)a0, (long long)a1);

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -53,6 +53,13 @@ namespace {
         uint64_t anchor_flip = 0;
         uint64_t last_ns = 0;
     };
+    // #707/PR #753 round 3: the corruptor is a one-shot ~288-byte ZEROING whose observed span is
+    // [g_det_clock .. g_apr_mx+64) on macOS — but nothing below g_det_clock was watched, so the
+    // true START is unknown. Mutex-typed decoys are the only objects the macOS linker will place
+    // below g_det_clock inside the __DATA mutex cluster (byte arrays get grouped after it), so
+    // these six extend the sig-watched window 384 bytes downward. Never locked; layout ballast.
+    std::mutex g_eq_decoy_lo0, g_eq_decoy_lo1, g_eq_decoy_lo2,
+               g_eq_decoy_lo3, g_eq_decoy_lo4, g_eq_decoy_lo5;
     DetClockState g_det_clock;
 
     uint64_t det_clock_fps() {
@@ -488,7 +495,13 @@ namespace {
         constexpr int kOff = 16, kLen = 8;    // glibc __kind/__spins: never written for a plain mutex
 #endif
         struct Target { const char* name; volatile uint8_t* p; uint8_t base[16]; };
-        static Target t[4] = {
+        static Target t[10] = {
+            { "g_eq_decoy_lo0",    (volatile uint8_t*)&g_eq_decoy_lo0, {} },
+            { "g_eq_decoy_lo1",    (volatile uint8_t*)&g_eq_decoy_lo1, {} },
+            { "g_eq_decoy_lo2",    (volatile uint8_t*)&g_eq_decoy_lo2, {} },
+            { "g_eq_decoy_lo3",    (volatile uint8_t*)&g_eq_decoy_lo3, {} },
+            { "g_eq_decoy_lo4",    (volatile uint8_t*)&g_eq_decoy_lo4, {} },
+            { "g_eq_decoy_lo5",    (volatile uint8_t*)&g_eq_decoy_lo5, {} },
             { "g_eq_decoy",        (volatile uint8_t*)&g_eq_decoy,  {} },
             { "g_eq_mx",           (volatile uint8_t*)&g_eq_mx,     {} },
             { "g_det_clock.mutex", (volatile uint8_t*)&g_det_clock, {} },

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -14,6 +14,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <dlfcn.h>
+#include <execinfo.h>
 #include <cerrno>
 #include <atomic>
 #include <ctime>
@@ -73,6 +75,15 @@ namespace {
     // belongs entirely to this object.
     struct alignas(4096) EqDecoyPage { std::mutex m[128]; };   // >= 4 KiB on both glibc and Darwin
     EqDecoyPage g_eq_decoy_page;
+    // #707 round 6: the alignas(4096) page above proved a DEAD END — the linker files aligned data in
+    // a separate __DATA sub-region, so the corruptor's contiguous cluster-zero never reaches it; the
+    // pageguard only ever caught the EXIT-path ~EqDecoyPage destructor (reliable rbp-chain:
+    // exit -> __cxa_finalize_ranges -> ~EqDecoyPage -> ~mutex -> pthread_mutex_destroy). So instead use
+    // a LARGE NON-ALIGNED mutex array declared right in the cluster: round 4 proved the zeroing engulfs
+    // any object added to the cluster, and a page in the MIDDLE of a 24 KiB array is owned entirely by
+    // the array (no other symbol, no hot writer) yet stays inside the contiguous zeroed run. Guard that
+    // middle page -> the region-zero's store into it faults with the REAL writer rip + rbp-chain caller.
+    std::mutex g_eq_bigdecoy[384];   // 384 * 64B = 24 KiB = 6 pages; never locked; layout ballast+guard
     std::atomic<bool> g_eq_pageguard_armed{false};
     DetClockState g_det_clock;
 
@@ -550,20 +561,182 @@ namespace {
         std::thread(eq_sigwatch_thread, repair).detach();
     }
 
+#ifdef __APPLE__
+    // #707 interpose probe (PROSPER_EQ_INTERPOSE=1): the decoy-page guard only ever caught its own
+    // exit-time destructor (pthread_mutex_destroy from EqDecoyPage::~EqDecoyPage during terminate
+    // unwinding), which told us the corruption MECHANISM may be pthread_mutex_destroy/init rather
+    // than a raw memset. Earlier interpose work covered memset/bzero/memcpy/memmove but NOT the
+    // pthread_* sig writers. Interpose them all, range-filtered to the equeue cluster, and stamp a
+    // monotonic ms + backtrace. A hit BEFORE the crash/terminate is the corruptor; a hit after is
+    // just teardown. Runs in normal (non-signal) context, so backtrace()/dladdr are safe here.
+    void eq_cluster_bounds(uintptr_t& lo, uintptr_t& hi) {
+        uintptr_t a[] = { (uintptr_t)&g_eq_mx, (uintptr_t)&g_det_clock, (uintptr_t)&g_apr_mx };
+        lo = a[0]; hi = a[0];
+        for (auto x : a) { if (x < lo) lo = x; if (x > hi) hi = x; }
+        lo -= 512; hi += 512;
+    }
+    bool eq_in_cluster(const void* p, size_t n) {
+        static const bool on = getenv("PROSPER_EQ_INTERPOSE") != nullptr;
+        if (!on || !p) return false;
+        uintptr_t lo, hi; eq_cluster_bounds(lo, hi);
+        uintptr_t s = (uintptr_t)p, e = s + (n ? n : 1);
+        return e > lo && s < hi;   // any overlap with the cluster window
+    }
+    void eq_report_cluster(const char* fn, const void* target, size_t n) {
+        static std::atomic<int> seen{0};
+        int idx = seen.fetch_add(1);
+        if (idx > 24) return;
+        struct timespec ts{}; clock_gettime(CLOCK_MONOTONIC, &ts);
+        unsigned long long ms = (unsigned long long)ts.tv_sec * 1000ull + ts.tv_nsec / 1000000ull;
+        void* bt[40]; int nb = backtrace(bt, 40);
+        fprintf(stderr, "[eq-interpose] #%d %s(%p,len=%zu) IN CLUSTER t=%llums:\n", idx, fn, target, n, ms);
+        char** syms = backtrace_symbols(bt, nb);
+        for (int i = 0; i < nb; i++) fprintf(stderr, "[eq-interpose]   %s\n", syms ? syms[i] : "?");
+        free(syms); fflush(stderr);
+    }
+    extern "C" int prosper_int_mtx_destroy(pthread_mutex_t* m) {
+        if (eq_in_cluster(m, sizeof(pthread_mutex_t))) eq_report_cluster("pthread_mutex_destroy", m, sizeof(pthread_mutex_t));
+        return pthread_mutex_destroy(m);
+    }
+    extern "C" int prosper_int_mtx_init(pthread_mutex_t* m, const pthread_mutexattr_t* a) {
+        if (eq_in_cluster(m, sizeof(pthread_mutex_t))) eq_report_cluster("pthread_mutex_init", m, sizeof(pthread_mutex_t));
+        return pthread_mutex_init(m, a);
+    }
+    extern "C" void* prosper_int_memset(void* d, int c, size_t n) {
+        if (eq_in_cluster(d, n)) eq_report_cluster("memset", d, n);
+        return memset(d, c, n);
+    }
+    extern "C" void prosper_int_bzero(void* d, size_t n) {
+        if (eq_in_cluster(d, n)) eq_report_cluster("bzero", d, n);
+        bzero(d, n);
+    }
+    extern "C" void* prosper_int_memmove(void* d, const void* s, size_t n) {
+        if (eq_in_cluster(d, n)) eq_report_cluster("memmove", d, n);
+        return memmove(d, s, n);
+    }
+    #define PROSPER_DYLD_INTERPOSE(_repl,_orig) \
+        __attribute__((used)) static struct { const void* r; const void* o; } \
+        _interpose_##_orig __attribute__((section("__DATA,__interpose"))) = \
+        { (const void*)&_repl, (const void*)&_orig };
+    PROSPER_DYLD_INTERPOSE(prosper_int_mtx_destroy, pthread_mutex_destroy)
+    PROSPER_DYLD_INTERPOSE(prosper_int_mtx_init, pthread_mutex_init)
+    PROSPER_DYLD_INTERPOSE(prosper_int_memset, memset)
+    PROSPER_DYLD_INTERPOSE(prosper_int_bzero, bzero)
+    PROSPER_DYLD_INTERPOSE(prosper_int_memmove, memmove)
+#endif
+
     // #707 decoy-page guard arming (PR #753 round 5; no-op unless PROSPER_EQ_PAGEGUARD is set and
     // never on Windows). PROT_READ the sacrificial page so the region-zeroing corruptor's first
     // store into it faults with a clean RIP; the fault handler reports, lifts the protection, and
     // resumes (see prosper_eq_decoy_page_range below and exec_image's fault_handler).
+    // Deferred symbolization: the fault handler cannot call dladdr (dyld lock). It records the writer rip
+    // + host-image return addresses here; this reporter thread dladdr-symbolizes them (module+offset+sym)
+    // in a safe context. Name the memset variant (rip) and the OUR-code/MoltenVK call site (frames).
+    volatile uint64_t g_eqpg_rip = 0, g_eqpg_frames[24] = {}; volatile int g_eqpg_n = 0;
+    std::atomic<bool> g_eqpg_pending{false};
+    extern "C" void prosper_eq_pageguard_record(uint64_t rip, const uint64_t* frames, int n) {
+        if (g_eqpg_pending.load()) return;
+        g_eqpg_rip = rip; int m = n > 24 ? 24 : n;
+        for (int i = 0; i < m; i++) g_eqpg_frames[i] = frames[i];
+        g_eqpg_n = m; g_eqpg_pending.store(true);
+    }
+    void eq_pageguard_reporter() {
+        for (;;) {
+            if (g_eqpg_pending.load()) {
+                auto sym = [](const char* what, uint64_t a) {
+                    Dl_info di{};
+                    if (dladdr((void*)(uintptr_t)a, &di) && di.dli_fname) {
+                        const char* slash = strrchr(di.dli_fname, '/');
+                        unsigned long soff = di.dli_saddr ? (unsigned long)(a - (uint64_t)(uintptr_t)di.dli_saddr) : 0;
+                        unsigned long ioff = (unsigned long)(a - (uint64_t)(uintptr_t)di.dli_fbase);   // atos -o <img> -l <fbase>
+                        fprintf(stderr, "[eq-pg-sym] %s 0x%llx  %s+0x%lx  (%s @%p +0x%lx)\n", what,
+                                (unsigned long long)a, di.dli_sname ? di.dli_sname : "?", soff,
+                                slash ? slash + 1 : di.dli_fname, di.dli_fbase, ioff);
+                    } else fprintf(stderr, "[eq-pg-sym] %s 0x%llx  (no module)\n", what, (unsigned long long)a);
+                };
+                sym("WRITER-RIP", g_eqpg_rip);
+                for (int i = 0; i < g_eqpg_n; i++) sym("frame", g_eqpg_frames[i]);
+                fflush(stderr);
+                g_eqpg_pending.store(false);
+            }
+            struct timespec ts{ 0, 2000000 }; nanosleep(&ts, nullptr);
+        }
+    }
+    // #707 round 6: the guarded page is a page fully INSIDE g_eq_bigdecoy (not the dead aligned page).
+    // Use the 2nd 4 KiB boundary within the 24 KiB array so the whole page belongs to the array.
+    // #707 round 7: the corruptor zeroes the det/eq_mx/apr region and extends UPWARD from g_det_clock;
+    // it never spills into the page below det, and relocating the victims dodges it (positional by
+    // __DATA offset). So the guard must sit on g_det_clock's OWN page — which also holds a co-located
+    // hot writer (test::persistent_ds_cache). `PROSPER_EQ_PAGEGUARD=det` guards that page and the
+    // classifier DISCRIMINATES by faulting address: a write to the mutex victims (g_det_clock..g_apr_mx)
+    // is the corruptor (report); any other write on the page (persistent_ds_cache etc.) is legit — lift
+    // briefly and let a re-arm thread re-apply RO. Default mode keeps the bigdecoy mid-page (teardown-
+    // proof but the real corruptor never touches it — retained only for the selftest).
+    std::atomic<bool> g_eq_guard_det{false};
+    std::atomic<bool> g_eq_guard_relift{false};
+    uint64_t eq_guard_page() {
+        if (g_eq_guard_det.load(std::memory_order_acquire))
+            return (uint64_t)(uintptr_t)&g_det_clock & ~4095ull;   // g_det_clock's own page
+        uint64_t end = (uint64_t)(uintptr_t)&g_eq_bigdecoy[384];   // one-past-end of the 24 KiB array
+        return (end & ~4095ull) - 4096;                            // last page fully inside the array
+    }
+    // Continuous re-arm: keep g_det_clock's page RO except for the brief windows the handler lifts it
+    // for a legitimate co-located write. Idempotent mprotect every ~25 µs, so the corruptor's store
+    // (which lands on a victim offset) almost always hits an RO page and faults -> caught.
+    void eq_guard_relift_thread(uint64_t until_flip) {
+        for (;;) {
+            if (!g_eq_pageguard_armed.load(std::memory_order_acquire)) return;   // corruptor caught -> stop
+            if (prosper_vo_flip_count() >= until_flip) {
+#ifndef _WIN32
+                mprotect((void*)(uintptr_t)eq_guard_page(), 4096, PROT_READ | PROT_WRITE);   // window closed
+#endif
+                g_eq_pageguard_armed.store(false, std::memory_order_release);
+                fprintf(stderr, "[eq-pageguard] window closed @flip=%llu — disarmed (no corruptor caught)\n",
+                        (unsigned long long)prosper_vo_flip_count());
+                return;
+            }
+            if (g_eq_guard_relift.exchange(false)) {
+#ifndef _WIN32
+                mprotect((void*)(uintptr_t)eq_guard_page(), 4096, PROT_READ);
+#endif
+            }
+            struct timespec ts{ 0, 10000 }; nanosleep(&ts, nullptr);   // 10 µs: tight RW gap, no livelock
+        }
+    }
     void eq_pageguard_maybe_arm() {
 #ifndef _WIN32
         static const char* mode = getenv("PROSPER_EQ_PAGEGUARD");
         if (!mode) return;
         static std::atomic<bool> once{false};
         if (once.exchange(true)) return;
-        void* pg = (void*)&g_eq_decoy_page;
+        std::thread(eq_pageguard_reporter).detach();
+        if (strcmp(mode, "det") == 0) {
+            // DET mode fault-storms the render if armed continuously (every co-located per-frame write on
+            // g_det_clock's page faults). The corruptor fires in a narrow flip-count window (~2400), so
+            // arm ONLY inside [GUARD_AFTER, GUARD_UNTIL] flips: render runs RW/full-speed before and
+            // after, and the storm is bounded to the ~40 render frames that bracket the corruption.
+            g_eq_guard_det.store(true, std::memory_order_release);   // MUST precede eq_guard_page() below
+            void* pg = (void*)(uintptr_t)eq_guard_page();            // now resolves to g_det_clock's page
+            uint64_t after = getenv("PROSPER_EQ_GUARD_AFTER") ? strtoull(getenv("PROSPER_EQ_GUARD_AFTER"), 0, 0) : 2000;
+            uint64_t until = getenv("PROSPER_EQ_GUARD_UNTIL") ? strtoull(getenv("PROSPER_EQ_GUARD_UNTIL"), 0, 0) : 3400;
+            std::thread([pg, after, until] {
+                while (prosper_vo_flip_count() < after) { struct timespec ts{ 0, 5000000 }; nanosleep(&ts, nullptr); }
+                if (mprotect(pg, 4096, PROT_READ) != 0) {
+                    fprintf(stderr, "[eq-pageguard] mprotect FAILED errno=%d\n", errno); return;
+                }
+                g_eq_pageguard_armed.store(true, std::memory_order_release);
+                fprintf(stderr, "[eq-pageguard] armed DET-DISCRIMINATE @flip=%llu page=%p (det=%p eq_mx=%p apr=%p) window[..%llu]\n",
+                        (unsigned long long)prosper_vo_flip_count(), pg, (void*)&g_det_clock,
+                        (void*)&g_eq_mx, (void*)&g_apr_mx, (unsigned long long)until);
+                eq_guard_relift_thread(until);   // relift until the window closes, then disarm
+            }).detach();
+            return;
+        }
+        void* pg = (void*)(uintptr_t)eq_guard_page();   // bigdecoy-mid page (selftest / non-det)
         if (mprotect(pg, 4096, PROT_READ) == 0) {
             g_eq_pageguard_armed.store(true, std::memory_order_release);
-            fprintf(stderr, "[eq-pageguard] armed: decoy page %p PROT_READ (4096 bytes)\n", pg);
+            fprintf(stderr, "[eq-pageguard] armed bigdecoy-mid: page %p PROT_READ (det=%p eq_mx=%p apr=%p)\n",
+                    pg, (void*)&g_det_clock, (void*)&g_eq_mx, (void*)&g_apr_mx);
         } else {
             fprintf(stderr, "[eq-pageguard] mprotect(%p) FAILED errno=%d — guard inactive\n", pg, errno);
             return;
@@ -574,7 +747,7 @@ namespace {
         // work before trusting a silent real run.
         if (strcmp(mode, "selftest") == 0) std::thread([] {
             struct timespec ts{ 2, 0 }; nanosleep(&ts, nullptr);
-            memset((void*)&g_eq_decoy_page, 0, 256);
+            memset((void*)(uintptr_t)eq_guard_page(), 0, 256);
             fprintf(stderr, "[eq-pageguard] selftest write survived (report should precede this)\n");
         }).detach();
 #endif
@@ -651,12 +824,27 @@ namespace {
 // continues) and return 1 so the caller reports the faulting RIP + guest stack and resumes.
 extern "C" int prosper_eq_pageguard_classify(uint64_t addr) {
     if (!g_eq_pageguard_armed.load(std::memory_order_acquire)) return 0;
-    uint64_t lo = (uint64_t)(uintptr_t)&g_eq_decoy_page;
+    uint64_t lo = eq_guard_page();
     if (addr < lo || addr >= lo + 4096) return 0;
 #ifndef _WIN32
-    mprotect((void*)(uintptr_t)lo, 4096, PROT_READ | PROT_WRITE);
+    mprotect((void*)(uintptr_t)lo, 4096, PROT_READ | PROT_WRITE);   // let the faulting store complete
 #endif
-    g_eq_pageguard_armed.store(false, std::memory_order_release);   // one-shot
+    if (g_eq_guard_det.load(std::memory_order_acquire)) {
+        // DET-DISCRIMINATE: the corruptor zeroes the mutex SIG words (offset 0 of each pthread_mutex_t).
+        // A legitimate pthread_mutex_lock/unlock writes only the lock/owner fields (offset ~0x20+) and
+        // NEVER the sig, and init runs once before arming — so a fault landing on a sig word (first 8
+        // bytes of g_det_clock.mutex / g_eq_mx / g_apr_mx) is the corruptor. Any other write on the page
+        // (persistent_ds_cache, a real lock word) is legit: flag the re-arm thread and resume silently.
+        auto sig_hit = [addr](const void* mtx) {
+            uint64_t b = (uint64_t)(uintptr_t)mtx; return addr >= b && addr < b + 8;
+        };
+        bool victim = sig_hit(&g_det_clock) || sig_hit(&g_eq_mx) || sig_hit(&g_apr_mx);
+        g_eq_guard_relift.store(true, std::memory_order_release);
+        if (!victim) return 2;                                     // legit co-located write: silent
+        g_eq_pageguard_armed.store(false, std::memory_order_release);
+        return 1;                                                  // corruptor hit a victim: report
+    }
+    g_eq_pageguard_armed.store(false, std::memory_order_release);   // bigdecoy mode: one-shot
     return 1;
 }
 

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -86,6 +86,15 @@ namespace {
     std::mutex g_eq_bigdecoy[384];   // 384 * 64B = 24 KiB = 6 pages; never locked; layout ballast+guard
     std::atomic<bool> g_eq_pageguard_armed{false};
     DetClockState g_det_clock;
+    // #707 round 8 (PR #753): quiet ballast ABOVE det. The async det-page guard loses its re-arm
+    // race, and det-step clashes with the macOS %fs emulation, ONLY because hot writers (g_eq_mx /
+    // g_apr_mx / vblank locks, pad recorder) share g_det_clock's page. With a page-plus of
+    // never-locked mutexes on EACH side (g_eq_bigdecoy below, this array above), det's page holds
+    // nothing legitimately written — so the guard can arm once at boot, PROT_READ, and STAY armed:
+    // no fault storm, no re-arm gap to race, and the FIRST fault on the page is the corruptor with
+    // a clean rbp-chain. 72 mutexes = 4.5 KiB on Darwin; declaration order keeps it between det
+    // and the hot cluster on macOS (verify with nm as usual).
+    std::mutex g_eq_ballast_hi[72];
 
     uint64_t det_clock_fps() {
         static const uint64_t fps = [] {

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -2,6 +2,7 @@
 // libkernel stubs the engine needs during init. Cross-platform (chrono + pthread).
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include <pthread.h>
 #include <chrono>
 #ifndef _WIN32
@@ -494,7 +495,7 @@ namespace {
 #else
     std::mutex g_eq_mx;
 #endif
-    extern std::mutex g_apr_mx;   // defined in the APR block below; sig-watched alongside g_eq_mx
+    PROSPER_HEAP_MUTEX_EXTERN(g_apr_mx);   // defined in the APR block below; #707: heap-backed on macOS (it sits INSIDE the corrupted __DATA cluster at image+0x17bca0)
     volatile uint8_t g_eq_canary_b[128] PROSPER_EQ_CANARY_INIT;   // #707 canary: immediately beside g_eq_mx/g_eqs in declaration order
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
@@ -1337,7 +1338,11 @@ namespace {
     constexpr int16_t EVFILT_AMPR_MODELED = -24;   // guest never reads filter; distinct on purpose
     struct AprEqReg { uint64_t eq; int64_t id; };
     // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
-    std::mutex g_apr_mx;
+    // #707: this mutex is CONFIRMED to sit inside the corrupted __DATA cluster (image+0x17bca0, i.e.
+    // [g_det_clock .. g_apr_mx+64]) and is HOT during asset load (APR ring-token posting), so leaving
+    // it a plain std::mutex would merely relocate the crash from vblank_pump (g_eq_mx) to the APR
+    // path. Heap-back it on macOS so the corruptor cannot reach its pthread sig. See heap_mutex.hpp.
+    PROSPER_HEAP_MUTEX(g_apr_mx);
     std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
     volatile uint8_t g_eq_canary_d[128] PROSPER_EQ_CANARY_INIT;   // #707 canary (declared beside g_eq_mx above)
     uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
@@ -1416,7 +1421,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
     unsigned ring = (unsigned)(token >> 58) & 0x3f;
     uint64_t cnt = token & ((1ull << 58) - 1);
     {
-        std::lock_guard<std::mutex> lk(g_apr_mx);
+        std::lock_guard lk(g_apr_mx);
         if (cnt > g_apr_tag_hwm[ring]) g_apr_tag_hwm[ring] = cnt;
     }
     if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u) -> eq=0x%llx scheduled\n",
@@ -1425,7 +1430,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
         struct timespec ts{ 0, 2000000 };   // 2 ms
         nanosleep(&ts, nullptr);
         uint64_t hwm;
-        { std::lock_guard<std::mutex> lk(g_apr_mx); hwm = g_apr_tag_hwm[ring]; }
+        { std::lock_guard lk(g_apr_mx); hwm = g_apr_tag_hwm[ring]; }
         AprEqReg r{ eq, id };
         apr_post(r, ring, ((uint64_t)ring << 58) | hwm);
     }).detach();
@@ -1435,7 +1440,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
 // event is ever posted for these — see the block comment above).
 uint64_t prosper_apr_next_token(unsigned ring) {
     ring &= 0x3f;
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     uint64_t seq = ++g_apr_ring_seq[ring];
     return ((uint64_t)ring << 58) | (seq & ((1ull << 58) - 1));
 }
@@ -1445,7 +1450,7 @@ uint64_t prosper_apr_next_token(unsigned ring) {
 // ctor-seeded per-ring last-processed (see the block comment above; the pre-#208 replay was the
 // root cause of the #180 range-walk fault).
 void prosper_eq_add_apr(uint64_t eq, int64_t id) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     for (auto& r : g_apr_eq_regs)
         if (r.eq == eq && r.id == id) return;   // idempotent
     g_apr_eq_regs.push_back({ eq, id });

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -383,6 +383,17 @@ namespace {
     // flip_event_trigger_func) — the game compares it against the arg it submitted.
     constexpr int64_t VIDEO_OUT_EVENT_FLIP = 0, VIDEO_OUT_EVENT_VBLANK = 1;
 
+    // --- #707 positional-corruptor canaries (PROSPER_EQ_CANARY=1; default off, zero behavior
+    // change). The B2/macOS corruptor performs a positional multi-byte write into the fixed
+    // __DATA/__bss range where this TU's equeue globals sit: relocating g_eq_mx dodges it and
+    // several neighbors are victims (issue #707). These pattern-filled guard arrays live in the
+    // same cluster and are never legitimately written after arming, so ANY deviation — including
+    // an all-zeros range write that a value-conditional hardware watchpoint cannot even see —
+    // is the stray write. The poller detects and localizes the hit bytes at native speed; the
+    // armed addresses are printed so a second run can aim exact hardware watchpoints at them.
+    // The linker decides final .bss placement — verify adjacency with `nm --numeric-sort`.
+    volatile uint8_t g_eq_canary_a[128];
+    extern volatile uint8_t g_eq_canary_d[128];   // defined beside the APR ring arrays below
     // Equeue lifetime (#67): states are SHARED-ptr owned. eq_find hands out a reference that keeps
     // the object alive across the caller's wait, so sceKernelDeleteEqueue can never destroy a mutex/
     // condvar a waiter is blocked on (the old raw-pointer scheme was a use-after-free: delete freed
@@ -390,6 +401,7 @@ namespace {
     // object dies when the last reference drops.
     struct EqState { std::mutex m; std::condition_variable cv; std::deque<SceKEvent> ready; bool deleted = false; };
     std::mutex g_eq_mx;
+    volatile uint8_t g_eq_canary_b[128];   // #707 canary: immediately beside g_eq_mx/g_eqs in declaration order
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
     std::vector<FlipReg> g_flip_regs, g_vblank_regs;
@@ -410,6 +422,34 @@ namespace {
     struct TimerTok { std::shared_ptr<std::atomic<bool>> cancelled; };
     std::map<std::pair<uint64_t, int64_t>, TimerTok> g_timers;
     std::atomic<bool> g_pump_started{false};
+    volatile uint8_t g_eq_canary_c[128];   // #707 canary: tail side of the timer/registration block
+    std::atomic<bool> g_eq_canary_started{false};
+    void eq_canary_thread() {
+        volatile uint8_t* rows[4] = { g_eq_canary_a, g_eq_canary_b, g_eq_canary_c, g_eq_canary_d };
+        for (int r = 0; r < 4; r++) for (int i = 0; i < 128; i++) rows[r][i] = 0xA5;
+        fprintf(stderr, "[eq-canary] armed a=%p b=%p c=%p d=%p (128B each, pattern 0xA5)\n",
+                (void*)rows[0], (void*)rows[1], (void*)rows[2], (void*)rows[3]);
+        auto ms = [] { struct timespec t{}; clock_gettime(CLOCK_MONOTONIC, &t);
+                       return (unsigned long long)t.tv_sec * 1000ull + (unsigned long long)t.tv_nsec / 1000000ull; };
+        uint64_t hits = 0;
+        for (;;) {
+            struct timespec ts{ 0, 200000 }; nanosleep(&ts, nullptr);   // 200 µs poll
+            for (int r = 0; r < 4; r++)
+                for (int i = 0; i < 128; i++)
+                    if (rows[r][i] != 0xA5) {
+                        uint8_t v = rows[r][i];
+                        fprintf(stderr, "[eq-canary] HIT row=%c off=%d addr=%p value=0x%02x t=%llums\n",
+                                'a' + r, i, (void*)&rows[r][i], v, ms());
+                        rows[r][i] = 0xA5;               // re-arm: repeated writes keep reporting
+                        if (++hits >= 256) { fprintf(stderr, "[eq-canary] report cap reached\n"); return; }
+                    }
+        }
+    }
+    void eq_canary_maybe_start() {
+        static const bool on = getenv("PROSPER_EQ_CANARY") != nullptr;
+        if (!on || g_eq_canary_started.exchange(true)) return;
+        std::thread(eq_canary_thread).detach();
+    }
 
     std::shared_ptr<EqState> eq_find(uint64_t eq) {
         std::lock_guard<std::mutex> lk(g_eq_mx);
@@ -467,7 +507,10 @@ namespace {
             }
         }
     }
-    void ensure_pump() { if (!g_pump_started.exchange(true)) std::thread(vblank_pump).detach(); }
+    void ensure_pump() {
+        eq_canary_maybe_start();   // #707 diagnostic; no-op unless PROSPER_EQ_CANARY is set
+        if (!g_pump_started.exchange(true)) std::thread(vblank_pump).detach();
+    }
 }
 
 // Exposed to hle_graphics.cpp (sceVideoOut* flip/vblank event registration).
@@ -747,6 +790,7 @@ namespace {
     // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
     std::mutex g_apr_mx;
     std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
+    volatile uint8_t g_eq_canary_d[128];               // #707 canary (declared beside g_eq_mx above)
     uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
     uint64_t g_apr_tag_hwm[64] = {};                   // per-ring highest tag counter posted (guarded)
     void apr_post(const AprEqReg& r, unsigned ring, uint64_t token) {   // no APR lock held

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -8,11 +8,13 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>   // process_vm_readv (slot-echo scan, issue #180)
+#include <sys/mman.h>  // mprotect (the #707 decoy page guard, PR #753)
 #endif
 #include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <cerrno>
 #include <atomic>
 #include <ctime>
 #include <deque>
@@ -60,6 +62,18 @@ namespace {
     // these six extend the sig-watched window 384 bytes downward. Never locked; layout ballast.
     std::mutex g_eq_decoy_lo0, g_eq_decoy_lo1, g_eq_decoy_lo2,
                g_eq_decoy_lo3, g_eq_decoy_lo4, g_eq_decoy_lo5;
+    // --- #707 sacrificial decoy PAGE (PROSPER_EQ_PAGEGUARD=1; PR #753 round 5). Round 4 proved
+    // the corruptor zeroes the whole __DATA mutex-cluster REGION, engulfing any object added to
+    // it — so give it a page-aligned, page-sized, never-locked sacrifice inside the region and
+    // mprotect it PROT_READ. Nothing legitimate ever touches these bytes, so the FIRST zeroing
+    // store faults with a clean writer RIP and none of the deadlock risk that killed guarding the
+    // live shared page (hot mutexes + condvar). The fault handler (exec_image fault_handler)
+    // reports rip + guest return addresses, lifts the protection, and resumes: the decoys are
+    // sacrificial and the run continues. alignas(4096) + sizeof >= 4096 means the first page
+    // belongs entirely to this object.
+    struct alignas(4096) EqDecoyPage { std::mutex m[128]; };   // >= 4 KiB on both glibc and Darwin
+    EqDecoyPage g_eq_decoy_page;
+    std::atomic<bool> g_eq_pageguard_armed{false};
     DetClockState g_det_clock;
 
     uint64_t det_clock_fps() {
@@ -536,6 +550,36 @@ namespace {
         std::thread(eq_sigwatch_thread, repair).detach();
     }
 
+    // #707 decoy-page guard arming (PR #753 round 5; no-op unless PROSPER_EQ_PAGEGUARD is set and
+    // never on Windows). PROT_READ the sacrificial page so the region-zeroing corruptor's first
+    // store into it faults with a clean RIP; the fault handler reports, lifts the protection, and
+    // resumes (see prosper_eq_decoy_page_range below and exec_image's fault_handler).
+    void eq_pageguard_maybe_arm() {
+#ifndef _WIN32
+        static const char* mode = getenv("PROSPER_EQ_PAGEGUARD");
+        if (!mode) return;
+        static std::atomic<bool> once{false};
+        if (once.exchange(true)) return;
+        void* pg = (void*)&g_eq_decoy_page;
+        if (mprotect(pg, 4096, PROT_READ) == 0) {
+            g_eq_pageguard_armed.store(true, std::memory_order_release);
+            fprintf(stderr, "[eq-pageguard] armed: decoy page %p PROT_READ (4096 bytes)\n", pg);
+        } else {
+            fprintf(stderr, "[eq-pageguard] mprotect(%p) FAILED errno=%d — guard inactive\n", pg, errno);
+            return;
+        }
+        // Known-answer validation (=selftest): simulate the corruptor with a delayed in-process
+        // zeroing of the guarded page. Expect one [eq-pageguard] CORRUPTOR report (host rip) from
+        // the fault handler, then the survival line — proving trap, report, lift, and resume all
+        // work before trusting a silent real run.
+        if (strcmp(mode, "selftest") == 0) std::thread([] {
+            struct timespec ts{ 2, 0 }; nanosleep(&ts, nullptr);
+            memset((void*)&g_eq_decoy_page, 0, 256);
+            fprintf(stderr, "[eq-pageguard] selftest write survived (report should precede this)\n");
+        }).detach();
+#endif
+    }
+
     std::shared_ptr<EqState> eq_find(uint64_t eq) {
         std::lock_guard<std::mutex> lk(g_eq_mx);
         auto it = g_eqs.find(eq);
@@ -595,8 +639,25 @@ namespace {
     void ensure_pump() {
         eq_canary_maybe_start();     // #707 diagnostics; no-ops unless their env vars are set
         eq_sigwatch_maybe_start();
+        eq_pageguard_maybe_arm();
         if (!g_pump_started.exchange(true)) std::thread(vblank_pump).detach();
     }
+}
+
+// #707 decoy-page guard classifier (PR #753 round 5) — called from exec_image's fault_handler on
+// SIGSEGV/SIGBUS, BEFORE any other fault interpretation. Async-signal-safe: atomics + one syscall.
+// A write fault inside the sacrificial RO decoy page IS the region-zeroing corruptor: lift the
+// protection (the decoys are sacrificial; the zeroing then completes harmlessly and the run
+// continues) and return 1 so the caller reports the faulting RIP + guest stack and resumes.
+extern "C" int prosper_eq_pageguard_classify(uint64_t addr) {
+    if (!g_eq_pageguard_armed.load(std::memory_order_acquire)) return 0;
+    uint64_t lo = (uint64_t)(uintptr_t)&g_eq_decoy_page;
+    if (addr < lo || addr >= lo + 4096) return 0;
+#ifndef _WIN32
+    mprotect((void*)(uintptr_t)lo, 4096, PROT_READ | PROT_WRITE);
+#endif
+    g_eq_pageguard_armed.store(false, std::memory_order_release);   // one-shot
+    return 1;
 }
 
 // Exposed to hle_graphics.cpp (sceVideoOut* flip/vblank event registration).

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -9,6 +9,9 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include "posix_shim.hpp"
 #include <sys/mman.h>
+#ifdef __APPLE__
+#include <dlfcn.h>
+#endif
 #include <signal.h>
 #include <setjmp.h>
 #include <pthread.h>
@@ -51,6 +54,7 @@ struct f_owner_ex { int type; pid_t pid; };
 #endif
 
 extern "C" int prosper_eq_pageguard_classify(uint64_t);  // #707 decoy-page guard (hle_kernel_time.cpp)
+extern "C" void prosper_eq_pageguard_record(uint64_t rip, const uint64_t* frames, int n);  // deferred symbolize
 
 namespace prosper {
 
@@ -822,8 +826,10 @@ namespace {
         // lifts the protection (sacrificial page; the run continues) and we report the writer:
         // RIP, guest/host classification, and guest return addresses from the faulting stack.
         // Raw syscalls only (may run on a guest-%fs thread).
-        if ((sig == SIGSEGV || sig == SIGBUS) &&
-            prosper_eq_pageguard_classify((uint64_t)(uintptr_t)si->si_addr)) {
+        if (sig == SIGSEGV || sig == SIGBUS) {
+          int pg_verdict = prosper_eq_pageguard_classify((uint64_t)(uintptr_t)si->si_addr);
+          if (pg_verdict == 2) return;   // legit co-located write on the guarded page: lifted, resume silently
+          if (pg_verdict == 1) {
             auto gpg = PROSPER_GREGS((ucontext_t*)uctx);
             uint64_t rip = (uint64_t)gpg[REG_RIP];
             bool guest_rip = rip >= 0x400000000ull && rip < 0x620000000ull;
@@ -851,7 +857,60 @@ namespace {
             }
             sn += snprintf(sb + sn, sizeof sb - sn, "\n");
             syscall(SYS_write, 2, sb, (size_t)sn);
+            // The writer is often HOST code (a libsystem memset variant called by our render path), so the
+            // guest-stack scan above finds nothing. Also scan for HOST return addresses (our binary + loaded
+            // dylibs, below the dyld shared cache at 0x7ff8..) and print the image base for `atos`.
+            // Wide stack scan: print EVERY code-pointer-looking return address (image AND shared-cache,
+            // tagged) up the stack so the chain from the libsystem memset back to OUR call site is visible.
+            // The writer is on a HOST thread, so probe_readable() (guest-oriented) rejects its stack.
+            // The current stack is valid — read it directly. Scan rsp upward for code-pointer RAs, tagged
+            // c=shared-cache (libsystem/libc++) vs H=host image/dylib (our code / MoltenVK = the call site).
+            char hb[900]; int hn = snprintf(hb, sizeof hb, "[eq-pageguard]   stack-scan:");
+            int hfound = 0;
+            uint64_t hostras[24]; int nhost = 0;   // collect HOST-image RAs for deferred symbolization
+            if (rsp > 0x10000ull) for (uint64_t p = rsp; p < rsp + 0x1000 && hfound < 40; p += 8) {
+                uint64_t ra = *(const uint64_t*)(uintptr_t)p;
+                if (ra < 0x100000000ull) continue;
+                bool cache = ra >= 0x7f0000000000ull;
+                hn += snprintf(hb + hn, sizeof hb - hn, " %s%llx", cache ? "c" : "H", (unsigned long long)ra);
+                if (!cache && nhost < 24) hostras[nhost++] = ra;   // host image/dylib RA (our code / MoltenVK)
+                hfound++;
+                if (hn > (int)sizeof hb - 24) break;
+            }
+            hn += snprintf(hb + hn, sizeof hb - hn, "\n");
+            syscall(SYS_write, 2, hb, (size_t)hn);
+            // The stack-SCAN above is noisy (it matches stale code-pointer-shaped stack garbage, e.g.
+            // atexit's stored &EqDecoyPage::~EqDecoyPage). Walk the REAL frame-pointer chain for the
+            // true caller of the faulting store: at pthread_mutex_destroy+0x1b the prologue has run,
+            // so rbp is the callee frame and [rbp+8] is its return address = OUR call site. These are
+            // the RAs that matter; hand THESE to the deferred symbolizer (dladdr), not the scan.
+            uint64_t rbp = (uint64_t)gpg[REG_RBP];
+            char cb[512]; int cn = snprintf(cb, sizeof cb, "[eq-pageguard]   rbp-chain:");
+            uint64_t chainras[24]; int nchain = 0;
+            for (int f = 0; f < 16 && rbp > 0x10000ull && rbp < 0x800000000000ull; f++) {
+                uint64_t ra   = *(const uint64_t*)(uintptr_t)(rbp + 8);
+                uint64_t next = *(const uint64_t*)(uintptr_t)rbp;
+                bool cache = ra >= 0x7f0000000000ull;
+                cn += snprintf(cb + cn, sizeof cb - cn, " %s%llx", cache ? "c" : "H", (unsigned long long)ra);
+                if (nchain < 24) chainras[nchain++] = ra;
+                if (next <= rbp) break;          // saved rbp must move up-stack (grows down)
+                rbp = next;
+                if (cn > (int)sizeof cb - 24) break;
+            }
+            cn += snprintf(cb + cn, sizeof cb - cn, "\n");
+            syscall(SYS_write, 2, cb, (size_t)cn);
+            // Hand the writer rip + REAL rbp-chain RAs to a safe reporter thread for dladdr symbolization
+            // (dladdr takes the dyld lock -> cannot run in this signal handler). Fall back to the scan
+            // RAs only if the chain walk produced nothing.
+            prosper_eq_pageguard_record(rip, nchain ? chainras : hostras, nchain ? nchain : nhost);
+#ifdef __APPLE__
+            Dl_info hdi{}; if (dladdr((void*)&fault_handler, &hdi)) {
+                char eb[96]; int en = snprintf(eb, sizeof eb, "[eq-pageguard]   boot_trace base=%p (atos -o boot_trace -l <base>)\n", hdi.dli_fbase);
+                syscall(SYS_write, 2, eb, (size_t)en);
+            }
+#endif
             return;
+          }
         }
 #ifdef __APPLE__
         // macOS/Rosetta: a guest `%fs:`-relative TLS access faults (fs base is 0). Redirect it to the

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -50,6 +50,8 @@ struct f_owner_ex { int type; pid_t pid; };
 #endif
 #endif
 
+extern "C" int prosper_eq_pageguard_classify(uint64_t);  // #707 decoy-page guard (hle_kernel_time.cpp)
+
 namespace prosper {
 
 namespace {
@@ -814,6 +816,43 @@ namespace {
     void fault_handler(int sig, siginfo_t* si, void* uctx) {
         // Emulate AMD-only SSE4a bitfield ops (insertq/extrq) that #UD on Intel hosts, then resume.
         if (sig == SIGILL && try_emulate_sse4a((ucontext_t*)uctx)) return;
+        // #707 decoy-page guard (PR #753 round 5): a write fault inside the sacrificial RO decoy
+        // page IS the region-zeroing corruptor. Checked FIRST — nothing legitimate touches that
+        // page, and on macOS the %fs emulation below must not swallow the fault. The classifier
+        // lifts the protection (sacrificial page; the run continues) and we report the writer:
+        // RIP, guest/host classification, and guest return addresses from the faulting stack.
+        // Raw syscalls only (may run on a guest-%fs thread).
+        if ((sig == SIGSEGV || sig == SIGBUS) &&
+            prosper_eq_pageguard_classify((uint64_t)(uintptr_t)si->si_addr)) {
+            auto gpg = PROSPER_GREGS((ucontext_t*)uctx);
+            uint64_t rip = (uint64_t)gpg[REG_RIP];
+            bool guest_rip = rip >= 0x400000000ull && rip < 0x620000000ull;
+            char b[192]; int n = snprintf(b, sizeof b,
+                "[eq-pageguard] CORRUPTOR rip=%s0x%llx writes 0x%llx tid=%ld — protection lifted, resuming\n",
+                guest_rip ? "guest:" : "host:", (unsigned long long)rip,
+                (unsigned long long)(uintptr_t)si->si_addr, (long)cur_tid());
+            syscall(SYS_write, 2, b, (size_t)n);
+            char ib[128]; int in_n = snprintf(ib, sizeof ib, "[eq-pageguard]   insn bytes:");
+            const uint8_t* ip = (const uint8_t*)(uintptr_t)rip;
+            for (int k = 0; k < 16 && probe_readable(rip + (uint64_t)k); k++)
+                in_n += snprintf(ib + in_n, sizeof ib - in_n, " %02x", ip[k]);
+            in_n += snprintf(ib + in_n, sizeof ib - in_n, "\n");
+            syscall(SYS_write, 2, ib, (size_t)in_n);
+            uint64_t rsp = (uint64_t)gpg[REG_RSP];
+            char sb[320]; int sn = snprintf(sb, sizeof sb, "[eq-pageguard]   guest-stack:");
+            int found = 0;
+            for (uint64_t p = rsp; p < rsp + 0x400 && found < 10; p += 8) {
+                if (!probe_readable(p)) break;
+                uint64_t ra = *(const uint64_t*)p;
+                if (ra >= 0x400000000ull && ra < 0x620000000ull) {
+                    sn += snprintf(sb + sn, sizeof sb - sn, " 0x%llx", (unsigned long long)ra);
+                    found++;
+                }
+            }
+            sn += snprintf(sb + sn, sizeof sb - sn, "\n");
+            syscall(SYS_write, 2, sb, (size_t)sn);
+            return;
+        }
 #ifdef __APPLE__
         // macOS/Rosetta: a guest `%fs:`-relative TLS access faults (fs base is 0). Redirect it to the
         // guest TCB (guest_TP + offset) and resume. Only fires when trap-mode TLS is active and the

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -11,6 +11,9 @@
 #include <sys/mman.h>
 #ifdef __APPLE__
 #include <dlfcn.h>
+#include <execinfo.h>
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
 #endif
 #include <signal.h>
 #include <setjmp.h>
@@ -52,6 +55,70 @@ struct f_owner_ex { int type; pid_t pid; };
 #define F_SETOWN_EX -1001
 #endif
 #endif
+
+// ---------------------------------------------------------------------------------------------
+// #707 — host-image collision guard.
+// On macOS, x86-64 Mach-O executables load at 0x100000000 (4 GiB) — exactly GPU_VA_LO, the base of
+// prosper's guest GPU-VA window [4 GiB, 64 GiB). So boot_trace's own __TEXT/__DATA/__LINKEDIT sit
+// INSIDE the guest window. A guest-memory MAP_FIXED (or the fault-handler's lazy backing) that lands
+// on those pages REPLACES the mapping with fresh zero pages — silently (mmap doesn't fault, so no
+// page-guard/watchpoint ever sees it), zeroing host globals such as g_eq_mx's pthread `__sig`
+// (-> pthread_mutex_lock EINVAL -> std::mutex::lock throws -> terminate in vblank_pump). Latent on
+// Linux, where the executable loads below 4 GiB, outside the window, so the same store never targets
+// our image. We compute the running executable's mapped span once at startup (signal-safe read
+// thereafter) and refuse any guest MAP_FIXED that would clobber it.
+namespace {
+    struct HostImageRange {
+        uint64_t lo = 0, hi = 0;
+        HostImageRange() {
+#ifdef __APPLE__
+            const struct mach_header_64* mh = (const struct mach_header_64*)_dyld_get_image_header(0);
+            if (!mh) return;
+            intptr_t slide = _dyld_get_image_vmaddr_slide(0);
+            uint64_t l = UINT64_MAX, h = 0;
+            const uint8_t* p = (const uint8_t*)(mh + 1);
+            for (uint32_t i = 0; i < mh->ncmds; i++) {
+                const struct load_command* lc = (const struct load_command*)p;
+                if (lc->cmd == LC_SEGMENT_64) {
+                    const struct segment_command_64* sg = (const struct segment_command_64*)lc;
+                    if (strcmp(sg->segname, "__PAGEZERO") != 0 && sg->vmsize) {
+                        uint64_t b = sg->vmaddr + (uint64_t)slide, e = b + sg->vmsize;
+                        if (b < l) l = b;
+                        if (e > h) h = e;
+                    }
+                }
+                p += lc->cmdsize;
+            }
+            if (l < h) { lo = l; hi = h; }
+            fprintf(stderr, "[#707] host image range [0x%llx,0x%llx) (GPU-VA window is [0x100000000,0x1000000000))\n",
+                    (unsigned long long)lo, (unsigned long long)hi);
+#endif
+        }
+    };
+    // Global static: constructed at program startup (single-threaded, before any guest mapping),
+    // so the fault handler and the memory HLE only ever READ lo/hi — async-signal-safe.
+    const HostImageRange g_host_image;
+}
+// Signal-safe: does [addr, addr+len) intersect the running executable's own mapped image?
+extern "C" int prosper_fixed_map_hits_host_image(uint64_t addr, uint64_t len) {
+    if (g_host_image.hi <= g_host_image.lo || !len) return 0;
+    uint64_t a0 = addr, a1 = addr + len;
+    return (a0 < g_host_image.hi && a1 > g_host_image.lo) ? 1 : 0;
+}
+// Non-signal context only (guest-memory HLE): log the offending call site + a backtrace so the
+// exact caller that tried to clobber our image is named, then the caller refuses the mapping.
+extern "C" void prosper_report_host_image_clobber(uint64_t addr, uint64_t len, const char* site) {
+    fprintf(stderr,
+            "[#707] write/map over host image: site=%s target=[0x%llx,0x%llx) image=[0x%llx,0x%llx)\n",
+            site ? site : "?", (unsigned long long)addr, (unsigned long long)(addr + len),
+            (unsigned long long)g_host_image.lo, (unsigned long long)g_host_image.hi);
+#ifdef __APPLE__
+    void* bt[32];
+    int n = backtrace(bt, 32);
+    backtrace_symbols_fd(bt, n, 2);
+#endif
+    fflush(stderr);
+}
 
 extern "C" int prosper_eq_pageguard_classify(uint64_t);  // #707 decoy-page guard (hle_kernel_time.cpp)
 extern "C" void prosper_eq_pageguard_record(uint64_t rip, const uint64_t* frames, int n);  // deferred symbolize
@@ -1650,8 +1717,19 @@ namespace {
         if (sig == SIGSEGV && si->si_addr && si->si_code == SEGV_MAPERR) {
             uint64_t a = (uint64_t)si->si_addr;
             uint64_t rip = (uint64_t)PROSPER_GREGS((ucontext_t*)uctx)[REG_RIP];
-            if (a >= GPU_VA_LO && a < GPU_VA_HI && a != rip) {
-                void* page = (void*)(a & ~(uint64_t)0xfff);
+            void* page = (void*)(a & ~(uint64_t)0xfff);
+            // #707: never "back" a page that is our OWN loaded image (macOS loads boot_trace inside
+            // the guest window). MAP_FIXED here would replace our __TEXT/__DATA with a fresh zero
+            // page and corrupt host globals. This is a real bug elsewhere, not an unmapped guest
+            // page — log it and let it fall through to a normal fault report.
+            if (a >= GPU_VA_LO && a < GPU_VA_HI && a != rip &&
+                prosper_fixed_map_hits_host_image((uint64_t)(uintptr_t)page, 0x1000)) {
+                char b[160];
+                int n = snprintf(b, sizeof b,
+                                 "[#707] refused GPU-VA lazy-back over host image page=0x%llx rip=0x%llx\n",
+                                 (unsigned long long)(uint64_t)(uintptr_t)page, (unsigned long long)rip);
+                syscall(SYS_write, 2, b, (size_t)n);
+            } else if (a >= GPU_VA_LO && a < GPU_VA_HI && a != rip) {
                 bool ok = mmap(page, 0x1000, PROT_READ | PROT_WRITE,
                                MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == page;
                 if (g_faultlog) {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -55,6 +55,8 @@ struct f_owner_ex { int type; pid_t pid; };
 
 extern "C" int prosper_eq_pageguard_classify(uint64_t);  // #707 decoy-page guard (hle_kernel_time.cpp)
 extern "C" void prosper_eq_pageguard_record(uint64_t rip, const uint64_t* frames, int n);  // deferred symbolize
+extern "C" int  prosper_eq_guard_step_mode();   // #707 det-step: TF single-step co-located writes
+extern "C" void prosper_eq_guard_rearm();       // re-arm the guard page RO after a single-step
 
 namespace prosper {
 
@@ -192,6 +194,7 @@ namespace {
     int      g_hwbp_fd = -1;
     bool     g_hwbp_stepping = false;
     volatile sig_atomic_t g_hwbp_count = 0;
+    volatile sig_atomic_t g_eq_guard_stepping = 0;   // #707 det-step: mid TF single-step of a co-located write
     int      g_hwbp_max = 200;
     // PROSPER_HWBP_ALLTHREADS=1: also arm the same execute bp on every guest worker thread (each thread
     // gets its own perf fd + owns its own SIGTRAP). Lets us observe code that runs off the main thread
@@ -828,7 +831,17 @@ namespace {
         // Raw syscalls only (may run on a guest-%fs thread).
         if (sig == SIGSEGV || sig == SIGBUS) {
           int pg_verdict = prosper_eq_pageguard_classify((uint64_t)(uintptr_t)si->si_addr);
-          if (pg_verdict == 2) return;   // legit co-located write on the guarded page: lifted, resume silently
+          if (pg_verdict == 2) {
+              // Legit co-located write; the page is now RW so the store can complete. In det-step mode,
+              // set TF so exactly ONE instruction executes, then the SIGTRAP below re-arms the page RO —
+              // the RW window is a single instruction wide (no gap the corruptor can slip through).
+              if (prosper_eq_guard_step_mode()) {
+                  auto gs = PROSPER_GREGS((ucontext_t*)uctx);
+                  gs[REG_EFL] |= 0x100ll;                 // trap flag: single-step the co-located store
+                  g_eq_guard_stepping = true;
+              }
+              return;
+          }
           if (pg_verdict == 1) {
             auto gpg = PROSPER_GREGS((ucontext_t*)uctx);
             uint64_t rip = (uint64_t)gpg[REG_RIP];
@@ -919,6 +932,15 @@ namespace {
         if ((sig == SIGSEGV || sig == SIGBUS) && try_emulate_fs_access((ucontext_t*)uctx, (uint64_t)si->si_addr))
             return;
 #endif
+        // #707 det-step: the single-step trap after a co-located write on the guarded page. Re-arm the
+        // page RO immediately (RW window was one instruction) and clear TF. Checked before the other
+        // SIGTRAP consumers — it only fires when a det-step guard set g_eq_guard_stepping.
+        if (sig == SIGTRAP && g_eq_guard_stepping) {
+            g_eq_guard_stepping = 0;
+            prosper_eq_guard_rearm();
+            PROSPER_GREGS((ucontext_t*)uctx)[REG_EFL] &= ~0x100ll;   // clear trap flag
+            return;
+        }
         // A SIGILL we did NOT emulate: log the faulting instruction bytes so the offending opcode can be
         // identified (another AMD-only ISA extension, or a decode miss in try_emulate_sse4a). #163-progress.
         if (sig == SIGILL) {
@@ -2094,6 +2116,7 @@ void install_trap_handler() {
         || getenv("PROSPER_WATCH_LABEL")
         || getenv("PROSPER_WATCH_ABS")
         || getenv("PROSPER_MB3WATCH")
+        || (getenv("PROSPER_EQ_PAGEGUARD") && !strcmp(getenv("PROSPER_EQ_PAGEGUARD"), "det-step"))
         || getenv("PROSPER_WATCH_HOT")) sigaction(SIGTRAP, &sa, nullptr);   // single-step / breakpoint
 }
 

--- a/prosper/src/host/posix_shim.hpp
+++ b/prosper/src/host/posix_shim.hpp
@@ -77,6 +77,11 @@ static inline int prosper_mincore(const void* addr, size_t len, unsigned char* v
     return mincore(const_cast<void*>(addr), len, reinterpret_cast<char*>(vec));
 }
 
+// #707: on macOS boot_trace loads inside the guest GPU-VA window [4 GiB, 64 GiB); a write whose
+// destination overlaps our own image must be refused (defined in exec_image_linux.cpp).
+extern "C" int  prosper_fixed_map_hits_host_image(uint64_t addr, uint64_t len);
+extern "C" void prosper_report_host_image_clobber(uint64_t addr, uint64_t len, const char* site);
+
 // ---- fault-safe same-process memory copy (Linux: process_vm_readv/writev) ----------------------
 // The HLE uses these as an EFAULT-safe memcpy against possibly-unmapped guest addresses (pid is
 // always getpid()). mach_vm_read_overwrite/mach_vm_write give the same guarantee on Darwin. The
@@ -87,6 +92,13 @@ static inline ssize_t process_vm_readv(pid_t /*pid: self*/,
                                        const struct iovec* remote, unsigned long riovcnt,
                                        unsigned long /*flags*/) {
     if (liovcnt != 1 || riovcnt != 1 || local->iov_len != remote->iov_len) { errno = EINVAL; return -1; }
+    // #707 probe: mach_vm_read_overwrite WRITES to `local` honoring max_protection. If a caller passes
+    // a host destination that overlaps our own image (e.g. a __DATA staging buffer that overflows into
+    // adjacent globals), this is the corruptor. LOG (with caller backtrace) but don't refuse yet —
+    // readv destinations can legitimately be host buffers.
+    if (prosper_fixed_map_hits_host_image((uint64_t)(uintptr_t)local->iov_base, (uint64_t)local->iov_len))
+        prosper_report_host_image_clobber((uint64_t)(uintptr_t)local->iov_base,
+                                          (uint64_t)local->iov_len, "process_vm_readv");
     mach_vm_size_t got = 0;
     kern_return_t kr = mach_vm_read_overwrite(mach_task_self(),
                                               (mach_vm_address_t)remote->iov_base,
@@ -100,6 +112,17 @@ static inline ssize_t process_vm_writev(pid_t /*pid: self*/,
                                         const struct iovec* remote, unsigned long riovcnt,
                                         unsigned long /*flags*/) {
     if (liovcnt != 1 || riovcnt != 1 || local->iov_len != remote->iov_len) { errno = EINVAL; return -1; }
+    // #707: mach_vm_write goes THROUGH the VM system — it writes per the region's max_protection and
+    // ignores the current mprotect, so it never faults and can silently overwrite a read-only page.
+    // On macOS boot_trace loads inside the guest GPU-VA window, so a `remote` (guest dst) that aliases
+    // our own __TEXT/__DATA corrupts host globals (e.g. g_eq_mx's pthread sig -> EINVAL crash). This is
+    // the choke point every EFAULT-safe guest-memory write funnels through. Writing guest data into
+    // prosper's own image is never legitimate — refuse it. No-op on Linux (image is outside the window).
+    if (prosper_fixed_map_hits_host_image((uint64_t)(uintptr_t)remote->iov_base, (uint64_t)remote->iov_len)) {
+        prosper_report_host_image_clobber((uint64_t)(uintptr_t)remote->iov_base,
+                                          (uint64_t)remote->iov_len, "process_vm_writev");
+        errno = EFAULT; return -1;
+    }
     kern_return_t kr = mach_vm_write(mach_task_self(),
                                      (mach_vm_address_t)remote->iov_base,
                                      (vm_offset_t)local->iov_base,


### PR DESCRIPTION
Fixes #707. **macOS Blasphemous 2 equeue-cluster corruption — characterized + mitigated.**

## The problem

On **macOS (x86-64 under Rosetta)** a routed Blasphemous 2 (`PPSA13579`) run corrupts prosper's own host globals at ~render frame 120 (asset/FMOD load): a page-granular region of `boot_trace`'s own `__DATA` is zeroed, wiping the pthread `__sig` of the equeue mutex cluster. A later `pthread_mutex_lock` returns `EINVAL`, `std::mutex::lock` throws, and the process terminates in `vblank_pump`. ~50–80% of runs reproduce. **Latent on Linux** (the write never happens there — see below).

### Corruptor — characterized (earlier window-collision hypothesis disproved)

- **In-place zeroing** of `boot_trace`'s own `__DATA` (equeue mutex cluster): `mach_vm_region` shows the mapping unchanged, only the bytes.
- **Image-relative** (`image_base + fixed_offset`, tracks the image): relocating the executable out of `[4 GiB, 64 GiB)` does not stop it.
- **Bypasses current `mprotect`** (RO decoy page zeroed, no fault) but **honors `max_protection`** (lowering max to `VM_PROT_READ` blocks it silently) ⇒ a **`mach_vm`-family VM-system write**, not a CPU store. This is *why it can't happen on Linux* — there is no `mach_vm`, so the write never occurs (3/3 taint runs clean). prosper's own `mach_vm` writers are guarded and never fire ⇒ writer is a **dylib / the Rosetta runtime**.
- **Ruled out**: CPU store, prosper `mmap(MAP_FIXED)`, `process_vm_writev`/`readv`, `madvise`/remap, the window collision, and (now) **instrumented prosper code** — ASAN on Linux is a proven dead end because the write mechanism cannot occur there.

**The exact writer is not yet named** (it evades every fault-based catch under Rosetta and every symbol interpose; hardware watchpoints do not exist under Rosetta). Full analysis, ruled-out list, and the remaining macOS-side attribution paths: [`docs/BLASPHEMOUS2_EQ_CORRUPTION.md`](prosper/docs/BLASPHEMOUS2_EQ_CORRUPTION.md).

## The fix (correct-by-construction)

Since the writer can't be attributed on this platform, keep the crash-critical mutexes **out of the region it writes** — mirroring what already keeps Linux alive. On macOS/libc++ a namespace-scope `std::mutex` is constant-initialized non-zero → `__DATA`; on Linux it is all-zero → `.bss` (untouched).

`nm -n` on the Mach-O pins the confirmed victim cluster at `image+0x179000..0x17bce0`. It holds two **hot** mutexes: `g_eq_mx` (vblank) and **`g_apr_mx` (`0x17bca0`, APR ring-token posting during asset load)**. cfcb41c moved only `g_eq_mx`, so the crash would merely **relocate** to the APR mutex. This PR completes the mitigation:

- **new `src/hle/heap_mutex.hpp`** — `PROSPER_HEAP_MUTEX(name)`: a trivially-constructed `.bss` forwarder to a heap `std::mutex` allocated **once, eagerly, at static init** (never `new`/`malloc` on a lock path — the `%fs` SIGSEGV handler also takes these locks and malloc there deadlocks; an earlier lazy variant did exactly that and wedged the runtime). Plain `std::mutex` on non-Apple platforms — Linux/Windows unchanged.
- both `g_apr_mx` mutexes (`hle_kernel_time.cpp` confirmed-in-region + `hle_file.cpp` defense-in-depth) now use it.

**Result:** the corrupted region now contains only `g_det_clock` (cold — locked only under `PROSPER_DET_CLOCK`), diagnostic decoys, and canaries — **no hot mutex**. The corruptor can keep zeroing `image+0x178000` indefinitely; nothing crash-critical lives there, so neither `vblank_pump` nor the APR path can hit `EINVAL`.

## Verification

- **Linux build clean; `ctest` green on every changed-code path** (`equeue_events`, `apr_registry_size_keying`, `kernel_signal_time`). *(The 4 unrelated failures in the colima x86-64/Rosetta CI VM are `WRFSBASE` `SIGILL`s — a Rosetta-VM instruction limitation in the `%fs`/TLS/fault tests, not this change; they pass on a native x86-64 Linux host.)*
- **macOS `__APPLE__` branch compiles + links** (build-mac-app, x86-64); `nm` confirms both `g_apr_mx` moved to `.bss` (`0x100ab74a0`, `0x100ab8768`).
- **Not runtime-verified on macOS**: an earlier buggy mitigation attempt deadlocked and wedged this host's Rosetta runtime (even a trivial x86-64 hello-world now hangs), so no x86-64 binary runs until the host is **rebooted**. After a reboot, run the reproduce recipe in the doc and confirm SIGWATCH no longer reports `g_eq_mx`/`g_apr_mx` and the route reaches sustained gameplay.

## Residual risk (documented)

If the crash *relocates again*, the corruptor's extent reaches past the confirmed cluster; the next candidates (`g_guard_mx`, `g_avp_mx`/`g_savemem_mx`, `g_smx`, one page above) each just need `PROSPER_HEAP_MUTEX`. Keep the diagnostic decoy/ballast/canary arrays until the corruptor is attributed — removing them shifts those mutexes toward the cluster.

## Diagnostics retained (all env-gated `PROSPER_EQ_*`, zero default-boot change)

`SIGWATCH` (sig-word poller + `mach_vm_region` probe), `PAGEGUARD` (`lo`/`ballast`/`det`/`selftest`), `CANARY`, and the host-image write/map guards (`prosper_fixed_map_hits_host_image`). These characterized the corruptor and remain the tools to attribute it.
