### PR TITLE
fix(ajm): make handle outputs fault-safe

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -18,6 +18,14 @@
 #ifndef _WIN32
 #include <sys/uio.h>
 #include <unistd.h>
+#else
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #endif
 #include "../host/posix_shim.hpp"   // Darwin: process_vm_readv/writev
 
@@ -316,26 +324,26 @@ std::mutex g_a2_mx;
 A2Context  g_a2_ctx[4];
 uint32_t   g_a2_users = 0, g_a2_ports = 0;
 
-// Fault-safe u64 store to a guest out-pointer (same rationale as apr_write_guest_dst: a bad
-// pointer must fail the call, not SIGSEGV inside the HLE).
-bool a2_store_u64(uint64_t dst, uint64_t v) {
+// Fault-safe store to a guest out-pointer (same rationale as apr_write_guest_dst: a bad pointer
+// must fail the call, not SIGSEGV inside the HLE). WriteProcessMemory validates the complete
+// destination range before copying, matching the all-or-fail process_vm_writev contract here.
+bool audio_store_bytes(uint64_t dst, const void* src, size_t n) {
+    if (!dst || (!src && n)) return false;
+    if (!n) return true;
 #ifndef _WIN32
-    struct iovec l { &v, sizeof v }, r { (void*)(uintptr_t)dst, sizeof v };
-    return process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)sizeof v;
-#else
-    if (!dst) return false;
-    *(uint64_t*)(uintptr_t)dst = v; return true;
-#endif
-}
-bool a2_store_zeros(uint64_t dst, size_t n) {
-#ifndef _WIN32
-    std::vector<uint8_t> z(n, 0);
-    struct iovec l { z.data(), n }, r { (void*)(uintptr_t)dst, n };
+    struct iovec l { const_cast<void*>(src), n }, r { (void*)(uintptr_t)dst, n };
     return process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)n;
 #else
-    if (!dst) return false;
-    memset((void*)(uintptr_t)dst, 0, n); return true;
+    SIZE_T written = 0;
+    return WriteProcessMemory(GetCurrentProcess(), (void*)(uintptr_t)dst, src, n, &written) &&
+           written == n;
 #endif
+}
+bool a2_store_u32(uint64_t dst, uint32_t v) { return audio_store_bytes(dst, &v, sizeof v); }
+bool a2_store_u64(uint64_t dst, uint64_t v) { return audio_store_bytes(dst, &v, sizeof v); }
+bool a2_store_zeros(uint64_t dst, size_t n) {
+    std::vector<uint8_t> z(n, 0);
+    return audio_store_bytes(dst, z.data(), n);
 }
 
 constexpr uint64_t kA2ErrInvalid = (uint64_t)(int64_t)(int32_t)0x80260003;   // AudioOut error space
