### PR TITLE
docs: restore risk-based review workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,29 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
   for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
   exact-head results.
+- **Use independent review whenever it can materially improve confidence.** Treat review as a correctness
+  tool, not merely a gate for large diffs: behavioral code changes involving non-obvious judgment, unfamiliar
+  code, cross-platform behavior, reverse-engineered semantics, or meaningful failure paths should normally be
+  reviewed even when the patch is small and the author verification is green. Complex or high-risk changes—such
+  as shader/recompiler
+  control flow, memory safety or untrusted bounds, synchronization, ABI-sensitive interfaces, persistent data,
+  shared renderer/executor format, size, or indexing semantics, or changes whose failure can silently corrupt
+  results—require an independent code review before merge. Review is also required when the validation itself
+  is easy to get wrong: for example, a regression test with another path that can produce the expected result,
+  or a snapshot route or baseline update that needs judgment to confirm it exercises the intended behavior.
+  Judge both implementation risk and verification risk, not merely the diff size. Skip independent review only
+  for genuinely routine, mechanical, well-bounded low-risk work where another reader is unlikely to uncover a
+  correctness problem; when in doubt, review. Passing author verification does not substitute for
+  review where review is warranted: verification demonstrates observed behavior, while review challenges the
+  contract assumptions, untested paths, and whether the regression actually proves the intended behavior.
+  When uncertain, favor review for reverse-engineered API semantics and other changes where an independent
+  reader can materially challenge the reasoning, even when the patch is small. The reviewer inspects the
+  assumptions, code, risks, and tests, including whether each regression test would fail without the fix, but
+  does not duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR
+  is published, run author verification and any required review; the author posts exact-head evidence and the
+  reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
+  corrections, then merge only after the merge agent separately confirms author verification, reviewer approval
+  where required, and green required CI.
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and


### PR DESCRIPTION
## Summary

Restores the risk-based independent-review workflow that #901 removed from `CLAUDE.md`.

The restored guidance is the previously accepted text requested by the repository owner: use review where it materially improves confidence, require it for complex/high-risk or deceptively validated changes, keep verification author-owned, prohibit reviewers from duplicating builds/tests/snapshots/CI, require exact-head approval after corrections, and merge only after author evidence, applicable review, and green CI.

## Why

#901 deleted this entire section in an unrelated shader PR without review discussion. That conflicts with the later explicit workflow decision that reviews were valuable and should be used where appropriate. Without the section, future agents see author verification but no risk-based review, exact-head re-review, or reviewer-no-verification rules.

## Scope and verification

- Restores exactly the 23 lines present before #901; `git diff e12a0effd7b030763e19c54b3c4a4a830ff8df82 HEAD -- CLAUDE.md` is empty.
- `git diff --check` — PASS.
- No code, build, test, snapshot, or runtime behavior changes.
- Full binary verification is not relevant to a Markdown-only restoration; CI will still run normally.

Independent inspection-only review and the author exact-head evidence comment will be posted before merge.