### PR TITLE
Advance Astro Bot through title and world-map flow (#825)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -177,6 +177,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_avplayer PRIVATE prosper_core)
   add_test(NAME avplayer_hle COMMAND test_avplayer)
 
+  add_executable(test_json2 tests/test_json2.cpp)
+  target_link_libraries(test_json2 PRIVATE prosper_core)
+  add_test(NAME json2_hle COMMAND test_json2)
+
   add_executable(test_equeue_events tests/test_equeue_events.cpp)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -728,11 +728,26 @@ struct GuestReadableCacheState {
 thread_local GuestReadableCacheState g_guest_readable_cache;
 
 bool guest_range_cache_hit(uint64_t begin, uint64_t end) {
-    if (!g_guest_readable_cache.active) return false;
-    ++g_guest_readable_cache.calls;
-    const bool hit = g_guest_readable_cache.persistent_ranges.contains(begin, end) ||
-                     g_guest_readable_cache.submit_ranges.contains(begin, end);
-    if (hit) ++g_guest_readable_cache.hits;
+    if (g_guest_readable_cache.active) ++g_guest_readable_cache.calls;
+
+    // Completion-label writes are folded on the guest draw thread before/after a renderer submit
+    // scope. On Windows, falling through to VirtualQuery for every 8-byte label read made Astro's
+    // otherwise headless frame loop take ~16 seconds per flip. The kernel-memory HLE already owns a
+    // generation-guarded registry of fully committed readable guest mappings; reuse it here on every
+    // call, not only while a renderer scope happens to be active. Sparse/lazy mappings are deliberately
+    // absent from that registry and retain the OS probe/commit path below.
+    g_guest_readable_cache.persistent_ranges.sync_generation(host::guest_mapping_generation());
+    bool hit = g_guest_readable_cache.persistent_ranges.contains(begin, end) ||
+               (g_guest_readable_cache.active &&
+                g_guest_readable_cache.submit_ranges.contains(begin, end));
+    if (!hit) {
+        host::GuestReadableRange mapping{};
+        if (host::guest_readable_mapping_containing(begin, end, mapping)) {
+            g_guest_readable_cache.persistent_ranges.insert(mapping.begin, mapping.end);
+            hit = true;
+        }
+    }
+    if (hit && g_guest_readable_cache.active) ++g_guest_readable_cache.hits;
     return hit;
 }
 

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -57,32 +57,38 @@ namespace {
     std::map<int, std::string> g_filelog_fd_paths;
 
 #ifdef _WIN32
-    // Host I/O stages through committed memory so it can discover the real short-read byte count.
-    // Its subsequent host memcpy still bypasses the guest VEH, so materialize sparse direct-memory
-    // or tracked reserved pages before publishing those bytes into the guest destination.
-    bool windows_prepare_guest_write(uint64_t dst, uint64_t bytes) {
-        if (!bytes) return true;
-        if (!dst || dst + bytes < dst) return false;
+    // Return the writable prefix of a guest destination, materializing sparse direct-memory or
+    // tracked reserved pages as the guest VEH would on first touch.  Host I/O bypasses that VEH, so
+    // every byte handed to _read/ReadFile must already be committed and writable.  Reporting a
+    // prefix (rather than a boolean) is important for sequential reads: a valid committed prefix may
+    // precede an inaccessible tail, and the file offset must advance only by bytes actually delivered.
+    uint64_t windows_prepare_guest_write_prefix(uint64_t dst, uint64_t bytes) {
+        if (!bytes) return 0;
+        if (!dst || dst + bytes < dst) return 0;
         prosper_try_commit_dmem(dst, bytes, 1);
         const uint64_t end = dst + bytes;
         for (uint64_t p = dst; p < end;) {
             MEMORY_BASIC_INFORMATION mbi{};
-            if (!VirtualQuery((const void*)(uintptr_t)p, &mbi, sizeof mbi)) return false;
+            if (!VirtualQuery((const void*)(uintptr_t)p, &mbi, sizeof mbi)) return p - dst;
             if (mbi.State == MEM_RESERVE && prosper_reserved_range_state(p) == 1) {
                 const uint64_t page = p & ~uint64_t{0x3fff};
                 if (!VirtualAlloc((void*)(uintptr_t)page, 0x4000, MEM_COMMIT, PAGE_READWRITE))
-                    return false;
+                    return p - dst;
                 continue;
             }
             const DWORD writable = PAGE_READWRITE | PAGE_WRITECOPY |
                                    PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
             if (mbi.State != MEM_COMMIT || (mbi.Protect & PAGE_GUARD) ||
-                !(mbi.Protect & writable)) return false;
+                !(mbi.Protect & writable)) return p - dst;
             const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
-            if (region_end <= p) return false;
+            if (region_end <= p) return p - dst;
             p = region_end < end ? region_end : end;
         }
-        return true;
+        return bytes;
+    }
+
+    bool windows_prepare_guest_write(uint64_t dst, uint64_t bytes) {
+        return !bytes || windows_prepare_guest_write_prefix(dst, bytes) == bytes;
     }
 #endif
 
@@ -523,37 +529,36 @@ HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
                // Full sequential read (loop) — same full-count contract as read_full: a short ::read
                // would leave Unity's asset cache block partially filled and deserialize corrupt data.
                // Windows validates the entire destination range before _read discovers a short EOF.
-               // Guest allocators can leave later pages reserved for lazy commit, so Unity's normal
-               // 64 KiB read from a small boot.config otherwise fails with EINVAL. Stage through
-               // committed host memory and copy only the bytes the file actually supplied. For a
-               // seekable regular file, cap each chunk to the exact remaining bytes before validating
-               // the destination. For a non-seekable descriptor, validate the whole requested chunk
-               // first: no path may consume bytes that were not delivered to the guest.
-               { size_t done = 0, cnt = (size_t)a2; char* b = (char*)P(a1);
-                 constexpr size_t kBounceSize = 0x10000;
-                 std::vector<char> bounce(cnt < kBounceSize ? cnt : kBounceSize);
-                 while (done < cnt) {
-                     size_t left = cnt - done;
-                     unsigned want = (unsigned)(left < bounce.size() ? left : bounce.size());
-                     const __int64 pos = ::_lseeki64((int)a0, 0, SEEK_CUR);
-                     struct _stat64 st{};
-                     if (pos >= 0 && ::_fstat64((int)a0, &st) == 0 &&
-                         (st.st_mode & _S_IFMT) == _S_IFREG) {
-                         const uint64_t len = st.st_size > 0 ? (uint64_t)st.st_size : 0;
-                         const uint64_t remaining = (uint64_t)pos < len
-                             ? len - (uint64_t)pos : 0;
-                         if (!remaining) break;
-                         if (remaining < want) want = (unsigned)remaining;
-                     }
-                     if (!windows_prepare_guest_write(
-                             (uint64_t)(uintptr_t)(b + done), want)) {
+               // Guest allocators can leave later pages reserved for lazy commit, so asking _read for
+               // the whole range can fail even when the available file prefix fits in committed pages.
+               // Validate the largest writable prefix first and read directly into it.  A normal
+               // multi-megabyte asset allocation is one committed region, so this is one validation
+               // and one host read instead of hundreds of 64 KiB bounce-buffer cycles.  An inaccessible
+               // tail still limits the request before any file bytes are consumed, preserving partial
+               // read and retry-offset behavior.
+               { size_t done = 0, cnt = (size_t)a2, readable = cnt; char* b = (char*)P(a1);
+                 const __int64 pos = ::_lseeki64((int)a0, 0, SEEK_CUR);
+                 struct _stat64 st{};
+                 if (pos >= 0 && ::_fstat64((int)a0, &st) == 0 &&
+                     (st.st_mode & _S_IFMT) == _S_IFREG) {
+                     const uint64_t len = st.st_size > 0 ? (uint64_t)st.st_size : 0;
+                     const uint64_t remaining = (uint64_t)pos < len
+                         ? len - (uint64_t)pos : 0;
+                     if (remaining < readable) readable = (size_t)remaining;
+                 }
+                 while (done < readable) {
+                     size_t left = readable - done;
+                     const size_t request = left < 0x40000000u ? left : 0x40000000u;
+                     const uint64_t prefix = windows_prepare_guest_write_prefix(
+                         (uint64_t)(uintptr_t)(b + done), request);
+                     if (!prefix) {
                          errno = EFAULT;
                          return logged_return(done ? (int64_t)done : (int64_t)-1);
                      }
-                     int r = ::read((int)a0, bounce.data(), want);
+                     const unsigned want = (unsigned)prefix;
+                     int r = ::read((int)a0, b + done, want);
                      if (r < 0) return logged_return(done ? (int64_t)done : (int64_t)-1);
                      if (r == 0) break;   // EOF
-                     memcpy(b + done, bounce.data(), (size_t)r);
                      done += (size_t)r;
                  }
                  return logged_return((int64_t)done); }

--- a/prosper/src/hle/hle_json2.cpp
+++ b/prosper/src/hle/hle_json2.cpp
@@ -1,0 +1,566 @@
+#include "hle_json2.hpp"
+#include "dispatch.hpp"
+
+#include <charconv>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace prosper {
+namespace {
+
+#define JHLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                                         uint64_t a3, uint64_t a4, uint64_t a5)
+template <typename T> T* ptr(uint64_t value) {
+    return reinterpret_cast<T*>(static_cast<uintptr_t>(value));
+}
+
+enum class ValueType : uint32_t { Null, Boolean, Integer, Unsigned, Real, String, Array, Object };
+struct Value;
+struct String { std::string* host = nullptr; };
+struct Array { std::vector<Value*>* host = nullptr; };
+struct Object { std::map<std::string, Value*>* host = nullptr; };
+struct Value {
+    Value* parent = nullptr;
+    void* root_parameter = nullptr;
+    union Data {
+        bool boolean;
+        int64_t integer;
+        uint64_t unsigned_integer;
+        double real;
+        String* string;
+        Array* array;
+        Object* object;
+        Data() : unsigned_integer(0) {}
+    } data;
+    uint8_t reserved[4]{};
+    ValueType type = ValueType::Null;
+};
+static_assert(sizeof(Value) == 32 && offsetof(Value, data) == 16 && offsetof(Value, type) == 28,
+              "libSceJson2 Value ABI");
+
+constexpr uint64_t JSON_PARSE_ERROR = 0x80848101u;
+constexpr uint64_t JSON_ARGUMENT_ERROR = 0x80848120u;
+
+bool logging() {
+    static const bool enabled = std::getenv("PROSPER_JSONLOG") != nullptr;
+    return enabled;
+}
+
+void clear(Value* value);
+void destroy(Value* value) { if (value) { clear(value); delete value; } }
+
+void clear(Value* value) {
+    if (!value) return;
+    if (value->type == ValueType::String && value->data.string) {
+        delete value->data.string->host; delete value->data.string;
+    } else if (value->type == ValueType::Array && value->data.array) {
+        if (value->data.array->host) for (Value* child : *value->data.array->host) destroy(child);
+        delete value->data.array->host; delete value->data.array;
+    } else if (value->type == ValueType::Object && value->data.object) {
+        if (value->data.object->host)
+            for (auto& entry : *value->data.object->host) destroy(entry.second);
+        delete value->data.object->host; delete value->data.object;
+    }
+    value->parent = nullptr; value->root_parameter = nullptr; value->data.unsigned_integer = 0;
+    std::memset(value->reserved, 0, sizeof(value->reserved)); value->type = ValueType::Null;
+}
+
+bool clone(Value* destination, const Value* source) {
+    if (!destination || !source) return false;
+    destination->type = source->type;
+    switch (source->type) {
+        case ValueType::Null: break;
+        case ValueType::Boolean: destination->data.boolean = source->data.boolean; break;
+        case ValueType::Integer: destination->data.integer = source->data.integer; break;
+        case ValueType::Unsigned: destination->data.unsigned_integer = source->data.unsigned_integer; break;
+        case ValueType::Real: destination->data.real = source->data.real; break;
+        case ValueType::String:
+            destination->data.string = new String{new std::string(
+                source->data.string && source->data.string->host ? *source->data.string->host : "")};
+            break;
+        case ValueType::Array:
+            destination->data.array = new Array{new std::vector<Value*>};
+            if (source->data.array && source->data.array->host) {
+                for (const Value* source_child : *source->data.array->host) {
+                    auto* child = new Value;
+                    if (!clone(child, source_child)) { destroy(child); return false; }
+                    child->parent = destination;
+                    destination->data.array->host->push_back(child);
+                }
+            }
+            break;
+        case ValueType::Object:
+            destination->data.object = new Object{new std::map<std::string, Value*>};
+            if (source->data.object && source->data.object->host) {
+                for (const auto& [key, source_child] : *source->data.object->host) {
+                    auto* child = new Value;
+                    if (!clone(child, source_child)) { destroy(child); return false; }
+                    child->parent = destination;
+                    destination->data.object->host->emplace(key, child);
+                }
+            }
+            break;
+    }
+    return true;
+}
+
+void escape_json_string(std::string& output, std::string_view input) {
+    static constexpr char hex[] = "0123456789abcdef";
+    output.push_back('"');
+    for (unsigned char c : input) {
+        switch (c) {
+            case '"': output += "\\\""; break;
+            case '\\': output += "\\\\"; break;
+            case '\b': output += "\\b"; break;
+            case '\f': output += "\\f"; break;
+            case '\n': output += "\\n"; break;
+            case '\r': output += "\\r"; break;
+            case '\t': output += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    output += "\\u00";
+                    output.push_back(hex[c >> 4]); output.push_back(hex[c & 15]);
+                } else output.push_back(static_cast<char>(c));
+                break;
+        }
+    }
+    output.push_back('"');
+}
+
+void serialize(std::string& output, const Value* value) {
+    if (!value) { output += "null"; return; }
+    char number[64]{};
+    switch (value->type) {
+        case ValueType::Null: output += "null"; break;
+        case ValueType::Boolean: output += value->data.boolean ? "true" : "false"; break;
+        case ValueType::Integer: {
+            const auto result = std::to_chars(number, number + sizeof(number), value->data.integer);
+            output.append(number, result.ptr); break;
+        }
+        case ValueType::Unsigned: {
+            const auto result = std::to_chars(number, number + sizeof(number), value->data.unsigned_integer);
+            output.append(number, result.ptr); break;
+        }
+        case ValueType::Real: {
+            const auto result = std::to_chars(number, number + sizeof(number), value->data.real,
+                                              std::chars_format::general,
+                                              std::numeric_limits<double>::max_digits10);
+            if (result.ec == std::errc{}) output.append(number, result.ptr); else output += "null";
+            break;
+        }
+        case ValueType::String:
+            escape_json_string(output, value->data.string && value->data.string->host
+                                           ? *value->data.string->host : std::string_view{});
+            break;
+        case ValueType::Array: {
+            output.push_back('['); bool first = true;
+            if (value->data.array && value->data.array->host) {
+                for (const Value* child : *value->data.array->host) {
+                    if (!first) output.push_back(','); first = false; serialize(output, child);
+                }
+            }
+            output.push_back(']'); break;
+        }
+        case ValueType::Object: {
+            output.push_back('{'); bool first = true;
+            if (value->data.object && value->data.object->host) {
+                for (const auto& [key, child] : *value->data.object->host) {
+                    if (!first) output.push_back(','); first = false;
+                    escape_json_string(output, key); output.push_back(':'); serialize(output, child);
+                }
+            }
+            output.push_back('}'); break;
+        }
+    }
+}
+
+Value& null_value() { static Value value; return value; }
+String& empty_string() { static String value{new std::string}; return value; }
+Array& empty_array() { static Array value{new std::vector<Value*>}; return value; }
+Object& empty_object() { static Object value{new std::map<std::string, Value*>}; return value; }
+
+class Parser {
+public:
+    Parser(const char* data, size_t size): cursor_(data), end_(data + size) {}
+    bool parse(Value* output) { space(); return value(output) && (space(), cursor_ == end_); }
+
+private:
+    const char* cursor_;
+    const char* end_;
+
+    void space() {
+        while (cursor_ != end_ && (*cursor_ == ' ' || *cursor_ == '\t' ||
+               *cursor_ == '\r' || *cursor_ == '\n')) ++cursor_;
+    }
+    bool take(char wanted) {
+        if (cursor_ == end_ || *cursor_ != wanted) return false;
+        ++cursor_; return true;
+    }
+    bool literal(std::string_view text) {
+        if (static_cast<size_t>(end_ - cursor_) < text.size() ||
+            std::memcmp(cursor_, text.data(), text.size()) != 0) return false;
+        cursor_ += text.size(); return true;
+    }
+    static int hex(char c) {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    }
+    bool code_unit(uint32_t& result) {
+        if (end_ - cursor_ < 4) return false;
+        result = 0;
+        for (unsigned i = 0; i < 4; ++i) {
+            int digit = hex(*cursor_++); if (digit < 0) return false;
+            result = (result << 4) | static_cast<uint32_t>(digit);
+        }
+        return true;
+    }
+    static void utf8(std::string& output, uint32_t codepoint) {
+        if (codepoint <= 0x7f) output.push_back(static_cast<char>(codepoint));
+        else if (codepoint <= 0x7ff) {
+            output.push_back(static_cast<char>(0xc0 | (codepoint >> 6)));
+            output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+        } else if (codepoint <= 0xffff) {
+            output.push_back(static_cast<char>(0xe0 | (codepoint >> 12)));
+            output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+            output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+        } else {
+            output.push_back(static_cast<char>(0xf0 | (codepoint >> 18)));
+            output.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f)));
+            output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+            output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+        }
+    }
+    bool string(std::string& output) {
+        if (!take('"')) return false;
+        output.clear();
+        while (cursor_ != end_) {
+            unsigned char c = static_cast<unsigned char>(*cursor_++);
+            if (c == '"') return true;
+            if (c < 0x20) return false;
+            if (c != '\\') { output.push_back(static_cast<char>(c)); continue; }
+            if (cursor_ == end_) return false;
+            switch (*cursor_++) {
+                case '"': output.push_back('"'); break; case '\\': output.push_back('\\'); break;
+                case '/': output.push_back('/'); break; case 'b': output.push_back('\b'); break;
+                case 'f': output.push_back('\f'); break; case 'n': output.push_back('\n'); break;
+                case 'r': output.push_back('\r'); break; case 't': output.push_back('\t'); break;
+                case 'u': {
+                    uint32_t high = 0; if (!code_unit(high)) return false;
+                    uint32_t point = high;
+                    if (high >= 0xd800 && high <= 0xdbff) {
+                        if (end_ - cursor_ < 6 || cursor_[0] != '\\' || cursor_[1] != 'u') return false;
+                        cursor_ += 2; uint32_t low = 0;
+                        if (!code_unit(low) || low < 0xdc00 || low > 0xdfff) return false;
+                        point = 0x10000 + ((high - 0xd800) << 10) + low - 0xdc00;
+                    } else if (high >= 0xdc00 && high <= 0xdfff) return false;
+                    utf8(output, point); break;
+                }
+                default: return false;
+            }
+        }
+        return false;
+    }
+    bool number(Value* output) {
+        const char* begin = cursor_;
+        if (cursor_ != end_ && *cursor_ == '-') ++cursor_;
+        if (cursor_ == end_) return false;
+        if (*cursor_ == '0') ++cursor_;
+        else {
+            if (*cursor_ < '1' || *cursor_ > '9') return false;
+            while (cursor_ != end_ && std::isdigit(static_cast<unsigned char>(*cursor_))) ++cursor_;
+        }
+        bool is_real = false;
+        if (cursor_ != end_ && *cursor_ == '.') {
+            is_real = true; ++cursor_; const char* digits = cursor_;
+            while (cursor_ != end_ && std::isdigit(static_cast<unsigned char>(*cursor_))) ++cursor_;
+            if (digits == cursor_) return false;
+        }
+        if (cursor_ != end_ && (*cursor_ == 'e' || *cursor_ == 'E')) {
+            is_real = true; ++cursor_;
+            if (cursor_ != end_ && (*cursor_ == '+' || *cursor_ == '-')) ++cursor_;
+            const char* digits = cursor_;
+            while (cursor_ != end_ && std::isdigit(static_cast<unsigned char>(*cursor_))) ++cursor_;
+            if (digits == cursor_) return false;
+        }
+        std::string_view token(begin, static_cast<size_t>(cursor_ - begin));
+        if (is_real) {
+            std::string temporary(token); char* parsed_end = nullptr;
+            output->data.real = std::strtod(temporary.c_str(), &parsed_end);
+            if (parsed_end != temporary.c_str() + temporary.size()) return false;
+            output->type = ValueType::Real; return true;
+        }
+        if (!token.empty() && token.front() == '-') {
+            auto result = std::from_chars(token.data(), token.data() + token.size(), output->data.integer);
+            if (result.ec != std::errc{} || result.ptr != token.data() + token.size()) return false;
+            output->type = ValueType::Integer; return true;
+        }
+        auto result = std::from_chars(token.data(), token.data() + token.size(), output->data.unsigned_integer);
+        if (result.ec != std::errc{} || result.ptr != token.data() + token.size()) return false;
+        output->type = ValueType::Unsigned; return true;
+    }
+    bool array(Value* output) {
+        if (!take('[')) return false;
+        output->type = ValueType::Array; output->data.array = new Array{new std::vector<Value*>};
+        space(); if (take(']')) return true;
+        for (;;) {
+            Value* child = new Value; if (!value(child)) { destroy(child); return false; }
+            child->parent = output; output->data.array->host->push_back(child); space();
+            if (take(']')) return true; if (!take(',')) return false; space();
+        }
+    }
+    bool object(Value* output) {
+        if (!take('{')) return false;
+        output->type = ValueType::Object; output->data.object = new Object{new std::map<std::string, Value*>};
+        space(); if (take('}')) return true;
+        for (;;) {
+            std::string key; if (!string(key)) return false; space();
+            if (!take(':')) return false; space();
+            Value* child = new Value; if (!value(child)) { destroy(child); return false; }
+            child->parent = output;
+            auto [position, inserted] = output->data.object->host->emplace(std::move(key), child);
+            if (!inserted) { destroy(position->second); position->second = child; }
+            space(); if (take('}')) return true; if (!take(',')) return false; space();
+        }
+    }
+    bool value(Value* output) {
+        if (!output || cursor_ == end_) return false;
+        if (*cursor_ == '{') return object(output); if (*cursor_ == '[') return array(output);
+        if (*cursor_ == '"') {
+            std::string text; if (!string(text)) return false; output->type = ValueType::String;
+            output->data.string = new String{new std::string(std::move(text))}; return true;
+        }
+        if (*cursor_ == 't' && literal("true")) {
+            output->type = ValueType::Boolean; output->data.boolean = true; return true;
+        }
+        if (*cursor_ == 'f' && literal("false")) {
+            output->type = ValueType::Boolean; output->data.boolean = false; return true;
+        }
+        if (*cursor_ == 'n' && literal("null")) return true;
+        return number(output);
+    }
+};
+
+std::string& text(String* string) {
+    static std::string fallback;
+    if (!string) return fallback;
+    if (!string->host) string->host = new std::string;
+    return *string->host;
+}
+const std::string& text(const String* string) {
+    static const std::string fallback;
+    return string && string->host ? *string->host : fallback;
+}
+
+JHLE(noop_self) { return a0; }
+JHLE(noop_zero) { return 0; }
+JHLE(value_ctor) { if (auto* value = ptr<Value>(a0)) *value = Value{}; return a0; }
+JHLE(value_dtor) { clear(ptr<Value>(a0)); return 0; }
+JHLE(value_assign) {
+    auto* destination = ptr<Value>(a0); auto* source = ptr<const Value>(a1);
+    if (!destination || !source || destination == source) return a0;
+    Value replacement;
+    if (!clone(&replacement, source)) { clear(&replacement); return a0; }
+    clear(destination); *destination = replacement;
+    if (destination->type == ValueType::Array && destination->data.array && destination->data.array->host)
+        for (Value* child : *destination->data.array->host) child->parent = destination;
+    if (destination->type == ValueType::Object && destination->data.object && destination->data.object->host)
+        for (auto& entry : *destination->data.object->host) entry.second->parent = destination;
+    return a0;
+}
+JHLE(set_bool) {
+    if (auto* value = ptr<Value>(a0)) { clear(value); value->type = ValueType::Boolean; value->data.boolean = a1 != 0; }
+    return 0;
+}
+JHLE(set_int) {
+    if (auto* value = ptr<Value>(a0)) { clear(value); value->type = ValueType::Integer; value->data.integer = static_cast<int64_t>(a1); }
+    return 0;
+}
+JHLE(set_uint) {
+    if (auto* value = ptr<Value>(a0)) { clear(value); value->type = ValueType::Unsigned; value->data.unsigned_integer = a1; }
+    return 0;
+}
+JHLE(set_double) {
+    // The current integer-only HLE entry ABI does not expose XMM0. Preserve the correct type; parsing
+    // (the path used by Astro) supplies real double payloads directly.
+    if (auto* value = ptr<Value>(a0)) { clear(value); value->type = ValueType::Real; value->data.real = 0.0; }
+    return 0;
+}
+JHLE(set_string) {
+    if (auto* value = ptr<Value>(a0)) {
+        clear(value); value->type = ValueType::String;
+        value->data.string = new String{new std::string(text(ptr<const String>(a1)))};
+    }
+    return 0;
+}
+JHLE(set_type) {
+    auto* value = ptr<Value>(a0); if (!value) return 0; clear(value);
+    const uint32_t raw = static_cast<uint32_t>(a1);
+    if (raw > static_cast<uint32_t>(ValueType::Object)) return 0;
+    value->type = static_cast<ValueType>(raw);
+    if (value->type == ValueType::String) value->data.string = new String{new std::string};
+    if (value->type == ValueType::Array) value->data.array = new Array{new std::vector<Value*>};
+    if (value->type == ValueType::Object) value->data.object = new Object{new std::map<std::string, Value*>};
+    return 0;
+}
+JHLE(string_cstring_ctor) {
+    auto* string = ptr<String>(a0); const char* source = ptr<const char>(a1);
+    if (string) string->host = new std::string(source ? source : ""); return a0;
+}
+JHLE(string_ctor) { if (auto* string = ptr<String>(a0)) string->host = new std::string; return a0; }
+JHLE(string_dtor) {
+    if (auto* string = ptr<String>(a0)) { delete string->host; string->host = nullptr; } return 0;
+}
+JHLE(parse) {
+    auto* output = ptr<Value>(a0); const char* source = ptr<const char>(a1);
+    if (!output || !source) return JSON_ARGUMENT_ERROR;
+    clear(output); Parser parser(source, static_cast<size_t>(a2)); const bool ok = parser.parse(output);
+    if (!ok) clear(output);
+    if (logging()) std::fprintf(stderr, "[json2] parse bytes=%llu ok=%d type=%u\n",
+        (unsigned long long)a2, (int)ok, static_cast<unsigned>(output->type));
+    return ok ? 0 : JSON_PARSE_ERROR;
+}
+JHLE(index_string) {
+    auto* value = ptr<Value>(a0); const char* key = ptr<const char>(a1); Value* result = &null_value();
+    if (value && value->type == ValueType::Object && value->data.object && value->data.object->host) {
+        const auto found = value->data.object->host->find(key ? key : "");
+        if (found != value->data.object->host->end()) result = found->second;
+    }
+    if (logging()) std::fprintf(stderr, "[json2] index key='%s' -> type=%u\n", key ? key : "",
+                                static_cast<unsigned>(result->type));
+    return reinterpret_cast<uintptr_t>(result);
+}
+JHLE(index_wrapped_string) {
+    auto* value = ptr<Value>(a0); auto* key = ptr<const String>(a1); Value* result = &null_value();
+    if (value && value->type == ValueType::Object && value->data.object && value->data.object->host) {
+        const auto found = value->data.object->host->find(text(key));
+        if (found != value->data.object->host->end()) result = found->second;
+    }
+    return reinterpret_cast<uintptr_t>(result);
+}
+JHLE(refer_wrapped_string) {
+    auto* value = ptr<Value>(a0); auto* key = ptr<const String>(a1);
+    if (!value || value->type != ValueType::Object || !value->data.object ||
+        !value->data.object->host) return 0;
+    const auto found = value->data.object->host->find(text(key));
+    return found == value->data.object->host->end() ? 0
+        : reinterpret_cast<uintptr_t>(found->second);
+}
+JHLE(index_uint) {
+    auto* value = ptr<Value>(a0); Value* result = &null_value();
+    if (value && value->type == ValueType::Array && value->data.array && value->data.array->host &&
+        a1 < value->data.array->host->size()) result = (*value->data.array->host)[static_cast<size_t>(a1)];
+    return reinterpret_cast<uintptr_t>(result);
+}
+JHLE(refer_uint) {
+    auto* value = ptr<Value>(a0);
+    if (!value || value->type != ValueType::Array || !value->data.array ||
+        !value->data.array->host || a1 >= value->data.array->host->size()) return 0;
+    return reinterpret_cast<uintptr_t>((*value->data.array->host)[static_cast<size_t>(a1)]);
+}
+JHLE(get_type) { auto* value = ptr<const Value>(a0); return value ? static_cast<uint32_t>(value->type) : 0; }
+JHLE(get_boolean) {
+    static const bool fallback = false; auto* value = ptr<const Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::Boolean ? &value->data.boolean : &fallback);
+}
+JHLE(get_integer) {
+    static const int64_t fallback = 0; auto* value = ptr<const Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::Integer ? &value->data.integer : &fallback);
+}
+JHLE(get_unsigned) {
+    static const uint64_t fallback = 0; auto* value = ptr<const Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::Unsigned
+                                           ? &value->data.unsigned_integer : &fallback);
+}
+JHLE(get_real) {
+    static const double fallback = 0; auto* value = ptr<const Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::Real ? &value->data.real : &fallback);
+}
+JHLE(get_string) {
+    auto* value = ptr<Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::String ? value->data.string : &empty_string());
+}
+JHLE(get_array) {
+    auto* value = ptr<Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::Array ? value->data.array : &empty_array());
+}
+JHLE(get_object) {
+    auto* value = ptr<Value>(a0);
+    return reinterpret_cast<uintptr_t>(value && value->type == ValueType::Object ? value->data.object : &empty_object());
+}
+JHLE(count) {
+    auto* value = ptr<const Value>(a0);
+    if (value && value->type == ValueType::Array && value->data.array && value->data.array->host)
+        return value->data.array->host->size();
+    if (value && value->type == ValueType::Object && value->data.object && value->data.object->host)
+        return value->data.object->host->size();
+    return 0;
+}
+JHLE(string_cstr) { return reinterpret_cast<uintptr_t>(text(ptr<const String>(a0)).c_str()); }
+JHLE(string_length) { return text(ptr<const String>(a0)).size(); }
+JHLE(value_to_string) {
+    auto* output = ptr<String>(a1); if (!output) return JSON_ARGUMENT_ERROR;
+    std::string& destination = text(output); destination.clear(); serialize(destination, ptr<const Value>(a0));
+    return 0;
+}
+JHLE(array_size) {
+    auto* array = ptr<const Array>(a0); return array && array->host ? array->host->size() : 0;
+}
+
+#undef JHLE
+} // namespace
+
+void register_json2_hle() {
+    auto reg = [](const char* nid, HleFn fn, const char* name) { Hle::register_fn(nid, fn, name); };
+    reg("-hJRce8wn1U", noop_self, "sceJsonMemAllocator::ctor");
+    reg("qBMjqyBn3OM", value_ctor, "sceJsonValue::ctor");
+    reg("-wa17B7TGnw", value_ctor, "sceJsonValue::ctor");
+    reg("WTtYf+cNnXI", value_dtor, "sceJsonValue::dtor");
+    reg("0eUrW9JAxM0", value_dtor, "sceJsonValue::dtor");
+    reg("4zrm6VrgIAw", value_assign, "sceJsonValue::assign");
+    reg("5yHuiWXo2gg", set_bool, "sceJsonValue::setBool");
+    reg("QxVVYhP-mvg", set_int, "sceJsonValue::setInt");
+    reg("SIe1ZmW7e7s", set_uint, "sceJsonValue::setUInt");
+    reg("BSmWDIkV4w4", set_double, "sceJsonValue::setDouble");
+    reg("6l3Bv2gysNc", set_string, "sceJsonValue::setString");
+    reg("IKQimvG9Wqs", set_type, "sceJsonValue::setType");
+    reg("9KUZFjI1IxA", string_cstring_ctor, "sceJsonString::cstringCtor");
+    reg("qSmqLXXCPas", string_ctor, "sceJsonString::ctor");
+    reg("cG1VE2HMl6c", string_dtor, "sceJsonString::dtor");
+    reg("cK6bYHf-Q5E", noop_self, "sceJsonInitializer::ctor");
+    reg("Cxwy7wHq4J0", noop_zero, "sceJsonInitializer::initializeV1");
+    reg("00oCq0RwSAY", noop_zero, "sceJsonInitializer::setGlobalNullAccessCallback");
+    reg("S5JxQnoGF3E", parse, "sceJsonParser::parse");
+    reg("HwDt5lD9Bfo", index_string, "sceJsonValue::indexString");
+    reg("clF7J7N9xXE", index_wrapped_string, "sceJsonValue::indexStringObject");
+    reg("MsMOdxWfbwQ", refer_wrapped_string, "sceJsonValue::getValueString");
+    reg("wLsJlmgEIaI", refer_wrapped_string, "sceJsonValue::referValueString");
+    reg("XlWbvieLj2M", index_uint, "sceJsonValue::indexUInt");
+    reg("0YqYAoO-+Uo", refer_uint, "sceJsonValue::getValueUInt");
+    reg("gLzCc67aTbw", refer_uint, "sceJsonValue::referValueUInt");
+    reg("SHtAad20YYM", get_type, "sceJsonValue::getType");
+    reg("zTwZdI8AZ5Y", get_boolean, "sceJsonValue::getBoolean");
+    reg("DIxvoy7Ngvk", get_integer, "sceJsonValue::getInteger");
+    reg("sn4HNCtNRzY", get_unsigned, "sceJsonValue::getUInteger");
+    reg("3qrge7L-AU4", get_real, "sceJsonValue::getReal");
+    reg("epJ6x2LV0kU", get_string, "sceJsonValue::getString");
+    reg("ONT8As5R1ug", get_array, "sceJsonValue::getArray");
+    reg("IlsmvBtMkak", get_object, "sceJsonValue::getObject");
+    reg("RBw+4NukeGQ", count, "sceJsonValue::count");
+    reg("L1KAkYWml-M", string_cstr, "sceJsonString::c_str");
+    reg("EUH+EmT-v9E", string_length, "sceJsonString::length");
+    reg("Ncel8t2Rrpc", value_to_string, "sceJsonValue::toString");
+    reg("R7FDWtcN6f8", value_to_string, "sceJsonValue::serialize");
+    reg("rQGJeNjOuUk", array_size, "sceJsonArray::size");
+}
+} // namespace prosper

