### PR TITLE
docs: clarify independent verification policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,8 +287,9 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
 - **Reaching the running frame loop** needs two gated switches (off by default, so the default boot stays
   stable): `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`. Add `PROSPER_RENDER=1` to run the
   live renderer, `PROSPER_GFXLOG=1` for graphics diagnostics.
-- **Correctness-first:** implement real behavior (cross-checked against the Kyty PS5-emulator reference in
-  `../Kyty`), not shims that fake output. Mark genuinely-uncertain code with `CONFIDENCE: HIGH/MED/LOW`.
+- **Correctness-first:** implement real behavior from primary evidence: live captures/traces, guest
+  disassembly, published platform contracts, firmware symbol data, and focused tests. Do not ship shims
+  that fake output. Mark genuinely uncertain code with `CONFIDENCE: HIGH/MED/LOW`.
 - **Independent review is a mandatory merge gate for every PR containing agent work.** This applies whenever
   the current PR head contains changes designed, debugged, authored, co-authored, implemented, or materially
   modified by an agent, regardless of who opened the branch or PR. An agent taking over an existing PR must
@@ -387,29 +388,28 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   <base-repo>:<base-ref>@<base-SHA> with tree <tree-SHA> or NOT APPROVED. Directly message the author only to say
   that the posted review is complete.
   ```
-- **Kyty is a reference, NOT an oracle — and its reliability is split by platform generation.**
-  Kyty CAN run PS4 games, so the PS4-inherited surface (libkernel, pthreads, equeue, VideoOut,
-  filesystem, GNM-era graphics concepts) is exercised by real titles and is solid evidence — PS5
-  evolved from PS4, so those behaviors usually carry over. But Kyty's PS5-SPECIFIC surface is
-  early transcription work it never runs: **AGC (the PS5's replacement for GNM) especially** —
-  Gen5 Dcb builders, T#/V# Gen5 descriptor formats, PS5-only kernel calls (APR/Ampr/BatchMap).
-  There, prosper's own live captures are the only exercised evidence (we boot the PS5 titles;
-  Kyty does not). Trust order when sources disagree: (1) prosper's live captures/traces of the
-  real guest, (2) Kyty+shadPS4 agreeing (strongest for PS4-inherited surfaces), (3) either alone
-  — cite which and mark CONFIDENCE accordingly, and weight Kyty DOWN for anything Gen5/AGC.
-  Never weaken a behavior that a live boot demonstrates just to match a reference.
+- **Evidence hierarchy and independent implementation.** Trust sources in this order: (1) prosper's
+  live captures/traces of the real guest, (2) published platform contracts, firmware symbol data, and
+  the guest's own disassembly, (3) agreement among independently written secondary implementations,
+  then (4) a single secondary implementation as a hypothesis only. PS5-specific AGC, Gen5 descriptors,
+  and PS5-only kernel calls require direct title evidence; inherited PS4 behavior still must be checked
+  against the exercised guest path. External implementations are verification-only: do not copy or port
+  their code, types, comments, prose, or tests. Re-derive behavior in prosper's own architecture and add
+  project-owned evidence/tests. Never weaken behavior demonstrated by a live boot to match a secondary
+  reference, and mark unresolved evidence with `CONFIDENCE: HIGH/MED/LOW`.
 - **PS5 3.20 firmware library reference — the definitive NID↔name database (`../PS5-3.20_Libs/`).**
   A `genstub.py`-generated dump of **all 275 PS5 3.20 system libraries**, one `libSceXxx.c` per library.
   Each file lists **every exported function AND its exact NID**: the loader lines read
   `sprx_dlsym(__handle, "<NID>", &__ptr_<funcName>)`, so each is a `<NID> ↔ <funcName>` pair. This is
-  the **authoritative PS5-specific symbol map** — trust it OVER the PS4-era shadPS4 aerolib / Kyty for
+  the **authoritative PS5-specific symbol map** — trust it over PS4-era symbol lists and secondary tables for
   any Gen5/PS5-only surface (AGC, Ampr, Pad/UserService Gen5, etc.), and use it to see a library's
   *complete* real API surface (e.g. what functions exist that a title might call). Recipes:
   - Resolve an unknown NID → name: `grep -rn '<NID>' ../PS5-3.20_Libs/` (the matching `__ptr_<name>` names it).
   - A library's full export list: `grep -oE '\.global sce[A-Za-z0-9]+' ../PS5-3.20_Libs/libSceXxx.c | sort -u`.
   - Which library exports a symbol: `grep -rl '<funcName>' ../PS5-3.20_Libs/`.
   Caveat: it gives **names + NIDs only, no bodies** — argument layouts and behavior still come from
-  prosper's live captures + Kyty/shadPS4. Gitignored sibling of the repo; never commit its contents.
+  prosper's live captures, published contracts, and guest disassembly. Gitignored sibling of the repo;
+  never commit its contents.
 - **Commit style:** small, verified commits; push to `origin` promptly. Co-author trailer as configured.
   **Do NOT add "Generated with Claude Code" attribution lines** (the 🤖 badge, "Generated with
   [Claude Code](...)" footers, session links) to PR bodies, commit messages, issue text, or

--- a/prosper/docs/AGC_IMPL_PLAN.md
+++ b/prosper/docs/AGC_IMPL_PLAN.md
@@ -79,53 +79,43 @@ Two ways to get them, fastest first:
 5. **Present.** `sceVideoOut` swapchain (already stubbed) → present the rendered target; framebuffer
    CRC golden checks (agentic-first).
 
-## ⭐ Kyty is a portable reference implementation (../Kyty, MIT) — this changes the plan to PORT-and-adapt
+## Independently derived AGC model
 
-Kyty (a primitive PS5 emulator) HLE-implements the **exact** libSceAgc "Gen5" driver our game uses (same
-NIDs). MIT-licensed → directly portable with attribution. Full survey map (file:line in
-`repos/Kyty/source/emulator/`):
+The implementation must be derived from the title's live calls, its statically linked wrappers, captured
+command buffers, firmware NID/name data, AMD's public ISA/register material, and project-owned tests. Public
+implementations may be used only to challenge a conclusion after it has been derived; no source, types,
+comments, prose, or tests are copied into prosper.
 
-**Dcb `CommandBuffer` = the game's own struct** (cast from the guest pointer; Kyty never allocates it),
-`Graphics.cpp:777-831`:
-`+0x00 uint32_t* bottom` (base), `+0x08 top` (end), `+0x10 cursor_up` (write ptr), `+0x18 cursor_down`
-(reserve limit), `+0x20 callback` (`bool(*)(CommandBuffer*, uint32_t needed_dw, void*)` buffer-full),
-`+0x28 user_data`, `+0x30 reserved_dw` (~0x34 total). `AllocateDW(n)` (`:821`) reserves n dwords via the
-callback when short, returns `cursor_up`, bumps it. `ResetQueue(buf, 0x3ff, 0)` (`:1806`) only appends a
-2-dw `R_DRAW_RESET` NOP — the game sets up the pointer fields itself before the first append.
-**Our `[obj+0x40]` fault is beyond Kyty's 0x34-byte layout** — The Messenger uses a fuller Dcb; that one
-field still needs reversing (or the real AGC SDK header), but everything else transfers.
+**Dcb `CommandBuffer` model.** Live setup and cursor traces establish guest-owned base/end/write/reserve
+pointers plus a refill callback and caller data. The Messenger accesses additional fields, including the
+observed `[obj+0x40]`, so the exact layout remains title/version-specific until each offset is pinned by the
+guest wrapper or a published SDK header. `ResetQueue` and allocation behavior must be verified from cursor
+deltas and emitted packets rather than assumed from a foreign object layout.
 
-**AGC HLE model:** each `GraphicsDcb*` fn appends a custom PM4 packet `KYTY_PM4(len, IT_NOP, R_*)`
-(`Pm4.h:16`; `R_*` sub-opcodes carried in IT_NOP, `Pm4.h:75-101`). `SubmitDcb` (`Graphics.cpp:2175`) →
-`GraphicsRunSubmit` → async `GraphicsRing` worker → `CommandProcessor::Run` (`GraphicsRun.cpp:989`)
-decodes PM4 via dispatch tables (`:4215-4260`) into `HW::Context/UserConfig/Shader`
-(`HardwareContext.h:635/855/880`) → on draw, `GraphicsRenderDrawIndexAuto` recompiles shaders, builds a
-Vulkan pipeline, binds V#/T#/S# descriptors, `vkCmdDraw`. Present: `R_FLIP`/`VideoOutSubmitFlip` →
-`FlipQueue` → `WindowDrawBuffer` (SDL2 swapchain — stub headless).
+**AGC HLE model.** Each `GraphicsDcb*` entry appends a framed PM4/NOP-carried operation to guest memory.
+`SubmitDcb` hands that stream to prosper's command processor, which folds register and resource state, runs
+the project-owned RDNA2 decoder/recompiler, binds V#/T#/S# descriptors, executes Vulkan work, and presents
+through the headless/live frontend. Packet framing and sub-opcodes are accepted only after capture/disassembly
+and a round-trip test agree.
 
-**Function inventory** (NID → Kyty impl, all `Graphics.cpp`): TRO721eVt4g ResetQueue :1806; ZvwO9euwYzc
-SetCxRegistersIndirect :1874; -HOOCn0JY48 SetShRegistersIndirect :1899; hvUfkUIQcOE SetUcRegistersIndirect
-:1924; pFLArOT53+w SetShRegisterDirect :1855; GIIW2J37e70 SetIndexSize :1949; Yw0jKSqop+E DrawIndexAuto
-:1971; aJf+j5yntiU EventWrite :1996; wr23dPKyWc0 CbReleaseMem :1763; 57labkp+rSQ AcquireMem :2021;
-i1jyy49AjXU WriteData :2061; VmW0Tdpy420 WaitRegMem :2096; YUeqkyT7mEQ SetFlip :2134; MWiElSNE8j8
-WaitUntilSafeForRendering :1829; f3dg2CSgRKY CreateShader :1432 (magic 0x34333231 "1234", ver 0x18,
-relocates header + patches SPI_SHADER_PGM_LO/HI); 2JtWUUiYBXs/wRbq6ZjNop4 GetRegisterDefaults :1307/1317;
-23LRUSvYu1M Init :1294. Indirect-patch helpers (vcmNN.../d-6uF9...) patch dwords of a prior packet.
+**Function inventory** from the firmware export map and observed wrappers: `TRO721eVt4g` ResetQueue;
+`ZvwO9euwYzc` SetCxRegistersIndirect; `-HOOCn0JY48` SetShRegistersIndirect; `hvUfkUIQcOE`
+SetUcRegistersIndirect; `pFLArOT53+w` SetShRegisterDirect; `GIIW2J37e70` SetIndexSize;
+`Yw0jKSqop+E` DrawIndexAuto; `aJf+j5yntiU` EventWrite; `wr23dPKyWc0` CbReleaseMem;
+`57labkp+rSQ` AcquireMem; `i1jyy49AjXU` WriteData; `VmW0Tdpy420` WaitRegMem;
+`YUeqkyT7mEQ` SetFlip; `MWiElSNE8j8` WaitUntilSafeForRendering; `f3dg2CSgRKY` CreateShader;
+`2JtWUUiYBXs`/`wRbq6ZjNop4` GetRegisterDefaults; and `23LRUSvYu1M` Init. The shader magic,
+header relocation, program-register patching, and indirect packet patch helpers are verified separately
+against captured bytes and guest disassembly.
 
-**Shader recompiler:** `ShaderParse.cpp` (GCN/RDNA2 decode → ShaderCode IR, "NextGen"=RDNA2 path) +
-`ShaderSpirv.cpp` (~8K lines, IR → SPIR-V asm text via per-instr templates) + `Shader.cpp` (SpirvRun uses
-SPIRV-Tools assemble+optimize). Portable (needs Kyty core types + SPIRV-Tools).
+**Shader strategy.** Use `llvm-mc -mcpu=gfx1030` as an independent encoding/decoding oracle, prosper's own
+RDNA2 decoder and IR, SPIR-V validation, and offscreen Vulkan assertions. Keep packet decode, hardware state,
+shader translation, resource binding, and presentation as separately testable project-owned layers.
 
-**Coupling to abstract when porting:** portable = the AGC HLE (Graphics.cpp Gen5), PM4 defs (Pm4.h), CP
-decode (GraphicsRun.cpp), recompiler (ShaderParse/ShaderSpirv/Shader.cpp), HW regs (HardwareContext.h) —
-depend mainly on Kyty core (`String8`/`Vector`/`Hashmap`) + SPIRV-Tools. Rewrite for prosper's backend =
-`GraphicsRender.cpp` (Kyty Vulkan wrappers + GpuMemory tracking) and `Window.cpp` (SDL2 swapchain →
-headless offscreen for us).
-
-**Port order:** (1) guest Dcb struct (Kyty layout + reverse our `+0x40`) + the `GraphicsDcb*` HLE fns; (2)
-Pm4.h + CommandProcessor decode → HW state (no Vulkan yet — verify by dumping decoded state); (3) shader
-recompiler (RDNA2 path; start with embedded/trivial shaders); (4) prosper Vulkan backend from HW state
-(reuse our offscreen harness); (5) headless present (offscreen image + CRC golden — our test harness).
+**Implementation order:** (1) derive the guest Dcb fields and HLE entry contracts; (2) decode captured PM4
+into hardware state and assert exact folds without Vulkan; (3) extend the RDNA2 recompiler from embedded and
+minimal captured shaders; (4) execute that state through prosper's Vulkan backend; (5) present headlessly and
+gate each stage with decoded-state, SPIR-V, and framebuffer assertions.
 
 ## Honest scope
 

--- a/prosper/docs/BUG_HUNT_BACKLOG.md
+++ b/prosper/docs/BUG_HUNT_BACKLOG.md
@@ -20,12 +20,12 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
 - FreeBSD→Linux open(2) flag words passed raw (O_CREAT became O_TRUNC).
 - sceKernelWaitEventFlag / WaitSema ignored their timeout (silent forever-block).
 - scePthread(Attr)Getschedparam/Getprio returned success with unwritten out-params.
-- EVFILT_VIDEO_OUT was -10 (FreeBSD EVFILT_LIO); Kyty + shadPS4 agree on -13.
+- EVFILT_VIDEO_OUT was -10 (FreeBSD EVFILT_LIO); FreeBSD-derived constants and independent implementations agree on -13.
 - guest_readable/probe_readable probed via /dev/null, which never faults → all guards
   were no-ops (now a drained O_NONBLOCK pipe; raw syscalls in the fault handler).
 - Lazy GPU-VA backing ignored si_code (clobbered live RO mappings; infinite fault loop
   on in-window instruction fetches). Now SEGV_MAPERR-only and addr != RIP.
-- SceAudioOutPortState layout diverged from Kyty (volume written into flag); audio
+- SceAudioOutPortState wrote volume into the flag field instead of the ABI's volume field; audio
   errors were generic -1 instead of 0x80260003/0x80260005.
 - Guest-%fs swap stubs shifted stack args by 2 qwords — ReleaseMem's (data_sel, fence
   value) read a TCB pointer + return address under PROSPER_GUEST_FS. Stub now forwards
@@ -54,7 +54,7 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
    (introduced 41b01f3)
 2. **[simplification] Indexed draws silently dropped** — hle_agc.cpp emits R_DRAW_INDEX
    (0x03) but pm4_decode never decodes it: every sceAgcDcbDrawIndex vanishes downstream
-   while the guest sees success. Decode it (verify a2/a3 roles vs Kyty), push a Draw
+   while the guest sees success. Decode it (verify a2/a3 roles from wrapper disassembly and live calls), push a Draw
    with index data, round-trip test. Directly relevant to scene-content rendering.
    (8d26489)
 3. **[hack] Quad-fan topology heuristic** — gpu_execute.hpp:107-112 rewrites any draw
@@ -64,7 +64,7 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
 4. **[hardcoded] Sampled textures assumed RGBA8** — agc_shader_layout.cpp:144,151: the
    decoded 9-bit T# format is thrown away; everything uploads as Unorm8 ×4 with
    size = w*h*4 (over-reads BCn allocations up to 8×). Add a Gen5 IMG_FMT→DataFormat
-   mapper (Kyty tables), size from block size, loud skip on unmapped. (13d70f7)
+   mapper from public format definitions and captures, size from block size, loud skip on unmapped. (13d70f7)
 5. **[defect] release-mem data_sel default write** — command_processor.cpp:58-67 writes
    8 bytes for ANY unrecognized data_sel and cases 1/2 lack the rel_value_valid guard.
    With the stub-frame fix in, data_sel now decodes correctly — make the default
@@ -72,7 +72,7 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
 6. **[defect] Equeue lifetime + semantics cluster** — hle_kernel_time.cpp:
    (a) k_eq_delete deletes EqState while waiters may sit in wait (UAF; registrations in
    g_*_regs never purged — address reuse resurrects them); (b) WaitEqueue returns
-   SUCCESS with *out=0 on timeout/unknown queue (Kyty/shadPS4 return ETIMEDOUT) and
+   SUCCESS with *out=0 on timeout/unknown queue (the platform-compatible result is ETIMEDOUT) and
    caps NULL timeout at 100 ms returning success; (c) eq_post drops the NEWEST event
    when 4 queued (a flip event can be the one dropped — coalesce by ident/filter
    instead); (d) detached HR-timer threads post to possibly-deleted queues and
@@ -87,7 +87,7 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
    cross-thread-dependent inits deadlock. Per-control state (3-state word + condvar),
    callback outside the lock (h_execute_once now shows the shape). (5fae501)
 9. **[defect] WaitRegMem args destroyed at build time** — hle_agc.cpp zeroes the whole
-   9-dword payload; the wait can never be honored downstream. Encode Kyty's layout;
+   9-dword payload; the wait can never be honored downstream. Encode the captured wrapper/packet layout;
    CP should at least assert the condition already holds at fold time. (2e4b9de)
 10. **[hardcoded] Ampr mirror view at fixed −0x540000000** — hle_kernel_mem.cpp:431:
     one-title constant, MAP_FIXED over whatever lives there. Track the guest's real
@@ -113,7 +113,7 @@ Tags: [defect] wrong behavior · [hack] shortcut standing in for real behavior �
 - [simplification] EventWrite drops its address arg (label-carrying events can never
   write) — hle_agc.cpp:136. (2e4b9de)
 - [hardcoded] vk_color_format maps ONLY 8_8_8_8 (else silently Undefined) —
-  vk_translate.cpp:20. Port Kyty rows; log unmapped. (822cd24)
+  vk_translate.cpp:20. Fill rows from public format definitions and validated captures; log unmapped. (822cd24)
 - [simplification] Special-operand ALU sources (VCC/EXEC/M0 as data) silently read 0 —
   rdna2_to_spirv.cpp operand_bits default. Route to tracked bools or reject. (e13f469)
 - [defect] v_cvt_u32_f32/i32_f32 emit bare OpConvertFToU/S (UB out-of-range; hardware

--- a/prosper/docs/GFX10_SW_64KB_TILING.md
+++ b/prosper/docs/GFX10_SW_64KB_TILING.md
@@ -24,8 +24,8 @@ search scored a truncated single-dump wrongly... the addrlib pattern decides it 
 
 Reference: Mesa `src/amd/addrlib/src/gfx10/gfx10SwizzlePattern.h` (tables) +
 `src/core/addrlib.cpp:ComputeOffsetFromSwizzlePattern` (evaluation) +
-`gfx10addrlib.cpp:ComputeSurfaceAddrFromCoordMacroTiled` (block layout). Kyty was deliberately NOT
-used (GCN/PS4 tiling — wrong generation, per CLAUDE.md).
+`gfx10addrlib.cpp:ComputeSurfaceAddrFromCoordMacroTiled` (block layout). Older GCN/PS4 tiling models were
+deliberately not used because they target the wrong hardware generation.
 
 For a 2D single-sample surface:
 

--- a/prosper/docs/GFXDEVICE_BRINGUP_PROBLEM.md
+++ b/prosper/docs/GFXDEVICE_BRINGUP_PROBLEM.md
@@ -156,14 +156,14 @@ evidence. The pattern — reasoning *about* Unity's internals from the fault sit
   is HDR tone-map luminance (benign); `IsOutputSupported → 1`. There is **no wrong device query**
   steering a degenerate path. The device *succeeds* — yet its sub-objects were never built. Model
   doesn't fit.
-- Reference cross-check is thin: **Kyty** only implements a shallow `GraphicsInit`; not much to diff.
+- Secondary-implementation cross-checks are thin here; direct title evidence must drive the conclusion.
 
 ### Also ruled out
 - **Display surface** is not the gate: we implemented real `libSceVideoOut` (1920×1080@59.94, 3
   buffers, real flip/vblank status) and the boot faults **identically**.
 - **Shader semantics are not mangled:** raw-byte trace confirmed our `CreateShader` relocation is
-  correct (a shader with varyings reads `num_out=1`, `output_semantics[0].semantic=0x0f`, exactly what
-  Kyty's VS→PS linkage expects). The faulting pair are genuinely **zero-varying** shaders
+  correct (a shader with varyings reads `num_out=1`, `output_semantics[0].semantic=0x0f`, matching the
+  observed VS→PS linkage contract). The faulting pair are genuinely **zero-varying** shaders
   (position-only / blit / clear) — so the empty reflection worklist is a *correct* consequence for
   them, not a surfacing bug. (One PS does have a single `sharp[3]` storage-buffer binding.)
 - **Late writer / ordering race** is not the gate: the companion watchpoint saw only zero writes, not

--- a/prosper/docs/GPU_EXECUTOR_DESIGN.md
+++ b/prosper/docs/GPU_EXECUTOR_DESIGN.md
@@ -2,9 +2,9 @@
 
 **Date:** 2026-07-06. **Goal:** execute the game's submitted AGC command buffers on a real Vulkan device
 and signal GPU completion so the Unity render loop advances past its current stall to actual frames.
-Grounded in two references in the parent folder: **shadPS4** (`src/video_core/amdgpu/liverpool.cpp`,
-`src/core/libraries/gnmdriver/gnmdriver.cpp` — mature, PS4/Gnm) and **Kyty** (`source/emulator/src/Graphics/*`
-— early, PS5/AGC-native; treat as a hint, cross-check against shadPS4).
+Grounded in live Dcb captures, guest wrapper disassembly, AMD PM4 documentation, FreeBSD event semantics,
+and the mature PS4/Gnm behavior documented by **shadPS4**. Secondary implementations are consistency
+checks only; prosper's behavior is derived and tested independently.
 
 ## The completion mechanism (cross-validated by BOTH references)
 A submit finishes and the CPU learns about it through **end-of-pipe (EOP) events**:
@@ -12,16 +12,17 @@ A submit finishes and the CPU learns about it through **end-of-pipe (EOP) events
    to a memory label** and optionally **raises a GPU interrupt**.
    - shadPS4 `liverpool.cpp`: `EventWriteEop` → `event_eop->SignalFence(...)` (the label write) + a lambda
      `IrqC::Signal(InterruptId::GfxEop)`; `ReleaseMem` → `SignalFence` + `IrqC::Signal(pipe_id)`.
-   - Kyty `GraphicsRun`: the ReleaseMem packet dispatches to `GraphicsRenderWriteAtEndOfPipeWithInterrupt*`
-     (label write) which, when a submit's work drains, calls `RenderContext::TriggerEopEvent()`.
+   - Independent implementations use the same two-step model: defer the label write until submitted
+     work drains, then route an EOP notification.
 2. The interrupt is routed to a **kevent** the app registered: `eq->TriggerEvent(ident=GfxEop=0x40,
-   filter=EVFILT_GRAPHICS, udata)`. (shadPS4 `equeue.cpp::TriggerEvent`; Kyty `KernelTriggerEvent`.)
+   filter=EVFILT_GRAPHICS, udata)`. (See shadPS4 `equeue.cpp::TriggerEvent` and FreeBSD kqueue semantics.)
 3. The app registered that source with **`sceGnmAddEqEvent`/`GraphicsAddEqEvent` (NID `b0xyllnVY-I`,
    id=`0x40`)** and a thread does `sceKernelWaitEqueue` on that queue; the trigger wakes it.
 4. Flips are the same shape: a flip `RELEASE_MEM` variant / `SubmitFlip` presents the buffer and posts a
    **flip** kevent (shadPS4 `videoout/driver.cpp` `equeue->TriggerEvent(...)` on `GfxFlip`).
 
-So completion = **{write the fence label} + {trigger the registered EOP/flip kevent}**. Both refs agree.
+So completion = **{write the fence label} + {trigger the registered EOP/flip kevent}**. The live packet
+stream and independent platform evidence agree.
 
 ## Where prosper already is (the halves that exist)
 - **Front half (done):** `agc_driver_submit_dcb` (NID `UglJIZjGssM`) replays the Dcb via
@@ -31,7 +32,7 @@ So completion = **{write the fence label} + {trigger the registered EOP/flip kev
   state; the recompiler turns the real shaders → SPIR-V (38/41, ~95%); `tests/render_runner.h` renders a
   `GpuState` to pixels on llvmpipe. `videoout_present.cpp` has `present_write_frame`/`present_readback`.
 - **Missing:** a *live, persistent* device that executes the accumulated draws at submit time and presents,
-  plus the **completion signaling** that both refs describe.
+  plus the **completion signaling** required by that model.
 
 ## The prosper-specific twist (must drive the design)
 Our target (The Messenger) does **NOT** follow the textbook EOP-equeue path:
@@ -64,12 +65,14 @@ directly (currently the backend renders to its own attachment at videoout resolu
 `GpuState::apply` performs the writes the Dcb requests, since our CommandProcessor folds a submit
 synchronously (GPU "done" the instant SubmitDcb returns → this IS the end-of-pipe moment):
 - `RELEASE_MEM`/`EVENT_WRITE_EOP` (`honor_eop_write`): write the fence value to the label address, honoring
-  `data_sel` (1=32-bit value, 2=64-bit value, 3=64-bit monotonic GPU clock). The AGC ABI is pinned to Kyty
-  `GraphicsCbReleaseMem` (`buf, action, gcr_cntl, dst, cache_policy, address, data_sel, data, …`) — this
+  `data_sel` (1=32-bit value, 2=64-bit value, 3=64-bit monotonic GPU clock). Guest wrapper disassembly and
+  live stack-argument capture pin the ABI as
+  `GraphicsCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address, data_sel, data, …)` — this
   resolved the earlier LOW-confidence "which arg is the value" (a5=address, stack arg 7=data_sel, stack arg
   8=the 64-bit value). `agc_cb_release_mem` now lays out `[0..1]=addr [2]=data_sel [3..4]=value [5]=action`.
 - `WRITE_DATA` (`honor_write_data`): copy the inline dwords to the destination; `agc_dcb_write_data` now
-  copies the real `data*`/`num_dwords` (Kyty `GraphicsDcbWriteData`) into the packet. `WAIT_REG_MEM`: no-op
+  copies the real `data*`/`num_dwords` observed at `GraphicsDcbWriteData` call sites into the packet.
+  `WAIT_REG_MEM`: no-op
   (the label is already written → condition satisfied).
 Correct end-of-pipe semantics, on by default; `PROSPER_NO_EOP_WRITE=1` disables for bisection. Verified by
 `test_eop_write` (data_sel 1/2/3 + WRITE_DATA + overflow-clamp). Replaces the old `PROSPER_AGC_FENCE` scaffold.

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -109,7 +109,7 @@ initializers to construct valid GPU objects (correctness-first — no plausible-
 ## ✔ USER-DATA PROBE (2026-07-04): zero-varying fault pair still has PS resource bindings
 
 Follow-up to PR #14's fork between "legitimate zero-varying pipeline, bad resident flag" and
-"`[+0xc0]` is fed by shader resource bindings." `PROSPER_PIPETRACE` now logs Kyty's
+"`[+0xc0]` is fed by shader resource bindings." `PROSPER_PIPETRACE` now logs the decoded
 `ShaderUserData` resource-binding table: direct resource offsets, `eud_size_dw`/`srt_size_dw`, and
 the four sharp-resource arrays (`sharp[0]` texture, `sharp[2]` sampler, `sharp[3]` storage buffer).
 
@@ -138,7 +138,7 @@ now logs semantic counts/arrays + the raw `0x50..0x5f` header region):
 
 - Shaders that HAVE varyings read correctly: `num_input_semantics=1` (`raw[0x50]=01 00 00 00`),
   `num_output_semantics=1` (`raw[0x56]=01 00`), and `output_semantics[0].semantic=0x0f` (=15) — exactly
-  the value Kyty's VS→PS linkage expects. So our offsets (in u32@0x50, out u16@0x56, arrays@0x30/0x38)
+  the value consumed by the observed VS→PS linkage. So our offsets (in u32@0x50, out u16@0x56, arrays@0x30/0x38)
   and relocation are correct.
 - The **faulting pipelines** use `gs` (num_out=0, `raw[0x56]=00 00`) + `ps` (num_in=0) — genuinely
   **zero-varying shaders** (position-only/blit). All 3 `CreateInterpolantMapping` calls therefore map 0
@@ -223,7 +223,7 @@ explain the empty reflection table. This is the remaining thread to the true roo
 ## ✔ libSceVideoOut real 1080p60 + swapchain scaffolding (2026-07-04) — and the [+0x140] gate is NOT the display surface
 
 Implemented the 5 previously-unimplemented VideoOut NIDs with real, self-consistent values (resolved
-via shadPS4 aerolib + Kyty VideoOut.cpp): `Nv8c-Kb+DUM` sceVideoOutIsOutputSupported, `PjS5uASwcV8`
+through firmware symbols, guest call sites, and PS4-inherited public contracts): `Nv8c-Kb+DUM` sceVideoOutIsOutputSupported, `PjS5uASwcV8`
 sceVideoOutSetBufferAttribute2, `rKBUtgRrtbk` sceVideoOutRegisterBuffers2, `utPrVdxio-8`
 sceVideoOutGetOutputStatus, `w0hLuNarQxY` sceVideoOutConfigureOutput. Plus fixed GetResolutionStatus
 (was all-zero → now 1920×1080@59.94Hz) and added GetVblankStatus (advancing counter) +
@@ -347,13 +347,13 @@ code writes the global" was the classic computed-addressing blind spot (same fai
 RGCTX hunt): the writer stores through `slot+0x10`, never through the literal address.
 
 The **register source object IS the Shader**: `SetSource` (eboot+0x3af400) reads `[src+0x08]`
-(user_data), `[src+0x28]` (specials), `[src+0x5a]` (type) — exactly the SDK Shader layout (Kyty
-Shader.h:974). The "classify table" ships inside each shader blob; nothing is fabricated.
+(user_data), `[src+0x28]` (specials), `[src+0x5a]` (type) — the layout established by the guest's own
+accesses and captured header bytes. The "classify table" ships inside each shader blob; nothing is fabricated.
 
-**Implemented in `hle_agc.cpp` (all real semantics, layout-verified via Kyty + the eboot disasm):**
+**Implemented in `hle_agc.cpp` (all real semantics, layout-verified via eboot disassembly and captures):**
 - `f3dg2CSgRKY` **sceAgcCreateShader** — relocates the header's self-relative pointers in place,
   binds the code pointer, patches the leading `SPI/COMPUTE_PGM_LO/HI` sh-register pair (all five
-  stage pairs, beyond Kyty's ES/PS-only), guards double-relocation, writes `*dst`, and registers
+  stage pairs, beyond the initially observed ES/PS pair), guards double-relocation, writes `*dst`, and registers
   the shader in a host-side registry (`prosper_agc_shader_count()`) for the AGC→Vulkan pipeline.
 - `V++UgBtQhn0` **sceAgcGetDataPacketPayloadAddress** — called from *inside* eboot's static AGC
   code (register-bank prepare, `eboot+0x3af040`): the returned payload becomes the register bank
@@ -361,15 +361,15 @@ Shader.h:974). The "classify table" ships inside each shader blob; nothing is fa
 - `n2fD4A+pb+g` **sceAgcCbSetShRegisterRangeDirect** — IT_SET_SH_REG range packet (+ the marker
   NOP the real library emits).
 - `D9sr1xGUriE` **sceAgcCreatePrimState**, `HV4j+E0MBHE` **sceAgcCreateInterpolantMapping** —
-  pipeline registers derived from the bound shaders' specials/semantics (generalized semantic
-  matching instead of Kyty's hard-asserted identity layout).
+  pipeline registers derived from the bound shaders' specials/semantics using generalized semantic
+  matching rather than a hard-coded identity layout.
 
 **Result:** all 36 built-in shaders register (`PROSPER_GFXLOG` shows `pgm_patched=1` on each), the
 whole `CreateWorkload` register-context chain (`0x3b5ea6` → `0x3b1562` → `0x3b1533` → `0x3afcff`)
 completes, and **no unimplemented libSceAgc call remains in the boot**. The boot now faults much
 later at `eboot+0xba6e08` (addr=0x8, non-AGC backtrace via `0xd3xxxx`/`0x15fxxxx`) — the next,
-separate frontier. Note: the game passes AGC interface version **13** (Kyty's Gen5 games used 8) —
-layouts verified against this title, not assumed from Kyty.
+separate frontier. Note: the game passes AGC interface version **13**; layouts are verified against
+this title rather than inferred from earlier-generation material.
 
 Tooling added: `build-linux/imgdump <module> <out.img>` dumps a module's flat image for offline
 `objdump -D -b binary -m i386:x86-64` disassembly (how the registry writer was found).
@@ -404,8 +404,8 @@ The boot faults at `eboot+0x3b5ea6` inside a GPU register-setting routine. Full 
 **Disproved proposed fix:** implement `+kSrjIVxKFE` as an AGC register-context constructor: allocate the two
 register banks, install `[context+0x10]`/`[context+0x18]`, and install a valid classify table at
 `[context+0x08]` mapping (register-set selector, SDK register index) → hardware slot. The register
-offsets for that mapping are exactly the data now vendored in `agc_reg_defaults.cpp` (the ported
-Kyty `RegisterDefaults`). Note: this AGC code is **statically linked into eboot** — only the leaf
+offsets for that mapping are exactly the independently verified tables now stored in
+`agc_reg_defaults.cpp`. Note: this AGC code is **statically linked into eboot** — only the leaf
 SDK entrypoints like `+kSrjIVxKFE` are imports (PLT/GOT), which is why implementing that one import
 unblocks the whole internal register path.
 

--- a/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
+++ b/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
@@ -141,7 +141,7 @@ This mirrors how real drivers stage a fetch shader. Needs the draw's vertex-buff
 5. **No regressions:** `ctest --test-dir build-linux` 45/45 and the Windows build 20/20 stay green.
 
 ## Known follow-ups (separate, do NOT scope-creep)
-- **Texture detiling** (`tile_mode != 0`) — Kyty `Tile.cpp` reference.
+- **Texture detiling** (`tile_mode != 0`) — derive from AMD addrlib equations and captured textures.
 - **Executing the full draw chain** so sampled render targets have real content.
 - **Per-draw state** (`GpuState::Draw` currently only `index_count`).
 - **Real swapchain/window present** (`videoout_present.cpp` scaffolding exists).
@@ -156,7 +156,7 @@ This mirrors how real drivers stage a fetch shader. Needs the draw's vertex-buff
 | Register-state fold (SET_SH_REG range fix) | `src/gpu/pm4_decode.cpp` (`IT_SET_SH_REG`), `command_processor.cpp` (`SetShRegDirect`) |
 | Shader-header lookup by code addr | `src/hle/hle_agc.cpp` `prosper_agc_shader_header_for_code` |
 | Live renderer + BMP dump | `tools/boot_trace/boot_trace.cpp` (`PROSPER_RENDER`), `tests/render_runner.h` |
-| Kyty reference | `../Kyty/source/emulator/src/Graphics/Shader.cpp` (`ShaderParseUsage`, fetch handling) |
+| Independent evidence | Captured shader headers/ISA, guest wrapper disassembly, AMD RDNA2 documentation |
 | Repro switches | `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_RESDUMP=1 PROSPER_SHADER_DUMP=/tmp PROSPER_FRAME_DIR=/tmp/frames` |
 
 **Environment:** build/run in WSL Ubuntu-24.04 as root; game dump at

--- a/prosper/docs/REAL_FRAMES_FINDINGS.md
+++ b/prosper/docs/REAL_FRAMES_FINDINGS.md
@@ -87,7 +87,8 @@ PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_FILELOG=1 PROSPER_PREADLOG=1 gdb ./
 2. **Determinism**: the llvmpipe render is ~400× slower than the native loop, so a "good" frame (texture
    loaded + fade complete) is timing-dependent. Consider an on-demand capture at a chosen frame.
 3. **Loader SIGSEGV** (for the real title/gameplay scene): watchpoint the slot that receives the `"Rewired_"`
-   bytes where a pointer belongs; implement the suspect libSceAgc/libSceAmpr NIDs for real (Kyty cross-check).
+   bytes where a pointer belongs; implement the suspect libSceAgc/libSceAmpr NIDs from live capture,
+   guest disassembly, and the firmware symbol map.
 
 ## Test recipes (worktree `ps5ys-frames`, build-linux)
 

--- a/prosper/docs/RENDER_LOOP.md
+++ b/prosper/docs/RENDER_LOOP.md
@@ -454,7 +454,8 @@ Built the GPU executor per `docs/GPU_EXECUTOR_DESIGN.md` (all committed, Linux 4
   `set_submit_renderer`/`execute_and_present` (`gpu_executor.cpp`); `agc_driver_submit_dcb` calls it after
   folding, gated on `have_submit_renderer() && draws>0`. Inert until a device is registered. `test_gpu_execute`.
 - **Stage B** — RESOLVES the "blocker for doing it correctly" below (capturing the fence value beyond a0–a5).
-  Pinned the AGC ABI to Kyty `GraphicsCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address,
+  Pinned the AGC ABI from guest wrapper disassembly and live stack-argument capture:
+  `GraphicsCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address,
   data_sel, data, …)`: a5=label address, stack arg 7=`data_sel`, stack arg 8=the **full 64-bit value**.
   `honor_eop_write` now writes the correct value honoring `data_sel` (1=32b, 2=64b, 3=GPU clock), on by
   default (`PROSPER_NO_EOP_WRITE=1` disables). `honor_write_data` copies WRITE_DATA's real dwords. `test_eop_write`.
@@ -488,7 +489,7 @@ semantics, not a hack. **Blocker for doing it correctly:** the fence *value* REL
 argument passed on the guest stack (beyond a0–a5), which the current HLE ABI shim doesn't capture, and the
 `cmpFunc`/`ref` encoding of WAIT_REG_MEM must be honored exactly (writing a guessed value would be a fake —
 correctness-first). Doing this right needs either (a) capturing the stack args in the HLE trampoline, or
-(b) the Kyty Gen5 RELEASE_MEM/WAIT_REG_MEM field reference. This is the precise, bounded task that should
+(b) direct disassembly/capture of the Gen5 RELEASE_MEM/WAIT_REG_MEM fields. This is the precise, bounded task that should
 crack the render loop — best done with the user/reference in the loop (boot-wall-caliber), but it is now a
 *specific* mechanism, not a vague "GPU-execution build."
 
@@ -664,9 +665,9 @@ trailing `SInt8 m_Type`/`m_RowCount` + align. `unity_builtin_extra` has NO embed
 descriptor** built WITHOUT referencing the type by name (a static init table), not from the per-type Transfer
 functions. **This is the fixable root class: a static-initializer / RTTI-field-registration built the
 MatrixParameter (and VectorParameter) descriptor with only 3 fields (byteSize 12) in our env** — matching
-Kyty's init-ordering divergence note and Fable's "corrupted RTTI/static-init generation" mechanism #2.
+Fable's "corrupted RTTI/static-init generation" mechanism #2.
 **NEXT:** (a) find the static init that registers MatrixParameter's fields and why our env leaves it with 3
-fields / byteSize 12 (init-array ordering: we run PRX init reverse vs Kyty forward; confirm we don't
+fields / byteSize 12 (init-array ordering: we run PRX init in reverse; confirm we do not
 double-run or skip `_init`); or (b) gated capture of `0xd4ce00`'s `*0x38` elemSize for the m_MatrixParams read
 (arm after the 5th driver hit to avoid init perturbation) to nail the 12.
 
@@ -736,8 +737,8 @@ null alloc → crash.
 
 ### Fixable root class
 A runtime reflection/registration produces `MatrixParameter`/`VectorParameter` with only 3 fields (byteSize
-12) instead of 5 (16) in our env — matching Fable's "corrupted RTTI/static-init generation" mechanism and
-Kyty's init-ordering divergence note. On real PS5 the same build reads 16 (game ships), so our env induces
+12) instead of 5 (16) in our env — matching Fable's "corrupted RTTI/static-init generation" mechanism.
+On real PS5 the same build reads 16 (game ships), so our env induces
 the 12.
 
 ### Reusable tooling added (all in `exec_image_linux.cpp`, gated, non-destructive)
@@ -910,7 +911,7 @@ first-frame draw (SubmitDcb #2, the Unity textured-UI pair):
   the registered `AgcShader` header by its bound code address (`prosper_agc_shader_header_for_code`),
   reads the user-data SGPR block from the folded `sh` register file, decodes V#/T#/S# descriptors, and
   assigns bindings to the recompiler convention (cbuf→2, vertex buffer→3, textures→4+). Added
-  `decode_image_descriptor` (T#, Kyty Gen5 layout) + texture emission in `build_shader_resources`.
+  `decode_image_descriptor` (T#, captured Gen5 layout) + texture emission in `build_shader_resources`.
 - **Result: the PIXEL shader RECOMPILES to 737 dwords of valid SPIR-V** — `image_sample` and
   `s_buffer_load` resolve against the table.
 
@@ -932,11 +933,11 @@ offset, and (for the recompiler's `sreg_srt` provenance already present) emit re
 detiling (`tile_mode`≠0) is the following step. Everything up to here is committed + green (Linux 45/45,
 Windows 20/20); the live renderer fires the moment both stages recompile.
 
-### The EUD (Extended User Data) mechanism — the exact recipe for the VS unblock (RE'd via Kyty)
+### The EUD (Extended User Data) mechanism — the exact recipe for the VS unblock
 
-Kyty `Shader.cpp` `ShaderParseUsage` shows how descriptors resolve when they don't fit in the 16-dword
-user-SGPR block:
-- A descriptor sharp's `offset_dw` (Kyty `start_register`) selects where its V#/T# bytes live:
+Captured shader metadata, ISA, and the guest's own table accesses establish how descriptors resolve when
+they do not fit in the 16-dword user-SGPR block:
+- A descriptor sharp's `offset_dw` selects where its V#/T# bytes live:
   - `offset_dw < 16`  → **inline**: read from `user_sgpr[offset_dw + j]` (what we do today).
   - `offset_dw >= 16` → **extended**: read from `extended_buffer[offset_dw - 16 + j]`, where
     `extended_buffer` is a pointer into guest memory (the EUD).

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -13,7 +13,7 @@ derefs the null chain terminator).
 DOLL now boots fully and runs a **stable frame loop**. Two blockers cleared this session:
 
 1. **CRI Atom audio init crash (fixed).** DOLL's CRI Atom (ADX) middleware drives audio through
-   **libSceAudioOut2** (PS5-only; no Kyty/shadPS4 surface). The generic unimplemented stub returned
+   **libSceAudioOut2** (PS5-only; no exercised inherited-platform surface). The generic unimplemented stub returned
    0 with out-params untouched, so CRI read an UNINITIALIZED context work-memory size, malloc'd it,
    and memset the result — when the stack garbage was unallocatable the MAIN thread died in
    `libc.prx+0x10556` (`mov %rdx,(%rdi)` inside memset) through the CRI region — the intermittent
@@ -470,8 +470,8 @@ disassembly (all offsets eboot-relative):
      completions are record-polled; ring-4 (tracked async) events are consumed correctly. The
      real discriminator is likely the H896 cb↔eq binding; ring-id gating reproduces observed
      behavior (CONFIDENCE MED).
-   - `sceKernelGetEventData/Id/Filter/Fflags/UserData/Error` implemented (Kyty field-read
-     semantics) — the listener consumes events exclusively through GetEventData.
+   - `sceKernelGetEventData/Id/Filter/Fflags/UserData/Error` implemented from the event structure
+     contract and live listener accesses — the listener consumes events exclusively through GetEventData.
 
 **Result: the GlobalShaderMap loads, PreInit continues through online/PSN init (which was never
 the blocker), pak/precacher async reads flow (180+ served in one run), and the boot reaches the
@@ -666,11 +666,11 @@ builds its own recursion on the FreeBSD self-lock contract:
 `err = mutex_lock(obj); if (err) /* EDEADLK: already mine */ skip-acquire; depth++;` — and DOLL
 creates those mutexes with `pthread_mutexattr_settype(type=4)` (ADAPTIVE_NP, live-captured via
 PROSPER_MUTEXLOG). FreeBSD libthr's `mutex_self_lock` returns EDEADLK for ERRORCHECK **and**
-ADAPTIVE_NP (adaptive = errorcheck + a spin heuristic); only NORMAL hard-deadlocks. #183 (after
-Kyty) mapped 4 -> host NORMAL, which self-deadlocks on glibc. Fixes in hle_kernel.cpp: settype
+ADAPTIVE_NP (adaptive = errorcheck + a spin heuristic); only NORMAL hard-deadlocks. #183 mapped
+4 -> host NORMAL, which self-deadlocks on glibc. Fixes in hle_kernel.cpp: settype
 type 4 -> host ERRORCHECK; a fresh mutexattr defaults to ERRORCHECK (FreeBSD attr default — the
 #183 change only covered the no-attr init path); the static ADAPTIVE sentinel (1) also maps to
-ERRORCHECK. Kyty is weighted DOWN here per policy: no title it runs exercises adaptive self-lock.
+ERRORCHECK. Direct FreeBSD and live-title evidence controls this mapping; unexercised secondary behavior does not.
 
 **Measured result (ext4 fast path, 240-480 s runs):** the 90-read wall is GONE — 978 APR reads
 served, the guest's own tag counter advanced past 0x458 (112+ batches consumed through the
@@ -812,7 +812,7 @@ path). The game now runs 200+ flips / 470+ compute dispatches, deep into post-lo
    addr, `0fWWK5uG9rQ`=ReleaseMem-patch-addr. With them stubbed, every per-draw GPU fence targeted
    address 0. Implemented all three (each validates the packet header sub-op first; 0 refusals
    across a full run). Also implemented `k3GhuSNmBLU`=sceAgcDcbDispatchDirect(dcb,x,y,z,modifier)
-   as a new R_DISPATCH_DIRECT packet (guest wrapper eboot+0x220ede0; Kyty Gen4 DispatchDirect ABI)
+   as a new R_DISPATCH_DIRECT packet (guest wrapper eboot+0x220ede0 plus captured Gen4 ABI arguments)
    — DOLL's compute prologue issues ~470 of these.
 
 3. **The 34.6 GB OOM / RenderThread-timeout was a trophy success-with-garbage-out.**
@@ -1053,8 +1053,8 @@ polls.**
 ### SESSION 5 (2026-07-10, issue #232): the PlayGo/SaveData/Trophy2/Share service contracts are implemented and the save flow now completes end-to-end — but still 0 DrawIndex; the "0x5044740 gate" hypothesis is DISPROVEN
 
 Implemented the real contracts for the services DOLL's boot flow calls (all NID<->name pairs
-verified against the PS5 3.20 library stub tables in `../PS5-3.20_Libs`; cross-checked shadPS4 +
-Kyty where the API is PS4-inherited):
+verified against the PS5 3.20 library stub tables in `../PS5-3.20_Libs`; PS4-inherited behavior was
+cross-checked against public platform contracts and independent tests):
 
 - **scePlayGo** — `Initialize`/`Open`/`GetLocus`/`GetProgress`/`GetToDoList`/`GetChunkId`/`GetEta`/
   `GetInstallSpeed`/`GetLanguageMask`/`Close`/`Terminate`. Reports everything installed &
@@ -1201,7 +1201,7 @@ best candidate improves coherence only ~4% over row-major and, rendered, is **st
 top-left micro-tile is roughly coherent). Conclusion: unlike SW_4KB_S — which this codebase models well
 enough with a flat Morton (`sw4kb_morton`) — **SW_64KB_S/_R_X need the real GFX10 addrlib swizzle equation**
 (256 B micro-tile hierarchy + the "S"/"R_X" macro pattern; "_X" adds a pipe/bank XOR), not a bit-interleave.
-Kyty is **not** a reference here (it is GCN/PS4 tiling, per CLAUDE.md). This is a bounded but genuine
+Older GCN/PS4 tiling models are **not** references here because they target the wrong generation. This is a bounded but genuine
 graphics-RE task, tracked as **#288**; shipping a guessed detiler would violate correctness-first
 (it would produce different-but-still-wrong pixels).
 

--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -7,15 +7,15 @@ frame, logo, menu, or wrong scene. The graphics path is verified in layers, chea
 
 ## 1. Structural assertions (no GPU) — the bulk of correctness
 
-Each pipeline stage is a pure function tested with exact-value assertions against an authoritative
-reference. This catches most bugs deterministically and instantly:
+Each pipeline stage is a pure function tested with exact-value assertions against primary evidence or
+an independently generated oracle. This catches most bugs deterministically and instantly:
 
 | Stage | Test | Reference |
 |-------|------|-----------|
 | PM4 decode | `test_pm4_decode` | packets built by the real AGC Dcb functions |
-| CommandProcessor apply | `test_command_processor` | Kyty `cp_op_indirect_cx_regs` |
-| RenderState extract | `test_render_state` | Kyty `hw_ctx_*` register decodes |
-| RDNA2→Vulkan translate | `test_render_state` | Kyty `GraphicsRender.cpp` enum maps |
+| CommandProcessor apply | `test_command_processor` | captured packet streams and exact expected folds |
+| RenderState extract | `test_render_state` | AMD register definitions plus captured state |
+| RDNA2→Vulkan translate | `test_render_state` | Vulkan specification and reviewed translation tables |
 | RDNA2 decode + operands | `test_rdna2_decode` | **`llvm-mc -mcpu=gfx1030` encodings** |
 
 Using `llvm-mc` to assemble authoritative RDNA2 encodings (and `glslangValidator` for GLSL→SPIR-V)


### PR DESCRIPTION
## Goal

Make the repository's independent-implementation policy explicit and remove the two project-name patterns requested by the repository owner from maintained documentation.

## Scope

This is an exact two-name cleanup, not a ban on every external implementation name. Other third-party names remain where they carry technical context. Source code, build files, tests, and historical Git commits are intentionally outside this documentation-only sweep.

## Changes

- Replaces all 68 documentation mentions of the two requested project names with primary evidence or neutral evidence categories.
- States that external implementations are verification-only and that source, types, comments, prose, and tests must not be copied or ported.
- Rewrites the historical AGC implementation plan around live captures, guest disassembly, firmware symbol data, AMD documentation, and project-owned tests.
- Preserves concrete addresses, NIDs, captured behavior, investigation conclusions, and historical decisions elsewhere.
- Does not modify source code, build files, tests, or historical Git commits.

## Verification

- Repository-wide case-insensitive scan of Markdown, text, project charter, and agent-instruction documentation for both exact requested patterns: zero matches.
- git diff --check: passed.

## Risk

Documentation-only. The main review risk is accidental loss of technical context; the diff keeps the underlying behavioral claims while changing attribution and implementation guidance.