### PR TITLE
feat(avplayer): add native Linux VA-API decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build
+          sudo apt-get install -y ninja-build pkg-config libavformat-dev libavcodec-dev \
+            libavutil-dev libswresample-dev libswscale-dev libva-dev
 
       - name: Configure
         run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
@@ -49,7 +50,8 @@ jobs:
           sudo apt-get install -y ninja-build pkg-config libvulkan-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev libx11-dev \
             libxext-dev libxcursor-dev libxi-dev libxrandr-dev libxfixes-dev \
-            libpulse-dev libasound2-dev
+            libpulse-dev libasound2-dev libavformat-dev libavcodec-dev libavutil-dev \
+            libswresample-dev libswscale-dev libva-dev
 
       - name: Configure
         run: cmake -S prosper -B prosper/build-app -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ Windows/MinGW), structured logs, and purpose-built tracing tooling — never by 
 ### Linux
 
 Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the graphics tests
-(the CI/headless path uses the `llvmpipe` software ICD).
+(the CI/headless path uses the `llvmpipe` software ICD). The native AvPlayer backend uses FFmpeg
+for MP4 demux/audio conversion and VA-API for hardware video decode. On Ubuntu/Debian:
+
+```sh
+sudo apt install ninja-build pkg-config libvulkan-dev libavformat-dev libavcodec-dev \
+  libavutil-dev libswresample-dev libswscale-dev libva-dev
+```
 
 ```sh
 cd prosper
@@ -105,7 +111,10 @@ ctest --test-dir build-linux          # 93 self-checking tests
 ```
 
 Add `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` to build the windowed frontend
-with audio and controller support. CMake fetches SDL3 when it is not installed.
+with audio and controller support. CMake fetches SDL3 when it is not installed. Video source-open
+requires a working VA-API render device by default; select a non-default node with
+`PROSPER_AVP_VAAPI_DEVICE=/dev/dri/renderD129`. `PROSPER_AVP_ALLOW_SOFTWARE=1` is an explicit
+diagnostic fallback, not normal playback behavior.
 
 ### Windows core
 

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -834,6 +834,35 @@ if(WIN32 AND TARGET prosper_core)
   endif()
 endif()
 
+# Linux native AvPlayer backend (#841): FFmpeg provides MP4 demux/audio conversion and drives a
+# VA-API hardware decoder for video. Keep the dependency outside prosper_core; systems without the
+# development packages retain the headless core but do not advertise a native video backend.
+option(PROSPER_VIDEO_VAAPI "Build the Linux FFmpeg/VA-API AvPlayer backend" ON)
+if(UNIX AND NOT APPLE AND PROSPER_VIDEO_VAAPI AND TARGET prosper_core)
+  find_package(PkgConfig QUIET)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(PROSPER_FFMPEG QUIET IMPORTED_TARGET
+                      libavformat libavcodec libavutil libswresample libswscale libva)
+  endif()
+  if(PROSPER_FFMPEG_FOUND)
+    add_library(prosper_video_vaapi STATIC
+                frontends/video_vaapi/vaapi_backend.cpp)
+    target_include_directories(prosper_video_vaapi PUBLIC frontends/video_vaapi PRIVATE src)
+    target_link_libraries(prosper_video_vaapi PUBLIC prosper_core PkgConfig::PROSPER_FFMPEG)
+
+    add_executable(test_video_vaapi frontends/video_vaapi/test_video_vaapi.cpp)
+    target_link_libraries(test_video_vaapi PRIVATE prosper_video_vaapi)
+    add_test(NAME video_vaapi COMMAND test_video_vaapi)
+
+    if(TARGET boot_trace)
+      target_link_libraries(boot_trace PRIVATE prosper_video_vaapi)
+      target_compile_definitions(boot_trace PRIVATE PROSPER_VIDEO_VAAPI=1)
+    endif()
+  else()
+    message(WARNING "FFmpeg/libva development packages not found - Linux AvPlayer video disabled")
+  endif()
+endif()
+
 # --- SDL3 frontends (optional; headless core stays dependency-free) --------------------------
 # The sceAudioOut sink (frontends/audio_sdl3) and the libScePad gamepad backend (frontends/pad_sdl3)
 # can both use SDL3. They must share ONE SDL3 build: if each fetched independently, the first fetch's
@@ -1007,4 +1036,10 @@ if(TARGET prosper-app AND TARGET prosper_video_mf)
   target_link_libraries(prosper-app PRIVATE prosper_video_mf)
   target_compile_definitions(prosper-app PRIVATE PROSPER_VIDEO_MF=1)
   message(STATUS "prosper-app: Media Foundation video enabled")
+endif()
+
+if(TARGET prosper-app AND TARGET prosper_video_vaapi)
+  target_link_libraries(prosper-app PRIVATE prosper_video_vaapi)
+  target_compile_definitions(prosper-app PRIVATE PROSPER_VIDEO_VAAPI=1)
+  message(STATUS "prosper-app: FFmpeg/VA-API video enabled")
 endif()

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -35,6 +35,9 @@
 #ifdef PROSPER_VIDEO_MF
 #include "media_foundation_backend.hpp" // native Windows AvPlayer demux + hardware decode
 #endif
