### PR TITLE
fix(gpu): emulate RDNA compute wave votes

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2080,6 +2080,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
         config.local_x = launch.local_x;
         config.local_y = launch.local_y;
         config.local_z = launch.local_z;
+        config.wave_size = ((dispatch.modifier >>
+            P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_SHIFT) &
+            P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_MASK) ? 32u : 64u;
         config.tgid_x_en = field(P::COMPUTE_PGM_RSRC2_TGID_X_EN_SHIFT,
                                  P::COMPUTE_PGM_RSRC2_TGID_X_EN_MASK) != 0;
         config.tgid_y_en = field(P::COMPUTE_PGM_RSRC2_TGID_Y_EN_SHIFT,

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -843,6 +843,10 @@ constexpr uint32_t COMPUTE_SHADER_CHKSUM      = 0x22A;
 constexpr uint32_t COMPUTE_USER_DATA_0        = 0x240;
 constexpr uint32_t COMPUTE_USER_DATA_15       = 0x24F;
 constexpr uint32_t COMPUTE_DISPATCH_TUNNEL    = 0x27D;
+// GFX10 DISPATCH_DIRECT initiator bit retained by sceAgcCbDispatch's ShaderDispatchModifier.
+// Clear selects wave64; set selects wave32.
+constexpr uint32_t COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_SHIFT = 15;
+constexpr uint32_t COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_MASK  = 0x1;
 constexpr uint32_t SH_NOP = 0x800002FF;
 constexpr uint32_t SH_NUM = 0x2FF + 1;
 constexpr uint32_t VGT_PRIMITIVE_TYPE                 = 0x242;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -85,6 +85,7 @@ struct SpirvCompute {
     uint32_t t_void=0, t_fn=0, t_f32=0, t_u32=0, t_i32=0, t_v3u=0, t_bool=0, t_ptr_sb_f32=0;
     uint32_t v_gid=0, v_groupid=0, v_in=0, v_out=0, gidx=0, f_main=0, glsl=0, bconst_false=0;
     uint32_t groupid[3] = {0, 0, 0}, localid_comp[3] = {0, 0, 0};
+    uint32_t linear_localid = 0, local_count = 64, wave_size = 64;
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
@@ -775,6 +776,25 @@ struct SpirvCompute {
         put(code, Op_ControlBarrier, {uconst(Scope_Workgroup), uconst(Scope_Workgroup), uconst(MemSem_WGAcqRel)});
     }
 
+    // Dispatcher-only scratch. Unlike guest LDS, this is private recompiler state: one flag slot per
+    // padded hardware-wave lane, one result per wave, and one whole-workgroup liveness result.
+    uint32_t cfg_scratch = 0, t_ptr_cfg_u32 = 0;
+    void declare_cfg_scratch(uint32_t dwords) {
+        if (cfg_scratch) return;
+        uint32_t t_arr = id(); put(types, Op_TypeArray, {t_arr, t_u32, uconst(dwords)});
+        uint32_t t_ptr = id(); put(types, Op_TypePointer, {t_ptr, SC_Workgroup, t_arr});
+        cfg_scratch = id(); put(types, Op_Variable, {t_ptr, cfg_scratch, SC_Workgroup});
+        t_ptr_cfg_u32 = id(); put(types, Op_TypePointer, {t_ptr_cfg_u32, SC_Workgroup, t_u32});
+    }
+    uint32_t cfg_scratch_load(uint32_t idx) {
+        uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_cfg_u32, p, cfg_scratch, idx});
+        uint32_t value = id(); put(code, Op_Load, {t_u32, value, p}); return value;
+    }
+    void cfg_scratch_store(uint32_t idx, uint32_t value) {
+        uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_cfg_u32, p, cfg_scratch, idx});
+        put(code, Op_Store, {p, value});
+    }
+
     // --- Wave model (cross-lane ops via a workgroup-as-wave + LDS). The compute shell dispatches one
     // 64-invocation workgroup per wave; gl_LocalInvocationID.x is the lane. A dedicated LDS scratch array
     // (separate from ds_read/write's lds_var) holds each lane's contribution so cross-lane reductions work.
