### PR TITLE
gpu: decode packed GFX10 vertex formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   So drive **git** (fetch/checkout/commit/push/worktree/status) from **PowerShell**, and use **WSL
   only for cmake/build/run**. Don't mix the two on one repo (it also avoids CRLF/filemode index churn).
 - **Build/run in WSL Ubuntu-24.04 as root.** Build dir `prosper/build-linux` (Linux, primary),
-  `prosper/build-win` (Windows/MinGW, secondary). Game dump at
+  `prosper/build-windows` (Windows/MinGW, secondary). Game dump at
   `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
@@ -294,13 +294,16 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   the current PR head contains changes designed, debugged, authored, co-authored, implemented, or materially
   modified by an agent, regardless of who opened the branch or PR. An agent taking over an existing PR must
   arrange the same review before merging. The implementing agent must never merge immediately after coding,
-  even when its tests pass. Once the implementation and author-side verification are ready, push the branch,
-  open or update the PR, and spawn a fresh, independent code-review sub-agent. Correctness is priority 1;
-  style and convenience never outweigh behavioral correctness.
-  - Before requesting review, make the PR description self-contained: link the issue/goal; explain the failure
+  even when its tests pass. Once the author is satisfied with the implementation, push the branch and open or
+  update the PR first. Then start two separate gates in parallel: spawn a fresh, independent code-review
+  sub-agent, while the author runs the applicable verification against the pushed PR head. Correctness is
+  priority 1; style and convenience never outweigh behavioral correctness.
+  - Before starting those gates, make the PR description self-contained: link the issue/goal; explain the failure
     scenario and violated contract; describe the approach and important invariants; identify affected and
     deliberately unaffected behavior; list risks, uncertainty, and compatibility concerns; and give exact
-    author-side build/test/snapshot commands and results. A reviewer should not need private chat context.
+    planned author-side build/test/snapshot commands. A reviewer should not need private chat context. Post the
+    actual results afterward in the author-verification comment described below; do not delay opening the PR just
+    to finish verification that should run alongside review.
   - Reviewer independence covers participation in producing the entire implementation under review: the
     reviewer must not have privately designed/debugged the solution with the author, authored or edited the
     patch, committed any part of it, or otherwise materially co-produced it. Spawn it with fresh context,
@@ -327,27 +330,49 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
     ownership and lifetimes, concurrency and ordering, bounds/overflow, error and cleanup paths, malformed
     inputs, platform differences, compatibility with old captures/state, and whether diagnostics themselves
     are race-safe and truthful. Inspect tests for meaningful failure coverage; passing tests are evidence, not
-    proof. For renderer/recompiler/detile/present changes, the mandatory snapshot gate remains part of review.
-  - The reviewer runs the strongest relevant focused builds/tests and required integration or snapshot checks.
-    Every applicable required check must be present, completed, and successful before merge. Only an explicit,
-    task-specific maintainer instruction may waive waiting for named CI checks (for example, on a docs-only
-    change), and the authorization and exact skipped checks must be recorded on the PR. Such an exception never
-    waives mandatory local, integration, or snapshot verification. If any other required check cannot run, the
-    reviewer posts the exact blocker and does not approve. It posts every finding on the PR with severity, exact
-    location, a concrete failing scenario, the violated contract, and the expected fix or regression test. New
-    regressions in the PR are blockers; pre-existing or out-of-scope bugs follow the issue-tracking rules below.
+    proof. For renderer/recompiler/detile/present changes, the mandatory snapshot gate remains part of the
+    author-side verification.
+  - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
+    improvement may be proposed and merged without implementing the same enhancement in every other frontend,
+    unless the issue/PR explicitly promises parity or a shared public contract requires it. The unaffected
+    platforms must still build and pass their applicable regression checks, and the PR must accurately state
+    its affected and deliberately unaffected behavior. Track desirable parity separately; do not refuse to open
+    a PR or block its merge merely because another unpublished app lacks the new improvement. This does not
+    relax correctness, safety, existing-behavior regression, or required-CI standards.
+  - **The author owns verification; the reviewer does not duplicate it.** After opening or updating the PR, the
+    author runs the strongest relevant focused builds/tests and required integration or snapshot checks against
+    the pushed head. Prefer `powershell -File prosper/tools/verify-pr.ps1 core` or, for render-affecting work,
+    `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>` so the commands, immutable head, and
+    results are captured consistently. The author then posts an `AUTHOR VERIFICATION` PR comment tied to the exact
+    head SHA, listing every applicable command and result; append `-Pr <N>` to either command to post the generated
+    comment automatically. The reviewer inspects whether the planned coverage is sufficient and may read any
+    available evidence, but does not wait for verification to finish as a condition of code approval and must not
+    rerun the author's builds, tests, snapshots, or CI jobs. If coverage is missing or a result is unclear, the
+    reviewer posts a finding and asks the author to run the additional check. This separation makes reviewer
+    approval and successful author verification independent, parallel merge gates instead of serial duplicate
+    work; the merge agent, not the reviewer, confirms that both completed successfully.
+  - Every applicable required check must be present, completed, and successful before merge. Only an explicit,
+    task-specific maintainer instruction may waive waiting for named CI or local checks (for example, on a
+    docs-only change), and the authorization and exact skipped checks must be recorded on the PR. If a required
+    author-side check cannot run, the author posts the exact blocker and the PR does not merge. The reviewer posts
+    every finding on the PR with severity, exact location, a concrete failing scenario, the violated contract,
+    and the expected fix or regression test. New regressions in the PR are blockers; pre-existing or out-of-scope
+    bugs follow the issue-tracking rules below.
   - The author addresses every finding on the PR by either pushing a fix with appropriate regression coverage
     or posting a concrete, evidence-based rebuttal. Correctness outranks reviewer authority: never implement a
     harmful request merely to obtain approval. The reviewer must explicitly accept the fix or withdraw/accept
     the rebuttal; otherwise the finding remains open and approval is withheld. The same reviewer then re-reads
-    the complete updated diff and re-runs affected verification. If unavailable, a replacement independent
-    reviewer must read the whole review record and perform the same full review.
+    the complete updated diff, while the author reruns the affected verification and posts updated evidence. If
+    the reviewer is unavailable, a replacement independent reviewer must read the whole review record and perform
+    the same full code review without duplicating author verification.
   - Continue until the reviewer explicitly posts either
     `APPROVED FOR MERGE <head-repo>:<head-ref>@<head-SHA> into <base-repo>:<base-ref>@<base-SHA> with tree <tree-SHA>`
     or `NOT APPROVED`, with remaining concerns. Approval covers the PR's reviewed authored change. Any later
     authored change to code, tests, workflows, fixtures, assets, generated files, configuration, docs, or
-    metadata invalidates approval and requires review of the updated change. Re-review is proportional to the
-    delta; do not repeat unrelated inspection or verification when the impact is clearly bounded.
+    metadata invalidates approval and requires review of the updated change. It also invalidates affected
+    author-verification evidence; the author may explicitly reuse unaffected evidence when the intervening diff
+    cannot affect that check. Re-review and re-verification are proportional to the delta; do not repeat unrelated
+    inspection or verification when the impact is clearly bounded.
   - **Synchronizing an approved PR with its target branch does not invalidate approval and does not require an
     external reviewer.** This includes rebasing onto the target, merging the target into the PR, or integrating
     a target tip that moved after approval. The PR author owns this synchronization. Fetch both refs directly,
@@ -380,10 +405,11 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
     live state and repeat base-sync validation or obtain review for new authored changes, as applicable. A normal
     `gh pr merge` head-only guard is not
     sufficient for this multi-agent repository.
-  - Never merge with an unresolved correctness finding; an applicable required check that is absent, pending,
-    or unsuccessful; an unrecorded/overbroad verification exception; unreviewed authored PR content; an
-    author-unvalidated live base/integration tree; or a merge mechanism that cannot atomically preserve the
-    transaction.
+  - Never merge with an unresolved correctness finding; a missing or stale SHA-bound reviewer approval; an
+    applicable author-side check that is absent, pending, unsuccessful, or not recorded in the current
+    `AUTHOR VERIFICATION` comment; an applicable CI job that is absent, pending, or unsuccessful; an
+    unrecorded/overbroad verification exception; unreviewed authored PR content; an author-unvalidated live
+    base/integration tree; or a merge mechanism that cannot atomically preserve the transaction.
     Reviewer approval satisfies the quality gate but is not permission to merge: the agent may merge only when
     the user/task separately authorizes it.
 
@@ -393,11 +419,12 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   modify the PR branch or implement fixes. Treat the PR description and comments as the complete coordination
   record. Resolve the live head and base repository/refs, fetch both directly, and record their full SHAs; do not
   rely on cached PR base metadata or a synthetic merge ref. Inspect the full diff, affected callers, invariants,
-  and prospective integration, and record its tree SHA. Run the strongest applicable verification, including
-  mandatory snapshot checks. Post every finding, question, test result, disposition, and final verdict on the
-  PR, signed with a stable reviewer name; include severity, exact location, concrete failure scenario, required
-  fix, and evidence. Do not approve while any correctness concern or required check remains. After any authored
-  update other than target-branch synchronization, review the complete new change. Post either APPROVED FOR MERGE
+  tests, author-verification plan/evidence, and prospective integration, and record its tree SHA. Do not rerun
+  author builds, tests, snapshots, or CI; request missing author-side coverage on the PR. Post every finding,
+  question, disposition, and final verdict on the PR, signed with one stable reviewer name; include severity,
+  exact location, concrete failure scenario, required fix, and evidence. Do not approve while any correctness
+  concern remains. After any authored update other than target-branch synchronization, review the complete new
+  change. Post either APPROVED FOR MERGE
   <head-repo>:<head-ref>@<head-SHA> into
   <base-repo>:<base-ref>@<base-SHA> with tree <tree-SHA> or NOT APPROVED. Directly message the author only to say
   that the posted review is complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,145 +290,20 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
 - **Correctness-first:** implement real behavior from primary evidence: live captures/traces, guest
   disassembly, published platform contracts, firmware symbol data, and focused tests. Do not ship shims
   that fake output. Mark genuinely uncertain code with `CONFIDENCE: HIGH/MED/LOW`.
-- **Independent review is a mandatory merge gate for every PR containing agent work.** This applies whenever
-  the current PR head contains changes designed, debugged, authored, co-authored, implemented, or materially
-  modified by an agent, regardless of who opened the branch or PR. An agent taking over an existing PR must
-  arrange the same review before merging. The implementing agent must never merge immediately after coding,
-  even when its tests pass. Once the author is satisfied with the implementation, push the branch and open or
-  update the PR first. Then start two separate gates in parallel: spawn a fresh, independent code-review
-  sub-agent, while the author runs the applicable verification against the pushed PR head. Correctness is
-  priority 1; style and convenience never outweigh behavioral correctness.
-  - Before starting those gates, make the PR description self-contained: link the issue/goal; explain the failure
-    scenario and violated contract; describe the approach and important invariants; identify affected and
-    deliberately unaffected behavior; list risks, uncertainty, and compatibility concerns; and give exact
-    planned author-side build/test/snapshot commands. A reviewer should not need private chat context. Post the
-    actual results afterward in the author-verification comment described below; do not delay opening the PR just
-    to finish verification that should run alongside review.
-  - Reviewer independence covers participation in producing the entire implementation under review: the
-    reviewer must not have privately designed/debugged the solution with the author, authored or edited the
-    patch, committed any part of it, or otherwise materially co-produced it. Spawn it with fresh context,
-    without the author's private implementation/debugging transcript; give it only the PR number and the neutral
-    brief below. The reviewer uses its own worktree and must not modify the PR branch or implement fixes. Normal
-    review work—identifying a failure, stating the required behavioral contract, suggesting possible remediation,
-    requesting regression coverage, and evaluating the author's fix or rebuttal—does not itself make the
-    reviewer a contributor. The author remains responsible for designing and implementing the patch. If the
-    reviewer supplies or edits the implementation or materially co-designs the final patch, it is disqualified
-    from approving that head and a different independent reviewer must perform the complete review. The author
-    may identify known risks and required checks on the PR, but not an expected conclusion.
-  - Direct author/reviewer communication is limited to coordination such as `review requested` and
-    `review posted`. Put all substantive context, questions, findings, replies, verification evidence, finding
-    dispositions, and verdicts on the PR as comments so the complete decision trail is durable and traceable.
-    Sign reviewer comments with one stable reviewer name.
-  - The reviewer resolves the live base repository and full target ref from the PR, fetches that target ref
-    directly, and records its identity and full SHA. Do not trust cached PR `base.sha`/`baseRefOid` metadata or a
-    synthetic PR merge ref as the authoritative target tip. Resolve and fetch the head repository/ref directly
-    too. Then read this file, every applicable `AGENTS.md`, the PR description and linked issue, the relevant
-    architecture/status docs, the complete base-to-head diff, all PR discussion, and the affected callers and
-    data paths. Inspect the prospective integration with that exact base and record its resulting tree SHA rather
-    than reviewing changed lines in isolation.
-  - The review must be adversarial and evidence-based. Check assumptions, invariants, ABI/API contracts,
-    ownership and lifetimes, concurrency and ordering, bounds/overflow, error and cleanup paths, malformed
-    inputs, platform differences, compatibility with old captures/state, and whether diagnostics themselves
-    are race-safe and truthful. Inspect tests for meaningful failure coverage; passing tests are evidence, not
-    proof. For renderer/recompiler/detile/present changes, the mandatory snapshot gate remains part of the
-    author-side verification.
-  - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
-    improvement may be proposed and merged without implementing the same enhancement in every other frontend,
-    unless the issue/PR explicitly promises parity or a shared public contract requires it. The unaffected
-    platforms must still build and pass their applicable regression checks, and the PR must accurately state
-    its affected and deliberately unaffected behavior. Track desirable parity separately; do not refuse to open
-    a PR or block its merge merely because another unpublished app lacks the new improvement. This does not
-    relax correctness, safety, existing-behavior regression, or required-CI standards.
-  - **The author owns verification; the reviewer does not duplicate it.** After opening or updating the PR, the
-    author runs the strongest relevant focused builds/tests and required integration or snapshot checks against
-    the pushed head. Prefer `powershell -File prosper/tools/verify-pr.ps1 core` or, for render-affecting work,
-    `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>` so the commands, immutable head, and
-    results are captured consistently. The author then posts an `AUTHOR VERIFICATION` PR comment tied to the exact
-    head SHA, listing every applicable command and result; append `-Pr <N>` to either command to post the generated
-    comment automatically. The reviewer inspects whether the planned coverage is sufficient and may read any
-    available evidence, but does not wait for verification to finish as a condition of code approval and must not
-    rerun the author's builds, tests, snapshots, or CI jobs. If coverage is missing or a result is unclear, the
-    reviewer posts a finding and asks the author to run the additional check. This separation makes reviewer
-    approval and successful author verification independent, parallel merge gates instead of serial duplicate
-    work; the merge agent, not the reviewer, confirms that both completed successfully.
-  - Every applicable required check must be present, completed, and successful before merge. Only an explicit,
-    task-specific maintainer instruction may waive waiting for named CI or local checks (for example, on a
-    docs-only change), and the authorization and exact skipped checks must be recorded on the PR. If a required
-    author-side check cannot run, the author posts the exact blocker and the PR does not merge. The reviewer posts
-    every finding on the PR with severity, exact location, a concrete failing scenario, the violated contract,
-    and the expected fix or regression test. New regressions in the PR are blockers; pre-existing or out-of-scope
-    bugs follow the issue-tracking rules below.
-  - The author addresses every finding on the PR by either pushing a fix with appropriate regression coverage
-    or posting a concrete, evidence-based rebuttal. Correctness outranks reviewer authority: never implement a
-    harmful request merely to obtain approval. The reviewer must explicitly accept the fix or withdraw/accept
-    the rebuttal; otherwise the finding remains open and approval is withheld. The same reviewer then re-reads
-    the complete updated diff, while the author reruns the affected verification and posts updated evidence. If
-    the reviewer is unavailable, a replacement independent reviewer must read the whole review record and perform
-    the same full code review without duplicating author verification.
-  - Continue until the reviewer explicitly posts either
-    `APPROVED FOR MERGE <head-repo>:<head-ref>@<head-SHA> into <base-repo>:<base-ref>@<base-SHA> with tree <tree-SHA>`
-    or `NOT APPROVED`, with remaining concerns. Approval covers the PR's reviewed authored change. Any later
-    authored change to code, tests, workflows, fixtures, assets, generated files, configuration, docs, or
-    metadata invalidates approval and requires review of the updated change. It also invalidates affected
-    author-verification evidence; the author may explicitly reuse unaffected evidence when the intervening diff
-    cannot affect that check. Re-review and re-verification are proportional to the delta; do not repeat unrelated
-    inspection or verification when the impact is clearly bounded.
-  - **Synchronizing an approved PR with its target branch does not invalidate approval and does not require an
-    external reviewer.** This includes rebasing onto the target, merging the target into the PR, or integrating
-    a target tip that moved after approval. The PR author owns this synchronization. Fetch both refs directly,
-    resolve conflicts, inspect the target delta and the refreshed PR diff, recompute the prospective integration
-    tree, run `diff --check`, and run any tests that the synchronization or conflict resolution can affect.
-    Record a `BASE SYNC VALIDATION` PR comment with the old/new base and head SHAs, changed/conflicting paths,
-    resulting tree SHA, and checks run. Existing review and CI evidence may be reused; do not rerun unrelated
-    suites or snapshots merely because the target advanced. If synchronization reveals a real bug, fix it and
-    obtain review for that authored fix, but the synchronization itself never needs reviewer re-approval.
-  - The final merge must atomically preserve every reviewed input. Prefer a repository merge queue/ruleset that
-    verifies the reviewed authored change and the author-validated current target/integration. Otherwise, only a
-    same-repository PR may use the direct-push fallback below; cross-repository PRs stop for a capable server-side
-    mechanism or maintainer
-    direction. Once approval, any required base-sync validation, and separate merge authorization exist, post the
-    complete transaction tuple as a `MERGE TRANSACTION` PR comment. That freezes the validated target for this
-    transaction: agents must not push/retarget it, a later PR UI retarget cannot redirect the hard-coded
-    destination, and only an explicit
-    maintainer cancellation revokes the authorized transaction. Abort if a head/target change is observed before
-    the push; repeat author-side base-sync validation for target synchronization, or obtain review for new
-    authored changes, as applicable.
-  - For the same-repository fallback, create a merge commit whose first parent is the validated transaction base
-    SHA, second parent is the current PR head SHA, and tree is the validated integration tree; verify all three
-    locally. In one server-side atomic push, advance both the exact target ref and exact PR head ref to that merge
-    commit with explicit expected-old-OID leases for the validated base and current head, for example:
-    `git push --atomic --force-with-lease=<base-ref>:<base-SHA> --force-with-lease=<head-ref>:<head-SHA> origin`
-    `<merge-commit>:<base-ref> <merge-commit>:<head-ref>`. The merge object fixes the reviewed content and target;
-    the two leases make concurrent base or head movement reject the entire transaction. The head's atomic advance
-    to the merge commit is part of the merge and does not invalidate approval. If either lease fails or
-    the server cannot perform the atomic push, never override/retry it or fall back to a plain merge: fetch the
-    live state and repeat base-sync validation or obtain review for new authored changes, as applicable. A normal
-    `gh pr merge` head-only guard is not
-    sufficient for this multi-agent repository.
-  - Never merge with an unresolved correctness finding; a missing or stale SHA-bound reviewer approval; an
-    applicable author-side check that is absent, pending, unsuccessful, or not recorded in the current
-    `AUTHOR VERIFICATION` comment; an applicable CI job that is absent, pending, or unsuccessful; an
-    unrecorded/overbroad verification exception; unreviewed authored PR content; an author-unvalidated live
-    base/integration tree; or a merge mechanism that cannot atomically preserve the transaction.
-    Reviewer approval satisfies the quality gate but is not permission to merge: the agent may merge only when
-    the user/task separately authorizes it.
-
-  Use this minimum review brief when spawning the sub-agent:
-  ```text
-  Independently review PR #<N> under the mandatory review policy in CLAUDE.md. Begin with fresh context; do not
-  modify the PR branch or implement fixes. Treat the PR description and comments as the complete coordination
-  record. Resolve the live head and base repository/refs, fetch both directly, and record their full SHAs; do not
-  rely on cached PR base metadata or a synthetic merge ref. Inspect the full diff, affected callers, invariants,
-  tests, author-verification plan/evidence, and prospective integration, and record its tree SHA. Do not rerun
-  author builds, tests, snapshots, or CI; request missing author-side coverage on the PR. Post every finding,
-  question, disposition, and final verdict on the PR, signed with one stable reviewer name; include severity,
-  exact location, concrete failure scenario, required fix, and evidence. Do not approve while any correctness
-  concern remains. After any authored update other than target-branch synchronization, review the complete new
-  change. Post either APPROVED FOR MERGE
-  <head-repo>:<head-ref>@<head-SHA> into
-  <base-repo>:<base-ref>@<base-SHA> with tree <tree-SHA> or NOT APPROVED. Directly message the author only to say
-  that the posted review is complete.
-  ```
+- **PR verification and merging.** Keep each PR description self-contained: link the issue or goal, explain the
+  failure scenario and behavioral contract, summarize the approach and important invariants, identify affected
+  and deliberately unaffected behavior, record risks, and list the exact build/test/snapshot commands and
+  results. Run the strongest relevant local checks and wait for every applicable required CI check. Before
+  merging, synchronize with the live target branch when needed, inspect the resulting diff, run `diff --check`,
+  and address every known correctness concern. An agent may merge only when the user or task explicitly
+  authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
+  for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
+  exact-head results. If a task explicitly requests an independent reviewer, the reviewer inspects the code and
+  author evidence but does not duplicate builds, tests, snapshots, or CI jobs.
+- **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
+  improvement may merge without matching work in every other frontend unless the issue explicitly promises
+  parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and
+  pass their applicable checks; track desirable parity separately rather than blocking the focused change.
 - **Evidence hierarchy and independent implementation.** Trust sources in this order: (1) prosper's
   live captures/traces of the real guest, (2) published platform contracts, firmware symbol data, and
   the guest's own disassembly, (3) agreement among independently written secondary implementations,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,8 +298,15 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   and address every known correctness concern. An agent may merge only when the user or task explicitly
   authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
   for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
-  exact-head results. If a task explicitly requests an independent reviewer, the reviewer inspects the code and
-  author evidence but does not duplicate builds, tests, snapshots, or CI jobs.
+  exact-head results.
+- **Use independent review where risk justifies it.** Complex or high-risk changes—such as shader recompilers and
+  control flow, memory safety, synchronization, ABI-sensitive interfaces, persistent data, or changes whose
+  failure can silently corrupt results—require an independent code review before merge. Routine, well-bounded,
+  low-risk changes do not. The reviewer inspects the code, tests, risks, and author evidence, but does not
+  duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR is
+  published, run author verification and any required review; the author posts exact-head evidence and the
+  reviewer posts approval on the corrected head. Address every blocking finding, then merge only after the merge
+  agent separately confirms author verification, reviewer approval where required, and green required CI.
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -124,13 +124,17 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
         d.format == DataFormat::Float10_11_11 || d.format == DataFormat::Unorm2_10_10_10 ||
         d.format == DataFormat::Snorm2_10_10_10 || d.format == DataFormat::Uint2_10_10_10 ||
         d.format == DataFormat::Sint2_10_10_10;
-    // BUFFER_LOAD_FORMAT applies the V#'s DST_SEL_X/Y/Z/W after format conversion. The recompiler's
-    // packed-word path currently returns physical R/G/B/A fields, so only accept the proven identity
-    // selector (SQ_SEL_X/Y/Z/W = 4/5/6/7 -> low 12 bits 0xFAC). Permutations and constant selectors
-    // must remain fail-closed until ShaderResource carries them through to SPIR-V; accepting them here
-    // would turn the old rejected draw into a silently wrong vector (#370 review).
+    // Packed loads currently lower physical fields directly, so accept only the exact selector shape
+    // represented by the recompiler: 2_10_10_10 uses X/Y/Z/W (0xFAC), while three-component
+    // 10_11_11_FLOAT uses X/Y/Z/1 (0x3AC), matching its W=1 default. Other permutations/constants
+    // remain fail-closed until ShaderResource carries arbitrary DST_SEL through to SPIR-V; accepting
+    // them here would turn the old rejected draw into a silently wrong vector (#370 review).
+    const uint32_t packed_selector = v[3] & 0xFFFu;
+    const bool supported_packed_selector =
+        d.format == DataFormat::Float10_11_11 ? packed_selector == 0x3ACu
+                                               : packed_selector == 0xFACu;
     const bool unsupported_scaled_2_10_10_10 = raw_format == 52u || raw_format == 53u;
-    if ((packed_word && (v[3] & 0xFFFu) != 0xFACu) || unsupported_scaled_2_10_10_10) {
+    if ((packed_word && !supported_packed_selector) || unsupported_scaled_2_10_10_10) {
         d.format = DataFormat::Unknown;
         d.num_components = 0;
         d.forbid_unknown_fallback = true;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -84,6 +84,11 @@ void rdna2_buffer_format(uint32_t fmt, DataFormat* out_fmt, uint32_t* out_compon
         case 27: f = DataFormat::Uint16;  n = 2; break;
         case 28: f = DataFormat::Sint16;  n = 2; break;
         case 29: f = DataFormat::Float16; n = 2; break;
+        case 36: f = DataFormat::Float10_11_11;       n = 3; break;
+        case 50: f = DataFormat::Unorm2_10_10_10;     n = 4; break;
+        case 51: f = DataFormat::Snorm2_10_10_10;     n = 4; break;
+        case 54: f = DataFormat::Uint2_10_10_10;      n = 4; break;
+        case 55: f = DataFormat::Sint2_10_10_10;      n = 4; break;
         case 56: f = DataFormat::Unorm8;  n = 4; break;   // 8_8_8_8_UNORM (vertex colors) — Kyty-confirmed
         case 57: f = DataFormat::Snorm8;  n = 4; break;
         case 60: f = DataFormat::Uint8;   n = 4; break;
@@ -144,11 +149,11 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
     if (fmt == 36) {
         // GFX10_FORMAT_10_11_11_FLOAT — packed 32-bit R11G11B10F (R=bits[10:0], G=[21:11],
         // B=[31:22], unsigned small floats, no alpha). UE4's scene-color render-target format;
-        // DOLL's final composite samples it at 3840x2160/1920x1080 (#294). Mapped HERE (not in
-        // rdna2_buffer_format) on purpose: as a texture the upload path unpacks it to RGBA8, but
-        // the vertex-fetch recompiler has no packed-component conversion, so a V# with this
-        // format must keep falling back rather than mis-convert. CONFIDENCE: HIGH (value from
-        // AMD's GFX10 register DB; live DOLL T#s confirmed fmt=36 at scene-color dimensions).
+        // DOLL's final composite samples it at 3840x2160/1920x1080 (#294). The explicit image case
+        // supplies its packed-texel byte size; rdna2_buffer_format also exposes the same value to the
+        // vertex-fetch recompiler, which widens the packed unsigned mini-floats exactly (#370).
+        // CONFIDENCE: HIGH (value from AMD's GFX10 register DB; live DOLL T#s confirmed fmt=36 at
+        // scene-color dimensions).
         fi.format = DataFormat::Float10_11_11; fi.num_components = 3; fi.bytes_per_block = 4;
     } else if (fmt == 50) {
         // GFX10_FORMAT_2_10_10_10_UNORM — Mesa maps a logical R10G10B10A2 format to this enum.
@@ -159,7 +164,10 @@ bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out) {
     } else if (fmt >= 1 && fmt <= 77) {          // shared with the V# buffer-format numbering
         DataFormat f = DataFormat::Unknown; uint32_t n = 0;
         rdna2_buffer_format(fmt, &f, &n);
-        if (f != DataFormat::Unknown) plain(f, n);
+        // Packed-word formats need an explicit image upload conversion and byte size. Float10_11_11
+        // and Unorm2_10_10_10 have those dedicated cases above; the newly supported V#-only signed
+        // and integer variants must remain fail-closed here instead of returning a zero-byte image.
+        if (f != DataFormat::Unknown && data_format_bytes(f) != 0) plain(f, n);
     } else switch (fmt) {
         case 128: plain(DataFormat::Unorm8, 1, true); break;   // 8_SRGB
         case 129: plain(DataFormat::Unorm8, 2, true); break;   // 8_8_SRGB

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -118,7 +118,8 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
     d.base        = ((uint64_t)v[0] | ((uint64_t)v[1] << 32)) & 0xFFFFFFFFFFFFull;  // Base48
     d.stride      = (v[1] >> 16) & 0x3FFFu;                                          // 14-bit stride
     d.num_records = v[2];
-    rdna2_buffer_format((v[3] >> 12) & 0x7Fu, &d.format, &d.num_components);
+    const uint32_t raw_format = (v[3] >> 12) & 0x7Fu;
+    rdna2_buffer_format(raw_format, &d.format, &d.num_components);
     const bool packed_word =
         d.format == DataFormat::Float10_11_11 || d.format == DataFormat::Unorm2_10_10_10 ||
         d.format == DataFormat::Snorm2_10_10_10 || d.format == DataFormat::Uint2_10_10_10 ||
@@ -128,9 +129,11 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
     // selector (SQ_SEL_X/Y/Z/W = 4/5/6/7 -> low 12 bits 0xFAC). Permutations and constant selectors
     // must remain fail-closed until ShaderResource carries them through to SPIR-V; accepting them here
     // would turn the old rejected draw into a silently wrong vector (#370 review).
-    if (packed_word && (v[3] & 0xFFFu) != 0xFACu) {
+    const bool unsupported_scaled_2_10_10_10 = raw_format == 52u || raw_format == 53u;
+    if ((packed_word && (v[3] & 0xFFFu) != 0xFACu) || unsupported_scaled_2_10_10_10) {
         d.format = DataFormat::Unknown;
         d.num_components = 0;
+        d.forbid_unknown_fallback = true;
     }
     // num_records is in units of `stride` when strided, else raw bytes. Compute in 64-bit and clamp so a
     // 32-bit wrap (num_records is a full 32-bit field) can't produce a small value that slips a bogus

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -119,6 +119,19 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
     d.stride      = (v[1] >> 16) & 0x3FFFu;                                          // 14-bit stride
     d.num_records = v[2];
     rdna2_buffer_format((v[3] >> 12) & 0x7Fu, &d.format, &d.num_components);
+    const bool packed_word =
+        d.format == DataFormat::Float10_11_11 || d.format == DataFormat::Unorm2_10_10_10 ||
+        d.format == DataFormat::Snorm2_10_10_10 || d.format == DataFormat::Uint2_10_10_10 ||
+        d.format == DataFormat::Sint2_10_10_10;
+    // BUFFER_LOAD_FORMAT applies the V#'s DST_SEL_X/Y/Z/W after format conversion. The recompiler's
+    // packed-word path currently returns physical R/G/B/A fields, so only accept the proven identity
+    // selector (SQ_SEL_X/Y/Z/W = 4/5/6/7 -> low 12 bits 0xFAC). Permutations and constant selectors
+    // must remain fail-closed until ShaderResource carries them through to SPIR-V; accepting them here
+    // would turn the old rejected draw into a silently wrong vector (#370 review).
+    if (packed_word && (v[3] & 0xFFFu) != 0xFACu) {
+        d.format = DataFormat::Unknown;
+        d.num_components = 0;
+    }
     // num_records is in units of `stride` when strided, else raw bytes. Compute in 64-bit and clamp so a
     // 32-bit wrap (num_records is a full 32-bit field) can't produce a small value that slips a bogus
     // buffer under the caller's `size_bytes > 0x10000000` plausibility guard.

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -107,6 +107,10 @@ struct DecodedBufferDescriptor {
     uint32_t   size_bytes = 0;
     DataFormat format = DataFormat::Float32;
     uint32_t   num_components = 1;
+    // True when the descriptor names a packed format whose exact semantics are known to be
+    // unsupported (currently non-identity DST_SEL or scaled 2_10_10_10). Dynamic fetch recovery
+    // must not reinterpret this deliberate rejection as the legacy unresolved-format Float32 fallback.
+    bool       forbid_unknown_fallback = false;
 };
 
 // Decode a 4-dword V# (RDNA2/Gen5 buffer resource). Pure; exposed for reuse + testing.

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -251,7 +251,7 @@ void write_resource(Writer& w, const GpuCapturedResource& c) {
 bool read_resource(Reader& rd, GpuCapturedResource& c) {
     auto& r = c.resource; uint32_t cls, fmt; uint8_t b;
     if (!rd.u32(cls) || cls > static_cast<uint32_t>(ResourceClass::StorageImage) ||
-        !rd.u32(fmt) || fmt > static_cast<uint32_t>(DataFormat::Unorm2_10_10_10)) return false;
+        !rd.u32(fmt) || fmt > static_cast<uint32_t>(DataFormat::Sint2_10_10_10)) return false;
     r.cls = static_cast<ResourceClass>(cls); r.format = static_cast<DataFormat>(fmt);
     if (!rd.u32(r.num_components) || !rd.u32(r.binding) || !rd.u64(r.gpu_addr) || !rd.u32(r.size) ||
         !rd.u32(r.stride) || !rd.u32(r.srt_offset) || !rd.u32(r.sgpr_base) || !rd.u32(r.fetch_pc) ||

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1424,6 +1424,19 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // it zeros -> a collapsed final vertex).
                         return d;
                     };
+                    auto append_fetch = [&](DecodedBufferDescriptor d, uint32_t desc_v3,
+                                            bool from_seed = false) {
+                        // decode_buffer_descriptor deliberately rejects packed formats whose selector
+                        // or conversion semantics are unsupported. Do not let build_stage_table's
+                        // legacy Unknown->Float32 fallback resurrect that descriptor as four raw dwords.
+                        if (d.forbid_unknown_fallback) {
+                            if (trc) fprintf(stderr,
+                                "[dyntrace]   MUBUF pc=%u packed V# v3=0x%x unsupported -> unresolved\n",
+                                in.pc, desc_v3);
+                            return;
+                        }
+                        out.push_back({ in.pc, srsrc, with_off(d), desc_v3, from_seed });
+                    };
                     if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x soff_known=%d\n",
                                      in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3,
                                      k3 ? vv[3] : 0, have_descr, fetch_off, (int)soff_known);
@@ -1438,11 +1451,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     // Per-fetch: record THIS fetch's live V# (the SRSRC SGPR is reloaded with a different V#
                     // per vertex attribute — position, uv, color…). Keyed by the fetch's pc so the recompiler
                     // resolves each buffer_load_format to the descriptor as loaded at that instruction.
-                    if (patched)          out.push_back({ in.pc, srsrc, with_off(decode_buffer_descriptor(vv)), vv[3] });
-                    else if (have_descr)
-                        out.push_back({ in.pc, srsrc,
-                                        with_off(decode_buffer_descriptor(descr[(size_t)srsrc].data())),
-                                        descr[(size_t)srsrc][3] });
+                    if (patched) {
+                        append_fetch(decode_buffer_descriptor(vv), vv[3]);
+                    } else if (have_descr) {
+                        append_fetch(decode_buffer_descriptor(descr[(size_t)srsrc].data()),
+                                     descr[(size_t)srsrc][3]);
+                    }
                     else if (srsrc >= (int)user_sgpr_base && srsrc + 4 <= (int)(user_sgpr_base + nsgpr) &&
                              valid_reg(srsrc + 3) && !reloaded.test((size_t)srsrc) &&
                              !reloaded.test((size_t)(srsrc + 1)) &&
@@ -1462,10 +1476,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                                  user_sgprs[srsrc - (int)user_sgpr_base + 3] };
                         DecodedBufferDescriptor d = decode_buffer_descriptor(sv);
                         // Plausibility: only emit a real-looking V# (mirrors the direct-resource guard).
-                        if (d.base > 0x10000 && d.size_bytes != 0 && d.size_bytes <= 0x10000000u) {
+                        if (d.base > 0x10000 && d.size_bytes != 0 && d.size_bytes <= 0x10000000u &&
+                            !d.forbid_unknown_fallback) {
                             if (trc) fprintf(stderr, "[dyntrace]   MUBUF pc=%u seed-V# fallback SRSRC=s%d base=0x%llx\n",
                                              in.pc, srsrc, (unsigned long long)d.base);
-                            out.push_back({ in.pc, srsrc, with_off(d), sv[3], /*from_seed=*/true });
+                            append_fetch(d, sv[3], /*from_seed=*/true);
                         }
                     }
                 }
@@ -1705,6 +1720,10 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         // (a raw 32-bit-per-component fetch, correct for float attributes like positions).
         for (auto& kv : dyn_vb) {
             const auto& d = kv.desc;
+            // Belt-and-suspenders: resolve_dynamic_fetch filters these before emitting DynFetch, but
+            // never allow a deliberately rejected packed descriptor to reach the generic Float32
+            // fallback if another producer constructs a DynFetch in the future.
+            if (d.forbid_unknown_fallback) continue;
             // A SEED-fallback entry must not shadow a metadata-described DIRECT vertex buffer at the
             // same SGPRs (see DynFetch::from_seed): the direct resource resolves the fetch through
             // the faithful address path, which is the correct model for a single un-patched V#.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2499,10 +2499,6 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
         case OperandKind::SGPR: {
             auto it = rs.sreg.find(o.value);
             if (it != rs.sreg.end()) return it->second;
-            if (rs.sreg_written.count(o.value)) {
-                if (ok) *ok = false;
-                return b.uconst(0);
-            }
             auto input = rs.sreg_input.find(o.value);
             return input == rs.sreg_input.end() ? b.uconst(0) : input->second;
         }
@@ -5643,6 +5639,7 @@ bool emit_compute_cfg_state_machine(
         b.emit_label(labels[block]);
         RegState state = load_state();
         state.sreg_written = scalar_may_write_in[block];
+        for (int reg : state.sreg_written) state.sreg_input.erase(reg);
         if (!direct_descriptor_sregs.empty()) {
             for (int reg : direct_descriptor_sregs)
                 if (!state.sreg_written.count(reg)) state.sreg.erase(reg);
@@ -6219,6 +6216,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 rs.exec = b.emit_phi_2way(b.t_bool, then_exec, then_block, rs.exec, else_block);
             rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
             rs.sreg_written.insert(then_written.begin(), then_written.end());
+            for (int reg : then_written) rs.sreg_input.erase(reg);
             if (then_bool != rs.sreg_bool) {
                 if (getenv("PROSPER_DBG"))
                     fprintf(stderr, "[recompile-reject] counted-loop prelude changes mask domain\n");
@@ -6600,6 +6598,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     if (then_exec != rs.exec) rs.exec = b.emit_phi_2way(b.t_bool, then_exec, thenEnd, rs.exec, elseEnd);
                     rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
                     rs.sreg_written.insert(then_written.begin(), then_written.end());
+                    for (int reg : then_written) rs.sreg_input.erase(reg);
                     // Merge the UNION of mask keys. A mask created in only one arm is false in the
                     // other arm; leaving that arm-local SSA id live after the merge is invalid SPIR-V.
                     std::set<int> bool_keys;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2438,6 +2438,21 @@ void for_each_scalar_write(const Rdna2Inst& in, Visitor&& visit) {
 }
 
 void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
+    // VOPC/VOP3 mask destinations live in sreg_bool, but they still overwrite the physical SGPR
+    // pair. Drop any scalar-data value or SRT descriptor tag left by that pair's earlier lifetime;
+    // keeping either would let a later descriptor use observe the pre-overwrite value.
+    auto invalidate_mask_pair = [&](int base) {
+        for (int word = 0; word < 2; ++word) {
+            rs.sreg.erase(base + word);
+            rs.sreg_srt.erase(base + word);
+        }
+    };
+    if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
+        invalidate_mask_pair(in.dst.value);
+    if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
+        invalidate_mask_pair(in.sdst.value);
+
     for_each_scalar_write(in, [&](int base, uint32_t width) {
         for (uint32_t word = 0; word < width; ++word) {
             const int reg = base + static_cast<int>(word);
@@ -2445,6 +2460,28 @@ void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
             rs.sreg_input.erase(reg);
         }
     });
+}
+
+// Scalar registers that MAY be overwritten while a loop executes. This is deliberately separate
+// from loop_written_regs: mask-pair destinations overwrite physical SGPRs (and therefore descriptor
+// provenance) but their values live in sreg_bool rather than the scalar-data SSA domain.
+void loop_scalar_may_writes(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t hi,
+                            std::set<int>& sregs) {
+    for (const auto& in : ins) {
+        if (in.pc < lo || in.pc >= hi) continue;
+        for_each_scalar_write(in, [&](int base, uint32_t width) {
+            for (uint32_t word = 0; word < width; ++word)
+                sregs.insert(base + static_cast<int>(word));
+        });
+    }
+}
+
+void invalidate_loop_descriptor_provenance(RegState& rs, const std::set<int>& sregs) {
+    for (int reg : sregs) {
+        rs.sreg_written.insert(reg);
+        rs.sreg_input.erase(reg);
+        rs.sreg_srt.erase(reg);
+    }
 }
 
 } // namespace
@@ -6266,9 +6303,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // value is the condition-block value (which dominates the merge), NOT the phi (defect A). SCC/VCC
         // always get a phi so any cross-iteration carry is valid SSA (defect C); they're recomputed each
         // iteration in practice, so the phi is usually dead — harmless.
-        std::set<int> cv, cs, condv, conds;
+        std::set<int> cv, cs, condv, conds, scalar_may_writes;
         loop_written_regs(ins, L.header_pc, L.backedge_pc, cv, cs);
         loop_written_regs(ins, L.header_pc, L.exit_branch_pc, condv, conds);
+        loop_scalar_may_writes(ins, L.header_pc, L.backedge_pc, scalar_may_writes);
         const uint32_t preheader = b.cur_block;
         const uint32_t hdr = b.id(), check = b.id(), body = b.id(), cont = b.id(), merge = b.id();
         b.emit_branch(hdr); b.emit_label(hdr);
@@ -6278,6 +6316,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         for (int r : cs) { size_t p; uint32_t ph = b.emit_phi2(b.t_u32, sget(r), preheader, p); rs.sreg[r] = ph; phis.push_back({r, 1, ph, p}); }
         { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc, preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
         { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+        // The header executes again after the back-edge. A direct/SRT descriptor overwritten
+        // anywhere in the loop is therefore not an invariant entry descriptor at header compile
+        // time. An exact descriptor load in the header may establish fresh provenance afterward.
+        invalidate_loop_descriptor_provenance(rs, scalar_may_writes);
         b.emit_loopmerge(merge, cont); b.emit_branch(check); b.emit_label(check);
         // 3. Condition block: emit [header, exit_branch); the SCC exit becomes OpBranchConditional.
         if (!emit_range(L.header_pc, L.exit_branch_pc)) return false;
@@ -6452,9 +6494,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // spirv-val + execution kernels + the live-boot A/B gate it).
         std::function<bool(const DivLoop&)> emit_divloop = [&](const DivLoop& L) -> bool {
             const bool entry_exec_narrowed = rs.exec_narrowed;
-            std::set<int> cv, cs, condv, conds;
+            std::set<int> cv, cs, condv, conds, scalar_may_writes;
             loop_written_regs(ins, L.header_pc, L.backedge_pc, cv, cs);
             loop_written_regs(ins, L.header_pc, L.exit_branch_pc, condv, conds);
+            loop_scalar_may_writes(ins, L.header_pc, L.backedge_pc, scalar_may_writes);
             const uint32_t preheader = b.cur_block;
             const uint32_t hdr = b.id(), chk = b.id(), body = b.id(), cont = b.id(), merge = b.id();
             b.emit_branch(hdr); b.emit_label(hdr);
@@ -6469,6 +6512,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             for (auto& kv : rs.sreg_bool) mask_keys.push_back(kv.first);
             std::sort(mask_keys.begin(), mask_keys.end());     // deterministic emission order
             for (int k : mask_keys) { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.sreg_bool[k], preheader, p); rs.sreg_bool[k] = ph; phis.push_back({k, 5, ph, p}); }
+            invalidate_loop_descriptor_provenance(rs, scalar_may_writes);
             b.emit_loopmerge(merge, cont); b.emit_branch(chk); b.emit_label(chk);
             // An EXEC-governed loop predicates vector writes. A VCC-governed loop branches on this
             // invocation's VCC bit but does not itself change EXEC, matching the hardware loop body.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5382,9 +5382,10 @@ bool emit_compute_cfg_state_machine(
 
     // The dispatcher reloads scalar values from Function variables, so map membership cannot say
     // whether shader code has overwritten an entry-time descriptor. Compute a forward MAY-write set
-    // for every basic-block entry instead. MAY is intentional: if one predecessor overwrote the
-    // descriptor, falling back to entry metadata after the join would be wrong on that path. Backedges
-    // participate in the fixed point, preventing a stale fallback on later loop iterations.
+    // for every reachable basic-block entry instead. MAY is intentional: if one reachable predecessor
+    // overwrote the descriptor, falling back to entry metadata after the join would be wrong on that
+    // path. Entry-rooted reachability excludes writes in dead blocks, while backedges participate in
+    // the fixed point and prevent stale fallback on later loop iterations.
     std::vector<std::unordered_set<int>> scalar_writes(starts.size());
     std::vector<std::vector<uint32_t>> successors(starts.size());
     for (uint32_t block = 0; block < starts.size(); ++block) {
@@ -5420,14 +5421,23 @@ bool emit_compute_cfg_state_machine(
         }
     }
     std::vector<std::unordered_set<int>> scalar_may_write_in(starts.size());
-    if (!scalar_may_write_in.empty()) scalar_may_write_in.front() = initial.sreg_written;
+    std::vector<bool> scalar_reachable(starts.size(), false);
+    if (!scalar_may_write_in.empty()) {
+        scalar_may_write_in.front() = initial.sreg_written;
+        scalar_reachable.front() = true;
+    }
     bool provenance_changed = true;
     while (provenance_changed) {
         provenance_changed = false;
         for (uint32_t block = 0; block < starts.size(); ++block) {
+            if (!scalar_reachable[block]) continue;
             std::unordered_set<int> out = scalar_may_write_in[block];
             out.insert(scalar_writes[block].begin(), scalar_writes[block].end());
             for (uint32_t successor : successors[block]) {
+                if (!scalar_reachable[successor]) {
+                    scalar_reachable[successor] = true;
+                    provenance_changed = true;
+                }
                 const size_t before = scalar_may_write_in[successor].size();
                 scalar_may_write_in[successor].insert(out.begin(), out.end());
                 provenance_changed |= scalar_may_write_in[successor].size() != before;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1299,6 +1299,10 @@ struct RegState {
     // descriptor provenance can still distinguish driver input from a shader overwrite, while
     // scalar ALU may read their real bits (Astro copies V#.word2 into M0 as an LDS base).
     std::unordered_map<int, uint32_t> sreg_input;
+    // SGPRs definitely written by shader instructions along at least one path to this point. This
+    // provenance is independent of `sreg`: an unrepresentable write deliberately erases its SSA
+    // value, but must still invalidate an entry-time direct descriptor stored in that register.
+    std::unordered_set<int> sreg_written;
     std::unordered_map<int, uint32_t> sreg_bool;   // SGPR (pairs) holding a saved per-lane mask (bool id)
     std::unordered_map<int, bool> sreg_bool_narrowed;  // was EXEC narrowed when this mask was saved? (restores it)
     std::unordered_map<int, uint32_t> sreg_srt;    // SGPR holding a descriptor -> its user_data/SRT byte offset
@@ -1340,6 +1344,12 @@ inline void predicate_write(SpirvCompute& b, RegState& rs, int idx, uint32_t old
 }
 inline uint32_t vreg_old(SpirvCompute& b, RegState& rs, int idx) {
     auto it = rs.vreg.find(idx); return it == rs.vreg.end() ? b.uconst(0) : it->second;
+}
+
+inline bool sreg_range_written(const RegState& rs, int base, uint32_t words) {
+    for (uint32_t word = 0; word < words; ++word)
+        if (rs.sreg_written.count(base + static_cast<int>(word))) return true;
+    return false;
 }
 
 // A scalar inline integer used by a B64 mask operation is sign-extended to 64 bits.  Return the bit
@@ -2377,6 +2387,52 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
     return out;
 }
 
+namespace {
+
+uint32_t scalar_write_width(const Rdna2Inst& in) {
+    switch (in.fmt) {
+        case Rdna2Format::SOP1:
+            if (in.opcode == 0x20) return 0; // s_setpc_b64 reads its decoded "dst" field.
+            switch (in.opcode) {
+                case 0x04: case 0x08: case 0x0a: case 0x1f:
+                case 0x24: case 0x25: case 0x37:
+                    return 2; // B64 data/mask writes
+                default: return 1;
+            }
+        case Rdna2Format::SOP2:
+            switch (in.opcode) {
+                case 0x0b: case 0x0f: case 0x11: case 0x13: case 0x15:
+                case 0x17: case 0x19: case 0x1b: case 0x1d: case 0x25: case 0x29:
+                    return 2; // B64 data/mask writes
+                default: return 1;
+            }
+        case Rdna2Format::SOPK: return 1;
+        case Rdna2Format::SMEM:
+            switch (in.opcode) {
+                case 0x0: case 0x8: return 1;
+                case 0x1: case 0x9: return 2;
+                case 0x2: case 0xa: return 4;
+                case 0x3: case 0xb: return 8;
+                case 0x4: case 0xc: return 16;
+                default: return 0;
+            }
+        case Rdna2Format::VOP1: return in.opcode == 0x02 ? 1u : 0u; // v_readfirstlane
+        case Rdna2Format::VOP3: return in.opcode == 0x360 ? 1u : 0u; // v_readlane
+        default: return 0;
+    }
+}
+
+void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
+    const uint32_t width = scalar_write_width(in);
+    for (uint32_t word = 0; word < width; ++word) {
+        const int reg = in.dst.value + static_cast<int>(word);
+        rs.sreg_written.insert(reg);
+        rs.sreg_input.erase(reg);
+    }
+}
+
+} // namespace
+
 // Registers WRITTEN in the pc range [lo, hi): candidates for an OpPhi at the loop header. Over-
 // approximation is safe (an extra phi for a non-carried value merges equal values). Mirrors emit_alu's
 // write targets, INCLUDING multi-register writes (MIMG dmask -> N consecutive VGPRs, SMEM -> N SGPRs) so
@@ -2443,6 +2499,10 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
         case OperandKind::SGPR: {
             auto it = rs.sreg.find(o.value);
             if (it != rs.sreg.end()) return it->second;
+            if (rs.sreg_written.count(o.value)) {
+                if (ok) *ok = false;
+                return b.uconst(0);
+            }
             auto input = rs.sreg_input.find(o.value);
             return input == rs.sreg_input.end() ? b.uconst(0) : input->second;
         }
@@ -3912,7 +3972,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (!res && it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
                 // A scalar buffer load reads a CONSTANT buffer — resolve the SBASE SGPR to a constant
                 // buffer specifically (the same SGPR may also hold a vertex-buffer V# elsewhere).
-                if (!res) res = rt->by_sgpr_base_cls(in.src[0].value, ResourceClass::ConstantBuffer);
+                if (!res && !sreg_range_written(rs, in.src[0].value, 4))
+                    res = rt->by_sgpr_base_cls(in.src[0].value, ResourceClass::ConstantBuffer);
                 if (res) { binding = res->binding; cbuf_resolved = true; } }
             if (getenv("PROSPER_CBUFLOG"))
                 fprintf(stderr, "[cbuf] pc=%u s_buffer_load x%u src0=s%d off=0x%x(dw%u) dyn=%d -> binding=%u %s\n",
@@ -4053,13 +4114,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // Any write to the four-dword SRSRC range invalidates its entry-time direct V#.
                     // Exact per-fetch and s_load provenance below may still identify the live descriptor,
                     // but a missing/rejected dynamic result must never fall back to stale user data.
-                    bool srsrc_rewritten = false;
-                    for (int component = 0; component < 4; ++component) {
-                        if (rs.sreg.find(in.src[1].value + component) != rs.sreg.end()) {
-                            srsrc_rewritten = true;
-                            break;
-                        }
-                    }
+                    const bool srsrc_rewritten = sreg_range_written(rs, in.src[1].value, 4);
                     // PER-FETCH first: a reloaded SRSRC holds a different V# per attribute, so match this
                     // exact fetch instruction's pc; fall back to untouched SGPR user data or an s_load
                     // SRT tag. A rewritten direct descriptor without either provenance stays unresolved.
@@ -4118,7 +4173,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const ShaderResource* res = rt->by_fetch_pc(in.pc);
                 if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
                     if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
-                if (!res) res = rt->by_sgpr_base(in.src[1].value);
+                if (!res && !sreg_range_written(rs, in.src[1].value, 4))
+                    res = rt->by_sgpr_base(in.src[1].value);
                 if (!res) { ok = false; return true; }   // unresolvable V# -> reject; NEVER default to binding 2
                 binding = res->binding;
                 stride  = res->stride;
@@ -4382,7 +4438,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 res = nullptr;
                 auto it = rs.sreg_srt.find(in.src[1].value);
                 if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
-                if (!res) res = rt->by_sgpr_base(in.src[1].value);
+                if (!res && !sreg_range_written(rs, in.src[1].value, 8))
+                    res = rt->by_sgpr_base(in.src[1].value);
             }
             // Exact per-use provenance wins over table keys. A sample and store may consume the same
             // T# through a colliding offset but require different Vulkan descriptor classes.
@@ -4906,27 +4963,6 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
 
 namespace {
 
-uint32_t scalar_write_width(const Rdna2Inst& in) {
-    switch (in.fmt) {
-        case Rdna2Format::SOP1:
-            if (in.opcode == 0x20) return 0; // s_setpc_b64 reads its decoded "dst" field.
-            return (in.opcode == 0x04 || in.opcode == 0x1f) ? 2u : 1u;
-        case Rdna2Format::SOP2: return in.opcode == 0x29 ? 2u : 1u;
-        case Rdna2Format::SOPK: return 1;
-        case Rdna2Format::SMEM:
-            switch (in.opcode) {
-                case 0x0: case 0x8: return 1;
-                case 0x1: case 0x9: return 2;
-                case 0x2: case 0xa: return 4;
-                case 0x3: case 0xb: return 8;
-                case 0x4: case 0xc: return 16;
-                default: return 0;
-            }
-        case Rdna2Format::VOP1: return in.opcode == 0x02 ? 1u : 0u; // v_readfirstlane
-        default: return 0;
-    }
-}
-
 const Rdna2Inst* last_scalar_writer(const std::vector<Rdna2Inst>& ins, uint32_t before_pc,
                                     int reg) {
     const Rdna2Inst* result = nullptr;
@@ -5348,6 +5384,61 @@ bool emit_compute_cfg_state_machine(
         }
     }
 
+    // The dispatcher reloads scalar values from Function variables, so map membership cannot say
+    // whether shader code has overwritten an entry-time descriptor. Compute a forward MAY-write set
+    // for every basic-block entry instead. MAY is intentional: if one predecessor overwrote the
+    // descriptor, falling back to entry metadata after the join would be wrong on that path. Backedges
+    // participate in the fixed point, preventing a stale fallback on later loop iterations.
+    std::vector<std::unordered_set<int>> scalar_writes(starts.size());
+    std::vector<std::vector<uint32_t>> successors(starts.size());
+    for (uint32_t block = 0; block < starts.size(); ++block) {
+        const uint32_t lo = starts[block];
+        const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
+        for (const auto& in : ins) {
+            if (in.pc < lo || in.pc >= hi) continue;
+            const uint32_t width = scalar_write_width(in);
+            for (uint32_t word = 0; word < width; ++word)
+                scalar_writes[block].insert(in.dst.value + static_cast<int>(word));
+        }
+
+        const Rdna2Inst* terminator = nullptr;
+        for (const auto& in : ins) {
+            if (in.pc < lo || in.pc >= hi) continue;
+            if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
+                              in.opcode <= 0x09 && in.opcode != 0x03)) {
+                terminator = &in;
+                break;
+            }
+        }
+        auto add_successor = [&](uint32_t pc) {
+            auto next = block_for_pc.find(pc);
+            if (pc <= end_pc && next != block_for_pc.end())
+                successors[block].push_back(next->second);
+        };
+        if (!terminator) {
+            add_successor(hi);
+        } else if (!terminator->is_end) {
+            add_successor(branch_target(*terminator));
+            if (terminator->opcode != 0x02)
+                add_successor(terminator->pc + terminator->len_dwords);
+        }
+    }
+    std::vector<std::unordered_set<int>> scalar_may_write_in(starts.size());
+    if (!scalar_may_write_in.empty()) scalar_may_write_in.front() = initial.sreg_written;
+    bool provenance_changed = true;
+    while (provenance_changed) {
+        provenance_changed = false;
+        for (uint32_t block = 0; block < starts.size(); ++block) {
+            std::unordered_set<int> out = scalar_may_write_in[block];
+            out.insert(scalar_writes[block].begin(), scalar_writes[block].end());
+            for (uint32_t successor : successors[block]) {
+                const size_t before = scalar_may_write_in[successor].size();
+                scalar_may_write_in[successor].insert(out.begin(), out.end());
+                provenance_changed |= scalar_may_write_in[successor].size() != before;
+            }
+        }
+    }
+
     // Saved mask pairs and scalar-spill lane slots have their own value domains.
     std::set<int> mask_keys = static_mask_keys;
     std::set<std::pair<int, int>> lane_slots, mask_lane_slots;
@@ -5551,11 +5642,10 @@ bool emit_compute_cfg_state_machine(
         const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
         b.emit_label(labels[block]);
         RegState state = load_state();
+        state.sreg_written = scalar_may_write_in[block];
         if (!direct_descriptor_sregs.empty()) {
-            std::set<int> written_vregs, written_sregs;
-            loop_written_regs(ins, 0, lo, written_vregs, written_sregs);
             for (int reg : direct_descriptor_sregs)
-                if (!written_sregs.count(reg)) state.sreg.erase(reg);
+                if (!state.sreg_written.count(reg)) state.sreg.erase(reg);
         }
         const Rdna2Inst* terminator = nullptr;
         const Rdna2Inst* mbcnt = nullptr;
@@ -5586,8 +5676,10 @@ bool emit_compute_cfg_state_machine(
                 continue;
             }
             bool ok = true;
-            if (!emit_alu(b, state, in, ok, allow_exec_update, &safe, allow_smem, rt,
-                          /*allow_wave*/false) || !ok) {
+            const bool handled = emit_alu(b, state, in, ok, allow_exec_update, &safe,
+                                          allow_smem, rt, /*allow_wave*/false);
+            if (handled && ok) record_scalar_write(state, in);
+            if (!handled || !ok) {
                 if (getenv("PROSPER_DBG"))
                     std::fprintf(stderr, "[cfg-recompile-reject] pc=%u fmt=%d op=0x%x\n",
                                  in.pc, static_cast<int>(in.fmt), in.opcode);
@@ -5966,7 +6058,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (dead_masks.count(in.pc)) continue;
             if (in.fmt == Rdna2Format::EXP) { if (!exp_fn(in)) return false; continue; }
             bool ok = true;
-            if (!emit_alu(b, rs, in, ok, allow_exec_update, &effective_safe, allow_smem, rt, wave_ok) || !ok) {
+            const bool handled = emit_alu(
+                b, rs, in, ok, allow_exec_update, &effective_safe, allow_smem, rt, wave_ok);
+            if (handled && ok) record_scalar_write(rs, in);
+            if (!handled || !ok) {
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
                 if (getenv("PROSPER_DBG"))
@@ -6095,6 +6190,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             const uint32_t then_scc = rs.scc, then_vcc = rs.vcc, then_exec = rs.exec;
             const bool then_narrowed = rs.exec_narrowed;
             const auto then_bool = rs.sreg_bool;
+            const auto then_written = rs.sreg_written;
             b.emit_branch(merge_label);
 
             rs = before;
@@ -6122,6 +6218,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (then_exec != rs.exec)
                 rs.exec = b.emit_phi_2way(b.t_bool, then_exec, then_block, rs.exec, else_block);
             rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
+            rs.sreg_written.insert(then_written.begin(), then_written.end());
             if (then_bool != rs.sreg_bool) {
                 if (getenv("PROSPER_DBG"))
                     fprintf(stderr, "[recompile-reject] counted-loop prelude changes mask domain\n");
@@ -6487,6 +6584,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     uint32_t then_scc = rs.scc, then_vcc = rs.vcc, then_exec = rs.exec;
                     const bool then_narrowed = rs.exec_narrowed;
                     const std::unordered_map<int,uint32_t> then_bool = rs.sreg_bool;
+                    const auto then_written = rs.sreg_written;
                     b.emit_branch(mergeL);
                     rs = pre;                               // else-arm starts from the pre-branch state
                     b.emit_label(elseL);
@@ -6501,6 +6599,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     if (then_vcc != rs.vcc) rs.vcc = b.emit_phi_2way(b.t_bool, then_vcc, thenEnd, rs.vcc, elseEnd);
                     if (then_exec != rs.exec) rs.exec = b.emit_phi_2way(b.t_bool, then_exec, thenEnd, rs.exec, elseEnd);
                     rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
+                    rs.sreg_written.insert(then_written.begin(), then_written.end());
                     // Merge the UNION of mask keys. A mask created in only one arm is false in the
                     // other arm; leaving that arm-local SSA id live after the merge is invalid SPIR-V.
                     std::set<int> bool_keys;
@@ -6653,9 +6752,11 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
         cov.total++;
         if (in.fmt == Rdna2Format::EXP) { cov.exports++; continue; }   // handled by the stage recompilers
         bool ok = true;
-        bool handled = cf_reconstructed(in)
-                     || (emit_alu(b, rs, in, ok, /*allow_exec_update*/true, &safe_branches, /*allow_smem*/true,
-                                  /*rt*/nullptr, /*allow_wave*/true) && ok);
+        const bool emitted = emit_alu(
+            b, rs, in, ok, /*allow_exec_update*/true, &safe_branches,
+            /*allow_smem*/true, /*rt*/nullptr, /*allow_wave*/true);
+        if (emitted && ok) record_scalar_write(rs, in);
+        bool handled = cf_reconstructed(in) || (emitted && ok);
         // Shapes the recompiler handles only in context (a resource table for MIMG sample/load/LOD/store
         // and buffer_load/store_format; a fragment stage for VINTRP). This table-less compute-shell pass
         // rejects them, so count them apart from truly-unsupported (cross-lane, etc.). Instruction-aware

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3579,8 +3579,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // buffer specifically (that SGPR may hold a constant-buffer V# at other points; the const-
                 // fold-resolved vertex buffer is keyed by this SRSRC SGPR). Fall back to an s_load SRT tag.
                 if (rt) {
+                    // Any write to the four-dword SRSRC range invalidates its entry-time direct V#.
+                    // Exact per-fetch and s_load provenance below may still identify the live descriptor,
+                    // but a missing/rejected dynamic result must never fall back to stale user data.
+                    bool srsrc_rewritten = false;
+                    for (int component = 0; component < 4; ++component) {
+                        if (rs.sreg.find(in.src[1].value + component) != rs.sreg.end()) {
+                            srsrc_rewritten = true;
+                            break;
+                        }
+                    }
                     // PER-FETCH first: a reloaded SRSRC holds a different V# per attribute, so match this
-                    // exact fetch instruction's pc; fall back to the SGPR (direct) then s_load SRT tag.
+                    // exact fetch instruction's pc; fall back to untouched SGPR user data or an s_load
+                    // SRT tag. A rewritten direct descriptor without either provenance stays unresolved.
                     // Only a VERTEX-buffer pc entry implies the vertex-index address model — a pc-keyed
                     // CONSTANT/structured buffer (a PS's per-lane table fetch, #273) keeps the faithful
                     // VADDR*stride+offset address below.
@@ -3594,19 +3605,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // those addresses with gl_VertexIndex reads the wrong matrix row and collapses
                     // the whole mesh, so preserve a non-v0 VADDR for untouched direct user data.
                     if (res) {
-                        const bool srsrc_rewritten = rs.sreg.find(in.src[1].value) != rs.sreg.end();
                         dyn_vfetch = res->cls == ResourceClass::VertexBuffer &&
                                      (in.src[0].value == 0 || srsrc_rewritten);
                     }
-                    if (!res) res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
+                    if (!res && !srsrc_rewritten)
+                        res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
                     if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
                         if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
                     // DIRECT user-data V# of any class (#273 — DOLL's title post PSes format-fetch
                     // through a V# the metadata labels a CONSTANT buffer sharp at s[24:27]): the class
                     // label doesn't change the descriptor's fields. Only when the SGPR was never
-                    // REWRITTEN in-shader (no rs.sreg entry) — a reloaded register no longer holds the
-                    // seed-time sharp, and trusting it would fetch through a stale descriptor.
-                    if (!res && rs.sreg.find(in.src[1].value) == rs.sreg.end())
+                    // REWRITTEN in-shader (no rs.sreg entry in its four-dword range) — a reloaded
+                    // register no longer holds the seed-time sharp, and trusting it would fetch through
+                    // a stale descriptor.
+                    if (!res && !srsrc_rewritten)
                         res = rt->by_sgpr_base(in.src[1].value);
                 }
                 if (!res) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2422,13 +2422,29 @@ uint32_t scalar_write_width(const Rdna2Inst& in) {
     }
 }
 
-void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
+// Visit every explicit scalar-register write performed by one supported instruction. Most scalar
+// instructions use `dst`, but VOPC SDWAB/e64 compares can write an SGPR mask pair through `dst`, and
+// VOP3B arithmetic writes its carry mask through the independent `sdst` field. Keeping this as the
+// single writer inventory prevents provenance/data-flow users from silently missing secondary dsts.
+template <typename Visitor>
+void for_each_scalar_write(const Rdna2Inst& in, Visitor&& visit) {
     const uint32_t width = scalar_write_width(in);
-    for (uint32_t word = 0; word < width; ++word) {
-        const int reg = in.dst.value + static_cast<int>(word);
-        rs.sreg_written.insert(reg);
-        rs.sreg_input.erase(reg);
-    }
+    if (width) visit(in.dst.value, width);
+    if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
+        visit(in.dst.value, 2);
+    if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
+        visit(in.sdst.value, 2);
+}
+
+void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
+    for_each_scalar_write(in, [&](int base, uint32_t width) {
+        for (uint32_t word = 0; word < width; ++word) {
+            const int reg = base + static_cast<int>(word);
+            rs.sreg_written.insert(reg);
+            rs.sreg_input.erase(reg);
+        }
+    });
 }
 
 } // namespace
@@ -4964,8 +4980,11 @@ const Rdna2Inst* last_scalar_writer(const std::vector<Rdna2Inst>& ins, uint32_t 
     const Rdna2Inst* result = nullptr;
     for (const auto& in : ins) {
         if (in.is_end || in.pc >= before_pc) break;
-        const uint32_t width = scalar_write_width(in);
-        if (width && reg >= in.dst.value && reg < in.dst.value + static_cast<int>(width)) result = &in;
+        bool writes_reg = false;
+        for_each_scalar_write(in, [&](int base, uint32_t width) {
+            writes_reg |= reg >= base && reg < base + static_cast<int>(width);
+        });
+        if (writes_reg) result = &in;
     }
     return result;
 }
@@ -5393,9 +5412,10 @@ bool emit_compute_cfg_state_machine(
         const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
         for (const auto& in : ins) {
             if (in.pc < lo || in.pc >= hi) continue;
-            const uint32_t width = scalar_write_width(in);
-            for (uint32_t word = 0; word < width; ++word)
-                scalar_writes[block].insert(in.dst.value + static_cast<int>(word));
+            for_each_scalar_write(in, [&](int base, uint32_t width) {
+                for (uint32_t word = 0; word < width; ++word)
+                    scalar_writes[block].insert(base + static_cast<int>(word));
+            });
         }
 
         const Rdna2Inst* terminator = nullptr;
@@ -6120,10 +6140,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             bool side_effect_free = true;
             for (const auto& candidate : ins) {
                 if (candidate.pc <= branch.pc || candidate.pc >= target) continue;
-                const uint32_t scalar_width = scalar_write_width(candidate);
-                const bool clobbers_guard_mask = scalar_width &&
-                    candidate.dst.value < saveexec.dst.value + 2 &&
-                    saveexec.dst.value < candidate.dst.value + static_cast<int>(scalar_width);
+                bool clobbers_guard_mask = false;
+                for_each_scalar_write(candidate, [&](int base, uint32_t width) {
+                    clobbers_guard_mask |= base < saveexec.dst.value + 2 &&
+                        saveexec.dst.value < base + static_cast<int>(width);
+                });
                 if (candidate.fmt == Rdna2Format::EXP || candidate.fmt == Rdna2Format::DS ||
                     candidate.fmt == Rdna2Format::MUBUF || candidate.fmt == Rdna2Format::MTBUF ||
                     candidate.fmt == Rdna2Format::MIMG || candidate.fmt == Rdna2Format::FLAT ||

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1352,6 +1352,20 @@ inline bool sreg_range_written(const RegState& rs, int base, uint32_t words) {
     return false;
 }
 
+// An SRT tag describes the complete hardware descriptor, not merely its base SGPR. Accept it only
+// while every word still carries the same provenance; any partial overwrite makes the descriptor
+// unrepresentable even when the base word itself was untouched.
+inline bool sreg_srt_range_tag(const RegState& rs, int base, uint32_t words, uint32_t& tag) {
+    auto first = rs.sreg_srt.find(base);
+    if (first == rs.sreg_srt.end()) return false;
+    tag = first->second;
+    for (uint32_t word = 1; word < words; ++word) {
+        auto it = rs.sreg_srt.find(base + static_cast<int>(word));
+        if (it == rs.sreg_srt.end() || it->second != tag) return false;
+    }
+    return true;
+}
+
 // A scalar inline integer used by a B64 mask operation is sign-extended to 64 bits.  Return the bit
 // belonging to this emulated hardware lane without ever issuing an undefined >=32 SPIR-V shift.
 // Astro's reduction tails use 15, 3, and 1 for the final 4/2/1 active lanes.
@@ -4017,8 +4031,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // (or that key collides). Exact per-use provenance must win, as it does for MUBUF/MIMG.
                 res = rt->by_fetch_pc(in.pc);
                 if (res && res->cls != ResourceClass::ConstantBuffer) res = nullptr;
-                auto it = rs.sreg_srt.find(in.src[0].value);
-                if (!res && it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
+                uint32_t srt_tag = 0;
+                if (!res && sreg_srt_range_tag(rs, in.src[0].value, 4, srt_tag))
+                    res = rt->by_srt_offset(srt_tag);
                 // A scalar buffer load reads a CONSTANT buffer — resolve the SBASE SGPR to a constant
                 // buffer specifically (the same SGPR may also hold a vertex-buffer V# elsewhere).
                 if (!res && !sreg_range_written(rs, in.src[0].value, 4))
@@ -4185,8 +4200,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     if (!res && !srsrc_rewritten)
                         res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
-                    if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
-                        if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
+                    uint32_t srt_tag = 0;
+                    if (!res && sreg_srt_range_tag(rs, in.src[1].value, 4, srt_tag))
+                        res = rt->by_srt_offset(srt_tag);
                     // DIRECT user-data V# of any class (#273 — DOLL's title post PSes format-fetch
                     // through a V# the metadata labels a CONSTANT buffer sharp at s[24:27]): the class
                     // label doesn't change the descriptor's fields. Only when the SGPR was never
@@ -4198,11 +4214,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 if (!res) {
                     if (getenv("PROSPER_DBG")) {   // which provenance step failed for this format load
-                        auto it = rs.sreg_srt.find(in.src[1].value);
+                        uint32_t srt_tag = 0;
+                        const bool has_srt_tag = sreg_srt_range_tag(
+                            rs, in.src[1].value, 4, srt_tag);
                         fprintf(stderr, "[mubuf-unresolved] pc=%u srsrc=s%d srt_tag=%s0x%x key_res=%s (%zu res)\n",
-                                in.pc, in.src[1].value, it != rs.sreg_srt.end() ? "" : "NONE ",
-                                it != rs.sreg_srt.end() ? it->second : 0u,
-                                it != rs.sreg_srt.end() && rt->by_srt_offset(it->second) ? "yes" : "null",
+                                in.pc, in.src[1].value, has_srt_tag ? "" : "NONE ",
+                                has_srt_tag ? srt_tag : 0u,
+                                has_srt_tag && rt->by_srt_offset(srt_tag) ? "yes" : "null",
                                 rt->resources.size());
                     }
                     ok = false; return true;
@@ -4220,8 +4238,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // Provenance order mirrors the format path: exact fetch pc, then s_load SRT tag
                 // (indirect), then user-data SGPR (direct).
                 const ShaderResource* res = rt->by_fetch_pc(in.pc);
-                if (!res) { auto it = rs.sreg_srt.find(in.src[1].value);
-                    if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second); }
+                uint32_t srt_tag = 0;
+                if (!res && sreg_srt_range_tag(rs, in.src[1].value, 4, srt_tag))
+                    res = rt->by_srt_offset(srt_tag);
                 if (!res && !sreg_range_written(rs, in.src[1].value, 4))
                     res = rt->by_sgpr_base(in.src[1].value);
                 if (!res) { ok = false; return true; }   // unresolvable V# -> reject; NEVER default to binding 2
@@ -4485,8 +4504,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const ShaderResource* res = rt->by_fetch_pc(in.pc);
             if (!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage)) {
                 res = nullptr;
-                auto it = rs.sreg_srt.find(in.src[1].value);
-                if (it != rs.sreg_srt.end()) res = rt->by_srt_offset(it->second);
+                uint32_t srt_tag = 0;
+                if (sreg_srt_range_tag(rs, in.src[1].value, 8, srt_tag))
+                    res = rt->by_srt_offset(srt_tag);
                 if (!res && !sreg_range_written(rs, in.src[1].value, 8))
                     res = rt->by_sgpr_base(in.src[1].value);
             }
@@ -4499,12 +4519,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if ((!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage))
                 && getenv("PROSPER_DBG")) {
                 // Resolution-failure diagnostic: which provenance step failed for this image op.
-                auto it = rs.sreg_srt.find(in.src[1].value);
-                const ShaderResource* pk = it != rs.sreg_srt.end() ? rt->by_srt_offset(it->second) : nullptr;
+                uint32_t srt_tag = 0;
+                const bool has_srt_tag = sreg_srt_range_tag(rs, in.src[1].value, 8, srt_tag);
+                const ShaderResource* pk = has_srt_tag ? rt->by_srt_offset(srt_tag) : nullptr;
                 const ShaderResource* pp = rt->by_fetch_pc(in.pc);
                 fprintf(stderr, "[mimg-unresolved] pc=%u srsrc=s%d srt_tag=%s0x%x key_res=%s pc_res=%s (%zu res)\n",
-                        in.pc, in.src[1].value, it != rs.sreg_srt.end() ? "" : "NONE ",
-                        it != rs.sreg_srt.end() ? it->second : 0u,
+                        in.pc, in.src[1].value, has_srt_tag ? "" : "NONE ",
+                        has_srt_tag ? srt_tag : 0u,
                         pk ? (pk->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
                         pp ? (pp->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
                         rt->resources.size());

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -349,6 +349,14 @@ struct SpirvCompute {
         uint32_t vec = id(); putv(code, Op_ExtInst, {t_v2f(), vec, glsl, Glsl_UnpackHalf2x16, dword});
         uint32_t f = id(); put(code, Op_CompositeExtract, {t_f32, f, vec, which}); return bcu(f);
     }
+    // GFX10's packed 10/11-bit vertex-float fields use binary16's five-bit exponent and a shortened
+    // mantissa, without a sign bit. Widening the complete field left by 4 (11-bit) or 5 (10-bit)
+    // produces the exact low-half binary16 encoding, including subnormals, infinity, and NaN.
+    uint32_t unpack_ufloat(uint32_t dword, uint32_t bit_off, uint32_t bits) {
+        uint32_t raw = bfe_u(dword, uconst(bit_off), uconst(bits));
+        uint32_t half = ibin(Op_ShiftLeftLogical, raw, uconst(bits == 11 ? 4u : 5u));
+        return unpack_half(half, 0);
+    }
     // Inverse of unpack_norm: pack a float VGPR (bits) into a `bits`-wide UNORM/SNORM integer field:
     // clamp to [0,1] (unsigned) or [-1,1] (signed), scale by `norm`, round-to-nearest-even, mask to width.
     uint32_t pack_norm(uint32_t fbits, uint32_t bits, bool is_signed, float norm) {
@@ -3637,20 +3645,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // table — the unit-test harness). Keep the legacy single-cbuf convention: binding 2, stride 0.
             // The live graphics path can never reach here table-less: recompile_vertex/recompile_fragment
             // set allow_smem = (rt != nullptr), so MUBUF already rejected above when rt is null there.
+            const bool packed_10_11_11 = fmt == DataFormat::Float10_11_11;
+            const bool packed_2_10_10_10 =
+                fmt == DataFormat::Unorm2_10_10_10 || fmt == DataFormat::Snorm2_10_10_10 ||
+                fmt == DataFormat::Uint2_10_10_10  || fmt == DataFormat::Sint2_10_10_10;
+            const bool packed_word = packed_10_11_11 || packed_2_10_10_10;
             const uint32_t comp_bytes = data_format_bytes(fmt);
-            if (comp_bytes == 0) { ok = false; return true; }   // unknown / unsupported format
+            if (!packed_word && comp_bytes == 0) { ok = false; return true; } // unknown / unsupported
             // Per-component decode. 4-byte formats (Float32/Uint32/Sint32) are a raw dword load — no
             // conversion in our bit model. Sub-dword formats are unpacked: UNORM/SNORM normalize an
             // integer field, Float16 unpacks a packed half. num_components components pack tightly.
-            const bool packed = comp_bytes < 4;
-            bool is_snorm = (fmt == DataFormat::Snorm8 || fmt == DataFormat::Snorm16);
+            const bool packed = packed_word || comp_bytes < 4;
+            bool is_snorm = (fmt == DataFormat::Snorm8 || fmt == DataFormat::Snorm16 ||
+                             fmt == DataFormat::Snorm2_10_10_10);
             bool is_half  = (fmt == DataFormat::Float16);
             // Integer sub-dword formats deliver the raw (un-normalized) INTEGER in the VGPR — the
             // hardware's UINT/SINT format-load contract. DOLL's skinned scene VS fetches its bone
             // indices as Uint8 x4 (stride 8, paired with Unorm8 weights); rejecting them dropped
             // every scene-geometry draw (#273). Zero-/sign-extend the field; no normalization.
-            bool is_uint = (fmt == DataFormat::Uint8 || fmt == DataFormat::Uint16);
-            bool is_sint = (fmt == DataFormat::Sint8 || fmt == DataFormat::Sint16);
+            bool is_uint = (fmt == DataFormat::Uint8 || fmt == DataFormat::Uint16 ||
+                            fmt == DataFormat::Uint2_10_10_10);
+            bool is_sint = (fmt == DataFormat::Sint8 || fmt == DataFormat::Sint16 ||
+                            fmt == DataFormat::Sint2_10_10_10);
             float norm = 0.0f;
             switch (fmt) {
                 case DataFormat::Unorm8:  norm = 255.0f;   break;
@@ -3659,7 +3675,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case DataFormat::Snorm16: norm = 32767.0f; break;
                 default: break;
             }
-            if (packed && !is_half && !is_uint && !is_sint && norm == 0.0f) {
+            if (packed && !packed_word && !is_half && !is_uint && !is_sint && norm == 0.0f) {
                 if (getenv("PROSPER_DBG"))
                     fprintf(stderr, "[mubuf-badfmt] pc=%u fmt=%u comp_bytes=%u stride=%u n=%u\n",
                             in.pc, (unsigned)fmt, comp_bytes, stride, n);
@@ -3701,7 +3717,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // offset (offen). Loads only (the packed store path still rejects sub-dword ints).
                     bool soff_zero = (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
                                      (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
-                    dyn_half = !is_store && n == 1 && comp_bytes == 2 && !offen && !dyn_vfetch &&
+                    dyn_half = !packed_word && !is_store && n == 1 && comp_bytes == 2 && !offen && !dyn_vfetch &&
                                (offset & 1u) == 0 && (!idxen || (stride & 1u) == 0) && soff_zero;
                     if (!dyn_half) {
                         if (getenv("PROSPER_DBG"))
@@ -3740,7 +3756,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (is_store) {
                 // Store the VDATA VGPRs (in.dst..+n-1). Integer sub-dword formats (Uint8/Sint8/...) have
                 // no packing path here -> reject rather than mis-store (loads extend them; stores don't pack).
-                if (packed && (is_uint || is_sint)) { ok = false; return true; }
+                if (packed_word || (packed && (is_uint || is_sint))) { ok = false; return true; }
                 auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
                 if (!packed) {
                     // Raw/Float32/Uint32: one dword per component.
@@ -3771,7 +3787,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             // Integer-typed format? Its absent-component default for W/A is integer 1, not float 1.0.
             const bool fmt_is_int = (fmt == DataFormat::Uint8  || fmt == DataFormat::Uint16 || fmt == DataFormat::Uint32 ||
-                                     fmt == DataFormat::Sint8  || fmt == DataFormat::Sint16 || fmt == DataFormat::Sint32);
+                                     fmt == DataFormat::Sint8  || fmt == DataFormat::Sint16 || fmt == DataFormat::Sint32 ||
+                                     fmt == DataFormat::Uint2_10_10_10 || fmt == DataFormat::Sint2_10_10_10);
             for (uint32_t k = 0; k < n; k++) {
                 int d = in.dst.value + (int)k;
                 uint32_t old = vreg_old(b, rs, d);
@@ -3789,6 +3806,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 } else if (!packed) {
                     uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
                     value = b.cbuf_load(kidx, binding);                  // raw 32-bit component
+                } else if (packed_word) {
+                    // All requested components share one packed dword. GFX10 names layouts from high
+                    // field to low field, so 2_10_10_10 is logical R/G/B in bits 0/10/20 and A in 30;
+                    // 10_11_11 is R/G/B in bits 0/11/22 with widths 11/11/10.
+                    uint32_t dw = b.cbuf_load(idx, binding);
+                    uint32_t boff = packed_10_11_11 ? (k == 0 ? 0u : k == 1 ? 11u : 22u)
+                                                    : (k == 0 ? 0u : k == 1 ? 10u : k == 2 ? 20u : 30u);
+                    uint32_t bits = packed_10_11_11 ? (k < 2 ? 11u : 10u) : (k < 3 ? 10u : 2u);
+                    if (packed_10_11_11) {
+                        value = b.unpack_ufloat(dw, boff, bits);
+                    } else if (is_uint) {
+                        value = b.bfe_u(dw, b.uconst(boff), b.uconst(bits));
+                    } else if (is_sint) {
+                        value = b.bfe_s(dw, b.uconst(boff), b.uconst(bits));
+                    } else {
+                        float field_norm = is_snorm ? (bits == 2 ? 1.0f : 511.0f)
+                                                    : (bits == 2 ? 3.0f : 1023.0f);
+                        value = b.unpack_norm(dw, boff, bits, is_snorm, field_norm);
+                    }
                 } else if (dyn_half) {
                     // Runtime dword half (n==1, 16-bit element, 2-aligned address): shift the loaded
                     // dword right by (addr&2)*8 and decode the 16-bit field at bit 0.

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -43,6 +43,13 @@ enum class DataFormat : uint32_t {
     // "2_10_10_10_UNORM" (IMG_FMT 50); logical R/G/B occupy the low/middle 10-bit fields and
     // alpha occupies the high 2 bits. Sampled uploads unpack it to RGBA8.
     Unorm2_10_10_10,
+    // Vertex-fetch variants of the same packed 32-bit R10G10B10A2 layout. These stay distinct so
+    // buffer_load_format_* can apply the descriptor's signed/normalized conversion contract while
+    // texture uploads keep their existing Unorm2_10_10_10 path. Per-component byte size is 0 for
+    // every packed-word format; the fetch recompiler handles their bit fields explicitly.
+    Snorm2_10_10_10,
+    Uint2_10_10_10,
+    Sint2_10_10_10,
 };
 
 // How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -219,15 +219,19 @@ int main() {
               "packed V# with identity DST_SEL decodes normally");
         v[3] = (50u << 12) | 0x977u; // A/B/G/R permutation: SQ_SEL_W/Z/Y/X
         d = decode_buffer_descriptor(v);
-        CHECK(d.format == DataFormat::Unknown && d.num_components == 0,
+        CHECK(d.format == DataFormat::Unknown && d.num_components == 0 && d.forbid_unknown_fallback,
               "packed V# with a component permutation stays fail-closed");
         v[3] = (36u << 12);          // all four selectors synthesize constant zero
         d = decode_buffer_descriptor(v);
-        CHECK(d.format == DataFormat::Unknown && d.num_components == 0,
+        CHECK(d.format == DataFormat::Unknown && d.num_components == 0 && d.forbid_unknown_fallback,
               "packed V# with constant selectors stays fail-closed");
+        v[3] = (52u << 12) | 0xFACu;
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Unknown && d.num_components == 0 && d.forbid_unknown_fallback,
+              "packed 2_10_10_10 USCALED forbids the dynamic Float32 fallback");
         v[3] = (77u << 12) | 0x977u;
         d = decode_buffer_descriptor(v);
-        CHECK(d.format == DataFormat::Float32 && d.num_components == 4,
+        CHECK(d.format == DataFormat::Float32 && d.num_components == 4 && !d.forbid_unknown_fallback,
               "non-packed V# selector behavior is unchanged");
     }
     {   // RDNA2 combined-format decode coverage (the four game-observed anchors + a real V# regression).

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -4,6 +4,7 @@
 // base/stride/size/format and assigns provenance (srt_offset) + bindings — the contract the recompiler
 // and pipeline consume. Pure/headless; validates the decode against hand-built descriptors.
 #include "../src/gpu/agc_shader_layout.hpp"
+#include "../src/gpu/rdna2_to_spirv.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
@@ -15,13 +16,13 @@ static int fails = 0;
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
 // Build a 4-dword V# (buffer resource): Base48, 14-bit stride @[16:29] of word1, num_records=word2,
-// RDNA2 combined 7-bit FORMAT @[18:12] of word3 (GFX10/PS5 layout).
+// RDNA2 combined 7-bit FORMAT @[18:12] of word3 and identity DST_SEL X/Y/Z/W in [11:0].
 static void make_vsharp(uint32_t v[4], uint64_t base, uint32_t stride, uint32_t records,
                         uint32_t fmt) {
     v[0] = (uint32_t)(base & 0xffffffffu);
     v[1] = (uint32_t)((base >> 32) & 0xffffu) | ((stride & 0x3fffu) << 16);
     v[2] = records;
-    v[3] = (fmt & 0x7Fu) << 12;
+    v[3] = ((fmt & 0x7Fu) << 12) | 0xFACu;
 }
 
 // Build an 8-dword T# (Gen5 image resource): Base40 (stored >>8), 9-bit IMG_FMT @[28:20] of word1,
@@ -211,6 +212,23 @@ int main() {
         CHECK(d.num_records == 64, "V# num_records decoded");
         CHECK(d.size_bytes == 64 * 16, "V# size = records*stride");
         CHECK(d.format == DataFormat::Float32 && d.num_components == 4, "fmt77 -> Float32 x4");
+
+        make_vsharp(v, 0x123456780ull, 4, 64, /*fmt*/50);
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Unorm2_10_10_10 && d.num_components == 4,
+              "packed V# with identity DST_SEL decodes normally");
+        v[3] = (50u << 12) | 0x977u; // A/B/G/R permutation: SQ_SEL_W/Z/Y/X
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Unknown && d.num_components == 0,
+              "packed V# with a component permutation stays fail-closed");
+        v[3] = (36u << 12);          // all four selectors synthesize constant zero
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Unknown && d.num_components == 0,
+              "packed V# with constant selectors stays fail-closed");
+        v[3] = (77u << 12) | 0x977u;
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Float32 && d.num_components == 4,
+              "non-packed V# selector behavior is unchanged");
     }
     {   // RDNA2 combined-format decode coverage (the four game-observed anchors + a real V# regression).
         DataFormat f; uint32_t n;
@@ -232,7 +250,7 @@ int main() {
                                                "fmt52 2_10_10_10_USCALED stays fail-closed");
         rdna2_buffer_format(53, &f, &n); CHECK(f == DataFormat::Unknown && n == 0,
                                                "fmt53 2_10_10_10_SSCALED stays fail-closed");
-        // The game's real color V# dword3 == 0x38fac: FORMAT field [18:12] == 56 (dst_sel [11:0] ignored).
+        // The game's real color V# dword3 == 0x38fac: FORMAT [18:12] == 56 and identity DST_SEL == 0xFAC.
         uint32_t real_v3 = 0x38facu;
         rdna2_buffer_format((real_v3 >> 12) & 0x7Fu, &f, &n);
         CHECK(f == DataFormat::Unorm8 && n == 4, "real color V# 0x38fac -> Unorm8 x4");
@@ -385,6 +403,27 @@ int main() {
           "unknown-format user data just below the size cap is not guessed as a direct V#");
     CHECK(t3.by_sgpr_base(4) != nullptr, "constant buffers still present alongside vertex buffers");
     CHECK(t3.by_sgpr_base(99) == nullptr, "unknown sgpr_base -> null");
+
+    make_vsharp(&sgprs[20], 0xC0000000ull, 4, 90, /*fmt*/50);
+    sgprs[23] = (50u << 12) | 0x977u; // non-identity packed selector must be rejected before recompilation
+    ShaderResourceTable packed_permuted = build_shader_resources(shdr, sgprs, 32);
+    CHECK(packed_permuted.by_sgpr_base(20) == nullptr,
+          "direct packed V# permutation is omitted from the runtime resource table");
+    sgprs[23] = 50u << 12;             // constant-zero selectors are likewise unsupported
+    ShaderResourceTable packed_constant = build_shader_resources(shdr, sgprs, 32);
+    CHECK(packed_constant.by_sgpr_base(20) == nullptr,
+          "direct packed V# constants are omitted from the runtime resource table");
+    const uint32_t packed_fetch[] = {
+        0x7e000f00u, 0xe0002000u, 0x80050100u, 0xbf810000u, // format_x v1, v0, s[20:23], 0 idxen
+    };
+    CHECK(recompile_valu(packed_fetch, sizeof(packed_fetch) / 4, 1, 1, &packed_permuted).empty() &&
+          recompile_valu(packed_fetch, sizeof(packed_fetch) / 4, 1, 1, &packed_constant).empty(),
+          "non-identity packed descriptors cannot reach emitted SPIR-V");
+    make_vsharp(&sgprs[20], 0xC0000000ull, 4, 90, /*fmt*/50);
+    ShaderResourceTable packed_identity = build_shader_resources(shdr, sgprs, 32);
+    CHECK(packed_identity.by_sgpr_base(20) != nullptr &&
+          !recompile_valu(packed_fetch, sizeof(packed_fetch) / 4, 1, 1, &packed_identity).empty(),
+          "identity packed descriptor reaches the tested unpacking path");
 
     // --- Dead Cells compute direct resource: type 1 points at an inline V# in user SGPRs (#574). --
     {

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -217,6 +217,15 @@ int main() {
         d = decode_buffer_descriptor(v);
         CHECK(d.format == DataFormat::Unorm2_10_10_10 && d.num_components == 4,
               "packed V# with identity DST_SEL decodes normally");
+        v[3] = (36u << 12) | 0x3ACu; // R11G11B10_FLOAT canonical SQ_SEL_X/Y/Z/1
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Float10_11_11 && d.num_components == 3 &&
+              !d.forbid_unknown_fallback,
+              "packed float V# with canonical X/Y/Z/1 selector decodes normally");
+        v[3] = (36u << 12) | 0x977u;
+        d = decode_buffer_descriptor(v);
+        CHECK(d.format == DataFormat::Unknown && d.num_components == 0 && d.forbid_unknown_fallback,
+              "packed float V# with a component permutation stays fail-closed");
         v[3] = (50u << 12) | 0x977u; // A/B/G/R permutation: SQ_SEL_W/Z/Y/X
         d = decode_buffer_descriptor(v);
         CHECK(d.format == DataFormat::Unknown && d.num_components == 0 && d.forbid_unknown_fallback,

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -80,6 +80,8 @@ int main() {
         CHECK(!gen5_image_format(0, &fi) && fi.format == DataFormat::Unknown, "IMG_FMT 0 (INVALID) unmapped");
         CHECK(!gen5_image_format(9, &fi), "IMG_FMT 9 (16_USCALED) unmapped -> false");
         CHECK(!gen5_image_format(44, &fi), "IMG_FMT 44 (10_10_10_2) unmapped -> false");
+        CHECK(!gen5_image_format(51, &fi) && !gen5_image_format(54, &fi) && !gen5_image_format(55, &fi),
+              "packed SNORM/UINT/SINT buffer formats remain fail-closed for image upload");
         CHECK(!gen5_image_format(157, &fi), "IMG_FMT 157 (FMASK) unmapped -> false");
         CHECK(!gen5_image_format(511, &fi), "IMG_FMT 511 out-of-table -> false");
         CHECK(image_type_to_dim(8) == 0 && image_type_to_dim(9) == 1 &&
@@ -216,6 +218,20 @@ int main() {
         rdna2_buffer_format(64, &f, &n); CHECK(f == DataFormat::Float32 && n == 2, "fmt64 -> Float32 x2 (uvs)");
         rdna2_buffer_format(56, &f, &n); CHECK(f == DataFormat::Unorm8 && n == 4, "fmt56 -> Unorm8 x4 (colors)");
         rdna2_buffer_format(22, &f, &n); CHECK(f == DataFormat::Float32 && n == 1, "fmt22 -> Float32 x1");
+        rdna2_buffer_format(36, &f, &n); CHECK(f == DataFormat::Float10_11_11 && n == 3,
+                                               "fmt36 -> packed Float10_11_11 x3");
+        rdna2_buffer_format(50, &f, &n); CHECK(f == DataFormat::Unorm2_10_10_10 && n == 4,
+                                               "fmt50 -> packed Unorm2_10_10_10 x4");
+        rdna2_buffer_format(51, &f, &n); CHECK(f == DataFormat::Snorm2_10_10_10 && n == 4,
+                                               "fmt51 -> packed Snorm2_10_10_10 x4");
+        rdna2_buffer_format(54, &f, &n); CHECK(f == DataFormat::Uint2_10_10_10 && n == 4,
+                                               "fmt54 -> packed Uint2_10_10_10 x4");
+        rdna2_buffer_format(55, &f, &n); CHECK(f == DataFormat::Sint2_10_10_10 && n == 4,
+                                               "fmt55 -> packed Sint2_10_10_10 x4");
+        rdna2_buffer_format(52, &f, &n); CHECK(f == DataFormat::Unknown && n == 0,
+                                               "fmt52 2_10_10_10_USCALED stays fail-closed");
+        rdna2_buffer_format(53, &f, &n); CHECK(f == DataFormat::Unknown && n == 0,
+                                               "fmt53 2_10_10_10_SSCALED stays fail-closed");
         // The game's real color V# dword3 == 0x38fac: FORMAT field [18:12] == 56 (dst_sel [11:0] ignored).
         uint32_t real_v3 = 0x38facu;
         rdna2_buffer_format((real_v3 >> 12) & 0x7Fu, &f, &n);

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -196,6 +196,27 @@ int main() {
                          1, 1, &packed_entry_table).empty(),
           "structured joins preserve erased SRSRC write provenance from either arm");
 
+    // Vector instructions can also have explicit scalar-pair destinations. Both encodings overwrite
+    // s[20:21], so neither may leave the entry-time packed V# usable by the following format fetch.
+    // Round-tripped with llvm-mc gfx1030.
+    const uint32_t vopc_srsrc[] = {
+        0x7C0400F9u, 0x06069400u, // v_cmp_eq_f32_sdwa s20, v0, v0 (SDST pair)
+        0xE00C2000u, 0x80050100u,
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(vopc_srsrc, sizeof(vopc_srsrc)/sizeof(vopc_srsrc[0]),
+                         1, 1, &packed_entry_table).empty(),
+          "explicit VOPC SGPR-pair writes invalidate a direct packed V#");
+    const uint32_t vop3_carry_srsrc[] = {
+        0xD5761401u, 0x040A0100u, // v_mad_u64_u32 v[1:2], s20, v0, v0, v[2:3]
+        0xE00C2000u, 0x80050100u,
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(vop3_carry_srsrc,
+                         sizeof(vop3_carry_srsrc)/sizeof(vop3_carry_srsrc[0]),
+                         4, 1, &packed_entry_table).empty(),
+          "VOP3 carry-out SGPR-pair writes invalidate a direct packed V#");
+
     // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
     // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample
     // (SRSRC/SSAMP) and s_buffer_load (SBASE). Each use must be reported with the load immediate as

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -217,6 +217,58 @@ int main() {
                          4, 1, &packed_entry_table).empty(),
           "VOP3 carry-out SGPR-pair writes invalidate a direct packed V#");
 
+    // The same pair writes must invalidate an INDIRECT descriptor loaded from the SRT. The physical
+    // SGPR words no longer contain the s_load result, so retaining only its old sreg_srt tag would
+    // bind the pre-overwrite resource even though direct-entry fallback is already disabled.
+    ShaderResourceTable packed_srt_table;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer;
+      vb.format = DataFormat::Unorm2_10_10_10; vb.num_components = 4;
+      vb.binding = 3; vb.stride = 4; vb.srt_offset = 0x40;
+      packed_srt_table.resources.push_back(vb); }
+    const uint32_t vopc_srt_srsrc[] = {
+        0xF4080504u, 0xFA000040u, // s_load_dwordx4 s[20:23], s[8:9], 0x40
+        0x7C0400F9u, 0x06069400u, // v_cmp_eq_f32_sdwa s20, v0, v0
+        0xE00C2000u, 0x80050100u,
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(vopc_srt_srsrc, std::size(vopc_srt_srsrc),
+                         1, 1, &packed_srt_table).empty(),
+          "explicit VOPC SGPR-pair writes invalidate stale SRT descriptor provenance");
+    const uint32_t vop3_srt_srsrc[] = {
+        0xF4080504u, 0xFA000040u,
+        0xD5761401u, 0x040A0100u, // v_mad_u64_u32 carry-out -> s[20:21]
+        0xE00C2000u, 0x80050100u,
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(vop3_srt_srsrc, std::size(vop3_srt_srsrc),
+                         4, 1, &packed_srt_table).empty(),
+          "VOP3 carry-out SGPR-pair writes invalidate stale SRT descriptor provenance");
+
+    // A loop header is compiled once but executes again after every back-edge. If any reachable
+    // body instruction overwrites the header fetch's SRSRC, the entry-time direct V# is valid only
+    // for iteration one and cannot be baked into the generated header. Reject both supported loop
+    // structurizers until a loop-varying descriptor can be represented exactly.
+    const uint32_t counted_header_srsrc[] = {
+        0xBE800380u, 0xBE820382u,                         // s0=0, s2=2
+        0xE00C2000u, 0x80050100u,                         // loop: packed fetch via s[20:23]
+        0xBF0A0200u, 0xBF840003u,                         // s0<s2; exit when false
+        0xBE940380u, 0x80008100u, 0xBF82FFF9u,            // overwrite s20; ++s0; back-edge
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(counted_header_srsrc, std::size(counted_header_srsrc),
+                         1, 1, &packed_entry_table).empty(),
+          "counted-loop header cannot reuse a direct V# overwritten on its back-edge");
+    const uint32_t divergent_header_srsrc[] = {
+        0xBE800380u, 0xBE820382u, 0x7E0A0202u,            // s0=0, s2=2, uniform v5=s2
+        0xE00C2000u, 0x80050100u,                         // loop: packed fetch via s[20:23]
+        0x7D820A00u, 0xBF860003u,                         // uniform vcc=(s0<v5); vccz exit
+        0xBE940380u, 0x80008100u, 0xBF82FFF9u,            // overwrite s20; ++s0; back-edge
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(divergent_header_srsrc, std::size(divergent_header_srsrc),
+                         1, 1, &packed_entry_table).empty(),
+          "divergent-loop header cannot reuse a direct V# overwritten on its back-edge");
+
     // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
     // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample
     // (SRSRC/SSAMP) and s_buffer_load (SBASE). Each use must be reported with the load immediate as

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -10,6 +10,7 @@
 // tracked values, routing the s_bfe_u64 result into V#.dword3 (desc_v3). All encodings assembled /
 // round-trip verified with llvm-mc -mcpu=gfx1030.
 #include "../src/gpu/gpu_execute.hpp"
+#include "../src/gpu/rdna2_to_spirv.hpp"
 #include <cstdio>
 #include <vector>
 
@@ -136,6 +137,34 @@ int main() {
     CHECK(f4packed.size() == 1 && f4packed[0].desc.format == DataFormat::Unorm2_10_10_10 &&
           !f4packed[0].desc.forbid_unknown_fallback,
           "dynamic identity packed V# reaches the real unpack format instead of Float32");
+
+    // #370 review: entry metadata may legitimately publish an identity packed direct V# while the
+    // shader rewrites only dword 3 before the fetch. If that live selector is unsupported, dynamic
+    // resolution omits it. Recompilation must not then fall back to the stale entry-time identity V#.
+    ShaderResourceTable packed_entry_table;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer;
+      vb.format = DataFormat::Unorm2_10_10_10; vb.num_components = 4;
+      vb.binding = 3; vb.stride = 4; vb.sgpr_base = 20;
+      packed_entry_table.resources.push_back(vb); }
+    const uint32_t rejected_v3[] = {
+        (50u << 12) | 0x977u, // A/B/G/R permutation
+        50u << 12,            // constant-zero selectors
+        (52u << 12) | 0xFACu, // unsupported USCALED conversion
+    };
+    bool rejected_rewrites_stay_closed = true;
+    for (uint32_t v3 : rejected_v3) {
+        const uint32_t code[] = {
+            0xBE9703FFu, v3,           // s_mov_b32 s23, literal (rewrite V#.dword3 only)
+            0xE00C2000u, 0x80050100u, // buffer_load_format_xyzw v[1:4], v0, s[20:23], 0 idxen
+            0xBF810000u,
+        };
+        rejected_rewrites_stay_closed &=
+            resolve_dynamic_fetch(code, sizeof(code)/sizeof(code[0]), packed_identity, 4, 20).empty();
+        rejected_rewrites_stay_closed &=
+            recompile_valu(code, sizeof(code)/sizeof(code[0]), 1, 1, &packed_entry_table).empty();
+    }
+    CHECK(rejected_rewrites_stay_closed,
+          "rejected packed SRSRC rewrites cannot compile through the stale direct identity V#");
 
     // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
     // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -166,6 +166,36 @@ int main() {
     CHECK(rejected_rewrites_stay_closed,
           "rejected packed SRSRC rewrites cannot compile through the stale direct identity V#");
 
+    // A shader write remains provenance even when its value cannot be represented. This B64 move
+    // reads an untracked pair, so the scalar SSA entries for s[20:21] are erased. The later fetch must
+    // still reject instead of resurrecting the entry-time direct V# merely because the map is empty.
+    // Encoding round-tripped with llvm-mc gfx1030: s_mov_b64 s[20:21], s[50:51].
+    const uint32_t erased_srsrc[] = {
+        0xBE940432u,
+        0xE00C2000u, 0x80050100u, // buffer_load_format_xyzw v[1:4], v0, s[20:23], 0 idxen
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(erased_srsrc, sizeof(erased_srsrc)/sizeof(erased_srsrc[0]),
+                         1, 1, &packed_entry_table).empty(),
+          "unrepresentable SRSRC writes cannot resurrect an entry-time direct V#");
+
+    // The same invalidation is a MAY-write property at structured joins: the untouched else edge
+    // cannot make entry metadata safe on the then edge that erased s[20:21]. Branch offsets and all
+    // instruction encodings were round-tripped with llvm-mc gfx1030.
+    const uint32_t branch_erased_srsrc[] = {
+        0xBF060000u,             // s_cmp_eq_u32 s0, s0
+        0xBF840002u,             // s_cbranch_scc0 else
+        0xBE940432u,             // then: s_mov_b64 s[20:21], s[50:51]
+        0xBF820001u,             // s_branch merge
+        0xBE840380u,             // else: s_mov_b32 s4, 0
+        0xE00C2000u, 0x80050100u,
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(branch_erased_srsrc,
+                         sizeof(branch_erased_srsrc)/sizeof(branch_erased_srsrc[0]),
+                         1, 1, &packed_entry_table).empty(),
+          "structured joins preserve erased SRSRC write provenance from either arm");
+
     // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
     // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample
     // (SRSRC/SSAMP) and s_buffer_load (SBASE). Each use must be reported with the load immediate as

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -243,6 +243,15 @@ int main() {
     CHECK(recompile_valu(vop3_srt_srsrc, std::size(vop3_srt_srsrc),
                          4, 1, &packed_srt_table).empty(),
           "VOP3 carry-out SGPR-pair writes invalidate stale SRT descriptor provenance");
+    const uint32_t vopc_srt_high_srsrc[] = {
+        0xF4080504u, 0xFA000040u,
+        0x7C0400F9u, 0x06069600u, // v_cmp_eq_f32_sdwa s22, v0, v0
+        0xE00C2000u, 0x80050100u,
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(vopc_srt_high_srsrc, std::size(vopc_srt_high_srsrc),
+                         1, 1, &packed_srt_table).empty(),
+          "an upper-half SRSRC write invalidates the complete SRT descriptor tag");
 
     // A loop header is compiled once but executes again after every back-edge. If any reachable
     // body instruction overwrites the header fetch's SRSRC, the entry-time direct V# is valid only
@@ -268,6 +277,18 @@ int main() {
     CHECK(recompile_valu(divergent_header_srsrc, std::size(divergent_header_srsrc),
                          1, 1, &packed_entry_table).empty(),
           "divergent-loop header cannot reuse a direct V# overwritten on its back-edge");
+    const uint32_t counted_header_srt_high_srsrc[] = {
+        0xF4080504u, 0xFA000040u,                         // SRT V# -> s[20:23]
+        0xBE800380u, 0xBE820382u,                         // s0=0, s2=2
+        0xE00C2000u, 0x80050100u,                         // loop: packed fetch via s[20:23]
+        0xBF0A0200u, 0xBF840003u,                         // s0<s2; exit when false
+        0xBE960380u, 0x80008100u, 0xBF82FFF9u,            // overwrite s22; ++s0; back-edge
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(counted_header_srt_high_srsrc,
+                         std::size(counted_header_srt_high_srsrc),
+                         1, 1, &packed_srt_table).empty(),
+          "loop upper-word writes invalidate the complete SRT descriptor tag at the header");
 
     // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
     // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -105,6 +105,38 @@ int main() {
     std::vector<DynFetch> f4b = resolve_dynamic_fetch(k4b, sizeof(k4b)/sizeof(k4b[0]), seed4, 4, 8);
     CHECK(f4b.empty(), "kernel 4b reloaded SGPR blocks the seed fallback (no fabricated V#)");
 
+    // #370 review: a fully-known dynamic packed V# used to decode its unsupported DST_SEL as Unknown,
+    // then build_stage_table's legacy Unknown->Float32 fallback resurrected it as four raw dwords.
+    // resolve_dynamic_fetch must omit deliberate packed rejections while retaining identity descriptors.
+    const uint32_t k4packed[] = {
+        0xE00C2000u, 0x80020100u,   // buffer_load_format_xyzw v[1:4], v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    const uint32_t packed_permuted[4] = {
+        0x00020000u, 0x00040000u, 64u, (50u << 12) | 0x977u, // A/B/G/R
+    };
+    const uint32_t packed_constant[4] = {
+        0x00020000u, 0x00040000u, 64u, 50u << 12,           // constant-zero selectors
+    };
+    const uint32_t packed_scaled[4] = {
+        0x00020000u, 0x00040000u, 64u, (52u << 12) | 0xFACu, // unsupported USCALED
+    };
+    CHECK(resolve_dynamic_fetch(k4packed, sizeof(k4packed)/sizeof(k4packed[0]),
+                                packed_permuted, 4, 8).empty() &&
+          resolve_dynamic_fetch(k4packed, sizeof(k4packed)/sizeof(k4packed[0]),
+                                packed_constant, 4, 8).empty() &&
+          resolve_dynamic_fetch(k4packed, sizeof(k4packed)/sizeof(k4packed[0]),
+                                packed_scaled, 4, 8).empty(),
+          "dynamic packed permutations/constants/scaled formats cannot reach the Float32 fallback");
+    const uint32_t packed_identity[4] = {
+        0x00020000u, 0x00040000u, 64u, (50u << 12) | 0xFACu,
+    };
+    std::vector<DynFetch> f4packed = resolve_dynamic_fetch(
+        k4packed, sizeof(k4packed)/sizeof(k4packed[0]), packed_identity, 4, 8);
+    CHECK(f4packed.size() == 1 && f4packed[0].desc.format == DataFormat::Unorm2_10_10_10 &&
+          !f4packed[0].desc.forbid_unknown_fallback,
+          "dynamic identity packed V# reaches the real unpack format instead of Float32");
+
     // Kernel 5: descriptor-TABLE uses (#294). s[8:9] = a pointer to a host-memory table; the shader
     // s_loads an 8-dword T# (imm 0x40) + a 4-dword S#/V# (imm 0x80), consumes them via image_sample
     // (SRSRC/SSAMP) and s_buffer_load (SBASE). Each use must be reported with the load immediate as

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -54,7 +54,7 @@ int main() {
 
     auto table = std::make_shared<ShaderResourceTable>();
     ShaderResource a{}; a.cls = ResourceClass::VertexBuffer; a.binding = 9; a.gpu_addr = 0x1000;
-    a.size = 16; a.stride = 4; a.format = DataFormat::Unorm2_10_10_10; a.num_components = 4; a.fetch_pc = 12;
+    a.size = 16; a.stride = 4; a.format = DataFormat::Sint2_10_10_10; a.num_components = 4; a.fetch_pc = 12;
     ShaderResource b{}; b.cls = ResourceClass::ConstantBuffer; b.binding = 2; b.gpu_addr = 0x1008;
     b.size = 16; b.format = DataFormat::Float32; b.num_components = 4; b.srt_offset = 0x20;
     ShaderResource dcc{}; dcc.cls = ResourceClass::Texture; dcc.binding = 4; dcc.gpu_addr = 0x1000;
@@ -281,8 +281,8 @@ int main() {
           loaded.draws[0].ps.has_clear_color1 && loaded.draws[0].ps.clear_color1[0] == 0.25f &&
           loaded.draws[0].ps.blend1_enable && loaded.draws[0].ps.color1_write_mask == 0xf,
           "MRT1 target and fixed-function state round-trip through the v10 extension");
-    CHECK(loaded.draws[0].vrt.resources[0].resource.format == DataFormat::Unorm2_10_10_10,
-          "newest packed image format enum round-trips");
+    CHECK(loaded.draws[0].vrt.resources[0].resource.format == DataFormat::Sint2_10_10_10,
+          "newest packed vertex format enum round-trips");
     CHECK(loaded.draws[0].vrt.resources[0].resource.depth == 7,
           "v9 resource depth round-trips");
     const auto& loaded_dcc = loaded.draws[0].vrt.resources[2].resource;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -776,6 +776,110 @@ int main() {
     printf("  kernel25 mismatches=%u (out[40]=%g expect=%g)\n", bad25, got25.size()==N?got25[40]:-1, got25.size()==N?exp25[40]:-1);
     CHECK(got25.size()==N && bad25==0, "recompiled kernel 25 (snorm16x2 -> normalized + clamped floats) correct");
 
+    // #370: packed-word vertex formats. All four logical components occupy one dword, so the ordinary
+    // uniform-byte-component path cannot represent them. Exercise the actual translated SPIR-V on Vulkan
+    // with distinct weighted components: this catches field order/width, sign extension, normalization,
+    // the two-bit alpha rule, and the R11G11B10 unsigned-small-float widening.
+    const uint32_t code25packed_float[] = {
+        0x7e000f00u, 0xe00c2000u, 0x80020100u, // index + buffer_load_format_xyzw v[1:4]
+        0x7e0a02f4u, 0x100c0505u, 0x06020d01u,
+        0x7e0a02f6u, 0x100c0905u, 0x06020d01u,
+        0x7e0a02ffu, 0x40400000u, 0x100c0705u, 0x06020d01u, 0xbf810000u,
+    };
+    const uint32_t code25packed_uint[] = {
+        0x7e000f00u, 0xe00c2000u, 0x80020100u,
+        0x7e020d01u, 0x7e040d02u, 0x7e060d03u, 0x7e080d04u, // uint fields -> float
+        0x7e0a02f4u, 0x100c0505u, 0x06020d01u,
+        0x7e0a02f6u, 0x100c0905u, 0x06020d01u,
+        0x7e0a02ffu, 0x40400000u, 0x100c0705u, 0x06020d01u, 0xbf810000u,
+    };
+    const uint32_t code25packed_sint[] = {
+        0x7e000f00u, 0xe00c2000u, 0x80020100u,
+        0x7e020b01u, 0x7e040b02u, 0x7e060b03u, 0x7e080b04u, // signed fields -> float
+        0x7e0a02f4u, 0x100c0505u, 0x06020d01u,
+        0x7e0a02f6u, 0x100c0905u, 0x06020d01u,
+        0x7e0a02ffu, 0x40400000u, 0x100c0705u, 0x06020d01u, 0xbf810000u,
+    };
+    auto check_packed_fetch = [&](const uint32_t* code, size_t code_dwords, DataFormat format,
+                                  const std::vector<uint32_t>& words,
+                                  const std::vector<float>& expected, const char* message) {
+        ShaderResourceTable table;
+        ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = format;
+        vb.num_components = format == DataFormat::Float10_11_11 ? 3 : 4;
+        vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8; table.resources.push_back(vb);
+        std::vector<uint32_t> spv = recompile_valu(code, code_dwords, 1, 1, &table);
+        std::vector<float> input(N); for (uint32_t i = 0; i < N; ++i) input[i] = (float)i;
+        std::vector<float> got = prosper::test::run_compute(spv, input, N, N, {}, words);
+        uint32_t bad = 0;
+        for (uint32_t i = 0; i < N && got.size() == N; ++i)
+            if (std::fabs(got[i] - expected[i]) > 3e-3f) ++bad;
+        CHECK(!spv.empty() && got.size() == N && bad == 0, message);
+    };
+    auto pack_2_10_10_10 = [](int32_t r, int32_t g, int32_t b, int32_t a) {
+        return ((uint32_t)r & 0x3ffu) | (((uint32_t)g & 0x3ffu) << 10) |
+               (((uint32_t)b & 0x3ffu) << 20) | (((uint32_t)a & 0x3u) << 30);
+    };
+    std::vector<uint32_t> packed_words(N);
+    std::vector<float> packed_expected(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        uint32_t r = i * 17u & 1023u, g = i * 29u + 3u & 1023u;
+        uint32_t b = i * 43u + 7u & 1023u, a = i & 3u;
+        packed_words[i] = pack_2_10_10_10(r, g, b, a);
+        packed_expected[i] = r / 1023.0f + 2.0f * g / 1023.0f +
+                             3.0f * b / 1023.0f + 4.0f * a / 3.0f;
+    }
+    check_packed_fetch(code25packed_float, sizeof(code25packed_float) / 4,
+                       DataFormat::Unorm2_10_10_10, packed_words, packed_expected,
+                       "packed 2_10_10_10 UNORM fetch decodes four normalized fields");
+
+    auto snorm = [](int32_t v, float scale) { return std::fmax((float)v / scale, -1.0f); };
+    for (uint32_t i = 0; i < N; ++i) {
+        int32_t r = (int32_t)(i * 17u & 1023u) - 512;
+        int32_t g = (int32_t)(i * 29u + 3u & 1023u) - 512;
+        int32_t b = (int32_t)(i * 43u + 7u & 1023u) - 512;
+        int32_t a = (int32_t)(i & 3u) - 2;
+        packed_words[i] = pack_2_10_10_10(r, g, b, a);
+        packed_expected[i] = snorm(r, 511.0f) + 2.0f * snorm(g, 511.0f) +
+                             3.0f * snorm(b, 511.0f) + 4.0f * snorm(a, 1.0f);
+    }
+    check_packed_fetch(code25packed_float, sizeof(code25packed_float) / 4,
+                       DataFormat::Snorm2_10_10_10, packed_words, packed_expected,
+                       "packed 2_10_10_10 SNORM fetch sign-extends and clamps every field");
+
+    for (uint32_t i = 0; i < N; ++i) {
+        uint32_t r = i * 17u & 1023u, g = i * 29u + 3u & 1023u;
+        uint32_t b = i * 43u + 7u & 1023u, a = i & 3u;
+        packed_words[i] = pack_2_10_10_10(r, g, b, a);
+        packed_expected[i] = (float)r + 2.0f * (float)g + 3.0f * (float)b + 4.0f * (float)a;
+    }
+    check_packed_fetch(code25packed_uint, sizeof(code25packed_uint) / 4,
+                       DataFormat::Uint2_10_10_10, packed_words, packed_expected,
+                       "packed 2_10_10_10 UINT fetch zero-extends four integer fields");
+
+    for (uint32_t i = 0; i < N; ++i) {
+        int32_t r = (int32_t)(i * 17u & 1023u) - 512;
+        int32_t g = (int32_t)(i * 29u + 3u & 1023u) - 512;
+        int32_t b = (int32_t)(i * 43u + 7u & 1023u) - 512;
+        int32_t a = (int32_t)(i & 3u) - 2;
+        packed_words[i] = pack_2_10_10_10(r, g, b, a);
+        packed_expected[i] = (float)r + 2.0f * (float)g + 3.0f * (float)b + 4.0f * (float)a;
+    }
+    check_packed_fetch(code25packed_sint, sizeof(code25packed_sint) / 4,
+                       DataFormat::Sint2_10_10_10, packed_words, packed_expected,
+                       "packed 2_10_10_10 SINT fetch sign-extends four integer fields");
+
+    for (uint32_t i = 0; i < N; ++i) {
+        uint32_t r = (15u << 6) | (i & 63u);       // 11-bit unsigned float, [1,2)
+        uint32_t g = (14u << 6) | (i * 3u & 63u);  // 11-bit unsigned float, [0.5,1)
+        uint32_t b = (16u << 5) | (i * 5u & 31u);  // 10-bit unsigned float, [2,4)
+        packed_words[i] = r | (g << 11) | (b << 22);
+        packed_expected[i] = f11_to_float((uint16_t)r) + 2.0f * f11_to_float((uint16_t)g) +
+                             3.0f * f10_to_float((uint16_t)b) + 4.0f; // absent W defaults to 1.0
+    }
+    check_packed_fetch(code25packed_float, sizeof(code25packed_float) / 4,
+                       DataFormat::Float10_11_11, packed_words, packed_expected,
+                       "packed 10_11_11 FLOAT fetch widens mini-floats and default-fills W");
+
     // Kernel 26: s_buffer_load_dwordx8 (wide scalar load). s[0:7] = cbuf[4..11] (offset 0x10>>2=4);
     // out = (float)s7 = cbuf[11]. Real shaders load whole constant blocks in one x8/x16 op; this proves
     // the wide loads emit all N dwords, not just x1/x2/x4.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -10,6 +10,7 @@
 //   s_endpgm
 // => out = ((a0+a1)*a2)*a3 + a1
 #include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/agc_shader_layout.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include "compute_runner.h"
 #include <cstdio>
@@ -879,6 +880,31 @@ int main() {
     check_packed_fetch(code25packed_float, sizeof(code25packed_float) / 4,
                        DataFormat::Float10_11_11, packed_words, packed_expected,
                        "packed 10_11_11 FLOAT fetch widens mini-floats and default-fills W");
+
+    // #370 review: exercise the canonical descriptor contract, not just an injected DataFormat.
+    // R11G11B10_FLOAT uses DST_SEL(X,Y,Z,1) = 0x3AC; the resulting W must be exactly 1.0.
+    const uint32_t packed_float_vsharp[4] = {
+        0x00020000u, 4u << 16, N, (36u << 12) | 0x3ACu,
+    };
+    const DecodedBufferDescriptor packed_float_desc = decode_buffer_descriptor(packed_float_vsharp);
+    ShaderResourceTable packed_float_table;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer;
+      vb.format = packed_float_desc.format; vb.num_components = packed_float_desc.num_components;
+      vb.binding = 3; vb.stride = packed_float_desc.stride; vb.sgpr_base = 8;
+      packed_float_table.resources.push_back(vb); }
+    std::vector<uint32_t> packed_float_spv = recompile_valu(
+        code25packed_float, sizeof(code25packed_float) / 4, 1, 1, &packed_float_table);
+    std::vector<float> packed_float_input(N);
+    for (uint32_t i = 0; i < N; ++i) packed_float_input[i] = (float)i;
+    std::vector<float> packed_float_got = prosper::test::run_compute(
+        packed_float_spv, packed_float_input, N, N, {}, packed_words);
+    uint32_t packed_float_bad = 0;
+    for (uint32_t i = 0; i < N && packed_float_got.size() == N; ++i)
+        if (std::fabs(packed_float_got[i] - packed_expected[i]) > 3e-3f) ++packed_float_bad;
+    CHECK(packed_float_desc.format == DataFormat::Float10_11_11 &&
+          packed_float_desc.num_components == 3 && !packed_float_desc.forbid_unknown_fallback &&
+          !packed_float_spv.empty() && packed_float_got.size() == N && packed_float_bad == 0,
+          "canonical format-36 X/Y/Z/1 descriptor executes R/G/B widening with W=1");
 
     // Kernel 26: s_buffer_load_dwordx8 (wide scalar load). s[0:7] = cbuf[4..11] (offset 0x10>>2=4);
     // out = (float)s7 = cbuf[11]. Real shaders load whole constant blocks in one x8/x16 op; this proves

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -82,6 +82,21 @@ int main() {
                           sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]), 0, 0,
                           &dispatch_rt).empty(),
           "a nested varying-VCC compute CFG preserves spilled EXEC and lowers through the dispatcher");
+    // The dispatcher includes branch-target/fallthrough blocks even when no entry path can reach
+    // them. This dead block overwrites half of direct V# s[8:11] and then targets the live entry;
+    // provenance at the reachable fetch must not include a write hardware can never execute.
+    std::vector<uint32_t> compute_cfg_dispatch_dead_descriptor = {
+        0xBF820002u, // entry: s_branch live (skip the next two instructions)
+        0xBE880432u, // dead: s_mov_b64 s[8:9], s[50:51]
+        0xBF820000u, // dead: s_branch live
+    };
+    compute_cfg_dispatch_dead_descriptor.insert(
+        compute_cfg_dispatch_dead_descriptor.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]));
+    CHECK(!recompile_valu(compute_cfg_dispatch_dead_descriptor.data(),
+                          compute_cfg_dispatch_dead_descriptor.size(), 0, 0,
+                          &dispatch_rt).empty(),
+          "unreachable dispatcher writes cannot invalidate a live direct descriptor");
     // UE4 also recycles a physical v_writelane slot: first as ordinary scalar data, then as an
     // EXEC-mask spill. Force a dispatcher block boundary after each lifetime so both typed views
     // must survive the Function-variable state round trip. Consumers remain statically typed.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -97,6 +97,16 @@ int main() {
                           compute_cfg_dispatch_dead_descriptor.size(), 0, 0,
                           &dispatch_rt).empty(),
           "unreachable dispatcher writes cannot invalidate a live direct descriptor");
+    std::vector<uint32_t> compute_cfg_dispatch_live_vopc_write = {
+        0x7C0400F9u, 0x06068800u, // v_cmp_eq_f32_sdwa s8, v0, v0 (writes s[8:9])
+    };
+    compute_cfg_dispatch_live_vopc_write.insert(
+        compute_cfg_dispatch_live_vopc_write.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]));
+    CHECK(recompile_valu(compute_cfg_dispatch_live_vopc_write.data(),
+                         compute_cfg_dispatch_live_vopc_write.size(), 0, 0,
+                         &dispatch_rt).empty(),
+          "reachable dispatcher VOPC pair writes invalidate a direct descriptor");
     // UE4 also recycles a physical v_writelane slot: first as ordinary scalar data, then as an
     // EXEC-mask spill. Force a dispatcher block boundary after each lifetime so both typed views
     // must survive the Function-variable state round trip. Consumers remain statically typed.

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -148,6 +148,10 @@ int main() {
           "Float10_11_11 is packed: per-component bytes = 0 (texel size lives in bytes_per_block)");
     CHECK(data_format_bytes(DataFormat::Unorm2_10_10_10) == 0,
           "Unorm2_10_10_10 is packed: per-component bytes = 0");
+    CHECK(data_format_bytes(DataFormat::Snorm2_10_10_10) == 0 &&
+          data_format_bytes(DataFormat::Uint2_10_10_10) == 0 &&
+          data_format_bytes(DataFormat::Sint2_10_10_10) == 0,
+          "packed 2_10_10_10 vertex variants have no uniform per-component byte size");
 
     uint8_t rgba10[4] = {};
     unorm2_10_10_10_to_rgba8(0xFFFFFFFFu, rgba10);

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -3,6 +3,11 @@
 Developer/agent tooling. These are debugging and verification aids, not part of
 the shipped runtime. Build them from `build-linux/` like everything else.
 
+- **`verify-pr.ps1`** - author-owned PR verification orchestrator for the Windows+WSL development
+  environment. Run it only from a clean, pushed PR head: `docs` records the diff check, `core` adds
+  Linux and Windows build+ctest, and `renderer -Snapshot NAME` also runs the selected real-game guard.
+  `-Pr N` posts the generated SHA-bound `AUTHOR VERIFICATION` record. Reviewers inspect its coverage
+  but do not rerun it; see the mandatory merge policy in the root `CLAUDE.md`.
 - **`snapshot/`** - routed, multi-frame **rendering regression guard**. Run
   `python3 tools/snapshot/snapshot.py check` after any change that can affect
   rendered output (recompiler, AGC decode, render state, detile, present). It

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -7,7 +7,9 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   environment. Run it only from a clean, pushed PR head: `docs` records the diff check, `core` adds
   Linux and Windows build+ctest, and `renderer -Snapshot NAME` also runs the selected real-game guard.
   `-Pr N` posts the generated SHA-bound `AUTHOR VERIFICATION` record. Reviewers inspect its coverage
-  but do not rerun it; see the mandatory merge policy in the root `CLAUDE.md`.
+  but do not rerun it; see the mandatory merge policy in the root `CLAUDE.md`. Run
+  `powershell -File tools/test-verify-pr.ps1` after changing the orchestrator; it probes exact-base
+  pinning, WSL selection, rejected skip attempts, and untracked-source contamination.
 - **`snapshot/`** - routed, multi-frame **rendering regression guard**. Run
   `python3 tools/snapshot/snapshot.py check` after any change that can affect
   rendered output (recompiler, AGC decode, render state, detile, present). It

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -5,7 +5,8 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 
 - **`verify-pr.ps1`** - author-owned PR verification orchestrator for the Windows+WSL development
   environment. Run it only from a clean, pushed PR head: `docs` records the diff check, `core` adds
-  Linux and Windows build+ctest, and `renderer -Snapshot NAME` also runs the selected real-game guard.
+  Linux and Windows build+ctest, and `renderer -Snapshot NAME` also runs the selected real-game guard
+  with `boot_trace` and `screenshot` pinned to that run's selected Linux build directory.
   `-Pr N` posts the generated SHA-bound `AUTHOR VERIFICATION` record. Reviewers inspect its coverage
   but do not rerun it; see the mandatory merge policy in the root `CLAUDE.md`. Run
   `powershell -File tools/test-verify-pr.ps1` after changing the orchestrator; it probes exact-base

--- a/prosper/tools/test-verify-pr.ps1
+++ b/prosper/tools/test-verify-pr.ps1
@@ -45,7 +45,26 @@ Assert-True ($Errors.Count -eq 0) 'verifier parses without PowerShell syntax err
 
 $HeadSha = (& git -C $Repo rev-parse HEAD).Trim()
 $BaseSha = (& git -C $Repo rev-parse origin/master).Trim()
-$DryRun = Invoke-Verifier @('renderer', '-Snapshot', 'messenger-scene', '-DryRun')
+$ProvenanceBuildRelative = 'prosper/build-linux/verify-pr-provenance'
+$ProvenanceBuild = Join-Path $Repo 'prosper\build-linux\verify-pr-provenance'
+$PreviousBootTrace = $env:PROSPER_BOOT_TRACE
+$PreviousScreenshot = $env:PROSPER_SCREENSHOT
+try {
+    New-Item -ItemType Directory -Path $ProvenanceBuild -Force | Out-Null
+    $env:PROSPER_BOOT_TRACE = '/tmp/hostile-boot-trace'
+    $env:PROSPER_SCREENSHOT = '/tmp/hostile-screenshot'
+    $DryRun = Invoke-Verifier @(
+        'renderer', '-Snapshot', 'messenger-scene',
+        '-LinuxBuild', $ProvenanceBuildRelative, '-DryRun'
+    )
+}
+finally {
+    if ($null -eq $PreviousBootTrace) { Remove-Item Env:PROSPER_BOOT_TRACE -ErrorAction SilentlyContinue }
+    else { $env:PROSPER_BOOT_TRACE = $PreviousBootTrace }
+    if ($null -eq $PreviousScreenshot) { Remove-Item Env:PROSPER_SCREENSHOT -ErrorAction SilentlyContinue }
+    else { $env:PROSPER_SCREENSHOT = $PreviousScreenshot }
+    Remove-Item -LiteralPath $ProvenanceBuild -Recurse -Force -ErrorAction SilentlyContinue
+}
 Assert-True ($DryRun.ExitCode -eq 0) 'renderer dry run succeeds on a clean pushed head'
 Assert-True ($DryRun.Output.Contains("git diff --check $BaseSha...$HeadSha")) `
     'diff check uses captured immutable base and head objects'
