### PR TITLE
perf(renderer): persist graphics pipelines

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -266,6 +266,16 @@ current guest addresses and backing data remain on each draw and are never cache
 every tested miss byte-for-byte with the direct recompiler and verifies that runtime-only resource
 changes hit while descriptor-interface changes miss.
 
+The Vulkan backend retains graphics pipelines across render-target calls. Live draws carry a
+process-unique, never-recycled identity from the exact shader cache, so a hot lookup does not copy or
+hash complete SPIR-V modules. Capture, replay, and test draws without those identities fall back to an
+exact full-module key. The rest of the key contains the descriptor-layout contract and every baked
+fixed-function value; equality still compares the complete key after hashing. The cache is bounded to
+1024 entries by default. Set `PROSPER_PIPELINE_CACHE_ENTRIES=<N>` to change the entry limit or
+`PROSPER_NO_BACKEND_PIPELINE_CACHE=1` for a transient-pipeline A/B. With `PROSPER_RENDER_TIMING=1`,
+the backend and submit-aligned windows report references, hits, misses, bypasses, current entries, and
+evictions. A pipeline hit also skips temporary Vulkan shader-module creation.
+
 Do not cache `build_stage_table` results using only shader addresses and user-SGPR values. Descriptor
 tables are reached through guest pointers, and their memory can change while every pointer/register
 value remains identical. That experiment caused Messenger to remain on its initial loading screen and

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -382,6 +382,45 @@ the workload playable. The next investigation must identify the true dependencie
 persisting pipelines addresses about 13 ms, while removing unnecessary synchronous wait/readback boundaries
 has the larger ceiling but requires preserving graphics/compute and RTT producer-consumer order.
 
+## Persistent graphics pipelines
+
+The backend now retains Vulkan graphics pipelines across target calls with an exact, bounded key. The first
+prototype copied and hashed both complete SPIR-V modules on every draw; despite a 100% hit rate, that made a
+54-draw loading submit slower. The accepted path assigns each entry in the exact shader-recompile cache a
+process-unique identity that is never recycled, even when that cache is cleared. Live pipeline keys use those
+two identities, an inline allocation-free fixed-state key, and the descriptor contract already named by the
+shader identities. Externally constructed, captured, and replayed draws have identity zero and retain the full
+SPIR-V plus descriptor-layout fallback. Hash collisions are benign because equality compares the exact key.
+Pipeline hits also skip temporary `VkShaderModule` creation.
+
+The cache defaults to 1024 entries and evicts the least-recently-used pipeline not referenced by the current
+backend call. `PROSPER_PIPELINE_CACHE_ENTRIES` changes the bound and
+`PROSPER_NO_BACKEND_PIPELINE_CACHE=1` restores transient creation. Timing output reports references, hits,
+misses, bypasses, entries, and evictions at both backend-call and submit-aligned scopes.
+
+Native Windows / RTX 4090, fresh saves, current master including #750, extended full-render input hold, and
+the workload-filtered target profiler produced nearby animated heavy windows rather than identical draw
+counts. The state-specific setup buckets are therefore the useful comparison:
+
+| Mode | Draws | Shader modules | Pipeline work | Total draw setup | Backend wall time |
+|---|---:|---:|---:|---:|---:|
+| Cache disabled | 378 | 3.27-3.35 ms | 14.96-15.75 ms | 30.19-31.51 ms | 106.45-110.35 ms |
+| Persistent cache | 359 | 0.00 ms | 10.05-10.24 ms | 20.89-20.99 ms | 95.63-97.88 ms |
+
+After normalizing the setup buckets for the draw-count difference, retained pipelines remove about 7-8 ms
+per heavy submit. The 54-draw loading loop improves by only about 1 ms because the Windows NVIDIA driver
+already makes repeated transient creation cheap; the larger expected benefit on MoltenVK remains to be
+measured. The enabled run held 30 pipelines in the heavy scene. Its final private-memory range was
+1.77-1.80 GiB and its working-set range was 3.74-3.76 GiB, indistinguishable from the disabled control at
+1.79-1.80 GiB / 3.74 GiB. Both extended routes reached the post-parse workload. Per-target logging materially
+perturbs whole-submit time, so the reported application FPS from these diagnostic runs is not a normal-play
+benchmark.
+
+This closes the measured pipeline-creation tranche, not the renderer problem. Ten target calls still perform
+synchronous GPU waits and readbacks, and the whole ordered submit remains hundreds of milliseconds under the
+target profiler. Coordinated GPU ownership across those producer-consumer boundaries is the next architectural
+step.
+
 ## Current frame budget
 
 After shared publication, the Dead Cells post-parse loading workload is the most useful current budget:

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -223,6 +223,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 double backend_readback_ms = 0, backend_cleanup_ms = 0;
                 double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                 double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
+                uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
+                uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
+                uint64_t backend_pipeline_entries = 0, backend_pipeline_evictions = 0;
                 uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                 uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                 uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
@@ -249,7 +252,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             }
             const auto callback_timing_start = timing_enabled
                 ? RenderClock::now() : RenderClock::time_point{};
