### PR TITLE
fix(snapshot): terminate game when harness dies

### DIFF
--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -29,7 +29,7 @@ window of normal composited screenshots, requires multiple frames to meet `min_c
 require visible pixel changes. Its pass/fail contract uses SSIM and content coverage to catch major
 collapse without rejecting subtle pixel improvements.
 """
-import sys, os, json, time, hashlib, math, struct, subprocess, tempfile, shutil, signal
+import sys, os, json, time, hashlib, math, struct, subprocess, tempfile, shutil, signal, ctypes
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PROSPER_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
@@ -37,6 +37,53 @@ MANIFEST = os.path.join(HERE, "snapshots.json")
 FAIL_DIR = os.path.join(HERE, "failures")
 REVIEW_DIR = os.path.join(HERE, "review")
 GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT", "/mnt/c/Users/matti/repos/ps5ys")
+
+_PR_SET_PDEATHSIG = 1
+_LIBC = ctypes.CDLL(None, use_errno=True) if sys.platform.startswith("linux") else None
+
+
+def _snapshot_child_setup(parent_pid):
+    """Create an isolated process group and die if the snapshot harness disappears."""
+    os.setsid()
+    if _LIBC.prctl(_PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    # The parent can die between fork() and prctl(). Once PR_SET_PDEATHSIG is
+    # installed, this check closes that race without opening a new one.
+    if os.getppid() != parent_pid:
+        os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _spawn_snapshot_process(command, env, logf):
+    kwargs = {
+        "env": env,
+        "stdout": logf,
+        "stderr": subprocess.STDOUT,
+    }
+    if sys.platform.startswith("linux"):
+        parent_pid = os.getpid()
+        kwargs["preexec_fn"] = lambda: _snapshot_child_setup(parent_pid)
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(command, **kwargs)
+
+
+def _stop_snapshot_process(proc):
+    if proc is None:
+        return
+    try:
+        if hasattr(os, "killpg"):
+            # setsid() makes the child's PID its process-group ID. Address the
+            # group directly so descendants are killed even if the leader exited.
+            os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def boot_trace_path():
@@ -495,8 +542,7 @@ def capture(entry, run_log=None):
     failed = False
     try:
         logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
-        proc = subprocess.Popen([bt_run, dump], env=env, stdout=logf, stderr=subprocess.STDOUT,
-                                preexec_fn=os.setsid)
+        proc = _spawn_snapshot_process([bt_run, dump], env, logf)
         deadline = time.time() + timeout
         settle = int(entry.get("settle", 0))
         if settle > 0:
@@ -550,11 +596,7 @@ def capture(entry, run_log=None):
         failed = True
         raise
     finally:
-        try:
-            if proc is not None:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except Exception:
-            pass
+        _stop_snapshot_process(proc)
         if run_log and logf is not None:
             logf.close()
         if failed:
@@ -598,8 +640,7 @@ def capture_content(entry, run_log=None):
             "--timeout", str(runner_timeout), "--require-composited-frame",
         ]
         logf = open(run_log, "wb") if run_log else subprocess.DEVNULL
-        proc = subprocess.Popen(command, env=env, stdout=logf, stderr=subprocess.STDOUT,
-                                preexec_fn=os.setsid)
+        proc = _spawn_snapshot_process(command, env, logf)
         deadline = time.time() + runner_timeout + 15
         while time.time() < deadline and proc.poll() is None:
             time.sleep(1.0)
@@ -613,11 +654,7 @@ def capture_content(entry, run_log=None):
         failed = True
         raise
     finally:
-        try:
-            if proc is not None:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except Exception:
-            pass
+        _stop_snapshot_process(proc)
         if run_log and logf is not None:
             logf.close()
         if failed:

--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -2,7 +2,11 @@
 import importlib.util
 import json
 import os
+import signal
+import subprocess
+import sys
 import tempfile
+import time
 import unittest
 
 
@@ -13,6 +17,70 @@ SPEC.loader.exec_module(SNAPSHOT)
 
 
 class SnapshotContentTests(unittest.TestCase):
+    @unittest.skipUnless(sys.platform.startswith("linux"), "PR_SET_PDEATHSIG is Linux-specific")
+    def test_snapshot_child_dies_when_harness_is_killed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pid_path = os.path.join(tmp, "child.pid")
+            harness_script = """
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+
+spec = importlib.util.spec_from_file_location("snapshot_harness", {snapshot_path})
+snapshot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(snapshot)
+child = snapshot._spawn_snapshot_process(
+    [sys.executable, "-c", "import time; time.sleep(60)"],
+    dict(os.environ), subprocess.DEVNULL)
+with open({pid_path}, "w") as pid_file:
+    pid_file.write(str(child.pid))
+    pid_file.flush()
+while True:
+    time.sleep(1)
+""".format(
+                snapshot_path=json.dumps(os.path.join(HERE, "snapshot.py")),
+                pid_path=json.dumps(pid_path),
+            )
+            harness = subprocess.Popen([sys.executable, "-c", harness_script])
+            child_pid = None
+            try:
+                deadline = time.time() + 10
+                while time.time() < deadline and not os.path.exists(pid_path):
+                    if harness.poll() is not None:
+                        self.fail(f"snapshot harness exited early with code {harness.returncode}")
+                    time.sleep(0.05)
+                self.assertTrue(os.path.exists(pid_path), "snapshot harness did not publish child PID")
+                with open(pid_path) as pid_file:
+                    child_pid = int(pid_file.read())
+                self.assertTrue(self._process_is_running(child_pid))
+
+                os.kill(harness.pid, signal.SIGKILL)
+                harness.wait(timeout=5)
+                deadline = time.time() + 10
+                while time.time() < deadline and self._process_is_running(child_pid):
+                    time.sleep(0.05)
+                self.assertFalse(
+                    self._process_is_running(child_pid),
+                    "snapshot child survived the harness's uncatchable termination",
+                )
+            finally:
+                if harness.poll() is None:
+                    harness.kill()
+                    harness.wait(timeout=5)
+                if child_pid is not None and self._process_is_running(child_pid):
+                    os.kill(child_pid, signal.SIGKILL)
+
+    @staticmethod
+    def _process_is_running(pid):
+        try:
+            with open(f"/proc/{pid}/stat") as stat_file:
+                state = stat_file.read().split()[2]
+            return state != "Z"
+        except FileNotFoundError:
+            return False
+
     def test_content_window_requires_multiple_frames_and_progression(self):
         with tempfile.TemporaryDirectory() as tmp:
             samples = [


### PR DESCRIPTION
Fixes #662

## Failure and contract

The snapshot harness launched each copied game frontend in a new session and relied on a `finally` block to kill that process group. If the Python harness itself received SIGKILL or otherwise disappeared without unwinding, the game process was reparented and could keep booting indefinitely with substantial CPU and memory use.

On Linux, the direct snapshot child must be killed by the kernel when its creating harness dies, including the fork-to-exec race where the parent disappears before child setup completes. Normal completion must still terminate the complete isolated process group and reap the direct child.

## Implementation

- Centralize both `bt_snap` and `screenshot_snap` launches in one process helper.
- Keep `setsid()` isolation and install `prctl(PR_SET_PDEATHSIG, SIGKILL)` before exec on Linux.
- Recheck the expected parent PID after `prctl`; a parent lost between fork and setup makes the child kill itself immediately.
- Centralize cleanup so the process group is killed by its stable group ID and the direct child is reaped.
- Preserve portable non-Linux session isolation with `start_new_session=True`; parent-death signaling remains Linux-specific.

## Regression coverage

A Linux-only subprocess regression starts a separate Python harness, has it launch a sleeping snapshot child through the production helper, kills the harness with uncatchable SIGKILL, and asserts the child is gone or no longer running. The test also proves the child was live before terminating its parent, so an early-exit false positive cannot pass.

## Author verification — exact head `20f6485ce392404f85580a2b37d3cf6016810c03`

- Focused WSL snapshot tests: 8/8 passed, including the parent-death regression.
- Full Linux build and CTest: 104/104 passed.
- Live Messenger interruption: launched the real copied `bt_snap`, SIGKILLed its Python harness, and observed the child transition to `gone` immediately.
- Post-test process audit: no `bt_snap`, `screenshot_snap`, or snapshot harness remained.
- `git diff --check`: passed.
- Verified base: `master@c56834d4e84837bd0f8e18f0690702edbe083d36`.

The routed image gate is not applicable: no game, rendering, capture output, route, or baseline behavior changed. The live Messenger interruption exercises the affected launcher with the real game process.

## Risk

Risk is LOW. The Linux-only kernel contract is narrowly contained in child setup; failure to install it fails the spawn rather than silently restoring orphan behavior. Existing session/process-group semantics are retained, and the non-Linux path does not call `prctl`.