### PR TITLE
videoout: register legacy buffer arrays

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -403,6 +403,51 @@ HLE(g_vo_set_buffer_attribute2) {  // a0=attr* a1=pixel_format a2=tiling a3=widt
     return 0;
 }
 
+// sceVideoOutRegisterBuffers (w3BY+tAEiQY): register a legacy flat framebuffer-address array and
+// return the lowest free attribute-group index. The Gen4 attribute stores its 32-bit pixel format at
+// offset 0; the remaining surface fields share the Gen5 offsets used by the present registry.
+HLE(g_vo_register_buffers) {  // a0=handle a1=start a2=addresses a3=buffer_num a4=attribute
+    vo_argtrace("RegisterBuffers", a0,a1,a2,a3,a4,a5);
+    const int start = (int)a1, num = (int)a3;
+    if (!a2 || !a4)
+        return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    if (start < 0 || start > 15 || num < 1 || num > 16 || start + num > 16)
+        return (uint64_t)(int64_t)(int32_t)0x80290001;  // SCE_VIDEO_OUT_ERROR_INVALID_VALUE
+
+    const uint8_t* attr = (const uint8_t*)(uintptr_t)a4;
+    const DisplayConfig::SetConfig config = {
+        *(const uint32_t*)(attr + 0x0c), *(const uint32_t*)(attr + 0x10),
+        *(const uint32_t*)(attr + 0x00), *(const uint32_t*)(attr + 0x04), true
+    };
+    const auto* addresses = (const void* const*)(uintptr_t)a2;
+    std::lock_guard<std::mutex> lk(g_display_mx);
+
+    int set = 0;
+    while (set < 4 && g_display.sets[set].registered) ++set;
+    if (set == 4)
+        return (uint64_t)(int64_t)(int32_t)0x8029000f;  // SCE_VIDEO_OUT_ERROR_NO_EMPTY_SLOT
+    for (int i = 0; i < num; ++i) {
+        if (g_display.buffer_set[start + i] != 0)
+            return (uint64_t)(int64_t)(int32_t)0x80290010;  // SCE_VIDEO_OUT_ERROR_SLOT_OCCUPIED
+    }
+
+    g_display.width = config.width;
+    g_display.height = config.height;
+    g_display.pixel_format = config.pixel_format;
+    g_display.tiling_mode = config.tiling_mode;
+    g_display.sets[set] = config;
+    for (int i = 0; i < num; ++i) {
+        g_display.buffer_addr[start + i] = (uint64_t)(uintptr_t)addresses[i];
+        g_display.buffer_set[start + i] = (uint8_t)(set + 1);
+        uint64_t generation = ++g_display.next_generation;
+        if (generation == 0) generation = ++g_display.next_generation;
+        g_display.buffer_generation[start + i] = generation;
+    }
+    if (g_display.buffer_num < start + num) g_display.buffer_num = start + num;
+    g_display.configured = true;
+    return (uint64_t)set;
+}
+
 // sceVideoOutRegisterBuffers2 (rKBUtgRrtbk): (handle, set_index, buffer_index_start, buffers,
 // buffer_num, attribute, [category, option on stack]). Validate ranges like Kyty and accept. The
 // buffers' GPU backing becomes swapchain images once the swapchain exists; for now, registration
