### PR TITLE
fix(recompiler): EarlyFragmentTests for guest early-Z shaders — fixes PPSA02664 black world (#320)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1607,10 +1607,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // blend factors, write mask, viewport, and each PS-sampled texture address (#319).
                     if (rtt_log) {
                         fprintf(stderr, "[rtt]   draw tgt=0x%llx vcount=%u nidx=%zu topo=%u mask=0x%x "
-                                "blend=%d(src=%u dst=%u) vp=%d(%.2f,%.2f %.2fx%.2f) z=%d zw=%d ps=",
+                                "blend=%d(csrc=%u cdst=%u cop=%u asrc=%u adst=%u aop=%u) vp=%d(%.2f,%.2f %.2fx%.2f) z=%d zw=%d ps=",
                                 (unsigned long long)it.color0_base, bd.vcount, bd.indices.size(),
                                 it.ps.topology, it.ps.color_write_mask, (int)it.ps.blend_enable,
-                                it.ps.src_color_blend_factor, it.ps.dst_color_blend_factor,
+                                it.ps.src_color_blend_factor, it.ps.dst_color_blend_factor, it.ps.color_blend_op,
+                                it.ps.src_alpha_blend_factor,
+                                it.ps.dst_alpha_blend_factor, it.ps.alpha_blend_op,
                                 (int)it.ps.has_viewport,
                                 it.ps.viewport_x, it.ps.viewport_y, it.ps.viewport_w, it.ps.viewport_h,
                                 (int)it.ps.depth_test_enable, (int)it.ps.depth_write_enable);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -209,7 +209,8 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const ShaderResourceTable* resources = nullptr,
                                                        const PixelInputMapping* pixel_inputs = nullptr,
                                                        const PixelSystemInputMapping* system_inputs = nullptr,
-                                                       uint64_t* cache_identity = nullptr);
+                                                       uint64_t* cache_identity = nullptr,
+                                                       bool early_depth_stencil = false);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -491,9 +492,16 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     std::vector<uint32_t> vs = recompile_graphics_shader_cached(
         ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
         max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
+    // #320: DB_SHADER_CONTROL.Z_ORDER (bits [5:4]) == EARLY_Z_THEN_LATE_Z (1) means the guest programs
+    // depth/stencil test+write BEFORE the pixel shader. Emit EarlyFragmentTests so a kill-shader's
+    // stencil/depth writes are not suppressed by the discard (a full-screen stencil mask drawn by a
+    // kill-shader was being lost -> a later masked opaque fill covered the whole scene). LATE_Z (0),
+    // RE_Z (2) and EARLY_Z_THEN_RE_Z (3) keep the default late-test behavior, so LATE_Z alpha-tested
+    // geometry (where the kill must suppress the depth write) is unaffected.
+    const bool ps_early_z = ((rs.db_shader_control >> 4) & 0x3u) == 1u;
     std::vector<uint32_t> fs = recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
-        max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+        max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity, ps_early_z);
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();
         record_draw_realization_phases(

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -127,6 +127,7 @@ struct ShaderCompileKey {
     PixelInputMapping pixel_inputs{};
     bool has_system_inputs = false;
     PixelSystemInputMapping system_inputs{};
+    bool early_depth_stencil = false;   // #320: guest DB_SHADER_CONTROL.Z_ORDER == EARLY_Z (fragment)
     std::vector<uint32_t> code;
     std::vector<ShaderResourceCompileKey> resources;
 
@@ -159,6 +160,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, key.system_inputs.ena);
             hash = hash_mix(hash, key.system_inputs.addr);
         }
+        hash = hash_mix(hash, key.early_depth_stencil);
         hash = hash_mix(hash, key.code.size());
         for (uint32_t word : key.code) hash = hash_mix(hash, word);
         hash = hash_mix(hash, key.resources.size());
@@ -446,7 +448,8 @@ uint64_t shader_cache_entry_bytes(const ShaderCompileKey& key, const std::vector
 ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* resources,
                                          const PixelInputMapping* pixel_inputs,
-                                         const PixelSystemInputMapping* system_inputs) {
+                                         const PixelSystemInputMapping* system_inputs,
+                                         bool early_depth_stencil) {
     ShaderCompileKey key;
     key.stage = stage;
     key.has_resource_table = resources != nullptr;
@@ -455,6 +458,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
     key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
     if (key.has_system_inputs) key.system_inputs = *system_inputs;
+    key.early_depth_stencil = stage == ShaderProgramStage::Fragment && early_depth_stencil;
     if (code && dwords) {
         // Most shaders end at S_ENDPGM. A compiler-generated s_getpc_b64 V# may instead address an
         // embedded lookup table after ENDPGM; retain that proven tail so cached recompilation sees the
@@ -483,7 +487,8 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
                                 key.has_pixel_inputs ? &key.pixel_inputs : nullptr);
     if (stage == ShaderProgramStage::Fragment)
         return recompile_fragment(code, key.code.size(), resources,
-                                  key.has_system_inputs ? &key.system_inputs : nullptr);
+                                  key.has_system_inputs ? &key.system_inputs : nullptr,
+                                  key.early_depth_stencil);
     return {};
 }
 
