### PR TITLE
tools(renderer): attribute target timing without log distortion

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -182,6 +182,9 @@ lines show only the latest 25 submits/calls so a scene transition is immediately
 an independent 25-call backend window across submit boundaries. Compare `measured` with `detail` and
 its `other` remainder to verify that the subphase attribution covers the frontend's backend wall time.
 The core window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
+The older independent 25-backend-call timing windows are disabled by default because their multi-line logging
+can materially perturb the target call charged for printing them on Windows. Set
+`PROSPER_BACKEND_TIMING_WINDOWS=1` only when that cross-submit legacy view or its memory-pool line is needed.
 Use `PROSPER_RENDER_TIMING=detail` to additionally print individual texture decodes taking at least
 0.5 ms (capped at 250 lines). Set `PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT=N` to begin those detail
 lines at renderer submit N, so boot textures do not consume the cap before the scene under study. Each
@@ -190,13 +193,17 @@ aggregate output also reports retained RTT bytes, decode-scratch capacity, and v
 use those figures before treating a process-memory increase as an unbounded cache.
 Set `PROSPER_RTT_TIMING=1` with timing enabled to print one lightweight `[rtt-timing]` line per rendered target
 group. It includes the submit number, target address, dimensions, draw count, and that target's exact Vulkan
-phase breakdown without scanning pixels or printing every draw. `PROSPER_RTTLOG=1` includes the same line plus
+phase breakdown without scanning pixels or printing every draw. `measured`, `detail`, and `other` show the
+frontend-observed call duration, attributed backend phase sum, and remaining wrapper/logging cost for that
+specific target. `PROSPER_RTTLOG=1` includes the same line plus
 the more expensive visual RTT diagnostics. Use `PROSPER_RTTLOG_MIN_SUBMIT=N` and
 `PROSPER_RTTLOG_MAX_SUBMIT=N` to bound either mode; unrestricted output can still perturb wall-clock routes.
 For scene selection that is stable across runs, set `PROSPER_RTT_TIMING_MIN_DRAWS=N`. Lightweight records are
 buffered for one ordered submit and emitted together only when its total backend draw count reaches N, so all
 target calls are retained without logging the boot/menu workloads. For example, 300 selects the current
 Dead Cells post-parse workload while excluding its 54-56-draw loading loop.
+Selected lightweight records are formatted together and written to stderr in one batch at submit completion;
+this preserves one parseable line per target without paying a Windows console write for every target.
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated
@@ -232,7 +239,7 @@ decode/probe/interpreter split. It prints every 4096 folds by default; set
 diagnostic runs and takes no timing samples when disabled.
 
 Transient Vulkan memory uses a bounded, exact-requirements pool because every backend call waits for its
-fence before cleanup. Timing output includes `memory_pool` hits, misses, cached allocation count/bytes,
+fence before cleanup. The optional backend timing windows include `memory_pool` hits, misses, cached allocation count/bytes,
 and budget-driven discards. The default budget is 512 MiB; override it with
 `PROSPER_MEMORY_POOL_MB=<MiB>`, or set `PROSPER_NO_MEMORY_POOL=1` for an A/B run against direct
 `vkAllocateMemory`/`vkFreeMemory`. The pool retains only allocation objects: images, buffers, views,

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -347,10 +347,21 @@ They also print the frontend-measured backend duration, the detailed phase sum, 
 This is the authoritative view for choosing the next backend optimization; the legacy per-call lines remain
 useful for spotting an individually slow render target. `PROSPER_RTT_TIMING=1` adds a lightweight
 `[rtt-timing]` record for each target group with its submit, address, dimensions, draw count, and exact phase
-costs. `PROSPER_RTTLOG=1` retains its visual pixel/draw diagnostics and also emits the timing record. Bound both
+costs. Each record also reports its frontend-measured duration and the remainder outside those phases, so an
+unattributed submit-level cost can be assigned to a concrete target call. `PROSPER_RTTLOG=1` retains its visual
+pixel/draw diagnostics and also emits the timing record. Bound both
 modes with `PROSPER_RTTLOG_MIN_SUBMIT` and `PROSPER_RTTLOG_MAX_SUBMIT`. The full visual mode scans rendered
 pixels and dropped one Dead Cells title loop from about 20 FPS to 13-14 FPS, causing its wall-clock input route
 to miss the menu; use the lightweight mode for performance attribution.
+Lightweight records selected for one submit are emitted with a single stderr write while preserving their
+line-oriented format, avoiding one slow Windows console operation per target.
+
+The legacy 25-backend-call window is now separately enabled with `PROSPER_BACKEND_TIMING_WINDOWS=1`.
+Printing its multiple aggregate lines from inside `render_draws_rgba` was charged to whichever target crossed
+the 25-call boundary. One Dead Cells 636x420 five-draw target measured 103.15 ms outside but only 2.55 ms across
+all backend phases; 100.60 ms was diagnostic output. This explained almost exactly the submit-aligned 39 ms
+unattributed remainder. Submit-aligned and lightweight target timing remain enabled by
+`PROSPER_RENDER_TIMING` without that legacy output.
 
 Submit ordinals also varied enough across fresh runs that preselected ranges repeatedly missed the transition.
 `PROSPER_RTT_TIMING_MIN_DRAWS=N` therefore buffers lightweight target records until the final graphics span and

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <vector>
 #include <set>
 #include <unordered_map>
