### PR TITLE
Fix Windows directory enumeration for Astro Bot cinematics

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -164,6 +164,24 @@ namespace {
         return hash ? hash : 1;
     }
 
+    int windows_directory_errno(DWORD error) {
+        switch (error) {
+        case ERROR_FILE_NOT_FOUND:
+        case ERROR_PATH_NOT_FOUND:
+        case ERROR_INVALID_NAME:
+        case ERROR_DIRECTORY:
+            return ENOENT;
+        case ERROR_ACCESS_DENIED:
+        case ERROR_SHARING_VIOLATION:
+            return EACCES;
+        case ERROR_NOT_ENOUGH_MEMORY:
+        case ERROR_OUTOFMEMORY:
+            return ENOMEM;
+        default:
+            return EIO;
+        }
+    }
+
     int windows_open_directory(const std::string& path) {
         WindowsDirState state;
         state.path = path;
@@ -174,17 +192,30 @@ namespace {
         WIN32_FIND_DATAA data{};
         HANDLE search = FindFirstFileA(pattern.c_str(), &data);
         if (search != INVALID_HANDLE_VALUE) {
-            do {
+            DWORD enumeration_error = ERROR_SUCCESS;
+            for (;;) {
                 WindowsDirEntry entry;
                 entry.name = data.cFileName;
                 entry.ino = windows_dir_ino(entry.name);
                 entry.type = (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? 4 : 8;
                 state.entries.push_back(std::move(entry));
-            } while (FindNextFileA(search, &data));
+                if (FindNextFileA(search, &data)) continue;
+                enumeration_error = GetLastError();
+                break;
+            }
             FindClose(search);
-        } else if (GetLastError() != ERROR_FILE_NOT_FOUND) {
-            errno = EACCES;
-            return -1;
+            if (enumeration_error != ERROR_NO_MORE_FILES) {
+                errno = windows_directory_errno(enumeration_error);
+                return -1;
+            }
+        } else {
+            const DWORD enumeration_error = GetLastError();
+            // With a directory already established by GetFileAttributesA, no wildcard match is
+            // the normal representation of an empty directory. Every other failure is real.
+            if (enumeration_error != ERROR_FILE_NOT_FOUND) {
+                errno = windows_directory_errno(enumeration_error);
+                return -1;
+            }
         }
 
         std::lock_guard<std::mutex> lk(g_windows_dir_mx);

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <atomic>        // sceKernelAio* submit-id/state table
 #include <map>
+#include <utility>
 #include <vector>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -131,6 +132,127 @@ namespace {
         for (size_t i = 0; i < low_count; ++i) ::_close(low_fds[i]);
         if (fd < 0) errno = duplicate_errno;
         return fd;
+    }
+
+    // The Windows CRT refuses to open directories as file descriptors. PS5 guests nevertheless
+    // use the normal open/getdents/close sequence, so represent directory opens with emulator-owned
+    // descriptors and a per-open cursor. Enumerating eagerly gives each descriptor an immutable
+    // snapshot and keeps getdents deterministic and thread-safe without retaining Win32 search
+    // handles. The descriptor range is far above UCRT's file table and remains positive to guests.
+    struct WindowsDirEntry {
+        std::string name;
+        uint32_t ino = 0;
+        uint8_t type = 0;
+    };
+    struct WindowsDirState {
+        std::string path;
+        std::vector<WindowsDirEntry> entries;
+        size_t cursor = 0;
+    };
+    std::mutex g_windows_dir_mx;
+    std::map<int, WindowsDirState> g_windows_dirs;
+    std::atomic<int> g_windows_next_dir_fd{0x40000000};
+
+    bool windows_host_path_is_directory(const std::string& path) {
+        const DWORD attrs = GetFileAttributesA(path.c_str());
+        return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    }
+
+    uint32_t windows_dir_ino(const std::string& name) {
+        uint32_t hash = 2166136261u;
+        for (unsigned char c : name) hash = (hash ^ c) * 16777619u;
+        return hash ? hash : 1;
+    }
+
+    int windows_open_directory(const std::string& path) {
+        WindowsDirState state;
+        state.path = path;
+        std::string pattern = path;
+        if (!pattern.empty() && pattern.back() != '/' && pattern.back() != '\\') pattern += '\\';
+        pattern += '*';
+
+        WIN32_FIND_DATAA data{};
+        HANDLE search = FindFirstFileA(pattern.c_str(), &data);
+        if (search != INVALID_HANDLE_VALUE) {
+            do {
+                WindowsDirEntry entry;
+                entry.name = data.cFileName;
+                entry.ino = windows_dir_ino(entry.name);
+                entry.type = (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? 4 : 8;
+                state.entries.push_back(std::move(entry));
+            } while (FindNextFileA(search, &data));
+            FindClose(search);
+        } else if (GetLastError() != ERROR_FILE_NOT_FOUND) {
+            errno = EACCES;
+            return -1;
+        }
+
+        std::lock_guard<std::mutex> lk(g_windows_dir_mx);
+        int fd = g_windows_next_dir_fd.fetch_add(1);
+        while (fd < 3 || g_windows_dirs.count(fd)) fd = g_windows_next_dir_fd.fetch_add(1);
+        g_windows_dirs.emplace(fd, std::move(state));
+        return fd;
+    }
+
+    bool windows_close_directory(int fd, int* result) {
+        std::lock_guard<std::mutex> lk(g_windows_dir_mx);
+        auto it = g_windows_dirs.find(fd);
+        if (it == g_windows_dirs.end()) return false;
+        g_windows_dirs.erase(it);
+        if (result) *result = 0;
+        return true;
+    }
+
+    bool windows_directory_path(int fd, std::string* path) {
+        std::lock_guard<std::mutex> lk(g_windows_dir_mx);
+        auto it = g_windows_dirs.find(fd);
+        if (it == g_windows_dirs.end()) return false;
+        if (path) *path = it->second.path;
+        return true;
+    }
+
+    bool windows_seek_directory(int fd, int64_t offset, int whence, int64_t* result) {
+        std::lock_guard<std::mutex> lk(g_windows_dir_mx);
+        auto it = g_windows_dirs.find(fd);
+        if (it == g_windows_dirs.end()) return false;
+        int64_t base = whence == SEEK_SET ? 0
+                     : whence == SEEK_CUR ? (int64_t)it->second.cursor
+                     : whence == SEEK_END ? (int64_t)it->second.entries.size() : -1;
+        if (base < 0 || offset < -base || offset > (int64_t)it->second.entries.size() - base) {
+            errno = EINVAL;
+            if (result) *result = -1;
+            return true;
+        }
+        it->second.cursor = (size_t)(base + offset);
+        if (result) *result = (int64_t)it->second.cursor;
+        return true;
+    }
+
+    uint64_t windows_getdents(int fd, uint64_t guest_buffer, uint64_t capacity) {
+        if (!guest_buffer || capacity < 32) return 0x80020016ull;
+        if (!windows_prepare_guest_write(guest_buffer, capacity)) return 0x8002000eull;
+        std::lock_guard<std::mutex> lk(g_windows_dir_mx);
+        auto it = g_windows_dirs.find(fd);
+        if (it == g_windows_dirs.end()) return 0x80020009ull;
+
+        uint8_t* out = (uint8_t*)(uintptr_t)guest_buffer;
+        size_t written = 0;
+        while (it->second.cursor < it->second.entries.size()) {
+            const WindowsDirEntry& entry = it->second.entries[it->second.cursor];
+            const size_t name_len = entry.name.size();
+            const size_t record_size = (8 + name_len + 1 + 3) & ~(size_t)3;
+            if (written + record_size > capacity) break;
+            uint8_t* record = out + written;
+            memset(record, 0, record_size);
+            *(uint32_t*)(record + 0) = entry.ino;
+            *(uint16_t*)(record + 4) = (uint16_t)record_size;
+            record[6] = entry.type;
+            record[7] = (uint8_t)name_len;
+            memcpy(record + 8, entry.name.c_str(), name_len + 1);
+            written += record_size;
+            it->second.cursor++;
+        }
+        return written;
     }
 #endif
 
@@ -507,7 +629,17 @@ static int host_open_flags(uint64_t f) {
     return h;
 }
 HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_flags(a1);
+#ifdef _WIN32
+               int fd;
+               if (windows_host_path_is_directory(h)) {
+                   if ((a1 & 3) != 0) { errno = EISDIR; fd = -1; }
+                   else fd = windows_open_directory(h);
+               } else {
+                   fd = (int)::open(h.c_str(), host_flags, (mode_t)a2);
+               }
+#else
                int fd = (int)::open(h.c_str(), host_flags, (mode_t)a2);
+#endif
 #ifdef _WIN32
                if (fd >= 0 && fd < 3) {
                    int low_fd = fd;
@@ -533,6 +665,9 @@ HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
                int fd = (int)a0;
 #ifdef __APPLE__
                int r = getdents_close_fd(fd);
+#elif defined(_WIN32)
+               int r = -1;
+               if (!windows_close_directory(fd, &r)) r = ::close(fd);
 #else
                int r = ::close(fd);
 #endif
@@ -648,6 +783,11 @@ HLE(f_write) {
 #endif
              }
 HLE(f_lseek) { if (fdlog_on() && ((int)a2 != SEEK_CUR || a1 != 0)) preadlog("lseek", a0, a1, (uint64_t)a2);
+#ifdef _WIN32
+               int64_t directory_result = -1;
+               if (windows_seek_directory((int)a0, (int64_t)a1, (int)a2, &directory_result))
+                   return (uint64_t)directory_result;
+#endif
                return (uint64_t)(int64_t)::lseek((int)a0, (off_t)a1, (int)a2); }
 #ifndef _WIN32
 HLE(f_pread)  { preadlog("pread", a0, a3, a2); int64_t r = read_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3);
@@ -825,7 +965,11 @@ HLE(f_lstat) { std::string h = translate(CS(a0)); struct stat st; int r = ::lsta
 HLE(f_fsync) { return (uint64_t)(int64_t)::fsync((int)a0); }
 #else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
-HLE(f_fstat) { struct _stat64 st; int r = ::_fstat64((int)a0, &st); int err = r < 0 ? errno : 0;
+HLE(f_fstat) { struct _stat64 st; std::string directory_path;
+               int r = windows_directory_path((int)a0, &directory_path)
+                     ? ::_stat64(directory_path.c_str(), &st)
+                     : ::_fstat64((int)a0, &st);
+               int err = r < 0 ? errno : 0;
                if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1));
                filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1); return (uint64_t)(int64_t)r; }
 HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
@@ -962,6 +1106,12 @@ HLE(k_getdirentries) {
 #else
 HLE(k_getdents) {
     if (!a1 || a2 < 32) return directory_sce_error(EINVAL);
+    if (windows_directory_path((int)a0, nullptr))
+        return windows_getdents((int)a0, a1, a2);
+
+    // Preserve support for directory HANDLEs attached to CRT descriptors by callers outside the
+    // normal guest open path. Guest opens use the emulator-owned descriptor table above because
+    // UCRT itself refuses to create such descriptors.
     ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
     intptr_t handle = ::_get_osfhandle((int)a0);
     if (handle == -1) return directory_sce_error(EBADF);
@@ -973,9 +1123,22 @@ HLE(k_getdents) {
     return 0;
 }
 HLE(k_getdirentries) {
-    uint64_t r = k_getdents(a0, a1, a2, a3, a4, a5);
-    if (!directory_result_is_error(r) && a3) *(int64_t*)P(a3) = 0;
-    return r;
+    int64_t base = -1;
+    if (windows_seek_directory((int)a0, 0, SEEK_CUR, &base)) {
+        if (a3 && !windows_prepare_guest_write(a3, sizeof(int64_t)))
+            return directory_sce_error(EFAULT);
+        uint64_t result = windows_getdents((int)a0, a1, a2);
+        if (!directory_result_is_error(result) && a3)
+            *(int64_t*)(uintptr_t)a3 = base;
+        return result;
+    }
+
+    uint64_t result = k_getdents(a0, a1, a2, a3, a4, a5);
+    if (directory_result_is_error(result)) return result;
+    if (a3 && !windows_prepare_guest_write(a3, sizeof(int64_t)))
+        return directory_sce_error(EFAULT);
+    if (a3) *(int64_t*)(uintptr_t)a3 = 0;
+    return result;
 }
 #endif
 HLE(f_getdents) {

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -182,17 +182,36 @@ int main() {
               ((*(const uint16_t*)(dir_stat.data() + 8)) & 0xf000u) == 0x4000u,
           "sceKernelFstat identifies an open directory descriptor");
 
+#ifdef _WIN32
     int64_t rewind_dir = dir_fd >= 0 && lseek_fn
         ? (int64_t)lseek_fn((uint64_t)dir_fd, 0, SEEK_SET, 0, 0, 0)
         : -1;
+    int64_t rewound_bytes = dir_fd >= 0 && kernel_getdents_fn
+        ? (int64_t)kernel_getdents_fn((uint64_t)dir_fd,
+                                      (uint64_t)(uintptr_t)dents.data(), dents.size(), 0, 0, 0)
+        : -1;
+    CHECK(rewind_dir == 0 && rewound_bytes > 0,
+          "Windows directory descriptors can be rewound and enumerated again");
+#endif
+
+    // Darwin's getdents compatibility path owns a duplicated descriptor behind DIR*. A raw
+    // lseek on the original descriptor cannot portably rewind that cached stream, so exercise
+    // getdirentries from a fresh open while retaining the Windows synthetic-cursor rewind check.
+    int64_t direntries_fd = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)dents_string.c_str(),
+                           kGuestDirectory, 0, 0, 0, 0)
+        : -1;
+    CHECK(direntries_fd >= 3, "open a fresh directory cursor for getdirentries");
     int64_t directory_cursor_base = -1;
-    int64_t entry_bytes = dir_fd >= 0 && kernel_getdirentries_fn
+    int64_t entry_bytes = direntries_fd >= 0 && kernel_getdirentries_fn
         ? (int64_t)kernel_getdirentries_fn(
-              (uint64_t)dir_fd, (uint64_t)(uintptr_t)dents.data(), dents.size(),
+              (uint64_t)direntries_fd, (uint64_t)(uintptr_t)dents.data(), dents.size(),
               (uint64_t)(uintptr_t)&directory_cursor_base, 0, 0)
         : -1;
-    CHECK(rewind_dir == 0 && entry_bytes > 0 && directory_cursor_base == 0,
-          "getdirentries reports and advances the rewound directory cursor");
+    CHECK(entry_bytes > 0 && directory_cursor_base == 0,
+          "getdirentries reports and advances a fresh directory cursor");
+    if (direntries_fd >= 0 && close_fn)
+        close_fn((uint64_t)direntries_fd, 0, 0, 0, 0, 0);
     if (dir_fd >= 0 && close_fn) close_fn((uint64_t)dir_fd, 0, 0, 0, 0, 0);
     uint64_t closed_dents = kernel_getdents_fn
         ? kernel_getdents_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dents.data(),

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -8,6 +8,9 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <map>
+#include <set>
+#include <string>
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
@@ -55,9 +58,10 @@ int main() {
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
     HleFn kernel_getdirentries_fn = Hle::lookup(nid_hash("sceKernelGetdirentries"));
+    HleFn fstat_fn = Hle::lookup(nid_hash("sceKernelFstat"));
     CHECK(open_fn && read_fn && lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
-              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn,
+              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn,
           "file HLE functions registered");
     std::array<uint8_t, 64> dir_buffer{};
 
@@ -115,6 +119,88 @@ int main() {
     if (pipe_fds[1] >= 0) ::_close(pipe_fds[1]);
 #endif
     std::filesystem::remove_all(dir_path, remove_error);
+
+    // PS5 directory enumeration uses the ordinary open/getdents/close descriptor flow. The
+    // Windows CRT refuses to open a directory at all, so the HLE must retain an emulator-owned
+    // directory cursor instead of reporting a successful empty enumeration. Astro Bot discovers
+    // each intro cinematic sublevel through this exact contract.
+    const std::filesystem::path dents_path = "prosper-test-getdents.tmp";
+    std::filesystem::remove_all(dents_path, remove_error);
+    std::filesystem::create_directories(dents_path / "c01");
+    std::filesystem::create_directories(dents_path / "c02b");
+    FILE* dents_file = std::fopen((dents_path / "cinematics.cx").string().c_str(), "wb");
+    CHECK(dents_file != nullptr, "create getdents file fixture");
+    if (dents_file) { std::fputc(0x5a, dents_file); std::fclose(dents_file); }
+
+    const std::string dents_string = dents_path.string();
+    constexpr uint64_t kGuestDirectory = 0x00020000ull;
+    int64_t dir_fd = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)dents_string.c_str(),
+                           kGuestDirectory, 0, 0, 0, 0)
+        : -1;
+    CHECK(dir_fd >= 3, "sceKernelOpen returns a guest directory descriptor");
+    std::array<uint8_t, 4096> dents{};
+    int64_t dent_bytes = dir_fd >= 0 && kernel_getdents_fn
+        ? (int64_t)kernel_getdents_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dents.data(),
+                                      dents.size(), 0, 0, 0)
+        : -1;
+    CHECK(dent_bytes > 0, "sceKernelGetdents returns directory records");
+    std::set<std::string> dent_names;
+    std::map<std::string, uint8_t> dent_types;
+    bool valid_records = dent_bytes > 0 && dent_bytes <= (int64_t)dents.size();
+    for (size_t offset = 0; valid_records && offset < (size_t)dent_bytes;) {
+        const uint16_t record_size = *(const uint16_t*)(dents.data() + offset + 4);
+        const uint8_t name_size = dents[offset + 7];
+        if (record_size < 8 || offset + record_size > (size_t)dent_bytes ||
+            name_size + 9 > record_size) {
+            valid_records = false;
+            break;
+        }
+        std::string name((const char*)dents.data() + offset + 8, name_size);
+        dent_names.insert(name);
+        dent_types[name] = dents[offset + 6];
+        offset += record_size;
+    }
+    CHECK(valid_records, "getdents records use bounded FreeBSD layout");
+    CHECK(dent_names.count("c01") && dent_names.count("c02b") &&
+              dent_names.count("cinematics.cx"),
+          "getdents exposes cinematic directories and files");
+    CHECK(dent_types["c01"] == 4 && dent_types["c02b"] == 4 &&
+              dent_types["cinematics.cx"] == 8,
+          "getdents reports directory/file d_type values");
+    int64_t dents_eof = dir_fd >= 0 && kernel_getdents_fn
+        ? (int64_t)kernel_getdents_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dents.data(),
+                                      dents.size(), 0, 0, 0)
+        : -1;
+    CHECK(dents_eof == 0, "getdents preserves its per-open end cursor");
+
+    std::array<uint8_t, 0x78> dir_stat{};
+    int64_t dir_stat_result = dir_fd >= 0 && fstat_fn
+        ? (int64_t)fstat_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dir_stat.data(), 0, 0, 0, 0)
+        : -1;
+    CHECK(dir_stat_result == 0 &&
+              ((*(const uint16_t*)(dir_stat.data() + 8)) & 0xf000u) == 0x4000u,
+          "sceKernelFstat identifies an open directory descriptor");
+
+    int64_t rewind_dir = dir_fd >= 0 && lseek_fn
+        ? (int64_t)lseek_fn((uint64_t)dir_fd, 0, SEEK_SET, 0, 0, 0)
+        : -1;
+    int64_t directory_cursor_base = -1;
+    int64_t entry_bytes = dir_fd >= 0 && kernel_getdirentries_fn
+        ? (int64_t)kernel_getdirentries_fn(
+              (uint64_t)dir_fd, (uint64_t)(uintptr_t)dents.data(), dents.size(),
+              (uint64_t)(uintptr_t)&directory_cursor_base, 0, 0)
+        : -1;
+    CHECK(rewind_dir == 0 && entry_bytes > 0 && directory_cursor_base == 0,
+          "getdirentries reports and advances the rewound directory cursor");
+    if (dir_fd >= 0 && close_fn) close_fn((uint64_t)dir_fd, 0, 0, 0, 0, 0);
+    uint64_t closed_dents = kernel_getdents_fn
+        ? kernel_getdents_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dents.data(),
+                             dents.size(), 0, 0, 0)
+        : 0;
+    CHECK((uint32_t)closed_dents == 0x80020009u,
+          "closed directory descriptor returns EBADF instead of silent EOF");
+    std::filesystem::remove_all(dents_path, remove_error);
 
     std::array<uint8_t, 512> actual{};
     int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;


