### PR TITLE
feat(gpu_capture): replay ordered DMA operations

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -478,7 +478,7 @@ if(TARGET prosper_core)
 
   add_executable(test_gpu_timeline_capture_exit tests/test_gpu_timeline_capture_exit.cpp)
   target_link_libraries(test_gpu_timeline_capture_exit PRIVATE prosper_core)
-  add_test(NAME gpu_timeline_capture_failure_exit COMMAND test_gpu_timeline_capture_exit)
+  add_test(NAME gpu_timeline_capture_exit COMMAND test_gpu_timeline_capture_exit)
 
   # gpu_replay output dimensions follow the selected draw/prefix target when its byte count agrees.
   # Pure/cross-platform so focused replay tooling remains available in CI.

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 13;
+constexpr uint32_t kVersion = 14;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -333,6 +333,7 @@ struct Interval {
 
 bool collect_intervals(const std::vector<DrawItem>& draws,
                        const std::vector<ComputeItem>& computes,
+                       const std::vector<GpuState::DmaCopy>& dma_copies,
                        uint64_t resource_limit_bytes,
                        std::vector<Interval>& intervals, std::string& error) {
     uint64_t total = 0;
@@ -358,6 +359,16 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
     };
     for (const auto& d : draws) if (!add_table(d.vrt.get()) || !add_table(d.prt.get())) return false;
     for (const auto& c : computes) if (!add_table(c.resources.get())) return false;
+    for (const auto& copy : dma_copies) {
+        if (!copy.dst || !copy.src || !copy.bytes ||
+            copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes ||
+            copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes) {
+            error = "ordered DMA capture range is invalid";
+            return false;
+        }
+        intervals.push_back({copy.dst, copy.dst + copy.bytes});
+        intervals.push_back({copy.src, copy.src + copy.bytes});
+    }
     std::sort(intervals.begin(), intervals.end(), [](auto a, auto b) { return a.begin < b.begin; });
     std::vector<Interval> merged;
     for (auto x : intervals) {
@@ -383,6 +394,18 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
     intervals = std::move(merged); return true;
 }
 
+bool assign_blob_range(const std::vector<Interval>& intervals, uint64_t addr, uint64_t bytes,
+                       uint32_t& index, uint64_t& offset, const char* missing,
+                       std::string& error) {
+    auto it = std::find_if(intervals.begin(), intervals.end(), [&](auto x) {
+        return x.begin <= addr && addr <= x.end && bytes <= x.end - addr;
+    });
+    if (it == intervals.end()) { error = missing; return false; }
+    index = it->blob_index;
+    offset = addr - it->begin;
+    return true;
+}
+
 bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& intervals,
                    bool include_resource_data, GpuCapturedTable& dst, std::string& error) {
     dst.present = src != nullptr;
@@ -393,23 +416,14 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
         c.resource.dcc_metadata_host_data_size = 0;
         c.metadata_size = dcc_metadata_footprint(r);
         c.resource.dcc_metadata_size = c.metadata_size;
-        auto assign_blob = [&](uint64_t addr, uint64_t bytes, uint32_t& index,
-                               uint64_t& offset, const char* missing) {
-            auto it = std::find_if(intervals.begin(), intervals.end(), [&](auto x) {
-                return x.begin <= addr && addr + bytes <= x.end;
-            });
-            if (it == intervals.end()) { error = missing; return false; }
-            index = it->blob_index; offset = addr - it->begin;
-            return true;
-        };
         uint64_t n = resource_footprint(r);
         if (n && include_resource_data &&
-            !assign_blob(r.gpu_addr, n, c.blob_index, c.blob_offset,
-                         "resource was not assigned to a capture blob")) return false;
+            !assign_blob_range(intervals, r.gpu_addr, n, c.blob_index, c.blob_offset,
+                               "resource was not assigned to a capture blob", error)) return false;
         if (c.metadata_size && include_resource_data &&
-            !assign_blob(r.metadata_addr, c.metadata_size, c.metadata_blob_index,
-                         c.metadata_blob_offset,
-                         "DCC metadata was not assigned to a capture blob")) return false;
+            !assign_blob_range(intervals, r.metadata_addr, c.metadata_size,
+                               c.metadata_blob_index, c.metadata_blob_offset,
+                               "DCC metadata was not assigned to a capture blob", error)) return false;
         dst.resources.push_back(std::move(c));
     }
     return true;
@@ -524,6 +538,67 @@ using OperationIdentity = std::tuple<uint8_t, uint64_t, uint64_t>;
 OperationIdentity operation_identity(SubmitOperationKind kind, uint64_t source_index,
                                      uint64_t command_order) {
     return {static_cast<uint8_t>(kind), source_index, command_order};
+}
+
+bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
+    if (capture.dma_copies.size() > kMaxOperations) {
+        error = "invalid ordered DMA count";
+        return false;
+    }
+    std::vector<uint8_t> referenced(capture.dma_copies.size(), 0);
+    auto validate_blob = [&](uint32_t index, uint64_t offset, uint32_t bytes,
+                             const char* invalid, const char* exceeds) {
+        if (index == 0xFFFFFFFFu) {
+            if (!offset) return true;
+            error = invalid;
+            return false;
+        }
+        if (index >= capture.blobs.size()) {
+            error = invalid;
+            return false;
+        }
+        const auto& blob = capture.blobs[index];
+        if (!capture_blob_payload_omitted(blob) &&
+            (offset > blob.bytes.size() || bytes > blob.bytes.size() - offset)) {
+            error = exceeds;
+            return false;
+        }
+        return true;
+    };
+    for (const auto& copy : capture.dma_copies) {
+        if (!copy.dst || !copy.src || !copy.bytes || copy.bytes > kMaxBlobBytes ||
+            copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes ||
+            copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes ||
+            !validate_blob(copy.destination_blob_index, copy.destination_blob_offset, copy.bytes,
+                           "ordered DMA destination references an invalid capture blob",
+                           "ordered DMA destination exceeds its capture blob") ||
+            !validate_blob(copy.source_blob_index, copy.source_blob_offset, copy.bytes,
+                           "ordered DMA source references an invalid capture blob",
+                           "ordered DMA source exceeds its capture blob")) {
+            if (error.empty()) error = "invalid ordered DMA record";
+            return false;
+        }
+    }
+    for (const auto& operation : capture.operations) {
+        if (operation.kind > SubmitOperationKind::DmaCopy) {
+            error = "invalid operation kind";
+            return false;
+        }
+        if (operation.kind != SubmitOperationKind::DmaCopy) continue;
+        if (!operation.realized || operation.source_index >= capture.dma_copies.size() ||
+            capture.dma_copies[operation.source_index].command_order != operation.command_order ||
+            referenced[operation.source_index] == UINT8_MAX) {
+            error = "ordered DMA operation does not match its record";
+            return false;
+        }
+        ++referenced[operation.source_index];
+    }
+    if (std::find_if(referenced.begin(), referenced.end(), [](uint8_t count) { return count != 1; }) !=
+        referenced.end()) {
+        error = "ordered DMA record must have exactly one operation";
+        return false;
+    }
+    return true;
 }
 
 bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& error) {
@@ -767,7 +842,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           const GpuCaptureMetadata& metadata,
                           const CaptureMemoryReader& reader, GpuCaptureFile& out,
                           std::string& error, const CaptureRttSeedReader& rtt_reader,
-                          const std::vector<OperationRealizationFailure>& failures) {
+                          const std::vector<OperationRealizationFailure>& failures,
+                          const std::vector<GpuState::DmaCopy>& dma_copies) {
     error.clear(); out = {}; out.metadata = metadata;
     out.failure_diagnostics_available = true;
     if (draws.size() > kMaxDraws || computes.size() > kMaxComputes ||
@@ -785,7 +861,7 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         out.metadata.renderer_env.emplace_back("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1");
     std::vector<Interval> intervals;
     if (include_resource_data &&
-        !collect_intervals(draws, computes, resource_limit_bytes, intervals, error)) return false;
+        !collect_intervals(draws, computes, dma_copies, resource_limit_bytes, intervals, error)) return false;
     for (auto& x : intervals) {
         GpuCaptureBlob b; b.guest_addr = x.begin; b.bytes.resize(static_cast<size_t>(x.end - x.begin), 0);
         b.bytes_read = std::min<uint64_t>(reader(x.begin, b.bytes.data(), b.bytes.size()), b.bytes.size());
@@ -823,15 +899,47 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                            c.resources, error)) return false;
         out.computes.push_back(std::move(c));
     }
+    out.dma_copies.reserve(dma_copies.size());
+    for (const auto& copy : dma_copies) {
+        GpuCapturedDmaCopy captured;
+        captured.dst = copy.dst; captured.src = copy.src; captured.bytes = copy.bytes;
+        captured.sels = copy.sels; captured.command_order = copy.command_order;
+        captured.packet_addr = copy.packet_addr;
+        if (include_resource_data &&
+            (!assign_blob_range(intervals, copy.dst, copy.bytes,
+                                captured.destination_blob_index,
+                                captured.destination_blob_offset,
+                                "ordered DMA destination was not assigned to a capture blob", error) ||
+             !assign_blob_range(intervals, copy.src, copy.bytes,
+                                captured.source_blob_index, captured.source_blob_offset,
+                                "ordered DMA source was not assigned to a capture blob", error)))
+            return false;
+        out.dma_copies.push_back(captured);
+    }
     std::unordered_set<uint64_t> realized_draws, realized_computes;
     for (const auto& draw : out.draws) realized_draws.insert(draw.draw_index);
     for (const auto& compute : out.computes) realized_computes.insert(compute.dispatch_index);
     for (const auto& operation : operations) {
-        const bool realized = operation.kind == SubmitOperationKind::Draw
-            ? realized_draws.count(operation.index) != 0
-            : realized_computes.count(operation.index) != 0;
+        bool realized = false;
+        switch (operation.kind) {
+            case SubmitOperationKind::Draw:
+                realized = realized_draws.count(operation.index) != 0;
+                break;
+            case SubmitOperationKind::Dispatch:
+                realized = realized_computes.count(operation.index) != 0;
+                break;
+            case SubmitOperationKind::DmaCopy:
+                if (operation.index >= out.dma_copies.size() ||
+                    out.dma_copies[operation.index].command_order != operation.command_order) {
+                    error = "ordered DMA operation references an invalid record";
+                    return false;
+                }
+                realized = true;
+                break;
+        }
         out.operations.push_back({operation.kind, operation.index, operation.command_order, realized});
     }
