### PR TITLE
Persist GPU color targets across render passes

### DIFF
--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -432,6 +432,41 @@ synchronous GPU waits and readbacks, and the whole ordered submit remains hundre
 target profiler. Coordinated GPU ownership across those producer-consumer boundaries is the next architectural
 step.
 
+## Persistent GPU color targets (2026-07-15)
+
+The first coordinated-ownership tranche retains exact RGBA8 color targets by guest identity, extent, and
+format in a bounded Vulkan cache. A later graphics pass that samples the same target can bind that image
+directly instead of reading it to CPU RGBA and uploading it again. Guest GPU writes invalidate overlapping
+entries through the same ordered write observer used by persistent depth/stencil state. Same-target feedback,
+scanout, presentation fallback, captures, replay seeds, and pixel diagnostics keep the established CPU path.
+
+The live path is initially opt-in with `PROSPER_LIVE_PERSISTENT_COLOR_TARGETS=1`. Set
+`PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS=1` to disable backend retention independently, or change its
+256 MiB budget with `PROSPER_BACKEND_TARGET_CACHE_MB`. The backend unit contract compares direct GPU
+producer-to-sampler output byte-for-byte with CPU readback/upload, verifies a deferred-readback LOAD pass,
+and proves that invalidation uses supplied CPU pixels rather than stale GPU contents.
+
+Native Windows Dead Cells post-`PARSEALL` evidence used one current-master binary with submit-aligned timing.
+The animated runs did not carry identical draw counts, so the phase counters establish the mechanism more
+reliably than the app overlay:
+
+| Measurement | CPU target path | Persistent GPU targets |
+|---|---:|---:|
+| Realized draws | 361 | 405 |
+| Target writes / readbacks | 10 / 10 | 10 / 4 |
+| Direct target samples | 0 | 8 |
+| Record/upload | 4.5 ms | 0.5 ms |
+| GPU fence waits | 26.7 ms | 16.8 ms |
+| Frontend Vulkan wall time | 60.8 ms | 48.9 ms |
+| Ordered backend total | 118.6 ms | 110.7 ms |
+| Whole submit | 154.2 ms | 151.1 ms |
+
+The enabled run retained 13 targets / 103.5 MiB and remained near 1.81 GiB private memory. It did more draw
+work while completing slightly faster, but this is not yet a playable frame budget. Four large CPU readbacks
+still cost about 9 ms, 405-draw realization costs about 40 ms, and the ordered path still executes ten target
+calls plus eight compute calls. The next architectural gain requires fewer synchronous submissions/fences or
+safe reuse of per-draw resource work; neither may weaken the captured graphics/compute dependency order.
+
 ## Current frame budget
 
 After shared publication, the Dead Cells post-parse loading workload is the most useful current budget:

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -50,6 +50,7 @@ namespace {
 struct RttSurf {
     std::shared_ptr<const std::vector<uint8_t>> rgba;
     uint32_t w = 0, h = 0;
+    bool gpu_valid = false;
 };
 
 // Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
@@ -115,13 +116,13 @@ struct PersistentDecodedTexture {
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     register_live_compute();
     const char* ds_invalidate = getenv("PROSPER_DS_GUEST_WRITE_INVALIDATE");
-    if (!ds_invalidate || strcmp(ds_invalidate, "0"))
-        prosper::gpu::set_guest_gpu_write_observer(
-            [](uint64_t addr, uint64_t size) {
+    const bool invalidate_ds = !ds_invalidate || strcmp(ds_invalidate, "0");
+    prosper::gpu::set_guest_gpu_write_observer(
+        [invalidate_ds](uint64_t addr, uint64_t size) {
+            if (invalidate_ds)
                 prosper::test::invalidate_persistent_ds_guest_write(addr, size);
-            });
-    else
-        prosper::gpu::set_guest_gpu_write_observer({});
+            prosper::test::invalidate_persistent_color_target_guest_write(addr, size);
+        });
     // Resource tables are built before the submit reaches this callback. Publish the renderer's
     // default mode now so unmapped render-target descriptors remain available for RTT injection.
     // Outside a registered renderer, resource decoding retains its strict unknown-format policy.
@@ -173,6 +174,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             RttSurf& surface = g_rtt[seed.guest_addr];
             surface.w = seed.width; surface.h = seed.height;
             surface.rgba = std::make_shared<const std::vector<uint8_t>>(seed.rgba);
+            surface.gpu_valid = false;
+            prosper::test::invalidate_persistent_color_target(seed.guest_addr);
             return true;
         });
     if (getenv("PROSPER_GPU_REPLAY_DS_SEEDS"))
@@ -185,6 +188,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr ||
                                   getenv("PROSPER_RTT_SINGLE_TARGET") == nullptr;
     static const bool rtt_on = getenv("PROSPER_RTT") != nullptr || pertarget;
+    // First deployment is opt-in. Captures and per-target pixel diagnostics require authoritative
+    // CPU pixels at every pass, so they retain the established readback path even when requested.
+    static const bool live_gpu_targets = getenv("PROSPER_LIVE_PERSISTENT_COLOR_TARGETS") &&
+        pertarget && !getenv("PROSPER_GPU_CAPTURE") &&
+        !getenv("PROSPER_GPU_TIMELINE_CAPTURE") && !getenv("PROSPER_GPU_REPLAY_EXPORT_RTT") &&
+        !getenv("PROSPER_GPU_REPLAY_RTT_SEEDS") && !getenv("PROSPER_DUMP_SAMPLED_RTT") &&
+        !getenv("PROSPER_DUMP_RTGROUPS") && !getenv("PROSPER_DUMP_DRAWSTEPS") &&
+        !getenv("PROSPER_RESOURCE_HASH_DIM") && !getenv("PROSPER_TARGET_STEP_HASH_DIM") &&
+        !getenv("PROSPER_RTTLOG");
+    if (live_gpu_targets)
+        fprintf(stderr, "[render] persistent GPU color targets enabled (experimental)\n");
     prosper::gpu::set_submit_renderer(
         [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items,
                                uint32_t w, uint32_t h) -> prosper::gpu::RenderedFrame {
@@ -231,6 +245,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
                 uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
                 uint64_t backend_pipeline_entries = 0, backend_pipeline_evictions = 0;
+                uint64_t color_target_writes = 0, color_target_write_hits = 0;
+                uint64_t color_target_sample_hits = 0, color_target_readbacks = 0;
+                uint64_t color_target_cached_bytes = 0, color_target_cached_entries = 0;
                 uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                 uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                 uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
@@ -247,6 +264,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 size_t draws = 0;
                 double measured_ms = 0;
                 prosper::test::BackendRenderTimingStats timing;
+                prosper::test::BackendColorTargetStats color_target;
             };
             static thread_local RenderTiming pending_timing;
             static thread_local std::vector<RttTimingRecord> pending_rtt_timing;
@@ -291,12 +309,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
                     "measured=%.2f detail=%.2f other=%.2f target_setup=%.2f "
                     "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f "
-                    "readback=%.2f cleanup=%.2f\n",
+                    "readback=%.2f cleanup=%.2f gpu_target=%llu load=%llu sample=%llu cpu=%llu\n",
                     record.submit, (unsigned long long)record.target,
                     record.width, record.height, record.draws, record.measured_ms, detail_ms,
                     record.measured_ms - detail_ms,
                     timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
-                    timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms);
+                    timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms,
+                    (unsigned long long)record.color_target.writes,
+                    (unsigned long long)record.color_target.write_hits,
+                    (unsigned long long)record.color_target.sampled_hits,
+                    (unsigned long long)record.color_target.readbacks);
                 if (length > 0)
                     output.append(line, std::min<size_t>(length, sizeof(line) - 1));
             };
