### PR TITLE
fix(file): implement Windows dup handlers

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -498,8 +498,25 @@ HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
 HLE(f_dup)  { int fd = ::dup((int)a0); while (fd >= 0 && fd < 3) { int n = fcntl(fd, F_DUPFD, 3); ::close(fd); fd = n; } return (uint64_t)(int64_t)fd; }
 HLE(f_dup2) { return (uint64_t)(int64_t)::dup2((int)a0, (int)a1); }
 #else
-HLE(f_dup)  { return (uint64_t)-1; }
-HLE(f_dup2) { return (uint64_t)-1; }
+HLE(f_dup)  {
+    int fd = ::_dup((int)a0);
+    int low_fds[3]{};
+    size_t low_count = 0;
+    // Windows has no F_DUPFD. Keep recycled stdio slots occupied until _dup reaches the
+    // guest-visible range, then release the temporary descriptors.
+    while (fd >= 0 && fd < 3) {
+        low_fds[low_count++] = fd;
+        fd = ::_dup((int)a0);
+    }
+    for (size_t i = 0; i < low_count; ++i) ::_close(low_fds[i]);
+    return (uint64_t)(int64_t)fd;
+}
+HLE(f_dup2) {
+    int r = ::_dup2((int)a0, (int)a1);
+    // The Windows CRT reports success as zero; the guest/POSIX contract returns the
+    // destination descriptor.
+    return (uint64_t)(int64_t)(r < 0 ? -1 : (int)a1);
+}
 #endif
 #ifndef _WIN32
 // FULL read: loop until `count` bytes are read (or EOF/error). POSIX read()/pread() may return FEWER

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -39,6 +39,12 @@
 #endif
 #include "../host/posix_shim.hpp"   // Darwin: process_vm_*, pthread_getattr_np, st_*tim, prosper_mincore
 
