### PR TITLE
fix(audio): make Windows NGS2 guest copies fault-safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,14 +301,19 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
   for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
   exact-head results.
-- **Use independent review where risk justifies it.** Complex or high-risk changes—such as shader/recompiler
+- **Use independent review whenever it can materially improve confidence.** Treat review as a correctness
+  tool, not merely a gate for large diffs: behavioral code changes involving non-obvious judgment, unfamiliar
+  code, cross-platform behavior, reverse-engineered semantics, or meaningful failure paths should normally be
+  reviewed even when the patch is small and the author verification is green. Complex or high-risk changes—such
+  as shader/recompiler
   control flow, memory safety or untrusted bounds, synchronization, ABI-sensitive interfaces, persistent data,
   shared renderer/executor format, size, or indexing semantics, or changes whose failure can silently corrupt
   results—require an independent code review before merge. Review is also required when the validation itself
   is easy to get wrong: for example, a regression test with another path that can produce the expected result,
   or a snapshot route or baseline update that needs judgment to confirm it exercises the intended behavior.
-  Judge both implementation risk and verification risk, not merely the diff size. Routine, well-bounded,
-  low-risk changes do not require an independent reviewer. Passing author verification does not substitute for
+  Judge both implementation risk and verification risk, not merely the diff size. Skip independent review only
+  for genuinely routine, mechanical, well-bounded low-risk work where another reader is unlikely to uncover a
+  correctness problem; when in doubt, review. Passing author verification does not substitute for
   review where review is warranted: verification demonstrates observed behavior, while review challenges the
   contract assumptions, untested paths, and whether the regression actually proves the intended behavior.
   When uncertain, favor review for reverse-engineered API semantics and other changes where an independent

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -339,6 +339,22 @@ bool audio_store_bytes(uint64_t dst, const void* src, size_t n) {
            written == n;
 #endif
 }
