### PR TITLE
fix(gpu): execute address-backed DMA_DATA copies

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -476,6 +476,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_timeline PRIVATE prosper_core)
   add_test(NAME gpu_timeline_roundtrip COMMAND test_gpu_timeline)
 
+  add_executable(test_gpu_timeline_capture_exit tests/test_gpu_timeline_capture_exit.cpp)
+  target_link_libraries(test_gpu_timeline_capture_exit PRIVATE prosper_core)
+  add_test(NAME gpu_timeline_capture_failure_exit COMMAND test_gpu_timeline_capture_exit)
+
   add_executable(test_gpu_dependency_graph tests/test_gpu_dependency_graph.cpp)
   target_link_libraries(test_gpu_dependency_graph PRIVATE prosper_core)
   add_test(NAME gpu_dependency_graph COMMAND test_gpu_dependency_graph)

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <set>
@@ -56,6 +57,27 @@ struct RttSurf {
 
 using RttCache = std::unordered_map<uint64_t, RttSurf>;
 
+struct PendingGuestGpuWrites {
+    std::mutex mutex;
+    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    bool overflowed = false;
+};
+
+PendingGuestGpuWrites& pending_guest_gpu_writes() {
+    static PendingGuestGpuWrites pending;
+    return pending;
+}
+
+void queue_guest_gpu_write(uint64_t addr, uint64_t size) {
+    auto& pending = pending_guest_gpu_writes();
+    std::lock_guard<std::mutex> lock(pending.mutex);
+    constexpr size_t kMaxPendingRanges = 65536;
+    if (pending.ranges.size() < kMaxPendingRanges)
+        pending.ranges.emplace_back(addr, size);
+    else
+        pending.overflowed = true;
+}
+
 void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t size) {
     if (!addr || !size) return;
     const uint64_t end = size > UINT64_MAX - addr ? UINT64_MAX : addr + size;
@@ -68,6 +90,38 @@ void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t siz
             ? UINT64_MAX : it->first + bytes;
         if (addr < target_end && it->first < end) it = cache.erase(it);
         else ++it;
+    }
+}
+
+void drain_guest_gpu_writes(RttCache& cache, bool invalidate_ds) {
+    auto& pending = pending_guest_gpu_writes();
+    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    bool overflowed = false;
+    {
+        std::lock_guard<std::mutex> lock(pending.mutex);
+        ranges.swap(pending.ranges);
+        overflowed = pending.overflowed;
+        pending.overflowed = false;
+    }
+    if (overflowed) {
+        for (auto& [key, target] : prosper::test::persistent_color_target_cache()) {
+            (void)key;
+            target.valid = false;
+        }
+        if (invalidate_ds)
+            for (auto& [key, image] : prosper::test::persistent_ds_cache()) {
+                (void)key;
+                image.depth_valid = false;
+                image.stencil_valid = false;
+            }
+        cache.clear();
+        return;
+    }
+    for (const auto& [addr, size] : ranges) {
+        if (invalidate_ds)
+            prosper::test::invalidate_persistent_ds_guest_write(addr, size);
+        prosper::test::invalidate_persistent_color_target_guest_write(addr, size);
+        invalidate_cpu_rtt_guest_write(cache, addr, size);
     }
 }
 
@@ -176,12 +230,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     const char* ds_invalidate = getenv("PROSPER_DS_GUEST_WRITE_INVALIDATE");
     const bool invalidate_ds = !ds_invalidate || strcmp(ds_invalidate, "0");
     prosper::gpu::set_guest_gpu_write_observer(
-        [invalidate_ds](uint64_t addr, uint64_t size) {
-            if (invalidate_ds)
-                prosper::test::invalidate_persistent_ds_guest_write(addr, size);
-            prosper::test::invalidate_persistent_color_target_guest_write(addr, size);
-            invalidate_cpu_rtt_guest_write(g_rtt, addr, size);
-        });
+        [](uint64_t addr, uint64_t size) { queue_guest_gpu_write(addr, size); });
     // Resource tables are built before the submit reaches this callback. Publish the renderer's
     // default mode now so unmapped render-target descriptors remain available for RTT injection.
     // Outside a registered renderer, resource decoding retains its strict unknown-format policy.
