### PR TITLE
feat(shader): execute UE4 volume-lighting compute producer

### DIFF
--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -87,6 +87,48 @@ void decode_operands(Rdna2Inst& i) {
                         i.has_modifier = false;
                     }
                 }
+                // v_cvt_f32_f16_sdwa may select either packed half before conversion. The source
+                // abs/neg modifiers apply to that f16 value (the recompiler applies them after
+                // unpacking); destination remains a full f32 dword. UE4's volume-lighting kernel
+                // uses WORD_1 heavily for packed half intermediates.
+                else if (((w >> 9) & 0xFFu) == 0x0Bu) {
+                    const uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    const uint32_t s0sel = (sd >> 16) & 7u;
+                    if (dsel == 6u && dun == 0u && s0sel >= 4u && s0sel <= 6u &&
+                        !((sd >> 19) & 0x9u) && !i.clamp && !i.omod) {
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.has_modifier = false;
+                    }
+                }
+                // v_cvt_f16_f32_sdwa packs a full f32 source into the selected destination half.
+                // The live producer writes WORD_1 with UNUSED_PRESERVE to assemble packed values.
+                else if (((w >> 9) & 0xFFu) == 0x0Au) {
+                    const uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    const uint32_t s0sel = (sd >> 16) & 7u;
+                    if ((dsel == 4u || dsel == 5u) && dun == 2u && s0sel == 6u &&
+                        !((sd >> 19) & 0x9u) && !i.clamp && !i.omod &&
+                        !i.src_neg[0] && !i.src_abs[0]) {
+                        i.sdwa_dst_sel = static_cast<uint8_t>(dsel);
+                        i.sdwa_dst_unused = static_cast<uint8_t>(dun);
+                        i.has_modifier = false;
+                    }
+                }
+                // Packed unary f16 SDWA selects one source half, writes one destination half, and
+                // preserves the other. The producer uses rcp/sqrt/cos (0x54/0x55/0x61).
+                else if (((w >> 9) & 0xFFu) == 0x54u ||
+                         ((w >> 9) & 0xFFu) == 0x55u ||
+                         ((w >> 9) & 0xFFu) == 0x61u) {
+                    const uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    const uint32_t s0sel = (sd >> 16) & 7u;
+                    if ((dsel == 4u || dsel == 5u) && dun == 2u &&
+                        (s0sel >= 4u && s0sel <= 6u) && !((sd >> 19) & 0x9u) &&
+                        !i.clamp && !i.omod && !i.src_neg[0] && !i.src_abs[0]) {
+                        i.sdwa_dst_sel = static_cast<uint8_t>(dsel);
+                        i.sdwa_dst_unused = static_cast<uint8_t>(dun);
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.has_modifier = false;
+                    }
+                }
             } else if (i.has_dpp) { i.src[0] = vgpr(i.words[1]); i.n_src = 1; }   // DPP16: real SRC0 in dw1[7:0]
             else { i.src[0] = decode_src_field(w & 0x1FFu); i.n_src = 1; }
             break;
@@ -114,15 +156,36 @@ void decode_operands(Rdna2Inst& i) {
                 // UNUSED_PRESERVE, src sels WORD/DWORD, no sext/neg/abs/clamp/omod. (llvm-mc gfx1010:
                 // 0x6a0000f9 0x0686156a -> v_mul_f16_sdwa v0, vcc_lo, v0 dst_sel:WORD_1
                 // dst_unused:UNUSED_PRESERVE — DOLL's box-blur tail.)
-                else if (((w >> 25) & 0x3Fu) == 0x35u) {
+                else if (((w >> 25) & 0x3Fu) == 0x32u ||
+                         ((w >> 25) & 0x3Fu) == 0x33u ||
+                         ((w >> 25) & 0x3Fu) == 0x35u ||
+                         ((w >> 25) & 0x3Fu) == 0x39u ||
+                         ((w >> 25) & 0x3Fu) == 0x3Au) {
+                    uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    uint32_t s0sel = (sd >> 16) & 7u, s1sel = (sd >> 24) & 7u;
+                    const bool preserve_word = (dsel == 4u || dsel == 5u) && dun == 2u;
+                    const bool padded_dword = dsel == 6u && dun == 0u;
+                    if ((preserve_word || padded_dword) &&
+                        (s0sel >= 4u && s0sel <= 6u) && (s1sel >= 4u && s1sel <= 6u) &&
+                        !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u) && !i.omod) {
+                        i.sdwa_dst_sel = (uint8_t)dsel; i.sdwa_dst_unused = (uint8_t)dun;
+                        i.sdwa_src0_sel = (uint8_t)s0sel; i.sdwa_src1_sel = (uint8_t)s1sel;
+                        i.has_modifier = false;
+                    }
+                }
+                // WORD-destination v_cndmask_b32_sdwa selects one 16-bit source through VCC and
+                // preserves the opposite destination half (the producer's packed conditional).
+                else if (((w >> 25) & 0x3Fu) == 0x01u) {
                     uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
                     uint32_t s0sel = (sd >> 16) & 7u, s1sel = (sd >> 24) & 7u;
                     if ((dsel == 4u || dsel == 5u) && dun == 2u &&
-                        (s0sel >= 4u && s0sel <= 6u) && (s1sel >= 4u && s1sel <= 6u) &&
+                        s0sel >= 4u && s0sel <= 6u && s1sel >= 4u && s1sel <= 6u &&
                         !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u) && !i.clamp && !i.omod &&
                         !i.src_neg[0] && !i.src_abs[0] && !i.src_neg[1] && !i.src_abs[1]) {
-                        i.sdwa_dst_sel = (uint8_t)dsel; i.sdwa_dst_unused = (uint8_t)dun;
-                        i.sdwa_src0_sel = (uint8_t)s0sel; i.sdwa_src1_sel = (uint8_t)s1sel;
+                        i.sdwa_dst_sel = static_cast<uint8_t>(dsel);
+                        i.sdwa_dst_unused = static_cast<uint8_t>(dun);
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.sdwa_src1_sel = static_cast<uint8_t>(s1sel);
                         i.has_modifier = false;
                     }
                 }
@@ -185,6 +248,10 @@ void decode_operands(Rdna2Inst& i) {
                 i.src_abs[0] = i.src_abs[1] = i.src_abs[2] = false;
                 i.clamp = false;
             }
