### PR TITLE
fix(audio): report port-specific output routes

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -225,9 +225,11 @@ HLE(audio_get_port_state) {
         memset(st, 0, 0x20);
         *(int16_t*)(st + 4) = 127;   // volume (Kyty AudioOutGetPortState reports 127)
         switch (type) {              // output/channel are port-type dependent (Kyty :432-448)
-            case 3: case 127: /* output=0, channel=0 */ break;
-            case 4:  *(uint16_t*)(st + 0) = 4; st[2] = 1; break;                          // pad speaker
-            default: *(uint16_t*)(st + 0) = 1; st[2] = (uint8_t)(channels > 2 ? 2 : channels); break;
+            case 2: case 3: *(uint16_t*)(st + 0) = 0x40; st[2] = 1; break;                // voice/personal -> headphone
+            case 4:         *(uint16_t*)(st + 0) = 0x04; st[2] = 1; break;                // pad speaker
+            case 127:       *(uint16_t*)(st + 0) = 0x80; break;                           // aux -> external
+            default:        *(uint16_t*)(st + 0) = 0x01;
+                            st[2] = (uint8_t)(channels > 2 ? 2 : channels); break;          // main/bgm -> primary
         }
     }
     return 0;

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -130,6 +130,21 @@ int main() {
     CHECK(*(int16_t*)(state + 4) == 127);                 // volume (Kyty reports 127)
     CHECK(*(uint64_t*)(state + 8) == 0);                  // flag must NOT carry a bogus volume
 
+    // Port routing is independent of the requested PCM channel count. Voice and Personal report
+    // a mono headphone route, Aux reports the external route, and PadSpk reports its mono route.
+    struct PortRoute { uint32_t type; uint16_t output; uint8_t channel; } routes[] = {
+        {1, 0x01, 2}, {2, 0x40, 1}, {3, 0x40, 1}, {4, 0x04, 1}, {127, 0x80, 0},
+    };
+    for (const auto& route : routes) {
+        int64_t route_h = call("sceAudioOutOpen", 1, route.type, 0, 256, 48000, 2 /* S16 8ch */);
+        CHECK(route_h >= 1);
+        uint8_t route_state[0x20]; memset(route_state, 0xEE, sizeof route_state);
+        CHECK(call("sceAudioOutGetPortState", (uint64_t)route_h, PTR(route_state)) == 0);
+        CHECK(*(uint16_t*)(route_state + 0) == route.output);
+        CHECK(route_state[2] == route.channel);
+        CHECK(call("sceAudioOutClose", (uint64_t)route_h) == 0);
+    }
+
     // --- 6. error paths: the real SCE codes (Kyty Errno.h), not a generic -1 -----------------
     CHECK((int32_t)call("sceAudioOutOutput", 999, PTR(pcm.data())) == (int32_t)0x80260003);  // INVALID_PORT
     CHECK((int32_t)call("sceAudioOutSetVolume", 999, 0x1, PTR(vols)) == (int32_t)0x80260003);


### PR DESCRIPTION
## Summary

- report Voice and Personal AudioOut ports as mono headphone routes
- report Aux as the external route while preserving Main/BGM and PadSpk routing
- cover every port class through the real open/GetPortState/close dispatch path

## Failure and contract

`sceAudioOutGetPortState` previously left Personal and Aux at zero and treated Voice as a normal primary output. Guests inspecting the ABI-visible `output` and `channel` fields could therefore select the wrong device/routing behavior. The inherited AudioOut contract reports Voice/Personal as headphone (`0x40`, mono), Aux as external (`0x80`, zero channels), PadSpk as `0x04` mono, and Main/BGM as primary (`0x01`, capped at two channels).

The regression opens every port type with an 8-channel format, so the Voice/Personal mono requirement cannot pass by inheriting the requested channel count. Against the old implementation, the new assertions fail for Voice, Personal, and Aux.

## Scope and risk

This addresses F5 of #396 only; the broader AJM/AudioIn tracker remains open. It does not change PCM transport, volume, timing, AudioOut2, host backends, or renderer behavior.

## Verification

Development check on exact commit `f50c05a`:

- Linux `audio_hle`: pass (1/1)
- Windows `audio_hle`: pass (1/1)
- `git diff --check`: pass
- snapshots: not applicable (HLE metadata only; no renderer change)

Full author-owned core verification and CI are pending. The independent reviewer is inspection-only and will not duplicate verification.

Refs #396