### PR TITLE
fix(renderer): tolerate UE4 reverse-Z prepass drift

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1476,7 +1476,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             dss.depthTestEnable  = VK_TRUE;
             dss.depthWriteEnable = ps->depth_write_enable ? VK_TRUE : VK_FALSE;
             dss.depthCompareOp   = (VkCompareOp)ps->depth_compare_op;
-            if (getenv("PROSPER_DEPTH_ALWAYS")) dss.depthCompareOp = VK_COMPARE_OP_ALWAYS;   // diag
+            // UE4 repeats its reverse-Z depth prepass in a separately translated base-pass shader.
+            // A one-ULP position difference between those shaders makes exact EQUAL reject the whole
+            // base pass, although the guest hardware accepts the pair. Preserve occlusion by relaxing
+            // only a read-only EQUAL against an already-populated, explicitly reverse-Z surface:
+            // GEQUAL still rejects geometry behind the prepass instead of disabling depth outright.
+            const bool reverse_z_equal_compat = persistent_ds && depth_was_valid &&
+                !ps->depth_write_enable && ps->depth_compare_op == VK_COMPARE_OP_EQUAL &&
+                ps->has_depth_clear && ps->depth_clear_value <= 0.5f;
+            if (reverse_z_equal_compat) {
+                dss.depthCompareOp = VK_COMPARE_OP_GREATER_OR_EQUAL;
+                if (getenv("PROSPER_DSLOG"))
+                    fprintf(stderr, "[ds] reverse-Z read-only EQUAL -> GEQUAL compatibility\n");
+            }
         }
         if (ps && ps->stencil_enable) {
             // Wire the front/back stencil op-state so masks clip (e.g. the title shimmer tests the

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -34,6 +34,22 @@ int main() {
     // Known-good fullscreen-triangle vertex shader (SPIR-V), shared by both draws.
     #include "../tools/boot_trace/refvs.inc"
     std::vector<uint32_t> vs(kRefVs, kRefVs + sizeof(kRefVs) / 4);
+    auto ref_vs_with_depth = [](std::vector<uint32_t> words, uint32_t depth_bits) {
+        // kRefVs builds gl_Position.z from float OpConstant %37. Patch only that literal so tests can
+        // model the tiny cross-shader position drift seen between UE4's depth and base passes.
+        for (size_t i = 5; i < words.size();) {
+            const uint32_t word_count = words[i] >> 16;
+            const uint32_t opcode = words[i] & 0xffffu;
+            if (word_count == 4 && opcode == 43 /* OpConstant */ &&
+                words[i + 1] == 6 /* float type */ && words[i + 2] == 0x25) {
+                words[i + 3] = depth_bits;
+                return words;
+            }
+            if (!word_count || i + word_count > words.size()) break;
+            i += word_count;
+        }
+        return std::vector<uint32_t>{};
+    };
 
     // Two solid-color pixel shaders, recompiled from tiny RDNA2 EXP blobs (v_mov the 4 color VGPRs, then
     // EXP mrt0). Inline consts: 0xF2 = 1.0f, 0x80 = 0.0f.  RED = (1,0,0,1)  GREEN = (0,1,0,1).
@@ -184,6 +200,58 @@ int main() {
         const uint8_t* c = center(initialized);
         CHECK(c && c[1] > 0xC0 && c[0] < 0x40,
               "stencil-only initialization does not poison a later reverse-Z depth plane");
+    }
+
+    // UE4 can emit its reverse-Z depth prepass and EQUAL base pass from different shaders. Their
+    // translated clip-space positions may differ by one float ULP. On the guest this pair shades;
+    // strict Vulkan EQUAL rejects it. Relax only a read-only EQUAL on an already-valid, explicitly
+    // reverse-Z guest surface to GEQUAL, which continues rejecting fragments behind the prepass.
+    {
+        std::vector<uint32_t> depth_vs = ref_vs_with_depth(vs, 0x3f000000u); // 0.5f
+        std::vector<uint32_t> drift_vs = ref_vs_with_depth(vs, 0x3f000001u); // next float above 0.5f
+        CHECK(!depth_vs.empty() && !drift_vs.empty(), "fullscreen VS depth literal is patchable");
+
+        ResolvedPipelineState writer = opaque;
+        writer.color_write_mask = 0;
+        writer.depth_test_enable = true;
+        writer.depth_write_enable = true;
+        writer.depth_compare_op = 7; // ALWAYS
+        writer.has_depth_clear = true;
+        writer.depth_clear_value = 0.0f;
+        writer.depth_read_base = writer.depth_write_base = 0x55550000;
+
+        ResolvedPipelineState reader = opaque;
+        reader.depth_test_enable = true;
+        reader.depth_compare_op = 2; // EQUAL
+        reader.has_depth_clear = true;
+        reader.depth_clear_value = 0.0f;
+        reader.depth_read_base = reader.depth_write_base = 0x55550000;
+
+        prosper::test::BackendDraw w; w.vs = depth_vs; w.fs = red; w.ps = &writer; w.vcount = 3;
+        prosper::test::BackendDraw r; r.vs = drift_vs; r.fs = green; r.ps = &reader; r.vcount = 3;
+        (void)prosper::test::render_draws_rgba({w}, W, H, nullptr, nullptr, true);
+        std::vector<uint8_t> compatible =
+            prosper::test::render_draws_rgba({r}, W, H, nullptr, nullptr, true);
+        const uint8_t* rc = center(compatible);
+        CHECK(rc && rc[1] > 0xC0 && rc[0] < 0x40,
+              "persistent reverse-Z EQUAL tolerates one-ULP translated shader drift");
+
+        ResolvedPipelineState fresh = reader;
+        fresh.depth_read_base = fresh.depth_write_base = 0x66660000;
+        prosper::test::BackendDraw f = r; f.ps = &fresh;
+        std::vector<uint8_t> uninitialized =
+            prosper::test::render_draws_rgba({f}, W, H, nullptr, nullptr, true);
+        const uint8_t* fc = center(uninitialized);
+        CHECK(fc && fc[1] < 0x80,
+              "reverse-Z EQUAL stays strict before the guest depth surface is populated");
+
+        ResolvedPipelineState standard_z = reader;
+        standard_z.depth_clear_value = 1.0f;
+        prosper::test::BackendDraw s = r; s.ps = &standard_z;
+        std::vector<uint8_t> strict =
+            prosper::test::render_draws_rgba({s}, W, H, nullptr, nullptr, true);
+        const uint8_t* sc = center(strict);
+        CHECK(sc && sc[1] < 0x80, "standard-Z EQUAL remains exact");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## What changed

- Relax read-only `EQUAL` depth tests to `GREATER_OR_EQUAL` only for an already-populated, persistent guest depth surface with an explicitly programmed reverse-Z clear.
- Keep uninitialized surfaces and standard-Z `EQUAL` tests exact.
- Add a Vulkan regression that gives the depth-prepass and base-pass vertex shaders a one-ULP clip-space Z difference.

## Why

UE4 emits DOLL's reverse-Z depth prepass and base pass from separately translated shaders. Their generated positions differ slightly, so strict Vulkan `EQUAL` rejects the entire base pass. The scoped `GEQUAL` compatibility preserves reverse-Z occlusion—fragments behind the prepass still fail—without disabling depth testing.

This is progress toward #719.

## Impact

The captured DOLL scene now survives the base pass and reaches the external presentation target. The resulting op370 frame is nonblack but still visually incomplete; later captured draws 78/79 clear that target, which remains separate follow-up work.

## Validation

- Full Linux build: passed
- `ctest --output-on-failure`: 97/97 passed
- DOLL replay through operation 308: BMP SHA-256 `187fe47a106ee7c64c5e2d05b2d241ba30c89d49c4c4c611d6e95f473d532af9`
- DOLL replay through operation 370: renderer hash `228d288e2f89a860`; BMP SHA-256 `76e76f2caef2a2ae6ed09427c7a6341097517eba89c05c173da01770cfad9aa1`
- Both capture hashes exactly match the earlier diagnostic GEQUAL experiment with all force-depth environment variables removed.

The required snapshot guard was invoked and stopped before rendering because the repository lacks completed visual-review notes for `messenger-scene`, `dead-cells-gameplay`, and `blasphemous2-gameplay`. No snapshot baseline was changed.