+    if (!validate_dma_copies(out, error)) return false;
     if (!capture_failure_diagnostics(failures, reader, out, error)) return false;
     collect_shader_versions(out);
     if (rtt_reader && include_resource_data) {
@@ -862,21 +970,38 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
             total += seed.rgba.size(); out.rtt_seeds.push_back(std::move(seed));
         }
     }
-    return true;
+    return validate_dma_copies(out, error);
 }
 
-static bool reject_unsupported_gpustate_capture(const GpuState& state, std::string& error) {
-    if (state.dma_copies.empty()) return false;
-    error = "GPU capture v13 cannot represent " + std::to_string(state.dma_copies.size()) +
-            " ordered DMA_DATA operation(s); capture would be incomplete (see #833)";
-    return true;
+static CaptureMemoryReader ordered_gpustate_capture_reader(const GpuState& state) {
+    return [&state](uint64_t addr, uint8_t* destination, size_t bytes) -> size_t {
+        size_t copied = read_capture_guest_memory(addr, destination, bytes);
+        if (!bytes || addr > std::numeric_limits<uint64_t>::max() - bytes) return copied;
+        const uint64_t end = addr + bytes;
+        for (const auto& copy : state.dma_copies) {
+            std::vector<uint8_t> source;
+            if (read_live_render_target_bytes(copy.src, copy.bytes, source) !=
+                    LiveTargetByteReadResult::Success || source.size() != copy.bytes)
+                continue;
+            const uint64_t copy_end = copy.src + copy.bytes;
+            const uint64_t overlap_begin = std::max(addr, copy.src);
+            const uint64_t overlap_end = std::min(end, copy_end);
+            if (overlap_begin >= overlap_end) continue;
+            const size_t destination_offset = static_cast<size_t>(overlap_begin - addr);
+            const size_t source_offset = static_cast<size_t>(overlap_begin - copy.src);
+            const size_t overlap_bytes = static_cast<size_t>(overlap_end - overlap_begin);
+            std::memcpy(destination + destination_offset, source.data() + source_offset,
+                        overlap_bytes);
+            copied = std::max(copied, destination_offset + overlap_bytes);
+        }
+        return copied;
+    };
 }
 
 bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
                              GpuCaptureFile& out, std::string& error) {
-    if (reject_unsupported_gpustate_capture(state, error)) return false;
     const bool caplog = std::getenv("PROSPER_GPU_CAPTURE_LOG") != nullptr;
     std::vector<OperationRealizationFailure> failures, compute_failures;
     if (caplog) std::fprintf(stderr, "[cap] realize_gpustate_draws...\n");
@@ -892,8 +1017,11 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
     actual.submit_index = submit_no;
     auto ops = plan_submit_operations(state);
     if (caplog) std::fprintf(stderr, "[cap] ops=%zu; capture_submit_items...\n", ops.size());
-    return capture_submit_items(draws, computes, ops, actual,
-                                read_capture_guest_memory, out, error, g_rtt_seed_reader, failures);
+    // Raw guest memory is normally authoritative. A live renderer-owned target is the exception:
+    // ordered DMA reads its host pixels, so overlay those exact bytes into the pre-submit closure.
+    CaptureMemoryReader ordered_reader = ordered_gpustate_capture_reader(state);
+    return capture_submit_items(draws, computes, ops, actual, ordered_reader, out, error,
+                                g_rtt_seed_reader, failures, state.dma_copies);
 }
 
 bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
