### PR TITLE
fix(gpu): restore Evergate title background

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6176,7 +6176,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // scalar loop for every invocation while narrowed EXEC predicates vector writes; inactive
         // lanes retain their old VGPRs until the exact restore. Reject stores/exports/barriers and
         // unclassified memory so this never becomes a general branch-linearization escape hatch.
-        for (size_t branch_index = 0; branch_index < ins.size(); ++branch_index) {
+        // Scan inside-out so an already-proven nested guard may contribute its balanced save/restore
+        // pair without making an otherwise-safe outer guarded loop look like it leaks narrowed EXEC.
+        struct GuardedExecRegion { uint32_t save_pc, restore_pc; };
+        std::vector<GuardedExecRegion> guarded_exec_regions;
+        for (size_t branch_index = ins.size(); branch_index-- > 0;) {
             const Rdna2Inst& branch = ins[branch_index];
             if (branch.fmt != Rdna2Format::SOPP || branch.opcode != 0x08 || branch.simm16 <= 0)
                 continue;
@@ -6203,10 +6207,19 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     clobbers_guard_mask |= base < saveexec.dst.value + 2 &&
                         saveexec.dst.value < base + static_cast<int>(width);
                 });
+                bool balanced_nested_exec = false;
+                for (const auto& nested : guarded_exec_regions) {
+                    if (nested.save_pc > branch.pc && nested.restore_pc < target &&
+                        (candidate.pc == nested.save_pc || candidate.pc == nested.restore_pc)) {
+                        balanced_nested_exec = true;
+                        break;
+                    }
+                }
                 if (candidate.fmt == Rdna2Format::EXP || candidate.fmt == Rdna2Format::DS ||
                     candidate.fmt == Rdna2Format::MUBUF || candidate.fmt == Rdna2Format::MTBUF ||
                     candidate.fmt == Rdna2Format::MIMG || candidate.fmt == Rdna2Format::FLAT ||
-                    instruction_may_change_exec(candidate) || clobbers_guard_mask ||
+                    (instruction_may_change_exec(candidate) && !balanced_nested_exec) ||
+                    clobbers_guard_mask ||
                     (candidate.fmt == Rdna2Format::SOPP && candidate.opcode == 0x0a)) {
                     side_effect_free = false;
                     break;
@@ -6214,6 +6227,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             }
             if (!side_effect_free) continue;
             effective_safe.insert(branch.pc);
+            guarded_exec_regions.push_back({saveexec.pc, target});
             if (branch.pc < L.header_pc && target >= L.exit_pc) guarded_narrow_entry = true;
         }
         // 1. Pre-loop body. A compiler may place one ordinary uniform if/else before the canonical

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6199,6 +6199,18 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             for (const auto& candidate : ins) if (candidate.pc == target) { restore = &candidate; break; }
             if (!restore || restore->fmt != Rdna2Format::SOP1 || restore->opcode != 0x04 ||
                 restore->dst.value < 126 || !reg_operand(restore->src[0], saveexec.dst.value)) continue;
