### PR TITLE
fix(posix): preserve native static mutex behavior

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -267,8 +267,8 @@ if(TARGET prosper_core)
   target_link_libraries(test_dlsym_handle PRIVATE prosper_core)
   add_test(NAME dlsym_handle COMMAND test_dlsym_handle)
 
-  # Guest mutex TYPE semantics (#145): settype honored, Sony/FreeBSD ERRORCHECK default (incl.
-  # static-sentinel self-init), FreeBSD errno values (EDEADLK=11). Pure, no game dump needed.
+  # Guest mutex TYPE semantics (#145): settype honored, explicit Sony/FreeBSD ERRORCHECK default,
+  # non-recursive static-sentinel self-init, FreeBSD errno values (EDEADLK=11). Pure, no game dump.
   add_executable(test_mutex_types tests/test_mutex_types.cpp)
   target_link_libraries(test_mutex_types PRIVATE prosper_core)
   add_test(NAME mutex_types COMMAND test_mutex_types)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -156,10 +156,15 @@ HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { free(*(void**)a0); *(voi
 // CONFIDENCE: HIGH (semantics cross-checked against FreeBSD libthr + the Kyty reference).
 namespace {
     inline bool pt_static_sentinel(void* v) { return (uintptr_t)v < 0x1000; }  // NULL/1/2/3... = static initializer
+#ifdef _WIN32
+    // winpthreads' cooperative try-lock loop cannot rely on pthread_mutex_lock to report a
+    // same-thread ERRORCHECK relock before it starts polling. Track ownership explicitly on Windows
+    // for that path. Native POSIX hosts already implement the ERRORCHECK contract in pthreads; putting
+    // their every guest lock/unlock through this one process-global map mutex serializes unrelated UE4
+    // locks and severely throttles synchronization-heavy titles (#719/#793 regression).
     struct GuestMutexState { int type = PTHREAD_MUTEX_NORMAL; uint64_t owner = 0; uint32_t depth = 0; };
     std::mutex g_guest_mutex_state_mutex;
     std::unordered_map<pthread_mutex_t*, GuestMutexState> g_guest_mutex_states;
-
     void guest_mutex_register(pthread_mutex_t* mutex, int type) {
         std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
         g_guest_mutex_states[mutex] = {type, 0, 0};
@@ -199,6 +204,13 @@ namespace {
             found->second.depth = 0;
         }
     }
+#else
+    inline void guest_mutex_register(pthread_mutex_t*, int) {}
+    inline void guest_mutex_unregister(pthread_mutex_t*) {}
+    inline bool guest_mutex_self_deadlock(pthread_mutex_t*) { return false; }
+    inline void guest_mutex_acquired(pthread_mutex_t*) {}
+    inline void guest_mutex_released(pthread_mutex_t*) {}
+#endif
 
     pthread_mutex_t* ensure_mutex(uint64_t slot_addr) {
         if (!slot_addr) return nullptr;
@@ -207,12 +219,18 @@ namespace {
         if (!pt_static_sentinel(cur)) return (pthread_mutex_t*)cur;
         auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
         pthread_mutexattr_t at; pthread_mutexattr_init(&at);
+#ifdef _WIN32
+        // winpthreads needs the explicit type so cooperative polling can reproduce FreeBSD's
+        // same-thread EDEADLK result. Preserve the native-POSIX initializer used before #793 on
+        // Linux/macOS; changing every UE4 static lock there was outside the Windows fix's scope and
+        // materially changes title progression.
         pthread_mutexattr_settype(&at, PTHREAD_MUTEX_ERRORCHECK);
-        // The FreeBSD static sentinel ENCODES the type: NULL = PTHREAD_MUTEX_INITIALIZER (the
-        // DEFAULT type, which is ERRORCHECK on FreeBSD), 1 = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP.
-        // BOTH map to host ERRORCHECK: FreeBSD's self-lock contract returns EDEADLK for the
-        // default AND adaptive types (libthr mutex_self_lock; adaptive's spin is pure
-        // performance). Previously every sentinel self-init forced RECURSIVE (#145).
+#endif
+        // The FreeBSD static sentinel ENCODES the type: NULL = PTHREAD_MUTEX_INITIALIZER and
+        // 1 = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP. Windows maps both to ERRORCHECK above because
+        // its cooperative poller needs an explicit same-owner result. Native POSIX retains the
+        // host-default self-init behavior used before #793; forcing every static UE4 mutex to
+        // ERRORCHECK there changed both scheduling and title progression.
         pthread_mutex_init(m, &at);
         pthread_mutexattr_destroy(&at);
         if (__atomic_compare_exchange_n(slot, &cur, (void*)m, false,

--- a/prosper/tests/test_mutex_types.cpp
+++ b/prosper/tests/test_mutex_types.cpp
@@ -74,13 +74,13 @@ int main() {
     CHECK(attr_settype(U(&battr), 99, 0, 0, 0, 0) == 0x16, "settype(99) rejected EINVAL(22)");
     attr_destroy(U(&battr), 0, 0, 0, 0, 0);
 
-    // 5. STATIC SENTINEL self-init (PTHREAD_MUTEX_INITIALIZER == NULL) = DEFAULT = ERRORCHECK:
+    // 5. STATIC SENTINEL self-init remains non-recursive (native POSIX default; Windows ERRORCHECK):
     //    this is the bdwgc GC_allocate_ml shape — trylock on an owned static lock MUST fail
     //    (before this fix the self-init forced RECURSIVE and trylock succeeded on the owner).
     void* smtx = nullptr;   // NULL sentinel; first use self-initializes
     CHECK(m_lock(U(&smtx), 0, 0, 0, 0, 0) == 0 && smtx, "static sentinel self-initializes on lock");
-    CHECK(m_trylock(U(&smtx), 0, 0, 0, 0, 0) == 16, "static default: trylock on owned fails EBUSY(16)");
-    CHECK(m_unlock(U(&smtx), 0, 0, 0, 0, 0) == 0, "static default: unlock");
+    CHECK(m_trylock(U(&smtx), 0, 0, 0, 0, 0) == 16, "static non-recursive: trylock on owned fails EBUSY(16)");
+    CHECK(m_unlock(U(&smtx), 0, 0, 0, 0, 0) == 0, "static non-recursive: unlock");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary

- keep #793's cooperative ownership tracking and forced ERRORCHECK static mutexes on Windows
- restore the pre-#793 native pthread static-mutex initializer on Linux and macOS
- avoid routing every POSIX guest mutex operation through one process-global ownership-map lock
- update the mutex regression wording to describe the platform-specific implementation accurately

Refs #690 and the regression introduced by #793.

## Why

#793 was Windows-focused but changed generic mutex behavior. On POSIX it forced every lazily initialized UE4 static mutex to ERRORCHECK and serialized every lock/unlock/condition transition through a single ownership map. DOLL stopped reliably reaching its known scene selector on current master.

Scoping those mechanisms to Windows preserves the cooperative exception delivery path while restoring the POSIX behavior that existed before #793.

## Validation

- `test_mutex_types`
- `test_sync_on_address`
- `test_sync_delete`
- `test_equeue_events`
- `test_rwlock_once`
- DOLL exact scene selector reached twice from current master:
  - submit 421 in 12.1s
  - submit 425 in 9.2s (46.3 submits/s)
- a third route showed the title's existing intermittent selector miss but still advanced 557 submits in 56.2s
- with ownership-map locking removed but forced POSIX ERRORCHECK still present, the same route advanced only 11.0 submits/s and missed the selector; restoring native static initialization was the decisive compatibility change

No game-derived capture data is included.