### PR TITLE
gpu: require instruction provenance for compute buffers

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -793,43 +793,10 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
         }
     }
 
-    // Additional directly-placed COMPUTE buffers (#566). Gen5 compute shaders put buffer V#s straight
-    // in the user-SGPR block and reference them by SRSRC, but the shader's resource-usage metadata only
-    // declares the FIRST (direct_resource_offset type 1 -> reg 0, handled above). A format-copy compute
-    // — Dead Cells: `buffer_load_format_xyzw v, vIDX, s[0:3]` then `buffer_store_format_xyzw v, vIDX,
-    // s[4:7]` — therefore had its STORE destination V# (at s4) absent from the table, so the store's
-    // SRSRC resolved to nothing and the whole shader was rejected (`[mubuf-unresolved] srsrc=s4`). Its
-    // dispatch was then dropped, losing the scene-composition pass. Expose every remaining 4-dword-
-    // aligned user-SGPR slot that decodes to a plausible buffer V#, keyed by sgpr_base, so the recompiler
-    // resolves the SRSRC via by_sgpr_base. The SAME plausibility guard used for the type-1/vertex buffers
-    // rejects leftover non-descriptor SGPRs: a real V# has a mapped base and a sane size, while stale
-    // registers decode as base 0 or the ~0xFFFFFFFF max size. In the exercised Dead Cells frame this
-    // emits ONLY the real copy destinations; every other compute shader's trailing slots are filtered.
-    // An unreferenced extra resource is harmless — the recompiler binds only the SRSRCs it actually uses.
-    // CONFIDENCE: HIGH (live-verified: dispatch 0x401aec800 realizes and the dropped pass returns).
-    if (shdr.type == 0) {
-        for (uint32_t reg = 0; reg + 4 <= num_user_sgprs; reg += 4) {
-            const uint32_t sgpr = user_sgpr_base + reg;
-            bool covered = false;
-            for (const ShaderResource& e : table.resources)
-                if (e.sgpr_base == sgpr) { covered = true; break; }
-            if (covered) continue;
-            DecodedBufferDescriptor d = decode_buffer_descriptor(&user_sgprs[reg]);
-            if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
-                d.format == DataFormat::Unknown || !d.num_components) continue;
-            ShaderResource r;
-            r.cls            = ResourceClass::ConstantBuffer;   // storage buffer (readable + writable)
-            r.format         = d.format;
-            r.num_components  = d.num_components;
-            r.binding        = binding++;
-            r.gpu_addr       = d.base;
-            r.size           = d.size_bytes;
-            r.stride         = d.stride;
-            r.sgpr_base      = sgpr;
-            r.srt_offset     = 0xFFFFFFFFu;      // direct (not s_loaded)
-            table.resources.push_back(r);
-        }
-    }
+    // Do not guess additional compute buffers by scanning arbitrary user-SGPR quartets. Scalar
+    // arguments can decode as plausible V#s and would then leak into capture/dependency tooling even
+    // when no instruction consumes them. Undeclared direct compute V#s are recovered at their actual
+    // MUBUF uses by resolve_dynamic_fetch, with exact instruction provenance and reload invalidation.
     return table;
 }
 

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -136,6 +136,14 @@ std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             std::vector<SrtUse>* srt_uses = nullptr,
                                             uint32_t pcrel_dispatch_target = UINT32_MAX);
 
+// Add instruction-provenance compute buffer resources to a metadata-built table. This is the exact
+// buffer-discovery path used by realize_compute_dispatches; it is exposed so tests can assert the
+// final resource identities instead of manually rebuilding a lookalike table. Returned SrtUses also
+// contain image uses, which the production caller materializes with image-specific view handling.
+std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
+                                                 const uint32_t* code, size_t dwords,
+                                                 const uint32_t* user_sgprs, uint32_t nsgpr);
+
 // The dynamic descriptor fold and shader-cache key builder both walk immutable shader instructions
 // on every draw. Cache only the decoded instructions, validating the complete consumed byte range on
 // every hit. Concrete SGPR values and descriptor-table memory remain per-draw inputs to the fold.

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -95,6 +95,10 @@ struct DynFetch {
     // patched V#s fold their in-record offset into the base), while a single direct V# needs the
     // faithful VADDR/inst-offset address — shadowing it collapses every attribute onto offset 0.
     bool from_seed = false;
+    // Descriptor before the instruction's constant OFFSET/SOFFSET is folded into `desc.base`.
+    // Graphics VertexBuffers need the shifted descriptor for their special vertex-index path;
+    // compute ConstantBuffers keep this original descriptor and apply those terms exactly once.
+    DecodedBufferDescriptor unshifted_desc;
 };
 
 // One descriptor-TABLE use recovered by the same const-fold (#294): UE4 shaders load their T#/S#/V#

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1562,7 +1562,9 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                 in.pc, desc_v3);
                             return;
                         }
-                        out.push_back({ in.pc, srsrc, with_off(d), desc_v3, from_seed });
+                        DynFetch fetch{ in.pc, srsrc, with_off(d), desc_v3, from_seed };
+                        fetch.unshifted_desc = d;
+                        out.push_back(fetch);
                     };
                     if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x soff_known=%d\n",
                                      in.pc, in.opcode, srsrc, patched, k0, k1, k2, k3,
@@ -1673,8 +1675,10 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         code, dwords, user_sgprs, nsgpr, /*user_sgpr_base*/0, &srt_uses);
 
     // A format-load resource has one identity: the descriptor live at its exact instruction pc.
+    // Keep its original base because the compute ConstantBuffer address path applies the MUBUF
+    // OFFSET/SOFFSET itself; `fetch.desc` is shifted for graphics' special vertex-index path.
     for (const auto& fetch : direct_fetches) {
-        const DecodedBufferDescriptor& d = fetch.desc;
+        const DecodedBufferDescriptor& d = fetch.unshifted_desc;
         if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
             d.format == DataFormat::Unknown || !d.num_components || d.forbid_unknown_fallback)
             continue;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1096,6 +1096,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         v = val[(size_t)r];
         return true;
     };
+    auto unchanged_seed_range = [&](int first, int count) {
+        if (!untouched_seed_range(first, count)) return false;
+        for (int r = first; r < first + count; ++r) {
+            uint32_t current = 0;
+            if (!known(r, current) ||
+                current != user_sgprs[r - (int)user_sgpr_base]) return false;
+        }
+        return true;
+    };
     // Resolve an ALU source operand to a concrete value (SGPR / inline int / literal / a vcc Special).
     // vcc_lo/hi (106/107) are written by ALU dsts as SGPR 106/107 but read back as Special operands with
     // the same field value, so map them onto the same val[] keys. Other Specials (EXEC/M0/...) stay unknown.
@@ -1450,7 +1459,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 const bool raw_buffer_use =
                     (in.opcode >= 0x08 && in.opcode <= 0x0F) ||
                     (in.opcode >= 0x1C && in.opcode <= 0x1E);
