### PR TITLE
fix(#343): preserve reservations across protection changes

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -340,6 +340,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_dmem PRIVATE prosper_core)
   add_test(NAME dmem_available COMMAND test_dmem)
 
+  # A protection-only change must retain an uncommitted reservation's state (#343), or guest
+  # VirtualQuery skips the later commit and the first access faults. Cross-platform HLE contract.
+  add_executable(test_retrack_reservation tests/test_retrack_reservation.cpp)
+  target_link_libraries(test_retrack_reservation PRIVATE prosper_core)
+  add_test(NAME retrack_reservation COMMAND test_retrack_reservation)
+
   # Hinted map must not clobber a live mapping (#137): MAP_FIXED_NOREPLACE unless the hint is our
   # own uncommitted reservation. Drives the real map HLE handlers. Linux-only (mmap semantics).
   if(UNIX)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -130,11 +130,30 @@ namespace {
         g_dmem.swap(out);
     }
 
+    // A successful host map replaces any reservation record under it. Keeping both as overlays
+    // lets the older uncommitted record win same-base queries after the real commit.
     void track(uint64_t base, uint64_t size, int prot, bool committed, const char* nm) {
-        std::lock_guard<std::mutex> lk(g_mx);
-        Mapping m{ base, size, prot, committed, {0} };
-        if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
-        g_maps.push_back(m);
+        if (!size || base > UINT64_MAX - size) return;
+        const uint64_t end = base + size;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            std::vector<Mapping> out;
+            out.reserve(g_maps.size() + 2);
+            for (const auto& old : g_maps) {
+                const uint64_t old_end = old.base + old.size;
+                if (old_end <= base || old.base >= end) { out.push_back(old); continue; }
+                if (old.base < base) {
+                    Mapping lo = old; lo.size = base - old.base; out.push_back(lo);
+                }
+                if (old_end > end) {
+                    Mapping hi = old; hi.base = end; hi.size = old_end - end; out.push_back(hi);
+                }
+            }
+            Mapping m{ base, size, prot, committed, {0} };
+            if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
+            out.push_back(m);
+            g_maps.swap(out);
+        }
         host::notify_guest_mapping_added(base, size, committed && (prot & 0x1));
     }
     // Trim/split tracked mappings overlapping [base, base+len). munmap/BatchMap-UNMAP must remove
@@ -158,12 +177,49 @@ namespace {
         g_maps.swap(out);
         host::notify_guest_mapping_removed(base, len);
     }
-    // Re-tag [base, base+len) with a new protection (mprotect): replace the overlapped span so
-    // VirtualQuery/the fault probe report the CURRENT prot, not the one from map time.
+    // Re-tag [base, base+len) with a new protection (mprotect) without changing whether each
+    // covered span is guest-committed. A reservation remains a reservation until a MAP operation
+    // commits it; VirtualQuery and the lazy-commit probe rely on that distinction (#343).
     void retrack_prot(uint64_t base, uint64_t len, int prot, const char* nm) {
-        if (!len) return;
-        untrack(base, len);
-        track(base, len, prot, true, nm);
+        if (!len || base > UINT64_MAX - len) return;
+        const uint64_t end = base + len;
+        std::vector<Mapping> retagged;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            std::vector<Mapping> out;
+            out.reserve(g_maps.size() + 2);
+            for (const auto& m : g_maps) {
+                const uint64_t me = m.base + m.size;
+                if (me <= base || m.base >= end) { out.push_back(m); continue; }
+                if (m.base < base) {
+                    Mapping lo = m; lo.size = base - m.base; out.push_back(lo);
+                }
+                Mapping changed = m;
+                changed.base = m.base < base ? base : m.base;
+                const uint64_t changed_end = me > end ? end : me;
+                changed.size = changed_end - changed.base;
+                changed.prot = prot;
+                memset(changed.name, 0, sizeof changed.name);
+                if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
+                out.push_back(changed);
+                retagged.push_back(changed);
+                if (me > end) {
+                    Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi);
+                }
+            }
+            // Preserve the prior treatment of a successful protection change over an otherwise
+            // untracked host mapping: begin tracking it as committed.
+            if (retagged.empty()) {
+                Mapping changed{base, len, prot, true, {0}};
+                if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
+                out.push_back(changed);
+                retagged.push_back(changed);
+            }
+            g_maps.swap(out);
+        }
+        host::notify_guest_mapping_removed(base, len);
+        for (const auto& m : retagged)
+            host::notify_guest_mapping_added(m.base, m.size, m.committed && (prot & 0x1));
     }
     const Mapping* find(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);
