### PR TITLE
videoout: unregister buffer sets

### DIFF
--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -8,14 +8,6 @@
 #include <mutex>
 #include <vector>
 
-// The display surface lives in the libSceVideoOut buffer registry (hle_graphics.cpp), exposed via
-// these C hooks. Reading through them keeps the present layer decoupled from the HLE.
-extern "C" int      prosper_vo_buffer_count();
-extern "C" uint32_t prosper_vo_display_width();
-extern "C" uint32_t prosper_vo_display_height();
-extern "C" uint64_t prosper_vo_display_format();
-extern "C" uint64_t prosper_vo_buffer_addr(int i);
-
 namespace prosper::gpu {
 namespace {
 std::atomic<int>      g_front{-1};
@@ -28,6 +20,16 @@ std::mutex           g_frame_mx;
 std::shared_ptr<const std::vector<uint8_t>> g_frame; // w*h*4 bytes when a frame is present
 uint32_t             g_frame_w = 0, g_frame_h = 0;
 std::atomic<bool>    g_have_frame{false};
+
+bool current_scanout(VideoOutBufferSnapshot& out, int* index = nullptr) {
+    const int front = g_front.load(std::memory_order_relaxed);
+    if (front >= 0 && videoout_buffer_snapshot(front, out)) {
+        if (index) *index = front;
+        return true;
+    }
+    if (index) *index = -1;
+    return videoout_display_snapshot(out);
+}
 }
 
 void present_write_frame(const void* pixels, uint32_t w, uint32_t h) {
@@ -55,30 +57,38 @@ bool present_has_frame() { return g_have_frame.load(std::memory_order_acquire); 
 void present_flip(int buffer_index, int64_t flip_arg) {
     // Only accept a buffer the game actually registered; otherwise leave the front unchanged (an
     // invalid index shouldn't corrupt scanout state).
-    if (buffer_index >= 0 && buffer_index < prosper_vo_buffer_count())
+    VideoOutBufferSnapshot selected;
+    if (videoout_buffer_snapshot(buffer_index, selected))
         g_front.store(buffer_index, std::memory_order_relaxed);
+    else
+        current_scanout(selected);
     uint64_t n = g_present_count.fetch_add(1, std::memory_order_relaxed);
     record_gpu_timeline_present(n + 1, buffer_index, flip_arg,
-                                prosper_vo_display_width(), prosper_vo_display_height());
+                                selected.width, selected.height);
     // PROSPER_DUMP_SCANOUT=<dir>: dump the RAW guest display buffer the game just flipped (what the game
     // actually puts on screen — vs our execute_and_present composite render). First 8 flips + every 60th.
     // Written as raw w*h*4 bytes; convert offline. This reveals whether the game's real display holds the
     // title/scene even when the captured draws are a no-op composite.
     if (const char* dir = getenv("PROSPER_DUMP_SCANOUT"); dir && (n < 8 || n % 60 == 0)) {
-        int idx = (buffer_index >= 0 && buffer_index < prosper_vo_buffer_count()) ? buffer_index : g_front.load();
-        uint64_t addr = prosper_vo_buffer_addr(idx);
-        uint32_t w = prosper_vo_display_width(), h = prosper_vo_display_height();
-        if (addr && w && h) {
+        int idx = -1;
+        VideoOutBufferSnapshot scanout;
+        if (videoout_buffer_snapshot(buffer_index, scanout)) idx = buffer_index;
+        else current_scanout(scanout, &idx);
+        if (scanout.address && scanout.width && scanout.height) {
             char fn[512]; snprintf(fn, sizeof fn, "%s/scanout_%04llu_buf%d.rgba", dir, (unsigned long long)n, idx);
-            if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)addr, 1, (size_t)w * h * 4, f); fclose(f); }
+            if (FILE* f = fopen(fn, "wb")) {
+                fwrite((const void*)(uintptr_t)scanout.address, 1,
+                       (size_t)scanout.width * scanout.height * 4, f);
+                fclose(f);
+            }
         }
     }
 }
 
 int      present_front_index() { return g_front.load(std::memory_order_relaxed); }
 uint64_t present_count()       { return g_present_count.load(std::memory_order_relaxed); }
-uint32_t present_width()       { return prosper_vo_display_width(); }
-uint32_t present_height()      { return prosper_vo_display_height(); }
+uint32_t present_width()       { VideoOutBufferSnapshot s; return current_scanout(s) ? s.width : 0; }
+uint32_t present_height()      { VideoOutBufferSnapshot s; return current_scanout(s) ? s.height : 0; }
 // Dimensions of the RENDERED frame handed in via present_write_frame (0 if none present). Distinct from
 // present_width/height (the guest DISPLAY dims): under PROSPER_RENDER_SCALE the rendered frame is smaller
 // than the display, so a readback consumer (screenshot) must size its buffer from THESE when a rendered
@@ -101,12 +111,12 @@ size_t present_readback(void* dst, size_t dst_cap) {
     // Fallback: scan out the raw guest display buffer (contents are whatever the guest put there).
     int front = g_front.load(std::memory_order_relaxed);
     if (front < 0) return 0;
-    uint64_t addr = prosper_vo_buffer_addr(front);
-    uint32_t w = prosper_vo_display_width(), h = prosper_vo_display_height();
-    if (!addr || !w || !h) return 0;
-    size_t bytes = (size_t)w * h * 4;   // 32-bit color (BGRA/RGBA per the registered pixel format)
+    VideoOutBufferSnapshot scanout;
+    if (!videoout_buffer_snapshot(front, scanout) || !scanout.address ||
+        !scanout.width || !scanout.height) return 0;
+    size_t bytes = (size_t)scanout.width * scanout.height * 4;
     if (dst_cap < bytes) return 0;
-    std::memcpy(dst, (const void*)(uintptr_t)addr, bytes);
+    std::memcpy(dst, (const void*)(uintptr_t)scanout.address, bytes);
     return bytes;
 }
 