@@ -901,7 +1029,6 @@ bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
                                     uint32_t target_width, uint32_t target_height,
                                     const GpuCaptureMetadata& metadata,
                                     GpuCaptureFile& out, std::string& error) {
-    if (reject_unsupported_gpustate_capture(state, error)) return false;
     std::vector<DrawItem> draws = realize_gpustate_draws(state);
     draws.erase(std::remove_if(draws.begin(), draws.end(), [&](const DrawItem& draw) {
         return draw.color0_width != target_width || draw.color0_height != target_height;
@@ -911,10 +1038,17 @@ bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
     for (const auto& draw : draws)
         operations.push_back({SubmitOperationKind::Draw, static_cast<size_t>(draw.draw_index),
                               draw.command_order});
+    for (size_t i = 0; i < state.dma_copies.size(); ++i)
+        operations.push_back({SubmitOperationKind::DmaCopy, i,
+                              state.dma_copies[i].command_order});
+    std::stable_sort(operations.begin(), operations.end(), [](const auto& a, const auto& b) {
+        return a.command_order < b.command_order;
+    });
     GpuCaptureMetadata actual = metadata;
     actual.width = width; actual.height = height; actual.submit_index = submit_no;
-    return capture_submit_items(draws, {}, operations, actual, read_capture_guest_memory,
-                                out, error, g_rtt_seed_reader);
+    return capture_submit_items(draws, {}, operations, actual,
+                                ordered_gpustate_capture_reader(state),
+                                out, error, g_rtt_seed_reader, {}, state.dma_copies);
 }
 
 bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes, std::string& error) {
@@ -987,7 +1121,10 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u64(compute.code_addr); w.u64(compute.dispatch_index); w.u64(compute.submit_no);
         w.u64(compute.command_order);
     }
-    if (c.operations.size() > kMaxOperations) { error = "invalid operation count"; return false; }
+    if (c.operations.size() > kMaxOperations || !validate_dma_copies(c, error)) {
+        if (error.empty()) error = "invalid operation count";
+        return false;
+    }
     w.u32(static_cast<uint32_t>(c.operations.size()));
     for (const auto& operation : c.operations) {
         w.u8(static_cast<uint8_t>(operation.kind)); w.u64(operation.source_index);
@@ -1135,6 +1272,16 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         if (!write_dcc_metadata(draw.vrt) || !write_dcc_metadata(draw.prt)) return false;
     for (const auto& compute : c.computes)
         if (!write_dcc_metadata(compute.resources)) return false;
+    // v14 appends ordered address-backed DMA_DATA records. Both endpoints reference the same
+    // content-addressed pre-submit blobs used by draw/compute resources, so replay mutations are
+    // visible to later consumers without changing any v1-v13 prefix.
+    w.u32(static_cast<uint32_t>(c.dma_copies.size()));
+    for (const auto& copy : c.dma_copies) {
+        w.u64(copy.dst); w.u64(copy.src); w.u32(copy.bytes); w.u32(copy.sels);
+        w.u64(copy.command_order); w.u64(copy.packet_addr);
+        w.u32(copy.destination_blob_index); w.u64(copy.destination_blob_offset);
+        w.u32(copy.source_blob_index); w.u64(copy.source_blob_offset);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1267,7 +1414,9 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         c.operations.resize(no);
         for (auto& operation : c.operations) {
             uint8_t kind = 0, realized = 0;
-            if (!r.u8(kind) || kind > static_cast<uint8_t>(SubmitOperationKind::Dispatch) ||
+            const uint8_t max_kind = static_cast<uint8_t>(version >= 14
+                ? SubmitOperationKind::DmaCopy : SubmitOperationKind::Dispatch);
+            if (!r.u8(kind) || kind > max_kind ||
                 !r.u64(operation.source_index) || !r.u64(operation.command_order) || !r.u8(realized)) return false;
             operation.kind = static_cast<SubmitOperationKind>(kind);
             operation.realized = realized != 0;
@@ -1508,12 +1657,31 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         for (auto& compute : c.computes)
             if (!read_dcc_metadata(compute.resources)) return false;
     }
+    if (version >= 14) {
+        uint32_t dma_count = 0;
+        if (!r.u32(dma_count) || dma_count > kMaxOperations) {
+            error = "invalid ordered DMA count";
+            return false;
+        }
+        c.dma_copies.resize(dma_count);
+        for (auto& copy : c.dma_copies) {
+            if (!r.u64(copy.dst) || !r.u64(copy.src) || !r.u32(copy.bytes) ||
+                !r.u32(copy.sels) || !r.u64(copy.command_order) ||
+                !r.u64(copy.packet_addr) || !r.u32(copy.destination_blob_index) ||
+                !r.u64(copy.destination_blob_offset) || !r.u32(copy.source_blob_index) ||
+                !r.u64(copy.source_blob_offset))
+                return false;
+        }
+        if (!validate_dma_copies(c, error)) return false;
+    }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
 }
 
 bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::string& error) {
-    error.clear(); out = {}; out.metadata = c.metadata; out.blobs = c.blobs;
+    error.clear();
+    if (!validate_dma_copies(c, error)) return false;
+    out = {}; out.metadata = c.metadata; out.blobs = c.blobs;
     out.rtt_seeds = c.rtt_seeds; out.ds_seeds = c.ds_seeds;
     out.raw_shader_versions = c.raw_shader_versions;
     out.failure_diagnostics = c.failure_diagnostics;
@@ -1525,6 +1693,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         resource_reference_count += draw.vrt.resources.size() + draw.prt.resources.size();
     for (const auto& compute : c.computes)
         resource_reference_count += compute.resources.resources.size();
+    resource_reference_count += c.dma_copies.size() * 2;
     out.resource_instances.reserve(resource_reference_count * 2);
     std::map<std::pair<uint32_t, uint64_t>, size_t> instance_by_version_and_base;
     auto bind_range = [&](uint32_t blob_index, uint64_t blob_offset, uint64_t guest_addr,
@@ -1594,6 +1763,28 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         compute.command_order = x.command_order;
         if (!table(x.resources, compute.resources)) return false;
         out.computes.push_back(std::move(compute));
+    }
+    out.dma_copies.reserve(c.dma_copies.size());
+    for (const auto& captured : c.dma_copies) {
+        ReplayDmaCopy copy;
+        copy.dst = captured.dst; copy.src = captured.src; copy.bytes = captured.bytes;
+        copy.sels = captured.sels; copy.command_order = captured.command_order;
+        copy.packet_addr = captured.packet_addr;
+        uint8_t* source = nullptr;
+        if (!bind_range(captured.destination_blob_index, captured.destination_blob_offset,
+                        captured.dst, captured.bytes, copy.destination_data,
+                        copy.destination_size,
+                        "ordered DMA destination references an invalid capture blob",
+                        "ordered DMA destination exceeds capture blob",
+                        "ordered DMA destination blob offset exceeds its logical address") ||
+            !bind_range(captured.source_blob_index, captured.source_blob_offset,
+                        captured.src, captured.bytes, source, copy.source_size,
+                        "ordered DMA source references an invalid capture blob",
+                        "ordered DMA source exceeds capture blob",
+                        "ordered DMA source blob offset exceeds its logical address"))
+            return false;
+        copy.source_data = source;
+        out.dma_copies.push_back(copy);
     }
     out.operations = c.operations;
     return true;
@@ -1697,8 +1888,9 @@ bool restore_gpu_replay_ds_seeds(const std::vector<GpuCaptureDsSeed>& seeds, std
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
     const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height,
-    bool has_ordered_dma, uint64_t unsupported_draw_count) {
+    const GpuState* semantic_state, uint64_t submit_no, uint64_t semantic_draw_count) {
     const char* path = std::getenv("PROSPER_GPU_CAPTURE"); if (!path || !*path) return {};
+    const bool has_ordered_dma = semantic_state && !semantic_state->dma_copies.empty();
     static std::atomic<uint64_t> invocation_sequence{0};
     const uint64_t invocation = invocation_sequence.fetch_add(1);
     uint64_t after = 0;
@@ -1707,23 +1899,16 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     uint64_t min_draws = 0, max_draws = std::numeric_limits<uint64_t>::max();
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MIN_DRAWS")) min_draws = std::strtoull(v, nullptr, 0);
     if (const char* v = std::getenv("PROSPER_GPU_CAPTURE_MAX_DRAWS")) max_draws = std::strtoull(v, nullptr, 0);
-    const uint64_t candidate_draw_count = has_ordered_dma && unsupported_draw_count != UINT64_MAX
-        ? unsupported_draw_count : static_cast<uint64_t>(draws.size());
+    const uint64_t candidate_draw_count = has_ordered_dma && semantic_draw_count != UINT64_MAX
+        ? semantic_draw_count : static_cast<uint64_t>(draws.size());
     if (candidate_draw_count < min_draws || candidate_draw_count > max_draws) return {};
     static std::atomic<uint64_t> sequence{0}; static std::atomic<bool> claimed{false};
     uint64_t current = sequence.fetch_add(1), wanted = 0;
     if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);
     if (current != wanted || claimed.exchange(true)) return {};
-    if (has_ordered_dma) {
-        std::fprintf(stderr,
-                     "[gpucap] selected match %llu at invocation %llu failed: capture v13 cannot "
-                     "represent ordered DMA_DATA (see #833)\n",
-                     static_cast<unsigned long long>(current),
-                     static_cast<unsigned long long>(invocation));
-        return {};
-    }
     auto pending = std::make_unique<PendingGpuCapture>(); pending->path = path;
-    GpuCaptureMetadata m; m.width = width; m.height = height; m.submit_index = current;
+    GpuCaptureMetadata m; m.width = width; m.height = height;
+    m.submit_index = submit_no ? submit_no : current;
 #ifdef PROSPER_GIT_REVISION
     m.revision = PROSPER_GIT_REVISION;
 #else
@@ -1749,14 +1934,20 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     };
     for (const char* name : render_env) if (const char* value = std::getenv(name)) m.renderer_env.emplace_back(name, value);
     std::string error;
-    if (!capture_submit_items(draws, computes, operations, m, read_capture_guest_memory,
-                              pending->capture, error, g_rtt_seed_reader)) {
+    const bool captured = has_ordered_dma
+        ? capture_gpustate_submit(*semantic_state, m.submit_index, width, height, m,
+                                  pending->capture, error)
+        : capture_submit_items(draws, computes, operations, m, read_capture_guest_memory,
+                               pending->capture, error, g_rtt_seed_reader);
+    if (!captured) {
         std::fprintf(stderr, "[gpucap] capture failed: %s\n", error.c_str()); return {};
     }
     std::fprintf(stderr, "[gpucap] captured match %llu at invocation %llu: %zu draws, %zu computes, "
-                         "%zu operations, %zu blobs, %zu RTT seeds -> %s\n",
+                         "%zu DMA copies, %zu operations, %zu blobs, %zu RTT seeds -> %s\n",
                  static_cast<unsigned long long>(current), static_cast<unsigned long long>(invocation),
-                 draws.size(), computes.size(), operations.size(), pending->capture.blobs.size(),
+                 pending->capture.draws.size(), pending->capture.computes.size(),
+                 pending->capture.dma_copies.size(), pending->capture.operations.size(),
+                 pending->capture.blobs.size(),
                  pending->capture.rtt_seeds.size(), path);
     return pending;
 }

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -90,6 +90,19 @@ struct GpuCapturedOperation {
     bool realized = false;
 };
 
+// Ordered address-backed DMA_DATA. Guest addresses preserve the semantic identity; blob references
+// bind the source and destination to their exact pre-submit backing versions for standalone replay.
+struct GpuCapturedDmaCopy {
+    uint64_t dst = 0, src = 0;
+    uint32_t bytes = 0, sels = 0;
+    uint64_t command_order = 0;
+    uint64_t packet_addr = 0;
+    uint32_t destination_blob_index = 0xFFFFFFFFu;
+    uint64_t destination_blob_offset = 0;
+    uint32_t source_blob_index = 0xFFFFFFFFu;
+    uint64_t source_blob_offset = 0;
+};
+
 struct GpuCapturedStageDiagnostic {
     ShaderProgramStage stage = ShaderProgramStage::Vertex;
     uint64_t program_addr = 0;
@@ -168,6 +181,7 @@ struct GpuCaptureFile {
     std::vector<GpuCaptureDsSeed> ds_seeds;
     std::vector<GpuCapturedDraw> draws;
     std::vector<GpuCapturedCompute> computes;
+    std::vector<GpuCapturedDmaCopy> dma_copies;
     std::vector<GpuCapturedOperation> operations;
     std::vector<GpuCapturedOperationFailure> failure_diagnostics;
     bool failure_diagnostics_available = false;
@@ -194,7 +208,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           const GpuCaptureMetadata& metadata,
                           const CaptureMemoryReader& reader, GpuCaptureFile& out,
                           std::string& error, const CaptureRttSeedReader& rtt_reader = {},
-                          const std::vector<OperationRealizationFailure>& failures = {});
+                          const std::vector<OperationRealizationFailure>& failures = {},
+                          const std::vector<GpuState::DmaCopy>& dma_copies = {});
 bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,
@@ -224,6 +239,7 @@ struct GpuReplayFrame {
     std::vector<GpuCaptureDsSeed> ds_seeds;
     std::vector<DrawItem> items;
     std::vector<ComputeItem> computes;
+    std::vector<ReplayDmaCopy> dma_copies;
     std::vector<GpuCapturedOperation> operations;
     std::vector<GpuCaptureRawShaderVersion> raw_shader_versions;
     std::vector<GpuCapturedOperationFailure> failure_diagnostics;
@@ -275,7 +291,8 @@ struct PendingGpuCapture {
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     const std::vector<DrawItem>& draws, const std::vector<ComputeItem>& computes,
     const std::vector<SubmitOperation>& operations, uint32_t width, uint32_t height,
-    bool has_ordered_dma = false, uint64_t unsupported_draw_count = UINT64_MAX);
+    const GpuState* semantic_state = nullptr, uint64_t submit_no = 0,
+    uint64_t semantic_draw_count = UINT64_MAX);
 bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
                                   const std::vector<uint8_t>& output, std::string& error);
 

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -168,6 +168,7 @@ GpuCaptureFile make_capture_manifest(const GpuCaptureFile& capture) {
     manifest.raw_shader_versions = capture.raw_shader_versions;
     manifest.draws = capture.draws;
     manifest.computes = capture.computes;
+    manifest.dma_copies = capture.dma_copies;
     manifest.operations = capture.operations;
     manifest.failure_diagnostics = capture.failure_diagnostics;
     manifest.blobs.resize(capture.blobs.size());

--- a/prosper/src/gpu/gpu_dependency_graph.cpp
+++ b/prosper/src/gpu/gpu_dependency_graph.cpp
@@ -77,7 +77,7 @@ bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
             if (draw.color1_base && draw.color1_width && draw.color1_height)
                 writes.push_back({draw.color1_base,
                                   static_cast<uint64_t>(draw.color1_width) * draw.color1_height * 4});
-        } else {
+        } else if (operation.kind == SubmitOperationKind::Dispatch) {
             auto it = computes.find(operation.source_index);
             if (it == computes.end()) {
                 error = "realized dispatch operation has no materialized item";
@@ -85,6 +85,15 @@ bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
             }
             append_accesses(it->second->resources.get(), "cs", reads);
             for (const auto& access : reads) writes.push_back({access.addr, access.size});
+        } else {
+            if (operation.source_index >= replay.dma_copies.size()) {
+                error = "realized DMA operation has no materialized copy";
+                return false;
+            }
+            const ReplayDmaCopy& copy = replay.dma_copies[operation.source_index];
+            reads.push_back({copy.src, copy.bytes, 0, 0, 0,
+                             ResourceClass::ConstantBuffer, "dma-src"});
+            writes.push_back({copy.dst, copy.bytes});
         }
 
         for (const auto& access : reads) {

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -185,11 +185,25 @@ struct ComputeItem {
     uint64_t command_order = 0;
 };
 
-enum class SubmitOperationKind : uint8_t { Draw, Dispatch };
+enum class SubmitOperationKind : uint8_t { Draw, Dispatch, DmaCopy };
 struct SubmitOperation {
     SubmitOperationKind kind = SubmitOperationKind::Draw;
     size_t index = 0;
     uint64_t command_order = 0;
+};
+
+// Offline captures keep guest addresses as stable identities while their bytes live in owned host
+// storage. This replay-facing DMA item binds both views so ordered execution can mutate the exact
+// resource instances consumed by later draws/dispatches and invalidate renderer caches by guest VA.
+struct ReplayDmaCopy {
+    uint64_t dst = 0, src = 0;
+    uint32_t bytes = 0, sels = 0;
+    uint64_t command_order = 0;
+    uint64_t packet_addr = 0;
+    uint8_t* destination_data = nullptr;
+    const uint8_t* source_data = nullptr;
+    uint64_t destination_size = 0;
+    uint64_t source_size = 0;
 };
 
 enum class ShaderProgramStage : uint8_t { Vertex, Fragment, Compute };
@@ -987,6 +1001,13 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
                                           const std::vector<DrawItem>& draws,
                                           const std::vector<ComputeItem>& computes,
                                           const std::vector<GpuState::DmaCopy>& dma_copies,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height);
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const std::vector<ReplayDmaCopy>& dma_copies,
                                           const LiveRenderFn& render,
                                           const LiveComputeFn& compute,
                                           uint32_t width, uint32_t height);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2661,24 +2661,30 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
 
 std::vector<SubmitOperation> plan_submit_operations(const GpuState& st) {
     std::vector<SubmitOperation> operations;
-    operations.reserve(st.draws.size() + st.dispatches.size());
+    operations.reserve(st.draws.size() + st.dispatches.size() + st.dma_copies.size());
     for (size_t i = 0; i < st.draws.size(); ++i)
         operations.push_back({SubmitOperationKind::Draw, i, st.draws[i].command_order});
     for (size_t i = 0; i < st.dispatches.size(); ++i)
         operations.push_back({SubmitOperationKind::Dispatch, i, st.dispatches[i].command_order});
+    for (size_t i = 0; i < st.dma_copies.size(); ++i)
+        operations.push_back({SubmitOperationKind::DmaCopy, i, st.dma_copies[i].command_order});
     std::stable_sort(operations.begin(), operations.end(), [](const auto& a, const auto& b) {
         return a.command_order < b.command_order;
     });
     return operations;
 }
 
-OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
-                                          const std::vector<DrawItem>& draws,
-                                          const std::vector<ComputeItem>& computes,
-                                          const std::vector<GpuState::DmaCopy>& dma_copies,
-                                          const LiveRenderFn& render,
-                                          const LiveComputeFn& compute,
-                                          uint32_t width, uint32_t height) {
+namespace {
+
+template <typename DmaCopyRecord, typename ExecuteDma>
+OrderedSubmitResult execute_ordered_items_impl(const std::vector<SubmitOperation>& operations,
+                                               const std::vector<DrawItem>& draws,
+                                               const std::vector<ComputeItem>& computes,
+                                               const std::vector<DmaCopyRecord>& dma_copies,
+                                               const LiveRenderFn& render,
+                                               const LiveComputeFn& compute,
+                                               uint32_t width, uint32_t height,
+                                               ExecuteDma&& execute_dma) {
     GuestGpuWriteSubmitScope guest_gpu_write_scope;
     std::unordered_map<size_t, size_t> draw_by_index, compute_by_index;
     for (size_t i = 0; i < draws.size(); ++i) draw_by_index[draws[i].draw_index] = i;
@@ -2692,19 +2698,27 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
         uint64_t command_order;
     };
     std::vector<ExecutableOperation> executable;
+    bool explicit_dma_operations = false;
     for (const auto& operation : operations) {
         if (operation.kind == SubmitOperationKind::Draw) {
             auto it = draw_by_index.find(operation.index);
             if (it != draw_by_index.end())
                 executable.push_back({ExecutableKind::Draw, it->second, operation.command_order});
-        } else {
+        } else if (operation.kind == SubmitOperationKind::Dispatch) {
             auto it = compute_by_index.find(operation.index);
             if (it != compute_by_index.end())
                 executable.push_back({ExecutableKind::Dispatch, it->second, operation.command_order});
+        } else {
+            explicit_dma_operations = true;
+            if (operation.index < dma_copies.size())
+                executable.push_back({ExecutableKind::DmaCopy, operation.index,
+                                      operation.command_order});
         }
     }
-    for (size_t i = 0; i < dma_copies.size(); ++i)
-        executable.push_back({ExecutableKind::DmaCopy, i, dma_copies[i].command_order});
+    // Compatibility for pre-v14 callers whose operation list predates the DMA kind.
+    if (!explicit_dma_operations)
+        for (size_t i = 0; i < dma_copies.size(); ++i)
+            executable.push_back({ExecutableKind::DmaCopy, i, dma_copies[i].command_order});
     std::stable_sort(executable.begin(), executable.end(), [](const auto& a, const auto& b) {
         return a.command_order < b.command_order;
     });
@@ -2741,7 +2755,25 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
             result.compute_executed |= compute && compute({computes[operation.item]});
         } else {
             flush_span(true);
-            const GpuState::DmaCopy& copy = dma_copies[operation.item];
+            execute_dma(dma_copies[operation.item]);
+        }
+    }
+    flush_span();
+    return result;
+}
+
+} // namespace
+
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const std::vector<GpuState::DmaCopy>& dma_copies,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height) {
+    return execute_ordered_items_impl(
+        operations, draws, computes, dma_copies, render, compute, width, height,
+        [](const GpuState::DmaCopy& copy) {
             std::vector<uint8_t> current_source;
             const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
                 copy.src, copy.bytes, current_source);
@@ -2751,15 +2783,30 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
                     std::fprintf(stderr,
                                  "[agc] DMA_DATA live-target source range invalid: src=0x%llx bytes=%u\n",
                                  static_cast<unsigned long long>(copy.src), copy.bytes);
-                continue;
+                return;
             }
             execute_ordered_dma_copy(
                 copy, source_result == LiveTargetByteReadResult::Success
                           ? current_source.data() : nullptr);
-        }
-    }
-    flush_span();
-    return result;
+        });
+}
+
+OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
+                                          const std::vector<DrawItem>& draws,
+                                          const std::vector<ComputeItem>& computes,
+                                          const std::vector<ReplayDmaCopy>& dma_copies,
+                                          const LiveRenderFn& render,
+                                          const LiveComputeFn& compute,
+                                          uint32_t width, uint32_t height) {
+    return execute_ordered_items_impl(
+        operations, draws, computes, dma_copies, render, compute, width, height,
+        [](const ReplayDmaCopy& copy) {
+            if (!copy.destination_data || !copy.source_data ||
+                copy.bytes > copy.destination_size || copy.bytes > copy.source_size)
+                return;
+            std::memmove(copy.destination_data, copy.source_data, copy.bytes);
+            notify_guest_gpu_write(copy.dst, copy.bytes);
+        });
 }
 
 OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& operations,