--- a/prosper/src/hle/hle_json2.hpp
+++ b/prosper/src/hle/hle_json2.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace prosper {
+void register_json2_hle();
+}

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -4,12 +4,14 @@
 // game gets consistent values instead of uninitialized memory.
 // (Game-controller input — libScePad — moved to hle_pad.cpp with a real host backend.)
 #include "dispatch.hpp"
+#include "hle_json2.hpp"
 #include "nid.hpp"
 #include "callback_fs.hpp"
 #include "platform_ui.hpp"
 #include "video_backend.hpp"   // sceAvPlayer -> host hardware-decode backend (#705)
 #include "../host/posix_shim.hpp"   // Darwin process_vm_readv shim + asm portability
 #include <cinttypes>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <cstdio>
@@ -36,6 +38,11 @@
 #endif
 
 namespace prosper {
+
+#ifdef _WIN32
+extern "C" uint64_t prosper_call_guest_sysv4(uint64_t fn, uint64_t a0, uint64_t a1,
+                                               uint64_t a2, uint64_t a3);
+#endif
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
@@ -135,12 +142,19 @@ struct AvpInitData {                 // sceAvPlayerInit
     AvpMemAllocator memory; AvpFileReplace file; AvpEventReplace event;
     uint32_t debug_level; uint32_t base_priority; int32_t num_fb; uint8_t auto_start; uint8_t rsv[3]; const char* default_language;
 };
+struct AvpThreadInfo {
+    uint32_t priority, stack_size; uint64_t affinity; uint8_t reserved[32];
+};
 struct AvpInitDataEx {               // sceAvPlayerInitEx (note: this_size first)
     uint64_t this_size; AvpMemAllocator memory; AvpFileReplace file; AvpEventReplace event;
-    const char* default_language; uint32_t debug_level;
-    uint32_t a_prio,a_aff,v_prio,v_aff,d_prio,d_aff,c_prio,c_aff,h_prio,h_aff,f_prio,f_aff;
-    int32_t num_fb; uint8_t auto_start; uint8_t rsv[3];
+    const char* default_language; uint32_t debug_level; uint8_t auto_start; uint8_t rsv[3];
+    AvpThreadInfo audio_decoder, video_decoder, demuxer, event_thread, call_queue;
+    AvpThreadInfo http_command_processor, http_segment_manager, http_streamlist, file_streaming;
+    int32_t num_fb; uint8_t rsv2[4];
 };
+static_assert(sizeof(AvpThreadInfo) == 48 && sizeof(AvpInitDataEx) == 560 &&
+              offsetof(AvpInitDataEx, auto_start) == 116 &&
+              offsetof(AvpInitDataEx, num_fb) == 552, "AvPlayerInitDataEx ABI");
 struct AvpUri           { const char* name; uint32_t length; };
 struct AvpSourceDetails { AvpUri uri; uint8_t rsv1[64]; uint32_t source_type; uint8_t rsv2[44]; };
 struct AvpFrameInfo {                // sceAvPlayerGetVideoData / GetAudioData out-param
@@ -148,38 +162,105 @@ struct AvpFrameInfo {                // sceAvPlayerGetVideoData / GetAudioData o
     uint32_t d0, d1, d2, d3;         // AvPlayerStreamDetails union (16B): video={width,height,aspect,lang}
 };
 struct AvpVideoEx {                  // AvPlayerVideoEx (in the 80B details union)
-    uint32_t width, height; float aspect; uint8_t lang[4];
-    uint32_t framerate, crop_l, crop_r, crop_t, crop_b, pitch;
-    uint8_t luma_bd, chroma_bd, full_range, rsv[37];
+    uint32_t width, height; float aspect; uint8_t lang[4]; uint8_t reserved0[4];
+    uint32_t crop_l, crop_r, crop_t, crop_b, pitch;
+    uint8_t luma_bd, chroma_bd, full_range, reserved1[5];
+    double framerate; uint32_t colour_primaries, transfer_characteristics; uint8_t reserved2[16];
 };
+static_assert(sizeof(AvpVideoEx) == 80 && offsetof(AvpVideoEx, pitch) == 36 &&
+              offsetof(AvpVideoEx, framerate) == 48, "AvPlayerVideoEx ABI");
 struct AvpFrameInfoEx {              // sceAvPlayerGetVideoDataEx out-param (larger details union)
     void* p_data; uint8_t reserved[4]; uint64_t timestamp;
     union { AvpVideoEx video; uint8_t raw[80]; } details;
 };
+struct AvpVideo { uint32_t width, height; float aspect; uint8_t lang[4]; };
+struct AvpAudio { uint16_t channels; uint8_t reserved[2]; uint32_t sample_rate, size; uint8_t lang[4]; };
+struct AvpAudioEx {
+    uint16_t channels; uint8_t reserved[2]; uint32_t sample_rate, size; uint8_t lang[4];
+    uint8_t reserved1[64];
+};
+static_assert(sizeof(AvpAudio) == 16 && sizeof(AvpAudioEx) == 80, "AvPlayerAudio ABI");
+struct AvpStreamInfo {
+    uint32_t type; uint8_t reserved[4];
+    union { AvpVideo video; AvpAudio audio; uint8_t raw[16]; } details; uint64_t duration;
+};
+struct AvpStreamInfoEx {
+    uint64_t this_size; uint32_t type; uint8_t reserved[4];
+    union { AvpVideoEx video; AvpAudioEx audio; uint8_t raw[80]; } details; uint64_t duration;
+};
+static_assert(sizeof(AvpStreamInfo) == 32 && offsetof(AvpStreamInfo, duration) == 24,
+              "AvPlayerStreamInfo ABI");
+static_assert(sizeof(AvpStreamInfoEx) == 104 && offsetof(AvpStreamInfoEx, duration) == 96,
+              "AvPlayerStreamInfoEx ABI");
 
 struct AvpPlayer {
     void* ev_obj = nullptr; AvpEventCb ev_cb = nullptr;
-    bool auto_start = false, have_source = false, playing = false, stop_fired = false;
+    bool auto_start = false, have_source = false, playing = false, paused = false, stop_fired = false;
     std::string guest_path;
     int backend_id = -1;             // >=0 when a host backend is decoding
     uint32_t width = 1920, height = 1080;
-    uint64_t poll = 0;               // synthetic-timeline frame counter (headless, no backend)
+    uint64_t poll = 0;               // synthetic frames delivered through GetVideoData[Ex]
+    uint64_t audio_poll = 0;
+    uint64_t active_poll = 0;        // independent progress for IsActive-only playback loops
     std::vector<uint8_t> frame;      // synthetic black NV12 buffer (kept alive across GetVideoData)
+    std::vector<int16_t> audio;      // synthetic silent stereo PCM
 };
 std::mutex g_avp_mx;
 std::unordered_map<uint64_t, AvpPlayer> g_avp;
 
 uint64_t avp_synth_frames() { static uint64_t n = []{ const char* e = getenv("PROSPER_AVP_SYNTH_FRAMES"); return e ? strtoull(e, nullptr, 0) : 120ull; }(); return n; }
+uint64_t avp_synth_duration_ms() {
+    static uint64_t n = [] {
+        const char* e = getenv("PROSPER_AVP_DURATION_MS");
+        return e ? strtoull(e, nullptr, 0) : avp_synth_frames() * 33;
+    }();
+    return n;
+}
+bool avp_log() { static const bool enabled = getenv("PROSPER_AVPLOG") != nullptr; return enabled; }
+
+#if defined(__linux__)
+// Linux import stubs swap the guest %fs to the host TCB before entering an HLE handler.  AvPlayer
+// event callbacks go the other way and are guest code, so they must run with the caller's guest TCB.
+// The entry shims below recover that TCB from the import-stub frame and publish it only for the
+// dynamic extent of the HLE call.  Nested AvPlayer calls from the callback preserve the outer value.
+thread_local uint64_t t_avp_callback_guest_fs = 0;
+struct AvpEntryGuestFsScope {
+    uint64_t previous;
+    explicit AvpEntryGuestFsScope(uint64_t guest_fs)
+        : previous(t_avp_callback_guest_fs) { t_avp_callback_guest_fs = guest_fs; }
+    ~AvpEntryGuestFsScope() { t_avp_callback_guest_fs = previous; }
+};
+struct AvpCallbackGuestFsScope {
+    uint64_t saved = 0;
+    bool active = false;
+    explicit AvpCallbackGuestFsScope(uint64_t guest_fs) {
+        if (guest_fs) {
+            __asm__ volatile("rdfsbase %0" : "=r"(saved));
+            __asm__ volatile("wrfsbase %0" : : "r"(guest_fs));
+            active = true;
+        }
+    }
+    ~AvpCallbackGuestFsScope() {
+        if (active) __asm__ volatile("wrfsbase %0" : : "r"(saved));
+    }
+};
+#endif
 
 // Fire the guest event callback. Caller MUST NOT hold g_avp_mx (the callback re-enters AvPlayer HLE).
 void avp_fire(void* obj, AvpEventCb cb, uint32_t ev) {
     if (!cb) return;
-    if (svclog()) fprintf(stderr, "[avp] -> event 0x%02x\n", ev);
+    if (svclog() || avp_log()) fprintf(stderr, "[avp] -> event 0x%02x\n", ev);
 #if defined(_WIN32)
-    // TODO(#705): Windows host ABI != guest SysV; route through a 4-arg prosper_call_guest_sysv
-    // trampoline. Milestone 1 targets Linux headless; the direct call is correct there.
-#endif
+    prosper_call_guest_sysv4((uint64_t)(uintptr_t)cb, (uint64_t)(uintptr_t)obj, ev, 0, 0);
+#elif defined(__linux__)
+    {
+        AvpCallbackGuestFsScope guest_fs(t_avp_callback_guest_fs);
+        cb(obj, ev, 0, nullptr);
+    }
+#else
     cb(obj, ev, 0, nullptr);
+#endif
+    if (avp_log()) fprintf(stderr, "[avp] <- event 0x%02x\n", ev);
 }
 } // namespace
 
@@ -211,10 +292,11 @@ HLE(s_avplayer_isactive) {   // bool sceAvPlayerIsActive(AvPlayerHandle)
         auto it = g_avp.find(a0); if (it == g_avp.end()) return 0;
         AvpPlayer& p = it->second;
         if (p.playing) {
-            p.poll++;
+            if (p.paused) return 1;
+            p.active_poll++;
             bool still = (p.backend_id >= 0 && prosper::video::backend())
                              ? !prosper::video::backend()->eof(p.backend_id)
-                             : (p.poll < avp_synth_frames());
+                             : (p.active_poll < avp_synth_frames());
             if (still) { active = 1; }
             else if (!p.stop_fired) { p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb; }
         }
@@ -224,6 +306,52 @@ HLE(s_avplayer_isactive) {   // bool sceAvPlayerIsActive(AvPlayerHandle)
 }
 HLE(s_avp_postinit)   { svc_log("sceAvPlayerPostInit", a0,a1,a2,a3,a4,a5); return 0; }
 HLE(s_avp_setlogcb)   { svc_log("sceAvPlayerSetLogCallback", a0,a1,a2,a3,a4,a5); return 0; }
+HLE(s_avp_streamcount) {   // s32 sceAvPlayerStreamCount(handle)
+    svc_log("sceAvPlayerStreamCount", a0,a1,a2,a3,a4,a5);
+    std::lock_guard<std::mutex> lk(g_avp_mx);
+    auto it = g_avp.find(a0);
+    int count = it != g_avp.end() && it->second.have_source ? 2 : 0;
+    if (avp_log()) fprintf(stderr, "[avp] stream-count handle=0x%llx -> %d\n",
+                           (unsigned long long)a0, count);
+    return count; // MP4-shaped synthetic source: video + audio
+}
+HLE(s_avp_getstreaminfo) { // s32 sceAvPlayerGetStreamInfo(handle, stream_id, out)
+    svc_log("sceAvPlayerGetStreamInfo", a0,a1,a2,a3,a4,a5);
+    auto* out = (AvpStreamInfo*)PW(a2); if (!out || a1 > 1) return 0x806a0001ull;
+    std::lock_guard<std::mutex> lk(g_avp_mx);
+    auto it = g_avp.find(a0); if (it == g_avp.end() || !it->second.have_source) return 0x806a0001ull;
+    const AvpPlayer& p = it->second;
+    *out = {}; out->type = a1 == 0 ? 1u : 2u;
+    if (a1 == 0) {
+        out->details.video.width = p.width; out->details.video.height = p.height;
+        out->details.video.aspect = (float)p.width / (float)p.height;
+    } else {
+        out->details.audio.channels = 2; out->details.audio.sample_rate = 48000;
+        out->details.audio.size = 1024 * 2 * sizeof(int16_t);
+    }
+    out->duration = avp_synth_duration_ms();
+    return 0;
+}
+HLE(s_avp_getstreaminfoex) { // s32 sceAvPlayerGetStreamInfoEx(handle, stream_id, out)
+    svc_log("sceAvPlayerGetStreamInfoEx", a0,a1,a2,a3,a4,a5);
+    auto* out = (AvpStreamInfoEx*)PW(a2); if (!out || a1 > 1) return 0x806a0001ull;
+    std::lock_guard<std::mutex> lk(g_avp_mx);
+    auto it = g_avp.find(a0); if (it == g_avp.end() || !it->second.have_source) return 0x806a0001ull;
+    const AvpPlayer& p = it->second; const uint64_t caller_size = out->this_size;
+    *out = {}; out->this_size = caller_size; out->type = a1 == 0 ? 1u : 2u;
+    if (a1 == 0) {
+        out->details.video.width = p.width; out->details.video.height = p.height;
+        out->details.video.aspect = (float)p.width / (float)p.height; out->details.video.pitch = p.width;
+        out->details.video.luma_bd = 8; out->details.video.chroma_bd = 8;
+        out->details.video.framerate = 30.0;
+    } else {
+        out->details.audio.channels = 2; out->details.audio.sample_rate = 48000;
+        out->details.audio.size = 1024 * 2 * sizeof(int16_t);
+    }
+    out->duration = avp_synth_duration_ms();
+    return 0;
+}
+HLE(s_avp_stream_ok) { svc_log("sceAvPlayerStreamControl", a0,a1,a2,a3,a4,a5); return 0; }
 // Begin a source: resolve/open it, fire READY, and (auto_start) begin playback with PLAY.
 static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
     void* obj = nullptr; AvpEventCb cb = nullptr; bool ready = false, play = false;
@@ -233,12 +361,15 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
         AvpPlayer& p = it->second;
         if (guest_path) p.guest_path = guest_path;
         p.have_source = true;
+        p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.paused = false; p.stop_fired = false;
         if (auto* b = prosper::video::backend()) p.backend_id = b->open(p.guest_path);  // TODO(#705): guest->host path resolve for real backend
         obj = p.ev_obj; cb = p.ev_cb; ready = true;
         if (p.auto_start) { p.playing = true; play = true; }
     }
     if (ready) avp_fire(obj, cb, AVP_READY);
     if (play)  avp_fire(obj, cb, AVP_PLAY);
+    if (avp_log()) fprintf(stderr, "[avp] add source handle=0x%llx path=%s auto_start=%d\n",
+                           (unsigned long long)handle, guest_path ? guest_path : "", (int)play);
     return 0;
 }
 HLE(s_avp_addsource)   {   // s32 sceAvPlayerAddSource(handle, const char* filename)
@@ -258,64 +389,144 @@ HLE(s_avp_start) {   // s32 sceAvPlayerStart(handle) — used when auto_start is
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0); if (it == g_avp.end()) return 0x80000000ull;
         AvpPlayer& p = it->second;
-        if (p.have_source && !p.playing && !p.stop_fired) { p.playing = true; play = true; obj = p.ev_obj; cb = p.ev_cb; }
+        if (p.have_source && !p.playing && !p.stop_fired) {
+            p.playing = true; p.paused = false; play = true; obj = p.ev_obj; cb = p.ev_cb;
+        }
     }
     if (play) avp_fire(obj, cb, AVP_PLAY);
