### PR TITLE
fix(hle): reject invalid equeue waits

### DIFF
--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -629,6 +629,15 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
     if (evlog()) fprintf(stderr, "[ev] WaitEqueue eq=0x%llx num=%llu timeout=%s ra=eboot+0x%llx\n",
         (unsigned long long)a0, (unsigned long long)a2, a4 ? "yes" : "inf",
         (unsigned long long)((uint64_t)__builtin_return_address(0) - 0x400000000ull));
+    const int num = static_cast<int32_t>(a2);
+    if (num < 1) {
+        if (a3) *(int32_t*)P(a3) = 0;
+        return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
+    }
+    if (!a1) {
+        if (a3) *(int32_t*)P(a3) = 0;
+        return 0x8002000eull;   // SCE_KERNEL_ERROR_EFAULT; do not dequeue an event without a buffer
+    }
     // PROSPER_WAITCALLER: scan the stack for the GAME's wait-loop return address (eboot code range,
     // NOT the stub region at 0x6..) so we can disassemble the loop's exit condition. Log once per eq.
     // PROSPER_DUMPCODE=<hex eboot offset>[,<off2>...]: dump 224 code bytes at each (guest memory is mapped),
@@ -676,7 +685,6 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
         }
     }
     auto s = eq_find(a0);
-    int num = (int)a2; if (num < 1) num = 1;
     // Unknown/deleted queue: the real API errors (Kyty EventQueue.cpp returns KERNEL_ERROR_EBADF);
     // the old success-with-0-events reply made the caller consume a never-written event struct.
     if (!s) { if (a3) *(int32_t*)P(a3) = 0; return 0x80020009ull; }   // KERNEL_ERROR_EBADF

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -630,14 +630,12 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
         (unsigned long long)a0, (unsigned long long)a2, a4 ? "yes" : "inf",
         (unsigned long long)((uint64_t)__builtin_return_address(0) - 0x400000000ull));
     const int num = static_cast<int32_t>(a2);
-    if (num < 1) {
-        if (a3) *(int32_t*)P(a3) = 0;
-        return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
-    }
-    if (!a1) {
-        if (a3) *(int32_t*)P(a3) = 0;
-        return 0x8002000eull;   // SCE_KERNEL_ERROR_EFAULT; do not dequeue an event without a buffer
-    }
+    auto s = eq_find(a0);
+    // Match the API's validation order: queue handle, event array, then count. EFAULT does not
+    // touch *out; EBADF and EINVAL report zero delivered events when the caller supplied it.
+    if (!s) { if (a3) *(int32_t*)P(a3) = 0; return 0x80020009ull; }   // SCE_KERNEL_ERROR_EBADF
+    if (!a1) return 0x8002000eull;                                    // SCE_KERNEL_ERROR_EFAULT
+    if (num < 1) { if (a3) *(int32_t*)P(a3) = 0; return 0x80020016ull; } // SCE_KERNEL_ERROR_EINVAL
     // PROSPER_WAITCALLER: scan the stack for the GAME's wait-loop return address (eboot code range,
     // NOT the stub region at 0x6..) so we can disassemble the loop's exit condition. Log once per eq.
     // PROSPER_DUMPCODE=<hex eboot offset>[,<off2>...]: dump 224 code bytes at each (guest memory is mapped),
@@ -684,10 +682,6 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
             fprintf(stderr, "[waitcaller] ---\n");
         }
     }
