### PR TITLE
fix(gpu): correct COLOR_5_6_5 comp_swap STD/ALT — AGC->Vulkan enum audit (#913)

### DIFF
--- a/prosper/docs/VK_TRANSLATE_AUDIT_2026_07.md
+++ b/prosper/docs/VK_TRANSLATE_AUDIT_2026_07.md
@@ -1,0 +1,63 @@
+# AGC→Vulkan enum-translation audit — prosper vs RDNA2 enums + Vulkan spec (2026-07)
+
+A systematic sweep of prosper's render-state **enum translation** (RDNA2 register enum value → Vulkan
+enum value), run against master `a449baf` on 2026-07-18. Fourth in the GPU-audit series (after the RDNA2
+ISA recompiler #878–#883, PM4 registers #911, and descriptors #912). Tracked by #913.
+
+## Scope and the two-sided reference
+
+Every mapping here takes an RDNA2 register enum **code** and must produce the correct **Vulkan enum
+value** — verified on both sides:
+
+- **RDNA2 side:** the gfx10.3 enums extracted from the Mesa AMD register database — `BlendOp` (blend
+  factor codes 0–20), `CombFunc` (blend combine 0–4), `CompareFrag` (0–7), `StencilOp` (0–15),
+  `VGT_DI_PRIM_TYPE`, plus ISA Table 47 for color formats.
+- **Vulkan side:** the stable spec enum values (`VkBlendFactor`, `VkBlendOp`, `VkCompareOp`,
+  `VkStencilOp`, `VkPrimitiveTopology`, `VkCullModeFlags`, `VkFrontFace`, `VkFormat`).
+
+This subsystem has a proven history of silent enum-mapping bugs (#534 reversed `VkFrontFace`, #654
+RectList topology), which is why it was swept.
+
+## Result: 1 confirmed fix, otherwise clean
+
+Across the blend-factor table (21 codes), blend combine, compare/stencil ops, cull/front-face,
+topology, and the color-format matrix, the sweep produced **one confirmed defect** (fixed here) and
+verified everything else correct.
+
+### Confirmed (fixed in this PR)
+
+**[MEDIUM] `COLOR_5_6_5` `comp_swap` STD/ALT reversed** — `vk_translate.cpp:128`.
+
+- **Convention (verified against the live-anchored rows):** `SWAP_STD` places R at the LOW end. This is
+  proven by the two anchor rows the sweep cross-checked — `0xA` `8_8_8_8` (live-verified, HIGH
+  confidence) STD → `R8G8B8A8` (R at byte 0), and `0x9` `2_10_10_10` STD → `A2B10G10R10` (R in bits
+  [9:0]). For a 565 packed word, R-at-low is Vulkan `B5G6R5_UNORM_PACK16` (R in bits [4:0]).
+- **Defect:** the 565 row returned `R5G6B5` (R in the HIGH bits [15:11]) for STD and `B5G6R5` for ALT —
+  the two arms swapped, the lone violator of prosper's own STD=R-low convention. The pre-existing test
+  had *enshrined* the reversed STD mapping.
+- **Consequence:** a guest 5_6_5 UNORM color/render target programmed with `SWAP_STD` renders with red
+  and blue channels swapped (and vice-versa for `SWAP_ALT`). Latent — no currently-booting title
+  (Messenger, Dead Cells, Blasphemous 2) uses a 565 CB surface (the exercised rows are `0xA` 8888 and
+  the packed HDR/2_10_10_10 rows), so rendered output for exercised titles is unchanged.
+- **Fix:** swap the arms (STD → `B5G6R5`, ALT → `R5G6B5`), matching the convention; the regression test
+  is corrected to the STD=R-low mapping and gains the ALT case.
+
+## Per-area coverage (all other mappings verified clean)
+
+- **Blend factor (`vk_blend_factor`, all 0–20):** correct, including the classic traps — DstColor
+  RDNA2=8 → VK `DST_COLOR`=4 (not 8), `SRC_ALPHA_SATURATE` RDNA2=10 → VK=14, the dual-source `SRC1_*`
+  factors (15–18 → 15–18), and the reordered CONSTANT_COLOR/ALPHA quad (13/14/19/20 → VK 10/11/12/13).
+  Codes 11/12 (`BOTH_SRC_ALPHA`/`BOTH_INV_SRC_ALPHA`) have no single VkBlendFactor equivalent and fall
+  through to ZERO — incompleteness, tracked in **#919**.
+- **Blend combine (`vk_blend_op`):** correct including the subtract/reverse-subtract direction —
+  `SRC_MINUS_DST`(1) → `SUBTRACT`(1, src-dst) and `DST_MINUS_SRC`(4) → `REVERSE_SUBTRACT`(2, dst-src),
+  NOT transposed; MIN/MAX remap (2/3 → 3/4). `CB_COLOR_CONTROL.MODE`/`ROP3` (hardware logic-op) are not
+  translated — incompleteness, tracked in **#919**.
+- **Compare / stencil / cull / front-face:** `vk_compare_op` (direct mask, valid because `CompareFrag`
+  0–7 == `VkCompareOp` 0–7); `vk_stencil_op` correctly remaps the RDNA2 `StencilOp` order to VkStencilOp
+  (ONES/REPLACE_TEST/REPLACE_OP → REPLACE with the ref value chosen by #466; ADD/SUB_CLAMP → INCR/DECR);
+  `cull_mode` bit assembly; and — critically — the `front_face` sense (the #534-class trap) is correct,
+  verified against the register definition and the `test_pipeline_render` regression.
+- **Topology / format:** `vk_topology` correct (RectList `7` → TriangleStrip is the #654 special-case,
+  not a finding); `vk_color_format` `number_type` mapping and the local `VkFormat` enum values are
+  correct (the 565 STD/ALT reversal above was the sole defect).

--- a/prosper/src/gpu/vk_translate.cpp
+++ b/prosper/src/gpu/vk_translate.cpp
@@ -125,8 +125,12 @@ VkFormat vk_color_format(uint32_t format, uint32_t number_type, uint32_t comp_sw
                           case 7: return VkFormat::R32G32B32A32_SFLOAT; }
             break;
         case 0x10u:  // COLOR_5_6_5
-            if (nt == 0u) return std_swap ? VkFormat::R5G6B5_UNORM_PACK16
-                        : alt_swap        ? VkFormat::B5G6R5_UNORM_PACK16 : VkFormat::Undefined;
+            // SWAP_STD places R at the LOW end (the convention proven by the live-verified 0xA row —
+            // STD -> R8G8B8A8, R at byte 0 — and the 0x9 row — STD -> A2B10G10R10, R in bits [9:0]).
+            // For a 565 packed word R-at-low is Vulkan B5G6R5_UNORM_PACK16 (R in bits [4:0]); the STD
+            // and ALT arms were previously reversed, swapping red/blue on any 565 surface (#913).
+            if (nt == 0u) return std_swap ? VkFormat::B5G6R5_UNORM_PACK16
+                        : alt_swap        ? VkFormat::R5G6B5_UNORM_PACK16 : VkFormat::Undefined;
             break;
         default: break;
     }

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -182,7 +182,10 @@ int main() {
     CHECK(vk_color_format(0x6u, 7u, 0u) == VkFormat::B10G11R11_UFLOAT_PACK32, "0x6 (alias of 0x7)/FLOAT -> B10G11R11");
     CHECK(vk_color_format(0x8u, 0u, 0u) == VkFormat::A2B10G10R10_UNORM_PACK32, "0x8 (alias of 0x9)/UNORM/STD -> A2B10G10R10");
     CHECK(vk_color_format(0x8u, 0u, 1u) == VkFormat::A2R10G10B10_UNORM_PACK32, "0x8 (alias of 0x9)/UNORM/ALT -> A2R10G10B10");
-    CHECK(vk_color_format(0x10u, 0u, 0u) == VkFormat::R5G6B5_UNORM_PACK16, "0x10/UNORM -> R5G6B5 (4)");
+    // #913: SWAP_STD places R at the low end (proven by the live-verified 0xA STD->R8G8B8A8 and the
+    // 0x9 STD->A2B10G10R10 rows above). For a 565 word R-at-low is B5G6R5; STD/ALT were reversed here.
+    CHECK(vk_color_format(0x10u, 0u, 0u) == VkFormat::B5G6R5_UNORM_PACK16, "0x10/UNORM/STD -> B5G6R5 (R low)");
+    CHECK(vk_color_format(0x10u, 0u, 1u) == VkFormat::R5G6B5_UNORM_PACK16, "0x10/UNORM/ALT -> R5G6B5 (R high)");
     CHECK(vk_color_format(0x1u, 0u, 0u) == VkFormat::R8_UNORM,   "0x1/UNORM -> R8_UNORM (9, Kyty's R8Unorm row)");
     CHECK(vk_color_format(0x4u, 7u, 0u) == VkFormat::R32_SFLOAT, "0x4/FLOAT -> R32_SFLOAT (100)");
     CHECK(vk_color_format(0x5u, 7u, 0u) == VkFormat::R16G16_SFLOAT, "0x5/FLOAT -> R16G16_SFLOAT (83)");


### PR DESCRIPTION
Result of the **AGC→Vulkan enum-translation audit (#913)** — a two-sided sweep of prosper's render-state enum translation (RDNA2 register enum code ↔ Vulkan enum value), same method as the recompiler (#889), PM4-register (#917), and descriptor (#918) audits. Full report: `prosper/docs/VK_TRANSLATE_AUDIT_2026_07.md`.

Fixes #913.

## What the sweep found

The translation layer is **well-built** — the tricky mappings all verified correct: the RDNA2→Vulkan **stencil-op reorder** (ONES/REPLACE_TEST/REPLACE_OP → REPLACE with the #466 ref-value logic; ADD/SUB_CLAMP → INCR/DECR), the **subtract/reverse-subtract direction** (`SRC_MINUS_DST`→SUBTRACT, `DST_MINUS_SRC`→REVERSE_SUBTRACT — not transposed), the blend-factor traps (DstColor RDNA2=8 → VK `DST_COLOR`=4; `SRC_ALPHA_SATURATE`=10 → VK=14; dual-source SRC1 15–18; the reordered CONSTANT quad), and the **#534-class front-face sense**. **One confirmed defect.**

## The fix

**`COLOR_5_6_5` `comp_swap` STD/ALT reversed** (`vk_translate.cpp:128`) — red/blue swapped on any 565 surface.

- **Convention (verified against the live-anchored rows):** `SWAP_STD` places R at the LOW end — proven by `0xA` 8_8_8_8 (live-verified) STD → `R8G8B8A8` (R at byte 0) and `0x9` 2_10_10_10 STD → `A2B10G10R10` (R in bits [9:0], asymmetric fields ruling out coincidence). For a 565 packed word, R-at-low is Vulkan `B5G6R5_UNORM_PACK16`.
- **Defect:** the 565 row returned `R5G6B5` (R in the HIGH bits) for STD — the two arms swapped, the lone violator of prosper's own STD=R-low convention. The pre-existing test had *enshrined* the reversed mapping.
- **Failure scenario:** a guest 5_6_5 UNORM color/render target with `SWAP_STD` renders red/blue swapped. **Latent** — no currently-booting title uses a 565 CB surface (the exercised rows are `0xA` 8888 and the packed HDR/2_10_10_10 rows), so rendered output for exercised titles is **unchanged**.
- **Fix:** swap the arms (STD → `B5G6R5`, ALT → `R5G6B5`); the regression test is corrected to STD=R-low and gains the ALT case (it fails against the old code).

## Deferred (tracked in #919, not fixed here)

Two incompleteness gaps the sweep surfaced — both latent, no exercised title hits them: dual-output blend factors 11/12 (`BOTH_SRC_ALPHA`) fall through to ZERO (no single VkBlendFactor equivalent); `CB_COLOR_CONTROL.MODE`/`ROP3` hardware logic-op is not translated.

## Independent review

Approved (HIGH confidence). The reviewer independently re-derived STD→B5G6R5 from first principles (the Vulkan MSB→LSB PACK naming rule + both anchor rows), confirmed the old code was the bug and the test enshrined it, verified no exercised title uses 565 (no regression risk), and spot-checked the "otherwise clean" claim (blend traps, subtract direction) — all holding.

## Risks

Minimal. Touches only the 565 UNORM STD/ALT arms; cs∈{2,3} still returns Undefined (unchanged). No exercised title uses a 565 CB surface, so rendering is unchanged for all booting titles; the change only moves the latent 565 path toward the proven convention.

## Verification (at head `ecc76df`)

- `cmake --build prosper/build-linux -j12` — clean.
- `ctest` (full suite, WSL Ubuntu-24.04, GAME_DUMP set) — **113/113 passed**, including the corrected 565 STD/ALT `test_render_state` assertions (which fail against the old mapping).
- `snapshot.py check` — blasphemous2-gameplay **OK** (98/98), evergate-title **OK** (9/9). messenger-scene and dead-cells-gameplay failed with the "route did not progress" signature under sustained multi-agent machine load — the SAME environmental failure already proven (in the #911 PR) via an in-place A/B: the parent commit fails these two routes identically, so it is a pre-existing load-driven condition on this shared box, not caused by any of these audit PRs. This change is also 565-only, and no exercised title uses a 565 CB surface (verified by the sweep and the reviewer), so it cannot affect any route's rendering. No rendering regression is attributable to this PR.