@@ -195,7 +244,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     static std::atomic<int> frame_no{0};
     if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
         getenv("PROSPER_GPU_REPLAY_EXPORT_RTT")) {
-        prosper::gpu::set_gpu_capture_rtt_seed_reader([](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {
+        prosper::gpu::set_gpu_capture_rtt_seed_reader([invalidate_ds](uint64_t addr, prosper::gpu::GpuCaptureRttSeed& seed) {
+            drain_guest_gpu_writes(g_rtt, invalidate_ds);
             auto it = g_rtt.find(addr); if (it == g_rtt.end()) return false;
             if (!it->second.rgba) return false;
             seed.guest_addr = addr; seed.width = it->second.w; seed.height = it->second.h;
@@ -203,7 +253,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             seed.rgba = *it->second.rgba; return true;
         });
         prosper::gpu::set_gpu_capture_rtt_seed_snapshot_reader(
-            [](std::vector<prosper::gpu::GpuCaptureRttSeed>& seeds, std::string&) {
+            [invalidate_ds](std::vector<prosper::gpu::GpuCaptureRttSeed>& seeds, std::string&) {
+                drain_guest_gpu_writes(g_rtt, invalidate_ds);
                 seeds.reserve(g_rtt.size());
                 for (const auto& [addr, surface] : g_rtt) {
                     if (!surface.rgba) continue;
@@ -218,9 +269,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     // The compute backend must not sample a surface whose CURRENT pixels live in this renderer's
     // RTT cache (raw guest memory is then empty/stale — the Dead Cells 642x362 lesson): publish the
     // exact-match identity and immutable CPU snapshot used by live compute (#590).
-    prosper::gpu::set_live_target_query([](uint64_t addr) { return g_rtt.count(addr) != 0; });
+    prosper::gpu::set_live_target_query([invalidate_ds](uint64_t addr) {
+        drain_guest_gpu_writes(g_rtt, invalidate_ds);
+        return g_rtt.count(addr) != 0;
+    });
     prosper::gpu::set_live_target_reader(
-        [](uint64_t addr, prosper::gpu::LiveTargetSnapshot& snapshot) {
+        [invalidate_ds](uint64_t addr, prosper::gpu::LiveTargetSnapshot& snapshot) {
+            drain_guest_gpu_writes(g_rtt, invalidate_ds);
             const auto it = g_rtt.find(addr);
             if (it == g_rtt.end() || !it->second.rgba || !it->second.w || !it->second.h)
                 return false;
@@ -239,9 +294,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             return true;
         });
     prosper::gpu::set_live_target_byte_range_reader(
-        [](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+        [invalidate_ds](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+            drain_guest_gpu_writes(g_rtt, invalidate_ds);
             if (!addr || !bytes) return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
-            for (const auto& [base, surface] : g_rtt) {
+            for (auto& [base, surface] : g_rtt) {
                 if (addr < base) continue;
                 if (!surface.w || !surface.h) {
                     if (addr == base) return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
@@ -254,6 +310,26 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 const uint64_t target_bytes = pixels * bpp;
                 const uint64_t offset = addr - base;
                 if (offset >= target_bytes) continue;
+                if ((!surface.rgba || surface.rgba->size() != target_bytes) &&
+                    surface.gpu_valid) {
+                    std::vector<uint8_t> materialized;
+                    std::string error;
+                    if (prosper::test::readback_persistent_color_target(
+                            base, surface.w, surface.h, format, materialized, error) &&
+                        materialized.size() == target_bytes) {
+                        surface.rgba = std::make_shared<const std::vector<uint8_t>>(
+                            std::move(materialized));
+                    } else {
+                        static std::atomic<int> warned{0};
+                        if (warned.fetch_add(1) < 24)
+                            std::fprintf(stderr,
+                                         "[rtt] ordered DMA target readback failed: base=0x%llx "
+                                         "extent=%ux%u error=%s\n",
+                                         static_cast<unsigned long long>(base), surface.w, surface.h,
+                                         error.c_str());
+                        return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
+                    }
+                }
                 if (!surface.rgba || surface.rgba->size() != target_bytes ||
                     bytes > target_bytes - offset)
                     return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
@@ -308,9 +384,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     if (live_gpu_targets)
         fprintf(stderr, "[render] persistent GPU color targets enabled (experimental)\n");
     prosper::gpu::set_submit_renderer(
-        [frame_dir, dump_bmps](const std::vector<prosper::gpu::DrawItem>& items,
+        [frame_dir, dump_bmps, invalidate_ds](const std::vector<prosper::gpu::DrawItem>& items,
                                uint32_t w, uint32_t h) -> prosper::gpu::RenderedFrame {
             using RC = prosper::gpu::ResourceClass;
+            drain_guest_gpu_writes(g_rtt, invalidate_ds);
             const prosper::gpu::LiveRenderPhase phase = prosper::gpu::live_render_phase();
             // PROSPER_RENDER_FIRST=<N>: skip the slow (~400x) Vulkan render for the first N GPU submits, so
             // the game reaches a LATE scene (e.g. the level1 cutscene, which only starts submitting after
@@ -1939,12 +2016,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             inspect(items[later].prt.get());
                         }
                     }
-                    // A later submit may perform an ordered DMA read of this target, so there is no
-                    // safe point here to discard its authoritative CPU mirror. Keep the candidate
-                    // calculation in place for an eventual on-demand persistent-target readback path.
-                    constexpr bool allow_gpu_only_target_cache = false;
-                    const bool defer_readback = allow_gpu_only_target_cache && live_gpu_targets &&
-                        vo_n > 0 && base && !is_vo &&
+                    // Defer only a proven graphics-to-graphics intermediate. A same-submit DMA asks
+                    // its producer span for readback; a later-submit DMA materializes the persistent
+                    // image synchronously through the byte-range reader above.
+                    const bool defer_readback = live_gpu_targets && vo_n > 0 && base && !is_vo &&
                         base != front_va && sampled_exact_later && !feedback_later &&
                         !phase.authoritative_readback;
                     prosper::test::BackendColorTarget backend_target{

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -238,6 +238,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             snapshot.pixels = it->second.rgba;
             return true;
         });
+    prosper::gpu::set_live_target_byte_range_reader(
+        [](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+            if (!addr || !bytes) return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
+            for (const auto& [base, surface] : g_rtt) {
+                if (addr < base) continue;
+                if (!surface.w || !surface.h) {
+                    if (addr == base) return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
+                    continue;
+                }
+                const VkFormat format = prosper::test::backend_color_format(surface.format);
+                const uint64_t bpp = prosper::test::backend_color_bytes_per_pixel(format);
+                const uint64_t pixels = static_cast<uint64_t>(surface.w) * surface.h;
+                if (!bpp || pixels > UINT64_MAX / bpp) continue;
+                const uint64_t target_bytes = pixels * bpp;
+                const uint64_t offset = addr - base;
+                if (offset >= target_bytes) continue;
+                if (!surface.rgba || surface.rgba->size() != target_bytes ||
+                    bytes > target_bytes - offset)
+                    return prosper::gpu::LiveTargetByteReadResult::InvalidRange;
+                output.assign(surface.rgba->begin() + static_cast<size_t>(offset),
+                              surface.rgba->begin() + static_cast<size_t>(offset + bytes));
+                return prosper::gpu::LiveTargetByteReadResult::Success;
+            }
+            return prosper::gpu::LiveTargetByteReadResult::NotFound;
+        });
     if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
         getenv("PROSPER_GPU_REPLAY_EXPORT_DS"))
         prosper::gpu::set_gpu_capture_ds_seed_snapshot_reader(
@@ -1914,10 +1939,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             inspect(items[later].prt.get());
                         }
                     }
-                    // Defer only a proven graphics-to-graphics intermediate. Scanout, fallback-present,
-                    // size conversion, and same-image feedback retain authoritative CPU pixels.
-                    const bool defer_readback = live_gpu_targets && vo_n > 0 && base && !is_vo &&
-                        base != front_va && sampled_exact_later && !feedback_later;
+                    // A later submit may perform an ordered DMA read of this target, so there is no
+                    // safe point here to discard its authoritative CPU mirror. Keep the candidate
+                    // calculation in place for an eventual on-demand persistent-target readback path.
+                    constexpr bool allow_gpu_only_target_cache = false;
+                    const bool defer_readback = allow_gpu_only_target_cache && live_gpu_targets &&
+                        vo_n > 0 && base && !is_vo &&
+                        base != front_va && sampled_exact_later && !feedback_later &&
+                        !phase.authoritative_readback;
                     prosper::test::BackendColorTarget backend_target{
                         base, seed_rtt, !defer_readback, pass_format};
                     const bool color1_extent_matches = base1 && !render_pass.empty() &&

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1277,6 +1277,15 @@ void apply_deferred_effect(const Pm4Command& c) {
 }
 } // namespace
 
+void execute_ordered_memory_effect(const GpuState::MemoryEffect& effect) {
+    apply_deferred_effect(effect.cmd);
+    uint64_t addr = 0, bytes = 0;
+    effect_span(effect.cmd, &addr, &bytes);
+    // Invalidating after a guarded no-op is conservative; retaining a stale renderer-owned image
+    // after a real write would make a later consumer observe the wrong storage version.
+    if (addr && bytes) notify_guest_gpu_write(addr, bytes);
+}
+
 bool last_fold_deferred() { return g_fold_deferring; }
 bool deferred_pending()   { return !g_deferred.empty(); }
 
@@ -1510,26 +1519,45 @@ void GpuState::apply(const Pm4Command& c) {
             // what let the game free live label memory. Otherwise it goes through the pipe-drain
             // queue: completion becomes guest-visible only after the submit returns.
             if (defer_gate(c)) { defer_push(c); break; }
+            if (!dma_copies.empty()) {
+                ordered_memory_effects.emplace_back(c, command_order);
+                break;
+            }
             if (eop_write_sync()) honor_eop_write(c); else pend_enqueue(c);
             break;
         case K::WriteData:
             if (defer_gate(c)) { defer_push(c); break; }
+            if (!dma_copies.empty()) {
+                ordered_memory_effects.emplace_back(c, command_order);
+                break;
+            }
             if (eop_write_sync()) honor_write_data(c); else pend_enqueue(c);
             break;
         case K::EventWrite:
             if (defer_gate(c)) { defer_push(c); break; }
+            if (!dma_copies.empty()) {
+                ordered_memory_effects.emplace_back(c, command_order);
+                break;
+            }
             if (eop_write_sync()) honor_event_write(c); else pend_enqueue(c);
             break;
         case K::DmaData:
             // Address-backed copies are ordinary in-stream producers: retain them beside draws and
             // dispatches so the ordered executor exposes old bytes to earlier consumers and copied
             // bytes to later consumers (#189). Immediate fills keep their established completion-
-            // FIFO behavior (#312): their observed uses are label init and command-chunk zeroing.
+            // FIFO behavior until a general copy appears; its suffix joins the ordered timeline.
             if (defer_gate(c)) { defer_push(c); break; }
             if (c.dd_src > UINT32_MAX) {
                 if (!c.dd_valid) { report_invalid_dma_data(c); break; }
+                // Everything queued before the first general copy is its ordered prefix. Land that
+                // prefix now; subsequent effects are retained below and cannot overtake the copy.
+                if (dma_copies.empty()) prosper_gpu_drain_completion_writes();
                 dma_copies.push_back({c.dd_dst, c.dd_src, c.dd_bytes, c.dd_sels,
                                       command_order, pkt_addr(c)});
+                break;
+            }
+            if (!dma_copies.empty()) {
+                ordered_memory_effects.emplace_back(c, command_order);
                 break;
             }
             if (eop_write_sync()) honor_dma_data(c); else pend_enqueue(c);

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -757,7 +757,7 @@ static void honor_event_write(const Pm4Command& c) {
 // CONFIDENCE: HIGH on immediate fill and mapped address-copy behavior; MED on the large-fill form.
 enum class DmaDataForm { Invalid, Immediate, Copy };
 
-static DmaDataForm dma_data_form(const Pm4Command& c) {
+static DmaDataForm dma_data_form(const Pm4Command& c, bool source_materialized = false) {
     constexpr uint32_t kMaxImmediateBytes = 0x1000000;   // existing 16 MiB fill safety bound
     constexpr uint32_t kMaxCopyBytes = 0x10000000;      // HLE builder's 256 MiB API bound
     if (!c.dd_valid || !c.dd_bytes || c.dd_bytes > kMaxCopyBytes || c.dd_dst < 0x10000)
@@ -772,7 +772,8 @@ static DmaDataForm dma_data_form(const Pm4Command& c) {
                    ? DmaDataForm::Immediate
                    : DmaDataForm::Invalid;
     }
-    return guest_readable(c.dd_src, c.dd_bytes) && guest_writable(c.dd_dst, c.dd_bytes)
+    return (source_materialized || guest_readable(c.dd_src, c.dd_bytes)) &&
+                   guest_writable(c.dd_dst, c.dd_bytes)
                ? DmaDataForm::Copy
                : DmaDataForm::Invalid;
 }
@@ -787,10 +788,11 @@ static void report_invalid_dma_data(const Pm4Command& c) {
                 (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes, c.dd_sels);
 }
 
-static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 0) {
+static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 0,
+                           const uint8_t* authoritative_source = nullptr) {
     if (eop_writes_disabled() || !c.dd_valid) return;
     const uint64_t packet_addr = retained_packet_addr ? retained_packet_addr : pkt_addr(c);
-    const DmaDataForm form = dma_data_form(c);
+    const DmaDataForm form = dma_data_form(c, authoritative_source != nullptr);
     if (form == DmaDataForm::Invalid) {
         report_invalid_dma_data(c);
         return;
@@ -833,7 +835,9 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
     } else {
         // memmove is byte-for-byte memcpy behavior for the normal non-overlapping GPU-buffer case,
         // while remaining deterministic if an unusual packet overlaps its endpoints.
-        memmove(dst, (const void*)(uintptr_t)c.dd_src, c.dd_bytes);
+        memmove(dst, authoritative_source ? authoritative_source
+                                          : (const uint8_t*)(uintptr_t)c.dd_src,
+                c.dd_bytes);
         notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
         if (getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc]   DmaData copy [0x%llx] <- [0x%llx] (%u bytes)\n",
@@ -846,7 +850,8 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
     wake_on_label(c.dd_dst);
 }
 
-void execute_ordered_dma_copy(const GpuState::DmaCopy& copy) {
+void execute_ordered_dma_copy(const GpuState::DmaCopy& copy,
+                              const uint8_t* authoritative_source) {
     Pm4Command c{};
     c.kind = Pm4Command::Kind::DmaData;
     c.dd_dst = copy.dst;
@@ -855,7 +860,7 @@ void execute_ordered_dma_copy(const GpuState::DmaCopy& copy) {
     c.dd_sels = copy.sels;
     c.dd_valid = true;
     c.stream_order = copy.command_order;
-    honor_dma_data(c, copy.packet_addr);
+    honor_dma_data(c, copy.packet_addr, authoritative_source);
 }
 
 // Honor a WRITE_DATA packet: copy the inline dwords to the destination address (same synchronous timing).

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -33,6 +33,9 @@ namespace prosper::gpu {
 // Readability probe (gpu_executor.cpp, declared in gpu_execute.hpp): page-granular check that a
 // guest range is mapped, so the Jump fold below never walks an unmapped segment address.
 bool guest_readable(uint64_t addr, uint32_t bytes);
+bool guest_writable(uint64_t addr, uint32_t bytes);
+// Guest GPU writes invalidate renderer-owned copies of overlapping resources.
+void notify_guest_gpu_write(uint64_t addr, uint64_t size);
 
 // Wake any thread blocked in sync_on_address (a futex) on `addr`. A GPU completion label write only
 // changes memory; a futex waiter does NOT wake on a value change — it needs an explicit FUTEX_WAKE. The
@@ -744,68 +747,98 @@ static void honor_event_write(const Pm4Command& c) {
 // completion leg is ReleaseMem(label <- 1). We previously DROPPED every DMA_DATA packet, so the
 // LIFO-recycled label kept the previous generation's 1 and the guest's consumption poll freed the
 // label while fences to it were still in flight (full evidence chain: hle_agc agc_dcb_dma_data).
-// Execution is deliberately GATED to the immediate-fill form (srcOrImm is a 32-bit value, PM4
-// CP-DMA src_sel=DATA semantics: the value is replicated across the destination). DOLL uses two
-// instances of it: the 4-byte per-segment label init above, and 64 KiB zero-fills of freshly
-// allocated 64 KiB-aligned command-stream CHUNKS (whose boundary headers hold the label pointers
-// the consumed-marker emitter reads — a recycled chunk with a stale header is the same stomp).
-// General CP-DMA copies (real src addresses / GDS) stay unexecuted with a bounded log, as before.
-// CONFIDENCE: HIGH on the init form (three-callsite ABI + live page-watch protocol capture);
-// MED on the large-fill form (same selectors + src=0 + fresh-buffer destinations).
-static void honor_dma_data(const Pm4Command& c) {
+// DOLL uses two immediate-fill instances: the 4-byte per-segment label init above, and 64 KiB
+// zero-fills of freshly allocated 64 KiB-aligned command-stream chunks. Issue #189 completes the
+// address-backed sibling: a source above the 32-bit immediate domain is copied only when the whole
+// source and destination spans are mapped. Raw selector arguments do not distinguish the forms:
+// the title's captured immediate-zero call passes 3/3, values which overlap the memory/L2 selector
+// vocabulary. Source mappedness plus the established 32-bit immediate ABI is the safe discriminator;
+// GDS offsets and malformed/unmapped endpoints remain fail-closed.
+// CONFIDENCE: HIGH on immediate fill and mapped address-copy behavior; MED on the large-fill form.
+enum class DmaDataForm { Invalid, Immediate, Copy };
+
+static DmaDataForm dma_data_form(const Pm4Command& c) {
+    constexpr uint32_t kMaxImmediateBytes = 0x1000000;   // existing 16 MiB fill safety bound
+    constexpr uint32_t kMaxCopyBytes = 0x10000000;      // HLE builder's 256 MiB API bound
+    if (!c.dd_valid || !c.dd_bytes || c.dd_bytes > kMaxCopyBytes || c.dd_dst < 0x10000)
+        return DmaDataForm::Invalid;
+    // Preserve the established ABI discriminator: every <=32-bit source is immediate data. Guest
+    // image/heap addresses in prosper are 64-bit, so address copies occupy the other domain.
+    if (c.dd_src <= UINT32_MAX) {
+        // The immediate path peeks one qword for the consumed-marker safety journal.
+        const uint32_t probe_bytes = c.dd_bytes < 8 ? 8 : c.dd_bytes;
+        return c.dd_bytes <= kMaxImmediateBytes && !(c.dd_dst & 3) &&
+                       guest_readable(c.dd_dst, probe_bytes)
+                   ? DmaDataForm::Immediate
+                   : DmaDataForm::Invalid;
+    }
+    return guest_readable(c.dd_src, c.dd_bytes) && guest_writable(c.dd_dst, c.dd_bytes)
+               ? DmaDataForm::Copy
+               : DmaDataForm::Invalid;
+}
+
+static void report_invalid_dma_data(const Pm4Command& c) {
+    // A skipped immediate init leaves the label pointer-valued. Address-copy failures have no
+    // consumed-marker protocol leg and must not alter those lifecycle counters.
+    if (c.dd_src <= UINT32_MAX) label_hist_dma_skip(c.dd_dst);
+    static std::atomic<int> n{0};
+    if (n.fetch_add(1) < 24)
+        fprintf(stderr, "[agc] DMA_DATA not executed (invalid/unmapped form): dst=0x%llx src=0x%llx bytes=%u sels=0x%x\n",
+                (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes, c.dd_sels);
+}
+
+static void honor_dma_data(const Pm4Command& c, bool notify_renderer = true) {
     if (eop_writes_disabled() || !c.dd_valid) return;
-    constexpr uint32_t kMaxFill = 0x1000000;   // 16 MiB — far past any observed fill
-    // dst >= 0x10000: a small dst is a GDS offset (unmodeled), and the PROSPER_NULL_PAGE
-    // read-only zero page would otherwise pass guest_readable() and SEGV the memset.
-    bool imm_form = c.dd_bytes >= 1 && c.dd_bytes <= kMaxFill &&
-                    c.dd_dst >= 0x10000 && !(c.dd_dst & 3) && c.dd_src <= 0xffffffffull;
-    if (!imm_form || !guest_readable(c.dd_dst, c.dd_bytes)) {
-        // Not the immediate-fill form we model (or unmapped dst) — log so the gap stays visible.
-        label_hist_dma_skip(c.dd_dst);   // #312: a skipped init leaves the label pointer-valued
-        static std::atomic<int> n{0};
-        if (n.fetch_add(1) < 24)
-            fprintf(stderr, "[agc] DMA_DATA not executed (unmodeled form): dst=0x%llx src=0x%llx bytes=%u sels=0x%x\n",
-                    (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes, c.dd_sels);
+    const DmaDataForm form = dma_data_form(c);
+    if (form == DmaDataForm::Invalid) {
+        report_invalid_dma_data(c);
         return;
     }
-    uint32_t v32 = (uint32_t)c.dd_src;
     uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;
-    uint64_t pre_dma = peek_qword(c.dd_dst);   // #312: pre-content for generation/membership checks
-    // The exact consumed-marker initializer is a 4-byte immediate zero. Test allocator membership
-    // BEFORE touching it: memset(0) would erase a free node's NextFreeBlock and make the later fence
-    // indistinguishable from a live initialized label (the session-11 residual).
-    if (mb3_freelist_guard() && c.dd_bytes == 4 && v32 == 0 &&
-        label_is_consumed_marker(c.dd_dst)) {
-        uint64_t build_pre = 0;
-        bool generation_changed = dma_build_pre_changed(c, pre_dma, &build_pre);
-        if (generation_changed) {
-            // Pair a debt with the skipped init so its following ReleaseMem cannot overwrite the
-            // new owner either. This is the allocated/reused sibling of a free-membership hit.
-            label_hist_dma_free(c.dd_dst, 0);
-            stale_dma_change_report(c.dd_dst, build_pre, pre_dma, pkt_addr(c));
-            return;
+    if (form == DmaDataForm::Immediate) {
+        const uint32_t v32 = (uint32_t)c.dd_src;
+        uint64_t pre_dma = peek_qword(c.dd_dst);   // #312: generation/membership pre-content
+        // The exact consumed-marker initializer is a 4-byte immediate zero. Test allocator
+        // membership BEFORE touching it: memset(0) would erase a free node's NextFreeBlock.
+        if (mb3_freelist_guard() && c.dd_bytes == 4 && v32 == 0 &&
+            label_is_consumed_marker(c.dd_dst)) {
+            uint64_t build_pre = 0;
+            bool generation_changed = dma_build_pre_changed(c, pre_dma, &build_pre);
+            if (generation_changed) {
+                label_hist_dma_free(c.dd_dst, 0);
+                stale_dma_change_report(c.dd_dst, build_pre, pre_dma, pkt_addr(c));
+                return;
+            }
+            Mb3FreelistMatch match{};
+            if (mb3_freelist_contains_stable(c.dd_dst, &match)) {
+                label_hist_dma_free(c.dd_dst, match.pool_base);
+                mb3_freelist_report("DMA", c.dd_dst, pre_dma, &match, false);
+                return;
+            }
         }
-        Mb3FreelistMatch match{};
-        if (mb3_freelist_contains_stable(c.dd_dst, &match)) {
-            label_hist_dma_free(c.dd_dst, match.pool_base);
-            mb3_freelist_report("DMA", c.dd_dst, pre_dma, &match, false);
-            return;
+        forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, pkt_addr(c));
+        if (v32 == 0) {
+            memset(dst, 0, c.dd_bytes);
+        } else {
+            uint32_t i = 0;
+            for (; i + 4 <= c.dd_bytes; i += 4) memcpy(dst + i, &v32, 4);
+            if (i < c.dd_bytes) memcpy(dst + i, &v32, c.dd_bytes - i);
         }
-    }
-    forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, pkt_addr(c));   // #312 session-10 tripwire (log-only)
-    if (v32 == 0) {
-        memset(dst, 0, c.dd_bytes);
+        poolshift_check("DMA", c.dd_dst, c.dd_bytes, c.dd_src, pkt_addr(c));
+        if (c.dd_bytes <= 8) label_hist_dma_exec(c.dd_dst, pre_dma);
+        if (getenv("PROSPER_GFXLOG"))
+            fprintf(stderr, "[agc]   DmaData fill [0x%llx] := 0x%x (%u bytes)\n",
+                    (unsigned long long)c.dd_dst, v32, c.dd_bytes);
     } else {
-        uint32_t i = 0;
-        for (; i + 4 <= c.dd_bytes; i += 4) memcpy(dst + i, &v32, 4);
-        if (i < c.dd_bytes) memcpy(dst + i, &v32, c.dd_bytes - i);
+        // memmove is byte-for-byte memcpy behavior for the normal non-overlapping GPU-buffer case,
+        // while remaining deterministic if an unusual packet overlaps its endpoints.
+        memmove(dst, (const void*)(uintptr_t)c.dd_src, c.dd_bytes);
+        if (notify_renderer) notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
+        if (getenv("PROSPER_GFXLOG"))
+            fprintf(stderr, "[agc]   DmaData copy [0x%llx] <- [0x%llx] (%u bytes)\n",
+                    (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes);
     }
     ring_record(c.dd_dst, c.dd_src, (uint8_t)(c.dd_bytes > 255 ? 255 : c.dd_bytes), 4, pkt_addr(c));
-    poolshift_check("DMA", c.dd_dst, c.dd_bytes, c.dd_src, pkt_addr(c));
-    if (c.dd_bytes <= 8) label_hist_dma_exec(c.dd_dst, pre_dma);   // #312 protocol history
-    if (getenv("PROSPER_GFXLOG"))
-        fprintf(stderr, "[agc]   DmaData [0x%llx] := 0x%x (%u bytes)\n",
-                (unsigned long long)c.dd_dst, v32, c.dd_bytes);
     if (writer_provenance_enabled() && c.dd_bytes >= 256)
         record_guest_write(GuestWriterKind::DmaData, c.dd_dst, c.dd_bytes,
                            0, 0, c.stream_order, pkt_addr(c));
@@ -881,6 +914,7 @@ bool eop_write_sync() {
 struct PendWrite {
     Pm4Command cmd;
     std::vector<uint32_t> wd_copy;     // owns a WriteData payload (cmd.wd_data repointed here)
+    bool dma_observer_handled = false; // address-copy invalidation ran safely on the submit thread
 };
 // IMMORTAL (leaked) worker state — same pattern as the EOP-event worker (hle_kernel_time.cpp):
 // the worker is detached and outlives main; static destructors must never run for it.
@@ -893,7 +927,7 @@ struct PendQueue {
 };
 PendQueue& pend_q() { static PendQueue* p = new PendQueue; return *p; }
 void apply_effect(const Pm4Command& c);   // fwd (defined with the WAIT_DEFER machinery below)
-void apply_deferred_effect(const Pm4Command& c);   // fwd: apply_effect + a guest_readable guard (#449)
+void apply_deferred_effect(const Pm4Command& c, bool notify_dma = true); // guarded apply (#449)
 // Drain returns only when every pending write has LANDED, and writes land STRICTLY IN QUEUE ORDER.
 //
 // #312 ROOT CAUSE (2026-07-10, label-event-ring attribution): the previous loop popped the NEXT
@@ -927,7 +961,7 @@ void pend_drain_locked(PendQueue& p, std::unique_lock<std::mutex>& lk) {
         // the label page (MallocBinned3, #312). apply_deferred_effect probes guest_readable before
         // the raw memcpy — without it an unmapped label SIGSEGVs here, exactly the case the deferred-
         // stream path already survives (this pend path releases asynchronously too, so it needs it).
-        apply_deferred_effect(w.cmd);
+        apply_deferred_effect(w.cmd, !w.dma_observer_handled);
         lk.lock();
         p.inflight--;
         p.cv.notify_all();               // wake both drain waiters and the pend worker
@@ -951,6 +985,21 @@ void pend_enqueue(const Pm4Command& c) {
     if (c.kind == Pm4Command::Kind::WriteData && c.wd_data && c.wd_num) {
         w.wd_copy.assign(c.wd_data, c.wd_data + c.wd_num);   // cb memory may be recycled before drain
         w.cmd.wd_data = w.wd_copy.data();
+    }
+    if (!eop_writes_disabled() && c.kind == Pm4Command::Kind::DmaData &&
+        c.dd_src > UINT32_MAX) {
+        // The live renderer's cache invalidation callback mutates submit-owned caches and is not
+        // worker-thread safe. Validate and notify address copies now, while the submit mutex is
+        // held; the queued memmove still lands in FIFO order before rendering. An invalid span is
+        // frozen invalid so an unrelated mapping appearing during the 1 ms drain window cannot turn
+        // into an unreported write on the worker.
+        w.dma_observer_handled = true;
+        if (dma_data_form(c) == DmaDataForm::Copy)
+            notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
+        else {
+            report_invalid_dma_data(c);
+            w.cmd.dd_valid = false;
+        }
     }
     {
         std::lock_guard<std::mutex> lk(p.mx);
@@ -1212,7 +1261,7 @@ uint64_t effect_target(const Pm4Command& c, uint32_t* bytes) {
         default: *bytes = 0; return 0;
     }
 }
-void apply_deferred_effect(const Pm4Command& c) {
+void apply_deferred_effect(const Pm4Command& c, bool notify_dma) {
     uint32_t bytes = 0;
     uint64_t t = effect_target(c, &bytes);
     if (t && bytes && !guest_readable(t, bytes)) {
@@ -1222,7 +1271,10 @@ void apply_deferred_effect(const Pm4Command& c) {
                     (unsigned)c.kind, (unsigned long long)t, bytes);
         return;
     }
-    apply_effect(c);
+    if (c.kind == Pm4Command::Kind::DmaData)
+        honor_dma_data(c, notify_dma);
+    else
+        apply_effect(c);
 }
 } // namespace
 

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1138,9 +1138,18 @@ struct DeferItem {
     std::vector<uint32_t> wd_copy;     // owns a WriteData payload (cmd.wd_data repointed into this)
     uint64_t first_blocked_ms = 0;     // barrier only: when it was first found unsatisfied
 };
-struct DeferredStream { std::vector<DeferItem> items; size_t next = 0; };
+struct DeferredStream {
+    std::vector<DeferItem> items;
+    size_t next = 0;
+    // A retained address DMA cannot execute through this legacy queue. Preserve effects before the
+    // rejected copy, but discard every same-stream completion effect appended after it so stale work
+    // cannot later signal success when the wait releases.
+    size_t discard_from = static_cast<size_t>(-1);
+    bool suppress_completion = false;
+};
 std::vector<DeferredStream> g_deferred;   // paused queue tails; guarded by the caller's submit mutex
 bool     g_fold_deferring = false;        // current fold hit an unsatisfied wait
+bool     g_fold_discard_deferred_suffix = false;
 uint64_t g_defer_streams = 0, g_defer_timeouts = 0;
 size_t   g_defer_items = 0;               // total queued items across streams (memory guard)
 // 1000 ms default. The timeout is the CORRUPTION knob, not a perf knob: every timeout is a
@@ -1229,6 +1238,10 @@ bool g_fold_stream_open = false;   // current top-level fold already opened its 
 void defer_push(const Pm4Command& c) {
     if (!g_fold_stream_open) {     // one deferred stream per fold that defers anything
         g_deferred.emplace_back();
+        if (g_fold_discard_deferred_suffix) {
+            g_deferred.back().discard_from = 0;
+            g_deferred.back().suppress_completion = true;
+        }
         g_fold_stream_open = true;
         g_defer_streams++;
     }
@@ -1301,7 +1314,8 @@ bool deferred_pending()   { return !g_deferred.empty(); }
 // CONFIDENCE: HIGH on the hardware contract (ring-ordered interrupt), MED that pulse-on-full-
 // drain (vs per-stream) is the right granularity — it only errs later, the safe direction.
 namespace { uint64_t g_owed_pulses = 0; }
-void submit_completion_pulse() {
+void submit_completion_pulse(bool submit_rejected) {
+    if (submit_rejected) return;
     if (!g_deferred.empty()) { g_owed_pulses++; return; }
     prosper_eq_trigger_eop();
 }
@@ -1319,12 +1333,16 @@ int flush_deferred_streams() {
     // applied here directly. Drain first so a released tail never overtakes its own head — and so
     // a producer fence still sitting in the pend queue is visible to the barrier checks below.
     prosper_gpu_drain_completion_writes();
-    int completed = 0;
+    int completed = 0, signalable_completed = 0;
     for (size_t si = 0; si < g_deferred.size(); ) {
         DeferredStream& s = g_deferred[si];
         bool blocked = false;
         bool force = g_deferred.size() > kDeferMaxStreams || g_defer_items > kDeferMaxItems;
         while (s.next < s.items.size()) {
+            if (s.next >= s.discard_from) {
+                s.next = s.items.size();
+                break;
+            }
             DeferItem& it = s.items[s.next];
             if (it.cmd.kind == Pm4Command::Kind::WaitRegMem) {
                 // The label page can be unmapped by the time we re-check (freed mid-defer):
@@ -1368,6 +1386,7 @@ int flush_deferred_streams() {
         }
         if (blocked) break;   // strict FIFO: the front barrier holds the whole gated tail
         g_defer_items -= s.items.size() < g_defer_items ? s.items.size() : g_defer_items;
+        signalable_completed += !s.suppress_completion;
         g_deferred.erase(g_deferred.begin() + si);
         completed++;
     }
@@ -1383,7 +1402,7 @@ int flush_deferred_streams() {
         // its label still gated (DOLL's "GameThread timed out waiting for RenderThread" wedge).
         uint64_t owed = g_owed_pulses;
         g_owed_pulses = 0;
-        if (!owed && completed > 0) owed = 1;   // deferral began before any pulse was owed
+        if (!owed && signalable_completed > 0) owed = 1; // valid deferral began before pulse was owed
         while (owed--) prosper_eq_trigger_eop();
     }
     return completed;
@@ -1562,6 +1581,12 @@ void GpuState::apply(const Pm4Command& c) {
                     dma_copies.push_back({c.dd_dst, c.dd_src, c.dd_bytes, c.dd_sels,
                                           command_order, pkt_addr(c)});
                     dma_execution_rejected = true;
+                    g_fold_discard_deferred_suffix = true;
+                    if (g_fold_stream_open && !g_deferred.empty()) {
+                        DeferredStream& stream = g_deferred.back();
+                        stream.discard_from = std::min(stream.discard_from, stream.items.size());
+                        stream.suppress_completion = true;
+                    }
                     static std::atomic<int> warned{0};
                     if (warned.fetch_add(1) < 24)
                         fprintf(stderr,
@@ -1752,6 +1777,7 @@ size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
     // of its labels).
     if (st.jump_depth == 0) {
         g_fold_deferring = false; g_fold_stream_open = false;
+        g_fold_discard_deferred_suffix = false;
         g_fold_seq.fetch_add(1, std::memory_order_relaxed);   // #312 label-history fold id
     }
     std::vector<Pm4Command> ops;

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -787,8 +787,9 @@ static void report_invalid_dma_data(const Pm4Command& c) {
                 (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes, c.dd_sels);
 }
 
-static void honor_dma_data(const Pm4Command& c, bool notify_renderer = true) {
+static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 0) {
     if (eop_writes_disabled() || !c.dd_valid) return;
+    const uint64_t packet_addr = retained_packet_addr ? retained_packet_addr : pkt_addr(c);
     const DmaDataForm form = dma_data_form(c);
     if (form == DmaDataForm::Invalid) {
         report_invalid_dma_data(c);
@@ -806,7 +807,7 @@ static void honor_dma_data(const Pm4Command& c, bool notify_renderer = true) {
             bool generation_changed = dma_build_pre_changed(c, pre_dma, &build_pre);
             if (generation_changed) {
                 label_hist_dma_free(c.dd_dst, 0);
-                stale_dma_change_report(c.dd_dst, build_pre, pre_dma, pkt_addr(c));
+                stale_dma_change_report(c.dd_dst, build_pre, pre_dma, packet_addr);
                 return;
             }
             Mb3FreelistMatch match{};
@@ -816,7 +817,7 @@ static void honor_dma_data(const Pm4Command& c, bool notify_renderer = true) {
                 return;
             }
         }
-        forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, pkt_addr(c));
+        forge_trip("DMA", c.dd_dst, pre_dma, v32, 4, packet_addr);
         if (v32 == 0) {
             memset(dst, 0, c.dd_bytes);
         } else {
@@ -824,7 +825,7 @@ static void honor_dma_data(const Pm4Command& c, bool notify_renderer = true) {
             for (; i + 4 <= c.dd_bytes; i += 4) memcpy(dst + i, &v32, 4);
             if (i < c.dd_bytes) memcpy(dst + i, &v32, c.dd_bytes - i);
         }
-        poolshift_check("DMA", c.dd_dst, c.dd_bytes, c.dd_src, pkt_addr(c));
+        poolshift_check("DMA", c.dd_dst, c.dd_bytes, c.dd_src, packet_addr);
         if (c.dd_bytes <= 8) label_hist_dma_exec(c.dd_dst, pre_dma);
         if (getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc]   DmaData fill [0x%llx] := 0x%x (%u bytes)\n",
@@ -833,16 +834,28 @@ static void honor_dma_data(const Pm4Command& c, bool notify_renderer = true) {
         // memmove is byte-for-byte memcpy behavior for the normal non-overlapping GPU-buffer case,
         // while remaining deterministic if an unusual packet overlaps its endpoints.
         memmove(dst, (const void*)(uintptr_t)c.dd_src, c.dd_bytes);
-        if (notify_renderer) notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
+        notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
         if (getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc]   DmaData copy [0x%llx] <- [0x%llx] (%u bytes)\n",
                     (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes);
     }
-    ring_record(c.dd_dst, c.dd_src, (uint8_t)(c.dd_bytes > 255 ? 255 : c.dd_bytes), 4, pkt_addr(c));
+    ring_record(c.dd_dst, c.dd_src, (uint8_t)(c.dd_bytes > 255 ? 255 : c.dd_bytes), 4, packet_addr);
     if (writer_provenance_enabled() && c.dd_bytes >= 256)
         record_guest_write(GuestWriterKind::DmaData, c.dd_dst, c.dd_bytes,
-                           0, 0, c.stream_order, pkt_addr(c));
+                           0, 0, c.stream_order, packet_addr);
     wake_on_label(c.dd_dst);
+}
+
+void execute_ordered_dma_copy(const GpuState::DmaCopy& copy) {
+    Pm4Command c{};
+    c.kind = Pm4Command::Kind::DmaData;
+    c.dd_dst = copy.dst;
+    c.dd_src = copy.src;
+    c.dd_bytes = copy.bytes;
+    c.dd_sels = copy.sels;
+    c.dd_valid = true;
+    c.stream_order = copy.command_order;
+    honor_dma_data(c, copy.packet_addr);
 }
 
 // Honor a WRITE_DATA packet: copy the inline dwords to the destination address (same synchronous timing).
@@ -914,7 +927,6 @@ bool eop_write_sync() {
 struct PendWrite {
     Pm4Command cmd;
     std::vector<uint32_t> wd_copy;     // owns a WriteData payload (cmd.wd_data repointed here)
-    bool dma_observer_handled = false; // address-copy invalidation ran safely on the submit thread
 };
 // IMMORTAL (leaked) worker state — same pattern as the EOP-event worker (hle_kernel_time.cpp):
 // the worker is detached and outlives main; static destructors must never run for it.
@@ -927,7 +939,7 @@ struct PendQueue {
 };
 PendQueue& pend_q() { static PendQueue* p = new PendQueue; return *p; }
 void apply_effect(const Pm4Command& c);   // fwd (defined with the WAIT_DEFER machinery below)
-void apply_deferred_effect(const Pm4Command& c, bool notify_dma = true); // guarded apply (#449)
+void apply_deferred_effect(const Pm4Command& c);   // fwd: guarded apply (#449)
 // Drain returns only when every pending write has LANDED, and writes land STRICTLY IN QUEUE ORDER.
 //
 // #312 ROOT CAUSE (2026-07-10, label-event-ring attribution): the previous loop popped the NEXT
@@ -961,7 +973,7 @@ void pend_drain_locked(PendQueue& p, std::unique_lock<std::mutex>& lk) {
         // the label page (MallocBinned3, #312). apply_deferred_effect probes guest_readable before
         // the raw memcpy — without it an unmapped label SIGSEGVs here, exactly the case the deferred-
         // stream path already survives (this pend path releases asynchronously too, so it needs it).
-        apply_deferred_effect(w.cmd, !w.dma_observer_handled);
+        apply_deferred_effect(w.cmd);
         lk.lock();
         p.inflight--;
         p.cv.notify_all();               // wake both drain waiters and the pend worker
@@ -985,21 +997,6 @@ void pend_enqueue(const Pm4Command& c) {
     if (c.kind == Pm4Command::Kind::WriteData && c.wd_data && c.wd_num) {
         w.wd_copy.assign(c.wd_data, c.wd_data + c.wd_num);   // cb memory may be recycled before drain
         w.cmd.wd_data = w.wd_copy.data();
-    }
-    if (!eop_writes_disabled() && c.kind == Pm4Command::Kind::DmaData &&
-        c.dd_src > UINT32_MAX) {
-        // The live renderer's cache invalidation callback mutates submit-owned caches and is not
-        // worker-thread safe. Validate and notify address copies now, while the submit mutex is
-        // held; the queued memmove still lands in FIFO order before rendering. An invalid span is
-        // frozen invalid so an unrelated mapping appearing during the 1 ms drain window cannot turn
-        // into an unreported write on the worker.
-        w.dma_observer_handled = true;
-        if (dma_data_form(c) == DmaDataForm::Copy)
-            notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
-        else {
-            report_invalid_dma_data(c);
-            w.cmd.dd_valid = false;
-        }
     }
     {
         std::lock_guard<std::mutex> lk(p.mx);
@@ -1261,7 +1258,7 @@ uint64_t effect_target(const Pm4Command& c, uint32_t* bytes) {
         default: *bytes = 0; return 0;
     }
 }
-void apply_deferred_effect(const Pm4Command& c, bool notify_dma) {
+void apply_deferred_effect(const Pm4Command& c) {
     uint32_t bytes = 0;
     uint64_t t = effect_target(c, &bytes);
     if (t && bytes && !guest_readable(t, bytes)) {
@@ -1271,10 +1268,7 @@ void apply_deferred_effect(const Pm4Command& c, bool notify_dma) {
                     (unsigned)c.kind, (unsigned long long)t, bytes);
         return;
     }
-    if (c.kind == Pm4Command::Kind::DmaData)
-        honor_dma_data(c, notify_dma);
-    else
-        apply_effect(c);
+    apply_effect(c);
 }
 } // namespace
 
@@ -1522,11 +1516,17 @@ void GpuState::apply(const Pm4Command& c) {
             if (eop_write_sync()) honor_event_write(c); else pend_enqueue(c);
             break;
         case K::DmaData:
-            // CP-DMA memory effect (#312: the per-segment fence-label INIT). Rides the same FIFO
-            // as the other guest-visible writes: stream order between a generation's ReleaseMem
-            // (label <- 1) and the NEXT generation's DmaData (label := 0) at the same recycled
-            // address is exactly what the guest's consumption poll depends on.
+            // Address-backed copies are ordinary in-stream producers: retain them beside draws and
+            // dispatches so the ordered executor exposes old bytes to earlier consumers and copied
+            // bytes to later consumers (#189). Immediate fills keep their established completion-
+            // FIFO behavior (#312): their observed uses are label init and command-chunk zeroing.
             if (defer_gate(c)) { defer_push(c); break; }
+            if (c.dd_src > UINT32_MAX) {
+                if (!c.dd_valid) { report_invalid_dma_data(c); break; }
+                dma_copies.push_back({c.dd_dst, c.dd_src, c.dd_bytes, c.dd_sels,
+                                      command_order, pkt_addr(c)});
+                break;
+            }
             if (eop_write_sync()) honor_dma_data(c); else pend_enqueue(c);
             break;
         case K::WaitRegMem:

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -711,6 +711,7 @@ static void honor_eop_write(const Pm4Command& c) {
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   EOP write [0x%llx] data_sel=%u value=0x%llx\n",
                 (unsigned long long)c.rel_addr, c.rel_data_sel, (unsigned long long)c.rel_value);
+    notify_guest_gpu_write(c.rel_addr, c.rel_data_sel == 1 ? 4 : 8);
     wake_on_label(c.rel_addr);   // wake any sync_on_address futex waiter on this completion label
 }
 
@@ -734,6 +735,7 @@ static void honor_event_write(const Pm4Command& c) {
     }
     uint64_t v = gpu_clock64();
     memcpy((void*)(uintptr_t)c.event_addr, &v, sizeof v);
+    notify_guest_gpu_write(c.event_addr, sizeof v);
     ring_record(c.event_addr, v, 8, 2, pkt_addr(c));
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   EventWrite [0x%llx] event_type=%u -> clock 0x%llx\n",
@@ -838,11 +840,11 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
         memmove(dst, authoritative_source ? authoritative_source
                                           : (const uint8_t*)(uintptr_t)c.dd_src,
                 c.dd_bytes);
-        notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
         if (getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc]   DmaData copy [0x%llx] <- [0x%llx] (%u bytes)\n",
                     (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes);
     }
+    notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
     ring_record(c.dd_dst, c.dd_src, (uint8_t)(c.dd_bytes > 255 ? 255 : c.dd_bytes), 4, packet_addr);
     if (writer_provenance_enabled() && c.dd_bytes >= 256)
         record_guest_write(GuestWriterKind::DmaData, c.dd_dst, c.dd_bytes,
@@ -885,6 +887,7 @@ static void honor_write_data(const Pm4Command& c) {
         forge_trip("WDATA", c.wd_addr, pre, c.wd_data[0], 4, pkt_addr(c));   // #312 session-10 tripwire
     }
     memcpy((void*)(uintptr_t)c.wd_addr, c.wd_data, (size_t)c.wd_num * 4);
+    notify_guest_gpu_write(c.wd_addr, static_cast<uint64_t>(c.wd_num) * 4);
     ring_record(c.wd_addr, c.wd_data[0], (uint8_t)(c.wd_num * 4 > 255 ? 255 : c.wd_num * 4), 3, pkt_addr(c));
     poolshift_check("WDATA", c.wd_addr, (uint64_t)c.wd_num * 4, c.wd_num ? c.wd_data[0] : 0, pkt_addr(c));
     if (getenv("PROSPER_GFXLOG"))
@@ -1279,11 +1282,6 @@ void apply_deferred_effect(const Pm4Command& c) {
 
 void execute_ordered_memory_effect(const GpuState::MemoryEffect& effect) {
     apply_deferred_effect(effect.cmd);
-    uint64_t addr = 0, bytes = 0;
-    effect_span(effect.cmd, &addr, &bytes);
-    // Invalidating after a guarded no-op is conservative; retaining a stale renderer-owned image
-    // after a real write would make a later consumer observe the wrong storage version.
-    if (addr && bytes) notify_guest_gpu_write(addr, bytes);
 }
 
 bool last_fold_deferred() { return g_fold_deferring; }
@@ -1396,6 +1394,16 @@ void GpuState::apply(const Pm4Command& c) {
     command_order = c.stream_order ? c.stream_order : command_order + 1;
     switch (c.kind) {
         case K::SetRegsIndirect: {
+            if (!dma_copies.empty()) {
+                dma_execution_rejected = true;
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    fprintf(stderr,
+                            "[agc] ordered DMA submit rejected: SetRegsIndirect reads guest memory "
+                            "after retained DMA (order=%llu)\n",
+                            (unsigned long long)command_order);
+                break;
+            }
             if (c.regs_vaddr == 0 || c.num_regs == 0 || c.num_regs > kMaxRegsPerPacket) return;
             auto* regs = reinterpret_cast<const ShaderReg*>(static_cast<uintptr_t>(c.regs_vaddr));
             auto& file = (c.reg_class == RegClass::Cx) ? cx
@@ -1546,9 +1554,24 @@ void GpuState::apply(const Pm4Command& c) {
             // dispatches so the ordered executor exposes old bytes to earlier consumers and copied
             // bytes to later consumers (#189). Immediate fills keep their established completion-
             // FIFO behavior until a general copy appears; its suffix joins the ordered timeline.
-            if (defer_gate(c)) { defer_push(c); break; }
             if (c.dd_src > UINT32_MAX) {
                 if (!c.dd_valid) { report_invalid_dma_data(c); break; }
+                const bool gated_destination = defer_gate(c);
+                const bool gated_source = !g_deferred.empty() && addr_gated(c.dd_src, c.dd_bytes);
+                if (gated_destination || gated_source) {
+                    dma_copies.push_back({c.dd_dst, c.dd_src, c.dd_bytes, c.dd_sels,
+                                          command_order, pkt_addr(c)});
+                    dma_execution_rejected = true;
+                    static std::atomic<int> warned{0};
+                    if (warned.fetch_add(1) < 24)
+                        fprintf(stderr,
+                                "[agc] ordered DMA submit rejected: WAIT_DEFER owns %s dependency "
+                                "(src=0x%llx dst=0x%llx bytes=%u order=%llu)\n",
+                                gated_source ? "source" : "destination/stream",
+                                (unsigned long long)c.dd_src, (unsigned long long)c.dd_dst,
+                                c.dd_bytes, (unsigned long long)command_order);
+                    break;
+                }
                 // Everything queued before the first general copy is its ordered prefix. Land that
                 // prefix now; subsequent effects are retained below and cannot overtake the copy.
                 if (dma_copies.empty()) prosper_gpu_drain_completion_writes();
@@ -1556,6 +1579,7 @@ void GpuState::apply(const Pm4Command& c) {
                                       command_order, pkt_addr(c)});
                 break;
             }
+            if (defer_gate(c)) { defer_push(c); break; }
             if (!dma_copies.empty()) {
                 ordered_memory_effects.emplace_back(c, command_order);
                 break;
@@ -1563,6 +1587,16 @@ void GpuState::apply(const Pm4Command& c) {
             if (eop_write_sync()) honor_dma_data(c); else pend_enqueue(c);
             break;
         case K::WaitRegMem:
+            if (!dma_copies.empty()) {
+                dma_execution_rejected = true;
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    fprintf(stderr,
+                            "[agc] ordered DMA submit rejected: WAIT_REG_MEM reads guest memory "
+                            "after retained DMA (order=%llu)\n",
+                            (unsigned long long)command_order);
+                break;
+            }
             // Real WAIT_REG_MEM semantics (#312): an unsatisfied wait PAUSES this queue — the
             // stream's remaining memory effects are deferred until the condition holds (flushed
             // at subsequent submits by flush_deferred_streams; loud timeout fallback preserves
@@ -1648,6 +1682,16 @@ void GpuState::apply(const Pm4Command& c) {
             // title frame REQUIRES the composite every frame on real hardware, and the condition
             // memory reads 0 throughout the title steady state, so 0 must mean "execute" here
             // ("skip when non-zero", matching PM4 SET_PREDICATION's draw-discard-on-set model).
+            if (!dma_copies.empty()) {
+                dma_execution_rejected = true;
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    fprintf(stderr,
+                            "[agc] ordered DMA submit rejected: Jump reads target/predication "
+                            "memory after retained DMA (order=%llu)\n",
+                            (unsigned long long)command_order);
+                break;
+            }
             if (!c.jump_valid || !c.jump_addr || (c.jump_addr & 3) || !c.jump_dwords) break;
             // PROSPER_NO_JUMP=1: diagnostic A/B — reproduce the pre-#319 behavior (jump ignored).
             static const bool no_jump = [] { const char* e = getenv("PROSPER_NO_JUMP"); return e && e[0] == '1'; }();

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -81,6 +81,11 @@ struct GpuState {
         uint64_t packet_addr = 0;
     };
     std::vector<DmaCopy> dma_copies;
+    // Some PM4 consumers (indirect register arrays, waits, and jump/predication memory) are still
+    // folded eagerly. If one follows a retained DMA, or WAIT_DEFER owns either copy dependency,
+    // executing the submit would consume stale bytes. Preserve the DMA record for diagnostics and
+    // capture truthfulness, but reject backend execution of the whole submit.
+    bool dma_execution_rejected = false;
     // Once a submit retains an address-backed DMA, later modeled memory effects must remain beside
     // it instead of entering the asynchronous completion FIFO and overtaking it. Own WRITE_DATA's
     // inline payload because the command buffer may be recycled before ordered execution.

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -70,6 +70,16 @@ struct GpuState {
         uint64_t command_order = 0;
     };
     std::vector<Dispatch> dispatches;                     // current submit's DispatchDirect packets
+    // Address-backed DMA_DATA memory effects execute in the same ordered backend timeline as
+    // draws/dispatches. Immediate fills remain completion-queue effects because their established
+    // uses are fence-label initialization and command-chunk zeroing (#312/#189).
+    struct DmaCopy {
+        uint64_t dst = 0, src = 0;
+        uint32_t bytes = 0, sels = 0;
+        uint64_t command_order = 0;
+        uint64_t packet_addr = 0;
+    };
+    std::vector<DmaCopy> dma_copies;
     uint64_t dispatch_count = 0;                          // process-lifetime DispatchDirect count
     uint64_t command_order = 0;                           // process-lifetime applied PM4 ordinal
 
@@ -96,6 +106,10 @@ private:
     std::shared_ptr<const GpuState> last_snapshot_;
     bool state_dirty_ = true;
 };
+
+// Execute one retained address-backed DMA_DATA operation at its ordered submit position.
+// Re-validates both guest spans immediately before the byte copy and notifies renderer caches.
+void execute_ordered_dma_copy(const GpuState::DmaCopy& copy);
 
 // Decode `dwords` dwords at `buf` and apply every op to `st`. Returns the number of packets applied.
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st);

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -108,8 +108,10 @@ private:
 };
 
 // Execute one retained address-backed DMA_DATA operation at its ordered submit position.
-// Re-validates both guest spans immediately before the byte copy and notifies renderer caches.
-void execute_ordered_dma_copy(const GpuState::DmaCopy& copy);
+// Re-validates the destination and either the raw guest source or a bounded authoritative renderer
+// snapshot immediately before the byte copy, then notifies renderer caches.
+void execute_ordered_dma_copy(const GpuState::DmaCopy& copy,
+                              const uint8_t* authoritative_source = nullptr);
 
 // Decode `dwords` dwords at `buf` and apply every op to `st`. Returns the number of packets applied.
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st);

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -181,7 +181,7 @@ int  flush_deferred_streams();
 // lets the guest's completion scan free label blocks our gated writes then stomp — see the
 // visibility-contract block in command_processor.cpp). Call instead of prosper_eq_trigger_eop
 // from the submit paths, under the submit mutex.
-void submit_completion_pulse();
+void submit_completion_pulse(bool submit_rejected = false);
 
 } // namespace prosper::gpu
 

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -71,8 +71,9 @@ struct GpuState {
     };
     std::vector<Dispatch> dispatches;                     // current submit's DispatchDirect packets
     // Address-backed DMA_DATA memory effects execute in the same ordered backend timeline as
-    // draws/dispatches. Immediate fills remain completion-queue effects because their established
-    // uses are fence-label initialization and command-chunk zeroing (#312/#189).
+    // draws/dispatches. Immediate fills retain their established completion-queue behavior until a
+    // general copy appears; effects after that boundary join the ordered timeline and cannot overtake
+    // it (#312/#189).
     struct DmaCopy {
         uint64_t dst = 0, src = 0;
         uint32_t bytes = 0, sels = 0;
@@ -80,6 +81,41 @@ struct GpuState {
         uint64_t packet_addr = 0;
     };
     std::vector<DmaCopy> dma_copies;
+    // Once a submit retains an address-backed DMA, later modeled memory effects must remain beside
+    // it instead of entering the asynchronous completion FIFO and overtaking it. Own WRITE_DATA's
+    // inline payload because the command buffer may be recycled before ordered execution.
+    struct MemoryEffect {
+        Pm4Command cmd;
+        std::vector<uint32_t> write_data;
+
+        MemoryEffect() = default;
+        MemoryEffect(const Pm4Command& source, uint64_t order) : cmd(source) {
+            cmd.stream_order = order;
+            if (cmd.kind == Pm4Command::Kind::WriteData && cmd.wd_data && cmd.wd_num)
+                write_data.assign(cmd.wd_data, cmd.wd_data + cmd.wd_num);
+            rebind();
+        }
+        MemoryEffect(const MemoryEffect& other) : cmd(other.cmd), write_data(other.write_data) {
+            rebind();
+        }
+        MemoryEffect& operator=(const MemoryEffect& other) {
+            if (this != &other) { cmd = other.cmd; write_data = other.write_data; rebind(); }
+            return *this;
+        }
+        MemoryEffect(MemoryEffect&& other) noexcept
+            : cmd(other.cmd), write_data(std::move(other.write_data)) { rebind(); }
+        MemoryEffect& operator=(MemoryEffect&& other) noexcept {
+            if (this != &other) { cmd = other.cmd; write_data = std::move(other.write_data); rebind(); }
+            return *this;
+        }
+
+    private:
+        void rebind() {
+            if (cmd.kind == Pm4Command::Kind::WriteData)
+                cmd.wd_data = write_data.empty() ? nullptr : write_data.data();
+        }
+    };
+    std::vector<MemoryEffect> ordered_memory_effects;
     uint64_t dispatch_count = 0;                          // process-lifetime DispatchDirect count
     uint64_t command_order = 0;                           // process-lifetime applied PM4 ordinal
 
@@ -112,6 +148,9 @@ private:
 // snapshot immediately before the byte copy, then notifies renderer caches.
 void execute_ordered_dma_copy(const GpuState::DmaCopy& copy,
                               const uint8_t* authoritative_source = nullptr);
+// Execute a retained post-DMA memory effect through the same mappedness, generation, freelist, and
+// label-wakeup guards as the legacy completion path, then invalidate renderer-owned guest caches.
+void execute_ordered_memory_effect(const GpuState::MemoryEffect& effect);
 
 // Decode `dwords` dwords at `buf` and apply every op to `st`. Returns the number of packets applied.
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -865,10 +865,18 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
     return true;
 }
 
+static bool reject_unsupported_gpustate_capture(const GpuState& state, std::string& error) {
+    if (state.dma_copies.empty()) return false;
+    error = "GPU capture v13 cannot represent " + std::to_string(state.dma_copies.size()) +
+            " ordered DMA_DATA operation(s); capture would be incomplete (see #833)";
+    return true;
+}
+
 bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
                              GpuCaptureFile& out, std::string& error) {
+    if (reject_unsupported_gpustate_capture(state, error)) return false;
     const bool caplog = std::getenv("PROSPER_GPU_CAPTURE_LOG") != nullptr;
     std::vector<OperationRealizationFailure> failures, compute_failures;
     if (caplog) std::fprintf(stderr, "[cap] realize_gpustate_draws...\n");
@@ -893,6 +901,7 @@ bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
                                     uint32_t target_width, uint32_t target_height,
                                     const GpuCaptureMetadata& metadata,
                                     GpuCaptureFile& out, std::string& error) {
+    if (reject_unsupported_gpustate_capture(state, error)) return false;
     std::vector<DrawItem> draws = realize_gpustate_draws(state);
     draws.erase(std::remove_if(draws.begin(), draws.end(), [&](const DrawItem& draw) {
         return draw.color0_width != target_width || draw.color0_height != target_height;
@@ -1687,7 +1696,8 @@ bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std
 
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
-    const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height) {
+    const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height,
+    bool has_ordered_dma) {
     const char* path = std::getenv("PROSPER_GPU_CAPTURE"); if (!path || !*path) return {};
     static std::atomic<uint64_t> invocation_sequence{0};
     const uint64_t invocation = invocation_sequence.fetch_add(1);
@@ -1702,6 +1712,14 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     uint64_t current = sequence.fetch_add(1), wanted = 0;
     if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);
     if (current != wanted || claimed.exchange(true)) return {};
+    if (has_ordered_dma) {
+        std::fprintf(stderr,
+                     "[gpucap] selected match %llu at invocation %llu failed: capture v13 cannot "
+                     "represent ordered DMA_DATA (see #833)\n",
+                     static_cast<unsigned long long>(current),
+                     static_cast<unsigned long long>(invocation));
+        return {};
+    }
     auto pending = std::make_unique<PendingGpuCapture>(); pending->path = path;
     GpuCaptureMetadata m; m.width = width; m.height = height; m.submit_index = current;
 #ifdef PROSPER_GIT_REVISION

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1697,7 +1697,7 @@ bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
     const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height,
-    bool has_ordered_dma) {
+    bool has_ordered_dma, uint64_t unsupported_draw_count) {
     const char* path = std::getenv("PROSPER_GPU_CAPTURE"); if (!path || !*path) return {};
     static std::atomic<uint64_t> invocation_sequence{0};
     const uint64_t invocation = invocation_sequence.fetch_add(1);
@@ -1707,7 +1707,9 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     uint64_t min_draws = 0, max_draws = std::numeric_limits<uint64_t>::max();
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MIN_DRAWS")) min_draws = std::strtoull(v, nullptr, 0);
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MAX_DRAWS")) max_draws = std::strtoull(v, nullptr, 0);
-    if (draws.size() < min_draws || draws.size() > max_draws) return {};
+    const uint64_t candidate_draw_count = has_ordered_dma && unsupported_draw_count != UINT64_MAX
+        ? unsupported_draw_count : static_cast<uint64_t>(draws.size());
+    if (candidate_draw_count < min_draws || candidate_draw_count > max_draws) return {};
     static std::atomic<uint64_t> sequence{0}; static std::atomic<bool> claimed{false};
     uint64_t current = sequence.fetch_add(1), wanted = 0;
     if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -274,7 +274,8 @@ struct PendingGpuCapture {
 };
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
-    const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height);
+    const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height,
+    bool has_ordered_dma = false);
 bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
                                   const std::vector<uint8_t>& output, std::string& error);
 

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -275,7 +275,7 @@ struct PendingGpuCapture {
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
     const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height,
-    bool has_ordered_dma = false);
+    bool has_ordered_dma = false, uint64_t unsupported_draw_count = UINT64_MAX);
 bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
                                   const std::vector<uint8_t>& output, std::string& error);
 

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -327,6 +327,9 @@ std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st,
                                                      uint64_t submit_no = 0,
                                                      std::vector<OperationRealizationFailure>* failures = nullptr);
 bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no = 0);
+// Execute retained dispatches and address-backed DMA copies in PM4 order when graphics rendering is
+// intentionally skipped or unavailable. Draw operations are omitted, but still delimit ordering.
+bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no = 0);
 std::vector<SubmitOperation> plan_submit_operations(const GpuState& st);
 
 // PROSPER_PROVENANCE_DIM=WxH: inspect sampled images of that size and report overlapping
@@ -971,6 +974,14 @@ struct OrderedSubmitResult {
     size_t render_spans = 0;
     bool compute_executed = false;
 };
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const std::vector<GpuState::DmaCopy>& dma_copies,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height);
+// Compatibility overload for capture replay and tests whose timelines contain only draws/dispatches.
 OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
                                           const std::vector<DrawItem>& draws,
                                           const std::vector<ComputeItem>& computes,

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -323,6 +323,15 @@ struct LiveTargetSnapshot {
 using LiveTargetReaderFn = std::function<bool(uint64_t gpu_addr, LiveTargetSnapshot& snapshot)>;
 void set_live_target_reader(LiveTargetReaderFn fn);
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot);
+// Ordered memory producers need the same authoritative storage version as live compute. A source
+// may begin inside a target, so the renderer validates the complete requested byte range instead of
+// exposing an unbounded pointer into its cache.
+enum class LiveTargetByteReadResult : uint8_t { NotFound, Success, InvalidRange };
+using LiveTargetByteRangeReaderFn = std::function<LiveTargetByteReadResult(
+    uint64_t gpu_addr, uint32_t bytes, std::vector<uint8_t>& output)>;
+void set_live_target_byte_range_reader(LiveTargetByteRangeReaderFn fn);
+LiveTargetByteReadResult read_live_render_target_bytes(uint64_t gpu_addr, uint32_t bytes,
+                                                       std::vector<uint8_t>& output);
 std::vector<ComputeItem> realize_compute_dispatches(const GpuState& st,
                                                      uint64_t submit_no = 0,
                                                      std::vector<OperationRealizationFailure>* failures = nullptr);
@@ -996,6 +1005,9 @@ bool have_submit_renderer();
 struct LiveRenderPhase {
     bool first_span = true;
     bool final_span = true;
+    // The next ordered operation reads render-target bytes on the CPU. Persistent Vulkan targets
+    // must synchronously read back this span instead of deferring their authoritative pixels.
+    bool authoritative_readback = false;
 };
 LiveRenderPhase live_render_phase();
 

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -68,10 +68,14 @@ struct DrawItem {
 // pixels (or {} on failure). Empty list -> {} (nothing to draw).
 using RenderFn = std::function<std::vector<uint8_t>(const std::vector<DrawItem>& items)>;
 
-// Safe guest-address readability probe: write() to /dev/null returns EFAULT for an unmapped source
-// (Linux; always-true on Windows), so callers can test a guest pointer without risking a SIGSEGV.
-// Implemented in gpu_executor.cpp; shared by the executor's const-eval and HLE diagnostic probes.
+// Safe guest-address readability probe: a page-touching pipe probe on Linux/macOS and VirtualQuery
+// on Windows let callers test a guest pointer without risking a host fault. Implemented in
+// gpu_executor.cpp; shared by the executor's const-eval and HLE diagnostic probes.
 bool guest_readable(uint64_t addr, uint32_t bytes);
+// True only when the complete guest range is currently mapped writable. DMA_DATA uses this before
+// copying into a guest-provided destination so a read-only mapping cannot turn a malformed packet
+// into a host fault.
+bool guest_writable(uint64_t addr, uint32_t bytes);
 
 // One resolved bindless-dynamic vertex fetch from the wave-uniform scalar const-fold in
 // gpu_executor.cpp: the exact fetch instruction (pc), its SRSRC SGPR, and the V# live in that SGPR

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2381,6 +2381,17 @@ bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     return !items.empty() && g_compute(items);
 }
 
+bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
+    if (st.dma_copies.empty() && (!g_compute || st.dispatches.empty())) return false;
+    GuestReadableSubmitScope guest_readable_scope;
+    std::vector<ComputeItem> computes = g_compute
+        ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
+    const auto operations = plan_submit_operations(st);
+    const OrderedSubmitResult result = execute_ordered_items(
+        operations, {}, computes, st.dma_copies, {}, g_compute, 0, 0);
+    return result.compute_executed || !st.dma_copies.empty();
+}
+
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     const char* enabled = getenv("PROSPER_COMPUTELOG");
     const char* dim_env = getenv("PROSPER_COMPUTELOG_DIM");
@@ -2660,6 +2671,7 @@ std::vector<SubmitOperation> plan_submit_operations(const GpuState& st) {
 OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
                                           const std::vector<DrawItem>& draws,
                                           const std::vector<ComputeItem>& computes,
+                                          const std::vector<GpuState::DmaCopy>& dma_copies,
                                           const LiveRenderFn& render,
                                           const LiveComputeFn& compute,
                                           uint32_t width, uint32_t height) {
@@ -2669,22 +2681,34 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
     for (size_t i = 0; i < computes.size(); ++i)
         compute_by_index[static_cast<size_t>(computes[i].dispatch_index)] = i;
 
-    struct ExecutableOperation { SubmitOperationKind kind; size_t item; };
+    enum class ExecutableKind : uint8_t { Draw, Dispatch, DmaCopy };
+    struct ExecutableOperation {
+        ExecutableKind kind;
+        size_t item;
+        uint64_t command_order;
+    };
     std::vector<ExecutableOperation> executable;
     for (const auto& operation : operations) {
         if (operation.kind == SubmitOperationKind::Draw) {
             auto it = draw_by_index.find(operation.index);
-            if (it != draw_by_index.end()) executable.push_back({operation.kind, it->second});
+            if (it != draw_by_index.end())
+                executable.push_back({ExecutableKind::Draw, it->second, operation.command_order});
         } else {
             auto it = compute_by_index.find(operation.index);
-            if (it != compute_by_index.end()) executable.push_back({operation.kind, it->second});
+            if (it != compute_by_index.end())
+                executable.push_back({ExecutableKind::Dispatch, it->second, operation.command_order});
         }
     }
+    for (size_t i = 0; i < dma_copies.size(); ++i)
+        executable.push_back({ExecutableKind::DmaCopy, i, dma_copies[i].command_order});
+    std::stable_sort(executable.begin(), executable.end(), [](const auto& a, const auto& b) {
+        return a.command_order < b.command_order;
+    });
 
     size_t total_spans = 0;
     bool in_draw_span = false;
     for (const auto& operation : executable) {
-        if (operation.kind == SubmitOperationKind::Draw) {
+        if (operation.kind == ExecutableKind::Draw) {
             if (!in_draw_span) ++total_spans;
             in_draw_span = true;
         } else {
@@ -2705,15 +2729,27 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
         ++result.render_spans;
     };
     for (const auto& operation : executable) {
-        if (operation.kind == SubmitOperationKind::Draw) {
+        if (operation.kind == ExecutableKind::Draw) {
             span.push_back(draws[operation.item]);
-        } else {
+        } else if (operation.kind == ExecutableKind::Dispatch) {
             flush_span();
             result.compute_executed |= compute && compute({computes[operation.item]});
+        } else {
+            flush_span();
+            execute_ordered_dma_copy(dma_copies[operation.item]);
         }
     }
     flush_span();
     return result;
+}
+
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height) {
+    return execute_ordered_items(operations, draws, computes, {}, render, compute, width, height);
 }
 
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
@@ -2777,7 +2813,8 @@ bool execute_compute_items(const std::vector<ComputeItem>& items) {
 
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
                                  uint64_t submit_no, bool publish) {
-    if ((!g_live && !g_compute) || (st.draws.empty() && st.dispatches.empty())) return false;
+    if ((!g_live && !g_compute && st.dma_copies.empty()) ||
+        (st.draws.empty() && st.dispatches.empty() && st.dma_copies.empty())) return false;
     // Guest allocations referenced by a GPU submit must remain mapped until that submit completes.
     // Reuse positive page/VirtualQuery results only inside this synchronous execution window; the
     // scope is discarded before guest code can submit a later mapping generation.
@@ -2813,10 +2850,19 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
 
     auto operations = plan_submit_operations(st);
     const auto timing_plan_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    auto pending_capture = begin_requested_gpu_capture(
-        draws, computes, operations, width, height);
+    // Capture formats through v13 have no DMA operation record. Refuse a partial artifact rather
+    // than silently snapshot pre-copy resources and replay a different submit.
+    std::unique_ptr<PendingGpuCapture> pending_capture;
+    if (st.dma_copies.empty()) {
+        pending_capture = begin_requested_gpu_capture(draws, computes, operations, width, height);
+    } else if (std::getenv("PROSPER_GPU_CAPTURE")) {
+        static std::atomic<int> warned{0};
+        if (warned.fetch_add(1) == 0)
+            std::fprintf(stderr,
+                         "[gpucap] submit capture skipped: ordered DMA_DATA is not represented by capture v13\n");
+    }
     OrderedSubmitResult result = execute_ordered_items(
-        operations, draws, computes, g_live, g_compute, width, height);
+        operations, draws, computes, st.dma_copies, g_live, g_compute, width, height);
     const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     const std::vector<uint8_t>& px = result.frame.bytes();
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2391,8 +2391,9 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
     GuestReadableSubmitScope guest_readable_scope;
     const OrderedSubmitResult result = execute_ordered_gpustate(
         st, 0, 0, submit_no, {}, g_compute);
-    return result.compute_executed || !st.dma_copies.empty() ||
-           !st.ordered_memory_effects.empty();
+    return !st.dma_execution_rejected &&
+           (result.compute_executed || !st.dma_copies.empty() ||
+            !st.ordered_memory_effects.empty());
 }
 
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
@@ -2826,6 +2827,14 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                                                      const LiveRenderFn& render,
                                                      const LiveComputeFn& compute) {
     GuestGpuWriteSubmitScope guest_gpu_write_scope;
+    if (st.dma_execution_rejected) {
+        static std::atomic<int> warned{0};
+        if (warned.fetch_add(1) < 24)
+            std::fprintf(stderr,
+                         "[agc] ordered DMA submit not executed: unsupported eager/deferred "
+                         "guest-memory dependency\n");
+        return {};
+    }
     std::vector<RetainedSubmitOperation> executable;
     executable.reserve(st.draws.size() + st.dispatches.size() + st.dma_copies.size() +
                        st.ordered_memory_effects.size());
@@ -2858,17 +2867,19 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
     const float scale_x = full_width ? static_cast<float>(width) / full_width : 1.0f;
     const float scale_y = full_height ? static_cast<float>(height) / full_height : 1.0f;
     OrderedSubmitResult result;
+    bool final_callback_sent = false;
     std::vector<DrawItem> span;
     auto flush_span = [&](bool authoritative_readback = false) {
         if (span.empty() || !render) return;
         LiveRenderPhase saved = g_live_phase;
-        g_live_phase = {result.render_spans == 0, result.render_spans + 1 == total_spans,
-                        authoritative_readback};
+        const bool final_span = result.render_spans + 1 == total_spans;
+        g_live_phase = {result.render_spans == 0, final_span, authoritative_readback};
         RenderedFrame rendered = render(span, width, height);
         g_live_phase = saved;
         if (!rendered.empty()) result.frame = std::move(rendered);
         span.clear();
         ++result.render_spans;
+        final_callback_sent |= final_span;
     };
 
     for (const auto& operation : executable) {
@@ -2914,6 +2925,17 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
         }
     }
     flush_span();
+    // A semantic draw record can fail only when lazily realized at its ordered position. If that
+    // record was counted as a later span, the last successful callback was intentionally marked
+    // intermediate. Send an empty terminal callback so the frontend can recover cached scanout,
+    // close timing state, and publish exactly once without re-rendering any draw.
+    if (render && result.render_spans && !final_callback_sent) {
+        LiveRenderPhase saved = g_live_phase;
+        g_live_phase = {false, true, false};
+        RenderedFrame rendered = render({}, width, height);
+        g_live_phase = saved;
+        if (!rendered.empty()) result.frame = std::move(rendered);
+    }
     return result;
 }
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2381,15 +2381,18 @@ bool execute_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     return !items.empty() && g_compute(items);
 }
 
+static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t width,
+                                                     uint32_t height, uint64_t submit_no,
+                                                     const LiveRenderFn& render,
+                                                     const LiveComputeFn& compute);
+
 bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
     if (st.dma_copies.empty() && (!g_compute || st.dispatches.empty())) return false;
     GuestReadableSubmitScope guest_readable_scope;
-    std::vector<ComputeItem> computes = g_compute
-        ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
-    const auto operations = plan_submit_operations(st);
-    const OrderedSubmitResult result = execute_ordered_items(
-        operations, {}, computes, st.dma_copies, {}, g_compute, 0, 0);
-    return result.compute_executed || !st.dma_copies.empty();
+    const OrderedSubmitResult result = execute_ordered_gpustate(
+        st, 0, 0, submit_no, {}, g_compute);
+    return result.compute_executed || !st.dma_copies.empty() ||
+           !st.ordered_memory_effects.empty();
 }
 
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
@@ -2767,6 +2770,153 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
     return execute_ordered_items(operations, draws, computes, {}, render, compute, width, height);
 }
 
+namespace {
+enum class RetainedSubmitKind : uint8_t { Draw, Dispatch, DmaCopy, MemoryEffect };
+struct RetainedSubmitOperation {
+    RetainedSubmitKind kind;
+    size_t index;
+    uint64_t command_order;
+};
+
+bool use_per_draw_policy(const GpuState& st) {
+    static const bool force_perdraw = getenv("PROSPER_PERDRAW") != nullptr;
+    static const bool force_folded = getenv("PROSPER_FOLDED") != nullptr;
+    return force_perdraw || (!force_folded && (st.draws.size() > 1 || !st.dispatches.empty()));
+}
+
+bool retained_draw_selected(const GpuState& st, size_t index) {
+    return use_per_draw_policy(st) || index + 1 == st.draws.size();
+}
+
+bool realize_retained_draw(const GpuState& st, size_t index, float scale_x, float scale_y,
+                           DrawItem& item) {
+    if (index >= st.draws.size() || !retained_draw_selected(st, index)) return false;
+    const bool per_draw = use_per_draw_policy(st);
+    const GpuState& draw_state = per_draw ? st.state_at_draw(index) : st;
+    const GpuState::Draw& draw = st.draws[index];
+    const bool log = getenv("PROSPER_GFXLOG") != nullptr || getenv("PROSPER_EXECLOG") != nullptr;
+    if (!realize_draw_item(draw_state, &draw, draw.index_count, 0x10000, log, item)) return false;
+    item.draw_index = index;
+    item.command_order = draw.command_order;
+    if ((scale_x != 1.0f || scale_y != 1.0f) && item.ps.has_viewport) {
+        item.ps.viewport_x *= scale_x; item.ps.viewport_w *= scale_x;
+        item.ps.viewport_y *= scale_y; item.ps.viewport_h *= scale_y;
+    }
+    return true;
+}
+
+bool realize_retained_compute(const GpuState& st, size_t index, uint64_t submit_no,
+                              ComputeItem& item) {
+    if (index >= st.dispatches.size()) return false;
+    // DMA-bearing submits are uncommon. A one-dispatch state keeps the mature realization path
+    // intact while ensuring it runs only after every preceding ordered producer has landed.
+    GpuState one = st.dispatches[index].state ? *st.dispatches[index].state : st;
+    one.dispatches.clear();
+    one.dispatches.push_back(st.dispatches[index]);
+    std::vector<ComputeItem> realized = realize_compute_dispatches(one, submit_no);
+    if (realized.empty()) return false;
+    item = std::move(realized.front());
+    item.dispatch_index = index;
+    return true;
+}
+} // namespace
+
+static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t width,
+                                                     uint32_t height, uint64_t submit_no,
+                                                     const LiveRenderFn& render,
+                                                     const LiveComputeFn& compute) {
+    GuestGpuWriteSubmitScope guest_gpu_write_scope;
+    std::vector<RetainedSubmitOperation> executable;
+    executable.reserve(st.draws.size() + st.dispatches.size() + st.dma_copies.size() +
+                       st.ordered_memory_effects.size());
+    for (size_t i = 0; i < st.draws.size(); ++i)
+        if (retained_draw_selected(st, i))
+            executable.push_back({RetainedSubmitKind::Draw, i, st.draws[i].command_order});
+    for (size_t i = 0; i < st.dispatches.size(); ++i)
+        executable.push_back({RetainedSubmitKind::Dispatch, i, st.dispatches[i].command_order});
+    for (size_t i = 0; i < st.dma_copies.size(); ++i)
+        executable.push_back({RetainedSubmitKind::DmaCopy, i, st.dma_copies[i].command_order});
+    for (size_t i = 0; i < st.ordered_memory_effects.size(); ++i)
+        executable.push_back({RetainedSubmitKind::MemoryEffect, i,
+                              st.ordered_memory_effects[i].cmd.stream_order});
+    std::stable_sort(executable.begin(), executable.end(), [](const auto& a, const auto& b) {
+        return a.command_order < b.command_order;
+    });
+
+    size_t total_spans = 0;
+    bool in_draw_span = false;
+    for (const auto& operation : executable) {
+        if (render && operation.kind == RetainedSubmitKind::Draw) {
+            if (!in_draw_span) ++total_spans;
+            in_draw_span = true;
+        } else {
+            in_draw_span = false;
+        }
+    }
+
+    uint32_t full_width = present_width(), full_height = present_height();
+    const float scale_x = full_width ? static_cast<float>(width) / full_width : 1.0f;
+    const float scale_y = full_height ? static_cast<float>(height) / full_height : 1.0f;
+    OrderedSubmitResult result;
+    std::vector<DrawItem> span;
+    auto flush_span = [&](bool authoritative_readback = false) {
+        if (span.empty() || !render) return;
+        LiveRenderPhase saved = g_live_phase;
+        g_live_phase = {result.render_spans == 0, result.render_spans + 1 == total_spans,
+                        authoritative_readback};
+        RenderedFrame rendered = render(span, width, height);
+        g_live_phase = saved;
+        if (!rendered.empty()) result.frame = std::move(rendered);
+        span.clear();
+        ++result.render_spans;
+    };
+
+    for (const auto& operation : executable) {
+        switch (operation.kind) {
+            case RetainedSubmitKind::Draw: {
+                if (!render) break;
+                DrawItem item;
+                if (realize_retained_draw(st, operation.index, scale_x, scale_y, item))
+                    span.push_back(std::move(item));
+                break;
+            }
+            case RetainedSubmitKind::Dispatch: {
+                flush_span();
+                if (!compute) break;
+                ComputeItem item;
+                if (realize_retained_compute(st, operation.index, submit_no, item))
+                    result.compute_executed |= compute({std::move(item)});
+                break;
+            }
+            case RetainedSubmitKind::DmaCopy: {
+                flush_span(true);
+                const GpuState::DmaCopy& copy = st.dma_copies[operation.index];
+                std::vector<uint8_t> current_source;
+                const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
+                    copy.src, copy.bytes, current_source);
+                if (source_result == LiveTargetByteReadResult::InvalidRange) {
+                    static std::atomic<int> warned{0};
+                    if (warned.fetch_add(1) < 24)
+                        std::fprintf(stderr,
+                                     "[agc] DMA_DATA live-target source range invalid: src=0x%llx bytes=%u\n",
+                                     static_cast<unsigned long long>(copy.src), copy.bytes);
+                    break;
+                }
+                execute_ordered_dma_copy(
+                    copy, source_result == LiveTargetByteReadResult::Success
+                              ? current_source.data() : nullptr);
+                break;
+            }
+            case RetainedSubmitKind::MemoryEffect:
+                flush_span();
+                execute_ordered_memory_effect(st.ordered_memory_effects[operation.index]);
+                break;
+        }
+    }
+    flush_span();
+    return result;
+}
+
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
 bool have_submit_renderer()               { return static_cast<bool>(g_live); }
 void set_submit_compute(LiveComputeFn fn) { g_compute = std::move(fn); }
@@ -2859,7 +3009,10 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
-    std::vector<DrawItem> draws = g_live && width && height
+    const bool has_ordered_dma = !st.dma_copies.empty();
+    // A DMA-bearing submit realizes consumers at their ordered position below. Pre-realizing here
+    // would snapshot old indices/descriptors/shader bytes before the copy updates their backing.
+    std::vector<DrawItem> draws = !has_ordered_dma && g_live && width && height
         ? realize_gpustate_draws(st, 0x10000, sx, sy) : std::vector<DrawItem>{};
     const ShaderRecompileCacheStats shader_after = timing_enabled
         ? shader_recompile_cache_stats() : ShaderRecompileCacheStats{};
@@ -2870,7 +3023,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     const StageTablePhaseStats table_phases_after = timing_enabled
         ? stage_table_phase_stats() : StageTablePhaseStats{};
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    std::vector<ComputeItem> computes = g_compute
+    std::vector<ComputeItem> computes = !has_ordered_dma && g_compute
         ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
     const auto timing_compute_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
 
@@ -2880,9 +3033,11 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     // selected unsupported submit is claimed-and-failed, never silently skipped in favor of a later
     // match. Direct/timeline capture rejects again at the central GpuState boundary.
     auto pending_capture = begin_requested_gpu_capture(
-        draws, computes, operations, width, height, !st.dma_copies.empty());
-    OrderedSubmitResult result = execute_ordered_items(
-        operations, draws, computes, st.dma_copies, g_live, g_compute, width, height);
+        draws, computes, operations, width, height, has_ordered_dma,
+        static_cast<uint64_t>(st.draws.size()));
+    OrderedSubmitResult result = has_ordered_dma
+        ? execute_ordered_gpustate(st, width, height, submit_no, g_live, g_compute)
+        : execute_ordered_items(operations, draws, computes, g_live, g_compute, width, height);
     const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     const std::vector<uint8_t>& px = result.frame.bytes();
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2718,10 +2718,11 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
 
     OrderedSubmitResult result;
     std::vector<DrawItem> span;
-    auto flush_span = [&] {
+    auto flush_span = [&](bool authoritative_readback = false) {
         if (span.empty() || !render) return;
         LiveRenderPhase saved = g_live_phase;
-        g_live_phase = {result.render_spans == 0, result.render_spans + 1 == total_spans};
+        g_live_phase = {result.render_spans == 0, result.render_spans + 1 == total_spans,
+                        authoritative_readback};
         RenderedFrame rendered = render(span, width, height);
         g_live_phase = saved;
         if (!rendered.empty()) result.frame = std::move(rendered);
@@ -2735,8 +2736,22 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
             flush_span();
             result.compute_executed |= compute && compute({computes[operation.item]});
         } else {
-            flush_span();
-            execute_ordered_dma_copy(dma_copies[operation.item]);
+            flush_span(true);
+            const GpuState::DmaCopy& copy = dma_copies[operation.item];
+            std::vector<uint8_t> current_source;
+            const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
+                copy.src, copy.bytes, current_source);
+            if (source_result == LiveTargetByteReadResult::InvalidRange) {
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    std::fprintf(stderr,
+                                 "[agc] DMA_DATA live-target source range invalid: src=0x%llx bytes=%u\n",
+                                 static_cast<unsigned long long>(copy.src), copy.bytes);
+                continue;
+            }
+            execute_ordered_dma_copy(
+                copy, source_result == LiveTargetByteReadResult::Success
+                          ? current_source.data() : nullptr);
         }
     }
     flush_span();
@@ -2767,6 +2782,17 @@ void set_live_target_reader(LiveTargetReaderFn fn) { g_live_target_reader = std:
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot) {
     snapshot = {};
     return g_live_target_reader && g_live_target_reader(gpu_addr, snapshot);
+}
+static LiveTargetByteRangeReaderFn g_live_target_byte_range_reader;
+void set_live_target_byte_range_reader(LiveTargetByteRangeReaderFn fn) {
+    g_live_target_byte_range_reader = std::move(fn);
+}
+LiveTargetByteReadResult read_live_render_target_bytes(uint64_t gpu_addr, uint32_t bytes,
+                                                       std::vector<uint8_t>& output) {
+    output.clear();
+    if (!g_live_target_byte_range_reader)
+        return LiveTargetByteReadResult::NotFound;
+    return g_live_target_byte_range_reader(gpu_addr, bytes, output);
 }
 
 void set_guest_gpu_write_observer(GuestGpuWriteObserver observer) {
@@ -2850,17 +2876,11 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
 
     auto operations = plan_submit_operations(st);
     const auto timing_plan_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    // Capture formats through v13 have no DMA operation record. Refuse a partial artifact rather
-    // than silently snapshot pre-copy resources and replay a different submit.
-    std::unique_ptr<PendingGpuCapture> pending_capture;
-    if (st.dma_copies.empty()) {
-        pending_capture = begin_requested_gpu_capture(draws, computes, operations, width, height);
-    } else if (std::getenv("PROSPER_GPU_CAPTURE")) {
-        static std::atomic<int> warned{0};
-        if (warned.fetch_add(1) == 0)
-            std::fprintf(stderr,
-                         "[gpucap] submit capture skipped: ordered DMA_DATA is not represented by capture v13\n");
-    }
+    // Capture formats through v13 have no DMA operation record. Pass that fact into selection so a
+    // selected unsupported submit is claimed-and-failed, never silently skipped in favor of a later
+    // match. Direct/timeline capture rejects again at the central GpuState boundary.
+    auto pending_capture = begin_requested_gpu_capture(
+        draws, computes, operations, width, height, !st.dma_copies.empty());
     OrderedSubmitResult result = execute_ordered_items(
         operations, draws, computes, st.dma_copies, g_live, g_compute, width, height);
     const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -32,6 +32,10 @@
 #else
 #include <fcntl.h>
 #include <unistd.h>
+#ifdef __APPLE__
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#endif
 #endif
 
 // Look up a registered AGC shader header by its bound code address (hle_agc.cpp). Layout-compatible
@@ -842,6 +846,67 @@ bool guest_readable(uint64_t a, uint32_t n) {
     return true;
 }
 #endif
+
+bool guest_writable(uint64_t a, uint32_t n) {
+    if (a < 0x1000 || n == 0 || a + n < a) return false;
+    const uint64_t end = a + n;
+#ifdef _WIN32
+    uint64_t cursor = a;
+    while (cursor < end) {
+        MEMORY_BASIC_INFORMATION mbi{};
+        if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
+        if (mbi.State != MEM_COMMIT) {
+            if (!prosper_try_commit_dmem(cursor, end - cursor, 1) ||
+                !VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
+        }
+        const DWORD blocked = PAGE_NOACCESS | PAGE_GUARD;
+        const DWORD writable = PAGE_READWRITE | PAGE_WRITECOPY |
+                               PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+        if (mbi.State != MEM_COMMIT || (mbi.Protect & blocked) || !(mbi.Protect & writable))
+            return false;
+        const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+        if (region_end <= cursor) return false;
+        cursor = std::min(end, region_end);
+    }
+    return true;
+#elif defined(__APPLE__)
+    uint64_t cursor = a;
+    while (cursor < end) {
+        mach_vm_address_t region = cursor;
+        mach_vm_size_t size = 0;
+        vm_region_basic_info_data_64_t info{};
+        mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+        mach_port_t object = MACH_PORT_NULL;
+        const kern_return_t result = mach_vm_region(
+            mach_task_self(), &region, &size, VM_REGION_BASIC_INFO_64,
+            reinterpret_cast<vm_region_info_t>(&info), &count, &object);
+        if (object != MACH_PORT_NULL) mach_port_deallocate(mach_task_self(), object);
+        if (result != KERN_SUCCESS || cursor < region || !(info.protection & VM_PROT_WRITE))
+            return false;
+        if (region > UINT64_MAX - size || region + size <= cursor) return false;
+        cursor = std::min(end, static_cast<uint64_t>(region + size));
+    }
+    return true;
+#else
+    FILE* maps = fopen("/proc/self/maps", "re");
+    if (!maps) return false;
+    uint64_t cursor = a;
+    char line[512];
+    while (cursor < end && fgets(line, sizeof line, maps)) {
+        unsigned long long begin = 0, finish = 0;
+        char perms[5] = {};
+        if (sscanf(line, "%llx-%llx %4s", &begin, &finish, perms) != 3 || finish <= cursor)
+            continue;
+        if (begin > cursor || perms[1] != 'w' || finish <= begin) {
+            fclose(maps);
+            return false;
+        }
+        cursor = std::min(end, static_cast<uint64_t>(finish));
+    }
+    fclose(maps);
+    return cursor == end;
+#endif
+}
 
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------
 // This game's NGG vertex shader loads its vertex-buffer V# from a descriptor table at a RUNTIME-computed

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -254,6 +254,7 @@ struct RuntimeDetailRequest {
     bool valid = false;
     std::atomic<bool> claimed{false};
     std::atomic<bool> predecessor_claimed{false};
+    std::atomic<bool> predecessor_failed{false};
     bool bundle_start_reached = false;
 
     RuntimeDetailRequest() {
@@ -1542,6 +1543,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         if (!capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
                                      metadata, predecessor, error) ||
             !write_gpu_capture(request.predecessor_path, predecessor, error)) {
+            request.predecessor_failed.store(true);
             std::fprintf(stderr, "[timeline] predecessor submit %llu capture failed: %s\n",
                          static_cast<unsigned long long>(submit_no), error.c_str());
         } else {
@@ -1691,7 +1693,10 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                      static_cast<unsigned long long>(submit_no), error.c_str());
         error.clear();
     }
-    bool requested_artifacts_written = true;
+    const bool predecessor_requested = !request.select_target_width &&
+        !request.predecessor_path.empty() && request.submit_no > 1;
+    bool requested_artifacts_written = !predecessor_requested ||
+        (request.predecessor_claimed.load() && !request.predecessor_failed.load());
     if (!request.bundle_path.empty()) {
         RuntimeCaptureBundle& state = runtime_capture_bundle();
         GpuCaptureBundle& bundle = state.bundle;
@@ -1738,11 +1743,13 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     }
     log_capture_detail(detail);
     history.remember(state, submit_no);
-    if (request.exit_after_capture && requested_artifacts_written) {
-        std::fprintf(stderr, "[timeline] selected capture complete; exiting as requested\n");
+    if (request.exit_after_capture) {
+        std::fprintf(stderr, requested_artifacts_written
+            ? "[timeline] selected capture complete; exiting as requested\n"
+            : "[timeline] one or more requested capture artifacts failed; exiting nonzero\n");
         close_gpu_timeline();
         std::fflush(nullptr);
-        std::exit(0);
+        std::exit(requested_artifacts_written ? 0 : 2);
     }
 }
 

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -36,7 +36,7 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 6;
+constexpr uint32_t kVersion = 7;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
@@ -843,10 +843,12 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
     payload.u32(submit.dispatch_count);
     payload.u32(submit.color0_width);
     payload.u32(submit.color0_height);
-    // Keep a metadata-free v6 submit byte-identical to v1-v4 for compatibility fixtures. Any v6
-    // tail carries both collection counts so the depth and target-span sections are unambiguous.
+    // v7 prefixes its optional tail with unsupported-operation metadata. Older versions retain
+    // their historical tail layout in the reader below.
     if (!submit.depth_surfaces.empty() || !submit.target_spans.empty() ||
-        submit.target_spans_truncated) {
+        submit.target_spans_truncated || submit.dma_copy_count || submit.capture_incomplete) {
+        payload.u32(submit.dma_copy_count);
+        payload.u32(submit.capture_incomplete ? 1u : 0u);
         payload.u32(static_cast<uint32_t>(submit.depth_surfaces.size()));
         for (const auto& ds : submit.depth_surfaces) {
             payload.u64(ds.depth_read_base); payload.u64(ds.depth_write_base);
@@ -1062,6 +1064,14 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
                 return false;
             }
             const bool have_submit_tail = p.left != 0;
+            if (version >= 7 && have_submit_tail) {
+                uint32_t incomplete = 0;
+                if (!p.u32(submit.dma_copy_count) || !p.u32(incomplete) || incomplete > 1) {
+                    error = "invalid timeline unsupported-operation metadata";
+                    return false;
+                }
+                submit.capture_incomplete = incomplete != 0;
+            }
             if (version >= 5 && have_submit_tail) {
                 uint32_t surface_count = 0;
                 if (!p.u32(surface_count) || surface_count > 65536) {
@@ -1334,6 +1344,9 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     submit.process_command_order = state.command_order;
     submit.draw_count = static_cast<uint32_t>(std::min<size_t>(state.draws.size(), UINT32_MAX));
     submit.dispatch_count = static_cast<uint32_t>(std::min<size_t>(state.dispatches.size(), UINT32_MAX));
+    submit.dma_copy_count = static_cast<uint32_t>(
+        std::min<size_t>(state.dma_copies.size(), UINT32_MAX));
+    submit.capture_incomplete = !state.dma_copies.empty();
     submit.first_command_order = std::numeric_limits<uint64_t>::max();
     const bool log_mrt = select_timeline_mrt_submit(state, submit_no);
     for (size_t draw_index = 0; draw_index < state.draws.size(); ++draw_index) {
@@ -1436,6 +1449,10 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     for (const auto& dispatch : state.dispatches) {
         submit.first_command_order = std::min(submit.first_command_order, dispatch.command_order);
         submit.last_command_order = std::max(submit.last_command_order, dispatch.command_order);
+    }
+    for (const auto& dma : state.dma_copies) {
+        submit.first_command_order = std::min(submit.first_command_order, dma.command_order);
+        submit.last_command_order = std::max(submit.last_command_order, dma.command_order);
     }
     if (submit.first_command_order == std::numeric_limits<uint64_t>::max())
         submit.first_command_order = submit.last_command_order = 0;

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -59,11 +59,15 @@ struct GpuTimelineSubmit {
     uint64_t color0_base = 0;
     uint32_t draw_count = 0;
     uint32_t dispatch_count = 0;
+    uint32_t dma_copy_count = 0;
     uint32_t color0_width = 0;
     uint32_t color0_height = 0;
     std::vector<GpuTimelineDepthSurface> depth_surfaces;
     std::vector<GpuTimelineTargetSpan> target_spans;
     bool target_spans_truncated = false;
+    // Capture v13 has no ordered DMA record. The compact timeline remains truthful and selectable,
+    // but detailed capture of this submit must fail closed until #833 extends the format.
+    bool capture_incomplete = false;
 };
 
 // Shared by live detailed-capture selection and offline timeline inspection. A zero target extent

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -161,7 +161,7 @@ struct Pm4Command {
     // [0..1]=dst lo/hi, [2..3]=srcOrImm lo/hi, [4]=numBytes, [5]=sels (a2 | a3<<8),
     // [6..7]=the destination qword captured at build time (stale-generation identity, #312).
     uint64_t dd_dst = 0;                 // DmaData: destination address
-    uint64_t dd_src = 0;                 // DmaData: source address OR immediate value
+    uint64_t dd_src = 0;                 // DmaData: mapped 64-bit source address OR 32-bit immediate
     uint32_t dd_bytes = 0;               // DmaData: byte count (0 = unrecovered -> not executed)
     uint32_t dd_sels = 0;                // DmaData: raw selector args (a2 | a3<<8)
     bool     dd_valid = false;           // DmaData: payload carried the full operand set

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1147,6 +1147,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
     agc_gpu_state().dma_copies.clear();
+    agc_gpu_state().ordered_memory_effects.clear();
     gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
@@ -1240,6 +1241,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
     agc_gpu_state().dma_copies.clear();
+    agc_gpu_state().ordered_memory_effects.clear();
     gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1147,6 +1147,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
     agc_gpu_state().dma_copies.clear();
+    agc_gpu_state().dma_execution_rejected = false;
     agc_gpu_state().ordered_memory_effects.clear();
     gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
@@ -1241,6 +1242,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
     agc_gpu_state().dma_copies.clear();
+    agc_gpu_state().dma_execution_rejected = false;
     agc_gpu_state().ordered_memory_effects.clear();
     gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1082,8 +1082,14 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
         std::chrono::steady_clock::now() - render_sampling_t0).count();
     const unsigned cadence = render_every_for_ms > 0 && sampling_elapsed_ms >= render_every_for_ms
         ? 1u : render_every;
-    const bool render = gpu::have_submit_renderer() && !st.draws.empty() &&
-                        (draw_submits++ % cadence) == 0;
+    // A retained copy may read pixels produced by an earlier draw in this submit. Sampling cadence
+    // cannot discard that producer and then let DMA read the previous cached target version.
+    const bool ordered_dma_requires_render = !st.dma_copies.empty() && !st.draws.empty();
+    bool render = false;
+    if (gpu::have_submit_renderer() && !st.draws.empty()) {
+        const bool cadence_render = (draw_submits++ % cadence) == 0;
+        render = ordered_dma_requires_render || cadence_render;
+    }
     if (!render) {
         if ((!st.dispatches.empty() || !st.dma_copies.empty()) &&
             !gpu::execute_nonrender_submit_work(st, submit_no) && getenv("PROSPER_COMPUTELOG"))

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -364,7 +364,8 @@ HLE(agc_cb_nop) {  // (dcb, num_dwords, ...)
 // Custom R_DMA_DATA payload: [1..2]=dst lo/hi, [3..4]=srcOrImm lo/hi, [5]=numBytes, [6]=sels,
 // [7..8]=the destination qword when this exact packet was built (#312 generation identity).
 // CONFIDENCE: HIGH on a4=dst/a1=srcOrImm (malloc-destination callsite + patcher names + protocol);
-// MED on the selector args (recorded raw; the executor only honors the small-immediate form).
+// MED on the selector args (recorded raw; the executor distinguishes the captured 32-bit immediate
+// domain from mapped 64-bit address sources and keeps GDS/unmapped forms fail-closed).
 static uint64_t label_build_pre(uint64_t dst, uint64_t num_bytes) {
     uint64_t pre = 0;
     if (num_bytes <= 8 && dst >= 0x10000 && !(dst & 3) && gpu::guest_readable(dst, sizeof pre))

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1085,8 +1085,8 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
     const bool render = gpu::have_submit_renderer() && !st.draws.empty() &&
                         (draw_submits++ % cadence) == 0;
     if (!render) {
-        if (gpu::have_submit_compute() && !st.dispatches.empty() &&
-            !gpu::execute_compute_dispatches(st, submit_no) && getenv("PROSPER_COMPUTELOG"))
+        if ((!st.dispatches.empty() || !st.dma_copies.empty()) &&
+            !gpu::execute_nonrender_submit_work(st, submit_no) && getenv("PROSPER_COMPUTELOG"))
             fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
                     (unsigned long long)submit_no);
         return false;
@@ -1140,6 +1140,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
+    agc_gpu_state().dma_copies.clear();
     gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(addr, walk, agc_gpu_state());
     g_submit_count++;
@@ -1232,6 +1233,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
     agc_gpu_state().dispatches.clear();
+    agc_gpu_state().dma_copies.clear();
     gpu::begin_gpu_timeline_submit(g_submit_count + 1);
     size_t applied = gpu::run_command_buffer(p->addr, p->dw_num, agc_gpu_state());
     g_submit_count++;

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1163,7 +1163,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     // stays alive (the naive always-pulse variant let the scan free live labels; the naive
     // never-pulse variant starved the pacer — both measured).
     gpu::flush_deferred_streams();
-    gpu::submit_completion_pulse();
+    gpu::submit_completion_pulse(agc_gpu_state().dma_execution_rejected);
     // Watchdog keys off PENDING streams, not just this fold: streams can outlive their fold (and
     // the Jump-recursion flag reset once hid a deferring fold entirely — the wedge class).
     if (gpu::deferred_pending()) start_defer_watchdog();
@@ -1256,7 +1256,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     // #312 EOP visibility contract: pulse only when no gated writes are pending, else owed until
     // the tail drains (see submit_dcb_stream / command_processor.cpp).
     gpu::flush_deferred_streams();
-    gpu::submit_completion_pulse();
+    gpu::submit_completion_pulse(agc_gpu_state().dma_execution_rejected);
     if (gpu::deferred_pending()) start_defer_watchdog();
     if (getenv("PROSPER_GFXLOG")) {
         fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu, dispatches total: %llu)\n",

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -780,6 +780,116 @@ inline bool submit_persistent_ds_transfer(const RenderVkCtx& ctx, VkImage image,
     return true;
 }
 
+// Materialize a valid GPU-only color target on demand. Ordered DMA may consume a target in a later
+// submit, which the producing render callback cannot predict; keeping the fast no-readback path and
+// synchronizing only at that consumer preserves both the persistent-target contract and DMA versioning.
+inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32_t height,
+                                             VkFormat format, std::vector<uint8_t>& output,
+                                             std::string& error) {
+    output.clear(); error.clear();
+    format = backend_color_format(format);
+    PersistentColorTargetImage* target = find_persistent_color_target(
+        id, width, height, format);
+    if (!target || !target->image || target->layout == VK_IMAGE_LAYOUT_UNDEFINED) {
+        error = "persistent color target is unavailable";
+        return false;
+    }
+    target->last_use = ++persistent_color_target_generation();
+    const uint64_t texels = static_cast<uint64_t>(width) * height;
+    const uint64_t bpp = backend_color_bytes_per_pixel(format);
+    if (!width || !height || !bpp || texels > UINT64_MAX / bpp || texels * bpp > SIZE_MAX) {
+        error = "persistent color target byte size is invalid";
+        return false;
+    }
+    const VkDeviceSize bytes = static_cast<VkDeviceSize>(texels * bpp);
+    const RenderVkCtx& ctx = render_vk_ctx();
+    if (!ctx.ok) { error = "Vulkan renderer is unavailable"; return false; }
+
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    if (!persistent_ds_transfer_buffer(ctx, bytes, VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                       buffer, memory, error)) {
+        error = "cannot allocate persistent color target readback buffer";
+        return false;
+    }
+    VkCommandPool pool = VK_NULL_HANDLE;
+    VkCommandBuffer command = VK_NULL_HANDLE;
+    VkFence fence = VK_NULL_HANDLE;
+    auto cleanup = [&] {
+        if (fence) vkDestroyFence(ctx.dev, fence, nullptr);
+        if (pool) vkDestroyCommandPool(ctx.dev, pool, nullptr);
+        if (buffer) vkDestroyBuffer(ctx.dev, buffer, nullptr);
+        if (memory) vkFreeMemory(ctx.dev, memory, nullptr);
+    };
+    VkCommandPoolCreateInfo pool_info{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+    pool_info.queueFamilyIndex = ctx.qfi;
+    if (vkCreateCommandPool(ctx.dev, &pool_info, nullptr, &pool) != VK_SUCCESS) {
+        cleanup(); error = "cannot create persistent color target readback command pool"; return false;
+    }
+    VkCommandBufferAllocateInfo command_info{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+    command_info.commandPool = pool;
+    command_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    command_info.commandBufferCount = 1;
+    VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    if (vkAllocateCommandBuffers(ctx.dev, &command_info, &command) != VK_SUCCESS ||
+        vkBeginCommandBuffer(command, &begin) != VK_SUCCESS) {
+        cleanup(); error = "cannot begin persistent color target readback command"; return false;
+    }
+
+    const VkImageLayout saved_layout = target->layout;
+    VkImageMemoryBarrier barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    barrier.oldLayout = saved_layout;
+    barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = target->image;
+    barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                            VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                         0, nullptr, 0, nullptr, 1, &barrier);
+    VkBufferImageCopy copy{};
+    copy.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy.imageExtent = {width, height, 1};
+    vkCmdCopyImageToBuffer(command, target->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           buffer, 1, &copy);
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barrier.newLayout = saved_layout;
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
+                         0, nullptr, 0, nullptr, 1, &barrier);
+
+    VkFenceCreateInfo fence_info{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    const bool recorded = vkEndCommandBuffer(command) == VK_SUCCESS;
+    const bool fenced = recorded &&
+        vkCreateFence(ctx.dev, &fence_info, nullptr, &fence) == VK_SUCCESS;
+    VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    submit.commandBufferCount = 1; submit.pCommandBuffers = &command;
+    const bool submitted = fenced && vkQueueSubmit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
+    bool finished = submitted &&
+        vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000) == VK_SUCCESS;
+    if (submitted && !finished) finished = vkQueueWaitIdle(ctx.queue) == VK_SUCCESS;
+    if (!finished) {
+        cleanup(); error = "persistent color target readback did not complete"; return false;
+    }
+    void* mapped = nullptr;
+    if (vkMapMemory(ctx.dev, memory, 0, bytes, 0, &mapped) != VK_SUCCESS || !mapped) {
+        cleanup(); error = "cannot map persistent color target readback"; return false;
+    }
+    const auto* first = static_cast<const uint8_t*>(mapped);
+    output.assign(first, first + static_cast<size_t>(bytes));
+    vkUnmapMemory(ctx.dev, memory);
+    ++backend_color_target_stats_storage().readbacks;
+    cleanup();
+    return true;
+}
+
 inline bool snapshot_persistent_ds_images(std::vector<prosper::gpu::GpuCaptureDsSeed>& seeds,
                                           std::string& error) {
     error.clear(); seeds.clear();

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -26,7 +26,7 @@ static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
 }
 constexpr uint32_t IT_NOP = 0x10, IT_NUM_INSTANCES = 0x2F, IT_SET_SH_REG = 0x76,
                    R_DRAW_RESET = 0x05, R_PUSH_MARKER = 0x0b, R_POP_MARKER = 0x0c,
-                   R_CX_REGS_INDIRECT = 0x12;
+                   R_CX_REGS_INDIRECT = 0x12, R_DMA_DATA = 0x19;
 
 struct ShaderRegister { uint32_t offset, value; };
 
@@ -38,8 +38,10 @@ int main() {
     auto setcx  = Hle::lookup("ZvwO9euwYzc");   // GraphicsDcbSetCxRegistersIndirect
     auto p_add  = Hle::lookup("d-6uF9sZDIU");   // SetCxRegIndirectPatchAddRegisters
     auto p_addr = Hle::lookup("vcmNN+AAXnY");   // SetCxRegIndirectPatchSetAddress
-    CHECK(reset && setcx && p_add && p_addr, "AGC Dcb functions registered (override the glog stubs)");
-    if (!(reset && setcx && p_add && p_addr)) { printf("== FAIL ==\n"); return 1; }
+    auto p_dma_src = Hle::lookup("cdDRpqcFGbU"); // DmaDataPatchSetSrcAddressOrOffsetOrImmediate
+    CHECK(reset && setcx && p_add && p_addr && p_dma_src,
+          "AGC Dcb functions registered (override the glog stubs)");
+    if (!(reset && setcx && p_add && p_addr && p_dma_src)) { printf("== FAIL ==\n"); return 1; }
 
     uint32_t buffer[256];
     memset(buffer, 0xEE, sizeof buffer);
@@ -70,6 +72,21 @@ int main() {
     CHECK(cmd[1] == 8, "PatchAddRegisters did cmd[1] += 5 (3 -> 8)");
     p_addr(rc, 0xAABBCCDD00112233ull, 0, 0, 0, 0);
     CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu, "PatchSetAddress rewrote cmd[2]/cmd[3]");
+
+    // sceAgcDmaDataPatchSetSrcAddressOrOffsetOrImmediate (#189): patch only the source qword of
+    // a verified DMA_DATA packet. A wrong packet kind must remain untouched.
+    uint32_t dma[9] = {};
+    dma[0] = PM4(9, IT_NOP, R_DMA_DATA);
+    dma[1] = 0x11111111u; dma[2] = 0x22222222u; // destination must survive the source patch
+    p_dma_src((uint64_t)(uintptr_t)dma, 0xAABBCCDD00112233ull, 0, 0, 0, 0);
+    CHECK(dma[1] == 0x11111111u && dma[2] == 0x22222222u,
+          "DmaData source patch leaves the destination address untouched");
+    CHECK(dma[3] == 0x00112233u && dma[4] == 0xAABBCCDDu,
+          "DmaData source patch writes the complete 64-bit source address");
+    uint32_t wrong_packet[5] = {PM4(5, IT_NOP, R_CX_REGS_INDIRECT), 1, 2, 3, 4};
+    p_dma_src((uint64_t)(uintptr_t)wrong_packet, 0xDEADBEEFCAFEBABEull, 0, 0, 0, 0);
+    CHECK(wrong_packet[1] == 1 && wrong_packet[2] == 2 && wrong_packet[3] == 3 && wrong_packet[4] == 4,
+          "DmaData source patch rejects a non-DMA packet without modifying it");
 
     // sceAgcGetDataPacketPayloadAddress (#140): resolves a data packet to its register-bank payload.
     // Type 0 is NOP header + metadata; type 1 is register header + offset. Both payloads start +2.

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -196,6 +196,48 @@ int main() {
               "DMA_DATA notified renderer caches about the guest-memory write");
     }
 
+    // A queued upload before an address copy is the copy's ordered prefix. The first retained copy
+    // must drain it before execution; otherwise a compute-only/non-render submit can copy stale bytes.
+    {
+        uint32_t source = 0;
+        uint32_t target = 0;
+        const uint64_t src = (uint64_t)(uintptr_t)&source;
+        const uint64_t dst = (uint64_t)(uintptr_t)&target;
+        uint32_t stream[13] = {};
+        stream[0] = PM4(6, IT_NOP, R_WRITE_DATA);
+        stream[1] = 0;
+        stream[2] = (uint32_t)src; stream[3] = (uint32_t)(src >> 32);
+        stream[4] = 1; stream[5] = 0x13579BDFu;
+        stream[6] = PM4(7, IT_NOP, R_DMA_DATA);
+        stream[7] = (uint32_t)dst; stream[8] = (uint32_t)(dst >> 32);
+        stream[9] = (uint32_t)src; stream[10] = (uint32_t)(src >> 32);
+        stream[11] = sizeof(source); stream[12] = 0;
+        GpuState st; run_cb(stream, 13, st);
+        CHECK(source == 0x13579BDFu && target == source,
+              "WRITE_DATA prefix lands before a later address DMA in a non-render submit");
+    }
+
+    // Conversely, a later immediate DMA fill must not enter the completion FIFO and overtake an
+    // earlier retained copy. Keeping the suffix in command_order leaves the destination filled.
+    {
+        uint32_t source = 0xA5C31E79u;
+        uint32_t target = 0xFFFFFFFFu;
+        const uint64_t src = (uint64_t)(uintptr_t)&source;
+        const uint64_t dst = (uint64_t)(uintptr_t)&target;
+        uint32_t stream[14] = {};
+        stream[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        stream[1] = (uint32_t)dst; stream[2] = (uint32_t)(dst >> 32);
+        stream[3] = (uint32_t)src; stream[4] = (uint32_t)(src >> 32);
+        stream[5] = sizeof(source); stream[6] = 0;
+        stream[7] = PM4(7, IT_NOP, R_DMA_DATA);
+        stream[8] = (uint32_t)dst; stream[9] = (uint32_t)(dst >> 32);
+        stream[10] = 0; stream[11] = 0;
+        stream[12] = sizeof(target); stream[13] = 0;
+        GpuState st; run_cb(stream, 14, st);
+        CHECK(st.ordered_memory_effects.size() == 1 && target == 0,
+              "immediate DMA suffix executes after an earlier address copy without FIFO reversal");
+    }
+
     // A malformed/unmapped address source is not an immediate value merely because the destination
     // is valid. It must fail closed without touching the target or notifying renderer caches.
     {

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -212,9 +212,47 @@ int main() {
         stream[7] = (uint32_t)dst; stream[8] = (uint32_t)(dst >> 32);
         stream[9] = (uint32_t)src; stream[10] = (uint32_t)(src >> 32);
         stream[11] = sizeof(source); stream[12] = 0;
+        bool source_invalidated = false;
+        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t) {
+            if (addr == src) source_invalidated = true;
+        });
+        set_live_target_byte_range_reader(
+            [&](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+                if (addr != src || bytes != sizeof(source))
+                    return LiveTargetByteReadResult::NotFound;
+                if (source_invalidated) return LiveTargetByteReadResult::NotFound;
+                const uint32_t stale = 0xAAAAAAAAu;
+                const auto* begin = reinterpret_cast<const uint8_t*>(&stale);
+                output.assign(begin, begin + sizeof(stale));
+                return LiveTargetByteReadResult::Success;
+            });
         GpuState st; run_cb(stream, 13, st);
-        CHECK(source == 0x13579BDFu && target == source,
-              "WRITE_DATA prefix lands before a later address DMA in a non-render submit");
+        set_live_target_byte_range_reader({});
+        set_guest_gpu_write_observer({});
+        CHECK(source_invalidated && source == 0x13579BDFu && target == source,
+              "WRITE_DATA prefix invalidates a renderer-owned source before later address DMA");
+    }
+
+    // Guest-memory consumers that are folded eagerly cannot observe a preceding retained DMA.
+    // Preserve the DMA in diagnostics, but reject the entire submit instead of snapshotting stale
+    // indirect registers and then executing a misleading partial timeline.
+    {
+        ShaderReg source_reg{0x44, 0xA1B2C3D4u};
+        ShaderReg target_reg{0x44, 0x11111111u};
+        const uint64_t src = (uint64_t)(uintptr_t)&source_reg;
+        const uint64_t dst = (uint64_t)(uintptr_t)&target_reg;
+        uint32_t stream[11] = {};
+        stream[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        stream[1] = (uint32_t)dst; stream[2] = (uint32_t)(dst >> 32);
+        stream[3] = (uint32_t)src; stream[4] = (uint32_t)(src >> 32);
+        stream[5] = sizeof(source_reg); stream[6] = 0;
+        stream[7] = PM4(4, IT_NOP, R_SH_REGS_INDIRECT);
+        stream[8] = 1; stream[9] = (uint32_t)dst; stream[10] = (uint32_t)(dst >> 32);
+        GpuState st; run_cb(stream, 11, st);
+        CHECK(st.dma_copies.size() == 1 && st.dma_execution_rejected,
+              "DMA before indirect registers is retained and rejected fail-closed");
+        CHECK(target_reg.value == 0x11111111u && st.sh.find(0x44) == st.sh.end(),
+              "rejected DMA/indirect submit executes neither copy nor stale register fold");
     }
 
     // Conversely, a later immediate DMA fill must not enter the completion FIFO and overtake an

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -38,6 +38,7 @@ static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
 // guest-visible at a drain point — tests assert the guest-visible (post-drain) state.
 static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
     size_t n = run_command_buffer(buf, dwords, st);
+    execute_nonrender_submit_work(st);
     prosper_gpu_drain_completion_writes();
     return n;
 }
@@ -185,6 +186,8 @@ int main() {
         GpuState st; run_cb(dma, 7, st);
         set_guest_gpu_write_observer({});
 
+        CHECK(st.dma_copies.size() == 1 && st.dma_copies[0].command_order > 0,
+              "address-backed DMA_DATA is retained as an ordered submit operation");
         CHECK(memcmp(target + 3, source + 1, 17) == 0,
               "DMA_DATA copied the exact address-backed byte span");
         CHECK(target[2] == 0xCC && target[20] == 0xCC,

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -5,11 +5,18 @@
 // builders themselves read SysV stack args via __builtin_frame_address, only valid under the loaded
 // game) and asserts run_command_buffer writes the right bytes to the target address.
 #include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/mb3_freelist.hpp"
 #include "../src/gpu/pm4_decode.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 using namespace prosper::gpu;
 
@@ -152,6 +159,109 @@ int main() {
         GpuState st;
         size_t n = run_cb(buf, 4, st);    // must not fault / write anywhere
         CHECK(n == 1, "address-less EVENT_WRITE decodes and is a harmless no-op");
+    }
+
+    // #189: an address-backed DMA_DATA packet copies the exact requested byte span at submit.
+    // Use deliberately unaligned byte ranges so this covers the API's byte-count contract rather
+    // than accidentally depending on dword-sized data.
+    {
+        alignas(8) uint8_t source[24] = {};
+        alignas(8) uint8_t target[24];
+        for (uint32_t i = 0; i < sizeof(source); ++i) source[i] = (uint8_t)(0x30u + i);
+        memset(target, 0xCC, sizeof(target));
+        const uint64_t src = (uint64_t)(uintptr_t)(source + 1);
+        const uint64_t dst = (uint64_t)(uintptr_t)(target + 3);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = (uint32_t)dst; dma[2] = (uint32_t)(dst >> 32);
+        dma[3] = (uint32_t)src; dma[4] = (uint32_t)(src >> 32);
+        dma[5] = 17;
+        dma[6] = 0; // selectors are retained for diagnostics; both endpoints are mapped memory
+
+        uint64_t observed_addr = 0, observed_size = 0;
+        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+            observed_addr = addr; observed_size = size;
+        });
+        GpuState st; run_cb(dma, 7, st);
+        set_guest_gpu_write_observer({});
+
+        CHECK(memcmp(target + 3, source + 1, 17) == 0,
+              "DMA_DATA copied the exact address-backed byte span");
+        CHECK(target[2] == 0xCC && target[20] == 0xCC,
+              "DMA_DATA did not write before or after the requested byte span");
+        CHECK(observed_addr == dst && observed_size == 17,
+              "DMA_DATA notified renderer caches about the guest-memory write");
+    }
+
+    // A malformed/unmapped address source is not an immediate value merely because the destination
+    // is valid. It must fail closed without touching the target or notifying renderer caches.
+    {
+        uint64_t target = 0x8877665544332211ull;
+        const uint64_t dst = (uint64_t)(uintptr_t)&target;
+        const uint64_t bad_src = 0x00000DEADBEEF000ull;
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = (uint32_t)dst; dma[2] = (uint32_t)(dst >> 32);
+        dma[3] = (uint32_t)bad_src; dma[4] = (uint32_t)(bad_src >> 32);
+        dma[5] = 8;
+        bool notified = false;
+        set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+        GpuState st; run_cb(dma, 7, st);
+        set_guest_gpu_write_observer({});
+        CHECK(target == 0x8877665544332211ull,
+              "DMA_DATA skips an unmapped address source without modifying the destination");
+        CHECK(!notified, "a skipped DMA_DATA copy does not report a guest-memory write");
+    }
+
+    // A mapped but read-only destination is readable, so source/destination mappedness alone is
+    // insufficient. The executor must reject it before memmove instead of taking a host fault.
+    {
+#ifdef _WIN32
+        SYSTEM_INFO sys{}; GetSystemInfo(&sys);
+        const size_t page_size = sys.dwPageSize;
+        uint8_t* page = (uint8_t*)VirtualAlloc(nullptr, page_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+#else
+        const size_t page_size = (size_t)sysconf(_SC_PAGESIZE);
+        uint8_t* page = (uint8_t*)mmap(nullptr, page_size, PROT_READ | PROT_WRITE,
+                                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (page == MAP_FAILED) page = nullptr;
+#endif
+        CHECK(page != nullptr, "allocated a page for the read-only DMA destination guard");
+        if (page) {
+            memset(page, 0x5A, page_size);
+#ifdef _WIN32
+            DWORD old_protect = 0;
+            const bool protected_read_only =
+                VirtualProtect(page, page_size, PAGE_READONLY, &old_protect) != 0;
+#else
+            const bool protected_read_only = mprotect(page, page_size, PROT_READ) == 0;
+#endif
+            CHECK(protected_read_only, "made the DMA destination page read-only");
+            if (protected_read_only) {
+                uint64_t source = 0x0123456789ABCDEFull;
+                const uint64_t src = (uint64_t)(uintptr_t)&source;
+                const uint64_t dst = (uint64_t)(uintptr_t)page;
+                uint32_t dma[7] = {};
+                dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+                dma[1] = (uint32_t)dst; dma[2] = (uint32_t)(dst >> 32);
+                dma[3] = (uint32_t)src; dma[4] = (uint32_t)(src >> 32);
+                dma[5] = sizeof(source);
+                bool notified = false;
+                set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+                GpuState st; run_cb(dma, 7, st);
+                set_guest_gpu_write_observer({});
+                CHECK(page[0] == 0x5A && page[sizeof(source) - 1] == 0x5A,
+                      "DMA_DATA skips a read-only destination without modifying it");
+                CHECK(!notified, "a read-only DMA destination does not report a guest-memory write");
+            }
+#ifdef _WIN32
+            DWORD ignored = 0; VirtualProtect(page, page_size, PAGE_READWRITE, &ignored);
+            VirtualFree(page, 0, MEM_RELEASE);
+#else
+            mprotect(page, page_size, PROT_READ | PROT_WRITE);
+            munmap(page, page_size);
+#endif
+        }
     }
 
     // #312: learn a per-thread MB3 pool array from pthread TLS and detect a 0x20-byte block in both

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -444,6 +444,31 @@ int main() {
               reinterpret_cast<const uint8_t*>(kDiagnosticBadPs), sizeof(kDiagnosticBadPs)),
           "failed stage retains the exact content-addressed raw stream through s_endpgm");
 
+    GpuState dma_state;
+    dma_state.dma_copies.push_back({0x200000, 0x100000000ull, 16, 0, 55, 0});
+    GpuCaptureFile unsupported_capture;
+    error.clear();
+    CHECK(!capture_gpustate_submit(
+              dma_state, 100, 640, 360, meta, unsupported_capture, error) &&
+          error.find("cannot represent 1 ordered DMA_DATA") != std::string::npos,
+          "central GpuState capture rejects an incomplete ordered-DMA artifact");
+    error.clear();
+    CHECK(!capture_gpustate_target_submit(
+              dma_state, 100, 640, 360, 640, 360, meta, unsupported_capture, error) &&
+          error.find("capture would be incomplete") != std::string::npos,
+          "target-selected capture cannot bypass ordered-DMA rejection");
+
+    // A selected unsupported live capture must consume the selector match. Otherwise AT=0 silently
+    // shifts to the next ordinary submit and writes an artifact for the wrong requested operation.
+    set_test_env("PROSPER_GPU_CAPTURE", "unsupported-dma-selector.prgcap");
+    set_test_env("PROSPER_GPU_CAPTURE_AT", "0");
+    const auto unsupported_pending = begin_requested_gpu_capture({}, {}, {}, 1, 1, true);
+    const auto retargeted_pending = begin_requested_gpu_capture({}, {}, {}, 1, 1, false);
+    CHECK(!unsupported_pending && !retargeted_pending,
+          "unsupported selected DMA capture fails once and cannot retarget a later submit");
+    set_test_env("PROSPER_GPU_CAPTURE_AT", nullptr);
+    set_test_env("PROSPER_GPU_CAPTURE", nullptr);
+
     const auto failed_path = std::filesystem::temp_directory_path() /
         "prosper_gpu_capture_failed_diagnostic_test.prgcap";
     CHECK(write_gpu_capture(failed_path.string(), failed_capture, error),

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -267,6 +267,46 @@ int main() {
     }
 
     render_submit_items({producer}, W, H);
+    const uint64_t producer_center = producer.color0_base +
+        (static_cast<uint64_t>(producer.color0_width) + producer.color0_width / 2u) * 4u;
+    std::vector<uint8_t> producer_range;
+    CHECK(read_live_render_target_bytes(producer_center, 4, producer_range) ==
+              LiveTargetByteReadResult::Success && producer_range.size() == 4,
+          "live renderer exposes a bounded interior byte range from its authoritative target");
+    std::vector<uint8_t> invalid_range;
+    CHECK(read_live_render_target_bytes(
+              producer.color0_base + producer.color0_width * producer.color0_height * 4u - 2u,
+              4, invalid_range) == LiveTargetByteReadResult::InvalidRange,
+          "live renderer rejects a source range that crosses the native target boundary");
+
+    uint8_t copied_target[4] = {};
+    GpuState ordered_state;
+    GpuState::Draw semantic_producer;
+    semantic_producer.command_order = 100;
+    ordered_state.draws.push_back(semantic_producer);
+    DrawItem ordered_producer = producer;
+    ordered_producer.color0_base = 0x100300000ull;
+    ordered_producer.draw_index = 0;
+    ordered_producer.command_order = 100;
+    const uint64_t ordered_center = ordered_producer.color0_base +
+        (static_cast<uint64_t>(ordered_producer.color0_width) +
+         ordered_producer.color0_width / 2u) * 4u;
+    ordered_state.dma_copies.push_back({
+        reinterpret_cast<uint64_t>(copied_target), ordered_center, sizeof copied_target,
+        0, 200, 0});
+    LiveRenderFn ordered_render = [](const std::vector<DrawItem>& items, uint32_t width,
+                                     uint32_t height) {
+        return render_submit_items(items, width, height);
+    };
+    execute_ordered_items(plan_submit_operations(ordered_state), {ordered_producer}, {},
+                          ordered_state.dma_copies, ordered_render, {}, W, H);
+    std::vector<uint8_t> ordered_range;
+    const bool ordered_source_read = read_live_render_target_bytes(
+        ordered_center, sizeof copied_target, ordered_range) == LiveTargetByteReadResult::Success;
+    CHECK(ordered_source_read && ordered_range.size() == sizeof copied_target &&
+          std::memcmp(copied_target, ordered_range.data(), sizeof copied_target) == 0,
+          "ordered DMA copies current bytes produced by the preceding live-render span");
+
     std::vector<uint8_t> cross_submit = render_submit_items({consumer}, W, H);
     CHECK(cross_submit.size() == static_cast<size_t>(16) * 16 * 4,
           "renderer retains a producer target across separate replay submits");

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -139,6 +139,63 @@ int main() {
               "write journal snapshots cannot suppress validation after submit completion");
     }
 
+    // #189: address-backed DMA is an in-stream producer, not a completion write. It must split a
+    // graphics span so an earlier consumer sees old bytes and a later consumer sees copied bytes.
+    {
+        uint8_t source = 0x39;
+        uint8_t target = 0x17;
+        GpuState mixed;
+        GpuState::Draw before, after;
+        before.command_order = 100;
+        after.command_order = 300;
+        mixed.draws = {before, after};
+        mixed.dma_copies.push_back({
+            (uint64_t)(uintptr_t)&target, (uint64_t)(uintptr_t)&source,
+            1, 0, 200, 0});
+        const auto operations = plan_submit_operations(mixed);
+
+        DrawItem first, second;
+        first.draw_index = 0;
+        second.draw_index = 1;
+        std::vector<uint8_t> observed;
+        LiveRenderFn consume = [&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            for (size_t i = 0; i < items.size(); ++i) observed.push_back(target);
+            return std::vector<uint8_t>(4, target);
+        };
+        const OrderedSubmitResult result = execute_ordered_items(
+            operations, {first, second}, {}, mixed.dma_copies, consume, {}, 1, 1);
+        CHECK(observed == std::vector<uint8_t>({0x17, 0x39}) && target == source,
+              "ordered DMA exposes old bytes before the copy and new bytes afterward");
+        CHECK(result.render_spans == 2,
+              "an ordered DMA copy splits graphics consumers into two render spans");
+    }
+
+    // A no-draw submit still executes DMA before a later compute consumer. The old completion-FIFO
+    // path left this copy pending because execute_submit_work's compute-only branch never drained it.
+    {
+        uint8_t source = 0xA5;
+        uint8_t target = 0x4C;
+        GpuState compute_only;
+        compute_only.dma_copies.push_back({
+            (uint64_t)(uintptr_t)&target, (uint64_t)(uintptr_t)&source,
+            1, 0, 100, 0});
+        GpuState::Dispatch dispatch;
+        dispatch.command_order = 200;
+        compute_only.dispatches.push_back(dispatch);
+        const auto operations = plan_submit_operations(compute_only);
+        ComputeItem consume;
+        consume.dispatch_index = 0;
+        uint8_t observed = 0;
+        LiveComputeFn compute = [&](const std::vector<ComputeItem>&) {
+            observed = target;
+            return true;
+        };
+        const OrderedSubmitResult result = execute_ordered_items(
+            operations, {}, {consume}, compute_only.dma_copies, {}, compute, 0, 0);
+        CHECK(result.compute_executed && observed == source && target == source,
+              "compute-only timeline executes a preceding DMA copy before its consumer");
+    }
+
     // Overflow or otherwise incomplete write history must fall back to exact validation.
     {
         DrawItem first, second;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -380,6 +380,38 @@ int main() {
     }
 
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
+    // #189: production submit execution must realize an indexed draw only after a preceding DMA
+    // supplies its index buffer. Callback ordering alone is insufficient because realization owns
+    // a copied index vector; the old eager path permanently captured {0,0,0} before DMA ran.
+    {
+        uint16_t copied_indices[3] = {0, 0, 0};
+        uint16_t source_indices[3] = {0, 1, 2};
+        GpuState ordered = st;
+        ordered.index_type = 0;
+        ordered.draws.clear();
+        ordered.dispatches.clear();
+        ordered.dma_copies.clear();
+        ordered.ordered_memory_effects.clear();
+        GpuState::Draw draw;
+        draw.index_count = 3;
+        draw.indexed = true;
+        draw.index_addr = (uint64_t)(uintptr_t)copied_indices;
+        draw.command_order = 200;
+        ordered.draws.push_back(draw);
+        ordered.dma_copies.push_back({
+            (uint64_t)(uintptr_t)copied_indices, (uint64_t)(uintptr_t)source_indices,
+            sizeof(copied_indices), 0, 100, 0});
+        std::vector<uint32_t> submitted_indices;
+        set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            if (!items.empty()) submitted_indices = items.front().indices;
+            return RenderedFrame{};
+        });
+        execute_ordered_and_present(ordered, W, H, 77, /*publish=*/false);
+        set_submit_renderer({});
+        CHECK(submitted_indices == std::vector<uint32_t>({0, 1, 2}),
+              "DMA-backed index buffer is realized after the ordered copy in the production path");
+    }
+
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");
     std::shared_ptr<const std::vector<uint8_t>> live_storage;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -412,6 +412,50 @@ int main() {
               "DMA-backed index buffer is realized after the ordered copy in the production path");
     }
 
+    // Lazy realization can drop a semantic draw only after earlier spans have already executed.
+    // If the dropped record was counted as the final span, send an empty terminal callback so the
+    // renderer finalizes cached scanout rather than losing the successful work or hanging timing.
+    for (bool failed_first : {false, true}) {
+        uint8_t source = 0x7A, target = 0;
+        GpuState ordered = st;
+        ordered.draws.clear();
+        ordered.dma_copies.clear();
+        GpuState::Draw good{3};
+        GpuState::Draw bad{0};
+        if (failed_first) {
+            bad.command_order = 100;
+            good.command_order = 300;
+            ordered.draws = {bad, good};
+        } else {
+            good.command_order = 100;
+            bad.command_order = 300;
+            ordered.draws = {good, bad};
+        }
+        ordered.dma_copies.push_back({
+            (uint64_t)(uintptr_t)&target, (uint64_t)(uintptr_t)&source,
+            sizeof(target), 0, 200, 0});
+        std::vector<LiveRenderPhase> phases;
+        size_t realized_callbacks = 0, terminal_callbacks = 0;
+        set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            phases.push_back(live_render_phase());
+            if (items.empty()) {
+                terminal_callbacks++;
+                return RenderedFrame(std::vector<uint8_t>(4, 0x5A));
+            }
+            realized_callbacks++;
+            return RenderedFrame{};
+        });
+        execute_ordered_and_present(ordered, 1, 1, 78 + failed_first, /*publish=*/false);
+        set_submit_renderer({});
+        CHECK(realized_callbacks == 1 && terminal_callbacks == 1 && phases.size() == 2,
+              failed_first
+                  ? "failed leading span still finalizes the later successful span"
+                  : "failed trailing span still finalizes the earlier successful span");
+        CHECK(phases[0].first_span && !phases[0].final_span &&
+              !phases[1].first_span && phases[1].final_span,
+              "lazy-span terminal callback closes the submit exactly once");
+    }
+
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");
     CHECK(!execute_and_present(st, W, H), "execute_and_present is a no-op with no renderer registered");
     std::shared_ptr<const std::vector<uint8_t>> live_storage;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -158,8 +158,10 @@ int main() {
         first.draw_index = 0;
         second.draw_index = 1;
         std::vector<uint8_t> observed;
+        std::vector<LiveRenderPhase> dma_phases;
         LiveRenderFn consume = [&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
             for (size_t i = 0; i < items.size(); ++i) observed.push_back(target);
+            dma_phases.push_back(live_render_phase());
             return std::vector<uint8_t>(4, target);
         };
         const OrderedSubmitResult result = execute_ordered_items(
@@ -168,6 +170,49 @@ int main() {
               "ordered DMA exposes old bytes before the copy and new bytes afterward");
         CHECK(result.render_spans == 2,
               "an ordered DMA copy splits graphics consumers into two render spans");
+        CHECK(dma_phases.size() == 2 && dma_phases[0].authoritative_readback &&
+              !dma_phases[1].authoritative_readback,
+              "the graphics span immediately before DMA requests authoritative target readback");
+    }
+
+    // A rendered target's authoritative bytes can live only in the backend cache. Resolve the
+    // requested interior range after the preceding graphics span rather than reading stale/unmapped
+    // guest backing at the target address.
+    {
+        constexpr uint64_t live_base = 0x100000000ull;
+        const std::vector<uint8_t> live_pixels = {0x10, 0x21, 0x32, 0x43, 0x54, 0x65};
+        uint8_t target[3] = {0, 0, 0};
+        bool producer_rendered = false;
+        set_live_target_byte_range_reader(
+            [&](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+                if (addr < live_base || addr >= live_base + live_pixels.size())
+                    return LiveTargetByteReadResult::NotFound;
+                const uint64_t offset = addr - live_base;
+                if (!producer_rendered || bytes > live_pixels.size() - offset)
+                    return LiveTargetByteReadResult::InvalidRange;
+                output.assign(live_pixels.begin() + static_cast<size_t>(offset),
+                              live_pixels.begin() + static_cast<size_t>(offset + bytes));
+                return LiveTargetByteReadResult::Success;
+            });
+        GpuState state;
+        GpuState::Draw producer;
+        producer.command_order = 100;
+        state.draws.push_back(producer);
+        state.dma_copies.push_back({
+            (uint64_t)(uintptr_t)target, live_base + 2, sizeof target, 0, 200, 0});
+        DrawItem draw;
+        draw.draw_index = 0;
+        LiveRenderFn render = [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+            producer_rendered = true;
+            return std::vector<uint8_t>(4, 0xff);
+        };
+        execute_ordered_items(plan_submit_operations(state), {draw}, {}, state.dma_copies,
+                              render, {}, 1, 1);
+        CHECK(producer_rendered &&
+              std::vector<uint8_t>(target, target + sizeof target) ==
+                  std::vector<uint8_t>({0x32, 0x43, 0x54}),
+              "ordered DMA reads an interior range from the preceding live render target");
+        set_live_target_byte_range_reader({});
     }
 
     // A no-draw submit still executes DMA before a later compute consumer. The old completion-FIFO

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -40,6 +40,7 @@ int main() {
     first.submit_no = 10; first.process_command_order = 400; first.first_command_order = 390;
     first.last_command_order = 400; first.color0_base = 0x12340000; first.draw_count = 3;
     first.dispatch_count = 1; first.color0_width = 642; first.color0_height = 362;
+    first.dma_copy_count = 2; first.capture_incomplete = true;
     first.target_spans.push_back({0, 1, 642, 362});
     first.target_spans.push_back({1, 2, 738, 420});
     GpuTimelineSubmit invalid_spans = first;
@@ -106,7 +107,7 @@ int main() {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.version == 6 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+    CHECK(timeline.version == 7 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
           timeline.details.size() == 1 && timeline.producers.size() == 1,
           "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
@@ -116,6 +117,9 @@ int main() {
     CHECK(timeline.submits[0].color0_base == 0x12340000 &&
           timeline.submits[0].color0_width == 642 && timeline.submits[0].color0_height == 362,
           "target identity and extent round-trip");
+    CHECK(timeline.submits[0].dma_copy_count == 2 &&
+          timeline.submits[0].capture_incomplete,
+          "ordered-DMA count and incomplete-capture marker round-trip");
     CHECK(timeline.submits[0].depth_surfaces.size() == 1 &&
           timeline.submits[0].depth_surfaces[0].htile_data_base == 0x820000 &&
           timeline.submits[0].depth_surfaces[0].db_depth_size_xy == 0x01690281 &&
@@ -213,6 +217,8 @@ int main() {
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1", 1);
 #endif
     GpuState prestart_state;
+    prestart_state.command_order = 105;
+    prestart_state.dma_copies.push_back({0x200000, 0x100000000ull, 16, 0, 104, 0});
     begin_gpu_timeline_submit(40);
     record_gpu_timeline_submit(prestart_state, 40);
     GpuState predecessor_state;
@@ -243,6 +249,11 @@ int main() {
     CHECK(runtime_timeline.presents.size() == 1 && runtime_timeline.submits.size() == 3 &&
           runtime_timeline.presents[0].latest_submit_no == 42,
           "a flip during folding is associated with its active submit");
+    CHECK(runtime_timeline.submits[0].dma_copy_count == 1 &&
+          runtime_timeline.submits[0].capture_incomplete &&
+          runtime_timeline.submits[0].first_command_order == 104 &&
+          runtime_timeline.submits[0].last_command_order == 104,
+          "runtime compact timeline exposes ordered DMA and marks v13 capture incomplete");
     CHECK(runtime_timeline.submits[1].depth_surfaces.size() == 1 &&
           runtime_timeline.submits[1].depth_surfaces[0].depth_read_base == 0x700000 &&
           runtime_timeline.submits[1].depth_surfaces[0].htile_data_base == 0x820000 &&
@@ -273,6 +284,7 @@ int main() {
     GpuTimelineWriter compat_writer;
     GpuTimelineSubmit legacy_first = first;
     legacy_first.depth_surfaces.clear(); legacy_first.target_spans.clear();
+    legacy_first.dma_copy_count = 0; legacy_first.capture_incomplete = false;
     CHECK(compat_writer.open(compat_v2, metadata, error) && compat_writer.append_submit(legacy_first, error),
           "created a detail-free compatibility timeline");
     compat_writer.close();

--- a/prosper/tests/test_gpu_timeline_capture_exit.cpp
+++ b/prosper/tests/test_gpu_timeline_capture_exit.cpp
@@ -1,0 +1,56 @@
+#include "../src/gpu/gpu_timeline.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
+using namespace prosper::gpu;
+
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+static int run_child() {
+    set_test_env("PROSPER_GPU_TIMELINE", "timeline-capture-exit.prgtl");
+    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", "timeline-capture-endpoint.prgcap");
+    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "2");
+    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR",
+                 "timeline-capture-predecessor.prgcap");
+    set_test_env("PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE", "1");
+
+    GpuState predecessor;
+    predecessor.command_order = 10;
+    predecessor.dma_copies.push_back({0x200000, 0x100000000ull, 16, 0, 10, 0});
+    begin_gpu_timeline_submit(1);
+    record_gpu_timeline_submit(predecessor, 1);
+
+    GpuState endpoint;
+    endpoint.command_order = 20;
+    begin_gpu_timeline_submit(2);
+    record_gpu_timeline_submit(endpoint, 2);
+    return 0; // EXIT_AFTER_CAPTURE must have terminated with status 2 before this point.
+}
+
+int main(int argc, char** argv) {
+    if (argc > 1 && std::string(argv[1]) == "--child") return run_child();
+    const std::string command = std::string("\"") + argv[0] + "\" --child";
+    const int status = std::system(command.c_str());
+#ifdef _WIN32
+    const int exit_code = status;
+#else
+    const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
+    if (exit_code != 2) {
+        std::fprintf(stderr, "expected child exit 2 after predecessor capture failure, got %d\n",
+                     exit_code);
+        return 1;
+    }
+    return 0;
+}

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -252,11 +252,17 @@ int main() {
         std::vector<uint8_t> deferred = prosper::test::render_draws_rgba(
             {add_green}, W, H, nullptr, nullptr, false, &deferred_target);
         const auto deferred_stats = prosper::test::backend_color_target_stats();
+        std::vector<uint8_t> materialized;
+        std::string materialize_error;
+        const bool materialized_ok = prosper::test::readback_persistent_color_target(
+            target_id, W, H, VK_FORMAT_R8G8B8A8_UNORM, materialized, materialize_error);
         std::vector<uint8_t> deferred_sample = prosper::test::render_draws_rgba(
             {gpu_sample}, W, H);
         CHECK(deferred.empty() && deferred_stats.write_hits == 1 &&
                   deferred_stats.readbacks == 0,
               "persistent LOAD pass can complete without allocating a CPU readback");
+        CHECK(materialized_ok && materialized == cpu_accumulated,
+              "GPU-only persistent target can be materialized on demand for an ordered consumer");
         CHECK(!deferred_sample.empty() && deferred_sample == cpu_accumulated_sample,
               "deferred-readback accumulation matches the CPU reference after sampling");
 

--- a/prosper/tests/test_wait_barrier.cpp
+++ b/prosper/tests/test_wait_barrier.cpp
@@ -18,6 +18,7 @@
 //      guest polling a gated label can wait at most one timeout.
 //   6. A SATISFIED wait is a pass-through no-op (the fast path every healthy frame takes).
 #include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/pm4_decode.hpp"
 #include <cstdio>
 #include <cstdint>
@@ -52,6 +53,12 @@ static void emit_wait_eq(uint32_t* buf, uint64_t addr, uint64_t ref) {
     buf[3] = 0xffffffffu; buf[4] = 0;               // mask (low 32)
     buf[5] = (uint32_t)ref; buf[6] = (uint32_t)(ref >> 32);
     buf[7] = 3;                                     // compare function: ==
+}
+static void emit_dma_copy(uint32_t* buf, uint64_t dst, uint64_t src, uint32_t bytes) {
+    buf[0] = PM4(7, IT_NOP, R_DMA_DATA);
+    buf[1] = (uint32_t)dst; buf[2] = (uint32_t)(dst >> 32);
+    buf[3] = (uint32_t)src; buf[4] = (uint32_t)(src >> 32);
+    buf[5] = bytes; buf[6] = 0;
 }
 
 // Fold + drain the pipe-drain queue (upstream effects become guest-visible at a drain point).
@@ -183,6 +190,50 @@ int main() {
         CHECK(!last_fold_deferred(), "satisfied wait does not pause the stream");
         CHECK(!deferred_pending(), "no deferred stream created");
         CHECK(label == 1, "downstream effect flushed promptly");
+    }
+
+    // Address DMA cannot be released through the legacy deferred-effect path: that would drop it
+    // from ordered execution/capture metadata and bypass authoritative renderer source reads.
+    {
+        volatile uint64_t cond = 0;
+        uint64_t source = 0x123456789ABCDEF0ull;
+        uint64_t target = 0;
+        uint32_t stream[8 + 7];
+        emit_wait_eq(stream, (uint64_t)(uintptr_t)&cond, 1);
+        emit_dma_copy(stream + 8, (uint64_t)(uintptr_t)&target,
+                      (uint64_t)(uintptr_t)&source, sizeof(source));
+        GpuState st;
+        run_cb(stream, 15, st);
+        CHECK(st.dma_copies.size() == 1 && st.dma_execution_rejected,
+              "WAIT_DEFER-gated address DMA remains visible and rejects execution");
+        cond = 1;
+        flush_deferred_streams();
+        execute_nonrender_submit_work(st);
+        CHECK(target == 0,
+              "gated address DMA never escapes through the unordered legacy deferred path");
+    }
+
+    // A copy also depends on its source. A prior gated producer to S must prevent a later
+    // address DMA(S->D) from reading stale S even when D itself is in an unrelated domain.
+    {
+        volatile uint64_t cond = 0;
+        uint64_t source = 0, target = 0;
+        uint32_t producer[8 + 7];
+        emit_wait_eq(producer, (uint64_t)(uintptr_t)&cond, 1);
+        emit_release(producer + 8, (uint64_t)(uintptr_t)&source, 0x55AAu);
+        GpuState producer_state;
+        run_cb(producer, 15, producer_state);
+
+        uint32_t copy[7];
+        emit_dma_copy(copy, (uint64_t)(uintptr_t)&target,
+                      (uint64_t)(uintptr_t)&source, sizeof(source));
+        GpuState copy_state;
+        run_cb(copy, 7, copy_state);
+        CHECK(copy_state.dma_copies.size() == 1 && copy_state.dma_execution_rejected,
+              "address DMA rejects a dependency on a previously gated source range");
+        CHECK(target == 0, "source-dependent DMA cannot overtake the gated producer");
+        cond = 1;
+        flush_deferred_streams();
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_wait_barrier.cpp
+++ b/prosper/tests/test_wait_barrier.cpp
@@ -193,24 +193,25 @@ int main() {
     }
 
     // Address DMA cannot be released through the legacy deferred-effect path: that would drop it
-    // from ordered execution/capture metadata and bypass authoritative renderer source reads.
+    // from ordered execution/capture metadata and bypass authoritative renderer source reads. Its
+    // same-stream completion suffix must also be discarded, never signaling work that was rejected.
     {
         volatile uint64_t cond = 0;
-        uint64_t source = 0x123456789ABCDEF0ull;
-        uint64_t target = 0;
-        uint32_t stream[8 + 7];
+        uint64_t source = 0x123456789ABCDEF0ull, target = 0, completion = 0;
+        uint32_t stream[8 + 7 + 7];
         emit_wait_eq(stream, (uint64_t)(uintptr_t)&cond, 1);
         emit_dma_copy(stream + 8, (uint64_t)(uintptr_t)&target,
                       (uint64_t)(uintptr_t)&source, sizeof(source));
+        emit_release(stream + 15, (uint64_t)(uintptr_t)&completion, 1);
         GpuState st;
-        run_cb(stream, 15, st);
+        run_cb(stream, 22, st);
         CHECK(st.dma_copies.size() == 1 && st.dma_execution_rejected,
               "WAIT_DEFER-gated address DMA remains visible and rejects execution");
         cond = 1;
         flush_deferred_streams();
         execute_nonrender_submit_work(st);
-        CHECK(target == 0,
-              "gated address DMA never escapes through the unordered legacy deferred path");
+        CHECK(target == 0 && completion == 0,
+              "rejected gated DMA discards its deferred completion suffix without signaling");
     }
 
     // A copy also depends on its source. A prior gated producer to S must prevent a later

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -257,6 +257,8 @@ int main(int argc, char** argv) {
                     continue;
                 const std::string signature = "draws=" + std::to_string(submit.draw_count) +
                     " dispatches=" + std::to_string(submit.dispatch_count) +
+                    " dmas=" + std::to_string(submit.dma_copy_count) +
+                    " capture=" + (submit.capture_incomplete ? "incomplete" : "complete") +
                     " targets=" + target_signature(submit);
                 Stats& stats = grouped[signature];
                 ++stats.count;
@@ -317,12 +319,14 @@ int main(int argc, char** argv) {
         return matches ? 0 : 1;
     }
 
-    uint64_t last_ns = 0, draws = 0, dispatches = 0;
+    uint64_t last_ns = 0, draws = 0, dispatches = 0, dmas = 0, incomplete = 0;
     std::map<std::pair<uint32_t, uint32_t>, uint64_t> target_extents;
     for (const auto& submit : timeline.submits) {
         last_ns = std::max(last_ns, submit.elapsed_ns);
         draws += submit.draw_count;
         dispatches += submit.dispatch_count;
+        dmas += submit.dma_copy_count;
+        incomplete += submit.capture_incomplete;
         if (submit.color0_width && submit.color0_height)
             target_extents[{submit.color0_width, submit.color0_height}]++;
     }
@@ -332,10 +336,11 @@ int main(int argc, char** argv) {
                 timeline.version, timeline.metadata.revision.c_str(), timeline.metadata.title_id.c_str(),
                 timeline.metadata.input_route.c_str());
     std::printf("duration=%.3fs submits=%zu presents=%zu details=%zu producers=%zu "
-                "draws=%llu dispatches=%llu truncated_tail=%s\n",
+                "draws=%llu dispatches=%llu dmas=%llu capture_incomplete=%llu truncated_tail=%s\n",
                 seconds, timeline.submits.size(), timeline.presents.size(), timeline.details.size(),
                 timeline.producers.size(),
                 static_cast<unsigned long long>(draws), static_cast<unsigned long long>(dispatches),
+                static_cast<unsigned long long>(dmas), static_cast<unsigned long long>(incomplete),
                 timeline.truncated_tail ? "yes" : "no");
     if (seconds > 0)
         std::printf("rates submits=%.1f/s presents=%.1f/s\n",
@@ -394,10 +399,11 @@ int main(int argc, char** argv) {
             const uint64_t xs = xi < timeline.producers.size() ? timeline.producers[xi].sequence : UINT64_MAX;
             if (ss <= ps && ss <= ds && ss <= xs) {
                 const auto& s = timeline.submits[si++];
-                std::printf("%llu %.6f submit=%llu draws=%u dispatches=%u order=%llu..%llu "
-                            "target=%016llx/%ux%u\n",
+                std::printf("%llu %.6f submit=%llu draws=%u dispatches=%u dmas=%u capture=%s "
+                            "order=%llu..%llu target=%016llx/%ux%u\n",
                             static_cast<unsigned long long>(s.sequence), s.elapsed_ns / 1e9,
                             static_cast<unsigned long long>(s.submit_no), s.draw_count, s.dispatch_count,
+                            s.dma_copy_count, s.capture_incomplete ? "incomplete" : "complete",
                             static_cast<unsigned long long>(s.first_command_order),
                             static_cast<unsigned long long>(s.last_command_order),
                             static_cast<unsigned long long>(s.color0_base),


### PR DESCRIPTION
Fixes #189

## Failure and contract

The AGC builder/patcher and PM4 decoder retained a complete 64-bit DMA_DATA source, but execution deliberately skipped every non-immediate packet. Games could therefore submit a mapped GPU-memory copy and observe no destination update.

The exercised ABI uses values through UINT32_MAX as 32-bit immediate fills and 64-bit mapped addresses as copy sources. Raw selector values remain diagnostic only: Messenger's captured immediate-zero command uses selectors 3/3.

## Implementation

- Retain mapped address copies as first-class submit operations and merge them with draws, dispatches, and post-copy memory effects by PM4 command order.
- Drain the completion prefix at the first address copy; later WRITE_DATA, RELEASE_MEM, EVENT_WRITE, and immediate DMA_DATA effects remain in the ordered timeline.
- Realize each draw/dispatch only at its ordered position in DMA-bearing submits, after preceding producers and cache invalidation.
- Fail the backend submit closed when a retained copy would precede an eager guest-memory consumer (indirect registers, waits, jump/predication) or intersects WAIT_DEFER state. The DMA record remains visible to timeline/capture diagnostics.
- Poison a rejected WAIT_DEFER stream at the DMA boundary: preserve the valid prefix, discard its completion suffix, and suppress rejected-submit EOP completion.
- Read renderer-owned sources from authoritative bounded byte ranges. Same-submit producers force readback; later-submit persistent Vulkan targets materialize on demand without disabling the GPU-only target fast path.
- Invalidate renderer ownership at every successful modeled write point. Asynchronous completion workers enqueue invalidations for safe renderer-thread draining.
- Validate complete source/destination spans, fail closed on invalid mappings/ranges, use memmove for deterministic overlap, and preserve the established immediate-fill generation/freelist guards.
- Reject every DMA-bearing v13 capture entrypoint explicitly. Timeline v7 records DMA count/incomplete state; #833 tracks lossless DMA capture/replay.
- Aggregate predecessor/bundle capture failures into terminal status. EXIT_AFTER_CAPTURE exits 2 when any requested artifact fails.
- Explicitly finalize the last successful graphics span when a later lazily realized record fails, without replaying draws.

## Regression coverage

Focused tests cover:

- 64-bit patching and exact unaligned mapped copies
- invalid/unmapped/read-only spans and renderer notification
- draw -> DMA -> draw and DMA -> compute ordering
- renderer-owned exact/interior source readback and persistent-target materialization
- WRITE_DATA -> address DMA and address DMA -> immediate fill ordering
- production indexed-draw realization after DMA supplies indices
- prefix-write invalidation before a renderer-owned DMA source
- fail-closed DMA -> indirect-register, WAIT_DEFER gated-copy, and gated-source cases
- rejected WAIT_DEFER completion-suffix suppression
- successful-span finalization with failed lazy spans on either side
- direct/timeline capture rejection, selector non-retargeting, and predecessor failure exit 2
- timeline v7 roundtrip and legacy compatibility

## Author verification - exact head 68bdbabbd86758c55c36898cc15746476814abdf

- Linux full build and suite: 104/104 passed
- Windows MinGW full build and suite: 74/74 passed
- Exact routed snapshot matrix:
  - Messenger: 49/49 qualifying, structural, and nonblack matches; 14 pixel changes
  - Dead Cells: 49/49 qualifying, structural, and nonblack matches; 48 pixel changes
  - Blasphemous 2: 98/98 qualifying, structural, and nonblack matches; 97 pixel changes
- Live Messenger 30-second trace reached DcbDmaData and executed its 64 KiB immediate fill
- git diff --check: passed
- Verified base: master@b607eac782315701d4eb2c1f9402f00c3d223c00

## Risk

Confidence is HIGH for the project-observed immediate/address discriminator, mapped byte-copy semantics, modeled PM4 ordering, renderer ownership transitions, and capture failure signaling. Selector-specific GDS/offset behavior remains unmodeled and fails closed. Eager/deferred guest-memory interleavings also fail closed until they can be represented in the ordered executor. macOS mapped-span validation relies on the native mach_vm_region protection contract and is exercised by CI.