+#ifdef PROSPER_VIDEO_VAAPI
+#include "vaapi_backend.hpp"            // native Linux FFmpeg demux + VA-API hardware decode
+#endif
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_vulkan.h>
@@ -390,6 +393,16 @@ int main(int argc, char** argv) {
                     fprintf(stderr, "[app] Media Foundation video backend installed.\n");
                 else
                     fprintf(stderr, "[app] Media Foundation video backend unavailable.\n");
+            } else {
+                fprintf(stderr, "[app] native video backend disabled.\n");
+            }
+#endif
+#ifdef PROSPER_VIDEO_VAAPI
+            if (!getenv("PROSPER_APP_DISABLE_VIDEO")) {
+                if (prosper::video::install_vaapi_backend())
+                    fprintf(stderr, "[app] FFmpeg/VA-API video backend installed.\n");
+                else
+                    fprintf(stderr, "[app] FFmpeg/VA-API video backend unavailable.\n");
             } else {
                 fprintf(stderr, "[app] native video backend disabled.\n");
             }

--- a/prosper/frontends/video_vaapi/test_video_vaapi.cpp
+++ b/prosper/frontends/video_vaapi/test_video_vaapi.cpp
@@ -1,0 +1,83 @@
+#include "vaapi_backend.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+using namespace prosper::video;
+
+namespace {
+int failures = 0;
+#define CHECK(condition, message) do { \
+    if (condition) std::printf("  [ok]   %s\n", message); \
+    else { std::printf("  [FAIL] %s\n", message); ++failures; } \
+} while (0)
+} // namespace
+
+int main(int argc, char** argv) {
+    std::puts("== test_video_vaapi ==");
+    set_backend(nullptr);
+    CHECK(install_vaapi_backend(), "FFmpeg VA-API backend is available");
+    CHECK(backend() != nullptr, "native backend is registered explicitly");
+    if (backend()) {
+        CHECK(backend()->open("/prosper-missing/no-such-video.mp4") < 0,
+              "missing source fails instead of fabricating a decode session");
+        if (argc == 2) {
+            const int id = backend()->open(argv[1]);
+            CHECK(id >= 0, "MP4 opens with the selected VA-API or explicit diagnostic pipeline");
+            if (id >= 0) {
+                StreamInfo stream{};
+                CHECK(backend()->info(id, stream) && stream.width && stream.height && stream.fps > 0,
+                      "MP4 stream metadata contains dimensions and frame rate");
+                unsigned video_frames = 0, audio_frames = 0;
+                uint64_t previous_video_pts = 0, previous_audio_pts = 0;
+                const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+                while (std::chrono::steady_clock::now() < deadline &&
+                       (video_frames < 3 || (stream.has_audio && audio_frames == 0)) &&
+                       !backend()->eof(id)) {
+                    VideoFrame video{};
+                    if (backend()->next_video(id, video)) {
+                        CHECK(video.y && video.uv && video.width == stream.width &&
+                                  video.height == stream.height && video.y_stride >= video.width &&
+                                  video.uv_stride >= video.width,
+                              "decoded video frame exposes stable NV12 planes and strides");
+                        CHECK(video_frames == 0 || video.pts_us >= previous_video_pts,
+                              "decoded video timestamps are monotonic");
+                        previous_video_pts = video.pts_us;
+                        ++video_frames;
+                    }
+                    AudioFrame audio{};
+                    if (backend()->next_audio(id, audio)) {
+                        CHECK(audio.pcm && audio.channels == stream.audio_channels &&
+                                  audio.sample_rate == stream.audio_rate && audio.samples > 0,
+                              "decoded audio frame exposes interleaved 16-bit PCM");
+                        CHECK(audio_frames == 0 || audio.pts_us >= previous_audio_pts,
+                              "decoded audio timestamps are monotonic");
+                        previous_audio_pts = audio.pts_us;
+                        ++audio_frames;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+                CHECK(video_frames >= 3, "backend delivers multiple real video frames");
+                if (stream.has_audio) CHECK(audio_frames > 0, "backend delivers real audio samples");
+                if (stream.has_audio && video_frames >= 3) {
+                    const auto eof_deadline =
+                        std::chrono::steady_clock::now() + std::chrono::seconds(30);
+                    while (std::chrono::steady_clock::now() < eof_deadline &&
+                           !backend()->eof(id)) {
+                        VideoFrame video{};
+                        if (backend()->next_video(id, video)) ++video_frames;
+                        else std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    }
+                    CHECK(backend()->eof(id),
+                          "video-only consumption reaches EOF despite queued audio");
+                }
+                backend()->close(id);
+            }
+        }
+    }
+    uninstall_vaapi_backend();
+    CHECK(backend() == nullptr, "native backend can be unregistered cleanly");
+    std::puts(failures ? "== FAIL ==" : "== PASS ==");
+    return failures ? 1 : 0;
+}

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -423,6 +423,7 @@ void decode_session(Session& session, std::stop_token stop) {
             goto finished;
         }
         result = avcodec_parameters_to_context(pipeline.audio, parameters);
+        if (result >= 0) pipeline.audio->pkt_timebase = audio_time_base;
         if (result < 0 || (result = avcodec_open2(pipeline.audio, codec, nullptr)) < 0) {
             failure = "could not start audio decoder: " + ff_error(result);
             goto finished;

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -1,0 +1,664 @@
+#include "vaapi_backend.hpp"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/error.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/rational.h>
+#include <libswresample/swresample.h>
+#include <libswscale/swscale.h>
+}
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace prosper::video {
+namespace {
+
+constexpr size_t kVideoQueueCapacity = 6;
+constexpr size_t kAudioQueueCapacity = 32;
+
+bool env_enabled(const char* name) {
+    const char* value = std::getenv(name);
+    return value && *value && std::strcmp(value, "0") != 0;
+}
+
+bool avp_log() { return env_enabled("PROSPER_AVP_LOG"); }
+bool software_decode_allowed() { return env_enabled("PROSPER_AVP_ALLOW_SOFTWARE"); }
+
+std::string ff_error(int error) {
+    char text[AV_ERROR_MAX_STRING_SIZE]{};
+    av_strerror(error, text, sizeof(text));
+    return text;
+}
+
+struct VideoPacket {
+    std::vector<uint8_t> nv12;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t stride = 0;
+    uint64_t pts_us = 0;
+};
+
+struct AudioPacket {
+    std::vector<int16_t> pcm;
+    uint32_t channels = 0;
+    uint32_t sample_rate = 0;
+    uint64_t pts_us = 0;
+};
+
+struct Session {
+    std::string path;
+    bool allow_software = false;
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool initialized = false;
+    bool init_ok = false;
+    bool stopping = false;
+    bool decode_done = false;
+    std::string failure;
+    StreamInfo stream_info;
+
+    std::deque<VideoPacket> video_queue;
+    std::deque<AudioPacket> audio_queue;
+    VideoPacket last_video;
+    AudioPacket last_audio;
+    std::jthread thread;
+};
+
+struct HardwareSelection {
+    AVPixelFormat format = AV_PIX_FMT_NONE;
+    bool require_hardware = true;
+};
+
+AVPixelFormat select_video_format(AVCodecContext* context, const AVPixelFormat* formats) {
+    auto* selection = static_cast<HardwareSelection*>(context->opaque);
+    if (!selection || !formats) return AV_PIX_FMT_NONE;
+    if (selection->format != AV_PIX_FMT_NONE) {
+        for (const AVPixelFormat* format = formats; *format != AV_PIX_FMT_NONE; ++format) {
+            if (*format == selection->format) {
+                return *format;
+            }
+        }
+    }
+    if (selection->require_hardware) return AV_PIX_FMT_NONE;
+    for (const AVPixelFormat* format = formats; *format != AV_PIX_FMT_NONE; ++format) {
+        const AVPixFmtDescriptor* descriptor = av_pix_fmt_desc_get(*format);
+        if (descriptor && !(descriptor->flags & AV_PIX_FMT_FLAG_HWACCEL)) return *format;
+    }
+    return AV_PIX_FMT_NONE;
+}
+
+struct Pipeline {
+    AVFormatContext* format = nullptr;
+    AVCodecContext* video = nullptr;
+    AVCodecContext* audio = nullptr;
+    AVBufferRef* hardware_device = nullptr;
+    AVPacket* packet = nullptr;
+    AVFrame* frame = nullptr;
+    AVFrame* transferred = nullptr;
+    SwsContext* scaler = nullptr;
+    SwrContext* resampler = nullptr;
+    AVSampleFormat resampler_format = AV_SAMPLE_FMT_NONE;
+    int resampler_rate = 0;
+    int resampler_channels = 0;
+
+    ~Pipeline() {
+        swr_free(&resampler);
+        sws_freeContext(scaler);
+        av_frame_free(&transferred);
+        av_frame_free(&frame);
+        av_packet_free(&packet);
+        avcodec_free_context(&audio);
+        avcodec_free_context(&video);
+        av_buffer_unref(&hardware_device);
+        avformat_close_input(&format);
+    }
+};
+
+bool session_stopping(Session& session, std::stop_token stop) {
+    if (stop.stop_requested()) return true;
+    std::lock_guard<std::mutex> lock(session.mutex);
+    return session.stopping;
+}
+
+uint64_t frame_timestamp_us(const AVFrame* frame, AVRational time_base) {
+    const int64_t timestamp = frame->best_effort_timestamp != AV_NOPTS_VALUE
+                                  ? frame->best_effort_timestamp
+                                  : frame->pts;
+    if (timestamp == AV_NOPTS_VALUE) return 0;
+    const int64_t value = av_rescale_q(timestamp, time_base, AVRational{1, 1'000'000});
+    return value > 0 ? static_cast<uint64_t>(value) : 0;
+}
+
+bool enqueue_video(Session& session, VideoPacket packet, std::stop_token stop) {
+    std::unique_lock<std::mutex> lock(session.mutex);
+    session.cv.wait(lock, [&] {
+        return session.stopping || stop.stop_requested() ||
+               session.video_queue.size() < kVideoQueueCapacity;
+    });
+    if (session.stopping || stop.stop_requested()) return false;
+    if (!session.initialized) {
+        session.stream_info.width = packet.width;
+        session.stream_info.height = packet.height;
+        session.init_ok = true;
+        session.initialized = true;
+    }
+    session.video_queue.push_back(std::move(packet));
+    session.cv.notify_all();
+    return true;
+}
+
+bool enqueue_audio(Session& session, AudioPacket packet, std::stop_token stop) {
+    std::lock_guard<std::mutex> lock(session.mutex);
+    if (session.stopping || stop.stop_requested()) return false;
+    // A title can render video while routing audio elsewhere. Keep decoding rather than allowing
+    // an unconsumed audio queue to block the demux worker before the next video packet.
+    if (session.audio_queue.size() == kAudioQueueCapacity) session.audio_queue.pop_front();
+    session.audio_queue.push_back(std::move(packet));
+    session.cv.notify_all();
+    return true;
+}
+
+bool convert_video_frame(Pipeline& pipeline, HardwareSelection& selection, Session& session,
+                         AVFrame* decoded, AVRational time_base, std::stop_token stop,
+                         std::string& failure) {
+    const bool hardware = selection.format != AV_PIX_FMT_NONE &&
+                          decoded->format == selection.format;
+    if (!hardware && selection.require_hardware) {
+        failure = "decoder returned a software frame while VA-API hardware decode is required";
+        return false;
+    }
+
+    AVFrame* source = decoded;
+    if (hardware) {
+        av_frame_unref(pipeline.transferred);
+        const int transfer = av_hwframe_transfer_data(pipeline.transferred, decoded, 0);
+        if (transfer < 0) {
+            failure = "VA-API surface transfer failed: " + ff_error(transfer);
+            return false;
+        }
+        source = pipeline.transferred;
+    }
+
+    if (source->width <= 0 || source->height <= 0 ||
+        (source->width & 1) || (source->height & 1)) {
+        failure = "decoded video dimensions are not valid for NV12";
+        return false;
+    }
+
+    VideoPacket packet;
+    packet.width = static_cast<uint32_t>(source->width);
+    packet.height = static_cast<uint32_t>(source->height);
+    packet.stride = packet.width;
+    packet.pts_us = frame_timestamp_us(decoded, time_base);
+    packet.nv12.resize(static_cast<size_t>(packet.stride) * packet.height * 3 / 2);
+    uint8_t* destination[4] = {
+        packet.nv12.data(),
+        packet.nv12.data() + static_cast<size_t>(packet.stride) * packet.height,
+        nullptr,
+        nullptr,
+    };
+    int destination_stride[4] = {
+        static_cast<int>(packet.stride),
+        static_cast<int>(packet.stride),
+        0,
+        0,
+    };
+    pipeline.scaler = sws_getCachedContext(
+        pipeline.scaler, source->width, source->height,
+        static_cast<AVPixelFormat>(source->format), source->width, source->height, AV_PIX_FMT_NV12,
+        SWS_POINT, nullptr, nullptr, nullptr);
+    if (!pipeline.scaler) {
+        failure = "could not create NV12 conversion context";
+        return false;
+    }
+    const int rows = sws_scale(pipeline.scaler, source->data, source->linesize, 0, source->height,
+                               destination, destination_stride);
+    if (rows != source->height) {
+        failure = "decoded frame could not be converted to NV12";
+        return false;
+    }
+
+    if (avp_log() && !session.initialized) {
+        std::fprintf(stderr, "[avp-vaapi] %s decode selected for '%s' (%s -> NV12)\n",
+                     hardware ? "hardware VA-API" : "diagnostic software",
+                     session.path.c_str(), av_get_pix_fmt_name(static_cast<AVPixelFormat>(source->format)));
+    }
+    return enqueue_video(session, std::move(packet), stop);
+}
+
+bool convert_audio_frame(Pipeline& pipeline, Session& session, AVFrame* frame,
+                         AVRational time_base, std::stop_token stop, std::string& failure) {
+    const int channels = frame->ch_layout.nb_channels;
+    const int rate = frame->sample_rate;
+    const auto format = static_cast<AVSampleFormat>(frame->format);
+    if (channels <= 0 || rate <= 0 || format == AV_SAMPLE_FMT_NONE) {
+        failure = "decoded audio frame has invalid format metadata";
+        return false;
+    }
+
+    if (!pipeline.resampler || pipeline.resampler_format != format ||
+        pipeline.resampler_rate != rate || pipeline.resampler_channels != channels) {
+        swr_free(&pipeline.resampler);
+        AVChannelLayout input_layout{};
+        if (frame->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC)
+            av_channel_layout_default(&input_layout, channels);
+        else if (av_channel_layout_copy(&input_layout, &frame->ch_layout) < 0) {
+            failure = "could not copy decoded audio channel layout";
+            return false;
+        }
+        AVChannelLayout output_layout{};
+        av_channel_layout_default(&output_layout, channels);
+        const int allocate = swr_alloc_set_opts2(
+            &pipeline.resampler, &output_layout, AV_SAMPLE_FMT_S16, rate,
+            &input_layout, format, rate, 0, nullptr);
+        av_channel_layout_uninit(&output_layout);
+        av_channel_layout_uninit(&input_layout);
+        if (allocate < 0 || !pipeline.resampler) {
+            failure = "could not create PCM conversion context: " + ff_error(allocate);
+            return false;
+        }
+        const int initialize = swr_init(pipeline.resampler);
+        if (initialize < 0) {
+            failure = "could not initialize PCM conversion context: " + ff_error(initialize);
+            return false;
+        }
+        pipeline.resampler_format = format;
+        pipeline.resampler_rate = rate;
+        pipeline.resampler_channels = channels;
+    }
+
+    const int output_capacity = static_cast<int>(av_rescale_rnd(
+        swr_get_delay(pipeline.resampler, rate) + frame->nb_samples, rate, rate, AV_ROUND_UP));
+    if (output_capacity <= 0) return true;
+    AudioPacket packet;
+    packet.channels = static_cast<uint32_t>(channels);
+    packet.sample_rate = static_cast<uint32_t>(rate);
+    packet.pts_us = frame_timestamp_us(frame, time_base);
+    packet.pcm.resize(static_cast<size_t>(output_capacity) * channels);
+    uint8_t* output = reinterpret_cast<uint8_t*>(packet.pcm.data());
+    const int converted = swr_convert(pipeline.resampler, &output, output_capacity,
+                                      const_cast<const uint8_t**>(frame->extended_data),
+                                      frame->nb_samples);
+    if (converted < 0) {
+        failure = "audio conversion failed: " + ff_error(converted);
+        return false;
+    }
+    packet.pcm.resize(static_cast<size_t>(converted) * channels);
+    return converted == 0 || enqueue_audio(session, std::move(packet), stop);
+}
+
+void decode_session(Session& session, std::stop_token stop) {
+    HardwareSelection selection;
+    selection.require_hardware = !session.allow_software;
+    Pipeline pipeline;
+    std::string failure;
+    int video_stream = -1;
+    int audio_stream = -1;
+    AVRational video_time_base{1, 1};
+    AVRational audio_time_base{1, 1};
+
+    int result = avformat_open_input(&pipeline.format, session.path.c_str(), nullptr, nullptr);
+    if (result < 0) {
+        failure = "could not open source: " + ff_error(result);
+        goto finished;
+    }
+    result = avformat_find_stream_info(pipeline.format, nullptr);
+    if (result < 0) {
+        failure = "could not read stream headers: " + ff_error(result);
+        goto finished;
+    }
+
+    video_stream = av_find_best_stream(pipeline.format, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
+    if (video_stream < 0) {
+        failure = "source has no supported video stream: " + ff_error(video_stream);
+        goto finished;
+    }
+    video_time_base = pipeline.format->streams[video_stream]->time_base;
+    {
+        const AVCodecParameters* parameters = pipeline.format->streams[video_stream]->codecpar;
+        const AVCodec* codec = avcodec_find_decoder(parameters->codec_id);
+        if (!codec) {
+            failure = "no decoder exists for the source video codec";
+            goto finished;
+        }
+        for (int index = 0;; ++index) {
+            const AVCodecHWConfig* config = avcodec_get_hw_config(codec, index);
+            if (!config) break;
+            if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+                config->device_type == AV_HWDEVICE_TYPE_VAAPI) {
+                selection.format = config->pix_fmt;
+                break;
+            }
+        }
+        if (selection.format == AV_PIX_FMT_NONE && selection.require_hardware) {
+            failure = "source video codec has no FFmpeg VA-API hardware configuration";
+            goto finished;
+        }
+        if (selection.format != AV_PIX_FMT_NONE) {
+            const char* configured_device = std::getenv("PROSPER_AVP_VAAPI_DEVICE");
+            if (configured_device && !*configured_device) configured_device = nullptr;
+            result = av_hwdevice_ctx_create(&pipeline.hardware_device, AV_HWDEVICE_TYPE_VAAPI,
+                                            configured_device, nullptr, 0);
+            if (result < 0) {
+                if (selection.require_hardware) {
+                    failure = "could not create VA-API device: " + ff_error(result);
+                    goto finished;
+                }
+                selection.format = AV_PIX_FMT_NONE;
+                if (avp_log()) {
+                    std::fprintf(stderr,
+                                 "[avp-vaapi] VA-API unavailable; explicit software override active: %s\n",
+                                 ff_error(result).c_str());
+                }
+            }
+        }
+        pipeline.video = avcodec_alloc_context3(codec);
+        if (!pipeline.video) {
+            failure = "could not allocate video decoder";
+            goto finished;
+        }
+        result = avcodec_parameters_to_context(pipeline.video, parameters);
+        if (result < 0) {
+            failure = "could not configure video decoder: " + ff_error(result);
+            goto finished;
+        }
+        pipeline.video->pkt_timebase = video_time_base;
+        pipeline.video->opaque = &selection;
+        pipeline.video->get_format = select_video_format;
+        if (pipeline.hardware_device)
+            pipeline.video->hw_device_ctx = av_buffer_ref(pipeline.hardware_device);
+        result = avcodec_open2(pipeline.video, codec, nullptr);
+        if (result < 0) {
+            failure = "could not start video decoder: " + ff_error(result);
+            goto finished;
+        }
+
+        StreamInfo stream;
+        stream.width = parameters->width > 0 ? static_cast<uint32_t>(parameters->width) : 0;
+        stream.height = parameters->height > 0 ? static_cast<uint32_t>(parameters->height) : 0;
+        AVRational frame_rate = av_guess_frame_rate(
+            pipeline.format, pipeline.format->streams[video_stream], nullptr);
+        if (frame_rate.num > 0 && frame_rate.den > 0)
+            stream.fps = static_cast<float>(av_q2d(frame_rate));
+        if (pipeline.format->duration != AV_NOPTS_VALUE && pipeline.format->duration > 0)
+            stream.duration_us = static_cast<uint64_t>(pipeline.format->duration);
+        else if (pipeline.format->streams[video_stream]->duration != AV_NOPTS_VALUE)
+            stream.duration_us = static_cast<uint64_t>(std::max<int64_t>(
+                0, av_rescale_q(pipeline.format->streams[video_stream]->duration,
+                                video_time_base, AVRational{1, 1'000'000})));
+        std::lock_guard<std::mutex> lock(session.mutex);
+        session.stream_info = stream;
+    }
+
+    audio_stream = av_find_best_stream(pipeline.format, AVMEDIA_TYPE_AUDIO, -1, video_stream,
+                                       nullptr, 0);
+    if (audio_stream >= 0) {
+        audio_time_base = pipeline.format->streams[audio_stream]->time_base;
+        const AVCodecParameters* parameters = pipeline.format->streams[audio_stream]->codecpar;
+        const AVCodec* codec = avcodec_find_decoder(parameters->codec_id);
+        if (!codec) {
+            failure = "no decoder exists for the source audio codec";
+            goto finished;
+        }
+        pipeline.audio = avcodec_alloc_context3(codec);
+        if (!pipeline.audio) {
+            failure = "could not allocate audio decoder";
+            goto finished;
+        }
+        result = avcodec_parameters_to_context(pipeline.audio, parameters);
+        if (result < 0 || (result = avcodec_open2(pipeline.audio, codec, nullptr)) < 0) {
+            failure = "could not start audio decoder: " + ff_error(result);
+            goto finished;
+        }
+        std::lock_guard<std::mutex> lock(session.mutex);
+        session.stream_info.has_audio = true;
+        session.stream_info.audio_channels =
+            static_cast<uint32_t>(pipeline.audio->ch_layout.nb_channels);
+        session.stream_info.audio_rate = static_cast<uint32_t>(pipeline.audio->sample_rate);
+    }
+
+    pipeline.packet = av_packet_alloc();
+    pipeline.frame = av_frame_alloc();
+    pipeline.transferred = av_frame_alloc();
+    if (!pipeline.packet || !pipeline.frame || !pipeline.transferred) {
+        failure = "could not allocate decoder packets/frames";
+        goto finished;
+    }
+
+    {
+        auto receive_frames = [&](AVCodecContext* decoder, bool video) -> bool {
+            for (;;) {
+                const int receive = avcodec_receive_frame(decoder, pipeline.frame);
+                if (receive == AVERROR(EAGAIN) || receive == AVERROR_EOF) return true;
+                if (receive < 0) {
+                    failure = std::string(video ? "video" : "audio") +
+                              " decode failed: " + ff_error(receive);
+                    return false;
+                }
+                const bool converted = video
+                    ? convert_video_frame(pipeline, selection, session, pipeline.frame,
+                                          video_time_base, stop, failure)
+                    : convert_audio_frame(pipeline, session, pipeline.frame,
+                                          audio_time_base, stop, failure);
+                av_frame_unref(pipeline.frame);
+                if (!converted) return false;
+            }
+        };
+        auto submit_packet = [&](AVCodecContext* decoder, AVPacket* packet, bool video) -> bool {
+            int send = avcodec_send_packet(decoder, packet);
+            if (send == AVERROR(EAGAIN)) {
+                if (!receive_frames(decoder, video)) return false;
+                send = avcodec_send_packet(decoder, packet);
+            }
+            if (send == AVERROR_EOF) return true;
+            if (send < 0) {
+                failure = std::string(video ? "video" : "audio") +
+                          " packet submission failed: " + ff_error(send);
+                return false;
+            }
+            return receive_frames(decoder, video);
+        };
+
+        bool decode_ok = true;
+        while (!session_stopping(session, stop)) {
+            result = av_read_frame(pipeline.format, pipeline.packet);
+            if (result == AVERROR_EOF) break;
+            if (result < 0) {
+                failure = "MP4 demux failed: " + ff_error(result);
+                decode_ok = false;
+                break;
+            }
+            if (pipeline.packet->stream_index == video_stream)
+                decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
+            else if (pipeline.audio && pipeline.packet->stream_index == audio_stream)
+                decode_ok = submit_packet(pipeline.audio, pipeline.packet, false);
+            av_packet_unref(pipeline.packet);
+            if (!decode_ok) break;
+        }
+        if (decode_ok && !session_stopping(session, stop)) {
+            decode_ok = submit_packet(pipeline.video, nullptr, true);
+            if (decode_ok && pipeline.audio)
+                decode_ok = submit_packet(pipeline.audio, nullptr, false);
+        }
+    }
+
+finished:
+    {
+        std::lock_guard<std::mutex> lock(session.mutex);
+        if (!session.initialized) {
+            session.initialized = true;
+            session.init_ok = false;
+        }
+        session.failure = failure;
+        session.decode_done = true;
+        session.cv.notify_all();
+    }
+    if (!failure.empty())
+        std::fprintf(stderr, "[avp-vaapi] '%s': %s\n", session.path.c_str(), failure.c_str());
+    else if (avp_log())
+        std::fprintf(stderr, "[avp-vaapi] decode loop stopped '%s'\n", session.path.c_str());
+}
+
+void stop_session(const std::shared_ptr<Session>& session) {
+    if (!session) return;
+    {
+        std::lock_guard<std::mutex> lock(session->mutex);
+        session->stopping = true;
+        session->cv.notify_all();
+    }
+    session->thread.request_stop();
+    if (session->thread.joinable()) session->thread.join();
+}
+
+} // namespace
+
+struct VaapiBackend::Impl {
+    std::atomic<int> next_id{1};
+    std::mutex mutex;
+    std::unordered_map<int, std::shared_ptr<Session>> sessions;
+
+    ~Impl() {
+        std::vector<std::shared_ptr<Session>> pending;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            for (auto& [id, session] : sessions) pending.push_back(std::move(session));
+            sessions.clear();
+        }
+        for (const auto& session : pending) stop_session(session);
+    }
+
+    std::shared_ptr<Session> get(int id) {
+        std::lock_guard<std::mutex> lock(mutex);
+        const auto found = sessions.find(id);
+        return found == sessions.end() ? nullptr : found->second;
+    }
+};
+
+VaapiBackend::VaapiBackend() : impl_(std::make_unique<Impl>()) {}
+VaapiBackend::~VaapiBackend() = default;
+
+bool VaapiBackend::available() const { return impl_ != nullptr; }
+
+int VaapiBackend::open(const std::string& host_path) {
+    if (!available() || host_path.empty()) return -1;
+    auto session = std::make_shared<Session>();
+    session->path = host_path;
+    session->allow_software = software_decode_allowed();
+    session->thread = std::jthread(
+        [session](std::stop_token stop) { decode_session(*session, stop); });
+    {
+        std::unique_lock<std::mutex> lock(session->mutex);
+        session->cv.wait(lock, [&] { return session->initialized; });
+        if (!session->init_ok) {
+            lock.unlock();
+            stop_session(session);
+            return -1;
+        }
+    }
+    const int id = impl_->next_id.fetch_add(1);
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->sessions.emplace(id, std::move(session));
+    return id;
+}
+
+bool VaapiBackend::info(int id, StreamInfo& out) {
+    const auto session = impl_->get(id);
+    if (!session) return false;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    out = session->stream_info;
+    return session->init_ok;
+}
+
+bool VaapiBackend::next_video(int id, VideoFrame& out) {
+    const auto session = impl_->get(id);
+    if (!session) return false;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    if (session->video_queue.empty()) return false;
+    session->last_video = std::move(session->video_queue.front());
+    session->video_queue.pop_front();
+    session->cv.notify_all();
+    const size_t y_bytes = static_cast<size_t>(session->last_video.stride) *
+                           session->last_video.height;
+    out.y = session->last_video.nv12.data();
+    out.uv = session->last_video.nv12.data() + y_bytes;
+    out.width = session->last_video.width;
+    out.height = session->last_video.height;
+    out.y_stride = session->last_video.stride;
+    out.uv_stride = session->last_video.stride;
+    out.pts_us = session->last_video.pts_us;
+    return true;
+}
+
+bool VaapiBackend::next_audio(int id, AudioFrame& out) {
+    const auto session = impl_->get(id);
+    if (!session) return false;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    if (session->audio_queue.empty()) return false;
+    session->last_audio = std::move(session->audio_queue.front());
+    session->audio_queue.pop_front();
+    session->cv.notify_all();
+    out.pcm = session->last_audio.pcm.data();
+    out.channels = session->last_audio.channels;
+    out.samples = session->last_audio.channels
+                      ? static_cast<uint32_t>(session->last_audio.pcm.size() /
+                                              session->last_audio.channels)
+                      : 0;
+    out.sample_rate = session->last_audio.sample_rate;
+    out.pts_us = session->last_audio.pts_us;
+    return true;
+}
+
+bool VaapiBackend::eof(int id) {
+    const auto session = impl_->get(id);
+    if (!session) return true;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    return session->decode_done && session->video_queue.empty();
+}
+
+void VaapiBackend::close(int id) {
+    std::shared_ptr<Session> session;
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        const auto found = impl_->sessions.find(id);
+        if (found == impl_->sessions.end()) return;
+        session = std::move(found->second);
+        impl_->sessions.erase(found);
+    }
+    stop_session(session);
+}
+
+VaapiBackend& shared_vaapi_backend() {
+    static VaapiBackend backend_instance;
+    return backend_instance;
+}
+
+bool install_vaapi_backend() {
+    auto& vaapi = shared_vaapi_backend();
+    if (!vaapi.available()) return false;
+    set_backend(&vaapi);
+    return true;
+}
+
+void uninstall_vaapi_backend() {
+    auto& vaapi = shared_vaapi_backend();
+    if (backend() == &vaapi) set_backend(nullptr);
+}
+
+} // namespace prosper::video

