### PR TITLE
fix(file): keep Windows opens above stdio

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -115,6 +115,23 @@ namespace {
     private:
         _invalid_parameter_handler previous_;
     };
+
+    int windows_duplicate_above_stdio(int source_fd) {
+        ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+        int fd = ::_dup(source_fd);
+        int low_fds[3]{};
+        size_t low_count = 0;
+        // Windows has no F_DUPFD. Keep recycled stdio slots occupied until _dup reaches the
+        // guest-visible range, then release the temporary descriptors.
+        while (fd >= 0 && fd < 3) {
+            low_fds[low_count++] = fd;
+            fd = ::_dup(source_fd);
+        }
+        int duplicate_errno = fd < 0 ? errno : 0;
+        for (size_t i = 0; i < low_count; ++i) ::_close(low_fds[i]);
+        if (fd < 0) errno = duplicate_errno;
+        return fd;
+    }
 #endif
 
     void filelog_remember_fd(int fd, const std::string& path) {
@@ -491,7 +508,15 @@ static int host_open_flags(uint64_t f) {
 }
 HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_flags(a1);
                int fd = (int)::open(h.c_str(), host_flags, (mode_t)a2);
-#ifndef _WIN32
+#ifdef _WIN32
+               if (fd >= 0 && fd < 3) {
+                   int low_fd = fd;
+                   fd = windows_duplicate_above_stdio(low_fd);
+                   int duplicate_errno = fd < 0 ? errno : 0;
+                   ::_close(low_fd);
+                   if (fd < 0) errno = duplicate_errno;
+               }
+#else
                while (fd >= 0 && fd < 3) { int nfd = fcntl(fd, F_DUPFD, 3); ::close(fd); fd = nfd; }
 #endif
                int err = fd < 0 ? errno : 0;
@@ -522,20 +547,7 @@ HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
 HLE(f_dup)  { int fd = ::dup((int)a0); while (fd >= 0 && fd < 3) { int n = fcntl(fd, F_DUPFD, 3); ::close(fd); fd = n; } return (uint64_t)(int64_t)fd; }
 HLE(f_dup2) { return (uint64_t)(int64_t)::dup2((int)a0, (int)a1); }
 #else
-HLE(f_dup)  {
-    ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
-    int fd = ::_dup((int)a0);
-    int low_fds[3]{};
-    size_t low_count = 0;
-    // Windows has no F_DUPFD. Keep recycled stdio slots occupied until _dup reaches the
-    // guest-visible range, then release the temporary descriptors.
-    while (fd >= 0 && fd < 3) {
-        low_fds[low_count++] = fd;
-        fd = ::_dup((int)a0);
-    }
-    for (size_t i = 0; i < low_count; ++i) ::_close(low_fds[i]);
-    return (uint64_t)(int64_t)fd;
-}
+HLE(f_dup)  { return (uint64_t)(int64_t)windows_duplicate_above_stdio((int)a0); }
 HLE(f_dup2) {
     ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
     int r = ::_dup2((int)a0, (int)a1);

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -143,8 +143,29 @@ int main() {
         close_fn((uint64_t)low_slot_duplicate, 0, 0, 0, 0, 0);
     if (low_slot_source >= 0 && close_fn)
         close_fn((uint64_t)low_slot_source, 0, 0, 0, 0, 0);
+
+    // With fd 0 still free, the Windows CRT will allocate it for the next open. The HLE must move
+    // that live file into the guest-visible range before returning it, without losing its contents.
+    int64_t low_slot_open = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0)
+        : -1;
+    CHECK(low_slot_open >= 3, "sceKernelOpen lifts a recycled Windows stdio descriptor");
+    std::array<uint8_t, 16> low_slot_open_chunk{};
+    int64_t low_slot_open_n = low_slot_open >= 0 && read_fn
+        ? (int64_t)read_fn((uint64_t)low_slot_open,
+                           (uint64_t)(uintptr_t)low_slot_open_chunk.data(),
+                           low_slot_open_chunk.size(), 0, 0, 0)
+        : -1;
+    CHECK(low_slot_open_n == (int64_t)low_slot_open_chunk.size() &&
+              std::memcmp(low_slot_open_chunk.data(), expected.data(),
+                          low_slot_open_chunk.size()) == 0,
+          "lifted sceKernelOpen descriptor reads the original file");
+    if (low_slot_open >= 3 && close_fn)
+        close_fn((uint64_t)low_slot_open, 0, 0, 0, 0, 0);
+    else if (low_slot_open >= 0)
+        ::_close((int)low_slot_open);
     if (saved_stdin >= 0) {
-        CHECK(::_dup2(saved_stdin, 0) == 0, "restore fd 0 after low-slot dup test");
+        CHECK(::_dup2(saved_stdin, 0) == 0, "restore fd 0 after low-slot descriptor tests");
         ::_close(saved_stdin);
     }
 #endif


### PR DESCRIPTION
## Problem

`sceKernelOpen` documented and enforced the invariant that guest file descriptors never use process-reserved slots 0-2, but the lifting logic was compiled only on non-Windows hosts. If a Windows process started with a CRT standard descriptor closed, `_open` recycled that slot and exposed it to the guest. `sceKernelClose` deliberately ignores 0-2, so the guest could not close that file normally and later stdio/sentinel behavior could alias live content.

## Approach

- Extract the reviewed Windows `_dup`-above-stdio loop into one helper shared by `dup` and `open`.
- When Windows `_open` returns 0-2, duplicate the live file into the first descriptor >=3 and close the original low descriptor.
- Preserve `_dup` failure `errno` across cleanup.
- Keep Linux behavior unchanged.

## Regression

The Windows `file_binary_roundtrip` test now deliberately frees fd 0, opens the binary fixture through `sceKernelOpen`, and proves the returned descriptor is >=3 and still reads the original bytes. The test restores the process's original stdin state and directly cleans up fd 0 when run against the broken implementation. This assertion fails on the parent behavior, which returns fd 0.

## Risk

This is file-descriptor lifetime/invariant code. The implementation reuses the Windows helper already exercised by `sceKernelDup`; independent inspection review is requested. No renderer behavior changes.

## Author checks so far

- Windows focused `test_file_binary` build and `file_binary_roundtrip` — passed.
- Linux focused `test_file_binary` build and `file_binary_roundtrip` — passed.
- `git diff --check` — passed.
- Snapshots not run: no rendered-output path changes.

Full exact-head author verification will be posted as a PR comment.

Fixes #869