### PR TITLE
renderer: invalidate stale CPU RTTs on guest GPU writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,14 @@ sampled images, and persistent target/texture/pipeline cache identities. Capture
 or `rgba16f` and reads v1..v12 artifacts. The current semantic selector is documented in
 `prosper/docs/DEAD_CELLS_STATUS.md`; do not reuse the historical 738x420 predicate for new captures.
 
+The first FP16 live run then exposed stale temporal history (#780), not another shader defect. Compute operation
+19 resets the same lighting backing to RGBA16F `(0,0,0,1)` before draws 17..22, but guest-write notification
+invalidated only the persistent Vulkan target; the frontend immediately uploaded the previous frame's CPU RTT
+copy as a seed and brightness fed back toward white/yellow. Guest GPU writes now discard overlapping CPU RTT
+entries using their native byte width as well as invalidating GPU targets. Live user validation reports stable,
+artifact-free composition apart from separately tracked window-light banding (#781). The corrected 77-submit
+source and standalone capsule are byte-identical at `13b4ccdfa15b1f4d`.
+
 `--bundle-final-capsule` snapshots both color RTT state and exact valid planes from persistent Vulkan
 depth/stencil images into capture v8 (#569). Capture v8 reads v1-v7 artifacts; pre-v7 failed-operation diagnostics
 report unavailable and pre-v8 captures contain no invented DS seeds. Timeline v6 reads timeline v1-v5

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -58,7 +58,9 @@ possible without console keys. Dumps are user-supplied and gitignored.
   The later giant translucent Dead Cells gameplay surface was a native-format loss: a 642x362 RGBA16F lighting
   target was rendered and sampled as RGBA8, clamping HDR values before composition. Renderer-owned targets now
   preserve RGBA16F through render, readback, seeding, sampling, and persistent Vulkan caches. Capture v13 records
-  the RTT format and remains backward-compatible with v1..v12 artifacts (#773).
+  the RTT format and remains backward-compatible with v1..v12 artifacts (#773). A compute reset of that lighting
+  backing also invalidates the overlapping CPU RTT copy; retaining it had re-seeded the previous frame and driven
+  the temporal effect toward white/yellow (#780). Residual window-light banding is tracked separately in #781.
 - ✅ **Blasphemous 2 reaches first gameplay:** prelinking the title's optional FMOD core/studio
   plugins lets IL2CPP P/Invoke complete `FMODAudioBanksManager` initialization (#638/#640). The later AGC
   fault was prosper corrupting live DCB state: `+kSrjIVxKFE` is `sceAgcDcbPushMarker`, not the context

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -37,8 +37,18 @@ deterministic operation-prefix replay localized the first bad composite to draw 
 RGBA8, clamping HDR values before the composite. Renderer-owned RTTs now retain
 `VK_FORMAT_R16G16B16A16_SFLOAT` through attachment creation, readback/seed bytes, texture upload/views, and
 persistent target/texture/pipeline cache identities. Capture v13 records each RTT seed's native format while
-remaining able to read v1..v12 captures. The issue-773 77-submit source and its standalone v13 capsule are
-byte-identical at `9145002cabc36e97`; inspection shows one 642x362 `rgba16f` seed with 1,859,232 bytes.
+remaining able to read v1..v12 captures. The issue-773 pre-#780 77-submit source and its standalone v13 capsule
+were byte-identical at `9145002cabc36e97`; inspection shows one 642x362 `rgba16f` seed with 1,859,232 bytes.
+
+That native-format fix exposed a second temporal defect (#780): compute operation 19 writes the FP16 backing at
+`0x...50810000` with repeating half-float `(0,0,0,1)` before draws 17..22, resetting the lighting history. Guest
+GPU write notification invalidated the persistent Vulkan color target but left the frontend's older CPU RTT copy
+alive. Pass setup then uploaded that stale copy as `seed_rgba`, defeating the reset and feeding brightness back
+until the moving background became white/yellow. Guest GPU writes now discard every overlapping CPU RTT using
+the surface's native byte width. The corrected 77-submit bundle and regenerated standalone v13 capsule are
+byte-identical at `13b4ccdfa15b1f4d` (BMP SHA-256
+`6a4e88dbc163d6075b18b768b20d91cfb6467c76e61af6798e22ec6ea3d2c53c`). Live Windows validation found no
+remaining composition artifacts; localized banding in the window light is tracked separately in #781.
 
 Startup and progression are stable after implementing both AGC resource-registration output queries. The former
 success-only `QueryResourceRegistrationUserMemoryRequirements` stub left Dead Cells' stack value untouched and
@@ -61,7 +71,9 @@ The important fixes already on `master` are:
 - directly placed compute buffer destinations resolve, so the current scene realizes all eight dispatches (#626);
 - MRT0, rather than the first-emitted non-color G-buffer plane, supplies the visible fragment output (#626);
 - AGC resource-registration memory requirements always initialize their output instead of leaking stack data into
-  the game's texture-pool allocation size (#660).
+  the game's texture-pool allocation size (#660);
+- guest compute/DMA writes invalidate overlapping native-format CPU RTT snapshots as well as persistent Vulkan
+  targets, so a reset backing cannot be overwritten by stale temporal history (#780).
 
 The producer-complete post-#626 checkpoint realizes every semantic draw and all eight dispatches. Descriptor
 validation has not identified a missing or undersized binding in the exercised frame.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -54,6 +54,23 @@ struct RttSurf {
     bool gpu_valid = false;
 };
 
+using RttCache = std::unordered_map<uint64_t, RttSurf>;
+
+void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t size) {
+    if (!addr || !size) return;
+    const uint64_t end = size > UINT64_MAX - addr ? UINT64_MAX : addr + size;
+    for (auto it = cache.begin(); it != cache.end();) {
+        const RttSurf& surface = it->second;
+        const uint64_t bpp = prosper::test::backend_color_bytes_per_pixel(surface.format);
+        const uint64_t pixels = static_cast<uint64_t>(surface.w) * surface.h;
+        const uint64_t bytes = pixels > UINT64_MAX / bpp ? UINT64_MAX : pixels * bpp;
+        const uint64_t target_end = bytes > UINT64_MAX - it->first
+            ? UINT64_MAX : it->first + bytes;
+        if (addr < target_end && it->first < end) it = cache.erase(it);
+        else ++it;
+    }
+}
+
 prosper::gpu::GpuCaptureColorFormat capture_color_format(VkFormat format) {
     return prosper::test::backend_color_format(format) == VK_FORMAT_R16G16B16A16_SFLOAT
         ? prosper::gpu::GpuCaptureColorFormat::Rgba16Float
@@ -151,6 +168,7 @@ struct PersistentDecodedTexture {
 }
 
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
+    static RttCache g_rtt;   // render-to-texture cache (#167)
     register_live_compute();
     const char* ds_invalidate = getenv("PROSPER_DS_GUEST_WRITE_INVALIDATE");
     const bool invalidate_ds = !ds_invalidate || strcmp(ds_invalidate, "0");
@@ -159,6 +177,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             if (invalidate_ds)
                 prosper::test::invalidate_persistent_ds_guest_write(addr, size);
             prosper::test::invalidate_persistent_color_target_guest_write(addr, size);
+            invalidate_cpu_rtt_guest_write(g_rtt, addr, size);
         });
     // Resource tables are built before the submit reaches this callback. Publish the renderer's
     // default mode now so unmapped render-target descriptors remain available for RTT injection.
@@ -171,7 +190,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
 #endif
     }
     static std::atomic<int> frame_no{0};
-    static std::unordered_map<uint64_t, RttSurf> g_rtt;   // render-to-texture cache (#167)
     if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
         getenv("PROSPER_GPU_REPLAY_EXPORT_RTT")) {
         prosper::gpu::set_gpu_capture_rtt_seed_reader([](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1,4 +1,5 @@
 #include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../frontends/shared/live_renderer.hpp"
 
@@ -61,10 +62,12 @@ int main() {
           "replay keeps logical VA and exposes exact host backing size");
 
 #ifdef _WIN32
+    _putenv_s("PROSPER_GPU_CAPTURE", "1");
     _putenv_s("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
     _putenv_s("PROSPER_GPU_REPLAY_DS_SEEDS", "1");
     _putenv_s("PROSPER_GPU_REPLAY_EXPORT_DS", "1");
 #else
+    setenv("PROSPER_GPU_CAPTURE", "1", 1);
     setenv("PROSPER_GPU_REPLAY_RTT_SEEDS", "1", 1);
     setenv("PROSPER_GPU_REPLAY_DS_SEEDS", "1", 1);
     setenv("PROSPER_GPU_REPLAY_EXPORT_DS", "1", 1);
@@ -294,6 +297,28 @@ int main() {
         CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
               "temporal consumer samples restored host RTT pixels, not guest-memory fallback");
     }
+
+    // A retained CPU RTT is only authoritative until compute/DMA writes its guest backing. Dead
+    // Cells clears this FP16 lighting history with compute before drawing the next frame; keeping the
+    // older CPU seed defeated that clear and fed brightness back until the scene became white/yellow.
+    GpuCaptureRttSeed fp16_history;
+    fp16_history.guest_addr = 0x610000;
+    fp16_history.width = fp16_history.height = 2;
+    fp16_history.format = GpuCaptureColorFormat::Rgba16Float;
+    fp16_history.rgba.assign(2u * 2u * 8u, 0x5a);
+    CHECK(restore_gpu_replay_rtt_seeds({fp16_history}, error),
+          "replay restores a native FP16 temporal history surface");
+    GpuCaptureRttSeed retained_history;
+    CHECK(read_gpu_capture_rtt_seed(fp16_history.guest_addr, retained_history, error) &&
+          retained_history.format == GpuCaptureColorFormat::Rgba16Float,
+          "restored FP16 history is visible to the capture reader");
+    notify_guest_gpu_write(fp16_history.guest_addr + fp16_history.rgba.size(), 1);
+    CHECK(read_gpu_capture_rtt_seed(fp16_history.guest_addr, retained_history, error),
+          "guest write at the native FP16 range end does not invalidate history");
+    notify_guest_gpu_write(fp16_history.guest_addr + fp16_history.rgba.size() - 1, 1);
+    CHECK(!read_gpu_capture_rtt_seed(fp16_history.guest_addr, retained_history, error) &&
+          error == "render target is absent from live cache",
+          "overlapping guest GPU write invalidates stale CPU FP16 history");
 
     GpuCaptureDsSeed ds_seed;
     ds_seed.depth_read_base = ds_seed.depth_write_base = 0x810000;


### PR DESCRIPTION
## Summary

- discard CPU RTT snapshots when compute, DMA, or another guest GPU producer writes overlapping backing memory
- size invalidation ranges from each cached surface's native format, including eight-byte RGBA16F texels
- add a real renderer/capture regression for exact-end and overlapping writes to an FP16 temporal surface
- document the Dead Cells failure chain and split residual window-light banding into #781

## Root cause

Dead Cells compute operation 19 resets the 642x362 FP16 lighting backing at `0x...50810000` to repeating `(0,0,0,1)` before draws 17..22. Guest write notification invalidated the persistent Vulkan target but left the frontend's older CPU RTT snapshot alive. Pass setup then uploaded that previous frame as `seed_rgba`, defeating the reset and feeding temporal brightness back until the scene became white/yellow.

## Validation

- live native Windows user validation: movement no longer increases background brightness; user reports the scene looks “a LOT better” with no composition artifacts
- residual window-light banding is separately tracked in #781
- Linux build succeeds after rebasing on merged PR #779
- `ctest --test-dir build-linux --output-on-failure -j2`: 102/102 pass
- focused regression restores a 2x2 RGBA16F RTT, proves a write at its exact end is non-overlapping, and proves a write to its final native byte invalidates the CPU cache
- 77-submit source and regenerated standalone v13 capsule are byte-identical at renderer hash `13b4ccdfa15b1f4d`
- BMP SHA-256: `6a4e88dbc163d6075b18b768b20d91cfb6467c76e61af6798e22ec6ea3d2c53c`
- standalone capsule replay after the #779 rebase still passes the embedded oracle
- native Windows app build succeeds and is the build used for live validation

Cross-title snapshot entries remain `review: pending` under #661, so this PR does not bypass or treat them as approved oracles.

Fixes #780

Related: #294, #773, #781