-            auto record_backend_timing = [&](const prosper::test::BackendRenderTimingStats& backend) {
+            auto record_backend_timing = [&]
+                (const prosper::test::BackendRenderTimingStats& backend,
+                 const prosper::test::BackendPipelineCacheStats& pipelines) {
                 pending_timing.backend_calls += backend.calls;
                 pending_timing.backend_draws += backend.draws;
                 pending_timing.backend_target_ms += backend.target_ms;
@@ -262,6 +267,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_setup_fixed_ms += backend.setup_fixed_ms;
                 pending_timing.backend_setup_resources_ms += backend.setup_resources_ms;
                 pending_timing.backend_setup_pipeline_ms += backend.setup_pipeline_ms;
+                pending_timing.backend_pipeline_refs += pipelines.references;
+                pending_timing.backend_pipeline_hits += pipelines.hits;
+                pending_timing.backend_pipeline_misses += pipelines.misses;
+                pending_timing.backend_pipeline_bypasses += pipelines.bypasses;
+                pending_timing.backend_pipeline_entries = pipelines.entries;
+                pending_timing.backend_pipeline_evictions += pipelines.evictions;
             };
             auto print_rtt_timing = [](const RttTimingRecord& record) {
                 const prosper::test::BackendRenderTimingStats& timing = record.timing;
@@ -1260,6 +1271,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     prosper::test::BackendDraw bd;
                     bd.vs     = refvs ? refvs_spv : it.vs;
                     bd.fs     = ps_override.empty() ? it.fs : ps_override;
+                    bd.vs_identity = refvs ? 0 : it.vs_identity;
+                    bd.fs_identity = ps_override.empty() ? it.fs_identity : 0;
                     bd.vcount = refvs ? 3u : it.vertex_count;
                     bd.ps     = nops ? nullptr : &it.ps;
                     bd.R      = build_R(it, it.vrt.get(), it.prt.get());
@@ -1460,12 +1473,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const prosper::test::BackendRenderTimingStats backend_call_timing = timing_enabled
                         ? prosper::test::backend_render_timing_stats()
                         : prosper::test::BackendRenderTimingStats{};
+                    const prosper::test::BackendPipelineCacheStats backend_pipeline_stats = timing_enabled
+                        ? prosper::test::backend_pipeline_cache_stats()
+                        : prosper::test::BackendPipelineCacheStats{};
                     if (timing_enabled) {
                         pending_timing.build_resources_ms +=
                             std::chrono::duration<double, std::milli>(build_done - build_start).count();
                         pending_timing.backend_ms +=
                             std::chrono::duration<double, std::milli>(backend_done - build_done).count();
-                        record_backend_timing(backend_call_timing);
+                        record_backend_timing(backend_call_timing, backend_pipeline_stats);
                     }
                     auto pass_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(gpx));
                     if (base && !pass_pixels->empty()) {
@@ -1623,12 +1639,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 const prosper::test::BackendRenderTimingStats backend_call_timing = timing_enabled
                     ? prosper::test::backend_render_timing_stats()
                     : prosper::test::BackendRenderTimingStats{};
+                const prosper::test::BackendPipelineCacheStats backend_pipeline_stats = timing_enabled
+                    ? prosper::test::backend_pipeline_cache_stats()
+                    : prosper::test::BackendPipelineCacheStats{};
                 if (timing_enabled) {
                     pending_timing.build_resources_ms +=
                         std::chrono::duration<double, std::milli>(build_done - build_start).count();
                     pending_timing.backend_ms +=
                         std::chrono::duration<double, std::milli>(backend_done - build_done).count();
-                    record_backend_timing(backend_call_timing);
+                    record_backend_timing(backend_call_timing, backend_pipeline_stats);
                 }
                 // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
                 // composite pass that samples that address gets the scene we drew (not empty guest memory).
@@ -1704,6 +1723,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     double backend_readback_ms = 0, backend_cleanup_ms = 0;
                     double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
+                    uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
+                    uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
+                    uint64_t backend_pipeline_entries = 0, backend_pipeline_evictions = 0;
                     uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                     uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                     uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
@@ -1732,6 +1754,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.backend_setup_fixed_ms += pending_timing.backend_setup_fixed_ms;
                     timing.backend_setup_resources_ms += pending_timing.backend_setup_resources_ms;
                     timing.backend_setup_pipeline_ms += pending_timing.backend_setup_pipeline_ms;
+                    timing.backend_pipeline_refs += pending_timing.backend_pipeline_refs;
+                    timing.backend_pipeline_hits += pending_timing.backend_pipeline_hits;
+                    timing.backend_pipeline_misses += pending_timing.backend_pipeline_misses;
+                    timing.backend_pipeline_bypasses += pending_timing.backend_pipeline_bypasses;
+                    timing.backend_pipeline_entries = pending_timing.backend_pipeline_entries;
+                    timing.backend_pipeline_evictions += pending_timing.backend_pipeline_evictions;
                     timing.textures += pending_timing.textures;
                     timing.texture_reuses += pending_timing.texture_reuses;
                     timing.persistent_hits += pending_timing.persistent_hits;
@@ -1779,6 +1807,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.backend_setup_fixed_ms / nsub,
                             totals.backend_setup_resources_ms / nsub,
                             totals.backend_setup_pipeline_ms / nsub);
+                    fprintf(stderr,
+                            "[render-timing] backend-submit pipelines refs=%.1f hits=%.1f misses=%.1f "
+                            "bypass=%.1f entries=%llu evictions=%.1f\n",
+                            totals.backend_pipeline_refs / nsub,
+                            totals.backend_pipeline_hits / nsub,
+                            totals.backend_pipeline_misses / nsub,
+                            totals.backend_pipeline_bypasses / nsub,
+                            (unsigned long long)totals.backend_pipeline_entries,
+                            totals.backend_pipeline_evictions / nsub);
                     fprintf(stderr,
                             "[render-timing] resources textures=%llu reused=%llu %.1f MiB %.2f ms/submit; "
                             "buffers=%llu %.1f MiB %.2f ms/submit\n",
@@ -1849,6 +1886,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.backend_setup_fixed_ms / wn,
                             window.backend_setup_resources_ms / wn,
                             window.backend_setup_pipeline_ms / wn);
+                    fprintf(stderr,
+                            "[render-window] backend-submit pipelines refs=%.1f hits=%.1f misses=%.1f "
+                            "bypass=%.1f entries=%llu evictions=%.1f\n",
+                            window.backend_pipeline_refs / wn,
+                            window.backend_pipeline_hits / wn,
+                            window.backend_pipeline_misses / wn,
+                            window.backend_pipeline_bypasses / wn,
+                            (unsigned long long)window.backend_pipeline_entries,
+                            window.backend_pipeline_evictions / wn);
                     fprintf(stderr,
                             "[render-window] texture_cache hits=%.1f submit_reuse=%.1f misses=%.1f "
                             "invalid=%.1f validations=%.1f %.1f MiB\n",

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -19,8 +19,10 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
 - `reach-first-gameplay-full-render.pad`: performs the same route with input
   delayed until the title appears when every submit is rendered. Use this for
   presented-image regression investigation; it does not depend on a renderer
-  warmup. WSL llvmpipe runs have not yet cleared Prisoners' Quarters loading
-  repeatably by 180 seconds, so the gameplay baseline remains pending.
+  warmup. Circle remains held through 240 seconds because synchronous rendering
+  has made `PARSEALL` take from about 60 to more than 160 seconds across measured
+  builds. The route now survives that throughput variance, but the gameplay
+  snapshot baseline remains pending until its retained frames are reviewed.
 - `reach-first-gameplay-capture.pad`: uses the same menu input but holds Circle from
   28 through 300 seconds. Use it when synchronous timeline/bundle capture begins during
   level loading; the ordinary six-second hold can expire while capture stalls GPU progress.

--- a/prosper/scripts/dead-cells/reach-first-gameplay-full-render.pad
+++ b/prosper/scripts/dead-cells/reach-first-gameplay-full-render.pad
@@ -2,9 +2,10 @@
 # Unlike reach-first-gameplay.pad, this does not depend on a renderer warmup making
 # guest startup run ahead. Full rendering can reduce pad polls below 1 Hz, so
 # every menu action is held across several polls with a release gap between it
-# and the next action. Circle remains held through the skippable opening.
+# and the next action. Circle remains held through the slow full-render parse and skippable opening;
+# it deliberately outlives the current snapshot timeout so host throughput cannot expire the skip.
 40-48:cross
 52-60:cross
 64-72:cross
 76-84:cross
-88-115:circle
+88-240:circle

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -40,6 +40,9 @@ struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backe
 // correctly instead of collapsing onto a single draw. The tables may be null (color-only shaders).
 struct DrawItem {
     std::vector<uint32_t> vs, fs;                     // recompiled SPIR-V
+    // Process-unique identities supplied by the exact shader-recompile cache. Zero means the
+    // shader came from an external/replay path, so persistent backend caches must compare words.
+    uint64_t vs_identity = 0, fs_identity = 0;
     ResolvedPipelineState ps;                         // THIS draw's fixed-function state
     std::shared_ptr<ShaderResourceTable> vrt, prt;    // may be null
     uint32_t vertex_count = 3;
@@ -199,7 +202,8 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
                                                        const ShaderResourceTable* resources = nullptr,
                                                        const PixelInputMapping* pixel_inputs = nullptr,
-                                                       const PixelSystemInputMapping* system_inputs = nullptr);
+                                                       const PixelSystemInputMapping* system_inputs = nullptr,
+                                                       uint64_t* cache_identity = nullptr);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -462,12 +466,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     PixelSystemInputMapping system_inputs{rs.ps_input_ena, rs.ps_input_addr};
     const PixelSystemInputMapping* system_input_ptr =
         (system_inputs.ena || system_inputs.addr) ? &system_inputs : nullptr;
+    uint64_t vs_identity = 0, fs_identity = 0;
     std::vector<uint32_t> vs = recompile_graphics_shader_cached(
         ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
-        max_shader_dwords, vrt.get(), pixel_input_ptr);
+        max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
     std::vector<uint32_t> fs = recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
-        max_shader_dwords, prt.get(), nullptr, system_input_ptr);
+        max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();
         record_draw_realization_phases(
@@ -784,7 +789,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
     }
