### PR TITLE
fix(windows): deliver guest GC stops cooperatively

### DIFF
--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -474,27 +474,36 @@ Native validation reads all 10,743,608 bytes, no longer prints `unable to initia
 the formerly-null global at `Il2cpp+0x268c878` initialized. That exposed the distinct #678 stop-the-world
 blocker described below.
 
-### GC target-thread exception delivery — SOLVED (#678)
+### GC target-thread exception delivery — SOLVED, cooperative on Windows (#678, #690)
 
 IL2CPP installs exception type `0x1e`, then raises it on each target thread to stop the world for GC.
-Windows had returned success without delivery, leaving the raiser blocked on `SuspendSemaphore` forever.
-The native path now suspends the requested winpthreads thread, captures its Windows `CONTEXT`, redirects
-it through a small aligned thunk, synthesizes the FreeBSD mcontext layout expected by the guest handler,
-runs that handler on the requested thread, and resumes the exact interrupted context with
-`RtlRestoreContext`.
+The first Windows implementation returned success without delivery. The next implementation used
+`SuspendThread`/`SetThreadContext`, but a target commonly stopped inside a native wait. Restoring the
+pre-wake Windows `CONTEXT` after the guest handler then resumed stale `ntdll` state, causing unrelated
+worker crashes and intermittent Blasphemous 2 stalls.
 
-A redirected context is not dispatched until a blocked `WaitOnAddress` returns. The futex layer therefore
-tracks each Windows waiter's guest address and wakes that exact address after the target's suspend count is
-dropped. The injection leaves the guest SysV red zone intact. `PROSPER_EXCLOG=1` records the target-thread
-handler enter/exit cycles without enabling the much noisier synchronization trace.
+Production Windows delivery is now cooperative. A raise publishes one pending stop for the requested
+winpthreads target and wakes its registered wait. The target accepts the stop at an HLE/wait safe point,
+captures a fresh context there, and calls the guest handler on a dedicated 256 KiB alternate stack. The
+handler returns normally to the wrapper, so no stale native syscall context is restored. Generated import
+stubs also check after every HLE return. `PROSPER_WIN_LEGACY_EXC=1` retains forced context injection only
+for compatibility testing.
+
+The Windows wait registry is nesting-safe. This is required because the guest GC handler itself waits on
+semaphores: its inner wait must not overwrite and unregister the interrupted outer wait. Each nesting level
+owns a separately published slot keyed by native Windows thread id, and condition interruption advances a
+sequence word before `WakeByAddressAll`, making the wake persistent if it lands immediately before
+`WaitOnAddress`. Mutex contention uses a try-lock/checkpoint loop because winpthreads timed locks were
+observed remaining in `WaitForSingleObject` after their deadline.
 
 The first live delivery exposed two more Windows success-no-ops: `sceKernelIsStack` always returned false,
 and `scePthreadAttrGet` never copied the registered worker-stack bounds. The latter made BDWGC abort with
 `Bad stack base in GC_register_my_thread`. Both now use the existing cross-platform stack registry.
-`win_exception_delivery` tests real delivery while the worker is blocked in the HLE WaitOnAddress path;
-`win_kernel_is_stack` covers both the direct query and IL2CPP's AttrGet/Getstackaddr/Getstacksize sequence.
-The live Messenger acceptance run completed many GC cycles and reached SubmitDcb #28 with repeated
-1920x1080 presentations.
+`win_exception_delivery` covers the legacy path, cooperative condition/mutex delivery, queue-before-wait,
+alternate-stack use, AVX/nonvolatile-register preservation, and the nested-wait registration regression.
+`win_kernel_is_stack` covers both direct and winpthreads-handle stack queries. On 2026-07-16 the focused
+suite passed 30 consecutive runs and Blasphemous 2 completed 12/12 ordinary 360-presented-frame Windows
+boots with no stalls or early exits (the separate tiled-compute limitation still blocks its main menu).
 
 (Historical, pre-fix diagnosis retained below for context.)
 

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -1,4 +1,4 @@
-# Windows native port — handoff (2026-07-14)
+# Windows native port — handoff (2026-07-16)
 
 For users of the prebuilt archive, start with `WINDOWS_RELEASE.md`. This document is the engineering
 build, validation, and debugging handoff.
@@ -25,6 +25,25 @@ The guest, on Windows (MinGW, native), reproducibly:
   repeated GC stop-the-world suspend/resume cycles to complete.
 - Runs the shared live Vulkan renderer and normal 1920x1080 present/readback path on an NVIDIA host.
 - Builds SDL3 with native Win32 video, WASAPI audio, XInput/HIDAPI controllers, and Vulkan support.
+
+### Current GC delivery model (#690)
+
+Do not reintroduce `SuspendThread`/`SetThreadContext` as the normal exception path. Restoring a context
+captured inside a native wait after waking it resumes stale `ntdll` state. Windows now queues the stop,
+wakes the target's registered wait, and runs the guest handler cooperatively at an HLE boundary on a
+dedicated alternate stack. `PROSPER_WIN_LEGACY_EXC=1` is the diagnostic opt-out.
+
+Wait registrations are per nesting level, not merely per thread. The GC callback performs its own
+semaphore waits, so a single thread-local registration lets the inner wait erase the still-live outer
+wait. Condition interruption also increments its sequence before waking, which closes the wake-before-
+`WaitOnAddress` race. Run `test_win_exception_delivery.exe` after touching any of these paths; its
+nested-wait case deliberately holds the handler after the inner wait returns and proves the outer wait
+is still discoverable. `PROSPER_APP_STALL_DUMP_MS=<milliseconds>` makes `prosper-app` dump the bounded
+exception ring when presented-frame progress stops, and `PROSPER_VEHLOG=1` adds fatal worker context.
+
+Validation on 2026-07-16: 30 consecutive exception-suite passes and 12/12 fresh-save Blasphemous 2
+Windows boots reached 360 presented frames with no stall or early exit. This validates boot/GC stability,
+not the title-to-menu graphics transition; tiled 2D compute storage writeback remains tracked in #787.
 
 Merged PRs that got it here (all `#ifdef _WIN32` — Linux/macOS unaffected, CI green on all 4 platforms):
 - **#624** substrate: `exec_image_win.cpp` (VirtualAlloc mapping, VEH fault handler, SysV↔MS-x64 stub

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -69,3 +69,5 @@ Esc or closing the window quits.
   separate presentation device; frames cross as CPU pixels via `present_readback`.
 - On window-close the guest thread is detached and reclaimed by process exit (a cooperative
   flip-boundary stop is a documented follow-up).
+- `PROSPER_APP_STALL_DUMP_MS=<milliseconds>` prints the recent Windows guest-exception ring when no new
+  presented frame arrives within that interval. It is an unattended-run diagnostic, disabled by default.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -394,7 +394,28 @@ int main(int argc, char** argv) {
 #endif
         };
         if (!boot_program(dump, prog, &err, install_backends)) { fprintf(stderr, "[app] boot failed: %s\n", err.c_str()); return 1; }
