### PR TITLE
Fix pixel-stage dynamic buffer resources

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1342,9 +1342,11 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         fprintf(stderr, "\n");
     }
 
-    // Bindless-dynamic vertex fetch (VS): const-fold the scalar setup to resolve each buffer_load_format's
+    // Bindless-dynamic buffer fetch: const-fold the scalar setup to resolve each buffer_load_format's
     // V#, then emit it as a VertexBuffer keyed by its SRSRC SGPR so the recompiler's by_sgpr_base resolves
-    // it. Only meaningful for the vertex stage (the PS has no vertex fetch).
+    // it. Despite the historical vertex-fetch name, pixel shaders use the same instructions for UE4
+    // structured/material buffers. Dropping the PS results leaves those loads with no storage-buffer
+    // binding, so the recompiler falls back to its legacy binding 2 and reads zeros (#719).
     // The SAME const-fold also recovers descriptor-TABLE uses for BOTH stages (#294): UE4 shaders
     // s_load their T#/S#/V# descriptors from a table pointer in the user-data SGPRs and consume them
     // via image_sample / s_buffer_load — srt_uses reports each with its load-immediate key, which
@@ -1354,7 +1356,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     const auto metadata_done = phase_timing ? StageClock::now() : StageClock::time_point{};
     if (is_ps) {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
-        resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000, sgprs, kUserSgprs, 0, &srt_uses);
+        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+                                       sgprs, kUserSgprs, 0, &srt_uses);
     } else {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
@@ -1401,7 +1404,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     for (uint32_t base : bases) {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, base + range_start, sgprs);
         ShaderResourceTable t = build_shader_resources(*hdr, sgprs, kUserSgprs, user_sgpr_base);
-        // Add the const-fold-resolved dynamic vertex buffers, keyed by their SRSRC SGPR so the
+        // Add the const-fold-resolved dynamic buffers, keyed by their SRSRC SGPR so the
         // recompiler's by_sgpr_base() resolves each buffer_load_format. The V#'s data format is patched
         // at runtime by the fetch shader (so the load-time snapshot reads Unknown) — default to Float32
         // (a raw 32-bit-per-component fetch, correct for float attributes like positions).

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -1,5 +1,6 @@
 // test_agc_shader -- focused guards for sceAgcCreateShader's guest-visible side effects.
 #include "../src/hle/dispatch.hpp"
+#include "../src/gpu/gpu_execute.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -97,6 +98,36 @@ int main() {
     CHECK(dst == &good, "valid shader writes *dst");
     CHECK(good.code == reinterpret_cast<const void*>(0x2000ull), "valid shader stores code pointer");
     CHECK(prosper_agc_shader_count() == count0 + 1, "valid shader enters registry");
+
+    // #719: UE4 pixel shaders use buffer_load_format_* for structured/material data too. The
+    // dynamic V# fold is stage-agnostic; build_stage_table must retain its result for PS instead of
+    // discarding it under the old "PS has no vertex fetch" assumption. Otherwise the recompiler
+    // silently accesses its legacy binding 2, which the PS table does not provide.
+    const uint32_t pixel_buffer_fetch[] = {
+        0xBE8803FFu, 0x00020000u,   // s_mov_b32 s8, 0x20000 (V# base low)
+        0xBE8903FFu, 0x00100000u,   // s_mov_b32 s9, 0x00100000 (stride 16)
+        0xBE8A03C0u,                // s_mov_b32 s10, 64 records
+        0xBE8B0380u,                // s_mov_b32 s11, 0 (format defaults conservatively)
+        0xE0002000u, 0x80020100u,   // pc=6: buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,                // s_endpgm
+    };
+    Shader pixel{};
+    pixel.file_header = 0x34333231u;
+    pixel.version = 0x18u;
+    pixel.shader_size = sizeof(pixel_buffer_fetch);
+    pixel.type = 1;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&pixel),
+                       reinterpret_cast<uint64_t>(pixel_buffer_fetch), 0, 0, 0);
+    CHECK(rc == 0 && dst == &pixel, "pixel buffer-fetch shader enters the AGC registry");
+    prosper::gpu::GpuState empty_state;
+    auto pixel_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(pixel_buffer_fetch), true);
+    const prosper::gpu::ShaderResource* pixel_buffer = pixel_table
+        ? pixel_table->by_fetch_pc(6) : nullptr;
+    CHECK(pixel_buffer && pixel_buffer->cls == prosper::gpu::ResourceClass::VertexBuffer &&
+          pixel_buffer->gpu_addr == 0x20000u && pixel_buffer->stride == 16u,
+          "pixel-stage buffer_load_format keeps its exact dynamic V# resource");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary

- retain const-folded `buffer_load_format_*` resources when building pixel-stage tables
- bind UE4 structured/material buffers as the storage buffers the recompiler resolved
- add a focused AGC-stage regression for exact pixel-shader fetch-PC resolution

## Root cause

The dynamic-fetch fold already ran for pixel shaders, but `build_stage_table` discarded its returned resources under the assumption that only vertex shaders use buffer fetches. UE4 pixel shaders also use those instructions for structured and material data. Without the exact resource, recompilation fell back to legacy pixel binding 2, which was absent at runtime and therefore read zeros.

This is progress on #719, not a claim that DOLL's complete presentation is fixed yet.

## Validation

- full Linux build
- `ctest --test-dir build-linux --output-on-failure`: 97/97 passed
- fresh DOLL capture: all 72 realized draw descriptor contracts accepted; no active pixel binding 2
- pre-fade replay changed from the old zero-backed material result, though the scene remains visually distorted
- 65-second DOLL live-render soak reached frame 70 without renderer, worker, allocator, or process faults

The documented local snapshot gate is currently unavailable because all three manifest entries remain `review: pending`; the documented `dead-cells-splash` name is also absent (the manifest now contains `dead-cells-gameplay`).