@@ -2768,7 +2815,9 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
                                           const LiveRenderFn& render,
                                           const LiveComputeFn& compute,
                                           uint32_t width, uint32_t height) {
-    return execute_ordered_items(operations, draws, computes, {}, render, compute, width, height);
+    return execute_ordered_items(operations, draws, computes,
+                                 std::vector<GpuState::DmaCopy>{},
+                                 render, compute, width, height);
 }
 
 namespace {
@@ -3051,11 +3100,10 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
 
     auto operations = plan_submit_operations(st);
     const auto timing_plan_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    // Capture formats through v13 have no DMA operation record. Pass that fact into selection so a
-    // selected unsupported submit is claimed-and-failed, never silently skipped in favor of a later
-    // match. Direct/timeline capture rejects again at the central GpuState boundary.
+    // DMA-bearing submits are captured from semantic state so v14 can retain both endpoint backings
+    // even though live execution deliberately realizes their consumers only at ordered positions.
     auto pending_capture = begin_requested_gpu_capture(
-        draws, computes, operations, width, height, has_ordered_dma,
+        draws, computes, operations, width, height, &st, submit_no,
         static_cast<uint64_t>(st.draws.size()));
     OrderedSubmitResult result = has_ordered_dma
         ? execute_ordered_gpustate(st, width, height, submit_no, g_live, g_compute)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2801,10 +2801,25 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
     return execute_ordered_items_impl(
         operations, draws, computes, dma_copies, render, compute, width, height,
         [](const ReplayDmaCopy& copy) {
-            if (!copy.destination_data || !copy.source_data ||
-                copy.bytes > copy.destination_size || copy.bytes > copy.source_size)
+            std::vector<uint8_t> current_source;
+            const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
+                copy.src, copy.bytes, current_source);
+            if (source_result == LiveTargetByteReadResult::InvalidRange) {
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    std::fprintf(stderr,
+                                 "[gpu_replay] DMA_DATA live-target source range invalid: src=0x%llx bytes=%u\n",
+                                 static_cast<unsigned long long>(copy.src), copy.bytes);
                 return;
-            std::memmove(copy.destination_data, copy.source_data, copy.bytes);
+            }
+            const uint8_t* source = source_result == LiveTargetByteReadResult::Success
+                ? current_source.data() : copy.source_data;
+            const uint64_t source_size = source_result == LiveTargetByteReadResult::Success
+                ? current_source.size() : copy.source_size;
+            if (!copy.destination_data || !source ||
+                copy.bytes > copy.destination_size || copy.bytes > source_size)
+                return;
+            std::memmove(copy.destination_data, source, copy.bytes);
             notify_guest_gpu_write(copy.dst, copy.bytes);
         });
 }

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -36,11 +36,12 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 7;
+constexpr uint32_t kVersion = 8;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
 constexpr uint32_t kMaxTargetSpans = 16384;
+constexpr uint32_t kMaxDmaCopies = 16384;
 
 enum class RecordType : uint32_t { Metadata = 1, Submit = 2, Present = 3, Detail = 4, Producer = 5 };
 
@@ -834,6 +835,11 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
         error = "timeline submit has invalid target spans";
         return false;
     }
+    if (submit.dma_copies.size() > kMaxDmaCopies ||
+        submit.dma_copy_count != submit.dma_copies.size()) {
+        error = "timeline submit has invalid ordered DMA records";
+        return false;
+    }
     Bytes payload;
     payload.u64(submit.submit_no);
     payload.u64(submit.process_command_order);
@@ -844,10 +850,11 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
     payload.u32(submit.dispatch_count);
     payload.u32(submit.color0_width);
     payload.u32(submit.color0_height);
-    // v7 prefixes its optional tail with unsupported-operation metadata. Older versions retain
-    // their historical tail layout in the reader below.
+    // v7 prefixes its optional tail with operation support metadata. v8 appends exact DMA records
+    // after the v6 target-span suffix, leaving the complete v1-v7 prefix byte-compatible.
     if (!submit.depth_surfaces.empty() || !submit.target_spans.empty() ||
-        submit.target_spans_truncated || submit.dma_copy_count || submit.capture_incomplete) {
+        submit.target_spans_truncated || submit.dma_copy_count || submit.capture_incomplete ||
+        !submit.dma_copies.empty()) {
         payload.u32(submit.dma_copy_count);
         payload.u32(submit.capture_incomplete ? 1u : 0u);
         payload.u32(static_cast<uint32_t>(submit.depth_surfaces.size()));
@@ -877,6 +884,12 @@ bool GpuTimelineWriter::append_submit(const GpuTimelineSubmit& submit, std::stri
             payload.u32(span.width); payload.u32(span.height);
         }
         payload.u32(submit.target_spans_truncated ? 1u : 0u);
+        payload.u32(static_cast<uint32_t>(submit.dma_copies.size()));
+        for (const auto& copy : submit.dma_copies) {
+            payload.u64(copy.dst); payload.u64(copy.src); payload.u32(copy.bytes);
+            payload.u32(copy.sels); payload.u64(copy.command_order);
+            payload.u64(copy.packet_addr);
+        }
     }
     return impl_->append(RecordType::Submit, payload, error);
 }
