### PR TITLE
hle: translate sceKernelOpen errors

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -701,6 +701,10 @@ static uint64_t open_sce_error(int error) {
     else if (error == EROFS) guest_error = 30;
     else if (error == EMLINK) guest_error = 31;
     else if (error == EPIPE) guest_error = 32;
+    else if (error == EAGAIN) guest_error = 35;
+#ifdef EWOULDBLOCK
+    else if (error == EWOULDBLOCK) guest_error = 35;
+#endif
 #ifdef ELOOP
     else if (error == ELOOP) guest_error = 62;
 #endif

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -667,6 +667,55 @@ static int host_open_flags(uint64_t f) {
 #endif
     return h;
 }
+
+// sceKernelOpen returns a FreeBSD/Orbis errno directly, while libc open returns -1 and
+// leaves the host errno for libc to expose.  Most common errno values coincide, but the
+// values after ERANGE diverge on Linux (for example ELOOP and ENAMETOOLONG), so translate
+// the errors open(2) can report instead of copying the host number into an SCE result.
+static uint64_t open_sce_error(int error) {
+    int guest_error = 5;  // EIO is the conservative fallback for an unmapped host failure.
+    if (error == EPERM) guest_error = 1;
+    else if (error == ENOENT) guest_error = 2;
+    else if (error == EINTR) guest_error = 4;
+    else if (error == EIO) guest_error = 5;
+    else if (error == ENXIO) guest_error = 6;
+    else if (error == EBADF) guest_error = 9;
+    else if (error == ENOMEM) guest_error = 12;
+    else if (error == EACCES) guest_error = 13;
+    else if (error == EFAULT) guest_error = 14;
+    else if (error == EBUSY) guest_error = 16;
+    else if (error == EEXIST) guest_error = 17;
+    else if (error == EXDEV) guest_error = 18;
+    else if (error == ENODEV) guest_error = 19;
+    else if (error == ENOTDIR) guest_error = 20;
+    else if (error == EISDIR) guest_error = 21;
+    else if (error == EINVAL) guest_error = 22;
+    else if (error == ENFILE) guest_error = 23;
+    else if (error == EMFILE) guest_error = 24;
+    else if (error == ENOTTY) guest_error = 25;
+#ifdef ETXTBSY
+    else if (error == ETXTBSY) guest_error = 26;
+#endif
+    else if (error == EFBIG) guest_error = 27;
+    else if (error == ENOSPC) guest_error = 28;
+    else if (error == EROFS) guest_error = 30;
+    else if (error == EMLINK) guest_error = 31;
+    else if (error == EPIPE) guest_error = 32;
+#ifdef ELOOP
+    else if (error == ELOOP) guest_error = 62;
+#endif
+#ifdef ENAMETOOLONG
+    else if (error == ENAMETOOLONG) guest_error = 63;
+#endif
+#ifdef EDQUOT
+    else if (error == EDQUOT) guest_error = 69;
+#endif
+#ifdef EOVERFLOW
+    else if (error == EOVERFLOW) guest_error = 84;
+#endif
+    return 0x80020000ull | (uint64_t)guest_error;
+}
+
 HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_flags(a1);
 #ifdef _WIN32
                int fd;
@@ -695,7 +744,11 @@ HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_fla
                if (filelog()) fprintf(stderr,
                    "[file] open-result host='%s' guest-flags=0x%llx host-flags=0x%x -> fd=%d error=%d\n",
                    h.c_str(), (unsigned long long)a1, host_flags, fd, err);
-               if (fd >= 0) preadlog("open", (uint64_t)fd, 0, 0); return (uint64_t)(int64_t)fd; }
+               if (fd >= 0) preadlog("open", (uint64_t)fd, 0, 0);
+               else errno = err;
+               return (uint64_t)(int64_t)fd; }
+HLE(k_open)  { uint64_t result = f_open(a0, a1, a2, a3, a4, a5);
+               return (int64_t)result < 0 ? open_sce_error(errno) : result; }
 #ifdef __APPLE__
 int getdents_close_fd(int fd);   // #843/#847: atomic cache invalidation + host close
 #endif
