### PR TITLE
fix(#707): relocate hot equeue/APR mutexes off macOS __DATA (clean core)

### DIFF
--- a/prosper/src/hle/heap_mutex.hpp
+++ b/prosper/src/hle/heap_mutex.hpp
@@ -1,0 +1,54 @@
+#pragma once
+// heap_mutex.hpp — #707 (Blasphemous 2, macOS): keep hot mutexes OFF the binary's __DATA.
+//
+// WHY THIS EXISTS
+// On macOS/libc++ a namespace-scope `std::mutex` is CONSTANT-initialized to a NON-ZERO value
+// (PTHREAD_MUTEX_INITIALIZER carries a non-zero _MUTEX_SIG), so the object lands in the Mach-O
+// __DATA segment. During Blasphemous 2 asset load an unattributed #707 corruptor (a mach_vm-family
+// write that bypasses current page protection but honors max_protection — see
+// docs/BLASPHEMOUS2_EQ_CORRUPTION.md) zeroes a page-granular region of this executable's OWN __DATA,
+// wiping the pthread `__sig` of any std::mutex living in that cluster. A later `lock()` then returns
+// EINVAL, `std::mutex::lock()` throws, and the process terminates. On Linux/glibc
+// PTHREAD_MUTEX_INITIALIZER is all-zero, so the same mutex is .bss and untouched — which is exactly
+// why #707 is latent on Linux.
+//
+// WHAT PROSPER_HEAP_MUTEX GIVES YOU
+// A mutex that survives the corruptor on macOS and is a drop-in for `std::mutex name;`
+// (works with std::lock_guard / std::unique_lock via CTAD — call sites must use the deduced form
+// `std::lock_guard lk(name)`, NOT `std::lock_guard<std::mutex> lk(name)`):
+//   * the guest-visible object is a trivially-constructed forwarder -> it is zero-initializable and
+//     therefore lands in .bss, which PR #753 round-2 evidence showed the corruptor does NOT reach —
+//     never __DATA;
+//   * the real std::mutex is heap-allocated ONCE, EAGERLY, at static-init time (single-threaded,
+//     before the guest ever runs). It is NEVER new/malloc'd on a lock path. This is critical: an
+//     earlier lazy-allocating variant (atomic pointer + first-use `new`) deadlocked inside the
+//     macOS %fs SIGSEGV handler — which itself takes one of these locks — and wedged the runtime.
+//     Keep allocation eager. The heap block is intentionally never freed (process-lifetime global).
+//
+// On non-Apple platforms this expands to a plain `std::mutex` (already .bss; zero overhead), so the
+// primary Linux/Windows paths are completely unaffected.
+#include <mutex>
+
+#ifdef __APPLE__
+namespace prosper {
+struct HeapMutex {
+    std::mutex* p;                      // .bss (zero-init); assigned by the paired initializer below
+    void lock()     { p->lock(); }
+    void unlock()   { p->unlock(); }
+    bool try_lock() { return p->try_lock(); }
+};
+}  // namespace prosper
+// The initializer MUST be declared immediately after the HeapMutex so that, within a TU, the
+// forwarder is zero-initialized (static-init phase, before any dynamic initializer runs) and this
+// ctor then assigns its heap backing during static init — before the guest runs. Cross-TU init
+// order is irrelevant because each TU initializes only its own forwarder.
+#define PROSPER_HEAP_MUTEX(name)                                              \
+    ::prosper::HeapMutex name;                                                \
+    static struct name##_HeapMutexInit {                                      \
+        name##_HeapMutexInit() { name.p = new std::mutex(); }                 \
+    } name##_heap_mutex_init_
+#define PROSPER_HEAP_MUTEX_EXTERN(name) extern ::prosper::HeapMutex name
+#else
+#define PROSPER_HEAP_MUTEX(name)        std::mutex name
+#define PROSPER_HEAP_MUTEX_EXTERN(name) extern std::mutex name
+#endif

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -6,6 +6,7 @@
 #endif
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -868,20 +869,20 @@ HLE(f_rename){ std::string from = translate(CS(a0)), to = translate(CS(a1));
 // id->host-path so the read path can pread by id. CONFIDENCE: MED (arg roles from live capture;
 // outFlags semantics unknown -> 0).
 namespace {
-    std::mutex g_apr_mx;
+    PROSPER_HEAP_MUTEX(g_apr_mx);   // #707: heap-backed on macOS (APR registry mutex near the corrupted __DATA cluster)
     struct AprFile { std::string path; uint64_t size; };
     std::vector<AprFile> g_apr_files;   // id (1-based index) -> {host path, size}
 }
 // Exposed to the read path (Ampr page-read) to map an APR id back to its host file.
 std::string prosper_apr_path_for_id(uint32_t id) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     return (id >= 1 && id <= g_apr_files.size()) ? g_apr_files[id - 1].path : std::string();
 }
 // Register a resolved container and return its stable 1-based id. Re-resolving the same host path
 // returns the existing id (updated size) instead of a duplicate entry — a duplicate would make
 // every size-keyed read of that file look ambiguous. Exposed (not static) for the unit test.
 uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     for (size_t i = 0; i < g_apr_files.size(); i++)
         if (g_apr_files[i].path == path) { g_apr_files[i].size = size; return (uint32_t)(i + 1); }
     g_apr_files.push_back({ path, size });
