### PR TITLE
agc: apply direct register writes

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1449,27 +1449,27 @@ void GpuState::apply(const Pm4Command& c) {
             state_dirty_ = true;   // register state changed -> the next draw needs a fresh snapshot
             break;
         }
-        case K::SetShRegDirect:
-            // SET_SH_REG writes a consecutive RANGE (the driver uploads the whole user-data SGPR block
-            // this way). Write every value, not just the first — else all descriptors past the range's
-            // first register are silently dropped (which left the shaders' V#/T# SGPRs empty).
+        case K::SetRegDirect: {
+            // SET_*_REG writes a consecutive range into the file named by its opcode. SH commonly
+            // uploads a whole user-data SGPR block, while the direct APIs emit one Cx/Sh/Uc pair.
+            auto& file = (c.reg_class == RegClass::Cx) ? cx
+                       : (c.reg_class == RegClass::Sh) ? sh : uc;
             if (getenv("PROSPER_RESDUMP")) {
-                fprintf(stderr, "[shdirect] off=0x%x count=%u vals:", c.sh_reg_offset,
-                        c.sh_reg_data ? c.sh_reg_count : 1u);
-                if (c.sh_reg_data && c.sh_reg_count)
-                    for (uint32_t k = 0; k < c.sh_reg_count && k < 40; k++)
-                        fprintf(stderr, " 0x%x", c.sh_reg_data[k]);
-                else fprintf(stderr, " 0x%x", c.sh_reg_value);
+                const char* cn = c.reg_class == RegClass::Cx ? "Cx" : c.reg_class == RegClass::Sh ? "Sh" : "Uc";
+                fprintf(stderr, "[regdirect] class=%s off=0x%x count=%u vals:", cn, c.reg_offset,
+                        c.reg_data ? c.reg_count : 1u);
+                if (c.reg_data && c.reg_count)
+                    for (uint32_t k = 0; k < c.reg_count && k < 40; k++)
+                        fprintf(stderr, " 0x%x", c.reg_data[k]);
+                else fprintf(stderr, " 0x%x", c.reg_value);
                 fprintf(stderr, "\n");
             }
-            if (c.sh_reg_data && c.sh_reg_count) {
-                for (uint32_t k = 0; k < c.sh_reg_count && c.sh_reg_count <= kMaxRegsPerPacket; k++)
-                    sh[c.sh_reg_offset + k] = c.sh_reg_data[k];
-            } else {
-                sh[c.sh_reg_offset] = c.sh_reg_value;   // fallback (single-register / legacy path)
-            }
+            if (!c.reg_data || c.reg_count == 0 || c.reg_count > kMaxRegsPerPacket) break;
+            for (uint32_t k = 0; k < c.reg_count; k++)
+                file[c.reg_offset + k] = c.reg_data[k];
             state_dirty_ = true;
             break;
+        }
         case K::SetIndexType:
             index_type = c.index_size;
             state_dirty_ = true;

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -52,14 +52,17 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
             // Address-carrying (timestamp/label) variant: [1..2] = address lo/hi (#132). Address-less
             // pipeline-sync events leave event_addr == 0 (a no-op in the CommandProcessor).
             if (npl >= 3) c.event_addr = (uint64_t)pl[1] | ((uint64_t)pl[2] << 32);
