### PR TITLE
fix(windows): register frontend init stacks

### DIFF
--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -12,6 +12,10 @@
 // that depend on Linux perf_event / ptrace (PROSPER_HWBP/HWWATCH/BP/PEEK/DUMPAT) remain absent.
 #ifdef _WIN32
 
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00   // GetCurrentThreadStackLimits (Windows 8+)
+#endif
+
 #include "exec_image.hpp"
 #include "guest_write_watch.hpp"
 #include "sse4a.hpp"
@@ -116,6 +120,19 @@ namespace {
     // Thread-stack registry (portable; mirrors the Linux one) so GC/thread code gets real bounds.
     std::map<uint64_t, std::pair<uint64_t, uint64_t>> g_stacks;
     std::mutex g_smx;
+
+    // Module initialization may attach a frontend-owned thread to IL2CPP before run_entry switches
+    // to its dedicated guest stack. Keep the init thread's native stack registered for that
+    // thread's lifetime, then remove it before Windows can recycle the native TID.
+    struct InitThreadStackRegistration {
+        uint64_t native_tid = 0;
+        ~InitThreadStackRegistration() {
+            if (!native_tid) return;
+            std::lock_guard<std::mutex> lk(g_smx);
+            g_stacks.erase(native_tid);
+        }
+    };
+    thread_local InitThreadStackRegistration t_init_stack_registration;
 
     std::vector<std::pair<uint64_t, uint64_t>> g_modstart_param_ranges;
     struct ModStartDesc { uint64_t a, b, c; } g_modstart_desc = { 0x10, 0x200, 0 };
@@ -475,6 +492,10 @@ bool guest_stack_for_thread(uint64_t tid, void** base, size_t* size) {
     };
     if (lookup(tid)) return true;
 
+    // Frontends enter the guest from std::thread. winpthreads cannot always translate that
+    // implicit handle with pthread_gethandle(), but a self-query has an unambiguous native ID.
+    if (tid == (uint64_t)pthread_self() && lookup(cur_tid())) return true;
+
     // Windows workers are registered by native thread id because exception delivery and stack
     // limits use Win32 APIs, while the guest sees winpthreads' small pthread_t handle. Translate
     // that handle before looking up another thread's stack. Without this, scePthreadAttrGet(target)
@@ -493,6 +514,13 @@ void set_module_start_param_ranges(const std::vector<std::pair<uint64_t, uint64_
 }
 
 size_t run_guest_inits(const std::vector<uint64_t>& fns) {
+    ULONG_PTR stack_lo = 0, stack_hi = 0;
+    GetCurrentThreadStackLimits(&stack_lo, &stack_hi);
+    if (stack_lo && stack_hi > stack_lo) {
+        const uint64_t native_tid = cur_tid();
+        register_thread_stack(native_tid, (void*)stack_lo, (uint64_t)(stack_hi - stack_lo));
+        t_init_stack_registration.native_tid = native_tid;
+    }
     guest_tls_activate_thread();   // give this (main) thread its guest %fs TCB before running guest code
     size_t ok = 0;
     for (uint64_t f : fns) {

--- a/prosper/tests/test_win_kernel_is_stack.cpp
+++ b/prosper/tests/test_win_kernel_is_stack.cpp
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include <cstdint>
 #include <cstdio>
+#include <thread>
 
 using namespace prosper;
 
@@ -84,6 +85,28 @@ int main() {
     InterlockedExchange(&probe.release, 1);
     if (worker_created) pthread_join(worker, nullptr);
 
+    // screenshot and prosper-app initialize guest modules from a frontend-owned std::thread.
+    // Verify its implicit pthread handle resolves through the native-ID registration and that the
+    // thread-local owner removes the record when the frontend thread exits.
+    bool std_thread_self_resolved = false;
+    uint64_t std_thread_native_id = 0;
+    std::thread frontend_guest([&] {
+        uint8_t stack_byte = 0;
+        std_thread_native_id = (uint64_t)GetCurrentThreadId();
+        run_guest_inits({});
+        void* self_base = nullptr;
+        size_t self_size = 0;
+        std_thread_self_resolved =
+            guest_stack_for_thread((uint64_t)pthread_self(), &self_base, &self_size) &&
+            (uintptr_t)&stack_byte >= (uintptr_t)self_base &&
+            (uintptr_t)&stack_byte < (uintptr_t)self_base + self_size;
+    });
+    frontend_guest.join();
+    void* exited_base = nullptr;
+    size_t exited_size = 0;
+    bool std_thread_registration_cleaned = !guest_stack_for_thread(
+        std_thread_native_id, &exited_base, &exited_size);
+
     // A stale/unknown target must leave the caller-provided attr unchanged. Falling back to the
     // querying thread here is the exact wrong-stack substitution that can corrupt a GC scan.
     void* sentinel_stack = VirtualAlloc(nullptr, 1024 * 1024,
@@ -104,13 +127,17 @@ int main() {
     bool unregistered = is_stack(addr, 0, 0, 0, 0, 0) == 0;
 
     if (!inside || !below || !at_end || !attr_bounds || !worker_created || !resolved_worker ||
-        !target_attr_bounds || !missing_target_unchanged || !unregistered) {
+        !target_attr_bounds || !std_thread_self_resolved || !std_thread_registration_cleaned ||
+        !missing_target_unchanged || !unregistered) {
         std::fprintf(stderr,
                      "stack HLE mismatch: inside=%d below=%d at_end=%d attr_bounds=%d "
-                     "worker_created=%d resolved_worker=%d target_attr_bounds=%d "
+                     "worker_created=%d resolved_worker=%d target_attr_bounds=%d std_self=%d "
+                     "std_cleaned=%d "
                      "missing_unchanged=%d reported=%p/%zu expected=%p/%zu unregistered=%d\n",
                      inside, below, at_end, attr_bounds, worker_created, resolved_worker,
-                     target_attr_bounds, missing_target_unchanged, reported_base, reported_size,
+                     target_attr_bounds, std_thread_self_resolved,
+                     std_thread_registration_cleaned, missing_target_unchanged,
+                     reported_base, reported_size,
                      probe.base, probe.size, unregistered);
         return 1;
     }


### PR DESCRIPTION
## Goal
Fix #819: Windows boot frontends must register the module-initialization thread's real stack before guest module constructors can attach it to IL2CPP/BDWGC.

This is the focused extraction of an independent shared-infrastructure fix that was also present in the oversized Evergate PR #808.

## Failure contract
On current master, Windows `screenshot.exe` starts Blasphemous 2 and exits in about 1.2 seconds before writing a PNG. The fatal worker faults at `Il2cppUserAssemblies.prx+0x2bb0ab`. Its preceding exception ring reports failed stack queries for guest pthread handles `0x1` and `0x2`, both with null base/size.

`run_guest_inits` can attach the calling frontend thread to the guest GC before `run_entry` allocates and registers its switched guest stack. Windows did not register the init caller's host stack. Also, a current-thread guest query supplies the small winpthreads `pthread_self()` handle while the registry is keyed by native Windows TID, and `pthread_gethandle()` cannot always translate an implicit `std::thread` handle.

## Implementation
- Register `GetCurrentThreadStackLimits()` under the native TID at the start of `run_guest_inits`.
- Retain that record through a thread-local owner and erase it when the frontend thread exits, before Windows can recycle the TID.
- Resolve current-thread `pthread_self()` queries directly through `GetCurrentThreadId()` before attempting cross-thread handle translation.
- Extend the Windows stack test with a frontend-owned `std::thread`, current-thread lookup, real stack containment, and post-join cleanup checks.

Only the Windows stack registry and lookup path changes. POSIX hosts, renderer output, guest thread creation, exception delivery, filesystem behavior, and app input are deliberately unchanged.

## Risk and compatibility
The main risk is stale native-TID state or returning another thread's bounds. The owner removes its exact native-TID entry at thread exit, the self fallback is gated by `tid == pthread_self()`, and existing unknown/cross-thread tests continue to verify that missing handles do not substitute the caller's stack.

## Author verification
Reviewed head `fee538276e4374763cffbb9b4bb26fb1335d6234` on target `54a0400c79bf1322b6e3de7f9f778e0691097812`.

```powershell
cmake -S prosper -B prosper/build-mingw -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build prosper/build-mingw -j 12
ctest --test-dir prosper/build-mingw --output-on-failure -j 12
```

Result: core-only Windows build passed; 70/70 configured CTests passed.

Exact failure A/B:

```powershell
$env:PROSPER_GUEST_FS='1'
$env:PROSPER_GUEST_ARGS='-force-gfx-direct'
$env:PROSPER_PAD_SCRIPT='@C:/Users/matti/repos/ps5ys-init-stack/prosper/scripts/blasphemous2/reach-first-gameplay.pad'
$env:PROSPER_PAD_SCRIPT_LOG='1'
$env:PROSPER_VEHLOG='1'
prosper/build-mingw/screenshot.exe C:/Users/matti/repos/ps5ys/PPSA13579-app0 `
  --seconds 1 --count 2 --timeout 10 --out $env:TEMP/prosper-819-shot
```

Before: exit 1 after ~1.2 seconds, no PNG, fatal `+0x2bb0ab` after missing stack queries.

After: exit 0 after 2.6 seconds, 2/2 1920x1080 PNGs, two distinct source frames and pixel CRCs (`eb9e4e4e`, `e0a05477`). Artifact: `C:\Users\matti\AppData\Local\Temp\prosper-819-shot-20260716-1225`.

No snapshot baseline is changed or required because this PR changes thread stack discovery, not rendered output.

Fixes #819
Related: #808