### PR TITLE
feat(gpu): add opt-in DCC fast-clear decode

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -71,6 +71,8 @@ struct TextureDecodeKey {
     uint32_t max_uncompressed_block_size = 0, max_compressed_block_size = 0;
     uint32_t dcc_flags = 0;
     uint64_t metadata_addr = 0;
+    uint64_t metadata_host_data = 0;
+    uint64_t metadata_host_data_size = 0;
     bool operator==(const TextureDecodeKey&) const = default;
 };
 
@@ -87,6 +89,7 @@ struct TextureDecodeKeyHash {
         mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height); mix(key.depth);
         mix(key.tile_mode); mix(key.img_dim); mix(key.max_uncompressed_block_size);
         mix(key.max_compressed_block_size); mix(key.dcc_flags); mix(key.metadata_addr);
+        mix(key.metadata_host_data); mix(key.metadata_host_data_size);
         return hash;
     }
 };
@@ -493,8 +496,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         std::memcpy(dst, r.host_data + off, take);
                         return take;
                     };
+                    auto copy_dcc_metadata = [&](uint8_t* dst, size_t n) -> size_t {
+                        if (!r.dcc_metadata_host_data)
+                            return safe_copy(dst, r.metadata_addr, n);
+                        const size_t take = static_cast<size_t>(std::min<uint64_t>(
+                            n, r.dcc_metadata_host_data_size));
+                        std::memcpy(dst, r.dcc_metadata_host_data, take);
+                        return take;
+                    };
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
+                        const char* dcc_fast_clear = getenv("PROSPER_DCC_FAST_CLEAR");
+                        const bool dcc_fast_clear_enabled =
+                            dcc_fast_clear && atoi(dcc_fast_clear) != 0;
                         const TextureDecodeKey decode_key{
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
                             r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
@@ -509,6 +523,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                    (r.color_transform ? 16u : 0u))
                                 : 0u,
                             r.compression_enabled ? r.metadata_addr : 0u,
+                            r.compression_enabled
+                                ? static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
+                                      r.dcc_metadata_host_data))
+                                : 0u,
+                            r.compression_enabled ? r.dcc_metadata_host_data_size : 0u,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
                         const bool has_cpu_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() &&