@@ -1127,6 +1140,25 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
                     return false;
                 }
             }
+            if (version >= 8 && have_submit_tail) {
+                uint32_t dma_count = 0;
+                if (!p.u32(dma_count) || dma_count > kMaxDmaCopies ||
+                    dma_count != submit.dma_copy_count) {
+                    error = "invalid timeline ordered DMA count";
+                    return false;
+                }
+                submit.dma_copies.resize(dma_count);
+                for (auto& copy : submit.dma_copies) {
+                    if (!p.u64(copy.dst) || !p.u64(copy.src) || !p.u32(copy.bytes) ||
+                        !p.u32(copy.sels) || !p.u64(copy.command_order) ||
+                        !p.u64(copy.packet_addr) || !copy.dst || !copy.src || !copy.bytes ||
+                        copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes ||
+                        copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes) {
+                        error = "invalid timeline ordered DMA record";
+                        return false;
+                    }
+                }
+            }
             if (p.left) {
                 error = "invalid timeline submit record size";
                 return false;
@@ -1347,7 +1379,11 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     submit.dispatch_count = static_cast<uint32_t>(std::min<size_t>(state.dispatches.size(), UINT32_MAX));
     submit.dma_copy_count = static_cast<uint32_t>(
         std::min<size_t>(state.dma_copies.size(), UINT32_MAX));
-    submit.capture_incomplete = !state.dma_copies.empty();
+    submit.dma_copies.reserve(state.dma_copies.size());
+    for (const auto& copy : state.dma_copies)
+        submit.dma_copies.push_back({copy.dst, copy.src, copy.bytes, copy.sels,
+                                     copy.command_order, copy.packet_addr});
+    submit.capture_incomplete = false;
     submit.first_command_order = std::numeric_limits<uint64_t>::max();
     const bool log_mrt = select_timeline_mrt_submit(state, submit_no);
     for (size_t draw_index = 0; draw_index < state.draws.size(); ++draw_index) {

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -49,6 +49,13 @@ struct GpuTimelineTargetSpan {
     uint32_t height = 0;
 };
 
+struct GpuTimelineDmaCopy {
+    uint64_t dst = 0, src = 0;
+    uint32_t bytes = 0, sels = 0;
+    uint64_t command_order = 0;
+    uint64_t packet_addr = 0;
+};
+
 struct GpuTimelineSubmit {
     uint64_t sequence = 0;
     uint64_t elapsed_ns = 0;
@@ -64,9 +71,10 @@ struct GpuTimelineSubmit {
     uint32_t color0_height = 0;
     std::vector<GpuTimelineDepthSurface> depth_surfaces;
     std::vector<GpuTimelineTargetSpan> target_spans;
+    std::vector<GpuTimelineDmaCopy> dma_copies;
     bool target_spans_truncated = false;
-    // Capture v13 has no ordered DMA record. The compact timeline remains truthful and selectable,
-    // but detailed capture of this submit must fail closed until #833 extends the format.
+    // Older timeline versions can report an operation count without the exact records required for
+    // replay. New v8 writers retain this flag only when some other capture limitation is discovered.
     bool capture_incomplete = false;
 };
 

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -3,6 +3,7 @@
 #include "../src/gpu/tile.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -213,7 +214,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
-    volume_bytes.resize(volume_bytes.size() - 24); // v12 count plus one 20-byte reference
+    volume_bytes.resize(volume_bytes.size() - 28); // v14 zero-DMA count + v12 count/reference
     volume_bytes[8] = 11; volume_bytes[9] = volume_bytes[10] = volume_bytes[11] = 0;
     CHECK(deserialize_gpu_capture(volume_bytes, volume_loaded, error) &&
           volume_loaded.draws[0].vrt.resources[0].metadata_size == 128 * 1024 &&
@@ -407,6 +408,86 @@ int main() {
     CHECK(mixed_draw_bytes[0] == repeated[0],
           "compute copy-on-write cannot create a false alias between equal resource versions");
 
+    // --- v14: ordered DMA mutates the shared replay instance between exact consumers. ---
+    std::array<uint8_t, 32> ordered_memory{};
+    ordered_memory[0] = 0x11; ordered_memory[16] = 0xa1;
+    auto ordered_reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr < 0x5000 || addr >= 0x5000 + ordered_memory.size()) return 0;
+        const size_t offset = static_cast<size_t>(addr - 0x5000);
+        const size_t take = std::min(n, ordered_memory.size() - offset);
+        std::memcpy(dst, ordered_memory.data() + offset, take);
+        return take;
+    };
+    auto ordered_table = std::make_shared<ShaderResourceTable>();
+    ShaderResource ordered_resource{};
+    ordered_resource.cls = ResourceClass::ConstantBuffer;
+    ordered_resource.gpu_addr = 0x5000; ordered_resource.size = 4;
+    ordered_table->resources = {ordered_resource};
+    DrawItem before_dma, after_dma;
+    before_dma.vs = after_dma.vs = {0x07230203, 71};
+    before_dma.fs = after_dma.fs = {0x07230203, 72};
+    before_dma.vrt = after_dma.vrt = ordered_table;
+    before_dma.draw_index = 100; before_dma.command_order = 10;
+    after_dma.draw_index = 101; after_dma.command_order = 30;
+    ComputeItem after_dma_compute;
+    after_dma_compute.spirv = {0x07230203, 73};
+    after_dma_compute.resources = ordered_table;
+    after_dma_compute.dispatch_index = 200; after_dma_compute.command_order = 40;
+    GpuState::DmaCopy ordered_copy{0x5000, 0x5010, 4, 0, 20, 0xabc0};
+    std::vector<SubmitOperation> ordered_operations = {
+        {SubmitOperationKind::Draw, 100, 10},
+        {SubmitOperationKind::DmaCopy, 0, 20},
+        {SubmitOperationKind::Draw, 101, 30},
+        {SubmitOperationKind::Dispatch, 200, 40},
+    };
+    GpuCaptureFile ordered_capture;
+    CHECK(capture_submit_items({before_dma, after_dma}, {after_dma_compute},
+                               ordered_operations, meta, ordered_reader, ordered_capture, error,
+                               {}, {}, {ordered_copy}) &&
+          ordered_capture.dma_copies.size() == 1 && ordered_capture.blobs.size() == 2 &&
+          ordered_capture.operations[1].kind == SubmitOperationKind::DmaCopy,
+          "v14 capture closes over ordered DMA source/destination versions");
+    std::vector<uint8_t> ordered_bytes;
+    GpuCaptureFile ordered_loaded;
+    GpuReplayFrame ordered_replay;
+    CHECK(serialize_gpu_capture(ordered_capture, ordered_bytes, error) &&
+          deserialize_gpu_capture(ordered_bytes, ordered_loaded, error) &&
+          materialize_gpu_replay(ordered_loaded, ordered_replay, error) &&
+          ordered_replay.dma_copies.size() == 1 &&
+          ordered_replay.dma_copies[0].source_data &&
+          ordered_replay.dma_copies[0].destination_data,
+          "v14 DMA records and endpoint bindings round-trip into owned replay storage");
+    std::vector<SubmitOperation> replay_operations;
+    for (const auto& operation : ordered_replay.operations)
+        if (operation.realized)
+            replay_operations.push_back({operation.kind,
+                                         static_cast<size_t>(operation.source_index),
+                                         operation.command_order});
+    std::vector<uint8_t> draw_observations, compute_observations;
+    std::vector<std::pair<uint64_t, uint64_t>> invalidations;
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        invalidations.emplace_back(addr, size);
+    });
+    execute_ordered_items(
+        replay_operations, ordered_replay.items, ordered_replay.computes,
+        ordered_replay.dma_copies,
+        [&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            for (const auto& item : items)
+                draw_observations.push_back(item.vrt->resources[0].host_data[0]);
+            return RenderedFrame{};
+        },
+        [&](const std::vector<ComputeItem>& items) {
+            compute_observations.push_back(items[0].resources->resources[0].host_data[0]);
+            return true;
+        }, 1, 1);
+    set_guest_gpu_write_observer({});
+    CHECK(draw_observations == std::vector<uint8_t>({0x11, 0xa1}),
+          "draw -> DMA -> draw replay observes pre-copy then post-copy destination bytes");
+    CHECK(compute_observations == std::vector<uint8_t>({0xa1}),
+          "DMA -> compute replay observes the copied bytes at exact command order");
+    CHECK((invalidations == std::vector<std::pair<uint64_t, uint64_t>>({{0x5000, 4}})),
+          "replay DMA invalidates renderer caches by captured guest destination identity");
+
     GpuState failed_state;
     set_pgm(failed_state, P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, kDiagnosticVs);
     set_pgm(failed_state, P::SPI_SHADER_PGM_LO_PS, P::SPI_SHADER_PGM_HI_PS, kDiagnosticBadPs);
@@ -444,28 +525,35 @@ int main() {
               reinterpret_cast<const uint8_t*>(kDiagnosticBadPs), sizeof(kDiagnosticBadPs)),
           "failed stage retains the exact content-addressed raw stream through s_endpgm");
 
+    std::array<uint8_t, 32> dma_memory{};
+    for (size_t i = 0; i < 16; ++i) dma_memory[16 + i] = static_cast<uint8_t>(0xa0 + i);
     GpuState dma_state;
-    dma_state.dma_copies.push_back({0x200000, 0x100000000ull, 16, 0, 55, 0});
-    GpuCaptureFile unsupported_capture;
+    dma_state.dma_copies.push_back({reinterpret_cast<uint64_t>(dma_memory.data()),
+                                    reinterpret_cast<uint64_t>(dma_memory.data() + 16),
+                                    16, 0, 55, 0x12345678});
+    GpuCaptureFile dma_capture;
     error.clear();
