### PR TITLE
fix(windows): guard service-log pointer dumps

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -295,6 +295,10 @@ if(TARGET prosper_core)
   add_test(NAME file_binary_roundtrip COMMAND test_file_binary)
 
   if(WIN32)
+    add_executable(test_service_logging tests/test_service_logging.cpp)
+    target_link_libraries(test_service_logging PRIVATE prosper_core)
+    add_test(NAME service_logging_unmapped_args COMMAND test_service_logging)
+
     add_executable(test_win_exception_delivery tests/test_win_exception_delivery.cpp)
     target_link_libraries(test_win_exception_delivery PRIVATE prosper_core)
     add_test(NAME win_exception_delivery COMMAND test_win_exception_delivery)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -21,6 +21,13 @@
 #include <string>
 #ifdef _WIN32
 #include <direct.h>     // _mkdir (SaveDataMemory persistence dir)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #else
 #include <sys/stat.h>   // mkdir
 #endif
@@ -56,7 +63,18 @@ void svc_log(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2,
         // page neighbor is unmapped, and a diagnostic must not be able to fault the boot.
         uint64_t page_left = 0x1000 - (args[i] & 0xfff);
         int words = (int)(page_left / 8); if (words > dump_words) words = dump_words;
-#ifdef __linux__
+#ifdef _WIN32
+        MEMORY_BASIC_INFORMATION region{};
+        if (!VirtualQuery((const void*)(uintptr_t)args[i], &region, sizeof region)) continue;
+        DWORD access = region.Protect & 0xff;
+        bool readable = access == PAGE_READONLY || access == PAGE_READWRITE ||
+                        access == PAGE_WRITECOPY || access == PAGE_EXECUTE_READ ||
+                        access == PAGE_EXECUTE_READWRITE || access == PAGE_EXECUTE_WRITECOPY;
+        uintptr_t region_end = (uintptr_t)region.BaseAddress + region.RegionSize;
+        if (region.State != MEM_COMMIT || !readable || (region.Protect & PAGE_GUARD) ||
+            args[i] + (uint64_t)words * 8 > region_end)
+            continue;
+#elif defined(__linux__)
         // Integer-valued args can masquerade as pointers; probe the page is actually mapped
         // (msync on an unmapped range fails ENOMEM) before dereferencing — a diagnostic must
         // never be able to fault the boot.

--- a/prosper/tests/test_service_logging.cpp
+++ b/prosper/tests/test_service_logging.cpp
@@ -1,0 +1,50 @@
+#include "hle/dispatch.hpp"
+#include "hle/nid.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+int main() {
+#ifdef _WIN32
+    _putenv_s("PROSPER_SVCLOG", "1");
+#else
+    setenv("PROSPER_SVCLOG", "1", 1);
+#endif
+
+    prosper::register_builtin_hle();
+    auto open = prosper::Hle::lookup("eaFXjfJv3xs"); // sceImeKeyboardOpen
+    if (!open) {
+        std::fprintf(stderr, "sceImeKeyboardOpen was not registered\n");
+        return 1;
+    }
+
+#ifdef _WIN32
+    void* reserved = VirtualAlloc(nullptr, 0x1000, MEM_RESERVE, PAGE_NOACCESS);
+    if (!reserved) {
+        std::fprintf(stderr, "VirtualAlloc reserve failed: %lu\n", GetLastError());
+        return 1;
+    }
+#else
+    void* reserved = reinterpret_cast<void*>(0xae6d000);
+#endif
+
+    // The remaining literals came from a Blasphemous 2 call. The reserved
+    // pointer is definitely not readable, so diagnostic logging must skip it.
+    uint64_t rc = open(1, 0xdcdfb7a0, reinterpret_cast<uintptr_t>(reserved), 1, 0x83, 0);
+#ifdef _WIN32
+    VirtualFree(reserved, 0, MEM_RELEASE);
+#endif
+    if (rc != 0) {
+        std::fprintf(stderr, "sceImeKeyboardOpen returned %#llx\n",
+                     static_cast<unsigned long long>(rc));
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Closes #806.

## What changed

- validate pointer-shaped `PROSPER_SVCLOG` arguments with `VirtualQuery` on Windows
- skip uncommitted, unreadable, guarded, or range-crossing hexdumps
- add a Windows regression test using a reserved, uncommitted address

## Root cause

The service logger treated every numerically pointer-shaped argument as readable on Windows. Blasphemous 2 passed an unmapped value to `sceImeKeyboardOpen`; enabling `PROSPER_SVCLOG=1` made the diagnostic itself dereference that value and terminate the guest with an access violation. Linux already probes mappings before dereferencing.

## Impact

Windows service tracing can now be enabled during live title investigation without changing guest behavior or crashing on scalar/unmapped arguments.

## Validation

- Windows MinGW full build
- `ctest --test-dir prosper/build-mingw-app --output-on-failure -j 8`: 71/71 passed
- focused test logs the exact call shape and safely skips a `MEM_RESERVE`/`PAGE_NOACCESS` address
