### PR TITLE
fix(windows): preserve pthread key destructor semantics

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -303,6 +303,10 @@ if(TARGET prosper_core)
     target_link_libraries(test_win_exception_delivery PRIVATE prosper_core)
     add_test(NAME win_exception_delivery COMMAND test_win_exception_delivery)
 
+    add_executable(test_win_pthread_key_destructor tests/test_win_pthread_key_destructor.cpp)
+    target_link_libraries(test_win_pthread_key_destructor PRIVATE prosper_core)
+    add_test(NAME win_pthread_key_destructor COMMAND test_win_pthread_key_destructor)
+
     add_executable(test_win_kernel_is_stack tests/test_win_kernel_is_stack.cpp)
     target_link_libraries(test_win_kernel_is_stack PRIVATE prosper_core)
     add_test(NAME win_kernel_is_stack COMMAND test_win_kernel_is_stack)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -97,6 +97,12 @@ void register_kernel_mem_hle();
 // libkernel time/clock + C11 threads + assorted stubs; called by register_kernel_hle().
 void register_kernel_time_hle();
 
+#ifdef _WIN32
+// Windows pthread-key lifecycle probes used by the focused concurrency regression.
+void win_set_key_delete_after_host_hook_for_test(void (*hook)(uint64_t));
+size_t win_key_destructor_thunk_count_for_test();
+#endif
+
 // The default target for unimplemented imports: logs (first-seen) and returns 0.
 // Called by generated stubs with the import index in the first arg.
 extern "C" uint64_t prosper_on_unimpl(uint64_t import_index);

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -726,15 +726,90 @@ HLE(k_pthread_exit)   {
 }
 
 // --- thread-local storage keys (IL2CPP uses these heavily) -> host pthread keys ---