@@ -55,6 +74,11 @@ Assert-True ($DryRun.Output.Contains('Windows build') -and
     $DryRun.Output.Contains('Windows ctest') -and
     $DryRun.Output.Contains('snapshot guard: messenger-scene')) `
     'renderer profile includes both platform checks and the selected snapshot'
+Assert-True ($DryRun.Output.Contains('/prosper/build-linux/verify-pr-provenance/boot_trace') -and
+    $DryRun.Output.Contains('/prosper/build-linux/verify-pr-provenance/screenshot') -and
+    -not $DryRun.Output.Contains('/tmp/hostile-boot-trace') -and
+    -not $DryRun.Output.Contains('/tmp/hostile-screenshot')) `
+    'snapshot executables are pinned to the selected Linux build instead of inherited overrides'
 
 $SkipAttempt = Invoke-Verifier @('core', '-SkipLinux', '-SkipWindows', '-DryRun')
 Assert-True ($SkipAttempt.ExitCode -ne 0 -and

--- a/prosper/tools/test-verify-pr.ps1
+++ b/prosper/tools/test-verify-pr.ps1
@@ -18,10 +18,18 @@ function Assert-True {
 function Invoke-Verifier {
     param([string[]] $Arguments)
 
-    $Output = @(& powershell -NoProfile -ExecutionPolicy Bypass -File $Verifier @Arguments 2>&1 |
-        ForEach-Object { $_.ToString() })
+    $PreviousErrorAction = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $Output = @(& powershell -NoProfile -ExecutionPolicy Bypass -File $Verifier @Arguments 2>&1 |
+            ForEach-Object { $_.ToString() })
+        $ExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $PreviousErrorAction
+    }
     return [pscustomobject]@{
-        ExitCode = $LASTEXITCODE
+        ExitCode = $ExitCode
         Output = $Output -join [Environment]::NewLine
     }
 }

--- a/prosper/tools/test-verify-pr.ps1
+++ b/prosper/tools/test-verify-pr.ps1
@@ -1,0 +1,92 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$Repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$Verifier = Join-Path $PSScriptRoot 'verify-pr.ps1'
+$Passed = 0
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) {
+        throw $Message
+    }
+    $script:Passed++
+    Write-Host "PASS: $Message"
+}
+
+function Invoke-Verifier {
+    param([string[]] $Arguments)
+
+    $Output = @(& powershell -NoProfile -ExecutionPolicy Bypass -File $Verifier @Arguments 2>&1 |
+        ForEach-Object { $_.ToString() })
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output = $Output -join [Environment]::NewLine
+    }
+}
+
+$Tokens = $null
+$Errors = $null
+[System.Management.Automation.Language.Parser]::ParseFile(
+    $Verifier,
+    [ref]$Tokens,
+    [ref]$Errors
+) | Out-Null
+Assert-True ($Errors.Count -eq 0) 'verifier parses without PowerShell syntax errors'
+
+$HeadSha = (& git -C $Repo rev-parse HEAD).Trim()
+$BaseSha = (& git -C $Repo rev-parse origin/master).Trim()
+$DryRun = Invoke-Verifier @('renderer', '-Snapshot', 'messenger-scene', '-DryRun')
+Assert-True ($DryRun.ExitCode -eq 0) 'renderer dry run succeeds on a clean pushed head'
+Assert-True ($DryRun.Output.Contains("git diff --check $BaseSha...$HeadSha")) `
+    'diff check uses captured immutable base and head objects'
+Assert-True ($DryRun.Output.Contains('wsl.exe -d Ubuntu-24.04 -u root -- bash -lc')) `
+    'Linux build, test, and snapshot commands pin Ubuntu-24.04 as root'
+Assert-True ($DryRun.Output.Contains('Windows build') -and
+    $DryRun.Output.Contains('Windows ctest') -and
+    $DryRun.Output.Contains('snapshot guard: messenger-scene')) `
+    'renderer profile includes both platform checks and the selected snapshot'
+
+$SkipAttempt = Invoke-Verifier @('core', '-SkipLinux', '-SkipWindows', '-DryRun')
+Assert-True ($SkipAttempt.ExitCode -ne 0 -and
+    $SkipAttempt.Output.Contains('parameter cannot be found')) `
+    'removed skip switches cannot produce an incomplete PASS'
+
+$UntrackedProbe = Join-Path $Repo 'prosper\src\verify_pr_untracked_probe.cpp'
+try {
+    [IO.File]::WriteAllText($UntrackedProbe, '// verifier cleanliness probe')
+    $DirtyRun = Invoke-Verifier @('docs', '-DryRun')
+    Assert-True ($DirtyRun.ExitCode -ne 0 -and
+        $DirtyRun.Output.Contains('commit or remove all nonignored changes')) `
+        'nonignored untracked source is rejected before verification'
+}
+finally {
+    Remove-Item -LiteralPath $UntrackedProbe -Force -ErrorAction SilentlyContinue
+}
+
+$ProbeRef = "refs/codex/verify-pr-base-$PID"
+$MoveJob = $null
+try {
+    & git -C $Repo update-ref $ProbeRef $BaseSha
+    if ($LASTEXITCODE -ne 0) { throw 'failed to create verifier base probe ref' }
+    $MoveJob = Start-Job -ScriptBlock {
+        param($WorkingTree, $RefName, $NewValue)
+        Start-Sleep -Seconds 1
+        & git -C $WorkingTree update-ref $RefName $NewValue
+    } -ArgumentList $Repo, $ProbeRef, $HeadSha
+    $MovedBaseRun = Invoke-Verifier @(
+        'docs', '-Base', $ProbeRef, '-DryRun', '-TestPauseAfterCaptureSeconds', '2'
+    )
+    Wait-Job $MoveJob | Out-Null
+    Receive-Job $MoveJob | Out-Null
+    Assert-True ($MovedBaseRun.ExitCode -ne 0 -and
+        $MovedBaseRun.Output.Contains('base ref')) `
+        'symbolic base movement after capture invalidates the evidence run'
+}
+finally {
+    if ($MoveJob) { Remove-Job $MoveJob -Force -ErrorAction SilentlyContinue }
+    & git -C $Repo update-ref -d $ProbeRef 2>$null
+}
+
+Write-Host "verify-pr self-test: $Passed assertions passed"

