### PR TITLE
fix(memory): reject missing allocation outputs

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -537,6 +537,7 @@ HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0
 
 // sceKernelAllocateDirectMemory(off_t start, off_t end, size_t len, size_t align, int memType, off_t* physOut)
 HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, physAddrOut)
+    if (!a5) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
     uint64_t align = a3 ? a3 : 0x4000;
     uint64_t sz = align_up(a2, align);
     uint64_t off;
@@ -560,6 +561,7 @@ HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, ph
 // DIFFERENT signature (4 args) from AllocateDirectMemory: physOut is arg3, not arg5. Aliasing them
 // to one handler wrote the result through arg5 (uninitialized garbage, e.g. 0xa) -> crash.
 HLE(k_alloc_main_dmem) {
+    if (!a3) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
     uint64_t align = a1 ? a1 : 0x4000;
     uint64_t sz = align_up(a0, align);
     uint64_t off;
@@ -2050,6 +2052,7 @@ HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0
 
 // sceKernelAllocateDirectMemory(start, end, len, align, memType, off_t* physOut)
 HLE(k_alloc_dmem) {
+    if (!a5) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
     uint64_t align = a3 ? a3 : 0x4000;
     uint64_t sz = align_up(a2, align);
     uint64_t off;
@@ -2065,6 +2068,7 @@ HLE(k_alloc_dmem) {
 }
 // sceKernelAllocateMainDirectMemory(len, align, memType, off_t* physOut) — physOut at arg3.
 HLE(k_alloc_main_dmem) {
+    if (!a3) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
     uint64_t align = a1 ? a1 : 0x4000;
     uint64_t sz = align_up(a0, align);
     uint64_t off;

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -43,11 +43,12 @@ int main() {
     auto reserve = Hle::lookup(nid_hash("sceKernelReserveVirtualRange"));
     auto unmap   = Hle::lookup(nid_hash("sceKernelMunmap"));
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
+    auto alloc_main = Hle::lookup(nid_hash("sceKernelAllocateMainDirectMemory"));
     auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
     auto protect = Hle::lookup(nid_hash("sceKernelMprotect"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
     auto query   = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
-    CHECK(reserve && unmap && alloc && map && protect && release && query,
+    CHECK(reserve && unmap && alloc && alloc_main && map && protect && release && query,
           "memory HLE functions registered");
     if (fails) return 1;
 
@@ -67,6 +68,10 @@ int main() {
     // releases and reuses small physical ranges aggressively; independent Windows allocations
     // let its allocator observe different metadata through two aliases and corrupt adjacent VA.
     constexpr uint64_t dlen = 0x10000;
+    CHECK((uint32_t)alloc(0, kEnd, dlen, dlen, 0, 0) == 0x80020016u,
+          "AllocateDirectMemory(null physAddrOut) -> EINVAL");
+    CHECK((uint32_t)alloc_main(dlen, dlen, 0, 0, 0, 0) == 0x80020016u,
+          "AllocateMainDirectMemory(null physAddrOut) -> EINVAL");
     uint64_t phys = 0, va1 = 0, va2 = 0;
     CHECK(alloc(0, kEnd, dlen, dlen, 0, (uint64_t)(uintptr_t)&phys) == 0 && phys == kBase,
           "allocate one 64 KiB direct-memory page");
@@ -210,10 +215,18 @@ int main() {
 
     auto avail   = Hle::lookup(nid_hash("sceKernelAvailableDirectMemorySize"));
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
+    auto alloc_main = Hle::lookup(nid_hash("sceKernelAllocateMainDirectMemory"));
     auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
-    CHECK(avail && alloc && map && release, "dmem fns registered");
-    if (!(avail && alloc && map && release)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(avail && alloc && alloc_main && map && release, "dmem fns registered");
+    if (!(avail && alloc && alloc_main && map && release)) { printf("== FAIL ==\n"); return 1; }
+
+    // Both allocation APIs require their physical-address output. Reject before taking from
+    // the pool so an unobservable allocation cannot leak capacity.
+    CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0x4000, 0, 0) == 0x80020016u,
+          "AllocateDirectMemory(null physAddrOut) -> EINVAL");
+    CHECK((uint32_t)alloc_main(0x4000, 0x4000, 0, 0, 0, 0) == 0x80020016u,
+          "AllocateMainDirectMemory(null physAddrOut) -> EINVAL");
 
     // Fresh pool: the largest free block is the whole pool, and BOTH out-params are written.
     uint64_t phys = 0xdead, size = 0xdead;


### PR DESCRIPTION
Refs #387

## Failure scenario and contract

`sceKernelAllocateDirectMemory` and `sceKernelAllocateMainDirectMemory` require a physical-address output pointer. Current master accepts a null output, consumes a direct-memory range, then reports success without returning the allocation to the guest. That silently leaks pool capacity and leaves the caller unable to map or release the range.

Both APIs must reject a missing output with `SCE_KERNEL_ERROR_EINVAL` before changing allocator state.

## Implementation

- Validate the correct ABI output argument at entry (`arg5` for AllocateDirectMemory, `arg3` for AllocateMainDirectMemory).
- Apply the same behavior to the Linux and Windows direct-memory backends.
- Extend `test_dmem` to exercise both registered guest entry points and preserve the existing fresh-pool invariant after the rejected calls.

## Deliberately unaffected

- Successful allocation placement, alignment, zeroing, reuse, and mapping behavior.
- Non-null but otherwise inaccessible guest pointers; this focused change covers the tracker’s null-output remainder.
- Renderer behavior; no snapshots are applicable.

## Risk and review

Low implementation complexity, but allocator-state mutation is correctness-sensitive. Independent inspection approved exact head `9da7f4d41c0290d29467d592c919d58aa5a1f184`: https://github.com/mattias800/ps5ys/pull/885#issuecomment-5010758898

## Author verification

Exact head `9da7f4d41c0290d29467d592c919d58aa5a1f184` passed `powershell -NoProfile -File prosper/tools/verify-pr.ps1 core -Pr 885`:

- `git diff --check`: PASS
- Linux build: PASS
- Linux ctest: 89/89 PASS
- Windows build: PASS
- Windows ctest: 82/82 PASS
- Snapshots: not applicable (no rendered-output path changed)

Full exact commands and timings: https://github.com/mattias800/ps5ys/pull/885#issuecomment-5010766875