### PR TITLE
perf(win): track guest writes for cross-submit texture reuse

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -414,6 +414,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_guest_memory_map PRIVATE prosper_core)
   add_test(NAME guest_memory_map COMMAND test_guest_memory_map)
 
+  if(WIN32)
+    add_executable(test_guest_write_watch tests/test_guest_write_watch.cpp)
+    target_link_libraries(test_guest_write_watch PRIVATE prosper_core)
+    add_test(NAME guest_write_watch COMMAND test_guest_write_watch)
+  endif()
+
   # Unannounced-32-bit index-buffer fingerprint (#304 — DOLL's Slate/UMG quads). No Vulkan needed.
   add_executable(test_index_size_detect tests/test_index_size_detect.cpp)
   target_link_libraries(test_index_size_detect PRIVATE prosper_core)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -200,10 +200,17 @@ Dead Cells post-parse workload while excluding its 54-56-draw loading loop.
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated
-full-byte scan when no later write overlaps it. Timing output reports these as `persistent-submit` details and
-`submit_reuse` aggregates, alongside the remaining exact validation count and bytes. Cross-submit reuse still
-uses exact comparison because guest CPU writes are not yet tracked. Set
-`PROSPER_NO_SUBMIT_TEXTURE_VALIDATION_REUSE=1` for the exact-validation A/B control. Set
+full-byte scan when no later write overlaps it. On Windows, cross-submit reuse also protects every writable
+virtual alias of the texture's physical guest pages and handles the first CPU write through the process VEH.
+An unchanged registration proves that the bytes were not written; a fault, host physical write, mapping
+change, incomplete alias set, or unsupported platform uses the exact byte-comparison fallback. Resources
+written on consecutive uses automatically stop using page faults and retain exact validation. Timing output
+reports `watch_reuse`, `watch_dirty`, `watch_unknown`, `watch_disabled`, registration/fault counts, and the
+remaining exact validation bytes. Set `PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH=1` for an exact-only A/B,
+or `PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH=1` to perform the exact comparison behind every proposed
+cross-submit shortcut and log any disagreement. `PROSPER_WRITE_WATCH_LOG=1` prints capped registration failure
+details. Non-Windows builds keep exact cross-submit validation. For the same-submit A/B control, set
+`PROSPER_NO_SUBMIT_TEXTURE_VALIDATION_REUSE=1`. Set
 `PROSPER_AUDIT_SUBMIT_TEXTURE_VALIDATION_REUSE=1` to keep every comparison while checking and logging any
 disagreement with the journal's unchanged decision; use that audit before extending writer coverage.
 The instrumentation does not take clock samples when the variable is unset. This is the first tool

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -471,6 +471,38 @@ resource-ownership scheduling rather than reordering by operation type.
 - Reordering compute and graphics by type is not valid. The corrected capture graph proves real
   producer/consumer edges in the representative frame.
 
+## Windows cross-submit texture write watch
+
+Windows direct memory is backed by shared sections, so `MEM_WRITE_WATCH` cannot observe writes through its
+aliases. The renderer now registers the physical 4 KiB pages behind an eligible cached texture, finds every
+writable virtual alias known to the HLE memory layer, and temporarily makes those aliases read-only. The
+existing vectored exception handler consumes the first write fault, marks the physical page generation dirty,
+and restores the original protection on every alias. Temporary host aliases used to zero recycled direct
+memory report their physical write explicitly. Mapping and protection changes invalidate affected watches.
+
+The shortcut is deliberately proof-based. A complete armed registration may return unchanged; a fault,
+incomplete mapping, protection failure, topology change, unsupported platform, or host notification falls back
+to the exact comparison. `PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH=1` retains that comparison behind
+unchanged decisions. More than 10,000 audited decisions in the Dead Cells full-render loading route produced
+zero disagreements. A focused Windows test maps one section through two aliases and proves that writes through
+either alias, a host physical write, and an alias removal are all observed. Non-Windows builds use the exact
+path unchanged.
+
+The first live implementation exposed a separate performance trap: two textures are rewritten through nearly
+every watched page on every post-parse submit, even when some writes reproduce identical bytes. Re-arming them
+generated about 490,000 handled faults in 180 seconds. The final policy disables page protection after two
+consecutive dirty observations and preserves that decision when changed content replaces the cache entry;
+exact comparison remains authoritative for those dynamic resources. In the final 144-second run, registrations
+stopped at 26 and faults plateaued at 17,821 after the workload transition instead of growing every submit.
+
+The stable four-span window reduced exact validation from roughly 145 MiB per submit after the same-submit
+journal to 3.3 MiB per submit. Post-transition process memory remained bounded at 1.60-1.68 GiB private and
+3.62-3.68 GiB working set. The run still remained on the Prisoners' Quarters loading screen, so this result is
+a renderer performance/correctness improvement, not evidence that the separate progression stall is fixed.
+With persistent pipelines and write-aware validation in place, the measured heavy path is now dominated by
+resource construction plus roughly ten synchronous Vulkan target calls, fence waits, and readbacks per guest
+submit. That boundary/lifetime architecture is the next performance target.
+
 ## Separate unresolved risk
 
 Native Windows boot can still intermittently stop after exactly 75 submits while asset loading and

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -11,6 +11,7 @@
 #include "gpu/shader_resources.hpp"     // ShaderResourceTable / ResourceClass
 #include "gpu/rdna2_to_spirv.hpp"       // recompile_fragment (diagnostic solid-color PS)
 #include "gpu/videoout_present.hpp"     // present_front_index (flip-anchored present selection)
+#include "host/guest_write_watch.hpp"
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
 
 #include <atomic>
@@ -102,6 +103,9 @@ struct PersistentDecodedTexture {
     uint64_t last_use = 0;
     uint64_t persistent_id = 0;
     prosper::gpu::GuestGpuWriteSnapshot validation_snapshot;
+    prosper::host::GuestWriteWatch source_watch;
+    uint32_t source_watch_dirty_count = 0;
+    bool source_watch_disabled = false;
 
     size_t bytes() const { return source_prefix.size() + pixels.size(); }
 };
@@ -230,6 +234,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                 uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
                 uint64_t persistent_validation_bytes = 0;
+                uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
+                uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
                 uint64_t texture_bytes = 0, buffer_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
             };
@@ -531,24 +537,67 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         cached->second.validation_snapshot, r.gpu_addr,
                                         persistent_source_size) ==
                                         prosper::gpu::GuestGpuWriteQuery::Unchanged;
