### PR TITLE
Fix bound scalar fallback buffers

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3138,11 +3138,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
-            // A data load with a runtime table must resolve to one of that table's buffers. The
-            // table-less compute harness still owns the legacy binding-2 convention, but silently
-            // retaining it here produces SPIR-V whose descriptor interface the live renderer cannot
-            // satisfy (and, worse, could read the wrong buffer if binding 2 happened to exist).
-            if (rt && !cbuf_resolved) { ok = false; return true; }
+            // A data load with a runtime table may retain the legacy binding-2 convention only when
+            // that table actually binds a buffer there. VS/compute tables start at binding 2 and use
+            // this path legitimately; PS tables start at 32, where keeping the fallback would emit an
+            // interface the renderer cannot satisfy (#719).
+            if (rt && !cbuf_resolved) {
+                const bool fallback_bound = std::any_of(
+                    rt->resources.begin(), rt->resources.end(), [](const ShaderResource& resource) {
+                        return resource.binding == 2 &&
+                               (resource.cls == ResourceClass::ConstantBuffer ||
+                                resource.cls == ResourceClass::VertexBuffer);
+                    });
+                if (!fallback_bound) { ok = false; return true; }
+            }
             if (soff_dyn) {
                 // Dynamic dword index: (soffset + signed imm) >> 2 (uint add == two's-complement add).
                 uint32_t idx0 = b.ibin(Op_ShiftRightLogical,

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -532,6 +532,19 @@ int main() {
     CHECK(spv22unresolved.empty(),
           "unresolved scalar data load with a runtime table is REJECTED (no binding-2 fallback)");
 
+    ShaderResourceTable rt22fallback;
+    { ShaderResource cb{}; cb.cls = ResourceClass::ConstantBuffer; cb.format = DataFormat::Uint32;
+      cb.num_components = 1; cb.binding = 2; rt22fallback.resources.push_back(cb); }
+    std::vector<uint32_t> spv22fallback = recompile_valu(
+        code22pc, sizeof(code22pc)/sizeof(code22pc[0]), 1, 0, &rt22fallback);
+    std::vector<float> got22fallback = prosper::test::run_compute(
+        spv22fallback, in22, N, N, cbuf22pc1);
+    bool good22fallback = got22fallback.size() == N;
+    for (uint32_t i = 0; i < N && good22fallback; ++i)
+        good22fallback = std::fabs(got22fallback[i] - 300.0f) <= 1e-3f;
+    CHECK(!spv22fallback.empty() && good22fallback,
+          "unresolved scalar data load may use binding 2 when the runtime table binds it");
+
     // Kernel 23: buffer_load_format_x FLOAT32 VERTEX FETCH (stage 2 — the real-VS mechanism). v0=(uint)
     // gid (element index); buffer_load_format_x v1, v0, s[8:11] idxen fetches vbuf[gid]; out=v1. The V#
     // descriptor is DIRECT (in user-data SGPR s8) -> resolved via sgpr_base -> VertexBuffer binding 3,


### PR DESCRIPTION
## Summary

- retain the legacy binding-2 scalar data-load fallback only when the runtime resource table actually binds a buffer there
- preserve valid vertex/compute shader tables while continuing to reject pixel-shader interfaces the renderer cannot satisfy
- add an execution regression test covering the valid runtime binding-2 path

## DOLL / issue #719 evidence

PR #760's first fail-closed guard was too broad: a sparse DOLL capture dropped to 7/101 realized draws because valid VS/compute tables begin at binding 2. With this refinement the same capture realizes 76/101 draws, up from 70 before the structured-buffer work, and `gpu_replay --validate` reports 0 descriptor rejects. The one unbindable pixel shader remains rejected.

The full capsule is still black because its temporal render-target/depth predecessors are not seeded; issue #719 remains open while that capture/replay closure is investigated.

## Validation

- clean Linux build
- `ctest --test-dir build-linux --output-on-failure` — 97/97 passed
- fresh DOLL capture — 76/101 realized draws, 293/300 realized dispatches
- `gpu_replay --validate` — 0 descriptor rejects

Follow-up regression fix for #760; progresses #719.