### PR TITLE
gpu: capture DCC metadata surfaces

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 11;
+constexpr uint32_t kVersion = 12;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -303,6 +303,19 @@ uint64_t resource_footprint(const ShaderResource& r) {
     return std::max(result, decoded);
 }
 
+uint64_t dcc_metadata_footprint(const ShaderResource& r) {
+    if (!r.compression_enabled || !r.metadata_addr ||
+        (r.cls != ResourceClass::Texture && r.cls != ResourceClass::StorageImage) ||
+        bc_block_bytes(r.format))
+        return 0;
+    uint32_t bytes_per_texel = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1u);
+    if (!bytes_per_texel && r.format == DataFormat::Unorm2_10_10_10)
+        bytes_per_texel = 4;
+    const uint32_t layers = r.img_dim == 3u ? 6u : (r.img_dim == 2u ? std::max(r.depth, 1u) : 1u);
+    return gfx10_dcc_metadata_bytes(r.width, r.height, layers, r.tile_mode,
+                                    bytes_per_texel, r.meta_pipe_aligned);
+}
+
 struct Interval {
     uint64_t begin = 0;
     uint64_t end = 0;
@@ -318,11 +331,19 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
         if (!t) return true;
         for (const auto& r : t->resources) {
             uint64_t n = resource_footprint(r);
-            if (!n) continue;
-            if (n > kMaxBlobBytes || r.gpu_addr > std::numeric_limits<uint64_t>::max() - n) {
-                error = "resource capture range is invalid or exceeds 1 GiB"; return false;
+            if (n) {
+                if (n > kMaxBlobBytes || r.gpu_addr > std::numeric_limits<uint64_t>::max() - n) {
+                    error = "resource capture range is invalid or exceeds 1 GiB"; return false;
+                }
+                intervals.push_back({r.gpu_addr, r.gpu_addr + n});
             }
-            intervals.push_back({r.gpu_addr, r.gpu_addr + n});
+            n = dcc_metadata_footprint(r);
+            if (n) {
+                if (n > kMaxBlobBytes || r.metadata_addr > std::numeric_limits<uint64_t>::max() - n) {
+                    error = "DCC metadata capture range is invalid or exceeds 1 GiB"; return false;
+                }
+                intervals.push_back({r.metadata_addr, r.metadata_addr + n});
+            }
         }
         return true;
     };
@@ -359,14 +380,27 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
     if (!src) return true;
     for (const auto& r : src->resources) {
         GpuCapturedResource c; c.resource = r; c.resource.host_data = nullptr; c.resource.host_data_size = 0;
-        uint64_t n = resource_footprint(r);
-        if (n && include_resource_data) {
+        c.resource.dcc_metadata_host_data = nullptr;
+        c.resource.dcc_metadata_host_data_size = 0;
+        c.metadata_size = dcc_metadata_footprint(r);
+        c.resource.dcc_metadata_size = c.metadata_size;
+        auto assign_blob = [&](uint64_t addr, uint64_t bytes, uint32_t& index,
+                               uint64_t& offset, const char* missing) {
             auto it = std::find_if(intervals.begin(), intervals.end(), [&](auto x) {
-                return x.begin <= r.gpu_addr && r.gpu_addr + n <= x.end;
+                return x.begin <= addr && addr + bytes <= x.end;
             });
-            if (it == intervals.end()) { error = "resource was not assigned to a capture blob"; return false; }
-            c.blob_index = it->blob_index; c.blob_offset = r.gpu_addr - it->begin;
-        }
+            if (it == intervals.end()) { error = missing; return false; }
+            index = it->blob_index; offset = addr - it->begin;
+            return true;
+        };
+        uint64_t n = resource_footprint(r);
+        if (n && include_resource_data &&
+            !assign_blob(r.gpu_addr, n, c.blob_index, c.blob_offset,
+                         "resource was not assigned to a capture blob")) return false;
+        if (c.metadata_size && include_resource_data &&
+            !assign_blob(r.metadata_addr, c.metadata_size, c.metadata_blob_index,
+                         c.metadata_blob_offset,
+                         "DCC metadata was not assigned to a capture blob")) return false;
         dst.resources.push_back(std::move(c));
     }
     return true;
@@ -665,6 +699,10 @@ bool capture_failure_diagnostics(
 
 uint64_t gpu_capture_resource_footprint(const ShaderResource& resource) {
     return resource_footprint(resource);
+}
+
+uint64_t gpu_capture_dcc_metadata_footprint(const ShaderResource& resource) {
+    return dcc_metadata_footprint(resource);
 }
 
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
@@ -1036,6 +1074,40 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         if (!write_dcc_state(draw.vrt) || !write_dcc_state(draw.prt)) return false;
     for (const auto& compute : c.computes)
         if (!write_dcc_state(compute.resources)) return false;
+    // v12 captures the exact DCC control surface as a normal content-addressed blob range. Keep the
+    // references in a tail so v1-v11 resource records remain byte-compatible. An invalid blob index
+    // with a non-zero size is intentional for metadata-only and legacy-upgraded captures.
+    w.u32(static_cast<uint32_t>(resource_depth_count));
+    auto write_dcc_metadata = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources) {
+            const uint64_t expected = dcc_metadata_footprint(captured.resource);
+            if (captured.metadata_size != expected ||
+                (!expected && (captured.metadata_blob_index != 0xFFFFFFFFu ||
+                               captured.metadata_blob_offset != 0)) ||
+                (captured.metadata_blob_index == 0xFFFFFFFFu &&
+                 captured.metadata_blob_offset != 0)) {
+                error = "invalid resource DCC metadata reference"; return false;
+            }
+            if (captured.metadata_blob_index != 0xFFFFFFFFu) {
+                if (captured.metadata_blob_index >= c.blobs.size()) {
+                    error = "resource DCC metadata references an invalid capture blob"; return false;
+                }
+                const auto& blob = c.blobs[captured.metadata_blob_index].bytes;
+                if (captured.metadata_blob_offset > blob.size() ||
+                    expected > blob.size() - captured.metadata_blob_offset) {
+                    error = "resource DCC metadata exceeds its capture blob"; return false;
+                }
+            }
+            w.u64(captured.metadata_size);
+            w.u32(captured.metadata_blob_index);
+            w.u64(captured.metadata_blob_offset);
+        }
+        return true;
+    };
+    for (const auto& draw : c.draws)
+        if (!write_dcc_metadata(draw.vrt) || !write_dcc_metadata(draw.prt)) return false;
+    for (const auto& compute : c.computes)
+        if (!write_dcc_metadata(compute.resources)) return false;
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1352,6 +1424,8 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 resource.compression_enabled = (flags & 4u) != 0;
                 resource.alpha_is_on_msb = (flags & 8u) != 0;
                 resource.color_transform = (flags & 16u) != 0;
