### PR TITLE
fix(gpu): complete forced ordered captures

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -306,7 +306,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // unbounded RTT/GPU resources across tens of thousands of submits (which OOM-kills the process).
             static int g_render_last = getenv("PROSPER_RENDER_LAST") ? atoi(getenv("PROSPER_RENDER_LAST")) : INT_MAX;
             static thread_local int g_this_submit = -1;
-            if (phase.first_span || g_this_submit < 0) g_this_submit = g_submit_idx++;
+            static thread_local bool g_force_this_submit = false;
+            if (phase.first_span || g_this_submit < 0) {
+                g_this_submit = g_submit_idx++;
+                g_force_this_submit = false;
+            }
             if (g_this_submit > g_render_last) return {};
             static const int g_rttlog_min_submit = getenv("PROSPER_RTTLOG_MIN_SUBMIT")
                 ? std::max(0, atoi(getenv("PROSPER_RTTLOG_MIN_SUBMIT"))) : 0;
@@ -445,6 +449,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (has_dim(it.vrt.get()) || has_dim(it.prt.get())) { force_target = true; break; }
                     }
             }
+            // Ordered submits can contain several graphics spans separated by compute work. Once a
+            // diagnostic target selects one span, keep rendering the rest of that transaction so the
+            // final span can recover and return the scanout assembled in the persistent RTT cache.
+            g_force_this_submit |= force_target;
             // A one-time offscreen producer may occur before a much later consumer render window.
             // Render that target even before the warmup ends so its RTT cache entry survives skipped
             // intermediate submits (#526). Submit-count and wall-clock gates are additive.
@@ -456,7 +464,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 fprintf(stderr, "[render] wall-clock warmup complete after %lld ms at submit %d\n",
                         (long long)elapsed_ms, g_this_submit);
             }
-            if ((g_this_submit < g_render_first || before_delay) && !force_target) return {};
+            if ((g_this_submit < g_render_first || before_delay) && !g_force_this_submit) return {};
             // Dump the FIRST item's recompiled SPIR-V (diagnostic; survives a mid-render crash).
             if (getenv("PROSPER_SHADER_DUMP") && !items.empty()) {
                 std::string d = getenv("PROSPER_SHADER_DUMP");

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1743,11 +1743,17 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
 bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
                                   const std::vector<uint8_t>& output, std::string& error) {
     if (!pending) return true;
-    pending->capture.expected_output_valid = true;
-    pending->capture.expected_output_bytes = output.size(); pending->capture.expected_output_hash = gpu_capture_hash(output);
+    pending->capture.expected_output_valid = !output.empty();
+    pending->capture.expected_output_bytes = output.size();
+    pending->capture.expected_output_hash = output.empty() ? 0 : gpu_capture_hash(output);
     if (!write_gpu_capture(pending->path, pending->capture, error)) return false;
-    std::fprintf(stderr, "[gpucap] wrote %s output_bytes=%zu hash=%016llx\n", pending->path.c_str(), output.size(),
-                 static_cast<unsigned long long>(pending->capture.expected_output_hash));
+    if (output.empty()) {
+        std::fprintf(stderr, "[gpucap] wrote %s without output oracle\n", pending->path.c_str());
+    } else {
+        std::fprintf(stderr, "[gpucap] wrote %s output_bytes=%zu hash=%016llx\n",
+                     pending->path.c_str(), output.size(),
+                     static_cast<unsigned long long>(pending->capture.expected_output_hash));
+    }
     return true;
 }
 

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -312,6 +312,17 @@ int main() {
           "replay resources point into shared owned backing at captured offsets");
     CHECK(replay.expected_output_valid && replay.expected_output_hash == captured.expected_output_hash,
           "expected render oracle round-trips");
+    const auto no_oracle_path = std::filesystem::temp_directory_path() /
+        "prosper_gpu_capture_no_oracle_test.prgcap";
+    auto no_oracle_pending = std::make_unique<PendingGpuCapture>();
+    no_oracle_pending->path = no_oracle_path.string();
+    no_oracle_pending->capture = captured;
+    GpuCaptureFile no_oracle_loaded;
+    CHECK(finish_requested_gpu_capture(std::move(no_oracle_pending), {}, error) &&
+          read_gpu_capture(no_oracle_path.string(), no_oracle_loaded, error) &&
+          !no_oracle_loaded.expected_output_valid && no_oracle_loaded.expected_output_bytes == 0 &&
+          no_oracle_loaded.expected_output_hash == 0,
+          "an empty renderer result does not become a valid replay oracle");
     CHECK(replay.items[0].draw_index == 7 && replay.items[0].command_order == 123,
           "materialized draw retains its source operation identity");
     CHECK(replay.rtt_seeds.size() == 1 && replay.rtt_seeds[0].guest_addr == draw.color0_base,
@@ -567,7 +578,7 @@ int main() {
     GpuCaptureFile bad;
     CHECK(!read_gpu_capture(truncated.string(), bad, error) && !error.empty(), "truncated capture fails loudly");
     std::filesystem::remove(path); std::filesystem::remove(truncated); std::filesystem::remove(mixed_path);
-    std::filesystem::remove(failed_path);
+    std::filesystem::remove(failed_path); std::filesystem::remove(no_oracle_path);
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;


### PR DESCRIPTION
## Summary

- keep a target-forced render decision active through the remaining graphics spans of an ordered submit
- prevent empty renderer results from being recorded as valid replay pixel oracles
- cover empty-output capture finalization with a round-trip regression test

## Verification

- full Linux build
- `ctest --test-dir build-linux --output-on-failure -j2` (99/99 passed)
- DOLL live capture using the same 76-draw selector that previously wrote `output_bytes=0`: now writes a 33,177,600-byte oracle with 23 RTT seeds
- standalone replay reproduces the exact `26ed8b6191338383` oracle hash

## Snapshot guard

`python3 tools/snapshot/snapshot.py check` stops before capture because the existing Messenger, Dead Cells, and Blasphemous 2 entries lack completed visual-review notes. No baseline or local capture data is included in this PR.

The deterministic DOLL output remains black; this PR fixes capture completeness so the remaining shading gap can be isolated offline.