### PR TITLE
fix(gpu): bound dynamic shader fetch walks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,14 +301,17 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
   for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
   exact-head results.
-- **Use independent review where risk justifies it.** Complex or high-risk changes—such as shader recompilers and
-  control flow, memory safety, synchronization, ABI-sensitive interfaces, persistent data, or changes whose
-  failure can silently corrupt results—require an independent code review before merge. Routine, well-bounded,
-  low-risk changes do not. The reviewer inspects the code, tests, risks, and author evidence, but does not
-  duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR is
-  published, run author verification and any required review; the author posts exact-head evidence and the
-  reviewer posts approval on the corrected head. Address every blocking finding, then merge only after the merge
-  agent separately confirms author verification, reviewer approval where required, and green required CI.
+- **Use independent review where risk justifies it.** Complex or high-risk changes—such as shader/recompiler
+  control flow, memory safety or untrusted bounds, synchronization, ABI-sensitive interfaces, persistent data,
+  shared renderer/executor format, size, or indexing semantics, or changes whose failure can silently corrupt
+  results—require an independent code review before merge. Judge the failure modes, not merely the diff size.
+  Routine, well-bounded, low-risk changes do not require an independent reviewer. The reviewer inspects the
+  assumptions, code, risks, and tests, including whether each regression test would fail without the fix, but
+  does not duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR
+  is published, run author verification and any required review; the author posts exact-head evidence and the
+  reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
+  corrections, then merge only after the merge agent separately confirms author verification, reviewer approval
+  where required, and green required CI.
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -160,8 +160,11 @@ void assign_convention_bindings(ShaderResourceTable& t, uint32_t first);
 // by its bound code address, read its user-data SGPR block from the sh register file, decode the V#/T#/S#
 // descriptors, and assign bindings matching the recompiler+backend convention (constant buffer -> binding
 // 2, vertex buffer -> binding 3, textures -> binding 4+). Returns null if the stage has no shader header
-// or no resources. Implemented in gpu_executor.cpp (needs the AGC registry + descriptor decode).
-std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr, bool is_ps);
+// or no resources. `draw_vertex_count` bounds dynamic descriptors whose V# publishes zero records;
+// indexed draws are grown to their decoded max-index range later in realize_draw_item. Implemented in
+// gpu_executor.cpp (needs the AGC registry + descriptor decode).
+std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr,
+                                                       bool is_ps, uint32_t draw_vertex_count = 0);
 
 // PROSPER_COMPUTELOG diagnostic: resolve every skipped DispatchDirect packet's compute shader and
 // AGC resource table from its retained register snapshot. PROSPER_COMPUTELOG_DIM=WxH restricts output
@@ -474,8 +477,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const bool phase_timing = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto table_start = phase_timing
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
-    std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(ds, rs.es_addr, false);
-    std::shared_ptr<ShaderResourceTable> prt = build_stage_table(ds, rs.ps_addr, true);
+    std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(ds, rs.es_addr, false, vcount_hint);
+    std::shared_ptr<ShaderResourceTable> prt = build_stage_table(ds, rs.ps_addr, true, vcount_hint);
     const auto table_done = phase_timing
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     // PROSPER_RTLOG: correlate this draw's render-target address (CB_COLOR0_BASE) with the addresses of
@@ -564,7 +567,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 fprintf(stderr, "[dynfail] replaying VS 0x%llx resource build with trace:\n",
                         (unsigned long long)rs.es_addr);
                 g_dyntrace_force = true;
-                (void)build_stage_table(ds, rs.es_addr, false);
+                (void)build_stage_table(ds, rs.es_addr, false, vcount_hint);
                 g_dyntrace_force = false;
             }
         }
@@ -575,7 +578,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 fprintf(stderr, "[dynfail] replaying PS 0x%llx resource build with trace:\n",
                         (unsigned long long)rs.ps_addr);
                 g_dyntrace_force = true;
-                (void)build_stage_table(ds, rs.ps_addr, true);
+                (void)build_stage_table(ds, rs.ps_addr, true, vcount_hint);
                 g_dyntrace_force = false;
             }
         }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -78,6 +78,11 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 // into a host fault.
 bool guest_writable(uint64_t addr, uint32_t bytes);
 
