### PR TITLE
hle: translate guest fcntl operations

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
+#include <climits>
 #include <string>
 #include <mutex>
 #include <atomic>        // sceKernelAio* submit-id/state table
@@ -117,21 +118,28 @@ namespace {
         _invalid_parameter_handler previous_;
     };
 
-    int windows_duplicate_above_stdio(int source_fd) {
+    int windows_duplicate_at_least(int source_fd, int minimum_fd) {
+        if (minimum_fd < 0) {
+            errno = EINVAL;
+            return -1;
+        }
         ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
         int fd = ::_dup(source_fd);
-        int low_fds[3]{};
-        size_t low_count = 0;
-        // Windows has no F_DUPFD. Keep recycled stdio slots occupied until _dup reaches the
-        // guest-visible range, then release the temporary descriptors.
-        while (fd >= 0 && fd < 3) {
-            low_fds[low_count++] = fd;
+        std::vector<int> low_fds;
+        // Windows has no F_DUPFD. Keep lower recycled slots occupied until _dup reaches the
+        // requested guest-visible range, then release the temporary descriptors.
+        while (fd >= 0 && fd < minimum_fd) {
+            low_fds.push_back(fd);
             fd = ::_dup(source_fd);
         }
         int duplicate_errno = fd < 0 ? errno : 0;
-        for (size_t i = 0; i < low_count; ++i) ::_close(low_fds[i]);
+        for (int low_fd : low_fds) ::_close(low_fd);
         if (fd < 0) errno = duplicate_errno;
         return fd;
+    }
+
+    int windows_duplicate_above_stdio(int source_fd) {
+        return windows_duplicate_at_least(source_fd, 3);
     }
 
     // The Windows CRT refuses to open directories as file descriptors. PS5 guests nevertheless
@@ -722,6 +730,185 @@ HLE(f_dup2) {
     return (uint64_t)(int64_t)(r < 0 ? -1 : (int)a1);
 }
 #endif
+
+namespace {
+constexpr uint64_t kGuestFDupFd = 0;
+constexpr uint64_t kGuestFGetFd = 1;
+constexpr uint64_t kGuestFSetFd = 2;
+constexpr uint64_t kGuestFGetFl = 3;
+constexpr uint64_t kGuestFSetFl = 4;
+constexpr uint64_t kGuestFGetOwn = 5;
+constexpr uint64_t kGuestFSetOwn = 6;
+constexpr uint64_t kGuestFdCloExec = 1;
+constexpr uint64_t kGuestONonblock = 0x0004;
+constexpr uint64_t kGuestOAppend = 0x0008;
+constexpr uint64_t kGuestOAsync = 0x0040;
+constexpr uint64_t kGuestOSync = 0x0080;
+constexpr uint64_t kGuestODirect = 0x00010000;
+
+#ifndef _WIN32
+uint64_t guest_status_flags_from_host(int flags) {
+    uint64_t guest = (uint64_t)(flags & O_ACCMODE);
+    if (flags & O_NONBLOCK) guest |= kGuestONonblock;
+    if (flags & O_APPEND) guest |= kGuestOAppend;
+#ifdef O_ASYNC
+    if (flags & O_ASYNC) guest |= kGuestOAsync;
+#endif
+#ifdef O_SYNC
+    if ((flags & O_SYNC) == O_SYNC) guest |= kGuestOSync;
+#endif
+#ifdef O_DIRECT
+    if (flags & O_DIRECT) guest |= kGuestODirect;
+#endif
+    return guest;
+}
+
+int host_settable_status_flags(uint64_t guest) {
+    int host = 0;
+    if (guest & kGuestONonblock) host |= O_NONBLOCK;
+    if (guest & kGuestOAppend) host |= O_APPEND;
+#ifdef O_ASYNC
+    if (guest & kGuestOAsync) host |= O_ASYNC;
+#endif
+#ifdef O_DIRECT
+    if (guest & kGuestODirect) host |= O_DIRECT;
+#endif
+    return host;
+}
+
+int host_settable_status_mask() {
+    int host = O_NONBLOCK | O_APPEND;
+#ifdef O_ASYNC
+    host |= O_ASYNC;
+#endif
+#ifdef O_DIRECT
+    host |= O_DIRECT;
+#endif
+    return host;
+}
+#endif
+} // namespace
+
+// FreeBSD/Orbis and host fcntl ABIs only coincide for a subset of commands, and their O_* status
+// bits differ substantially on Linux. Translate the descriptor/status operations used by libc and
+// game runtimes; reject record-lock commands until their FreeBSD flock layout is translated too.
+HLE(f_fcntl) {
+    if (a0 > INT_MAX) {
+        errno = EBADF;
+        return (uint64_t)-1;
+    }
+    const int fd = (int)a0;
+    switch (a1) {
+    case kGuestFDupFd: {
+        if (a2 > INT_MAX) {
+            errno = EINVAL;
+            return (uint64_t)-1;
+        }
+        const int minimum = (int)a2 < 3 ? 3 : (int)a2;
+#ifdef _WIN32
+        if (windows_directory_path(fd, nullptr)) {
+            errno = ENOTSUP;
+            return (uint64_t)-1;
+        }
+        return (uint64_t)(int64_t)windows_duplicate_at_least(fd, minimum);
+#else
+        return (uint64_t)(int64_t)::fcntl(fd, F_DUPFD, minimum);
+#endif
+    }
+    case kGuestFGetFd:
+#ifdef _WIN32
+        if (windows_directory_path(fd, nullptr)) return kGuestFdCloExec;
+        {
+            ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+            const intptr_t raw = ::_get_osfhandle(fd);
+            if (raw == -1) {
+                errno = EBADF;
+                return (uint64_t)-1;
+            }
+            DWORD flags = 0;
+            if (!GetHandleInformation((HANDLE)raw, &flags)) {
+                errno = GetLastError() == ERROR_INVALID_HANDLE ? EBADF : EACCES;
+                return (uint64_t)-1;
+            }
+            return (flags & HANDLE_FLAG_INHERIT) ? 0 : kGuestFdCloExec;
+        }
+#else
+        {
+            const int flags = ::fcntl(fd, F_GETFD);
+            return flags < 0 ? (uint64_t)-1
+                             : (uint64_t)((flags & FD_CLOEXEC) ? kGuestFdCloExec : 0);
+        }
+#endif
+    case kGuestFSetFd:
+        if (a2 & ~kGuestFdCloExec) {
+            errno = EINVAL;
+            return (uint64_t)-1;
+        }
+#ifdef _WIN32
+        if (windows_directory_path(fd, nullptr)) return 0;
+        {
+            ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+            const intptr_t raw = ::_get_osfhandle(fd);
+            if (raw == -1) {
+                errno = EBADF;
+                return (uint64_t)-1;
+            }
+            const DWORD inherit = (a2 & kGuestFdCloExec) ? 0 : HANDLE_FLAG_INHERIT;
+            if (!SetHandleInformation((HANDLE)raw, HANDLE_FLAG_INHERIT, inherit)) {
+                errno = GetLastError() == ERROR_INVALID_HANDLE ? EBADF : EACCES;
+                return (uint64_t)-1;
+            }
+            return 0;
+        }
+#else
+        return (uint64_t)(int64_t)::fcntl(
+            fd, F_SETFD, (a2 & kGuestFdCloExec) ? FD_CLOEXEC : 0);
+#endif
+    case kGuestFGetFl:
+#ifdef _WIN32
+        // UCRT has no status-flag query. Do not preserve the old missing-import false success.
+        errno = ENOTSUP;
+        return (uint64_t)-1;
+#else
+        {
+            const int flags = ::fcntl(fd, F_GETFL);
+            return flags < 0 ? (uint64_t)-1 : guest_status_flags_from_host(flags);
+        }
+#endif
+    case kGuestFSetFl:
+#ifdef _WIN32
+        // Likewise, UCRT cannot update O_NONBLOCK/O_APPEND on an existing descriptor.
+        errno = ENOTSUP;
+        return (uint64_t)-1;
+#else
+        {
+            const int old_flags = ::fcntl(fd, F_GETFL);
+            if (old_flags < 0) return (uint64_t)-1;
+            const int new_flags = (old_flags & ~host_settable_status_mask()) |
+                                  host_settable_status_flags(a2);
+            return (uint64_t)(int64_t)::fcntl(fd, F_SETFL, new_flags);
+        }
+#endif
+    case kGuestFGetOwn:
+#ifdef _WIN32
+        errno = ENOTSUP;
+        return (uint64_t)-1;
+#else
+        return (uint64_t)(int64_t)::fcntl(fd, F_GETOWN);
+#endif
+    case kGuestFSetOwn:
+#ifdef _WIN32
+        errno = ENOTSUP;
+        return (uint64_t)-1;
+#else
+        return (uint64_t)(int64_t)::fcntl(fd, F_SETOWN, (int)a2);
+#endif
+    default:
+        errno = EINVAL;
+        return (uint64_t)-1;
+    }
+}
+
 #ifndef _WIN32
 // FULL read: loop until `count` bytes are read (or EOF/error). POSIX read()/pread() may return FEWER
 // bytes than requested (a "short read") for a perfectly valid regular file — at internal buffer
@@ -1759,6 +1946,7 @@ void register_file_hle() {
     R("unlink", f_unlink);        R("sceKernelUnlink", f_unlink);
     R("rename", f_rename);        R("sceKernelRename", f_rename);   // real move (was fake-success -> lost atomic saves)
     R("dup", f_dup);   R("sceKernelDup", f_dup);   R("dup2", f_dup2);   R("sceKernelDup2", f_dup2);   // were 0 = stdin
+    R("fcntl", f_fcntl);          R("sceKernelFcntl", f_fcntl);       // FreeBSD commands/flags need translation
     R("sceKernelGetdents", k_getdents); R("getdents", f_getdents);
     // vectored IO + getdirentries — real host ops (were MISSING -> silent-EOF / empty-dir corruption trap)
     R("sceKernelReadv", f_readv);       R("readv", f_readv);

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -845,7 +845,13 @@ HLE(f_fcntl) {
             return (uint64_t)-1;
         }
 #ifdef _WIN32
-        if (windows_directory_path(fd, nullptr)) return 0;
+        if (windows_directory_path(fd, nullptr)) {
+            // Synthetic directory descriptors never escape to a child process. Their fixed
+            // CLOEXEC state cannot be cleared without introducing descriptor inheritance.
+            if (a2 & kGuestFdCloExec) return 0;
+            errno = ENOTSUP;
+            return (uint64_t)-1;
+        }
         {
             ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
             const intptr_t raw = ::_get_osfhandle(fd);
@@ -884,6 +890,14 @@ HLE(f_fcntl) {
         {
             const int old_flags = ::fcntl(fd, F_GETFL);
             if (old_flags < 0) return (uint64_t)-1;
+            const uint64_t old_guest_flags = guest_status_flags_from_host(old_flags);
+            // FreeBSD permits O_SYNC in F_SETFL, but Linux and Darwin do not reliably change it
+            // after open. Reject a requested transition instead of claiming success while the
+            // host descriptor remains unchanged.
+            if ((old_guest_flags ^ a2) & kGuestOSync) {
+                errno = ENOTSUP;
+                return (uint64_t)-1;
+            }
             const int new_flags = (old_flags & ~host_settable_status_mask()) |
                                   host_settable_status_flags(a2);
             return (uint64_t)(int64_t)::fcntl(fd, F_SETFL, new_flags);

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -26,6 +26,17 @@ static int fails = 0;
 #define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
                               else        { std::printf("  [ok]   %s\n", msg); } } while (0)
 
+// FreeBSD/Orbis fcntl ABI values. Host constants are deliberately not used here: Linux and
+// Windows assign different bits to several status flags even when command numbers coincide.
+static constexpr uint64_t kGuestFDupFd = 0;
+static constexpr uint64_t kGuestFGetFd = 1;
+static constexpr uint64_t kGuestFSetFd = 2;
+static constexpr uint64_t kGuestFGetFl = 3;
+static constexpr uint64_t kGuestFSetFl = 4;
+static constexpr uint64_t kGuestFdCloExec = 1;
+static constexpr uint64_t kGuestONonblock = 0x0004;
+static constexpr uint64_t kGuestOAppend = 0x0008;
+
 int main() {
     std::printf("== test_file_binary ==\n");
     const char* path = "prosper-test-file-binary.tmp";
@@ -59,9 +70,12 @@ int main() {
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
     HleFn kernel_getdirentries_fn = Hle::lookup(nid_hash("sceKernelGetdirentries"));
     HleFn fstat_fn = Hle::lookup(nid_hash("sceKernelFstat"));
+    HleFn fcntl_fn = Hle::lookup(nid_hash("fcntl"));
+    HleFn kernel_fcntl_fn = Hle::lookup(nid_hash("sceKernelFcntl"));
     CHECK(open_fn && read_fn && lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
-              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn,
+              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn &&
+              fcntl_fn && kernel_fcntl_fn,
           "file HLE functions registered");
     std::array<uint8_t, 64> dir_buffer{};
 
@@ -224,6 +238,66 @@ int main() {
     std::array<uint8_t, 512> actual{};
     int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;
     CHECK(fd >= 0, "open fixture through guest fd HLE");
+
+    // fcntl was unregistered, so the generic missing-import path returned false success (zero).
+    // Exercise descriptor discovery and status updates with guest values that catch raw Linux
+    // passthrough: O_NONBLOCK is 0x4 on FreeBSD/Orbis, but 0x800 on Linux.
+#ifndef _WIN32
+    uint64_t guest_flags = fcntl_fn && fd >= 0
+        ? fcntl_fn((uint64_t)fd, kGuestFGetFl, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    CHECK(guest_flags == 0, "fcntl F_GETFL reports guest O_RDONLY flags");
+    int64_t set_flags = fcntl_fn && fd >= 0
+        ? (int64_t)fcntl_fn((uint64_t)fd, kGuestFSetFl,
+                            kGuestONonblock | kGuestOAppend, 0, 0, 0)
+        : -1;
+    uint64_t changed_flags = kernel_fcntl_fn && fd >= 0
+        ? kernel_fcntl_fn((uint64_t)fd, kGuestFGetFl, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    CHECK(set_flags == 0, "fcntl F_SETFL accepts translated guest status flags");
+    CHECK((changed_flags & (3 | kGuestONonblock | kGuestOAppend)) ==
+              (kGuestONonblock | kGuestOAppend),
+          "sceKernelFcntl F_GETFL returns translated non-blocking and append bits");
+#else
+    // UCRT exposes neither F_GETFL nor F_SETFL. Until the secondary Windows host grows an
+    // equivalent descriptor-status layer, report that limitation instead of fake success.
+    errno = 0;
+    int64_t guest_flags = fcntl_fn && fd >= 0
+        ? (int64_t)fcntl_fn((uint64_t)fd, kGuestFGetFl, 0, 0, 0, 0)
+        : 0;
+    int getfl_errno = errno;
+    errno = 0;
+    int64_t set_flags = kernel_fcntl_fn && fd >= 0
+        ? (int64_t)kernel_fcntl_fn((uint64_t)fd, kGuestFSetFl,
+                                   kGuestONonblock | kGuestOAppend, 0, 0, 0)
+        : 0;
+    CHECK(guest_flags == -1 && getfl_errno == ENOTSUP &&
+              set_flags == -1 && errno == ENOTSUP,
+          "Windows fcntl status commands fail explicitly instead of returning false success");
+#endif
+
+    int64_t set_fd_flags = fcntl_fn && fd >= 0
+        ? (int64_t)fcntl_fn((uint64_t)fd, kGuestFSetFd, kGuestFdCloExec, 0, 0, 0)
+        : -1;
+    uint64_t fd_flags = fcntl_fn && fd >= 0
+        ? fcntl_fn((uint64_t)fd, kGuestFGetFd, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    CHECK(set_fd_flags == 0 && fd_flags == kGuestFdCloExec,
+          "fcntl translates the close-on-exec descriptor flag");
+
+    int64_t fcntl_duplicate = fcntl_fn && fd >= 0
+        ? (int64_t)fcntl_fn((uint64_t)fd, kGuestFDupFd, 8, 0, 0, 0)
+        : -1;
+    CHECK(fcntl_duplicate >= 8, "fcntl F_DUPFD honors the guest minimum descriptor");
+    if (fcntl_duplicate >= 0 && close_fn)
+        close_fn((uint64_t)fcntl_duplicate, 0, 0, 0, 0, 0);
+
+    errno = 0;
+    int64_t unsupported_fcntl = fcntl_fn && fd >= 0
+        ? (int64_t)fcntl_fn((uint64_t)fd, 0x7fffffff, 0, 0, 0, 0)
+        : 0;
+    CHECK(unsupported_fcntl == -1 && errno == EINVAL,
+          "fcntl rejects unsupported guest commands instead of returning false success");
 
     // libc and sceKernel expose the same enumeration operation with different error conventions.
     // The old shared handler returned a positive-looking SCE error to libc; Windows returned false

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -36,6 +36,7 @@ static constexpr uint64_t kGuestFSetFl = 4;
 static constexpr uint64_t kGuestFdCloExec = 1;
 static constexpr uint64_t kGuestONonblock = 0x0004;
 static constexpr uint64_t kGuestOAppend = 0x0008;
+static constexpr uint64_t kGuestOSync = 0x0080;
 
 int main() {
     std::printf("== test_file_binary ==\n");
@@ -206,6 +207,17 @@ int main() {
         : -1;
     CHECK(rewind_dir == 0 && rewound_bytes > 0,
           "Windows directory descriptors can be rewound and enumerated again");
+    errno = 0;
+    int64_t clear_dir_cloexec = dir_fd >= 0 && fcntl_fn
+        ? (int64_t)fcntl_fn((uint64_t)dir_fd, kGuestFSetFd, 0, 0, 0, 0)
+        : 0;
+    int clear_dir_errno = errno;
+    uint64_t dir_fd_flags = dir_fd >= 0 && fcntl_fn
+        ? fcntl_fn((uint64_t)dir_fd, kGuestFGetFd, 0, 0, 0, 0)
+        : 0;
+    CHECK(clear_dir_cloexec == -1 && clear_dir_errno == ENOTSUP &&
+              dir_fd_flags == kGuestFdCloExec,
+          "Windows directory fcntl rejects an unrepresentable close-on-exec change");
 #endif
 
     // Darwin's getdents compatibility path owns a duplicated descriptor behind DIR*. A raw
@@ -258,6 +270,17 @@ int main() {
     CHECK((changed_flags & (3 | kGuestONonblock | kGuestOAppend)) ==
               (kGuestONonblock | kGuestOAppend),
           "sceKernelFcntl F_GETFL returns translated non-blocking and append bits");
+    errno = 0;
+    int64_t unsupported_sync_change = fcntl_fn && fd >= 0
+        ? (int64_t)fcntl_fn((uint64_t)fd, kGuestFSetFl,
+                            changed_flags | kGuestOSync, 0, 0, 0)
+        : 0;
+    uint64_t flags_after_sync_change = fcntl_fn && fd >= 0
+        ? fcntl_fn((uint64_t)fd, kGuestFGetFl, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    CHECK(unsupported_sync_change == -1 && errno == ENOTSUP &&
+              (flags_after_sync_change & kGuestOSync) == 0,
+          "fcntl rejects an unsupported O_SYNC change instead of reporting false success");
 #else
     // UCRT exposes neither F_GETFL nor F_SETFL. Until the secondary Windows host grows an
     // equivalent descriptor-status layer, report that limitation instead of fake success.


### PR DESCRIPTION
Addresses only the remaining `fcntl` command/flag-translation finding in #389; the broader filesystem errno-remapping work remains separate.

- registers both `fcntl` and `sceKernelFcntl`
- translates FreeBSD/Orbis `F_GETFL`/`F_SETFL` status bits instead of passing Linux values through
- supports `F_DUPFD`, descriptor close-on-exec flags, and ownership commands where the host provides them
- rejects untranslated record-lock/unknown commands with `EINVAL` instead of fake success
- keeps Windows secondary-host behavior explicit: descriptor duplication and close-on-exec work, while unavailable UCRT status/ownership operations return `ENOTSUP`
- adds cross-host dispatch/contract coverage; the regression fails before the implementation because neither import is registered

Author focused checks before PR:
- Linux `file_binary_roundtrip`: pass
- Windows `file_binary_roundtrip`: pass
- `git diff --check`: pass

No snapshot tests were run or requested.