### PR TITLE
fix(compute): enable cached tiled image writeback

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -539,6 +539,12 @@ if(TARGET prosper_core)
       target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
       target_link_libraries(boot_trace PRIVATE prosper_live_renderer)
+
+      # Keep the production compute backend covered on native Windows too. This catches host- and
+      # driver-specific image upload/writeback failures in the same backend prosper-app uses.
+      add_executable(test_game_compute tests/test_game_compute.cpp)
+      target_link_libraries(test_game_compute PRIVATE prosper_live_renderer)
+      add_test(NAME game_compute_exec COMMAND test_game_compute)
     else()
       message(STATUS "Vulkan not found — Windows boot_trace built without the live renderer")
     endif()

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -96,7 +96,7 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
   renderer-owned RGBA16F RTT inputs are replaced in their native format. `PROSPER_TESTTEX_FILTER=linear|point`
   uses the same draw/binding selectors for sampler-only A/B tests. `PROSPER_DUMP_RTGROUPS_ADDR=0x...` scopes
   `PROSPER_DUMP_RTGROUPS` to one target during a long run. `PROSPER_SHADER_DUMP_SUCCESS=DIR` captures both the
-  exact raw RDNA2 bytes and translated SPIR-V for successfully recompiled graphics shaders. These are
+  exact raw RDNA2 bytes and translated SPIR-V for successfully recompiled graphics and compute shaders. These are
   diagnostics, not renderer policy; record an unmodified output before interpreting an override.
 
 ## Build environment

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -779,13 +779,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             }
                         }
                     }
