### PR TITLE
audio: build AJM batch jobs

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -33,6 +33,12 @@ namespace prosper {
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
+#define HLE8(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6, \
+                                       uint64_t a7)
+#define HLE10(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6, \
+                                       uint64_t a7, uint64_t a8, uint64_t a9)
 #define P(x) ((void*)(uintptr_t)(x))
 
 namespace {
@@ -504,7 +510,83 @@ namespace {
     // matching the AudioOut error constants above rather than leaving the upper half zeroed.
     constexpr uint64_t AJM_ERR_INVALID_CONTEXT   = (uint64_t)(int64_t)(int32_t)0x80930002u;
     constexpr uint64_t AJM_ERR_INVALID_INSTANCE  = (uint64_t)(int64_t)(int32_t)0x80930003u;
+    constexpr uint64_t AJM_ERR_INVALID_BATCH     = (uint64_t)(int64_t)(int32_t)0x80930004u;
     constexpr uint64_t AJM_ERR_INVALID_PARAMETER = (uint64_t)(int64_t)(int32_t)0x80930005u;
+
+    // The four pointer-returning builder exports serialize a batch from 8/16-byte chunks. These
+    // layout values are shared by Sony's PS4-inherited AJM ABI and the PS5 3.20 export surface.
+    enum : uint32_t {
+        AJM_IDENT_JOB = 0,
+        AJM_IDENT_INPUT_RUN = 1,
+        AJM_IDENT_INPUT_CONTROL = 2,
+        AJM_IDENT_CONTROL_FLAGS = 3,
+        AJM_IDENT_RUN_FLAGS = 4,
+        AJM_IDENT_RETURN_ADDRESS = 6,
+        AJM_IDENT_INLINE = 7,
+        AJM_IDENT_OUTPUT_RUN = 17,
+        AJM_IDENT_OUTPUT_CONTROL = 18,
+    };
+    constexpr uint32_t AJM_INSTANCE_STATISTICS = 0x80000;
+    constexpr uint64_t AJM_CONTROL_FLAGS_MASK = 0x000060000000e7ffull;
+    constexpr uint64_t AJM_STATISTICS_FLAGS_MASK = 0x00000000c0018007ull;
+    constexpr uint64_t AJM_RUN_FLAGS_MASK = 0x0000e00000001fffull;
+    constexpr size_t AJM_MAX_BUILDER_BYTES = 64u * 1024u * 1024u;
+
+    struct AjmJobChunk {
+        uint32_t header;
+        uint32_t size;
+    };
+    struct AjmFlagsChunk {
+        uint32_t header;
+        uint32_t flags_low;
+    };
+    struct AjmBufferChunk {
+        uint32_t header;
+        uint32_t size;
+        uint64_t address;
+    };
+    struct AjmGuestBuffer {
+        uint64_t address;
+        uint64_t size;
+    };
+    static_assert(sizeof(AjmJobChunk) == 8);
+    static_assert(sizeof(AjmFlagsChunk) == 8);
+    static_assert(sizeof(AjmBufferChunk) == 16);
+    static_assert(sizeof(AjmGuestBuffer) == 16);
+
+    uint32_t ajm_chunk_header(uint32_t ident, uint32_t payload = 0) {
+        return (ident & 0x3fu) | ((payload & 0xfffffu) << 6u);
+    }
+
+    template <typename T>
+    void ajm_append(std::vector<uint8_t>& bytes, const T& value) {
+        const size_t offset = bytes.size();
+        bytes.resize(offset + sizeof(value));
+        std::memcpy(bytes.data() + offset, &value, sizeof(value));
+    }
+
+    void ajm_append_buffer(std::vector<uint8_t>& bytes, uint32_t ident,
+                           uint64_t address, uint32_t size) {
+        ajm_append(bytes, AjmBufferChunk{ajm_chunk_header(ident), size, address});
+    }
+
+    void ajm_append_flags(std::vector<uint8_t>& bytes, uint32_t ident, uint64_t flags) {
+        ajm_append(bytes, AjmFlagsChunk{ajm_chunk_header(ident, (uint32_t)(flags >> 32)),
+                                        (uint32_t)flags});
+    }
+
+    uint64_t ajm_write_job(uint64_t destination, uint32_t instance,
+                           const std::vector<uint8_t>& payload) {
+        if (!destination || payload.size() > UINT32_MAX ||
+            payload.size() + sizeof(AjmJobChunk) > AJM_MAX_BUILDER_BYTES) return 0;
+        std::vector<uint8_t> job;
+        job.reserve(sizeof(AjmJobChunk) + payload.size());
+        ajm_append(job, AjmJobChunk{ajm_chunk_header(AJM_IDENT_JOB, instance),
+                                    (uint32_t)payload.size()});
+        job.insert(job.end(), payload.begin(), payload.end());
+        return audio_store_bytes(destination, job.data(), job.size())
+            ? destination + job.size() : 0;
+    }
 }
 // sceAjmInitialize(s64 reserved, u32* out_context): create a context. Filling out_context is the point.
 HLE(ajm_initialize) {
@@ -539,7 +621,82 @@ HLE(ajm_batch_start) {
     return 0;
 }
 HLE(ajm_batch_wait)       { return a0 ? 0 : AJM_ERR_INVALID_CONTEXT; }   // batch completed
+HLE(ajm_batch_cancel) {
+    if (!a0) return AJM_ERR_INVALID_CONTEXT;
+    if (!a1) return AJM_ERR_INVALID_BATCH;
+    return 0;
+}
 HLE(ajm_batch_errordump)  { return 0; }
+
+// Build one control job and return the next free byte in the caller's batch buffer. Returning zero
+// here is not a harmless stub result: the guest chains the returned cursor into its next builder.
+HLE8(ajm_batch_job_control_buffer_ra) {
+    if (a4 > UINT32_MAX || a6 > UINT32_MAX) return 0;
+    std::vector<uint8_t> payload;
+    payload.reserve(a7 ? 56 : 40);
+    if (a7) ajm_append_buffer(payload, AJM_IDENT_RETURN_ADDRESS, a7, 0);
+    ajm_append_buffer(payload, AJM_IDENT_INPUT_CONTROL, a3, (uint32_t)a4);
+    const uint64_t mask = (uint32_t)a1 == AJM_INSTANCE_STATISTICS
+        ? AJM_STATISTICS_FLAGS_MASK : AJM_CONTROL_FLAGS_MASK;
+    ajm_append_flags(payload, AJM_IDENT_CONTROL_FLAGS, a2 & mask);
+    ajm_append_buffer(payload, AJM_IDENT_OUTPUT_CONTROL, a5, (uint32_t)a6);
+    return ajm_write_job(a0, (uint32_t)a1, payload);
+}
+
+// Store caller data inline after an AJM inline header. The reported batch address points at the
+// copied payload; the next cursor is rounded up to AJM's required 8-byte boundary.
+HLE(ajm_batch_job_inline_buffer) {
+    if (!a0 || !a3 || a2 > UINT32_MAX || a2 > AJM_MAX_BUILDER_BYTES - sizeof(AjmJobChunk))
+        return 0;
+    const size_t data_size = (size_t)a2;
+    const size_t aligned_size = (data_size + 7u) & ~size_t{7u};
+    std::vector<uint8_t> bytes(sizeof(AjmJobChunk) + aligned_size, 0);
+    const AjmJobChunk header{ajm_chunk_header(AJM_IDENT_INLINE), (uint32_t)aligned_size};
+    std::memcpy(bytes.data(), &header, sizeof(header));
+    if (data_size && !audio_read_bytes(a1, bytes.data() + sizeof(header), data_size)) return 0;
+    if (!audio_store_bytes(a0, bytes.data(), bytes.size()) ||
+        !a2_store_u64(a3, a0 + sizeof(AjmJobChunk))) return 0;
+    return a0 + bytes.size();
+}
+
+HLE10(ajm_batch_job_run_buffer_ra) {
+    if (a4 > UINT32_MAX || a6 > UINT32_MAX || a8 > UINT32_MAX) return 0;
+    std::vector<uint8_t> payload;
+    payload.reserve(a9 ? 72 : 56);
+    if (a9) ajm_append_buffer(payload, AJM_IDENT_RETURN_ADDRESS, a9, 0);
+    ajm_append_buffer(payload, AJM_IDENT_INPUT_RUN, a3, (uint32_t)a4);
+    ajm_append_flags(payload, AJM_IDENT_RUN_FLAGS, a2 & AJM_RUN_FLAGS_MASK);
+    ajm_append_buffer(payload, AJM_IDENT_OUTPUT_RUN, a5, (uint32_t)a6);
+    ajm_append_buffer(payload, AJM_IDENT_OUTPUT_CONTROL, a7, (uint32_t)a8);
+    return ajm_write_job(a0, (uint32_t)a1, payload);
+}
+
+HLE10(ajm_batch_job_run_split_buffer_ra) {
+    if (a4 > UINT32_MAX || a6 > UINT32_MAX || a8 > UINT32_MAX) return 0;
+    const uint64_t chunk_count = a4 + a6 + 2u + (a9 ? 1u : 0u);
+    if (chunk_count > (AJM_MAX_BUILDER_BYTES - sizeof(AjmJobChunk)) /
+                      sizeof(AjmBufferChunk)) return 0;
+    if ((a4 && !a3) || (a6 && !a5)) return 0;
+
+    std::vector<uint8_t> payload;
+    payload.reserve((size_t)chunk_count * sizeof(AjmBufferChunk));
+    if (a9) ajm_append_buffer(payload, AJM_IDENT_RETURN_ADDRESS, a9, 0);
+    for (uint64_t i = 0; i < a4; ++i) {
+        AjmGuestBuffer buffer{};
+        if (!audio_read_bytes(a3 + i * sizeof(buffer), &buffer, sizeof(buffer)) ||
+            buffer.size > UINT32_MAX) return 0;
+        ajm_append_buffer(payload, AJM_IDENT_INPUT_RUN, buffer.address, (uint32_t)buffer.size);
+    }
+    ajm_append_flags(payload, AJM_IDENT_RUN_FLAGS, a2 & AJM_RUN_FLAGS_MASK);
+    for (uint64_t i = 0; i < a6; ++i) {
+        AjmGuestBuffer buffer{};
+        if (!audio_read_bytes(a5 + i * sizeof(buffer), &buffer, sizeof(buffer)) ||
+            buffer.size > UINT32_MAX) return 0;
+        ajm_append_buffer(payload, AJM_IDENT_OUTPUT_RUN, buffer.address, (uint32_t)buffer.size);
+    }
+    ajm_append_buffer(payload, AJM_IDENT_OUTPUT_CONTROL, a7, (uint32_t)a8);
+    return ajm_write_job(a0, (uint32_t)a1, payload);
+}
 
 // --- libSceNgs2 silent lifecycle ---------------------------------------------------------------
 // Dead Cells is the first title to exercise NGS2. PROSPER_NGS2_TRACE preserves and logs all six
@@ -783,6 +940,11 @@ void register_audio_hle() {
     R("sceAjmModuleRegister", ajm_module_register);   R("sceAjmModuleUnregister", ajm_module_unregister);
     R("sceAjmInstanceCreate", ajm_instance_create);   R("sceAjmInstanceDestroy", ajm_instance_destroy);
     R("sceAjmBatchStartBuffer", ajm_batch_start);     R("sceAjmBatchWait", ajm_batch_wait);
+    R("sceAjmBatchCancel", ajm_batch_cancel);
+    R("sceAjmBatchJobControlBufferRa", ajm_batch_job_control_buffer_ra);
+    R("sceAjmBatchJobInlineBuffer", ajm_batch_job_inline_buffer);
+    R("sceAjmBatchJobRunBufferRa", ajm_batch_job_run_buffer_ra);
+    R("sceAjmBatchJobRunSplitBufferRa", ajm_batch_job_run_split_buffer_ra);
     R("sceAjmBatchErrorDump", ajm_batch_errordump);
     Hle::register_fn("pgFAiLR5qT4", ngs2_system_query_buffer, "sceNgs2SystemQueryBufferSize");
     Hle::register_fn("koBbCMvOKWw", ngs2_system_create, "sceNgs2SystemCreate");

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1755,44 +1755,42 @@ namespace {
     // it checks a magic at [fs+0x108] that marks OUR guest TCB (guest_tls.cpp). If present (guest thread),
     // it swaps %fs to the stashed host TCB [fs+0x100] for the handler call, then restores the guest %fs.
     // If absent (a host-context thread, or the main thread during pre-entry init), it just tail-calls the
-    // handler on the current fs — exactly the old behavior. Uses FSGSBASE. Clobbers only rax/r11 (never
-    // the arg regs rdi..r9).
+    // handler on the current fs — exactly the old behavior. Uses FSGSBASE. Clobbers only
+    // caller-saved rax/r10/r11 (never the argument registers rdi..r9).
     //
     // STACK-ARG FORWARDING: the guest path interposes a call between the guest caller and handler.
-    // Re-push args 9,8,7 so fixed-arity handlers receive the normal SysV layout ([rsp+8]=arg7,
-    // [rsp+16]=arg8, [rsp+24]=arg9). The saved r11 plus an 8-byte pad remain behind those arguments.
-    // Alignment: entry rsp is 8 mod 16; five qwords of storage make the call site 0 mod 16 and the
-    // handler entry 8 mod 16. Keep offsets/magic in sync with guest_tls.cpp.
+    // Re-push args 10,9,8,7 so fixed-arity handlers receive the normal SysV layout ([rsp+8]=arg7
+    // through [rsp+32]=arg10). Saved r11 remains behind those arguments. Alignment: entry rsp is
+    // 8 mod 16; five qwords of storage make the call site 0 mod 16 and the handler entry 8 mod 16.
+    // Keep offsets/magic in sync with guest_tls.cpp.
     size_t emit_swap_stub(uint8_t* p, uint32_t idx, uint64_t fn, bool unimpl) {
         uint8_t* s = p;
-        auto mid = [&](uint8_t*& q) {   // per-variant: unimpl loads its slot index into edi first
-            if (unimpl) { *q++ = 0xBF; memcpy(q, &idx, 4); q += 4; }         // mov edi, idx
-            *q++ = 0x48; *q++ = 0xB8; memcpy(q, &fn, 8); q += 8;            // movabs rax, fn
-        };
+        // Keep the target in caller-saved r10 across the FS probe/swap. Loading it once avoids
+        // duplicating a movabs in both branches and leaves room for the fourth guest stack arg.
+        if (unimpl) { *p++ = 0xBF; memcpy(p, &idx, 4); p += 4; }             // mov edi, idx
+        *p++ = 0x49; *p++ = 0xBA; memcpy(p, &fn, 8); p += 8;                // movabs r10, fn
         // rdfsbase r11 ; cmp dword [r11+0x108], MAGIC ; jne .host
         *p++=0xF3; *p++=0x49; *p++=0x0F; *p++=0xAE; *p++=0xC3;
         *p++=0x41; *p++=0x81; *p++=0xBB; uint32_t mo=0x108; memcpy(p,&mo,4); p+=4;
         uint32_t magic=0x50524F53u; memcpy(p,&magic,4); p+=4;
         *p++=0x75; uint8_t* jne_rel = p++;                                  // jne rel8 (patched below)
-        // .guest: push r11 ; push rax (alignment pad) ; push [rsp+0x28] (arg9/8/7) x3 ; mov rax,[r11+0x100] ;
-        //         wrfsbase rax ; <mid> ; call rax ; add rsp,0x20 ; pop r11 ; wrfsbase r11 ; ret
-        *p++=0x41; *p++=0x53;
-        *p++=0x50;                                                          // push rax (alignment pad)
+        // .guest: save r11, then re-push original args 10/9/8/7. Each source remains at rsp+0x28
+        // as the stack moves. Five qwords put the handler call site at the required alignment.
+        *p++=0x41; *p++=0x53;                                               // push r11
+        *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg10
         *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg9
         *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg8
         *p++=0xFF; *p++=0x74; *p++=0x24; *p++=0x28;                         // push original arg7
         *p++=0x49; *p++=0x8B; *p++=0x83; uint32_t ho=0x100; memcpy(p,&ho,4); p+=4;
-        *p++=0xF3; *p++=0x48; *p++=0x0F; *p++=0xAE; *p++=0xD0;
-        mid(p);
-        *p++=0xFF; *p++=0xD0;                                               // call rax
-        *p++=0x48; *p++=0x83; *p++=0xC4; *p++=0x20;                         // discard arg copies + pad
+        *p++=0xF3; *p++=0x48; *p++=0x0F; *p++=0xAE; *p++=0xD0;              // wrfsbase host FS
+        *p++=0x41; *p++=0xFF; *p++=0xD2;                                    // call r10
+        *p++=0x48; *p++=0x83; *p++=0xC4; *p++=0x20;                         // discard arg copies
         *p++=0x41; *p++=0x5B;                                               // pop r11
-        *p++=0xF3; *p++=0x49; *p++=0x0F; *p++=0xAE; *p++=0xD3;              // wrfsbase r11
+        *p++=0xF3; *p++=0x49; *p++=0x0F; *p++=0xAE; *p++=0xD3;              // restore guest FS
         *p++=0xC3;                                                          // ret
-        // .host: <mid> ; jmp rax   (host-context: no swap, tail-call as before)
+        // .host: no FS swap is needed; tail-call the already loaded target.
         *jne_rel = (uint8_t)(p - (jne_rel + 1));
-        mid(p);
-        *p++=0xFF; *p++=0xE0;                                               // jmp rax
+        *p++=0x41; *p++=0xFF; *p++=0xE2;                                    // jmp r10
         return static_cast<size_t>(p - s);
     }
     size_t emit_impl_swap(uint8_t* p, uint64_t fn)                 { return emit_swap_stub(p, 0,   fn, false); }

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -258,21 +258,21 @@ namespace {
     // Import-stub machine code. Unlike Linux (where host ABI == guest SysV, so the stub is a bare
     // tail-jump with args intact), Windows handlers are Microsoft x64, so the stub is a TRAMPOLINE
     // that converts the guest's SysV integer arguments to MS x64 before calling the handler:
-    //   SysV in: rdi rsi rdx rcx r8 r9 [guest rsp+8] [guest rsp+16] [guest rsp+24] (a0..a8)
-    //   MS out:  rcx rdx r8 r9 [rsp+20]...[rsp+40] (+32B shadow, stack args a4..a8)
+    //   SysV in: rdi rsi rdx rcx r8 r9 [guest rsp+8]...[guest rsp+32] (a0..a9)
+    //   MS out:  rcx rdx r8 r9 [rsp+20]...[rsp+48] (+32B shadow, stack args a4..a9)
     // Return value is rax in both ABIs. This handles integer/pointer args (the whole HleFn surface);
     // XMM/float args (e.g. some libc formatters) are NOT converted yet — see docs/PORTING.md.
-    // The 0x48-byte outgoing area is 8 mod 16, so a normally-entered stub (RSP%16==8) has the required
-    // RSP%16==0 at its handler call site. The ABI conformance test verifies args 1-9 and alignment.
+    // The pad + four copied guest stack args + 0x30-byte outgoing area consume 0x58 bytes (8 mod 16),
+    // so a normally-entered stub (RSP%16==8) has RSP%16==0 at its handler call site. The ABI
+    // conformance test verifies args 1-10 and alignment.
     size_t emit_sysv_to_ms_prologue(uint8_t* p) {
         static const uint8_t seq[] = {
-            0x48,0x83,0xEC,0x48,              // sub rsp,0x48   (shadow + a4..a8; call rsp%16==0)
-            0x48,0x8B,0x44,0x24,0x50,         // mov rax,[rsp+0x50]   ; guest a6 at original rsp+8
-            0x48,0x89,0x44,0x24,0x30,         // mov [rsp+0x30],rax  ; MS 7th arg = a6
-            0x48,0x8B,0x44,0x24,0x58,         // mov rax,[rsp+0x58]   ; guest a7 at original rsp+16
-            0x48,0x89,0x44,0x24,0x38,         // mov [rsp+0x38],rax  ; MS 8th arg = a7
-            0x48,0x8B,0x44,0x24,0x60,         // mov rax,[rsp+0x60]   ; guest a8 at original rsp+24
-            0x48,0x89,0x44,0x24,0x40,         // mov [rsp+0x40],rax  ; MS 9th arg = a8
+            0x50,                              // push rax             ; alignment pad
+            0xFF,0x74,0x24,0x28,              // push [rsp+0x28]      ; original guest a9
+            0xFF,0x74,0x24,0x28,              // push [rsp+0x28]      ; original guest a8
+            0xFF,0x74,0x24,0x28,              // push [rsp+0x28]      ; original guest a7
+            0xFF,0x74,0x24,0x28,              // push [rsp+0x28]      ; original guest a6
+            0x48,0x83,0xEC,0x30,              // sub rsp,0x30         ; shadow + a4/a5
             0x4C,0x89,0x44,0x24,0x20,         // mov [rsp+0x20],r8    ; MS 5th arg = a4
             0x4C,0x89,0x4C,0x24,0x28,         // mov [rsp+0x28],r9    ; MS 6th arg = a5
             0x49,0x89,0xC9,                   // mov r9,rcx           ; MS 4th = a3  (save before rcx clobbered)
@@ -299,7 +299,7 @@ namespace {
         p[o++] = 0x48; p[o++] = 0xB8; memcpy(p + o, &fn, 8); o += 8;   // movabs rax,fn
         p[o++] = 0xFF; p[o++] = 0xD0;                                  // call rax
         o += emit_hle_return_checkpoint(p + o);
-        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x48;    // add rsp,0x48
+        p[o++] = 0x48; p[o++] = 0x83; p[o++] = 0xC4; p[o++] = 0x58;    // discard outgoing args + pad
         p[o++] = 0xC3;                                                 // ret
     }
     void emit_unimpl(uint8_t* p, uint32_t idx, uint64_t fn) {
@@ -1111,9 +1111,9 @@ uint64_t hle_guest_return_address(uint64_t entry_rsp) {
     const uint64_t immediate = *(const uint64_t*)(uintptr_t)entry_rsp;
     const bool from_stub = g_stub_size && immediate >= g_stub_base &&
                            (immediate - g_stub_base) / g_stub_size < g_nstubs;
-    // The SysV-to-MS bridge reserves 0x48 bytes and CALLS the HLE handler. Including that call's
-    // return slot, the original guest return address is 0x50 bytes above the handler-entry RSP.
-    if (from_stub) return *(const uint64_t*)(uintptr_t)(entry_rsp + 0x50);
+    // The SysV-to-MS bridge consumes 0x58 bytes and CALLS the HLE handler. Including that call's
+    // return slot, the original guest return address is 0x60 bytes above the handler-entry RSP.
+    if (from_stub) return *(const uint64_t*)(uintptr_t)(entry_rsp + 0x60);
     return immediate;
 }
 uint64_t invoke_stub(uint64_t idx) {

--- a/prosper/tests/test_ajm.cpp
+++ b/prosper/tests/test_ajm.cpp
@@ -7,6 +7,7 @@
 #include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 
 using namespace prosper;
 
@@ -16,7 +17,30 @@ static int fails = 0;
 
 static constexpr uint64_t kInvalidContext   = 0xffffffff80930002ull;
 static constexpr uint64_t kInvalidInstance  = 0xffffffff80930003ull;
+static constexpr uint64_t kInvalidBatch     = 0xffffffff80930004ull;
 static constexpr uint64_t kInvalidParameter = 0xffffffff80930005ull;
+
+using Hle8Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t);
+using Hle10Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                             uint64_t, uint64_t, uint64_t, uint64_t);
+
+struct JobChunk { uint32_t header, size; };
+struct FlagsChunk { uint32_t header, flags_low; };
+struct BufferChunk { uint32_t header, size; uint64_t address; };
+struct GuestBuffer { uint64_t address, size; };
+static_assert(sizeof(JobChunk) == 8 && sizeof(FlagsChunk) == 8 &&
+              sizeof(BufferChunk) == 16 && sizeof(GuestBuffer) == 16);
+
+static uint32_t ident(uint32_t header) { return header & 0x3f; }
+static uint32_t payload(uint32_t header) { return (header >> 6) & 0xfffff; }
+
+template <typename T>
+static T chunk_at(const uint8_t* bytes, size_t offset) {
+    T value{};
+    std::memcpy(&value, bytes + offset, sizeof(value));
+    return value;
+}
 
 int main() {
     printf("== test_ajm ==\n");
@@ -25,6 +49,12 @@ int main() {
     // The names must hash to the game's import NIDs (#187 table), else R() registers under the wrong key.
     CHECK(nid_hash("sceAjmInitialize") == "dl+4eHSzUu4", "sceAjmInitialize hashes to its import NID");
     CHECK(nid_hash("sceAjmModuleRegister") == "Q3dyFuwGn64", "sceAjmModuleRegister hashes to its import NID");
+    CHECK(nid_hash("sceAjmBatchCancel") == "NVDXiUesSbA" &&
+          nid_hash("sceAjmBatchJobControlBufferRa") == "dmDybN--Fn8" &&
+          nid_hash("sceAjmBatchJobInlineBuffer") == "stlghnic3Jc" &&
+          nid_hash("sceAjmBatchJobRunBufferRa") == "ElslOCpOIns" &&
+          nid_hash("sceAjmBatchJobRunSplitBufferRa") == "7jdAXK+2fMo",
+          "AJM cancel/cursor builders hash to the PS5 3.20 import NIDs");
 
     HleFn init = Hle::lookup(nid_hash("sceAjmInitialize"));
     HleFn modreg = Hle::lookup(nid_hash("sceAjmModuleRegister"));
@@ -32,9 +62,19 @@ int main() {
     HleFn idestroy = Hle::lookup(nid_hash("sceAjmInstanceDestroy"));
     HleFn bstart = Hle::lookup(nid_hash("sceAjmBatchStartBuffer"));
     HleFn bwait = Hle::lookup(nid_hash("sceAjmBatchWait"));
+    HleFn bcancel = Hle::lookup(nid_hash("sceAjmBatchCancel"));
+    auto control = reinterpret_cast<Hle8Fn>(
+        Hle::lookup(nid_hash("sceAjmBatchJobControlBufferRa")));
+    HleFn inline_buffer = Hle::lookup(nid_hash("sceAjmBatchJobInlineBuffer"));
+    auto run = reinterpret_cast<Hle10Fn>(
+        Hle::lookup(nid_hash("sceAjmBatchJobRunBufferRa")));
+    auto run_split = reinterpret_cast<Hle10Fn>(
+        Hle::lookup(nid_hash("sceAjmBatchJobRunSplitBufferRa")));
     HleFn fin = Hle::lookup(nid_hash("sceAjmFinalize"));
-    CHECK(init && modreg && icreate && idestroy && bstart && bwait && fin, "AJM functions registered");
-    if (!(init && modreg && icreate && idestroy && bstart && bwait && fin)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(init && modreg && icreate && idestroy && bstart && bwait && bcancel && control &&
+          inline_buffer && run && run_split && fin, "AJM functions registered");
+    if (!(init && modreg && icreate && idestroy && bstart && bwait && bcancel && control &&
+          inline_buffer && run && run_split && fin)) { printf("== FAIL ==\n"); return 1; }
 
     // Initialize fills a valid (non-zero) context handle.
     uint32_t ctx = 0xDEAD;
@@ -68,6 +108,101 @@ int main() {
     CHECK(bstart(ctx, 0, 0, 0, 0, 1) == kInvalidParameter,
           "BatchStartBuffer(inaccessible out) -> INVALID_PARAMETER without host fault");
     CHECK(bwait(ctx, batch, 0, 0, 0, 0) == 0, "sceAjmBatchWait -> OK (batch completed)");
+    CHECK(bcancel(ctx, batch, 0, 0, 0, 0) == 0, "sceAjmBatchCancel accepts a valid batch handle");
+    CHECK(bcancel(0, batch, 0, 0, 0, 0) == kInvalidContext,
+          "sceAjmBatchCancel rejects context 0");
+    CHECK(bcancel(ctx, 0, 0, 0, 0, 0) == kInvalidBatch,
+          "sceAjmBatchCancel rejects batch 0");
+
+    // The guest chains each builder's returned write cursor. Exercise byte-exact chunks, including
+    // the return-address and flag fields that live past the first six register arguments.
+    alignas(8) uint8_t job[256];
+    std::memset(job, 0xEE, sizeof job);
+    const uint64_t base = (uint64_t)(uintptr_t)job;
+    const uint64_t input_addr = 0x1111222233334444ull;
+    const uint64_t output_addr = 0x5555666677778888ull;
+    const uint64_t sideband_addr = 0x9999aaaabbbbccccull;
+    const uint64_t return_addr = 0xddddeeeeffff0000ull;
+    uint64_t cursor = control(base, 0x12345, ~uint64_t{0}, input_addr, 0x21,
+                              sideband_addr, 0x32, return_addr);
+    const JobChunk control_job = chunk_at<JobChunk>(job, 0);
+    const BufferChunk control_ra = chunk_at<BufferChunk>(job, 8);
+    const BufferChunk control_in = chunk_at<BufferChunk>(job, 24);
+    const FlagsChunk control_flags = chunk_at<FlagsChunk>(job, 40);
+    const BufferChunk control_out = chunk_at<BufferChunk>(job, 48);
+    CHECK(cursor == base + 64 && ident(control_job.header) == 0 &&
+          payload(control_job.header) == 0x12345 && control_job.size == 56,
+          "ControlBufferRa returns the next cursor and writes the job header");
+    CHECK(ident(control_ra.header) == 6 && control_ra.size == 0 &&
+          control_ra.address == return_addr && ident(control_in.header) == 2 &&
+          control_in.size == 0x21 && control_in.address == input_addr,
+          "ControlBufferRa serializes return and input-control chunks");
+    CHECK(ident(control_flags.header) == 3 &&
+          payload(control_flags.header) == 0x6000 && control_flags.flags_low == 0x0000e7ff &&
+          ident(control_out.header) == 18 && control_out.size == 0x32 &&
+          control_out.address == sideband_addr,
+          "ControlBufferRa masks flags and serializes the output-control chunk");
+    CHECK(job[64] == 0xEE, "ControlBufferRa writes exactly through its returned cursor");
+
+    std::memset(job, 0xEE, sizeof job);
+    const uint8_t inline_data[5] = {1, 2, 3, 4, 5};
+    uint64_t inline_address = 0;
+    cursor = inline_buffer(base, (uint64_t)(uintptr_t)inline_data, sizeof inline_data,
+                           (uint64_t)(uintptr_t)&inline_address, 0, 0);
+    const JobChunk inline_job = chunk_at<JobChunk>(job, 0);
+    CHECK(cursor == base + 16 && inline_address == base + 8 &&
+          ident(inline_job.header) == 7 && inline_job.size == 8,
+          "InlineBuffer returns an aligned cursor and reports its in-batch payload address");
+    CHECK(std::memcmp(job + 8, inline_data, sizeof inline_data) == 0 &&
+          job[13] == 0 && job[14] == 0 && job[15] == 0 && job[16] == 0xEE,
+          "InlineBuffer copies data, zero-pads to 8 bytes, and preserves the canary");
+    CHECK(inline_buffer(base, 1, 4, (uint64_t)(uintptr_t)&inline_address, 0, 0) == 0,
+          "InlineBuffer rejects inaccessible input without a host fault");
+
+    std::memset(job, 0xEE, sizeof job);
+    cursor = run(base, 0x23456, ~uint64_t{0}, input_addr, 0x43, output_addr, 0x54,
+                 sideband_addr, 0x65, return_addr);
+    const JobChunk run_job = chunk_at<JobChunk>(job, 0);
+    const BufferChunk run_ra = chunk_at<BufferChunk>(job, 8);
+    const BufferChunk run_in = chunk_at<BufferChunk>(job, 24);
+    const FlagsChunk run_flags = chunk_at<FlagsChunk>(job, 40);
+    const BufferChunk run_out = chunk_at<BufferChunk>(job, 48);
+    const BufferChunk run_sideband = chunk_at<BufferChunk>(job, 64);
+    CHECK(cursor == base + 80 && run_job.size == 72 && payload(run_job.header) == 0x23456,
+          "RunBufferRa consumes all ten ABI arguments and advances by its exact job size");
+    CHECK(ident(run_ra.header) == 6 && run_ra.address == return_addr &&
+          ident(run_in.header) == 1 && run_in.size == 0x43 && run_in.address == input_addr &&
+          ident(run_flags.header) == 4 && payload(run_flags.header) == 0xe000 &&
+          run_flags.flags_low == 0x00001fff,
+          "RunBufferRa serializes return/input chunks and masked run flags");
+    CHECK(ident(run_out.header) == 17 && run_out.size == 0x54 &&
+          run_out.address == output_addr && ident(run_sideband.header) == 18 &&
+          run_sideband.size == 0x65 && run_sideband.address == sideband_addr && job[80] == 0xEE,
+          "RunBufferRa serializes matching output chunks without overrunning the cursor");
+
+    std::memset(job, 0xEE, sizeof job);
+    const GuestBuffer inputs[2] = {{input_addr, 0x10}, {input_addr + 0x100, 0x20}};
+    const GuestBuffer outputs[1] = {{output_addr, 0x30}};
+    cursor = run_split(base, 0x34567, ~uint64_t{0}, (uint64_t)(uintptr_t)inputs, 2,
+                       (uint64_t)(uintptr_t)outputs, 1, sideband_addr, 0x40, return_addr);
+    const JobChunk split_job = chunk_at<JobChunk>(job, 0);
+    const BufferChunk split_in0 = chunk_at<BufferChunk>(job, 24);
+    const BufferChunk split_in1 = chunk_at<BufferChunk>(job, 40);
+    const FlagsChunk split_flags = chunk_at<FlagsChunk>(job, 56);
+    const BufferChunk split_out = chunk_at<BufferChunk>(job, 64);
+    const BufferChunk split_sideband = chunk_at<BufferChunk>(job, 80);
+    CHECK(cursor == base + 96 && split_job.size == 88 &&
+          ident(split_in0.header) == 1 && split_in0.address == inputs[0].address &&
+          split_in1.address == inputs[1].address,
+          "RunSplitBufferRa serializes every input descriptor and advances the cursor");
+    CHECK(ident(split_flags.header) == 4 && ident(split_out.header) == 17 &&
+          split_out.address == outputs[0].address && split_out.size == outputs[0].size &&
+          ident(split_sideband.header) == 18 && split_sideband.address == sideband_addr &&
+          job[96] == 0xEE,
+          "RunSplitBufferRa serializes flags and matching output/sideband chunks exactly");
+    CHECK(run_split(base, 1, 0, 1, 1, (uint64_t)(uintptr_t)outputs, 1,
+                    sideband_addr, 0x40, 0) == 0,
+          "RunSplitBufferRa rejects an inaccessible descriptor array without a host fault");
 
     // Teardown.
     CHECK(idestroy(ctx, inst, 0, 0, 0, 0) == 0, "sceAjmInstanceDestroy -> OK");

--- a/prosper/tests/test_hle_stack_args.cpp
+++ b/prosper/tests/test_hle_stack_args.cpp
@@ -1,6 +1,6 @@
 // test_hle_stack_args - the generated import stub must preserve the guest's complete fixed-arity
 // SysV call across the host ABI boundary. Windows needs a SysV->Microsoft-x64 conversion; Linux's
-// guest-FS path interposes a call while swapping FS. Both paths must forward stack args 7-9.
+// guest-FS path interposes a call while swapping FS. Both paths must forward stack args 7-10.
 #include "../src/host/exec_image.hpp"
 #include "../src/hle/dispatch.hpp"
 
@@ -14,13 +14,14 @@ using namespace prosper;
 
 namespace {
 
-constexpr uint64_t kArgs[9] = {
+constexpr uint64_t kArgs[10] = {
     0x1111111111111111ull, 0x2222222222222222ull, 0x3333333333333333ull,
     0x4444444444444444ull, 0x5555555555555555ull, 0x6666666666666666ull,
     0x7777777777777777ull, 0x8888888888888888ull, 0x9999999999999999ull,
+    0xaaaaaaaaaaaaaaaaull,
 };
 constexpr uint64_t kReturn = 0xabcddcba01234567ull;
-uint64_t g_seen[9] = {};
+uint64_t g_seen[10] = {};
 extern "C" {
 uint64_t prosper_test_hle_entry_rsp_mod16 = ~uint64_t{0};
 uint64_t prosper_test_hle_entry_rsp = 0;
@@ -28,17 +29,17 @@ uint64_t prosper_test_hle_entry_rsp = 0;
 uint64_t g_immediate_return = 0;
 uint64_t g_guest_return = 0;
 
-extern "C" uint64_t prosper_test_hle9_handler(
+extern "C" uint64_t prosper_test_hle10_handler(
     uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4,
-    uint64_t a5, uint64_t a6, uint64_t a7, uint64_t a8) {
-    const uint64_t args[9] = {a0, a1, a2, a3, a4, a5, a6, a7, a8};
-    for (int i = 0; i < 9; ++i) g_seen[i] = args[i];
+    uint64_t a5, uint64_t a6, uint64_t a7, uint64_t a8, uint64_t a9) {
+    const uint64_t args[10] = {a0, a1, a2, a3, a4, a5, a6, a7, a8, a9};
+    for (int i = 0; i < 10; ++i) g_seen[i] = args[i];
     g_immediate_return = *(const uint64_t*)(uintptr_t)prosper_test_hle_entry_rsp;
     g_guest_return = hle_guest_return_address(prosper_test_hle_entry_rsp);
     return kReturn;
 }
 
-extern "C" void prosper_test_hle9_entry();
+extern "C" void prosper_test_hle10_entry();
 
 #define PROSPER_STRINGIFY_INNER(x) #x
 #define PROSPER_STRINGIFY(x) PROSPER_STRINGIFY_INNER(x)
@@ -53,23 +54,23 @@ extern "C" void prosper_test_hle9_entry();
 __asm__(
     ".text\n"
     ".p2align 4\n"
-    ".globl " PROSPER_ASM_SYMBOL(prosper_test_hle9_entry) "\n"
-    PROSPER_ASM_SYMBOL(prosper_test_hle9_entry) ":\n"
+    ".globl " PROSPER_ASM_SYMBOL(prosper_test_hle10_entry) "\n"
+    PROSPER_ASM_SYMBOL(prosper_test_hle10_entry) ":\n"
     "    movq %rsp, " PROSPER_ASM_SYMBOL(prosper_test_hle_entry_rsp) "(%rip)\n"
     "    movq %rsp, %r10\n"
     "    andq $15, %r10\n"
     "    movq %r10, " PROSPER_ASM_SYMBOL(prosper_test_hle_entry_rsp_mod16) "(%rip)\n"
-    "    jmp " PROSPER_ASM_SYMBOL(prosper_test_hle9_handler) "\n"
+    "    jmp " PROSPER_ASM_SYMBOL(prosper_test_hle10_handler) "\n"
 );
 
 #ifdef _WIN32
-using GuestHle9 = uint64_t (__attribute__((sysv_abi)) *)(
+using GuestHle10 = uint64_t (__attribute__((sysv_abi)) *)(
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
-    uint64_t, uint64_t, uint64_t, uint64_t);
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 #else
-using GuestHle9 = uint64_t (*)(
+using GuestHle10 = uint64_t (*)(
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
-    uint64_t, uint64_t, uint64_t, uint64_t);
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 #endif
 
 int fails = 0;
@@ -96,8 +97,8 @@ int main(int argc, char** argv) {
 #endif
 
     constexpr const char* kNid = "test.hle.stack.args";
-    Hle::register_fn(kNid, reinterpret_cast<HleFn>(&prosper_test_hle9_entry),
-                     "prosper_test_hle9_entry");
+    Hle::register_fn(kNid, reinterpret_cast<HleFn>(&prosper_test_hle10_entry),
+                     "prosper_test_hle10_entry");
     // Keep an unresolved import immediately before the implemented one. The largest Linux guest-FS
     // variant is the unresolved stub; it must fit its fixed 96-byte slot without corrupting its
     // neighbour.
@@ -108,7 +109,8 @@ int main(int argc, char** argv) {
 #if defined(__linux__)
     if (guest_fs) {
         const auto* second = reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(stub_addr(1)));
-        CHECK(second[0] == 0xF3, "unresolved guest-FS stub stayed within its 96-byte slot");
+        CHECK(second[0] == 0x49 && second[1] == 0xBA,
+              "unresolved guest-FS stub stayed within its 96-byte slot");
     }
 #endif
     if (fails) {
@@ -119,9 +121,9 @@ int main(int argc, char** argv) {
 #ifdef _WIN32
     _putenv_s("PROSPER_UNIMPL_STACK", "1");
 #endif
-    auto unresolved = reinterpret_cast<GuestHle9>(static_cast<uintptr_t>(stub_addr(0)));
+    auto unresolved = reinterpret_cast<GuestHle10>(static_cast<uintptr_t>(stub_addr(0)));
     CHECK(unresolved(kArgs[0], kArgs[1], kArgs[2], kArgs[3], kArgs[4],
-                     kArgs[5], kArgs[6], kArgs[7], kArgs[8]) == 0,
+                     kArgs[5], kArgs[6], kArgs[7], kArgs[8], kArgs[9]) == 0,
           "unresolved import stub returned the generic result");
     CHECK(call_order().size() == 1 && call_order()[0] == 0,
           "unresolved import stub preserved its dispatch index");
@@ -133,13 +135,13 @@ int main(int argc, char** argv) {
     if (guest_fs) guest_fs_active = guest_tls_activate_thread() != 0;
 #endif
 
-    auto call = reinterpret_cast<GuestHle9>(static_cast<uintptr_t>(stub_addr(1)));
+    auto call = reinterpret_cast<GuestHle10>(static_cast<uintptr_t>(stub_addr(1)));
     const uint64_t callsite_begin = (uint64_t)(uintptr_t)&&before_hle_call;
     const uint64_t callsite_end = (uint64_t)(uintptr_t)&&after_hle_call;
 before_hle_call:
     asm volatile("" ::: "memory");
     const uint64_t result = call(kArgs[0], kArgs[1], kArgs[2], kArgs[3], kArgs[4],
-                                 kArgs[5], kArgs[6], kArgs[7], kArgs[8]);
+                                 kArgs[5], kArgs[6], kArgs[7], kArgs[8], kArgs[9]);
     asm volatile("" ::: "memory");
 after_hle_call:
 
@@ -171,7 +173,7 @@ after_hle_call:
     const uint64_t callsite_hi = callsite_begin < callsite_end ? callsite_end : callsite_begin;
     CHECK(g_guest_return >= callsite_lo && g_guest_return <= callsite_hi,
           "recovered HLE caller points to the real import callsite, not the generated stub");
-    for (int i = 0; i < 9; ++i) {
+    for (int i = 0; i < 10; ++i) {
         char what[96];
         std::snprintf(what, sizeof what, "argument %d preserved (0x%016llx)", i + 1,
                       static_cast<unsigned long long>(kArgs[i]));


### PR DESCRIPTION
## Summary
- implement the PS5 3.20 AJM cancel and pointer-returning batch-builder exports
- serialize byte-exact control, inline, run, and split-run chunks with fault-safe guest access
- extend Linux guest-FS and Windows SysV import bridges to preserve fixed arguments through argument 10

## Scope
This is the F2 AJM batch-builder cursor/cancel slice from #396. It intentionally does not implement compressed-audio decoding, AudioIn, or other findings from that umbrella issue.

## Author focused verification
- Linux: `ajm_hle`, `hle_stack_args`, `hle_stack_args_guest_fs`
- Windows: `ajm_hle`, `hle_stack_args`
- `git diff --check`

Snapshots were not run and are not part of this PR's verification.

Refs #396