### PR TITLE
videoout: validate live handles

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <unordered_set>
 #include <utility>
 
 namespace prosper {
@@ -66,7 +67,26 @@ HLE(g_agc_regdefs_int) { gfx_tick(); return (uint64_t)(uintptr_t)prosper_agc_reg
 // window/surface exists. All output-struct writes are size-exact — over-writing smashes the guest's
 // stack canary (cf. the historical f_fstat bug).
 namespace {
-    int      g_vo_handle = 0;
+    constexpr uint64_t kVoErrorInvalidHandle =
+        (uint64_t)(int64_t)(int32_t)0x8029000b;  // SCE_VIDEO_OUT_ERROR_INVALID_HANDLE
+    int32_t g_vo_handle = 0;
+    std::mutex g_vo_handle_mx;
+    std::unordered_set<int32_t> g_vo_handles;
+
+    // Keep a live handle pinned until the HLE operation finishes. This makes validation and close
+    // atomic with respect to each other: a concurrent Close cannot retire a handle after a caller
+    // validates it but before that caller mutates flip, event, or buffer-registration state.
+    class VideoOutHandleGuard {
+    public:
+        explicit VideoOutHandleGuard(uint64_t raw_handle)
+            : lock_(g_vo_handle_mx),
+              valid_(g_vo_handles.find((int32_t)raw_handle) != g_vo_handles.end()) {}
+        bool valid() const { return valid_; }
+
+    private:
+        std::unique_lock<std::mutex> lock_;
+        bool valid_;
+    };
     // Flip bookkeeping (#82): count/flipArg/currentBuffer are written by TWO paths — SubmitFlip on
     // any guest thread and prosper_vo_flip_from_gpu on the submit thread — and read by GetFlipStatus
     // on Unity's pacer thread. They must move as ONE unit under a mutex: an unsynchronized reader
@@ -293,16 +313,30 @@ HLE(g_agc_add_eq_event) {   // (eq, id, udata, ...)
     prosper_eq_add_eop(a0, (int64_t)a1, a2);
     return 0;
 }
-HLE(g_vo_open)        { gfx_tick(); return (uint64_t)(int64_t)(++g_vo_handle + 0x1000); }  // positive handle
-HLE(g_vo_close)       { return 0; }
+HLE(g_vo_open) {
+    gfx_tick();
+    std::lock_guard<std::mutex> lk(g_vo_handle_mx);
+    const int32_t handle = ++g_vo_handle + 0x1000;
+    g_vo_handles.insert(handle);
+    return (uint64_t)(int64_t)handle;
+}
+HLE(g_vo_close) {
+    std::lock_guard<std::mutex> lk(g_vo_handle_mx);
+    if (g_vo_handles.erase((int32_t)a0) != 1) return kVoErrorInvalidHandle;
+    return 0;
+}
 // sceVideoOutAddFlipEvent(eq, handle, udata): register a flip-completion event source on an equeue.
 HLE(g_vo_addflipevent) {
+    VideoOutHandleGuard handle(a1);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     if (evlog()) fprintf(stderr, "[ev] AddFlipEvent eq=0x%llx handle=0x%llx udata=0x%llx\n",
         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2);
     prosper_eq_add_flip(a0, (int64_t)(int32_t)a1, a2);
     return 0;
 }
 HLE(g_vo_addvblankevent) {
+    VideoOutHandleGuard handle(a1);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     if (evlog()) fprintf(stderr, "[ev] AddVblankEvent eq=0x%llx handle=0x%llx udata=0x%llx\n",
         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2);
     prosper_eq_add_vblank(a0, (int64_t)(int32_t)a1, a2);
@@ -313,12 +347,16 @@ HLE(g_vo_addvblankevent) {
 HLE(g_vo_get_buffer_label_address) {
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     *(uintptr_t*)(uintptr_t)a1 = (uintptr_t)g_buffer_labels;
     return 16;
 }
 // sceVideoOutSetFlipRate (CBiu4mCE1DA): remember the port's requested divisor. Presentation is
 // synchronous today, but callers must still observe the documented validation/state contract.
 HLE(g_vo_set_flip_rate) {
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     const int32_t rate = (int32_t)a1;
     if (rate < 0 || rate > 2)
         return (uint64_t)(int64_t)(int32_t)0x80290001;  // SCE_VIDEO_OUT_ERROR_INVALID_VALUE
@@ -327,6 +365,8 @@ HLE(g_vo_set_flip_rate) {
     return 0;
 }
 HLE(g_vo_submitflip)  {
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     if (evlog()) fprintf(stderr, "[ev] SubmitFlip handle=0x%llx bufidx=%lld flipmode=0x%llx fl013arg=0x%llx\n",
         (unsigned long long)a0, (long long)(int32_t)a1, (unsigned long long)a2, (unsigned long long)a3);
     const int32_t buffer_index = (int32_t)a1;
@@ -344,17 +384,26 @@ HLE(g_vo_submitflip)  {
 // Unity's frame pacer polls for its submitted flipArg to complete before building the next frame, so
 // dropping this packet stalls the game at one rendered frame forever.
 extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx, uint32_t flip_mode, int64_t flip_arg) {
+    VideoOutHandleGuard live_handle(handle);
+    if (!live_handle.valid()) return;
     if (evlog()) fprintf(stderr, "[ev] GpuFlip handle=0x%x bufidx=%d mode=0x%x fliparg=0x%llx\n",
                          handle, bufidx, flip_mode, (unsigned long long)flip_arg);
     flip_advance(bufidx, flip_arg);
     gpu::present_flip(bufidx, flip_arg);   // scanout bookkeeping, same as the API flip
     prosper_eq_trigger_flip(flip_arg);     // flip completed (synchronous): fire the flip event
 }
-HLE(g_vo_flippending) { if (evlog()) fprintf(stderr, "[ev] IsFlipPending\n"); return 0; }        // never pending
+HLE(g_vo_flippending) {
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
+    if (evlog()) fprintf(stderr, "[ev] IsFlipPending\n");
+    return 0;  // never pending in the synchronous present model
+}
 HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our simulated flip count.
     // SceVideoOutFlipStatus is exactly 0x40 bytes — writing more smashes the caller's stack canary!
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x40);
     uint64_t cnt; int64_t arg; int32_t buf;
     { std::lock_guard<std::mutex> lk(g_flip_mx);   // consistent snapshot of the flip triple
@@ -369,6 +418,8 @@ HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our s
 HLE(g_vo_resstatus)   {
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x30);
     *(uint32_t*)(s + 0x00) = kDispW;   *(uint32_t*)(s + 0x04) = kDispH;   // full w/h
     *(uint32_t*)(s + 0x08) = kDispW;   *(uint32_t*)(s + 0x0c) = kDispH;   // pane w/h
@@ -385,6 +436,8 @@ HLE(g_vo_resstatus)   {
 HLE(g_vo_vblankstatus) {
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x28);
     uint64_t ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                       std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -404,13 +457,20 @@ HLE(g_vo_vblankstatus) {
 HLE(g_vo_devcap) {
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     *(uint64_t*)(uintptr_t)a1 = 0;
     return 0;
 }
 
-// sceVideoOutIsOutputSupported (Nv8c-Kb+DUM): (port_type, mode/feature) -> bool. A standard main-bus
+// sceVideoOutIsOutputSupported (Nv8c-Kb+DUM): (handle, mode/feature) -> bool. A standard main-bus
 // output supports the queried mode → 1.
-HLE(g_vo_is_output_supported) { vo_argtrace("IsOutputSupported", a0,a1,a2,a3,a4,a5); return 1; }
+HLE(g_vo_is_output_supported) {
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
+    vo_argtrace("IsOutputSupported", a0,a1,a2,a3,a4,a5);
+    return 1;
+}
 
 // sceVideoOutSetBufferAttribute (i6-sR91Wt-4): initialize the legacy/Gen4 BufferAttribute from
 // (attr, pixel_format, tiling_mode, aspect_ratio, width, height, pitch_in_pixel). The ABI object is
@@ -450,6 +510,8 @@ HLE(g_vo_set_buffer_attribute2) {  // a0=attr* a1=pixel_format a2=tiling a3=widt
 // offset 0; the remaining surface fields share the Gen5 offsets used by the present registry.
 HLE(g_vo_register_buffers) {  // a0=handle a1=start a2=addresses a3=buffer_num a4=attribute
     vo_argtrace("RegisterBuffers", a0,a1,a2,a3,a4,a5);
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     const int start = (int)a1, num = (int)a3;
     if (!a2 || !a4)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
@@ -500,6 +562,8 @@ HLE(g_vo_register_buffers) {  // a0=handle a1=start a2=addresses a3=buffer_num a
 // succeeds so the game proceeds to flips.
 HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a3=buffers a4=buffer_num a5=attribute
     vo_argtrace("RegisterBuffers2", a0,a1,a2,a3,a4,a5);
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     int set = (int)a1, start = (int)a2, num = (int)a4;
     if (!a3 || !a5) return (uint64_t)(int64_t)-1;
     if (set < 0 || set > 3 || start < 0 || start > 15 || num < 1 || num > 16 || start + num > 16)
@@ -548,6 +612,8 @@ HLE(g_vo_register_buffers2) {  // a0=handle a1=set_index a2=buffer_index_start a
 // recompute the highest visible slot instead of clearing the entire display unconditionally.
 HLE(g_vo_unregister_buffers) {
     vo_argtrace("UnregisterBuffers", a0,a1,a2,a3,a4,a5);
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     const int set = (int)a1;
     if (set < 0 || set > 3)
         return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
@@ -600,7 +666,12 @@ HLE(g_vo_unregister_buffers) {
 
 // sceVideoOutConfigureOutput (w0hLuNarQxY): set the output mode (resolution/refresh/format). We only
 // advertise one mode (1080p60), so accept the configuration.
-HLE(g_vo_configure_output) { vo_argtrace("ConfigureOutput", a0,a1,a2,a3,a4,a5); return 0; }
+HLE(g_vo_configure_output) {
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
+    vo_argtrace("ConfigureOutput", a0,a1,a2,a3,a4,a5);
+    return 0;
+}
 
 // sceVideoOutGetOutputStatus (utPrVdxio-8): (handle, status*). The full out-struct layout has NO
 // reference (Kyty predates it, shadPS4 only stubs the name), but the ONE consumer in the wild is
@@ -618,6 +689,8 @@ HLE(g_vo_get_output_status) {
     vo_argtrace("GetOutputStatus", a0,a1,a2,a3,a4,a5);
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
     if (a1 > 0xffffull) {
         *(uint32_t*)(uintptr_t)a1       = 0;   // +0x00: output state (0 = the boring/default state)
         *(uint32_t*)(uintptr_t)(a1 + 4) = 0;   // +0x04: dynamic-range mode (2 = HDR; 0 = SDR)
@@ -659,7 +732,12 @@ HLE(g_vo_get_event_data) {
 // sceVideoOutSetWindowModeMargins (MTxxrOCeSig — same brute-force naming): windowed-mode margin
 // hint for the system compositor. No compositor here — accept and ignore. CONFIDENCE: HIGH (pure
 // cosmetic setter; success unblocks the caller).
-HLE(g_vo_set_window_mode_margins) { vo_argtrace("SetWindowModeMargins", a0,a1,a2,a3,a4,a5); return 0; }
+HLE(g_vo_set_window_mode_margins) {
+    VideoOutHandleGuard handle(a0);
+    if (!handle.valid()) return kVoErrorInvalidHandle;
+    vo_argtrace("SetWindowModeMargins", a0,a1,a2,a3,a4,a5);
+    return 0;
+}
 
 // Diagnostic tracer for the (undocumented) libSceAgc / libSceAgcDriver calls: logs the NID, the guest
 // callsite, and all six args (gated on PROSPER_GFXLOG). Behaviour is identical to the unimplemented

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -122,18 +122,21 @@ int main() {
     // GetFlipStatus's count/flipArg/currentBuffer are what Unity's frame pacer polls before building
     // the next frame; a dropped in-stream flip stalls the game at one rendered frame.
     {
+        auto open       = Hle::lookup(nid_hash("sceVideoOutOpen"));
         auto setflip    = Hle::lookup("YUeqkyT7mEQ");                            // sceAgcDcbSetFlip
         auto flipstatus = Hle::lookup(nid_hash("sceVideoOutGetFlipStatus"));
-        CHECK(setflip && flipstatus, "SetFlip builder + GetFlipStatus registered");
-        if (setflip && flipstatus) {
+        CHECK(open && setflip && flipstatus,
+              "VideoOutOpen + SetFlip builder + GetFlipStatus registered");
+        if (open && setflip && flipstatus) {
+            const uint64_t handle = open(0, 0, 0, 0, 0, 0);
             uint8_t st_before[0x40], st_after[0x40];
-            flipstatus(0x1001, (uint64_t)(uintptr_t)st_before, 0, 0, 0, 0);
+            flipstatus(handle, (uint64_t)(uintptr_t)st_before, 0, 0, 0, 0);
             uint32_t fbuf[64]; memset(fbuf, 0, sizeof fbuf);
             Dcb fd{}; fd.bottom = fbuf; fd.top = fbuf + 64; fd.cursor_up = fbuf; fd.cursor_down = fbuf + 64;
-            setflip((uint64_t)(uintptr_t)&fd, 0x1001, 1, 2, 0x1234567890abcdefull, 0);
+            setflip((uint64_t)(uintptr_t)&fd, handle, 1, 2, 0x1234567890abcdefull, 0);
             GpuState s3;
             run_cb(fbuf, 64, s3);
-            flipstatus(0x1001, (uint64_t)(uintptr_t)st_after, 0, 0, 0, 0);
+            flipstatus(handle, (uint64_t)(uintptr_t)st_after, 0, 0, 0, 0);
             uint64_t cnt_b = *(uint64_t*)(st_before + 0x00), cnt_a = *(uint64_t*)(st_after + 0x00);
             int64_t  arg_a = *(int64_t*)(st_after + 0x18);
             int32_t  buf_a = *(int32_t*)(st_after + 0x38);

--- a/prosper/tests/test_det_clock.cpp
+++ b/prosper/tests/test_det_clock.cpp
@@ -28,9 +28,14 @@ int main() {
     setenv("PROSPER_DET_FPS", "60", 1);
 #endif
     register_builtin_hle();
+    auto videoout_open = Hle::lookup(nid_hash("sceVideoOutOpen"));
     auto ptc = Hle::lookup(nid_hash("sceKernelGetProcessTimeCounter"));
     auto clock_gettime_fn = Hle::lookup(nid_hash("sceKernelClockGettime"));
-    CHECK(ptc && clock_gettime_fn, "monotonic and realtime entry points registered");
+    CHECK(videoout_open && ptc && clock_gettime_fn,
+          "VideoOut and monotonic/realtime entry points registered");
+    if (fails) return 1;
+    const uint64_t handle = videoout_open(0, 0, 0, 0, 0, 0);
+    CHECK((int64_t)handle > 0, "opened a live VideoOut handle for flip pacing");
     if (fails) return 1;
 
     uint64_t pre0 = ptc(0, 0, 0, 0, 0, 0);
@@ -38,7 +43,7 @@ int main() {
     uint64_t pre1 = ptc(0, 0, 0, 0, 0, 0);
     CHECK(pre1 > pre0, "real monotonic time advances before the first flip");
 
-    prosper_vo_flip_from_gpu(0, 0, 0, 1);
+    prosper_vo_flip_from_gpu((uint32_t)handle, 0, 0, 1);
     constexpr size_t kThreads = 16;
     std::atomic<size_t> ready{0};
     std::atomic<bool> go{false};
@@ -73,7 +78,7 @@ int main() {
     int64_t wall_delta = (rt1[0] - rt0[0]) * 1000000000ll + (rt1[1] - rt0[1]);
     CHECK(wall_delta >= 10000000ll, "CLOCK_REALTIME continues advancing while monotonic time is paused");
 
-    prosper_vo_flip_from_gpu(0, 0, 0, 2);
+    prosper_vo_flip_from_gpu((uint32_t)handle, 0, 0, 2);
     uint64_t next = ptc(0, 0, 0, 0, 0, 0);
     CHECK(next - held == 1000000000ull / 60ull, "one flip advances monotonic time by exactly 1/60 second");
 

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -91,23 +91,25 @@ int main() {
 
     // VideoOut flip event accessor (#394 F5): the producer stores the submitted flipArg raw in
     // kevent.data, so GetEventData must preserve all 64 bits rather than decode a packed value.
+    auto vo_open   = Hle::lookup(nid_hash("sceVideoOutOpen"));
     auto addflip   = Hle::lookup(nid_hash("sceVideoOutAddFlipEvent"));
     auto submitflp = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
     auto vo_evid   = Hle::lookup("U2JJtSqNKZI");
     auto vo_evdata = Hle::lookup("rWUTcKdkUzQ");
-    CHECK(addflip && submitflp && vo_evid && vo_evdata,
+    CHECK(vo_open && addflip && submitflp && vo_evid && vo_evdata,
           "VideoOut flip event producer and accessors registered");
-    if (addflip && submitflp && vo_evid && vo_evdata) {
+    if (vo_open && addflip && submitflp && vo_evid && vo_evdata) {
+        const uint64_t handle = vo_open(0, 0, 0, 0, 0, 0);
         constexpr uint64_t kFlipArg = 0x8000000000001234ull;
         constexpr uint64_t kFlipUdata = 0xFACEB00Cull;
-        addflip(eq, 0x1001, kFlipUdata, 0, 0, 0);
-        CHECK((uint32_t)submitflp(0x1001, (uint64_t)(int64_t)-2, 0, kFlipArg, 0, 0) ==
+        addflip(eq, handle, kFlipUdata, 0, 0, 0);
+        CHECK((uint32_t)submitflp(handle, (uint64_t)(int64_t)-2, 0, kFlipArg, 0, 0) ==
                   0x8029000au && getcount(eq, 0, 0, 0, 0, 0) == 0,
               "invalid low flip index does not post a VideoOut completion event");
-        CHECK((uint32_t)submitflp(0x1001, 16, 0, kFlipArg, 0, 0) == 0x8029000au &&
+        CHECK((uint32_t)submitflp(handle, 16, 0, kFlipArg, 0, 0) == 0x8029000au &&
                   getcount(eq, 0, 0, 0, 0, 0) == 0,
               "invalid high flip index does not post a VideoOut completion event");
-        submitflp(0x1001, 0, 0, kFlipArg, 0, 0);
+        submitflp(handle, 0, 0, kFlipArg, 0, 0);
         CHECK(getcount(eq, 0, 0, 0, 0, 0) == 1,
               "valid flip posts one VideoOut completion event");
 

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -22,12 +22,15 @@ int main() {
     register_builtin_hle();
     gpu::present_reset();
 
+    auto open   = Hle::lookup(nid_hash("sceVideoOutOpen"));
     auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
     auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
-    CHECK(setba2 && regb2 && unreg && flip, "VideoOut functions registered");
-    if (!(setba2 && regb2 && unreg && flip)) { printf("== FAIL ==\n"); return 1; }
+    CHECK(open && setba2 && regb2 && unreg && flip, "VideoOut functions registered");
+    if (!(open && setba2 && regb2 && unreg && flip)) { printf("== FAIL ==\n"); return 1; }
+    const uint64_t handle = open(0, 0, 0, 0, 0, 0);
+    CHECK((int64_t)handle > 0, "opened a live VideoOut handle");
 
     // A small surface so the test framebuffers are cheap: 16x8 BGRA (512 bytes each), triple-buffered.
     const uint32_t W = 16, H = 8;
@@ -40,7 +43,7 @@ int main() {
     setba2((uint64_t)(uintptr_t)attr, 0x8000000000000000ull /*fmt*/, 0 /*tiling*/, W, H, 0 /*option*/);
     struct VOB { const void* data; const void* metadata; const void* reserved[2]; };
     VOB buffers[3] = { {fb0.data(),0,{0,0}}, {fb1.data(),0,{0,0}}, {fb2.data(),0,{0,0}} };
-    uint64_t rc = regb2(0x1001, 0, 0, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
+    uint64_t rc = regb2(handle, 0, 0, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
     CHECK(rc == 0, "registered a 3-buffer 16x8 surface");
     CHECK(gpu::present_width() == W && gpu::present_height() == H, "present layer sees the surface dimensions");
 
@@ -51,7 +54,7 @@ int main() {
 
     // Flip buffer 1 -> it becomes the presented (scanned-out) frame.
     uint64_t base_count = gpu::present_count();
-    flip(0x1001, 1 /*buffer*/, 0 /*mode*/, 0xABCD /*flipArg*/, 0, 0);
+    flip(handle, 1 /*buffer*/, 0 /*mode*/, 0xABCD /*flipArg*/, 0, 0);
     CHECK(gpu::present_front_index() == 1, "flip selected buffer 1 as front");
     CHECK(gpu::present_count() == base_count + 1, "present count incremented");
     size_t got = gpu::present_readback(out.data(), out.size());
@@ -59,14 +62,14 @@ int main() {
     CHECK(out[0] == 0x22 && out[FB_BYTES - 1] == 0x22, "presented frame is buffer 1's pixels");
 
     // Flip buffer 2 -> scanout follows.
-    flip(0x1001, 2, 0, 0, 0, 0);
+    flip(handle, 2, 0, 0, 0, 0);
     CHECK(gpu::present_front_index() == 2, "flip selected buffer 2 as front");
     gpu::present_readback(out.data(), out.size());
     CHECK(out[0] == 0x33, "presented frame now buffer 2's pixels");
 
     // Update buffer 2's contents (as a renderer would) and re-present: readback reflects live memory.
     for (size_t i = 0; i < FB_BYTES; i++) fb2[i] = 0x44;
-    flip(0x1001, 2, 0, 0, 0, 0);
+    flip(handle, 2, 0, 0, 0, 0);
     gpu::present_readback(out.data(), out.size());
     CHECK(out[0] == 0x44 && out[100] == 0x44, "readback reflects updated framebuffer memory");
     gpu::PresentSnapshot raw_snap;
@@ -85,10 +88,10 @@ int main() {
     setba2((uint64_t)(uintptr_t)small_attr, 0x8000000000000000ull,
            0 /*tiling*/, SMALL_W, SMALL_H, 0 /*option*/);
     VOB small_buffers[2] = { {fb4.data(),0,{0,0}}, {fb5.data(),0,{0,0}} };
-    rc = regb2(0x1001, 1 /*set*/, 4 /*start*/, (uint64_t)(uintptr_t)small_buffers, 2,
+    rc = regb2(handle, 1 /*set*/, 4 /*start*/, (uint64_t)(uintptr_t)small_buffers, 2,
                (uint64_t)(uintptr_t)small_attr);
     CHECK(rc == 0, "registered a second 2-buffer 4x2 surface");
-    flip(0x1001, 4, 0, 0, 0, 0);
+    flip(handle, 4, 0, 0, 0, 0);
     std::vector<uint8_t> small_out(SMALL_BYTES, 0xEE);
     got = gpu::present_readback(small_out.data(), small_out.size());
     CHECK(gpu::present_width() == SMALL_W && gpu::present_height() == SMALL_H &&
@@ -97,14 +100,14 @@ int main() {
 
     // Unregister invalidates the front identity under the same registry lock. Reusing the numeric
     // slot receives a new generation and must not present its new backing until another guest flip.
-    CHECK(unreg(0x1001, 1 /*set*/, 0, 0, 0, 0) == 0 &&
+    CHECK(unreg(handle, 1 /*set*/, 0, 0, 0, 0) == 0 &&
           gpu::present_front_index() == -1,
           "unregistering the front set atomically clears the front identity");
     std::vector<uint8_t> fb4_reused(SMALL_BYTES, 0x88), fb5_reused(SMALL_BYTES, 0x99);
     VOB reused_buffers[2] = {
         {fb4_reused.data(),0,{0,0}}, {fb5_reused.data(),0,{0,0}}
     };
-    CHECK(regb2(0x1001, 1 /*same set*/, 4 /*same start*/,
+    CHECK(regb2(handle, 1 /*same set*/, 4 /*same start*/,
                 (uint64_t)(uintptr_t)reused_buffers, 2,
                 (uint64_t)(uintptr_t)small_attr) == 0,
           "re-registered the same slots with new backing");
@@ -114,20 +117,20 @@ int main() {
           gpu::present_readback(small_out.data(), small_out.size()) == 0 &&
           !gpu::present_snapshot(no_flip_snap),
           "re-registering a numeric slot does not present new backing without a flip");
-    flip(0x1001, 4, 0, 0, 0, 0);
+    flip(handle, 4, 0, 0, 0, 0);
     got = gpu::present_readback(small_out.data(), small_out.size());
     CHECK(got == SMALL_BYTES && small_out.front() == 0x88 && small_out.back() == 0x88,
           "a new flip presents the re-registered generation");
 
-    flip(0x1001, 1, 0, 0, 0, 0);
+    flip(handle, 1, 0, 0, 0, 0);
     std::fill(out.begin(), out.end(), 0xEE);
     got = gpu::present_readback(out.data(), out.size());
     CHECK(gpu::present_width() == W && gpu::present_height() == H &&
           got == FB_BYTES && out.front() == 0x22 && out.back() == 0x22,
           "set 0 flip restores its 16x8 buffer with matching geometry");
 
-    // Out-of-range flip index leaves the front buffer unchanged (but still counts as a flip).
-    flip(0x1001, 99, 0, 0, 0, 0);
+    // Out-of-range flip index leaves the front buffer unchanged.
+    flip(handle, 99, 0, 0, 0, 0);
     CHECK(gpu::present_front_index() == 1, "out-of-range flip index does not corrupt the front buffer");
 
     // Receiving side: the renderer hands a finished frame -> present_readback returns THOSE pixels
@@ -164,7 +167,7 @@ int main() {
           *lease.rgba == rendered,
           "rendered-frame lease remains valid after a newer publication");
     // The rendered frame wins over the raw guest buffer even across flips.
-    flip(0x1001, 0, 0, 0, 0, 0);
+    flip(handle, 0, 0, 0, 0, 0);
     gpu::present_readback(out.data(), out.size());
     CHECK(memcmp(out.data(), replacement.data(), FB_BYTES) == 0,
           "latest rendered frame takes precedence over the flipped guest buffer");

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -33,6 +33,8 @@ int main() {
     printf("== test_videoout ==\n");
     register_builtin_hle();
 
+    auto open   = Hle::lookup(nid_hash("sceVideoOutOpen"));
+    auto close  = Hle::lookup(nid_hash("sceVideoOutClose"));
     auto res    = Hle::lookup(nid_hash("sceVideoOutGetResolutionStatus"));
     auto vbl    = Hle::lookup(nid_hash("sceVideoOutGetVblankStatus"));
     auto cap    = Hle::lookup(nid_hash("sceVideoOutGetDeviceCapabilityInfo"));
@@ -47,63 +49,125 @@ int main() {
     auto cfg    = Hle::lookup("w0hLuNarQxY");   // ConfigureOutput
     auto outstat = Hle::lookup("utPrVdxio-8");  // GetOutputStatus
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
+    auto pending = Hle::lookup(nid_hash("sceVideoOutIsFlipPending"));
+    auto addflip = Hle::lookup(nid_hash("sceVideoOutAddFlipEvent"));
+    auto addvblank = Hle::lookup(nid_hash("sceVideoOutAddVblankEvent"));
     auto fstat  = Hle::lookup(nid_hash("sceVideoOutGetFlipStatus"));
-    CHECK(res && vbl && cap && issup && setba && regb && setba2 && regb2 && unreg && labels &&
-              setrate && cfg && outstat && flip && fstat,
+    auto margins = Hle::lookup("MTxxrOCeSig");  // SetWindowModeMargins
+    CHECK(open && close && res && vbl && cap && issup && setba && regb && setba2 && regb2 &&
+              unreg && labels && setrate && cfg && outstat && flip && pending && addflip &&
+              addvblank && fstat && margins,
           "VideoOut functions registered");
-    if (!(res && vbl && cap && issup && setba && regb && setba2 && regb2 && unreg && labels &&
-          setrate && cfg && outstat && flip && fstat)) {
+    if (!(open && close && res && vbl && cap && issup && setba && regb && setba2 && regb2 &&
+          unreg && labels && setrate && cfg && outstat && flip && pending && addflip &&
+          addvblank && fstat && margins)) {
         printf("== FAIL ==\n"); return 1;
     }
+
+    const uint64_t handle = open(0, 0, 0, 0, 0, 0);
+    CHECK((int64_t)handle > 0, "VideoOutOpen returns a live positive handle");
 
     // #394 F10 (status-query output scope): a null result is an invalid address, not a successful
     // query that silently leaves the caller without status data.
     constexpr uint32_t kInvalidAddress = 0x80290002u;
-    CHECK((uint32_t)fstat(0x1001, 0, 0, 0, 0, 0) == kInvalidAddress,
+    CHECK((uint32_t)fstat(handle, 0, 0, 0, 0, 0) == kInvalidAddress,
           "GetFlipStatus rejects a null output pointer");
-    CHECK((uint32_t)res(0x1001, 0, 0, 0, 0, 0) == kInvalidAddress,
+    CHECK((uint32_t)res(handle, 0, 0, 0, 0, 0) == kInvalidAddress,
           "GetResolutionStatus rejects a null output pointer");
-    CHECK((uint32_t)vbl(0x1001, 0, 0, 0, 0, 0) == kInvalidAddress,
+    CHECK((uint32_t)vbl(handle, 0, 0, 0, 0, 0) == kInvalidAddress,
           "GetVblankStatus rejects a null output pointer");
-    CHECK((uint32_t)cap(0x1001, 0, 0, 0, 0, 0) == kInvalidAddress,
+    CHECK((uint32_t)cap(handle, 0, 0, 0, 0, 0) == kInvalidAddress,
           "GetDeviceCapabilityInfo rejects a null output pointer");
-    CHECK((uint32_t)outstat(0x1001, 0, 0, 0, 0, 0) == kInvalidAddress,
+    CHECK((uint32_t)outstat(handle, 0, 0, 0, 0, 0) == kInvalidAddress,
           "GetOutputStatus rejects a null output pointer");
+
+    // #394 F10 (handle scope): every handle-taking entrypoint must reject an unknown handle before
+    // it mutates output, flip/present state, event registrations, or the display-buffer registry.
+    constexpr uint32_t kInvalidHandle = 0x8029000bu;
+    const uint64_t invalid_handle = handle + 0x10000;
+    uint8_t invalid_output[0x80]; memset(invalid_output, 0xEE, sizeof invalid_output);
+    uintptr_t invalid_label_address = UINTPTR_MAX;
+    const uint64_t invalid_flip_count = prosper_vo_flip_count();
+    const uint64_t invalid_present_count = gpu::present_count();
+    CHECK((uint32_t)close(invalid_handle, 0, 0, 0, 0, 0) == kInvalidHandle,
+          "Close rejects an unknown handle");
+    CHECK((uint32_t)addflip(0, invalid_handle, 0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)addvblank(0, invalid_handle, 0, 0, 0, 0) == kInvalidHandle,
+          "event registration rejects an unknown handle before touching an equeue");
+    CHECK((uint32_t)labels(invalid_handle,
+                           (uint64_t)(uintptr_t)&invalid_label_address, 0, 0, 0, 0) ==
+              kInvalidHandle && invalid_label_address == UINTPTR_MAX,
+          "GetBufferLabelAddress rejects an unknown handle without writing output");
+    CHECK((uint32_t)setrate(invalid_handle, 1, 0, 0, 0, 0) == kInvalidHandle &&
+              prosper_vo_flip_rate() == 0,
+          "SetFlipRate rejects an unknown handle without changing rate state");
+    CHECK((uint32_t)flip(invalid_handle, 0, 0, 0xBAD, 0, 0) == kInvalidHandle &&
+              prosper_vo_flip_count() == invalid_flip_count &&
+              gpu::present_count() == invalid_present_count,
+          "SubmitFlip rejects an unknown handle before completion side effects");
+    prosper_vo_flip_from_gpu((uint32_t)invalid_handle, 0, 0, 0xBAD);
+    CHECK(prosper_vo_flip_count() == invalid_flip_count &&
+              gpu::present_count() == invalid_present_count,
+          "in-stream GPU flip ignores an unknown handle");
+    CHECK((uint32_t)pending(invalid_handle, 0, 0, 0, 0, 0) == kInvalidHandle,
+          "IsFlipPending rejects an unknown handle");
+    CHECK((uint32_t)fstat(invalid_handle, (uint64_t)(uintptr_t)invalid_output,
+                          0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)res(invalid_handle, (uint64_t)(uintptr_t)invalid_output,
+                            0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)vbl(invalid_handle, (uint64_t)(uintptr_t)invalid_output,
+                            0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)cap(invalid_handle, (uint64_t)(uintptr_t)invalid_output,
+                            0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)outstat(invalid_handle, (uint64_t)(uintptr_t)invalid_output,
+                                0, 0, 0, 0) == kInvalidHandle,
+          "status queries reject an unknown handle");
+    bool invalid_output_untouched = true;
+    for (uint8_t byte: invalid_output) invalid_output_untouched &= byte == 0xEE;
+    CHECK(invalid_output_untouched, "invalid-handle status queries leave output untouched");
+    CHECK((uint32_t)issup(invalid_handle, 0xd000000a, 0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)cfg(invalid_handle, 1, 0, 0, 0, 0) == kInvalidHandle &&
+              (uint32_t)margins(invalid_handle, 0, 0, 0, 0, 0) == kInvalidHandle,
+          "output configuration entrypoints reject an unknown handle");
+    CHECK((uint32_t)regb(invalid_handle, 0, 0, 1, 0, 0) == kInvalidHandle &&
+              (uint32_t)regb2(invalid_handle, 0, 0, 0, 1, 0) == kInvalidHandle &&
+              (uint32_t)unreg(invalid_handle, 0, 0, 0, 0, 0) == kInvalidHandle,
+          "buffer registration entrypoints reject an unknown handle before argument/state work");
 
     // #394 F7: the rate selector is per-port state rather than a success-returning no-op. All
     // documented rates are accepted; invalid values leave the last valid selection unchanged.
     CHECK(prosper_vo_flip_rate() == 0, "flip rate defaults to 60 Hz");
-    CHECK(setrate(0x1001, 1, 0, 0, 0, 0) == 0 && prosper_vo_flip_rate() == 1,
+    CHECK(setrate(handle, 1, 0, 0, 0, 0) == 0 && prosper_vo_flip_rate() == 1,
           "SetFlipRate stores the 30 Hz selector");
-    CHECK(setrate(0x1001, 2, 0, 0, 0, 0) == 0 && prosper_vo_flip_rate() == 2,
+    CHECK(setrate(handle, 2, 0, 0, 0, 0) == 0 && prosper_vo_flip_rate() == 2,
           "SetFlipRate stores the 20 Hz selector");
-    CHECK((uint32_t)setrate(0x1001, (uint64_t)(int64_t)-1, 0, 0, 0, 0) == 0x80290001u &&
+    CHECK((uint32_t)setrate(handle, (uint64_t)(int64_t)-1, 0, 0, 0, 0) == 0x80290001u &&
               prosper_vo_flip_rate() == 2,
           "SetFlipRate rejects -1 without changing the selected rate");
-    CHECK((uint32_t)setrate(0x1001, 3, 0, 0, 0, 0) == 0x80290001u &&
+    CHECK((uint32_t)setrate(handle, 3, 0, 0, 0, 0) == 0x80290001u &&
               prosper_vo_flip_rate() == 2,
           "SetFlipRate rejects values above 2 without changing the selected rate");
-    CHECK(setrate(0x1001, 0, 0, 0, 0, 0) == 0 && prosper_vo_flip_rate() == 0,
+    CHECK(setrate(handle, 0, 0, 0, 0, 0) == 0 && prosper_vo_flip_rate() == 0,
           "SetFlipRate restores the 60 Hz selector");
 
     // #394 F4: the query must initialize its output with stable, guest-writable storage for all
     // 16 buffer labels. A missing handler returned success without touching this pointer.
     uintptr_t label_address = UINTPTR_MAX;
-    CHECK((uint32_t)labels(0x1001, 0, 0, 0, 0, 0) == 0x80290002u,
+    CHECK((uint32_t)labels(handle, 0, 0, 0, 0, 0) == 0x80290002u,
           "GetBufferLabelAddress rejects a null output pointer");
-    CHECK(labels(0x1001, (uint64_t)(uintptr_t)&label_address, 0, 0, 0, 0) == 16 &&
+    CHECK(labels(handle, (uint64_t)(uintptr_t)&label_address, 0, 0, 0, 0) == 16 &&
               label_address != 0 && label_address != UINTPTR_MAX,
           "GetBufferLabelAddress returns 16 initialized labels");
     auto* buffer_labels = (uint64_t*)label_address;
     uintptr_t second_label_address = 0;
-    CHECK(labels(0x1001, (uint64_t)(uintptr_t)&second_label_address, 0, 0, 0, 0) == 16 &&
+    CHECK(labels(handle, (uint64_t)(uintptr_t)&second_label_address, 0, 0, 0, 0) == 16 &&
               second_label_address == label_address,
           "GetBufferLabelAddress returns stable storage");
 
     // #394 F3: before any completed flip, -1 is the ABI's "none yet" sentinel for both the argument
     // and current buffer. Zero is valid and used to make a frame pacer advance prematurely.
     uint8_t initial_fs[0x48]; memset(initial_fs, 0xEE, sizeof initial_fs);
-    CHECK(fstat(0x1001, (uint64_t)(uintptr_t)initial_fs, 0, 0, 0, 0) == 0,
+    CHECK(fstat(handle, (uint64_t)(uintptr_t)initial_fs, 0, 0, 0, 0) == 0,
           "initial GetFlipStatus succeeds");
     CHECK(*(uint64_t*)(initial_fs + 0x00) == 0 &&
           *(int64_t*)(initial_fs + 0x18) == -1 &&
@@ -117,9 +181,9 @@ int main() {
     // #394 F10 (SubmitFlip index scope): reject values outside -1..15 before any completion
     // bookkeeping. An invalid call must not advance either VideoOut status or present state.
     const uint64_t initial_present_count = gpu::present_count();
-    CHECK((uint32_t)flip(0x1001, (uint64_t)(int64_t)-2, 0, 0xBAD, 0, 0) == 0x8029000au,
+    CHECK((uint32_t)flip(handle, (uint64_t)(int64_t)-2, 0, 0xBAD, 0, 0) == 0x8029000au,
           "SubmitFlip rejects an index below the -1 special slot");
-    CHECK((uint32_t)flip(0x1001, 16, 0, 0xBAD, 0, 0) == 0x8029000au,
+    CHECK((uint32_t)flip(handle, 16, 0, 0xBAD, 0, 0) == 0x8029000au,
           "SubmitFlip rejects an index above slot 15");
     CHECK(prosper_vo_flip_count() == 0 && gpu::present_count() == initial_present_count,
           "rejected flips do not advance status or present state");
@@ -127,7 +191,7 @@ int main() {
     // Resolution: real 1080p @ 59.94Hz (refresh enum 3), not zeroed. The ABI struct is 0x30
     // bytes: flags/reserved0 at 0x1c and reserved1[3] at 0x20 must not retain caller garbage.
     uint8_t rs[0x38]; memset(rs, 0xEE, sizeof rs);
-    res(0x1001, (uint64_t)(uintptr_t)rs, 0, 0, 0, 0);
+    res(handle, (uint64_t)(uintptr_t)rs, 0, 0, 0, 0);
     CHECK(*(uint32_t*)(rs + 0x00) == 1920 && *(uint32_t*)(rs + 0x04) == 1080, "resolution 1920x1080 (full)");
     CHECK(*(uint32_t*)(rs + 0x08) == 1920 && *(uint32_t*)(rs + 0x0c) == 1080, "resolution 1920x1080 (pane)");
     CHECK(*(uint64_t*)(rs + 0x10) == 3, "refresh rate = 59.94Hz (enum 3)");
@@ -143,22 +207,22 @@ int main() {
     // the old ++-per-call behavior made every poll look like a fresh vblank (issue #82). Two
     // immediate calls land in the same period; a > one-period sleep must advance the count.
     uint8_t vb[0x28];
-    vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c0 = *(uint64_t*)vb;
+    vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c0 = *(uint64_t*)vb;
     CHECK(c0 > 0, "first vblank query reports a live non-zero counter");
-    vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c1 = *(uint64_t*)vb;
+    vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c1 = *(uint64_t*)vb;
     CHECK(c1 - c0 <= 1, "vblank counter does NOT tick per poll (immediate re-poll ~same period)");
     std::this_thread::sleep_for(std::chrono::milliseconds(40));   // > 2 vblank periods
-    vbl(0x1001, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c2 = *(uint64_t*)vb;
+    vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c2 = *(uint64_t*)vb;
     CHECK(c2 > c1, "vblank counter advances across a >1-period sleep");
     CHECK(*(uint64_t*)(vb + 0x08) > 0, "vblank processTime filled (Kyty layout @0x08)");
 
     // Device capability: plain SDR display (capability 0).
     uint64_t dc = 0xDEAD;
-    cap(0x1001, (uint64_t)(uintptr_t)&dc, 0, 0, 0, 0);
+    cap(handle, (uint64_t)(uintptr_t)&dc, 0, 0, 0, 0);
     CHECK(dc == 0, "device capability = 0 (SDR)");
 
     // IsOutputSupported → supported.
-    CHECK(issup(0x1001, 0xd000000a, 0, 0, 0, 0) == 1, "IsOutputSupported returns 1");
+    CHECK(issup(handle, 0xd000000a, 0, 0, 0, 0) == 1, "IsOutputSupported returns 1");
 
     // #394 F2: the legacy setter is an output function, not a success-returning no-op. It fills
     // the seven public fields, zeros option/reserved storage, and writes exactly 0x28 bytes.
@@ -186,12 +250,12 @@ int main() {
     // and records its non-zero slot range using the Gen4 attribute layout.
     uint8_t legacy_fb2[16], legacy_fb3[16];
     const void* legacy_buffers[2] = {legacy_fb2, legacy_fb3};
-    CHECK((uint32_t)regb(0x1001, 15, (uint64_t)(uintptr_t)legacy_buffers, 2,
+    CHECK((uint32_t)regb(handle, 15, (uint64_t)(uintptr_t)legacy_buffers, 2,
                          (uint64_t)(uintptr_t)legacy_attr, 0) == 0x80290001u,
           "legacy RegisterBuffers rejects a range past slot 15");
     buffer_labels[2] = 0xAAAA;
     buffer_labels[3] = 0xBBBB;
-    uint64_t legacy_group = regb(0x1001, 2, (uint64_t)(uintptr_t)legacy_buffers, 2,
+    uint64_t legacy_group = regb(handle, 2, (uint64_t)(uintptr_t)legacy_buffers, 2,
                                  (uint64_t)(uintptr_t)legacy_attr, 0);
     CHECK(legacy_group == 0, "legacy RegisterBuffers returns the lowest free attribute group");
     CHECK(prosper_vo_buffer_count() == 4 &&
@@ -203,10 +267,10 @@ int main() {
     CHECK(prosper_vo_display_width() == 1280 && prosper_vo_display_height() == 720 &&
           prosper_vo_display_format() == 0x80002200u,
           "legacy RegisterBuffers records Gen4 surface geometry and format");
-    CHECK((uint32_t)regb(0x1001, 3, (uint64_t)(uintptr_t)legacy_buffers, 2,
+    CHECK((uint32_t)regb(handle, 3, (uint64_t)(uintptr_t)legacy_buffers, 2,
                          (uint64_t)(uintptr_t)legacy_attr, 0) == 0x80290010u,
           "legacy RegisterBuffers rejects an overlapping slot range");
-    CHECK(unreg(0x1001, legacy_group, 0, 0, 0, 0) == 0 &&
+    CHECK(unreg(handle, legacy_group, 0, 0, 0, 0) == 0 &&
           prosper_vo_buffer_count() == 0 && prosper_vo_display_width() == 0,
           "legacy buffer group unregisters cleanly before Gen5 registration");
 
@@ -219,7 +283,7 @@ int main() {
     CHECK(*(uint32_t*)(attr + 0x04) == 0, "attribute tiling_mode set");
 
     // ConfigureOutput accepts the (single advertised) mode.
-    CHECK(cfg(0x1001, 1, 0, 0, 0, 0) == 0, "ConfigureOutput accepted");
+    CHECK(cfg(handle, 1, 0, 0, 0, 0) == 0, "ConfigureOutput accepted");
 
     // RegisterBuffers2: triple-buffered surface. buffers = array of VideoOutBuffers {data, ...}.
     struct VOB { const void* data; const void* metadata; const void* reserved[2]; };
@@ -228,7 +292,7 @@ int main() {
     buffer_labels[0] = 0x1111;
     buffer_labels[1] = 0x2222;
     buffer_labels[2] = 0x3333;
-    uint64_t rc = regb2(0x1001, 0 /*set*/, 0 /*start*/, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
+    uint64_t rc = regb2(handle, 0 /*set*/, 0 /*start*/, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
     CHECK(rc == 0, "RegisterBuffers2 accepted 3 buffers");
     CHECK(buffer_labels[0] == 0 && buffer_labels[1] == 0 && buffer_labels[2] == 0,
           "RegisterBuffers2 resets labels for its registered slots");
@@ -244,14 +308,14 @@ int main() {
     // must happen before any slot is changed, even when the proposed range itself is free.
     uint8_t fb4a[16], fb5a[16];
     VOB candidate_buffers[2] = { {fb4a,0,{0,0}}, {fb5a,0,{0,0}} };
-    rc = regb2(0x1001, 0 /*duplicate set*/, 4 /*free start*/,
+    rc = regb2(handle, 0 /*duplicate set*/, 4 /*free start*/,
                (uint64_t)(uintptr_t)candidate_buffers, 2, (uint64_t)(uintptr_t)attr);
     CHECK((uint32_t)rc == 0x8029000au,
           "RegisterBuffers2 rejects a duplicate active set identifier");
 
     // A different set may not claim any slot already owned by set 0. The whole range is validated
     // before mutation, so this failure cannot replace either overlapping address or reserve set 1.
-    rc = regb2(0x1001, 1 /*new set*/, 1 /*occupied start*/,
+    rc = regb2(handle, 1 /*new set*/, 1 /*occupied start*/,
                (uint64_t)(uintptr_t)candidate_buffers, 2, (uint64_t)(uintptr_t)attr);
     CHECK((uint32_t)rc == 0x80290010u,
           "RegisterBuffers2 rejects slots owned by another active set");
@@ -263,20 +327,20 @@ int main() {
 
     uint8_t fs[0x40]; memset(fs, 0xEE, sizeof fs);
     buffer_labels[2] = 1;
-    CHECK(flip(0x1001, 2 /*buffer*/, 0 /*mode*/, 0x12345678 /*flipArg*/, 0, 0) == 0,
+    CHECK(flip(handle, 2 /*buffer*/, 0 /*mode*/, 0x12345678 /*flipArg*/, 0, 0) == 0,
           "SubmitFlip accepted buffer 2");
     CHECK(buffer_labels[2] == 1,
           "first completed flip retains the current buffer label");
-    fstat(0x1001, (uint64_t)(uintptr_t)fs, 0, 0, 0, 0);
+    fstat(handle, (uint64_t)(uintptr_t)fs, 0, 0, 0, 0);
     CHECK(*(uint64_t*)(fs + 0x00) == 1, "flip status count increments");
     CHECK(*(int64_t*) (fs + 0x18) == 0x12345678, "flip status reports the submitted flipArg");
     CHECK(*(int32_t*) (fs + 0x38) == 2, "flip status reports the submitted currentBuffer");
 
     // Range validation: out-of-range buffer counts are rejected.
-    CHECK(regb2(0x1001, 2, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,
+    CHECK(regb2(handle, 2, 0, (uint64_t)(uintptr_t)buffers, 99, (uint64_t)(uintptr_t)attr) != 0,
           "RegisterBuffers2 rejects an out-of-range buffer_num");
 
-    CHECK((uint32_t)unreg(0x1001, 3 /*unregistered set*/, 0, 0, 0, 0) == 0x8029000au,
+    CHECK((uint32_t)unreg(handle, 3 /*unregistered set*/, 0, 0, 0, 0) == 0x8029000au,
           "UnregisterBuffers rejects an absent set without changing registration");
     CHECK(prosper_vo_buffer_count() == 3 &&
               prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0,
@@ -289,56 +353,78 @@ int main() {
     *(uint32_t*)(high_attr + 0x10) = 720;
     uint8_t fb4[16], fb5[16];
     VOB high_buffers[2] = { {fb4,0,{0,0}}, {fb5,0,{0,0}} };
-    uint64_t high_rc = regb2(0x1001, 1 /*set*/, 4 /*start*/,
+    uint64_t high_rc = regb2(handle, 1 /*set*/, 4 /*start*/,
                              (uint64_t)(uintptr_t)high_buffers, 2,
                              (uint64_t)(uintptr_t)high_attr);
     CHECK(high_rc == 0 && prosper_vo_buffer_count() == 6 &&
               prosper_vo_display_width() == 1280 && prosper_vo_display_height() == 720,
           "registry tracks two independently owned buffer sets");
-    flip(0x1001, 2 /*set 0 buffer*/, 0, 0, 0, 0);
+    flip(handle, 2 /*set 0 buffer*/, 0, 0, 0, 0);
     CHECK(buffer_labels[2] == 0,
           "SubmitFlip releases the previously displayed buffer label");
     CHECK(gpu::present_width() == 1920 && gpu::present_height() == 1080,
           "present uses set 0 geometry when an older set's buffer is flipped");
     buffer_labels[2] = 1;
     buffer_labels[4] = 1;
-    prosper_vo_flip_from_gpu(0x1001, 4 /*set 1 buffer*/, 0, 0);
+    prosper_vo_flip_from_gpu(handle, 4 /*set 1 buffer*/, 0, 0);
     CHECK(buffer_labels[2] == 0 && buffer_labels[4] == 1,
           "GPU flip releases the previous label without overwriting the current label");
     CHECK(gpu::present_width() == 1280 && gpu::present_height() == 720,
           "present uses set 1 geometry when its buffer is flipped");
-    CHECK(unreg(0x1001, 1 /*set*/, 0, 0, 0, 0) == 0 &&
+    CHECK(unreg(handle, 1 /*set*/, 0, 0, 0, 0) == 0 &&
               prosper_vo_buffer_count() == 3 &&
               prosper_vo_buffer_addr(0) == (uint64_t)(uintptr_t)fb0 &&
               prosper_vo_buffer_addr(2) == (uint64_t)(uintptr_t)fb2 &&
               prosper_vo_display_width() == 1920 && prosper_vo_display_height() == 1080,
           "unregistering one set restores the remaining set's range and geometry");
-    CHECK(regb2(0x1001, 1 /*reused set*/, 4 /*reused start*/,
+    CHECK(regb2(handle, 1 /*reused set*/, 4 /*reused start*/,
                 (uint64_t)(uintptr_t)high_buffers, 2,
                 (uint64_t)(uintptr_t)high_attr) == 0,
           "an unregistered buffer range can be registered again");
     buffer_labels[4] = 1;
-    flip(0x1001, 4 /*new registration in reused slot*/, 0, 0, 0, 0);
+    flip(handle, 4 /*new registration in reused slot*/, 0, 0, 0, 0);
     CHECK(buffer_labels[4] == 1,
           "first flip of a reused slot retains the new registration's current label");
-    CHECK(unreg(0x1001, 1 /*reused set*/, 0, 0, 0, 0) == 0 &&
+    CHECK(unreg(handle, 1 /*reused set*/, 0, 0, 0, 0) == 0 &&
               buffer_labels[4] == 0,
           "unregistering a displayed slot retires its label identity");
     buffer_labels[2] = 1;
-    flip(0x1001, 2 /*remaining set 0 buffer*/, 0, 0, 0, 0);
+    flip(handle, 2 /*remaining set 0 buffer*/, 0, 0, 0, 0);
     CHECK(buffer_labels[2] == 1,
           "first flip after the previous slot is unregistered retains the current label");
     CHECK(gpu::present_width() == 1920 && gpu::present_height() == 1080,
           "present continues with the surviving set after unregister");
-    CHECK(unreg(0x1001, 0 /*set*/, 0, 0, 0, 0) == 0 &&
+    CHECK(unreg(handle, 0 /*set*/, 0, 0, 0, 0) == 0 &&
               prosper_vo_buffer_count() == 0 && prosper_vo_buffer_addr(0) == 0 &&
               prosper_vo_display_width() == 0 && prosper_vo_display_height() == 0,
           "unregistering the remaining set clears the registry and geometry");
 
     const uint64_t before_blank_flip = prosper_vo_flip_count();
-    CHECK(flip(0x1001, (uint64_t)(int64_t)-1, 0, 0, 0, 0) == 0 &&
+    CHECK(flip(handle, (uint64_t)(int64_t)-1, 0, 0, 0, 0) == 0 &&
               prosper_vo_flip_count() == before_blank_flip + 1,
           "SubmitFlip accepts the documented -1 blank-buffer special index");
+
+    // Closing retires exactly this handle. API and in-stream flip paths must both stop accepting it,
+    // and a repeated Close reports INVALID_HANDLE instead of false success.
+    const uint64_t before_close_flip_count = prosper_vo_flip_count();
+    const uint64_t before_close_present_count = gpu::present_count();
+    CHECK(close(handle, 0, 0, 0, 0, 0) == 0,
+          "Close retires a live VideoOut handle");
+    CHECK((uint32_t)close(handle, 0, 0, 0, 0, 0) == kInvalidHandle,
+          "Close rejects an already-closed handle");
+    CHECK((uint32_t)flip(handle, 0, 0, 0xC105ED, 0, 0) == kInvalidHandle,
+          "SubmitFlip rejects a closed handle");
+    prosper_vo_flip_from_gpu((uint32_t)handle, 0, 0, 0xC105ED);
+    CHECK(prosper_vo_flip_count() == before_close_flip_count &&
+              gpu::present_count() == before_close_present_count,
+          "closed-handle flips cannot advance API or in-stream present state");
+    uint8_t closed_status[0x40]; memset(closed_status, 0xEE, sizeof closed_status);
+    CHECK((uint32_t)fstat(handle, (uint64_t)(uintptr_t)closed_status, 0, 0, 0, 0) ==
+              kInvalidHandle,
+          "status queries reject a closed handle");
+    bool closed_status_untouched = true;
+    for (uint8_t byte: closed_status) closed_status_untouched &= byte == 0xEE;
+    CHECK(closed_status_untouched, "closed-handle status query leaves output untouched");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary
- track every live handle returned by `sceVideoOutOpen` and retire it exactly once in `sceVideoOutClose`
- reject unknown or closed handles with `SCE_VIDEO_OUT_ERROR_INVALID_HANDLE` before VideoOut output, event, flip/present, or buffer-registry side effects
- serialize close against in-flight handle operations and cover the in-stream GPU flip path
- update VideoOut tests to use real opened handles and add unknown/closed-handle regressions

Refs #394 (focused F10 remainder; the broader audit issue stays open).

## Focused validation before publication
- Windows MinGW: `command_processor_apply`, `equeue_events` — 2/2 passed
- Linux: `videoout_queries`, `videoout_present`, `command_processor_apply`, `equeue_events` — 4/4 passed
- native Windows Messenger fresh-save smoke: progressed to 114 submits / 113 presents with no invalid-handle errors
- no snapshots run

The full author verifier is intentionally run after the ready PR is posted, per repository workflow.