### PR TITLE
fix(#546): report real guest callsites through HLE bridges

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -12,6 +12,7 @@
 // Sony libs, so they're registered by raw NID with a note on the observed role.
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "host/exec_image.hpp"
 #include "gpu/videoout_present.hpp"
 #include "gpu/gpu_execute.hpp"      // guest_readable (safe pointer probe for the diagnostic dumps)
 #include <cstdlib>
@@ -333,10 +334,11 @@ HLE(g_vo_set_window_mode_margins) { vo_argtrace("SetWindowModeMargins", a0,a1,a2
 // the real AGC->Vulkan work (M4/M5), NOT faked output.
 //
 // Per-NID identification: each NID is bound to a distinct template thunk `glog_thunk<I>` that knows
-// its own name (kAgcNids[I]). The guest reaches the thunk via our stub's tail-jump, so at thunk entry
-// [rsp] is the guest return address into eboot (base 0x400000000) — __builtin_return_address(0) gives
-// the exact callsite. Result: `PROSPER_GFXLOG=1 boot_trace <dump>` emits a self-describing dataset
-// (NID + callsite + args per call) — everything needed to RE the AGC object model.
+// its own name (kAgcNids[I]). Plain POSIX stubs tail-jump into the thunk, while Linux guest-FS and
+// Windows ABI bridge stubs CALL it. Capture the thunk's pre-prologue stack and unwrap either shape so
+// the trace always reports the original guest return address, never the generated-stub return site.
+// Result: `PROSPER_GFXLOG=1 boot_trace <dump>` emits a self-describing dataset (NID + guest callsite +
+// args per call) — everything needed to RE the AGC object model.
 namespace {
 // The libSceAgc/AgcDriver NIDs the game calls (observed via boot_trace's unimplemented log). The
 // first four are AgcDriver; the rest are libSceAgc functions used during GfxDevicePS5SharedData init
@@ -490,7 +492,9 @@ uint64_t glog_impl(const char* nid, void* ra,
 template <size_t I>
 __attribute__((noinline)) PROSPER_SYSV_ABI uint64_t glog_thunk(uint64_t a0, uint64_t a1, uint64_t a2,
                                               uint64_t a3, uint64_t a4, uint64_t a5) {
-    return glog_impl(kAgcNids[I], __builtin_return_address(0), a0, a1, a2, a3, a4, a5);
+    const uint64_t entry_rsp = (uint64_t)(uintptr_t)__builtin_frame_address(0) + sizeof(uint64_t);
+    const uint64_t guest_ra = hle_guest_return_address(entry_rsp);
+    return glog_impl(kAgcNids[I], (void*)(uintptr_t)guest_ra, a0, a1, a2, a3, a4, a5);
 }
 template <size_t Offset, size_t... Is>
 void register_agc_tracers(std::index_sequence<Is...>) {

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -38,6 +38,13 @@ void install_sigaltstack();
 // Address of the idx-th import's stub (for tests/bring-up).
 uint64_t stub_addr(uint64_t idx);
 
+// Recover the original caller from an HLE handler's entry stack. Plain POSIX import stubs
+// tail-jump, so [entry_rsp] is already the guest return address. Linux guest-FS and Windows ABI
+// bridge stubs call the handler and leave a generated-stub return address at [entry_rsp]; this
+// unwraps the bridge-specific frame to the guest return address saved behind it.
+// `entry_rsp` must be captured before the handler's compiler prologue.
+uint64_t hle_guest_return_address(uint64_t entry_rsp);
+
 // Test/bring-up: call the idx-th import's stub as the guest would; returns its result.
 uint64_t invoke_stub(uint64_t idx);
 

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2068,6 +2068,21 @@ void arm_hwbp_this_thread() {
 
 uint64_t stub_addr(uint64_t idx) { return g_stub_base + idx * g_stub_size; }
 
+uint64_t hle_guest_return_address(uint64_t entry_rsp) {
+    if (!entry_rsp) return 0;
+    const uint64_t immediate = *(const uint64_t*)(uintptr_t)entry_rsp;
+#if defined(__linux__)
+    // Only the Linux guest-FS path CALLS the HLE handler. At handler entry its frame is:
+    //   +0x00 return-to-stub, +0x08..0x18 forwarded args 7..9, +0x20 alignment pad,
+    //   +0x28 saved guest FS, +0x30 original guest return address.
+    // The host-context and macOS paths tail-jump, so their immediate return is not in the table.
+    const bool from_stub = g_stub_size && immediate >= g_stub_base &&
+                           (immediate - g_stub_base) / g_stub_size < g_nstubs;
+    if (from_stub) return *(const uint64_t*)(uintptr_t)(entry_rsp + 0x30);
+#endif
+    return immediate;
+}
+
 uint64_t invoke_stub(uint64_t idx) {
     auto fn = (uint64_t(*)())(stub_addr(idx));
     return fn();

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -623,6 +623,16 @@ int recovery_thunk_call_rsp_mod16() {
 void arm_hwbp_this_thread() {}
 
 uint64_t stub_addr(uint64_t idx) { return g_stub_base + idx * g_stub_size; }
+uint64_t hle_guest_return_address(uint64_t entry_rsp) {
+    if (!entry_rsp) return 0;
+    const uint64_t immediate = *(const uint64_t*)(uintptr_t)entry_rsp;
+    const bool from_stub = g_stub_size && immediate >= g_stub_base &&
+                           (immediate - g_stub_base) / g_stub_size < g_nstubs;
+    // The SysV-to-MS bridge reserves 0x48 bytes and CALLS the HLE handler. Including that call's
+    // return slot, the original guest return address is 0x50 bytes above the handler-entry RSP.
+    if (from_stub) return *(const uint64_t*)(uintptr_t)(entry_rsp + 0x50);
+    return immediate;
+}
 uint64_t invoke_stub(uint64_t idx) {
     if (idx >= g_nstubs) return 0;
     return ((HleFn)(uintptr_t)stub_addr(idx))(0, 0, 0, 0, 0, 0);

--- a/prosper/tests/test_hle_stack_args.cpp
+++ b/prosper/tests/test_hle_stack_args.cpp
@@ -23,13 +23,18 @@ constexpr uint64_t kReturn = 0xabcddcba01234567ull;
 uint64_t g_seen[9] = {};
 extern "C" {
 uint64_t prosper_test_hle_entry_rsp_mod16 = ~uint64_t{0};
+uint64_t prosper_test_hle_entry_rsp = 0;
 }
+uint64_t g_immediate_return = 0;
+uint64_t g_guest_return = 0;
 
 extern "C" uint64_t prosper_test_hle9_handler(
     uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4,
     uint64_t a5, uint64_t a6, uint64_t a7, uint64_t a8) {
     const uint64_t args[9] = {a0, a1, a2, a3, a4, a5, a6, a7, a8};
     for (int i = 0; i < 9; ++i) g_seen[i] = args[i];
+    g_immediate_return = *(const uint64_t*)(uintptr_t)prosper_test_hle_entry_rsp;
+    g_guest_return = hle_guest_return_address(prosper_test_hle_entry_rsp);
     return kReturn;
 }
 
@@ -50,6 +55,7 @@ __asm__(
     ".p2align 4\n"
     ".globl " PROSPER_ASM_SYMBOL(prosper_test_hle9_entry) "\n"
     PROSPER_ASM_SYMBOL(prosper_test_hle9_entry) ":\n"
+    "    movq %rsp, " PROSPER_ASM_SYMBOL(prosper_test_hle_entry_rsp) "(%rip)\n"
     "    movq %rsp, %r10\n"
     "    andq $15, %r10\n"
     "    movq %r10, " PROSPER_ASM_SYMBOL(prosper_test_hle_entry_rsp_mod16) "(%rip)\n"
@@ -128,8 +134,14 @@ int main(int argc, char** argv) {
 #endif
 
     auto call = reinterpret_cast<GuestHle9>(static_cast<uintptr_t>(stub_addr(1)));
+    const uint64_t callsite_begin = (uint64_t)(uintptr_t)&&before_hle_call;
+    const uint64_t callsite_end = (uint64_t)(uintptr_t)&&after_hle_call;
+before_hle_call:
+    asm volatile("" ::: "memory");
     const uint64_t result = call(kArgs[0], kArgs[1], kArgs[2], kArgs[3], kArgs[4],
                                  kArgs[5], kArgs[6], kArgs[7], kArgs[8]);
+    asm volatile("" ::: "memory");
+after_hle_call:
 
 #if defined(__linux__)
     if (guest_fs_active) guest_fs_enter_host_for_signal();
@@ -138,6 +150,27 @@ int main(int argc, char** argv) {
     CHECK(!guest_fs || guest_fs_active, "activated a guest FS base for the call");
     CHECK(result == kReturn, "return value crossed the import ABI bridge");
     CHECK(prosper_test_hle_entry_rsp_mod16 == 8, "host handler entered with RSP%16 == 8");
+    const bool called_bridge =
+#if defined(_WIN32)
+        true;
+#elif defined(__linux__)
+        guest_fs;
+#else
+        false;
+#endif
+    const uint64_t stub_begin = stub_addr(1);
+    const uint64_t stub_end = stub_begin + 96;
+    if (called_bridge) {
+        CHECK(g_immediate_return >= stub_begin && g_immediate_return < stub_end,
+              "bridge handler's immediate return points into its generated stub");
+    } else {
+        CHECK(g_immediate_return == g_guest_return,
+              "tail-jump handler uses its immediate return as the guest callsite");
+    }
+    const uint64_t callsite_lo = callsite_begin < callsite_end ? callsite_begin : callsite_end;
+    const uint64_t callsite_hi = callsite_begin < callsite_end ? callsite_end : callsite_begin;
+    CHECK(g_guest_return >= callsite_lo && g_guest_return <= callsite_hi,
+          "recovered HLE caller points to the real import callsite, not the generated stub");
     for (int i = 0; i < 9; ++i) {
         char what[96];
         std::snprintf(what, sizeof what, "argument %d preserved (0x%016llx)", i + 1,


### PR DESCRIPTION
## Summary
- unwrap Linux guest-FS and Windows ABI-bridge HLE frames to recover the original guest return address
- use the recovered address for `PROSPER_GFXLOG` AGC tracer attribution
- extend the import-boundary regression test across POSIX tail-jump, Linux guest-FS, and Windows bridge paths

## Focused checks
- Linux: `ctest -R '^hle_stack_args'` (2/2)
- Windows: `ctest -R '^hle_stack_args$'` (1/1)
- no snapshots (diagnostic callsite-only change)

Fixes #546