### PR TITLE
fix(libc): separate throwing new failures

### DIFF
--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -265,10 +265,36 @@ HLE(h_posix_memalign) {
     return 0;
 }
 HLE(h_aligned_alloc)  { return (uint64_t)(uintptr_t)aligned_alloc_portable(a0, a1); }
-// C++ operators new/delete (the whole IL2CPP game is C++). new -> malloc; the aligned
-// forms take (size, align); nothrow forms take an extra tag arg we ignore.
-HLE(h_new)         { return (uint64_t)(uintptr_t)guest_malloc_portable(a0 ? a0 : 1); }
-HLE(h_new_align)   { return (uint64_t)(uintptr_t)aligned_alloc_portable(a1 ? a1 : 16, a0 ? a0 : 1); }
+// C++ operators new/delete (the whole IL2CPP game is C++). Throwing operator new must never
+// return null: the caller would treat an illegal null as constructed storage instead of taking
+// its exception/termination path.
+// prosper cannot yet propagate a guest std::bad_alloc across the HLE boundary, so allocation
+// failure is fail-stop. The explicit nothrow overloads retain their required null return.
+[[noreturn]] static void guest_new_oom(uint64_t size, uint64_t alignment) {
+    if (alignment) {
+        fprintf(stderr, "[libc] throwing aligned operator new failed: size=%llu alignment=%llu\n",
+                (unsigned long long)size, (unsigned long long)alignment);
+    } else {
+        fprintf(stderr, "[libc] throwing operator new failed: size=%llu\n",
+                (unsigned long long)size);
+    }
+    abort();
+}
+HLE(h_new) {
+    void* p = guest_malloc_portable(a0 ? a0 : 1);
+    if (!p) guest_new_oom(a0, 0);
+    return (uint64_t)(uintptr_t)p;
+}
+HLE(h_new_nothrow) { return (uint64_t)(uintptr_t)guest_malloc_portable(a0 ? a0 : 1); }
+HLE(h_new_align) {
+    uint64_t alignment = a1 ? a1 : 16;
+    void* p = aligned_alloc_portable(alignment, a0 ? a0 : 1);
+    if (!p) guest_new_oom(a0, alignment);
+    return (uint64_t)(uintptr_t)p;
+}
+HLE(h_new_align_nothrow) {
+    return (uint64_t)(uintptr_t)aligned_alloc_portable(a1 ? a1 : 16, a0 ? a0 : 1);
+}
 HLE(h_delete)      { guest_free_portable(P(a0)); return 0; }
 
 // --- stdio ---
