### PR TITLE
tools(sync): attribute delayed Windows traces

### DIFF
--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -229,6 +229,12 @@ raise/deliver/resume), `PROSPER_MEMLOG`, `PROSPER_VEHLOG`, and boot_trace `[memc
 known-good Linux capture when separating cross-platform frontend faults from shared renderer faults. For a
 long boot, `PROSPER_SYNCLOG_DELAY_MS=N` suppresses the high-volume `[sync2]` stream until N milliseconds
 after the first synchronization call, retaining normal progression before the suspected boundary.
+`PROSPER_SYNCLOG_PTHREAD=0xN` restricts `[sync2]` records to one guest pthread when a full trace perturbs
+the title; pair it with the app's guest-thread checkpoint to obtain the pthread id.
+`PROSPER_SYNCLOG_COND_ONLY=1` further suppresses semaphore and event-flag records while retaining raw
+condition waits/signals/broadcasts.
+`PROSPER_SYNCLOG_SEMA_ONLY=1` instead keeps semaphore records. With a pthread filter, the last semaphore
+that thread waits on becomes the focus, so matching signals from other threads are retained automatically.
 
 ## Gotchas learned (so the next agent doesn't relearn them)
 

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -224,9 +224,11 @@ See `FRONTEND_APP.md` for the invalidation requirement.
 
 Diagnostics (env, all off by default): `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode + the `NOT satisfied`
 fence log), `PROSPER_EVLOG` (`[ev]` equeue/flip/EOP), `PROSPER_SYNCLOG` (`[sync]` WaitOnAddress/Wake with
-tid + validated guest caller, `[sync2]` cond/sema/EventFlag), `PROSPER_EXCLOG` (GC exception
+native thread id + validated guest caller, `[sync2]` cond/sema/EventFlag), `PROSPER_EXCLOG` (GC exception
 raise/deliver/resume), `PROSPER_MEMLOG`, `PROSPER_VEHLOG`, and boot_trace `[memclass]`. Compare with a
-known-good Linux capture when separating cross-platform frontend faults from shared renderer faults.
+known-good Linux capture when separating cross-platform frontend faults from shared renderer faults. For a
+long boot, `PROSPER_SYNCLOG_DELAY_MS=N` suppresses the high-volume `[sync2]` stream until N milliseconds
+after the first synchronization call, retaining normal progression before the suspected boundary.
 
 ## Gotchas learned (so the next agent doesn't relearn them)
 

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -103,6 +103,10 @@ void win_set_key_delete_after_host_hook_for_test(void (*hook)(uint64_t));
 size_t win_key_destructor_thunk_count_for_test();
 #endif
 
