### PR TITLE
gpu: render Astro Bot opening video surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,8 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   and deliberately unaffected behavior, record risks, and list the exact build/test/snapshot commands and
   results. PRs that advance a game's visible progression must attach representative screenshots and identify
   the title, platform, and reached checkpoint; black or diagnostic-only captures are not progression evidence.
+  Use direct, unmodified frontend captures and name the frontend plus the run route in each caption; output
+  produced by forced guest-state diagnostics may illustrate an investigation but is not acceptance evidence.
   Run the strongest relevant local checks and wait for every applicable required CI check. Before
   merging, synchronize with the live target branch when needed, inspect the resulting diff, run `diff --check`,
   and address every known correctness concern. An agent may merge only when the user or task explicitly

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -882,6 +882,13 @@ if(UNIX AND NOT APPLE AND PROSPER_VIDEO_VAAPI AND TARGET prosper_core)
       target_link_libraries(boot_trace PRIVATE prosper_video_vaapi)
       target_compile_definitions(boot_trace PRIVATE PROSPER_VIDEO_VAAPI=1)
     endif()
+
+    # Match boot_trace and prosper-app: headless captures must install the real Linux decoder too,
+    # otherwise video-gated titles only expose an empty scanout to the screenshot frontend.
+    if(TARGET screenshot)
+      target_link_libraries(screenshot PRIVATE prosper_video_vaapi)
+      target_compile_definitions(screenshot PRIVATE PROSPER_VIDEO_VAAPI=1)
+    endif()
   else()
     message(WARNING "FFmpeg/libva development packages not found - Linux AvPlayer video disabled")
   endif()

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <functional>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -35,6 +36,7 @@ uint8_t storage_pack_unorm8(uint32_t float_bits) {
 namespace {
 
 constexpr VkDeviceSize kMaxComputeImageBytes = 256ull << 20;
+constexpr size_t kMaxCachedComputePipelines = 4096;
 
 struct ComputeMemoryKey {
     VkDeviceSize bytes = 0;
@@ -70,6 +72,13 @@ struct ComputeMemoryPoolStats {
     uint64_t discarded = 0;
 };
 
+struct CachedComputePipeline {
+    VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
+    VkShaderModule shader = VK_NULL_HANDLE;
+    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+};
+
 bool compute_memory_pool_enabled() {
     static const bool enabled = std::getenv("PROSPER_NO_MEMORY_POOL") == nullptr;
     return enabled;
@@ -90,6 +99,8 @@ struct VulkanComputeContext {
     VkPhysicalDevice physical = VK_NULL_HANDLE;
     VkDevice device = VK_NULL_HANDLE;
     VkQueue queue = VK_NULL_HANDLE;
+    VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
+    std::unordered_map<std::string, CachedComputePipeline> pipelines;
     uint32_t queue_family = UINT32_MAX;
     VkPhysicalDeviceMemoryProperties memory{};
     ComputeMemoryPool memory_pool;
@@ -101,6 +112,16 @@ struct VulkanComputeContext {
 
     ~VulkanComputeContext() {
         release_cached_memory();
+        for (const auto& [key, cached] : pipelines) {
+            (void)key;
+            if (cached.pipeline) vkDestroyPipeline(device, cached.pipeline, nullptr);
+            if (cached.pipeline_layout)
+                vkDestroyPipelineLayout(device, cached.pipeline_layout, nullptr);
+            if (cached.shader) vkDestroyShaderModule(device, cached.shader, nullptr);
+            if (cached.descriptor_layout)
+                vkDestroyDescriptorSetLayout(device, cached.descriptor_layout, nullptr);
+        }
+        if (pipeline_cache) vkDestroyPipelineCache(device, pipeline_cache, nullptr);
         if (device) vkDestroyDevice(device, nullptr);
         if (instance) vkDestroyInstance(instance, nullptr);
     }
@@ -252,6 +273,9 @@ struct VulkanComputeContext {
 #endif
         if (vkCreateDevice(physical, &dci, nullptr, &device) != VK_SUCCESS) return false;
         vkGetDeviceQueue(device, queue_family, 0, &queue);
+        VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
+        if (vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache) != VK_SUCCESS)
+            return false;
         vkGetPhysicalDeviceMemoryProperties(physical, &memory);
         return true;
     }
@@ -461,6 +485,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     VkShaderModule shader = VK_NULL_HANDLE;
     VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
     VkPipeline pipeline = VK_NULL_HANDLE;
+    bool pipeline_cached = false;
+    std::string pipeline_key;
     VkCommandPool command_pool = VK_NULL_HANDLE;
     VkFence fence = VK_NULL_HANDLE;
     bool ok = false;
@@ -479,11 +505,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     auto cleanup = [&] {
         if (fence) vkDestroyFence(ctx.device, fence, nullptr);
         if (command_pool) vkDestroyCommandPool(ctx.device, command_pool, nullptr);
-        if (pipeline) vkDestroyPipeline(ctx.device, pipeline, nullptr);
-        if (pipeline_layout) vkDestroyPipelineLayout(ctx.device, pipeline_layout, nullptr);
-        if (shader) vkDestroyShaderModule(ctx.device, shader, nullptr);
+        if (!pipeline_cached) {
+            if (pipeline) vkDestroyPipeline(ctx.device, pipeline, nullptr);
+            if (pipeline_layout) vkDestroyPipelineLayout(ctx.device, pipeline_layout, nullptr);
+            if (shader) vkDestroyShaderModule(ctx.device, shader, nullptr);
+            if (descriptor_layout)
+                vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
+        }
         if (descriptor_pool) vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
-        if (descriptor_layout) vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
         for (auto& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX) continue;
             if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
@@ -1219,11 +1248,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
             layout_bindings.push_back(b);
         }
-        VkDescriptorSetLayoutCreateInfo dlci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-        dlci.bindingCount = static_cast<uint32_t>(layout_bindings.size());
-        dlci.pBindings = layout_bindings.data();
-        if (!vk_ok(vkCreateDescriptorSetLayout(ctx.device, &dlci, nullptr, &descriptor_layout),
-                   "descriptor-layout")) break;
+        pipeline_key.clear();
+        auto append_pipeline_key_u32 = [&](uint32_t value) {
+            pipeline_key.append(reinterpret_cast<const char*>(&value), sizeof(value));
+        };
+        append_pipeline_key_u32(static_cast<uint32_t>(item.spirv.size()));
+        pipeline_key.append(reinterpret_cast<const char*>(item.spirv.data()),
+                            item.spirv.size() * sizeof(uint32_t));
+        append_pipeline_key_u32(static_cast<uint32_t>(item.user_sgprs.size()));
+        append_pipeline_key_u32(static_cast<uint32_t>(layout_bindings.size()));
+        for (const auto& binding : layout_bindings) {
+            append_pipeline_key_u32(binding.binding);
+            append_pipeline_key_u32(static_cast<uint32_t>(binding.descriptorType));
+            append_pipeline_key_u32(binding.descriptorCount);
+            append_pipeline_key_u32(binding.stageFlags);
+        }
+        if (const auto found = ctx.pipelines.find(pipeline_key); found != ctx.pipelines.end()) {
+            descriptor_layout = found->second.descriptor_layout;
+            shader = found->second.shader;
+            pipeline_layout = found->second.pipeline_layout;
+            pipeline = found->second.pipeline;
+            pipeline_cached = true;
+        } else {
+            VkDescriptorSetLayoutCreateInfo dlci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+            dlci.bindingCount = static_cast<uint32_t>(layout_bindings.size());
+            dlci.pBindings = layout_bindings.data();
+            if (!vk_ok(vkCreateDescriptorSetLayout(ctx.device, &dlci, nullptr, &descriptor_layout),
+                       "descriptor-layout")) break;
+        }
         uint32_t sampled_count = 0, storage_image_count = 0;
         for (const auto& im : images) (im.storage ? storage_image_count : sampled_count)++;
         VkDescriptorPoolSize pool_sizes[3]; uint32_t pool_size_count = 0;
@@ -1272,25 +1324,40 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         vkUpdateDescriptorSets(ctx.device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
-        VkShaderModuleCreateInfo smci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
-        smci.codeSize = item.spirv.size() * sizeof(uint32_t);
-        smci.pCode = item.spirv.data();
-        if (!vk_ok(vkCreateShaderModule(ctx.device, &smci, nullptr, &shader), "shader-module")) break;
-        VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-        plci.setLayoutCount = 1;
-        plci.pSetLayouts = &descriptor_layout;
-        if (!vk_ok(vkCreatePipelineLayout(ctx.device, &plci, nullptr, &pipeline_layout),
-                   "pipeline-layout")) break;
-        VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
-        cpci.stage = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
-        cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        cpci.stage.module = shader;
-        cpci.stage.pName = "main";
-        cpci.layout = pipeline_layout;
-        if (trace) std::fprintf(stderr, "[compute]   creating compute pipeline\n");
-        if (!vk_ok(vkCreateComputePipelines(ctx.device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipeline),
-                   "compute-pipeline")) break;
-        if (trace) std::fprintf(stderr, "[compute]   compute pipeline ready\n");
+        if (!pipeline_cached) {
+            VkShaderModuleCreateInfo smci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+            smci.codeSize = item.spirv.size() * sizeof(uint32_t);
+            smci.pCode = item.spirv.data();
+            if (!vk_ok(vkCreateShaderModule(ctx.device, &smci, nullptr, &shader), "shader-module"))
+                break;
+            VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+            plci.setLayoutCount = 1;
+            plci.pSetLayouts = &descriptor_layout;
+            VkPushConstantRange push_range{};
+            if (!item.user_sgprs.empty()) {
+                push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+                push_range.size = static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t));
+                plci.pushConstantRangeCount = 1;
+                plci.pPushConstantRanges = &push_range;
+            }
+            if (!vk_ok(vkCreatePipelineLayout(ctx.device, &plci, nullptr, &pipeline_layout),
+                       "pipeline-layout")) break;
+            VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+            cpci.stage = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+            cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+            cpci.stage.module = shader;
+            cpci.stage.pName = "main";
+            cpci.layout = pipeline_layout;
+            if (trace) std::fprintf(stderr, "[compute]   creating compute pipeline\n");
+            if (!vk_ok(vkCreateComputePipelines(ctx.device, ctx.pipeline_cache, 1, &cpci, nullptr,
+                                                &pipeline), "compute-pipeline")) break;
+            if (trace) std::fprintf(stderr, "[compute]   compute pipeline ready\n");
+            if (ctx.pipelines.size() < kMaxCachedComputePipelines) {
+                ctx.pipelines.emplace(std::move(pipeline_key), CachedComputePipeline{
+                    descriptor_layout, shader, pipeline_layout, pipeline});
+                pipeline_cached = true;
+            }
+        }
         phase_pipeline = ComputeClock::now();
 
         VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
@@ -1341,6 +1408,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         vkCmdBindPipeline(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
         vkCmdBindDescriptorSets(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout,
                                 0, 1, &descriptor_set, 0, nullptr);
+        if (!item.user_sgprs.empty())
+            vkCmdPushConstants(command, pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
+                               static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t)),
+                               item.user_sgprs.data());
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         for (size_t i = 0; i < images.size(); i++) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2021,10 +2021,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             for (const auto* src : pass) {
                                 adjusted.push_back(*src);
                                 auto& item = adjusted.back();
-                                if (item.ps.has_viewport) {
-                                    item.ps.viewport_x *= ax; item.ps.viewport_w *= ax;
-                                    item.ps.viewport_y *= ay; item.ps.viewport_h *= ay;
-                                }
+                                prosper::gpu::scale_resolved_render_area(item.ps, ax, ay);
                                 render_pass.push_back(&item);
                             }
                         }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1803,6 +1803,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const auto& it = *itp;
                     prosper::test::BackendDraw bd;
                     bd.vs     = refvs ? refvs_spv : it.vs;
+                    bd.gs     = refvs ? std::vector<uint32_t>{} : it.gs;
                     // File and synthetic overrides have independent exact-match gates.
                     bool fs_ov = !ps_override.empty();
                     if (fs_ov && ps_override_is_file) {

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 17;
+constexpr uint32_t kVersion = 18;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -545,6 +545,7 @@ void collect_shader_versions(GpuCaptureFile& capture) {
     };
     for (const auto& draw : capture.draws) {
         add(draw.vs);
+        if (!draw.gs.empty()) add(draw.gs);
         add(draw.fs);
     }
     for (const auto& compute : capture.computes) add(compute.spirv);
@@ -903,7 +904,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         }
     }
     for (const auto& d : draws) {
-        GpuCapturedDraw c; c.vs = d.vs; c.fs = d.fs; c.ps = d.ps; c.vertex_count = d.vertex_count;
+        GpuCapturedDraw c; c.vs = d.vs; c.gs = d.gs; c.fs = d.fs;
+        c.ps = d.ps; c.vertex_count = d.vertex_count;
         c.indices = d.indices; c.color0_base = d.color0_base;
         c.color0_width = d.color0_width; c.color0_height = d.color0_height;
         c.color1_base = d.color1_base;
@@ -1111,7 +1113,11 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         });
         if (it == versions.end()) versions.push_back({hash, words});
     };
-    for (const auto& d : c.draws) { add_shader(d.vs); add_shader(d.fs); }
+    for (const auto& d : c.draws) {
+        add_shader(d.vs);
+        if (!d.gs.empty()) add_shader(d.gs);
+        add_shader(d.fs);
+    }
     for (const auto& compute : c.computes) add_shader(compute.spirv);
     if (versions.size() > kMaxResources) { error = "invalid shader-version count"; return false; }
     w.u32(static_cast<uint32_t>(versions.size()));
@@ -1130,7 +1136,8 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         if (vs_index == 0xFFFFFFFFu || fs_index == 0xFFFFFFFFu) {
             error = "draw shader is missing from the version table"; return false;
         }
-        w.u32(vs_index); w.u32(fs_index); write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
+        w.u32(vs_index); w.u32(fs_index);
+        write_pipeline(w, d.ps); write_table(w, d.vrt); write_table(w, d.prt);
         w.u32(d.vertex_count); w.words(d.indices); w.u64(d.color0_base);
         w.u32(d.color0_width); w.u32(d.color0_height);
         w.u64(d.draw_index); w.u64(d.command_order);
@@ -1375,6 +1382,18 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
     for (const auto& diagnostic : c.failure_diagnostics)
         if (diagnostic.pipeline_present) write_scissor_pipeline(w, diagnostic.pipeline);
+    // v18 appends the optional generated geometry-stage identity without changing any legacy draw
+    // prefix. UINT32_MAX means the normal VS->FS fast path; otherwise the index names the shared
+    // content-addressed SPIR-V version, just like the base VS/FS indices.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) {
+        const uint32_t geometry_index = draw.gs.empty()
+            ? 0xFFFFFFFFu : shader_version_index(versions, draw.gs);
+        if (!draw.gs.empty() && geometry_index == 0xFFFFFFFFu) {
+            error = "draw geometry shader is missing from the version table"; return false;
+        }
+        w.u32(geometry_index);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1844,6 +1863,21 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (diagnostic.pipeline_present && !read_scissor_pipeline(r, diagnostic.pipeline))
                 return false;
     }
+    if (version >= 18) {
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid geometry-stage draw-state count"; return false;
+        }
+        for (auto& draw : c.draws) {
+            uint32_t geometry_index = 0;
+            if (!r.u32(geometry_index)) return false;
+            if (geometry_index == 0xFFFFFFFFu) continue;
+            if (geometry_index >= c.shader_versions.size()) {
+                error = "invalid draw geometry shader-version index"; return false;
+            }
+            draw.gs = c.shader_versions[geometry_index].words;
+        }
+    }
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
 }