### PR DESCRIPTION
## What changed

- Add emulator-owned Windows directory descriptors because UCRT cannot open directories as CRT file descriptors.
- Implement Windows `sceKernelGetdents` / `sceKernelGetdirentries` records, per-open cursors, seek, close, and directory `fstat`.
- Preserve the existing libc-vs-`sceKernel` error conventions and native Windows handle behavior merged from #877.
- Distinguish normal Win32 enumeration exhaustion (`ERROR_NO_MORE_FILES`) from real `FindFirstFileA` / `FindNextFileA` failures and map those failures to host `errno` instead of returning false EOF.
- Add cross-platform regression coverage for FreeBSD-compatible records, names, `d_type`, cursor/EOF behavior, `fstat`, error outputs, and close-to-EBADF. Windows additionally verifies synthetic-directory rewind.

## Root cause and game impact

The Windows implementation returned silent EOF from both directory-enumeration APIs. Astro Bot enumerates the opening cinematic sublevels through `open(..., O_DIRECTORY)` plus `getdents`; Windows therefore skipped `c01` and the rest of the intro dependency chain. It entered `ui_pause_cinematics` with an empty resource vector and eventually hit the invalid-handle assertion tracked in #875.

A runtime run at `aad0d693` with real Media Foundation hardware decode (`decoder=hardware DXVA MFT`) first proved the fixed path. The final exact head `9e7f488e` independently repeated the game-control-flow acceptance and recorded:

