### PR TITLE
fix(#847): serialize macOS getdents cache lifetime

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -798,6 +798,8 @@ HLE(f_rmdir) { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::rm
 // ReadDirR -> GetDirectoryEntryFullPath) opens+closes many directories, reusing fd numbers, so a stale
 // DIR* returns a consumed/closed directory -> a garbage DirectoryEntry -> strcmp on a bad name pointer,
 // crashing scene load (the macOS Blasphemous 2 first-level wall). File-scope so f_close can invalidate.
+// The mutex covers both the map and every DIR* operation: invalidation must not closedir a stream
+// while getdents is using it, and two reads of one stream must not race its cursor (#847).
 static std::mutex g_getdents_mx;
 static std::map<int, DIR*> g_getdents_dirs;
 void getdents_forget_fd(int fd) {
@@ -812,18 +814,18 @@ HLE(f_getdents) {
     // Darwin has no getdents-on-fd (getdirentries is unavailable with 64-bit inodes). Keep the
     // per-fd kernel cursor by caching one DIR* per directory fd (fdopendir owns a dup, so the
     // guest's fd number stays valid); seekdir puts back the first entry that doesn't fit.
-    // CONFIDENCE: MED — a guest that closes the fd and gets the number reused for a different
-    // directory would see a stale cursor; not exercised by current titles.
+    // Hold the cache mutex through the complete read so f_close cannot invalidate/free dp
+    // underneath us; this also serializes concurrent reads of the same cursor.
+    std::lock_guard<std::mutex> lk(g_getdents_mx);
     DIR* dp = nullptr;
-    { std::lock_guard<std::mutex> lk(g_getdents_mx);
-      auto it = g_getdents_dirs.find((int)a0);
-      if (it != g_getdents_dirs.end()) dp = it->second;
-      else {
-          int d2 = dup((int)a0);
-          dp = d2 >= 0 ? fdopendir(d2) : nullptr;
-          if (!dp) { if (d2 >= 0) ::close(d2); return 0x80020000ull | (uint64_t)(errno & 0xff); }
-          g_getdents_dirs[(int)a0] = dp;
-      } }
+    auto it = g_getdents_dirs.find((int)a0);
+    if (it != g_getdents_dirs.end()) dp = it->second;
+    else {
+        int d2 = dup((int)a0);
+        dp = d2 >= 0 ? fdopendir(d2) : nullptr;
+        if (!dp) { if (d2 >= 0) ::close(d2); return 0x80020000ull | (uint64_t)(errno & 0xff); }
+        g_getdents_dirs[(int)a0] = dp;
+    }
     uint8_t* out = (uint8_t*)P(a1);
     size_t w = 0;
     for (;;) {

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -477,15 +477,17 @@ HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_fla
                    h.c_str(), (unsigned long long)a1, host_flags, fd, err);
                if (fd >= 0) preadlog("open", (uint64_t)fd, 0, 0); return (uint64_t)(int64_t)fd; }
 #ifdef __APPLE__
-void getdents_forget_fd(int fd);   // #843: cache invalidator, defined with f_getdents below
+int getdents_close_fd(int fd);   // #843/#847: atomic cache invalidation + host close
 #endif
 HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
                preadlog("close", a0, 0, 0);
                int fd = (int)a0;
 #ifdef __APPLE__
-               getdents_forget_fd(fd);   // #843: drop any cached DIR* before this fd is closed/reused
+               int r = getdents_close_fd(fd);
+#else
+               int r = ::close(fd);
 #endif
-               int r = ::close(fd); int err = r < 0 ? errno : 0;
+               int err = r < 0 ? errno : 0;
                filelog_fd_io("close", fd, 0, 0, r, err);
                if (r == 0) filelog_forget_fd(fd);
                return (uint64_t)(int64_t)r; }
@@ -802,10 +804,13 @@ HLE(f_rmdir) { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::rm
 // while getdents is using it, and two reads of one stream must not race its cursor (#847).
 static std::mutex g_getdents_mx;
 static std::map<int, DIR*> g_getdents_dirs;
-void getdents_forget_fd(int fd) {
+int getdents_close_fd(int fd) {
     std::lock_guard<std::mutex> lk(g_getdents_mx);
     auto it = g_getdents_dirs.find(fd);
     if (it != g_getdents_dirs.end()) { if (it->second) closedir(it->second); g_getdents_dirs.erase(it); }
+    // Keep the guest-fd close under the same guard. Otherwise getdents can repopulate this key
+    // after erase but before close, leaving the replacement DIR* stale when the fd is reused.
+    return ::close(fd);
 }
 #endif
 HLE(f_getdents) {


### PR DESCRIPTION
Fixes #847

## Failure scenario and contract

PR #846 added a Darwin `DIR*` cache and made `f_close` invalidate it with `closedir`. Cache lookup/insertion was protected by `g_getdents_mx`, but `telldir`/`readdir`/`seekdir` and conversion ran after releasing the mutex. A concurrent close of the same guest fd could therefore free the `DIR*` while `f_getdents` was using it (use-after-free). Two concurrent reads could also race one stream's cursor.

Every operation on a cached `DIR*`, including destruction, must be mutually exclusive with reads of that stream.

## Approach and invariants

- Hold `g_getdents_mx` continuously from cache lookup/creation through the full Darwin directory-read loop and output conversion.
- `getdents_forget_fd` already acquires the same mutex before `closedir`/erase, so close now waits for an active read to finish.
- The same scope serializes cursor updates for concurrent reads.
- Keep fd duplication/ownership, record layout, rewind-on-no-fit behavior, error values, and non-Darwin implementations unchanged.

This intentionally serializes reads on distinct cached directories too. The directory enumeration is startup/control-path work, and the simple lifetime proof is preferable to adding refcount/deferred-destruction machinery for an unobserved throughput need.

## Affected and unaffected behavior

Affected: macOS `sceKernelGetdents` concurrency with `f_close` or another `getdents` call.

Unaffected: the serial Blasphemous 2 enumeration fixed by #846, Linux `getdents64`, Windows stubs, file contents/path translation, renderer output, and snapshot baselines.

## Risk

Memory-safety and synchronization change in a game-enabling macOS path. Independent exact-head review is required. The changed `__APPLE__` block cannot be compiled on this Windows/Linux host; macOS CI is the platform validation gate. No snapshots are relevant.

## Pre-PR verification

- `git diff --check` — pass.
- Static lock-scope inspection: both read and invalidation use `g_getdents_mx`; no return or DIR operation escapes the read guard.

Full exact-head core verification, independent review, and CI will be posted separately.