+            // v_fma_f16 VOP3: OPSEL[2:0] selects each packed source half and OPSEL[3]
+            // selects the destination half. Reuse the packed-op selector field for this family.
+            if (i.opcode == 0x34Bu)
+                i.vop3p_opsel = static_cast<uint8_t>((w >> 11) & 0xFu);
             break;
         }
         case Rdna2Format::VOP3P: {
@@ -197,13 +264,23 @@ void decode_operands(Rdna2Inst& i) {
             i.src[0] = decode_src_field(d1 & 0x1FFu);
             i.src[1] = decode_src_field((d1 >> 9) & 0x1FFu);
             i.src[2] = decode_src_field((d1 >> 18) & 0x1FFu); i.n_src = 3;
-            // v_fma_mix_f32/mixlo/mixhi (0x20-0x22): every modifier bit is MODELED (#273) —
+            // Packed f16 add/mul (0x0f/0x10) and v_fma_mix_f32/mixlo/mixhi (0x20-0x22): every
+            // modifier bit is MODELED (#273). For packed ops OPSEL/NEG select and negate each source
+            // independently for the low result; OPSEL_HI/NEG_HI do the same for the high result.
+            // For the mix family:
             // OPSEL_HI[k] selects an f16-half read (which half via OPSEL[k]), NEG negates, NEG_HI
             // is ABS for the mix family, CLAMP saturates. (llvm-mc gfx1030 round-trip on the live
             // DOLL bytes: 0xcc200044 0x9a02170b = v_fma_mix_f32 v68, v11, v11, neg(0)
             // op_sel_hi:[1,1,0].) Other VOP3P ops (v_pk_*, per-half packed semantics) still reject
             // on any modifier bit.
-            if (i.opcode >= 0x20 && i.opcode <= 0x22) {
+            if (i.opcode == 0x0F || i.opcode == 0x10) {
+                const uint32_t neg = (d1 >> 29) & 7u;
+                for (int k = 0; k < 3; ++k) i.src_neg[k] = ((neg >> k) & 1u) != 0;
+                i.vop3p_neg_hi  = static_cast<uint8_t>((w >> 8) & 7u);
+                i.vop3p_opsel   = static_cast<uint8_t>((w >> 11) & 7u);
+                i.vop3p_opsel_hi = static_cast<uint8_t>(((d1 >> 27) & 3u) | (((w >> 14) & 1u) << 2));
+                i.clamp = ((w >> 15) & 1u) != 0;
+            } else if (i.opcode >= 0x20 && i.opcode <= 0x22) {
                 const uint32_t neg = (d1 >> 29) & 7u, neg_hi = (w >> 8) & 7u;
                 for (int k = 0; k < 3; k++) {
                     i.src_neg[k] = ((neg >> k) & 1u) != 0;
@@ -285,14 +362,16 @@ void decode_operands(Rdna2Inst& i) {
         }
         case Rdna2Format::DS: {
             // LDS/GDS op. opcode[25:18]; 16-bit byte offset[15:0]; dword1: ADDR[7:0], DATA0[15:8],
-            // DATA1[23:16], VDST[31:24]. (Verified via llvm-mc gfx1030: ds_write_b32=0x0d, ds_read_b32=0x36.)
+            // DATA1[23:16], VDST[31:24]. (Verified via llvm-mc gfx1030: ds_write_b32=0x0d,
+            // ds_read_b32=0x36, ds_write_b64=0x4d, ds_write2_b64=0x4e.)
             const uint32_t d1 = i.words[1];
             i.opcode  = (w >> 18) & 0xFFu;
             i.literal = w & 0xFFFFu;                 // byte offset (offset0:offset1)
             i.src[0]  = vgpr(d1 & 0xFFu);            // ADDR (byte offset into LDS)
             i.src[1]  = vgpr((d1 >> 8) & 0xFFu);     // DATA0 (store source)
+            i.src[2]  = vgpr((d1 >> 16) & 0xFFu);    // DATA1 (write2 store source)
             i.dst     = vgpr((d1 >> 24) & 0xFFu);    // VDST (load dest)
-            i.n_src = 2; break;
+            i.n_src = 3; break;
         }
         case Rdna2Format::VINTRP: {
             // Pixel-shader interpolation. opcode[17:16] (p1=0,p2=1,mov=2); vdst[25:18]; attr[15:10];

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -107,11 +107,12 @@ struct Rdna2Inst {
     uint32_t vintrp_attr = 0;
     uint32_t vintrp_chan = 0;
 
-    // VOP3P v_fma_mix* only (#273): per-source half-select bitmasks. Bit k of vop3p_opsel_hi set =
-    // source k reads as an f16 HALF (which half chosen by bit k of vop3p_opsel: 0 = low, 1 = high)
-    // converted to f32; clear = full f32. NEG lands in src_neg[], NEG_HI (abs for the mix ops) in
-    // src_abs[], CLAMP in clamp.
+    // Packed/mixed f16 selector bitmasks. For VOP3P mix ops, bit k of vop3p_opsel_hi means source k
+    // reads as an f16 half selected by vop3p_opsel[k]; packed add/mul use the two masks for the low
+    // and high results. VOP3 v_fma_f16 reuses vop3p_opsel[2:0] for its sources and bit 3 for dst.
+    // NEG lands in src_neg[], NEG_HI (abs for mix ops) in src_abs[], and CLAMP in clamp.
     uint8_t vop3p_opsel = 0, vop3p_opsel_hi = 0;
+    uint8_t vop3p_neg_hi = 0;   // packed add/mul: per-source negate for the HIGH f16 result
 };
 
 // Decode the single instruction at code[0..]; `max_dwords` bounds the read. On a truncated/unknown

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -38,7 +38,7 @@ enum : uint32_t {
     Op_TypeImage=25, Op_TypeSampledImage=27, Op_SampledImage=86,
     Op_ImageSampleImplicitLod=87, Op_ImageSampleExplicitLod=88, Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
     Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQueryLevels=106,
-    Op_TypeArray=28, Op_ControlBarrier=224,
+    Op_TypeArray=28, Op_ControlBarrier=224, Op_AtomicIAdd=234, Op_AtomicUMin=237, Op_AtomicUMax=239,
     Op_DPdx=207, Op_DPdy=208,   // screen-space derivatives (Fragment; plain Shader capability)
     Op_Phi=245, Op_LoopMerge=246,
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
@@ -729,6 +729,46 @@ struct SpirvCompute {
         put(code, Op_Store, {p, value});
         put(code, Op_Branch, {merge});
         put(code, Op_Label, {merge}); cur_block = merge;
+    }
+    // Unsigned LDS atomic RMW. The old value is intentionally discarded; the non-returning RDNA DS
+    // form exposes only the memory effect. Workgroup scope + WorkgroupMemory AcquireRelease matches
+    // the storage class and the barrier helper used around cooperating accesses.
+    void lds_atomic(uint32_t op, uint32_t idx, uint32_t value, bool predicated, uint32_t pred) {
+        auto emit = [&]() {
+            uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32, p, lds_var, idx});
+            uint32_t result = id();
+            put(code, op, {t_u32, result, p, uconst(Scope_Workgroup), uconst(MemSem_WGAcqRel), value});
+        };
+        if (!predicated) { emit(); return; }
+        uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        emit();
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+    }
+    // Returning LDS atomic RMW. Inactive lanes must neither touch LDS nor observe an undefined
+    // atomic result, so the predicated form joins the old destination fallback through OpPhi.
+    uint32_t lds_atomic_rtn(uint32_t op, uint32_t idx, uint32_t value,
+                            bool predicated, uint32_t pred, uint32_t fallback) {
+        auto emit = [&]() {
+            uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32, p, lds_var, idx});
+            uint32_t result = id();
+            put(code, op, {t_u32, result, p, uconst(Scope_Workgroup), uconst(MemSem_WGAcqRel), value});
+            return result;
+        };
+        if (!predicated) return emit();
+        const uint32_t entry = cur_block;
+        uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        const uint32_t result = emit();
+        const uint32_t then_end = cur_block;
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+        return emit_phi_2way(t_u32, result, then_end, fallback, entry);
     }
     // s_barrier: workgroup execution + memory barrier (OpControlBarrier).
     void barrier() {
@@ -1464,7 +1504,10 @@ uint32_t vgpr_write_count(const Rdna2Inst& in) {
         case Rdna2Format::VOP2: case Rdna2Format::VOP3: case Rdna2Format::VOP3P:
             return 1;
         case Rdna2Format::DS:
-            return in.opcode == 0x36 || in.opcode == 0xb1 ? 1 : 0;
+            if (in.opcode == 0x36 || in.opcode == 0xb1) return 1;
+            if (in.opcode == 0x76) return 2;
+            if (in.opcode == 0x77) return 4;
+            return 0;
         case Rdna2Format::MUBUF:
             switch (in.opcode) {
                 case 0x1: case 0x5: case 0xD: return 2;
@@ -1783,14 +1826,14 @@ ForwardIf detect_forward_if(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
 // plus a structural check: blocks must nest or be disjoint — a partial overlap (branch into the
 // middle of another block) is not an if-tree and rejects. Returns branches in pc order; empty =
 // no/unsupported control flow (the caller falls back to straight-line, which rejects loudly at the
-// branch). s_branch / execz / execnz still reject wholesale, exactly like detect_forward_if.
+// branch). Compute execz uses a subgroup vote; execnz and unclaimed s_branch still reject wholesale.
 // CONFIDENCE: HIGH on the structure (guarded by the phi machinery shared with the single-if path).
 std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, bool allow_vcc,
                                           const uint32_t* code, size_t dwords,
                                           const std::unordered_set<uint32_t>* skip = nullptr,
                                           const std::vector<DivLoop>* loops = nullptr,
                                           bool* rejected = nullptr,
-                                          bool uniform_vcc_compute = false) {
+                                          bool compute_wave_branches = false) {
     std::vector<ForwardIf> out;
     if (rejected) *rejected = false;
     auto reject = [&]() -> std::vector<ForwardIf> { if (rejected) *rejected = true; return {}; };
@@ -1820,9 +1863,9 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
             case 0x08:                                               // execz: safe-linearized predication
                 if (skip && skip->count(in.pc)) continue;            // branch -> emit_alu no-ops it; else a
                 if (loop_exit(in.pc)) continue;                      // loop exit test: the loop emitter's
-                if (!allow_vcc) return reject();                     // OpBranchConditional consumes it
-                break;                                               // DIVERGENT-REGION if (per-invocation
-                                                                     // stages only — compute has wave VCC/EXEC)
+                if (!allow_vcc && !compute_wave_branches) return reject();
+                break;                                               // compute lowers the wave-empty test with
+                                                                     // OpGroupNonUniformAny(EXEC)
             case 0x06: case 0x07:                                    // vccz / vccnz
                 if (loop_exit(in.pc)) continue;                      // canonical loop condition: loop emitter owns it
                 if (!allow_vcc) {
@@ -1832,7 +1875,7 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                     // branch (cannot_write_vcc walk). Every lane's bool is then identical, so the
                     // wave-empty vccz test lowers to this invocation's bool. Varying compares keep
                     // rejecting loudly (per-invocation lowering of a varying wave test is wrong).
-                    if (!uniform_vcc_compute || !vcc_exit_is_wave_uniform(ins, in.pc)) return reject();
+                    if (!compute_wave_branches || !vcc_exit_is_wave_uniform(ins, in.pc)) return reject();
                     compute_uniform_vcc = true;
                 }
                 break;
@@ -1890,6 +1933,41 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 if (lm <= tgt || lm > end_pc) return reject();       // merge must be forward, in-stream
                 F.has_else = true; F.sb_pc = sb.pc; F.merge_pc = lm;
                 break;
+            }
+        }
+        if (!allow_vcc && compute_wave_branches && F.on_exec) {
+            // A compute execz condition is subgroup-uniform, so live scalar writes and LDS are safe
+            // inside the structured arm. A workgroup barrier is not: different waves may take
+            // different arms. Scalar writes into VCC_LO/HI also have an implicit mask-domain side
+            // effect which the scalar scratch model cannot reconstruct; accept those only when the
+            // mask is provably overwritten before any post-merge implicit read. The captured UE4
+            // kernel writes VCC_LO as an integer scratch in the arm and overwrites VCC with a VOPC at
+            // the merge, which this deliberately narrow proof accepts.
+            const uint32_t region_end = F.has_else ? F.merge_pc : F.target_pc;
+            for (const auto& r : ins) {
+                if (r.is_end || r.pc >= region_end) break;
+                if (r.pc <= in.pc) continue;
+                if (r.fmt == Rdna2Format::SOPP && r.opcode == 0x0a) return reject();
+
+                uint32_t scalar_width = 0;
+                if (r.fmt == Rdna2Format::SOP1) scalar_width = r.opcode == 0x04 ? 2u : 1u;
+                else if (r.fmt == Rdna2Format::SOP2 || r.fmt == Rdna2Format::SOPK) scalar_width = 1;
+                else if (r.fmt == Rdna2Format::SMEM) {
+                    switch (r.opcode) {
+                        case 0x0: case 0x8: scalar_width = 1; break;
+                        case 0x1: case 0x9: scalar_width = 2; break;
+                        case 0x2: case 0xA: scalar_width = 4; break;
+                        case 0x3: case 0xB: scalar_width = 8; break;
+                        case 0x4: case 0xC: scalar_width = 16; break;
+                        default: break;
+                    }
+                }
+                if (!scalar_width ||
+                    (r.dst.kind != OperandKind::SGPR && r.dst.kind != OperandKind::Special)) continue;
+                for (int vcc_half = 106; vcc_half <= 107; ++vcc_half) {
+                    if (vcc_half < r.dst.value || vcc_half >= r.dst.value + (int)scalar_width) continue;
+                    if (!sgpr_dead_at_merge(ins, region_end, vcc_half)) return reject();
+                }
             }
         }
         if (compute_uniform_vcc) {
@@ -1966,8 +2044,10 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
             case Rdna2Format::VOP3:
                 if (in.opcode == 0x360) sregs.insert(in.dst.value);       // v_readlane -> SGPR
                 else vregs.insert(in.dst.value); break;                   // (writelane: slots, not SSA)
-            case Rdna2Format::DS:                                          // ds_read writes one VGPR
-                if (in.opcode == 0x36 || in.opcode == 0xb1) vregs.insert(in.dst.value); break;
+            case Rdna2Format::DS:
+                for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
+                    vregs.insert(in.dst.value + (int)k);
+                break;
             case Rdna2Format::MUBUF: case Rdna2Format::MIMG:
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
@@ -2347,6 +2427,39 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::VOP3P: {
+            if (in.opcode == 0x0F || in.opcode == 0x10) {  // v_pk_add_f16 / v_pk_mul_f16
+                const uint32_t old_d = vreg_old(b, rs, in.dst.value);
+                auto half = [&](int source, bool high_result) -> uint32_t {
+                    uint32_t v = val(in.src[source]);
+                    // Inline float constants already arrive as full f32 values; register operands
+                    // contain two packed halves selected independently for each result half.
+                    if (in.src[source].kind == OperandKind::InlineInt) {
+                        v = b.uconst(fbits(static_cast<float>(in.src[source].value)));
+                    } else if (in.src[source].kind != OperandKind::InlineFloat) {
+                        const uint8_t selectors = high_result ? in.vop3p_opsel_hi : in.vop3p_opsel;
+                        v = b.unpack_half(v, (selectors >> source) & 1u);
+                    }
+                    const bool negate = high_result
+                        ? ((in.vop3p_neg_hi >> source) & 1u) != 0
+                        : in.src_neg[source];
+                    return negate ? b.fbin(Op_FSub, b.uconst(0), v) : v;
+                };
+                auto operation = [&](bool high) {
+                    uint32_t r = in.opcode == 0x0F
+                        ? b.fbin(Op_FAdd, half(0, high), half(1, high))
+                        : b.fbin(Op_FMul, half(0, high), half(1, high));
+                    if (in.clamp)
+                        r = b.fext2(Glsl_FMax,
+                                    b.fext2(Glsl_FMin, r, b.uconst(fbits(1.0f))),
+                                    b.uconst(fbits(0.0f)));
+                    return r;
+                };
+                const uint32_t lo = b.pack_half_lo(operation(false));
+                const uint32_t hi = b.ibin(Op_ShiftLeftLogical, b.pack_half_lo(operation(true)), b.uconst(16));
+                rs.vreg[in.dst.value] = b.ibin(Op_BitwiseOr, lo, hi);
+                predicate_write(b, rs, in.dst.value, old_d);
+                return true;
+            }
             // Mixed-precision FMA family, trivial form only (all sources full f32 — the decoder set
             // has_modifier for any opsel/neg/clamp bits, rejected above). v_fma_mix_f32 (0x20):
             // d = s0*s1+s2. v_fma_mixlo/hi_f16 (0x21/0x22): the f32 result converts to f16 into the
@@ -2441,9 +2554,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (!b.is_fragment || in.opcode != 0x01) { ok = false; return true; }
                 a = b.dpp_quad(a, in.dpp_ctrl);
             }
-            // SDWA float source modifiers on src0 (abs then neg) — only set on float ops by the assembler.
-            if (in.src_abs[0]) a = b.fext1(Glsl_FAbs, a);
-            if (in.src_neg[0]) a = b.fbin(Op_FSub, b.uconst(0), a);
+            // SDWA float source modifiers on src0 (abs then neg). v_cvt_f32_f16 applies them after
+            // selecting and unpacking the requested half below; applying them to the packed u32 as
+            // though it were an f32 changes both the value and the selected sign bit.
+            if (in.opcode != 0x0B) {
+                if (in.src_abs[0]) a = b.fext1(Glsl_FAbs, a);
+                if (in.src_neg[0]) a = b.fbin(Op_FSub, b.uconst(0), a);
+            }
             if (in.opcode == 0x02) {   // v_readfirstlane_b32: SGPR dst = value of the lowest active lane
                 // Cross-lane broadcast. Our per-lane scalar model has no cross-lane reduction, so we use
                 // THIS lane's value. SPECULATIVE(confidence: med): exact only when src0 is wave-uniform —
@@ -2476,6 +2593,34 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 predicate_write(b, rs, in.dst.value, old_d);
                 return true;
             }
+            // Packed unary f16 SDWA: select one source half, compute in f32, round back to f16, and
+            // insert while preserving the opposite destination half. Trig input is in revolutions.
+            if ((in.opcode == 0x54 || in.opcode == 0x55 || in.opcode == 0x61) &&
+                in.sdwa_dst_sel != 6) {
+                uint32_t x = b.unpack_half(a, in.sdwa_src0_sel == 5 ? 1 : 0);
+                uint32_t result = in.opcode == 0x54 ? b.frcp(x)
+                                : in.opcode == 0x55 ? b.fext1(Glsl_Sqrt, x)
+                                : b.fext1(Glsl_Cos,
+                                          b.fbin(Op_FMul, x, b.uconst(fbits(6.28318530717958647692f))));
+                uint32_t r16 = b.pack_half_lo(result);
+                d = in.sdwa_dst_sel == 5
+                    ? b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0x0000FFFFu)),
+                             b.ibin(Op_ShiftLeftLogical, r16, b.uconst(16)))
+                    : b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0xFFFF0000u)), r16);
+                predicate_write(b, rs, in.dst.value, old_d);
+                return true;
+            }
+            // v_cvt_f16_f32_sdwa inserts the converted half into the selected destination word and
+            // preserves the other word (unlike the plain form, whose result occupies the low half).
+            if (in.opcode == 0x0A && in.sdwa_dst_sel != 6) {
+                uint32_t r16 = b.pack_half_lo(a);
+                d = in.sdwa_dst_sel == 5
+                    ? b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0x0000FFFFu)),
+                             b.ibin(Op_ShiftLeftLogical, r16, b.uconst(16)))
+                    : b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0xFFFF0000u)), r16);
+                predicate_write(b, rs, in.dst.value, old_d);
+                return true;
+            }
             switch (in.opcode) {
                 case 0x00: return true;                              // v_nop — no-op (writes nothing; common
                                                                      // scheduling/hazard filler in real shaders)
@@ -2488,7 +2633,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // v_cvt_f16_f32 packs into the LOW half (high bits zero); v_cvt_f32_f16 unpacks the
                 // low half. VERIFIED(round-trip llvm-mc gfx1030: 0x0a/0x0b).
                 case 0x0A: d = b.pack_half_lo(a); break;              // v_cvt_f16_f32
-                case 0x0B: d = b.unpack_half(a, 0); break;            // v_cvt_f32_f16
+                case 0x0B: {                                        // v_cvt_f32_f16 (SDWA may select high half)
+                    d = b.unpack_half(a, in.sdwa_src0_sel == 5 ? 1 : 0);
+                    if (in.src_abs[0]) d = b.fext1(Glsl_FAbs, d);
+                    if (in.src_neg[0]) d = b.fbin(Op_FSub, b.uconst(0), d);
+                    break;
+                }
                 // v_cvt_off_f32_i4: sign-extend the low 4-bit integer and scale by 1/16.
                 // AMD RDNA2 ISA: "4-bit signed int to 32-bit float"; LLVM's intrinsic
                 // contract specifies result = 0.0625f * src_i4. This is the only opcode
@@ -2570,13 +2720,30 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 a = b.dpp_quad(a, in.dpp_ctrl);
             }
             // SDWA float source modifiers (only ever set on float ops by the assembler): abs then neg.