+                captured.metadata_size = dcc_metadata_footprint(resource);
+                resource.dcc_metadata_size = captured.metadata_size;
             }
             return true;
         };
@@ -1359,6 +1433,48 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (!read_dcc_state(draw.vrt) || !read_dcc_state(draw.prt)) return false;
         for (auto& compute : c.computes)
             if (!read_dcc_state(compute.resources)) return false;
+    }
+    if (version >= 12) {
+        uint64_t expected_refs = 0;
+        for (const auto& draw : c.draws)
+            expected_refs += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected_refs += compute.resources.resources.size();
+        uint32_t ref_count = 0;
+        if (!r.u32(ref_count) || ref_count != expected_refs) {
+            error = "invalid resource DCC-metadata reference count"; return false;
+        }
+        auto read_dcc_metadata = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                if (!r.u64(captured.metadata_size) ||
+                    !r.u32(captured.metadata_blob_index) ||
+                    !r.u64(captured.metadata_blob_offset) ||
+                    captured.metadata_size != dcc_metadata_footprint(captured.resource) ||
+                    (!captured.metadata_size &&
+                     (captured.metadata_blob_index != 0xFFFFFFFFu ||
+                      captured.metadata_blob_offset != 0)) ||
+                    (captured.metadata_blob_index == 0xFFFFFFFFu &&
+                     captured.metadata_blob_offset != 0)) {
+                    error = "invalid resource DCC metadata reference"; return false;
+                }
+                if (captured.metadata_blob_index != 0xFFFFFFFFu) {
+                    if (captured.metadata_blob_index >= c.blobs.size()) {
+                        error = "resource DCC metadata references an invalid capture blob"; return false;
+                    }
+                    const auto& blob = c.blobs[captured.metadata_blob_index].bytes;
+                    if (captured.metadata_blob_offset > blob.size() ||
+                        captured.metadata_size > blob.size() - captured.metadata_blob_offset) {
+                        error = "resource DCC metadata exceeds its capture blob"; return false;
+                    }
+                }
+                captured.resource.dcc_metadata_size = captured.metadata_size;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_dcc_metadata(draw.vrt) || !read_dcc_metadata(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_dcc_metadata(compute.resources)) return false;
     }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -1377,29 +1493,49 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         resource_reference_count += draw.vrt.resources.size() + draw.prt.resources.size();
     for (const auto& compute : c.computes)
         resource_reference_count += compute.resources.resources.size();