@@ -521,16 +540,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::find_persistent_color_target(
                                 r.gpu_addr, tw, th, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
                         const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
-                        if (r.compression_enabled && !has_live_rtt) {
-                            static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
-                            if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
-                                fprintf(stderr,
-                                        "[render] DCC-compressed sampled image addr=0x%llx meta=0x%llx "
-                                        "%ux%ux%u fmt=%u tile=%u is unsupported; base bytes are not a valid decode\n",
-                                        (unsigned long long)r.gpu_addr,
-                                        (unsigned long long)r.metadata_addr,
-                                        tw, th, r.depth, (unsigned)r.format, r.tile_mode);
-                        }
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
@@ -549,6 +558,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (!getenv("PROSPER_DETILE") || atoi(getenv("PROSPER_DETILE")) == 0);
                         const bool persistent_cache_eligible =
                             !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
+                            !(r.compression_enabled && dcc_fast_clear_enabled) &&
                             persistent_decode_limit &&
                             (persistent_source_is_tiled || persistent_source_matches_pixels);
                         const size_t persistent_source_size = persistent_source_matches_pixels
@@ -761,6 +771,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
+                        bool dcc_fast_clear_done = false;
+                        bool cube_done = false;
                         if (rtt_on && !is_volume) { auto rit = g_rtt.find(r.gpu_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&
                                 !rit->second.rgba->empty()) {
@@ -807,6 +819,66 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
                                         rtt_hit ? "HIT" : "miss", g_rtt.size());
                         }
+                        // GFX8-GFX10 embeds four self-contained 0/1 fast clears in DCC metadata. A
+                        // uniform metadata surface means every compression block has that same value,
+                        // so it can be materialized without interpreting any base bytes. This remains
+                        // opt-in until emulated GPU writers also keep guest DCC metadata coherent: DOLL
+                        // initializes uniform metadata, then relies on compute programs we currently skip.
+                        // All other codes remain fail-visible; 0xff explicitly means the base allocation
+                        // is uncompressed.
+                        if (r.compression_enabled && !rtt_hit && dcc_fast_clear_enabled) {
+                            const uint64_t metadata_bytes =
+                                prosper::gpu::gpu_capture_dcc_metadata_footprint(r);
+                            std::vector<uint8_t> metadata(static_cast<size_t>(metadata_bytes), 0);
+                            const size_t metadata_got = metadata_bytes
+                                ? copy_dcc_metadata(metadata.data(), metadata.size()) : 0;
+                            uint8_t clear_code = 0;
+                            if (metadata_got == metadata.size() &&
+                                prosper::gpu::gfx10_dcc_fast_clear_rgba8(
+                                    texture_pixels.data(), texture_pixels.size() / 4,
+                                    metadata.data(), metadata.size(), r.num_components,
+                                    r.alpha_is_on_msb, &clear_code)) {
+                                dcc_fast_clear_done = true;
+                                cube_done = is_cube;
+                                static std::set<std::pair<uint64_t, uint64_t>> decoded_dcc_images;
+                                if (decoded_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                    fprintf(stderr,
+                                            "[render] DCC fast-clear addr=0x%llx meta=0x%llx "
+                                            "%ux%ux%u fmt=%u code=0x%02x bytes=%zu\n",
+                                            (unsigned long long)r.gpu_addr,
+                                            (unsigned long long)r.metadata_addr,
+                                            tw, th, r.depth, (unsigned)r.format, clear_code,
+                                            metadata.size());
+                            } else {
+                                const bool uncompressed = metadata_got == metadata.size() &&
+                                    !metadata.empty() &&
+                                    std::all_of(metadata.begin(), metadata.end(),
+                                                [](uint8_t code) { return code == 0xff; });
+                                if (!uncompressed) {
+                                    static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
+                                    if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                        fprintf(stderr,
+                                                "[render] DCC-compressed sampled image addr=0x%llx "
+                                                "meta=0x%llx %ux%ux%u fmt=%u tile=%u is unsupported; "
+                                                "metadata=%zu/%llu first=0x%02x\n",
+                                                (unsigned long long)r.gpu_addr,
+                                                (unsigned long long)r.metadata_addr,
+                                                tw, th, r.depth, (unsigned)r.format, r.tile_mode,
+                                                metadata_got,
+                                                (unsigned long long)metadata_bytes,
+                                                metadata_got ? metadata[0] : 0u);
+                                }
+                            }
+                        } else if (r.compression_enabled && !rtt_hit) {
+                            static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
+                            if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                fprintf(stderr,
+                                        "[render] DCC-compressed sampled image addr=0x%llx meta=0x%llx "
+                                        "%ux%ux%u fmt=%u tile=%u is unsupported; base bytes are not a valid decode\n",
+                                        (unsigned long long)r.gpu_addr,
+                                        (unsigned long long)r.metadata_addr,
+                                        tw, th, r.depth, (unsigned)r.format, r.tile_mode);
+                        }
                         // CUBE texture (#273 — DOLL's title reflection probes / skybox): six faces,
                         // each an independently-tiled w x h surface, laid out face-major at
                         // gpu_addr + f*face_stride; decode each into rows [f*th, (f+1)*th) of the
@@ -814,8 +886,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // detile + decode; anything else reads 4 B/texel with the surface detiler.
                         // CONFIDENCE: MED on the face stride (padded tiled footprint) — visually
                         // validated; a wrong stride garbles faces 1..5, it cannot crash (safe_copy).
-                        bool cube_done = false;
-                        if (is_cube && !rtt_hit) {
+                        if (is_cube && !rtt_hit && !dcc_fast_clear_done) {
                             const uint32_t cb = prosper::gpu::bc_block_bytes(r.format);
                             const bool ctiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                             for (uint32_t fface = 0; fface < 6; fface++) {
@@ -852,8 +923,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
                         // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
                         // 16 bytes -> SW_4KB_S 16x16-block micro-tiles). #121.
-                        const uint32_t bcb = (rtt_hit || cube_done) ? 0u : prosper::gpu::bc_block_bytes(r.format);
-                        if (rtt_hit || cube_done) { /* pixels already injected/stacked above */ }
+                        const uint32_t bcb = (rtt_hit || cube_done || dcc_fast_clear_done)
+                            ? 0u : prosper::gpu::bc_block_bytes(r.format);
+                        if (rtt_hit || cube_done || dcc_fast_clear_done) { /* pixels already injected/stacked above */ }
                         else if (bcb) {
                             uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
                             // Block-detile: tiled_elements_bytes/detile_elements now derive the 4KB
@@ -975,7 +1047,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!rtt_hit && !cube_done && !bcb && !narrow_done && !f16_done &&
+                        if (!rtt_hit && !cube_done && !dcc_fast_clear_done && !bcb && !narrow_done && !f16_done &&
                             !getenv("PROSPER_NODETILE") &&
                             (auto_tiled || (!is_volume && dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
@@ -1014,7 +1086,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
                         // above already produced linear packed words; unpack each to RGBA8 in place with
                         // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
-                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Float10_11_11) {
+                        if (!rtt_hit && !dcc_fast_clear_done &&
+                            r.format == prosper::gpu::DataFormat::Float10_11_11) {
                             uint8_t* tp = texture_pixels.data();
                             for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);
@@ -1030,7 +1103,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Packed R10G10B10A2 UNORM (GFX10 IMG_FMT 50 / "2_10_10_10_UNORM"):
                         // the generic 4-B read and detile above preserve packed texels; normalize each
                         // field to the RGBA8 image format used by this renderer before sampling.
-                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
+                        if (!rtt_hit && !dcc_fast_clear_done &&
+                            r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
                             uint8_t* tp = texture_pixels.data();
                             for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -55,6 +55,30 @@ size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
     return bytes <= std::numeric_limits<size_t>::max() ? static_cast<size_t>(bytes) : 0;
 }
 
+bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
+                                const uint8_t* metadata, size_t metadata_bytes,
+                                uint32_t num_components, bool alpha_is_on_msb,
+                                uint8_t* clear_code) {
+    if (!metadata || !metadata_bytes || num_components != 4 || (!dst && texel_count))
+        return false;
+    const uint8_t code = metadata[0];
+    if (code != 0x00 && code != 0x40 && code != 0x80 && code != 0xc0)
+        return false;
+    if (!std::all_of(metadata + 1, metadata + metadata_bytes,
+                     [=](uint8_t value) { return value == code; }))
+        return false;
+
+    const uint8_t color = (code == 0x80 || code == 0xc0) ? 255 : 0;
+    const uint8_t alpha = (code == 0x40 || code == 0xc0) ? 255 : 0;
+    const uint32_t alpha_component = alpha_is_on_msb ? 3u : 0u;
+    uint8_t pixel[4] = {color, color, color, color};
+    pixel[alpha_component] = alpha;
+    for (size_t i = 0; i < texel_count; ++i)
+        std::memcpy(dst + i * 4, pixel, sizeof(pixel));
+    if (clear_code) *clear_code = code;
+    return true;
+}
+
 // One-time diagnostic when a NON-ZERO (tiled) tile_mode is not one of the swizzles we de-swizzle
 // (Sw4KbS=5 / Sw64KbS=9 / Sw64KbRX=27): the caller then copies the surface VERBATIM as if linear, so
 // it samples as a scrambled swizzle-weave. Other GFX10 modes a PS5 T# can legally carry — SW_256B_*,

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -79,4 +79,14 @@ size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
                                 uint32_t tile_mode, uint32_t bytes_per_texel,
                                 bool pipe_aligned);
 
+// Materialize a uniform, self-contained GFX8-GFX10 DCC fast-clear code into the renderer's RGBA8
+// upload format. The validated path is deliberately limited to four-component surfaces and the
+// embedded 0000/0001/1110/1111 codes; register clears, single-color codes, uncompressed (0xff), and
+// actual compressed blocks return false. `alpha_is_on_msb` selects the raw component that receives
+// the clear alpha before the T# destination swizzle is applied.
+bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
+                                const uint8_t* metadata, size_t metadata_bytes,
+                                uint32_t num_components, bool alpha_is_on_msb,
+                                uint8_t* clear_code = nullptr);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -466,6 +466,41 @@ int main() {
         CHECK(gfx10_dcc_metadata_bytes(32, 32, 32, (uint32_t)TileMode::Sw64KbS,
                                        4, true) == 0,
               "DCC sizing rejects a swizzle outside the supported R_X contract");
+        std::vector<uint8_t> clear_pixels(8, 0xaa);
+        const std::vector<uint8_t> clear_0001(4096, 0x40);
+        uint8_t clear_code = 0xff;
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 2,
+                                         clear_0001.data(), clear_0001.size(),
+                                         4, true, &clear_code) && clear_code == 0x40 &&
+              clear_pixels == std::vector<uint8_t>({0, 0, 0, 255, 0, 0, 0, 255}),
+              "uniform DCC_CLEAR_0001 materializes color zero and MSB alpha one");
+        const std::vector<uint8_t> clear_0000(16, 0x00);
+        const std::vector<uint8_t> clear_1111(16, 0xc0);
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_0000.data(), clear_0000.size(), 4, true) &&
+              clear_pixels[0] == 0 && clear_pixels[1] == 0 &&
+              clear_pixels[2] == 0 && clear_pixels[3] == 0 &&
+              gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_1111.data(), clear_1111.size(), 4, true) &&
+              clear_pixels[0] == 255 && clear_pixels[1] == 255 &&
+              clear_pixels[2] == 255 && clear_pixels[3] == 255,
+              "uniform DCC_CLEAR_0000 and DCC_CLEAR_1111 materialize all-zero/all-one");
+        const std::vector<uint8_t> clear_1110(16, 0x80);
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_1110.data(), clear_1110.size(),
+                                         4, false) &&
+              clear_pixels[0] == 0 && clear_pixels[1] == 255 &&
+              clear_pixels[2] == 255 && clear_pixels[3] == 255,
+              "uniform DCC_CLEAR_1110 places alpha zero in the LSB component");
+        std::vector<uint8_t> mixed_clear(16, 0); mixed_clear.back() = 0x40;
+        const std::vector<uint8_t> uncompressed(16, 0xff);
+        CHECK(!gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                          mixed_clear.data(), mixed_clear.size(), 4, true) &&
+              !gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                          uncompressed.data(), uncompressed.size(), 4, true) &&
+              !gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                          clear_0001.data(), clear_0001.size(), 2, true),
+              "mixed, uncompressed, and unvalidated component layouts remain unsupported");
         CHECK(tiled_volume_bytes(120, 68, 32, M, 8) == (size_t)1 * 2 * 32 * 65536,
               "120x68x32 @ 8 B uses 1x2 padded 2D blocks per Z slice");
         auto rt_volume = [&](uint32_t bpe) {


### PR DESCRIPTION
## Summary
- add a pure decoder for uniform GFX8-GFX10 DCC 0000/0001/1110/1111 fast-clear metadata
- materialize replay-owned or live metadata into RGBA8 without reading invalid compressed base bytes
- keep the live path opt-in behind `PROSPER_DCC_FAST_CLEAR=1` until emulated GPU writers keep guest DCC metadata coherent
- retain fail-visible diagnostics for mixed, unsupported, or unavailable metadata

## Validation
- full Linux build
- 97/97 CTest tests pass
- submit-165 replay detects and materializes both consumed 32x32x32 Unreal LUTs
- live DOLL opt-in run reached submit 165 and captured five additional uniform clears
- default remains unchanged because opt-in exposed an existing coherency gap: skipped DOLL compute programs leave initialized DCC metadata stale and visibly mask the CRIWARE splash

## Why draft
The decoding primitive and capture/replay plumbing are tested, but enabling it by default would currently be a visible regression. The next step is to make emulated GPU writes update/invalidate DCC metadata, then repeat the live comparison.

Refs #719