### PR TITLE
fix(service): preserve 64-bit diagnostic arguments

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -66,9 +66,9 @@ size_t svc_copy_words(uint64_t src, uint64_t* dst, size_t words) {
 void svc_log(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2,
              uint64_t a3, uint64_t a4, uint64_t a5, int dump_words = 8) {
     if (!svclog()) return;
-    fprintf(stderr, "[svc] %s(%#lx, %#lx, %#lx, %#lx, %#lx, %#lx)\n",
-            fn, (unsigned long)a0, (unsigned long)a1, (unsigned long)a2,
-            (unsigned long)a3, (unsigned long)a4, (unsigned long)a5);
+    fprintf(stderr, "[svc] %s(%#" PRIx64 ", %#" PRIx64 ", %#" PRIx64
+                    ", %#" PRIx64 ", %#" PRIx64 ", %#" PRIx64 ")\n",
+            fn, a0, a1, a2, a3, a4, a5);
     const uint64_t args[6] = { a0, a1, a2, a3, a4, a5 };
     for (int i = 0; i < 6; i++) {
         if (!svc_ptrish(args[i])) continue;

--- a/prosper/tests/test_service_logging.cpp
+++ b/prosper/tests/test_service_logging.cpp
@@ -22,7 +22,7 @@ bool call_open(prosper::HleFn open, void* pointer) {
     return open(1, 0xdcdfb7a0, reinterpret_cast<uintptr_t>(pointer), 1, 0x83, 0) == 0;
 }
 
-bool logs_full_word(prosper::HleFn open, void* pointer) {
+bool logs_full_values(prosper::HleFn open, void* pointer) {
     FILE* capture = std::tmpfile();
     if (!capture) return false;
     if (std::fflush(stderr) != 0) {
@@ -51,7 +51,9 @@ bool logs_full_word(prosper::HleFn open, void* pointer) {
         return false;
     }
 
-    const bool called = call_open(open, pointer);
+    const bool called =
+        open(1, 0xdcdfb7a0, reinterpret_cast<uintptr_t>(pointer), 1, 0x83,
+             0x1122334455667788ull) == 0;
     const bool flushed = std::fflush(stderr) == 0;
 #ifdef _WIN32
     const bool restored = _dup2(saved_stderr, stderr_fd) == 0;
@@ -66,8 +68,13 @@ bool logs_full_word(prosper::HleFn open, void* pointer) {
     const size_t bytes = std::fread(output, 1, sizeof(output) - 1, capture);
     std::fclose(capture);
     output[bytes] = '\0';
-    return called && flushed && restored &&
-           std::strstr(output, "[svc]   a2 -> 1122334455667788") != nullptr;
+    const bool full_argument =
+        std::strstr(output, ", 0x1122334455667788)") != nullptr;
+    const bool full_word =
+        std::strstr(output, "[svc]   a2 -> 1122334455667788") != nullptr;
+    if (!full_argument || !full_word)
+        std::fprintf(stderr, "captured service log:\n%s", output);
+    return called && flushed && restored && full_argument && full_word;
 }
 }
 
@@ -115,7 +122,7 @@ int main() {
     // The remaining literals came from a Blasphemous 2 call. Each address is pointer-shaped but
     // cannot safely be dereferenced for every requested word.
     bool ok = call_open(open, reserved) && call_open(open, protected_page) &&
-              call_open(open, guard_page) && logs_full_word(open, boundary + page_size - 8);
+              call_open(open, guard_page) && logs_full_values(open, boundary + page_size - 8);
 
     // Exercise the review finding: the mapping can disappear concurrently with the snapshot.
     std::atomic<bool> run{true};


### PR DESCRIPTION
Fixes #827

## Failure

The six direct `uint64_t` arguments in `svc_log` were printed with `%#lx` after narrowing each value to `unsigned long`. Native Windows uses LLP64, so a direct argument above `UINT32_MAX` lost its upper 32 bits.

A regression call with its ignored sixth argument set to `0x1122334455667788` reproduced this on merged `master`:

```text
[svc] sceImeKeyboardOpen(..., 0x55667788)
[svc]   a2 -> 1122334455667788
```

The copied guest word is already correct after PR #826, leaving the two parts of the same diagnostic inconsistent.

## Approach and invariants

- Format all six direct `uint64_t` arguments with the matching portable `PRIx64` macro and remove the narrowing casts.
- Preserve the existing alternate-form hexadecimal presentation, argument order, punctuation, lowercase digits, and zero behavior.
- Extend the real registered `sceImeKeyboardOpen` regression call to require both the full-width direct argument and full-width copied guest word in one captured log.
- Print the captured log when either assertion fails, while restoring `stderr` before the existing concurrent mapping stress continues.

Service return behavior, pointer-copy bounds/fault containment, and non-diagnostic execution are unchanged.

## Risk and compatibility

Risk is limited to restoring previously lost upper bits in opt-in `PROSPER_SVCLOG=1` text on LLP64 hosts. Linux output is unchanged for the same values. No renderer/recompiler/detile/executor/present code changes, so the snapshot gate is not applicable.

## Author verification

- Pre-fix native Windows focused regression: failed as expected, capturing `0x55667788` in the header and the full copied word.
- Post-fix native Windows focused regression:
  `cmake --build prosper/build-windows-core --target test_service_logging -j 8`
  `ctest --test-dir prosper/build-windows-core -R '^service_logging_unmapped_args$' --output-on-failure`
  Result: 1/1 passed.
- Native Windows/MinGW full core:
  `cmake --build prosper/build-windows-core -j 8`
  `ctest --test-dir prosper/build-windows-core --output-on-failure`
  Result: 70/70 passed.
- Ubuntu 24.04 full core:
  `cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE`
  `cmake --build prosper/build-linux -j8`
  `ctest --test-dir prosper/build-linux --output-on-failure`
  Result: 79/79 passed.
