### PR TITLE
videoout: report no flip before first completion

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -72,8 +72,11 @@ namespace {
     // believe a flip completed with the wrong arg; concurrent flips could lose an increment.
     std::mutex g_flip_mx;
     uint64_t g_flip_count = 0;      // incremented per flip so GetFlipStatus shows progress
-    int32_t  g_current_buffer = 0;
-    int64_t  g_last_flip_arg = 0;
+    // The VideoOut ABI uses -1 for both fields until the first completed flip. Zero is a valid
+    // buffer index/argument, so exposing zero early can fool a frame pacer into consuming a flip
+    // that never happened (#394 F3).
+    int32_t  g_current_buffer = -1;
+    int64_t  g_last_flip_arg = -1;
     void flip_advance(int32_t bufidx, int64_t flip_arg) {
         std::lock_guard<std::mutex> lk(g_flip_mx);
         g_flip_count++;

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -37,6 +37,20 @@ int main() {
     CHECK(res && vbl && cap && issup && setba2 && regb2 && cfg && flip && fstat, "VideoOut functions registered");
     if (!(res && vbl && cap && issup && setba2 && regb2 && cfg && flip && fstat)) { printf("== FAIL ==\n"); return 1; }
 
+    // #394 F3: before any completed flip, -1 is the ABI's "none yet" sentinel for both the argument
+    // and current buffer. Zero is valid and used to make a frame pacer advance prematurely.
+    uint8_t initial_fs[0x48]; memset(initial_fs, 0xEE, sizeof initial_fs);
+    CHECK(fstat(0x1001, (uint64_t)(uintptr_t)initial_fs, 0, 0, 0, 0) == 0,
+          "initial GetFlipStatus succeeds");
+    CHECK(*(uint64_t*)(initial_fs + 0x00) == 0 &&
+          *(int64_t*)(initial_fs + 0x18) == -1 &&
+          *(int32_t*)(initial_fs + 0x38) == -1,
+          "initial flip status reports count=0 and -1 argument/buffer sentinels");
+    bool initial_tail_untouched = true;
+    for (size_t i = 0x40; i < sizeof initial_fs; ++i)
+        initial_tail_untouched &= initial_fs[i] == 0xEE;
+    CHECK(initial_tail_untouched, "GetFlipStatus writes exactly its 0x40-byte ABI struct");
+
     // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed.
     uint8_t rs[0x20]; memset(rs, 0xEE, sizeof rs);
     res(0x1001, (uint64_t)(uintptr_t)rs, 0, 0, 0, 0);


### PR DESCRIPTION
﻿## Summary
- initialize `sceVideoOutGetFlipStatus`'s current buffer and flip argument to the ABI's `-1` "none yet" sentinel
- keep zero reserved for real buffer/argument values after the first completed flip
- add byte-level coverage for the initial status and exact 0x40-byte write boundary

This addresses only finding F3 from #394. The broader audit issue intentionally remains open.

## Focused verification
- Linux: `test_videoout` ? PASS
- Windows: build and run `test_command_processor` ? PASS
- `git diff --check` ? PASS

The repository core verifier will be run against the published PR head and reported in a separate author comment. No snapshots are required or being run for this HLE-only change.