-    out.resource_instances.reserve(resource_reference_count);
+    out.resource_instances.reserve(resource_reference_count * 2);
     std::map<std::pair<uint32_t, uint64_t>, size_t> instance_by_version_and_base;
+    auto bind_range = [&](uint32_t blob_index, uint64_t blob_offset, uint64_t guest_addr,
+                          uint64_t need, uint8_t*& host_data, uint64_t& host_data_size,
+                          const char* invalid_error, const char* exceeds_error,
+                          const char* offset_error) {
+        if (blob_index == 0xFFFFFFFFu) return true;
+        if (blob_index >= out.blobs.size() || blob_offset > out.blobs[blob_index].bytes.size()) {
+            error = invalid_error; return false;
+        }
+        const auto& blob = out.blobs[blob_index].bytes;
+        if (need > blob.size() - blob_offset) { error = exceeds_error; return false; }
+        if (blob_offset > guest_addr) { error = offset_error; return false; }
+        const uint64_t logical_base = guest_addr - blob_offset;
+        const auto key = std::make_pair(blob_index, logical_base);
+        auto [it, inserted] = instance_by_version_and_base.emplace(key, out.resource_instances.size());
+        if (inserted)
+            out.resource_instances.push_back({logical_base, blob_index, blob});
+        auto& instance = out.resource_instances[it->second].bytes;
+        host_data = instance.data() + blob_offset;
+        host_data_size = need;
+        return true;
+    };
     auto table = [&](const GpuCapturedTable& src, std::shared_ptr<ShaderResourceTable>& dst) -> bool {
         if (!src.present) { dst.reset(); return src.resources.empty(); }
         dst = std::make_shared<ShaderResourceTable>();
         for (const auto& x : src.resources) {
             ShaderResource r = x.resource; r.host_data = nullptr; r.host_data_size = 0;
-            if (x.blob_index != 0xFFFFFFFFu) {
-                if (x.blob_index >= out.blobs.size() || x.blob_offset > out.blobs[x.blob_index].bytes.size()) {
-                    error = "resource references an invalid capture blob"; return false;
-                }
-                const auto& b = out.blobs[x.blob_index].bytes;
-                uint64_t need = resource_footprint(r);
-                if (need > b.size() - x.blob_offset) { error = "resource footprint exceeds capture blob"; return false; }
-                if (x.blob_offset > r.gpu_addr) { error = "resource blob offset exceeds its logical address"; return false; }
-                const uint64_t logical_base = r.gpu_addr - x.blob_offset;
-                const auto key = std::make_pair(x.blob_index, logical_base);
-                auto [it, inserted] = instance_by_version_and_base.emplace(key, out.resource_instances.size());
-                if (inserted)
-                    out.resource_instances.push_back({logical_base, x.blob_index, b});
-                auto& instance = out.resource_instances[it->second].bytes;
-                r.host_data = instance.data() + x.blob_offset; r.host_data_size = need;
-            }
+            r.dcc_metadata_size = x.metadata_size;
+            r.dcc_metadata_host_data = nullptr;
+            r.dcc_metadata_host_data_size = 0;
+            if (!bind_range(x.blob_index, x.blob_offset, r.gpu_addr, resource_footprint(r),
+                            r.host_data, r.host_data_size,
+                            "resource references an invalid capture blob",
+                            "resource footprint exceeds capture blob",
+                            "resource blob offset exceeds its logical address") ||
+                !bind_range(x.metadata_blob_index, x.metadata_blob_offset, r.metadata_addr,
+                            x.metadata_size, r.dcc_metadata_host_data,
+                            r.dcc_metadata_host_data_size,
+                            "resource DCC metadata references an invalid capture blob",
+                            "resource DCC metadata exceeds capture blob",
+                            "resource DCC metadata blob offset exceeds its logical address"))
+                return false;
             dst->resources.push_back(r);
         }
         return true;

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -47,6 +47,9 @@ struct GpuCapturedResource {
     ShaderResource resource;
     uint32_t blob_index = 0xFFFFFFFFu;
     uint64_t blob_offset = 0;
+    uint64_t metadata_size = 0;
+    uint32_t metadata_blob_index = 0xFFFFFFFFu;
+    uint64_t metadata_blob_offset = 0;
 };
 
 struct GpuCapturedTable {
@@ -229,6 +232,10 @@ bool materialize_gpu_replay(const GpuCaptureFile& capture, GpuReplayFrame& repla
 // Byte range the capture planner reserves for one descriptor. This includes decoded/tiled image
 // storage when it is larger than the descriptor's declared byte count.
 uint64_t gpu_capture_resource_footprint(const ShaderResource& resource);
+
+// Exact supported GFX10 DCC control-surface span for one descriptor, or zero when the descriptor is
+// uncompressed or outside the currently validated SW_64KB_R_X single-sample/base-level contract.
+uint64_t gpu_capture_dcc_metadata_footprint(const ShaderResource& resource);
 
 // The Vulkan frontend owns the RTT and persistent DS caches and registers these hooks when its renderer
 // is installed. Normal capture queries only RTT addresses referenced by the selected submit; final bundle

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -176,6 +176,13 @@ struct ShaderResource {
     bool          color_transform             = false;
     uint64_t      metadata_addr               = 0;
 
+    // Replay-only DCC backing. Captures retain the exact control-surface span separately from the
+    // compressed base allocation. Production tables leave these zero/null and read guest memory by
+    // metadata_addr; a future software decoder can consume either source without changing identity.
+    uint64_t      dcc_metadata_size           = 0;
+    uint8_t*      dcc_metadata_host_data      = nullptr;
+    uint64_t      dcc_metadata_host_data_size = 0;
+
     // Replay-only owned backing. `gpu_addr` remains the captured logical guest address so render-target
     // identity/alias checks stay faithful. Graphics reads from host_data; compute may update it before a
     // later operation consumes the same version. Production tables leave both fields zero and use guest memory.

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <algorithm>
+#include <limits>
 #include <mutex>
 #include <set>
 #include <vector>
@@ -15,6 +16,43 @@ bool tile_mode_is_tiled(uint32_t tile_mode) {
     return tile_mode == (uint32_t)TileMode::Sw4KbS ||
            tile_mode == (uint32_t)TileMode::Sw64KbS ||
            tile_mode == (uint32_t)TileMode::Sw64KbRX;
+}
+
+size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
+                                uint32_t tile_mode, uint32_t bytes_per_texel,
+                                bool pipe_aligned) {
+    if (tile_mode != (uint32_t)TileMode::Sw64KbRX || !width || !height || !depth)
+        return 0;
+    uint32_t elem_log2 = 0;
+    switch (bytes_per_texel) {
+        case 1: elem_log2 = 0; break;
+        case 2: elem_log2 = 1; break;
+        case 4: elem_log2 = 2; break;
+        case 8: elem_log2 = 3; break;
+        case 16: elem_log2 = 4; break;
+        default: return 0;
+    }
+
+    // AddrLib GetMetaBlkSize(Gfx10DataColor): PS5's 16-pipe R_X configuration resolves to a
+    // 2^12-byte metadata block for both pipe-aligned and unaligned single-sample surfaces. A color
+    // compression block is 2^8 bytes and one DCC metadata element is one byte.
+    (void)pipe_aligned;
+    constexpr uint64_t meta_block_bytes = 1u << 12;
+    const uint32_t meta_bits_log2 = 12u + 8u - elem_log2;
+    const uint64_t meta_width = 1ull << ((meta_bits_log2 + 1u) / 2u);
+    const uint64_t meta_height = 1ull << (meta_bits_log2 / 2u);
+    const uint64_t blocks_w = (static_cast<uint64_t>(width) + meta_width - 1u) / meta_width;
+    const uint64_t blocks_h = (static_cast<uint64_t>(height) + meta_height - 1u) / meta_height;
+    if (blocks_w > std::numeric_limits<uint64_t>::max() / blocks_h)
+        return 0;
+    const uint64_t blocks_per_slice = blocks_w * blocks_h;
+    if (blocks_per_slice > std::numeric_limits<uint64_t>::max() / depth)
+        return 0;
+    const uint64_t blocks = blocks_per_slice * depth;
+    if (blocks > std::numeric_limits<uint64_t>::max() / meta_block_bytes)
+        return 0;
+    const uint64_t bytes = blocks * meta_block_bytes;
+    return bytes <= std::numeric_limits<size_t>::max() ? static_cast<size_t>(bytes) : 0;
 }
 
 // One-time diagnostic when a NON-ZERO (tiled) tile_mode is not one of the swizzles we de-swizzle

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -71,4 +71,12 @@ bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
                  uint32_t width, uint32_t height, uint32_t depth,
                  uint32_t tile_mode, uint32_t bytes_per_texel);
 
+// GFX10 DCC control-surface size for the single-sample, base-level SW_64KB_R_X images currently
+// emitted by PS5 Unreal. The PS5/default 16-pipe layout uses a 4 KiB metadata block. Each byte in
+// that block describes one 256-byte compressed block, so the covered texel extent follows AddrLib's
+// thin-resource equation. Returns zero for unsupported swizzles/element sizes or overflow.
+size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
+                                uint32_t tile_mode, uint32_t bytes_per_texel,
+                                bool pipe_aligned);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1,5 +1,6 @@
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/pm4_registers.hpp"
+#include "../src/gpu/tile.hpp"
 
 #include <cstdio>
 #include <cstdlib>
@@ -143,6 +144,69 @@ int main() {
     set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", nullptr);
     set_test_env("PROSPER_GPU_CAPTURE_MAX_MB", nullptr);
 
+    // --- v12: capture the separate GFX10 DCC control surface for Unreal's R_X volume LUTs. ---
+    ShaderResource volume_dcc{};
+    volume_dcc.cls = ResourceClass::Texture; volume_dcc.binding = 7;
+    volume_dcc.gpu_addr = 0x100000; volume_dcc.size = 32 * 32 * 32 * 4;
+    volume_dcc.format = DataFormat::Sint32; volume_dcc.num_components = 1;
+    volume_dcc.img_dim = 2; volume_dcc.width = 32; volume_dcc.height = 32;
+    volume_dcc.depth = 32; volume_dcc.tile_mode = (uint32_t)TileMode::Sw64KbRX;
+    volume_dcc.compression_enabled = true; volume_dcc.meta_pipe_aligned = true;
+    volume_dcc.metadata_addr = 0x400000;
+    CHECK(gpu_capture_dcc_metadata_footprint(volume_dcc) == 128 * 1024,
+          "32x32x32 R_X volume descriptor plans the validated 128 KiB DCC span");
+    auto volume_table = std::make_shared<ShaderResourceTable>();
+    volume_table->resources = {volume_dcc};
+    DrawItem volume_draw; volume_draw.vs = {0x07230203, 31};
+    volume_draw.fs = {0x07230203, 32}; volume_draw.vrt = volume_table;
+    auto volume_reader = [](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        for (size_t i = 0; i < n; ++i) {
+            const uint64_t at = addr + i;
+            dst[i] = static_cast<uint8_t>(at ^ (at >> 11) ^ (at >> 23));
+        }
+        return n;
+    };
+    GpuCaptureFile volume_capture;
+    CHECK(capture_draw_items({volume_draw}, meta, volume_reader, volume_capture, error),
+          "capture reads a compressed base allocation and its separate DCC control surface");
+    const auto& captured_volume = volume_capture.draws[0].vrt.resources[0];
+    CHECK(volume_capture.blobs.size() == 2 && captured_volume.metadata_size == 128 * 1024 &&
+          captured_volume.metadata_blob_index != 0xFFFFFFFFu &&
+          volume_capture.blobs[captured_volume.metadata_blob_index].guest_addr == 0x400000 &&
+          volume_capture.blobs[captured_volume.metadata_blob_index].bytes.size() == 128 * 1024,
+          "DCC metadata receives an exact independently-addressed content blob");
+    std::vector<uint8_t> volume_bytes;
+    CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
+          "v12 DCC metadata capture serializes");
+    GpuCaptureFile volume_loaded;
+    GpuReplayFrame volume_replay;
+    CHECK(deserialize_gpu_capture(volume_bytes, volume_loaded, error) &&
+          materialize_gpu_replay(volume_loaded, volume_replay, error) &&
+          volume_replay.items[0].vrt->resources[0].dcc_metadata_host_data &&
+          volume_replay.items[0].vrt->resources[0].dcc_metadata_host_data_size == 128 * 1024 &&
+          volume_replay.resource_instances.size() == 2,
+          "v12 replay owns base and DCC bytes as distinct mutable address instances");
+    GpuCaptureFile bad_metadata_ref = volume_capture;
+    bad_metadata_ref.draws[0].vrt.resources[0].metadata_blob_offset = 128 * 1024;
+    CHECK(!serialize_gpu_capture(bad_metadata_ref, volume_bytes, error) &&
+          error == "resource DCC metadata exceeds its capture blob",
+          "writer rejects an out-of-bounds DCC metadata reference");
+    CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
+          "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 24); // v12 count plus one 20-byte reference
+    volume_bytes[8] = 11; volume_bytes[9] = volume_bytes[10] = volume_bytes[11] = 0;
+    CHECK(deserialize_gpu_capture(volume_bytes, volume_loaded, error) &&
+          volume_loaded.draws[0].vrt.resources[0].metadata_size == 128 * 1024 &&
+          volume_loaded.draws[0].vrt.resources[0].metadata_blob_index == 0xFFFFFFFFu,
+          "v11 capsule reopens with the DCC span derivable but metadata bytes explicitly unavailable");
+    set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1");
+    CHECK(capture_draw_items({volume_draw}, meta, volume_reader, volume_capture, error) &&
+          volume_capture.blobs.empty() &&
+          volume_capture.draws[0].vrt.resources[0].metadata_size == 128 * 1024 &&
+          volume_capture.draws[0].vrt.resources[0].metadata_blob_index == 0xFFFFFFFFu,
+          "metadata-only capture retains the planned DCC span without pretending bytes exist");
+    set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", nullptr);
+
     captured.expected_output_valid = true;
     captured.expected_output_hash = 0x1122334455667788ull; captured.expected_output_bytes = 480ull * 270 * 4;
     GpuCaptureDsSeed ds_seed;
@@ -170,7 +234,7 @@ int main() {
           deserialize_gpu_capture(stencil_only_bytes, stencil_only_loaded, error) &&
           !stencil_only_loaded.ds_seeds[0].depth_valid &&
           stencil_only_loaded.ds_seeds[0].stencil_valid,
-          "stencil-only validity survives capture v11 independently of depth");
+          "stencil-only validity survives capture v12 independently of depth");
     GpuCaptureFile invalid_stencil_format = stencil_only;
     invalid_stencil_format.ds_seeds[0].format = GpuCaptureDsFormat::D32Float;
     CHECK(!serialize_gpu_capture(invalid_stencil_format, stencil_only_bytes, error) &&
@@ -206,7 +270,7 @@ int main() {
           !loaded_dcc.color_transform && loaded_dcc.max_uncompressed_block_size == 2 &&
           loaded_dcc.max_compressed_block_size == 1 &&
           loaded_dcc.metadata_addr == 0x206e33ab00ull,
-          "v11 resource DCC descriptor state round-trips without inventing metadata bytes");
+          "v11 resource DCC descriptor state remains intact in the v12 capsule");
     CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");
