### PR TITLE
Boot Astro Bot to its loading screen (#825)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -217,6 +217,18 @@ if(TARGET prosper_core)
   target_link_libraries(test_http PRIVATE prosper_core)
   add_test(NAME http_hle COMMAND test_http)
 
+  add_executable(test_font tests/test_font.cpp)
+  target_link_libraries(test_font PRIVATE prosper_core)
+  add_test(NAME font_hle COMMAND test_font)
+
+  add_executable(test_fiber tests/test_fiber.cpp)
+  target_link_libraries(test_fiber PRIVATE prosper_core)
+  add_test(NAME fiber_hle COMMAND test_fiber)
+
+  add_executable(test_posix_sem tests/test_posix_sem.cpp)
+  target_link_libraries(test_posix_sem PRIVATE prosper_core)
+  add_test(NAME posix_sem_hle COMMAND test_posix_sem)
+
   # PlatformUi hook (#347): the app frontend can service the guest's ImeDialog with real UI; with no
   # backend registered the headless auto-complete default is unchanged. Pure, no game dump.
   add_executable(test_platform_ui tests/test_platform_ui.cpp)

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -274,6 +274,7 @@ struct BoundBuffer {
     const prosper::gpu::ShaderResource* resource = nullptr;
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
+    size_t alias_of = SIZE_MAX;         // exact guest range sharing an earlier storage buffer
     uint64_t before_hash = 0, after_hash = 0;
     uint64_t changed_bytes = 0;
 };
@@ -291,7 +292,7 @@ struct BoundImage {
     VkSampler sampler = VK_NULL_HANDLE; // combined image sampler only
     VkDeviceSize row_pitch = 0;         // LINEAR-tiling row pitch (bytes), from vkGetImageSubresourceLayout
     size_t guest_bytes = 0;             // real linear/tiled guest backing footprint
-    size_t alias_of = SIZE_MAX;         // identical storage binding sharing an earlier image/view
+    size_t alias_of = SIZE_MAX;         // exact sampled/storage binding sharing an earlier image/view
     uint8_t* dcc_metadata = nullptr;    // DCC control bytes to mark uncompressed after writeback
     size_t dcc_metadata_bytes = 0;
     uint64_t before_hash = 0, after_hash = 0; // trace-only storage-image writeback evidence
@@ -309,17 +310,26 @@ struct BoundImage {
 // skips the dispatch loudly (never a silent wrong-layout write — correctness-first).
 bool storage_unpack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
-    return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 || f == DF::Uint32 || f == DF::Sint32;
+    return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 || f == DF::Uint32 ||
+           f == DF::Sint32 || f == DF::Float10_11_11;
 }
 bool storage_pack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
     return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 ||
-           f == DF::Uint32 || f == DF::Sint32;
+           f == DF::Uint32 || f == DF::Sint32 || f == DF::Float10_11_11;
 }
 void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32_t ncomp, uint32_t out[4]) {
     using DF = prosper::gpu::DataFormat;
     const uint32_t one_f32 = 0x3f800000u;                 // hardware default: missing channels = (0,0,0,1.0f)
     out[0] = out[1] = out[2] = 0; out[3] = one_f32;
+    if (f == DF::Float10_11_11) {
+        uint32_t packed = 0; std::memcpy(&packed, src, sizeof(packed));
+        const float values[3] = { prosper::gpu::f11_to_float(static_cast<uint16_t>(packed)),
+                                  prosper::gpu::f11_to_float(static_cast<uint16_t>(packed >> 11)),
+                                  prosper::gpu::f10_to_float(static_cast<uint16_t>(packed >> 22)) };
+        for (uint32_t c = 0; c < 3; ++c) std::memcpy(&out[c], &values[c], sizeof(values[c]));
+        return;
+    }
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: { float v = src[c] / 255.0f; std::memcpy(&out[c], &v, 4); break; }
@@ -332,6 +342,15 @@ void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32
 }
 void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32_t ncomp, uint8_t* dst) {
     using DF = prosper::gpu::DataFormat;
+    if (f == DF::Float10_11_11) {
+        float values[3];
+        for (uint32_t c = 0; c < 3; ++c) std::memcpy(&values[c], &in[c], sizeof(values[c]));
+        const uint32_t packed = static_cast<uint32_t>(prosper::gpu::float_to_f11(values[0])) |
+                                (static_cast<uint32_t>(prosper::gpu::float_to_f11(values[1])) << 11) |
+                                (static_cast<uint32_t>(prosper::gpu::float_to_f10(values[2])) << 22);
+        std::memcpy(dst, &packed, sizeof(packed));
+        return;
+    }
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: dst[c] = storage_pack_unorm8(in[c]); break;
@@ -414,8 +433,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         image_descriptors.begin(), image_descriptors.end(), [](const auto& descriptor) {
             return descriptor.kind == SpirvDescriptorKind::StorageImage;
         });
-    const bool phase_timing = has_storage_images &&
-                              std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
+    // The phase timer is also useful for buffer-only kernels. Astro Bot's heaviest dispatcher writes
+    // buffers exclusively, so the historical storage-image gate hid the actual frame bottleneck.
+    const bool phase_timing = std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
     if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
         if (!warned) { warned = true;
@@ -465,6 +485,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (descriptor_pool) vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
         if (descriptor_layout) vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
         for (auto& buffer : buffers) {
+            if (buffer.alias_of != SIZE_MAX) continue;
             if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
             if (buffer.memory) ctx.release_memory(buffer.memory);
         }
@@ -497,23 +518,38 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ((!resource->host_data || resource->host_data_size < resource->size) &&
                  !guest_readable(resource->gpu_addr, resource->size))) break;
             buffers[i].resource = resource;
-            VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-            bci.size = resource->size;
-            bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-            if (vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer) != VK_SUCCESS) break;
-            VkMemoryRequirements requirements{};
-            vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
-            const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
-            if (memory_type == UINT32_MAX) break;
-            buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type);
-            if (!buffers[i].memory) break;
-            if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
-            void* mapped = nullptr;
-            if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
-            const uint8_t* source = resource_bytes(resource);
-            if (trace) buffers[i].before_hash = fnv1a(source, resource->size);
-            std::memcpy(mapped, source, resource->size);
-            vkUnmapMemory(ctx.device, buffers[i].memory);
+            for (size_t j = 0; j < i; ++j) {
+                const ShaderResource* prior = buffers[j].resource;
+                if (!prior || prior->gpu_addr != resource->gpu_addr ||
+                    prior->size != resource->size ||
+                    prior->host_data != resource->host_data ||
+                    prior->host_data_size != resource->host_data_size)
+                    continue;
+                buffers[i].alias_of = buffers[j].alias_of == SIZE_MAX ? j : buffers[j].alias_of;
+                const BoundBuffer& owner = buffers[buffers[i].alias_of];
+                buffers[i].buffer = owner.buffer;
+                buffers[i].memory = owner.memory;
+                break;
+            }
+            if (buffers[i].alias_of == SIZE_MAX) {
+                VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                bci.size = resource->size;
+                bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+                if (vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer) != VK_SUCCESS) break;
+                VkMemoryRequirements requirements{};
+                vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
+                const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
+                if (memory_type == UINT32_MAX) break;
+                buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type);
+                if (!buffers[i].memory) break;
+                if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
+                void* mapped = nullptr;
+                if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
+                const uint8_t* source = resource_bytes(resource);
+                if (trace) buffers[i].before_hash = fnv1a(source, resource->size);
+                std::memcpy(mapped, source, resource->size);
+                vkUnmapMemory(ctx.device, buffers[i].memory);
+            }
 
             layout_bindings[i].binding = descriptors[i].binding;
             layout_bindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -564,11 +600,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
             const bool dim_1d = r->img_dim == 0;
             const bool dim_3d = r->img_dim == 2;
-            if (!dim_1d && r->img_dim != 1 && !dim_3d) {
+            const bool dim_2d_array = r->img_dim == 5 && r->depth_compare;
+            if (!dim_1d && r->img_dim != 1 && !dim_3d && !dim_2d_array) {
                 skip_image(r, "layered image deferred to #657"); break;
             }
             if (dim_1d && r->height != 1) { skip_image(r, "1D image has non-unit height"); break; }
-            if (!r->depth || (!dim_3d && r->depth != 1)) {
+            if (!r->depth || (!dim_3d && !dim_2d_array && r->depth != 1)) {
                 skip_image(r, "image depth does not match its dimensionality"); break;
             }
             if (dim_3d && r->depth > 1 && r->tile_mode &&
@@ -601,25 +638,39 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // immutable CPU snapshot for sampled and storage bindings; a successful storage
             // writeback publishes ordinary guest bytes and invalidates the renderer-owned copy.
             LiveTargetSnapshot live_target;
-            const bool renderer_owned = is_live_render_target(r->gpu_addr);
+            bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
             if (renderer_owned) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
                 }
                 if (live_target.width != r->width || live_target.height != r->height) {
-                    skip_image(r, "renderer-owned RTT snapshot extent mismatch"); break;
+                    // Address-only ownership is insufficient when the guest reuses or aliases an
+                    // allocation with another image view. Astro Bot renders a 960x540 R11G11B10
+                    // target at a base, then dispatches a 1216x684 R32 Z_X view at the same base
+                    // after changing dynamic resolution. That stale cache entry does not own the
+                    // new view; import its ordinary guest backing and let successful writeback
+                    // invalidate the overlapping renderer entry.
+                    renderer_owned = false;
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   renderer RTT view miss binding=%u addr=0x%llx "
+                                     "cached=%ux%u requested=%ux%u -> guest backing\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     live_target.width, live_target.height, r->width, r->height);
                 }
-                const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
-                const uint64_t texels = static_cast<uint64_t>(r->width) * r->height;
-                if (texels > UINT64_MAX / bpp) {
-                    skip_image(r, "renderer-owned RTT snapshot size overflow"); break;
+                if (renderer_owned) {
+                    const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
+                    const uint64_t texels = static_cast<uint64_t>(r->width) * r->height;
+                    if (texels > UINT64_MAX / bpp) {
+                        skip_image(r, "renderer-owned RTT snapshot size overflow"); break;
+                    }
+                    const uint64_t expected = texels * bpp;
+                    if (expected != live_target.pixels->size()) {
+                        skip_image(r, "renderer-owned RTT snapshot byte count mismatch"); break;
+                    }
                 }
-                const uint64_t expected = texels * bpp;
-                if (expected != live_target.pixels->size()) {
-                    skip_image(r, "renderer-owned RTT snapshot byte count mismatch"); break;
-                }
-                if (bi.storage) {
+                if (renderer_owned && bi.storage) {
                     const uint32_t nc = r->num_components ? r->num_components : 1;
                     const bool compatible =
                         (live_target.format == LiveTargetPixelFormat::Rgba8Unorm &&
@@ -627,54 +678,99 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         (live_target.format == LiveTargetPixelFormat::Rgba16Float &&
                          r->format == DataFormat::Float16 && nc == 4);
                     if (!compatible) {
-                        skip_image(r, "renderer RTT storage format mismatch"); break;
+                        // The same allocation can carry another target view before this compute
+                        // operation (Astro Bot uses R8G8 and RGBA16F views at one base). A snapshot
+                        // in the wrong storage format is not current bytes for this view.
+                        renderer_owned = false;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   renderer RTT format miss binding=%u "
+                                         "addr=0x%llx cached=%s requested=f%u/c%u -> guest backing\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         live_target.format == LiveTargetPixelFormat::Rgba16Float
+                                             ? "rgba16f" : "rgba8",
+                                         (unsigned)r->format, nc);
                     }
                 }
             }
-            // Multiple U# bindings may intentionally name the same guest surface (read/modify/write
-            // views of one UE4 volume). They must see one Vulkan image and produce one guest
-            // writeback; independent images let an unwritten alias clobber the written result.
-            if (bi.storage) {
-                for (size_t j = 0; j < i; j++) {
-                    const BoundImage& prior = images[j];
-                    const ShaderResource* p = prior.resource;
-                    const bool same_dcc_identity = p &&
-                        p->max_uncompressed_block_size == r->max_uncompressed_block_size &&
-                        p->max_compressed_block_size == r->max_compressed_block_size &&
-                        p->meta_pipe_aligned == r->meta_pipe_aligned &&
-                        p->write_compress_enabled == r->write_compress_enabled &&
-                        p->compression_enabled == r->compression_enabled &&
-                        p->alpha_is_on_msb == r->alpha_is_on_msb &&
-                        p->color_transform == r->color_transform &&
-                        p->metadata_addr == r->metadata_addr &&
-                        p->dcc_metadata_size == r->dcc_metadata_size &&
-                        p->dcc_metadata_host_data == r->dcc_metadata_host_data &&
-                        p->dcc_metadata_host_data_size == r->dcc_metadata_host_data_size;
-                    if (!prior.storage || !p || p->gpu_addr != r->gpu_addr ||
-                        p->width != r->width || p->height != r->height || p->depth != r->depth ||
-                        p->format != r->format || p->num_components != r->num_components ||
-                        p->tile_mode != r->tile_mode || p->img_dim != r->img_dim ||
-                        !same_dcc_identity)
-                        continue;
-                    bi.alias_of = prior.alias_of == SIZE_MAX ? j : prior.alias_of;
-                    const BoundImage& owner = images[bi.alias_of];
-                    bi.image = owner.image; bi.memory = owner.memory; bi.view = owner.view;
-                    bi.guest_bytes = owner.guest_bytes;
-                    bi.dcc_metadata = owner.dcc_metadata;
-                    bi.dcc_metadata_bytes = owner.dcc_metadata_bytes;
-                    staging_bytes[i] = staging_bytes[bi.alias_of];
-                    if (trace)
-                        std::fprintf(stderr, "[compute]   image-alias binding=%u -> binding=%u addr=0x%llx\n",
-                                     bi.binding, owner.binding, (unsigned long long)r->gpu_addr);
-                    break;
+            // Exact descriptor aliases share one Vulkan image. Storage aliases must observe the same
+            // read/modify/write state and produce one guest writeback; sampled aliases avoid repeatedly
+            // detiling and uploading Astro Bot's full-resolution source through dozens of SRT slots.
+            for (size_t j = 0; j < i; j++) {
+                const BoundImage& prior = images[j];
+                const ShaderResource* p = prior.resource;
+                const bool same_dcc_identity = p &&
+                    p->max_uncompressed_block_size == r->max_uncompressed_block_size &&
+                    p->max_compressed_block_size == r->max_compressed_block_size &&
+                    p->meta_pipe_aligned == r->meta_pipe_aligned &&
+                    p->write_compress_enabled == r->write_compress_enabled &&
+                    p->compression_enabled == r->compression_enabled &&
+                    p->alpha_is_on_msb == r->alpha_is_on_msb &&
+                    p->color_transform == r->color_transform &&
+                    p->metadata_addr == r->metadata_addr &&
+                    p->dcc_metadata_size == r->dcc_metadata_size &&
+                    p->dcc_metadata_host_data == r->dcc_metadata_host_data &&
+                    p->dcc_metadata_host_data_size == r->dcc_metadata_host_data_size;
+                const bool same_view = p && prior.storage == bi.storage &&
+                    p->gpu_addr == r->gpu_addr && p->size == r->size &&
+                    p->width == r->width && p->height == r->height && p->depth == r->depth &&
+                    p->format == r->format && p->num_components == r->num_components &&
+                    p->tile_mode == r->tile_mode && p->img_dim == r->img_dim &&
+                    p->srgb == r->srgb && p->host_data == r->host_data &&
+                    p->host_data_size == r->host_data_size && same_dcc_identity;
+                bool same_sampler = true;
+                if (!bi.storage && same_view) {
+                    same_sampler = p->mag_filter == r->mag_filter &&
+                        p->min_filter == r->min_filter && p->mip_filter == r->mip_filter &&
+                        p->addr_uvw[0] == r->addr_uvw[0] && p->addr_uvw[1] == r->addr_uvw[1] &&
+                        p->addr_uvw[2] == r->addr_uvw[2] &&
+                        p->border_color_type == r->border_color_type &&
+                        p->min_lod == r->min_lod && p->max_lod == r->max_lod &&
+                        p->lod_bias == r->lod_bias && p->max_aniso_ratio == r->max_aniso_ratio &&
+                        p->depth_compare_func == r->depth_compare_func &&
+                        p->depth_compare == r->depth_compare && p->unnormalized == r->unnormalized &&
+                        p->swizzle[0] == r->swizzle[0] && p->swizzle[1] == r->swizzle[1] &&
+                        p->swizzle[2] == r->swizzle[2] && p->swizzle[3] == r->swizzle[3];
                 }
-                if (bi.alias_of != SIZE_MAX) continue;
+                if (!same_view || !same_sampler) continue;
+                bi.alias_of = prior.alias_of == SIZE_MAX ? j : prior.alias_of;
+                const BoundImage& owner = images[bi.alias_of];
+                bi.image = owner.image; bi.memory = owner.memory; bi.view = owner.view;
+                bi.sampler = owner.sampler; bi.guest_bytes = owner.guest_bytes;
+                bi.dcc_metadata = owner.dcc_metadata;
+                bi.dcc_metadata_bytes = owner.dcc_metadata_bytes;
+                staging_bytes[i] = staging_bytes[bi.alias_of];
+                if (trace)
+                    std::fprintf(stderr, "[compute]   image-alias binding=%u -> binding=%u addr=0x%llx\n",
+                                 bi.binding, owner.binding, (unsigned long long)r->gpu_addr);
+                break;
             }
+            if (bi.alias_of != SIZE_MAX) continue;
             const VkDeviceSize volume_texels = static_cast<VkDeviceSize>(r->width) * r->height * r->depth;
             const uint32_t sampled_components = r->num_components ? r->num_components : 1;
-            const bool sampled_float32 = !bi.storage && r->format == DataFormat::Float32 &&
+            const bool sampled_depth = !bi.storage && r->depth_compare && dim_2d_array &&
+                                       sampled_components == 1 &&
+                                       (r->format == DataFormat::Float32 ||
+                                        r->format == DataFormat::Unorm16);
+            if (r->depth_compare && !sampled_depth) {
+                skip_image(r, "depth-compare image format/dimension unsupported"); break;
+            }
+            const bool sampled_float32 = !bi.storage && !sampled_depth &&
+                                         r->format == DataFormat::Float32 &&
                                          sampled_components >= 1 && sampled_components <= 4;
-            const uint32_t texel_bytes = bi.storage || sampled_float32 ? 16u : 4u;
+            const bool sampled_unorm8x2 = !bi.storage && r->format == DataFormat::Unorm8 &&
+                                          sampled_components == 2;
+            const bool sampled_unorm16_native = !bi.storage && r->format == DataFormat::Unorm16 &&
+                                                (sampled_components == 1 || sampled_components == 2 ||
+                                                 sampled_components == 4);
+            const bool sampled_uint8_native = !bi.storage && r->format == DataFormat::Uint8 &&
+                                              (sampled_components == 1 || sampled_components == 2 ||
+                                               sampled_components == 4);
+            const uint32_t texel_bytes = bi.storage || sampled_float32 ? 16u
+                                         : sampled_depth ? data_format_bytes(r->format)
+                                         : sampled_unorm16_native ? sampled_components * 2u
+                                         : sampled_uint8_native ? sampled_components
+                                         : sampled_unorm8x2 ? 2u : 4u;
             // Storage images use raw uvec4 channels. Most sampled formats are normalized to RGBA8,
             // but Float32 stays native so exposure/HDR kernels do not lose sign or dynamic range.
             const VkDeviceSize sbytes = volume_texels * texel_bytes;
@@ -697,7 +793,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "storage format has no channel pack/unpack yet"); break; }
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
-                const size_t guest_texel = (size_t)cb * nc;
+                const size_t guest_texel = r->format == DataFormat::Float10_11_11
+                    ? 4u : (size_t)cb * nc;
                 const size_t texels = (size_t)volume_texels;
                 const uint64_t linear_guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
                 const size_t guest_bytes = r->tile_mode
@@ -736,6 +833,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                        r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
                         skip_image(r, "storage volume detile failed"); break;
                     }
+                } else if (r->tile_mode && r->in_mip_tail) {
+                    if (trace) bi.before_hash = fnv1a(src, guest_bytes);
+                    detile_surface_level(linear.data(), src, guest_bytes,
+                                         r->width, r->height, r->tile_mode,
+                                         static_cast<uint32_t>(guest_texel),
+                                         r->mip_tail_x, r->mip_tail_y);
                 } else if (r->tile_mode) {
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     detile_surface(linear.data(), src, r->width, r->height, r->tile_mode, 0,
@@ -763,7 +866,61 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         break;
                     }
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
-                    if (f32) {
+                    if (sampled_uint8_native) {
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            for (uint32_t c = 0; c < sampled_components; ++c) {
+                                if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                                    upload[t * sampled_components + c] = pixels[t * 4 + c];
+                                } else {
+                                    uint16_t half = 0;
+                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
+                                    float value = half_to_float(half);
+                                    if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
+                                    else if (value >= 255.0f) value = 255.0f;
+                                    upload[t * sampled_components + c] = static_cast<uint8_t>(
+                                        std::lround(value));
+                                }
+                            }
+                        }
+                    } else if (sampled_unorm8x2) {
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            for (uint32_t c = 0; c < 2; ++c) {
+                                if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                                    upload[t * 2 + c] = pixels[t * 4 + c];
+                                } else {
+                                    uint16_t half = 0;
+                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
+                                    float value = half_to_float(half);
+                                    if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
+                                    else if (value >= 1.0f) value = 1.0f;
+                                    upload[t * 2 + c] = static_cast<uint8_t>(
+                                        std::lround(value * 255.0f));
+                                }
+                            }
+                        }
+                    } else if (sampled_unorm16_native) {
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            for (uint32_t c = 0; c < sampled_components; ++c) {
+                                uint16_t value = 0;
+                                if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                                    value = static_cast<uint16_t>(pixels[t * 4 + c]) * 257u;
+                                } else {
+                                    uint16_t half = 0;
+                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
+                                    float f = half_to_float(half);
+                                    if (!std::isfinite(f) || f <= 0.0f) f = 0.0f;
+                                    else if (f >= 1.0f) f = 1.0f;
+                                    value = static_cast<uint16_t>(std::lround(f * 65535.0f));
+                                }
+                                std::memcpy(upload.data() +
+                                                (t * sampled_components + c) * sizeof(value),
+                                            &value, sizeof(value));
+                            }
+                        }
+                    } else if (f32) {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
                             for (uint32_t c = 0; c < 4; ++c) {
@@ -817,16 +974,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         skip_image(r, "block-compressed 3D texture deferred"); break;
                     } else if (bpb) {
                         const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
-                        need = r->tile_mode ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
-                                            : (size_t)bw * bh * bpb;
-                    } else if (rgba8 || uint8 || r8 || f16 || f32 || r11g11b10) {
+                        const size_t slice = r->tile_mode
+                            ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
+                            : (size_t)bw * bh * bpb;
+                        need = dim_2d_array ? slice * r->depth : slice;
+                    } else if (rgba8 || uint8 || r8 || f16 || f32 || r11g11b10 ||
+                               sampled_unorm8x2 || sampled_unorm16_native || sampled_uint8_native ||
+                               sampled_depth) {
                         const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
-                        need = r->tile_mode
-                            ? (dim_3d && r->depth > 1
-                                   ? tiled_volume_bytes(r->width, r->height, r->depth,
-                                                        r->tile_mode, bpt)
-                                   : tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt))
-                            : (size_t)volume_texels * bpt;
+                        if (r->tile_mode && dim_3d && r->depth > 1) {
+                            need = tiled_volume_bytes(r->width, r->height, r->depth,
+                                                      r->tile_mode, bpt);
+                        } else if (r->tile_mode && dim_2d_array) {
+                            need = tiled_surface_bytes(r->width, r->height,
+                                                       r->tile_mode, 0, bpt) * r->depth;
+                        } else {
+                            need = r->tile_mode
+                                ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt)
+                                : (size_t)volume_texels * bpt;
+                        }
                     } else { skip_image(r, "sampled format not decodable yet"); break; }
                     if (!need || need > kMaxComputeImageBytes || need > UINT32_MAX) {
                         skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
@@ -838,8 +1004,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
                     if (bpb) {                                      // BCn: (block-detile ->) decode
                         const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
+                        if (dim_2d_array) {
+                            skip_image(r, "block-compressed sampled arrays deferred"); break;
+                        }
                         std::vector<uint8_t> lin((size_t)bw * bh * bpb, 0);
-                        if (r->tile_mode)
+                        if (r->tile_mode && r->in_mip_tail)
+                            detile_elements_level(lin.data(), src, need, bw, bh, bpb,
+                                                  r->tile_mode, r->mip_tail_x,
+                                                  r->mip_tail_y);
+                        else if (r->tile_mode)
                             detile_elements(lin.data(), src, need, bw, bh, bpb, r->tile_mode);
                         else
                             std::memcpy(lin.data(), src, lin.size());
@@ -854,13 +1027,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                                r->tile_mode, bpt)) {
                                 skip_image(r, "sampled volume detile failed"); break;
                             }
+                        } else if (r->tile_mode && dim_2d_array) {
+                            const size_t tiled_slice = tiled_surface_bytes(
+                                r->width, r->height, r->tile_mode, 0, bpt);
+                            const size_t linear_slice = static_cast<size_t>(r->width) * r->height * bpt;
+                            for (uint32_t layer = 0; layer < r->depth; ++layer)
+                                detile_surface(lin.data() + linear_slice * layer,
+                                               src + tiled_slice * layer,
+                                               r->width, r->height, r->tile_mode, 0, bpt);
+                        } else if (r->tile_mode && r->in_mip_tail) {
+                            detile_surface_level(lin.data(), src, need, r->width, r->height,
+                                                 r->tile_mode, bpt, r->mip_tail_x,
+                                                 r->mip_tail_y);
                         } else if (r->tile_mode) {
                             detile_surface(lin.data(), src, r->width, r->height, r->tile_mode, 0, bpt);
                         } else {
                             std::memcpy(lin.data(), src, lin.size());
                         }
                         const size_t texels = (size_t)volume_texels;
-                        if (rgba8 || uint8 || r11g11b10) {          // Native 4-byte sampled texels
+                        if (rgba8 || uint8 || r11g11b10 ||
+                            sampled_unorm8x2 || sampled_unorm16_native ||
+                            sampled_uint8_native || sampled_depth) {   // Native sampled texels
                             std::memcpy(upload.data(), lin.data(), lin.size());
                         } else if (f32) {                           // Native float channels + default fill
                             for (size_t t = 0; t < texels; ++t) {
@@ -922,19 +1109,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
             ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : (dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D);
-            const bool sampled_uint8 = !bi.storage && r->format == DataFormat::Uint8 &&
-                                       (r->num_components ? r->num_components : 1) == 4;
             const bool sampled_r11g11b10 = !bi.storage &&
                 r->format == DataFormat::Float10_11_11 &&
                 (r->num_components ? r->num_components : 1) == 3;
             ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT
-                                    : (sampled_uint8 ? VK_FORMAT_R8G8B8A8_UINT
+                                    : (sampled_depth
+                                           ? (r->format == DataFormat::Float32
+                                                  ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D16_UNORM)
+                                       : sampled_uint8_native
+                                           ? (sampled_components == 1 ? VK_FORMAT_R8_UINT
+                                              : sampled_components == 2 ? VK_FORMAT_R8G8_UINT
+                                                                         : VK_FORMAT_R8G8B8A8_UINT)
                                        : sampled_r11g11b10 ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                                         : sampled_unorm8x2 ? VK_FORMAT_R8G8_UNORM
+                                           : sampled_unorm16_native
+                                               ? (sampled_components == 1 ? VK_FORMAT_R16_UNORM
+                                                  : sampled_components == 2 ? VK_FORMAT_R16G16_UNORM
+                                                                            : VK_FORMAT_R16G16B16A16_UNORM)
                                          : sampled_float32 ? VK_FORMAT_R32G32B32A32_SFLOAT
                                                            : VK_FORMAT_R8G8B8A8_UNORM);
             ici.extent = {r->width, r->height, r->depth};
             ici.mipLevels = 1;
-            ici.arrayLayers = 1;
+            if (dim_2d_array) ici.extent.depth = 1;
+            ici.arrayLayers = dim_2d_array ? r->depth : 1;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
             ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
@@ -953,7 +1150,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             vci.image = bi.image;
             vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D
-                                  : (dim_3d ? VK_IMAGE_VIEW_TYPE_3D : VK_IMAGE_VIEW_TYPE_2D);
+                                  : (dim_3d ? VK_IMAGE_VIEW_TYPE_3D
+                                     : dim_2d_array ? VK_IMAGE_VIEW_TYPE_2D_ARRAY
+                                                    : VK_IMAGE_VIEW_TYPE_2D);
             vci.format = ici.format;
             if (!bi.storage) {
                 // T# DST_SEL channel routing (SQ_SEL: 0=0, 1=1, 4=R, 5=G, 6=B, 7=A) — same mapping
@@ -972,7 +1171,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vci.components = {sel(r->swizzle[0]), sel(r->swizzle[1]),
                                   sel(r->swizzle[2]), sel(r->swizzle[3])};
             }
-            vci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, ici.arrayLayers};
+            const VkImageAspectFlags image_aspect = sampled_depth
+                ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
+            vci.subresourceRange = {image_aspect, 0, 1, 0, ici.arrayLayers};
             if (!vk_ok(vkCreateImageView(ctx.device, &vci, nullptr, &bi.view),
                        "image-view")) { images_ready = false; break; }
             if (!bi.storage) {
@@ -990,15 +1191,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // Integer sampled formats cannot be linearly filtered in Vulkan. DOLL's UINT8x4
                 // volume is consumed by image_load (texel fetch), so the sampler is unused there;
                 // nearest also preserves integer semantics if a shader samples such a descriptor.
-                smci.magFilter = sampled_uint8 ? VK_FILTER_NEAREST
+                smci.magFilter = sampled_uint8_native ? VK_FILTER_NEAREST
                                                : (r->mag_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
-                smci.minFilter = sampled_uint8 ? VK_FILTER_NEAREST
+                smci.minFilter = sampled_uint8_native ? VK_FILTER_NEAREST
                                                : (r->min_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
                 smci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
                 smci.addressModeU = wrap(r->addr_uvw[0]);
                 smci.addressModeV = wrap(r->addr_uvw[1]);
                 smci.addressModeW = wrap(r->addr_uvw[2]);
                 smci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+                smci.compareEnable = sampled_depth ? VK_TRUE : VK_FALSE;
+                smci.compareOp = static_cast<VkCompareOp>(r->depth_compare_func & 0x7u);
                 if (!vk_ok(vkCreateSampler(ctx.device, &smci, nullptr, &bi.sampler), "image-sampler")) {
                     images_ready = false; break; }
             }
@@ -1114,12 +1317,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             to_dst.srcQueueFamilyIndex = to_dst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             to_dst.image = bi.image;
-            to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            const bool array_depth = r->img_dim == 5 && r->depth_compare;
+            const VkImageAspectFlags aspect = r->depth_compare
+                ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
+            to_dst.subresourceRange = {aspect, 0, 1, 0, array_depth ? r->depth : 1u};
             vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
             VkBufferImageCopy region{};
-            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            region.imageExtent = {r->width, r->height, r->depth};
+            region.imageSubresource = {aspect, 0, 0, array_depth ? r->depth : 1u};
+            region.imageExtent = {r->width, r->height, array_depth ? 1u : r->depth};
             vkCmdCopyBufferToImage(command, staging[i], bi.image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
             VkImageMemoryBarrier to_general = to_dst;
@@ -1173,6 +1379,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
         bool readback_ok = true;
         for (auto& buffer : buffers) {
+            if (buffer.alias_of != SIZE_MAX) continue;
             void* mapped = nullptr;
             if (vkMapMemory(ctx.device, buffer.memory, 0, buffer.resource->size, 0, &mapped) != VK_SUCCESS) {
                 readback_ok = false;
@@ -1209,7 +1416,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const uint32_t cb = data_format_bytes(r->format);
             const uint32_t nc = r->num_components ? r->num_components : 1;
-            const size_t guest_texel = (size_t)cb * nc;
+            const size_t guest_texel = r->format == DataFormat::Float10_11_11
+                ? 4u : (size_t)cb * nc;
             const size_t texels = (size_t)r->width * r->height * r->depth;
             std::vector<uint8_t> linear(texels * guest_texel, 0);
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
@@ -1231,6 +1439,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     vkUnmapMemory(ctx.device, staging_memory[i]);
                     break;
                 }
+            } else if (r->tile_mode && r->in_mip_tail) {
+                tile_surface_level(destination, bi.guest_bytes, linear.data(),
+                                   r->width, r->height, r->tile_mode,
+                                   static_cast<uint32_t>(guest_texel),
+                                   r->mip_tail_x, r->mip_tail_y);
             } else if (r->tile_mode) {
                 tile_surface(destination, linear.data(), r->width, r->height, r->tile_mode, 0,
                              static_cast<uint32_t>(guest_texel));
@@ -1280,7 +1493,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      ok ? "ok" : "failed");
     if (trace) {
         for (const auto& buffer : buffers) {
-            if (!buffer.resource) continue;
+            if (!buffer.resource || buffer.alias_of != SIZE_MAX) continue;
             const uint8_t* bytes = resource_bytes(buffer.resource);
             std::fprintf(stderr,
                          "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -857,7 +857,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
-                        if (rtt_on && !is_volume) { auto rit = g_rtt.find(r.gpu_addr);
+                        if (rtt_on && !is_volume && !r.in_mip_tail) { auto rit = g_rtt.find(r.gpu_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
@@ -1015,7 +1015,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 size_t tbytes = prosper::gpu::tiled_elements_bytes(bw, bh, bcb, r.tile_mode);
                                 std::vector<uint8_t> traw(tbytes, 0);
                                 copy_resource(traw.data(), r.gpu_addr, tbytes);
-                                prosper::gpu::detile_elements(lin.data(), traw.data(), tbytes, bw, bh, bcb, r.tile_mode);
+                                if (r.in_mip_tail)
+                                    prosper::gpu::detile_elements_level(
+                                        lin.data(), traw.data(), tbytes, bw, bh, bcb,
+                                        r.tile_mode, r.mip_tail_x, r.mip_tail_y);
+                                else
+                                    prosper::gpu::detile_elements(
+                                        lin.data(), traw.data(), tbytes, bw, bh, bcb, r.tile_mode);
                             } else {
                                 copy_resource(lin.data(), r.gpu_addr, comp_bytes);
                             }
@@ -1046,6 +1052,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 if (got < hlin.size()) copy_resource(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
                                 else if (is_volume) prosper::gpu::detile_volume(
                                     hlin.data(), traw.data(), got, tw, th, r.depth, r.tile_mode, bpt);
+                                else if (r.in_mip_tail) prosper::gpu::detile_surface_level(
+                                    hlin.data(), traw.data(), got, tw, th, r.tile_mode, bpt,
+                                    r.mip_tail_x, r.mip_tail_y);
                                 else prosper::gpu::detile_surface(
                                     hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
@@ -1091,6 +1100,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 if (got < nlin.size()) copy_resource(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
                                 else if (is_volume) prosper::gpu::detile_volume(
                                     nlin.data(), traw.data(), got, tw, th, r.depth, r.tile_mode, bpt);
+                                else if (r.in_mip_tail) prosper::gpu::detile_surface_level(
+                                    nlin.data(), traw.data(), got, tw, th, r.tile_mode, bpt,
+                                    r.mip_tail_x, r.mip_tail_y);
                                 else prosper::gpu::detile_surface(
                                     nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else {
@@ -1156,6 +1168,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             if (is_volume) prosper::gpu::detile_volume(
                                 texture_pixels.data(), tiled.data(), got, tw, th, r.depth, tmode, 4);
+                            else if (r.in_mip_tail) prosper::gpu::detile_surface_level(
+                                texture_pixels.data(), tiled.data(), got, tw, th, tmode, 4,
+                                r.mip_tail_x, r.mip_tail_y);
                             else prosper::gpu::detile_surface(
                                 texture_pixels.data(), tiled.data(), tw, th, tmode, pitch);
                         }
@@ -1596,7 +1611,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             };
             // Diagnostic shader/state overrides (computed once, applied to EVERY draw item):
             //   REFVS  -> a known-good fullscreen-triangle VS (isolates the game's real VS).
-            //   TESTPS -> a solid-magenta PS (isolates VS geometry from PS shading).
+            //   TESTPS -> a solid-magenta PS (isolates VS geometry from PS shading). The optional
+            //             TESTPS_MATCH file restricts it to one exact recompiled guest PS.
             //   FS_SPV -> a caller-supplied PS SPIR-V (e.g. a UV visualizer).
             //   NOPS   -> bypass the resolved pipeline state (default state).
             #include "refvs.inc"
@@ -1604,10 +1620,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             std::vector<uint32_t> refvs_spv(kRefVs, kRefVs + sizeof(kRefVs) / 4);
             std::vector<uint32_t> ps_override;
             bool ps_override_is_file = false;   // true only for a valid PROSPER_FS_SPV *file* override
+            bool ps_override_is_test = false;
             if (getenv("PROSPER_RENDER_TESTPS")) {
                 static const uint32_t kMagentaPs[] = {   // v0=1.0(R) v1=0.0(G) v2=1.0(B) v3=1.0(A); exp mrt0; endpgm
                     0x7E0002F2u, 0x7E020280u, 0x7E0402F2u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u };
                 ps_override = prosper::gpu::recompile_fragment(kMagentaPs, sizeof(kMagentaPs) / 4, nullptr);
+                ps_override_is_test = true;
             }
             // Validated SPIR-V file load: require a complete read of a word-aligned file >= 20 bytes
             // (5 words: the minimum SPIR-V header). Validate size BEFORE allocating so a failed ftell
@@ -1648,6 +1666,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     fprintf(stderr, "[fs-match] PROSPER_FS_SPV_MATCH='%s' invalid/unreadable -> applying NO "
                             "fragment file override (fail closed)\n", mp);
             }
+            // PROSPER_RENDER_TESTPS_MATCH=<file> is the geometry half of a per-shader A/B test: replace
+            // only that exact guest PS with the known solid output while retaining its real VS, indices,
+            // viewport, depth and raster state. As with FS_SPV_MATCH, a bad path fails closed.
+            int testps_match_mode = 0;
+            std::vector<uint32_t> testps_match;
+            if (const char* mp = getenv("PROSPER_RENDER_TESTPS_MATCH")) {
+                testps_match_mode = load_spv_file(mp, testps_match) ? 1 : 2;
+                if (testps_match_mode == 2)
+                    fprintf(stderr, "[testps-match] PROSPER_RENDER_TESTPS_MATCH='%s' invalid/unreadable -> "
+                            "applying NO test fragment override (fail closed)\n", mp);
+            }
             const bool nops = getenv("PROSPER_RENDER_NOPS");
             // Assemble backend draws for a subset of the submit's items — one BackendDraw per realized
             // DrawItem with its own resources + fixed-function state (or the diagnostic overrides above).
@@ -1659,15 +1688,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const auto& it = *itp;
                     prosper::test::BackendDraw bd;
                     bd.vs     = refvs ? refvs_spv : it.vs;
-                    // The PROSPER_FS_SPV *file* override is match-gated; a TESTPS override is not.
+                    // File and synthetic overrides have independent exact-match gates.
                     bool fs_ov = !ps_override.empty();
                     if (fs_ov && ps_override_is_file) {
                         if (fs_match_mode == 1)      fs_ov = (it.fs == fs_match);   // valid match -> exact only
                         else if (fs_match_mode == 2) fs_ov = false;                // requested-but-invalid -> off
                         // mode 0 -> legacy global file override (unchanged)
                     }
+                    if (fs_ov && ps_override_is_test) {
+                        if (testps_match_mode == 1)      fs_ov = (it.fs == testps_match);
+                        else if (testps_match_mode == 2) fs_ov = false;
+                        // mode 0 -> legacy global TESTPS override (unchanged)
+                    }
                     if (fs_ov && ps_override_is_file && fs_match_mode == 1)
                         fprintf(stderr, "[fs-match] file override applied to draw#%llu\n",
+                                (unsigned long long)it.draw_index);
+                    if (fs_ov && ps_override_is_test && testps_match_mode == 1)
+                        fprintf(stderr, "[testps-match] synthetic override applied to draw#%llu\n",
                                 (unsigned long long)it.draw_index);
                     bd.fs     = fs_ov ? ps_override : it.fs;
                     bd.vs_identity = refvs ? 0 : it.vs_identity;
@@ -1693,8 +1730,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // state to diagnose a pass whose inputs HIT the RTT cache yet outputs nothing —
                     // blend factors, write mask, viewport, and each PS-sampled texture address (#319).
                     if (rtt_log) {
-                        fprintf(stderr, "[rtt]   draw tgt=0x%llx vcount=%u nidx=%zu topo=%u mask=0x%x "
+                        fprintf(stderr, "[rtt]   draw#%llu vs=0x%llx fs=0x%llx tgt=0x%llx "
+                                "vcount=%u nidx=%zu topo=%u mask=0x%x "
                                 "blend=%d(src=%u dst=%u) vp=%d(%.2f,%.2f %.2fx%.2f) z=%d zw=%d ps=",
+                                (unsigned long long)it.draw_index,
+                                (unsigned long long)it.vs_guest_addr,
+                                (unsigned long long)it.fs_guest_addr,
                                 (unsigned long long)it.color0_base, bd.vcount, bd.indices.size(),
                                 it.ps.topology, it.ps.color_write_mask, (int)it.ps.blend_enable,
                                 it.ps.src_color_blend_factor, it.ps.dst_color_blend_factor,

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -196,7 +196,12 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.last_level = (t[3] >> 16) & 0xFu;
     d.max_mip    = (t[5] >> 4) & 0xFu;
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
-    d.depth     = d.type == 10 ? ((t[4] & 0x1FFFu) + 1u) : 1u;                                     // DEPTH (3D)
+    // WORD4.DEPTH is depth-1 for 3D and layer-count-1 for array resources. On
+    // ordinary 1D/2D descriptors the same bits may carry pitch state, so do not
+    // interpret them as a layer count there.
+    const bool depth_or_array = d.type == 10 || d.type == 12 || d.type == 13 || d.type == 15;
+    d.depth      = depth_or_array ? ((t[4] & 0x1FFFu) + 1u) : 1u;
+    d.base_array = (t[4] >> 16) & 0x1FFFu;
     d.dst_sel[0] = (uint8_t)((t[3] >> 0) & 0x7u);   // DST_SEL_X (WORD3 [2:0])
     d.dst_sel[1] = (uint8_t)((t[3] >> 3) & 0x7u);   // DST_SEL_Y ([5:3])
     d.dst_sel[2] = (uint8_t)((t[3] >> 6) & 0x7u);   // DST_SEL_Z ([8:6])
@@ -232,25 +237,46 @@ DecodedImageView image_base_level_view(const DecodedImageDescriptor& d,
     }
     const uint32_t element_width = (d.width + fi.block_width - 1) / fi.block_width;
     const uint32_t element_height = (d.height + fi.block_height - 1) / fi.block_height;
-    view.mip_offset = tiled_mip_level_offset(element_width, element_height, fi.bytes_per_block,
-                                              d.tile_mode, d.max_mip, d.base_level);
-    // A zero offset is conclusive for level zero, but ambiguous for a non-zero level: linear chains
-    // and levels packed inside the shared mip tail need layout-specific coordinates that this thin-2D
-    // helper intentionally does not guess. Reject those views rather than binding a different mip.
-    if (d.base_level && !view.mip_offset) {
+    // The public RDNA2 definition says MAX_MIP is the allocation's final mip, but live PS5 AGC
+    // emits a narrowly different storage-view encoding for the final pyramid level: BASE=LAST and
+    // MAX_MIP=BASE-1 (Astro: 1920x1080, BASE/LAST=6, MAX_MIP=5). Hardware accepts that descriptor.
+    // Extend only this exact one-level PS5 form; broader contradictory ranges remain rejected.
+    uint32_t effective_max_mip = d.max_mip;
+    if (d.max_mip != 0 && d.base_level == d.last_level &&
+        d.base_level == static_cast<uint32_t>(d.max_mip) + 1u)
+        effective_max_mip = d.base_level;
+    const TiledMipLevelLayout layout = tiled_mip_level_layout(
+        element_width, element_height, fi.bytes_per_block, d.tile_mode,
+        effective_max_mip, d.base_level);
+    // Linear mip chains and invalid tiled descriptors have no proven placement. A tiled level whose
+    // byte origin is zero can still be valid (the final packed-tail mip), hence the explicit status.
+    if (!layout.supported) {
+        view.supported = d.base_level == 0;
+        return view;
+    }
+    view.mip_offset = layout.byte_offset;
+    view.in_mip_tail = layout.in_tail;
+    view.mip_tail_bytes = layout.tail_block_bytes;
+    view.mip_tail_x = layout.tail_x;
+    view.mip_tail_y = layout.tail_y;
+    if (d.base_level && !effective_max_mip) {
         view.supported = false;
         return view;
     }
     view.width = std::max(d.width >> d.base_level, 1u);
     view.height = std::max(d.height >> d.base_level, 1u);
-    view.base += view.mip_offset;
+    // Non-tail mips own a disjoint byte range. Tail levels share the allocation's first block, so
+    // shifting the guest pointer would lose sibling-preserving writeback and overstate readability.
+    if (!view.in_mip_tail) view.base += view.mip_offset;
     return view;
 }
 
 void warn_unsupported_image_view(const DecodedImageDescriptor& d) {
     const uint32_t signature = static_cast<uint32_t>(d.type) |
                                (d.tile_mode << 8) |
-                               (static_cast<uint32_t>(d.base_level) << 16);
+                               (static_cast<uint32_t>(d.base_level) << 16) |
+                               (static_cast<uint32_t>(d.last_level) << 20) |
+                               (static_cast<uint32_t>(d.max_mip) << 24);
     static std::mutex warning_mutex;
     static std::set<uint32_t> warned;
     static bool suppression_reported = false;
@@ -266,9 +292,11 @@ void warn_unsupported_image_view(const DecodedImageDescriptor& d) {
     }
     warned.insert(signature);
     fprintf(stderr,
-            "[t#] unsupported BASE_LEVEL %u for type=%u tile_mode=%u (%ux%u T#); "
+            "[t#] unsupported BASE_LEVEL %u (last=%u max_mip=%u) for type=%u tile_mode=%u "
+            "fmt=%u (%ux%u T#); "
             "skipping image binding\n",
-            d.base_level, d.type, d.tile_mode, d.width, d.height);
+            d.base_level, d.last_level, d.max_mip, d.type, d.tile_mode, d.format,
+            d.width, d.height);
 }
 
 uint32_t image_type_to_dim(uint8_t type) {
@@ -573,11 +601,17 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.height        = view.height;
             r.depth         = d.depth;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
+            r.in_mip_tail   = view.in_mip_tail;
+            r.mip_tail_offset = view.in_mip_tail
+                ? static_cast<uint32_t>(view.mip_offset) : 0;
+            r.mip_tail_bytes = view.mip_tail_bytes;
+            r.mip_tail_x = view.mip_tail_x;
+            r.mip_tail_y = view.mip_tail_y;
             r.max_uncompressed_block_size = d.max_uncompressed_block_size;
             r.max_compressed_block_size = d.max_compressed_block_size;
             // DCC metadata has its own per-mip layout. Until that offset is proven, a shifted texel
             // view must not be paired with the allocation-level metadata base for another mip.
-            const bool shifted_view = view.mip_offset != 0;
+            const bool shifted_view = view.mip_offset != 0 || view.in_mip_tail;
             r.meta_pipe_aligned = shifted_view ? false : d.meta_pipe_aligned;
             r.write_compress_enabled = shifted_view ? false : d.write_compress_enabled;
             r.compression_enabled = shifted_view ? false : d.compression_enabled;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -196,12 +196,26 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.last_level = (t[3] >> 16) & 0xFu;
     d.max_mip    = (t[5] >> 4) & 0xFu;
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
-    // WORD4.DEPTH is depth-1 for 3D and layer-count-1 for array resources. On
-    // ordinary 1D/2D descriptors the same bits may carry pitch state, so do not
-    // interpret them as a layer count there.
-    const bool depth_or_array = d.type == 10 || d.type == 12 || d.type == 13 || d.type == 15;
-    d.depth      = depth_or_array ? ((t[4] & 0x1FFFu) + 1u) : 1u;
-    d.base_array = (t[4] >> 16) & 0x1FFFu;
+    // WORD4.DEPTH is depth-1 for 3D, but the LAST_ARRAY slice for array resources.  BASE_ARRAY is
+    // the first selected slice, so an array view contains last-first+1 layers (not last+1).
+    const uint32_t depth_or_last = t[4] & 0x1FFFu;
+    const bool is_array = d.type == 11 || d.type == 12 || d.type == 13 || d.type == 15;
+    if (d.type == 10) {
+        // ARRAY_PITCH bit 0 distinguishes a 3D SRV (depth relative to mip 0) from a UAV view,
+        // where BASE_ARRAY/DEPTH are the first/last selected layers.
+        const bool is_uav_view = (t[5] & 1u) != 0;
+        if (is_uav_view) {
+            d.base_array = (t[4] >> 16) & 0x1FFFu;
+            d.depth = depth_or_last >= d.base_array
+                ? depth_or_last - d.base_array + 1u : 0u;
+        } else {
+            d.depth = depth_or_last + 1u;
+        }
+    } else if (is_array) {
+        d.base_array = (t[4] >> 16) & 0x1FFFu;
+        d.depth = depth_or_last >= d.base_array
+            ? depth_or_last - d.base_array + 1u : 0u;
+    }
     d.dst_sel[0] = (uint8_t)((t[3] >> 0) & 0x7u);   // DST_SEL_X (WORD3 [2:0])
     d.dst_sel[1] = (uint8_t)((t[3] >> 3) & 0x7u);   // DST_SEL_Y ([5:3])
     d.dst_sel[2] = (uint8_t)((t[3] >> 6) & 0x7u);   // DST_SEL_Z ([8:6])
@@ -224,6 +238,13 @@ DecodedImageView image_base_level_view(const DecodedImageDescriptor& d,
     view.base = d.base;
     view.width = d.width;
     view.height = d.height;
+    // The selected array slice changes the texel origin.  Until the per-tile-mode slice stride is
+    // modeled, a nonzero BASE_ARRAY must fail closed instead of binding slice zero with the selected
+    // layer count.
+    if (d.base_array != 0 || d.depth == 0) {
+        view.supported = false;
+        return view;
+    }
     // The offset helper models only thin 2D allocations. Cube, 3D, array, and MSAA resources have
     // additional slice/tail rules. Level zero still names their allocation base, but a non-zero view
     // must be rejected until those rules are modeled; returning the base would sample the wrong mip.
@@ -495,7 +516,8 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             if (tsrt == 0xFFFFFFFFu) continue;                  // out of block / EUD absent / unreadable
             const bool tex_in_eud = (uint64_t)off + 8 > num_user_sgprs;
             DecodedImageDescriptor d = decode_image_descriptor(tv);
-            if (d.base == 0 || d.width == 0 || d.height == 0 ||
+            if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
+                d.base_array != 0 ||
                 d.width > 16384 || d.height > 16384) continue;  // skip a garbage/degenerate T#
             // PROSPER_DUMP_TILERAW (issue #282 derivation): dump the raw guest texel bytes of a tiled
             // texture once per address, so its GPU tile swizzle can be reversed offline (coherence

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -120,6 +120,7 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 struct DecodedImageDescriptor {
     uint64_t base = 0;
     uint32_t width = 0, height = 0, depth = 1;
+    uint32_t base_array = 0;
     uint32_t format = 0;      // Gen5 surface-format enum (fields[1] bits 20..28)
     uint32_t tile_mode = 0;   // 0 = linear
     uint8_t  base_level = 0;  // WORD3[15:12]
@@ -168,6 +169,11 @@ struct DecodedImageView {
     uint64_t base = 0;
     uint32_t width = 0, height = 0;
     size_t mip_offset = 0;
+    // Packed-tail views keep `base` at the allocation's first shared macroblock. mip_offset is the
+    // byte origin inside that block and must be applied by the tail-aware detile/writeback helpers.
+    bool in_mip_tail = false;
+    uint32_t mip_tail_bytes = 0;
+    uint32_t mip_tail_x = 0, mip_tail_y = 0;
     // False when BASE_LEVEL selects a mip whose layout this helper cannot prove. Callers must reject
     // the binding instead of silently sampling the allocation's base level with the wrong dimensions.
     bool supported = true;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 13;
+constexpr uint32_t kVersion = 15;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -240,7 +240,8 @@ void write_resource(Writer& w, const GpuCapturedResource& c) {
     w.u32(static_cast<uint32_t>(r.cls)); w.u32(static_cast<uint32_t>(r.format));
     w.u32(r.num_components); w.u32(r.binding); w.u64(r.gpu_addr); w.u32(r.size); w.u32(r.stride);
     w.u32(r.srt_offset); w.u32(r.sgpr_base); w.u32(r.fetch_pc); w.u32(r.img_dim);
-    w.u32(r.width); w.u32(r.height); w.u32(r.tile_mode); w.u8(r.srgb); w.u32(r.sampler_sgpr_base);
+    w.u32(r.width); w.u32(r.height);
+    w.u32(r.tile_mode); w.u8(r.srgb); w.u32(r.sampler_sgpr_base);
     w.u32(r.mag_filter); w.u32(r.min_filter); w.u32(r.mip_filter); for (auto v : r.addr_uvw) w.u32(v);
     w.u32(r.border_color_type); w.f32(r.min_lod); w.f32(r.max_lod); w.f32(r.lod_bias);
     w.u32(r.max_aniso_ratio); w.u32(r.depth_compare_func); w.u32(r.unnormalized);
@@ -248,14 +249,17 @@ void write_resource(Writer& w, const GpuCapturedResource& c) {
     w.u32(c.blob_index); w.u64(c.blob_offset);
 }
 
-bool read_resource(Reader& rd, GpuCapturedResource& c) {
+bool read_resource(Reader& rd, GpuCapturedResource& c, uint32_t version) {
     auto& r = c.resource; uint32_t cls, fmt; uint8_t b;
     if (!rd.u32(cls) || cls > static_cast<uint32_t>(ResourceClass::StorageImage) ||
         !rd.u32(fmt) || fmt > static_cast<uint32_t>(DataFormat::Unorm2_10_10_10)) return false;
     r.cls = static_cast<ResourceClass>(cls); r.format = static_cast<DataFormat>(fmt);
     if (!rd.u32(r.num_components) || !rd.u32(r.binding) || !rd.u64(r.gpu_addr) || !rd.u32(r.size) ||
         !rd.u32(r.stride) || !rd.u32(r.srt_offset) || !rd.u32(r.sgpr_base) || !rd.u32(r.fetch_pc) ||
-        !rd.u32(r.img_dim) || !rd.u32(r.width) || !rd.u32(r.height) || !rd.u32(r.tile_mode) || !rd.u8(b)) return false;
+        !rd.u32(r.img_dim) || !rd.u32(r.width) || !rd.u32(r.height)) return false;
+    r.depth = 1;
+    r.depth_compare = false;
+    if (!rd.u32(r.tile_mode) || !rd.u8(b)) return false;
     r.srgb = b != 0;
     if (!rd.u32(r.sampler_sgpr_base) || !rd.u32(r.mag_filter) || !rd.u32(r.min_filter) || !rd.u32(r.mip_filter)) return false;
     for (auto& v : r.addr_uvw) if (!rd.u32(v)) return false;
@@ -270,9 +274,10 @@ void write_table(Writer& w, const GpuCapturedTable& t) {
     for (const auto& r : t.resources) write_resource(w, r);
 }
 
-bool read_table(Reader& r, GpuCapturedTable& t) {
+bool read_table(Reader& r, GpuCapturedTable& t, uint32_t version) {
     uint8_t b; uint32_t n; if (!r.u8(b) || !r.u32(n) || n > kMaxResources) return false;
-    t.present = b != 0; t.resources.resize(n); for (auto& x : t.resources) if (!read_resource(r, x)) return false;
+    t.present = b != 0; t.resources.resize(n);
+    for (auto& x : t.resources) if (!read_resource(r, x, version)) return false;
     if (!t.present && n != 0) { if (r.error) *r.error = "absent resource table has resources"; return false; }
     return true;
 }
@@ -1126,6 +1131,65 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         if (!write_dcc_metadata(draw.vrt) || !write_dcc_metadata(draw.prt)) return false;
     for (const auto& compute : c.computes)
         if (!write_dcc_metadata(compute.resources)) return false;
+    // v14 records whether an image is declared for depth comparison. Keep this in a deterministic
+    // extension tail, just like the v9 depth and v11/v12 DCC additions, so every older resource
+    // record remains byte-compatible.
+    w.u32(static_cast<uint32_t>(resource_depth_count));
+    auto write_depth_compare = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources)
+            w.u8(captured.resource.depth_compare);
+    };
+    for (const auto& draw : c.draws) {
+        write_depth_compare(draw.vrt);
+        write_depth_compare(draw.prt);
+    }
+    for (const auto& compute : c.computes) write_depth_compare(compute.resources);
+    // v15 records packed GFX10 mip-tail placement. Tail siblings share one captured allocation block,
+    // so replay must retain both the common base and the selected in-block byte origin.
+    w.u32(static_cast<uint32_t>(resource_depth_count));
+    auto write_mip_tail = [&](const GpuCapturedTable& table, const char* owner,
+                              size_t owner_index) {
+        for (size_t resource_index = 0; resource_index < table.resources.size();
+             ++resource_index) {
+            const auto& captured = table.resources[resource_index];
+            const auto& resource = captured.resource;
+            if ((resource.in_mip_tail &&
+                 (resource.mip_tail_bytes != 4096u && resource.mip_tail_bytes != 65536u)) ||
+                (resource.in_mip_tail && resource.mip_tail_offset >= resource.mip_tail_bytes) ||
+                (!resource.in_mip_tail &&
+                 (resource.mip_tail_offset != 0 || resource.mip_tail_bytes != 0 ||
+                  resource.mip_tail_x != 0 || resource.mip_tail_y != 0))) {
+                char detail[512]{};
+                std::snprintf(detail, sizeof(detail),
+                              "invalid resource mip-tail state: %s[%zu] resource[%zu] "
+                              "class=%u binding=%u addr=0x%llx size=%u enabled=%u "
+                              "offset=%u bytes=%u xy=(%u,%u)",
+                              owner, owner_index, resource_index,
+                              static_cast<unsigned>(resource.cls), resource.binding,
+                              static_cast<unsigned long long>(resource.gpu_addr), resource.size,
+                              resource.in_mip_tail ? 1u : 0u, resource.mip_tail_offset,
+                              resource.mip_tail_bytes, resource.mip_tail_x,
+                              resource.mip_tail_y);
+                error = detail;
+                return false;
+            }
+            w.u8(resource.in_mip_tail);
+            w.u32(resource.mip_tail_offset);
+            w.u32(resource.mip_tail_bytes);
+            w.u32(resource.mip_tail_x);
+            w.u32(resource.mip_tail_y);
+        }
+        return true;
+    };
+    for (size_t draw_index = 0; draw_index < c.draws.size(); ++draw_index) {
+        const auto& draw = c.draws[draw_index];
+        if (!write_mip_tail(draw.vrt, "draw-vs", draw_index) ||
+            !write_mip_tail(draw.prt, "draw-ps", draw_index))
+            return false;
+    }
+    for (size_t compute_index = 0; compute_index < c.computes.size(); ++compute_index)
+        if (!write_mip_tail(c.computes[compute_index].resources, "compute", compute_index))
+            return false;
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1231,8 +1295,8 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             d.vs = c.shader_versions[vs_index].words;
             d.fs = c.shader_versions[fs_index].words;
         } else if (!r.words(d.vs) || !r.words(d.fs)) return false;
-        if (!read_pipeline(r, d.ps, version) || !read_table(r, d.vrt) ||
-            !read_table(r, d.prt) || !r.u32(d.vertex_count) || !r.words(d.indices) || !r.u64(d.color0_base)) return false;
+        if (!read_pipeline(r, d.ps, version) || !read_table(r, d.vrt, version) ||
+            !read_table(r, d.prt, version) || !r.u32(d.vertex_count) || !r.words(d.indices) || !r.u64(d.color0_base)) return false;
         if (version >= 3 && (!r.u32(d.color0_width) || !r.u32(d.color0_height))) return false;
         if (version >= 5 && (!r.u64(d.draw_index) || !r.u64(d.command_order))) return false;
     }
@@ -1246,7 +1310,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 error = "invalid compute shader-version index"; return false;
             }
             compute.spirv = c.shader_versions[shader_index].words;
-            if (!read_table(r, compute.resources) ||
+            if (!read_table(r, compute.resources, version) ||
                 !r.u32(compute.launch.threads_x) || !r.u32(compute.launch.threads_y) || !r.u32(compute.launch.threads_z) ||
                 !r.u32(compute.launch.local_x) || !r.u32(compute.launch.local_y) || !r.u32(compute.launch.local_z) ||
                 !r.u32(compute.launch.groups_x) || !r.u32(compute.launch.groups_y) || !r.u32(compute.launch.groups_z) ||
@@ -1499,6 +1563,68 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         for (auto& compute : c.computes)
             if (!read_dcc_metadata(compute.resources)) return false;
     }
+    if (version >= 14) {
+        uint64_t expected_states = 0;
+        for (const auto& draw : c.draws)
+            expected_states += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected_states += compute.resources.resources.size();
+        uint32_t state_count = 0;
+        if (!r.u32(state_count) || state_count != expected_states) {
+            error = "invalid resource depth-compare count"; return false;
+        }
+        auto read_depth_compare = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                uint8_t enabled = 0;
+                if (!r.u8(enabled) || enabled > 1) {
+                    error = "invalid resource depth-compare state"; return false;
+                }
+                captured.resource.depth_compare = enabled != 0;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_depth_compare(draw.vrt) || !read_depth_compare(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_depth_compare(compute.resources)) return false;
+    }
+    if (version >= 15) {
+        uint64_t expected_states = 0;
+        for (const auto& draw : c.draws)
+            expected_states += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected_states += compute.resources.resources.size();
+        uint32_t state_count = 0;
+        if (!r.u32(state_count) || state_count != expected_states) {
+            error = "invalid resource mip-tail count"; return false;
+        }
+        auto read_mip_tail = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                auto& resource = captured.resource;
+                uint8_t enabled = 0;
+                if (!r.u8(enabled) || enabled > 1 ||
+                    !r.u32(resource.mip_tail_offset) ||
+                    !r.u32(resource.mip_tail_bytes) ||
+                    !r.u32(resource.mip_tail_x) ||
+                    !r.u32(resource.mip_tail_y) ||
+                    (enabled && resource.mip_tail_bytes != 4096u &&
+                                resource.mip_tail_bytes != 65536u) ||
+                    (enabled && resource.mip_tail_offset >= resource.mip_tail_bytes) ||
+                    (!enabled && (resource.mip_tail_offset != 0 ||
+                                  resource.mip_tail_bytes != 0 ||
+                                  resource.mip_tail_x != 0 ||
+                                  resource.mip_tail_y != 0))) {
+                    error = "invalid resource mip-tail state"; return false;
+                }
+                resource.in_mip_tail = enabled != 0;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_mip_tail(draw.vrt) || !read_mip_tail(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_mip_tail(compute.resources)) return false;
+    }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
 }
@@ -1665,6 +1791,46 @@ bool read_all_gpu_capture_ds_seeds(std::vector<GpuCaptureDsSeed>& seeds, std::st
     return true;
 }
 
+bool gpu_capture_ds_seed_snapshot_available() {
+    return static_cast<bool>(g_ds_seed_snapshot_reader);
+}
+
+bool capture_referenced_gpu_ds_seeds(GpuCaptureFile& capture, std::string& error) {
+    error.clear();
+    if (!capture.ds_seeds.empty()) {
+        error = "capture already contains DS checkpoints";
+        return false;
+    }
+    const bool metadata_only = std::any_of(
+        capture.metadata.renderer_env.begin(), capture.metadata.renderer_env.end(),
+        [](const auto& entry) {
+            return entry.first == "PROSPER_GPU_CAPTURE_METADATA_ONLY" &&
+                   !entry.second.empty() && entry.second != "0" && entry.second != "off";
+        });
+    if (metadata_only) return true;
+
+    std::vector<GpuCaptureDsSeed> live;
+    if (!read_all_gpu_capture_ds_seeds(live, error)) return false;
+    for (auto& seed : live) {
+        const bool referenced = std::any_of(
+            capture.draws.begin(), capture.draws.end(), [&](const GpuCapturedDraw& draw) {
+                const auto& ps = draw.ps;
+                const bool uses_ds = ps.depth_test_enable || ps.depth_write_enable ||
+                                     ps.depth_clear_enable || ps.stencil_enable ||
+                                     ps.stencil_clear_enable;
+                return uses_ds && draw.color0_width == seed.width &&
+                       draw.color0_height == seed.height &&
+                       ps.depth_read_base == seed.depth_read_base &&
+                       ps.depth_write_base == seed.depth_write_base &&
+                       ps.stencil_read_base == seed.stencil_read_base &&
+                       ps.stencil_write_base == seed.stencil_write_base &&
+                       ps.htile_data_base == seed.htile_data_base;
+            });
+        if (referenced) capture.ds_seeds.push_back(std::move(seed));
+    }
+    return true;
+}
+
 void set_gpu_replay_ds_seed_writer(ReplayDsSeedWriter writer) {
     g_ds_seed_writer = std::move(writer);
 }
@@ -1721,6 +1887,7 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
         "PROSPER_NO_SWIZZLE", "PROSPER_NODETILE",
         "PROSPER_DESCRIPTOR_VALIDATE",
         "PROSPER_PITCH", "PROSPER_RENDER_NOPS", "PROSPER_RENDER_REFVS", "PROSPER_RENDER_TESTPS",
+        "PROSPER_RENDER_TESTPS_MATCH",
         "PROSPER_RTT", "PROSPER_RTT_NOSEED", "PROSPER_RTT_PERTARGET", "PROSPER_RTT_SINGLE_TARGET",
         "PROSPER_DUMP_RTGROUPS", "PROSPER_DUMP_RTGROUPS_RGBA", "PROSPER_DUMP_RTGROUPS_ADDR",
         "PROSPER_DUMP_DRAWSTEPS",

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -256,6 +256,10 @@ void set_gpu_replay_rtt_seed_writer(ReplayRttSeedWriter writer);
 bool restore_gpu_replay_rtt_seeds(const std::vector<GpuCaptureRttSeed>& seeds, std::string& error);
 void set_gpu_capture_ds_seed_snapshot_reader(CaptureDsSeedSnapshotReader reader);
 bool read_all_gpu_capture_ds_seeds(std::vector<GpuCaptureDsSeed>& seeds, std::string& error);
+bool gpu_capture_ds_seed_snapshot_available();
+// Add only live depth/stencil checkpoints referenced by this capsule's realized draws. Standalone
+// pre-render captures otherwise replay a read-only depth pass against a newly-cleared attachment.
+bool capture_referenced_gpu_ds_seeds(GpuCaptureFile& capture, std::string& error);
 void set_gpu_replay_ds_seed_writer(ReplayDsSeedWriter writer);
 bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std::string& error);
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -40,6 +40,7 @@ struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backe
 // correctly instead of collapsing onto a single draw. The tables may be null (color-only shaders).
 struct DrawItem {
     std::vector<uint32_t> vs, fs;                     // recompiled SPIR-V
+    uint64_t vs_guest_addr = 0, fs_guest_addr = 0;    // diagnostic/source identity in guest VA space
     // Process-unique identities supplied by the exact shader-recompile cache. Zero means the
     // shader came from an external/replay path, so persistent backend caches must compare words.
     uint64_t vs_identity = 0, fs_identity = 0;
@@ -116,6 +117,9 @@ struct SrtUse {
     // STORAGE image, not a sampled texture (#590 — the recompiler's storage path requires
     // ResourceClass::StorageImage). Only meaningful for kind 0.
     bool is_store = false;
+    // The consuming MIMG opcode is a comparison/depth sample (IMAGE_SAMPLE_C*). This is a
+    // property of the use, not merely the S# compare function: NEVER is a valid compare op.
+    bool is_depth_compare = false;
 };
 std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             const uint32_t* user_sgprs, uint32_t nsgpr,
@@ -448,7 +452,9 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // the textures it SAMPLES. If a sampled texture's base equals some draw's color0_base, that surface is
     // a GPU render target (the game renders into it then samples it) -> render-to-texture (#83/#101).
     if (getenv("PROSPER_RTLOG")) {
-        fprintf(stderr, "[rt] color0=0x%llx", (unsigned long long)rs.color0_base);
+        fprintf(stderr, "[rt] color0=0x%llx %ux%u cf=0x%x nt=%u cs=%u",
+                (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
+                rs.color0_format, rs.color0_number_type, rs.color0_comp_swap);
         if (prt) for (const auto& r : prt->resources)
             if (r.cls == ResourceClass::Texture)
                 fprintf(stderr, " tex=0x%llx(%ux%u f%u c%u)", (unsigned long long)r.gpu_addr, r.width, r.height,
@@ -543,6 +549,28 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 g_dyntrace_force = false;
             }
         }
+        if (getenv("PROSPER_DBG"))
+            fprintf(stderr, "[exec-recompile-reject] es=0x%llx ps=0x%llx vs=%zu fs=%zu order=%llu\n",
+                    (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                    vs.size(), fs.size(),
+                    (unsigned long long)(draw ? draw->command_order : 0));
+        if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
+            for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
+                if (!addr || !guest_readable(addr, sizeof(uint32_t))) continue;
+                const size_t dump_dwords = rdna2_recompile_code_span(
+                    reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(addr)),
+                    max_shader_dwords);
+                const size_t dump_bytes = dump_dwords * sizeof(uint32_t);
+                if (!dump_bytes || !guest_readable(addr, static_cast<uint32_t>(dump_bytes))) continue;
+                char fn[512];
+                snprintf(fn, sizeof fn, "%s/exec_%s_%llx.bin", dd, tag,
+                         (unsigned long long)addr);
+                if (FILE* f = fopen(fn, "wb")) {
+                    fwrite((const void*)(uintptr_t)addr, 1, dump_bytes, f);
+                    fclose(f);
+                }
+            }
+        }
         if (log) {
             fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; order=%llu "
                             "es=0x%llx ps=0x%llx color0=0x%llx/%ux%u "
@@ -564,12 +592,6 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 fprintf(stderr, "[exec]   %s coverage: total=%u alu=%u exp=%u tabledep=%u unsupported=%u "
                                 "first_bad fmt=%d op=0x%x\n", tag, c.total, c.alu, c.exports,
                         c.table_dependent, c.unsupported, c.first_bad_fmt, c.first_bad_op);
-                if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
-                    // 64 KB: a large UE4 post-process PS (~1500 instrs) far exceeds the old 4 KB
-                    // window, which truncated the very control-flow tail the reject is about (#319).
-                    char fn[512]; snprintf(fn, sizeof fn, "%s/exec_%s_%llx.bin", dd, tag, (unsigned long long)addr);
-                    if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)addr, 1, 0x10000, f); fclose(f); }
-                }
             }
         }
         return false;
@@ -813,6 +835,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
     }
     out.vs = std::move(vs); out.fs = std::move(fs);
+    out.vs_guest_addr = rs.es_addr; out.fs_guest_addr = rs.ps_addr;
     out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
     out.color0_base = rs.color0_base;   // render-to-texture: the target this draw writes into (#167)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1255,14 +1255,30 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             from_seed = true;
                         }
                     }
-                    if (trc) fprintf(stderr, "[dyntrace] MIMG pc=%u srsrc=s%d ssamp=s%d have_t8=%d seed_t8=%d key=0x%x t8[0]=0x%x\n",
-                                     in.pc, tbase, samp_base, have_t8, from_seed,
-                                     tkey, t8 ? (*t8)[0] : 0u);
+                    if (trc) {
+                        fprintf(stderr, "[dyntrace] MIMG pc=%u op=0x%x srsrc=s%d ssamp=s%d "
+                                        "have_t8=%d seed_t8=%d key=0x%x t8=",
+                                in.pc, in.opcode, tbase, samp_base, have_t8, from_seed, tkey);
+                        if (t8) {
+                            for (uint32_t word : *t8) fprintf(stderr, "%08x ", word);
+                            const DecodedImageDescriptor td = decode_image_descriptor(t8->data());
+                            fprintf(stderr,
+                                    "-> base=0x%llx %ux%ux%u type=%u fmt=%u tile=%u mip=%u:%u",
+                                    (unsigned long long)td.base, td.width, td.height, td.depth,
+                                    td.type, td.format, td.tile_mode, td.base_level, td.max_mip);
+                        } else {
+                            fprintf(stderr, "<unknown>");
+                        }
+                        fputc('\n', stderr);
+                    }
                     if (t8) {
                         SrtUse u; u.kind = 0; u.t8 = *t8;
                         u.key = tkey;
                         u.use_pc = in.pc;
                         u.is_store = in.opcode == 0x08;   // image_store: a STORAGE-image use (#590)
+                        u.is_depth_compare = (in.opcode >= 0x28 && in.opcode <= 0x2f) ||
+                                             (in.opcode >= 0x38 && in.opcode <= 0x3f) ||
+                                             (in.opcode >= 0x58 && in.opcode <= 0x5f);
                         if (valid_reg(samp_base) && descr_known.test((size_t)samp_base)) {
                             u.has_samp = true;
                             u.s4 = descr[(size_t)samp_base];
@@ -1285,7 +1301,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // a keyed table slot. Report it as a kind-1 (buffer) use so the consuming instruction
                 // resolves via its sreg_srt tag -> by_srt_offset — the same key model the s_buffer_loads
                 // use. (The VS vertex-fetch path below is unchanged: by_fetch_pc still wins there.)
-                if (srt_uses && (in.opcode <= 3 || (in.opcode >= 0x0C && in.opcode <= 0x0F))) {
+                const bool raw_buffer_use =
+                    (in.opcode >= 0x08 && in.opcode <= 0x0F) ||
+                    (in.opcode >= 0x1C && in.opcode <= 0x1E);
+                if (srt_uses && (in.opcode <= 3 || raw_buffer_use)) {
                     int srsrc = in.src[1].value;
                     if (valid_reg(srsrc) && descr_known.test((size_t)srsrc)) {
                         // Key-less snapshots (an s_buffer_load-fetched V# — a structured-buffer
@@ -1297,7 +1316,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             ? descr_key[(size_t)srsrc] : 0xFFFFFFFFu;
                         u.use_pc = in.pc;
                         srt_uses->push_back(u);
-                    } else if (in.opcode >= 0x0C && untouched_seed_range(srsrc, 4)) {
+                    } else if (raw_buffer_use && untouched_seed_range(srsrc, 4)) {
                         // Direct RAW V#: an untyped MUBUF can consume a V# placed in the initial
                         // user-data SGPRs without any preceding s_load. This is not a vertex-format
                         // fetch, so the dyn_vb path below never reports it. Preserve the exact V# as
@@ -1559,7 +1578,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         }
         for (uint32_t base : bases) {
             uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, base, sgprs);
-            fprintf(stderr, "[resdump]   sgprs@0x%x:", base);
+            fprintf(stderr, "[resdump] %s code=0x%llx sgprs@0x%x:",
+                    is_ps ? "PS" : "VS", (unsigned long long)code_addr, base);
             for (uint32_t i = 0; i < kUserSgprs; i++) fprintf(stderr, " %08x", sgprs[i]);
             fprintf(stderr, "\n");
         }
@@ -1762,7 +1782,12 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         for (auto& r0 : t.resources)
                             if (r0.cls == ResourceClass::Texture && r0.gpu_addr == view.base &&
                                 r0.width == view.width && r0.height == view.height &&
-                                r0.depth == d.depth && r0.format == fi.format && r0.img_dim == img_dim) {
+                                r0.depth == d.depth && r0.format == fi.format && r0.img_dim == img_dim &&
+                                r0.depth_compare == u.is_depth_compare &&
+                                r0.in_mip_tail == view.in_mip_tail &&
+                                r0.mip_tail_offset == (view.in_mip_tail ? view.mip_offset : 0) &&
+                                r0.mip_tail_x == view.mip_tail_x &&
+                                r0.mip_tail_y == view.mip_tail_y) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
                                 if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
                             }
@@ -1773,9 +1798,15 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.format = fi.format; r.num_components = fi.num_components;
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
+                    r.in_mip_tail = view.in_mip_tail;
+                    r.mip_tail_offset = view.in_mip_tail
+                        ? static_cast<uint32_t>(view.mip_offset) : 0;
+                    r.mip_tail_bytes = view.mip_tail_bytes;
+                    r.mip_tail_x = view.mip_tail_x;
+                    r.mip_tail_y = view.mip_tail_y;
                     r.max_uncompressed_block_size = d.max_uncompressed_block_size;
                     r.max_compressed_block_size = d.max_compressed_block_size;
-                    const bool shifted_view = view.mip_offset != 0;
+                    const bool shifted_view = view.mip_offset != 0 || view.in_mip_tail;
                     r.meta_pipe_aligned = shifted_view ? false : d.meta_pipe_aligned;
                     r.write_compress_enabled = shifted_view ? false : d.write_compress_enabled;
                     r.compression_enabled = shifted_view ? false : d.compression_enabled;
@@ -1785,6 +1816,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     // T# TYPE -> MIMG dim (GFX10: 9=2D, 10=3D, 11=CUBE, 13=2D_ARRAY); a cube
                     // uploads as six vertically-stacked faces (#273 — see agc_shader_layout).
                     r.img_dim = img_dim;
+                    r.depth_compare = u.is_depth_compare;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     const uint64_t backing_bytes = is_bcn
@@ -2084,7 +2116,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     if (mapped_fmt && fi.block_width > 1 && fi.snorm) continue;   // signed BCn: not wired
                     const DecodedImageView view = mapped_fmt
                         ? image_base_level_view(d, fi)
-                        : DecodedImageView{d.base, d.width, d.height, 0, d.base_level == 0};
+                        : DecodedImageView{d.base, d.width, d.height, 0, false, 0, 0, 0,
+                                           d.base_level == 0};
                     if (!view.supported) {
                         warn_unsupported_image_view(d);
                         continue;
@@ -2099,7 +2132,11 @@ std::vector<ComputeItem> realize_compute_dispatches(
                             if (r0.cls == wanted && r0.gpu_addr == view.base &&
                                 r0.width == view.width && r0.height == view.height &&
                                 r0.depth == d.depth && r0.format == view_format &&
-                                r0.img_dim == img_dim) {
+                                r0.img_dim == img_dim && r0.depth_compare == u.is_depth_compare &&
+                                r0.in_mip_tail == view.in_mip_tail &&
+                                r0.mip_tail_offset == (view.in_mip_tail ? view.mip_offset : 0) &&
+                                r0.mip_tail_x == view.mip_tail_x &&
+                                r0.mip_tail_y == view.mip_tail_y) {
                                 if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
                                 if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
                             }
@@ -2124,9 +2161,15 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     }
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode;
+                    r.in_mip_tail = view.in_mip_tail;
+                    r.mip_tail_offset = view.in_mip_tail
+                        ? static_cast<uint32_t>(view.mip_offset) : 0;
+                    r.mip_tail_bytes = view.mip_tail_bytes;
+                    r.mip_tail_x = view.mip_tail_x;
+                    r.mip_tail_y = view.mip_tail_y;
                     r.max_uncompressed_block_size = d.max_uncompressed_block_size;
                     r.max_compressed_block_size = d.max_compressed_block_size;
-                    const bool shifted_view = view.mip_offset != 0;
+                    const bool shifted_view = view.mip_offset != 0 || view.in_mip_tail;
                     r.meta_pipe_aligned = shifted_view ? false : d.meta_pipe_aligned;
                     r.write_compress_enabled = shifted_view ? false : d.write_compress_enabled;
                     r.compression_enabled = shifted_view ? false : d.compression_enabled;
@@ -2134,10 +2177,29 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     r.color_transform = d.color_transform;
                     r.metadata_addr = shifted_view ? 0 : d.metadata_addr;
                     r.img_dim = img_dim;
+                    r.depth_compare = u.is_depth_compare;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
                     r.fetch_pc = u.use_pc;               // per-use pc provenance (the image op)
+                    if (u.has_samp) {
+                        const uint32_t* sm = u.s4.data();
+                        r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
+                        r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
+                        r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;
+                        r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
+                        r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
+                        r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
+                        r.max_aniso_ratio    = (sm[0] >> 9) & 0x7u;
+                        r.depth_compare_func = (sm[0] >> 12) & 0x7u;
+                        r.unnormalized       = (sm[0] >> 15) & 0x1u;
+                        r.min_lod            = static_cast<float>(sm[1] & 0xFFFu) / 256.0f;
+                        r.max_lod            = static_cast<float>((sm[1] >> 12) & 0xFFFu) / 256.0f;
+                        int32_t bias14        = static_cast<int32_t>(sm[2] & 0x3FFFu);
+                        if (bias14 & 0x2000) bias14 -= 0x4000;
+                        r.lod_bias           = static_cast<float>(bias14) / 256.0f;
+                        r.border_color_type  = (sm[3] >> 30) & 0x3u;
+                    }
                     table->resources.push_back(r);
                 }
             }
@@ -2253,19 +2315,21 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 // PROSPER_SHADER_DUMP=<dir>: write the failed COMPUTE program's raw bytes for offline
                 // shader_inspect, mirroring the graphics VS/PS dump (gpu_execute.hpp). The graphics
                 // path was the only dumper, so a failing dispatch's CFG could not be mapped offline.
-                // Bounded like the graphics dump (64 KB covers the largest observed shaders); shrink
-                // to the readable prefix instead of faulting on a short final mapping.
+                // Keep the established 64 KiB diagnostic window: some compiler-generated branches
+                // jump thousands of dwords forward even when the first rejection is near the entry.
+                // The registered shader mapping is already proven readable by the decoder.
                 if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
-                    size_t n = 0x10000;
-                    while (n >= 0x1000 && !guest_readable(code_addr, (uint32_t)n)) n >>= 1;
-                    if (n >= 0x1000) {
-                        char fn[512];
-                        snprintf(fn, sizeof fn, "%s/exec_cs_%llx.bin", dd,
-                                 (unsigned long long)code_addr);
-                        if (FILE* f = fopen(fn, "wb")) {
-                            fwrite((const void*)(uintptr_t)code_addr, 1, n, f);
-                            fclose(f);
-                        }
+                    constexpr size_t dump_bytes = 0x10000;
+                    char fn[512];
+                    snprintf(fn, sizeof fn, "%s/exec_cs_%llx.bin", dd,
+                             (unsigned long long)code_addr);
+                    if (FILE* f = fopen(fn, "wb")) {
+                        fwrite(reinterpret_cast<const void*>(static_cast<uintptr_t>(code_addr)),
+                               1, dump_bytes, f);
+                        fclose(f);
+                    } else if (getenv("PROSPER_DBG")) {
+                        std::fprintf(stderr, "[shader-dump] cannot open %s: %s\n",
+                                     fn, std::strerror(errno));
                     }
                 }
             }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1817,7 +1817,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         fprintf(stderr, "[dynfail] tex use pc=%u key=0x%x base=0x%llx %ux%u fmt=%u tile=%u\n",
                                 u.use_pc, u.key, (unsigned long long)d.base, d.width, d.height,
                                 d.format, d.tile_mode);
-                    if (d.base == 0 || d.width == 0 || d.height == 0 ||
+                    if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
+                        d.base_array != 0 ||
                         d.width > 16384 || d.height > 16384) continue;       // garbage/degenerate T#
                     // A previous use already produced a resource for this SAME selected view (address +
                     // extent): don't duplicate the binding/upload — give it this use's pc provenance
@@ -2170,7 +2171,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     table->resources.push_back(r);
                 } else {                                  // T# — storage image (store) or sampled texture
                     DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
-                    if (d.base == 0 || d.width == 0 || d.height == 0 ||
+                    if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
+                        d.base_array != 0 ||
                         d.width > 16384 || d.height > 16384) continue;   // garbage/degenerate T#
                     Gen5ImageFormatInfo fi;
                     const bool mapped_fmt = gen5_image_format(d.format, &fi);

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1573,6 +1573,22 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                  static_cast<unsigned long long>(submit_no),
                  static_cast<unsigned long long>(realization_ms), capture.draws.size(),
                  capture.computes.size(), capture.operations.size(), capture.blobs.size());
+    if (gpu_capture_ds_seed_snapshot_available() &&
+        !capture_referenced_gpu_ds_seeds(capture, error)) {
+        std::fprintf(stderr, "[timeline] submit %llu DS checkpoint capture failed: %s\n",
+                     static_cast<unsigned long long>(submit_no), error.c_str());
+        history.remember(state, submit_no);
+        if (request.exit_after_capture) {
+            std::fprintf(stderr, "[timeline] selected capture failed; exiting nonzero as requested\n");
+            close_gpu_timeline();
+            std::fflush(nullptr);
+            std::exit(2);
+        }
+        return;
+    }
+    if (!capture.ds_seeds.empty())
+        std::fprintf(stderr, "[timeline] submit %llu retained %zu referenced DS checkpoint(s)\n",
+                     static_cast<unsigned long long>(submit_no), capture.ds_seeds.size());
     if (!write_gpu_capture(request.path, capture, error)) {
         std::fprintf(stderr, "[timeline] submit %llu detailed capture write failed: %s\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -113,6 +113,28 @@ void decode_operands(Rdna2Inst& i) {
                         i.has_modifier = false;
                     }
                 }
+                // Integer-to-f32 conversion may select a byte/word before conversion. Unsigned
+                // conversion zero-extends it; signed conversion honors SDWA SEXT (bit 19). Astro's
+                // title post PS uses WORD_1+SEXT for v_cvt_f32_i32.
+                // Astro title-ship PS uses the exact packet 7e0a0cf9 0000160b:
+                // v_cvt_f32_u32_sdwa v5, v11 src0_sel:BYTE_0. Destination is a full dword; the
+                // canonical UNUSED_PRESERVE value is immaterial because all 32 bits are written.
+                else if (((w >> 9) & 0xFFu) == 0x05u ||
+                         ((w >> 9) & 0xFFu) == 0x06u) {
+                    const uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    const uint32_t s0sel = (sd >> 16) & 7u;
+                    const bool signed_cvt = ((w >> 9) & 0xFFu) == 0x05u;
+                    const bool sext = ((sd >> 19) & 1u) != 0;
+                    if (dsel == 6u && (dun == 0u || dun == 2u) && s0sel <= 5u &&
+                        !((sd >> 20) & 0x7u) && (signed_cvt || !sext) &&
+                        !i.clamp && !i.omod &&
+                        !i.src_neg[0] && !i.src_abs[0]) {
+                        i.sdwa_dst_sel = static_cast<uint8_t>(dsel);
+                        i.sdwa_dst_unused = static_cast<uint8_t>(dun);
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.has_modifier = false;
+                    }
+                }
                 // Packed unary f16 SDWA selects one source half, writes one destination half, and
                 // preserves the other. The producer uses rcp/sqrt/cos (0x54/0x55/0x61).
                 else if (((w >> 9) & 0xFFu) == 0x54u ||
@@ -215,12 +237,27 @@ void decode_operands(Rdna2Inst& i) {
                 // values (`v_cmpx_gt_f16_sdwa ..., v7, 0 src0_sel:WORD_1`). Preserve the selects so
                 // the recompiler can unpack the chosen half; other sub-dword compare forms reject.
                 else {
-                    const uint32_t eff = i.opcode >= 0xD9u && i.opcode <= 0xDEu
-                                           ? i.opcode - 0x10u : i.opcode;
+                    const bool cmpx = (i.opcode >= 0x10u && i.opcode <= 0x1Fu) ||
+                                      (i.opcode >= 0x90u && i.opcode <= 0x9Fu) ||
+                                      (i.opcode >= 0xD0u && i.opcode <= 0xDFu);
+                    const uint32_t eff = cmpx ? i.opcode - 0x10u : i.opcode;
                     const uint32_t s0sel = (sd >> 16) & 7u, s1sel = (sd >> 24) & 7u;
                     if (eff >= 0xC9u && eff <= 0xCEu &&
                         s0sel >= 4u && s0sel <= 6u && s1sel >= 4u && s1sel <= 6u &&
                         !((sd >> 19) & 0x9u) && !((sd >> 27) & 0x9u)) {
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.sdwa_src1_sel = static_cast<uint8_t>(s1sel);
+                        i.has_modifier = false;
+                    }
+                    // Integer VOPC SDWA may compare a selected byte/word after zero extension.
+                    // Astro Bot uses `v_cmp_ne_u32 1, v63 src1_sel:BYTE_0` in its visibility
+                    // kernel. Admit the exact no-SEXT/no-neg/abs subset; signed extension and
+                    // integer source modifiers remain fail-visible until modeled.
+                    const bool integer_compare =
+                        (eff >= 0x81u && eff <= 0x86u) ||
+                        (eff >= 0xC1u && eff <= 0xC6u);
+                    if (integer_compare && s0sel <= 6u && s1sel <= 6u &&
+                        !((sd >> 19) & 0xFu) && !((sd >> 27) & 0xFu)) {
                         i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
                         i.sdwa_src1_sel = static_cast<uint8_t>(s1sel);
                         i.has_modifier = false;
@@ -243,7 +280,8 @@ void decode_operands(Rdna2Inst& i) {
             i.omod  = (uint8_t)((d1 >> 27) & 3u);
             // VOP3B carry ops (v_add/sub/subrev_co_ci_u32 = 0x128/0x129/0x12A): dword0[14:8] is a scalar
             // carry-OUT dst, not abs modifiers — decode it and clear the mis-read abs/clamp bits.
-            if (i.opcode == 0x128u || i.opcode == 0x129u || i.opcode == 0x12Au) {
+            if (i.opcode == 0x128u || i.opcode == 0x129u || i.opcode == 0x12Au ||
+                i.opcode == 0x176u) {
                 i.sdst = sgpr((w >> 8) & 0x7Fu);
                 i.src_abs[0] = i.src_abs[1] = i.src_abs[2] = false;
                 i.clamp = false;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -34,15 +34,20 @@ enum : uint32_t {
     Op_ULessThanEqual=178, Op_SLessThanEqual=179,
     Op_ShiftRightLogical=194, Op_ShiftRightArithmetic=195, Op_ShiftLeftLogical=196, Op_BitwiseOr=197,
     Op_BitwiseXor=198, Op_BitwiseAnd=199, Op_Not=200, Op_BitFieldSExtract=202, Op_BitFieldUExtract=203,
-    Op_BitReverse=204, Op_UConvert=113,
+    Op_BitReverse=204, Op_BitCount=205, Op_UConvert=113,
     Op_TypeImage=25, Op_TypeSampledImage=27, Op_SampledImage=86,
-    Op_ImageSampleImplicitLod=87, Op_ImageSampleExplicitLod=88, Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
+    Op_ImageSampleImplicitLod=87, Op_ImageSampleExplicitLod=88,
+    Op_ImageSampleDrefImplicitLod=89, Op_ImageSampleDrefExplicitLod=90,
+    Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
     Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQueryLevels=106,
-    Op_TypeArray=28, Op_ControlBarrier=224, Op_AtomicIAdd=234, Op_AtomicUMin=237, Op_AtomicUMax=239,
+    Op_TypeArray=28, Op_ControlBarrier=224, Op_AtomicExchange=229, Op_AtomicIAdd=234,
+    Op_AtomicISub=235,
+    Op_AtomicUMin=237, Op_AtomicUMax=239,
     Op_DPdx=207, Op_DPdy=208,   // screen-space derivatives (Fragment; plain Shader capability)
     Op_Phi=245, Op_LoopMerge=246,
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
     Op_Kill=252, Op_Return=253, Op_GroupNonUniformAny=335,
+    Op_GroupNonUniformQuadSwap=366,
 };
 // GLSL.std.450 extended-instruction numbers.
 enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Glsl_Ceil=9, Glsl_Fract=10, Glsl_Sin=13, Glsl_Cos=14,
@@ -51,6 +56,7 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_UMax=41, Glsl_SMax=42, Glsl_PackHalf2x16=58, Glsl_UnpackHalf2x16=62 };
 enum : uint32_t {
     Cap_Shader=1, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
+    Cap_GroupNonUniformQuad=68,
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_LocalSize=17,
     SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_StorageBuffer=12, FC_None=0,
@@ -65,11 +71,12 @@ enum : uint32_t {
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Sample=0x40,   // ImageOperands bits: LOD bias / explicit LOD / MSAA Sample index.
-    SC_Workgroup=4, Scope_Workgroup=2, Scope_Subgroup=3, MemSem_WGAcqRel=0x108,   // LDS: Workgroup storage + barrier scope/semantics
+    SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
+    MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage/LDS AcquireRelease memory semantics
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_Flat=14, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
     BI_Position=0, BI_FragCoord=15, BI_WorkgroupId=26, BI_LocalInvocationId=27,
-    BI_GlobalInvocationId=28, BI_VertexIndex=42,
+    BI_GlobalInvocationId=28, BI_VertexIndex=42, BI_InstanceIndex=43,
 };
 
 uint32_t fbits(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
@@ -206,6 +213,18 @@ struct SpirvCompute {
     uint32_t subgroup_any(uint32_t value) {
         uint32_t result = id();
         put(code, Op_GroupNonUniformAny, {t_bool, result, uconst(Scope_Subgroup), value});
+        return result;
+    }
+    bool declared_subgroup_quad = false;
+    uint32_t subgroup_quad_swap(uint32_t value, uint32_t direction) {
+        if (!declared_subgroup_quad) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            put(caps, Op_Capability, {Cap_GroupNonUniformQuad});
+            declared_subgroup_quad = true;
+        }
+        uint32_t result = id();
+        put(code, Op_GroupNonUniformQuadSwap,
+            {t_u32, result, uconst(Scope_Subgroup), value, uconst(direction)});
         return result;
     }
     // Fragment discard: OpKill any lane where `alive` is false, survivors fall through to `mergeL`. Used to
@@ -369,21 +388,25 @@ struct SpirvCompute {
     uint32_t t_v3f() { if (!t_v3f_cache) { t_v3f_cache = id(); put(types, Op_TypeVector, {t_v3f_cache, t_f32, 3}); } return t_v3f_cache; }
     uint32_t t_v3i_cache = 0;
     uint32_t t_v3i() { if (!t_v3i_cache) { t_v3i_cache = id(); put(types, Op_TypeVector, {t_v3i_cache, t_i32, 3}); } return t_v3i_cache; }
-    static uint32_t sampled_image_key(uint32_t dim, bool is_uint) {
-        return dim | (is_uint ? 0x100u : 0u);
+    static uint32_t sampled_image_key(uint32_t dim, bool is_uint, bool arrayed, bool depth) {
+        return dim | (is_uint ? 0x100u : 0u) | (arrayed ? 0x200u : 0u) |
+               (depth ? 0x400u : 0u);
     }
-    uint32_t sampled_image_type(uint32_t dim, bool is_uint = false) {
-        const uint32_t key = sampled_image_key(dim, is_uint);
+    uint32_t sampled_image_type(uint32_t dim, bool is_uint = false,
+                                bool arrayed = false, bool depth = false) {
+        const uint32_t key = sampled_image_key(dim, is_uint, arrayed, depth);
         auto it = tex_simg_type.find(key); if (it != tex_simg_type.end()) return it->second;
         uint32_t ti = id(); put(types, Op_TypeImage, {ti, is_uint ? t_u32 : t_f32,
-                                                      dim, 0, 0, 0, 1, 0});  // sampled, Sampled=1
+                                                      dim, depth ? 1u : 0u, arrayed ? 1u : 0u,
+                                                      0, 1, 0});  // sampled, Sampled=1
         uint32_t si = id(); put(types, Op_TypeSampledImage, {si, ti});
         tex_simg_type[key] = si; tex_img_type[key] = ti; return si;
     }
     // Declare (idempotently) a combined image+sampler of SPIR-V `dim` at descriptor-set 0, `binding`.
-    void declare_texture(uint32_t binding, uint32_t dim = Dim_2D, bool is_uint = false) {
-        const uint32_t key = sampled_image_key(dim, is_uint);
-        uint32_t simg = sampled_image_type(dim, is_uint);
+    void declare_texture(uint32_t binding, uint32_t dim = Dim_2D, bool is_uint = false,
+                         bool arrayed = false, bool depth = false) {
+        const uint32_t key = sampled_image_key(dim, is_uint, arrayed, depth);
+        uint32_t simg = sampled_image_type(dim, is_uint, arrayed, depth);
         if (tex_var.count(binding)) return;
         uint32_t t_ptr = id(); put(types, Op_TypePointer, {t_ptr, SC_UniformConstant, simg});
         uint32_t v = id();     put(types, Op_Variable,    {t_ptr, v, SC_UniformConstant});
@@ -443,6 +466,21 @@ struct SpirvCompute {
         uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(w_bits)});
         uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, bcf(lod_bits)});
         unpack_texture_result(binding, res, out);
+    }
+    // IMAGE_SAMPLE_C_LZ on a 2D array: compare the sampled depth against DREF at
+    // explicit LOD zero. Array coordinates are (u,v,layer); the comparison result is
+    // scalar and RDNA writes that value for the requested dmask component.
+    void image_sample_dref_lz_2d_array(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
+                                       uint32_t layer_bits, uint32_t dref_bits, uint32_t out[4]) {
+        uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t coord = id();
+        put(code, Op_CompositeConstruct,
+            {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(layer_bits)});
+        uint32_t result = id();
+        put(code, Op_ImageSampleDrefExplicitLod,
+            {t_f32, result, si, coord, bcf(dref_bits), ImgOp_Lod, fconstf(0.0f)});
+        const uint32_t bits = bcu(result);
+        out[0] = out[1] = out[2] = out[3] = bits;
     }
     // image_sample_b 2D: implicit-LOD sample with an LOD BIAS (bias_bits float). Bias only means
     // anything with implicit LOD (fragment derivatives); outside the fragment stage the op resolves
@@ -696,6 +734,31 @@ struct SpirvCompute {
         put(code, Op_Branch, {merge});
         put(code, Op_Label, {merge}); cur_block = merge;
     }
+    // Returning atomic RMW on a descriptor-backed storage buffer. BUFFER_ATOMIC_* writes memory and
+    // returns the pre-operation value in VDATA. Inactive EXEC lanes neither access the buffer nor
+    // clobber VDATA, hence the predicated path joins the old destination through OpPhi.
+    uint32_t cbuf_atomic_rtn(uint32_t op, uint32_t idx, uint32_t value, uint32_t binding,
+                             bool predicated, uint32_t pred, uint32_t fallback) {
+        const uint32_t buf = buf_for_binding(binding);
+        auto emit = [&]() {
+            uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
+            uint32_t result = id();
+            put(code, op, {t_u32, result, p, uconst(Scope_Device),
+                           uconst(MemSem_UniformAcqRel), value});
+            return result;
+        };
+        if (!predicated) return emit();
+        const uint32_t entry = cur_block;
+        uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        const uint32_t result = emit();
+        const uint32_t then_end = cur_block;
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+        return emit_phi_2way(t_u32, result, then_end, fallback, entry);
+    }
     // LDS (Local Data Share) — a workgroup-shared u32 array for compute ds_read/ds_write. Declared on
     // first use, sized to `lds_dwords`. RDNA2's per-workgroup LDS MAX is 64 KB (16384 dwords); the real
     // per-shader allocation is COMPUTE_PGM_RSRC2.LDS_SIZE. `lds_dwords` defaults to 4096 (16 KB) — a
@@ -798,15 +861,14 @@ struct SpirvCompute {
         put(code, Op_Store, {p, value});
     }
 
-    // --- Wave model (cross-lane ops via a workgroup-as-wave + LDS). The compute shell dispatches one
-    // 64-invocation workgroup per wave; gl_LocalInvocationID.x is the lane. A dedicated LDS scratch array
-    // (separate from ds_read/write's lds_var) holds each lane's contribution so cross-lane reductions work.
+    // --- Wave model (cross-lane ops via workgroup scratch). A dedicated LDS scratch array (separate
+    // from ds_read/write's lds_var) holds each lane's contribution so cross-lane reductions work.
     // Inactive lanes still EXECUTE (exec is a per-lane predication bool), so all 64 reach the barriers —
     // valid only at wave-uniform points (the caller must not emit these inside divergent control flow). ---
     uint32_t v_localid = 0, localid = 0, lds_wave = 0, t_ptr_wg_u32b = 0;
     void declare_wave_lds() {
         if (lds_wave) return;
-        uint32_t t_arr = id();  put(types, Op_TypeArray, {t_arr, t_u32, uconst(64)});
+        uint32_t t_arr = id();  put(types, Op_TypeArray, {t_arr, t_u32, uconst(std::max(1u, local_count))});
         uint32_t t_ptr = id();  put(types, Op_TypePointer, {t_ptr, SC_Workgroup, t_arr});
         lds_wave = id();        put(types, Op_Variable, {t_ptr, lds_wave, SC_Workgroup});
         t_ptr_wg_u32b = id();   put(types, Op_TypePointer, {t_ptr_wg_u32b, SC_Workgroup, t_u32});
@@ -818,17 +880,70 @@ struct SpirvCompute {
     uint32_t mbcnt(uint32_t active_bool, uint32_t acc_bits, bool lo) {
         declare_wave_lds();
         uint32_t bit = sel(active_bool, uconst(1), uconst(0));
-        { uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32b, p, lds_wave, localid}); put(code, Op_Store, {p, bit}); }
+        { uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32b, p, lds_wave, linear_localid}); put(code, Op_Store, {p, bit}); }
         barrier();
+        const uint32_t lane = ibin(Op_BitwiseAnd, linear_localid, uconst(wave_size - 1));
+        const uint32_t wave_index = ibin(Op_ShiftRightLogical, linear_localid,
+                                          uconst(wave_size == 32 ? 5u : 6u));
         uint32_t sum = uconst(0);
-        for (uint32_t i = (lo ? 0u : 32u); i < (lo ? 32u : 64u); i++) {
-            uint32_t cond = ucmp(Op_ULessThan, uconst(i), localid);        // i < lane
+        const uint32_t first = lo ? 0u : 32u;
+        const uint32_t last = std::min(wave_size, lo ? 32u : 64u);
+        for (uint32_t i = 0; i < local_count; i++) {
+            const uint32_t candidate_lane = i % wave_size;
+            if (candidate_lane < first || candidate_lane >= last) continue;
+            uint32_t cond = land(ucmp(Op_IEqual, wave_index, uconst(i / wave_size)),
+                                 ucmp(Op_ULessThan, uconst(candidate_lane), lane));
             uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32b, p, lds_wave, uconst(i)});
             uint32_t v = id(); put(code, Op_Load, {t_u32, v, p});
             sum = b_iadd(sum, sel(cond, v, uconst(0)));
         }
         barrier();
         return b_iadd(acc_bits, sum);
+    }
+    // DS_APPEND/DS_CONSUME: one atomic add/subtract per emulated hardware wave, changing the counter
+    // by popcount(EXEC), with the old value broadcast to every lane. Every Vulkan invocation participates in the barriers;
+    // the per-lane EXEC bool only contributes 0/1 to the reduction. A partial final hardware wave
+    // (including a one-thread workgroup) contains only the launched lanes; every scratch read remains
+    // statically in-bounds and absent hardware lanes contribute zero.
+    uint32_t wave_append(uint32_t lds_idx, uint32_t active_bool, bool consume = false) {
+        declare_wave_lds();
+        const uint32_t active = sel(active_bool, uconst(1), uconst(0));
+        uint32_t p = id(); putv(code, Op_AccessChain,
+            {t_ptr_wg_u32b, p, lds_wave, linear_localid});
+        put(code, Op_Store, {p, active});
+        barrier();
+
+        const uint32_t wave_shift = wave_size == 32 ? 5u : 6u;
+        const uint32_t lane = ibin(Op_BitwiseAnd, linear_localid, uconst(wave_size - 1));
+        const uint32_t wave_base = ibin(Op_ShiftLeftLogical,
+            ibin(Op_ShiftRightLogical, linear_localid, uconst(wave_shift)), uconst(wave_shift));
+        const uint32_t wave_index = ibin(Op_ShiftRightLogical, linear_localid, uconst(wave_shift));
+        uint32_t count = uconst(0);
+        for (uint32_t i = 0; i < local_count; ++i) {
+            uint32_t q = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32b, q, lds_wave, uconst(i)});
+            uint32_t v = id(); put(code, Op_Load, {t_u32, v, q});
+            const uint32_t same_wave = ucmp(Op_IEqual, wave_index, uconst(i / wave_size));
+            count = b_iadd(count, sel(same_wave, v, uconst(0)));
+        }
+
+        const uint32_t is_leader = ucmp(Op_IEqual, lane, uconst(0));
+        const uint32_t leader = id(), reduced = id();
+        emit_selmerge(reduced);
+        emit_condbranch(is_leader, leader, reduced);
+        emit_label(leader);
+        const uint32_t old = lds_atomic_rtn(consume ? Op_AtomicISub : Op_AtomicIAdd, lds_idx, count,
+                                             false, btrue(), uconst(0));
+        uint32_t result_slot = id(); putv(code, Op_AccessChain,
+            {t_ptr_wg_u32b, result_slot, lds_wave, wave_base});
+        put(code, Op_Store, {result_slot, old});
+        emit_branch(reduced);
+        emit_label(reduced);
+        barrier();
+        uint32_t result_ptr = id(); putv(code, Op_AccessChain,
+            {t_ptr_wg_u32b, result_ptr, lds_wave, wave_base});
+        uint32_t result = id(); put(code, Op_Load, {t_u32, result, result_ptr});
+        barrier();
+        return result;
     }
     uint32_t b_iadd(uint32_t a, uint32_t b_) { uint32_t r = id(); put(code, Op_IAdd, {t_u32, r, a, b_}); return r; }
     // Declare the two scalar-memory constant/vertex buffers (bindings 2 & 3) that SMEM / buffer_load_
@@ -1009,19 +1124,20 @@ struct SpirvCompute {
         put(code, Op_Store, {v_color[mrt], v});
     }
 
-    // --- Vertex-shader shell: gl_VertexIndex input + gl_Position (member 0 of a gl_PerVertex Block). ---
-    uint32_t v_vid = 0, v_pos = 0, t_ptr_out_v4f = 0;
+    // --- Vertex-shader shell: draw inputs + gl_Position (member 0 of a gl_PerVertex Block). ---
+    uint32_t v_vid = 0, v_iid = 0, v_pos = 0, t_ptr_out_v4f = 0;
     void begin_vertex(const ShaderResourceTable* rt = nullptr) { bool with_cbufs = rt != nullptr;
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_bool = id();
         t_v4f = id();
-        uint32_t t_ptr_in_i32 = id(); v_vid = id();
+        uint32_t t_ptr_in_i32 = id(); v_vid = id(); v_iid = id();
         uint32_t t_pv = id(), t_ptr_out_pv = id(); v_pos = id(); t_ptr_out_v4f = id();
         f_main = id(); uint32_t lbl = id(); glsl = id();
         put(caps, Op_Capability, {Cap_Shader});
         { std::vector<uint32_t> o{glsl}; pstr(o, "GLSL.std.450"); putv(extimp, Op_ExtInstImport, o); }
         put(mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
-        exec_model = Exec_Vertex; iface = {v_vid, v_pos};   // EntryPoint deferred to finish()
+        exec_model = Exec_Vertex; iface = {v_vid, v_iid, v_pos};   // EntryPoint deferred to finish()
         put(deco, Op_Decorate, {v_vid, Dec_BuiltIn, BI_VertexIndex});
+        put(deco, Op_Decorate, {v_iid, Dec_BuiltIn, BI_InstanceIndex});
         put(deco, Op_MemberDecorate, {t_pv, 0, Dec_BuiltIn, BI_Position});   // gl_PerVertex.gl_Position
         put(deco, Op_Decorate, {t_pv, Dec_Block});
         put(types, Op_TypeVoid, {t_void});
@@ -1033,6 +1149,7 @@ struct SpirvCompute {
         put(types, Op_TypeVector, {t_v4f, t_f32, 4});
         put(types, Op_TypePointer, {t_ptr_in_i32, SC_Input, t_i32});
         put(types, Op_Variable, {t_ptr_in_i32, v_vid, SC_Input});
+        put(types, Op_Variable, {t_ptr_in_i32, v_iid, SC_Input});
         put(types, Op_TypeStruct, {t_pv, t_v4f});
         put(types, Op_TypePointer, {t_ptr_out_pv, SC_Output, t_pv});
         put(types, Op_Variable, {t_ptr_out_pv, v_pos, SC_Output});
@@ -1043,6 +1160,7 @@ struct SpirvCompute {
     }
     // Load gl_VertexIndex as raw bits (VGPR v0 for a vertex shader).
     uint32_t load_vertex_index() { uint32_t r = id(); put(code, Op_Load, {t_i32, r, v_vid}); return i2u(r); }
+    uint32_t load_instance_index() { uint32_t r = id(); put(code, Op_Load, {t_i32, r, v_iid}); return i2u(r); }
     // Write vec4(x,y,z,w) (bit-operands) to gl_Position (EXP POS0).
     void export_position(uint32_t x, uint32_t y, uint32_t z, uint32_t w) {
         // PROSPER_FORCE_W: diagnostic — force the clip-space w to 1.0. Some shaders' factored MVP
@@ -1159,6 +1277,10 @@ struct SpirvCompute {
 // operands may reference either (SGPR is a valid ALU operand), so both are resolved by operand_bits.
 struct RegState {
     std::unordered_map<int, uint32_t> vreg, sreg;
+    // Immutable raw user-data words for DIRECT descriptors. They stay absent from `sreg` so
+    // descriptor provenance can still distinguish driver input from a shader overwrite, while
+    // scalar ALU may read their real bits (Astro copies V#.word2 into M0 as an LDS base).
+    std::unordered_map<int, uint32_t> sreg_input;
     std::unordered_map<int, uint32_t> sreg_bool;   // SGPR (pairs) holding a saved per-lane mask (bool id)
     std::unordered_map<int, bool> sreg_bool_narrowed;  // was EXEC narrowed when this mask was saved? (restores it)
     std::unordered_map<int, uint32_t> sreg_srt;    // SGPR holding a descriptor -> its user_data/SRT byte offset
@@ -1200,6 +1322,43 @@ inline void predicate_write(SpirvCompute& b, RegState& rs, int idx, uint32_t old
 }
 inline uint32_t vreg_old(SpirvCompute& b, RegState& rs, int idx) {
     auto it = rs.vreg.find(idx); return it == rs.vreg.end() ? b.uconst(0) : it->second;
+}
+
+// A scalar inline integer used by a B64 mask operation is sign-extended to 64 bits.  Return the bit
+// belonging to this emulated hardware lane without ever issuing an undefined >=32 SPIR-V shift.
+// Astro's reduction tails use 15, 3, and 1 for the final 4/2/1 active lanes.
+uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
+    if (value == -1) return b.btrue();
+    if (value == 0) return b.bfalse();
+    const uint32_t lane = b.ibin(Op_BitwiseAnd, b.linear_localid,
+                                  b.uconst(b.wave_size - 1));
+    const uint32_t bit = b.ibin(Op_BitwiseAnd, lane, b.uconst(31));
+    const uint32_t high = b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
+    const uint32_t word = b.sel(high, b.uconst(value < 0 ? UINT32_MAX : 0u),
+                                b.uconst(static_cast<uint32_t>(value)));
+    return b.ucmp(Op_INotEqual,
+        b.ibin(Op_BitwiseAnd, b.ibin(Op_ShiftRightLogical, word, bit), b.uconst(1)),
+        b.uconst(0));
+}
+
+// Per-invocation bit of a 64-bit mask consumed by V_MBCNT. The HI instruction names the odd SGPR
+// of an aligned scalar pair (for example s7 for s[6:7]), while our bool-domain mask is keyed by the
+// pair's low register. Accept the exact key first for unusual compiler allocations, then the aligned
+// low half. VCC/EXEC are represented directly rather than through the scalar-data register file.
+uint32_t mbcnt_source_bit(SpirvCompute& b, const RegState& rs, const Operand& source,
+                          bool high_half) {
+    if (source.value == 126 || source.value == 127) return rs.exec;
+    if (source.value == 106 || source.value == 107) return rs.vcc;
+    if (source.kind == OperandKind::InlineInt)
+        return inline_int_mask_bit(b, source.value);
+    if (source.kind != OperandKind::SGPR) return 0;
+    auto found = rs.sreg_bool.find(source.value);
+    if (found != rs.sreg_bool.end()) return found->second;
+    if (high_half && source.value > 0) {
+        found = rs.sreg_bool.find(source.value - 1);
+        if (found != rs.sreg_bool.end()) return found->second;
+    }
+    return 0;
 }
 
 bool sopp_is_noop(const Rdna2Inst& in) {
@@ -1411,7 +1570,9 @@ std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& in
             if (prev) {
                 bool mask_sop2 = prev->fmt == Rdna2Format::SOP2 &&
                     (prev->opcode == 0x0f || prev->opcode == 0x11 || prev->opcode == 0x13 || prev->opcode == 0x15);
-                bool mask_saveexec = prev->fmt == Rdna2Format::SOP1 && (prev->opcode == 0x24 || prev->opcode == 0x25);
+                bool mask_saveexec = prev->fmt == Rdna2Format::SOP1 &&
+                                     (prev->opcode == 0x24 || prev->opcode == 0x25 ||
+                                      prev->opcode == 0x37);
                 // The kill mask may live in a plain SGPR pair (s0..s105) OR in VCC itself — DOLL's
                 // alpha-cull PS does `s_andn2_b64 vcc, exec, vcc; s_cbranch_scc0 <null-export>` then
                 // `s_mov_b64 exec, vcc; export`. The SOP2 dst field decodes VCC_LO as SGPR 106, and
@@ -1424,6 +1585,118 @@ std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& in
         prev = &in;
     }
     return out;
+}
+
+// Some GFX10 pixel shaders leave scheduled 64-bit mask operations whose VCC/SCC results feed only
+// other dead mask operations and are overwritten before an observable read. Astro Bot's SSAO shader does this with
+// `s_and_b64 vcc, s[0:1], vcc`, where s[0:1] is also a live T# descriptor; attempting to reinterpret
+// the descriptor bits as a per-lane mask is both impossible in descriptor-backed SPIR-V and pointless.
+// Elide only the mechanically proven dead form: the shader has no SCC consumer anywhere, and CFG
+// liveness proves the VCC pair cannot reach a non-mask read before redefinition. This deliberately
+// does not become a general scalar-pair-to-wave-mask fallback.
+std::unordered_set<uint32_t> dead_wave_mask_writes(const std::vector<Rdna2Inst>& ins) {
+    for (const auto& in : ins) {
+        const bool reads_scc =
+            (in.fmt == Rdna2Format::SOPP && (in.opcode == 0x04 || in.opcode == 0x05)) ||
+            (in.fmt == Rdna2Format::SOP2 &&
+             (in.opcode == 0x04 || in.opcode == 0x05 ||
+              in.opcode == 0x0a || in.opcode == 0x0b)) ||
+            (in.fmt == Rdna2Format::SOP1 && (in.opcode == 0x05 || in.opcode == 0x06)) ||
+            (in.fmt == Rdna2Format::SOPK && in.opcode == 0x02);
+        if (reads_scc) return {};
+    }
+    auto is_mask = [](const Rdna2Inst& in) {
+        return in.fmt == Rdna2Format::SOP2 &&
+            (in.opcode == 0x0f || in.opcode == 0x11 || in.opcode == 0x13 ||
+             in.opcode == 0x15 || in.opcode == 0x17 || in.opcode == 0x19 ||
+             in.opcode == 0x1b || in.opcode == 0x1d) &&
+            (in.dst.value == 106 || in.dst.value == 107);
+    };
+    const auto is_cmpx = [](uint32_t op) {
+        return (op >= 0x10 && op <= 0x1f) || (op >= 0x90 && op <= 0x9f) ||
+               (op >= 0xd0 && op <= 0xdf);
+    };
+    std::unordered_map<uint32_t, size_t> by_pc;
+    for (size_t i = 0; i < ins.size(); ++i) by_pc[ins[i].pc] = i;
+    std::vector<std::vector<size_t>> succ(ins.size());
+    for (size_t i = 0; i < ins.size(); ++i) {
+        const auto& in = ins[i];
+        if (in.is_end) continue;
+        const bool branch = in.fmt == Rdna2Format::SOPP &&
+                            in.opcode >= 0x02 && in.opcode <= 0x09 && in.opcode != 0x03;
+        if (!branch || in.opcode != 0x02) {
+            if (i + 1 < ins.size()) succ[i].push_back(i + 1);
+        }
+        if (branch) {
+            const uint32_t target = in.pc + in.len_dwords +
+                                    static_cast<uint32_t>(static_cast<int32_t>(in.simm16));
+            auto it = by_pc.find(target);
+            if (it == by_pc.end()) return {}; // malformed/unbounded CFG: make no dead-write claim
+            succ[i].push_back(it->second);
+        }
+    }
+    auto uses = [&](const Rdna2Inst& in) -> uint8_t {
+        uint8_t bits = 0;
+        for (uint8_t k = 0; k < in.n_src; ++k) {
+            if (in.src[k].kind != OperandKind::SGPR &&
+                in.src[k].kind != OperandKind::Special) continue;
+            if (in.src[k].value == 106) bits |= 1;
+            if (in.src[k].value == 107) bits |= 2;
+        }
+        if (is_mask(in) && bits) bits = 3; // every modeled mask logical reads a full B64 pair
+        if (in.fmt == Rdna2Format::VOP2 &&
+            (in.opcode == 0x01 || (in.opcode >= 0x28 && in.opcode <= 0x2a))) bits |= 3;
+        if (in.fmt == Rdna2Format::SOPP && (in.opcode == 0x06 || in.opcode == 0x07)) bits |= 3;
+        return bits;
+    };
+    auto defs = [&](const Rdna2Inst& in) -> uint8_t {
+        if (is_mask(in)) return 3;
+        if (in.fmt == Rdna2Format::VOPC && !is_cmpx(in.opcode) &&
+            (in.dst.value == 106 || in.dst.value == 107)) return 3;
+        if (in.fmt == Rdna2Format::VOP2 && in.opcode >= 0x28 && in.opcode <= 0x2a)
+            return 3;
+        if (in.fmt == Rdna2Format::VOP3 &&
+            (in.sdst.value == 106 || in.sdst.value == 107)) return 3;
+        if (in.fmt == Rdna2Format::SOP1) {
+            if (in.dst.value == 106) return in.opcode == 0x04 ? 3 : 1;
+            if (in.dst.value == 107) return 2;
+        }
+        if (in.fmt == Rdna2Format::SMEM) {
+            uint32_t n = 0;
+            switch (in.opcode) {
+                case 0x0: case 0x8: n=1; break; case 0x1: case 0x9: n=2; break;
+                case 0x2: case 0xa: n=4; break; case 0x3: case 0xb: n=8; break;
+                case 0x4: case 0xc: n=16; break; default: break;
+            }
+            uint8_t bits = 0;
+            if (n && in.dst.value <= 106 && 106 < in.dst.value + static_cast<int>(n)) bits |= 1;
+            if (n && in.dst.value <= 107 && 107 < in.dst.value + static_cast<int>(n)) bits |= 2;
+            return bits;
+        }
+        return 0;
+    };
+    // Least-fixed-point dataflow rooted only in observable (non-candidate) VCC reads. A mask
+    // candidate propagates liveness to its B64 input only when its output is itself live; this also
+    // removes dead self-dependent mask chains inside loops without mistaking the cycle for a use.
+    std::vector<uint8_t> live_in(ins.size(), 0), live_out(ins.size(), 0);
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (size_t ri = ins.size(); ri-- > 0;) {
+            uint8_t out = 0;
+            for (size_t s : succ[ri]) out |= live_in[s];
+            const uint8_t def = defs(ins[ri]), use = uses(ins[ri]);
+            const uint8_t propagated_use = is_mask(ins[ri]) && !(out & def) ? 0 : use;
+            const uint8_t in = propagated_use | (out & static_cast<uint8_t>(~def));
+            if (out != live_out[ri] || in != live_in[ri]) {
+                live_out[ri] = out; live_in[ri] = in; changed = true;
+            }
+        }
+    }
+    std::unordered_set<uint32_t> dead;
+    for (size_t i = 0; i < ins.size(); ++i)
+        if (is_mask(ins[i]) && !(live_out[i] & 3)) dead.insert(ins[i].pc);
+    return dead;
 }
 
 // WATERFALL loops (#273 — DOLL's skinned scene VS): the readfirstlane-uniformize idiom
@@ -1553,11 +1826,13 @@ uint32_t vgpr_write_count(const Rdna2Inst& in) {
     switch (in.fmt) {
         case Rdna2Format::VOP1:
             return in.opcode == 0x02 ? 0 : 1;                   // v_readfirstlane writes an SGPR
-        case Rdna2Format::VOP2: case Rdna2Format::VOP3: case Rdna2Format::VOP3P:
+        case Rdna2Format::VOP2: case Rdna2Format::VOP3P:
             return 1;
+        case Rdna2Format::VOP3:
+            return in.opcode == 0x176 ? 2 : 1;                 // v_mad_u64_u32 writes a VGPR pair
         case Rdna2Format::DS:
-            if (in.opcode == 0x36 || in.opcode == 0xb1) return 1;
-            if (in.opcode == 0x76) return 2;
+            if (in.opcode == 0x36 || in.opcode == 0x3d || in.opcode == 0x3e || in.opcode == 0xb1) return 1;
+            if (in.opcode == 0x37 || in.opcode == 0x76) return 2;
             if (in.opcode == 0x77) return 4;
             return 0;
         case Rdna2Format::MUBUF:
@@ -1587,7 +1862,8 @@ bool vopc_is_cmpx(uint32_t opcode) {
 bool instruction_may_change_exec(const Rdna2Inst& in) {
     if (in.fmt == Rdna2Format::VOPC && vopc_is_cmpx(in.opcode)) return true;
     // saveexec writes EXEC implicitly while its explicit destination receives the previous mask.
-    if (in.fmt == Rdna2Format::SOP1 && (in.opcode == 0x24 || in.opcode == 0x25)) return true;
+    if (in.fmt == Rdna2Format::SOP1 &&
+        (in.opcode == 0x24 || in.opcode == 0x25 || in.opcode == 0x37)) return true;
     auto is_exec = [](const Operand& operand) {
         return (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special) &&
                (operand.value == 126 || operand.value == 127);
@@ -1631,6 +1907,8 @@ static bool cannot_write_vcc(const Rdna2Inst& in) {
             // sequences of these two ops between a uniform VOPC and its s_cbranch_vccz.
             if (in.opcode == 0x361) return true;
             if (in.opcode == 0x360) return sgpr_dst_misses_vcc(1);
+            if (in.opcode == 0x176)
+                return in.sdst.value != 106 && in.sdst.value != 107; // v_mad_u64_u32 carry-out
             return in.opcode >= 0x140 && in.opcode < 0x300 &&
                    sgpr_dst_misses_vcc(1);                         // plain-VALU window only
         case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPK:
@@ -2097,7 +2375,11 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 vregs.insert(in.dst.value); break;
             case Rdna2Format::VOP3:
                 if (in.opcode == 0x360) sregs.insert(in.dst.value);       // v_readlane -> SGPR
-                else vregs.insert(in.dst.value); break;                   // (writelane: slots, not SSA)
+                else {
+                    for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
+                        vregs.insert(in.dst.value + (int)k);
+                }
+                break;                                                    // (writelane: slots, not SSA)
             case Rdna2Format::DS:
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
@@ -2140,7 +2422,12 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
                 if (ok) *ok = false; return b.uconst(0);
             }
             auto it = rs.vreg.find(o.value); return it == rs.vreg.end() ? b.uconst(0) : it->second; }
-        case OperandKind::SGPR: { auto it = rs.sreg.find(o.value); return it == rs.sreg.end() ? b.uconst(0) : it->second; }
+        case OperandKind::SGPR: {
+            auto it = rs.sreg.find(o.value);
+            if (it != rs.sreg.end()) return it->second;
+            auto input = rs.sreg_input.find(o.value);
+            return input == rs.sreg_input.end() ? b.uconst(0) : input->second;
+        }
         case OperandKind::InlineInt:   return b.uconst((uint32_t)o.value);
         case OperandKind::InlineFloat: return b.uconst(fbits(inline_float_value((uint32_t)o.value)));
         case OperandKind::Literal:     return b.uconst(in.literal);
@@ -2182,15 +2469,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // mask is a single bool for this lane. EXEC=SGPR 126/127, VCC=106/107; a saved mask lives
             // in sreg_bool. These implement divergent control flow (if/endif via saveexec + restore).
             if (in.opcode == 0x04 || in.opcode == 0x08 || in.opcode == 0x0a ||
-                in.opcode == 0x24 || in.opcode == 0x25) {
+                in.opcode == 0x24 || in.opcode == 0x25 || in.opcode == 0x37) {
                 auto is_exec = [](const Operand& o){ return o.value == 126 || o.value == 127; };
                 auto src_mask = [&](const Operand& o) -> uint32_t {
                     if (o.value == 106 || o.value == 107) return rs.vcc;    // VCC
                     if (o.value == 126 || o.value == 127) return rs.exec;   // EXEC
                     if (o.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(o.value);
                         if (it != rs.sreg_bool.end()) return it->second; }
-                    if (o.kind == OperandKind::InlineInt) { if (o.value == -1) return b.btrue();
-                        if (o.value == 0) return b.bfalse(); }
+                    if (o.kind == OperandKind::InlineInt)
+                        return inline_int_mask_bit(b, o.value);
                     return 0;   // not a recognizable mask
                 };
                 if (in.opcode == 0x0a) {                    // s_wqm_b64: whole-quad-mode mask widen
@@ -2294,12 +2581,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         }
                         if (!m && !data_copied) ok = false;
                     }
-                } else {                                    // s_and/or_saveexec_b64 sDST, src
+                } else {                                    // s_and/or/andn1_saveexec_b64 sDST, src
                     rs.sreg_bool[in.dst.value] = rs.exec;   // save current EXEC to the dest SGPR pair
                     rs.sreg_bool_narrowed[in.dst.value] = rs.exec_narrowed;   // ...and its narrowed-state
                     uint32_t m = src_mask(in.src[0]);
                     if (!m) ok = false;
-                    else { rs.exec = (in.opcode == 0x24) ? b.land(rs.exec, m) : b.lor(rs.exec, m);
+                    else { rs.exec = in.opcode == 0x24 ? b.land(rs.exec, m)
+                                     : in.opcode == 0x25 ? b.lor(rs.exec, m)
+                                                        : b.land(rs.exec, b.logical_not(m));
                            rs.exec_narrowed = true; }
                 }
                 return true;
@@ -2334,11 +2623,38 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 case 0x07:                                  // s_not_b32 changes the descriptor word
                     d = b.iun(Op_Not, a); rs.sreg_srt.erase(in.dst.value); break;
+                case 0x0b:                                  // s_brev_b32
+                    d = b.iun(Op_BitReverse, a); rs.sreg_srt.erase(in.dst.value); break;
                 default: ok = false;
             }
             return true;
         }
         case Rdna2Format::SOP2: {
+            if (in.opcode == 0x25) {   // s_bfm_b64: D=((1ULL<<(S0&63))-1)<<(S1&63)
+                // Wave masks are represented as one bool per SPIR-V invocation.  Constructing the
+                // architectural 64-bit integer and then splitting it would lose that domain, so test
+                // the current lane directly: bits [offset, offset+width) are set, truncated at bit 63.
+                // This is also exact for width==0 (the ISA expression produces an empty mask).
+                const uint32_t width = b.ibin(Op_BitwiseAnd, val(in.src[0]), b.uconst(63));
+                const uint32_t offset = b.ibin(Op_BitwiseAnd, val(in.src[1]), b.uconst(63));
+                const uint32_t lane = b.ibin(Op_BitwiseAnd, b.linear_localid,
+                                              b.uconst(b.wave_size - 1));
+                const uint32_t at_or_after = b.ucmp(Op_UGreaterThanEqual, lane, offset);
+                const uint32_t within_width = b.ucmp(
+                    Op_ULessThan, b.ibin(Op_ISub, lane, offset), width);
+                const uint32_t r = b.land(at_or_after, within_width);
+                if (in.dst.value == 126 || in.dst.value == 127) {
+                    rs.exec = r;
+                    rs.exec_narrowed = true;
+                } else if (in.dst.value == 106 || in.dst.value == 107) {
+                    rs.vcc = r;
+                    rs.sreg_bool_narrowed[in.dst.value] = true;
+                } else {
+                    rs.sreg_bool[in.dst.value] = r;
+                    rs.sreg_bool_narrowed[in.dst.value] = true;
+                }
+                return true;
+            }
             if (in.opcode == 0x0b) {   // s_cselect_b64: 64-bit MASK dst = SCC ? src0 : src1 (mask domain)
                 // Operands/dest are wave masks (EXEC/VCC/saved/inline), NOT uint bits — resolve like the
                 // SOP1 mask ops and select in the bool domain. (s_cselect_b32 0x0a stays in the uint path.)
@@ -2348,8 +2664,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (o.value == 126 || o.value == 127) return rs.exec;
                     if (o.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(o.value);
                         if (it != rs.sreg_bool.end()) return it->second; }
-                    if (o.kind == OperandKind::InlineInt) { if (o.value == -1) return b.btrue();
-                        if (o.value == 0) return b.bfalse(); }
+                    if (o.kind == OperandKind::InlineInt)
+                        return inline_int_mask_bit(b, o.value);
                     return 0;   // not a recognizable mask
                 };
                 uint32_t m0 = mask(in.src[0]), m1 = mask(in.src[1]);
@@ -2372,8 +2688,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (o.value == 126 || o.value == 127) return rs.exec;
                     if (o.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(o.value);
                         if (it != rs.sreg_bool.end()) return it->second; }
-                    if (o.kind == OperandKind::InlineInt) { if (o.value == -1) return b.btrue();
-                        if (o.value == 0) return b.bfalse(); }
+                    if (o.kind == OperandKind::InlineInt)
+                        return inline_int_mask_bit(b, o.value);
                     return 0;
                 };
                 uint32_t m0 = mask(in.src[0]), m1 = mask(in.src[1]);
@@ -2583,6 +2899,32 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x09: rs.scc = b.ucmp(Op_UGreaterThanEqual, a, c); break;        // s_cmp_ge_u32
                 case 0x0A: rs.scc = b.ucmp(Op_ULessThan, a, c); break;                // s_cmp_lt_u32
                 case 0x0B: rs.scc = b.ucmp(Op_ULessThanEqual, a, c); break;           // s_cmp_le_u32
+                case 0x12: case 0x13: {                                                // s_cmp_eq/lg_u64
+                    // AMD RDNA2 ISA 12.4: each encoded source names the low half of an SGPR pair.
+                    // Inline integer/literal sources are extended to 64 bits; Astro compares
+                    // s[2:3] against inline zero while rebuilding a wave mask.
+                    auto high = [&](const Operand& o) -> uint32_t {
+                        if (o.kind == OperandKind::SGPR ||
+                            (o.kind == OperandKind::Special && o.value >= 106 && o.value < 124)) {
+                            auto it = rs.sreg.find(o.value + 1);
+                            if (it != rs.sreg.end()) return it->second;
+                            ok = false;
+                            return b.uconst(0);
+                        }
+                        if (o.kind == OperandKind::InlineInt)
+                            return b.uconst(o.value < 0 ? UINT32_MAX : 0);
+                        if (o.kind == OperandKind::Literal || o.kind == OperandKind::InlineFloat ||
+                            (o.kind == OperandKind::Special && o.value == 125))
+                            return b.uconst(0);
+                        ok = false;
+                        return b.uconst(0);
+                    };
+                    const uint32_t equal = b.land(
+                        b.ucmp(Op_IEqual, a, c),
+                        b.ucmp(Op_IEqual, high(in.src[0]), high(in.src[1])));
+                    rs.scc = in.opcode == 0x12 ? equal : b.logical_not(equal);
+                    break;
+                }
                 default: ok = false;
             }
             return true;
@@ -2609,13 +2951,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
         }
         case Rdna2Format::VOP1: {
             uint32_t a = val(in.src[0]); uint32_t old_d = vreg_old(b, rs, in.dst.value);
-            // DPP16 quad_perm on src0 (#273): reconstruct the selected quad lane's value from
-            // screen-space derivatives (fragment-only; v_mov is the observed carrier — the manual
-            // ddx/ddy idiom). Other VOP1 ops with DPP stay rejected (derivatives of non-float moves
-            // have no meaning in this lowering).
+            // DPP16 quad_perm on src0 (#273): fragment shaders reconstruct the selected quad lane
+            // from derivatives. Compute shaders use the exact subgroup quad-swap operation for the
+            // three XOR permutations emitted by Astro Bot's blur kernels: horizontal (0xb1), vertical
+            // (0x4e), and diagonal (0x1b). Quad boundaries are architectural and remain exact even
+            // when the host subgroup width differs from the guest wave width.
             if (in.has_dpp) {
-                if (!b.is_fragment || in.opcode != 0x01) { ok = false; return true; }
-                a = b.dpp_quad(a, in.dpp_ctrl);
+                if (in.opcode != 0x01) { ok = false; return true; }
+                if (b.is_fragment) {
+                    a = b.dpp_quad(a, in.dpp_ctrl);
+                } else if (b.is_compute) {
+                    uint32_t direction = in.dpp_ctrl == 0xb1 ? 0u
+                                       : in.dpp_ctrl == 0x4e ? 1u
+                                       : in.dpp_ctrl == 0x1b ? 2u : UINT32_MAX;
+                    if (direction == UINT32_MAX) { ok = false; return true; }
+                    a = b.subgroup_quad_swap(a, direction);
+                } else {
+                    ok = false; return true;
+                }
             }
             // SDWA float source modifiers on src0 (abs then neg). v_cvt_f32_f16 applies them after
             // selecting and unpacking the requested half below; applying them to the packed u32 as
@@ -2623,6 +2976,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (in.opcode != 0x0B) {
                 if (in.src_abs[0]) a = b.fext1(Glsl_FAbs, a);
                 if (in.src_neg[0]) a = b.fbin(Op_FSub, b.uconst(0), a);
+            }
+            if ((in.opcode == 0x05 || in.opcode == 0x06) && in.sdwa_src0_sel <= 5) {
+                const uint32_t bits = in.sdwa_src0_sel <= 3 ? 8u : 16u;
+                const uint32_t offset = in.sdwa_src0_sel <= 3
+                    ? 8u * in.sdwa_src0_sel : 16u * (in.sdwa_src0_sel - 4u);
+                a = ((in.words[1] >> 19) & 1u)
+                    ? b.bfe_s(a, b.uconst(offset), b.uconst(bits))
+                    : b.bfe_u(a, b.uconst(offset), b.uconst(bits));
             }
             if (in.opcode == 0x02) {   // v_readfirstlane_b32: SGPR dst = value of the lowest active lane
                 // Cross-lane broadcast. Our per-lane scalar model has no cross-lane reduction, so we use
@@ -2702,6 +3063,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (in.src_neg[0]) d = b.fbin(Op_FSub, b.uconst(0), d);
                     break;
                 }
+                case 0x0D:                                          // v_cvt_flr_i32_f32
+                    // AMD RDNA2 ISA: floor the f32 value before converting to signed i32. This is
+                    // observably different from v_cvt_i32_f32's truncation for negative fractions.
+                    d = b.cvt_f2i(b.fext1(Glsl_Floor, a));
+                    break;
                 // v_cvt_off_f32_i4: sign-extend the low 4-bit integer and scale by 1/16.
                 // AMD RDNA2 ISA: "4-bit signed int to 32-bit float"; LLVM's intrinsic
                 // contract specifies result = 0.0625f * src_i4. This is the only opcode
@@ -2779,8 +3145,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const bool fop = in.opcode == 0x03 || in.opcode == 0x04 || in.opcode == 0x05 ||
                                  in.opcode == 0x08 || in.opcode == 0x0F || in.opcode == 0x10 ||
                                  in.opcode == 0x1F || in.opcode == 0x2B;
-                if (!b.is_fragment || !fop) { ok = false; return true; }
-                a = b.dpp_quad(a, in.dpp_ctrl);
+                if (!fop) { ok = false; return true; }
+                if (b.is_fragment) {
+                    a = b.dpp_quad(a, in.dpp_ctrl);
+                } else if (b.is_compute) {
+                    // Astro's title blur/reduction kernels use the same three XOR quad permutations
+                    // as their v_mov DPP forms. DPP transforms src0 only; src1 remains in this lane.
+                    const uint32_t direction = in.dpp_ctrl == 0xb1 ? 0u
+                                             : in.dpp_ctrl == 0x4e ? 1u
+                                             : in.dpp_ctrl == 0x1b ? 2u : UINT32_MAX;
+                    if (direction == UINT32_MAX) { ok = false; return true; }
+                    a = b.subgroup_quad_swap(a, direction);
+                } else {
+                    ok = false; return true;
+                }
             }
             // SDWA float source modifiers (only ever set on float ops by the assembler): abs then neg.
             // Packed-f16 ops apply these after selecting/unpacking the half below.
@@ -2812,6 +3190,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x05: d = b.fbin(Op_FSub, c, a); break;          // v_subrev_f32 (src1 - src0; e32 form of
                                                                       // VOP3 0x105 — round-trip llvm-mc gfx1010 0x0a020702)
                 case 0x08: d = b.fbin(Op_FMul, a, c); break;          // v_mul_f32
+                case 0x0B: {                                        // v_mul_u32_u24
+                    // Only the low 24 bits of each source participate; the result is the low
+                    // 32 bits of the unsigned product (AMD RDNA2 ISA 11.6).
+                    const uint32_t mask = b.uconst(0x00FFFFFFu);
+                    d = b.ibin(Op_IMul, b.ibin(Op_BitwiseAnd, a, mask),
+                                          b.ibin(Op_BitwiseAnd, c, mask));
+                    break;
+                }
                 case 0x0F: d = b.fext2(Glsl_FMin, a, c); break;       // v_min_f32
                 case 0x10: d = b.fext2(Glsl_FMax, a, c); break;       // v_max_f32
                 case 0x11: d = b.sext2(Glsl_SMin, a, c); break;       // v_min_i32
@@ -2827,6 +3213,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x1B: d = b.ibin(Op_BitwiseAnd, a, c); break;    // v_and_b32
                 case 0x1C: d = b.ibin(Op_BitwiseOr,  a, c); break;    // v_or_b32
                 case 0x1D: d = b.ibin(Op_BitwiseXor, a, c); break;    // v_xor_b32
+                case 0x1E: d = b.iun(Op_Not, b.ibin(Op_BitwiseXor, a, c)); break; // v_xnor_b32
                 case 0x25: d = b.ibin(Op_IAdd, a, c); break;          // v_add_nc_u32
                 case 0x26: d = b.ibin(Op_ISub, a, c); break;          // v_sub_nc_u32
                 case 0x27: d = b.ibin(Op_ISub, c, a); break;          // v_subrev_nc_u32 (reverse: src1 - src0)
@@ -2943,6 +3330,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             bool is_cmpx = vopc_is_cmpx(op);
             if (is_cmpx && !allow_exec_update) { ok = false; return true; }
             uint32_t eff = is_cmpx ? op - 0x10 : op;
+            const bool integer_compare =
+                (eff >= 0x81u && eff <= 0x86u) ||
+                (eff >= 0xC1u && eff <= 0xC6u);
+            if (integer_compare) {
+                auto sdwa_integer = [&](uint32_t raw, uint8_t sel) {
+                    if (sel <= 3u) return b.bfe_u(raw, b.uconst(8u * sel), b.uconst(8));
+                    if (sel <= 5u) return b.bfe_u(raw, b.uconst(16u * (sel - 4u)), b.uconst(16));
+                    return raw;
+                };
+                a = sdwa_integer(ra, in.sdwa_src0_sel);
+                c = sdwa_integer(rc, in.sdwa_src1_sel);
+            }
             uint32_t cmp = 0;
             switch (eff) {
                 case 0x01: cmp = b.fcmp(Op_FOrdLessThan, a, c); break;         // v_cmp_lt_f32
@@ -3140,6 +3539,55 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // immaterial here. VERIFIED(round-trip llvm-mc gfx1010, both directions): VOP3 op 0x141.
                 uint32_t m = b.fbin(Op_FMul, fv(0), fv(1));
                 vreg[in.dst.value] = fresult(b.fbin(Op_FAdd, m, fv(2)));
+            } else if (in.opcode == 0x176) {                          // v_mad_u64_u32
+                // AMD RDNA2: {carry,D.u64} = S0.u32*S1.u32 + S2.u64. A literal
+                // or positive inline constant used as the 64-bit addend is zero-extended;
+                // a negative integer inline constant is sign-extended. Register addends
+                // consume the consecutive high register.
+                if (in.dst.value >= 255) { ok = false; }
+                else {
+                    auto high_half = [&](const Operand& operand) -> uint32_t {
+                        if (operand.kind == OperandKind::InlineInt)
+                            return b.uconst(operand.value < 0 ? 0xFFFFFFFFu : 0u);
+                        if (operand.kind == OperandKind::Literal ||
+                            operand.kind == OperandKind::InlineFloat)
+                            return b.uconst(0);
+                        if (operand.kind == OperandKind::Special && operand.value == 125)
+                            return b.uconst(0);                       // null pair
+                        if (operand.kind == OperandKind::VGPR ||
+                            operand.kind == OperandKind::SGPR ||
+                            (operand.kind == OperandKind::Special &&
+                             operand.value >= 106 && operand.value < 124)) {
+                            Operand next = operand;
+                            ++next.value;
+                            return val(next);
+                        }
+                        ok = false;
+                        return b.uconst(0);
+                    };
+
+                    const uint32_t a = val(in.src[0]), c = val(in.src[1]);
+                    const uint32_t add_lo = val(in.src[2]), add_hi = high_half(in.src[2]);
+                    const uint32_t mul_lo = b.ibin(Op_IMul, a, c);
+                    const uint32_t mul_hi = b.umul_hi(a, c);
+                    const uint32_t result_lo = b.ibin(Op_IAdd, mul_lo, add_lo);
+                    const uint32_t carry_lo = b.ucmp(Op_ULessThan, result_lo, mul_lo);
+                    const uint32_t high_sum = b.ibin(Op_IAdd, mul_hi, add_hi);
+                    const uint32_t carry_hi0 = b.ucmp(Op_ULessThan, high_sum, mul_hi);
+                    const uint32_t carry_word = b.sel(carry_lo, b.uconst(1), b.uconst(0));
+                    const uint32_t result_hi = b.ibin(Op_IAdd, high_sum, carry_word);
+                    const uint32_t carry_hi1 = b.ucmp(Op_ULessThan, result_hi, high_sum);
+                    const uint32_t carry_out = b.lor(carry_hi0, carry_hi1);
+
+                    const int hi_dst = in.dst.value + 1;
+                    const uint32_t old_hi = vreg_old(b, rs, hi_dst);
+                    vreg[in.dst.value] = result_lo;
+                    vreg[hi_dst] = result_hi;
+                    predicate_write(b, rs, hi_dst, old_hi);
+                    if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = carry_out;
+                    else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = carry_out;
+                    else ok = false;
+                }
             } else if (in.opcode == 0x169) {                          // v_mul_lo_u32
                 vreg[in.dst.value] = b.ibin(Op_IMul, val(in.src[0]), val(in.src[1]));
             } else if (in.opcode == 0x16a) {                          // v_mul_hi_u32 (high 32 bits)
@@ -3155,6 +3603,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // VOP3 0x151 = v_min3_f32, 0x154 = v_max3_f32 — 0xd551…/0xd554…). CONFIDENCE: HIGH.
                 uint32_t op = in.opcode == 0x151 ? (uint32_t)Glsl_FMin : (uint32_t)Glsl_FMax;
                 vreg[in.dst.value] = fresult(b.fext2(op, b.fext2(op, fv(0), fv(1)), fv(2)));
+            } else if (in.opcode == 0x368 || in.opcode == 0x369) {    // v_cvt_pknorm_{i16,u16}_f32
+                // Clamp and normalize two f32 values, then pack src0 in bits[15:0] and src1 in
+                // bits[31:16]. Astro's title ship VS uses the unsigned form (exact first word
+                // d7690002). AMD specifies round-to-nearest-even for the normalized conversion.
+                const bool is_signed = in.opcode == 0x368;
+                const float scale = is_signed ? 32767.0f : 65535.0f;
+                const uint32_t lo = b.pack_norm(fv(0), 16, is_signed, scale);
+                const uint32_t hi = b.pack_norm(fv(1), 16, is_signed, scale);
+                vreg[in.dst.value] = b.ibin(
+                    Op_BitwiseOr, lo, b.ibin(Op_ShiftLeftLogical, hi, b.uconst(16)));
             } else if (in.opcode == 0x36A) {                          // v_cvt_pk_u16_u32
                 // Pack two u32 into u16 halves with UNSIGNED SATURATION: lo = min(s0,0xFFFF),
                 // hi = min(s1,0xFFFF); dst = lo | hi<<16. VERIFIED(round-trip llvm-mc gfx1010:
@@ -3219,6 +3677,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t t1 = b.ibin(Op_BitwiseAnd, s0, val(in.src[1]));
                 uint32_t t2 = b.ibin(Op_BitwiseAnd, b.iun(Op_Not, s0), val(in.src[2]));
                 vreg[in.dst.value] = b.ibin(Op_BitwiseOr, t1, t2);
+            } else if (in.opcode == 0x364) {                          // v_bcnt_u32_b32
+                // AMD RDNA2: D = popcount(S0) + S1. The third VOP3 source field is unused.
+                vreg[in.dst.value] = b.ibin(Op_IAdd,
+                                             b.iun(Op_BitCount, val(in.src[0])),
+                                             val(in.src[1]));
             } else if (in.opcode == 0x36D) {                          // v_add3_u32 = s0+s1+s2
                 vreg[in.dst.value] = b.ibin(Op_IAdd, b.ibin(Op_IAdd, val(in.src[0]), val(in.src[1])), val(in.src[2]));
             } else if (in.opcode == 0x346) {                          // v_lshl_add_u32 = (s0<<(s1&31))+s2
@@ -3283,11 +3746,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // index, the common "get my lane id" idiom, e.g. shader 037); inline 0 -> never; an SGPR
                 // pair -> that saved mask's bool. A general computed 32-bit mask VALUE isn't representable
                 // per-lane, so reject that. LDS+barriers (allow_wave => straight-line, barrier-uniform).
-                const Operand& s0 = in.src[0]; uint32_t active = 0;
-                if (s0.value == 126 || s0.value == 127) active = rs.exec;
-                else if (s0.kind == OperandKind::InlineInt && s0.value == -1) active = b.btrue();
-                else if (s0.kind == OperandKind::InlineInt && s0.value == 0)  active = b.bfalse();
-                else if (s0.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(s0.value); if (it != rs.sreg_bool.end()) active = it->second; }
+                const uint32_t active = mbcnt_source_bit(
+                    b, rs, in.src[0], in.opcode == 0x366);
                 if (active) vreg[in.dst.value] = b.mbcnt(active, val(in.src[1]), in.opcode == 0x365);
                 else ok = false;
             } else if (in.opcode == 0x12F) {                          // v_cvt_pkrtz_f16_f32 = pack(s0->lo, s1->hi)
@@ -3495,9 +3955,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // per-lane load from the bound constant buffer: byte addr = (offen ? VADDR : 0) + SOFFSET
             // + inst-offset; index = addr>>2; N dwords -> VDATA..+N-1. Descriptor (SRSRC), idxen*stride,
             // and the format-converting buffer_load_format_* variants are deferred. Compute-only (cbuf).
-            if (!allow_smem) { ok = false; return true; }
-            uint32_t n = 0; bool is_format = false, is_store = false;
+            uint32_t n = 0; bool is_format = false, is_store = false, is_atomic = false;
+            bool raw_subword = false, raw_signed = false;
+            uint32_t raw_bits = 32;
             switch (in.opcode) {
+                case 0x8: n = 1; raw_subword = true; raw_bits = 8; break;   // buffer_load_ubyte
+                case 0x9: n = 1; raw_subword = true; raw_signed = true; raw_bits = 8; break; // sbyte
+                case 0xA: n = 1; raw_subword = true; raw_bits = 16; break;  // buffer_load_ushort
+                case 0xB: n = 1; raw_subword = true; raw_signed = true; raw_bits = 16; break; // sshort
                 case 0xC: n = 1; break;                     // buffer_load_dword
                 case 0xD: n = 2; break;                     // buffer_load_dwordx2
                 case 0xE: n = 4; break;                     // buffer_load_dwordx4
@@ -3514,7 +3979,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x5: n = 2; is_format = true; is_store = true; break;   // buffer_store_format_xy
                 case 0x6: n = 3; is_format = true; is_store = true; break;   // buffer_store_format_xyz
                 case 0x7: n = 4; is_format = true; is_store = true; break;   // buffer_store_format_xyzw
-                default: ok = false; return true;           // typed / atomics not yet
+                case 0x38: n = 1; is_atomic = true; break; // buffer_atomic_umax: mem=max_u32(mem,VDATA), VDATA=old
+                default: ok = false; return true;           // remaining typed/atomic opcodes deferred
             }
             uint32_t offset = in.literal & 0xFFFu;
             bool offen = (in.literal >> 12) & 1u, idxen = (in.literal >> 13) & 1u;
@@ -3522,7 +3988,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // table bytes live inside the shader blob — detect_pcrel_tables already copied them out.
             // Fold to a compile-time constant lookup: dword index = (inst offset + offen VADDR) >> 2;
             // out-of-range indexes read 0 (the hardware's OOB contract for a bounded V#).
-            if (!is_format && !is_store) {
+            if (!is_format && !is_store && !is_atomic && !raw_subword) {
                 auto pt = rs.mubuf_pcrel_tables.find(in.pc);
                 if (pt != rs.mubuf_pcrel_tables.end()) {
                     const std::vector<uint32_t>& tab = pt->second;
@@ -3543,6 +4009,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
             }
+            // A proven PC-relative table is self-contained shader data and needs no runtime resource
+            // bindings. Only external buffer accesses require the stage's SMEM/MUBUF resource gate.
+            // Keep this check after the fold so resource-free graphics shaders (Astro Bot's loading VS)
+            // can consume their embedded lookup table without making unresolved V# accesses permissive.
+            if (!allow_smem) { ok = false; return true; }
             uint32_t binding = 2, stride = 0;   // overwritten by SRSRC resolution below whenever a resource
                                                 // table is present (format AND raw ops); the binding-2 default
                                                 // survives only on the table-less offline path (see below)
@@ -3623,6 +4094,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 stride  = res->stride;
                 // fmt stays raw Uint32: untyped ops move raw dwords regardless of the V#'s declared format.
             }
+            if (raw_subword) {
+                if (raw_bits == 8) fmt = raw_signed ? DataFormat::Sint8 : DataFormat::Uint8;
+                else               fmt = raw_signed ? DataFormat::Sint16 : DataFormat::Uint16;
+            }
             // else (rt == nullptr): table-less offline compute shell (recompile_valu without a resource
             // table — the unit-test harness). Keep the legacy single-cbuf convention: binding 2, stride 0.
             // The live graphics path can never reach here table-less: recompile_vertex/recompile_fragment
@@ -3665,7 +4140,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // the gap) rather than silently mis-decode. Aligned iff: inst offset %4==0; stride %4==0
             // when idxen; no offen (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0.
             bool dyn_half = false;   // 16-bit element at a runtime dword half (stride-2 buffers, #273)
-            if (packed) {
+            if (packed && !raw_subword) {
                 bool base_aligned;
                 if (dyn_vfetch) {
                     // The dyn_vfetch address path (below) is exactly gl_VertexIndex*stride and DROPS the
@@ -3727,6 +4202,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 addr = b.ibin(Op_IAdd, addr, val(in.src[2]));          // SOFFSET
             }
             uint32_t idx = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
+            if (is_atomic) {
+                const int d = in.dst.value;
+                const uint32_t old = vreg_old(b, rs, d);
+                const auto it = rs.vreg.find(d);
+                const uint32_t value = it == rs.vreg.end() ? b.uconst(0) : it->second;
+                rs.vreg[d] = b.cbuf_atomic_rtn(Op_AtomicUMax, idx, value, binding,
+                                               rs.exec_narrowed, rs.exec, old);
+                return true;
+            }
             if (is_store) {
                 // Store the VDATA VGPRs (in.dst..+n-1). Integer sub-dword formats (Uint8/Sint8/...) have
                 // no packing path here -> reject rather than mis-store (loads extend them; stores don't pack).
@@ -3776,6 +4260,27 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (is_format && fmt_ncomp && k >= fmt_ncomp) {
                     uint32_t one = fmt_is_int ? 1u : 0x3f800000u;   // integer 1 vs float 1.0 (raw bits)
                     value = b.uconst(k == 3 ? one : 0u);            // W/A -> 1, G/B/Z -> 0
+                } else if (raw_subword) {
+                    // Raw byte/short loads use their full byte address, unlike typed packed-format
+                    // loads whose component packing is descriptor-defined. A 16-bit access may begin
+                    // at byte 3 and straddle two dwords, so join the adjacent words before extracting.
+                    const uint32_t dw0 = b.cbuf_load(idx, binding);
+                    const uint32_t byte_in_dw = b.ibin(Op_BitwiseAnd, addr, b.uconst(3));
+                    const uint32_t shift = b.ibin(Op_ShiftLeftLogical, byte_in_dw, b.uconst(3));
+                    uint32_t joined = b.ibin(Op_ShiftRightLogical, dw0, shift);
+                    if (raw_bits == 16) {
+                        const uint32_t dw1 = b.cbuf_load(b.ibin(Op_IAdd, idx, b.uconst(1)), binding);
+                        const uint32_t inv_shift = b.ibin(
+                            Op_BitwiseAnd,
+                            b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
+                        const uint32_t upper = b.ibin(Op_ShiftLeftLogical, dw1, inv_shift);
+                        joined = b.ibin(Op_BitwiseOr, joined,
+                                        b.sel(b.ucmp(Op_IEqual, shift, b.uconst(0)),
+                                              b.uconst(0), upper));
+                    }
+                    value = raw_signed
+                        ? b.bfe_s(joined, b.uconst(0), b.uconst(raw_bits))
+                        : b.bfe_u(joined, b.uconst(0), b.uconst(raw_bits));
                 } else if (!packed) {
                     uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
                     value = b.cbuf_load(kidx, binding);                  // raw 32-bit component
@@ -3925,6 +4430,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const bool is_sample = (in.opcode == 0x20), is_load = (in.opcode == 0x00);
             const bool is_sample_l = (in.opcode == 0x24), is_sample_lz = (in.opcode == 0x27);
             const bool is_sample_b = (in.opcode == 0x25), is_gather_lz = (in.opcode == 0x47);
+            const bool is_sample_c_lz = (in.opcode == 0x2f);
             // image_gather4_lz_o = 0x57 (gather at base level with the _o packed-offset operand in the
             // FIRST vaddr — llvm-mc gfx1030 round-trip on live DOLL bytes: 0xf15c0808 "image_gather4_lz_o
             // v[4:7], [v0, v18, v19], ..." — coords follow the offset, matching image_sample_b's
@@ -3943,7 +4449,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const bool dimcube = (in.mimg_dim == 3u);   // CUBE: stacked-face 2D lowering (#273, below)
             if (in.mimg_dim == 5u && getenv("PROSPER_GFXLOG"))
                 fprintf(stderr, "[recompile] 2D_ARRAY image_sample -> sampled as base slice 0 (array index dropped; #325)\n");
-            if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b && !is_gather_lz &&
+            if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b &&
+                 !is_sample_c_lz && !is_gather_lz &&
                  !is_gather_lz_o && !is_sample_lz_o) || (!dim2d && !dim3d && !dimcube)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
             // coords (normalized float for sample, integer texel for load). Non-NSA: consecutive from VADDR.
@@ -3984,6 +4491,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 else if (is_load)   b.image_fetch_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
                 else                b.image_sample_lod_3d(res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)),
                                                           b.uconst(0), out);   // _lz: base level
+            } else if (is_sample_c_lz) {
+                // Astro Bot shadow/visibility packet (exact live opcode 0x2f, dim 2D_ARRAY,
+                // NSA vaddr=[u,v,layer,dref]). Integer views and non-array dimensions are not
+                // legal for this lowering; reject rather than silently turning a comparison
+                // sample into an ordinary color read.
+                if (in.mimg_dim != 5u || uint_texture || !res->depth_compare) {
+                    ok = false; return true;
+                }
+                b.declare_texture(res->binding, Dim_2D, false, true, true);
+                b.image_sample_dref_lz_2d_array(
+                    res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), out);
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
                 // four texels of that channel -> 4 consecutive VDATA VGPRs, gather order preserved.
@@ -4063,14 +4581,34 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // offset; the backing store is dword-indexed. gfx10 ds_write2_b64 carries two independent
             // 8-bit offsets in units of 64-bit elements, while ds_write_b64 uses the ordinary 16-bit
             // byte offset. GDS and the remaining widths/atomics are deferred.
-            if (!b.is_compute || (in.opcode != 0x07 && in.opcode != 0x08 && in.opcode != 0x20 &&
-                                  in.opcode != 0x0d && in.opcode != 0x36 &&
-                                  in.opcode != 0x4d && in.opcode != 0x4e &&
-                                  in.opcode != 0x76 && in.opcode != 0x77)) {
+            if (!b.is_compute || (in.opcode != 0x00 && in.opcode != 0x07 &&
+                                  in.opcode != 0x08 && in.opcode != 0x20 &&
+                                  in.opcode != 0x2d &&
+                                  in.opcode != 0x0d && in.opcode != 0x36 && in.opcode != 0x37 &&
+                                  in.opcode != 0x3d && in.opcode != 0x3e && in.opcode != 0x4d && in.opcode != 0x4e &&
+                                  in.opcode != 0x76 && in.opcode != 0x77 &&
+                                  in.opcode != 0xde && in.opcode != 0xdf &&
+                                  in.opcode != 0xfe && in.opcode != 0xff)) {
                 ok = false; return true;
             }
             b.declare_lds();
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+            if (in.opcode == 0x3d || in.opcode == 0x3e) { // ds_consume/append: wave-wide LDS counter allocation
+                // AMD RDNA2 ISA 12.13: address = M0[15:0] + byte offset; atomically subtract/add
+                // popcount(EXEC) once for the wave and broadcast the pre-op value to valid lanes.
+                auto m0 = rs.sreg.find(124);
+                if (!allow_wave || m0 == rs.sreg.end() ||
+                    (b.wave_size != 32 && b.wave_size != 64)) {
+                    ok = false; return true;
+                }
+                const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xFFFFu));
+                const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(in.literal));
+                const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+                const uint32_t old = vreg_old(b, rs, in.dst.value);
+                rs.vreg[in.dst.value] = b.wave_append(idx, rs.exec, in.opcode == 0x3d);
+                predicate_write(b, rs, in.dst.value, old);
+                return true;
+            }
             if (in.opcode == 0x4e) {                    // ds_write2_b64: two VGPR pairs at offset0/offset1
                 const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
                 const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst((in.literal & 0xFFu) * 2u));
@@ -4098,9 +4636,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
+            if (in.opcode == 0x37) {                    // ds_read2_b32: two dwords at offset0/offset1
+                // AMD RDNA2 ISA 12.13: RETURN_DATA[0/1] = MEM[ADDR + OFFSET0/1 * 4].
+                // The two 8-bit offsets share the instruction's 16-bit offset field. Astro's
+                // loading compositor uses both adjacent (0,1) and non-zero (16,17) pairs.
+                const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
+                const uint32_t indices[2] = {
+                    b.ibin(Op_IAdd, base, b.uconst(in.literal & 0xFFu)),
+                    b.ibin(Op_IAdd, base, b.uconst((in.literal >> 8) & 0xFFu)),
+                };
+                for (int k = 0; k < 2; ++k) {
+                    const uint32_t old = vreg_old(b, rs, in.dst.value + k);
+                    rs.vreg[in.dst.value + k] = b.lds_load(indices[k]);
+                    predicate_write(b, rs, in.dst.value + k, old);
+                }
+                return true;
+            }
             uint32_t addr = b.ibin(Op_IAdd, vread(in.src[0].value), b.uconst(in.literal));
             uint32_t idx  = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
-            if (in.opcode == 0x07 || in.opcode == 0x08) { // ds_min_u32 / ds_max_u32
+            if (in.opcode == 0x00) {                     // ds_add_u32: LDS += DATA0, no VGPR return
+                b.lds_atomic(Op_AtomicIAdd, idx, vread(in.src[1].value),
+                             rs.exec_narrowed, rs.exec);
+            } else if (in.opcode == 0x07 || in.opcode == 0x08) { // ds_min_u32 / ds_max_u32
                 b.lds_atomic(in.opcode == 0x07 ? Op_AtomicUMin : Op_AtomicUMax,
                              idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
             } else if (in.opcode == 0x20) {             // ds_add_rtn_u32: VDST = old LDS; LDS += DATA0
@@ -4108,16 +4665,29 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 rs.vreg[in.dst.value] = b.lds_atomic_rtn(
                     Op_AtomicIAdd, idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec, old);
                 predicate_write(b, rs, in.dst.value, old);
+            } else if (in.opcode == 0x2d) {             // ds_wrxchg_rtn_b32: swap DATA0, return old LDS
+                const uint32_t old = vreg_old(b, rs, in.dst.value);
+                rs.vreg[in.dst.value] = b.lds_atomic_rtn(
+                    Op_AtomicExchange, idx, vread(in.src[1].value),
+                    rs.exec_narrowed, rs.exec, old);
+                predicate_write(b, rs, in.dst.value, old);
             } else if (in.opcode == 0x0d) {             // ds_write_b32: LDS[idx] = DATA0
                 b.lds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
-            } else if (in.opcode == 0x4d) {             // ds_write_b64: LDS[idx:idx+1] = DATA0 pair
-                b.lds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
-                b.lds_store(b.ibin(Op_IAdd, idx, b.uconst(1)), vread(in.src[1].value + 1),
-                            rs.exec_narrowed, rs.exec);
-            } else if (in.opcode == 0x76) {             // ds_read_b64: VDST pair = LDS[idx:idx+1]
-                for (int k = 0; k < 2; ++k) {
+            } else if (in.opcode == 0x4d || in.opcode == 0xde || in.opcode == 0xdf) {
+                // ds_write_b64 / ds_write_b96 / ds_write_b128. The wide forms consume consecutive
+                // DATA0 VGPRs and write consecutive LDS dwords from the ordinary byte address.
+                const int dwords = in.opcode == 0x4d ? 2 : in.opcode == 0xde ? 3 : 4;
+                for (int k = 0; k < dwords; ++k) {
+                    const uint32_t at = k ? b.ibin(Op_IAdd, idx, b.uconst((uint32_t)k)) : idx;
+                    b.lds_store(at, vread(in.src[1].value + k), rs.exec_narrowed, rs.exec);
+                }
+            } else if (in.opcode == 0x76 || in.opcode == 0xfe || in.opcode == 0xff) {
+                // ds_read_b64 / ds_read_b96 / ds_read_b128. RDNA2 ISA 12.13 opcodes 118/254/255;
+                // all return consecutive dwords beginning at the ordinary LDS byte address.
+                const int dwords = in.opcode == 0x76 ? 2 : in.opcode == 0xfe ? 3 : 4;
+                for (int k = 0; k < dwords; ++k) {
                     const uint32_t old = vreg_old(b, rs, in.dst.value + k);
-                    const uint32_t at = k ? b.ibin(Op_IAdd, idx, b.uconst(1)) : idx;
+                    const uint32_t at = k ? b.ibin(Op_IAdd, idx, b.uconst((uint32_t)k)) : idx;
                     rs.vreg[in.dst.value + k] = b.lds_load(at);
                     predicate_write(b, rs, in.dst.value + k, old);
                 }
@@ -4218,7 +4788,17 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
                 }
                 break;
             }
-            case Rdna2Format::SOPK: kill(in.dst.value); break;
+            case Rdna2Format::SOPK:
+                // s_movk_i32 is also a common way to fill V# word2 (num_records). Astro Bot's
+                // fullscreen-table VS uses it immediately before s_getpc_b64; treating every SOPK
+                // as an unknown write prevented the otherwise-proven embedded table from folding.
+                // The immediate is sign-extended by the ISA, matching the scalar register value.
+                kill(in.dst.value);
+                if (in.opcode == 0x00) {
+                    kconst[in.dst.value] = static_cast<uint32_t>(static_cast<int32_t>(in.simm16));
+                    fact_pc[in.dst.value] = in.pc;
+                }
+                break;
             case Rdna2Format::SMEM: {
                 uint32_t n = 1;
                 switch (in.opcode) { case 0x1: case 0x9: n=2; break; case 0x2: case 0xA: n=4; break;
@@ -4573,8 +5153,9 @@ size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords) {
 // Native subgroup widths are implementation-defined (llvmpipe is commonly 8), so every invocation
 // remains in the dispatcher until the whole workgroup is done and exchanges its vote at the common
 // switch merge. Dedicated Workgroup scratch keeps multiple hardware waves independent. The fallback
-// is gated by emit_body to complex compute CFGs without guest barriers or synthesized cross-lane
-// operations; ordinary LDS reads, writes, and atomics remain valid while waves visit different cases.
+// is gated by emit_body to complex compute CFGs without guest barriers. Ordinary LDS reads, writes,
+// and atomics remain valid while waves visit different cases. V_MBCNT is split into a dedicated
+// common phase so every workgroup invocation reaches its synthesized barriers in uniform control flow.
 bool emit_compute_cfg_state_machine(
     SpirvCompute& b, RegState& initial, const std::vector<Rdna2Inst>& ins,
     const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
@@ -4593,11 +5174,74 @@ bool emit_compute_cfg_state_machine(
     const uint32_t group_active_slot = wave_result_base + wave_count;
     b.declare_cfg_scratch(group_active_slot + 1);
 
-    // Split at every branch target and fallthrough. Case values are dense block indices, not guest PCs.
+    // Discover every scalar pair that lives in the per-lane mask domain.  Besides defining the
+    // dispatcher variables below, this identifies s_cmp_{eq,lg}_u64 mask,0: its SCC result is a
+    // whole-wave reduction and therefore must be lowered in the common synchronized phase.
+    std::set<int> static_mask_keys;
+    for (const auto& kv : initial.sreg_bool) static_mask_keys.insert(kv.first);
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt == Rdna2Format::SOP1 &&
+            (in.opcode == 0x04 || in.opcode == 0x08 || in.opcode == 0x0a ||
+             in.opcode == 0x24 || in.opcode == 0x25 || in.opcode == 0x37) &&
+            in.dst.value != 126 && in.dst.value != 127)
+            static_mask_keys.insert(in.dst.value);
+        if (in.fmt == Rdna2Format::SOP2 &&
+            (in.opcode == 0x0b || in.opcode == 0x0f || in.opcode == 0x11 ||
+             in.opcode == 0x13 || in.opcode == 0x15 || in.opcode == 0x17 ||
+             in.opcode == 0x19 || in.opcode == 0x1b || in.opcode == 0x1d ||
+             in.opcode == 0x25) &&
+            in.dst.value != 106 && in.dst.value != 107 &&
+            in.dst.value != 126 && in.dst.value != 127)
+            static_mask_keys.insert(in.dst.value);
+        if (in.fmt == Rdna2Format::VOPC && in.dst.kind == OperandKind::SGPR &&
+            in.dst.value <= 105)
+            static_mask_keys.insert(in.dst.value);
+    }
+    auto mask_zero_compare_source = [&](const Rdna2Inst& in) -> int {
+        if (in.fmt != Rdna2Format::SOPC || (in.opcode != 0x12 && in.opcode != 0x13))
+            return -1;
+        auto zero = [](const Operand& o) {
+            return o.kind == OperandKind::InlineInt && o.value == 0;
+        };
+        if (in.src[0].kind == OperandKind::SGPR && static_mask_keys.count(in.src[0].value) &&
+            zero(in.src[1]))
+            return in.src[0].value;
+        if (in.src[1].kind == OperandKind::SGPR && static_mask_keys.count(in.src[1].value) &&
+            zero(in.src[0]))
+            return in.src[1].value;
+        return -1;
+    };
+
+    // Split at every branch target/fallthrough and around every cross-lane operation. Case values are
+    // dense block indices, not guest PCs. A cross-lane op must end its block so the common synchronized
+    // phase can publish its result before any invocation advances to the following guest instruction.
     std::set<uint32_t> start_set{ins.front().pc};
+    std::unordered_map<uint32_t, uint32_t> mbcnt_event_for_pc;
+    std::unordered_map<uint32_t, uint32_t> append_event_for_pc;
     for (size_t i = 0; i < ins.size(); ++i) {
         const auto& in = ins[i];
         if (in.is_end) break;
+        if (in.fmt == Rdna2Format::VOP3 &&
+            (in.opcode == 0x365 || in.opcode == 0x366)) {
+            mbcnt_event_for_pc.emplace(in.pc,
+                static_cast<uint32_t>(mbcnt_event_for_pc.size()));
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (in.fmt == Rdna2Format::DS && (in.opcode == 0x3d || in.opcode == 0x3e)) {
+            append_event_for_pc.emplace(in.pc,
+                static_cast<uint32_t>(append_event_for_pc.size()));
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (mask_zero_compare_source(in) >= 0) {
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
         if (in.fmt != Rdna2Format::SOPP || in.opcode < 0x02 || in.opcode > 0x09 ||
             in.opcode == 0x03) continue;
         const uint32_t target = branch_target(in);
@@ -4622,6 +5266,10 @@ bool emit_compute_cfg_state_machine(
                      (src.kind == OperandKind::Special && src.value >= 106 && src.value <= 124))
                 sregs.insert(src.value);
         }
+        // 64-bit scalar compares encode only the low SGPR of each pair in their two source fields.
+        if (in.fmt == Rdna2Format::SOPC && (in.opcode == 0x12 || in.opcode == 0x13))
+            for (uint32_t k = 0; k < 2; ++k)
+                if (in.src[k].kind == OperandKind::SGPR) sregs.insert(in.src[k].value + 1);
     }
     for (const auto& kv : initial.vreg) vregs.insert(kv.first);
     for (const auto& kv : initial.sreg) sregs.insert(kv.first);
@@ -4643,26 +5291,10 @@ bool emit_compute_cfg_state_machine(
     }
 
     // Saved mask pairs and scalar-spill lane slots have their own value domains.
-    std::set<int> mask_keys;
-    for (const auto& kv : initial.sreg_bool) mask_keys.insert(kv.first);
+    std::set<int> mask_keys = static_mask_keys;
     std::set<std::pair<int, int>> lane_slots, mask_lane_slots;
-    // Discover every mask-valued SGPR first. A lane spill can precede another static definition of
-    // that mask in a back-edge block, so classifying spills in the same pass would be order-dependent.
-    for (const auto& in : ins) {
-        if (in.is_end) break;
-        if (in.fmt == Rdna2Format::SOP1 &&
-            (in.opcode == 0x04 || in.opcode == 0x0a || in.opcode == 0x24 || in.opcode == 0x25) &&
-            in.dst.value != 126 && in.dst.value != 127)
-            mask_keys.insert(in.dst.value);
-        if (in.fmt == Rdna2Format::SOP2 &&
-            (in.opcode == 0x0b || in.opcode == 0x0f || in.opcode == 0x11 ||
-             in.opcode == 0x13 || in.opcode == 0x15 || in.opcode == 0x17 ||
-             in.opcode == 0x19 || in.opcode == 0x1b || in.opcode == 0x1d) &&
-            in.dst.value != 106 && in.dst.value != 107 && in.dst.value != 126 && in.dst.value != 127)
-            mask_keys.insert(in.dst.value);
-        if (in.fmt == Rdna2Format::VOPC && in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
-            mask_keys.insert(in.dst.value);
-    }
+    // A lane spill can precede another static definition of its mask in a back-edge block, hence the
+    // complete discovery pass above occurs before classifying any spill slots here.
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt == Rdna2Format::VOP3 && in.opcode == 0x361 &&
@@ -4698,8 +5330,24 @@ bool emit_compute_cfg_state_machine(
     const uint32_t vote_pending_var = b.function_var(b.t_bool, ptr_bool);
     const uint32_t vote_value_var = b.function_var(b.t_bool, ptr_bool);
     const uint32_t vote_invert_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t vote_to_scc_var = b.function_var(b.t_bool, ptr_bool);
     const uint32_t vote_taken_var = b.function_var(b.t_u32, ptr_u32);
     const uint32_t vote_next_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t mbcnt_pending_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t mbcnt_mask_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t mbcnt_low_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t mbcnt_write_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t mbcnt_event_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t mbcnt_acc_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t mbcnt_dst_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t mbcnt_sum_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t append_pending_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t append_active_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t append_event_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t append_consume_var = b.function_var(b.t_bool, ptr_bool);
+    const uint32_t append_idx_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t append_dst_var = b.function_var(b.t_u32, ptr_u32);
+    const uint32_t append_count_var = b.function_var(b.t_u32, ptr_u32);
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
     for (const auto& kv : vv) {
@@ -4740,6 +5388,7 @@ bool emit_compute_cfg_state_machine(
 
     auto load_state = [&]() {
         RegState state;
+        state.sreg_input = initial.sreg_input;
         for (const auto& kv : vv) state.vreg[kv.first] = b.load_function(b.t_u32, kv.second);
         for (const auto& kv : sv) state.sreg[kv.first] = b.load_function(b.t_u32, kv.second);
         for (const auto& kv : mv) {
@@ -4810,8 +5459,22 @@ bool emit_compute_cfg_state_machine(
     b.store_function(vote_pending_var, no);
     b.store_function(vote_value_var, no);
     b.store_function(vote_invert_var, no);
+    b.store_function(vote_to_scc_var, no);
     b.store_function(vote_taken_var, zero);
     b.store_function(vote_next_var, zero);
+    b.store_function(mbcnt_pending_var, no);
+    b.store_function(mbcnt_mask_var, no);
+    b.store_function(mbcnt_low_var, no);
+    b.store_function(mbcnt_write_var, no);
+    b.store_function(mbcnt_event_var, zero);
+    b.store_function(mbcnt_acc_var, zero);
+    b.store_function(mbcnt_dst_var, zero);
+    b.store_function(append_pending_var, no);
+    b.store_function(append_active_var, no);
+    b.store_function(append_event_var, zero);
+    b.store_function(append_consume_var, no);
+    b.store_function(append_idx_var, zero);
+    b.store_function(append_dst_var, zero);
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
@@ -4837,11 +5500,27 @@ bool emit_compute_cfg_state_machine(
                 if (!written_sregs.count(reg)) state.sreg.erase(reg);
         }
         const Rdna2Inst* terminator = nullptr;
+        const Rdna2Inst* mbcnt = nullptr;
+        const Rdna2Inst* append = nullptr;
+        const Rdna2Inst* mask_compare = nullptr;
         for (const auto& in : ins) {
             if (in.pc < lo || in.pc >= hi) continue;
             if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
                               in.opcode <= 0x09 && in.opcode != 0x03)) {
                 terminator = &in;
+                break;
+            }
+            if (in.fmt == Rdna2Format::VOP3 &&
+                (in.opcode == 0x365 || in.opcode == 0x366)) {
+                mbcnt = &in;
+                break;
+            }
+            if (in.fmt == Rdna2Format::DS && (in.opcode == 0x3d || in.opcode == 0x3e)) {
+                append = &in;
+                break;
+            }
+            if (mask_zero_compare_source(in) >= 0) {
+                mask_compare = &in;
                 break;
             }
             if (in.fmt == Rdna2Format::EXP) {
@@ -4857,8 +5536,58 @@ bool emit_compute_cfg_state_machine(
                 return false;
             }
         }
+        if (mbcnt) {
+            bool operand_ok = true;
+            const uint32_t mask = mbcnt_source_bit(
+                b, state, mbcnt->src[0], mbcnt->opcode == 0x366);
+            const uint32_t acc = operand_bits(b, state, *mbcnt, mbcnt->src[1], &operand_ok);
+            const auto event = mbcnt_event_for_pc.find(mbcnt->pc);
+            if (!mask || !operand_ok || event == mbcnt_event_for_pc.end()) return false;
+            b.store_function(mbcnt_pending_var, yes);
+            b.store_function(mbcnt_mask_var, mask);
+            b.store_function(mbcnt_low_var, mbcnt->opcode == 0x365 ? yes : no);
+            // load_state conservatively marks EXEC narrowed. Writing under the current per-lane EXEC
+            // is equivalent for a known-full mask and preserves inactive VGPR lanes for divergent code.
+            b.store_function(mbcnt_write_var, state.exec);
+            b.store_function(mbcnt_event_var, b.uconst(event->second));
+            b.store_function(mbcnt_acc_var, acc);
+            b.store_function(mbcnt_dst_var, b.uconst(static_cast<uint32_t>(mbcnt->dst.value)));
+        }
+        if (append) {
+            const auto m0 = state.sreg.find(124);
+            const auto event = append_event_for_pc.find(append->pc);
+            if (m0 == state.sreg.end() || event == append_event_for_pc.end()) return false;
+            b.declare_lds();
+            const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xffffu));
+            const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(append->literal));
+            b.store_function(append_pending_var, yes);
+            b.store_function(append_active_var, state.exec);
+            b.store_function(append_event_var, b.uconst(event->second));
+            b.store_function(append_consume_var, append->opcode == 0x3d ? yes : no);
+            b.store_function(append_idx_var,
+                b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2)));
+            b.store_function(append_dst_var,
+                b.uconst(static_cast<uint32_t>(append->dst.value)));
+        }
+        if (mask_compare) {
+            const int source = mask_zero_compare_source(*mask_compare);
+            const auto value = state.sreg_bool.find(source);
+            if (value == state.sreg_bool.end()) return false;
+            b.store_function(vote_pending_var, yes);
+            b.store_function(vote_value_var, value->second);
+            // EQ mask,0 means !any(mask); LG mask,0 means any(mask).
+            b.store_function(vote_invert_var,
+                mask_compare->opcode == 0x12 ? yes : no);
+            b.store_function(vote_to_scc_var, yes);
+        }
         save_state(state);
-        if (!terminator) {
+        if (mbcnt) {
+            set_next(mbcnt->pc + mbcnt->len_dwords);
+        } else if (append) {
+            set_next(append->pc + append->len_dwords);
+        } else if (mask_compare) {
+            set_next(mask_compare->pc + mask_compare->len_dwords);
+        } else if (!terminator) {
             set_next(hi);
         } else if (terminator->is_end) {
             b.store_function(active_var, no);
@@ -4897,6 +5626,179 @@ bool emit_compute_cfg_state_machine(
     b.emit_label(switch_merge);
     b.emit_branch(loop_continue);
     b.emit_label(loop_continue);
+
+    // MBCNT common phase. Cases publish an event-tagged mask bit and accumulator, but never emit a
+    // barrier themselves. Every invocation—including ended waves and lanes currently at a different
+    // guest block—therefore executes these two barriers in identical structured control flow. Event
+    // tags keep contributions from different static MBCNT sites isolated if malformed/nonuniform
+    // scalar state ever lets waves reach different sites during the same dispatcher iteration.
+    const uint32_t mbcnt_wave_index = b.ibin(
+        Op_ShiftRightLogical, b.linear_localid,
+        b.uconst(b.wave_size == 32 ? 5u : 6u));
+    const uint32_t mbcnt_lane = b.ibin(
+        Op_BitwiseAnd, b.linear_localid, b.uconst(b.wave_size - 1));
+
+    if (!mbcnt_event_for_pc.empty()) {
+    const uint32_t mbcnt_pending = b.load_function(b.t_bool, mbcnt_pending_var);
+    const uint32_t mbcnt_mask = b.load_function(b.t_bool, mbcnt_mask_var);
+    const uint32_t mbcnt_tag = b.ibin(
+        Op_IAdd, b.load_function(b.t_u32, mbcnt_event_var), b.uconst(1));
+    const uint32_t mbcnt_encoded = b.sel(
+        mbcnt_pending,
+        b.ibin(Op_BitwiseOr,
+               b.ibin(Op_ShiftLeftLogical, mbcnt_tag, b.uconst(1)),
+               b.sel(mbcnt_mask, b.uconst(1), zero)),
+        zero);
+    b.cfg_scratch_store(b.linear_localid, mbcnt_encoded);
+    b.barrier();
+
+    const uint32_t mbcnt_low = b.load_function(b.t_bool, mbcnt_low_var);
+    b.store_function(mbcnt_sum_var, zero);
+    const uint32_t mbcnt_scan = b.id(), mbcnt_scanned = b.id();
+    b.emit_selmerge(mbcnt_scanned);
+    b.emit_condbranch(mbcnt_pending, mbcnt_scan, mbcnt_scanned);
+    b.emit_label(mbcnt_scan);
+    uint32_t mbcnt_sum = zero;
+    const uint32_t mbcnt_wave_base = b.ibin(
+        Op_ShiftLeftLogical, mbcnt_wave_index,
+        b.uconst(b.wave_size == 32 ? 5u : 6u));
+    const uint32_t half_size = std::min(32u, b.wave_size);
+    for (uint32_t i = 0; i < half_size; ++i) {
+        const uint32_t candidate_lane = b.sel(
+            mbcnt_low, b.uconst(i), b.uconst(i + (b.wave_size == 64 ? 32u : 0u)));
+        const uint32_t candidate = b.cfg_scratch_load(
+            b.ibin(Op_IAdd, mbcnt_wave_base, candidate_lane));
+        const uint32_t candidate_tag = b.ibin(
+            Op_ShiftRightLogical, candidate, b.uconst(1));
+        const uint32_t candidate_bit = b.ibin(Op_BitwiseAnd, candidate, b.uconst(1));
+        const uint32_t below = b.ucmp(
+            Op_ULessThan, candidate_lane, mbcnt_lane);
+        uint32_t include = below;
+        if (b.wave_size == 32) include = b.land(include, mbcnt_low);
+        include = b.land(include, b.ucmp(Op_IEqual, candidate_tag, mbcnt_tag));
+        mbcnt_sum = b.b_iadd(mbcnt_sum, b.sel(include, candidate_bit, zero));
+    }
+    b.store_function(mbcnt_sum_var, mbcnt_sum);
+    b.emit_branch(mbcnt_scanned);
+    b.emit_label(mbcnt_scanned);
+    const uint32_t mbcnt_result = b.b_iadd(
+        b.load_function(b.t_u32, mbcnt_acc_var),
+        b.load_function(b.t_u32, mbcnt_sum_var));
+    const uint32_t mbcnt_dst = b.load_function(b.t_u32, mbcnt_dst_var);
+    const uint32_t mbcnt_write = b.land(
+        mbcnt_pending, b.load_function(b.t_bool, mbcnt_write_var));
+    for (const auto& kv : vv) {
+        const uint32_t selected = b.land(
+            mbcnt_write, b.ucmp(Op_IEqual, mbcnt_dst, b.uconst(static_cast<uint32_t>(kv.first))));
+        const uint32_t old = b.load_function(b.t_u32, kv.second);
+        b.store_function(kv.second, b.sel(selected, mbcnt_result, old));
+    }
+    // An ordinary VGPR write ends any scalar-spill lifetime even for lanes masked off by EXEC.
+    for (const auto& kv : lv) {
+        const uint32_t selected = b.land(
+            mbcnt_pending,
+            b.ucmp(Op_IEqual, mbcnt_dst, b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_u32, kv.second);
+        b.store_function(kv.second, b.sel(selected, zero, old));
+    }
+    for (const auto& kv : lmv) {
+        const uint32_t selected = b.land(
+            mbcnt_pending,
+            b.ucmp(Op_IEqual, mbcnt_dst, b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_bool, kv.second);
+        b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    b.barrier();
+    }
+
+    if (!append_event_for_pc.empty()) {
+    // DS_APPEND/DS_CONSUME common phase. Each wave reduces popcount(EXEC), its lane zero performs
+    // exactly one LDS atomic add/subtract, and the pre-op value is broadcast through the result slot.
+    // The event tag prevents a wave at one static append from counting another event's lanes.
+    const uint32_t append_pending = b.load_function(b.t_bool, append_pending_var);
+    const uint32_t append_active = b.load_function(b.t_bool, append_active_var);
+    const uint32_t append_tag = b.ibin(
+        Op_IAdd, b.load_function(b.t_u32, append_event_var), b.uconst(1));
+    const uint32_t append_encoded = b.sel(
+        append_pending,
+        b.ibin(Op_BitwiseOr,
+               b.ibin(Op_ShiftLeftLogical, append_tag, b.uconst(1)),
+               b.sel(append_active, b.uconst(1), zero)),
+        zero);
+    b.cfg_scratch_store(b.linear_localid, append_encoded);
+    b.barrier();
+
+    b.store_function(append_count_var, zero);
+    const uint32_t append_scan = b.id(), append_scanned = b.id();
+    b.emit_selmerge(append_scanned);
+    b.emit_condbranch(append_pending, append_scan, append_scanned);
+    b.emit_label(append_scan);
+    uint32_t append_count = zero;
+    const uint32_t append_wave_base = b.ibin(
+        Op_ShiftLeftLogical, mbcnt_wave_index,
+        b.uconst(b.wave_size == 32 ? 5u : 6u));
+    for (uint32_t i = 0; i < b.wave_size; ++i) {
+        const uint32_t candidate_index = b.ibin(
+            Op_IAdd, append_wave_base, b.uconst(i));
+        const uint32_t candidate = b.cfg_scratch_load(candidate_index);
+        const uint32_t candidate_tag = b.ibin(
+            Op_ShiftRightLogical, candidate, b.uconst(1));
+        uint32_t include = b.ucmp(
+            Op_ULessThan, candidate_index, b.uconst(b.local_count));
+        include = b.land(include, b.ucmp(Op_IEqual, candidate_tag, append_tag));
+        append_count = b.b_iadd(
+            append_count,
+            b.sel(include, b.ibin(Op_BitwiseAnd, candidate, b.uconst(1)), zero));
+    }
+    b.store_function(append_count_var, append_count);
+    b.emit_branch(append_scanned);
+    b.emit_label(append_scanned);
+    const uint32_t append_is_leader = b.land(
+        append_pending, b.ucmp(Op_IEqual, mbcnt_lane, zero));
+    const uint32_t append_leader = b.id(), append_reduced = b.id();
+    b.emit_selmerge(append_reduced);
+    b.emit_condbranch(append_is_leader, append_leader, append_reduced);
+    b.emit_label(append_leader);
+    const uint32_t append_count_value = b.load_function(b.t_u32, append_count_var);
+    const uint32_t append_delta = b.sel(
+        b.load_function(b.t_bool, append_consume_var),
+        b.ibin(Op_ISub, zero, append_count_value), append_count_value);
+    const uint32_t append_old = b.lds_atomic_rtn(
+        Op_AtomicIAdd, b.load_function(b.t_u32, append_idx_var),
+        append_delta, false, yes, zero);
+    b.cfg_scratch_store(
+        b.ibin(Op_IAdd, b.uconst(wave_result_base), mbcnt_wave_index), append_old);
+    b.emit_branch(append_reduced);
+    b.emit_label(append_reduced);
+    b.barrier();
+
+    const uint32_t append_result = b.cfg_scratch_load(
+        b.ibin(Op_IAdd, b.uconst(wave_result_base), mbcnt_wave_index));
+    const uint32_t append_dst = b.load_function(b.t_u32, append_dst_var);
+    const uint32_t append_write = b.land(append_pending, append_active);
+    for (const auto& kv : vv) {
+        const uint32_t selected = b.land(
+            append_write,
+            b.ucmp(Op_IEqual, append_dst, b.uconst(static_cast<uint32_t>(kv.first))));
+        const uint32_t old = b.load_function(b.t_u32, kv.second);
+        b.store_function(kv.second, b.sel(selected, append_result, old));
+    }
+    for (const auto& kv : lv) {
+        const uint32_t selected = b.land(
+            append_pending,
+            b.ucmp(Op_IEqual, append_dst, b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_u32, kv.second);
+        b.store_function(kv.second, b.sel(selected, zero, old));
+    }
+    for (const auto& kv : lmv) {
+        const uint32_t selected = b.land(
+            append_pending,
+            b.ucmp(Op_IEqual, append_dst, b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_bool, kv.second);
+        b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    b.barrier();
+    }
 
     // Publish this lane's pending vote bit and liveness. The switch merge is reached by every
     // invocation on every iteration, including lanes whose emulated wave has already ended.
@@ -4961,7 +5863,12 @@ bool emit_compute_cfg_state_machine(
         b.load_function(b.t_bool, vote_invert_var), b.logical_not(wave_any), wave_any);
     const uint32_t selected_pc = b.sel(vote_condition,
         b.load_function(b.t_u32, vote_taken_var), b.load_function(b.t_u32, vote_next_var));
-    b.store_function(pc_var, b.sel(pending, selected_pc, b.load_function(b.t_u32, pc_var)));
+    const uint32_t vote_to_scc = b.load_function(b.t_bool, vote_to_scc_var);
+    const uint32_t write_scc = b.land(pending, vote_to_scc);
+    b.store_function(scc_var,
+        b.bsel(write_scc, vote_condition, b.load_function(b.t_bool, scc_var)));
+    const uint32_t write_pc = b.land(pending, b.logical_not(vote_to_scc));
+    b.store_function(pc_var, b.sel(write_pc, selected_pc, b.load_function(b.t_u32, pc_var)));
     const uint32_t group_active = b.ucmp(
         Op_INotEqual, b.cfg_scratch_load(b.uconst(group_active_slot)), zero);
     b.emit_condbranch(group_active, loop_header, loop_merge);
@@ -4987,6 +5894,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
     // MUBUF/SOP1 handlers consult rs.mubuf_pcrel_tables (#273).
     if (code) rs.mubuf_pcrel_tables = detect_pcrel_tables(ins, code, dwords);
     std::unordered_set<uint32_t> effective_safe = safe;
+    const std::unordered_set<uint32_t> dead_masks = dead_wave_mask_writes(ins);
     const CountedLoop L = detect_counted_loop(ins);
     size_t idx = 0;
     // Cross-lane wave ops (mbcnt) emit LDS + barriers, which are only valid at wave-uniform points — so
@@ -4997,15 +5905,24 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             const Rdna2Inst& in = ins[idx];
             if (in.is_end || in.pc >= pc_hi) break;
             if (in.pc < pc_lo) continue;
+            if (dead_masks.count(in.pc)) continue;
             if (in.fmt == Rdna2Format::EXP) { if (!exp_fn(in)) return false; continue; }
             bool ok = true;
             if (!emit_alu(b, rs, in, ok, allow_exec_update, &effective_safe, allow_smem, rt, wave_ok) || !ok) {
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
                 if (getenv("PROSPER_DBG"))
-                    fprintf(stderr, "[recompile-reject] pc=%u fmt=%d op=0x%x dst=%d(kind%d) dmask=0x%x dim=%u len=%u\n",
-                        in.pc, (int)in.fmt, in.opcode, in.dst.value, (int)in.dst.kind,
-                        in.mimg_dmask, in.mimg_dim, in.len_dwords);
+                    fprintf(stderr, "[recompile-reject] pc=%u words=%08x,%08x fmt=%d op=0x%x "
+                                    "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
+                                    "dim=%u len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u\n",
+                        in.pc, in.words[0], in.words[1], (int)in.fmt, in.opcode,
+                        in.dst.value, (int)in.dst.kind,
+                        in.src[0].value, (int)in.src[0].kind,
+                        in.src[1].value, (int)in.src[1].kind,
+                        in.src[2].value, (int)in.src[2].kind,
+                        in.mimg_dmask, in.mimg_dim, in.len_dwords, (int)in.has_modifier,
+                        (int)in.has_dpp, in.sdwa_dst_sel, in.sdwa_dst_unused,
+                        in.sdwa_src0_sel, in.sdwa_src1_sel);
                 return false;
             }
         }
@@ -5273,16 +6190,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // That shape is intentionally outside the narrow pattern structurizer above. Use the
         // dispatcher fallback only when there is unmistakably complex compute control flow and the
         // body is free of operations whose workgroup-uniform placement the dispatcher cannot prove.
-        // Raw DS operations are wave-local memory effects and are valid in a case; only barriers and
-        // cross-lane operations which synthesize barriers require workgroup-uniform placement.
+        // Raw DS operations are wave-local memory effects and are valid in a case. Guest barriers
+        // remain unsupported; MBCNT is hoisted into the dispatcher's uniform synchronized phase.
         // Existing straight-line, single-if, and recognized single-loop shaders keep their old path.
         size_t cfg_branches = 0;
         bool cfg_has_backedge = false, cfg_dispatch_safe = b.is_compute;
         for (const auto& in : ins) {
             if (in.is_end) break;
-            if ((in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
-                (in.fmt == Rdna2Format::VOP3 &&
-                 (in.opcode == 0x365 || in.opcode == 0x366)))
+            if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a)
                 cfg_dispatch_safe = false;
             if (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 && in.opcode <= 0x09 &&
                 in.opcode != 0x03) {
@@ -5292,7 +6207,16 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         }
         // A lone exit + back-edge is the ordinary single-loop shape. Keep rejecting it when its
         // wave-uniformity proof fails; the dispatcher is reserved for genuinely nested/multi-branch CFGs.
-        const bool complex_compute_cfg = cfg_dispatch_safe && cfg_branches > 2 && cfg_has_backedge;
+        // The fallback is equally valid for an acyclic branch tree: Astro Bot's screen-space kernels
+        // contain several nested forward EXEC/SCC early-outs but no back-edge. Requiring a back-edge
+        // left those valid CFGs in the straight-line path, where their first branch rejected.
+        const bool complex_compute_cfg = cfg_dispatch_safe && cfg_branches > 2;
+        if (b.is_compute && cfg_branches && getenv("PROSPER_DBG"))
+            std::fprintf(stderr,
+                         "[compute-cfg] branches=%zu backedge=%d dispatch_safe=%d complex=%d "
+                         "structured_ifs=%zu loops=%zu cf_rejected=%d local=%u wave=%u\n",
+                         cfg_branches, cfg_has_backedge, cfg_dispatch_safe, complex_compute_cfg,
+                         Fs.size(), Ls.size(), cf_rejected, b.local_count, b.wave_size);
         if (complex_compute_cfg && (cf_rejected || Ls.empty()) &&
             emit_compute_cfg_state_machine(b, rs, ins, safe, rt,
                                            allow_exec_update, allow_smem, exp_fn))
@@ -5610,9 +6534,13 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                 descriptor_sgprs.insert(resource.sgpr_base + word);
         }
     }
-    for (size_t i = 0; i < config.user_sgprs.size(); i++)
-        if (!descriptor_sgprs.count(static_cast<uint32_t>(i)))
-            rs.sreg[static_cast<int>(i)] = b.uconst(config.user_sgprs[i]);
+    for (size_t i = 0; i < config.user_sgprs.size(); i++) {
+        const uint32_t value = b.uconst(config.user_sgprs[i]);
+        if (descriptor_sgprs.count(static_cast<uint32_t>(i)))
+            rs.sreg_input[static_cast<int>(i)] = value;
+        else
+            rs.sreg[static_cast<int>(i)] = value;
+    }
 
     rs.vreg[0] = b.localid_comp[0];
     if (config.tidig_comp_cnt >= 1) rs.vreg[1] = b.localid_comp[1];
@@ -5689,6 +6617,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     // is accepted for all sample paths and handled as its base 2D slice (array index dropped,
                     // #325) — so array-sampling draws recompile+render instead of being skipped.
                     if (i.opcode == 0x20u || i.opcode == 0x27u) return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
+                    if (i.opcode == 0x2fu) return i.mimg_dim == 5u; // IMAGE_SAMPLE_C_LZ 2D_ARRAY
                     if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
                     return false;
                 }
@@ -5731,14 +6660,19 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     // Preserve hardware target locations. MRT0 and MRT1 are backed by real Vulkan attachments; later
     // targets remain unsupported and must never be silently remapped to location 0 (#635).
     uint32_t color_mask = 0;
+    bool has_null_export = false;
     for (const auto& in : ins) {
         if (in.is_end) break;
-        if (in.fmt == Rdna2Format::EXP && in.exp_target < 2)
-            color_mask |= 1u << in.exp_target;
+        if (in.fmt != Rdna2Format::EXP) continue;
+        if (in.exp_target < 2) color_mask |= 1u << in.exp_target;
+        else if (in.exp_target == 9) has_null_export = true;
     }
-    if (!color_mask) {
+    // A NULL export is a real fragment-shader terminator. Depth/stencil-only draws use it after
+    // narrowing EXEC to the surviving samples, so the module intentionally has no color outputs.
+    // Keep other unsupported MRT-only programs fail-visible instead of accepting every no-color PS.
+    if (!color_mask && !has_null_export) {
         if (getenv("PROSPER_DBG") && pcrel_dispatch_target != UINT32_MAX)
-            fprintf(stderr, "[recompile-reject] pcrel target=%u has no color export\n",
+            fprintf(stderr, "[recompile-reject] pcrel target=%u has no supported export\n",
                     pcrel_dispatch_target);
         return {};
     }
@@ -5806,7 +6740,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
             if (!eok) return false;
             exported[in.exp_target] = true;
         }
-        return true;   // ignore NULL / additional exports for now
+        return true;   // NULL carries the EXEC/discard effect above; ignore additional exports for now
     };
     // cmpx is now ALLOWED (allow_exec_update=true): a fragment divergent-if (v_cmpx ... s_mov exec,saved)
     // is handled by EXEC predication like compute, and the export is guarded above. Memory ops need a
@@ -5816,7 +6750,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
             fprintf(stderr, "[recompile-reject] pcrel target=%u body failed\n", pcrel_dispatch_target);
         return {};
     }
-    if (!exported[0] && !exported[1]) {
+    if (!exported[0] && !exported[1] && !has_null_export) {
         if (getenv("PROSPER_DBG") && pcrel_dispatch_target != UINT32_MAX)
             fprintf(stderr, "[recompile-reject] pcrel target=%u emitted no color\n",
                     pcrel_dispatch_target);
@@ -5843,8 +6777,18 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
     for (const auto& in : ins) { if (in.is_end) break;
         if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x10) { ngg = true; break; } }
     uint32_t vidx = b.load_vertex_index();
-    rs.vreg[0] = vidx;                       // VS ABI: v0 = vertex index
-    if (ngg) rs.vreg[5] = vidx;              // NGG VS ABI: v5 = vertex index
+    uint32_t iidx = b.load_instance_index();
+    rs.vreg[0] = vidx;                       // Legacy VS ABI: v0 = vertex index
+    rs.vreg[3] = iidx;                       // Legacy VS ABI: v3 = instance index
+    if (ngg) {
+        // GFX10's merged GS/ES ABI enters the ES prolog with vertex/instance indices in v5/v8 and
+        // merged-wave counts in s3 ([7:0] ES vertices, [15:8] GS primitives). SPIR-V invokes one
+        // vertex at a time, so model one active ES vertex and no GS primitive. Leaving s3 at the
+        // generic zero default makes the prolog's EXEC/descriptor selection collapse real meshes.
+        rs.vreg[5] = vidx;
+        rs.vreg[8] = iidx;
+        rs.sreg[3] = b.uconst(1);
+    }
     bool exported = false;
     auto exp_fn = [&](const Rdna2Inst& in) -> bool {         // EXP POS0..3 -> gl_Position; PARAM -> varyings
         bool eok = true;   // a Special (wave-mask) source has no data value — reject, don't export 0 (#134)

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -101,8 +101,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ShaderResourceTable* rt,
                                         const ComputeShaderConfig& config);
 
-// Recompile a pixel/fragment shader to a fragment SPIR-V module: run the VALU, and on EXP to an MRT
-// target write vec4(src0..3) to the location-0 color output. Returns {} if unsupported / no export.
+// Recompile a pixel/fragment shader to a fragment SPIR-V module: run the VALU, and on EXP to MRT0/1
+// write vec4(src0..3) to the matching color output. NULL-only shaders retain discard/EXEC effects and
+// intentionally expose no color output. Returns {} if unsupported / no implemented export.
 // An optional ShaderResourceTable enables memory ops (SMEM/MUBUF) with resolved bindings.
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt = nullptr,

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -88,6 +88,68 @@ float f10_to_float(uint16_t v) {
     return half_to_float((uint16_t)(((v & 0x3FFu) >> 5 << 10) | ((v & 0x1Fu) << 5)));
 }
 
+namespace {
+
+uint32_t round_shift_even(uint32_t value, uint32_t shift) {
+    if (!shift) return value;
+    // value is at most 24 bits here. For shifts above that it is strictly below halfway.
+    if (shift >= 32) return 0;
+    uint32_t rounded = value >> shift;
+    const uint32_t remainder = value & ((1u << shift) - 1u);
+    const uint32_t halfway = 1u << (shift - 1u);
+    if (remainder > halfway || (remainder == halfway && (rounded & 1u))) ++rounded;
+    return rounded;
+}
+
+uint16_t float_to_unsigned_small(float f, uint32_t mantissa_bits) {
+    uint32_t bits = 0;
+    std::memcpy(&bits, &f, sizeof(bits));
+    const uint32_t sign = bits >> 31;
+    const uint32_t exponent = (bits >> 23) & 0xffu;
+    const uint32_t mantissa = bits & 0x7fffffu;
+    const uint32_t mantissa_mask = (1u << mantissa_bits) - 1u;
+
+    // Both formats use the binary16 exponent (5 bits, bias 15), but have no sign bit.
+    if (exponent == 0xffu) {
+        if (!mantissa) return static_cast<uint16_t>(0x1fu << mantissa_bits); // +inf
+        uint32_t payload = mantissa >> (23u - mantissa_bits);
+        if (!payload) payload = 1;
+        return static_cast<uint16_t>((0x1fu << mantissa_bits) | payload);    // NaN
+    }
+    if (sign || exponent == 0) return 0; // negative values clamp to +0; f32 subnormals underflow
+
+    int32_t target_exponent = static_cast<int32_t>(exponent) - 127 + 15;
+    if (target_exponent >= 31)
+        return static_cast<uint16_t>(0x1fu << mantissa_bits);                // overflow -> +inf
+
+    const uint32_t significand = 0x800000u | mantissa;
+    if (target_exponent <= 0) {
+        // Target subnormal unit is 2^(-14-mantissa_bits). Express the exact f32 significand in
+        // those units, then perform one round-to-nearest-even step (no double rounding via f16).
+        const int32_t unbiased = static_cast<int32_t>(exponent) - 127;
+        const uint32_t shift = static_cast<uint32_t>(9 - static_cast<int32_t>(mantissa_bits) - unbiased);
+        const uint32_t rounded = round_shift_even(significand, shift);
+        // Rounding the largest subnormal upward produces the smallest normal (exp=1, mantissa=0).
+        if (rounded >= (1u << mantissa_bits))
+            return static_cast<uint16_t>(1u << mantissa_bits);
+        return static_cast<uint16_t>(rounded);
+    }
+
+    uint32_t rounded = round_shift_even(significand, 23u - mantissa_bits);
+    if (rounded == (1u << (mantissa_bits + 1u))) {
+        rounded >>= 1;
+        if (++target_exponent >= 31)
+            return static_cast<uint16_t>(0x1fu << mantissa_bits);
+    }
+    return static_cast<uint16_t>((static_cast<uint32_t>(target_exponent) << mantissa_bits) |
+                                 (rounded & mantissa_mask));
+}
+
+} // namespace
+
+uint16_t float_to_f11(float f) { return float_to_unsigned_small(f, 6); }
+uint16_t float_to_f10(float f) { return float_to_unsigned_small(f, 5); }
+
 void unorm2_10_10_10_to_rgba8(uint32_t packed, uint8_t rgba[4]) {
     // Mesa's GFX10 format table maps a logical R10G10B10A2 description to hardware IMG_FMT 50,
     // whose name lists the packed fields high-to-low. Scale with integer rounding so both endpoints

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -62,6 +62,8 @@ uint16_t float_to_half(float f);
 // widening (subnormals scale identically, inf/NaN preserved). Pure + testable.
 float f11_to_float(uint16_t v);   // low 11 bits used
 float f10_to_float(uint16_t v);   // low 10 bits used
+uint16_t float_to_f11(float f);   // negative clamps to zero; round-to-nearest-even
+uint16_t float_to_f10(float f);   // negative clamps to zero; round-to-nearest-even
 
 // GFX10_FORMAT_2_10_10_10_UNORM packed texel -> RGBA8, with nearest UNORM scaling. Pure + testable.
 void unorm2_10_10_10_to_rgba8(uint32_t packed, uint8_t rgba[4]);
@@ -119,6 +121,13 @@ struct ShaderResource {
     uint32_t      height            = 0;
     uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
+    // A packed mip-tail view shares the allocation's first 4/64 KiB block. gpu_addr remains the
+    // shared block base; the backend applies mip_tail_offset and preserves sibling levels on writes.
+    bool          in_mip_tail       = false;
+    uint32_t      mip_tail_offset   = 0;
+    uint32_t      mip_tail_bytes    = 0;
+    uint32_t      mip_tail_x        = 0;
+    uint32_t      mip_tail_y        = 0;
     bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;
 
@@ -155,6 +164,7 @@ struct ShaderResource {
     float         lod_bias          = 0.0f;
     uint32_t      max_aniso_ratio   = 0;
     uint32_t      depth_compare_func = 0;
+    bool          depth_compare      = false;  // MIMG IMAGE_SAMPLE_C* use
     uint32_t      unnormalized      = 0;
 
     // T# DST_SEL channel swizzle (SQ_SEL enum per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Applied as a Vulkan

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -15,6 +15,7 @@ namespace prosper::gpu {
 bool tile_mode_is_tiled(uint32_t tile_mode) {
     return tile_mode == (uint32_t)TileMode::Sw4KbS ||
            tile_mode == (uint32_t)TileMode::Sw64KbS ||
+           tile_mode == (uint32_t)TileMode::Sw64KbZX ||
            tile_mode == (uint32_t)TileMode::Sw64KbRX;
 }
 
@@ -84,7 +85,7 @@ bool gfx10_dcc_fast_clear_rgba8(uint8_t* dst, size_t texel_count,
 }
 
 // One-time diagnostic when a NON-ZERO (tiled) tile_mode is not one of the swizzles we de-swizzle
-// (Sw4KbS=5 / Sw64KbS=9 / Sw64KbRX=27): the caller then copies the surface VERBATIM as if linear, so
+// (Sw4KbS=5 / Sw64KbS=9 / Sw64KbZX=24 / Sw64KbRX=27): the caller then copies the surface VERBATIM as if linear, so
 // it samples as a scrambled swizzle-weave. Other GFX10 modes a PS5 T# can legally carry — SW_256B_*,
 // SW_4KB_D/*_X, SW_64KB_S_T/D_T, the SW_64KB_Z/D depth/displayable families, SW_VAR_* — all land here.
 // Log once per unrecognized mode under PROSPER_GFXLOG so this silent linear-fallback is observable
@@ -96,7 +97,7 @@ static void warn_unhandled_tile_mode(uint32_t tile_mode, uint32_t w, uint32_t h)
     std::lock_guard<std::mutex> lk(mu);
     if (seen.insert(tile_mode).second)
         fprintf(stderr, "[tile] UNHANDLED GFX10 tile_mode=%u (%ux%u) -> copied as LINEAR; surface will "
-                        "sample SCRAMBLED (only Sw4KbS=5/Sw64KbS=9/Sw64KbRX=27 are de-swizzled)\n",
+                        "sample SCRAMBLED (only Sw4KbS=5/Sw64KbS=9/Sw64KbZX=24/Sw64KbRX=27 are de-swizzled)\n",
                         tile_mode, w, h);
 }
 
@@ -193,7 +194,7 @@ const Sw4kbLookup& sw4kb_lookup(uint32_t bpe) {
 // element reads as zero when detiling and is skipped when tiling (tile pre-zeroes the destination).
 template <bool ToTiled>
 void sw4kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uint32_t pitch,
-                uint32_t bpe, size_t tiled_bytes) {
+                uint32_t bpe, size_t tiled_bytes, size_t tiled_origin = 0) {
     const Sw4kbLookup& lookup = sw4kb_lookup(bpe);
     uint32_t pw = pitch ? pitch : ew;
     uint32_t tiles_per_row = (pw + lookup.tw - 1) / lookup.tw;
@@ -210,7 +211,7 @@ void sw4kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uint
                 const uint16_t* offsets =
                     lookup.byte_offsets.data() + static_cast<size_t>(iy) * lookup.tw;
                 for (uint32_t ix = 0; ix < columns; ++ix) {
-                    const size_t tiled = tile_base + offsets[ix];
+                    const size_t tiled = tiled_origin + tile_base + offsets[ix];
                     const size_t linear = linear_base + static_cast<size_t>(ix) * bpe;
                     if (ToTiled) {
                         if (tiled + bpe <= tiled_bytes) std::memcpy(dst + tiled, src + linear, bpe);
@@ -261,6 +262,19 @@ const PatBit kSw64kS[5][16] = {
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0002,0x0000}, {0x0000,0x0001}, {0x0000,0x0002}, {0x0000,0x0004}, {0x0004,0x0000}, {0x0000,0x0008}, {0x0008,0x0000}, {0x0000,0x0010}, {0x0010,0x0000}, {0x0000,0x0020}, {0x0020,0x0000}, {0x0000,0x0040}, {0x0040,0x0000} },  // 4 bpe
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0000,0x0002}, {0x0002,0x0000}, {0x0004,0x0000}, {0x0000,0x0004}, {0x0008,0x0000}, {0x0000,0x0008}, {0x0010,0x0000}, {0x0000,0x0010}, {0x0020,0x0000}, {0x0000,0x0020}, {0x0040,0x0000} },  // 8 bpe
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0001}, {0x0000,0x0002}, {0x0001,0x0000}, {0x0002,0x0000}, {0x0000,0x0004}, {0x0004,0x0000}, {0x0000,0x0008}, {0x0008,0x0000}, {0x0000,0x0010}, {0x0010,0x0000}, {0x0000,0x0020}, {0x0020,0x0000} },  // 16 bpe
+};
+
+// SW_64K_Z_X, 1 fragment, 16 pipes. Expanded directly from AMD AddrLib's
+// GFX10_SW_64K_Z_X_1xaa_PATINFO rows {12,9,10,11,7}/{74}/{1,30,31,32,33}, with z=0
+// for a 2D surface. Mode 24 first appeared live as Astro Bot's R32 compute destination (#825).
+// Like R_X, bits 8..11 rotate the 64KB block across pipes; unlike R_X, the low byte follows
+// Z/Morton ordering. Oberon uses the same fixed 16-pipe selection as the existing mode-27 path.
+static const PatBit kSw64kZX[5][16] = {
+    { {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0004,0x0000}, {0x0000,0x0004}, {0x0008,0x0000}, {0x0000,0x0010}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0040}, {0x0040,0x0000}, {0x0000,0x0080}, {0x0080,0x0000} },  // 1 bpe
+    { {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0004,0x0000}, {0x0000,0x0004}, {0x0008,0x0000}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0010}, {0x0040,0x0000}, {0x0000,0x0040}, {0x0080,0x0000} },  // 2 bpe
+    { {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0004,0x0000}, {0x0000,0x0004}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0008}, {0x0010,0x0000}, {0x0000,0x0040}, {0x0040,0x0000} },  // 4 bpe
+    { {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0004,0x0000}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0004}, {0x0008,0x0000}, {0x0000,0x0010}, {0x0040,0x0000} },  // 8 bpe
+    { {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0004}, {0x0004,0x0000}, {0x0000,0x0008}, {0x0010,0x0000} },  // 16 bpe
 };
 
 // SW_64K_R_X (1 fragment): the pattern depends on the pipe count; [pipesLog2][elemLog2][bit].
@@ -350,6 +364,7 @@ inline uint32_t sw64kb_rx_pipes_log2() {
 
 inline const PatBit* sw64kb_pattern(uint32_t tile_mode, uint32_t elem_log2) {
     if (tile_mode == (uint32_t)TileMode::Sw64KbRX) return kSw64kRX[sw64kb_rx_pipes_log2()][elem_log2];
+    if (tile_mode == (uint32_t)TileMode::Sw64KbZX) return kSw64kZX[elem_log2];
     return kSw64kS[elem_log2];
 }
 
@@ -370,7 +385,8 @@ size_t sw64kb_tiled_bytes(uint32_t ew, uint32_t eh, uint32_t pitch, uint32_t bpe
 // coords keep even wider masks correct).
 template <bool ToTiled>
 void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uint32_t pitch,
-                 uint32_t bpe, size_t tiled_bytes, uint32_t tile_mode) {
+                 uint32_t bpe, size_t tiled_bytes, uint32_t tile_mode,
+                 size_t tiled_origin = 0) {
     uint32_t el = sw64kb_elem_log2(bpe);
     if (el == UINT32_MAX) {                                    // unsupported bpe -> straight copy
         size_t n = (size_t)ew * eh * bpe;
@@ -396,7 +412,8 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
     for (uint32_t y = 0; y < eh; y++) {
         uint64_t brow = (uint64_t)(y / bh) * blocks_per_row;
         for (uint32_t x = 0; x < ew; x++) {
-            uint64_t t = ((brow + x / bw) << 16) | (uint32_t)(fx[x] ^ fy[y]);
+            uint64_t t = tiled_origin +
+                         (((brow + x / bw) << 16) | (uint32_t)(fx[x] ^ fy[y]));
             size_t   l = ((size_t)y * ew + x) * bpe;
             if (ToTiled) { if (t + bpe <= tiled_bytes) std::memcpy(dst + t, src + l, bpe); }
             else         { if (t + bpe <= tiled_bytes) std::memcpy(dst + l, src + t, bpe);
@@ -406,7 +423,73 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
 }
 
 inline bool is_64kb_mode(uint32_t tile_mode) {
-    return tile_mode == (uint32_t)TileMode::Sw64KbS || tile_mode == (uint32_t)TileMode::Sw64KbRX;
+    return tile_mode == (uint32_t)TileMode::Sw64KbS ||
+           tile_mode == (uint32_t)TileMode::Sw64KbZX ||
+           tile_mode == (uint32_t)TileMode::Sw64KbRX;
+}
+
+// A packed tail level is addressed by GLOBAL element coordinates inside one shared macroblock.
+// Its AddrLib mipTailOffset is metadata, not a linear pointer delta: adding it to the ordinary
+// within-level swizzle produces a self-consistent but physically wrong layout. These walks apply
+// mipTailCoordX/Y before evaluating the same authoritative pattern as the full-surface paths.
+template <bool ToTiled>
+void sw4kb_level_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
+                      uint32_t ew, uint32_t eh, uint32_t bpe,
+                      uint32_t tail_x, uint32_t tail_y) {
+    const Sw4kbLookup& lookup = sw4kb_lookup(bpe);
+    for (uint32_t y = 0; y < eh; ++y) {
+        const uint32_t gy = tail_y + y;
+        for (uint32_t x = 0; x < ew; ++x) {
+            const uint32_t gx = tail_x + x;
+            // Thin GFX10 tails occupy exactly one block. Coordinates outside it indicate a bad
+            // layout descriptor; the bounds check below turns those accesses into zero/no-op.
+            const size_t block = static_cast<size_t>(gy / lookup.th) + gx / lookup.tw;
+            const size_t tiled = block * 4096u +
+                lookup.byte_offsets[static_cast<size_t>(gy % lookup.th) * lookup.tw +
+                                    (gx % lookup.tw)];
+            const size_t linear = (static_cast<size_t>(y) * ew + x) * bpe;
+            if (ToTiled) {
+                if (tiled + bpe <= tiled_bytes) std::memcpy(dst + tiled, src + linear, bpe);
+            } else if (tiled + bpe <= tiled_bytes) {
+                std::memcpy(dst + linear, src + tiled, bpe);
+            } else {
+                std::memset(dst + linear, 0, bpe);
+            }
+        }
+    }
+}
+
+template <bool ToTiled>
+void sw64kb_level_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
+                       uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
+                       uint32_t tail_x, uint32_t tail_y) {
+    const uint32_t el = sw64kb_elem_log2(bpe);
+    if (el == UINT32_MAX) return;
+    uint32_t bw = 0, bh = 0;
+    sw64kb_dims(el, bw, bh);
+    const PatBit* pat = sw64kb_pattern(tile_mode, el);
+    for (uint32_t y = 0; y < eh; ++y) {
+        const uint32_t gy = tail_y + y;
+        for (uint32_t x = 0; x < ew; ++x) {
+            const uint32_t gx = tail_x + x;
+            uint32_t within = 0;
+            for (uint32_t i = el; i < 16; ++i) {
+                const uint32_t bit = (__builtin_popcount(gx & pat[i].x) ^
+                                      __builtin_popcount(gy & pat[i].y)) & 1u;
+                within |= bit << i;
+            }
+            const size_t block = static_cast<size_t>(gy / bh) + gx / bw;
+            const size_t tiled = block * 65536u + within;
+            const size_t linear = (static_cast<size_t>(y) * ew + x) * bpe;
+            if (ToTiled) {
+                if (tiled + bpe <= tiled_bytes) std::memcpy(dst + tiled, src + linear, bpe);
+            } else if (tiled + bpe <= tiled_bytes) {
+                std::memcpy(dst + linear, src + tiled, bpe);
+            } else {
+                std::memset(dst + linear, 0, bpe);
+            }
+        }
+    }
 }
 
 // For the PS5/default 16-pipe GFX10_SW_64K_R_X_1xaa pattern, AddrLib nibble2[74]
@@ -534,25 +617,51 @@ size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t til
     return sw4kb_tiled_bytes(ew, eh, /*pitch*/0, bpe);
 }
 
-size_t tiled_mip_level_offset(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
-                              uint32_t max_mip, uint32_t mip_level) {
-    if (!tile_mode_is_tiled(tile_mode) || !ew || !eh || !bpe || !max_mip ||
-        mip_level > max_mip || max_mip >= 16)
-        return 0;
+TiledMipLevelLayout tiled_mip_level_layout(uint32_t ew, uint32_t eh, uint32_t bpe,
+                                           uint32_t tile_mode, uint32_t max_mip,
+                                           uint32_t mip_level) {
+    TiledMipLevelLayout result;
+    if (!ew || !eh || !bpe || mip_level > max_mip || max_mip >= 16)
+        return result;
+
+    if (tile_mode == 0) {
+        // Official GFX10 AddrLib HwlComputeSurfaceInfoLinear: ADDR_SW_LINEAR aligns every mip's
+        // pitch to 256 bytes and stores a multi-level chain in reverse order (smallest level first).
+        // pMipInfo[i].offset is therefore the sum of aligned levels max_mip..i+1.
+        if (bpe > 256 || (256 % bpe) != 0) return result;
+        const uint32_t pitch_align = 256 / bpe;
+        size_t offset = 0;
+        for (uint32_t level = max_mip; level > mip_level; --level) {
+            const uint32_t width = std::max(ew >> level, 1u);
+            const uint32_t height = std::max(eh >> level, 1u);
+            const uint32_t pitch = ((width + pitch_align - 1) / pitch_align) * pitch_align;
+            const size_t level_bytes = static_cast<size_t>(pitch) * height * bpe;
+            if (offset > SIZE_MAX - level_bytes) return {};
+            offset += level_bytes;
+        }
+        result.byte_offset = offset;
+        result.supported = true;
+        return result;
+    }
+    if (!tile_mode_is_tiled(tile_mode)) return result;
 
     uint32_t block_width = 0, block_height = 0, block_log2 = 0;
     if (is_64kb_mode(tile_mode)) {
         const uint32_t elem_log2 = sw64kb_elem_log2(bpe);
-        if (elem_log2 == UINT32_MAX) return 0;
+        if (elem_log2 == UINT32_MAX) return result;
         sw64kb_dims(elem_log2, block_width, block_height);
         block_log2 = 16;
     } else {
+        if (bpe != 1 && bpe != 2 && bpe != 4 && bpe != 8 && bpe != 16)
+            return result;
         uint32_t bx = 0, by = 0;
         sw4kb_dims(bpe, bx, by);
         block_width = 1u << bx;
         block_height = 1u << by;
         block_log2 = 12;
     }
+    result.supported = true;
+    if (max_mip == 0) return result;
 
     const uint32_t num_levels = max_mip + 1;
     const uint32_t tail_width = block_width >> 1;   // AddrLib GetMipTailDim, thin GFX10 resource
@@ -569,22 +678,65 @@ size_t tiled_mip_level_offset(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t t
             break;
         }
     }
-    if (mip_level >= first_tail) return 0;          // packed inside the shared tail block
+    if (mip_level >= first_tail) {
+        // GFX10 AddrLib ComputeSurfaceInfo: tail levels use an addressable byte origin inside the
+        // allocation's first macroblock. The alternating bit extraction below converts that byte
+        // origin to the equivalent element coordinate; keeping both makes the layout independently
+        // testable and documents why adding byte_offset to the ordinary within-level swizzle works.
+        const uint32_t m = max_tail_levels - 1u - (mip_level - first_tail);
+        const uint32_t mip_offset = m > 6u ? (16u << m) : (m << 8u);
+        uint32_t mip_x = ((mip_offset >> 9)  & 1u) |
+                         ((mip_offset >> 10) & 2u) |
+                         ((mip_offset >> 11) & 4u) |
+                         ((mip_offset >> 12) & 8u) |
+                         ((mip_offset >> 13) & 16u) |
+                         ((mip_offset >> 14) & 32u);
+        uint32_t mip_y = ((mip_offset >> 8)  & 1u) |
+                         ((mip_offset >> 9)  & 2u) |
+                         ((mip_offset >> 10) & 4u) |
+                         ((mip_offset >> 11) & 8u) |
+                         ((mip_offset >> 12) & 16u) |
+                         ((mip_offset >> 13) & 32u);
+        const uint32_t elem_log2 = static_cast<uint32_t>(__builtin_ctz(bpe));
+        if (block_log2 & 1u) {
+            std::swap(mip_x, mip_y);
+            if (elem_log2 & 1u) {
+                mip_y = (mip_y << 1u) | (mip_x & 1u);
+                mip_x >>= 1u;
+            }
+        }
+        result.byte_offset = mip_offset;
+        result.tail_x = mip_x * (block_width >> 4u);   // Block256_2d element dimensions
+        result.tail_y = mip_y * (block_height >> 4u);
+        result.tail_block_bytes = 1u << block_log2;
+        result.in_tail = true;
+        return result;
+    }
 
     const size_t block_bytes = size_t{1} << block_log2;
     size_t offset = first_tail == num_levels ? 0 : block_bytes;
     for (int level = static_cast<int>(first_tail) - 1; level >= 0; --level) {
-        if (static_cast<uint32_t>(level) == mip_level) return offset;
+        if (static_cast<uint32_t>(level) == mip_level) {
+            result.byte_offset = offset;
+            return result;
+        }
         const uint32_t width = std::max(ew >> level, 1u);
         const uint32_t height = std::max(eh >> level, 1u);
         const uint32_t pitch = (width + block_width - 1) / block_width * block_width;
         const uint32_t padded_height =
             (height + block_height - 1) / block_height * block_height;
         const size_t level_bytes = static_cast<size_t>(pitch) * padded_height * bpe;
-        if (offset > SIZE_MAX - level_bytes) return 0;
+        if (offset > SIZE_MAX - level_bytes) return {};
         offset += level_bytes;
     }
-    return 0;
+    return {};
+}
+
+size_t tiled_mip_level_offset(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
+                              uint32_t max_mip, uint32_t mip_level) {
+    const TiledMipLevelLayout layout = tiled_mip_level_layout(
+        ew, eh, bpe, tile_mode, max_mip, mip_level);
+    return layout.supported && !layout.in_tail ? layout.byte_offset : 0;
 }
 
 void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
@@ -601,6 +753,53 @@ void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
         return;
     }
     sw4kb_copy<false>(dst, src, ew, eh, /*pitch*/0, bpe, src_bytes);
+}
+
+void detile_elements_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                           uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
+                           uint32_t tail_x, uint32_t tail_y) {
+    const size_t linear_bytes = static_cast<size_t>(ew) * eh * bpe;
+    if (!bpe) {
+        if (linear_bytes) std::memset(dst, 0, linear_bytes);
+        return;
+    }
+    if (!tile_mode_is_tiled(tile_mode)) {
+        const size_t n = std::min(linear_bytes, src_bytes);
+        std::memcpy(dst, src, n);
+        if (n < linear_bytes) std::memset(dst + n, 0, linear_bytes - n);
+        return;
+    }
+    if (is_64kb_mode(tile_mode)) {
+        sw64kb_level_copy<false>(dst, src, src_bytes, ew, eh, bpe, tile_mode,
+                                 tail_x, tail_y);
+    } else {
+        sw4kb_level_copy<false>(dst, src, src_bytes, ew, eh, bpe, tail_x, tail_y);
+    }
+}
+
+void detile_surface_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                          uint32_t width, uint32_t height, uint32_t tile_mode,
+                          uint32_t bytes_per_texel, uint32_t tail_x, uint32_t tail_y) {
+    detile_elements_level(dst, src, src_bytes, width, height, bytes_per_texel,
+                          tile_mode, tail_x, tail_y);
+}
+
+void tile_surface_level(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
+                        uint32_t width, uint32_t height, uint32_t tile_mode,
+                        uint32_t bytes_per_texel, uint32_t tail_x, uint32_t tail_y) {
+    if (!bytes_per_texel) return;
+    const size_t linear_bytes = static_cast<size_t>(width) * height * bytes_per_texel;
+    if (!tile_mode_is_tiled(tile_mode)) {
+        std::memcpy(dst, src, std::min(linear_bytes, dst_bytes));
+        return;
+    }
+    if (is_64kb_mode(tile_mode)) {
+        sw64kb_level_copy<true>(dst, src, dst_bytes, width, height, bytes_per_texel,
+                                tile_mode, tail_x, tail_y);
+    } else {
+        sw4kb_level_copy<true>(dst, src, dst_bytes, width, height, bytes_per_texel,
+                               tail_x, tail_y);
+    }
 }
 
 bool tile_mode_supports_volume(uint32_t tile_mode) {

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -14,9 +14,17 @@
 namespace prosper::gpu {
 
 // AGC/GFX10 T# tile_mode values we recognize. 0 = linear (no swizzle). 5 = SW_4KB_S (the RGBA render
-// target). 9 = SW_64KB_S (standard 64KB, DOLL's material textures) and 27 = SW_64KB_R_X (render-target
-// 64KB with pipe XOR, DOLL's RT/post composites) — #288. Others fall through to a linear copy for now.
-enum class TileMode : uint32_t { Linear = 0, Sw4KbS = 5, Sw64KbS = 9, Sw64KbRX = 27 };
+// target). 9 = SW_64KB_S (standard 64KB, DOLL's material textures), 24 = SW_64KB_Z_X
+// (depth/texture 64KB with pipe XOR, Astro Bot compute surfaces), and 27 = SW_64KB_R_X
+// (render-target 64KB with pipe XOR, DOLL's RT/post composites) — #288/#825.
+// Others fall through to a linear copy for now.
+enum class TileMode : uint32_t {
+    Linear = 0,
+    Sw4KbS = 5,
+    Sw64KbS = 9,
+    Sw64KbZX = 24,
+    Sw64KbRX = 27,
+};
 
 // True if `tile_mode` denotes a swizzled layout that detile_surface will de-swizzle.
 bool tile_mode_is_tiled(uint32_t tile_mode);
@@ -57,13 +65,40 @@ void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 // must read at least this many bytes of tiled source before detiling.
 size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode);
 
-// Byte offset of a non-tail mip level inside a GFX10 thin-2D tiled mip chain. GFX10 places the
-// shared mip-tail block first, then lays the remaining levels out from smallest to largest; mip 0
-// is therefore NOT at descriptor BASE_ADDRESS when MAX_MIP is non-zero. `ew`/`eh` are element-grid
-// dimensions (texels for plain formats, compressed blocks for BCn). Returns zero for linear,
-// single-level, invalid, or mip-tail levels (tail extraction needs an in-block coordinate).
+// One thin-2D mip's location in a GFX10 allocation. SW_MODE 0 follows AddrLib's reverse,
+// 256-byte-pitch-aligned linear chain. Tiled layouts place the shared mip-tail block first, then the
+// remaining levels from smallest to largest. Tail levels share the first 4/64 KiB block;
+// byte_offset is their independently addressable in-block origin, and tail_x/y are the equivalent
+// element coordinates from AddrLib. `ew`/`eh` are the allocation's level-zero element dimensions
+// (texels for plain formats, compressed blocks for BCn).
+struct TiledMipLevelLayout {
+    size_t byte_offset = 0;
+    uint32_t tail_x = 0, tail_y = 0;
+    uint32_t tail_block_bytes = 0;
+    bool in_tail = false;
+    bool supported = false;
+};
+TiledMipLevelLayout tiled_mip_level_layout(uint32_t ew, uint32_t eh, uint32_t bpe,
+                                           uint32_t tile_mode, uint32_t max_mip,
+                                           uint32_t mip_level);
+
+// Compatibility helper for callers interested only in non-tail placement. Tail levels intentionally
+// retain the historical zero result; use tiled_mip_level_layout when a packed-tail view is required.
 size_t tiled_mip_level_offset(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
                               uint32_t max_mip, uint32_t mip_level);
+
+// Access one level packed inside a shared mip-tail block. `src`/`dst` name the allocation base and
+// `tail_x/y` are TiledMipLevelLayout's element coordinates. Unlike tile_surface, the write helper
+// preserves every byte outside this level so sibling mips in the same block are not destroyed.
+void detile_surface_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                          uint32_t width, uint32_t height, uint32_t tile_mode,
+                          uint32_t bytes_per_texel, uint32_t tail_x, uint32_t tail_y);
+void tile_surface_level(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
+                        uint32_t width, uint32_t height, uint32_t tile_mode,
+                        uint32_t bytes_per_texel, uint32_t tail_x, uint32_t tail_y);
+void detile_elements_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                           uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
+                           uint32_t tail_x, uint32_t tail_y);
 
 // GFX10 volume layout. PS5's observed 3D surfaces use SW_64KB_R_X (mode 27), which AddrLib defines
 // as a thin/view-as-2D volume: each Z slice owns a padded grid of 2D 64KB blocks, but Z still

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -83,6 +83,10 @@ std::vector<std::string> savedata0_list_dirs();   // existing save dirs under th
 void register_service_hle();
 // libSceHttp local URI helpers; called by register_builtin_hle().
 void register_http_hle();
+// libSceFont/libSceFontFt opaque lifecycle and deterministic metrics; called by register_builtin_hle().
+void register_font_hle();
+// libSceFiber cooperative guest-stack switching; called by register_builtin_hle().
+void register_fiber_hle();
 // libScePad game-controller input (real host controller via input/pad.cpp); called by register_builtin_hle().
 void register_pad_hle();
 // Headless graphics bring-up (libSceAgc/libSceVideoOut placeholders); see hle_graphics.cpp.
@@ -146,10 +150,9 @@ void tls_dtv_purge_current_thread();
 // regression test assert that thread exit really purged — i.e. no per-thread-churn leak).
 size_t tls_dtv_thread_count();
 
-// Guest initial-exec TLS (Linux; GATED behind PROSPER_GUEST_FS, default off). Backs guest %fs-relative
-// static thread-locals by giving each guest thread its own guest TCB + Variant-II static TLS and running
-// guest code with %fs = guest TP; import stubs swap %fs back to the host TCB for HLE calls. See
-// guest_tls.cpp. Call set_templates with the SAME descs as set_tls_modules (after images are mapped).
+// Guest initial-exec TLS. Enabled by default on Linux/Windows (PROSPER_NO_GUEST_FS opts out); macOS
+// trap emulation is opt-in with PROSPER_GUEST_FS. Backs guest %fs-relative static thread-locals with a
+// guest TCB + Variant-II static TLS; Linux import stubs swap %fs back for HLE calls. See guest_tls.cpp.
 void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count);
 bool guest_tls_enabled();
 uint64_t guest_tls_activate_thread();   // per guest thread at entry; returns guest TP (0 if disabled)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1310,8 +1310,12 @@ HLE(agc_driver_submit_acb) {  // sceAgcDriverSubmitAcb(queue, const AcbPacket*, 
     uint64_t stream = 0, count64 = 0;
     memcpy(&stream, (const void*)(uintptr_t)a1, 8);
     memcpy(&count64, (const void*)(uintptr_t)(a1 + 8), 8);
-    if (!stream || count64 == 0 || count64 > 0x400000ull || (a3 && a3 != count64) ||
-        !gpu::guest_readable(stream, sizeof(uint32_t)))
+    if (!stream || count64 == 0 || count64 > 0x400000ull || (a3 && a3 != count64))
+        return kAgcErrInvalidArg;
+    // The decoder consumes every advertised dword.  Checking only the header allowed a stream at
+    // the end of a readable page to fault as soon as decode crossed into the following guard page.
+    const uint64_t stream_bytes = count64 * sizeof(uint32_t);  // bounded above, cannot overflow
+    if (!gpu::guest_readable(stream, (size_t)stream_bytes))
         return kAgcErrInvalidArg;
     uint32_t header = 0; memcpy(&header, (const void*)(uintptr_t)stream, sizeof header);
     if ((header & 0xc0000000u) != 0xc0000000u && header != 0x80000000u)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1268,6 +1268,44 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     return 0;
 }
 
+// Async-compute submissions use the same AgcDriver::Packet layout as DCB submissions. The command
+// processor already retains dispatches and orders their ReleaseMem/WaitRegMem side effects, so fold
+// ACB streams through the same serialized queue model. Keeping a named wrapper makes the queue type
+// visible in diagnostics and leaves room for independent hardware queue state later.
+HLE(agc_driver_submit_acb) {  // sceAgcDriverSubmitAcb(queue, const AcbPacket*, ...)
+    if (getenv("PROSPER_GFXLOG")) {
+        static std::atomic<unsigned> logged{0};
+        if (logged.fetch_add(1) < 16) {
+            uint64_t words[8]{};
+            bool readable = a1 >= 0x10000 && gpu::guest_readable(a1, sizeof words);
+            if (readable) memcpy(words, (const void*)(uintptr_t)a1, sizeof words);
+            fprintf(stderr, "[agc] SubmitAcb args=[0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx] a1mem=%s "
+                    "[%llx %llx %llx %llx %llx %llx %llx %llx]\n",
+                    (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                    (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5,
+                    readable ? "yes" : "no", (unsigned long long)words[0],
+                    (unsigned long long)words[1], (unsigned long long)words[2],
+                    (unsigned long long)words[3], (unsigned long long)words[4],
+                    (unsigned long long)words[5], (unsigned long long)words[6],
+                    (unsigned long long)words[7]);
+        }
+    }
+    // Live Astro Bot ABI: a0 is the hardware async-queue id (0x40/0x48); a1 points to a larger
+    // submission record whose first two qwords are {stream address, dword count}. a3 repeats the
+    // count. Validate both copies and the PM4 header before allowing the fold.
+    if (!a1 || !gpu::guest_readable(a1, 16)) return kAgcErrInvalidArg;
+    uint64_t stream = 0, count64 = 0;
+    memcpy(&stream, (const void*)(uintptr_t)a1, 8);
+    memcpy(&count64, (const void*)(uintptr_t)(a1 + 8), 8);
+    if (!stream || count64 == 0 || count64 > 0x400000ull || (a3 && a3 != count64) ||
+        !gpu::guest_readable(stream, sizeof(uint32_t)))
+        return kAgcErrInvalidArg;
+    uint32_t header = 0; memcpy(&header, (const void*)(uintptr_t)stream, sizeof header);
+    if ((header & 0xc0000000u) != 0xc0000000u && header != 0x80000000u)
+        return kAgcErrInvalidArg;
+    return submit_dcb_stream((const uint32_t*)(uintptr_t)stream, (uint32_t)count64, "SubmitAcb");
+}
+
 // --- Indirect-register patch helpers: modify a packet returned by a Set*RegsIndirect call.
 // cmd = a0 (that returned pointer). Old stub returned 0 for Set*RegsIndirect -> these wrote to null. -
 HLE(agc_patch_set_address) {  // (cmd, regs): cmd[2..3] = regs vaddr
@@ -1410,6 +1448,15 @@ void register_agc_hle() {
     RN("wr23dPKyWc0", agc_cb_release_mem);
     RN("i1jyy49AjXU", agc_dcb_write_data);
     RN("VmW0Tdpy420", agc_dcb_wait_reg_mem);
+    // Async-compute command-buffer builders share the packet encodings with their DCB siblings.
+    // Astro Bot builds producer fences on ACBs and waits for them from its graphics DCB; dropping
+    // these calls leaves the consumer queue permanently parked on labels that can never be written.
+    RN("JrtiDtKeS38", agc_dcb_reset_queue);       // sceAgcAcbResetQueue
+    RN("cpCILPya5Zk", agc_dcb_push_marker);       // sceAgcAcbPushMarker
+    RN("6mFxkVqdmbQ", agc_dcb_pop_marker);        // sceAgcAcbPopMarker
+    RN("KT-hTp-Ch14", agc_dcb_acquire_mem);       // sceAgcAcbAcquireMem
+    RN("cFazmnXpJOE", agc_dcb_event_write);       // sceAgcAcbEventWrite
+    RN("htn36gPnBk4", agc_dcb_wait_reg_mem);      // sceAgcAcbWaitRegMem
     // Indirect-register patch helpers (SetAddress patches cmd[2..3]; AddRegisters patches cmd[1]).
     RN("vcmNN+AAXnY", agc_patch_set_address);   RN("d-6uF9sZDIU", agc_patch_add_registers);   // Cx
     RN("Qrj4c+61z4A", agc_patch_set_address);   RN("z2duB-hHQSM", agc_patch_add_registers);   // Sh
@@ -1428,6 +1475,7 @@ void register_agc_hle() {
     RN("cdDRpqcFGbU", agc_patch_dma_data_src);  // sceAgcDmaDataPatchSetSrcAddressOrOffsetOrImmediate
     RN("YUeqkyT7mEQ", agc_dcb_set_flip);        // sceAgcDcbSetFlip (Kyty LibGraphicsDriver.cpp:98)
     RN("UglJIZjGssM", agc_driver_submit_dcb);   // sceAgcDriverSubmitDcb -> CommandProcessor replay
+    RN("gSRnr79F8tQ", agc_driver_submit_acb);   // sceAgcDriverSubmitAcb -> ordered compute replay
     RN("w1KFAHVqpaU", agc_driver_submit_dcb_variant);  // final-buffer submit variant (#232, DOLL RHI batch)
     #undef RN
 }

--- a/prosper/src/hle/hle_fiber.cpp
+++ b/prosper/src/hle/hle_fiber.cpp
@@ -28,6 +28,16 @@
 #include <unistd.h>
 #endif
 
+// Global-assembly symbol spelling differs between ELF and Mach-O.  Keep the fiber context
+// helpers usable on macOS as well as Linux: Mach-O prefixes C symbols with '_' and rejects
+// ELF's .type directive.
+#ifdef __APPLE__
+#define PROSPER_FIBER_ASM_HEADER(name) ".globl _" #name "\n_" #name ":\n"
+#else
+#define PROSPER_FIBER_ASM_HEADER(name) \
+    ".globl " #name "\n.type " #name ",@function\n" #name ":\n"
+#endif
+
 namespace prosper {
 namespace {
 
@@ -41,9 +51,7 @@ extern "C" [[noreturn]] void prosper_fiber_context_restore(FiberContext*, uint64
 asm(
     ".text\n"
     ".p2align 4\n"
-    ".globl prosper_fiber_context_save\n"
-    ".type prosper_fiber_context_save,@function\n"
-    "prosper_fiber_context_save:\n"
+    PROSPER_FIBER_ASM_HEADER(prosper_fiber_context_save)
     "  movq %rbx,0(%rdi)\n"
     "  movq %rbp,8(%rdi)\n"
     "  movq %r12,16(%rdi)\n"
@@ -57,9 +65,7 @@ asm(
     "  xorl %eax,%eax\n"
     "  ret\n"
     ".p2align 4\n"
-    ".globl prosper_fiber_context_restore\n"
-    ".type prosper_fiber_context_restore,@function\n"
-    "prosper_fiber_context_restore:\n"
+    PROSPER_FIBER_ASM_HEADER(prosper_fiber_context_restore)
     "  movq 0(%rdi),%rbx\n"
     "  movq 8(%rdi),%rbp\n"
     "  movq 16(%rdi),%r12\n"
@@ -236,17 +242,17 @@ void set_windows_root_stack(const ThreadFibers* thread) {
 #endif
 
 #ifndef _WIN32
+#ifndef __APPLE__
 inline uint64_t read_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
 inline void write_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
+#endif
 
 extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
                                                   uint64_t a0, uint64_t a1);
 asm(
     ".text\n"
     ".p2align 4\n"
-    ".globl prosper_call_guest_on_stack\n"
-    ".type prosper_call_guest_on_stack,@function\n"
-    "prosper_call_guest_on_stack:\n"
+    PROSPER_FIBER_ASM_HEADER(prosper_call_guest_on_stack)
     "  pushq %r12\n"
     "  movq %rsp,%r12\n"
     "  movq %rsi,%r11\n"
@@ -266,7 +272,13 @@ extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn
 
 uint64_t call_fiber_entry(ThreadFibers* thread, FiberRecord* fiber, uint64_t run_arg) {
     uintptr_t stack_top = (uintptr_t)fiber->stack + fiber->stack_size;
-#ifndef _WIN32
+#if defined(__APPLE__)
+    // Rosetta does not expose FSGSBASE and macOS guest TLS is maintained by the import-trap
+    // dispatcher.  Fiber entry therefore leaves the host FS base untouched.
+    (void)thread;
+    return prosper_call_guest_on_stack(stack_top, (uint64_t)(uintptr_t)fiber->entry,
+                                       fiber->initialize_arg, run_arg);
+#elif !defined(_WIN32)
     const uint64_t host_fs = read_fsbase();
     if (thread->guest_fs) write_fsbase(thread->guest_fs);
     uint64_t result = prosper_call_guest_on_stack(stack_top, (uint64_t)(uintptr_t)fiber->entry,
@@ -344,7 +356,9 @@ uint64_t fiber_run_impl(GuestFiber* guest, uint64_t run_arg, uint64_t* return_ar
     if (guest->state == kStateTerminated) return kErrState;
 
     thread->active = true; thread->current = fiber; thread->previous = nullptr;
-#ifndef _WIN32
+#if defined(__APPLE__)
+    thread->guest_fs = guest_tls_tp();
+#elif !defined(_WIN32)
     thread->guest_fs = callback_guest_fs_from_entry_stack(entry_rsp);
 #else
     NT_TIB* tib = (NT_TIB*)NtCurrentTeb();

--- a/prosper/src/hle/hle_fiber.cpp
+++ b/prosper/src/hle/hle_fiber.cpp
@@ -1,0 +1,476 @@
+// hle_fiber.cpp - cooperative libSceFiber execution for native PS5 engines.
+//
+// Guest code runs natively, so a fiber can retain its real guest call stack. A small private
+// register context transfers between suspended HLE frames; first entry is made on the
+// guest-provided stack. The CRT setjmp/longjmp cannot be used here: fortified glibc deliberately
+// rejects jumps to a lower stack and the Windows CRT tries to unwind SEH frames.
+#include "dispatch.hpp"
+#include "callback_fs.hpp"
+#include "../host/posix_shim.hpp"
+
+#include <atomic>
+#include <cstdlib>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <pthread.h>
+#include <unordered_map>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+namespace prosper {
+namespace {
+
+struct alignas(16) FiberContext { uint64_t words[32]{}; };
+
+extern "C" uint64_t prosper_fiber_context_save(FiberContext*)
+    __attribute__((returns_twice));
+extern "C" [[noreturn]] void prosper_fiber_context_restore(FiberContext*, uint64_t);
+
+#ifndef _WIN32
+asm(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_fiber_context_save\n"
+    ".type prosper_fiber_context_save,@function\n"
+    "prosper_fiber_context_save:\n"
+    "  movq %rbx,0(%rdi)\n"
+    "  movq %rbp,8(%rdi)\n"
+    "  movq %r12,16(%rdi)\n"
+    "  movq %r13,24(%rdi)\n"
+    "  movq %r14,32(%rdi)\n"
+    "  movq %r15,40(%rdi)\n"
+    "  leaq 8(%rsp),%rax\n"
+    "  movq %rax,48(%rdi)\n"
+    "  movq (%rsp),%rax\n"
+    "  movq %rax,56(%rdi)\n"
+    "  xorl %eax,%eax\n"
+    "  ret\n"
+    ".p2align 4\n"
+    ".globl prosper_fiber_context_restore\n"
+    ".type prosper_fiber_context_restore,@function\n"
+    "prosper_fiber_context_restore:\n"
+    "  movq 0(%rdi),%rbx\n"
+    "  movq 8(%rdi),%rbp\n"
+    "  movq 16(%rdi),%r12\n"
+    "  movq 24(%rdi),%r13\n"
+    "  movq 32(%rdi),%r14\n"
+    "  movq 40(%rdi),%r15\n"
+    "  movq 48(%rdi),%rsp\n"
+    "  movq %rsi,%rax\n"
+    "  testq %rax,%rax\n"
+    "  jnz 1f\n"
+    "  movl $1,%eax\n"
+    "1: jmp *56(%rdi)\n"
+);
+#else
+// Microsoft x64 additionally makes rdi/rsi and xmm6-xmm15 nonvolatile. Preserve them so the
+// context can resume an optimized C++ HLE frame without depending on CRT unwinding internals.
+asm(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_fiber_context_save\n"
+    "prosper_fiber_context_save:\n"
+    "  movq %rbx,0(%rcx)\n"
+    "  movq %rbp,8(%rcx)\n"
+    "  movq %rdi,16(%rcx)\n"
+    "  movq %rsi,24(%rcx)\n"
+    "  movq %r12,32(%rcx)\n"
+    "  movq %r13,40(%rcx)\n"
+    "  movq %r14,48(%rcx)\n"
+    "  movq %r15,56(%rcx)\n"
+    "  leaq 8(%rsp),%rax\n"
+    "  movq %rax,64(%rcx)\n"
+    "  movq (%rsp),%rax\n"
+    "  movq %rax,72(%rcx)\n"
+    "  movdqu %xmm6,80(%rcx)\n"
+    "  movdqu %xmm7,96(%rcx)\n"
+    "  movdqu %xmm8,112(%rcx)\n"
+    "  movdqu %xmm9,128(%rcx)\n"
+    "  movdqu %xmm10,144(%rcx)\n"
+    "  movdqu %xmm11,160(%rcx)\n"
+    "  movdqu %xmm12,176(%rcx)\n"
+    "  movdqu %xmm13,192(%rcx)\n"
+    "  movdqu %xmm14,208(%rcx)\n"
+    "  movdqu %xmm15,224(%rcx)\n"
+    "  xorl %eax,%eax\n"
+    "  ret\n"
+    ".p2align 4\n"
+    ".globl prosper_fiber_context_restore\n"
+    "prosper_fiber_context_restore:\n"
+    "  movdqu 80(%rcx),%xmm6\n"
+    "  movdqu 96(%rcx),%xmm7\n"
+    "  movdqu 112(%rcx),%xmm8\n"
+    "  movdqu 128(%rcx),%xmm9\n"
+    "  movdqu 144(%rcx),%xmm10\n"
+    "  movdqu 160(%rcx),%xmm11\n"
+    "  movdqu 176(%rcx),%xmm12\n"
+    "  movdqu 192(%rcx),%xmm13\n"
+    "  movdqu 208(%rcx),%xmm14\n"
+    "  movdqu 224(%rcx),%xmm15\n"
+    "  movq 0(%rcx),%rbx\n"
+    "  movq 8(%rcx),%rbp\n"
+    "  movq 16(%rcx),%rdi\n"
+    "  movq 24(%rcx),%rsi\n"
+    "  movq 32(%rcx),%r12\n"
+    "  movq 40(%rcx),%r13\n"
+    "  movq 48(%rcx),%r14\n"
+    "  movq 56(%rcx),%r15\n"
+    "  movq 64(%rcx),%rsp\n"
+    "  movq %rdx,%rax\n"
+    "  testq %rax,%rax\n"
+    "  jnz 1f\n"
+    "  movl $1,%eax\n"
+    "1: jmp *72(%rcx)\n"
+);
+#endif
+
+constexpr uint32_t kMagicStart = 0xdef1649c;
+constexpr uint32_t kMagicEnd = 0xb37592a0;
+constexpr uint64_t kStackSignature = 0x7149f2ca7149f2caull;
+constexpr uint32_t kStateRun = 1, kStateIdle = 2, kStateTerminated = 3;
+constexpr uint64_t kErrNull = 0x80590001u, kErrAlignment = 0x80590002u;
+constexpr uint64_t kErrRange = 0x80590003u, kErrInvalid = 0x80590004u;
+constexpr uint64_t kErrPermission = 0x80590005u, kErrState = 0x80590006u;
+
+using FiberEntry = void (*)(uint64_t, uint64_t);
+
+struct GuestFiber {
+    uint32_t magic_start;
+    uint32_t state;
+    FiberEntry entry;
+    uint64_t initialize_arg;
+    void* stack;
+    uint64_t stack_size;
+    char name[32];
+    void* saved_context;
+    uint32_t flags;
+    uint32_t pad;
+    void* context_start;
+    void* context_end;
+    uint32_t magic_end;
+};
+static_assert(sizeof(GuestFiber) <= 256);
+
+struct FiberRecord {
+    GuestFiber* guest = nullptr;
+    FiberEntry entry = nullptr;
+    uint64_t initialize_arg = 0;
+    void* stack = nullptr;
+    uint64_t stack_size = 0;
+    std::unique_ptr<uint8_t[]> fallback_stack;
+    FiberContext resume{};
+    bool started = false;
+    bool suspended = false;
+    uint64_t incoming_arg = 0;
+};
+
+struct ThreadFibers {
+    FiberContext root{};
+    FiberRecord* current = nullptr;
+    FiberRecord* previous = nullptr;
+    uint64_t return_arg = 0;
+    uint64_t guest_fs = 0;
+    bool active = false;
+#ifdef _WIN32
+    void* root_stack_base = nullptr;
+    void* root_stack_limit = nullptr;
+#endif
+};
+
+std::mutex g_fiber_mutex;
+std::unordered_map<GuestFiber*, std::unique_ptr<FiberRecord>> g_fibers;
+std::unordered_map<uint64_t, std::unique_ptr<ThreadFibers>> g_threads;
+
+uint64_t thread_key() {
+#ifdef _WIN32
+    return (uint64_t)GetCurrentThreadId();
+#elif defined(__linux__)
+    return (uint64_t)syscall(SYS_gettid);
+#else
+    return (uint64_t)(uintptr_t)pthread_self();
+#endif
+}
+
+ThreadFibers* thread_fibers() {
+    const uint64_t key = thread_key();
+    std::lock_guard<std::mutex> lock(g_fiber_mutex);
+    auto& slot = g_threads[key];
+    if (!slot) slot = std::make_unique<ThreadFibers>();
+    return slot.get();
+}
+
+FiberRecord* find_fiber(GuestFiber* guest) {
+    std::lock_guard<std::mutex> lock(g_fiber_mutex);
+    auto it = g_fibers.find(guest);
+    return it == g_fibers.end() ? nullptr : it->second.get();
+}
+
+bool fiber_log() { static const bool enabled = std::getenv("PROSPER_FIBERLOG") != nullptr; return enabled; }
+
+#ifdef _WIN32
+void set_windows_stack_bounds(void* limit, void* base) {
+    NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+    tib->StackLimit = limit;
+    tib->StackBase = base;
+}
+
+void set_windows_fiber_stack(const FiberRecord* fiber) {
+    set_windows_stack_bounds(fiber->stack,
+                             (void*)((uintptr_t)fiber->stack + fiber->stack_size));
+}
+
+void set_windows_root_stack(const ThreadFibers* thread) {
+    set_windows_stack_bounds(thread->root_stack_limit, thread->root_stack_base);
+}
+#endif
+
+#ifndef _WIN32
+inline uint64_t read_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
+inline void write_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
+
+extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
+                                                  uint64_t a0, uint64_t a1);
+asm(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_call_guest_on_stack\n"
+    ".type prosper_call_guest_on_stack,@function\n"
+    "prosper_call_guest_on_stack:\n"
+    "  pushq %r12\n"
+    "  movq %rsp,%r12\n"
+    "  movq %rsi,%r11\n"
+    "  movq %rdi,%rsp\n"
+    "  andq $-16,%rsp\n"
+    "  movq %rdx,%rdi\n"
+    "  movq %rcx,%rsi\n"
+    "  call *%r11\n"
+    "  movq %r12,%rsp\n"
+    "  popq %r12\n"
+    "  ret\n"
+);
+#else
+extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
+                                                  uint64_t a0, uint64_t a1);
+#endif
+
+uint64_t call_fiber_entry(ThreadFibers* thread, FiberRecord* fiber, uint64_t run_arg) {
+    uintptr_t stack_top = (uintptr_t)fiber->stack + fiber->stack_size;
+#ifndef _WIN32
+    const uint64_t host_fs = read_fsbase();
+    if (thread->guest_fs) write_fsbase(thread->guest_fs);
+    uint64_t result = prosper_call_guest_on_stack(stack_top, (uint64_t)(uintptr_t)fiber->entry,
+                                                   fiber->initialize_arg, run_arg);
+    // A normal return did not pass through an import gate, so %fs is still the guest value.
+    if (thread->guest_fs) write_fsbase(host_fs);
+    return result;
+#else
+    // Windows exception delivery and __chkstk consult NT_TIB.StackBase/StackLimit.  The assembly
+    // helper switches RSP to the Sony-provided stack, so describe that stack in the TEB for the
+    // duration of guest execution and restore the caller's bounds on a normal return.  Yield/switch
+    // paths restore their destination bounds immediately before the non-local context jump below.
+    NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+    void* saved_base = tib->StackBase;
+    void* saved_limit = tib->StackLimit;
+    set_windows_fiber_stack(fiber);
+    uint64_t result = prosper_call_guest_on_stack(stack_top, (uint64_t)(uintptr_t)fiber->entry,
+                                                   fiber->initialize_arg, run_arg);
+    set_windows_stack_bounds(saved_limit, saved_base);
+    return result;
+#endif
+}
+
+uint64_t fiber_initialize(GuestFiber* guest, const char* name, FiberEntry entry,
+                          uint64_t initialize_arg, void* stack, uint64_t stack_size,
+                          const void*, uint32_t) {
+    if (!guest || !name || !entry) return kErrNull;
+    if (((uintptr_t)guest & 7) || ((uintptr_t)stack & 15)) return kErrAlignment;
+    if (stack_size && stack_size < 512) return kErrRange;
+    if ((!stack) != (!stack_size) || (stack_size & 15)) return kErrInvalid;
+
+    auto record = std::make_unique<FiberRecord>();
+    record->guest = guest; record->entry = entry; record->initialize_arg = initialize_arg;
+    record->stack = stack; record->stack_size = stack_size;
+    if (!record->stack) {
+        record->stack_size = 1024 * 1024;
+        record->fallback_stack = std::make_unique<uint8_t[]>(record->stack_size);
+        record->stack = record->fallback_stack.get();
+    }
+
+    std::memset(guest, 0, sizeof(*guest));
+    guest->magic_start = kMagicStart; guest->state = kStateIdle; guest->entry = entry;
+    guest->initialize_arg = initialize_arg; guest->stack = stack; guest->stack_size = stack_size;
+    std::strncpy(guest->name, name, sizeof(guest->name) - 1);
+    guest->context_start = stack; guest->context_end = stack ? (uint8_t*)stack + stack_size : nullptr;
+    guest->magic_end = kMagicEnd;
+    if (stack && stack_size >= sizeof(uint64_t)) *(uint64_t*)stack = kStackSignature;
+
+    {
+        std::lock_guard<std::mutex> lock(g_fiber_mutex);
+        g_fibers[guest] = std::move(record);
+    }
+    if (fiber_log())
+        std::fprintf(stderr, "[fiber] init %p name=%s entry=%p stack=%p+0x%llx\n",
+                     (void*)guest, name, (void*)entry, stack, (unsigned long long)stack_size);
+    return 0;
+}
+
+uint64_t fiber_finalize(GuestFiber* guest) {
+    FiberRecord* fiber = find_fiber(guest);
+    if (!guest || !fiber) return kErrInvalid;
+    if (guest->state == kStateRun) return kErrState;
+    guest->state = kStateTerminated;
+    std::lock_guard<std::mutex> lock(g_fiber_mutex);
+    g_fibers.erase(guest);
+    return 0;
+}
+
+uint64_t fiber_run_impl(GuestFiber* guest, uint64_t run_arg, uint64_t* return_arg,
+                        uint64_t entry_rsp) {
+    FiberRecord* fiber = find_fiber(guest);
+    if (!guest || !fiber) return kErrInvalid;
+    ThreadFibers* thread = thread_fibers();
+    if (thread->active) return kErrPermission;
+    if (guest->state == kStateTerminated) return kErrState;
+
+    thread->active = true; thread->current = fiber; thread->previous = nullptr;
+#ifndef _WIN32
+    thread->guest_fs = callback_guest_fs_from_entry_stack(entry_rsp);
+#else
+    NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+    thread->root_stack_base = tib->StackBase;
+    thread->root_stack_limit = tib->StackLimit;
+#endif
+    fiber->incoming_arg = run_arg; guest->state = kStateRun;
+    if (fiber_log())
+        std::fprintf(stderr, "[fiber] run %p started=%d arg=0x%llx\n", (void*)guest,
+                     fiber->started ? 1 : 0, (unsigned long long)run_arg);
+
+    if (prosper_fiber_context_save(&thread->root) == 0) {
+        if (fiber->suspended) {
+#ifdef _WIN32
+            set_windows_fiber_stack(fiber);
+#endif
+            prosper_fiber_context_restore(&fiber->resume, 1);
+        }
+        fiber->started = true;
+        (void)call_fiber_entry(thread, fiber, run_arg);
+        // Sony entries conventionally yield/return through sceFiberReturnToThread. Treat a plain
+        // return as a zero-valued return-to-thread so a malformed title cannot strand the caller.
+        thread->return_arg = 0;
+    }
+
+    if (return_arg) *return_arg = thread->return_arg;
+    if (thread->current && thread->current->guest->state != kStateTerminated)
+        thread->current->guest->state = kStateIdle;
+    thread->current = nullptr; thread->previous = nullptr; thread->active = false;
+    return 0;
+}
+
+uint64_t fiber_return_to_thread(uint64_t return_arg, uint64_t* next_run_arg) {
+    ThreadFibers* thread = thread_fibers();
+    FiberRecord* current = thread->current;
+    if (!thread->active || !current) return kErrPermission;
+    if (prosper_fiber_context_save(&current->resume) == 0) {
+        current->suspended = true;
+        current->guest->saved_context = &current->resume;
+        current->guest->state = kStateIdle;
+        thread->return_arg = return_arg;
+        if (fiber_log())
+            std::fprintf(stderr, "[fiber] yield %p arg=0x%llx\n", (void*)current->guest,
+                         (unsigned long long)return_arg);
+#ifdef _WIN32
+        set_windows_root_stack(thread);
+#endif
+        prosper_fiber_context_restore(&thread->root, 1);
+    }
+    current->guest->state = kStateRun;
+    thread->current = current;
+    if (next_run_arg) *next_run_arg = current->incoming_arg;
+    return 0;
+}
+
+uint64_t fiber_switch_impl(GuestFiber* target_guest, uint64_t run_arg, uint64_t* resumed_arg,
+                           uint64_t) {
+    ThreadFibers* thread = thread_fibers();
+    FiberRecord* current = thread->current;
+    FiberRecord* target = find_fiber(target_guest);
+    if (!thread->active || !current) return kErrPermission;
+    if (!target_guest || !target || target == current) return kErrInvalid;
+    if (target_guest->state == kStateRun || target_guest->state == kStateTerminated) return kErrState;
+
+    if (prosper_fiber_context_save(&current->resume) == 0) {
+        current->suspended = true; current->guest->saved_context = &current->resume;
+        current->guest->state = kStateIdle;
+        target->incoming_arg = run_arg; target_guest->state = kStateRun;
+        thread->previous = current; thread->current = target;
+        if (target->suspended) {
+#ifdef _WIN32
+            set_windows_fiber_stack(target);
+#endif
+            prosper_fiber_context_restore(&target->resume, 1);
+        }
+        target->started = true;
+        (void)call_fiber_entry(thread, target, run_arg);
+        thread->return_arg = 0;
+#ifdef _WIN32
+        set_windows_root_stack(thread);
+#endif
+        prosper_fiber_context_restore(&thread->root, 1);
+    }
+    thread->current = current; current->guest->state = kStateRun;
+    if (resumed_arg) *resumed_arg = current->incoming_arg;
+    return 0;
+}
+
+uint64_t fiber_get_self(GuestFiber** out) {
+    if (!out) return kErrNull;
+    ThreadFibers* thread = thread_fibers();
+    if (!thread->active || !thread->current) return kErrPermission;
+    *out = thread->current->guest;
+    return 0;
+}
+
+#ifndef _WIN32
+extern "C" uint64_t fiber_run_c(uint64_t a0, uint64_t a1, uint64_t a2,
+                                 uint64_t, uint64_t, uint64_t, uint64_t entry_rsp) {
+    return fiber_run_impl((GuestFiber*)(uintptr_t)a0, a1, (uint64_t*)(uintptr_t)a2, entry_rsp);
+}
+PROSPER_ASM_TRAMPOLINE(fiber_run_entry, fiber_run_c)
+extern "C" void fiber_run_entry();
+
+extern "C" uint64_t fiber_switch_c(uint64_t a0, uint64_t a1, uint64_t a2,
+                                    uint64_t, uint64_t, uint64_t, uint64_t entry_rsp) {
+    return fiber_switch_impl((GuestFiber*)(uintptr_t)a0, a1, (uint64_t*)(uintptr_t)a2, entry_rsp);
+}
+PROSPER_ASM_TRAMPOLINE(fiber_switch_entry, fiber_switch_c)
+extern "C" void fiber_switch_entry();
+#endif
+
+} // namespace
+
+void register_fiber_hle() {
+    Hle::register_fn("hVYD7Ou2pCQ", (HleFn)fiber_initialize, "_sceFiberInitializeImpl");
+    Hle::register_fn("JeNX5F-NzQU", (HleFn)fiber_finalize, "sceFiberFinalize");
+#ifndef _WIN32
+    Hle::register_fn("a0LLrZWac0M", (HleFn)fiber_run_entry, "sceFiberRun");
+    Hle::register_fn("PFT2S-tJ7Uk", (HleFn)fiber_switch_entry, "sceFiberSwitch");
+#else
+    Hle::register_fn("a0LLrZWac0M", (HleFn)fiber_run_impl, "sceFiberRun");
+    Hle::register_fn("PFT2S-tJ7Uk", (HleFn)fiber_switch_impl, "sceFiberSwitch");
+#endif
+    Hle::register_fn("B0ZX2hx9DMw", (HleFn)fiber_return_to_thread, "sceFiberReturnToThread");
+    Hle::register_fn("p+zLIOg27zU", (HleFn)fiber_get_self, "sceFiberGetSelf");
+}
+
+} // namespace prosper

--- a/prosper/src/hle/hle_font.cpp
+++ b/prosper/src/hle/hle_font.cpp
@@ -1,0 +1,355 @@
+// hle_font.cpp - minimal libSceFont/libSceFontFt lifecycle for native-engine bring-up.
+//
+// Astro Bot initializes Sony Font, opens system and memory-backed faces, then uses its own GPU
+// text path. Returning success without writing opaque handles made FontSystem assert during boot.
+// This implementation supplies real opaque lifetimes and deterministic empty-text/metric results;
+// it deliberately does not claim to rasterize Sony system fonts.
+#include "dispatch.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+namespace prosper {
+namespace {
+
+constexpr uint64_t kLibraryMagic = 0x5052464f4e544c49ull; // "PRFONTLI"
+constexpr uint64_t kFontMagic    = 0x5052464f4e54464eull; // "PRFONTFN"
+constexpr uint64_t kRendererMagic= 0x5052464f4e545244ull; // "PRFONTRD"
+constexpr uint64_t kStringMagic  = 0x5052464f4e545354ull; // "PRFONTST"
+
+struct FontMemory {
+    uint16_t kind;
+    uint16_t attrs;
+    uint32_t region_size;
+    void* region;
+    void* mspace;
+    const void* callbacks;
+    void* destroy;
+    void* destroy_ctx;
+    void* context1;
+    void* context2;
+};
+static_assert(sizeof(FontMemory) == 64);
+
+struct FontLibrary { uint64_t magic = kLibraryMagic; };
+struct FontRenderer { uint64_t magic = kRendererMagic; };
+struct FontFace {
+    uint64_t magic = kFontMagic;
+    float width = 16.0f;
+    float height = 16.0f;
+    float slant = 0.0f;
+    float weight_x = 1.0f;
+    float weight_y = 1.0f;
+    void* renderer = nullptr;
+};
+struct FontString { uint64_t magic = kStringMagic; uint32_t terminate_code = 0; };
+struct FontGlyph { uint64_t magic = kFontMagic; };
+
+struct GlyphMetrics {
+    float width, height;
+    float h_bearing_x, h_bearing_y, h_advance;
+    float v_bearing_x, v_bearing_y, v_advance;
+};
+static_assert(sizeof(GlyphMetrics) == 32);
+struct HorizontalLayout { float baseline, advance, decoration; };
+struct VerticalLayout { float baseline, advance, decoration; };
+struct WritingMetrics { float advance_x, advance_y, top, bottom, left, right; };
+
+struct TextSource {
+    uint64_t system;
+    const void* start;
+    const void* end;
+    const void* current;
+    void* parser;
+    void* object;
+    void* default_font;
+    void* reserved[5];
+};
+static_assert(sizeof(TextSource) == 0x60);
+
+struct TextCharacter {
+    TextCharacter* prev;
+    TextCharacter* next;
+    void* order;
+    void* font;
+    void* shape;
+    uint32_t code;
+};
+
+struct RenderSurface {
+    void* buffer;
+    int32_t width_bytes;
+    int8_t pixel_size;
+    uint8_t pad0;
+    uint8_t style;
+    uint8_t pad1;
+    int32_t width;
+    int32_t height;
+    uint32_t scissor[4];
+    uint64_t reserved[11];
+};
+static_assert(sizeof(RenderSurface) == 128);
+
+FontLibrary g_library;
+FontRenderer g_renderer;
+uint8_t g_ft_selection[64]{};
+
+FontFace* face(void* handle) {
+    auto* f = static_cast<FontFace*>(handle);
+    return f && f->magic == kFontMagic ? f : nullptr;
+}
+
+int32_t font_memory_init(FontMemory* mem, void* region, uint32_t region_size,
+                         const void* callbacks, void* mspace, void* destroy,
+                         void* destroy_ctx) {
+    if (!mem) return static_cast<int32_t>(0x80540002u);
+    std::memset(mem, 0, sizeof(*mem));
+    mem->kind = region ? 1 : 0;
+    mem->region_size = region_size;
+    mem->region = region;
+    mem->mspace = mspace;
+    mem->callbacks = callbacks;
+    mem->destroy = destroy;
+    mem->destroy_ctx = destroy_ctx;
+    return 0;
+}
+
+const void* font_select_library_ft(int) { return g_ft_selection; }
+
+int32_t font_create_library(const FontMemory*, const void*, uint64_t, void** out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    *out = &g_library;
+    return 0;
+}
+int32_t font_create_renderer(const FontMemory*, const void*, uint64_t, void** out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    *out = &g_renderer;
+    return 0;
+}
+int32_t font_destroy_handle(void** handle) {
+    if (handle) *handle = nullptr;
+    return 0;
+}
+
+int32_t font_open(void*, uint64_t, uint64_t, const void*, void** out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    auto* f = new (std::nothrow) FontFace;
+    if (!f) return static_cast<int32_t>(0x80540001u);
+    *out = f;
+    return 0;
+}
+int32_t font_open_memory(void* library, const void* bytes, uint32_t size,
+                         const void* params, void** out) {
+    (void)bytes; (void)size;
+    return font_open(library, 0, 0, params, out);
+}
+int32_t font_open_instance(void*, void* source, void** out) {
+    int32_t rc = font_open(nullptr, 0, 0, nullptr, out);
+    if (!rc && face(source)) **reinterpret_cast<FontFace**>(out) = *face(source);
+    return rc;
+}
+int32_t font_close(void*) { return 0; }
+
+int32_t font_bind_renderer(void* handle, void* renderer) {
+    if (auto* f = face(handle)) f->renderer = renderer;
+    return 0;
+}
+int32_t font_unbind_renderer(void* handle) {
+    if (auto* f = face(handle)) f->renderer = nullptr;
+    return 0;
+}
+int32_t font_set_scale(void* handle, float width, float height) {
+    if (auto* f = face(handle)) {
+        f->width = std::max(width, 1.0f);
+        f->height = std::max(height, 1.0f);
+    }
+    return 0;
+}
+int32_t font_set_slant(void* handle, float slant) {
+    if (auto* f = face(handle)) f->slant = slant;
+    return 0;
+}
+int32_t font_set_weight(void* handle, float x, float y, uint32_t) {
+    if (auto* f = face(handle)) { f->weight_x = x; f->weight_y = y; }
+    return 0;
+}
+
+void fill_metrics(void* handle, GlyphMetrics* out) {
+    if (!out) return;
+    const auto* f = face(handle);
+    const float h = f ? f->height : 16.0f;
+    const float w = f ? f->width * 0.6f : 9.6f;
+    *out = {w, h, 0.0f, h * 0.8f, w, w * 0.5f, h * 0.5f, h};
+}
+int32_t font_get_metrics(void* handle, uint32_t, GlyphMetrics* out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    fill_metrics(handle, out);
+    return 0;
+}
+int32_t font_get_horizontal(void* handle, HorizontalLayout* out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    const auto* f = face(handle); const float h = f ? f->height : 16.0f;
+    *out = {h * 0.8f, h * 1.2f, h};
+    return 0;
+}
+int32_t font_get_vertical(void* handle, VerticalLayout* out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    const auto* f = face(handle); const float w = f ? f->width : 16.0f;
+    *out = {w * 0.5f, w * 1.2f, w};
+    return 0;
+}
+
+int32_t font_generate_glyph(void*, uint32_t, const void*, void** out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    *out = new (std::nothrow) FontGlyph;
+    return *out ? 0 : static_cast<int32_t>(0x80540001u);
+}
+int32_t font_delete_glyph(const FontMemory*, void** glyph) {
+    if (glyph) { delete static_cast<FontGlyph*>(*glyph); *glyph = nullptr; }
+    return 0;
+}
+
+void font_surface_init(RenderSurface* out, void* buffer, int width_bytes, int pixel_size,
+                       int width, int height) {
+    if (!out) return;
+    std::memset(out, 0, sizeof(*out));
+    out->buffer = buffer; out->width_bytes = width_bytes; out->pixel_size = (int8_t)pixel_size;
+    out->width = width; out->height = height;
+    out->scissor[2] = width > 0 ? (uint32_t)width : 0;
+    out->scissor[3] = height > 0 ? (uint32_t)height : 0;
+}
+
+int32_t font_text_source_init(TextSource* out, const void* text, uint32_t size,
+                              void* parser, void* object) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    std::memset(out, 0, sizeof(*out));
+    out->start = text; out->current = text;
+    out->end = text ? static_cast<const uint8_t*>(text) + size : nullptr;
+    out->parser = parser; out->object = object;
+    return 0;
+}
+int32_t font_text_default(TextSource* source, void* handle) {
+    if (source) source->default_font = handle;
+    return 0;
+}
+int32_t font_text_writing_form(TextSource* source, int32_t form) {
+    if (source) source->system = (uint32_t)form;
+    return 0;
+}
+
+int32_t font_create_string(const FontMemory*, TextSource*, const void*, void** out) {
+    if (!out) return static_cast<int32_t>(0x80540002u);
+    *out = new (std::nothrow) FontString;
+    return *out ? 0 : static_cast<int32_t>(0x80540001u);
+}
+uint32_t font_string_terminate(void* string) {
+    auto* s = static_cast<FontString*>(string);
+    return s && s->magic == kStringMagic ? s->terminate_code : 0;
+}
+TextCharacter* font_string_characters(void*, uint32_t* count) {
+    if (count) *count = 0;
+    return nullptr;
+}
+const TextCharacter* font_string_render_characters(void*, TextCharacter*, TextCharacter*,
+                                                    uint32_t* count) {
+    if (count) *count = 0;
+    return nullptr;
+}
+int32_t font_string_writing_form(void*) { return 0; }
+
+int32_t font_writing_init(void* writing, void*, const TextCharacter*) {
+    if (writing) std::memset(writing, 0, 0x100);
+    return 0;
+}
+int32_t font_writing_metrics(void*, WritingMetrics* out) {
+    if (out) std::memset(out, 0, sizeof(*out));
+    return 0;
+}
+const void* font_writing_step(void*) { return nullptr; }
+TextCharacter* font_writing_character(void*, void* letter_step) {
+    if (letter_step) std::memset(letter_step, 0, 0x40);
+    return nullptr;
+}
+
+int32_t font_character_bidi(TextCharacter*, int* out) { if (out) *out = 0; return 0; }
+int32_t font_character_code(TextCharacter* ch, void** handle, uint32_t* code) {
+    if (handle) *handle = ch ? ch->font : nullptr;
+    if (code) *code = ch ? ch->code : 0;
+    return 0;
+}
+int32_t font_character_order(TextCharacter* ch, void** order) {
+    if (order) *order = ch ? ch->order : nullptr;
+    return 0;
+}
+uint32_t font_character_whitespace(TextCharacter* ch) {
+    if (!ch) return 0;
+    return ch->code == ' ' || ch->code == '\t' || ch->code == '\n' || ch->code == '\r';
+}
+TextCharacter* font_character_next(TextCharacter* ch) { return ch ? ch->next : nullptr; }
+
+uint64_t font_ok(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { return 0; }
+
+} // namespace
+
+void register_font_hle() {
+    auto R = [](const char* nid, HleFn fn, const char* name) { Hle::register_fn(nid, fn, name); };
+    R("whrS4oksXc4", (HleFn)font_memory_init, "sceFontMemoryInit");
+    R("oM+XCzVG3oM", (HleFn)font_select_library_ft, "sceFontSelectLibraryFt");
+    R("n590hj5Oe-k", (HleFn)font_create_library, "sceFontCreateLibraryWithEdition");
+    R("WaSFJoRWXaI", (HleFn)font_create_renderer, "sceFontCreateRendererWithEdition");
+    R("exAxkyVLt0s", (HleFn)font_destroy_handle, "sceFontDestroyRenderer");
+    R("SSCaczu2aMQ", (HleFn)font_destroy_handle, "sceFontDestroyString");
+    R("PEjv7CVDRYs", (HleFn)font_ok, "sceFontDestroyWritingLine");
+    R("cKYtVmeSTcw", (HleFn)font_open, "sceFontOpenFontSet");
+    R("KXUpebrFk1U", (HleFn)font_open_memory, "sceFontOpenFontMemory");
+    R("JzCH3SCFnAU", (HleFn)font_open_instance, "sceFontOpenFontInstance");
+    R("vzHs3C8lWJk", (HleFn)font_close, "sceFontCloseFont");
+    R("3OdRkSjOcog", (HleFn)font_bind_renderer, "sceFontBindRenderer");
+    R("1QjhKxrsOB8", (HleFn)font_unbind_renderer, "sceFontUnbindRenderer");
+    R("N1EBMeGhf7E", (HleFn)font_set_scale, "sceFontSetScalePixel");
+    R("6vGCkkQJOcI", (HleFn)font_set_scale, "sceFontSetupRenderScalePixel");
+    R("TMtqoFQjjbA", (HleFn)font_set_slant, "sceFontSetEffectSlant");
+    R("lz9y9UFO2UU", (HleFn)font_set_slant, "sceFontSetupRenderEffectSlant");
+    R("v0phZwa4R5o", (HleFn)font_set_weight, "sceFontSetEffectWeight");
+    R("XIGorvLusDQ", (HleFn)font_set_weight, "sceFontSetupRenderEffectWeight");
+    R("IQtleGLL5pQ", (HleFn)font_get_metrics, "sceFontGetRenderCharGlyphMetrics");
+    R("imxVx8lm+KM", (HleFn)font_get_horizontal, "sceFontGetHorizontalLayout");
+    R("3BrWWFU+4ts", (HleFn)font_get_vertical, "sceFontGetVerticalLayout");
+    R("C-4Qw5Srlyw", (HleFn)font_generate_glyph, "sceFontGenerateCharGlyph");
+    R("LHDoRWVFGqk", (HleFn)font_delete_glyph, "sceFontDeleteGlyph");
+    R("gdUCnU0gHdI", (HleFn)font_surface_init, "sceFontRenderSurfaceInit");
+    R("kAenWy1Zw5o", (HleFn)font_ok, "sceFontRenderCharGlyphImageHorizontal");
+    R("oaJ1BpN2FQk", (HleFn)font_text_source_init, "sceFontTextSourceInit");
+    R("eCRMCSk96NU", (HleFn)font_text_default, "sceFontTextSourceSetDefaultFont");
+    R("OqQKX0h5COw", (HleFn)font_text_writing_form, "sceFontTextSourceSetWritingForm");
+    R("MO24vDhmS4E", (HleFn)font_create_string, "sceFontCreateString");
+    R("ObkDGDBsVtw", (HleFn)font_string_terminate, "sceFontStringGetTerminateCode");
+    R("Avv7OApgCJk", (HleFn)font_string_characters, "sceFontStringRefersTextCharacters");
+    R("hq5LffQjz-s", (HleFn)font_string_render_characters, "sceFontStringRefersRenderCharacters");
+    R("o1vIEHeb6tw", (HleFn)font_string_writing_form, "sceFontStringGetWritingForm");
+    R("fD5rqhEXKYQ", (HleFn)font_writing_init, "sceFontWritingInit");
+    R("fljdejMcG1c", (HleFn)font_writing_metrics, "sceFontWritingGetRenderMetrics");
+    R("W-2WOXEHGck", (HleFn)font_writing_step, "sceFontWritingRefersRenderStep");
+    R("f4Onl7efPEY", (HleFn)font_writing_character, "sceFontWritingRefersRenderStepCharacter");
+    R("6DFUkCwQLa8", (HleFn)font_character_bidi, "sceFontCharacterGetBidiLevel");
+    R("zN3+nuA0SFQ", (HleFn)font_character_code, "sceFontCharacterGetTextFontCode");
+    R("mxgmMj-Mq-o", (HleFn)font_character_order, "sceFontCharacterGetTextOrder");
+    R("SaRlqtqaCew", (HleFn)font_character_whitespace, "sceFontCharacterLooksWhiteSpace");
+    R("BkjBP+YC19w", (HleFn)font_character_next, "sceFontCharacterRefersTextNext");
+
+    // Intentional no-op lifecycle/capability surface used during Astro's initialization.
+    R("SsRbbCiWoGw", (HleFn)font_ok, "sceFontSupportSystemFonts");
+    R("mz2iTY0MK4A", (HleFn)font_ok, "sceFontSupportExternalFonts");
+    R("CUKn5pX-NVY", (HleFn)font_ok, "sceFontAttachDeviceCacheBuffer");
+    R("7rogx92EEyc", (HleFn)font_ok, "sceFontCreateWritingLine");
+    R("1+DgKL0haWQ", (HleFn)font_ok, "sceFontWritingLineClear");
+    R("JQKWIsS9joE", (HleFn)font_ok, "sceFontWritingLineGetOrderingSpace");
+    R("nlU2VnfpqTM", (HleFn)font_ok, "sceFontWritingLineGetRenderMetrics");
+    R("+FYcYefsVX0", (HleFn)font_ok, "sceFontWritingLineRefersRenderStep");
+    R("wyKFUOWdu3Q", (HleFn)font_ok, "sceFontWritingLineWritesOrder");
+    R("8-zmgsxkBek", (HleFn)font_ok, "sceFontGlyphDefineAttribute");
+}
+
+} // namespace prosper

--- a/prosper/src/hle/hle_font.cpp
+++ b/prosper/src/hle/hle_font.cpp
@@ -150,7 +150,10 @@ int32_t font_open_instance(void*, void* source, void** out) {
     if (!rc && face(source)) **reinterpret_cast<FontFace**>(out) = *face(source);
     return rc;
 }
-int32_t font_close(void*) { return 0; }
+int32_t font_close(void* handle) {
+    delete static_cast<FontFace*>(handle);
+    return 0;
+}
 
 int32_t font_bind_renderer(void* handle, void* renderer) {
     if (auto* f = face(handle)) f->renderer = renderer;
@@ -244,6 +247,13 @@ int32_t font_create_string(const FontMemory*, TextSource*, const void*, void** o
     *out = new (std::nothrow) FontString;
     return *out ? 0 : static_cast<int32_t>(0x80540001u);
 }
+int32_t font_destroy_string(void** string) {
+    if (string) {
+        delete static_cast<FontString*>(*string);
+        *string = nullptr;
+    }
+    return 0;
+}
 uint32_t font_string_terminate(void* string) {
     auto* s = static_cast<FontString*>(string);
     return s && s->magic == kStringMagic ? s->terminate_code : 0;
@@ -300,7 +310,7 @@ void register_font_hle() {
     R("n590hj5Oe-k", (HleFn)font_create_library, "sceFontCreateLibraryWithEdition");
     R("WaSFJoRWXaI", (HleFn)font_create_renderer, "sceFontCreateRendererWithEdition");
     R("exAxkyVLt0s", (HleFn)font_destroy_handle, "sceFontDestroyRenderer");
-    R("SSCaczu2aMQ", (HleFn)font_destroy_handle, "sceFontDestroyString");
+    R("SSCaczu2aMQ", (HleFn)font_destroy_string, "sceFontDestroyString");
     R("PEjv7CVDRYs", (HleFn)font_ok, "sceFontDestroyWritingLine");
     R("cKYtVmeSTcw", (HleFn)font_open, "sceFontOpenFontSet");
     R("KXUpebrFk1U", (HleFn)font_open_memory, "sceFontOpenFontMemory");

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -220,7 +220,11 @@ HLE(g_vo_vblankstatus) {
                                 std::chrono::steady_clock::now().time_since_epoch()).count();
               static const uint64_t t0 = ns;                       // process-relative, first-call anchored
               constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
-              *(uint64_t*)(s + 0x00) = (ns - t0) / kVblankNs;      // count: one tick per vblank period
+              // A live VideoOut handle has already observed at least one vblank. Returning zero on
+              // the first query made Astro Bot compute a frame-rate sample as
+              // `(frames * refresh) / (count - previous_count)` with both counts zero and trap on
+              // IDIV. Keep the time-based behavior, but number the first process-relative vblank 1.
+              *(uint64_t*)(s + 0x00) = 1 + (ns - t0) / kVblankNs;  // count: one tick per vblank period
               *(uint64_t*)(s + 0x08) = (ns - t0) / 1000;           // processTime (µs)
               *(uint64_t*)(s + 0x10) = ns; }                       // tsc (monotonic ns; matches ReadTsc's unit)
     return 0;

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -488,6 +488,22 @@ HLE(k_rwlock_wrlock)  { if (auto* rw = ensure_rwlock(a0)) pthread_rwlock_wrlock(
 HLE(k_rwlock_unlock)  { if (auto* rw = ensure_rwlock(a0)) pthread_rwlock_unlock(rw); return 0; }
 HLE(k_rwlock_tryrdlock){ auto* rw = ensure_rwlock(a0); return rw ? (uint64_t)pthread_rwlock_tryrdlock(rw) : 0x16; }
 HLE(k_rwlock_trywrlock){ auto* rw = ensure_rwlock(a0); return rw ? (uint64_t)pthread_rwlock_trywrlock(rw) : 0x16; }
+HLE(k_rwlockattr_init) {
+    if (!a0) return 0x16;
+    auto* attr = (pthread_rwlockattr_t*)calloc(1, sizeof(pthread_rwlockattr_t));
+    if (!attr) return 12;
+    const int rc = pthread_rwlockattr_init(attr);
+    if (rc) { free(attr); return (uint64_t)(unsigned)rc; }
+    *(void**)(uintptr_t)a0 = attr;
+    return 0;
+}
+HLE(k_rwlockattr_destroy) {
+    if (!a0) return 0x16;
+    void** slot = (void**)(uintptr_t)a0;
+    if (*slot) { pthread_rwlockattr_destroy((pthread_rwlockattr_t*)*slot); free(*slot); }
+    *slot = nullptr;
+    return 0;
+}
 
 // scePthreadOnce(once_control*, init_routine): run init exactly once, PER CONTROL. The old
 // implementation held ONE process-global recursive mutex across the guest init routine — if init
@@ -533,6 +549,14 @@ HLE(k_pthread_yield){ sched_yield(); return 0; }
 HLE(k_attr_init)        { if (a0) { auto* at = (pthread_attr_t*)calloc(1, sizeof(pthread_attr_t)); pthread_attr_init(at); *(void**)a0 = at; } return 0; }
 HLE(k_attr_destroy)     { if (a0 && *(void**)a0) { pthread_attr_destroy((pthread_attr_t*)*(void**)a0); free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
 HLE(k_attr_setstacksize){ if (a0 && *(void**)a0 && a1 >= 16384) pthread_attr_setstacksize((pthread_attr_t*)*(void**)a0, a1); return 0; }
+HLE(k_attr_setstack) {
+    // Sony and every host backend we support require at least 16 KiB here.  MinGW's winpthreads
+    // headers do not consistently expose PTHREAD_STACK_MIN, so keep this check aligned with the
+    // setstacksize path above instead of depending on that optional libc macro.
+    if (!a0 || !*(void**)(uintptr_t)a0 || !a1 || a2 < 16384) return 0x16;
+    return (uint64_t)(unsigned)pthread_attr_setstack(
+        (pthread_attr_t*)*(void**)(uintptr_t)a0, (void*)(uintptr_t)a1, (size_t)a2);
+}
 HLE(k_attr_noop)        { return 0; }
 
 // sceKernelGetSanitizerMallocReplaceExternal returns the process replacement table, even when no
@@ -707,6 +731,46 @@ namespace {
 // TCB, then call the guest entry through the SysV marshalling shim, and purge DTV on exit.
 struct WinThreadStart { uint64_t entry; void* arg; char name[64]; };
 extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
+
+// PS5 code is compiled for a stack whose entire usable range is writable.  Windows instead
+// initially commits only the top of a reserved thread stack and relies on a moving guard page;
+// native Windows compilers probe each intervening page before a large stack allocation.  Guest
+// code has no reason to emit those Windows probes, so an otherwise-valid `sub rsp, large_size`
+// followed by a call can jump past the guard and fault in still-reserved memory.  Commit the
+// guest worker's usable reservation before entering it, retaining one guard page above the
+// permanently inaccessible bottom page so a real stack overflow is still caught.
+bool prepare_guest_windows_stack(ULONG_PTR* out_low, ULONG_PTR* out_high) {
+    ULONG_PTR api_low = 0, high = 0;
+    GetCurrentThreadStackLimits(&api_low, &high);
+    if (!high) return false;
+
+    MEMORY_BASIC_INFORMATION top{};
+    if (!VirtualQuery((void*)(high - 1), &top, sizeof(top)) || !top.AllocationBase)
+        return false;
+
+    const ULONG_PTR reserve_low = (ULONG_PTR)top.AllocationBase;
+    SYSTEM_INFO si{};
+    GetSystemInfo(&si);
+    const SIZE_T page = si.dwPageSize ? si.dwPageSize : 0x1000;
+    if (high <= reserve_low + 2 * page) return false;
+
+    // VirtualAlloc also succeeds for pages that are already committed.  Supplying the entire
+    // usable interval therefore both fills the reserved gap and leaves the existing top frames
+    // intact.  PAGE_GUARD on an already-committed page is cleared explicitly below.
+    void* usable = (void*)(reserve_low + page);
+    const SIZE_T usable_size = (SIZE_T)(high - (reserve_low + page));
+    if (!VirtualAlloc(usable, usable_size, MEM_COMMIT, PAGE_READWRITE)) return false;
+
+    DWORD old_protect = 0;
+    if (!VirtualProtect((void*)(reserve_low + page), page,
+                        PAGE_READWRITE | PAGE_GUARD, &old_protect))
+        return false;
+
+    if (out_low) *out_low = reserve_low + page;
+    if (out_high) *out_high = high;
+    return true;
+}
+
 void* win_thread_trampoline(void* p) {
     auto* ts = (WinThreadStart*)p;
     uint64_t entry = ts->entry; void* arg = ts->arg;
@@ -725,7 +789,8 @@ void* win_thread_trampoline(void* p) {
     // base". Mirrors the Linux thread_trampoline's register-first ordering. GetCurrentThreadStackLimits
     // gives the committed stack range (Win8+).
     ULONG_PTR stk_lo = 0, stk_hi = 0;
-    GetCurrentThreadStackLimits(&stk_lo, &stk_hi);
+    if (!prepare_guest_windows_stack(&stk_lo, &stk_hi))
+        GetCurrentThreadStackLimits(&stk_lo, &stk_hi);
     if (stk_lo && stk_hi > stk_lo) {
         register_thread_stack((uint64_t)GetCurrentThreadId(), (void*)stk_lo, (uint64_t)(stk_hi - stk_lo));
         register_thread_stack(guest_thread, (void*)stk_lo, (uint64_t)(stk_hi - stk_lo));
@@ -785,13 +850,29 @@ HLE(k_pthread_create) {
     // Windows: route through win_thread_trampoline so the guest entry is called with the SysV ABI and
     // gets its guest %fs TCB — a bare pthread_create(entry, arg) mis-passes the arg (MS x64 vs SysV) and
     // skips TLS activation, crashing the worker on a null-derived pointer.
-    pthread_attr_t* at = (a1 && *(void**)a1) ? (pthread_attr_t*)*(void**)a1 : nullptr;
+    constexpr size_t kStackFloor = 1 * 1024 * 1024, kStackDefault = 8 * 1024 * 1024;
+    size_t ssz = kStackDefault;
+    int detach = PTHREAD_CREATE_JOINABLE;
+    if (a1 && *(void**)a1) {
+        auto* gat = (pthread_attr_t*)*(void**)a1;
+        size_t req = 0;
+        if (pthread_attr_getstacksize(gat, &req) == 0 && req)
+            ssz = req < kStackFloor ? kStackFloor : req;
+        pthread_attr_getdetachstate(gat, &detach);
+    }
+    // Use a host-owned attr just like Linux: preserve the Sony-requested size/detach state, but
+    // do not pass through a guest-owned stack address to winpthreads.  The trampoline commits
+    // this reservation before guest entry because PS5 code does not contain Windows probes.
+    pthread_attr_t la; pthread_attr_init(&la);
+    pthread_attr_setstacksize(&la, ssz);
+    pthread_attr_setdetachstate(&la, detach);
     auto* ts = (WinThreadStart*)malloc(sizeof(WinThreadStart));
-    if (!ts) return 12;                                        // ENOMEM (FreeBSD and host agree)
+    if (!ts) { pthread_attr_destroy(&la); return 12; }          // ENOMEM (FreeBSD and host agree)
     ts->entry = (uint64_t)(uintptr_t)entry; ts->arg = arg;
     ts->name[0] = 0;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
-    int r = pthread_create(&tid, at, win_thread_trampoline, ts);
+    int r = pthread_create(&tid, &la, win_thread_trampoline, ts);
+    pthread_attr_destroy(&la);
     if (r) { free(ts); return (uint64_t)r; }
 #endif
     if (a0) *(uint64_t*)a0 = (uint64_t)tid;
@@ -1047,11 +1128,12 @@ HLE(k_rwlock_timedwrlock) {
 // the generic stub returned 0: SemInit created nothing, SemWait returned immediately (never blocked),
 // SemGetvalue left *value uninitialized -> a producer/consumer or gate built on these got NO
 // synchronization (the silent-unsync / UAF class). Back them with host sem_t.
-HLE(k_sem_init)      { if (!a0) return 0x16; auto* s = (sem_t*)calloc(1, sizeof(sem_t)); sem_init(s, 0, (unsigned)a2); *(void**)(uintptr_t)a0 = s; return 0; }
-HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_wait(s) == 0 ? 0 : (uint64_t)(unsigned)errno; }
+namespace { bool semlog() { static const bool on = getenv("PROSPER_SEMLOG") != nullptr; return on; } }
+HLE(k_sem_init)      { if (!a0) return 0x16; auto* s = (sem_t*)calloc(1, sizeof(sem_t)); sem_init(s, 0, (unsigned)a2); *(void**)(uintptr_t)a0 = s; if (semlog()) fprintf(stderr, "[sem] init slot=%p value=%u\n", (void*)(uintptr_t)a0, (unsigned)a2); return 0; }
+HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog()) fprintf(stderr, "[sem] wait slot=%p enter\n", (void*)(uintptr_t)a0); int rc = sem_wait(s); if (semlog()) fprintf(stderr, "[sem] wait slot=%p exit rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : (uint64_t)(unsigned)errno; }
 HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : (uint64_t)(unsigned)errno; }
 HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return 0x16; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : (errno == ETIMEDOUT ? 60u : (uint64_t)(unsigned)errno); }
-HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; sem_post(s); return 0; }
+HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : (uint64_t)(unsigned)errno; }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
 HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { sem_destroy((sem_t*)*slot); free(*slot); *slot = nullptr; } } return 0; }
 // scePthreadBarrier* -- were MISSING -> the generic stub returned 0, so BarrierWait let every thread sail
@@ -2172,6 +2254,10 @@ void register_kernel_hle() {
     R("scePthreadRwlockTrywrlock", k_rwlock_trywrlock);
     R("scePthreadRwlockTimedrdlock", k_rwlock_timedrdlock);   // were MISSING -> faked "locked" without locking
     R("scePthreadRwlockTimedwrlock", k_rwlock_timedwrlock);
+    R("scePthreadRwlockattrInit", k_rwlockattr_init);
+    R("scePthreadRwlockattrDestroy", k_rwlockattr_destroy);
+    R("pthread_rwlockattr_init", k_rwlockattr_init);
+    R("pthread_rwlockattr_destroy", k_rwlockattr_destroy);
     // scePthreadSem* counting semaphores (were MISSING -> SemWait never blocked)
     R("scePthreadSemInit", k_sem_init);         R("scePthreadSemDestroy", k_sem_destroy);
     R("scePthreadSemWait", k_sem_wait);         R("scePthreadSemTrywait", k_sem_trywait);
@@ -2193,6 +2279,7 @@ void register_kernel_hle() {
     R("scePthreadExit", k_pthread_exit);
     R("scePthreadAttrInit", k_attr_init);
     R("scePthreadAttrDestroy", k_attr_destroy);
+    R("scePthreadAttrSetstack", k_attr_setstack);
     R("scePthreadAttrSetstacksize", k_attr_setstacksize);
     R("scePthreadAttrSetinheritsched", k_attr_noop);
     R("scePthreadAttrSetschedpolicy", k_attr_noop);
@@ -2238,12 +2325,18 @@ void register_kernel_hle() {
     R("pthread_cond_timedwait", k_cond_timedwait);   // issue #115: unimpl-0 spun WaitCompletion loops
     R("pthread_condattr_init", k_condattr_init); R("pthread_condattr_destroy", k_condattr_destroy);
     R("pthread_attr_init", k_attr_init);      R("pthread_attr_destroy", k_attr_destroy);
+    R("pthread_attr_setstack", k_attr_setstack);
     R("pthread_attr_setstacksize", k_attr_setstacksize);
     R("pthread_attr_setdetachstate", k_attr_setdetachstate); R("pthread_attr_getdetachstate", k_attr_getdetachstate);
     R("pthread_attr_setinheritsched", k_attr_noop);
     R("pthread_attr_setschedpolicy", k_attr_noop);  R("pthread_attr_setschedparam", k_attr_noop);
     R("pthread_attr_getstacksize", k_attr_getstacksize);
     R("scePthreadAttrSetaffinity", k_attr_noop); R("pthread_setname_np", k_attr_noop);
+    // Plain libScePosix sem_* imports use the same guest object representation as scePthreadSem*.
+    // Registering only the Sony-prefixed spellings left successful no-op imports in native engines.
+    R("sem_init", k_sem_init);       R("sem_destroy", k_sem_destroy);
+    R("sem_wait", k_sem_wait);       R("sem_trywait", k_sem_trywait);
+    R("sem_post", k_sem_post);       R("sem_getvalue", k_sem_getvalue);
     // event flags + semaphores (engine thread synchronization)
     R("sceKernelCreateEventFlag", k_ef_create); R("sceKernelDeleteEventFlag", k_ef_delete);
     R("sceKernelSetEventFlag", k_ef_set);       R("sceKernelClearEventFlag", k_ef_clear);

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -546,16 +546,62 @@ HLE(k_pthread_equal){ return (uint64_t)(a0 == a1); }
 HLE(k_pthread_yield){ sched_yield(); return 0; }
 
 // --- thread attributes ---
-HLE(k_attr_init)        { if (a0) { auto* at = (pthread_attr_t*)calloc(1, sizeof(pthread_attr_t)); pthread_attr_init(at); *(void**)a0 = at; } return 0; }
-HLE(k_attr_destroy)     { if (a0 && *(void**)a0) { pthread_attr_destroy((pthread_attr_t*)*(void**)a0); free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
-HLE(k_attr_setstacksize){ if (a0 && *(void**)a0 && a1 >= 16384) pthread_attr_setstacksize((pthread_attr_t*)*(void**)a0, a1); return 0; }
+struct GuestPthreadAttr {
+    pthread_attr_t host;
+    void* supplied_stack = nullptr;
+    size_t supplied_stack_size = 0;
+};
+static_assert(offsetof(GuestPthreadAttr, host) == 0);
+HLE(k_attr_init) {
+    if (a0) {
+        auto* at = (GuestPthreadAttr*)calloc(1, sizeof(GuestPthreadAttr));
+        if (!at) return 12;
+        pthread_attr_init(&at->host); *(void**)a0 = at;
+    }
+    return 0;
+}
+HLE(k_attr_destroy) {
+    if (a0 && *(void**)a0) {
+        auto* at = (GuestPthreadAttr*)*(void**)a0;
+        pthread_attr_destroy(&at->host); free(at); *(void**)a0 = nullptr;
+    }
+    return 0;
+}
+HLE(k_attr_setstacksize) {
+    if (a0 && *(void**)a0 && a1 >= 16384) {
+        auto* at = (GuestPthreadAttr*)*(void**)a0;
+        int rc = pthread_attr_setstacksize(&at->host, a1);
+        if (getenv("PROSPER_SYNCLOG"))
+            fprintf(stderr, "[thread] attr setstacksize attr=%p size=0x%llx rc=%d\n",
+                    (void*)at, (unsigned long long)a1, rc);
+        if (rc == 0) {
+            at->supplied_stack = nullptr; at->supplied_stack_size = 0;
+        }
+    }
+    return 0;
+}
 HLE(k_attr_setstack) {
     // Sony and every host backend we support require at least 16 KiB here.  MinGW's winpthreads
     // headers do not consistently expose PTHREAD_STACK_MIN, so keep this check aligned with the
     // setstacksize path above instead of depending on that optional libc macro.
     if (!a0 || !*(void**)(uintptr_t)a0 || !a1 || a2 < 16384) return 0x16;
-    return (uint64_t)(unsigned)pthread_attr_setstack(
-        (pthread_attr_t*)*(void**)(uintptr_t)a0, (void*)(uintptr_t)a1, (size_t)a2);
+#ifdef _WIN32
+    // The host pthread remains on a winpthreads-owned stack, while win_thread_trampoline switches
+    // guest entry to this exact range. Preserve the range explicitly instead of asking CreateThread
+    // to choose an address (which Windows cannot do).
+    auto* at = (GuestPthreadAttr*)*(void**)(uintptr_t)a0;
+    int rc = pthread_attr_setstacksize(&at->host, (size_t)a2);
+    if (!rc) { at->supplied_stack = (void*)(uintptr_t)a1; at->supplied_stack_size = (size_t)a2; }
+    return (uint64_t)(unsigned)rc;
+#else
+    auto* at = (GuestPthreadAttr*)*(void**)(uintptr_t)a0;
+    int rc = pthread_attr_setstack(&at->host, (void*)(uintptr_t)a1, (size_t)a2);
+    if (getenv("PROSPER_SYNCLOG"))
+        fprintf(stderr, "[thread] attr setstack attr=%p base=%p size=0x%llx rc=%d\n",
+                (void*)at, (void*)(uintptr_t)a1, (unsigned long long)a2, rc);
+    if (!rc) { at->supplied_stack = (void*)(uintptr_t)a1; at->supplied_stack_size = (size_t)a2; }
+    return (uint64_t)(unsigned)rc;
+#endif
 }
 HLE(k_attr_noop)        { return 0; }
 
@@ -617,16 +663,18 @@ HLE(k_attr_get) {
 // scePthreadAttrGetstackaddr(attr, void** addr) — Sony reports the stack *base* (low addr).
 HLE(k_attr_getstackaddr) {
     if (a0 && *(void**)a0 && a1) {
-        void* base = nullptr; size_t sz = 0;
-        pthread_attr_getstack((pthread_attr_t*)*(void**)a0, &base, &sz);
+        auto* at = (GuestPthreadAttr*)*(void**)a0;
+        void* base = at->supplied_stack; size_t sz = at->supplied_stack_size;
+        if (!base) pthread_attr_getstack(&at->host, &base, &sz);
         *(void**)(uintptr_t)a1 = base;
     }
     return 0;
 }
 HLE(k_attr_getstacksize) {
     if (a0 && *(void**)a0 && a1) {
-        void* base = nullptr; size_t sz = 0;
-        pthread_attr_getstack((pthread_attr_t*)*(void**)a0, &base, &sz);
+        auto* at = (GuestPthreadAttr*)*(void**)a0;
+        void* base = at->supplied_stack; size_t sz = at->supplied_stack_size;
+        if (!base) pthread_attr_getstack(&at->host, &base, &sz);
         *(size_t*)(uintptr_t)a1 = sz;
     }
     return 0;
@@ -673,21 +721,35 @@ HLE(k_getprio)            { // scePthreadGetprio(thread, int* prio)
 // ids are recycled, so a stale entry would serve the next thread the dead thread's bounds.
 #if defined(__linux__) || defined(__APPLE__)
 namespace {
-struct ThreadStart { void* (*entry)(void*); void* arg; char name[16]; };
+extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
+                                                  uint64_t a0, uint64_t a1);
+struct ThreadStart {
+    void* (*entry)(void*);
+    void* arg;
+    void* guest_stack;
+    size_t guest_stack_size;
+    char name[16];
+};
 // Runs first on the new thread: register our own stack (keyed by our tid) BEFORE any guest code,
 // so an early GC_register_my_thread / stack-base query from this thread finds it. Closes a race
 // where a fast-starting worker ran before the parent's post-create registration → "Bad stack base".
 void* thread_trampoline(void* p) {
     auto* ts = (ThreadStart*)p;
+    void* registered_stack = ts->guest_stack;
+    size_t registered_stack_size = ts->guest_stack_size;
     {
         pthread_attr_t sa;
         if (pthread_getattr_np(pthread_self(), &sa) == 0) {
             void* sb = nullptr; size_t ss = 0;
-            if (pthread_attr_getstack(&sa, &sb, &ss) == 0 && sb)
-                register_thread_stack((uint64_t)pthread_self(), sb, ss);
+            if (!registered_stack && pthread_attr_getstack(&sa, &sb, &ss) == 0 && sb) {
+                registered_stack = sb;
+                registered_stack_size = ss;
+            }
             pthread_attr_destroy(&sa);
         }
     }
+    if (registered_stack)
+        register_thread_stack((uint64_t)pthread_self(), registered_stack, registered_stack_size);
     install_sigaltstack();   // so a guest stack overflow on this worker is still catchable
     // Adopt the guest's thread name (scePthreadCreate/pthread_create_name_np arg) as the HOST
     // thread name so debugger/procfs views (gdb, /proc/PID/task/*/comm) show the engine's own
@@ -698,7 +760,9 @@ void* thread_trampoline(void* p) {
 #else
     if (ts->name[0]) pthread_setname_np(pthread_self(), ts->name);
 #endif
-    auto entry = ts->entry; void* arg = ts->arg; free(ts);   // all host libc — MUST run on the host %fs
+    auto entry = ts->entry; void* arg = ts->arg;
+    void* guest_stack = ts->guest_stack; size_t guest_stack_size = ts->guest_stack_size;
+    free(ts);   // all host libc — MUST run on the host %fs
     // gated (PROSPER_GUEST_FS): give this guest worker its own guest TCB + static TLS and switch %fs to it
     // as the LAST host action before entering guest code (so guest initial-exec TLS — incl. libc.prx's
     // allocator arena/tcache — resolves to real guest storage, not the aliased host glibc TCB). The import
@@ -706,7 +770,17 @@ void* thread_trampoline(void* p) {
     // is host glibc (host-TLS tcache) — running it under the guest %fs corrupts the host heap.
     arm_hwbp_this_thread();   // no-op unless PROSPER_HWBP_ALLTHREADS; MUST run on host %fs (host libc calls)
     guest_tls_activate_thread();
-    void* rv = entry ? entry(arg) : nullptr;
+    void* rv = nullptr;
+    if (entry) {
+        // glibc reserves part of a native pthread stack for its static TLS and rejects valid Sony
+        // stacks as small as 32 KiB. Keep the pthread runtime on its host-owned stack, but enter the
+        // guest at the exact caller-supplied base/size.
+        rv = guest_stack
+            ? (void*)(uintptr_t)prosper_call_guest_on_stack(
+                  (uintptr_t)guest_stack + guest_stack_size, (uint64_t)(uintptr_t)entry,
+                  (uint64_t)(uintptr_t)arg, 0)
+            : entry(arg);
+    }
     // Normal-return exit path: purge this thread's __tls_get_addr DTV entries and free the blocks
     // (#68 — glibc recycles pthread ids, so a stale entry would hand the NEXT thread on this id the
     // dead thread's dirty TLS). The guest entry can return with %fs still = the guest TP
@@ -729,8 +803,16 @@ namespace {
 // null-derived pointer; (2) it never ran guest_tls_activate_thread(), so the worker had no guest
 // %fs TCB and its initial-exec TLS was wrong. This trampoline fixes both: activate the guest %fs
 // TCB, then call the guest entry through the SysV marshalling shim, and purge DTV on exit.
-struct WinThreadStart { uint64_t entry; void* arg; char name[64]; };
+struct WinThreadStart {
+    uint64_t entry;
+    void* arg;
+    void* guest_stack;
+    size_t guest_stack_size;
+    char name[64];
+};
 extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
+extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
+                                                  uint64_t a0, uint64_t a1);
 
 // PS5 code is compiled for a stack whose entire usable range is writable.  Windows instead
 // initially commits only the top of a reserved thread stack and relies on a moving guard page;
@@ -774,6 +856,7 @@ bool prepare_guest_windows_stack(ULONG_PTR* out_low, ULONG_PTR* out_high) {
 void* win_thread_trampoline(void* p) {
     auto* ts = (WinThreadStart*)p;
     uint64_t entry = ts->entry; void* arg = ts->arg;
+    void* guest_stack = ts->guest_stack; size_t guest_stack_size = ts->guest_stack_size;
     char name[sizeof(ts->name)]; memcpy(name, ts->name, sizeof(name));
     free(ts);   // host libc: run on host %fs (before activate)
     if (name[0]) {
@@ -791,19 +874,32 @@ void* win_thread_trampoline(void* p) {
     ULONG_PTR stk_lo = 0, stk_hi = 0;
     if (!prepare_guest_windows_stack(&stk_lo, &stk_hi))
         GetCurrentThreadStackLimits(&stk_lo, &stk_hi);
-    if (stk_lo && stk_hi > stk_lo) {
-        register_thread_stack((uint64_t)GetCurrentThreadId(), (void*)stk_lo, (uint64_t)(stk_hi - stk_lo));
-        register_thread_stack(guest_thread, (void*)stk_lo, (uint64_t)(stk_hi - stk_lo));
+    void* registered_base = guest_stack ? guest_stack : (void*)stk_lo;
+    size_t registered_size = guest_stack ? guest_stack_size : (size_t)(stk_hi - stk_lo);
+    if (registered_base && registered_size) {
+        register_thread_stack((uint64_t)GetCurrentThreadId(), registered_base, registered_size);
+        register_thread_stack(guest_thread, registered_base, registered_size);
     }
     trace_guest_thread_lifecycle(true, (uint64_t)pthread_self(),
-                                 (uint64_t)GetCurrentThreadId(), (void*)stk_lo,
-                                 (size_t)(stk_hi - stk_lo));
+                                 (uint64_t)GetCurrentThreadId(), registered_base, registered_size);
     guest_tls_activate_thread();   // this worker's guest %fs TCB (FSGSBASE); no-op if the gate is off
-    void* rv = entry ? (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0) : nullptr;
+    void* rv = nullptr;
+    if (entry) {
+        if (guest_stack) {
+            NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+            void* saved_base = tib->StackBase; void* saved_limit = tib->StackLimit;
+            tib->StackLimit = guest_stack;
+            tib->StackBase = (void*)((uintptr_t)guest_stack + guest_stack_size);
+            rv = (void*)(uintptr_t)prosper_call_guest_on_stack(
+                (uintptr_t)guest_stack + guest_stack_size, entry, (uint64_t)(uintptr_t)arg, 0);
+            tib->StackLimit = saved_limit; tib->StackBase = saved_base;
+        } else {
+            rv = (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0);
+        }
+    }
     tls_dtv_purge_current_thread();
     trace_guest_thread_lifecycle(false, (uint64_t)pthread_self(),
-                                 (uint64_t)GetCurrentThreadId(), (void*)stk_lo,
-                                 (size_t)(stk_hi - stk_lo));
+                                 (uint64_t)GetCurrentThreadId(), registered_base, registered_size);
     unregister_thread_stack((uint64_t)GetCurrentThreadId());   // ids recycle; stale bounds = wrong bounds
     unregister_thread_stack(guest_thread);
     unregister_current_thread_handle(guest_thread);
@@ -825,25 +921,38 @@ HLE(k_pthread_create) {
     // would on the same stack. No attr (or no explicit size) keeps the 8 MiB default.
     constexpr size_t kStackFloor = 1 * 1024 * 1024, kStackDefault = 8 * 1024 * 1024;
     size_t ssz = kStackDefault;
+    void* supplied_stack = nullptr;
+    size_t supplied_stack_size = 0;
     int detach = PTHREAD_CREATE_JOINABLE;
     if (a1 && *(void**)a1) {
-        auto* gat = (pthread_attr_t*)*(void**)a1;
+        auto* guest_attr = (GuestPthreadAttr*)*(void**)a1;
+        auto* gat = &guest_attr->host;
         size_t req = 0;
         if (pthread_attr_getstacksize(gat, &req) == 0 && req)
             ssz = req < kStackFloor ? kStackFloor : req;
+        supplied_stack = guest_attr->supplied_stack;
+        supplied_stack_size = guest_attr->supplied_stack_size;
         pthread_attr_getdetachstate(gat, &detach);
+        if (getenv("PROSPER_SYNCLOG"))
+            fprintf(stderr, "[thread] attr create attr=%p requested=0x%zx supplied=%p+0x%zx detach=%d\n",
+                    (void*)guest_attr, req, supplied_stack, supplied_stack_size, detach);
     }
-    // A local attr with setstackSIZE (not setstack): glibc allocates AND RECLAIMS the stack
-    // (join / detached exit) — the old caller-owned mmap was never freed (#138). Also stops
-    // mutating the guest's own attr object (setstack used to be applied to it in place).
+    // Size-only attrs keep a host-owned/reclaimed stack; an explicit base stays caller-owned and
+    // must be copied exactly into the local attr.
     pthread_attr_t la; pthread_attr_init(&la);
-    pthread_attr_setstacksize(&la, ssz);
+    // The trampoline enters guest code on an explicit Sony stack. The host pthread itself retains a
+    // glibc-owned stack large enough for static TLS and native start/exit bookkeeping.
+    int attr_rc = pthread_attr_setstacksize(&la, supplied_stack ? kStackFloor : ssz);
+    if (attr_rc) { pthread_attr_destroy(&la); return (uint64_t)(unsigned)attr_rc; }
     pthread_attr_setdetachstate(&la, detach);
     auto* ts = (ThreadStart*)malloc(sizeof(ThreadStart));
     if (!ts) { pthread_attr_destroy(&la); return 12; }         // ENOMEM (FreeBSD and host agree)
-    ts->entry = entry; ts->arg = arg; ts->name[0] = 0;
+    ts->entry = entry; ts->arg = arg;
+    ts->guest_stack = supplied_stack; ts->guest_stack_size = supplied_stack_size;
+    ts->name[0] = 0;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
+    if (getenv("PROSPER_SYNCLOG")) fprintf(stderr, "[thread] pthread_create rc=%d\n", r);
     pthread_attr_destroy(&la);
     if (r) { free(ts); return (uint64_t)r; }
 #else
@@ -852,23 +961,28 @@ HLE(k_pthread_create) {
     // skips TLS activation, crashing the worker on a null-derived pointer.
     constexpr size_t kStackFloor = 1 * 1024 * 1024, kStackDefault = 8 * 1024 * 1024;
     size_t ssz = kStackDefault;
+    void* supplied_stack = nullptr;
+    size_t supplied_stack_size = 0;
     int detach = PTHREAD_CREATE_JOINABLE;
     if (a1 && *(void**)a1) {
-        auto* gat = (pthread_attr_t*)*(void**)a1;
+        auto* guest_attr = (GuestPthreadAttr*)*(void**)a1;
+        auto* gat = &guest_attr->host;
         size_t req = 0;
         if (pthread_attr_getstacksize(gat, &req) == 0 && req)
             ssz = req < kStackFloor ? kStackFloor : req;
+        supplied_stack = guest_attr->supplied_stack;
+        supplied_stack_size = guest_attr->supplied_stack_size;
         pthread_attr_getdetachstate(gat, &detach);
     }
-    // Use a host-owned attr just like Linux: preserve the Sony-requested size/detach state, but
-    // do not pass through a guest-owned stack address to winpthreads.  The trampoline commits
-    // this reservation before guest entry because PS5 code does not contain Windows probes.
+    // Keep winpthreads on a host-owned stack; the trampoline switches guest entry to an explicit
+    // Sony range after preparing the native reservation used by Windows runtime cleanup.
     pthread_attr_t la; pthread_attr_init(&la);
-    pthread_attr_setstacksize(&la, ssz);
+    pthread_attr_setstacksize(&la, supplied_stack ? kStackFloor : ssz);
     pthread_attr_setdetachstate(&la, detach);
     auto* ts = (WinThreadStart*)malloc(sizeof(WinThreadStart));
     if (!ts) { pthread_attr_destroy(&la); return 12; }          // ENOMEM (FreeBSD and host agree)
     ts->entry = (uint64_t)(uintptr_t)entry; ts->arg = arg;
+    ts->guest_stack = supplied_stack; ts->guest_stack_size = supplied_stack_size;
     ts->name[0] = 0;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, win_thread_trampoline, ts);

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -52,7 +52,7 @@ namespace {
     // allocator handed out offsets past the pool, the guest's 512GB-arena block bitmap indexed
     // out of range, and user_malloc_init crashed on the bitmap read.
     constexpr uint64_t kDmemBase  = 0x10000000;
-    constexpr uint64_t kDmemTotal = 8ull * 1024 * 1024 * 1024;   // 8 GiB pool
+    constexpr uint64_t kDmemTotal = 16ull * 1024 * 1024 * 1024;  // PS5 unified-memory aperture
     // Direct ("physical") memory allocations, kept SORTED by start (first-fit allocation walks the
     // gaps). Also serves sceKernelDirectMemoryQuery.
     struct DMem { uint64_t start, end; int type; };
@@ -220,10 +220,47 @@ namespace {
         return hp;   // p == 0 -> PROT_NONE (no access), NOT read-write
     }
     uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
+
+    // The console chooses automatic mappings from its guest user-VA space.  Letting mmap(nullptr)
+    // choose instead leaks a host VA (commonly 0x7f...) to the guest.  Besides being outside the PS5
+    // address model, Sony libc explicitly rejects such an address as mspace backing.  Search a quiet
+    // guest range atomically with MAP_FIXED_NOREPLACE; all HLE-created occupants are tracked, so a
+    // collision can skip directly past them instead of probing every 64 KiB page.
+    constexpr uint64_t kGuestAutoMapBase  = 0x2000000000ull;
+    constexpr uint64_t kGuestAutoMapLimit = 0x40000000000ull;
+    void* map_guest_auto(uint64_t len, int prot, uint64_t align) {
+        const uint64_t page = (uint64_t)sysconf(_SC_PAGESIZE);
+        if (align < page) align = page;
+        if (!len || (align & (align - 1)) != 0 || len > kGuestAutoMapLimit - kGuestAutoMapBase)
+            return nullptr;
+        const uint64_t step = align > 0x10000 ? align : 0x10000;
+        uint64_t cand = align_up(kGuestAutoMapBase, align);
+        while (cand <= kGuestAutoMapLimit - len) {
+            void* p = prosper_mmap_noreplace((void*)cand, len, prot,
+                                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            if (p != MAP_FAILED) return p;
+
+            uint64_t next = cand + step;
+            {
+                std::lock_guard<std::mutex> lk(g_mx);
+                const uint64_t end = cand + len;
+                for (const auto& m : g_maps) {
+                    const uint64_t me = m.base + m.size;
+                    if (m.base < end && me > cand) {
+                        const uint64_t past = align_up(me, align);
+                        if (past > next) next = past;
+                    }
+                }
+            }
+            if (next <= cand) return nullptr;
+            cand = next;
+        }
+        return nullptr;
+    }
+
     void* map_at(uint64_t hint, uint64_t len, int prot) {
         if (!hint) {
-            void* p = mmap(nullptr, len, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-            return p == MAP_FAILED ? nullptr : p;
+            return map_guest_auto(len, prot, 0x4000);
         }
         // Non-zero hint: claim it WITHOUT clobbering (#137). MAP_FIXED_NOREPLACE fails if anything
         // is already there; only if the occupant is entirely our own uncommitted reservation do we
@@ -273,23 +310,14 @@ namespace {
     // Reserve an anonymous span whose returned base satisfies `align`. Linux mmap only promises
     // host-page alignment, while Orbis direct-memory callers can require larger alignment.
     void* reserve_aligned(uint64_t len, uint64_t align) {
-        const uint64_t page = (uint64_t)sysconf(_SC_PAGESIZE);
-        if (align < page) align = page;
-        if ((align & (align - 1)) != 0 || len > UINT64_MAX - align) return nullptr;
-        void* raw = mmap(nullptr, len + align, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (raw == MAP_FAILED) return nullptr;
-        uint64_t raw_base = (uint64_t)raw;
-        uint64_t base = align_up(raw_base, align);
-        if (base > raw_base) munmap(raw, base - raw_base);
-        uint64_t used_end = base + len, raw_end = raw_base + len + align;
-        if (raw_end > used_end) munmap((void*)used_end, raw_end - used_end);
-        return (void*)base;
+        return map_guest_auto(len, PROT_NONE, align);
     }
 
     // Map `len` bytes of the phys pool at `hint` (0 = anywhere). Falls back to anonymous memory
     // if the memfd is unavailable (still boots; loses aliasing). A zero-hint mapping honors the
     // caller's requested VA alignment; the old host-page-aligned mmap violated that ABI contract.
-    void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align = 0) {
+    void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align = 0,
+                      bool fixed = true) {
         int fd = dmem_fd();
         if (fd >= 0 && phys < kDmemBase + kDmemTotal) {
             if (!hint) {
@@ -299,21 +327,37 @@ namespace {
                     if (p != MAP_FAILED) return p;
                     munmap(reserved, len);
                 }
-            } else {
+            } else if (range_is_free_reservation(hint, len)) {
+                // A prior sceKernelReserveVirtualRange owns this exact span. Replacing that
+                // PROT_NONE placeholder is safe even when MAP_FIXED was not requested.
+                void* p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
+                if (p != MAP_FAILED) return p;
+            } else if (fixed) {
                 // Same no-clobber discipline as map_at (#137): NOREPLACE first, MAP_FIXED replace
                 // only over our own uncommitted reservation, else refuse rather than destroy a live
                 // (committed / untracked) mapping — the exact clobber class of issues #88 / #107.
                 void* p = prosper_mmap_noreplace((void*)hint, len, prot, MAP_SHARED, fd, (off_t)phys);
                 if (p != MAP_FAILED) return p;
-                if (range_is_free_reservation(hint, len)) {
-                    p = mmap((void*)hint, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
+                return nullptr;
+            } else {
+                // Without SCE_KERNEL_MAP_FIXED the input address is a search hint, not a demand
+                // to replace that VA. Try the hint atomically, then relocate within the *guest* VA
+                // range. Plain mmap(hint) may silently return a 0x7f... host address when the hint is
+                // occupied; Sony libc rejects such a pointer as mspace backing.
+                void* p = prosper_mmap_noreplace((void*)hint, len, prot, MAP_SHARED, fd,
+                                                  (off_t)phys);
+                if (p != MAP_FAILED &&
+                    (!align || (((uint64_t)p & (align - 1)) == 0))) return p;
+                if (p != MAP_FAILED) munmap(p, len);
+                void* reserved = reserve_aligned(len, align ? align : 0x4000);
+                if (reserved) {
+                    p = mmap(reserved, len, prot, MAP_SHARED | MAP_FIXED, fd, (off_t)phys);
                     if (p != MAP_FAILED) return p;
-                } else {
-                    return nullptr;
+                    munmap(reserved, len);
                 }
             }
         }
-        if (hint) return map_at(hint, len, prot);
+        if (hint && fixed) return map_at(hint, len, prot);
         void* reserved = reserve_aligned(len, align ? align : 0x4000);
         if (!reserved) return nullptr;
         void* p = mmap(reserved, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
@@ -401,14 +445,9 @@ HLE(k_reserve_vrange) {
         MLOG("reserve search from 0x%llx FAILED (no free range)\n", (unsigned long long)hint);
         return 0x8002000cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
-    // Over-map by `align`, then trim the head/tail slack to yield an aligned span.
-    uint64_t total = a1 + align;
-    void* raw = mmap(nullptr, total, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (raw == MAP_FAILED) { MLOG("reserve len=0x%llx FAILED\n", (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
-    uint64_t base = align_up((uint64_t)raw, align);
-    if (base > (uint64_t)raw) munmap(raw, base - (uint64_t)raw);
-    uint64_t used_end = base + a1, raw_end = (uint64_t)raw + total;
-    if (raw_end > used_end) munmap((void*)used_end, raw_end - used_end);
+    void* raw = map_guest_auto(a1, PROT_NONE, align);
+    if (!raw) { MLOG("reserve len=0x%llx FAILED\n", (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
+    uint64_t base = (uint64_t)raw;
     if (a0) *(uint64_t*)a0 = base;
     track(base, a1, 0, false, "reserved");
     MLOG("reserve -> 0x%llx len=0x%llx align=0x%llx (raw 0x%llx)\n",
@@ -448,13 +487,16 @@ HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, ph
     // Honor the [searchStart, searchEnd) window (a0/a1) — dropping it handed the guest an offset
     // outside the window it asked for.
     if (!dmem_take(sz, align, (int)a4, off, a0, a1 ? a1 : ~0ull)) {
-        MLOG("alloc_dmem len=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
-             (unsigned long long)a2, (unsigned long long)a0, (unsigned long long)a1);
+        MLOG("alloc_dmem len=0x%llx align=0x%llx type=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
+             (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)a4,
+             (unsigned long long)a0, (unsigned long long)a1);
         return 0x8002000Cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
     dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
     if (a5 > 0xffff) *(uint64_t*)a5 = off;   // only write through a plausible out-pointer
-    MLOG("alloc_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a2, (unsigned long long)off);
+    MLOG("alloc_dmem range=[0x%llx,0x%llx) len=0x%llx align=0x%llx type=0x%llx -> phys=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)off);
     return 0;
 }
 
@@ -501,13 +543,17 @@ HLE(k_direct_memory_query) {
 // sceKernelMapDirectMemory(void** addrInOut, size_t len, int prot, int flags, off_t phys, size_t align)
 HLE(k_map_dmem) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
-    void* p = map_phys_at(hint, a1, host_prot(a2), a4, a5);
-    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
+    const bool fixed = (a3 & 0x10) != 0;
+    void* p = map_phys_at(hint, a1, host_prot(a2), a4, a5, fixed);
+    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx flags=0x%llx phys=0x%llx align=0x%llx FAILED\n",
+                   (unsigned long long)hint, (unsigned long long)a1,
+                   (unsigned long long)a3, (unsigned long long)a4,
+                   (unsigned long long)a5); return 0x8002000cull; } // ENOMEM
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), true, "direct");
-    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx align=0x%llx\n",
+    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
          (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4,
-         (unsigned long long)a2, (unsigned long long)a5);
+         (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)a5);
     return 0;
 }
 
@@ -644,7 +690,7 @@ HLE(k_mprotect) { if (a0) { mprotect((void*)a0, a1, host_prot(a2)); retrack_prot
 // as the batch-map TYPE_PROTECT op. We don't track memoryType yet, so apply the protection (the load-
 // bearing half). NOTE prot is arg a3 here, not a2.
 HLE(k_mtypeprotect) { if (a0) { mprotect((void*)a0, a1, host_prot(a3)); retrack_prot(a0, a1, host_prot(a3), "mtypeprotect"); } return 0; }
-HLE(k_dmem_size){ return kDmemTotal; }   // 8 GiB pool (allocation failures enforce this bound)
+HLE(k_dmem_size){ return kDmemTotal; }   // sparse-backed; allocation failures enforce this bound
 // sceKernelAvailableDirectMemorySize(searchStart, searchEnd, alignment, off_t* physAddrOut,
 // size_t* sizeOut) — report the LARGEST free aligned direct-memory block in [searchStart, searchEnd).
 // Signature per shadPS4 memory.cpp:120 (NID C0f7TJcbfac, PS4-inherited). Was aliased to
@@ -1195,7 +1241,7 @@ namespace {
     std::vector<Mapping> g_maps;
     bool sparse_dmem_view_overlaps(uint64_t begin, uint64_t end);
     constexpr uint64_t kDmemBase  = 0x10000000;
-    constexpr uint64_t kDmemTotal = 8ull * 1024 * 1024 * 1024;   // 8 GiB pool
+    constexpr uint64_t kDmemTotal = 16ull * 1024 * 1024 * 1024;  // PS5 unified-memory aperture
     struct DMem { uint64_t start, end; int type; };
     std::mutex g_dmx;
     std::vector<DMem> g_dmem;
@@ -1323,7 +1369,7 @@ namespace {
     constexpr uint64_t kWinAllocationGranularity = 0x10000;
 
     // One sparse paging-file section is the Windows equivalent of the POSIX direct-memory memfd.
-    // SEC_RESERVE avoids charging 8 GiB of host commit up front; each view commits only its guest span.
+    // SEC_RESERVE avoids charging 16 GiB of host commit up front; each view commits only its guest span.
     HANDLE dmem_section() {
         static HANDLE section = [] {
             HANDLE h = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr,
@@ -1959,7 +2005,12 @@ HLE(k_avail_dmem) {
     *(uint64_t*)(uintptr_t)a4 = size;
     return 0;
 }
-HLE(k_release_dmem) { dmem_release(a0, a1); return 0; }
+HLE(k_release_dmem) {
+    MLOG("release_dmem phys=0x%llx len=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1);
+    dmem_release(a0, a1);
+    return 0;
+}
 
 // sceKernelBatchMap(entries, num, int* numOut) — entry 0x20 bytes: start@0, phys@8, len@0x10,
 // prot@0x18(char), type@0x19, op@0x1c. Ops: 0=MAP_DIRECT 1=UNMAP 2=PROTECT 3=MAP_FLEXIBLE 4=TYPE_PROTECT.

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -338,19 +338,23 @@ HLE(k_debug_raise_release) {
     fflush(nullptr);
     _Exit(0x66);
 }
-#if defined(__APPLE__)
-HLE(k_getthreadid) {
-    uint64_t tid = 0;
-    return pthread_threadid_np(nullptr, &tid) == 0 ? tid : 0;
-} // scePthreadGetthreadid
-#elif defined(__linux__)
-HLE(k_getthreadid) { return (uint64_t)syscall(SYS_gettid); }   // scePthreadGetthreadid
-#else
-// The guest uses this as an ownership/current-thread identity, so a process-wide constant makes every
-// guest pthread appear to be the same thread. Windows thread IDs are stable for a live thread and unique
-// among concurrently running threads, matching the observable contract of Linux gettid here.
-HLE(k_getthreadid) { return (uint64_t)GetCurrentThreadId(); }
-#endif
+// Console pthread IDs are small, process-local identities, not native kernel TIDs.  Exposing Linux
+// gettid/GetCurrentThreadId happened to satisfy mutex ownership checks, but it also leaked a different
+// identity domain into guest code which stores the value in its TCB and uses it as a Havok context-map
+// key.  Allocate a monotonically increasing guest ID lazily on the host thread's first guest call.  HLE
+// handlers run with the host TLS base restored, so host thread_local storage is safe even while the
+// surrounding program uses a guest FS base.  IDs are deliberately never recycled during the process.
+namespace {
+std::atomic<uint32_t> g_next_guest_thread_id{1};
+
+uint32_t current_guest_thread_id() {
+    static thread_local const uint32_t id =
+        g_next_guest_thread_id.fetch_add(1, std::memory_order_relaxed);
+    return id;
+}
+} // namespace
+
+HLE(k_getthreadid) { return current_guest_thread_id(); } // scePthreadGetthreadid
 // sceKernelAprResolveFilepathsToIdsAndFileSizes — PS5 APR (async page read) IO path. Signature
 // unconfirmed; a garbage-out "success" poisons the engine's file table, so fail cleanly and let
 // the engine take its non-APR file path. CONFIDENCE: LOW on ABI, MED that failing is safer.

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -506,6 +506,8 @@ void register_builtin_hle() {
     register_file_hle();     // file I/O (stdio + POSIX, /app0 translation)
     register_service_hle();  // PS5 system services (user/NP/mouse/appcontent/dialog)
     register_http_hle();     // libSceHttp local URI parsing
+    register_font_hle();     // libSceFont opaque handles + deterministic text/metric fallback
+    register_fiber_hle();    // libSceFiber cooperative guest-stack execution
     register_pad_hle();      // libScePad: real game-controller input (input/pad.cpp)
     register_audio_hle();    // libSceAudioOut backed by a headless/pluggable AudioSink
     register_graphics_hle(); // headless libSceAgc/libSceVideoOut placeholders (bring-up)

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -75,7 +75,7 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     for (auto& img : p.imgs) if (!map_image(img, &e)) return fail("map failed: " + e);
     { std::vector<TlsModuleDesc> td; for (auto& t : p.tls_templates) td.push_back({t.init_va, t.filesz, t.memsz, t.align});
       set_tls_modules(td.data(), td.size());              // __tls_get_addr for loaded modules (real libc.prx)
-      guest_tls_set_templates(td.data(), td.size()); }    // gated PROSPER_GUEST_FS: guest initial-exec %fs TLS
+      guest_tls_set_templates(td.data(), td.size()); }    // guest initial-exec %fs TLS (Linux/Windows default on)
 
     // C++ exception unwinding: give each module's .eh_frame_hdr + text segment to the unwinder.
     { static std::vector<std::string> names; names.reserve(p.imgs.size());

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -13,14 +13,17 @@ namespace prosper {
 
 // Fixed guest module bases (the PS5 title's fixed address map). Shared so callers that classify
 // guest addresses (e.g. boot_trace's diagnostics) use the same constants the boot uses.
-inline constexpr uint64_t BOOT_EBOOT    = 0x400000000ull;
+// Keep executable images out of the fixed direct-memory apertures used by current PS5 titles.
+// Astro Bot maps [0x400000000,0x40b800000) and [0x500000000,0x587400000) before bringing up
+// AGC; placing eboot/libc at the old 0x400/0x500 bases made those legitimate mappings alias code.
+inline constexpr uint64_t BOOT_EBOOT    = 0x410000000ull;
 inline constexpr uint64_t BOOT_IL2CPP   = 0x440000000ull;
 inline constexpr uint64_t BOOT_PS5UTIL  = 0x4c0000000ull;
 inline constexpr uint64_t BOOT_PSNCORE  = 0x480000000ull;   // PPSA02664's Unity PSN native plugin
 inline constexpr uint64_t BOOT_PSNCOMMON = 0x4a0000000ull;  //   (PSNCore.prx + PSNCommon.prx)
 inline constexpr uint64_t BOOT_PSN      = 0x4e0000000ull;
 inline constexpr uint64_t BOOT_SAVEDATA = 0x4f0000000ull;
-inline constexpr uint64_t BOOT_LIBC     = 0x500000000ull;
+inline constexpr uint64_t BOOT_LIBC     = 0x5c0000000ull;
 inline constexpr uint64_t BOOT_FMODSTUDIO = 0x520000000ull; // optional Unity FMOD native plugins
 inline constexpr uint64_t BOOT_FMOD       = 0x540000000ull;
 inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
@@ -36,7 +39,8 @@ inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 // images are mapped — the point a caller installs host frontends (audio sink / pad backend) so they
 // are in place before the guest runs. Returns false (with *err set) on a link/map/stub failure.
 //
-// Linux-only (the whole guest-execution substrate is). On other platforms it returns false.
+// Available on every platform with a guest-execution substrate (currently Linux, Windows, and macOS).
+// Other platforms return false.
 bool boot_program(const std::string& dump_root, Program& out, std::string* err,
                   const std::function<void()>& after_hle_registered = {});
 

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2288,7 +2288,7 @@ BootResult run_entry(const LoadedImage& img) {
     arm_bp();     // write the PROSPER_BP int3 now that the guest image is fully mapped
     arm_hwbp();   // open the PROSPER_HWBP hardware breakpoint on this (guest main) thread
     if (sigsetjmp(g_jb, 1) == 0) {
-        // gated (PROSPER_GUEST_FS): switch %fs to a guest TCB as the LAST host action before entering the
+        // Switch %fs to a guest TCB as the LAST host action before entering the
         // guest — any host C++ after this point would run on the guest TCB. Import stubs swap back per-call.
         guest_tls_activate_thread();
         register uint64_t e  asm("rax") = img.entry;

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -1,4 +1,5 @@
-// guest_tls.cpp — guest initial-exec TLS support (Linux). GATED behind PROSPER_GUEST_FS (default off).
+// guest_tls.cpp — guest initial-exec TLS support. Enabled by default on Linux/Windows (opt out with
+// PROSPER_NO_GUEST_FS); macOS/Rosetta trap emulation remains opt-in with PROSPER_GUEST_FS.
 //
 // The guest (FreeBSD/PS5, x86-64 Variant II TLS) accesses static/initial-exec thread-locals directly via
 // %fs: `mov %fs:0x0,%rax; mov -0xa8(%rax),%rdx`. We normally run guest code on the HOST pthread's %fs (so
@@ -41,8 +42,8 @@ static constexpr uint64_t MAGIC_OFF       = 0x108;   // == GUEST_TCB_MAGIC_OFF i
 static constexpr uint32_t TCB_MAGIC       = 0x50524F53u;  // "PROS" — marks OUR guest TCB (== GUEST_TCB_MAGIC)
 
 void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
-    g_enabled = getenv("PROSPER_GUEST_FS") != nullptr;
 #ifdef __APPLE__
+    g_enabled = getenv("PROSPER_GUEST_FS") != nullptr;
     // Rosetta 2 does not implement rdfsbase/wrfsbase (verified: SIGILL on an M2) and Darwin has no
     // fsbase API, so we cannot give the CPU a real guest %fs base. Instead run in TRAP mode: build
     // the guest TCB, leave the hardware fs base at Rosetta's 0, and emulate each `%fs:`-prefixed
@@ -50,6 +51,11 @@ void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
     // so the real target is guest_TP + fault_addr). Enabled by the same PROSPER_GUEST_FS gate.
     // See exec_image_linux.cpp try_emulate_fs_access and docs/PORTING.md "macOS harness app".
     if (g_enabled) fprintf(stderr, "[guest-tls] macOS TRAP mode: %%fs accesses emulated (no wrfsbase)\n");
+#else
+    // Initial-exec guest accesses must never alias glibc's host TCB. Astro Bot, for example, seeds
+    // its Havok thread-context key to -1 in PT_TLS; reading the same offset from the host TCB yields
+    // zero and later fails a context lookup. Keep an opt-out only for compatibility bisection.
+    g_enabled = getenv("PROSPER_NO_GUEST_FS") == nullptr;
 #endif
     g_mods.assign(descs, descs + count);
     // x86-64 Variant II static-TLS layout (glibc _dl_determine_tlsoffset, TLS_TCB_AT_TP): each

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -972,14 +972,25 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (const auto& d : draws) {
         if (!d.ps) continue;
         if (d.ps->depth_test_enable || d.ps->depth_clear_enable) { use_depth = true;
-            // An ALWAYS-compare draw passes regardless of the depth clear, so it must NOT dictate it.
-            // The Messenger menu primes depth with an ALWAYS+write draw (its compare-op default clear is
-            // 1.0), then draws the real UI with GEQUAL (default clear 0.0). Latching 1.0 off the ALWAYS
-            // draw made every GEQUAL fragment fail (z >= 1.0) -> the whole menu went black (#508). Latch
-            // the clear from the first draw whose compare actually depends on it (skip ALWAYS/NEVER).
-            if (!got_depth_clear && d.ps->depth_compare_op != VK_COMPARE_OP_ALWAYS
-                                 && d.ps->depth_compare_op != VK_COMPARE_OP_NEVER) {
-                depth_clear = d.ps->depth_clear_value; got_depth_clear = true; } }
+            // DB_DEPTH_CLEAR is only consumed when DB_RENDER_CONTROL requests an actual clear. Merely
+            // programming the register does not initialize a newly-created host depth image: it is
+            // commonly stale state, and Astro Bot even leaves the packed 1920x1080 max coordinates
+            // (0x0437077f) there. Interpreting those bits as a float initialized every LEQUAL surface
+            // to 2.15e-36 and rejected the entire scene. Without an explicit clear, approximate the
+            // unavailable guest depth contents with the compare-appropriate far value (#371).
+            //
+            // An explicit clear wins even on ALWAYS/NEVER. Otherwise those compare modes do not depend
+            // on the initial value and must not poison the first later meaningful draw (#508).
+            if (!got_depth_clear && d.ps->depth_clear_enable) {
+                depth_clear = d.ps->depth_clear_value;
+                got_depth_clear = true;
+            } else if (!got_depth_clear && d.ps->depth_compare_op != VK_COMPARE_OP_ALWAYS
+                                            && d.ps->depth_compare_op != VK_COMPARE_OP_NEVER) {
+                depth_clear = (d.ps->depth_compare_op == VK_COMPARE_OP_GREATER ||
+                               d.ps->depth_compare_op == VK_COMPARE_OP_GREATER_OR_EQUAL)
+                    ? 0.0f : 1.0f;
+                got_depth_clear = true;
+            } }
         if (d.ps->stencil_enable || d.ps->stencil_clear_enable) { use_stencil = true;
             if (!got_stencil_clear) {
                 stencil_clear = d.ps->stencil_clear_value; got_stencil_clear = true;

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -10,6 +10,15 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 using namespace prosper;
 
@@ -130,6 +139,39 @@ int main() {
               "SubmitAcb returns OK");
         uint64_t after = 0; prosper_agc_submit_stats(&after, &ignored);
         CHECK(after == before + 1, "SubmitAcb folds one async command stream");
+    }
+
+    // A valid header at the last dword of a readable page must not make the decoder walk into the
+    // inaccessible next page when the packet advertises two dwords.
+    {
+#ifdef _WIN32
+        const size_t page_size = 0x1000;
+        auto* pages = static_cast<uint8_t*>(VirtualAlloc(
+            nullptr, page_size * 2, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+        DWORD old_protect = 0;
+        const bool protected_second = pages && VirtualProtect(
+            pages + page_size, page_size, PAGE_NOACCESS, &old_protect) != 0;
+#else
+        const size_t page_size = (size_t)sysconf(_SC_PAGESIZE);
+        auto* pages = static_cast<uint8_t*>(mmap(
+            nullptr, page_size * 2, PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        const bool protected_second = pages != MAP_FAILED &&
+            mprotect(pages + page_size, page_size, PROT_NONE) == 0;
+#endif
+        CHECK(protected_second, "created a readable-page/guard-page ACB boundary");
+        if (protected_second) {
+            auto* boundary_stream = reinterpret_cast<uint32_t*>(pages + page_size - 4);
+            *boundary_stream = 0x80000000u;
+            Packet packet{boundary_stream, 2, {0,0,0,0}};
+            CHECK(submit_acb(0x40, (uint64_t)(uintptr_t)&packet, 4, 2, 0, 0) != 0,
+                  "SubmitAcb rejects a stream whose full dword range crosses a guard page");
+        }
+#ifdef _WIN32
+        if (pages) VirtualFree(pages, 0, MEM_RELEASE);
+#else
+        if (pages != MAP_FAILED) munmap(pages, page_size * 2);
+#endif
     }
 
     // Fixed args 7-9 must be real function parameters, not compiler-frame offsets. This is the exact

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -39,13 +39,14 @@ int main() {
     auto setidx = Hle::lookup("GIIW2J37e70");   // GraphicsDcbSetIndexSize
     auto draw   = Hle::lookup("Yw0jKSqop+E");   // GraphicsDcbDrawIndexAuto
     auto submit = Hle::lookup("UglJIZjGssM");   // GraphicsDriverSubmitDcb
+    auto submit_acb = Hle::lookup("gSRnr79F8tQ"); // GraphicsDriverSubmitAcb
     auto regmem = Hle::lookup("AOLcoIkQDgM");   // QueryResourceRegistrationUserMemoryRequirements
     auto maxname = Hle::lookup("uJziRsODk1c");   // sceAgcDriverGetResourceRegistrationMaxNameLength
     auto release = reinterpret_cast<HostHle9>(Hle::lookup("wr23dPKyWc0")); // GraphicsCbReleaseMem
     auto waitmem = reinterpret_cast<HostHle9>(Hle::lookup("VmW0Tdpy420")); // GraphicsDcbWaitRegMem
-    CHECK(reset && setcx && setidx && draw && submit && regmem && maxname && release && waitmem,
-          "AGC Dcb, submit, and resource-registration functions registered");
-    if (!(reset && setcx && setidx && draw && submit && regmem && maxname && release && waitmem)) {
+    CHECK(reset && setcx && setidx && draw && submit && submit_acb && regmem && maxname && release && waitmem,
+          "AGC Dcb/Acb submit and resource-registration functions registered");
+    if (!(reset && setcx && setidx && draw && submit && submit_acb && regmem && maxname && release && waitmem)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -110,6 +111,25 @@ int main() {
         CHECK(st.index_type == 1, "folded the index type");
         CHECK(st.draws.size() == 1 && st.draws[0].index_count == 42,
               "recorded one DrawIndexAuto with index_count=42");
+    }
+
+
+    // ACB uses the same packet descriptor and must enter the command processor instead of silently
+    // disappearing. An empty reset packet is sufficient to prove that the async submit is folded.
+    {
+        static uint32_t acb_buffer[16]{};
+        Dcb acb{};
+        acb.bottom = acb_buffer; acb.top = acb_buffer + 16;
+        acb.cursor_up = acb_buffer; acb.cursor_down = acb_buffer + 16;
+        auto acb_reset = Hle::lookup("JrtiDtKeS38");
+        CHECK(acb_reset && acb_reset((uint64_t)(uintptr_t)&acb, 0x3ff, 0, 0, 0, 0) != 0,
+              "async-compute queue builder appends a packet");
+        Packet packet{acb_buffer, (uint32_t)(acb.cursor_up - acb_buffer), {0,0,0,0}};
+        uint64_t before = 0, ignored = 0; prosper_agc_submit_stats(&before, &ignored);
+        CHECK(submit_acb(0x40, (uint64_t)(uintptr_t)&packet, 4, packet.dw_num, 0, 0) == 0,
+              "SubmitAcb returns OK");
+        uint64_t after = 0; prosper_agc_submit_stats(&after, &ignored);
+        CHECK(after == before + 1, "SubmitAcb folds one async command stream");
     }
 
     // Fixed args 7-9 must be real function parameters, not compiler-frame offsets. This is the exact

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -122,6 +122,14 @@ int main() {
         CHECK(vmip1.base == 0x18000000ull + 827392 && vmip1.width == 1024 &&
                   vmip1.height == 576 && vmip1.mip_offset == 827392,
               "non-tail base-level view applies its proven offset and dimensions");
+        tmip[3] = (tmip[3] & ~(0xfu << 12)) | (7u << 12); // BASE_LEVEL 7, first packed-tail mip
+        const DecodedImageDescriptor dmip7 = decode_image_descriptor(tmip);
+        const DecodedImageView vmip7 = image_base_level_view(dmip7, mip_format);
+        CHECK(vmip7.supported && vmip7.in_mip_tail && vmip7.base == 0x18000000ull &&
+                  vmip7.width == 16 && vmip7.height == 9 && vmip7.mip_offset == 2048 &&
+                  vmip7.mip_tail_bytes == 4096 && vmip7.mip_tail_x == 4 &&
+                  vmip7.mip_tail_y == 0,
+              "packed-tail base level keeps the shared block base and exact in-block origin");
         uint32_t tmip_cube[8]; memcpy(tmip_cube, tmip, sizeof tmip_cube);
         tmip_cube[3] = (tmip_cube[3] & ~(0xfu << 28)) | (11u << 28); // CUBE
         const DecodedImageDescriptor dmip_cube = decode_image_descriptor(tmip_cube);
@@ -129,11 +137,29 @@ int main() {
         CHECK(!vmip_cube.supported && vmip_cube.base == dmip_cube.base &&
                   vmip_cube.mip_offset == 0,
               "nonzero cube mip view is rejected until its slice/tail layout is modeled");
-        tmip[3] &= ~(0x1fu << 20); // linear layout: offset is not modeled by the tiled helper
+        tmip[3] &= ~(0x1fu << 20); // SW_MODE 0: AddrLib linear mip chain
         const DecodedImageDescriptor dlinear = decode_image_descriptor(tmip);
         const DecodedImageView vlinear = image_base_level_view(dlinear, mip_format);
-        CHECK(!vlinear.supported && vlinear.base == dlinear.base && vlinear.mip_offset == 0,
-              "unmodeled nonzero linear mip view is rejected instead of sampling level zero");
+        CHECK(vlinear.supported && !vlinear.in_mip_tail &&
+                  vlinear.base == dlinear.base + 2048 && vlinear.mip_offset == 2048 &&
+                  vlinear.width == 16 && vlinear.height == 9,
+              "linear mip view uses AddrLib's reverse, 256-byte-pitch-aligned placement");
+
+        // Exact Astro final-pyramid storage T#. PS5 AGC encodes BASE=LAST=MAX_MIP+1 for this final
+        // view; accept that single observed extension and derive the level-6 tail geometry.
+        const uint32_t astro_tail_tsharp[8] = {
+            0x05600400u, 0xc4700000u, 0x010dc1dfu, 0x91b66facu,
+            0x00000000u, 0x00700050u, 0x00000000u, 0x00000000u,
+        };
+        const DecodedImageDescriptor dastro = decode_image_descriptor(astro_tail_tsharp);
+        Gen5ImageFormatInfo astro_format;
+        CHECK(gen5_image_format(dastro.format, &astro_format),
+              "Astro final-pyramid storage format is mapped");
+        const DecodedImageView vastro = image_base_level_view(dastro, astro_format);
+        CHECK(dastro.base_level == 6 && dastro.last_level == 6 && dastro.max_mip == 5 &&
+                  vastro.supported && vastro.in_mip_tail && vastro.width == 30 &&
+                  vastro.height == 16 && vastro.base == dastro.base,
+              "PS5 final-pyramid BASE=LAST=MAX_MIP+1 descriptor resolves to its packed tail view");
     }
 
     // A shifted thin-2D mip emits the selected extent and a matching backing span. Allocation-level
@@ -156,14 +182,32 @@ int main() {
         CHECK(mip && mip->gpu_addr == 0x18000000ull + 827392 && mip->width == 1024 &&
                   mip->height == 576 && mip->size == 1024u * 576u * 4u,
               "shifted mip resource uses selected address, extent, and backing span");
+        CHECK(mip && !mip->in_mip_tail && mip->mip_tail_offset == 0 &&
+                  mip->mip_tail_bytes == 0 && mip->mip_tail_x == 0 && mip->mip_tail_y == 0,
+              "ordinary shifted mip does not leak its allocation offset into packed-tail state");
         CHECK(mip && !mip->compression_enabled && !mip->write_compress_enabled &&
                   !mip->meta_pipe_aligned && mip->metadata_addr == 0,
               "shifted mip resource does not pair texels with unshifted DCC metadata");
 
-        sg[3] &= ~(0x1fu << 20); // same nonzero BASE_LEVEL, now an unsupported linear chain
-        const ShaderResourceTable unsupported = build_shader_resources(sh, sg, 8);
-        CHECK(!unsupported.by_sgpr_base(0),
-              "resource builder rejects an unmodeled nonzero mip view instead of binding level zero");
+        sg[3] = (sg[3] & ~(0xfu << 12)) | (7u << 12);
+        const ShaderResourceTable tail_resources = build_shader_resources(sh, sg, 8);
+        const ShaderResource* tail = tail_resources.by_sgpr_base(0);
+        CHECK(tail && tail->gpu_addr == 0x18000000ull && tail->width == 16 &&
+                  tail->height == 9 && tail->size == 16u * 9u * 4u &&
+                  tail->in_mip_tail && tail->mip_tail_offset == 2048 &&
+                  tail->mip_tail_bytes == 4096 && tail->mip_tail_x == 4 &&
+                  tail->mip_tail_y == 0,
+              "packed-tail resource retains the shared base and exact swizzled level coordinate");
+        CHECK(tail && !tail->compression_enabled && tail->metadata_addr == 0,
+              "packed-tail resource cannot reuse allocation-level DCC metadata");
+
+        sg[3] &= ~(0x1fu << 20); // same BASE_LEVEL 7, now an AddrLib linear chain
+        const ShaderResourceTable linear_resources = build_shader_resources(sh, sg, 8);
+        const ShaderResource* linear = linear_resources.by_sgpr_base(0);
+        CHECK(linear && linear->gpu_addr == 0x18000000ull + 2048 &&
+                  linear->width == 16 && linear->height == 9 && !linear->in_mip_tail &&
+                  linear->mip_tail_offset == 0 && linear->mip_tail_bytes == 0,
+              "resource builder exposes a shifted linear mip view instead of dropping it");
     }
 
     // --- AGC semantic metadata -> SPI_PS_INPUT_CNTL wiring ------------------------------------

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -28,7 +28,8 @@ static void make_vsharp(uint32_t v[4], uint64_t base, uint32_t stride, uint32_t 
 // Width5-1 split over word1[31:30] (lo) + word2[11:0] (hi), Height5-1 @word2[27:14], TileMode
 // @word3[24:20], Type @word3[31:28]. Mirrors decode_image_descriptor / Kyty's Gen5 getters.
 static void make_tsharp(uint32_t t[8], uint64_t base, uint32_t w, uint32_t h, uint32_t fmt,
-                        uint32_t tile_mode, uint32_t type, uint32_t depth = 1) {
+                        uint32_t tile_mode, uint32_t type, uint32_t depth = 1,
+                        uint32_t base_array = 0) {
     memset(t, 0, 8 * sizeof(uint32_t));
     uint64_t b = base >> 8;                       // 256-byte-aligned base, stored >>8
     t[0] = (uint32_t)(b & 0xffffffffu);
@@ -36,6 +37,8 @@ static void make_tsharp(uint32_t t[8], uint64_t base, uint32_t w, uint32_t h, ui
     t[2] = (((w - 1) >> 2) & 0xfffu) | (((h - 1) & 0x3fffu) << 14);
     t[3] = ((tile_mode & 0x1fu) << 20) | ((type & 0xfu) << 28);
     if (type == 10) t[4] = (depth - 1) & 0x1fffu;
+    if (type == 11 || type == 12 || type == 13 || type == 15)
+        t[4] = (base_array << 16) | ((base_array + depth - 1) & 0x1fffu);
 }
 
 int main() {
@@ -97,6 +100,17 @@ int main() {
         const DecodedImageDescriptor d3d = decode_image_descriptor(t3d);
         CHECK(d3d.width == 32 && d3d.height == 16 && d3d.depth == 8,
               "3D T# word4 DEPTH decodes as depth-minus-one");
+
+        uint32_t tarray[8];
+        make_tsharp(tarray, 0x13000000ull, 32, 16, /*fmt*/56, /*tile*/0,
+                    /*type 2D array*/13, /*depth*/4, /*base array*/4);
+        const DecodedImageDescriptor darray = decode_image_descriptor(tarray);
+        CHECK(darray.base_array == 4 && darray.depth == 4,
+              "array T# derives layer count from LAST_ARRAY minus BASE_ARRAY");
+        Gen5ImageFormatInfo array_format;
+        CHECK(gen5_image_format(56, &array_format) &&
+              !image_base_level_view(darray, array_format).supported,
+              "nonzero BASE_ARRAY fails closed until slice-offset layout is modeled");
         CHECK(d3d.compression_enabled && d3d.write_compress_enabled && d3d.meta_pipe_aligned &&
               d3d.alpha_is_on_msb && d3d.color_transform &&
               d3d.max_uncompressed_block_size == 2 && d3d.max_compressed_block_size == 1 &&

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -27,7 +27,7 @@ static int fails = 0;
 
 // Pool bounds mirror hle_kernel_mem.cpp (kDmemBase / kDmemTotal).
 static constexpr uint64_t kBase  = 0x10000000ull;
-static constexpr uint64_t kTotal = 8ull * 1024 * 1024 * 1024;
+static constexpr uint64_t kTotal = 16ull * 1024 * 1024 * 1024;
 static constexpr uint64_t kEnd   = kBase + kTotal;
 
 int main() {
@@ -281,6 +281,44 @@ int main() {
               "map direct memory honors requested 64KiB VA alignment");
         if (va) munmap((void*)(uintptr_t)va, 0x10000);
         if (p) release(p, 0x10000, 0, 0, 0, 0);
+    }
+
+    // A non-fixed direct-memory address is a search hint. Astro Bot supplies the eboot base as
+    // its preferred address; treating every non-zero input as fixed returned ENOMEM instead of
+    // relocating the mapping. A genuinely fixed collision must still fail without clobbering it.
+    {
+        constexpr uint64_t len = 0x10000;
+        uint64_t p = 0;
+        void* live = mmap(nullptr, len, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        CHECK(live != MAP_FAILED, "create a live mapping for direct-memory hint collision");
+        if (live != MAP_FAILED) {
+            *(volatile uint32_t*)live = 0xA57B0782u;
+            uint64_t hinted = (uint64_t)(uintptr_t)live;
+            uint64_t rr = alloc(0, kEnd, len, len, 0, (uint64_t)(uintptr_t)&p);
+            CHECK(rr == 0 && p, "allocate direct memory for occupied-hint test");
+            if (rr == 0 && p) {
+                rr = map((uint64_t)(uintptr_t)&hinted, len, 0x2 /*RW*/, 0,
+                         p, len);
+                CHECK(rr == 0 && hinted && hinted != (uint64_t)(uintptr_t)live,
+                      "non-fixed occupied direct-memory hint relocates");
+                CHECK(hinted >= 0x2000000000ull && hinted < 0x40000000000ull,
+                      "relocated direct mapping stays in the guest user-VA range");
+                CHECK(*(volatile uint32_t*)live == 0xA57B0782u,
+                      "relocated direct mapping does not clobber the live hint");
+                if (hinted && hinted != (uint64_t)(uintptr_t)live)
+                    munmap((void*)(uintptr_t)hinted, len);
+
+                uint64_t fixed_hint = (uint64_t)(uintptr_t)live;
+                rr = map((uint64_t)(uintptr_t)&fixed_hint, len, 0x2 /*RW*/,
+                         0x10 /*SCE_KERNEL_MAP_FIXED*/, p, len);
+                CHECK(rr != 0, "fixed occupied direct-memory hint fails");
+                CHECK(*(volatile uint32_t*)live == 0xA57B0782u,
+                      "failed fixed direct mapping preserves the live range");
+                release(p, len, 0, 0, 0, 0);
+            }
+            munmap(live, len);
+        }
     }
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -258,6 +258,35 @@ int main() {
           direct_v_uses[0].v4[1] == seed5v[1] && direct_v_uses[0].v4[2] == seed5v[2],
           "direct raw-MUBUF V# preserves base/stride/record dwords");
 
+    // Astro Bot's compact compute dispatcher s_loads output V#s from a table, then consumes them
+    // with buffer_store_dword/dwordx2/dwordx3. Stores need the same descriptor provenance as raw
+    // loads or the compute resource front-half never creates their writable storage-buffer binding.
+    static uint32_t store_output[16];
+    static uint32_t store_table[8];
+    const uint64_t store_output_base = (uint64_t)(uintptr_t)store_output;
+    store_table[4] = (uint32_t)store_output_base;
+    store_table[5] = (uint32_t)(store_output_base >> 32) & 0xFFFFu;
+    store_table[6] = 16u;
+    store_table[7] = 4u << 12;
+    const uint64_t store_table_base = (uint64_t)(uintptr_t)store_table;
+    const uint32_t k5vs[] = {
+        0xF4080504u, 0xFA000010u,   // s_load_dwordx4 s[20:23], s[8:9], 0x10
+        0xE0702000u, 0x80051100u,   // buffer_store_dword v17, v0, s[20:23], 0 idxen
+        0xBF810000u,
+    };
+    const uint32_t seed5vs[2] = {
+        (uint32_t)store_table_base, (uint32_t)(store_table_base >> 32),
+    };
+    std::vector<SrtUse> store_uses;
+    resolve_dynamic_fetch(k5vs, sizeof(k5vs) / sizeof(k5vs[0]), seed5vs, 2, 8,
+                          &store_uses);
+    CHECK(store_uses.size() == 1 && store_uses[0].kind == 1 &&
+          store_uses[0].key == 0x10 && store_uses[0].use_pc == 2,
+          "table-loaded V# resolves raw buffer_store_dword by SRT key");
+    CHECK(store_uses.size() == 1 && store_uses[0].v4[0] == store_table[4] &&
+          store_uses[0].v4[1] == store_table[5] && store_uses[0].v4[2] == 16u,
+          "raw buffer-store V# preserves the table-loaded descriptor dwords");
+
     // Kernel 5dr: once any T# SGPR is reloaded, the initial sharp is stale. An unresolved reload must
     // not silently resurrect it and fabricate a texture mapping for the later image operation.
     const uint32_t k5dr[] = {

--- a/prosper/tests/test_fiber.cpp
+++ b/prosper/tests/test_fiber.cpp
@@ -1,0 +1,100 @@
+#include "../src/hle/dispatch.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+using namespace prosper;
+
+static uint64_t seen_initialize, seen_run[2], resumed[2];
+static int entries;
+#ifdef _WIN32
+static bool fiber_bounds_valid[2];
+static bool root_bounds_valid[2];
+
+static bool current_stack_contains(const void* address) {
+    NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+    return (uintptr_t)address >= (uintptr_t)tib->StackLimit &&
+           (uintptr_t)address < (uintptr_t)tib->StackBase;
+}
+#endif
+
+extern "C" void fiber_body_ms(uint64_t initialize_arg, uint64_t run_arg) {
+    uint8_t fiber_local = 0;
+#ifdef _WIN32
+    fiber_bounds_valid[0] = current_stack_contains(&fiber_local);
+#endif
+    seen_initialize = initialize_arg;
+    seen_run[0] = run_arg;
+    auto yield = Hle::lookup("B0ZX2hx9DMw");
+    uint64_t next = 0;
+    yield(0x1111, (uint64_t)(uintptr_t)&next, 0, 0, 0, 0);
+    resumed[0] = next;
+#ifdef _WIN32
+    fiber_bounds_valid[1] = current_stack_contains(&fiber_local);
+#endif
+    seen_run[1] = next;
+    yield(0x2222, (uint64_t)(uintptr_t)&next, 0, 0, 0, 0);
+    resumed[1] = next;
+    ++entries;
+}
+
+#ifdef _WIN32
+// The production fiber entry is guest SysV code.  Keep this test's body as ordinary Microsoft-x64
+// C++ (so MinGW can emit valid SEH metadata) and use a tiny assembly guest entry to marshal its two
+// arguments.  Applying sysv_abi directly to a MinGW function with EH state produces invalid .seh data.
+extern "C" void fiber_body_guest();
+__asm__(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl fiber_body_guest\n"
+    "fiber_body_guest:\n"
+    "  movq %rdi,%rcx\n"
+    "  movq %rsi,%rdx\n"
+    "  subq $40,%rsp\n"
+    "  call fiber_body_ms\n"
+    "  addq $40,%rsp\n"
+    "  ret\n"
+);
+#else
+#define fiber_body_guest fiber_body_ms
+#endif
+
+static int fails;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    register_builtin_hle();
+    using InitFn = uint64_t (*)(void*, const char*, void*, uint64_t, void*, uint64_t,
+                                const void*, uint32_t);
+    auto init = reinterpret_cast<InitFn>(Hle::lookup("hVYD7Ou2pCQ"));
+    auto run = Hle::lookup("a0LLrZWac0M");
+    alignas(16) uint8_t fiber[256]{};
+    alignas(16) uint8_t stack[64 * 1024]{};
+    CHECK(init && run && init(fiber, "test", (void*)fiber_body_guest, 0xabc, stack, sizeof(stack),
+                              nullptr, 0) == 0,
+          "fiber initializes with a guest-provided stack");
+    uint64_t returned = 0;
+    CHECK(run((uint64_t)(uintptr_t)fiber, 0x10, (uint64_t)(uintptr_t)&returned, 0, 0, 0) == 0 &&
+          returned == 0x1111 && seen_initialize == 0xabc && seen_run[0] == 0x10,
+          "first run enters the guest stack and yields to its thread");
+#ifdef _WIN32
+    uint8_t root_local = 0;
+    root_bounds_valid[0] = current_stack_contains(&root_local);
+#endif
+    CHECK(run((uint64_t)(uintptr_t)fiber, 0x20, (uint64_t)(uintptr_t)&returned, 0, 0, 0) == 0 &&
+          returned == 0x2222 && resumed[0] == 0x20 && seen_run[1] == 0x20,
+          "second run resumes the suspended guest call stack");
+#ifdef _WIN32
+    root_bounds_valid[1] = current_stack_contains(&root_local);
+    CHECK(fiber_bounds_valid[0] && fiber_bounds_valid[1],
+          "Windows TEB describes the Sony fiber stack on entry and resume");
+    CHECK(root_bounds_valid[0] && root_bounds_valid[1],
+          "Windows TEB restores the native root stack after each fiber yield");
+#endif
+    std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_font.cpp
+++ b/prosper/tests/test_font.cpp
@@ -19,7 +19,10 @@ int main() {
     auto text_init = Hle::lookup("oaJ1BpN2FQk");
     auto create_string = Hle::lookup("MO24vDhmS4E");
     auto chars = Hle::lookup("Avv7OApgCJk");
-    CHECK(create && open_set && metrics && text_init && create_string && chars,
+    auto destroy_string = Hle::lookup("SSCaczu2aMQ");
+    auto close_font = Hle::lookup("vzHs3C8lWJk");
+    CHECK(create && open_set && metrics && text_init && create_string && chars &&
+          destroy_string && close_font,
           "Astro Font HLE surface is registered");
 
     uint8_t mem[64]{};
@@ -46,6 +49,10 @@ int main() {
     uint32_t count = 0xdeadbeef;
     CHECK(chars((uint64_t)(uintptr_t)string, (uint64_t)(uintptr_t)&count, 0, 0, 0, 0) == 0 && count == 0,
           "fallback string exposes a safe empty character range");
+    CHECK(destroy_string((uint64_t)(uintptr_t)&string, 0, 0, 0, 0, 0) == 0 && !string,
+          "DestroyString releases and clears the opaque string handle");
+    CHECK(close_font((uint64_t)(uintptr_t)font, 0, 0, 0, 0, 0) == 0,
+          "CloseFont releases the opened face");
 
     std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
     return fails ? 1 : 0;

--- a/prosper/tests/test_font.cpp
+++ b/prosper/tests/test_font.cpp
@@ -1,0 +1,52 @@
+#include "../src/hle/dispatch.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    register_builtin_hle();
+    auto create = Hle::lookup("n590hj5Oe-k");
+    auto open_set = Hle::lookup("cKYtVmeSTcw");
+    auto metrics = Hle::lookup("IQtleGLL5pQ");
+    auto text_init = Hle::lookup("oaJ1BpN2FQk");
+    auto create_string = Hle::lookup("MO24vDhmS4E");
+    auto chars = Hle::lookup("Avv7OApgCJk");
+    CHECK(create && open_set && metrics && text_init && create_string && chars,
+          "Astro Font HLE surface is registered");
+
+    uint8_t mem[64]{};
+    void* library = nullptr;
+    CHECK(create((uint64_t)(uintptr_t)mem, 0, 0, (uint64_t)(uintptr_t)&library, 0, 0) == 0 && library,
+          "CreateLibraryWithEdition writes a non-null library handle");
+    void* font = nullptr;
+    CHECK(open_set((uint64_t)(uintptr_t)library, 0, 0, 0,
+                   (uint64_t)(uintptr_t)&font, 0) == 0 && font,
+          "OpenFontSet writes a non-null font handle");
+    float glyph[8]{};
+    CHECK(metrics((uint64_t)(uintptr_t)font, 'A', (uint64_t)(uintptr_t)glyph, 0, 0, 0) == 0 &&
+          glyph[0] > 0.0f && glyph[1] > 0.0f && glyph[4] > 0.0f,
+          "glyph metrics are deterministic and non-zero");
+
+    uint8_t source[0x60]; std::memset(source, 0xcc, sizeof(source));
+    const char text[] = "ASTRO";
+    CHECK(text_init((uint64_t)(uintptr_t)source, (uint64_t)(uintptr_t)text, sizeof(text), 0, 0, 0) == 0,
+          "TextSourceInit initializes the public source layout");
+    void* string = nullptr;
+    CHECK(create_string((uint64_t)(uintptr_t)mem, (uint64_t)(uintptr_t)source, 0,
+                        (uint64_t)(uintptr_t)&string, 0, 0) == 0 && string,
+          "CreateString writes an opaque string handle");
+    uint32_t count = 0xdeadbeef;
+    CHECK(chars((uint64_t)(uintptr_t)string, (uint64_t)(uintptr_t)&count, 0, 0, 0, 0) == 0 && count == 0,
+          "fallback string exposes a safe empty character range");
+
+    std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -116,6 +116,42 @@ int main() {
           captured.operations[0].source_index == 7 && captured.operations[0].realized,
           "capture indexes unique shaders and retains operation provenance");
 
+    // v15: a packed mip-tail view captures the shared macroblock and retains both AddrLib origins.
+    std::vector<uint8_t> tail_memory(65536, 0x6d);
+    auto tail_reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr < 0x900000 || addr >= 0x900000 + tail_memory.size()) return 0;
+        const size_t offset = static_cast<size_t>(addr - 0x900000);
+        const size_t take = std::min(n, tail_memory.size() - offset);
+        std::memcpy(dst, tail_memory.data() + offset, take);
+        return take;
+    };
+    ShaderResource tail_resource{};
+    tail_resource.cls = ResourceClass::Texture; tail_resource.binding = 3;
+    tail_resource.gpu_addr = 0x900000; tail_resource.size = 60 * 33 * 4;
+    tail_resource.format = DataFormat::Uint32; tail_resource.num_components = 1;
+    tail_resource.width = 60; tail_resource.height = 33;
+    tail_resource.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+    tail_resource.in_mip_tail = true; tail_resource.mip_tail_offset = 32768;
+    tail_resource.mip_tail_bytes = 65536; tail_resource.mip_tail_x = 64;
+    tail_resource.mip_tail_y = 0;
+    auto tail_table = std::make_shared<ShaderResourceTable>();
+    tail_table->resources = {tail_resource};
+    DrawItem tail_draw = draw; tail_draw.vrt = tail_table;
+    GpuCaptureFile tail_capture;
+    CHECK(capture_draw_items({tail_draw}, meta, tail_reader, tail_capture, error) &&
+              tail_capture.blobs.size() == 1 && tail_capture.blobs[0].bytes.size() == 65536,
+          "packed mip-tail capture owns the complete shared 64 KiB macroblock");
+    std::vector<uint8_t> tail_bytes;
+    GpuCaptureFile tail_loaded;
+    CHECK(serialize_gpu_capture(tail_capture, tail_bytes, error) &&
+              deserialize_gpu_capture(tail_bytes, tail_loaded, error) &&
+              tail_loaded.draws[0].vrt.resources[0].resource.in_mip_tail &&
+              tail_loaded.draws[0].vrt.resources[0].resource.mip_tail_offset == 32768 &&
+              tail_loaded.draws[0].vrt.resources[0].resource.mip_tail_bytes == 65536 &&
+              tail_loaded.draws[0].vrt.resources[0].resource.mip_tail_x == 64 &&
+              tail_loaded.draws[0].vrt.resources[0].resource.mip_tail_y == 0,
+          "v15 capture round-trips packed-tail byte and coordinate placement exactly");
+
     auto large_table = std::make_shared<ShaderResourceTable>();
     ShaderResource large_resource = a;
     large_resource.size = 2u << 20;
@@ -213,6 +249,8 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 21); // v15 count plus one 17-byte mip-tail state
+    volume_bytes.resize(volume_bytes.size() - 5); // v14 count plus one depth-compare flag
     volume_bytes.resize(volume_bytes.size() - 24); // v12 count plus one 20-byte reference
     volume_bytes[8] = 11; volume_bytes[9] = volume_bytes[10] = volume_bytes[11] = 0;
     CHECK(deserialize_gpu_capture(volume_bytes, volume_loaded, error) &&
@@ -477,10 +515,14 @@ int main() {
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 28,
-          "created a diagnostic-free v13 payload for legacy-reader fixtures");
+          "created a diagnostic-free v15 payload for legacy-reader fixtures");
     if (legacy_bytes.size() >= 28) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        // Remove the v15 mip-tail tail: count + one 17-byte state per resource.
+        legacy_bytes.resize(legacy_bytes.size() - (4 + 17 * legacy_resource_count));
+        // Remove the v14 depth-compare tail: count + one flag per resource.
+        legacy_bytes.resize(legacy_bytes.size() - (4 + legacy_resource_count));
         // Remove the v12 DCC metadata-reference tail: count + 20-byte reference per resource.
         legacy_bytes.resize(legacy_bytes.size() - (4 + 20 * legacy_resource_count));
         // Remove the v11 DCC tail: count + 17-byte state record per resource.
@@ -520,9 +562,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 14;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 16;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 14",
+          error == "unsupported capture version 16",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;
@@ -575,6 +617,21 @@ int main() {
           exported_ds[0].depth_read_base == 0x710000 &&
           exported_ds[1].depth_read_base == 0xa10000,
           "registered DS snapshot reader validates and sorts the complete live cache");
+    GpuCaptureFile referenced_ds_capture;
+    referenced_ds_capture.draws.resize(1);
+    referenced_ds_capture.draws[0].color0_width = 2;
+    referenced_ds_capture.draws[0].color0_height = 2;
+    referenced_ds_capture.draws[0].ps.depth_test_enable = true;
+    referenced_ds_capture.draws[0].ps.depth_read_base = 0xa10000;
+    referenced_ds_capture.draws[0].ps.depth_write_base = 0xa10000;
+    referenced_ds_capture.draws[0].ps.stencil_read_base = ds_seed.stencil_read_base;
+    referenced_ds_capture.draws[0].ps.stencil_write_base = ds_seed.stencil_write_base;
+    referenced_ds_capture.draws[0].ps.htile_data_base = ds_seed.htile_data_base;
+    CHECK(gpu_capture_ds_seed_snapshot_available() &&
+          capture_referenced_gpu_ds_seeds(referenced_ds_capture, error) &&
+          referenced_ds_capture.ds_seeds.size() == 1 &&
+          referenced_ds_capture.ds_seeds[0].depth_read_base == 0xa10000,
+          "standalone capture retains only the exact referenced live DS checkpoint");
     GpuCaptureDsSeed restored_ds;
     set_gpu_replay_ds_seed_writer([&](const GpuCaptureDsSeed& seed, std::string&) {
         restored_ds = seed; return true;

--- a/prosper/tests/test_guest_tls_align.cpp
+++ b/prosper/tests/test_guest_tls_align.cpp
@@ -1,11 +1,11 @@
 // test_guest_tls_align — the x86-64 Variant II static-TLS layout must round each module's offset to
 // its REAL PT_TLS p_align (#143), not a hardcoded 16. Otherwise a module with p_align > 16 gets its
 // block at the wrong distance below the thread pointer and every initial-exec %fs:-N access resolves
-// off. Drives guest_tls_set_templates (which computes the layout regardless of the PROSPER_GUEST_FS
-// gate) and reads back the per-module offsets. Linux-only (the layout code is __linux__).
+// off. Drives guest_tls_set_templates and reads back the per-module offsets. Linux-only.
 #include "../src/hle/dispatch.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 using namespace prosper;
@@ -18,6 +18,9 @@ static uint64_t align_up(uint64_t v, uint64_t a) { return (v + a - 1) & ~(a - 1)
 
 int main() {
     printf("== test_guest_tls_align ==\n");
+#if defined(__linux__)
+    unsetenv("PROSPER_NO_GUEST_FS");
+#endif
 
     // descs[0] is the reserved slot (module id 0 = "no TLS"); real modules start at index 1.
     // Module 1: memsz 0x30, p_align 64 (aligned TLS vars — the case the old 16-hardcode broke).
@@ -28,6 +31,9 @@ int main() {
         { 0, 0, /*memsz*/0x10, /*align*/16 },
     };
     guest_tls_set_templates(descs.data(), descs.size());
+#if defined(__linux__)
+    CHECK(guest_tls_enabled(), "guest initial-exec TLS is enabled by default on Linux");
+#endif
 
     // Variant II: off[i] = round_up(off[i-1] + memsz[i], align[i]); block start = TP - off[i].
     uint64_t exp1 = align_up(0 + 0x30, 64);          // = 0x40 (rounded to 64, NOT 0x30)

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -5,7 +5,9 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <atomic>
+#include <array>
 #include <cstdio>
+#include <limits>
 #include <thread>
 
 using namespace prosper;
@@ -64,21 +66,30 @@ int main() {
     if (HleFn fn = Hle::lookup(nid_hash("scePthreadGetthreadid"))) {
         const uint64_t main_id = fn(0, 0, 0, 0, 0, 0);
         const uint64_t main_id_again = fn(0, 0, 0, 0, 0, 0);
-        std::atomic<uint64_t> worker_id{0};
-        std::atomic<uint64_t> worker_id_again{0};
-        std::thread worker([&] {
-            worker_id.store(fn(0, 0, 0, 0, 0, 0), std::memory_order_relaxed);
-            worker_id_again.store(fn(0, 0, 0, 0, 0, 0), std::memory_order_relaxed);
-        });
-        worker.join();
-        if (main_id == 0 || main_id != main_id_again) {
-            printf("  [FAIL] scePthreadGetthreadid is zero or unstable on the main thread\n");
+        std::array<std::atomic<uint64_t>, 2> worker_id{};
+        std::array<std::atomic<uint64_t>, 2> worker_id_again{};
+        std::array<std::thread, 2> workers;
+        for (size_t i = 0; i < workers.size(); ++i) {
+            workers[i] = std::thread([&, i] {
+                worker_id[i].store(fn(0, 0, 0, 0, 0, 0), std::memory_order_relaxed);
+                worker_id_again[i].store(fn(0, 0, 0, 0, 0, 0), std::memory_order_relaxed);
+            });
+        }
+        for (auto& worker : workers) worker.join();
+        if (main_id == 0 || main_id > std::numeric_limits<int32_t>::max() ||
+            main_id != main_id_again) {
+            printf("  [FAIL] scePthreadGetthreadid is not a stable positive guest ID on the main thread\n");
             fails++;
         }
-        if (worker_id.load(std::memory_order_relaxed) == 0 ||
-            worker_id.load(std::memory_order_relaxed) != worker_id_again.load(std::memory_order_relaxed) ||
-            worker_id.load(std::memory_order_relaxed) == main_id) {
-            printf("  [FAIL] scePthreadGetthreadid does not distinguish concurrent threads\n");
+        const uint64_t worker0 = worker_id[0].load(std::memory_order_relaxed);
+        const uint64_t worker1 = worker_id[1].load(std::memory_order_relaxed);
+        if (worker0 == 0 || worker1 == 0 ||
+            worker0 > std::numeric_limits<int32_t>::max() ||
+            worker1 > std::numeric_limits<int32_t>::max() ||
+            worker0 != worker_id_again[0].load(std::memory_order_relaxed) ||
+            worker1 != worker_id_again[1].load(std::memory_order_relaxed) ||
+            worker0 == main_id || worker1 == main_id || worker0 == worker1) {
+            printf("  [FAIL] scePthreadGetthreadid does not assign stable, distinct guest IDs\n");
             fails++;
         }
     } else { printf("  [FAIL] not registered: scePthreadGetthreadid\n"); fails++; }

--- a/prosper/tests/test_map_noreplace.cpp
+++ b/prosper/tests/test_map_noreplace.cpp
@@ -30,6 +30,8 @@ int main() {
     // 1. Commit a range via MapFlexible at hint=0 (kernel picks a free VA), write a sentinel.
     uint64_t va = 0;
     CHECK(flexible(U(&va), LEN, 0x2 /*RW*/, 0, U("live"), 0) == 0 && va, "MapFlexible(hint=0) succeeds");
+    CHECK(va >= 0x2000000000ull && va < 0x40000000000ull,
+          "automatic flexible mapping stays in the guest user-VA range");
     volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)va;
     *cell = 0xC0FFEE42u;
 

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -200,6 +201,41 @@ int main() {
         const uint8_t* c = center(initialized);
         CHECK(c && c[1] > 0xC0 && c[0] < 0x40,
               "stencil-only initialization does not poison a later reverse-Z depth plane");
+    }
+
+    // Programming DB_DEPTH_CLEAR only updates clear state; it does not clear a depth allocation until
+    // DB_RENDER_CONTROL enables the clear. Treating a stale programmed word as the implicit contents of
+    // a newly-created host image can reject every fragment. Astro Bot exposes this with 0x0437077f --
+    // its packed 1919x1079 surface maxima, interpreted as the tiny float 2.15e-36 -- under LEQUAL.
+    {
+        std::vector<uint32_t> mid_depth_vs = ref_vs_with_depth(vs, 0x3f000000u); // 0.5f
+        CHECK(!mid_depth_vs.empty(), "fullscreen VS can expose stale depth-clear initialization");
+
+        ResolvedPipelineState stale = opaque;
+        stale.depth_test_enable = true;
+        stale.depth_compare_op = 3; // LEQUAL
+        stale.has_depth_clear = true;
+        uint32_t packed_extent = 0x0437077fu;
+        std::memcpy(&stale.depth_clear_value, &packed_extent, sizeof(packed_extent));
+        stale.depth_read_base = stale.depth_write_base = 0x77770000;
+
+        prosper::test::BackendDraw s;
+        s.vs = mid_depth_vs; s.fs = green; s.ps = &stale; s.vcount = 3;
+        std::vector<uint8_t> implicit =
+            prosper::test::render_draws_rgba({s}, W, H, nullptr, nullptr, true);
+        const uint8_t* ic = center(implicit);
+        CHECK(ic && ic[1] > 0xC0 && ic[0] < 0x40,
+              "stale DB_DEPTH_CLEAR does not initialize an uncleared LEQUAL surface");
+
+        ResolvedPipelineState explicit_clear = stale;
+        explicit_clear.depth_clear_enable = true;
+        explicit_clear.depth_read_base = explicit_clear.depth_write_base = 0x88880000;
+        prosper::test::BackendDraw e = s; e.ps = &explicit_clear;
+        std::vector<uint8_t> explicitly_rejected =
+            prosper::test::render_draws_rgba({e}, W, H, nullptr, nullptr, true);
+        const uint8_t* ec = center(explicitly_rejected);
+        CHECK(ec && ec[1] < 0x80,
+              "explicit DB_RENDER_CONTROL clear still consumes the programmed depth value");
     }
 
     // UE4 can emit its reverse-Z depth prepass and EQUAL base pass from different shaders. Their

--- a/prosper/tests/test_posix_sem.cpp
+++ b/prosper/tests/test_posix_sem.cpp
@@ -1,0 +1,44 @@
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+
+using namespace prosper;
+
+static int failures;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++failures; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    register_builtin_hle();
+    auto init = Hle::lookup(nid_hash("sem_init"));
+    auto wait = Hle::lookup(nid_hash("sem_wait"));
+    auto post = Hle::lookup(nid_hash("sem_post"));
+    auto destroy = Hle::lookup(nid_hash("sem_destroy"));
+    CHECK(init && wait && post && destroy, "plain libScePosix semaphore imports are registered");
+
+    alignas(16) uint8_t sem[32]{};
+    CHECK(init((uint64_t)sem, 0, 0, 0, 0, 0) == 0, "zero-count semaphore initializes");
+
+    std::atomic<bool> entered{false}, released{false};
+    std::thread consumer([&] {
+        entered.store(true, std::memory_order_release);
+        const uint64_t rc = wait((uint64_t)sem, 0, 0, 0, 0, 0);
+        released.store(rc == 0, std::memory_order_release);
+    });
+    while (!entered.load(std::memory_order_acquire)) std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    CHECK(!released.load(std::memory_order_acquire), "sem_wait blocks while the count is zero");
+    CHECK(post((uint64_t)sem, 0, 0, 0, 0, 0) == 0, "sem_post wakes one waiter");
+    consumer.join();
+    CHECK(released.load(std::memory_order_acquire), "blocked waiter resumes successfully");
+    CHECK(destroy((uint64_t)sem, 0, 0, 0, 0, 0) == 0 && *(void**)sem == nullptr,
+          "semaphore destroys and clears its guest handle");
+
+    std::printf(failures ? "== FAIL: %d ==\n" : "== PASS ==\n", failures);
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -103,6 +103,18 @@ int main() {
           isS(mb.src[1], 8) && ((mb.literal >> 12) & 1u), "buffer_load_dwordx4 MUBUF op/VDATA/VADDR/SRSRC/offen");
     CHECK(mb.src[2].kind == OperandKind::InlineInt && mb.src[2].value == 0,
           "MUBUF SOFFSET 0x80 decodes as inline 0, not SGPR s0");
+    // Exact DS_READ2_B32 words from Astro Bot's loading-surface compute producer. The packed
+    // offset bytes are dword indices (offset0 in the low byte, offset1 in the high byte).
+    const uint32_t ds_read2_adjacent[] = { 0xd8dc0100u, 0x04000002u };
+    Rdna2Inst dr2a = rdna2_decode_one(ds_read2_adjacent, 2);
+    CHECK(dr2a.fmt == Rdna2Format::DS && dr2a.opcode == 0x37u && dr2a.literal == 0x0100u &&
+          isV(dr2a.src[0], 2) && isV(dr2a.dst, 4),
+          "Astro DS_READ2_B32 decodes adjacent offsets, ADDR v2, and VDST v4");
+    const uint32_t ds_read2_16_17[] = { 0xd8dc1110u, 0x02000002u };
+    Rdna2Inst dr2b = rdna2_decode_one(ds_read2_16_17, 2);
+    CHECK(dr2b.fmt == Rdna2Format::DS && dr2b.opcode == 0x37u && dr2b.literal == 0x1110u &&
+          isV(dr2b.src[0], 2) && isV(dr2b.dst, 2),
+          "Astro DS_READ2_B32 decodes non-zero offsets 16/17");
     // VOP SDWA/DPP forms carry a mandatory 2nd (control) dword — the decoder must count it (miss it and
     // the whole downstream stream mis-aligns) and flag has_modifier so the recompiler rejects it.
     // Encodings from llvm-mc gfx1030: SDWA src0=0xf9, DPP16 src0=0xfa, DPP8 src0=0xe9.
@@ -115,6 +127,16 @@ int main() {
     CHECK(fc.fmt == Rdna2Format::VOPC && fc.opcode == 0xDCu && !fc.has_modifier &&
           fc.sdwa_src0_sel == 5u && fc.sdwa_src1_sel == 6u,
           "VOPC f16 SDWA WORD_1 source select is decoded for recompilation");
+    const uint32_t cvt_byte[] = { 0x7e0a0cf9u, 0x0000160bu };
+    Rdna2Inst cb = rdna2_decode_one(cvt_byte, 2);
+    CHECK(cb.fmt == Rdna2Format::VOP1 && cb.opcode == 0x06u && !cb.has_modifier &&
+          isV(cb.dst, 5) && isV(cb.src[0], 11) && cb.sdwa_src0_sel == 0u,
+          "Astro v_cvt_f32_u32 SDWA BYTE_0 packet is admitted with exact sub-dword select");
+    const uint32_t cvt_signed_word[] = { 0x7e240af9u, 0x000d0610u };
+    Rdna2Inst csw = rdna2_decode_one(cvt_signed_word, 2);
+    CHECK(csw.fmt == Rdna2Format::VOP1 && csw.opcode == 0x05u && !csw.has_modifier &&
+          isV(csw.dst, 18) && isV(csw.src[0], 16) && csw.sdwa_src0_sel == 5u,
+          "Astro v_cvt_f32_i32 SDWA WORD_1+SEXT packet is admitted");
     const uint32_t dpp16[] = { 0x4a0e0cfau, 0xff011106u };   // v_add_nc_u32_dpp v7, v6, v6 row_shr:1
     Rdna2Inst dp = rdna2_decode_one(dpp16, 2);
     CHECK(dp.fmt == Rdna2Format::VOP2 && dp.len_dwords == 2 && dp.has_modifier,

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -12,6 +12,7 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include "compute_runner.h"
+#include <bit>
 #include <cstdio>
 #include <cmath>
 #include <cstring>
@@ -445,6 +446,77 @@ int main() {
     CHECK(got17d.size()==N && bad17d==0,
           "CFG dispatcher emulates a 64-lane wave across narrower Vulkan subgroups");
 
+    // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
+    // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises
+    // the generic dispatcher.  Wave 0's mask is empty and selects all lanes; wave 1 has one set bit in
+    // lane 63 (outside a narrow host subgroup) and must select none.
+    const uint32_t code17d2[] = {
+        0x7e040280u, 0x7c020300u, 0xbf860001u, 0x7e040281u,
+        0x7d840100u, 0xbf870001u, 0xbf82fffdu,
+        0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1
+        0xbe82046au,              // s_mov_b64 s[2:3], vcc
+        0xbf128002u,              // s_cmp_eq_u64 s[2:3], 0
+        0x858480c1u,              // s_cselect_b64 s[4:5], -1, 0
+        0xbefe0404u,              // s_mov_b64 exec, s[4:5]
+        0x7e040287u,              // v_mov_b32 v2, 7 (predicated by selected wave mask)
+        0xbefe04c1u,              // s_mov_b64 exec, -1
+        0x7e040d02u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv17d2 = recompile_valu(
+        code17d2, std::size(code17d2), 2, /*out_vgpr*/2);
+    CHECK(!spv17d2.empty(), "#825: recompiled CFG wave-mask u64 compare/cselect -> SPIR-V");
+    std::vector<float> got17d2 = prosper::test::run_compute(spv17d2, in17d, N, N);
+    uint32_t bad17d2 = 0;
+    for (uint32_t i = 0; i < N && got17d2.size() == N; ++i) {
+        const float expected = i < 64 ? 7.0f : 1.0f;
+        if (got17d2[i] != expected) ++bad17d2;
+    }
+    CHECK(got17d2.size() == N && bad17d2 == 0,
+          "#825: dispatcher reduces mask==0 across the full emulated wave64");
+
+    // Kernel 17e: the same irreducible-for-the-narrow-structurizer CFG followed by MBCNT. The
+    // cross-lane pair must execute in the dispatcher's uniform common phase rather than beneath a
+    // switch case, where OpControlBarrier would be invalid and could deadlock a real Vulkan driver.
+    const uint32_t code17e[] = {
+        0x7e040280u,              // v_mov_b32 v2, 0
+        0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1
+        0xbf860001u,              // s_cbranch_vccz +1
+        0x7e040281u,              // v_mov_b32 v2, 1
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0
+        0xbf870001u,              // s_cbranch_vccnz +1
+        0xbf82fffdu,              // s_branch -3
+        0xd7650003u, 0x0001007eu, // v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+        0xd7660003u, 0x0002067fu, // v_mbcnt_hi_u32_b32 v3, exec_hi, v3
+        0x7e060d03u,              // v_cvt_f32_u32 v3, v3
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv17e = recompile_valu(
+        code17e, std::size(code17e), 2, /*out_vgpr*/3);
+    CHECK(!spv17e.empty(), "#825: recompiled CFG-dispatch MBCNT kernel -> SPIR-V");
+    std::vector<float> got17e = prosper::test::run_compute(spv17e, in17d, N, N);
+    uint32_t bad17e = 0;
+    for (uint32_t i = 0; i < N && got17e.size() == N; ++i)
+        if (std::fabs(got17e[i] - static_cast<float>(i % 64)) > 1e-3f) ++bad17e;
+    CHECK(got17e.size() == N && bad17e == 0,
+          "#825: CFG dispatcher synchronizes MBCNT across each emulated wave64");
+
+    // Kernel 17f: DS_APPEND in the same generic dispatcher. The LDS initial value is intentionally
+    // unspecified; this test verifies that the generated module executes to completion with the
+    // append atomic/barriers in uniform control flow. Exact append values are checked by kernel 32b5.
+    const uint32_t code17f[] = {
+        0x7e040280u, 0x7c020300u, 0xbf860001u, 0x7e040281u,
+        0x7d840100u, 0xbf870001u, 0xbf82fffdu,
+        0xbefc0380u,                          // s_mov_b32 m0, 0
+        0xd8fa0008u, 0x03000000u,           // ds_append v3 offset:8
+        0x7e060d03u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv17f = recompile_valu(
+        code17f, std::size(code17f), 2, /*out_vgpr*/3);
+    CHECK(!spv17f.empty(), "#825: recompiled CFG-dispatch DS_APPEND kernel -> SPIR-V");
+    std::vector<float> got17f = prosper::test::run_compute(spv17f, in17d, N, N);
+    CHECK(got17f.size() == N,
+          "#825: Vulkan executes dispatcher DS_APPEND with uniform barriers");
+
     // Kernel 18: the REAL if-then idiom with a forward branch. v3=7; vcc=(u0>u1);
     // s_and_saveexec_b64 s[0:1],vcc (save exec, exec=vcc); s_cbranch_execz skip (forward -> no-op);
     // v_add v3=u0+u1 (predicated); skip: s_mov_b64 exec,s[0:1] (restore); cvt+store. Same result as
@@ -466,6 +538,28 @@ int main() {
     for (uint32_t i=0;i<N&&got18.size()==N;i++){ if (std::fabs(got18[i]-exp18[i])>1e-3f) bad18++; if((i%17)>(i%13)) act18++; }
     printf("  kernel18 mismatches=%u (active=%u, out[1]=%g exp=%g)\n", bad18, act18, got18.size()==N?got18[1]:-1, exp18[1]);
     CHECK(got18.size()==N && bad18==0, "recompiled kernel 18 (real saveexec+cbranch_execz if-then) correct");
+
+    // Astro's exact inverse-mask form: save EXEC in s[22:23], then EXEC &= ~VCC. The guarded add
+    // therefore runs for u0<=u1, after which the original EXEC mask is restored from s[22:23].
+    const uint32_t code18b[] = {
+        0x7e000f00u, 0x7e020f01u, 0x7e060287u, 0x7d880300u,
+        0xbe96376au, 0xbf880001u, 0x4a060300u, 0xbefe0416u,
+        0x7e060d03u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv18b = recompile_valu(
+        code18b, sizeof(code18b)/sizeof(code18b[0]), 2, /*out_vgpr*/3);
+    CHECK(!spv18b.empty(), "recompiled kernel 18b (Astro s_andn1_saveexec_b64) -> SPIR-V");
+    std::vector<float> exp18b(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const uint32_t u0 = i % 17, u1 = i % 13;
+        exp18b[i] = (u0 <= u1) ? (float)(u0 + u1) : 7.0f;
+    }
+    std::vector<float> got18b = prosper::test::run_compute(spv18b, in18, N, N);
+    uint32_t bad18b = 0;
+    for (uint32_t i=0;i<N&&got18b.size()==N;i++)
+        if (std::fabs(got18b[i]-exp18b[i])>1e-3f) ++bad18b;
+    CHECK(got18b.size()==N && bad18b==0,
+          "kernel 18b saves EXEC, applies ~VCC, and restores the original mask");
 
     // Kernel 19: scalar s_bfe_u32. s0=0xF0; s1=bfe_u(s0, off=4,width=4)=(0xF0>>4)&0xF=0xF=15;
     // v2=(float)s1; out = a0 + 15. Proves scalar bitfield-extract (a top real-shader blocker).
@@ -905,6 +999,130 @@ int main() {
     CHECK(got32b.size()==1 && std::fabs(got32b[0]-10.0f)<1e-3f,
           "kernel 32b wide LDS stores and loads preserve both dwords of both VGPR pairs");
 
+    // Kernel 32b2: Astro Bot's loading-surface producer uses DS_READ2_B32 twice, first with
+    // offset0/1=(0,1) and then (16,17). Populate those exact LDS locations with integers 1..4,
+    // execute the two live instruction words, and make both return pairs observable as sum=10.
+    const uint32_t code32b2[] = {
+        0x7e000280u, 0x7e020281u, 0x7e040282u, 0x7e060283u, 0x7e080284u,
+        0xd9340000u, 0x00000100u, 0xd9340040u, 0x00000300u, 0xbf8a0000u,
+        0xd8dc0100u, 0x05000000u, 0xd8dc1110u, 0x07000000u,
+        0x7e0a0d05u, 0x7e0c0d06u, 0x7e0e0d07u, 0x7e100d08u,
+        0x060a0d05u, 0x060a0f05u, 0x060a1105u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b2 = recompile_valu(code32b2, std::size(code32b2), 0, 5);
+    CHECK(!spv32b2.empty(), "recompiled kernel 32b2 (Astro DS_READ2_B32 words) -> SPIR-V");
+    std::vector<float> got32b2 = prosper::test::run_compute(spv32b2, std::vector<float>(1), 1, 1);
+    CHECK(got32b2.size()==1 && std::fabs(got32b2[0]-10.0f)<1e-3f,
+          "kernel 32b2 DS_READ2_B32 applies both packed dword offsets exactly");
+
+    // Kernel 32b3: three other exact words from Astro's loading compute shaders. V_MUL_U32_U24
+    // must mask both operands to 24 bits, while V_CVT_FLR_I32_F32 must round negative values toward
+    // -infinity (not toward zero). Add the converted results: (64 * 3) + floor(-2.25) = 189.
+    const uint32_t code32b3[] = {
+        0x7e000f00u,               // v_cvt_u32_f32 v0, v0
+        0x160600c0u,               // live: v_mul_u32_u24 v3, 64, v0
+        0x7e060d03u,               // v_cvt_f32_u32 v3, v3
+        0x7e681b01u,               // live: v_cvt_flr_i32_f32 v52, v1
+        0x7e680b34u,               // v_cvt_f32_i32 v52, v52
+        0x06686903u,               // v_add_f32 v52, v3, v52
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b3 = recompile_valu(code32b3, std::size(code32b3), 2, 52);
+    CHECK(!spv32b3.empty(), "recompiled kernel 32b3 (Astro U24 multiply + floor-convert words) -> SPIR-V");
+    std::vector<float> got32b3 = prosper::test::run_compute(spv32b3, {3.0f, -2.25f}, 1, 1);
+    CHECK(got32b3.size()==1 && std::fabs(got32b3[0]-189.0f)<1e-3f,
+          "kernel 32b3 masks U24 multiplication and floors negative f32 before i32 conversion");
+
+    // Kernel 32b4: exact DS_WRITE_B96/B128 and DS_READ_B96/B128 forms from Astro. Store 1,2,3 at
+    // byte 0x510 and 4,5,6,7 at byte 0, read both vectors back, and sum all seven dwords to 28.
+    const uint32_t code32b4[] = {
+        0x7e000284u, 0x7e020285u, 0x7e040286u, 0x7e060287u,
+        0x7e080281u, 0x7e0a0282u, 0x7e0c0283u, 0x7e0e0280u,
+        0xdb780510u, 0x00000407u,   // live: ds_write_b96  v7, v[4:6] offset:0x510
+        0xdb7c0000u, 0x00000007u,   // live: ds_write_b128 v7, v[0:3]
+        0xbf8a0000u,
+        0xdbfc0000u, 0x08000007u,   // live form: ds_read_b128 v[8:11], v7
+        0xdbf80510u, 0x0c000007u,   // live form: ds_read_b96 v[12:14], v7 offset:0x510
+        0x7e100d08u, 0x7e120d09u, 0x7e140d0au, 0x7e160d0bu,
+        0x7e180d0cu, 0x7e1a0d0du, 0x7e1c0d0eu,
+        0x06101308u, 0x06101508u, 0x06101708u,
+        0x06101908u, 0x06101b08u, 0x06101d08u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b4 = recompile_valu(code32b4, std::size(code32b4), 0, 8);
+    CHECK(!spv32b4.empty(), "recompiled kernel 32b4 (Astro wide LDS read/write words) -> SPIR-V");
+    std::vector<float> got32b4 = prosper::test::run_compute(spv32b4, std::vector<float>(1), 1, 1);
+    CHECK(got32b4.size()==1 && std::fabs(got32b4[0]-28.0f)<1e-3f,
+          "kernel 32b4 wide LDS reads/writes preserve all three/four consecutive dwords");
+
+    // Kernel 32b5: Astro's exact DS_APPEND word. Initialize the LDS counter to 10, narrow EXEC to
+    // the first 32 lanes, then append. Hardware performs one atomic +32 and broadcasts old=10 only
+    // to active lanes; inactive lanes preserve their old v8=99. Reading the new counter (42) makes
+    // both effects observable: active output=52, inactive output=141.
+    const uint32_t code32b5[] = {
+        0x7e000f00u,               // v_cvt_u32_f32 v0, v0 (lane number input)
+        0x7e04028au, 0x7e060280u,  // v2=10, v3=byte address 0
+        0x7e1002ffu, 0x00000063u,  // v8=99 fallback for inactive lanes
+        0xbefc0380u,               // s_mov_b32 m0, 0
+        0x7da40080u,               // v_cmpx_eq_u32 0, v0 (lane zero initializes)
+        0xd8340010u, 0x00000203u,  // ds_write_b32 v3, v2 offset:0x10
+        0xbefe04c1u, 0xbf8a0000u,  // restore EXEC; barrier
+        0x7e0202a0u, 0x7da20300u,  // v1=32; v_cmpx_lt_u32 v0,v1
+        0xd8fa0010u, 0x08000000u,  // live: ds_append v8 offset:0x10
+        0xbefe04c1u, 0xbf8a0000u,  // restore EXEC; barrier
+        0xd8d80010u, 0x09000003u,  // ds_read_b32 v9, v3 offset:0x10
+        0x7e100d08u, 0x7e120d09u, 0x06101308u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b5 = recompile_valu(code32b5, std::size(code32b5), 1, 8);
+    CHECK(!spv32b5.empty(), "recompiled kernel 32b5 (Astro DS_APPEND word) -> SPIR-V");
+    std::vector<float> in32b5(WG); for (uint32_t i = 0; i < WG; ++i) in32b5[i] = (float)i;
+    std::vector<float> got32b5 = prosper::test::run_compute(spv32b5, in32b5, WG, WG);
+    uint32_t bad32b5 = 0;
+    for (uint32_t i = 0; i < WG && got32b5.size() == WG; ++i) {
+        const float expected = i < 32 ? 52.0f : 141.0f;
+        if (std::fabs(got32b5[i] - expected) > 1e-3f) ++bad32b5;
+    }
+    printf("  kernel32b5 output count=%zu", got32b5.size());
+    if (got32b5.size() == WG)
+        printf("  kernel32b5 mismatches=%u out[0/31/32/63]=%g/%g/%g/%g expect=52/52/141/141\n",
+               bad32b5, got32b5[0], got32b5[31], got32b5[32], got32b5[63]);
+    else
+        printf("\n");
+    CHECK(got32b5.size()==WG && bad32b5==0,
+          "kernel 32b5 atomically adds popcount(EXEC), broadcasts old counter, and predicates VDST");
+
+    // Kernel 32b6: Astro's exact DS_CONSUME word is the inverse operation. Start at 50, make the
+    // first 16 lanes valid, and consume once. Active lanes observe old=50 and all lanes read the new
+    // counter=34, while inactive lanes preserve their fallback destination value of 99.
+    const uint32_t code32b6[] = {
+        0x7e000f00u,                         // v_cvt_u32_f32 v0, v0 (lane number input)
+        0x7e0402ffu, 0x00000032u,            // v2=50
+        0x7e060280u,                         // v3=byte address 0
+        0x7e1802ffu, 0x00000063u,            // v12=99 fallback for inactive lanes
+        0xbefc0380u,                         // s_mov_b32 m0, 0
+        0x7da40080u,                         // v_cmpx_eq_u32 0, v0 (lane zero initializes)
+        0xd8340004u, 0x00000203u,            // ds_write_b32 v3, v2 offset:4
+        0xbefe04c1u, 0xbf8a0000u,            // restore EXEC; barrier
+        0x7e020290u, 0x7da20300u,            // v1=16; v_cmpx_lt_u32 v0,v1
+        0xd8f60004u, 0x0c000000u,            // live: ds_consume v12 offset:4
+        0xbefe04c1u, 0xbf8a0000u,            // restore EXEC; barrier
+        0xd8d80004u, 0x0d000003u,            // ds_read_b32 v13, v3 offset:4
+        0x7e180d0cu, 0x7e1a0d0du,            // uint -> float
+        0x06181b0cu, 0xbf810000u,             // v12 += v13; end
+    };
+    std::vector<uint32_t> spv32b6 = recompile_valu(code32b6, std::size(code32b6), 1, 12);
+    CHECK(!spv32b6.empty(), "recompiled kernel 32b6 (Astro DS_CONSUME word) -> SPIR-V");
+    std::vector<float> got32b6 = prosper::test::run_compute(spv32b6, in32b5, WG, WG);
+    uint32_t bad32b6 = 0;
+    for (uint32_t i = 0; i < WG && got32b6.size() == WG; ++i) {
+        const float expected = i < 16 ? 84.0f : 133.0f;
+        if (std::fabs(got32b6[i] - expected) > 1e-3f) ++bad32b6;
+    }
+    if (got32b6.size() == WG)
+        printf("  kernel32b6 mismatches=%u out[0/15/16/63]=%g/%g/%g/%g expect=84/84/133/133\n",
+               bad32b6, got32b6[0], got32b6[15], got32b6[16], got32b6[63]);
+    CHECK(got32b6.size()==WG && bad32b6==0,
+          "kernel 32b6 atomically subtracts popcount(EXEC), broadcasts old counter, and predicates VDST");
+
     // Kernel 32c: the same UE4 producer uses non-returning unsigned LDS min/max atomics. Start at
     // 10, min with 3, then max with 7; a read and uint->float conversion must report 7.
     const uint32_t code32c[] = {
@@ -940,6 +1158,57 @@ int main() {
            bad32c2, got32c2.size()==WG ? got32c2[0] : -1.0f);
     CHECK(got32c2.size()==WG && bad32c2==0,
           "kernel 32c2 returns old LDS and atomically stores the sum");
+
+    // Kernel 32c3: exact Astro DS_ADD_U32 form. Give every lane its own dword, initialize it to 10,
+    // add 1 atomically without a return value, then read back 11.
+    const uint32_t code32c3[] = {
+        0x7e02028au,                              // v1 = 10
+        0xd8340514u, 0x00000100u, 0xbf8a0000u,  // ds_write_b32 v0, v1 offset:0x514; barrier
+        0x7e020281u,                              // v1 = 1
+        0xd8000514u, 0x00000100u, 0xbf8a0000u,  // live: ds_add_u32 v0, v1 offset:0x514; barrier
+        0xd8d80514u, 0x02000000u,                 // ds_read_b32 v2, v0 offset:0x514
+        0x7e040d02u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32c3 = recompile_valu(
+        code32c3, std::size(code32c3), 1, 2);
+    CHECK(!spv32c3.empty(), "recompiled kernel 32c3 (Astro DS_ADD_U32 word) -> SPIR-V");
+    std::vector<float> in32c3(WG);
+    for (uint32_t i = 0; i < WG; ++i) {
+        const uint32_t addr = 4u * i;
+        std::memcpy(&in32c3[i], &addr, sizeof(addr));
+    }
+    std::vector<float> got32c3 = prosper::test::run_compute(spv32c3, in32c3, WG, WG);
+    uint32_t bad32c3 = 0;
+    for (uint32_t i = 0; i < WG && got32c3.size() == WG; ++i)
+        if (std::fabs(got32c3[i] - 11.0f) > 1e-3f) ++bad32c3;
+    CHECK(got32c3.size() == WG && bad32c3 == 0,
+          "kernel 32c3 atomically adds DATA0 to each LDS dword");
+
+    // Kernel 32c4: exact Astro DS_WRXCHG_RTN_B32 form. Swap 20 over 10 and observe both the
+    // returned old value and the new LDS value: 10 + 20 = 30.
+    const uint32_t code32c4[] = {
+        0x7e02028au,
+        0xd8340510u, 0x00000100u, 0xbf8a0000u,
+        0x7e0402ffu, 0x00000014u,
+        0xd8b40510u, 0x03000200u, 0xbf8a0000u,
+        0xd8d80510u, 0x04000000u,
+        0x7e060d03u, 0x7e080d04u, 0x06060903u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32c4 = recompile_valu(
+        code32c4, std::size(code32c4), 1, 3);
+    CHECK(!spv32c4.empty(),
+          "recompiled kernel 32c4 (Astro DS_WRXCHG_RTN_B32 word) -> SPIR-V");
+    std::vector<float> in32c4(WG);
+    for (uint32_t i = 0; i < WG; ++i) {
+        const uint32_t addr = 4u * i;
+        std::memcpy(&in32c4[i], &addr, sizeof(addr));
+    }
+    std::vector<float> got32c4 = prosper::test::run_compute(spv32c4, in32c4, WG, WG);
+    uint32_t bad32c4 = 0;
+    for (uint32_t i = 0; i < WG && got32c4.size() == WG; ++i)
+        if (std::fabs(got32c4[i] - 30.0f) > 1e-3f) ++bad32c4;
+    CHECK(got32c4.size() == WG && bad32c4 == 0,
+          "kernel 32c4 atomically exchanges LDS and returns the previous dword");
 
     // Kernel 32d: SDWA f16->f32 conversion selects WORD_1 before applying source negate. The packed
     // high half is -2, so `-WORD_1` converts to +2 (not a negation of the packed 32-bit payload).
@@ -1213,6 +1482,22 @@ int main() {
     uint32_t bad37 = 0; for (uint32_t i=0;i<N&&got37.size()==N;i++) if (std::fabs(got37[i]-exp37[i])>1e-3f) bad37++;
     printf("  kernel37 mismatches=%u (out[5]=%g expect=%g)\n", bad37, got37.size()==N?got37[5]:-1, exp37[5]);
     CHECK(got37.size()==N && bad37==0, "recompiled kernel 37 (s_movk_i32 -100) computes a0-100");
+
+    // Astro Bot's loading composite starts with s_brev_b32 s16,1 to construct 0x80000000.
+    // AMD ISA 70648 also specifies that S_BREV does not set SCC. Seed SCC=true, reverse bit 0,
+    // then select the reversed value through SCC so the test covers both contracts.
+    const uint32_t code37b[] = {
+        0xBE800381u, 0xBF068100u, 0xBE800B00u, 0x85018900u, 0x7E000C01u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv37b = recompile_valu(
+        code37b, sizeof(code37b)/sizeof(code37b[0]), 1, 0);
+    CHECK(!spv37b.empty(), "recompiled kernel 37b (s_brev_b32) -> SPIR-V");
+    std::vector<float> got37b = prosper::test::run_compute(spv37b, in37, N, N);
+    uint32_t bad37b = 0;
+    for (uint32_t i=0;i<N&&got37b.size()==N;i++)
+        if (got37b[i] != 2147483648.0f) bad37b++;
+    CHECK(got37b.size()==N && bad37b==0,
+          "kernel 37b reverses scalar bit 0 into bit 31 without changing SCC");
 
     // Kernel 38: s_cselect_b64 (SOP2 0x0b) — mask-domain select. s_cmp_eq_u32 5,5 sets SCC=1, then
     //   s_cselect_b64 vcc, exec, 0 => vcc = SCC ? exec : 0 = exec (all lanes on). v_cndmask v0,v1(42),
@@ -1734,6 +2019,31 @@ int main() {
            got66b.size()==N?got66b[3]:-1, 500u + 2u*3u + 1u);
     CHECK(got66b.size()==N && bad66b==0, "kernel 66b (idxen+offen): addr = idx*stride + byteoffset (both applied)");
 
+    // Astro Bot's visibility kernel uses raw buffer_load_ubyte at arbitrary byte offsets. Exercise
+    // all four byte positions in each dword through the same SRSRC-provenance binding as kernel 66.
+    const uint32_t code66c[] = {
+        0x7e000f00u,               // v_cvt_u32_f32 v0, v0
+        0xe0201000u, 0x80020000u,  // buffer_load_ubyte v0, v0, s[8:11], 0 offen
+        0x7e000d00u,               // v_cvt_f32_u32 v0, v0
+        0xbf810000u,
+    };
+    ShaderResourceTable rt66c;
+    { ShaderResource rb{}; rb.cls = ResourceClass::ConstantBuffer; rb.format = DataFormat::Uint32;
+      rb.num_components = 1; rb.binding = 3; rb.sgpr_base = 8; rt66c.resources.push_back(rb); }
+    std::vector<uint32_t> spv66c = recompile_valu(
+        code66c, sizeof(code66c)/sizeof(code66c[0]), 1, 0, &rt66c);
+    CHECK(!spv66c.empty(), "recompiled kernel 66c (raw buffer_load_ubyte) -> SPIR-V");
+    std::vector<uint32_t> bytes66c((N + 3) / 4, 0u), decoy66c(bytes66c.size(), 0u);
+    for (uint32_t i = 0; i < N; ++i)
+        bytes66c[i / 4] |= ((i * 3u + 7u) & 0xFFu) << ((i & 3u) * 8u);
+    std::vector<float> got66c = prosper::test::run_compute(
+        spv66c, in66, N, N, decoy66c, bytes66c);
+    uint32_t bad66c = 0;
+    for (uint32_t i=0;i<N&&got66c.size()==N;i++)
+        if (got66c[i] != (float)((i * 3u + 7u) & 0xFFu)) ++bad66c;
+    CHECK(got66c.size()==N && bad66c==0,
+          "kernel 66c extracts raw unsigned bytes at every in-dword position");
+
     // Kernel 67: RAW MUBUF UNRESOLVABLE SRSRC -> REJECT (#91). Same code, but the table's only
     // resource lives at sgpr_base 4 — SRSRC s[8:11] resolves to nothing. With a table present the
     // recompiler must reject (empty SPIR-V), never silently fall back to binding 2.
@@ -2142,6 +2452,117 @@ int main() {
     uint32_t badT11 = 0; for (uint32_t i=0;i<N&&gotT11.size()==N;i++) if (gotT11[i]!=expT11[i]) badT11++;
     CHECK(gotT11.size()==N && badT11==0, "T11: v_cmp_gt_f32_sdwa applies |src0| before comparing");
 
+    // Astro Bot's exact visibility-kernel compare: move the input bits to v63, compare integer 1
+    // against its zero-extended low byte, then materialize the VCC result as float 0/1.
+    const uint32_t codeT11b[] = {
+        0x7e7e0300u,               // v_mov_b32 v63, v0
+        0x7d8a7ef9u, 0x00860081u,  // v_cmp_ne_u32 vcc, 1, v63 src1_sel:BYTE_0
+        0xd5010000u, 0x01a9e480u,  // v_cndmask_b32_e64 v0, 0.0, 1.0, vcc
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvT11b = recompile_valu(codeT11b, sizeof(codeT11b)/4, 1, 0);
+    CHECK(!spvT11b.empty(), "recompiled T11b (Astro integer VOPC SDWA BYTE_0) -> SPIR-V");
+    std::vector<float> gotT11b = prosper::test::run_compute(spvT11b, inX, N, N);
+    uint32_t badT11b = 0;
+    for (uint32_t i = 0; i < N && gotT11b.size() == N; ++i)
+        if (gotT11b[i] != (((bits_of(inX[i]) & 0xFFu) != 1u) ? 1.0f : 0.0f)) ++badT11b;
+    CHECK(gotT11b.size()==N && badT11b==0,
+          "T11b: unsigned SDWA compare zero-extends the selected source byte");
+
+    // Its later paired form selects WORD_1 and updates EXEC instead of VCC. Exact live words;
+    // compilation proves the CMPX opcode family is normalized before the integer SDWA admission.
+    const uint32_t codeT11c[] = {
+        0x7e7e0300u,               // v_mov_b32 v63, v0
+        0x7daa7ef9u, 0x05860081u,  // v_cmpx_ne_u32 1, v63 src1_sel:WORD_1
+        0x7e0002f2u,               // v_mov_b32 v0, 1.0 (EXEC-predicated)
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvT11c = recompile_valu(codeT11c, sizeof(codeT11c)/4, 1, 0);
+    CHECK(!spvT11c.empty(), "recompiled T11c (Astro CMPX SDWA WORD_1) -> SPIR-V");
+    std::vector<float> gotT11c = prosper::test::run_compute(spvT11c, inX, N, N);
+    uint32_t badT11c = 0;
+    for (uint32_t i = 0; i < N && gotT11c.size() == N; ++i) {
+        const bool active = ((bits_of(inX[i]) >> 16) & 0xFFFFu) != 1u;
+        if (gotT11c[i] != (active ? 1.0f : inX[i])) ++badT11c;
+    }
+    CHECK(gotT11c.size()==N && badT11c==0,
+          "T11c: CMPX compares the zero-extended high word and predicates the following write");
+
+    // Exact Astro visibility-kernel word. Both unwritten sources are architectural undefined on
+    // hardware but initialize to zero in the test shell, so XNOR(0,0) must produce all one bits.
+    const uint32_t codeT11d[] = { 0x3cc0c18du, 0xbf810000u }; // v_xnor_b32 v96, v141, v96
+    std::vector<uint32_t> spvT11d = recompile_valu(
+        codeT11d, sizeof(codeT11d)/sizeof(codeT11d[0]), 1, /*out_vgpr*/96);
+    CHECK(!spvT11d.empty(), "recompiled T11d (Astro v_xnor_b32 word) -> SPIR-V");
+    std::vector<float> gotT11d = prosper::test::run_compute(spvT11d, inX, N, N);
+    uint32_t badT11d = 0;
+    for (uint32_t i=0;i<N&&gotT11d.size()==N;i++)
+        if (bits_of(gotT11d[i]) != 0xFFFFFFFFu) ++badT11d;
+    CHECK(gotT11d.size()==N && badT11d==0,
+          "T11d: v_xnor_b32 is the bitwise complement of XOR");
+
+    // Exact Astro V_BCNT packet: copy the input bits to v97, then popcount into v98 with addend 0.
+    const uint32_t codeT11e[] = {
+        0x7ec20300u,               // v_mov_b32 v97, v0
+        0xd7640062u, 0x00010161u,  // v_bcnt_u32_b32 v98, v97, 0
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT11e = recompile_valu(
+        codeT11e, sizeof(codeT11e)/sizeof(codeT11e[0]), 1, /*out_vgpr*/98);
+    CHECK(!spvT11e.empty(), "recompiled T11e (Astro v_bcnt_u32_b32 word) -> SPIR-V");
+    std::vector<float> gotT11e = prosper::test::run_compute(spvT11e, inX, N, N);
+    uint32_t badT11e = 0;
+    for (uint32_t i=0;i<N&&gotT11e.size()==N;i++)
+        if (bits_of(gotT11e[i]) != std::popcount(bits_of(inX[i]))) ++badT11e;
+    CHECK(gotT11e.size()==N && badT11e==0,
+          "T11e: v_bcnt_u32_b32 adds the exact 32-bit population count");
+
+    // Astro's next blocker is VOP3B v_mad_u64_u32. Exercise all three architectural
+    // outputs with an overflowing case:
+    //   0xffffffff*2 + 0xffffffffffffffff = carry:1, hi:1, lo:0xfffffffd.
+    // XOR the low word to zero, convert hi to 1.0, and select 41.0 through carry => 42.0.
+    const uint32_t codeT11f[] = {
+        0x7eb80282u,                         // v_mov_b32 v92, 2
+        0x7e0e02c1u, 0x7e1002c1u,           // v_mov_b32 v7/v8, -1
+        0xd5766a05u, 0x041eb8c1u,           // v_mad_u64_u32 v[5:6],vcc,-1,v92,v[7:8]
+        0x3a0a0ac3u,                         // v_xor_b32 v5, -3, v5 (validates low)
+        0x7e0a0d05u, 0x7e0c0d06u,           // v_cvt_f32_u32 v5/v6, v5/v6
+        0x7e1402ffu, 0x42240000u,            // v_mov_b32 v10, 41.0
+        0x7e160280u,                         // v_mov_b32 v11, 0
+        0x0214150bu,                         // v_cndmask_b32 v10, v11, v10, vcc
+        0x06000d05u, 0x06001500u,           // v0 = v5 + v6 + v10
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT11f = recompile_valu(
+        codeT11f, sizeof(codeT11f)/sizeof(codeT11f[0]), 1, 0);
+    CHECK(!spvT11f.empty(), "recompiled T11f (Astro v_mad_u64_u32 VOP3B) -> SPIR-V");
+    std::vector<float> gotT11f = prosper::test::run_compute(spvT11f, inX, N, N);
+    uint32_t badT11f = 0;
+    for (uint32_t i=0;i<N&&gotT11f.size()==N;i++)
+        if (gotT11f[i] != 42.0f) ++badT11f;
+    CHECK(gotT11f.size()==N && badT11f==0,
+          "T11f: v_mad_u64_u32 writes exact low/high words and carry-out");
+
+    // Astro's SSAO pixel shader carries dead `s_and_b64 vcc,s[0:1],vcc` operations between
+    // comparisons; s[0:1] is a T# descriptor, not a wave-mask value available to SPIR-V. Prove that
+    // the dead write is removed while the following, observable comparison still controls cndmask.
+    const uint32_t codeT11g[] = {
+        0x7c080300u,              // v_cmp_gt_f32 vcc, v0, v1
+        0x87ea6a00u,              // s_and_b64 vcc, s[0:1], vcc (dead before the next compare)
+        0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1
+        0x02000101u,              // v_cndmask_b32 v0, v1, v0, vcc => min(v0,v1)
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT11g = recompile_valu(
+        codeT11g, sizeof(codeT11g)/sizeof(codeT11g[0]), 2, 0);
+    CHECK(!spvT11g.empty(), "recompiled T11g (dead Astro scalar-pair mask write) -> SPIR-V");
+    std::vector<float> gotT11g = prosper::test::run_compute(spvT11g, in6, N, N);
+    uint32_t badT11g = 0;
+    for (uint32_t i=0;i<N&&gotT11g.size()==N;i++)
+        if (gotT11g[i] != std::min(in6[i*2], in6[i*2+1])) ++badT11g;
+    CHECK(gotT11g.size()==N && badT11g==0,
+          "T11g: dead mask removal preserves the following VCC compare result");
+
     // Kernel T12: PC-RELATIVE EMBEDDED TABLE (#273 — DOLL's dither PS idiom). The shader builds a
     // V# with s_getpc_b64 + adds and buffer_loads from a constant table appended AFTER s_endpgm in
     // the code blob. The recompiler folds the load to a compile-time lookup.
@@ -2171,6 +2592,54 @@ int main() {
     uint32_t badT12 = 0; for (uint32_t i=0;i<N&&gotT12.size()==N;i++) if (gotT12[i]!=expT12[i]) badT12++;
     printf("  T12(pcrel table) mismatches=%u (out[2]=%g expect=%g)\n", badT12, gotT12.size()==N?gotT12[2]:-1, expT12[2]);
     CHECK(gotT12.size()==N && badT12==0, "T12: buffer_load through a getpc-built V# reads the embedded table");
+
+    // Astro Bot emits the same proven V# shape with s_movk_i32 for num_records. Keep that descriptor
+    // construction equivalent to s_mov_b32; otherwise s_getpc_b64 is rejected even though all loads
+    // remain bounded to the embedded table.
+    const uint32_t codeT12movk[] = {
+        0xb0060010u,               // s_movk_i32 s6, 16
+        0xbe841f00u,               // s_getpc_b64 s[4:5]
+        0x800404acu,               // s_add_u32 s4, 44, s4 (table = next-PC byte 8 + 44)
+        0x82050580u,               // s_addc_u32 s5, 0, s5
+        0xbe8703ffu, 0x10005004u,  // s_mov_b32 s7, 0x10005004
+        0x7e020f00u,               // v_cvt_u32_f32 v1, v0
+        0x34020282u,               // v_lshlrev_b32 v1, 2, v1
+        0xe0301000u, 0x80010101u,  // buffer_load_dword v1, v1, s[4:7], 0 offen
+        0xbf8c3f70u,               // s_waitcnt vmcnt(0)
+        0x7e000d01u,               // v_cvt_f32_u32 v0, v1
+        0xBF810000u,               // s_endpgm
+        7u, 11u, 13u, 17u,
+    };
+    std::vector<uint32_t> spvT12movk = recompile_valu(
+        codeT12movk, sizeof(codeT12movk)/4, 1, 0);
+    CHECK(!spvT12movk.empty(), "recompiled T12 movk V# (Astro Bot descriptor shape) -> SPIR-V");
+    std::vector<float> gotT12movk = prosper::test::run_compute(spvT12movk, inT12, N, N);
+    uint32_t badT12movk = 0;
+    for (uint32_t i=0;i<N&&gotT12movk.size()==N;i++)
+        if (gotT12movk[i]!=expT12[i]) badT12movk++;
+    CHECK(gotT12movk.size()==N && badT12movk==0,
+          "T12 movk: getpc-built V# reads the embedded table");
+
+    // A PC-relative table belongs to the shader itself, not to the runtime resource table. Astro
+    // Bot's loading-screen VS has no external resources and loads its position from exactly this
+    // shape. The graphics-stage gate must therefore accept the proven MUBUF before requiring `rt`.
+    const uint32_t codeT12vertex[] = {
+        0xb0020010u,               // s_movk_i32 s2, 16 bytes
+        0xbe8303ffu, 0x10005004u,  // s_mov_b32 s3, V# config
+        0xbe801f00u,               // s_getpc_b64 s[0:1] (next PC byte = 16)
+        0x800000ffu, 0x00000028u,  // s_add_u32 s0, 40, s0 (table byte = 56)
+        0x82010180u,               // s_addc_u32 s1, 0, s1
+        0x7e080280u,               // v_mov_b32 v4, 0 (table byte offset)
+        0xe0381000u, 0x80000004u,  // buffer_load_dwordx4 v[0:3], v4, s[0:3], 0 offen
+        0xbf8c3f70u,               // s_waitcnt vmcnt(0)
+        0xf80008cfu, 0x03020100u,  // exp pos0, v0, v1, v2, v3
+        0xbf810000u,               // s_endpgm
+        0xbf800000u, 0xbf800000u, 0u, 0x3f800000u,
+    };
+    std::vector<uint32_t> spvT12vertex = recompile_vertex(
+        codeT12vertex, sizeof(codeT12vertex)/4, nullptr);
+    CHECK(!spvT12vertex.empty(),
+          "T12 vertex: resource-free stage accepts a proven embedded-table MUBUF");
 
     // Kernel T13: UINT8x1 vertex fetch (#273 — DOLL's skinned scene VS bone-index attribute class).
     // buffer_load_format_x of a Uint8 element delivers the RAW integer (no normalization) in the VGPR.
@@ -2335,6 +2804,28 @@ int main() {
     printf("  T20(bitcmp1) mismatches=%u (out[2]=%g expect=100)\n", badT20, gotT20.size()==8?gotT20[2]:-1);
     CHECK(gotT20.size()==8 && badT20==0, "T20: s_bitcmp1_b32 sets SCC from the selected bit");
 
+    // Kernel T20b: Astro's exact s_cmp_eq_u64 s[2:3], 0 form. Exercise both the equal pair and a
+    // value whose low half is zero but high half is one, proving that SCC uses both encoded dwords.
+    const uint32_t codeT20b_eq[] = {
+        0xbe820380u, 0xbe830380u, 0xbf128002u,
+        0x850580ffu, 0x00000064u, 0x7e000c05u, 0xbf810000u,
+    };
+    const uint32_t codeT20b_ne[] = {
+        0xbe820380u, 0xbe830381u, 0xbf128002u,
+        0x850580ffu, 0x00000064u, 0x7e000c05u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spvT20b_eq = recompile_valu(codeT20b_eq, std::size(codeT20b_eq), 0, 0);
+    std::vector<uint32_t> spvT20b_ne = recompile_valu(codeT20b_ne, std::size(codeT20b_ne), 0, 0);
+    CHECK(!spvT20b_eq.empty() && !spvT20b_ne.empty(),
+          "recompiled T20b (Astro s_cmp_eq_u64 word) -> SPIR-V");
+    std::vector<float> gotT20b_eq = prosper::test::run_compute(spvT20b_eq, inT20, 8, 8);
+    std::vector<float> gotT20b_ne = prosper::test::run_compute(spvT20b_ne, inT20, 8, 8);
+    uint32_t badT20b = 0;
+    for (uint32_t i = 0; i < 8 && gotT20b_eq.size() == 8 && gotT20b_ne.size() == 8; ++i)
+        if (gotT20b_eq[i] != 100.0f || gotT20b_ne[i] != 0.0f) ++badT20b;
+    CHECK(gotT20b_eq.size()==8 && gotT20b_ne.size()==8 && badT20b==0,
+          "T20b: u64 equality compares both SGPR halves and drives SCC exactly");
+
     // Kernel T23: v_cube{id,sc,tc,ma}_f32 (#273 — DOLL's reflection-probe cube math). Direction
     // (x,y,z) = (1.0, 0.5, -2.0): |z| is the major axis and z<0, so per the GL cube table
     // id=5, sc=-x=-1, tc=-y=-0.5, ma=2z=-4. out = id*100 + sc*10 + tc + ma/1024
@@ -2432,6 +2923,165 @@ int main() {
            gotT24.size()==16?gotT24[7]:-9.f, gotT24.size()==16?gotT24[8]:-9.f);
     CHECK(gotT24.size()==16 && badT24==0,
           "T24: signed i4 values convert to f32 multiples of 1/16 exactly");
+
+    // T25: Astro Bot's compute blur uses v_mov_b32_dpp quad permutations to exchange values inside
+    // each 2x2 quad. These are subgroup quad swaps, not screen-space derivatives (the fragment-only
+    // lowering). Exercise the exact live DPP controls: 0xb1 = lane^1 (horizontal), 0x4e = lane^2
+    // (vertical), 0x1b = lane^3 (diagonal).
+    const uint32_t dpp_controls[] = {0xff08b100u, 0xff084e00u, 0xff081b00u};
+    const uint32_t dpp_xor[] = {1u, 2u, 3u};
+    for (uint32_t k = 0; k < 3; ++k) {
+        const uint32_t codeT25[] = {0x7e0002fau, dpp_controls[k], 0xbf810000u};
+        std::vector<uint32_t> spvT25 = recompile_valu(codeT25, sizeof(codeT25)/4, 1, 0);
+        CHECK(!spvT25.empty(), "recompiled T25 (compute DPP16 quad swap) -> SPIR-V");
+        std::vector<float> inT25(128), expT25(128);
+        for (uint32_t i = 0; i < 128; ++i) inT25[i] = (float)i;
+        for (uint32_t i = 0; i < 128; ++i) expT25[i] = inT25[i ^ dpp_xor[k]];
+        std::vector<float> gotT25 = prosper::test::run_compute(spvT25, inT25, 128, 128);
+        uint32_t badT25 = 0;
+        for (uint32_t i = 0; i < 128 && gotT25.size() == 128; ++i)
+            if (gotT25[i] != expT25[i]) ++badT25;
+        CHECK(gotT25.size() == 128 && badT25 == 0,
+              "T25: compute DPP16 returns the selected neighbor from each quad");
+    }
+
+    // T26: Astro title-ship VS exact VOP3 opcode word for v_cvt_pknorm_u16_f32. The high half is
+    // fixed at 0.5; the low half exercises clamping and round-to-nearest-even across [0,1].
+    const uint32_t codeT26[] = {
+        0xd7690002u, 0x0001e100u, // v_cvt_pknorm_u16_f32 v2, v0, 0.5
+        0x7e000302u,              // v_mov_b32 v0, v2
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT26 = recompile_valu(codeT26, std::size(codeT26), 1, 0);
+    CHECK(!spvT26.empty(), "recompiled T26 (Astro v_cvt_pknorm_u16_f32 word) -> SPIR-V");
+    std::vector<float> inT26 = {-1.0f, 0.0f, 0.25f, 0.5f, 0.75f, 1.0f, 2.0f, 0.1f};
+    std::vector<float> expT26(inT26.size());
+    for (size_t i = 0; i < inT26.size(); ++i) {
+        const float clamped = std::max(0.0f, std::min(1.0f, inT26[i]));
+        const uint32_t lo = static_cast<uint32_t>(std::nearbyint(clamped * 65535.0f));
+        const uint32_t packed = (32768u << 16) | lo;
+        std::memcpy(&expT26[i], &packed, sizeof(packed));
+    }
+    std::vector<float> gotT26 = prosper::test::run_compute(spvT26, inT26, 8, 8);
+    uint32_t badT26 = 0;
+    for (size_t i = 0; i < expT26.size() && gotT26.size() == expT26.size(); ++i)
+        if (gotT26[i] != expT26[i]) ++badT26;
+    printf("  T26(pknorm u16) mismatches=%u (got[2]=%.0f expect=%.0f, got[3]=%.0f expect=%.0f)\n",
+           badT26, gotT26.size()==8?gotT26[2]:-1.f, expT26[2],
+           gotT26.size()==8?gotT26[3]:-1.f, expT26[3]);
+    CHECK(gotT26.size() == expT26.size() && badT26 == 0,
+          "T26: PKNORM_U16 clamps, rounds, and packs both normalized halves exactly");
+
+    // T27: the title PS's exact SDWA operation, reduced only from v11/v5 to v0/v0 so the compute
+    // harness can feed it. BYTE_0 is zero-extended before the unsigned-int-to-float conversion.
+    const uint32_t codeT27[] = {0x7e000cf9u, 0x00001600u, 0xbf810000u};
+    std::vector<uint32_t> spvT27 = recompile_valu(codeT27, std::size(codeT27), 1, 0);
+    CHECK(!spvT27.empty(), "recompiled T27 (Astro v_cvt_f32_u32 SDWA BYTE_0) -> SPIR-V");
+    const uint32_t rawT27[] = {0u, 1u, 0xffu, 0x12345678u, 0xabcdef80u, 0xffffff00u, 0x100u, 0x7fu};
+    std::vector<float> inT27(std::size(rawT27)), expT27(std::size(rawT27));
+    for (size_t i = 0; i < std::size(rawT27); ++i) {
+        std::memcpy(&inT27[i], &rawT27[i], sizeof(uint32_t));
+        expT27[i] = static_cast<float>(rawT27[i] & 0xffu);
+    }
+    std::vector<float> gotT27 = prosper::test::run_compute(spvT27, inT27, 8, 8);
+    CHECK(gotT27 == expT27,
+          "T27: SDWA BYTE_0 conversion produces the exact zero-extended byte value");
+
+    // T28: Astro title compute exact rejected word from the live trace. DPP applies only to src0
+    // (v3); src1 (v15) stays in the current lane. With quad_perm [1,0,3,2], every lane receives its
+    // horizontal neighbour plus itself.
+    const uint32_t codeT28[] = {
+        0x7e060300u,                         // v_mov_b32 v3, v0
+        0x7e1e0300u,                         // v_mov_b32 v15, v0
+        0x061e1efau, 0xff08b103u,            // exact v_add_f32_dpp v15,v3,v15 quad_perm:[1,0,3,2]
+        0x7e00030fu,                         // v_mov_b32 v0, v15
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT28 = recompile_valu(codeT28, std::size(codeT28), 1, 0);
+    CHECK(!spvT28.empty(), "recompiled T28 (Astro compute VOP2 DPP add) -> SPIR-V");
+    std::vector<float> inT28(128), expT28(128);
+    for (uint32_t i = 0; i < 128; ++i) inT28[i] = (float)i;
+    for (uint32_t i = 0; i < 128; ++i) expT28[i] = inT28[i] + inT28[i ^ 1u];
+    std::vector<float> gotT28 = prosper::test::run_compute(spvT28, inT28, 128, 128);
+    uint32_t badT28 = 0;
+    for (uint32_t i = 0; i < 128 && gotT28.size() == 128; ++i)
+        if (gotT28[i] != expT28[i]) ++badT28;
+    CHECK(gotT28.size() == 128 && badT28 == 0,
+          "T28: VOP2 DPP permutes only src0 and adds current-lane src1");
+
+    // T29: exact S_BFM_B64 word from Astro's title reduction shader.  It creates VCC with the low
+    // 32 lanes set, then saveexec predicates a write.  The operation repeats independently in each
+    // architectural wave64 even when the Vulkan workgroup contains two waves.
+    const uint32_t codeT29[] = {
+        0x7e0602ffu, 0x40e00000u,            // v_mov_b32 v3, 7.0
+        0x92ea80a0u,                         // exact s_bfm_b64 vcc, 32, 0
+        0xbe80246au,                         // s_and_saveexec_b64 s[0:1], vcc
+        0x7e0602ffu, 0x42280000u,            // v_mov_b32 v3, 42.0 (low 32 lanes)
+        0xbefe0400u,                         // s_mov_b64 exec, s[0:1]
+        0x7e000303u,                         // v_mov_b32 v0, v3
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT29 = recompile_valu(codeT29, std::size(codeT29), 1, 0);
+    CHECK(!spvT29.empty(), "recompiled T29 (Astro S_BFM_B64 VCC mask) -> SPIR-V");
+    std::vector<float> inT29(128, 0.0f), expT29(128);
+    for (uint32_t i = 0; i < 128; ++i) expT29[i] = (i % 64u) < 32u ? 42.0f : 7.0f;
+    std::vector<float> gotT29 = prosper::test::run_compute(spvT29, inT29, 128, 128);
+    CHECK(gotT29 == expT29,
+          "T29: S_BFM_B64 sets exactly the requested lanes in every wave64");
+
+    // T30: Astro's exact final reduction word narrows EXEC with inline mask 15 (lanes 0..3).
+    const uint32_t codeT30[] = {
+        0x7e0602ffu, 0x40e00000u,            // v_mov_b32 v3, 7.0
+        0xbeea248fu,                         // exact s_and_saveexec_b64 vcc, 15
+        0x7e0602ffu, 0x42280000u,            // v_mov_b32 v3, 42.0
+        0xbefe046au,                         // s_mov_b64 exec, vcc (saved original EXEC)
+        0x7e000303u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spvT30 = recompile_valu(codeT30, std::size(codeT30), 1, 0);
+    CHECK(!spvT30.empty(), "recompiled T30 (Astro inline B64 lane mask 15) -> SPIR-V");
+    std::vector<float> inT30(128, 0.0f), expT30(128);
+    for (uint32_t i = 0; i < 128; ++i) expT30[i] = (i % 64u) < 4u ? 42.0f : 7.0f;
+    std::vector<float> gotT30 = prosper::test::run_compute(spvT30, inT30, 128, 128);
+    CHECK(gotT30 == expT30,
+          "T30: inline B64 mask 15 activates exactly four lanes per wave64");
+
+    // T31: Astro's exact title-PS SDWA controls, reduced only to v0. WORD_1 is sign-extended before
+    // v_cvt_f32_i32, so both positive and negative int16 values must survive the conversion.
+    const uint32_t codeT31[] = {0x7e000af9u, 0x000d0600u, 0xbf810000u};
+    std::vector<uint32_t> spvT31 = recompile_valu(codeT31, std::size(codeT31), 1, 0);
+    CHECK(!spvT31.empty(), "recompiled T31 (Astro v_cvt_f32_i32 SDWA WORD_1+SEXT) -> SPIR-V");
+    const uint32_t rawT31[] = {0x00011234u, 0x7fff0000u, 0x80000000u, 0xfffe1234u,
+                               0x00000000u, 0xffffaaaau, 0x12340000u, 0xfedc0000u};
+    std::vector<float> inT31(std::size(rawT31)), expT31(std::size(rawT31));
+    for (size_t i = 0; i < std::size(rawT31); ++i) {
+        std::memcpy(&inT31[i], &rawT31[i], sizeof(uint32_t));
+        expT31[i] = static_cast<float>(static_cast<int16_t>(rawT31[i] >> 16));
+    }
+    std::vector<float> gotT31 = prosper::test::run_compute(spvT31, inT31, 8, 8);
+    CHECK(gotT31 == expT31,
+          "T31: signed SDWA conversion sign-extends the selected high word exactly");
+
+    // T32: Astro visibility-reduction BUFFER_ATOMIC_UMAX packet. The operation targets byte offset 4,
+    // returns the old u32 in VDATA, and atomically replaces memory with max(old, VDATA).
+    const uint32_t codeT32[] = {
+        0xe0e00004u, 0x80000000u,            // exact buffer_atomic_umax v0, v0, s[0:3], 0 offset:4
+        0x7e000d00u,                         // v_cvt_f32_u32 v0, v0 (returned old value)
+        0xbf810000u,
+    };
+    ShaderResourceTable rtT32;
+    { ShaderResource rb{}; rb.cls = ResourceClass::ConstantBuffer; rb.format = DataFormat::Uint32;
+      rb.num_components = 1; rb.binding = 3; rb.sgpr_base = 0; rtT32.resources.push_back(rb); }
+    std::vector<uint32_t> spvT32 = recompile_valu(codeT32, std::size(codeT32), 1, 0, &rtT32);
+    CHECK(!spvT32.empty(), "recompiled T32 (Astro buffer_atomic_umax) -> SPIR-V");
+    uint32_t forty_two = 42u; float raw_input = 0.0f;
+    std::memcpy(&raw_input, &forty_two, sizeof(forty_two));
+    std::vector<uint32_t> atomic_buf = {0u, 17u}, atomic_out;
+    std::vector<float> gotT32 = prosper::test::run_compute(
+        spvT32, {raw_input}, 1, 1, /*binding2*/{}, /*binding3*/atomic_buf, &atomic_out);
+    printf("  T32 atomic got=%g memory=%u (expect 17/42)\n",
+           gotT32.empty() ? -1.0f : gotT32[0], atomic_out.size() < 2 ? 0u : atomic_out[1]);
+    CHECK(gotT32.size() == 1 && gotT32[0] == 17.0f && atomic_out.size() == 2 && atomic_out[1] == 42u,
+          "T32: buffer_atomic_umax returns old memory and stores the unsigned maximum");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -95,6 +95,28 @@ int main() {
         }
     }
 
+    // Astro Bot's depth/stencil prepass PS exports only NULL. The VCC mask becomes EXEC immediately
+    // before that export, so inactive fragments must still lower to OpKill even though there is no MRT
+    // output. These are its exact gfx1030 control-flow/export tail (PPSA21564, 0x500540000); the
+    // preceding resource sample is covered separately by the texture execution tests.
+    const uint32_t null_only_ps[] = {
+        0x7d840080u, 0x8aea6a7eu, 0xbf840004u, 0xbefe046au,
+        0xf8001890u, 0x00000000u, 0xbf810000u,
+    };
+    std::vector<uint32_t> null_frag = recompile_fragment(null_only_ps, std::size(null_only_ps));
+    CHECK(!null_frag.empty() && null_frag[0] == 0x07230203u,
+          "#825: recompiled Astro Bot's NULL-export depth/stencil fragment shader");
+    if (!null_frag.empty()) {
+        std::vector<uint8_t> null_px = prosper::test::render_triangle_rgba(vert, null_frag, W, H);
+        CHECK(null_px.size() == (size_t)W * H * 4,
+              "#825: Vulkan accepts a fragment module with no color outputs");
+        if (null_px.size() == (size_t)W * H * 4) {
+            const uint8_t* nc = &null_px[((size_t)(H/2) * W + W/2) * 4];
+            CHECK(nc[2] > 0x80 && nc[0] < 0x40 && nc[1] < 0x40,
+                  "#825: NULL export leaves the BLUE color attachment unchanged");
+        }
+    }
+
     // DIVERGENT execz region (#273 — DOLL's FXAA PS shape): v_cmpx narrows EXEC, s_cbranch_execz
     // skips a block containing a SCALAR write read after the merge (so it is NOT safe-linearizable
     // and must go through the structured exec-if). Then-arm sets v1 = s5 = 1.0; the export runs

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -144,6 +144,21 @@ int main() {
     CHECK(f11_to_float(0x7BF) == 65024.0f, "f11 0x7BF = max finite (65024)");
     { float inf = f11_to_float(0x7C0); CHECK(inf > 3.4e38f && inf == inf * 2, "f11 0x7C0 = +inf"); }
     { float nan = f10_to_float(0x3E1); CHECK(nan != nan, "f10 0x3E1 = NaN"); }
+    CHECK(float_to_f11(1.0f) == 0x3C0 && float_to_f10(1.0f) == 0x1E0,
+          "1.0 packs to the exact f11/f10 exponent fields");
+    CHECK(float_to_f11(-1.0f) == 0 && float_to_f10(-0.5f) == 0,
+          "negative unsigned-small-float values clamp to zero");
+    CHECK(float_to_f11(1.0078125f) == 0x3C0 && float_to_f11(1.0234375f) == 0x3C2,
+          "f11 halfway cases round to an even mantissa");
+    CHECK(float_to_f11(65024.0f) == 0x7BF && float_to_f10(64512.0f) == 0x3DF,
+          "maximum finite f11/f10 values pack without overflowing");
+    uint32_t bad_small_float_roundtrip = 0;
+    for (uint16_t v = 0; v <= 0x7BF; ++v)
+        if (float_to_f11(f11_to_float(v)) != v) ++bad_small_float_roundtrip;
+    for (uint16_t v = 0; v <= 0x3DF; ++v)
+        if (float_to_f10(f10_to_float(v)) != v) ++bad_small_float_roundtrip;
+    CHECK(bad_small_float_roundtrip == 0,
+          "every finite f11/f10 code survives unpack then repack exactly");
     CHECK(data_format_bytes(DataFormat::Float10_11_11) == 0,
           "Float10_11_11 is packed: per-component bytes = 0 (texel size lives in bytes_per_block)");
     CHECK(data_format_bytes(DataFormat::Unorm2_10_10_10) == 0,

--- a/prosper/tests/test_stack_registry.cpp
+++ b/prosper/tests/test_stack_registry.cpp
@@ -7,6 +7,10 @@
 #include <cstdio>
 #include <cstddef>
 #include <cstdint>
+#ifdef __linux__
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 using namespace prosper;
 
@@ -47,15 +51,29 @@ int main() {
         register_builtin_hle();
         auto attr_init = Hle::lookup(nid_hash("scePthreadAttrInit"));
         auto attr_ssz  = Hle::lookup(nid_hash("scePthreadAttrSetstacksize"));
+        auto attr_stack = Hle::lookup(nid_hash("scePthreadAttrSetstack"));
+        auto attr_destroy = Hle::lookup(nid_hash("scePthreadAttrDestroy"));
         auto t_create  = Hle::lookup(nid_hash("scePthreadCreate"));
         auto t_join    = Hle::lookup(nid_hash("scePthreadJoin"));
-        CHECK(attr_init && attr_ssz && t_create && t_join, "thread HLE functions registered");
-        struct Probe { size_t sz = 0; bool found = false; };
+        CHECK(attr_init && attr_ssz && attr_stack && attr_destroy && t_create && t_join,
+              "thread HLE functions registered");
+        struct Probe {
+            size_t sz = 0;
+            bool found = false;
+            const void* expected_base = nullptr;
+            size_t expected_size = 0;
+            bool local_on_expected_stack = false;
+        };
         auto entry = +[](void* p) -> void* {
             auto* pr = (Probe*)p;
+            uint8_t local = 0;
             void* b = nullptr; size_t s = 0;
             pr->found = guest_stack_for_current_thread(&b, &s);
             pr->sz = s;
+            const uintptr_t address = (uintptr_t)&local;
+            const uintptr_t first = (uintptr_t)pr->expected_base;
+            pr->local_on_expected_stack = !pr->expected_base ||
+                (address >= first && address < first + pr->expected_size);
             return nullptr;
         };
         auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
@@ -70,6 +88,7 @@ int main() {
         CHECK(pr.sz >= 2 * 1024 * 1024 && pr.sz < 3 * 1024 * 1024,
               "attr stacksize honored (~2 MiB, not the old fixed 8 MiB)");
         CHECK(!guest_stack_for_thread(tid, &base, &sz), "entry unregistered after the thread exited");
+        attr_destroy(U(&at), 0, 0, 0, 0, 0);
 
         // Tiny request: floored (our HLE + host libc need headroom the Sony runtime doesn't).
         void* at2 = nullptr; attr_init(U(&at2), 0, 0, 0, 0, 0);
@@ -78,6 +97,28 @@ int main() {
         CHECK(t_create(U(&tid2), U(&at2), U((void*)entry), U(&pr2), 0, 0) == 0, "create with 64 KiB attr");
         t_join(tid2, 0, 0, 0, 0, 0);
         CHECK(pr2.found && pr2.sz >= 1 * 1024 * 1024, "tiny request floored to >= 1 MiB");
+        attr_destroy(U(&at2), 0, 0, 0, 0, 0);
+
+        // An exact caller-owned stack must survive the guest-attr -> local-attr copy. Checking a
+        // local variable proves pthread actually ran on that address range, not merely its size.
+        const size_t exact_size = 2 * 1024 * 1024;
+        void* exact_stack = mmap(nullptr, exact_size, PROT_READ | PROT_WRITE,
+                                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        CHECK(exact_stack != MAP_FAILED, "allocated caller-owned exact stack");
+        if (exact_stack != MAP_FAILED) {
+            void* at3 = nullptr; attr_init(U(&at3), 0, 0, 0, 0, 0);
+            CHECK(attr_stack(U(&at3), U(exact_stack), exact_size, 0, 0, 0) == 0,
+                  "scePthreadAttrSetstack accepts an exact POSIX stack range");
+            uint64_t tid3 = 0; Probe pr3;
+            pr3.expected_base = exact_stack; pr3.expected_size = exact_size;
+            CHECK(t_create(U(&tid3), U(&at3), U((void*)entry), U(&pr3), 0, 0) == 0,
+                  "create with caller-owned exact stack");
+            t_join(tid3, 0, 0, 0, 0, 0);
+            CHECK(pr3.found && pr3.local_on_expected_stack,
+                  "created thread executes inside the exact requested stack range");
+            attr_destroy(U(&at3), 0, 0, 0, 0, 0);
+            munmap(exact_stack, exact_size);
+        }
     }
 #endif
 

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -321,8 +321,9 @@ int main() {
         #undef GOLD
     }
 
-    // --- GFX10 64KB modes (#288): SW_64KB_S (tile_mode 9) and SW_64KB_R_X (tile_mode 27). ---
+    // --- GFX10 64KB modes (#288/#825): S (9), Z_X (24), and R_X (27). ---
     CHECK(tile_mode_is_tiled((uint32_t)TileMode::Sw64KbS),  "tile_mode 9 (SW_64KB_S) is tiled");
+    CHECK(tile_mode_is_tiled((uint32_t)TileMode::Sw64KbZX), "tile_mode 24 (SW_64KB_Z_X) is tiled");
     CHECK(tile_mode_is_tiled((uint32_t)TileMode::Sw64KbRX), "tile_mode 27 (SW_64KB_R_X) is tiled");
 
     // GFX10 thin 2D mip chains are tail-first, then smallest-to-largest outside the tail. Evergate's
@@ -338,6 +339,50 @@ int main() {
               "last non-tail mip immediately follows the shared 4KB tail");
         CHECK(tiled_mip_level_offset(2048, 1152, 4, M, 0, 0) == 0,
               "single-level surfaces remain based at byte zero");
+
+        const TiledMipLevelLayout tail7 =
+            tiled_mip_level_layout(2048, 1152, 4, M, 11, 7);
+        CHECK(tail7.supported && tail7.in_tail && tail7.byte_offset == 2048 &&
+                  tail7.tail_x == 4 && tail7.tail_y == 0 && tail7.tail_block_bytes == 4096,
+              "first SW_4KB_S tail level exposes AddrLib byte and element origins");
+        const TiledMipLevelLayout tail11 =
+            tiled_mip_level_layout(2048, 1152, 4, M, 11, 11);
+        CHECK(tail11.supported && tail11.in_tail && tail11.byte_offset == 768 &&
+                  tail11.tail_x == 2 && tail11.tail_y == 2,
+              "last allocated tail level retains its sparse max-tail slot");
+
+        // Pack level 7 into its shared block using the equivalent global tail coordinate, then read
+        // it through the byte-origin API. A write must alter only that level and preserve every
+        // sentinel byte belonging to its siblings.
+        std::vector<uint8_t> full_linear((size_t)32 * 32 * 4, 0);
+        std::vector<uint8_t> level_linear((size_t)16 * 9 * 4, 0);
+        for (uint32_t y = 0; y < 9; ++y) for (uint32_t x = 0; x < 16; ++x) {
+            const uint32_t value = 0x81000000u | (y << 8) | x;
+            std::memcpy(level_linear.data() + ((size_t)y * 16 + x) * 4, &value, 4);
+            std::memcpy(full_linear.data() +
+                            ((size_t)(tail7.tail_y + y) * 32 + tail7.tail_x + x) * 4,
+                        &value, 4);
+        }
+        std::vector<uint8_t> shared_tail(4096, 0);
+        tile_surface(shared_tail.data(), full_linear.data(), 32, 32, M, 0, 4);
+        std::vector<uint8_t> extracted(level_linear.size(), 0);
+        detile_surface_level(extracted.data(), shared_tail.data(), shared_tail.size(),
+                             16, 9, M, 4, tail7.tail_x, tail7.tail_y);
+        CHECK(extracted == level_linear,
+              "tail byte origin detiles the same texels as the documented global coordinate");
+        std::vector<uint8_t> rewritten = shared_tail;
+        std::vector<uint8_t> replacement(level_linear.size(), 0x5a);
+        tile_surface_level(rewritten.data(), rewritten.size(), replacement.data(),
+                           16, 9, M, 4, tail7.tail_x, tail7.tail_y);
+        std::vector<uint8_t> roundtrip(replacement.size(), 0);
+        detile_surface_level(roundtrip.data(), rewritten.data(), rewritten.size(),
+                             16, 9, M, 4, tail7.tail_x, tail7.tail_y);
+        CHECK(roundtrip == replacement,
+              "tail level write/read round-trip preserves the selected mip");
+        size_t changed = 0;
+        for (size_t i = 0; i < rewritten.size(); ++i) changed += rewritten[i] != shared_tail[i];
+        CHECK(changed <= replacement.size(),
+              "tail writeback does not clear or overwrite sibling padding bytes");
     }
 
     // Tiled footprint: a 64KB block holds 65536 bytes; its element dims depend on bpe
@@ -352,7 +397,51 @@ int main() {
               "16-byte elements (BC7 blocks): 256x128 -> 4x2 blocks of 64x64");
     }
 
-    // Round-trip identity for both 64KB modes at every element size (incl. block-unaligned dims).
+    // Official GFX10 AddrLib linear mip chains are also smallest-first. Astro's 480x270 RGBA32F
+    // post resource has eight levels: each pitch is 256-byte aligned (64 four-byte elements).
+    {
+        const TiledMipLevelLayout linear3 = tiled_mip_level_layout(480, 270, 4, 0, 7, 3);
+        const TiledMipLevelLayout linear5 = tiled_mip_level_layout(480, 270, 4, 0, 7, 5);
+        CHECK(linear3.supported && !linear3.in_tail && linear3.byte_offset == 7680,
+              "Astro linear mip3 follows smaller aligned levels exactly");
+        CHECK(linear5.supported && !linear5.in_tail && linear5.byte_offset == 1536,
+              "Astro linear mip5 follows levels 7 and 6 exactly");
+    }
+
+    // Astro Bot's 1920x1080 post chain selects levels 5/6 of an eight-level 64KB_R_X allocation.
+    // Both are packed into the first 64 KiB macroblock, at the exact coordinates below.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbRX;
+        const TiledMipLevelLayout tail5 =
+            tiled_mip_level_layout(1920, 1080, 4, M, 7, 5);
+        const TiledMipLevelLayout tail6 =
+            tiled_mip_level_layout(1920, 1080, 4, M, 7, 6);
+        CHECK(tail5.supported && tail5.in_tail && tail5.byte_offset == 32768 &&
+                  tail5.tail_x == 64 && tail5.tail_y == 0 &&
+                  tail5.tail_block_bytes == 65536,
+              "Astro 60x33 level-5 R_X tail coordinate is exact");
+        CHECK(tail6.supported && tail6.in_tail && tail6.byte_offset == 16384 &&
+                  tail6.tail_x == 0 && tail6.tail_y == 64,
+              "Astro 30x16 level-6 R_X tail coordinate is exact");
+
+        std::vector<uint8_t> block_linear((size_t)128 * 128 * 4, 0);
+        std::vector<uint8_t> mip_linear((size_t)60 * 33 * 4, 0);
+        for (uint32_t y = 0; y < 33; ++y) for (uint32_t x = 0; x < 60; ++x) {
+            const uint32_t value = 0xa5000000u | (y << 10) | x;
+            std::memcpy(mip_linear.data() + ((size_t)y * 60 + x) * 4, &value, 4);
+            std::memcpy(block_linear.data() +
+                            ((size_t)(tail5.tail_y + y) * 128 + tail5.tail_x + x) * 4,
+                        &value, 4);
+        }
+        std::vector<uint8_t> tiled(65536, 0), extracted(mip_linear.size(), 0);
+        tile_surface(tiled.data(), block_linear.data(), 128, 128, M, 0, 4);
+        detile_surface_level(extracted.data(), tiled.data(), tiled.size(), 60, 33, M, 4,
+                             tail5.tail_x, tail5.tail_y);
+        CHECK(extracted == mip_linear,
+              "Astro R_X tail extraction matches the full-block swizzle exactly");
+    }
+
+    // Round-trip identity for all three 64KB modes at every element size (incl. block-unaligned dims).
     {
         auto rt64 = [&](uint32_t M, uint32_t w, uint32_t h, uint32_t bpe) -> bool {
             std::vector<uint8_t> ref((size_t)w * h * bpe);
@@ -363,17 +452,48 @@ int main() {
             detile_surface(back.data(), tiled.data(), w, h, M, 0, bpe);
             return back == ref;
         };
-        const uint32_t S = (uint32_t)TileMode::Sw64KbS, R = (uint32_t)TileMode::Sw64KbRX;
+        const uint32_t S = (uint32_t)TileMode::Sw64KbS;
+        const uint32_t Z = (uint32_t)TileMode::Sw64KbZX;
+        const uint32_t R = (uint32_t)TileMode::Sw64KbRX;
         CHECK(rt64(S, 256, 256, 1),  "SW_64KB_S round-trip 256x256 @ 1 B (one block)");
         CHECK(rt64(S, 300, 140, 2),  "SW_64KB_S round-trip 300x140 @ 2 B (unaligned)");
         CHECK(rt64(S, 500, 300, 4),  "SW_64KB_S round-trip 500x300 @ 4 B (unaligned)");
         CHECK(rt64(S, 128, 64, 8),   "SW_64KB_S round-trip 128x64 @ 8 B (one block, BC1 grid)");
         CHECK(rt64(S, 130, 70, 16),  "SW_64KB_S round-trip 130x70 @ 16 B (unaligned BC7 grid)");
+        CHECK(rt64(Z, 260, 260, 1),  "SW_64KB_Z_X round-trip 260x260 @ 1 B");
+        CHECK(rt64(Z, 300, 140, 2),  "SW_64KB_Z_X round-trip 300x140 @ 2 B");
+        CHECK(rt64(Z, 500, 300, 4),  "SW_64KB_Z_X round-trip 500x300 @ 4 B");
+        CHECK(rt64(Z, 130, 70, 8),   "SW_64KB_Z_X round-trip 130x70 @ 8 B");
+        CHECK(rt64(Z, 70, 70, 16),   "SW_64KB_Z_X round-trip 70x70 @ 16 B");
         CHECK(rt64(R, 260, 130, 1),  "SW_64KB_R_X round-trip 260x130 @ 1 B");
         CHECK(rt64(R, 300, 140, 2),  "SW_64KB_R_X round-trip 300x140 @ 2 B");
         CHECK(rt64(R, 500, 300, 4),  "SW_64KB_R_X round-trip 500x300 @ 4 B");
         CHECK(rt64(R, 130, 70, 8),   "SW_64KB_R_X round-trip 130x70 @ 8 B");
         CHECK(rt64(R, 70, 70, 16),   "SW_64KB_R_X round-trip 70x70 @ 16 B");
+    }
+
+    // AMD AddrLib GFX10_SW_64K_Z_X_1xaa golden, 16 pipes, 4 bpe. The selected pattern is
+    // nibble01[10] + nibble2[74] + nibble3[31]: low Morton pairs, four pipe-XOR bits, then
+    // y3/x4/y6/x6. These independent positions pin both the Z order and the pipe rotation used
+    // by Astro Bot's live mode-24 compute surfaces; a tile/detile round-trip alone cannot do that.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbZX;
+        const uint32_t ew = 128, eh = 128, bpe = 4;
+        std::vector<uint8_t> ref((size_t)ew * eh * bpe);
+        for (size_t i = 0; i < ref.size(); i++) ref[i] = (uint8_t)((i >> 2) * 181 + i);
+        std::vector<uint8_t> tiled(65536, 0);
+        tile_surface(tiled.data(), ref.data(), ew, eh, M, 0, bpe);
+        auto at = [&](uint32_t x, uint32_t y) { return &ref[((size_t)y * ew + x) * bpe]; };
+        CHECK(std::memcmp(&tiled[4],      at(1, 0),  bpe) == 0, "64KB_Z_X 4B golden: element (1,0) at byte 4");
+        CHECK(std::memcmp(&tiled[8],      at(0, 1),  bpe) == 0, "64KB_Z_X 4B golden: element (0,1) at byte 8");
+        CHECK(std::memcmp(&tiled[256],    at(8, 0),  bpe) == 0, "64KB_Z_X 4B golden: element (8,0) at byte 256");
+        CHECK(std::memcmp(&tiled[4352],   at(0, 8),  bpe) == 0, "64KB_Z_X 4B golden: element (0,8) at byte 4352");
+        CHECK(std::memcmp(&tiled[8704],   at(16, 0), bpe) == 0, "64KB_Z_X 4B golden: element (16,0) at byte 8704");
+        CHECK(std::memcmp(&tiled[512],    at(0, 16), bpe) == 0, "64KB_Z_X 4B golden: element (0,16) at byte 512");
+        CHECK(std::memcmp(&tiled[2048],   at(32, 0), bpe) == 0, "64KB_Z_X 4B golden: element (32,0) at byte 2048");
+        CHECK(std::memcmp(&tiled[1024],   at(0, 32), bpe) == 0, "64KB_Z_X 4B golden: element (0,32) at byte 1024");
+        CHECK(std::memcmp(&tiled[33792],  at(64, 0), bpe) == 0, "64KB_Z_X 4B golden: element (64,0) at byte 33792");
+        CHECK(std::memcmp(&tiled[18432],  at(0, 64), bpe) == 0, "64KB_Z_X 4B golden: element (0,64) at byte 18432");
     }
 
     // Golden positions from the addrlib GFX10_SW_64K_S pattern (gfx10SwizzlePattern.h). At 8 bpe the

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -49,6 +49,7 @@ int main() {
     // immediate calls land in the same period; a > one-period sleep must advance the count.
     uint8_t vb[0x28];
     vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c0 = *(uint64_t*)vb;
+    CHECK(c0 > 0, "first vblank query reports a live non-zero counter");
     vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c1 = *(uint64_t*)vb;
     CHECK(c1 - c0 <= 1, "vblank counter does NOT tick per poll (immediate re-poll ~same period)");
     std::this_thread::sleep_for(std::chrono::milliseconds(40));   // > 2 vblank periods

--- a/prosper/tests/test_win_kernel_is_stack.cpp
+++ b/prosper/tests/test_win_kernel_is_stack.cpp
@@ -19,6 +19,44 @@ struct WorkerStackProbe {
     size_t size = 0;
 };
 
+struct GuestStackProbe {
+    bool registered = false;
+    bool fully_committed = false;
+    size_t registered_size = 0;
+};
+
+// k_pthread_create enters guest functions with the SysV ABI even in the native Windows build.
+// Inspect the resulting reservation from inside that exact trampoline, after its PS5 stack setup.
+static void* __attribute__((sysv_abi)) prepared_guest_worker(void* raw) {
+    auto* probe = static_cast<GuestStackProbe*>(raw);
+    void* registered_base = nullptr;
+    probe->registered = guest_stack_for_current_thread(&registered_base, &probe->registered_size);
+
+    ULONG_PTR low = 0, high = 0;
+    GetCurrentThreadStackLimits(&low, &high);
+    MEMORY_BASIC_INFORMATION top{};
+    if (!high || !VirtualQuery((void*)(high - 1), &top, sizeof(top)) || !top.AllocationBase)
+        return nullptr;
+
+    SYSTEM_INFO si{};
+    GetSystemInfo(&si);
+    const uintptr_t page = si.dwPageSize ? si.dwPageSize : 0x1000;
+    uintptr_t cursor = (uintptr_t)top.AllocationBase + page; // bottom page remains inaccessible
+    bool committed = cursor < high;
+    while (committed && cursor < high) {
+        MEMORY_BASIC_INFORMATION mbi{};
+        if (!VirtualQuery((void*)cursor, &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT) {
+            committed = false;
+            break;
+        }
+        uintptr_t next = (uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+        if (next <= cursor) { committed = false; break; }
+        cursor = next;
+    }
+    probe->fully_committed = committed;
+    return nullptr;
+}
+
 static void* registered_worker(void* raw) {
     auto* probe = static_cast<WorkerStackProbe*>(raw);
     ULONG_PTR low = 0, high = 0;
@@ -39,8 +77,12 @@ int main() {
     auto attr_get = Hle::lookup(nid_hash("scePthreadAttrGet"));
     auto attr_getaddr = Hle::lookup(nid_hash("scePthreadAttrGetstackaddr"));
     auto attr_getsize = Hle::lookup(nid_hash("scePthreadAttrGetstacksize"));
+    auto attr_setsize = Hle::lookup(nid_hash("scePthreadAttrSetstacksize"));
     auto attr_destroy = Hle::lookup(nid_hash("scePthreadAttrDestroy"));
-    if (!is_stack || !attr_init || !attr_get || !attr_getaddr || !attr_getsize || !attr_destroy) {
+    auto thread_create = Hle::lookup(nid_hash("scePthreadCreate"));
+    auto thread_join = Hle::lookup(nid_hash("scePthreadJoin"));
+    if (!is_stack || !attr_init || !attr_get || !attr_getaddr || !attr_getsize || !attr_setsize ||
+        !attr_destroy || !thread_create || !thread_join) {
         std::fprintf(stderr, "required stack HLE is not registered\n");
         return 1;
     }
@@ -123,20 +165,40 @@ int main() {
     attr_destroy((uint64_t)(uintptr_t)&attr, 0, 0, 0, 0, 0);
     if (sentinel_stack) VirtualFree(sentinel_stack, 0, MEM_RELEASE);
 
+    // A tiny Sony request is floored to leave room for the emulator boundary, and every usable
+    // page is committed before guest entry.  This specifically guards PS5 code that makes a large
+    // stack jump without the Windows page-by-page probes emitted by native Windows compilers.
+    void* guest_attr = nullptr;
+    attr_init((uint64_t)(uintptr_t)&guest_attr, 0, 0, 0, 0, 0);
+    attr_setsize((uint64_t)(uintptr_t)&guest_attr, 64 * 1024, 0, 0, 0, 0);
+    GuestStackProbe guest_probe;
+    uint64_t guest_tid = 0;
+    bool guest_created = thread_create((uint64_t)(uintptr_t)&guest_tid,
+                                       (uint64_t)(uintptr_t)&guest_attr,
+                                       (uint64_t)(uintptr_t)&prepared_guest_worker,
+                                       (uint64_t)(uintptr_t)&guest_probe, 0, 0) == 0;
+    if (guest_created) thread_join(guest_tid, 0, 0, 0, 0, 0);
+    attr_destroy((uint64_t)(uintptr_t)&guest_attr, 0, 0, 0, 0, 0);
+    bool guest_stack_prepared = guest_created && guest_probe.registered &&
+                                guest_probe.registered_size >= 1024 * 1024 &&
+                                guest_probe.fully_committed;
+
     unregister_thread_stack((uint64_t)GetCurrentThreadId());
     bool unregistered = is_stack(addr, 0, 0, 0, 0, 0) == 0;
 
     if (!inside || !below || !at_end || !attr_bounds || !worker_created || !resolved_worker ||
         !target_attr_bounds || !std_thread_self_resolved || !std_thread_registration_cleaned ||
-        !missing_target_unchanged || !unregistered) {
+        !missing_target_unchanged || !guest_stack_prepared || !unregistered) {
         std::fprintf(stderr,
                      "stack HLE mismatch: inside=%d below=%d at_end=%d attr_bounds=%d "
                      "worker_created=%d resolved_worker=%d target_attr_bounds=%d std_self=%d "
                      "std_cleaned=%d "
-                     "missing_unchanged=%d reported=%p/%zu expected=%p/%zu unregistered=%d\n",
+                     "missing_unchanged=%d guest_prepared=%d guest_size=%zu committed=%d "
+                     "reported=%p/%zu expected=%p/%zu unregistered=%d\n",
                      inside, below, at_end, attr_bounds, worker_created, resolved_worker,
                      target_attr_bounds, std_thread_self_resolved,
                      std_thread_registration_cleaned, missing_target_unchanged,
+                     guest_stack_prepared, guest_probe.registered_size, guest_probe.fully_committed,
                      reported_base, reported_size,
                      probe.base, probe.size, unregistered);
         return 1;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -258,8 +258,30 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     for (const auto& seed : replay.ds_seeds) {
         const uint64_t depth_hash = prosper::gpu::gpu_capture_hash(seed.depth);
         const uint64_t stencil_hash = prosper::gpu::gpu_capture_hash(seed.stencil);
+        float depth_min = INFINITY, depth_max = -INFINITY, depth_first = 0.0f;
+        size_t depth_finite = 0, depth_nonfinite = 0, depth_first_count = 0;
+        uint32_t depth_first_bits = 0;
+        if (seed.depth.size() >= sizeof(float))
+            std::memcpy(&depth_first_bits, seed.depth.data(), sizeof(depth_first_bits));
+        std::memcpy(&depth_first, &depth_first_bits, sizeof(depth_first));
+        for (size_t offset = 0; offset + sizeof(float) <= seed.depth.size();
+             offset += sizeof(float)) {
+            uint32_t bits = 0;
+            float value = 0.0f;
+            std::memcpy(&bits, seed.depth.data() + offset, sizeof(bits));
+            std::memcpy(&value, &bits, sizeof(value));
+            depth_first_count += bits == depth_first_bits;
+            if (std::isfinite(value)) {
+                depth_min = std::min(depth_min, value);
+                depth_max = std::max(depth_max, value);
+                ++depth_finite;
+            } else {
+                ++depth_nonfinite;
+            }
+        }
         std::printf("ds-seed base-z=%016llx/%016llx base-s=%016llx/%016llx htile=%016llx "
-                    "extent=%ux%u format=%s valid=%d/%d depth=%zu/%016llx stencil=%zu/%016llx\n",
+                    "extent=%ux%u format=%s valid=%d/%d depth=%zu/%016llx stencil=%zu/%016llx "
+                    "depth-stats first=%g/0x%08x same=%zu finite=%zu nonfinite=%zu range=[%g,%g]\n",
                     static_cast<unsigned long long>(seed.depth_read_base),
                     static_cast<unsigned long long>(seed.depth_write_base),
                     static_cast<unsigned long long>(seed.stencil_read_base),
@@ -268,7 +290,9 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     seed.format == prosper::gpu::GpuCaptureDsFormat::D32FloatS8 ? "D32S8" : "D32",
                     seed.depth_valid, seed.stencil_valid, seed.depth.size(),
                     static_cast<unsigned long long>(depth_hash), seed.stencil.size(),
-                    static_cast<unsigned long long>(stencil_hash));
+                    static_cast<unsigned long long>(stencil_hash), depth_first, depth_first_bits,
+                    depth_first_count, depth_finite, depth_nonfinite,
+                    depth_finite ? depth_min : 0.0f, depth_finite ? depth_max : 0.0f);
     }
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -6,6 +6,9 @@ flow before changing the recompiler.
 ```bash
 cmake --build build-linux -j8 --target shader_inspect
 ./build-linux/shader_inspect /tmp/shaders/exec_ps_7f123400.bin
+
+# Run the complete stage translator too; PROSPER_DBG identifies a contextual rejection PC.
+PROSPER_DBG=1 ./build-linux/shader_inspect /tmp/shaders/exec_vs_7f123400.bin --stage vertex
 ```
 
 `PROSPER_SHADER_DUMP=DIR` writes raw shaders that fail recompilation. To inspect a shader that succeeds,
@@ -27,6 +30,8 @@ Each instruction row includes its dword PC, encoded length, format/opcode, exact
 operands, and, for SOPP branches, the signed immediate and resolved target PC. The header also prints
 the stage-agnostic `recompile_coverage` result. That coverage is intentionally compute-safe; a VCC
 control-flow shape may remain listed there even when the vertex/fragment structurizer accepts it.
+`--stage vertex|fragment` additionally runs the complete stage translator, which exposes contextual
+resource and structured-control-flow failures that per-instruction coverage cannot decide.
 When a shader contains the fully proven bounded scalar `s_setpc_b64` jump-table idiom, the header also
 prints its constant-buffer selector, adjustment/clamp, complete target list, merge PC, and owning span.
 

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -46,8 +46,11 @@ void print_operand(const char* label, const Operand& operand) {
 } // namespace
 
 int main(int argc, char** argv) {
-    if (argc != 2) {
-        std::fprintf(stderr, "usage: %s <raw-rdna2.bin>\n", argv[0]);
+    std::string stage;
+    if (argc == 4 && std::strcmp(argv[2], "--stage") == 0) stage = argv[3];
+    if ((argc != 2 && argc != 4) ||
+        (!stage.empty() && stage != "vertex" && stage != "fragment")) {
+        std::fprintf(stderr, "usage: %s <raw-rdna2.bin> [--stage vertex|fragment]\n", argv[0]);
         return 2;
     }
 
@@ -87,6 +90,15 @@ int main(int argc, char** argv) {
                 coverage.unsupported,
                 coverage.first_bad_fmt < 0 ? "none" : format_name(static_cast<Rdna2Format>(coverage.first_bad_fmt)),
                 coverage.first_bad_op);
+    bool stage_ok = true;
+    if (!stage.empty()) {
+        std::vector<uint32_t> spirv = stage == "vertex"
+            ? recompile_vertex(words.data(), words.size())
+            : recompile_fragment(words.data(), words.size());
+        stage_ok = !spirv.empty();
+        std::printf("stage-recompile stage=%s status=%s spirv_dwords=%zu\n",
+                    stage.c_str(), stage_ok ? "ok" : "rejected", spirv.size());
+    }
     const PcrelDispatchInfo dispatch = rdna2_pcrel_dispatch_info(words.data(), words.size());
     if (dispatch.valid) {
         std::printf("pcrel-dispatch selector=s%u+0x%x add=%d max=%u setpc=%u merge=%u "
@@ -123,5 +135,5 @@ int main(int argc, char** argv) {
         std::printf("\n");
     }
 
-    return ended ? 0 : 1;
+    return ended && stage_ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

This is the first natural checkpoint for #825. It boots Astro Bot (`PPSA21564`) through its early startup sequence and renders the loading screen on all four requested frontends:

- Linux headless capture
- Linux SDL application
- Windows headless capture
- Windows SDL application

The Linux runs progress beyond the diagonal loading background to the `Sony Interactive Entertainment presents` frame. The native Windows application and capture frontend render the same loading sequence without the worker-stack and fiber-switch crashes seen at the start of the issue.

This PR does not claim the title/menu or first-level milestones. Work on those continues separately after this checkpoint. Progresses #825.

## Root causes

Astro exercises substantially more of the PS5 userspace and RDNA2 surface than the existing fixtures. Reaching a visible frame required addressing several independent gaps rather than adding a title-specific bypass:

- legitimate direct-memory mappings overlapped the old fixed boot-image addresses;
- Windows guest workers could jump over the OS guard page with PS5-sized stack movement, and Windows TEB stack bounds became stale across Sony fiber switches;
- required kernel, POSIX semaphore, fiber, font, AGC, and memory services were missing or incomplete;
- captured AGC state, texture layouts, mip tails, storage formats, and compute dependencies were incomplete;
- multiple scalar/vector RDNA2, SDWA, DPP, wave-mask, buffer-atomic, conversion, and image operations were not decoded or lowered;
- the render runner treated a programmed depth-clear value as an enabled clear, collapsing valid content.

## What changed

- reserve and commit Windows guest-worker stacks safely, preserve guard semantics, and keep TEB `StackBase` / `StackLimit` synchronized across fiber switches;
- add the HLE services and state needed by Astro's boot path, including Sony fibers, font calls, POSIX semaphores, AGC shader creation, stack attributes, and memory queries;
- move fixed boot images away from Astro's valid direct-memory ranges;
- expand AGC capture/replay, live compute execution, resource dependency tracking, and format/layout handling;
- implement the RDNA2 instructions and resource conventions exercised by the loading workload;
- correct depth-clear fallback behavior and extend focused unit/render tests.

No game dumps, shader captures, screenshots, or other copyrighted game assets are included.

## Validation

- Linux configure/build with GCC 13.3 and `PROSPER_APP=ON`
- Linux CTest: **108/108 passed**
- Windows MinGW-w64 UCRT GCC 16.1 full build with SDL audio/pad/app enabled
- Windows CTest: **80/80 passed**, including `fiber_hle` and `win_kernel_is_stack`
- required real-game snapshot matrix:
  - `messenger-scene`: 49/49 qualifying frames
  - `dead-cells-gameplay`: 49/49 qualifying frames, 48 pixel changes
  - `blasphemous2-gameplay`: 99/99 qualifying frames, 98 pixel changes
- Astro Linux headless: 20 rendered frames; reaches the Sony presentation screen
- Astro Linux app: 20 presented frames; reaches the Sony presentation screen
- Astro Windows headless: 20 composited frames; diagonal loading background visible
- Astro Windows app: 20 presented frames; diagonal loading background visible; clean exit
- `git diff --check origin/master...HEAD`

## Risk and follow-up

The change is necessarily broad because the boot path crosses HLE, memory, capture, texture, compute, and shader-recompiler boundaries. Focused tests cover the new primitives and the existing three-title snapshot matrix guards renderer regressions, but additional shader/resource combinations will appear at the title and gameplay milestones. The next checkpoint will target a correctly rendered title screen and main menu across the same frontend matrix.
