### PR TITLE
gpu: preserve DCC state for compressed Unreal textures

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -68,6 +68,9 @@ struct TextureDecodeKey {
     uint32_t width = 0, height = 0, depth = 1;
     uint32_t tile_mode = 0;
     uint32_t img_dim = 0;
+    uint32_t max_uncompressed_block_size = 0, max_compressed_block_size = 0;
+    uint32_t dcc_flags = 0;
+    uint64_t metadata_addr = 0;
     bool operator==(const TextureDecodeKey&) const = default;
 };
 
@@ -82,7 +85,8 @@ struct TextureDecodeKeyHash {
         };
         mix(key.gpu_addr); mix(key.host_data); mix(key.host_data_size); mix(key.size);
         mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height); mix(key.depth);
-        mix(key.tile_mode); mix(key.img_dim);
+        mix(key.tile_mode); mix(key.img_dim); mix(key.max_uncompressed_block_size);
+        mix(key.max_compressed_block_size); mix(key.dcc_flags); mix(key.metadata_addr);
         return hash;
     }
 };
@@ -496,6 +500,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
                             static_cast<uint32_t>(r.format), r.num_components, tw, th, r.depth,
                             r.tile_mode, r.img_dim,
+                            r.compression_enabled ? r.max_uncompressed_block_size : 0u,
+                            r.compression_enabled ? r.max_compressed_block_size : 0u,
+                            r.compression_enabled
+                                ? ((r.meta_pipe_aligned ? 1u : 0u) |
+                                   (r.write_compress_enabled ? 2u : 0u) | 4u |
+                                   (r.alpha_is_on_msb ? 8u : 0u) |
+                                   (r.color_transform ? 16u : 0u))
+                                : 0u,
+                            r.compression_enabled ? r.metadata_addr : 0u,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
                         const bool has_cpu_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() &&
@@ -508,6 +521,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::find_persistent_color_target(
                                 r.gpu_addr, tw, th, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
                         const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
+                        if (r.compression_enabled && !has_live_rtt) {
+                            static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
+                            if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                fprintf(stderr,
+                                        "[render] DCC-compressed sampled image addr=0x%llx meta=0x%llx "
+                                        "%ux%ux%u fmt=%u tile=%u is unsupported; base bytes are not a valid decode\n",
+                                        (unsigned long long)r.gpu_addr,
+                                        (unsigned long long)r.metadata_addr,
+                                        tw, th, r.depth, (unsigned)r.format, r.tile_mode);
+                        }
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
@@ -1036,14 +1059,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 r.gpu_addr, raw_size);
                             fprintf(stderr,
                                     "[resource-version] render-submit=%llu draw=%llu order=%llu set=%u bind=%u "
-                                    "addr=0x%llx dims=%ux%u class=%u fmt=%u tile=%u rtt=%d "
+                                    "addr=0x%llx dims=%ux%u class=%u fmt=%u tile=%u dcc=%u meta=0x%llx rtt=%d "
                                     "raw=%zu/%zu:%016llx sample=%zu:%016llx "
                                     "writer=%s/%llu/%llu/%llu/0x%llx\n",
                                     (unsigned long long)g_this_submit,
                                     (unsigned long long)draw.draw_index,
                                     (unsigned long long)draw.command_order,
                                     set, r.binding, (unsigned long long)r.gpu_addr, tw, th,
-                                    (unsigned)r.cls, (unsigned)r.format, r.tile_mode, (int)rtt_hit,
+                                    (unsigned)r.cls, (unsigned)r.format, r.tile_mode,
+                                    r.compression_enabled, (unsigned long long)r.metadata_addr,
+                                    (int)rtt_hit,
                                     raw_got, raw_size, (unsigned long long)raw_hash,
                                     texture_pixels.size(), (unsigned long long)sample_hash,
                                     writer ? prosper::gpu::guest_writer_kind_name(writer->kind) : "none",

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -195,6 +195,15 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.dst_sel[1] = (uint8_t)((t[3] >> 3) & 0x7u);   // DST_SEL_Y ([5:3])
     d.dst_sel[2] = (uint8_t)((t[3] >> 6) & 0x7u);   // DST_SEL_Z ([8:6])
     d.dst_sel[3] = (uint8_t)((t[3] >> 9) & 0x7u);   // DST_SEL_W ([11:9])
+    d.max_uncompressed_block_size = (t[6] >> 15) & 0x3u;
+    d.max_compressed_block_size   = (t[6] >> 17) & 0x3u;
+    d.meta_pipe_aligned           = ((t[6] >> 19) & 0x1u) != 0;
+    d.write_compress_enabled      = ((t[6] >> 20) & 0x1u) != 0;
+    d.compression_enabled         = ((t[6] >> 21) & 0x1u) != 0;
+    d.alpha_is_on_msb             = ((t[6] >> 22) & 0x1u) != 0;
+    d.color_transform             = ((t[6] >> 23) & 0x1u) != 0;
+    const uint64_t metadata_field = (static_cast<uint64_t>(t[7]) << 8) | (t[6] >> 24);
+    d.metadata_addr               = metadata_field << 8;
     return d;
 }
 
