### PR TITLE
fix(renderer): publish uncompressed DCC storage writes

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,6 +1,7 @@
 #include "live_compute.hpp"
 
 #include "gpu/bc_decode.hpp"
+#include "gpu/gpu_capture.hpp"
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"
 #include "gpu/tile.hpp"
@@ -276,6 +277,8 @@ struct BoundImage {
     VkDeviceSize row_pitch = 0;         // LINEAR-tiling row pitch (bytes), from vkGetImageSubresourceLayout
     size_t guest_bytes = 0;             // real linear/tiled guest backing footprint
     size_t alias_of = SIZE_MAX;         // identical storage binding sharing an earlier image/view
+    uint8_t* dcc_metadata = nullptr;    // DCC control bytes to mark uncompressed after writeback
+    size_t dcc_metadata_bytes = 0;
     uint64_t before_hash = 0, after_hash = 0; // trace-only storage-image writeback evidence
     uint64_t nonzero_channels = 0;
 };
@@ -548,6 +551,28 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 !tile_mode_supports_volume(r->tile_mode)) {
                 skip_image(r, "3D tile mode has no volume address pattern"); break;
             }
+            // The backend writes an ordinary tiled base allocation, not hardware-compressed blocks.
+            // A compressed U# therefore also needs writable DCC metadata so successful writeback can
+            // publish the hardware's 0xff (uncompressed) state before a later sampled descriptor sees it.
+            if (bi.storage && r->compression_enabled) {
+                const uint64_t metadata_bytes = gpu_capture_dcc_metadata_footprint(*r);
+                if (!r->metadata_addr || !metadata_bytes || metadata_bytes > SIZE_MAX ||
+                    metadata_bytes > UINT32_MAX) {
+                    skip_image(r, "DCC metadata extent is unsupported"); break;
+                }
+                bi.dcc_metadata_bytes = static_cast<size_t>(metadata_bytes);
+                if (r->dcc_metadata_host_data) {
+                    if (r->dcc_metadata_host_data_size < metadata_bytes) {
+                        skip_image(r, "replay DCC metadata backing is truncated"); break;
+                    }
+                    bi.dcc_metadata = r->dcc_metadata_host_data;
+                } else {
+                    if (!guest_readable(r->metadata_addr, static_cast<uint32_t>(metadata_bytes))) {
+                        skip_image(r, "live DCC metadata backing is unreadable"); break;
+                    }
+                    bi.dcc_metadata = reinterpret_cast<uint8_t*>(uintptr_t(r->metadata_addr));
+                }
+            }
             // A renderer-owned target's current pixels are not in raw guest memory. Import its
             // immutable CPU snapshot for sampled bindings; storage bindings and GPU-only targets
             // stay unsupported rather than silently reading or overwriting stale guest bytes.
@@ -590,6 +615,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     const BoundImage& owner = images[bi.alias_of];
                     bi.image = owner.image; bi.memory = owner.memory; bi.view = owner.view;
                     bi.guest_bytes = owner.guest_bytes;
+                    bi.dcc_metadata = owner.dcc_metadata;
+                    bi.dcc_metadata_bytes = owner.dcc_metadata_bytes;
                     staging_bytes[i] = staging_bytes[bi.alias_of];
                     if (trace)
                         std::fprintf(stderr, "[compute]   image-alias binding=%u -> binding=%u addr=0x%llx\n",
@@ -1107,6 +1134,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                    r->gpu_addr, bi.guest_bytes,
                                    item.submit_no, item.dispatch_index,
                                    item.command_order, item.code_addr);
