### PR TITLE
docs: record Dead Cells full-render progression

### DIFF
--- a/prosper/README.md
+++ b/prosper/README.md
@@ -40,8 +40,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595). Capture v7 retains
   bounded, content-addressed raw RDNA2 and exact opcode/PC/state diagnostics for unrealized draws/dispatches;
   `gpu_replay` can inspect and extract the failed stage without rerunning the title (#618).
-- ✅ **Dead Cells reaches gameplay reproducibly:** a deterministic input route passes the splash and menus
-  into the first playable scene. The persistent-depth rejection is fixed: timeline-v5 backing hashes and
+- ✅ **Dead Cells reaches gameplay reproducibly:** deterministic native-Windows routes pass the splash and menus
+  into the first playable scene with rendering disabled or with every retained GPU submit fully executed and
+  published (#766). The persistent-depth rejection is fixed: timeline-v5 backing hashes and
   compute writer provenance identify Unity's 32 KiB HTILE fill as the per-frame fast clear, and overlapping
   guest GPU writes now invalidate the detached Vulkan depth cache (#611). A routed live A/B restores the
   foreground/platform/HUD layers that remained black without invalidation.

--- a/prosper/docs/DEAD_CELLS_PROGRESSION_MATRIX.md
+++ b/prosper/docs/DEAD_CELLS_PROGRESSION_MATRIX.md
@@ -4,9 +4,10 @@ Last updated: 2026-07-15
 
 This matrix separates guest progression from renderer output and frontend behavior. It exists because a
 native-speed or sampled-render run reaching `PrisonStart` does not prove that the full synchronous renderer
-reaches the same state. Track the current full-render stall in
+reaches the same state. The matrix localized and verified the fixes for the full-render stall in
 [#723](https://github.com/mattias800/ps5ys/issues/723) and the native-Windows render-disabled divergence in
-[#768](https://github.com/mattias800/ps5ys/issues/768).
+[#768](https://github.com/mattias800/ps5ys/issues/768); both issues are closed by the #766 lifecycle fix and its
+post-merge validation.
 
 ## Run It
 
@@ -41,7 +42,12 @@ Post-#767/#769 validation on 2026-07-15 reached the selector in both native-Wind
 disabled, the first match was at 28.35 seconds and the 38-second run contained 1,104 matches. With live compute
 enabled, the first match was at 30.67 seconds and the run remained alive through the same timeout. This establishes
 that SaveDataDialog progression is independent of rendering, while current compute execution no longer exits at
-its first live dispatch. It does not resolve the full synchronous-render throughput problem tracked by #723.
+its first live dispatch.
+
+The post-merge full-render row also reaches the same semantic gameplay state. In a 240-second run it completed
+`PARSEALL` in 22.94 seconds, first matched at 104.81 seconds, and produced 697 matches while executing and publishing
+every retained submit. This closes the progression question from #723. The much longer wall-clock route remains a
+renderer-throughput concern, and a semantic match still does not replace inspected pixel evidence.
 
 ## Rows And Semantics
 

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -6,21 +6,24 @@ The operational route and selector reference is
 [`../scripts/dead-cells/README.md`](../scripts/dead-cells/README.md). The gameplay-composition bug
 [#566](https://github.com/mattias800/ps5ys/issues/566) was fixed by #626; this document retains the exact
 checkpoint recipe as a regression and future-investigation workflow.
-The current full-render progression investigation and its behavior-equivalence rows are documented in
+The full-render progression investigation and its behavior-equivalence rows are documented in
 [`DEAD_CELLS_PROGRESSION_MATRIX.md`](DEAD_CELLS_PROGRESSION_MATRIX.md) and tracked by
-[#723](https://github.com/mattias800/ps5ys/issues/723). The former native-Windows render-disabled divergence is
-tracked by [#768](https://github.com/mattias800/ps5ys/issues/768).
+the now-closed [#723](https://github.com/mattias800/ps5ys/issues/723). The former native-Windows
+render-disabled divergence was tracked by the now-closed
+[#768](https://github.com/mattias800/ps5ys/issues/768).
 
 ## Current state
 
 *Dead Cells* boots, passes the splash and menus, and loads `PrisonStart`. WSL/Linux native-speed and sampled-graphics
-routes reach the controllable Jump tutorial and have supplied full-color gameplay captures. Native Windows now also
-reaches the sustained 92-94 draw / 8-dispatch gameplay state in the no-GPU-work progression control. #768's former
+routes reach the controllable Jump tutorial and have supplied full-color gameplay captures. Native Windows reaches
+the sustained 91-94 draw / 8-dispatch gameplay state both with rendering disabled and with every retained GPU submit
+fully executed and published. #768's former
 356-390-draw loop was not a renderer stall: `sceSaveDataDialogUpdateStatus` was unimplemented and returned `NONE`
-more than a thousand times while the game waited for `FINISHED`. The separate full synchronous-render throughput
-and progression gap remains #723. After renderer PRs #767 and #769, the native-Windows compute-enabled,
-render-disabled control also reaches the sustained gameplay signature; its earlier first-dispatch process exit is
-not reproducible on current `master`.
+more than a thousand times while the game waited for `FINISHED`. After #766, a 240-second native-Windows full-render
+control completed `PARSEALL` in 22.94 seconds, first matched gameplay at 104.81 seconds, and accumulated 697 matches.
+This closes #723's progression bug; synchronous renderer throughput remains performance work. After renderer PRs
+#767 and #769, the native-Windows compute-enabled, render-disabled control also reaches the sustained gameplay
+signature; its earlier first-dispatch process exit is not reproducible on current `master`.
 
 The scene renders in full color, including geometry, lighting, smoke, silhouettes, the player, terrain, effects,
 the tutorial prompt, and the HUD. The final grayscale-world root cause was the fragment recompiler selecting the

--- a/prosper/scripts/dead-cells/README.md
+++ b/prosper/scripts/dead-cells/README.md
@@ -29,9 +29,10 @@ no-graphics diagnostics with isolated saves and the same semantic gameplay selec
   warmup. Circle remains held through 240 seconds because synchronous rendering
   has made `PARSEALL` take from about 60 to more than 160 seconds across measured
   builds. The route now survives that throughput variance, but the gameplay
-  snapshot baseline remains pending until its retained frames are reviewed. Current master reaches
-  `PrisonStart` and finishes `PARSEALL`, but the full synchronous-render route remains on the loading
-  screen under the measured timeout (#723); do not conflate it with the sampled route below.
+  snapshot baseline remains pending until its retained frames are reviewed. Post-#766 native-Windows
+  validation executes and publishes every retained submit, completes `PARSEALL`, and first matches the
+  sustained gameplay semantic selector at 104.81 seconds. #723 is closed; the route remains much slower
+  than the render-disabled control, and the selector does not replace visual inspection.
 - `reach-first-gameplay-capture.pad`: uses the same menu input but holds Circle from
   28 through 300 seconds. Use it when synchronous timeline/bundle capture begins during
   level loading; the ordinary six-second hold can expire while capture stalls GPU progress.


### PR DESCRIPTION
Refs #723 and #768.

## Summary

- record that the merged SaveDataDialog lifecycle fix restores native-Windows progression with rendering disabled and with every retained GPU submit fully executed and published
- replace the stale statement that the full-render route remains indefinitely on Prisoners' Quarters loading
- keep the semantic-selector proof separate from the still-pending inspected full-render pixel baseline

## Validation

On merged `master` (`41aa2b8`), the 240-second native-Windows `headless-full` matrix row:

- entered `PrisonStart`
- completed `PARSEALL` in 22.94 seconds
- first matched the known gameplay signature at 104.81 seconds
- accumulated 697 matches while remaining alive through the observation window

Local evidence: `%TEMP%\prosper-dc-master-full-240-after-savedlg`.

Documentation-only change; `git diff --check` passes.