@@ -553,10 +558,11 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const ShaderResourceTable* resources,
                                                        const PixelInputMapping* pixel_inputs,
                                                        const PixelSystemInputMapping* system_inputs,
-                                                       uint64_t* cache_identity) {
+                                                       uint64_t* cache_identity,
+                                                       bool early_depth_stencil) {
     if (cache_identity) *cache_identity = 0;
     ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs,
-                                                   system_inputs);
+                                                   system_inputs, early_depth_stencil);
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
         auto& cache = shader_cache();
         {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -52,7 +52,7 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
 enum : uint32_t {
     Cap_Shader=1, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Fragment=4, Exec_GLCompute=5,
-    EM_OriginUpperLeft=7, EM_LocalSize=17,
+    EM_EarlyFragmentTests=5, EM_OriginUpperLeft=7, EM_LocalSize=17,
     SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_StorageBuffer=12, FC_None=0,
     Dim_1D=0, Dim_2D=1, Dim_3D=2,   // SPIR-V Dim. (2D coincides with the SQ_RSRC 2D dim value, but distinct.)
     Cap_Sampled1D=43, Cap_Image1D=44,   // Dim=1D needs Sampled1D; a 1D STORAGE image (read/write) also needs Image1D
@@ -923,7 +923,8 @@ struct SpirvCompute {
     // --- Fragment-shader shell: vec4 outputs for the implemented MRT0/MRT1 exports. ---
     uint32_t t_v4f = 0;
     std::array<uint32_t, 2> v_color{};
-    void begin_fragment(const ShaderResourceTable* rt = nullptr, uint32_t color_mask = 1u) {
+    void begin_fragment(const ShaderResourceTable* rt = nullptr, uint32_t color_mask = 1u,
+                        bool early_fragment_tests = false) {
         bool with_cbufs = rt != nullptr;
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_bool = id();
         t_v4f = id(); uint32_t t_ptr_out = id();
@@ -938,6 +939,16 @@ struct SpirvCompute {
         exec_model = Exec_Fragment;
         for (uint32_t output : v_color) if (output) iface.push_back(output); // EntryPoint deferred
         put(exec, Op_ExecutionMode, {f_main, EM_OriginUpperLeft});
+        // Early depth/stencil (#320): when the guest programs DB_SHADER_CONTROL.Z_ORDER = EARLY_Z, the
+        // depth/stencil test AND write happen BEFORE the pixel shader — so a shader that discards
+        // (OpKill) still writes stencil/depth for covered samples. Without EarlyFragmentTests, Vulkan
+        // runs the tests LATE and the discard suppresses the stencil write, silently dropping
+        // stencil-mask writers (PPSA02664 draws a full-screen stencil mask via a kill-shader; losing it
+        // made a later masked opaque fill cover the whole scene -> black gameplay world). Emitting this
+        // only for guest-programmed early-Z leaves LATE_Z alpha-tested geometry (foliage etc., where the
+        // kill must suppress the depth write) unchanged.
+        if (early_fragment_tests)
+            put(exec, Op_ExecutionMode, {f_main, EM_EarlyFragmentTests});
         for (uint32_t mrt = 0; mrt < v_color.size(); ++mrt)
             if (v_color[mrt]) put(deco, Op_Decorate, {v_color[mrt], Dec_Location, mrt});
         put(types, Op_TypeVoid, {t_void});
@@ -5098,7 +5109,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
 
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt,
-                                         const PixelSystemInputMapping* system_inputs) {
+                                         const PixelSystemInputMapping* system_inputs,
+                                         bool early_fragment_tests) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
 
@@ -5113,7 +5125,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     if (!color_mask) return {};
 
     SpirvCompute b;
-    b.begin_fragment(rt, color_mask);
+    b.begin_fragment(rt, color_mask, early_fragment_tests);
     // Classify each interpolated attribute by HOW it's read (#152): v_interp_p2 (op 1) = smooth
     // rasterizer interpolation; v_interp_mov (op 2) = a raw per-vertex / provoking-vertex value (a
     // flat read). An attribute read only via v_interp_mov gets its Input varying decorated Flat so

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -81,7 +81,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 // An optional ShaderResourceTable enables memory ops (SMEM/MUBUF) with resolved bindings.
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt = nullptr,
-                                         const PixelSystemInputMapping* system_inputs = nullptr);
+                                         const PixelSystemInputMapping* system_inputs = nullptr,
+                                         bool early_fragment_tests = false);
 
 // Recompile a vertex shader to a vertex SPIR-V module: v0 = gl_VertexIndex, run the VALU, and on EXP
 // to a POS target write vec4(src0..3) to gl_Position. Returns {} if unsupported / no position export.


### PR DESCRIPTION
## Fix the PPSA02664 (Alex Kidd DX) black first gameplay world (#320)

### Root cause (live-confirmed)
The world **is** rendered correctly — the HDR tonemap writes the full first level into the scanout.
It is then destroyed by a full-screen **opaque UI-buffer fill** composited over it. That fill is
**stencil-masked** (`DB` stencil compare `GREATER`, ref 1) and is meant to be excluded from the scene
region by a preceding **stencil-mask writer** (a `color-write-mask=0` draw that `INCR`s stencil where the
scene is). That mask writer's fragment shader contains an **`OpKill`**, and the guest programs
**`DB_SHADER_CONTROL.Z_ORDER = EARLY_Z_THEN_LATE_Z`** (`db_shader_control=0x50`, `Z_ORDER` bits [5:4] = 1)
so depth/stencil are tested **and written before** the pixel shader.

prosper recompiled that shader **without** SPIR-V `EarlyFragmentTests`, so Vulkan ran the tests **late**
and the `OpKill` **suppressed the stencil write**. The mask was never marked → the masked opaque fill
covered the whole overlay → compositing it over the world blacked out the level.

This reproduces identically offline (captured scene) and in a live routed boot, so it's a real shared
defect, not a capture artifact.

### The fix
When the guest programs `Z_ORDER == EARLY_Z_THEN_LATE_Z`, recompile the fragment shader with
`OpExecutionMode EarlyFragmentTests`. The early-Z flag is plumbed from render state
(`gpu_execute` realize) through the shader compile key (early/late variants cache separately) into
`recompile_fragment` / `begin_fragment`. `LATE_Z` (0), `RE_Z` (2) and `EARLY_Z_THEN_RE_Z` (3) keep the
default late-test behavior, so **`LATE_Z` alpha-tested geometry — where the kill must suppress the depth
write (foliage etc.) — is unaffected**.

Files: `rdna2_to_spirv.{cpp,hpp}` (execution-mode emit + param), `gpu_executor.cpp` (compile-key field +
hash + plumb), `gpu_execute.hpp` (compute early-Z from `DB_SHADER_CONTROL` at the fragment recompile).
Plus a diagnostic: RTTLOG now prints the full color+alpha blend state.

### Verification
- **Mechanism proven (deterministic):** forcing `EarlyFragmentTests` on exactly these mask shaders in an
  offline replay of the captured world scene renders the **complete, correct first level** — sky,
  clouds, floating platforms, player, the "Well, that's fine for today…" dialogue box, and the HUD
  (portrait, hearts, minimap) — matching the hardware reference. The mask draws carry
  `db_shader_control=0x50` (`Z_ORDER=1`), so this fix's gate triggers for them and not for late-Z shaders.
- **Regression:** `ctest` 101/102 — the recompiler/render suites (`rdna2_to_spirv_exec`,
  `pipeline_state_resolve`, render tests) pass. The one failure (`module_loads_eboot`) is an unrelated
  game-dump import-count mismatch (loader, not the recompiler).
- **Blast radius:** shared recompiler path, but narrowly gated — `EarlyFragmentTests` is emitted only for
  guest early-Z shaders, and only changes observable behavior when combined with a discard (the buggy
  case); early-Z shaders without a kill are unaffected.
- **Note:** the golden-image snapshot guard could not be exercised here — it requires a completed
  visual-review note on the baselines (a workflow prerequisite absent in this worktree), not a pixel
  regression. A reviewer with the baseline review-note setup should run it.

Full diagnosis history and evidence: #320. This is the root-cause fix for the black world; the earlier
#757 landed the diagnostics used to find it.

Fixes #320
