### PR TITLE
videoout: reject invalid flip indices

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -329,8 +329,11 @@ HLE(g_vo_set_flip_rate) {
 HLE(g_vo_submitflip)  {
     if (evlog()) fprintf(stderr, "[ev] SubmitFlip handle=0x%llx bufidx=%lld flipmode=0x%llx fl013arg=0x%llx\n",
         (unsigned long long)a0, (long long)(int32_t)a1, (unsigned long long)a2, (unsigned long long)a3);
-    flip_advance((int32_t)a1, (int64_t)a3);
-    gpu::present_flip((int)(int32_t)a1, (int64_t)a3);   // present the buffer (scanout front + count)
+    const int32_t buffer_index = (int32_t)a1;
+    if (buffer_index < -1 || buffer_index > 15)
+        return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
+    flip_advance(buffer_index, (int64_t)a3);
+    gpu::present_flip(buffer_index, (int64_t)a3);   // present the buffer (scanout front + count)
     prosper_eq_trigger_flip((int64_t)a3);   // flip completed (synchronous): fire the flip event
     return 0;
 }

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -32,8 +32,12 @@ int main() {
     auto trigger = Hle::lookup(nid_hash("sceKernelTriggerUserEvent"));
     auto addhrt  = Hle::lookup(nid_hash("sceKernelAddHRTimerEvent"));
     auto wait    = Hle::lookup(nid_hash("sceKernelWaitEqueue"));
-    CHECK(create && adduser && trigger && addhrt && wait, "all equeue event fns registered");
-    if (!(create && adduser && trigger && addhrt && wait)) { printf("== FAIL ==\n"); return 1; }
+    auto getcount = Hle::lookup(nid_hash("sceKernelGetEventCount"));
+    CHECK(create && adduser && trigger && addhrt && wait && getcount,
+          "all equeue event fns registered");
+    if (!(create && adduser && trigger && addhrt && wait && getcount)) {
+        printf("== FAIL ==\n"); return 1;
+    }
 
     // Create an equeue: the handle is written to *arg0.
     uint64_t eq = 0;
@@ -97,7 +101,15 @@ int main() {
         constexpr uint64_t kFlipArg = 0x8000000000001234ull;
         constexpr uint64_t kFlipUdata = 0xFACEB00Cull;
         addflip(eq, 0x1001, kFlipUdata, 0, 0, 0);
+        CHECK((uint32_t)submitflp(0x1001, (uint64_t)(int64_t)-2, 0, kFlipArg, 0, 0) ==
+                  0x8029000au && getcount(eq, 0, 0, 0, 0, 0) == 0,
+              "invalid low flip index does not post a VideoOut completion event");
+        CHECK((uint32_t)submitflp(0x1001, 16, 0, kFlipArg, 0, 0) == 0x8029000au &&
+                  getcount(eq, 0, 0, 0, 0, 0) == 0,
+              "invalid high flip index does not post a VideoOut completion event");
         submitflp(0x1001, 0, 0, kFlipArg, 0, 0);
+        CHECK(getcount(eq, 0, 0, 0, 0, 0) == 1,
+              "valid flip posts one VideoOut completion event");
 
         KEvent fev{}; int32_t fout = -1; uint32_t fcap = 50000;
         wait(eq, (uint64_t)(uintptr_t)&fev, 1, (uint64_t)(uintptr_t)&fout,

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -17,6 +17,7 @@ extern "C" uint32_t prosper_vo_display_width();
 extern "C" uint32_t prosper_vo_display_height();
 extern "C" uint64_t prosper_vo_display_format();
 extern "C" uint64_t prosper_vo_buffer_addr(int i);
+extern "C" uint64_t prosper_vo_flip_count();
 extern "C" int prosper_vo_flip_rate();
 extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx,
                                            uint32_t flip_mode, int64_t flip_arg);
@@ -97,6 +98,16 @@ int main() {
     for (size_t i = 0x40; i < sizeof initial_fs; ++i)
         initial_tail_untouched &= initial_fs[i] == 0xEE;
     CHECK(initial_tail_untouched, "GetFlipStatus writes exactly its 0x40-byte ABI struct");
+
+    // #394 F10 (SubmitFlip index scope): reject values outside -1..15 before any completion
+    // bookkeeping. An invalid call must not advance either VideoOut status or present state.
+    const uint64_t initial_present_count = gpu::present_count();
+    CHECK((uint32_t)flip(0x1001, (uint64_t)(int64_t)-2, 0, 0xBAD, 0, 0) == 0x8029000au,
+          "SubmitFlip rejects an index below the -1 special slot");
+    CHECK((uint32_t)flip(0x1001, 16, 0, 0xBAD, 0, 0) == 0x8029000au,
+          "SubmitFlip rejects an index above slot 15");
+    CHECK(prosper_vo_flip_count() == 0 && gpu::present_count() == initial_present_count,
+          "rejected flips do not advance status or present state");
 
     // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed. The ABI struct is 0x30
     // bytes: flags/reserved0 at 0x1c and reserved1[3] at 0x20 must not retain caller garbage.
@@ -308,6 +319,11 @@ int main() {
               prosper_vo_buffer_count() == 0 && prosper_vo_buffer_addr(0) == 0 &&
               prosper_vo_display_width() == 0 && prosper_vo_display_height() == 0,
           "unregistering the remaining set clears the registry and geometry");
+
+    const uint64_t before_blank_flip = prosper_vo_flip_count();
+    CHECK(flip(0x1001, (uint64_t)(int64_t)-1, 0, 0, 0, 0) == 0 &&
+              prosper_vo_flip_count() == before_blank_flip + 1,
+          "SubmitFlip accepts the documented -1 blank-buffer special index");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary
- reject sceVideoOutSubmitFlip indices below -1 or above 15 with INVALID_INDEX
- perform validation before flip status, presentation, or completion-event side effects
- retain -1 as the documented blank-buffer special index
- add focused boundary and no-side-effect coverage

Addresses #394 F10 buffer-index validation only; other F10 validation remains separate and the umbrella issue stays open.

## Focused author checks
- Linux: videoout_queries passed
- Windows: prosper_core compiled
- No snapshots run