+                                static const bool cross_submit_watch_enabled =
+                                    !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
+                                static const bool audit_cross_submit_watch =
+                                    getenv("PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH") != nullptr;
+                                prosper::host::GuestWriteWatchQuery watch_query =
+                                    prosper::host::GuestWriteWatchQuery::Unknown;
+                                if (!submit_unchanged && cross_submit_watch_enabled &&
+                                    !cached->second.source_watch_disabled) {
+                                    watch_query = cached->second.source_watch.query();
+                                    if (timing_enabled) {
+                                        if (watch_query == prosper::host::GuestWriteWatchQuery::Dirty)
+                                            pending_timing.persistent_watch_dirty++;
+                                        else if (watch_query == prosper::host::GuestWriteWatchQuery::Unknown)
+                                            pending_timing.persistent_watch_unknown++;
+                                    }
+                                    if (watch_query == prosper::host::GuestWriteWatchQuery::Dirty &&
+                                        ++cached->second.source_watch_dirty_count >= 2) {
+                                        cached->second.source_watch.reset();
+                                        cached->second.source_watch_disabled = true;
+                                        if (timing_enabled)
+                                            pending_timing.persistent_watch_disabled++;
+                                    } else if (watch_query ==
+                                               prosper::host::GuestWriteWatchQuery::Unchanged) {
+                                        cached->second.source_watch_dirty_count = 0;
+                                    }
+                                }
+                                const bool watch_unchanged = !submit_unchanged &&
+                                    watch_query == prosper::host::GuestWriteWatchQuery::Unchanged;
                                 bool content_matches = false;
-                                if (submit_unchanged) {
-                                    content_matches = audit_submit_reuse ? validate_exact() : true;
+                                if (submit_unchanged || watch_unchanged) {
+                                    const bool audit = submit_unchanged
+                                        ? audit_submit_reuse : audit_cross_submit_watch;
+                                    content_matches = audit ? validate_exact() : true;
                                     if (!content_matches) {
                                         fprintf(stderr,
-                                                "[render] in-submit texture validation audit failed "
+                                                "[render] %s texture validation audit failed "
                                                 "addr=0x%llx bytes=%zu\n",
+                                                submit_unchanged ? "in-submit" : "cross-submit-watch",
                                                 (unsigned long long)r.gpu_addr,
                                                 persistent_source_size);
                                     } else {
-                                        resource_persistent_submit_reuse = true;
-                                        if (timing_enabled)
-                                            pending_timing.persistent_submit_reuses++;
+                                        if (submit_unchanged) {
+                                            resource_persistent_submit_reuse = true;
+                                            if (timing_enabled)
+                                                pending_timing.persistent_submit_reuses++;
+                                        } else if (timing_enabled) {
+                                            pending_timing.persistent_watch_reuses++;
+                                        }
                                     }
                                 } else {
                                     content_matches = validate_exact();
                                 }
                                 if (content_matches) {
+                                    if (!submit_unchanged && cross_submit_watch_enabled &&
+                                        !cached->second.source_watch_disabled &&
+                                        watch_query != prosper::host::GuestWriteWatchQuery::Unchanged) {
+                                        if (!cached->second.source_watch.rearm())
+                                            cached->second.source_watch =
+                                                prosper::host::GuestWriteWatch::create(
+                                                    r.gpu_addr, persistent_source_size);
+                                    }
                                     cached->second.last_use = decode_generation;
                                     cached->second.validation_snapshot =
                                         prosper::gpu::guest_gpu_write_snapshot();
@@ -1039,6 +1088,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     persistent_source_size);
                             }
                             auto old = persistent_decoded_textures.find(decode_key);
+                            uint32_t inherited_watch_dirty_count = 0;
+                            bool inherited_watch_disabled = false;
+                            if (old != persistent_decoded_textures.end()) {
+                                inherited_watch_dirty_count = old->second.source_watch_dirty_count;
+                                inherited_watch_disabled = old->second.source_watch_disabled;
+                            }
                             const bool can_replace = old == persistent_decoded_textures.end() ||
                                 old->second.last_use != decode_generation;
                             if (old != persistent_decoded_textures.end() && can_replace) {
@@ -1084,6 +1139,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     cached.persistent_id = ++persistent_texture_id;
                                 cached.validation_snapshot =
                                     prosper::gpu::guest_gpu_write_snapshot();
+                                cached.source_watch_dirty_count = inherited_watch_dirty_count;
+                                cached.source_watch_disabled = inherited_watch_disabled;
+                                if (!cached.source_watch_disabled &&
+                                    !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH"))
+                                    cached.source_watch = prosper::host::GuestWriteWatch::create(
+                                        r.gpu_addr, persistent_source_size);
                                 auto [inserted, ok] = persistent_decoded_textures.emplace(
                                     decode_key, std::move(cached));
                                 if (ok) {
@@ -1730,6 +1791,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                     uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
                     uint64_t persistent_validation_bytes = 0;
+                    uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
+                    uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
                     uint64_t texture_bytes = 0, buffer_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                 };
@@ -1768,6 +1831,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.persistent_submit_reuses += pending_timing.persistent_submit_reuses;
                     timing.persistent_validations += pending_timing.persistent_validations;
                     timing.persistent_validation_bytes += pending_timing.persistent_validation_bytes;
+                    timing.persistent_watch_reuses += pending_timing.persistent_watch_reuses;
+                    timing.persistent_watch_dirty += pending_timing.persistent_watch_dirty;
+                    timing.persistent_watch_unknown += pending_timing.persistent_watch_unknown;
+                    timing.persistent_watch_disabled += pending_timing.persistent_watch_disabled;
                     timing.buffers += pending_timing.buffers;
                     timing.texture_bytes += pending_timing.texture_bytes;
                     timing.buffer_bytes += pending_timing.buffer_bytes;
@@ -1826,10 +1893,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.buffer_bytes / (1024.0 * 1024.0), totals.buffer_ms / nsub);
                     fprintf(stderr,
                             "[render-timing] texture_cache hits=%llu submit_reuse=%llu misses=%llu "
-                            "invalid=%llu validations=%llu %.1f GiB entries=%zu %.1f MiB\n",
+                            "watch_reuse=%llu watch_dirty=%llu watch_unknown=%llu watch_disabled=%llu "
+                            "invalid=%llu "
+                            "validations=%llu %.1f GiB entries=%zu %.1f MiB\n",
                             (unsigned long long)totals.persistent_hits,
                             (unsigned long long)totals.persistent_submit_reuses,
                             (unsigned long long)totals.persistent_misses,
+                            (unsigned long long)totals.persistent_watch_reuses,
+                            (unsigned long long)totals.persistent_watch_dirty,
+                            (unsigned long long)totals.persistent_watch_unknown,
+                            (unsigned long long)totals.persistent_watch_disabled,
                             (unsigned long long)totals.persistent_invalidations,
                             (unsigned long long)totals.persistent_validations,
                             totals.persistent_validation_bytes / (1024.0 * 1024.0 * 1024.0),
@@ -1849,6 +1922,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             g_rtt.size(), rtt_bytes / (1024.0 * 1024.0),
                             texstore.size(), scratch_bytes / (1024.0 * 1024.0),
                             persistent_validation_scratch.capacity() / (1024.0 * 1024.0));
+                    const auto write_watch = prosper::host::guest_write_watch_stats();
+                    fprintf(stderr,
+                            "[render-timing] write_watch create=%llu ok=%llu pages=%llu no_map=%llu "
+                            "alias=%llu protect=%llu query=%llu unchanged=%llu dirty=%llu "
+                            "unknown=%llu faults=%llu physical=%llu rearms=%llu\n",
+                            (unsigned long long)write_watch.create_attempts,
+                            (unsigned long long)write_watch.registrations,
+                            (unsigned long long)write_watch.registered_pages,
+                            (unsigned long long)write_watch.create_no_mapping,
+                            (unsigned long long)write_watch.create_incomplete_aliases,
+                            (unsigned long long)write_watch.create_protect_failures,
+                            (unsigned long long)write_watch.queries,
+                            (unsigned long long)write_watch.unchanged,
+                            (unsigned long long)write_watch.dirty,
+                            (unsigned long long)write_watch.unknown,
+                            (unsigned long long)write_watch.faults,
+                            (unsigned long long)write_watch.physical_writes,
+                            (unsigned long long)write_watch.rearms);
                     const double wn = static_cast<double>(window.submits);
                     const double window_other = window.total_ms - window.build_resources_ms -
                                                 window.backend_ms - window.output_copy_ms;
@@ -1897,9 +1988,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.backend_pipeline_evictions / wn);
                     fprintf(stderr,
                             "[render-window] texture_cache hits=%.1f submit_reuse=%.1f misses=%.1f "
-                            "invalid=%.1f validations=%.1f %.1f MiB\n",
+                            "watch_reuse=%.1f watch_dirty=%.1f watch_unknown=%.1f watch_disabled=%.1f "
+                            "invalid=%.1f "
+                            "validations=%.1f %.1f MiB\n",
                             window.persistent_hits / wn, window.persistent_submit_reuses / wn,
-                            window.persistent_misses / wn, window.persistent_invalidations / wn,
+                            window.persistent_misses / wn, window.persistent_watch_reuses / wn,
+                            window.persistent_watch_dirty / wn, window.persistent_watch_unknown / wn,
+                            window.persistent_watch_disabled / wn,
+                            window.persistent_invalidations / wn,
                             window.persistent_validations / wn,
                             window.persistent_validation_bytes / (wn * 1024.0 * 1024.0));
                     window = {};

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -491,6 +491,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 ? prosper::gpu::tiled_surface_bytes(
                                       tw, th, r.tile_mode, persistent_pitch)
                                 : 0);
