### PR TITLE
fix(windows): preserve short reads into sparse guest buffers

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -477,12 +477,20 @@ HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
 #else
                // Full sequential read (loop) — same full-count contract as read_full: a short ::read
                // would leave Unity's asset cache block partially filled and deserialize corrupt data.
+               // Windows validates the entire destination range before _read discovers a short EOF.
+               // Guest allocators can leave later pages reserved for lazy commit, so Unity's normal
+               // 64 KiB read from a small boot.config otherwise fails with EINVAL. Stage through
+               // committed host memory and copy only the bytes the file actually supplied.
                { size_t done = 0, cnt = (size_t)a2; char* b = (char*)P(a1);
+                 constexpr size_t kBounceSize = 0x10000;
+                 std::vector<char> bounce(cnt < kBounceSize ? cnt : kBounceSize);
                  while (done < cnt) {
-                     unsigned want = (cnt - done) > 0x40000000u ? 0x40000000u : (unsigned)(cnt - done);
-                     int r = ::read((int)a0, b + done, want);
+                     size_t left = cnt - done;
+                     unsigned want = (unsigned)(left < bounce.size() ? left : bounce.size());
+                     int r = ::read((int)a0, bounce.data(), want);
                      if (r < 0) return logged_return(done ? (int64_t)done : (int64_t)-1);
                      if (r == 0) break;   // EOF
+                     memcpy(b + done, bounce.data(), (size_t)r);
                      done += (size_t)r;
                  }
                  return logged_return((int64_t)done); }

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -6,6 +6,9 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 using namespace prosper;
 
@@ -46,6 +49,31 @@ int main() {
     CHECK(n == (int64_t)expected.size() && actual == expected,
           "read preserves binary bytes including CRLF");
     if (fd >= 0 && close_fn) close_fn((uint64_t)fd, 0, 0, 0, 0, 0);
+
+#ifdef _WIN32
+    // Unity asks for a whole 64 KiB cache block even when boot.config is only a few hundred bytes.
+    // Guest allocators may leave later pages reserved until first touch. Windows _read validates the
+    // entire requested destination range before discovering EOF, so a direct host read fails EINVAL;
+    // PS5/Linux instead copy the available prefix and return its short byte count.
+    void* sparse = VirtualAlloc(nullptr, 0x10000, MEM_RESERVE, PAGE_NOACCESS);
+    CHECK(sparse != nullptr, "reserve sparse guest-style read buffer");
+    void* committed = sparse ? VirtualAlloc(sparse, 0x4000, MEM_COMMIT, PAGE_READWRITE) : nullptr;
+    CHECK(committed == sparse, "commit only the first guest page");
+    int64_t sparse_fd = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    CHECK(sparse_fd >= 0, "reopen fixture for sparse-buffer short read");
+    int64_t sparse_n = sparse_fd >= 0 && read_fn && sparse
+        ? (int64_t)read_fn((uint64_t)sparse_fd, (uint64_t)(uintptr_t)sparse, 0x10000, 0, 0, 0)
+        : -1;
+    CHECK(sparse_n == (int64_t)expected.size(),
+          "short read does not probe reserved destination pages past EOF");
+    CHECK(sparse_n == (int64_t)expected.size() &&
+              std::memcmp(sparse, expected.data(), expected.size()) == 0,
+          "short read preserves the available file prefix");
+    if (sparse_fd >= 0 && close_fn) close_fn((uint64_t)sparse_fd, 0, 0, 0, 0, 0);
+    if (sparse) VirtualFree(sparse, 0, MEM_RELEASE);
+#endif
     std::remove(path);
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## What changed

- stage Windows sequential guest reads through a 64 KiB committed host buffer
- copy only the bytes actually returned by the host into guest memory
- add a Windows regression case with a committed first guest page and reserved pages after it

## Root cause

Unity opens `Media/boot.config` and requests a 64 KiB cache block even though the file is only a few hundred bytes. Its guest destination has the first 16 KiB page committed and later pages reserved for lazy commit.

Linux `read` copies the available file prefix and returns a short byte count without touching pages beyond EOF. Windows `_read` validates the whole requested destination first, sees the reserved pages, and returns `EINVAL` without copying anything. Unity therefore constructed an empty `platform-ps5-content-ids` setting. Blasphemous 2 later failed while deriving its title ID for save metadata, never reached SaveData initialization or the main menu, and retried the failing entitlement path every frame.

The bounce buffer restores the guest-visible short-read behavior without forcing pages beyond the actual file data to be committed.

Closes #799.

## Validation

- regression test fails on the old direct-read path and passes with this change
- Windows MinGW: all 70 CTest tests pass
- Linux: `test_file_binary` passes
- Blasphemous 2 Windows app reads the complete 108-byte content-ID list and reaches `sceSaveDataInitialize3` on the scripted route in about 41 seconds; the previous build never crossed that boundary
