### PR TITLE
fix(audio): sign-extend AJM errors

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -500,9 +500,11 @@ A2_PROBE(audio2_mastering_get_state, "sceAudioOut2MasteringGetState")
 // the no-decode behavior is intentional, not a guess.
 namespace {
     std::atomic<uint32_t> g_ajm_next{1};   // one non-zero counter for context/instance/batch handles
-    constexpr uint64_t AJM_ERR_INVALID_CONTEXT   = 0x80930002ull;
-    constexpr uint64_t AJM_ERR_INVALID_INSTANCE  = 0x80930003ull;
-    constexpr uint64_t AJM_ERR_INVALID_PARAMETER = 0x80930005ull;
+    // AJM returns signed 32-bit SCE errors. Preserve that ABI in the full HLE return register,
+    // matching the AudioOut error constants above rather than leaving the upper half zeroed.
+    constexpr uint64_t AJM_ERR_INVALID_CONTEXT   = (uint64_t)(int64_t)(int32_t)0x80930002u;
+    constexpr uint64_t AJM_ERR_INVALID_INSTANCE  = (uint64_t)(int64_t)(int32_t)0x80930003u;
+    constexpr uint64_t AJM_ERR_INVALID_PARAMETER = (uint64_t)(int64_t)(int32_t)0x80930005u;
 }
 // sceAjmInitialize(s64 reserved, u32* out_context): create a context. Filling out_context is the point.
 HLE(ajm_initialize) {

--- a/prosper/tests/test_ajm.cpp
+++ b/prosper/tests/test_ajm.cpp
@@ -14,6 +14,10 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+static constexpr uint64_t kInvalidContext   = 0xffffffff80930002ull;
+static constexpr uint64_t kInvalidInstance  = 0xffffffff80930003ull;
+static constexpr uint64_t kInvalidParameter = 0xffffffff80930005ull;
+
 int main() {
     printf("== test_ajm ==\n");
     register_builtin_hle();
@@ -36,24 +40,24 @@ int main() {
     uint32_t ctx = 0xDEAD;
     CHECK(init(0, (uint64_t)(uintptr_t)&ctx, 0, 0, 0, 0) == 0, "sceAjmInitialize -> OK");
     CHECK(ctx != 0 && ctx != 0xDEAD, "Initialize WROTE a valid non-zero context (not left garbage)");
-    CHECK(init(0, 0, 0, 0, 0, 0) == 0x80930005ull, "Initialize(NULL out) -> INVALID_PARAMETER");
-    CHECK(init(0, 1, 0, 0, 0, 0) == 0x80930005ull,
+    CHECK(init(0, 0, 0, 0, 0, 0) == kInvalidParameter, "Initialize(NULL out) -> INVALID_PARAMETER");
+    CHECK(init(0, 1, 0, 0, 0, 0) == kInvalidParameter,
           "Initialize(inaccessible out) -> INVALID_PARAMETER without host fault");
     uint32_t rejected_ctx = 0xCAFE;
-    CHECK(init(1, (uint64_t)(uintptr_t)&rejected_ctx, 0, 0, 0, 0) == 0x80930005ull,
+    CHECK(init(1, (uint64_t)(uintptr_t)&rejected_ctx, 0, 0, 0, 0) == kInvalidParameter,
           "Initialize(nonzero reserved) -> INVALID_PARAMETER");
     CHECK(rejected_ctx == 0xCAFE, "invalid Initialize leaves the context output untouched");
 
     // ModuleRegister needs a context.
     CHECK(modreg(ctx, 1 /*At9Dec*/, 0, 0, 0, 0) == 0, "sceAjmModuleRegister(ctx) -> OK");
-    CHECK(modreg(0, 1, 0, 0, 0, 0) == 0x80930002ull, "ModuleRegister(context 0) -> INVALID_CONTEXT");
+    CHECK(modreg(0, 1, 0, 0, 0, 0) == kInvalidContext, "ModuleRegister(context 0) -> INVALID_CONTEXT");
 
     // InstanceCreate fills a valid instance handle, distinct from the context.
     uint32_t inst = 0xBEEF;
     CHECK(icreate(ctx, 1 /*At9Dec*/, 0 /*flags*/, (uint64_t)(uintptr_t)&inst, 0, 0) == 0, "sceAjmInstanceCreate -> OK");
     CHECK(inst != 0 && inst != 0xBEEF && inst != ctx, "InstanceCreate WROTE a distinct non-zero instance");
-    CHECK(icreate(0, 1, 0, (uint64_t)(uintptr_t)&inst, 0, 0) == 0x80930002ull, "InstanceCreate(ctx 0) -> INVALID_CONTEXT");
-    CHECK(icreate(ctx, 1, 0, 1, 0, 0) == 0x80930005ull,
+    CHECK(icreate(0, 1, 0, (uint64_t)(uintptr_t)&inst, 0, 0) == kInvalidContext, "InstanceCreate(ctx 0) -> INVALID_CONTEXT");
+    CHECK(icreate(ctx, 1, 0, 1, 0, 0) == kInvalidParameter,
           "InstanceCreate(inaccessible out) -> INVALID_PARAMETER without host fault");
 
     // Batch: StartBuffer fills a batch id; Wait completes it.
@@ -61,13 +65,14 @@ int main() {
     CHECK(bstart(ctx, 0 /*batch buf*/, 0 /*size*/, 0 /*prio*/, 0 /*err*/, (uint64_t)(uintptr_t)&batch) == 0,
           "sceAjmBatchStartBuffer -> OK");
     CHECK(batch != 0 && batch != 0xF00D, "BatchStartBuffer WROTE a valid non-zero batch id");
-    CHECK(bstart(ctx, 0, 0, 0, 0, 1) == 0x80930005ull,
+    CHECK(bstart(ctx, 0, 0, 0, 0, 1) == kInvalidParameter,
           "BatchStartBuffer(inaccessible out) -> INVALID_PARAMETER without host fault");
     CHECK(bwait(ctx, batch, 0, 0, 0, 0) == 0, "sceAjmBatchWait -> OK (batch completed)");
 
     // Teardown.
     CHECK(idestroy(ctx, inst, 0, 0, 0, 0) == 0, "sceAjmInstanceDestroy -> OK");
-    CHECK(idestroy(0, inst, 0, 0, 0, 0) == 0x80930002ull, "InstanceDestroy(ctx 0) -> INVALID_CONTEXT");
+    CHECK(idestroy(0, inst, 0, 0, 0, 0) == kInvalidContext, "InstanceDestroy(ctx 0) -> INVALID_CONTEXT");
+    CHECK(idestroy(ctx, 0, 0, 0, 0, 0) == kInvalidInstance, "InstanceDestroy(instance 0) -> INVALID_INSTANCE");
     CHECK(fin(0, 0, 0, 0, 0, 0) == 0, "sceAjmFinalize -> OK");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
Refs #396

## Failure scenario and contract

AJM APIs return signed 32-bit SCE error values. The current constants contain the correct low 32 bits but leave the upper half of the HLE return register zeroed (for example `0x0000000080930005` instead of `0xffffffff80930005`). That differs from the signed-error convention already used by AudioOut and the rest of this ABI surface.

## Implementation

- Define all three exercised AJM errors through signed 32-bit conversion before widening to the HLE return type.
- Update dispatch tests to assert the exact full-register values for INVALID_CONTEXT, INVALID_INSTANCE, and INVALID_PARAMETER.
- Add the previously missing invalid-instance assertion.

## Deliberately unaffected

- AJM handle allocation, output stores, batch lifecycle, and headless decode behavior.
- AudioOut, AudioOut2, NGS2, and renderer behavior.
- No snapshots are applicable.

## Risk and review

This is a mechanical constant-representation correction with direct exact-value coverage. It changes no control flow, memory access, state, or platform-specific behavior, so no independent reviewer is required under the project’s risk-based review policy.

## Author verification

Exact head `10073f57d076928326106252a61ea2114ffb1db0` passed `powershell -NoProfile -File prosper/tools/verify-pr.ps1 core -Pr 886`:

- `git diff --check`: PASS
- Linux build: PASS
- Linux ctest: 89/89 PASS
- Windows build: PASS
- Windows ctest: 82/82 PASS
- Snapshots: not applicable

Full exact commands and timings: https://github.com/mattias800/ps5ys/pull/886#issuecomment-5010793050