@@ -358,9 +367,14 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             }
             if (getenv("PROSPER_GFXLOG")) {
                 const uint32_t* t = tv;   // the fetched T# (SGPR block or EUD spill)
-                fprintf(stderr, "[t#] %ux%u base=0x%llx tile_mode=%u type=%u fmt=%u swz=%u,%u,%u,%u | raw: %08x %08x %08x %08x %08x %08x %08x %08x\n",
+                fprintf(stderr, "[t#] %ux%u base=0x%llx tile_mode=%u type=%u fmt=%u swz=%u,%u,%u,%u "
+                                "dcc=%u meta=0x%llx blocks=%u/%u flags=%u%u%u%u | raw: %08x %08x %08x %08x %08x %08x %08x %08x\n",
                         d.width, d.height, (unsigned long long)d.base, d.tile_mode, d.type, d.format,
                         d.dst_sel[0], d.dst_sel[1], d.dst_sel[2], d.dst_sel[3],
+                        d.compression_enabled, (unsigned long long)d.metadata_addr,
+                        d.max_uncompressed_block_size, d.max_compressed_block_size,
+                        d.meta_pipe_aligned, d.write_compress_enabled,
+                        d.alpha_is_on_msb, d.color_transform,
                         t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
             }
             // Decode the T#'s real Gen5 IMG_FMT (#65 — was hardcoded Unorm8 x4 / size w*h*4, which
@@ -411,6 +425,14 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.height        = d.height;
             r.depth         = d.depth;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
+            r.max_uncompressed_block_size = d.max_uncompressed_block_size;
+            r.max_compressed_block_size = d.max_compressed_block_size;
+            r.meta_pipe_aligned = d.meta_pipe_aligned;
+            r.write_compress_enabled = d.write_compress_enabled;
+            r.compression_enabled = d.compression_enabled;
+            r.alpha_is_on_msb = d.alpha_is_on_msb;
+            r.color_transform = d.color_transform;
+            r.metadata_addr = d.metadata_addr;
             r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
             r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];   // T# DST_SEL channel remap (#261)
             // T# TYPE -> the MIMG dim convention (GFX10 SQ_RSRC_IMG: 8=1D, 9=2D, 10=3D, 11=CUBE,

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -112,7 +112,9 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 
 // A decoded image resource descriptor (T#, 8 dwords / 256-bit). Layout = Kyty ShaderTextureResource
 // Gen5 getters (Base40/Width5/Height5/Format/TileMode). `base` is the byte address of the texel data
-// in unified guest memory. `tile_mode` 0 = linear (no detiling needed); non-zero = GPU-tiled.
+// in unified guest memory. `tile_mode` 0 = linear (no detiling needed); non-zero = GPU-tiled. GFX10
+// DCC state lives in WORD6/7 and is kept separately from the base allocation: compressed texels are
+// not meaningful without the metadata surface.
 struct DecodedImageDescriptor {
     uint64_t base = 0;
     uint32_t width = 0, height = 0, depth = 1;
@@ -124,6 +126,14 @@ struct DecodedImageDescriptor {
     // DST_SEL_X/Y/Z/W channel swizzle (WORD3 [2:0]/[5:3]/[8:6]/[11:9]); SQ_SEL enum:
     // 0=0, 1=1, 4=X(R), 5=Y(G), 6=Z(B), 7=W(A). Default = identity (R,G,B,A).
     uint8_t  dst_sel[4] = {4, 5, 6, 7};
+    uint32_t max_uncompressed_block_size = 0; // WORD6[16:15]
+    uint32_t max_compressed_block_size = 0;   // WORD6[18:17]
+    bool     meta_pipe_aligned = false;       // WORD6[19]
+    bool     write_compress_enabled = false;  // WORD6[20]
+    bool     compression_enabled = false;     // WORD6[21]
+    bool     alpha_is_on_msb = false;          // WORD6[22]
+    bool     color_transform = false;          // WORD6[23]
+    uint64_t metadata_addr = 0;                // 40-bit META_DATA_ADDRESS, in 256-byte units
 };
 // Decode an 8-dword T# (RDNA2/Gen5 image resource). Pure; exposed for reuse + testing.
 DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 10;
+constexpr uint32_t kVersion = 11;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -1009,6 +1009,33 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u32(diagnostic.color1_height);
         if (diagnostic.pipeline_present) write_mrt1_pipeline(w, diagnostic.pipeline);
     }
+    // v11 preserves GFX10 DCC descriptor state in deterministic resource-table order. Like the v9
+    // depth tail, this leaves the v1-v10 resource record byte-compatible while making compressed
+    // base allocations explicit to offline inspection. Metadata bytes are not inferred or invented.
+    w.u32(static_cast<uint32_t>(resource_depth_count));
+    auto write_dcc_state = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources) {
+            const auto& resource = captured.resource;
+            if (resource.max_uncompressed_block_size > 3u ||
+                resource.max_compressed_block_size > 3u) {
+                error = "invalid resource DCC state"; return false;
+            }
+            const uint8_t flags = (resource.meta_pipe_aligned ? 1u : 0u) |
+                                  (resource.write_compress_enabled ? 2u : 0u) |
+                                  (resource.compression_enabled ? 4u : 0u) |
+                                  (resource.alpha_is_on_msb ? 8u : 0u) |
+                                  (resource.color_transform ? 16u : 0u);
+            w.u8(flags);
+            w.u32(resource.max_uncompressed_block_size);
+            w.u32(resource.max_compressed_block_size);
+            w.u64(resource.metadata_addr);
+        }
+        return true;
+    };
+    for (const auto& draw : c.draws)
+        if (!write_dcc_state(draw.vrt) || !write_dcc_state(draw.prt)) return false;
+    for (const auto& compute : c.computes)
+        if (!write_dcc_state(compute.resources)) return false;
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1297,6 +1324,41 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 !r.u32(diagnostic.color1_height)) return false;
             if (diagnostic.pipeline_present && !read_mrt1_pipeline(r, diagnostic.pipeline)) return false;
         }