-    out.vs = std::move(vs); out.fs = std::move(fs); out.ps = ps;
+    out.vs = std::move(vs); out.fs = std::move(fs);
+    out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
     out.color0_base = rs.color0_base;   // render-to-texture: the target this draw writes into (#167)
     out.color0_width = rs.color0_width; out.color0_height = rs.color0_height; // per-target extent (#526)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -176,6 +176,7 @@ struct ShaderCompileKeyHash {
 
 struct CachedShader {
     std::vector<uint32_t> spirv;
+    uint64_t identity = 0;
     uint64_t last_use = 0;
     uint64_t bytes = 0;
 };
@@ -185,6 +186,7 @@ struct ShaderCache {
     std::unordered_map<ShaderCompileKey, CachedShader, ShaderCompileKeyHash> entries;
     ShaderRecompileCacheStats stats;
     uint64_t use_counter = 0;
+    uint64_t next_identity = 1;
 };
 
 ShaderCache& shader_cache() {
@@ -488,7 +490,9 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const uint32_t* code, size_t dwords,
                                                        const ShaderResourceTable* resources,
                                                        const PixelInputMapping* pixel_inputs,
-                                                       const PixelSystemInputMapping* system_inputs) {
+                                                       const PixelSystemInputMapping* system_inputs,
+                                                       uint64_t* cache_identity) {
+    if (cache_identity) *cache_identity = 0;
     ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs,
                                                    system_inputs);
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
@@ -506,6 +510,7 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
     if (found != cache.entries.end()) {
         ++cache.stats.hits;
         found->second.last_use = ++cache.use_counter;
+        if (cache_identity) *cache_identity = found->second.identity;
         return found->second.spirv;
     }
 
