### PR TITLE
fix(ajm): reject nonzero initialize reserved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,9 +308,13 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   is easy to get wrong: for example, a regression test with another path that can produce the expected result,
   or a snapshot route or baseline update that needs judgment to confirm it exercises the intended behavior.
   Judge both implementation risk and verification risk, not merely the diff size. Routine, well-bounded,
-  low-risk changes do not require an independent reviewer. The reviewer inspects the assumptions, code, risks,
-  and tests, including whether each regression test would fail without the fix, but does not duplicate the
-  author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR
+  low-risk changes do not require an independent reviewer. Passing author verification does not substitute for
+  review where review is warranted: verification demonstrates observed behavior, while review challenges the
+  contract assumptions, untested paths, and whether the regression actually proves the intended behavior.
+  When uncertain, favor review for reverse-engineered API semantics and other changes where an independent
+  reader can materially challenge the reasoning, even when the patch is small. The reviewer inspects the
+  assumptions, code, risks, and tests, including whether each regression test would fail without the fix, but
+  does not duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR
   is published, run author verification and any required review; the author posts exact-head evidence and the
   reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
   corrections, then merge only after the merge agent separately confirms author verification, reviewer approval

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -482,7 +482,7 @@ namespace {
 }
 // sceAjmInitialize(s64 reserved, u32* out_context): create a context. Filling out_context is the point.
 HLE(ajm_initialize) {
-    if (!a1) return AJM_ERR_INVALID_PARAMETER;
+    if (a0 != 0 || !a1) return AJM_ERR_INVALID_PARAMETER;
     *(uint32_t*)P(a1) = g_ajm_next.fetch_add(1);
     return 0;
 }

--- a/prosper/tests/test_ajm.cpp
+++ b/prosper/tests/test_ajm.cpp
@@ -37,6 +37,10 @@ int main() {
     CHECK(init(0, (uint64_t)(uintptr_t)&ctx, 0, 0, 0, 0) == 0, "sceAjmInitialize -> OK");
     CHECK(ctx != 0 && ctx != 0xDEAD, "Initialize WROTE a valid non-zero context (not left garbage)");
     CHECK(init(0, 0, 0, 0, 0, 0) == 0x80930005ull, "Initialize(NULL out) -> INVALID_PARAMETER");
+    uint32_t rejected_ctx = 0xCAFE;
+    CHECK(init(1, (uint64_t)(uintptr_t)&rejected_ctx, 0, 0, 0, 0) == 0x80930005ull,
+          "Initialize(nonzero reserved) -> INVALID_PARAMETER");
+    CHECK(rejected_ctx == 0xCAFE, "invalid Initialize leaves the context output untouched");
 
     // ModuleRegister needs a context.
     CHECK(modreg(ctx, 1 /*At9Dec*/, 0, 0, 0, 0) == 0, "sceAjmModuleRegister(ctx) -> OK");


### PR DESCRIPTION
## What changed

- reject sceAjmInitialize calls whose reserved argument is nonzero
- preserve the caller's output value when initialization is rejected
- add a dispatch-level regression for the reserved-argument contract
- clarify in CLAUDE.md that green author verification does not replace risk-based independent review

## Failure scenario

sceAjmInitialize declares its first argument as reserved and requires it to be zero. The previous implementation validated only the output pointer, so a nonzero reserved value incorrectly allocated a context, returned success, and overwrote caller memory.

## Contract and scope

The implementation now validates the reserved value before allocating or writing a context. Existing behavior for valid initialization and a null output pointer is unchanged.

This addresses only the F8 reserved-argument finding in #396. It deliberately does not address the issue's unrelated AJM builder, decode, AudioIn, or sign-extension findings.

## Verification

Focused author checks passed on the exact implementation:

- Linux: ajm_hle (1/1)
- Windows: ajm_hle (1/1)
- git diff --check

No snapshots were run because this change cannot affect rendered output. Full author verification and CI results will be posted on the PR exact head.

Refs #396