@@ -476,9 +498,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.tile_mode, r.img_dim,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
-                        const bool has_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() && live_rtt->second.w &&
-                            live_rtt->second.h && live_rtt->second.rgba &&
+                        const bool has_cpu_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() &&
+                            live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
                             !live_rtt->second.rgba->empty();
+                        const bool has_gpu_live_rtt = live_gpu_targets && r.img_dim == 1u &&
+                            live_rtt != g_rtt.end() && live_rtt->second.gpu_valid &&
+                            live_rtt->second.w == tw && live_rtt->second.h == th &&
+                            r.gpu_addr != draw.color0_base &&
+                            prosper::test::find_persistent_color_target(
+                                r.gpu_addr, tw, th, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
+                        const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
@@ -643,7 +672,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                             }
                         }
-                        if (decoded_reuse) {
+                        if (has_gpu_live_rtt) {
+                            fr.persistent_render_target_id = r.gpu_addr;
+                            fr.tw = tw; fr.th = th; fr.td = 1; fr.img_dim = r.img_dim;
+                            resource_rtt_hit = true;
+                        } else if (decoded_reuse) {
                             fr.tex_rgba = decoded_reuse->pixels;
                             fr.tw = tw;
                             fr.th = decoded_reuse->output_height;
@@ -1546,19 +1579,60 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                     }
                     const uint8_t* seed = nullptr;
+                    bool gpu_seed_available = false;
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
-                        if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
+                        gpu_seed_available = live_gpu_targets && sit != g_rtt.end() &&
+                            sit->second.gpu_valid && sit->second.w == gw && sit->second.h == gh &&
+                            prosper::test::find_persistent_color_target(
+                                base, gw, gh, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
+                        if (!gpu_seed_available && sit != g_rtt.end() &&
+                            sit->second.w == gw && sit->second.h == gh &&
                             sit->second.rgba && sit->second.rgba->size() == (size_t)gw * gh * 4)
                             seed = sit->second.rgba->data(); }
+                    bool is_vo = false;
+                    for (int i = 0; i < vo_n && !is_vo; i++)
+                        is_vo = base && base == prosper_vo_buffer_addr(i);
+                    bool sampled_exact_later = false;
+                    bool feedback_later = false;
+                    if (live_gpu_targets && base) {
+                        for (size_t later = pass_i; later < items.size(); ++later) {
+                            auto inspect = [&](const prosper::gpu::ShaderResourceTable* table) {
+                                if (!table) return;
+                                for (const auto& resource : table->resources) {
+                                    if ((resource.cls != RC::Texture &&
+                                         resource.cls != RC::StorageImage) ||
+                                        resource.gpu_addr != base || resource.img_dim != 1u)
+                                        continue;
+                                    const uint32_t rw = resource.width ? resource.width : 4u;
+                                    const uint32_t rh = resource.height ? resource.height : 4u;
+                                    if (rw == gw && rh == gh) {
+                                        sampled_exact_later = true;
+                                        feedback_later |= items[later].color0_base == base;
+                                    }
+                                }
+                            };
+                            inspect(items[later].vrt.get());
+                            inspect(items[later].prt.get());
+                        }
+                    }
+                    // Defer only a proven graphics-to-graphics intermediate. Scanout, fallback-present,
+                    // size conversion, and same-image feedback retain authoritative CPU pixels.
+                    const bool defer_readback = live_gpu_targets && vo_n > 0 && base && !is_vo &&
+                        base != front_va && sampled_exact_later && !feedback_later;
+                    prosper::test::BackendColorTarget backend_target{
+                        base, seed_rtt, !defer_readback};
                     const auto build_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     auto backend_draws = build_bds(render_pass);
                     const auto build_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
-                        backend_draws, gw, gh, seed, clear_for(render_pass), true);
+                        backend_draws, gw, gh, seed, clear_for(render_pass), true,
+                        live_gpu_targets && base ? &backend_target : nullptr);
                     const auto backend_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
+                    const prosper::test::BackendColorTargetStats color_target_call =
+                        prosper::test::backend_color_target_stats();
                     const prosper::test::BackendRenderTimingStats backend_call_timing = timing_enabled
                         ? prosper::test::backend_render_timing_stats()
                         : prosper::test::BackendRenderTimingStats{};
@@ -1571,13 +1645,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         pending_timing.backend_ms +=
                             std::chrono::duration<double, std::milli>(backend_done - build_done).count();
                         record_backend_timing(backend_call_timing, backend_pipeline_stats);
+                        pending_timing.color_target_writes += color_target_call.writes;
+                        pending_timing.color_target_write_hits += color_target_call.write_hits;
+                        pending_timing.color_target_sample_hits += color_target_call.sampled_hits;
+                        pending_timing.color_target_readbacks += color_target_call.readbacks;
+                        pending_timing.color_target_cached_bytes = color_target_call.cached_bytes;
+                        pending_timing.color_target_cached_entries = color_target_call.cached_entries;
                     }
                     auto pass_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(gpx));