@@ -530,8 +535,10 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
     if (bytes <= limit && max_entries != 0) {
         CachedShader value;
         value.spirv = spirv;
+        value.identity = cache.next_identity++;
         value.last_use = ++cache.use_counter;
         value.bytes = bytes;
+        if (cache_identity) *cache_identity = value.identity;
         cache.stats.bytes += bytes;
         cache.entries.emplace(std::move(key), std::move(value));
     }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.h>
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/render_state.hpp"
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -110,6 +111,7 @@ struct FrameResource {
 // correctly. render_triangle_rgba is a thin single-draw wrapper (below).
 struct BackendDraw {
     std::vector<uint32_t> vs, fs;
+    uint64_t vs_identity = 0, fs_identity = 0;
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
     uint32_t vcount = 3;
@@ -136,6 +138,74 @@ inline BackendTextureUploadStats& backend_texture_upload_stats_storage() {
 
 inline BackendTextureUploadStats backend_texture_upload_stats() {
     return backend_texture_upload_stats_storage();
+}
+
+struct BackendPipelineCacheStats {
+    uint64_t references = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t bypasses = 0;
+    uint64_t entries = 0;
+    uint64_t evictions = 0;
+};
+
+inline BackendPipelineCacheStats& backend_pipeline_cache_stats_storage() {
+    static thread_local BackendPipelineCacheStats stats;
+    return stats;
+}
+
+inline BackendPipelineCacheStats backend_pipeline_cache_stats() {
+    return backend_pipeline_cache_stats_storage();
+}
+
+struct PersistentPipelineKey {
+    static constexpr size_t kInlineWords = 64;
+    std::array<uint32_t, kInlineWords> inline_words{};
+    std::vector<uint32_t> overflow_words;
+    uint32_t word_count = 0;
+    uint64_t hash = 1469598103934665603ull;
+
+    bool operator==(const PersistentPipelineKey& other) const {
+        if (hash != other.hash || word_count != other.word_count) return false;
+        const size_t inline_count = std::min<size_t>(word_count, kInlineWords);
+        return std::equal(inline_words.begin(), inline_words.begin() + inline_count,
+                          other.inline_words.begin()) &&
+               overflow_words == other.overflow_words;
+    }
+};
+
+struct PersistentPipelineKeyHash {
+    size_t operator()(const PersistentPipelineKey& key) const {
+        return static_cast<size_t>(key.hash);
+    }
+};
+
+struct PersistentPipeline {
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    uint64_t last_use = 0;
+};
+
+inline std::unordered_map<PersistentPipelineKey, PersistentPipeline, PersistentPipelineKeyHash>&
+persistent_pipeline_cache() {
+    static std::unordered_map<PersistentPipelineKey, PersistentPipeline, PersistentPipelineKeyHash> cache;
+    return cache;
+}
+
+inline uint64_t& persistent_pipeline_generation() {
+    static uint64_t generation = 0;
+    return generation;
+}
+
+inline bool persistent_pipeline_cache_enabled() {
+    return getenv("PROSPER_NO_BACKEND_PIPELINE_CACHE") == nullptr;
+}
+
+inline size_t persistent_pipeline_cache_limit() {
+    static const size_t limit = [] {
+        const char* value = getenv("PROSPER_PIPELINE_CACHE_ENTRIES");
+        return value ? static_cast<size_t>(strtoull(value, nullptr, 10)) : size_t{1024};
+    }();
+    return limit;
 }
 
 struct BackendRenderTimingStats {
@@ -916,7 +986,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         std::vector<VkImageView> tview; std::vector<VkSampler> tsamp;
         VkPipelineLayout layout = VK_NULL_HANDLE; VkPipeline pipe = VK_NULL_HANDLE;
         VkBuffer ibuf = VK_NULL_HANDLE; VkDeviceMemory ibmem = VK_NULL_HANDLE;   // index buffer (indexed draws)
-        uint32_t n_sets = 1, vcount = 3, icount = 0; bool use_desc = false, ok = false;
+        uint32_t n_sets = 1, vcount = 3, icount = 0;
+        bool use_desc = false, ok = false, pipeline_cached = false;
     };
     struct TextureUploadKey {
         const uint8_t* pixels = nullptr;
@@ -997,15 +1068,33 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     auto setup_elapsed_ms = [](auto begin, auto end) {
         return std::chrono::duration<double, std::milli>(end - begin).count();
     };
+    BackendPipelineCacheStats& pipeline_stats = backend_pipeline_cache_stats_storage();
+    pipeline_stats = {};
+    auto& pipeline_cache = persistent_pipeline_cache();
+    const uint64_t pipeline_generation = ++persistent_pipeline_generation();
+    const bool pipeline_cache_enabled = persistent_pipeline_cache_enabled();
+    const size_t pipeline_cache_limit = persistent_pipeline_cache_limit();
+    auto evict_pipeline = [&]() {
+        auto victim = pipeline_cache.end();
+        for (auto it = pipeline_cache.begin(); it != pipeline_cache.end(); ++it) {
+            if (it->second.last_use == pipeline_generation) continue;
+            if (victim == pipeline_cache.end() ||
+                it->second.last_use < victim->second.last_use) victim = it;
+        }
+        if (victim == pipeline_cache.end()) return false;
+        vkDestroyPipeline(dev, victim->second.pipeline, nullptr);
+        pipeline_cache.erase(victim);
+        ++pipeline_stats.evictions;
+        return true;
+    };
     // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
     for (size_t di = 0; di < draws.size(); di++) {
         const auto setup_begin = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         const BackendDraw& bd = draws[di];
         DV& v = dv[di];
-        v.vs = mkmod(bd.vs); v.fs = mkmod(bd.fs);
-        const auto setup_shaders_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-        if (timing_enabled) setup_shader_ms += setup_elapsed_ms(setup_begin, setup_shaders_ready);
-        if (!v.vs || !v.fs) continue;   // rejected SPIR-V -> skip this draw
+        // Pipeline hits do not need temporary VkShaderModules. Defer module creation until after the
+        // persistent lookup; the fixed/resource setup below is also required by the hit pipeline.
+        const auto setup_shaders_ready = setup_begin;
         const prosper::gpu::ResolvedPipelineState* ps = bd.ps;
         v.vcount = bd.vcount;
         // Indexed draw: upload the 32-bit index data to a host-visible VkIndexBuffer now; the record
@@ -1351,9 +1440,136 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
         gp.pColorBlendState = &cb; gp.layout = v.layout; gp.renderPass = rp; gp.subpass = 0;
         if (ps && (ps->depth_test_enable || ps->stencil_enable)) gp.pDepthStencilState = &dss;
-        if (vkCreateGraphicsPipelines(dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) v.ok = true;
+        ++pipeline_stats.references;
+        bool create_pipeline = true;
+        PersistentPipelineKey pipeline_key;
+        if (pipeline_cache_enabled && pipeline_cache_limit) {
+            auto append = [&](uint32_t word) {
+                if (pipeline_key.word_count < PersistentPipelineKey::kInlineWords)
+                    pipeline_key.inline_words[pipeline_key.word_count] = word;
+                else
+                    pipeline_key.overflow_words.push_back(word);
+                ++pipeline_key.word_count;
+                pipeline_key.hash ^= word;
+                pipeline_key.hash *= 1099511628211ull;
+            };
+            auto append_float = [&](float value) {
+                uint32_t word = 0;
+                static_assert(sizeof word == sizeof value);
+                memcpy(&word, &value, sizeof word);
+                append(word);
+            };
+            append(1); // key schema version
+            append(W); append(H); append(use_ds); append(static_cast<uint32_t>(DFMT));
+            const bool exact_shader_identities = bd.vs_identity && bd.fs_identity;
+            append(bd.vs_identity != 0);
+            if (bd.vs_identity) {
+                append(static_cast<uint32_t>(bd.vs_identity));
+                append(static_cast<uint32_t>(bd.vs_identity >> 32));
+            } else {
+                append(static_cast<uint32_t>(bd.vs.size()));
+                for (uint32_t word : bd.vs) append(word);
+            }
+            append(bd.fs_identity != 0);
+            if (bd.fs_identity) {
+                append(static_cast<uint32_t>(bd.fs_identity));
+                append(static_cast<uint32_t>(bd.fs_identity >> 32));
+            } else {
+                append(static_cast<uint32_t>(bd.fs.size()));
+                for (uint32_t word : bd.fs) append(word);
+            }
+            append(v.use_desc); append(v.n_sets);
+            // A pair of shader-cache identities names the exact compile keys, including every
+            // descriptor's class and binding. External/replay shaders have identity zero and keep
+            // the full layout contract in the fallback key.
+            append(!exact_shader_identities);
+            if (!exact_shader_identities) {
+                append(static_cast<uint32_t>(R.size()));
+                for (size_t i = 0; i < R.size(); ++i) {
+                    const bool texture = R[i].is_texture();
+                    const VkDescriptorType descriptor_type = texture
+                        ? VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+                        : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                    const VkShaderStageFlags stage_flags = !texture || R[i].set == 0
+                        ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
+                        : VK_SHADER_STAGE_FRAGMENT_BIT;
+                    append(R[i].set); append(R[i].binding); append(descriptor_type);
+                    append(1); append(stage_flags);
+                }
+            }
+            append(ia.topology); append(ia.primitiveRestartEnable);
+            append_float(vp.x); append_float(vp.y); append_float(vp.width); append_float(vp.height);
+            append_float(vp.minDepth); append_float(vp.maxDepth);
+            append(static_cast<uint32_t>(sc.offset.x)); append(static_cast<uint32_t>(sc.offset.y));
+            append(sc.extent.width); append(sc.extent.height);
+            append(rs.polygonMode); append(rs.cullMode); append(rs.frontFace); append_float(rs.lineWidth);
+            append(cba.blendEnable); append(cba.srcColorBlendFactor); append(cba.dstColorBlendFactor);
+            append(cba.colorBlendOp); append(cba.srcAlphaBlendFactor); append(cba.dstAlphaBlendFactor);
+            append(cba.alphaBlendOp); append(cba.colorWriteMask);
+            append(gp.pDepthStencilState != nullptr);
+            if (gp.pDepthStencilState) {
+                append(dss.depthTestEnable); append(dss.depthWriteEnable); append(dss.depthCompareOp);
+                append(dss.depthBoundsTestEnable); append(dss.stencilTestEnable);
+                auto append_stencil = [&](const VkStencilOpState& stencil) {
+                    append(stencil.failOp); append(stencil.passOp); append(stencil.depthFailOp);
+                    append(stencil.compareOp); append(stencil.compareMask); append(stencil.writeMask);
+                    append(stencil.reference);
+                };
+                append_stencil(dss.front); append_stencil(dss.back);
+                append_float(dss.minDepthBounds); append_float(dss.maxDepthBounds);
+            }
+            auto found = pipeline_cache.find(pipeline_key);
+            if (found != pipeline_cache.end()) {
+                found->second.last_use = pipeline_generation;
+                v.pipe = found->second.pipeline;
+                v.pipeline_cached = true;
+                v.ok = true;
+                create_pipeline = false;
+                ++pipeline_stats.hits;
+            } else {
+                ++pipeline_stats.misses;
+            }
+        } else {
+            ++pipeline_stats.bypasses;
+        }
+        const auto setup_pipeline_key_ready = timing_enabled
+            ? TimingClock::now() : TimingClock::time_point{};
+        auto setup_pipeline_create_begin = setup_pipeline_key_ready;
+        if (create_pipeline) {
+            const auto setup_shader_begin = timing_enabled
+                ? TimingClock::now() : TimingClock::time_point{};
+            v.vs = mkmod(bd.vs); v.fs = mkmod(bd.fs);
+            const auto setup_shader_ready = timing_enabled
+                ? TimingClock::now() : TimingClock::time_point{};
+            if (timing_enabled)
+                setup_shader_ms += setup_elapsed_ms(setup_shader_begin, setup_shader_ready);
+            if (!v.vs || !v.fs) {
+                if (timing_enabled)
+                    setup_pipeline_ms += setup_elapsed_ms(
+                        setup_resources_ready, setup_pipeline_key_ready);
+                continue;   // rejected SPIR-V -> skip this draw
+            }
+            st[0].module = v.vs; st[1].module = v.fs;
+            setup_pipeline_create_begin = setup_shader_ready;
+            if (vkCreateGraphicsPipelines(
+                    dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) {
+                v.ok = true;
+                bool retain = pipeline_cache_enabled && pipeline_cache_limit;
+                while (retain && pipeline_cache.size() >= pipeline_cache_limit)
+                    if (!evict_pipeline()) retain = false;
+                if (retain) {
+                    pipeline_cache.emplace(std::move(pipeline_key),
+                                           PersistentPipeline{v.pipe, pipeline_generation});
+                    v.pipeline_cached = true;
+                }
+            }
+        }
+        pipeline_stats.entries = pipeline_cache.size();
         const auto setup_pipeline_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-        if (timing_enabled) setup_pipeline_ms += setup_elapsed_ms(setup_resources_ready, setup_pipeline_ready);
+        if (timing_enabled) {
+            setup_pipeline_ms += setup_elapsed_ms(setup_resources_ready, setup_pipeline_key_ready);
+            setup_pipeline_ms += setup_elapsed_ms(setup_pipeline_create_begin, setup_pipeline_ready);
+        }
     }
 
     BackendTextureUploadStats& texture_stats = backend_texture_upload_stats_storage();
@@ -1593,7 +1809,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
 
     vkDestroyFence(dev, fence, nullptr); vkDestroyCommandPool(dev, pool, nullptr);
     for (auto& v : dv) {   // per-draw objects
-        if (v.pipe)   vkDestroyPipeline(dev, v.pipe, nullptr);
+        if (v.pipe && !v.pipeline_cached) vkDestroyPipeline(dev, v.pipe, nullptr);
         if (v.layout) vkDestroyPipelineLayout(dev, v.layout, nullptr);
         if (v.ibuf)   vkDestroyBuffer(dev, v.ibuf, nullptr);
         if (v.ibmem)  release_transient_render_memory(dev, v.ibmem);
@@ -1687,6 +1903,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             uint64_t calls = 0, draws = 0;
             uint64_t texture_references = 0, texture_uploads = 0, texture_upload_bytes = 0;
             uint64_t persistent_hits = 0, persistent_misses = 0, persistent_cached_bytes = 0;
+            uint64_t pipeline_references = 0, pipeline_hits = 0, pipeline_misses = 0;
+            uint64_t pipeline_bypasses = 0, pipeline_entries = 0, pipeline_evictions = 0;
             double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
             double setup_shader = 0, setup_fixed = 0, setup_resources = 0, setup_pipeline = 0;
         };
@@ -1701,6 +1919,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             timing.persistent_hits += texture_stats.persistent_hits;
             timing.persistent_misses += texture_stats.persistent_misses;
             timing.persistent_cached_bytes = texture_stats.persistent_cached_bytes;
+            timing.pipeline_references += pipeline_stats.references;
+            timing.pipeline_hits += pipeline_stats.hits;
+            timing.pipeline_misses += pipeline_stats.misses;
+            timing.pipeline_bypasses += pipeline_stats.bypasses;
+            timing.pipeline_entries = pipeline_stats.entries;
+            timing.pipeline_evictions += pipeline_stats.evictions;
             timing.target += call_timing.target_ms;
             timing.draw_setup += call_timing.draw_setup_ms;
             timing.record += call_timing.record_upload_ms;
@@ -1737,6 +1961,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     (unsigned long long)totals.persistent_hits,
                     (unsigned long long)totals.persistent_misses,
                     totals.persistent_cached_bytes / (1024.0 * 1024.0));
+            fprintf(stderr,
+                    "[render-timing] backend pipelines refs=%llu hits=%llu misses=%llu bypass=%llu "
+                    "entries=%llu evictions=%llu\n",
+                    (unsigned long long)totals.pipeline_references,
+                    (unsigned long long)totals.pipeline_hits,
+                    (unsigned long long)totals.pipeline_misses,
+                    (unsigned long long)totals.pipeline_bypasses,
+                    (unsigned long long)totals.pipeline_entries,
+                    (unsigned long long)totals.pipeline_evictions);
             const RenderMemoryPoolStats pool = render_memory_pool_stats();
             fprintf(stderr,
                     "[render-timing] memory_pool hits=%llu misses=%llu cached=%zu %.1f MiB "
@@ -1765,6 +1998,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     window.texture_upload_bytes / (wn * 1024.0 * 1024.0),
                     window.persistent_hits / wn, window.persistent_misses / wn,
                     window.persistent_cached_bytes / (1024.0 * 1024.0));
+            fprintf(stderr,
+                    "[render-window] backend pipelines refs=%.1f hits=%.1f misses=%.1f bypass=%.1f "
+                    "entries=%llu evictions=%.1f\n",
+                    window.pipeline_references / wn, window.pipeline_hits / wn,
+                    window.pipeline_misses / wn, window.pipeline_bypasses / wn,
+                    (unsigned long long)window.pipeline_entries, window.pipeline_evictions / wn);
             window = {};
         }
     }

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -18,13 +18,17 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+static void set_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+
 int main() {
     printf("== test_multidraw_render ==\n");
-#ifdef _WIN32
-    _putenv_s("PROSPER_RENDER_TIMING", "1");
-#else
-    setenv("PROSPER_RENDER_TIMING", "1", 1);
-#endif
+    set_env("PROSPER_RENDER_TIMING", "1");
     const uint32_t W = 64, H = 64;
 
     // Known-good fullscreen-triangle vertex shader (SPIR-V), shared by both draws.
@@ -80,6 +84,27 @@ int main() {
         CHECK(timing.draw_setup_ms + 0.001 >= timing.setup_shader_ms + timing.setup_fixed_ms +
                   timing.setup_resources_ms + timing.setup_pipeline_ms,
               "draw-setup subphases fit inside the backend draw-setup phase");
+        const prosper::test::BackendPipelineCacheStats first_cache =
+            prosper::test::backend_pipeline_cache_stats();
+        CHECK(first_cache.references == 2 && first_cache.hits == 1 && first_cache.misses == 1,
+              "pipeline cache reuses the prior opaque pipeline but separates blend state");
+
+        std::vector<uint8_t> cached = prosper::test::render_draws_rgba({d0, d1}, W, H);
+        const prosper::test::BackendPipelineCacheStats cached_stats =
+            prosper::test::backend_pipeline_cache_stats();
+        CHECK(cached == px, "persistent pipeline hits preserve multi-draw pixels byte-for-byte");
+        CHECK(cached_stats.references == 2 && cached_stats.hits == 2 && cached_stats.misses == 0,
+              "repeated draw contracts hit the persistent pipeline cache");
+
+        set_env("PROSPER_NO_BACKEND_PIPELINE_CACHE", "1");
+        std::vector<uint8_t> bypassed = prosper::test::render_draws_rgba({d0, d1}, W, H);
+        const prosper::test::BackendPipelineCacheStats bypassed_stats =
+            prosper::test::backend_pipeline_cache_stats();
+        set_env("PROSPER_NO_BACKEND_PIPELINE_CACHE", nullptr);
+        CHECK(bypassed == px, "pipeline-cache disable A/B preserves output byte-for-byte");
+        CHECK(bypassed_stats.references == 2 && bypassed_stats.bypasses == 2 &&
+                  bypassed_stats.hits == 0,
+              "pipeline-cache disable A/B bypasses every lookup");
     }
 
     // A guest depth/stencil surface survives renderer calls. The first call writes stencil=2 with no

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -43,19 +43,25 @@ int main() {
     table.resources.push_back(resource);
 
     const auto direct_vs = recompile_vertex(kVs, std::size(kVs), &table);
+    uint64_t first_identity = 0;
     const auto cached_vs = recompile_graphics_shader_cached(
-        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table);
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &first_identity);
     CHECK(!direct_vs.empty() && cached_vs == direct_vs,
           "cache miss is byte-identical to the direct vertex recompiler");
     auto stats = shader_recompile_cache_stats();
     CHECK(stats.misses == 1 && stats.hits == 0 && stats.entries == 1,
           "first shader realization records one cache miss");
 
+    uint64_t repeated_identity = 0;
     const auto repeated_vs = recompile_graphics_shader_cached(
-        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table);
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &repeated_identity);
     stats = shader_recompile_cache_stats();
     CHECK(repeated_vs == direct_vs && stats.hits == 1 && stats.misses == 1,
           "identical code and descriptor semantics hit the cache");
+    CHECK(first_identity != 0 && repeated_identity == first_identity,
+          "shader cache hits preserve a non-zero compiled-shader identity");
 
     // These fields are consumed by the runtime backend, not by the recompiler. Changing them must
     // reuse SPIR-V while each DrawItem continues to carry the new table to descriptor upload.
@@ -123,10 +129,17 @@ int main() {
               stats.misses == system_misses + 2,
           "pixel-system ENA/ADDR mappings participate in the fragment shader cache key");
 
+    const uint64_t identity_before_clear = first_identity;
     clear_shader_recompile_cache();
     stats = shader_recompile_cache_stats();
     CHECK(stats.entries == 0 && stats.hits == 0 && stats.misses == 0 && stats.bytes == 0,
           "cache reset clears entries and instrumentation");
+    uint64_t identity_after_clear = 0;
+    (void)recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &identity_after_clear);
+    CHECK(identity_after_clear > identity_before_clear,
+          "cache reset never recycles compiled-shader identities");
 
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);


### PR DESCRIPTION
## What changed

- retain Vulkan graphics pipelines across render-target calls with an exact, bounded LRU cache
- carry never-reused identities from the exact shader-recompile cache so live hits do not copy/hash full SPIR-V modules
- keep a full-module and descriptor-layout fallback for capture, replay, and test draws
- skip temporary Vulkan shader-module creation on pipeline hits
- add cache counters, an entry-limit control, and a forced transient-pipeline A/B control
- extend the Dead Cells full-render Circle hold through slow `PARSEALL` runs and document the workflow/results

## Why

Submit-aligned Dead Cells profiling attributed about 13 ms of a heavy ordered submit to repeated graphics-pipeline creation. The first cache prototype was slower because it rebuilt a heap-backed key containing both complete SPIR-V modules for every hit. The final key uses exact shader-cache identities and inline fixed state, while retaining exact fallback semantics for external draws.

Native Windows / RTX 4090 heavy-scene A/B:

| Mode | Draws | Shader modules | Pipeline work | Total draw setup | Backend wall |
|---|---:|---:|---:|---:|---:|
| cache disabled | 378 | 3.27-3.35 ms | 14.96-15.75 ms | 30.19-31.51 ms | 106.45-110.35 ms |
| persistent cache | 359 | 0.00 ms | 10.05-10.24 ms | 20.89-20.99 ms | 95.63-97.88 ms |

Normalized for the animated draw-count difference, retained pipelines remove about 7-8 ms of heavy-submit setup. The 54-draw loading loop gains only about 1 ms. Memory was indistinguishable from control: enabled ended at 1.77-1.80 GiB private / 3.74-3.76 GiB working set; disabled ended at 1.79-1.80 GiB / 3.74 GiB. The heavy scene held 30 cached pipelines.

This does not solve the larger synchronous renderer problem. Ten target calls still wait and read back separately; that architecture remains tracked by #702 and #723.

## Validation

- WSL/Linux: 97/97 tests
- native Windows MinGW: 69/69 tests
- focused Vulkan multi-draw, blend-key, persistent depth/stencil, bypass, and byte-identical output checks
- shader identity hit, compile-key change, cache-clear non-reuse, and direct-recompiler equivalence checks
- two fresh-save native Dead Cells heavy runs, cache enabled/disabled, both reaching the post-parse workload

Real-title cross-title visual sequences are running while CI executes; findings will be posted before marking ready.

Fixes #752
Refs #702
Refs #723