-            if (in.src_abs[0]) a = b.fext1(Glsl_FAbs, a);
-            if (in.src_neg[0]) a = b.fbin(Op_FSub, b.uconst(0), a);
-            if (in.src_abs[1]) c = b.fext1(Glsl_FAbs, c);
-            if (in.src_neg[1]) c = b.fbin(Op_FSub, b.uconst(0), c);
+            // Packed-f16 ops apply these after selecting/unpacking the half below.
+            const bool packed_f16 = in.opcode == 0x32 || in.opcode == 0x33 || in.opcode == 0x35 ||
+                                    in.opcode == 0x39 || in.opcode == 0x3A;
+            if (!packed_f16) {
+                if (in.src_abs[0]) a = b.fext1(Glsl_FAbs, a);
+                if (in.src_neg[0]) a = b.fbin(Op_FSub, b.uconst(0), a);
+                if (in.src_abs[1]) c = b.fext1(Glsl_FAbs, c);
+                if (in.src_neg[1]) c = b.fbin(Op_FSub, b.uconst(0), c);
+            }
             uint32_t& d = vreg[in.dst.value];
             switch (in.opcode) {
-                case 0x01: d = b.sel(vcc, c, a); break;               // v_cndmask_b32: dst = vcc ? src1 : src0
+                case 0x01: {                                         // v_cndmask_b32: dst = vcc ? src1 : src0
+                    if (in.sdwa_dst_sel == 6) { d = b.sel(vcc, c, a); break; }
+                    auto word = [&](uint32_t raw, uint8_t sel) {
+                        if (sel == 5) raw = b.ibin(Op_ShiftRightLogical, raw, b.uconst(16));
+                        return b.ibin(Op_BitwiseAnd, raw, b.uconst(0xFFFFu));
+                    };
+                    uint32_t selected = b.sel(vcc, word(c, in.sdwa_src1_sel), word(a, in.sdwa_src0_sel));
+                    d = in.sdwa_dst_sel == 5
+                        ? b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0x0000FFFFu)),
+                                 b.ibin(Op_ShiftLeftLogical, selected, b.uconst(16)))
+                        : b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0xFFFF0000u)), selected);
+                    break;
+                }
                 case 0x03: d = b.fbin(Op_FAdd, a, c); break;          // v_add_f32
                 case 0x04: d = b.fbin(Op_FSub, a, c); break;          // v_sub_f32
                 case 0x05: d = b.fbin(Op_FSub, c, a); break;          // v_subrev_f32 (src1 - src0; e32 form of