-        guestThread = std::thread([]{ run_entry(prog.imgs[0]); });   // runs the guest frame loop
+        guestThread = std::thread([]{
+            const BootResult result = run_entry(prog.imgs[0]);
+            fprintf(stderr,
+                    "[app] guest thread ended: kind=%d detail=%s rip=0x%llx addr=0x%llx "
+                    "rax=0x%llx rbx=0x%llx rdi=0x%llx rsi=0x%llx rdx=0x%llx "
+                    "rbp=0x%llx rsp=0x%llx\n",
+                    result.kind, result.detail.c_str(),
+                    static_cast<unsigned long long>(result.fault_rip),
+                    static_cast<unsigned long long>(result.fault_addr),
+                    static_cast<unsigned long long>(result.rax),
+                    static_cast<unsigned long long>(result.rbx),
+                    static_cast<unsigned long long>(result.rdi),
+                    static_cast<unsigned long long>(result.rsi),
+                    static_cast<unsigned long long>(result.rdx),
+                    static_cast<unsigned long long>(result.rbp),
+                    static_cast<unsigned long long>(result.rsp));
+            if (result.kind != 0)
+                dump_guest_exception_trace();
+            for (uint64_t address : result.backtrace)
+                fprintf(stderr, "[app] guest backtrace: 0x%llx\n",
+                        static_cast<unsigned long long>(address));
+        });   // runs the guest frame loop
         fprintf(stderr, "[app] guest booted; presenting its frames.\n");
     } else if (!testPattern) {
         fprintf(stderr, "[app] no dump given and not --test-pattern; waiting for external present frames.\n");
@@ -444,7 +465,11 @@ int main(int argc, char** argv) {
     fprintf(stderr, "[app] keyboard: WASD/Arrows=move  J/Space=Cross(jump)  K=Square(attack)  L=Circle  "
                     "I=Triangle  U/O=L1/R1  Y/H=L2/R2  Enter=Options  Esc=quit\n");
 
-    uint64_t shown = 0, lastCount = ~0ull, patFrame = 0;
+    const bool frameTrace = getenv("PROSPER_APP_FRAME_TRACE") != nullptr;
+    const char* stallDumpEnv = getenv("PROSPER_APP_STALL_DUMP_MS");
+    const int stallDumpMs = stallDumpEnv ? std::max(0, atoi(stallDumpEnv)) : 0;
+    auto lastFrameProgress = std::chrono::steady_clock::now();
+    uint64_t shown = 0, lastFrameSeq = ~0ull, patFrame = 0;
     bool running = true;
     while (running && !prosper_stop_requested()) {
         SDL_Event ev;
@@ -466,9 +491,10 @@ int main(int argc, char** argv) {
         // test-pattern mode there is no guest, so use the dims we feed (present_width/height report
         // the VideoOut registry, which is empty without a guest). Either way, readback needs a
         // buffer sized to the frame it holds — guard zero dims so we never present a 0-extent image.
-        // In normal use a frame is "new" when the guest flips (present_count advances); test-pattern
-        // has no flips, so treat every iteration as new.
-        bool newFrame = testPattern || (gpu::present_count() != lastCount);
+        // Render completion and guest flips are separate clocks: the command stream can flip before
+        // the renderer publishes its CPU frame. Key this loop to the completed-frame sequence so a
+        // late renderer publication is not missed or marked handled while only the previous frame exists.
+        bool newFrame = testPattern || (gpu::present_frame_seq() != lastFrameSeq);
         gpu::PresentFrameLease frame;
         if (newFrame && gpu::present_acquire_rendered_frame(frame)) {
             uint32_t w = frame.width;
@@ -482,13 +508,33 @@ int main(int argc, char** argv) {
                     int dw = 0, dh = 0; SDL_GetWindowSizeInPixels(win, &dw, &dh);
                     create_swapchain(vk, (uint32_t)dw, (uint32_t)dh);
                 } else {
-                    lastCount = gpu::present_count(); shown++;
+                    lastFrameSeq = frame.frame_seq; shown++;
+                    lastFrameProgress = std::chrono::steady_clock::now();
                     // Periodic present-rate log (every 60 presented frames).
                     static auto t0 = std::chrono::steady_clock::now(); static uint64_t mark = 0;
                     if (shown - mark >= 60) {
                         auto now = std::chrono::steady_clock::now();
                         double s = std::chrono::duration<double>(now - t0).count();
-                        fprintf(stderr, "[app] %.1f fps (%llu frames)\n", (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown);
+                        if (frameTrace) {
+                            size_t nonzeroRgbBytes = 0;
+                            for (size_t i = 0; i + 3 < frame.rgba->size(); i += 4) {
+                                nonzeroRgbBytes += (*frame.rgba)[i] != 0;
+                                nonzeroRgbBytes += (*frame.rgba)[i + 1] != 0;
+                                nonzeroRgbBytes += (*frame.rgba)[i + 2] != 0;
+                            }
+                            fprintf(stderr,
+                                    "[app] %.1f fps (%llu frames) render_seq=%llu flips=%llu "
+                                    "nonzero_rgb_bytes=%zu/%zu\n",
+                                    (shown - mark) / (s > 0 ? s : 1),
+                                    (unsigned long long)shown,
+                                    (unsigned long long)frame.frame_seq,
+                                    (unsigned long long)gpu::present_count(), nonzeroRgbBytes,
+                                    (size_t)w * h * 3);
+                        } else {
+                            fprintf(stderr, "[app] %.1f fps (%llu frames)\n",
+                                    (shown - mark) / (s > 0 ? s : 1),
+                                    (unsigned long long)shown);
+                        }
                         t0 = now; mark = shown;
                     }
                     if (exitAfter && (int)shown >= exitAfter) running = false;
@@ -496,6 +542,14 @@ int main(int argc, char** argv) {
             }
         } else {
             std::this_thread::sleep_for(std::chrono::milliseconds(2));   // no new frame — don't spin
+        }
+        if (stallDumpMs > 0 &&
+            std::chrono::steady_clock::now() - lastFrameProgress >=
+                std::chrono::milliseconds(stallDumpMs)) {
+            fprintf(stderr, "[app] no presented-frame progress for %d ms at frame %llu\n",
+                    stallDumpMs, (unsigned long long)shown);
+            dump_guest_exception_trace();
+            lastFrameProgress = std::chrono::steady_clock::now();
         }
     }
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2080,8 +2080,15 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
                 break;
-            case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPK:
+            case Rdna2Format::SOP1: case Rdna2Format::SOPK:
                 sregs.insert(in.dst.value); break;
+            case Rdna2Format::SOP2:
+                // s_lshr_b64 -> EXEC is modeled only in the per-lane mask domain. It does not
+                // produce scalar SGPR data, so carrying a scalar value through a loop/if merge is
+                // both unnecessary and semantically wrong.
+                if (in.opcode != 0x21 || (in.dst.value != 126 && in.dst.value != 127))
+                    sregs.insert(in.dst.value);
+                break;
             case Rdna2Format::SMEM: {                                      // s_load/s_buffer_load: N consecutive SGPRs
                 uint32_t n = 1; switch (in.opcode) { case 0x1: case 0x9: n=2; break; case 0x2: case 0xA: n=4; break;
                     case 0x3: case 0xB: n=8; break; case 0x4: case 0xC: n=16; break; }
@@ -2360,6 +2367,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 else { rs.sreg_bool[in.dst.value] = r; rs.sreg_bool_narrowed[in.dst.value] = true; }
                 return true;
             }
+            // s_lshr_b64 — only the NGG wave-packing form (dst = EXEC) is modeled: it sets EXEC to
+            // the count of active vertices/primitives in the wave. A per-invocation SPIR-V shader has
+            // no wave to pack, so leave EXEC full. Handle this before taking an operator[] reference
+            // to rs.sreg[dst]: inserting a default SSA id 0 leaked into a later OpPhi and produced
+            // invalid SPIR-V (and an NVIDIA Windows driver crash during pipeline creation).
+            if (in.opcode == 0x21) {
+                if (in.dst.value != 126 && in.dst.value != 127) ok = false;
+                return true;
+            }
             uint32_t a = val(in.src[0]), c = val(in.src[1]); uint32_t& d = rs.sreg[in.dst.value];
             auto scc_nz = [&](uint32_t v){ rs.scc = b.ucmp(Op_INotEqual, v, b.uconst(0)); };  // SCC = (result != 0)
             switch (in.opcode) {
@@ -2412,13 +2428,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                              d = b.ibin(Op_ShiftRightLogical, a, sh); scc_nz(d); break; }  // dst = src0 >> (src1 & 31)
                 case 0x22: { uint32_t sh = b.ibin(Op_BitwiseAnd, c, b.uconst(31));   // s_ashr_i32
                              d = b.sbin(Op_ShiftRightArithmetic, a, sh); scc_nz(d); break; }  // dst = src0 >>a (src1 & 31)
-                case 0x21:   // s_lshr_b64 — only the NGG wave-packing form (dst = EXEC) is modeled: it sets
-                             // EXEC to the count of active vertices/primitives in the wave. A per-invocation
-                             // SPIR-V shader has no wave to pack (each invocation is one vertex), so leave
-                             // EXEC full — no narrowing. Non-EXEC 64-bit shifts stay unsupported.
-                             // (RE-TAG: NGG exec packing.)
-                    if (in.dst.value != 126 && in.dst.value != 127) ok = false;
-                    break;
                 case 0x26: d = b.ibin(Op_IMul, a, c); break;         // s_mul_i32 (low 32 bits; no SCC)
                 case 0x31: d = b.ibin(Op_IAdd, b.ibin(Op_ShiftLeftLogical, a, b.uconst(4)), c); break;  // s_lshl4_add_u32 = (src0<<4)+src1
                 case 0x35: d = b.umul_hi(a, c); break;               // s_mul_hi_u32 (high 32 bits; no SCC)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -172,6 +172,15 @@ struct UnwindModuleDesc {
 // Install module unwind descriptors (call after images are mapped). Enables sceKernelGetModuleInfoForUnwind.
 void set_unwind_modules(const UnwindModuleDesc* descs, size_t count);
 
+// Windows-only fatal-fault diagnostics. Other hosts provide empty implementations.
+void trace_guest_stack_query(uint64_t target, bool found, void* base, size_t size);
+void trace_guest_thread_lifecycle(bool starting, uint64_t pthread_id, uint64_t native_id,
+                                  void* stack_base, size_t stack_size);
+// Windows cooperative exception checkpoint used when a target was woken from a registered HLE wait.
+// Other hosts provide an empty implementation.
+void dispatch_pending_guest_exception();
+void dump_guest_exception_trace();
+
 // Register the linked program's global export table (NID -> absolute guest address) so
 // sceKernelDlsym can resolve exported symbols by name. Unity's native-plugin loader dlsym's
 // UnityPluginLoad / PSN_PrxInitialize / etc. by name; k_dlsym hashes the name (nid_hash) and

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <thread>
 #include <atomic>
+#include <array>
 #include <condition_variable>
 #include <new>
 #ifdef _WIN32
@@ -155,6 +156,50 @@ HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { free(*(void**)a0); *(voi
 // CONFIDENCE: HIGH (semantics cross-checked against FreeBSD libthr + the Kyty reference).
 namespace {
     inline bool pt_static_sentinel(void* v) { return (uintptr_t)v < 0x1000; }  // NULL/1/2/3... = static initializer
+    struct GuestMutexState { int type = PTHREAD_MUTEX_NORMAL; uint64_t owner = 0; uint32_t depth = 0; };
+    std::mutex g_guest_mutex_state_mutex;
+    std::unordered_map<pthread_mutex_t*, GuestMutexState> g_guest_mutex_states;
+
+    void guest_mutex_register(pthread_mutex_t* mutex, int type) {
+        std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
+        g_guest_mutex_states[mutex] = {type, 0, 0};
+    }
+    void guest_mutex_unregister(pthread_mutex_t* mutex) {
+        std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
+        g_guest_mutex_states.erase(mutex);
+    }
+    bool guest_mutex_self_deadlock(pthread_mutex_t* mutex) {
+        std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
+        auto found = g_guest_mutex_states.find(mutex);
+        return found != g_guest_mutex_states.end() &&
+               found->second.type == PTHREAD_MUTEX_ERRORCHECK &&
+               found->second.owner == (uint64_t)pthread_self();
+    }
+    void guest_mutex_acquired(pthread_mutex_t* mutex) {
+        std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
+        auto found = g_guest_mutex_states.find(mutex);
+        if (found == g_guest_mutex_states.end()) return;
+        const uint64_t self = (uint64_t)pthread_self();
+        if (found->second.owner == self) {
+            ++found->second.depth;
+        } else {
+            found->second.owner = self;
+            found->second.depth = 1;
+        }
+    }
+    void guest_mutex_released(pthread_mutex_t* mutex) {
+        std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
+        auto found = g_guest_mutex_states.find(mutex);
+        if (found == g_guest_mutex_states.end() ||
+            found->second.owner != (uint64_t)pthread_self()) return;
+        if (found->second.depth > 1) {
+            --found->second.depth;
+        } else {
+            found->second.owner = 0;
+            found->second.depth = 0;
+        }
+    }
+
     pthread_mutex_t* ensure_mutex(uint64_t slot_addr) {
         if (!slot_addr) return nullptr;
         void** slot = (void**)(uintptr_t)slot_addr;
@@ -162,6 +207,7 @@ namespace {
         if (!pt_static_sentinel(cur)) return (pthread_mutex_t*)cur;
         auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
         pthread_mutexattr_t at; pthread_mutexattr_init(&at);
+        pthread_mutexattr_settype(&at, PTHREAD_MUTEX_ERRORCHECK);
         // The FreeBSD static sentinel ENCODES the type: NULL = PTHREAD_MUTEX_INITIALIZER (the
         // DEFAULT type, which is ERRORCHECK on FreeBSD), 1 = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP.
         // BOTH map to host ERRORCHECK: FreeBSD's self-lock contract returns EDEADLK for the
@@ -170,8 +216,10 @@ namespace {
         pthread_mutex_init(m, &at);
         pthread_mutexattr_destroy(&at);
         if (__atomic_compare_exchange_n(slot, &cur, (void*)m, false,
-                                        __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+                                        __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+            guest_mutex_register(m, PTHREAD_MUTEX_ERRORCHECK);
             return m;
+        }
         pthread_mutex_destroy(m); free(m);          // lost the init race: use the winner's object
         return (pthread_mutex_t*)cur;
     }
@@ -224,6 +272,8 @@ HLE(k_mutex_init) {
     pthread_mutexattr_t* at = (a1 && !pt_static_sentinel(*(void**)a1)) ? (pthread_mutexattr_t*)*(void**)a1 : nullptr;
     pthread_mutexattr_t def;
     if (!at) { pthread_mutexattr_init(&def); pthread_mutexattr_settype(&def, PTHREAD_MUTEX_ERRORCHECK); at = &def; }
+    int host_type = PTHREAD_MUTEX_NORMAL;
+    pthread_mutexattr_gettype(at, &host_type);
     pthread_mutex_init(m, at);
     static const bool mtxlog = getenv("PROSPER_MUTEXLOG") != nullptr;
     if (mtxlog) {
@@ -233,6 +283,7 @@ HLE(k_mutex_init) {
     }
     if (at == &def) pthread_mutexattr_destroy(&def);
     *(void**)a0 = m;
+    guest_mutex_register(m, host_type);
     return 0;
 }
 // The guest sees FreeBSD errno values; EBUSY(16)/EPERM(1)/EINVAL(22) coincide with both Linux and
@@ -244,7 +295,7 @@ namespace { inline uint64_t fbsd_errno(int host) {
     if (host == EDEADLK) return 11;
     return (uint64_t)(unsigned)host;
 } }
-HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
+HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); pthread_mutex_destroy(m); free(m); } if (a0) *(void**)a0 = nullptr; return 0; }
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
 // with the guest slot address and the host object it resolved to. Diagnostic for the macOS
 // guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
@@ -259,20 +310,40 @@ namespace {
         return fbsd_errno(host);
     }
 }
-HLE(k_mutex_lock)    { auto* m = ensure_mutex(a0); return m ? mtx_report("lock",    a0, m, pthread_mutex_lock(m))    : 0x16; }
-HLE(k_mutex_trylock) { auto* m = ensure_mutex(a0); return m ? mtx_report("trylock", a0, m, pthread_mutex_trylock(m)) : 0x16; }
-HLE(k_mutex_unlock)  { auto* m = ensure_mutex(a0); return m ? mtx_report("unlock",  a0, m, pthread_mutex_unlock(m))  : 0x16; }
+HLE(k_mutex_lock)    {
+    auto* m = ensure_mutex(a0); if (!m) return 0x16;
+    if (guest_mutex_self_deadlock(m)) return mtx_report("lock", a0, m, EDEADLK);
+    const int result = interruptible_mutex_lock(m);
+    if (result == 0) guest_mutex_acquired(m);
+    return mtx_report("lock", a0, m, result);
+}
+HLE(k_mutex_trylock) {
+    auto* m = ensure_mutex(a0); if (!m) return 0x16;
+    const int result = pthread_mutex_trylock(m);
+    if (result == 0) guest_mutex_acquired(m);
+    return mtx_report("trylock", a0, m, result);
+}
+HLE(k_mutex_unlock)  {
+    auto* m = ensure_mutex(a0); if (!m) return 0x16;
+    const int result = pthread_mutex_unlock(m);
+    if (result == 0) guest_mutex_released(m);
+    return mtx_report("unlock", a0, m, result);
+}
 
 // --- condition variables ---
 HLE(k_condattr_init)    { if (a0) { auto* c = (pthread_condattr_t*)calloc(1, sizeof(pthread_condattr_t)); pthread_condattr_init(c); *(void**)a0 = c; } return 0; }
 HLE(k_condattr_destroy) { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 HLE(k_cond_init)      { if (!a0) return 0x16; auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)a0 = c; return 0; }
 HLE(k_cond_destroy)   { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_cond_destroy((pthread_cond_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
-HLE(k_cond_signal)    { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) pthread_cond_signal(c); return 0; }
-HLE(k_cond_broadcast) { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) pthread_cond_broadcast(c); return 0; }
+HLE(k_cond_signal)    { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_signal(c); return 0; }
+HLE(k_cond_broadcast) { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_broadcast(c); return 0; }
 HLE(k_cond_wait)      { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
     { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
-      if (c && m) pthread_cond_wait(c, m); }
+      if (c && m) {
+          guest_mutex_released(m);
+          const int result = interruptible_cond_wait(c, m);
+          if (result == 0) guest_mutex_acquired(m);
+      } }
     if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
 // POSIX pthread_cond_timedwait(cond_slot, mutex_slot, const timespec* abstime) — abstime is an
 // ABSOLUTE CLOCK_REALTIME deadline ({i64 sec, i64 nsec}, FreeBSD == Linux x86-64 layout), and the
@@ -286,10 +357,17 @@ HLE(k_cond_wait)      { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.ent
 HLE(k_cond_timedwait) {
     auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
     if (!c || !m) return 22;                                   // EINVAL
-    if (!a2) { pthread_cond_wait(c, m); return 0; }
+    if (!a2) {
+        guest_mutex_released(m);
+        int rc = interruptible_cond_wait(c, m);
+        if (rc == 0) guest_mutex_acquired(m);
+        return (uint64_t)rc;
+    }
     const int64_t* gts = (const int64_t*)(uintptr_t)a2;
     struct timespec dl { (time_t)gts[0], (long)gts[1] };
-    int rc = pthread_cond_timedwait(c, m, &dl);
+    guest_mutex_released(m);
+    int rc = interruptible_cond_timedwait(c, m, &dl);
+    if (rc == 0 || rc == ETIMEDOUT) guest_mutex_acquired(m);
     if (rc == ETIMEDOUT) return 60;                            // FreeBSD ETIMEDOUT
     return (uint64_t)rc;
 }
@@ -398,8 +476,15 @@ HLE(k_attr_get) {
     if (a1 && *(void**)a1) {
         auto* at = (pthread_attr_t*)*(void**)a1;
         void* base = nullptr; size_t sz = 0;
-        bool ok = (a0 && guest_stack_for_thread(a0, &base, &sz)) ||
-                  guest_stack_for_current_thread(&base, &sz);
+        // A supplied handle names a specific thread. Never replace a failed target lookup with
+        // the caller's stack: a collector querying a parked worker would then scan itself.
+        bool ok = a0 ? guest_stack_for_thread(a0, &base, &sz)
+                     : guest_stack_for_current_thread(&base, &sz);
+#ifdef _WIN32
+        const uint64_t self = (uint64_t)pthread_self();
+        if (!ok || (a0 && a0 != self))
+            trace_guest_stack_query(a0, ok, base, sz);
+#endif
         if (ok) pthread_attr_setstack(at, base, sz);   // real, tracked stack for that thread
         // else: leave the attr as-is (avoid the fragile pthread_getattr_np)
     }
@@ -534,9 +619,15 @@ void* win_thread_trampoline(void* p) {
     GetCurrentThreadStackLimits(&stk_lo, &stk_hi);
     if (stk_lo && stk_hi > stk_lo)
         register_thread_stack((uint64_t)GetCurrentThreadId(), (void*)stk_lo, (uint64_t)(stk_hi - stk_lo));
+    trace_guest_thread_lifecycle(true, (uint64_t)pthread_self(),
+                                 (uint64_t)GetCurrentThreadId(), (void*)stk_lo,
+                                 (size_t)(stk_hi - stk_lo));
     guest_tls_activate_thread();   // this worker's guest %fs TCB (FSGSBASE); no-op if the gate is off
     void* rv = entry ? (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0) : nullptr;
     tls_dtv_purge_current_thread();
+    trace_guest_thread_lifecycle(false, (uint64_t)pthread_self(),
+                                 (uint64_t)GetCurrentThreadId(), (void*)stk_lo,
+                                 (size_t)(stk_hi - stk_lo));
     unregister_thread_stack((uint64_t)GetCurrentThreadId());   // ids recycle; stale bounds = wrong bounds
     return rv;
 }
@@ -605,6 +696,12 @@ HLE(k_pthread_exit)   {
     tls_dtv_purge_current_thread();
 #if defined(__linux__) || defined(__APPLE__)
     unregister_thread_stack((uint64_t)pthread_self());
+#elif defined(_WIN32)
+    void* stack_base = nullptr; size_t stack_size = 0;
+    guest_stack_for_current_thread(&stack_base, &stack_size);
+    trace_guest_thread_lifecycle(false, (uint64_t)pthread_self(),
+                                 (uint64_t)GetCurrentThreadId(), stack_base, stack_size);
+    unregister_thread_stack((uint64_t)GetCurrentThreadId());
 #endif
     pthread_exit((void*)(uintptr_t)a0);
     return 0;
@@ -660,16 +757,16 @@ HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
 }
 HLE(k_ef_delete)  {
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
-    pthread_mutex_lock(&e->m);
+    interruptible_mutex_lock(&e->m);
     e->deleted = true;
-    pthread_cond_broadcast(&e->c);                 // wake every waiter -> they return EACCES
+    interruptible_cond_broadcast(&e->c);           // wake every waiter -> they return EACCES
     bool has_waiters = e->waiters > 0;
     pthread_mutex_unlock(&e->m);
     if (!has_waiters) ef_destroy(e);               // none parked -> free now; else the last waiter frees
     return 0;
 }
-HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; if (sclog()) fprintf(stderr, "[sync2] T%ld EF.set       ef=0x%llx bits|=0x%llx\n", sctid(), (unsigned long long)a0, (unsigned long long)a1); pthread_mutex_lock(&e->m); e->bits |= a1; pthread_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
-HLE(k_ef_clear)   { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; pthread_mutex_lock(&e->m); e->bits &= a1; pthread_mutex_unlock(&e->m); return 0; }
+HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; if (sclog()) fprintf(stderr, "[sync2] T%ld EF.set       ef=0x%llx bits|=0x%llx\n", sctid(), (unsigned long long)a0, (unsigned long long)a1); interruptible_mutex_lock(&e->m); e->bits |= a1; interruptible_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
+HLE(k_ef_clear)   { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; interruptible_mutex_lock(&e->m); e->bits &= a1; pthread_mutex_unlock(&e->m); return 0; }
 // Absolute CLOCK_REALTIME deadline `usec` microseconds from now (for pthread_cond_timedwait
 // on default-attr condvars, which time against CLOCK_REALTIME).
 static timespec abs_deadline_us(uint64_t usec) {
@@ -685,8 +782,10 @@ static timespec abs_deadline_us(uint64_t usec) {
 // root-caused for null static locks). ETIMEDOUT -> FreeBSD 60 (fbsd_errno doesn't remap it).
 HLE(k_mutex_timedlock) {
     auto* m = ensure_mutex(a0); if (!m) return 0x16;   // EINVAL
+    if (guest_mutex_self_deadlock(m)) return 11u;
     timespec dl = abs_deadline_us(a1);
     int rc = pthread_mutex_timedlock(m, &dl);
+    if (rc == 0) guest_mutex_acquired(m);
     return rc == ETIMEDOUT ? 60u : fbsd_errno(rc);
 }
 // scePthreadCondTimedwait(cond, mutex, SceKernelUseconds usec): the Sony 3rd arg is a RELATIVE µs scalar,
@@ -697,7 +796,7 @@ HLE(k_cond_timedwait_sce) {
     auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
     if (!c || !m) return 0x16;                          // EINVAL
     timespec dl = abs_deadline_us(a2);
-    int rc = pthread_cond_timedwait(c, m, &dl);
+    int rc = interruptible_cond_timedwait(c, m, &dl);
     return rc == ETIMEDOUT ? 60u : (uint64_t)rc;        // FreeBSD ETIMEDOUT
 }
 // scePthreadRwlockTimedrd/wrlock(rwlock, SceKernelUseconds usec): acquire with a RELATIVE µs timeout.
@@ -743,7 +842,7 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
     if (sclog()) fprintf(stderr, "[sync2] T%ld EF.wait.ent  ef=0x%llx pat=0x%llx mode=0x%llx bits=0x%llx\n",
                          sctid(), (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
                          (unsigned long long)e->bits);
-    pthread_mutex_lock(&e->m);
+    interruptible_mutex_lock(&e->m);
     e->waiters++;
     if (a4) {
         uint32_t usec = *(uint32_t*)(uintptr_t)a4;
@@ -751,7 +850,7 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
         timespec dl = abs_deadline_us(usec);
         int rc = 0;
         while (!evf_match(e->bits, a1, (uint32_t)a2) && rc != ETIMEDOUT && !e->deleted)
-            rc = pthread_cond_timedwait(&e->c, &e->m, &dl);
+            rc = interruptible_cond_timedwait(&e->c, &e->m, &dl);
         timespec t1; clock_gettime(CLOCK_MONOTONIC, &t1);
         int64_t spent_i = (int64_t)(t1.tv_sec - t0.tv_sec) * 1000000
                         + ((int64_t)t1.tv_nsec - (int64_t)t0.tv_nsec) / 1000;
@@ -759,7 +858,7 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
         *(uint32_t*)(uintptr_t)a4 = spent >= usec ? 0u : (uint32_t)(usec - spent);
         if (!e->deleted && !evf_match(e->bits, a1, (uint32_t)a2)) ret = 0x8002003Cull;  // ETIMEDOUT
     } else {
-        while (!evf_match(e->bits, a1, (uint32_t)a2) && !e->deleted) pthread_cond_wait(&e->c, &e->m);
+        while (!evf_match(e->bits, a1, (uint32_t)a2) && !e->deleted) interruptible_cond_wait(&e->c, &e->m);
     }
     bool deleted = e->deleted;                     // deleted under us -> EACCES (Kyty EventFlag.cpp)
     if (deleted) ret = 0x8002000Dull;
@@ -775,7 +874,7 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
 }
 HLE(k_ef_poll)    { // (ef, pattern, waitMode, resultPat*)
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
-    pthread_mutex_lock(&e->m);
+    interruptible_mutex_lock(&e->m);
     bool ok = evf_match(e->bits, a1, (uint32_t)a2); uint64_t res = e->bits;
     if (ok) { if (a2 & 0x10) e->bits = 0; else if (a2 & 0x20) e->bits &= ~a1; }
     pthread_mutex_unlock(&e->m);
@@ -801,9 +900,9 @@ HLE(k_sema_create) { // (sema*, name, attr, initCount, maxCount, opt)
 }
 HLE(k_sema_delete) {
     auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0;
-    pthread_mutex_lock(&s->m);
+    interruptible_mutex_lock(&s->m);
     s->deleted = true;
-    pthread_cond_broadcast(&s->c);
+    interruptible_cond_broadcast(&s->c);
     bool has_waiters = s->waiters > 0;
     pthread_mutex_unlock(&s->m);
     if (!has_waiters) sema_destroy(s);
@@ -813,14 +912,15 @@ HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout hon
     auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
     if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
     uint64_t ret = 0;
-    pthread_mutex_lock(&s->m);
+    interruptible_mutex_lock(&s->m);
     s->waiters++;
     if (a2) {
         uint32_t usec = *(uint32_t*)(uintptr_t)a2;
         timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
         timespec dl = abs_deadline_us(usec);
         int rc = 0;
-        while (s->count < need && rc != ETIMEDOUT && !s->deleted) rc = pthread_cond_timedwait(&s->c, &s->m, &dl);
+        while (s->count < need && rc != ETIMEDOUT && !s->deleted)
+            rc = interruptible_cond_timedwait(&s->c, &s->m, &dl);
         timespec t1; clock_gettime(CLOCK_MONOTONIC, &t1);
         int64_t spent_i = (int64_t)(t1.tv_sec - t0.tv_sec) * 1000000
                         + ((int64_t)t1.tv_nsec - (int64_t)t0.tv_nsec) / 1000;
@@ -828,7 +928,7 @@ HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout hon
         *(uint32_t*)(uintptr_t)a2 = spent >= usec ? 0u : (uint32_t)(usec - spent);
         if (!s->deleted && s->count < need) ret = 0x8002003Cull;    // KERNEL_ERROR_ETIMEDOUT
     } else {
-        while (s->count < need && !s->deleted) pthread_cond_wait(&s->c, &s->m);
+        while (s->count < need && !s->deleted) interruptible_cond_wait(&s->c, &s->m);
     }
     bool deleted = s->deleted;                       // deleted under us -> EACCES
     if (deleted) ret = 0x8002000Dull;
@@ -839,9 +939,9 @@ HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout hon
     return ret; }
 HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n = a1 ? (int64_t)a1 : 1;
     if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
-    pthread_mutex_lock(&s->m); s->count += n; pthread_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
+    interruptible_mutex_lock(&s->m); s->count += n; interruptible_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
 HLE(k_sema_poll)   { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
-    pthread_mutex_lock(&s->m); bool ok = s->count >= need; if (ok) s->count -= need; pthread_mutex_unlock(&s->m); return ok ? 0 : 0x80020023; }
+    interruptible_mutex_lock(&s->m); bool ok = s->count >= need; if (ok) s->count -= need; pthread_mutex_unlock(&s->m); return ok ? 0 : 0x80020023; }
 
 // ---- C++ exception unwinding: sceKernelGetModuleInfoForUnwind (libkernel RpQJJVKTiFM) ----
 // The guest's libunwind calls this per code address to locate that module's .eh_frame_hdr for stack
@@ -1044,15 +1144,198 @@ void ensure_exc_sig() {
     sigaction(g_exc_sig, &sa, nullptr);
 }
 #elif defined(_WIN32)
+struct WinExcStackSlot {
+    std::atomic<uint64_t> thread{0};
+    std::atomic<uintptr_t> base{0};
+    std::atomic<uint32_t> active{0};
+    std::mutex raise_mutex;
+};
+constexpr DWORD kWinExcContextFlags = CONTEXT_ALL | CONTEXT_XSTATE;
+constexpr size_t kWinExcContextBufferSize = 64 * 1024;
 struct WinExcDelivery {
-    CONTEXT saved{};
+    alignas(64) std::array<uint8_t, kWinExcContextBufferSize> context_storage{};
+    PCONTEXT saved = nullptr;
     uint64_t type = 0;
     uint64_t handler = 0;
 };
+constexpr size_t kWinExcStackSize = 256 * 1024;
+std::array<WinExcStackSlot, 1024> g_win_exc_stacks;
+std::atomic<uint32_t> g_win_exc_active_busy{0};
+std::atomic<uint32_t> g_win_exc_suspended_busy{0};
+enum class WinExcTraceKind : uint32_t {
+    Redirect = 1, Enter = 2, Exit = 3, Reject = 4,
+    StackQuery = 5, ThreadStart = 6, ThreadExit = 7,
+    CoopQueue = 8, CoopEnter = 9, CoopExit = 10,
+};
+struct WinExcTraceEvent {
+    std::atomic<uint64_t> published{0};
+    uint64_t sequence = 0;
+    WinExcTraceKind kind = WinExcTraceKind::Redirect;
+    uint32_t windows_tid = 0;
+    uint64_t target = 0;
+    uint64_t rip = 0;
+    uint64_t rsp = 0;
+    uint64_t extra = 0;
+};
+std::array<WinExcTraceEvent, 1024> g_win_exc_trace;
+std::atomic<uint64_t> g_win_exc_trace_sequence{0};
+bool g_win_exc_trace_enabled = true;
+
+enum class WinCoopState : uint32_t { Idle, Publishing, Queued, Running };
+struct WinCoopSlot {
+    std::atomic<uint64_t> thread{0};
+    std::atomic<WinCoopState> state{WinCoopState::Idle};
+    std::atomic<uint64_t> type{0};
+    std::atomic<uintptr_t> stack_base{0};
+    alignas(16) CONTEXT captured{};
+    alignas(16) std::array<uint8_t, 0x400> guest_context{};
+};
+std::array<WinCoopSlot, 1024> g_win_coop_slots;
+std::atomic<uint32_t> g_win_coop_queued{0};
+
+void win_exc_trace(WinExcTraceKind kind, uint64_t target, uint32_t windows_tid,
+                   uint64_t rip, uint64_t rsp, uint64_t extra = 0);
+
+WinCoopSlot* win_coop_slot_for(uint64_t thread, bool create) {
+    for (;;) {
+        bool initializing = false;
+        for (WinCoopSlot& slot : g_win_coop_slots) {
+            uint64_t owner = slot.thread.load(std::memory_order_acquire);
+            if (owner == thread) {
+                if (slot.stack_base.load(std::memory_order_acquire)) return &slot;
+                initializing = true;
+                continue;
+            }
+            if (!create || owner != 0 || !slot.thread.compare_exchange_strong(
+                    owner, thread, std::memory_order_acq_rel))
+                continue;
+
+            void* base = VirtualAlloc(nullptr, kWinExcStackSize,
+                                      MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            if (!base) {
+                slot.thread.store(0, std::memory_order_release);
+                return nullptr;
+            }
+            slot.stack_base.store((uintptr_t)base, std::memory_order_release);
+            return &slot;
+        }
+        if (initializing) {
+            SwitchToThread();
+            continue;
+        }
+        return nullptr;
+    }
+}
+
+enum class WinCoopQueueResult { Fallback, Queued, Busy };
+WinCoopQueueResult try_queue_wait_exception(uint64_t target, uint64_t type) {
+    if (getenv("PROSPER_WIN_LEGACY_EXC")) return WinCoopQueueResult::Fallback;
+    WinCoopSlot* slot = win_coop_slot_for(target, true);
+    if (!slot) return WinCoopQueueResult::Fallback;
+    WinCoopState expected = WinCoopState::Idle;
+    if (!slot->state.compare_exchange_strong(expected, WinCoopState::Publishing,
+                                              std::memory_order_acq_rel))
+        return WinCoopQueueResult::Busy;
+    slot->type.store(type, std::memory_order_relaxed);
+    slot->state.store(WinCoopState::Queued, std::memory_order_release);
+    g_win_coop_queued.fetch_add(1, std::memory_order_release);
+    const bool interrupted = interrupt_guest_wait(target);
+    HANDLE target_handle = (HANDLE)pthread_gethandle((pthread_t)target);
+    win_exc_trace(WinExcTraceKind::CoopQueue, target,
+                  target_handle && target_handle != INVALID_HANDLE_VALUE
+                      ? GetThreadId(target_handle) : 0,
+                  type, 0, interrupted ? 1 : 0);
+
+    // The target claims Queued at the wrapper checkpoint before executing the handler. A bounded
+    // handoff closes the race where it left the wait just before our wake. If it does not accept
+    // immediately, leave the request queued: every Windows HLE return is also a safe point, so the
+    // target will acknowledge at its next guest/host boundary without restoring stale native state.
+    for (unsigned spin = 0; spin < 20; ++spin) {
+        if (slot->state.load(std::memory_order_acquire) != WinCoopState::Queued)
+            return WinCoopQueueResult::Queued;
+        Sleep(1);
+    }
+    return WinCoopQueueResult::Queued;
+}
+
+void win_exc_trace(WinExcTraceKind kind, uint64_t target, uint32_t windows_tid,
+                   uint64_t rip, uint64_t rsp, uint64_t extra) {
+    if (!g_win_exc_trace_enabled) return;
+    const uint64_t sequence = g_win_exc_trace_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    WinExcTraceEvent& event = g_win_exc_trace[(sequence - 1) % g_win_exc_trace.size()];
+    event.published.store(0, std::memory_order_relaxed);
+    event.sequence = sequence;
+    event.kind = kind;
+    event.windows_tid = windows_tid;
+    event.target = target;
+    event.rip = rip;
+    event.rsp = rsp;
+    event.extra = extra;
+    event.published.store(sequence, std::memory_order_release);
+}
+
+bool win_init_xstate_context(void* storage, size_t storage_size, PCONTEXT* context) {
+    DWORD length = static_cast<DWORD>(storage_size);
+    if (!InitializeContext(storage, kWinExcContextFlags, context, &length)) return false;
+    return SetXStateFeaturesMask(*context, GetEnabledXStateFeatures()) != FALSE;
+}
+
+void win_exc_log_rejected(const char* reason, std::atomic<uint32_t>& counter,
+                          uint64_t target, uint64_t type, DWORD suspend_count = 0) {
+    const uint32_t occurrence = counter.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (occurrence > 16) return;
+    win_exc_trace(WinExcTraceKind::Reject, target, GetCurrentThreadId(), type, suspend_count);
+    char message[192];
+    const int length = std::snprintf(
+        message, sizeof(message),
+        "[exc] Windows delivery rejected reason=%s count=%u target=0x%llx type=0x%llx suspend=%lu\n",
+        reason, occurrence, (unsigned long long)target, (unsigned long long)type,
+        (unsigned long)suspend_count);
+    if (length <= 0) return;
+    DWORD written = 0;
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), message,
+              static_cast<DWORD>(std::min<int>(length, sizeof(message) - 1)), &written, nullptr);
+}
+
+WinExcStackSlot* win_exc_stack_for(uint64_t thread) {
+    for (;;) {
+        bool initializing = false;
+        for (WinExcStackSlot& slot : g_win_exc_stacks) {
+            uint64_t owner = slot.thread.load(std::memory_order_acquire);
+            if (owner == thread) {
+                const uintptr_t base = slot.base.load(std::memory_order_acquire);
+                if (base) return &slot;
+                initializing = true;
+                continue;
+            }
+            if (owner != 0 || !slot.thread.compare_exchange_strong(
+                    owner, thread, std::memory_order_acq_rel))
+                continue;
+
+            void* base = VirtualAlloc(nullptr, kWinExcStackSize,
+                                      MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            if (!base) {
+                slot.thread.store(0, std::memory_order_release);
+                return nullptr;
+            }
+            slot.base.store((uintptr_t)base, std::memory_order_release);
+            return &slot;
+        }
+        // Another raiser may be publishing this target's slot. It completes without depending on
+        // the target thread, so a scheduler handoff is sufficient and avoids duplicate stacks.
+        if (initializing) {
+            SwitchToThread();
+            continue;
+        }
+        return nullptr;
+    }
+}
 using RtlRestoreContextFn = VOID (WINAPI*)(PCONTEXT, PEXCEPTION_RECORD);
 RtlRestoreContextFn g_rtl_restore_context = nullptr;
 
 extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
+extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
+                                                  uint64_t a0, uint64_t a1);
 extern "C" __attribute__((noreturn)) void prosper_win_exc_delivery(WinExcDelivery* delivery);
 extern "C" void prosper_win_exc_thunk();
 
@@ -1072,6 +1355,30 @@ __asm__(
     "    ud2\n"
 );
 
+// Cooperative delivery must still use an alternate stack. The guest TLS allocation can sit only
+// a few hundred bytes below its normal RSP, so placing the 0x400-byte context and GC handler frames
+// there corrupts TLS even though no Windows CONTEXT redirection is involved. Unlike the injected
+// path, this helper returns to the wait wrapper normally after the guest handler is released.
+__asm__(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_call_guest_on_stack\n"
+    "prosper_call_guest_on_stack:\n"
+    "    movq %rcx, %r10\n"
+    "    movq %rdx, %rcx\n"
+    "    movq %r8, %rdx\n"
+    "    movq %r9, %r8\n"
+    "    pushq %r12\n"
+    "    movq %rsp, %r12\n"
+    "    movq %r10, %rsp\n"
+    "    andq $-16, %rsp\n"
+    "    subq $32, %rsp\n"
+    "    call prosper_call_guest_sysv\n"
+    "    movq %r12, %rsp\n"
+    "    popq %r12\n"
+    "    ret\n"
+);
+
 void win_exc_log(const char* msg) {
     if (!g_exc_log && !g_exc_log2) return;
     DWORD written = 0;
@@ -1080,25 +1387,36 @@ void win_exc_log(const char* msg) {
 
 extern "C" __attribute__((noinline, noreturn))
 void prosper_win_exc_delivery(WinExcDelivery* delivery) {
-    CONTEXT saved = delivery->saved;
+    PCONTEXT captured = delivery->saved;
     uint64_t type = delivery->type;
     uint64_t handler = delivery->handler;
+    alignas(64) std::array<uint8_t, kWinExcContextBufferSize> restore_storage{};
+    PCONTEXT saved = nullptr;
+    if (!win_init_xstate_context(restore_storage.data(), restore_storage.size(), &saved) ||
+        !CopyContext(saved, kWinExcContextFlags, captured)) {
+        TerminateProcess(GetCurrentProcess(), ERROR_INVALID_STATE);
+    }
 
     // FreeBSD amd64 mcontext layout; keep in lockstep with the POSIX signal path above.
     alignas(16) uint8_t ctx[0x400]{};
     auto WQ = [&](int off, uint64_t v) { *(uint64_t*)(ctx + off) = v; };
-    WQ(0x08, saved.Rdi); WQ(0x10, saved.Rsi); WQ(0x18, saved.Rdx); WQ(0x20, saved.Rcx);
-    WQ(0x28, saved.R8);  WQ(0x30, saved.R9);  WQ(0x38, saved.Rax); WQ(0x40, saved.Rbx);
-    WQ(0x48, saved.Rbp); WQ(0x50, saved.R10); WQ(0x58, saved.R11); WQ(0x60, saved.R12);
-    WQ(0x68, saved.R13); WQ(0x70, saved.R14); WQ(0x78, saved.R15);
-    WQ(0xA0, saved.Rip); WQ(0xB8, saved.Rsp); WQ(0xF8, saved.Rsp);
+    WQ(0x08, saved->Rdi); WQ(0x10, saved->Rsi); WQ(0x18, saved->Rdx); WQ(0x20, saved->Rcx);
+    WQ(0x28, saved->R8);  WQ(0x30, saved->R9);  WQ(0x38, saved->Rax); WQ(0x40, saved->Rbx);
+    WQ(0x48, saved->Rbp); WQ(0x50, saved->R10); WQ(0x58, saved->R11); WQ(0x60, saved->R12);
+    WQ(0x68, saved->R13); WQ(0x70, saved->R14); WQ(0x78, saved->R15);
+    WQ(0xA0, saved->Rip); WQ(0xB8, saved->Rsp); WQ(0xF8, saved->Rsp);
 
+    win_exc_trace(WinExcTraceKind::Enter, 0, GetCurrentThreadId(), saved->Rip, saved->Rsp);
     win_exc_log("[exc] handler ENTER on Windows target\n");
     prosper_call_guest_sysv(handler, type, (uint64_t)(uintptr_t)ctx);
     win_exc_log("[exc] handler EXIT on Windows target (resumed)\n");
+    win_exc_trace(WinExcTraceKind::Exit, 0, GetCurrentThreadId(), saved->Rip, saved->Rsp);
 
-    delete delivery;
-    g_rtl_restore_context(&saved, nullptr);
+    VirtualFree(delivery, 0, MEM_RELEASE);
+    // Keep the slot active through RtlRestoreContext. Clearing it here lets another raiser reuse
+    // this stack while the target is still executing on it. The next raiser reclaims the slot only
+    // after suspending the target and proving that RSP has left the dedicated exception stack.
+    g_rtl_restore_context(saved, nullptr);
     TerminateProcess(GetCurrentProcess(), ERROR_INVALID_STATE);   // RtlRestoreContext never returns
     __builtin_unreachable();
 }
@@ -1111,53 +1429,128 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     HANDLE thread = (HANDLE)pthread_gethandle((pthread_t)target);
     if (!thread || thread == INVALID_HANDLE_VALUE) return 0x80020003ull;       // ESRCH
 
-    // Allocate before suspending: the target could currently own the process heap lock.
-    auto* delivery = new (std::nothrow) WinExcDelivery;
+    const WinCoopQueueResult cooperative = try_queue_wait_exception(target, type);
+    if (cooperative == WinCoopQueueResult::Queued) return 0;
+    if (cooperative == WinCoopQueueResult::Busy) return 0x80020010ull;
+
+    // Do not use the process heap for delivery records. The target can be interrupted while it owns
+    // that heap's lock, and freeing a record from its injected handler would then deadlock before the
+    // original context gets a chance to release it.
+    auto* delivery = (WinExcDelivery*)VirtualAlloc(nullptr, sizeof(WinExcDelivery),
+                                                   MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
     if (!delivery) return 0x8002000cull;                                      // ENOMEM
+    std::memset(delivery, 0, sizeof(*delivery));
     delivery->type = type;
     delivery->handler = g_exc_handlers[type];
+    WinExcStackSlot* stack_slot = win_exc_stack_for(target);
+    if (!stack_slot) {
+        VirtualFree(delivery, 0, MEM_RELEASE);
+        return 0x8002000cull;
+    }
+    std::lock_guard<std::mutex> raise_lock(stack_slot->raise_mutex);
+    const uintptr_t exception_stack = stack_slot->base.load(std::memory_order_acquire);
 
-    DWORD previous_suspend = SuspendThread(thread);
-    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); delete delivery; return 0x80020000ull | (e & 0xffff); }
+    CONTEXT captured{};
+    bool target_suspended = false;
+    if (stack_slot->active.load(std::memory_order_acquire)) {
+        DWORD previous_suspend = SuspendThread(thread);
+        if (previous_suspend == (DWORD)-1) {
+            DWORD e = GetLastError();
+            VirtualFree(delivery, 0, MEM_RELEASE);
+            return 0x80020000ull | (e & 0xffff);
+        }
+        if (previous_suspend != 0) {
+            ResumeThread(thread);
+            win_exc_log_rejected("already-suspended", g_win_exc_suspended_busy,
+                                 target, type, previous_suspend);
+            VirtualFree(delivery, 0, MEM_RELEASE);
+            return 0x80020010ull;
+        }
+        target_suspended = true;
+        captured.ContextFlags = CONTEXT_CONTROL;
+        if (!GetThreadContext(thread, &captured)) {
+            DWORD e = GetLastError();
+            ResumeThread(thread);
+            VirtualFree(delivery, 0, MEM_RELEASE);
+            return 0x80020000ull | (e & 0xffff);
+        }
+        const uintptr_t rsp = static_cast<uintptr_t>(captured.Rsp);
+        if (rsp >= exception_stack && rsp < exception_stack + kWinExcStackSize) {
+            ResumeThread(thread);
+            win_exc_log_rejected("active", g_win_exc_active_busy, target, type);
+            VirtualFree(delivery, 0, MEM_RELEASE);
+            return 0x80020010ull;
+        }
+        // The prior handler completed and restored ordinary guest execution. Its active bit was
+        // intentionally retained to protect the exception stack during RtlRestoreContext; this
+        // suspended context proves the stack can now be reused for the new delivery.
+    } else {
+        stack_slot->active.store(1, std::memory_order_release);
+    }
+
+    DWORD previous_suspend = target_suspended ? 0 : SuspendThread(thread);
+    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE); return 0x80020000ull | (e & 0xffff); }
     if (previous_suspend != 0) {
         ResumeThread(thread);
-        delete delivery;
+        win_exc_log_rejected("already-suspended", g_win_exc_suspended_busy,
+                             target, type, previous_suspend);
+        stack_slot->active.store(0, std::memory_order_release);
+        VirtualFree(delivery, 0, MEM_RELEASE);
         return 0x80020010ull;                                                 // EBUSY
     }
 
-    delivery->saved.ContextFlags = CONTEXT_ALL;
-    if (!GetThreadContext(thread, &delivery->saved)) {
-        DWORD e = GetLastError(); ResumeThread(thread); delete delivery;
+    if (!win_init_xstate_context(delivery->context_storage.data(),
+                                 delivery->context_storage.size(), &delivery->saved)) {
+        ResumeThread(thread);
+        stack_slot->active.store(0, std::memory_order_release);
+        VirtualFree(delivery, 0, MEM_RELEASE);
+        return 0x8002000cull;
+    }
+    if (!GetThreadContext(thread, delivery->saved)) {
+        DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
         return 0x80020000ull | (e & 0xffff);
     }
+    win_exc_trace(WinExcTraceKind::Redirect, target, GetThreadId(thread),
+                  delivery->saved->Rip, delivery->saved->Rsp);
 
-    CONTEXT injected = delivery->saved;
+    CONTEXT injected = *delivery->saved;
     injected.ContextFlags = CONTEXT_FULL;
     injected.Rip = (DWORD64)(uintptr_t)&prosper_win_exc_thunk;
-    constexpr DWORD64 kGuestRedZone = 128;
-    injected.Rsp = (injected.Rsp & ~(DWORD64)0xf) - kGuestRedZone - 8;
+    // Match the POSIX SA_ONSTACK path: Unity's guest TLS can sit only a few hundred bytes below the
+    // live guest RSP, so even respecting the 128-byte red zone is insufficient for the 0x400-byte
+    // exception context and the guest GC handler's call frames.
+    injected.Rsp = ((exception_stack + kWinExcStackSize) & ~(DWORD64)0xf) - 8;
     DWORD64 delivery_ptr = (DWORD64)(uintptr_t)delivery;
     SIZE_T written = 0;
     if (!WriteProcessMemory(GetCurrentProcess(), (void*)(uintptr_t)injected.Rsp,
                             &delivery_ptr, sizeof(delivery_ptr), &written) ||
         written != sizeof(delivery_ptr)) {
-        DWORD e = GetLastError(); ResumeThread(thread); delete delivery;
+        DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
         return 0x80020000ull | (e & 0xffff);
     }
     if (!SetThreadContext(thread, &injected)) {
-        DWORD e = GetLastError(); ResumeThread(thread); delete delivery;
+        DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
         return 0x80020000ull | (e & 0xffff);
     }
+    // Wake while the target is still suspended. Its registration is stable until resume, and the
+    // wait will be ready to return as soon as Windows restores the redirected context. This avoids
+    // racing the target's wait-unregistration and the lifetime of the condition object.
+    const bool interrupted = interrupt_guest_wait(target);
     if (ResumeThread(thread) == (DWORD)-1) {
         DWORD e = GetLastError();
-        bool restored = SetThreadContext(thread, &delivery->saved) != FALSE;
-        if (restored && ResumeThread(thread) != (DWORD)-1) delete delivery;
+        bool restored = SetThreadContext(thread, delivery->saved) != FALSE;
+        if (restored && ResumeThread(thread) != (DWORD)-1) {
+            stack_slot->active.store(0, std::memory_order_release);
+            VirtualFree(delivery, 0, MEM_RELEASE);
+        }
         return 0x80020000ull | (e & 0xffff);
     }
     // A redirected Windows CONTEXT is not dispatched until a blocking syscall returns. Current
-    // IL2CPP targets commonly sit in our infinite WaitOnAddress HLE; wake its registered address
-    // after dropping the suspend count so the target enters prosper_win_exc_thunk immediately.
-    interrupt_futex_wait(target);
+    // IL2CPP targets commonly sit in a condition-variable or WaitOnAddress HLE; waking its registered
+    // object lets the target enter prosper_win_exc_thunk immediately after it is resumed.
+    if (g_exc_log2)
+        win_exc_log(interrupted ? "[exc2] Windows wait-interrupted=1\n"
+                                : "[exc2] Windows wait-interrupted=0\n");
     return 0;
 }
 
@@ -1165,6 +1558,7 @@ void ensure_exc_sig() {
     if (g_rtl_restore_context) return;
     g_exc_log = getenv("PROSPER_SYNCLOG") != nullptr;
     g_exc_log2 = getenv("PROSPER_EXCLOG") != nullptr;
+    g_win_exc_trace_enabled = getenv("PROSPER_EXC_RING_DISABLE") == nullptr;
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     g_rtl_restore_context = ntdll
         ? (RtlRestoreContextFn)GetProcAddress(ntdll, "RtlRestoreContext") : nullptr;
@@ -1174,10 +1568,103 @@ void ensure_exc_sig() {}
 #endif
 } // namespace
 
+void dump_guest_exception_trace() {
+#ifdef _WIN32
+    const uint64_t end = g_win_exc_trace_sequence.load(std::memory_order_acquire);
+    const uint64_t begin = end > 128 ? end - 127 : 1;
+    std::fprintf(stderr, "[exc-trace] recent events begin=%llu end=%llu queued=%u\n",
+                 (unsigned long long)begin, (unsigned long long)end,
+                 g_win_coop_queued.load(std::memory_order_acquire));
+    for (uint64_t sequence = begin; sequence <= end; sequence++) {
+        const WinExcTraceEvent& event = g_win_exc_trace[(sequence - 1) % g_win_exc_trace.size()];
+        if (event.published.load(std::memory_order_acquire) != sequence) continue;
+        const char* kind = event.kind == WinExcTraceKind::Redirect ? "redirect"
+                         : event.kind == WinExcTraceKind::Enter ? "enter"
+                         : event.kind == WinExcTraceKind::Exit ? "exit"
+                         : event.kind == WinExcTraceKind::Reject ? "reject"
+                         : event.kind == WinExcTraceKind::StackQuery ? "stack-query"
+                         : event.kind == WinExcTraceKind::ThreadStart ? "thread-start"
+                         : event.kind == WinExcTraceKind::ThreadExit ? "thread-exit"
+                         : event.kind == WinExcTraceKind::CoopQueue ? "coop-queue"
+                         : event.kind == WinExcTraceKind::CoopEnter ? "coop-enter"
+                         : "coop-exit";
+        std::fprintf(stderr,
+                     "[exc-trace] seq=%llu kind=%s tid=%lu target=0x%llx "
+                     "a=0x%llx b=0x%llx extra=0x%llx\n",
+                     (unsigned long long)sequence, kind, (unsigned long)event.windows_tid,
+                     (unsigned long long)event.target, (unsigned long long)event.rip,
+                     (unsigned long long)event.rsp, (unsigned long long)event.extra);
+    }
+#endif
+}
+
+void dispatch_pending_guest_exception() {
+#ifdef _WIN32
+    if (g_win_coop_queued.load(std::memory_order_acquire) == 0) return;
+    const uint64_t self = (uint64_t)pthread_self();
+    WinCoopSlot* slot = win_coop_slot_for(self, false);
+    if (!slot) return;
+    WinCoopState expected = WinCoopState::Queued;
+    if (!slot->state.compare_exchange_strong(expected, WinCoopState::Running,
+                                              std::memory_order_acq_rel))
+        return;
+    g_win_coop_queued.fetch_sub(1, std::memory_order_acq_rel);
+
+    const uint64_t type = slot->type.load(std::memory_order_relaxed);
+    const uint64_t handler = type < 128 ? g_exc_handlers[type] : 0;
+    if (!handler) {
+        slot->state.store(WinCoopState::Idle, std::memory_order_release);
+        return;
+    }
+
+    CONTEXT& captured = slot->captured;
+    RtlCaptureContext(&captured);
+    auto& ctx = slot->guest_context;
+    ctx.fill(0);
+    auto WQ = [&](int off, uint64_t value) { *(uint64_t*)(ctx.data() + off) = value; };
+    WQ(0x08, captured.Rdi); WQ(0x10, captured.Rsi); WQ(0x18, captured.Rdx);
+    WQ(0x20, captured.Rcx); WQ(0x28, captured.R8);  WQ(0x30, captured.R9);
+    WQ(0x38, captured.Rax); WQ(0x40, captured.Rbx); WQ(0x48, captured.Rbp);
+    WQ(0x50, captured.R10); WQ(0x58, captured.R11); WQ(0x60, captured.R12);
+    WQ(0x68, captured.R13); WQ(0x70, captured.R14); WQ(0x78, captured.R15);
+    WQ(0xA0, captured.Rip); WQ(0xB8, captured.Rsp); WQ(0xF8, captured.Rsp);
+
+    win_exc_trace(WinExcTraceKind::CoopEnter, self, GetCurrentThreadId(),
+                  captured.Rip, captured.Rsp);
+    const uintptr_t stack_top = slot->stack_base.load(std::memory_order_acquire)
+                              + kWinExcStackSize;
+    prosper_call_guest_on_stack(stack_top, handler, type,
+                                (uint64_t)(uintptr_t)ctx.data());
+    win_exc_trace(WinExcTraceKind::CoopExit, self, GetCurrentThreadId(),
+                  captured.Rip, captured.Rsp);
+    slot->state.store(WinCoopState::Idle, std::memory_order_release);
+#endif
+}
+
+void trace_guest_stack_query(uint64_t target, bool found, void* base, size_t size) {
+#ifdef _WIN32
+    win_exc_trace(WinExcTraceKind::StackQuery, target, GetCurrentThreadId(),
+                  (uint64_t)(uintptr_t)base, (uint64_t)size, found ? 1 : 0);
+#else
+    (void)target; (void)found; (void)base; (void)size;
+#endif
+}
+
+void trace_guest_thread_lifecycle(bool starting, uint64_t pthread_id, uint64_t native_id,
+                                  void* stack_base, size_t stack_size) {
+#ifdef _WIN32
+    win_exc_trace(starting ? WinExcTraceKind::ThreadStart : WinExcTraceKind::ThreadExit,
+                  pthread_id, (uint32_t)native_id, (uint64_t)(uintptr_t)stack_base,
+                  (uint64_t)stack_size);
+#else
+    (void)starting; (void)pthread_id; (void)native_id; (void)stack_base; (void)stack_size;
+#endif
+}
+
 HLE(k_install_exc_handler) {   // (exceptionType, handler, ...)
     ensure_exc_sig();
     if (a0 < 128) g_exc_handlers[a0] = a1;
-    if (getenv("PROSPER_SYNCLOG"))
+    if (g_exc_log)
         fprintf(stderr, "[exc] install type=0x%llx handler=0x%llx\n",
                 (unsigned long long)a0, (unsigned long long)a1);
     return 0;
@@ -1185,7 +1672,7 @@ HLE(k_install_exc_handler) {   // (exceptionType, handler, ...)
 HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionType, arg)
     ensure_exc_sig();
     if (g_exc_counter) (*g_exc_counter)++;
-    if (getenv("PROSPER_SYNCLOG"))
+    if (g_exc_log)
         fprintf(stderr, "[exc] T%ld raise target=0x%llx type=0x%llx\n",
                 sctid(), (unsigned long long)a0, (unsigned long long)a1);
 #if defined(__linux__) || defined(__APPLE__)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -596,10 +596,10 @@ HLE(k_wait_on_address) {
                            (long)prosper_gettid(), (unsigned long long)a0, *(uint32_t*)a0,
                            (unsigned long long)a1, pts ? (long long)(ts.tv_sec*1000000 + ts.tv_nsec/1000) : -1,
                            (unsigned long long)goff);
-    futex_wait_enter(a0); // registers this waiter so GPU-side label wakes know someone is blocked
+    WaitRegistration registration = futex_wait_enter(a0); // lets labels and GC wake this waiter
     long r = prosper_futex_wait((uint32_t*)a0, (uint32_t)a1, pts);
     int e = errno;
-    futex_wait_exit();
+    futex_wait_exit(registration);
     if (synclog()) fprintf(stderr, "[sync] T%ld WAIT.exit   addr=0x%llx r=%ld errno=%d\n",
                            (long)prosper_gettid(), (unsigned long long)a0, r, r < 0 ? e : 0);
     // Return the RIGHT status to the guest. Previously we always returned 0 (=woken/success), so on a
@@ -2100,8 +2100,11 @@ HLE(k_wait_on_address) {
     volatile uint32_t* wa = (volatile uint32_t*)(uintptr_t)a0;
     // Register as a futex waiter so the GPU command processor's RELEASE_MEM/EOP wake (wake_label_waiters,
     // which only fires when g_waiters>0) reaches this thread. RAII so every return path unregisters.
-    futex_wait_enter(a0);
-    struct WaiterGuard { ~WaiterGuard() { futex_wait_exit(); } } _waiter_guard;
+    WaitRegistration registration = futex_wait_enter(a0);
+    struct WaiterGuard {
+        WaitRegistration registration;
+        ~WaiterGuard() { futex_wait_exit(registration); }
+    } _waiter_guard{registration};
     while (*wa == expected) {
         DWORD wait_ms = INFINITE;
         if (deadline) {

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -2,6 +2,7 @@
 // libkernel stubs the engine needs during init. Cross-platform (chrono + pthread).
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "sync_futex.hpp"
 #include <pthread.h>
 #include <chrono>
 #if defined(__linux__)
@@ -361,13 +362,13 @@ HLE(k_uuid_create) {                                       // fill 16 non-zero b
 
 // --- C11 threads (used by MSVC STL std::mutex/std::condition_variable) ---
 HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t)); pthread_mutexattr_t at; pthread_mutexattr_init(&at); pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE); pthread_mutex_init(m, &at); pthread_mutexattr_destroy(&at); *(void**)P(a0) = m; } return 0; }
-HLE(m_mtx_lock)   { if (a0 && *(void**)P(a0)) pthread_mutex_lock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
+HLE(m_mtx_lock)   { if (a0 && *(void**)P(a0)) interruptible_mutex_lock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
 HLE(m_mtx_unlock) { if (a0 && *(void**)P(a0)) pthread_mutex_unlock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
 HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)P(a0)); free(*(void**)P(a0)); } return 0; }
 HLE(m_cnd_init)   { if (a0) { auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)P(a0) = c; } return 0; }
-HLE(m_cnd_signal) { if (a0 && *(void**)P(a0)) pthread_cond_signal((pthread_cond_t*)*(void**)P(a0)); return 0; }
-HLE(m_cnd_broadcast){ if (a0 && *(void**)P(a0)) pthread_cond_broadcast((pthread_cond_t*)*(void**)P(a0)); return 0; }
-HLE(m_cnd_wait)   { if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1)) pthread_cond_wait((pthread_cond_t*)*(void**)P(a0), (pthread_mutex_t*)*(void**)P(a1)); return 0; }
+HLE(m_cnd_signal) { if (a0 && *(void**)P(a0)) interruptible_cond_signal((pthread_cond_t*)*(void**)P(a0)); return 0; }
+HLE(m_cnd_broadcast){ if (a0 && *(void**)P(a0)) interruptible_cond_broadcast((pthread_cond_t*)*(void**)P(a0)); return 0; }
+HLE(m_cnd_wait)   { if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1)) interruptible_cond_wait((pthread_cond_t*)*(void**)P(a0), (pthread_mutex_t*)*(void**)P(a1)); return 0; }
 HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { pthread_cond_destroy((pthread_cond_t*)*(void**)P(a0)); free(*(void**)P(a0)); } return 0; }
 
 // --- event queue (sceKernelEqueue): kqueue-like event mechanism the engine uses for vsync/flip

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -1,5 +1,6 @@
 // sync_futex.cpp — see sync_futex.hpp.
 #include "sync_futex.hpp"
+#include "dispatch.hpp"
 #include <atomic>
 #include <climits>
 #if defined(__linux__) || defined(__APPLE__)
@@ -15,47 +16,219 @@
 #endif
 #include <windows.h>   // native futex: WakeByAddressAll (pairs with WaitOnAddress in hle_kernel_mem.cpp)
 #include <pthread.h>
-#include <mutex>
-#include <unordered_map>
+#include <array>
 #endif
 
 namespace prosper {
 namespace {
 std::atomic<int> g_waiters{0};
 #ifdef _WIN32
-std::mutex g_wait_mx;
-std::unordered_map<uint64_t, uint64_t> g_thread_waits;  // pthread_t -> guest wait address
+enum class WaitKind : uint32_t { None, Address, Sequence };
+struct WaitSlot {
+    std::atomic<uint64_t> windows_tid{0};
+    std::atomic<uintptr_t> object{0};
+    std::atomic<WaitKind> kind{WaitKind::None};
+};
+// SuspendThread can stop a target at any instruction. A mutex-protected registry can therefore
+// deadlock when the target is suspended while owning that mutex and the raising thread tries to
+// look up the wait it must wake. Fixed atomic slots keep exception delivery suspension-safe.
+std::array<WaitSlot, 1024> g_wait_slots;
+constexpr uint64_t kWaitSlotPublishing = UINT64_MAX;
+
+struct CondSlot {
+    std::atomic<uintptr_t> cond{0};
+    std::atomic<uint32_t> sequence{0};
+};
+std::array<CondSlot, 4096> g_cond_slots;
+
+CondSlot* cond_slot_for(pthread_cond_t* cond) {
+    const uintptr_t key = (uintptr_t)cond;
+    for (CondSlot& slot : g_cond_slots) {
+        uintptr_t owner = slot.cond.load(std::memory_order_acquire);
+        if (owner == key || (owner == 0 && slot.cond.compare_exchange_strong(
+                owner, key, std::memory_order_acq_rel)))
+            return &slot;
+    }
+    return nullptr;
+}
+
+WaitSlot* register_wait(WaitKind kind, uintptr_t object) {
+    const uint64_t windows_tid = GetCurrentThreadId();
+    for (WaitSlot& slot : g_wait_slots) {
+        uint64_t owner = 0;
+        if (!slot.windows_tid.compare_exchange_strong(
+                owner, kWaitSlotPublishing, std::memory_order_acq_rel))
+            continue;
+
+        // Publish the owner last. Each nested wait owns a distinct slot: the GC callback itself
+        // waits on semaphores and must not erase the interrupted outer wait when it returns.
+        slot.object.store(object, std::memory_order_relaxed);
+        slot.kind.store(kind, std::memory_order_relaxed);
+        slot.windows_tid.store(windows_tid, std::memory_order_release);
+        return &slot;
+    }
+    return nullptr;
+}
+
+void unregister_wait(WaitSlot* slot) {
+    if (!slot) return;
+    slot->windows_tid.store(0, std::memory_order_release);
+}
 #endif
 }
 
-void futex_wait_enter(uint64_t addr) {
+WaitRegistration futex_wait_enter(uint64_t addr) {
 #ifdef _WIN32
-    { std::lock_guard<std::mutex> lk(g_wait_mx); g_thread_waits[(uint64_t)pthread_self()] = addr; }
+    WaitSlot* registration = register_wait(WaitKind::Address, (uintptr_t)addr);
+    // Close queue-before-sleep: a GC stop can be published just before this wait is registered.
+    // Accept it now rather than blocking forever after the raiser's wake lookup already missed us.
+    dispatch_pending_guest_exception();
 #else
     (void)addr;
 #endif
     g_waiters.fetch_add(1, std::memory_order_seq_cst);
+#ifdef _WIN32
+    return registration;
+#else
+    return nullptr;
+#endif
 }
-void futex_wait_exit() {
+void futex_wait_exit(WaitRegistration registration) {
+#ifdef _WIN32
+    dispatch_pending_guest_exception();
+#endif
     g_waiters.fetch_sub(1, std::memory_order_seq_cst);
 #ifdef _WIN32
-    std::lock_guard<std::mutex> lk(g_wait_mx);
-    g_thread_waits.erase((uint64_t)pthread_self());
+    unregister_wait(static_cast<WaitSlot*>(registration));
+#else
+    (void)registration;
 #endif
 }
 
-bool interrupt_futex_wait(uint64_t thread) {
+int interruptible_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex) {
 #ifdef _WIN32
-    uint64_t addr = 0;
-    { std::lock_guard<std::mutex> lk(g_wait_mx);
-      auto it = g_thread_waits.find(thread);
-      if (it != g_thread_waits.end()) addr = it->second; }
-    if (addr) WakeByAddressAll((PVOID)(uintptr_t)addr);
-    return addr != 0;
+    CondSlot* slot = cond_slot_for(cond);
+    if (!slot) return ENOMEM;
+    uint32_t expected = slot->sequence.load(std::memory_order_acquire);
+    WaitSlot* registration = register_wait(WaitKind::Sequence, (uintptr_t)&slot->sequence);
+    const int unlock_result = pthread_mutex_unlock(mutex);
+    if (unlock_result != 0) {
+        unregister_wait(registration);
+        return unlock_result;
+    }
+    dispatch_pending_guest_exception();
+    WaitOnAddress((volatile void*)&slot->sequence, &expected, sizeof(expected), INFINITE);
+    dispatch_pending_guest_exception();
+    unregister_wait(registration);
+    return interruptible_mutex_lock(mutex);
+#else
+    return pthread_cond_wait(cond, mutex);
+#endif
+}
+
+int interruptible_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex,
+                                 const timespec* deadline) {
+#ifdef _WIN32
+    CondSlot* slot = cond_slot_for(cond);
+    if (!slot) return ENOMEM;
+    uint32_t expected = slot->sequence.load(std::memory_order_acquire);
+    WaitSlot* registration = register_wait(WaitKind::Sequence, (uintptr_t)&slot->sequence);
+    const int unlock_result = pthread_mutex_unlock(mutex);
+    if (unlock_result != 0) {
+        unregister_wait(registration);
+        return unlock_result;
+    }
+    dispatch_pending_guest_exception();
+
+    timespec now{};
+    clock_gettime(CLOCK_REALTIME, &now);
+    int64_t sec = (int64_t)deadline->tv_sec - (int64_t)now.tv_sec;
+    int64_t nsec = (int64_t)deadline->tv_nsec - (int64_t)now.tv_nsec;
+    if (nsec < 0) { nsec += 1000000000; sec--; }
+    DWORD timeout = 0;
+    if (sec >= 0) {
+        uint64_t ms = (uint64_t)sec * 1000 + ((uint64_t)nsec + 999999) / 1000000;
+        timeout = ms >= (uint64_t)INFINITE ? INFINITE - 1 : (DWORD)ms;
+    }
+    const bool signaled = WaitOnAddress((volatile void*)&slot->sequence, &expected,
+                                        sizeof(expected), timeout) != FALSE;
+    dispatch_pending_guest_exception();
+    unregister_wait(registration);
+    const int lock_result = interruptible_mutex_lock(mutex);
+    if (lock_result != 0) return lock_result;
+    return signaled ? 0 : ETIMEDOUT;
+#else
+    return pthread_cond_timedwait(cond, mutex, deadline);
+#endif
+}
+
+int interruptible_cond_signal(pthread_cond_t* cond) {
+#ifdef _WIN32
+    CondSlot* slot = cond_slot_for(cond);
+    if (!slot) return ENOMEM;
+    slot->sequence.fetch_add(1, std::memory_order_release);
+    WakeByAddressSingle((PVOID)&slot->sequence);
+    return 0;
+#else
+    return pthread_cond_signal(cond);
+#endif
+}
+
+int interruptible_cond_broadcast(pthread_cond_t* cond) {
+#ifdef _WIN32
+    CondSlot* slot = cond_slot_for(cond);
+    if (!slot) return ENOMEM;
+    slot->sequence.fetch_add(1, std::memory_order_release);
+    WakeByAddressAll((PVOID)&slot->sequence);
+    return 0;
+#else
+    return pthread_cond_broadcast(cond);
+#endif
+}
+
+int interruptible_mutex_lock(pthread_mutex_t* mutex) {
+#ifdef _WIN32
+    // Winpthreads' timed mutex wait has remained inside WaitForSingleObject after its absolute
+    // deadline was already seconds in the past. Polling trylock keeps the wait cooperative: a GC
+    // stop request is acknowledged even when the mutex owner is itself waiting for that thread.
+    for (;;) {
+        const int result = pthread_mutex_trylock(mutex);
+        if (result != EBUSY) return result;
+        dispatch_pending_guest_exception();
+        Sleep(1);
+    }
+#else
+    return pthread_mutex_lock(mutex);
+#endif
+}
+
+bool interrupt_guest_wait(uint64_t thread) {
+#ifdef _WIN32
+    HANDLE handle = (HANDLE)pthread_gethandle((pthread_t)thread);
+    if (!handle || handle == INVALID_HANDLE_VALUE) return false;
+    const uint64_t windows_tid = GetThreadId(handle);
+    if (!windows_tid) return false;
+    bool interrupted = false;
+    for (WaitSlot& slot : g_wait_slots) {
+        if (slot.windows_tid.load(std::memory_order_acquire) != windows_tid) continue;
+        const WaitKind kind = slot.kind.load(std::memory_order_acquire);
+        const uintptr_t object = slot.object.load(std::memory_order_relaxed);
+        if (kind == WaitKind::Address && object) {
+            WakeByAddressAll((PVOID)object);
+            interrupted = true;
+        }
+        if (kind == WaitKind::Sequence && object) {
+            auto* sequence = reinterpret_cast<std::atomic<uint32_t>*>(object);
+            sequence->fetch_add(1, std::memory_order_release);
+            WakeByAddressAll((PVOID)object);
+            interrupted = true;
+        }
+    }
+    return interrupted;
 #else
     (void)thread;
-    return false;
 #endif
+    return false;
 }
 
 void futex_wake(uint64_t addr, int n) {

--- a/prosper/src/hle/sync_futex.hpp
+++ b/prosper/src/hle/sync_futex.hpp
@@ -5,18 +5,29 @@
 // e.g. Windows WaitOnAddress — changes both sides together).
 #pragma once
 #include <cstdint>
+#include <pthread.h>
 
 namespace prosper {
 
 // Bracket a blocking guest futex wait: enter before FUTEX_WAIT, exit after it returns. Lets
 // wake_label_waiters skip its wake syscalls entirely while no thread is blocked.
-void futex_wait_enter(uint64_t addr);
-void futex_wait_exit();
+using WaitRegistration = void*;
+WaitRegistration futex_wait_enter(uint64_t addr);
+void futex_wait_exit(WaitRegistration registration);
 
-// Windows applies SetThreadContext only after a blocked syscall returns. If `thread` is currently
-// inside the HLE WaitOnAddress path, wake that exact address so an asynchronous guest exception can
-// enter its redirected context. Returns true when a registered futex wait was woken.
-bool interrupt_futex_wait(uint64_t thread);
+// Register pthread condition waits that may need interruption for asynchronous guest exception
+// delivery on Windows. Other hosts call pthread directly through these wrappers.
+int interruptible_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex);
+int interruptible_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex,
+                                 const timespec* deadline);
+int interruptible_cond_signal(pthread_cond_t* cond);
+int interruptible_cond_broadcast(pthread_cond_t* cond);
+int interruptible_mutex_lock(pthread_mutex_t* mutex);
+
+// Windows applies SetThreadContext only after a blocked syscall returns. Wake the target's exact
+// registered WaitOnAddress or pthread-condition wait so it can enter its redirected context.
+// Returns true when a registered wait was found and woken.
+bool interrupt_guest_wait(uint64_t thread);
 
 // FUTEX_WAKE up to n waiters blocked on the 32-bit word at addr. No-op when addr==0 or non-Linux.
 void futex_wake(uint64_t addr, int n);

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -19,6 +19,7 @@
 #include "../hle/dispatch.hpp"
 
 #include <windows.h>
+#include <pthread.h>
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -149,10 +150,23 @@ namespace {
         };
         memcpy(p, seq, sizeof seq); return sizeof seq;
     }
+    size_t emit_hle_return_checkpoint(uint8_t* p) {
+        size_t o = 0;
+        p[o++] = 0x48; p[o++] = 0x89; p[o++] = 0x44; p[o++] = 0x24; p[o++] = 0x20;
+                                                                        // mov [rsp+0x20],rax
+        const uint64_t checkpoint = (uint64_t)(uintptr_t)&dispatch_pending_guest_exception;
+        p[o++] = 0x49; p[o++] = 0xBB; memcpy(p + o, &checkpoint, 8); o += 8;
+                                                                        // movabs r11,checkpoint
+        p[o++] = 0x41; p[o++] = 0xFF; p[o++] = 0xD3;                    // call r11
+        p[o++] = 0x48; p[o++] = 0x8B; p[o++] = 0x44; p[o++] = 0x24; p[o++] = 0x20;
+                                                                        // mov rax,[rsp+0x20]
+        return o;
+    }
     void emit_impl(uint8_t* p, uint64_t fn) {
         size_t o = emit_sysv_to_ms_prologue(p);
         p[o++] = 0x48; p[o++] = 0xB8; memcpy(p + o, &fn, 8); o += 8;   // movabs rax,fn
         p[o++] = 0xFF; p[o++] = 0xD0;                                  // call rax
+        o += emit_hle_return_checkpoint(p + o);
         p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x48;    // add rsp,0x48
         p[o++] = 0xC3;                                                 // ret
     }
@@ -162,6 +176,7 @@ namespace {
         p[o++] = 0xB9; memcpy(p + o, &idx, 4); o += 4;                 // mov ecx,idx  (MS 1st arg)
         p[o++] = 0x48; p[o++] = 0xB8; memcpy(p + o, &fn, 8); o += 8;   // movabs rax,fn
         p[o++] = 0xFF; p[o++] = 0xD0;                                  // call rax  (prosper_on_unimpl)
+        o += emit_hle_return_checkpoint(p + o);
         p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x28;    // add rsp,0x28
         p[o++] = 0xC3;                                                 // ret
     }
@@ -174,6 +189,14 @@ namespace {
         DWORD ok = PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE
                  | PAGE_WRITECOPY | PAGE_EXECUTE_WRITECOPY;
         return (mbi.Protect & ok) != 0 && !(mbi.Protect & PAGE_GUARD);
+    }
+    bool addr_executable(uint64_t addr) {
+        MEMORY_BASIC_INFORMATION mbi;
+        if (!VirtualQuery((LPCVOID)(uintptr_t)addr, &mbi, sizeof mbi)) return false;
+        if (mbi.State != MEM_COMMIT || (mbi.Protect & PAGE_GUARD)) return false;
+        const DWORD protection = mbi.Protect & 0xff;
+        return protection == PAGE_EXECUTE || protection == PAGE_EXECUTE_READ ||
+               protection == PAGE_EXECUTE_READWRITE || protection == PAGE_EXECUTE_WRITECOPY;
     }
     // Does the instruction at p carry an %fs segment-override prefix (0x64)? Scans the legacy
     // prefixes and REX; stops at the opcode. Used to tell a drifted-guest-%fs fault (Windows zeroed
@@ -317,6 +340,38 @@ namespace {
             fprintf(stderr, "[veh] tid=%lu code=0x%lx rip=0x%llx addr=0x%llx armed=%d rstate=%d\n",
                     (unsigned long)cur_tid(), (unsigned long)code, (unsigned long long)c->Rip,
                     (unsigned long long)fa, (int)t_armed, prosper_reserved_range_state(fa));
+            if (!t_armed) {
+                fprintf(stderr,
+                        "[veh] regs rax=%016llx rbx=%016llx rcx=%016llx rdx=%016llx "
+                        "rsi=%016llx rdi=%016llx\n",
+                        (unsigned long long)c->Rax, (unsigned long long)c->Rbx,
+                        (unsigned long long)c->Rcx, (unsigned long long)c->Rdx,
+                        (unsigned long long)c->Rsi, (unsigned long long)c->Rdi);
+                fprintf(stderr,
+                        "[veh] regs rbp=%016llx rsp=%016llx r8=%016llx r9=%016llx "
+                        "r10=%016llx r11=%016llx r12=%016llx r13=%016llx "
+                        "r14=%016llx r15=%016llx\n",
+                        (unsigned long long)c->Rbp, (unsigned long long)c->Rsp,
+                        (unsigned long long)c->R8, (unsigned long long)c->R9,
+                        (unsigned long long)c->R10, (unsigned long long)c->R11,
+                        (unsigned long long)c->R12, (unsigned long long)c->R13,
+                        (unsigned long long)c->R14, (unsigned long long)c->R15);
+                fprintf(stderr, "[veh] bytes@rip:");
+                dump_fault_bytes(c->Rip, 24);
+                fprintf(stderr, "\n[veh] executable stack candidates:");
+                unsigned candidates = 0;
+                for (uint64_t offset = 0; offset < 0x400; offset += sizeof(uint64_t)) {
+                    const uint64_t slot = c->Rsp + offset;
+                    if (!addr_readable(slot)) break;
+                    const uint64_t value = *(const uint64_t*)(uintptr_t)slot;
+                    if (!addr_executable(value)) continue;
+                    fprintf(stderr, " +0x%llx=0x%llx", (unsigned long long)offset,
+                            (unsigned long long)value);
+                    if (++candidates == 24) break;
+                }
+                fprintf(stderr, "\n");
+                dump_guest_exception_trace();
+            }
         }
         if (!t_armed) return EXCEPTION_CONTINUE_SEARCH;   // worker thread with no recovery point
 
@@ -349,7 +404,7 @@ bool map_image(const LoadedImage& img, std::string* err) {
 bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                    uint64_t stub_size, std::string* err) {
     auto fail = [&](const char* s){ if (err) *err = s; return false; };
-    if (stub_size < 80) return fail("stub_size too small for Windows ABI bridge (need >= 80)");
+    if (stub_size < 96) return fail("stub_size too small for Windows ABI bridge (need >= 96)");
     if (!g_nid_db) g_nid_db = new NidDb();
     dispatch_init(&slots, g_nid_db);
 
@@ -410,12 +465,24 @@ void unregister_thread_stack(uint64_t tid) {
     std::lock_guard<std::mutex> lk(g_smx); g_stacks.erase(tid);
 }
 bool guest_stack_for_thread(uint64_t tid, void** base, size_t* size) {
-    std::lock_guard<std::mutex> lk(g_smx);
-    auto it = g_stacks.find(tid);
-    if (it == g_stacks.end()) return false;
-    if (base) *base = (void*)(uintptr_t)it->second.first;
-    if (size) *size = (size_t)it->second.second;
-    return true;
+    auto lookup = [&](uint64_t key) {
+        std::lock_guard<std::mutex> lk(g_smx);
+        auto it = g_stacks.find(key);
+        if (it == g_stacks.end()) return false;
+        if (base) *base = (void*)(uintptr_t)it->second.first;
+        if (size) *size = (size_t)it->second.second;
+        return true;
+    };
+    if (lookup(tid)) return true;
+
+    // Windows workers are registered by native thread id because exception delivery and stack
+    // limits use Win32 APIs, while the guest sees winpthreads' small pthread_t handle. Translate
+    // that handle before looking up another thread's stack. Without this, scePthreadAttrGet(target)
+    // missed every worker and IL2CPP's collector scanned the caller's stack instead.
+    HANDLE thread = (HANDLE)pthread_gethandle((pthread_t)tid);
+    if (!thread || thread == INVALID_HANDLE_VALUE) return false;
+    const DWORD native_tid = GetThreadId(thread);
+    return native_tid != 0 && native_tid != tid && lookup(native_tid);
 }
 bool guest_stack_for_current_thread(void** base, size_t* size) {
     return guest_stack_for_thread(cur_tid(), base, size);
@@ -463,6 +530,7 @@ BootResult run_entry(const LoadedImage& img) {
     BootResult r;
     if (!stk) { r.kind = 2; r.detail = "guest stack VirtualAlloc failed"; return r; }
     register_thread_stack(cur_tid(), stk, STK);
+    trace_guest_thread_lifecycle(true, (uint64_t)pthread_self(), cur_tid(), stk, STK);
 
     uint64_t top = ((uint64_t)(uintptr_t)stk + STK) & ~(uint64_t)0xf;
     std::vector<std::string> args = { "/app0/eboot.bin" };
@@ -546,6 +614,8 @@ BootResult run_entry(const LoadedImage& img) {
         }
         t_armed = 0;
     }
+    trace_guest_thread_lifecycle(false, (uint64_t)pthread_self(), cur_tid(), stk, STK);
+    unregister_thread_stack(cur_tid());
     return r;
 }
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1383,10 +1383,20 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         return true;
     };
     // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
+    const bool backend_trace = getenv("PROSPER_BACKEND_TRACE") != nullptr;
     for (size_t di = 0; di < draws.size(); di++) {
         const auto setup_begin = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         const BackendDraw& bd = draws[di];
         DV& v = dv[di];
+        if (backend_trace) {
+            fprintf(stderr,
+                    "[backend-trace] draw=%zu/%zu begin extent=%ux%u vs=%zu fs=%zu "
+                    "vs_id=%016llx fs_id=%016llx resources=%zu\n",
+                    di, draws.size(), W, H, bd.vs.size(), bd.fs.size(),
+                    (unsigned long long)bd.vs_identity,
+                    (unsigned long long)bd.fs_identity, bd.R.size());
+            fflush(stderr);
+        }
         // Pipeline hits do not need temporary VkShaderModules. Defer module creation until after the
         // persistent lookup; the fixed/resource setup below is also required by the hit pipeline.
         const auto setup_shaders_ready = setup_begin;
@@ -1878,7 +1888,17 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (create_pipeline) {
             const auto setup_shader_begin = timing_enabled
                 ? TimingClock::now() : TimingClock::time_point{};
+            if (backend_trace) {
+                fprintf(stderr, "[backend-trace] draw=%zu create-shaders begin\n", di);
+                fflush(stderr);
+            }
             v.vs = mkmod(bd.vs); v.fs = mkmod(bd.fs);
+            if (backend_trace) {
+                fprintf(stderr,
+                        "[backend-trace] draw=%zu create-shaders end vs=%p fs=%p\n",
+                        di, (void*)v.vs, (void*)v.fs);
+                fflush(stderr);
+            }
             const auto setup_shader_ready = timing_enabled
                 ? TimingClock::now() : TimingClock::time_point{};
             if (timing_enabled)
@@ -1891,8 +1911,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             }
             st[0].module = v.vs; st[1].module = v.fs;
             setup_pipeline_create_begin = setup_shader_ready;
-            if (vkCreateGraphicsPipelines(
-                    dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe) == VK_SUCCESS) {
+            if (backend_trace) {
+                fprintf(stderr, "[backend-trace] draw=%zu create-pipeline begin\n", di);
+                fflush(stderr);
+            }
+            const VkResult pipeline_result = vkCreateGraphicsPipelines(
+                    dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe);
+            if (backend_trace) {
+                fprintf(stderr,
+                        "[backend-trace] draw=%zu create-pipeline end result=%d pipeline=%p\n",
+                        di, (int)pipeline_result, (void*)v.pipe);
+                fflush(stderr);
+            }
+            if (pipeline_result == VK_SUCCESS) {
                 v.ok = true;
                 bool retain = pipeline_cache_enabled && pipeline_cache_limit;
                 while (retain && pipeline_cache.size() >= pipeline_cache_limit)
@@ -2146,7 +2177,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const auto timing_recorded = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount = 1; si.pCommandBuffers = &cmd;
     VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev, &fci, nullptr, &fence);
-    vkQueueSubmit(queue, 1, &si, fence); vkWaitForFences(dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+    if (backend_trace) {
+        fprintf(stderr, "[backend-trace] queue-submit begin draws=%zu\n", draws.size());
+        fflush(stderr);
+    }
+    const VkResult submit_result = vkQueueSubmit(queue, 1, &si, fence);
+    if (backend_trace) {
+        fprintf(stderr, "[backend-trace] queue-submit end result=%d; fence-wait begin\n",
+                (int)submit_result);
+        fflush(stderr);
+    }
+    const VkResult wait_result = vkWaitForFences(
+        dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+    if (backend_trace) {
+        fprintf(stderr, "[backend-trace] fence-wait end result=%d\n", (int)wait_result);
+        fflush(stderr);
+    }
     const auto timing_gpu_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     if (cached_ds) {
         cached_ds->layout_initialized = true;

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -83,6 +83,23 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+bool phi_ids_are_nonzero(const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpPhi = 245;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t word = spv[i];
+        const uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == OpPhi) {
+            if (wc < 5 || ((wc - 3) & 1u) != 0) return false;
+            for (uint32_t operand = 1; operand < wc; ++operand)
+                if (spv[i + operand] == 0) return false;
+        }
+        i += wc;
+    }
+    return true;
+}
+
 // Whether the module contains OpDecorate (71) with the given decoration (word[i+2]).
 bool has_decoration(const std::vector<uint32_t>& spv, uint32_t decoration) {
     enum : uint32_t { OpDecorateL = 71 };
@@ -160,6 +177,30 @@ int main() {
         return 1;
     }
     printf("  [ok]   signed kernel SPIR-V declares signed i32 with a nonzero id\n");
+
+    // NGG wave packing writes EXEC through s_lshr_b64 before later structured control flow. The
+    // instruction is mask-domain only; inserting rs.sreg[EXEC] left an SSA id 0 that a later merge
+    // emitted as an OpPhi input. NVIDIA's Windows driver faults in vkCreateGraphicsPipelines on that
+    // invalid module, so guard the exact wave-pack -> forward-if shape independently of a Vulkan driver.
+    const uint32_t ngg_exec_if[] = {
+        0x93EAFF03u, 0x00080008u, 0x876BFF03u, 0x000000FFu, 0x8F6A8C6Au,
+        0x887C6A6Bu, 0xBF900009u, 0x906A8803u, 0x81EA6A80u, 0x90FE6AC1u,
+        0xF8000941u, 0x00000000u, 0x81EA0380u, 0x90FE6AC1u,
+        0xBE80246Au,                         // s_and_saveexec_b64 s[0:1], vcc
+        0xBF880001u,                         // s_cbranch_execz +1
+        0x8AFE7E00u,                         // s_andn2_b64 exec, s[0:1], exec
+        0xBEFE0400u,                         // s_mov_b64 exec, s[0:1]
+        0x34040A81u, 0x36060AC2u, 0x7E000280u, 0x7E0202F2u, 0x36040482u,
+        0x4A0606C1u, 0x4A0404C1u, 0x7E060B03u, 0x7E040B02u,
+        0xF80008CFu, 0x01000302u, 0xBF810000u,
+    };
+    const auto ngg_exec_if_spv = recompile_vertex(
+        ngg_exec_if, sizeof(ngg_exec_if) / sizeof(ngg_exec_if[0]));
+    if (ngg_exec_if_spv.empty() || !phi_ids_are_nonzero(ngg_exec_if_spv)) {
+        printf("  [FAIL] NGG EXEC wave-pack control flow emitted a zero-id OpPhi\n");
+        return 1;
+    }
+    printf("  [ok]   NGG EXEC wave-pack control flow emits only valid nonzero OpPhi ids\n");
 
     // v_cmpx_* narrows EXEC. A FRAGMENT export under a narrowed EXEC is a discard (alpha test / kill): it
     // now lowers to a per-invocation OpKill of the inactive lanes followed by an export from the survivors,

--- a/prosper/tests/test_win_exception_delivery.cpp
+++ b/prosper/tests/test_win_exception_delivery.cpp
@@ -2,10 +2,12 @@
 // then restore the exact interrupted host context so that thread continues normally.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "../src/hle/sync_futex.hpp"
 #include <pthread.h>
 #include <windows.h>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 
 using namespace prosper;
 
@@ -15,21 +17,61 @@ static volatile DWORD worker_tid;
 static volatile DWORD handler_tid;
 static volatile uint64_t context_rip;
 static volatile uint64_t context_rsp;
+static volatile uint64_t handler_rsp;
 static volatile uint32_t wait_word;
+static volatile LONG cond_ready;
+static volatile LONG mutex_ready;
+static volatile LONG hold_handler;
+static volatile LONG release_handler;
+static volatile LONG repeat_stage;
+static volatile LONG avx_stop;
+static volatile LONG avx_test_active;
+static volatile LONG gpr_ready;
+static volatile LONG gpr_stop;
+static volatile uint64_t gpr_observed;
+static volatile LONG prewait_ready;
+static volatile LONG prewait_release;
+static volatile LONG nested_wait_enabled;
+static volatile LONG nested_wait_ready;
+static volatile LONG nested_wait_release;
+static volatile LONG nested_wait_returned;
+static volatile LONG nested_wait_finish;
+static constexpr uint64_t kGprExpected = 0xd3a5f17c2468be90ull;
+alignas(32) static uint8_t avx_expected[32];
+alignas(32) static uint8_t avx_observed[32];
 static HleFn wait_on_address;
+static pthread_mutex_t wait_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t wait_cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t blocked_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t nested_wait_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t nested_wait_cond = PTHREAD_COND_INITIALIZER;
 static int fails;
 
 #define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
                               else        { std::printf("  [ok]   %s\n", msg); } } while (0)
 
 extern "C" __attribute__((sysv_abi)) void guest_exception_handler(uint64_t type, void* raw_ctx) {
+    uint64_t stack_marker = 0;
     auto* ctx = (const uint8_t*)raw_ctx;
     handler_tid = GetCurrentThreadId();
     context_rip = *(const uint64_t*)(ctx + 0xa0);
     context_rsp = *(const uint64_t*)(ctx + 0xf8);
+    handler_rsp = (uint64_t)(uintptr_t)&stack_marker;
     if (type == 0x1e) {
         wait_word = 1;
-        InterlockedExchange(&delivered, 1);
+        InterlockedIncrement(&delivered);
+        if (avx_test_active)
+            __asm__ volatile("vpxor %%ymm0, %%ymm0, %%ymm0" ::: "ymm0");
+        while (hold_handler && !release_handler) Sleep(1);
+        if (nested_wait_enabled) {
+            pthread_mutex_lock(&nested_wait_mutex);
+            InterlockedExchange(&nested_wait_ready, 1);
+            while (!nested_wait_release)
+                interruptible_cond_wait(&nested_wait_cond, &nested_wait_mutex);
+            pthread_mutex_unlock(&nested_wait_mutex);
+            InterlockedExchange(&nested_wait_returned, 1);
+            while (!nested_wait_finish) Sleep(1);
+        }
     }
 }
 
@@ -40,8 +82,114 @@ static void* worker(void*) {
     return nullptr;
 }
 
+static void* cond_worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    pthread_mutex_lock(&wait_mutex);
+    InterlockedExchange(&cond_ready, 1);
+    interruptible_cond_wait(&wait_cond, &wait_mutex);
+    pthread_mutex_unlock(&wait_mutex);
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+static void* mutex_worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    InterlockedExchange(&mutex_ready, 1);
+    const int result = interruptible_mutex_lock(&blocked_mutex);
+    if (result == 0) pthread_mutex_unlock(&blocked_mutex);
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+static void* prewait_worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    InterlockedExchange(&prewait_ready, 1);
+    while (!prewait_release) Sleep(1);
+    pthread_mutex_lock(&wait_mutex);
+    InterlockedExchange(&cond_ready, 1);
+    interruptible_cond_wait(&wait_cond, &wait_mutex);
+    pthread_mutex_unlock(&wait_mutex);
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+static void* repeat_worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    wait_on_address((uint64_t)(uintptr_t)&wait_word, 0, 0, 0, 0, 0);
+    wait_word = 0;
+    InterlockedExchange(&repeat_stage, 1);
+    wait_on_address((uint64_t)(uintptr_t)&wait_word, 0, 0, 0, 0, 0);
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+static void* avx_worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    __asm__ volatile(
+        "vmovdqu (%0), %%ymm0\n"
+        "1:\n"
+        "cmpl $0, (%1)\n"
+        "je 1b\n"
+        "vmovdqu %%ymm0, (%2)\n"
+        "vzeroupper\n"
+        :
+        : "r"(avx_expected), "r"(&avx_stop), "r"(avx_observed)
+        : "ymm0", "memory", "cc");
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+static void* gpr_worker(void*) {
+    worker_tid = GetCurrentThreadId();
+    __asm__ volatile(
+        "movq %[expected], %%r12\n"
+        "movl $1, (%[ready])\n"
+        "1:\n"
+        "cmpl $0, (%[stop])\n"
+        "je 1b\n"
+        "movq %%r12, (%[observed])\n"
+        :
+        : [expected] "r"(kGprExpected), [ready] "r"(&gpr_ready),
+          [stop] "r"(&gpr_stop), [observed] "r"(&gpr_observed)
+        : "r12", "memory", "cc");
+    InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+static void reset_delivery_state() {
+    delivered = 0;
+    resumed = 0;
+    worker_tid = 0;
+    handler_tid = 0;
+    context_rip = 0;
+    context_rsp = 0;
+    handler_rsp = 0;
+    wait_word = 0;
+    cond_ready = 0;
+    mutex_ready = 0;
+    hold_handler = 0;
+    release_handler = 0;
+    repeat_stage = 0;
+    avx_stop = 0;
+    avx_test_active = 0;
+    gpr_ready = 0;
+    gpr_stop = 0;
+    gpr_observed = 0;
+    prewait_ready = 0;
+    prewait_release = 0;
+    nested_wait_enabled = 0;
+    nested_wait_ready = 0;
+    nested_wait_release = 0;
+    nested_wait_returned = 0;
+    nested_wait_finish = 0;
+    memset(avx_observed, 0, sizeof avx_observed);
+}
+
 int main() {
     std::printf("== test_win_exception_delivery ==\n");
+    // Exercise the forced-CONTEXT compatibility path first; production Windows runs use cooperative
+    // safe points by default. The final cases below remove this override.
+    _putenv_s("PROSPER_WIN_LEGACY_EXC", "1");
     register_builtin_hle();
     HleFn install = Hle::lookup(nid_hash("sceKernelInstallExceptionHandler"));
     HleFn raise = Hle::lookup(nid_hash("sceKernelRaiseException"));
@@ -68,7 +216,211 @@ int main() {
     CHECK(delivered != 0, "guest handler executed");
     CHECK(handler_tid == worker_tid, "guest handler executed on requested target");
     CHECK(context_rip != 0 && context_rsp != 0, "interrupted RIP and GC stack pointer captured");
+    const uint64_t stack_gap = handler_rsp > context_rsp ? handler_rsp - context_rsp
+                                                         : context_rsp - handler_rsp;
+    CHECK(stack_gap > 64 * 1024, "guest handler ran on a dedicated exception stack");
     CHECK(resumed != 0, "target resumed its interrupted context after handler return");
+
+    reset_delivery_state();
+    pthread_mutex_lock(&wait_mutex);
+    CHECK(pthread_create(&thread, nullptr, cond_worker, nullptr) == 0,
+          "create pthread-condition target thread");
+    for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+    pthread_mutex_unlock(&wait_mutex);
+    for (int i = 0; i < 1000 && !cond_ready; ++i) Sleep(1);
+    // The worker holds wait_mutex until interruptible_cond_wait has registered its pthread handle
+    // and atomically released the mutex inside pthread_cond_wait. Acquiring it here closes the race
+    // between the ready marker and the actual blocking wait.
+    pthread_mutex_lock(&wait_mutex);
+    pthread_mutex_unlock(&wait_mutex);
+    CHECK(worker_tid != 0 && cond_ready != 0, "target entered registered pthread-condition wait");
+
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "raise exception to pthread-condition target");
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) interruptible_cond_broadcast(&wait_cond);
+    pthread_join(thread, nullptr);
+
+    CHECK(delivered != 0, "guest handler executed from pthread-condition wait");
+    CHECK(handler_tid == worker_tid, "pthread-condition handler ran on requested target");
+    CHECK(context_rip != 0 && context_rsp != 0,
+          "pthread-condition interruption captured RIP and GC stack pointer");
+    CHECK(resumed != 0, "pthread-condition target resumed after handler return");
+
+    reset_delivery_state();
+    pthread_mutex_lock(&blocked_mutex);
+    CHECK(pthread_create(&thread, nullptr, mutex_worker, nullptr) == 0,
+          "create pthread-mutex target thread");
+    for (int i = 0; i < 1000 && !mutex_ready; ++i) Sleep(1);
+    CHECK(worker_tid != 0 && mutex_ready != 0, "target entered contended pthread-mutex lock");
+    Sleep(10);
+
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "raise exception to pthread-mutex target");
+    for (int i = 0; i < 2000 && !delivered; ++i) Sleep(1);
+    CHECK(delivered != 0, "guest handler interrupted contended pthread-mutex lock");
+    CHECK(handler_tid == worker_tid, "pthread-mutex handler ran on requested target");
+    pthread_mutex_unlock(&blocked_mutex);
+    pthread_join(thread, nullptr);
+    CHECK(resumed != 0, "pthread-mutex target resumed and acquired lock after handler return");
+
+    reset_delivery_state();
+    hold_handler = 1;
+    CHECK(pthread_create(&thread, nullptr, worker, nullptr) == 0,
+          "create nested-delivery target thread");
+    for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+    CHECK(worker_tid != 0, "nested-delivery target entered blocking wait");
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "start first exception delivery");
+    for (int i = 0; i < 2000 && !delivered; ++i) Sleep(1);
+    CHECK(delivered != 0, "first handler is active on its exception stack");
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0x80020010ull, "overlapping delivery to one target is rejected as EBUSY");
+    InterlockedExchange(&release_handler, 1);
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) WakeByAddressAll((void*)&wait_word);
+    pthread_join(thread, nullptr);
+    CHECK(resumed != 0, "target resumes cleanly after serialized delivery");
+
+    reset_delivery_state();
+    CHECK(pthread_create(&thread, nullptr, repeat_worker, nullptr) == 0,
+          "create repeated-delivery target thread");
+    for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+    CHECK(worker_tid != 0, "repeated-delivery target entered first wait");
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "start first serialized delivery");
+    for (int i = 0; i < 2000 && !repeat_stage; ++i) Sleep(1);
+    CHECK(repeat_stage == 1, "first delivery restored the target's original context");
+    Sleep(10);
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "reuse exception stack after restored context is observed");
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) WakeByAddressAll((void*)&wait_word);
+    pthread_join(thread, nullptr);
+    CHECK(delivered == 2, "both serialized exception handlers executed");
+    CHECK(resumed != 0, "target resumes after repeated exception delivery");
+
+    reset_delivery_state();
+    if (GetEnabledXStateFeatures() & XSTATE_MASK_AVX) {
+        for (size_t i = 0; i < sizeof avx_expected; i++)
+            avx_expected[i] = static_cast<uint8_t>(0x31u + i * 7u);
+        avx_test_active = 1;
+        CHECK(pthread_create(&thread, nullptr, avx_worker, nullptr) == 0,
+              "create AVX-state target thread");
+        for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+        CHECK(worker_tid != 0, "AVX-state target entered register-live loop");
+        result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+        CHECK(result == 0, "deliver exception while YMM register is live");
+        for (int i = 0; i < 2000 && !delivered; ++i) Sleep(1);
+        InterlockedExchange(&avx_stop, 1);
+        pthread_join(thread, nullptr);
+        CHECK(memcmp(avx_expected, avx_observed, sizeof avx_expected) == 0,
+              "extended AVX state survives injected exception handler");
+        CHECK(resumed != 0, "AVX-state target resumes after delivery");
+    } else {
+        std::printf("  [skip] AVX XSTATE is not enabled on this host\n");
+    }
+
+    reset_delivery_state();
+    CHECK(pthread_create(&thread, nullptr, gpr_worker, nullptr) == 0,
+          "create nonvolatile-register target thread");
+    for (int i = 0; i < 1000 && !gpr_ready; ++i) Sleep(1);
+    CHECK(worker_tid != 0 && gpr_ready != 0, "nonvolatile R12 pattern is live");
+    bool all_deliveries = true;
+    for (LONG i = 1; i <= 100; ++i) {
+        result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+        if (result != 0) { all_deliveries = false; break; }
+        for (int spin = 0; spin < 2000 && delivered < i; ++spin) Sleep(1);
+        if (delivered < i) { all_deliveries = false; break; }
+    }
+    InterlockedExchange(&gpr_stop, 1);
+    pthread_join(thread, nullptr);
+    CHECK(all_deliveries && delivered == 100,
+          "100 serialized deliveries complete while R12 is live");
+    CHECK(gpr_observed == kGprExpected,
+          "nonvolatile R12 survives repeated context redirection");
+    CHECK(resumed != 0, "nonvolatile-register target resumes after stress delivery");
+
+    reset_delivery_state();
+    _putenv_s("PROSPER_WIN_LEGACY_EXC", "");
+    _putenv_s("PROSPER_WIN_COOPERATIVE_EXC", "1");
+    pthread_mutex_lock(&wait_mutex);
+    CHECK(pthread_create(&thread, nullptr, cond_worker, nullptr) == 0,
+          "create cooperative-delivery target thread");
+    for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+    pthread_mutex_unlock(&wait_mutex);
+    for (int i = 0; i < 1000 && !cond_ready; ++i) Sleep(1);
+    pthread_mutex_lock(&wait_mutex);
+    pthread_mutex_unlock(&wait_mutex);
+    CHECK(worker_tid != 0 && cond_ready != 0,
+          "cooperative target entered registered wait");
+
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "queue cooperative exception delivery");
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) interruptible_cond_broadcast(&wait_cond);
+    pthread_join(thread, nullptr);
+    _putenv_s("PROSPER_WIN_COOPERATIVE_EXC", "");
+
+    const uintptr_t cooperative_checkpoint =
+        (uintptr_t)&dispatch_pending_guest_exception;
+    const uint64_t cooperative_rip_gap = context_rip > cooperative_checkpoint
+        ? context_rip - cooperative_checkpoint : cooperative_checkpoint - context_rip;
+    CHECK(delivered == 1, "cooperative guest handler executed exactly once");
+    CHECK(handler_tid == worker_tid, "cooperative handler ran on requested target");
+    CHECK(cooperative_rip_gap < 64 * 1024,
+          "context was captured at the cooperative wait checkpoint");
+    const uint64_t cooperative_stack_gap = handler_rsp > context_rsp
+        ? handler_rsp - context_rsp : context_rsp - handler_rsp;
+    CHECK(cooperative_stack_gap > 64 * 1024,
+          "cooperative handler ran on a dedicated exception stack");
+    CHECK(resumed != 0, "cooperative target returned normally from its wait wrapper");
+
+    reset_delivery_state();
+    nested_wait_enabled = 1;
+    pthread_mutex_lock(&wait_mutex);
+    CHECK(pthread_create(&thread, nullptr, cond_worker, nullptr) == 0,
+          "create nested-wait cooperative target thread");
+    for (int i = 0; i < 1000 && !worker_tid; ++i) Sleep(1);
+    pthread_mutex_unlock(&wait_mutex);
+    for (int i = 0; i < 1000 && !cond_ready; ++i) Sleep(1);
+    pthread_mutex_lock(&wait_mutex);
+    pthread_mutex_unlock(&wait_mutex);
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "deliver cooperative exception whose handler performs a nested wait");
+    for (int i = 0; i < 2000 && !nested_wait_ready; ++i) Sleep(1);
+    CHECK(nested_wait_ready != 0, "guest handler entered its nested semaphore-style wait");
+    InterlockedExchange(&nested_wait_release, 1);
+    interruptible_cond_broadcast(&nested_wait_cond);
+    for (int i = 0; i < 2000 && !nested_wait_returned; ++i) Sleep(1);
+    CHECK(nested_wait_returned != 0, "nested wait returned while handler remains active");
+    CHECK(interrupt_guest_wait((uint64_t)thread),
+          "outer wait remains registered after nested wait unregisters");
+    InterlockedExchange(&nested_wait_finish, 1);
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) interruptible_cond_broadcast(&wait_cond);
+    pthread_join(thread, nullptr);
+    CHECK(delivered == 1, "nested-wait cooperative handler executed exactly once");
+    CHECK(resumed != 0, "target resumed after nested-wait handler returned");
+
+    reset_delivery_state();
+    CHECK(pthread_create(&thread, nullptr, prewait_worker, nullptr) == 0,
+          "create queue-before-wait target thread");
+    for (int i = 0; i < 1000 && !prewait_ready; ++i) Sleep(1);
+    CHECK(prewait_ready != 0, "target paused before registering its wait");
+    result = raise((uint64_t)thread, 0x1e, 0, 0, 0, 0);
+    CHECK(result == 0, "queue cooperative delivery before wait registration");
+    InterlockedExchange(&prewait_release, 1);
+    for (int i = 0; i < 2000 && !delivered; ++i) Sleep(1);
+    interruptible_cond_broadcast(&wait_cond);
+    for (int i = 0; i < 2000 && !resumed; ++i) Sleep(1);
+    if (!resumed) interruptible_cond_broadcast(&wait_cond);
+    pthread_join(thread, nullptr);
+
+    CHECK(delivered == 1, "pre-sleep checkpoint accepted the queued delivery once");
+    CHECK(handler_tid == worker_tid, "pre-sleep handler ran on requested target");
+    CHECK(resumed != 0, "target continued through its wait after pre-sleep delivery");
+    _putenv_s("PROSPER_WIN_COOPERATIVE_EXC", "");
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");

