### PR TITLE
kernel: map direct memory v2

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -37,6 +37,8 @@ namespace prosper {
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
+#define HLE7(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
 
 namespace {
     bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
@@ -756,6 +758,15 @@ HLE(k_mprotect) {
     retrack_prot(a0, a1, prot, "mprotect");
     return 0;
 }
+
+// sceKernelMapDirectMemory2(void** addrInOut, len, type, prot, flags, phys, align) inserts a
+// memory-type argument before the ordinary mapper's protection argument. The current VA tracker
+// does not expose per-mapping memory types yet, but mapping must still consume the shifted
+// protection/flags/physical-offset/alignment arguments rather than silently returning success.
+HLE7(k_map_dmem2) {
+    (void)a2;   // Memory-type reporting is tracked separately in #387.
+    return k_map_dmem(a0, a1, a3, a4, a5, a6);
+}
 // sceKernelMtypeprotect(addr, size, mtype, prot): apply the CPU protection (arg a3) then set the direct-
 // memory type (a2). Was MISSING -> the stub returned success without applying EITHER, so a later access
 // under the wrong protection faults (write to a still-RO page / exec of a still-NX page) -- the same class
@@ -1212,6 +1223,7 @@ void register_kernel_mem_hle() {
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
     R("sceKernelAllocateMainDirectMemory", k_alloc_main_dmem);  // 4-arg signature (physOut at arg3)
     R("sceKernelMapDirectMemory", k_map_dmem);
+    R("sceKernelMapDirectMemory2", k_map_dmem2);
     R("sceKernelMapNamedDirectMemory", k_map_dmem);
     R("sceKernelMunmap", k_munmap);
     // sceKernelReleaseFlexibleMemory(addr, len): same shape as munmap (unmap + untrack the flexible range).
@@ -1302,6 +1314,8 @@ namespace prosper {
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
+#define HLE7(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
 
 namespace {
     bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
@@ -2161,6 +2175,14 @@ HLE(k_map_dmem) {
     return 0;
 }
 
+// sceKernelMapDirectMemory2 inserts `type` before prot/flags/phys/align. Windows uses the same
+// direct-memory view mapper after shifting those arguments; memory-type queries remain separate
+// #387 tracking work.
+HLE7(k_map_dmem2) {
+    (void)a2;
+    return k_map_dmem(a0, a1, a3, a4, a5, a6);
+}
+
 HLE(k_munmap)   { if (!a1) return 0x80020016ull;
                   if (a0) { win_unmap(a0, a1); untrack(a0, a1); } return 0; }
 static uint64_t sce_win_mprotect_error(DWORD error) {
@@ -2398,6 +2420,7 @@ void register_kernel_mem_hle() {
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
     R("sceKernelAllocateMainDirectMemory", k_alloc_main_dmem);
     R("sceKernelMapDirectMemory", k_map_dmem);
+    R("sceKernelMapDirectMemory2", k_map_dmem2);
     R("sceKernelMapNamedDirectMemory", k_map_dmem);
     R("sceKernelMunmap", k_munmap);
     R("sceKernelReleaseFlexibleMemory", k_munmap);

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -29,6 +29,8 @@ static int fails = 0;
 static constexpr uint64_t kBase  = 0x10000000ull;
 static constexpr uint64_t kTotal = 16ull * 1024 * 1024 * 1024;
 static constexpr uint64_t kEnd   = kBase + kTotal;
+using Hle7Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t, uint64_t);
 #ifdef _WIN32
 static constexpr uint64_t kGuestAutoVaMin = 0x2000000000ull;
 static constexpr uint64_t kGuestAutoVaMax = 0xfbffffffffull;
@@ -45,10 +47,14 @@ int main() {
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
     auto alloc_main = Hle::lookup(nid_hash("sceKernelAllocateMainDirectMemory"));
     auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
+    auto map2    = reinterpret_cast<Hle7Fn>(
+        Hle::lookup(nid_hash("sceKernelMapDirectMemory2")));
     auto protect = Hle::lookup(nid_hash("sceKernelMprotect"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
     auto query   = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
-    CHECK(reserve && unmap && alloc && alloc_main && map && protect && release && query,
+    CHECK(nid_hash("sceKernelMapDirectMemory2") == "BQQniolj9tQ",
+          "sceKernelMapDirectMemory2 hashes to the PS5 3.20 import NID");
+    CHECK(reserve && unmap && alloc && alloc_main && map && map2 && protect && release && query,
           "memory HLE functions registered");
     if (fails) return 1;
 
@@ -72,7 +78,7 @@ int main() {
           "AllocateDirectMemory(null physAddrOut) -> EINVAL");
     CHECK((uint32_t)alloc_main(dlen, dlen, 0, 0, 0, 0) == 0x80020016u,
           "AllocateMainDirectMemory(null physAddrOut) -> EINVAL");
-    uint64_t phys = 0, va1 = 0, va2 = 0;
+    uint64_t phys = 0, va1 = 0, va2 = 0, va_map2 = 0;
     CHECK(alloc(0, kEnd, dlen, dlen, 0, (uint64_t)(uintptr_t)&phys) == 0 && phys == kBase,
           "allocate one 64 KiB direct-memory page");
     CHECK(map((uint64_t)(uintptr_t)&va1, dlen, 0x2, 0, phys, dlen) == 0 && va1,
@@ -83,10 +89,16 @@ int main() {
 #endif
     CHECK(map((uint64_t)(uintptr_t)&va2, dlen, 0x2, 0, phys, dlen) == 0 && va2 && va2 != va1,
           "map second direct-memory view");
+    CHECK(map2((uint64_t)(uintptr_t)&va_map2, dlen, 0 /* type */, 0x2 /* RW */, 0,
+               phys, dlen) == 0 && va_map2 && va_map2 != va1 && va_map2 != va2,
+          "MapDirectMemory2 consumes shifted prot/flags/phys/alignment arguments");
     if (va1 && va2) {
         *(volatile uint64_t*)(uintptr_t)(va1 + 0x1230) = 0x6310CAFEDEADC0DEull;
         CHECK(*(volatile uint64_t*)(uintptr_t)(va2 + 0x1230) == 0x6310CAFEDEADC0DEull,
               "two virtual mappings of one physical offset alias the same bytes");
+        CHECK(va_map2 && *(volatile uint64_t*)(uintptr_t)(va_map2 + 0x1230) ==
+                         0x6310CAFEDEADC0DEull,
+              "MapDirectMemory2 view aliases the requested physical range");
     }
 
     uint64_t hinted = va1;
@@ -111,6 +123,8 @@ int main() {
     if (va1) CHECK(unmap(va1, dlen, 0, 0, 0, 0) == 0, "unmap first direct-memory view");
     if (va2) CHECK(unmap(va2, dlen, 0, 0, 0, 0) == 0, "unmap second direct-memory view");
     if (va3) CHECK(unmap(va3, dlen, 0, 0, 0, 0) == 0, "unmap reused direct-memory view");
+    if (va_map2) CHECK(unmap(va_map2, dlen, 0, 0, 0, 0) == 0,
+                       "unmap MapDirectMemory2 view");
     if (hinted) CHECK(unmap(hinted, dlen, 0, 0, 0, 0) == 0, "unmap relocated direct-memory view");
     if (reused_phys) release(reused_phys, dlen, 0, 0, 0, 0);
 
@@ -217,9 +231,13 @@ int main() {
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
     auto alloc_main = Hle::lookup(nid_hash("sceKernelAllocateMainDirectMemory"));
     auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
+    auto map2    = reinterpret_cast<Hle7Fn>(
+        Hle::lookup(nid_hash("sceKernelMapDirectMemory2")));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
-    CHECK(avail && alloc && alloc_main && map && release, "dmem fns registered");
-    if (!(avail && alloc && alloc_main && map && release)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(nid_hash("sceKernelMapDirectMemory2") == "BQQniolj9tQ",
+          "sceKernelMapDirectMemory2 hashes to the PS5 3.20 import NID");
+    CHECK(avail && alloc && alloc_main && map && map2 && release, "dmem fns registered");
+    if (!(avail && alloc && alloc_main && map && map2 && release)) { printf("== FAIL ==\n"); return 1; }
 
     // Both allocation APIs require their physical-address output. Reject before taking from
     // the pool so an unobservable allocation cannot leak capacity.
@@ -301,6 +319,30 @@ int main() {
         CHECK(rr == 0 && va && (va & 0xffff) == 0,
               "map direct memory honors requested 64KiB VA alignment");
         if (va) munmap((void*)(uintptr_t)va, 0x10000);
+        if (p) release(p, 0x10000, 0, 0, 0, 0);
+    }
+
+    // MapDirectMemory2 inserts `type` before prot/flags/phys/alignment. Type zero deliberately
+    // differs from RW protection so an unshifted six-argument alias cannot pass this write/alias
+    // check, and the seventh alignment argument is exercised by the real fixed-arity prototype.
+    {
+        uint64_t p = 0, va = 0, alias = 0;
+        uint64_t rr = alloc(0, kEnd, 0x10000, 0x10000, 0,
+                            (uint64_t)(uintptr_t)&p);
+        CHECK(rr == 0, "allocate direct page for MapDirectMemory2");
+        rr = map2((uint64_t)(uintptr_t)&va, 0x10000, 0 /* type */, 0x2 /* RW */, 0,
+                  p, 0x10000);
+        CHECK(rr == 0 && va && (va & 0xffff) == 0,
+              "MapDirectMemory2 consumes shifted arguments and seventh-argument alignment");
+        rr = map((uint64_t)(uintptr_t)&alias, 0x10000, 0x2, 0, p, 0x10000);
+        CHECK(rr == 0 && alias, "map ordinary alias for MapDirectMemory2 physical range");
+        if (va && alias) {
+            *(volatile uint64_t*)(uintptr_t)(va + 0x120) = 0xB002D1EC7A11A5ull;
+            CHECK(*(volatile uint64_t*)(uintptr_t)(alias + 0x120) == 0xB002D1EC7A11A5ull,
+                  "MapDirectMemory2 maps the requested physical offset as writable shared memory");
+        }
+        if (va) munmap((void*)(uintptr_t)va, 0x10000);
+        if (alias) munmap((void*)(uintptr_t)alias, 0x10000);
         if (p) release(p, 0x10000, 0, 0, 0, 0);
     }
 


### PR DESCRIPTION
## Summary
- register the missing PS5 3.20 `sceKernelMapDirectMemory2` export on Linux and Windows
- preserve its seven-argument ABI by shifting type/protection/flags/physical-offset/alignment into the proven direct-memory mapper
- cover exact NID registration, writable shared physical aliasing, and the seventh alignment argument on both platforms

## Scope
This is only F2 from #387. The memory-type argument is accepted, but exposing per-VA memory type through VirtualQuery/GetDirectMemoryType remains separate #387 tracking work, along with the other findings.

## Author focused verification
- Linux: `dmem_available`
- Windows: `dmem_available`
- `git diff --check`

Snapshots were not run and are not part of this PR's verification.

Refs #387