+    }
+    if (version >= 11) {
+        uint64_t expected_states = 0;
+        for (const auto& draw : c.draws)
+            expected_states += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected_states += compute.resources.resources.size();
+        uint32_t state_count = 0;
+        if (!r.u32(state_count) || state_count != expected_states) {
+            error = "invalid resource DCC-state count"; return false;
+        }
+        auto read_dcc_state = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                auto& resource = captured.resource;
+                uint8_t flags = 0;
+                if (!r.u8(flags) || (flags & ~0x1fu) ||
+                    !r.u32(resource.max_uncompressed_block_size) ||
+                    !r.u32(resource.max_compressed_block_size) ||
+                    !r.u64(resource.metadata_addr) ||
+                    resource.max_uncompressed_block_size > 3u ||
+                    resource.max_compressed_block_size > 3u) {
+                    error = "invalid resource DCC state"; return false;
+                }
+                resource.meta_pipe_aligned = (flags & 1u) != 0;
+                resource.write_compress_enabled = (flags & 2u) != 0;
+                resource.compression_enabled = (flags & 4u) != 0;
+                resource.alpha_is_on_msb = (flags & 8u) != 0;
+                resource.color_transform = (flags & 16u) != 0;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_dcc_state(draw.vrt) || !read_dcc_state(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_dcc_state(compute.resources)) return false;
     }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1657,6 +1657,14 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.format = fi.format; r.num_components = fi.num_components;
                     r.gpu_addr = d.base; r.width = d.width; r.height = d.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