-    CHECK(!capture_gpustate_submit(
-              dma_state, 100, 640, 360, meta, unsupported_capture, error) &&
-          error.find("cannot represent 1 ordered DMA_DATA") != std::string::npos,
-          "central GpuState capture rejects an incomplete ordered-DMA artifact");
-    error.clear();
-    CHECK(!capture_gpustate_target_submit(
-              dma_state, 100, 640, 360, 640, 360, meta, unsupported_capture, error) &&
-          error.find("capture would be incomplete") != std::string::npos,
-          "target-selected capture cannot bypass ordered-DMA rejection");
+    CHECK(capture_gpustate_submit(dma_state, 100, 640, 360, meta, dma_capture, error) &&
+          dma_capture.dma_copies.size() == 1 && dma_capture.operations.size() == 1 &&
+          dma_capture.operations[0].kind == SubmitOperationKind::DmaCopy &&
+          dma_capture.operations[0].realized && dma_capture.blobs.size() == 1 &&
+          dma_capture.dma_copies[0].source_blob_offset == 16,
+          "central GpuState capture retains ordered DMA endpoints and backing closure");
+    GpuCaptureFile target_dma_capture;
+    CHECK(capture_gpustate_target_submit(
+              dma_state, 100, 640, 360, 640, 360, meta, target_dma_capture, error) &&
+          target_dma_capture.dma_copies.size() == 1 &&
+          target_dma_capture.operations[0].kind == SubmitOperationKind::DmaCopy,
+          "target-selected capture preserves ordered DMA instead of bypassing it");
 
-    // A selected unsupported live capture must consume the selector match. Otherwise AT=0 silently
-    // shifts to the next ordinary submit and writes an artifact for the wrong requested operation.
-    set_test_env("PROSPER_GPU_CAPTURE", "unsupported-dma-selector.prgcap");
+    // A selected live DMA capture consumes exactly one selector match and cannot silently retarget.
+    set_test_env("PROSPER_GPU_CAPTURE", "ordered-dma-selector.prgcap");
     set_test_env("PROSPER_GPU_CAPTURE_AT", "0");
-    const auto unsupported_pending = begin_requested_gpu_capture({}, {}, {}, 1, 1, true);
-    const auto retargeted_pending = begin_requested_gpu_capture({}, {}, {}, 1, 1, false);
-    CHECK(!unsupported_pending && !retargeted_pending,
-          "unsupported selected DMA capture fails once and cannot retarget a later submit");
+    const auto dma_pending = begin_requested_gpu_capture({}, {}, {}, 1, 1,
+                                                         &dma_state, 100, 0);
+    const auto retargeted_pending = begin_requested_gpu_capture({}, {}, {}, 1, 1);
+    CHECK(dma_pending && !retargeted_pending && dma_pending->capture.dma_copies.size() == 1,
+          "selected DMA capture succeeds once and cannot retarget a later submit");
     set_test_env("PROSPER_GPU_CAPTURE_AT", nullptr);
     set_test_env("PROSPER_GPU_CAPTURE", nullptr);
 
@@ -501,11 +589,25 @@ int main() {
 
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
-    CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 28,
-          "created a diagnostic-free v13 payload for legacy-reader fixtures");
-    if (legacy_bytes.size() >= 28) {
+    CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 32,
+          "created a diagnostic-free v14 payload for legacy-reader fixtures");
+    std::vector<uint8_t> v13_bytes = legacy_bytes;
+    if (v13_bytes.size() >= 16) {
+        v13_bytes.resize(v13_bytes.size() - 4);
+        v13_bytes[8] = 13; v13_bytes[9] = v13_bytes[10] = v13_bytes[11] = 0;
+    }
+    GpuCaptureFile v13_loaded;
+    CHECK(deserialize_gpu_capture(v13_bytes, v13_loaded, error) &&
+          v13_loaded.dma_copies.empty() &&
+          std::none_of(v13_loaded.operations.begin(), v13_loaded.operations.end(),
+                       [](const auto& operation) {
+                           return operation.kind == SubmitOperationKind::DmaCopy;
+                       }),
+          "v13 readers remain backward-compatible without inventing DMA operations");
+    if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 4); // remove v14 zero-DMA count
         // Remove the v12 DCC metadata-reference tail: count + 20-byte reference per resource.
         legacy_bytes.resize(legacy_bytes.size() - (4 + 20 * legacy_resource_count));
         // Remove the v11 DCC tail: count + 17-byte state record per resource.
@@ -545,9 +647,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 14;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 15;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 14",
+          error == "unsupported capture version 15",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -465,6 +465,16 @@ int main() {
                                          operation.command_order});
     std::vector<uint8_t> draw_observations, compute_observations;
     std::vector<std::pair<uint64_t, uint64_t>> invalidations;
+    bool producer_rendered = false;
+    const std::vector<uint8_t> current_render_target = {0xe1, 0xe2, 0xe3, 0xe4};
+    set_live_target_byte_range_reader(
+        [&](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+            if (addr != ordered_copy.src) return LiveTargetByteReadResult::NotFound;
+            if (!producer_rendered || bytes != current_render_target.size())
+                return LiveTargetByteReadResult::InvalidRange;
+            output = current_render_target;
+            return LiveTargetByteReadResult::Success;
+        });
     set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
         invalidations.emplace_back(addr, size);
     });
@@ -474,6 +484,7 @@ int main() {
         [&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
             for (const auto& item : items)
                 draw_observations.push_back(item.vrt->resources[0].host_data[0]);
+            producer_rendered = true;
             return RenderedFrame{};
         },
         [&](const std::vector<ComputeItem>& items) {
@@ -481,10 +492,11 @@ int main() {
             return true;
         }, 1, 1);
     set_guest_gpu_write_observer({});
-    CHECK(draw_observations == std::vector<uint8_t>({0x11, 0xa1}),
-          "draw -> DMA -> draw replay observes pre-copy then post-copy destination bytes");
-    CHECK(compute_observations == std::vector<uint8_t>({0xa1}),
-          "DMA -> compute replay observes the copied bytes at exact command order");
+    set_live_target_byte_range_reader({});
+    CHECK(draw_observations == std::vector<uint8_t>({0x11, 0xe1}),
+          "draw -> DMA -> draw replay copies the current producer target, not its stale blob");
+    CHECK(compute_observations == std::vector<uint8_t>({0xe1}),
+          "DMA -> compute replay observes the current producer bytes at exact command order");
     CHECK((invalidations == std::vector<std::pair<uint64_t, uint64_t>>({{0x5000, 4}})),
           "replay DMA invalidates renderer caches by captured guest destination identity");
 

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -33,6 +33,13 @@ int main() {
     }
     blob.content_hash = gpu_capture_hash(blob.bytes);
     first.blobs.push_back(blob);
+    GpuCapturedDmaCopy bundle_dma;
+    bundle_dma.dst = 0x100000; bundle_dma.src = 0x100010; bundle_dma.bytes = 4;
+    bundle_dma.command_order = 850; bundle_dma.packet_addr = 0x123400;
+    bundle_dma.destination_blob_index = 0; bundle_dma.source_blob_index = 0;
+    bundle_dma.source_blob_offset = 16;
+    first.dma_copies.push_back(bundle_dma);
+    first.operations.push_back({SubmitOperationKind::DmaCopy, 0, 850, true});
     first.operations.push_back({SubmitOperationKind::Draw, 5, 900, false});
     GpuCaptureRawShaderVersion failed_shader;
     failed_shader.words = {0xbf860001u, 0xbf810000u};
@@ -116,13 +123,16 @@ int main() {
           restored_second.blobs[0].guest_addr == 0x200000 && restored_second.blobs[0].bytes == blob.bytes &&
           restored_second.failure_diagnostics_available && restored_second.failure_diagnostics.size() == 1 &&
           restored_second.raw_shader_versions[0].words == failed_shader.words &&
+          restored_second.dma_copies.size() == 1 &&
+          restored_second.dma_copies[0].source_blob_offset == 16 &&
           restored_second.ds_seeds.size() == 1 && restored_second.ds_seeds[0].depth == ds_seed.depth,
-          "bundle reconstructs an exact validated capture");
+          "bundle reconstructs exact validated capture and ordered DMA records");
     CHECK(materialize_gpu_capture_bundle_manifest(loaded, 1, second_manifest, error) &&
           second_manifest.metadata.submit_index == 42 && second_manifest.blobs.size() == 1 &&
           second_manifest.blobs[0].bytes.empty() && second_manifest.draws.size() == restored_second.draws.size() &&
+          second_manifest.dma_copies.size() == 1 &&
           second_manifest.ds_seeds.size() == 1 && second_manifest.ds_seeds[0].depth == ds_seed.depth,
-          "manifest-only materialization exposes submit state without resource payload reconstruction");
+          "manifest-only materialization exposes DMA state without resource payload reconstruction");
     restored_first.blobs[0].bytes[0] ^= 0xff;
     CHECK(restored_second.blobs[0].bytes == blob.bytes,
           "materialized submits own independent mutable resource bytes");

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -307,6 +307,37 @@ int main() {
           std::memcmp(copied_target, ordered_range.data(), sizeof copied_target) == 0,
           "ordered DMA copies current bytes produced by the preceding live-render span");
 
+    DrawItem replay_producer = producer;
+    replay_producer.color0_base = 0x100400000ull;
+    replay_producer.draw_index = 0;
+    replay_producer.command_order = 100;
+    const uint64_t replay_center = replay_producer.color0_base +
+        (static_cast<uint64_t>(replay_producer.color0_width) +
+         replay_producer.color0_width / 2u) * 4u;
+    uint8_t stale_captured_source[4] = {0x5a, 0x5a, 0x5a, 0x5a};
+    uint8_t replay_copied_target[4] = {};
+    ReplayDmaCopy replay_copy;
+    replay_copy.dst = reinterpret_cast<uint64_t>(replay_copied_target);
+    replay_copy.src = replay_center;
+    replay_copy.bytes = sizeof replay_copied_target;
+    replay_copy.command_order = 200;
+    replay_copy.destination_data = replay_copied_target;
+    replay_copy.destination_size = sizeof replay_copied_target;
+    replay_copy.source_data = stale_captured_source;
+    replay_copy.source_size = sizeof stale_captured_source;
+    execute_ordered_items(
+        {{SubmitOperationKind::Draw, 0, 100}, {SubmitOperationKind::DmaCopy, 0, 200}},
+        {replay_producer}, {}, {replay_copy}, ordered_render, {}, W, H);
+    std::vector<uint8_t> replay_range;
+    const bool replay_source_read = read_live_render_target_bytes(
+        replay_center, sizeof replay_copied_target, replay_range) ==
+        LiveTargetByteReadResult::Success;
+    CHECK(replay_source_read && replay_range.size() == sizeof replay_copied_target &&
+          std::memcmp(replay_copied_target, replay_range.data(), sizeof replay_copied_target) == 0 &&
+          std::memcmp(replay_copied_target, stale_captured_source,
+                      sizeof replay_copied_target) != 0,
+          "offline DMA replay prefers the preceding draw's live target over its captured blob");
+
     std::vector<uint8_t> cross_submit = render_submit_items({consumer}, W, H);
     CHECK(cross_submit.size() == static_cast<size_t>(16) * 16 * 4,
           "renderer retains a producer target across separate replay submits");