+// Convert the untrusted byte size published by an AGC shader header into the exact instruction
+// span that dynamic descriptor folding may probe and decode. Exposed so the safety/work bound has
+// direct regression coverage instead of being inferred from whether a large guest range is mapped.
+size_t dynamic_fold_shader_dwords(uint32_t shader_size_bytes);
+
 // One resolved bindless-dynamic vertex fetch from the wave-uniform scalar const-fold in
 // gpu_executor.cpp: the exact fetch instruction (pc), its SRSRC SGPR, and the V# live in that SGPR
 // at that instruction. Exposed (with resolve_dynamic_fetch) so the fold's scalar-ALU semantics are

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -925,6 +925,17 @@ bool guest_writable(uint64_t a, uint32_t n) {
 #endif
 }
 
+// Registered AGC headers publish the shader blob size in bytes. Dynamic descriptor folding used to
+// ignore it and hand the decoder a fixed 0x4000-dword window, allowing the walk to read up to 64 KiB
+// past a short shader. Truncate a non-dword-aligned tail rather than reading one byte beyond the blob,
+// and refuse a declared span that is not wholly readable. A zero result safely disables only the
+// optional fold; metadata-described resources remain available to build_stage_table.
+size_t registered_shader_dwords(const AgcShaderHeader& header, uint64_t code_addr) {
+    const uint32_t shader_bytes = header.shader_size & ~uint32_t{3};
+    if (!shader_bytes || !guest_readable(code_addr, shader_bytes)) return 0;
+    return shader_bytes / sizeof(uint32_t);
+}
+
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------
 // This game's NGG vertex shader loads its vertex-buffer V# from a descriptor table at a RUNTIME-computed
 // offset (e.g. `s_load_dwordx4 s[8:11], s[24:25], vcc_hi` where `vcc_hi = (s64<<4)&0x1f0` and
@@ -1602,7 +1613,8 @@ void assign_convention_bindings(ShaderResourceTable& t, uint32_t first) {
             r.binding = tex_next++;
 }
 
-std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr, bool is_ps) {
+std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint64_t code_addr,
+                                                       bool is_ps, uint32_t draw_vertex_count) {
     if (!code_addr) return nullptr;
     const auto* hdr = (const AgcShaderHeader*)prosper_agc_shader_header_for_code(code_addr);
     if (!hdr) return nullptr;
@@ -1611,6 +1623,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     const auto metadata_start = phase_timing ? StageClock::now() : StageClock::time_point{};
     namespace P = prosper::agc::Pm4;
     const bool log = getenv("PROSPER_GFXLOG") != nullptr;
+    const size_t shader_dwords = registered_shader_dwords(*hdr, code_addr);
 
     // The V#/T# descriptors live in the stage's user-data SGPR block. The pixel stage uses PS user
     // data; the vertex/geometry stage under NGG merges the ES program's descriptors into GS user data.
@@ -1703,13 +1716,13 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     const auto metadata_done = phase_timing ? StageClock::now() : StageClock::time_point{};
     if (is_ps) {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
-        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
                                        sgprs, kUserSgprs, 0, &srt_uses);
     } else {
         uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
         // shader's s[8:11]/s[24:25] descriptor pointers to the register file at GS_0+offset).
-        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+        dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
                                        sgprs, kUserSgprs, 8, &srt_uses);
         if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_RESDUMP")) {
             fprintf(stderr, "[dynvb] VS resolved %zu dynamic vertex-fetch descriptor(s):\n", dyn_vb.size());
@@ -1780,11 +1793,37 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             r.format        = (d.format == DataFormat::Unknown) ? DataFormat::Float32 : d.format;
             r.num_components = d.num_components ? d.num_components : 4;
             r.gpu_addr      = d.base;