+#ifdef _WIN32
+namespace {
+std::mutex g_win_key_thunks_mutex;
+std::unordered_map<uint64_t, void*> g_win_key_thunks;
+
+// winpthreads invokes key destructors with the Microsoft x64 ABI, but every guest callback uses
+// the PS5/FreeBSD SysV ABI. Emit one tiny Microsoft-ABI thunk per live key so winpthreads can retain
+// its normal destructor iteration semantics while the callback value is delivered in guest RDI.
+void* win_make_key_destructor_thunk(uint64_t guest_destructor) {
+    auto* code = static_cast<uint8_t*>(VirtualAlloc(
+        nullptr, 0x1000, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+    if (!code) return nullptr;
+
+    size_t offset = 0;
+    auto byte = [&](uint8_t value) { code[offset++] = value; };
+    auto qword = [&](uint64_t value) {
+        std::memcpy(code + offset, &value, sizeof value);
+        offset += sizeof value;
+    };
+
+    // rcx=value -> prosper_call_guest_sysv(guest_destructor, value, 0).
+    byte(0x48); byte(0x89); byte(0xca);                 // mov rdx, rcx
+    byte(0x48); byte(0xb9); qword(guest_destructor);    // mov rcx, guest_destructor
+    byte(0x45); byte(0x31); byte(0xc0);                 // xor r8d, r8d
+    byte(0x48); byte(0xb8);
+    qword((uint64_t)(uintptr_t)&prosper_call_guest_sysv); // mov rax, ABI bridge
+    byte(0x48); byte(0x83); byte(0xec); byte(0x28);     // shadow space + call alignment
+    byte(0xff); byte(0xd0);                             // call rax
+    byte(0x48); byte(0x83); byte(0xc4); byte(0x28);
+    byte(0xc3);                                         // ret
+
+    DWORD old_protect = 0;
+    if (!VirtualProtect(code, 0x1000, PAGE_EXECUTE_READ, &old_protect)) {
+        VirtualFree(code, 0, MEM_RELEASE);
+        return nullptr;
+    }
+    FlushInstructionCache(GetCurrentProcess(), code, offset);
+    return code;
+}
+
+void win_release_key_destructor_thunk(pthread_key_t key) {
+    void* thunk = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
+        auto it = g_win_key_thunks.find((uint64_t)key);
+        if (it == g_win_key_thunks.end()) return;
+        thunk = it->second;
+        g_win_key_thunks.erase(it);
+    }
+    VirtualFree(thunk, 0, MEM_RELEASE);
+}
+}
+#endif
+
 HLE(k_key_create) {
     if (!a0) return 0x16;
     pthread_key_t k;
+#ifdef _WIN32
+    void* thunk = a1 ? win_make_key_destructor_thunk(a1) : nullptr;
+    if (a1 && !thunk) return ENOMEM;
+    int r = pthread_key_create(&k, (void (*)(void*))thunk);
+    if (r) {
+        if (thunk) VirtualFree(thunk, 0, MEM_RELEASE);
+        return (uint64_t)r;
+    }
+    if (thunk) {
+        std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
+        g_win_key_thunks.emplace((uint64_t)k, thunk);
+    }
+#else
     int r = pthread_key_create(&k, (void (*)(void*))(uintptr_t)a1);
     if (r) return (uint64_t)r;
+#endif
     *(uint32_t*)(uintptr_t)a0 = (uint32_t)k;   // hand the guest our host key
     return 0;
 }
-HLE(k_key_delete)    { pthread_key_delete((pthread_key_t)a0); return 0; }
+HLE(k_key_delete)    {
+    const pthread_key_t key = (pthread_key_t)a0;
+    const int result = pthread_key_delete(key);
+#ifdef _WIN32
+    if (!result) win_release_key_destructor_thunk(key);
+#endif
+    return (uint64_t)(int64_t)result;
+}
 HLE(k_getspecific)   {
     uint64_t rv = (uint64_t)(uintptr_t)pthread_getspecific((pthread_key_t)a0);
     // #312: learn the non-trapping MB3 pool-array address even when the hardware-watch diagnostic

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -746,6 +746,12 @@ void* win_make_key_destructor_thunk(uint64_t guest_destructor) {
         offset += sizeof value;
     };
 
+    // winpthreads leaves its per-key "used" flag set after pthread_setspecific(key, nullptr),
+    // then invokes the destructor with a null value at thread exit. POSIX requires callbacks only
+    // for non-null values, so discard that spurious invocation before crossing into guest code.
+    byte(0x48); byte(0x85); byte(0xc9);                 // test rcx, rcx
+    byte(0x74); byte(0x24);                             // je final ret
+
     // rcx=value -> prosper_call_guest_sysv(guest_destructor, value, 0).
     byte(0x48); byte(0x89); byte(0xca);                 // mov rdx, rcx
     byte(0x48); byte(0xb9); qword(guest_destructor);    // mov rcx, guest_destructor

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -730,6 +730,7 @@ HLE(k_pthread_exit)   {
 namespace {
 std::mutex g_win_key_thunks_mutex;
 std::unordered_map<uint64_t, void*> g_win_key_thunks;
+std::atomic<void (*)(uint64_t)> g_win_key_delete_after_host_hook{nullptr};
 
 // winpthreads invokes key destructors with the Microsoft x64 ABI, but every guest callback uses
 // the PS5/FreeBSD SysV ABI. Emit one tiny Microsoft-ABI thunk per live key so winpthreads can retain
@@ -772,17 +773,15 @@ void* win_make_key_destructor_thunk(uint64_t guest_destructor) {
     return code;
 }
 
-void win_release_key_destructor_thunk(pthread_key_t key) {
-    void* thunk = nullptr;
-    {
-        std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
-        auto it = g_win_key_thunks.find((uint64_t)key);
-        if (it == g_win_key_thunks.end()) return;
-        thunk = it->second;
-        g_win_key_thunks.erase(it);
-    }
-    VirtualFree(thunk, 0, MEM_RELEASE);
 }
+
+void win_set_key_delete_after_host_hook_for_test(void (*hook)(uint64_t)) {
+    g_win_key_delete_after_host_hook.store(hook, std::memory_order_release);
+}
+
+size_t win_key_destructor_thunk_count_for_test() {
+    std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
+    return g_win_key_thunks.size();
 }
 #endif
 
@@ -790,16 +789,28 @@ HLE(k_key_create) {
     if (!a0) return 0x16;
     pthread_key_t k;
 #ifdef _WIN32
-    void* thunk = a1 ? win_make_key_destructor_thunk(a1) : nullptr;
-    if (a1 && !thunk) return ENOMEM;
-    int r = pthread_key_create(&k, (void (*)(void*))thunk);
+    void* thunk = nullptr;
+    int r = 0;
+    {
+        // Keep host key allocation and registry publication atomic with deletion. winpthreads can
+        // immediately reuse a deleted numeric key, so exposing it before the old map entry is gone
+        // can make the new emplace lose and leave its RX thunk permanently untracked.
+        std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
+        thunk = a1 ? win_make_key_destructor_thunk(a1) : nullptr;
+        if (a1 && !thunk) return ENOMEM;
+        r = pthread_key_create(&k, (void (*)(void*))thunk);
+        if (!r && thunk) {
+            try {
+                if (!g_win_key_thunks.emplace((uint64_t)k, thunk).second) r = EAGAIN;
+            } catch (const std::bad_alloc&) {
+                r = ENOMEM;
+            }
+            if (r) pthread_key_delete(k);
+        }
+    }
     if (r) {
         if (thunk) VirtualFree(thunk, 0, MEM_RELEASE);
         return (uint64_t)r;
-    }
-    if (thunk) {
-        std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
-        g_win_key_thunks.emplace((uint64_t)k, thunk);
     }
 #else
     int r = pthread_key_create(&k, (void (*)(void*))(uintptr_t)a1);
@@ -810,9 +821,27 @@ HLE(k_key_create) {
 }
 HLE(k_key_delete)    {
     const pthread_key_t key = (pthread_key_t)a0;
-    const int result = pthread_key_delete(key);
 #ifdef _WIN32
-    if (!result) win_release_key_destructor_thunk(key);
+    void* thunk = nullptr;
+    int result = 0;
+    {
+        // Do not release the host key until creation is excluded: winpthreads may recycle its
+        // numeric value before the corresponding thunk entry has otherwise been erased.
+        std::lock_guard<std::mutex> lock(g_win_key_thunks_mutex);
+        result = pthread_key_delete(key);
+        if (!result) {
+            if (auto hook = g_win_key_delete_after_host_hook.load(std::memory_order_acquire))
+                hook((uint64_t)key);
+            auto it = g_win_key_thunks.find((uint64_t)key);
+            if (it != g_win_key_thunks.end()) {
+                thunk = it->second;
+                g_win_key_thunks.erase(it);
+            }
+        }
+    }
+    if (thunk) VirtualFree(thunk, 0, MEM_RELEASE);
+#else
+    const int result = pthread_key_delete(key);
 #endif
     return (uint64_t)(int64_t)result;
 }

--- a/prosper/tests/test_win_pthread_key_destructor.cpp
+++ b/prosper/tests/test_win_pthread_key_destructor.cpp
@@ -6,8 +6,10 @@
 #include "../src/hle/nid.hpp"
 #include <pthread.h>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <thread>
 
 using namespace prosper;
 
@@ -18,6 +20,13 @@ constexpr uintptr_t kSecondValue = 0x8877665544332211ull;
 pthread_key_t g_key{};
 std::atomic<unsigned> g_calls{0};
 std::atomic<uintptr_t> g_values[2]{};
+std::atomic<bool> g_delete_host_done{false};
+std::atomic<bool> g_release_delete{false};
+
+void delete_after_host_hook(uint64_t) {
+    g_delete_host_done.store(true, std::memory_order_release);
+    while (!g_release_delete.load(std::memory_order_acquire)) std::this_thread::yield();
+}
 
 extern "C" __attribute__((sysv_abi)) void guest_destructor(void* value) {
     const unsigned call = g_calls.fetch_add(1, std::memory_order_relaxed);
@@ -101,6 +110,71 @@ int main() {
                      (unsigned long long)clear_join_result, worker_result,
                      (unsigned long long)clear_delete_result,
                      g_calls.load(std::memory_order_relaxed));
+        return 1;
+    }
+
+    if (win_key_destructor_thunk_count_for_test() != 0) return 1;
+
+    uint32_t old_key = 0;
+    if (key_create((uint64_t)(uintptr_t)&old_key,
+                   (uint64_t)(uintptr_t)&guest_destructor, 0, 0, 0, 0) != 0)
+        return 1;
+
+    g_delete_host_done.store(false, std::memory_order_relaxed);
+    g_release_delete.store(false, std::memory_order_relaxed);
+    win_set_key_delete_after_host_hook_for_test(&delete_after_host_hook);
+
+    std::atomic<uint64_t> raced_delete_result{UINT64_MAX};
+    std::thread deleter([&] {
+        raced_delete_result.store(key_delete(old_key, 0, 0, 0, 0, 0),
+                                  std::memory_order_release);
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!g_delete_host_done.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline)
+        std::this_thread::yield();
+    if (!g_delete_host_done.load(std::memory_order_acquire)) {
+        g_release_delete.store(true, std::memory_order_release);
+        deleter.join();
+        win_set_key_delete_after_host_hook_for_test(nullptr);
+        return 1;
+    }
+
+    uint32_t reused_key = UINT32_MAX;
+    std::atomic<uint64_t> raced_create_result{UINT64_MAX};
+    std::atomic<bool> create_done{false};
+    std::thread creator([&] {
+        raced_create_result.store(
+            key_create((uint64_t)(uintptr_t)&reused_key,
+                       (uint64_t)(uintptr_t)&guest_destructor, 0, 0, 0, 0),
+            std::memory_order_release);
+        create_done.store(true, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    const bool create_escaped_delete_transition =
+        create_done.load(std::memory_order_acquire);
+    g_release_delete.store(true, std::memory_order_release);
+    deleter.join();
+    creator.join();
+    win_set_key_delete_after_host_hook_for_test(nullptr);
+
+    const uint64_t create_result = raced_create_result.load(std::memory_order_acquire);
+    const uint64_t delete_race_result = raced_delete_result.load(std::memory_order_acquire);
+    const uint64_t reused_delete_result =
+        create_result == 0 ? key_delete(reused_key, 0, 0, 0, 0, 0) : UINT64_MAX;
+    if (create_escaped_delete_transition || delete_race_result != 0 || create_result != 0 ||
+        reused_key != old_key || reused_delete_result != 0 ||
+        win_key_destructor_thunk_count_for_test() != 0) {
+        std::fprintf(stderr,
+                     "pthread key reuse race: escaped=%d old=%u new=%u delete=%llu "
+                     "create=%llu cleanup=%llu tracked=%zu\n",
+                     create_escaped_delete_transition, old_key, reused_key,
+                     (unsigned long long)delete_race_result,
+                     (unsigned long long)create_result,
+                     (unsigned long long)reused_delete_result,
+                     win_key_destructor_thunk_count_for_test());
         return 1;
     }
     return 0;

--- a/prosper/tests/test_win_pthread_key_destructor.cpp
+++ b/prosper/tests/test_win_pthread_key_destructor.cpp
@@ -1,6 +1,7 @@
 // Windows winpthreads owns pthread-key teardown, but guest destructors use the PS5 SysV ABI.
 // Drive the real HLE key and thread lifecycle and verify both the callback argument and POSIX
-// destructor retry when the callback installs another non-null value.
+// destructor retry when the callback installs another non-null value. Also cover clearing a value:
+// winpthreads calls its destructor with nullptr in that case, while POSIX requires no callback.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <pthread.h>
@@ -27,6 +28,12 @@ extern "C" __attribute__((sysv_abi)) void guest_destructor(void* value) {
 
 extern "C" __attribute__((sysv_abi)) void* guest_worker(void*) {
     const int result = pthread_setspecific(g_key, (void*)kFirstValue);
+    return (void*)(uintptr_t)result;
+}
+
+extern "C" __attribute__((sysv_abi)) void* guest_clear_worker(void*) {
+    int result = pthread_setspecific(g_key, (void*)kFirstValue);
+    if (!result) result = pthread_setspecific(g_key, nullptr);
     return (void*)(uintptr_t)result;
 }
 }
@@ -67,6 +74,33 @@ int main() {
                      g_calls.load(std::memory_order_relaxed),
                      (unsigned long long)g_values[0].load(std::memory_order_relaxed),
                      (unsigned long long)g_values[1].load(std::memory_order_relaxed));
+        return 1;
+    }
+
+    g_calls.store(0, std::memory_order_relaxed);
+    g_values[0].store(0, std::memory_order_relaxed);
+    g_values[1].store(0, std::memory_order_relaxed);
+    if (key_create((uint64_t)(uintptr_t)&key,
+                   (uint64_t)(uintptr_t)&guest_destructor, 0, 0, 0, 0) != 0)
+        return 1;
+    g_key = (pthread_key_t)key;
+
+    thread = 0;
+    if (thread_create((uint64_t)(uintptr_t)&thread, 0,
+                      (uint64_t)(uintptr_t)&guest_clear_worker, 0, 0, 0) != 0)
+        return 1;
+    worker_result = (void*)1;
+    const uint64_t clear_join_result = thread_join(
+        thread, (uint64_t)(uintptr_t)&worker_result, 0, 0, 0, 0);
+    const uint64_t clear_delete_result = key_delete(key, 0, 0, 0, 0, 0);
+    if (clear_join_result != 0 || worker_result != nullptr || clear_delete_result != 0 ||
+        g_calls.load(std::memory_order_relaxed) != 0) {
+        std::fprintf(stderr,
+                     "cleared pthread key invoked destructor: join=%llu worker=%p delete=%llu "
+                     "calls=%u\n",
+                     (unsigned long long)clear_join_result, worker_result,
+                     (unsigned long long)clear_delete_result,
+                     g_calls.load(std::memory_order_relaxed));
         return 1;
     }
     return 0;

--- a/prosper/tests/test_win_pthread_key_destructor.cpp
+++ b/prosper/tests/test_win_pthread_key_destructor.cpp
@@ -1,0 +1,73 @@
+// Windows winpthreads owns pthread-key teardown, but guest destructors use the PS5 SysV ABI.
+// Drive the real HLE key and thread lifecycle and verify both the callback argument and POSIX
+// destructor retry when the callback installs another non-null value.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <pthread.h>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+namespace {
+constexpr uintptr_t kFirstValue = 0x1122334455667788ull;
+constexpr uintptr_t kSecondValue = 0x8877665544332211ull;
+
+pthread_key_t g_key{};
+std::atomic<unsigned> g_calls{0};
+std::atomic<uintptr_t> g_values[2]{};
+
+extern "C" __attribute__((sysv_abi)) void guest_destructor(void* value) {
+    const unsigned call = g_calls.fetch_add(1, std::memory_order_relaxed);
+    if (call < 2) g_values[call].store((uintptr_t)value, std::memory_order_relaxed);
+    if (call == 0)
+        pthread_setspecific(g_key, (void*)kSecondValue);
+}
+
+extern "C" __attribute__((sysv_abi)) void* guest_worker(void*) {
+    const int result = pthread_setspecific(g_key, (void*)kFirstValue);
+    return (void*)(uintptr_t)result;
+}
+}
+
+int main() {
+    register_builtin_hle();
+    HleFn key_create = Hle::lookup(nid_hash("scePthreadKeyCreate"));
+    HleFn key_delete = Hle::lookup(nid_hash("scePthreadKeyDelete"));
+    HleFn thread_create = Hle::lookup(nid_hash("scePthreadCreate"));
+    HleFn thread_join = Hle::lookup(nid_hash("scePthreadJoin"));
+    if (!key_create || !key_delete || !thread_create || !thread_join) return 1;
+
+    uint32_t key = 0;
+    if (key_create((uint64_t)(uintptr_t)&key,
+                   (uint64_t)(uintptr_t)&guest_destructor, 0, 0, 0, 0) != 0)
+        return 1;
+    g_key = (pthread_key_t)key;
+
+    uint64_t thread = 0;
+    if (thread_create((uint64_t)(uintptr_t)&thread, 0,
+                      (uint64_t)(uintptr_t)&guest_worker, 0, 0, 0) != 0)
+        return 1;
+    void* worker_result = (void*)1;
+    const uint64_t join_result = thread_join(
+        thread, (uint64_t)(uintptr_t)&worker_result, 0, 0, 0, 0);
+    const uint64_t delete_result = key_delete(key, 0, 0, 0, 0, 0);
+
+    const bool ok = join_result == 0 && worker_result == nullptr && delete_result == 0 &&
+                    g_calls.load(std::memory_order_relaxed) == 2 &&
+                    g_values[0].load(std::memory_order_relaxed) == kFirstValue &&
+                    g_values[1].load(std::memory_order_relaxed) == kSecondValue;
+    if (!ok) {
+        std::fprintf(stderr,
+                     "pthread key destructor mismatch: join=%llu worker=%p delete=%llu "
+                     "calls=%u values=%llx,%llx\n",
+                     (unsigned long long)join_result, worker_result,
+                     (unsigned long long)delete_result,
+                     g_calls.load(std::memory_order_relaxed),
+                     (unsigned long long)g_values[0].load(std::memory_order_relaxed),
+                     (unsigned long long)g_values[1].load(std::memory_order_relaxed));
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Goal
Fix the Windows pthread-key teardown contract exposed by Blasphemous 2's deterministic opening-cinematic crash (#810), and the underlying guest callback ABI/lifecycle defects tracked in #817.

## Failure contract
There were three Windows boundary defects:

1. `k_key_create` passed a PS5 guest function pointer directly to winpthreads. winpthreads calls destructors with the value in Microsoft x64 `rcx`, while guest callbacks read their first SysV argument from `rdi`.
2. This winpthreads build leaves its per-key `used` flag set after `pthread_setspecific(key, nullptr)`. At thread exit it calls the destructor with a null value, contrary to POSIX's non-null destructor condition.
3. Host key deletion released a numeric winpthreads key before its thunk-map entry was removed, while creation published the host key before inserting the new thunk. Concurrent delete/create could reuse the number, lose the new insertion against the stale entry, and orphan a 4 KiB RX thunk.

A late-attach GDB trace captured one Blasphemous 2 worker registering once at `Il2cppUserAssemblies.prx+0x2c12b0`, explicitly unregistering through its guest return path, and then receiving the spurious null key-destructor callback. That callback entered the IL2CPP cleanup path and unregistered the same worker again; the second GC-table lookup returned null and faulted at `+0x2c11e0` (`record+0xf8`).

## Implementation
Each live Windows key with a guest destructor owns a small RX thunk. The thunk and lifecycle path:

- return immediately for a null callback value;
- marshal non-null callbacks through `prosper_call_guest_sysv`, delivering the exact value in guest `rdi`;
- preserve winpthreads' normal non-null destructor iterations;
- serialize host key creation plus thunk publication and host deletion plus thunk removal under one Windows lifecycle lock;
- check/roll back failed registry insertion; and
- release the thunk after successful pthread-key deletion.

The direct POSIX path is unchanged. No renderer, shader, capture, input, save-data, or timing behavior is modified.

## Risk and compatibility
The change is Windows-only and affects guest pthread-key destructors. The main risks are the generated callback stub's calling convention/stack contract and concurrent host key reuse. The end-to-end regression drives the real HLE create/key/thread/join/delete path, checks ABI value delivery and destructor iteration, and deterministically pauses deletion after the host releases a numeric key to prove creation cannot cross the registry transition. The null guard restores the POSIX contract that winpthreads violates; it does not suppress any conforming non-null callback.

## Author verification
Reviewed head `1e952657087682688a19f4859e97b28d21ca0c04` on target `82a1298dca32badf7fe45f99cca0dd92dec27a9c`.

```powershell
cmake --build prosper/build-mingw-app -j 12
ctest --test-dir prosper/build-mingw-app --output-on-failure -j 12
ctest --test-dir prosper/build-mingw-app -R '^win_pthread_key_destructor$' `
  --output-on-failure --repeat until-fail:100
```

Results: Windows MinGW build passed; 72/72 CTests passed; focused lifecycle regression passed 100/100.

The regression verifies:

- exact 64-bit non-null value delivery to a SysV guest destructor;
- a second destructor iteration after the callback installs another non-null value;
- set non-null, clear to null, exit worker produces zero destructor calls; and
- a concurrent delete/create reuse window remains serialized, reuses the released numeric key, and leaves zero tracked thunks.

The preceding combined #818/#820 Windows screenshot integration completed a fresh-save 360-second Blasphemous 2 route with 36/36 distinct 1920x1080 frames through sustained gameplay. The final pushed head then completed a fresh-save 230-second rerun with 23/23 source-distinct and 22/23 pixel-distinct 1920x1080 frames, visible first-room gameplay, exit 0, and no fatal exception, failed stack query, or guest-thread termination.

Fixes #817
Fixes #810