@@ -370,10 +434,12 @@ int main() {
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 28,
-          "created a diagnostic-free v11 payload for legacy-reader fixtures");
+          "created a diagnostic-free v12 payload for legacy-reader fixtures");
     if (legacy_bytes.size() >= 28) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        // Remove the v12 DCC metadata-reference tail: count + 20-byte reference per resource.
+        legacy_bytes.resize(legacy_bytes.size() - (4 + 20 * legacy_resource_count));
         // Remove the v11 DCC tail: count + 17-byte state record per resource.
         legacy_bytes.resize(legacy_bytes.size() - (4 + 17 * legacy_resource_count));
         // Remove the v10 MRT tail: draw count + one (target identity + 50-byte pipeline state) +
@@ -394,9 +460,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 12;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 13;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 12",
+          error == "unsupported capture version 13",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -459,6 +459,13 @@ int main() {
     if (!getenv("PROSPER_RX_PIPES")) {
         const uint32_t M = (uint32_t)TileMode::Sw64KbRX;
         CHECK(tile_mode_supports_volume(M), "SW_64KB_R_X has an explicit 3D pipe-XOR pattern");
+        CHECK(gfx10_dcc_metadata_bytes(32, 32, 32, M, 4, true) == 128 * 1024,
+              "32x32x32 RGBA8 R_X DCC occupies one 4 KiB metadata block per slice");
+        CHECK(gfx10_dcc_metadata_bytes(513, 512, 1, M, 4, true) == 8 * 1024,
+              "R_X DCC sizing rounds a 4-B image to 512x512 metadata-block coverage");
+        CHECK(gfx10_dcc_metadata_bytes(32, 32, 32, (uint32_t)TileMode::Sw64KbS,
+                                       4, true) == 0,
+              "DCC sizing rejects a swizzle outside the supported R_X contract");
         CHECK(tiled_volume_bytes(120, 68, 32, M, 8) == (size_t)1 * 2 * 32 * 65536,
               "120x68x32 @ 8 B uses 1x2 padded 2D blocks per Z slice");
         auto rt_volume = [&](uint32_t bpe) {

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -150,8 +150,10 @@ an evidence-gated optimization, not automatic dependency closure.
 `--bundle-final-capsule PATH` snapshots the complete live color RTT and persistent Vulkan depth/stencil caches
 before executing the final submit and writes them as seeds in a standalone current-version capsule. Capture v9
 introduced the base-level depth of every 3D image resource; v11 also retains each image T#'s GFX10 DCC flags,
-block-size fields, and metadata address. `--inspect-only` reports compressed base allocations explicitly;
-metadata bytes and a software DCC decode are not inferred. The capsule's standalone
+block-size fields, and metadata address. Version 12 captures the exact DCC control-surface bytes for the
+validated single-sample/base-level SW_64KB_R_X layout; metadata-only and older capsules keep their absence
+explicit. `--inspect-only` reports the planned/captured byte counts, non-zero and unique-byte counts,
+first control word, and content hash. A software DCC decode is still not inferred. The capsule's standalone
 output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or
 shader experiments. Export validates every surface and fails when a required temporal color surface is absent;
 it never substitutes zero pixels. The file is installed only after the source final submit renders, and embeds

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -164,13 +164,32 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
             if (r.host_data_size >= 4) std::memcpy(&first, r.host_data, 4);
         }
         uint64_t hash = r.host_data ? prosper::gpu::gpu_capture_hash(r.host_data, static_cast<size_t>(r.host_data_size)) : 0;
+        size_t metadata_nz = 0, metadata_unique = 0;
+        size_t metadata_histogram[256] = {};
+        uint32_t metadata_first = 0;
+        if (r.dcc_metadata_host_data) {
+            for (uint64_t i = 0; i < r.dcc_metadata_host_data_size; ++i) {
+                const uint8_t value = r.dcc_metadata_host_data[i];
+                metadata_nz += value != 0;
+                metadata_histogram[value]++;
+            }
+            for (size_t count : metadata_histogram) metadata_unique += count != 0;
+            if (r.dcc_metadata_host_data_size >= 4)
+                std::memcpy(&metadata_first, r.dcc_metadata_host_data, 4);
+        }
+        const uint64_t metadata_hash = r.dcc_metadata_host_data
+            ? prosper::gpu::gpu_capture_hash(r.dcc_metadata_host_data,
+                                             static_cast<size_t>(r.dcc_metadata_host_data_size))
+            : 0;
         const bool temporal_seed = std::any_of(seeds.begin(), seeds.end(), [&](const auto& seed) {
             return seed.guest_addr == r.gpu_addr;
         });
         std::printf("  %s %-7s b=%u addr=%016llx declared=%u footprint=%llu captured=%llu "
                     "nz=%zu hash=%016llx first=%08x "
                     "fmt=%u nc=%u stride=%u %ux%ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
-                    "dcc=%u meta=%016llx blocks=%u/%u flags=%u%u%u%u "
+                    "dcc=%u meta=%016llx meta-bytes=%llu/%llu meta-nz=%zu meta-unique=%zu "
+                    "meta-first=%08x meta-hash=%016llx "
+                    "blocks=%u/%u flags=%u%u%u%u "
                     "srt=%08x sgpr=%08x pc=%08x%s\n",
                     stage, class_name(r.cls), r.binding, static_cast<unsigned long long>(r.gpu_addr),
                     r.size,
@@ -183,6 +202,10 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
                     r.swizzle[0], r.swizzle[1], r.swizzle[2], r.swizzle[3],
                     r.mag_filter, r.min_filter, r.mip_filter,
                     r.compression_enabled, static_cast<unsigned long long>(r.metadata_addr),
+                    static_cast<unsigned long long>(r.dcc_metadata_host_data_size),
+                    static_cast<unsigned long long>(r.dcc_metadata_size), metadata_nz,
+                    metadata_unique, metadata_first,
+                    static_cast<unsigned long long>(metadata_hash),
                     r.max_uncompressed_block_size, r.max_compressed_block_size,
                     r.meta_pipe_aligned, r.write_compress_enabled,
                     r.alpha_is_on_msb, r.color_transform,


### PR DESCRIPTION
## Summary

- derive the validated GFX10 SW_64KB_R_X DCC control-surface extent for PS5's 16-pipe, single-sample base-level images
- capture DCC metadata as a separate content-addressed guest range and materialize replay-owned metadata backing
- bump capsules to v12 while retaining v1-v11 reads and explicit metadata-only/legacy absence
- report metadata byte counts, non-zero/unique counts, first word, and hash in `gpu_replay --inspect-only`

Continues #719. This deliberately captures truthful inputs for software DCC handling; it does not yet pretend arbitrary compressed blocks are decoded.

## Live Unreal evidence

A fresh DOLL submit-50 capture (`/root/doll719_ui165_dccv12cap.prgcap`, 181 MiB) completed and reopened offline. The computed spans match every supported live descriptor inspected, including:

- 32x32x32 LUT: 131072/131072 metadata bytes, uniform `0x00`
- 120x68x32 post-process volumes: 131072/131072 bytes, uniform `0x40`
- 1920x1080 surface: 16384/16384 bytes, uniform `0x80`
- 960x540 surface: 8192/8192 bytes
- 40x5x5 volumes: 20480/20480 bytes

Mesa's AMD definitions identify `0x00`, `0x40`, and `0x80` as GFX8-10 fast-clear codes (`0xFF` is uncompressed). This gives the next PR a narrow evidence-backed target: materialize uniform fast clears first, then leave genuinely compressed blocks fail-visible.

## Verification

- full Linux build
- `ctest --output-on-failure`: 97/97 passed
- focused `test_tile` and `test_gpu_capture` coverage for sizing, v12 round-trip, malformed references, metadata-only capture, and v11 compatibility
- real DOLL v12 capture and offline inspection succeeded