@@ -1299,12 +1355,30 @@ namespace {
         }
         g_dmem.swap(out);
     }
+    // Keep tracking non-overlapping when a commit replaces part of an existing reservation.
     void track(uint64_t base, uint64_t size, int prot, bool committed, const char* nm,
                bool host_readable = true) {
-        std::lock_guard<std::mutex> lk(g_mx);
-        Mapping m{ base, size, prot, committed, {0} };
-        if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
-        g_maps.push_back(m);
+        if (!size || base > UINT64_MAX - size) return;
+        const uint64_t end = base + size;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            std::vector<Mapping> out;
+            out.reserve(g_maps.size() + 2);
+            for (const auto& old : g_maps) {
+                const uint64_t old_end = old.base + old.size;
+                if (old_end <= base || old.base >= end) { out.push_back(old); continue; }
+                if (old.base < base) {
+                    Mapping lo = old; lo.size = base - old.base; out.push_back(lo);
+                }
+                if (old_end > end) {
+                    Mapping hi = old; hi.base = end; hi.size = old_end - end; out.push_back(hi);
+                }
+            }
+            Mapping m{ base, size, prot, committed, {0} };
+            if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
+            out.push_back(m);
+            g_maps.swap(out);
+        }
         host::notify_guest_mapping_added(base, size,
                                          committed && host_readable && (prot & 0x1));
     }