-            r.size          = d.size_bytes ? d.size_bytes : (d.stride ? d.stride * 4 : 128);
+            if (d.size_bytes) {
+                r.size = d.size_bytes;
+            } else {
+                const bool packed_word =
+                    r.format == DataFormat::Float10_11_11 ||
+                    r.format == DataFormat::Unorm2_10_10_10 ||
+                    r.format == DataFormat::Snorm2_10_10_10 ||
+                    r.format == DataFormat::Uint2_10_10_10 ||
+                    r.format == DataFormat::Sint2_10_10_10;
+                const uint64_t element_bytes = packed_word ? 4u :
+                    static_cast<uint64_t>(data_format_bytes(r.format)) * r.num_components;
+                const uint64_t record_bytes = d.stride ? d.stride : element_bytes;
+                const uint64_t draw_bytes = record_bytes * draw_vertex_count;
+                r.size = static_cast<uint32_t>(std::min<uint64_t>(draw_bytes, 0x10000000ull));
+            }
             r.stride        = d.stride;
             r.sgpr_base     = kv.srsrc;           // DIRECT provenance = the fetch's SRSRC SGPR (fallback)
             r.fetch_pc      = kv.fetch_pc;        // PER-FETCH provenance = the exact fetch instruction
             r.srt_offset    = 0xFFFFFFFFu;
+            if (d.format == DataFormat::Unknown) {
+                static std::mutex unknown_mx;
+                static std::set<std::tuple<uint64_t, bool, uint32_t, uint32_t>> unknown_seen;
+                std::lock_guard<std::mutex> lk(unknown_mx);
+                if (unknown_seen.emplace(code_addr, is_ps, kv.fetch_pc, kv.desc_v3).second)
+                    std::fprintf(stderr,
+                                 "[dynvb] %s code=0x%llx fetch pc=%u has unknown V# format 0x%x; "
+                                 "using Float32x4 (draw_vertices=%u size=%u)\n",
+                                 is_ps ? "PS" : "VS", (unsigned long long)code_addr,
+                                 kv.fetch_pc, (kv.desc_v3 >> 12) & 0x7fu,
+                                 draw_vertex_count, r.size);
+            }
             t.resources.push_back(r);
         }
         // Descriptor-TABLE resources (#294): one ShaderResource per distinct table use, keyed by the
@@ -2148,6 +2187,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                              (unsigned long long)code_addr);
             continue;
         }
