### PR TITLE
fix(savedata): register v1 memory API

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1164,6 +1164,27 @@ namespace {
     template <class T> T ld(uint64_t base, size_t off) {   // read a guest struct field at byte offset
         T v; memcpy(&v, (const uint8_t*)PW(base) + off, sizeof(T)); return v;
     }
+    uint64_t savemem_setup_block(int32_t userId, uint32_t slotId, uint64_t memSize) {
+        uint64_t existed = 0;
+        std::lock_guard<std::mutex> lk(g_savemem_mx);
+        auto& buf = g_savemem[savemem_key(userId, slotId)];
+        if (buf.empty()) buf = savemem_load(userId, slotId);
+        existed = buf.size();
+        if (memSize > buf.size()) buf.resize(memSize, 0);
+        return existed;
+    }
+    void savemem_write_range(std::vector<uint8_t>& dst, uint64_t guestBuf, uint64_t guestSize,
+                             int64_t offset) {
+        if (!guestBuf || offset < 0 || (uint64_t)offset >= dst.size()) return;
+        uint64_t n = std::min<uint64_t>(guestSize, dst.size() - (uint64_t)offset);
+        memcpy(dst.data() + offset, PW(guestBuf), n);
+    }
+    void savemem_read_range(const std::vector<uint8_t>& src, uint64_t guestBuf, uint64_t guestSize,
+                            int64_t offset) {
+        if (!guestBuf || offset < 0 || (uint64_t)offset >= src.size()) return;
+        uint64_t n = std::min<uint64_t>(guestSize, src.size() - (uint64_t)offset);
+        memcpy(PW(guestBuf), src.data() + offset, n);
+    }
     constexpr uint64_t SD_ERR_PARAMETER      = 0x809F0000ull;
     constexpr uint64_t SD_ERR_MEMORY_NOTREADY = 0x809F0012ull;   // Set/Get before a successful Setup
 }
@@ -1176,14 +1197,7 @@ HLE(s_savemem_setup) {
     int32_t  userId  = ld<int32_t>(a0, 4);
     uint64_t memSize = ld<uint64_t>(a0, 8);
     uint32_t slotId  = ld<uint32_t>(a0, 40);
-    uint64_t existed = 0;
-    {
-        std::lock_guard<std::mutex> lk(g_savemem_mx);
-        auto& buf = g_savemem[savemem_key(userId, slotId)];
-        if (buf.empty()) buf = savemem_load(userId, slotId);       // reload a prior session's save from disk
-        existed = buf.size();                                       // -> existedMemorySize is truthful across restarts
-        if (memSize > buf.size()) buf.resize(memSize, 0);          // grow only; never drop live data
-    }
+    uint64_t existed = savemem_setup_block(userId, slotId, memSize);
     if (a1) *(uint64_t*)PW(a1) = existed;                          // result->existedMemorySize
     return 0;
 }
@@ -1205,9 +1219,7 @@ HLE(s_savemem_set) {
         uint64_t gbuf  = ld<uint64_t>(d, 0);
         uint64_t gsize = ld<uint64_t>(d, 8);
         int64_t  off   = ld<int64_t>(d, 16);
-        if (!gbuf || off < 0 || (uint64_t)off >= buf.size()) continue;
-        uint64_t n = std::min<uint64_t>(gsize, buf.size() - (uint64_t)off);
-        memcpy(buf.data() + off, PW(gbuf), n);
+        savemem_write_range(buf, gbuf, gsize, off);
     }
     return 0;
 }
@@ -1227,11 +1239,32 @@ HLE(s_savemem_get) {
         uint64_t gbuf  = ld<uint64_t>(dataPtr, 0);
         uint64_t gsize = ld<uint64_t>(dataPtr, 8);
         int64_t  off   = ld<int64_t>(dataPtr, 16);
-        if (gbuf && off >= 0 && (uint64_t)off < buf.size()) {
-            uint64_t n = std::min<uint64_t>(gsize, buf.size() - (uint64_t)off);
-            memcpy(PW(gbuf), buf.data() + off, n);
-        }
+        savemem_read_range(buf, gbuf, gsize, off);
     }
+    return 0;
+}
+// The original SaveDataMemory API passes scalar arguments and always addresses slot 0. These PS4-
+// inherited exports are still present in the PS5 3.20 table; route them through the same backing
+// store as the struct-based *2 API so callers do not receive fake success with no data transfer.
+HLE(s_savemem_setup_v1) {
+    svc_log("sceSaveDataSetupSaveDataMemory", a0,a1,a2,a3,a4,a5);
+    savemem_setup_block((int32_t)a0, 0, a1);
+    return 0;
+}
+HLE(s_savemem_set_v1) {
+    svc_log("sceSaveDataSetSaveDataMemory", a0,a1,a2,a3,a4,a5);
+    std::lock_guard<std::mutex> lk(g_savemem_mx);
+    auto it = g_savemem.find(savemem_key((int32_t)a0, 0));
+    if (it == g_savemem.end()) return SD_ERR_MEMORY_NOTREADY;
+    savemem_write_range(it->second, a1, a2, (int64_t)a3);
+    return 0;
+}
+HLE(s_savemem_get_v1) {
+    svc_log("sceSaveDataGetSaveDataMemory", a0,a1,a2,a3,a4,a5);
+    std::lock_guard<std::mutex> lk(g_savemem_mx);
+    auto it = g_savemem.find(savemem_key((int32_t)a0, 0));
+    if (it == g_savemem.end()) return SD_ERR_MEMORY_NOTREADY;
+    savemem_read_range(it->second, a1, a2, (int64_t)a3);
     return 0;
 }
 // sceSaveDataSyncSaveDataMemory(sync*): commit the slot's block. A session's Set is already visible to a