@@ -142,19 +152,20 @@ bool present_snapshot(PresentSnapshot& out) {
 
     const int front = g_front.load(std::memory_order_relaxed);
     if (front < 0) return false;
-    const uint64_t addr = prosper_vo_buffer_addr(front);
-    const uint32_t w = prosper_vo_display_width(), h = prosper_vo_display_height();
-    if (!addr || !w || !h) return false;
-    const size_t bytes = static_cast<size_t>(w) * h * 4;
+    VideoOutBufferSnapshot scanout;
+    if (!videoout_buffer_snapshot(front, scanout) || !scanout.address ||
+        !scanout.width || !scanout.height) return false;
+    const size_t bytes = static_cast<size_t>(scanout.width) * scanout.height * 4;
     out.source = PresentSource::RawScanout;
     out.present_count = g_present_count.load(std::memory_order_relaxed);
     out.source_seq = out.present_count;
     out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
     out.front_index = front;
-    out.width = w;
-    out.height = h;
+    out.width = scanout.width;
+    out.height = scanout.height;
     out.rgba.resize(bytes);
-    std::memcpy(out.rgba.data(), reinterpret_cast<const void*>(static_cast<uintptr_t>(addr)), bytes);
+    std::memcpy(out.rgba.data(),
+                reinterpret_cast<const void*>(static_cast<uintptr_t>(scanout.address)), bytes);
     return true;
 }
 

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -10,7 +10,6 @@
 
 namespace prosper::gpu {
 namespace {
-std::atomic<int>      g_front{-1};
 std::atomic<uint64_t> g_present_count{0};
 std::atomic<uint64_t> g_frame_seq{0};   // # of rendered frames handed in via present_write_frame
 
@@ -22,9 +21,8 @@ uint32_t             g_frame_w = 0, g_frame_h = 0;
 std::atomic<bool>    g_have_frame{false};
 
 bool current_scanout(VideoOutBufferSnapshot& out, int* index = nullptr) {
-    const int front = g_front.load(std::memory_order_relaxed);
-    if (front >= 0 && videoout_buffer_snapshot(front, out)) {
-        if (index) *index = front;
+    if (videoout_front_snapshot(out)) {
+        if (index) *index = out.buffer_index;
         return true;
     }
     if (index) *index = -1;
@@ -58,9 +56,7 @@ void present_flip(int buffer_index, int64_t flip_arg) {
     // Only accept a buffer the game actually registered; otherwise leave the front unchanged (an
     // invalid index shouldn't corrupt scanout state).
     VideoOutBufferSnapshot selected;
-    if (videoout_buffer_snapshot(buffer_index, selected))
-        g_front.store(buffer_index, std::memory_order_relaxed);
-    else
+    if (!videoout_select_buffer(buffer_index, selected))
         current_scanout(selected);
     uint64_t n = g_present_count.fetch_add(1, std::memory_order_relaxed);
     record_gpu_timeline_present(n + 1, buffer_index, flip_arg,
@@ -70,22 +66,19 @@ void present_flip(int buffer_index, int64_t flip_arg) {
     // Written as raw w*h*4 bytes; convert offline. This reveals whether the game's real display holds the
     // title/scene even when the captured draws are a no-op composite.
     if (const char* dir = getenv("PROSPER_DUMP_SCANOUT"); dir && (n < 8 || n % 60 == 0)) {
-        int idx = -1;
-        VideoOutBufferSnapshot scanout;
-        if (videoout_buffer_snapshot(buffer_index, scanout)) idx = buffer_index;
-        else current_scanout(scanout, &idx);
-        if (scanout.address && scanout.width && scanout.height) {
-            char fn[512]; snprintf(fn, sizeof fn, "%s/scanout_%04llu_buf%d.rgba", dir, (unsigned long long)n, idx);
+        std::vector<uint8_t> raw;
+        if (videoout_copy_buffer(selected, raw)) {
+            char fn[512]; snprintf(fn, sizeof fn, "%s/scanout_%04llu_buf%d.rgba", dir,
+                                   (unsigned long long)n, selected.buffer_index);
             if (FILE* f = fopen(fn, "wb")) {
-                fwrite((const void*)(uintptr_t)scanout.address, 1,
-                       (size_t)scanout.width * scanout.height * 4, f);
+                fwrite(raw.data(), 1, raw.size(), f);
                 fclose(f);
             }
         }
     }
 }
 
-int      present_front_index() { return g_front.load(std::memory_order_relaxed); }
+int      present_front_index() { return videoout_front_index(); }
 uint64_t present_count()       { return g_present_count.load(std::memory_order_relaxed); }
 uint32_t present_width()       { VideoOutBufferSnapshot s; return current_scanout(s) ? s.width : 0; }
 uint32_t present_height()      { VideoOutBufferSnapshot s; return current_scanout(s) ? s.height : 0; }
@@ -109,15 +102,7 @@ size_t present_readback(void* dst, size_t dst_cap) {
         return 0;
     }
     // Fallback: scan out the raw guest display buffer (contents are whatever the guest put there).
-    int front = g_front.load(std::memory_order_relaxed);
-    if (front < 0) return 0;
-    VideoOutBufferSnapshot scanout;
-    if (!videoout_buffer_snapshot(front, scanout) || !scanout.address ||
-        !scanout.width || !scanout.height) return 0;
-    size_t bytes = (size_t)scanout.width * scanout.height * 4;
-    if (dst_cap < bytes) return 0;
-    std::memcpy(dst, (const void*)(uintptr_t)scanout.address, bytes);
-    return bytes;
+    return videoout_copy_front_buffer(dst, dst_cap);
 }
 
 bool present_acquire_rendered_frame(PresentFrameLease& out) {
@@ -143,34 +128,27 @@ bool present_snapshot(PresentSnapshot& out) {
         out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
         out.source_seq = out.frame_seq;
         out.present_count = g_present_count.load(std::memory_order_relaxed);
-        out.front_index = g_front.load(std::memory_order_relaxed);
+        out.front_index = videoout_front_index();
         out.width = g_frame_w;
         out.height = g_frame_h;
         out.rgba = *g_frame;
         return true;
     }
 
-    const int front = g_front.load(std::memory_order_relaxed);
-    if (front < 0) return false;
     VideoOutBufferSnapshot scanout;
-    if (!videoout_buffer_snapshot(front, scanout) || !scanout.address ||
-        !scanout.width || !scanout.height) return false;
-    const size_t bytes = static_cast<size_t>(scanout.width) * scanout.height * 4;
+    if (!videoout_copy_front_buffer(out.rgba, scanout)) return false;
     out.source = PresentSource::RawScanout;
     out.present_count = g_present_count.load(std::memory_order_relaxed);
     out.source_seq = out.present_count;
     out.frame_seq = g_frame_seq.load(std::memory_order_relaxed);
-    out.front_index = front;
+    out.front_index = scanout.buffer_index;
     out.width = scanout.width;
     out.height = scanout.height;
-    out.rgba.resize(bytes);
-    std::memcpy(out.rgba.data(),
-                reinterpret_cast<const void*>(static_cast<uintptr_t>(scanout.address)), bytes);
     return true;
 }
 
 void present_reset() {
-    g_front.store(-1, std::memory_order_relaxed);
+    videoout_reset_front();
     g_present_count.store(0, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(g_frame_mx);
     g_frame.reset(); g_frame_w = g_frame_h = 0;

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -16,6 +16,24 @@
 #include <memory>
 #include <vector>
 
+namespace prosper {
+
+// One lock-coherent view of a registered guest scanout buffer and the attributes of its owning
+// VideoOut set. The HLE registry supplies these snapshots to the present layer so an unregister or
+// another set's registration cannot pair one buffer address with unrelated dimensions.
+struct VideoOutBufferSnapshot {
+    uint64_t address = 0;
+    uint64_t pixel_format = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t tiling_mode = 0;
+};
+
+bool videoout_buffer_snapshot(int buffer_index, VideoOutBufferSnapshot& out);
+bool videoout_display_snapshot(VideoOutBufferSnapshot& out);
+
+} // namespace prosper
+
 namespace prosper::gpu {
 
 enum class PresentSource : uint8_t { None, Rendered, RawScanout };

--- a/prosper/src/gpu/videoout_present.hpp
+++ b/prosper/src/gpu/videoout_present.hpp
@@ -24,13 +24,28 @@ namespace prosper {
 struct VideoOutBufferSnapshot {
     uint64_t address = 0;
     uint64_t pixel_format = 0;
+    uint64_t generation = 0;
+    int buffer_index = -1;
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t tiling_mode = 0;
 };
 
-bool videoout_buffer_snapshot(int buffer_index, VideoOutBufferSnapshot& out);
+// Front-buffer selection and invalidation live under the registry mutex. A generation distinguishes
+// a newly registered buffer from an older registration that occupied the same numeric slot.
+bool videoout_select_buffer(int buffer_index, VideoOutBufferSnapshot& out);
+bool videoout_front_snapshot(VideoOutBufferSnapshot& out);
 bool videoout_display_snapshot(VideoOutBufferSnapshot& out);
+int videoout_front_index();
+void videoout_reset_front();
+
+// Copy while holding the registry lease so UnregisterBuffers cannot return (and let the guest reuse
+// the backing allocation) until the raw read completes. The expected-snapshot overload additionally
+// rejects unregister/re-register ABA by checking the registration generation.
+bool videoout_copy_buffer(const VideoOutBufferSnapshot& expected, std::vector<uint8_t>& out);
+bool videoout_copy_front_buffer(std::vector<uint8_t>& out, VideoOutBufferSnapshot& metadata);
+size_t videoout_copy_front_buffer(void* dst, size_t dst_cap,
+                                  VideoOutBufferSnapshot* metadata = nullptr);
 
 } // namespace prosper
 

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -115,6 +115,7 @@ namespace {
         bool     configured = false;
     };
     DisplayConfig g_display;
+    std::mutex g_display_mx;
     struct VideoOutBuffers { const void* data; const void* metadata; const void* reserved[2]; };
 }
 
@@ -122,12 +123,48 @@ namespace {
 // prosper_vo_flip_count: total flips so far (either flip path) — read by the PROSPER_PROGRESS
 // heartbeat in hle_agc.cpp as a cheap forward-progress signal for long diagnostic runs.
 extern "C" uint64_t prosper_vo_flip_count() { std::lock_guard<std::mutex> lk(g_flip_mx); return g_flip_count; }
-extern "C" int      prosper_vo_buffer_count()   { return g_display.buffer_num; }
-extern "C" uint32_t prosper_vo_display_width()  { return g_display.width; }
-extern "C" uint32_t prosper_vo_display_height() { return g_display.height; }
-extern "C" uint64_t prosper_vo_display_format() { return g_display.pixel_format; }
+extern "C" int prosper_vo_buffer_count() {
+    std::lock_guard<std::mutex> lk(g_display_mx); return g_display.buffer_num;
+}
+extern "C" uint32_t prosper_vo_display_width() {
+    std::lock_guard<std::mutex> lk(g_display_mx); return g_display.width;
+}
+extern "C" uint32_t prosper_vo_display_height() {
+    std::lock_guard<std::mutex> lk(g_display_mx); return g_display.height;
+}
+extern "C" uint64_t prosper_vo_display_format() {
+    std::lock_guard<std::mutex> lk(g_display_mx); return g_display.pixel_format;
+}
 extern "C" uint64_t prosper_vo_buffer_addr(int i) {
+    std::lock_guard<std::mutex> lk(g_display_mx);
     return (i >= 0 && i < g_display.buffer_num) ? g_display.buffer_addr[i] : 0;
+}
+
+bool videoout_buffer_snapshot(int buffer_index, VideoOutBufferSnapshot& out) {
+    out = {};
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    if (buffer_index < 0 || buffer_index >= 16) return false;
+    const uint8_t tag = g_display.buffer_set[buffer_index];
+    if (tag == 0) return false;
+    const auto& config = g_display.sets[tag - 1];
+    if (!config.registered) return false;
+    out.address = g_display.buffer_addr[buffer_index];
+    out.pixel_format = config.pixel_format;
+    out.width = config.width;
+    out.height = config.height;
+    out.tiling_mode = config.tiling_mode;
+    return true;
+}
+
+bool videoout_display_snapshot(VideoOutBufferSnapshot& out) {
+    out = {};
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    if (!g_display.configured) return false;
+    out.pixel_format = g_display.pixel_format;
+    out.width = g_display.width;
+    out.height = g_display.height;
+    out.tiling_mode = g_display.tiling_mode;
+    return true;
 }
 namespace { bool evlog() { static int v = getenv("PROSPER_EVLOG") ? 1 : 0; return v; } }
 // Implemented in hle_kernel_time.cpp (the equeue backend). Register a flip/vblank event source so the
@@ -277,14 +314,24 @@ HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a
     // Record the display surface (swapchain scaffolding). attribute is the 0x50-byte
     // VideoOutBufferAttribute2 we fill in SetBufferAttribute2: width@0x0c, height@0x10, format@0x20.
     const uint8_t* attr = (const uint8_t*)(uintptr_t)a5;
-    g_display.width        = *(const uint32_t*)(attr + 0x0c);
-    g_display.height       = *(const uint32_t*)(attr + 0x10);
-    g_display.pixel_format = *(const uint64_t*)(attr + 0x20);
-    g_display.tiling_mode  = *(const uint32_t*)(attr + 0x04);
-    g_display.sets[set] = {g_display.width, g_display.height, g_display.pixel_format,
-                           g_display.tiling_mode, true};
+    const DisplayConfig::SetConfig config = {
+        *(const uint32_t*)(attr + 0x0c), *(const uint32_t*)(attr + 0x10),
+        *(const uint64_t*)(attr + 0x20), *(const uint32_t*)(attr + 0x04), true
+    };
     const auto* bufs = (const VideoOutBuffers*)(uintptr_t)a3;
-    for (int i = 0; i < num && start + i < 16; i++) {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    if (g_display.sets[set].registered)
+        return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
+    for (int i = 0; i < num; ++i) {
+        if (g_display.buffer_set[start + i] != 0)
+            return (uint64_t)(int64_t)(int32_t)0x80290010;  // SCE_VIDEO_OUT_ERROR_SLOT_OCCUPIED
+    }
+    g_display.width = config.width;
+    g_display.height = config.height;
+    g_display.pixel_format = config.pixel_format;
+    g_display.tiling_mode = config.tiling_mode;
+    g_display.sets[set] = config;
+    for (int i = 0; i < num; i++) {
         g_display.buffer_addr[start + i] = (uint64_t)(uintptr_t)bufs[i].data;
         g_display.buffer_set[start + i] = (uint8_t)(set + 1);
     }
@@ -305,6 +352,7 @@ HLE(g_vo_unregister_buffers) {
     if (set < 0 || set > 3)
         return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
 
+    std::lock_guard<std::mutex> lk(g_display_mx);
     const uint8_t tag = (uint8_t)(set + 1);
     bool found = false;
     for (int i = 0; i < 16; ++i) {

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -100,11 +100,18 @@ namespace {
     // back-half present path turns each into a swapchain image; SubmitFlip picks by buffer index.
     // Recorded now so that surface is ready even before real presentation exists.
     struct DisplayConfig {
+        struct SetConfig {
+            uint32_t width = 0, height = 0;
+            uint64_t pixel_format = 0;
+            uint32_t tiling_mode = 0;
+            bool registered = false;
+        } sets[4];
         uint32_t width = 0, height = 0;
         uint64_t pixel_format = 0;
         uint32_t tiling_mode = 0;
         int      buffer_num = 0;
         uint64_t buffer_addr[16] = {0};   // guest GPU-VA of each registered framebuffer
+        uint8_t  buffer_set[16] = {0};    // set_index + 1; zero means the slot is unregistered
         bool     configured = false;
     };
     DisplayConfig g_display;
@@ -263,9 +270,10 @@ HLE(g_vo_set_buffer_attribute2) {  // a0=attr* a1=pixel_format a2=tiling a3=widt
 // succeeds so the game proceeds to flips.
 HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a3=buffers a4=buffer_num a5=attribute
     vo_argtrace("RegisterBuffers2", a0,a1,a2,a3,a4,a5);
-    int start = (int)a2, num = (int)a4;
+    int set = (int)a1, start = (int)a2, num = (int)a4;
     if (!a3 || !a5) return (uint64_t)(int64_t)-1;
-    if (start < 0 || start > 15 || num < 1 || num > 16 || start + num > 16) return (uint64_t)(int64_t)-1;
+    if (set < 0 || set > 3 || start < 0 || start > 15 || num < 1 || num > 16 || start + num > 16)
+        return (uint64_t)(int64_t)-1;
     // Record the display surface (swapchain scaffolding). attribute is the 0x50-byte
     // VideoOutBufferAttribute2 we fill in SetBufferAttribute2: width@0x0c, height@0x10, format@0x20.
     const uint8_t* attr = (const uint8_t*)(uintptr_t)a5;
@@ -273,14 +281,59 @@ HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a
     g_display.height       = *(const uint32_t*)(attr + 0x10);
     g_display.pixel_format = *(const uint64_t*)(attr + 0x20);
     g_display.tiling_mode  = *(const uint32_t*)(attr + 0x04);
+    g_display.sets[set] = {g_display.width, g_display.height, g_display.pixel_format,
+                           g_display.tiling_mode, true};
     const auto* bufs = (const VideoOutBuffers*)(uintptr_t)a3;
-    for (int i = 0; i < num && start + i < 16; i++)
+    for (int i = 0; i < num && start + i < 16; i++) {
         g_display.buffer_addr[start + i] = (uint64_t)(uintptr_t)bufs[i].data;
+        g_display.buffer_set[start + i] = (uint8_t)(set + 1);
+    }
     if (g_display.buffer_num < start + num) g_display.buffer_num = start + num;
     g_display.configured = true;
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[vo] display surface: %ux%u fmt=0x%llx %d buffers registered\n",
                 g_display.width, g_display.height, (unsigned long long)g_display.pixel_format, num);
+    return 0;
+}
+
+// sceVideoOutUnregisterBuffers (N5KDtkIjjJ4): release every slot owned by one attribute set.
+// RegisterBuffers2 may place independent sets in disjoint ranges, so retain the other sets and
+// recompute the highest visible slot instead of clearing the entire display unconditionally.
+HLE(g_vo_unregister_buffers) {
+    vo_argtrace("UnregisterBuffers", a0,a1,a2,a3,a4,a5);
+    const int set = (int)a1;
+    if (set < 0 || set > 3)
+        return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
+
+    const uint8_t tag = (uint8_t)(set + 1);
+    bool found = false;
+    for (int i = 0; i < 16; ++i) {
+        if (g_display.buffer_set[i] != tag) continue;
+        found = true;
+        g_display.buffer_set[i] = 0;
+        g_display.buffer_addr[i] = 0;
+    }
+    if (!found)
+        return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
+    g_display.sets[set] = {};
+
+    int remaining = 16;
+    while (remaining > 0 && g_display.buffer_set[remaining - 1] == 0) --remaining;
+    g_display.buffer_num = remaining;
+    g_display.configured = remaining != 0;
+    if (!g_display.configured) {
+        g_display.width = 0;
+        g_display.height = 0;
+        g_display.pixel_format = 0;
+        g_display.tiling_mode = 0;
+    } else {
+        const int remaining_set = (int)g_display.buffer_set[remaining - 1] - 1;
+        const auto& config = g_display.sets[remaining_set];
+        g_display.width = config.width;
+        g_display.height = config.height;
+        g_display.pixel_format = config.pixel_format;
+        g_display.tiling_mode = config.tiling_mode;
+    }
     return 0;
 }
 
@@ -539,6 +592,7 @@ void register_graphics_hle() {
     RN("Nv8c-Kb+DUM", g_vo_is_output_supported);   // sceVideoOutIsOutputSupported
     RN("PjS5uASwcV8", g_vo_set_buffer_attribute2);  // sceVideoOutSetBufferAttribute2
     RN("rKBUtgRrtbk", g_vo_register_buffers2);       // sceVideoOutRegisterBuffers2
+    RN("N5KDtkIjjJ4", g_vo_unregister_buffers);      // sceVideoOutUnregisterBuffers
     RN("utPrVdxio-8", g_vo_get_output_status);        // sceVideoOutGetOutputStatus
     RN("w0hLuNarQxY", g_vo_configure_output);          // sceVideoOutConfigureOutput
     RN("U2JJtSqNKZI", g_vo_get_event_id);              // sceVideoOutGetEventId (#210)

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -112,6 +112,10 @@ namespace {
         int      buffer_num = 0;
         uint64_t buffer_addr[16] = {0};   // guest GPU-VA of each registered framebuffer
         uint8_t  buffer_set[16] = {0};    // set_index + 1; zero means the slot is unregistered
+        uint64_t buffer_generation[16] = {0};
+        uint64_t next_generation = 0;
+        int      front_index = -1;
+        uint64_t front_generation = 0;
         bool     configured = false;
     };
     DisplayConfig g_display;
@@ -140,9 +144,9 @@ extern "C" uint64_t prosper_vo_buffer_addr(int i) {
     return (i >= 0 && i < g_display.buffer_num) ? g_display.buffer_addr[i] : 0;
 }
 
-bool videoout_buffer_snapshot(int buffer_index, VideoOutBufferSnapshot& out) {
+namespace {
+bool videoout_buffer_snapshot_locked(int buffer_index, VideoOutBufferSnapshot& out) {
     out = {};
-    std::lock_guard<std::mutex> lk(g_display_mx);
     if (buffer_index < 0 || buffer_index >= 16) return false;
     const uint8_t tag = g_display.buffer_set[buffer_index];
     if (tag == 0) return false;
@@ -150,10 +154,43 @@ bool videoout_buffer_snapshot(int buffer_index, VideoOutBufferSnapshot& out) {
     if (!config.registered) return false;
     out.address = g_display.buffer_addr[buffer_index];
     out.pixel_format = config.pixel_format;
+    out.generation = g_display.buffer_generation[buffer_index];
+    out.buffer_index = buffer_index;
     out.width = config.width;
     out.height = config.height;
     out.tiling_mode = config.tiling_mode;
     return true;
+}
+
+bool videoout_front_snapshot_locked(VideoOutBufferSnapshot& out) {
+    if (!videoout_buffer_snapshot_locked(g_display.front_index, out) ||
+        out.generation != g_display.front_generation) {
+        out = {};
+        return false;
+    }
+    return true;
+}
+
+bool videoout_buffer_bytes(const VideoOutBufferSnapshot& buffer, size_t& bytes) {
+    if (!buffer.address || !buffer.width || !buffer.height) return false;
+    const uint64_t pixels = (uint64_t)buffer.width * buffer.height;
+    if (pixels > SIZE_MAX / 4) return false;
+    bytes = (size_t)pixels * 4;
+    return true;
+}
+} // namespace
+
+bool videoout_select_buffer(int buffer_index, VideoOutBufferSnapshot& out) {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    if (!videoout_buffer_snapshot_locked(buffer_index, out)) return false;
+    g_display.front_index = buffer_index;
+    g_display.front_generation = out.generation;
+    return true;
+}
+
+bool videoout_front_snapshot(VideoOutBufferSnapshot& out) {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    return videoout_front_snapshot_locked(out);
 }
 
 bool videoout_display_snapshot(VideoOutBufferSnapshot& out) {
@@ -165,6 +202,52 @@ bool videoout_display_snapshot(VideoOutBufferSnapshot& out) {
     out.height = g_display.height;
     out.tiling_mode = g_display.tiling_mode;
     return true;
+}
+
+int videoout_front_index() {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    VideoOutBufferSnapshot out;
+    return videoout_front_snapshot_locked(out) ? out.buffer_index : -1;
+}
+
+void videoout_reset_front() {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    g_display.front_index = -1;
+    g_display.front_generation = 0;
+}
+
+bool videoout_copy_buffer(const VideoOutBufferSnapshot& expected, std::vector<uint8_t>& out) {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    VideoOutBufferSnapshot current;
+    if (!videoout_buffer_snapshot_locked(expected.buffer_index, current) ||
+        current.generation != expected.generation) return false;
+    size_t bytes = 0;
+    if (!videoout_buffer_bytes(current, bytes)) return false;
+    out.resize(bytes);
+    std::memcpy(out.data(), reinterpret_cast<const void*>((uintptr_t)current.address), bytes);
+    return true;
+}
+
+bool videoout_copy_front_buffer(std::vector<uint8_t>& out, VideoOutBufferSnapshot& metadata) {
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    if (!videoout_front_snapshot_locked(metadata)) return false;
+    size_t bytes = 0;
+    if (!videoout_buffer_bytes(metadata, bytes)) return false;
+    out.resize(bytes);
+    std::memcpy(out.data(), reinterpret_cast<const void*>((uintptr_t)metadata.address), bytes);
+    return true;
+}
+
+size_t videoout_copy_front_buffer(void* dst, size_t dst_cap, VideoOutBufferSnapshot* metadata) {
+    if (!dst) return 0;
+    std::lock_guard<std::mutex> lk(g_display_mx);
+    VideoOutBufferSnapshot current;
+    if (!videoout_front_snapshot_locked(current)) return 0;
+    size_t bytes = 0;
+    if (!videoout_buffer_bytes(current, bytes) || dst_cap < bytes) return 0;
+    std::memcpy(dst, reinterpret_cast<const void*>((uintptr_t)current.address), bytes);
+    if (metadata) *metadata = current;
+    return bytes;
 }
 namespace { bool evlog() { static int v = getenv("PROSPER_EVLOG") ? 1 : 0; return v; } }
 // Implemented in hle_kernel_time.cpp (the equeue backend). Register a flip/vblank event source so the
@@ -334,6 +417,9 @@ HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a
     for (int i = 0; i < num; i++) {
         g_display.buffer_addr[start + i] = (uint64_t)(uintptr_t)bufs[i].data;
         g_display.buffer_set[start + i] = (uint8_t)(set + 1);
+        uint64_t generation = ++g_display.next_generation;
+        if (generation == 0) generation = ++g_display.next_generation;
+        g_display.buffer_generation[start + i] = generation;
     }
     if (g_display.buffer_num < start + num) g_display.buffer_num = start + num;
     g_display.configured = true;
@@ -358,8 +444,14 @@ HLE(g_vo_unregister_buffers) {
     for (int i = 0; i < 16; ++i) {
         if (g_display.buffer_set[i] != tag) continue;
         found = true;
+        if (g_display.front_index == i &&
+            g_display.front_generation == g_display.buffer_generation[i]) {
+            g_display.front_index = -1;
+            g_display.front_generation = 0;
+        }
         g_display.buffer_set[i] = 0;
         g_display.buffer_addr[i] = 0;
+        g_display.buffer_generation[i] = 0;
     }
     if (!found)
         return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -24,9 +24,10 @@ int main() {
 
     auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
+    auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
-    CHECK(setba2 && regb2 && flip, "VideoOut functions registered");
-    if (!(setba2 && regb2 && flip)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(setba2 && regb2 && unreg && flip, "VideoOut functions registered");
+    if (!(setba2 && regb2 && unreg && flip)) { printf("== FAIL ==\n"); return 1; }
 
     // A small surface so the test framebuffers are cheap: 16x8 BGRA (512 bytes each), triple-buffered.
     const uint32_t W = 16, H = 8;
@@ -93,6 +94,31 @@ int main() {
     CHECK(gpu::present_width() == SMALL_W && gpu::present_height() == SMALL_H &&
           got == SMALL_BYTES && small_out.front() == 0x66 && small_out.back() == 0x66,
           "set 1 flip reads its 4x2 buffer with matching geometry");
+
+    // Unregister invalidates the front identity under the same registry lock. Reusing the numeric
+    // slot receives a new generation and must not present its new backing until another guest flip.
+    CHECK(unreg(0x1001, 1 /*set*/, 0, 0, 0, 0) == 0 &&
+          gpu::present_front_index() == -1,
+          "unregistering the front set atomically clears the front identity");
+    std::vector<uint8_t> fb4_reused(SMALL_BYTES, 0x88), fb5_reused(SMALL_BYTES, 0x99);
+    VOB reused_buffers[2] = {
+        {fb4_reused.data(),0,{0,0}}, {fb5_reused.data(),0,{0,0}}
+    };
+    CHECK(regb2(0x1001, 1 /*same set*/, 4 /*same start*/,
+                (uint64_t)(uintptr_t)reused_buffers, 2,
+                (uint64_t)(uintptr_t)small_attr) == 0,
+          "re-registered the same slots with new backing");
+    std::fill(small_out.begin(), small_out.end(), 0xEE);
+    gpu::PresentSnapshot no_flip_snap;
+    CHECK(gpu::present_front_index() == -1 &&
+          gpu::present_readback(small_out.data(), small_out.size()) == 0 &&
+          !gpu::present_snapshot(no_flip_snap),
+          "re-registering a numeric slot does not present new backing without a flip");
+    flip(0x1001, 4, 0, 0, 0, 0);
+    got = gpu::present_readback(small_out.data(), small_out.size());
+    CHECK(got == SMALL_BYTES && small_out.front() == 0x88 && small_out.back() == 0x88,
+          "a new flip presents the re-registered generation");
+
     flip(0x1001, 1, 0, 0, 0, 0);
     std::fill(out.begin(), out.end(), 0xEE);
     got = gpu::present_readback(out.data(), out.size());

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -74,9 +74,35 @@ int main() {
           raw_snap.width == W && raw_snap.height == H && raw_snap.rgba[0] == 0x44,
           "raw snapshot identifies and copies the selected guest scanout");
 
+    // Register a second set with different dimensions. Flipping between the sets must select one
+    // coherent address + geometry snapshot; otherwise the raw copy would use the latest set's size
+    // with the older set's address (or vice versa).
+    const uint32_t SMALL_W = 4, SMALL_H = 2;
+    const size_t SMALL_BYTES = (size_t)SMALL_W * SMALL_H * 4;
+    std::vector<uint8_t> fb4(SMALL_BYTES, 0x66), fb5(SMALL_BYTES, 0x77);
+    uint8_t small_attr[0x50]; memset(small_attr, 0, sizeof small_attr);
+    setba2((uint64_t)(uintptr_t)small_attr, 0x8000000000000000ull,
+           0 /*tiling*/, SMALL_W, SMALL_H, 0 /*option*/);
+    VOB small_buffers[2] = { {fb4.data(),0,{0,0}}, {fb5.data(),0,{0,0}} };
+    rc = regb2(0x1001, 1 /*set*/, 4 /*start*/, (uint64_t)(uintptr_t)small_buffers, 2,
+               (uint64_t)(uintptr_t)small_attr);
+    CHECK(rc == 0, "registered a second 2-buffer 4x2 surface");
+    flip(0x1001, 4, 0, 0, 0, 0);
+    std::vector<uint8_t> small_out(SMALL_BYTES, 0xEE);
+    got = gpu::present_readback(small_out.data(), small_out.size());
+    CHECK(gpu::present_width() == SMALL_W && gpu::present_height() == SMALL_H &&
+          got == SMALL_BYTES && small_out.front() == 0x66 && small_out.back() == 0x66,
+          "set 1 flip reads its 4x2 buffer with matching geometry");
+    flip(0x1001, 1, 0, 0, 0, 0);
+    std::fill(out.begin(), out.end(), 0xEE);
+    got = gpu::present_readback(out.data(), out.size());
+    CHECK(gpu::present_width() == W && gpu::present_height() == H &&
+          got == FB_BYTES && out.front() == 0x22 && out.back() == 0x22,
+          "set 0 flip restores its 16x8 buffer with matching geometry");
+
     // Out-of-range flip index leaves the front buffer unchanged (but still counts as a flip).
     flip(0x1001, 99, 0, 0, 0, 0);
-    CHECK(gpu::present_front_index() == 2, "out-of-range flip index does not corrupt the front buffer");
+    CHECK(gpu::present_front_index() == 1, "out-of-range flip index does not corrupt the front buffer");
 
     // Receiving side: the renderer hands a finished frame -> present_readback returns THOSE pixels
     // (the real rendered frame), not the raw guest buffer. This is shader->render->present->readback.

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -3,6 +3,7 @@
 // (swapchain scaffolding) must record the surface the game set up. Drives the functions through the
 // NID registry exactly as the guest does, then asserts the reported display + recorded buffers.
 #include "../src/hle/dispatch.hpp"
+#include "../src/gpu/videoout_present.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
@@ -116,15 +117,26 @@ int main() {
     CHECK(prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
           prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2, "registry recorded each framebuffer address");
 
-    uint8_t fb1b[16], fb2b[16];
-    VOB offset_buffers[2] = { {fb1b,0,{0,0}}, {fb2b,0,{0,0}} };
-    rc = regb2(0x1001, 0, 1 /*start*/, (uint64_t)(uintptr_t)offset_buffers, 2, (uint64_t)(uintptr_t)attr);
-    CHECK(rc == 0, "RegisterBuffers2 accepted a non-zero buffer_index_start");
-    CHECK(prosper_vo_buffer_count() == 3, "registry exposes the highest registered buffer index");
-    CHECK(prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
-          prosper_vo_buffer_addr(1) == (uint64_t)(uintptr_t)fb1b &&
-          prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2b,
-          "registry records non-zero-start buffers at their absolute indices");
+    // A set identifier owns one registration until it is unregistered. Rejecting the duplicate
+    // must happen before any slot is changed, even when the proposed range itself is free.
+    uint8_t fb4a[16], fb5a[16];
+    VOB candidate_buffers[2] = { {fb4a,0,{0,0}}, {fb5a,0,{0,0}} };
+    rc = regb2(0x1001, 0 /*duplicate set*/, 4 /*free start*/,
+               (uint64_t)(uintptr_t)candidate_buffers, 2, (uint64_t)(uintptr_t)attr);
+    CHECK((uint32_t)rc == 0x8029000au,
+          "RegisterBuffers2 rejects a duplicate active set identifier");
+
+    // A different set may not claim any slot already owned by set 0. The whole range is validated
+    // before mutation, so this failure cannot replace either overlapping address or reserve set 1.
+    rc = regb2(0x1001, 1 /*new set*/, 1 /*occupied start*/,
+               (uint64_t)(uintptr_t)candidate_buffers, 2, (uint64_t)(uintptr_t)attr);
+    CHECK((uint32_t)rc == 0x80290010u,
+          "RegisterBuffers2 rejects slots owned by another active set");
+    CHECK(prosper_vo_buffer_count() == 3 &&
+          prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
+          prosper_vo_buffer_addr(1) == (uint64_t)(uintptr_t)fb1 &&
+          prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2,
+          "failed registrations leave all existing slots unchanged");
 
     uint8_t fs[0x40]; memset(fs, 0xEE, sizeof fs);
     CHECK(flip(0x1001, 2 /*buffer*/, 0 /*mode*/, 0x12345678 /*flipArg*/, 0, 0) == 0,
@@ -135,7 +147,7 @@ int main() {
     CHECK(*(int32_t*) (fs + 0x38) == 2, "flip status reports the submitted currentBuffer");
 
     // Range validation: out-of-range buffer counts are rejected.
-    CHECK(regb2(0x1001, 0, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,
+    CHECK(regb2(0x1001, 2, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,
           "RegisterBuffers2 rejects an out-of-range buffer_num");
 
     CHECK((uint32_t)unreg(0x1001, 3 /*unregistered set*/, 0, 0, 0, 0) == 0x8029000au,
@@ -143,14 +155,8 @@ int main() {
     CHECK(prosper_vo_buffer_count() == 3 &&
               prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0,
           "failed unregistration preserves the active buffer set");
-    CHECK(unreg(0x1001, 0 /*set*/, 0, 0, 0, 0) == 0,
-          "UnregisterBuffers releases the active set");
-    CHECK(prosper_vo_buffer_count() == 0 && prosper_vo_buffer_addr(0) == 0 &&
-              prosper_vo_display_width() == 0 && prosper_vo_display_height() == 0,
-          "releasing the last set clears the display registration");
-
-    rc = regb2(0x1001, 0 /*set*/, 0 /*start*/, (uint64_t)(uintptr_t)buffers, 3,
-               (uint64_t)(uintptr_t)attr);
+    // A second set at a non-zero start is valid. Give it different geometry so flips can prove the
+    // present path takes dimensions from the selected buffer's owning set, not the latest global.
     uint8_t high_attr[0x50];
     memcpy(high_attr, attr, sizeof high_attr);
     *(uint32_t*)(high_attr + 0x0c) = 1280;
@@ -160,18 +166,28 @@ int main() {
     uint64_t high_rc = regb2(0x1001, 1 /*set*/, 4 /*start*/,
                              (uint64_t)(uintptr_t)high_buffers, 2,
                              (uint64_t)(uintptr_t)high_attr);
-    CHECK(rc == 0 && high_rc == 0 && prosper_vo_buffer_count() == 6 &&
+    CHECK(high_rc == 0 && prosper_vo_buffer_count() == 6 &&
               prosper_vo_display_width() == 1280 && prosper_vo_display_height() == 720,
           "registry tracks two independently owned buffer sets");
+    flip(0x1001, 2 /*set 0 buffer*/, 0, 0, 0, 0);
+    CHECK(gpu::present_width() == 1920 && gpu::present_height() == 1080,
+          "present uses set 0 geometry when an older set's buffer is flipped");
+    flip(0x1001, 4 /*set 1 buffer*/, 0, 0, 0, 0);
+    CHECK(gpu::present_width() == 1280 && gpu::present_height() == 720,
+          "present uses set 1 geometry when its buffer is flipped");
     CHECK(unreg(0x1001, 1 /*set*/, 0, 0, 0, 0) == 0 &&
               prosper_vo_buffer_count() == 3 &&
               prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
               prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2 &&
               prosper_vo_display_width() == 1920 && prosper_vo_display_height() == 1080,
           "unregistering one set restores the remaining set's range and geometry");
+    flip(0x1001, 2 /*remaining set 0 buffer*/, 0, 0, 0, 0);
+    CHECK(gpu::present_width() == 1920 && gpu::present_height() == 1080,
+          "present continues with the surviving set after unregister");
     CHECK(unreg(0x1001, 0 /*set*/, 0, 0, 0, 0) == 0 &&
-              prosper_vo_buffer_count() == 0,
-          "unregistering the remaining set clears the registry");
+              prosper_vo_buffer_count() == 0 && prosper_vo_buffer_addr(0) == 0 &&
+              prosper_vo_display_width() == 0 && prosper_vo_display_height() == 0,
+          "unregistering the remaining set clears the registry and geometry");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -31,11 +31,15 @@ int main() {
     auto issup  = Hle::lookup("Nv8c-Kb+DUM");   // IsOutputSupported
     auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
+    auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto cfg    = Hle::lookup("w0hLuNarQxY");   // ConfigureOutput
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
     auto fstat  = Hle::lookup(nid_hash("sceVideoOutGetFlipStatus"));
-    CHECK(res && vbl && cap && issup && setba2 && regb2 && cfg && flip && fstat, "VideoOut functions registered");
-    if (!(res && vbl && cap && issup && setba2 && regb2 && cfg && flip && fstat)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(res && vbl && cap && issup && setba2 && regb2 && unreg && cfg && flip && fstat,
+          "VideoOut functions registered");
+    if (!(res && vbl && cap && issup && setba2 && regb2 && unreg && cfg && flip && fstat)) {
+        printf("== FAIL ==\n"); return 1;
+    }
 
     // #394 F3: before any completed flip, -1 is the ABI's "none yet" sentinel for both the argument
     // and current buffer. Zero is valid and used to make a frame pacer advance prematurely.
@@ -133,6 +137,41 @@ int main() {
     // Range validation: out-of-range buffer counts are rejected.
     CHECK(regb2(0x1001, 0, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,
           "RegisterBuffers2 rejects an out-of-range buffer_num");
+
+    CHECK((uint32_t)unreg(0x1001, 3 /*unregistered set*/, 0, 0, 0, 0) == 0x8029000au,
+          "UnregisterBuffers rejects an absent set without changing registration");
+    CHECK(prosper_vo_buffer_count() == 3 &&
+              prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0,
+          "failed unregistration preserves the active buffer set");
+    CHECK(unreg(0x1001, 0 /*set*/, 0, 0, 0, 0) == 0,
+          "UnregisterBuffers releases the active set");
+    CHECK(prosper_vo_buffer_count() == 0 && prosper_vo_buffer_addr(0) == 0 &&
+              prosper_vo_display_width() == 0 && prosper_vo_display_height() == 0,
+          "releasing the last set clears the display registration");
+
+    rc = regb2(0x1001, 0 /*set*/, 0 /*start*/, (uint64_t)(uintptr_t)buffers, 3,
+               (uint64_t)(uintptr_t)attr);
+    uint8_t high_attr[0x50];
+    memcpy(high_attr, attr, sizeof high_attr);
+    *(uint32_t*)(high_attr + 0x0c) = 1280;
+    *(uint32_t*)(high_attr + 0x10) = 720;
+    uint8_t fb4[16], fb5[16];
+    VOB high_buffers[2] = { {fb4,0,{0,0}}, {fb5,0,{0,0}} };
+    uint64_t high_rc = regb2(0x1001, 1 /*set*/, 4 /*start*/,
+                             (uint64_t)(uintptr_t)high_buffers, 2,
+                             (uint64_t)(uintptr_t)high_attr);
+    CHECK(rc == 0 && high_rc == 0 && prosper_vo_buffer_count() == 6 &&
+              prosper_vo_display_width() == 1280 && prosper_vo_display_height() == 720,
+          "registry tracks two independently owned buffer sets");
+    CHECK(unreg(0x1001, 1 /*set*/, 0, 0, 0, 0) == 0 &&
+              prosper_vo_buffer_count() == 3 &&
+              prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
+              prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2 &&
+              prosper_vo_display_width() == 1920 && prosper_vo_display_height() == 1080,
+          "unregistering one set restores the remaining set's range and geometry");
+    CHECK(unreg(0x1001, 0 /*set*/, 0, 0, 0, 0) == 0 &&
+              prosper_vo_buffer_count() == 0,
+          "unregistering the remaining set clears the registry");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary
- implement `sceVideoOutUnregisterBuffers` instead of falling through to unimplemented success
- retain per-slot set ownership and per-set display metadata so removing one set preserves the others
- clear the display configuration when the final set is released and return `SCE_VIDEO_OUT_ERROR_INVALID_INDEX` for absent sets

## Scope
This addresses only body F3 (`sceVideoOutUnregisterBuffers`) of #394. Other VideoOut findings remain open.

## Focused checks
- Linux/WSL `videoout_queries`: passed, including absent-set, last-set, and two-set geometry/range cases
- Windows `prosper_core`: compiled
- No snapshots run: this changes HLE registration bookkeeping, not rendering output

Refs #394