### PR TITLE
fix(gpu_replay): use selected draw output extent

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -480,6 +480,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_timeline_capture_exit PRIVATE prosper_core)
   add_test(NAME gpu_timeline_capture_failure_exit COMMAND test_gpu_timeline_capture_exit)
 
+  # gpu_replay output dimensions follow the selected draw/prefix target when its byte count agrees.
+  # Pure/cross-platform so focused replay tooling remains available in CI.
+  add_executable(test_gpu_replay_extent tests/test_gpu_replay_extent.cpp)
+  target_link_libraries(test_gpu_replay_extent PRIVATE prosper_core)
+  add_test(NAME gpu_replay_output_extent COMMAND test_gpu_replay_extent)
+
   add_executable(test_gpu_dependency_graph tests/test_gpu_dependency_graph.cpp)
   target_link_libraries(test_gpu_dependency_graph PRIVATE prosper_core)
   add_test(NAME gpu_dependency_graph COMMAND test_gpu_dependency_graph)

--- a/prosper/tests/test_gpu_replay_extent.cpp
+++ b/prosper/tests/test_gpu_replay_extent.cpp
@@ -1,0 +1,79 @@
+#include "../tools/gpu_replay/replay_output_extent.hpp"
+
+#include <cstdio>
+
+using namespace prosper::gpu;
+using namespace prosper::gpu::replay_tool;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_replay_extent ==\n");
+
+    GpuReplayFrame replay;
+    replay.metadata.width = 3840;
+    replay.metadata.height = 2160;
+
+    DrawItem offscreen;
+    offscreen.draw_index = 23;
+    offscreen.color0_width = 642;
+    offscreen.color0_height = 362;
+    replay.items.push_back(offscreen);
+
+    OutputExtent extent = replay_output_extent(
+        replay, OutputExtentMode::Capture, static_cast<size_t>(3840) * 2160 * 4);
+    CHECK(extent.width == 3840 && extent.height == 2160,
+          "full replay retains the capture output extent");
+
+    extent = replay_output_extent(
+        replay, OutputExtentMode::SelectedDraws, static_cast<size_t>(642) * 362 * 4);
+    CHECK(extent.width == 642 && extent.height == 362,
+          "single selected draw uses its offscreen target extent");
+
+    DrawItem later = offscreen;
+    later.draw_index = 24;
+    later.color0_width = 320;
+    later.color0_height = 180;
+    replay.items.push_back(later);
+    extent = replay_output_extent(
+        replay, OutputExtentMode::SelectedDraws, static_cast<size_t>(320) * 180 * 4);
+    CHECK(extent.width == 320 && extent.height == 180,
+          "selected draw range uses the final selected target extent");
+
+    replay.operations = {
+        {SubmitOperationKind::Draw, 23, 100, true},
+        {SubmitOperationKind::Dispatch, 7, 200, true},
+        {SubmitOperationKind::Draw, 24, 300, true},
+    };
+    extent = replay_output_extent(
+        replay, OutputExtentMode::OrderedPrefix, static_cast<size_t>(642) * 362 * 4, 1);
+    CHECK(extent.width == 642 && extent.height == 362,
+          "ordered prefix uses its last realized draw extent");
+    extent = replay_output_extent(
+        replay, OutputExtentMode::OrderedPrefix, static_cast<size_t>(642) * 362 * 4, 2);
+    CHECK(extent.width == 642 && extent.height == 362,
+          "compute operations do not change the output extent");
+    extent = replay_output_extent(
+        replay, OutputExtentMode::OrderedPrefix, static_cast<size_t>(320) * 180 * 4, 3);
+    CHECK(extent.width == 320 && extent.height == 180,
+          "later realized draw replaces the ordered-prefix extent");
+
+    replay.items.back().color0_width = 0;
+    replay.items.back().color0_height = 0;
+    extent = replay_output_extent(
+        replay, OutputExtentMode::SelectedDraws, static_cast<size_t>(3840) * 2160 * 4);
+    CHECK(extent.width == 3840 && extent.height == 2160,
+          "missing target dimensions fall back to the capture extent");
+
+    replay.items = {offscreen};
+    extent = replay_output_extent(
+        replay, OutputExtentMode::SelectedDraws, static_cast<size_t>(3840) * 2160 * 4);
+    CHECK(extent.width == 3840 && extent.height == 2160,
+          "capture-sized renderer output overrides stale native draw dimensions");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -81,6 +81,10 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 ./build-linux/gpu_replay --dump-failed-shader 0:1 /tmp/failed-fragment.bin /tmp/submit.prgcap
 ```
 
+Selected draw ranges and ordered prefixes write the BMP at the final selected draw target's extent when
+the returned RGBA byte count confirms that native size. Presentation-scaled replays retain the capsule's
+top-level extent, so a recorded native target cannot mislabel a deliberately scaled pixel buffer.
+
 ### Failed operations
 
 Capture v7 and later retain bounded diagnostics for draws and dispatches that semantic PM4 ordering contains but the

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -4,6 +4,7 @@
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"
 #include "live_renderer.hpp"
+#include "replay_output_extent.hpp"
 #include "render_runner.h"
 
 #include <algorithm>
@@ -1568,22 +1569,17 @@ int main(int argc, char** argv) {
     }
     const size_t operation_limit = through_operation >= 0
         ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
-    std::vector<uint8_t> pixels = execute_frame(
-        replay, draw_first >= 0 && !draw_with_compute_prefix, operation_limit);
-    uint32_t output_width = m.width, output_height = m.height;
-    if (through_operation >= 0) {
-        for (size_t operation_index = 0; operation_index < operation_limit; ++operation_index) {
-            const auto& operation = replay.operations[operation_index];
-            if (!operation.realized ||
-                operation.kind != prosper::gpu::SubmitOperationKind::Draw) continue;
-            const auto item = std::find_if(replay.items.begin(), replay.items.end(),
-                [&](const auto& draw) { return draw.draw_index == operation.source_index; });
-            if (item != replay.items.end() && item->color0_width && item->color0_height) {
-                output_width = item->color0_width;
-                output_height = item->color0_height;
-            }
-        }
-    }
+    const bool selected_draws_only = draw_first >= 0 && !draw_with_compute_prefix;
+    std::vector<uint8_t> pixels = execute_frame(replay, selected_draws_only, operation_limit);
+    const auto extent_mode = selected_draws_only
+        ? prosper::gpu::replay_tool::OutputExtentMode::SelectedDraws
+        : (through_operation >= 0 || (draw_first >= 0 && draw_with_compute_prefix))
+            ? prosper::gpu::replay_tool::OutputExtentMode::OrderedPrefix
+            : prosper::gpu::replay_tool::OutputExtentMode::Capture;
+    const auto output_extent = prosper::gpu::replay_tool::replay_output_extent(
+        replay, extent_mode, pixels.size(), operation_limit);
+    const uint32_t output_width = output_extent.width;
+    const uint32_t output_height = output_extent.height;
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
     std::fprintf(stderr, "[gpureplay] output=%ux%u bytes=%zu hash=%016llx "
                          "expected_bytes=%llu expected_hash=%016llx\n",

--- a/prosper/tools/gpu_replay/replay_output_extent.hpp
+++ b/prosper/tools/gpu_replay/replay_output_extent.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "gpu/gpu_capture.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::gpu::replay_tool {
+
+enum class OutputExtentMode {
+    Capture,
+    SelectedDraws,
+    OrderedPrefix,
+};
+
+struct OutputExtent {
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
+
+inline OutputExtent replay_output_extent(const GpuReplayFrame& replay, OutputExtentMode mode,
+                                         size_t output_bytes,
+                                         size_t operation_limit = SIZE_MAX) {
+    const OutputExtent capture_extent{replay.metadata.width, replay.metadata.height};
+    OutputExtent selected_extent = capture_extent;
+    auto select_draw = [&](const DrawItem& draw) {
+        if (draw.color0_width && draw.color0_height)
+            selected_extent = {draw.color0_width, draw.color0_height};
+    };
+
+    if (mode == OutputExtentMode::SelectedDraws) {
+        if (!replay.items.empty()) select_draw(replay.items.back());
+    } else if (mode == OutputExtentMode::OrderedPrefix) {
+        const size_t count = std::min(operation_limit, replay.operations.size());
+        for (size_t operation_index = 0; operation_index < count; ++operation_index) {
+            const auto& operation = replay.operations[operation_index];
+            if (!operation.realized || operation.kind != SubmitOperationKind::Draw) continue;
+            const auto draw = std::find_if(replay.items.begin(), replay.items.end(),
+                [&](const auto& item) { return item.draw_index == operation.source_index; });
+            if (draw != replay.items.end()) select_draw(*draw);
+        }
+    }
+
+    // Some legacy captures retain a native target extent while replay intentionally returns a
+    // presentation-scaled frame. Only switch away from the capture dimensions when the actual RGBA
+    // byte count proves that the selected target is what the renderer returned.
+    const uint64_t selected_bytes = static_cast<uint64_t>(selected_extent.width) *
+                                    selected_extent.height * 4;
+    return mode != OutputExtentMode::Capture && selected_bytes == output_bytes
+        ? selected_extent : capture_extent;
+}
+
+} // namespace prosper::gpu::replay_tool


### PR DESCRIPTION
Fixes #775

## Failure

`gpu_replay --draw` could return the selected offscreen target pixels while still labeling the BMP with the capture's top-level extent. For the reported Dead Cells capture that meant 929,616 RGBA bytes (642x362) were checked against 3840x2160 and the output was rejected.

## Change

- Choose output dimensions from the final selected draw target for draw-only and ordered-prefix replay modes.
- Require the actual RGBA byte count to confirm that target before departing from capture metadata.
- Preserve capture dimensions for full replays and presentation-scaled legacy captures.
- Add a pure cross-platform regression covering draw ranges, compute prefixes, missing metadata, and scaled-output fallback.

## Verification

- Linux Debug + Vulkan: `105/105` CTest tests passed.
- Native Windows MinGW (Vulkan-disabled): `72/72` CTest tests passed.
- Focused extent regression: `8/8` assertions passed on Linux and Windows.
- Built the Linux `gpu_replay` target successfully.
- Existing scaled Messenger capsule smoke: replay remained `320x180`, `230400` bytes, and wrote a valid 320x180 BMP despite a recorded 1920x1080 native draw target.
- `git diff --check` passed.

## Visual verification

Not applicable: this changes replay-tool BMP metadata selection, not renderer pixels. The byte-count guard and exact capsule replay exercise the affected output contract.