@@ -889,7 +890,7 @@ uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
 }
 // Test hook: drop all registered containers (the registry is process-global).
 void prosper_apr_reset_for_test() {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     g_apr_files.clear();
 }
 // Find resolved host paths whose TOTAL size equals `size`. Returns the match count and sets
@@ -898,7 +899,7 @@ void prosper_apr_reset_for_test() {
 // legible in the captured request layout (docs/UE4_APR_IOSTORE_BRINGUP.md field map, +0x00..+0x40),
 // so size is the only correlation currently available. Exposed (not static) for the unit test.
 int prosper_apr_match_by_size(uint64_t size, std::string* out_path) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     int n = 0;
     for (auto& f : g_apr_files)
         if (f.size == size) { if (n++ == 0 && out_path) *out_path = f.path; }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -2,6 +2,7 @@
 // libkernel stubs the engine needs during init. Cross-platform (chrono + pthread).
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include "sync_futex.hpp"
 #include <pthread.h>
 #include <chrono>
@@ -400,7 +401,7 @@ namespace {
     // the state while k_eq_wait sat in cv.wait on it). Delete marks `deleted` and wakes waiters; the
     // object dies when the last reference drops.
     struct EqState { std::mutex m; std::condition_variable cv; std::deque<SceKEvent> ready; bool deleted = false; };
-    std::mutex g_eq_mx;
+    PROSPER_HEAP_MUTEX(g_eq_mx);   // #707: heap-backed on macOS (std::mutex would land in the corrupted __DATA cluster)
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
     std::vector<FlipReg> g_flip_regs, g_vblank_regs;
@@ -423,7 +424,7 @@ namespace {
     std::atomic<bool> g_pump_started{false};
 
     std::shared_ptr<EqState> eq_find(uint64_t eq) {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_eqs.find(eq);
         return it == g_eqs.end() ? nullptr : it->second;
     }
@@ -460,7 +461,7 @@ namespace {
             struct timespec ts{ 0, 16666667 }; nanosleep(&ts, nullptr);   // ~60 Hz
             frame++;
             std::vector<FlipReg> vr;
-            { std::lock_guard<std::mutex> lk(g_eq_mx); vr = g_vblank_regs; }
+            { std::lock_guard lk(g_eq_mx); vr = g_vblank_regs; }
             // Vblank ticks are periodic by nature — pump them. FLIP events are NOT pumped: a flip
             // event fires when a submitted flip completes (prosper_eq_trigger_flip below), carrying
             // that flip's flipArg in `data`. The old timer-driven flip event carried a frame counter
@@ -473,7 +474,7 @@ namespace {
             // to signal work; if the producer path isn't reached, that thread starves and the game idles.
             // Firing it each vblank tests whether waking that consumer lets the game progress to real draws.
             if (getenv("PROSPER_PUMP_USEREV")) {
-                std::vector<UserReg> ur; { std::lock_guard<std::mutex> lk(g_eq_mx); ur = g_user_regs; }
+                std::vector<UserReg> ur; { std::lock_guard lk(g_eq_mx); ur = g_user_regs; }
                 for (auto& r : ur) { SceKEvent e{}; e.ident = r.id; e.filter = -11 /*EVFILT_USER*/; e.udata = r.udata; eq_post(r.eq, e); }
             }
         }
@@ -483,7 +484,7 @@ namespace {
 
 // Exposed to hle_graphics.cpp (sceVideoOut* flip/vblank event registration).
 void prosper_eq_add_flip(uint64_t eq, int64_t ident, uint64_t udata) {
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_flip_regs.push_back({ eq, ident, udata }); }
+    { std::lock_guard lk(g_eq_mx); g_flip_regs.push_back({ eq, ident, udata }); }
     ensure_pump();
 }
 // Fire the flip-completion event on every registered flip equeue — called by BOTH flip paths
@@ -491,7 +492,7 @@ void prosper_eq_add_flip(uint64_t eq, int64_t ident, uint64_t udata) {
 // flip_event_trigger_func: ident=VIDEO_OUT_EVENT_FLIP, data=the completed flip's flipArg.
 void prosper_eq_trigger_flip(int64_t flip_arg) {
     std::vector<FlipReg> regs;
-    { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_flip_regs; }
+    { std::lock_guard lk(g_eq_mx); regs = g_flip_regs; }
     for (auto& r : regs) {
         SceKEvent e{}; e.ident = VIDEO_OUT_EVENT_FLIP; e.filter = EVFILT_VIDEO_OUT;
         e.fflags = 1; e.data = flip_arg; e.udata = r.udata;
@@ -499,12 +500,12 @@ void prosper_eq_trigger_flip(int64_t flip_arg) {
     }
 }
 void prosper_eq_add_vblank(uint64_t eq, int64_t ident, uint64_t udata) {
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_vblank_regs.push_back({ eq, ident, udata }); }
+    { std::lock_guard lk(g_eq_mx); g_vblank_regs.push_back({ eq, ident, udata }); }
     ensure_pump();
 }
 // Exposed to the AGC submit path (hle_agc.cpp). Register a GPU EOP event source (sceGnmAddEqEvent).
 void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
-    std::lock_guard<std::mutex> lk(g_eq_mx); g_eop_regs.push_back({ eq, id, udata });
+    std::lock_guard lk(g_eq_mx); g_eop_regs.push_back({ eq, id, udata });
 }
 // Fire the registered EOP events — called when a submit completes. Posts TriggerEvent(ident=id,
 // filter=GraphicsCore, data=id, udata) to each registered equeue, matching shadPS4's IRQ handler.
@@ -527,7 +528,7 @@ namespace {
         // is a discrete count, never a level. PROSPER_EOP_COALESCE restores the old behavior.
         static const bool coalesce = getenv("PROSPER_EOP_COALESCE") != nullptr;
         std::vector<FlipReg> regs;
-        { std::lock_guard<std::mutex> lk(g_eq_mx); regs = g_eop_regs; }
+        { std::lock_guard lk(g_eq_mx); regs = g_eop_regs; }
         for (auto& r : regs) {
             SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
             eq_post(r.eq, e, coalesce);
@@ -587,7 +588,7 @@ void prosper_eq_trigger_eop() {
 HLE(k_eq_create) {
     auto s = std::make_shared<EqState>();
     if (a0) *(void**)P(a0) = (void*)s.get();   // the guest's opaque SceKernelEqueue handle IS our state ptr
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_eqs[(uint64_t)(uintptr_t)s.get()] = s; }
+    { std::lock_guard lk(g_eq_mx); g_eqs[(uint64_t)(uintptr_t)s.get()] = s; }
     if (evlog()) fprintf(stderr, "[ev] CreateEqueue -> eq=%p name=%s\n", (void*)s.get(), a1 ? (const char*)P(a1) : "");
     return 0;
 }
@@ -595,7 +596,7 @@ HLE(k_eq_delete) {
     if (!a0) return 0;
     std::shared_ptr<EqState> s;
     {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_eqs.find(a0);
         if (it != g_eqs.end()) { s = std::move(it->second); g_eqs.erase(it); }
         // Purge every registration pointing at this queue (#67). Without this, a later heap
@@ -756,7 +757,7 @@ namespace {
     constexpr int16_t EVFILT_AMPR_MODELED = -24;   // guest never reads filter; distinct on purpose
     struct AprEqReg { uint64_t eq; int64_t id; };
     // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
-    std::mutex g_apr_mx;
+    PROSPER_HEAP_MUTEX(g_apr_mx);   // #707: heap-backed on macOS (hot APR mutex in the corrupted __DATA cluster)
     std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
     uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
     uint64_t g_apr_tag_hwm[64] = {};                   // per-ring highest tag counter posted (guarded)
@@ -834,7 +835,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
     unsigned ring = (unsigned)(token >> 58) & 0x3f;
     uint64_t cnt = token & ((1ull << 58) - 1);
     {
-        std::lock_guard<std::mutex> lk(g_apr_mx);
+        std::lock_guard lk(g_apr_mx);
         if (cnt > g_apr_tag_hwm[ring]) g_apr_tag_hwm[ring] = cnt;
     }
     if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u) -> eq=0x%llx scheduled\n",
@@ -843,7 +844,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
         struct timespec ts{ 0, 2000000 };   // 2 ms
         nanosleep(&ts, nullptr);
         uint64_t hwm;
-        { std::lock_guard<std::mutex> lk(g_apr_mx); hwm = g_apr_tag_hwm[ring]; }
+        { std::lock_guard lk(g_apr_mx); hwm = g_apr_tag_hwm[ring]; }
         AprEqReg r{ eq, id };
         apr_post(r, ring, ((uint64_t)ring << 58) | hwm);
     }).detach();
@@ -853,7 +854,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
 // event is ever posted for these — see the block comment above).
 uint64_t prosper_apr_next_token(unsigned ring) {
     ring &= 0x3f;
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     uint64_t seq = ++g_apr_ring_seq[ring];
     return ((uint64_t)ring << 58) | (seq & ((1ull << 58) - 1));
 }
@@ -863,7 +864,7 @@ uint64_t prosper_apr_next_token(unsigned ring) {
 // ctor-seeded per-ring last-processed (see the block comment above; the pre-#208 replay was the
 // root cause of the #180 range-walk fault).
 void prosper_eq_add_apr(uint64_t eq, int64_t id) {
-    std::lock_guard<std::mutex> lk(g_apr_mx);
+    std::lock_guard lk(g_apr_mx);
     for (auto& r : g_apr_eq_regs)
         if (r.eq == eq && r.id == id) return;   // idempotent
     g_apr_eq_regs.push_back({ eq, id });
@@ -891,14 +892,14 @@ namespace {
     // (UserReg / g_user_regs are declared above, before the vblank pump.)
 }
 HLE(k_add_user_event) {   // (eq, id, udata?) — register a user event source on the equeue
-    { std::lock_guard<std::mutex> lk(g_eq_mx); g_user_regs.push_back({ a0, (int64_t)a1, a2 }); }
+    { std::lock_guard lk(g_eq_mx); g_user_regs.push_back({ a0, (int64_t)a1, a2 }); }
     if (evlog()) fprintf(stderr, "[ev] AddUserEvent eq=0x%llx id=%lld udata=0x%llx\n",
         (unsigned long long)a0, (long long)a1, (unsigned long long)a2);
     return 0;
 }
 HLE(k_trigger_user_event) {   // (eq, id, udata) — fire the user event: post it to the equeue
     uint64_t udata = a2;
-    { std::lock_guard<std::mutex> lk(g_eq_mx);
+    { std::lock_guard lk(g_eq_mx);
       for (auto& r : g_user_regs) if (r.eq == a0 && r.id == (int64_t)a1) { if (!udata) udata = r.udata; break; } }
     SceKEvent e{}; e.ident = (int64_t)a1; e.filter = EVFILT_USER; e.udata = udata;
     eq_post(a0, e);
@@ -919,7 +920,7 @@ HLE(k_trigger_user_event) {   // (eq, id, udata) — fire the user event: post i
 static void post_after(uint64_t eq, int64_t id, uint64_t udata, uint64_t usec, int16_t filter, bool periodic) {
     auto cancelled = std::make_shared<std::atomic<bool>>(false);
     {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto key = std::make_pair(eq, id);
         auto it = g_timers.find(key);
         if (it != g_timers.end()) it->second.cancelled->store(true);   // re-arm replaces the pending shot
@@ -938,7 +939,7 @@ static void post_after(uint64_t eq, int64_t id, uint64_t udata, uint64_t usec, i
             eq_post(eq, e);
         } while (periodic && !cancelled->load());
         // forget the registration once we stop firing (only if it is still OUR token, not a re-arm's)
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_timers.find(std::make_pair(eq, id));
         if (it != g_timers.end() && it->second.cancelled == cancelled) g_timers.erase(it);
     }).detach();
@@ -947,7 +948,7 @@ static void post_after(uint64_t eq, int64_t id, uint64_t udata, uint64_t usec, i
 HLE(k_del_timer_event) {   // (eq, id)
     bool cancelled = false;
     {
-        std::lock_guard<std::mutex> lk(g_eq_mx);
+        std::lock_guard lk(g_eq_mx);
         auto it = g_timers.find(std::make_pair(a0, (int64_t)a1));
         if (it != g_timers.end()) { it->second.cancelled->store(true); g_timers.erase(it); cancelled = true; }
     }
@@ -958,7 +959,7 @@ HLE(k_del_timer_event) {   // (eq, id)
 // Remove a registered user-event source (previously a no-op: a deleted source kept receiving
 // TriggerUserEvent posts and diagnostic-pump heartbeats).
 HLE(k_del_user_event) {   // (eq, id)
-    std::lock_guard<std::mutex> lk(g_eq_mx);
+    std::lock_guard lk(g_eq_mx);
     g_user_regs.erase(std::remove_if(g_user_regs.begin(), g_user_regs.end(),
                       [&](const UserReg& r){ return r.eq == a0 && r.id == (int64_t)a1; }), g_user_regs.end());
     if (evlog()) fprintf(stderr, "[ev] DeleteUserEvent eq=0x%llx id=%lld\n", (unsigned long long)a0, (long long)a1);


### PR DESCRIPTION
Fixes #707. **Clean core fix — supersedes the diagnostic-heavy approach in #753.**

## Problem
On macOS (x86-64 under Rosetta) a routed Blasphemous 2 run corrupts prosper's own host globals during asset load: a page-granular region of `boot_trace`'s `__DATA` is zeroed, wiping the pthread `__sig` of the equeue mutex cluster. A later `pthread_mutex_lock` returns `EINVAL`, `std::mutex::lock` throws, and the process terminates. **Latent on Linux** because glibc's `PTHREAD_MUTEX_INITIALIZER` is all-zero → the same mutex is `.bss` (untouched); on macOS/libc++ the initializer carries a non-zero `_MUTEX_SIG` → the mutex lands in `__DATA`, exactly where the corruptor writes. (The corruptor itself — an unattributed `mach_vm`-family write — is characterized in `docs/BLASPHEMOUS2_EQ_CORRUPTION.md`; this PR mitigates the crash correct-by-construction without needing to name the writer.)

## Fix
New `src/hle/heap_mutex.hpp` — `PROSPER_HEAP_MUTEX(name)`: a trivially-constructed `.bss` forwarder to a heap `std::mutex` allocated **once, eagerly, at static init** (single-threaded, before the guest runs — never `new`/`malloc` on a lock path, because the `%fs` SIGSEGV handler also takes these locks and malloc there deadlocks; an earlier lazy variant did exactly that). `.bss` is not reached by the corruptor. Applied to `g_eq_mx` + `g_apr_mx` (`hle_kernel_time.cpp`) and `g_apr_mx` (`hle_file.cpp`). On non-Apple platforms the macro expands to a plain `std::mutex` — **Linux/Windows byte-identical**.

## Relationship to #753
#753 carried the same core idea plus heavy `#707` diagnostic scaffolding (ballast/decoy/canary arrays, sigwatch, `dlfcn`/`execinfo` includes). Its review (reviewer-753) approved the core but blocked on: (1) a Windows/MinGW build break (`dlfcn.h`/`execinfo.h`/`dladdr` outside `_WIN32` guards), (2) ~695 always-constructed diagnostic ballast mutexes shipping in every build, (3) CRLF conflicts. **This PR is the clean core with none of that** — no Windows-only includes, no ballast, no CRLF churn, rebased on current master. Recommend closing #753 in favor of this.

## Affected / unaffected
- **Affected:** macOS only — `g_eq_mx`/`g_apr_mx` move from `__DATA` to `.bss`+heap.
- **Unaffected:** Linux/Windows (plain `std::mutex`, byte-identical). Lock call sites use CTAD (`std::lock_guard lk(m)`) which deduces the correct type on all platforms.

## Verification
- macOS (`build-mac-app`, x86-64): builds clean; `nm` confirms `g_eq_mx` and both `g_apr_mx` relocated to `.bss`.
- The identical relocation was **runtime-verified on macOS** (see #707 / PR #753 comments): the corruptor fires (SIGWATCH catches `g_det_clock.mutex`'s sig `0x32AAABA7`→0) yet `g_eq_mx`/`g_apr_mx` are never hit and the route runs to frame 350 / clean exit — zero equeue crashes across runs (was 50–80% before).
- Linux `build-linux` + `ctest`: running (results to follow in a comment); expected no change since the `#else` path is a plain `std::mutex`.

Per CLAUDE.md this needs independent review before merge; not merging without maintainer authorization.
