### PR TITLE
fix(gpu): preserve recycled UE4 spill lanes

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3037,18 +3037,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
                     ok = false; return true;
                 }
+                auto vit = rs.vgpr_lane_slots.find(in.src[0].value);
                 auto mit = rs.vgpr_lane_mask_slots.find(in.src[0].value);
                 if (mit != rs.vgpr_lane_mask_slots.end()) {
                     auto sit = mit->second.find(in.src[1].value);
                     if (sit != mit->second.end()) {
                         rs.sreg_bool[in.dst.value] = sit->second;
                         rs.sreg_bool_narrowed[in.dst.value] = true;
-                        rs.sreg.erase(in.dst.value);
+                        // The compute CFG dispatcher can persist a physical spill lane that is
+                        // recycled between scalar-data and wave-mask lifetimes. It exposes both
+                        // views after a block join; keep both destination domains when present so
+                        // the statically typed consumer selects the representation it needs.
+                        if (vit != rs.vgpr_lane_slots.end()) {
+                            auto data = vit->second.find(in.src[1].value);
+                            if (data != vit->second.end()) rs.sreg[in.dst.value] = data->second;
+                            else rs.sreg.erase(in.dst.value);
+                        } else {
+                            rs.sreg.erase(in.dst.value);
+                        }
                         rs.sreg_srt.erase(in.dst.value);
                         return true;
                     }
                 }
-                auto vit = rs.vgpr_lane_slots.find(in.src[0].value);
                 if (vit == rs.vgpr_lane_slots.end()) { ok = false; return true; }   // not a spill array
                 auto sit = vit->second.find(in.src[1].value);
                 if (sit == vit->second.end()) { ok = false; return true; }          // slot never written
@@ -4353,11 +4363,9 @@ bool emit_compute_cfg_state_machine(
         for (const auto& slot : vg.second) lane_slots.emplace(vg.first, slot.first);
     for (const auto& vg : initial.vgpr_lane_mask_slots)
         for (const auto& slot : vg.second) mask_lane_slots.emplace(vg.first, slot.first);
-    // The dispatcher has separate persisted value domains for scalar data and lane masks. If one
-    // physical spill slot changes domain across paths, rejecting is safer than reloading both and
-    // letting v_readlane choose an arbitrary representation.
-    for (const auto& slot : lane_slots)
-        if (mask_lane_slots.count(slot)) return false;
+    // A physical spill lane may be recycled between scalar-data and wave-mask lifetimes. Persist
+    // both domains across dispatcher blocks; v_readlane retains both destination views when both
+    // are present, and the statically typed consumer selects the representation it needs.
 
     uint32_t ptr_u32 = 0, ptr_bool = 0;
     std::map<int, uint32_t> vv, sv, mv;

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -82,6 +82,26 @@ int main() {
                           sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]), 0, 0,
                           &dispatch_rt).empty(),
           "a nested varying-VCC compute CFG preserves spilled EXEC and lowers through the dispatcher");
+    // UE4 also recycles a physical v_writelane slot: first as ordinary scalar data, then as an
+    // EXEC-mask spill. Force a dispatcher block boundary after each lifetime so both typed views
+    // must survive the Function-variable state round trip. Consumers remain statically typed.
+    const uint32_t compute_cfg_dispatch_recycled_lane[] = {
+        0xBE800381u, 0x7E000280u, 0x7E020300u,
+        0xD7610013u, 0x00014A00u, 0xBF820000u,       // v19[37] = s0; next block
+        0xD7600002u, 0x00014B13u,                   // s2 = v19[37] (data view)
+        0xD7610013u, 0x00014A7Eu, 0xD7610013u, 0x0001507Fu,
+        0xBF820000u,                                // v19[37:40] = EXEC; next block
+        0xD760000Eu, 0x00014B13u, 0xD760000Fu, 0x00015113u, 0xBEFE040Eu,
+        0xE00C2000u, 0x80020400u, 0x7DB900F9u, 0x86050007u,
+        0x7D020200u, 0xBF860006u, 0xBF0A8204u, 0x360000FDu, 0xBF840001u,
+        0x81008100u, 0x81008100u, 0xBF82FFF4u,
+        0xBF810000u,
+    };
+    CHECK(!recompile_valu(compute_cfg_dispatch_recycled_lane,
+                          sizeof(compute_cfg_dispatch_recycled_lane) /
+                              sizeof(compute_cfg_dispatch_recycled_lane[0]),
+                          0, 0, &dispatch_rt).empty(),
+          "the compute CFG dispatcher preserves a recycled scalar/mask spill lane");
     // Ordinary LDS effects do not require workgroup-uniform control flow. Keep the same dispatcher
     // shape, but make the inner SCC arm conditionally execute a ds_write_b32 before the back-edge.
     // (A barrier remains forbidden below; only the blanket rejection of raw DS is being relaxed.)


### PR DESCRIPTION
## Summary

- preserve both scalar-data and wave-mask views when the compute CFG dispatcher carries a recycled `v_writelane` slot across basic blocks
- let statically typed consumers select the matching view after `v_readlane`
- add a reduced UE4-style regression with scalar-to-EXEC spill-lane reuse

## Root cause

UE4's volume-lighting kernel reuses the same physical VGPR lane first for ordinary scalar spill data and later for an EXEC/VCC mask. The dispatcher globally discovered both lifetimes and rejected the shader as an ambiguous mixed-domain spill, even though each consumer is statically typed.

## Impact

The previously missing DOLL volume-lighting dispatch now recompiles and executes in the captured submit, reducing unrealized compute work by one. Its output is legitimately zero in the current scene capture, so this PR does not claim the shaded-scene milestone by itself.

Refs #719.

## Validation

- `messenger_recompile_guard`
- `recompile_coverage`
- `compute_exec_differential`
- `rdna2_to_spirv_exec`
- `recompiled_fragment_render`
- `recompiled_shaders_render`
- fresh DOLL full-resource capture: target volume-lighting dispatch realized and executed
- snapshot guard invoked; it stops before rendering because the repository lacks completed visual-review notes for Messenger, Dead Cells, and Blasphemous 2
