### PR TITLE
feat(gpu): sample Float32 compute images

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -626,7 +626,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (bi.alias_of != SIZE_MAX) continue;
             }
             const VkDeviceSize volume_texels = static_cast<VkDeviceSize>(r->width) * r->height * r->depth;
-            const uint32_t texel_bytes = bi.storage ? 16u : 4u;   // uvec4 raw channels / RGBA8
+            const uint32_t sampled_components = r->num_components ? r->num_components : 1;
+            const bool sampled_float32 = !bi.storage && r->format == DataFormat::Float32 &&
+                                         sampled_components >= 1 && sampled_components <= 4;
+            const uint32_t texel_bytes = bi.storage || sampled_float32 ? 16u : 4u;
+            // Storage images use raw uvec4 channels. Most sampled formats are normalized to RGBA8,
+            // but Float32 stays native so exposure/HDR kernels do not lose sign or dynamic range.
             const VkDeviceSize sbytes = volume_texels * texel_bytes;
             if (!sbytes || sbytes > kMaxComputeImageBytes) {
                 skip_image(r, "expanded image exceeds the 256 MiB backend bound"); break;
@@ -687,6 +692,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool uint8 = r->format == DataFormat::Uint8 && nc == 4;
                 const bool r8 = r->format == DataFormat::Unorm8 && nc == 1;
                 const bool f16 = r->format == DataFormat::Float16 && nc >= 1 && nc <= 4;
+                const bool f32 = sampled_float32;
                 const bool r11g11b10 = r->format == DataFormat::Float10_11_11 && nc == 3;
                 if (renderer_owned) {
                     if (r11g11b10) {
@@ -694,7 +700,24 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         break;
                     }
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
-                    if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                    if (f32) {
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            for (uint32_t c = 0; c < 4; ++c) {
+                                float value = 0.0f;
+                                if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                                    value = pixels[t * 4 + c] / 255.0f;
+                                } else {
+                                    uint16_t half = 0;
+                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
+                                    value = half_to_float(half);
+                                    if (std::isnan(value)) value = 0.0f;
+                                }
+                                std::memcpy(upload.data() + (t * 4 + c) * sizeof(float),
+                                            &value, sizeof(value));
+                            }
+                        }
+                    } else if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
                         std::memcpy(upload.data(), pixels.data(), upload.size());
                     } else {
                         const size_t texels = static_cast<size_t>(volume_texels);
@@ -726,7 +749,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
                         need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
                                             : (size_t)bw * bh * bpb;
-                    } else if (rgba8 || uint8 || r8 || f16 || r11g11b10) {
+                    } else if (rgba8 || uint8 || r8 || f16 || f32 || r11g11b10) {
                         const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
                         need = r->tile_mode
                             ? (dim_3d && r->depth > 1
@@ -769,6 +792,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         const size_t texels = (size_t)volume_texels;
                         if (rgba8 || uint8 || r11g11b10) {          // Native 4-byte sampled texels
                             std::memcpy(upload.data(), lin.data(), lin.size());
+                        } else if (f32) {                           // Native float channels + default fill
+                            for (size_t t = 0; t < texels; ++t) {
+                                for (uint32_t c = 0; c < 4; ++c) {
+                                    float value = c == 3 ? 1.0f : 0.0f;
+                                    if (c < nc)
+                                        std::memcpy(&value, lin.data() + (t * nc + c) * sizeof(float),
+                                                    sizeof(value));
+                                    std::memcpy(upload.data() + (t * 4 + c) * sizeof(float),
+                                                &value, sizeof(value));
+                                }
+                            }
                         } else if (r8) {                            // R8: broadcast coverage to RGBA
                             for (size_t t = 0; t < texels; t++) {
                                 const uint8_t v = lin[t];
@@ -826,6 +860,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT
                                     : (sampled_uint8 ? VK_FORMAT_R8G8B8A8_UINT
                                        : sampled_r11g11b10 ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                                         : sampled_float32 ? VK_FORMAT_R32G32B32A32_SFLOAT
                                                            : VK_FORMAT_R8G8B8A8_UNORM);
             ici.extent = {r->width, r->height, r->depth};
             ici.mipLevels = 1;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -300,6 +300,59 @@ int main() {
     set_live_target_reader({});
     set_live_target_query({});
 
+    // UE4's exposure chain samples tiny tiled Float32 surfaces. Preserve those values natively:
+    // normalizing through RGBA8 would clamp negative and HDR channels before the compute shader sees
+    // them. Copy a tiled Float32x4 source through the production sampled-image path into the existing
+    // raw-channel Float32 storage path and require exact bits at the guest destination.
+    std::vector<float> float_src(W * 4), float_dst(W * 4, 0.0f);
+    for (uint32_t i = 0; i < W * 4; ++i)
+        float_src[i] = (static_cast<int32_t>(i % 17) - 8) * 0.375f;
+    const size_t float_tiled_bytes = tiled_surface_bytes(W, 1, dcc_tile, 0, 16);
+    std::vector<uint8_t> float_tiled(float_tiled_bytes, 0);
+    tile_surface(float_tiled.data(), reinterpret_cast<const uint8_t*>(float_src.data()),
+                 W, 1, dcc_tile, 0, 16);
+    ShaderResourceTable float_rt = irt;
+    for (ShaderResource& resource : float_rt.resources) {
+        if (resource.binding != 4 && resource.binding != 5) continue;
+        resource.img_dim = 1;
+        resource.format = DataFormat::Float32;
+        resource.num_components = 4;
+        resource.width = W;
+        resource.height = resource.depth = 1;
+        if (resource.binding == 4) {
+            resource.cls = ResourceClass::Texture;
+            resource.tile_mode = dcc_tile;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(float_tiled.data());
+            resource.size = static_cast<uint32_t>(float_tiled.size());
+            resource.swizzle[0] = 4;
+            resource.swizzle[1] = 5;
+            resource.swizzle[2] = 6;
+            resource.swizzle[3] = 7;
+        } else {
+            resource.tile_mode = 0;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(float_dst.data());
+            resource.size = static_cast<uint32_t>(float_dst.size() * sizeof(float));
+        }
+    }
+    std::vector<uint32_t> float_spirv = recompile_valu(
+        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0, &float_rt);
+    CHECK(!float_spirv.empty(), "sampled-image copy kernel recompiles for tiled Float32 input");
+    if (!float_spirv.empty()) {
+        ComputeItem float_item;
+        float_item.spirv = float_spirv;
+        float_item.resources = std::make_shared<ShaderResourceTable>(float_rt);
+        float_item.launch.threads_x = W;
+        float_item.launch.local_x = 64;
+        float_item.launch.groups_x = 1;
+        float_item.launch.local_y = float_item.launch.local_z = 1;
+        float_item.launch.groups_y = float_item.launch.groups_z = 1;
+        float_item.code_addr = 0x590f32;
+        CHECK(prosper::frontend::execute_live_compute_items({float_item}),
+              "live backend executes a dispatch sampling a tiled Float32 image");
+        CHECK(float_dst == float_src,
+              "tiled Float32 sampled values preserve negative and HDR channels byte-exactly");
+    }
+
     if (fails) {
         std::printf("== FAIL: %d ==\n", fails);
         return 1;


### PR DESCRIPTION
## Summary

- materialize sampled `Float32` compute images as native `VK_FORMAT_R32G32B32A32_SFLOAT`
- preserve negative and HDR channels instead of clamping through the existing RGBA8 upload path
- support tiled guest backing and renderer-owned RGBA8/RGBA16F snapshots
- add a production-backend test that copies tiled Float32 samples to Float32 storage byte-exactly

This advances the compute-image coverage tracked by #590.

## Verification

- full Linux build
- `ctest --test-dir build-linux --output-on-failure -j2` (99/99 passed)
- DOLL capsule: program `0x2015a60000` previously logged `sampled format not decodable yet`; it now executes successfully with two images and writes its Float32 destination
- the captured 1x1 input/output are all zero, so the expected black transition oracle remains byte-exact (`26ed8b6191338383`)

## Snapshot guard

`python3 tools/snapshot/snapshot.py check` stops before capture because the existing Messenger, Dead Cells, and Blasphemous 2 entries lack completed visual-review notes. No baseline or local game data is included.