### PR TITLE
fix(recompiler): avoid signed float conversion on Metal

### DIFF
--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -348,10 +348,12 @@ the game live instead of dumping screenshots) now **builds and runs on macOS** u
   `%fs` TLS wall** as `boot_trace` — so the harness is complete and will show live gameplay the moment
   that frontier is solved, exactly like the Linux app.
 - **MoltenVK renders correctly**, not just presents: with `PROSPER_MACOS_MOLTENVK` set, the offscreen
-  GPU tests run on macOS and **90/91 pass** (SPIR-V recompile → MoltenVK → readback → CRC). The one
-  failure, `rdna2_to_spirv_exec`, is a genuine Metal semantics gap — `v_cvt_i32_f32` NaN→0 /
-  INT_MIN/MAX saturation differs from Vulkan/RDNA2 (Metal's out-of-range float→int is undefined). All
-  compute values match (`mismatches=0`); only that saturation subcase diverges. Tracked as an issue.
+  GPU tests run on macOS. The original bring-up passed **90/91**; its sole gap was
+  `v_cvt_i32_f32` saturation because Metal's signed float-to-int conversion is undefined near the
+  limits (#686). The recompiler now avoids that operation: it converts a bounded absolute magnitude
+  through the defined unsigned path, restores two's-complement sign, and selects the saturation
+  endpoints explicitly. `rdna2_to_spirv_exec` checks both the boundary results and the absence of
+  `OpConvertFToS` in this lowering.
 
 Build recipe (see the CMake `PROSPER_MACOS_MOLTENVK` override and `scripts/fetch-macos-vulkan.sh`):
 ```bash

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -240,18 +240,28 @@ struct SpirvCompute {
     }
     uint32_t sbin(uint32_t op, uint32_t a, uint32_t b) { uint32_t ri = id(); put(code, op, {t_i32, ri, bcs(a), bcs(b)}); return i2u(ri); }
     uint32_t sext2(uint32_t inst, uint32_t a, uint32_t b) { uint32_t ri = id(); putv(code, Op_ExtInst, {t_i32, ri, glsl, inst, bcs(a), bcs(b)}); return i2u(ri); }
-    // v_cvt_i32_f32 SATURATES: NaN -> 0, clamp to [INT_MIN, INT_MAX] (#135). 2147483520.0f
-    // (0x4EFFFFFF) is the largest float < 2^31, so the high clamp is exact in range and inputs
-    // >= 2^31 select INT_MAX; -2^31 is exactly representable, so the low clamp needs no select.
+    // v_cvt_i32_f32 SATURATES: NaN -> 0, clamp to [INT_MIN, INT_MAX] (#135). Do not emit
+    // OpConvertFToS: SPIR-V leaves invalid conversions undefined, and Metal also produces a
+    // backend-specific result near the signed limits even after a float clamp (#686). Convert a
+    // bounded absolute magnitude through the working unsigned path, then restore two's-complement
+    // sign. 2^31 is representable by u32, so every conversion is defined on all backends.
     uint32_t cvt_f2i(uint32_t bits) {
         uint32_t f = bcf(bits);
         uint32_t nan = id();  put(code, Op_FUnordNotEqual, {t_bool, nan, f, f});   // true iff NaN
         uint32_t safe = id(); put(code, Op_Select, {t_f32, safe, nan, fconstf(0.0f), f});
-        uint32_t hi = id();   putv(code, Op_ExtInst, {t_f32, hi, glsl, Glsl_FMin, safe, fconstf(2147483520.0f)});
-        uint32_t cl = id();   putv(code, Op_ExtInst, {t_f32, cl, glsl, Glsl_FMax, hi, fconstf(-2147483648.0f)});
-        uint32_t ri = id();   put(code, Op_ConvertFToS, {t_i32, ri, cl});
+        uint32_t magnitude = id();
+        putv(code, Op_ExtInst, {t_f32, magnitude, glsl, Glsl_FAbs, safe});
+        uint32_t bounded = id();
+        putv(code, Op_ExtInst,
+             {t_f32, bounded, glsl, Glsl_FMin, magnitude, fconstf(2147483648.0f)});
+        uint32_t unsigned_magnitude = id();
+        put(code, Op_ConvertFToU, {t_u32, unsigned_magnitude, bounded});
+        uint32_t negative = id();
+        put(code, Op_FOrdLessThan, {t_bool, negative, f, fconstf(0.0f)});
+        uint32_t negated = ibin(Op_ISub, uconst(0), unsigned_magnitude);
+        uint32_t signed_bits = sel(negative, negated, unsigned_magnitude);
         uint32_t big = id();  put(code, Op_FOrdGreaterThanEqual, {t_bool, big, f, fconstf(2147483648.0f)});
-        return sel(big, uconst(0x7FFFFFFFu), i2u(ri));
+        return sel(big, uconst(0x7FFFFFFFu), signed_bits);
     }
     uint32_t cvt_i2f(uint32_t bits) { uint32_t rf = id(); put(code, Op_ConvertSToF, {t_f32, rf, bcs(bits)}); return bcu(rf); }
     // Integer compares -> bool. scmp treats operands as signed, ucmp as unsigned.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -35,6 +35,16 @@ static uint16_t f32_to_f16_exact(float f) {
 }
 static uint32_t bits_of(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
 static uint32_t bitrev32(uint32_t v) { uint32_t r = 0; for (int i = 0; i < 32; i++) { r = (r << 1) | (v & 1u); v >>= 1; } return r; }
+static size_t count_spirv_opcode(const std::vector<uint32_t>& spv, uint16_t opcode) {
+    size_t matches = 0;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        if (!count || word + count > spv.size()) return 0;
+        if ((spv[word] & 0xFFFFu) == opcode) ++matches;
+        word += count;
+    }
+    return matches;
+}
 
 int main() {
     printf("== test_rdna2_to_spirv ==\n");
@@ -1831,8 +1841,10 @@ int main() {
     std::vector<uint32_t> spvS2 = recompile_valu(codeS2, sizeof(codeS2)/sizeof(codeS2[0]), 1, 0);
     CHECK(!spvS1.empty(), "recompiled kernel S1 (v_cvt_u32_f32 saturating) -> SPIR-V");
     CHECK(!spvS2.empty(), "recompiled kernel S2 (v_cvt_i32_f32 saturating) -> SPIR-V");
+    CHECK(count_spirv_opcode(spvS2, 110) == 0 && count_spirv_opcode(spvS2, 109) != 0,
+          "v_cvt_i32_f32 avoids Metal's undefined signed float-conversion path");
     const float satIn[] = { 3.7f, 0.0f, -0.5f, -5.5f, 255.9f, -1e10f, 1e10f, 4294967040.0f,
-                            2147483520.0f, std::nanf(""), INFINITY, -INFINITY };
+                            2147483520.0f, -2147483520.0f, std::nanf(""), INFINITY, -INFINITY };
     const uint32_t NSAT = sizeof(satIn)/sizeof(satIn[0]);
     auto sat_u32 = [](float x) -> uint32_t {
         if (std::isnan(x)) return 0u;
@@ -1859,9 +1871,9 @@ int main() {
     for (uint32_t i = 0; i < N && gotS2.size() == N; i++)
         if (std::fabs(gotS2[i] - expS2[i]) > 1e-3f + 1e-6f*std::fabs(expS2[i])) badS2++;
     printf("  kernelS1(u32 sat) mismatches=%u (nan->%g, -5.5->%g, 1e10->%g expect 0,0,%g)\n", badS1,
-           gotS1.size()==N?gotS1[9]:-1, gotS1.size()==N?gotS1[3]:-1, gotS1.size()==N?gotS1[6]:-1, expS1[6]);
+           gotS1.size()==N?gotS1[10]:-1, gotS1.size()==N?gotS1[3]:-1, gotS1.size()==N?gotS1[6]:-1, expS1[6]);
     printf("  kernelS2(i32 sat) mismatches=%u (nan->%g, -1e10->%g, 1e10->%g expect 0,%g,%g)\n", badS2,
-           gotS2.size()==N?gotS2[9]:-1, gotS2.size()==N?gotS2[5]:-1, gotS2.size()==N?gotS2[6]:-1, expS2[5], expS2[6]);
+           gotS2.size()==N?gotS2[10]:-1, gotS2.size()==N?gotS2[5]:-1, gotS2.size()==N?gotS2[6]:-1, expS2[5], expS2[6]);
     CHECK(gotS1.size()==N && badS1==0, "v_cvt_u32_f32 saturates (NaN/neg -> 0, >=2^32 -> UINT_MAX)");
     CHECK(gotS2.size()==N && badS2==0, "v_cvt_i32_f32 saturates (NaN -> 0, clamps to INT_MIN/INT_MAX)");
 


### PR DESCRIPTION
Fixes #686

## Failure

The existing `v_cvt_i32_f32` lowering guards NaN and clamps the float before `OpConvertFToS`, but MoltenVK still lowers that signed conversion through Metal's undefined edge behavior. The macOS offscreen execution suite therefore diverges only in the NaN/INT_MIN/INT_MAX saturation subcase.

## Change

- Convert a NaN-safe, absolute magnitude clamped to `2^31` through `OpConvertFToU`, whose input is fully representable.
- Restore negative values with defined two's-complement unsigned subtraction.
- Select `INT_MAX` explicitly for positive overflow; negative overflow naturally resolves to `INT_MIN`.
- Add the adjacent negative boundary case and a structural regression requiring the signed kernel to contain `OpConvertFToU` and no `OpConvertFToS`.
- Update the macOS porting note with the portable lowering contract.

## Verification

- Focused Linux Vulkan execution-differential: all `test_rdna2_to_spirv` cases passed; `v_cvt_i32_f32` reported zero mismatches for ordinary values, NaN, both infinities, positive/negative overflow, and `±2147483520.0f`.
- Linux Debug + Vulkan: `105/105` CTest tests passed, including `rdna2_to_spirv_exec`, SPIR-V validation, and real-shader rendering.
- Native Windows MinGW (Vulkan-disabled): `72/72` CTest tests passed.
- `git diff --check` passed.

## Routed game guard

- `blasphemous2-gameplay`: PASS — 98/98 qualifying, structural, and nonblack frames; 97 pixel changes; richest frame 2579 colors.
- `messenger-scene` and `dead-cells-gameplay` reached rich/moving but wrong route states (early dialogue and loading card) and missed the reviewed SSIM references. The exact same two failures were rerun on the unchanged pre-fix tree: visually identical wrong states, 0 structural matches, 49 evidence frames each, matching richness ranges. This is a base route/baseline miss, not a patch regression; no threshold, route, save, or baseline was changed.

Hosted macOS app CI is build-only because headless Metal is intentionally not a reliable runner gate. The regression instead proves structurally that the operation responsible for the Metal divergence is absent, while retaining execution-differential semantics on Vulkan.