--- a/prosper/tests/test_win_kernel_is_stack.cpp
+++ b/prosper/tests/test_win_kernel_is_stack.cpp
@@ -1,3 +1,6 @@
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00
+#endif
 #include "../src/host/exec_image.hpp"
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
@@ -7,6 +10,26 @@
 #include <cstdio>
 
 using namespace prosper;
+
+struct WorkerStackProbe {
+    volatile LONG ready = 0;
+    volatile LONG release = 0;
+    void* base = nullptr;
+    size_t size = 0;
+};
+
+static void* registered_worker(void* raw) {
+    auto* probe = static_cast<WorkerStackProbe*>(raw);
+    ULONG_PTR low = 0, high = 0;
+    GetCurrentThreadStackLimits(&low, &high);
+    probe->base = (void*)low;
+    probe->size = (size_t)(high - low);
+    register_thread_stack((uint64_t)GetCurrentThreadId(), probe->base, probe->size);
+    InterlockedExchange(&probe->ready, 1);
+    while (!probe->release) Sleep(1);
+    unregister_thread_stack((uint64_t)GetCurrentThreadId());
+    return nullptr;
+}
 
 int main() {
     register_builtin_hle();
@@ -37,17 +60,58 @@ int main() {
     attr_get((uint64_t)pthread_self(), (uint64_t)(uintptr_t)&attr, 0, 0, 0, 0);
     attr_getaddr((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_base, 0, 0, 0, 0);
     attr_getsize((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_size, 0, 0, 0, 0);
-    attr_destroy((uint64_t)(uintptr_t)&attr, 0, 0, 0, 0, 0);
     bool attr_bounds = reported_base == (void*)(uintptr_t)base && reported_size == 0x2000;
+
+    // The guest passes a winpthreads pthread_t handle for another thread, while Windows stack
+    // registration is keyed by GetCurrentThreadId(). The registry must bridge those identities.
+    WorkerStackProbe probe;
+    pthread_t worker = 0;
+    bool worker_created = pthread_create(&worker, nullptr, registered_worker, &probe) == 0;
+    for (int i = 0; worker_created && i < 2000 && !probe.ready; ++i) Sleep(1);
+    void* resolved_base = nullptr;
+    size_t resolved_size = 0;
+    bool resolved_worker = worker_created && probe.ready &&
+        guest_stack_for_thread((uint64_t)worker, &resolved_base, &resolved_size) &&
+        resolved_base == probe.base && resolved_size == probe.size;
+
+    reported_base = nullptr;
+    reported_size = 0;
+    attr_get((uint64_t)worker, (uint64_t)(uintptr_t)&attr, 0, 0, 0, 0);
+    attr_getaddr((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_base, 0, 0, 0, 0);
+    attr_getsize((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_size, 0, 0, 0, 0);
+    bool target_attr_bounds = reported_base == probe.base && reported_size == probe.size;
+
+    InterlockedExchange(&probe.release, 1);
+    if (worker_created) pthread_join(worker, nullptr);
+
+    // A stale/unknown target must leave the caller-provided attr unchanged. Falling back to the
+    // querying thread here is the exact wrong-stack substitution that can corrupt a GC scan.
+    void* sentinel_stack = VirtualAlloc(nullptr, 1024 * 1024,
+                                        MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+    bool sentinel_set = sentinel_stack &&
+        pthread_attr_setstack((pthread_attr_t*)attr, sentinel_stack, 1024 * 1024) == 0;
+    reported_base = nullptr;
+    reported_size = 0;
+    attr_get((uint64_t)worker, (uint64_t)(uintptr_t)&attr, 0, 0, 0, 0);
+    attr_getaddr((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_base, 0, 0, 0, 0);
+    attr_getsize((uint64_t)(uintptr_t)&attr, (uint64_t)(uintptr_t)&reported_size, 0, 0, 0, 0);
+    bool missing_target_unchanged = sentinel_set && reported_base == sentinel_stack &&
+                                    reported_size == 1024 * 1024;
+    attr_destroy((uint64_t)(uintptr_t)&attr, 0, 0, 0, 0, 0);
+    if (sentinel_stack) VirtualFree(sentinel_stack, 0, MEM_RELEASE);
 
     unregister_thread_stack((uint64_t)GetCurrentThreadId());
     bool unregistered = is_stack(addr, 0, 0, 0, 0, 0) == 0;
 
-    if (!inside || !below || !at_end || !attr_bounds || !unregistered) {
+    if (!inside || !below || !at_end || !attr_bounds || !worker_created || !resolved_worker ||
+        !target_attr_bounds || !missing_target_unchanged || !unregistered) {
         std::fprintf(stderr,
                      "stack HLE mismatch: inside=%d below=%d at_end=%d attr_bounds=%d "
-                     "reported=%p/%zu unregistered=%d\n",
-                     inside, below, at_end, attr_bounds, reported_base, reported_size, unregistered);
+                     "worker_created=%d resolved_worker=%d target_attr_bounds=%d "
+                     "missing_unchanged=%d reported=%p/%zu expected=%p/%zu unregistered=%d\n",
+                     inside, below, at_end, attr_bounds, worker_created, resolved_worker,
+                     target_attr_bounds, missing_target_unchanged, reported_base, reported_size,
+                     probe.base, probe.size, unregistered);
         return 1;
     }
     return 0;

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -504,7 +504,20 @@ int main(int argc, char** argv) {
     prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false);
     Program prog; std::string err;
     if (!boot_program(dump, prog, &err)) { fprintf(stderr, "screenshot: boot failed: %s\n", err.c_str()); return 1; }
-    std::thread guest([&prog] { run_entry(prog.imgs[0]); });
+    std::thread guest([&prog] {
+        const BootResult result = run_entry(prog.imgs[0]);
+        fprintf(stderr,
+                "[shot] guest thread ended: kind=%d detail=%s rip=0x%llx addr=0x%llx "
+                "rbp=0x%llx rsp=0x%llx\n",
+                result.kind, result.detail.c_str(),
+                static_cast<unsigned long long>(result.fault_rip),
+                static_cast<unsigned long long>(result.fault_addr),
+                static_cast<unsigned long long>(result.rbp),
+                static_cast<unsigned long long>(result.rsp));
+        for (uint64_t address : result.backtrace)
+            fprintf(stderr, "[shot] guest backtrace: 0x%llx\n",
+                    static_cast<unsigned long long>(address));
+    });
     guest.detach();
 
     const bool time_mode = seconds > 0;   // capture on wall-clock interval vs. every N rendered frames


### PR DESCRIPTION
## Summary

- replace normal Windows `SuspendThread`/`SetThreadContext` guest-stop delivery with cooperative delivery at HLE and registered-wait safe points, on a dedicated alternate stack
- make futex/condition wait interruption nesting-safe and close the wake-before-wait race; track guest mutex ownership so ERRORCHECK and condition-wait semantics remain correct
- add bounded Windows exception/stall diagnostics and resolve winpthreads handles to native thread IDs
- harden invalid scalar `OpPhi` generation found during Windows driver validation
- document the delivery model, diagnostics, and current Blasphemous 2 boundary

`PROSPER_WIN_LEGACY_EXC=1` retains the old forced injection path for diagnostics. Normal execution no longer restores stale native wait contexts after waking a target thread.

## Validation

- Windows MinGW build: clean
- full Windows suite: 72/72 passed
- `test_win_exception_delivery.exe`: 30/30 consecutive runs passed
- Blasphemous 2 fresh-save production app: 6/6 additional runs reached 360 presented frames after the final rebase, no stalls or early exits (12/12 earlier during development)

The 360-frame check validates boot and guest-thread stability only. Blasphemous 2 still reaches the title but not the main menu with the default renderer; the required tiled 2D compute writeback and its performance work remain tracked separately in #787.

Refs #690
Refs #787