```text
GAME: LoadLevelResources: c01 : 2.219 sec.
GAME: LoadLevelResources: intro_next : 81.624 sec.
GAME: Level has started: intro_next
PLAY: SubLevelLocator sublevel_locator_hub [hub_crashsite_tutorial], state changed 1->4
GAME: LoadLevelResources: ui_hub : 1.489 sec.
GAME: LoadLevelResources: hub_crashsite_tutorial : 57.330 sec.
PLAY: SubLevelLocator sublevel_locator3 [...] restore to 6 (current: 1)
```

The exact-head logs contain no `ASSERT`, `Invalid Handle`, or missing-cinematic marker (`bad_markers=0`). Its faster input timing skipped opening the movie, so the DXVA claim is deliberately tied to the earlier runtime run rather than inferred from the exact-head log.

## Scope and invariants

- Affected: Windows guest directory opens and `getdents` / `getdirentries` / `lseek` / `fstat` / `close` on those emulator-owned descriptors.
- Unaffected: Unix directory runtime paths, regular-file descriptors, and the Windows native-handle fallback.
- Each Windows directory open gets an independent immutable snapshot and cursor. Record packing remains the guest FreeBSD ABI (8-byte header, NUL-terminated name, 4-byte alignment).
- Failed calls retain the caller's `basep`; libc APIs return `-1` plus `errno`, while `sceKernel` APIs return SCE errors directly.
- `ERROR_FILE_NOT_FOUND` after wildcard enumeration of a verified directory represents an empty snapshot; only `ERROR_NO_MORE_FILES` normally terminates an active enumeration. Other Win32 failures are surfaced.
- Risk is intentionally bounded to the synthetic Windows descriptor map. Live host-directory mutation after open is not reflected until a new open.