-                if (srt_uses && (in.opcode <= 3 || raw_buffer_use)) {
+                const bool format_store_use = in.opcode >= 0x04 && in.opcode <= 0x07;
+                if (srt_uses && (in.opcode <= 3 || format_store_use || raw_buffer_use)) {
                     int srsrc = in.src[1].value;
                     if (valid_reg(srsrc) && descr_known.test((size_t)srsrc)) {
                         // Key-less snapshots (an s_buffer_load-fetched V# — a structured-buffer
@@ -1462,20 +1472,26 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             ? descr_key[(size_t)srsrc] : 0xFFFFFFFFu;
                         u.use_pc = in.pc;
                         srt_uses->push_back(u);
-                    } else if (raw_buffer_use && untouched_seed_range(srsrc, 4)) {
-                        // Direct RAW V#: an untyped MUBUF can consume a V# placed in the initial
-                        // user-data SGPRs without any preceding s_load. This is not a vertex-format
-                        // fetch, so the dyn_vb path below never reports it. Preserve the exact V# as
-                        // a pc-keyed buffer view; treating the same eight SGPRs as a plausible T# can
-                        // otherwise make raw MUBUF resolve to a texture (stride 0), dropping idxen.
+                    } else if ((format_store_use || raw_buffer_use) &&
+                               unchanged_seed_range(srsrc, 4)) {
+                        // Direct V#: a raw or format-store MUBUF can consume a V# placed in the
+                        // initial user-data SGPRs without any preceding s_load. Preserve it only for
+                        // the exact consuming instruction and only while all four seed values remain
+                        // current; guessing every descriptor-looking user-data quartet invents
+                        // capture/dependency resources, while accepting a rewritten seed resurrects
+                        // stale provenance.
                         SrtUse u; u.kind = 1; u.key = 0xFFFFFFFFu; u.use_pc = in.pc;
                         for (int k = 0; k < 4; ++k)
                             u.v4[k] = user_sgprs[srsrc - (int)user_sgpr_base + k];
                         DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                        const bool format_supported = !format_store_use ||
+                            (d.format != DataFormat::Unknown && d.num_components != 0 &&
+                             !d.forbid_unknown_fallback);
                         if (d.base > 0x10000 && d.size_bytes != 0 &&
-                            d.size_bytes <= 0x10000000u && d.stride != 0) {
+                            d.size_bytes <= 0x10000000u && d.stride != 0 &&
+                            format_supported) {
                             if (trc) fprintf(stderr,
-                                             "[dyntrace] raw MUBUF pc=%u direct V# s%d base=0x%llx "
+                                             "[dyntrace] direct MUBUF pc=%u direct V# s%d base=0x%llx "
                                              "stride=%u size=%u\n",
                                              in.pc, srsrc, (unsigned long long)d.base,
                                              d.stride, d.size_bytes);
@@ -2303,8 +2319,36 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // Texture. Never shadow an existing resource at the same srt_offset (first-match-wins).
         {
             std::vector<SrtUse> srt_uses;
-            resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
-                                  sgprs, kUserSgprs, /*user_sgpr_base*/0, &srt_uses);
+            const std::vector<DynFetch> direct_fetches = resolve_dynamic_fetch(
+                (const uint32_t*)(uintptr_t)code_addr, shader_dwords,
+                sgprs, kUserSgprs, /*user_sgpr_base*/0, &srt_uses);
+            // Format-load V#s use resolve_dynamic_fetch's exact fetch-pc result. This covers direct
+            // compute sources that metadata omits without reviving the old all-SGPR scan.
+            for (const auto& fetch : direct_fetches) {
+                const DecodedBufferDescriptor& d = fetch.desc;
+                if (d.base <= 0x10000 || d.size_bytes == 0 ||
+                    d.size_bytes > 0x10000000u || d.format == DataFormat::Unknown ||
+                    !d.num_components || d.forbid_unknown_fallback) continue;
+                bool mapped = false;
+                for (auto& r0 : table->resources) {
+                    if (r0.cls != ResourceClass::ConstantBuffer ||
+                        r0.gpu_addr != d.base || r0.size != d.size_bytes ||
+                        r0.stride != d.stride || r0.format != d.format ||
+                        r0.num_components != d.num_components) continue;
+                    if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = fetch.fetch_pc;
+                    if (r0.fetch_pc == fetch.fetch_pc) { mapped = true; break; }
+                }
+                if (mapped) continue;
+                ShaderResource r;
+                r.cls = ResourceClass::ConstantBuffer;
+                r.format = d.format;
+                r.num_components = d.num_components;
+                r.gpu_addr = d.base;
+                r.size = d.size_bytes;
+                r.stride = d.stride;
+                r.fetch_pc = fetch.fetch_pc;
+                table->resources.push_back(r);
+            }
             std::set<uint64_t> srt_seen;
             for (const auto& u : srt_uses) {
                 // Dedupe: keyed cbuf uses per key; texture/storage and key-less uses per consuming pc

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1451,47 +1451,58 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 break;
             }
             case Rdna2Format::MUBUF: {
-                // Descriptor-table V# use (#273 — the title post-chain PSes' per-lane structured-buffer
-                // fetches): a buffer_load_format_* / buffer_load_dword* whose SRSRC V# was s_loaded from
-                // a keyed table slot. Report it as a kind-1 (buffer) use so the consuming instruction
-                // resolves via its sreg_srt tag -> by_srt_offset — the same key model the s_buffer_loads
-                // use. (The VS vertex-fetch path below is unchanged: by_fetch_pc still wins there.)
+                // Buffer stores, raw loads/stores, and supported atomics need a kind-1 resource use.
+                // Format loads are intentionally handled only by DynFetch below: it snapshots the V#
+                // live at the instruction and resolves by exact pc, avoiding a duplicate stale SRT use.
                 const bool raw_buffer_use =
                     (in.opcode >= 0x08 && in.opcode <= 0x0F) ||
                     (in.opcode >= 0x1C && in.opcode <= 0x1E);
                 const bool format_store_use = in.opcode >= 0x04 && in.opcode <= 0x07;
-                if (srt_uses && (in.opcode <= 3 || format_store_use || raw_buffer_use)) {
-                    int srsrc = in.src[1].value;
-                    if (valid_reg(srsrc) && descr_known.test((size_t)srsrc)) {
-                        // Key-less snapshots (an s_buffer_load-fetched V# — a structured-buffer
-                        // descriptor stored INSIDE a constant buffer, DOLL's title post PSes) carry
-                        // the consuming instruction's pc instead; the recompiler resolves those via
-                        // ShaderResource::fetch_pc with the faithful (non-vertex-index) address path.
-                        SrtUse u; u.kind = 1; u.v4 = descr[(size_t)srsrc];
-                        u.key = descr_key_known.test((size_t)srsrc)
-                            ? descr_key[(size_t)srsrc] : 0xFFFFFFFFu;
-                        u.use_pc = in.pc;
-                        srt_uses->push_back(u);
-                    } else if ((format_store_use || raw_buffer_use) &&
-                               unchanged_seed_range(srsrc, 4)) {
-                        // Direct V#: a raw or format-store MUBUF can consume a V# placed in the
-                        // initial user-data SGPRs without any preceding s_load. Preserve it only for
-                        // the exact consuming instruction and only while all four seed values remain
-                        // current; guessing every descriptor-looking user-data quartet invents
-                        // capture/dependency resources, while accepting a rewritten seed resurrects
-                        // stale provenance.
-                        SrtUse u; u.kind = 1; u.key = 0xFFFFFFFFu; u.use_pc = in.pc;
-                        for (int k = 0; k < 4; ++k)
-                            u.v4[k] = user_sgprs[srsrc - (int)user_sgpr_base + k];
+                const bool atomic_buffer_use = in.opcode == 0x38; // buffer_atomic_umax
+                if (srt_uses && (format_store_use || raw_buffer_use || atomic_buffer_use)) {
+                    const int srsrc = in.src[1].value;
+                    std::array<uint32_t, 4> current{};
+                    bool current_known = true;
+                    for (int k = 0; k < 4; ++k)
+                        current_known &= known(srsrc + k, current[(size_t)k]);
+                    const bool loaded_provenance = valid_reg(srsrc) &&
+                                                   descr_known.test((size_t)srsrc);
+                    const bool direct_provenance = unchanged_seed_range(srsrc, 4);
+                    if (current_known && (loaded_provenance || direct_provenance)) {
+                        // Publish the four values LIVE at the consumer. A modeled scalar patch is
+                        // exact; an unmodeled/incompatible write becomes unknown and fails closed
+                        // instead of resurrecting the load-time descriptor snapshot.
+                        SrtUse u; u.kind = 1; u.v4 = current; u.key = 0xFFFFFFFFu; u.use_pc = in.pc;
+                        if (loaded_provenance) {
+                            uint32_t common_key = 0;
+                            bool have_common_key = true;
+                            for (int k = 0; k < 4; ++k) {
+                                const size_t r = (size_t)(srsrc + k);
+                                if (!valid_reg(srsrc + k) || !val_srt_key_known.test(r)) {
+                                    have_common_key = false;
+                                    break;
+                                }
+                                if (k == 0) common_key = val_srt_key[r];
+                                else if (val_srt_key[r] != common_key) {
+                                    have_common_key = false;
+                                    break;
+                                }
+                            }
+                            // Rewrites clear the recompiler's complete sreg_srt tag, so the live V#
+                            // must then resolve through this consuming instruction's exact pc.
+                            if (have_common_key) u.key = common_key;
+                        }
                         DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
                         const bool format_supported = !format_store_use ||
                             (d.format != DataFormat::Unknown && d.num_components != 0 &&
                              !d.forbid_unknown_fallback);
+                        // Byte-addressed raw/atomic V#s validly use stride zero: NUM_RECORDS is bytes.
+                        // Typed format stores retain the strided record requirement.
+                        const bool stride_supported = !format_store_use || d.stride != 0;
                         if (d.base > 0x10000 && d.size_bytes != 0 &&
-                            d.size_bytes <= 0x10000000u && d.stride != 0 &&
-                            format_supported) {
+                            d.size_bytes <= 0x10000000u && stride_supported && format_supported) {
                             if (trc) fprintf(stderr,
-                                             "[dyntrace] direct MUBUF pc=%u direct V# s%d base=0x%llx "
+                                             "[dyntrace] MUBUF pc=%u live V# s%d base=0x%llx "
                                              "stride=%u size=%u\n",
                                              in.pc, srsrc, (unsigned long long)d.base,
                                              d.stride, d.size_bytes);
@@ -1652,6 +1663,81 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             std::chrono::duration<double, std::milli>(decode_done - fold_start).count(),
             guest_probe_ms);
     return out;
+}
+
+std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
+                                                 const uint32_t* code, size_t dwords,
+                                                 const uint32_t* user_sgprs, uint32_t nsgpr) {
+    std::vector<SrtUse> srt_uses;
+    const std::vector<DynFetch> direct_fetches = resolve_dynamic_fetch(
+        code, dwords, user_sgprs, nsgpr, /*user_sgpr_base*/0, &srt_uses);
+
+    // A format-load resource has one identity: the descriptor live at its exact instruction pc.
+    for (const auto& fetch : direct_fetches) {
+        const DecodedBufferDescriptor& d = fetch.desc;
+        if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
+            d.format == DataFormat::Unknown || !d.num_components || d.forbid_unknown_fallback)
+            continue;
+        bool mapped = false;
+        for (auto& r0 : table.resources) {
+            if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
+                r0.size != d.size_bytes || r0.stride != d.stride || r0.format != d.format ||
+                r0.num_components != d.num_components)
+                continue;
+            if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = fetch.fetch_pc;
+            if (r0.fetch_pc == fetch.fetch_pc) { mapped = true; break; }
+        }
+        if (mapped) continue;
+        ShaderResource r;
+        r.cls = ResourceClass::ConstantBuffer;
+        r.format = d.format;
+        r.num_components = d.num_components;
+        r.gpu_addr = d.base;
+        r.size = d.size_bytes;
+        r.stride = d.stride;
+        r.fetch_pc = fetch.fetch_pc;
+        table.resources.push_back(r);
+    }
+
+    std::set<uint64_t> seen;
+    for (const auto& u : srt_uses) {
+        if (u.kind != 1) continue;
+        // Keyed buffer uses dedupe by table offset; key-less live descriptors dedupe by consumer pc.
+        const uint64_t dk = u.key == 0xFFFFFFFFu
+            ? (0x8000000100000000ull | u.use_pc)
+            : (0x0000000100000000ull | u.key);
+        if (!seen.insert(dk).second) continue;
+        bool clash = u.key == 0xFFFFFFFFu;
+        if (!clash)
+            for (const auto& r0 : table.resources)
+                if (r0.srt_offset == u.key) { clash = true; break; }
+
+        const DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+        if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+        if (clash) {
+            bool piggybacked = false;
+            for (auto& r0 : table.resources) {
+                if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
+                    r0.size != d.size_bytes)
+                    continue;
+                if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
+                piggybacked = r0.fetch_pc == u.use_pc;
+                if (piggybacked) break;
+            }
+            if (piggybacked) continue;
+        }
+        ShaderResource r;
+        r.cls = ResourceClass::ConstantBuffer;
+        r.format = d.format;
+        r.num_components = d.num_components ? d.num_components : 1;
+        r.gpu_addr = d.base;
+        r.size = d.size_bytes;
+        r.stride = d.stride;
+        r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
+        if (clash) r.fetch_pc = u.use_pc;
+        table.resources.push_back(r);
+    }
+    return srt_uses;
 }
 
 namespace { constexpr uint32_t kPsBindingBase = 32; }
@@ -2318,71 +2404,20 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // (the recompiler's storage path requires ResourceClass::StorageImage), a sampled use a
         // Texture. Never shadow an existing resource at the same srt_offset (first-match-wins).
         {
-            std::vector<SrtUse> srt_uses;
-            const std::vector<DynFetch> direct_fetches = resolve_dynamic_fetch(
-                (const uint32_t*)(uintptr_t)code_addr, shader_dwords,
-                sgprs, kUserSgprs, /*user_sgpr_base*/0, &srt_uses);
-            // Format-load V#s use resolve_dynamic_fetch's exact fetch-pc result. This covers direct
-            // compute sources that metadata omits without reviving the old all-SGPR scan.
-            for (const auto& fetch : direct_fetches) {
-                const DecodedBufferDescriptor& d = fetch.desc;
-                if (d.base <= 0x10000 || d.size_bytes == 0 ||
-                    d.size_bytes > 0x10000000u || d.format == DataFormat::Unknown ||
-                    !d.num_components || d.forbid_unknown_fallback) continue;
-                bool mapped = false;
-                for (auto& r0 : table->resources) {
-                    if (r0.cls != ResourceClass::ConstantBuffer ||
-                        r0.gpu_addr != d.base || r0.size != d.size_bytes ||
-                        r0.stride != d.stride || r0.format != d.format ||
-                        r0.num_components != d.num_components) continue;
-                    if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = fetch.fetch_pc;
-                    if (r0.fetch_pc == fetch.fetch_pc) { mapped = true; break; }
-                }
-                if (mapped) continue;
-                ShaderResource r;
-                r.cls = ResourceClass::ConstantBuffer;
-                r.format = d.format;
-                r.num_components = d.num_components;
-                r.gpu_addr = d.base;
-                r.size = d.size_bytes;
-                r.stride = d.stride;
-                r.fetch_pc = fetch.fetch_pc;
-                table->resources.push_back(r);
-            }
+            const std::vector<SrtUse> srt_uses = add_compute_buffer_resources(
+                *table, (const uint32_t*)(uintptr_t)code_addr, shader_dwords,
+                sgprs, kUserSgprs);
             std::set<uint64_t> srt_seen;
             for (const auto& u : srt_uses) {
-                // Dedupe: keyed cbuf uses per key; texture/storage and key-less uses per consuming pc
-                // (distinct namespaces so pc keys never collide with byte-offset keys).
-                uint64_t dk = (u.kind == 0 || u.key == 0xFFFFFFFFu)
-                                  ? (0x8000000000000000ull | ((uint64_t)(uint32_t)u.kind << 32) | u.use_pc)
-                                  : ((uint64_t)(uint32_t)u.kind << 32) | u.key;
+                if (u.kind != 0) continue;                 // buffers were materialized by the shared helper
+                // Texture/storage uses are instruction-specific even when their table keys repeat.
+                const uint64_t dk = 0x8000000000000000ull | u.use_pc;
                 if (!srt_seen.insert(dk).second) continue;
                 bool clash = u.key == 0xFFFFFFFFu;
                 if (!clash)
                     for (const auto& r0 : table->resources)
                         if (r0.srt_offset == u.key) { clash = true; break; }
-                if (u.kind == 1) {                       // constant/structured-buffer V#
-                    DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
-                    if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
-                    if (clash) {
-                        bool piggybacked = false;
-                        for (auto& r0 : table->resources)
-                            if (r0.cls == ResourceClass::ConstantBuffer &&
-                                r0.gpu_addr == d.base && r0.size == d.size_bytes) {
-                                if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
-                                piggybacked = r0.fetch_pc == u.use_pc;
-                                if (piggybacked) break;
-                            }
-                        if (piggybacked) continue;
-                    }
-                    ShaderResource r;
-                    r.cls = ResourceClass::ConstantBuffer;
-                    r.format = d.format; r.num_components = d.num_components ? d.num_components : 1;
-                    r.gpu_addr = d.base; r.size = d.size_bytes; r.stride = d.stride;
-                    r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
-                    if (clash) r.fetch_pc = u.use_pc;    // pc-only provenance (key-less/collided V#)
-                    table->resources.push_back(r);
-                } else {                                  // T# — storage image (store) or sampled texture
+                {                                         // T# — storage image (store) or sampled texture
                     DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
                     if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
                         d.base_array != 0 ||

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -519,19 +519,19 @@ int main() {
               "type-1 direct resource is not guessed for unobserved non-compute stages");
     }
 
-    // --- #566: additional directly-placed compute buffers (store-destination V# not in metadata). ---
-    // A Gen5 format-copy compute (Dead Cells) places TWO buffer V#s straight in the user-SGPR block —
-    // load source at reg0, store destination at reg4 — but its resource-usage metadata declares only the
-    // FIRST (direct_resource_offset type 1 -> reg 0). The store's SRSRC (s4) therefore had no resource and
-    // the whole dispatch was rejected/dropped, losing a scene-composition pass. build_shader_resources
-    // now also exposes plausible buffer V#s found directly in the user-SGPR block (keyed by sgpr_base),
-    // while the same plausibility guard filters leftover non-descriptor SGPRs, and the scan is compute-only.
+    // --- #636: metadata discovery must not guess unreferenced compute V#s. ------------------------
+    // Dead Cells' format-copy destination at s4 is real but absent from the metadata; the instruction
+    // walk recovers it at its buffer_store_format_xyzw use. This metadata-only builder must expose only
+    // declared entries. In particular, arbitrary scalar arguments can carry descriptor-looking format
+    // bits and pass every old plausibility check while no MUBUF instruction ever consumes them.
     {
         uint32_t csgprs[32]; memset(csgprs, 0, sizeof csgprs);
         make_vsharp(&csgprs[0], 0x74BA456E0000ull, 4, 393216, /*fmt*/2);   // src (declared via type 1)
-        make_vsharp(&csgprs[4], 0x74BA2F3E0000ull, 4, 393216, /*fmt*/2);   // dst (NOT declared anywhere)
+        make_vsharp(&csgprs[4], 0x74BA2F3E0000ull, 4, 393216, /*fmt*/2);   // used dst, recovered by code walk
+        csgprs[8] = 0x00100000u; csgprs[9] = 0; csgprs[10] = 16;
+        csgprs[11] = (2u << 12) | 0xFACu;                                 // scalar-only false V#
         make_vsharp(&csgprs[12], 0x50000000ull,    4, 0x8000000, /*fmt*/2);// 512 MB -> implausible, filtered
-        // reg8 + reg16..28 stay zero -> base 0 -> filtered.
+        // reg16..28 stay zero.
         uint16_t cdro[11]; for (auto& x : cdro) x = 0xffff;
         cdro[1] = 0;                                                       // declare ONLY reg0
         AgcShaderUserData cud; memset(&cud, 0, sizeof cud);
@@ -541,19 +541,20 @@ int main() {
 
         ShaderResourceTable ct = build_shader_resources(csh, csgprs, 32);
         const ShaderResource* src = ct.by_sgpr_base(0);
-        const ShaderResource* dst = ct.by_sgpr_base(4);
-        CHECK(src && src->gpu_addr == 0x74BA456E0000ull, "#566: declared compute source buffer at sgpr 0");
-        CHECK(dst && dst->cls == ResourceClass::ConstantBuffer && dst->gpu_addr == 0x74BA2F3E0000ull,
-              "#566: undeclared compute store-dest V# at sgpr 4 exposed (store SRSRC now resolves)");
-        CHECK(dst && dst->size == 393216u * 4u && dst->stride == 4, "#566: dest V# base/size/stride decoded");
-        CHECK(ct.by_sgpr_base(8) == nullptr, "#566: leftover base-0 SGPR slot not emitted");
-        CHECK(ct.by_sgpr_base(12) == nullptr, "#566: >256 MB implausible V# filtered (no stale-SGPR binding)");
+        CHECK(src && src->gpu_addr == 0x74BA456E0000ull,
+              "#636: declared compute source buffer remains metadata-backed at sgpr 0");
+        CHECK(ct.by_sgpr_base(4) == nullptr,
+              "#636: undeclared store destination waits for instruction provenance");
+        CHECK(ct.by_sgpr_base(8) == nullptr,
+              "#636: plausible scalar-only user data is not invented as a compute resource");
+        CHECK(ct.by_sgpr_base(12) == nullptr, "#636: >256 MB implausible V# remains filtered");
         int at0 = 0; for (const auto& r : ct.resources) if (r.sgpr_base == 0) at0++;
-        CHECK(at0 == 1, "#566: declared source buffer emitted exactly once (scan dedups the type-1 slot)");
+        CHECK(at0 == 1 && ct.resources.size() == 1,
+              "#636: metadata builder emits exactly the one declared compute buffer");
 
-        csh.type = 1;   // PS: the additional-buffer scan is compute-only.
+        csh.type = 1;
         CHECK(build_shader_resources(csh, csgprs, 32).by_sgpr_base(4) == nullptr,
-              "#566: additional directly-placed-buffer scan does not run for non-compute stages");
+              "#636: undeclared direct buffer is not guessed for non-compute stages either");
     }
 
     // --- textures: sharp[0] T#s carry their real format + byte size; BC1/2/3 are bound (decoded to RGBA8

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -564,6 +564,30 @@ int main() {
                              &direct_copy_table, direct_copy_config).empty(),
           "#636: instruction-provenance table keeps the Dead Cells format-copy dispatch realizable");
 
+    // DynFetch shifts graphics vertex descriptors by a constant instruction offset because their
+    // special address path drops the original OFFSET/SOFFSET. Compute resources use ConstantBuffer's
+    // faithful MUBUF path instead, so the production helper must retain base B and let that path add
+    // offset 16 once (not bind B+16 and then index another 16 bytes).
+    const uint32_t offset_format_load[] = {
+        0xE00C2010u, 0x80000100u,   // buffer_load_format_xyzw ..., s[0:3], offset:16 idxen
+        0xBF810000u,
+    };
+    const std::vector<DynFetch> offset_fetches = resolve_dynamic_fetch(
+        offset_format_load, std::size(offset_format_load), direct_copy_seed, 4, 0);
+    CHECK(offset_fetches.size() == 1 && offset_fetches[0].desc.base == 0x20010u &&
+          offset_fetches[0].unshifted_desc.base == 0x20000u,
+          "#636: DynFetch retains both shifted graphics and original compute descriptor bases");
+    ShaderResourceTable offset_compute_table;
+    add_compute_buffer_resources(offset_compute_table, offset_format_load,
+                                 std::size(offset_format_load), direct_copy_seed, 4);
+    assign_convention_bindings(offset_compute_table, 2);
+    CHECK(offset_compute_table.resources.size() == 1 &&
+          offset_compute_table.resources[0].gpu_addr == 0x20000u &&
+          offset_compute_table.resources[0].fetch_pc == 0 &&
+          !recompile_compute(offset_format_load, std::size(offset_format_load),
+                             &offset_compute_table, direct_copy_config).empty(),
+          "#636: compute format-load keeps base B and applies nonzero instruction offset once");
+
     const uint32_t rewritten_copy_dest[] = {
         0xBE840380u,                // s_mov_b32 s4, 0 (seed destination is no longer live)
         0xE01C2000u, 0x80010101u,   // buffer_store_format_xyzw v[1:4], v1, s[4:7], 0 idxen

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -548,32 +548,15 @@ int main() {
           "#636: Dead Cells s4 destination resolves only at its format-store instruction");
 
     ShaderResourceTable direct_copy_table;
-    if (direct_copy_fetches.size() == 1) {
-        ShaderResource source{};
-        source.cls = ResourceClass::ConstantBuffer;
-        source.format = direct_copy_fetches[0].desc.format;
-        source.num_components = direct_copy_fetches[0].desc.num_components;
-        source.binding = 2;
-        source.gpu_addr = direct_copy_fetches[0].desc.base;
-        source.size = direct_copy_fetches[0].desc.size_bytes;
-        source.stride = direct_copy_fetches[0].desc.stride;
-        source.fetch_pc = direct_copy_fetches[0].fetch_pc;
-        direct_copy_table.resources.push_back(source);
-    }
-    if (direct_copy_uses.size() == 1) {
-        const DecodedBufferDescriptor destination =
-            decode_buffer_descriptor(direct_copy_uses[0].v4.data());
-        ShaderResource dest{};
-        dest.cls = ResourceClass::ConstantBuffer;
-        dest.format = destination.format;
-        dest.num_components = destination.num_components;
-        dest.binding = 3;
-        dest.gpu_addr = destination.base;
-        dest.size = destination.size_bytes;
-        dest.stride = destination.stride;
-        dest.fetch_pc = direct_copy_uses[0].use_pc;
-        direct_copy_table.resources.push_back(dest);
-    }
+    add_compute_buffer_resources(direct_copy_table, direct_copy,
+                                 sizeof(direct_copy) / sizeof(direct_copy[0]),
+                                 direct_copy_seed, 8);
+    assign_convention_bindings(direct_copy_table, 2);
+    CHECK(direct_copy_table.resources.size() == 2 &&
+          direct_copy_table.by_fetch_pc(0) && direct_copy_table.by_fetch_pc(2) &&
+          direct_copy_table.by_fetch_pc(0)->binding == 2 &&
+          direct_copy_table.by_fetch_pc(2)->binding == 3,
+          "#636: production compute discovery emits exactly the used source and destination");
     ComputeShaderConfig direct_copy_config;
     direct_copy_config.user_sgprs.assign(direct_copy_seed, direct_copy_seed + 8);
     direct_copy_config.local_x = direct_copy_config.local_y = direct_copy_config.local_z = 1;
@@ -621,6 +604,110 @@ int main() {
     CHECK(store_uses.size() == 1 && store_uses[0].v4[0] == store_table[4] &&
           store_uses[0].v4[1] == store_table[5] && store_uses[0].v4[2] == 16u,
           "raw buffer-store V# preserves the table-loaded descriptor dwords");
+
+    // A scalar patch after the table load changes the descriptor that the store actually consumes.
+    // The table key is no longer live as a complete four-dword provenance tag, so publish the current
+    // V# by exact store pc rather than retaining the pre-patch output range.
+    static uint32_t rewritten_store_output[16];
+    static uint32_t rewritten_store_table[4];
+    const uint64_t rewritten_output_base = (uint64_t)(uintptr_t)rewritten_store_output;
+    rewritten_store_table[0] = store_table[4];
+    rewritten_store_table[1] = store_table[5] | (4u << 16);
+    rewritten_store_table[2] = store_table[6];
+    rewritten_store_table[3] = (2u << 12) | 0xFACu;
+    const uint64_t rewritten_table_base = (uint64_t)(uintptr_t)rewritten_store_table;
+    const uint32_t rewritten_table_store[] = {
+        0xF4080104u, 0xFA000000u,                       // s_load_dwordx4 s[4:7], s[8:9], 0
+        0xBE8403FFu, (uint32_t)rewritten_output_base,   // s_mov_b32 s4, literal (live base patch)
+        0xE01C2000u, 0x80010101u,                       // buffer_store_format_xyzw ..., s[4:7]
+        0xBF810000u,
+    };
+    const uint32_t rewritten_table_seed[2] = {
+        (uint32_t)rewritten_table_base, (uint32_t)(rewritten_table_base >> 32),
+    };
+    uint32_t rewritten_compute_seed[10] = {};
+    rewritten_compute_seed[8] = rewritten_table_seed[0];
+    rewritten_compute_seed[9] = rewritten_table_seed[1];
+    std::vector<SrtUse> rewritten_table_uses;
+    resolve_dynamic_fetch(rewritten_table_store, std::size(rewritten_table_store),
+                          rewritten_table_seed, 2, 8, &rewritten_table_uses);
+    CHECK(rewritten_table_uses.size() == 1 && rewritten_table_uses[0].use_pc == 4 &&
+          rewritten_table_uses[0].key == 0xFFFFFFFFu &&
+          rewritten_table_uses[0].v4[0] == (uint32_t)rewritten_output_base,
+          "#636: table-loaded format store uses its live patched V# by exact pc");
+
+    // The analogous format LOAD must materialize only DynFetch's live pc-keyed descriptor. Before
+    // #636 it also produced an SrtUse from the old table snapshot, duplicating the binding and capture
+    // range. Exercise the same helper called by realize_compute_dispatches, including binding assignment.
+    const uint32_t rewritten_table_load[] = {
+        0xF4080104u, 0xFA000000u,                       // s_load_dwordx4 s[4:7], s[8:9], 0
+        0xBE8403FFu, (uint32_t)rewritten_output_base,   // s_mov_b32 s4, literal
+        0xE00C2000u, 0x80010100u,                       // buffer_load_format_xyzw ..., s[4:7]
+        0xBF810000u,
+    };
+    ShaderResourceTable rewritten_load_table;
+    const std::vector<SrtUse> rewritten_load_uses = add_compute_buffer_resources(
+        rewritten_load_table, rewritten_table_load, std::size(rewritten_table_load),
+        rewritten_compute_seed, 10);
+    assign_convention_bindings(rewritten_load_table, 2);
+    CHECK(rewritten_load_uses.empty() && rewritten_load_table.resources.size() == 1,
+          "#636: table-loaded format load has one production-path resource identity");
+    CHECK(rewritten_load_table.resources.size() == 1 &&
+          rewritten_load_table.resources[0].gpu_addr == rewritten_output_base &&
+          rewritten_load_table.resources[0].fetch_pc == 4 &&
+          rewritten_load_table.resources[0].srt_offset == 0xFFFFFFFFu &&
+          rewritten_load_table.resources[0].binding == 2,
+          "#636: format-load resource uses the live range, pc provenance, and assigned binding");
+
+    // Raw byte-addressed descriptors use stride zero, and the recompiler's supported atomic_umax is
+    // an external-buffer consumer too. Both were accepted before the catch-all scan was removed and
+    // must remain discoverable through instruction provenance.
+    static uint32_t atomic_output[16];
+    const uint64_t atomic_output_base = (uint64_t)(uintptr_t)atomic_output;
+    const uint32_t atomic_seed[4] = {
+        (uint32_t)atomic_output_base,
+        (uint32_t)(atomic_output_base >> 32) & 0xFFFFu,
+        sizeof(atomic_output), 0u,
+    };
+    const uint32_t stride_zero_raw[] = {
+        0xE0300000u, 0x80000000u, // buffer_load_dword v0, off, s[0:3], 0
+        0xBF810000u,
+    };
+    std::vector<SrtUse> stride_zero_raw_uses;
+    resolve_dynamic_fetch(stride_zero_raw, std::size(stride_zero_raw), atomic_seed, 4, 0,
+                          &stride_zero_raw_uses);
+    ShaderResourceTable stride_zero_raw_table;
+    add_compute_buffer_resources(stride_zero_raw_table, stride_zero_raw,
+                                 std::size(stride_zero_raw), atomic_seed, 4);
+    assign_convention_bindings(stride_zero_raw_table, 2);
+    ComputeShaderConfig raw_config;
+    raw_config.user_sgprs.assign(atomic_seed, atomic_seed + 4);
+    raw_config.local_x = raw_config.local_y = raw_config.local_z = 1;
+    CHECK(stride_zero_raw_uses.size() == 1 && stride_zero_raw_table.resources.size() == 1 &&
+          stride_zero_raw_table.resources[0].stride == 0 &&
+          !recompile_compute(stride_zero_raw, std::size(stride_zero_raw),
+                             &stride_zero_raw_table, raw_config).empty(),
+          "#636: direct stride-zero raw buffer remains discovered and realizable");
+    const uint32_t atomic_umax[] = {
+        0xE0E00004u, 0x80000000u, // buffer_atomic_umax v0, v0, s[0:3], offset:4
+        0xBF810000u,
+    };
+    std::vector<SrtUse> atomic_uses;
+    resolve_dynamic_fetch(atomic_umax, std::size(atomic_umax), atomic_seed, 4, 0,
+                          &atomic_uses);
+    CHECK(atomic_uses.size() == 1 && atomic_uses[0].use_pc == 0 &&
+          atomic_uses[0].v4[2] == sizeof(atomic_output),
+          "#636: direct stride-zero buffer_atomic_umax retains its exact resource use");
+    ShaderResourceTable atomic_table;
+    add_compute_buffer_resources(atomic_table, atomic_umax, std::size(atomic_umax), atomic_seed, 4);
+    assign_convention_bindings(atomic_table, 2);
+    ComputeShaderConfig atomic_config;
+    atomic_config.user_sgprs.assign(atomic_seed, atomic_seed + 4);
+    atomic_config.local_x = atomic_config.local_y = atomic_config.local_z = 1;
+    CHECK(atomic_table.resources.size() == 1 && atomic_table.resources[0].stride == 0 &&
+          !recompile_compute(atomic_umax, std::size(atomic_umax),
+                             &atomic_table, atomic_config).empty(),
+          "#636: production resource table keeps stride-zero supported atomic realizable");
 
     // Kernel 5dr: once any T# SGPR is reloaded, the initial sharp is stale. An unresolved reload must
     // not silently resurrect it and fabricate a texture mapping for the later image operation.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -522,6 +522,77 @@ int main() {
           direct_v_uses[0].v4[1] == seed5v[1] && direct_v_uses[0].v4[2] == seed5v[2],
           "direct raw-MUBUF V# preserves base/stride/record dwords");
 
+    // #636: Dead Cells' format-copy compute places its declared source V# at s0 and its otherwise
+    // undeclared destination V# at s4. Resource discovery must follow the two actual MUBUF uses:
+    // the load arrives through DynFetch and the store through a pc-keyed SrtUse. No all-SGPR scan is
+    // needed, and rewriting any destination dword before the store invalidates the seed descriptor.
+    const uint32_t direct_copy[] = {
+        0xE00C2000u, 0x80000100u,   // buffer_load_format_xyzw v[1:4], v0, s[0:3], 0 idxen
+        0xE01C2000u, 0x80010101u,   // buffer_store_format_xyzw v[1:4], v1, s[4:7], 0 idxen
+        0xBF810000u,
+    };
+    const uint32_t direct_copy_seed[8] = {
+        0x00020000u, 0x00040000u, 16u, (2u << 12) | 0xFACu,
+        0x00030000u, 0x00040000u, 16u, (2u << 12) | 0xFACu,
+    };
+    std::vector<SrtUse> direct_copy_uses;
+    const std::vector<DynFetch> direct_copy_fetches = resolve_dynamic_fetch(
+        direct_copy, sizeof(direct_copy) / sizeof(direct_copy[0]),
+        direct_copy_seed, 8, 0, &direct_copy_uses);
+    CHECK(direct_copy_fetches.size() == 1 && direct_copy_fetches[0].fetch_pc == 0 &&
+          direct_copy_fetches[0].srsrc == 0 && direct_copy_fetches[0].desc.base == 0x20000,
+          "#636: direct format-copy source resolves only at its load instruction");
+    CHECK(direct_copy_uses.size() == 1 && direct_copy_uses[0].kind == 1 &&
+          direct_copy_uses[0].key == 0xFFFFFFFFu && direct_copy_uses[0].use_pc == 2 &&
+          direct_copy_uses[0].v4[0] == direct_copy_seed[4],
+          "#636: Dead Cells s4 destination resolves only at its format-store instruction");
+
+    ShaderResourceTable direct_copy_table;
+    if (direct_copy_fetches.size() == 1) {
+        ShaderResource source{};
+        source.cls = ResourceClass::ConstantBuffer;
+        source.format = direct_copy_fetches[0].desc.format;
+        source.num_components = direct_copy_fetches[0].desc.num_components;
+        source.binding = 2;
+        source.gpu_addr = direct_copy_fetches[0].desc.base;
+        source.size = direct_copy_fetches[0].desc.size_bytes;
+        source.stride = direct_copy_fetches[0].desc.stride;
+        source.fetch_pc = direct_copy_fetches[0].fetch_pc;
+        direct_copy_table.resources.push_back(source);
+    }
+    if (direct_copy_uses.size() == 1) {
+        const DecodedBufferDescriptor destination =
+            decode_buffer_descriptor(direct_copy_uses[0].v4.data());
+        ShaderResource dest{};
+        dest.cls = ResourceClass::ConstantBuffer;
+        dest.format = destination.format;
+        dest.num_components = destination.num_components;
+        dest.binding = 3;
+        dest.gpu_addr = destination.base;
+        dest.size = destination.size_bytes;
+        dest.stride = destination.stride;
+        dest.fetch_pc = direct_copy_uses[0].use_pc;
+        direct_copy_table.resources.push_back(dest);
+    }
+    ComputeShaderConfig direct_copy_config;
+    direct_copy_config.user_sgprs.assign(direct_copy_seed, direct_copy_seed + 8);
+    direct_copy_config.local_x = direct_copy_config.local_y = direct_copy_config.local_z = 1;
+    CHECK(!recompile_compute(direct_copy, sizeof(direct_copy) / sizeof(direct_copy[0]),
+                             &direct_copy_table, direct_copy_config).empty(),
+          "#636: instruction-provenance table keeps the Dead Cells format-copy dispatch realizable");
+
+    const uint32_t rewritten_copy_dest[] = {
+        0xBE840380u,                // s_mov_b32 s4, 0 (seed destination is no longer live)
+        0xE01C2000u, 0x80010101u,   // buffer_store_format_xyzw v[1:4], v1, s[4:7], 0 idxen
+        0xBF810000u,
+    };
+    std::vector<SrtUse> rewritten_copy_uses;
+    resolve_dynamic_fetch(rewritten_copy_dest,
+                          sizeof(rewritten_copy_dest) / sizeof(rewritten_copy_dest[0]),
+                          direct_copy_seed, 8, 0, &rewritten_copy_uses);
+    CHECK(rewritten_copy_uses.empty(),
+          "#636: rewritten direct destination cannot resurrect its entry-time V#");
+
     // Astro Bot's compact compute dispatcher s_loads output V#s from a table, then consumes them
     // with buffer_store_dword/dwordx2/dwordx3. Stores need the same descriptor provenance as raw
     // loads or the compute resource front-half never creates their writable storage-buffer binding.

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1,4 +1,5 @@
 #include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/agc_shader_layout.hpp"
 #include "../src/gpu/pm4_registers.hpp"
 #include "../src/gpu/tile.hpp"
 
@@ -118,6 +119,43 @@ int main() {
     CHECK(captured.shader_versions.size() == 2 && captured.operations.size() == 1 &&
           captured.operations[0].source_index == 7 && captured.operations[0].realized,
           "capture indexes unique shaders and retains operation provenance");
+
+    // #636: a descriptor-looking scalar quartet with no matching MUBUF instruction is not a compute
+    // resource. The capture path must therefore neither probe its guest address nor retain a blob.
+    uint32_t scalar_sgprs[32] = {};
+    scalar_sgprs[0] = 0x00100000u;
+    scalar_sgprs[2] = 16u;
+    scalar_sgprs[3] = (2u << 12) | 0xFACu;
+    AgcShaderUserData scalar_user_data{};
+    AgcShaderHeader scalar_header{};
+    scalar_header.file_header = 0x34333231u;
+    scalar_header.version = 0x18;
+    scalar_header.type = 0;
+    scalar_header.user_data = &scalar_user_data;
+    auto scalar_table = std::make_shared<ShaderResourceTable>(
+        build_shader_resources(scalar_header, scalar_sgprs, 32));
+    CHECK(scalar_table->resources.empty(),
+          "#636: scalar-only compute user data produces no capture-table resource");
+    ComputeItem scalar_compute;
+    scalar_compute.spirv = {0x07230203u};
+    scalar_compute.resources = scalar_table;
+    scalar_compute.dispatch_index = 636;
+    scalar_compute.command_order = 636;
+    const std::vector<SubmitOperation> scalar_operations = {
+        {SubmitOperationKind::Dispatch, 636, 636},
+    };
+    size_t scalar_reader_calls = 0;
+    auto scalar_reader = [&](uint64_t, uint8_t*, size_t) -> size_t {
+        ++scalar_reader_calls;
+        return 0;
+    };
+    GpuCaptureFile scalar_capture;
+    CHECK(capture_submit_items({}, {scalar_compute}, scalar_operations, meta,
+                               scalar_reader, scalar_capture, error) &&
+              scalar_reader_calls == 0 && scalar_capture.blobs.empty() &&
+              scalar_capture.computes.size() == 1 &&
+              scalar_capture.computes[0].resources.resources.empty(),
+          "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
     // v17 appends scissor state without changing the legacy pipeline prefix. Removing this one-draw,
     // zero-failure tail produces a byte-exact v16 capture whose missing state means full target.

--- a/prosper/tests/test_gpu_dependency_graph.cpp
+++ b/prosper/tests/test_gpu_dependency_graph.cpp
@@ -1,3 +1,4 @@
+#include "../src/gpu/agc_shader_layout.hpp"
 #include "../src/gpu/gpu_dependency_graph.hpp"
 
 #include <cstdio>
@@ -91,6 +92,34 @@ int main() {
     CHECK(graph.external_leaves[0].first_future_writer == UINT32_MAX &&
           graph.external_leaves[1].first_future_writer == 1,
           "read-before-write leaves identify the first in-capsule future writer");
+
+    // #636: dependency analysis consumes the realized resource table, so descriptor-looking scalar
+    // user data must never appear as a read/write access unless an instruction actually uses it.
+    uint32_t scalar_sgprs[32] = {};
+    scalar_sgprs[0] = 0x00100000u;
+    scalar_sgprs[2] = 16u;
+    scalar_sgprs[3] = (2u << 12) | 0xFACu;
+    AgcShaderUserData scalar_user_data{};
+    AgcShaderHeader scalar_header{};
+    scalar_header.file_header = 0x34333231u;
+    scalar_header.version = 0x18;
+    scalar_header.type = 0;
+    scalar_header.user_data = &scalar_user_data;
+    ComputeItem scalar_compute;
+    scalar_compute.dispatch_index = 636;
+    scalar_compute.command_order = 636;
+    scalar_compute.resources = std::make_shared<ShaderResourceTable>(
+        build_shader_resources(scalar_header, scalar_sgprs, 32));
+    GpuReplayFrame scalar_replay;
+    scalar_replay.computes = {scalar_compute};
+    scalar_replay.operations = {
+        {SubmitOperationKind::Dispatch, 636, 636, true},
+    };
+    GpuDependencyGraph scalar_graph;
+    CHECK(build_gpu_dependency_graph(scalar_replay, scalar_graph, error) &&
+              scalar_compute.resources->resources.empty() && scalar_graph.edges.empty() &&
+              scalar_graph.external_leaves.empty(),
+          "#636: dependency graph ignores unconsumed descriptor-looking scalar arguments");
 
     replay.operations[4].realized = true;
     CHECK(!build_gpu_dependency_graph(replay, graph, error) &&


### PR DESCRIPTION
## Summary

Fixes #636.

Compute resource discovery no longer scans every aligned user-SGPR quartet and treats descriptor-looking scalar arguments as buffers. Resources now require either declared AGC metadata or an actual decoded MUBUF use.

## Failure scenario and contract

The old compute-only fallback admitted any four dwords that decoded to a plausible V#, even when no shader instruction referenced that SGPR range. Live descriptor reflection hid the extra binding, but GPU capture still read the invented range and the dependency graph treated it as a compute read/write.

The contract after this change is:

- metadata-declared direct buffers remain available by SGPR;
- undeclared direct format-load/store and raw-buffer resources are admitted only at a consuming MUBUF instruction;
- direct seed descriptors are rejected after any tracked dword changes or is reloaded;
- capture and dependency tooling see only resources retained by that provenance process.

## Approach

- remove the catch-all compute SGPR scan from `build_shader_resources`;
- extend `resolve_dynamic_fetch` to report direct `buffer_store_format_*` V# uses by exact instruction PC;
- fold exact-PC format-load results into compute resource tables so undeclared direct sources remain supported;
- retain the existing size/format bounds and fail visibly when provenance cannot be proved;
- add regressions for scalar-only data, capture reads, dependency accesses, Dead Cells' direct s0 source/s4 destination, and rewritten seed invalidation.

## Affected and deliberately unaffected behavior

Affected: compute buffer resource discovery, compute capture intervals, and compute dependency access lists.

Unaffected: graphics-stage resource discovery, metadata-declared compute buffers, sampled/storage images, rendering/presentation, and desktop frontend behavior.

Risk: an unmodeled MUBUF form may now remain unresolved instead of being guessed from user data. That is intentional fail-visible behavior; supported raw and format load/store forms retain instruction-based paths.

## Focused author validation

Exact head: `407f821d0f6d064569de9c02b8c81326b9b8e643`.

- Windows focused build:
  `cmake --build prosper\build-windows --parallel 8 --target test_build_shader_resources test_dynfetch_fold test_gpu_capture test_gpu_dependency_graph`
- Linux focused build:
  `cmake --build prosper/build-linux -j8 --target test_build_shader_resources test_dynfetch_fold test_gpu_capture test_gpu_dependency_graph`
- Windows focused ctest: 4/4 passed
  (`build_shader_resources`, `dynfetch_fold`, `gpu_capture_roundtrip`, `gpu_dependency_graph`)
- Linux focused ctest: 4/4 passed (same set)
- Windows shared guards: 2/2 passed
  (`messenger_recompile_guard`, `shader_resource_contract`)
- Linux shared/compute guards: 4/4 passed
  (`messenger_recompile_guard`, `shader_resource_contract`, `compute_exec_differential`, `game_compute_exec`)
- Native Windows Dead Cells, fresh save, graphics disabled/compute enabled, `PROSPER_COMPUTELOG=1`: reached `PrisonStart`; relocated format-copy program `0x411aec800` executed successfully with two buffers at submits 1838, 1839, and 1840 (`result=ok`). No MUBUF, descriptor-contract, or Vulkan failures.
- `git diff --check`: passed.

No snapshot workflow was run. Full author verification and independent inspection review start after this ready PR is published.