-    auto s = eq_find(a0);
-    // Unknown/deleted queue: the real API errors (Kyty EventQueue.cpp returns KERNEL_ERROR_EBADF);
-    // the old success-with-0-events reply made the caller consume a never-written event struct.
-    if (!s) { if (a3) *(int32_t*)P(a3) = 0; return 0x80020009ull; }   // KERNEL_ERROR_EBADF
     std::unique_lock<std::mutex> lk(s->m);
     if (s->ready.empty() && !s->deleted) {
         // timeout arg is a pointer to micro-seconds; NULL = wait forever (real semantics — the old

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -85,6 +85,37 @@ int main() {
         CHECK(gev.udata == kEopUdata, "EOP event echoed the registered udata");
     }
 
+    // --- Invalid WaitEqueue arguments (#388): num < 1 is EINVAL and a null event array is EFAULT.
+    //     Neither failure may consume a ready event; the next valid wait must still receive it.
+    {
+        trigger(eq, (uint64_t)kId, 0x3333, 0, 0, 0);
+        KEvent iev{}; int32_t iout = -1; uint32_t icap = 2000;
+        uint64_t ri = wait(eq, (uint64_t)(uintptr_t)&iev, 0,
+                           (uint64_t)(uintptr_t)&iout, (uint64_t)(uintptr_t)&icap, 0);
+        CHECK((uint32_t)ri == 0x80020016u && iout == 0,
+              "WaitEqueue num<1 returns EINVAL with 0 events");
+        iout = -1;
+        ri = wait(eq, (uint64_t)(uintptr_t)&iev, static_cast<uint64_t>(-1ll),
+                  (uint64_t)(uintptr_t)&iout, (uint64_t)(uintptr_t)&icap, 0);
+        CHECK((uint32_t)ri == 0x80020016u && iout == 0,
+              "WaitEqueue negative count returns EINVAL with 0 events");
+        uint64_t rv = wait(eq, (uint64_t)(uintptr_t)&iev, 1,
+                           (uint64_t)(uintptr_t)&iout, (uint64_t)(uintptr_t)&icap, 0);
+        CHECK(rv == 0 && iout == 1 && iev.udata == 0x3333,
+              "invalid-count wait leaves its ready event queued");
+
+        trigger(eq, (uint64_t)kId, 0x4444, 0, 0, 0);
+        iout = -1;
+        uint64_t rf = wait(eq, 0, 1, (uint64_t)(uintptr_t)&iout,
+                           (uint64_t)(uintptr_t)&icap, 0);
+        CHECK((uint32_t)rf == 0x8002000eu && iout == 0,
+              "WaitEqueue null event array returns EFAULT with 0 events");
+        rv = wait(eq, (uint64_t)(uintptr_t)&iev, 1,
+                  (uint64_t)(uintptr_t)&iout, (uint64_t)(uintptr_t)&icap, 0);
+        CHECK(rv == 0 && iout == 1 && iev.udata == 0x4444,
+              "null-array wait leaves its ready event queued");
+    }
+
     // --- Real wait semantics (#67): a timed wait that expires with nothing returns ETIMEDOUT
     //     (0x8002003C, Kyty EventQueue.cpp:310), NOT success-with-0-events; an unknown queue
     //     handle returns EBADF (0x80020009), not success. ---

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -108,8 +108,13 @@ int main() {
         iout = -1;
         uint64_t rf = wait(eq, 0, 1, (uint64_t)(uintptr_t)&iout,
                            (uint64_t)(uintptr_t)&icap, 0);
-        CHECK((uint32_t)rf == 0x8002000eu && iout == 0,
-              "WaitEqueue null event array returns EFAULT with 0 events");
+        CHECK((uint32_t)rf == 0x8002000eu && iout == -1,
+              "WaitEqueue null event array returns EFAULT without changing out");
+        iout = -2;
+        rf = wait(eq, 0, 0, (uint64_t)(uintptr_t)&iout,
+                  (uint64_t)(uintptr_t)&icap, 0);
+        CHECK((uint32_t)rf == 0x8002000eu && iout == -2,
+              "null event array takes EFAULT precedence over an invalid count");
         rv = wait(eq, (uint64_t)(uintptr_t)&iev, 1,
                   (uint64_t)(uintptr_t)&iout, (uint64_t)(uintptr_t)&icap, 0);
         CHECK(rv == 0 && iout == 1 && iev.udata == 0x4444,
@@ -124,9 +129,11 @@ int main() {
         uint64_t r = wait(eq, (uint64_t)(uintptr_t)&xev, 1, (uint64_t)(uintptr_t)&xout,
                           (uint64_t)(uintptr_t)&xcap, 0);
         CHECK((uint32_t)r == 0x8002003Cu && xout == 0, "timed empty wait returns ETIMEDOUT with 0 events");
-        uint64_t rb = wait(0xDEAD0000ull, (uint64_t)(uintptr_t)&xev, 1, (uint64_t)(uintptr_t)&xout,
+        xout = -1;
+        uint64_t rb = wait(0xDEAD0000ull, 0, 0, (uint64_t)(uintptr_t)&xout,
                            (uint64_t)(uintptr_t)&xcap, 0);
-        CHECK((uint32_t)rb == 0x80020009u, "unknown equeue handle returns EBADF");
+        CHECK((uint32_t)rb == 0x80020009u && xout == 0,
+              "unknown equeue handle takes EBADF precedence and reports 0 events");
     }
 
     // --- kqueue coalescing (#67): two triggers of the SAME (ident, filter) update one pending


### PR DESCRIPTION
Closes #388.

## Problem

`sceKernelWaitEqueue` silently promoted `num < 1` to one event. It also accepted a null event-array pointer, popped ready events, and reported them delivered even though the guest could not receive them. Both paths violated the API error contract and could lose queued events.

The issue's other historical findings are already resolved on master: missing time exports landed in #429 and expirations-since-last-read timer accounting landed in #496.

## Change

- Interpret the ABI count as signed 32-bit and return `SCE_KERNEL_ERROR_EINVAL` for zero/negative counts.
- Return `SCE_KERNEL_ERROR_EFAULT` for a null event array.
- Write `*out = 0` when supplied.
- Validate before queue lookup/wait/dequeue so ready events remain untouched.
- Add real queued-event regressions proving each failed call preserves the event for the next valid wait.

## Risk

Low-to-moderate and localized to invalid API calls. Valid waits, timeouts, queue deletion, event coalescing, and delivery are unchanged and remain covered by the same suite.

## Verification so far

- Windows `equeue_events`: 1/1 passed
- Linux `equeue_events`: 1/1 passed

Full author-owned core verification will be posted on the exact PR head. No renderer snapshot is applicable.