### PR TITLE
fix(pthread): preserve adaptive mutex attr type

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -148,11 +148,20 @@ namespace prosper {
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 
-// --- mutex attributes (opaque; we back with host pthread_mutexattr_t) ---
+// --- mutex attributes (opaque; retain Sony type identity beside the host attribute) ---
+// Type 4 intentionally maps to host ERRORCHECK for FreeBSD-compatible self-lock behavior, so the
+// host attribute alone cannot distinguish it from Sony type 1 when Gettype reads it back.
+struct GuestMutexAttr {
+    pthread_mutexattr_t host;
+    int sony_type;
+};
+
 HLE(k_mutexattr_init) {
     if (!a0) return 0x16; // EINVAL-ish
-    auto* at = (pthread_mutexattr_t*)calloc(1, sizeof(pthread_mutexattr_t));
-    pthread_mutexattr_init(at);
+    auto* at = (GuestMutexAttr*)calloc(1, sizeof(GuestMutexAttr));
+    if (!at) return 0x0c; // ENOMEM
+    int result = pthread_mutexattr_init(&at->host);
+    if (result != 0) { free(at); return (uint64_t)(unsigned)result; }
     // A FRESH attr's type must be the FreeBSD/Sony DEFAULT — ERRORCHECK — not the host default
     // (glibc: NORMAL). Kyty's PthreadMutexattrInit does exactly this (settype(1) on init). The
     // #183 change covered the no-attr init path but left attr-without-settype at glibc NORMAL,
@@ -162,7 +171,9 @@ HLE(k_mutexattr_init) {
     // — with a NORMAL mutex the relock BLOCKS forever instead of returning EDEADLK (live-verified:
     // single-thread wedge in k_mutex_lock, mutex __owner == self, ~10 s into the DOLL boot).
     // CONFIDENCE: HIGH (FreeBSD contract + Kyty + live wedge disassembly).
-    pthread_mutexattr_settype(at, PTHREAD_MUTEX_ERRORCHECK);
+    result = pthread_mutexattr_settype(&at->host, PTHREAD_MUTEX_ERRORCHECK);
+    if (result != 0) { pthread_mutexattr_destroy(&at->host); free(at); return (uint64_t)(unsigned)result; }
+    at->sony_type = 1;
     *(void**)a0 = at;                     // store handle through caller's slot
     return 0;
 }
@@ -180,6 +191,7 @@ HLE(k_mutexattr_init) {
 // the platform contract. CONFIDENCE: HIGH (FreeBSD source + the live wedge -> unwedge flip).
 HLE(k_mutexattr_settype) {
     if (!a0 || !*(void**)a0) return 0x16;
+    auto* at = (GuestMutexAttr*)*(void**)a0;
     int host;
     switch ((int)a1) {
         case 1: host = PTHREAD_MUTEX_ERRORCHECK; break;
@@ -190,19 +202,19 @@ HLE(k_mutexattr_settype) {
     }
     static const bool mtxlog = getenv("PROSPER_MUTEXLOG") != nullptr;
     if (mtxlog) fprintf(stderr, "[mtx] settype attr=%p type=%d\n", *(void**)a0, (int)a1);
-    pthread_mutexattr_settype((pthread_mutexattr_t*)*(void**)a0, host);
+    int result = pthread_mutexattr_settype(&at->host, host);
+    if (result != 0) return (uint64_t)(unsigned)result;
+    at->sony_type = (int)a1;
     return 0;
 }
 // scePthreadMutexattrGettype: the read-back inverse of settype. Was MISSING -> the generic stub
 // returned 0 while leaving the caller's `int* type` (a1) unwritten, so the guest read stack garbage as
-// the mutex type (the harmful-Get-stub class the affinity/sched paths already guard against). Translate
-// host type -> Sony (ERRORCHECK->1, RECURSIVE->2, NORMAL->3), the inverse of k_mutexattr_settype above.
+// the mutex type (the harmful-Get-stub class the affinity/sched paths already guard against). Preserve
+// the original Sony type because host ERRORCHECK represents both Sony ERRORCHECK(1) and ADAPTIVE_NP(4).
 HLE(k_mutexattr_gettype) {
     if (!a0 || !*(void**)a0 || !a1) return 0x16;   // EINVAL
-    int host = PTHREAD_MUTEX_NORMAL;
-    pthread_mutexattr_gettype((pthread_mutexattr_t*)*(void**)a0, &host);
-    int sony = (host == PTHREAD_MUTEX_ERRORCHECK) ? 1 : (host == PTHREAD_MUTEX_RECURSIVE) ? 2 : 3;
-    *(int*)(uintptr_t)a1 = sony;
+    auto* at = (GuestMutexAttr*)*(void**)a0;
+    *(int*)(uintptr_t)a1 = at->sony_type;
     return 0;
 }
 HLE(k_mutexattr_setprotocol) { return 0; }
@@ -222,7 +234,8 @@ HLE(k_stack_chk_fail) {
     return 0;
 }
 HLE(k_mutexattr_setpshared)  { return 0; }
-HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { free(*(void**)a0); *(void**)a0 = nullptr; } return 0; }
+HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { auto* at = (GuestMutexAttr*)*(void**)a0;
+                               pthread_mutexattr_destroy(&at->host); free(at); *(void**)a0 = nullptr; } return 0; }
 
 // --- mutexes ---
 // FreeBSD/PS5 pthread objects are POINTERS, and a STATICALLY-INITIALIZED object is a small
@@ -369,7 +382,8 @@ namespace {
 HLE(k_mutex_init) {
     if (!a0) return 0x16;
     auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
-    pthread_mutexattr_t* at = (a1 && !pt_static_sentinel(*(void**)a1)) ? (pthread_mutexattr_t*)*(void**)a1 : nullptr;
+    GuestMutexAttr* guest_at = (a1 && !pt_static_sentinel(*(void**)a1)) ? (GuestMutexAttr*)*(void**)a1 : nullptr;
+    pthread_mutexattr_t* at = guest_at ? &guest_at->host : nullptr;
     pthread_mutexattr_t def;
     if (!at) { pthread_mutexattr_init(&def); pthread_mutexattr_settype(&def, PTHREAD_MUTEX_ERRORCHECK); at = &def; }
     int host_type = PTHREAD_MUTEX_NORMAL;

--- a/prosper/tests/test_mutex_types.cpp
+++ b/prosper/tests/test_mutex_types.cpp
@@ -20,13 +20,15 @@ int main() {
     register_builtin_hle();
     auto attr_init    = Hle::lookup(nid_hash("scePthreadMutexattrInit"));
     auto attr_settype = Hle::lookup(nid_hash("scePthreadMutexattrSettype"));
+    auto attr_gettype = Hle::lookup(nid_hash("scePthreadMutexattrGettype"));
     auto attr_destroy = Hle::lookup(nid_hash("scePthreadMutexattrDestroy"));
     auto m_init    = Hle::lookup(nid_hash("scePthreadMutexInit"));
     auto m_lock    = Hle::lookup(nid_hash("scePthreadMutexLock"));
     auto m_trylock = Hle::lookup(nid_hash("scePthreadMutexTrylock"));
     auto m_unlock  = Hle::lookup(nid_hash("scePthreadMutexUnlock"));
     auto m_destroy = Hle::lookup(nid_hash("scePthreadMutexDestroy"));
-    CHECK(attr_init && attr_settype && attr_destroy && m_init && m_lock && m_trylock && m_unlock && m_destroy,
+    CHECK(attr_init && attr_settype && attr_gettype && attr_destroy &&
+              m_init && m_lock && m_trylock && m_unlock && m_destroy,
           "mutex HLE functions registered");
     if (fails) { printf("== FAIL ==\n"); return 1; }
 
@@ -47,7 +49,12 @@ int main() {
     // 2. Type 2 = RECURSIVE (settype honored): relock succeeds; needs two unlocks.
     void* attr = nullptr; void* rmtx = nullptr;
     CHECK(attr_init(U(&attr), 0, 0, 0, 0, 0) == 0 && attr, "attr init");
+    int attr_type = -1;
+    CHECK(attr_gettype(U(&attr), U(&attr_type), 0, 0, 0, 0) == 0 && attr_type == 1,
+          "fresh attr reports Sony DEFAULT/ERRORCHECK type 1");
     CHECK(attr_settype(U(&attr), 2, 0, 0, 0, 0) == 0, "settype(2 RECURSIVE) accepted");
+    CHECK(attr_gettype(U(&attr), U(&attr_type), 0, 0, 0, 0) == 0 && attr_type == 2,
+          "recursive attr round-trips as type 2");
     CHECK(m_init(U(&rmtx), U(&attr), 0, 0, 0, 0) == 0, "recursive init");
     CHECK(m_lock(U(&rmtx), 0, 0, 0, 0, 0) == 0 && m_lock(U(&rmtx), 0, 0, 0, 0, 0) == 0,
           "recursive: relock on owner succeeds");
@@ -61,6 +68,9 @@ int main() {
     void* nattr = nullptr; void* nmtx = nullptr;
     attr_init(U(&nattr), 0, 0, 0, 0, 0);
     CHECK(attr_settype(U(&nattr), 3, 0, 0, 0, 0) == 0, "settype(3 NORMAL) accepted");
+    attr_type = -1;
+    CHECK(attr_gettype(U(&nattr), U(&attr_type), 0, 0, 0, 0) == 0 && attr_type == 3,
+          "normal attr round-trips as type 3");
     m_init(U(&nmtx), U(&nattr), 0, 0, 0, 0);
     CHECK(m_lock(U(&nmtx), 0, 0, 0, 0, 0) == 0, "normal: lock");
     CHECK(m_trylock(U(&nmtx), 0, 0, 0, 0, 0) == 16, "normal: trylock on owned fails EBUSY(16)");
@@ -68,13 +78,23 @@ int main() {
     m_destroy(U(&nmtx), 0, 0, 0, 0, 0);
     attr_destroy(U(&nattr), 0, 0, 0, 0, 0);
 
-    // 4. Invalid type rejected.
+    // 4. Type 4 = ADAPTIVE_NP: retains its guest identity even though its proven host behavior is
+    //    implemented with ERRORCHECK (the same host type used for Sony type 1).
+    void* aattr = nullptr;
+    attr_init(U(&aattr), 0, 0, 0, 0, 0);
+    CHECK(attr_settype(U(&aattr), 4, 0, 0, 0, 0) == 0, "settype(4 ADAPTIVE_NP) accepted");
+    attr_type = -1;
+    CHECK(attr_gettype(U(&aattr), U(&attr_type), 0, 0, 0, 0) == 0 && attr_type == 4,
+          "adaptive attr round-trips as type 4");
+    attr_destroy(U(&aattr), 0, 0, 0, 0, 0);
+
+    // 5. Invalid type rejected.
     void* battr = nullptr;
     attr_init(U(&battr), 0, 0, 0, 0, 0);
     CHECK(attr_settype(U(&battr), 99, 0, 0, 0, 0) == 0x16, "settype(99) rejected EINVAL(22)");
     attr_destroy(U(&battr), 0, 0, 0, 0, 0);
 
-    // 5. STATIC SENTINEL self-init remains non-recursive (native POSIX default; Windows ERRORCHECK):
+    // 6. STATIC SENTINEL self-init remains non-recursive (native POSIX default; Windows ERRORCHECK):
     //    this is the bdwgc GC_allocate_ml shape — trylock on an owned static lock MUST fail
     //    (before this fix the self-init forced RECURSIVE and trylock succeeded on the owner).
     void* smtx = nullptr;   // NULL sentinel; first use self-initializes


### PR DESCRIPTION
## Summary

- retain the Sony mutex type beside each host `pthread_mutexattr_t`
- preserve the established type-4-to-host-ERRORCHECK synchronization behavior
- make `scePthreadMutexattrGettype` round-trip Sony ADAPTIVE_NP as type 4 instead of type 1
- destroy the embedded host attribute before freeing its guest wrapper

## Failure and contract

Sony type 4 (ADAPTIVE_NP) intentionally uses host ERRORCHECK in prosper because both Sony ERRORCHECK and ADAPTIVE_NP must report a self-lock error instead of deadlocking. `Gettype` previously inferred the Sony value from the host value, so both Sony types 1 and 4 came back as 1.

The host mapping is deliberately unchanged. The opaque guest attribute now owns the host attribute plus the last successfully applied Sony type. `MutexInit` consumes the embedded host attribute, while `Gettype` returns the retained guest identity.

The regression exercises init/set/get/destroy through the HLE dispatch table and protects types 1, 2, 3, and 4. Against old master, only the adaptive round-trip assertion fails (`1 != 4`). Existing recursive, normal, default, and static-sentinel locking checks remain in the same test.

## Scope and risk

This addresses only the adaptive Gettype remainder in #386. It does not change mutex lock/unlock/trylock behavior, static initializer handling, condvars, rwlocks, barriers, or semaphores. The internal attribute allocation changes shape, and every in-file producer, consumer, and destroy path is updated together.

## Verification

Development check on exact commit `0ed03bd`:

- Linux `mutex_types`: pass (1/1)
- Windows `mutex_types`: pass (1/1)
- `git diff --check`: pass
- snapshots: not applicable (pthread HLE only; no renderer change)

Full author-owned core verification and CI are pending. The independent reviewer is inspection-only and will not duplicate verification.

Refs #386