--- a/prosper/frontends/video_vaapi/vaapi_backend.hpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "hle/video_backend.hpp"
+
+#include <memory>
+
+namespace prosper::video {
+
+// Native Linux AvPlayer backend. FFmpeg handles MP4 demux and audio conversion while decoded
+// video must come from its VA-API hardware-device path. Hardware surfaces are transferred and
+// converted to bounded CPU-side NV12 packets for the guest AvPlayer ABI. Software video decode is
+// available only through the explicit PROSPER_AVP_ALLOW_SOFTWARE=1 diagnostic override.
+class VaapiBackend final : public VideoBackend {
+public:
+    VaapiBackend();
+    ~VaapiBackend() override;
+
+    VaapiBackend(const VaapiBackend&) = delete;
+    VaapiBackend& operator=(const VaapiBackend&) = delete;
+
+    bool available() const;
+    int open(const std::string& host_path) override;
+    bool info(int id, StreamInfo& out) override;
+    bool next_video(int id, VideoFrame& out) override;
+    bool next_audio(int id, AudioFrame& out) override;
+    bool eof(int id) override;
+    void close(int id) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+bool install_vaapi_backend();
+void uninstall_vaapi_backend();
+
+} // namespace prosper::video

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -27,6 +27,9 @@ extern "C" int prosper_reserved_range_state(uint64_t);   // memory-HLE mapping c
 #ifdef PROSPER_VIDEO_MF
 #include "media_foundation_backend.hpp"   // native Windows AvPlayer demux + hardware decode
 #endif
+#ifdef PROSPER_VIDEO_VAAPI
+#include "vaapi_backend.hpp"              // native Linux FFmpeg demux + VA-API hardware decode
+#endif
 #ifdef PROSPER_HAVE_VULKAN
 #include "gpu/gpu_execute.hpp"
 #include "gpu/tile.hpp"                   // render-target de-swizzle (detile_surface, tiled_surface_bytes)
@@ -127,6 +130,10 @@ int main(int argc, char** argv) {
 #ifdef PROSPER_VIDEO_MF
         if (!prosper::video::install_media_foundation_backend())
             fprintf(stderr, "[avp] Media Foundation backend unavailable\n");
+#endif
+#ifdef PROSPER_VIDEO_VAAPI
+        if (!prosper::video::install_vaapi_backend())
+            fprintf(stderr, "[avp] FFmpeg/VA-API backend unavailable\n");
 #endif
 #ifdef PROSPER_AUDIO_SDL3
         prosper::install_sdl3_audio_sink();


### PR DESCRIPTION
## Goal

Continue #841 by adding a native Linux AvPlayer backend. Linux source-open previously had no production backend and failed unless the synthetic test backend was installed.

## Approach

- use FFmpeg libraries for container demux, codec/stream discovery, timestamps, audio decode, and format conversion
- require FFmpeg's VA-API hardware-device path for video by default
- transfer hardware frames and expose bounded CPU-side NV12 packets through the existing `VideoBackend` ABI
- expose decoded audio as interleaved signed 16-bit PCM
- keep the backend outside `prosper_core`; builds without the development packages retain the headless core
- register the backend in `prosper-app` and `boot_trace`
- add an explicit `PROSPER_AVP_ALLOW_SOFTWARE=1` diagnostic fallback and `PROSPER_AVP_VAAPI_DEVICE` render-node override

The video queue is bounded and back-pressured. The audio queue is bounded and drops its oldest packet so a title that consumes video only cannot deadlock demux. Successful pull pointers remain valid until the next pull of the same media type.

## Impact

Linux builds with FFmpeg/libva development packages gain native MP4 video/audio decode. Windows Media Foundation behavior and the dependency-free core are unchanged.

## Verification

- Linux Debug core build completed
- Linux core test suite: 86/86 passed
- Linux `prosper-app` configured and linked with the FFmpeg/VA-API backend
- `video_vaapi` decoded NV12 video, S16 PCM audio, and monotonic timestamps from local MP4 fixtures with the explicit diagnostic software override
- strict default source-open rejected playback when no VA-API render device was exposed
- Windows `avplayer_hle` and `video_media_foundation` regression tests passed
- `git diff --cached --check` passed
- staged-diff scan found no local filesystem paths

## Risk / remaining validation

The available WSL environment exposes no `/dev/dri` render node, so the strict VA-API execution path could be compiled and failure-tested but not run on physical Linux GPU hardware here. That remains the main validation item for this PR.

Issue #841 remains open for macOS support and the later playback-control/stream-selection work.

Refs #841