-                    if (trace)
+                    if (trace) {
+                        const uint64_t snapshot_hash = fnv1a(live_target.pixels->data(),
+                                                             live_target.pixels->size());
+                        const size_t nonzero_bytes = static_cast<size_t>(std::count_if(
+                            live_target.pixels->begin(), live_target.pixels->end(),
+                            [](uint8_t value) { return value != 0; }));
                         std::fprintf(stderr,
                                      "[compute]   imported renderer RTT binding=%u addr=0x%llx "
-                                     "extent=%ux%u format=%s\n",
+                                     "extent=%ux%u format=%s hash=%016llx nonzero-bytes=%zu\n",
                                      bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
                                      live_target.format == LiveTargetPixelFormat::Rgba16Float
-                                         ? "rgba16f" : "rgba8");
+                                         ? "rgba16f" : "rgba8",
+                                     (unsigned long long)snapshot_hash, nonzero_bytes);
+                    }
                     bi.guest_bytes = 0;
                 } else {
                     size_t need;                                   // guest bytes the decode reads
@@ -1260,14 +1267,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const uint8_t* bytes = resource_bytes(buffer.resource);
             std::fprintf(stderr,
                          "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
-                         "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x\n",
+                         "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x,%08x,%08x,%08x,%08x\n",
                          buffer.resource->binding, (unsigned long long)buffer.resource->gpu_addr,
                          buffer.resource->size, (unsigned long long)buffer.changed_bytes,
                          (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash,
                          buffer.resource->size >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
                          buffer.resource->size >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
                          buffer.resource->size >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
-                         buffer.resource->size >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
+                         buffer.resource->size >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0,
+                         buffer.resource->size >= 20 ? reinterpret_cast<const uint32_t*>(bytes)[4] : 0,
+                         buffer.resource->size >= 24 ? reinterpret_cast<const uint32_t*>(bytes)[5] : 0,
+                         buffer.resource->size >= 28 ? reinterpret_cast<const uint32_t*>(bytes)[6] : 0,
+                         buffer.resource->size >= 32 ? reinterpret_cast<const uint32_t*>(bytes)[7] : 0);
         }
         for (const auto& image : images) {
             if (!image.storage || !image.resource || image.alias_of != SIZE_MAX) continue;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -21,6 +21,17 @@
 #include <vector>
 
 namespace prosper::frontend {
+
+uint8_t storage_pack_unorm8(uint32_t float_bits) {
+    float value;
+    std::memcpy(&value, &float_bits, sizeof(value));
+    if (!(value > 0.0f)) return 0; // Includes negative values and NaN.
+    if (value >= 1.0f) return 255;
+    const float scaled = value * 255.0f;
+    const uint32_t whole = static_cast<uint32_t>(scaled);
+    return static_cast<uint8_t>(whole + (scaled - static_cast<float>(whole) >= 0.5f));
+}
+
 namespace {
 
 constexpr VkDeviceSize kMaxComputeImageBytes = 256ull << 20;
@@ -248,6 +259,10 @@ struct VulkanComputeContext {
     uint32_t host_memory_type(uint32_t bits) const {
         const VkMemoryPropertyFlags wanted = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
                                              VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        const VkMemoryPropertyFlags cached = wanted | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+        for (uint32_t i = 0; i < memory.memoryTypeCount; i++)
+            if ((bits & (1u << i)) && (memory.memoryTypes[i].propertyFlags & cached) == cached)
+                return i;
         for (uint32_t i = 0; i < memory.memoryTypeCount; i++)
             if ((bits & (1u << i)) && (memory.memoryTypes[i].propertyFlags & wanted) == wanted)
                 return i;
@@ -319,10 +334,7 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
     using DF = prosper::gpu::DataFormat;
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
-            case DF::Unorm8: { float v; std::memcpy(&v, &in[c], 4);
-                               if (std::isnan(v)) v = 0.f;
-                               v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
-                               dst[c] = (uint8_t)std::lround(v * 255.0f); break; }
+            case DF::Unorm8: dst[c] = storage_pack_unorm8(in[c]); break;
             case DF::Float16: { float v; std::memcpy(&v, &in[c], 4);
                                 const uint16_t h = prosper::gpu::float_to_half(v);
                                 dst[c * 2] = static_cast<uint8_t>(h);
@@ -372,6 +384,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     auto phase_pipeline = phase_start;
     auto phase_dispatch = phase_start;
     auto phase_writeback = phase_start;
+    double pack_ms = 0.0;
+    double layout_ms = 0.0;
     const bool trace = trace_compute_item(item);
     auto report = validate_spirv_descriptor_interface(
         item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
@@ -584,14 +598,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
             // A renderer-owned target's current pixels are not in raw guest memory. Import its
-            // immutable CPU snapshot for sampled bindings; storage bindings and GPU-only targets
-            // stay unsupported rather than silently reading or overwriting stale guest bytes.
+            // immutable CPU snapshot for sampled and storage bindings; a successful storage
+            // writeback publishes ordinary guest bytes and invalidates the renderer-owned copy.
             LiveTargetSnapshot live_target;
             const bool renderer_owned = is_live_render_target(r->gpu_addr);
             if (renderer_owned) {
-                if (bi.storage) {
-                    skip_image(r, "renderer-owned RTT bound as storage image"); break;
-                }
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
@@ -607,6 +618,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const uint64_t expected = texels * bpp;
                 if (expected != live_target.pixels->size()) {
                     skip_image(r, "renderer-owned RTT snapshot byte count mismatch"); break;
+                }
+                if (bi.storage) {
+                    const uint32_t nc = r->num_components ? r->num_components : 1;
+                    const bool compatible =
+                        (live_target.format == LiveTargetPixelFormat::Rgba8Unorm &&
+                         r->format == DataFormat::Unorm8 && nc == 4) ||
+                        (live_target.format == LiveTargetPixelFormat::Rgba16Float &&
+                         r->format == DataFormat::Float16 && nc == 4);
+                    if (!compatible) {
+                        skip_image(r, "renderer RTT storage format mismatch"); break;
+                    }
                 }
             }
             // Multiple U# bindings may intentionally name the same guest surface (read/modify/write
@@ -651,12 +673,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Fill the upload staging bytes.
             std::vector<uint8_t> upload((size_t)sbytes, 0);
             if (bi.storage) {
-                // The pure tile mapping and a production-backend fixture pass, but arbitrary live
-                // 1D/2D storage descriptors still need title validation before becoming the default.
-                // Keep the prior fail-visible behavior while allowing a bounded game A/B.
                 if (r->tile_mode && !dim_3d &&
-                    !std::getenv("PROSPER_COMPUTE_TILED_2D_STORAGE")) {
-                    skip_image(r, "tiled 1D/2D storage writeback deferred"); break;
+                    std::getenv("PROSPER_DISABLE_COMPUTE_TILED_2D_STORAGE")) {
+                    skip_image(r, "tiled 1D/2D storage writeback disabled"); break;
                 }
                 if (!storage_unpack_supported(r->format) || !storage_pack_supported(r->format)) {
                     skip_image(r, "storage format has no channel pack/unpack yet"); break; }
@@ -681,17 +700,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool readable = (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
-                if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                 std::vector<uint8_t> linear((size_t)linear_guest_bytes, 0);
-                if (r->tile_mode && r->depth > 1) {
+                if (renderer_owned) {
+                    std::memcpy(linear.data(), live_target.pixels->data(), linear.size());
+                    if (trace) {
+                        bi.before_hash = fnv1a(linear.data(), linear.size());
+                        std::fprintf(stderr,
+                                     "[compute]   imported writable renderer RTT binding=%u "
+                                     "addr=0x%llx extent=%ux%u format=%s\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     r->width, r->height,
+                                     live_target.format == LiveTargetPixelFormat::Rgba16Float
+                                         ? "rgba16f" : "rgba8");
+                    }
+                } else if (r->tile_mode && r->depth > 1) {
+                    if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     if (!detile_volume(linear.data(), src, guest_bytes, r->width, r->height,
                                        r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
                         skip_image(r, "storage volume detile failed"); break;
                     }
                 } else if (r->tile_mode) {
+                    if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     detile_surface(linear.data(), src, r->width, r->height, r->tile_mode, 0,
                                    static_cast<uint32_t>(guest_texel));
                 } else {
+                    if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     std::memcpy(linear.data(), src, linear.size());
                 }
                 for (size_t t = 0; t < texels; t++)
@@ -1161,9 +1194,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     for (uint32_t c = 0; c < 4; c++)
                         bi.nonzero_channels += channels[t * 4 + c] != 0;
             }
+            const auto pack_start = ComputeClock::now();
             for (size_t t = 0; t < texels; t++)
                 storage_pack_texel(channels + t * 4, r->format, nc,
                                    linear.data() + t * guest_texel);
+            const auto pack_done = ComputeClock::now();
             uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
             if (r->tile_mode && r->depth > 1) {
                 if (!tile_volume(destination, bi.guest_bytes, linear.data(), r->width, r->height,
@@ -1178,6 +1213,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             } else {
                 std::memcpy(destination, linear.data(), linear.size());
             }
+            const auto layout_done = ComputeClock::now();
+            pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
+            layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
             if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
             notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
             if (!r->host_data && writer_provenance_enabled())
@@ -1257,12 +1295,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::fprintf(stderr,
                      "[compute-phase] submit=%llu code=0x%llx ok=%u "
                      "setup_ms=%.2f pipeline_ms=%.2f dispatch_ms=%.2f "
-                     "writeback_ms=%.2f cleanup_ms=%.2f total_ms=%.2f\n",
+                     "writeback_ms=%.2f pack_ms=%.2f layout_ms=%.2f "
+                     "cleanup_ms=%.2f total_ms=%.2f\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
                      ok ? 1u : 0u, milliseconds(phase_start, phase_setup),
                      milliseconds(phase_setup, phase_pipeline),
                      milliseconds(phase_pipeline, phase_dispatch),
                      milliseconds(phase_dispatch, phase_writeback),
+                     pack_ms, layout_ms,
                      milliseconds(phase_writeback, phase_cleanup),
                      milliseconds(phase_start, phase_cleanup));
     }

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -638,10 +638,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 for (size_t j = 0; j < i; j++) {
                     const BoundImage& prior = images[j];
                     const ShaderResource* p = prior.resource;
+                    const bool same_dcc_identity = p &&
+                        p->max_uncompressed_block_size == r->max_uncompressed_block_size &&
+                        p->max_compressed_block_size == r->max_compressed_block_size &&
+                        p->meta_pipe_aligned == r->meta_pipe_aligned &&
+                        p->write_compress_enabled == r->write_compress_enabled &&
+                        p->compression_enabled == r->compression_enabled &&
+                        p->alpha_is_on_msb == r->alpha_is_on_msb &&
+                        p->color_transform == r->color_transform &&
+                        p->metadata_addr == r->metadata_addr &&
+                        p->dcc_metadata_size == r->dcc_metadata_size &&
+                        p->dcc_metadata_host_data == r->dcc_metadata_host_data &&
+                        p->dcc_metadata_host_data_size == r->dcc_metadata_host_data_size;
                     if (!prior.storage || !p || p->gpu_addr != r->gpu_addr ||
                         p->width != r->width || p->height != r->height || p->depth != r->depth ||
                         p->format != r->format || p->num_components != r->num_components ||
-                        p->tile_mode != r->tile_mode || p->img_dim != r->img_dim)
+                        p->tile_mode != r->tile_mode || p->img_dim != r->img_dim ||
+                        !same_dcc_identity)
                         continue;
                     bi.alias_of = prior.alias_of == SIZE_MAX ? j : prior.alias_of;
                     const BoundImage& owner = images[bi.alias_of];
@@ -673,6 +686,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Fill the upload staging bytes.
             std::vector<uint8_t> upload((size_t)sbytes, 0);
             if (bi.storage) {
+                if (r->tile_mode && !tile_mode_is_tiled(r->tile_mode)) {
+                    skip_image(r, "storage tile mode has no supported address pattern"); break;
+                }
                 if (r->tile_mode && !dim_3d &&
                     std::getenv("PROSPER_DISABLE_COMPUTE_TILED_2D_STORAGE")) {
                     skip_image(r, "tiled 1D/2D storage writeback disabled"); break;
@@ -696,8 +712,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "storage backing size is invalid"); break;
                 }
                 bi.guest_bytes = guest_bytes;
-                const uint8_t* src = resource_bytes_for(r, guest_bytes);
-                const bool readable = (r->host_data && r->host_data_size >= guest_bytes) ||
+                const uint8_t* src = renderer_owned ? nullptr : resource_bytes_for(r, guest_bytes);
+                const bool readable = renderer_owned ||
+                                      (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
                 std::vector<uint8_t> linear((size_t)linear_guest_bytes, 0);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -366,6 +366,12 @@ bool trace_compute_item(const prosper::gpu::ComputeItem& item) {
 
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
+    using ComputeClock = std::chrono::steady_clock;
+    const auto phase_start = ComputeClock::now();
+    auto phase_setup = phase_start;
+    auto phase_pipeline = phase_start;
+    auto phase_dispatch = phase_start;
+    auto phase_writeback = phase_start;
     const bool trace = trace_compute_item(item);
     auto report = validate_spirv_descriptor_interface(
         item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
@@ -394,6 +400,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         image_descriptors.begin(), image_descriptors.end(), [](const auto& descriptor) {
             return descriptor.kind == SpirvDescriptorKind::StorageImage;
         });
+    const bool phase_timing = has_storage_images &&
+                              std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
     if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
         if (!warned) { warned = true;
@@ -521,11 +529,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const uint64_t key = r ? r->gpu_addr : 0;
             if (std::find(warned.begin(), warned.end(), key) == warned.end()) {
                 warned.push_back(key);
-                std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u fmt=%u: %s -> "
+                std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u fmt=%u comps=%u "
+                                     "tile=%u size=%u: %s -> "
                                      "dispatch skipped (#590)\n",
                              (unsigned long long)item.code_addr, (unsigned long long)key,
                              r ? r->width : 0, r ? r->height : 0, r ? r->depth : 0,
-                             r ? (unsigned)r->format : 0u, why);
+                             r ? (unsigned)r->format : 0u, r ? r->num_components : 0u,
+                             r ? r->tile_mode : 0u, r ? r->size : 0u, why);
             }
             images_ready = false;
         };
@@ -641,6 +651,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Fill the upload staging bytes.
             std::vector<uint8_t> upload((size_t)sbytes, 0);
             if (bi.storage) {
+                // The pure tile mapping and a production-backend fixture pass, but arbitrary live
+                // 1D/2D storage descriptors still need title validation before becoming the default.
+                // Keep the prior fail-visible behavior while allowing a bounded game A/B.
                 if (r->tile_mode && !dim_3d &&
                     !std::getenv("PROSPER_COMPUTE_TILED_2D_STORAGE")) {
                     skip_image(r, "tiled 1D/2D storage writeback deferred"); break;
@@ -934,6 +947,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
         }
         if (!images_ready) break;
+        phase_setup = ComputeClock::now();
 
         // Layout: the buffer bindings (filled above) + one entry per image binding (#590).
         for (size_t i = 0; i < images.size(); i++) {
@@ -1017,6 +1031,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (!vk_ok(vkCreateComputePipelines(ctx.device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipeline),
                    "compute-pipeline")) break;
         if (trace) std::fprintf(stderr, "[compute]   compute pipeline ready\n");
+        phase_pipeline = ComputeClock::now();
 
         VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
         pci.queueFamilyIndex = ctx.queue_family;
@@ -1097,6 +1112,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (!vk_ok(vkWaitForFences(ctx.device, 1, &fence, VK_TRUE,
                                    30ull * 1000 * 1000 * 1000), "queue-wait")) break;
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
+        phase_dispatch = ComputeClock::now();
 
         bool readback_ok = true;
         for (auto& buffer : buffers) {
@@ -1187,6 +1203,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         if (!readback_ok) break;
         ok = true;
+        phase_writeback = ComputeClock::now();
     } while (false);
 
     if (trace)
@@ -1232,6 +1249,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
     }
     cleanup();
+    if (phase_timing) {
+        const auto phase_cleanup = ComputeClock::now();
+        auto milliseconds = [](auto begin, auto end) {
+            return std::chrono::duration<double, std::milli>(end - begin).count();
+        };
+        std::fprintf(stderr,
+                     "[compute-phase] submit=%llu code=0x%llx ok=%u "
+                     "setup_ms=%.2f pipeline_ms=%.2f dispatch_ms=%.2f "
+                     "writeback_ms=%.2f cleanup_ms=%.2f total_ms=%.2f\n",
+                     (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
+                     ok ? 1u : 0u, milliseconds(phase_start, phase_setup),
+                     milliseconds(phase_setup, phase_pipeline),
+                     milliseconds(phase_pipeline, phase_dispatch),
+                     milliseconds(phase_dispatch, phase_writeback),
+                     milliseconds(phase_writeback, phase_cleanup),
+                     milliseconds(phase_start, phase_cleanup));
+    }
     return ok;
 }
 

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -1,9 +1,14 @@
 #pragma once
 #include "gpu/gpu_execute.hpp"
 
+#include <cstdint>
 #include <vector>
 
 namespace prosper::frontend {
+
+// Pack one raw float32 channel to UNORM8 using the storage-image conversion contract. Kept public
+// so the optimized scalar conversion can be checked directly against the previous lround path.
+uint8_t storage_pack_unorm8(uint32_t float_bits);
 
 // Execute already-realized compute items synchronously. Exposed for the production-backend test.
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items);

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1206,12 +1206,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             };
                             const uint64_t raw_hash = fnv(raw.data(), raw_got);
                             const uint64_t sample_hash = fnv(texture_pixels.data(), texture_pixels.size());
+                            const std::vector<uint8_t> inspected = inspection_rgba8(
+                                texture_pixels, tw, th, fr.texture_format);
+                            size_t rgb_nonblack = 0, alpha_nonzero = 0;
+                            for (size_t p = 0; p + 3 < inspected.size(); p += 4) {
+                                rgb_nonblack += inspected[p] != 0 || inspected[p + 1] != 0 ||
+                                                inspected[p + 2] != 0;
+                                alpha_nonzero += inspected[p + 3] != 0;
+                            }
                             const auto writer = prosper::gpu::last_guest_write_overlap(
                                 r.gpu_addr, raw_size);
                             fprintf(stderr,
                                     "[resource-version] render-submit=%llu draw=%llu order=%llu set=%u bind=%u "
                                     "addr=0x%llx dims=%ux%u class=%u fmt=%u tile=%u dcc=%u meta=0x%llx rtt=%d "
-                                    "raw=%zu/%zu:%016llx sample=%zu:%016llx "
+                                    "raw=%zu/%zu:%016llx sample=%zu:%016llx rgb_nonblack=%zu alpha_nonzero=%zu "
                                     "writer=%s/%llu/%llu/%llu/0x%llx\n",
                                     (unsigned long long)g_this_submit,
                                     (unsigned long long)draw.draw_index,
@@ -1222,11 +1230,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     (int)rtt_hit,
                                     raw_got, raw_size, (unsigned long long)raw_hash,
                                     texture_pixels.size(), (unsigned long long)sample_hash,
+                                    rgb_nonblack, alpha_nonzero,
                                     writer ? prosper::gpu::guest_writer_kind_name(writer->kind) : "none",
                                     (unsigned long long)(writer ? writer->submit : 0),
                                     (unsigned long long)(writer ? writer->item : 0),
                                     (unsigned long long)(writer ? writer->order : 0),
                                     (unsigned long long)(writer ? writer->identity : 0));
+                            if (getenv("PROSPER_DUMP_RESOURCE_VERSION")) {
+                                static std::set<std::pair<uint64_t, uint64_t>> dumped_versions;
+                                if (dumped_versions.emplace(r.gpu_addr, sample_hash).second) {
+                                    const char* dd = getenv("PROSPER_FRAME_DIR");
+                                    char fn[512];
+                                    snprintf(fn, sizeof fn, "%s/resource_%llx_%ux%u_%016llx.bmp",
+                                             dd && *dd ? dd : ".", (unsigned long long)r.gpu_addr, tw, th,
+                                             (unsigned long long)sample_hash);
+                                    prosper::test::dump_bmp(fn, inspected, tw, th);
+                                    fprintf(stderr, "[resource-version] dumped decoded sample -> %s\n", fn);
+                                }
+                            }
                         }
                         // PROSPER_PALETTELOG: compact identity/provenance trace for Unity's 256x16
                         // palette textures. Unlike GFXLOG this is cheap enough for a focused render

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -305,7 +305,8 @@ bool have_submit_compute();
 // Live render-target query (#590): the compute backend must not read a sampled input from raw guest
 // memory when the LIVE RENDERER owns that surface's current pixels (an RTT color target — raw memory
 // is then empty/stale, the Dead Cells 642x362 lesson). The live renderer registers this; the compute
-// backend imports an immutable CPU snapshot when one exists and otherwise skips loudly.
+// backend imports an immutable CPU snapshot for sampled bindings. Writable bindings seed from the
+// snapshot, publish their result to guest backing, and notify the renderer to invalidate its copy.
 using LiveTargetQueryFn = std::function<bool(uint64_t gpu_addr)>;
 void set_live_target_query(LiveTargetQueryFn fn);
 bool is_live_render_target(uint64_t gpu_addr);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -507,7 +507,8 @@ void maybe_dump_successful_shader(ShaderProgramStage stage, const ShaderCompileK
         fprintf(stderr, "[shader-dump] cannot create %s: %s\n", directory, ec.message().c_str());
         return;
     }
-    const char* tag = stage == ShaderProgramStage::Vertex ? "vs" : "ps";
+    const char* tag = stage == ShaderProgramStage::Vertex ? "vs" :
+                      stage == ShaderProgramStage::Fragment ? "ps" : "cs";
     char raw_path[1024], spirv_path[1024];
     snprintf(raw_path, sizeof(raw_path), "%s/success_%s_%016llx_%016llx.bin", directory, tag,
              static_cast<unsigned long long>(spirv_hash),
@@ -2099,6 +2100,13 @@ std::vector<ComputeItem> realize_compute_dispatches(
         ComputeItem item;
         item.spirv = recompile_compute((const uint32_t*)(uintptr_t)code_addr, 0x10000,
                                        table.get(), config);
+        if (!item.spirv.empty() && getenv("PROSPER_SHADER_DUMP_SUCCESS")) {
+            const ShaderCompileKey dump_key = make_shader_compile_key(
+                ShaderProgramStage::Compute,
+                reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+                0x10000, table.get(), nullptr, nullptr);
+            maybe_dump_successful_shader(ShaderProgramStage::Compute, dump_key, item.spirv);
+        }
         item.resources = std::move(table);
         item.launch = launch;
         item.code_addr = code_addr;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -4,9 +4,12 @@
 #include "live_compute.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
+#include <limits>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -14,15 +17,52 @@ using namespace prosper::gpu;
 static int fails = 0;
 #define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
 
-static void set_test_env(const char* name, const char* value) {
-#ifdef _WIN32
-    _putenv_s(name, value ? value : "");
-#else
-    if (value) setenv(name, value, 1); else unsetenv(name);
-#endif
-}
-
 int main() {
+    // MinGW's lround dominates full-HD storage-image writeback. Prove the bounded integer path is
+    // identical to the previous conversion across all half-float values, every UNORM threshold and
+    // adjacent float, plus a deterministic million-value float32 sample.
+    auto reference_unorm8 = [](uint32_t bits) {
+        float value;
+        std::memcpy(&value, &bits, sizeof(value));
+        if (std::isnan(value)) value = 0.0f;
+        value = value < 0.0f ? 0.0f : (value > 1.0f ? 1.0f : value);
+        return static_cast<uint8_t>(std::lround(value * 255.0f));
+    };
+    auto check_unorm8 = [&](float value) {
+        uint32_t bits;
+        std::memcpy(&bits, &value, sizeof(bits));
+        return prosper::frontend::storage_pack_unorm8(bits) == reference_unorm8(bits);
+    };
+    bool unorm8_matches = true;
+    const float edge_values[] = {
+        -std::numeric_limits<float>::infinity(), -1.0f, -0.0f, 0.0f,
+        std::numeric_limits<float>::denorm_min(), 1.0f,
+        std::numeric_limits<float>::infinity(), std::numeric_limits<float>::quiet_NaN(),
+    };
+    for (float value : edge_values) unorm8_matches &= check_unorm8(value);
+    for (uint32_t i = 0; i < 255; ++i) {
+        const float threshold = (static_cast<float>(i) + 0.5f) / 255.0f;
+        unorm8_matches &= check_unorm8(std::nextafter(threshold, 0.0f));
+        unorm8_matches &= check_unorm8(threshold);
+        unorm8_matches &= check_unorm8(std::nextafter(threshold, 1.0f));
+    }
+    for (uint32_t bits = 0; bits <= 0xffff; ++bits) {
+        const float value = prosper::gpu::half_to_float(static_cast<uint16_t>(bits));
+        unorm8_matches &= check_unorm8(value);
+    }
+    uint32_t random_bits = 0x6d2b79f5u;
+    for (uint32_t i = 0; i < 1000000; ++i) {
+        random_bits ^= random_bits << 13;
+        random_bits ^= random_bits >> 17;
+        random_bits ^= random_bits << 5;
+        if (prosper::frontend::storage_pack_unorm8(random_bits) !=
+            reference_unorm8(random_bits)) {
+            unorm8_matches = false;
+            break;
+        }
+    }
+    CHECK(unorm8_matches, "fast UNORM8 pack is equivalent to the lround reference");
+
     // Dead Cells' bound startup fill kernel, copied verbatim from eboot.elf at runtime address
     // 0x401aec200. It stores s4-s7 to record `(TGID_X << 6) + local_id_x` through the V# in s0-s3.
     static const uint32_t code[] = {
@@ -227,10 +267,8 @@ int main() {
         dcc_item.launch.local_y = dcc_item.launch.local_z = 1;
         dcc_item.launch.groups_y = dcc_item.launch.groups_z = 1;
         dcc_item.code_addr = 0x719dcc;
-        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", "1");
         CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
               "live backend writes the tiled DCC storage image");
-        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", nullptr);
         std::vector<uint8_t> dcc_linear(W * 4, 0);
         detile_surface(dcc_linear.data(), tiled_dst.data(), W, 1, dcc_tile, 0, 4);
         CHECK(dcc_linear == img_src,
@@ -273,7 +311,6 @@ int main() {
         &tiled2d_rt);
     CHECK(!tiled2d_spirv.empty(), "tiled 2D storage-image copy kernel recompiles");
     if (!tiled2d_spirv.empty()) {
-        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", "1");
         ComputeItem tiled2d_item;
         tiled2d_item.spirv = tiled2d_spirv;
         tiled2d_item.resources = std::make_shared<ShaderResourceTable>(tiled2d_rt);
@@ -293,7 +330,6 @@ int main() {
         std::copy_n(tiled2d_src_linear.begin(), W * 4, tiled2d_expected.begin());
         CHECK(tiled2d_result == tiled2d_expected,
               "tiled 2D storage-image writeback matches the linear reference byte-exactly");
-        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", nullptr);
     }
 
     // A renderer-owned color target is newer than its guest backing. Recompile the same copy kernel
@@ -353,6 +389,63 @@ int main() {
               "sampled renderer RTT pixels reach storage-image writeback byte-exactly");
         CHECK(live_dst != stale_rtt, "renderer RTT import does not use stale guest backing");
     }
+
+    // A renderer target can become a writable storage image before its pixels have been materialized
+    // in guest RAM. Seed the dispatch from the immutable renderer snapshot, modify row zero, and
+    // prove writeback preserves every untouched row while publishing a cache-invalidation write.
+    std::vector<uint8_t> writable_rtt_guest(tiled2d_bytes, 0);
+    auto writable_rtt = std::make_shared<std::vector<uint8_t>>(W * TILED_H * 4);
+    for (size_t i = 0; i < writable_rtt->size(); ++i)
+        (*writable_rtt)[i] = static_cast<uint8_t>(i * 17 + 3);
+    ShaderResourceTable writable_rt = tiled2d_rt;
+    for (ShaderResource& resource : writable_rt.resources) {
+        if (resource.binding == 5) {
+            resource.gpu_addr = reinterpret_cast<uint64_t>(writable_rtt_guest.data());
+            resource.size = static_cast<uint32_t>(writable_rtt_guest.size());
+        }
+    }
+    const uint64_t writable_addr = reinterpret_cast<uint64_t>(writable_rtt_guest.data());
+    set_live_target_query([writable_addr](uint64_t addr) { return addr == writable_addr; });
+    set_live_target_reader(
+        [writable_addr, writable_rtt](uint64_t addr, LiveTargetSnapshot& snapshot) {
+            if (addr != writable_addr) return false;
+            snapshot.width = W;
+            snapshot.height = TILED_H;
+            snapshot.format = LiveTargetPixelFormat::Rgba8Unorm;
+            snapshot.pixels = writable_rtt;
+            return true;
+        });
+    bool writable_rtt_published = false;
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        writable_rtt_published |= addr == writable_addr && size == writable_rtt_guest.size();
+    });
+    const std::vector<uint32_t> writable_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0,
+        &writable_rt);
+    CHECK(!writable_spirv.empty(), "writable renderer RTT copy kernel recompiles");
+    if (!writable_spirv.empty()) {
+        ComputeItem writable_item;
+        writable_item.spirv = writable_spirv;
+        writable_item.resources = std::make_shared<ShaderResourceTable>(writable_rt);
+        writable_item.launch.threads_x = W;
+        writable_item.launch.local_x = 64;
+        writable_item.launch.groups_x = 1;
+        writable_item.launch.local_y = writable_item.launch.local_z = 1;
+        writable_item.launch.groups_y = writable_item.launch.groups_z = 1;
+        writable_item.code_addr = 0x590593;
+        CHECK(prosper::frontend::execute_live_compute_items({writable_item}),
+              "live backend executes a dispatch writing a renderer-owned RTT");
+        std::vector<uint8_t> writable_result(W * TILED_H * 4, 0);
+        detile_surface(writable_result.data(), writable_rtt_guest.data(), W, TILED_H,
+                       tiled2d_mode, 0, 4);
+        std::vector<uint8_t> writable_expected = *writable_rtt;
+        std::copy_n(tiled2d_src_linear.begin(), W * 4, writable_expected.begin());
+        CHECK(writable_result == writable_expected,
+              "writable renderer RTT seeds from live pixels and preserves untouched rows");
+        CHECK(writable_rtt_published,
+              "writable renderer RTT publishes guest writeback for cache invalidation");
+    }
+    set_guest_gpu_write_observer({});
     set_live_target_reader({});
     set_live_target_query({});
 

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -240,6 +240,62 @@ int main() {
               "DCC storage writeback publishes uniform uncompressed metadata");
     }
 
+    // Exercise the same production path with a tiled 2D guest surface. The kernel copies row zero;
+    // every untouched row must survive upload/readback/retiling exactly. This guards the inverse
+    // address mapping used by live tiled StorageImage dispatches, not only the pure tile helper.
+    constexpr uint32_t TILED_H = 19;
+    constexpr uint32_t tiled2d_mode = static_cast<uint32_t>(TileMode::Sw4KbS);
+    std::vector<uint8_t> tiled2d_src_linear(W * TILED_H * 4);
+    std::vector<uint8_t> tiled2d_dst_initial(W * TILED_H * 4, 0x5a);
+    for (size_t i = 0; i < tiled2d_src_linear.size(); ++i)
+        tiled2d_src_linear[i] = static_cast<uint8_t>(i * 41 + 7);
+    const size_t tiled2d_bytes = tiled_surface_bytes(W, TILED_H, tiled2d_mode, 0, 4);
+    std::vector<uint8_t> tiled2d_src(tiled2d_bytes, 0), tiled2d_dst(tiled2d_bytes, 0);
+    tile_surface(tiled2d_src.data(), tiled2d_src_linear.data(), W, TILED_H,
+                 tiled2d_mode, 0, 4);
+    tile_surface(tiled2d_dst.data(), tiled2d_dst_initial.data(), W, TILED_H,
+                 tiled2d_mode, 0, 4);
+
+    ShaderResourceTable tiled2d_rt = irt;
+    for (ShaderResource& resource : tiled2d_rt.resources) {
+        if (resource.binding != 4 && resource.binding != 5) continue;
+        resource.img_dim = 1;
+        resource.width = W;
+        resource.height = TILED_H;
+        resource.depth = 1;
+        resource.tile_mode = tiled2d_mode;
+        resource.size = static_cast<uint32_t>(tiled2d_bytes);
+        resource.gpu_addr = reinterpret_cast<uint64_t>(
+            resource.binding == 4 ? tiled2d_src.data() : tiled2d_dst.data());
+    }
+    const std::vector<uint32_t> tiled2d_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0,
+        &tiled2d_rt);
+    CHECK(!tiled2d_spirv.empty(), "tiled 2D storage-image copy kernel recompiles");
+    if (!tiled2d_spirv.empty()) {
+        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", "1");
+        ComputeItem tiled2d_item;
+        tiled2d_item.spirv = tiled2d_spirv;
+        tiled2d_item.resources = std::make_shared<ShaderResourceTable>(tiled2d_rt);
+        tiled2d_item.launch.threads_x = W;
+        tiled2d_item.launch.local_x = 64;
+        tiled2d_item.launch.groups_x = 1;
+        tiled2d_item.launch.local_y = tiled2d_item.launch.local_z = 1;
+        tiled2d_item.launch.groups_y = tiled2d_item.launch.groups_z = 1;
+        tiled2d_item.code_addr = 0x590592;
+        CHECK(prosper::frontend::execute_live_compute_items({tiled2d_item}),
+              "production backend executes a tiled 2D storage-image dispatch");
+
+        std::vector<uint8_t> tiled2d_result(W * TILED_H * 4, 0);
+        detile_surface(tiled2d_result.data(), tiled2d_dst.data(), W, TILED_H,
+                       tiled2d_mode, 0, 4);
+        std::vector<uint8_t> tiled2d_expected = tiled2d_dst_initial;
+        std::copy_n(tiled2d_src_linear.begin(), W * 4, tiled2d_expected.begin());
+        CHECK(tiled2d_result == tiled2d_expected,
+              "tiled 2D storage-image writeback matches the linear reference byte-exactly");
+        set_test_env("PROSPER_COMPUTE_TILED_2D_STORAGE", nullptr);
+    }
+
     // A renderer-owned color target is newer than its guest backing. Recompile the same copy kernel
     // with a sampled source, publish deliberately different live pixels, and prove the production
     // backend imports the immutable renderer snapshot instead of either skipping or reading stale RAM.

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -278,6 +278,42 @@ int main() {
               "DCC storage writeback publishes uniform uncompressed metadata");
     }
 
+    // Two storage views may share base texels while only one carries DCC state. They are not safe
+    // Vulkan-image aliases: collapsing the compressed view onto an uncompressed owner drops its
+    // separate metadata writeback obligation and leaves later sampled users reading stale DCC.
+    std::vector<uint8_t> mixed_alias_base = tiled_src;
+    std::vector<uint8_t> mixed_alias_metadata(metadata_bytes, 0x40);
+    ShaderResourceTable mixed_alias_rt = dcc_rt;
+    for (ShaderResource& resource : mixed_alias_rt.resources) {
+        if (resource.binding != 4 && resource.binding != 5) continue;
+        resource.gpu_addr = reinterpret_cast<uint64_t>(mixed_alias_base.data());
+        if (resource.binding == 5) {
+            resource.metadata_addr = 0x207cf00000ull;
+            resource.dcc_metadata_host_data = mixed_alias_metadata.data();
+            resource.dcc_metadata_host_data_size = mixed_alias_metadata.size();
+        }
+    }
+    const std::vector<uint32_t> mixed_alias_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0,
+        &mixed_alias_rt);
+    CHECK(!mixed_alias_spirv.empty(), "mixed DCC storage-alias kernel recompiles");
+    if (!mixed_alias_spirv.empty()) {
+        ComputeItem mixed_alias_item;
+        mixed_alias_item.spirv = mixed_alias_spirv;
+        mixed_alias_item.resources = std::make_shared<ShaderResourceTable>(mixed_alias_rt);
+        mixed_alias_item.launch.threads_x = W;
+        mixed_alias_item.launch.local_x = 64;
+        mixed_alias_item.launch.groups_x = 1;
+        mixed_alias_item.launch.local_y = mixed_alias_item.launch.local_z = 1;
+        mixed_alias_item.launch.groups_y = mixed_alias_item.launch.groups_z = 1;
+        mixed_alias_item.code_addr = 0x719dcd;
+        CHECK(prosper::frontend::execute_live_compute_items({mixed_alias_item}),
+              "mixed compressed/uncompressed storage views execute independently");
+        CHECK(std::all_of(mixed_alias_metadata.begin(), mixed_alias_metadata.end(),
+                          [](uint8_t code) { return code == 0xff; }),
+              "compressed storage alias retains its DCC writeback obligation");
+    }
+
     // Exercise the same production path with a tiled 2D guest surface. The kernel copies row zero;
     // every untouched row must survive upload/readback/retiling exactly. This guards the inverse
     // address mapping used by live tiled StorageImage dispatches, not only the pure tile helper.
@@ -330,6 +366,96 @@ int main() {
         std::copy_n(tiled2d_src_linear.begin(), W * 4, tiled2d_expected.begin());
         CHECK(tiled2d_result == tiled2d_expected,
               "tiled 2D storage-image writeback matches the linear reference byte-exactly");
+    }
+
+    // Exercise the wider element mappings that become default-on with tiled storage. Float16 uses
+    // finite values so half->float->half is exact; Float32 follows the backend's raw channel contract.
+    auto wide_tiled_roundtrip = [&](DataFormat format, uint32_t bytes_per_texel,
+                                    uint64_t code_addr) {
+        const size_t linear_bytes = static_cast<size_t>(W) * TILED_H * bytes_per_texel;
+        std::vector<uint8_t> src_linear(linear_bytes, 0);
+        std::vector<uint8_t> dst_initial(linear_bytes, 0);
+        if (format == DataFormat::Float16) {
+            for (size_t i = 0; i < linear_bytes / 2; ++i) {
+                const uint16_t src_half = float_to_half(
+                    static_cast<float>(static_cast<int>(i % 31) - 15) / 16.0f);
+                const uint16_t dst_half = float_to_half(
+                    static_cast<float>(static_cast<int>(i % 17) - 8) / 8.0f);
+                std::memcpy(src_linear.data() + i * 2, &src_half, sizeof(src_half));
+                std::memcpy(dst_initial.data() + i * 2, &dst_half, sizeof(dst_half));
+            }
+        } else {
+            for (size_t i = 0; i < linear_bytes / 4; ++i) {
+                const uint32_t src_word = static_cast<uint32_t>(i * 2654435761u + 0x1020304u);
+                const uint32_t dst_word = static_cast<uint32_t>(i * 2246822519u + 0x5060708u);
+                std::memcpy(src_linear.data() + i * 4, &src_word, sizeof(src_word));
+                std::memcpy(dst_initial.data() + i * 4, &dst_word, sizeof(dst_word));
+            }
+        }
+        const size_t tiled_bytes_wide = tiled_surface_bytes(
+            W, TILED_H, tiled2d_mode, 0, bytes_per_texel);
+        std::vector<uint8_t> src_tiled(tiled_bytes_wide, 0);
+        std::vector<uint8_t> dst_tiled(tiled_bytes_wide, 0);
+        tile_surface(src_tiled.data(), src_linear.data(), W, TILED_H,
+                     tiled2d_mode, 0, bytes_per_texel);
+        tile_surface(dst_tiled.data(), dst_initial.data(), W, TILED_H,
+                     tiled2d_mode, 0, bytes_per_texel);
+        ShaderResourceTable wide_rt = tiled2d_rt;
+        for (ShaderResource& resource : wide_rt.resources) {
+            if (resource.binding != 4 && resource.binding != 5) continue;
+            resource.format = format;
+            resource.num_components = 4;
+            resource.size = static_cast<uint32_t>(tiled_bytes_wide);
+            resource.gpu_addr = reinterpret_cast<uint64_t>(
+                resource.binding == 4 ? src_tiled.data() : dst_tiled.data());
+        }
+        const std::vector<uint32_t> wide_spirv = recompile_valu(
+            image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0,
+            &wide_rt);
+        if (wide_spirv.empty()) return false;
+        ComputeItem wide_item;
+        wide_item.spirv = wide_spirv;
+        wide_item.resources = std::make_shared<ShaderResourceTable>(wide_rt);
+        wide_item.launch.threads_x = W;
+        wide_item.launch.local_x = 64;
+        wide_item.launch.groups_x = 1;
+        wide_item.launch.local_y = wide_item.launch.local_z = 1;
+        wide_item.launch.groups_y = wide_item.launch.groups_z = 1;
+        wide_item.code_addr = code_addr;
+        if (!prosper::frontend::execute_live_compute_items({wide_item})) return false;
+        std::vector<uint8_t> result(linear_bytes, 0);
+        detile_surface(result.data(), dst_tiled.data(), W, TILED_H,
+                       tiled2d_mode, 0, bytes_per_texel);
+        std::vector<uint8_t> expected = dst_initial;
+        std::copy_n(src_linear.begin(), static_cast<size_t>(W) * bytes_per_texel,
+                    expected.begin());
+        return result == expected;
+    };
+    CHECK(wide_tiled_roundtrip(DataFormat::Float16, 8, 0x590595),
+          "tiled Float16x4 storage writeback is byte-exact");
+    CHECK(wide_tiled_roundtrip(DataFormat::Float32, 16, 0x590596),
+          "tiled Float32x4 storage writeback is byte-exact");
+
+    ShaderResourceTable unsupported_tiled_rt = tiled2d_rt;
+    for (ShaderResource& resource : unsupported_tiled_rt.resources)
+        if (resource.binding == 4 || resource.binding == 5) resource.tile_mode = 6;
+    const std::vector<uint32_t> unsupported_tiled_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0,
+        &unsupported_tiled_rt);
+    CHECK(!unsupported_tiled_spirv.empty(), "unsupported tiled storage kernel still recompiles");
+    if (!unsupported_tiled_spirv.empty()) {
+        ComputeItem unsupported_tiled_item;
+        unsupported_tiled_item.spirv = unsupported_tiled_spirv;
+        unsupported_tiled_item.resources =
+            std::make_shared<ShaderResourceTable>(unsupported_tiled_rt);
+        unsupported_tiled_item.launch.threads_x = W;
+        unsupported_tiled_item.launch.local_x = 64;
+        unsupported_tiled_item.launch.groups_x = 1;
+        unsupported_tiled_item.launch.local_y = unsupported_tiled_item.launch.local_z = 1;
+        unsupported_tiled_item.launch.groups_y = unsupported_tiled_item.launch.groups_z = 1;
+        unsupported_tiled_item.code_addr = 0x590594;
+        CHECK(!prosper::frontend::execute_live_compute_items({unsupported_tiled_item}),
+              "unknown nonzero tile mode is rejected before storage writeback");
     }
 
     // A renderer-owned color target is newer than its guest backing. Recompile the same copy kernel

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -88,7 +88,9 @@ late consumer.
 `PROSPER_RENDER_RESOURCE_DIM=WxH` likewise executes submits that sample a matching image, allowing a
 producer/consumer A/B without rendering every unrelated submit between them.
 `PROSPER_RESOURCE_HASH_DIM=WxH` logs each matching sampled resource's raw guest hash, decoded/sample
-hash, RTT-hit state, last compute/DMA writer, draw index, and PM4 order. `PROSPER_TARGET_STEP_HASH_DIM`
+hash, nonblack RGB/alpha occupancy, RTT-hit state, last compute/DMA writer, draw index, and PM4 order.
+Add `PROSPER_DUMP_RESOURCE_VERSION=1` to write each distinct decoded version as a BMP under
+`PROSPER_FRAME_DIR`; this is an inspection artifact, not a pixel oracle. `PROSPER_TARGET_STEP_HASH_DIM`
 rerenders matching target passes by prefix and logs per-draw hashes plus dark/white/mean metrics;
 `PROSPER_TARGET_STEP_HASH_MIN_DRAWS=N` bounds that intentionally expensive bisect.
 `PROSPER_RENDER_DELAY_MS=N` skips synchronous Vulkan work for N milliseconds from the first submit while
@@ -205,8 +207,10 @@ external numeric/image inspection without dereferencing the original guest addre
 `--compute-only N` executes one realized dispatch in isolation; combine it with
 `--override-compute-spv N PATH` to minimize or hardware-A/B a captured shader without changing its exact
 resource descriptors. The override disables the pixel oracle. Tiled 1D/2D compute storage stays skipped
-unless `PROSPER_COMPUTE_TILED_2D_STORAGE=1` is explicitly set for a bounded diagnostic replay;
-`PROSPER_COMPUTELOG=1` then separates pipeline creation, submission, and dispatch-wait failures.
+unless `PROSPER_COMPUTE_TILED_2D_STORAGE=1` is explicitly set for a bounded diagnostic replay.
+`PROSPER_COMPUTELOG=1` separates pipeline creation, submission, dispatch-wait, import, and writeback failures.
+Renderer-owned RTT imports include their hash and nonzero-byte count, and buffer writeback logs include the
+first eight dwords so bounds/offset constant buffers can be identified without another code change.
 
 For compute producer provenance, `PROSPER_COMPUTELOG=1` records each `DispatchDirect` packet's
 threadgroup counts, compute-program address/hash, and AGC-resolved resources from the register state at

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -206,8 +206,8 @@ external numeric/image inspection without dereferencing the original guest addre
 `--dump-compute-resource N:BINDING PATH` writes its exact pre-dispatch storage-buffer bytes.
 `--compute-only N` executes one realized dispatch in isolation; combine it with
 `--override-compute-spv N PATH` to minimize or hardware-A/B a captured shader without changing its exact
-resource descriptors. The override disables the pixel oracle. Tiled 1D/2D compute storage stays skipped
-unless `PROSPER_COMPUTE_TILED_2D_STORAGE=1` is explicitly set for a bounded diagnostic replay.
+resource descriptors. The override disables the pixel oracle. Validated tiled 1D/2D compute storage executes
+by default; `PROSPER_DISABLE_COMPUTE_TILED_2D_STORAGE=1` restores the old skip for a diagnostic A/B.
 `PROSPER_COMPUTELOG=1` separates pipeline creation, submission, dispatch-wait, import, and writeback failures.
 Renderer-owned RTT imports include their hash and nonzero-byte count, and buffer writeback logs include the
 first eight dwords so bounds/offset constant buffers can be identified without another code change.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -110,10 +110,10 @@ or dispatches. `--override-compute-spv N PATH` replaces that dispatch's module a
 the input must be a 20-byte-to-16-MiB SPIR-V binary with the standard magic word. Overrides intentionally
 disable the capture pixel oracle and are for differential diagnosis, not correctness evidence.
 
-Tiled 1D/2D storage writeback remains disabled by default. Setting
-`PROSPER_COMPUTE_TILED_2D_STORAGE=1` enables the existing tiled upload/writeback path for an explicit replay
-A/B. This can expose host Vulkan compiler or execution failures, so use it only with a bounded capsule and
-the compute-only selector. With `PROSPER_COMPUTELOG=1`, replay identifies whether failure occurred while
+Validated tiled 1D/2D storage upload/writeback runs by default. Setting
+`PROSPER_DISABLE_COMPUTE_TILED_2D_STORAGE=1` restores the old skip for an explicit replay A/B. Use a bounded
+capsule and the compute-only selector when localizing a host Vulkan compiler or execution failure. With
+`PROSPER_COMPUTELOG=1`, replay identifies whether failure occurred while
 creating the pipeline, submitting it, or waiting for the dispatch.
 
 For a long live run, `PROSPER_COMPUTELOG_CODE=0x...` and

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -9,17 +9,19 @@ cmake --build build-linux -j8 --target shader_inspect
 ```
 
 `PROSPER_SHADER_DUMP=DIR` writes raw shaders that fail recompilation. To inspect a shader that succeeds,
-run the title or replay with `PROSPER_SHADER_DUMP_SUCCESS=DIR`. Each unique successful graphics shader
+run the title or replay with `PROSPER_SHADER_DUMP_SUCCESS=DIR`. Each unique successful graphics or compute shader
 produces a pair such as:
 
 ```text
 success_ps_35956264829da0c6_62ad8faab4566b7a.bin
 success_ps_35956264829da0c6_62ad8faab4566b7a.spv
+success_cs_6f6a5fdd6e9f8d73_2339aa565126d182.bin
+success_cs_6f6a5fdd6e9f8d73_2339aa565126d182.spv
 ```
 
 The first hash identifies the translated SPIR-V and the second identifies the exact raw RDNA2 stream.
 Pass the `.bin` file to `shader_inspect`; use the adjacent `.spv` for SPIR-V disassembly or validation.
-The dump directory is created automatically. `vs` and `ps` in filenames identify vertex and pixel stages.
+The dump directory is created automatically. `vs`, `ps`, and `cs` identify vertex, pixel, and compute stages.
 
 Each instruction row includes its dword PC, encoded length, format/opcode, exact raw words, decoded
 operands, and, for SOPP branches, the signed immediate and resolved target PC. The header also prints


### PR DESCRIPTION
## Summary
- enable the validated tiled 1D/2D compute storage path by default, retaining an explicit diagnostic opt-out
- prefer host-cached coherent Vulkan staging memory and replace the serial floating-point UNORM pack bottleneck with a byte-equivalent bounded conversion
- import renderer-owned RGBA8/RGBA16F RTT snapshots into compute and publish the written guest image bytes back to renderer invalidation
- extend the production Vulkan fixture across untouched-row preservation, RTT handoff, all half-float inputs, threshold edges, and randomized float bit patterns
- add successful compute shader and decoded resource-version diagnostics used during the investigation

## Performance
Native Windows, Blasphemous 2 1920x1080 tiled storage transition on RTX 4090:

- old CPU pack + retile/writeback: ~630-714 ms
- new pack: ~10-14 ms
- new layout/writeback: ~5-6 ms
- complete affected dispatch: ~55-63 ms after warmup

The previous GPU upload/dispatch/readback portion was already ~9-15 ms; cached staging and bounded packing remove the dominant CPU cost.

## Correctness
- every 65,536 half-float bit pattern and 1,000,000 deterministic random float bit patterns match the previous `lround(clamp(x)*255)` result
- renderer-owned storage writeback preserves untouched rows and notifies overlapping target invalidation
- full `test_game_compute` production Vulkan fixture passes
- full rebased Linux suite passes: 102/102
- DOLL Unreal capsule executes the 960×540 tiled storage dispatch by default and remains byte-exact with its live oracle (`26ed8b6191338383`)

## Review follow-up
- reject unknown nonzero tile modes before upload or writeback instead of treating them as linear
- require complete compression and metadata identity before storage views can share a Vulkan image
- cover a mixed compressed/uncompressed base alias and require the compressed view to publish its own DCC metadata
- cover production Float16x4 and Float32x4 tiled writeback byte-exactly
- allow renderer-owned storage upload to come entirely from its immutable snapshot without requiring guest RAM to be readable

The independent AGC dimension-mode fix is split into #796. Together, #796 and this PR make Blasphemous 2's `240x135` groups execute and copy the full `1920x1080` surface at practical speed. The copied source is still opaque black in the unresolved Windows menu state, which proves compute is no longer the producer of that black image; title-to-menu guest progression remains under investigation in #787.

Closes the tiled-writeback/performance portion of #787; does not close the issue.

## Snapshot guard
`python3 tools/snapshot/snapshot.py check` still stops before capture because the existing Messenger, Dead Cells, and Blasphemous 2 entries lack completed visual-review notes. No baseline or local game data is included.