### PR TITLE
fix(#392): report the en-US date format enum

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -796,13 +796,16 @@ HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = ((int32_t)a0 == 0) ? 3 : 0; 
 // value 0 = SCE_SYSTEM_PARAM_LANG_JAPANESE, so games localise their UI/text to Japanese. Default to
 // US English (SCE_SYSTEM_PARAM_LANG_ENGLISH_US = 1) instead. Configurable via PROSPER_SYS_LANG, which
 // takes the Sony SCE_SYSTEM_PARAM_LANG_* enum (0=ja, 1=en-US, 2=fr, 4=de, 5=it, 9=ko, 18=en-GB, …).
-// Date/time-format params (2/3) default to the US convention (0 = MM/DD/YYYY, 12-hour).
+// Date/time-format params (2/3) default to the US convention: date enum 2 = MM/DD/YYYY and
+// time enum 0 = 12-hour. Date enum 0 is YYYYMMDD, despite the old comment claiming it was US.
 HLE(s_syss_param_int) {
     int32_t paramId = (int32_t)a0;           // a0 = paramId, a1 = int32_t* value out (matches s_appcontent_int)
     int32_t val = 0;
     if (paramId == 1) {                      // SCE_SYSTEM_SERVICE_PARAM_ID_LANG
         val = 1;                             // SCE_SYSTEM_PARAM_LANG_ENGLISH_US
         if (const char* e = getenv("PROSPER_SYS_LANG")) val = (int32_t)strtol(e, nullptr, 0);
+    } else if (paramId == 2) {               // SCE_SYSTEM_SERVICE_PARAM_ID_DATE_FORMAT
+        val = 2;                             // SCE_SYSTEM_PARAM_DATE_FORMAT_MMDDYYYY
     } else if (paramId == 1000) {            // SCE_SYSTEM_SERVICE_PARAM_ID_ENTER_BUTTON_ASSIGN
         // Cross = confirm (Western default). Previously fell through to val=0 = Circle, which inverts
         // ✕/○ confirm/cancel and on-screen button prompts relative to the en-US locale we present.

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -163,6 +163,11 @@ int main() {
         if (HleFn f = Hle::lookup(nid_hash("sceSystemServiceParamGetInt"))) {
             int32_t out = (int32_t)0xDEAD; f(1 /*LANG*/, (uint64_t)(uintptr_t)&out, 0, 0, 0, 0);
             CHECK(out == 1, "ParamGetInt(LANG) -> en-US(1), not the uninitialized/Japanese default");
+
+            out = (int32_t)0xDEAD;
+            f(2 /*DATE_FORMAT*/, (uint64_t)(uintptr_t)&out, 0, 0, 0, 0);
+            CHECK(out == 2,
+                  "ParamGetInt(DATE_FORMAT) -> MM/DD/YYYY(2), matching the en-US default");
         } else CHECK(false, "sceSystemServiceParamGetInt registered");
 
         // sceSystemServiceGetStatus(status*) -> fills 12 bytes, byte[6] (isCpuMode7CpuNormal)=1, and


### PR DESCRIPTION
Refs #392 (date-format remainder only; the broader SaveData/service audit stays open)

## Failure scenario and contract

`SceSystemServiceParamGetInt(DATE_FORMAT=2)` returned `0`. Sony enum 0 is `YYYYMMDD`, but prosper presents an en-US language/confirm-button configuration and the code comment incorrectly called 0 the US `MM/DD/YYYY` format.

For the existing en-US default, DATE_FORMAT must return Sony enum 2 (`MM/DD/YYYY`). TIME_FORMAT remains enum 0 (12-hour).

## Approach

- Return 2 only for system parameter ID 2 (`DATE_FORMAT`).
- Correct the misleading enum comment.
- Extend the existing real-HLE service getter regression to assert the en-US date format.

## Affected and unaffected behavior

Affected: only `sceSystemServiceParamGetInt` parameter ID 2.

Unchanged: language and its environment override, 12/24-hour selection, Enter-button assignment and its override, unknown parameter defaults, SaveData behavior, renderer output, and all snapshots.

## Risk and review decision

Low risk: this is one fixed enum result with a regression that fails on the old handler. Under `CLAUDE.md`'s risk-based policy, this routine mechanically verified change does not require independent review.

## Pre-PR verification

- Windows MinGW Release `service_getters` — pass.
- `git diff --check` — pass.

Full exact-head core verification and CI will be posted separately.