+                        static const bool cross_submit_watch_enabled =
+                            !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
+                        static const bool audit_cross_submit_watch =
+                            getenv("PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH") != nullptr;
+                        prosper::host::GuestWriteWatch pending_source_watch;
                         bool narrow_done = false;
                         auto reused = has_live_rtt ? decoded_textures.end()
                                                    : decoded_textures.find(decode_key);
@@ -537,10 +542,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         cached->second.validation_snapshot, r.gpu_addr,
                                         persistent_source_size) ==
                                         prosper::gpu::GuestGpuWriteQuery::Unchanged;
-                                static const bool cross_submit_watch_enabled =
-                                    !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
-                                static const bool audit_cross_submit_watch =
-                                    getenv("PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH") != nullptr;
                                 prosper::host::GuestWriteWatchQuery watch_query =
                                     prosper::host::GuestWriteWatchQuery::Unknown;
                                 if (!submit_unchanged && cross_submit_watch_enabled &&
@@ -565,6 +566,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                                 const bool watch_unchanged = !submit_unchanged &&
                                     watch_query == prosper::host::GuestWriteWatchQuery::Unchanged;
+                                if (!submit_unchanged && !watch_unchanged &&
+                                    cross_submit_watch_enabled &&
+                                    !cached->second.source_watch_disabled) {
+                                    // Arm before reading. A concurrent CPU write during or after the
+                                    // authoritative comparison then dirties this registration instead of
+                                    // landing in an unprotected compare-to-rearm window.
+                                    if (!cached->second.source_watch.rearm())
+                                        cached->second.source_watch =
+                                            prosper::host::GuestWriteWatch::create(
+                                                r.gpu_addr, persistent_source_size);
+                                }
                                 bool content_matches = false;
                                 if (submit_unchanged || watch_unchanged) {
                                     const bool audit = submit_unchanged
@@ -590,14 +602,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     content_matches = validate_exact();
                                 }
                                 if (content_matches) {
-                                    if (!submit_unchanged && cross_submit_watch_enabled &&
-                                        !cached->second.source_watch_disabled &&
-                                        watch_query != prosper::host::GuestWriteWatchQuery::Unchanged) {
-                                        if (!cached->second.source_watch.rearm())
-                                            cached->second.source_watch =
-                                                prosper::host::GuestWriteWatch::create(
-                                                    r.gpu_addr, persistent_source_size);
-                                    }
                                     cached->second.last_use = decode_generation;
                                     cached->second.validation_snapshot =
                                         prosper::gpu::guest_gpu_write_snapshot();
@@ -612,9 +616,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     resource_persistent_invalidation = true;
                                     pending_timing.persistent_invalidations++;
                                 }
-                            } else if (timing_enabled) {
-                                resource_persistent_miss = true;
-                                pending_timing.persistent_misses++;
+                            } else {
+                                // Establish the mutation boundary before the initial source read/decode.
+                                // If registration is unsupported, the empty watch keeps all later reuse on
+                                // the exact fallback.
+                                if (cross_submit_watch_enabled)
+                                    pending_source_watch = prosper::host::GuestWriteWatch::create(
+                                        r.gpu_addr, persistent_source_size);
+                                if (timing_enabled) {
+                                    resource_persistent_miss = true;
+                                    pending_timing.persistent_misses++;
+                                }
                             }
                         }
                         if (decoded_reuse) {
@@ -1090,9 +1102,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             auto old = persistent_decoded_textures.find(decode_key);
                             uint32_t inherited_watch_dirty_count = 0;
                             bool inherited_watch_disabled = false;
-                            if (old != persistent_decoded_textures.end()) {
+                            prosper::host::GuestWriteWatch inherited_source_watch =
+                                std::move(pending_source_watch);
+                            if (old != persistent_decoded_textures.end() &&
+                                old->second.source_size == persistent_source_size) {
                                 inherited_watch_dirty_count = old->second.source_watch_dirty_count;
                                 inherited_watch_disabled = old->second.source_watch_disabled;
+                                if (!inherited_watch_disabled)
+                                    inherited_source_watch = std::move(old->second.source_watch);
                             }
                             const bool can_replace = old == persistent_decoded_textures.end() ||
                                 old->second.last_use != decode_generation;
@@ -1141,10 +1158,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     prosper::gpu::guest_gpu_write_snapshot();
                                 cached.source_watch_dirty_count = inherited_watch_dirty_count;
                                 cached.source_watch_disabled = inherited_watch_disabled;
-                                if (!cached.source_watch_disabled &&
-                                    !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH"))
-                                    cached.source_watch = prosper::host::GuestWriteWatch::create(
-                                        r.gpu_addr, persistent_source_size);
+                                cached.source_watch = std::move(inherited_source_watch);
                                 auto [inserted, ok] = persistent_decoded_textures.emplace(
                                     decode_key, std::move(cached));
                                 if (ok) {

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -7,6 +7,7 @@
 #include "nid.hpp"
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
 #include "../host/guest_memory_map.hpp"
+#include "../host/guest_write_watch.hpp"
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "../host/posix_shim.hpp"
@@ -1472,6 +1473,8 @@ namespace {
             }
             g_dviews.push_back(std::move(tracked));
         }
+        host::guest_write_watch_notify_direct_mapping_added(
+            (uint64_t)(uintptr_t)guest, len, phys, win_page_prot(hp));
         if (sparse)
             MLOG("map_dmem sparse aligned view va=0x%llx len=0x%llx phys=0x%llx align=0x%llx\n",
                  (unsigned long long)(uintptr_t)guest, (unsigned long long)len,
@@ -1629,6 +1632,10 @@ namespace {
     // A released physical range can be allocated again while old virtual aliases still exist.
     // Zeroing the shared section at allocation time gives every alias the console's fresh-page view.
     void dmem_zero(uint64_t phys, uint64_t len) {
+        // A temporary physical-section alias bypasses protections installed on persistent guest
+        // aliases. Invalidate first so a recycled direct-memory allocation cannot retain a clean
+        // texture watch for bytes this zeroing operation is about to replace.
+        host::guest_write_watch_notify_physical_write(phys, len);
         HANDLE section = dmem_section();
         if (!section || !len || phys < kDmemBase || phys - kDmemBase > kDmemTotal ||
             len > kDmemTotal - (phys - kDmemBase)) return;
@@ -1690,9 +1697,18 @@ namespace {
     // first (succeeds only over an existing reservation) then MEM_RESERVE|MEM_COMMIT.
     void* win_commit(uint64_t hint, uint64_t len, int hp) {
         DWORD pp = win_page_prot(hp);
-        if (!hint) return VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
-        if (void* p = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_COMMIT, pp)) return p;
-        return VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
+        void* result = nullptr;
+        if (!hint) {
+            result = VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
+        } else {
+            result = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_COMMIT, pp);
+            if (!result)
+                result = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
+        }
+        if (result)
+            host::guest_write_watch_notify_direct_mapping_added(
+                (uint64_t)(uintptr_t)result, len, (uint64_t)(uintptr_t)result, pp);
+        return result;
     }
     void* win_map_phys(uint64_t hint, uint64_t len, int hp, uint64_t phys, uint64_t align,
                        bool fixed) {
@@ -1729,27 +1745,42 @@ namespace {
         return (void*)(((uint64_t)raw + (align - 1)) & ~(align - 1));
     }
     bool win_protect(uint64_t addr, uint64_t len, int hp) {
+        // Update the alias registry before changing the OS protection so an overlapping watch first
+        // restores its old writable pages. Unrelated mappings leave existing watches armed.
+        host::guest_write_watch_notify_direct_mapping_protection(
+            addr, len, win_page_prot(hp));
         if (len && addr <= UINT64_MAX - len && sparse_dmem_view_overlaps(addr, addr + len)) {
             const uint64_t end = addr + len;
             uint64_t cursor = addr;
             while (cursor < end) {
                 MEMORY_BASIC_INFORMATION mbi{};
-                if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
+                if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) {
+                    host::guest_write_watch_notify_direct_mapping_removed(addr, len);
+                    return false;
+                }
                 const uint64_t region_end = std::min<uint64_t>(
                     end, (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize);
-                if (region_end <= cursor || mbi.State == MEM_FREE) return false;
+                if (region_end <= cursor || mbi.State == MEM_FREE) {
+                    host::guest_write_watch_notify_direct_mapping_removed(addr, len);
+                    return false;
+                }
                 if (mbi.State == MEM_COMMIT) {
                     DWORD old = 0;
                     if (!VirtualProtect((void*)(uintptr_t)cursor,
                                         (SIZE_T)(region_end - cursor),
-                                        win_page_prot(hp), &old)) return false;
+                                        win_page_prot(hp), &old)) {
+                        host::guest_write_watch_notify_direct_mapping_removed(addr, len);
+                        return false;
+                    }
                 }
                 cursor = region_end;
             }
             return true;
         }
         DWORD old = 0;
-        return VirtualProtect((void*)addr, (SIZE_T)len, win_page_prot(hp), &old) != 0;
+        const bool ok = VirtualProtect((void*)addr, (SIZE_T)len, win_page_prot(hp), &old) != 0;
+        if (!ok) host::guest_write_watch_notify_direct_mapping_removed(addr, len);
+        return ok;
     }
     // Shared section views must be released with UnmapViewOfFile. Anonymous/private mappings keep
     // the old partial-safe decommit behavior.
@@ -1767,9 +1798,11 @@ namespace {
             }
         }
         if (section_view) {
+            host::guest_write_watch_notify_direct_mapping_removed(addr, len);
             UnmapViewOfFile(section_view);
             return;
         }
+        host::guest_write_watch_notify_direct_mapping_removed(addr, len);
         VirtualFree((void*)addr, (SIZE_T)len, MEM_DECOMMIT);
     }
 } // namespace

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -13,6 +13,7 @@
 #ifdef _WIN32
 
 #include "exec_image.hpp"
+#include "guest_write_watch.hpp"
 #include "sse4a.hpp"
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
@@ -283,6 +284,9 @@ namespace {
         if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2 &&
             ep->ExceptionRecord->ExceptionInformation[0] != 8) {
             uint64_t a = (uint64_t)ep->ExceptionRecord->ExceptionInformation[1];
+            if (ep->ExceptionRecord->ExceptionInformation[0] == 1 &&
+                host::guest_write_watch_handle_fault(a))
+                return EXCEPTION_CONTINUE_EXECUTION;
             if (a >= 0x1000000000ull &&
                 prosper_try_commit_dmem(
                     a, 1, ep->ExceptionRecord->ExceptionInformation[0] == 1))

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -1,0 +1,529 @@
+#include "guest_write_watch.hpp"
+
+#include <atomic>
+#include <utility>
+
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace prosper::host {
+namespace {
+
+constexpr uint64_t kPageSize = 0x1000;
+
+struct AliasRange {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    uint64_t phys = 0;
+    DWORD protection = 0;
+};
+
+struct PageAlias {
+    uint64_t addr = 0;
+    DWORD protection = 0;
+};
+
+struct WatchedPage {
+    uint64_t phys = 0;
+    uint64_t generation = 0;
+    uint32_t references = 0;
+    bool armed = false;
+    std::vector<PageAlias> aliases;
+};
+
+struct RegistrationPage {
+    WatchedPage* page = nullptr;
+    uint64_t generation = 0;
+};
+
+struct Registration {
+    std::vector<RegistrationPage> pages;
+};
+
+struct WatchState {
+    std::mutex mutex;
+    uint64_t next_id = 0;
+    std::vector<AliasRange> aliases;
+    std::unordered_map<uint64_t, std::unique_ptr<WatchedPage>> pages_by_phys;
+    std::unordered_map<uint64_t, WatchedPage*> pages_by_addr;
+    std::unordered_map<uint64_t, Registration> registrations;
+};
+
+WatchState& state() {
+    // Watches can outlive other translation-unit statics during process teardown.
+    static WatchState* value = new WatchState;
+    return *value;
+}
+
+struct AtomicStats {
+    std::atomic<uint64_t> create_attempts{0};
+    std::atomic<uint64_t> registrations{0};
+    std::atomic<uint64_t> registered_pages{0};
+    std::atomic<uint64_t> create_no_mapping{0};
+    std::atomic<uint64_t> create_incomplete_aliases{0};
+    std::atomic<uint64_t> create_protect_failures{0};
+    std::atomic<uint64_t> queries{0};
+    std::atomic<uint64_t> unchanged{0};
+    std::atomic<uint64_t> dirty{0};
+    std::atomic<uint64_t> unknown{0};
+    std::atomic<uint64_t> faults{0};
+    std::atomic<uint64_t> physical_writes{0};
+    std::atomic<uint64_t> rearms{0};
+};
+
+AtomicStats& stats() {
+    static AtomicStats value;
+    return value;
+}
+
+void log_create_failure(const char* reason, uint64_t addr, uint64_t size, uint64_t page) {
+    if (!std::getenv("PROSPER_WRITE_WATCH_LOG")) return;
+    static std::atomic<uint32_t> count{0};
+    if (count.fetch_add(1, std::memory_order_relaxed) >= 128) return;
+    std::fprintf(stderr,
+                 "[write-watch] create failed reason=%s addr=0x%llx bytes=0x%llx page=0x%llx\n",
+                 reason, (unsigned long long)addr, (unsigned long long)size,
+                 (unsigned long long)page);
+}
+
+bool writable_protection(DWORD protection) {
+    const DWORD base = protection & 0xffu;
+    return base == PAGE_READWRITE || base == PAGE_WRITECOPY ||
+           base == PAGE_EXECUTE_READWRITE || base == PAGE_EXECUTE_WRITECOPY;
+}
+
+DWORD read_only_protection(DWORD protection) {
+    const DWORD base = protection & 0xffu;
+    if (base == PAGE_EXECUTE || base == PAGE_EXECUTE_READ ||
+        base == PAGE_EXECUTE_READWRITE || base == PAGE_EXECUTE_WRITECOPY)
+        return PAGE_EXECUTE_READ;
+    return PAGE_READONLY;
+}
+
+bool restore_page(WatchedPage& page) {
+    bool ok = true;
+    for (const PageAlias& alias : page.aliases) {
+        DWORD ignored = 0;
+        if (!VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(alias.addr)),
+                            kPageSize, alias.protection, &ignored))
+            ok = false;
+    }
+    page.armed = false;
+    return ok;
+}
+
+struct ProtectionRun {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    DWORD from = 0;
+    DWORD to = 0;
+};
+
+std::vector<ProtectionRun> protection_runs(const std::vector<WatchedPage*>& pages,
+                                           bool arm) {
+    std::vector<ProtectionRun> runs;
+    for (WatchedPage* page : pages) {
+        if (!page || page->armed != !arm) continue;
+        for (const PageAlias& alias : page->aliases) {
+            if (!writable_protection(alias.protection)) continue;
+            runs.push_back({alias.addr, kPageSize,
+                            arm ? alias.protection : read_only_protection(alias.protection),
+                            arm ? read_only_protection(alias.protection) : alias.protection});
+        }
+    }
+    std::sort(runs.begin(), runs.end(), [](const ProtectionRun& a, const ProtectionRun& b) {
+        if (a.from != b.from) return a.from < b.from;
+        if (a.to != b.to) return a.to < b.to;
+        return a.addr < b.addr;
+    });
+    std::vector<ProtectionRun> merged;
+    merged.reserve(runs.size());
+    for (const ProtectionRun& run : runs) {
+        if (!merged.empty() && merged.back().from == run.from && merged.back().to == run.to &&
+            merged.back().addr + merged.back().size == run.addr) {
+            merged.back().size += run.size;
+        } else {
+            merged.push_back(run);
+        }
+    }
+    return merged;
+}
+
+bool set_pages_armed(const std::vector<WatchedPage*>& pages, bool armed) {
+    std::vector<ProtectionRun> runs = protection_runs(pages, armed);
+    size_t changed = 0;
+    for (const ProtectionRun& run : runs) {
+        DWORD ignored = 0;
+        if (!VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(run.addr)),
+                            static_cast<SIZE_T>(run.size), run.to, &ignored)) {
+            while (changed) {
+                const ProtectionRun& prior = runs[--changed];
+                VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(prior.addr)),
+                               static_cast<SIZE_T>(prior.size), prior.from, &ignored);
+            }
+            return false;
+        }
+        ++changed;
+    }
+    for (WatchedPage* page : pages)
+        if (page && page->armed == !armed) page->armed = armed;
+    return true;
+}
+
+void clear_locked(WatchState& watch) {
+    std::vector<WatchedPage*> pages;
+    pages.reserve(watch.pages_by_phys.size());
+    for (auto& [phys, page] : watch.pages_by_phys) {
+        (void)phys;
+        pages.push_back(page.get());
+    }
+    set_pages_armed(pages, false);
+    watch.registrations.clear();
+    watch.pages_by_addr.clear();
+    watch.pages_by_phys.clear();
+}
+
+bool watched_phys_overlaps(const WatchState& watch, uint64_t begin, uint64_t end) {
+    for (const auto& [phys, page] : watch.pages_by_phys) {
+        (void)page;
+        if (phys < end && phys + kPageSize > begin) return true;
+    }
+    return false;
+}
+
+bool watched_addr_overlaps(const WatchState& watch, uint64_t begin, uint64_t end) {
+    for (const auto& [addr, page] : watch.pages_by_addr) {
+        (void)page;
+        if (addr < end && addr + kPageSize > begin) return true;
+    }
+    return false;
+}
+
+const AliasRange* alias_at(const WatchState& watch, uint64_t addr) {
+    for (const AliasRange& alias : watch.aliases)
+        if (addr >= alias.addr && addr < alias.addr + alias.size) return &alias;
+    return nullptr;
+}
+
+bool collect_aliases(const WatchState& watch, uint64_t phys, std::vector<PageAlias>& out) {
+    for (const AliasRange& alias : watch.aliases) {
+        if (phys < alias.phys || phys + kPageSize > alias.phys + alias.size) continue;
+        const uint64_t addr = alias.addr + (phys - alias.phys);
+        if (alias.protection & (PAGE_GUARD | PAGE_NOACCESS))
+            return false;
+        out.push_back({addr, alias.protection});
+    }
+    return !out.empty();
+}
+
+void release_registration_locked(WatchState& watch,
+                                 std::unordered_map<uint64_t, Registration>::iterator reg) {
+    std::vector<WatchedPage*> released;
+    for (const RegistrationPage& registered : reg->second.pages) {
+        WatchedPage* page = registered.page;
+        if (!page || !page->references) continue;
+        if (--page->references) continue;
+        released.push_back(page);
+    }
+    set_pages_armed(released, false);
+    for (WatchedPage* page : released) {
+        for (const PageAlias& alias : page->aliases) watch.pages_by_addr.erase(alias.addr);
+        watch.pages_by_phys.erase(page->phys);
+    }
+    watch.registrations.erase(reg);
+}
+
+} // namespace
+
+GuestWriteWatch::~GuestWriteWatch() { reset(); }
+
+GuestWriteWatch::GuestWriteWatch(GuestWriteWatch&& other) noexcept
+    : id_(std::exchange(other.id_, 0)) {}
+
+GuestWriteWatch& GuestWriteWatch::operator=(GuestWriteWatch&& other) noexcept {
+    if (this != &other) {
+        reset();
+        id_ = std::exchange(other.id_, 0);
+    }
+    return *this;
+}
+
+GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
+    stats().create_attempts.fetch_add(1, std::memory_order_relaxed);
+    if (!addr || !size || addr > UINT64_MAX - size) return {};
+    const uint64_t begin = addr & ~(kPageSize - 1);
+    const uint64_t range_end = addr + size;
+    if (range_end > UINT64_MAX - (kPageSize - 1)) return {};
+    const uint64_t end = (range_end + kPageSize - 1) & ~(kPageSize - 1);
+    if (end <= begin) return {};
+
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+
+    Registration registration;
+    registration.pages.reserve(static_cast<size_t>((end - begin) / kPageSize));
+    auto rollback = [&] {
+        for (auto it = registration.pages.rbegin(); it != registration.pages.rend(); ++it) {
+            WatchedPage* page = it->page;
+            if (!page || !page->references || --page->references) continue;
+            if (page->armed) restore_page(*page);
+            for (const PageAlias& alias : page->aliases) watch.pages_by_addr.erase(alias.addr);
+            watch.pages_by_phys.erase(page->phys);
+        }
+        registration.pages.clear();
+    };
+    for (uint64_t page_addr = begin; page_addr < end; page_addr += kPageSize) {
+        const AliasRange* source = alias_at(watch, page_addr);
+        if (!source) {
+            stats().create_no_mapping.fetch_add(1, std::memory_order_relaxed);
+            log_create_failure("no-mapping", addr, size, page_addr);
+            rollback();
+            return {};
+        }
+        const uint64_t phys = source->phys + (page_addr - source->addr);
+        auto found = watch.pages_by_phys.find(phys);
+        WatchedPage* page = found == watch.pages_by_phys.end() ? nullptr : found->second.get();
+        if (!page) {
+            auto owned = std::make_unique<WatchedPage>();
+            owned->phys = phys;
+            if (!collect_aliases(watch, phys, owned->aliases)) {
+                stats().create_incomplete_aliases.fetch_add(1, std::memory_order_relaxed);
+                log_create_failure("incomplete-aliases", addr, size, page_addr);
+                rollback();
+                return {};
+            }
+            const bool source_alias_present = std::any_of(
+                owned->aliases.begin(), owned->aliases.end(),
+                [&](const PageAlias& alias) { return alias.addr == page_addr; });
+            if (!source_alias_present) {
+                stats().create_incomplete_aliases.fetch_add(1, std::memory_order_relaxed);
+                log_create_failure("source-alias-missing", addr, size, page_addr);
+                rollback();
+                return {};
+            }
+            page = owned.get();
+            watch.pages_by_phys.emplace(phys, std::move(owned));
+            for (const PageAlias& alias : page->aliases)
+                watch.pages_by_addr[alias.addr] = page;
+        }
+        ++page->references;
+        registration.pages.push_back({page, page->generation});
+    }
+
+    std::vector<WatchedPage*> pages;
+    pages.reserve(registration.pages.size());
+    for (const RegistrationPage& registered : registration.pages)
+        pages.push_back(registered.page);
+    if (!set_pages_armed(pages, true)) {
+        stats().create_protect_failures.fetch_add(1, std::memory_order_relaxed);
+        log_create_failure("protect", addr, size, begin);
+        rollback();
+        return {};
+    }
+
+    uint64_t id = ++watch.next_id;
+    if (!id) id = ++watch.next_id;
+    watch.registrations.emplace(id, std::move(registration));
+    stats().registrations.fetch_add(1, std::memory_order_relaxed);
+    stats().registered_pages.fetch_add((end - begin) / kPageSize, std::memory_order_relaxed);
+    return GuestWriteWatch(id);
+}
+
+GuestWriteWatchQuery GuestWriteWatch::query() const {
+    stats().queries.fetch_add(1, std::memory_order_relaxed);
+    if (!id_) {
+        stats().unknown.fetch_add(1, std::memory_order_relaxed);
+        return GuestWriteWatchQuery::Unknown;
+    }
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    auto found = watch.registrations.find(id_);
+    if (found == watch.registrations.end()) {
+        stats().unknown.fetch_add(1, std::memory_order_relaxed);
+        return GuestWriteWatchQuery::Unknown;
+    }
+    for (const RegistrationPage& registered : found->second.pages) {
+        if (!registered.page || !registered.page->armed ||
+            registered.page->generation != registered.generation) {
+            stats().dirty.fetch_add(1, std::memory_order_relaxed);
+            return GuestWriteWatchQuery::Dirty;
+        }
+    }
+    stats().unchanged.fetch_add(1, std::memory_order_relaxed);
+    return GuestWriteWatchQuery::Unchanged;
+}
+
+bool GuestWriteWatch::rearm() {
+    if (!id_) return false;
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    auto found = watch.registrations.find(id_);
+    if (found == watch.registrations.end()) return false;
+    std::vector<WatchedPage*> pages;
+    pages.reserve(found->second.pages.size());
+    for (const RegistrationPage& registered : found->second.pages)
+        pages.push_back(registered.page);
+    if (!set_pages_armed(pages, true)) return false;
+    for (RegistrationPage& registered : found->second.pages) {
+        if (!registered.page) return false;
+        registered.generation = registered.page->generation;
+    }
+    stats().rearms.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+void GuestWriteWatch::reset() {
+    if (!id_) return;
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    auto found = watch.registrations.find(id_);
+    if (found != watch.registrations.end()) release_registration_locked(watch, found);
+    id_ = 0;
+}
+
+GuestWriteWatchStats guest_write_watch_stats() {
+    AtomicStats& value = stats();
+    return {
+        value.create_attempts.load(std::memory_order_relaxed),
+        value.registrations.load(std::memory_order_relaxed),
+        value.registered_pages.load(std::memory_order_relaxed),
+        value.create_no_mapping.load(std::memory_order_relaxed),
+        value.create_incomplete_aliases.load(std::memory_order_relaxed),
+        value.create_protect_failures.load(std::memory_order_relaxed),
+        value.queries.load(std::memory_order_relaxed),
+        value.unchanged.load(std::memory_order_relaxed),
+        value.dirty.load(std::memory_order_relaxed),
+        value.unknown.load(std::memory_order_relaxed),
+        value.faults.load(std::memory_order_relaxed),
+        value.physical_writes.load(std::memory_order_relaxed),
+        value.rearms.load(std::memory_order_relaxed),
+    };
+}
+
+void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size, uint64_t phys,
+                                                    uint32_t protection) {
+    if (!addr || !size || addr > UINT64_MAX - size || phys > UINT64_MAX - size) return;
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    if (watched_phys_overlaps(watch, phys, phys + size)) clear_locked(watch);
+    watch.aliases.push_back({addr, size, phys, static_cast<DWORD>(protection)});
+}
+
+void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
+                                                        uint32_t protection) {
+    if (!addr || !size || addr > UINT64_MAX - size) return;
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    const uint64_t end = addr + size;
+    if (watched_addr_overlaps(watch, addr, end)) clear_locked(watch);
+    std::vector<AliasRange> updated;
+    updated.reserve(watch.aliases.size() + 2);
+    for (const AliasRange& alias : watch.aliases) {
+        const uint64_t alias_end = alias.addr + alias.size;
+        if (end <= alias.addr || addr >= alias_end) {
+            updated.push_back(alias);
+            continue;
+        }
+        const uint64_t overlap_begin = std::max(addr, alias.addr);
+        const uint64_t overlap_end = std::min(end, alias_end);
+        if (alias.addr < overlap_begin)
+            updated.push_back({alias.addr, overlap_begin - alias.addr,
+                               alias.phys, alias.protection});
+        updated.push_back({overlap_begin, overlap_end - overlap_begin,
+                           alias.phys + (overlap_begin - alias.addr),
+                           static_cast<DWORD>(protection)});
+        if (overlap_end < alias_end)
+            updated.push_back({overlap_end, alias_end - overlap_end,
+                               alias.phys + (overlap_end - alias.addr), alias.protection});
+    }
+    watch.aliases.swap(updated);
+}
+
+void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size) {
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    const uint64_t end = addr <= UINT64_MAX - size ? addr + size : UINT64_MAX;
+    if (watched_addr_overlaps(watch, addr, end)) clear_locked(watch);
+    watch.aliases.erase(
+        std::remove_if(watch.aliases.begin(), watch.aliases.end(), [&](const AliasRange& alias) {
+            return addr < alias.addr + alias.size && end > alias.addr;
+        }),
+        watch.aliases.end());
+}
+
+void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
+    if (!size || phys > UINT64_MAX - size) return;
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    const uint64_t end = phys + size;
+    std::vector<WatchedPage*> dirty;
+    for (const auto& [page_phys, page] : watch.pages_by_phys) {
+        if (page_phys >= end || page_phys + kPageSize <= phys) continue;
+        ++page->generation;
+        dirty.push_back(page.get());
+    }
+    if (!dirty.empty()) {
+        set_pages_armed(dirty, false);
+        stats().physical_writes.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+void guest_write_watch_invalidate_all() {
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    clear_locked(watch);
+}
+
+bool guest_write_watch_handle_fault(uint64_t addr) {
+    WatchState& watch = state();
+    std::lock_guard lock(watch.mutex);
+    const uint64_t page_addr = addr & ~(kPageSize - 1);
+    auto found = watch.pages_by_addr.find(page_addr);
+    if (found == watch.pages_by_addr.end() || !found->second || !found->second->armed) return false;
+    WatchedPage& page = *found->second;
+    ++page.generation;
+    restore_page(page);
+    stats().faults.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+} // namespace prosper::host
+
+#else
+
+namespace prosper::host {
+
+GuestWriteWatch::~GuestWriteWatch() = default;
+GuestWriteWatch::GuestWriteWatch(GuestWriteWatch&& other) noexcept
+    : id_(std::exchange(other.id_, 0)) {}
+GuestWriteWatch& GuestWriteWatch::operator=(GuestWriteWatch&& other) noexcept {
+    if (this != &other) id_ = std::exchange(other.id_, 0);
+    return *this;
+}
+GuestWriteWatch GuestWriteWatch::create(uint64_t, uint64_t) { return {}; }
+GuestWriteWatchQuery GuestWriteWatch::query() const { return GuestWriteWatchQuery::Unknown; }
+bool GuestWriteWatch::rearm() { return false; }
+void GuestWriteWatch::reset() { id_ = 0; }
+GuestWriteWatchStats guest_write_watch_stats() { return {}; }
+void guest_write_watch_notify_direct_mapping_added(uint64_t, uint64_t, uint64_t, uint32_t) {}
+void guest_write_watch_notify_direct_mapping_removed(uint64_t, uint64_t) {}
+void guest_write_watch_notify_direct_mapping_protection(uint64_t, uint64_t, uint32_t) {}
+void guest_write_watch_notify_physical_write(uint64_t, uint64_t) {}
+void guest_write_watch_invalidate_all() {}
+bool guest_write_watch_handle_fault(uint64_t) { return false; }
+
+} // namespace prosper::host
+
+#endif

--- a/prosper/src/host/guest_write_watch.hpp
+++ b/prosper/src/host/guest_write_watch.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::host {
+
+enum class GuestWriteWatchQuery {
+    Unchanged,
+    Dirty,
+    Unknown,
+};
+
+struct GuestWriteWatchStats {
+    uint64_t create_attempts = 0;
+    uint64_t registrations = 0;
+    uint64_t registered_pages = 0;
+    uint64_t create_no_mapping = 0;
+    uint64_t create_incomplete_aliases = 0;
+    uint64_t create_protect_failures = 0;
+    uint64_t queries = 0;
+    uint64_t unchanged = 0;
+    uint64_t dirty = 0;
+    uint64_t unknown = 0;
+    uint64_t faults = 0;
+    uint64_t physical_writes = 0;
+    uint64_t rearms = 0;
+};
+
+// Windows direct memory is section-backed so MEM_WRITE_WATCH cannot observe it. This registration
+// instead makes every writable alias of the covered physical pages read-only. The process VEH marks
+// the page dirty and restores its original protection on the first write. Unsupported platforms,
+// incomplete aliases and mapping changes report Unknown so callers retain their exact byte-comparison
+// fallback. Private mappings are tracked with their virtual page as their unique physical identity.
+class GuestWriteWatch {
+public:
+    GuestWriteWatch() = default;
+    ~GuestWriteWatch();
+    GuestWriteWatch(const GuestWriteWatch&) = delete;
+    GuestWriteWatch& operator=(const GuestWriteWatch&) = delete;
+    GuestWriteWatch(GuestWriteWatch&& other) noexcept;
+    GuestWriteWatch& operator=(GuestWriteWatch&& other) noexcept;
+
+    static GuestWriteWatch create(uint64_t addr, uint64_t size);
+    explicit operator bool() const { return id_ != 0; }
+    GuestWriteWatchQuery query() const;
+    bool rearm();
+    void reset();
+
+private:
+    explicit GuestWriteWatch(uint64_t id) : id_(id) {}
+    uint64_t id_ = 0;
+};
+
+GuestWriteWatchStats guest_write_watch_stats();
+
+// Direct-memory mapping notifications. A topology/protection change invalidates existing watches;
+// their next query is Unknown and the exact path may establish a fresh complete registration.
+void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size, uint64_t phys,
+                                                    uint32_t protection);
+void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size);
+void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
+                                                        uint32_t protection);
+void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
+void guest_write_watch_invalidate_all();
+
+// Called first from the Windows vectored exception handler for write access violations.
+bool guest_write_watch_handle_fault(uint64_t addr);
+
+} // namespace prosper::host