@@ -2629,19 +2796,48 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x20: case 0x2C: d = b.fbin(Op_FAdd, b.fbin(Op_FMul, a, b.uconst(in.literal)), c); break;  // v_madmk / v_fmamk
                 case 0x21: case 0x2D: d = b.fbin(Op_FAdd, b.fbin(Op_FMul, a, c), b.uconst(in.literal)); break;  // v_madak / v_fmaak
                 case 0x2F: d = b.pack_half2x16_rtz(a, c); break;      // v_cvt_pkrtz_f16_f32 (e32 form): RTZ clamp (#452)
-                case 0x35: {   // v_mul_f16: 16-bit float multiply. Sources read their selected halves
+                case 0x3C: {                                         // v_pk_fmac_f16: packed dst += src0*src1
+                    auto fmac_half = [&](uint32_t half) {
+                        return b.fbin(Op_FAdd,
+                                      b.fbin(Op_FMul, b.unpack_half(a, half), b.unpack_half(c, half)),
+                                      b.unpack_half(old_d, half));
+                    };
+                    uint32_t lo = b.pack_half_lo(fmac_half(0));
+                    uint32_t hi = b.ibin(Op_ShiftLeftLogical, b.pack_half_lo(fmac_half(1)), b.uconst(16));
+                    d = b.ibin(Op_BitwiseOr, lo, hi);
+                    break;
+                }
+                case 0x32: case 0x33: case 0x35: case 0x39: case 0x3A: { // v_add/sub/mul/max/min_f16
                     // (SDWA WORD_1 = high 16; DWORD/WORD_0 = low 16 — an f16 op reads bits[15:0]);
                     // f16xf16 products are exact in f32, so multiply in f32 and round once to f16.
                     // The 16-bit result inserts into the selected dest half PRESERVING the other
                     // (dst_sel WORD_1 for the SDWA pack idiom; DWORD/WORD_0 = the plain e32 form's
                     // "write [15:0], preserve [31:16]" gfx10 f16-VOP2 contract). #273 (DOLL box-blur).
-                    auto half_of = [&](uint32_t x, uint8_t s) {
-                        return s == 5 ? b.ibin(Op_ShiftRightLogical, x, b.uconst(16)) : x;
+                    auto source = [&](uint32_t raw, const Operand& operand, uint8_t sel, int k) {
+                        // Inline float constants already carry the numeric f32 value. Register/scalar
+                        // operands carry packed halves and must be selected before abs/neg.
+                        uint32_t v = operand.kind == OperandKind::InlineFloat ? raw
+                                   : operand.kind == OperandKind::InlineInt
+                                       ? b.uconst(fbits(static_cast<float>(operand.value)))
+                                       : b.unpack_half(raw, sel == 5 ? 1 : 0);
+                        if (in.src_abs[k]) v = b.fext1(Glsl_FAbs, v);
+                        if (in.src_neg[k]) v = b.fbin(Op_FSub, b.uconst(0), v);
+                        return v;
                     };
-                    uint32_t p = b.fbin(Op_FMul, b.unpack_half(half_of(a, in.sdwa_src0_sel), 0),
-                                                 b.unpack_half(half_of(c, in.sdwa_src1_sel), 0));
+                    uint32_t x = source(a, in.src[0], in.sdwa_src0_sel, 0);
+                    uint32_t y = source(c, in.src[1], in.sdwa_src1_sel, 1);
+                    uint32_t p = in.opcode == 0x32 ? b.fbin(Op_FAdd, x, y)
+                               : in.opcode == 0x33 ? b.fbin(Op_FSub, x, y)
+                               : in.opcode == 0x35 ? b.fbin(Op_FMul, x, y)
+                               : in.opcode == 0x39 ? b.fext2(Glsl_FMax, x, y)
+                                                   : b.fext2(Glsl_FMin, x, y);
+                    if (in.clamp)
+                        p = b.fext2(Glsl_FMax,
+                                    b.fext2(Glsl_FMin, p, b.uconst(fbits(1.0f))),
+                                    b.uconst(fbits(0.0f)));
                     uint32_t r16 = b.pack_half_lo(p);
-                    d = (in.sdwa_dst_sel == 5)
+                    d = in.sdwa_dst_sel == 6 ? r16
+                      : (in.sdwa_dst_sel == 5)
                         ? b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0x0000FFFFu)),
                                  b.ibin(Op_ShiftLeftLogical, r16, b.uconst(16)))
                         : b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0xFFFF0000u)), r16);
@@ -2651,7 +2847,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             // SDWA output modifier: OMOD scale (×2/×4/×0.5) then CLAMP saturate, on FLOAT-result opcodes
             // only (int ops never carry omod). Mirrors the VOP3 fresult path; a no-op when omod/clamp unset.
-            if (ok && (in.omod || in.clamp)) switch (in.opcode) {
+            if (ok && (in.omod || in.clamp) && !packed_f16) switch (in.opcode) {
                 case 0x03: case 0x04: case 0x05: case 0x08: case 0x0F: case 0x10:
                 case 0x1F: case 0x2B: case 0x20: case 0x2C: case 0x21: case 0x2D:
                     if      (in.omod == 1) d = b.fbin(Op_FMul, d, b.uconst(fbits(2.0f)));
@@ -2844,7 +3040,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (in.clamp) bits = b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, bits, b.uconst(fbits(1.0f))), b.uconst(fbits(0.0f)));
                 return bits;
             };
-            if (in.opcode == 0x14B || in.opcode == 0x141) {           // v_fma_f32 / v_mad_f32 = src0*src1 + src2
+            if (in.opcode == 0x34B) {                                // v_fma_f16: one selected packed half
+                auto f16src = [&](int k) {
+                    const Operand& operand = in.src[k];
+                    uint32_t raw = val(operand);
+                    uint32_t value = operand.kind == OperandKind::InlineFloat ? raw
+                                   : operand.kind == OperandKind::InlineInt
+                                       ? b.uconst(fbits(static_cast<float>(operand.value)))
+                                       : b.unpack_half(raw, (in.vop3p_opsel >> k) & 1u);
+                    if (in.src_abs[k]) value = b.fext1(Glsl_FAbs, value);
+                    if (in.src_neg[k]) value = b.fbin(Op_FSub, b.uconst(0), value);
+                    return value;
+                };
+                uint32_t result = fresult(
+                    b.fbin(Op_FAdd, b.fbin(Op_FMul, f16src(0), f16src(1)), f16src(2)));
+                uint32_t r16 = b.pack_half_lo(result);
+                vreg[in.dst.value] = (in.vop3p_opsel & 8u)
+                    ? b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0x0000FFFFu)),
+                             b.ibin(Op_ShiftLeftLogical, r16, b.uconst(16)))
+                    : b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0xFFFF0000u)), r16);
+            } else if (in.opcode == 0x14B || in.opcode == 0x141) {    // v_fma_f32 / v_mad_f32 = src0*src1 + src2
                 // v_mad_f32 (op 0x141) is a gfx10.1 (Navi) instruction REMOVED in gfx10.3, so llvm-mc
                 // -mcpu=gfx1030 rejects it as invalid — but the PS5 shader compiler targets gfx10.1 and
                 // emits it (real game shaders 5,26-29: manual attribute interpolation p0+i*p1). Its result
@@ -3771,15 +3986,68 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 predicate_write(b, rs, in.dst.value, old);
                 return true;
             }
-            // LDS (workgroup shared memory), compute-only. ds_write_b32 (0x0d) / ds_read_b32 (0x36);
-            // GDS and wider widths deferred. Byte address = ADDR VGPR + inst offset; dword index = >>2.
-            if (!b.is_compute || (in.opcode != 0x0d && in.opcode != 0x36)) { ok = false; return true; }
+            // LDS (workgroup shared memory), compute-only. Byte address = ADDR VGPR + instruction
+            // offset; the backing store is dword-indexed. gfx10 ds_write2_b64 carries two independent
+            // 8-bit offsets in units of 64-bit elements, while ds_write_b64 uses the ordinary 16-bit
+            // byte offset. GDS and the remaining widths/atomics are deferred.
+            if (!b.is_compute || (in.opcode != 0x07 && in.opcode != 0x08 && in.opcode != 0x20 &&
+                                  in.opcode != 0x0d && in.opcode != 0x36 &&
+                                  in.opcode != 0x4d && in.opcode != 0x4e &&
+                                  in.opcode != 0x76 && in.opcode != 0x77)) {
+                ok = false; return true;
+            }
             b.declare_lds();
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+            if (in.opcode == 0x4e) {                    // ds_write2_b64: two VGPR pairs at offset0/offset1
+                const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
+                const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst((in.literal & 0xFFu) * 2u));
+                const uint32_t idx1 = b.ibin(Op_IAdd, base, b.uconst(((in.literal >> 8) & 0xFFu) * 2u));
+                b.lds_store(idx0, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
+                b.lds_store(b.ibin(Op_IAdd, idx0, b.uconst(1)), vread(in.src[1].value + 1),
+                            rs.exec_narrowed, rs.exec);
+                b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
+                b.lds_store(b.ibin(Op_IAdd, idx1, b.uconst(1)), vread(in.src[2].value + 1),
+                            rs.exec_narrowed, rs.exec);
+                return true;
+            }
+            if (in.opcode == 0x77) {                    // ds_read2_b64: two pairs at scaled offsets
+                const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
+                const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst((in.literal & 0xFFu) * 2u));
+                const uint32_t idx1 = b.ibin(Op_IAdd, base, b.uconst(((in.literal >> 8) & 0xFFu) * 2u));
+                const uint32_t indices[4] = {
+                    idx0, b.ibin(Op_IAdd, idx0, b.uconst(1)),
+                    idx1, b.ibin(Op_IAdd, idx1, b.uconst(1)),
+                };
+                for (int k = 0; k < 4; ++k) {
+                    const uint32_t old = vreg_old(b, rs, in.dst.value + k);
+                    rs.vreg[in.dst.value + k] = b.lds_load(indices[k]);
+                    predicate_write(b, rs, in.dst.value + k, old);
+                }
+                return true;
+            }
             uint32_t addr = b.ibin(Op_IAdd, vread(in.src[0].value), b.uconst(in.literal));
             uint32_t idx  = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
