### PR TITLE
videoout: expose flip event data

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -583,6 +583,20 @@ HLE(g_vo_get_event_id) {
     return (uint64_t)*(const int64_t*)ev;                     // ident: FLIP=0 / VBLANK=1 / ...
 }
 
+// sceVideoOutGetEventData (rWUTcKdkUzQ): return the data carried by a delivered VideoOut kevent.
+// Prosper's producer owns this contract: flip completion posts the submitted flipArg verbatim at
+// SceKernelEvent+0x10, while vblank posts its frame counter there. Do not apply the packed-event
+// decoding used by backends whose producers encode time/count bits into this field.
+HLE(g_vo_get_event_data) {
+    if (!a0 || !a1)
+        return (uint64_t)(int64_t)(int32_t)0x80290002;         // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    const uint8_t* ev = (const uint8_t*)(uintptr_t)a0;
+    if (*(const int16_t*)(ev + 8) != -13)
+        return (uint64_t)(int64_t)(int32_t)0x8029000d;         // SCE_VIDEO_OUT_ERROR_INVALID_EVENT
+    *(int64_t*)(uintptr_t)a1 = *(const int64_t*)(ev + 0x10);
+    return 0;
+}
+
 // sceVideoOutSetWindowModeMargins (MTxxrOCeSig — same brute-force naming): windowed-mode margin
 // hint for the system compositor. No compositor here — accept and ignore. CONFIDENCE: HIGH (pure
 // cosmetic setter; success unblocks the caller).