@@ -745,7 +790,7 @@ void register_graphics_hle() {
     R("sceVideoOutGetResolutionStatus", g_vo_resstatus);
     R("sceVideoOutGetVblankStatus", g_vo_vblankstatus);
     R("sceVideoOutGetDeviceCapabilityInfo", g_vo_devcap);
-    R("sceVideoOutRegisterBuffers", g_vo_close);R("sceVideoOutSetBufferAttribute", g_vo_set_buffer_attribute);
+    R("sceVideoOutRegisterBuffers", g_vo_register_buffers);R("sceVideoOutSetBufferAttribute", g_vo_set_buffer_attribute);
     // PS5 "2"/query variants — the 5 previously-unimplemented VideoOut NIDs (resolved via shadPS4
     // aerolib + Kyty VideoOut.cpp). Registered by raw NID (PS5-specific, not in our name DB).
     RN("Nv8c-Kb+DUM", g_vo_is_output_supported);   // sceVideoOutIsOutputSupported

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -34,15 +34,16 @@ int main() {
     auto cap    = Hle::lookup(nid_hash("sceVideoOutGetDeviceCapabilityInfo"));
     auto issup  = Hle::lookup("Nv8c-Kb+DUM");   // IsOutputSupported
     auto setba  = Hle::lookup(nid_hash("sceVideoOutSetBufferAttribute"));
+    auto regb   = Hle::lookup(nid_hash("sceVideoOutRegisterBuffers"));
     auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
     auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto cfg    = Hle::lookup("w0hLuNarQxY");   // ConfigureOutput
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
     auto fstat  = Hle::lookup(nid_hash("sceVideoOutGetFlipStatus"));
-    CHECK(res && vbl && cap && issup && setba && setba2 && regb2 && unreg && cfg && flip && fstat,
+    CHECK(res && vbl && cap && issup && setba && regb && setba2 && regb2 && unreg && cfg && flip && fstat,
           "VideoOut functions registered");
-    if (!(res && vbl && cap && issup && setba && setba2 && regb2 && unreg && cfg && flip && fstat)) {
+    if (!(res && vbl && cap && issup && setba && regb && setba2 && regb2 && unreg && cfg && flip && fstat)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -117,6 +118,30 @@ int main() {
         legacy_canary_untouched &= legacy_attr[i] == 0xEE;
     CHECK(legacy_canary_untouched,
           "SetBufferAttribute writes exactly its 0x28-byte ABI struct");
+
+    // #394 F1: legacy registration consumes a flat address array, assigns the lowest free group,
+    // and records its non-zero slot range using the Gen4 attribute layout.
+    uint8_t legacy_fb2[16], legacy_fb3[16];
+    const void* legacy_buffers[2] = {legacy_fb2, legacy_fb3};
+    CHECK((uint32_t)regb(0x1001, 15, (uint64_t)(uintptr_t)legacy_buffers, 2,
+                         (uint64_t)(uintptr_t)legacy_attr, 0) == 0x80290001u,
+          "legacy RegisterBuffers rejects a range past slot 15");
+    uint64_t legacy_group = regb(0x1001, 2, (uint64_t)(uintptr_t)legacy_buffers, 2,
+                                 (uint64_t)(uintptr_t)legacy_attr, 0);
+    CHECK(legacy_group == 0, "legacy RegisterBuffers returns the lowest free attribute group");
+    CHECK(prosper_vo_buffer_count() == 4 &&
+          prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)legacy_fb2 &&
+          prosper_vo_buffer_addr(3) == (uint64_t)(uintptr_t)legacy_fb3,
+          "legacy RegisterBuffers records the flat framebuffer array at the requested slots");
+    CHECK(prosper_vo_display_width() == 1280 && prosper_vo_display_height() == 720 &&
+          prosper_vo_display_format() == 0x80002200u,
+          "legacy RegisterBuffers records Gen4 surface geometry and format");
+    CHECK((uint32_t)regb(0x1001, 3, (uint64_t)(uintptr_t)legacy_buffers, 2,
+                         (uint64_t)(uintptr_t)legacy_attr, 0) == 0x80290010u,
+          "legacy RegisterBuffers rejects an overlapping slot range");
+    CHECK(unreg(0x1001, legacy_group, 0, 0, 0, 0) == 0 &&
+          prosper_vo_buffer_count() == 0 && prosper_vo_display_width() == 0,
+          "legacy buffer group unregisters cleanly before Gen5 registration");
 
     // SetBufferAttribute2 fills the 0x50 attribute struct from (fmt, tiling, w, h, option).
     uint8_t attr[0x50]; memset(attr, 0xEE, sizeof attr);


### PR DESCRIPTION
## Summary

Addresses #394 F1 only.

The legacy `sceVideoOutRegisterBuffers` export was mapped to a generic success-returning close/no-op handler. Legacy callers therefore received group 0 but no framebuffer slots or surface metadata were registered, so later flips could not select a display surface.

This PR implements the documented five-argument legacy ABI. It consumes the flat framebuffer pointer array, allocates the lowest free attribute group, validates the 16-slot range and overlap before mutation, records Gen4 geometry/format/tiling in the existing synchronized registry, assigns fresh lifetime generations, and returns the allocated group index.

## Behavioral contract

- Null address/attribute pointers and invalid slot ranges fail without registry mutation.
- Registration uses a flat `void* const*` array, not the Gen5 `VideoOutBuffers` structure array.
- The lowest free one of four groups is allocated and returned.
- Occupied slots reject the whole registration atomically.
- Gen4 attributes are read at format@0x00, tiling@0x04, width@0x0c, and height@0x10.
- Existing Gen5 RegisterBuffers2 behavior is unchanged.
- Unregistering the returned group releases the legacy slots through the existing common registry path.

## Evidence and risk

The signature, group allocation, flat array shape, 16-buffer/four-group bounds, and attribute offsets come from the established Orbis-compatible VideoOut contract cited by #394. The regression registers at non-zero slots, checks exact addresses and surface metadata, proves out-of-range and overlap failures, and unregisters the group before the existing Gen5 scenarios. It fails against master because the old handler records nothing.

Risk is confined to the previously inert legacy registration path and its interaction with the shared registry. Synchronization, overlap rejection, per-slot group ownership, and lifetime generations use the same invariants already exercised by the Gen5 path.

## Verification

Pre-PR focused checks:

- Linux: `cmake --build build-linux --target test_videoout -j8 && ctest --test-dir build-linux -R '^videoout_queries$' --output-on-failure` — PASS (1/1)
- Windows: `cmake --build build-windows --target prosper_core -j 8` — PASS. `test_videoout` is not defined by the existing Windows CMake gate.
- `git diff --check` — PASS
- Snapshots — not run per requested workflow; no snapshot baseline or Gen5 rendered-output path changes.

Exact-head core verification and independent inspection-only review will be posted separately before merge.