@@ -483,7 +491,7 @@ namespace {
 // sceAjmInitialize(s64 reserved, u32* out_context): create a context. Filling out_context is the point.
 HLE(ajm_initialize) {
     if (a0 != 0 || !a1) return AJM_ERR_INVALID_PARAMETER;
-    *(uint32_t*)P(a1) = g_ajm_next.fetch_add(1);
+    if (!a2_store_u32(a1, g_ajm_next.fetch_add(1))) return AJM_ERR_INVALID_PARAMETER;
     return 0;
 }
 HLE(ajm_finalize)         { return 0; }
@@ -494,7 +502,7 @@ HLE(ajm_module_unregister){ return 0; }
 HLE(ajm_instance_create) {
     if (!a0) return AJM_ERR_INVALID_CONTEXT;
     if (!a3) return AJM_ERR_INVALID_PARAMETER;
-    *(uint32_t*)P(a3) = g_ajm_next.fetch_add(1);
+    if (!a2_store_u32(a3, g_ajm_next.fetch_add(1))) return AJM_ERR_INVALID_PARAMETER;
     return 0;
 }
 // sceAjmInstanceDestroy(u32 context, u32 instance).
@@ -509,7 +517,7 @@ HLE(ajm_instance_destroy) {
 HLE(ajm_batch_start) {
     if (!a0) return AJM_ERR_INVALID_CONTEXT;
     if (!a5) return AJM_ERR_INVALID_PARAMETER;
-    *(uint32_t*)P(a5) = g_ajm_next.fetch_add(1);
+    if (!a2_store_u32(a5, g_ajm_next.fetch_add(1))) return AJM_ERR_INVALID_PARAMETER;
     return 0;
 }
 HLE(ajm_batch_wait)       { return a0 ? 0 : AJM_ERR_INVALID_CONTEXT; }   // batch completed

--- a/prosper/tests/test_ajm.cpp
+++ b/prosper/tests/test_ajm.cpp
@@ -37,6 +37,8 @@ int main() {
     CHECK(init(0, (uint64_t)(uintptr_t)&ctx, 0, 0, 0, 0) == 0, "sceAjmInitialize -> OK");
     CHECK(ctx != 0 && ctx != 0xDEAD, "Initialize WROTE a valid non-zero context (not left garbage)");
     CHECK(init(0, 0, 0, 0, 0, 0) == 0x80930005ull, "Initialize(NULL out) -> INVALID_PARAMETER");
+    CHECK(init(0, 1, 0, 0, 0, 0) == 0x80930005ull,
+          "Initialize(inaccessible out) -> INVALID_PARAMETER without host fault");
     uint32_t rejected_ctx = 0xCAFE;
     CHECK(init(1, (uint64_t)(uintptr_t)&rejected_ctx, 0, 0, 0, 0) == 0x80930005ull,
           "Initialize(nonzero reserved) -> INVALID_PARAMETER");
@@ -51,12 +53,16 @@ int main() {
     CHECK(icreate(ctx, 1 /*At9Dec*/, 0 /*flags*/, (uint64_t)(uintptr_t)&inst, 0, 0) == 0, "sceAjmInstanceCreate -> OK");
     CHECK(inst != 0 && inst != 0xBEEF && inst != ctx, "InstanceCreate WROTE a distinct non-zero instance");
     CHECK(icreate(0, 1, 0, (uint64_t)(uintptr_t)&inst, 0, 0) == 0x80930002ull, "InstanceCreate(ctx 0) -> INVALID_CONTEXT");
+    CHECK(icreate(ctx, 1, 0, 1, 0, 0) == 0x80930005ull,
+          "InstanceCreate(inaccessible out) -> INVALID_PARAMETER without host fault");
 
     // Batch: StartBuffer fills a batch id; Wait completes it.
     uint32_t batch = 0xF00D;
     CHECK(bstart(ctx, 0 /*batch buf*/, 0 /*size*/, 0 /*prio*/, 0 /*err*/, (uint64_t)(uintptr_t)&batch) == 0,
           "sceAjmBatchStartBuffer -> OK");
     CHECK(batch != 0 && batch != 0xF00D, "BatchStartBuffer WROTE a valid non-zero batch id");
+    CHECK(bstart(ctx, 0, 0, 0, 0, 1) == 0x80930005ull,
+          "BatchStartBuffer(inaccessible out) -> INVALID_PARAMETER without host fault");
     CHECK(bwait(ctx, batch, 0, 0, 0, 0) == 0, "sceAjmBatchWait -> OK (batch completed)");
 
     // Teardown.

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -74,6 +74,11 @@ int main() {
         CHECK(ch == t.ch); CHECK(f == t.fmt);
     }
 
+    // AudioOut2 shares the guest-store primitive with AJM. Inaccessible outputs must report an
+    // error instead of faulting the host; these cover both fixed-size zero-fill and u64 stores.
+    CHECK((int32_t)call("sceAudioOut2ContextResetParam", 1) == (int32_t)0x80260003);
+    CHECK((int32_t)call("sceAudioOut2ContextQueryMemory", 0, 1) == (int32_t)0x80260003);
+
     // --- 2. open -> handle + backend.open with decoded params --------------------------------
     audio_reset();
     CapturingSink sink; audio_set_sink(&sink);


### PR DESCRIPTION
## Problem

AJM's three handle-producing entry points wrote guest out-pointers with raw host dereferences. A non-null but inaccessible pointer therefore crashed the emulator instead of returning `AJM_ERR_INVALID_PARAMETER`.

The existing AudioOut2 helper had the intended fault-safe contract on Linux/macOS, but its Windows branch also used raw dereferences, so simply routing AJM through it would not protect Windows.

## Approach

- Add one byte-oriented audio guest-store primitive.
- Keep POSIX on exact-length `process_vm_writev`.
- Use `WriteProcessMemory` against the current process on Windows and require the complete byte count; Microsoft documents that it validates the full destination range and fails when inaccessible: https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-writeprocessmemory
- Build u32, u64, and zero-fill stores on that primitive.
- Route `sceAjmInitialize`, `sceAjmInstanceCreate`, and `sceAjmBatchStartBuffer` outputs through the u32 store and return `AJM_ERR_INVALID_PARAMETER` on failure.

Valid handle/lifecycle behavior is unchanged. The separate Windows NGS2 raw-copy finding is tracked in #872 rather than expanding this PR.

## Regression coverage

- AJM tests pass address `1` as each handle output and require `INVALID_PARAMETER` without a host fault.
- AudioOut2 tests exercise inaccessible zero-fill and u64 output ranges, protecting the Windows prerequisite path.
- Existing valid AJM and AudioOut/NGS2 lifecycle tests remain green.

The new AJM cases crash the parent implementation on both platforms; the new AudioOut2 cases specifically crash the parent Windows branch.

## Risk

This is guest-memory safety code shared by AJM and AudioOut2 output helpers. It changes only failure behavior for inaccessible destinations; valid stores retain their exact widths and values. Independent memory-safety review is required.

## Author checks so far

- Windows: `audio_hle` and `ajm_hle` — 2/2 passed.
- Linux: `audio_hle` and `ajm_hle` — 2/2 passed.
- `git diff --check` — passed.
- Snapshots not run: no renderer path changed.

Full exact-head author verification will be posted as a PR comment.

Refs #396