### PR TITLE
tools(app): add frontend A/B checkpoints

### DIFF
--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -65,6 +65,16 @@ Esc or closing the window quits.
 
 ## Notes
 
+Set `PROSPER_APP_DUMP_FRAMES=1` to retain the renderer's normal composited BMP checkpoints while the
+interactive harness runs. `PROSPER_FRAME_DIR` selects their directory (the current directory by default).
+This is useful when a title only reproduces in the realtime app; use the screenshot frontend for routed
+PNG sequences and manifests when both frontends reproduce the same behavior.
+
+For frontend A/B diagnostics, `PROSPER_APP_DISABLE_AUDIO=1`, `PROSPER_APP_DISABLE_PAD=1`, and
+`PROSPER_APP_DISABLE_DIALOG=1` individually disable the corresponding SDL backend. The app then uses
+the core's realtime silent audio sink, keyboard/scripted pad input, or headless dialog auto-dismiss.
+These switches isolate frontend-specific behavior without requiring a separate build.
+
 - Two Vulkan contexts by design (`docs/FRONTEND_APP.md`): the core renders headless; the app owns a
   separate presentation device; frames cross as CPU pixels via `present_readback`.
 - On window-close the guest thread is detached and reclaimed by process exit (a cooperative

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -370,7 +370,10 @@ int main(int argc, char** argv) {
     std::thread guestThread;
     if (!testPattern && !dump.empty()) {
 #ifdef PROSPER_HAVE_LIVE_RENDERER
-        prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false);   // composite to the present layer, no disk spam
+        const char* frame_dir = getenv("PROSPER_FRAME_DIR");
+        prosper::frontend::register_live_renderer(
+            frame_dir && *frame_dir ? frame_dir : ".",
+            getenv("PROSPER_APP_DUMP_FRAMES") != nullptr);
 #else
         fprintf(stderr, "[app] built without the live renderer; the window will stay blank.\n");
 #endif
@@ -380,17 +383,29 @@ int main(int argc, char** argv) {
         // corresponding SDL3 frontend is enabled; a window app wants both on by default.
         auto install_backends = []{
 #ifdef PROSPER_AUDIO_SDL3
-            prosper::install_sdl3_audio_sink();
+            if (!getenv("PROSPER_APP_DISABLE_AUDIO")) {
+                prosper::install_sdl3_audio_sink();
+            } else {
+                fprintf(stderr, "[app] SDL audio backend disabled; using the realtime silent sink.\n");
+            }
 #endif
 #ifdef PROSPER_PAD_SDL3
-            if (prosper::install_sdl3_pad_backend()) {
-                g_keyboard_pad.set_fallback(prosper::input::pad_backend());
-                fprintf(stderr, "[app] controller backend installed.\n");
+            if (!getenv("PROSPER_APP_DISABLE_PAD")) {
+                if (prosper::install_sdl3_pad_backend()) {
+                    g_keyboard_pad.set_fallback(prosper::input::pad_backend());
+                    fprintf(stderr, "[app] controller backend installed.\n");
+                }
+            } else {
+                fprintf(stderr, "[app] SDL controller backend disabled; keyboard and scripted input remain available.\n");
             }
 #endif
 #ifdef PROSPER_HAVE_DIALOG_SDL3
-            prosper::install_sdl3_platform_ui();   // real SDL message boxes for MsgDialog/ErrorDialog (#347)
-            fprintf(stderr, "[app] dialog backend installed.\n");
+            if (!getenv("PROSPER_APP_DISABLE_DIALOG")) {
+                prosper::install_sdl3_platform_ui();   // real SDL message boxes for MsgDialog/ErrorDialog (#347)
+                fprintf(stderr, "[app] dialog backend installed.\n");
+            } else {
+                fprintf(stderr, "[app] SDL dialog backend disabled; using headless auto-dismiss.\n");
+            }
 #endif
         };
         if (!boot_program(dump, prog, &err, install_backends)) { fprintf(stderr, "[app] boot failed: %s\n", err.c_str()); return 1; }


### PR DESCRIPTION
## Goal

Provide runtime A/B controls for issue #690 without coupling them to the Windows timed thread tracer in #797.

## Behavior

- `PROSPER_APP_DUMP_FRAMES=1` retains the renderer's normal composited BMP checkpoints.
- `PROSPER_FRAME_DIR` selects their output directory.
- `PROSPER_APP_DISABLE_AUDIO=1`, `PROSPER_APP_DISABLE_PAD=1`, and `PROSPER_APP_DISABLE_DIALOG=1` independently bypass the corresponding SDL backend while preserving the existing silent-audio, keyboard/scripted-input, and headless-dialog fallbacks.
- Defaults are unchanged when none of the variables are set.

## Scope and risk

This changes only the interactive app frontend and its README. It does not change guest APIs, synchronization, renderer behavior, or the screenshot frontend. The main risk is build-time coverage across the optional SDL feature combinations.

## Author verification

- Native Windows MinGW configure with `PROSPER_APP=ON`, `PROSPER_AUDIO_SDL3=ON`, and `PROSPER_PAD_SDL3=ON`: passed.
- `cmake --build prosper/build-mingw-app --target prosper-app -j 8`: passed; produced `prosper-app.exe`.

This is intentionally split from #797 so the controls can be reviewed independently from the timed Windows diagnostic machinery.