### PR TITLE
feat(renderer): bridge live RTT snapshots into compute

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -535,7 +535,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             bi.storage = image_descriptors[i].kind == SpirvDescriptorKind::StorageImage;
             // A surface whose CURRENT pixels live in the renderer's RTT cache must not be read from
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
-            if (is_live_render_target(r->gpu_addr)) { skip_image(r, "renderer-owned RTT surface"); break; }
             const bool dim_1d = r->img_dim == 0;
             const bool dim_3d = r->img_dim == 2;
             if (!dim_1d && r->img_dim != 1 && !dim_3d) {
@@ -548,6 +547,32 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (dim_3d && r->depth > 1 && r->tile_mode &&
                 !tile_mode_supports_volume(r->tile_mode)) {
                 skip_image(r, "3D tile mode has no volume address pattern"); break;
+            }
+            // A renderer-owned target's current pixels are not in raw guest memory. Import its
+            // immutable CPU snapshot for sampled bindings; storage bindings and GPU-only targets
+            // stay unsupported rather than silently reading or overwriting stale guest bytes.
+            LiveTargetSnapshot live_target;
+            const bool renderer_owned = is_live_render_target(r->gpu_addr);
+            if (renderer_owned) {
+                if (bi.storage) {
+                    skip_image(r, "renderer-owned RTT bound as storage image"); break;
+                }
+                if (dim_3d || r->depth != 1 ||
+                    !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
+                    skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
+                }
+                if (live_target.width != r->width || live_target.height != r->height) {
+                    skip_image(r, "renderer-owned RTT snapshot extent mismatch"); break;
+                }
+                const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
+                const uint64_t texels = static_cast<uint64_t>(r->width) * r->height;
+                if (texels > UINT64_MAX / bpp) {
+                    skip_image(r, "renderer-owned RTT snapshot size overflow"); break;
+                }
+                const uint64_t expected = texels * bpp;
+                if (expected != live_target.pixels->size()) {
+                    skip_image(r, "renderer-owned RTT snapshot byte count mismatch"); break;
+                }
             }
             // Multiple U# bindings may intentionally name the same guest surface (read/modify/write
             // views of one UE4 volume). They must see one Vulkan image and produce one guest
@@ -635,74 +660,106 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool r8 = r->format == DataFormat::Unorm8 && nc == 1;
                 const bool f16 = r->format == DataFormat::Float16 && nc >= 1 && nc <= 4;
                 const bool r11g11b10 = r->format == DataFormat::Float10_11_11 && nc == 3;
-                size_t need;                                       // guest bytes the decode reads
-                if (bpb && dim_3d) {
-                    skip_image(r, "block-compressed 3D texture deferred"); break;
-                } else if (bpb) {
-                    const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
-                    need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
-                                        : (size_t)bw * bh * bpb;
-                } else if (rgba8 || uint8 || r8 || f16 || r11g11b10) {
-                    const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
-                    need = r->tile_mode
-                        ? (dim_3d && r->depth > 1
-                               ? tiled_volume_bytes(r->width, r->height, r->depth,
-                                                    r->tile_mode, bpt)
-                                  : tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt))
-                        : (size_t)volume_texels * bpt;
-                } else { skip_image(r, "sampled format not decodable yet"); break; }
-                if (!need || need > kMaxComputeImageBytes || need > UINT32_MAX) {
-                    skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
-                }
-                bi.guest_bytes = need;
-                const uint8_t* src = resource_bytes_for(r, need);
-                const bool readable = (r->host_data && r->host_data_size >= need) ||
-                                      guest_readable(r->gpu_addr, (uint32_t)need);
-                if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
-                if (bpb) {                                          // BCn: (block-detile ->) decode
-                    const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
-                    std::vector<uint8_t> lin((size_t)bw * bh * bpb, 0);
-                    if (r->tile_mode)
-                        detile_elements(lin.data(), src, need, bw, bh, bpb, r->tile_mode);
-                    else
-                        std::memcpy(lin.data(), src, lin.size());
-                    if (!bc_decode_surface(upload.data(), lin.data(), lin.size(),
-                                           r->width, r->height, r->format)) {
-                        skip_image(r, "BC decode unsupported"); break; }
-                } else {
-                    const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
-                    std::vector<uint8_t> lin((size_t)volume_texels * bpt, 0);
-                    if (r->tile_mode && dim_3d && r->depth > 1) {
-                        if (!detile_volume(lin.data(), src, need, r->width, r->height, r->depth,
-                                           r->tile_mode, bpt)) {
-                            skip_image(r, "sampled volume detile failed"); break;
-                        }
-                    } else if (r->tile_mode) {
-                        detile_surface(lin.data(), src, r->width, r->height, r->tile_mode, 0, bpt);
-                    } else {
-                        std::memcpy(lin.data(), src, lin.size());
+                if (renderer_owned) {
+                    if (r11g11b10) {
+                        skip_image(r, "renderer RTT cannot be reconstructed as packed R11G11B10");
+                        break;
                     }
-                    const size_t texels = (size_t)volume_texels;
-                    if (rgba8 || uint8 || r11g11b10) {              // Native 4-byte sampled texels
-                        std::memcpy(upload.data(), lin.data(), lin.size());
-                    } else if (r8) {                                // R8: broadcast coverage to RGBA
-                        for (size_t t = 0; t < texels; t++) {
-                            const uint8_t v = lin[t];
-                            upload[t * 4 + 0] = v; upload[t * 4 + 1] = v;
-                            upload[t * 4 + 2] = v; upload[t * 4 + 3] = v;
+                    const std::vector<uint8_t>& pixels = *live_target.pixels;
+                    if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                        std::memcpy(upload.data(), pixels.data(), upload.size());
+                    } else {
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            for (uint32_t c = 0; c < 4; ++c) {
+                                uint16_t half = 0;
+                                std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
+                                float value = half_to_float(half);
+                                if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
+                                else if (value >= 1.0f) value = 1.0f;
+                                upload[t * 4 + c] = static_cast<uint8_t>(
+                                    std::lround(value * 255.0f));
+                            }
                         }
-                    } else {                                        // Float16: half -> UNORM8 + default fill
-                        const uint16_t* hp = reinterpret_cast<const uint16_t*>(lin.data());
-                        for (size_t t = 0; t < texels; t++) {
-                            for (uint32_t c = 0; c < 4; c++) {
-                                if (c >= nc) {
-                                    upload[t * 4 + c] = c == 3 ? 255 : 0;
-                                    continue;
+                    }
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   imported renderer RTT binding=%u addr=0x%llx "
+                                     "extent=%ux%u format=%s\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
+                                     live_target.format == LiveTargetPixelFormat::Rgba16Float
+                                         ? "rgba16f" : "rgba8");
+                    bi.guest_bytes = 0;
+                } else {
+                    size_t need;                                   // guest bytes the decode reads
+                    if (bpb && dim_3d) {
+                        skip_image(r, "block-compressed 3D texture deferred"); break;
+                    } else if (bpb) {
+                        const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
+                        need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
+                                            : (size_t)bw * bh * bpb;
+                    } else if (rgba8 || uint8 || r8 || f16 || r11g11b10) {
+                        const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
+                        need = r->tile_mode
+                            ? (dim_3d && r->depth > 1
+                                   ? tiled_volume_bytes(r->width, r->height, r->depth,
+                                                        r->tile_mode, bpt)
+                                   : tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt))
+                            : (size_t)volume_texels * bpt;
+                    } else { skip_image(r, "sampled format not decodable yet"); break; }
+                    if (!need || need > kMaxComputeImageBytes || need > UINT32_MAX) {
+                        skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
+                    }
+                    bi.guest_bytes = need;
+                    const uint8_t* src = resource_bytes_for(r, need);
+                    const bool readable = (r->host_data && r->host_data_size >= need) ||
+                                          guest_readable(r->gpu_addr, (uint32_t)need);
+                    if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
+                    if (bpb) {                                      // BCn: (block-detile ->) decode
+                        const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
+                        std::vector<uint8_t> lin((size_t)bw * bh * bpb, 0);
+                        if (r->tile_mode)
+                            detile_elements(lin.data(), src, need, bw, bh, bpb, r->tile_mode);
+                        else
+                            std::memcpy(lin.data(), src, lin.size());
+                        if (!bc_decode_surface(upload.data(), lin.data(), lin.size(),
+                                               r->width, r->height, r->format)) {
+                            skip_image(r, "BC decode unsupported"); break; }
+                    } else {
+                        const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
+                        std::vector<uint8_t> lin((size_t)volume_texels * bpt, 0);
+                        if (r->tile_mode && dim_3d && r->depth > 1) {
+                            if (!detile_volume(lin.data(), src, need, r->width, r->height, r->depth,
+                                               r->tile_mode, bpt)) {
+                                skip_image(r, "sampled volume detile failed"); break;
+                            }
+                        } else if (r->tile_mode) {
+                            detile_surface(lin.data(), src, r->width, r->height, r->tile_mode, 0, bpt);
+                        } else {
+                            std::memcpy(lin.data(), src, lin.size());
+                        }
+                        const size_t texels = (size_t)volume_texels;
+                        if (rgba8 || uint8 || r11g11b10) {          // Native 4-byte sampled texels
+                            std::memcpy(upload.data(), lin.data(), lin.size());
+                        } else if (r8) {                            // R8: broadcast coverage to RGBA
+                            for (size_t t = 0; t < texels; t++) {
+                                const uint8_t v = lin[t];
+                                upload[t * 4 + 0] = v; upload[t * 4 + 1] = v;
+                                upload[t * 4 + 2] = v; upload[t * 4 + 3] = v;
+                            }
+                        } else {                                    // Float16: half -> UNORM8 + default fill
+                            const uint16_t* hp = reinterpret_cast<const uint16_t*>(lin.data());
+                            for (size_t t = 0; t < texels; t++) {
+                                for (uint32_t c = 0; c < 4; c++) {
+                                    if (c >= nc) {
+                                        upload[t * 4 + c] = c == 3 ? 255 : 0;
+                                        continue;
+                                    }
+                                    float v = half_to_float(hp[t * nc + c]);
+                                    if (std::isnan(v)) v = 0.f;
+                                    v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
+                                    upload[t * 4 + c] = (uint8_t)std::lround(v * 255.0f);
                                 }
-                                float v = half_to_float(hp[t * nc + c]);
-                                if (std::isnan(v)) v = 0.f;
-                                v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
-                                upload[t * 4 + c] = (uint8_t)std::lround(v * 255.0f);
                             }
                         }
                     }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -214,8 +214,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     }
     // The compute backend must not sample a surface whose CURRENT pixels live in this renderer's
     // RTT cache (raw guest memory is then empty/stale — the Dead Cells 642x362 lesson): publish the
-    // exact-match target query it skips on (#590). Same keying as the RTT injection below.
+    // exact-match identity and immutable CPU snapshot used by live compute (#590).
     prosper::gpu::set_live_target_query([](uint64_t addr) { return g_rtt.count(addr) != 0; });
+    prosper::gpu::set_live_target_reader(
+        [](uint64_t addr, prosper::gpu::LiveTargetSnapshot& snapshot) {
+            const auto it = g_rtt.find(addr);
+            if (it == g_rtt.end() || !it->second.rgba || !it->second.w || !it->second.h)
+                return false;
+            const VkFormat format = prosper::test::backend_color_format(it->second.format);
+            const uint32_t bytes_per_pixel = prosper::test::backend_color_bytes_per_pixel(format);
+            const uint64_t texels = static_cast<uint64_t>(it->second.w) * it->second.h;
+            if (texels > UINT64_MAX / bytes_per_pixel) return false;
+            const uint64_t expected = texels * bytes_per_pixel;
+            if (expected != it->second.rgba->size()) return false;
+            snapshot.width = it->second.w;
+            snapshot.height = it->second.h;
+            snapshot.format = format == VK_FORMAT_R16G16B16A16_SFLOAT
+                ? prosper::gpu::LiveTargetPixelFormat::Rgba16Float
+                : prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm;
+            snapshot.pixels = it->second.rgba;
+            return true;
+        });
     if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
         getenv("PROSPER_GPU_REPLAY_EXPORT_DS"))
         prosper::gpu::set_gpu_capture_ds_seed_snapshot_reader(

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -305,10 +305,19 @@ bool have_submit_compute();
 // Live render-target query (#590): the compute backend must not read a sampled input from raw guest
 // memory when the LIVE RENDERER owns that surface's current pixels (an RTT color target — raw memory
 // is then empty/stale, the Dead Cells 642x362 lesson). The live renderer registers this; the compute
-// backend skips such dispatches loudly. Cross-device RTT sharing is the follow-up.
+// backend imports an immutable CPU snapshot when one exists and otherwise skips loudly.
 using LiveTargetQueryFn = std::function<bool(uint64_t gpu_addr)>;
 void set_live_target_query(LiveTargetQueryFn fn);
 bool is_live_render_target(uint64_t gpu_addr);
+enum class LiveTargetPixelFormat : uint8_t { Rgba8Unorm, Rgba16Float };
+struct LiveTargetSnapshot {
+    uint32_t width = 0, height = 0;
+    LiveTargetPixelFormat format = LiveTargetPixelFormat::Rgba8Unorm;
+    std::shared_ptr<const std::vector<uint8_t>> pixels;
+};
+using LiveTargetReaderFn = std::function<bool(uint64_t gpu_addr, LiveTargetSnapshot& snapshot)>;
+void set_live_target_reader(LiveTargetReaderFn fn);
+bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot);
 std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st,
                                                      uint64_t submit_no = 0,
                                                      std::vector<OperationRealizationFailure>* failures = nullptr);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2501,6 +2501,12 @@ void set_live_target_query(LiveTargetQueryFn fn) { g_live_target_query = std::mo
 bool is_live_render_target(uint64_t gpu_addr) {
     return g_live_target_query && g_live_target_query(gpu_addr);
 }
+static LiveTargetReaderFn g_live_target_reader;
+void set_live_target_reader(LiveTargetReaderFn fn) { g_live_target_reader = std::move(fn); }
+bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot) {
+    snapshot = {};
+    return g_live_target_reader && g_live_target_reader(gpu_addr, snapshot);
+}
 
 void set_guest_gpu_write_observer(GuestGpuWriteObserver observer) {
     g_guest_gpu_write_observer = std::move(observer);

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -114,6 +114,12 @@ int main() {
     static const uint32_t image_copy[] = {
         0x7E080300u, 0xF0000F00u, 0x00000004u, 0xBF8C3F70u, 0xF0200F00u, 0x00020004u, 0xBF810000u,
     };
+    static const uint32_t image_copy_2d[] = {
+        0x7E080300u,             // v4 = x from the shell input
+        0x7E0A0280u,             // v5 = y = 0
+        0xF0000F08u, 0x00000004u, 0xBF8C3F70u,
+        0xF0200F08u, 0x00020004u, 0xBF810000u,
+    };
     const uint32_t W = 64;
     std::vector<uint32_t> lane_index(W);
     for (uint32_t i = 0; i < W; i++) lane_index[i] = i;      // shell input: v0 = input[gid] = gid
@@ -169,6 +175,66 @@ int main() {
                              bad, W * 4, img_src[0], img_dst[0]);
         CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
     }
+
+    // A renderer-owned color target is newer than its guest backing. Recompile the same copy kernel
+    // with a sampled source, publish deliberately different live pixels, and prove the production
+    // backend imports the immutable renderer snapshot instead of either skipping or reading stale RAM.
+    std::vector<uint8_t> stale_rtt(W * 4, 0);
+    auto live_rtt = std::make_shared<std::vector<uint8_t>>(W * 4);
+    std::vector<uint8_t> live_dst(W * 4, 0xEE);
+    for (uint32_t i = 0; i < W * 4; ++i) (*live_rtt)[i] = static_cast<uint8_t>(i * 29 + 11);
+    ShaderResourceTable live_rt = irt;
+    for (ShaderResource& resource : live_rt.resources) {
+        if (resource.binding == 4) {
+            resource.cls = ResourceClass::Texture;
+            resource.img_dim = 1;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(stale_rtt.data());
+            resource.host_data = nullptr;
+            resource.host_data_size = 0;
+            resource.swizzle[0] = 4;
+            resource.swizzle[1] = 5;
+            resource.swizzle[2] = 6;
+            resource.swizzle[3] = 7;
+        } else if (resource.binding == 5) {
+            resource.img_dim = 1;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(live_dst.data());
+            resource.host_data = nullptr;
+            resource.host_data_size = 0;
+        }
+    }
+    const uint64_t live_addr = reinterpret_cast<uint64_t>(stale_rtt.data());
+    set_live_target_query([live_addr](uint64_t addr) { return addr == live_addr; });
+    set_live_target_reader(
+        [live_addr, live_rtt](uint64_t addr, LiveTargetSnapshot& snapshot) {
+            if (addr != live_addr) return false;
+            snapshot.width = W;
+            snapshot.height = 1;
+            snapshot.format = LiveTargetPixelFormat::Rgba8Unorm;
+            snapshot.pixels = live_rtt;
+            return true;
+        });
+    std::vector<uint32_t> live_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0,
+        &live_rt);
+    CHECK(!live_spirv.empty(), "sampled-image copy kernel recompiles for renderer RTT import");
+    if (!live_spirv.empty()) {
+        ComputeItem live_item;
+        live_item.spirv = live_spirv;
+        live_item.resources = std::make_shared<ShaderResourceTable>(live_rt);
+        live_item.launch.threads_x = W;
+        live_item.launch.local_x = 64;
+        live_item.launch.groups_x = 1;
+        live_item.launch.local_y = live_item.launch.local_z = 1;
+        live_item.launch.groups_y = live_item.launch.groups_z = 1;
+        live_item.code_addr = 0x590591;
+        CHECK(prosper::frontend::execute_live_compute_items({live_item}),
+              "live backend executes a dispatch sampling a renderer-owned RTT");
+        CHECK(live_dst == *live_rtt,
+              "sampled renderer RTT pixels reach storage-image writeback byte-exactly");
+        CHECK(live_dst != stale_rtt, "renderer RTT import does not use stale guest backing");
+    }
+    set_live_target_reader({});
+    set_live_target_query({});
 
     if (fails) {
         std::printf("== FAIL: %d ==\n", fails);


### PR DESCRIPTION
## Summary
- publish immutable CPU render-target snapshots from the live renderer
- import RGBA8 and RGBA16F sampled RTTs into live compute while rejecting storage, GPU-only, and mismatched surfaces loudly
- add a production Vulkan regression proving current renderer pixels win over stale guest backing

## Unreal Engine progress
The deterministic DOLL capture now imports the live 2048x2048 RTT at `0x20735d0000` into compute and reaches the next existing safety boundary: tiled 2D storage output at `0x207d760000`. That path remains skipped because removing the guard makes llvmpipe crash inside generated shader code; this PR keeps the safe behavior and isolates the proven handoff.

No visual-output improvement is claimed yet. This removes one concrete black-frame boundary and makes the next blocker observable.

Progresses #719.

## Verification
- `cmake --build build-linux -j 8`
- `ctest --output-on-failure`: 102/102 passed
- exact DOLL replay completes, logs the RTT import, and produces output hash `135929f8d0b5eb2a`
- snapshot guard check attempted; existing checked-in guards abort because their required visual-review notes are incomplete