+            if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
+                std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                if (!r->dcc_metadata_host_data && writer_provenance_enabled())
+                    record_guest_write(GuestWriterKind::ComputeBuffer,
+                                       r->metadata_addr, bi.dcc_metadata_bytes,
+                                       item.submit_no, item.dispatch_index,
+                                       item.command_order, item.code_addr);
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   DCC uncompressed binding=%u meta=0x%llx bytes=%zu code=0xff\n",
+                                 bi.binding, (unsigned long long)r->metadata_addr,
+                                 bi.dcc_metadata_bytes);
+            }
             vkUnmapMemory(ctx.device, staging_memory[i]);
         }
         if (!readback_ok) break;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -121,6 +121,8 @@ struct TextureDecodeKey {
     uint32_t max_uncompressed_block_size = 0, max_compressed_block_size = 0;
     uint32_t dcc_flags = 0;
     uint64_t metadata_addr = 0;
+    uint64_t metadata_host_data = 0;
+    uint64_t metadata_host_data_size = 0;
     bool operator==(const TextureDecodeKey&) const = default;
 };
 
@@ -137,6 +139,7 @@ struct TextureDecodeKeyHash {
         mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height); mix(key.depth);
         mix(key.tile_mode); mix(key.img_dim); mix(key.max_uncompressed_block_size);
         mix(key.max_compressed_block_size); mix(key.dcc_flags); mix(key.metadata_addr);
+        mix(key.metadata_host_data); mix(key.metadata_host_data_size);
         return hash;
     }
 };
@@ -569,6 +572,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         std::memcpy(dst, r.host_data + off, take);
                         return take;
                     };
+                    auto copy_dcc_metadata = [&](uint8_t* dst, size_t n) -> size_t {
+                        if (!r.dcc_metadata_host_data)
+                            return safe_copy(dst, r.metadata_addr, n);
+                        const size_t take = static_cast<size_t>(std::min<uint64_t>(
+                            n, r.dcc_metadata_host_data_size));
+                        std::memcpy(dst, r.dcc_metadata_host_data, take);
+                        return take;
+                    };
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
                         const TextureDecodeKey decode_key{
@@ -585,6 +596,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                    (r.color_transform ? 16u : 0u))
                                 : 0u,
                             r.compression_enabled ? r.metadata_addr : 0u,
+                            r.compression_enabled
+                                ? static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
+                                      r.dcc_metadata_host_data))
+                                : 0u,
+                            r.compression_enabled ? r.dcc_metadata_host_data_size : 0u,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
                         const bool has_cpu_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() &&
@@ -597,16 +613,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::find_persistent_color_target(
                                 r.gpu_addr, tw, th, live_rtt->second.format) != nullptr;
                         const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
-                        if (r.compression_enabled && !has_live_rtt) {
-                            static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
-                            if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
-                                fprintf(stderr,
-                                        "[render] DCC-compressed sampled image addr=0x%llx meta=0x%llx "
-                                        "%ux%ux%u fmt=%u tile=%u is unsupported; base bytes are not a valid decode\n",
-                                        (unsigned long long)r.gpu_addr,
-                                        (unsigned long long)r.metadata_addr,
-                                        tw, th, r.depth, (unsigned)r.format, r.tile_mode);
-                        }
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
@@ -625,6 +631,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (!getenv("PROSPER_DETILE") || atoi(getenv("PROSPER_DETILE")) == 0);
                         const bool persistent_cache_eligible =
                             !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
+                            !r.compression_enabled &&
                             persistent_decode_limit &&
                             (persistent_source_is_tiled || persistent_source_matches_pixels);
                         const size_t persistent_source_size = persistent_source_matches_pixels
@@ -899,8 +906,56 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // detile + decode; anything else reads 4 B/texel with the surface detiler.
                         // CONFIDENCE: MED on the face stride (padded tiled footprint) — visually
                         // validated; a wrong stride garbles faces 1..5, it cannot crash (safe_copy).
