### PR TITLE
fix(file): preserve mkdir EEXIST failures

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -781,8 +781,7 @@ HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode
 #ifdef _WIN32
     return (uint64_t)(int64_t)::_mkdir(h.c_str());
 #else
-    int r = ::mkdir(h.c_str(), (mode_t)(a1 ? a1 : 0777));
-    return (uint64_t)(int64_t)(r == 0 || errno == EEXIST ? 0 : r);   // treat "already exists" as success
+    return (uint64_t)(int64_t)::mkdir(h.c_str(), (mode_t)(a1 ? a1 : 0777));
 #endif
 }
 HLE(f_rmdir) { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::rmdir(h.c_str()); }

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -3,9 +3,11 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <array>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -41,7 +43,32 @@ int main() {
     HleFn read_fn = Hle::lookup(nid_hash("sceKernelRead"));
     HleFn lseek_fn = Hle::lookup(nid_hash("sceKernelLseek"));
     HleFn close_fn = Hle::lookup(nid_hash("sceKernelClose"));
-    CHECK(open_fn && read_fn && lseek_fn && close_fn, "file HLE functions registered");
+    HleFn mkdir_fn = Hle::lookup(nid_hash("mkdir"));
+    HleFn kernel_mkdir_fn = Hle::lookup(nid_hash("sceKernelMkdir"));
+    CHECK(open_fn && read_fn && lseek_fn && close_fn && mkdir_fn && kernel_mkdir_fn,
+          "file HLE functions registered");
+
+    // Creating an existing directory is a failure, not an idempotent success. Linux previously
+    // suppressed EEXIST while Windows propagated it, so save-directory control flow differed by host.
+    const char* dir_path = "prosper-test-mkdir-eexist.tmp";
+    std::error_code remove_error;
+    std::filesystem::remove_all(dir_path, remove_error);
+    int64_t mkdir_first = mkdir_fn
+        ? (int64_t)mkdir_fn((uint64_t)(uintptr_t)dir_path, 0777, 0, 0, 0, 0)
+        : -1;
+    errno = 0;
+    int64_t mkdir_duplicate = mkdir_fn
+        ? (int64_t)mkdir_fn((uint64_t)(uintptr_t)dir_path, 0777, 0, 0, 0, 0)
+        : 0;
+    int duplicate_errno = errno;
+    int64_t kernel_mkdir_duplicate = kernel_mkdir_fn
+        ? (int64_t)kernel_mkdir_fn((uint64_t)(uintptr_t)dir_path, 0777, 0, 0, 0, 0)
+        : 0;
+    CHECK(mkdir_first == 0, "mkdir creates a new directory");
+    CHECK(mkdir_duplicate == -1, "mkdir reports an existing directory as failure");
+    CHECK(duplicate_errno == EEXIST, "mkdir preserves EEXIST for the caller");
+    CHECK(kernel_mkdir_duplicate != 0, "sceKernelMkdir does not report false success on EEXIST");
+    std::filesystem::remove_all(dir_path, remove_error);
 
     std::array<uint8_t, 512> actual{};
     int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;


### PR DESCRIPTION
## Summary

- stop converting Linux `mkdir(...)=EEXIST` into success
- preserve the host failure/`errno` behavior already used on Windows
- cover both `mkdir` and `sceKernelMkdir` through the real HLE dispatch table

## Failure and contract

The POSIX/Linux handler special-cased `EEXIST` as success while the Windows handler returned `-1`. A guest creating a save/config directory could therefore take different control flow by host and could believe it had created a directory when the requested path already existed.

The regression creates a directory, retries through `mkdir`, and checks for `-1` plus `EEXIST`; it then confirms `sceKernelMkdir` also cannot report false success. Against the old Linux implementation, both duplicate-create failure assertions fail.

## Scope and risk

This addresses only the `mkdir` false-success remainder in #389. It deliberately does not lock the regression to `-1` for `sceKernelMkdir`, because the tracker separately retains the broader work to translate host errno values into exact FreeBSD/SCE kernel error codes. Other filesystem operations and path translation are unchanged.

## Verification

Development check on exact commit `b3b76af`:

- Linux `file_binary_roundtrip`: pass (1/1)
- Windows `file_binary_roundtrip`: pass (1/1)
- `git diff --check`: pass
- snapshots: not applicable (filesystem HLE only; no renderer change)

Full author-owned core verification and CI are pending. The independent reviewer is inspection-only and will not duplicate verification.

Refs #389