### PR TITLE
fix(service): preserve 64-bit diagnostic words

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -9,6 +9,7 @@
 #include "platform_ui.hpp"
 #include "video_backend.hpp"   // sceAvPlayer -> host hardware-decode backend (#705)
 #include "../host/posix_shim.hpp"   // Darwin process_vm_readv shim + asm portability
+#include <cinttypes>
 #include <cstdint>
 #include <cstring>
 #include <cstdio>
@@ -80,7 +81,7 @@ void svc_log(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2,
         words = (int)svc_copy_words(args[i], q, (size_t)words);
         if (!words) continue;
         fprintf(stderr, "[svc]   a%d ->", i);
-        for (int w = 0; w < words; w++) fprintf(stderr, " %016lx", (unsigned long)q[w]);
+        for (int w = 0; w < words; w++) fprintf(stderr, " %016" PRIx64, q[w]);
         fprintf(stderr, "\n");
     }
 }

--- a/prosper/tests/test_service_logging.cpp
+++ b/prosper/tests/test_service_logging.cpp
@@ -4,8 +4,10 @@
 #include <cstdio>
 #include <cstdlib>
 #include <atomic>
+#include <cstring>
 #include <thread>
 #ifdef _WIN32
+#include <io.h>
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -18,6 +20,54 @@
 namespace {
 bool call_open(prosper::HleFn open, void* pointer) {
     return open(1, 0xdcdfb7a0, reinterpret_cast<uintptr_t>(pointer), 1, 0x83, 0) == 0;
+}
+
+bool logs_full_word(prosper::HleFn open, void* pointer) {
+    FILE* capture = std::tmpfile();
+    if (!capture) return false;
+    if (std::fflush(stderr) != 0) {
+        std::fclose(capture);
+        return false;
+    }
+
+#ifdef _WIN32
+    const int stderr_fd = _fileno(stderr);
+    const int saved_stderr = _dup(stderr_fd);
+    const bool redirected = saved_stderr >= 0 && _dup2(_fileno(capture), stderr_fd) == 0;
+#else
+    const int stderr_fd = fileno(stderr);
+    const int saved_stderr = dup(stderr_fd);
+    const bool redirected = saved_stderr >= 0 && dup2(fileno(capture), stderr_fd) >= 0;
+#endif
+    if (!redirected) {
+        if (saved_stderr >= 0) {
+#ifdef _WIN32
+            _close(saved_stderr);
+#else
+            close(saved_stderr);
+#endif
+        }
+        std::fclose(capture);
+        return false;
+    }
+
+    const bool called = call_open(open, pointer);
+    const bool flushed = std::fflush(stderr) == 0;
+#ifdef _WIN32
+    const bool restored = _dup2(saved_stderr, stderr_fd) == 0;
+    _close(saved_stderr);
+#else
+    const bool restored = dup2(saved_stderr, stderr_fd) >= 0;
+    close(saved_stderr);
+#endif
+
+    char output[512]{};
+    std::rewind(capture);
+    const size_t bytes = std::fread(output, 1, sizeof(output) - 1, capture);
+    std::fclose(capture);
+    output[bytes] = '\0';
+    return called && flushed && restored &&
+           std::strstr(output, "[svc]   a2 -> 1122334455667788") != nullptr;
 }
 }
 
@@ -65,7 +115,7 @@ int main() {
     // The remaining literals came from a Blasphemous 2 call. Each address is pointer-shaped but
     // cannot safely be dereferenced for every requested word.
     bool ok = call_open(open, reserved) && call_open(open, protected_page) &&
-              call_open(open, guard_page) && call_open(open, boundary + page_size - 8);
+              call_open(open, guard_page) && logs_full_word(open, boundary + page_size - 8);
 
     // Exercise the review finding: the mapping can disappear concurrently with the snapshot.
     std::atomic<bool> run{true};


### PR DESCRIPTION
Fixes #821

## Failure

`svc_log` printed copied guest words with `%016lx` after converting them to `unsigned long`. That happens to be 64-bit on Linux, but Windows uses LLP64, where `unsigned long` is 32-bit. A copied diagnostic word such as `0x1122334455667788` therefore appeared as `0000000055667788` in native Windows logs.

This only affects diagnostic truthfulness when `PROSPER_SVCLOG=1`; service behavior, pointer-copy fault containment, and normal game execution are unchanged.

## Approach and invariants

- Print copied `uint64_t` words with the portable `PRIx64` format macro.
- Extend the existing fault-containment test to capture the actual `stderr` service-log output and require the exact full-width sentinel line.
- Restore `stderr` before continuing the existing concurrent map/unmap stress coverage.

The test exercises the real registered `sceImeKeyboardOpen` HLE path rather than a standalone formatter. It runs on both Linux and Windows; the pre-fix native Windows executable was observed to emit `[svc]   a2 -> 0000000055667788`.

## Risk and compatibility

Risk is limited to the text of opt-in service diagnostics. The format remains 16 lowercase hexadecimal digits with leading zeroes; only the lost upper 32 bits are restored on LLP64 hosts. No renderer/recompiler/present code changes, so the snapshot gate is not applicable.

## Author verification

- Native Windows/MinGW focused regression:
  `cmake --build prosper/build-windows-core --target test_service_logging -j 8`
  `ctest --test-dir prosper/build-windows-core -R '^service_logging_unmapped_args$' --output-on-failure`
  Result: 1/1 passed.
- Native Windows/MinGW full core:
  `cmake --build prosper/build-windows-core -j 8`
  `ctest --test-dir prosper/build-windows-core --output-on-failure`
  Result: 70/70 passed.
- Ubuntu 24.04 full core:
  `cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE`
  `cmake --build prosper/build-linux -j8`
  `ctest --test-dir prosper/build-linux --output-on-failure`
  Result: 79/79 passed.
