### PR TITLE
videoout: initialize legacy buffer attributes

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -30,6 +30,8 @@ namespace prosper {
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
+#define HLE7(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
 
 namespace {
 // Optional fork-safe counter bumped when the guest calls into the graphics libs (libSceAgc /
@@ -367,6 +369,23 @@ HLE(g_vo_devcap) { if (a1) *(uint64_t*)(uintptr_t)a1 = 0; return 0; }
 // sceVideoOutIsOutputSupported (Nv8c-Kb+DUM): (port_type, mode/feature) -> bool. A standard main-bus
 // output supports the queried mode → 1.
 HLE(g_vo_is_output_supported) { vo_argtrace("IsOutputSupported", a0,a1,a2,a3,a4,a5); return 1; }
+
+// sceVideoOutSetBufferAttribute (i6-sR91Wt-4): initialize the legacy/Gen4 BufferAttribute from
+// (attr, pixel_format, tiling_mode, aspect_ratio, width, height, pitch_in_pixel). The ABI object is
+// 0x28 bytes: seven u32 fields followed by reserved u32/u64 storage. Size-exact initialization keeps
+// reserved bytes deterministic without touching the caller's following object.
+HLE7(g_vo_set_buffer_attribute) {
+    if (!a0) return 0;
+    uint8_t* p = (uint8_t*)(uintptr_t)a0;
+    memset(p, 0, 0x28);
+    *(uint32_t*)(p + 0x00) = (uint32_t)a1;   // pixel_format
+    *(uint32_t*)(p + 0x04) = (uint32_t)a2;   // tiling_mode
+    *(uint32_t*)(p + 0x08) = (uint32_t)a3;   // aspect_ratio
+    *(uint32_t*)(p + 0x0c) = (uint32_t)a4;   // width
+    *(uint32_t*)(p + 0x10) = (uint32_t)a5;   // height
+    *(uint32_t*)(p + 0x14) = (uint32_t)a6;   // pitch_in_pixel
+    return 0;
+}
 
 // sceVideoOutSetBufferAttribute2 (PjS5uASwcV8): fill the caller's VideoOutBufferAttribute2 (0x50
 // bytes, Kyty layout) from (attr, pixel_format, tiling_mode, width, height, option, [dcc_control,
@@ -726,7 +745,7 @@ void register_graphics_hle() {
     R("sceVideoOutGetResolutionStatus", g_vo_resstatus);
     R("sceVideoOutGetVblankStatus", g_vo_vblankstatus);
     R("sceVideoOutGetDeviceCapabilityInfo", g_vo_devcap);
-    R("sceVideoOutRegisterBuffers", g_vo_close);R("sceVideoOutSetBufferAttribute", g_vo_close);
+    R("sceVideoOutRegisterBuffers", g_vo_close);R("sceVideoOutSetBufferAttribute", g_vo_set_buffer_attribute);
     // PS5 "2"/query variants — the 5 previously-unimplemented VideoOut NIDs (resolved via shadPS4
     // aerolib + Kyty VideoOut.cpp). Registered by raw NID (PS5-specific, not in our name DB).
     RN("Nv8c-Kb+DUM", g_vo_is_output_supported);   // sceVideoOutIsOutputSupported

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -22,6 +22,9 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+using Hle7Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t, uint64_t);
+
 int main() {
     printf("== test_videoout ==\n");
     register_builtin_hle();
@@ -30,15 +33,16 @@ int main() {
     auto vbl    = Hle::lookup(nid_hash("sceVideoOutGetVblankStatus"));
     auto cap    = Hle::lookup(nid_hash("sceVideoOutGetDeviceCapabilityInfo"));
     auto issup  = Hle::lookup("Nv8c-Kb+DUM");   // IsOutputSupported
+    auto setba  = Hle::lookup(nid_hash("sceVideoOutSetBufferAttribute"));
     auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
     auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto cfg    = Hle::lookup("w0hLuNarQxY");   // ConfigureOutput
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
     auto fstat  = Hle::lookup(nid_hash("sceVideoOutGetFlipStatus"));
-    CHECK(res && vbl && cap && issup && setba2 && regb2 && unreg && cfg && flip && fstat,
+    CHECK(res && vbl && cap && issup && setba && setba2 && regb2 && unreg && cfg && flip && fstat,
           "VideoOut functions registered");
-    if (!(res && vbl && cap && issup && setba2 && regb2 && unreg && cfg && flip && fstat)) {
+    if (!(res && vbl && cap && issup && setba && setba2 && regb2 && unreg && cfg && flip && fstat)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -91,6 +95,28 @@ int main() {
 
     // IsOutputSupported → supported.
     CHECK(issup(0x1001, 0xd000000a, 0, 0, 0, 0) == 1, "IsOutputSupported returns 1");
+
+    // #394 F2: the legacy setter is an output function, not a success-returning no-op. It fills
+    // the seven public fields, zeros option/reserved storage, and writes exactly 0x28 bytes.
+    uint8_t legacy_attr[0x30]; memset(legacy_attr, 0xEE, sizeof legacy_attr);
+    auto setba7 = reinterpret_cast<Hle7Fn>(setba);
+    setba7((uint64_t)(uintptr_t)legacy_attr, 0x80002200u, 1, 2, 1280, 720, 1344);
+    CHECK(*(uint32_t*)(legacy_attr + 0x00) == 0x80002200u &&
+          *(uint32_t*)(legacy_attr + 0x04) == 1 &&
+          *(uint32_t*)(legacy_attr + 0x08) == 2,
+          "legacy attribute format, tiling, and aspect set");
+    CHECK(*(uint32_t*)(legacy_attr + 0x0c) == 1280 &&
+          *(uint32_t*)(legacy_attr + 0x10) == 720 &&
+          *(uint32_t*)(legacy_attr + 0x14) == 1344,
+          "legacy attribute dimensions and pitch set");
+    bool legacy_reserved_zero = true;
+    for (size_t i = 0x18; i < 0x28; ++i) legacy_reserved_zero &= legacy_attr[i] == 0;
+    CHECK(legacy_reserved_zero, "legacy attribute option and reserved fields initialized");
+    bool legacy_canary_untouched = true;
+    for (size_t i = 0x28; i < sizeof legacy_attr; ++i)
+        legacy_canary_untouched &= legacy_attr[i] == 0xEE;
+    CHECK(legacy_canary_untouched,
+          "SetBufferAttribute writes exactly its 0x28-byte ABI struct");
 
     // SetBufferAttribute2 fills the 0x50 attribute struct from (fmt, tiling, w, h, option).
     uint8_t attr[0x50]; memset(attr, 0xEE, sizeof attr);


### PR DESCRIPTION
## Summary

Addresses #394 F2 only.

`sceVideoOutSetBufferAttribute` was registered to a generic success-returning no-op, so callers received unchanged stack/heap bytes instead of a valid legacy VideoOut buffer attribute. This PR adds the documented seven-argument SysV handler, initializes exactly the 0x28-byte ABI object, fills format/tiling/aspect/dimensions/pitch, and leaves option/reserved storage zero.

## Behavioral contract

- The legacy setter writes the seven public fields at their ABI offsets.
- Option and reserved storage are deterministic zeroes.
- The write stops at byte 0x28; memory following the object is untouched.
- The Gen5 `sceVideoOutSetBufferAttribute2`, buffer registration, and rendering paths are unchanged.
- This is a compatibility/output-initialization fix; no snapshot behavior changes.

## Evidence and risk

The signature and layout are the published Orbis-compatible VideoOut contract used by the existing audit evidence. The regression calls the function through the NID registry using the actual seventh stack/register argument and checks every public field, the zeroed tail, and a post-object canary. It fails against master because the old handler writes nothing.

Risk is limited to legacy callers that currently depend on uninitialized output, which is not a valid contract. The wider #394 findings remain out of scope.

## Verification

Pre-PR focused checks:

- Linux: `cmake --build build-linux --target test_videoout -j8 && ctest --test-dir build-linux -R '^videoout_queries$' --output-on-failure` — PASS (1/1)
- Windows: `cmake --build build-windows --target prosper_core -j 8` — PASS. `test_videoout` is not defined by the existing Windows CMake gate.
- `git diff --check` — PASS
- Snapshots — not run; no rendered-output behavior changes.

Exact-head core verification and independent inspection-only review will be posted separately before merge.