@@ -861,8 +881,11 @@ struct SpirvCompute {
     uint32_t lor(uint32_t a, uint32_t b_)  { uint32_t r = id(); put(code, Op_LogicalOr,  {t_bool, r, a, b_}); return r; }
 
     void begin(uint32_t input_stride, const ShaderResourceTable* rt = nullptr,
-               uint32_t local_x = 64, uint32_t local_y = 1, uint32_t local_z = 1) {
+               uint32_t local_x = 64, uint32_t local_y = 1, uint32_t local_z = 1,
+               uint32_t hardware_wave_size = 64) {
         stride = input_stride;
+        local_count = local_x * local_y * local_z;
+        wave_size = hardware_wave_size;
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_v3u = id(); t_bool = id();
         t_v4f = id();   // vec4<float>: needed by the sampled-texture path (image_sample) in a compute shader
         uint32_t t_ptr_in_v3u = id(); v_gid = id(); v_groupid = id(); v_localid = id();
@@ -914,6 +937,11 @@ struct SpirvCompute {
             put(code, Op_CompositeExtract, {t_u32, localid_comp[c], ldl, c});
         }
         localid = localid_comp[0];   // wave lane index
+        // Vulkan and RDNA both linearize X fastest, then Y, then Z. Keep the legacy X-only lane id
+        // for the older 64x1 wave helpers, but retain the exact linear id for 2D/3D dispatcher waves.
+        uint32_t yz = ibin(Op_IMul, localid_comp[2], uconst(local_y));
+        yz = ibin(Op_IAdd, yz, localid_comp[1]);
+        linear_localid = ibin(Op_IAdd, ibin(Op_IMul, yz, uconst(local_x)), localid_comp[0]);
         uint32_t ldg = id(); put(code, Op_Load, {t_v3u, ldg, v_groupid});
         for (uint32_t c = 0; c < 3; c++) {
             groupid[c] = id();
@@ -4207,10 +4235,12 @@ size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords) {
 // a small backward VCC vote loop. They are valid reducible machine CFGs, but deliberately exceed the
 // narrow pattern structurizer below. Lower them as a structured dispatcher loop: one switch case per
 // basic block, with the emulated register file persisted in Function variables between iterations.
-// VCCZ/EXECZ test subgroup-wide Any, matching the hardware branch's wave-mask reduction instead of
-// treating one invocation's bit as the whole mask. The fallback is gated by emit_body to complex
-// compute CFGs without workgroup barriers or synthesized cross-lane operations; ordinary LDS reads,
-// writes, and atomics remain valid when different waves visit them independently.
+// VCCZ/EXECZ reduce over the dispatch's 32/64-lane hardware wave, not the host Vulkan subgroup.
+// Native subgroup widths are implementation-defined (llvmpipe is commonly 8), so every invocation
+// remains in the dispatcher until the whole workgroup is done and exchanges its vote at the common
+// switch merge. Dedicated Workgroup scratch keeps multiple hardware waves independent. The fallback
+// is gated by emit_body to complex compute CFGs without guest barriers or synthesized cross-lane
+// operations; ordinary LDS reads, writes, and atomics remain valid while waves visit different cases.
 bool emit_compute_cfg_state_machine(
     SpirvCompute& b, RegState& initial, const std::vector<Rdna2Inst>& ins,
     const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
@@ -4221,6 +4251,13 @@ bool emit_compute_cfg_state_machine(
     uint32_t end_pc = UINT32_MAX;
     for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
     if (end_pc == UINT32_MAX) return false;
+    if ((b.wave_size != 32 && b.wave_size != 64) || !b.local_count || b.local_count > 1024)
+        return false;
+    const uint32_t wave_count = (b.local_count + b.wave_size - 1) / b.wave_size;
+    const uint32_t padded_lanes = wave_count * b.wave_size;
+    const uint32_t wave_result_base = padded_lanes;
+    const uint32_t group_active_slot = wave_result_base + wave_count;
+    b.declare_cfg_scratch(group_active_slot + 1);
 
     // Split at every branch target and fallthrough. Case values are dense block indices, not guest PCs.
     std::set<uint32_t> start_set{ins.front().pc};
@@ -4326,6 +4363,11 @@ bool emit_compute_cfg_state_machine(
     const uint32_t exec_var = b.function_var(b.t_bool, ptr_bool);
     const uint32_t pc_var = b.function_var(b.t_u32, ptr_u32);
     const uint32_t active_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t vote_pending_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t vote_value_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t vote_invert_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t vote_taken_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t vote_next_var = b.function_var(b.t_u32, ptr_u32);
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
     for (const auto& kv : vv) {
@@ -4421,11 +4463,6 @@ bool emit_compute_cfg_state_machine(
         b.store_function(exec_var, state.exec);
     };
 
-    // Subgroup votes are required only by this fallback and therefore add no capability to the
-    // normal shader path.
-    SpirvCompute::put(b.caps, Op_Capability, {Cap_GroupNonUniform});
-    SpirvCompute::put(b.caps, Op_Capability, {Cap_GroupNonUniformVote});
-
     const uint32_t loop_header = b.id(), switch_header = b.id(), switch_merge = b.id();
     const uint32_t loop_continue = b.id(), loop_merge = b.id(), fallback = b.id();
     std::vector<uint32_t> labels(starts.size());
@@ -4436,10 +4473,18 @@ bool emit_compute_cfg_state_machine(
     }
     b.emit_branch(loop_header);
     b.emit_label(loop_header);
+    // Every live hardware wave executes one guest basic block per dispatcher iteration. Inactive
+    // invocations remain in the loop as synchronization participants until all waves finish.
+    b.store_function(vote_pending_var, no);
+    b.store_function(vote_value_var, no);
+    b.store_function(vote_invert_var, no);
+    b.store_function(vote_taken_var, zero);
+    b.store_function(vote_next_var, zero);
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
-    const uint32_t selector = b.load_function(b.t_u32, pc_var);
+    const uint32_t selector = b.sel(b.load_function(b.t_bool, active_var),
+                                    b.load_function(b.t_u32, pc_var), b.uconst(UINT32_MAX));
     b.emit_selmerge(switch_merge);
     b.emit_switch(selector, fallback, switch_cases);
 
@@ -4492,18 +4537,25 @@ bool emit_compute_cfg_state_machine(
             switch (terminator->opcode) {
                 case 0x04: condition = b.logical_not(state.scc); break; // s_cbranch_scc0
                 case 0x05: condition = state.scc; break;
-                case 0x06: condition = b.logical_not(b.subgroup_any(state.vcc)); break;
-                case 0x07: condition = b.subgroup_any(state.vcc); break;
-                case 0x08: condition = b.logical_not(b.subgroup_any(state.exec)); break;
-                case 0x09: condition = b.subgroup_any(state.exec); break;
+                case 0x06: case 0x07: case 0x08: case 0x09: break;
                 default: return false;
             }
             const uint32_t target = branch_target(*terminator);
             const uint32_t fallthrough = terminator->pc + terminator->len_dwords;
             auto taken = block_for_pc.find(target), next = block_for_pc.find(fallthrough);
             if (taken == block_for_pc.end() || next == block_for_pc.end()) return false;
-            b.store_function(pc_var,
-                b.sel(condition, b.uconst(taken->second), b.uconst(next->second)));
+            if (terminator->opcode == 0x04 || terminator->opcode == 0x05) {
+                b.store_function(pc_var,
+                    b.sel(condition, b.uconst(taken->second), b.uconst(next->second)));
+            } else {
+                b.store_function(vote_pending_var, yes);
+                b.store_function(vote_value_var,
+                    terminator->opcode <= 0x07 ? state.vcc : state.exec);
+                b.store_function(vote_invert_var,
+                    terminator->opcode == 0x06 || terminator->opcode == 0x08 ? yes : no);
+                b.store_function(vote_taken_var, b.uconst(taken->second));
+                b.store_function(vote_next_var, b.uconst(next->second));
+            }
         }
         b.emit_branch(switch_merge);
     }
@@ -4513,7 +4565,74 @@ bool emit_compute_cfg_state_machine(
     b.emit_label(switch_merge);
     b.emit_branch(loop_continue);
     b.emit_label(loop_continue);
-    b.emit_condbranch(b.load_function(b.t_bool, active_var), loop_header, loop_merge);
+
+    // Publish this lane's pending vote bit and liveness. The switch merge is reached by every
+    // invocation on every iteration, including lanes whose emulated wave has already ended.
+    const uint32_t pending = b.load_function(b.t_bool, vote_pending_var);
+    const uint32_t vote_value = b.load_function(b.t_bool, vote_value_var);
+    const uint32_t vote_bit = b.sel(b.land(pending, vote_value), b.uconst(1), zero);
+    const uint32_t active_bit = b.sel(b.load_function(b.t_bool, active_var), b.uconst(2), zero);
+    b.cfg_scratch_store(b.linear_localid, b.ibin(Op_BitwiseOr, vote_bit, active_bit));
+    b.barrier();
+
+    const uint32_t wave_shift = b.wave_size == 32 ? 5u : 6u;
+    const uint32_t wave_index = b.ibin(Op_ShiftRightLogical, b.linear_localid,
+                                       b.uconst(wave_shift));
+    const uint32_t wave_base = b.ibin(Op_ShiftLeftLogical, wave_index,
+                                      b.uconst(wave_shift));
+    const uint32_t lane_in_wave = b.ibin(Op_BitwiseAnd, b.linear_localid,
+                                         b.uconst(b.wave_size - 1));
+
+    // One lane per hardware wave reduces that wave's vote. Padding keeps every dynamic access in
+    // bounds for a partial final wave; padded values are explicitly masked out.
+    uint32_t wave_leader = b.id(), wave_reduced = b.id();
+    const uint32_t is_wave_leader = b.ucmp(Op_IEqual, lane_in_wave, zero);
+    b.emit_selmerge(wave_reduced);
+    b.emit_condbranch(is_wave_leader, wave_leader, wave_reduced);
+    b.emit_label(wave_leader);
+    uint32_t wave_flags = zero;
+    for (uint32_t lane = 0; lane < b.wave_size; ++lane) {
+        const uint32_t idx = b.ibin(Op_IAdd, wave_base, b.uconst(lane));
+        uint32_t flags = b.cfg_scratch_load(idx);
+        if (padded_lanes != b.local_count)
+            flags = b.sel(b.ucmp(Op_ULessThan, idx, b.uconst(b.local_count)), flags, zero);
+        wave_flags = b.ibin(Op_BitwiseOr, wave_flags,
+                            b.ibin(Op_BitwiseAnd, flags, b.uconst(1)));
+    }
+    b.cfg_scratch_store(b.ibin(Op_IAdd, b.uconst(wave_result_base), wave_index), wave_flags);
+    b.emit_branch(wave_reduced);
+    b.emit_label(wave_reduced);
+
+    // Lane zero also reduces workgroup liveness. This uniform dispatcher loop is what makes the
+    // internal barriers legal even after one hardware wave reaches S_ENDPGM before another.
+    uint32_t group_leader = b.id(), group_reduced = b.id();
+    const uint32_t is_group_leader = b.ucmp(Op_IEqual, b.linear_localid, zero);
+    b.emit_selmerge(group_reduced);
+    b.emit_condbranch(is_group_leader, group_leader, group_reduced);
+    b.emit_label(group_leader);
+    uint32_t group_flags = zero;
+    for (uint32_t lane = 0; lane < b.local_count; ++lane) {
+        const uint32_t flags = b.cfg_scratch_load(b.uconst(lane));
+        group_flags = b.ibin(Op_BitwiseOr, group_flags,
+                             b.ibin(Op_BitwiseAnd, flags, b.uconst(2)));
+    }
+    b.cfg_scratch_store(b.uconst(group_active_slot), group_flags);
+    b.emit_branch(group_reduced);
+    b.emit_label(group_reduced);
+    b.barrier();
+
+    const uint32_t wave_flags_result = b.cfg_scratch_load(
+        b.ibin(Op_IAdd, b.uconst(wave_result_base), wave_index));
+    const uint32_t wave_any = b.ucmp(
+        Op_INotEqual, b.ibin(Op_BitwiseAnd, wave_flags_result, b.uconst(1)), zero);
+    const uint32_t vote_condition = b.bsel(
+        b.load_function(b.t_bool, vote_invert_var), b.logical_not(wave_any), wave_any);
+    const uint32_t selected_pc = b.sel(vote_condition,
+        b.load_function(b.t_u32, vote_taken_var), b.load_function(b.t_u32, vote_next_var));
+    b.store_function(pc_var, b.sel(pending, selected_pc, b.load_function(b.t_u32, pc_var)));
+    const uint32_t group_active = b.ucmp(
+        Op_INotEqual, b.cfg_scratch_load(b.uconst(group_active_slot)), zero);
+    b.emit_condbranch(group_active, loop_header, loop_merge);
     b.emit_label(loop_merge);
 
     // Expose the final emulated state to the caller (compute currently consumes no register output,
@@ -4980,7 +5099,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t local_x = std::max(1u, config.local_x);
     const uint32_t local_y = std::max(1u, config.local_y);
     const uint32_t local_z = std::max(1u, config.local_z);
-    b.begin(1, rt, local_x, local_y, local_z);
+    const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
+    b.begin(1, rt, local_x, local_y, local_z, wave_size);
 
     RegState rs;
     rs.vcc = b.bfalse();

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -64,6 +64,7 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
 struct ComputeShaderConfig {
     std::vector<uint32_t> user_sgprs;
     uint32_t local_x = 64, local_y = 1, local_z = 1;
+    uint32_t wave_size = 64; // COMPUTE_DISPATCH_INITIATOR.CS_W32_EN selects 32; otherwise 64.
     uint32_t tidig_comp_cnt = 0;
     bool tgid_x_en = false, tgid_y_en = false, tgid_z_en = false;
     bool tg_size_en = false;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -411,6 +411,40 @@ int main() {
     CHECK(got17c.size()==N && bad17c==0,
           "compute execz uses subgroupAny(EXEC): empty wave skips, active wave enters");
 
+    // Kernel 17d: force the generic CFG dispatcher (a varying VCC branch plus a VCC loop) and
+    // verify that its wave vote spans all 64 emulated RDNA2 lanes, independent of the host Vulkan
+    // subgroup width. Wave 0 has no matching lanes and skips v2=1; wave 1 has one matching lane at
+    // its end, deliberately outside llvmpipe's first 8-lane subgroup, so every lane must enter.
+    const uint32_t code17d[] = {
+        0x7e040280u,              // v_mov_b32 v2, 0
+        0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1
+        0xbf860001u,              // s_cbranch_vccz +1
+        0x7e040281u,              // v_mov_b32 v2, 1
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0 (always true)
+        0xbf870001u,              // s_cbranch_vccnz +1
+        0xbf82fffdu,              // s_branch -3
+        0x7e040d02u,              // v_cvt_f32_u32 v2, v2
+        0xbf810000u,              // s_endpgm
+    };
+    std::vector<uint32_t> spv17d = recompile_valu(
+        code17d, sizeof(code17d)/sizeof(code17d[0]), 2, /*out_vgpr*/2);
+    CHECK(!spv17d.empty(), "recompiled kernel 17d (wave64 CFG dispatcher) -> SPIR-V");
+    std::vector<float> in17d(N * 2), exp17d(N);
+    for (uint32_t i = 0; i < N; i++) {
+        in17d[i*2+0] = (i == N - 1) ? 0.0f : 1.0f;
+        in17d[i*2+1] = 0.5f;
+        exp17d[i] = i < 64 ? 0.0f : 1.0f;
+    }
+    std::vector<float> got17d = prosper::test::run_compute(spv17d, in17d, N, N);
+    uint32_t bad17d = 0;
+    for (uint32_t i=0;i<N&&got17d.size()==N;i++)
+        if (std::fabs(got17d[i]-exp17d[i])>1e-3f) bad17d++;
+    printf("  kernel17d mismatches=%u (out[63]=%g out[64]=%g out[127]=%g)\n",
+           bad17d, got17d.size()==N?got17d[63]:-1, got17d.size()==N?got17d[64]:-1,
+           got17d.size()==N?got17d[127]:-1);
+    CHECK(got17d.size()==N && bad17d==0,
+          "CFG dispatcher emulates a 64-lane wave across narrower Vulkan subgroups");
+
     // Kernel 18: the REAL if-then idiom with a forward branch. v3=7; vcc=(u0>u1);
     // s_and_saveexec_b64 s[0:1],vcc (save exec, exec=vcc); s_cbranch_execz skip (forward -> no-op);
     // v_add v3=u0+u1 (predicated); skip: s_mov_b64 exec,s[0:1] (restore); cvt+store. Same result as

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -61,7 +61,7 @@ int main() {
     CHECK(recompile_valu(compute_vcc_loop_varying,
                          sizeof(compute_vcc_loop_varying)/sizeof(compute_vcc_loop_varying[0]), 0, 0).empty(),
           "a VCCZ-exit loop whose compare reads a varying VGPR still rejects in the compute shell");
-    // A genuinely nested/multi-branch compute CFG uses the subgroup-vote dispatcher fallback. This
+    // A genuinely nested/multi-branch compute CFG uses the hardware-wave-vote dispatcher fallback. This
     // is the reduced shape of UE4's volume-lighting kernel: varying VCC exit, an inner scalar branch,
     // and a backward loop edge. The simpler two-branch loop above deliberately remains rejected.
     const uint32_t compute_cfg_dispatch[] = {

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
     { const uint32_t c[] = {0x7C040CF9u,0x06869880u,0x8DEA6A18u,0xBF810000u};
       dump(dir, "compute_mask_nor", recompile_valu(c, sizeof(c)/4, 0, 0)); }
     // Compute: nested/multi-branch CFG dispatcher (varying VCC exit + inner SCC branch + back-edge).
-    // Locks both structured switch-loop formation and the subgroup Any vote used for wave branches.
+    // Locks both structured switch-loop formation and the workgroup-scratch hardware-wave vote.
     { const uint32_t c[] = {0xBE800380u,0x7E000280u,0x7E020300u,
                             0xD7610013u,0x00014A7Eu,0xD7610013u,0x0001507Fu,
                             0xD760000Eu,0x00014B13u,0xD760000Fu,0x00015113u,0xBEFE040Eu,


### PR DESCRIPTION
## Summary
- honor GFX10 `CS_W32_EN` when selecting the emulated compute wave width
- replace host-subgroup votes in the complex compute CFG dispatcher with explicit 32/64-lane RDNA wave reductions in workgroup scratch
- keep completed waves in the uniform dispatcher loop until the whole workgroup finishes, so internal barriers remain valid
- add a Vulkan execution regression whose only matching lane lies outside llvmpipe's first 8-lane subgroup

## Verification
- `ctest --output-on-failure -j4`: 102/102 passed
- `spv_validate`: all generated modules passed strict validation
- live DOLL run with `PROSPER_COMPUTE_TILED_2D_STORAGE=1`: the exact 120x68, local-8x8 UE kernel (`modifier=0x1`, wave64) created its pipeline, dispatched, completed, and reported `result=ok` with tiled image writeback
- `snapshot.py check`: blocked before execution because the clean worktree lacks completed visual-review notes for the existing Messenger, Dead Cells, and Blasphemous 2 content guards; no baselines were changed

Progress on #719.