--- a/prosper/tools/verify-pr.ps1
+++ b/prosper/tools/verify-pr.ps1
@@ -1,0 +1,286 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet('docs', 'core', 'renderer')]
+    [string] $Profile,
+
+    [string] $Base = 'origin/master',
+    [string] $LinuxBuild = 'prosper/build-linux',
+    [string] $WindowsBuild = 'prosper/build-windows',
+    [string[]] $Snapshot = @(),
+    [int] $Jobs = 8,
+    [switch] $SkipLinux,
+    [switch] $SkipWindows,
+    [switch] $DryRun,
+    [string] $EvidenceFile,
+    [int] $Pr = 0
+)
+
+$ErrorActionPreference = 'Stop'
+$Repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$Prosper = Join-Path $Repo 'prosper'
+$Results = @()
+$Notes = @()
+$Succeeded = $false
+$HeadSha = $null
+$TreeSha = $null
+$BaseSha = $null
+
+function Invoke-Capture {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Executable,
+        [Parameter(Mandatory = $true)] [string[]] $Arguments,
+        [Parameter(Mandatory = $true)] [string] $WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $Output = & $Executable @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "$Executable failed with exit code $LASTEXITCODE`: $($Output -join [Environment]::NewLine)"
+        }
+        return ($Output -join [Environment]::NewLine).Trim()
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Format-Command {
+    param([string] $Executable, [string[]] $Arguments)
+
+    $Parts = @($Executable) + $Arguments
+    return (($Parts | ForEach-Object {
+        if ($_ -match '[\s"]') {
+            '"' + ($_ -replace '"', '\"') + '"'
+        }
+        else {
+            $_
+        }
+    }) -join ' ')
+}
+
+function ConvertTo-BashLiteral {
+    param([string] $Value)
+    $Quote = [string][char]39
+    $Replacement = $Quote + '"' + $Quote + '"' + $Quote
+    return $Quote + $Value.Replace($Quote, $Replacement) + $Quote
+}
+
+function Invoke-AuthorCheck {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Label,
+        [Parameter(Mandatory = $true)] [string] $Executable,
+        [Parameter(Mandatory = $true)] [string[]] $Arguments,
+        [Parameter(Mandatory = $true)] [string] $WorkingDirectory
+    )
+
+    $Display = Format-Command $Executable $Arguments
+    Write-Host "`n==> $Label"
+    Write-Host "`$ $Display"
+    if ($DryRun) {
+        $script:Results += [pscustomobject]@{
+            Label = $Label; Command = $Display; Status = 'DRY-RUN'; Seconds = 0; Detail = ''
+        }
+        return
+    }
+
+    $Watch = [Diagnostics.Stopwatch]::StartNew()
+    Push-Location $WorkingDirectory
+    try {
+        $Lines = @(& $Executable @Arguments 2>&1 | ForEach-Object {
+            Write-Host $_
+            $_.ToString()
+        })
+        $ExitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+        $Watch.Stop()
+    }
+
+    $Output = $Lines -join [Environment]::NewLine
+    $Match = [regex]::Match($Output, '(\d+)% tests passed, (\d+) tests failed out of (\d+)')
+    $Detail = ''
+    if ($Match.Success) {
+        $Passed = [int]$Match.Groups[3].Value - [int]$Match.Groups[2].Value
+        $Detail = "$Passed/$($Match.Groups[3].Value) tests passed"
+    }
+    $Status = if ($ExitCode -eq 0) { 'PASS' } else { 'FAIL' }
+    $script:Results += [pscustomobject]@{
+        Label = $Label
+        Command = $Display
+        Status = $Status
+        Seconds = $Watch.Elapsed.TotalSeconds
+        Detail = $Detail
+    }
+    if ($ExitCode -ne 0) {
+        throw "$Label failed with exit code $ExitCode"
+    }
+}
+
+if ($Profile -eq 'renderer' -and $Snapshot.Count -eq 0) {
+    throw 'renderer requires at least one -Snapshot NAME (or -Snapshot all)'
+}
+if ($Profile -ne 'renderer' -and $Snapshot.Count -ne 0) {
+    throw '-Snapshot is only valid with the renderer profile'
+}
+if ($Snapshot -contains 'all' -and -not ($Snapshot.Count -eq 1 -and $Snapshot[0] -eq 'all')) {
+    throw 'use -Snapshot all by itself'
+}
+if ($Pr -ne 0 -and $DryRun) {
+    throw '-Pr cannot be combined with -DryRun'
+}
+if ($Jobs -lt 1) {
+    throw '-Jobs must be positive'
+}
+
+try {
+    $HeadSha = Invoke-Capture git @('rev-parse', 'HEAD') $Repo
+    $TreeSha = Invoke-Capture git @('rev-parse', 'HEAD^{tree}') $Repo
+    $BaseSha = Invoke-Capture git @('rev-parse', $Base) $Repo
+    $Status = Invoke-Capture git @('status', '--porcelain', '--untracked-files=no') $Repo
+    if ($Status) {
+        throw 'commit tracked changes before author verification'
+    }
+
+    try {
+        $Upstream = Invoke-Capture git @('rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}') $Repo
+        $UpstreamSha = Invoke-Capture git @('rev-parse', '@{upstream}') $Repo
+    }
+    catch {
+        throw 'push the PR branch and configure its upstream before verification'
+    }
+    if ($UpstreamSha -ne $HeadSha) {
+        throw "pushed upstream $Upstream is $UpstreamSha, not local HEAD $HeadSha"
+    }
+
+    Invoke-AuthorCheck 'base-to-head whitespace check' git @('diff', '--check', "$Base...HEAD") $Repo
+
+    if ($Profile -in @('core', 'renderer')) {
+        if ($SkipLinux) {
+            $Notes += 'Local Linux build and tests explicitly skipped; applicable CI remains required.'
+        }
+        else {
+            if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+                throw 'wsl.exe is required for the Linux verification on this Windows host'
+            }
+            $LinuxBuildPath = (Resolve-Path (Join-Path $Repo $LinuxBuild)).Path
+            $LinuxBuildWsl = Invoke-Capture wsl.exe @('-e', 'wslpath', '-a', $LinuxBuildPath) $Repo
+            $QuotedLinuxBuild = ConvertTo-BashLiteral $LinuxBuildWsl
+            Invoke-AuthorCheck 'Linux build' wsl.exe @(
+                '-e', 'bash', '-lc', "cmake --build $QuotedLinuxBuild -j$Jobs"
+            ) $Repo
+            Invoke-AuthorCheck 'Linux ctest' wsl.exe @(
+                '-e', 'bash', '-lc', "ctest --test-dir $QuotedLinuxBuild --output-on-failure"
+            ) $Repo
+        }
+
+        if ($SkipWindows) {
+            $Notes += 'Local Windows build and tests explicitly skipped; applicable CI remains required.'
+        }
+        else {
+            $WindowsBuildPath = (Resolve-Path (Join-Path $Repo $WindowsBuild)).Path
+            Invoke-AuthorCheck 'Windows build' cmake @(
+                '--build', $WindowsBuildPath, '--parallel', $Jobs.ToString()
+            ) $Repo
+            Invoke-AuthorCheck 'Windows ctest' ctest @(
+                '--test-dir', $WindowsBuildPath, '--output-on-failure'
+            ) $Repo
+        }
+    }
+
+    if ($Profile -eq 'renderer') {
+        $ProsperWsl = Invoke-Capture wsl.exe @('-e', 'wslpath', '-a', $Prosper) $Repo
+        $SnapshotNames = if ($Snapshot.Count -eq 1 -and $Snapshot[0] -eq 'all') { @() } else { $Snapshot }
+        $SnapshotArguments = @('python3', 'tools/snapshot/snapshot.py', 'check') + $SnapshotNames
+        $SnapshotShell = ($SnapshotArguments | ForEach-Object { ConvertTo-BashLiteral $_ }) -join ' '
+        $SnapshotLabel = if ($SnapshotNames.Count -eq 0) {
+            'snapshot guard: all'
+        }
+        else {
+            'snapshot guard: ' + ($SnapshotNames -join ', ')
+        }
+        Invoke-AuthorCheck $SnapshotLabel wsl.exe @(
+            '-e', 'bash', '-lc', "cd $(ConvertTo-BashLiteral $ProsperWsl) && $SnapshotShell"
+        ) $Prosper
+    }
+
+    $FinalHead = Invoke-Capture git @('rev-parse', 'HEAD') $Repo
+    $FinalUpstream = Invoke-Capture git @('rev-parse', '@{upstream}') $Repo
+    $FinalStatus = Invoke-Capture git @('status', '--porcelain', '--untracked-files=no') $Repo
+    if ($FinalHead -ne $HeadSha -or $FinalUpstream -ne $HeadSha -or $FinalStatus) {
+        throw 'HEAD, pushed upstream, or tracked worktree state changed during verification'
+    }
+    $Succeeded = $true
+}
+catch {
+    Write-Host "`nERROR: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+if (-not $HeadSha) {
+    exit 1
+}
+
+$State = if (-not $Succeeded) { 'FAIL' } elseif ($DryRun) { 'DRY-RUN' } else { 'PASS' }
+$Evidence = @(
+    "### AUTHOR VERIFICATION - $State"
+    ''
+    "- Head: ``$HeadSha``"
+    "- Tree: ``$TreeSha``"
+    "- Compared with: ``$Base@$BaseSha``"
+    ''
+    'Checks:'
+)
+foreach ($Result in $Results) {
+    $Elapsed = if ($Result.Seconds) { ", $([math]::Round($Result.Seconds, 1))s" } else { '' }
+    $Detail = if ($Result.Detail) { ", $($Result.Detail)" } else { '' }
+    $Evidence += "- **$($Result.Status)** - $($Result.Label) (``$($Result.Command)``$Detail$Elapsed)"
+}
+if ($Notes.Count -ne 0) {
+    $Evidence += ''
+    $Evidence += 'Notes:'
+    $Evidence += $Notes | ForEach-Object { "- $_" }
+}
+$Evidence += ''
+$Evidence += 'Reviewer note: this is author-owned verification; inspect its coverage but do not rerun it.'
+$EvidenceText = ($Evidence -join [Environment]::NewLine) + [Environment]::NewLine
+Write-Host "`n$EvidenceText"
+
+if ($EvidenceFile) {
+    $EvidenceParent = Split-Path -Parent $EvidenceFile
+    if ($EvidenceParent) {
+        New-Item -ItemType Directory -Force -Path $EvidenceParent | Out-Null
+    }
+    Set-Content -LiteralPath $EvidenceFile -Value $EvidenceText -Encoding utf8
+    Write-Host "Wrote verification record to $EvidenceFile"
+}
+
+if ($Succeeded -and $Pr) {
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw 'gh is required to post the verification comment'
+    }
+    $PrHead = Invoke-Capture gh @('pr', 'view', $Pr.ToString(), '--json', 'headRefOid', '--jq', '.headRefOid') $Repo
+    if ($PrHead -ne $HeadSha) {
+        throw "PR #$Pr head is $PrHead, not verified HEAD $HeadSha"
+    }
+    $TemporaryEvidence = [IO.Path]::GetTempFileName()
+    try {
+        Set-Content -LiteralPath $TemporaryEvidence -Value $EvidenceText -Encoding utf8
+        Push-Location $Repo
+        try {
+            & gh pr comment $Pr --body-file $TemporaryEvidence
+            if ($LASTEXITCODE -ne 0) {
+                throw "gh pr comment failed with exit code $LASTEXITCODE"
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $TemporaryEvidence -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($Succeeded) { exit 0 } else { exit 1 }

--- a/prosper/tools/verify-pr.ps1
+++ b/prosper/tools/verify-pr.ps1
@@ -9,11 +9,10 @@ param(
     [string] $WindowsBuild = 'prosper/build-windows',
     [string[]] $Snapshot = @(),
     [int] $Jobs = 8,
-    [switch] $SkipLinux,
-    [switch] $SkipWindows,
     [switch] $DryRun,
     [string] $EvidenceFile,
-    [int] $Pr = 0
+    [int] $Pr = 0,
+    [int] $TestPauseAfterCaptureSeconds = 0
 )
 
 $ErrorActionPreference = 'Stop'
@@ -134,14 +133,17 @@ if ($Pr -ne 0 -and $DryRun) {
 if ($Jobs -lt 1) {
     throw '-Jobs must be positive'
 }
+if ($TestPauseAfterCaptureSeconds -lt 0) {
+    throw '-TestPauseAfterCaptureSeconds cannot be negative'
+}
 
 try {
     $HeadSha = Invoke-Capture git @('rev-parse', 'HEAD') $Repo
     $TreeSha = Invoke-Capture git @('rev-parse', 'HEAD^{tree}') $Repo
     $BaseSha = Invoke-Capture git @('rev-parse', $Base) $Repo
-    $Status = Invoke-Capture git @('status', '--porcelain', '--untracked-files=no') $Repo
+    $Status = Invoke-Capture git @('status', '--porcelain') $Repo
     if ($Status) {
-        throw 'commit tracked changes before author verification'
+        throw 'commit or remove all nonignored changes before author verification'
     }
 
     try {
@@ -155,43 +157,49 @@ try {
         throw "pushed upstream $Upstream is $UpstreamSha, not local HEAD $HeadSha"
     }
 
-    Invoke-AuthorCheck 'base-to-head whitespace check' git @('diff', '--check', "$Base...HEAD") $Repo
+    if ($TestPauseAfterCaptureSeconds) {
+        Start-Sleep -Seconds $TestPauseAfterCaptureSeconds
+    }
+
+    Invoke-AuthorCheck 'base-to-head whitespace check' git @(
+        'diff', '--check', "$BaseSha...$HeadSha"
+    ) $Repo
 
     if ($Profile -in @('core', 'renderer')) {
-        if ($SkipLinux) {
-            $Notes += 'Local Linux build and tests explicitly skipped; applicable CI remains required.'
+        if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+            throw 'wsl.exe is required for the Linux verification on this Windows host'
         }
-        else {
-            if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
-                throw 'wsl.exe is required for the Linux verification on this Windows host'
-            }
-            $LinuxBuildPath = (Resolve-Path (Join-Path $Repo $LinuxBuild)).Path
-            $LinuxBuildWsl = Invoke-Capture wsl.exe @('-e', 'wslpath', '-a', $LinuxBuildPath) $Repo
-            $QuotedLinuxBuild = ConvertTo-BashLiteral $LinuxBuildWsl
-            Invoke-AuthorCheck 'Linux build' wsl.exe @(
-                '-e', 'bash', '-lc', "cmake --build $QuotedLinuxBuild -j$Jobs"
-            ) $Repo
-            Invoke-AuthorCheck 'Linux ctest' wsl.exe @(
-                '-e', 'bash', '-lc', "ctest --test-dir $QuotedLinuxBuild --output-on-failure"
-            ) $Repo
-        }
+        $LinuxBuildPath = (Resolve-Path (Join-Path $Repo $LinuxBuild)).Path
+        $QuotedWindowsLinuxBuild = ConvertTo-BashLiteral $LinuxBuildPath
+        $LinuxBuildWsl = Invoke-Capture wsl.exe @(
+            '-d', 'Ubuntu-24.04', '-u', 'root', '--',
+            'bash', '-lc', "wslpath -a $QuotedWindowsLinuxBuild"
+        ) $Repo
+        $QuotedLinuxBuild = ConvertTo-BashLiteral $LinuxBuildWsl
+        Invoke-AuthorCheck 'Linux build' wsl.exe @(
+            '-d', 'Ubuntu-24.04', '-u', 'root', '--',
+            'bash', '-lc', "cmake --build $QuotedLinuxBuild -j$Jobs"
+        ) $Repo
+        Invoke-AuthorCheck 'Linux ctest' wsl.exe @(
+            '-d', 'Ubuntu-24.04', '-u', 'root', '--',
+            'bash', '-lc', "ctest --test-dir $QuotedLinuxBuild --output-on-failure"
+        ) $Repo
 
-        if ($SkipWindows) {
-            $Notes += 'Local Windows build and tests explicitly skipped; applicable CI remains required.'
-        }
-        else {
-            $WindowsBuildPath = (Resolve-Path (Join-Path $Repo $WindowsBuild)).Path
-            Invoke-AuthorCheck 'Windows build' cmake @(
-                '--build', $WindowsBuildPath, '--parallel', $Jobs.ToString()
-            ) $Repo
-            Invoke-AuthorCheck 'Windows ctest' ctest @(
-                '--test-dir', $WindowsBuildPath, '--output-on-failure'
-            ) $Repo
-        }
+        $WindowsBuildPath = (Resolve-Path (Join-Path $Repo $WindowsBuild)).Path
+        Invoke-AuthorCheck 'Windows build' cmake @(
+            '--build', $WindowsBuildPath, '--parallel', $Jobs.ToString()
+        ) $Repo
+        Invoke-AuthorCheck 'Windows ctest' ctest @(
+            '--test-dir', $WindowsBuildPath, '--output-on-failure'
+        ) $Repo
     }
 
     if ($Profile -eq 'renderer') {
-        $ProsperWsl = Invoke-Capture wsl.exe @('-e', 'wslpath', '-a', $Prosper) $Repo
+        $QuotedWindowsProsper = ConvertTo-BashLiteral $Prosper
+        $ProsperWsl = Invoke-Capture wsl.exe @(
+            '-d', 'Ubuntu-24.04', '-u', 'root', '--',
+            'bash', '-lc', "wslpath -a $QuotedWindowsProsper"
+        ) $Repo
         $SnapshotNames = if ($Snapshot.Count -eq 1 -and $Snapshot[0] -eq 'all') { @() } else { $Snapshot }
         $SnapshotArguments = @('python3', 'tools/snapshot/snapshot.py', 'check') + $SnapshotNames
         $SnapshotShell = ($SnapshotArguments | ForEach-Object { ConvertTo-BashLiteral $_ }) -join ' '
@@ -202,15 +210,18 @@ try {
             'snapshot guard: ' + ($SnapshotNames -join ', ')
         }
         Invoke-AuthorCheck $SnapshotLabel wsl.exe @(
-            '-e', 'bash', '-lc', "cd $(ConvertTo-BashLiteral $ProsperWsl) && $SnapshotShell"
+            '-d', 'Ubuntu-24.04', '-u', 'root', '--',
+            'bash', '-lc', "cd $(ConvertTo-BashLiteral $ProsperWsl) && $SnapshotShell"
         ) $Prosper
     }
 
     $FinalHead = Invoke-Capture git @('rev-parse', 'HEAD') $Repo
     $FinalUpstream = Invoke-Capture git @('rev-parse', '@{upstream}') $Repo
-    $FinalStatus = Invoke-Capture git @('status', '--porcelain', '--untracked-files=no') $Repo
-    if ($FinalHead -ne $HeadSha -or $FinalUpstream -ne $HeadSha -or $FinalStatus) {
-        throw 'HEAD, pushed upstream, or tracked worktree state changed during verification'
+    $FinalBase = Invoke-Capture git @('rev-parse', $Base) $Repo
+    $FinalStatus = Invoke-Capture git @('status', '--porcelain') $Repo
+    if ($FinalHead -ne $HeadSha -or $FinalUpstream -ne $HeadSha -or
+        $FinalBase -ne $BaseSha -or $FinalStatus) {
+        throw 'HEAD, pushed upstream, base ref, or nonignored worktree state changed during verification'
     }
     $Succeeded = $true
 }

--- a/prosper/tools/verify-pr.ps1
+++ b/prosper/tools/verify-pr.ps1
@@ -202,7 +202,12 @@ try {
         ) $Repo
         $SnapshotNames = if ($Snapshot.Count -eq 1 -and $Snapshot[0] -eq 'all') { @() } else { $Snapshot }
         $SnapshotArguments = @('python3', 'tools/snapshot/snapshot.py', 'check') + $SnapshotNames
-        $SnapshotShell = ($SnapshotArguments | ForEach-Object { ConvertTo-BashLiteral $_ }) -join ' '
+        $SnapshotEnvironment = @(
+            'PROSPER_BOOT_TRACE=' + (ConvertTo-BashLiteral "$LinuxBuildWsl/boot_trace")
+            'PROSPER_SCREENSHOT=' + (ConvertTo-BashLiteral "$LinuxBuildWsl/screenshot")
+        ) -join ' '
+        $SnapshotShell = $SnapshotEnvironment + ' ' +
+            (($SnapshotArguments | ForEach-Object { ConvertTo-BashLiteral $_ }) -join ' ')
         $SnapshotLabel = if ($SnapshotNames.Count -eq 0) {
             'snapshot guard: all'
         }


### PR DESCRIPTION
Closes #370.

## Failure and contract
GFX10 V# descriptors for packed `10_11_11_FLOAT` and `2_10_10_10` attributes decoded as `Unknown`. `buffer_load_format_*` then saw a zero component size, rejected the shader, and dropped the draw. A legal packed load must unpack one shared dword and apply the descriptor's conversion semantics without guessing unsupported selector behavior.

## Summary
- decode unified buffer formats 36, 50, 51, 54, and 55 as packed `10_11_11_FLOAT` and `2_10_10_10` UNORM/SNORM/UINT/SINT vertex attributes
- unpack exact field widths with signed extension, SNORM signed-minimum clamping, raw integer delivery, and unsigned mini-float widening in SPIR-V
- accept only selector shapes exactly represented by the packed lowering: `X/Y/Z/1` (`0x3AC`) for three-component R11G11B10_FLOAT and `X/Y/Z/W` (`0xFAC`) for four-component 2_10_10_10; other permutations/constants remain fail-closed
- preserve deliberate packed-format rejection through dynamic V# recovery, preventing the legacy `Unknown -> Float32x4` fallback from resurrecting unsupported descriptors
- invalidate entry-time direct V# provenance when any dword in its four-SGPR range is rewritten; a rejected live descriptor cannot fall through to stale identity semantics
- keep USCALED/SSCALED (52/53), packed format stores, and unsupported packed image uploads fail-closed
- append capture enum values without renumbering existing capsules and extend round-trip validation
- codify the maintainer-directed PR flow: open/update PR, run author verification in parallel with independent review, prohibit duplicate reviewer verification, then require approval + author evidence + green CI before merge
- add `prosper/tools/verify-pr.ps1`, which runs clean/pushed-head verification profiles and emits or posts a SHA-bound `AUTHOR VERIFICATION` record
- state explicitly that unpublished Linux/Windows/macOS app feature parity is not a PR-creation or merge prerequisite unless the issue or a shared contract requires it

## Compatibility and deliberate limits
Existing non-packed V# selector behavior and explicit packed texture upload conversions are unchanged. Arbitrary packed permutations/constants are deliberately rejected until selectors are carried through `ShaderResource`; this preserves fail-closed behavior instead of silently returning physical components in the wrong order. Known unsupported packed semantics carry an explicit no-fallback marker through dynamic resolution; genuinely unresolved legacy descriptors retain their existing Float32 fallback. Exact per-fetch and descriptor-table provenance still resolve rewritten SRSRCs, while untouched direct user-data descriptors keep their existing lookup. Capture enum additions are append-only.

The workflow update does not lower the correctness bar: regressions, broken platform builds, unresolved correctness findings, missing applicable verification, and failed CI remain blockers. It only rejects unrelated completeness as a blocker. A platform-specific improvement may land before matching unpublished-app work elsewhere when unaffected platforms retain their existing behavior and checks.

## Verification
Runtime verification was completed on renderer head `fbb2f0e2766750c0c7f034af40fd1d2ab8378a75` and is reused for current head `bd153ab39e830c65c303ff52c6a1b341c573e45b`: the intervening authored delta changes only `CLAUDE.md`, `prosper/tools/AGENTS.md`, and the new author-verification PowerShell tool, so it cannot change the built emulator, packed-format execution, or Messenger pixels.

- `ctest --test-dir prosper/build-linux --output-on-failure -j 4`: 100/100 passed (Vulkan/llvmpipe enabled)
- `ctest --test-dir prosper/build-windows --output-on-failure -j 4`: 73/73 passed (MinGW)
- execution differential: all five packed formats pass through RDNA2 -> SPIR-V -> llvmpipe, including two-bit alpha, SNORM clamps, and Float10_11_11 default W
- canonical format-36 descriptor `(36 << 12) | 0x3AC` decodes and executes through Vulkan with exact R/G/B mini-float widening and W=`1.0`; an A/B/G/R format-36 permutation is rejected
- descriptor regressions: supported selector shapes accepted; A/B/G/R, unsupported constants, and USCALED rejected; rejected descriptors remain absent through production `resolve_dynamic_fetch`
- stale-direct regression: entry-time identity V# plus in-shader permutation, constant, or USCALED dword-3 rewrite resolves no dynamic resource and emits no SPIR-V
- `python3 tools/snapshot/snapshot.py check messenger-scene`: 49/49 qualifying, 49/49 structural, 49/49 non-black, 15 pixel changes
- `powershell -File prosper/tools/test-verify-pr.ps1`: 8/8 assertions passed (syntax, immutable object diff, pinned Ubuntu-24.04/root commands, complete renderer profile, rejected skip switches, rejected untracked source, and detected symbolic-base movement)
- `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot messenger-scene -DryRun`: passed and generated the expected Linux, Windows, snapshot, and evidence commands
- `powershell -File prosper/tools/verify-pr.ps1 docs`: passed on the current clean, pushed head
- `git diff --check origin/master...HEAD`: passed on the current head
- GitHub CI: all six core/app jobs passed on the renderer head; the current docs/tool head must also be green before merge

## Review tuple
- base: `c2adbb5cd0b762e8946e60bbca9f86bf34ee79dc`
- head: `bd153ab39e830c65c303ff52c6a1b341c573e45b`
- integration tree: `9bd642bc12863b82bd75c10ffaee928474af8216`

## Evidence
The numeric slots, conversion families, and canonical component-count-specific selector shapes follow AMD's GFX10 buffer-format contract. Existing texture-only packed conversions remain explicit, so recognizing vertex descriptors does not make zero-byte packed images appear valid.