-                    if (base && !pass_pixels->empty()) {
+                    if (base && color_target_call.writes) {
+                        RttSurf& surface = g_rtt[base];
+                        surface.w = gw;
+                        surface.h = gh;
+                        surface.gpu_valid = prosper::test::find_persistent_color_target(
+                            base, gw, gh, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
+                        if (!pass_pixels->empty()) surface.rgba = pass_pixels;
+                        else if (surface.gpu_valid) surface.rgba.reset();
+                    } else if (base && !pass_pixels->empty()) {
                         RttSurf& surface = g_rtt[base];
                         surface.rgba = pass_pixels;
                         surface.w = gw;
                         surface.h = gh;
+                        surface.gpu_valid = false;
                     }
                     const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
                     if (native_w == resource_hash_w && native_h == resource_hash_h &&
@@ -1656,13 +1745,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     (unsigned long long)hash, dark, near_white, mean_rgb);
                         }
                     }
-                    bool is_vo = false;
-                    for (int i = 0; i < vo_n && !is_vo; i++) is_vo = base && base == prosper_vo_buffer_addr(i);
                     const RttTimingRecord rtt_timing_record{
                         g_this_submit, base, gw, gh, pass.size(),
                         std::chrono::duration<double, std::milli>(
                             backend_done - build_done).count(),
-                        backend_call_timing};
+                        backend_call_timing, color_target_call};
                     if (lightweight_rtt_timing) pending_rtt_timing.push_back(rtt_timing_record);
                     else if (timing_enabled && rtt_log) print_rtt_timing(rtt_timing_record);
                     if (rtt_log) {
@@ -1747,7 +1834,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 if (rtt_on && !selected_pixels->empty()) {
                     uint64_t tgt = 0;
                     for (const auto& it : items) if (it.color0_base) { tgt = it.color0_base; break; }
-                    if (tgt) { RttSurf& s = g_rtt[tgt]; s.rgba = selected_pixels; s.w = w; s.h = h; }
+                    if (tgt) {
+                        RttSurf& s = g_rtt[tgt];
+                        s.rgba = selected_pixels; s.w = w; s.h = h; s.gpu_valid = false;
+                        prosper::test::invalidate_persistent_color_target(tgt);
+                    }
                     if (rtt_log) { size_t nz=0;
                         for (uint8_t byte : *selected_pixels) nz += byte != 0;
                         fprintf(stderr, "[rtt] store target=0x%llx (%zu items, color0s:", (unsigned long long)tgt, items.size());
@@ -1823,6 +1914,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
                     uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
                     uint64_t backend_pipeline_entries = 0, backend_pipeline_evictions = 0;
+                    uint64_t color_target_writes = 0, color_target_write_hits = 0;
+                    uint64_t color_target_sample_hits = 0, color_target_readbacks = 0;
+                    uint64_t color_target_cached_bytes = 0, color_target_cached_entries = 0;
                     uint64_t textures = 0, texture_reuses = 0, buffers = 0;
                     uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                     uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
@@ -1859,6 +1953,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.backend_pipeline_bypasses += pending_timing.backend_pipeline_bypasses;
                     timing.backend_pipeline_entries = pending_timing.backend_pipeline_entries;
                     timing.backend_pipeline_evictions += pending_timing.backend_pipeline_evictions;
+                    timing.color_target_writes += pending_timing.color_target_writes;
+                    timing.color_target_write_hits += pending_timing.color_target_write_hits;
+                    timing.color_target_sample_hits += pending_timing.color_target_sample_hits;
+                    timing.color_target_readbacks += pending_timing.color_target_readbacks;
+                    timing.color_target_cached_bytes = pending_timing.color_target_cached_bytes;
+                    timing.color_target_cached_entries = pending_timing.color_target_cached_entries;
                     timing.textures += pending_timing.textures;
                     timing.texture_reuses += pending_timing.texture_reuses;
                     timing.persistent_hits += pending_timing.persistent_hits;
@@ -1919,6 +2019,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.backend_pipeline_bypasses / nsub,
                             (unsigned long long)totals.backend_pipeline_entries,
                             totals.backend_pipeline_evictions / nsub);
+                    fprintf(stderr,
+                            "[render-timing] color_targets writes=%llu load_hits=%llu sample_hits=%llu "
+                            "readbacks=%llu deferred=%llu cached=%llu %.1f MiB\n",
+                            (unsigned long long)totals.color_target_writes,
+                            (unsigned long long)totals.color_target_write_hits,
+                            (unsigned long long)totals.color_target_sample_hits,
+                            (unsigned long long)totals.color_target_readbacks,
+                            (unsigned long long)(totals.color_target_writes -
+                                                 totals.color_target_readbacks),
+                            (unsigned long long)totals.color_target_cached_entries,
+                            totals.color_target_cached_bytes / (1024.0 * 1024.0));
                     fprintf(stderr,
                             "[render-timing] resources textures=%llu reused=%llu %.1f MiB %.2f ms/submit; "
                             "buffers=%llu %.1f MiB %.2f ms/submit\n",
@@ -2022,6 +2133,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.backend_pipeline_bypasses / wn,
                             (unsigned long long)window.backend_pipeline_entries,
                             window.backend_pipeline_evictions / wn);
+                    fprintf(stderr,
+                            "[render-window] color_targets writes=%.1f load_hits=%.1f sample_hits=%.1f "
+                            "readbacks=%.1f deferred=%.1f cached=%llu %.1f MiB\n",
+                            window.color_target_writes / wn,
+                            window.color_target_write_hits / wn,
+                            window.color_target_sample_hits / wn,
+                            window.color_target_readbacks / wn,
+                            (window.color_target_writes - window.color_target_readbacks) / wn,
+                            (unsigned long long)window.color_target_cached_entries,
+                            window.color_target_cached_bytes / (1024.0 * 1024.0));
                     fprintf(stderr,
                             "[render-window] texture_cache hits=%.1f submit_reuse=%.1f misses=%.1f "
                             "watch_reuse=%.1f watch_dirty=%.1f watch_unknown=%.1f watch_disabled=%.1f "

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -421,6 +421,16 @@ inline void invalidate_persistent_color_target(uint64_t id) {
         if (key.id == id) target.valid = false;
 }
 
+inline void invalidate_persistent_color_target_guest_write(uint64_t addr, uint64_t size) {
+    if (!addr || !size) return;
+    const uint64_t end = size > UINT64_MAX - addr ? UINT64_MAX : addr + size;
+    for (auto& [key, target] : persistent_color_target_cache()) {
+        const uint64_t bytes = static_cast<uint64_t>(key.width) * key.height * 4;
+        const uint64_t target_end = bytes > UINT64_MAX - key.id ? UINT64_MAX : key.id + bytes;
+        if (addr < target_end && key.id < end) target.valid = false;
+    }
+}
+
 inline void destroy_persistent_color_target(const RenderVkCtx& ctx,
                                             PersistentColorTargetImage& target) {
     if (target.view) vkDestroyImageView(ctx.dev, target.view, nullptr);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -90,8 +90,40 @@ struct FrameResource {
     // prove these decoded pixels are the same content version as a prior callback. The Vulkan
     // backend may retain an uploaded image under this ID; zero remains callback-local/transient.
     uint64_t persistent_texture_id = 0;
-    bool is_texture() const { return tex_rgba != nullptr; }
+    // Non-zero identifies a color target retained by an earlier backend call. When that exact
+    // target is available, bind its GPU image directly instead of uploading `tex_rgba` again.
+    // `tex_rgba` remains an optional conservative fallback for an invalidated/missing target.
+    uint64_t persistent_render_target_id = 0;
+    bool is_texture() const { return tex_rgba != nullptr || persistent_render_target_id != 0; }
 };
+
+// Optional color-target contract for the live backend. A non-zero ID gives the target a stable
+// guest identity across calls. Existing contents are loaded only when both `load_existing` and a
+// valid matching image are present. `readback=false` leaves the completed result GPU-resident and
+// deliberately returns an empty CPU vector.
+struct BackendColorTarget {
+    uint64_t persistent_id = 0;
+    bool load_existing = true;
+    bool readback = true;
+};
+
+struct BackendColorTargetStats {
+    uint64_t writes = 0;
+    uint64_t write_hits = 0;
+    uint64_t sampled_hits = 0;
+    uint64_t readbacks = 0;
+    uint64_t cached_bytes = 0;
+    uint64_t cached_entries = 0;
+};
+
+inline BackendColorTargetStats& backend_color_target_stats_storage() {
+    static thread_local BackendColorTargetStats stats;
+    return stats;
+}
+
+inline BackendColorTargetStats backend_color_target_stats() {
+    return backend_color_target_stats_storage();
+}
 
 // Returns W*H*4 RGBA bytes, or {} on any Vulkan failure (incl. a rejected SPIR-V module). When `ps`
 // is non-null, the pipeline's fixed-function state (topology, blend, color write mask) is taken from
@@ -315,6 +347,101 @@ inline const RenderVkCtx& render_vk_ctx() {
         return r;
     }();
     return c;
+}
+
+struct PersistentColorTargetKey {
+    uint64_t id = 0;
+    uint32_t width = 0, height = 0;
+    VkFormat format = VK_FORMAT_UNDEFINED;
+    bool operator==(const PersistentColorTargetKey&) const = default;
+};
+
+struct PersistentColorTargetKeyHash {
+    size_t operator()(const PersistentColorTargetKey& key) const {
+        size_t h = std::hash<uint64_t>{}(key.id);
+        auto mix = [&](uint32_t value) {
+            h ^= static_cast<size_t>(value) + 0x9e3779b9u + (h << 6) + (h >> 2);
+        };
+        mix(key.width); mix(key.height); mix(static_cast<uint32_t>(key.format));
+        return h;
+    }
+};
+
+struct PersistentColorTargetImage {
+    VkImage image = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkImageView view = VK_NULL_HANDLE;
+    VkDeviceSize bytes = 0;
+    VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    uint64_t last_use = 0;
+    bool valid = false;
+};
+
+inline std::unordered_map<PersistentColorTargetKey, PersistentColorTargetImage,
+                          PersistentColorTargetKeyHash>& persistent_color_target_cache() {
+    static std::unordered_map<PersistentColorTargetKey, PersistentColorTargetImage,
+                              PersistentColorTargetKeyHash> cache;
+    return cache;
+}
+
+inline VkDeviceSize& persistent_color_target_bytes() {
+    static VkDeviceSize bytes = 0;
+    return bytes;
+}
+
+inline uint64_t& persistent_color_target_generation() {
+    static uint64_t generation = 0;
+    return generation;
+}
+
+inline VkDeviceSize persistent_color_target_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = getenv("PROSPER_BACKEND_TARGET_CACHE_MB");
+        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
+
+inline PersistentColorTargetImage* find_persistent_color_target(
+    uint64_t id, uint32_t width, uint32_t height, VkFormat format, bool require_valid = true) {
+    if (!id) return nullptr;
+    auto& cache = persistent_color_target_cache();
+    auto found = cache.find({id, width, height, format});
+    if (found == cache.end() || (require_valid && !found->second.valid)) return nullptr;
+    return &found->second;
+}
+
+// Guest/compute writes invalidate the GPU-produced version without immediately freeing the image.
+// The next render may reuse the allocation, but it cannot LOAD or sample stale pixels.
+inline void invalidate_persistent_color_target(uint64_t id) {
+    if (!id) return;
+    for (auto& [key, target] : persistent_color_target_cache())
+        if (key.id == id) target.valid = false;
+}
+
+inline void destroy_persistent_color_target(const RenderVkCtx& ctx,
+                                            PersistentColorTargetImage& target) {
+    if (target.view) vkDestroyImageView(ctx.dev, target.view, nullptr);
+    if (target.image) vkDestroyImage(ctx.dev, target.image, nullptr);
+    if (target.memory) vkFreeMemory(ctx.dev, target.memory, nullptr);
+    target = {};
+}
+
+inline bool evict_persistent_color_target(const RenderVkCtx& ctx, uint64_t current_generation) {
+    auto& cache = persistent_color_target_cache();
+    auto victim = cache.end();
+    for (auto it = cache.begin(); it != cache.end(); ++it) {
+        if (it->second.last_use == current_generation) continue;
+        if (victim == cache.end() || it->second.last_use < victim->second.last_use)
+            victim = it;
+    }
+    if (victim == cache.end()) return false;
+    persistent_color_target_bytes() -= victim->second.bytes;
+    destroy_persistent_color_target(ctx, victim->second);
+    cache.erase(victim);
+    return true;
 }
 
 // Each call waits for its fence before cleanup, so transient allocations can be safely recycled by
@@ -756,15 +883,23 @@ inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& se
 inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H,
                                               const uint8_t* seed_rgba = nullptr,
                                               const float* clear_rgba = nullptr,
-                                              bool persist_depth_stencil = false) {
+                                              bool persist_depth_stencil = false,
+                                              const BackendColorTarget* color_target = nullptr) {
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     if (timing_enabled) backend_render_timing_stats_storage() = {};
+    BackendColorTargetStats& color_target_stats = backend_color_target_stats_storage();
+    color_target_stats = {};
     std::vector<uint8_t> out;
     if (draws.empty()) return out;
     const RenderVkCtx& ctx = render_vk_ctx();
     if (!ctx.ok) return out;
+    const bool persistent_color_targets_enabled =
+        getenv("PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS") == nullptr;
+    const bool persistent_color_enabled = persistent_color_targets_enabled && color_target &&
+                                          color_target->persistent_id;
+    const uint64_t color_target_generation = ++persistent_color_target_generation();
     VkInstance inst = ctx.inst; (void)inst; VkPhysicalDevice phys = ctx.phys;
     VkDevice dev = ctx.dev; VkQueue queue = ctx.queue; uint32_t qfi = ctx.qfi;
     const bool aniso_enabled = ctx.aniso_enabled; const float max_aniso_limit = ctx.max_aniso_limit;
@@ -891,23 +1026,81 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
     }
 
-    VkImageCreateInfo imgci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-    imgci.imageType = VK_IMAGE_TYPE_2D; imgci.format = FMT; imgci.extent = {W, H, 1};
-    imgci.mipLevels = 1; imgci.arrayLayers = 1; imgci.samples = VK_SAMPLE_COUNT_1_BIT;
-    imgci.tiling = VK_IMAGE_TILING_OPTIMAL;
-    imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-                  (seed_rgba ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-    VkImage img; vkCreateImage(dev, &imgci, nullptr, &img);
-    VkMemoryRequirements ir; vkGetImageMemoryRequirements(dev, img, &ir);
-    VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-    iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
-    VkDeviceMemory imem = allocate_transient_render_memory(dev, iai.allocationSize,
-                                                            iai.memoryTypeIndex);
-    vkBindImageMemory(dev, img, imem, 0);
-    VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
-    ivci.image = img; ivci.viewType = VK_IMAGE_VIEW_TYPE_2D; ivci.format = FMT;
-    ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    VkImageView view; vkCreateImageView(dev, &ivci, nullptr, &view);
+    // Protect every GPU target sampled by this call from LRU eviction while its descriptors are built.
+    for (const auto& draw : draws)
+        for (const auto& resource : draw.R)
+            if (persistent_color_targets_enabled && resource.persistent_render_target_id)
+                if (auto* sampled = find_persistent_color_target(
+                        resource.persistent_render_target_id, resource.tw, resource.th, FMT))
+                    sampled->last_use = color_target_generation;
+
+    bool persistent_color = persistent_color_enabled;
+    PersistentColorTargetKey color_key{};
+    PersistentColorTargetImage* cached_color = nullptr;
+    if (persistent_color) {
+        color_key = {color_target->persistent_id, W, H, FMT};
+        auto [found, inserted] = persistent_color_target_cache().try_emplace(color_key);
+        cached_color = &found->second;
+        cached_color->last_use = color_target_generation;
+    }
+
+    VkImage img = cached_color ? cached_color->image : VK_NULL_HANDLE;
+    VkDeviceMemory imem = cached_color ? cached_color->memory : VK_NULL_HANDLE;
+    VkImageView view = cached_color ? cached_color->view : VK_NULL_HANDLE;
+    if (!img) {
+        VkImageCreateInfo imgci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+        imgci.imageType = VK_IMAGE_TYPE_2D; imgci.format = FMT; imgci.extent = {W, H, 1};
+        imgci.mipLevels = 1; imgci.arrayLayers = 1; imgci.samples = VK_SAMPLE_COUNT_1_BIT;
+        imgci.tiling = VK_IMAGE_TILING_OPTIMAL;
+        imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                      (persistent_color ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u) |
+                      ((seed_rgba || persistent_color) ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
+        vkCreateImage(dev, &imgci, nullptr, &img);
+        VkMemoryRequirements ir{}; vkGetImageMemoryRequirements(dev, img, &ir);
+        VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
+        if (persistent_color) {
+            const VkDeviceSize limit = persistent_color_target_limit();
+            while ((persistent_color_target_cache().size() > 64 || ir.size > limit ||
+                    persistent_color_target_bytes() > limit - ir.size) &&
+                   evict_persistent_color_target(ctx, color_target_generation)) {}
+            if (ir.size <= limit && persistent_color_target_cache().size() <= 64 &&
+                persistent_color_target_bytes() <= limit - ir.size &&
+                vkAllocateMemory(dev, &iai, nullptr, &imem) == VK_SUCCESS) {
+                cached_color->bytes = ir.size;
+                persistent_color_target_bytes() += ir.size;
+            } else {
+                vkDestroyImage(dev, img, nullptr);
+                img = VK_NULL_HANDLE;
+                persistent_color_target_cache().erase(color_key);
+                cached_color = nullptr;
+                persistent_color = false;
+                imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                              (seed_rgba ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
+                vkCreateImage(dev, &imgci, nullptr, &img);
+                vkGetImageMemoryRequirements(dev, img, &ir);
+                iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
+            }
+        }
+        if (!imem)
+            imem = allocate_transient_render_memory(dev, iai.allocationSize, iai.memoryTypeIndex);
+        vkBindImageMemory(dev, img, imem, 0);
+        VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+        ivci.image = img; ivci.viewType = VK_IMAGE_VIEW_TYPE_2D; ivci.format = FMT;
+        ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        vkCreateImageView(dev, &ivci, nullptr, &view);
+        if (cached_color) {
+            cached_color->image = img;
+            cached_color->memory = imem;
+            cached_color->view = view;
+        }
+    }
+    const bool load_cached_color = cached_color && cached_color->valid &&
+                                   color_target->load_existing && !seed_rgba;
+    if (cached_color) {
+        ++color_target_stats.writes;
+        color_target_stats.write_hits = load_cached_color ? 1 : 0;
+    }
 
     if (use_ds && !dimg) {
         VkImageCreateInfo dci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -933,13 +1126,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
 
     VkAttachmentDescription att[2]{};
     att[0].format = FMT; att[0].samples = VK_SAMPLE_COUNT_1_BIT;
-    // Seeded: the attachment already holds the preloaded pixels (uploaded before the pass below), so
-    // LOAD them instead of clearing, and declare the matching initial layout.
-    att[0].loadOp = seed_rgba ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
+    // Seeded or persistent: the attachment already holds valid pixels before this pass, so LOAD them.
+    att[0].loadOp = (seed_rgba || load_cached_color) ? VK_ATTACHMENT_LOAD_OP_LOAD
+                                                     : VK_ATTACHMENT_LOAD_OP_CLEAR;
     att[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     att[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE; att[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    att[0].initialLayout = seed_rgba ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
-    att[0].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    att[0].initialLayout = (seed_rgba || load_cached_color)
+        ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+    att[0].finalLayout = persistent_color ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+                                          : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     att[1].format = DFMT; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
     // A guest-identified DS surface survives calls. New attachments get a defined initial value;
     // existing ones LOAD. Explicit DB_RENDER_CONTROL clears execute at their draw below, preserving
@@ -991,16 +1186,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     };
     struct TextureUploadKey {
         const uint8_t* pixels = nullptr;
+        uint64_t render_target_id = 0;
         uint32_t width = 0, height = 0, depth = 1;
         uint32_t img_dim = 1;
         bool operator==(const TextureUploadKey& other) const {
-            return pixels == other.pixels && width == other.width && height == other.height &&
-                   depth == other.depth && img_dim == other.img_dim;
+            return pixels == other.pixels && render_target_id == other.render_target_id &&
+                   width == other.width && height == other.height && depth == other.depth &&
+                   img_dim == other.img_dim;
         }
     };
     struct TextureUploadKeyHash {
         size_t operator()(const TextureUploadKey& key) const {
             size_t h = std::hash<const uint8_t*>{}(key.pixels);
+            h ^= std::hash<uint64_t>{}(key.render_target_id) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.width) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.height) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.depth) + 0x9e3779b9u + (h << 6) + (h >> 2);
@@ -1017,6 +1215,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         uint64_t persistent_id = 0;
         VkDeviceSize image_bytes = 0;
         bool persistent_hit = false;
+        bool borrowed_target = false;
         bool direct_memory = false;
     };
     struct PersistentTextureKey {
@@ -1237,7 +1436,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
                         : VK_SHADER_STAGE_FRAGMENT_BIT;
                     texture_references++;
-                    const TextureUploadKey texture_key{r.tex_rgba, r.tw, r.th, r.td, r.img_dim};
+                    const TextureUploadKey texture_key{
+                        r.tex_rgba, r.persistent_render_target_id, r.tw, r.th, r.td, r.img_dim};
                     size_t upload_index = SIZE_MAX;
                     if (share_texture_uploads) {
                         auto found = texture_upload_indices.find(texture_key);
@@ -1250,10 +1450,24 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         upload.key = texture_key;
                         if (share_texture_uploads) texture_upload_indices.emplace(texture_key, upload_index);
 
+                        const bool target_feedback = persistent_color &&
+                            r.persistent_render_target_id == color_target->persistent_id;
+                        if (persistent_color_targets_enabled && !target_feedback &&
+                            r.persistent_render_target_id && r.img_dim == 1) {
+                            if (auto* target = find_persistent_color_target(
+                                    r.persistent_render_target_id, r.tw, r.th, FMT)) {
+                                target->last_use = color_target_generation;
+                                upload.image = target->image;
+                                upload.image_bytes = target->bytes;
+                                upload.borrowed_target = true;
+                                ++color_target_stats.sampled_hits;
+                            }
+                        }
                         upload.persistent_id = r.persistent_texture_id;
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim};
-                        if (persistent_textures_enabled && r.persistent_texture_id) {
+                        if (!upload.borrowed_target && persistent_textures_enabled &&
+                            r.persistent_texture_id) {
                             auto cached = persistent_texture_images.find(persistent_key);
                             if (cached != persistent_texture_images.end()) {
                                 cached->second.last_use = texture_generation;
@@ -1266,7 +1480,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             }
                         }
 
-                        if (!upload.persistent_hit) {
+                        if (!upload.persistent_hit && !upload.borrowed_target) {
                             VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
                             const bool texture_3d = r.img_dim == 2;
                             tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
@@ -1586,10 +1800,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     VkDeviceSize bytes = (VkDeviceSize)W * H * 4;
-    VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; bci.size = bytes; bci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    VkBuffer rb; vkCreateBuffer(dev, &bci, nullptr, &rb);
-    VkMemoryRequirements br; vkGetBufferMemoryRequirements(dev, rb, &br);
-    VkMemoryAllocateInfo bai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; bai.allocationSize = br.size;
+    const bool readback_requested = !persistent_color || color_target->readback;
+    VkBuffer rb = VK_NULL_HANDLE;
+    VkDeviceMemory bmem = VK_NULL_HANDLE;
+    if (readback_requested) {
+        VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        bci.size = bytes; bci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        vkCreateBuffer(dev, &bci, nullptr, &rb);
+        VkMemoryRequirements br; vkGetBufferMemoryRequirements(dev, rb, &br);
+        VkMemoryAllocateInfo bai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; bai.allocationSize = br.size;
     // Prefer cached host memory for GPU -> CPU readback. Discrete NVIDIA exposes an earlier coherent,
     // write-combined BAR type and a later HOST_CACHED type; the generic first-match selector chose the
     // former, making an 8 MiB 1080p read take roughly 570 ms on Windows. Upload buffers deliberately keep
@@ -1597,12 +1816,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // back to the original required flags.
     constexpr VkMemoryPropertyFlags host_coherent =
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
-    if (bai.memoryTypeIndex == UINT32_MAX)
-        bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent);
-    VkDeviceMemory bmem = allocate_transient_render_memory(dev, bai.allocationSize,
-                                                            bai.memoryTypeIndex);
-    vkBindBufferMemory(dev, rb, bmem, 0);
+        bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+        if (bai.memoryTypeIndex == UINT32_MAX)
+            bai.memoryTypeIndex = pick(br.memoryTypeBits, host_coherent);
+        bmem = allocate_transient_render_memory(dev, bai.allocationSize, bai.memoryTypeIndex);
+        vkBindBufferMemory(dev, rb, bmem, 0);
+    }
 
     VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO}; pci.queueFamilyIndex = qfi;
     VkCommandPool pool; vkCreateCommandPool(dev, &pci, nullptr, &pool);
@@ -1611,6 +1830,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkCommandBuffer cmd; vkAllocateCommandBuffers(dev, &cbai, &cmd);
     VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(cmd, &cbbi);
+    if (load_cached_color) {
+        VkImageMemoryBarrier load{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        load.oldLayout = cached_color->layout;
+        load.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        load.image = img;
+        load.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        load.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
+        load.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &load);
+    }
     // Preload the color attachment with the seed pixels (render-target persistence): staging upload +
     // transition to COLOR_ATTACHMENT_OPTIMAL, matching att[0]'s LOAD/initialLayout above.
     VkBuffer seedbuf = VK_NULL_HANDLE; VkDeviceMemory seedmem = VK_NULL_HANDLE;
@@ -1706,8 +1941,37 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
     }
     vkCmdEndRenderPass(cmd);
-    VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {W, H, 1};
-    vkCmdCopyImageToBuffer(cmd, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
+    if (readback_requested) {
+        if (persistent_color) {
+            VkImageMemoryBarrier to_readback{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            to_readback.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            to_readback.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            to_readback.image = img;
+            to_readback.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            to_readback.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            to_readback.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 0, 0, nullptr, 0, nullptr, 1, &to_readback);
+        }
+        VkBufferImageCopy cp{};
+        cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        cp.imageExtent = {W, H, 1};
+        vkCmdCopyImageToBuffer(cmd, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
+        if (persistent_color) {
+            VkImageMemoryBarrier to_sample{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            to_sample.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            to_sample.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            to_sample.image = img;
+            to_sample.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            to_sample.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            to_sample.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                     VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                                 0, 0, nullptr, 0, nullptr, 1, &to_sample);
+        }
+    }
     vkEndCommandBuffer(cmd);
     const auto timing_recorded = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount = 1; si.pCommandBuffers = &cmd;
@@ -1719,13 +1983,20 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         cached_ds->depth_valid |= use_depth && depth_used_meaningfully;
         cached_ds->stencil_valid |= use_stencil;
     }
+    if (cached_color) {
+        cached_color->valid = true;
+        cached_color->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
 
-    void* mp = nullptr; vkMapMemory(dev, bmem, 0, bytes, 0, &mp);
-    const auto* readback = static_cast<const uint8_t*>(mp);
-    // A range assignment constructs directly from the mapped pixels. resize()+memcpy first zeroed the
-    // entire 8.3 MiB 1080p vector even though every byte was immediately overwritten.
-    out.assign(readback, readback + static_cast<size_t>(bytes));
-    vkUnmapMemory(dev, bmem);
+    if (readback_requested) {
+        void* mp = nullptr; vkMapMemory(dev, bmem, 0, bytes, 0, &mp);
+        const auto* readback = static_cast<const uint8_t*>(mp);
+        // A range assignment constructs directly from the mapped pixels. resize()+memcpy first zeroed the
+        // entire 8.3 MiB 1080p vector even though every byte was immediately overwritten.
+        out.assign(readback, readback + static_cast<size_t>(bytes));
+        vkUnmapMemory(dev, bmem);
+        color_target_stats.readbacks = persistent_color ? 1 : 0;
+    }
     const auto timing_readback_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
 
     // PROSPER_DRAW_ISO + PROSPER_ISO_AT="x,y": per-draw kill isolation (generalizes the #240 title harness
@@ -1863,7 +2134,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     while (persistent_texture_bytes > persistent_texture_limit && evict_persistent_texture()) {}
     texture_stats.persistent_cached_bytes = persistent_texture_bytes;
     for (auto& upload : texture_uploads) {
-        if (upload.image && !upload.persistent_hit) vkDestroyImage(dev, upload.image, nullptr);
+        if (upload.image && !upload.persistent_hit && !upload.borrowed_target)
+            vkDestroyImage(dev, upload.image, nullptr);
         if (upload.memory) {
             if (upload.direct_memory) vkFreeMemory(dev, upload.memory, nullptr);
             else release_transient_render_memory(dev, upload.memory);
@@ -1874,13 +2146,23 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     }
     if (seedbuf) vkDestroyBuffer(dev, seedbuf, nullptr);
     if (seedmem) release_transient_render_memory(dev, seedmem);
-    vkDestroyBuffer(dev, rb, nullptr); release_transient_render_memory(dev, bmem);
-    vkDestroyFramebuffer(dev, fb, nullptr); vkDestroyRenderPass(dev, rp, nullptr); vkDestroyImageView(dev, view, nullptr);
-    vkDestroyImage(dev, img, nullptr); release_transient_render_memory(dev, imem);
+    if (rb) vkDestroyBuffer(dev, rb, nullptr);
+    if (bmem) release_transient_render_memory(dev, bmem);
+    vkDestroyFramebuffer(dev, fb, nullptr); vkDestroyRenderPass(dev, rp, nullptr);
+    if (!cached_color) {
+        vkDestroyImageView(dev, view, nullptr);
+        vkDestroyImage(dev, img, nullptr);
+        release_transient_render_memory(dev, imem);
+    }
     if (use_ds && !cached_ds) {
         vkDestroyImageView(dev, dview, nullptr); vkDestroyImage(dev, dimg, nullptr);
         release_transient_render_memory(dev, dmem);
     }
+    while ((persistent_color_target_cache().size() > 64 ||
+            persistent_color_target_bytes() > persistent_color_target_limit()) &&
+           evict_persistent_color_target(ctx, color_target_generation)) {}
+    color_target_stats.cached_bytes = persistent_color_target_bytes();
+    color_target_stats.cached_entries = persistent_color_target_cache().size();
     if (timing_enabled) {
         const auto timing_done = TimingClock::now();
         auto ms = [](auto begin, auto end) {

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -178,6 +178,99 @@ int main() {
               "a new content version uploads and renders its changed pixels");
     }
 
+    // A guest color target can remain on the backend GPU between render calls and be sampled by
+    // exact identity. Compare that path with the established CPU readback+upload route, then prove
+    // a LOADing second pass can skip readback without changing the eventual sampled pixels.
+    {
+        static const uint32_t kRedPs[] = {
+            0x7E0002F2u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+            0xF800180Fu, 0x03020100u, 0xBF810000u};
+        static const uint32_t kGreenPs[] = {
+            0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,
+            0xF800180Fu, 0x03020100u, 0xBF810000u};
+        std::vector<uint32_t> red = recompile_fragment(
+            kRedPs, sizeof(kRedPs) / sizeof(kRedPs[0]), nullptr);
+        std::vector<uint32_t> green = recompile_fragment(
+            kGreenPs, sizeof(kGreenPs) / sizeof(kGreenPs[0]), nullptr);
+        std::vector<uint32_t> sample_ps(
+            ps_template, ps_template + sizeof(ps_template) / sizeof(ps_template[0]));
+        sample_ps[1] = C025; sample_ps[3] = C025;
+        std::vector<uint32_t> sample = recompile_fragment(
+            sample_ps.data(), sample_ps.size(), &rt);
+
+        ResolvedPipelineState opaque{};
+        opaque.topology = 3; opaque.color_write_mask = 0xF;
+        ResolvedPipelineState additive = opaque;
+        additive.blend_enable = true;
+        additive.src_color_blend_factor = 1; // ONE
+        additive.dst_color_blend_factor = 1; // ONE
+        additive.color_blend_op = 0;         // ADD
+
+        prosper::test::BackendDraw producer;
+        producer.vs = vert; producer.fs = red; producer.ps = &opaque; producer.vcount = 3;
+        constexpr uint64_t target_id = 0x7590000000000001ull;
+        prosper::test::BackendColorTarget first_target{target_id, false, true};
+        std::vector<uint8_t> first = prosper::test::render_draws_rgba(
+            {producer}, W, H, nullptr, nullptr, false, &first_target);
+        const auto first_target_stats = prosper::test::backend_color_target_stats();
+        CHECK(first.size() == (size_t)W * H * 4 && first_target_stats.writes == 1 &&
+                  first_target_stats.write_hits == 0 && first_target_stats.readbacks == 1,
+              "first persistent color-target write materializes its requested CPU result");
+
+        prosper::test::FrameResource cpu_resource;
+        cpu_resource.binding = 4; cpu_resource.set = 1;
+        cpu_resource.tex_rgba = first.data(); cpu_resource.tw = W; cpu_resource.th = H;
+        prosper::test::BackendDraw cpu_sample;
+        cpu_sample.vs = vert; cpu_sample.fs = sample; cpu_sample.R = {cpu_resource};
+        cpu_sample.vcount = 3;
+        std::vector<uint8_t> cpu_roundtrip = prosper::test::render_draws_rgba(
+            {cpu_sample}, W, H);
+
+        prosper::test::FrameResource gpu_resource = cpu_resource;
+        gpu_resource.tex_rgba = nullptr;
+        gpu_resource.persistent_render_target_id = target_id;
+        prosper::test::BackendDraw gpu_sample = cpu_sample;
+        gpu_sample.R = {gpu_resource};
+        std::vector<uint8_t> gpu_resident = prosper::test::render_draws_rgba(
+            {gpu_sample}, W, H);
+        const auto sampled_stats = prosper::test::backend_color_target_stats();
+        CHECK(!gpu_resident.empty() && gpu_resident == cpu_roundtrip &&
+                  sampled_stats.sampled_hits == 1,
+              "GPU-resident target sampling matches CPU readback+upload byte-for-byte");
+
+        prosper::test::BackendDraw add_green;
+        add_green.vs = vert; add_green.fs = green; add_green.ps = &additive;
+        add_green.vcount = 3;
+        std::vector<uint8_t> cpu_accumulated = prosper::test::render_draws_rgba(
+            {add_green}, W, H, first.data());
+        cpu_resource.tex_rgba = cpu_accumulated.data();
+        cpu_sample.R = {cpu_resource};
+        std::vector<uint8_t> cpu_accumulated_sample = prosper::test::render_draws_rgba(
+            {cpu_sample}, W, H);
+
+        prosper::test::BackendColorTarget deferred_target{target_id, true, false};
+        std::vector<uint8_t> deferred = prosper::test::render_draws_rgba(
+            {add_green}, W, H, nullptr, nullptr, false, &deferred_target);
+        const auto deferred_stats = prosper::test::backend_color_target_stats();
+        std::vector<uint8_t> deferred_sample = prosper::test::render_draws_rgba(
+            {gpu_sample}, W, H);
+        CHECK(deferred.empty() && deferred_stats.write_hits == 1 &&
+                  deferred_stats.readbacks == 0,
+              "persistent LOAD pass can complete without allocating a CPU readback");
+        CHECK(!deferred_sample.empty() && deferred_sample == cpu_accumulated_sample,
+              "deferred-readback accumulation matches the CPU reference after sampling");
+
+        prosper::test::invalidate_persistent_color_target(target_id);
+        gpu_resource.tex_rgba = cpu_accumulated.data();
+        gpu_sample.R = {gpu_resource};
+        std::vector<uint8_t> invalidated_fallback = prosper::test::render_draws_rgba(
+            {gpu_sample}, W, H);
+        const auto fallback_stats = prosper::test::backend_color_target_stats();
+        CHECK(fallback_stats.sampled_hits == 0 &&
+                  invalidated_fallback == cpu_accumulated_sample,
+              "invalidated GPU target uses the supplied CPU fallback instead of stale pixels");
+    }
+
     // The backend upload key includes depth and image dimensionality. Exercise a real 3D image here
     // so depth-1 3D resources cannot accidentally regress to a 2D Vulkan image/view during sharing.
     {


### PR DESCRIPTION
## Summary

- retain exact RGBA8 color targets in a bounded Vulkan cache and bind matching producer images directly when later graphics passes sample them
- defer CPU readback for proven non-scanout intermediates while preserving presentation, capture, replay, diagnostic, size-conversion, and same-target-feedback fallbacks
- invalidate retained color targets on overlapping guest GPU writes and expose submit-aligned target residency/readback counters
- document the Dead Cells A/B and the remaining synchronous-boundary budget

The live integration is initially opt-in with `PROSPER_LIVE_PERSISTENT_COLOR_TARGETS=1`. `PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS=1` restores transient backend behavior, and `PROSPER_BACKEND_TARGET_CACHE_MB` controls the 256 MiB default budget.

## Correctness

`test_texture_sample_render` uses the same producer twice and requires:

- the first target write returns authoritative CPU pixels
- direct GPU producer-to-sampler output is byte-for-byte identical to CPU readback/upload
- a persistent LOAD pass completes without CPU readback and accumulates identically to the CPU reference
- an overlapping invalidation prevents sampling stale GPU pixels and uses the supplied CPU fallback

Live captures, replay seed/export modes, RTT pixel diagnostics, scanout targets, feedback, and fallback presentation retain the old CPU path. Mixed graphics/compute operation order is unchanged.

## Dead Cells evidence

A post-`PARSEALL` submit writes ten targets. The opt-in path directly samples eight and defers six readbacks, retaining 13 targets / 103.5 MiB. Against the same instrumented binary with retention disabled:

| Phase | CPU path | Persistent targets |
|---|---:|---:|
| Realized draws | 361 | 405 |
| Record/upload | 4.5 ms | 0.5 ms |
| Fence waits | 26.7 ms | 16.8 ms |
| Frontend Vulkan | 60.8 ms | 48.9 ms |
| Ordered backend | 118.6 ms | 110.7 ms |
| Whole submit | 154.2 ms | 151.1 ms |

The runs are animated and have different draw counts, so the phase counters are the mechanism evidence. The optimization does more work while completing slightly faster; it is a first architectural tranche, not a claim of playable performance.

## Validation

- `test_rdna2_to_spirv` passed after current-master/#762 integration
- `test_texture_sample_render` passed
- full Linux build + `ctest --output-on-failure`: 102/102 passed
- native Windows app build and controlled Dead Cells A/B

Fixes #759