+// Preserve the unsigned native-thread identifier used by sync/exception diagnostics. Exposed so
+// the high-bit formatting contract can be covered without relying on the OS to allocate such a TID.
+uint64_t sync_trace_tid_value(uint64_t native_tid);
+
 // The default target for unimplemented imports: logs (first-seen) and returns 0.
 // Called by generated stubs with the import index in the first arg. Windows stubs also preserve the
 // guest return address and pre-call stack pointer for low-volume caller attribution.

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -51,6 +51,8 @@ namespace { bool sclog() { static int v = getenv("PROSPER_SYNCLOG") ? 1 : 0; ret
     long sctid() {
 #if defined(__linux__) || defined(__APPLE__)
         return (long)prosper_gettid();
+#elif defined(_WIN32)
+        return (long)GetCurrentThreadId();
 #else
         return 0;
 #endif

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -49,7 +49,14 @@
 
 namespace prosper {
 namespace {
-    bool sclog() {
+    uint64_t sclog_pthread_filter() {
+        static const uint64_t filter = [] {
+            const char* value = getenv("PROSPER_SYNCLOG_PTHREAD");
+            return value ? strtoull(value, nullptr, 0) : 0ull;
+        }();
+        return filter;
+    }
+    bool sclog_time_enabled() {
         static const bool enabled = getenv("PROSPER_SYNCLOG") != nullptr;
         if (!enabled) return false;
         static const uint64_t delay_ms = [] {
@@ -59,6 +66,28 @@ namespace {
         if (!delay_ms) return true;
         static const auto start = std::chrono::steady_clock::now();
         return std::chrono::steady_clock::now() - start >= std::chrono::milliseconds(delay_ms);
+    }
+    bool sclog_thread_enabled() {
+        const uint64_t filter = sclog_pthread_filter();
+        return sclog_time_enabled() && (!filter || (uint64_t)pthread_self() == filter);
+    }
+    bool sclog_condition() {
+        static const bool semaphore_only = getenv("PROSPER_SYNCLOG_SEMA_ONLY") != nullptr;
+        return !semaphore_only && sclog_thread_enabled();
+    }
+    bool sclog_semaphore() {
+        static const bool condition_only = getenv("PROSPER_SYNCLOG_COND_ONLY") != nullptr;
+        return !condition_only && sclog_thread_enabled();
+    }
+    bool sclog() {
+        static const bool condition_only = getenv("PROSPER_SYNCLOG_COND_ONLY") != nullptr;
+        static const bool semaphore_only = getenv("PROSPER_SYNCLOG_SEMA_ONLY") != nullptr;
+        return !condition_only && !semaphore_only && sclog_thread_enabled();
+    }
+    std::atomic<uint64_t> g_sclog_focus_sema{0};
+    bool sclog_focused_semaphore(uint64_t sema) {
+        return sclog_time_enabled() && sema &&
+               g_sclog_focus_sema.load(std::memory_order_acquire) == sema;
     }
     long sctid() {
 #if defined(__linux__) || defined(__APPLE__)
@@ -367,16 +396,16 @@ HLE(k_condattr_init)    { if (a0) { auto* c = (pthread_condattr_t*)calloc(1, siz
 HLE(k_condattr_destroy) { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 HLE(k_cond_init)      { if (!a0) return 0x16; auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)a0 = c; return 0; }
 HLE(k_cond_destroy)   { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_cond_destroy((pthread_cond_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
-HLE(k_cond_signal)    { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_signal(c); return 0; }
-HLE(k_cond_broadcast) { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_broadcast(c); return 0; }
-HLE(k_cond_wait)      { if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
+HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_signal(c); return 0; }
+HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_broadcast(c); return 0; }
+HLE(k_cond_wait)      { if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
     { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
       if (c && m) {
           guest_mutex_released(m);
           const int result = interruptible_cond_wait(c, m);
           if (result == 0) guest_mutex_acquired(m);
       } }
-    if (sclog()) fprintf(stderr, "[sync2] T%ld COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
+    if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
 // POSIX pthread_cond_timedwait(cond_slot, mutex_slot, const timespec* abstime) — abstime is an
 // ABSOLUTE CLOCK_REALTIME deadline ({i64 sec, i64 nsec}, FreeBSD == Linux x86-64 layout), and the
 // POSIX shim returns the errno VALUE directly (FreeBSD ETIMEDOUT = 60). This was an unimplemented
@@ -1035,7 +1064,7 @@ HLE(k_sema_create) { // (sema*, name, attr, initCount, maxCount, opt)
     auto* s = (Sema*)calloc(1, sizeof(Sema));
     pthread_mutex_init(&s->m, nullptr); pthread_cond_init(&s->c, nullptr); s->count = (int64_t)(int32_t)a3;
     if (a0) *(void**)(uintptr_t)a0 = s;
-    if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.create  sema=0x%llx name='%s' init=%lld max=%lld\n",
+    if (sclog_semaphore()) fprintf(stderr, "[sync2] T%ld SEMA.create  sema=0x%llx name='%s' init=%lld max=%lld\n",
                          sctid(), (unsigned long long)(uintptr_t)s, a1 ? (const char*)(uintptr_t)a1 : "",
                          (long long)(int32_t)a3, (long long)(int32_t)a4);
     return 0;
@@ -1052,7 +1081,10 @@ HLE(k_sema_delete) {
 }
 HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout honored like k_ef_wait
     auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
-    if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
+    const bool log_wait = sclog_semaphore();
+    if (log_wait && sclog_pthread_filter())
+        g_sclog_focus_sema.store(a0, std::memory_order_release);
+    if (log_wait) fprintf(stderr, "[sync2] T%ld SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
     uint64_t ret = 0;
     interruptible_mutex_lock(&s->m);
     s->waiters++;
@@ -1080,7 +1112,8 @@ HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout hon
     if (last) sema_destroy(s);
     return ret; }
 HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n = a1 ? (int64_t)a1 : 1;
-    if (sclog()) fprintf(stderr, "[sync2] T%ld SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
+    if (sclog_semaphore() || sclog_focused_semaphore(a0))
+        fprintf(stderr, "[sync2] T%ld SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
     interruptible_mutex_lock(&s->m); s->count += n; interruptible_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
 HLE(k_sema_poll)   { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
     interruptible_mutex_lock(&s->m); bool ok = s->count >= need; if (ok) s->count -= need; pthread_mutex_unlock(&s->m); return ok ? 0 : 0x80020023; }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -32,6 +32,7 @@
 #include <atomic>
 #include <array>
 #include <condition_variable>
+#include <chrono>
 #include <new>
 #ifdef _WIN32
 #include <windows.h>   // GetCurrentThreadStackLimits/GetCurrentThreadId for the guest-thread trampoline
@@ -47,7 +48,18 @@
 #endif
 
 namespace prosper {
-namespace { bool sclog() { static int v = getenv("PROSPER_SYNCLOG") ? 1 : 0; return v; }
+namespace {
+    bool sclog() {
+        static const bool enabled = getenv("PROSPER_SYNCLOG") != nullptr;
+        if (!enabled) return false;
+        static const uint64_t delay_ms = [] {
+            const char* value = getenv("PROSPER_SYNCLOG_DELAY_MS");
+            return value ? strtoull(value, nullptr, 10) : 0ull;
+        }();
+        if (!delay_ms) return true;
+        static const auto start = std::chrono::steady_clock::now();
+        return std::chrono::steady_clock::now() - start >= std::chrono::milliseconds(delay_ms);
+    }
     long sctid() {
 #if defined(__linux__) || defined(__APPLE__)
         return (long)prosper_gettid();

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -31,6 +31,7 @@
 #include <thread>
 #include <atomic>
 #include <array>
+#include <cinttypes>
 #include <condition_variable>
 #include <chrono>
 #include <new>
@@ -48,6 +49,10 @@
 #endif
 
 namespace prosper {
+uint64_t sync_trace_tid_value(uint64_t native_tid) {
+    return native_tid;
+}
+
 namespace {
     uint64_t sclog_pthread_filter() {
         static const uint64_t filter = [] {
@@ -73,27 +78,30 @@ namespace {
     }
     bool sclog_condition() {
         static const bool semaphore_only = getenv("PROSPER_SYNCLOG_SEMA_ONLY") != nullptr;
-        return !semaphore_only && sclog_thread_enabled();
+        const bool thread_enabled = sclog_thread_enabled();
+        return thread_enabled && !semaphore_only;
     }
     bool sclog_semaphore() {
         static const bool condition_only = getenv("PROSPER_SYNCLOG_COND_ONLY") != nullptr;
-        return !condition_only && sclog_thread_enabled();
+        const bool thread_enabled = sclog_thread_enabled();
+        return thread_enabled && !condition_only;
     }
     bool sclog() {
         static const bool condition_only = getenv("PROSPER_SYNCLOG_COND_ONLY") != nullptr;
         static const bool semaphore_only = getenv("PROSPER_SYNCLOG_SEMA_ONLY") != nullptr;
-        return !condition_only && !semaphore_only && sclog_thread_enabled();
+        const bool thread_enabled = sclog_thread_enabled();
+        return thread_enabled && !condition_only && !semaphore_only;
     }
     std::atomic<uint64_t> g_sclog_focus_sema{0};
     bool sclog_focused_semaphore(uint64_t sema) {
         return sclog_time_enabled() && sema &&
                g_sclog_focus_sema.load(std::memory_order_acquire) == sema;
     }
-    long sctid() {
+    uint64_t sctid() {
 #if defined(__linux__) || defined(__APPLE__)
-        return (long)prosper_gettid();
+        return sync_trace_tid_value(static_cast<uint64_t>(prosper_gettid()));
 #elif defined(_WIN32)
-        return (long)GetCurrentThreadId();
+        return sync_trace_tid_value(static_cast<uint32_t>(GetCurrentThreadId()));
 #else
         return 0;
 #endif
@@ -396,16 +404,16 @@ HLE(k_condattr_init)    { if (a0) { auto* c = (pthread_condattr_t*)calloc(1, siz
 HLE(k_condattr_destroy) { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 HLE(k_cond_init)      { if (!a0) return 0x16; auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)a0 = c; return 0; }
 HLE(k_cond_destroy)   { if (a0 && !pt_static_sentinel(*(void**)a0)) { pthread_cond_destroy((pthread_cond_t*)*(void**)a0); free(*(void**)a0); } if (a0) *(void**)a0 = nullptr; return 0; }
-HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_signal(c); return 0; }
-HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_broadcast(c); return 0; }
-HLE(k_cond_wait)      { if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
+HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_signal(c); return 0; }
+HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) interruptible_cond_broadcast(c); return 0; }
+HLE(k_cond_wait)      { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
     { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
       if (c && m) {
           guest_mutex_released(m);
           const int result = interruptible_cond_wait(c, m);
           if (result == 0) guest_mutex_acquired(m);
       } }
-    if (sclog_condition()) fprintf(stderr, "[sync2] T%ld COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
+    if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
 // POSIX pthread_cond_timedwait(cond_slot, mutex_slot, const timespec* abstime) — abstime is an
 // ABSOLUTE CLOCK_REALTIME deadline ({i64 sec, i64 nsec}, FreeBSD == Linux x86-64 layout), and the
 // POSIX shim returns the errno VALUE directly (FreeBSD ETIMEDOUT = 60). This was an unimplemented
@@ -936,7 +944,7 @@ HLE(k_ef_delete)  {
     if (!has_waiters) ef_destroy(e);               // none parked -> free now; else the last waiter frees
     return 0;
 }
-HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; if (sclog()) fprintf(stderr, "[sync2] T%ld EF.set       ef=0x%llx bits|=0x%llx\n", sctid(), (unsigned long long)a0, (unsigned long long)a1); interruptible_mutex_lock(&e->m); e->bits |= a1; interruptible_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
+HLE(k_ef_set)     { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; if (sclog()) fprintf(stderr, "[sync2] T%" PRIu64 " EF.set       ef=0x%llx bits|=0x%llx\n", sctid(), (unsigned long long)a0, (unsigned long long)a1); interruptible_mutex_lock(&e->m); e->bits |= a1; interruptible_cond_broadcast(&e->c); pthread_mutex_unlock(&e->m); return 0; }
 HLE(k_ef_clear)   { auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0; interruptible_mutex_lock(&e->m); e->bits &= a1; pthread_mutex_unlock(&e->m); return 0; }
 // Absolute CLOCK_REALTIME deadline `usec` microseconds from now (for pthread_cond_timedwait
 // on default-attr condvars, which time against CLOCK_REALTIME).
@@ -1010,7 +1018,7 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
     // expiry returns KERNEL_ERROR_ETIMEDOUT (Kyty EventFlag.cpp / Errno.h 0x8002003C).
     auto* e = (EventFlag*)(uintptr_t)a0; if (!e) return 0;
     uint64_t ret = 0;
-    if (sclog()) fprintf(stderr, "[sync2] T%ld EF.wait.ent  ef=0x%llx pat=0x%llx mode=0x%llx bits=0x%llx\n",
+    if (sclog()) fprintf(stderr, "[sync2] T%" PRIu64 " EF.wait.ent  ef=0x%llx pat=0x%llx mode=0x%llx bits=0x%llx\n",
                          sctid(), (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
                          (unsigned long long)e->bits);
     interruptible_mutex_lock(&e->m);
@@ -1039,7 +1047,7 @@ HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* ti
     pthread_mutex_unlock(&e->m);
     if (last) ef_destroy(e);                        // safe: `res` was copied before the free
     if (a3) *(uint64_t*)(uintptr_t)a3 = res;
-    if (sclog()) fprintf(stderr, "[sync2] T%ld EF.wait.exit ef=0x%llx res=0x%llx ret=0x%llx\n",
+    if (sclog()) fprintf(stderr, "[sync2] T%" PRIu64 " EF.wait.exit ef=0x%llx res=0x%llx ret=0x%llx\n",
                          sctid(), (unsigned long long)a0, (unsigned long long)res, (unsigned long long)ret);
     return ret;
 }
@@ -1064,13 +1072,16 @@ HLE(k_sema_create) { // (sema*, name, attr, initCount, maxCount, opt)
     auto* s = (Sema*)calloc(1, sizeof(Sema));
     pthread_mutex_init(&s->m, nullptr); pthread_cond_init(&s->c, nullptr); s->count = (int64_t)(int32_t)a3;
     if (a0) *(void**)(uintptr_t)a0 = s;
-    if (sclog_semaphore()) fprintf(stderr, "[sync2] T%ld SEMA.create  sema=0x%llx name='%s' init=%lld max=%lld\n",
+    if (sclog_semaphore()) fprintf(stderr, "[sync2] T%" PRIu64 " SEMA.create  sema=0x%llx name='%s' init=%lld max=%lld\n",
                          sctid(), (unsigned long long)(uintptr_t)s, a1 ? (const char*)(uintptr_t)a1 : "",
                          (long long)(int32_t)a3, (long long)(int32_t)a4);
     return 0;
 }
 HLE(k_sema_delete) {
     auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0;
+    uint64_t focused = a0;
+    g_sclog_focus_sema.compare_exchange_strong(focused, 0, std::memory_order_acq_rel,
+                                                std::memory_order_acquire);
     interruptible_mutex_lock(&s->m);
     s->deleted = true;
     interruptible_cond_broadcast(&s->c);
@@ -1084,7 +1095,7 @@ HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout hon
     const bool log_wait = sclog_semaphore();
     if (log_wait && sclog_pthread_filter())
         g_sclog_focus_sema.store(a0, std::memory_order_release);
-    if (log_wait) fprintf(stderr, "[sync2] T%ld SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
+    if (log_wait) fprintf(stderr, "[sync2] T%" PRIu64 " SEMA.wait     sema=0x%llx need=%lld\n", sctid(), (unsigned long long)a0, (long long)need);
     uint64_t ret = 0;
     interruptible_mutex_lock(&s->m);
     s->waiters++;
@@ -1113,7 +1124,7 @@ HLE(k_sema_wait)   { // (sema, need, SceKernelUseconds* timeout) — timeout hon
     return ret; }
 HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n = a1 ? (int64_t)a1 : 1;
     if (sclog_semaphore() || sclog_focused_semaphore(a0))
-        fprintf(stderr, "[sync2] T%ld SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
+        fprintf(stderr, "[sync2] T%" PRIu64 " SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
     interruptible_mutex_lock(&s->m); s->count += n; interruptible_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
 HLE(k_sema_poll)   { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
     interruptible_mutex_lock(&s->m); bool ok = s->count >= need; if (ok) s->count -= need; pthread_mutex_unlock(&s->m); return ok ? 0 : 0x80020023; }
@@ -1848,7 +1859,7 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
     ensure_exc_sig();
     if (g_exc_counter) (*g_exc_counter)++;
     if (g_exc_log)
-        fprintf(stderr, "[exc] T%ld raise target=0x%llx type=0x%llx\n",
+        fprintf(stderr, "[exc] T%" PRIu64 " raise target=0x%llx type=0x%llx\n",
                 sctid(), (unsigned long long)a0, (unsigned long long)a1);
 #if defined(__linux__) || defined(__APPLE__)
     if (a0 && a1 < 128 && g_exc_handlers[a1]) {

--- a/prosper/tests/test_sync_delete.cpp
+++ b/prosper/tests/test_sync_delete.cpp
@@ -8,9 +8,20 @@
 #include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cinttypes>
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
 #include <thread>
+#include <vector>
+#include <pthread.h>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace prosper;
 
@@ -19,9 +30,75 @@ static int fails = 0;
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
 static constexpr uint32_t kEACCES = 0x8002000Du;
+static constexpr uint32_t kETIMEDOUT = 0x8002003Cu;
+
+static bool set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, 1) == 0;
+#endif
+}
+
+static int file_descriptor(FILE* file) {
+#ifdef _WIN32
+    return _fileno(file);
+#else
+    return fileno(file);
+#endif
+}
+
+static int duplicate_descriptor(int fd) {
+#ifdef _WIN32
+    return _dup(fd);
+#else
+    return dup(fd);
+#endif
+}
+
+static int replace_descriptor(int from, int to) {
+#ifdef _WIN32
+    return _dup2(from, to);
+#else
+    return dup2(from, to);
+#endif
+}
+
+static void close_descriptor(int fd) {
+#ifdef _WIN32
+    _close(fd);
+#else
+    close(fd);
+#endif
+}
 
 int main() {
     printf("== test_sync_delete ==\n");
+    char formatted_tid[32]{};
+    snprintf(formatted_tid, sizeof(formatted_tid), "%" PRIu64,
+             sync_trace_tid_value(0x80000000u));
+    CHECK(strcmp(formatted_tid, "2147483648") == 0,
+          "sync trace formats an unsigned high-bit native TID");
+
+    char pthread_filter[32]{};
+    snprintf(pthread_filter, sizeof(pthread_filter), "%llu",
+             (unsigned long long)(uintptr_t)pthread_self());
+    CHECK(set_test_env("PROSPER_SYNCLOG", "1"), "sync trace enabled for regression");
+    CHECK(set_test_env("PROSPER_SYNCLOG_SEMA_ONLY", "1"), "semaphore-only trace enabled");
+    CHECK(set_test_env("PROSPER_SYNCLOG_DELAY_MS", "20"), "sync trace delay configured");
+    CHECK(set_test_env("PROSPER_SYNCLOG_PTHREAD", pthread_filter), "sync trace pthread filter configured");
+
+    FILE* trace_file = tmpfile();
+    int saved_stderr = -1;
+    bool capturing = false;
+    if (trace_file) {
+        fflush(stderr);
+        saved_stderr = duplicate_descriptor(file_descriptor(stderr));
+        capturing = saved_stderr >= 0 &&
+                    replace_descriptor(file_descriptor(trace_file), file_descriptor(stderr)) >= 0;
+    }
+    CHECK(capturing, "stderr trace capture initialized");
+
     register_builtin_hle();
 
     auto ef_create = Hle::lookup(nid_hash("sceKernelCreateEventFlag"));
@@ -30,8 +107,12 @@ int main() {
     auto se_create = Hle::lookup(nid_hash("sceKernelCreateSema"));
     auto se_wait   = Hle::lookup(nid_hash("sceKernelWaitSema"));
     auto se_delete = Hle::lookup(nid_hash("sceKernelDeleteSema"));
-    CHECK(ef_create && ef_wait && ef_delete && se_create && se_wait && se_delete, "ef/sema fns registered");
-    if (!(ef_create && ef_wait && ef_delete && se_create && se_wait && se_delete)) { printf("== FAIL ==\n"); return 1; }
+    auto se_signal = Hle::lookup(nid_hash("sceKernelSignalSema"));
+    CHECK(ef_create && ef_wait && ef_delete && se_create && se_wait && se_delete && se_signal,
+          "ef/sema fns registered");
+    if (!(ef_create && ef_wait && ef_delete && se_create && se_wait && se_delete && se_signal)) {
+        printf("== FAIL ==\n"); return 1;
+    }
 
     // --- EventFlag: park a thread on an infinite wait for a bit-pattern that never gets set, then
     //     delete the flag. The waiter must wake with EACCES (not hang, not crash on freed memory). ---
@@ -56,7 +137,9 @@ int main() {
     // --- Semaphore: same shape — park on a count that never arrives, delete, expect EACCES wake. ---
     {
         void* se = nullptr;
-        se_create((uint64_t)(uintptr_t)&se, 0, 0, 0 /*initCount*/, 8 /*maxCount*/, 0);
+        static const char delay_origin_name[] = "delay-origin";
+        se_create((uint64_t)(uintptr_t)&se, (uint64_t)(uintptr_t)delay_origin_name, 0,
+                  0 /*initCount*/, 8 /*maxCount*/, 0);
         CHECK(se != nullptr, "semaphore created");
         std::atomic<uint64_t> wret{~0ull}; std::atomic<bool> done{false};
         std::thread t([&]{
@@ -72,6 +155,42 @@ int main() {
         CHECK((uint32_t)wret.load() == kEACCES, "woken semaphore waiter returned EACCES");
     }
 
+    // Focus is an object-lifetime identity, not just an address. Focus A from the filtered thread,
+    // delete it, require allocator reuse for B, then signal B from an excluded thread. A stale
+    // pointer-only focus would incorrectly retain that signal as causal traffic for A.
+    {
+        void* focused = nullptr;
+        se_create((uint64_t)(uintptr_t)&focused, (uint64_t)(uintptr_t)"focus-a", 0, 0, 8, 0);
+        CHECK(focused != nullptr, "focused semaphore created");
+        const uintptr_t focused_address = (uintptr_t)focused;
+        uint32_t timeout = 1;
+        const uint64_t wait_result = se_wait((uint64_t)focused_address, 1,
+                                             (uint64_t)(uintptr_t)&timeout, 0, 0, 0);
+        CHECK((uint32_t)wait_result == kETIMEDOUT, "focused semaphore wait timed out");
+        se_delete((uint64_t)focused_address, 0, 0, 0, 0, 0);
+
+#ifdef _WIN32
+        void* reused = nullptr;
+        std::vector<void*> held;
+        for (int i = 0; i < 256 && !reused; ++i) {
+            void* candidate = nullptr;
+            se_create((uint64_t)(uintptr_t)&candidate, (uint64_t)(uintptr_t)"focus-b", 0, 0, 8, 0);
+            if ((uintptr_t)candidate == focused_address) reused = candidate;
+            else held.push_back(candidate);
+        }
+        CHECK(reused != nullptr, "allocator reused the deleted focused semaphore address");
+        if (reused) {
+            std::thread signaler([&] { se_signal((uint64_t)(uintptr_t)reused, 1, 0, 0, 0, 0); });
+            signaler.join();
+            se_delete((uint64_t)(uintptr_t)reused, 0, 0, 0, 0, 0);
+        }
+        for (void* candidate : held)
+            se_delete((uint64_t)(uintptr_t)candidate, 0, 0, 0, 0, 0);
+#else
+        CHECK(true, "deleted-focus address-reuse regression is Windows-specific");
+#endif
+    }
+
     // --- Delete with NO waiters must also be safe (frees immediately, no crash on a later create). ---
     {
         void* ef = nullptr; ef_create((uint64_t)(uintptr_t)&ef, 0, 0, 0, 0, 0);
@@ -80,6 +199,23 @@ int main() {
         se_delete((uint64_t)(uintptr_t)se, 0, 0, 0, 0, 0);
         CHECK(true, "delete with no waiters frees cleanly");
     }
+
+    std::string trace;
+    if (capturing) {
+        fflush(stderr);
+        replace_descriptor(saved_stderr, file_descriptor(stderr));
+        close_descriptor(saved_stderr);
+        saved_stderr = -1;
+        rewind(trace_file);
+        char buffer[4096];
+        while (size_t count = fread(buffer, 1, sizeof(buffer), trace_file))
+            trace.append(buffer, count);
+    }
+    if (trace_file) fclose(trace_file);
+    CHECK(trace.find("name='delay-origin'") != std::string::npos,
+          "excluded event-flag traffic anchors the common trace delay");
+    CHECK(trace.find("SEMA.signal") == std::string::npos,
+          "deleted semaphore focus does not retain a reused object's signal");
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Goal
Make the opt-in Windows synchronization trace useful for diagnosing issue #799 without changing synchronization behavior.

## Failure scenario and contract
Blasphemous 2 reaches the investigated boundary only after substantial startup traffic. The trace needs to:

- identify native Windows threads consistently with the other Windows diagnostics;
- anchor `PROSPER_SYNCLOG_DELAY_MS` at the first synchronization operation, even when that primitive is excluded by a category filter; and
- retain cross-thread signals only for the same live semaphore generation selected by the filtered waiter.

A signed native TID, a category-relative delay origin, or a stale pointer-only semaphore focus can each produce plausible but causally false attribution.

## Implementation

- print synchronization and exception diagnostic TIDs as unsigned 64-bit values;
- evaluate the common time/thread gate before condition/semaphore/event category short-circuiting;
- clear the single focused semaphore with compare/exchange when that object is deleted;
- retain `PROSPER_SYNCLOG_PTHREAD`, `PROSPER_SYNCLOG_COND_ONLY`, and `PROSPER_SYNCLOG_SEMA_ONLY` behavior documented in the Windows handoff; and
- extend `test_sync_delete` with stderr-capture regressions for high-bit TID formatting, excluded-primitive delay anchoring, and Windows allocator address reuse after focused deletion.

The environment-gated diagnostics remain off by default. Mutex/condition/event/semaphore synchronization semantics are deliberately unchanged.

## Risk and compatibility

The behavioral surface is diagnostic output only. The focus invalidation is an independent atomic compare/exchange during semaphore deletion; it neither dereferences the diagnostic address nor changes semaphore ownership or wakeup ordering. Real-game rendering paths are unaffected, so the rendering snapshot gate is not applicable; the snapshot harness logic test remains part of the full Linux suite.

## Author verification

Final head: `bad514f3e7f9c27020f2c0a880c612c84b49cd19`, rebased onto `master@868b56e29b317bd24606fea61b8375fa7e2945a5`.

- Native MinGW full `prosper-app` build: pass.
- Native MinGW CTest: **75/75 pass**.
- Focused `sync_delete` repeated until-fail 100: **100/100 pass**.
- Linux full build with the canonical Messenger dump: pass.
- Linux CTest: **103/103 pass**, including Vulkan and `snapshot_guard_logic`.
- Final focused regression executable: pass on Windows and Linux.

Related: #799