@@ -1841,6 +1874,9 @@ void register_service_hle() {
     Hle::register_fn("oQySEUfgXRA", (HleFn)s_savemem_setup, "sceSaveDataSetupSaveDataMemory2");
     Hle::register_fn("cduy9v4YmT4", (HleFn)s_savemem_set,   "sceSaveDataSetSaveDataMemory2");
     Hle::register_fn("QwOO7vegnV8", (HleFn)s_savemem_get,   "sceSaveDataGetSaveDataMemory2");
+    Hle::register_fn("v7AAAMo0Lz4", (HleFn)s_savemem_setup_v1, "sceSaveDataSetupSaveDataMemory");
+    Hle::register_fn("h3YURzXGSVQ", (HleFn)s_savemem_set_v1,   "sceSaveDataSetSaveDataMemory");
+    Hle::register_fn("7Bt5pBC-Aco", (HleFn)s_savemem_get_v1,   "sceSaveDataGetSaveDataMemory");
     Hle::register_fn("wiT9jeC7xPw", (HleFn)s_savemem_sync,  "sceSaveDataSyncSaveDataMemory");
     Hle::register_fn("yKDy8S5yLA0", (HleFn)s_savedata_term,      "sceSaveDataTerminate");
     Hle::register_fn("gjRZNnw0JPE", (HleFn)s_savedata_txres,     "sceSaveDataCreateTransactionResource");

--- a/prosper/tests/test_savedata_ime.cpp
+++ b/prosper/tests/test_savedata_ime.cpp
@@ -97,6 +97,24 @@ int main() {
         CHECK(set(0,0,0,0,0,0) == 0x809F0000ull, "Set(NULL) -> PARAMETER error (no wild deref)");
     }
 
+    // The original scalar-argument API uses slot 0 and must share the same backing behavior as *2.
+    HleFn setup_v1 = Hle::lookup("v7AAAMo0Lz4"), set_v1 = Hle::lookup("h3YURzXGSVQ"),
+          get_v1 = Hle::lookup("7Bt5pBC-Aco");
+    CHECK(setup_v1 && set_v1 && get_v1, "SaveData memory v1 functions registered");
+    if (setup_v1 && set_v1 && get_v1) {
+        constexpr uint64_t user = 0x392;
+        CHECK(setup_v1(user, 64, 0, 0, 0, 0) == 0, "SetupSaveDataMemory(v1) -> OK");
+        uint8_t src[8] = {0x39, 0x20, 0x17, 0x07, 0x18, 0x01, 0x08, 0x00};
+        CHECK(set_v1(user, (uint64_t)(uintptr_t)src, sizeof src, 11, 0, 0) == 0,
+              "SetSaveDataMemory(v1) -> OK");
+        uint8_t dst[8]{};
+        CHECK(get_v1(user, (uint64_t)(uintptr_t)dst, sizeof dst, 11, 0, 0) == 0,
+              "GetSaveDataMemory(v1) -> OK");
+        CHECK(memcmp(src, dst, sizeof src) == 0, "v1 Set -> Get round-trips bytes through slot 0");
+        CHECK(get_v1(user + 1, (uint64_t)(uintptr_t)dst, sizeof dst, 0, 0, 0) == 0x809F0012ull,
+              "v1 Get before Setup -> MEMORY_NOT_READY");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## What changed

- register the original sceSaveData Setup/Get/SetSaveDataMemory exports from the PS5 3.20 table
- adapt their scalar ABI to slot 0 in the existing per-user, per-slot SaveDataMemory backing store
- share setup and bounded-copy helpers with the existing *2 implementation
- add dispatch-level v1 registration, round-trip, and not-ready regression coverage

## Failure scenario

The v1 exports were absent, so imported calls fell through to the generic unimplemented path and returned fake success without allocating memory or transferring save bytes. A title using the original API could believe a save write succeeded while no data changed, then read stale caller memory.

## Contract and scope

The v1 ABI supplies userId, buffer, size, and offset directly and addresses slot 0. The adapters retain the existing bounded-copy behavior, MEMORY_NOT_READY response before setup, and disk-backed store shared by the *2 API. Setup's optional metadata pointer remains deliberately ignored, matching the current *2 metadata behavior.

This addresses only #392's remaining v1 SaveDataMemory registration gap. It does not implement the separate non-Mount3 mount variants or choose a LoadExec policy.

## Verification

Focused author checks passed on Linux and Windows:

- savedata_ime
- hle_functions_registered
- hle_no_shadow
- git diff --check

No snapshots were run because this service-layer change cannot affect rendered output. Full author verification and CI results will be posted for the exact PR head.

Refs #392