--- a/prosper/tests/test_guest_write_watch.cpp
+++ b/prosper/tests/test_guest_write_watch.cpp
@@ -1,0 +1,101 @@
+#include "host/guest_write_watch.hpp"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <cstdint>
+#include <cstdio>
+
+using prosper::host::GuestWriteWatch;
+using prosper::host::GuestWriteWatchQuery;
+
+namespace {
+int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { std::fprintf(stderr, "FAIL: %s\n", msg); ++failures; } \
+} while (0)
+
+LONG CALLBACK watch_veh(EXCEPTION_POINTERS* exception) {
+    const EXCEPTION_RECORD* record = exception->ExceptionRecord;
+    if (record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
+        record->NumberParameters >= 2 && record->ExceptionInformation[0] == 1 &&
+        prosper::host::guest_write_watch_handle_fault(
+            static_cast<uint64_t>(record->ExceptionInformation[1])))
+        return EXCEPTION_CONTINUE_EXECUTION;
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+} // namespace
+
+int main() {
+    constexpr uint64_t kSize = 0x10000;
+    HANDLE section = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE | SEC_COMMIT,
+                                        0, static_cast<DWORD>(kSize), nullptr);
+    CHECK(section != nullptr, "paging-file section created");
+    if (!section) return 1;
+    auto* first = static_cast<uint8_t*>(MapViewOfFile(section, FILE_MAP_ALL_ACCESS, 0, 0, kSize));
+    auto* second = static_cast<uint8_t*>(MapViewOfFile(section, FILE_MAP_ALL_ACCESS, 0, 0, kSize));
+    CHECK(first && second, "two aliases mapped");
+    if (!first || !second) {
+        if (first) UnmapViewOfFile(first);
+        if (second) UnmapViewOfFile(second);
+        CloseHandle(section);
+        return 1;
+    }
+
+    void* handler = AddVectoredExceptionHandler(1, watch_veh);
+    CHECK(handler != nullptr, "test write-watch VEH installed");
+    constexpr uint64_t kPhys = 0x10000000;
+    prosper::host::guest_write_watch_notify_direct_mapping_added(
+        reinterpret_cast<uint64_t>(first), kSize, kPhys, PAGE_READWRITE);
+    prosper::host::guest_write_watch_notify_direct_mapping_added(
+        reinterpret_cast<uint64_t>(second), kSize, kPhys, PAGE_READWRITE);
+
+    first[0x180] = 0x11;
+    GuestWriteWatch watch = GuestWriteWatch::create(
+        reinterpret_cast<uint64_t>(first + 0x100), 0x2100);
+    CHECK(static_cast<bool>(watch), "section-backed range is watchable");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged,
+          "new registration starts unchanged");
+
+    second[0x180] = 0x22;
+    CHECK(first[0x180] == 0x22, "write through second alias updates first alias");
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
+          "write through any physical alias dirties the registration");
+    CHECK(watch.rearm(), "dirty registration rearms after exact validation");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged,
+          "rearmed registration has a fresh generation");
+
+    first[0x1180] = 0x33;
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
+          "write through the original alias dirties another covered page");
+    CHECK(watch.rearm(), "registration rearms before a host physical write");
+    prosper::host::guest_write_watch_notify_physical_write(kPhys + 0x1000, 0x1000);
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
+          "temporary physical-section writes dirty overlapping registrations");
+
+    prosper::host::guest_write_watch_notify_direct_mapping_removed(
+        reinterpret_cast<uint64_t>(second), kSize);
+    CHECK(watch.query() == GuestWriteWatchQuery::Unknown,
+          "alias topology changes invalidate existing registrations");
+    watch.reset();
+
+    first[0x180] = 0x44;
+    CHECK(second[0x180] == 0x44, "invalidation restores writable page protections");
+
+    prosper::host::guest_write_watch_notify_direct_mapping_removed(
+        reinterpret_cast<uint64_t>(first), kSize);
+    if (handler) RemoveVectoredExceptionHandler(handler);
+    UnmapViewOfFile(second);
+    UnmapViewOfFile(first);
+    CloseHandle(section);
+
+    const auto stats = prosper::host::guest_write_watch_stats();
+    CHECK(stats.faults >= 2, "write faults were handled");
+    CHECK(stats.rearms >= 1, "rearm was counted");
+    CHECK(stats.physical_writes >= 1, "physical write was counted");
+    if (failures) return 1;
+    std::puts("== PASS ==");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- track CPU writes to Windows guest direct-memory pages across all mapped aliases
- use authoritative unchanged pages to reuse persistent decoded textures across submits
- retain exact comparison for dirty, incomplete, unsupported, or dynamically rewritten resources
- add focused alias-write coverage, diagnostics, A/B controls, and performance documentation

## Evidence

A Dead Cells audit performed more than 10,000 proposed cross-submit shortcuts while retaining the old exact comparison and found zero disagreements.

In the final full-resolution heavy workload:
- exact validation fell from about 145 MiB to 3.3 MiB per submit
- write faults plateaued at 17,821 instead of continuing toward roughly 490,000
- process memory stabilized at 1.60-1.68 GiB private and 3.62-3.68 GiB working set

The game still remains on its Prisoners' Quarters loading screen; this PR does not claim to resolve #723.

## Validation

- Windows: 70/70 tests
- Linux: 102/102 tests
- focused two-alias section write/rearm/physical-write/invalidation test
- rebased cleanly over #756; its pixel-stage dynamic-buffer regression passes
- snapshot gate attempted, but all three title guards correctly reject because their required visual reviews remain pending; no baseline or threshold was changed

Fixes #743