@@ -800,6 +814,7 @@ void register_graphics_hle() {
     RN("utPrVdxio-8", g_vo_get_output_status);        // sceVideoOutGetOutputStatus
     RN("w0hLuNarQxY", g_vo_configure_output);          // sceVideoOutConfigureOutput
     RN("U2JJtSqNKZI", g_vo_get_event_id);              // sceVideoOutGetEventId (#210)
+    RN("rWUTcKdkUzQ", g_vo_get_event_data);            // sceVideoOutGetEventData (#394 F5)
     RN("MTxxrOCeSig", g_vo_set_window_mode_margins);   // sceVideoOutSetWindowModeMargins (#210)
     RN("b0xyllnVY-I", g_gnm_add_eq_event);             // sceGnmAddEqEvent / GraphicsAddEqEvent (GPU EOP)
     #undef R

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -85,6 +85,46 @@ int main() {
         CHECK(gev.udata == kEopUdata, "EOP event echoed the registered udata");
     }
 
+    // VideoOut flip event accessor (#394 F5): the producer stores the submitted flipArg raw in
+    // kevent.data, so GetEventData must preserve all 64 bits rather than decode a packed value.
+    auto addflip   = Hle::lookup(nid_hash("sceVideoOutAddFlipEvent"));
+    auto submitflp = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
+    auto vo_evid   = Hle::lookup("U2JJtSqNKZI");
+    auto vo_evdata = Hle::lookup("rWUTcKdkUzQ");
+    CHECK(addflip && submitflp && vo_evid && vo_evdata,
+          "VideoOut flip event producer and accessors registered");
+    if (addflip && submitflp && vo_evid && vo_evdata) {
+        constexpr uint64_t kFlipArg = 0x8000000000001234ull;
+        constexpr uint64_t kFlipUdata = 0xFACEB00Cull;
+        addflip(eq, 0x1001, kFlipUdata, 0, 0, 0);
+        submitflp(0x1001, 0, 0, kFlipArg, 0, 0);
+
+        KEvent fev{}; int32_t fout = -1; uint32_t fcap = 50000;
+        wait(eq, (uint64_t)(uintptr_t)&fev, 1, (uint64_t)(uintptr_t)&fout,
+             (uint64_t)(uintptr_t)&fcap, 0);
+        CHECK(fout == 1 && fev.ident == 0 && fev.filter == -13 && fev.udata == kFlipUdata,
+              "WaitEqueue returns the registered VideoOut flip event");
+        int64_t decoded = 0;
+        CHECK(vo_evid((uint64_t)(uintptr_t)&fev, 0, 0, 0, 0, 0) == 0 &&
+              vo_evdata((uint64_t)(uintptr_t)&fev, (uint64_t)(uintptr_t)&decoded,
+                        0, 0, 0, 0) == 0 &&
+              (uint64_t)decoded == kFlipArg,
+              "VideoOut accessors return flip id and the raw 64-bit flipArg");
+
+        decoded = 0x1122334455667788ll;
+        CHECK((uint32_t)vo_evdata(0, (uint64_t)(uintptr_t)&decoded, 0, 0, 0, 0) ==
+                  0x80290002u && decoded == 0x1122334455667788ll,
+              "GetEventData rejects a null event without changing output");
+        CHECK((uint32_t)vo_evdata((uint64_t)(uintptr_t)&fev, 0, 0, 0, 0, 0) ==
+                  0x80290002u,
+              "GetEventData rejects a null output pointer");
+        KEvent non_video{}; non_video.filter = -14; non_video.data = 0x55;
+        CHECK((uint32_t)vo_evdata((uint64_t)(uintptr_t)&non_video,
+                                  (uint64_t)(uintptr_t)&decoded, 0, 0, 0, 0) ==
+                  0x8029000du && decoded == 0x1122334455667788ll,
+              "GetEventData rejects a non-VideoOut event without changing output");
+    }
+
     // --- Invalid WaitEqueue arguments (#388): num < 1 is EINVAL and a null event array is EFAULT.
     //     Neither failure may consume a ready event; the next valid wait must still receive it.
     {


### PR DESCRIPTION
## Summary

Addresses #394 F5 only.

`sceVideoOutGetEventData` was absent from the VideoOut HLE registry. A caller could successfully receive a flip event and then fail to resolve the accessor (or retain an uninitialized output) instead of obtaining the completed flip's argument.

This PR registers the PS5 3.20 NID and returns the signed 64-bit `SceKernelEvent.data` field for VideoOut-filter events. That deliberately matches prosper's own equeue producer: flip completion stores the submitted `flipArg` verbatim at offset 0x10, while vblank stores its frame counter there.

## Behavioral contract

- A valid VideoOut event copies exactly its raw 64-bit data field to the output and returns success.
- Top-bit-set flip arguments are preserved bit-for-bit; no packed time/count decoding is applied.
- Null event/output pointers return `SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS`.
- Non-VideoOut filters return `SCE_VIDEO_OUT_ERROR_INVALID_EVENT`.
- Every failure leaves caller output unchanged.
- Event production, coalescing, IDs, flip timing, and renderer/present behavior are unchanged.

## Evidence and risk

The NID/name pair comes from the PS5 3.20 firmware symbol map. The data semantics come from prosper's directly owned producer in `hle_kernel_time.cpp`, which posts `flipArg` as `SceKernelEvent.data`; accessor and producer must agree. Importing another backend's packed-event decoder would corrupt prosper's raw value.

The regression uses the real `AddFlipEvent -> SubmitFlip -> WaitEqueue -> GetEventId/GetEventData` path with `0x8000000000001234`, then exercises null pointers and a GraphicsCore-filter event. It fails on master because the GetEventData NID is not registered.

## Verification

Pre-PR focused checks:

- Linux: `cmake --build build-linux --target test_equeue_events -j8 && ctest --test-dir build-linux -R '^equeue_events$' --output-on-failure` — PASS (1/1)
- Windows: `cmake --build build-windows --target test_equeue_events -j 8 && ctest --test-dir build-windows -R '^equeue_events$' --output-on-failure` — PASS (1/1)
- `git diff --check` — PASS
- Snapshots — not run; this exposes existing event metadata and does not change rendered output.

Exact-head core verification and independent inspection-only review will be posted separately before merge.