+    return 0;
+}
+HLE(s_avp_pause) {   // s32 sceAvPlayerPause(handle)
+    svc_log("sceAvPlayerPause", a0,a1,a2,a3,a4,a5);
+    void* obj = nullptr; AvpEventCb cb = nullptr; bool notify = false;
+    {
+        std::lock_guard<std::mutex> lk(g_avp_mx);
+        auto it = g_avp.find(a0); if (it == g_avp.end()) return 0x806a0001ull;
+        if (it->second.playing && !it->second.paused) {
+            it->second.paused = true;
+            obj = it->second.ev_obj; cb = it->second.ev_cb; notify = true;
+        }
+    }
+    if (notify) avp_fire(obj, cb, AVP_PAUSE);
+    return 0;
+}
+HLE(s_avp_resume) {   // s32 sceAvPlayerResume(handle)
+    svc_log("sceAvPlayerResume", a0,a1,a2,a3,a4,a5);
+    void* obj = nullptr; AvpEventCb cb = nullptr; bool notify = false;
+    {
+        std::lock_guard<std::mutex> lk(g_avp_mx);
+        auto it = g_avp.find(a0); if (it == g_avp.end()) return 0x806a0001ull;
+        if (it->second.playing && it->second.paused) {
+            it->second.paused = false;
+            obj = it->second.ev_obj; cb = it->second.ev_cb; notify = true;
+        }
+    }
+    if (notify) avp_fire(obj, cb, AVP_PLAY);
     return 0;
 }
 // bool sceAvPlayerGetVideoData(handle, AvPlayerFrameInfo*) — deliver the next decoded frame (NV12).
 HLE(s_avp_getvideodata) {
     svc_log("sceAvPlayerGetVideoData", a0,a1,a2,a3,a4,a5);
     auto* fi = (AvpFrameInfo*)PW(a1); if (!fi) return 0;
-    std::lock_guard<std::mutex> lk(g_avp_mx);
-    auto it = g_avp.find(a0); if (it == g_avp.end() || !it->second.playing) return 0;
-    AvpPlayer& p = it->second;
-    if (auto* b = prosper::video::backend(); b && p.backend_id >= 0) {
-        prosper::video::VideoFrame vf;
-        if (!b->next_video(p.backend_id, vf)) return 0;
-        fi->p_data = const_cast<uint8_t*>(vf.y); fi->timestamp = vf.pts_us * 1000;
-        fi->d0 = vf.width; fi->d1 = vf.height; fi->d2 = 0; fi->d3 = 0;
-        return 1;
+    void* obj = nullptr; AvpEventCb cb = nullptr; bool fire_stop = false; uint64_t result = 0;
+    {
+        std::lock_guard<std::mutex> lk(g_avp_mx);
+        auto it = g_avp.find(a0);
+        if (it == g_avp.end() || !it->second.playing || it->second.paused) return 0;
+        AvpPlayer& p = it->second;
+        if (auto* b = prosper::video::backend(); b && p.backend_id >= 0) {
+            prosper::video::VideoFrame vf;
+            if (b->next_video(p.backend_id, vf)) {
+                fi->p_data = const_cast<uint8_t*>(vf.y); fi->timestamp = vf.pts_us / 1000;
+                fi->d0 = vf.width; fi->d1 = vf.height; fi->d2 = 0; fi->d3 = 0;
+                result = 1;
+            } else if (b->eof(p.backend_id) && !p.stop_fired) {
+                p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
+            }
+        } else if (p.poll < avp_synth_frames()) {
+            // Synthetic (headless): a black NV12 frame at the default dimensions.  Advance on
+            // frame delivery: Astro Bot never polls IsActive, so an IsActive-only counter made EOF
+            // and the STOP event unreachable even though it continuously pulled video frames.
+            size_t need = (size_t)p.width * p.height * 3 / 2;
+            if (p.frame.size() != need) p.frame.assign(need, 0);
+            fi->p_data = p.frame.data(); fi->timestamp = p.poll * 33ull; // ~30fps PTS (ms)
+            fi->d0 = p.width; fi->d1 = p.height; fi->d2 = 0; fi->d3 = 0;
+            p.poll++; result = 1;
+        } else if (!p.stop_fired) {
+            p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
+        }
     }
-    // Synthetic (headless): a black NV12 frame at the default dimensions.
-    size_t need = (size_t)p.width * p.height * 3 / 2;
-    if (p.frame.size() != need) p.frame.assign(need, 0);
-    fi->p_data = p.frame.data(); fi->timestamp = p.poll * 33'000'000ull;   // ~30fps pts (ns)
-    fi->d0 = p.width; fi->d1 = p.height; fi->d2 = 0; fi->d3 = 0;
-    return 1;
+    if (fire_stop) avp_fire(obj, cb, AVP_STOP);
+    if (avp_log()) fprintf(stderr, "[avp] video handle=0x%llx result=%llu stop=%d\n",
+                           (unsigned long long)a0, (unsigned long long)result, (int)fire_stop);
+    return result;
 }
 // bool sceAvPlayerGetVideoDataEx(handle, AvPlayerFrameInfoEx*) — the game uses this Ex variant.
 HLE(s_avp_getvideodataex) {
     svc_log("sceAvPlayerGetVideoDataEx", a0,a1,a2,a3,a4,a5);
     auto* fi = (AvpFrameInfoEx*)PW(a1); if (!fi) return 0;
-    std::lock_guard<std::mutex> lk(g_avp_mx);
-    auto it = g_avp.find(a0); if (it == g_avp.end() || !it->second.playing) return 0;
-    AvpPlayer& p = it->second;
-    if (auto* b = prosper::video::backend(); b && p.backend_id >= 0) {
-        prosper::video::VideoFrame vf;
-        if (!b->next_video(p.backend_id, vf)) return 0;
-        fi->p_data = const_cast<uint8_t*>(vf.y); fi->timestamp = vf.pts_us * 1000;
-        fi->details.video = {}; fi->details.video.width = vf.width; fi->details.video.height = vf.height;
-        fi->details.video.pitch = vf.y_stride ? vf.y_stride : vf.width; fi->details.video.framerate = 30;
-        return 1;
+    void* obj = nullptr; AvpEventCb cb = nullptr; bool fire_stop = false; uint64_t result = 0;
+    {
+        std::lock_guard<std::mutex> lk(g_avp_mx);
+        auto it = g_avp.find(a0);
+        if (it == g_avp.end() || !it->second.playing || it->second.paused) return 0;
+        AvpPlayer& p = it->second;
+        if (auto* b = prosper::video::backend(); b && p.backend_id >= 0) {
+            prosper::video::VideoFrame vf;
+            if (b->next_video(p.backend_id, vf)) {
+                fi->p_data = const_cast<uint8_t*>(vf.y); fi->timestamp = vf.pts_us / 1000;
+                fi->details.video = {}; fi->details.video.width = vf.width; fi->details.video.height = vf.height;
+                fi->details.video.aspect = vf.height ? (float)vf.width / (float)vf.height : 0.0f;
+                fi->details.video.pitch = vf.y_stride ? vf.y_stride : vf.width;
+                fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
+                fi->details.video.framerate = 30.0;
+                result = 1;
+            } else if (b->eof(p.backend_id) && !p.stop_fired) {
+                p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
+            }
+        } else if (p.poll < avp_synth_frames()) {
+            size_t need = (size_t)p.width * p.height * 3 / 2;        // synthetic black NV12
+            if (p.frame.size() != need) p.frame.assign(need, 0);
+            fi->p_data = p.frame.data(); fi->timestamp = p.poll * 33ull;
+            fi->details.video = {}; fi->details.video.width = p.width; fi->details.video.height = p.height;
+            fi->details.video.aspect = (float)p.width / (float)p.height; fi->details.video.pitch = p.width;
+            fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
+            fi->details.video.framerate = 30.0;
+            p.poll++; result = 1;
+        } else if (!p.stop_fired) {
+            p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
+        }
     }
-    size_t need = (size_t)p.width * p.height * 3 / 2;        // synthetic black NV12
-    if (p.frame.size() != need) p.frame.assign(need, 0);
-    fi->p_data = p.frame.data(); fi->timestamp = p.poll * 33'000'000ull;
-    fi->details.video = {}; fi->details.video.width = p.width; fi->details.video.height = p.height;
-    fi->details.video.pitch = p.width; fi->details.video.framerate = 30;
-    return 1;
+    if (fire_stop) avp_fire(obj, cb, AVP_STOP);
+    if (avp_log()) fprintf(stderr, "[avp] video-ex handle=0x%llx result=%llu stop=%d\n",
+                           (unsigned long long)a0, (unsigned long long)result, (int)fire_stop);
+    return result;
 }
 HLE(s_avp_getaudiodata)   {   // bool sceAvPlayerGetAudioData(handle, AvPlayerFrameInfo*)
     svc_log("sceAvPlayerGetAudioData", a0,a1,a2,a3,a4,a5);
     auto* b = prosper::video::backend();
-    if (!b) return 0;   // synthetic: no audio frames (silent intro); playback still ends via IsActive
     std::lock_guard<std::mutex> lk(g_avp_mx);
-    auto it = g_avp.find(a0); if (it == g_avp.end() || it->second.backend_id < 0 || !it->second.playing) return 0;
+    auto it = g_avp.find(a0);
+    if (it == g_avp.end() || !it->second.playing || it->second.paused) return 0;
     auto* fi = (AvpFrameInfo*)PW(a1); if (!fi) return 0;
-    prosper::video::AudioFrame af;
-    if (!b->next_audio(it->second.backend_id, af)) return 0;
-    fi->p_data = (uint8_t*)const_cast<int16_t*>(af.pcm); fi->timestamp = af.pts_us * 1000; return 1;
+    AvpPlayer& p = it->second;
+    if (b && p.backend_id >= 0) {
+        prosper::video::AudioFrame af;
+        if (!b->next_audio(p.backend_id, af)) return 0;
+        fi->p_data = (uint8_t*)const_cast<int16_t*>(af.pcm); fi->timestamp = af.pts_us / 1000;
+        return 1;
+    }
+    if (p.audio_poll >= avp_synth_frames()) return 0;
+    constexpr uint32_t samples = 1024, channels = 2;
+    if (p.audio.size() != samples * channels) p.audio.assign(samples * channels, 0);
+    fi->p_data = (uint8_t*)p.audio.data();
+    fi->timestamp = p.audio_poll * 21ull; // 1024/48 kHz, milliseconds
+    AvpAudio details{2, {}, 48000, samples * channels * sizeof(int16_t), {}};
+    memcpy(&fi->d0, &details, sizeof(details));
+    p.audio_poll++;
+    if (avp_log()) fprintf(stderr, "[avp] audio handle=0x%llx result=1 poll=%llu\n",
+                           (unsigned long long)a0, (unsigned long long)p.audio_poll);
+    return 1;
 }
 HLE(s_avp_stop) {   // s32 sceAvPlayerStop(handle)
     svc_log("sceAvPlayerStop", a0,a1,a2,a3,a4,a5);
@@ -324,7 +535,10 @@ HLE(s_avp_stop) {   // s32 sceAvPlayerStop(handle)
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0); if (it == g_avp.end()) return 0;
         AvpPlayer& p = it->second;
-        if (p.playing && !p.stop_fired) { p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb; }
+        if (p.playing && !p.stop_fired) {
+            p.playing = false; p.paused = false; p.stop_fired = true;
+            fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
+        }
     }
     if (fire_stop) avp_fire(obj, cb, AVP_STOP);
     return 0;
@@ -339,6 +553,48 @@ HLE(s_avp_close) {   // s32 sceAvPlayerClose(handle)
     }
     return 0;
 }
+
+#ifndef _WIN32
+// Pass the HLE-entry stack pointer to callback-producing AvPlayer handlers.  On Linux it identifies
+// the guest TCB saved by the import stub; on macOS callback_guest_fs_from_entry_stack() fails closed
+// to zero because guest TLS uses trap emulation rather than a hardware %fs switch.
+#define AVP_CALLBACK_ENTRY(entry, target, handler) \
+    extern "C" uint64_t target(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t); \
+    PROSPER_ASM_TRAMPOLINE(entry, target) \
+    extern "C" void entry(); \
+    extern "C" uint64_t target(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, \
+                                uint64_t a4, uint64_t a5, uint64_t entry_rsp) { \
+        const uint64_t guest_fs = callback_guest_fs_from_entry_stack(entry_rsp); \
+        if (avp_log() && guest_fs) { \
+            const uint64_t guest_ra = *(const uint64_t*)(uintptr_t)(entry_rsp + 0x30); \
+            fprintf(stderr, "[avp] call %s guest_ra=0x%llx guest_fs=1\n", #handler, \
+                    (unsigned long long)guest_ra); \
+        } \
+        (void)guest_fs; \
+        /* Only Linux swaps hardware %fs at the import boundary. */ \
+        PROSPER_AVP_ENTRY_SCOPE(guest_fs) \
+        return handler(a0, a1, a2, a3, a4, a5); \
+    }
+
+#if defined(__linux__)
+#define PROSPER_AVP_ENTRY_SCOPE(guest_fs) AvpEntryGuestFsScope avp_entry_guest_fs_scope(guest_fs);
+#else
+#define PROSPER_AVP_ENTRY_SCOPE(guest_fs)
+#endif
+
+AVP_CALLBACK_ENTRY(s_avp_addsource_entry, s_avp_addsource_entry_c, s_avp_addsource)
+AVP_CALLBACK_ENTRY(s_avp_addsourceex_entry, s_avp_addsourceex_entry_c, s_avp_addsourceex)
+AVP_CALLBACK_ENTRY(s_avp_start_entry, s_avp_start_entry_c, s_avp_start)
+AVP_CALLBACK_ENTRY(s_avplayer_isactive_entry, s_avplayer_isactive_entry_c, s_avplayer_isactive)
+AVP_CALLBACK_ENTRY(s_avp_getvideodata_entry, s_avp_getvideodata_entry_c, s_avp_getvideodata)
+AVP_CALLBACK_ENTRY(s_avp_getvideodataex_entry, s_avp_getvideodataex_entry_c, s_avp_getvideodataex)
+AVP_CALLBACK_ENTRY(s_avp_stop_entry, s_avp_stop_entry_c, s_avp_stop)
+AVP_CALLBACK_ENTRY(s_avp_pause_entry, s_avp_pause_entry_c, s_avp_pause)
+AVP_CALLBACK_ENTRY(s_avp_resume_entry, s_avp_resume_entry_c, s_avp_resume)
+
+#undef PROSPER_AVP_ENTRY_SCOPE
+#undef AVP_CALLBACK_ENTRY
+#endif
 // sceUserServiceGetGamePresets(userId, presets): MUST return success (0). The Unity engine's
 // per-controller connection check (eboot 0x14707e0, reached from the pad "reset" path 0x1470ca0)
 // calls this and treats ANY non-zero user-service return as "controller invalid" — it then clears the
@@ -1305,6 +1561,7 @@ HLE(s_syss_noticeskip) {
 }
 
 void register_service_hle() {
+    register_json2_hle();
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
 #ifndef _WIN32
     // NetCtl offline-console state delivery — default ON since #306 (see block comment above).
@@ -1427,15 +1684,46 @@ void register_service_hle() {
     R("sceAvPlayerInitEx",         s_avplayer_initex);
     R("sceAvPlayerPostInit",       s_avp_postinit);
     R("sceAvPlayerSetLogCallback", s_avp_setlogcb);
+#ifdef _WIN32
     R("sceAvPlayerAddSource",      s_avp_addsource);
     R("sceAvPlayerAddSourceEx",    s_avp_addsourceex);
     R("sceAvPlayerStart",          s_avp_start);
     R("sceAvPlayerIsActive",       s_avplayer_isactive);
     R("sceAvPlayerGetVideoData",   s_avp_getvideodata);
     R("sceAvPlayerGetVideoDataEx", s_avp_getvideodataex);
+#else
+    R("sceAvPlayerAddSource",      s_avp_addsource_entry);
+    R("sceAvPlayerAddSourceEx",    s_avp_addsourceex_entry);
+    R("sceAvPlayerStart",          s_avp_start_entry);
+    R("sceAvPlayerIsActive",       s_avplayer_isactive_entry);
+    R("sceAvPlayerGetVideoData",   s_avp_getvideodata_entry);
+    R("sceAvPlayerGetVideoDataEx", s_avp_getvideodataex_entry);
+#endif
     R("sceAvPlayerGetAudioData",   s_avp_getaudiodata);
+#ifdef _WIN32
     R("sceAvPlayerStop",           s_avp_stop);
+#else
+    R("sceAvPlayerStop",           s_avp_stop_entry);
+#endif
     R("sceAvPlayerClose",          s_avp_close);
+    // PS5 raw NIDs verified against the 3.20 import stubs. Astro Bot enumerates streams before it
+    // consumes GetVideoDataEx; returning the generic unresolved-import zero meant "no streams" and
+    // left its logo movie state machine permanently resident even after synthetic EOF.
+    Hle::register_fn("hdTyRzCXQeQ", (HleFn)s_avp_streamcount,   "sceAvPlayerStreamCount");
+    Hle::register_fn("d8FcbzfAdQw", (HleFn)s_avp_getstreaminfo, "sceAvPlayerGetStreamInfo");
+    Hle::register_fn("ctTAcF5DiKQ", (HleFn)s_avp_getstreaminfoex, "sceAvPlayerGetStreamInfoEx");
+    Hle::register_fn("ODJK2sn9w4A", (HleFn)s_avp_stream_ok, "sceAvPlayerEnableStream");
+    Hle::register_fn("BOVKAzRmuTQ", (HleFn)s_avp_stream_ok, "sceAvPlayerDisableStream");
+    Hle::register_fn("buMCiJftcfw", (HleFn)s_avp_stream_ok, "sceAvPlayerChangeStream");
+#ifdef _WIN32
+    Hle::register_fn("9y5v+fGN4Wk", (HleFn)s_avp_pause, "sceAvPlayerPause");
+    Hle::register_fn("w5moABNwnRY", (HleFn)s_avp_resume, "sceAvPlayerResume");
+#else
+    Hle::register_fn("9y5v+fGN4Wk", (HleFn)s_avp_pause_entry, "sceAvPlayerPause");
+    Hle::register_fn("w5moABNwnRY", (HleFn)s_avp_resume_entry, "sceAvPlayerResume");
+#endif
+    Hle::register_fn("k-q+xOxdc3E", (HleFn)s_avp_stream_ok, "sceAvPlayerSetAvSyncMode");
+    Hle::register_fn("OVths0xGfho", (HleFn)s_avp_stream_ok, "sceAvPlayerSetLooping");
     R("sceSystemServiceGetStatus", s_syss_getstatus);
     R("sceSystemServiceReceiveEvent", s_sysservice_receiveevent);   // NO_EVENT, don't leave the struct garbage
     // sceSystemServiceGetDisplaySafeAreaInfo (1n37q1Bvc5Y) — fill ratio=1.0 (see s_syss_safearea).

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -46,6 +46,8 @@
 // guest's rax. run_entry does the equivalent inline (it jmp's and never returns); this is the
 // call-and-return path used for the init/module_start functions.
 extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t argc, uint64_t argp);
+extern "C" uint64_t prosper_call_guest_sysv4(uint64_t fn, uint64_t a0, uint64_t a1,
+                                               uint64_t a2, uint64_t a3);
 __asm__(
     ".text\n"
     ".p2align 4\n"
@@ -69,6 +71,54 @@ __asm__(
     "    movq  %rcx, %rax\n"           // MS x64: rcx=fn, rdx=argc, r8=argp
     "    movq  %rdx, %rdi\n"           // argc -> SysV arg0
     "    movq  %r8,  %rsi\n"           // argp -> SysV arg1
+    "    callq *%rax\n"
+    "    movaps    0(%rsp), %xmm6\n"
+    "    movaps   16(%rsp), %xmm7\n"
+    "    movaps   32(%rsp), %xmm8\n"
+    "    movaps   48(%rsp), %xmm9\n"
+    "    movaps   64(%rsp), %xmm10\n"
+    "    movaps   80(%rsp), %xmm11\n"
+    "    movaps   96(%rsp), %xmm12\n"
+    "    movaps  112(%rsp), %xmm13\n"
+    "    movaps  128(%rsp), %xmm14\n"
+    "    movaps  144(%rsp), %xmm15\n"
+    "    addq  $176, %rsp\n"
+    "    popq  %rdi\n"
+    "    popq  %rsi\n"
+    "    popq  %rbp\n"
+    "    retq\n"
+);
+
+// Four-argument host->guest bridge used by registered Sony callbacks.  Microsoft x64 passes
+// fn/a0/a1/a2 in rcx/rdx/r8/r9 and a3 at [entry-rsp+0x28]; the PS5 callback reads the four payload
+// arguments from rdi/rsi/rdx/rcx.  Preserve every register that is nonvolatile to the Windows caller
+// but volatile to a SysV callee, exactly as the two-argument module-init bridge above does.
+__asm__(
+    ".text\n"
+    ".p2align 4\n"
+    ".globl prosper_call_guest_sysv4\n"
+    "prosper_call_guest_sysv4:\n"
+    "    pushq %rbp\n"
+    "    movq  %rsp, %rbp\n"
+    "    pushq %rsi\n"
+    "    pushq %rdi\n"
+    "    subq  $176, %rsp\n"
+    "    movaps %xmm6,    0(%rsp)\n"
+    "    movaps %xmm7,   16(%rsp)\n"
+    "    movaps %xmm8,   32(%rsp)\n"
+    "    movaps %xmm9,   48(%rsp)\n"
+    "    movaps %xmm10,  64(%rsp)\n"
+    "    movaps %xmm11,  80(%rsp)\n"
+    "    movaps %xmm12,  96(%rsp)\n"
+    "    movaps %xmm13, 112(%rsp)\n"
+    "    movaps %xmm14, 128(%rsp)\n"
+    "    movaps %xmm15, 144(%rsp)\n"
+    "    movq  %rcx, %rax\n"           // callback address
+    "    movq  %r9,  %r10\n"           // save a2 before r9 is reused
+    "    movq  %rdx, %rdi\n"           // a0 -> SysV rdi
+    "    movq  %r8,  %rsi\n"           // a1 -> SysV rsi
+    "    movq  %r10, %rdx\n"           // a2 -> SysV rdx
+    "    movq  48(%rbp), %rcx\n"       // a3 -> SysV rcx (5th MS argument)
     "    callq *%rax\n"
     "    movaps    0(%rsp), %xmm6\n"
     "    movaps   16(%rsp), %xmm7\n"

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -3,17 +3,57 @@
 // result. sceAvPlayerInit RETURNS the handle; sceAvPlayerInitEx returns an int32 error code (0 = success)
 // and WRITES the handle to its out-param. Registering InitEx to the return-the-handle handler made
 // PPSA02664's PS5VideoPlayback wrapper read a non-zero handle as an error code and abort the intro video
-// ("[PS5VideoPlayback] ERROR: sceAvPlayerInitEx() failed"). This locks the InitEx out-param contract.
+// ("[PS5VideoPlayback] ERROR: sceAvPlayerInitEx() failed"). Astro Bot also pulls frames without ever
+// polling IsActive, so synthetic EOF must be driven by GetVideoData[Ex] and fire STOP outside the
+// player mutex. This locks both contracts.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 using namespace prosper;
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
+
+struct AvpInitData {
+    struct { void* obj; void* allocate; void* deallocate; void* allocate_texture; void* deallocate_texture; } memory{};
+    struct { void* obj; void* open; void* close; void* read_offset; void* size; } file{};
+    struct { void* obj; void* event_callback; } event{};
+    uint32_t debug_level = 0, base_priority = 0; int32_t num_fb = 0; uint8_t auto_start = 0, reserved[3]{};
+    const char* default_language = nullptr;
+};
+struct AvpFrameInfoEx {
+    void* data = nullptr; uint8_t reserved[4]{}; uint64_t timestamp = 0; uint8_t details[80]{};
+};
+static_assert(offsetof(AvpFrameInfoEx, details) == 24, "AvPlayerFrameInfoEx ABI");
+
+static uint32_t events[8]{};
+static int event_count = 0;
+#ifdef _WIN32
+extern "C" void on_avplayer_event_host(uint32_t event) {
+    if (event_count < 8) events[event_count++] = event;
+}
+extern "C" void on_avplayer_event();
+// Production callbacks are guest SysV functions even in a Windows build.  Keep the test honest by
+// accepting event in SysV RSI, then bridge the one value into a normal Microsoft-x64 C++ helper.
+__asm__(
+    ".text\n"
+    ".globl on_avplayer_event\n"
+    "on_avplayer_event:\n"
+    "  movl %esi, %ecx\n"
+    "  subq $40, %rsp\n"
+    "  callq on_avplayer_event_host\n"
+    "  addq $40, %rsp\n"
+    "  retq\n");
+#else
+static void PROSPER_SYSV_ABI on_avplayer_event(void*, uint32_t event, int32_t, void*) {
+    if (event_count < 8) events[event_count++] = event;
+}
+#endif
 
 int main() {
     printf("== test_avplayer ==\n");
@@ -22,8 +62,19 @@ int main() {
     HleFn init   = Hle::lookup(nid_hash("sceAvPlayerInit"));
     HleFn initex = Hle::lookup(nid_hash("sceAvPlayerInitEx"));
     HleFn active = Hle::lookup(nid_hash("sceAvPlayerIsActive"));
-    CHECK(init && initex && active, "AvPlayer Init/InitEx/IsActive registered");
-    if (!(init && initex && active)) { printf("== FAIL ==\n"); return 1; }
+    HleFn add    = Hle::lookup(nid_hash("sceAvPlayerAddSource"));
+    HleFn start  = Hle::lookup(nid_hash("sceAvPlayerStart"));
+    HleFn video  = Hle::lookup(nid_hash("sceAvPlayerGetVideoDataEx"));
+    HleFn audio  = Hle::lookup(nid_hash("sceAvPlayerGetAudioData"));
+    HleFn streams = Hle::lookup("hdTyRzCXQeQ");
+    HleFn infoex  = Hle::lookup("ctTAcF5DiKQ");
+    HleFn pause   = Hle::lookup("9y5v+fGN4Wk");
+    HleFn resume  = Hle::lookup("w5moABNwnRY");
+    CHECK(init && initex && active && add && start && video && audio && streams && infoex && pause && resume,
+          "AvPlayer lifecycle and stream functions registered");
+    if (!(init && initex && active && add && start && video && audio && streams && infoex && pause && resume)) {
+        printf("== FAIL ==\n"); return 1;
+    }
 
     // sceAvPlayerInit(data) -> handle (the RETURN value is the handle; non-NULL so the game proceeds).
     uint64_t h1 = init(0, 0, 0, 0, 0, 0);
@@ -38,6 +89,54 @@ int main() {
 
     // IsActive must report "not active" so the game's while(IsActive) playback loop ends and it advances.
     CHECK(active(out, 0, 0, 0, 0, 0) == 0, "sceAvPlayerIsActive -> 0 (finished, proceed)");
+
+    // One delivered synthetic frame, then EOF on the next pull. Astro Bot follows this path and does
+    // not call IsActive. The STOP callback re-enters no HLE here, but the production callback may do
+    // so, therefore GetVideoDataEx must release the player mutex before firing it.
+#ifdef _WIN32
+    _putenv_s("PROSPER_AVP_SYNTH_FRAMES", "1");
+#else
+    setenv("PROSPER_AVP_SYNTH_FRAMES", "1", 1);
+#endif
+    AvpInitData data{};
+    data.event.event_callback = (void*)&on_avplayer_event;
+    uint64_t h2 = init((uint64_t)(uintptr_t)&data, 0, 0, 0, 0, 0);
+    const char source[] = "/app0/test.mp4";
+    CHECK(add(h2, (uint64_t)(uintptr_t)source, 0, 0, 0, 0) == 0, "sceAvPlayerAddSource succeeds");
+    CHECK(streams(h2, 0, 0, 0, 0, 0) == 2, "synthetic MP4 source enumerates video and audio streams");
+    struct StreamInfoEx { uint64_t size; uint32_t type; uint8_t reserved[4]; uint8_t details[80]; uint64_t duration; } info{};
+    info.size = sizeof(info);
+    CHECK(infoex(h2, 0, (uint64_t)(uintptr_t)&info, 0, 0, 0) == 0 && info.size == sizeof(info) &&
+          info.type == 1 && info.duration == 33, "synthetic stream metadata is valid and size-preserving");
+    info = {}; info.size = sizeof(info);
+    CHECK(infoex(h2, 1, (uint64_t)(uintptr_t)&info, 0, 0, 0) == 0 && info.type == 2,
+          "synthetic audio stream metadata is enumerated");
+    CHECK(start(h2, 0, 0, 0, 0, 0) == 0, "sceAvPlayerStart succeeds");
+    CHECK(event_count == 2 && events[0] == 2 && events[1] == 3, "READY and PLAY callbacks fire");
+
+    AvpFrameInfoEx frame{};
+    struct AudioFrameInfo { void* data; uint8_t reserved[4]; uint64_t timestamp; uint8_t details[16]; } audio_frame{};
+    CHECK(audio(h2, (uint64_t)(uintptr_t)&audio_frame, 0, 0, 0, 0) == 1 && audio_frame.data,
+          "synthetic audio pull returns stable silent PCM");
+    CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 1, "first synthetic video pull returns a frame");
+    CHECK(frame.data != nullptr, "synthetic frame has stable storage");
+    uint32_t width = 0, height = 0, pitch = 0; double fps = 0.0;
+    memcpy(&width, frame.details + 0, sizeof(width));
+    memcpy(&height, frame.details + 4, sizeof(height));
+    memcpy(&pitch, frame.details + 36, sizeof(pitch));
+    memcpy(&fps, frame.details + 48, sizeof(fps));
+    CHECK(width == 1920 && height == 1080 && pitch == 1920 && fps == 30.0,
+          "AvPlayerVideoEx uses the published 80-byte layout");
+    CHECK(pause(h2, 0, 0, 0, 0, 0) == 0 && event_count == 3 && events[2] == 4,
+          "Pause reports success and fires PAUSE without deadlocking the callback");
+    CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 0 && event_count == 3,
+          "paused video pull returns no frame without consuming EOF");
+    CHECK(resume(h2, 0, 0, 0, 0, 0) == 0 && event_count == 4 && events[3] == 3,
+          "Resume restarts delivery and fires PLAY");
+    CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 0, "resumed synthetic video pull reports EOF");
+    CHECK(event_count == 5 && events[4] == 1, "EOF fires one STOP callback");
+    CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 0 && event_count == 5,
+          "EOF remains stopped without duplicate callbacks");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_json2.cpp
+++ b/prosper/tests/test_json2.cpp
@@ -1,0 +1,133 @@
+// libSceJson2 parsing and value access. Astro Bot parses configuration JSON during level startup
+// and asserts that values reported as booleans have the matching Json2 type.
+#include "../src/hle/dispatch.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+namespace {
+int failures = 0;
+#define CHECK(condition, message) do { \
+    if (condition) std::printf("  [ok]   %s\n", message); \
+    else { std::printf("  [FAIL] %s\n", message); ++failures; } \
+} while (0)
+
+struct JsonValue {
+    void* parent;
+    void* root_parameter;
+    uint64_t payload;
+    uint8_t reserved[4];
+    uint32_t type;
+};
+static_assert(sizeof(JsonValue) == 32 && offsetof(JsonValue, type) == 28);
+
+uint64_t call(HleFn fn, const void* a0 = nullptr, const void* a1 = nullptr,
+              uint64_t a2 = 0, uint64_t a3 = 0) {
+    return fn(reinterpret_cast<uintptr_t>(a0), reinterpret_cast<uintptr_t>(a1), a2, a3, 0, 0);
+}
+} // namespace
+
+int main() {
+    std::puts("== test_json2 ==");
+    register_builtin_hle();
+
+    HleFn ctor = Hle::lookup("qBMjqyBn3OM");
+    HleFn dtor = Hle::lookup("WTtYf+cNnXI");
+    HleFn parse = Hle::lookup("S5JxQnoGF3E");
+    HleFn index_string = Hle::lookup("HwDt5lD9Bfo");
+    HleFn index_uint = Hle::lookup("XlWbvieLj2M");
+    HleFn get_type = Hle::lookup("SHtAad20YYM");
+    HleFn get_boolean = Hle::lookup("zTwZdI8AZ5Y");
+    HleFn get_integer = Hle::lookup("DIxvoy7Ngvk");
+    HleFn get_unsigned = Hle::lookup("sn4HNCtNRzY");
+    HleFn get_string = Hle::lookup("epJ6x2LV0kU");
+    HleFn string_cstr = Hle::lookup("L1KAkYWml-M");
+    HleFn count = Hle::lookup("RBw+4NukeGQ");
+    HleFn assign = Hle::lookup("4zrm6VrgIAw");
+    HleFn string_ctor = Hle::lookup("qSmqLXXCPas");
+    HleFn string_dtor = Hle::lookup("cG1VE2HMl6c");
+    HleFn to_string = Hle::lookup("Ncel8t2Rrpc");
+    HleFn refer_string = Hle::lookup("wLsJlmgEIaI");
+    CHECK(ctor && dtor && parse && index_string && index_uint && get_type && get_boolean &&
+          get_integer && get_unsigned && get_string && string_cstr && count && assign && string_ctor && string_dtor &&
+          to_string && refer_string, "Json2 entry points are registered");
+    if (failures) return 1;
+
+    constexpr char source[] =
+        R"({"enabled":true,"nested":{"off":false},"items":[-7,2],"emoji":"\uD83D\uDE80"})";
+    JsonValue root{};
+    call(ctor, &root);
+    CHECK(call(parse, &root, source, std::strlen(source)) == 0, "object JSON parses successfully");
+    CHECK(call(get_type, &root) == 7, "root is reported as an object");
+    CHECK(call(count, &root) == 4, "object member count is preserved");
+
+    auto* enabled = reinterpret_cast<JsonValue*>(call(index_string, &root, "enabled"));
+    CHECK(enabled && call(get_type, enabled) == 1, "boolean member has boolean type");
+    auto* enabled_value = reinterpret_cast<const bool*>(call(get_boolean, enabled));
+    CHECK(enabled_value && *enabled_value, "boolean member has true value");
+
+    auto* nested = reinterpret_cast<JsonValue*>(call(index_string, &root, "nested"));
+    auto* off = reinterpret_cast<JsonValue*>(call(index_string, nested, "off"));
+    auto* off_value = reinterpret_cast<const bool*>(call(get_boolean, off));
+    CHECK(off && call(get_type, off) == 1 && off_value && !*off_value,
+          "nested false boolean is preserved");
+
+    auto* items = reinterpret_cast<JsonValue*>(call(index_string, &root, "items"));
+    CHECK(items && call(get_type, items) == 6 && call(count, items) == 2,
+          "array type and element count are preserved");
+    auto* first = reinterpret_cast<JsonValue*>(call(index_uint, items, nullptr, 0));
+    auto* integer = reinterpret_cast<const int64_t*>(call(get_integer, first));
+    CHECK(first && call(get_type, first) == 2 && integer && *integer == -7,
+          "signed array element is preserved");
+    auto* second = reinterpret_cast<JsonValue*>(
+        index_uint(reinterpret_cast<uintptr_t>(items), 1, 0, 0, 0, 0));
+    auto* unsigned_integer = reinterpret_cast<const uint64_t*>(call(get_unsigned, second));
+    CHECK(second && call(get_type, second) == 3 && unsigned_integer && *unsigned_integer == 2,
+          "unsigned array element is preserved");
+
+    auto* emoji = reinterpret_cast<JsonValue*>(call(index_string, &root, "emoji"));
+    auto* json_string = reinterpret_cast<void*>(call(get_string, emoji));
+    auto* utf8 = reinterpret_cast<const char*>(call(string_cstr, json_string));
+    CHECK(utf8 && std::strcmp(utf8, "\xF0\x9F\x9A\x80") == 0,
+          "UTF-16 surrogate pair decodes to UTF-8");
+
+    JsonValue copy{};
+    call(ctor, &copy);
+    CHECK(call(assign, &copy, &root) == reinterpret_cast<uintptr_t>(&copy),
+          "value assignment returns its destination");
+    call(dtor, &root);
+    auto* copied_enabled = reinterpret_cast<JsonValue*>(call(index_string, &copy, "enabled"));
+    auto* copied_boolean = reinterpret_cast<const bool*>(call(get_boolean, copied_enabled));
+    CHECK(copied_boolean && *copied_boolean, "value assignment owns an independent deep copy");
+
+    struct JsonString { void* implementation; } serialized{};
+    call(string_ctor, &serialized);
+    CHECK(call(to_string, &copy, &serialized) == 0, "value serialization succeeds");
+    const char* serialized_text = reinterpret_cast<const char*>(call(string_cstr, &serialized));
+    CHECK(serialized_text && std::strstr(serialized_text, "\"enabled\":true"),
+          "serialized object retains boolean members");
+    call(string_dtor, &serialized);
+
+    auto* missing = reinterpret_cast<JsonValue*>(call(index_string, &copy, "missing"));
+    CHECK(missing && call(get_type, missing) == 0, "missing member yields stable null value");
+    call(string_ctor, &serialized);
+    CHECK(call(refer_string, &copy, &serialized) == 0,
+          "missing pointer-style lookup returns null");
+    call(string_dtor, &serialized);
+    call(dtor, &copy);
+    CHECK(copy.type == 0, "value destructor releases the parsed tree");
+
+    constexpr char invalid[] = R"({"broken":])";
+    call(ctor, &root);
+    CHECK(call(parse, &root, invalid, std::strlen(invalid)) == 0x80848101u,
+          "invalid JSON returns the Json2 parse error");
+    CHECK(root.type == 0, "failed parse leaves a null value");
+    call(dtor, &root);
+
+    std::puts(failures ? "== FAIL ==" : "== PASS ==");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

This is the next natural #825 checkpoint, stacked on #837. It advances Astro Bot beyond the loading-screen milestone through the PS-logo/title state machine and into world-map / first-level intro loading.

The checkpoint is intentionally mergeable without waiting for every frontend to render the title correctly. This private research project benefits from landing substantial verified progress while platform follow-ups continue.

## What changed

### Json2

- add an independent `libSceJson2` HLE implementation for the ABI used by Astro;
- implement parsing, strings/escapes/surrogate pairs, numbers, arrays, objects, deep copy, lookup, type/value access, and serialization;
- preserve the observed 32-byte value layout and missing-key null/reference behavior;
- add focused Json2 tests.

### AvPlayer

- correct the published 560-byte `InitDataEx`, 80-byte video/audio detail, and stream-info layouts;
- implement stream metadata/control, pause/resume, synthetic audio/video delivery, millisecond timestamps, and EOF/STOP ordering outside the player mutex;
- restore guest FS correctly for Linux callbacks and add a four-argument Windows host-to-guest SysV callback bridge;
- keep real decoder queue starvation distinct from EOF;
- extend AvPlayer lifecycle/ABI tests on both hosts.

Real video decoding is deliberately out of scope here and tracked by #841 / #705. The progression run uses `PROSPER_AVP_SYNTH_FRAMES=1`.

### Windows performance

- reuse generation-guarded committed guest ranges outside renderer submit scope, eliminating repeated `VirtualQuery` probes for completion labels;
- read regular files directly into the largest validated writable guest prefix instead of cycling through a 64 KiB bounce buffer;
- preserve sparse/lazy commit, invalid-tail, short-read, EOF, and file-offset semantics.

These two changes move native Windows diagnostic execution from roughly one flip per 16 seconds to ~60 fps and reduce Astro's UI resource loading from effectively unbounded to under a minute on this host.

## Runtime evidence

Linux headless diagnostic (`PROSPER_NO_COMPUTE=1`, progression evidence only):

- `LevelDocument Loaded: title_controller_ship [title]`
- `PLAY: Playing: , Continue: worldmap`
- `LevelDocument Loaded: worldmap [worldmap]`
- `LevelDocument Loaded: intro_next [intro]`
- `GAME: Level has started: intro_next`
- `GAME: LoadLevelResources: hub_crashsite_tutorial`

Windows headless diagnostic after the performance changes:

- `LevelDocument Loaded: ps_logo [ps_logo]`
- `GAME: Level has started: ps_logo`
- `LevelDocument Loaded: title_controller_ship [title]`
- `GAME: Level has started: title_controller_ship`
- `PLAY: Playing: , Continue: worldmap`

A hardware watch verified that the Windows `VideoPlayerHeap` mspace is created successfully. One earlier run faulted during PS-logo transition; a later watched run reached the title/world-map continuation without reproducing it, so Windows app/title rendering is not claimed complete here.

Visible Linux headless output currently reaches the `Sony Interactive Entertainment presents` composite. Guest-state progression is ahead of visible renderer output; this PR does not claim a correctly rendered title screen.

## Validation

- Linux focused CTest: Json2, AvPlayer, file binary roundtrip, guest memory map — 4/4 passed
- Windows focused CTest: Json2, AvPlayer, file binary roundtrip, guest memory map — 4/4 passed
- Linux headless capture: 60 composited samples, 16 pixel-distinct frames, clean exit
- Windows watched title/world-map diagnostic: clean progression through `Continue: worldmap`
- `git diff --check`

Full-suite and required renderer snapshot gates will run during review. No game assets, screenshots, or copyrighted media are included.

Progresses #825. Refs #705, #837, #841.