### PR TITLE
renderer: preserve native FP16 render targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,8 @@ Bundle v2 (#606) now uses fault-safe bulk guest reads plus an exact shared-resou
 windows, successful-only exit, final compaction, and `gpu_replay --bundle-tail` prevent timing drift and replay
 holes. A compact two-submit closure resolves both 642x362 edges with no bounded leaves, but its 80-draw endpoint
 is the opening vignette rather than gameplay. The preserved #608 playable bundle used exactly 90 semantic draws
-and the 738x420 target at draw 79..81. Current routes use 91..93 draws, exactly 8 dispatches, and the 738x420
-target at draw 80..82; two independent timelines selected only sustained gameplay from about 29.5 seconds onward.
+and the 738x420 target at draw 79..81. Current routes use 91..94 draws, exactly 8 dispatches, and the 636x420
+target at draw 77..85; timeline selection isolates sustained gameplay without depending on run-local submits.
 Target extent or total draw count alone also selects cinematic/transition frames and must not be used as the
 oracle. This checkpoint established the stable offline baseline used to isolate the composition defects.
 The faithful playable bundle spans submits 18,165..19,047, stores 158.94 GiB logical state in 739 MiB, and
@@ -198,6 +198,13 @@ G-buffer plane as color0. Selecting MRT0 restores the full-color Prisoners' Quar
 also exposes the directly placed destination V# for a format-copy compute shader, taking the current checkpoint
 from seven to eight realized dispatches. #566 is closed. Use `prosper/docs/DEAD_CELLS_STATUS.md` for the current
 route and regression workflow rather than restarting the completed composition localization.
+
+The later giant translucent gameplay surface was native-format loss (#773). Draw 23 sampled a 642x362
+`Float16x4` lighting target that the backend had rendered and reuploaded as RGBA8, clamping its HDR data.
+Renderer-owned targets now preserve `VK_FORMAT_R16G16B16A16_SFLOAT` through attachments, readback/seed bytes,
+sampled images, and persistent target/texture/pipeline cache identities. Capture v13 tags RTT seeds as `rgba8`
+or `rgba16f` and reads v1..v12 artifacts. The current semantic selector is documented in
+`prosper/docs/DEAD_CELLS_STATUS.md`; do not reuse the historical 738x420 predicate for new captures.
 
 `--bundle-final-capsule` snapshots both color RTT state and exact valid planes from persistent Vulkan
 depth/stencil images into capture v8 (#569). Capture v8 reads v1-v7 artifacts; pre-v7 failed-operation diagnostics

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -55,6 +55,10 @@ possible without console keys. Dumps are user-supplied and gitignored.
   faithful offline isolation (#568/#594/#569). Dispatch thread counts and derived workgroup dimensions,
   compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
   (#580/#576/#584).
+  The later giant translucent Dead Cells gameplay surface was a native-format loss: a 642x362 RGBA16F lighting
+  target was rendered and sampled as RGBA8, clamping HDR values before composition. Renderer-owned targets now
+  preserve RGBA16F through render, readback, seeding, sampling, and persistent Vulkan caches. Capture v13 records
+  the RTT format and remains backward-compatible with v1..v12 artifacts (#773).
 - ✅ **Blasphemous 2 reaches first gameplay:** prelinking the title's optional FMOD core/studio
   plugins lets IL2CPP P/Invoke complete `FMODAudioBanksManager` initialization (#638/#640). The later AGC
   fault was prosper corrupting live DCB state: `+kSrjIVxKFE` is `sceAgcDcbPushMarker`, not the context
@@ -73,8 +77,8 @@ possible without console keys. Dumps are user-supplied and gitignored.
   run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal
   642×362 edges without bounded leaves, but the first 80-draw semantic endpoint is the opening vignette rather
   than playable gameplay. The preserved #608 bundle selected the Jump tutorial with exactly 90 draws and the
-  738x420 pass at draw 79..81. Current routes are selected without submit ordinals by combining 91..93 semantic
-  draws, exactly 8 dispatches, and that pass at draw 80..82. Timeline v6 records compact target spans so the
+  738x420 pass at draw 79..81. Current routes are selected without submit ordinals by combining 91..94 semantic
+  draws, exactly 8 dispatches, and the 636x420 pass at draw 77..85. Timeline v6 records compact target spans so the
   predicate can be discovered and validated offline before an expensive detailed capture (#594).
   The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
   failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -31,6 +31,15 @@ first color export from shaders that emit MRT3..MRT0; MRT0 now feeds the backend
 The same change set recovers a separately dropped format-copy dispatch by resolving its directly placed
 destination buffer descriptor at s4.
 
+Issue #773 exposed a later generic format gap as a giant translucent green/blue surface over gameplay. A
+deterministic operation-prefix replay localized the first bad composite to draw 23 sampling binding 36: a
+642x362 `Float16x4` lighting target produced by draws 17..22. The backend rendered and reuploaded that target as
+RGBA8, clamping HDR values before the composite. Renderer-owned RTTs now retain
+`VK_FORMAT_R16G16B16A16_SFLOAT` through attachment creation, readback/seed bytes, texture upload/views, and
+persistent target/texture/pipeline cache identities. Capture v13 records each RTT seed's native format while
+remaining able to read v1..v12 captures. The issue-773 77-submit source and its standalone v13 capsule are
+byte-identical at `9145002cabc36e97`; inspection shows one 642x362 `rgba16f` seed with 1,859,232 bytes.
+
 Startup and progression are stable after implementing both AGC resource-registration output queries. The former
 success-only `QueryResourceRegistrationUserMemoryRequirements` stub left Dead Cells' stack value untouched and
 occasionally requested a multi-gigabyte texture-pool allocation (#660). A native-speed fresh-save matrix improved
@@ -101,10 +110,10 @@ PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-current.prgbundle \
 PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=1000 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
 PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=642x362 \
-PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
-PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=80:82 \
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=636x420 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=77:85 \
 PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=91 \
-PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=93 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=94 \
 PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
@@ -117,7 +126,7 @@ Confirm the timeline selected the intended scene:
 
 ```bash
 ./build-linux/gpu_timeline /tmp/dead-cells-current.prgtl \
-  --select 738x420 80:82 91:93 8
+  --select 636x420 77:85 91:94 8
 ```
 
 Replay the complete source once and export the exact final checkpoint:
@@ -125,11 +134,11 @@ Replay the complete source once and export the exact final checkpoint:
 ```bash
 ./build-linux/gpu_replay \
   --bundle /tmp/dead-cells-current.prgbundle \
-  --bundle-final-capsule /tmp/dead-cells-current-v8.prgcap \
+  --bundle-final-capsule /tmp/dead-cells-current-v13.prgcap \
   /tmp/dead-cells-current-source.bmp
 
 ./build-linux/gpu_replay \
-  /tmp/dead-cells-current-v8.prgcap \
+  /tmp/dead-cells-current-v13.prgcap \
   /tmp/dead-cells-current-standalone.bmp
 
 cmp /tmp/dead-cells-current-source.bmp \
@@ -159,3 +168,9 @@ at final-submit entry and embeds the source output oracle. A standalone capsule 
 is useful for state inspection, but it does not by itself prove complete renderer history or source-image
 equality. Prefer improving the capture/replay diagnostics when an investigation would otherwise require repeated
 full-title runs.
+
+Capture v13 stores `rgba8` or `rgba16f` with every temporal RTT seed. `gpu_replay --inspect-only` prints the
+format, extent, byte count, and hash; use those together to catch a format/size mismatch before rendering.
+For consumer localization, `PROSPER_TESTTEX_DRAW=N PROSPER_TESTTEX_BINDING=B PROSPER_TESTTEX=zero` replaces only
+one draw's selected sampled resource. A non-`zero` value writes a format-correct checker. This is an A/B probe,
+not a renderer fix or a valid output oracle.

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -91,7 +91,9 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 - **libSceAgc** getters that return dereferenced objects → stable zeroed singletons.
 - **event queues** (`hle_kernel_time.cpp`) — valid queue objects; `WaitEqueue` yields + reports no
   events.
-- **Diagnostics** — `PROSPER_GFXLOG` logs AgcDriver call args.
+- **Diagnostics** — `PROSPER_GFXLOG` logs AgcDriver call args. Sampled-texture isolation accepts
+  `PROSPER_TESTTEX_DRAW=N`, `PROSPER_TESTTEX_BINDING=B`, and `PROSPER_TESTTEX=zero|checker`; both RGBA8 and
+  renderer-owned RGBA16F RTT inputs are replaced in their native format.
 
 ## Build environment
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -50,8 +50,41 @@ namespace {
 struct RttSurf {
     std::shared_ptr<const std::vector<uint8_t>> rgba;
     uint32_t w = 0, h = 0;
+    VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     bool gpu_valid = false;
 };
+
+prosper::gpu::GpuCaptureColorFormat capture_color_format(VkFormat format) {
+    return prosper::test::backend_color_format(format) == VK_FORMAT_R16G16B16A16_SFLOAT
+        ? prosper::gpu::GpuCaptureColorFormat::Rgba16Float
+        : prosper::gpu::GpuCaptureColorFormat::Rgba8Unorm;
+}
+
+VkFormat replay_color_format(prosper::gpu::GpuCaptureColorFormat format) {
+    return format == prosper::gpu::GpuCaptureColorFormat::Rgba16Float
+        ? VK_FORMAT_R16G16B16A16_SFLOAT
+        : VK_FORMAT_R8G8B8A8_UNORM;
+}
+
+std::vector<uint8_t> inspection_rgba8(const std::vector<uint8_t>& pixels,
+                                      uint32_t width, uint32_t height, VkFormat format) {
+    const size_t texels = static_cast<size_t>(width) * height;
+    if (format == VK_FORMAT_R8G8B8A8_UNORM && pixels.size() == texels * 4)
+        return pixels;
+    if (format != VK_FORMAT_R16G16B16A16_SFLOAT || pixels.size() != texels * 8)
+        return {};
+    std::vector<uint8_t> rgba(texels * 4);
+    for (size_t texel = 0; texel < texels; ++texel) {
+        for (uint32_t channel = 0; channel < 4; ++channel) {
+            uint16_t half = 0;
+            std::memcpy(&half, pixels.data() + texel * 8 + channel * 2, sizeof(half));
+            const float value = prosper::gpu::half_to_float(half);
+            rgba[texel * 4 + channel] = !std::isfinite(value) || value <= 0.0f ? 0
+                : value >= 1.0f ? 255 : static_cast<uint8_t>(value * 255.0f + 0.5f);
+        }
+    }
+    return rgba;
+}
 
 // Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
 // to one renderer callback: graphics spans are split at compute operations, so guest texture bytes
@@ -145,6 +178,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             auto it = g_rtt.find(addr); if (it == g_rtt.end()) return false;
             if (!it->second.rgba) return false;
             seed.guest_addr = addr; seed.width = it->second.w; seed.height = it->second.h;
+            seed.format = capture_color_format(it->second.format);
             seed.rgba = *it->second.rgba; return true;
         });
         prosper::gpu::set_gpu_capture_rtt_seed_snapshot_reader(
@@ -154,6 +188,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (!surface.rgba) continue;
                     prosper::gpu::GpuCaptureRttSeed seed;
                     seed.guest_addr = addr; seed.width = surface.w; seed.height = surface.h;
+                    seed.format = capture_color_format(surface.format);
                     seed.rgba = *surface.rgba; seeds.push_back(std::move(seed));
                 }
                 return true;
@@ -171,12 +206,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             });
     if (getenv("PROSPER_GPU_REPLAY_RTT_SEEDS"))
         prosper::gpu::set_gpu_replay_rtt_seed_writer([](const prosper::gpu::GpuCaptureRttSeed& seed, std::string& error) {
-            const uint64_t expected = static_cast<uint64_t>(seed.width) * seed.height * 4;
+            const VkFormat format = replay_color_format(seed.format);
+            const uint64_t expected = static_cast<uint64_t>(seed.width) * seed.height *
+                                      prosper::test::backend_color_bytes_per_pixel(format);
             if (!seed.guest_addr || !seed.width || !seed.height || expected != seed.rgba.size()) {
                 error = "invalid temporal RTT seed"; return false;
             }
             RttSurf& surface = g_rtt[seed.guest_addr];
             surface.w = seed.width; surface.h = seed.height;
+            surface.format = format;
             surface.rgba = std::make_shared<const std::vector<uint8_t>>(seed.rgba);
             surface.gpu_valid = false;
             prosper::test::invalidate_persistent_color_target(seed.guest_addr);
@@ -519,7 +557,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             live_rtt->second.w == tw && live_rtt->second.h == th &&
                             r.gpu_addr != draw.color0_base &&
                             prosper::test::find_persistent_color_target(
-                                r.gpu_addr, tw, th, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
+                                r.gpu_addr, tw, th, live_rtt->second.format) != nullptr;
                         const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
                         if (r.compression_enabled && !has_live_rtt) {
                             static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
@@ -698,6 +736,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (has_gpu_live_rtt) {
                             fr.persistent_render_target_id = r.gpu_addr;
                             fr.tw = tw; fr.th = th; fr.td = 1; fr.img_dim = r.img_dim;
+                            fr.texture_format = live_rtt->second.format;
                             resource_rtt_hit = true;
                         } else if (decoded_reuse) {
                             fr.tex_rgba = decoded_reuse->pixels;
@@ -713,7 +752,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
                         const size_t volume_texels = (size_t)tw * th * (is_volume ? r.depth : 1u);
-                        size_t nb = volume_texels * 4 * (is_cube ? 6u : 1u);
+                        const VkFormat live_rtt_format = has_cpu_live_rtt
+                            ? live_rtt->second.format : VK_FORMAT_R8G8B8A8_UNORM;
+                        const uint32_t output_bpp = has_cpu_live_rtt
+                            ? prosper::test::backend_color_bytes_per_pixel(live_rtt_format) : 4u;
+                        size_t nb = volume_texels * output_bpp * (is_cube ? 6u : 1u);
                         size_t linear_source_prefix_size = 0;
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
@@ -752,8 +795,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // narrow read+expand path below. StorageImage / unknown formats keep 4 B (bpt=0->4).
                         uint32_t bpt = prosper::gpu::data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
                         // fp16 surfaces (fmt 71 Float16x4 = 8 B/texel, 29 = 4 B, 13 = 2 B) get a real
-                        // half->UNORM8 conversion path below; everything else unknown/oversized keeps
-                        // the legacy RGBA8 read (bpt=4).
+                        // half->UNORM8 conversion path below for guest-backed textures. Renderer-owned
+                        // Float16x4 RTTs bypass it and retain native bytes. Other unknown formats keep RGBA8.
                         const bool f16 = r.format == prosper::gpu::DataFormat::Float16 &&
                                          (bpt == 2 || bpt == 4 || bpt == 8);
                         if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
@@ -765,19 +808,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
-                                const size_t expected = static_cast<size_t>(tw) * th * 4;
+                                const uint32_t rtt_bpp = prosper::test::backend_color_bytes_per_pixel(s.format);
+                                const size_t expected = static_cast<size_t>(tw) * th * rtt_bpp;
                                 if (s.w == tw && s.h == th && s.rgba->size() == expected) {
                                     std::memcpy(texture_pixels.data(), s.rgba->data(), expected);
                                 } else {
                                     std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
                                     for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
                                         uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
-                                        size_t si = ((size_t)sy * s.w + sx) * 4;
-                                        if (si + 4 <= s.rgba->size())
-                                            std::memcpy(&texture_pixels[((size_t)y * tw + x) * 4],
-                                                        &(*s.rgba)[si], 4);
+                                        size_t si = ((size_t)sy * s.w + sx) * rtt_bpp;
+                                        if (si + rtt_bpp <= s.rgba->size())
+                                            std::memcpy(&texture_pixels[((size_t)y * tw + x) * rtt_bpp],
+                                                        &(*s.rgba)[si], rtt_bpp);
                                     }
                                 }
+                                fr.texture_format = s.format;
                                 rtt_hit = true;
                                 resource_rtt_hit = true;
                                 // PROSPER_DUMP_SAMPLED_RTT (#710/#320): dump the EXACT RTT-layer pixels a
@@ -788,15 +833,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 if (getenv("PROSPER_DUMP_SAMPLED_RTT")) {
                                     static std::set<uint64_t> seen;
                                     if (seen.insert(r.gpu_addr).second) {
+                                        const std::vector<uint8_t> inspected = inspection_rgba8(
+                                            texture_pixels, tw, th, s.format);
                                         size_t nz = 0, rgbnz = 0;
-                                        for (size_t p = 0; p + 3 < texture_pixels.size(); p += 4) {
-                                            if (texture_pixels[p] || texture_pixels[p+1] || texture_pixels[p+2]) rgbnz++;
-                                            for (int k = 0; k < 4; k++) nz += (texture_pixels[p+k] != 0);
+                                        for (size_t p = 0; p + 3 < inspected.size(); p += 4) {
+                                            if (inspected[p] || inspected[p+1] || inspected[p+2]) rgbnz++;
+                                            for (int k = 0; k < 4; k++) nz += (inspected[p+k] != 0);
                                         }
                                         const char* dd = getenv("PROSPER_FRAME_DIR");
                                         char fn[512]; snprintf(fn, sizeof fn, "%s/sampledrtt_%llx_%ux%u.bmp",
                                                                dd ? dd : ".", (unsigned long long)r.gpu_addr, tw, th);
-                                        prosper::test::dump_bmp(fn, texture_pixels, tw, th);
+                                        prosper::test::dump_bmp(fn, inspected, tw, th);
                                         fprintf(stderr, "[sampledrtt] addr=0x%llx %ux%u rgb_nonblack=%zu/%u -> %s\n",
                                                 (unsigned long long)r.gpu_addr, tw, th, rgbnz, tw*th, fn);
                                     }
@@ -878,13 +925,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // with the REAL element size — the old clamp read an 8-B/texel Float16x4
                             // surface at 4 B AND detiled it with bpe=4 against 8-B tiled elements, so
                             // the result was doubly wrong ("confetti" regions, e.g. DOLL's 960x540 /
-                            // 480x270 bloom-chain buffers). Convert half->UNORM8 on upload: the backend
-                            // uploads RGBA8 only (the whole render path is 8-bit gamma space — see the
-                            // #263 note in render_runner), so HDR values above 1.0 clamp to 255.
+                            // 480x270 bloom-chain buffers). Guest memory still converts half->UNORM8 on
+                            // upload. That path clamps values above 1.0 and remains separate from native
+                            // tiled guest-texture upload and the renderer-owned RTT fix in #773.
                             // Missing components read (0,0,0,1) per the hardware rule; the T# DST_SEL
                             // swizzle still applies. CONFIDENCE: MED — the half decode is exact and
-                            // unit-tested, but the [0,1] clamp loses >1.0 bloom energy (native
-                            // VK_FORMAT_R16G16B16A16_SFLOAT upload is the documented follow-up).
+                            // unit-tested, but the [0,1] clamp loses >1.0 bloom energy for guest-backed
+                            // textures; renderer-owned RTTs retain RGBA16F through the #773 path.
                             const uint32_t nc = bpt / 2;                    // fp16 components per texel
                             std::vector<uint8_t> hlin(volume_texels * bpt, 0);
                             bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
@@ -1099,22 +1146,42 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // sampling diagnosis (#522).
                         const char* test_texture = getenv("PROSPER_TESTTEX");
                         const char* test_texture_binding = getenv("PROSPER_TESTTEX_BINDING");
+                        const char* test_texture_draw = getenv("PROSPER_TESTTEX_DRAW");
                         const bool test_this_texture = test_texture &&
                             (!test_texture_binding ||
-                             strtoul(test_texture_binding, nullptr, 0) == r.binding);
+                             strtoul(test_texture_binding, nullptr, 0) == r.binding) &&
+                            (!test_texture_draw ||
+                             strtoull(test_texture_draw, nullptr, 0) == draw.draw_index);
                         if (test_this_texture) {
                             const uint32_t slices = is_volume ? std::max(r.depth, 1u) : 1u;
-                            for (uint32_t z = 0; z < slices; ++z)
-                                for (uint32_t y = 0; y < th; ++y)
-                                    for (uint32_t x = 0; x < tw; ++x) {
-                                        uint8_t* p = &texture_pixels[
-                                            (((size_t)z * th + y) * tw + x) * 4];
-                                        bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
-                                        p[0] = (uint8_t)(255 * x / tw);
-                                        p[1] = (uint8_t)(255 * y / th);
-                                        p[2] = ck ? 200 : 40;
-                                        p[3] = 255;
-                                    }
+                            if (!strcmp(test_texture, "zero")) {
+                                std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
+                            } else if (fr.texture_format == VK_FORMAT_R16G16B16A16_SFLOAT) {
+                                for (uint32_t z = 0; z < slices; ++z)
+                                    for (uint32_t y = 0; y < th; ++y)
+                                        for (uint32_t x = 0; x < tw; ++x) {
+                                            uint16_t* p = reinterpret_cast<uint16_t*>(
+                                                texture_pixels.data() +
+                                                (((size_t)z * th + y) * tw + x) * 8);
+                                            const bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
+                                            p[0] = prosper::gpu::float_to_half((float)x / tw);
+                                            p[1] = prosper::gpu::float_to_half((float)y / th);
+                                            p[2] = prosper::gpu::float_to_half(ck ? 0.8f : 0.16f);
+                                            p[3] = prosper::gpu::float_to_half(1.0f);
+                                        }
+                            } else {
+                                for (uint32_t z = 0; z < slices; ++z)
+                                    for (uint32_t y = 0; y < th; ++y)
+                                        for (uint32_t x = 0; x < tw; ++x) {
+                                            uint8_t* p = &texture_pixels[
+                                                (((size_t)z * th + y) * tw + x) * 4];
+                                            bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
+                                            p[0] = (uint8_t)(255 * x / tw);
+                                            p[1] = (uint8_t)(255 * y / th);
+                                            p[2] = ck ? 200 : 40;
+                                            p[3] = 255;
+                                        }
+                            }
                         }
                         // This 256x16 sparse palette is addressed like 16 blue slices, each 16 texels wide.
                         // The identity probe preserves source color through shaders using
@@ -1143,7 +1210,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         // PROSPER_DUMP_TEX: write the RAW texture memory (interpreted linearly) to a BMP,
                         // bypassing the shader — reveals whether the render target is tiled or linear.
-                        if (getenv("PROSPER_DUMP_TEX") && !texture_pixels.empty() && frame_no < 200) {
+                        if (getenv("PROSPER_DUMP_TEX") && !texture_pixels.empty() && frame_no < 200 &&
+                            fr.texture_format == VK_FORMAT_R8G8B8A8_UNORM) {
                             std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
                             char fn[512]; snprintf(fn, sizeof fn, "%s/rawtex_f%04d_b%u.bmp", d.c_str(), (int)frame_no, r.binding);
                             prosper::test::dump_bmp(fn, texture_pixels, tw, th);
@@ -1151,7 +1219,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         // PROSPER_DUMP_ATLAS: dump each SMALL sampled texture once per ADDRESS (find the caption
                         // font among same-size UI textures). Capped.
-                        if (getenv("PROSPER_DUMP_ATLAS") && !texture_pixels.empty() && tw <= 2048 && th <= 1024) {
+                        if (getenv("PROSPER_DUMP_ATLAS") && !texture_pixels.empty() && tw <= 2048 && th <= 1024 &&
+                            fr.texture_format == VK_FORMAT_R8G8B8A8_UNORM) {
                             static std::unordered_map<uint64_t,int> seen; static int ndumped = 0;
                             if (seen[r.gpu_addr]++ == 0 && ndumped++ < 60) {
                                 std::string d = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
@@ -1295,7 +1364,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             RenderClock::now() - resource_timing_start).count();
                         if (fr.is_texture()) {
                             pending_timing.textures++;
-                            pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * fr.td * 4;
+                            pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * fr.td *
+                                prosper::test::backend_color_bytes_per_pixel(fr.texture_format);
                             pending_timing.texture_ms += elapsed;
                             const uint64_t detail_min_submit = getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT")
                                 ? strtoull(getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT"), nullptr, 0) : 0;
@@ -1512,13 +1582,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     return draw.ps.color1_write_mask && draw.color1_base
                         ? draw.color1_base : uint64_t{0};
                 };
+                auto active_format = [](const prosper::gpu::DrawItem& draw, bool color1) {
+                    return prosper::test::backend_color_format(static_cast<VkFormat>(
+                        color1 ? draw.ps.color1_format : draw.ps.color0_format));
+                };
                 size_t pass_i = 0;
                 while (pass_i < items.size()) {
                     const uint64_t base = items[pass_i].color0_base;
                     const uint64_t base1 = active_color1(items[pass_i]);
+                    const VkFormat format0 = active_format(items[pass_i], false);
+                    const VkFormat format1 = base1
+                        ? active_format(items[pass_i], true) : VK_FORMAT_UNDEFINED;
                     std::vector<const prosper::gpu::DrawItem*> pass;
                     while (pass_i < items.size() && items[pass_i].color0_base == base &&
-                           active_color1(items[pass_i]) == base1) {
+                           active_color1(items[pass_i]) == base1 &&
+                           active_format(items[pass_i], false) == format0 &&
+                           (!base1 || active_format(items[pass_i], true) == format1)) {
                         pass.push_back(&items[pass_i]); ++pass_i;
                     }
 
@@ -1613,14 +1692,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     const uint8_t* seed = nullptr;
                     bool gpu_seed_available = false;
+                    const VkFormat pass_format = format0;
+                    const size_t pass_bytes = static_cast<size_t>(gw) * gh *
+                        prosper::test::backend_color_bytes_per_pixel(pass_format);
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
                         gpu_seed_available = live_gpu_targets && sit != g_rtt.end() &&
                             sit->second.gpu_valid && sit->second.w == gw && sit->second.h == gh &&
+                            sit->second.format == pass_format &&
                             prosper::test::find_persistent_color_target(
-                                base, gw, gh, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
+                                base, gw, gh, pass_format) != nullptr;
                         if (!gpu_seed_available && sit != g_rtt.end() &&
                             sit->second.w == gw && sit->second.h == gh &&
-                            sit->second.rgba && sit->second.rgba->size() == (size_t)gw * gh * 4)
+                            sit->second.format == pass_format && sit->second.rgba &&
+                            sit->second.rgba->size() == pass_bytes)
                             seed = sit->second.rgba->data(); }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++)
@@ -1653,7 +1737,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const bool defer_readback = live_gpu_targets && vo_n > 0 && base && !is_vo &&
                         base != front_va && sampled_exact_later && !feedback_later;
                     prosper::test::BackendColorTarget backend_target{
-                        base, seed_rtt, !defer_readback};
+                        base, seed_rtt, !defer_readback, pass_format};
                     const bool color1_extent_matches = base1 && !render_pass.empty() &&
                         render_pass.front()->color1_width == native_w &&
                         render_pass.front()->color1_height == native_h;
@@ -1661,10 +1745,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // against the previous single-target behavior without recapturing.
                     const bool use_color1 = base1 && color1_extent_matches &&
                                             getenv("PROSPER_NO_MRT1") == nullptr;
+                    const VkFormat pass_format1 = use_color1 ? format1 : VK_FORMAT_UNDEFINED;
                     const uint8_t* seed1 = nullptr;
                     if (seed_rtt && use_color1) { auto sit = g_rtt.find(base1);
                         if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
-                            sit->second.rgba && sit->second.rgba->size() == (size_t)gw * gh * 4)
+                            sit->second.format == pass_format1 && sit->second.rgba &&
+                            sit->second.rgba->size() == static_cast<size_t>(gw) * gh *
+                                prosper::test::backend_color_bytes_per_pixel(pass_format1))
                             seed1 = sit->second.rgba->data(); }
                     if (base1 && !use_color1 && rtt_log) {
                         const auto* first = render_pass.empty() ? nullptr : render_pass.front();
@@ -1713,8 +1800,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         RttSurf& surface = g_rtt[base];
                         surface.w = gw;
                         surface.h = gh;
+                        surface.format = pass_format;
                         surface.gpu_valid = prosper::test::find_persistent_color_target(
-                            base, gw, gh, VK_FORMAT_R8G8B8A8_UNORM) != nullptr;
+                            base, gw, gh, pass_format) != nullptr;
                         if (!pass_pixels->empty()) surface.rgba = pass_pixels;
                         else if (surface.gpu_valid) surface.rgba.reset();
                     } else if (base && !pass_pixels->empty()) {
@@ -1722,15 +1810,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         surface.rgba = pass_pixels;
                         surface.w = gw;
                         surface.h = gh;
+                        surface.format = pass_format;
                         surface.gpu_valid = false;
                     }
                     if (use_color1 && !gpx1.empty()) {
                         if (rtt_log) {
                             size_t nz = 0, rgb_nz = 0;
                             for (uint8_t byte : gpx1) nz += byte != 0;
-                            for (size_t p = 0; p + 3 < gpx1.size(); p += 4)
-                                rgb_nz += gpx1[p] != 0 || gpx1[p + 1] != 0 ||
-                                          gpx1[p + 2] != 0;
+                            if (pass_format1 == VK_FORMAT_R8G8B8A8_UNORM)
+                                for (size_t p = 0; p + 3 < gpx1.size(); p += 4)
+                                    rgb_nz += gpx1[p] != 0 || gpx1[p + 1] != 0 ||
+                                              gpx1[p + 2] != 0;
                             fprintf(stderr,
                                     "[rtt] pass target1=0x%llx extent=%ux%u (%zu draws) "
                                     "px_nonzero=%zu rgb_nonblack=%zu\n",
@@ -1738,7 +1828,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         RttSurf& surface = g_rtt[base1];
                         surface.rgba = std::make_shared<const std::vector<uint8_t>>(std::move(gpx1));
-                        surface.w = gw; surface.h = gh; surface.gpu_valid = false;
+                        surface.w = gw; surface.h = gh; surface.format = pass_format1;
+                        surface.gpu_valid = false;
                     }
                     const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
                     if (native_w == resource_hash_w && native_h == resource_hash_h &&
@@ -1783,14 +1874,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             size_t dark = 0, near_white = 0;
                             uint64_t rgb_sum = 0;
-                            for (size_t p = 0; p + 3 < step.size(); p += 4) {
-                                const uint8_t r = step[p], g = step[p + 1], b = step[p + 2];
+                            const VkFormat step_format = prosper::test::backend_color_format(
+                                static_cast<VkFormat>(prefix.front()->ps.color0_format));
+                            const std::vector<uint8_t> step_rgba = inspection_rgba8(
+                                step, gw, gh, step_format);
+                            for (size_t p = 0; p + 3 < step_rgba.size(); p += 4) {
+                                const uint8_t r = step_rgba[p], g = step_rgba[p + 1], b = step_rgba[p + 2];
                                 dark += std::max({r, g, b}) < 64;
                                 near_white += std::min({r, g, b}) > 240;
                                 rgb_sum += r + g + b;
                             }
-                            const double mean_rgb = step.empty() ? 0.0 :
-                                (double)rgb_sum / ((step.size() / 4) * 3);
+                            const double mean_rgb = step_rgba.empty() ? 0.0 :
+                                (double)rgb_sum / ((step_rgba.size() / 4) * 3);
                             const auto* draw = prefix.back();
                             auto spirv_hash = [](const std::vector<uint32_t>& words) {
                                 uint64_t hash = 1469598103934665603ull;
@@ -1825,11 +1920,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (lightweight_rtt_timing) pending_rtt_timing.push_back(rtt_timing_record);
                     else if (timing_enabled && rtt_log) print_rtt_timing(rtt_timing_record);
                     if (rtt_log) {
+                        const std::vector<uint8_t> inspected = inspection_rgba8(
+                            rendered_pixels, gw, gh, pass_format);
                         size_t nz = 0, rgb_nz = 0;
                         for (uint8_t b : rendered_pixels) nz += (b != 0);
-                        for (size_t p = 0; p + 3 < rendered_pixels.size(); p += 4)
-                            rgb_nz += (rendered_pixels[p] != 0 || rendered_pixels[p + 1] != 0 ||
-                                       rendered_pixels[p + 2] != 0);
+                        for (size_t p = 0; p + 3 < inspected.size(); p += 4)
+                            rgb_nz += (inspected[p] != 0 || inspected[p + 1] != 0 ||
+                                       inspected[p + 2] != 0);
                         fprintf(stderr, "[rtt] pass target=0x%llx extent=%ux%u native=%ux%u (%zu draws) "
                                 "px_nonzero=%zu rgb_nonblack=%zu cache_size=%zu%s%s\n",
                                 (unsigned long long)base, gw, gh, native_w, native_h, pass.size(), nz, rgb_nz, g_rtt.size(),
@@ -1859,13 +1956,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (const char* rg = getenv("PROSPER_DUMP_RTGROUPS"); rg && !rendered_pixels.empty()) {
                         size_t nz = 0; for (uint8_t b : rendered_pixels) nz += (b != 0);
                         if (nz >= (size_t)atol(rg)) {
+                            const std::vector<uint8_t> inspected = inspection_rgba8(
+                                rendered_pixels, gw, gh, pass_format);
                             const char* dd = getenv("PROSPER_FRAME_DIR");
                             char fn[512]; snprintf(fn, sizeof fn, "%s/rtgrp_%llx_%04d.bmp",
                                                    dd ? dd : ".", (unsigned long long)base, frame_no.load());
-                            prosper::test::dump_bmp(fn, rendered_pixels, gw, gh);
+                            prosper::test::dump_bmp(fn, inspected, gw, gh);
                         }
                     }
-                    if (!rendered_pixels.empty()) {
+                    if (!rendered_pixels.empty() && pass_format == VK_FORMAT_R8G8B8A8_UNORM) {
                         if (base && base == front_va) px_front = pass_pixels;  // the flipped buffer
                         if (is_vo)                    px_vo = pass_pixels;     // any registered scanout
                         px_last = pass_pixels;                                  // last non-empty (fallback)
@@ -1908,7 +2007,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     for (const auto& it : items) if (it.color0_base) { tgt = it.color0_base; break; }
                     if (tgt) {
                         RttSurf& s = g_rtt[tgt];
-                        s.rgba = selected_pixels; s.w = w; s.h = h; s.gpu_valid = false;
+                        s.rgba = selected_pixels; s.w = w; s.h = h;
+                        s.format = VK_FORMAT_R8G8B8A8_UNORM; s.gpu_valid = false;
                         prosper::test::invalidate_persistent_color_target(tgt);
                     }
                     if (rtt_log) { size_t nz=0;
@@ -1926,6 +2026,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 auto cached_scanout = [&](uint64_t addr) -> const RttSurf* {
                     auto it = g_rtt.find(addr);
                     if (it == g_rtt.end() || it->second.w != w || it->second.h != h ||
+                        it->second.format != VK_FORMAT_R8G8B8A8_UNORM ||
                         !it->second.rgba || it->second.rgba->size() != (size_t)w * h * 4)
                         return nullptr;
                     return &it->second;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 12;
+constexpr uint32_t kVersion = 13;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -431,10 +431,16 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
     if (!seed.guest_addr || !seed.width || !seed.height) {
         error = "RTT seed has an invalid address or extent"; return false;
     }
+    uint32_t bytes_per_pixel = 0;
+    switch (seed.format) {
+        case GpuCaptureColorFormat::Rgba8Unorm: bytes_per_pixel = 4; break;
+        case GpuCaptureColorFormat::Rgba16Float: bytes_per_pixel = 8; break;
+        default: error = "RTT seed has an unsupported color format"; return false;
+    }
     const uint64_t pixels = checked_mul(seed.width, seed.height);
-    const uint64_t bytes = checked_mul(pixels, 4);
+    const uint64_t bytes = checked_mul(pixels, bytes_per_pixel);
     if (bytes > kMaxBlobBytes || bytes != seed.rgba.size()) {
-        error = "RTT seed byte count does not match its RGBA extent"; return false;
+        error = "RTT seed byte count does not match its color format and extent"; return false;
     }
     return true;
 }
@@ -916,7 +922,8 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
             error = "capture RTT seed data exceeds 1 GiB"; return false;
         }
         seed_total += seed.rgba.size();
-        w.u64(seed.guest_addr); w.u32(seed.width); w.u32(seed.height); w.bytes(seed.rgba);
+        w.u64(seed.guest_addr); w.u32(seed.width); w.u32(seed.height);
+        w.u32(static_cast<uint32_t>(seed.format)); w.bytes(seed.rgba);
     }
     std::vector<GpuCaptureShaderVersion> versions = c.shader_versions;
     auto add_shader = [&](const std::vector<uint32_t>& words) {
@@ -1180,7 +1187,10 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         uint64_t seed_total = 0; c.rtt_seeds.resize(ns);
         std::unordered_set<uint64_t> addresses;
         for (auto& seed : c.rtt_seeds) {
-            if (!r.u64(seed.guest_addr) || !r.u32(seed.width) || !r.u32(seed.height) || !r.bytes(seed.rgba)) return false;
+            uint32_t format = static_cast<uint32_t>(GpuCaptureColorFormat::Rgba8Unorm);
+            if (!r.u64(seed.guest_addr) || !r.u32(seed.width) || !r.u32(seed.height) ||
+                (version >= 13 && !r.u32(format)) || !r.bytes(seed.rgba)) return false;
+            seed.format = static_cast<GpuCaptureColorFormat>(format);
             if (!validate_rtt_seed(seed, error)) return false;
             if (!addresses.insert(seed.guest_addr).second) { error = "duplicate RTT seed address"; return false; }
             if (seed_total > kMaxTotalRttSeedBytes - seed.rgba.size()) {

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -123,10 +123,16 @@ struct GpuCapturedOperationFailure {
 // Host-rendered pixels retained across submits. The HLE renderer does not write these pixels back to
 // guest memory, so a standalone replay must seed its RTT cache explicitly to reproduce consumers whose
 // producer was in an earlier submit.
+enum class GpuCaptureColorFormat : uint32_t {
+    Rgba8Unorm = 1,
+    Rgba16Float = 2,
+};
+
 struct GpuCaptureRttSeed {
     uint64_t guest_addr = 0;
     uint32_t width = 0;
     uint32_t height = 0;
+    GpuCaptureColorFormat format = GpuCaptureColorFormat::Rgba8Unorm;
     std::vector<uint8_t> rgba;
 };
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -70,6 +70,9 @@ struct FrameResource {
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
     uint32_t tw = 0, th = 0, td = 1;
     uint32_t img_dim = 1;             // ShaderResource/MIMG dim (1=2D, 2=3D); depth-1 3D stays 3D
+    // Renderer-owned RTTs keep their native format between producer and consumer. Guest-backed
+    // textures still arrive through the existing RGBA8 decoder unless explicitly tagged otherwise.
+    VkFormat texture_format = VK_FORMAT_R8G8B8A8_UNORM;
     // Sampler state (Texture only). Defaults = LINEAR + clamp-to-edge — the harness's prior fixed
     // sampler — so render tests that build FrameResources directly stay byte-identical. The live path
     // fills these from the decoded S# (shader_resources.hpp). filter: 0=nearest, 1=linear; addr = Gen5
@@ -105,7 +108,18 @@ struct BackendColorTarget {
     uint64_t persistent_id = 0;
     bool load_existing = true;
     bool readback = true;
+    VkFormat format = VK_FORMAT_UNDEFINED;
 };
+
+inline VkFormat backend_color_format(VkFormat format) {
+    return format == VK_FORMAT_R16G16B16A16_SFLOAT
+        ? VK_FORMAT_R16G16B16A16_SFLOAT
+        : VK_FORMAT_R8G8B8A8_UNORM;
+}
+
+inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
+    return backend_color_format(format) == VK_FORMAT_R16G16B16A16_SFLOAT ? 8u : 4u;
+}
 
 struct BackendColorTargetStats {
     uint64_t writes = 0;
@@ -125,7 +139,7 @@ inline BackendColorTargetStats backend_color_target_stats() {
     return backend_color_target_stats_storage();
 }
 
-// Returns W*H*4 RGBA bytes, or {} on any Vulkan failure (incl. a rejected SPIR-V module). When `ps`
+// Returns native target bytes (RGBA8 by default, RGBA16F when requested), or {} on failure. When `ps`
 // is non-null, the pipeline's fixed-function state (topology, blend, color write mask) is taken from
 // the resolved RDNA2 render-state — this is how the back-half realizes a GpuState as a real VkPipeline.
 //
@@ -268,7 +282,7 @@ inline BackendRenderTimingStats backend_render_timing_stats() {
     return backend_render_timing_stats_storage();
 }
 
-// `seed_rgba` (optional): W*H*4 RGBA8 pixels to PRELOAD the color attachment with before the draws
+// `seed_rgba` (optional): native-format pixels to PRELOAD the color attachment with before the draws
 // run (loadOp LOAD instead of the blue clear). This is real render-target memory semantics: a game
 // pass that draws into a target it (or an earlier submit) already rendered composites OVER that
 // content — without it every pass starts from the diagnostic blue clear, so cross-submit
@@ -425,7 +439,8 @@ inline void invalidate_persistent_color_target_guest_write(uint64_t addr, uint64
     if (!addr || !size) return;
     const uint64_t end = size > UINT64_MAX - addr ? UINT64_MAX : addr + size;
     for (auto& [key, target] : persistent_color_target_cache()) {
-        const uint64_t bytes = static_cast<uint64_t>(key.width) * key.height * 4;
+        const uint64_t bytes = static_cast<uint64_t>(key.width) * key.height *
+                               backend_color_bytes_per_pixel(key.format);
         const uint64_t target_end = bytes > UINT64_MAX - key.id ? UINT64_MAX : key.id + bytes;
         if (addr < target_end && key.id < end) target.valid = false;
     }
@@ -922,8 +937,25 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         for (uint32_t i = 0; i < memp.memoryTypeCount; i++)
             if ((bits & (1u << i)) && (memp.memoryTypes[i].propertyFlags & want) == want) return i;
         return UINT32_MAX; };
-    const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const bool use_color1 = out_rgba1 != nullptr;
+    const auto first_pipeline_format = [&](bool color1) {
+        for (const auto& draw : draws) {
+            if (!draw.ps) continue;
+            const VkFormat format = static_cast<VkFormat>(
+                color1 ? draw.ps->color1_format : draw.ps->color0_format);
+            if (format != VK_FORMAT_UNDEFINED) return backend_color_format(format);
+        }
+        return VK_FORMAT_R8G8B8A8_UNORM;
+    };
+    const VkFormat FMT = color_target && color_target->format != VK_FORMAT_UNDEFINED
+        ? backend_color_format(color_target->format)
+        : first_pipeline_format(false);
+    const VkFormat FMT1 = use_color1 ? first_pipeline_format(true) : VK_FORMAT_UNDEFINED;
+    const VkDeviceSize bytes = static_cast<VkDeviceSize>(W) * H *
+                               backend_color_bytes_per_pixel(FMT);
+    const VkDeviceSize bytes1 = use_color1
+        ? static_cast<VkDeviceSize>(W) * H * backend_color_bytes_per_pixel(FMT1)
+        : 0;
     const uint32_t color_count = use_color1 ? 2u : 1u;
     const uint32_t ds_attachment = color_count;
     // Depth attachment is created if ANY draw enables the depth test (the shared render pass has one
@@ -1048,7 +1080,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         for (const auto& resource : draw.R)
             if (persistent_color_targets_enabled && resource.persistent_render_target_id)
                 if (auto* sampled = find_persistent_color_target(
-                        resource.persistent_render_target_id, resource.tw, resource.th, FMT))
+                        resource.persistent_render_target_id, resource.tw, resource.th,
+                        backend_color_format(resource.texture_format)))
                     sampled->last_use = color_target_generation;
 
     bool persistent_color = persistent_color_enabled;
@@ -1123,7 +1156,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkImageView view1 = VK_NULL_HANDLE;
     if (use_color1) {
         VkImageCreateInfo color1_ci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-        color1_ci.imageType = VK_IMAGE_TYPE_2D; color1_ci.format = FMT;
+        color1_ci.imageType = VK_IMAGE_TYPE_2D; color1_ci.format = FMT1;
         color1_ci.extent = {W, H, 1}; color1_ci.mipLevels = 1; color1_ci.arrayLayers = 1;
         color1_ci.samples = VK_SAMPLE_COUNT_1_BIT; color1_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
         color1_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
@@ -1139,7 +1172,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         vkBindImageMemory(dev, img1, imem1, 0);
         VkImageViewCreateInfo color1_view_ci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         color1_view_ci.image = img1; color1_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        color1_view_ci.format = FMT;
+        color1_view_ci.format = FMT1;
         color1_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         vkCreateImageView(dev, &color1_view_ci, nullptr, &view1);
     }
@@ -1178,7 +1211,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     att[0].finalLayout = persistent_color ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
                                           : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     if (use_color1) {
-        att[1].format = FMT; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        att[1].format = FMT1; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
         att[1].loadOp = seed_rgba1 ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
         att[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         att[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
@@ -1248,10 +1281,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         uint64_t render_target_id = 0;
         uint32_t width = 0, height = 0, depth = 1;
         uint32_t img_dim = 1;
+        VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool operator==(const TextureUploadKey& other) const {
             return pixels == other.pixels && render_target_id == other.render_target_id &&
                    width == other.width && height == other.height && depth == other.depth &&
-                   img_dim == other.img_dim;
+                   img_dim == other.img_dim && format == other.format;
         }
     };
     struct TextureUploadKeyHash {
@@ -1262,6 +1296,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             h ^= static_cast<size_t>(key.height) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.depth) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.img_dim) + 0x9e3779b9u + (h << 6) + (h >> 2);
+            h ^= static_cast<size_t>(key.format) + 0x9e3779b9u + (h << 6) + (h >> 2);
             return h;
         }
     };
@@ -1280,6 +1315,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     struct PersistentTextureKey {
         uint64_t id = 0;
         uint32_t width = 0, height = 0, depth = 1, img_dim = 1;
+        VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool operator==(const PersistentTextureKey&) const = default;
     };
     struct PersistentTextureKeyHash {
@@ -1289,6 +1325,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 h ^= static_cast<size_t>(value) + 0x9e3779b9u + (h << 6) + (h >> 2);
             };
             mix(key.width); mix(key.height); mix(key.depth); mix(key.img_dim);
+            mix(static_cast<uint32_t>(key.format));
             return h;
         }
     };
@@ -1506,7 +1543,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         : VK_SHADER_STAGE_FRAGMENT_BIT;
                     texture_references++;
                     const TextureUploadKey texture_key{
-                        r.tex_rgba, r.persistent_render_target_id, r.tw, r.th, r.td, r.img_dim};
+                        r.tex_rgba, r.persistent_render_target_id, r.tw, r.th, r.td, r.img_dim,
+                        backend_color_format(r.texture_format)};
                     size_t upload_index = SIZE_MAX;
                     if (share_texture_uploads) {
                         auto found = texture_upload_indices.find(texture_key);
@@ -1524,7 +1562,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         if (persistent_color_targets_enabled && !target_feedback &&
                             r.persistent_render_target_id && r.img_dim == 1) {
                             if (auto* target = find_persistent_color_target(
-                                    r.persistent_render_target_id, r.tw, r.th, FMT)) {
+                                    r.persistent_render_target_id, r.tw, r.th,
+                                    backend_color_format(r.texture_format))) {
                                 target->last_use = color_target_generation;
                                 upload.image = target->image;
                                 upload.image_bytes = target->bytes;
@@ -1534,7 +1573,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         }
                         upload.persistent_id = r.persistent_texture_id;
                         const PersistentTextureKey persistent_key{
-                            r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim};
+                            r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
+                            backend_color_format(r.texture_format)};
                         if (!upload.borrowed_target && persistent_textures_enabled &&
                             r.persistent_texture_id) {
                             auto cached = persistent_texture_images.find(persistent_key);
@@ -1553,7 +1593,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
                             const bool texture_3d = r.img_dim == 2;
                             tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
-                            tci.format = VK_FORMAT_R8G8B8A8_UNORM;
+                            tci.format = backend_color_format(r.texture_format);
                             tci.extent = {r.tw, r.th, r.td};
                             tci.mipLevels = 1; tci.arrayLayers = 1;
                             tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -1577,7 +1617,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             vkBindImageMemory(dev, upload.image, upload.memory, 0);
 
                             const VkDeviceSize tbytes =
-                                static_cast<VkDeviceSize>(r.tw) * r.th * r.td * 4;
+                                static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
+                                backend_color_bytes_per_pixel(r.texture_format);
                             VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                             stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
                             vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
@@ -1611,7 +1652,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     // #263 discussion), NOT a per-view format flip. r.srgb is decoded now as groundwork.
                     tvci.image = upload.image;
                     tvci.viewType = r.img_dim == 2 ? VK_IMAGE_VIEW_TYPE_3D : VK_IMAGE_VIEW_TYPE_2D;
-                    tvci.format = VK_FORMAT_R8G8B8A8_UNORM;
+                    tvci.format = backend_color_format(r.texture_format);
                     // T# DST_SEL channel remap (#261): map each SQ_SEL to a VkComponentSwizzle. Identity
                     // (the default, and the narrow/font path) yields IDENTITY == a no-op. PROSPER_NO_SWIZZLE
                     // forces identity for A/B testing against the pre-swizzle behavior.
@@ -1742,8 +1783,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(2); // key schema version
-            append(W); append(H); append(color_count); append(use_ds); append(static_cast<uint32_t>(DFMT));
+            append(3); // key schema version
+            append(W); append(H); append(color_count); append(static_cast<uint32_t>(FMT));
+            append(static_cast<uint32_t>(FMT1)); append(use_ds); append(static_cast<uint32_t>(DFMT));
             const bool exact_shader_identities = bd.vs_identity && bd.fs_identity;
             append(bd.vs_identity != 0);
             if (bd.vs_identity) {
@@ -1867,12 +1909,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (!upload.staging) continue;
         ++texture_stats.unique_uploads;
         texture_stats.upload_bytes += static_cast<uint64_t>(upload.key.width) * upload.key.height *
-                                      upload.key.depth * 4;
+                                      upload.key.depth * backend_color_bytes_per_pixel(upload.key.format);
     }
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    VkDeviceSize bytes = (VkDeviceSize)W * H * 4;
-    const VkDeviceSize readback_bytes = bytes * color_count;
+    const VkDeviceSize readback_bytes = bytes + bytes1;
     // MRT1 is currently retained in the live renderer's CPU RTT cache, so a paired pass always
     // reads both attachments back. Single-target passes keep the persistent no-readback fast path.
     const bool readback_requested = use_color1 || !persistent_color || color_target->readback;
@@ -1953,7 +1994,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkBuffer seedbuf1 = VK_NULL_HANDLE; VkDeviceMemory seedmem1 = VK_NULL_HANDLE;
     if (use_color1 && seed_rgba1) {
         VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-        sci.size = bytes; sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        sci.size = bytes1; sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
         vkCreateBuffer(dev, &sci, nullptr, &seedbuf1);
         VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, seedbuf1, &sr);
         VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; sai.allocationSize = sr.size;
@@ -1961,8 +2002,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
         seedmem1 = allocate_transient_render_memory(dev, sai.allocationSize, sai.memoryTypeIndex);
         vkBindBufferMemory(dev, seedbuf1, seedmem1, 0);
-        void* sp = nullptr; vkMapMemory(dev, seedmem1, 0, bytes, 0, &sp);
-        memcpy(sp, seed_rgba1, static_cast<size_t>(bytes)); vkUnmapMemory(dev, seedmem1);
+        void* sp = nullptr; vkMapMemory(dev, seedmem1, 0, bytes1, 0, &sp);
+        memcpy(sp, seed_rgba1, static_cast<size_t>(bytes1)); vkUnmapMemory(dev, seedmem1);
         VkImageMemoryBarrier s0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         s0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; s0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         s0.image = img1; s0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -2125,7 +2166,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // that pixel — the kill index that turns (x,y) dark is the culprit. Reuses the built pipelines/
     // descriptors; a fresh clear each pass. Env-gated, no default behavior. Used to locate a stray primitive
     // such as the #298 menu focus-ring sliver. Dumps iso_kill_<k>.bmp to PROSPER_FRAME_DIR.
-    if (getenv("PROSPER_DRAW_ISO") && getenv("PROSPER_ISO_AT")) {
+    if (FMT == VK_FORMAT_R8G8B8A8_UNORM &&
+        getenv("PROSPER_DRAW_ISO") && getenv("PROSPER_ISO_AT")) {
         static bool iso_done = false;
         int tx = -1, ty = -1; sscanf(getenv("PROSPER_ISO_AT"), "%d,%d", &tx, &ty);
         // Optional PROSPER_ISO_RGB="r,g,b" (+ PROSPER_ISO_TOL, default 45): the target submit is the first
@@ -2233,7 +2275,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (auto& upload : texture_uploads) {
         if (!upload.direct_memory || !upload.persistent_id || upload.persistent_hit) continue;
         const PersistentTextureKey key{upload.persistent_id, upload.key.width, upload.key.height,
-                                       upload.key.depth, upload.key.img_dim};
+                                       upload.key.depth, upload.key.img_dim, upload.key.format};
         while ((persistent_texture_images.size() >= persistent_texture_max_entries ||
                 (upload.image_bytes <= persistent_texture_limit &&
                  persistent_texture_bytes > persistent_texture_limit - upload.image_bytes)) &&

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -2,6 +2,7 @@
 #include "../src/gpu/pm4_registers.hpp"
 #include "../src/gpu/tile.hpp"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -275,7 +276,19 @@ int main() {
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");
     CHECK(loaded.rtt_seeds.size() == 1 && loaded.rtt_seeds[0].width == 2 &&
+          loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rgba8Unorm &&
           loaded.rtt_seeds[0].rgba == temporal_rgba, "temporal RTT seed round-trips");
+    GpuCaptureFile fp16_capture = captured;
+    fp16_capture.rtt_seeds[0].format = GpuCaptureColorFormat::Rgba16Float;
+    fp16_capture.rtt_seeds[0].rgba.assign(2 * 2 * 8, 0x5a);
+    std::vector<uint8_t> fp16_bytes;
+    GpuCaptureFile fp16_loaded;
+    CHECK(serialize_gpu_capture(fp16_capture, fp16_bytes, error) &&
+          deserialize_gpu_capture(fp16_bytes, fp16_loaded, error) &&
+          fp16_loaded.rtt_seeds.size() == 1 &&
+          fp16_loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rgba16Float &&
+          fp16_loaded.rtt_seeds[0].rgba == fp16_capture.rtt_seeds[0].rgba,
+          "native FP16 RTT seed format and bytes round-trip");
     CHECK(loaded.ds_seeds.size() == 1 && loaded.ds_seeds[0].depth == ds_seed.depth &&
           loaded.ds_seeds[0].stencil == ds_seed.stencil && loaded.ds_seeds[0].depth_valid &&
           loaded.ds_seeds[0].stencil_valid,
@@ -434,7 +447,7 @@ int main() {
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 28,
-          "created a diagnostic-free v12 payload for legacy-reader fixtures");
+          "created a diagnostic-free v13 payload for legacy-reader fixtures");
     if (legacy_bytes.size() >= 28) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
@@ -442,6 +455,23 @@ int main() {
         legacy_bytes.resize(legacy_bytes.size() - (4 + 20 * legacy_resource_count));
         // Remove the v11 DCC tail: count + 17-byte state record per resource.
         legacy_bytes.resize(legacy_bytes.size() - (4 + 17 * legacy_resource_count));
+        // v13 inserted one format dword between every RTT seed extent and byte vector. Remove the
+        // fixture's only format word to recover a byte-exact v10 prefix before trimming older tails.
+        const auto& seed = legacy_source.rtt_seeds[0];
+        std::vector<uint8_t> marker;
+        auto append_u32 = [&](uint32_t value) {
+            for (unsigned i = 0; i < 4; ++i) marker.push_back(uint8_t(value >> (8 * i)));
+        };
+        auto append_u64 = [&](uint64_t value) {
+            for (unsigned i = 0; i < 8; ++i) marker.push_back(uint8_t(value >> (8 * i)));
+        };
+        append_u64(seed.guest_addr); append_u32(seed.width); append_u32(seed.height);
+        append_u32(static_cast<uint32_t>(seed.format)); append_u64(seed.rgba.size());
+        auto seed_header = std::search(legacy_bytes.begin(), legacy_bytes.end(),
+                                       marker.begin(), marker.end());
+        if (seed_header != legacy_bytes.end())
+            legacy_bytes.erase(seed_header + 16, seed_header + 20);
+        legacy_bytes[8] = 10;
         // Remove the v10 MRT tail: draw count + one (target identity + 50-byte pipeline state) +
         // zero failure count. The remaining payload is byte-exact v9.
         legacy_bytes.resize(legacy_bytes.size() - (4 + 16 + 50 + 4));
@@ -460,9 +490,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 13;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 14;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 13",
+          error == "unsupported capture version 14",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -271,6 +271,84 @@ int main() {
               "invalidated GPU target uses the supplied CPU fallback instead of stale pixels");
     }
 
+    // Renderer-owned FP16 targets must retain HDR values through both CPU RTT readback/upload and
+    // direct GPU-resident sampling. A producer value of 2.0 multiplied by 0.25 in the consumer is
+    // 0.5; the historical RGBA8 conversion clamped it to 1.0 first and therefore produced 0.25.
+    {
+        static const uint32_t kHdrPs[] = {
+            0x7E0002FFu, 0x40000000u,  // v0 = 2.0
+            0x7E0202FFu, 0x3E800000u,  // v1 = 0.25
+            0x7E040280u,               // v2 = 0.0
+            0x7E0602F2u,               // v3 = 1.0
+            0xF800180Fu, 0x03020100u, 0xBF810000u,
+        };
+        const uint32_t kHdrSamplePs[] = {
+            0x7E0002FFu, C025, 0x7E0202FFu, C025,
+            0xF0800F08u, 0x00820000u,  // image_sample v[0:3]
+            0x100000FFu, 0x3E800000u,  // v0 *= 0.25
+            0xF800000Fu, 0x03020100u, 0xBF810000u,
+        };
+        std::vector<uint32_t> hdr = recompile_fragment(
+            kHdrPs, sizeof(kHdrPs) / sizeof(kHdrPs[0]), nullptr);
+        std::vector<uint32_t> hdr_sample = recompile_fragment(
+            kHdrSamplePs, sizeof(kHdrSamplePs) / sizeof(kHdrSamplePs[0]), &rt);
+        CHECK(!hdr.empty() && !hdr_sample.empty(),
+              "recompiled native FP16 producer and sampled consumer shaders");
+        if (!hdr.empty() && !hdr_sample.empty()) {
+            ResolvedPipelineState fp16_state{};
+            fp16_state.topology = 3;
+            fp16_state.color_write_mask = 0xF;
+            fp16_state.color0_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+            prosper::test::BackendDraw producer;
+            producer.vs = vert; producer.fs = hdr; producer.ps = &fp16_state;
+            producer.vcount = 3;
+
+            constexpr uint64_t fp16_target_id = 0x7590000000000016ull;
+            prosper::test::BackendColorTarget fp16_target{
+                fp16_target_id, false, true, VK_FORMAT_R16G16B16A16_SFLOAT};
+            std::vector<uint8_t> native = prosper::test::render_draws_rgba(
+                {producer}, W, H, nullptr, nullptr, false, &fp16_target);
+            bool native_ok = native.size() == static_cast<size_t>(W) * H * 8;
+            float native_red = 0.0f;
+            if (native_ok) {
+                uint16_t half = 0;
+                std::memcpy(&half, native.data() +
+                    ((static_cast<size_t>(H / 2) * W + W / 2) * 8), sizeof(half));
+                native_red = half_to_float(half);
+                native_ok = native_red > 1.99f && native_red < 2.01f;
+            }
+            CHECK(native_ok, "native FP16 target readback preserves HDR value 2.0");
+
+            prosper::test::FrameResource fp16_resource;
+            fp16_resource.binding = 4; fp16_resource.set = 1;
+            fp16_resource.tex_rgba = native.data(); fp16_resource.tw = W; fp16_resource.th = H;
+            fp16_resource.texture_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+            prosper::test::BackendDraw consumer;
+            consumer.vs = vert; consumer.fs = hdr_sample; consumer.R = {fp16_resource};
+            consumer.vcount = 3;
+            std::vector<uint8_t> cpu_sampled = prosper::test::render_draws_rgba(
+                {consumer}, W, H);
+            auto center_red = [&](const std::vector<uint8_t>& pixels) -> uint8_t {
+                return pixels.size() == static_cast<size_t>(W) * H * 4
+                    ? pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : 0;
+            };
+            const uint8_t cpu_red = center_red(cpu_sampled);
+            CHECK(cpu_red >= 126 && cpu_red <= 129,
+                  "FP16 readback/upload consumer observes 2.0 before scaling to 0.5");
+
+            prosper::test::FrameResource gpu_fp16_resource = fp16_resource;
+            gpu_fp16_resource.tex_rgba = nullptr;
+            gpu_fp16_resource.persistent_render_target_id = fp16_target_id;
+            consumer.R = {gpu_fp16_resource};
+            std::vector<uint8_t> gpu_sampled = prosper::test::render_draws_rgba(
+                {consumer}, W, H);
+            const auto gpu_sample_stats = prosper::test::backend_color_target_stats();
+            CHECK(gpu_sample_stats.sampled_hits == 1 && gpu_sampled == cpu_sampled,
+                  "GPU-resident FP16 target sampling matches native CPU RTT round-trip");
+            prosper::test::invalidate_persistent_color_target(fp16_target_id);
+        }
+    }
+
     // The backend upload key includes depth and image dimensionality. Exercise a real 3D image here
     // so depth-1 3D resources cannot accidentally regress to a 2D Vulkan image/view during sharing.
     {

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -152,7 +152,9 @@ before executing the final submit and writes them as seeds in a standalone curre
 introduced the base-level depth of every 3D image resource; v11 also retains each image T#'s GFX10 DCC flags,
 block-size fields, and metadata address. Version 12 captures the exact DCC control-surface bytes for the
 validated single-sample/base-level SW_64KB_R_X layout; metadata-only and older capsules keep their absence
-explicit. `--inspect-only` reports the planned/captured byte counts, non-zero and unique-byte counts,
+explicit. Version 13 tags every temporal color RTT seed as `rgba8` or `rgba16f`, preserving its native byte
+width through standalone replay while reading v1..v12 seeds as the historical RGBA8 default.
+`--inspect-only` reports the RTT format and the planned/captured byte counts, non-zero and unique-byte counts,
 first control word, and content hash. A software DCC decode is still not inferred. The capsule's standalone
 output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or
 shader experiments. Export validates every surface and fails when a required temporal color surface is absent;
@@ -215,9 +217,9 @@ hardware boundary: supported compute program `0x401aec200` fills the exact 32 Ki
 GPU writeback (#611); capture v8 preserves the state exactly when an investigation deliberately disables that
 invalidation.
 
-For new routed captures, timeline v6 replaces that historical endpoint with 91..93 semantic draws, exactly
-8 dispatches, and the 738x420 pass at draw 80..82. `gpu_timeline --signatures` derived the conjunction from two
-independent routes, and `--select` proves it has no splash/menu/loading or adjacent-index matches before capture.
+For new routed captures, timeline v6 replaces that historical endpoint with 91..94 semantic draws, exactly
+8 dispatches, and the 636x420 pass at draw 77..85. `gpu_timeline --signatures` derives the conjunction, and
+`--select` proves it has no splash/menu/loading or adjacent-index matches before capture.
 
 The #594/#595 gameplay capsule at submit 18,750 has two external 642x362 temporal versions. Timeline-v4
 full-run aggregation shows that both surfaces begin around submit 17,400 in current runs and are rewritten

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -223,9 +223,11 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
 void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     for (const auto& seed : replay.rtt_seeds) {
         const uint64_t hash = prosper::gpu::gpu_capture_hash(seed.rgba);
-        std::printf("rtt-seed addr=%016llx extent=%ux%u bytes=%zu hash=%016llx\n",
+        const char* format = seed.format == prosper::gpu::GpuCaptureColorFormat::Rgba16Float
+            ? "rgba16f" : "rgba8";
+        std::printf("rtt-seed addr=%016llx extent=%ux%u format=%s bytes=%zu hash=%016llx\n",
                     static_cast<unsigned long long>(seed.guest_addr), seed.width, seed.height,
-                    seed.rgba.size(), static_cast<unsigned long long>(hash));
+                    format, seed.rgba.size(), static_cast<unsigned long long>(hash));
     }
     for (const auto& seed : replay.ds_seeds) {
         const uint64_t depth_hash = prosper::gpu::gpu_capture_hash(seed.depth);

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -17,8 +17,8 @@ PROSPER_PAD_SCRIPT=@scripts/dead-cells/reach-first-gameplay.pad \
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl --records
 ./build-linux/gpu_timeline /tmp/dead-cells.prgtl --depth-summary 642x362
-./build-linux/gpu_timeline /tmp/dead-cells.prgtl --signatures 91:93 8
-./build-linux/gpu_timeline /tmp/dead-cells.prgtl --select 738x420 80:82 91:93 8
+./build-linux/gpu_timeline /tmp/dead-cells.prgtl --signatures 91:94 8
+./build-linux/gpu_timeline /tmp/dead-cells.prgtl --select 636x420 77:85 91:94 8
 ```
 
 Capture a selected submit and, optionally, its immediate predecessor from the same run:
@@ -56,10 +56,10 @@ PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-gameplay.prgbundle \
 PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=1000 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
 PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=642x362 \
-PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=738x420 \
-PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=80:82 \
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=636x420 \
+PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=77:85 \
 PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=91 \
-PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=93 \
+PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS=94 \
 PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \


### PR DESCRIPTION
## Summary

- preserve renderer-owned `VK_FORMAT_R16G16B16A16_SFLOAT` targets through attachment creation, native readback/seeding, sampled image upload/views, and persistent target/texture/pipeline cache keys
- split render passes when the target format changes and keep diagnostics format-aware
- add capture v13 RTT format metadata while retaining v1..v12 compatibility, including the newly merged v11/v12 DCC state
- document the current Dead Cells selector and native-format investigation workflow

## Root cause

Dead Cells draw 23 samples binding 36 from a 642x362 `Float16x4` lighting target produced by draws 17..22. The backend previously rendered and reuploaded that target as RGBA8, clamping HDR values before the full-screen composite and producing the giant translucent green/blue surface.

## Validation

- Linux build succeeds
- `ctest --test-dir build-linux --output-on-failure -j2`: 102/102 pass
- new Vulkan regression writes red=2.0 to RGBA16F, verifies native half-float readback, then samples and scales by 0.25 to produce 0.5 through both CPU RTT upload and persistent GPU target paths
- 77-submit Dead Cells bundle replay and exported standalone v13 capsule are byte-identical
- both output hash `9145002cabc36e97`; BMP SHA-256 is `d697c8c87a17110589d6ff4f3ed8fda30af8872b2041c5dae855ad8a7a536bee`
- v13 inspection records the relevant 642x362 seed as `rgba16f`, 1,859,232 bytes
- native Windows `prosper-app.exe` RelWithDebInfo build succeeds; 10-frame Vulkan window smoke passes on the RTX 4090
- before the final rebase, a fresh-save Windows full-render route completed `PARSEALL`, found 29 sustained gameplay selector matches, and stayed alive until the bounded harness exit

Cross-title snapshot baselines remain `review: pending` under #661, so the snapshot tool correctly refuses to treat them as approved regression oracles. This PR does not weaken or bypass that trust boundary.

Fixes #773

Related: #294, #775