### PR TITLE
fix(file): split directory enumeration errors

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -850,11 +850,15 @@ static uint64_t directory_sce_error(int error) {
     return 0x80020000ull | (uint64_t)(error & 0xff);
 }
 
+static bool directory_result_is_error(uint64_t result) {
+    return (result & ~0xffull) == 0x80020000ull;
+}
+
 // libc's getdents/getdirentries use the POSIX -1 + errno contract, while their sceKernel siblings
 // return an SCE_KERNEL_ERROR value directly. They used to share the kernel handler, so libc saw a
 // large positive byte count on failure and could walk an untouched directory buffer as valid data.
 static uint64_t directory_result_to_posix(uint64_t result) {
-    if ((result & ~0xffull) != 0x80020000ull) return result;
+    if (!directory_result_is_error(result)) return result;
     errno = (int)(result & 0xff);
     return (uint64_t)(int64_t)-1;
 }
@@ -952,7 +956,7 @@ HLE(k_getdents) {
 HLE(k_getdirentries) {
     off_t base = ::lseek((int)a0, 0, SEEK_CUR);
     uint64_t r = k_getdents(a0, a1, a2, 0, 0, 0);
-    if (a3) *(int64_t*)P(a3) = (int64_t)base;
+    if (!directory_result_is_error(r) && a3) *(int64_t*)P(a3) = (int64_t)base;
     return r;
 }
 #else
@@ -961,13 +965,18 @@ HLE(k_getdents) {
     ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
     intptr_t handle = ::_get_osfhandle((int)a0);
     if (handle == -1) return directory_sce_error(EBADF);
+    if (GetFileType((HANDLE)handle) != FILE_TYPE_DISK) return directory_sce_error(ENOTDIR);
     BY_HANDLE_FILE_INFORMATION info{};
-    if (!GetFileInformationByHandle((HANDLE)handle, &info)) return directory_sce_error(EBADF);
+    if (!GetFileInformationByHandle((HANDLE)handle, &info)) return directory_sce_error(ENOTDIR);
     if (!(info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) return directory_sce_error(ENOTDIR);
     // Directory descriptors are not currently produced by the Windows CRT-backed open path.
     return 0;
 }
-HLE(k_getdirentries) { return k_getdents(a0, a1, a2, a3, a4, a5); }
+HLE(k_getdirentries) {
+    uint64_t r = k_getdents(a0, a1, a2, a3, a4, a5);
+    if (!directory_result_is_error(r) && a3) *(int64_t*)P(a3) = 0;
+    return r;
+}
 #endif
 HLE(f_getdents) {
     return directory_result_to_posix(k_getdents(a0, a1, a2, a3, a4, a5));

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -841,12 +841,25 @@ HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode
 }
 HLE(f_rmdir) { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::rmdir(h.c_str()); }
 
-#ifndef _WIN32
 // sceKernelGetdents(int fd, char* buf, size_t nbytes) — fill FreeBSD dirent records
 // {u32 fileno; u16 reclen; u8 type; u8 namlen; char name[]} (4-aligned). Backed by the host's
 // getdents64 on the SAME fd so the kernel keeps the directory cursor; Linux and BSD DT_* type
 // values match. Returns bytes written (0 = end of directory), or an SCE error. UE4 (PPSA17942)
 // enumerates its pak directory with this during IO-stack init.
+static uint64_t directory_sce_error(int error) {
+    return 0x80020000ull | (uint64_t)(error & 0xff);
+}
+
+// libc's getdents/getdirentries use the POSIX -1 + errno contract, while their sceKernel siblings
+// return an SCE_KERNEL_ERROR value directly. They used to share the kernel handler, so libc saw a
+// large positive byte count on failure and could walk an untouched directory buffer as valid data.
+static uint64_t directory_result_to_posix(uint64_t result) {
+    if ((result & ~0xffull) != 0x80020000ull) return result;
+    errno = (int)(result & 0xff);
+    return (uint64_t)(int64_t)-1;
+}
+
+#ifndef _WIN32
 #ifdef __APPLE__
 // #843: sceKernelGetdents caches one DIR* per directory fd (Darwin has no getdents-on-fd). The cache
 // MUST be dropped when the guest closes that fd — otherwise a reused fd number hands back a STALE DIR*
@@ -867,7 +880,7 @@ int getdents_close_fd(int fd) {
     return ::close(fd);
 }
 #endif
-HLE(f_getdents) {
+HLE(k_getdents) {
     if (!a1 || a2 < 32) return 0x80020016ull;   // EINVAL
 #ifdef __APPLE__
     // Darwin has no getdents-on-fd (getdirentries is unavailable with 64-bit inodes). Keep the
@@ -882,7 +895,11 @@ HLE(f_getdents) {
     else {
         int d2 = dup((int)a0);
         dp = d2 >= 0 ? fdopendir(d2) : nullptr;
-        if (!dp) { if (d2 >= 0) ::close(d2); return 0x80020000ull | (uint64_t)(errno & 0xff); }
+        if (!dp) {
+            int error = errno;
+            if (d2 >= 0) ::close(d2);
+            return directory_sce_error(error);
+        }
         g_getdents_dirs[(int)a0] = dp;
     }
     uint8_t* out = (uint8_t*)P(a1);
@@ -908,7 +925,7 @@ HLE(f_getdents) {
     uint8_t tmp[4096];
     size_t want = a2 < sizeof tmp ? (size_t)a2 : sizeof tmp;
     long n = syscall(SYS_getdents64, (int)a0, tmp, (unsigned)want);
-    if (n < 0)  return 0x80020000ull | (uint64_t)(errno & 0xff);
+    if (n < 0)  return directory_sce_error(errno);
     if (n == 0) return 0;
     uint8_t* out = (uint8_t*)P(a1);
     size_t o = 0, w = 0;
@@ -932,16 +949,32 @@ HLE(f_getdents) {
 // sceKernelGetdirentries(fd, buf, nbytes, long* basep): like getdents but also writes the pre-call
 // directory offset to *basep. Was MISSING -> returned 0 = "empty directory". Delegate to f_getdents and
 // stamp basep with the cursor position captured before the read.
-HLE(f_getdirentries) {
+HLE(k_getdirentries) {
     off_t base = ::lseek((int)a0, 0, SEEK_CUR);
-    uint64_t r = f_getdents(a0, a1, a2, 0, 0, 0);
+    uint64_t r = k_getdents(a0, a1, a2, 0, 0, 0);
     if (a3) *(int64_t*)P(a3) = (int64_t)base;
     return r;
 }
 #else
-HLE(f_getdents) { return 0; }
-HLE(f_getdirentries) { return 0; }
+HLE(k_getdents) {
+    if (!a1 || a2 < 32) return directory_sce_error(EINVAL);
+    ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+    intptr_t handle = ::_get_osfhandle((int)a0);
+    if (handle == -1) return directory_sce_error(EBADF);
+    BY_HANDLE_FILE_INFORMATION info{};
+    if (!GetFileInformationByHandle((HANDLE)handle, &info)) return directory_sce_error(EBADF);
+    if (!(info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) return directory_sce_error(ENOTDIR);
+    // Directory descriptors are not currently produced by the Windows CRT-backed open path.
+    return 0;
+}
+HLE(k_getdirentries) { return k_getdents(a0, a1, a2, a3, a4, a5); }
 #endif
+HLE(f_getdents) {
+    return directory_result_to_posix(k_getdents(a0, a1, a2, a3, a4, a5));
+}
+HLE(f_getdirentries) {
+    return directory_result_to_posix(k_getdirentries(a0, a1, a2, a3, a4, a5));
+}
 HLE(f_unlink){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::
 #ifdef _WIN32
     _unlink
@@ -1523,13 +1556,13 @@ void register_file_hle() {
     R("unlink", f_unlink);        R("sceKernelUnlink", f_unlink);
     R("rename", f_rename);        R("sceKernelRename", f_rename);   // real move (was fake-success -> lost atomic saves)
     R("dup", f_dup);   R("sceKernelDup", f_dup);   R("dup2", f_dup2);   R("sceKernelDup2", f_dup2);   // were 0 = stdin
-    R("sceKernelGetdents", f_getdents); R("getdents", f_getdents);
+    R("sceKernelGetdents", k_getdents); R("getdents", f_getdents);
     // vectored IO + getdirentries — real host ops (were MISSING -> silent-EOF / empty-dir corruption trap)
     R("sceKernelReadv", f_readv);       R("readv", f_readv);
     R("sceKernelWritev", f_writev);     R("writev", f_writev);
     R("sceKernelPreadv", f_preadv);     R("preadv", f_preadv);
     R("sceKernelPwritev", f_pwritev);   R("pwritev", f_pwritev);
-    R("sceKernelGetdirentries", f_getdirentries); R("getdirentries", f_getdirentries);
+    R("sceKernelGetdirentries", k_getdirentries); R("getdirentries", f_getdirentries);
     // sceKernelAio* (issue #312): NIDs verified identical in shadPS4's PS4 registration table and
     // the PS5 3.20 libkernel stub dump. Raw-NID registration (names not in our NidDb).
     Hle::register_fn("vYU8P9Td2Zo", (HleFn)k_aio_init,         "sceKernelAioInitializeImpl");

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -51,8 +51,13 @@ int main() {
     HleFn kernel_dup2_fn = Hle::lookup(nid_hash("sceKernelDup2"));
     HleFn mkdir_fn = Hle::lookup(nid_hash("mkdir"));
     HleFn kernel_mkdir_fn = Hle::lookup(nid_hash("sceKernelMkdir"));
+    HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
+    HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
+    HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
+    HleFn kernel_getdirentries_fn = Hle::lookup(nid_hash("sceKernelGetdirentries"));
     CHECK(open_fn && read_fn && lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
-              dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn,
+              dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
+              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn,
           "file HLE functions registered");
 
     // Creating an existing directory is a failure, not an idempotent success. Linux previously
@@ -80,6 +85,40 @@ int main() {
     std::array<uint8_t, 512> actual{};
     int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;
     CHECK(fd >= 0, "open fixture through guest fd HLE");
+
+    // libc and sceKernel expose the same enumeration operation with different error conventions.
+    // The old shared handler returned a positive-looking SCE error to libc; Windows returned false
+    // EOF for every call. Exercise both invalid arguments and a valid non-directory descriptor.
+    std::array<uint8_t, 64> dir_buffer{};
+    int64_t base = 0x12345678;
+    errno = 0;
+    int64_t libc_bad_buffer = getdents_fn
+        ? (int64_t)getdents_fn((uint64_t)fd, 0, dir_buffer.size(), 0, 0, 0)
+        : 0;
+    int libc_bad_buffer_errno = errno;
+    uint64_t kernel_bad_buffer = kernel_getdents_fn
+        ? kernel_getdents_fn((uint64_t)fd, 0, dir_buffer.size(), 0, 0, 0)
+        : 0;
+    CHECK(libc_bad_buffer == -1 && libc_bad_buffer_errno == EINVAL,
+          "libc getdents returns -1 with EINVAL for an invalid buffer");
+    CHECK((uint32_t)kernel_bad_buffer == 0x80020016u,
+          "sceKernelGetdents returns SCE_KERNEL_ERROR_EINVAL directly");
+
+    errno = 0;
+    int64_t libc_not_directory = getdirentries_fn
+        ? (int64_t)getdirentries_fn((uint64_t)fd, (uint64_t)(uintptr_t)dir_buffer.data(),
+                                   dir_buffer.size(), (uint64_t)(uintptr_t)&base, 0, 0)
+        : 0;
+    int libc_not_directory_errno = errno;
+    uint64_t kernel_not_directory = kernel_getdirentries_fn
+        ? kernel_getdirentries_fn((uint64_t)fd, (uint64_t)(uintptr_t)dir_buffer.data(),
+                                  dir_buffer.size(), (uint64_t)(uintptr_t)&base, 0, 0)
+        : 0;
+    CHECK(libc_not_directory == -1 && libc_not_directory_errno == ENOTDIR,
+          "libc getdirentries returns -1 with ENOTDIR for a regular file");
+    CHECK((uint32_t)kernel_not_directory == 0x80020014u,
+          "sceKernelGetdirentries returns SCE_KERNEL_ERROR_ENOTDIR directly");
+
     int64_t n = fd >= 0 && read_fn
         ? (int64_t)read_fn((uint64_t)fd, (uint64_t)(uintptr_t)actual.data(), actual.size(), 0, 0, 0)
         : -1;

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -59,6 +59,7 @@ int main() {
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn,
           "file HLE functions registered");
+    std::array<uint8_t, 64> dir_buffer{};
 
     // Creating an existing directory is a failure, not an idempotent success. Linux previously
     // suppressed EEXIST while Windows propagated it, so save-directory control flow differed by host.
@@ -80,6 +81,39 @@ int main() {
     CHECK(mkdir_duplicate == -1, "mkdir reports an existing directory as failure");
     CHECK(duplicate_errno == EEXIST, "mkdir preserves EEXIST for the caller");
     CHECK(kernel_mkdir_duplicate != 0, "sceKernelMkdir does not report false success on EEXIST");
+#ifdef _WIN32
+    // Windows has no CRT directory-open API, but a directory HANDLE can be attached to a CRT fd.
+    // The zero-entry stub must still publish the defined starting offset through basep.
+    HANDLE directory_handle = CreateFileA(dir_path, GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+    int directory_fd = directory_handle != INVALID_HANDLE_VALUE
+        ? ::_open_osfhandle((intptr_t)directory_handle, _O_RDONLY | _O_BINARY)
+        : -1;
+    int64_t directory_base = 0x12345678;
+    uint64_t directory_result = directory_fd >= 0 && kernel_getdirentries_fn
+        ? kernel_getdirentries_fn((uint64_t)directory_fd,
+                                  (uint64_t)(uintptr_t)dir_buffer.data(), dir_buffer.size(),
+                                  (uint64_t)(uintptr_t)&directory_base, 0, 0)
+        : ~uint64_t{0};
+    CHECK(directory_result == 0 && directory_base == 0,
+          "Windows sceKernelGetdirentries initializes basep on success");
+    if (directory_fd >= 0) ::_close(directory_fd);
+    else if (directory_handle != INVALID_HANDLE_VALUE) CloseHandle(directory_handle);
+
+    // A pipe is a valid CRT descriptor, but not a directory. Do not conflate an unsupported
+    // handle type with EBADF after _get_osfhandle has established descriptor validity.
+    int pipe_fds[2]{-1, -1};
+    int pipe_result = ::_pipe(pipe_fds, 256, _O_BINARY);
+    uint64_t pipe_getdents = pipe_result == 0 && kernel_getdents_fn
+        ? kernel_getdents_fn((uint64_t)pipe_fds[0], (uint64_t)(uintptr_t)dir_buffer.data(),
+                             dir_buffer.size(), 0, 0, 0)
+        : 0;
+    CHECK(pipe_result == 0 && (uint32_t)pipe_getdents == 0x80020014u,
+          "Windows valid non-directory handles return SCE_KERNEL_ERROR_ENOTDIR");
+    if (pipe_fds[0] >= 0) ::_close(pipe_fds[0]);
+    if (pipe_fds[1] >= 0) ::_close(pipe_fds[1]);
+#endif
     std::filesystem::remove_all(dir_path, remove_error);
 
     std::array<uint8_t, 512> actual{};
@@ -89,7 +123,6 @@ int main() {
     // libc and sceKernel expose the same enumeration operation with different error conventions.
     // The old shared handler returned a positive-looking SCE error to libc; Windows returned false
     // EOF for every call. Exercise both invalid arguments and a valid non-directory descriptor.
-    std::array<uint8_t, 64> dir_buffer{};
     int64_t base = 0x12345678;
     errno = 0;
     int64_t libc_bad_buffer = getdents_fn
@@ -118,6 +151,25 @@ int main() {
           "libc getdirentries returns -1 with ENOTDIR for a regular file");
     CHECK((uint32_t)kernel_not_directory == 0x80020014u,
           "sceKernelGetdirentries returns SCE_KERNEL_ERROR_ENOTDIR directly");
+    CHECK(base == 0x12345678,
+          "failed getdirentries calls leave basep untouched");
+
+    // A failure must be determined before touching basep. Address 1 is deliberately inaccessible;
+    // this also exercises Windows' guarded _get_osfhandle invalid-descriptor path.
+    errno = 0;
+    int64_t libc_bad_fd = getdirentries_fn
+        ? (int64_t)getdirentries_fn(~uint64_t{0}, (uint64_t)(uintptr_t)dir_buffer.data(),
+                                   dir_buffer.size(), 1, 0, 0)
+        : 0;
+    int libc_bad_fd_errno = errno;
+    uint64_t kernel_bad_fd = kernel_getdirentries_fn
+        ? kernel_getdirentries_fn(~uint64_t{0}, (uint64_t)(uintptr_t)dir_buffer.data(),
+                                  dir_buffer.size(), 1, 0, 0)
+        : 0;
+    CHECK(libc_bad_fd == -1 && libc_bad_fd_errno == EBADF,
+          "libc getdirentries rejects an invalid descriptor without touching basep");
+    CHECK((uint32_t)kernel_bad_fd == 0x80020009u,
+          "sceKernelGetdirentries returns EBADF without touching basep");
 
     int64_t n = fd >= 0 && read_fn
         ? (int64_t)read_fn((uint64_t)fd, (uint64_t)(uintptr_t)actual.data(), actual.size(), 0, 0, 0)


### PR DESCRIPTION
## Summary

Refs #389 (getdents/getdirentries error-contract remainder only).

The same HLE handlers were registered for the libc and `sceKernel` directory-enumeration names. On failure they returned a direct `SCE_KERNEL_ERROR_*` value to both call families, so libc callers could interpret a large positive result as a byte count and walk an untouched directory buffer. The Windows stubs instead returned zero for every call, masking invalid arguments and regular-file descriptors as end-of-directory.

This change:

- keeps kernel-style cores for `sceKernelGetdents` and `sceKernelGetdirentries`;
- adds libc adapters that translate kernel errors to `-1` and restore `errno`;
- makes the Windows path validate the output contract and CRT descriptor safely, returning `EINVAL`, `EBADF`, or `ENOTDIR` instead of false EOF; and
- adds cross-platform dispatch regressions covering both call families and both invalid-buffer/non-directory failures.

The separate #389 `fcntl` flag translation and broad host-to-FreeBSD errno mapping remain out of scope.

## Contract and invariants

- Successful enumeration byte counts and record layout are unchanged.
- libc names use the POSIX `-1` + `errno` convention.
- `sceKernel` names return the established `0x800200xx` error directly.
- Known `EINVAL`, `EBADF`, and `ENOTDIR` numbers coincide across the supported hosts; this PR does not claim general errno-number equivalence.
- Windows CRT invalid-parameter callbacks are suppressed while validating descriptors.
- Renderer behavior is unaffected.

## Risk

ABI/error-contract and cross-platform file-I/O behavior. Independent inspection is required on the exact head. The reviewer must not duplicate author builds, tests, snapshots, or CI.

## Author preflight

- `cmake --build build-linux --target test_file_binary -j2`
- `ctest --test-dir build-linux -R '^file_binary_roundtrip$' --output-on-failure` ? 1/1 passed
- `cmake --build build-win --target test_file_binary -j2`
- `ctest --test-dir build-win -R '^file_binary_roundtrip$' --output-on-failure` ? 1/1 passed
- `git diff --check` ? clean

Full exact-head author verification will be posted as a PR comment. Snapshots are not applicable because no rendered-output path changed.
