### PR TITLE
fix(gpu): mask COMPUTE_NUM_THREAD to NUM_THREAD_FULL [15:0] — PM4 register audit (#911)

### DIFF
--- a/prosper/docs/PM4_REGISTER_AUDIT_2026_07.md
+++ b/prosper/docs/PM4_REGISTER_AUDIT_2026_07.md
@@ -1,0 +1,87 @@
+# PM4 register-definition audit — prosper vs the RDNA2 (gfx10.3) register database (2026-07)
+
+A systematic sweep of prosper's GPU register definitions and their consumers against the
+authoritative RDNA2 register truth, run against master `53df2b7` on 2026-07-18. Companion to the
+RDNA2 ISA recompiler audit (`RDNA2_ISA_AUDIT_2026_07.md`, issues #878–#883) and tracked by #911.
+
+## Scope and reference
+
+- **In scope:** the register OFFSET constants and per-field `*_SHIFT` / `*_MASK` constants in
+  `src/gpu/pm4_registers.hpp` (887 constants across DB / CB / PA / SPI / COMPUTE / GE-VGT-TA groups),
+  the standard `IT_*` PM4 type-3 opcode constants, and the register-field extraction in the
+  consumers (`render_state.cpp`, `command_processor.cpp`, and `gpu_executor.cpp`'s dispatch resolve).
+- **Deliberately out of scope:** the PM4 packet *framing* and payload layout in `pm4_decode.cpp`.
+  That is prosper's own **AGC-internal** encoding produced by `hle_agc.cpp` (the `IT_NOP` `R_*`
+  sub-opcodes are a Sony/Kyty AGC convention, not hardware PM4), a producer/consumer contract
+  verified by the existing `test_pm4_decode` / `test_command_processor` / `test_agc_dcb` tests and by
+  `hle_agc.cpp` consistency — not by an AMD hardware reference. Sweeping it against the AMD PM4 spec
+  would produce spurious findings, so it was excluded.
+- **Reference (authoritative):** the Mesa AMD register database (`gfx10.json` base + `gfx10.3`
+  overlay = RDNA2), flattened to a grep-able `REG name offset= / FIELD name bits=[hi:lo] shift= mask=`
+  form. Offsets were reconciled through the class base convention (prosper's constant is a
+  class-relative dword index: CONTEXT base `0xA000`, SH base `0x2C00`, UCONFIG base `0xC000`, versus
+  the reference's absolute byte address). Field shift/mask are convention-independent and directly
+  comparable. `IT_*` opcodes were cross-checked against the stable consensus gfx10 PM4 opcode values.
+
+## Method
+
+Eight register-group reviewers compared their slice of `pm4_registers.hpp` + the consumers with the
+reference; every candidate finding was re-derived by an independent adversarial verifier (the most
+common false positive — an offset "mismatch" that dissolves once the class base is applied — was
+explicitly guarded against). Deliberate PS5/AGC deviations backed by live evidence, and registers
+prosper simply does not define/consume, were excluded by design.
+
+## Result
+
+The register layer is **overwhelmingly correct**: every offset reconciles, and every field actually
+extracted by a consumer uses the right register, shift, and mask. Across all 887 constants and their
+consumers the sweep produced **one confirmed defect** (low severity) and **one refuted candidate**.
+
+### Confirmed (fixed in this PR)
+
+**[LOW] `resolve_compute_launch` reads `COMPUTE_NUM_THREAD_X/Y/Z` as full 32-bit values instead of
+the `NUM_THREAD_FULL` field [15:0]** — `src/gpu/gpu_executor.cpp:2184`.
+
+- **Reference:** `COMPUTE_NUM_THREAD_X.NUM_THREAD_FULL` = bits [15:0] (mask `0xFFFF`);
+  `NUM_THREAD_PARTIAL` = bits [31:16] (residual-thread count for partial dispatches, which prosper
+  does not model).
+- **Code behavior:** the consumer assigned `out.local_x/y/z = reg(COMPUTE_NUM_THREAD_*)` with no
+  mask, folding any nonzero `NUM_THREAD_PARTIAL` into the workgroup local size.
+- **Consequence / severity:** the exercised titles program these registers with small counts (high
+  half zero), so the value is correct today — hence LOW. A guest that ever set `NUM_THREAD_PARTIAL`
+  would get a wildly wrong local size (e.g. `0x3_0020` instead of `32`) and a corrupt dispatch.
+- **Fix:** add the `COMPUTE_NUM_THREAD_FULL_SHIFT/MASK` field constants (they were missing) and mask
+  the read to [15:0]. Regression test in `test_command_processor.cpp` programs a set `PARTIAL` field
+  and asserts the resolved local size ignores it.
+
+### Refuted (documented, not changed)
+
+**`VGT_INDEX_TYPE` consumer treats any nonzero index type as 32-bit** — `command_processor.cpp:1499`,
+`uint32_t elem = index_type ? 4u : 2u`. The reviewer correctly noted that per the reference
+(`VGT_INDEX_TYPE_MODE`: 16-bit=0, 32-bit=1, 8-bit=2) an 8-bit index type would resolve to 4 bytes
+instead of 1, and the low `INDEX_TYPE` bits [1:0] are not masked off the swap-mode bits [3:2].
+**Refuted as unreachable:** prosper's `index_type` comes from its own `IT_INDEX_TYPE` payload, which
+the exercised titles set only to 16-bit (0) or 32-bit (1); no 8-bit index buffer or swap-mode bit is
+produced on any reached path, so no wrong render result occurs. Recorded here so a future title using
+8-bit indices re-examines this line (a defensive `elem = (index_type & 3) == 1 ? 4 : (index_type & 3) == 2 ? 1 : 2`
+would harden it, but is deliberately not applied absent an exercising case, per the audit's
+cleanly-unreachable exclusion rule).
+
+## Per-group coverage (all verified clean)
+
+- **DB (219):** all offsets reconcile (context base); every consumed field
+  (`DB_DEPTH_CONTROL`, `DB_STENCIL_CONTROL`, `DB_STENCILREFMASK[_BF]`, `DB_RENDER_CONTROL`,
+  `DB_SHADER_CONTROL`, clears) uses the correct shift/mask. Legacy GFX6-named fields
+  (`DB_DEPTH_INFO` tile-mode) are defined but never field-extracted → no wrong output.
+- **CB (153):** color-target dims (`CB_COLOR*_ATTRIB2` MIP0_WIDTH/HEIGHT +1), formats
+  (`CB_COLOR*_INFO`), blend (`CB_BLEND*_CONTROL`), and the `CB_TARGET_MASK` nibble ordering all match.
+- **PA (190):** cull/front-face/poly-mode (`PA_SU_SC_MODE_CNTL`), scissor, and clip/viewport fields
+  all match (the field layout underlying the historical #534 front-face bug is correct here — that
+  bug was in the Vulkan enum translation, not the register decode).
+- **SPI (160):** context vs SH register-class split correct; `SPI_SHADER_PGM_*` RSRC1/RSRC2 fields,
+  PS input mapping, and the 256-byte-aligned program-address encoding all match.
+- **COMPUTE (48):** all offsets (SH base) and RSRC1/RSRC2/DISPATCH fields match; the one consumer
+  masking defect above is the sole finding.
+- **GE-VGT-TA (43):** primitive/index-type registers and fields match (the one consumer question was
+  the refuted VGT_INDEX_TYPE note above).
+- **IT opcodes (48):** the standard PM4 type-3 opcode constants match the consensus gfx10 values.

--- a/prosper/docs/PM4_REGISTER_AUDIT_2026_07.md
+++ b/prosper/docs/PM4_REGISTER_AUDIT_2026_07.md
@@ -56,16 +56,16 @@ the `NUM_THREAD_FULL` field [15:0]** — `src/gpu/gpu_executor.cpp:2184`.
 
 ### Refuted (documented, not changed)
 
-**`VGT_INDEX_TYPE` consumer treats any nonzero index type as 32-bit** — `command_processor.cpp:1499`,
-`uint32_t elem = index_type ? 4u : 2u`. The reviewer correctly noted that per the reference
-(`VGT_INDEX_TYPE_MODE`: 16-bit=0, 32-bit=1, 8-bit=2) an 8-bit index type would resolve to 4 bytes
-instead of 1, and the low `INDEX_TYPE` bits [1:0] are not masked off the swap-mode bits [3:2].
-**Refuted as unreachable:** prosper's `index_type` comes from its own `IT_INDEX_TYPE` payload, which
-the exercised titles set only to 16-bit (0) or 32-bit (1); no 8-bit index buffer or swap-mode bit is
-produced on any reached path, so no wrong render result occurs. Recorded here so a future title using
-8-bit indices re-examines this line (a defensive `elem = (index_type & 3) == 1 ? 4 : (index_type & 3) == 2 ? 1 : 2`
-would harden it, but is deliberately not applied absent an exercising case, per the audit's
-cleanly-unreachable exclusion rule).
+**Index-size consumer treats any nonzero index type as 32-bit** — `command_processor.cpp:1499`,
+`uint32_t elem = index_type ? 4u : 2u`. In hardware terms an 8-bit index (`VGT_INDEX_TYPE_MODE`:
+16-bit=0, 32-bit=1, 8-bit=2) would resolve to 4 bytes instead of 1. **Refuted as unreachable BY
+CONSTRUCTION:** `index_type` here is NOT a decoded `VGT_INDEX_TYPE` hardware register field — it is
+`c.index_size = pl[0]` of the AGC `IT_INDEX_TYPE` packet, i.e. the argument to `sceAgc*SetIndexSize`
+(the Gnm/AGC `IndexSize` enum), which exposes only 16-bit (0) and 32-bit (1). There is no 8-bit
+`IndexSize` in the AGC path at all, so no reached — indeed no *representable* — value hits the wrong
+branch. The `elem = index_type ? 4u : 2u` form is therefore correct for every value the AGC API can
+produce; a defensive remap would be dead code. (Recorded so that if prosper ever decodes the raw
+hardware `VGT_INDEX_TYPE` register directly, this branch is revisited.)
 
 ## Per-group coverage (all verified clean)
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2181,9 +2181,14 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
         auto it = ds->sh.find(off);
         return it == ds->sh.end() ? 0u : it->second;
     };
-    out.local_x = reg(P::COMPUTE_NUM_THREAD_X);
-    out.local_y = reg(P::COMPUTE_NUM_THREAD_Y);
-    out.local_z = reg(P::COMPUTE_NUM_THREAD_Z);
+    // The workgroup local size is the NUM_THREAD_FULL field [15:0]; masking prevents a nonzero
+    // NUM_THREAD_PARTIAL ([31:16]) from being folded into the dimension (#911).
+    auto num_thread = [&](uint32_t off) {
+        return (reg(off) >> P::COMPUTE_NUM_THREAD_FULL_SHIFT) & P::COMPUTE_NUM_THREAD_FULL_MASK;
+    };
+    out.local_x = num_thread(P::COMPUTE_NUM_THREAD_X);
+    out.local_y = num_thread(P::COMPUTE_NUM_THREAD_Y);
+    out.local_z = num_thread(P::COMPUTE_NUM_THREAD_Z);
     if (!out.local_x) out.local_x = 1;
     if (!out.local_y) out.local_y = 1;
     if (!out.local_z) out.local_z = 1;

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -821,6 +821,11 @@ constexpr uint32_t COMPUTE_PGM_HI                  = 0x20D;
 constexpr uint32_t COMPUTE_NUM_THREAD_X             = 0x207;
 constexpr uint32_t COMPUTE_NUM_THREAD_Y             = 0x208;
 constexpr uint32_t COMPUTE_NUM_THREAD_Z             = 0x209;
+// The workgroup dimension is the NUM_THREAD_FULL field [15:0]; bits [31:16] are NUM_THREAD_PARTIAL
+// (residual-thread count for partial dispatches, which prosper does not model). Consumers must mask
+// to [15:0] — reading the full 32-bit register would fold a nonzero PARTIAL into the local size.
+constexpr uint32_t COMPUTE_NUM_THREAD_FULL_SHIFT    = 0;
+constexpr uint32_t COMPUTE_NUM_THREAD_FULL_MASK     = 0xFFFF;
 constexpr uint32_t COMPUTE_PGM_RSRC1             = 0x212;
 constexpr uint32_t COMPUTE_PGM_RSRC1_VGPRS_SHIFT = 0;
 constexpr uint32_t COMPUTE_PGM_RSRC1_VGPRS_MASK  = 0x3F;

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -272,6 +272,32 @@ int main() {
         }
     }
 
+    // #911: the workgroup local size is COMPUTE_NUM_THREAD_*.NUM_THREAD_FULL [15:0]; a nonzero
+    // NUM_THREAD_PARTIAL in bits [31:16] must NOT be folded into the dimension. Program X with a set
+    // PARTIAL field (0x3 << 16) over a real count of 32; the resolved local_x must be 32, not 0x30020.
+    {
+        namespace P = prosper::agc::Pm4;
+        alignas(4) uint32_t cbuf[128];
+        Dcb cd{}; cd.bottom = cbuf; cd.top = cbuf + 128; cd.cursor_up = cbuf; cd.cursor_down = cbuf + 128;
+        auto CD = (uint64_t)(uintptr_t)&cd;
+        reset(CD, 0x3ff, 0, 0, 0, 0);
+        ShaderReg thread_regs[3] = {
+            {P::COMPUTE_NUM_THREAD_X, (0x3u << 16) | 32u},   // PARTIAL=3, FULL=32
+            {P::COMPUTE_NUM_THREAD_Y, (0x7u << 16) | 4u},    // PARTIAL=7, FULL=4
+            {P::COMPUTE_NUM_THREAD_Z, 1u},
+        };
+        setsh(CD, (uint64_t)(uintptr_t)thread_regs, 3, 0, 0, 0);
+        dispatch(CD, 32, 4, 1, 0x1, 0);   // native workgroup dimensions
+        GpuState cs;
+        run_cb(cbuf, 128, cs);
+        CHECK(cs.dispatches.size() == 1, "#911 masked-thread dispatch counted");
+        if (cs.dispatches.size() == 1) {
+            const auto launch = resolve_compute_launch(cs.dispatches[0]);
+            CHECK(launch.local_x == 32 && launch.local_y == 4 && launch.local_z == 1,
+                  "#911: NUM_THREAD local size masks to FULL [15:0], ignoring PARTIAL [31:16]");
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Result of the **PM4 register-definition audit (#911)** — a systematic sweep of prosper's GPU register definitions and their consumers against the authoritative RDNA2 (gfx10.3) register database (Mesa's `gfx10.json` + `gfx10.3` overlay, flattened to a grep-able offset/shift/mask reference). Same find-then-adversarially-verify method as the RDNA2 ISA recompiler audit (#889 / #878–#883). Full report: `prosper/docs/PM4_REGISTER_AUDIT_2026_07.md`.

Fixes #911.

## What the sweep found

The register layer is **overwhelmingly correct**. Across all **887** offset/field constants in `pm4_registers.hpp` (DB/CB/PA/SPI/COMPUTE/GE-VGT-TA + the `IT_*` opcodes) and every consumer extraction in `render_state.cpp` / `command_processor.cpp` / `gpu_executor.cpp`, the sweep produced **one confirmed low-severity defect** and **one refuted candidate**. Every offset reconciles through the class-base convention (CONTEXT `0xA000` / SH `0x2C00` / UCONFIG `0xC000`), and every consumed field uses the right register, shift, and mask.

## The fix (1 confirmed finding)

**`resolve_compute_launch` read `COMPUTE_NUM_THREAD_X/Y/Z` as full 32-bit register values instead of the `NUM_THREAD_FULL` field [15:0]** (`gpu_executor.cpp:2184`).

- **Reference:** `COMPUTE_NUM_THREAD_X.NUM_THREAD_FULL` = bits [15:0]; `NUM_THREAD_PARTIAL` = [31:16] (residual-thread count for partial dispatches, which prosper does not model).
- **Failure scenario:** a guest that programs a nonzero `NUM_THREAD_PARTIAL` gets that folded into the workgroup local size (e.g. `0x3_0020` instead of `32`) → a corrupt dispatch. Exercised titles program small counts (`PARTIAL`=0), so **current output is byte-identical** — this is a correctness/hardening fix, hence LOW severity.
- **Change:** add the missing `COMPUTE_NUM_THREAD_FULL_SHIFT/MASK` constants; mask the consumer read to [15:0]. Regression test (`test_command_processor.cpp`) programs a set `PARTIAL` field and asserts the resolved local size ignores it (fails without the mask).

## Refuted candidate (documented, not changed)

`VGT_INDEX_TYPE` consumer (`command_processor.cpp:1499`, `elem = index_type ? 4u : 2u`): an 8-bit index type (code 2) would resolve to 4 bytes instead of 1, and bits [1:0] aren't masked off the swap-mode bits. **Refuted as unreachable** — prosper's `index_type` comes from `IT_INDEX_TYPE`, which exercised titles set only to 16/32-bit; no reached path uses 8-bit indices. Documented in the report so a future 8-bit-index title revisits it.

## Deliberately out of scope

The PM4 **packet framing / payload layout** in `pm4_decode.cpp` is prosper's own AGC-internal encoding (produced by `hle_agc.cpp`; the `IT_NOP` `R_*` sub-opcodes are a Sony/Kyty AGC convention, not hardware PM4). It's a producer/consumer contract verified by the existing `test_pm4_decode` / `test_command_processor` / `test_agc_dcb` tests, not by an AMD hardware reference — sweeping it against the AMD PM4 spec would produce spurious findings, so it was excluded.

## Risks

Minimal. The masked value equals the unmasked value for every register with `bits[31:16]==0` (all exercised titles), so rendered output is unchanged; the mask can only turn a future wrong dispatch into a correct one. No renderer/executor format or PM4-framing change.

## Verification (at head `f01a5e1`)

- `cmake --build prosper/build-linux -j12` — clean.
- `ctest` (full suite, WSL Ubuntu-24.04, GAME_DUMP set) — **113/113 passed**, including the new `#911` masked-thread regression assertions.
- `snapshot.py check` — blasphemous2-gameplay **OK** (98/98), evergate-title **OK** (9/9). messenger-scene and dead-cells-gameplay failed with a "route did not progress" signature (0 structural/qualifying frames, not wrong pixels), under heavy concurrent machine load (a competing build in another worktree at loadavg 7.3 during the run — software/llvmpipe rendering starves the wall-clock-scheduled Messenger route and the multi-minute Dead Cells warmup). **Isolated, not assumed:** an in-place A/B reverting this change's two source files to the parent commit (`53df2b7`) and rebuilding the renderer reproduced the **identical** failure on both routes — so the failures are environmental/pre-existing on master, independent of this PR. This change is also a provable no-op for exercised register values (all titles program `NUM_THREAD_PARTIAL`=0), and the compute-heavy Blasphemous 2 route passes every frame, so compute dispatch is unaffected. No rendering regression is attributable to this PR.