+        const size_t shader_dwords = registered_shader_dwords(*header, code_addr);
 
         uint32_t range_start = 0;
         if (header->specials && guest_readable((uint64_t)(uintptr_t)header->specials,
@@ -2170,7 +2210,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // Texture. Never shadow an existing resource at the same srt_offset (first-match-wins).
         {
             std::vector<SrtUse> srt_uses;
-            resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+            resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
                                   sgprs, kUserSgprs, /*user_sgpr_base*/0, &srt_uses);
             std::set<uint64_t> srt_seen;
             for (const auto& u : srt_uses) {
@@ -2317,7 +2357,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 continue;
             const uint32_t required = rdna2_sload_required_bytes(
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
-                0x4000, resource.sgpr_base);
+                shader_dwords, resource.sgpr_base);
             if (required > resource.size && required <= 0x10000000u &&
                 guest_readable(resource.gpu_addr, required)) {
                 if (std::getenv("PROSPER_DBG"))
@@ -2400,7 +2440,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                      sgprs[i], sgprs[i + 1], sgprs[i + 2], sgprs[i + 3]);
                     std::vector<SrtUse> cs_uses;
                     g_dyntrace_force = true;
-                    resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, 0x4000,
+                    resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
                                           sgprs, kUserSgprs, 0, &cs_uses);
                     g_dyntrace_force = false;
                     std::fprintf(stderr, "[dynfail]   const-fold recovered %zu descriptor use(s):\n",
@@ -2663,7 +2703,7 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
         // Query before recording this draw's target: a feedback draw should resolve to the preceding
         // writer, not identify itself as its own producer.
         if (inspect_consumers && rs.ps_addr) {
-            auto prt = build_stage_table(ds, rs.ps_addr, true);
+            auto prt = build_stage_table(ds, rs.ps_addr, true, st.draws[i].index_count);
             if (prt) for (const auto& r : prt->resources) {
                 if (r.width != want_w || r.height != want_h) continue;
                 const uint64_t resource_size = r.size ? r.size :

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -932,11 +932,13 @@ bool guest_writable(uint64_t a, uint32_t n) {
 // Truncate a non-dword-aligned tail rather than reading one byte beyond the blob, and refuse the bounded
 // span if it is not wholly readable. A zero result safely disables only the optional fold;
 // metadata-described resources remain available to build_stage_table.
-size_t registered_shader_dwords(const AgcShaderHeader& header, uint64_t code_addr) {
+size_t dynamic_fold_shader_dwords(uint32_t shader_size_bytes) {
     constexpr size_t kMaxDynamicFoldDwords = 0x4000;
-    const uint32_t shader_bytes = header.shader_size & ~uint32_t{3};
-    const size_t dwords = std::min<size_t>(shader_bytes / sizeof(uint32_t),
-                                          kMaxDynamicFoldDwords);
+    return std::min<size_t>(shader_size_bytes / sizeof(uint32_t), kMaxDynamicFoldDwords);
+}
+
+size_t registered_shader_dwords(const AgcShaderHeader& header, uint64_t code_addr) {
+    const size_t dwords = dynamic_fold_shader_dwords(header.shader_size);
     const uint32_t bounded_bytes = static_cast<uint32_t>(dwords * sizeof(uint32_t));
     if (!bounded_bytes || !guest_readable(code_addr, bounded_bytes)) return 0;
     return dwords;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -927,13 +927,19 @@ bool guest_writable(uint64_t a, uint32_t n) {
 
 // Registered AGC headers publish the shader blob size in bytes. Dynamic descriptor folding used to
 // ignore it and hand the decoder a fixed 0x4000-dword window, allowing the walk to read up to 64 KiB
-// past a short shader. Truncate a non-dword-aligned tail rather than reading one byte beyond the blob,
-// and refuse a declared span that is not wholly readable. A zero result safely disables only the
-// optional fold; metadata-described resources remain available to build_stage_table.
+// past a short shader. Retain that historical 64 KiB ceiling as a WORK bound too: CreateShader accepts
+// guest metadata, so a corrupt multi-gigabyte shader_size must not become a page-probe/decode/OOM budget.
+// Truncate a non-dword-aligned tail rather than reading one byte beyond the blob, and refuse the bounded
+// span if it is not wholly readable. A zero result safely disables only the optional fold;
+// metadata-described resources remain available to build_stage_table.
 size_t registered_shader_dwords(const AgcShaderHeader& header, uint64_t code_addr) {
+    constexpr size_t kMaxDynamicFoldDwords = 0x4000;
     const uint32_t shader_bytes = header.shader_size & ~uint32_t{3};
-    if (!shader_bytes || !guest_readable(code_addr, shader_bytes)) return 0;
-    return shader_bytes / sizeof(uint32_t);
+    const size_t dwords = std::min<size_t>(shader_bytes / sizeof(uint32_t),
+                                          kMaxDynamicFoldDwords);
+    const uint32_t bounded_bytes = static_cast<uint32_t>(dwords * sizeof(uint32_t));
+    if (!bounded_bytes || !guest_readable(code_addr, bounded_bytes)) return 0;
+    return dwords;
 }
 
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------
@@ -1795,6 +1801,13 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             r.gpu_addr      = d.base;
             if (d.size_bytes) {
                 r.size = d.size_bytes;
+            } else if (is_ps) {
+                // A pixel-stage buffer_load_format_* retains its real VADDR/stride addressing as a
+                // ConstantBuffer. Fragment/material indices are unrelated to submitted vertex count,
+                // so applying the VS draw-derived bound here can truncate an access that the previous
+                // compatibility allocation covered. Keep that allocation for PS until the fold can
+                // prove an access range, and surface the uncertainty below.
+                r.size = d.stride ? d.stride * 4u : 128u;
             } else {
                 const bool packed_word =
                     r.format == DataFormat::Float10_11_11 ||
@@ -1812,6 +1825,17 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             r.sgpr_base     = kv.srsrc;           // DIRECT provenance = the fetch's SRSRC SGPR (fallback)
             r.fetch_pc      = kv.fetch_pc;        // PER-FETCH provenance = the exact fetch instruction
             r.srt_offset    = 0xFFFFFFFFu;
+            if (!d.size_bytes && is_ps) {
+                static std::mutex zero_ps_mx;
+                static std::set<std::tuple<uint64_t, uint32_t, uint32_t>> zero_ps_seen;
+                std::lock_guard<std::mutex> lk(zero_ps_mx);
+                if (zero_ps_seen.emplace(code_addr, kv.fetch_pc, kv.desc_v3).second)
+                    std::fprintf(stderr,
+                                 "[dynvb] PS code=0x%llx fetch pc=%u has zero-record V#; "
+                                 "VADDR range is not derivable from draw vertices, preserving "
+                                 "compatibility size=%u\n",
+                                 (unsigned long long)code_addr, kv.fetch_pc, r.size);
+            }
             if (d.format == DataFormat::Unknown) {
                 static std::mutex unknown_mx;
                 static std::set<std::tuple<uint64_t, bool, uint32_t, uint32_t>> unknown_seen;

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -122,12 +122,118 @@ int main() {
     CHECK(rc == 0 && dst == &pixel, "pixel buffer-fetch shader enters the AGC registry");
     prosper::gpu::GpuState empty_state;
     auto pixel_table = prosper::gpu::build_stage_table(
-        empty_state, reinterpret_cast<uint64_t>(pixel_buffer_fetch), true);
+        empty_state, reinterpret_cast<uint64_t>(pixel_buffer_fetch), true, 4);
     const prosper::gpu::ShaderResource* pixel_buffer = pixel_table
         ? pixel_table->by_fetch_pc(6) : nullptr;
     CHECK(pixel_buffer && pixel_buffer->cls == prosper::gpu::ResourceClass::ConstantBuffer &&
           pixel_buffer->gpu_addr == 0x20000u && pixel_buffer->stride == 16u,
           "pixel-stage buffer_load_format keeps its exact structured-buffer V# resource");
+
+    // #158: the dynamic fold must use the registered header's byte size, not a fixed 64 KiB walk.
+    // The valid-looking descriptor setup and fetch deliberately sit beyond the declared one-dword
+    // shader. The old 0x4000-dword call found them; the bounded walk must not inspect them.
+    const uint32_t trailing_fetch[] = {
+        0xBF800000u,                // declared shader: s_nop 0
+        0xBE8803FFu, 0x00020000u,   // outside blob: s_mov_b32 s8, V# base low
+        0xBE8903FFu, 0x00100000u,   // s_mov_b32 s9, stride 16
+        0xBE8A0380u,                // s_mov_b32 s10, 0 records
+        0xBE8B0380u,                // s_mov_b32 s11, unknown format
+        0xE0002000u, 0x80020100u,   // pc=7: buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    Shader bounded{};
+    bounded.file_header = 0x34333231u;
+    bounded.version = 0x18u;
+    bounded.shader_size = sizeof(uint32_t);
+    bounded.type = 2;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&bounded),
+                       reinterpret_cast<uint64_t>(trailing_fetch), 0, 0, 0);
+    CHECK(rc == 0 && dst == &bounded, "short shader enters the AGC registry");
+    auto bounded_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(trailing_fetch), false, 7);
+    CHECK(!bounded_table || !bounded_table->by_fetch_pc(7),
+          "dynamic fetch walk cannot discover instructions beyond header.shader_size");
+
+    // A zero-record V# has no descriptor-provided byte bound. Size it from this draw instead of the
+    // title-screen-specific stride*4 fallback. Unknown format remains a compatibility fallback, but
+    // is surfaced and its unstrided record width is derived from the effective Float32x4 shape.
+    const uint32_t zero_record_strided[] = {
+        0xBE8803FFu, 0x00020000u,   // s_mov_b32 s8, V# base low
+        0xBE8903FFu, 0x00140000u,   // s_mov_b32 s9, stride 20
+        0xBE8A0380u,                // s_mov_b32 s10, 0 records
+        0xBE8B0380u,                // s_mov_b32 s11, unknown format
+        0xE0002000u, 0x80020100u,   // pc=6: buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    Shader strided{};
+    strided.file_header = 0x34333231u;
+    strided.version = 0x18u;
+    strided.shader_size = sizeof(zero_record_strided);
+    strided.type = 2;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&strided),
+                       reinterpret_cast<uint64_t>(zero_record_strided), 0, 0, 0);
+    CHECK(rc == 0 && dst == &strided, "zero-record strided shader enters the AGC registry");
+    auto strided_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(zero_record_strided), false, 7);
+    const prosper::gpu::ShaderResource* strided_buffer = strided_table
+        ? strided_table->by_fetch_pc(6) : nullptr;
+    CHECK(strided_buffer && strided_buffer->format == prosper::gpu::DataFormat::Float32 &&
+          strided_buffer->num_components == 4 && strided_buffer->size == 7u * 20u,
+          "zero-record strided V# size follows draw vertex count, not four vertices");
+
+    const uint32_t zero_record_unstrided[] = {
+        0xBE8803FFu, 0x00030000u,   // s_mov_b32 s8, V# base low
+        0xBE890380u,                // s_mov_b32 s9, stride 0
+        0xBE8A0380u,                // s_mov_b32 s10, 0 records
+        0xBE8B0380u,                // s_mov_b32 s11, unknown format
+        0xE0002000u, 0x80020100u,   // pc=5: buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    Shader unstrided{};
+    unstrided.file_header = 0x34333231u;
+    unstrided.version = 0x18u;
+    unstrided.shader_size = sizeof(zero_record_unstrided);
+    unstrided.type = 2;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&unstrided),
+                       reinterpret_cast<uint64_t>(zero_record_unstrided), 0, 0, 0);
+    CHECK(rc == 0 && dst == &unstrided, "zero-record unstrided shader enters the AGC registry");
+    auto unstrided_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(zero_record_unstrided), false, 7);
+    const prosper::gpu::ShaderResource* unstrided_buffer = unstrided_table
+        ? unstrided_table->by_fetch_pc(5) : nullptr;
+    CHECK(unstrided_buffer && unstrided_buffer->size == 7u * 4u * sizeof(float),
+          "zero-record unstrided V# size uses draw count and effective format, not magic 128");
+
+    // Packed V# formats report no per-component byte size because their fields share one dword.
+    // The draw-derived fallback must retain that physical four-byte record instead of collapsing
+    // the resource to zero bytes when both NUM_RECORDS and STRIDE are zero.
+    const uint32_t zero_record_packed[] = {
+        0xBE8803FFu, 0x00040000u,   // s_mov_b32 s8, V# base low
+        0xBE890380u,                // s_mov_b32 s9, stride 0
+        0xBE8A0380u,                // s_mov_b32 s10, 0 records
+        0xBE8B03FFu, (50u << 12) | 0xFACu, // identity 2_10_10_10_UNORM
+        0xE00C2000u, 0x80020100u,   // pc=6: buffer_load_format_xyzw v[1:4], v0, s[8:11]
+        0xBF810000u,
+    };
+    Shader packed{};
+    packed.file_header = 0x34333231u;
+    packed.version = 0x18u;
+    packed.shader_size = sizeof(zero_record_packed);
+    packed.type = 2;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&packed),
+                       reinterpret_cast<uint64_t>(zero_record_packed), 0, 0, 0);
+    CHECK(rc == 0 && dst == &packed, "zero-record packed shader enters the AGC registry");
+    auto packed_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(zero_record_packed), false, 7);
+    const prosper::gpu::ShaderResource* packed_buffer = packed_table
+        ? packed_table->by_fetch_pc(6) : nullptr;
+    CHECK(packed_buffer && packed_buffer->format == prosper::gpu::DataFormat::Unorm2_10_10_10 &&
+          packed_buffer->size == 7u * sizeof(uint32_t),
+          "zero-record packed V# size uses one physical dword per drawn record");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <vector>
 
 using namespace prosper;
 
@@ -155,6 +156,35 @@ int main() {
     CHECK(!bounded_table || !bounded_table->by_fetch_pc(7),
           "dynamic fetch walk cannot discover instructions beyond header.shader_size");
 
+    // The declared size is also untrusted work metadata. A nearly-4-GiB size must not make the
+    // resolver probe/commit/decode that range; retain the old 0x4000-dword work ceiling while still
+    // using shader_size as the read ceiling for short blobs. The non-terminating mapped prefix is
+    // followed by a valid fetch just beyond the cap so an accidentally unbounded walk is observable.
+    std::vector<uint32_t> oversized_fetch(0x4000u + 10u, 0u);
+    const size_t tail = 0x4000u;
+    oversized_fetch[tail + 0] = 0xBE8803FFu;
+    oversized_fetch[tail + 1] = 0x00020000u;
+    oversized_fetch[tail + 2] = 0xBE8903FFu;
+    oversized_fetch[tail + 3] = 0x00100000u;
+    oversized_fetch[tail + 4] = 0xBE8A0380u;
+    oversized_fetch[tail + 5] = 0xBE8B0380u;
+    oversized_fetch[tail + 6] = 0xE0002000u;
+    oversized_fetch[tail + 7] = 0x80020100u;
+    oversized_fetch[tail + 8] = 0xBF810000u;
+    Shader oversized{};
+    oversized.file_header = 0x34333231u;
+    oversized.version = 0x18u;
+    oversized.shader_size = 0xFFFFFFFCu;
+    oversized.type = 2;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&oversized),
+                       reinterpret_cast<uint64_t>(oversized_fetch.data()), 0, 0, 0);
+    CHECK(rc == 0 && dst == &oversized, "oversized shader metadata enters the AGC registry");
+    auto oversized_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(oversized_fetch.data()), false, 7);
+    CHECK(!oversized_table || !oversized_table->by_fetch_pc(static_cast<uint32_t>(tail + 6)),
+          "oversized shader metadata cannot expand dynamic-fold work beyond 64 KiB");
+
     // A zero-record V# has no descriptor-provided byte bound. Size it from this draw instead of the
     // title-screen-specific stride*4 fallback. Unknown format remains a compatibility fallback, but
     // is surfaced and its unstrided record width is derived from the effective Float32x4 shape.