+#if defined(_WIN32) && defined(__MINGW32__)
+// MinGW's UCRT import library exposes this API, but its current headers omit the declaration.
+extern "C" _invalid_parameter_handler __cdecl
+_set_thread_local_invalid_parameter_handler(_invalid_parameter_handler);
+#endif
+
 namespace prosper {
 
 #ifdef _WIN32
@@ -91,6 +97,24 @@ namespace {
     bool windows_prepare_guest_write(uint64_t dst, uint64_t bytes) {
         return !bytes || windows_prepare_guest_write_prefix(dst, bytes) == bytes;
     }
+
+    void __cdecl ignore_crt_invalid_parameter(const wchar_t*, const wchar_t*, const wchar_t*,
+                                               unsigned int, uintptr_t) {}
+
+    class ScopedCrtInvalidParameterHandler {
+    public:
+        ScopedCrtInvalidParameterHandler()
+            : previous_(_set_thread_local_invalid_parameter_handler(
+                  ignore_crt_invalid_parameter)) {}
+        ~ScopedCrtInvalidParameterHandler() {
+            _set_thread_local_invalid_parameter_handler(previous_);
+        }
+        ScopedCrtInvalidParameterHandler(const ScopedCrtInvalidParameterHandler&) = delete;
+        ScopedCrtInvalidParameterHandler& operator=(const ScopedCrtInvalidParameterHandler&) = delete;
+
+    private:
+        _invalid_parameter_handler previous_;
+    };
 #endif
 
     void filelog_remember_fd(int fd, const std::string& path) {
@@ -499,6 +523,7 @@ HLE(f_dup)  { int fd = ::dup((int)a0); while (fd >= 0 && fd < 3) { int n = fcntl
 HLE(f_dup2) { return (uint64_t)(int64_t)::dup2((int)a0, (int)a1); }
 #else
 HLE(f_dup)  {
+    ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
     int fd = ::_dup((int)a0);
     int low_fds[3]{};
     size_t low_count = 0;
@@ -512,6 +537,7 @@ HLE(f_dup)  {
     return (uint64_t)(int64_t)fd;
 }
 HLE(f_dup2) {
+    ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
     int r = ::_dup2((int)a0, (int)a1);
     // The Windows CRT reports success as zero; the guest/POSIX contract returns the
     // destination descriptor.

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -184,6 +184,44 @@ int main() {
     if (dup2_target >= 0 && close_fn) close_fn((uint64_t)dup2_target, 0, 0, 0, 0, 0);
 
 #ifdef _WIN32
+    // UCRT reports invalid descriptors through its invalid-parameter handler before returning -1.
+    // Guest inputs must not reach the default terminating handler, and a failed dup2 must not close
+    // or replace its valid target.
+    int64_t invalid_duplicate = kernel_dup_fn
+        ? (int64_t)kernel_dup_fn(~uint64_t{0}, 0, 0, 0, 0, 0)
+        : 0;
+    CHECK(invalid_duplicate == -1, "sceKernelDup safely rejects an invalid source descriptor");
+    int64_t preserved_target = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    constexpr int64_t preserved_offset = 137;
+    int64_t preserved_seek = preserved_target >= 0 && lseek_fn
+        ? (int64_t)lseek_fn((uint64_t)preserved_target, preserved_offset, SEEK_SET, 0, 0, 0)
+        : -1;
+    int64_t invalid_dup2 = preserved_target >= 0 && kernel_dup2_fn
+        ? (int64_t)kernel_dup2_fn(~uint64_t{0}, (uint64_t)preserved_target, 0, 0, 0, 0)
+        : 0;
+    int64_t preserved_position = preserved_target >= 0 && lseek_fn
+        ? (int64_t)lseek_fn((uint64_t)preserved_target, 0, SEEK_CUR, 0, 0, 0)
+        : -1;
+    std::array<uint8_t, 16> preserved_chunk{};
+    int64_t preserved_n = preserved_target >= 0 && read_fn
+        ? (int64_t)read_fn((uint64_t)preserved_target,
+                           (uint64_t)(uintptr_t)preserved_chunk.data(), preserved_chunk.size(),
+                           0, 0, 0)
+        : -1;
+    CHECK(preserved_seek == preserved_offset, "position the invalid-dup2 target");
+    CHECK(invalid_dup2 == -1, "sceKernelDup2 safely rejects an invalid source descriptor");
+    CHECK(preserved_position == preserved_offset &&
+              preserved_n == (int64_t)preserved_chunk.size() &&
+              std::memcmp(preserved_chunk.data(), expected.data() + preserved_offset,
+                          preserved_chunk.size()) == 0,
+          "failed sceKernelDup2 leaves the target descriptor unchanged");
+    if (preserved_target >= 0 && close_fn)
+        close_fn((uint64_t)preserved_target, 0, 0, 0, 0, 0);
+#endif
+
+#ifdef _WIN32
     // Unity asks for a whole 64 KiB cache block even when boot.config is only a few hundred bytes.
     // Guest allocators may leave later pages reserved until first touch. Windows _read validates the
     // entire requested destination range before discovering EOF, so a direct host read fails EINVAL;

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -9,6 +9,8 @@
 #include <cstring>
 #include <filesystem>
 #ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -43,9 +45,14 @@ int main() {
     HleFn read_fn = Hle::lookup(nid_hash("sceKernelRead"));
     HleFn lseek_fn = Hle::lookup(nid_hash("sceKernelLseek"));
     HleFn close_fn = Hle::lookup(nid_hash("sceKernelClose"));
+    HleFn dup_fn = Hle::lookup(nid_hash("dup"));
+    HleFn kernel_dup_fn = Hle::lookup(nid_hash("sceKernelDup"));
+    HleFn dup2_fn = Hle::lookup(nid_hash("dup2"));
+    HleFn kernel_dup2_fn = Hle::lookup(nid_hash("sceKernelDup2"));
     HleFn mkdir_fn = Hle::lookup(nid_hash("mkdir"));
     HleFn kernel_mkdir_fn = Hle::lookup(nid_hash("sceKernelMkdir"));
-    CHECK(open_fn && read_fn && lseek_fn && close_fn && mkdir_fn && kernel_mkdir_fn,
+    CHECK(open_fn && read_fn && lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
+              dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn,
           "file HLE functions registered");
 
     // Creating an existing directory is a failure, not an idempotent success. Linux previously
@@ -80,6 +87,101 @@ int main() {
     CHECK(n == (int64_t)expected.size() && actual == expected,
           "read preserves binary bytes including CRLF");
     if (fd >= 0 && close_fn) close_fn((uint64_t)fd, 0, 0, 0, 0, 0);
+
+    // A duplicate is a distinct descriptor for the same open file description: it shares the
+    // current offset and remains usable after the original descriptor is closed.
+    int64_t dup_source = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    int64_t duplicated = dup_source >= 0 && kernel_dup_fn
+        ? (int64_t)kernel_dup_fn((uint64_t)dup_source, 0, 0, 0, 0, 0)
+        : -1;
+    CHECK(duplicated >= 3 && duplicated != dup_source,
+          "sceKernelDup returns a distinct non-stdio descriptor");
+    std::array<uint8_t, 16> first_chunk{};
+    std::array<uint8_t, 16> second_chunk{};
+    int64_t first_n = dup_source >= 0 && read_fn
+        ? (int64_t)read_fn((uint64_t)dup_source,
+                           (uint64_t)(uintptr_t)first_chunk.data(), first_chunk.size(), 0, 0, 0)
+        : -1;
+    int64_t second_n = duplicated >= 0 && read_fn
+        ? (int64_t)read_fn((uint64_t)duplicated,
+                           (uint64_t)(uintptr_t)second_chunk.data(), second_chunk.size(), 0, 0, 0)
+        : -1;
+    CHECK(first_n == (int64_t)first_chunk.size() &&
+              std::memcmp(first_chunk.data(), expected.data(), first_chunk.size()) == 0,
+          "original descriptor reads the first chunk");
+    CHECK(second_n == (int64_t)second_chunk.size() &&
+              std::memcmp(second_chunk.data(), expected.data() + first_chunk.size(),
+                          second_chunk.size()) == 0,
+          "sceKernelDup shares the original file offset");
+    if (dup_source >= 0 && close_fn) close_fn((uint64_t)dup_source, 0, 0, 0, 0, 0);
+    int64_t duplicate_seek = duplicated >= 0 && lseek_fn
+        ? (int64_t)lseek_fn((uint64_t)duplicated, 0, SEEK_SET, 0, 0, 0)
+        : -1;
+    CHECK(duplicate_seek == 0, "duplicate remains usable after closing the original");
+    if (duplicated >= 0 && close_fn) close_fn((uint64_t)duplicated, 0, 0, 0, 0, 0);
+
+#ifdef _WIN32
+    // Force fd 0 free while duplicating an already-open guest file. _dup chooses the lowest free
+    // CRT descriptor, so the wrapper must hold that temporary result and return one above stdio.
+    int saved_stdin = ::_dup(0);
+    int stdin_filler = -1;
+    if (saved_stdin < 0) stdin_filler = ::_open("NUL", _O_RDONLY | _O_BINARY);
+    CHECK(saved_stdin >= 0 || stdin_filler == 0, "occupy fd 0 before low-slot dup test");
+    int64_t low_slot_source = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    CHECK(low_slot_source >= 3, "open dup source outside the stdio range");
+    CHECK(::_close(0) == 0, "free fd 0 for deterministic dup reuse");
+    int64_t low_slot_duplicate = low_slot_source >= 0 && kernel_dup_fn
+        ? (int64_t)kernel_dup_fn((uint64_t)low_slot_source, 0, 0, 0, 0, 0)
+        : -1;
+    CHECK(low_slot_duplicate >= 3,
+          "sceKernelDup lifts a recycled Windows stdio descriptor");
+    if (low_slot_duplicate >= 0 && close_fn)
+        close_fn((uint64_t)low_slot_duplicate, 0, 0, 0, 0, 0);
+    if (low_slot_source >= 0 && close_fn)
+        close_fn((uint64_t)low_slot_source, 0, 0, 0, 0, 0);
+    if (saved_stdin >= 0) {
+        CHECK(::_dup2(saved_stdin, 0) == 0, "restore fd 0 after low-slot dup test");
+        ::_close(saved_stdin);
+    }
+#endif
+
+    // dup2 must replace an already-open target, share the source offset, and return the target
+    // descriptor. The Windows CRT returns zero on success, so this catches a missing ABI translation.
+    int64_t dup2_source = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    int64_t dup2_target = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    constexpr int64_t source_offset = 73;
+    constexpr int64_t old_target_offset = 211;
+    int64_t source_seek = dup2_source >= 0 && lseek_fn
+        ? (int64_t)lseek_fn((uint64_t)dup2_source, source_offset, SEEK_SET, 0, 0, 0)
+        : -1;
+    int64_t target_seek = dup2_target >= 0 && lseek_fn
+        ? (int64_t)lseek_fn((uint64_t)dup2_target, old_target_offset, SEEK_SET, 0, 0, 0)
+        : -1;
+    int64_t dup2_result = dup2_source >= 0 && dup2_target >= 0 && kernel_dup2_fn
+        ? (int64_t)kernel_dup2_fn((uint64_t)dup2_source, (uint64_t)dup2_target, 0, 0, 0, 0)
+        : -1;
+    CHECK(source_seek == source_offset && target_seek == old_target_offset,
+          "position dup2 source and old target independently");
+    CHECK(dup2_result == dup2_target, "sceKernelDup2 returns the replaced target descriptor");
+    if (dup2_source >= 0 && close_fn) close_fn((uint64_t)dup2_source, 0, 0, 0, 0, 0);
+    std::array<uint8_t, 16> dup2_chunk{};
+    int64_t dup2_n = dup2_target >= 0 && read_fn
+        ? (int64_t)read_fn((uint64_t)dup2_target,
+                           (uint64_t)(uintptr_t)dup2_chunk.data(), dup2_chunk.size(), 0, 0, 0)
+        : -1;
+    CHECK(dup2_n == (int64_t)dup2_chunk.size() &&
+              std::memcmp(dup2_chunk.data(), expected.data() + source_offset,
+                          dup2_chunk.size()) == 0,
+          "sceKernelDup2 replaces the target and shares the source offset");
+    if (dup2_target >= 0 && close_fn) close_fn((uint64_t)dup2_target, 0, 0, 0, 0, 0);
 
 #ifdef _WIN32
     // Unity asks for a whole 64 KiB cache block even when boot.config is only a few hundred bytes.


### PR DESCRIPTION
## Problem

The registered Windows `dup` and `dup2` HLE handlers unconditionally returned `-1`, so Windows guests could not duplicate file descriptors even though the Linux path already provided host-backed behavior.

## Contract and approach

- Route Windows `dup` through `_dup`.
- Keep any recycled CRT descriptors 0-2 occupied until the duplicate reaches the guest-visible range, preserving prosper's reserved-stdio invariant.
- Route Windows `dup2` through `_dup2`, translating the CRT's success value `0` to the POSIX/guest contract of returning the destination descriptor.
- Suppress and restore UCRT's invalid-parameter handler thread-locally around the guest-controlled calls, so invalid/closed descriptors return `-1` instead of terminating the host.
- Leave Linux behavior and the separate `fcntl`, errno-mapping, `getdents`, and Windows-open-low-fd findings unchanged.

Microsoft documents `_dup` as returning the new descriptor and `_dup2` as returning zero on success: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/dup-dup2?view=msvc-170

Microsoft also documents that the default UCRT invalid-parameter handler terminates the process, and that a thread-local handler overrides it for calls on only the current thread: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/set-invalid-parameter-handler-set-thread-local-invalid-parameter-handler?view=msvc-170

## Regression coverage

`test_file_binary` now proves that:

- both POSIX and `sceKernel` names are registered;
- `dup` returns a distinct descriptor, shares the source offset, and survives closing the source;
- Windows low CRT fd reuse is lifted above 2;
- `dup2` replaces an already-open target, shares the source offset, survives closing the source, and returns the target descriptor;
- invalid Windows sources return `-1` safely, and failed `dup2` preserves an already-open target and its offset/content.

The success behavior checks fail against the prior Windows hard-fail handlers; the invalid-source checks protect the review-discovered host-termination path introduced by routing through UCRT.

## Risk

This changes Windows file-descriptor ABI behavior and descriptor lifetime. The patch is isolated to the previously hard-failed Windows branches; Linux is regression-tested but unchanged. Independent inspection review is required.

## Author checks so far

- Corrected head focused Windows and Linux `file_binary_roundtrip` builds/tests — passed.
- `git diff --check` — passed.
- Snapshots not run: this does not affect rendered output.

Full corrected exact-head author verification will be posted as a PR comment.

Refs #389