+                    r.max_uncompressed_block_size = d.max_uncompressed_block_size;
+                    r.max_compressed_block_size = d.max_compressed_block_size;
+                    r.meta_pipe_aligned = d.meta_pipe_aligned;
+                    r.write_compress_enabled = d.write_compress_enabled;
+                    r.compression_enabled = d.compression_enabled;
+                    r.alpha_is_on_msb = d.alpha_is_on_msb;
+                    r.color_transform = d.color_transform;
+                    r.metadata_addr = d.metadata_addr;
                     // T# TYPE -> MIMG dim (GFX10: 9=2D, 10=3D, 11=CUBE, 13=2D_ARRAY); a cube
                     // uploads as six vertically-stacked faces (#273 — see agc_shader_layout).
                     r.img_dim = image_type_to_dim(d.type);
@@ -1973,6 +1981,14 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     }
                     r.gpu_addr = d.base; r.width = d.width; r.height = d.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode;
+                    r.max_uncompressed_block_size = d.max_uncompressed_block_size;
+                    r.max_compressed_block_size = d.max_compressed_block_size;
+                    r.meta_pipe_aligned = d.meta_pipe_aligned;
+                    r.write_compress_enabled = d.write_compress_enabled;
+                    r.compression_enabled = d.compression_enabled;
+                    r.alpha_is_on_msb = d.alpha_is_on_msb;
+                    r.color_transform = d.color_transform;
+                    r.metadata_addr = d.metadata_addr;
                     r.img_dim = image_type_to_dim(d.type);
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -163,6 +163,19 @@ struct ShaderResource {
     // path (that already broadcasts coverage to every channel).
     uint32_t      swizzle[4]        = {4, 5, 6, 7};
 
+    // GFX10 image-compression state decoded from T# WORD6/7. A DCC-compressed base allocation cannot
+    // be interpreted as ordinary tiled texels: metadata_addr names the separate compression-control
+    // surface. These fields are preserved through captures even though software DCC decode is not yet
+    // implemented, so live/replay diagnostics remain truthful instead of hiding corrupt source bytes.
+    uint32_t      max_uncompressed_block_size = 0;
+    uint32_t      max_compressed_block_size   = 0;
+    bool          meta_pipe_aligned           = false;
+    bool          write_compress_enabled      = false;
+    bool          compression_enabled         = false;
+    bool          alpha_is_on_msb             = false;
+    bool          color_transform             = false;
+    uint64_t      metadata_addr               = 0;
+
     // Replay-only owned backing. `gpu_addr` remains the captured logical guest address so render-target
     // identity/alias checks stay faithful. Graphics reads from host_data; compute may update it before a
     // later operation consumes the same version. Production tables leave both fields zero and use guest memory.

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -91,9 +91,17 @@ int main() {
         CHECK(image_type_to_dim(0) == 1, "unknown T# TYPE keeps the conservative 2D fallback");
         uint32_t t3d[8];
         make_tsharp(t3d, 0x12000000ull, 32, 16, /*fmt*/56, /*tile*/0, /*type 3D*/10, /*depth*/8);
+        t3d[6] = (2u << 15) | (1u << 17) | (1u << 19) | (1u << 20) |
+                 (1u << 21) | (1u << 22) | (1u << 23) | (0xabu << 24);
+        t3d[7] = 0x00206e33u;
         const DecodedImageDescriptor d3d = decode_image_descriptor(t3d);
         CHECK(d3d.width == 32 && d3d.height == 16 && d3d.depth == 8,
               "3D T# word4 DEPTH decodes as depth-minus-one");
+        CHECK(d3d.compression_enabled && d3d.write_compress_enabled && d3d.meta_pipe_aligned &&
+              d3d.alpha_is_on_msb && d3d.color_transform &&
+              d3d.max_uncompressed_block_size == 2 && d3d.max_compressed_block_size == 1 &&
+              d3d.metadata_addr == 0x206e33ab00ull,
+              "GFX10 T# WORD6/7 DCC flags and 40-bit metadata address decode exactly");
     }
 
     // --- AGC semantic metadata -> SPI_PS_INPUT_CNTL wiring ------------------------------------
@@ -302,6 +310,9 @@ int main() {
     {
         uint32_t tsgprs[32]; memset(tsgprs, 0, sizeof tsgprs);
         make_tsharp(&tsgprs[0],  0xD0000000ull, 1920, 1080, /*fmt*/56,  /*tile*/5, /*type 2D*/9);
+        tsgprs[6] = (2u << 15) | (1u << 17) | (1u << 19) | (1u << 21) |
+                    (1u << 22) | (0xabu << 24);
+        tsgprs[7] = 0x00206e33u;
         make_tsharp(&tsgprs[8],  0xE0000000ull, 2048, 1024, /*fmt*/1,   /*tile*/5, /*type*/9);
         make_tsharp(&tsgprs[16], 0xF0000000ull,  256,  256, /*fmt*/169, /*tile*/5, /*type*/9);  // BC1
         make_tsharp(&tsgprs[24], 0xF0010000ull,  128,  128, /*fmt*/44,  /*tile*/5, /*type*/9);  // unmapped
@@ -329,6 +340,11 @@ int main() {
         CHECK(t0 && t0->format == DataFormat::Unorm8 && t0->num_components == 4,
               "fmt=56 -> Unorm8 x4 (current behavior preserved)");
         CHECK(t0 && t0->size == 1920u * 1080u * 4u, "fmt=56 size = w*h*4 (unchanged)");
+        CHECK(t0 && t0->compression_enabled && t0->meta_pipe_aligned && t0->alpha_is_on_msb &&
+              !t0->write_compress_enabled && !t0->color_transform &&
+              t0->max_uncompressed_block_size == 2 && t0->max_compressed_block_size == 1 &&
+              t0->metadata_addr == 0x206e33ab00ull,
+              "texture resource preserves all decoded DCC state for renderer/capture consumers");
 
         const ShaderResource* t1 = tt.by_sgpr_base(8);
         CHECK(t1 && t1->format == DataFormat::Unorm8 && t1->num_components == 1,

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -54,7 +54,13 @@ int main() {
     a.size = 16; a.stride = 4; a.format = DataFormat::Unorm2_10_10_10; a.num_components = 4; a.fetch_pc = 12;
     ShaderResource b{}; b.cls = ResourceClass::ConstantBuffer; b.binding = 2; b.gpu_addr = 0x1008;
     b.size = 16; b.format = DataFormat::Float32; b.num_components = 4; b.srt_offset = 0x20;
-    table->resources = {a, b};
+    ShaderResource dcc{}; dcc.cls = ResourceClass::Texture; dcc.binding = 4; dcc.gpu_addr = 0x1000;
+    dcc.size = 16; dcc.format = DataFormat::Unorm8; dcc.num_components = 4;
+    dcc.width = dcc.height = 2; dcc.max_uncompressed_block_size = 2;
+    dcc.max_compressed_block_size = 1; dcc.meta_pipe_aligned = true;
+    dcc.compression_enabled = true; dcc.alpha_is_on_msb = true;
+    dcc.metadata_addr = 0x206e33ab00ull;
+    table->resources = {a, b, dcc};
 
     DrawItem draw; draw.vs = {0x07230203, 1, 2}; draw.fs = {0x07230203, 3}; draw.vrt = table;
     draw.vertex_count = 6; draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
@@ -164,12 +170,17 @@ int main() {
           deserialize_gpu_capture(stencil_only_bytes, stencil_only_loaded, error) &&
           !stencil_only_loaded.ds_seeds[0].depth_valid &&
           stencil_only_loaded.ds_seeds[0].stencil_valid,
-          "stencil-only validity survives capture v10 independently of depth");
+          "stencil-only validity survives capture v11 independently of depth");
     GpuCaptureFile invalid_stencil_format = stencil_only;
     invalid_stencil_format.ds_seeds[0].format = GpuCaptureDsFormat::D32Float;
     CHECK(!serialize_gpu_capture(invalid_stencil_format, stencil_only_bytes, error) &&
           error == "DS seed stencil byte count does not match its extent, format, and validity",
           "writer rejects stencil bytes for a depth-only format");
+    GpuCaptureFile invalid_dcc = captured;
+    invalid_dcc.draws[0].vrt.resources[2].resource.max_compressed_block_size = 4;
+    CHECK(!serialize_gpu_capture(invalid_dcc, stencil_only_bytes, error) &&
+          error == "invalid resource DCC state",
+          "writer rejects DCC block-size values wider than their two-bit descriptor fields");
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
@@ -189,6 +200,13 @@ int main() {
           "newest packed image format enum round-trips");
     CHECK(loaded.draws[0].vrt.resources[0].resource.depth == 7,
           "v9 resource depth round-trips");
+    const auto& loaded_dcc = loaded.draws[0].vrt.resources[2].resource;
+    CHECK(loaded_dcc.compression_enabled && loaded_dcc.meta_pipe_aligned &&
+          loaded_dcc.alpha_is_on_msb && !loaded_dcc.write_compress_enabled &&
+          !loaded_dcc.color_transform && loaded_dcc.max_uncompressed_block_size == 2 &&
+          loaded_dcc.max_compressed_block_size == 1 &&
+          loaded_dcc.metadata_addr == 0x206e33ab00ull,
+          "v11 resource DCC descriptor state round-trips without inventing metadata bytes");
     CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");
@@ -352,13 +370,15 @@ int main() {
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 28,
-          "created a diagnostic-free v10 payload for legacy-reader fixtures");
+          "created a diagnostic-free v11 payload for legacy-reader fixtures");
     if (legacy_bytes.size() >= 28) {
+        const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
+                                             legacy_source.draws[0].prt.resources.size();
+        // Remove the v11 DCC tail: count + 17-byte state record per resource.
+        legacy_bytes.resize(legacy_bytes.size() - (4 + 17 * legacy_resource_count));
         // Remove the v10 MRT tail: draw count + one (target identity + 50-byte pipeline state) +
         // zero failure count. The remaining payload is byte-exact v9.
         legacy_bytes.resize(legacy_bytes.size() - (4 + 16 + 50 + 4));
-        const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
-                                             legacy_source.draws[0].prt.resources.size();
         legacy_bytes.resize(legacy_bytes.size() - 4 - 4 - 4 * legacy_resource_count);
         // remove v9 depth section (count + values) and the v8 DS-seed zero count
         legacy_bytes[8] = 7; legacy_bytes[9] = legacy_bytes[10] = legacy_bytes[11] = 0;
@@ -374,9 +394,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 11;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 12;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 11",
+          error == "unsupported capture version 12",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -148,13 +148,15 @@ if an included temporal image leaf has another extent or an intermediate submit 
 an evidence-gated optimization, not automatic dependency closure.
 
 `--bundle-final-capsule PATH` snapshots the complete live color RTT and persistent Vulkan depth/stencil caches
-before executing the final submit and writes them as seeds in a standalone capture-v9 capsule. Capture v9 also
-retains the base-level depth of every 3D image resource. Its standalone
+before executing the final submit and writes them as seeds in a standalone current-version capsule. Capture v9
+introduced the base-level depth of every 3D image resource; v11 also retains each image T#'s GFX10 DCC flags,
+block-size fields, and metadata address. `--inspect-only` reports compressed base allocations explicitly;
+metadata bytes and a software DCC decode are not inferred. The capsule's standalone
 output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or
 shader experiments. Export validates every surface and fails when a required temporal color surface is absent;
 it never substitutes zero pixels. The file is installed only after the source final submit renders, and embeds
 that output byte count/hash as its replay oracle. A legacy pre-v7 manifest with unrealized operations is migrated explicitly to
-`Unknown` failure diagnostics with the original operation kind/source/order, so the v9 writer remains strict.
+`Unknown` failure diagnostics with the original operation kind/source/order, so the current writer remains strict.
 The DS snapshot uses transfer barriers to return every image to depth/stencil-attachment layout before the final
 bundle submit executes; equality therefore also checks that readback did not perturb the source run.
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -170,6 +170,7 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
         std::printf("  %s %-7s b=%u addr=%016llx declared=%u footprint=%llu captured=%llu "
                     "nz=%zu hash=%016llx first=%08x "
                     "fmt=%u nc=%u stride=%u %ux%ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
+                    "dcc=%u meta=%016llx blocks=%u/%u flags=%u%u%u%u "
                     "srt=%08x sgpr=%08x pc=%08x%s\n",
                     stage, class_name(r.cls), r.binding, static_cast<unsigned long long>(r.gpu_addr),
                     r.size,
@@ -181,6 +182,10 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
                     r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2],
                     r.swizzle[0], r.swizzle[1], r.swizzle[2], r.swizzle[3],
                     r.mag_filter, r.min_filter, r.mip_filter,
+                    r.compression_enabled, static_cast<unsigned long long>(r.metadata_addr),
+                    r.max_uncompressed_block_size, r.max_compressed_block_size,
+                    r.meta_pipe_aligned, r.write_compress_enabled,
+                    r.alpha_is_on_msb, r.color_transform,
                     r.srt_offset, r.sgpr_base, r.fetch_pc, temporal_seed ? " temporal-RTT-seed" : "");
         if (r.host_data && r.host_data_size >= 16 &&
             (r.cls == prosper::gpu::ResourceClass::ConstantBuffer ||


### PR DESCRIPTION
## Summary
- decode the complete GFX10 `SQ_IMG_RSRC_WORD6/7` DCC state, including the separate metadata address
- propagate compression state through direct, dynamic graphics, and compute image resources
- add capture v11 persistence plus `gpu_replay --inspect-only` reporting and a fail-visible live warning
- preserve v1-v10 capture compatibility without inventing metadata bytes or a fake decompression result

## DOLL evidence
A fresh submit-50 v11 capsule reports the active grading input as:

```
PS TEX b=36 fmt=21 32x32x32 tile=27 dcc=1 meta=000000206e130000 blocks=2/1
```

This explains why treating the base allocation as ordinary tiled R10G10B10A2 data produced stable color bands. The resource has no prior tracked GPU writer, so it is a statically uploaded compressed image. Actual DCC metadata capture/decompression remains the next #719 step.

## Validation
- `ctest --output-on-failure`: 97/97 passed
- `test_build_shader_resources`: passed, including exact WORD6/7 decode
- `test_gpu_capture`: passed, including v11 round-trip and v7 legacy reopen
- built `gpu_replay` and `boot_trace`
- fresh DOLL submit-50 capsule opens with `gpu_replay --inspect-only` and retains real DCC state

Refs #719