@@ -1939,7 +1992,7 @@ void register_file_hle() {
     R("fgetc", f_fgetc);   R("getc", f_fgetc);
     R("open", f_open);     R("close", f_close);   R("read", f_read);     R("write", f_write);
     R("lseek", f_lseek);   R("stat", f_stat);     R("fstat", f_fstat);   R("access", f_access);
-    R("sceKernelOpen", f_open);   R("sceKernelClose", f_close);  R("sceKernelRead", f_read);
+    R("sceKernelOpen", k_open);   R("sceKernelClose", f_close);  R("sceKernelRead", f_read);
     R("sceKernelWrite", f_write); R("sceKernelLseek", f_lseek);  R("sceKernelStat", f_stat);
     R("sceKernelFtruncate", f_ftruncate);   // real resize (was fake-success -> corrupt saves)
     R("lstat", f_lstat);   R("sceKernelLstat", f_lstat);     // was MISSING -> uninitialized stat buffer

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -56,6 +56,7 @@ int main() {
     }
 
     register_file_hle();
+    HleFn posix_open_fn = Hle::lookup(nid_hash("open"));
     HleFn open_fn = Hle::lookup(nid_hash("sceKernelOpen"));
     HleFn read_fn = Hle::lookup(nid_hash("sceKernelRead"));
     HleFn lseek_fn = Hle::lookup(nid_hash("sceKernelLseek"));
@@ -73,7 +74,7 @@ int main() {
     HleFn fstat_fn = Hle::lookup(nid_hash("sceKernelFstat"));
     HleFn fcntl_fn = Hle::lookup(nid_hash("fcntl"));
     HleFn kernel_fcntl_fn = Hle::lookup(nid_hash("sceKernelFcntl"));
-    CHECK(open_fn && read_fn && lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
+    CHECK(posix_open_fn && open_fn && read_fn && lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -248,6 +249,32 @@ int main() {
     std::filesystem::remove_all(dents_path, remove_error);
 
     std::array<uint8_t, 512> actual{};
+    const char* missing_path = "prosper-test-file-binary-missing.tmp";
+    std::error_code missing_remove_error;
+    std::filesystem::remove(missing_path, missing_remove_error);
+    errno = 0;
+    int64_t posix_missing = posix_open_fn
+        ? (int64_t)posix_open_fn((uint64_t)(uintptr_t)missing_path, 0, 0, 0, 0, 0)
+        : 0;
+    int posix_missing_errno = errno;
+    uint64_t kernel_missing = open_fn
+        ? open_fn((uint64_t)(uintptr_t)missing_path, 0, 0, 0, 0, 0)
+        : 0;
+    CHECK(posix_missing == -1 && posix_missing_errno == ENOENT,
+          "libc open retains the -1 plus errno contract");
+    CHECK((uint32_t)kernel_missing == 0x80020002u,
+          "sceKernelOpen returns SCE_KERNEL_ERROR_ENOENT directly");
+
+    constexpr uint64_t kGuestOWriteOnly = 0x0001;
+    constexpr uint64_t kGuestOCreate = 0x0200;
+    constexpr uint64_t kGuestOExclusive = 0x0800;
+    uint64_t kernel_existing = open_fn
+        ? open_fn((uint64_t)(uintptr_t)path,
+                  kGuestOWriteOnly | kGuestOCreate | kGuestOExclusive, 0600, 0, 0, 0)
+        : 0;
+    CHECK((uint32_t)kernel_existing == 0x80020011u,
+          "sceKernelOpen translates an exclusive-create collision to EEXIST");
+
     int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;
     CHECK(fd >= 0, "open fixture through guest fd HLE");
 

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -275,6 +275,25 @@ int main() {
     CHECK((uint32_t)kernel_existing == 0x80020011u,
           "sceKernelOpen translates an exclusive-create collision to EEXIST");
 
+#ifndef _WIN32
+    // Linux ELOOP is 40, while FreeBSD/Orbis ELOOP is 62. A real symlink cycle guards
+    // against accidentally embedding the host errno in a kernel result.
+    const char* loop_a = "prosper-test-open-loop-a.tmp";
+    const char* loop_b = "prosper-test-open-loop-b.tmp";
+    std::error_code symlink_error;
+    std::filesystem::remove(loop_a, symlink_error);
+    std::filesystem::remove(loop_b, symlink_error);
+    std::filesystem::create_symlink(loop_b, loop_a, symlink_error);
+    if (!symlink_error) std::filesystem::create_symlink(loop_a, loop_b, symlink_error);
+    uint64_t kernel_loop = !symlink_error && open_fn
+        ? open_fn((uint64_t)(uintptr_t)loop_a, 0, 0, 0, 0, 0)
+        : 0;
+    CHECK(!symlink_error && (uint32_t)kernel_loop == 0x8002003eu,
+          "sceKernelOpen translates host ELOOP to the divergent Orbis value");
+    std::filesystem::remove(loop_a, symlink_error);
+    std::filesystem::remove(loop_b, symlink_error);
+#endif
+
     int64_t fd = open_fn ? (int64_t)open_fn((uint64_t)(uintptr_t)path, 0, 0, 0, 0, 0) : -1;
     CHECK(fd >= 0, "open fixture through guest fd HLE");
 


### PR DESCRIPTION
## Summary
- give `sceKernelOpen` its kernel-style direct SCE error contract while preserving libc `open` as `-1` plus `errno`
- translate host `open(2)` failures to FreeBSD/Orbis errno values instead of copying divergent Linux errno numbers
- preserve the original host errno across diagnostics and cover ENOENT and EEXIST on both supported hosts

## Scope
This addresses only the `sceKernelOpen` error-contract slice of #389. The broader filesystem tracker remains open for the other `sceKernel*` calls.

## Focused tests
- Windows: `file_binary_roundtrip` passed
- Linux/WSL: `file_binary_roundtrip` passed
- No snapshots run (not a renderer change)

Refs #389