### PR TITLE
tools(gpu): add temporal lighting diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,10 @@ copy as a seed and brightness fed back toward white/yellow. Guest GPU writes now
 entries using their native byte width as well as invalidating GPU targets. Live user validation reports stable,
 artifact-free composition apart from separately tracked window-light banding (#781). The corrected 77-submit
 source and standalone capsule are byte-identical at `13b4ccdfa15b1f4d`.
+The #781 investigation localizes that residual pattern to the additive window-light visibility pass and rejects
+depth, history-alpha, simple sampler-filter, and perspective-interpolation explanations. It remains open and
+deprioritized; see `docs/DEAD_CELLS_STATUS.md` before repeating live experiments. Successful raw RDNA2/SPIR-V
+pairs can now be captured with `PROSPER_SHADER_DUMP_SUCCESS=DIR` for offline inspection.
 
 `--bundle-final-capsule` snapshots both color RTT state and exact valid planes from persistent Vulkan
 depth/stencil images into capture v8 (#569). Capture v8 reads v1-v7 artifacts; pre-v7 failed-operation diagnostics

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -50,6 +50,19 @@ byte-identical at `13b4ccdfa15b1f4d` (BMP SHA-256
 `6a4e88dbc163d6075b18b768b20d91cfb6467c76e61af6798e22ec6ea3d2c53c`). Live Windows validation found no
 remaining composition artifacts; localized banding in the window light is tracked separately in #781.
 
+The #781 investigation localized that remaining window-light pattern without finding a justified renderer
+change. In the deterministic `13b4ccdfa15b1f4d` capsule, compute operation 19 resets the FP16 lighting target,
+draws 17..22 build it, and draw 23 composites it with the base/history inputs. Draw 19 is the window light
+(pixel shader `35956264829da0c6`): a 69-vertex CPU-generated visibility polygon with additive blending. Its
+history input already contains the evolving rays, has uniform alpha, and builds progressively across
+producer-complete submit history. Disabling depth, forcing linear filtering on its history input, and changing
+its relevant varying to non-perspective interpolation did not change the output. Forcing linear filtering on
+draw 23's FP16 light input changed and softened the standalone image, but a matching live run retained the
+visible radial bands, so that override is not a fix. The successfully recompiled raw shader decodes to coherent
+radial-distance, visibility, and attenuation math, and its translated SPIR-V preserves that structure. Keep
+[#781](https://github.com/mattias800/ps5ys/issues/781) open, but do not spend more live-run time on it without a
+pixel-aligned hardware oracle or evidence of a generic error. The user judged the residual artifact low priority.
+
 Startup and progression are stable after implementing both AGC resource-registration output queries. The former
 success-only `QueryResourceRegistrationUserMemoryRequirements` stub left Dead Cells' stack value untouched and
 occasionally requested a multi-gigabyte texture-pool allocation (#660). A native-speed fresh-save matrix improved

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -93,7 +93,11 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
   events.
 - **Diagnostics** — `PROSPER_GFXLOG` logs AgcDriver call args. Sampled-texture isolation accepts
   `PROSPER_TESTTEX_DRAW=N`, `PROSPER_TESTTEX_BINDING=B`, and `PROSPER_TESTTEX=zero|checker`; both RGBA8 and
-  renderer-owned RGBA16F RTT inputs are replaced in their native format.
+  renderer-owned RGBA16F RTT inputs are replaced in their native format. `PROSPER_TESTTEX_FILTER=linear|point`
+  uses the same draw/binding selectors for sampler-only A/B tests. `PROSPER_DUMP_RTGROUPS_ADDR=0x...` scopes
+  `PROSPER_DUMP_RTGROUPS` to one target during a long run. `PROSPER_SHADER_DUMP_SUCCESS=DIR` captures both the
+  exact raw RDNA2 bytes and translated SPIR-V for successfully recompiled graphics shaders. These are
+  diagnostics, not renderer policy; record an unmodified output before interpreting an override.
 
 ## Build environment
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1335,6 +1335,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
+                        // Draw/binding-scoped sampler A/B. This shares TESTTEX's selectors but leaves
+                        // the sampled pixels intact, isolating descriptor filtering from texture content.
+                        const char* test_filter = getenv("PROSPER_TESTTEX_FILTER");
+                        const char* test_filter_binding = getenv("PROSPER_TESTTEX_BINDING");
+                        const char* test_filter_draw = getenv("PROSPER_TESTTEX_DRAW");
+                        const bool filter_valid = test_filter &&
+                            (!strcmp(test_filter, "linear") || !strcmp(test_filter, "point"));
+                        if (filter_valid &&
+                            (!test_filter_binding ||
+                             strtoul(test_filter_binding, nullptr, 0) == r.binding) &&
+                            (!test_filter_draw ||
+                             strtoull(test_filter_draw, nullptr, 0) == draw.draw_index)) {
+                            const uint32_t filter = !strcmp(test_filter, "linear") ? 1u : 0u;
+                            fr.mag_filter = fr.min_filter = filter;
+                        }
                         fr.addr_uvw[0] = r.addr_uvw[0]; fr.addr_uvw[1] = r.addr_uvw[1]; fr.addr_uvw[2] = r.addr_uvw[2];
                         // Remaining S# sampler fields (#262): border color + LOD clamp/bias (applied where
                         // valid; the decode-only compare/unnorm stay on ShaderResource).
@@ -1971,9 +1986,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes>: dump each per-target group's rendered
                     // pixels (rtgrp_<base>_<frame>.bmp in PROSPER_FRAME_DIR) — to inspect an intermediate
                     // pass (e.g. the UI/banner RT) instead of only the presented composite. Diagnostic.
+                    // PROSPER_DUMP_RTGROUPS_ADDR optionally limits a long replay to one target.
                     if (const char* rg = getenv("PROSPER_DUMP_RTGROUPS"); rg && !rendered_pixels.empty()) {
                         size_t nz = 0; for (uint8_t b : rendered_pixels) nz += (b != 0);
-                        if (nz >= (size_t)atol(rg)) {
+                        const char* address_filter = getenv("PROSPER_DUMP_RTGROUPS_ADDR");
+                        const uint64_t wanted_base = address_filter && *address_filter
+                            ? strtoull(address_filter, nullptr, 0) : 0;
+                        if (nz >= (size_t)atol(rg) && (!wanted_base || base == wanted_base)) {
                             const std::vector<uint8_t> inspected = inspection_rgba8(
                                 rendered_pixels, gw, gh, pass_format);
                             const char* dd = getenv("PROSPER_FRAME_DIR");

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -20,9 +20,11 @@
 #include <algorithm>
 #include <atomic>
 #include <bitset>
+#include <filesystem>
 #include <iterator>
 #include <mutex>
 #include <set>
+#include <tuple>
 #include <vector>
 #include <unordered_map>
 #ifdef _WIN32
@@ -485,6 +487,49 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
     return {};
 }
 
+void maybe_dump_successful_shader(ShaderProgramStage stage, const ShaderCompileKey& key,
+                                  const std::vector<uint32_t>& spirv) {
+    const char* directory = getenv("PROSPER_SHADER_DUMP_SUCCESS");
+    if (!directory || !*directory || key.code.empty() || spirv.empty()) return;
+
+    const uint64_t spirv_hash = gpu_capture_hash(
+        reinterpret_cast<const uint8_t*>(spirv.data()), spirv.size() * sizeof(uint32_t));
+    const uint64_t raw_hash = gpu_capture_hash(
+        reinterpret_cast<const uint8_t*>(key.code.data()), key.code.size() * sizeof(uint32_t));
+    static std::mutex dump_mutex;
+    static std::set<std::tuple<uint32_t, uint64_t, uint64_t>> dumped;
+    std::lock_guard lock(dump_mutex);
+    if (!dumped.emplace(static_cast<uint32_t>(stage), spirv_hash, raw_hash).second) return;
+
+    std::error_code ec;
+    std::filesystem::create_directories(directory, ec);
+    if (ec) {
+        fprintf(stderr, "[shader-dump] cannot create %s: %s\n", directory, ec.message().c_str());
+        return;
+    }
+    const char* tag = stage == ShaderProgramStage::Vertex ? "vs" : "ps";
+    char raw_path[1024], spirv_path[1024];
+    snprintf(raw_path, sizeof(raw_path), "%s/success_%s_%016llx_%016llx.bin", directory, tag,
+             static_cast<unsigned long long>(spirv_hash),
+             static_cast<unsigned long long>(raw_hash));
+    snprintf(spirv_path, sizeof(spirv_path), "%s/success_%s_%016llx_%016llx.spv", directory, tag,
+             static_cast<unsigned long long>(spirv_hash),
+             static_cast<unsigned long long>(raw_hash));
+    FILE* raw = fopen(raw_path, "wb");
+    FILE* translated = fopen(spirv_path, "wb");
+    const size_t raw_bytes = key.code.size() * sizeof(uint32_t);
+    const size_t spirv_bytes = spirv.size() * sizeof(uint32_t);
+    const bool ok = raw && translated &&
+        fwrite(key.code.data(), 1, raw_bytes, raw) == raw_bytes &&
+        fwrite(spirv.data(), 1, spirv_bytes, translated) == spirv_bytes;
+    if (raw) fclose(raw);
+    if (translated) fclose(translated);
+    fprintf(stderr, "[shader-dump] %s spv=%016llx raw=%016llx words=%zu/%zu result=%s\n", tag,
+            static_cast<unsigned long long>(spirv_hash),
+            static_cast<unsigned long long>(raw_hash), key.code.size(), spirv.size(),
+            ok ? "written" : "failed");
+}
+
 } // namespace
 
 ShaderDecodeCacheStats shader_decode_cache_stats() {
@@ -518,7 +563,9 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
             std::lock_guard lock(cache.mutex);
             ++cache.stats.bypasses;
         }
-        return compile_graphics_shader(stage, key, resources);
+        std::vector<uint32_t> spirv = compile_graphics_shader(stage, key, resources);
+        maybe_dump_successful_shader(stage, key, spirv);
+        return spirv;
     }
 
     auto& cache = shader_cache();
@@ -528,11 +575,13 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
         ++cache.stats.hits;
         found->second.last_use = ++cache.use_counter;
         if (cache_identity) *cache_identity = found->second.identity;
+        maybe_dump_successful_shader(stage, key, found->second.spirv);
         return found->second.spirv;
     }
 
     const auto start = std::chrono::steady_clock::now();
     std::vector<uint32_t> spirv = compile_graphics_shader(stage, key, resources);
+    maybe_dump_successful_shader(stage, key, spirv);
     const auto end = std::chrono::steady_clock::now();
     ++cache.stats.misses;
     cache.stats.compile_ms += std::chrono::duration<double, std::milli>(end - start).count();

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1,6 +1,8 @@
 #include "../src/gpu/gpu_execute.hpp"
 #include <cstdint>
+#include <cstdlib>
 #include <cstdio>
+#include <filesystem>
 #include <iterator>
 #include <vector>
 
@@ -11,6 +13,24 @@ static int failures = 0;
     if (condition) std::printf("  [ok]   %s\n", message); \
     else { std::printf("  [FAIL] %s\n", message); ++failures; } \
 } while (0)
+
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+
+static size_t count_extension(const std::filesystem::path& directory, const char* extension) {
+    std::error_code ec;
+    size_t count = 0;
+    for (std::filesystem::directory_iterator it(directory, ec), end; !ec && it != end;
+         it.increment(ec)) {
+        if (it->is_regular_file(ec) && it->path().extension() == extension) ++count;
+    }
+    return ec ? 0 : count;
+}
 
 // Fullscreen triangle and solid green shaders assembled for gfx1030. These are also used by the
 // end-to-end GPU executor tests, but this test needs no Vulkan device.
@@ -43,6 +63,11 @@ int main() {
     table.resources.push_back(resource);
 
     const auto direct_vs = recompile_vertex(kVs, std::size(kVs), &table);
+    const std::filesystem::path dump_directory =
+        std::filesystem::temp_directory_path() / "prosper-shader-dump-test";
+    std::error_code dump_ec;
+    std::filesystem::remove_all(dump_directory, dump_ec);
+    set_test_env("PROSPER_SHADER_DUMP_SUCCESS", dump_directory.string().c_str());
     uint64_t first_identity = 0;
     const auto cached_vs = recompile_graphics_shader_cached(
         ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
@@ -52,6 +77,9 @@ int main() {
     auto stats = shader_recompile_cache_stats();
     CHECK(stats.misses == 1 && stats.hits == 0 && stats.entries == 1,
           "first shader realization records one cache miss");
+    CHECK(count_extension(dump_directory, ".bin") == 1 &&
+              count_extension(dump_directory, ".spv") == 1,
+          "successful shader diagnostics create one raw/SPIR-V pair");
 
     uint64_t repeated_identity = 0;
     const auto repeated_vs = recompile_graphics_shader_cached(
@@ -62,6 +90,11 @@ int main() {
           "identical code and descriptor semantics hit the cache");
     CHECK(first_identity != 0 && repeated_identity == first_identity,
           "shader cache hits preserve a non-zero compiled-shader identity");
+    CHECK(count_extension(dump_directory, ".bin") == 1 &&
+              count_extension(dump_directory, ".spv") == 1,
+          "successful shader diagnostics deduplicate cache hits");
+    set_test_env("PROSPER_SHADER_DUMP_SUCCESS", nullptr);
+    std::filesystem::remove_all(dump_directory, dump_ec);
 
     // These fields are consumed by the runtime backend, not by the recompiler. Changing them must
     // reuse SPIR-V while each DrawItem continues to carry the new table to descriptor upload.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -70,6 +70,8 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 ./build-linux/gpu_replay --through-operation 52 /tmp/submit.prgcap /tmp/prefix.bmp
 ./build-linux/gpu_replay --warmup-repeats 2 /tmp/submit.prgcap /tmp/converged.bmp
 ./build-linux/gpu_replay --dump-resource 18:ps:34 /tmp/texture.bin /tmp/submit.prgcap
+./build-linux/gpu_replay --dump-rtt-seed 0x7f9f504b0000 /tmp/history.bmp \
+  --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute-resource 0:2 /tmp/storage.bin /tmp/submit.prgcap
@@ -102,6 +104,19 @@ Compute selectors use the realized compute index printed by `--inspect-only`. Th
 the exact specialized SPIR-V executed by replay. For a long live run, `PROSPER_COMPUTELOG_CODE=0x...` and
 `PROSPER_COMPUTELOG_SIZE=N` restrict before/after hash diagnostics to dispatches matching the configured
 program address and storage-buffer byte size. Either filter may be used alone.
+
+`--dump-rtt-seed ADDR PATH` writes one serialized temporal color surface as an inspection BMP. RGBA8
+seeds retain their bytes; RGBA16F seeds are clamped to 0..1 and converted to RGBA8 for viewing. The address
+is the `guest_addr` printed by `--inspect-only`. This exposes the input to operation zero, not the surface after
+the selected submit executes, and the inspection conversion is not a pixel oracle for HDR values.
+
+Live runs can narrow intermediate-target dumps with
+`PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes> PROSPER_DUMP_RTGROUPS_ADDR=0x...`; only a target whose guest base
+matches the optional address filter is written. A sampled-texture filter A/B uses
+`PROSPER_TESTTEX_FILTER=linear|point` together with `PROSPER_TESTTEX_DRAW=N` and/or
+`PROSPER_TESTTEX_BINDING=B`. It changes only the matching descriptor's minification and magnification filters.
+These environment variables are localization probes, not fixes, and their output must not replace an unmodified
+regression oracle.
 
 `--draw` uses realized draw indices, while graphs use mixed semantic operation indices. They are not
 interchangeable when dispatches or unrealized operations are present. Replay restores serialized render-target

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2,10 +2,12 @@
 #include "gpu/gpu_capture_bundle.hpp"
 #include "gpu/gpu_dependency_graph.hpp"
 #include "gpu/gpu_execute.hpp"
+#include "gpu/shader_resources.hpp"
 #include "live_renderer.hpp"
 #include "render_runner.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -40,11 +42,34 @@ void usage(const char* argv0) {
                          "[--bundle-zero-boundary] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
+                         "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
                          "[--dump-failed-shader FAILURE:STAGE PATH] "
                          "[--dump-compute-resource N:BINDING PATH] "
                          "[--legacy-htile-before-stencil] "
                          "<capture.prgcap> [output.bmp]\n", argv0);
+}
+
+std::vector<uint8_t> inspect_rtt_seed(const prosper::gpu::GpuCaptureRttSeed& seed) {
+    const size_t texels = static_cast<size_t>(seed.width) * seed.height;
+    if (seed.format == prosper::gpu::GpuCaptureColorFormat::Rgba8Unorm &&
+        seed.rgba.size() == texels * 4)
+        return seed.rgba;
+    if (seed.format != prosper::gpu::GpuCaptureColorFormat::Rgba16Float ||
+        seed.rgba.size() != texels * 8)
+        return {};
+
+    std::vector<uint8_t> rgba(texels * 4);
+    for (size_t texel = 0; texel < texels; ++texel) {
+        for (uint32_t channel = 0; channel < 4; ++channel) {
+            uint16_t half = 0;
+            std::memcpy(&half, seed.rgba.data() + texel * 8 + channel * 2, sizeof(half));
+            const float value = prosper::gpu::half_to_float(half);
+            rgba[texel * 4 + channel] = !std::isfinite(value) || value <= 0.0f ? 0
+                : value >= 1.0f ? 255 : static_cast<uint8_t>(value * 255.0f + 0.5f);
+        }
+    }
+    return rgba;
 }
 
 std::vector<uint8_t> execute_frame(const prosper::gpu::GpuReplayFrame& replay,
@@ -1051,12 +1076,14 @@ int main(int argc, char** argv) {
     std::string compute_shader_spec, compute_shader_path;
     std::string compute_resource_spec, compute_resource_path;
     std::string failed_shader_spec, failed_shader_path;
+    std::string rtt_seed_path;
     std::string graph_json_path, prepend_path;
     std::string bundle_path, bundle_compact_path;
     std::string bundle_final_capsule_path;
     std::string bundle_extract_submit_path;
     uint64_t bundle_extract_submit_no = 0;
     uint64_t bundle_find_ds_addr = 0;
+    uint64_t rtt_seed_addr = 0;
     std::vector<const char*> positional;
     for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--inspect") inspect = true;
@@ -1123,6 +1150,12 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-resource" && i + 2 < argc) {
             dump_spec = argv[++i]; dump_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--dump-rtt-seed" && i + 2 < argc) {
+            char* end = nullptr;
+            rtt_seed_addr = std::strtoull(argv[++i], &end, 0);
+            if (!end || *end || !rtt_seed_addr) { usage(argv[0]); return 2; }
+            rtt_seed_path = argv[++i];
+        }
         else if (std::string(argv[i]) == "--dump-shader" && i + 2 < argc) {
             shader_spec = argv[++i]; shader_path = argv[++i];
         }
@@ -1143,7 +1176,7 @@ int main(int argc, char** argv) {
         if (bundle_ds_summary && bundle_find_ds_addr) { usage(argv[0]); return 2; }
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
             draw_first >= 0 || draw_with_compute_prefix || through_operation >= 0 ||
-            warmup_repeats || !dump_spec.empty() ||
+            warmup_repeats || !dump_spec.empty() || rtt_seed_addr ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
             !compute_resource_spec.empty() || !failed_shader_spec.empty() ||
             !prepend_path.empty()) {
@@ -1193,6 +1226,28 @@ int main(int argc, char** argv) {
     if (!prepend_path.empty() && prepend.metadata.submit_index >= replay.metadata.submit_index) {
         std::fprintf(stderr, "gpu_replay: predecessor submit must be earlier than consumer submit\n");
         return 2;
+    }
+    if (rtt_seed_addr) {
+        const auto seed = std::find_if(replay.rtt_seeds.begin(), replay.rtt_seeds.end(),
+            [&](const auto& candidate) { return candidate.guest_addr == rtt_seed_addr; });
+        if (seed == replay.rtt_seeds.end()) {
+            std::fprintf(stderr, "gpu_replay: RTT seed %016llx not found\n",
+                         static_cast<unsigned long long>(rtt_seed_addr));
+            return 2;
+        }
+        const std::vector<uint8_t> rgba = inspect_rtt_seed(*seed);
+        if (rgba.empty() || !prosper::test::dump_bmp(
+                rtt_seed_path.c_str(), rgba, seed->width, seed->height)) {
+            std::fprintf(stderr, "gpu_replay: cannot write RTT seed %s\n",
+                         rtt_seed_path.c_str());
+            return 2;
+        }
+        std::fprintf(stderr,
+                     "[gpureplay] dumped RTT seed %016llx %ux%u format=%s -> %s\n",
+                     static_cast<unsigned long long>(seed->guest_addr), seed->width, seed->height,
+                     seed->format == prosper::gpu::GpuCaptureColorFormat::Rgba16Float
+                         ? "rgba16f" : "rgba8",
+                     rtt_seed_path.c_str());
     }
     if (graph_only) {
         prosper::gpu::GpuDependencyGraph graph;

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -1,12 +1,25 @@
 # Shader inspect
 
-`shader_inspect` decodes one raw RDNA2 shader captured with `PROSPER_SHADER_DUMP`. It is the fast
-offline path for mapping a failed shader's control flow before changing the recompiler.
+`shader_inspect` decodes one raw RDNA2 shader. It is the fast offline path for mapping shader control
+flow before changing the recompiler.
 
 ```bash
 cmake --build build-linux -j8 --target shader_inspect
 ./build-linux/shader_inspect /tmp/shaders/exec_ps_7f123400.bin
 ```
+
+`PROSPER_SHADER_DUMP=DIR` writes raw shaders that fail recompilation. To inspect a shader that succeeds,
+run the title or replay with `PROSPER_SHADER_DUMP_SUCCESS=DIR`. Each unique successful graphics shader
+produces a pair such as:
+
+```text
+success_ps_35956264829da0c6_62ad8faab4566b7a.bin
+success_ps_35956264829da0c6_62ad8faab4566b7a.spv
+```
+
+The first hash identifies the translated SPIR-V and the second identifies the exact raw RDNA2 stream.
+Pass the `.bin` file to `shader_inspect`; use the adjacent `.spv` for SPIR-V disassembly or validation.
+The dump directory is created automatically. `vs` and `ps` in filenames identify vertex and pixel stages.
 
 Each instruction row includes its dword PC, encoded length, format/opcode, exact raw words, decoded
 operands, and, for SOPP branches, the signed immediate and resolved target PC. The header also prints
@@ -14,4 +27,4 @@ the stage-agnostic `recompile_coverage` result. That coverage is intentionally c
 control-flow shape may remain listed there even when the vertex/fragment structurizer accepts it.
 
 The input is bounded to 16 MiB and decoding stops at the first `s_endpgm` or unknown instruction.
-Raw dumps contain title-derived code, are local-only, and must not be committed.
+Raw and SPIR-V dumps contain title-derived code, are local-only, and must not be committed.


### PR DESCRIPTION
## Summary
- dump exact raw RDNA2 and translated SPIR-V pairs for successfully recompiled graphics shaders
- export captured RGBA8/RGBA16F temporal RTT seeds for offline inspection and scope live target/filter A/B probes
- document the Dead Cells #781 pass localization, rejected hypotheses, and stop decision

## Findings
The deterministic post-#780 frame localizes the remaining window-light bands to draw 19's additive visibility/light pass and draw 23's composite. Depth, history alpha, the draw-19 sampler, and simple perspective interpolation are not responsible. Linear filtering of draw 23's FP16 light input changes the standalone image, but the matching live run still shows the bands, so this PR does not promote that diagnostic override to renderer policy.

Issue #781 remains open and deprioritized until a pixel-aligned hardware oracle or evidence of a generic renderer error justifies further work.

## Validation
- full Linux build
- `ctest --test-dir build-linux --output-on-failure` (102/102 passed)
- MinGW `prosper_core` and `prosper_live_renderer` build
- `--dump-rtt-seed` smoke-tested with RGBA8 and RGBA16F seeds from the deterministic capsule
- successful shader dump unit coverage verifies directory creation, raw/SPIR-V output, and cache-hit deduplication

Relates to #781.