@@ -1324,12 +1398,48 @@ namespace {
         host::notify_guest_mapping_removed(base, len);
     }
     void retrack_prot(uint64_t base, uint64_t len, int prot, const char* nm) {
-        if (!len) return;
-        untrack(base, len);
-        // Sparse protection overlays remain submit-local; fully committed mappings retain the
-        // generation-guarded cross-submit readability optimization from #737.
-        track(base, len, prot, true, nm,
-              base <= UINT64_MAX - len && !sparse_dmem_view_overlaps(base, base + len));
+        if (!len || base > UINT64_MAX - len) return;
+        const uint64_t end = base + len;
+        std::vector<Mapping> retagged;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            std::vector<Mapping> out;
+            out.reserve(g_maps.size() + 2);
+            for (const auto& m : g_maps) {
+                const uint64_t me = m.base + m.size;
+                if (me <= base || m.base >= end) { out.push_back(m); continue; }
+                if (m.base < base) {
+                    Mapping lo = m; lo.size = base - m.base; out.push_back(lo);
+                }
+                Mapping changed = m;
+                changed.base = m.base < base ? base : m.base;
+                const uint64_t changed_end = me > end ? end : me;
+                changed.size = changed_end - changed.base;
+                changed.prot = prot;
+                memset(changed.name, 0, sizeof changed.name);
+                if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
+                out.push_back(changed);
+                retagged.push_back(changed);
+                if (me > end) {
+                    Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi);
+                }
+            }
+            if (retagged.empty()) {
+                Mapping changed{base, len, prot, true, {0}};
+                if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
+                out.push_back(changed);
+                retagged.push_back(changed);
+            }
+            g_maps.swap(out);
+        }
+        host::notify_guest_mapping_removed(base, len);
+        for (const auto& m : retagged) {
+            // Sparse protection overlays remain submit-local; fully committed mappings retain the
+            // generation-guarded cross-submit readability optimization from #737.
+            const bool host_readable = !sparse_dmem_view_overlaps(m.base, m.base + m.size);
+            host::notify_guest_mapping_added(
+                m.base, m.size, m.committed && host_readable && (prot & 0x1));
+        }
     }
     const Mapping* find(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -1,0 +1,85 @@
+// test_retrack_reservation (#343) -- changing protection on an uncommitted guest reservation
+// must not make the tracking layer report that the pages were committed. Guests use
+// VirtualQuery to decide whether a later commit is necessary; a false committed result skips that
+// commit and leaves the first access faulting.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+extern "C" int prosper_reserved_range_state(uint64_t addr);
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_retrack_reservation ==\n");
+    register_builtin_hle();
+    auto reserve  = Hle::lookup(nid_hash("sceKernelReserveVirtualRange"));
+    auto protect  = Hle::lookup(nid_hash("sceKernelMprotect"));
+    auto query    = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
+    auto flexible = Hle::lookup(nid_hash("sceKernelMapNamedFlexibleMemory"));
+    auto unmap    = Hle::lookup(nid_hash("sceKernelMunmap"));
+    CHECK(reserve && protect && query && flexible && unmap, "memory HLE functions registered");
+    if (fails) return 1;
+
+    constexpr uint64_t page = 0x10000;
+    constexpr uint64_t len = page * 3;
+    uint64_t base = 0;
+    CHECK(reserve((uint64_t)(uintptr_t)&base, len, 0, page, 0, 0) == 0 && base,
+          "reserve three uncommitted pages");
+    if (!base) return 1;
+
+    const uint64_t middle = base + page;
+    CHECK(protect(middle, page, 0x2 /* SCE_KERNEL_PROT_CPU_RW */, 0, 0, 0) == 0,
+          "mprotect accepts the middle reservation page");
+
+    uint8_t info[0x48]{};
+    CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0,
+          "VirtualQuery accepts the protected reservation page");
+    CHECK(*(uint64_t*)(info + 0x00) == middle &&
+              *(uint64_t*)(info + 0x08) == middle + page,
+          "protection tracking splits the reservation at the requested bounds");
+    CHECK(*(int32_t*)(info + 0x18) == 0 && *(uint32_t*)(info + 0x20) == 0,
+          "VirtualQuery still reports the protected reservation as uncommitted");
+    CHECK(prosper_reserved_range_state(middle) == 1,
+          "the lazy-commit probe still classifies the page as reserved");
+
+    uint64_t committed = middle;
+    CHECK(flexible((uint64_t)(uintptr_t)&committed, page, 0x2, 0,
+                   (uint64_t)(uintptr_t)"retrack-commit", 0) == 0 && committed == middle,
+          "MapFlexible can commit the protected reservation in place");
+    if (committed == middle) {
+        volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)committed;
+        *cell = 0x343343u;
+        CHECK(*cell == 0x343343u, "the committed page is writable");
+    }
+    memset(info, 0, sizeof(info));
+    CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+              *(uint32_t*)(info + 0x20) == 0x10,
+          "VirtualQuery reports the page as committed only after MapFlexible");
+
+    CHECK(protect(base, len, 0x1 /* SCE_KERNEL_PROT_CPU_READ */, 0, 0, 0) == 0,
+          "mprotect accepts a range spanning reserved and committed pages");
+    memset(info, 0, sizeof(info));
+    CHECK(query(base, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+              *(uint32_t*)(info + 0x20) == 0,
+          "range protection keeps the leading page uncommitted");
+    memset(info, 0, sizeof(info));
+    CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+              *(uint32_t*)(info + 0x20) == 0x10,
+          "range protection keeps the middle page committed");
+    memset(info, 0, sizeof(info));
+    CHECK(query(middle + page, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+              *(uint32_t*)(info + 0x20) == 0,
+          "range protection keeps the trailing page uncommitted");
+
+    CHECK(unmap(base, len, 0, 0, 0, 0) == 0, "the test reservation unmaps cleanly");
+    if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #343

## Failure scenario and contract

A guest can reserve virtual memory without committing backing pages, then change protection on a subrange before its real `MapFlexible`/BatchMap commit. The old `retrack_prot` always replaced that subrange with `committed=true`, so `sceKernelVirtualQuery` and `prosper_reserved_range_state` claimed the reservation was live. POSIX fixed-address mapping then refused the legitimate commit, or the guest skipped it and faulted on first access.

A protection-only operation must update protection metadata without changing the guest commit state. A later successful map is the transition that marks the span committed.

## Approach and invariants

- Preserve each overlapped mapping segment's existing `committed` bit while splitting/re-tagging protection ranges, on both POSIX and Windows.
- Make `track` replace overlapping reservation records when a real map succeeds, so same-base stale reservation overlays cannot hide the later committed record.
- Keep the existing behavior for protection changes over otherwise untracked host mappings.
- Refresh guest-readable mapping generations for each resulting segment.
- Add a cross-platform real-HLE regression covering partial reservation protection, lazy-commit classification, the later in-place commit, and a protection range spanning reserved/committed/reserved segments.

## Affected and deliberately unaffected behavior

Affected: kernel-memory tracking for reserve/protect/map sequences and the VirtualQuery/lazy-commit answers derived from it.

Unaffected: host VM protection primitives and their return contract, direct-memory allocation/accounting, renderer behavior, and snapshot baselines.

## Risk

The tracking vector is shared infrastructure used by the fault probe and safe guest-memory reads. The implementation retains the existing mutex discipline and validates adjacent map/protection/direct-memory tests on both platform implementations. No game snapshots are relevant because this changes memory metadata, not rendered output.

## Pre-PR verification

- Windows MinGW Release: `test_retrack_reservation`, `dmem_available`, `file_binary_roundtrip` — pass.
- Linux Release: `test_retrack_reservation`, `map_noreplace`, `prot_none`, `dmem_available`, `file_binary_roundtrip` — pass.
- `git diff --check` — pass.

Full exact-head core verification and independent code review will be posted separately.