### PR TITLE
fix(gpu): expose UE4 mixed sharp buffers

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -306,15 +306,93 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
         }
     }
 
-    // Textures: sharp_resource_offset[0] (textures2D). Each slot's offset_dw points at an 8-dword T#
-    // in the user-data SGPR block. The PS reads it directly in SGPRs (image_sample SRSRC), so DIRECT
+    // Writable resources: sharp_resource_offset[1] is mixed, like sharp[0]. DOLL's source-258 UE4
+    // volume-lighting dispatch declares a size=1 EUD-resident 4-dword V# here (offset_dw=0x4c with 32
+    // user SGPRs), then loads it with `s_load_dwordx4 ..., 0xb0` and consumes it in
+    // buffer_store_format_xyzw. Other live kernels put size=0 8-dword image descriptors in the same
+    // category; interpreting their first four dwords as V#s fabricated gigabyte-class capture ranges.
+    // Emit only size-flagged, buffer-shaped entries here. Writable images remain handled by the dynamic
+    // descriptor fold. ConstantBuffer is the existing read/write Vulkan storage-buffer class (the live
+    // compute backend copies every reflected storage buffer back to guest memory). Keep sharp[3] first so
+    // shaders using the two conventional cbuf bindings retain their ordering.
+    const AgcShaderSharp* writable_buffers = ud->sharp_resource_offset[1];
+    if (arr_ok(writable_buffers, ud->sharp_resource_count[1], sizeof(AgcShaderSharp))) {
+        for (uint16_t slot = 0; slot < ud->sharp_resource_count[1]; slot++) {
+            const AgcShaderSharp& s = writable_buffers[slot];
+            if (s.empty() || !s.size()) continue;
+            const uint32_t off = s.offset_dw();
+            uint32_t vv[4];
+            const uint32_t srt = load_sharp(off, 4, vv);
+            if (srt == 0xFFFFFFFFu) continue;
+            const DecodedBufferDescriptor d = decode_buffer_descriptor(vv);
+            if (d.base < 0x1000000000ull || !d.stride || !d.size_bytes ||
+                d.size_bytes > 0x10000000u)
+                continue;
+            ShaderResource r;
+            r.cls            = ResourceClass::ConstantBuffer;
+            r.format         = d.format;
+            r.num_components = d.num_components;
+            r.binding        = binding++;
+            r.gpu_addr       = d.base;
+            r.size           = d.size_bytes;
+            r.stride         = d.stride;
+            const bool in_eud = (uint64_t)off + 4 > num_user_sgprs;
+            r.srt_offset = in_eud ? srt : 0xFFFFFFFFu;
+            r.sgpr_base  = in_eud ? 0xFFFFFFFFu : (user_sgpr_base + off);
+            table.resources.push_back(r);
+        }
+    }
+
+    // Read-only buffer entries share sharp[0] with textures. A 4-dword V# carries the sharp size bit,
+    // but that bit is only a hint: live UE4 T# entries can carry it too. Source 258's size=1 direct
+    // entry at offset_dw=8 decodes as base=0x10c109ac60, stride=16, records=7 (112 bytes) and is
+    // consumed by s_buffer_load_dwordx8/x4. Treating every sharp[0] entry as a T# fabricated a tiny
+    // texture and left those scalar loads on the unrelated binding-2 fallback, which then failed the
+    // descriptor contract (required 48, available 32). EUD-resident size=1 entries use the same SRT
+    // provenance as the writable/category-1 and constant/category-3 buffers.
+    const AgcShaderSharp* readonly_resources = ud->sharp_resource_offset[0];
+    std::vector<bool> readonly_buffer_slots(ud->sharp_resource_count[0], false);
+    if (arr_ok(readonly_resources, ud->sharp_resource_count[0], sizeof(AgcShaderSharp))) {
+        for (uint16_t slot = 0; slot < ud->sharp_resource_count[0]; slot++) {
+            const AgcShaderSharp& s = readonly_resources[slot];
+            if (s.empty() || !s.size()) continue;
+            const uint32_t off = s.offset_dw();
+            uint32_t vv[4];
+            const uint32_t srt = load_sharp(off, 4, vv);
+            if (srt == 0xFFFFFFFFu) continue;
+            const DecodedBufferDescriptor d = decode_buffer_descriptor(vv);
+            // A size-flagged T# reinterpreted as V# loses the descriptor's <<8 address scale and often
+            // produces a gigabyte-class `records*stride` extent (observed: 1,247,051,952 bytes). Use the
+            // same 256 MiB sanity ceiling as direct compute V# discovery, and require the PS5 guest-VA
+            // floor plus a real stride. If this shape check fails, leave the slot for the T# path below.
+            if (d.base < 0x1000000000ull || !d.stride || !d.size_bytes ||
+                d.size_bytes > 0x10000000u)
+                continue;
+            ShaderResource r;
+            r.cls            = ResourceClass::ConstantBuffer;
+            r.format         = d.format;
+            r.num_components = d.num_components;
+            r.binding        = binding++;
+            r.gpu_addr       = d.base;
+            r.size           = d.size_bytes;
+            r.stride         = d.stride;
+            const bool in_eud = (uint64_t)off + 4 > num_user_sgprs;
+            r.srt_offset = in_eud ? srt : 0xFFFFFFFFu;
+            r.sgpr_base  = in_eud ? 0xFFFFFFFFu : (user_sgpr_base + off);
+            table.resources.push_back(r);
+            readonly_buffer_slots[slot] = true;
+        }
+    }
+
+    // Textures: sharp[0] entries that did not decode as plausible V#s above. Each slot's offset_dw points
+    // at an 8-dword T# in the user-data SGPR block. The PS reads it directly in SGPRs, so DIRECT
     // provenance: sgpr_base = offset_dw. The paired sampler (sharp[2]) is folded into the combined
     // image-sampler at the same binding by the backend, so we don't emit a separate Sampler resource.
     const AgcShaderSharp* texs = ud->sharp_resource_offset[0];
     if (arr_ok(texs, ud->sharp_resource_count[0], sizeof(AgcShaderSharp))) {
         for (uint16_t slot = 0; slot < ud->sharp_resource_count[0]; slot++) {
             const AgcShaderSharp& s = texs[slot];
-            if (s.empty()) continue;
+            if (s.empty() || readonly_buffer_slots[slot]) continue;
             uint32_t off = s.offset_dw();
             // A T# may live in the user-SGPR block OR spill into the EUD, exactly like the cbuf path
             // (#257/#382) — the old hard `continue` for off+8 > num_user_sgprs silently DROPPED any

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -25,7 +25,9 @@ struct AgcShaderSharp {
 
 // Shader resource-usage table (Kyty ShaderUserData, Shader.h:911). Categories (from ShaderParseUsage2):
 //   direct_resource_offset[type]: type 8 = vertex buffer, type 10 = vertex attrib (value = SGPR index)
-//   sharp_resource_offset[0]: textures2D   [2]: samplers   [3]: constant/storage buffers   [1]: unused
+//   sharp_resource_offset[0]: read-only T#/V# resources (4-dword V# entries use size=1; some T#s do too)
+//                         [1]: writable T#/V# resources (4-dword V# entries use size=1)
+//                         [2]: samplers   [3]: constant/storage buffers
 struct AgcShaderUserData {
     uint16_t*       direct_resource_offset;      // +0x00
     AgcShaderSharp* sharp_resource_offset[4];    // +0x08

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -222,6 +222,69 @@ int main() {
         CHECK(re && re->gpu_addr == 0xD0000000ull, "#375: in-bounds EUD cbuf decoded from the spill buffer");
     }
 
+    // --- #719: UE4 mixed sharp[0] buffers + sharp[1] writable buffer. -------------------------------
+    // Live source 258 declares sharp_counts={8,1,1,2}. sharp[0] contains both size=0 T#s and size=1
+    // V#s: a direct read-only V# at offset 8 and an EUD V# at offset 0x48. sharp[1] has the writable
+    // V# at offset 0x4c. With 32 user SGPRs, those EUD entries have provenance keys 0xa0 and 0xb0.
+    {
+        uint32_t sg[32]; memset(sg, 0, sizeof sg);
+        uint32_t eud[60]; memset(eud, 0, sizeof eud);
+        make_vsharp(&sg[8], 0x10C109AC60ull, 16, 7, 5);       // live-shaped raw V#, unknown format
+        make_vsharp(&eud[40], 0x207D300000ull, 16, 18, 77);   // sharp[0] EUD read-only V#
+        make_vsharp(&eud[44], 0x207D400000ull, 16, 64, 77);
+        const uint64_t eud_ptr = (uint64_t)(uintptr_t)eud;
+        uint16_t dro5[11]; for (auto& x : dro5) x = 0xffff;
+        dro5[5] = 12;
+        sg[12] = (uint32_t)eud_ptr; sg[13] = (uint32_t)(eud_ptr >> 32);
+        AgcShaderSharp readonly_buffers[2];
+        readonly_buffers[0].bits = (uint16_t)(0x8000u | 0x08u);
+        readonly_buffers[1].bits = (uint16_t)(0x8000u | 0x48u);
+        AgcShaderSharp writable;
+        writable.bits = (uint16_t)(0x8000u | 0x4cu);
+        AgcShaderUserData wud; memset(&wud, 0, sizeof wud);
+        wud.direct_resource_offset = dro5; wud.direct_resource_count = 11;
+        wud.eud_size_dw = 60;
+        wud.sharp_resource_offset[0] = readonly_buffers; wud.sharp_resource_count[0] = 2;
+        wud.sharp_resource_offset[1] = &writable; wud.sharp_resource_count[1] = 1;
+        AgcShaderHeader wsh; memset(&wsh, 0, sizeof wsh);
+        wsh.file_header = 0x34333231u; wsh.version = 0x18; wsh.type = 0; wsh.user_data = &wud;
+
+        ShaderResourceTable wt = build_shader_resources(wsh, sg, 32);
+        const ShaderResource* direct = wt.by_sgpr_base(8);
+        CHECK(direct && direct->cls == ResourceClass::ConstantBuffer &&
+              direct->gpu_addr == 0x10C109AC60ull && direct->size == 112 && direct->stride == 16,
+              "#719: sharp[0] size=1 direct entry decodes as a read-only V#, not a texture");
+        const ShaderResource* indirect = wt.by_srt_offset(0xa0);
+        CHECK(indirect && indirect->gpu_addr == 0x207D300000ull && indirect->size == 288,
+              "#719: sharp[0] size=1 EUD entry resolves by its 0xa0 s_load provenance key");
+        const ShaderResource* wr = wt.by_srt_offset(0xb0);
+        CHECK(wr && wr->cls == ResourceClass::ConstantBuffer,
+              "#719: sharp[1] writable V# becomes a storage-buffer-backed resource");
+        CHECK(wr && wr->gpu_addr == 0x207D400000ull && wr->size == 1024 && wr->stride == 16,
+              "#719: sharp[1] writable buffer descriptor decodes base/size/stride");
+        CHECK(wr && wr->sgpr_base == 0xFFFFFFFFu,
+              "#719: EUD-resident sharp[1] resolves only by its 0xb0 s_load provenance key");
+    }
+
+    // sharp[1] also contains writable images. Live volume kernels use size=0 8-dword T#/U# entries;
+    // decoding their first four dwords as a V# loses the image descriptor's <<8 address scale and can
+    // fabricate a >1 GiB storage-buffer range, which makes full capture fail preflight. Leave these for
+    // the compute backend's dynamic storage-image fold instead of emitting a false buffer resource.
+    {
+        uint32_t sg[32]; memset(sg, 0, sizeof sg);
+        make_tsharp(&sg[0], 0x207C670000ull, 120, 68, /*fmt*/56, /*tile*/27, /*type 2D*/9);
+        AgcShaderSharp writable_image;
+        writable_image.bits = 0;   // sharp[1] offset_dw=0, size=0: live writable image shape
+        AgcShaderUserData iud; memset(&iud, 0, sizeof iud);
+        iud.sharp_resource_offset[1] = &writable_image; iud.sharp_resource_count[1] = 1;
+        AgcShaderHeader ish; memset(&ish, 0, sizeof ish);
+        ish.file_header = 0x34333231u; ish.version = 0x18; ish.type = 0; ish.user_data = &iud;
+
+        ShaderResourceTable it = build_shader_resources(ish, sg, 32);
+        CHECK(it.resources.empty(),
+              "#719: sharp[1] size=0 writable image is not misclassified as a giant buffer");
+    }
+
     // --- vertex buffers: direct resource usage type 8 (V# inline in the user-data SGPRs) ------------
     // A 16-entry direct_resource_offset table; type 8 (vertex buffer) points at a V# at SGPR dword 20.
     uint16_t dro[16]; for (auto& x : dro) x = 0xffff;
@@ -314,7 +377,7 @@ int main() {
                     (1u << 22) | (0xabu << 24);
         tsgprs[7] = 0x00206e33u;
         make_tsharp(&tsgprs[8],  0xE0000000ull, 2048, 1024, /*fmt*/1,   /*tile*/5, /*type*/9);
-        make_tsharp(&tsgprs[16], 0xF0000000ull,  256,  256, /*fmt*/169, /*tile*/5, /*type*/9);  // BC1
+        make_tsharp(&tsgprs[16], 0x207E870000ull, 256, 256, /*fmt*/169, /*tile*/5, /*type*/9);  // BC1
         make_tsharp(&tsgprs[24], 0xF0010000ull,  128,  128, /*fmt*/44,  /*tile*/5, /*type*/9);  // unmapped
 
         {   // T# decode round-trip of the first descriptor
@@ -325,6 +388,7 @@ int main() {
 
         AgcShaderSharp tex_sharps[4];
         for (int i = 0; i < 4; i++) tex_sharps[i].bits = (uint16_t)(i * 8);
+        tex_sharps[2].bits |= 0x8000u;  // live UE4 T#s may carry size=1: must remain textures, not fake V#s
         AgcShaderUserData tud; memset(&tud, 0, sizeof tud);
         tud.sharp_resource_offset[0] = tex_sharps;
         tud.sharp_resource_count[0]  = 4;
@@ -353,6 +417,8 @@ int main() {
 
         const ShaderResource* t2 = tt.by_sgpr_base(16);
         CHECK(t2 && t2->format == DataFormat::Bc1, "BC1 T# now bound (decoded to RGBA8 on upload)");
+        CHECK(t2 && t2->gpu_addr == 0x207E870000ull,
+              "#719: size=1 T# that fails V# shape checks remains a texture");
         CHECK(t2 && t2->size == ((256u + 3) / 4) * ((256u + 3) / 4) * 8u,
               "BC1 size = ceil(w/4)*ceil(h/4)*8 (compressed block bytes, not w*h*4)");
         CHECK(tt.by_sgpr_base(24) == nullptr, "unmapped IMG_FMT T# skipped (no silent RGBA8)");


### PR DESCRIPTION
## Summary

- decode size-flagged 4-dword V# buffer descriptors from AGC sharp categories 0 and 1
- preserve direct-SGPR versus EUD/SRT provenance for scalar loads and writable stores
- keep texture/image-shaped entries on their existing paths, avoiding false gigabyte-class buffer captures
- add regressions for DOLL's source-258 layout, EUD offsets `0xa0`/`0xb0`, size-flagged textures, and writable images

Refs #719.

## Validation

- `test_build_shader_resources`
- `test_rdna2_to_spirv`
- `test_recompile_coverage`
- `test_shader_resources`
- full local DOLL scene capsule completed: 224 resource blobs / 153,254,592 bytes
- compute-only replay of source dispatch 263 (`code=0x2013500000`) completed successfully
- the writable `srt=0xb0` buffer changed 142/288 bytes during replay (`2e36859777b89fe5 -> de1c70c4f47faa3b`)

The live scene proof used pre-#793 commit `8cb5b4b`, because current #793 makes DOLL miss this scene selector in repeated bounded runs. The exact change was then rebuilt and all focused tests were rerun on current master `0265334`.

`snapshot.py check` was invoked but stopped before rendering because the repository content guard lacks completed visual-review notes for Messenger, Dead Cells, and Blasphemous 2. No snapshot baseline or captured game data is included.