### PR TITLE
feat(shader): lower s_not_b64 wave masks

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2040,7 +2040,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // 64-bit per-lane MASK ops (EXEC / VCC / saved masks). In our per-invocation model a wave
             // mask is a single bool for this lane. EXEC=SGPR 126/127, VCC=106/107; a saved mask lives
             // in sreg_bool. These implement divergent control flow (if/endif via saveexec + restore).
-            if (in.opcode == 0x04 || in.opcode == 0x0a || in.opcode == 0x24 || in.opcode == 0x25) {
+            if (in.opcode == 0x04 || in.opcode == 0x08 || in.opcode == 0x0a ||
+                in.opcode == 0x24 || in.opcode == 0x25) {
                 auto is_exec = [](const Operand& o){ return o.value == 126 || o.value == 127; };
                 auto src_mask = [&](const Operand& o) -> uint32_t {
                     if (o.value == 106 || o.value == 107) return rs.vcc;    // VCC
@@ -2084,6 +2085,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     auto it = rs.sreg_bool_narrowed.find(o.value);
                     return it != rs.sreg_bool_narrowed.end() ? it->second : true;
                 };
+                if (in.opcode == 0x08) {                    // s_not_b64
+                    const uint32_t m = src_mask(in.src[0]);
+                    if (!m) { ok = false; return true; }
+                    const uint32_t inverted = b.logical_not(m);
+                    if (is_exec(in.dst)) {
+                        rs.exec = inverted;
+                        rs.exec_narrowed = true;
+                    } else if (in.dst.value == 106 || in.dst.value == 107) {
+                        rs.vcc = inverted;
+                        rs.sreg_bool[in.dst.value] = inverted;
+                        rs.sreg_bool_narrowed[in.dst.value] = true;
+                    } else {
+                        rs.sreg_bool[in.dst.value] = inverted;
+                        rs.sreg_bool_narrowed[in.dst.value] = true;
+                    }
+                    return true;
+                }
                 if (in.opcode == 0x04) {                    // s_mov_b64
                     if (is_exec(in.dst)) {                  // set/restore EXEC
                         if (in.src[0].kind == OperandKind::InlineInt && in.src[0].value == -1) {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -361,6 +361,31 @@ int main() {
     CHECK(act17>0 && msk17>0, "kernel 17 exercises both active and masked lanes");
     CHECK(got17.size()==N && bad17==0, "recompiled kernel 17 (per-write predication + EXEC restore) correct");
 
+    // Kernel 17b: s_not_b64 complements a VCC lane mask before saveexec. DOLL's failed
+    // 120x68 LUT producer uses the exact gfx1030 encoding below (`s_not_b64 vcc,vcc`).
+    // v3=7; vcc=(u0>u1); vcc=!vcc; saveexec(vcc); v3=u0+u1; restore; output v3.
+    const uint32_t code17b[] = {
+        0x7e000f00u, 0x7e020f01u, 0x7e060287u, 0x7d880300u, 0xbeea086au,
+        0xbe80246au, 0xbf880001u, 0x4a060300u, 0xbefe0400u, 0x7e060d03u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv17b = recompile_valu(
+        code17b, sizeof(code17b)/sizeof(code17b[0]), 2, /*out_vgpr*/3);
+    CHECK(!spv17b.empty(), "recompiled kernel 17b (s_not_b64 VCC complement) -> SPIR-V");
+    std::vector<float> in17b(N * 2), exp17b(N);
+    for (uint32_t i = 0; i < N; i++) {
+        uint32_t u0 = i % 17, u1 = i % 13;
+        in17b[i*2+0]=(float)u0; in17b[i*2+1]=(float)u1;
+        exp17b[i] = (u0 <= u1) ? (float)(u0 + u1) : 7.0f;
+    }
+    std::vector<float> got17b = prosper::test::run_compute(spv17b, in17b, N, N);
+    uint32_t bad17b = 0, act17b = 0;
+    for (uint32_t i=0;i<N&&got17b.size()==N;i++) {
+        if (std::fabs(got17b[i]-exp17b[i])>1e-3f) bad17b++;
+        if ((i%17)<=(i%13)) act17b++;
+    }
+    CHECK(act17b>0 && act17b<N, "kernel 17b exercises both complemented-mask outcomes");
+    CHECK(got17b.size()==N && bad17b==0, "s_not_b64 complements VCC before EXEC predication");
+
     // Kernel 18: the REAL if-then idiom with a forward branch. v3=7; vcc=(u0>u1);
     // s_and_saveexec_b64 s[0:1],vcc (save exec, exec=vcc); s_cbranch_execz skip (forward -> no-op);
     // v_add v3=u0+u1 (predicated); skip: s_mov_b64 exec,s[0:1] (restore); cvt+store. Same result as


### PR DESCRIPTION
## Summary
- lower gfx1030 `s_not_b64` in the per-invocation wave-mask domain
- support EXEC, VCC, and saved SGPR-pair destinations while retaining conservative narrowed-mask tracking
- add an end-to-end Vulkan test for the exact `s_not_b64 vcc,vcc` encoding used by DOLL

## Unreal evidence
DOLL's failed `0x201b2a0000` compute dispatch is the 120x68 producer associated with the stale DCC volume. On its captured 578-dword shader, this change:
- raises supported ALU instructions from 294 to 296
- reduces unsupported instructions from 71 to 69
- advances the first rejection from `SOP1 s_not_b64` to the next control-flow blocker

## Validation
- exact encoding independently disassembled by LLVM 18 gfx1030 as `s_not_b64 vcc, vcc`
- new Vulkan differential test: both complemented mask outcomes, zero mismatches
- full Linux build
- 97/97 CTest tests pass

Refs #719