+            // A lexical save/restore pair is not necessarily balanced along the counted-loop CFG.
+            // In particular, a save in the body with its restore after the backedge leaves EXEC
+            // narrowed between iterations (EXEC has no loop phi), and a zero-trip path reaches an
+            // undominated restore. Accept only a pair contained in one straight-line loop segment,
+            // or a true preheader-to-postloop wrapper around the complete loop.
+            const bool same_preloop = saveexec.pc < L.header_pc && target < L.header_pc;
+            const bool same_condition = saveexec.pc >= L.header_pc && target < L.exit_branch_pc;
+            const bool same_body = saveexec.pc > L.exit_branch_pc && target < L.backedge_pc;
+            const bool same_postloop = saveexec.pc >= L.exit_pc;
+            const bool wraps_loop = saveexec.pc < L.header_pc && target >= L.exit_pc;
+            if (!same_preloop && !same_condition && !same_body && !same_postloop && !wraps_loop)
+                continue;
             bool side_effect_free = true;
             for (const auto& candidate : ins) {
                 if (candidate.pc <= branch.pc || candidate.pc >= target) continue;

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -284,6 +284,22 @@ int main() {
     CHECK(!recompile_valu(guarded_counted_loop, std::size(guarded_counted_loop), 0, 0).empty(),
           "guarded counted loop is accepted when EXEC and the saved guard mask are preserved");
 
+    // The loop may contain its own balanced saveexec/execz region. Unity emits this when a
+    // per-iteration color contribution is lane-masked: the inner restore returns EXEC to the
+    // outer guard before the backedge, so the loop-carried mask remains unchanged.
+    const uint32_t guarded_counted_loop_nested_save[] = {
+        0xBE84247Eu, 0xBF88000Cu,                         // outer guard -> outer restore
+        0xB0020005u, 0xBE800380u, 0x7E020280u,           // limit=5, i=0, sum=0
+        0xBF0A0200u, 0xBF840006u,                         // loop compare/exit
+        0xBE86247Eu, 0xBF880001u,                         // inner guard -> inner restore
+        0x4A020200u, 0xBEFE0406u,                         // sum += i; restore inner EXEC
+        0x81008100u, 0xBF82FFF8u,                         // i++; backedge
+        0x7E000D01u, 0xBEFE0404u, 0xBF810000u,           // convert; restore outer EXEC; end
+    };
+    CHECK(!recompile_valu(guarded_counted_loop_nested_save,
+                          std::size(guarded_counted_loop_nested_save), 0, 0).empty(),
+          "guarded counted loop accepts a balanced nested EXEC guard");
+
     const uint32_t guarded_counted_loop_inner_save[] = {
         0xBE84247Eu, 0xBF88000Au,
         0xB0020005u, 0xBE800380u, 0x7E020280u,

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -300,6 +300,18 @@ int main() {
                           std::size(guarded_counted_loop_nested_save), 0, 0).empty(),
           "guarded counted loop accepts a balanced nested EXEC guard");
 
+    const uint32_t guarded_counted_loop_cross_backedge[] = {
+        0xBE84247Eu, 0xBF88000Cu,                         // outer guard -> outer restore
+        0xB0020005u, 0xBE800380u, 0x7E020280u,
+        0xBF0A0200u, 0xBF840005u,                         // loop compare/exit
+        0xBE86247Eu, 0xBF880004u,                         // inner restore is after the backedge
+        0x4A020200u, 0x81008100u, 0xBF82FFF9u,
+        0x7E000D01u, 0xBEFE0406u, 0xBEFE0404u, 0xBF810000u,
+    };
+    CHECK(recompile_valu(guarded_counted_loop_cross_backedge,
+                         std::size(guarded_counted_loop_cross_backedge), 0, 0).empty(),
+          "nested EXEC guard crossing the counted-loop backedge is rejected");
+
     const uint32_t guarded_counted_loop_inner_save[] = {
         0xBE84247Eu, 0xBF88000Au,
         0xB0020005u, 0xBE800380u, 0x7E020280u,


### PR DESCRIPTION
Closes #861

## Failure

Evergate reached its main menu and rendered the logo, prompt, and corner UI, but the scenic title composition was missing. A semantic capture showed 55 draws in the stable title submit; draws 3–35 all failed fragment-shader recompilation, leaving only the later UI passes visible.

Both failed fragment programs select a PC-relative shader body successfully, then reject the same control-flow shape: an outer `saveexec` / `s_cbranch_execz` guard around a scalar counted loop containing a second, balanced EXEC guard.

## Fix

Recognize proven nested EXEC guards inside the existing guarded-counted-loop path.

The proof stays deliberately narrow:

- each guard must be a `saveexec` immediately followed by a forward `execz` branch;
- the branch target must restore EXEC from that guard's exact saved SGPR pair;
- nested guards are accepted inside-out, so only their already-proven save/restore pair is exempted from the outer EXEC-mutation rejection;
- a nested guard must remain within one straight-line loop segment, or wrap the complete loop—pairs crossing a backedge or exit are rejected;
- stores, exports, barriers, unclassified memory, and clobbers of any enclosing saved mask still reject;
- an unbalanced inner EXEC mutation remains fail-visible.

## Visible result

Title: Evergate (PPSA01885), Linux/WSLg  
Checkpoint: main menu / title screen after the opening logos

Before, the captured frame was a flat dark field behind the logo. With this change, a fresh run restores the starfield, blue/purple nebula, horizon silhouettes, luminous tree/beam, logo, prompt, and corner UI.

The full-size progress screenshot is attached in the PR conversation. It was captured at the pre-rebase equivalent commit `1f5d3b3`; the final review correction is rejection-only for malformed cross-loop guards and leaves the accepted Evergate path unchanged. No title-derived capture is committed.

## Scope and risk

Affected: fragment/VALU recompilation of counted loops guarded by recursively balanced EXEC save/restore regions.

Unaffected: unbalanced or cross-loop EXEC mutation, side-effecting guarded regions, general branch linearization, renderer resource formats/indexing, and guest/HLE behavior.

The main risk is admitting malformed mask nesting. The implementation requires exact save/restore pairing, keeps nested guards within valid CFG segments, and preserves the existing saved-mask clobber checks. Regression coverage includes the newly accepted balanced case plus rejected cross-backedge and unbalanced cases.

## Verification

Exact head: `5584a28bc58112762d4a239cce6e507fe3449e07`

Focused preflight:

- `test_recompile_coverage`
- `test_shader_recompile_cache`
- `test_rdna2_spirv_struct`
- `test_rdna2_to_spirv`
- `test_recompiled_fragment`

Full author-owned verification:

- Linux: 110/110 tests
- Windows: 85/85 tests
- Messenger snapshot: 49/49 qualifying, structural, and nonblack frames

Independent control-flow re-review approved this exact head after the cross-backedge correction. Sanitized evidence and the full-size screenshot are posted in the PR conversation.