### PR TITLE
videoout: initialize resolution status tail

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -202,10 +202,10 @@ HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our s
               *(int32_t*) (s + 0x38) = buf; }  // currentBuffer
     return 0;
 }
-// SceVideoOutResolutionStatus (0x20 bytes, Kyty VideoOutResolutionStatus): report a real 1080p60
-// panel instead of the previous all-zero (which advertised a 0x0 display).
+// SceVideoOutResolutionStatus (0x30 bytes): report a real 1080p60 panel instead of the previous
+// all-zero display, and initialize flags/reserved0/reserved1 rather than leaking caller garbage.
 HLE(g_vo_resstatus)   {
-    if (a1) { uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x20);
+    if (a1) { uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x30);
               *(uint32_t*)(s + 0x00) = kDispW;   *(uint32_t*)(s + 0x04) = kDispH;   // full w/h
               *(uint32_t*)(s + 0x08) = kDispW;   *(uint32_t*)(s + 0x0c) = kDispH;   // pane w/h
               *(uint64_t*)(s + 0x10) = kRefresh5994;

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -51,12 +51,20 @@ int main() {
         initial_tail_untouched &= initial_fs[i] == 0xEE;
     CHECK(initial_tail_untouched, "GetFlipStatus writes exactly its 0x40-byte ABI struct");
 
-    // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed.
-    uint8_t rs[0x20]; memset(rs, 0xEE, sizeof rs);
+    // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed. The ABI struct is 0x30
+    // bytes: flags/reserved0 at 0x1c and reserved1[3] at 0x20 must not retain caller garbage.
+    uint8_t rs[0x38]; memset(rs, 0xEE, sizeof rs);
     res(0x1001, (uint64_t)(uintptr_t)rs, 0, 0, 0, 0);
     CHECK(*(uint32_t*)(rs + 0x00) == 1920 && *(uint32_t*)(rs + 0x04) == 1080, "resolution 1920x1080 (full)");
     CHECK(*(uint32_t*)(rs + 0x08) == 1920 && *(uint32_t*)(rs + 0x0c) == 1080, "resolution 1920x1080 (pane)");
     CHECK(*(uint64_t*)(rs + 0x10) == 3, "refresh rate = 59.94Hz (enum 3)");
+    bool resolution_reserved_zero = true;
+    for (size_t i = 0x1c; i < 0x30; ++i) resolution_reserved_zero &= rs[i] == 0;
+    CHECK(resolution_reserved_zero, "resolution flags and reserved tail are initialized");
+    bool resolution_canary_untouched = true;
+    for (size_t i = 0x30; i < sizeof rs; ++i) resolution_canary_untouched &= rs[i] == 0xEE;
+    CHECK(resolution_canary_untouched,
+          "GetResolutionStatus writes exactly its 0x30-byte ABI struct");
 
     // Vblank counter advances with TIME (one tick per ~16.68 ms vblank period), not per poll —
     // the old ++-per-call behavior made every poll look like a fresh vblank (issue #82). Two


### PR DESCRIPTION
Addresses only F8 in #394: the `SceVideoOutResolutionStatus` output tail. The broader VideoOut audit remains open.

- initializes the full verified 0x30-byte status object, including `flags`, `reserved0`, and `reserved1[3]`
- preserves the existing 1080p/59.94 Hz fields
- adds a byte-level regression that proves the reserved tail is cleared and an eight-byte post-struct canary is untouched

Focused author check before PR:
- Linux `videoout_queries`: pass (the test fails before the fix because bytes 0x20..0x2f retain caller garbage)
- `git diff --check`: pass

No renderer snapshots were run or requested; this change only initializes an HLE output struct and does not alter rendering.