### PR TITLE
fix(#396 F1): honor sparse audio volume masks

### DIFF
--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -70,8 +70,7 @@ public:
     void set_volume(int port, uint32_t mask, const int* vols) override {
         if (port < 1 || port > kMaxPorts || !vols) return;
         // Approximate the PS5 per-channel volumes as a single stream gain (0..1) from the loudest set channel.
-        int maxv = 0, vi = 0;
-        for (int c = 0; c < 8; c++) if (mask & (1u << c)) { if (vols[vi] > maxv) maxv = vols[vi]; vi++; }
+        int maxv = audio_peak_channel_volume(mask, vols);
         float gain = maxv / 32768.0f;                     // SCE_AUDIO_VOLUME_0DB == 32768
         std::lock_guard<std::mutex> lk(mx_);
         if (SDL_AudioStream* st = slots_[port - 1].stream) SDL_SetAudioStreamGain(st, gain);

--- a/prosper/src/hle/audio.hpp
+++ b/prosper/src/hle/audio.hpp
@@ -30,6 +30,11 @@ inline int audio_grain_bytes(const AudioPortInfo& p) { return p.grain * audio_fr
 // SceAudioOutParamFormat enum; higher bits are attributes (ignored here). Unknown -> S16 stereo.
 void audio_decode_format(uint32_t param, int& channels, AudioFmt& fmt);
 
+// Sony's volume array is channel-indexed even when `mask` is sparse: bit i selects vols[i], not
+// the next compacted element. Shared helpers keep the HLE cache and concrete sinks on that contract.
+void audio_apply_channel_volumes(int dst[8], uint32_t mask, const int* vols);
+int audio_peak_channel_volume(uint32_t mask, const int* vols);
+
 // Pluggable audio backend. All calls arrive on the guest's audio thread; output() MAY block to
 // pace it (as real hardware does — sceAudioOutOutput blocks until the ring has room).
 struct AudioSink {
@@ -38,8 +43,8 @@ struct AudioSink {
     virtual bool open(int port, const AudioPortInfo& info) { (void)port; (void)info; return true; }
     // Deliver one grain (info.grain frames) of interleaved PCM. `pcm` is host-readable, non-owning.
     virtual void output(int port, const void* pcm, int frames) = 0;
-    // Per-channel volume in [0, 32768] (SCE_AUDIO_VOLUME_0DB). `mask` selects which channels
-    // `vols` covers (bit i -> channel i); `vols` is a host-readable array of set bits' values.
+    // Per-channel volume in [0, 32768] (SCE_AUDIO_VOLUME_0DB). `mask` selects which channels;
+    // `vols` is a host-readable eight-element channel-indexed array (bit i applies vols[i]).
     virtual void set_volume(int port, uint32_t mask, const int* vols) { (void)port; (void)mask; (void)vols; }
     virtual void close(int port) { (void)port; }
 };

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -109,6 +109,20 @@ void audio_decode_format(uint32_t param, int& channels, AudioFmt& fmt) {
     }
 }
 
+void audio_apply_channel_volumes(int dst[8], uint32_t mask, const int* vols) {
+    if (!dst || !vols) return;
+    for (int c = 0; c < 8; c++)
+        if (mask & (1u << c)) dst[c] = vols[c];
+}
+
+int audio_peak_channel_volume(uint32_t mask, const int* vols) {
+    if (!vols) return 0;
+    int peak = 0;
+    for (int c = 0; c < 8; c++)
+        if ((mask & (1u << c)) && vols[c] > peak) peak = vols[c];
+    return peak;
+}
+
 void audio_reset() {
     AudioSink* s = audio_sink();
     std::lock_guard<std::mutex> lk(g_mx);
@@ -183,7 +197,7 @@ HLE(audio_set_volume) {
     const int* vols = (const int*)P(a2);
     { std::lock_guard<std::mutex> lk(g_mx);
       Port* p = port_of((int)a0); if (!p) return kAudioErrInvalidPort;
-      if (vols) { int vi = 0; for (int c = 0; c < 8; c++) if (mask & (1u << c)) p->vol[c] = vols[vi++]; } }
+      audio_apply_channel_volumes(p->vol, mask, vols); }
     if (auto* s = audio_sink()) s->set_volume((int)a0, mask, vols);
     return 0;
 }

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -105,14 +105,20 @@ int main() {
     CHECK(call("sceAudioOutOutput", (uint64_t)h, 0) == 0);
     CHECK(sink.outs.size() == 1);
 
-    // --- 4. set volume forwards mask + values -----------------------------------------------
-    int vols[2] = { 20000, 15000 };
-    CHECK(call("sceAudioOutSetVolume", (uint64_t)h, 0x3 /*ch0|ch1*/, PTR(vols)) == 0);
+    // --- 4. sparse volume masks use Sony's channel-indexed array, not compacted values -------
+    int vols[8] = {1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000};
+    constexpr uint32_t sparse_mask = (1u << 4) | (1u << 7);
+    int cached[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+    audio_apply_channel_volumes(cached, sparse_mask, vols);
+    CHECK(cached[4] == 5000); CHECK(cached[7] == 8000);
+    CHECK(cached[0] == -1); CHECK(cached[6] == -1);
+    CHECK(audio_peak_channel_volume(sparse_mask, vols) == 8000);
+    CHECK(call("sceAudioOutSetVolume", (uint64_t)h, sparse_mask, PTR(vols)) == 0);
     CHECK(sink.vols_.size() == 1);
     if (!sink.vols_.empty()) {
-        CHECK(sink.vols_[0].mask == 0x3);
+        CHECK(sink.vols_[0].mask == sparse_mask);
         CHECK(sink.vols_[0].vols.size() == 2);
-        CHECK(sink.vols_[0].vols[0] == 20000); CHECK(sink.vols_[0].vols[1] == 15000);
+        CHECK(sink.vols_[0].vols[0] == 5000); CHECK(sink.vols_[0].vols[1] == 8000);
     }
 
     // --- 5. get port state fills the struct --------------------------------------------------


### PR DESCRIPTION
## Summary
- treat `sceAudioOutSetVolume` values as Sony's eight-element channel-indexed array for sparse masks
- keep the HLE port cache and SDL3 stream-gain approximation on the same contract
- add sparse-mask regression coverage for channels 4 and 7

## Focused checks
- Linux `audio_hle`: pass
- Windows `audio_hle`: pass
- Linux SDL3 dummy-audio `audio_sdl3`: pass
- no snapshots (audio-only change)

Addresses #396 F1 only; the broader AJM/AudioIn tracker remains open.