### PR TITLE
fix(gpu): materialize RGB DCC fast clears

### DIFF
--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -59,7 +59,8 @@ bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
                                 const uint8_t* metadata, size_t metadata_bytes,
                                 uint32_t num_components, bool alpha_is_on_msb,
                                 uint8_t* clear_code) {
-    if (!metadata || !metadata_bytes || num_components != 4 || (!dst && texel_count))
+    if (!metadata || !metadata_bytes ||
+        (num_components != 3 && num_components != 4) || (!dst && texel_count))
         return false;
     const uint8_t code = metadata[0];
     if (code != 0x00 && code != 0x40 && code != 0x80 && code != 0xc0)
@@ -69,10 +70,13 @@ bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
         return false;
 
     const uint8_t color = (code == 0x80 || code == 0xc0) ? 255 : 0;
-    const uint8_t alpha = (code == 0x40 || code == 0xc0) ? 255 : 0;
-    const uint32_t alpha_component = alpha_is_on_msb ? 3u : 0u;
-    uint8_t pixel[4] = {color, color, color, color};
-    pixel[alpha_component] = alpha;
+    uint8_t pixel[4] = {color, color, color, 255};
+    if (num_components == 4) {
+        const uint8_t alpha = (code == 0x40 || code == 0xc0) ? 255 : 0;
+        const uint32_t alpha_component = alpha_is_on_msb ? 3u : 0u;
+        std::fill(pixel, pixel + 4, color);
+        pixel[alpha_component] = alpha;
+    }
     for (size_t i = 0; i < texel_count; ++i)
         std::memcpy(dst + i * 4, pixel, sizeof(pixel));
     if (clear_code) *clear_code = code;

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -80,10 +80,11 @@ size_t gfx10_dcc_metadata_bytes(uint32_t width, uint32_t height, uint32_t depth,
                                 bool pipe_aligned);
 
 // Materialize a uniform, self-contained GFX8-GFX10 DCC fast-clear code into the renderer's RGBA8
-// upload format. The validated path is deliberately limited to four-component surfaces and the
-// embedded 0000/0001/1110/1111 codes; register clears, single-color codes, uncompressed (0xff), and
-// actual compressed blocks return false. `alpha_is_on_msb` selects the raw component that receives
-// the clear alpha before the T# destination swizzle is applied.
+// upload format. The validated path is deliberately limited to three-component color surfaces,
+// four-component color/alpha surfaces, and the embedded 0000/0001/1110/1111 codes; register clears,
+// single-color codes, uncompressed (0xff), and actual compressed blocks return false. Three-component
+// formats receive the sampled-format default alpha of one. `alpha_is_on_msb` selects the raw component
+// that receives the clear alpha on four-component formats before the T# destination swizzle is applied.
 bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
                                 const uint8_t* metadata, size_t metadata_bytes,
                                 uint32_t num_components, bool alpha_is_on_msb,

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -492,6 +492,17 @@ int main() {
               clear_pixels[0] == 0 && clear_pixels[1] == 255 &&
               clear_pixels[2] == 255 && clear_pixels[3] == 255,
               "uniform DCC_CLEAR_1110 places alpha zero in the LSB component");
+        CHECK(gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_0000.data(), clear_0000.size(),
+                                         3, true) &&
+              clear_pixels[0] == 0 && clear_pixels[1] == 0 &&
+              clear_pixels[2] == 0 && clear_pixels[3] == 255 &&
+              gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,
+                                         clear_1110.data(), clear_1110.size(),
+                                         3, false) &&
+              clear_pixels[0] == 255 && clear_pixels[1] == 255 &&
+              clear_pixels[2] == 255 && clear_pixels[3] == 255,
+              "three-component DCC clears materialize RGB with sampled alpha one");
         std::vector<uint8_t> mixed_clear(16, 0); mixed_clear.back() = 0x40;
         const std::vector<uint8_t> uncompressed(16, 0xff);
         CHECK(!gfx10_dcc_fast_clear_rgba8(clear_pixels.data(), 1,


### PR DESCRIPTION
## Summary

- materialize uniform GFX10 DCC clear codes for three-component sampled images
- synthesize alpha one for RGB formats, matching the sampled RGBA representation used by the renderer
- retain the existing four-component alpha-position behavior
- cover zero and one RGB clear values in the tile/DCC unit test

## Root cause and impact

The DCC fast-clear helper accepted only four-component formats. After #813 made Unreal's packed R11G11B10 DCC metadata available to replay, its uniform `DCC_CLEAR_0000` state was still rejected and the renderer fell through to compressed base bytes. The renderer can now materialize that self-contained clear without implementing general DCC block decompression.

## Verification

- focused `test_tile` passes
- full Linux build
- `ctest --test-dir build-linux --output-on-failure -j2` (99/99 passed)
- DOLL Unreal capsule changes from `DCC-compressed ... unsupported` to `DCC fast-clear ... fmt=20 code=0x00 bytes=20480`
- standalone replay remains byte-exact with the live oracle (`26ed8b6191338383`)

## Snapshot guard

`python3 tools/snapshot/snapshot.py check` stops before capture because the existing Messenger, Dead Cells, and Blasphemous 2 entries lack completed visual-review notes. No baseline or local game data is included.