### PR TITLE
Fix packed texture conversion with reused renderer scratch

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1008,7 +1008,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // the generic 4-B read and detile above preserve packed texels; normalize each
                         // field to the RGBA8 image format used by this renderer before sampling.
                         if (!rtt_hit && r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
-                            uint8_t* tp = texstore.back().data();
+                            uint8_t* tp = texture_pixels.data();
                             for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);
                                 prosper::gpu::unorm2_10_10_10_to_rgba8(v, tp + t * 4);

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -78,6 +78,62 @@ int main() {
               "replay samples captured red texel from owned backing");
     }
 
+    // Texture decode scratch survives between renderer callbacks and reuses slots from the front.
+    // Grow it to two slots, then make a packed texture the sole decode in the next callback. Converting
+    // texstore.back() here used to mutate the stale second slot while uploading the first slot's raw
+    // R10G10B10A2 bytes, so a logical half-red texel arrived almost black.
+    {
+        uint8_t filler_a[16] = {
+            255, 0, 0, 255, 255, 0, 0, 255,
+            255, 0, 0, 255, 255, 0, 0, 255,
+        };
+        uint8_t filler_b[16] = {
+            0, 255, 0, 255, 0, 255, 0, 255,
+            0, 255, 0, 255, 0, 255, 0, 255,
+        };
+        auto texture_draw = [&](uint64_t texture_addr, uint64_t target_addr,
+                                uint8_t* host_data, DataFormat format) {
+            DrawItem draw = replay.items[0];
+            draw.color0_base = target_addr;
+            auto table = std::make_shared<ShaderResourceTable>(*draw.prt);
+            ShaderResource& resource = table->resources[0];
+            resource.gpu_addr = texture_addr;
+            resource.size = 16;
+            resource.width = resource.height = 2;
+            resource.depth = 1;
+            resource.tile_mode = 0;
+            resource.format = format;
+            resource.num_components = 4;
+            resource.host_data = host_data;
+            resource.host_data_size = 16;
+            draw.prt = std::move(table);
+            return draw;
+        };
+        DrawItem filler_draw_a = texture_draw(
+            0xd10000, 0xd30000, filler_a, DataFormat::Unorm8);
+        DrawItem filler_draw_b = texture_draw(
+            0xd20000, 0xd30000, filler_b, DataFormat::Unorm8);
+        std::vector<uint8_t> filler = render_submit_items(
+            {filler_draw_a, filler_draw_b}, W, H);
+        CHECK(!filler.empty(), "renderer grows reusable texture decode scratch beyond one slot");
+
+        uint32_t packed_texels[4] = {
+            0xC0000200u, 0xC0000200u, 0xC0000200u, 0xC0000200u,
+        };  // logical RGBA = (128,0,0,255); raw little-endian bytes = (0,2,0,192)
+        DrawItem packed_draw = texture_draw(
+            0xd40000, 0xd50000, reinterpret_cast<uint8_t*>(packed_texels),
+            DataFormat::Unorm2_10_10_10);
+        std::vector<uint8_t> packed = render_submit_items({packed_draw}, W, H);
+        bool packed_red = packed.size() == static_cast<size_t>(W) * H * 4;
+        if (packed_red) {
+            const uint8_t* center = &packed[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+            packed_red = center[0] >= 120 && center[0] <= 136 &&
+                         center[1] < 8 && center[2] < 8 && center[3] > 240;
+        }
+        CHECK(packed_red,
+              "reused scratch converts and uploads the current packed R10G10B10A2 texture");
+    }
+
     // A non-VideoOut producer must render at CB_COLOR0_ATTRIB2's extent, be cached under its
     // target address, and feed a later pass. Before #526 both passes used the global 64x64 extent.
     DrawItem producer = replay.items[0];


### PR DESCRIPTION
## Summary
- convert packed R10G10B10A2 pixels in the active reusable decode-scratch slot
- add an end-to-end replay regression that grows scratch to multiple slots, then decodes a sole packed texture in the next callback

## Why
`texstore` is retained across renderer callbacks and reused from the front. `texstore.back()` can therefore name a stale slot rather than the current texture, leaving the texture's packed bytes unconverted before upload.

This is one concrete corruption fix found while investigating #719; it does not claim to complete that issue or fix the remaining black scene inputs.

## Validation
- regression fails with the old `texstore.back()` behavior and passes with this fix
- full Linux build succeeds
- `ctest --test-dir build-linux --output-on-failure -j 6`: 97/97 passed