### PR TITLE
fix(gpu): capture packed image DCC metadata

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -309,7 +309,8 @@ uint64_t dcc_metadata_footprint(const ShaderResource& r) {
         bc_block_bytes(r.format))
         return 0;
     uint32_t bytes_per_texel = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1u);
-    if (!bytes_per_texel && r.format == DataFormat::Unorm2_10_10_10)
+    if (!bytes_per_texel &&
+        (r.format == DataFormat::Float10_11_11 || r.format == DataFormat::Unorm2_10_10_10))
         bytes_per_texel = 4;
     const uint32_t layers = r.img_dim == 3u ? 6u : (r.img_dim == 2u ? std::max(r.depth, 1u) : 1u);
     return gfx10_dcc_metadata_bytes(r.width, r.height, layers, r.tile_mode,

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -156,6 +156,13 @@ int main() {
     volume_dcc.metadata_addr = 0x400000;
     CHECK(gpu_capture_dcc_metadata_footprint(volume_dcc) == 128 * 1024,
           "32x32x32 R_X volume descriptor plans the validated 128 KiB DCC span");
+    ShaderResource packed_volume_dcc = volume_dcc;
+    packed_volume_dcc.gpu_addr = 0x500000; packed_volume_dcc.size = 40 * 5 * 5 * 4;
+    packed_volume_dcc.format = DataFormat::Float10_11_11; packed_volume_dcc.num_components = 3;
+    packed_volume_dcc.width = 40; packed_volume_dcc.height = 5; packed_volume_dcc.depth = 5;
+    packed_volume_dcc.metadata_addr = 0x600000;
+    CHECK(gpu_capture_dcc_metadata_footprint(packed_volume_dcc) == 20 * 1024,
+          "40x5x5 packed R11G11B10 volume descriptor plans its 20 KiB DCC span");
     auto volume_table = std::make_shared<ShaderResourceTable>();
     volume_table->resources = {volume_dcc};
     DrawItem volume_draw; volume_draw.vs = {0x07230203, 31};
@@ -187,6 +194,18 @@ int main() {
           volume_replay.items[0].vrt->resources[0].dcc_metadata_host_data_size == 128 * 1024 &&
           volume_replay.resource_instances.size() == 2,
           "v12 replay owns base and DCC bytes as distinct mutable address instances");
+    auto packed_volume_table = std::make_shared<ShaderResourceTable>();
+    packed_volume_table->resources = {packed_volume_dcc};
+    DrawItem packed_volume_draw = volume_draw; packed_volume_draw.vrt = packed_volume_table;
+    GpuCaptureFile packed_volume_capture;
+    CHECK(capture_draw_items({packed_volume_draw}, meta, volume_reader,
+                             packed_volume_capture, error) &&
+          packed_volume_capture.blobs.size() == 2 &&
+          packed_volume_capture.draws[0].vrt.resources[0].metadata_size == 20 * 1024 &&
+          packed_volume_capture.blobs[
+              packed_volume_capture.draws[0].vrt.resources[0].metadata_blob_index].bytes.size() ==
+              20 * 1024,
+          "capture retains packed R11G11B10 volume DCC bytes as a separate content blob");
     GpuCaptureFile bad_metadata_ref = volume_capture;
     bad_metadata_ref.draws[0].vrt.resources[0].metadata_blob_offset = 128 * 1024;
     CHECK(!serialize_gpu_capture(bad_metadata_ref, volume_bytes, error) &&


### PR DESCRIPTION
## Summary

- treat packed `Float10_11_11` / R11G11B10 images as four bytes per texel when planning GFX10 DCC metadata
- retain the separate compression-control surface in GPU captures instead of silently omitting it
- cover the exact 40×5×5 tiled Unreal volume shape with a regression test

## Root cause and impact

`data_format_bytes(Float10_11_11)` is intentionally zero because the format has no uniform per-component width. The DCC footprint planner only corrected that zero for packed `Unorm2_10_10_10`, so R11G11B10 resources planned a zero-byte metadata span. Replays then lacked the state needed to distinguish compressed texels from ordinary base data.

## Verification

- focused `test_gpu_capture` passes
- full Linux build
- `ctest --test-dir build-linux --output-on-failure -j2` (99/99 passed)
- fresh DOLL Unreal capsule captures `0x206def0000` as `20480/20480` metadata bytes for the 40×5×5 R11G11B10 volume
- standalone replay remains byte-exact with the live oracle (`26ed8b6191338383`)

The captured metadata is compressed state (`0x00`), so decoding that content remains explicit future renderer work; this PR fixes capture completeness only.

## Snapshot guard

`python3 tools/snapshot/snapshot.py check` stops before capture because the existing Messenger, Dead Cells, and Blasphemous 2 entries lack completed visual-review notes. No baseline or local game data is included.