@@ -244,6 +245,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t target = 0;
                 uint32_t width = 0, height = 0;
                 size_t draws = 0;
+                double measured_ms = 0;
                 prosper::test::BackendRenderTimingStats timing;
             };
             static thread_local RenderTiming pending_timing;
@@ -280,16 +282,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_pipeline_entries = pipelines.entries;
                 pending_timing.backend_pipeline_evictions += pipelines.evictions;
             };
-            auto print_rtt_timing = [](const RttTimingRecord& record) {
+            auto append_rtt_timing = [](std::string& output, const RttTimingRecord& record) {
                 const prosper::test::BackendRenderTimingStats& timing = record.timing;
-                fprintf(stderr,
-                        "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
-                        "total=%.2f target_setup=%.2f draw_setup=%.2f record_upload=%.2f "
-                        "gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
-                        record.submit, (unsigned long long)record.target,
-                        record.width, record.height, record.draws, timing.total_ms(),
-                        timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
-                        timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms);
+                const double detail_ms = timing.total_ms();
+                char line[512];
+                const int length = snprintf(
+                    line, sizeof(line),
+                    "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
+                    "measured=%.2f detail=%.2f other=%.2f target_setup=%.2f "
+                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f "
+                    "readback=%.2f cleanup=%.2f\n",
+                    record.submit, (unsigned long long)record.target,
+                    record.width, record.height, record.draws, record.measured_ms, detail_ms,
+                    record.measured_ms - detail_ms,
+                    timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
+                    timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms);
+                if (length > 0)
+                    output.append(line, std::min<size_t>(length, sizeof(line) - 1));
+            };
+            auto print_rtt_timing = [&](const RttTimingRecord& record) {
+                std::string output;
+                append_rtt_timing(output, record);
+                if (!output.empty()) fwrite(output.data(), 1, output.size(), stderr);
             };
             // PROSPER_SUBMITLOG: print the GPU-submit index periodically (at native speed, before the slow
             // render) so it can be correlated with guest-side log lines (e.g. a MsgDialog wait) to find the
@@ -1645,7 +1659,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
                     const RttTimingRecord rtt_timing_record{
-                        g_this_submit, base, gw, gh, pass.size(), backend_call_timing};
+                        g_this_submit, base, gw, gh, pass.size(),
+                        std::chrono::duration<double, std::milli>(
+                            backend_done - build_done).count(),
+                        backend_call_timing};
                     if (lightweight_rtt_timing) pending_rtt_timing.push_back(rtt_timing_record);
                     else if (timing_enabled && rtt_log) print_rtt_timing(rtt_timing_record);
                     if (rtt_log) {
@@ -1760,8 +1777,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 if (scanout) selected_pixels = scanout->rgba;
             }
             if (phase.final_span && lightweight_rtt_timing && rtt_log_in_range &&
-                pending_timing.backend_draws >= rtt_timing_min_draws)
-                for (const RttTimingRecord& record : pending_rtt_timing) print_rtt_timing(record);
+                pending_timing.backend_draws >= rtt_timing_min_draws) {
+                std::string output;
+                output.reserve(pending_rtt_timing.size() * 320);
+                for (const RttTimingRecord& record : pending_rtt_timing)
+                    append_rtt_timing(output, record);
+                if (!output.empty()) fwrite(output.data(), 1, output.size(), stderr);
+            }
             if (!phase.final_span) {
                 if (timing_enabled) {
                     pending_timing.callbacks++;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1938,7 +1938,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         };
         accumulate(totals);
         accumulate(window);
-        if (totals.calls % 25 == 0) {
+        static const bool print_backend_timing_windows =
+            getenv("PROSPER_BACKEND_TIMING_WINDOWS") != nullptr;
+        if (print_backend_timing_windows && totals.calls % 25 == 0) {
             const double n = static_cast<double>(totals.calls);
             const double total = totals.target + totals.draw_setup + totals.record +
                                  totals.gpu_wait + totals.readback + totals.cleanup;


### PR DESCRIPTION
## Summary

- add frontend-measured duration and unattributed remainder to each lightweight target timing record
- batch selected target records into one stderr write
- make the legacy independent 25-backend-call timing windows explicitly opt-in
- document the non-distorting profiling workflow and measured Dead Cells artifact

## Finding

A Dead Cells 636x420 five-draw target was previously charged 103.15 ms while its complete backend phases totaled 2.55 ms. The remaining 100.60 ms was the legacy timing window printing several lines inside render_draws_rgba when that target happened to cross the 25-call boundary.

With legacy windows disabled:
- all ten heavy-submit target remainders are 0-0.25 ms
- no legacy backend-window lines are emitted
- the two 4K calls are about 17 ms each
- the real wait/readback ceiling is now directly visible

The old view remains available through PROSPER_BACKEND_TIMING_WINDOWS=1.

## Validation

- native Windows build and 72/72 tests
- Linux build and 102/102 tests
- two clean-save full-resolution Dead Cells measurement runs
- routed screenshots remained source-distinct and pixel-distinct

Refs #759