### PR TITLE
tools(gpu): isolate captured compute dispatches

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -609,7 +609,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Fill the upload staging bytes.
             std::vector<uint8_t> upload((size_t)sbytes, 0);
             if (bi.storage) {
-                if (r->tile_mode && !dim_3d) {
+                if (r->tile_mode && !dim_3d &&
+                    !std::getenv("PROSPER_COMPUTE_TILED_2D_STORAGE")) {
                     skip_image(r, "tiled 1D/2D storage writeback deferred"); break;
                 }
                 if (!storage_unpack_supported(r->format) || !storage_pack_supported(r->format)) {
@@ -950,8 +951,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         cpci.stage.module = shader;
         cpci.stage.pName = "main";
         cpci.layout = pipeline_layout;
+        if (trace) std::fprintf(stderr, "[compute]   creating compute pipeline\n");
         if (!vk_ok(vkCreateComputePipelines(ctx.device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipeline),
                    "compute-pipeline")) break;
+        if (trace) std::fprintf(stderr, "[compute]   compute pipeline ready\n");
 
         VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
         pci.queueFamilyIndex = ctx.queue_family;
@@ -1026,9 +1029,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &command;
+        if (trace) std::fprintf(stderr, "[compute]   submitting dispatch\n");
         if (!vk_ok(vkQueueSubmit(ctx.queue, 1, &submit, fence), "queue-submit")) break;
+        if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
         if (!vk_ok(vkWaitForFences(ctx.device, 1, &fence, VK_TRUE,
                                    30ull * 1000 * 1000 * 1000), "queue-wait")) break;
+        if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
 
         bool readback_ok = true;
         for (auto& buffer : buffers) {

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -202,6 +202,11 @@ external numeric/image inspection without dereferencing the original guest addre
 `--dump-shader DRAW:vs|fs PATH` writes the captured SPIR-V module for validation/disassembly.
 `--dump-compute N PATH` writes one realized compute SPIR-V module, and
 `--dump-compute-resource N:BINDING PATH` writes its exact pre-dispatch storage-buffer bytes.
+`--compute-only N` executes one realized dispatch in isolation; combine it with
+`--override-compute-spv N PATH` to minimize or hardware-A/B a captured shader without changing its exact
+resource descriptors. The override disables the pixel oracle. Tiled 1D/2D compute storage stays skipped
+unless `PROSPER_COMPUTE_TILED_2D_STORAGE=1` is explicitly set for a bounded diagnostic replay;
+`PROSPER_COMPUTELOG=1` then separates pipeline creation, submission, and dispatch-wait failures.
 
 For compute producer provenance, `PROSPER_COMPUTELOG=1` records each `DispatchDirect` packet's
 threadgroup counts, compute-program address/hash, and AGC-resolved resources from the register state at

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -74,6 +74,9 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
   --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
+./build-linux/gpu_replay --compute-only 0 /tmp/submit.prgcap
+./build-linux/gpu_replay --compute-only 0 --override-compute-spv 0 /tmp/reduced.spv \
+  /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute-resource 0:2 /tmp/storage.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-failed-shader 0:1 /tmp/failed-fragment.bin /tmp/submit.prgcap
 ```
@@ -101,7 +104,19 @@ seeds. `--inspect-only` prints every seed's identity, validity, byte counts, and
 
 Compute selectors use the realized compute index printed by `--inspect-only`. The resource selector is
 `COMPUTE:BINDING`; it writes the captured pre-dispatch storage-buffer bytes, while `--dump-compute` writes
-the exact specialized SPIR-V executed by replay. For a long live run, `PROSPER_COMPUTELOG_CODE=0x...` and
+the exact specialized SPIR-V executed by replay. `--compute-only N` retains just that realized dispatch and
+its captured resources, making a driver or recompiler failure deterministic without running unrelated draws
+or dispatches. `--override-compute-spv N PATH` replaces that dispatch's module after capture materialization;
+the input must be a 20-byte-to-16-MiB SPIR-V binary with the standard magic word. Overrides intentionally
+disable the capture pixel oracle and are for differential diagnosis, not correctness evidence.
+
+Tiled 1D/2D storage writeback remains disabled by default. Setting
+`PROSPER_COMPUTE_TILED_2D_STORAGE=1` enables the existing tiled upload/writeback path for an explicit replay
+A/B. This can expose host Vulkan compiler or execution failures, so use it only with a bounded capsule and
+the compute-only selector. With `PROSPER_COMPUTELOG=1`, replay identifies whether failure occurred while
+creating the pipeline, submitting it, or waiting for the dispatch.
+
+For a long live run, `PROSPER_COMPUTELOG_CODE=0x...` and
 `PROSPER_COMPUTELOG_SIZE=N` restrict before/after hash diagnostics to dispatches matching the configured
 program address and storage-buffer byte size. Either filter may be used alone.
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -32,7 +32,7 @@ bool set_environment(const std::string& name, const std::string& value) {
 void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] [--draw-with-compute-prefix] "
-                         "[--through-operation N] [--warmup-repeats N] "
+                         "[--through-operation N] [--compute-only N] [--warmup-repeats N] "
                          "[--bundle capture.prgbundle] [--bundle-tail N] [--bundle-compact PATH] "
                          "[--bundle-intermediate-through-target WxH] "
                          "[--bundle-final-capsule PATH] "
@@ -44,6 +44,7 @@ void usage(const char* argv0) {
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
+                         "[--override-compute-spv N PATH] "
                          "[--dump-failed-shader FAILURE:STAGE PATH] "
                          "[--dump-compute-resource N:BINDING PATH] "
                          "[--legacy-htile-before-stencil] "
@@ -1071,9 +1072,11 @@ int main(int argc, char** argv) {
     uint32_t bundle_intermediate_target_width = 0, bundle_intermediate_target_height = 0;
     int draw_first = -1, draw_last = -1;
     int through_operation = -1;
+    int compute_only = -1;
     uint32_t warmup_repeats = 0;
     std::string dump_spec, dump_path, shader_spec, shader_path;
     std::string compute_shader_spec, compute_shader_path;
+    std::string compute_override_spec, compute_override_path;
     std::string compute_resource_spec, compute_resource_path;
     std::string failed_shader_spec, failed_shader_path;
     std::string rtt_seed_path;
@@ -1141,6 +1144,12 @@ int main(int argc, char** argv) {
             if (!end || *end || value < 0 || value > INT_MAX) { usage(argv[0]); return 2; }
             through_operation = static_cast<int>(value);
         }
+        else if (std::string(argv[i]) == "--compute-only" && i + 1 < argc) {
+            char* end = nullptr;
+            const long value = std::strtol(argv[++i], &end, 0);
+            if (!end || *end || value < 0 || value > INT_MAX) { usage(argv[0]); return 2; }
+            compute_only = static_cast<int>(value);
+        }
         else if (std::string(argv[i]) == "--warmup-repeats" && i + 1 < argc) {
             char* end = nullptr;
             const unsigned long value = std::strtoul(argv[++i], &end, 0);
@@ -1162,6 +1171,9 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-compute" && i + 2 < argc) {
             compute_shader_spec = argv[++i]; compute_shader_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--override-compute-spv" && i + 2 < argc) {
+            compute_override_spec = argv[++i]; compute_override_path = argv[++i];
+        }
         else if (std::string(argv[i]) == "--dump-compute-resource" && i + 2 < argc) {
             compute_resource_spec = argv[++i]; compute_resource_path = argv[++i];
         }
@@ -1176,8 +1188,10 @@ int main(int argc, char** argv) {
         if (bundle_ds_summary && bundle_find_ds_addr) { usage(argv[0]); return 2; }
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
             draw_first >= 0 || draw_with_compute_prefix || through_operation >= 0 ||
+            compute_only >= 0 ||
             warmup_repeats || !dump_spec.empty() || rtt_seed_addr ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
+            !compute_override_spec.empty() ||
             !compute_resource_spec.empty() || !failed_shader_spec.empty() ||
             !prepend_path.empty()) {
             usage(argv[0]); return 2;
@@ -1198,7 +1212,10 @@ int main(int argc, char** argv) {
         usage(argv[0]); return 2;
     }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
-    if (draw_first >= 0 && through_operation >= 0) { usage(argv[0]); return 2; }
+    if ((draw_first >= 0 && through_operation >= 0) ||
+        (compute_only >= 0 && (draw_first >= 0 || through_operation >= 0))) {
+        usage(argv[0]); return 2;
+    }
     if (draw_with_compute_prefix && draw_first < 0) { usage(argv[0]); return 2; }
     prosper::gpu::GpuCaptureFile capture; std::string error;
     if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {
@@ -1226,6 +1243,57 @@ int main(int argc, char** argv) {
     if (!prepend_path.empty() && prepend.metadata.submit_index >= replay.metadata.submit_index) {
         std::fprintf(stderr, "gpu_replay: predecessor submit must be earlier than consumer submit\n");
         return 2;
+    }
+    if (!compute_override_spec.empty()) {
+        char* end = nullptr;
+        const long index = std::strtol(compute_override_spec.c_str(), &end, 0);
+        if (!end || *end || index < 0 || static_cast<size_t>(index) >= replay.computes.size()) {
+            std::fprintf(stderr, "gpu_replay: invalid compute override selector %s\n",
+                         compute_override_spec.c_str());
+            return 2;
+        }
+        FILE* file = std::fopen(compute_override_path.c_str(), "rb");
+        if (!file || std::fseek(file, 0, SEEK_END) != 0) {
+            if (file) std::fclose(file);
+            std::fprintf(stderr, "gpu_replay: cannot read compute override %s\n",
+                         compute_override_path.c_str());
+            return 2;
+        }
+        const long byte_count = std::ftell(file);
+        if (byte_count < 20 || byte_count > 16 * 1024 * 1024 || (byte_count & 3) != 0 ||
+            std::fseek(file, 0, SEEK_SET) != 0) {
+            std::fclose(file);
+            std::fprintf(stderr, "gpu_replay: invalid SPIR-V size for compute override %s\n",
+                         compute_override_path.c_str());
+            return 2;
+        }
+        std::vector<uint32_t> words(static_cast<size_t>(byte_count) / sizeof(uint32_t));
+        if (std::fread(words.data(), 1, static_cast<size_t>(byte_count), file) !=
+                static_cast<size_t>(byte_count) || words[0] != 0x07230203u) {
+            std::fclose(file);
+            std::fprintf(stderr, "gpu_replay: invalid SPIR-V compute override %s\n",
+                         compute_override_path.c_str());
+            return 2;
+        }
+        std::fclose(file);
+        replay.computes[static_cast<size_t>(index)].spirv = std::move(words);
+        allow_mismatch = true;
+        std::fprintf(stderr, "[gpureplay] override compute %ld with %ld bytes from %s\n",
+                     index, byte_count, compute_override_path.c_str());
+    }
+    if (compute_only >= 0) {
+        if (static_cast<size_t>(compute_only) >= replay.computes.size()) {
+            std::fprintf(stderr, "gpu_replay: compute index %d is out of range\n", compute_only);
+            return 2;
+        }
+        const prosper::gpu::ComputeItem& item = replay.computes[static_cast<size_t>(compute_only)];
+        replay.operations = {{prosper::gpu::SubmitOperationKind::Dispatch,
+                              item.dispatch_index, item.command_order, true}};
+        replay.items.clear();
+        allow_mismatch = true;
+        std::fprintf(stderr, "[gpureplay] selected compute %d (dispatch=%llu code=0x%llx)\n",
+                     compute_only, static_cast<unsigned long long>(item.dispatch_index),
+                     static_cast<unsigned long long>(item.code_addr));
     }
     if (rtt_seed_addr) {
         const auto seed = std::find_if(replay.rtt_seeds.begin(), replay.rtt_seeds.end(),


### PR DESCRIPTION
## What changed

- add `gpu_replay --compute-only N` to execute one realized captured dispatch with its exact resources
- add `--override-compute-spv N PATH` for bounded SPIR-V minimization and hardware A/B testing
- keep tiled 1D/2D compute storage disabled by default, with an explicit diagnostic opt-in
- trace pipeline creation, queue submission, dispatch wait, and completion under `PROSPER_COMPUTELOG`
- document the oracle and safety constraints

## Why

Issue #719's Unreal Engine capture contains a deterministic compute failure, but the previous replay interface required unrelated submit work and could not substitute a reduced shader while preserving the captured descriptors and resources. The new controls reduce that failure to one dispatch and separate resource-path failures from shader execution failures.

The exact DOLL capture now proves that a small replacement shader can sample the captured 2048x2048 renderer RTT and write the captured 960x540 tiled storage image successfully. The original shader still fails during dispatch execution on llvmpipe, narrowing the remaining work to the recompiled control-flow/wave semantics rather than the image bridge or descriptor setup.

Progresses #719.

## Validation

- full Linux build
- `ctest --output-on-failure -j8`: 102/102 passed
- isolated captured dispatch with default tiled-storage safety skip
- isolated replacement SPIR-V with tiled upload, dispatch, completion, and writeback
- malformed replacement SPIR-V rejected before Vulkan initialization