-                        bool cube_done = false;
-                        if (is_cube && !rtt_hit) {
+                        // GFX8-GFX10 embeds four self-contained 0/1 fast clears in DCC metadata. A
+                        // uniform metadata surface means every compression block has that value, so it
+                        // can be materialized without interpreting compressed base bytes. Uniform 0xff
+                        // means an emulated writer published ordinary uncompressed base texels and the
+                        // normal format/detile path below is authoritative.
+                        bool dcc_fast_clear_done = false;
+                        bool dcc_uncompressed = false;
+                        if (r.compression_enabled && !rtt_hit) {
+                            const uint64_t metadata_bytes =
+                                prosper::gpu::gpu_capture_dcc_metadata_footprint(r);
+                            std::vector<uint8_t> metadata(static_cast<size_t>(metadata_bytes), 0);
+                            const size_t metadata_got = metadata_bytes
+                                ? copy_dcc_metadata(metadata.data(), metadata.size()) : 0;
+                            uint8_t clear_code = 0;
+                            dcc_uncompressed = metadata_got == metadata.size() &&
+                                !metadata.empty() &&
+                                std::all_of(metadata.begin(), metadata.end(),
+                                            [](uint8_t code) { return code == 0xff; });
+                            if (!dcc_uncompressed && metadata_got == metadata.size() &&
+                                prosper::gpu::gfx10_dcc_fast_clear_rgba8(
+                                    texture_pixels.data(), texture_pixels.size() / 4,
+                                    metadata.data(), metadata.size(), r.num_components,
+                                    r.alpha_is_on_msb, &clear_code)) {
+                                dcc_fast_clear_done = true;
+                                static std::set<std::pair<uint64_t, uint64_t>> decoded_dcc_images;
+                                if (decoded_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                    fprintf(stderr,
+                                            "[render] DCC fast-clear addr=0x%llx meta=0x%llx "
+                                            "%ux%ux%u fmt=%u code=0x%02x bytes=%zu\n",
+                                            (unsigned long long)r.gpu_addr,
+                                            (unsigned long long)r.metadata_addr,
+                                            tw, th, r.depth, (unsigned)r.format, clear_code,
+                                            metadata.size());
+                            } else if (!dcc_uncompressed) {
+                                static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
+                                if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                    fprintf(stderr,
+                                            "[render] DCC-compressed sampled image addr=0x%llx "
+                                            "meta=0x%llx %ux%ux%u fmt=%u tile=%u is unsupported; "
+                                            "metadata=%zu/%llu first=0x%02x\n",
+                                            (unsigned long long)r.gpu_addr,
+                                            (unsigned long long)r.metadata_addr,
+                                            tw, th, r.depth, (unsigned)r.format, r.tile_mode,
+                                            metadata_got,
+                                            (unsigned long long)metadata_bytes,
+                                            metadata_got ? metadata[0] : 0u);
+                            }
+                        }
+                        bool cube_done = dcc_fast_clear_done && is_cube;
+                        if (is_cube && !rtt_hit && !dcc_fast_clear_done) {
                             const uint32_t cb = prosper::gpu::bc_block_bytes(r.format);
                             const bool ctiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                             for (uint32_t fface = 0; fface < 6; fface++) {
@@ -937,8 +992,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
                         // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
                         // 16 bytes -> SW_4KB_S 16x16-block micro-tiles). #121.
-                        const uint32_t bcb = (rtt_hit || cube_done) ? 0u : prosper::gpu::bc_block_bytes(r.format);
-                        if (rtt_hit || cube_done) { /* pixels already injected/stacked above */ }
+                        const uint32_t bcb = (rtt_hit || cube_done || dcc_fast_clear_done)
+                            ? 0u : prosper::gpu::bc_block_bytes(r.format);
+                        if (rtt_hit || cube_done || dcc_fast_clear_done) { /* pixels already materialized */ }
                         else if (bcb) {
                             uint32_t bw = (tw + 3) / 4, bh = (th + 3) / 4;
                             // Block-detile: tiled_elements_bytes/detile_elements now derive the 4KB
@@ -1060,7 +1116,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool auto_tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const char* dt = getenv("PROSPER_DETILE");
                         // BC textures already block-detiled + decoded above; the 32-bpp detiler must not touch them.
-                        if (!rtt_hit && !cube_done && !bcb && !narrow_done && !f16_done &&
+                        if (!rtt_hit && !cube_done && !dcc_fast_clear_done && !bcb && !narrow_done && !f16_done &&
                             !getenv("PROSPER_NODETILE") &&
                             (auto_tiled || (!is_volume && dt && atoi(dt) != 0))) {
                             const uint32_t tmode = auto_tiled ? r.tile_mode : (uint32_t)prosper::gpu::TileMode::Sw4KbS;
@@ -1099,7 +1155,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
                         // above already produced linear packed words; unpack each to RGBA8 in place with
                         // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
-                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Float10_11_11) {
+                        if (!rtt_hit && !dcc_fast_clear_done &&
+                            r.format == prosper::gpu::DataFormat::Float10_11_11) {
                             uint8_t* tp = texture_pixels.data();
                             for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);
@@ -1115,7 +1172,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Packed R10G10B10A2 UNORM (GFX10 IMG_FMT 50 / "2_10_10_10_UNORM"):
                         // the generic 4-B read and detile above preserve packed texels; normalize each
                         // field to the RGBA8 image format used by this renderer before sampling.
-                        if (!rtt_hit && r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
+                        if (!rtt_hit && !dcc_fast_clear_done &&
+                            r.format == prosper::gpu::DataFormat::Unorm2_10_10_10) {
                             uint8_t* tp = texture_pixels.data();
                             for (size_t t = 0; t < volume_texels; t++) {
                                 uint32_t v; std::memcpy(&v, tp + t * 4, 4);

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -55,6 +55,30 @@ size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
     return bytes <= std::numeric_limits<size_t>::max() ? static_cast<size_t>(bytes) : 0;
 }
 
+bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
+                                const uint8_t* metadata, size_t metadata_bytes,
+                                uint32_t num_components, bool alpha_is_on_msb,
+                                uint8_t* clear_code) {
+    if (!metadata || !metadata_bytes || num_components != 4 || (!dst && texel_count))
+        return false;
+    const uint8_t code = metadata[0];
+    if (code != 0x00 && code != 0x40 && code != 0x80 && code != 0xc0)
+        return false;
+    if (!std::all_of(metadata + 1, metadata + metadata_bytes,
+                     [=](uint8_t value) { return value == code; }))
+        return false;
+
+    const uint8_t color = (code == 0x80 || code == 0xc0) ? 255 : 0;
+    const uint8_t alpha = (code == 0x40 || code == 0xc0) ? 255 : 0;
+    const uint32_t alpha_component = alpha_is_on_msb ? 3u : 0u;
+    uint8_t pixel[4] = {color, color, color, color};
+    pixel[alpha_component] = alpha;
+    for (size_t i = 0; i < texel_count; ++i)
+        std::memcpy(dst + i * 4, pixel, sizeof(pixel));
+    if (clear_code) *clear_code = code;
+    return true;
+}
+
 // One-time diagnostic when a NON-ZERO (tiled) tile_mode is not one of the swizzles we de-swizzle
 // (Sw4KbS=5 / Sw64KbS=9 / Sw64KbRX=27): the caller then copies the surface VERBATIM as if linear, so
 // it samples as a scrambled swizzle-weave. Other GFX10 modes a PS5 T# can legally carry — SW_256B_*,

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -79,4 +79,14 @@ size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
                                 uint32_t tile_mode, uint32_t bytes_per_texel,
                                 bool pipe_aligned);
 
+// Materialize a uniform, self-contained GFX8-GFX10 DCC fast-clear code into the renderer's RGBA8
+// upload format. The validated path is deliberately limited to four-component surfaces and the
+// embedded 0000/0001/1110/1111 codes; register clears, single-color codes, uncompressed (0xff), and
+// actual compressed blocks return false. `alpha_is_on_msb` selects the raw component that receives
+// the clear alpha before the T# destination swizzle is applied.
+bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
+                                const uint8_t* metadata, size_t metadata_bytes,
+                                uint32_t num_components, bool alpha_is_on_msb,
+                                uint8_t* clear_code = nullptr);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1,8 +1,11 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/shader_resources.hpp"
+#include "../src/gpu/tile.hpp"
 #include "live_compute.hpp"
 
+#include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <cstdio>
 #include <vector>
 
@@ -10,6 +13,14 @@ using namespace prosper::gpu;
 
 static int fails = 0;
 #define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
+
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
 
 int main() {
     // Dead Cells' bound startup fill kernel, copied verbatim from eboot.elf at runtime address
@@ -174,6 +185,59 @@ int main() {
         if (bad) std::printf("  image copy mismatched bytes = %u/%u (b0 src=%02x dst=%02x)\n",
                              bad, W * 4, img_src[0], img_dst[0]);
         CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
+    }
+
+    // The backend publishes ordinary tiled texels, not hardware-compressed blocks. Prove that a
+    // DCC-enabled storage destination atomically becomes the uncompressed (0xff) metadata state,
+    // including replay-owned metadata that a later sampled descriptor shares by logical address.
+    const uint32_t dcc_tile = static_cast<uint32_t>(TileMode::Sw64KbRX);
+    const size_t tiled_bytes = tiled_surface_bytes(W, 1, dcc_tile, 0, 4);
+    const size_t metadata_bytes = gfx10_dcc_metadata_bytes(W, 1, 1, dcc_tile, 4, true);
+    std::vector<uint8_t> tiled_src(tiled_bytes, 0), tiled_dst(tiled_bytes, 0);
+    std::vector<uint8_t> dcc_metadata(metadata_bytes, 0x40);
+    tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+    ShaderResourceTable dcc_rt = irt;
+    for (ShaderResource& resource : dcc_rt.resources) {
+        if (resource.binding != 4 && resource.binding != 5) continue;
+        resource.img_dim = 1;
+        resource.tile_mode = dcc_tile;
+        resource.size = static_cast<uint32_t>(tiled_bytes);
+        resource.gpu_addr = reinterpret_cast<uint64_t>(
+            resource.binding == 4 ? tiled_src.data() : tiled_dst.data());
+        if (resource.binding == 5) {
+            resource.compression_enabled = true;
+            resource.write_compress_enabled = true;
+            resource.meta_pipe_aligned = true;
+            resource.metadata_addr = 0x207cef0000ull;
+            resource.dcc_metadata_size = metadata_bytes;
+            resource.dcc_metadata_host_data = dcc_metadata.data();
+            resource.dcc_metadata_host_data_size = dcc_metadata.size();
+        }
+    }
+    std::vector<uint32_t> dcc_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0, &dcc_rt);
+    CHECK(!dcc_spirv.empty(), "2D storage copy recompiles for a DCC-enabled tiled destination");
+    if (!dcc_spirv.empty()) {
+        ComputeItem dcc_item;
+        dcc_item.spirv = dcc_spirv;
+        dcc_item.resources = std::make_shared<ShaderResourceTable>(dcc_rt);
+        dcc_item.launch.threads_x = W;
+        dcc_item.launch.local_x = 64;
+        dcc_item.launch.groups_x = 1;
+        dcc_item.launch.local_y = dcc_item.launch.local_z = 1;
+        dcc_item.launch.groups_y = dcc_item.launch.groups_z = 1;
+        dcc_item.code_addr = 0x719dcc;
+        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", "1");
+        CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
+              "live backend writes the tiled DCC storage image");
+        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", nullptr);
+        std::vector<uint8_t> dcc_linear(W * 4, 0);
+        detile_surface(dcc_linear.data(), tiled_dst.data(), W, 1, dcc_tile, 0, 4);
+        CHECK(dcc_linear == img_src,
+              "DCC storage writeback preserves the producer's tiled base texels");
+        CHECK(std::all_of(dcc_metadata.begin(), dcc_metadata.end(),
+                          [](uint8_t code) { return code == 0xff; }),
+              "DCC storage writeback publishes uniform uncompressed metadata");
     }
 
     // A renderer-owned color target is newer than its guest backing. Recompile the same copy kernel

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -466,6 +466,41 @@ int main() {
         CHECK(gfx10_dcc_metadata_bytes(32, 32, 32, (uint32_t)TileMode::Sw64KbS,
                                        4, true) == 0,
               "DCC sizing rejects a swizzle outside the supported R_X contract");
+        std::vector<uint8_t> clear_pixels(8, 0xaa);
+        const std::vector<uint8_t> clear_0001(4096, 0x40);
+        uint8_t clear_code = 0xff;
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 2,
+                                         clear_0001.data(), clear_0001.size(),
+                                         4, true, &clear_code) && clear_code == 0x40 &&
+              clear_pixels == std::vector<uint8_t>({0, 0, 0, 255, 0, 0, 0, 255}),
+              "uniform DCC_CLEAR_0001 materializes color zero and MSB alpha one");
+        const std::vector<uint8_t> clear_0000(16, 0x00);
+        const std::vector<uint8_t> clear_1111(16, 0xc0);
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_0000.data(), clear_0000.size(), 4, true) &&
+              clear_pixels[0] == 0 && clear_pixels[1] == 0 &&
+              clear_pixels[2] == 0 && clear_pixels[3] == 0 &&
+              gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_1111.data(), clear_1111.size(), 4, true) &&
+              clear_pixels[0] == 255 && clear_pixels[1] == 255 &&
+              clear_pixels[2] == 255 && clear_pixels[3] == 255,
+              "uniform DCC_CLEAR_0000 and DCC_CLEAR_1111 materialize all-zero/all-one");
+        const std::vector<uint8_t> clear_1110(16, 0x80);
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_1110.data(), clear_1110.size(),
+                                         4, false) &&
+              clear_pixels[0] == 0 && clear_pixels[1] == 255 &&
+              clear_pixels[2] == 255 && clear_pixels[3] == 255,
+              "uniform DCC_CLEAR_1110 places alpha zero in the LSB component");
+        std::vector<uint8_t> mixed_clear(16, 0); mixed_clear.back() = 0x40;
+        const std::vector<uint8_t> uncompressed(16, 0xff);
+        CHECK(!gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                          mixed_clear.data(), mixed_clear.size(), 4, true) &&
+              !gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                          uncompressed.data(), uncompressed.size(), 4, true) &&
+              !gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                          clear_0001.data(), clear_0001.size(), 2, true),
+              "mixed, uncompressed, and unvalidated component layouts remain unsupported");
         CHECK(tiled_volume_bytes(120, 68, 32, M, 8) == (size_t)1 * 2 * 32 * 65536,
               "120x68x32 @ 8 B uses 1x2 padded 2D blocks per Z slice");
         auto rt_volume = [&](uint32_t bpe) {


### PR DESCRIPTION
## Summary

- materialize uniform GFX8-GFX10 embedded DCC fast-clear codes for sampled four-component images
- treat uniform `0xff` metadata as authoritative uncompressed base texels and bypass stale persistent texture decoding
- publish `0xff` DCC metadata after successful live-compute storage-image writeback, including replay-owned metadata and aliased bindings
- add pure decoder coverage plus an exact Vulkan tiled-storage regression

## Root cause

The compute backend writes ordinary tiled base texels, not hardware-compressed blocks. It previously left the guest's DCC metadata at the old fast-clear value, so later sampled descriptors continued to describe compressed data and the renderer correctly refused to decode the base allocation. This made a successful Unreal volume-lighting producer invisible to downstream draws.

## Impact

A compute-written DCC storage image now transitions coherently to the hardware uncompressed metadata state before consumers sample it. Uniform embedded fast clears also decode without interpreting invalid compressed base bytes. Unsupported DCC encodings remain fail-visible.

## Validation

- full Linux build completed
- `ctest --test-dir prosper/build-linux --output-on-failure -j2`: 97/97 passed
- fresh DOLL/UE4 capture replay: dispatches 255 and 257 changed the affected metadata surfaces from `0x40` to uniform `0xff`; the later renderer consumer accepted the updated tiled base allocation and the full 375-operation replay completed
- final presentation remains black because of a separate depth-prepass/color-pass equality mismatch; this PR does not claim a visual-output improvement
- `python3 tools/snapshot/snapshot.py check` is blocked before rendering because the existing Messenger, Dead Cells, and Blasphemous 2 guards lack completed visual-review notes; no baseline or threshold was changed

Refs #719.
Supersedes #777.