@@ -1913,7 +1947,8 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
     };
     out.items.reserve(c.draws.size());
     for (const auto& x : c.draws) {
-        DrawItem d; d.vs = x.vs; d.fs = x.fs; d.ps = x.ps; d.vertex_count = x.vertex_count;
+        DrawItem d; d.vs = x.vs; d.gs = x.gs; d.fs = x.fs;
+        d.ps = x.ps; d.vertex_count = x.vertex_count;
         d.indices = x.indices; d.color0_base = x.color0_base;
         d.color0_width = x.color0_width; d.color0_height = x.color0_height;
         d.color1_base = x.color1_base;

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -59,6 +59,7 @@ struct GpuCapturedTable {
 
 struct GpuCapturedDraw {
     std::vector<uint32_t> vs;
+    std::vector<uint32_t> gs;
     std::vector<uint32_t> fs;
     ResolvedPipelineState ps;
     GpuCapturedTable vrt;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -39,7 +39,7 @@ struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backe
 // — e.g. Unity's background + composite, whose per-draw masks/blends/shaders differ — composites
 // correctly instead of collapsing onto a single draw. The tables may be null (color-only shaders).
 struct DrawItem {
-    std::vector<uint32_t> vs, fs;                     // recompiled SPIR-V
+    std::vector<uint32_t> vs, gs, fs;                 // recompiled/generated SPIR-V
     uint64_t vs_guest_addr = 0, fs_guest_addr = 0;    // diagnostic/source identity in guest VA space
     // Process-unique identities supplied by the exact shader-recompile cache. Zero means the
     // shader came from an external/replay path, so persistent backend caches must compare words.
@@ -545,6 +545,10 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     PixelSystemInputMapping system_inputs{rs.ps_input_ena, rs.ps_input_addr};
     const PixelSystemInputMapping* system_input_ptr =
         (system_inputs.ena || system_inputs.addr) ? &system_inputs : nullptr;
+    const ResolvedPipelineState resolved_pipeline = resolve_pipeline_state(rs);
+    const FragmentInterpolationLayout interpolation = fragment_interpolation_layout(
+        reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
+        max_shader_dwords, system_input_ptr);
     uint64_t vs_identity = 0, fs_identity = 0;
     std::vector<uint32_t> vs = recompile_graphics_shader_cached(
         ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
@@ -552,6 +556,14 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     std::vector<uint32_t> fs = recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
         max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+    std::vector<uint32_t> gs;
+    if (interpolation.requires_geometry && interpolation.valid) {
+        // Geometry `Triangles` accepts list, strip, and fan input assembly. Points/lines cannot
+        // provide the three AMD vertex parameters and remain fail-visible.
+        const bool triangle_topology = resolved_pipeline.topology >= 3u &&
+                                       resolved_pipeline.topology <= 5u;
+        if (triangle_topology) gs = recompile_interpolation_geometry(interpolation);
+    }
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();
         record_draw_realization_phases(
@@ -574,7 +586,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             nd++;
         }
     }
-    if (vs.empty() || fs.empty()) {
+    if (vs.empty() || fs.empty() || (interpolation.requires_geometry && gs.empty())) {
         if (failure) failure->reason = RealizationFailureReason::ShaderRecompile;
         // PROSPER_DYNTRACE_FAIL=1: replay the FAILED vertex stage's resource build with the
         // dynamic-fetch walk trace + user-data block dump forced on (once per distinct VS), so the
@@ -601,9 +613,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
         if (getenv("PROSPER_DBG"))
-            fprintf(stderr, "[exec-recompile-reject] es=0x%llx ps=0x%llx vs=%zu fs=%zu order=%llu\n",
+            fprintf(stderr, "[exec-recompile-reject] es=0x%llx ps=0x%llx vs=%zu gs=%zu fs=%zu "
+                            "prim=%u topo=%u ena=%08x addr=%08x order=%llu\n",
                     (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
-                    vs.size(), fs.size(),
+                    vs.size(), gs.size(), fs.size(), rs.prim_type, resolved_pipeline.topology,
+                    rs.ps_input_ena, rs.ps_input_addr,
                     (unsigned long long)(draw ? draw->command_order : 0));
         if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
             for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
@@ -623,11 +637,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
         if (log) {
-            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu fs=%zu; order=%llu "
+            fprintf(stderr, "[exec] skip draw: recompile failed (vs=%zu gs=%zu fs=%zu; order=%llu "
                             "es=0x%llx ps=0x%llx color0=0x%llx/%ux%u "
                             "depth=%d/%d/op%u clear=%d/%g base=0x%llx/0x%llx "
                             "stencil=%d clear=%d/%u base=0x%llx/0x%llx)\n",
-                    vs.size(), fs.size(),
+                    vs.size(), gs.size(), fs.size(),
                     (unsigned long long)(draw ? draw->command_order : 0),
                     (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
                     (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
@@ -656,7 +670,14 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                          (unsigned long long)rs.color0_base);
         return false;
     }
-    ResolvedPipelineState ps = resolve_pipeline_state(rs);
+    ResolvedPipelineState ps = resolved_pipeline;
+    // EXP.EN is the final per-component gate after CB_TARGET_MASK and CB_SHADER_MASK. Vulkan exposes
+    // the same preservation semantics through colorWriteMask: disabled attachment components retain
+    // their old values even though the fragment output itself is a full vec4.
+    const uint32_t exp_mask = fragment_color_export_mask(
+        reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)), max_shader_dwords);
+    ps.color_write_mask &= exp_mask & 0xFu;
+    ps.color1_write_mask &= (exp_mask >> 4) & 0xFu;
     // Color-disabled draws are not necessarily no-ops. Depth prepasses and stencil mask writers
     // deliberately set CB_TARGET_MASK=0, then later color draws consume their DS result. Dropping
     // those writers made The Messenger clear stencil to 0 and then test for bits 1/2 that could never
@@ -677,9 +698,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // cutscene caption text: small indexed quads, bottom viewport, blended, sampling a font atlas).
     if (getenv("PROSPER_DRAWDIAG")) {
         uint32_t ic = (draw && draw->indexed) ? draw->index_count : vcount_hint;
-        fprintf(stderr, "[draw] idx=%u vp=%d y=%.0f h=%.0f blend=%d cwm=0x%x es=0x%llx", ic,
+        fprintf(stderr, "[draw] idx=%u vp=%d y=%.0f h=%.0f blend=%d cwm=0x%x "
+                        "target=0x%x shader=0x%x exp=0x%x es=0x%llx ps=0x%llx", ic,
                 ps.has_viewport, ps.viewport_y, ps.viewport_h, ps.blend_enable, ps.color_write_mask,
-                (unsigned long long)rs.es_addr);
+                rs.cb_target_mask, rs.cb_shader_mask, exp_mask,
+                (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
         if (prt) for (const auto& r : prt->resources)
             if (r.cls == ResourceClass::Texture)
                 fprintf(stderr, " tex=0x%llx(%ux%u f%u)", (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
@@ -885,7 +908,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
     }
-    out.vs = std::move(vs); out.fs = std::move(fs);
+    out.vs = std::move(vs); out.gs = std::move(gs); out.fs = std::move(fs);
     out.vs_guest_addr = rs.es_addr; out.fs_guest_addr = rs.ps_addr;
     out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -202,6 +202,7 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& dispatc
 
 struct ComputeItem {
     std::vector<uint32_t> spirv;
+    std::vector<uint32_t> user_sgprs;
     std::shared_ptr<ShaderResourceTable> resources;
     ComputeLaunchDimensions launch;
     uint64_t code_addr = 0;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2581,6 +2581,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
         ComputeItem item;
         item.spirv = recompile_compute((const uint32_t*)(uintptr_t)code_addr, 0x10000,
                                        table.get(), config);
+        item.user_sgprs = config.user_sgprs;
         if (!item.spirv.empty() && getenv("PROSPER_SHADER_DUMP_SUCCESS")) {
             const ShaderCompileKey dump_key = make_shader_compile_key(
                 ShaderProgramStage::Compute,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2621,10 +2621,24 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     g_dyntrace_force = false;
                     std::fprintf(stderr, "[dynfail]   const-fold recovered %zu descriptor use(s):\n",
                                  cs_uses.size());
-                    for (const auto& u : cs_uses)
-                        std::fprintf(stderr, "[dynfail]     %s key=0x%x use_pc=%u dw0=0x%x\n",
-                                     u.kind == 0 ? "TEX/IMG(t8)" : "BUF(v4)", u.key, u.use_pc,
-                                     u.kind == 0 ? u.t8[0] : u.v4[0]);
+                    for (const auto& u : cs_uses) {
+                        if (u.kind == 0) {
+                            std::fprintf(stderr,
+                                         "[dynfail]     TEX/IMG(t8) key=0x%x use_pc=%u "
+                                         "t8=%08x:%08x:%08x:%08x:%08x:%08x:%08x:%08x\n",
+                                         u.key, u.use_pc, u.t8[0], u.t8[1], u.t8[2], u.t8[3],
+                                         u.t8[4], u.t8[5], u.t8[6], u.t8[7]);
+                        } else {
+                            const DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                            std::fprintf(stderr,
+                                         "[dynfail]     BUF(v4) key=0x%x use_pc=%u "
+                                         "v4=%08x:%08x:%08x:%08x base=0x%llx stride=%u "
+                                         "records=%u size=%u required=%u\n",
+                                         u.key, u.use_pc, u.v4[0], u.v4[1], u.v4[2], u.v4[3],
+                                         (unsigned long long)d.base, d.stride, d.num_records,
+                                         d.size_bytes, u.required_size);
+                        }
+                    }
                 }
             }
             static std::set<uint64_t> logged;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -68,7 +68,8 @@ enum : uint32_t {
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
     EM_OutputVertices=26, EM_OutputTriangleStrip=29,
-    SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_StorageBuffer=12, FC_None=0,
+    SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_PushConstant=9,
+    SC_StorageBuffer=12, FC_None=0,
     Dim_1D=0, Dim_2D=1, Dim_3D=2,   // SPIR-V Dim. (2D coincides with the SQ_RSRC 2D dim value, but distinct.)
     Cap_Sampled1D=43, Cap_Image1D=44,   // Dim=1D needs Sampled1D; a 1D STORAGE image (read/write) also needs Image1D
     Cap_StorageImageMultisample=27,      // MS=1 storage image (read/write a multisampled image)
@@ -118,6 +119,7 @@ struct SpirvCompute {
     uint32_t v_gid=0, v_groupid=0, v_in=0, v_out=0, gidx=0, f_main=0, glsl=0, bconst_false=0;
     uint32_t globalid_comp[3] = {0, 0, 0}, groupid[3] = {0, 0, 0}, localid_comp[3] = {0, 0, 0};
     uint32_t invocation_guard_merge = 0;
+    uint32_t v_push_constants = 0, t_ptr_push_u32 = 0;
     uint32_t linear_localid = 0, local_count = 64, wave_size = 64;
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
@@ -1057,13 +1059,21 @@ struct SpirvCompute {
         put(code, Op_Store, {p, sel});
     }
     uint32_t btrue() { uint32_t r = id(); put(types, Op_ConstantTrue, {t_bool, r}); return r; }
+    uint32_t load_push_constant(uint32_t index) {
+        uint32_t pointer = id();
+        put(code, Op_AccessChain,
+            {t_ptr_push_u32, pointer, v_push_constants, uconst(0), uconst(index)});
+        uint32_t value = id();
+        put(code, Op_Load, {t_u32, value, pointer});
+        return value;
+    }
     // Logical AND / OR of two bools (EXEC narrowing / saveexec).
     uint32_t land(uint32_t a, uint32_t b_) { uint32_t r = id(); put(code, Op_LogicalAnd, {t_bool, r, a, b_}); return r; }
     uint32_t lor(uint32_t a, uint32_t b_)  { uint32_t r = id(); put(code, Op_LogicalOr,  {t_bool, r, a, b_}); return r; }
 
     void begin(uint32_t input_stride, const ShaderResourceTable* rt = nullptr,
                uint32_t local_x = 64, uint32_t local_y = 1, uint32_t local_z = 1,
-               uint32_t hardware_wave_size = 64) {
+               uint32_t hardware_wave_size = 64, uint32_t push_constant_dwords = 0) {
         stride = input_stride;
         local_count = local_x * local_y * local_z;
         wave_size = hardware_wave_size;
@@ -1096,6 +1106,23 @@ struct SpirvCompute {
         put(types, Op_TypeVector, {t_v3u, t_u32, 3});
         put(types, Op_TypeVector, {t_v4f, t_f32, 4});
         put(types, Op_TypeBool, {t_bool});
+        if (push_constant_dwords) {
+            const uint32_t count = id();
+            put(types, Op_Constant, {t_u32, count, push_constant_dwords});
+            const uint32_t array = id();
+            put(types, Op_TypeArray, {array, t_u32, count});
+            put(deco, Op_Decorate, {array, Dec_ArrayStride, 4});
+            const uint32_t block = id();
+            put(types, Op_TypeStruct, {block, array});
+            put(deco, Op_MemberDecorate, {block, 0, Dec_Offset, 0});
+            put(deco, Op_Decorate, {block, Dec_Block});
+            const uint32_t block_pointer = id();
+            put(types, Op_TypePointer, {block_pointer, SC_PushConstant, block});
+            t_ptr_push_u32 = id();
+            put(types, Op_TypePointer, {t_ptr_push_u32, SC_PushConstant, t_u32});
+            v_push_constants = id();
+            put(types, Op_Variable, {block_pointer, v_push_constants, SC_PushConstant});
+        }
         put(types, Op_TypePointer, {t_ptr_in_v3u, SC_Input, t_v3u});
         put(types, Op_Variable, {t_ptr_in_v3u, v_gid, SC_Input});
         put(types, Op_Variable, {t_ptr_in_v3u, v_groupid, SC_Input});
@@ -7407,7 +7434,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t local_y = std::max(1u, config.local_y);
     const uint32_t local_z = std::max(1u, config.local_z);
     const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
-    b.begin(1, rt, local_x, local_y, local_z, wave_size);
+    b.begin(1, rt, local_x, local_y, local_z, wave_size,
+            static_cast<uint32_t>(config.user_sgprs.size()));
     const bool has_partial_workgroup = config.threads_x % local_x != 0 ||
                                        config.threads_y % local_y != 0 ||
                                        config.threads_z % local_z != 0;
@@ -7432,7 +7460,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
         }
     }
     for (size_t i = 0; i < config.user_sgprs.size(); i++) {
-        const uint32_t value = b.uconst(config.user_sgprs[i]);
+        const uint32_t value = b.load_push_constant(static_cast<uint32_t>(i));
         if (descriptor_sgprs.count(static_cast<uint32_t>(i)))
             rs.sreg_input[static_cast<int>(i)] = value;
         else

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -14,6 +14,12 @@
 #include <vector>
 
 namespace prosper::gpu {
+
+FragmentInterpolationLayout::FragmentInterpolationLayout() {
+    for (auto& locations : parameter_locations) locations.fill(kUnusedLocation);
+    system_locations.fill(kUnusedLocation);
+}
+
 namespace {
 
 enum : uint32_t {
@@ -46,6 +52,7 @@ enum : uint32_t {
     Op_DPdx=207, Op_DPdy=208,   // screen-space derivatives (Fragment; plain Shader capability)
     Op_Phi=245, Op_LoopMerge=246,
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
+    Op_EmitVertex=218, Op_EndPrimitive=219,
     Op_Kill=252, Op_Return=253, Op_GroupNonUniformAny=335,
     Op_GroupNonUniformQuadSwap=366,
 };
@@ -56,10 +63,11 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_UMax=41, Glsl_SMax=42, Glsl_PackHalf2x16=58, Glsl_UnpackHalf2x16=62,
                   Glsl_NMin=79, Glsl_NMax=80 };   // NaN-aware min/max: one-NaN operand -> the other operand
 enum : uint32_t {
-    Cap_Shader=1, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
+    Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
     Cap_GroupNonUniformQuad=68,
-    Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Fragment=4, Exec_GLCompute=5,
-    EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17,
+    Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
+    EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
+    EM_OutputVertices=26, EM_OutputTriangleStrip=29,
     SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_StorageBuffer=12, FC_None=0,
     Dim_1D=0, Dim_2D=1, Dim_3D=2,   // SPIR-V Dim. (2D coincides with the SQ_RSRC 2D dim value, but distinct.)
     Cap_Sampled1D=43, Cap_Image1D=44,   // Dim=1D needs Sampled1D; a 1D STORAGE image (read/write) also needs Image1D
@@ -74,7 +82,8 @@ enum : uint32_t {
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Sample=0x40,   // ImageOperands bits: LOD bias / explicit LOD / MSAA Sample index.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
     MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage/LDS AcquireRelease memory semantics
-    Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_Flat=14, Dec_Location=30, Dec_Binding=33,
+    Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
+    Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
     BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_WorkgroupId=26, BI_LocalInvocationId=27,
     BI_GlobalInvocationId=28, BI_VertexIndex=42, BI_InstanceIndex=43,
@@ -1244,6 +1253,7 @@ struct SpirvCompute {
     // --- Interpolated I/O varyings: VS EXP PARAM_n (output) <-> FS v_interp attribute (input) ---
     std::unordered_map<uint32_t, uint32_t> in_varying, out_varying;
     uint32_t t_ptr_in_v4f = 0;
+    const FragmentInterpolationLayout* fragment_interpolation = nullptr;
     // Attributes read via v_interp_mov (a raw per-vertex / provoking-vertex value, NOT rasterizer-
     // interpolated) — their FS Input varying is decorated Flat so the driver delivers the provoking
     // vertex value instead of a smooth blend of the three (#152). Populated by recompile_fragment's
@@ -1264,6 +1274,56 @@ struct SpirvCompute {
         uint32_t v = frag_input(attr);
         uint32_t vec = id(); put(code, Op_Load, {t_v4f, vec, v});
         uint32_t e = id(); put(code, Op_CompositeExtract, {t_f32, e, vec, chan}); return bcu(e);
+    }
+    // AMD v_interp_mov selects one of the triangle coefficients directly: P10, P20, or P0. On the
+    // portable geometry fallback each selected coefficient has a packed Flat vec4 input. The legacy
+    // P0-only path remains the ordinary Flat attribute at Location=attr and needs no extra stage.
+    uint32_t interp_parameter(uint32_t attr, uint32_t chan, uint32_t selector) {
+        if (!fragment_interpolation || !fragment_interpolation->requires_geometry)
+            return selector == 2 ? interp_read(attr, chan) : 0;
+        if (attr >= fragment_interpolation->parameter_locations.size() || selector >= 3) return 0;
+        const uint32_t location = fragment_interpolation->parameter_locations[attr][selector];
+        if (location == FragmentInterpolationLayout::kUnusedLocation) return 0;
+        auto it = in_varying.find(0x10000u | location);
+        uint32_t variable = 0;
+        if (it != in_varying.end()) variable = it->second;
+        else {
+            if (!t_ptr_in_v4f) {
+                t_ptr_in_v4f = id();
+                put(types, Op_TypePointer, {t_ptr_in_v4f, SC_Input, t_v4f});
+            }
+            variable = id(); put(types, Op_Variable, {t_ptr_in_v4f, variable, SC_Input});
+            put(deco, Op_Decorate, {variable, Dec_Location, location});
+            put(deco, Op_Decorate, {variable, Dec_Flat});
+            in_varying[0x10000u | location] = variable; iface.push_back(variable);
+        }
+        uint32_t vec = id(); put(code, Op_Load, {t_v4f, vec, variable});
+        uint32_t element = id(); put(code, Op_CompositeExtract, {t_f32, element, vec, chan});
+        return bcu(element);
+    }
+    uint32_t system_interpolation_component(uint32_t field, uint32_t component) {
+        if (!fragment_interpolation || !fragment_interpolation->requires_geometry || field >= 7)
+            return 0;
+        const uint32_t location = fragment_interpolation->system_locations[field];
+        if (location == FragmentInterpolationLayout::kUnusedLocation) return 0;
+        auto it = in_varying.find(0x20000u | location);
+        uint32_t variable = 0;
+        if (it != in_varying.end()) variable = it->second;
+        else {
+            if (!t_ptr_in_v4f) {
+                t_ptr_in_v4f = id();
+                put(types, Op_TypePointer, {t_ptr_in_v4f, SC_Input, t_v4f});
+            }
+            variable = id(); put(types, Op_Variable, {t_ptr_in_v4f, variable, SC_Input});
+            put(deco, Op_Decorate, {variable, Dec_Location, location});
+            if (field >= 4) put(deco, Op_Decorate, {variable, Dec_NoPerspective});
+            if (field == 0 || field == 4) put(deco, Op_Decorate, {variable, Dec_Sample});
+            if (field == 2 || field == 6) put(deco, Op_Decorate, {variable, Dec_Centroid});
+            in_varying[0x20000u | location] = variable; iface.push_back(variable);
+        }
+        uint32_t vec = id(); put(code, Op_Load, {t_v4f, vec, variable});
+        uint32_t element = id(); put(code, Op_CompositeExtract, {t_f32, element, vec, component});
+        return bcu(element);
     }
     // FS: gl_FragCoord (BuiltIn 15), lazily declared — used by the DPP quad_perm lowering.
     uint32_t v_fragcoord = 0;
@@ -1323,6 +1383,165 @@ struct SpirvCompute {
         put(code, Op_Store, {v, vec});
     }
 
+    // Descriptor-free geometry pass-through used when a fragment program asks for AMD's explicit
+    // P0/P10/P20 vertex parameters on a Vulkan device without a barycentric/vertex-parameter
+    // extension. Input assembly has already decomposed lists/strips/fans into triangles here.
+    std::vector<uint32_t> build_interpolation_geometry(const FragmentInterpolationLayout& layout) {
+        if (!layout.requires_geometry || !layout.valid) return {};
+
+        t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_bool = id();
+        t_v4f = id();
+        const uint32_t t_per_vertex = id();
+        const uint32_t c_three = id();
+        const uint32_t t_input_positions = id(), t_input_varyings = id();
+        const uint32_t ptr_in_positions = id(), ptr_in_varyings = id();
+        const uint32_t ptr_in_v4f = id(), ptr_out_position = id(), ptr_out_v4f = id();
+        const uint32_t input_position = id(), output_position = id();
+        f_main = id(); const uint32_t label = id(); glsl = id();
+
+        std::array<uint32_t, 32> attribute_inputs{}, attribute_outputs{};
+        std::array<std::array<uint32_t, 3>, 32> parameter_outputs{};
+        std::array<uint32_t, 7> system_outputs{};
+        for (uint32_t attr = 0; attr < 32; ++attr) {
+            if (!(layout.attribute_mask & (1u << attr))) continue;
+            attribute_inputs[attr] = id();
+            if (layout.smooth_mask & (1u << attr)) attribute_outputs[attr] = id();
+            for (uint32_t selector = 0; selector < 3; ++selector)
+                if (layout.parameter_locations[attr][selector] !=
+                    FragmentInterpolationLayout::kUnusedLocation)
+                    parameter_outputs[attr][selector] = id();
+        }
+        for (uint32_t field = 0; field < 7; ++field)
+            if (layout.system_locations[field] != FragmentInterpolationLayout::kUnusedLocation)
+                system_outputs[field] = id();
+
+        put(caps, Op_Capability, {Cap_Shader});
+        put(caps, Op_Capability, {Cap_Geometry});
+        { std::vector<uint32_t> operands{glsl}; pstr(operands, "GLSL.std.450");
+          putv(extimp, Op_ExtInstImport, operands); }
+        put(mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
+        exec_model = Exec_Geometry;
+        put(exec, Op_ExecutionMode, {f_main, EM_Triangles});
+        put(exec, Op_ExecutionMode, {f_main, EM_OutputTriangleStrip});
+        put(exec, Op_ExecutionMode, {f_main, EM_OutputVertices, 3});
+
+        put(deco, Op_MemberDecorate, {t_per_vertex, 0, Dec_BuiltIn, BI_Position});
+        put(deco, Op_Decorate, {t_per_vertex, Dec_Block});
+        for (uint32_t attr = 0; attr < 32; ++attr) {
+            if (attribute_inputs[attr]) {
+                put(deco, Op_Decorate, {attribute_inputs[attr], Dec_Location, attr});
+                iface.push_back(attribute_inputs[attr]);
+            }
+            if (attribute_outputs[attr]) {
+                put(deco, Op_Decorate, {attribute_outputs[attr], Dec_Location, attr});
+                iface.push_back(attribute_outputs[attr]);
+            }
+            for (uint32_t selector = 0; selector < 3; ++selector) {
+                const uint32_t variable = parameter_outputs[attr][selector];
+                if (!variable) continue;
+                put(deco, Op_Decorate,
+                    {variable, Dec_Location, layout.parameter_locations[attr][selector]});
+                put(deco, Op_Decorate, {variable, Dec_Flat});
+                iface.push_back(variable);
+            }
+        }
+        for (uint32_t field = 0; field < 7; ++field) {
+            const uint32_t variable = system_outputs[field];
+            if (!variable) continue;
+            put(deco, Op_Decorate, {variable, Dec_Location, layout.system_locations[field]});
+            if (field >= 4) put(deco, Op_Decorate, {variable, Dec_NoPerspective});
+            if (field == 0 || field == 4) put(deco, Op_Decorate, {variable, Dec_Sample});
+            if (field == 2 || field == 6) put(deco, Op_Decorate, {variable, Dec_Centroid});
+            iface.push_back(variable);
+        }
+        iface.push_back(input_position); iface.push_back(output_position);
+
+        put(types, Op_TypeVoid, {t_void});
+        put(types, Op_TypeFunction, {t_fn, t_void});
+        put(types, Op_TypeFloat, {t_f32, 32});
+        put(types, Op_TypeInt, {t_u32, 32, 0});
+        put(types, Op_TypeInt, {t_i32, 32, 1});
+        put(types, Op_TypeBool, {t_bool});
+        put(types, Op_TypeVector, {t_v4f, t_f32, 4});
+        put(types, Op_TypeStruct, {t_per_vertex, t_v4f});
+        put(types, Op_Constant, {t_u32, c_three, 3});
+        put(types, Op_TypeArray, {t_input_positions, t_per_vertex, c_three});
+        put(types, Op_TypeArray, {t_input_varyings, t_v4f, c_three});
+        put(types, Op_TypePointer, {ptr_in_positions, SC_Input, t_input_positions});
+        put(types, Op_TypePointer, {ptr_in_varyings, SC_Input, t_input_varyings});
+        put(types, Op_TypePointer, {ptr_in_v4f, SC_Input, t_v4f});
+        put(types, Op_TypePointer, {ptr_out_position, SC_Output, t_per_vertex});
+        put(types, Op_TypePointer, {ptr_out_v4f, SC_Output, t_v4f});
+        put(types, Op_Variable, {ptr_in_positions, input_position, SC_Input});
+        put(types, Op_Variable, {ptr_out_position, output_position, SC_Output});
+        for (uint32_t variable : attribute_inputs)
+            if (variable) put(types, Op_Variable, {ptr_in_varyings, variable, SC_Input});
+        for (uint32_t variable : attribute_outputs)
+            if (variable) put(types, Op_Variable, {ptr_out_v4f, variable, SC_Output});
+        for (const auto& selectors : parameter_outputs)
+            for (uint32_t variable : selectors)
+                if (variable) put(types, Op_Variable, {ptr_out_v4f, variable, SC_Output});
+        for (uint32_t variable : system_outputs)
+            if (variable) put(types, Op_Variable, {ptr_out_v4f, variable, SC_Output});
+
+        put(code, Op_Function, {t_void, f_main, FC_None, t_fn});
+        put(code, Op_Label, {label}); cur_block = label;
+
+        std::array<std::array<uint32_t, 3>, 32> attribute_values{};
+        for (uint32_t attr = 0; attr < 32; ++attr) {
+            if (!attribute_inputs[attr]) continue;
+            for (uint32_t vertex = 0; vertex < 3; ++vertex) {
+                const uint32_t pointer = id();
+                put(code, Op_AccessChain,
+                    {ptr_in_v4f, pointer, attribute_inputs[attr], uconst(vertex)});
+                attribute_values[attr][vertex] = id();
+                put(code, Op_Load, {t_v4f, attribute_values[attr][vertex], pointer});
+            }
+        }
+        std::array<std::array<uint32_t, 3>, 32> parameters{};
+        for (uint32_t attr = 0; attr < 32; ++attr) {
+            if (!attribute_inputs[attr]) continue;
+            parameters[attr][2] = attribute_values[attr][0];
+            parameters[attr][0] = id();
+            put(code, Op_FSub, {t_v4f, parameters[attr][0],
+                                attribute_values[attr][1], attribute_values[attr][0]});
+            parameters[attr][1] = id();
+            put(code, Op_FSub, {t_v4f, parameters[attr][1],
+                                attribute_values[attr][2], attribute_values[attr][0]});
+        }
+
+        for (uint32_t vertex = 0; vertex < 3; ++vertex) {
+            uint32_t input_pointer = id();
+            put(code, Op_AccessChain,
+                {ptr_in_v4f, input_pointer, input_position, uconst(vertex), uconst(0)});
+            uint32_t position = id(); put(code, Op_Load, {t_v4f, position, input_pointer});
+            uint32_t output_pointer = id();
+            put(code, Op_AccessChain,
+                {ptr_out_v4f, output_pointer, output_position, uconst(0)});
+            put(code, Op_Store, {output_pointer, position});
+
+            for (uint32_t attr = 0; attr < 32; ++attr) {
+                if (attribute_outputs[attr])
+                    put(code, Op_Store,
+                        {attribute_outputs[attr], attribute_values[attr][vertex]});
+                for (uint32_t selector = 0; selector < 3; ++selector)
+                    if (parameter_outputs[attr][selector])
+                        put(code, Op_Store,
+                            {parameter_outputs[attr][selector], parameters[attr][selector]});
+            }
+            const float i = vertex == 1 ? 1.0f : 0.0f;
+            const float j = vertex == 2 ? 1.0f : 0.0f;
+            const uint32_t barycentric = id();
+            putv(code, Op_CompositeConstruct,
+                 {t_v4f, barycentric, fconstf(i), fconstf(j), fconstf(1.0f), fconstf(1.0f)});
+            for (uint32_t variable : system_outputs)
+                if (variable) put(code, Op_Store, {variable, barycentric});
+            put(code, Op_EmitVertex, {});
+        }
+        put(code, Op_EndPrimitive, {});
+        return finish();
+    }
+
     std::vector<uint32_t> finish() {
         if (invocation_guard_merge) {
             emit_branch(invocation_guard_merge);
@@ -1340,6 +1559,62 @@ struct SpirvCompute {
 };
 
 }  // namespace
+
+FragmentInterpolationLayout fragment_interpolation_layout(
+        const uint32_t* code, size_t dwords,
+        const PixelSystemInputMapping* system_inputs) {
+    FragmentInterpolationLayout layout;
+    std::vector<Rdna2Inst> instructions;
+    rdna2_walk(code, dwords, instructions);
+    std::array<uint8_t, 32> selectors{};
+    uint32_t highest_attribute = 0;
+    bool has_attribute = false;
+    for (const auto& instruction : instructions) {
+        if (instruction.is_end) break;
+        if (instruction.fmt != Rdna2Format::VINTRP || instruction.vintrp_attr >= 32) continue;
+        const uint32_t attr = instruction.vintrp_attr;
+        layout.attribute_mask |= 1u << attr;
+        highest_attribute = std::max(highest_attribute, attr);
+        has_attribute = true;
+        if (instruction.opcode == 0 || instruction.opcode == 1)
+            layout.smooth_mask |= 1u << attr;
+        else if (instruction.opcode == 2 && instruction.src[0].value < 3)
+            selectors[attr] |= static_cast<uint8_t>(1u << instruction.src[0].value);
+    }
+
+    // P10/P20 have no ordinary Vulkan varying equivalent. P0 can retain the cheap Flat-input path
+    // when it is the attribute's only interpolation mode; mixed P0+smooth needs the geometry copy too.
+    for (uint32_t attr = 0; attr < 32; ++attr) {
+        if (selectors[attr] & 0x3u) layout.requires_geometry = true;
+        if ((selectors[attr] & 0x4u) && (layout.smooth_mask & (1u << attr)))
+            layout.requires_geometry = true;
+    }
+    if (!layout.requires_geometry) return layout;
+
+    uint32_t location = has_attribute ? highest_attribute + 1 : 0;
+    for (uint32_t attr = 0; attr < 32; ++attr) {
+        for (uint32_t selector = 0; selector < 3; ++selector) {
+            if (!(selectors[attr] & (1u << selector))) continue;
+            if (location >= 32) { layout.valid = false; return layout; }
+            layout.parameter_locations[attr][selector] = location++;
+        }
+    }
+    if (system_inputs) {
+        for (uint32_t field = 0; field < 7; ++field) {
+            const uint32_t bit = 1u << field;
+            if (!(system_inputs->addr & bit) || !(system_inputs->ena & bit)) continue;
+            if (location >= 32) { layout.valid = false; return layout; }
+            layout.system_locations[field] = location++;
+        }
+    }
+    return layout;
+}
+
+std::vector<uint32_t> recompile_interpolation_geometry(
+        const FragmentInterpolationLayout& layout) {
+    SpirvCompute builder;
+    return builder.build_interpolation_geometry(layout);
+}
 
 // Machine state during recompilation: the VGPR and SGPR files (VGPR/SGPR number -> current SSA bits
 // id) and VCC (current bool condition). VGPRs and SGPRs are separate register files; VALU/EXP source
@@ -5191,13 +5466,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // deliver the interpolated attribute component from the matching Input varying. Fragment-only.
             if (!b.is_fragment) { ok = false; return true; }
             if (in.opcode == 0) return true;   // p1: no-op (p2/mov produce the value)
-            // v_interp_mov_f32's VSRC selects WHICH parameter to load: 0=P10 (v1-v0 delta),
-            // 1=P20 (v2-v0 delta), 2=P0 (provoking-vertex value). Only P0 maps to our
-            // rasterizer-interpolated flat varying; the per-vertex deltas are not recoverable
-            // from it, so a P10/P20 load must reject, not silently return the attribute value.
-            if (in.opcode == 2 && in.src[0].value != 2) { ok = false; return true; }
             uint32_t old = vreg_old(b, rs, in.dst.value);
-            rs.vreg[in.dst.value] = b.interp_read(in.vintrp_attr, in.vintrp_chan);
+            if (in.opcode == 2) {
+                const uint32_t parameter = b.interp_parameter(
+                    in.vintrp_attr, in.vintrp_chan, in.src[0].value);
+                if (!parameter) { ok = false; return true; }
+                rs.vreg[in.dst.value] = parameter;
+            } else {
+                rs.vreg[in.dst.value] = b.interp_read(in.vintrp_attr, in.vintrp_chan);
+            }
             predicate_write(b, rs, in.dst.value, old);
             return true;
         }
@@ -7263,10 +7540,27 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     return cov;
 }
 
+uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    uint32_t packed = 0;
+    std::array<bool, 2> realized{};
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::EXP || in.exp_target >= realized.size() ||
+            realized[in.exp_target] || in.exp_en == 0)
+            continue;
+        packed |= (in.exp_en & 0xFu) << (in.exp_target * 4u);
+        realized[in.exp_target] = true;
+    }
+    return packed;
+}
+
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt,
                                          const PixelSystemInputMapping* system_inputs,
-                                         uint32_t pcrel_dispatch_target) {
+                                         uint32_t pcrel_dispatch_target,
+                                         const FragmentInterpolationLayout* interpolation) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     if (pcrel_dispatch_target != UINT32_MAX) {
@@ -7299,21 +7593,20 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
         return {};
     }
 
+    const FragmentInterpolationLayout derived_interpolation = interpolation
+        ? *interpolation : fragment_interpolation_layout(code, dwords, system_inputs);
+    if (!derived_interpolation.valid) return {};
     SpirvCompute b;
     b.begin_fragment(rt, color_mask);
-    // Classify each interpolated attribute by HOW it's read (#152): v_interp_p2 (op 1) = smooth
-    // rasterizer interpolation; v_interp_mov (op 2) = a raw per-vertex / provoking-vertex value (a
-    // flat read). An attribute read only via v_interp_mov gets its Input varying decorated Flat so
-    // the driver delivers the provoking vertex value, not a blend of the three. An attribute read
-    // via BOTH is contradictory (a varying can't be smooth and flat at once) -> reject the shader.
-    { std::unordered_set<uint32_t> smooth_attr;
-      for (const auto& in : ins) {
-          if (in.is_end) break;
-          if (in.fmt != Rdna2Format::VINTRP) continue;
-          if (in.opcode == 1) smooth_attr.insert(in.vintrp_attr);        // v_interp_p2
-          else if (in.opcode == 2) b.flat_attrs.insert(in.vintrp_attr);  // v_interp_mov
-      }
-      for (uint32_t a : b.flat_attrs) if (smooth_attr.count(a)) return {};   // mixed smooth+flat: reject
+    b.fragment_interpolation = &derived_interpolation;
+    // P0-only attributes retain the cheap Flat varying path. Mixed smooth/explicit-parameter reads
+    // are legal with the portable geometry stage and use separate packed locations there.
+    if (!derived_interpolation.requires_geometry) {
+        for (const auto& in : ins) {
+            if (in.is_end) break;
+            if (in.fmt == Rdna2Format::VINTRP && in.opcode == 2)
+                b.flat_attrs.insert(in.vintrp_attr);
+        }
     }
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     if (system_inputs) {
@@ -7325,8 +7618,17 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
         for (uint32_t field = 0; field < 16; ++field) {
             const uint32_t bit = 1u << field;
             if (!(system_inputs->addr & bit)) continue;
-            if ((system_inputs->ena & bit) && field >= 8 && field <= 11)
-                rs.vreg[(int)vgpr] = b.fragcoord_component(field - 8);
+            if (system_inputs->ena & bit) {
+                if (field <= 6 && derived_interpolation.requires_geometry) {
+                    for (uint32_t component = 0; component < widths[field]; ++component) {
+                        const uint32_t value = b.system_interpolation_component(field, component);
+                        if (!value) return {};
+                        rs.vreg[(int)(vgpr + component)] = value;
+                    }
+                } else if (field >= 8 && field <= 11) {
+                    rs.vreg[(int)vgpr] = b.fragcoord_component(field - 8);
+                }
+            }
             vgpr += widths[field];
         }
     }
@@ -7359,23 +7661,28 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
         }
         if (in.exp_target < exported.size() && !exported[in.exp_target]) {
             // EN (Table 56) selects which VSRC channels the export sends; hardware does not update
-            // disabled components. EN=0 sends nothing; a PARTIAL mask cannot be expressed against
-            // our full-RGBA attachments (the old code exported stale VGPR data in the disabled
-            // channels) — reject fail-visibly until partial-EN MRT exports are modeled with the
-            // export-format machinery. All exercised titles export EN=0xF.
+            // disabled components. The executor maps this mask to Vulkan colorWriteMask, so the SPIR-V
+            // value in a disabled channel is irrelevant and must not force a read of a stale VGPR.
             if (in.exp_en == 0) return true;
-            if (in.exp_en != 0xFu) return false;
             bool eok = true;   // a Special (wave-mask) source has no data value — reject, don't export 0 (#134)
             if (in.exp_compr) {
                 // COMPR: the 4 channels are two f16x2 pairs — src[0] holds (r,g), src[1] holds (b,a).
                 // Unpack each half to a float and reassemble the vec4 (the pkrtz'd tonemap/sRGB output).
-                uint32_t p0 = operand_bits(b, rs, in, in.src[0], &eok), p1 = operand_bits(b, rs, in, in.src[1], &eok);
-                b.export_color(in.exp_target, b.unpack_half(p0, 0), b.unpack_half(p0, 1),
-                               b.unpack_half(p1, 0), b.unpack_half(p1, 1));
+                const uint32_t p0 = (in.exp_en & 0x3u)
+                    ? operand_bits(b, rs, in, in.src[0], &eok) : b.uconst(0);
+                const uint32_t p1 = (in.exp_en & 0xCu)
+                    ? operand_bits(b, rs, in, in.src[1], &eok) : b.uconst(0);
+                b.export_color(in.exp_target,
+                               (in.exp_en & 0x1u) ? b.unpack_half(p0, 0) : b.uconst(0),
+                               (in.exp_en & 0x2u) ? b.unpack_half(p0, 1) : b.uconst(0),
+                               (in.exp_en & 0x4u) ? b.unpack_half(p1, 0) : b.uconst(0),
+                               (in.exp_en & 0x8u) ? b.unpack_half(p1, 1) : b.uconst(0));
             } else {
                 b.export_color(in.exp_target,
-                               operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
-                               operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
+                               (in.exp_en & 0x1u) ? operand_bits(b, rs, in, in.src[0], &eok) : b.uconst(0),
+                               (in.exp_en & 0x2u) ? operand_bits(b, rs, in, in.src[1], &eok) : b.uconst(0),
+                               (in.exp_en & 0x4u) ? operand_bits(b, rs, in, in.src[2], &eok) : b.uconst(0),
+                               (in.exp_en & 0x8u) ? operand_bits(b, rs, in, in.src[3], &eok) : b.uconst(0));
             }
             if (!eok) return false;
             exported[in.exp_target] = true;
@@ -7442,10 +7749,16 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
         // VGPR writes like compute. A vertex MUST still export from full EXEC — the compiled shape
         // always restores EXEC before its pos/param exports; if one ever arrives narrowed, reject
         // (fail-visibly) rather than export possibly-inactive-lane values.
-        if (rs.exec_narrowed && (in.exp_target >= 32 || (in.exp_target >= 12 && in.exp_target <= 15))) return false;
-        if (in.exp_target >= 12 && in.exp_target <= 15 && !exported) {
-            // A position export must supply all four components (EN=0xF); a partial position is
-            // not meaningfully completable, so reject rather than invent components.
+        if (rs.exec_narrowed && (in.exp_target >= 32 ||
+            (in.exp_target >= 12 && in.exp_target <= 16))) return false;
+        if (in.exp_target == 12 && !exported) {
+            // POS0 is the mandatory x/y/z/w position vector. POS1..POS4 carry ancillary position
+            // data (clip/cull distances, point size, viewport/layer selection according to the
+            // programmed position format) and must never be mistaken for gl_Position merely because
+            // an NGG shader emits one before POS0. Until those built-ins are modeled, retain the
+            // existing deliberate behavior of ignoring them.
+            // A position export must supply all four components (EN=0xF); a partial POS0 is not
+            // meaningfully completable in the current model, so reject rather than invent components.
             if (in.exp_en != 0xFu) return false;
             b.export_position(operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
                               operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -114,8 +114,8 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      uint32_t num_inputs, uint32_t out_vgpr,
                                      const ShaderResourceTable* rt = nullptr, uint32_t lds_bytes = 0);
 
-// Register and launch state for a real compute program. User SGPR values are baked into the module
-// for one retained dispatch; enabled system SGPRs follow them in hardware order. TIDIG_COMP_CNT
+// Register and launch state for a real compute program. User SGPR values are supplied as one
+// push-constant dword per register; enabled system SGPRs follow them in hardware order. TIDIG_COMP_CNT
 // controls whether local IDs seed v0 only (0), v0-v1 (1), or v0-v2 (2+).
 struct ComputeShaderConfig {
     std::vector<uint32_t> user_sgprs;

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -75,6 +75,35 @@ struct PixelSystemInputMapping {
     bool operator==(const PixelSystemInputMapping&) const = default;
 };
 
+// Portable lowering contract for GFX10's explicit pixel-interpolation parameters. AMD hardware can
+// expose P0/P10/P20 directly to v_interp_mov; Vulkan only has an equivalent fragment extension on a
+// subset of devices. When `requires_geometry` is true, the renderer inserts the generated geometry
+// stage returned by recompile_interpolation_geometry(). It passes ordinary smooth attributes through
+// and publishes P0, P10=(P1-P0), P20=(P2-P0), plus any requested barycentric system inputs, as a
+// packed interface understood by recompile_fragment(). Locations are capped at Vulkan's portable
+// 128-component fragment-input minimum (32 vec4 locations); `valid == false` keeps overflow visible.
+struct FragmentInterpolationLayout {
+    static constexpr uint32_t kUnusedLocation = UINT32_MAX;
+    std::array<std::array<uint32_t, 3>, 32> parameter_locations{}; // [attr][0=P10,1=P20,2=P0]
+    std::array<uint32_t, 7> system_locations{};                    // PS system fields 0..6
+    uint32_t attribute_mask = 0;                                  // attributes consumed by VINTRP
+    uint32_t smooth_mask = 0;                                     // attributes consumed by P1/P2
+    bool requires_geometry = false;
+    bool valid = true;
+
+    FragmentInterpolationLayout();
+};
+
+FragmentInterpolationLayout fragment_interpolation_layout(
+    const uint32_t* code, size_t dwords,
+    const PixelSystemInputMapping* system_inputs = nullptr);
+
+// Generate the descriptor-free triangle geometry stage described above. Returns {} when no fallback
+// is required or the packed interface is invalid. Triangle lists, strips, fans, and the RectList
+// triangle-strip lowering all feed Vulkan's `Triangles` geometry input primitive.
+std::vector<uint32_t> recompile_interpolation_geometry(
+    const FragmentInterpolationLayout& layout);
+
 // Translate a straight-line float-VALU RDNA2 stream to a compute-shader SPIR-V module.
 // Returns {} if the stream contains an opcode/format this stage does not yet handle. An optional
 // ShaderResourceTable routes SMEM constant-buffer loads to distinct bindings via descriptor provenance.
@@ -116,7 +145,14 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt = nullptr,
                                          const PixelSystemInputMapping* system_inputs = nullptr,
-                                         uint32_t pcrel_dispatch_target = UINT32_MAX);
+                                         uint32_t pcrel_dispatch_target = UINT32_MAX,
+                                         const FragmentInterpolationLayout* interpolation = nullptr);
+
+// Packed RGBA component-enable nibbles for the first realized color export to MRT0/MRT1. EXP.EN is
+// an attachment write mask, not a request to source disabled VGPRs; callers intersect this with the
+// fixed-function CB_TARGET_MASK/CB_SHADER_MASK before creating the Vulkan pipeline. This preserves
+// destination channels disabled by a partial export exactly as RDNA2 does.
+uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords);
 
 // Recompile a vertex shader to a vertex SPIR-V module: v0 = gl_VertexIndex, run the VALU, and on EXP
 // to a POS target write vec4(src0..3) to gl_Position. Returns {} if unsupported / no position export.

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -221,6 +221,11 @@ RenderState extract_render_state(const GpuState& st) {
     // the real art rendered only under PROSPER_FORCE_COLORWRITE. A register that IS present (even 0) is
     // honored, so a genuine depth-only pass that programs mask 0 still skips correctly.
     rs.cb_target_mask    = st.cx.count(P::CB_TARGET_MASK) ? rd(st.cx, P::CB_TARGET_MASK) : 0xFFFFFFFFu;
+    // CB_SHADER_MASK is programmed from the pixel shader's color-export contract. Like the target
+    // mask, an absent register must not suppress color in synthetic/legacy command streams. The
+    // resolved Vulkan write mask intersects both registers so channels the shader does not export
+    // preserve their existing attachment contents (AMD RDNA2 EXP EN semantics, Table 56).
+    rs.cb_shader_mask    = st.cx.count(P::CB_SHADER_MASK) ? rd(st.cx, P::CB_SHADER_MASK) : 0xFFFFFFFFu;
 
     // Viewport 0 transform (guest floats; all-zero when never programmed).
     rs.vport_xscale  = flt(rd(st.cx, P::PA_CL_VPORT_XSCALE));
@@ -455,10 +460,11 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         ps.alpha_blend_op1 = ps.color_blend_op1;
     }
 
-    // CB_TARGET_MASK holds a 4-bit write mask per MRT; MRT0 is bits [3:0]. RDNA2's R/G/B/A bit order
-    // matches VkColorComponentFlags (R=1,G=2,B=4,A=8), so the nibble maps 1:1.
-    ps.color_write_mask = rs.cb_target_mask & 0xFu;
-    ps.color1_write_mask = (rs.cb_target_mask >> 4) & 0xFu;
+    // CB_TARGET_MASK and CB_SHADER_MASK each hold a 4-bit mask per MRT. Hardware writes only their
+    // intersection; RDNA2's R/G/B/A bit order matches VkColorComponentFlags 1:1.
+    const uint32_t effective_color_mask = rs.cb_target_mask & rs.cb_shader_mask;
+    ps.color_write_mask = effective_color_mask & 0xFu;
+    ps.color1_write_mask = (effective_color_mask >> 4) & 0xFu;
 
     // Viewport: hardware maps screen = offset + scale * ndc; Vulkan maps px = (x + w/2) + ndc * (w/2).
     // Equating the two: x = xoffset - xscale, w = 2*xscale (same for y). A guest with GNM's +Y-up NDC

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -125,6 +125,7 @@ struct RenderState {
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)
+    uint32_t cb_shader_mask    = 0;   // CB_SHADER_MASK (components exported by the pixel shader)
     // Rasterizer cull/front-face/polygon mode (PA_SU_SC_MODE_CNTL). An ABSENT register reads 0, which
     // decodes to CULL_NONE + CCW-front + FILL — exactly the prior hardcoded default, so nothing changes
     // for a guest that never programs it. Decoded in resolve to Vk enums (#456).

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -125,7 +125,10 @@ struct RenderState {
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)
-    uint32_t cb_shader_mask    = 0;   // CB_SHADER_MASK (components exported by the pixel shader)
+    // Synthetic/direct RenderState users historically supplied only CB_TARGET_MASK. Match the
+    // hardware/command-stream absent-register fallback so adding CB_SHADER_MASK cannot silently
+    // turn those otherwise-valid color writes off.
+    uint32_t cb_shader_mask    = 0xFFFFFFFFu; // CB_SHADER_MASK (components exported by the pixel shader)
     // Rasterizer cull/front-face/polygon mode (PA_SU_SC_MODE_CNTL). An ABSENT register reads 0, which
     // decodes to CULL_NONE + CCW-front + FILL — exactly the prior hardcoded default, so nothing changes
     // for a guest that never programs it. Decoded in resolve to Vk enums (#456).

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -133,9 +133,19 @@ HLE(s_ok)             { return 0; }
 namespace {
 // Guest event callback: void(void* object_ptr, uint32_t event, int32_t source_id, void* data).
 using AvpEventCb = void (PROSPER_SYSV_ABI *)(void*, uint32_t, int32_t, void*);
+// Guest memory callbacks use the PS5/SysV ABI even when the emulator host is Windows.  Keep their
+// types explicit here; calling them as native Windows functions corrupts the argument registers.
+using AvpAllocateCb = void* (PROSPER_SYSV_ABI *)(void*, uint32_t, uint32_t);
+using AvpDeallocateCb = void (PROSPER_SYSV_ABI *)(void*, void*);
 enum : uint32_t { AVP_STOP = 0x01, AVP_READY = 0x02, AVP_PLAY = 0x03, AVP_PAUSE = 0x04, AVP_BUFFERING = 0x05 };
 
-struct AvpMemAllocator  { void* obj; void* allocate; void* deallocate; void* allocate_texture; void* deallocate_texture; };
+struct AvpMemAllocator {
+    void* obj;
+    AvpAllocateCb allocate;
+    AvpDeallocateCb deallocate;
+    AvpAllocateCb allocate_texture;
+    AvpDeallocateCb deallocate_texture;
+};
 struct AvpFileReplace   { void* obj; void* open; void* close; void* read_offset; void* size; };
 struct AvpEventReplace  { void* obj; void* event_callback; };
 struct AvpInitData {                 // sceAvPlayerInit
@@ -155,6 +165,9 @@ struct AvpInitDataEx {               // sceAvPlayerInitEx (note: this_size first
 static_assert(sizeof(AvpThreadInfo) == 48 && sizeof(AvpInitDataEx) == 560 &&
               offsetof(AvpInitDataEx, auto_start) == 116 &&
               offsetof(AvpInitDataEx, num_fb) == 552, "AvPlayerInitDataEx ABI");
+static_assert(sizeof(AvpMemAllocator) == 40 && offsetof(AvpInitData, num_fb) == 104 &&
+              offsetof(AvpInitData, default_language) == 112 && sizeof(AvpInitData) == 120,
+              "AvPlayerInitData ABI");
 struct AvpUri           { const char* name; uint32_t length; };
 struct AvpSourceDetails { AvpUri uri; uint8_t rsv1[64]; uint32_t source_type; uint8_t rsv2[44]; };
 struct AvpFrameInfo {                // sceAvPlayerGetVideoData / GetAudioData out-param
@@ -195,6 +208,8 @@ static_assert(sizeof(AvpStreamInfoEx) == 104 && offsetof(AvpStreamInfoEx, durati
 
 struct AvpPlayer {
     void* ev_obj = nullptr; AvpEventCb ev_cb = nullptr;
+    AvpMemAllocator memory{};
+    int32_t num_fb = 0;
     bool auto_start = false, have_source = false, synthetic = false;
     bool playing = false, paused = false, stop_fired = false;
     std::string guest_path;
@@ -208,18 +223,31 @@ struct AvpPlayer {
     uint64_t poll = 0;               // synthetic frames delivered through GetVideoData[Ex]
     uint64_t audio_poll = 0;
     uint64_t active_poll = 0;        // independent progress for IsActive-only playback loops
-    std::vector<uint8_t> frame;      // synthetic black NV12 buffer (kept alive across GetVideoData)
+    // When the title supplies its AvPlayer texture allocator, decoded NV12 must be written into those
+    // guest-visible buffers.  A host vector is invisible to the title's pre-wired texture descriptors.
+    std::vector<uint8_t*> texture_frames;
+    size_t texture_frame_bytes = 0;
+    size_t next_texture_frame = 0;
+    std::vector<uint8_t> frame;      // fallback for tests/titles with no texture callbacks
     std::vector<int16_t> audio;      // synthetic silent stereo PCM
 };
 std::mutex g_avp_mx;
 std::unordered_map<uint64_t, AvpPlayer> g_avp;
 
-// Native decoders own their dequeue storage and may move or recycle it on the next pull. Never
-// expose that backend lifetime directly to guest code: Astro submits the returned pointer to host
-// memcpy/GPU work that can outlive the backend packet. Keep one size-stable, player-owned staging
-// allocation instead. Its address remains valid until the next pull updates or resizes that
-// player's staging buffer, matching the transient-buffer contract without a dangling backend
-// pointer.
+bool avp_nv12_bytes(uint32_t width, uint32_t height, size_t& bytes) {
+    if (!width || !height || width > SIZE_MAX / height) return false;
+    const size_t y_bytes = static_cast<size_t>(width) * height;
+    const size_t uv_rows = (static_cast<size_t>(height) + 1) / 2;
+    if (width > SIZE_MAX / uv_rows) return false;
+    const size_t uv_bytes = static_cast<size_t>(width) * uv_rows;
+    if (uv_bytes > SIZE_MAX - y_bytes) return false;
+    bytes = y_bytes + uv_bytes;
+    return true;
+}
+
+// Native decoders own their dequeue storage and may move or recycle it on the next pull. Copy the
+// visible NV12 rows into a guest texture buffer when one exists.  The host-vector fallback preserves
+// the old lifetime guarantee for native tests and titles that omit the replacement callbacks.
 bool avp_stage_video(AvpPlayer& player, const prosper::video::VideoFrame& frame,
                      uint8_t*& data, uint32_t& pitch) {
     if (!frame.y || !frame.uv || frame.width == 0 || frame.height == 0) return false;
@@ -227,6 +255,23 @@ bool avp_stage_video(AvpPlayer& player, const prosper::video::VideoFrame& frame,
     const size_t uv_stride = frame.uv_stride ? frame.uv_stride : frame.width;
     if (y_stride < frame.width || uv_stride < frame.width) return false;
     const size_t uv_rows = (static_cast<size_t>(frame.height) + 1) / 2;
+    if (!player.texture_frames.empty()) {
+        size_t bytes = 0;
+        if (!avp_nv12_bytes(frame.width, frame.height, bytes) ||
+            bytes > player.texture_frame_bytes) return false;
+        uint8_t* dst = player.texture_frames[player.next_texture_frame++ %
+                                              player.texture_frames.size()];
+        if (!dst) return false;
+        for (uint32_t row = 0; row < frame.height; ++row)
+            memcpy(dst + static_cast<size_t>(row) * frame.width,
+                   frame.y + static_cast<size_t>(row) * y_stride, frame.width);
+        uint8_t* dst_uv = dst + static_cast<size_t>(frame.width) * frame.height;
+        for (size_t row = 0; row < uv_rows; ++row)
+            memcpy(dst_uv + row * frame.width, frame.uv + row * uv_stride, frame.width);
+        data = dst;
+        pitch = frame.width;
+        return true;
+    }
     if (y_stride > SIZE_MAX / frame.height || uv_stride > SIZE_MAX / uv_rows) return false;
     const size_t y_bytes = y_stride * frame.height;
     const size_t uv_bytes = uv_stride * uv_rows;
@@ -237,6 +282,21 @@ bool avp_stage_video(AvpPlayer& player, const prosper::video::VideoFrame& frame,
     memcpy(player.frame.data() + y_bytes, frame.uv, uv_bytes);
     data = player.frame.data();
     pitch = static_cast<uint32_t>(y_stride);
+    return true;
+}
+
+bool avp_stage_synthetic(AvpPlayer& player, uint8_t*& data) {
+    size_t need = 0;
+    if (!avp_nv12_bytes(player.width, player.height, need)) return false;
+    if (!player.texture_frames.empty()) {
+        if (need > player.texture_frame_bytes) return false;
+        data = player.texture_frames[player.next_texture_frame++ % player.texture_frames.size()];
+        if (!data) return false;
+        memset(data, 0, need);
+        return true;
+    }
+    if (player.frame.size() != need) player.frame.assign(need, 0);
+    data = player.frame.data();
     return true;
 }
 
@@ -279,6 +339,74 @@ struct AvpCallbackGuestFsScope {
 };
 #endif
 
+void* avp_allocate_texture(const AvpMemAllocator& memory, uint32_t align, uint32_t size) {
+    if (!memory.allocate_texture) return nullptr;
+#if defined(_WIN32)
+    return reinterpret_cast<void*>(static_cast<uintptr_t>(prosper_call_guest_sysv4(
+        reinterpret_cast<uint64_t>(memory.allocate_texture),
+        reinterpret_cast<uint64_t>(memory.obj), align, size, 0)));
+#elif defined(__linux__)
+    AvpCallbackGuestFsScope guest_fs(t_avp_callback_guest_fs);
+    return memory.allocate_texture(memory.obj, align, size);
+#else
+    return memory.allocate_texture(memory.obj, align, size);
+#endif
+}
+
+void avp_deallocate_texture(const AvpMemAllocator& memory, void* allocation) {
+    if (!memory.deallocate_texture || !allocation) return;
+#if defined(_WIN32)
+    prosper_call_guest_sysv4(reinterpret_cast<uint64_t>(memory.deallocate_texture),
+                             reinterpret_cast<uint64_t>(memory.obj),
+                             reinterpret_cast<uint64_t>(allocation), 0, 0);
+#elif defined(__linux__)
+    AvpCallbackGuestFsScope guest_fs(t_avp_callback_guest_fs);
+    memory.deallocate_texture(memory.obj, allocation);
+#else
+    memory.deallocate_texture(memory.obj, allocation);
+#endif
+}
+
+void avp_release_textures(const AvpMemAllocator& memory,
+                          const std::vector<uint8_t*>& textures) {
+    for (auto* texture : textures) avp_deallocate_texture(memory, texture);
+}
+
+bool avp_build_textures(const AvpMemAllocator& memory, int32_t requested,
+                        uint32_t width, uint32_t height,
+                        std::vector<uint8_t*>& textures, size_t& texture_bytes) {
+    const bool have_allocate = memory.allocate_texture != nullptr;
+    const bool have_deallocate = memory.deallocate_texture != nullptr;
+    if (!have_allocate && !have_deallocate) return true; // legacy/test fallback
+    if (!have_allocate || !have_deallocate ||
+        !avp_nv12_bytes(width, height, texture_bytes) || texture_bytes > UINT32_MAX)
+        return false;
+
+    // The public API permits a caller-selected framebuffer count.  Zero requests the normal double
+    // buffer; bound hostile values so a malformed guest structure cannot fan out allocations.
+    const int count = std::clamp(requested > 0 ? requested : 2, 2, 16);
+    constexpr uint32_t alignment = 0x100;
+    textures.reserve(static_cast<size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        void* allocation = avp_allocate_texture(memory, alignment,
+                                                static_cast<uint32_t>(texture_bytes));
+        if (!allocation) {
+            avp_release_textures(memory, textures);
+            textures.clear();
+            texture_bytes = 0;
+            return false;
+        }
+        textures.push_back(static_cast<uint8_t*>(allocation));
+    }
+    if (avp_log()) {
+        fprintf(stderr,
+                "[avp] guest texture buffers requested=%d allocated=%d align=%u bytes=%zu first=%p\n",
+                requested, count, alignment, texture_bytes,
+                textures.empty() ? nullptr : textures.front());
+    }
+    return true;
+}
+
 // Fire the guest event callback. Caller MUST NOT hold g_avp_mx (the callback re-enters AvPlayer HLE).
 void avp_fire(void* obj, AvpEventCb cb, uint32_t ev) {
     if (!cb) return;
@@ -301,7 +429,16 @@ HLE(s_avplayer_init) {   // AvPlayerHandle sceAvPlayerInit(AvPlayerInitData*)
     svc_log("sceAvPlayerInit", a0,a1,a2,a3,a4,a5);
     uint64_t h = g_handle.fetch_add(1);
     AvpPlayer p;
-    if (auto* d = (const AvpInitData*)PW(a0)) { p.ev_obj = d->event.obj; p.ev_cb = (AvpEventCb)d->event.event_callback; p.auto_start = d->auto_start != 0; }
+    if (auto* d = (const AvpInitData*)PW(a0)) {
+        p.memory = d->memory; p.num_fb = d->num_fb;
+        p.ev_obj = d->event.obj; p.ev_cb = (AvpEventCb)d->event.event_callback;
+        p.auto_start = d->auto_start != 0;
+        if (avp_log()) fprintf(stderr,
+            "[avp] init memory=%p alloc=%p free=%p texture=%p texture-free=%p num-fb=%d auto=%d\n",
+            p.memory.obj, (void*)p.memory.allocate, (void*)p.memory.deallocate,
+            (void*)p.memory.allocate_texture, (void*)p.memory.deallocate_texture,
+            p.num_fb, (int)p.auto_start);
+    }
     { std::lock_guard<std::mutex> lk(g_avp_mx); g_avp[h] = std::move(p); }
     return h;   // non-NULL SceAvPlayerHandle
 }
@@ -312,7 +449,16 @@ HLE(s_avplayer_initex) {   // s32 sceAvPlayerInitEx(const AvPlayerInitDataEx*, A
     svc_log("sceAvPlayerInitEx", a0,a1,a2,a3,a4,a5);
     uint64_t h = g_handle.fetch_add(1);
     AvpPlayer p;
-    if (auto* d = (const AvpInitDataEx*)PW(a0)) { p.ev_obj = d->event.obj; p.ev_cb = (AvpEventCb)d->event.event_callback; p.auto_start = d->auto_start != 0; }
+    if (auto* d = (const AvpInitDataEx*)PW(a0)) {
+        p.memory = d->memory; p.num_fb = d->num_fb;
+        p.ev_obj = d->event.obj; p.ev_cb = (AvpEventCb)d->event.event_callback;
+        p.auto_start = d->auto_start != 0;
+        if (avp_log()) fprintf(stderr,
+            "[avp] init-ex memory=%p alloc=%p free=%p texture=%p texture-free=%p num-fb=%d auto=%d\n",
+            p.memory.obj, (void*)p.memory.allocate, (void*)p.memory.deallocate,
+            (void*)p.memory.allocate_texture, (void*)p.memory.deallocate_texture,
+            p.num_fb, (int)p.auto_start);
+    }
     { std::lock_guard<std::mutex> lk(g_avp_mx); g_avp[h] = std::move(p); }
     if (a1) *(uint64_t*)PW(a1) = h;
     return 0;
@@ -402,16 +548,25 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
 
     prosper::video::VideoBackend* old_backend = nullptr;
     int old_backend_id = -1;
+    AvpMemAllocator memory{};
+    int32_t requested_textures = 0;
+    std::vector<uint8_t*> old_textures;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(handle); if (it == g_avp.end()) return 0x80000000ull;
         AvpPlayer& p = it->second;
         old_backend = p.backend;
         old_backend_id = p.backend_id;
+        memory = p.memory;
+        requested_textures = p.num_fb;
+        old_textures = std::move(p.texture_frames);
+        p.texture_frame_bytes = 0;
+        p.next_texture_frame = 0;
         p.have_source = false; p.synthetic = false; p.playing = false; p.paused = false;
         p.backend = nullptr; p.backend_id = -1;
     }
     if (old_backend && old_backend_id >= 0) old_backend->close(old_backend_id);
+    avp_release_textures(memory, old_textures);
 
     const std::string host_path = resolve_guest_path(guest_path);
     auto* selected_backend = prosper::video::backend();
@@ -433,6 +588,19 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
         return 0x806a0001ull;
     }
 
+    const uint32_t video_width = synthetic ? 1920u : stream.width;
+    const uint32_t video_height = synthetic ? 1080u : stream.height;
+    std::vector<uint8_t*> textures;
+    size_t texture_bytes = 0;
+    if (!avp_build_textures(memory, requested_textures, video_width, video_height,
+                            textures, texture_bytes)) {
+        if (backend_id >= 0) selected_backend->close(backend_id);
+        if (avp_log()) fprintf(stderr,
+            "[avp] source rejected: guest texture allocation failed (%ux%u num-fb=%d)\n",
+            video_width, video_height, requested_textures);
+        return 0x806a0001ull;
+    }
+
     void* obj = nullptr; AvpEventCb cb = nullptr; bool play = false, player_missing = false;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
@@ -444,6 +612,9 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
             p.guest_path = guest_path;
             p.have_source = true; p.synthetic = synthetic;
             p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.paused = false; p.stop_fired = false;
+            p.texture_frames = std::move(textures);
+            p.texture_frame_bytes = texture_bytes;
+            p.next_texture_frame = 0;
             p.backend = backend_id >= 0 ? selected_backend : nullptr;
             p.backend_id = backend_id;
             if (synthetic) {
@@ -461,6 +632,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
     }
     if (player_missing) {
         if (backend_id >= 0) selected_backend->close(backend_id);
+        avp_release_textures(memory, textures);
         return 0x80000000ull;
     }
     avp_fire(obj, cb, AVP_READY);
@@ -551,11 +723,12 @@ HLE(s_avp_getvideodata) {
             // Synthetic (headless): a black NV12 frame at the default dimensions.  Advance on
             // frame delivery: Astro Bot never polls IsActive, so an IsActive-only counter made EOF
             // and the STOP event unreachable even though it continuously pulled video frames.
-            size_t need = (size_t)p.width * p.height * 3 / 2;
-            if (p.frame.size() != need) p.frame.assign(need, 0);
-            fi->p_data = p.frame.data(); fi->timestamp = p.poll * 33ull; // ~30fps PTS (ms)
-            fi->d0 = p.width; fi->d1 = p.height; fi->d2 = 0; fi->d3 = 0;
-            p.poll++; result = 1;
+            uint8_t* staged = nullptr;
+            if (avp_stage_synthetic(p, staged)) {
+                fi->p_data = staged; fi->timestamp = p.poll * 33ull; // ~30fps PTS (ms)
+                fi->d0 = p.width; fi->d1 = p.height; fi->d2 = 0; fi->d3 = 0;
+                p.poll++; result = 1;
+            }
         } else if (!p.stop_fired) {
             p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
         }
@@ -595,14 +768,15 @@ HLE(s_avp_getvideodataex) {
                 p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
             }
         } else if (p.synthetic && p.poll < avp_synth_frames()) {
-            size_t need = (size_t)p.width * p.height * 3 / 2;        // synthetic black NV12
-            if (p.frame.size() != need) p.frame.assign(need, 0);
-            fi->p_data = p.frame.data(); fi->timestamp = p.poll * 33ull;
-            fi->details.video = {}; fi->details.video.width = p.width; fi->details.video.height = p.height;
-            fi->details.video.aspect = (float)p.width / (float)p.height; fi->details.video.pitch = p.width;
-            fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
-            fi->details.video.framerate = p.fps;
-            p.poll++; result = 1;
+            uint8_t* staged = nullptr;
+            if (avp_stage_synthetic(p, staged)) {
+                fi->p_data = staged; fi->timestamp = p.poll * 33ull;
+                fi->details.video = {}; fi->details.video.width = p.width; fi->details.video.height = p.height;
+                fi->details.video.aspect = (float)p.width / (float)p.height; fi->details.video.pitch = p.width;
+                fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
+                fi->details.video.framerate = p.fps;
+                p.poll++; result = 1;
+            }
         } else if (!p.stop_fired) {
             p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
         }
@@ -651,11 +825,16 @@ HLE(s_avp_stop) {   // s32 sceAvPlayerStop(handle)
     svc_log("sceAvPlayerStop", a0,a1,a2,a3,a4,a5);
     void* obj = nullptr; AvpEventCb cb = nullptr; bool fire_stop = false;
     prosper::video::VideoBackend* backend = nullptr; int backend_id = -1;
+    AvpMemAllocator memory{};
+    std::vector<uint8_t*> textures;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0); if (it == g_avp.end()) return 0;
         AvpPlayer& p = it->second;
         backend = p.backend; backend_id = p.backend_id;
+        memory = p.memory;
+        textures = std::move(p.texture_frames);
+        p.texture_frame_bytes = 0; p.next_texture_frame = 0;
         p.backend = nullptr; p.backend_id = -1; p.have_source = false; p.synthetic = false;
         if (p.playing && !p.stop_fired) {
             p.playing = false; p.paused = false; p.stop_fired = true;
@@ -663,21 +842,27 @@ HLE(s_avp_stop) {   // s32 sceAvPlayerStop(handle)
         }
     }
     if (backend && backend_id >= 0) backend->close(backend_id);
+    avp_release_textures(memory, textures);
     if (fire_stop) avp_fire(obj, cb, AVP_STOP);
     return 0;
 }
 HLE(s_avp_close) {   // s32 sceAvPlayerClose(handle)
     svc_log("sceAvPlayerClose", a0,a1,a2,a3,a4,a5);
     prosper::video::VideoBackend* backend = nullptr; int backend_id = -1;
+    AvpMemAllocator memory{};
+    std::vector<uint8_t*> textures;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0);
         if (it != g_avp.end()) {
             backend = it->second.backend; backend_id = it->second.backend_id;
+            memory = it->second.memory;
+            textures = std::move(it->second.texture_frames);
             g_avp.erase(it);
         }
     }
     if (backend && backend_id >= 0) backend->close(backend_id);
+    avp_release_textures(memory, textures);
     return 0;
 }
 
@@ -719,6 +904,7 @@ AVP_CALLBACK_ENTRY(s_avplayer_isactive_entry, s_avplayer_isactive_entry_c, s_avp
 AVP_CALLBACK_ENTRY(s_avp_getvideodata_entry, s_avp_getvideodata_entry_c, s_avp_getvideodata)
 AVP_CALLBACK_ENTRY(s_avp_getvideodataex_entry, s_avp_getvideodataex_entry_c, s_avp_getvideodataex)
 AVP_CALLBACK_ENTRY(s_avp_stop_entry, s_avp_stop_entry_c, s_avp_stop)
+AVP_CALLBACK_ENTRY(s_avp_close_entry, s_avp_close_entry_c, s_avp_close)
 AVP_CALLBACK_ENTRY(s_avp_pause_entry, s_avp_pause_entry_c, s_avp_pause)
 AVP_CALLBACK_ENTRY(s_avp_resume_entry, s_avp_resume_entry_c, s_avp_resume)
 
@@ -1868,10 +2054,11 @@ void register_service_hle() {
     R("sceAvPlayerGetAudioData",   s_avp_getaudiodata);
 #ifdef _WIN32
     R("sceAvPlayerStop",           s_avp_stop);
+    R("sceAvPlayerClose",          s_avp_close);
 #else
     R("sceAvPlayerStop",           s_avp_stop_entry);
+    R("sceAvPlayerClose",          s_avp_close_entry);
 #endif
-    R("sceAvPlayerClose",          s_avp_close);
     // PS5 raw NIDs verified against the 3.20 import stubs. Astro Bot enumerates streams before it
     // consumes GetVideoDataEx; returning the generic unresolved-import zero meant "no streams" and
     // left its logo movie state machine permanently resident even after synthetic EOF.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -160,7 +160,7 @@ inline BackendColorTargetStats backend_color_target_stats() {
 // render pass (clear once, then per-draw pipeline+descriptors+draw) so a multi-draw frame composites
 // correctly. render_triangle_rgba is a thin single-draw wrapper (below).
 struct BackendDraw {
-    std::vector<uint32_t> vs, fs;
+    std::vector<uint32_t> vs, gs, fs;
     uint64_t vs_identity = 0, fs_identity = 0;
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
@@ -338,6 +338,10 @@ inline const RenderVkCtx& render_vk_ctx() {
         r.aniso_enabled = supported.samplerAnisotropy;
         r.max_aniso_limit = phys_props.limits.maxSamplerAnisotropy;
         if (r.aniso_enabled) feats.samplerAnisotropy = VK_TRUE;
+        // Portable AMD P0/P10/P20 lowering inserts a descriptor-free geometry pass on devices that
+        // lack explicit vertex-parameter fragment extensions. Core geometryShader is available on
+        // the Linux llvmpipe headless target and the desktop Vulkan drivers we support.
+        feats.geometryShader = supported.geometryShader;
         // Storage-image shaders declare the format-free read/write capabilities. Enable every
         // corresponding core feature advertised by the device; fragment/vertex stores additionally
         // need their pipeline-stage store features.
@@ -1396,7 +1400,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // Per-draw Vulkan objects — kept alive until after the queue submit, freed at the end.
     const auto timing_target_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     struct DV {
-        VkShaderModule vs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
+        VkShaderModule vs = VK_NULL_HANDLE, gs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
         std::vector<FrameResource> R;
         std::vector<VkDescriptorSetLayout> dsls; std::vector<VkDescriptorSet> dsets;
         VkDescriptorPool dpool = VK_NULL_HANDLE;
@@ -1526,9 +1530,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         DV& v = dv[di];
         if (backend_trace) {
             fprintf(stderr,
-                    "[backend-trace] draw=%zu/%zu begin extent=%ux%u vs=%zu fs=%zu "
+                    "[backend-trace] draw=%zu/%zu begin extent=%ux%u vs=%zu gs=%zu fs=%zu "
                     "vs_id=%016llx fs_id=%016llx resources=%zu\n",
-                    di, draws.size(), W, H, bd.vs.size(), bd.fs.size(),
+                    di, draws.size(), W, H, bd.vs.size(), bd.gs.size(), bd.fs.size(),
                     (unsigned long long)bd.vs_identity,
                     (unsigned long long)bd.fs_identity, bd.R.size());
             fflush(stderr);
@@ -1565,9 +1569,17 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             std::memcpy(ip, bd.indices.data(), (size_t)isz); vkUnmapMemory(dev, v.ibmem);
             v.icount = (uint32_t)bd.indices.size();
         }
-        VkPipelineShaderStageCreateInfo st[2]{};
+        VkPipelineShaderStageCreateInfo st[3]{};
         st[0] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[0].stage = VK_SHADER_STAGE_VERTEX_BIT; st[0].module = v.vs; st[0].pName = "main";
-        st[1] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT; st[1].module = v.fs; st[1].pName = "main";
+        const uint32_t fragment_stage_index = bd.gs.empty() ? 1u : 2u;
+        if (!bd.gs.empty()) {
+            st[1] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+            st[1].stage = VK_SHADER_STAGE_GEOMETRY_BIT; st[1].module = v.gs; st[1].pName = "main";
+        }
+        st[fragment_stage_index] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+        st[fragment_stage_index].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+        st[fragment_stage_index].module = v.fs;
+        st[fragment_stage_index].pName = "main";
         VkPipelineVertexInputStateCreateInfo vin{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
         VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
         ia.topology = ps ? (VkPrimitiveTopology)ps->topology : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
@@ -1941,7 +1953,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (v.use_desc) { plci.setLayoutCount = v.n_sets; plci.pSetLayouts = v.dsls.data(); }
         vkCreatePipelineLayout(dev, &plci, nullptr, &v.layout);
         VkGraphicsPipelineCreateInfo gp{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
-        gp.stageCount = 2; gp.pStages = st; gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
+        gp.stageCount = bd.gs.empty() ? 2u : 3u; gp.pStages = st;
+        gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
         gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
         gp.pColorBlendState = &cb; gp.pDynamicState = &dynamic_state;
         gp.layout = v.layout; gp.renderPass = rp; gp.subpass = 0;
@@ -1965,7 +1978,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(4); // key schema version (scissor is dynamic per draw)
+            append(5); // key schema version (geometry stage + dynamic scissor)
             append(W); append(H); append(color_count); append(static_cast<uint32_t>(FMT));
             append(static_cast<uint32_t>(FMT1)); append(use_ds); append(static_cast<uint32_t>(DFMT));
             const bool exact_shader_identities = bd.vs_identity && bd.fs_identity;
@@ -1985,6 +1998,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 append(static_cast<uint32_t>(bd.fs.size()));
                 for (uint32_t word : bd.fs) append(word);
             }
+            append(static_cast<uint32_t>(bd.gs.size()));
+            for (uint32_t word : bd.gs) append(word);
             append(v.use_desc); append(v.n_sets);
             // A pair of shader-cache identities names the exact compile keys, including every
             // descriptor's class and binding. External/replay shaders have identity zero and keep
@@ -2051,24 +2066,27 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 fprintf(stderr, "[backend-trace] draw=%zu create-shaders begin\n", di);
                 fflush(stderr);
             }
-            v.vs = mkmod(bd.vs); v.fs = mkmod(bd.fs);
+            v.vs = mkmod(bd.vs); v.gs = bd.gs.empty() ? VK_NULL_HANDLE : mkmod(bd.gs);
+            v.fs = mkmod(bd.fs);
             if (backend_trace) {
                 fprintf(stderr,
-                        "[backend-trace] draw=%zu create-shaders end vs=%p fs=%p\n",
-                        di, (void*)v.vs, (void*)v.fs);
+                        "[backend-trace] draw=%zu create-shaders end vs=%p gs=%p fs=%p\n",
+                        di, (void*)v.vs, (void*)v.gs, (void*)v.fs);
                 fflush(stderr);
             }
             const auto setup_shader_ready = timing_enabled
                 ? TimingClock::now() : TimingClock::time_point{};
             if (timing_enabled)
                 setup_shader_ms += setup_elapsed_ms(setup_shader_begin, setup_shader_ready);
-            if (!v.vs || !v.fs) {
+            if (!v.vs || !v.fs || (!bd.gs.empty() && !v.gs)) {
                 if (timing_enabled)
                     setup_pipeline_ms += setup_elapsed_ms(
                         setup_resources_ready, setup_pipeline_key_ready);
                 continue;   // rejected SPIR-V -> skip this draw
             }
-            st[0].module = v.vs; st[1].module = v.fs;
+            st[0].module = v.vs;
+            if (!bd.gs.empty()) st[1].module = v.gs;
+            st[fragment_stage_index].module = v.fs;
             setup_pipeline_create_begin = setup_shader_ready;
             if (backend_trace) {
                 fprintf(stderr, "[backend-trace] draw=%zu create-pipeline begin\n", di);
@@ -2472,6 +2490,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (v.ibuf)   vkDestroyBuffer(dev, v.ibuf, nullptr);
         if (v.ibmem)  release_transient_render_memory(dev, v.ibmem);
         if (v.vs)     vkDestroyShaderModule(dev, v.vs, nullptr);
+        if (v.gs)     vkDestroyShaderModule(dev, v.gs, nullptr);
         if (v.fs)     vkDestroyShaderModule(dev, v.fs, nullptr);
         if (v.dpool)  vkDestroyDescriptorPool(dev, v.dpool, nullptr);
         for (auto d : v.dsls) if (d) vkDestroyDescriptorSetLayout(dev, d, nullptr);

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -10,6 +10,7 @@
 #include "../src/hle/nid.hpp"
 #include "../src/hle/video_backend.hpp"
 #include <cstdio>
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -88,11 +89,41 @@ static void set_synthetic_frames(const char* value) {
 
 static uint32_t events[8]{};
 static int event_count = 0;
+static int texture_alloc_count = 0, texture_free_count = 0;
+static uint32_t texture_last_align = 0, texture_last_size = 0;
+static void* texture_expected_object = nullptr;
+static std::vector<void*> texture_allocations;
+
+static void* texture_allocate_host(void* object, uint32_t align, uint32_t size) {
+    if (object != texture_expected_object) return nullptr;
+    void* result = malloc(size);
+    if (!result) return nullptr;
+    memset(result, 0xcc, size);
+    texture_alloc_count++;
+    texture_last_align = align;
+    texture_last_size = size;
+    texture_allocations.push_back(result);
+    return result;
+}
+static void texture_deallocate_host(void* object, void* allocation) {
+    if (object != texture_expected_object || !allocation) return;
+    texture_free_count++;
+    free(allocation);
+}
+
 #ifdef _WIN32
 extern "C" void on_avplayer_event_host(uint32_t event) {
     if (event_count < 8) events[event_count++] = event;
 }
 extern "C" void on_avplayer_event();
+extern "C" void* on_avplayer_texture_allocate_host(void* object, uint32_t align, uint32_t size) {
+    return texture_allocate_host(object, align, size);
+}
+extern "C" void on_avplayer_texture_deallocate_host(void* object, void* allocation) {
+    texture_deallocate_host(object, allocation);
+}
+extern "C" void on_avplayer_texture_allocate();
+extern "C" void on_avplayer_texture_deallocate();
 // Production callbacks are guest SysV functions even in a Windows build.  Keep the test honest by
 // accepting event in SysV RSI, then bridge the one value into a normal Microsoft-x64 C++ helper.
 __asm__(
@@ -104,9 +135,37 @@ __asm__(
     "  callq on_avplayer_event_host\n"
     "  addq $40, %rsp\n"
     "  retq\n");
+// Texture allocation arrives as SysV (RDI object, RSI alignment, RDX size) and is forwarded to the
+// Windows host helper (RCX, RDX, R8).  Deallocation similarly forwards RDI/RSI to RCX/RDX.
+__asm__(
+    ".text\n"
+    ".globl on_avplayer_texture_allocate\n"
+    "on_avplayer_texture_allocate:\n"
+    "  movq %rdx, %r8\n"
+    "  movl %esi, %edx\n"
+    "  movq %rdi, %rcx\n"
+    "  subq $40, %rsp\n"
+    "  callq on_avplayer_texture_allocate_host\n"
+    "  addq $40, %rsp\n"
+    "  retq\n"
+    ".globl on_avplayer_texture_deallocate\n"
+    "on_avplayer_texture_deallocate:\n"
+    "  movq %rsi, %rdx\n"
+    "  movq %rdi, %rcx\n"
+    "  subq $40, %rsp\n"
+    "  callq on_avplayer_texture_deallocate_host\n"
+    "  addq $40, %rsp\n"
+    "  retq\n");
 #else
 static void PROSPER_SYSV_ABI on_avplayer_event(void*, uint32_t event, int32_t, void*) {
     if (event_count < 8) events[event_count++] = event;
+}
+static void* PROSPER_SYSV_ABI on_avplayer_texture_allocate(void* object, uint32_t align,
+                                                           uint32_t size) {
+    return texture_allocate_host(object, align, size);
+}
+static void PROSPER_SYSV_ABI on_avplayer_texture_deallocate(void* object, void* allocation) {
+    texture_deallocate_host(object, allocation);
 }
 #endif
 
@@ -170,10 +229,22 @@ int main() {
 
     fake.fail_open = false;
     event_count = 0;
-    uint64_t native_handle = init((uint64_t)(uintptr_t)&data, 0, 0, 0, 0, 0);
+    texture_alloc_count = texture_free_count = 0;
+    texture_allocations.clear();
+    int texture_object = 0x1234;
+    texture_expected_object = &texture_object;
+    AvpInitData texture_data = data;
+    texture_data.memory.obj = texture_expected_object;
+    texture_data.memory.allocate_texture = (void*)&on_avplayer_texture_allocate;
+    texture_data.memory.deallocate_texture = (void*)&on_avplayer_texture_deallocate;
+    texture_data.num_fb = 3;
+    uint64_t native_handle = init((uint64_t)(uintptr_t)&texture_data, 0, 0, 0, 0, 0);
     const char native_source[] = "movie.mp4";
     CHECK(add(native_handle, (uint64_t)(uintptr_t)native_source, 0, 0, 0, 0) == 0,
           "native source opens through the registered backend");
+    CHECK(texture_alloc_count == 3 && texture_last_align == 0x100 &&
+              texture_last_size == fake.nv12.size(),
+          "native source allocates the requested guest NV12 texture ring");
     CHECK(fake.opened_path == "C:/prosper-test-app0/movie.mp4",
           "native backend receives the resolved host path, not the raw relative guest path");
     CHECK(streams(native_handle, 0, 0, 0, 0, 0) == 2,
@@ -192,9 +263,11 @@ int main() {
     AvpFrameInfoEx native_frame{};
     CHECK(video(native_handle, (uint64_t)(uintptr_t)&native_frame, 0, 0, 0, 0) == 1 &&
               native_frame.data && native_frame.data != fake.nv12.data() &&
+              std::find(texture_allocations.begin(), texture_allocations.end(), native_frame.data) !=
+                  texture_allocations.end() &&
               native_frame.timestamp == 16 &&
               memcmp(native_frame.data, fake.nv12.data(), fake.nv12.size()) == 0,
-          "native decoded NV12 frame is copied into player-owned guest staging");
+          "native decoded NV12 frame is copied into caller-owned guest texture staging");
     fake.nv12[0] = 0x7f;
     CHECK(static_cast<const uint8_t*>(native_frame.data)[0] == 0x40,
           "guest frame storage remains independent when the backend recycles its packet");
@@ -212,7 +285,8 @@ int main() {
               event_count == 3,
           "completed audio-bearing playback stays inactive without repeating STOP");
     close(native_handle, 0, 0, 0, 0, 0);
-    CHECK(fake.close_count == 1, "Close releases the native decode session");
+    CHECK(fake.close_count == 1 && texture_free_count == 3,
+          "Close releases the native decode session and every guest texture");
     prosper::video::set_backend(nullptr);
 
     // One delivered synthetic frame, then EOF on the next pull. Astro Bot follows this path and does

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -105,6 +105,11 @@ int main() {
         code, sizeof(code) / sizeof(code[0]), &rt, config);
     CHECK(!spirv.empty(), "real Dead Cells compute kernel recompiles");
     if (spirv.empty()) return 1;
+    ComputeShaderConfig alternate_config = config;
+    alternate_config.user_sgprs[4] ^= 0xffffffffu;
+    alternate_config.user_sgprs[7] ^= 0x13579bdfu;
+    CHECK(recompile_compute(code, sizeof(code) / sizeof(code[0]), &rt, alternate_config) == spirv,
+          "per-dispatch user SGPR values do not specialize the reusable SPIR-V module");
 
     auto report = validate_spirv_descriptor_interface(
         spirv, &rt, 0, SpirvShaderStage::Compute);
@@ -119,6 +124,7 @@ int main() {
 
     ComputeItem item;
     item.spirv = spirv;
+    item.user_sgprs = config.user_sgprs;
     item.resources = std::make_shared<ShaderResourceTable>(rt);
     item.launch.threads_x = records;
     item.launch.local_x = 64;
@@ -152,6 +158,22 @@ int main() {
             padded_lanes_untouched &= result[record * 4 + component] == 0xcccccccc;
     CHECK(padded_lanes_untouched,
           "partial workgroup suppresses all 62 padded invocations without a guest bounds check");
+
+    std::fill(result.begin(), result.end(), 0xeeeeeeee);
+    item.user_sgprs = alternate_config.user_sgprs;
+    CHECK(prosper::frontend::execute_live_compute_items({item}),
+          "cached compute pipeline executes with updated user SGPR push constants");
+    const uint32_t alternate_expected[4] = {
+        alternate_config.user_sgprs[4], alternate_config.user_sgprs[5],
+        alternate_config.user_sgprs[6], alternate_config.user_sgprs[7],
+    };
+    bool alternate_filled = true;
+    for (uint32_t record = 0; record < records && alternate_filled; ++record)
+        for (uint32_t component = 0; component < 4; ++component)
+            alternate_filled &= result[record * 4 + component] == alternate_expected[component];
+    CHECK(alternate_filled,
+          "cached compute pipeline observes per-dispatch user SGPR values");
+    item.user_sgprs = config.user_sgprs;
 
     std::vector<uint32_t> replay_owned(launched_records * 4, 0xdddddddd);
     ShaderResource replay_buffer = buffer;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -157,14 +157,15 @@ int main() {
               scalar_capture.computes[0].resources.resources.empty(),
           "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
-    // v17 appends scissor state without changing the legacy pipeline prefix. Removing this one-draw,
-    // zero-failure tail produces a byte-exact v16 capture whose missing state means full target.
+    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v18's one-draw
+    // geometry index first, then the v17 tail, to recover a byte-exact v16 capture.
     std::vector<uint8_t> v16_scissor_bytes;
     GpuCaptureFile v16_scissor_loaded;
     CHECK(serialize_gpu_capture(captured, v16_scissor_bytes, error) &&
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - 8); // v18 draw count + no-GS sentinel
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 25);
         v16_scissor_bytes[8] = 16;
         v16_scissor_bytes[9] = v16_scissor_bytes[10] = v16_scissor_bytes[11] = 0;
@@ -306,6 +307,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 8); // v18 draw count + no-GS sentinel
     volume_bytes.resize(volume_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
     volume_bytes.resize(volume_bytes.size() - 21); // v16 count plus one 17-byte mip-tail state
     volume_bytes.resize(volume_bytes.size() - 5); // v15 count plus one depth-compare flag
@@ -709,11 +711,12 @@ int main() {
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 32,
-          "created a diagnostic-free v17 payload for legacy-reader fixtures");
+          "created a diagnostic-free v18 payload for legacy-reader fixtures");
     std::vector<uint8_t> v13_bytes = legacy_bytes;
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - 8); // v18 draw count + no-GS sentinel
         v13_bytes.resize(v13_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
         v13_bytes.resize(v13_bytes.size() - (4 + 17 * legacy_resource_count));
         v13_bytes.resize(v13_bytes.size() - (4 + legacy_resource_count));
@@ -731,6 +734,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 8); // v18 draw count + no-GS sentinel
         legacy_bytes.resize(legacy_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
         legacy_bytes.resize(legacy_bytes.size() - (4 + 17 * legacy_resource_count));
         legacy_bytes.resize(legacy_bytes.size() - (4 + legacy_resource_count));
@@ -774,9 +778,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 18;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 19;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 18",
+          error == "unsupported capture version 19",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1,6 +1,8 @@
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/videoout_present.hpp"
+#include "../src/hle/dispatch.hpp"
 #include "../frontends/shared/live_renderer.hpp"
 
 #include <algorithm>
@@ -46,6 +48,37 @@ static void unset_env(const char* name) {
 int main() {
     std::printf("== test_gpu_capture_render ==\n");
     constexpr uint32_t W = 64, H = 64;
+
+    // Give the renderer a 128x128 guest presentation surface while rendering at 64x64. DrawItems
+    // entering the live callback have therefore already had viewport/scissor coordinates scaled by
+    // one half, exactly like a PROSPER_RENDER_SCALE=2 game run.
+    prosper::register_builtin_hle();
+    present_reset();
+    auto open = prosper::Hle::lookup(prosper::nid_hash("sceVideoOutOpen"));
+    auto setba2 = prosper::Hle::lookup("PjS5uASwcV8");
+    auto regb2 = prosper::Hle::lookup("rKBUtgRrtbk");
+    constexpr uint32_t PRESENT_W = 128, PRESENT_H = 128;
+    std::vector<uint8_t> scanout0(PRESENT_W * PRESENT_H * 4u);
+    std::vector<uint8_t> scanout1(PRESENT_W * PRESENT_H * 4u);
+    std::vector<uint8_t> scanout2(PRESENT_W * PRESENT_H * 4u);
+    uint8_t scanout_attr[0x50]{};
+    struct VideoBuffer { const void* data; const void* metadata; const void* reserved[2]; };
+    VideoBuffer scanouts[3] = {
+        {scanout0.data(), nullptr, {nullptr, nullptr}},
+        {scanout1.data(), nullptr, {nullptr, nullptr}},
+        {scanout2.data(), nullptr, {nullptr, nullptr}},
+    };
+    const uint64_t video_handle = open ? open(0, 0, 0, 0, 0, 0) : 0;
+    if (setba2)
+        setba2(reinterpret_cast<uint64_t>(scanout_attr), 0x8000000000000000ull,
+               0, PRESENT_W, PRESENT_H, 0);
+    const uint64_t register_result = regb2
+        ? regb2(video_handle, 0, 0, reinterpret_cast<uint64_t>(scanouts), 3,
+                reinterpret_cast<uint64_t>(scanout_attr))
+        : UINT64_MAX;
+    CHECK(open && setba2 && regb2 && register_result == 0 &&
+              present_width() == PRESENT_W && present_height() == PRESENT_H,
+          "live-render test configures a reduced-resolution presentation surface");
 
     const uint32_t vs_rdna[] = {
         0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u, 0x7E0C02F2u, 0x10020B01u,
@@ -226,6 +259,29 @@ int main() {
         CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
               "later pass samples pixels cached from the 32x2 producer target");
     }
+
+    // A native 32x32 offscreen target receives a scissor that was globally scaled from 32 to 16
+    // for the 128->64 presentation reduction above. The pass-local target correction must undo that
+    // scale for scissors as well as viewports. Otherwise only the target's top-left 16x16 quadrant is
+    // rendered (the exact collapse caught by the Dead Cells gameplay snapshot at render scale 4).
+    DrawItem native_scissor = replay.items[0];
+    native_scissor.color0_base = 0x4f0000;
+    native_scissor.color0_width = 32;
+    native_scissor.color0_height = 32;
+    native_scissor.ps.has_scissor = true;
+    native_scissor.ps.scissor_left = 0;
+    native_scissor.ps.scissor_top = 0;
+    native_scissor.ps.scissor_right = 16;
+    native_scissor.ps.scissor_bottom = 16;
+    std::vector<uint8_t> scissored = render_submit_items({native_scissor}, W, H);
+    bool native_scissor_reaches_lower_right = scissored.size() == 32u * 32u * 4u;
+    if (native_scissor_reaches_lower_right) {
+        const uint8_t* lower_right = &scissored[(24u * 32u + 24u) * 4u];
+        native_scissor_reaches_lower_right =
+            lower_right[0] > 0xc0 && lower_right[1] < 0x40 && lower_right[2] < 0x40;
+    }
+    CHECK(native_scissor_reaches_lower_right,
+          "native offscreen pass undoes the global scale for its guest scissor");
 
     // A simultaneous MRT producer must publish its second attachment under CB_COLOR1_BASE so a later
     // pass can sample it in the same submit. This is DOLL's missing temporal scene dependency (#719).

--- a/prosper/tests/test_interp_render.cpp
+++ b/prosper/tests/test_interp_render.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdint>
+#include <iterator>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -57,6 +58,53 @@ int main() {
     printf("  red range [%u..%u]  max(green,blue)=%u\n", rmin, rmax, max_gb);
     CHECK(rmax - rmin > 40, "the interpolated attribute forms a red GRADIENT across the viewport");
     CHECK(max_gb < 0x20, "green/blue stay ~0 (output is the interpolated attribute, not garbage)");
+
+    // AMD's explicit-parameter form reconstructs that same smooth value from
+    //   Final = P0 + P10*I + P20*J
+    // (official GFX10/RDNA2 ISA). Linux llvmpipe exposes no fragment-barycentric extension, so the
+    // generated geometry stage publishes P0/P10/P20 plus perspective-center I/J. This is the exact
+    // mechanism Astro Bot's title composite needs; verify it with a real Vulkan pipeline and pixels.
+    const uint32_t explicit_ps[] = {
+        0xc80e0000u, 0xc8120001u, 0xc8160002u,       // v3=P10, v4=P20, v5=P0, attr0.x
+        0xd54b0003u, 0x04160103u,                    // v3 = P10*I + P0
+        0xd54b0003u, 0x040e0304u,                    // v3 = P20*J + v3
+        0x7e080280u, 0x7e0a0280u, 0x7e0c02f2u,       // G=B=0, A=1
+        0xf800000fu, 0x06050403u, 0xbf810000u,
+    };
+    PixelSystemInputMapping perspective_center{1u << 1, 1u << 1};
+    FragmentInterpolationLayout explicit_layout = fragment_interpolation_layout(
+        explicit_ps, std::size(explicit_ps), &perspective_center);
+    std::vector<uint32_t> explicit_frag = recompile_fragment(
+        explicit_ps, std::size(explicit_ps), nullptr, &perspective_center,
+        UINT32_MAX, &explicit_layout);
+    std::vector<uint32_t> explicit_geom = recompile_interpolation_geometry(explicit_layout);
+    CHECK(explicit_layout.valid && explicit_layout.requires_geometry &&
+          !explicit_frag.empty() && !explicit_geom.empty(),
+          "P0/P10/P20 + perspective-center barycentrics generate portable SPIR-V stages");
+    ResolvedPipelineState explicit_state;
+    explicit_state.topology = 3; // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+    prosper::test::BackendDraw explicit_draw;
+    explicit_draw.vs = vert; explicit_draw.gs = explicit_geom; explicit_draw.fs = explicit_frag;
+    explicit_draw.ps = &explicit_state;
+    std::vector<prosper::test::BackendDraw> explicit_draws;
+    explicit_draws.push_back(std::move(explicit_draw));
+    std::vector<uint8_t> explicit_px = prosper::test::render_draws_rgba(explicit_draws, W, H);
+    CHECK(explicit_px.size() == (size_t)W * H * 4,
+          "Vulkan links and renders the generated interpolation geometry stage");
+    if (explicit_px.size() == (size_t)W * H * 4) {
+        uint8_t explicit_min = 255, explicit_max = 0;
+        uint32_t explicit_max_gb = 0;
+        for (uint32_t y = 2; y < H - 2; y += 4) for (uint32_t x = 2; x < W - 2; x += 4) {
+            const uint8_t* p = &explicit_px[((size_t)y * W + x) * 4];
+            explicit_min = std::min(explicit_min, p[0]);
+            explicit_max = std::max(explicit_max, p[0]);
+            explicit_max_gb = std::max<uint32_t>(explicit_max_gb, std::max(p[1], p[2]));
+        }
+        printf("  explicit-parameter red range [%u..%u] max(green,blue)=%u\n",
+               explicit_min, explicit_max, explicit_max_gb);
+        CHECK(explicit_max - explicit_min > 40 && explicit_max_gb < 0x20,
+              "P0 + P10*I + P20*J reconstructs the original smooth red gradient");
+    }
 
     // DOLL's live linkage shape is non-identity: PS input 1 consumes producer PARAM3. Exercise the
     // generic form here by moving this fixture's export from PARAM0 to PARAM3, then remapping logical

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -392,10 +392,9 @@ int main() {
     }
     printf("  [ok]   lds_bytes>64 KB clamps to the RDNA2 max (16384 dwords)\n");
 
-    // v_interp_mov flat read (#152): an attribute read via v_interp_mov (a provoking-vertex / flat
-    // read) must decorate its FS Input varying Flat so the driver delivers the raw vertex value, not
-    // a smooth blend. An attribute read via BOTH v_interp_mov and v_interp_p2 is contradictory ->
-    // reject. Encodings llvm-mc gfx1030 verified. Dec_Flat = 14.
+    // v_interp_mov explicit-parameter reads (#152/#897). P0-only retains the cheap Flat varying.
+    // Mixed smooth+P0 and P10/P20 use the portable generated geometry stage, which publishes the
+    // coefficient values through separate Flat locations. Encodings llvm-mc gfx1030 verified.
     enum : uint32_t { OpDecorate = 71, DecFlat = 14 };
     // Flat-only: v_interp_mov v3, p0, attr0.x ; exp mrt0 v3,v3,v3,v3 ; s_endpgm
     const uint32_t ps_flat[] = { 0xc80e0002u, 0xf800000fu, 0x03030303u, 0xbf810000u };
@@ -413,14 +412,39 @@ int main() {
         return 1;
     }
     printf("  [ok]   v_interp_p2-only attribute stays smooth (no Flat decoration)\n");
-    // Mixed: attr0 read via BOTH v_interp_mov (flat) and v_interp_p2 (smooth) -> reject (can't be both).
+    // Mixed: attr0 read via BOTH P0 and smooth interpolation needs separate interface locations.
     const uint32_t ps_mixed[] = { 0xc80e0002u, 0xc8110002u, 0xf800000fu, 0x03030303u, 0xbf810000u };
-    std::vector<uint32_t> mixed_spv = recompile_fragment(ps_mixed, sizeof(ps_mixed)/sizeof(ps_mixed[0]));
-    if (!mixed_spv.empty()) {
-        printf("  [FAIL] an attribute read via BOTH v_interp_mov and v_interp_p2 must be REJECTED\n");
+    FragmentInterpolationLayout mixed_layout = fragment_interpolation_layout(
+        ps_mixed, sizeof(ps_mixed)/sizeof(ps_mixed[0]));
+    std::vector<uint32_t> mixed_spv = recompile_fragment(
+        ps_mixed, sizeof(ps_mixed)/sizeof(ps_mixed[0]), nullptr, nullptr, UINT32_MAX, &mixed_layout);
+    std::vector<uint32_t> mixed_gs = recompile_interpolation_geometry(mixed_layout);
+    if (!mixed_layout.valid || !mixed_layout.requires_geometry || mixed_spv.empty() ||
+        mixed_gs.empty() || !has_opcode(mixed_gs, 218) || !has_opcode(mixed_gs, 219)) {
+        printf("  [FAIL] mixed P0+smooth interpolation did not generate a geometry fallback\n");
         return 1;
     }
-    printf("  [ok]   mixed flat+smooth read of one attribute is rejected\n");
+    printf("  [ok]   mixed P0+smooth interpolation generates coefficient pass-through SPIR-V\n");
+
+    // Explicit P10/P20/P0 values are the three AMD parameters used by Astro Bot's rejected title
+    // composite PS. All three fragment inputs are Flat outputs of the generated geometry stage.
+    const uint32_t ps_parameters[] = {
+        0xc80e0000u, 0xc8120001u, 0xc8160002u,
+        0xf800000fu, 0x05050403u, 0xbf810000u,
+    };
+    FragmentInterpolationLayout parameter_layout = fragment_interpolation_layout(
+        ps_parameters, sizeof(ps_parameters)/sizeof(ps_parameters[0]));
+    std::vector<uint32_t> parameter_spv = recompile_fragment(
+        ps_parameters, sizeof(ps_parameters)/sizeof(ps_parameters[0]), nullptr, nullptr,
+        UINT32_MAX, &parameter_layout);
+    std::vector<uint32_t> parameter_gs = recompile_interpolation_geometry(parameter_layout);
+    if (!parameter_layout.valid || !parameter_layout.requires_geometry || parameter_spv.empty() ||
+        parameter_gs.empty() || !has_decoration(parameter_spv, DecFlat) ||
+        !has_decoration(parameter_gs, DecFlat)) {
+        printf("  [FAIL] P10/P20/P0 explicit parameters did not lower through Flat geometry outputs\n");
+        return 1;
+    }
+    printf("  [ok]   P10/P20/P0 lower through the portable Flat geometry interface\n");
 
     // Pixel-system VGPR initialization: with perspective sample/center enabled, disabled
     // centroid/pull-model slots reserved by ADDR, and position X/Y enabled, the packed destinations

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -97,6 +97,39 @@ int main() {
                           compute_cfg_dispatch_dead_descriptor.size(), 0, 0,
                           &dispatch_rt).empty(),
           "unreachable dispatcher writes cannot invalidate a live direct descriptor");
+
+    // Descriptor identity is compile-time provenance, not part of the scalar value persisted by the
+    // complex-CFG dispatcher's Function variables. This reduced Astro shape loads V# s[20:23] before
+    // the branch tree and consumes it with a raw MUBUF at the shared exit. SRT-only lookup cannot be
+    // proven at that later block; the front-half's exact per-MUBUF fetch_pc alias makes it unambiguous.
+    std::vector<uint32_t> compute_cfg_dispatch_cross_block_vsharp = {
+        0xF4080504u, 0xFA000010u, // s_load_dwordx4 s[20:23], s[8:9], 0x10
+    };
+    compute_cfg_dispatch_cross_block_vsharp.insert(
+        compute_cfg_dispatch_cross_block_vsharp.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + sizeof(compute_cfg_dispatch) / sizeof(compute_cfg_dispatch[0]) - 1);
+    const uint32_t cross_block_fetch_pc =
+        static_cast<uint32_t>(compute_cfg_dispatch_cross_block_vsharp.size());
+    compute_cfg_dispatch_cross_block_vsharp.push_back(0xE00C2000u);
+    compute_cfg_dispatch_cross_block_vsharp.push_back(0x80050400u); // buffer_load_dword v4,v0,s[20:23]
+    compute_cfg_dispatch_cross_block_vsharp.push_back(0xBF810000u);
+    ShaderResourceTable cross_block_rt = dispatch_rt;
+    ShaderResource cross_block_vsharp{};
+    cross_block_vsharp.cls = ResourceClass::ConstantBuffer;
+    cross_block_vsharp.binding = 4;
+    cross_block_vsharp.srt_offset = 0x10;
+    cross_block_vsharp.stride = 4;
+    cross_block_rt.resources.push_back(cross_block_vsharp);
+    CHECK(recompile_valu(compute_cfg_dispatch_cross_block_vsharp.data(),
+                         compute_cfg_dispatch_cross_block_vsharp.size(), 0, 0,
+                         &cross_block_rt).empty(),
+          "a cross-block V# without exact fetch provenance remains unresolved");
+    cross_block_rt.resources.back().fetch_pc = cross_block_fetch_pc;
+    CHECK(!recompile_valu(compute_cfg_dispatch_cross_block_vsharp.data(),
+                          compute_cfg_dispatch_cross_block_vsharp.size(), 0, 0,
+                          &cross_block_rt).empty(),
+          "exact MUBUF fetch provenance survives the complex compute CFG boundary");
+
     std::vector<uint32_t> compute_cfg_dispatch_live_vopc_write = {
         0x7C0400F9u, 0x06068800u, // v_cmp_eq_f32_sdwa s8, v0, v0 (writes s[8:9])
     };

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -41,6 +41,50 @@ int main() {
     CHECK(c[1] > 0x80 && c[0] < 0x40 && c[2] < 0x40, "center pixel is GREEN (from the recompiled shader)");
     CHECK(k[2] > 0x80 && k[0] < 0x40 && k[1] < 0x40, "corner pixel is the BLUE clear");
 
+    // Astro Bot's early foreground pass exports only R/G (EN=0x3). AMD's EXP contract preserves
+    // disabled destination components; the live executor therefore intersects EN with the Vulkan
+    // pipeline write mask. Prove both the exact rejected shader now recompiles and a partial draw
+    // changes R/G while retaining the BLUE clear's B/A channels.
+    const uint32_t astro_partial_ps[] = {
+        0x7E000280u, 0xF8001803u, 0x00000000u, 0xBF810000u,
+    };
+    CHECK(fragment_color_export_mask(astro_partial_ps, std::size(astro_partial_ps)) == 0x3u,
+          "#825: decoded Astro Bot's MRT0 R/G export-enable mask");
+    CHECK(!recompile_fragment(astro_partial_ps, std::size(astro_partial_ps)).empty(),
+          "#825: recompiled Astro Bot's partial-EN fragment shader");
+
+    const uint32_t astro_ngg_vs[] = {
+        0xBFA00001u, 0x93EAFF03u, 0x00080008u, 0x876BFF03u, 0x000000FFu,
+        0x8F6A8C6Au, 0x887C6A6Bu, 0xBF800000u, 0xBF900009u, 0x906A8803u,
+        0x81EA6A80u, 0x90FE6AC1u, 0xF8000941u, 0x00000000u, 0x81EA0380u,
+        0xBF8CFF0Fu, 0x90FE6AC1u, 0x34040A81u, 0x36060AC2u, 0x7E000280u,
+        0x7E0202F2u, 0x36040482u, 0x4A0606C1u, 0x4A0404C1u, 0x7E060B03u,
+        0x7E040B02u, 0xF80000D4u, 0x00080000u, 0xF80008CFu, 0x01000302u,
+        0xBF810000u,
+    };
+    std::vector<uint32_t> astro_vert = recompile_vertex(astro_ngg_vs, std::size(astro_ngg_vs));
+    CHECK(!astro_vert.empty(),
+          "#825: recompiled Astro Bot NGG shader with ancillary POS1 before mandatory POS0");
+
+    const uint32_t preserve_ps[] = {
+        0x7E0002F2u, 0x7E020280u, // v0=1.0 (R), v1=0.0 (G)
+        0xF8001803u, 0x00000100u, 0xBF810000u,
+    };
+    std::vector<uint32_t> preserve_frag = recompile_fragment(preserve_ps, std::size(preserve_ps));
+    ResolvedPipelineState preserve_state;
+    preserve_state.topology = 3; // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+    preserve_state.color_write_mask = fragment_color_export_mask(preserve_ps, std::size(preserve_ps));
+    std::vector<uint8_t> preserve_px = prosper::test::render_triangle_rgba(
+        vert, preserve_frag, W, H, &preserve_state);
+    CHECK(preserve_px.size() == (size_t)W * H * 4,
+          "#825: rendered partial-EN fragment shader with its attachment mask");
+    if (preserve_px.size() == (size_t)W * H * 4) {
+        const uint8_t* pc = &preserve_px[((size_t)(H/2) * W + W/2) * 4];
+        printf("  partial-EN center=(%u,%u,%u,%u)\n", pc[0], pc[1], pc[2], pc[3]);
+        CHECK(pc[0] > 0x80 && pc[1] < 0x40 && pc[2] > 0x80 && pc[3] > 0x80,
+              "#825: partial R/G export preserves destination B/A components");
+    }
+
     // DOLL's volume-sampling PS uses ENA=ADDR=0x702: perspective-center occupies v0:v1 and
     // POS_X/Y/Z_FLOAT occupy v2:v4. Export v2 as red; a real FragCoord.x saturates the UNORM target
     // while the old undefined-register fallback exported zero and left the triangle black.

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -73,6 +73,7 @@ int main() {
         { P::CB_BLEND0_CONTROL,  (1u << 30) | (4u << 0) | (5u << 8) | (0u << 5) },
         { P::CB_BLEND1_CONTROL,  (1u << 30) | (1u << 0) | (5u << 8) | (0u << 5) },
         { P::CB_TARGET_MASK,     0x000000FFu },
+        { P::CB_SHADER_MASK,     0x000000F3u },
         // CB fast-clear (#309): CLEAR_WORD0 holds one texel in the surface's 8_8_8_8 format.
         { P::CB_COLOR0_CLEAR_WORD0, 0x11223344u },
         { P::CB_COLOR0_CLEAR_WORD1, 0x00000000u },
@@ -345,6 +346,7 @@ int main() {
     CHECK(rs.db_depth_control  == 0x00000046u, "db_depth_control raw preserved");
     CHECK(rs.cb_color_control  == 0x00CC0010u, "cb_color_control raw preserved");
     CHECK(rs.cb_target_mask    == 0x000000FFu, "cb_target_mask raw preserved");
+    CHECK(rs.cb_shader_mask    == 0x000000F3u, "cb_shader_mask raw preserved");
 
     // #309: CB fast-clear word extraction + format-aware decode in resolve_pipeline_state.
     CHECK(rs.color0_has_clear, "color0_has_clear = true (CLEAR_WORD programmed)");
@@ -352,6 +354,8 @@ int main() {
     {
         // This target is ALT/BGRA + SRGB, so byte0=B, byte1=G, byte2=R, byte3=A, with RGB linearized.
         ResolvedPipelineState ps = resolve_pipeline_state(rs);
+        CHECK(ps.color_write_mask == 0x3u,
+              "MRT0 write mask intersects CB_TARGET_MASK with CB_SHADER_MASK");
         CHECK(ps.has_clear_color, "resolve decodes the fast-clear color");
         CHECK_NEAR(ps.clear_color[0], srgb2lin(0x22 / 255.0f), "clear R = byte2 (ALT swap), sRGB-linearized");
         CHECK_NEAR(ps.clear_color[1], srgb2lin(0x33 / 255.0f), "clear G = byte1, sRGB-linearized");

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -31,6 +31,9 @@
 #ifdef PROSPER_VIDEO_MF
 #include "media_foundation_backend.hpp" // native Windows AvPlayer demux + hardware decode
 #endif
+#ifdef PROSPER_VIDEO_VAAPI
+#include "vaapi_backend.hpp"             // native Linux FFmpeg demux + VA-API hardware decode
+#endif
 
 #ifdef _WIN32
 #include <windows.h>
@@ -510,6 +513,10 @@ int main(int argc, char** argv) {
 #ifdef PROSPER_VIDEO_MF
         if (!prosper::video::install_media_foundation_backend())
             fprintf(stderr, "[avp] Media Foundation backend unavailable\n");
+#endif
+#ifdef PROSPER_VIDEO_VAAPI
+        if (!prosper::video::install_vaapi_backend())
+            fprintf(stderr, "[avp] FFmpeg/VA-API backend unavailable\n");
 #endif
     })) { fprintf(stderr, "screenshot: boot failed: %s\n", err.c_str()); return 1; }
     std::thread guest([&prog] {


### PR DESCRIPTION
Refs #897.

## What this checkpoint reaches

Astro Bot now feeds real decoded NV12 video frames into guest-visible AvPlayer buffers and the live Vulkan renderer can recompile and execute the opening workload far enough to present the `Sony Interactive Entertainment presents` frame on Linux. This is a meaningful visible-progression checkpoint, not title-screen completion: the image is still dark/incomplete and the current Linux route remains at the opening card.

The same branch also removes the repeated live-compute pipeline specialization that made the opening workload impractically slow. User SGPR values are push constants, while the SPIR-V module, descriptor layout, pipeline layout, and pipeline are cached by their true structural identity.

During verification, the new master scissor support exposed an independent cross-game collapse: native 960x540 Dead Cells targets were globally divided by render scale 4 and never corrected back for the pass-local target, leaving only a 240x135 top-left quadrant. The native-target correction now rescales both viewport and scissor. Guest scissors remain enabled.

## Root causes and behavior

- AvPlayer decoded frames stayed in host-owned backend memory, so the guest texture descriptor never referenced current NV12 planes.
- The guest allocator/free callbacks were not used for decoded-video surfaces on both SysV host paths.
- Several Astro shaders required exact EXP/POS export handling and portable explicit interpolation lowering.
- Compute modules baked per-dispatch SGPR values, forcing shader and pipeline rebuilds for otherwise identical dispatches.
- The live renderer corrected native-target viewports after global render scaling but omitted the newly modeled scissor.

The implementation keeps synthetic video opt-in only. The Linux screenshot evidence below uses the real FFmpeg decoder with its explicit software override because this WSL host has no usable VA-API device. Windows retains Media Foundation/DXVA as its default hardware path.

## Performance

Measured over the same Astro opening workload:

| | Before | After |
|---|---:|---:|
| Dispatches observed | 1,304 | 681 |
| Total compute time | 71.621 s | 33.057 s |
| Pipeline time | 24.236 s | 0.792 s |
| Dispatch time | 15.615 s | 14.337 s |

## Visual evidence

![Astro Bot — Linux app — Sony Interactive Entertainment presents](https://github.com/mattias800/ps5ys/blob/master/prosper/docs/screenshots/issue-825-astrobot-linux-sony-presents.png?raw=1)

Direct, unmodified Astro Bot (`PPSA21564`) Linux app capture at the `Sony Interactive Entertainment presents` checkpoint, using the normal `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct` route and real decoded opening movie.

A fresh exact-head Linux headless sequence is also retained locally in `Downloads/AstroBot-Linux-cbc161e-real-software-60s`: 60 one-per-second frontend captures, 45 distinct source frames and 20 pixel-distinct frames. Its disclosed route adds the screenshot frontend's 80-second warmup and `PROSPER_AVP_ALLOW_SOFTWARE=1`; it corroborates the checkpoint but is not claimed as full-render acceptance evidence.

## Verification at `cbc161e`

- `git diff --check origin/master...HEAD` — PASS
- Linux full build — PASS
- Linux `ctest --test-dir build-linux --output-on-failure -j$(nproc)` — **113/113 PASS**
- Windows MinGW headless full build — PASS
- Windows MinGW headless `ctest --test-dir build-mingw-headless --output-on-failure -j 8` — **83/83 PASS**
- Windows MinGW SDL `prosper-app.exe` build — PASS
- `python3 tools/snapshot/snapshot.py check dead-cells-gameplay` — **PASS**: 44/44 qualifying frames, 44 structural matches, 9,806 colors in richest frame
- Fresh Linux headless Astro screenshot run with real FFmpeg software decode — PASS: 60/60 captures, 45 source-distinct, 20 pixel-distinct

## Risk and remaining work

The shader/export/interpolation changes are broad renderer behavior, so the full unit matrix and reviewed Dead Cells gameplay guard are included above. The Windows app compiles and Windows headless tests pass, but this PR does not claim a fresh native-Windows Astro runtime acceptance run. Title screen, main menu, and first level remain follow-up milestones under #897.