+
+// Fault-safe read from guest memory. Both platform paths require the complete range so callers
+// never consume a partially copied guest structure after an inaccessible-range failure.
+bool audio_read_bytes(uint64_t src, void* dst, size_t n) {
+    if (!src || (!dst && n)) return false;
+    if (!n) return true;
+#ifndef _WIN32
+    struct iovec l { dst, n }, r { (void*)(uintptr_t)src, n };
+    return process_vm_readv(getpid(), &l, 1, &r, 1, 0) == (ssize_t)n;
+#else
+    SIZE_T read = 0;
+    return ReadProcessMemory(GetCurrentProcess(), (const void*)(uintptr_t)src, dst, n, &read) &&
+           read == n;
+#endif
+}
+
 bool a2_store_u32(uint64_t dst, uint32_t v) { return audio_store_bytes(dst, &v, sizeof v); }
 bool a2_store_u64(uint64_t dst, uint64_t v) { return audio_store_bytes(dst, &v, sizeof v); }
 bool a2_store_zeros(uint64_t dst, size_t n) {
@@ -569,41 +585,20 @@ std::mutex g_ngs2_zero_mx;
 std::vector<uint8_t> g_ngs2_zeros;
 
 bool ngs2_read_u32(uint64_t src, uint32_t& value) {
-#ifndef _WIN32
-    struct iovec l { &value, sizeof value }, r { (void*)(uintptr_t)src, sizeof value };
-    return src && process_vm_readv(getpid(), &l, 1, &r, 1, 0) == (ssize_t)sizeof value;
-#else
-    if (!src) return false;
-    value = *(const uint32_t*)(uintptr_t)src;
-    return true;
-#endif
+    return audio_read_bytes(src, &value, sizeof value);
 }
 
 bool ngs2_read_bytes(uint64_t src, void* dst, size_t size) {
-#ifndef _WIN32
-    struct iovec l { dst, size }, r { (void*)(uintptr_t)src, size };
-    return src && process_vm_readv(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
-#else
-    if (!src) return false;
-    memcpy(dst, (const void*)(uintptr_t)src, size);
-    return true;
-#endif
+    return audio_read_bytes(src, dst, size);
 }
 
 bool ngs2_zero_bytes(uint64_t dst, size_t size) {
-#ifndef _WIN32
     // Do not use thread_local here: guest execution swaps %fs, and adding host TLS to prosper_core
     // perturbs Messenger before its first syscall. Process-global zero storage is sufficient because
     // NGS2 rendering is serialized by its audio thread; the lock also makes that contract explicit.
     std::lock_guard<std::mutex> lock(g_ngs2_zero_mx);
     if (g_ngs2_zeros.size() < size) g_ngs2_zeros.resize(size, 0);
-    struct iovec l { g_ngs2_zeros.data(), size }, r { (void*)(uintptr_t)dst, size };
-    return dst && process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
-#else
-    if (!dst) return false;
-    memset((void*)(uintptr_t)dst, 0, size);
-    return true;
-#endif
+    return audio_store_bytes(dst, g_ngs2_zeros.data(), size);
 }
 
 uint32_t ngs2_max_voices(uint64_t option) {

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -208,6 +208,10 @@ int main() {
     CHECK(call_raw("koBbCMvOKWw", 0, PTR(&sys_info), PTR(&system)) == 0); // SystemCreate
     CHECK(system != 0 && system != 0xDEADBEEFDEADBEEFull);
 
+    BufferInfo fallback_info; memset(&fallback_info, 0xDD, sizeof fallback_info);
+    CHECK(call_raw("0eFLVCfWVds", 0x2001, 1, PTR(&fallback_info)) == 0);
+    CHECK(fallback_info.host_buffer == 0 && fallback_info.host_buffer_size == 0x2000);
+
     RackOption rack_opt{}; rack_opt.size = sizeof rack_opt; rack_opt.max_voices = 2;
     memcpy(rack_opt.name, "test", 5);
     BufferInfo rack_info; memset(&rack_info, 0xDD, sizeof rack_info);
@@ -235,6 +239,10 @@ int main() {
     CHECK(call_raw("i0VnXM-C9fc", system, PTR(&render), 1) == 0);
     for (uint8_t b : ngs_pcm) CHECK(b == 0);               // silent backend produces silence
     CHECK((int32_t)call_raw("i0VnXM-C9fc", 0, PTR(&render), 1) == (int32_t)0x804A0230);
+    CHECK((int32_t)call_raw("i0VnXM-C9fc", system, 1, 1) == (int32_t)0x804A0053);
+    RenderInfo inaccessible_output{1, 16, 0, 2};
+    CHECK((int32_t)call_raw("i0VnXM-C9fc", system, PTR(&inaccessible_output), 1) ==
+          (int32_t)0x804A0053);
 
     uint8_t source[0xA8], listener[0xA0], listener_work[0x60];
     memset(source, 0xBB, sizeof source); memset(listener, 0xBB, sizeof listener);


### PR DESCRIPTION
﻿## Summary

Fixes #872.

Windows NGS2 guest-memory helpers directly dereferenced render descriptors, rack options, and render output pointers. Invalid guest addresses could therefore raise a host access violation instead of returning the established NGS2 error contract.

This change:

- adds one exact-length fault-safe audio guest-read primitive using `process_vm_readv` on POSIX and `ReadProcessMemory` on Windows;
- routes the NGS2 u32/structure reads through that primitive;
- routes NGS2 silence writes through the existing exact-length safe guest-store primitive;
- adds regressions for inaccessible rack-option, render-descriptor, and render-output addresses; and
- clarifies in `CLAUDE.md` that independent review should be used whenever it can materially improve confidence, while verification remains author-owned.

## Contract and invariants

- Guest-memory transfers succeed only when the complete requested range is copied.
- Inaccessible NGS2 render inputs/outputs return `SCE_NGS2_ERROR_INVALID_OUTPUT` rather than faulting the host.
- An inaccessible optional rack configuration preserves the existing default of 64 voices.
- Valid NGS2 lifecycle and silent-render behavior is unchanged.
- No renderer path or snapshot baseline is affected.

## Risk

Memory-safety and cross-platform behavior. The PR requires independent inspection of the exact head. The reviewer must not duplicate author builds, tests, snapshots, or CI.

## Author preflight

- `cmake --build build-linux --target test_audio -j2`
- `ctest --test-dir build-linux -R '^audio_hle$' --output-on-failure` ? 1/1 passed
- `cmake --build build-win --target test_audio -j2`
- `ctest --test-dir build-win -R '^audio_hle$' --output-on-failure` ? 1/1 passed
- `git diff --check` ? clean

Full exact-head author verification will be posted as a PR comment. Snapshots are not applicable because this does not affect rendered output.