@@ -182,6 +212,37 @@ int main() {
     CHECK(strided_buffer && strided_buffer->format == prosper::gpu::DataFormat::Float32 &&
           strided_buffer->num_components == 4 && strided_buffer->size == 7u * 20u,
           "zero-record strided V# size follows draw vertex count, not four vertices");
+
+    // The same descriptor in a pixel shader is a VADDR-indexed structured/material buffer, not a
+    // gl_VertexIndex-backed vertex attribute. A three-vertex draw therefore cannot shrink its bound
+    // to three records: index 3 still needs the fourth strided record that the old compatibility
+    // allocation exposed.
+    const uint32_t ps_zero_record[] = {
+        0xBE8803FFu, 0x00028000u,   // s_mov_b32 s8, V# base low
+        0xBE8903FFu, 0x00100000u,   // s_mov_b32 s9, stride 16
+        0xBE8A0380u,                // s_mov_b32 s10, 0 records
+        0xBE8B0380u,                // s_mov_b32 s11, unknown format
+        0xE0002000u, 0x80020100u,   // pc=6: buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    Shader ps_zero{};
+    ps_zero.file_header = 0x34333231u;
+    ps_zero.version = 0x18u;
+    ps_zero.shader_size = sizeof(ps_zero_record);
+    ps_zero.type = 1;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&ps_zero),
+                       reinterpret_cast<uint64_t>(ps_zero_record), 0, 0, 0);
+    CHECK(rc == 0 && dst == &ps_zero, "zero-record pixel shader enters the AGC registry");
+    auto ps_zero_table = prosper::gpu::build_stage_table(
+        empty_state, reinterpret_cast<uint64_t>(ps_zero_record), true, 3);
+    const prosper::gpu::ShaderResource* ps_zero_buffer = ps_zero_table
+        ? ps_zero_table->by_fetch_pc(6) : nullptr;
+    CHECK(ps_zero_buffer &&
+          ps_zero_buffer->cls == prosper::gpu::ResourceClass::ConstantBuffer &&
+          ps_zero_buffer->stride == 16u && ps_zero_buffer->size == 4u * 16u &&
+          3u * ps_zero_buffer->stride + sizeof(uint32_t) <= ps_zero_buffer->size,
+          "pixel zero-record V# keeps VADDR index 3 in-bounds on a three-vertex draw");
 
     const uint32_t zero_record_unstrided[] = {
         0xBE8803FFu, 0x00030000u,   // s_mov_b32 s8, V# base low

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -156,10 +156,17 @@ int main() {
     CHECK(!bounded_table || !bounded_table->by_fetch_pc(7),
           "dynamic fetch walk cannot discover instructions beyond header.shader_size");
 
-    // The declared size is also untrusted work metadata. A nearly-4-GiB size must not make the
-    // resolver probe/commit/decode that range; retain the old 0x4000-dword work ceiling while still
-    // using shader_size as the read ceiling for short blobs. The non-terminating mapped prefix is
-    // followed by a valid fetch just beyond the cap so an accidentally unbounded walk is observable.
+    // The declared size is also untrusted work metadata. Assert the exact production span calculation
+    // directly: the previous implementation would request the whole declared range, while the bounded
+    // implementation truncates partial dwords and retains the old 0x4000-dword work ceiling.
+    CHECK(prosper::gpu::dynamic_fold_shader_dwords(3u) == 0u &&
+          prosper::gpu::dynamic_fold_shader_dwords(7u) == 1u,
+          "dynamic-fold span never probes a partial trailing dword");
+    CHECK(prosper::gpu::dynamic_fold_shader_dwords(0x10000u) == 0x4000u &&
+          prosper::gpu::dynamic_fold_shader_dwords(0xFFFFFFFCu) == 0x4000u,
+          "dynamic-fold probe and decode request is capped at 0x4000 dwords");
+
+    // Keep an integration assertion as well: a valid fetch just beyond that cap must stay hidden.
     std::vector<uint32_t> oversized_fetch(0x4000u + 10u, 0u);
     const size_t tail = 0x4000u;
     oversized_fetch[tail + 0] = 0xBE8803FFu;


### PR DESCRIPTION
﻿Fixes #158

## Failure scenario and contract

Dynamic descriptor folding ignored each registered `AgcShaderHeader::shader_size` and decoded a fixed 0x4000-dword window. A short shader could therefore be read up to 64 KiB beyond its declared blob. The same path silently treated an unknown runtime V# format as Float32x4 and sized a zero-record descriptor as either four vertices or a magic 128 bytes, both assumptions inherited from the original Messenger title-screen quad.

The fold must stay inside the registered, readable shader blob without letting corrupt header metadata expand its work budget. A VS dynamic V# with no record bound must follow the current draw rather than a particular four-vertex scene. PS VADDR-driven structured buffers cannot use geometry cardinality as their bound. Any remaining compatibility fallback must be visible.

## What changed

- bound every graphics and compute dynamic-fold walk by both the registered header's aligned `shader_size` and the historical 0x4000-dword/64 KiB maximum work span
- validate only that bounded span before decoding, so oversized metadata cannot cause multi-gigabyte probes, sparse commits, or decoder allocation
- expose the exact work-span calculation and assert its partial-dword behavior and 0x4000-dword cap directly, so the safety regression has negative power independent of guest mappings
- use the same bound for compute SLOAD range inference
- pass the draw's vertex-count hint into stage-table construction and derive VS zero-record sizes from effective record width and draw count, with the existing 256 MiB ceiling
- retain the previous four-record/128-byte compatibility allocation for PS zero-record buffers because PS VADDR indices are unrelated to vertex count, and log that unproven bound once
- preserve four-byte physical sizing for supported packed-word VS formats
- log each distinct unknown-format dynamic fetch once, including stage, shader, PC, raw format, draw count, and chosen size
- add regressions for a fetch beyond a short `shader_size`, the exact oversized-metadata cap, VS strided/unstrided/packed zero-record sizing, and a PS VADDR index beyond a three-vertex draw
- clarify the risk-based independent-review rule in `CLAUDE.md`, including untrusted bounds, shared renderer sizing/indexing semantics, and regression-test negative power

## Scope and risks

This affects only dynamic descriptors recovered by the scalar fold. Metadata-described resources and descriptors with a nonzero `num_records` retain their existing sizes. The Unknown-to-Float32x4 behavior is intentionally retained for compatibility but is no longer silent. Indexed VS buffers are still grown later from the decoded maximum index, so the early draw hint cannot truncate their realized range. PS dynamic buffers do not use the draw-derived path.

The main risk is silent resource-bound/rendering change across shared graphics and compute paths, so independent GPU review and all current routed game guards are required.

## Focused checks completed

On current head `3e0a5e4388ef8885a519ac1b946fb1327461c85a`:

- Linux: built `test_agc_shader` and `test_dynfetch_fold`; `agc_shader_create` and `dynfetch_fold` passed
- Windows/MinGW: built the same targets; `agc_shader_create` and `dynfetch_fold` passed
- `git diff --check` passed

## Exact-head author verification planned

On corrected head `3e0a5e4388ef8885a519ac1b946fb1327461c85a`, the PR author will run:

```powershell
powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot all -Pr 854
```

This runs Linux and Windows builds/ctest plus every current routed real-game guard. No snapshot baseline will be created or updated. The independent reviewer must inspect this evidence but must not rerun it.