@@ -551,9 +577,10 @@ void register_builtin_hle() {
     R("memalign", h_memalign); R("posix_memalign", h_posix_memalign); R("aligned_alloc", h_aligned_alloc);
     // operator new / new[] (+ nothrow), and aligned variants
     R("_Znwm", h_new); R("_Znam", h_new);
-    R("_ZnwmRKSt9nothrow_t", h_new); R("_ZnamRKSt9nothrow_t", h_new);
+    R("_ZnwmRKSt9nothrow_t", h_new_nothrow); R("_ZnamRKSt9nothrow_t", h_new_nothrow);
     R("_ZnwmSt11align_val_t", h_new_align); R("_ZnamSt11align_val_t", h_new_align);
-    R("_ZnwmSt11align_val_tRKSt9nothrow_t", h_new_align); R("_ZnamSt11align_val_tRKSt9nothrow_t", h_new_align);
+    R("_ZnwmSt11align_val_tRKSt9nothrow_t", h_new_align_nothrow);
+    R("_ZnamSt11align_val_tRKSt9nothrow_t", h_new_align_nothrow);
     // operator delete / delete[] (+ sized, aligned, nothrow) -> free
     R("_ZdlPv", h_delete); R("_ZdaPv", h_delete);
     R("_ZdlPvm", h_delete); R("_ZdaPvm", h_delete);

--- a/prosper/tests/test_libc_alloc.cpp
+++ b/prosper/tests/test_libc_alloc.cpp
@@ -6,8 +6,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <string>
 
 using namespace prosper;
 
@@ -17,9 +19,34 @@ static int fails = 0;
 
 static uint64_t U(const void* p) { return (uint64_t)(uintptr_t)p; }
 
-int main() {
+static int run_self(const char* executable, const char* mode) {
+    std::string command = "\"";
+    command += executable;
+    command += "\" ";
+    command += mode;
+    return std::system(command.c_str());
+}
+
+int main(int argc, char** argv) {
     printf("== test_libc_alloc ==\n");
     register_builtin_hle();
+
+    // Child modes return normally only if a throwing allocation handler violates its contract.
+    // The parent first proves that the quoted self-launch works, then requires these modes to
+    // terminate before returning from the HLE call.
+    if (argc == 2) {
+        if (!strcmp(argv[1], "probe")) return 0;
+        if (!strcmp(argv[1], "throwing-new")) {
+            Hle::lookup(nid_hash("_Znwm"))(std::numeric_limits<uint64_t>::max(), 0, 0, 0, 0, 0);
+            return 0;
+        }
+        if (!strcmp(argv[1], "throwing-aligned-new")) {
+            Hle::lookup(nid_hash("_ZnwmSt11align_val_t"))(
+                std::numeric_limits<uint64_t>::max(), 64, 0, 0, 0, 0);
+            return 0;
+        }
+        return 2;
+    }
 
     auto malloc_fn = Hle::lookup(nid_hash("malloc"));
     auto calloc_fn = Hle::lookup(nid_hash("calloc"));
@@ -27,10 +54,14 @@ int main() {
     auto free_fn = Hle::lookup(nid_hash("free"));
     auto memalign_fn = Hle::lookup(nid_hash("memalign"));
     auto posix_memalign_fn = Hle::lookup(nid_hash("posix_memalign"));
+    auto new_fn = Hle::lookup(nid_hash("_Znwm"));
+    auto new_nothrow_fn = Hle::lookup(nid_hash("_ZnwmRKSt9nothrow_t"));
     auto aligned_new_fn = Hle::lookup(nid_hash("_ZnwmSt11align_val_t"));
+    auto aligned_new_nothrow_fn = Hle::lookup(nid_hash("_ZnwmSt11align_val_tRKSt9nothrow_t"));
     auto aligned_delete_fn = Hle::lookup(nid_hash("_ZdlPvSt11align_val_t"));
     CHECK(malloc_fn && calloc_fn && realloc_fn && free_fn && memalign_fn &&
-              posix_memalign_fn && aligned_new_fn && aligned_delete_fn,
+              posix_memalign_fn && new_fn && new_nothrow_fn && aligned_new_fn &&
+              aligned_new_nothrow_fn && aligned_delete_fn,
           "allocation HLE functions registered");
     if (fails) return 1;
 
@@ -54,6 +85,20 @@ int main() {
           "calloc rejects multiplication overflow");
     CHECK(memalign_fn(std::numeric_limits<uint64_t>::max(), 1, 0, 0, 0, 0) == 0,
           "memalign rejects an alignment that cannot be rounded to a power of two");
+
+    CHECK(new_nothrow_fn(std::numeric_limits<uint64_t>::max(), 0, 0, 0, 0, 0) == 0,
+          "nothrow operator new returns null on allocation failure");
+    CHECK(aligned_new_nothrow_fn(std::numeric_limits<uint64_t>::max(), 64, 0, 0, 0, 0) == 0,
+          "aligned nothrow operator new returns null on allocation failure");
+    CHECK(run_self(argv[0], "probe") == 0, "allocation death-test child launches successfully");
+    CHECK(run_self(argv[0], "throwing-new") != 0,
+          "throwing operator new never returns null on allocation failure");
+    CHECK(run_self(argv[0], "throwing-aligned-new") != 0,
+          "throwing aligned operator new never returns null on allocation failure");
+
+    void* cpp_plain = (void*)(uintptr_t)new_fn(333, 0, 0, 0, 0, 0);
+    CHECK(cpp_plain != nullptr, "throwing operator new still returns storage on success");
+    free_fn(U(cpp_plain), 0, 0, 0, 0, 0);
 
     auto* aligned = (uint8_t*)(uintptr_t)memalign_fn(256, 513, 0, 0, 0, 0);
     CHECK(aligned != nullptr && ((uintptr_t)aligned & 255) == 0,

--- a/prosper/tests/test_libc_alloc.cpp
+++ b/prosper/tests/test_libc_alloc.cpp
@@ -40,8 +40,17 @@ int main(int argc, char** argv) {
             Hle::lookup(nid_hash("_Znwm"))(std::numeric_limits<uint64_t>::max(), 0, 0, 0, 0, 0);
             return 0;
         }
+        if (!strcmp(argv[1], "throwing-new-array")) {
+            Hle::lookup(nid_hash("_Znam"))(std::numeric_limits<uint64_t>::max(), 0, 0, 0, 0, 0);
+            return 0;
+        }
         if (!strcmp(argv[1], "throwing-aligned-new")) {
             Hle::lookup(nid_hash("_ZnwmSt11align_val_t"))(
+                std::numeric_limits<uint64_t>::max(), 64, 0, 0, 0, 0);
+            return 0;
+        }
+        if (!strcmp(argv[1], "throwing-aligned-new-array")) {
+            Hle::lookup(nid_hash("_ZnamSt11align_val_t"))(
                 std::numeric_limits<uint64_t>::max(), 64, 0, 0, 0, 0);
             return 0;
         }
@@ -56,12 +65,17 @@ int main(int argc, char** argv) {
     auto posix_memalign_fn = Hle::lookup(nid_hash("posix_memalign"));
     auto new_fn = Hle::lookup(nid_hash("_Znwm"));
     auto new_nothrow_fn = Hle::lookup(nid_hash("_ZnwmRKSt9nothrow_t"));
+    auto new_array_fn = Hle::lookup(nid_hash("_Znam"));
+    auto new_array_nothrow_fn = Hle::lookup(nid_hash("_ZnamRKSt9nothrow_t"));
     auto aligned_new_fn = Hle::lookup(nid_hash("_ZnwmSt11align_val_t"));
     auto aligned_new_nothrow_fn = Hle::lookup(nid_hash("_ZnwmSt11align_val_tRKSt9nothrow_t"));
+    auto aligned_new_array_fn = Hle::lookup(nid_hash("_ZnamSt11align_val_t"));
+    auto aligned_new_array_nothrow_fn = Hle::lookup(nid_hash("_ZnamSt11align_val_tRKSt9nothrow_t"));
     auto aligned_delete_fn = Hle::lookup(nid_hash("_ZdlPvSt11align_val_t"));
     CHECK(malloc_fn && calloc_fn && realloc_fn && free_fn && memalign_fn &&
-              posix_memalign_fn && new_fn && new_nothrow_fn && aligned_new_fn &&
-              aligned_new_nothrow_fn && aligned_delete_fn,
+              posix_memalign_fn && new_fn && new_nothrow_fn && new_array_fn &&
+              new_array_nothrow_fn && aligned_new_fn && aligned_new_nothrow_fn &&
+              aligned_new_array_fn && aligned_new_array_nothrow_fn && aligned_delete_fn,
           "allocation HLE functions registered");
     if (fails) return 1;
 
@@ -88,17 +102,29 @@ int main(int argc, char** argv) {
 
     CHECK(new_nothrow_fn(std::numeric_limits<uint64_t>::max(), 0, 0, 0, 0, 0) == 0,
           "nothrow operator new returns null on allocation failure");
+    CHECK(new_array_nothrow_fn(std::numeric_limits<uint64_t>::max(), 0, 0, 0, 0, 0) == 0,
+          "nothrow operator new[] returns null on allocation failure");
     CHECK(aligned_new_nothrow_fn(std::numeric_limits<uint64_t>::max(), 64, 0, 0, 0, 0) == 0,
           "aligned nothrow operator new returns null on allocation failure");
+    CHECK(aligned_new_array_nothrow_fn(
+              std::numeric_limits<uint64_t>::max(), 64, 0, 0, 0, 0) == 0,
+          "aligned nothrow operator new[] returns null on allocation failure");
     CHECK(run_self(argv[0], "probe") == 0, "allocation death-test child launches successfully");
     CHECK(run_self(argv[0], "throwing-new") != 0,
           "throwing operator new never returns null on allocation failure");
+    CHECK(run_self(argv[0], "throwing-new-array") != 0,
+          "throwing operator new[] never returns null on allocation failure");
     CHECK(run_self(argv[0], "throwing-aligned-new") != 0,
           "throwing aligned operator new never returns null on allocation failure");
+    CHECK(run_self(argv[0], "throwing-aligned-new-array") != 0,
+          "throwing aligned operator new[] never returns null on allocation failure");
 
     void* cpp_plain = (void*)(uintptr_t)new_fn(333, 0, 0, 0, 0, 0);
     CHECK(cpp_plain != nullptr, "throwing operator new still returns storage on success");
     free_fn(U(cpp_plain), 0, 0, 0, 0, 0);
+    void* cpp_array = (void*)(uintptr_t)new_array_fn(444, 0, 0, 0, 0, 0);
+    CHECK(cpp_array != nullptr, "throwing operator new[] still returns storage on success");
+    free_fn(U(cpp_array), 0, 0, 0, 0, 0);
 
     auto* aligned = (uint8_t*)(uintptr_t)memalign_fn(256, 513, 0, 0, 0, 0);
     CHECK(aligned != nullptr && ((uintptr_t)aligned & 255) == 0,
@@ -122,6 +148,12 @@ int main(int argc, char** argv) {
     CHECK(cpp && ((uintptr_t)cpp & 1023) == 0,
           "aligned operator new honors its alignment");
     aligned_delete_fn(U(cpp), 1024, 0, 0, 0, 0);
+
+    void* cpp_aligned_array =
+        (void*)(uintptr_t)aligned_new_array_fn(555, 128, 0, 0, 0, 0);
+    CHECK(cpp_aligned_array && ((uintptr_t)cpp_aligned_array & 127) == 0,
+          "aligned operator new[] honors its alignment");
+    aligned_delete_fn(U(cpp_aligned_array), 128, 0, 0, 0, 0);
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Refs #390

## Failure scenario and contract

The throwing scalar, array, and aligned `operator new` imports currently share handlers with their explicit `std::nothrow_t` overloads. When allocation fails, every form returns null. Returning null from a throwing allocation function violates its contract; ordinary C++ callers may treat it as usable storage and fault later instead of taking an allocation-failure path.

prosper does not yet bridge a guest `std::bad_alloc` exception across the HLE boundary. Until that exists, the throwing forms must fail-stop on allocation failure rather than return an illegal null. The explicit nothrow forms must continue returning null.

## Implementation

- Split throwing and nothrow handlers for ordinary and aligned `new`/`new[]` registrations.
- Keep the existing guest-compatible allocator family on every successful path.
- Emit a size/alignment diagnostic and terminate only when a throwing allocation actually fails.
- Extend `test_libc_alloc` with deterministic maximum-size child-process cases for every scalar/array ordinary/aligned throwing and nothrow registration, plus successful-allocation checks.

## Deliberately unaffected

- `malloc`, `calloc`, `realloc`, `memalign`, `posix_memalign`, delete/free compatibility, and successful allocation layout.
- Guest exception propagation remains future work; this PR implements the issue’s documented fail-stop fallback.
- Renderer behavior; no snapshots are applicable.

## Risk and review

The normal success path remains the same allocator call, but failure behavior intentionally changes from an invalid return to termination. Initial review identified missing array-overload coverage; the corrected exact head adds all four array paths and is independently approved: https://github.com/mattias800/ps5ys/pull/887#issuecomment-5010833128

## Author verification

Exact head `aeb81249b9dd5f4dae1c37097dc39d26121a6b92` passed `powershell -NoProfile -File prosper/tools/verify-pr.ps1 core -Pr 887`:

- `git diff --check`: PASS
- Linux build: PASS
- Linux ctest: 89/89 PASS
- Windows build: PASS
- Windows ctest: 82/82 PASS
- Snapshots: not applicable

Full exact commands and timings: https://github.com/mattias800/ps5ys/pull/887#issuecomment-5010832791