-            if (in.opcode == 0x0d) {                    // ds_write_b32: LDS[idx] = DATA0
+            if (in.opcode == 0x07 || in.opcode == 0x08) { // ds_min_u32 / ds_max_u32
+                b.lds_atomic(in.opcode == 0x07 ? Op_AtomicUMin : Op_AtomicUMax,
+                             idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
+            } else if (in.opcode == 0x20) {             // ds_add_rtn_u32: VDST = old LDS; LDS += DATA0
+                const uint32_t old = vreg_old(b, rs, in.dst.value);
+                rs.vreg[in.dst.value] = b.lds_atomic_rtn(
+                    Op_AtomicIAdd, idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec, old);
+                predicate_write(b, rs, in.dst.value, old);
+            } else if (in.opcode == 0x0d) {             // ds_write_b32: LDS[idx] = DATA0
                 b.lds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
+            } else if (in.opcode == 0x4d) {             // ds_write_b64: LDS[idx:idx+1] = DATA0 pair
+                b.lds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
+                b.lds_store(b.ibin(Op_IAdd, idx, b.uconst(1)), vread(in.src[1].value + 1),
+                            rs.exec_narrowed, rs.exec);
+            } else if (in.opcode == 0x76) {             // ds_read_b64: VDST pair = LDS[idx:idx+1]
+                for (int k = 0; k < 2; ++k) {
+                    const uint32_t old = vreg_old(b, rs, in.dst.value + k);
+                    const uint32_t at = k ? b.ibin(Op_IAdd, idx, b.uconst(1)) : idx;
+                    rs.vreg[in.dst.value + k] = b.lds_load(at);
+                    predicate_write(b, rs, in.dst.value + k, old);
+                }
             } else {                                    // ds_read_b32: VDST = LDS[idx]
                 uint32_t old = vreg_old(b, rs, in.dst.value);
                 rs.vreg[in.dst.value] = b.lds_load(idx);
@@ -3940,8 +4208,9 @@ size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords) {
 // narrow pattern structurizer below. Lower them as a structured dispatcher loop: one switch case per
 // basic block, with the emulated register file persisted in Function variables between iterations.
 // VCCZ/EXECZ test subgroup-wide Any, matching the hardware branch's wave-mask reduction instead of
-// treating one invocation's bit as the whole mask. The fallback is gated by emit_body to complex,
-// barrier/LDS-free compute CFGs; simple or unsafe shaders retain the existing conservative path.
+// treating one invocation's bit as the whole mask. The fallback is gated by emit_body to complex
+// compute CFGs without workgroup barriers or synthesized cross-lane operations; ordinary LDS reads,
+// writes, and atomics remain valid when different waves visit them independently.
 bool emit_compute_cfg_state_machine(
     SpirvCompute& b, RegState& initial, const std::vector<Rdna2Inst>& ins,
     const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
@@ -4393,19 +4662,20 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         bool cf_rejected = false;
         const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe,
                                                              Ls.empty() ? nullptr : &Ls, &cf_rejected,
-                                                             /*uniform_vcc_compute*/b.is_compute);
+                                                             /*compute_wave_branches*/b.is_compute);
 
         // UE4's volume-lighting kernels combine nested EXEC loops with a backward VCC vote loop.
         // That shape is intentionally outside the narrow pattern structurizer above. Use the
         // dispatcher fallback only when there is unmistakably complex compute control flow and the
         // body is free of operations whose workgroup-uniform placement the dispatcher cannot prove.
+        // Raw DS operations are wave-local memory effects and are valid in a case; only barriers and
+        // cross-lane operations which synthesize barriers require workgroup-uniform placement.
         // Existing straight-line, single-if, and recognized single-loop shaders keep their old path.
         size_t cfg_branches = 0;
         bool cfg_has_backedge = false, cfg_dispatch_safe = b.is_compute;
         for (const auto& in : ins) {
             if (in.is_end) break;
-            if (in.fmt == Rdna2Format::DS ||
-                (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
+            if ((in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
                 (in.fmt == Rdna2Format::VOP3 &&
                  (in.opcode == 0x365 || in.opcode == 0x366)))
                 cfg_dispatch_safe = false;
@@ -4429,6 +4699,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             (void)safe_branches;
             return true;
         }
+        if (b.is_compute && std::any_of(Fs.begin(), Fs.end(),
+                                        [](const ForwardIf& branch) { return branch.on_exec; })) {
+            SpirvCompute::put(b.caps, Op_Capability, {Cap_GroupNonUniform});
+            SpirvCompute::put(b.caps, Op_Capability, {Cap_GroupNonUniformVote});
+        }
         // Structured uniform IFs (forward s_cbranch_scc*/vcc*), possibly SEQUENTIAL and/or NESTED
         // (detect_forward_ifs verified the region tree). Each if emits as OpSelectionMerge +
         // OpBranchConditional on the SCC/VCC bool, with an OpPhi per register written in the
@@ -4444,8 +4719,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // `cont` = the pc control flows to after `hi` — the enclosing construct's merge chain. An
         // if/else whose merge ESCAPES the current region (the shared-outer-merge cascade) is legal
         // only when it targets exactly this continuation (no skipped instructions); anything else
-        // rejects, fail-visible. Divergent execz-ifs (#273) condition on THIS lane's EXEC bool and
-        // may enter/leave with EXEC narrowed — EXEC is phi'd across the merge like any other value.
+        // rejects, fail-visible. Fragment execz-ifs (#273) condition on THIS lane's EXEC bool;
+        // compute execz-ifs condition on subgroupAny(EXEC). Either may enter/leave with EXEC narrowed,
+        // and EXEC is phi'd across the merge like any other value.
         // CONFIDENCE: MED — per-invocation lowering of wave-level branches; spirv-val + exec-diff
         // kernels + the live-boot A/B gate it.
         std::function<bool(uint32_t, uint32_t, uint32_t)> emit_structured;
@@ -4552,8 +4828,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 const ForwardIf F = Fs[bi++];
                 if (idx < ins.size() && ins[idx].pc == F.branch_pc) ++idx;   // skip the branch itself
                 // scc0/vccz/execz: branch (skip block) taken when the flag==0 → the block runs when
-                // flag!=0; scc1/vccnz are the inverse. Condition = SCC/VCC/EXEC per-invocation bool.
-                uint32_t cond_reg  = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
+                // flag!=0; scc1/vccnz are the inverse. Compute execz first reduces the per-invocation
+                // EXEC bool to the architecture's wave-wide "any lane active" predicate.
+                uint32_t cond_reg = F.on_exec
+                    ? (b.is_compute ? b.subgroup_any(rs.exec) : rs.exec)
+                    : (F.on_vcc ? rs.vcc : rs.scc);
                 uint32_t exec_cond = F.on_scc0 ? cond_reg : b.bsel(cond_reg, b.bfalse(), b.btrue());
                 const uint32_t preblock = b.cur_block;      // block holding the OpBranchConditional
                 if (!F.has_else) {
@@ -4759,7 +5038,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     const CountedLoop cL = detect_counted_loop(ins);
     const std::vector<ForwardIf> cFs = detect_forward_ifs(ins, /*allow_vcc*/false, code, dwords,
                                                           nullptr, nullptr, nullptr,
-                                                          /*uniform_vcc_compute*/true);   // matches the compute shell (#590)
+                                                          /*compute_wave_branches*/true);   // matches the compute shell (#590)
     auto cf_reconstructed = [&](const Rdna2Inst& i) {
         if (cL.found && (i.pc == cL.backedge_pc || i.pc == cL.exit_branch_pc)) return true;
         for (const auto& F : cFs) if (i.pc == F.branch_pc) return true;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -386,6 +386,31 @@ int main() {
     CHECK(act17b>0 && act17b<N, "kernel 17b exercises both complemented-mask outcomes");
     CHECK(got17b.size()==N && bad17b==0, "s_not_b64 complements VCC before EXEC predication");
 
+    // Kernel 17c: compute s_cbranch_execz tests whether the whole wave's EXEC mask is empty.
+    // The guarded scalar write is live after the merge, so the safe-linearization shortcut cannot
+    // consume this branch. Wave 0 has no surviving lanes and keeps s0=0; wave 1 is active and writes
+    // s0=5. The following EXEC restore lets every lane report its wave's scalar result.
+    const uint32_t code17c[] = {
+        0x7e000f00u, 0x7e020f01u, 0x7d880300u, 0xbeea086au, 0xbefe046au,
+        0xbf880001u, 0xbe800385u, 0xbefe04c1u, 0x7e040c00u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv17c = recompile_valu(
+        code17c, sizeof(code17c)/sizeof(code17c[0]), 2, /*out_vgpr*/2);
+    CHECK(!spv17c.empty(), "recompiled kernel 17c (compute wave-wide execz if) -> SPIR-V");
+    std::vector<float> in17c(N * 2), exp17c(N);
+    for (uint32_t i = 0; i < N; i++) {
+        const bool empty_after_not = i < 64;
+        in17c[i*2+0] = empty_after_not ? 2.0f : 1.0f;
+        in17c[i*2+1] = empty_after_not ? 1.0f : 2.0f;
+        exp17c[i] = empty_after_not ? 0.0f : 5.0f;
+    }
+    std::vector<float> got17c = prosper::test::run_compute(spv17c, in17c, N, N);
+    uint32_t bad17c = 0;
+    for (uint32_t i=0;i<N&&got17c.size()==N;i++)
+        if (std::fabs(got17c[i]-exp17c[i])>1e-3f) bad17c++;
+    CHECK(got17c.size()==N && bad17c==0,
+          "compute execz uses subgroupAny(EXEC): empty wave skips, active wave enters");
+
     // Kernel 18: the REAL if-then idiom with a forward branch. v3=7; vcc=(u0>u1);
     // s_and_saveexec_b64 s[0:1],vcc (save exec, exec=vcc); s_cbranch_execz skip (forward -> no-op);
     // v_add v3=u0+u1 (predicated); skip: s_mov_b64 exec,s[0:1] (restore); cvt+store. Same result as
@@ -831,6 +856,248 @@ int main() {
            bad32, got32.size()==WG?got32[0]:-1, got32.size()==WG?got32[63]:-1);
     CHECK(got32.size()==WG && bad32==0, "recompiled kernel 32 (LDS write->barrier->cross-lane read) correct");
 
+    // Kernel 32b: gfx10 wide LDS operations used by UE4's volume-lighting compute producer. write2_b64
+    // writes v[1:2] at byte 0 and v[3:4] at byte 8; write_b64 repeats the first pair. read_b64 recovers
+    // the first pair and read2_b64 recovers both; selecting the non-duplicate halves gives 1+2+3+4=10.
+    const uint32_t code32b[] = {
+        0x7e000280u, 0x7e0202f2u, 0x7e0402f4u, 0x7e0602ffu, 0x40400000u, 0x7e0802f6u,
+        0xd9380100u, 0x00030100u, 0xd9340000u, 0x00000100u, 0xbf8a0000u,
+        0xd9d80000u, 0x05000000u, 0xd9dc0100u, 0x07000000u,
+        0x060a0d05u, 0x060a1305u, 0x060a1505u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b = recompile_valu(code32b, sizeof(code32b)/sizeof(code32b[0]), 0, 5);
+    CHECK(!spv32b.empty(), "recompiled kernel 32b (ds_write_b64 + ds_write2_b64) -> SPIR-V");
+    std::vector<float> got32b = prosper::test::run_compute(spv32b, std::vector<float>(1), 1, 1);
+    CHECK(got32b.size()==1 && std::fabs(got32b[0]-10.0f)<1e-3f,
+          "kernel 32b wide LDS stores and loads preserve both dwords of both VGPR pairs");
+
+    // Kernel 32c: the same UE4 producer uses non-returning unsigned LDS min/max atomics. Start at
+    // 10, min with 3, then max with 7; a read and uint->float conversion must report 7.
+    const uint32_t code32c[] = {
+        0x7e000280u, 0x7e02028au, 0x7e040283u, 0x7e060287u,
+        0xd8340000u, 0x00000100u, 0xbf8a0000u,
+        0xd81c0000u, 0x00000200u, 0xd8200000u, 0x00000300u, 0xbf8a0000u,
+        0xd8d80000u, 0x04000000u, 0x7e080d04u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32c = recompile_valu(code32c, sizeof(code32c)/sizeof(code32c[0]), 0, 4);
+    CHECK(!spv32c.empty(), "recompiled kernel 32c (ds_min_u32 + ds_max_u32) -> SPIR-V");
+    std::vector<float> got32c = prosper::test::run_compute(spv32c, std::vector<float>(1), 1, 1);
+    CHECK(got32c.size()==1 && std::fabs(got32c[0]-7.0f)<1e-3f,
+          "kernel 32c LDS min/max atomics update shared memory exactly");
+
+    // Kernel 32c2: ds_add_rtn_u32 returns the old value (10) while atomically updating LDS to 13.
+    // Convert and add both observations so the single output must be 23.
+    const uint32_t code32c2[] = {
+        0x7e02028au, 0x7e040283u,
+        0xd8340000u, 0x00000100u, 0xbf8a0000u,
+        0xd8800000u, 0x03000200u, 0xbf8a0000u,
+        0xd8d80000u, 0x04000000u, 0x7e060d03u, 0x7e080d04u,
+        0x060a0903u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32c2 = recompile_valu(code32c2, sizeof(code32c2)/sizeof(code32c2[0]), 1, 5);
+    CHECK(!spv32c2.empty(), "recompiled kernel 32c2 (ds_add_rtn_u32) -> SPIR-V");
+    std::vector<float> in32c2(WG);
+    for (uint32_t i = 0; i < WG; ++i) { const uint32_t addr = 4u*i; std::memcpy(&in32c2[i], &addr, 4); }
+    std::vector<float> got32c2 = prosper::test::run_compute(spv32c2, in32c2, WG, WG);
+    uint32_t bad32c2 = 0;
+    for (uint32_t i = 0; i < WG && got32c2.size()==WG; ++i)
+        if (std::fabs(got32c2[i]-23.0f) >= 1e-3f) ++bad32c2;
+    printf("  kernel32c2 mismatches=%u out[0]=%g expect=23\n",
+           bad32c2, got32c2.size()==WG ? got32c2[0] : -1.0f);
+    CHECK(got32c2.size()==WG && bad32c2==0,
+          "kernel 32c2 returns old LDS and atomically stores the sum");
+
+    // Kernel 32d: SDWA f16->f32 conversion selects WORD_1 before applying source negate. The packed
+    // high half is -2, so `-WORD_1` converts to +2 (not a negation of the packed 32-bit payload).
+    const uint32_t code32d[] = {
+        0x7e0002ffu, 0xc0003c00u, 0x7e0216f9u, 0x00150600u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32d = recompile_valu(code32d, sizeof(code32d)/sizeof(code32d[0]), 0, 1);
+    CHECK(!spv32d.empty(), "recompiled kernel 32d (v_cvt_f32_f16_sdwa WORD_1 negate) -> SPIR-V");
+    std::vector<float> got32d = prosper::test::run_compute(spv32d, std::vector<float>(1), 1, 1);
+    CHECK(got32d.size()==1 && std::fabs(got32d[0]-2.0f)<1e-3f,
+          "kernel 32d selects the high f16 half before applying float modifiers");
+
+    // Kernel 32e: packed f16 add/mul operate independently on both halves. Inputs are (1,2) and
+    // (3,4); XORing add=(4,6) with mul=(3,8) makes both packed results observable as 0x0e000600.
+    const uint32_t code32e[] = {
+        0x7e0002ffu, 0x40003c00u, 0x7e0202ffu, 0x44004200u,
+        0xcc0f4002u, 0x18020300u, 0xcc104003u, 0x18020300u,
+        0x3a080702u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32e = recompile_valu(code32e, sizeof(code32e)/sizeof(code32e[0]), 0, 4);
+    CHECK(!spv32e.empty(), "recompiled kernel 32e (v_pk_add_f16 + v_pk_mul_f16) -> SPIR-V");
+    std::vector<float> got32e = prosper::test::run_compute(spv32e, std::vector<float>(1), 1, 1);
+    CHECK(got32e.size()==1 && bits_of(got32e[0])==0x0e000600u,
+          "kernel 32e packed f16 add/mul compute both halves exactly");
+
+    // Kernel 32f: the live UE4 modifier word selects src1's high half for both results and negates
+    // it in both low/high operations: (1* -4, 2* -4) -> packed (-4,-8).
+    const uint32_t code32f[] = {
+        0x7e0002ffu, 0x40003c00u, 0x7e0c02ffu, 0x44004200u,
+        0xcc105202u, 0x58020d00u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32f = recompile_valu(code32f, sizeof(code32f)/sizeof(code32f[0]), 0, 2);
+    CHECK(!spv32f.empty(), "recompiled kernel 32f (live v_pk_mul_f16 modifiers) -> SPIR-V");
+    std::vector<float> got32f = prosper::test::run_compute(spv32f, std::vector<float>(1), 1, 1);
+    CHECK(got32f.size()==1 && bits_of(got32f[0])==0xc800c400u,
+          "kernel 32f honors packed low/high selects and negates");
+
+    // Kernel 32g: exact live DCC-producer SDWA forms select src1 WORD_1 while src0 uses the low
+    // half, write WORD_0, and preserve WORD_1. max((1,3)) -> (3,3), min((4,2)) -> (2,2).
+    const uint32_t code32g[] = {
+        0x7e0002ffu, 0x42003c00u, 0x7e0202ffu, 0x40004400u,
+        0x720000f9u, 0x05061400u, 0x740202f9u, 0x05061401u,
+        0x3a040300u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32g = recompile_valu(code32g, sizeof(code32g)/sizeof(code32g[0]), 0, 2);
+    CHECK(!spv32g.empty(), "recompiled kernel 32g (live v_max/min_f16_sdwa forms) -> SPIR-V");
+    std::vector<float> got32g = prosper::test::run_compute(spv32g, std::vector<float>(1), 1, 1);
+    CHECK(got32g.size()==1 && bits_of(got32g[0])==0x02000200u,
+          "kernel 32g selects f16 halves and preserves destinations exactly");
+
+    // Kernel 32h: the live producer's paired v_add_f16_sdwa writes assemble a packed result in v7.
+    // The first writes low=(1+3)=4; the second preserves it while writing high=(2+4)=6.
+    const uint32_t code32h[] = {
+        0x7e0002ffu, 0x42003c00u, 0x7e0202ffu, 0x40004400u,
+        0x640e00f9u, 0x05061400u, 0x640e02f9u, 0x06051501u,
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv32h = recompile_valu(code32h, sizeof(code32h)/sizeof(code32h[0]), 0, 7);
+    CHECK(!spv32h.empty(), "recompiled kernel 32h (live paired v_add_f16_sdwa forms) -> SPIR-V");
+    std::vector<float> got32h = prosper::test::run_compute(spv32h, std::vector<float>(1), 1, 1);
+    CHECK(got32h.size()==1 && bits_of(got32h[0])==0x46004400u,
+          "kernel 32h writes and preserves both packed f16 destination halves");
+
+    // Kernel 32i: the live paired v_sub_f16_sdwa forms likewise assemble both halves in v0.
+    // low=(1-4)=-3 and high=(5-6)=-1, with each instruction preserving the opposite half.
+    const uint32_t code32i[] = {
+        0x7e0002ffu, 0x44004000u, 0x7e0202ffu, 0x46004200u,
+        0x7e1602ffu, 0x45003c00u, 0x660000f9u, 0x0506140bu,
+        0x660002f9u, 0x0505150bu, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32i = recompile_valu(code32i, sizeof(code32i)/sizeof(code32i[0]), 0, 0);
+    CHECK(!spv32i.empty(), "recompiled kernel 32i (live paired v_sub_f16_sdwa forms) -> SPIR-V");
+    std::vector<float> got32i = prosper::test::run_compute(spv32i, std::vector<float>(1), 1, 1);
+    CHECK(got32i.size()==1 && bits_of(got32i[0])==0xbc00c200u,
+          "kernel 32i subtracts selected halves and preserves both destination halves");
+
+    // Kernel 32j: v_pk_fmac_f16 accumulates both half lanes independently. Starting from (5,6),
+    // (1,2)*(3,4)+(5,6) produces packed (8,14).
+    const uint32_t code32j[] = {
+        0x7e0002ffu, 0x40003c00u, 0x7e0202ffu, 0x44004200u,
+        0x7e0402ffu, 0x46004500u, 0x78040300u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32j = recompile_valu(code32j, sizeof(code32j)/sizeof(code32j[0]), 0, 2);
+    CHECK(!spv32j.empty(), "recompiled kernel 32j (v_pk_fmac_f16) -> SPIR-V");
+    std::vector<float> got32j = prosper::test::run_compute(spv32j, std::vector<float>(1), 1, 1);
+    CHECK(got32j.size()==1 && bits_of(got32j[0])==0x4b004800u,
+          "kernel 32j accumulates both packed f16 lanes exactly");
+
+    // Kernel 32k: exact live v_sqrt_f16_sdwa pair writes sqrt(4)=2 to a high half and sqrt(9)=3
+    // to a low half, preserving the opposite destination halves in both cases.
+    const uint32_t code32k[] = {
+        0x7e1c02ffu, 0x45003c00u, 0x7e2c02ffu, 0x47004600u,
+        0x7e2a02ffu, 0x48804400u, 0x7e1caaf9u, 0x00061515u,
+        0x7e2caaf9u, 0x00051415u, 0x3a042d0eu, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32k = recompile_valu(code32k, sizeof(code32k)/sizeof(code32k[0]), 0, 2);
+    CHECK(!spv32k.empty(), "recompiled kernel 32k (live paired v_sqrt_f16_sdwa forms) -> SPIR-V");
+    std::vector<float> got32k = prosper::test::run_compute(spv32k, std::vector<float>(1), 1, 1);
+    CHECK(got32k.size()==1 && bits_of(got32k[0])==0x07007e00u,
+          "kernel 32k selects, roots, writes, and preserves packed f16 halves");
+
+    // Kernel 32l: exact live v_cvt_f16_f32_sdwa forms write WORD_1 and preserve WORD_0. The first
+    // aliases source/destination, while the second preserves an unrelated packed low word.
+    const uint32_t code32l[] = {
+        0x7e0202ffu, 0x40800000u, 0x7e0802ffu, 0x40000000u,
+        0x7e0a02ffu, 0x12345678u, 0x7e0214f9u, 0x00061501u,
+        0x7e0a14f9u, 0x00061504u, 0x3a040b01u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32l = recompile_valu(code32l, sizeof(code32l)/sizeof(code32l[0]), 0, 2);
+    CHECK(!spv32l.empty(), "recompiled kernel 32l (live v_cvt_f16_f32_sdwa WORD_1 forms) -> SPIR-V");
+    std::vector<float> got32l = prosper::test::run_compute(spv32l, std::vector<float>(1), 1, 1);
+    CHECK(got32l.size()==1 && bits_of(got32l[0])==0x04005678u,
+          "kernel 32l converts into high f16 halves while preserving low halves");
+
+    // Kernel 32m: exact live f16 SDWA controls apply abs after selecting src1 WORD_1, and treat an
+    // inline f32 constant as a numeric value before packing the product back into WORD_1.
+    const uint32_t code32m[] = {
+        0x7e0402ffu, 0xc4001234u, 0x7e0802ffu, 0x40005678u,
+        0x640404f9u, 0x25861480u, 0x6a0808f9u, 0x058615f8u,
+        0x3a0c0902u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32m = recompile_valu(code32m, sizeof(code32m)/sizeof(code32m[0]), 0, 6);
+    CHECK(!spv32m.empty(), "recompiled kernel 32m (live f16 SDWA abs + inline float) -> SPIR-V");
+    std::vector<float> got32m = prosper::test::run_compute(spv32m, std::vector<float>(1), 1, 1);
+    CHECK(got32m.size()==1 && bits_of(got32m[0])==0xf1181278u,
+          "kernel 32m applies packed f16 modifiers and inline constants exactly");
+
+    // Kernel 32n: exact live cos/rcp f16 SDWA controls write WORD_1 and preserve WORD_0. cos(0
+    // revolutions)=1 and rcp(2)=0.5; XOR makes both packed results observable.
+    const uint32_t code32n[] = {
+        0x7e0802ffu, 0x00001234u, 0x7e08c2f9u, 0x00051504u,
+        0x7e0c0304u, 0x7e0802ffu, 0x40005678u, 0x7e08a8f9u,
+        0x00051504u, 0x3a040906u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32n = recompile_valu(code32n, sizeof(code32n)/sizeof(code32n[0]), 0, 2);
+    CHECK(!spv32n.empty(), "recompiled kernel 32n (live v_cos/rcp_f16_sdwa forms) -> SPIR-V");
+    std::vector<float> got32n = prosper::test::run_compute(spv32n, std::vector<float>(1), 1, 1);
+    CHECK(got32n.size()==1 && bits_of(got32n[0])==0x0400444cu,
+          "kernel 32n evaluates packed f16 cosine/reciprocal and preserves low halves");
+
+    // Kernel 32o: exact live v_fma_f16 VOP3 forms select a source high half and independently write
+    // the low/high destination halves. Literals are f16 bit patterns; inline -2 remains numeric.
+    const uint32_t code32o[] = {
+        0x7e0602ffu, 0x12345678u, 0x7e0802ffu, 0x40005678u,
+        0xd74b1003u, 0x23fe08ffu, 0x00004648u,
+        0xd74b5004u, 0x03fe08f5u, 0x00004200u,
+        0x3a040903u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32o = recompile_valu(code32o, sizeof(code32o)/sizeof(code32o[0]), 0, 2);
+    CHECK(!spv32o.empty(), "recompiled kernel 32o (live v_fma_f16 VOP3 forms) -> SPIR-V");
+    std::vector<float> got32o = prosper::test::run_compute(spv32o, std::vector<float>(1), 1, 1);
+    CHECK(got32o.size()==1 && bits_of(got32o[0])==0xae349030u,
+          "kernel 32o selects f16 sources and preserves the opposite destination halves");
+
+    // Kernel 32o2: the same low-half fma with OMOD x2 must scale before f16 packing. The unscaled
+    // result is -6.28125 (0xc648); x2 becomes -12.5625 (0xca48), preserving the high destination.
+    const uint32_t code32o2[] = {
+        0x7e0602ffu, 0x12345678u, 0x7e0802ffu, 0x40005678u,
+        0xd74b1003u, 0x2bfe08ffu, 0x00004648u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32o2 = recompile_valu(code32o2, sizeof(code32o2)/sizeof(code32o2[0]), 0, 3);
+    CHECK(!spv32o2.empty(), "recompiled kernel 32o2 (v_fma_f16 OMOD) -> SPIR-V");
+    std::vector<float> got32o2 = prosper::test::run_compute(spv32o2, std::vector<float>(1), 1, 1);
+    CHECK(got32o2.size()==1 && bits_of(got32o2[0])==0x1234ca48u,
+          "kernel 32o2 applies VOP3 output scaling before f16 packing");
+
+    // Kernel 32p: exact live v_cndmask_b32_sdwa selects src1 WORD_0 through VCC, writes WORD_1,
+    // and preserves the destination's low half.
+    const uint32_t code32p[] = {
+        0x7e0002ffu, 0x3f800000u, 0x7e0202ffu, 0x3f800000u,
+        0x7e0602ffu, 0x9999abcdu, 0x7e1c02ffu, 0x12345678u,
+        0x7c040300u, 0x021c06f9u, 0x04861580u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32p = recompile_valu(code32p, sizeof(code32p)/sizeof(code32p[0]), 0, 14);
+    CHECK(!spv32p.empty(), "recompiled kernel 32p (live v_cndmask_b32_sdwa WORD form) -> SPIR-V");
+    std::vector<float> got32p = prosper::test::run_compute(spv32p, std::vector<float>(1), 1, 1);
+    CHECK(got32p.size()==1 && bits_of(got32p[0])==0xabcd5678u,
+          "kernel 32p selects and inserts a word while preserving the opposite half");
+
+    // Kernel 32q: exact live CLAMP forms saturate before f16 packing. The first preserves WORD_0;
+    // the final form reads the tracked vcc_lo scalar scratch and writes a zero-padded DWORD.
+    const uint32_t code32q[] = {
+        0x7e0802ffu, 0x40004000u, 0x6a0808f9u, 0x06053504u,
+        0x7e0a0304u, 0xb06a385au, 0x6a0808f9u, 0x0686266au,
+        0x3a040905u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32q = recompile_valu(code32q, sizeof(code32q)/sizeof(code32q[0]), 0, 2);
+    CHECK(!spv32q.empty(), "recompiled kernel 32q (live clamped/padded f16 SDWA forms) -> SPIR-V");
+    std::vector<float> got32q = prosper::test::run_compute(spv32q, std::vector<float>(1), 1, 1);
+    CHECK(got32q.size()==1 && bits_of(got32q[0])==0x3c007c00u,
+          "kernel 32q clamps packed f16 results and zero-pads DWORD destinations");
+
     // Kernel 33: PACKED-format store. buffer_store_format_xyzw of (0,0.25,0.5,1.0) as UNORM8x4 packs to
     // bytes (0,64,128,255) = dword 0xFF804000 (inverse of the unorm8 unpack). Verifies pack_norm + the
     // tight-component packing into one dword.
@@ -1073,17 +1340,28 @@ int main() {
     CHECK(act47>0 && msk47>0, "kernel 47 exercises both active and masked lanes");
     CHECK(got47.size()==N && bad47==0, "recompiled kernel 47 (dead scalar write in divergent block) correct");
 
-    // Kernel 47b (NEGATIVE): same shape but the block's s5 is READ after the merge without being
-    // redefined -> s5 is LIVE at the merge, so linearizing the unconditional scalar write would corrupt
-    // masked lanes. The dead-at-merge analysis must NOT prove it dead, so the execz block is not
-    // linearizable and recompilation must FAIL (return empty) rather than silently miscompile. Guards the
-    // soundness of the relaxation (it accepts only provably-dead scalar writes).
+    // Kernel 47b: same shape but the block's s5 is LIVE at the merge. The linearization shortcut must
+    // not consume it; structured compute execz instead branches on subgroupAny(EXEC), making the scalar
+    // write wave-uniform. Wave 0 enters and produces 102; wave 1 is empty and preserves s5=0 / v3=100.
     const uint32_t code47b[] = {
         0x7e0602ffu, 0x42c80000u, 0x7d880300u, 0xbe80246au, 0xbf880003u, 0xbe8503ffu, 0x42480000u,
         0x06060005u, 0xbefe0400u, 0x06060605u, 0xbf810000u,
     };
     std::vector<uint32_t> spv47b = recompile_valu(code47b, sizeof(code47b)/sizeof(code47b[0]), 2, /*out_vgpr*/3);
-    CHECK(spv47b.empty(), "kernel 47b (LIVE scalar write in divergent block) correctly REJECTED (not miscompiled)");
+    CHECK(!spv47b.empty(), "recompiled kernel 47b (live scalar write in wave-uniform execz block) -> SPIR-V");
+    std::vector<float> in47b(N * 2), exp47b(N);
+    for (uint32_t i = 0; i < N; i++) {
+        const bool active_wave = i < 64;
+        in47b[i*2+0] = active_wave ? 2.0f : 1.0f;
+        in47b[i*2+1] = active_wave ? 1.0f : 2.0f;
+        exp47b[i] = active_wave ? 102.0f : 100.0f;
+    }
+    std::vector<float> got47b = prosper::test::run_compute(spv47b, in47b, N, N);
+    uint32_t bad47b = 0;
+    for (uint32_t i=0;i<N&&got47b.size()==N;i++)
+        if (std::fabs(got47b[i]-exp47b[i])>1e-3f) bad47b++;
+    CHECK(got47b.size()==N && bad47b==0,
+          "compute execz preserves live scalar state on both wave-uniform paths");
 
     // Kernel 47c (NEGATIVE, soundness): the in-block "scalar move" targets vcc_lo (SDST code 106, which
     // decodes as SGPR-kind). A move into VCC/EXEC/M0 has wave-wide side effects read IMPLICITLY, so it can
@@ -1091,7 +1369,7 @@ int main() {
     // corruption past the merge). Must return empty.
     const uint32_t code47c[] = {
         0x7e0602ffu, 0x42c80000u, 0x7d880300u, 0xbe80246au, 0xbf880003u, 0xbeea03ffu, 0x42480000u,
-        0x06060100u, 0xbefe0400u, 0x06060703u, 0xbf810000u,
+        0x06060100u, 0xbefe0400u, 0x02060703u, 0xbf810000u,
     };
     std::vector<uint32_t> spv47c = recompile_valu(code47c, sizeof(code47c)/sizeof(code47c[0]), 2, /*out_vgpr*/3);
     CHECK(spv47c.empty(), "kernel 47c (special-reg (vcc) write in divergent block) correctly REJECTED");

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -82,6 +82,22 @@ int main() {
                           sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]), 0, 0,
                           &dispatch_rt).empty(),
           "a nested varying-VCC compute CFG preserves spilled EXEC and lowers through the dispatcher");
+    // Ordinary LDS effects do not require workgroup-uniform control flow. Keep the same dispatcher
+    // shape, but make the inner SCC arm conditionally execute a ds_write_b32 before the back-edge.
+    // (A barrier remains forbidden below; only the blanket rejection of raw DS is being relaxed.)
+    const uint32_t compute_cfg_dispatch_lds[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020300u,
+        0xD7610013u, 0x00014A7Eu, 0xD7610013u, 0x0001507Fu,
+        0xD760000Eu, 0x00014B13u, 0xD760000Fu, 0x00015113u, 0xBEFE040Eu,
+        0xE00C2000u, 0x80020400u, 0x7DB900F9u, 0x86050007u,
+        0x7D020200u, 0xBF860006u, 0xBF0A8204u, 0x360000FDu, 0xBF840002u,
+        0xD8340000u, 0x00000302u, 0xBF82FFF4u,
+        0xBF810000u,
+    };
+    CHECK(!recompile_valu(compute_cfg_dispatch_lds,
+                          sizeof(compute_cfg_dispatch_lds)/sizeof(compute_cfg_dispatch_lds[0]), 0, 0,
+                          &dispatch_rt).empty(),
+          "a complex compute CFG may execute ordinary LDS writes through the dispatcher");
     const uint32_t scc_data_source[] = {
         0xBF060000u, 0x360000FDu, 0xBF810000u, // s_cmp_eq_u32 s0,s0; v_and_b32 v0,scc,v0
     };
@@ -158,17 +174,16 @@ int main() {
                          sizeof(compute_vcc_if_clobber)/sizeof(compute_vcc_if_clobber[0]), 0, 0).empty(),
           "an intervening write to s106 (VCC) between compare and branch stops the proof");
 
-    // A forward s_cbranch_execz that REJOINS LIVE CODE is only safe to linearize when its skipped block
-    // is EXEC-predicated VGPR writes. Here the block is a scalar write (s_mov_b32 s0,1) and the branch
-    // target is a live use of s0 (v_mov_b32 v0,s0) — the scalar write is NOT dead, so linearizing would
-    // wrongly set s0 for lanes that should have skipped. Must reject.
+    // A forward s_cbranch_execz that REJOINS LIVE CODE cannot be linearized when its skipped block has
+    // a live scalar write. The compute structurizer now handles that case with subgroupAny(EXEC), so
+    // the whole wave either executes or skips the scalar write and its live use remains exact.
     //   v_cmpx ; s_cbranch_execz +1 ; s_mov_b32 s0,1 ; v_mov_b32 v0,s0 ; s_endpgm
     const uint32_t execz_scalar[] = { 0x7da80300u, 0xbf880001u, 0xbe800381u, 0x7e000200u, 0xBF810000u };
     RecompileCoverage d = recompile_coverage(execz_scalar, sizeof(execz_scalar)/sizeof(execz_scalar[0]));
-    CHECK(d.unsupported == 1 && d.first_bad_fmt >= 0 && d.first_bad_op == 0x08,
-          "a narrowed EXEC branch over live scalar state (rejoining live code) is rejected");
-    CHECK(recompile_valu(execz_scalar, sizeof(execz_scalar)/sizeof(execz_scalar[0]), 2, 0).empty(),
-          "the production recompiler rejects execz branches that would skip live scalar writes");
+    CHECK(d.unsupported == 0,
+          "a narrowed EXEC branch over live scalar state is reconstructed in compute coverage");
+    CHECK(!recompile_valu(execz_scalar, sizeof(execz_scalar)/sizeof(execz_scalar[0]), 2, 0).empty(),
+          "the production recompiler structures execz branches over live scalar writes");
 
     // But the SAME scalar write IS safe to linearize when the execz skips straight to s_endpgm: the
     // write is dead (nothing runs after s_endpgm) and scalar ops are wave-uniform, so running it under


### PR DESCRIPTION
## Summary
- structure compute `s_cbranch_execz` with subgroup-wide EXEC votes while preserving live scalar state
- lower the UE4 producer's wide LDS operations, LDS atomics, packed/SDWA f16 arithmetic, and `v_fma_f16`
- allow ordinary LDS effects in the complex compute-CFG dispatcher while continuing to reject divergent barriers and synthesized cross-lane operations

## Live evidence
- the captured UE4 volume-lighting producer (`469de7853963f71e`, 578 dwords, local size 8x8x1) now recompiles and executes instead of reaching `cfg-recompile-reject` / `recompile-reject`
- its 120x68x32 DCC output remains a separate presentation concern handled by follow-up PR #777

## Validation
- exact live-word Vulkan regression kernels for every newly lowered instruction family
- control-flow soundness and rejection coverage for live scalar/VCC state and divergent barriers
- full Linux build and CTest suite: 97/97 passed

Advances #719.