### PR TITLE
renderer: retain PC-relative shader tables in the cache

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -439,9 +439,11 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
     if (key.has_system_inputs) key.system_inputs = *system_inputs;
     if (code && dwords) {
-        std::vector<Rdna2Inst> instructions;
-        const size_t consumed = rdna2_walk(code, dwords, instructions);
-        key.code.assign(code, code + consumed);
+        // Most shaders end at S_ENDPGM. A compiler-generated s_getpc_b64 V# may instead address an
+        // embedded lookup table after ENDPGM; retain that proven tail so cached recompilation sees the
+        // same blob as the direct path and table contents participate in the cache identity.
+        const size_t span = rdna2_recompile_code_span(code, dwords);
+        key.code.assign(code, code + span);
     }
     if (resources) {
         key.resources.reserve(resources->resources.size());

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3795,7 +3795,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
 // CONFIDENCE: MED-HIGH — exact for the compiler idiom (verified against DOLL's dither PS); every
 // guard failure falls back to the old reject.
 std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
-        const std::vector<Rdna2Inst>& ins, const uint32_t* code, size_t dwords) {
+        const std::vector<Rdna2Inst>& ins, const uint32_t* code, size_t dwords,
+        size_t* required_dwords = nullptr) {
     std::unordered_map<uint32_t, std::vector<uint32_t>> out;
     std::unordered_map<int, uint64_t> pcoff;   // reg -> byte offset into the code blob (pair LO half)
     std::unordered_set<int> pchi;              // regs holding the matching HI half
@@ -3893,6 +3894,9 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
                 if (entered) break;
                 if (idxen || !soff0 || (off & 3u) || (nrec & 3u) || nrec == 0 || nrec > 1024 ||
                     off / 4 + nrec / 4 > dwords) break;            // unprovable / out of window -> reject
+                if (required_dwords)
+                    *required_dwords = std::max(*required_dwords,
+                                                static_cast<size_t>(off / 4 + nrec / 4));
                 out[in.pc] = std::vector<uint32_t>(code + off / 4, code + off / 4 + nrec / 4);
                 (void)offen;                                       // offen just adds the runtime index
                 break;
@@ -3901,6 +3905,16 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
         }
     }
     return out;
+}
+
+size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords) {
+    if (!code || !dwords) return 0;
+    std::vector<Rdna2Inst> ins;
+    size_t required = rdna2_walk(code, dwords, ins);
+    // Detection both proves the compiler idiom and bounds every referenced table. Do not retain an
+    // arbitrary post-ENDPGM trailer: only bytes that can affect the generated SPIR-V belong in the key.
+    (void)detect_pcrel_tables(ins, code, dwords, &required);
+    return std::min(required, dwords);
 }
 
 // Arbitrary compute CFG fallback. Some UE4 volume-lighting kernels contain nested EXEC loops plus

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -20,6 +20,11 @@ namespace prosper::gpu {
 
 struct ShaderResourceTable;   // resource-binding contract (shader_resources.hpp); optional to recompile_valu
 
+// Return the portion of a raw shader blob that participates in recompilation. This normally ends at
+// S_ENDPGM, but compiler-generated PC-relative lookup tables may live immediately after the program and
+// must remain part of an owning/cache copy. The result never exceeds `dwords`.
+size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords);
+
 // Fixed-function PS interpolant wiring captured from SPI_PS_INPUT_CNTL_0..31. A valid entry's
 // OFFSET selects the vertex PARAM export feeding that logical PS input; OFFSET=0x20 selects the
 // four hardware default vectors encoded by DEFAULT_VAL instead. Keeping this separate from

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -93,6 +93,41 @@ int main() {
     CHECK(!direct_ps.empty() && cached_ps == direct_ps,
           "fragment cache output is byte-identical to the direct recompiler");
 
+    // Unreal fragment shaders place small constant tables after S_ENDPGM and address them through an
+    // s_getpc_b64-built V#. The owning cache copy must include that proven tail; copying only the walked
+    // instruction span makes the cached recompiler reject s_getpc_b64 even though the direct path works.
+    std::vector<uint32_t> pcrel_ps = {
+        0xbe841f00u,               // s_getpc_b64 s[4:5]
+        0x800404b0u,               // s_add_u32 s4, 48, s4 (table begins at byte 52)
+        0x82050580u,               // s_addc_u32 s5, 0, s5
+        0xbe860390u,               // s_mov_b32 s6, 16 bytes
+        0xbe8703ffu, 0x10005004u,  // s_mov_b32 s7, V# format/stride
+        0x7e020280u,               // v_mov_b32 v1, 0 (table byte offset)
+        0xe0301000u, 0x80010101u,  // buffer_load_dword v1, v1, s[4:7], 0 offen
+        0xbf8c3f70u,               // s_waitcnt vmcnt(0)
+        0xf800180fu, 0x01010101u,  // exp mrt0 v1,v1,v1,v1
+        0xbf810000u,               // s_endpgm
+        7u, 11u, 13u, 17u,        // embedded table
+    };
+    CHECK(rdna2_recompile_code_span(pcrel_ps.data(), pcrel_ps.size()) == pcrel_ps.size(),
+          "PC-relative cache span includes the embedded table tail");
+    ShaderResourceTable pcrel_table;
+    const auto direct_pcrel_ps = recompile_fragment(
+        pcrel_ps.data(), pcrel_ps.size(), &pcrel_table);
+    const auto cached_pcrel_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, pcrel_ps.data(), pcrel_ps.size(), &pcrel_table);
+    CHECK(!direct_pcrel_ps.empty() && cached_pcrel_ps == direct_pcrel_ps,
+          "fragment cache retains a proven post-ENDPGM PC-relative table");
+
+    const auto pcrel_stats = shader_recompile_cache_stats();
+    pcrel_ps.back() = 19u;
+    const auto changed_pcrel_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, pcrel_ps.data(), pcrel_ps.size(), &pcrel_table);
+    stats = shader_recompile_cache_stats();
+    CHECK(!changed_pcrel_ps.empty() && changed_pcrel_ps != cached_pcrel_ps &&
+              stats.misses == pcrel_stats.misses + 1,
+          "embedded table contents participate in the shader cache key");
+
     // Interpolant wiring changes vertex PARAM export locations/defaults, so it is part of the
     // compile-time key even when the guest code and resource interface are otherwise identical.
     stats = shader_recompile_cache_stats();


### PR DESCRIPTION
## Summary

- preserve compiler-proven PC-relative lookup-table bytes after `s_endpgm` when constructing the graphics shader cache key
- include those bytes in cached recompilation and shader identity without retaining arbitrary shader trailers
- add an integration regression proving cached fragment recompilation matches the direct path and table-only changes miss the cache

## DOLL verification

A fresh PPSA17942 semantic capture confirms the affected fragment shader (`983879cfe5fc40e1`) now reports `recompiled=yes` in the live cached graphics path. Five depth/stencil-effect draws using it execute in the sampled frame; 21 siblings are correctly rejected as no-effect because color writes and depth/stencil side effects are all disabled. The previous live rejection at `s_getpc_b64` is gone.

## Tests

- full Linux build
- `ctest --test-dir prosper/build-linux --output-on-failure -j8`: 97/97 passed
- fresh DOLL live capture and operation audit

Fixes #273
Refs #719