### PR TITLE
hle: unblock Dead Cells level progression

### DIFF
--- a/prosper/docs/DEAD_CELLS_PROGRESSION_MATRIX.md
+++ b/prosper/docs/DEAD_CELLS_PROGRESSION_MATRIX.md
@@ -1,0 +1,67 @@
+# Dead Cells Progression Matrix
+
+Last updated: 2026-07-15
+
+This matrix separates guest progression from renderer output and frontend behavior. It exists because a
+native-speed or sampled-render run reaching `PrisonStart` does not prove that the full synchronous renderer
+reaches the same state. Track the current full-render stall in
+[#723](https://github.com/mattias800/ps5ys/issues/723).
+
+## Run It
+
+Build `boot_trace`, `prosper-app`, and `gpu_timeline` from one commit, then run in native Windows PowerShell:
+
+```powershell
+cmake --build prosper/build-mingw-app --target boot_trace prosper-app gpu_timeline -j 8
+prosper/scripts/dead-cells/progression-matrix.ps1
+```
+
+Use `-Mode headless-full` to run one row, `-BuildDir PATH` for another build, and `-OutputDir PATH` to retain
+evidence at a chosen location. Every row gets a fresh save root, pad log, progress heartbeat, GPU timeline,
+stdout/stderr logs, and an offline selector for the current gameplay semantic signature:
+
+```text
+target 738x420, target draw index 80:82, total draws 91:93, dispatches 8
+```
+
+The script writes `summary.json`. A selector match proves that the guest submitted the known gameplay-shaped
+work; it does not by itself prove correct pixels. New image baselines still require human inspection.
+
+## Rows And Semantics
+
+| Row | Graphics work | Publication | Frontend | Correctness use |
+| --- | --- | --- | --- | --- |
+| `headless-full` | Every retained draw and dispatch | Every completed frame | `boot_trace`, paced silent audio | Full-render reference |
+| `app-full` | Every retained draw and dispatch | Every completed frame | SDL video/audio/input | Compare frontend-only behavior |
+| `headless-publish-10` | Every retained draw and dispatch | One in ten completed frames | `boot_trace` | Isolate publication/presentation pressure |
+| `headless-render-every-10` | One in ten graphics submits; compute still runs | Every rendered frame | `boot_trace` | Diagnostic only |
+| `headless-no-graphics` | No graphics backend; compute still runs | None | `boot_trace` | Guest/HLE progression diagnostic only |
+
+`headless-full` and `app-full` share the loader, HLE, command folding, live renderer, and synchronous GPU
+execution. Their intended differences are SDL window/swapchain consumption, real audio output, physical input,
+and platform-dialog integration. They should reach the same semantic state under the same scripted input.
+
+`PROSPER_PRESENT_EVERY=N` changes only `present_write_frame`: the live renderer executes every selected submit,
+persistent render targets advance normally, and a valid output frame is simply not published on suppressed
+iterations. This is the safe row for asking whether frontend publication is responsible for a progression
+difference. It is not expected to improve a workload dominated by synchronous Vulkan execution or readback.
+
+`PROSPER_RENDER_EVERY=N` is fundamentally different. On unselected draw submits it skips graphics realization
+and Vulkan execution, while separately executing retained compute dispatches. It can change temporal render
+targets, synchronization pressure, guest pacing, and frame-count timing. Never treat it as a correctness oracle.
+The no-graphics row is even less representative; it is useful only to show that guest/HLE logic can progress
+when synchronous graphics work is absent. Both diagnostic rows use the capture-safe route whose Circle hold lasts
+through 300 seconds, so a slow transition cannot outlive the scripted skip input.
+
+## Interpreting Divergence
+
+1. If `headless-full` and `app-full` diverge, investigate frontend audio/input/dialog/presentation behavior.
+2. If both full rows stall but `headless-publish-10` progresses, publication or frontend frame consumption is
+   implicated even though GPU execution is unchanged.
+3. If all full-execution rows stall while sampled/no-graphics rows progress, the boundary is synchronous GPU
+   execution, guest pacing, or completion ordering. Skipping graphics has not proven a rendering bug.
+4. Compare the first `Loading level PrisonStart`, `PARSEALL TOOK`, last `[progress]`, and semantic selector match.
+   Do not infer a deadlock solely from a low FPS counter.
+
+`boot_trace` historically wrote periodic BMPs whenever `PROSPER_RENDER=1`; the matrix sets
+`PROSPER_NO_FRAME_DUMPS=1` so headless-full is not penalized by tool-only disk I/O.

--- a/prosper/docs/DEAD_CELLS_PROGRESSION_MATRIX.md
+++ b/prosper/docs/DEAD_CELLS_PROGRESSION_MATRIX.md
@@ -5,7 +5,8 @@ Last updated: 2026-07-15
 This matrix separates guest progression from renderer output and frontend behavior. It exists because a
 native-speed or sampled-render run reaching `PrisonStart` does not prove that the full synchronous renderer
 reaches the same state. Track the current full-render stall in
-[#723](https://github.com/mattias800/ps5ys/issues/723).
+[#723](https://github.com/mattias800/ps5ys/issues/723) and the native-Windows render-disabled divergence in
+[#768](https://github.com/mattias800/ps5ys/issues/768).
 
 ## Run It
 
@@ -18,14 +19,29 @@ prosper/scripts/dead-cells/progression-matrix.ps1
 
 Use `-Mode headless-full` to run one row, `-BuildDir PATH` for another build, and `-OutputDir PATH` to retain
 evidence at a chosen location. Every row gets a fresh save root, pad log, progress heartbeat, GPU timeline,
-stdout/stderr logs, and an offline selector for the current gameplay semantic signature:
+stdout/stderr logs, and an offline selector for the current native-Windows gameplay semantic signature:
 
 ```text
-target 738x420, target draw index 80:82, total draws 91:93, dispatches 8
+target 636x420, target draw index 77:85, total draws 91:94, dispatches 8
 ```
 
-The script writes `summary.json`. A selector match proves that the guest submitted the known gameplay-shaped
+The script writes `summary.json`. `termination=timeout_killed` means the row remained alive until the configured
+observation window and was intentionally stopped; its `exit_code` may therefore be null. `termination=process_exit`
+retains the real process exit code. A selector match proves that the guest submitted the known gameplay-shaped
 work; it does not by itself prove correct pixels. New image baselines still require human inspection.
+
+The matrix is deliberately a native-Windows runner. Compare it with a WSL/Linux run from the same source tree
+before describing a failed no-graphics row as a code regression. On 2026-07-15 the exact tree that remained in a
+native-Windows 378-draw loading workload reached the sustained 92-94 draw / 8-dispatch gameplay signature under
+WSL. A source bisect that mixed those hosts produced a false first-bad result. The host split was subsequently
+root-caused to `sceSaveDataDialogUpdateStatus`: returning generic success meant status `NONE`, which Dead Cells
+polled forever. The lifecycle HLE in #768 restores native-Windows progression in the no-GPU-work control.
+
+Post-#767/#769 validation on 2026-07-15 reached the selector in both native-Windows diagnostic rows. With compute
+disabled, the first match was at 28.35 seconds and the 38-second run contained 1,104 matches. With live compute
+enabled, the first match was at 30.67 seconds and the run remained alive through the same timeout. This establishes
+that SaveDataDialog progression is independent of rendering, while current compute execution no longer exits at
+its first live dispatch. It does not resolve the full synchronous-render throughput problem tracked by #723.
 
 ## Rows And Semantics
 
@@ -36,6 +52,7 @@ work; it does not by itself prove correct pixels. New image baselines still requ
 | `headless-publish-10` | Every retained draw and dispatch | One in ten completed frames | `boot_trace` | Isolate publication/presentation pressure |
 | `headless-render-every-10` | One in ten graphics submits; compute still runs | Every rendered frame | `boot_trace` | Diagnostic only |
 | `headless-no-graphics` | No graphics backend; compute still runs | None | `boot_trace` | Guest/HLE progression diagnostic only |
+| `headless-no-gpu-work` | No graphics or compute execution | None | `boot_trace` | Separate compute throughput from guest/HLE progression |
 
 `headless-full` and `app-full` share the loader, HLE, command folding, live renderer, and synchronous GPU
 execution. Their intended differences are SDL window/swapchain consumption, real audio output, physical input,
@@ -50,8 +67,13 @@ difference. It is not expected to improve a workload dominated by synchronous Vu
 and Vulkan execution, while separately executing retained compute dispatches. It can change temporal render
 targets, synchronization pressure, guest pacing, and frame-count timing. Never treat it as a correctness oracle.
 The no-graphics row is even less representative; it is useful only to show that guest/HLE logic can progress
-when synchronous graphics work is absent. Both diagnostic rows use the capture-safe route whose Circle hold lasts
+when synchronous graphics work is absent. These diagnostic rows use the capture-safe route whose Circle hold lasts
 through 300 seconds, so a slow transition cannot outlive the scripted skip input.
+
+`headless-no-gpu-work` additionally sets `PROSPER_NO_COMPUTE=1`. The timeline still records semantic dispatches,
+but their writes do not occur. This row is not a correctness oracle: use it only when `headless-no-graphics`
+remains slow or stuck and the question is whether synchronous compute throughput is consuming the guest submit
+thread. If it progresses, repeat with compute enabled before blaming a non-GPU HLE contract.
 
 ## Interpreting Divergence
 
@@ -60,8 +82,12 @@ through 300 seconds, so a slow transition cannot outlive the scripted skip input
    implicated even though GPU execution is unchanged.
 3. If all full-execution rows stall while sampled/no-graphics rows progress, the boundary is synchronous GPU
    execution, guest pacing, or completion ordering. Skipping graphics has not proven a rendering bug.
-4. Compare the first `Loading level PrisonStart`, `PARSEALL TOOK`, last `[progress]`, and semantic selector match.
+4. If `headless-no-gpu-work` progresses but `headless-no-graphics` does not, isolate live compute cost or side
+   effects before investigating unrelated guest synchronization.
+5. Compare the first `Loading level PrisonStart`, `PARSEALL TOOK`, last `[progress]`, and semantic selector match.
    Do not infer a deadlock solely from a low FPS counter.
+6. If native Windows fails even in `headless-no-graphics`, compare the same source under WSL/Linux. #768 is the
+   reference example: a system-dialog HLE poll looked like an endless loading render loop.
 
 `boot_trace` historically wrote periodic BMPs whenever `PROSPER_RENDER=1`; the matrix sets
 `PROSPER_NO_FRAME_DUMPS=1` so headless-full is not penalized by tool-only disk I/O.

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -8,16 +8,19 @@ The operational route and selector reference is
 checkpoint recipe as a regression and future-investigation workflow.
 The current full-render progression investigation and its behavior-equivalence rows are documented in
 [`DEAD_CELLS_PROGRESSION_MATRIX.md`](DEAD_CELLS_PROGRESSION_MATRIX.md) and tracked by
-[#723](https://github.com/mattias800/ps5ys/issues/723).
+[#723](https://github.com/mattias800/ps5ys/issues/723). The former native-Windows render-disabled divergence is
+tracked by [#768](https://github.com/mattias800/ps5ys/issues/768).
 
 ## Current state
 
-*Dead Cells* boots, passes the splash and menus, and loads `PrisonStart`. Native-speed and sampled-graphics routes
-reach the controllable Jump tutorial and have supplied full-color gameplay captures. The current full synchronous
-renderer reaches `Loading level PrisonStart` and completes `PARSEALL`, but remains on the loading screen under the
-measured timeout. Therefore "reaches gameplay" currently describes the diagnostic/sampled route and the renderer's
-ability to render a selected gameplay checkpoint, not end-to-end full-render app progression. Issue #723 owns that
-remaining behavior gap.
+*Dead Cells* boots, passes the splash and menus, and loads `PrisonStart`. WSL/Linux native-speed and sampled-graphics
+routes reach the controllable Jump tutorial and have supplied full-color gameplay captures. Native Windows now also
+reaches the sustained 92-94 draw / 8-dispatch gameplay state in the no-GPU-work progression control. #768's former
+356-390-draw loop was not a renderer stall: `sceSaveDataDialogUpdateStatus` was unimplemented and returned `NONE`
+more than a thousand times while the game waited for `FINISHED`. The separate full synchronous-render throughput
+and progression gap remains #723. After renderer PRs #767 and #769, the native-Windows compute-enabled,
+render-disabled control also reaches the sustained gameplay signature; its earlier first-dispatch process exit is
+not reproducible on current `master`.
 
 The scene renders in full color, including geometry, lighting, smoke, silhouettes, the player, terrain, effects,
 the tutorial prompt, and the HUD. The final grayscale-world root cause was the fragment recompiler selecting the

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -1,15 +1,24 @@
 # Dead Cells graphics status and regression workflow
 
-Last updated: 2026-07-14
+Last updated: 2026-07-15
 
 The operational route and selector reference is
 [`../scripts/dead-cells/README.md`](../scripts/dead-cells/README.md). The gameplay-composition bug
 [#566](https://github.com/mattias800/ps5ys/issues/566) was fixed by #626; this document retains the exact
 checkpoint recipe as a regression and future-investigation workflow.
+The current full-render progression investigation and its behavior-equivalence rows are documented in
+[`DEAD_CELLS_PROGRESSION_MATRIX.md`](DEAD_CELLS_PROGRESSION_MATRIX.md) and tracked by
+[#723](https://github.com/mattias800/ps5ys/issues/723).
 
 ## Current state
 
-*Dead Cells* boots, passes the splash and menus, loads `PrisonStart`, and reaches the controllable Jump tutorial.
+*Dead Cells* boots, passes the splash and menus, and loads `PrisonStart`. Native-speed and sampled-graphics routes
+reach the controllable Jump tutorial and have supplied full-color gameplay captures. The current full synchronous
+renderer reaches `Loading level PrisonStart` and completes `PARSEALL`, but remains on the loading screen under the
+measured timeout. Therefore "reaches gameplay" currently describes the diagnostic/sampled route and the renderer's
+ability to render a selected gameplay checkpoint, not end-to-end full-render app progression. Issue #723 owns that
+remaining behavior gap.
+
 The scene renders in full color, including geometry, lighting, smoke, silhouettes, the player, terrain, effects,
 the tutorial prompt, and the HUD. The final grayscale-world root cause was the fragment recompiler selecting the
 first color export from shaders that emit MRT3..MRT0; MRT0 now feeds the backend's single color attachment (#626).

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -9,6 +9,12 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
   --warmup-seconds 35 --seconds 1 --count 5 --timeout 65 --out shots
 ```
 
+For progression investigations, use
+[`progression-matrix.ps1`](progression-matrix.ps1) and read
+[`../../docs/DEAD_CELLS_PROGRESSION_MATRIX.md`](../../docs/DEAD_CELLS_PROGRESSION_MATRIX.md). It compares
+full-render headless and SDL-app runs against full-execution sparse publication, sampled graphics, and
+no-graphics diagnostics with isolated saves and the same semantic gameplay selector.
+
 ## Routes
 
 - `reach-first-gameplay.pad`: selects Play/slot 1, starts `PrisonStart`, and
@@ -22,7 +28,9 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
   warmup. Circle remains held through 240 seconds because synchronous rendering
   has made `PARSEALL` take from about 60 to more than 160 seconds across measured
   builds. The route now survives that throughput variance, but the gameplay
-  snapshot baseline remains pending until its retained frames are reviewed.
+  snapshot baseline remains pending until its retained frames are reviewed. Current master reaches
+  `PrisonStart` and finishes `PARSEALL`, but the full synchronous-render route remains on the loading
+  screen under the measured timeout (#723); do not conflate it with the sampled route below.
 - `reach-first-gameplay-capture.pad`: uses the same menu input but holds Circle from
   28 through 300 seconds. Use it when synchronous timeline/bundle capture begins during
   level loading; the ordinary six-second hold can expire while capture stalls GPU progress.

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -19,7 +19,8 @@ no-graphics diagnostics with isolated saves and the same semantic gameplay selec
 
 - `reach-first-gameplay.pad`: selects Play/slot 1, starts `PrisonStart`, and
   holds Circle through the skippable opening. It was verified from fresh save
-  roots on current master and reaches the controllable Jump tutorial. The
+  roots under WSL/Linux and native Windows and reaches the controllable Jump tutorial. The former Windows-only
+  post-`PARSEALL` wait was the SaveDataDialog lifecycle bug tracked in #768. The
   route is wall-clock anchored because Dead Cells submits tens of thousands of
   loading flips before the menu.
 - `reach-first-gameplay-full-render.pad`: performs the same route with input
@@ -64,7 +65,7 @@ and the full HUD. Nearby cinematic and transition captures were outside this con
 
 Treat that conjunction as a preserved-capture recipe only.
 
-### Current timeline-v6 checkpoint (#594)
+### Historical WSL timeline-v6 checkpoint (#594)
 
 Two independent 90-second native-speed routes selected sustained gameplay from about 29.5 seconds onward with
 this conjunction, despite different submit ordinals:
@@ -88,6 +89,18 @@ large capsule or bundle:
 
 The adjacent target indices 79 and 83, exact 90-draw count, and dispatch counts 7 and 9 all produced zero
 matches. The live selector reproduced the offline result and installed a gameplay capsule at its first match.
+
+### Current native-Windows progression checkpoint (#768)
+
+Current native-Windows timelines use a different target layout from the historical WSL capture. The progression
+matrix selects the sustained gameplay workload with:
+
+```text
+target 636x420, target draw index 77:85, total draws 91:94, dispatches 8
+```
+
+On current `master` this selector matches with live compute enabled and disabled. It is a semantic progression
+check only, not a pixel oracle; use the inspected full-render snapshot workflow for visual regression decisions.
 
 The faithful playable reference on #608 retained 883 submits; its `5759c125812154dc` hash is historical to the
 pre-#611/#615 renderer. A two-submit color-bounded replay still renders `71b84bdfae53933c`. Use

--- a/prosper/scripts/dead-cells/progression-matrix.ps1
+++ b/prosper/scripts/dead-cells/progression-matrix.ps1
@@ -1,0 +1,209 @@
+[CmdletBinding()]
+param(
+    [string]$Dump = 'C:\Users\matti\repos\ps5ys\PPSA15552-app0',
+    [string]$BuildDir,
+    [string]$OutputDir,
+    [ValidateSet('all', 'headless-full', 'app-full', 'headless-publish-10',
+                 'headless-render-every-10', 'headless-no-graphics')]
+    [string]$Mode = 'all',
+    [int]$FullTimeoutSeconds = 240,
+    [int]$FastTimeoutSeconds = 90
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows -and $PSVersionTable.PSEdition -eq 'Core') {
+    throw 'progression-matrix.ps1 must run in native Windows PowerShell.'
+}
+
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\..'))
+$prosperRoot = Join-Path $repoRoot 'prosper'
+if (-not $BuildDir) { $BuildDir = Join-Path $prosperRoot 'build-mingw-app' }
+$BuildDir = [IO.Path]::GetFullPath($BuildDir)
+$Dump = (Resolve-Path -LiteralPath $Dump).Path
+
+if (-not $OutputDir) {
+    $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $OutputDir = Join-Path $env:TEMP "prosper-dead-cells-matrix-$stamp"
+}
+$OutputDir = [IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+$bootTrace = Join-Path $BuildDir 'boot_trace.exe'
+$app = Join-Path $BuildDir 'prosper-app.exe'
+$timelineTool = Join-Path $BuildDir 'gpu_timeline.exe'
+foreach ($binary in @($bootTrace, $app)) {
+    if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+        throw "Required binary was not found: $binary"
+    }
+}
+
+$fullRoute = [IO.Path]::GetFullPath(
+    (Join-Path $PSScriptRoot 'reach-first-gameplay-full-render.pad'))
+$captureRoute = [IO.Path]::GetFullPath(
+    (Join-Path $PSScriptRoot 'reach-first-gameplay-capture.pad'))
+
+$controlledEnvironment = @(
+    'PROSPER_CAPTURE_TITLE', 'PROSPER_GUEST_FS', 'PROSPER_GUEST_ARGS',
+    'PROSPER_PAD_SCRIPT', 'PROSPER_PAD_SCRIPT_LOG', 'PROSPER_SAVEDATA_DIR',
+    'PROSPER_PROGRESS', 'PROSPER_GPU_TIMELINE', 'PROSPER_RENDER',
+    'PROSPER_NO_FRAME_DUMPS', 'PROSPER_PRESENT_EVERY', 'PROSPER_RENDER_EVERY',
+    'PROSPER_RENDER_EVERY_FOR_MS', 'PROSPER_RENDER_DELAY_MS', 'PROSPER_RENDER_FIRST',
+    'PROSPER_RENDER_TIMING', 'PROSPER_FRAME_DIR'
+)
+$savedEnvironment = @{}
+foreach ($name in $controlledEnvironment) {
+    $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+}
+
+function Reset-ControlledEnvironment {
+    foreach ($name in $controlledEnvironment) {
+        [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+    }
+}
+
+function Set-RunEnvironment {
+    param($Spec, [string]$RunDir, [string]$Timeline)
+
+    Reset-ControlledEnvironment
+    $common = @{
+        PROSPER_CAPTURE_TITLE = 'PPSA15552'
+        PROSPER_GUEST_FS = '1'
+        PROSPER_GUEST_ARGS = ''
+        PROSPER_PAD_SCRIPT = "@$($Spec.Route)"
+        PROSPER_PAD_SCRIPT_LOG = '1'
+        PROSPER_SAVEDATA_DIR = (Join-Path $RunDir 'savedata')
+        PROSPER_PROGRESS = '2'
+        PROSPER_GPU_TIMELINE = $Timeline
+    }
+    foreach ($entry in $common.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process')
+    }
+    foreach ($entry in $Spec.Environment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process')
+    }
+    New-Item -ItemType Directory -Path $common.PROSPER_SAVEDATA_DIR -Force | Out-Null
+}
+
+function Get-LastMatch {
+    param([string[]]$Paths, [string]$Pattern)
+    $matches = Select-String -Path $Paths -Pattern $Pattern -ErrorAction SilentlyContinue
+    if ($matches) { return $matches[-1].Line.Trim() }
+    return ''
+}
+
+$specs = @(
+    [pscustomobject]@{
+        Name = 'headless-full'; Program = $bootTrace; Route = $fullRoute
+        Timeout = $FullTimeoutSeconds
+        Environment = @{ PROSPER_RENDER = '1'; PROSPER_NO_FRAME_DUMPS = '1' }
+        Meaning = 'Full GPU execution and publication through boot_trace.'
+    },
+    [pscustomobject]@{
+        Name = 'app-full'; Program = $app; Route = $fullRoute
+        Timeout = $FullTimeoutSeconds
+        Environment = @{ PROSPER_RENDER = '1' }
+        Meaning = 'Full GPU execution/publication through SDL video, audio, and input frontend.'
+    },
+    [pscustomobject]@{
+        Name = 'headless-publish-10'; Program = $bootTrace; Route = $fullRoute
+        Timeout = $FullTimeoutSeconds
+        Environment = @{
+            PROSPER_RENDER = '1'; PROSPER_NO_FRAME_DUMPS = '1'; PROSPER_PRESENT_EVERY = '10'
+        }
+        Meaning = 'Full GPU execution; publish only one in ten completed frames.'
+    },
+    [pscustomobject]@{
+        Name = 'headless-render-every-10'; Program = $bootTrace; Route = $captureRoute
+        Timeout = $FastTimeoutSeconds
+        Environment = @{
+            PROSPER_RENDER = '1'; PROSPER_NO_FRAME_DUMPS = '1'; PROSPER_RENDER_EVERY = '10'
+        }
+        Meaning = 'Diagnostic: skip graphics execution on nine in ten draw submits.'
+    },
+    [pscustomobject]@{
+        Name = 'headless-no-graphics'; Program = $bootTrace; Route = $captureRoute
+        Timeout = $FastTimeoutSeconds
+        Environment = @{}
+        Meaning = 'Diagnostic: no graphics backend; retained compute still executes.'
+    }
+)
+if ($Mode -ne 'all') { $specs = @($specs | Where-Object Name -eq $Mode) }
+
+$results = @()
+try {
+    foreach ($spec in $specs) {
+        $runDir = Join-Path $OutputDir $spec.Name
+        New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+        $stdout = Join-Path $runDir 'stdout.log'
+        $stderr = Join-Path $runDir 'stderr.log'
+        $timeline = Join-Path $runDir 'run.prgtl'
+        Set-RunEnvironment $spec $runDir $timeline
+
+        $arguments = if ($spec.Program -eq $app) { @('--dump', $Dump) } else { @($Dump) }
+        Write-Host "[$($spec.Name)] $($spec.Meaning)"
+        $started = Get-Date
+        $process = Start-Process -FilePath $spec.Program -ArgumentList $arguments -PassThru `
+            -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+        $completed = $process.WaitForExit($spec.Timeout * 1000)
+        if (-not $completed) {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            $process.WaitForExit()
+        }
+        $elapsed = [Math]::Round(((Get-Date) - $started).TotalSeconds, 1)
+        $paths = @($stdout, $stderr)
+
+        $selectorOutput = ''
+        $selectorExit = $null
+        if ((Test-Path -LiteralPath $timeline -PathType Leaf) -and
+            (Test-Path -LiteralPath $timelineTool -PathType Leaf)) {
+            $selectorStdout = Join-Path $runDir 'selector.stdout.log'
+            $selectorStderr = Join-Path $runDir 'selector.stderr.log'
+            $selectorProcess = Start-Process -FilePath $timelineTool -ArgumentList @(
+                $timeline, '--select', '738x420', '80:82', '91:93', '8'
+            ) -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $selectorStdout `
+                -RedirectStandardError $selectorStderr
+            $selectorExit = $selectorProcess.ExitCode
+            $selectorLines = @()
+            if (Test-Path -LiteralPath $selectorStdout) {
+                $selectorLines += Get-Content -LiteralPath $selectorStdout
+            }
+            if (Test-Path -LiteralPath $selectorStderr) {
+                $selectorLines += Get-Content -LiteralPath $selectorStderr
+            }
+            $selectorOutput = ($selectorLines -join [Environment]::NewLine).Trim()
+            $selectorLines | Set-Content -LiteralPath (Join-Path $runDir 'selector.log')
+        }
+
+        $result = [pscustomobject]@{
+            mode = $spec.Name
+            meaning = $spec.Meaning
+            timed_out = -not $completed
+            exit_code = if ($completed) { $process.ExitCode } else { $null }
+            elapsed_seconds = $elapsed
+            loading_level = Get-LastMatch $paths 'Loading level PrisonStart'
+            parseall = Get-LastMatch $paths 'PARSEALL TOOK'
+            last_progress = Get-LastMatch $paths '^\[progress\]'
+            semantic_selector_exit = $selectorExit
+            semantic_selector = $selectorOutput
+            run_dir = $runDir
+        }
+        $results += $result
+        Write-Host "[$($spec.Name)] timeout=$($result.timed_out) elapsed=${elapsed}s"
+        if ($result.loading_level) { Write-Host "  $($result.loading_level)" }
+        if ($result.parseall) { Write-Host "  $($result.parseall)" }
+        if ($result.last_progress) { Write-Host "  $($result.last_progress)" }
+        if ($selectorOutput) { Write-Host "  selector: $($selectorOutput -replace "`r?`n", ' | ')" }
+    }
+}
+finally {
+    Reset-ControlledEnvironment
+    foreach ($name in $controlledEnvironment) {
+        [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], 'Process')
+    }
+}
+
+$summaryPath = Join-Path $OutputDir 'summary.json'
+$results | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryPath
+Write-Host "Matrix complete: $summaryPath"
+$results | Format-Table mode, timed_out, exit_code, elapsed_seconds, loading_level, parseall -AutoSize

--- a/prosper/scripts/dead-cells/progression-matrix.ps1
+++ b/prosper/scripts/dead-cells/progression-matrix.ps1
@@ -4,7 +4,7 @@ param(
     [string]$BuildDir,
     [string]$OutputDir,
     [ValidateSet('all', 'headless-full', 'app-full', 'headless-publish-10',
-                 'headless-render-every-10', 'headless-no-graphics')]
+                 'headless-render-every-10', 'headless-no-graphics', 'headless-no-gpu-work')]
     [string]$Mode = 'all',
     [int]$FullTimeoutSeconds = 240,
     [int]$FastTimeoutSeconds = 90
@@ -48,6 +48,7 @@ $controlledEnvironment = @(
     'PROSPER_PAD_SCRIPT', 'PROSPER_PAD_SCRIPT_LOG', 'PROSPER_SAVEDATA_DIR',
     'PROSPER_PROGRESS', 'PROSPER_GPU_TIMELINE', 'PROSPER_RENDER',
     'PROSPER_NO_FRAME_DUMPS', 'PROSPER_PRESENT_EVERY', 'PROSPER_RENDER_EVERY',
+    'PROSPER_NO_COMPUTE',
     'PROSPER_RENDER_EVERY_FOR_MS', 'PROSPER_RENDER_DELAY_MS', 'PROSPER_RENDER_FIRST',
     'PROSPER_RENDER_TIMING', 'PROSPER_FRAME_DIR'
 )
@@ -126,6 +127,12 @@ $specs = @(
         Timeout = $FastTimeoutSeconds
         Environment = @{}
         Meaning = 'Diagnostic: no graphics backend; retained compute still executes.'
+    },
+    [pscustomobject]@{
+        Name = 'headless-no-gpu-work'; Program = $bootTrace; Route = $captureRoute
+        Timeout = $FastTimeoutSeconds
+        Environment = @{ PROSPER_NO_COMPUTE = '1' }
+        Meaning = 'Diagnostic: no graphics or compute execution; semantic dispatches remain indexed.'
     }
 )
 if ($Mode -ne 'all') { $specs = @($specs | Where-Object Name -eq $Mode) }
@@ -149,7 +156,12 @@ try {
         if (-not $completed) {
             Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
             $process.WaitForExit()
+        } else {
+            # Drain redirected output and populate ExitCode on all supported PowerShell runtimes.
+            $process.WaitForExit()
         }
+        $process.Refresh()
+        $exitCode = $process.ExitCode
         $elapsed = [Math]::Round(((Get-Date) - $started).TotalSeconds, 1)
         $paths = @($stdout, $stderr)
 
@@ -160,7 +172,7 @@ try {
             $selectorStdout = Join-Path $runDir 'selector.stdout.log'
             $selectorStderr = Join-Path $runDir 'selector.stderr.log'
             $selectorProcess = Start-Process -FilePath $timelineTool -ArgumentList @(
-                $timeline, '--select', '738x420', '80:82', '91:93', '8'
+                $timeline, '--select', '636x420', '77:85', '91:94', '8'
             ) -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $selectorStdout `
                 -RedirectStandardError $selectorStderr
             $selectorExit = $selectorProcess.ExitCode
@@ -179,7 +191,8 @@ try {
             mode = $spec.Name
             meaning = $spec.Meaning
             timed_out = -not $completed
-            exit_code = if ($completed) { $process.ExitCode } else { $null }
+            termination = if ($completed) { 'process_exit' } else { 'timeout_killed' }
+            exit_code = $exitCode
             elapsed_seconds = $elapsed
             loading_level = Get-LastMatch $paths 'Loading level PrisonStart'
             parseall = Get-LastMatch $paths 'PARSEALL TOOK'
@@ -189,7 +202,7 @@ try {
             run_dir = $runDir
         }
         $results += $result
-        Write-Host "[$($spec.Name)] timeout=$($result.timed_out) elapsed=${elapsed}s"
+        Write-Host "[$($spec.Name)] termination=$($result.termination) exit=$($result.exit_code) elapsed=${elapsed}s"
         if ($result.loading_level) { Write-Host "  $($result.loading_level)" }
         if ($result.parseall) { Write-Host "  $($result.parseall)" }
         if ($result.last_progress) { Write-Host "  $($result.last_progress)" }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -981,14 +981,17 @@ std::vector<uint8_t> render_submit_items(const std::vector<DrawItem>& items,
 bool execute_compute_items(const std::vector<ComputeItem>& items);
 
 // Render a folded GpuState at (width,height) via the registered live renderer and hand the frame to the
-// present path (present_write_frame). Returns true iff a frame was produced and presented. A no-op
+// present path (present_write_frame) when publish is true. Returns true iff a frame was produced and
+// published. With publish=false the renderer still executes all GPU work, but scanout remains unchanged.
+// A no-op
 // returning false when there is no renderer registered or the state has no draws — so it is inert on the
 // game path until the runtime wires a device, yet fully exercised by tests. Stage A of GPU_EXECUTOR_DESIGN.
-bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height);
+bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height,
+                         bool publish = true);
 
 // Execute retained graphics and compute work in PM4 order. Graphics spans share the frontend's
 // persistent render-target cache, and only the final span is handed to the present path.
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
-                                 uint64_t submit_no = 0);
+                                 uint64_t submit_no = 0, bool publish = true);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2529,7 +2529,7 @@ bool execute_compute_items(const std::vector<ComputeItem>& items) {
 }
 
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
-                                 uint64_t submit_no) {
+                                 uint64_t submit_no, bool publish) {
     if ((!g_live && !g_compute) || (st.draws.empty() && st.dispatches.empty())) return false;
     // Guest allocations referenced by a GPU submit must remain mapped until that submit completes.
     // Reuse positive page/VirtualQuery results only inside this synchronous execution window; the
@@ -2578,7 +2578,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
         if (!finish_requested_gpu_capture(std::move(pending_capture), px, error))
             std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
     }
-    const bool presented = px.size() == static_cast<size_t>(width) * height * 4;
+    const bool frame_ready = px.size() == static_cast<size_t>(width) * height * 4;
+    const bool presented = frame_ready && publish;
     if (presented) present_write_frame(result.frame.storage, width, height);
     if (timing_enabled) {
         const auto timing_done = TimingClock::now();
@@ -2668,7 +2669,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     return presented;
 }
 
-bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
+bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height, bool publish) {
     if (!g_live || st.draws.empty() || !width || !height) return false;
     // Bind the target dimensions and defer to the pure core, which recompiles the shaders from their
     // SHADER_PGM addresses and resolves fixed-function state before calling back into the live renderer.
@@ -2693,6 +2694,7 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height) {
             std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
     }
     if (rendered.size() != static_cast<size_t>(width) * height * 4) return false;
+    if (!publish) return false;
     present_write_frame(rendered.storage, width, height);
     return true;
 }

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1107,7 +1107,17 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
     // resources, then retire completion only after the ordered mixed timeline has finished.
     gpu::flush_deferred_streams();
     prosper_gpu_drain_completion_writes();
-    const bool presented = gpu::execute_ordered_and_present(st, w, h, submit_no);
+    // PROSPER_PRESENT_EVERY=N suppresses publication only. Unlike PROSPER_RENDER_EVERY, every
+    // graphics/compute operation still executes and persistent targets advance on every submit.
+    // Publish the first eligible frame, then one in every N so a consumer gets an image promptly.
+    static const unsigned present_every = [] {
+        const char* e = getenv("PROSPER_PRESENT_EVERY");
+        long v = e ? atol(e) : 1;
+        return v > 0 ? (unsigned)v : 1u;
+    }();
+    static uint64_t publication_candidates = 0;
+    const bool publish = (publication_candidates++ % present_every) == 0;
+    const bool presented = gpu::execute_ordered_and_present(st, w, h, submit_no, publish);
     if (presented) g_presents_cum++;
     if (presented && getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc] SubmitDcb #%llu: executed %zu draws -> presented %ux%u frame\n",

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -4,10 +4,12 @@
 #include "nid.hpp"
 #include <pthread.h>
 #include <chrono>
-#ifndef _WIN32
+#if defined(__linux__)
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>   // process_vm_readv (slot-echo scan, issue #180)
+#elif defined(_WIN32)
+#include <windows.h>
 #endif
 #include <cstdint>
 #include <cstdlib>
@@ -335,10 +337,18 @@ HLE(k_debug_raise_release) {
     fflush(nullptr);
     _Exit(0x66);
 }
-#ifndef _WIN32
+#if defined(__APPLE__)
+HLE(k_getthreadid) {
+    uint64_t tid = 0;
+    return pthread_threadid_np(nullptr, &tid) == 0 ? tid : 0;
+} // scePthreadGetthreadid
+#elif defined(__linux__)
 HLE(k_getthreadid) { return (uint64_t)syscall(SYS_gettid); }   // scePthreadGetthreadid
 #else
-HLE(k_getthreadid) { return 1; }
+// The guest uses this as an ownership/current-thread identity, so a process-wide constant makes every
+// guest pthread appear to be the same thread. Windows thread IDs are stable for a live thread and unique
+// among concurrently running threads, matching the observable contract of Linux gettid here.
+HLE(k_getthreadid) { return (uint64_t)GetCurrentThreadId(); }
 #endif
 // sceKernelAprResolveFilepathsToIdsAndFileSizes — PS5 APR (async page read) IO path. Signature
 // unconfirmed; a garbage-out "success" poisons the engine's file table, so fail cleanly and let

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -560,6 +560,62 @@ HLE(s_dialog_result) {
     return 0;
 }
 
+// --- libSceSaveDataDialog ---------------------------------------------------------------
+// Uses the common-dialog status enum: NONE=0, INITIALIZED=1, RUNNING=2, FINISHED=3. A generic
+// success stub is not safe for UpdateStatus: Dead Cells polled it 1,135 times in 16 seconds because
+// zero means NONE, leaving its level transition in a permanent wait (#768). The headless policy
+// matches MsgDialog above: Open auto-dismisses to FINISHED so the guest can consume a neutral result.
+//
+// PS4/PS5 SDK layout used below (also used by shadPS4): param.mode is u32 at +0x34 and param.userData
+// is a pointer at +0x70. Result begins with mode/result/buttonId/pad followed by three pointers. Write
+// only that proven 0x28-byte prefix; the remaining 32 reserved bytes belong to the caller.
+namespace {
+    std::atomic<int> g_savedatadialog_status{0 /*NONE*/};
+    std::atomic<uint32_t> g_savedatadialog_mode{0 /*INVALID*/};
+    std::atomic<uint64_t> g_savedatadialog_user_data{0};
+}
+HLE(s_savedlg_initialize) {
+    g_savedatadialog_mode.store(0);
+    g_savedatadialog_user_data.store(0);
+    g_savedatadialog_status.store(1 /*INITIALIZED*/);
+    return 0;
+}
+HLE(s_savedlg_open) {
+    if (a0) {
+        const uint8_t* param = (const uint8_t*)PW(a0);
+        g_savedatadialog_mode.store(*(const uint32_t*)(param + 0x34));
+        g_savedatadialog_user_data.store(*(const uint64_t*)(param + 0x70));
+    } else {
+        g_savedatadialog_mode.store(0);
+        g_savedatadialog_user_data.store(0);
+    }
+    g_savedatadialog_status.store(3 /*FINISHED (auto-dismiss)*/);
+    return 0;
+}
+HLE(s_savedlg_status) { return (uint64_t)(unsigned)g_savedatadialog_status.load(); }
+HLE(s_savedlg_result) {
+    if (a0) {
+        uint8_t* result = (uint8_t*)PW(a0);
+        *(uint32_t*)(result + 0x00) = g_savedatadialog_mode.load();
+        *(uint32_t*)(result + 0x04) = 0 /*CommonDialogResult::OK*/;
+        *(uint32_t*)(result + 0x08) = 0 /*ButtonId::INVALID*/;
+        *(uint32_t*)(result + 0x0c) = 0;
+        *(uint64_t*)(result + 0x10) = 0 /*dirName*/;
+        *(uint64_t*)(result + 0x18) = 0 /*save param*/;
+        *(uint64_t*)(result + 0x20) = g_savedatadialog_user_data.load();
+    }
+    return 0;
+}
+HLE(s_savedlg_close) { g_savedatadialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_savedlg_terminate) {
+    g_savedatadialog_status.store(0 /*NONE*/);
+    g_savedatadialog_mode.store(0);
+    g_savedatadialog_user_data.store(0);
+    return 0;
+}
+HLE(s_savedlg_ready) { return 1; }
+HLE(s_savedlg_progress) { return 0; }
+
 // --- libSceImeDialog (on-screen text-entry dialog) (#191). We have no keyboard UI, so the dialog
 // auto-completes: Init -> FINISHED immediately, so the game's "poll GetStatus until Finished" loop
 // exits at once instead of hanging on a dialog that never appears; GetResult reports endStatus =
@@ -1323,6 +1379,19 @@ void register_service_hle() {
     R("sceMsgDialogUpdateStatus", s_dialog_status);
     R("sceMsgDialogGetStatus", s_dialog_status);
     R("sceMsgDialogGetResult", s_dialog_result);
+    // libSceSaveDataDialog[.native] uses raw NIDs in current dumps. Register the complete lifecycle
+    // so future modes do not fall back to success-without-state even though Dead Cells currently uses
+    // only Initialize/Open/UpdateStatus (#768).
+    Hle::register_fn("fH46Lag88XY", (HleFn)s_savedlg_close,      "sceSaveDataDialogClose");
+    Hle::register_fn("yEiJ-qqr6Cg", (HleFn)s_savedlg_result,     "sceSaveDataDialogGetResult");
+    Hle::register_fn("ERKzksauAJA", (HleFn)s_savedlg_status,     "sceSaveDataDialogGetStatus");
+    Hle::register_fn("s9e3+YpRnzw", (HleFn)s_savedlg_initialize, "sceSaveDataDialogInitialize");
+    Hle::register_fn("en7gNVnh878", (HleFn)s_savedlg_ready,      "sceSaveDataDialogIsReadyToDisplay");
+    Hle::register_fn("4tPhsP6FpDI", (HleFn)s_savedlg_open,       "sceSaveDataDialogOpen");
+    Hle::register_fn("V-uEeFKARJU", (HleFn)s_savedlg_progress,   "sceSaveDataDialogProgressBarInc");
+    Hle::register_fn("hay1CfTmLyA", (HleFn)s_savedlg_progress,   "sceSaveDataDialogProgressBarSetValue");
+    Hle::register_fn("YuH2FA7azqQ", (HleFn)s_savedlg_terminate,  "sceSaveDataDialogTerminate");
+    Hle::register_fn("KK3Bdg1RWK0", (HleFn)s_savedlg_status,     "sceSaveDataDialogUpdateStatus");
     // libSceImeDialog (#191): auto-completing text-entry dialog (no keyboard UI). Raw NIDs.
     Hle::register_fn("NUeBrN7hzf0", (HleFn)s_imedlg_init,   "sceImeDialogInit");
     Hle::register_fn("IADmD4tScBY", (HleFn)s_imedlg_status, "sceImeDialogGetStatus");

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -367,6 +367,16 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
         else    emit_unimpl(slot, (uint32_t)i, (uint64_t)&prosper_on_unimpl);
     }
     g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = n;
+    // Keep the stack-address-to-import diagnostic available on every execution host. The fingerprint
+    // tool reports return addresses inside this table; index/off/name output makes those frames useful
+    // without relying on a Linux-only boot.
+    if (getenv("PROSPER_STUBDUMP")) {
+        for (uint64_t i = 0; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[stub] #%llu off=0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(i * stub_size), slots[i].lib.c_str(), slots[i].nid.c_str(), nm.c_str());
+        }
+    }
     return true;
 }
 

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -281,15 +281,28 @@ int main() {
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");
     std::shared_ptr<const std::vector<uint8_t>> live_storage;
+    unsigned live_calls = 0;
     set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t w, uint32_t h) -> RenderedFrame {
         if (items.empty()) return {};
+        live_calls++;
         live_storage = std::make_shared<const std::vector<uint8_t>>(
             prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, w, h, &items[0].ps));
         return RenderedFrame(live_storage);
     });
     CHECK(have_submit_renderer(), "live renderer registered");
     prosper::gpu::present_reset();
+    CHECK(!execute_ordered_and_present(st, W, H, 1, /*publish=*/false),
+          "ordered publication suppression reports no presented frame");
+    CHECK(live_calls == 1, "ordered publication suppression still executes the live renderer");
+    CHECK(!prosper::gpu::present_has_frame(),
+          "ordered publication suppression leaves the scanout path unchanged");
+    CHECK(!execute_and_present(st, W, H, /*publish=*/false),
+          "publication suppression reports no presented frame");
+    CHECK(live_calls == 2, "publication suppression still executes the live renderer");
+    CHECK(!prosper::gpu::present_has_frame(),
+          "publication suppression leaves the scanout path unchanged");
     CHECK(execute_and_present(st, W, H), "execute_and_present rendered + presented the submit");
+    CHECK(live_calls == 3, "normal publication executes the live renderer again");
     CHECK(prosper::gpu::present_has_frame(), "the presented submit frame reached the scanout path");
     std::vector<uint8_t> submit_scan((size_t)W * H * 4, 0);
     prosper::gpu::present_readback(submit_scan.data(), submit_scan.size());

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -4,7 +4,9 @@
 // a representative set across every HLE module (libc, math, file, kernel, time, service, graphics).
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include <atomic>
 #include <cstdio>
+#include <thread>
 
 using namespace prosper;
 
@@ -58,6 +60,28 @@ int main() {
         uint64_t v = fn(0, 0, 0, 0, 0, 0);
         if (v == 0) { printf("  [FAIL] getpid returned kernel-special pid 0\n"); fails++; }
     } else { printf("  [FAIL] not registered: getpid\n"); fails++; }
+
+    if (HleFn fn = Hle::lookup(nid_hash("scePthreadGetthreadid"))) {
+        const uint64_t main_id = fn(0, 0, 0, 0, 0, 0);
+        const uint64_t main_id_again = fn(0, 0, 0, 0, 0, 0);
+        std::atomic<uint64_t> worker_id{0};
+        std::atomic<uint64_t> worker_id_again{0};
+        std::thread worker([&] {
+            worker_id.store(fn(0, 0, 0, 0, 0, 0), std::memory_order_relaxed);
+            worker_id_again.store(fn(0, 0, 0, 0, 0, 0), std::memory_order_relaxed);
+        });
+        worker.join();
+        if (main_id == 0 || main_id != main_id_again) {
+            printf("  [FAIL] scePthreadGetthreadid is zero or unstable on the main thread\n");
+            fails++;
+        }
+        if (worker_id.load(std::memory_order_relaxed) == 0 ||
+            worker_id.load(std::memory_order_relaxed) != worker_id_again.load(std::memory_order_relaxed) ||
+            worker_id.load(std::memory_order_relaxed) == main_id) {
+            printf("  [FAIL] scePthreadGetthreadid does not distinguish concurrent threads\n");
+            fails++;
+        }
+    } else { printf("  [FAIL] not registered: scePthreadGetthreadid\n"); fails++; }
 
     if (fails) { printf("== FAIL: %d function(s) not registered ==\n", fails); return 1; }
     printf("== PASS: all %zu checked HLE functions registered ==\n", sizeof(names)/sizeof(names[0]) + 1);

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -116,6 +116,43 @@ int main() {
         }
     }
 
+    // SaveDataDialog lifecycle (#768): returning generic success (0 == NONE) from UpdateStatus makes
+    // a title poll forever. Headless Open auto-dismisses to FINISHED and preserves the proven result
+    // prefix without touching the reserved tail.
+    {
+        auto init   = Hle::lookup("s9e3+YpRnzw");
+        auto open   = Hle::lookup("4tPhsP6FpDI");
+        auto close  = Hle::lookup("fH46Lag88XY");
+        auto status = Hle::lookup("ERKzksauAJA");
+        auto update = Hle::lookup("KK3Bdg1RWK0");
+        auto result = Hle::lookup("yEiJ-qqr6Cg");
+        auto term   = Hle::lookup("YuH2FA7azqQ");
+        CHECK(init && open && close && status && update && result && term,
+              "SaveDataDialog lifecycle functions registered");
+        if (init && open && close && status && update && result && term) {
+            term(0,0,0,0,0,0);
+            CHECK(status(0,0,0,0,0,0) == 0, "SaveDataDialog before Initialize -> NONE(0)");
+            init(0,0,0,0,0,0);
+            CHECK(update(0,0,0,0,0,0) == 1, "SaveDataDialog Initialize -> INITIALIZED(1)");
+            uint8_t param[0x98]{};
+            *(uint32_t*)(param + 0x34) = 3;
+            *(uint64_t*)(param + 0x70) = 0x123456789abcdef0ull;
+            open((uint64_t)(uintptr_t)param,0,0,0,0,0);
+            CHECK(update(0,0,0,0,0,0) == 3, "SaveDataDialog Open auto-dismisses -> FINISHED(3)");
+            uint8_t out[0x50]; memset(out, 0xAB, sizeof out);
+            result((uint64_t)(uintptr_t)out,0,0,0,0,0);
+            CHECK(*(uint32_t*)(out + 0x00) == 3 && *(uint32_t*)(out + 0x04) == 0 &&
+                  *(uint32_t*)(out + 0x08) == 0,
+                  "SaveDataDialog result reports mode and neutral OK/INVALID outcome");
+            CHECK(*(uint64_t*)(out + 0x20) == 0x123456789abcdef0ull,
+                  "SaveDataDialog result preserves caller userData");
+            CHECK(out[0x28] == 0xAB && out[0x4f] == 0xAB,
+                  "SaveDataDialog result does not overwrite its reserved tail");
+            close(0,0,0,0,0,0);
+            CHECK(status(0,0,0,0,0,0) == 0, "SaveDataDialog Close -> NONE(0)");
+        }
+    }
+
     // SystemService / AppContent / NP getters: each must WRITE its out-param with the CORRECT value —
     // returning success with an unfilled (or wrong-valued) out is the harmful-stub class whose downstream
     // effects are hard to trace (a 0.0 safe-area ratio collapses the viewport; lang 0 localizes to

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -222,7 +222,10 @@ int main(int argc, char** argv) {
 
 #ifdef PROSPER_HAVE_VULKAN
     // Compute is part of command submission even when frame rendering/dumping is disabled.
-    prosper::frontend::register_live_compute();
+    // PROSPER_NO_COMPUTE=1 is a progression diagnostic only: semantic timelines still retain the
+    // dispatches, but neither graphics nor compute mutates guest GPU resources. This distinguishes
+    // host compute throughput from guest/HLE progression; it is never a correctness mode.
+    if (!getenv("PROSPER_NO_COMPUTE")) prosper::frontend::register_live_compute();
     // PROSPER_RENDER=1: register the live Vulkan renderer (shared with prosper-app via
     // frontends/shared/live_renderer) so execute_and_present composites every submitted Dcb with
     // draws and hands the frame to the present path; periodic BMP screenshots go to PROSPER_FRAME_DIR

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -226,10 +226,12 @@ int main(int argc, char** argv) {
     // PROSPER_RENDER=1: register the live Vulkan renderer (shared with prosper-app via
     // frontends/shared/live_renderer) so execute_and_present composites every submitted Dcb with
     // draws and hands the frame to the present path; periodic BMP screenshots go to PROSPER_FRAME_DIR
-    // (default cwd). llvmpipe renders headless in WSL.
+    // (default cwd). Set PROSPER_NO_FRAME_DUMPS=1 for renderer-equivalence diagnostics without that
+    // boot_trace-only disk I/O. llvmpipe renders headless in WSL.
     if (getenv("PROSPER_RENDER")) {
         std::string fdir = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
-        prosper::frontend::register_live_renderer(fdir, /*dump_bmps=*/true);
+        const bool dump_bmps = getenv("PROSPER_NO_FRAME_DUMPS") == nullptr;
+        prosper::frontend::register_live_renderer(fdir, dump_bmps);
     }
 #endif
 

--- a/prosper/tools/dbg/README.md
+++ b/prosper/tools/dbg/README.md
@@ -1,0 +1,60 @@
+# Guest Debugger Helpers
+
+## Guest stack fingerprints
+
+`guest_stack_fingerprint.py` gives a compact cross-host view of every thread in a stopped prosper process. It
+prints the current PC, a short native GDB backtrace, the guest frame-pointer chain, and guest return addresses
+found by scanning the native stack. Unlike the older title-specific scans, a stack word is accepted only when
+the preceding guest bytes encode an x86-64 `call` ending at that address.
+
+Attach to an existing native Windows process from PowerShell:
+
+```powershell
+gdb -p $pid -batch -x prosper/tools/dbg/guest_stack_fingerprint.py |
+  Tee-Object guest-fingerprint.txt
+```
+
+Attach under WSL/Linux:
+
+```bash
+gdb -p "$pid" -batch -x prosper/tools/dbg/guest_stack_fingerprint.py \
+  | tee guest-fingerprint.txt
+```
+
+Linux `ptrace_scope` may reject attachment from an unrelated shell. A launch-under-GDB sample avoids that. The
+timeout's `SIGINT` stops the inferior and lets GDB execute the fingerprint script before exiting:
+
+```bash
+timeout --signal=INT 25s gdb --batch \
+  -ex 'handle SIGSEGV SIGBUS SIGILL nostop noprint pass' \
+  -ex 'set environment PROSPER_NO_COMPUTE 1' \
+  -ex run \
+  -x prosper/tools/dbg/guest_stack_fingerprint.py \
+  --args prosper/build-linux/boot_trace /path/to/app0
+```
+
+The signal rule is required for launch-under-GDB: Prosper handles those guest faults itself. Without it, GDB
+can stop on an emulated guest instruction before the timeout and produce a fingerprint for the wrong moment.
+
+The output is diagnostic evidence, not a symbolic backtrace. Compare repeated samples and focus on stable
+chains or host-specific branches. Absolute stack addresses, thread IDs, and a PC moving within one function are
+expected to differ.
+
+Set `PROSPER_STUBDUMP=1` on the target process to print the import-stub index, offset, NID, and resolved name.
+Use that table to resolve `stub+0x...` return addresses in a fingerprint. The stub stride is printed implicitly by
+the offsets and is currently 96 bytes; do not hard-code it into an investigation script.
+
+Configuration is optional:
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `PROSPER_GDB_STACK_SCAN_BYTES` | `0x2000` | Bytes scanned above each thread's current stack pointer |
+| `PROSPER_GDB_MAX_CANDIDATES` | `24` | Maximum validated stack candidates per thread |
+| `PROSPER_GDB_MAX_FRAMES` | `16` | Maximum frame-pointer links followed per thread |
+| `PROSPER_GDB_HOST_FRAMES` | `5` | Native GDB frames printed per thread; use `0` to omit |
+
+Run the instruction-decoder smoke test outside GDB with:
+
+```bash
+python3 prosper/tools/dbg/guest_stack_fingerprint.py --self-test
+```

--- a/prosper/tools/dbg/guest_stack_fingerprint.py
+++ b/prosper/tools/dbg/guest_stack_fingerprint.py
@@ -1,0 +1,248 @@
+"""Print cross-host guest stack fingerprints from a stopped prosper process.
+
+Attach with:
+  gdb -p PID -batch -x prosper/tools/dbg/guest_stack_fingerprint.py
+
+The fixed module slots mirror host/boot_program.hpp. Stack words are reported as
+return addresses only when the bytes immediately before them decode as an x86-64
+near call. This removes most data/code-pointer false positives from raw scans.
+"""
+
+import os
+import struct
+import sys
+
+try:
+    import gdb
+except ImportError:
+    gdb = None
+
+
+MODULES = (
+    ("eboot", 0x400000000, 0x440000000),
+    ("il2cpp", 0x440000000, 0x480000000),
+    ("psncore", 0x480000000, 0x4A0000000),
+    ("psncommon", 0x4A0000000, 0x4C0000000),
+    ("ps5util", 0x4C0000000, 0x4E0000000),
+    ("psn", 0x4E0000000, 0x4F0000000),
+    ("savedata", 0x4F0000000, 0x500000000),
+    ("libc", 0x500000000, 0x520000000),
+    ("fmodstudio", 0x520000000, 0x540000000),
+    ("fmod", 0x540000000, 0x600000000),
+    ("stub", 0x600000000, 0x700000000),
+)
+
+PREFIXES = {
+    0xF0, 0xF2, 0xF3, 0x2E, 0x36, 0x3E, 0x26, 0x64, 0x65, 0x66, 0x67,
+}
+
+
+def _module_for(value):
+    for name, begin, end in MODULES:
+        if begin <= value < end:
+            return name, begin
+    return None
+
+
+def _symbol(value):
+    if value is None:
+        return "?"
+    module = _module_for(value)
+    if module:
+        return "%s+0x%x" % (module[0], value - module[1])
+    return "0x%x" % value
+
+
+def _indirect_call_length(code):
+    """Return the instruction length when code begins with an FF /2 call."""
+    i = 0
+    while i < len(code):
+        byte = code[i]
+        if byte in PREFIXES or 0x40 <= byte <= 0x4F:
+            i += 1
+            continue
+        break
+
+    if i + 2 > len(code) or code[i] != 0xFF:
+        return None
+    i += 1
+    modrm = code[i]
+    i += 1
+    if ((modrm >> 3) & 7) != 2:
+        return None
+
+    mod = modrm >> 6
+    rm = modrm & 7
+    if mod == 3:
+        return i
+
+    # With either 32- or 64-bit addressing, r/m=4 introduces a SIB byte.
+    sib_base = None
+    if rm == 4:
+        if i >= len(code):
+            return None
+        sib_base = code[i] & 7
+        i += 1
+
+    if mod == 0:
+        if rm == 5 or (rm == 4 and sib_base == 5):
+            i += 4
+    elif mod == 1:
+        i += 1
+    elif mod == 2:
+        i += 4
+
+    return i if i <= len(code) else None
+
+
+def _call_kind(code_before_return):
+    """Classify a call instruction ending at the byte after this buffer."""
+    if len(code_before_return) >= 5 and code_before_return[-5] == 0xE8:
+        return "direct"
+
+    for start in range(max(0, len(code_before_return) - 15), len(code_before_return) - 1):
+        candidate = code_before_return[start:]
+        length = _indirect_call_length(candidate)
+        if length == len(candidate):
+            return "indirect"
+    return None
+
+
+def _self_test():
+    cases = (
+        (b"\x90\xe8\x12\x34\x56\x78", "direct"),
+        (b"\xff\xd0", "indirect"),
+        (b"\xff\x50\x08", "indirect"),
+        (b"\x41\xff\xd4", "indirect"),
+        (b"\xff\x94\x24\x34\x12\x00\x00", "indirect"),
+        (b"\x67\xff\x14\x85\x00\x10\x00\x00", "indirect"),
+        (b"\xff\xe0", None),
+        (b"\x90\xe8\x00\x00\x00\x00\x90", None),
+    )
+    for code, expected in cases:
+        actual = _call_kind(code)
+        if actual != expected:
+            raise AssertionError("%r: expected %r, got %r" % (code, expected, actual))
+    print("guest_stack_fingerprint self-test passed")
+
+
+def _env_int(name, default, minimum, maximum):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw, 0)
+    except ValueError:
+        print("warning: ignoring invalid %s=%r" % (name, raw))
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _run_gdb():
+    scan_bytes = _env_int("PROSPER_GDB_STACK_SCAN_BYTES", 0x2000, 0x100, 0x100000)
+    max_candidates = _env_int("PROSPER_GDB_MAX_CANDIDATES", 24, 1, 256)
+    max_frames = _env_int("PROSPER_GDB_MAX_FRAMES", 16, 1, 128)
+    host_frames = _env_int("PROSPER_GDB_HOST_FRAMES", 5, 0, 32)
+
+    gdb.execute("set pagination off")
+    gdb.execute("set confirm off")
+    inferior = gdb.selected_inferior()
+
+    def read(address, size):
+        try:
+            return bytes(inferior.read_memory(address, size))
+        except gdb.error:
+            return None
+
+    def u64(address):
+        data = read(address, 8)
+        return struct.unpack("<Q", data)[0] if data else None
+
+    def call_kind(return_address):
+        code = read(return_address - 15, 15)
+        return _call_kind(code) if code else None
+
+    def register(name):
+        try:
+            return int(gdb.parse_and_eval("$" + name)) & 0xFFFFFFFFFFFFFFFF
+        except gdb.error:
+            return None
+
+    print(
+        "GUEST-FINGERPRINT version=1 scan=0x%x max_candidates=%d max_frames=%d"
+        % (scan_bytes, max_candidates, max_frames)
+    )
+    threads = sorted(inferior.threads(), key=lambda thread: (thread.ptid[1], thread.num))
+    for thread in threads:
+        try:
+            thread.switch()
+            pc = register("pc")
+            sp = register("sp")
+            bp = register("rbp")
+            lwp = thread.ptid[1]
+            print(
+                "THREAD gdb=%d lwp=%d name=%s pc=%s sp=%s"
+                % (thread.num, lwp, thread.name or "?", _symbol(pc), _symbol(sp))
+            )
+
+            host = []
+            frame = gdb.newest_frame()
+            for _ in range(host_frames):
+                if frame is None:
+                    break
+                try:
+                    host.append(frame.name() or _symbol(int(frame.pc())))
+                    frame = frame.older()
+                except gdb.error:
+                    break
+            if host:
+                print("  host=" + " <- ".join(host))
+
+            frame_chain = []
+            frame_pointer = bp
+            for _ in range(max_frames):
+                if frame_pointer is None:
+                    break
+                next_frame = u64(frame_pointer)
+                return_address = u64(frame_pointer + 8)
+                if next_frame is None or return_address is None:
+                    break
+                kind = call_kind(return_address) if _module_for(return_address) else None
+                if kind:
+                    frame_chain.append("%s:%s" % (_symbol(return_address), kind))
+                if next_frame <= frame_pointer or next_frame - frame_pointer > 0x100000:
+                    break
+                frame_pointer = next_frame
+            print("  frame_chain=" + (" > ".join(frame_chain) if frame_chain else "-"))
+
+            candidates = []
+            memory = read(sp, scan_bytes) if sp is not None else None
+            if memory:
+                for offset in range(0, len(memory) - 7, 8):
+                    value = struct.unpack_from("<Q", memory, offset)[0]
+                    if not _module_for(value):
+                        continue
+                    kind = call_kind(value)
+                    if not kind:
+                        continue
+                    candidates.append("+0x%x:%s:%s" % (offset, _symbol(value), kind))
+                    if len(candidates) >= max_candidates:
+                        break
+            print("  stack=" + (" ".join(candidates) if candidates else "-"))
+            fingerprint = [_symbol(pc)] if pc is not None else ["?"]
+            fingerprint.extend(item.split(":", 1)[0] for item in frame_chain)
+            if len(fingerprint) == 1:
+                fingerprint.extend(item.split(":", 2)[1] for item in candidates[:8])
+            print("  fingerprint=" + ">".join(fingerprint))
+        except (gdb.error, RuntimeError) as error:
+            print("THREAD gdb=%d error=%s" % (thread.num, error))
+    print("GUEST-FINGERPRINT-DONE")
+
+
+if gdb is None:
+    if "--self-test" not in sys.argv:
+        print("run this script through GDB, or pass --self-test", file=sys.stderr)
+        sys.exit(2)
+    _self_test()
+else:
+    _run_gdb()


### PR DESCRIPTION
Fixes #768. Refs #723.

## Summary

- implement the complete headless `libSceSaveDataDialog` lifecycle instead of treating status calls as generic success
- return stable per-thread IDs on Windows and add a cross-thread contract test
- add a native-Windows Dead Cells progression matrix, a no-compute diagnostic, Windows stub dumps, and a cross-host guest-stack fingerprint tool
- document the current Windows/WSL routes, selectors, evidence boundaries, and debugger workflow

## Root cause

Dead Cells entered `PrisonStart` and completed `PARSEALL`, but then called the unimplemented `sceSaveDataDialogUpdateStatus` 1,135 times in 16 seconds. The generic stub returned `0`, which is common-dialog status `NONE`, so the game waited forever for `FINISHED`. `Open` now auto-dismisses the headless dialog to `FINISHED` and `GetResult` returns a neutral result while writing only the verified ABI prefix.

The apparent native-Windows/WSL renderer divergence was therefore an HLE dialog-state bug, not a render stall. The earlier compute-enabled first-dispatch exit is also no longer reproducible after merged renderer PRs #767 and #769.

## Validation

- Windows and Linux: `test_service_getters` passes, including SaveDataDialog lifecycle and ABI-boundary checks
- Windows and Linux: `test_hle_registered` passes, including stable/distinct concurrent thread IDs
- native Windows, no GPU execution: reaches `PrisonStart`, `PARSEALL` completes in 2.02s, first gameplay selector match at 28.35s, 1,104 matches in 38s
- native Windows, live compute with graphics disabled: reaches `PrisonStart`, `PARSEALL` completes in 2.08s, first gameplay selector match at 30.67s, remains alive through 38s
- PowerShell matrix parser, Python fingerprint self-test, and `git diff --check` pass

The remaining full synchronous-render throughput/progression work stays tracked by #723.