--- a/prosper/tests/test_gpu_dependency_graph.cpp
+++ b/prosper/tests/test_gpu_dependency_graph.cpp
@@ -59,9 +59,13 @@ int main() {
 
     replay.items = {producer, consumer};
     replay.computes = {compute};
+    ReplayDmaCopy dma;
+    dma.src = 0x6000; dma.dst = 0x4000; dma.bytes = 0x40; dma.command_order = 25;
+    replay.dma_copies = {dma};
     replay.operations = {
         {SubmitOperationKind::Draw, 0, 10, true},
         {SubmitOperationKind::Dispatch, 2, 20, true},
+        {SubmitOperationKind::DmaCopy, 0, 25, true},
         {SubmitOperationKind::Draw, 1, 30, true},
         {SubmitOperationKind::Draw, 9, 40, false},
     };
@@ -69,24 +73,26 @@ int main() {
     GpuDependencyGraph graph;
     std::string error;
     CHECK(build_gpu_dependency_graph(replay, graph, error), "mixed operation graph builds");
-    CHECK(graph.nodes.size() == 4 && !graph.nodes[3].realized,
+    CHECK(graph.nodes.size() == 5 && graph.nodes[2].kind == SubmitOperationKind::DmaCopy &&
+          !graph.nodes[4].realized,
           "all semantic operations remain visible, including missing work");
-    CHECK(graph.edges.size() == 2 && graph.edges[0].producer_operation == 0 &&
-          graph.edges[0].consumer_operation == 2 && graph.edges[1].producer_operation == 1 &&
-          graph.edges[1].consumer_operation == 2,
-          "consumer resolves latest overlapping MRT1 and compute writers");
+    CHECK(graph.edges.size() == 3 && graph.edges[0].producer_operation == 0 &&
+          graph.edges[0].consumer_operation == 3 && graph.edges[1].producer_operation == 1 &&
+          graph.edges[1].consumer_operation == 3 && graph.edges[2].producer_operation == 2 &&
+          graph.edges[2].consumer_operation == 3,
+          "consumer resolves latest overlapping MRT1, compute, and DMA writers");
     CHECK(graph.external_leaves.size() == 3,
           "resources with no earlier in-capsule writer remain explicit external leaves");
     CHECK(graph.external_leaves[0].access.addr == 0x1000 &&
           graph.external_leaves[1].access.addr == 0x3000 &&
-          graph.external_leaves[2].access.addr == 0x4000 &&
+          graph.external_leaves[2].access.addr == 0x6000 &&
           graph.external_leaves[0].consumer_operations[0] == 0,
           "external leaf identities preserve operation order");
     CHECK(graph.external_leaves[0].first_future_writer == UINT32_MAX &&
           graph.external_leaves[1].first_future_writer == 1,
           "read-before-write leaves identify the first in-capsule future writer");
 
-    replay.operations[3].realized = true;
+    replay.operations[4].realized = true;
     CHECK(!build_gpu_dependency_graph(replay, graph, error) &&
           error.find("no materialized item") != std::string::npos,
           "graph rejects a falsely realized operation");

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -40,7 +40,10 @@ int main() {
     first.submit_no = 10; first.process_command_order = 400; first.first_command_order = 390;
     first.last_command_order = 400; first.color0_base = 0x12340000; first.draw_count = 3;
     first.dispatch_count = 1; first.color0_width = 642; first.color0_height = 362;
-    first.dma_copy_count = 2; first.capture_incomplete = true;
+    first.dma_copy_count = 2;
+    first.dma_copies.push_back({0x500000, 0x600000, 64, 0, 395, 0x1000});
+    first.dma_copies.push_back({0x500040, 0x600040, 32, 3, 398, 0x1100});
+    first.capture_incomplete = false;
     first.target_spans.push_back({0, 1, 642, 362});
     first.target_spans.push_back({1, 2, 738, 420});
     GpuTimelineSubmit invalid_spans = first;
@@ -107,7 +110,7 @@ int main() {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.version == 7 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+    CHECK(timeline.version == 8 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
           timeline.details.size() == 1 && timeline.producers.size() == 1,
           "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
@@ -118,8 +121,12 @@ int main() {
           timeline.submits[0].color0_width == 642 && timeline.submits[0].color0_height == 362,
           "target identity and extent round-trip");
     CHECK(timeline.submits[0].dma_copy_count == 2 &&
-          timeline.submits[0].capture_incomplete,
-          "ordered-DMA count and incomplete-capture marker round-trip");
+          !timeline.submits[0].capture_incomplete &&
+          timeline.submits[0].dma_copies.size() == 2 &&
+          timeline.submits[0].dma_copies[0].src == 0x600000 &&
+          timeline.submits[0].dma_copies[1].dst == 0x500040 &&
+          timeline.submits[0].dma_copies[1].command_order == 398,
+          "ordered-DMA identities and exact command order round-trip");
     CHECK(timeline.submits[0].depth_surfaces.size() == 1 &&
           timeline.submits[0].depth_surfaces[0].htile_data_base == 0x820000 &&
           timeline.submits[0].depth_surfaces[0].db_depth_size_xy == 0x01690281 &&
@@ -250,10 +257,13 @@ int main() {
           runtime_timeline.presents[0].latest_submit_no == 42,
           "a flip during folding is associated with its active submit");
     CHECK(runtime_timeline.submits[0].dma_copy_count == 1 &&
-          runtime_timeline.submits[0].capture_incomplete &&
+          !runtime_timeline.submits[0].capture_incomplete &&
+          runtime_timeline.submits[0].dma_copies.size() == 1 &&
+          runtime_timeline.submits[0].dma_copies[0].src == 0x100000000ull &&
+          runtime_timeline.submits[0].dma_copies[0].dst == 0x200000 &&
           runtime_timeline.submits[0].first_command_order == 104 &&
           runtime_timeline.submits[0].last_command_order == 104,
-          "runtime compact timeline exposes ordered DMA and marks v13 capture incomplete");
+          "runtime compact timeline exposes replayable ordered DMA identities");
     CHECK(runtime_timeline.submits[1].depth_surfaces.size() == 1 &&
           runtime_timeline.submits[1].depth_surfaces[0].depth_read_base == 0x700000 &&
           runtime_timeline.submits[1].depth_surfaces[0].htile_data_base == 0x820000 &&
@@ -284,6 +294,7 @@ int main() {
     GpuTimelineWriter compat_writer;
     GpuTimelineSubmit legacy_first = first;
     legacy_first.depth_surfaces.clear(); legacy_first.target_spans.clear();
+    legacy_first.dma_copies.clear();
     legacy_first.dma_copy_count = 0; legacy_first.capture_incomplete = false;
     CHECK(compat_writer.open(compat_v2, metadata, error) && compat_writer.append_submit(legacy_first, error),
           "created a detail-free compatibility timeline");

--- a/prosper/tests/test_gpu_timeline_capture_exit.cpp
+++ b/prosper/tests/test_gpu_timeline_capture_exit.cpp
@@ -1,7 +1,9 @@
 #include "../src/gpu/gpu_timeline.hpp"
+#include "../src/gpu/gpu_capture.hpp"
 
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <string>
 #ifndef _WIN32
 #include <sys/wait.h>
@@ -35,7 +37,7 @@ static int run_child() {
     endpoint.command_order = 20;
     begin_gpu_timeline_submit(2);
     record_gpu_timeline_submit(endpoint, 2);
-    return 0; // EXIT_AFTER_CAPTURE must have terminated with status 2 before this point.
+    return 3; // EXIT_AFTER_CAPTURE must have terminated successfully before this point.
 }
 
 int main(int argc, char** argv) {
@@ -47,10 +49,22 @@ int main(int argc, char** argv) {
 #else
     const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 #endif
-    if (exit_code != 2) {
-        std::fprintf(stderr, "expected child exit 2 after predecessor capture failure, got %d\n",
+    if (exit_code != 0) {
+        std::fprintf(stderr, "expected child exit 0 after ordered-DMA capture, got %d\n",
                      exit_code);
         return 1;
     }
+    GpuCaptureFile predecessor;
+    std::string error;
+    if (!read_gpu_capture("timeline-capture-predecessor.prgcap", predecessor, error) ||
+        predecessor.dma_copies.size() != 1 || predecessor.operations.size() != 1 ||
+        predecessor.operations[0].kind != SubmitOperationKind::DmaCopy) {
+        std::fprintf(stderr, "ordered-DMA predecessor capture is incomplete: %s\n", error.c_str());
+        return 1;
+    }
+    std::error_code ec;
+    std::filesystem::remove("timeline-capture-exit.prgtl", ec);
+    std::filesystem::remove("timeline-capture-endpoint.prgcap", ec);
+    std::filesystem::remove("timeline-capture-predecessor.prgcap", ec);
     return 0;
 }

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -1,8 +1,8 @@
 # GPU replay
 
 `gpu_replay` inspects, validates, graphs, and renders a local `.prgcap` without booting the guest.
-Capsules contain title-derived shaders, resource bytes, addresses, optional rendered RTT pixels, and optional
-exact persistent Vulkan depth/stencil checkpoint planes.
+Capsules contain title-derived shaders, resource bytes, addresses, ordered DMA endpoints, optional rendered RTT
+pixels, and optional exact persistent Vulkan depth/stencil checkpoint planes.
 They are gitignored local artifacts and must never be committed or shared as project fixtures.
 
 Normal capture preflights merged resource ranges and rejects plans above 512 MiB before allocating.
@@ -147,10 +147,10 @@ realized item's `draw_index`, never treat them as offsets into the compact draw 
 other graphics draws. This isolates geometry whose vertex/indirect buffers are produced earlier in the same
 submit without losing those producers. Plain `--draw` intentionally remains the cheaper graphics-only path.
 
-`--through-operation N` executes the inclusive mixed graphics/compute prefix `0..N`, preserving operation
+`--through-operation N` executes the inclusive mixed graphics/compute/DMA prefix `0..N`, preserving operation
 order and all earlier work. Prefix output uses the last executed draw target's native dimensions. Use it with
 a hash-verified seeded final capsule for fast composition bisection; unlike `--draw`, it does not discard
-compute dispatches or earlier draws.
+DMA copies, compute dispatches, or earlier draws.
 
 `--prepend` materializes and executes one earlier capsule in the same renderer instance before the consumer.
 Its rendered targets take precedence over consumer RTT seeds at matching addresses; unrelated seeds are still
@@ -188,6 +188,10 @@ block-size fields, and metadata address. Version 12 captures the exact DCC contr
 validated single-sample/base-level SW_64KB_R_X layout; metadata-only and older capsules keep their absence
 explicit. Version 13 tags every temporal color RTT seed as `rgba8` or `rgba16f`, preserving its native byte
 width through standalone replay while reading v1..v12 seeds as the historical RGBA8 default.
+Version 14 appends address-backed `DMA_DATA` records with exact source and destination guest identities, byte
+counts, PM4 order, and content-addressed endpoint blob references. Replay mutates the same owned resource
+instances used by later draws and dispatches and invalidates renderer caches for the guest destination range;
+v1..v13 capsules remain readable and do not invent DMA operations.
 `--inspect-only` reports the RTT format and the planned/captured byte counts, non-zero and unique-byte counts,
 first control word, and content hash. A software DCC decode is still not inferred. The capsule's standalone
 output must match the bundle's final hash before using it for fast `--draw`, operation-prefix, resource, or

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -22,6 +22,15 @@
 
 namespace {
 
+const char* operation_kind_name(prosper::gpu::SubmitOperationKind kind) {
+    switch (kind) {
+        case prosper::gpu::SubmitOperationKind::Draw: return "draw";
+        case prosper::gpu::SubmitOperationKind::Dispatch: return "dispatch";
+        case prosper::gpu::SubmitOperationKind::DmaCopy: return "dma";
+    }
+    return "unknown";
+}
+
 bool set_environment(const std::string& name, const std::string& value) {
 #ifdef _WIN32
     return _putenv_s(name.c_str(), value.c_str()) == 0;
@@ -78,19 +87,25 @@ std::vector<uint8_t> execute_frame(const prosper::gpu::GpuReplayFrame& replay,
                                    bool draws_only = false,
                                    size_t operation_limit = SIZE_MAX) {
     std::vector<prosper::gpu::SubmitOperation> operations;
+    std::vector<prosper::gpu::ReplayDmaCopy> dma_copies;
     const size_t count = std::min(operation_limit, replay.operations.size());
     for (size_t i = 0; i < count; ++i) {
         const auto& operation = replay.operations[i];
-        if (operation.realized)
-            operations.push_back({operation.kind, static_cast<size_t>(operation.source_index),
-                                  operation.command_order});
+        if (!operation.realized) continue;
+        size_t source_index = static_cast<size_t>(operation.source_index);
+        if (operation.kind == prosper::gpu::SubmitOperationKind::DmaCopy) {
+            if (source_index >= replay.dma_copies.size()) continue;
+            source_index = dma_copies.size();
+            dma_copies.push_back(replay.dma_copies[operation.source_index]);
+        }
+        operations.push_back({operation.kind, source_index, operation.command_order});
     }
     if (draws_only || replay.operations.empty())
         return prosper::gpu::render_submit_items(
             replay.items, replay.metadata.width, replay.metadata.height);
     if (operations.empty()) return {};
     auto result = prosper::gpu::execute_ordered_items(
-        operations, replay.items, replay.computes,
+        operations, replay.items, replay.computes, dma_copies,
         [](const auto& items, uint32_t width, uint32_t height) {
             return prosper::gpu::render_submit_items(items, width, height);
         },
@@ -108,7 +123,7 @@ void print_graph(const prosper::gpu::GpuDependencyGraph& graph) {
         if (!node.realized)
             std::printf("missing operation=%u kind=%s source=%llu order=%llu\n",
                         node.operation_index,
-                        node.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                        operation_kind_name(node.kind),
                         static_cast<unsigned long long>(node.source_index),
                         static_cast<unsigned long long>(node.command_order));
     for (const auto& edge : graph.edges)
@@ -136,7 +151,7 @@ bool write_graph_json(const std::string& path, const prosper::gpu::GpuDependency
         std::fprintf(file, "    {\"operation\":%u,\"kind\":\"%s\",\"source\":%llu,"
                            "\"order\":%llu,\"realized\":%s}%s\n",
                      node.operation_index,
-                     node.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                     operation_kind_name(node.kind),
                      static_cast<unsigned long long>(node.source_index),
                      static_cast<unsigned long long>(node.command_order),
                      node.realized ? "true" : "false", i + 1 == graph.nodes.size() ? "" : ",");
@@ -341,10 +356,20 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                         reinterpret_cast<const uint8_t*>(c.spirv.data()), c.spirv.size() * 4)));
         inspect_table("CS", c.resources.get(), replay.rtt_seeds);
     }
+    for (size_t i = 0; i < replay.dma_copies.size(); ++i) {
+        const auto& copy = replay.dma_copies[i];
+        std::printf("dma[%zu] order=%llu src=%016llx dst=%016llx bytes=%u sels=%08x packet=%016llx backing=%s/%s\n",
+                    i, static_cast<unsigned long long>(copy.command_order),
+                    static_cast<unsigned long long>(copy.src),
+                    static_cast<unsigned long long>(copy.dst), copy.bytes, copy.sels,
+                    static_cast<unsigned long long>(copy.packet_addr),
+                    copy.source_data ? "yes" : "no",
+                    copy.destination_data ? "yes" : "no");
+    }
     for (size_t i = 0; i < replay.operations.size(); ++i) {
         const auto& operation = replay.operations[i];
         std::printf("operation[%zu] %s source=%llu order=%llu realized=%s\n", i,
-                    operation.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                    operation_kind_name(operation.kind),
                     static_cast<unsigned long long>(operation.source_index),
                     static_cast<unsigned long long>(operation.command_order),
                     operation.realized ? "yes" : "no");
@@ -357,7 +382,7 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     for (size_t i = 0; i < replay.failure_diagnostics.size(); ++i) {
         const auto& failure = replay.failure_diagnostics[i];
         std::printf("failure[%zu] %s source=%llu order=%llu reason=%s stages=%zu\n", i,
-                    failure.kind == prosper::gpu::SubmitOperationKind::Draw ? "draw" : "dispatch",
+                    operation_kind_name(failure.kind),
                     static_cast<unsigned long long>(failure.source_index),
                     static_cast<unsigned long long>(failure.command_order),
                     prosper::gpu::realization_failure_reason_name(failure.reason),

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -74,7 +74,7 @@ semantics, draw isolation, resource/shader extraction, and the distinction betwe
 
 The summary reports duration, submit/present/draw/dispatch counts, rates, target extents, and whether
 an incomplete final record was discarded. `--records` prints the globally ordered submit/present
-index plus v6 target spans. `--signatures DRAWS DISPATCHES` groups target-span sequences for candidate
+index, v6 target spans, and exact v8 ordered DMA records. `--signatures DRAWS DISPATCHES` groups target-span sequences for candidate
 submit-count ranges; each range accepts `N` or `MIN:MAX`. `--select WxH DRAW_INDEX DRAWS DISPATCHES` applies
 the same semantic predicate as live capture, reports its first/last match and total, and exits nonzero when no
 submit matches. It reports an inconclusive error instead of treating a truncated target signature as a negative.
@@ -106,6 +106,12 @@ positive and nearby negative `.prgtl` samples when timing can move the endpoint.
 
 ## Current boundary
 
+Version 8 reads version-1 through version-7 indexes. It appends exact ordered `DMA_DATA` records to each
+submit: source and destination guest identities, byte count, selectors, PM4 command order, and packet address.
+Older indexes retain their historical count/incomplete signal and do not invent individual DMA operations.
+Detailed current-version capture v14 also closes both DMA endpoint ranges into content-addressed blobs so
+standalone replay can execute draw-to-DMA-to-draw or DMA-to-compute sequences at their original order.
+
 Version 6 reads version-1 through version-5 indexes. It adds run-length encoded color-target extent spans over
 the semantic draw sequence, excluding run-local addresses, so scene predicates can be discovered and tested
 offline before a detailed rerun. Span storage is bounded and an incomplete signature is marked truncated.
@@ -136,7 +142,7 @@ including inputs that are not overwritten later in the selected submit. Set
 the consumer submit/operation/range, the in-submit future writer, and either the matched prior graphics
 submit/draw/PM4 order/target extent or an explicit unresolved result.
 
-Version 2 added exactly one bounded detailed submit per run. The linked version-8 `.prgcap` contains
+Version 2 added exactly one bounded detailed submit per run. The linked current-version `.prgcap` contains
 content-hashed/deduplicated shaders and resource
 bytes, graphics and compute items, complete raw depth-surface programming, and the original mixed PM4 operation
 order. An operation whose shader

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -408,6 +408,12 @@ int main(int argc, char** argv) {
                             static_cast<unsigned long long>(s.last_command_order),
                             static_cast<unsigned long long>(s.color0_base),
                             s.color0_width, s.color0_height);
+                for (const auto& copy : s.dma_copies)
+                    std::printf("  dma order=%llu src=%016llx dst=%016llx bytes=%u sels=%08x packet=%016llx\n",
+                                static_cast<unsigned long long>(copy.command_order),
+                                static_cast<unsigned long long>(copy.src),
+                                static_cast<unsigned long long>(copy.dst), copy.bytes, copy.sels,
+                                static_cast<unsigned long long>(copy.packet_addr));
                 for (const auto& depth : s.depth_surfaces)
                     std::printf("  depth z=%016llx/%016llx s=%016llx/%016llx htile=%016llx "
                                 "target=%ux%u draws=%u tests=%u writes=%u clears=%u compare-mask=%08x\n",


### PR DESCRIPTION
## Summary

- add capture v14 records for ordered address-backed DMA_DATA copies, including exact source/destination guest identities, byte counts, PM4 order, and endpoint blob versions
- replay DMA at its original operation position through shared owned resource instances and invalidate renderer caches by guest destination range
- expose DMA in v8 timelines, bundles, dependency graphs, prefix replay, and inspection output while preserving older-format readers without invented operations
- cover draw -> DMA -> draw and DMA -> compute round trips, direct/timeline capture, bundle reconstruction, graph edges, and compatibility readers

## Verification

- Linux Debug/Vulkan build: complete
- Linux ctest: 100/100 passed
- Windows MinGW RelWithDebInfo core build: complete
- Windows ctest: 72/72 passed
- messenger-scene routed snapshot: passed (49/49 qualifying and structural frames, 30 pixel changes)
- dead-cells-gameplay routed snapshot: candidate and exact merged-base control both missed the reviewed gameplay window with 0 qualifying frames and the same 0.00207-0.00247 non-black loading-state range; base PARSEALL took 142.3s and candidate 176.5s

Closes #833