## Visual evidence

Representative Windows app baseline from the documented Astro Bot route:

![Astro Bot title screen on the Windows app](https://raw.githubusercontent.com/mattias800/ps5ys/9e7f488ee5e5580364ed31bd141d08280e21f8b0/prosper/docs/screenshots/issue-825-astrobot-windows-title.png)

The new first-level frontend samples are currently black, so they are not presented as rendering-progress evidence. The control-flow claim above comes from guest state markers.

## Reproduction and validation

Windows fresh-save exact-head route:

```powershell
$env:PROSPER_GUEST_FS = '1'
$env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
$env:PROSPER_NO_COMPUTE = '1'
$env:PROSPER_PAD_SCRIPT = '@C:/Users/matti/repos/ps5ys-astro875/prosper/scripts/astrobot/reach-first-level-windows.pad'
$env:PROSPER_PAD_SCRIPT_LOG = '1'
$env:PROSPER_SAVEDATA_DIR = 'C:/Users/matti/Downloads/AstroBot-875-analysis/win-headless-save-20260718-pr884-head-9e7f488'
prosper/build-mingw-app/boot_trace.exe C:/Users/matti/repos/ps5ys/PPSA21564-app0
```

No `PROSPER_AVP_SYNTH_FRAMES` or software fallback was enabled. Exact-head logs are retained locally as `AstroBot-875-analysis/win-headless-pr884-head-9e7f488.{stdout,stderr}.log`; prior real-DXVA evidence is `win-headless-pr884-final.{stdout,stderr}.log`.

Exact final head `9e7f488ee5e5580364ed31bd141d08280e21f8b0`:

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File prosper/tools/verify-pr.ps1 core -WindowsBuild prosper/build-mingw-app
```

Result: **AUTHOR VERIFICATION — PASS**
- whitespace: PASS against `origin/master@50ad951d`
- Linux build: PASS
- Linux CTest: 113/113
- Windows app build: PASS
- Windows CTest: 87/87
- total: 200/200

Focused `file_binary_roundtrip`: PASS on Windows. GitHub Actions run `29640337482`: **PASS** on Linux, Linux app, Windows MinGW, Windows app, macOS app, and macOS x86_64/Rosetta.

Primary host-contract references:
- Microsoft `_open`: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen
- Microsoft `FindFirstFileA`: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea
- Microsoft `FindNextFileA`: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilea

Fixes #875