-        } else if (c.op == IT_SET_SH_REG) {
-            // SET_SH_REG sets a RANGE: pl[0] = start register offset, pl[1..npl-1] = consecutive values
-            // (this is how the driver uploads the whole user-data descriptor block in one packet — e.g. a
-            // len-22 packet at GS_0 loads s0..s20). Capture the full range, not just the first register.
-            c.kind = K::SetShRegDirect;
+        } else if (c.op == IT_SET_CONTEXT_REG || c.op == IT_SET_SH_REG ||
+                   c.op == IT_SET_UCONFIG_REG) {
+            // SET_*_REG sets a RANGE: pl[0] = start register offset, pl[1..npl-1] = consecutive
+            // values. Capture the class from the opcode so single-register Cx/Uc builders do not
+            // silently disappear and SH range packets keep their existing behavior (#395 F5).
+            c.kind = K::SetRegDirect;
+            c.reg_class = c.op == IT_SET_CONTEXT_REG ? RegClass::Cx
+                        : c.op == IT_SET_SH_REG ? RegClass::Sh : RegClass::Uc;
             if (npl >= 2) {
-                c.sh_reg_offset = pl[0]; c.sh_reg_value = pl[1];
-                c.sh_reg_count = npl - 1; c.sh_reg_data = &pl[1];
+                c.reg_offset = pl[0]; c.reg_value = pl[1];
+                c.reg_count = npl - 1; c.reg_data = &pl[1];
             }
         } else if (c.op == IT_NOP) {
             switch (c.r) {

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -17,7 +17,8 @@ namespace prosper::gpu {
 
 // IT_* opcodes and the R_* sub-opcodes carried inside IT_NOP (mirror hle_agc.cpp).
 enum : uint32_t {
-    IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46, IT_SET_SH_REG = 0x76,
+    IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46,
+    IT_SET_CONTEXT_REG = 0x69, IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79,
 };
 enum : uint32_t {
     R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
@@ -47,7 +48,7 @@ enum class RegClass { Cx, Sh, Uc };
 // the header), so unknown packets are still walkable and inspectable.
 struct Pm4Command {
     enum class Kind {
-        DrawReset, WaitFlipDone, PushMarker, PopMarker, SetShRegDirect, SetRegsIndirect, SetIndexType,
+        DrawReset, WaitFlipDone, PushMarker, PopMarker, SetRegDirect, SetRegsIndirect, SetIndexType,
         DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
         DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Jump, SetPredication,
         DmaData, Unknown,
@@ -63,7 +64,7 @@ struct Pm4Command {
     const char* marker_label = nullptr;
 
     // Decoded operands (only the ones relevant to `kind` are meaningful):
-    RegClass reg_class = RegClass::Cx;   // SetRegsIndirect
+    RegClass reg_class = RegClass::Cx;   // SetRegDirect / SetRegsIndirect
     uint32_t num_regs = 0;               // SetRegsIndirect
     uint64_t regs_vaddr = 0;             // SetRegsIndirect: guest addr of the register array
     uint32_t index_count = 0;            // DrawIndexAuto / DrawIndex
@@ -98,9 +99,9 @@ struct Pm4Command {
     uint32_t index_offset = 0;           // DrawIndexOffset: first index (start location)
     uint32_t event_type = 0;             // EventWrite
     uint64_t event_addr = 0;             // EventWrite: destination address (0 = address-less sync event) (#132)
-    uint32_t sh_reg_offset = 0, sh_reg_value = 0;  // SetShRegDirect (sh_reg_value = first value)
-    uint32_t sh_reg_count = 0;                 // SetShRegDirect: # of consecutive registers this packet sets
-    const uint32_t* sh_reg_data = nullptr;     // SetShRegDirect: -> the value dwords (count of them) in-packet
+    uint32_t reg_offset = 0, reg_value = 0;  // SetRegDirect (reg_value = first value)
+    uint32_t reg_count = 0;                  // SetRegDirect: # of consecutive registers this packet sets
+    const uint32_t* reg_data = nullptr;      // SetRegDirect: -> the value dwords (count of them) in-packet
 
     // ReleaseMem (EOP fence) — laid out by hle_agc.cpp agc_cb_release_mem, whose args are now pinned to the
     // AGC ABI sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, cache_policy, address, data_sel, data, …)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1273,14 +1273,38 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         // Dump each packet's kind + first payload dwords so we can see whether the game embeds a
         // completion-label write (WriteData/ReleaseMem/EventWrite) or a GPU-side wait in the stream.
         std::vector<gpu::Pm4Command> ops; gpu::decode_pm4(p->addr, p->dw_num, ops);
-        static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetRegDirect","SetRegsIndirect",
-            "SetIndexType","DrawIndex","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem",
-            "Flip","ReleaseMem","DispatchDirect","SetIndexBase","SetIndexCount","DrawIndexOffset",
-            "Jump","SetPredication","DmaData","Unknown"};
+        auto kind_name = [](gpu::Pm4Command::Kind kind) {
+            using K = gpu::Pm4Command::Kind;
+            switch (kind) {
+                case K::DrawReset:       return "DrawReset";
+                case K::WaitFlipDone:    return "WaitFlipDone";
+                case K::PushMarker:      return "PushMarker";
+                case K::PopMarker:       return "PopMarker";
+                case K::SetRegDirect:    return "SetRegDirect";
+                case K::SetRegsIndirect: return "SetRegsIndirect";
+                case K::SetIndexType:    return "SetIndexType";
+                case K::DrawIndex:       return "DrawIndex";
+                case K::DrawIndexAuto:   return "DrawIndexAuto";
+                case K::EventWrite:      return "EventWrite";
+                case K::AcquireMem:      return "AcquireMem";
+                case K::WriteData:       return "WriteData";
+                case K::WaitRegMem:      return "WaitRegMem";
+                case K::Flip:            return "Flip";
+                case K::ReleaseMem:      return "ReleaseMem";
+                case K::DispatchDirect:  return "DispatchDirect";
+                case K::SetIndexBase:    return "SetIndexBase";
+                case K::SetIndexCount:   return "SetIndexCount";
+                case K::DrawIndexOffset: return "DrawIndexOffset";
+                case K::Jump:            return "Jump";
+                case K::SetPredication:  return "SetPredication";
+                case K::DmaData:         return "DmaData";
+                case K::Unknown:         return "Unknown";
+            }
+            return "?";
+        };
         for (auto& c : ops) {
-            uint32_t k = (uint32_t)c.kind; const char* nm = k < 21 ? kKindName[k] : "?";
             fprintf(stderr, "[agc]   pkt op=0x%02x r=0x%02x len=%u kind=%s pl0=0x%08x pl1=0x%08x pl2=0x%08x\n",
-                    c.op, c.r, c.len, nm,
+                    c.op, c.r, c.len, kind_name(c.kind),
                     c.len > 1 ? c.payload[0] : 0, c.len > 2 ? c.payload[1] : 0, c.len > 3 ? c.payload[2] : 0);
         }
     }

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -55,7 +55,8 @@ namespace {
 
 // --- PM4 encoding (Kyty Pm4.h) ---------------------------------------------------------------
 constexpr uint32_t IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_NUM_INSTANCES = 0x2F,
-                   IT_EVENT_WRITE = 0x46, IT_SET_SH_REG = 0x76;
+                   IT_EVENT_WRITE = 0x46, IT_SET_CONTEXT_REG = 0x69,
+                   IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79;
 // Custom sub-opcodes carried inside IT_NOP:
 constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET = 0x05, R_WAIT_FLIP_DONE = 0x06,
                    R_PUSH_MARKER = 0x0b, R_POP_MARKER = 0x0c,
@@ -164,11 +165,18 @@ HLE(agc_dcb_wait_safe_for_rendering) {  // (buf, video_out_handle, display_buffe
     cmd[1] = (uint32_t)a1; cmd[2] = (uint32_t)a2; cmd[3] = cmd[4] = cmd[5] = cmd[6] = 0;
     return (uint64_t)(uintptr_t)cmd;
 }
-HLE(agc_dcb_set_sh_register_direct) {  // (buf, ShaderRegister reg)  reg packed in a1: offset|value<<32
-    uint32_t* cmd; if (!begin_packet(a0, 3, IT_SET_SH_REG, 0, &cmd)) return 0;
-    cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
+static uint64_t set_register_direct(uint64_t buf, uint64_t packed_reg, uint32_t opcode) {
+    uint32_t* cmd; if (!begin_packet(buf, 3, opcode, 0, &cmd)) return 0;
+    cmd[1] = (uint32_t)(packed_reg & 0xffffffffu);
+    cmd[2] = (uint32_t)(packed_reg >> 32u);
     return (uint64_t)(uintptr_t)cmd;
 }
+// ShaderRegister is passed by value as {uint32_t offset, uint32_t value}, packed into a1 by the
+// SysV ABI. These are real hardware SET_*_REG packets; keeping the register class in the opcode lets
+// the command processor update the correct persistent register file before the next draw (#395 F5).
+HLE(agc_dcb_set_cx_register_direct) { return set_register_direct(a0, a1, IT_SET_CONTEXT_REG); }
+HLE(agc_dcb_set_sh_register_direct) { return set_register_direct(a0, a1, IT_SET_SH_REG); }
+HLE(agc_dcb_set_uc_register_direct) { return set_register_direct(a0, a1, IT_SET_UCONFIG_REG); }
 static uint64_t set_regs_indirect(uint64_t buf, uint64_t regs, uint64_t num_regs, uint32_t r) {
     uint32_t* cmd; if (!begin_packet(buf, 4, IT_NOP, r, &cmd)) return 0;
     cmd[1] = (uint32_t)num_regs; cmd[2] = (uint32_t)(regs & 0xffffffffu); cmd[3] = (uint32_t)(regs >> 32u);
@@ -1265,7 +1273,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
         // Dump each packet's kind + first payload dwords so we can see whether the game embeds a
         // completion-label write (WriteData/ReleaseMem/EventWrite) or a GPU-side wait in the stream.
         std::vector<gpu::Pm4Command> ops; gpu::decode_pm4(p->addr, p->dw_num, ops);
-        static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetShRegDirect","SetRegsIndirect",
+        static const char* kKindName[] = {"DrawReset","WaitFlipDone","SetRegDirect","SetRegsIndirect",
             "SetIndexType","DrawIndex","DrawIndexAuto","EventWrite","AcquireMem","WriteData","WaitRegMem",
             "Flip","ReleaseMem","DispatchDirect","SetIndexBase","SetIndexCount","DrawIndexOffset",
             "Jump","SetPredication","DmaData","Unknown"};
@@ -1445,6 +1453,9 @@ void register_agc_hle() {
     RN("H7uZqCoNuWk", agc_dcb_pop_marker);
     RN("tSBxhAPyytQ", agc_dcb_set_num_instances);
     RN("MWiElSNE8j8", agc_dcb_wait_safe_for_rendering);
+    RN("LHFXRrlTPD8", agc_dcb_set_cx_register_direct);
+    RN("pFLArOT53+w", agc_dcb_set_sh_register_direct);
+    RN("w4-d0n60hdo", agc_dcb_set_uc_register_direct);
     RN("ZvwO9euwYzc", agc_dcb_set_cx_regs_indirect);
     RN("-HOOCn0JY48", agc_dcb_set_sh_regs_indirect);
     RN("hvUfkUIQcOE", agc_dcb_set_uc_regs_indirect);

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -24,7 +24,8 @@ struct Dcb {
 static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & 0x3fu) << 2u);
 }
-constexpr uint32_t IT_NOP = 0x10, IT_NUM_INSTANCES = 0x2F, IT_SET_SH_REG = 0x76,
+constexpr uint32_t IT_NOP = 0x10, IT_NUM_INSTANCES = 0x2F, IT_SET_CONTEXT_REG = 0x69,
+                   IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79,
                    R_DRAW_RESET = 0x05, R_PUSH_MARKER = 0x0b, R_POP_MARKER = 0x0c,
                    R_CX_REGS_INDIRECT = 0x12, R_DMA_DATA = 0x19;
 
@@ -39,9 +40,14 @@ int main() {
     auto p_add  = Hle::lookup("d-6uF9sZDIU");   // SetCxRegIndirectPatchAddRegisters
     auto p_addr = Hle::lookup("vcmNN+AAXnY");   // SetCxRegIndirectPatchSetAddress
     auto p_dma_src = Hle::lookup("cdDRpqcFGbU"); // DmaDataPatchSetSrcAddressOrOffsetOrImmediate
-    CHECK(reset && setcx && p_add && p_addr && p_dma_src,
+    auto setcx_direct = Hle::lookup("LHFXRrlTPD8"); // sceAgcDcbSetCxRegisterDirect
+    auto setsh_direct = Hle::lookup("pFLArOT53+w"); // sceAgcDcbSetShRegisterDirect
+    auto setuc_direct = Hle::lookup("w4-d0n60hdo"); // sceAgcDcbSetUcRegisterDirect
+    CHECK(reset && setcx && p_add && p_addr && p_dma_src &&
+          setcx_direct && setsh_direct && setuc_direct,
           "AGC Dcb functions registered (override the glog stubs)");
-    if (!(reset && setcx && p_add && p_addr && p_dma_src)) { printf("== FAIL ==\n"); return 1; }
+    if (!(reset && setcx && p_add && p_addr && p_dma_src &&
+          setcx_direct && setsh_direct && setuc_direct)) { printf("== FAIL ==\n"); return 1; }
 
     uint32_t buffer[256];
     memset(buffer, 0xEE, sizeof buffer);
@@ -72,6 +78,31 @@ int main() {
     CHECK(cmd[1] == 8, "PatchAddRegisters did cmd[1] += 5 (3 -> 8)");
     p_addr(rc, 0xAABBCCDD00112233ull, 0, 0, 0, 0);
     CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu, "PatchSetAddress rewrote cmd[2]/cmd[3]");
+
+    // #395 F5: all three single-register direct NIDs append the native packet opcode and preserve
+    // the by-value ShaderRegister's offset/value halves. Previously SH was dead code and Cx/Uc fell
+    // through to unimplemented-success without advancing the DCB at all.
+    uint32_t* direct_before = dcb.cursor_up;
+    auto pack_reg = [](uint32_t offset, uint32_t value) {
+        return (uint64_t)offset | ((uint64_t)value << 32u);
+    };
+    auto* cx_direct = (uint32_t*)(uintptr_t)setcx_direct(D, pack_reg(0x123, 0x11111111), 0, 0, 0, 0);
+    auto* sh_direct = (uint32_t*)(uintptr_t)setsh_direct(D, pack_reg(0x234, 0x22222222), 0, 0, 0, 0);
+    auto* uc_direct = (uint32_t*)(uintptr_t)setuc_direct(D, pack_reg(0x345, 0x33333333), 0, 0, 0, 0);
+    CHECK(cx_direct == direct_before &&
+          cx_direct[0] == PM4(3, IT_SET_CONTEXT_REG, 0) &&
+          cx_direct[1] == 0x123 && cx_direct[2] == 0x11111111,
+          "SetCxRegisterDirect appends one context-register packet");
+    CHECK(sh_direct == direct_before + 3 &&
+          sh_direct[0] == PM4(3, IT_SET_SH_REG, 0) &&
+          sh_direct[1] == 0x234 && sh_direct[2] == 0x22222222,
+          "SetShRegisterDirect appends one shader-register packet");
+    CHECK(uc_direct == direct_before + 6 &&
+          uc_direct[0] == PM4(3, IT_SET_UCONFIG_REG, 0) &&
+          uc_direct[1] == 0x345 && uc_direct[2] == 0x33333333,
+          "SetUcRegisterDirect appends one user-config-register packet");
+    CHECK(dcb.cursor_up == direct_before + 9,
+          "single-register direct writers advance the DCB by all three packets");
 
     // sceAgcDmaDataPatchSetSrcAddressOrOffsetOrImmediate (#189): patch only the source qword of
     // a verified DMA_DATA packet. A wrong packet kind must remain untouched.

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -42,8 +42,13 @@ int main() {
     auto setsh = Hle::lookup("-HOOCn0JY48");   // SetShRegistersIndirect
     auto draw  = Hle::lookup("Yw0jKSqop+E");   // DrawIndexAuto
     auto dispatch = Hle::lookup("k3GhuSNmBLU"); // DispatchDirect
-    CHECK(reset && idx && setcx && setsh && draw && dispatch, "AGC Dcb builders registered");
-    if (!(reset && idx && setcx && setsh && draw && dispatch)) { printf("== FAIL ==\n"); return 1; }
+    auto setcx_direct = Hle::lookup("LHFXRrlTPD8"); // SetCxRegisterDirect (#395 F5)
+    auto setsh_direct = Hle::lookup("pFLArOT53+w"); // SetShRegisterDirect (#395 F5)
+    auto setuc_direct = Hle::lookup("w4-d0n60hdo"); // SetUcRegisterDirect (#395 F5)
+    CHECK(reset && idx && setcx && setsh && draw && dispatch &&
+          setcx_direct && setsh_direct && setuc_direct, "AGC Dcb builders registered");
+    if (!(reset && idx && setcx && setsh && draw && dispatch &&
+          setcx_direct && setsh_direct && setuc_direct)) { printf("== FAIL ==\n"); return 1; }
 
     uint32_t buffer[256];
     memset(buffer, 0, sizeof buffer);
@@ -60,6 +65,12 @@ int main() {
     idx(D, 2, 0, 0, 0, 0);
     setcx(D, (uint64_t)(uintptr_t)cx_regs, 3, 0, 0, 0);
     setsh(D, (uint64_t)(uintptr_t)sh_regs, 2, 0, 0, 0);
+    auto pack_reg = [](uint32_t offset, uint32_t value) {
+        return (uint64_t)offset | ((uint64_t)value << 32u);
+    };
+    setcx_direct(D, pack_reg(0xA318u, 0xCCCCCCCCu), 0, 0, 0, 0);
+    setsh_direct(D, pack_reg(0x2C0Du, 0xDDDDDDDDu), 0, 0, 0, 0);
+    setuc_direct(D, pack_reg(0x0123u, 0xEEEEEEEEu), 0, 0, 0, 0);
     draw(D, 0x0300, 0, 0, 0, 0);
     draw(D, 0x0006, 0, 0, 0, 0);
 
@@ -69,15 +80,18 @@ int main() {
 
     // Cx register file: the three offsets set to their values.
     CHECK(st.cx.size() == 3, "cx file has 3 registers");
-    CHECK(st.cx.count(0xA318u) && st.cx[0xA318u] == 0x11111111u, "cx[0xA318] = 0x11111111");
+    CHECK(st.cx.count(0xA318u) && st.cx[0xA318u] == 0xCCCCCCCCu,
+          "direct Cx write overrides cx[0xA318]");
     CHECK(st.cx.count(0x00C0u) && st.cx[0x00C0u] == 0x22222222u, "cx[0x00C0] = 0x22222222");
     CHECK(st.cx.count(0x02DEu) && st.cx[0x02DEu] == 0x33333333u, "cx[0x02DE] = 0x33333333");
 
     // Sh register file: two registers; must NOT leak into cx/uc.
     CHECK(st.sh.size() == 2, "sh file has 2 registers");
     CHECK(st.sh.count(0x2C0Cu) && st.sh[0x2C0Cu] == 0xAAAAAAAAu, "sh[0x2C0C] = 0xAAAAAAAA");
-    CHECK(st.sh.count(0x2C0Du) && st.sh[0x2C0Du] == 0xBBBBBBBBu, "sh[0x2C0D] = 0xBBBBBBBB");
-    CHECK(st.uc.empty(), "uc file untouched");
+    CHECK(st.sh.count(0x2C0Du) && st.sh[0x2C0Du] == 0xDDDDDDDDu,
+          "direct Sh write overrides sh[0x2C0D]");
+    CHECK(st.uc.size() == 1 && st.uc.count(0x0123u) && st.uc[0x0123u] == 0xEEEEEEEEu,
+          "direct Uc write reaches only the user-config register file");
 
     CHECK(st.index_type == 2, "index_type = 2 (from SetIndexSize)");
 

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -37,9 +37,14 @@ int main() {
     auto evt   = Hle::lookup("aJf+j5yntiU");   // EventWrite
     auto push  = Hle::lookup("+kSrjIVxKFE");   // PushMarker (#641)
     auto pop   = Hle::lookup("H7uZqCoNuWk");   // PopMarker (#641)
-    CHECK(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop,
+    auto setcx_direct = Hle::lookup("LHFXRrlTPD8"); // SetCxRegisterDirect (#395 F5)
+    auto setsh_direct = Hle::lookup("pFLArOT53+w"); // SetShRegisterDirect (#395 F5)
+    auto setuc_direct = Hle::lookup("w4-d0n60hdo"); // SetUcRegisterDirect (#395 F5)
+    CHECK(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop &&
+          setcx_direct && setsh_direct && setuc_direct,
           "AGC Dcb builders registered");
-    if (!(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop)) {
+    if (!(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop &&
+          setcx_direct && setsh_direct && setuc_direct)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -57,6 +62,12 @@ int main() {
     uint64_t rc = setcx(D, /*regs vaddr*/ 0x1122334455667788ull, /*num*/ 3, 0, 0, 0);
     p_add(rc, 5, 0, 0, 0, 0);                                     // num_regs: 3 -> 8
     p_adr(rc, 0xCAFEF00DDEADBEEFull, 0, 0, 0, 0);                 // rewrite the regs vaddr
+    auto pack_reg = [](uint32_t offset, uint32_t value) {
+        return (uint64_t)offset | ((uint64_t)value << 32u);
+    };
+    setcx_direct(D, pack_reg(0x100, 0x11111111), 0, 0, 0, 0);
+    setsh_direct(D, pack_reg(0x200, 0x22222222), 0, 0, 0, 0);
+    setuc_direct(D, pack_reg(0x300, 0x33333333), 0, 0, 0, 0);
     draw(D, /*index_count*/ 0x1234, 0, 0, 0, 0);
     drawi(D, /*index_count*/ 0x0600, /*indices*/ 0xDEAD0000BEEF0040ull, /*modifier*/ 0x40000000ull, 0, 0);
     evt(D, /*event_type*/ 0x42, /*address*/ 0x1400ABCD00ull, 0, 0, 0);
@@ -68,8 +79,8 @@ int main() {
     std::vector<Pm4Command> ops;
     size_t consumed = decode_pm4(buffer, 256, ops);   // pass full buffer; decoder stops at the zero tail
     CHECK(consumed == used_dw, "decoder consumed exactly the built dwords (stops at zero pad)");
-    CHECK(ops.size() == 8, "decoded 8 packets");
-    if (ops.size() != 8) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
+    CHECK(ops.size() == 11, "decoded 11 packets");
+    if (ops.size() != 11) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
 
     using K = Pm4Command::Kind;
     CHECK(ops[0].kind == K::PushMarker && ops[0].marker_label &&
@@ -84,19 +95,32 @@ int main() {
     CHECK(ops[3].num_regs == 8, "op3 num_regs = 8 (3 + patched 5)");
     CHECK(ops[3].regs_vaddr == 0xCAFEF00DDEADBEEFull, "op3 regs_vaddr = patched address");
 
-    CHECK(ops[4].kind == K::DrawIndexAuto && ops[4].index_count == 0x1234, "op4 = DrawIndexAuto(0x1234)");
+    CHECK(ops[4].kind == K::SetRegDirect && ops[4].reg_class == RegClass::Cx &&
+          ops[4].reg_offset == 0x100 && ops[4].reg_count == 1 &&
+          ops[4].reg_data && ops[4].reg_data[0] == 0x11111111,
+          "op4 = SetCxRegisterDirect(offset/value)");
+    CHECK(ops[5].kind == K::SetRegDirect && ops[5].reg_class == RegClass::Sh &&
+          ops[5].reg_offset == 0x200 && ops[5].reg_count == 1 &&
+          ops[5].reg_data && ops[5].reg_data[0] == 0x22222222,
+          "op5 = SetShRegisterDirect(offset/value)");
+    CHECK(ops[6].kind == K::SetRegDirect && ops[6].reg_class == RegClass::Uc &&
+          ops[6].reg_offset == 0x300 && ops[6].reg_count == 1 &&
+          ops[6].reg_data && ops[6].reg_data[0] == 0x33333333,
+          "op6 = SetUcRegisterDirect(offset/value)");
+
+    CHECK(ops[7].kind == K::DrawIndexAuto && ops[7].index_count == 0x1234, "op7 = DrawIndexAuto(0x1234)");
 
     // DrawIndex round-trip (issue #63): the builder wrote [1]=count, [2..3]=index addr, [4..5]=modifier;
     // the decoder must hand every field back (indexed draws were previously dropped as unknown NOPs).
-    CHECK(ops[5].kind == K::DrawIndex && ops[5].index_count == 0x0600, "op5 = DrawIndex(count=0x600)");
-    CHECK(ops[5].di_index_addr == 0xDEAD0000BEEF0040ull, "op5 index-buffer address round-trips");
-    CHECK(ops[5].di_modifier == 0x40000000ull && ops[5].di_valid, "op5 modifier round-trips (valid)");
+    CHECK(ops[8].kind == K::DrawIndex && ops[8].index_count == 0x0600, "op8 = DrawIndex(count=0x600)");
+    CHECK(ops[8].di_index_addr == 0xDEAD0000BEEF0040ull, "op8 index-buffer address round-trips");
+    CHECK(ops[8].di_modifier == 0x40000000ull && ops[8].di_valid, "op8 modifier round-trips (valid)");
 
-    CHECK(ops[6].kind == K::EventWrite && ops[6].event_type == 0x42, "op6 = EventWrite(0x42)");
+    CHECK(ops[9].kind == K::EventWrite && ops[9].event_type == 0x42, "op9 = EventWrite(0x42)");
     // Address-carrying EVENT_WRITE (#132): the widened packet now round-trips its destination
     // address (was discarded, so an address-carrying event lost its write target).
-    CHECK(ops[6].event_addr == 0x1400ABCD00ull, "op6 EventWrite address round-trips (was dropped)");
-    CHECK(ops[7].kind == K::PopMarker, "op7 = PopMarker");
+    CHECK(ops[9].event_addr == 0x1400ABCD00ull, "op9 EventWrite address round-trips (was dropped)");
+    CHECK(ops[10].kind == K::PopMarker, "op10 = PopMarker");
 
     // Every decoded packet's len must match its header, and the payload pointer must be in-buffer.
     bool spans_ok = true;


### PR DESCRIPTION
﻿## Summary
- register the missing Cx, Sh, and Uc single-register direct AGC writers
- emit the native `SET_CONTEXT_REG`, `SET_SH_REG`, and `SET_UCONFIG_REG` packet classes
- decode/apply direct register ranges to the correct persistent GPU register file
- add builder, decoder, and end-to-end apply regressions

This addresses only finding F5 from #395. The broader audit issue intentionally remains open.

## Focused verification
- Linux: `agc_dcb_pm4`, `pm4_decode_stream`, `command_processor_apply` ? PASS
- Windows: `pm4_decode_stream`, `command_processor_apply` ? PASS (`agc_dcb_pm4` is configured only under the repository's UNIX CMake block)
- `git diff --check` ? PASS

The repository core verifier will be run against the published PR head and reported in a separate author comment. No snapshots are being run.
