### PR TITLE
fix(windows): complete fixed direct-memory views and partial unmap

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -52,6 +52,7 @@ namespace prosper {
 #ifdef _WIN32
 extern "C" int prosper_reserved_range_state(uint64_t addr);
 extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
+extern "C" int prosper_try_commit_reserved_placeholder(uint64_t addr, uint64_t len);
 #endif
 
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
@@ -81,7 +82,9 @@ namespace {
             if (!VirtualQuery((const void*)(uintptr_t)p, &mbi, sizeof mbi)) return p - dst;
             if (mbi.State == MEM_RESERVE && prosper_reserved_range_state(p) == 1) {
                 const uint64_t page = p & ~uint64_t{0x3fff};
-                if (!VirtualAlloc((void*)(uintptr_t)page, 0x4000, MEM_COMMIT, PAGE_READWRITE))
+                if (!prosper_try_commit_reserved_placeholder(page, 0x4000) &&
+                    !VirtualAlloc((void*)(uintptr_t)page, 0x4000,
+                                  MEM_COMMIT, PAGE_READWRITE))
                     return p - dst;
                 continue;
             }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1542,9 +1542,22 @@ namespace {
         std::vector<uint64_t> committed_pages;
     };
     struct PlaceholderSpan { uint64_t base, size; };
+    struct PrivatePlaceholderView { uint64_t base, size; };
+    enum class PlaceholderOwner { Free, Guest };
+    struct AcquiredPlaceholder {
+        void* address = nullptr;
+        PlaceholderOwner owner = PlaceholderOwner::Free;
+    };
     std::mutex g_dview_mx;
     std::vector<DmemView> g_dviews;
     std::vector<PlaceholderSpan> g_free_placeholders;
+    // Host placeholders owned by an uncommitted guest reservation. Keeping these separate from
+    // guest-free placeholders prevents a zero-hint map from consuming another allocation while
+    // still allowing a fixed map to replace its own reservation.
+    std::vector<PlaceholderSpan> g_guest_placeholders;
+    // Private allocations created with MEM_REPLACE_PLACEHOLDER must be returned to placeholders
+    // on unmap; VirtualFree(..., MEM_DECOMMIT) would leave a non-replaceable private reservation.
+    std::vector<PrivatePlaceholderView> g_private_placeholder_views;
 
     using VirtualAlloc2Fn = PVOID (WINAPI*)(HANDLE, PVOID, SIZE_T, ULONG, ULONG,
                                             MEM_EXTENDED_PARAMETER*, ULONG);
@@ -1576,38 +1589,48 @@ namespace {
         return apis;
     }
 
-    // g_free_placeholders describes exact Windows placeholder regions. These ranges are reserved
-    // in the host but free in the guest tracker; retaining a 16 KiB hole is what lets a later fixed
-    // direct map replace it even when adjacent guest pages occupy the same 64 KiB host granule.
-    void remember_free_placeholder_locked(uint64_t base, uint64_t size) {
+    // Store one exact Windows placeholder and coalesce only adjacent spans with the same guest
+    // ownership. Coalescing free and guest-reserved spans together would lose the boundary needed
+    // to stop an automatic map from consuming someone else's reservation.
+    void remember_placeholder_locked(std::vector<PlaceholderSpan>& spans,
+                                     uint64_t base, uint64_t size) {
         if (!size) return;
-        g_free_placeholders.push_back({base, size});
-        std::sort(g_free_placeholders.begin(), g_free_placeholders.end(),
+        spans.push_back({base, size});
+        std::sort(spans.begin(), spans.end(),
                   [](const PlaceholderSpan& a, const PlaceholderSpan& b) {
                       return a.base < b.base;
                   });
-        for (size_t i = 1; i < g_free_placeholders.size();) {
-            PlaceholderSpan& left = g_free_placeholders[i - 1];
-            const PlaceholderSpan right = g_free_placeholders[i];
+        for (size_t i = 1; i < spans.size();) {
+            PlaceholderSpan& left = spans[i - 1];
+            const PlaceholderSpan right = spans[i];
             if (left.base + left.size != right.base) { ++i; continue; }
             if (VirtualFree(reinterpret_cast<void*>(static_cast<uintptr_t>(left.base)),
                             static_cast<SIZE_T>(left.size + right.size),
                             MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS)) {
                 left.size += right.size;
-                g_free_placeholders.erase(g_free_placeholders.begin() + i);
+                spans.erase(spans.begin() + i);
             } else {
                 ++i;
             }
         }
     }
 
+    void remember_free_placeholder_locked(uint64_t base, uint64_t size) {
+        remember_placeholder_locked(g_free_placeholders, base, size);
+    }
+
+    void remember_guest_placeholder_locked(uint64_t base, uint64_t size) {
+        remember_placeholder_locked(g_guest_placeholders, base, size);
+    }
+
     // Remove one exact page-aligned subrange from a free placeholder. VirtualFree with
     // MEM_PRESERVE_PLACEHOLDER splits the Windows placeholder without releasing either side.
-    void* take_free_placeholder_locked(uint64_t hint, uint64_t len, uint64_t align) {
+    void* take_placeholder_locked(std::vector<PlaceholderSpan>& spans,
+                                  uint64_t hint, uint64_t len, uint64_t align) {
         if (!len) return nullptr;
         const uint64_t requested_align = align ? align : 0x1000;
-        for (size_t i = 0; i < g_free_placeholders.size(); ++i) {
-            const PlaceholderSpan span = g_free_placeholders[i];
+        for (size_t i = 0; i < spans.size(); ++i) {
+            const PlaceholderSpan span = spans[i];
             uint64_t base = hint ? hint : align_up(span.base, requested_align);
             if ((base & (requested_align - 1)) || base < span.base ||
                 base > UINT64_MAX - len ||
@@ -1617,12 +1640,12 @@ namespace {
 
             const uint64_t prefix = base - span.base;
             const uint64_t suffix = span.base + span.size - (base + len);
-            g_free_placeholders.erase(g_free_placeholders.begin() + i);
+            spans.erase(spans.begin() + i);
             if (prefix && !VirtualFree(
                     reinterpret_cast<void*>(static_cast<uintptr_t>(span.base)),
                     static_cast<SIZE_T>(prefix),
                     MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
-                remember_free_placeholder_locked(span.base, span.size);
+                remember_placeholder_locked(spans, span.base, span.size);
                 return nullptr;
             }
             if (suffix && !VirtualFree(
@@ -1630,42 +1653,63 @@ namespace {
                     static_cast<SIZE_T>(len),
                     MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
                 if (prefix) {
-                    remember_free_placeholder_locked(span.base, prefix);
-                    remember_free_placeholder_locked(base, len + suffix);
+                    remember_placeholder_locked(spans, span.base, prefix);
+                    remember_placeholder_locked(spans, base, len + suffix);
                 } else {
-                    remember_free_placeholder_locked(span.base, span.size);
+                    remember_placeholder_locked(spans, span.base, span.size);
                 }
                 return nullptr;
             }
-            if (prefix) remember_free_placeholder_locked(span.base, prefix);
-            if (suffix) remember_free_placeholder_locked(base + len, suffix);
+            if (prefix) remember_placeholder_locked(spans, span.base, prefix);
+            if (suffix) remember_placeholder_locked(spans, base + len, suffix);
             return reinterpret_cast<void*>(static_cast<uintptr_t>(base));
         }
         return nullptr;
     }
 
-    void* acquire_placeholder_locked(uint64_t hint, uint64_t len, uint64_t align) {
+    void* take_free_placeholder_locked(uint64_t hint, uint64_t len, uint64_t align) {
+        return take_placeholder_locked(g_free_placeholders, hint, len, align);
+    }
+
+    void* take_guest_placeholder_locked(uint64_t hint, uint64_t len, uint64_t align) {
+        return take_placeholder_locked(g_guest_placeholders, hint, len, align);
+    }
+
+    void restore_placeholder_owner_locked(PlaceholderOwner owner, uint64_t base, uint64_t size) {
+        if (owner == PlaceholderOwner::Guest)
+            remember_guest_placeholder_locked(base, size);
+        else
+            remember_free_placeholder_locked(base, size);
+    }
+
+    AcquiredPlaceholder acquire_placeholder_locked(uint64_t hint, uint64_t len,
+                                                   uint64_t align, bool allow_guest) {
         const PlaceholderApis& apis = placeholder_apis();
         if (!apis.virtual_alloc2 || !apis.map_view_of_file3 ||
             !apis.unmap_view_of_file2 || !len || (len & 0xfff) ||
-            (align && (align & (align - 1)))) return nullptr;
+            (align && (align & (align - 1)))) return {};
 
-        if (void* recycled = take_free_placeholder_locked(hint, len, align)) return recycled;
+        if (void* recycled = take_free_placeholder_locked(hint, len, align))
+            return {recycled, PlaceholderOwner::Free};
+        if (hint && allow_guest) {
+            if (void* reserved = take_guest_placeholder_locked(hint, len, align))
+                return {reserved, PlaceholderOwner::Guest};
+        }
 
         if (hint) {
-            if (hint & 0xfff) return nullptr;
+            if (hint & 0xfff) return {};
             const uint64_t cover_base = hint & ~(kWinAllocationGranularity - 1);
             const uint64_t end = hint + len;
-            if (end < hint) return nullptr;
+            if (end < hint) return {};
             const uint64_t cover_end = align_up(end, kWinAllocationGranularity);
             void* cover = apis.virtual_alloc2(
                 GetCurrentProcess(),
                 reinterpret_cast<void*>(static_cast<uintptr_t>(cover_base)),
                 static_cast<SIZE_T>(cover_end - cover_base),
                 MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, nullptr, 0);
-            if (!cover) return nullptr;
+            if (!cover) return {};
             remember_free_placeholder_locked(cover_base, cover_end - cover_base);
-            return take_free_placeholder_locked(hint, len, align);
+            return {take_free_placeholder_locked(hint, len, align), PlaceholderOwner::Free};
         }
 
         MEM_ADDRESS_REQUIREMENTS requirements{};
@@ -1678,27 +1722,73 @@ namespace {
         MEM_EXTENDED_PARAMETER parameter{};
         parameter.Type = MemExtendedParameterAddressRequirements;
         parameter.Pointer = &requirements;
-        return apis.virtual_alloc2(
-            GetCurrentProcess(), nullptr, static_cast<SIZE_T>(len),
+        if (len > UINT64_MAX - (kWinAllocationGranularity - 1)) return {};
+        const uint64_t cover_size = align_up(len, kWinAllocationGranularity);
+        void* cover = apis.virtual_alloc2(
+            GetCurrentProcess(), nullptr, static_cast<SIZE_T>(cover_size),
             MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, &parameter, 1);
+        if (!cover) return {};
+        const uint64_t base = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(cover));
+        remember_free_placeholder_locked(base, cover_size);
+        return {take_free_placeholder_locked(base, len, align), PlaceholderOwner::Free};
+    }
+
+    bool protect_committed_regions(uint64_t base, uint64_t len, int hp) {
+        if (!len || base > UINT64_MAX - len) return false;
+        const uint64_t end = base + len;
+        uint64_t cursor = base;
+        while (cursor < end) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                              &mbi, sizeof(mbi))) return false;
+            const uint64_t region_end = std::min<uint64_t>(
+                end, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress)) +
+                         mbi.RegionSize);
+            if (region_end <= cursor || mbi.State == MEM_FREE) return false;
+            if (mbi.State == MEM_COMMIT) {
+                DWORD old = 0;
+                if (!VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                                    static_cast<SIZE_T>(region_end - cursor),
+                                    win_page_prot(hp), &old)) return false;
+            }
+            cursor = region_end;
+        }
+        return true;
     }
 
     void* map_placeholder_section_view(HANDLE section, uint64_t hint, uint64_t rel,
-                                       uint64_t len, uint64_t align) {
+                                       uint64_t len, uint64_t align, int hp) {
         const PlaceholderApis& apis = placeholder_apis();
         if (!apis.map_view_of_file3 || (rel & 0xfff)) return nullptr;
         std::lock_guard<std::mutex> lk(g_dview_mx);
-        void* placeholder = acquire_placeholder_locked(hint, len, align);
-        if (!placeholder) return nullptr;
+        const AcquiredPlaceholder acquired =
+            acquire_placeholder_locked(hint, len, align, true);
+        if (!acquired.address) return nullptr;
         void* view = apis.map_view_of_file3(
-            section, GetCurrentProcess(), placeholder, rel,
+            section, GetCurrentProcess(), acquired.address, rel,
             static_cast<SIZE_T>(len), MEM_REPLACE_PLACEHOLDER,
             PAGE_READWRITE, nullptr, 0);
         if (!view) {
             const DWORD error = GetLastError();
-            remember_free_placeholder_locked(
-                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(placeholder)), len);
+            restore_placeholder_owner_locked(
+                acquired.owner,
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(acquired.address)), len);
             SetLastError(error);
+            return nullptr;
+        }
+        const uint64_t base = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(view));
+        if (!protect_committed_regions(base, len, hp)) {
+            const DWORD error = GetLastError();
+            if (!apis.unmap_view_of_file2(GetCurrentProcess(), view,
+                                          MEM_PRESERVE_PLACEHOLDER)) {
+                std::fprintf(stderr,
+                             "[memhle] fatal: could not restore placeholder after protection "
+                             "failure\n");
+                std::abort();
+            }
+            restore_placeholder_owner_locked(acquired.owner, base, len);
+            SetLastError(error);
+            return nullptr;
         }
         return view;
     }
@@ -1718,7 +1808,7 @@ namespace {
         void* view = nullptr;
         // Placeholder replacement is page-granular, unlike MapViewOfFileEx. Map the guest range
         // directly at its physical-section offset, with no 64 KiB congruence requirement.
-        view = map_placeholder_section_view(section, hint, rel, len, requested_align);
+        view = map_placeholder_section_view(section, hint, rel, len, requested_align, hp);
         sparse = placeholder = view != nullptr;
         if (!view) {
             void* requested = nullptr;
@@ -1742,7 +1832,22 @@ namespace {
 
         if (!hint && requested_align &&
             ((uint64_t)(uintptr_t)guest & (requested_align - 1)) != 0) {
-            UnmapViewOfFile(view);
+            if (placeholder) {
+                const PlaceholderApis& apis = placeholder_apis();
+                if (!apis.unmap_view_of_file2 ||
+                    !apis.unmap_view_of_file2(GetCurrentProcess(), view,
+                                              MEM_PRESERVE_PLACEHOLDER)) {
+                    std::fprintf(stderr,
+                                 "[memhle] fatal: could not restore misaligned placeholder "
+                                 "view\n");
+                    std::abort();
+                }
+                std::lock_guard<std::mutex> lk(g_dview_mx);
+                remember_free_placeholder_locked(
+                    static_cast<uint64_t>(reinterpret_cast<uintptr_t>(view)), len);
+            } else {
+                UnmapViewOfFile(view);
+            }
             return nullptr;
         }
         if (!sparse && !VirtualAlloc(guest, (SIZE_T)len, MEM_COMMIT, PAGE_READWRITE)) {
@@ -1989,18 +2094,81 @@ namespace {
         if (reused) dmem_zero(phys, len);
     }
 
-    // Commit `len` at `hint` (0 = OS chooses). Handles BOTH the guest's reserve-then-commit flow
-    // (ReserveVirtualRange did MEM_RESERVE; commit within it) AND a fresh map, by trying MEM_COMMIT
-    // first (succeeds only over an existing reservation) then MEM_RESERVE|MEM_COMMIT.
+    PrivatePlaceholderView* private_placeholder_view_containing_locked(uint64_t begin,
+                                                                       uint64_t end) {
+        for (PrivatePlaceholderView& view : g_private_placeholder_views) {
+            if (begin >= view.base && end >= begin && end <= view.base + view.size)
+                return &view;
+        }
+        return nullptr;
+    }
+
+    void* replace_placeholder_with_private_locked(uint64_t base, uint64_t len, int hp,
+                                                  PlaceholderOwner owner) {
+        const PlaceholderApis& apis = placeholder_apis();
+        if (!apis.virtual_alloc2) return nullptr;
+        void* result = apis.virtual_alloc2(
+            GetCurrentProcess(),
+            reinterpret_cast<void*>(static_cast<uintptr_t>(base)),
+            static_cast<SIZE_T>(len),
+            MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+            win_page_prot(hp), nullptr, 0);
+        if (!result) {
+            restore_placeholder_owner_locked(owner, base, len);
+            return nullptr;
+        }
+        g_private_placeholder_views.push_back({base, len});
+        return result;
+    }
+
+    // Commit `len` at `hint` (0 = OS chooses). Placeholder-backed guest reservations and holes
+    // are replaced with ordinary private pages so the same 16 KiB address can later be reused by
+    // either flexible or direct memory. Legacy VirtualAlloc reservations retain their old path.
     void* win_commit(uint64_t hint, uint64_t len, int hp) {
         DWORD pp = win_page_prot(hp);
         void* result = nullptr;
         if (!hint) {
             result = VirtualAlloc(nullptr, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
         } else {
-            result = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_COMMIT, pp);
-            if (!result)
-                result = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, pp);
+            bool placeholder_owned = false;
+            bool direct_collision = false;
+            if (hint <= UINT64_MAX - len) {
+                std::lock_guard<std::mutex> lk(g_dview_mx);
+                if (private_placeholder_view_containing_locked(hint, hint + len)) {
+                    placeholder_owned = true;
+                    DWORD old = 0;
+                    if (VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+                                       static_cast<SIZE_T>(len), pp, &old))
+                        result = reinterpret_cast<void*>(static_cast<uintptr_t>(hint));
+                } else {
+                    PlaceholderOwner owner = PlaceholderOwner::Guest;
+                    void* placeholder = take_guest_placeholder_locked(hint, len, 0x1000);
+                    if (!placeholder) {
+                        owner = PlaceholderOwner::Free;
+                        placeholder = take_free_placeholder_locked(hint, len, 0x1000);
+                    }
+                    if (placeholder) {
+                        placeholder_owned = true;
+                        result = replace_placeholder_with_private_locked(hint, len, hp, owner);
+                    } else {
+                        for (const DmemView& view : g_dviews) {
+                            if (hint < view.guest_base + view.guest_size &&
+                                hint + len > view.guest_base) {
+                                direct_collision = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if (!result && !placeholder_owned && !direct_collision) {
+                result = VirtualAlloc(reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+                                      static_cast<SIZE_T>(len), MEM_COMMIT, pp);
+                if (!result)
+                    result = VirtualAlloc(reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+                                          static_cast<SIZE_T>(len),
+                                          MEM_RESERVE | MEM_COMMIT, pp);
+            }
         }
         if (result)
             host::guest_write_watch_notify_direct_mapping_added(
@@ -2024,9 +2192,22 @@ namespace {
              (unsigned long long)phys, (unsigned long long)align, GetLastError());
         return win_commit(fixed ? hint : 0, len, hp);
     }
-    // Reserve (no commit). VirtualAlloc reservations are 64 KiB-aligned, satisfying guest aligns
-    // up to 64 KiB; larger alignment is logged and left to the OS base (follow-up).
+    // Reserve (no commit). Modern Windows placeholders can be partitioned at the guest's 16 KiB
+    // page boundary and later replaced by either a section view or private pages.
     void* win_reserve(uint64_t hint, uint64_t len, bool fixed, uint64_t align) {
+        {
+            std::lock_guard<std::mutex> lk(g_dview_mx);
+            AcquiredPlaceholder acquired =
+                acquire_placeholder_locked(hint, len, align, false);
+            if (!acquired.address && hint && !fixed)
+                acquired = acquire_placeholder_locked(0, len, align, false);
+            if (acquired.address) {
+                const uint64_t base = static_cast<uint64_t>(
+                    reinterpret_cast<uintptr_t>(acquired.address));
+                remember_guest_placeholder_locked(base, len);
+                return acquired.address;
+            }
+        }
         if (hint) {
             if (void* p = VirtualAlloc((void*)hint, (SIZE_T)len, MEM_RESERVE, PAGE_NOACCESS)) return p;
             if (fixed) return nullptr;   // SCE_KERNEL_MAP_FIXED: must be exactly this address
@@ -2176,6 +2357,14 @@ namespace {
         }
     }
 
+    void notify_private_watch_added(const PrivatePlaceholderView& view) {
+        const auto slices = tracked_protection_slices(view.base, view.base + view.size);
+        for (const ProtectionSlice& slice : slices) {
+            host::guest_write_watch_notify_direct_mapping_added(
+                slice.base, slice.size, slice.base, win_page_prot(slice.prot));
+        }
+    }
+
     bool replace_free_placeholder_with_view_locked(uint64_t base, uint64_t size, uint64_t phys,
                                                    DmemView& out) {
         const PlaceholderApis& apis = placeholder_apis();
@@ -2310,33 +2499,46 @@ namespace {
         return true;
     }
 
-    bool tracked_mappings_covered_by_views(uint64_t begin, uint64_t end,
-                                           const std::vector<DmemView>& views) {
-        std::vector<PlaceholderSpan> covered;
-        for (const DmemView& view : views) {
-            const uint64_t overlap_begin = std::max(begin, view.guest_base);
-            const uint64_t overlap_end = std::min(end, view.guest_base + view.guest_size);
-            if (overlap_begin < overlap_end)
-                covered.push_back({overlap_begin, overlap_end - overlap_begin});
-        }
-        std::sort(covered.begin(), covered.end(),
+    void normalize_spans(std::vector<PlaceholderSpan>& spans) {
+        std::sort(spans.begin(), spans.end(),
                   [](const PlaceholderSpan& a, const PlaceholderSpan& b) {
                       return a.base < b.base;
                   });
+        size_t out = 0;
+        for (const PlaceholderSpan& span : spans) {
+            if (!span.size) continue;
+            if (!out || spans[out - 1].base + spans[out - 1].size < span.base) {
+                spans[out++] = span;
+                continue;
+            }
+            const uint64_t merged_end = std::max(
+                spans[out - 1].base + spans[out - 1].size, span.base + span.size);
+            spans[out - 1].size = merged_end - spans[out - 1].base;
+        }
+        spans.resize(out);
+    }
 
+    bool span_is_covered(uint64_t begin, uint64_t end,
+                         const std::vector<PlaceholderSpan>& covered) {
+        if (begin >= end) return false;
+        uint64_t cursor = begin;
+        for (const PlaceholderSpan& span : covered) {
+            if (span.base + span.size <= cursor) continue;
+            if (span.base > cursor) break;
+            cursor = std::min(end, span.base + span.size);
+            if (cursor == end) return true;
+        }
+        return false;
+    }
+
+    bool tracked_mappings_covered_by_spans(uint64_t begin, uint64_t end,
+                                           const std::vector<PlaceholderSpan>& covered) {
         std::lock_guard<std::mutex> lk(g_mx);
         for (const Mapping& mapping : g_maps) {
             const uint64_t overlap_begin = std::max(begin, mapping.base);
             const uint64_t overlap_end = std::min(end, mapping.base + mapping.size);
             if (overlap_begin >= overlap_end) continue;
-            uint64_t cursor = overlap_begin;
-            for (const PlaceholderSpan& span : covered) {
-                if (span.base + span.size <= cursor) continue;
-                if (span.base > cursor) break;
-                cursor = std::min(overlap_end, span.base + span.size);
-                if (cursor == overlap_end) break;
-            }
-            if (cursor != overlap_end) return false;
+            if (!span_is_covered(overlap_begin, overlap_end, covered)) return false;
         }
         return true;
     }
@@ -2346,94 +2548,189 @@ namespace {
     // untouched prefix/suffix with views of their original physical offsets, and retain the hole as
     // an inaccessible free placeholder for an exact future remap.
     bool win_unmap(uint64_t addr, uint64_t len) {
-        if (!addr || !len || addr > UINT64_MAX - len) return false;
+        if (!addr || !len || (addr & 0xfff) || (len & 0xfff) ||
+            addr > UINT64_MAX - len) return false;
         const uint64_t end = addr + len;
         std::vector<DmemView> added;
-        bool section_overlap = false;
+        bool special_overlap = false;
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
             std::vector<DmemView> targets;
+            std::vector<PrivatePlaceholderView> private_targets;
+            std::vector<PlaceholderSpan> guest_cuts;
+            std::vector<PlaceholderSpan> covered;
             for (const DmemView& view : g_dviews) {
                 if (addr < view.guest_base + view.guest_size && end > view.guest_base) {
                     targets.push_back(view);
                     const uint64_t cut_begin = std::max(addr, view.guest_base);
                     const uint64_t cut_end = std::min(end, view.guest_base + view.guest_size);
+                    covered.push_back({cut_begin, cut_end - cut_begin});
                     if ((cut_begin != view.guest_base || cut_end != view.guest_base + view.guest_size) &&
                         !view.placeholder) return false;
                 }
+            }
+            for (const PrivatePlaceholderView& view : g_private_placeholder_views) {
+                const uint64_t cut_begin = std::max(addr, view.base);
+                const uint64_t cut_end = std::min(end, view.base + view.size);
+                if (cut_begin >= cut_end) continue;
+                // Returning a private replacement to a placeholder releases the whole allocation.
+                // Refuse partial cuts instead of discarding retained bytes.
+                if (cut_begin != view.base || cut_end != view.base + view.size) return false;
+                private_targets.push_back(view);
+                covered.push_back({cut_begin, cut_end - cut_begin});
+            }
+            for (const PlaceholderSpan& span : g_guest_placeholders) {
+                const uint64_t cut_begin = std::max(addr, span.base);
+                const uint64_t cut_end = std::min(end, span.base + span.size);
+                if (cut_begin >= cut_end) continue;
+                guest_cuts.push_back({cut_begin, cut_end - cut_begin});
+                covered.push_back({cut_begin, cut_end - cut_begin});
+            }
+            for (const PlaceholderSpan& span : g_free_placeholders) {
+                const uint64_t cut_begin = std::max(addr, span.base);
+                const uint64_t cut_end = std::min(end, span.base + span.size);
+                if (cut_begin < cut_end)
+                    covered.push_back({cut_begin, cut_end - cut_begin});
             }
             std::sort(targets.begin(), targets.end(),
                       [](const DmemView& a, const DmemView& b) {
                           return a.guest_base < b.guest_base;
                       });
-            section_overlap = !targets.empty();
-            if (section_overlap && !tracked_mappings_covered_by_views(addr, end, targets))
-                return false;
+            normalize_spans(covered);
+            special_overlap = !covered.empty();
+            if (special_overlap &&
+                (!span_is_covered(addr, end, covered) ||
+                 !tracked_mappings_covered_by_spans(addr, end, covered))) return false;
+            if (!special_overlap) {
+                // No placeholder-owned range participates; retain the legacy private allocation
+                // path outside the registry lock.
+            } else {
 
-            // Disarm any active physical write watch while every old alias is still mapped. On
-            // failure, the transaction restores both the views and their alias registrations.
-            for (const DmemView& target : targets)
-                host::guest_write_watch_notify_direct_mapping_removed(
-                    target.guest_base, target.guest_size);
+                // Disarm active physical write watches while every old direct alias is still
+                // mapped. On failure, the transaction restores views and alias registrations.
+                for (const DmemView& target : targets)
+                    host::guest_write_watch_notify_direct_mapping_removed(
+                        target.guest_base, target.guest_size);
 
-            std::vector<UnmapChange> changes;
-            changes.reserve(targets.size());
-            auto rollback = [&]() {
-                for (auto it = changes.rbegin(); it != changes.rend(); ++it) {
-                    if (!rollback_unmap_change_locked(*it)) {
-                        std::fprintf(stderr,
-                                     "[memhle] fatal: could not roll back direct-memory unmap\n");
-                        std::abort();
+                std::vector<UnmapChange> changes;
+                changes.reserve(targets.size());
+                auto rollback_views = [&]() {
+                    for (auto it = changes.rbegin(); it != changes.rend(); ++it) {
+                        if (!rollback_unmap_change_locked(*it)) {
+                            std::fprintf(stderr,
+                                         "[memhle] fatal: could not roll back direct-memory "
+                                         "unmap\n");
+                            std::abort();
+                        }
                     }
-                }
-                for (const DmemView& target : targets) notify_view_watch_added(target);
-            };
+                    for (const DmemView& target : targets) notify_view_watch_added(target);
+                };
 
-            for (const DmemView& target : targets) {
-                const uint64_t cut_begin = std::max(addr, target.guest_base);
-                const uint64_t cut_end = std::min(end, target.guest_base + target.guest_size);
-                UnmapChange change{target, {}};
-                bool ok = false;
-                if (cut_begin == target.guest_base &&
-                    cut_end == target.guest_base + target.guest_size) {
-                    if (target.placeholder) {
-                        const PlaceholderApis& apis = placeholder_apis();
-                        ok = apis.unmap_view_of_file2 &&
-                             apis.unmap_view_of_file2(GetCurrentProcess(), target.view_base,
-                                                     MEM_PRESERVE_PLACEHOLDER);
-                        if (ok) remember_free_placeholder_locked(
-                            target.guest_base, target.guest_size);
+                for (const DmemView& target : targets) {
+                    const uint64_t cut_begin = std::max(addr, target.guest_base);
+                    const uint64_t cut_end = std::min(end, target.guest_base + target.guest_size);
+                    UnmapChange change{target, {}};
+                    bool ok = false;
+                    if (cut_begin == target.guest_base &&
+                        cut_end == target.guest_base + target.guest_size) {
+                        if (target.placeholder) {
+                            const PlaceholderApis& apis = placeholder_apis();
+                            ok = apis.unmap_view_of_file2 &&
+                                 apis.unmap_view_of_file2(GetCurrentProcess(), target.view_base,
+                                                         MEM_PRESERVE_PLACEHOLDER);
+                            if (ok) remember_free_placeholder_locked(
+                                target.guest_base, target.guest_size);
+                        } else {
+                            ok = UnmapViewOfFile(target.view_base) != 0;
+                        }
                     } else {
-                        ok = UnmapViewOfFile(target.view_base) != 0;
+                        ok = split_placeholder_view_locked(
+                            target, cut_begin, cut_end, change.replacements);
                     }
-                } else {
-                    ok = split_placeholder_view_locked(
-                        target, cut_begin, cut_end, change.replacements);
+                    if (!ok) {
+                        rollback_views();
+                        return false;
+                    }
+                    changes.push_back(std::move(change));
                 }
-                if (!ok) {
-                    rollback();
-                    return false;
-                }
-                changes.push_back(std::move(change));
-            }
 
-            for (const UnmapChange& change : changes) {
-                const DmemView& target = change.original;
-                auto it = std::find_if(g_dviews.begin(), g_dviews.end(),
-                    [&](const DmemView& view) {
-                        return view.view_base == target.view_base &&
-                               view.guest_base == target.guest_base &&
-                               view.guest_size == target.guest_size &&
-                               view.phys == target.phys;
-                    });
-                if (it != g_dviews.end()) g_dviews.erase(it);
-                for (const DmemView& replacement : change.replacements) {
-                    added.push_back(replacement);
-                    g_dviews.push_back(replacement);
+                std::vector<PlaceholderSpan> converted_guest;
+                auto rollback_guest = [&]() {
+                    for (auto it = converted_guest.rbegin();
+                         it != converted_guest.rend(); ++it) {
+                        if (!take_free_placeholder_locked(it->base, it->size, 0x1000)) {
+                            std::fprintf(stderr,
+                                         "[memhle] fatal: could not restore guest placeholder "
+                                         "ownership\n");
+                            std::abort();
+                        }
+                        remember_guest_placeholder_locked(it->base, it->size);
+                    }
+                };
+                for (const PlaceholderSpan& cut : guest_cuts) {
+                    if (!take_guest_placeholder_locked(cut.base, cut.size, 0x1000)) {
+                        rollback_guest();
+                        rollback_views();
+                        return false;
+                    }
+                    remember_free_placeholder_locked(cut.base, cut.size);
+                    converted_guest.push_back(cut);
+                }
+
+                size_t private_unmapped = 0;
+                for (const PrivatePlaceholderView& view : private_targets) {
+                    host::guest_write_watch_notify_direct_mapping_removed(
+                        view.base, view.size);
+                    if (!VirtualFree(
+                            reinterpret_cast<void*>(static_cast<uintptr_t>(view.base)),
+                            static_cast<SIZE_T>(view.size),
+                            MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
+                        MLOG("private placeholder release va=0x%llx len=0x%llx failed "
+                             "error=%lu\n",
+                             (unsigned long long)view.base,
+                             (unsigned long long)view.size, GetLastError());
+                        if (private_unmapped) {
+                            std::fprintf(stderr,
+                                         "[memhle] fatal: partial private-placeholder unmap\n");
+                            std::abort();
+                        }
+                        notify_private_watch_added(view);
+                        rollback_guest();
+                        rollback_views();
+                        return false;
+                    }
+                    remember_free_placeholder_locked(view.base, view.size);
+                    ++private_unmapped;
+                }
+
+                for (const UnmapChange& change : changes) {
+                    const DmemView& target = change.original;
+                    auto it = std::find_if(g_dviews.begin(), g_dviews.end(),
+                        [&](const DmemView& view) {
+                            return view.view_base == target.view_base &&
+                                   view.guest_base == target.guest_base &&
+                                   view.guest_size == target.guest_size &&
+                                   view.phys == target.phys;
+                        });
+                    if (it != g_dviews.end()) g_dviews.erase(it);
+                    for (const DmemView& replacement : change.replacements) {
+                        added.push_back(replacement);
+                        g_dviews.push_back(replacement);
+                    }
+                }
+                for (const PrivatePlaceholderView& target : private_targets) {
+                    auto it = std::find_if(
+                        g_private_placeholder_views.begin(),
+                        g_private_placeholder_views.end(),
+                        [&](const PrivatePlaceholderView& view) {
+                            return view.base == target.base && view.size == target.size;
+                        });
+                    if (it != g_private_placeholder_views.end())
+                        g_private_placeholder_views.erase(it);
                 }
             }
         }
-        if (!section_overlap) {
+        if (!special_overlap) {
             host::guest_write_watch_notify_direct_mapping_removed(addr, len);
             return VirtualFree(reinterpret_cast<void*>(static_cast<uintptr_t>(addr)),
                                static_cast<SIZE_T>(len), MEM_DECOMMIT) != 0;
@@ -2447,6 +2744,18 @@ namespace {
 // Returns 0 for an unrelated, inaccessible, or invalid range so callers retain their normal guard.
 extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write) {
     return commit_sparse_dmem(addr, len, write != 0);
+}
+
+// Materialize one page of an uncommitted guest reservation on first touch. The legacy VEH path
+// still handles ordinary VirtualAlloc reservations; this helper owns only modern placeholders.
+extern "C" int prosper_try_commit_reserved_placeholder(uint64_t addr, uint64_t len) {
+    if (!len || (addr & 0xfff) || (len & 0xfff) || addr > UINT64_MAX - len) return 0;
+    std::lock_guard<std::mutex> lk(g_dview_mx);
+    if (private_placeholder_view_containing_locked(addr, addr + len)) return 1;
+    void* placeholder = take_guest_placeholder_locked(addr, len, 0x1000);
+    if (!placeholder) return 0;
+    return replace_placeholder_with_private_locked(
+               addr, len, HP_R | HP_W, PlaceholderOwner::Guest) != nullptr;
 }
 
 // Fault-handler lazy-commit probe parity (Linux exports this for its SIGSEGV handler). The Windows

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1283,10 +1283,11 @@ void register_kernel_mem_hle() {
 // What DIFFERS: the OS primitives. Linux uses mmap over a shared memfd so a phys offset can be
 // mapped at two VAs that ALIAS the same bytes (unified-physical-memory contract). One sparse
 // paging-file section backs the entire pool, matching the POSIX memfd implementation. Windows
-// file views require 64 KiB-aligned offsets and bases, so an unaligned guest physical offset is
-// represented by a view of the containing 64 KiB block plus an in-view delta. Exact hinted maps
-// whose VA/physical deltas are incompatible with that host constraint retain the old private
-// fallback; ordinary zero-hint allocations and congruent fixed maps preserve aliasing.
+// ordinary file views require 64 KiB-aligned offsets and bases. Modern placeholder replacement
+// removes that restriction: MapViewOfFile3 accepts page-aligned offsets/bases when replacing an
+// exact placeholder, so every 16 KiB guest mapping can preserve physical aliasing. The legacy
+// MapViewOfFileEx path remains for systems without the modern APIs, but never fakes a fixed direct
+// mapping with private memory.
 // ============================================================================================
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -1536,20 +1537,25 @@ namespace {
         void* view_base;
         uint64_t view_size;
         bool sparse;
+        bool placeholder;
         uint64_t page_cache_generation = 0;
         std::vector<uint64_t> committed_pages;
     };
+    struct PlaceholderSpan { uint64_t base, size; };
     std::mutex g_dview_mx;
     std::vector<DmemView> g_dviews;
+    std::vector<PlaceholderSpan> g_free_placeholders;
 
     using VirtualAlloc2Fn = PVOID (WINAPI*)(HANDLE, PVOID, SIZE_T, ULONG, ULONG,
                                             MEM_EXTENDED_PARAMETER*, ULONG);
     using MapViewOfFile3Fn = PVOID (WINAPI*)(HANDLE, HANDLE, PVOID, ULONG64, SIZE_T,
                                              ULONG, ULONG, MEM_EXTENDED_PARAMETER*, ULONG);
+    using UnmapViewOfFile2Fn = BOOL (WINAPI*)(HANDLE, PVOID, ULONG);
 
     struct PlaceholderApis {
         VirtualAlloc2Fn virtual_alloc2 = nullptr;
         MapViewOfFile3Fn map_view_of_file3 = nullptr;
+        UnmapViewOfFile2Fn unmap_view_of_file2 = nullptr;
     };
 
     const PlaceholderApis& placeholder_apis() {
@@ -1562,41 +1568,137 @@ namespace {
                     GetProcAddress(module, "VirtualAlloc2"));
                 out.map_view_of_file3 = reinterpret_cast<MapViewOfFile3Fn>(
                     GetProcAddress(module, "MapViewOfFile3"));
+                out.unmap_view_of_file2 = reinterpret_cast<UnmapViewOfFile2Fn>(
+                    GetProcAddress(module, "UnmapViewOfFile2"));
             }
             return out;
         }();
         return apis;
     }
 
-    void* map_sparse_aligned_section_view(HANDLE section, uint64_t file_off,
-                                          uint64_t view_size, uint64_t align) {
+    // g_free_placeholders describes exact Windows placeholder regions. These ranges are reserved
+    // in the host but free in the guest tracker; retaining a 16 KiB hole is what lets a later fixed
+    // direct map replace it even when adjacent guest pages occupy the same 64 KiB host granule.
+    void remember_free_placeholder_locked(uint64_t base, uint64_t size) {
+        if (!size) return;
+        g_free_placeholders.push_back({base, size});
+        std::sort(g_free_placeholders.begin(), g_free_placeholders.end(),
+                  [](const PlaceholderSpan& a, const PlaceholderSpan& b) {
+                      return a.base < b.base;
+                  });
+        for (size_t i = 1; i < g_free_placeholders.size();) {
+            PlaceholderSpan& left = g_free_placeholders[i - 1];
+            const PlaceholderSpan right = g_free_placeholders[i];
+            if (left.base + left.size != right.base) { ++i; continue; }
+            if (VirtualFree(reinterpret_cast<void*>(static_cast<uintptr_t>(left.base)),
+                            static_cast<SIZE_T>(left.size + right.size),
+                            MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS)) {
+                left.size += right.size;
+                g_free_placeholders.erase(g_free_placeholders.begin() + i);
+            } else {
+                ++i;
+            }
+        }
+    }
+
+    // Remove one exact page-aligned subrange from a free placeholder. VirtualFree with
+    // MEM_PRESERVE_PLACEHOLDER splits the Windows placeholder without releasing either side.
+    void* take_free_placeholder_locked(uint64_t hint, uint64_t len, uint64_t align) {
+        if (!len) return nullptr;
+        const uint64_t requested_align = align ? align : 0x1000;
+        for (size_t i = 0; i < g_free_placeholders.size(); ++i) {
+            const PlaceholderSpan span = g_free_placeholders[i];
+            uint64_t base = hint ? hint : align_up(span.base, requested_align);
+            if ((base & (requested_align - 1)) || base < span.base ||
+                base > UINT64_MAX - len ||
+                base + len > span.base + span.size) continue;
+            if (!hint && (base < kGuestAutoVaMin ||
+                          base + len - 1 > kGuestAutoVaMax)) continue;
+
+            const uint64_t prefix = base - span.base;
+            const uint64_t suffix = span.base + span.size - (base + len);
+            g_free_placeholders.erase(g_free_placeholders.begin() + i);
+            if (prefix && !VirtualFree(
+                    reinterpret_cast<void*>(static_cast<uintptr_t>(span.base)),
+                    static_cast<SIZE_T>(prefix),
+                    MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
+                remember_free_placeholder_locked(span.base, span.size);
+                return nullptr;
+            }
+            if (suffix && !VirtualFree(
+                    reinterpret_cast<void*>(static_cast<uintptr_t>(base)),
+                    static_cast<SIZE_T>(len),
+                    MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
+                if (prefix) {
+                    remember_free_placeholder_locked(span.base, prefix);
+                    remember_free_placeholder_locked(base, len + suffix);
+                } else {
+                    remember_free_placeholder_locked(span.base, span.size);
+                }
+                return nullptr;
+            }
+            if (prefix) remember_free_placeholder_locked(span.base, prefix);
+            if (suffix) remember_free_placeholder_locked(base + len, suffix);
+            return reinterpret_cast<void*>(static_cast<uintptr_t>(base));
+        }
+        return nullptr;
+    }
+
+    void* acquire_placeholder_locked(uint64_t hint, uint64_t len, uint64_t align) {
         const PlaceholderApis& apis = placeholder_apis();
         if (!apis.virtual_alloc2 || !apis.map_view_of_file3 ||
-            align < kWinAllocationGranularity || (align & (align - 1))) return nullptr;
+            !apis.unmap_view_of_file2 || !len || (len & 0xfff) ||
+            (align && (align & (align - 1)))) return nullptr;
+
+        if (void* recycled = take_free_placeholder_locked(hint, len, align)) return recycled;
+
+        if (hint) {
+            if (hint & 0xfff) return nullptr;
+            const uint64_t cover_base = hint & ~(kWinAllocationGranularity - 1);
+            const uint64_t end = hint + len;
+            if (end < hint) return nullptr;
+            const uint64_t cover_end = align_up(end, kWinAllocationGranularity);
+            void* cover = apis.virtual_alloc2(
+                GetCurrentProcess(),
+                reinterpret_cast<void*>(static_cast<uintptr_t>(cover_base)),
+                static_cast<SIZE_T>(cover_end - cover_base),
+                MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, nullptr, 0);
+            if (!cover) return nullptr;
+            remember_free_placeholder_locked(cover_base, cover_end - cover_base);
+            return take_free_placeholder_locked(hint, len, align);
+        }
 
         MEM_ADDRESS_REQUIREMENTS requirements{};
         requirements.LowestStartingAddress =
             reinterpret_cast<void*>(static_cast<uintptr_t>(kGuestAutoVaMin));
         requirements.HighestEndingAddress =
             reinterpret_cast<void*>(static_cast<uintptr_t>(kGuestAutoVaMax));
-        requirements.Alignment = static_cast<SIZE_T>(align);
+        requirements.Alignment = static_cast<SIZE_T>(
+            std::max<uint64_t>(align ? align : 0x4000, kWinAllocationGranularity));
         MEM_EXTENDED_PARAMETER parameter{};
         parameter.Type = MemExtendedParameterAddressRequirements;
         parameter.Pointer = &requirements;
-        void* placeholder = apis.virtual_alloc2(
-            GetCurrentProcess(), nullptr, static_cast<SIZE_T>(view_size),
+        return apis.virtual_alloc2(
+            GetCurrentProcess(), nullptr, static_cast<SIZE_T>(len),
             MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, &parameter, 1);
-        if (!placeholder) return nullptr;
+    }
 
+    void* map_placeholder_section_view(HANDLE section, uint64_t hint, uint64_t rel,
+                                       uint64_t len, uint64_t align) {
+        const PlaceholderApis& apis = placeholder_apis();
+        if (!apis.map_view_of_file3 || (rel & 0xfff)) return nullptr;
+        std::lock_guard<std::mutex> lk(g_dview_mx);
+        void* placeholder = acquire_placeholder_locked(hint, len, align);
+        if (!placeholder) return nullptr;
         void* view = apis.map_view_of_file3(
-            section, GetCurrentProcess(), placeholder, file_off,
-            static_cast<SIZE_T>(view_size), MEM_REPLACE_PLACEHOLDER,
+            section, GetCurrentProcess(), placeholder, rel,
+            static_cast<SIZE_T>(len), MEM_REPLACE_PLACEHOLDER,
             PAGE_READWRITE, nullptr, 0);
         if (!view) {
             const DWORD error = GetLastError();
-            VirtualFree(placeholder, 0, MEM_RELEASE);
+            remember_free_placeholder_locked(
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(placeholder)), len);
             SetLastError(error);
-            return nullptr;
         }
         return view;
     }
@@ -1609,39 +1711,34 @@ namespace {
         const uint64_t rel = phys - kDmemBase;
         const uint64_t file_off = rel & ~(kWinAllocationGranularity - 1);
         const uint64_t delta = rel - file_off;
-        const uint64_t view_size = align_up(delta + len, kWinAllocationGranularity);
-        void* requested = nullptr;
-        if (hint) {
-            if (hint < delta || ((hint - delta) & (kWinAllocationGranularity - 1)) != 0) {
-                MLOG("section map incompatible hint=0x%llx phys=0x%llx delta=0x%llx\n",
-                     (unsigned long long)hint, (unsigned long long)phys,
-                     (unsigned long long)delta);
-                return nullptr;
-            }
-            requested = (void*)(uintptr_t)(hint - delta);
-        }
-
+        uint64_t view_size = align_up(delta + len, kWinAllocationGranularity);
         const uint64_t requested_align = align ? align : 0x4000;
         bool sparse = false;
+        bool placeholder = false;
         void* view = nullptr;
-        // MapViewOfFileEx only chooses a 64 KiB-aligned base. A zero-hint title requesting a
-        // larger alignment needs a placeholder reservation with explicit address requirements.
-        // Keep the SEC_RESERVE pages uncommitted here; first CPU/GPU access materializes 16 KiB.
-        if (!hint &&
-            (requested_align <= kWinAllocationGranularity ||
-             (delta & (requested_align - 1)) == 0)) {
-            const uint64_t view_align = std::max<uint64_t>(
-                requested_align, kWinAllocationGranularity);
-            view = map_sparse_aligned_section_view(section, file_off, view_size, view_align);
-            sparse = view != nullptr;
-        }
+        // Placeholder replacement is page-granular, unlike MapViewOfFileEx. Map the guest range
+        // directly at its physical-section offset, with no 64 KiB congruence requirement.
+        view = map_placeholder_section_view(section, hint, rel, len, requested_align);
+        sparse = placeholder = view != nullptr;
         if (!view) {
+            void* requested = nullptr;
+            if (hint) {
+                if (hint < delta || ((hint - delta) & (kWinAllocationGranularity - 1)) != 0) {
+                    MLOG("section map incompatible hint=0x%llx phys=0x%llx delta=0x%llx\n",
+                         (unsigned long long)hint, (unsigned long long)phys,
+                         (unsigned long long)delta);
+                    return nullptr;
+                }
+                requested = (void*)(uintptr_t)(hint - delta);
+            }
             view = MapViewOfFileEx(section, FILE_MAP_ALL_ACCESS,
                                    (DWORD)(file_off >> 32), (DWORD)(file_off & 0xffffffffu),
                                    (SIZE_T)view_size, requested);
         }
         if (!view) return nullptr;
-        uint8_t* guest = (uint8_t*)view + delta;
+        uint8_t* guest = placeholder ? static_cast<uint8_t*>(view)
+                                     : static_cast<uint8_t*>(view) + delta;
+        if (placeholder) view_size = len;
 
         if (!hint && requested_align &&
             ((uint64_t)(uintptr_t)guest & (requested_align - 1)) != 0) {
@@ -1664,7 +1761,7 @@ namespace {
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
             DmemView tracked{
-                (uint64_t)(uintptr_t)guest, len, phys, view, view_size, sparse
+                (uint64_t)(uintptr_t)guest, len, phys, view, view_size, sparse, placeholder
             };
             if (sparse) {
                 const uint64_t pages = (len + 0x3fff) / 0x4000;
@@ -1676,7 +1773,7 @@ namespace {
         host::guest_write_watch_notify_direct_mapping_added(
             (uint64_t)(uintptr_t)guest, len, phys, win_page_prot(hp));
         if (sparse)
-            MLOG("map_dmem sparse aligned view va=0x%llx len=0x%llx phys=0x%llx align=0x%llx\n",
+            MLOG("map_dmem sparse placeholder view va=0x%llx len=0x%llx phys=0x%llx align=0x%llx\n",
                  (unsigned long long)(uintptr_t)guest, (unsigned long long)len,
                  (unsigned long long)phys, (unsigned long long)requested_align);
         return guest;
@@ -1919,6 +2016,9 @@ namespace {
         if (hint && !fixed) {
             if (void* p = map_section_view(0, len, hp, phys, align)) return p;
         }
+        // A private fixed mapping would report success while severing the physical alias contract.
+        // Older Windows versions without placeholder replacement fail visibly instead.
+        if (fixed) return nullptr;
         MLOG("map_dmem private fallback hint=0x%llx len=0x%llx phys=0x%llx align=0x%llx error=%lu\n",
              (unsigned long long)hint, (unsigned long long)len,
              (unsigned long long)phys, (unsigned long long)align, GetLastError());
@@ -2011,28 +2111,335 @@ namespace {
         }
         return true;
     }
-    // Shared section views must be released with UnmapViewOfFile. Anonymous/private mappings keep
-    // the old partial-safe decommit behavior.
-    void win_unmap(uint64_t addr, uint64_t len) {
-        if (!addr || !len) return;
-        void* section_view = nullptr;
+    struct ProtectionSlice { uint64_t base, size; int prot; };
+
+    std::vector<ProtectionSlice> tracked_protection_slices(uint64_t begin, uint64_t end) {
+        std::vector<ProtectionSlice> slices;
+        std::lock_guard<std::mutex> lk(g_mx);
+        for (const Mapping& mapping : g_maps) {
+            const uint64_t mapping_end = mapping.base + mapping.size;
+            const uint64_t overlap_begin = std::max(begin, mapping.base);
+            const uint64_t overlap_end = std::min(end, mapping_end);
+            if (overlap_begin < overlap_end && mapping.committed)
+                slices.push_back({overlap_begin, overlap_end - overlap_begin, mapping.prot});
+        }
+        std::sort(slices.begin(), slices.end(),
+                  [](const ProtectionSlice& a, const ProtectionSlice& b) {
+                      return a.base < b.base;
+                  });
+        return slices;
+    }
+
+    bool restore_view_protections(const DmemView& view) {
+        const auto slices = tracked_protection_slices(
+            view.guest_base, view.guest_base + view.guest_size);
+        for (const ProtectionSlice& slice : slices) {
+            uint64_t cursor = slice.base;
+            const uint64_t end = slice.base + slice.size;
+            while (cursor < end) {
+                MEMORY_BASIC_INFORMATION mbi{};
+                if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                                  &mbi, sizeof(mbi))) {
+                    MLOG("partial-unmap VirtualQuery failed va=0x%llx error=%lu\n",
+                         (unsigned long long)cursor, GetLastError());
+                    return false;
+                }
+                const uint64_t region_end = std::min<uint64_t>(
+                    end, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress)) +
+                             mbi.RegionSize);
+                if (region_end <= cursor || mbi.State == MEM_FREE) return false;
+                if (mbi.State == MEM_COMMIT) {
+                    DWORD old = 0;
+                    if (!VirtualProtect(
+                            reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                            static_cast<SIZE_T>(region_end - cursor),
+                            win_page_prot(slice.prot), &old)) {
+                        MLOG("partial-unmap VirtualProtect failed va=0x%llx len=0x%llx error=%lu\n",
+                             (unsigned long long)cursor,
+                             (unsigned long long)(region_end - cursor), GetLastError());
+                        return false;
+                    }
+                }
+                cursor = region_end;
+            }
+        }
+        return true;
+    }
+
+    void notify_view_watch_added(const DmemView& view) {
+        const auto slices = tracked_protection_slices(
+            view.guest_base, view.guest_base + view.guest_size);
+        for (const ProtectionSlice& slice : slices) {
+            host::guest_write_watch_notify_direct_mapping_added(
+                slice.base, slice.size,
+                view.phys + (slice.base - view.guest_base), win_page_prot(slice.prot));
+        }
+    }
+
+    bool replace_free_placeholder_with_view_locked(uint64_t base, uint64_t size, uint64_t phys,
+                                                   DmemView& out) {
+        const PlaceholderApis& apis = placeholder_apis();
+        HANDLE section = dmem_section();
+        if (!apis.map_view_of_file3 || !section || phys < kDmemBase) return false;
+        void* placeholder = take_free_placeholder_locked(base, size, 0x1000);
+        if (!placeholder) return false;
+        void* mapped = apis.map_view_of_file3(
+            section, GetCurrentProcess(), placeholder, phys - kDmemBase,
+            static_cast<SIZE_T>(size), MEM_REPLACE_PLACEHOLDER,
+            PAGE_READWRITE, nullptr, 0);
+        if (!mapped) {
+            remember_free_placeholder_locked(base, size);
+            return false;
+        }
+        out = DmemView{base, size, phys, mapped, size, true, true};
+        const uint64_t pages = (size + 0x3fff) / 0x4000;
+        out.committed_pages.resize((pages + 63) / 64);
+        out.page_cache_generation = host::guest_mapping_generation();
+        return true;
+    }
+
+    void invalidate_view_page_cache_locked(const DmemView& original) {
+        for (DmemView& view : g_dviews) {
+            if (view.view_base != original.view_base ||
+                view.guest_base != original.guest_base ||
+                view.guest_size != original.guest_size || view.phys != original.phys) continue;
+            std::fill(view.committed_pages.begin(), view.committed_pages.end(), 0);
+            view.page_cache_generation = 0;
+            return;
+        }
+    }
+
+    bool restore_legacy_view_locked(const DmemView& original) {
+        HANDLE section = dmem_section();
+        if (!section || original.phys < kDmemBase) return false;
+        const uint64_t rel = original.phys - kDmemBase;
+        const uint64_t file_off = rel & ~(kWinAllocationGranularity - 1);
+        void* mapped = MapViewOfFileEx(
+            section, FILE_MAP_ALL_ACCESS,
+            static_cast<DWORD>(file_off >> 32), static_cast<DWORD>(file_off & 0xffffffffu),
+            static_cast<SIZE_T>(original.view_size), original.view_base);
+        if (!mapped || mapped != original.view_base) {
+            if (mapped) UnmapViewOfFile(mapped);
+            return false;
+        }
+        if (!VirtualAlloc(reinterpret_cast<void*>(static_cast<uintptr_t>(original.guest_base)),
+                          static_cast<SIZE_T>(original.guest_size), MEM_COMMIT,
+                          PAGE_READWRITE) ||
+            !restore_view_protections(original)) {
+            UnmapViewOfFile(mapped);
+            return false;
+        }
+        return true;
+    }
+
+    struct UnmapChange {
+        DmemView original;
+        std::vector<DmemView> replacements;
+    };
+
+    bool rollback_unmap_change_locked(const UnmapChange& change) {
+        const PlaceholderApis& apis = placeholder_apis();
+        for (auto it = change.replacements.rbegin(); it != change.replacements.rend(); ++it) {
+            if (!apis.unmap_view_of_file2 ||
+                !apis.unmap_view_of_file2(GetCurrentProcess(), it->view_base,
+                                          MEM_PRESERVE_PLACEHOLDER)) return false;
+            remember_free_placeholder_locked(it->guest_base, it->guest_size);
+        }
+
+        bool restored = false;
+        if (change.original.placeholder) {
+            DmemView replacement;
+            restored = replace_free_placeholder_with_view_locked(
+                           change.original.guest_base, change.original.guest_size,
+                           change.original.phys, replacement) &&
+                       restore_view_protections(replacement);
+        } else {
+            restored = restore_legacy_view_locked(change.original);
+        }
+        if (restored) invalidate_view_page_cache_locked(change.original);
+        return restored;
+    }
+
+    bool split_placeholder_view_locked(const DmemView& old, uint64_t hole_begin,
+                                       uint64_t hole_end,
+                                       std::vector<DmemView>& replacements) {
+        const PlaceholderApis& apis = placeholder_apis();
+        if (!old.placeholder || !apis.unmap_view_of_file2 ||
+            !apis.unmap_view_of_file2(GetCurrentProcess(), old.view_base,
+                                      MEM_PRESERVE_PLACEHOLDER)) return false;
+        remember_free_placeholder_locked(old.guest_base, old.guest_size);
+
+        auto rollback = [&]() {
+            UnmapChange change{old, replacements};
+            const bool restored = rollback_unmap_change_locked(change);
+            replacements.clear();
+            if (!restored) {
+                std::fprintf(stderr,
+                             "[memhle] fatal: could not restore direct-memory view after "
+                             "partial-unmap failure\n");
+                std::abort();
+            }
+        };
+
+        const uint64_t left_size = hole_begin - old.guest_base;
+        const uint64_t right_size = old.guest_base + old.guest_size - hole_end;
+        if (left_size) {
+            DmemView left;
+            if (!replace_free_placeholder_with_view_locked(
+                    old.guest_base, left_size, old.phys, left)) {
+                rollback();
+                return false;
+            }
+            replacements.push_back(std::move(left));
+        }
+        if (right_size) {
+            DmemView right;
+            if (!replace_free_placeholder_with_view_locked(
+                    hole_end, right_size, old.phys + (hole_end - old.guest_base), right)) {
+                rollback();
+                return false;
+            }
+            replacements.push_back(std::move(right));
+        }
+        for (const DmemView& replacement : replacements) {
+            if (!restore_view_protections(replacement)) {
+                rollback();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool tracked_mappings_covered_by_views(uint64_t begin, uint64_t end,
+                                           const std::vector<DmemView>& views) {
+        std::vector<PlaceholderSpan> covered;
+        for (const DmemView& view : views) {
+            const uint64_t overlap_begin = std::max(begin, view.guest_base);
+            const uint64_t overlap_end = std::min(end, view.guest_base + view.guest_size);
+            if (overlap_begin < overlap_end)
+                covered.push_back({overlap_begin, overlap_end - overlap_begin});
+        }
+        std::sort(covered.begin(), covered.end(),
+                  [](const PlaceholderSpan& a, const PlaceholderSpan& b) {
+                      return a.base < b.base;
+                  });
+
+        std::lock_guard<std::mutex> lk(g_mx);
+        for (const Mapping& mapping : g_maps) {
+            const uint64_t overlap_begin = std::max(begin, mapping.base);
+            const uint64_t overlap_end = std::min(end, mapping.base + mapping.size);
+            if (overlap_begin >= overlap_end) continue;
+            uint64_t cursor = overlap_begin;
+            for (const PlaceholderSpan& span : covered) {
+                if (span.base + span.size <= cursor) continue;
+                if (span.base > cursor) break;
+                cursor = std::min(overlap_end, span.base + span.size);
+                if (cursor == overlap_end) break;
+            }
+            if (cursor != overlap_end) return false;
+        }
+        return true;
+    }
+
+    // Shared section views must be released with the view APIs. Placeholder-backed views can be
+    // split at the guest's 16 KiB boundary: unmap the old view back to a placeholder, replace the
+    // untouched prefix/suffix with views of their original physical offsets, and retain the hole as
+    // an inaccessible free placeholder for an exact future remap.
+    bool win_unmap(uint64_t addr, uint64_t len) {
+        if (!addr || !len || addr > UINT64_MAX - len) return false;
+        const uint64_t end = addr + len;
+        std::vector<DmemView> added;
+        bool section_overlap = false;
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
-            for (auto it = g_dviews.begin(); it != g_dviews.end(); ++it) {
-                if (it->guest_base == addr && it->guest_size == len) {
-                    section_view = it->view_base;
-                    g_dviews.erase(it);
-                    break;
+            std::vector<DmemView> targets;
+            for (const DmemView& view : g_dviews) {
+                if (addr < view.guest_base + view.guest_size && end > view.guest_base) {
+                    targets.push_back(view);
+                    const uint64_t cut_begin = std::max(addr, view.guest_base);
+                    const uint64_t cut_end = std::min(end, view.guest_base + view.guest_size);
+                    if ((cut_begin != view.guest_base || cut_end != view.guest_base + view.guest_size) &&
+                        !view.placeholder) return false;
+                }
+            }
+            std::sort(targets.begin(), targets.end(),
+                      [](const DmemView& a, const DmemView& b) {
+                          return a.guest_base < b.guest_base;
+                      });
+            section_overlap = !targets.empty();
+            if (section_overlap && !tracked_mappings_covered_by_views(addr, end, targets))
+                return false;
+
+            // Disarm any active physical write watch while every old alias is still mapped. On
+            // failure, the transaction restores both the views and their alias registrations.
+            for (const DmemView& target : targets)
+                host::guest_write_watch_notify_direct_mapping_removed(
+                    target.guest_base, target.guest_size);
+
+            std::vector<UnmapChange> changes;
+            changes.reserve(targets.size());
+            auto rollback = [&]() {
+                for (auto it = changes.rbegin(); it != changes.rend(); ++it) {
+                    if (!rollback_unmap_change_locked(*it)) {
+                        std::fprintf(stderr,
+                                     "[memhle] fatal: could not roll back direct-memory unmap\n");
+                        std::abort();
+                    }
+                }
+                for (const DmemView& target : targets) notify_view_watch_added(target);
+            };
+
+            for (const DmemView& target : targets) {
+                const uint64_t cut_begin = std::max(addr, target.guest_base);
+                const uint64_t cut_end = std::min(end, target.guest_base + target.guest_size);
+                UnmapChange change{target, {}};
+                bool ok = false;
+                if (cut_begin == target.guest_base &&
+                    cut_end == target.guest_base + target.guest_size) {
+                    if (target.placeholder) {
+                        const PlaceholderApis& apis = placeholder_apis();
+                        ok = apis.unmap_view_of_file2 &&
+                             apis.unmap_view_of_file2(GetCurrentProcess(), target.view_base,
+                                                     MEM_PRESERVE_PLACEHOLDER);
+                        if (ok) remember_free_placeholder_locked(
+                            target.guest_base, target.guest_size);
+                    } else {
+                        ok = UnmapViewOfFile(target.view_base) != 0;
+                    }
+                } else {
+                    ok = split_placeholder_view_locked(
+                        target, cut_begin, cut_end, change.replacements);
+                }
+                if (!ok) {
+                    rollback();
+                    return false;
+                }
+                changes.push_back(std::move(change));
+            }
+
+            for (const UnmapChange& change : changes) {
+                const DmemView& target = change.original;
+                auto it = std::find_if(g_dviews.begin(), g_dviews.end(),
+                    [&](const DmemView& view) {
+                        return view.view_base == target.view_base &&
+                               view.guest_base == target.guest_base &&
+                               view.guest_size == target.guest_size &&
+                               view.phys == target.phys;
+                    });
+                if (it != g_dviews.end()) g_dviews.erase(it);
+                for (const DmemView& replacement : change.replacements) {
+                    added.push_back(replacement);
+                    g_dviews.push_back(replacement);
                 }
             }
         }
-        if (section_view) {
+        if (!section_overlap) {
             host::guest_write_watch_notify_direct_mapping_removed(addr, len);
-            UnmapViewOfFile(section_view);
-            return;
+            return VirtualFree(reinterpret_cast<void*>(static_cast<uintptr_t>(addr)),
+                               static_cast<SIZE_T>(len), MEM_DECOMMIT) != 0;
         }
-        host::guest_write_watch_notify_direct_mapping_removed(addr, len);
-        VirtualFree((void*)addr, (SIZE_T)len, MEM_DECOMMIT);
+        for (const DmemView& view : added) notify_view_watch_added(view);
+        return true;
     }
 } // namespace
 
@@ -2184,7 +2591,9 @@ HLE7(k_map_dmem2) {
 }
 
 HLE(k_munmap)   { if (!a1) return 0x80020016ull;
-                  if (a0) { win_unmap(a0, a1); untrack(a0, a1); } return 0; }
+                  if (a0 && !win_unmap(a0, a1)) return 0x80020016ull;
+                  if (a0) untrack(a0, a1);
+                  return 0; }
 static uint64_t sce_win_mprotect_error(DWORD error) {
     switch (error) {
         case ERROR_ACCESS_DENIED:
@@ -2256,7 +2665,11 @@ HLE(k_batch_map) {
                 if (ok) track((uint64_t)p, len, host_prot(prot), true, "batch-flex");
                 break;
             }
-            case 1: if (start) { win_unmap(start, len); untrack(start, len); } break;   // UNMAP
+            case 1: {                               // UNMAP
+                ok = !start || win_unmap(start, len);
+                if (ok && start) untrack(start, len);
+                break;
+            }
             case 2: case 4:                                                              // PROTECT / TYPE_PROTECT
                 if (start) { win_protect(start, len, host_prot(prot));
                              retrack_prot(start, len, host_prot(prot), "batch-prot"); } break;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1941,6 +1941,50 @@ namespace {
         return true;
     }
 
+    bool tracked_mapping_protection(uint64_t begin, uint64_t end, int& hp) {
+        if (begin >= end) return false;
+        std::lock_guard<std::mutex> lk(g_mx);
+        const Mapping* best = nullptr;
+        for (const Mapping& mapping : g_maps) {
+            if (!mapping.committed || begin < mapping.base ||
+                begin >= mapping.base + mapping.size) continue;
+            if (!best || mapping.base > best->base) best = &mapping;
+        }
+        if (!best || end > best->base + best->size) return false;
+        hp = best->prot;
+        return true;
+    }
+
+    // SEC_RESERVE commitment is shared by every view of the physical page, but each view keeps
+    // its own protection contract. A page first committed through an RW alias can therefore make
+    // an untouched RO alias committed too; immediately apply every alias's tracked protection.
+    bool apply_dmem_page_protections_locked(uint64_t phys_page) {
+        if (phys_page > UINT64_MAX - 0x4000) return false;
+        const uint64_t generation = host::guest_mapping_generation();
+        for (DmemView& view : g_dviews) {
+            if (!view.sparse || phys_page < view.phys ||
+                phys_page + 0x4000 > view.phys + view.guest_size) continue;
+            const uint64_t alias_page = view.guest_base + (phys_page - view.phys);
+            int hp = 0;
+            if (!tracked_mapping_protection(alias_page, alias_page + 0x4000, hp)) return false;
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(alias_page)),
+                              &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT) return false;
+            DWORD old = 0;
+            if (!VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(alias_page)),
+                                0x4000, win_page_prot(hp), &old)) return false;
+
+            if (view.page_cache_generation != generation) {
+                std::fill(view.committed_pages.begin(), view.committed_pages.end(), 0);
+                view.page_cache_generation = generation;
+            }
+            const uint64_t index = (alias_page - view.guest_base) / 0x4000;
+            if (index / 64 >= view.committed_pages.size()) return false;
+            view.committed_pages[index / 64] |= 1ull << (index & 63);
+        }
+        return true;
+    }
+
     int commit_sparse_dmem(uint64_t addr, uint64_t len, bool write) {
         if (!len || addr > UINT64_MAX - len ||
             !sparse_dmem_view_contains(addr, addr + len)) return 0;
@@ -1986,7 +2030,8 @@ namespace {
                         if ((mbi.Protect & blocked) || !(mbi.Protect & readable) ||
                             (write && !(mbi.Protect & writable))) return 0;
                     }
-                    selected->committed_pages[index / 64] |= mask;
+                    const uint64_t phys_page = selected->phys + (page - selected->guest_base);
+                    if (!apply_dmem_page_protections_locked(phys_page)) return 0;
                 }
                 if (page == last) break;
             }
@@ -2012,11 +2057,18 @@ namespace {
                                        PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
                 if ((mbi.Protect & blocked) || !(mbi.Protect & readable) ||
                     (write && !(mbi.Protect & writable))) return 0;
-                const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
-                if (region_end > last) break;
-                if (region_end <= page) return 0;
-                page = (region_end + 0x3fff) & ~0x3fffull;
-                continue;
+            }
+            {
+                std::lock_guard<std::mutex> lk(g_dview_mx);
+                DmemView* selected = nullptr;
+                for (DmemView& view : g_dviews) {
+                    if (!view.sparse || page < view.guest_base ||
+                        page + 0x4000 > view.guest_base + view.guest_size) continue;
+                    selected = &view;
+                    break;
+                }
+                if (!selected || !apply_dmem_page_protections_locked(
+                        selected->phys + (page - selected->guest_base))) return 0;
             }
             if (page == last) break;
             page += 0x4000;
@@ -2056,6 +2108,19 @@ namespace {
         uint8_t* bytes = (uint8_t*)view + delta;
         if (VirtualAlloc(bytes, (SIZE_T)len, MEM_COMMIT, PAGE_READWRITE)) {
             memset(bytes, 0, (size_t)len);
+            bool protections_ok = true;
+            {
+                std::lock_guard<std::mutex> lk(g_dview_mx);
+                for (uint64_t page = phys; page < phys + len; page += 0x4000) {
+                    if (!apply_dmem_page_protections_locked(page)) {
+                        protections_ok = false;
+                        break;
+                    }
+                }
+            }
+            if (!protections_ok)
+                MLOG("dmem zero could not restore alias protections phys=0x%llx len=0x%llx\n",
+                     (unsigned long long)phys, (unsigned long long)len);
         } else {
             MLOG("dmem zero commit phys=0x%llx len=0x%llx failed error=%lu\n",
                  (unsigned long long)phys, (unsigned long long)len, GetLastError());
@@ -2136,10 +2201,32 @@ namespace {
                 std::lock_guard<std::mutex> lk(g_dview_mx);
                 if (private_placeholder_view_containing_locked(hint, hint + len)) {
                     placeholder_owned = true;
-                    DWORD old = 0;
-                    if (VirtualProtect(reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
-                                       static_cast<SIZE_T>(len), pp, &old))
-                        result = reinterpret_cast<void*>(static_cast<uintptr_t>(hint));
+                    bool needs_commit = false;
+                    uint64_t cursor = hint;
+                    while (cursor < hint + len) {
+                        MEMORY_BASIC_INFORMATION mbi{};
+                        if (!VirtualQuery(
+                                reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                                &mbi, sizeof(mbi)) || mbi.State == MEM_FREE) break;
+                        if (mbi.State == MEM_RESERVE) needs_commit = true;
+                        const uint64_t region_end = std::min<uint64_t>(
+                            hint + len,
+                            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress)) +
+                                mbi.RegionSize);
+                        if (region_end <= cursor) break;
+                        cursor = region_end;
+                    }
+                    if (cursor == hint + len) {
+                        if (!needs_commit || VirtualAlloc(
+                                reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+                                static_cast<SIZE_T>(len), MEM_COMMIT, pp)) {
+                            DWORD old = 0;
+                            if (VirtualProtect(
+                                    reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+                                    static_cast<SIZE_T>(len), pp, &old))
+                                result = reinterpret_cast<void*>(static_cast<uintptr_t>(hint));
+                        }
+                    }
                 } else {
                     PlaceholderOwner owner = PlaceholderOwner::Guest;
                     void* placeholder = take_guest_placeholder_locked(hint, len, 0x1000);
@@ -2548,15 +2635,20 @@ namespace {
     // untouched prefix/suffix with views of their original physical offsets, and retain the hole as
     // an inaccessible free placeholder for an exact future remap.
     bool win_unmap(uint64_t addr, uint64_t len) {
-        if (!addr || !len || (addr & 0xfff) || (len & 0xfff) ||
-            addr > UINT64_MAX - len) return false;
+        if (!addr || !len || addr > UINT64_MAX - len) return false;
         const uint64_t end = addr + len;
         std::vector<DmemView> added;
         bool special_overlap = false;
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
+            struct PrivateUnmapTarget {
+                PrivatePlaceholderView view;
+                uint64_t cut_base;
+                uint64_t cut_size;
+                bool whole;
+            };
             std::vector<DmemView> targets;
-            std::vector<PrivatePlaceholderView> private_targets;
+            std::vector<PrivateUnmapTarget> private_targets;
             std::vector<PlaceholderSpan> guest_cuts;
             std::vector<PlaceholderSpan> covered;
             for (const DmemView& view : g_dviews) {
@@ -2573,10 +2665,15 @@ namespace {
                 const uint64_t cut_begin = std::max(addr, view.base);
                 const uint64_t cut_end = std::min(end, view.base + view.size);
                 if (cut_begin >= cut_end) continue;
-                // Returning a private replacement to a placeholder releases the whole allocation.
-                // Refuse partial cuts instead of discarding retained bytes.
-                if (cut_begin != view.base || cut_end != view.base + view.size) return false;
-                private_targets.push_back(view);
+                const bool whole = cut_begin == view.base &&
+                                   cut_end == view.base + view.size;
+                // A whole replacement returns to a reusable placeholder. A partial unmap retains
+                // the private reservation and decommits only the requested guest pages, matching
+                // the former VirtualAlloc path without discarding prefix/suffix contents.
+                if (!whole && ((cut_begin & 0x3fff) || ((cut_end - cut_begin) & 0x3fff)))
+                    return false;
+                private_targets.push_back(
+                    {view, cut_begin, cut_end - cut_begin, whole});
                 covered.push_back({cut_begin, cut_end - cut_begin});
             }
             for (const PlaceholderSpan& span : g_guest_placeholders) {
@@ -2678,28 +2775,38 @@ namespace {
                 }
 
                 size_t private_unmapped = 0;
-                for (const PrivatePlaceholderView& view : private_targets) {
+                for (const PrivateUnmapTarget& target : private_targets) {
                     host::guest_write_watch_notify_direct_mapping_removed(
-                        view.base, view.size);
-                    if (!VirtualFree(
-                            reinterpret_cast<void*>(static_cast<uintptr_t>(view.base)),
-                            static_cast<SIZE_T>(view.size),
-                            MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
+                        target.cut_base, target.cut_size);
+                    const bool released = target.whole
+                        ? VirtualFree(
+                              reinterpret_cast<void*>(
+                                  static_cast<uintptr_t>(target.view.base)),
+                              static_cast<SIZE_T>(target.view.size),
+                              MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER) != 0
+                        : VirtualFree(
+                              reinterpret_cast<void*>(
+                                  static_cast<uintptr_t>(target.cut_base)),
+                              static_cast<SIZE_T>(target.cut_size), MEM_DECOMMIT) != 0;
+                    if (!released) {
                         MLOG("private placeholder release va=0x%llx len=0x%llx failed "
                              "error=%lu\n",
-                             (unsigned long long)view.base,
-                             (unsigned long long)view.size, GetLastError());
+                             (unsigned long long)target.cut_base,
+                             (unsigned long long)target.cut_size, GetLastError());
                         if (private_unmapped) {
                             std::fprintf(stderr,
                                          "[memhle] fatal: partial private-placeholder unmap\n");
                             std::abort();
                         }
-                        notify_private_watch_added(view);
+                        notify_private_watch_added(
+                            {target.cut_base, target.cut_size});
                         rollback_guest();
                         rollback_views();
                         return false;
                     }
-                    remember_free_placeholder_locked(view.base, view.size);
+                    if (target.whole)
+                        remember_free_placeholder_locked(
+                            target.view.base, target.view.size);
                     ++private_unmapped;
                 }
 
@@ -2718,12 +2825,14 @@ namespace {
                         g_dviews.push_back(replacement);
                     }
                 }
-                for (const PrivatePlaceholderView& target : private_targets) {
+                for (const PrivateUnmapTarget& target : private_targets) {
+                    if (!target.whole) continue;
                     auto it = std::find_if(
                         g_private_placeholder_views.begin(),
                         g_private_placeholder_views.end(),
                         [&](const PrivatePlaceholderView& view) {
-                            return view.base == target.base && view.size == target.size;
+                            return view.base == target.view.base &&
+                                   view.size == target.view.size;
                         });
                     if (it != g_private_placeholder_views.end())
                         g_private_placeholder_views.erase(it);

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2776,8 +2776,12 @@ namespace {
 
                 size_t private_unmapped = 0;
                 for (const PrivateUnmapTarget& target : private_targets) {
+                    // The notification API invalidates every overlapping AliasRange rather than
+                    // splitting one. Remove the complete private allocation deliberately, then
+                    // rebuild retained tracked slices after a successful partial decommit (or the
+                    // complete allocation if the host operation fails).
                     host::guest_write_watch_notify_direct_mapping_removed(
-                        target.cut_base, target.cut_size);
+                        target.view.base, target.view.size);
                     const bool released = target.whole
                         ? VirtualFree(
                               reinterpret_cast<void*>(
@@ -2798,15 +2802,23 @@ namespace {
                                          "[memhle] fatal: partial private-placeholder unmap\n");
                             std::abort();
                         }
-                        notify_private_watch_added(
-                            {target.cut_base, target.cut_size});
+                        notify_private_watch_added(target.view);
                         rollback_guest();
                         rollback_views();
                         return false;
                     }
-                    if (target.whole)
+                    if (target.whole) {
                         remember_free_placeholder_locked(
                             target.view.base, target.view.size);
+                    } else {
+                        if (target.view.base < target.cut_base)
+                            notify_private_watch_added(
+                                {target.view.base, target.cut_base - target.view.base});
+                        const uint64_t cut_end = target.cut_base + target.cut_size;
+                        const uint64_t view_end = target.view.base + target.view.size;
+                        if (cut_end < view_end)
+                            notify_private_watch_added({cut_end, view_end - cut_end});
+                    }
                     ++private_unmapped;
                 }
 

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -830,6 +830,7 @@ namespace {
     // 0 = untracked/gap, 1 = reserved, 2 = committed, 3 = sparse direct-memory page.
     extern "C" int prosper_reserved_range_state(uint64_t addr);
     extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
+    extern "C" int prosper_try_commit_reserved_placeholder(uint64_t addr, uint64_t len);
 
     LONG CALLBACK veh(EXCEPTION_POINTERS* ep) {
         CONTEXT* c = ep->ContextRecord;
@@ -928,7 +929,9 @@ namespace {
                 return EXCEPTION_CONTINUE_EXECUTION;
             if (a >= 0x1000000000ull && prosper_reserved_range_state(a) == 1) {
                 void* page = (void*)(uintptr_t)(a & ~(uint64_t)0x3fff);
-                if (VirtualAlloc(page, 0x4000, MEM_COMMIT, PAGE_READWRITE))
+                if (prosper_try_commit_reserved_placeholder(
+                        (uint64_t)(uintptr_t)page, 0x4000) ||
+                    VirtualAlloc(page, 0x4000, MEM_COMMIT, PAGE_READWRITE))
                     return EXCEPTION_CONTINUE_EXECUTION;   // re-execute against the now-committed page
             }
         }

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -43,6 +43,7 @@ int main() {
     // granularity span. The latter crosses this reservation and fails with ERROR_INVALID_ADDRESS.
     register_builtin_hle();
     auto reserve = Hle::lookup(nid_hash("sceKernelReserveVirtualRange"));
+    auto flexible = Hle::lookup(nid_hash("sceKernelMapNamedFlexibleMemory"));
     auto unmap   = Hle::lookup(nid_hash("sceKernelMunmap"));
     auto alloc   = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
     auto alloc_main = Hle::lookup(nid_hash("sceKernelAllocateMainDirectMemory"));
@@ -55,8 +56,8 @@ int main() {
     auto batch   = Hle::lookup(nid_hash("sceKernelBatchMap"));
     CHECK(nid_hash("sceKernelMapDirectMemory2") == "BQQniolj9tQ",
           "sceKernelMapDirectMemory2 hashes to the PS5 3.20 import NID");
-    CHECK(reserve && unmap && alloc && alloc_main && map && map2 && protect && release && query &&
-              batch,
+    CHECK(reserve && flexible && unmap && alloc && alloc_main && map && map2 && protect &&
+              release && query && batch,
           "memory HLE functions registered");
     if (fails) return 1;
 
@@ -233,16 +234,22 @@ int main() {
     // middle page must preserve both neighboring aliases and permit an exact remap of the hole.
     constexpr uint64_t fixed_len = 0x10000;
     constexpr uint64_t fixed_base = 0x30000104000ull; // 16 KiB into a free 64 KiB host granule
+    constexpr uint64_t readonly_base = 0x30000304000ull;
     uint64_t fixed_phys = 0, fixed_va = fixed_base, fixed_alias = 0;
+    uint64_t readonly_va = readonly_base;
     bool fixed_mapped = false, hole_remapped = false;
     CHECK(alloc(0, kEnd, fixed_len, 0x4000, 0,
                 (uint64_t)(uintptr_t)&fixed_phys) == 0 && fixed_phys,
           "allocate physical range for incompatible fixed mapping");
+    CHECK(reserve((uint64_t)(uintptr_t)&fixed_va, fixed_len,
+                  0x10 /* SCE_KERNEL_MAP_FIXED */, 0x4000, 0, 0) == 0 &&
+              fixed_va == fixed_base,
+          "reserve the exact range used by a fixed direct mapping");
     fixed_mapped = map((uint64_t)(uintptr_t)&fixed_va, fixed_len, 0x2,
                        0x10 /* SCE_KERNEL_MAP_FIXED */, fixed_phys, 0x4000) == 0 &&
                    fixed_va == fixed_base;
     CHECK(fixed_mapped,
-          "fixed 16 KiB placement ignores the host 64 KiB VA/physical delta restriction");
+          "fixed direct mapping replaces its own reservation at 16 KiB granularity");
     CHECK(map((uint64_t)(uintptr_t)&fixed_alias, fixed_len, 0x2, 0,
               fixed_phys, 0x4000) == 0 && fixed_alias,
           "map ordinary alias for incompatible fixed view");
@@ -257,6 +264,31 @@ int main() {
               *(volatile uint64_t*)(uintptr_t)(fixed_alias + 0xc100) ==
                   0x9999aaaabbbbccccull,
               "incompatible fixed view preserves physical alias coherence");
+
+        CHECK(reserve((uint64_t)(uintptr_t)&readonly_va, fixed_len,
+                      0x10 /* SCE_KERNEL_MAP_FIXED */, 0x4000, 0, 0) == 0 &&
+                  readonly_va == readonly_base,
+              "reserve an exact range for a read-only physical alias");
+        const bool readonly_mapped =
+            map((uint64_t)(uintptr_t)&readonly_va, fixed_len, 0x1,
+                0x10 /* SCE_KERNEL_MAP_FIXED */, fixed_phys, 0x4000) == 0 &&
+            readonly_va == readonly_base;
+        CHECK(readonly_mapped,
+              "map a fixed read-only alias after the physical pages are committed");
+        if (readonly_mapped) {
+            MEMORY_BASIC_INFORMATION readonly_info{};
+            VirtualQuery((void*)(uintptr_t)readonly_va, &readonly_info,
+                         sizeof(readonly_info));
+            CHECK(readonly_info.State == MEM_COMMIT &&
+                      (readonly_info.Protect & 0xff) == PAGE_READONLY,
+                  "new sparse alias applies its requested protection to existing pages");
+            CHECK(*(volatile uint64_t*)(uintptr_t)(readonly_va + 0x4100) ==
+                      0x5555666677778888ull,
+                  "read-only fixed alias sees the precommitted physical contents");
+            CHECK(unmap(readonly_va, fixed_len, 0, 0, 0, 0) == 0,
+                  "unmap the fixed read-only alias");
+            readonly_va = 0;
+        }
 
         CHECK((uint32_t)unmap(fixed_va + 0x4000, 0x4001, 0, 0, 0, 0) == 0x80020016u,
               "invalid partial unmap fails after restoring the original shared view");
@@ -290,6 +322,23 @@ int main() {
                   0x9999aaaabbbbccccull,
               "partial unmap preserves the prefix and suffix views");
 
+        uint64_t flexible_hole = hole;
+        const bool flexible_mapped =
+            flexible((uint64_t)(uintptr_t)&flexible_hole, 0x4000, 0x2, 0,
+                     (uint64_t)(uintptr_t)"placeholder-hole", 0) == 0 &&
+            flexible_hole == hole;
+        CHECK(flexible_mapped,
+              "flexible memory replaces a 16 KiB hole left by partial direct unmap");
+        if (flexible_mapped) {
+            *(volatile uint64_t*)(uintptr_t)(flexible_hole + 0x100) =
+                0xf1e81b1ecafebeefull;
+            CHECK(*(volatile uint64_t*)(uintptr_t)(fixed_alias + 0x4100) ==
+                      0x5555666677778888ull,
+                  "private reuse of the hole does not overwrite its physical page");
+            CHECK(unmap(flexible_hole, 0x4000, 0, 0, 0, 0) == 0,
+                  "flexible hole returns to an exact replaceable placeholder");
+        }
+
         uint64_t remapped_hole = hole;
         hole_remapped = map((uint64_t)(uintptr_t)&remapped_hole, 0x4000, 0x2,
                             0x10 /* SCE_KERNEL_MAP_FIXED */,
@@ -313,6 +362,8 @@ int main() {
               "split fixed mapping unmaps cleanly as one guest range");
     if (fixed_alias) CHECK(unmap(fixed_alias, fixed_len, 0, 0, 0, 0) == 0,
                            "unmap incompatible-view alias");
+    if (readonly_va) CHECK(unmap(readonly_va, fixed_len, 0, 0, 0, 0) == 0,
+                           "clean up reserved read-only alias range");
     if (fixed_phys) release(fixed_phys, fixed_len, 0, 0, 0, 0);
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -73,6 +73,64 @@ int main() {
     CHECK(*cell == 0x6310CAFEu, "first touch commits one guest page and preserves the write");
     CHECK(unmap(va, len, 0, 0, 0, 0) == 0, "reserved page unmaps cleanly");
 
+    // Placeholder-backed flexible memory must retain the old VirtualAlloc partial-unmap
+    // semantics: decommit only the requested guest page, preserve neighboring data, and allow
+    // the hole to be committed again in place.
+    constexpr uint64_t flexible_len = 0x10000;
+    uint64_t flexible_base = 0;
+    CHECK(reserve((uint64_t)(uintptr_t)&flexible_base, flexible_len, 0, 0x4000, 0, 0) == 0 &&
+              flexible_base,
+          "reserve a multi-page placeholder-backed flexible range");
+    uint64_t flexible_full = flexible_base;
+    const bool flexible_full_mapped = flexible_base &&
+        flexible((uint64_t)(uintptr_t)&flexible_full, flexible_len, 0x2, 0,
+                 (uint64_t)(uintptr_t)"partial-flexible", 0) == 0 &&
+        flexible_full == flexible_base;
+    CHECK(flexible_full_mapped,
+          "commit the full placeholder-backed flexible range");
+    if (flexible_full_mapped) {
+        *(volatile uint64_t*)(uintptr_t)(flexible_base + 0x0100) = 0x1111aaaabbbb2222ull;
+        *(volatile uint64_t*)(uintptr_t)(flexible_base + 0x4100) = 0x3333ccccdddd4444ull;
+        *(volatile uint64_t*)(uintptr_t)(flexible_base + 0xc100) = 0x5555eeeeffff6666ull;
+        CHECK(unmap(flexible_base + 0x4000, 0x4000, 0, 0, 0, 0) == 0,
+              "partial unmap decommits one page of a placeholder-backed flexible mapping");
+        MEMORY_BASIC_INFORMATION flexible_hole_info{}, flexible_prefix_info{},
+                                 flexible_suffix_info{};
+        VirtualQuery((void*)(uintptr_t)(flexible_base + 0x4000), &flexible_hole_info,
+                     sizeof(flexible_hole_info));
+        VirtualQuery((void*)(uintptr_t)flexible_base, &flexible_prefix_info,
+                     sizeof(flexible_prefix_info));
+        VirtualQuery((void*)(uintptr_t)(flexible_base + 0xc000), &flexible_suffix_info,
+                     sizeof(flexible_suffix_info));
+        CHECK(flexible_hole_info.State == MEM_RESERVE &&
+                  flexible_prefix_info.State == MEM_COMMIT &&
+                  flexible_suffix_info.State == MEM_COMMIT,
+              "partial flexible unmap preserves committed prefix and suffix pages");
+        CHECK(*(volatile uint64_t*)(uintptr_t)(flexible_base + 0x0100) ==
+                  0x1111aaaabbbb2222ull &&
+              *(volatile uint64_t*)(uintptr_t)(flexible_base + 0xc100) ==
+                  0x5555eeeeffff6666ull,
+              "partial flexible unmap preserves neighboring contents");
+        uint64_t flexible_hole = flexible_base + 0x4000;
+        const bool flexible_hole_mapped =
+            flexible((uint64_t)(uintptr_t)&flexible_hole, 0x4000, 0x2, 0,
+                     (uint64_t)(uintptr_t)"partial-flexible-hole", 0) == 0 &&
+            flexible_hole == flexible_base + 0x4000;
+        CHECK(flexible_hole_mapped,
+              "MapFlexible recommits the decommitted private page in place");
+        if (flexible_hole_mapped) {
+            *(volatile uint64_t*)(uintptr_t)(flexible_hole + 0x100) =
+                0x7777000011118888ull;
+            CHECK(*(volatile uint64_t*)(uintptr_t)(flexible_hole + 0x100) ==
+                      0x7777000011118888ull,
+                  "recommitted flexible page is writable");
+        }
+        CHECK(unmap(flexible_base, flexible_len, 0, 0, 0, 0) == 0,
+              "partially unmapped flexible allocation releases cleanly as one range");
+    } else if (flexible_base) {
+        unmap(flexible_base, flexible_len, 0, 0, 0, 0);
+    }
+
     alignas(8) uint8_t invalid_unmap[0x20]{};
     *(uint64_t*)(invalid_unmap + 0x00) = 0x30000020000ull;
     *(uint64_t*)(invalid_unmap + 0x10) = len;
@@ -213,14 +271,34 @@ int main() {
                   (writable_after.Protect & 0xff) == PAGE_READWRITE,
               "mprotect updates an existing sparse host page");
     }
-    CHECK(map((uint64_t)(uintptr_t)&sparse_va2, sparse_len, 0x2, 0,
+    CHECK(map((uint64_t)(uintptr_t)&sparse_va2, sparse_len, 0x1, 0,
               sparse_phys, sparse_align) == 0 && sparse_va2 && sparse_va2 != sparse_va1,
-          "map a second sparse view of the same physical range");
+          "map a second read-only sparse view of the same physical range");
     if (sparse_va1 && sparse_va2) {
         *(volatile uint64_t*)(uintptr_t)(sparse_va1 + 0x5120) = 0x5A17C0DE6310CAFEull;
         CHECK(*(volatile uint64_t*)(uintptr_t)(sparse_va2 + 0x5120) ==
                   0x5A17C0DE6310CAFEull,
               "sparse views retain physical alias coherence");
+
+        constexpr uint64_t late_commit_offset = 0x01800000;
+        MEMORY_BASIC_INFORMATION late_rw_before{}, late_ro_before{};
+        VirtualQuery((void*)(uintptr_t)(sparse_va1 + late_commit_offset),
+                     &late_rw_before, sizeof(late_rw_before));
+        VirtualQuery((void*)(uintptr_t)(sparse_va2 + late_commit_offset),
+                     &late_ro_before, sizeof(late_ro_before));
+        CHECK(late_rw_before.State == MEM_RESERVE && late_ro_before.State == MEM_RESERVE,
+              "inverse-order alias test starts with the physical page untouched");
+        *(volatile uint64_t*)(uintptr_t)(sparse_va1 + late_commit_offset + 0x120) =
+            0x1a7ec0de6310cafeull;
+        MEMORY_BASIC_INFORMATION late_ro_after{};
+        VirtualQuery((void*)(uintptr_t)(sparse_va2 + late_commit_offset),
+                     &late_ro_after, sizeof(late_ro_after));
+        CHECK(late_ro_after.State == MEM_COMMIT &&
+                  (late_ro_after.Protect & 0xff) == PAGE_READONLY,
+              "late physical commit reapplies the untouched alias's read-only protection");
+        CHECK(*(volatile uint64_t*)(uintptr_t)(sparse_va2 + late_commit_offset + 0x120) ==
+                  0x1a7ec0de6310cafeull,
+              "late-committed read-only alias remains physically coherent");
     }
     if (sparse_va1) CHECK(unmap(sparse_va1, sparse_len, 0, 0, 0, 0) == 0,
                           "unmap first sparse direct-memory view");

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -9,6 +9,7 @@
 #ifdef _WIN32
 #include "../src/host/exec_image.hpp"
 #include "../src/host/guest_memory_map.hpp"
+#include "../src/host/guest_write_watch.hpp"
 #include "../src/gpu/gpu_execute.hpp"
 #include <windows.h>
 extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
@@ -111,6 +112,13 @@ int main() {
               *(volatile uint64_t*)(uintptr_t)(flexible_base + 0xc100) ==
                   0x5555eeeeffff6666ull,
               "partial flexible unmap preserves neighboring contents");
+        auto flexible_prefix_watch = host::GuestWriteWatch::create(flexible_base, 0x4000);
+        auto flexible_suffix_watch = host::GuestWriteWatch::create(
+            flexible_base + 0xc000, 0x4000);
+        CHECK(flexible_prefix_watch && flexible_suffix_watch &&
+                  flexible_prefix_watch.query() == host::GuestWriteWatchQuery::Unchanged &&
+                  flexible_suffix_watch.query() == host::GuestWriteWatchQuery::Unchanged,
+              "partial flexible unmap rebuilds retained write-watch aliases");
         uint64_t flexible_hole = flexible_base + 0x4000;
         const bool flexible_hole_mapped =
             flexible((uint64_t)(uintptr_t)&flexible_hole, 0x4000, 0x2, 0,

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -52,9 +52,11 @@ int main() {
     auto protect = Hle::lookup(nid_hash("sceKernelMprotect"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
     auto query   = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
+    auto batch   = Hle::lookup(nid_hash("sceKernelBatchMap"));
     CHECK(nid_hash("sceKernelMapDirectMemory2") == "BQQniolj9tQ",
           "sceKernelMapDirectMemory2 hashes to the PS5 3.20 import NID");
-    CHECK(reserve && unmap && alloc && alloc_main && map && map2 && protect && release && query,
+    CHECK(reserve && unmap && alloc && alloc_main && map && map2 && protect && release && query &&
+              batch,
           "memory HLE functions registered");
     if (fails) return 1;
 
@@ -69,6 +71,15 @@ int main() {
     *cell = 0x6310CAFEu;
     CHECK(*cell == 0x6310CAFEu, "first touch commits one guest page and preserves the write");
     CHECK(unmap(va, len, 0, 0, 0, 0) == 0, "reserved page unmaps cleanly");
+
+    alignas(8) uint8_t invalid_unmap[0x20]{};
+    *(uint64_t*)(invalid_unmap + 0x00) = 0x30000020000ull;
+    *(uint64_t*)(invalid_unmap + 0x10) = len;
+    *(int32_t*)(invalid_unmap + 0x1c) = 1; // UNMAP
+    int32_t batch_done = -1;
+    CHECK(batch((uint64_t)(uintptr_t)invalid_unmap, 1,
+                (uint64_t)(uintptr_t)&batch_done, 0, 0, 0) != 0 && batch_done == 0,
+          "BatchMap reports an invalid host unmap instead of counting it as complete");
 
     // Direct memory is one physical pool, not private memory per virtual mapping. Dead Cells
     // releases and reuses small physical ranges aggressively; independent Windows allocations
@@ -215,6 +226,94 @@ int main() {
     if (sparse_va2) CHECK(unmap(sparse_va2, sparse_len, 0, 0, 0, 0) == 0,
                           "unmap second sparse direct-memory view");
     if (sparse_phys) release(sparse_phys, sparse_len, 0, 0, 0, 0);
+
+    // MapViewOfFileEx requires the virtual base and physical offset to have the same 64 KiB
+    // remainder. Placeholder replacement is page-granular, so an exact 16 KiB fixed mapping with
+    // incompatible remainders must still be a real shared section view. Partially unmapping its
+    // middle page must preserve both neighboring aliases and permit an exact remap of the hole.
+    constexpr uint64_t fixed_len = 0x10000;
+    constexpr uint64_t fixed_base = 0x30000104000ull; // 16 KiB into a free 64 KiB host granule
+    uint64_t fixed_phys = 0, fixed_va = fixed_base, fixed_alias = 0;
+    bool fixed_mapped = false, hole_remapped = false;
+    CHECK(alloc(0, kEnd, fixed_len, 0x4000, 0,
+                (uint64_t)(uintptr_t)&fixed_phys) == 0 && fixed_phys,
+          "allocate physical range for incompatible fixed mapping");
+    fixed_mapped = map((uint64_t)(uintptr_t)&fixed_va, fixed_len, 0x2,
+                       0x10 /* SCE_KERNEL_MAP_FIXED */, fixed_phys, 0x4000) == 0 &&
+                   fixed_va == fixed_base;
+    CHECK(fixed_mapped,
+          "fixed 16 KiB placement ignores the host 64 KiB VA/physical delta restriction");
+    CHECK(map((uint64_t)(uintptr_t)&fixed_alias, fixed_len, 0x2, 0,
+              fixed_phys, 0x4000) == 0 && fixed_alias,
+          "map ordinary alias for incompatible fixed view");
+    if (fixed_mapped && fixed_alias) {
+        *(volatile uint64_t*)(uintptr_t)(fixed_va + 0x0100) = 0x1111222233334444ull;
+        *(volatile uint64_t*)(uintptr_t)(fixed_va + 0x4100) = 0x5555666677778888ull;
+        *(volatile uint64_t*)(uintptr_t)(fixed_va + 0xc100) = 0x9999aaaabbbbccccull;
+        CHECK(*(volatile uint64_t*)(uintptr_t)(fixed_alias + 0x0100) ==
+                  0x1111222233334444ull &&
+              *(volatile uint64_t*)(uintptr_t)(fixed_alias + 0x4100) ==
+                  0x5555666677778888ull &&
+              *(volatile uint64_t*)(uintptr_t)(fixed_alias + 0xc100) ==
+                  0x9999aaaabbbbccccull,
+              "incompatible fixed view preserves physical alias coherence");
+
+        CHECK((uint32_t)unmap(fixed_va + 0x4000, 0x4001, 0, 0, 0, 0) == 0x80020016u,
+              "invalid partial unmap fails after restoring the original shared view");
+        CHECK(*(volatile uint64_t*)(uintptr_t)(fixed_va + 0x0100) ==
+                  0x1111222233334444ull &&
+              *(volatile uint64_t*)(uintptr_t)(fixed_va + 0x4100) ==
+                  0x5555666677778888ull &&
+              *(volatile uint64_t*)(uintptr_t)(fixed_alias + 0xc100) ==
+                  0x9999aaaabbbbccccull,
+              "failed partial-unmap transaction preserves data and physical aliases");
+
+        CHECK(protect(fixed_va, 0x4000, 0x1, 0, 0, 0) == 0,
+              "make fixed-view prefix read-only before partial unmap");
+
+        const uint64_t hole = fixed_va + 0x4000;
+        CHECK(unmap(hole, 0x4000, 0, 0, 0, 0) == 0,
+              "partial unmap removes one page from a shared section view");
+        MEMORY_BASIC_INFORMATION hole_info{};
+        VirtualQuery((void*)(uintptr_t)hole, &hole_info, sizeof(hole_info));
+        CHECK(hole_info.State == MEM_RESERVE &&
+                  !prosper_try_commit_dmem(hole, 0x4000, 0),
+              "partially unmapped page is an inaccessible, untracked placeholder");
+        MEMORY_BASIC_INFORMATION prefix_info{};
+        VirtualQuery((void*)(uintptr_t)fixed_va, &prefix_info, sizeof(prefix_info));
+        CHECK(prefix_info.State == MEM_COMMIT &&
+                  (prefix_info.Protect & 0xff) == PAGE_READONLY,
+              "partial unmap preserves the retained prefix protection");
+        CHECK(*(volatile uint64_t*)(uintptr_t)(fixed_va + 0x0100) ==
+                  0x1111222233334444ull &&
+              *(volatile uint64_t*)(uintptr_t)(fixed_va + 0xc100) ==
+                  0x9999aaaabbbbccccull,
+              "partial unmap preserves the prefix and suffix views");
+
+        uint64_t remapped_hole = hole;
+        hole_remapped = map((uint64_t)(uintptr_t)&remapped_hole, 0x4000, 0x2,
+                            0x10 /* SCE_KERNEL_MAP_FIXED */,
+                            fixed_phys + 0x4000, 0x4000) == 0 &&
+                        remapped_hole == hole;
+        CHECK(hole_remapped,
+              "fixed direct mapping replaces the exact 16 KiB placeholder hole");
+        if (hole_remapped) {
+            CHECK(*(volatile uint64_t*)(uintptr_t)(remapped_hole + 0x100) ==
+                      0x5555666677778888ull,
+                  "partial unmap/remap retains the physical page contents");
+            *(volatile uint64_t*)(uintptr_t)(remapped_hole + 0x100) =
+                0xd00df00dcafef00dull;
+            CHECK(*(volatile uint64_t*)(uintptr_t)(fixed_alias + 0x4100) ==
+                      0xd00df00dcafef00dull,
+                  "remapped placeholder hole remains coherent with its physical alias");
+        }
+    }
+    if (fixed_mapped)
+        CHECK(unmap(fixed_va, fixed_len, 0, 0, 0, 0) == 0,
+              "split fixed mapping unmaps cleanly as one guest range");
+    if (fixed_alias) CHECK(unmap(fixed_alias, fixed_len, 0, 0, 0, 0) == 0,
+                           "unmap incompatible-view alias");
+    if (fixed_phys) release(fixed_phys, fixed_len, 0, 0, 0, 0);
 
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Fixes #697.

## Failure scenario and contract

Windows' legacy section-view API requires 64 KiB-congruent virtual and physical offsets. A guest fixed map at a 16 KiB address with a different 64 KiB remainder could therefore fail or fall back to private memory and lose direct-memory aliasing. Partial `sceKernelMunmap` also could not safely remove one guest page from a shared section view.

Direct-memory mappings must preserve one shared physical backing at every virtual alias. Fixed maps must be exact, ordinary guest reservations must be replaceable by fixed direct views, and an unmapped 16 KiB hole must be reusable by either direct or flexible memory. Retained pages must keep their contents, protections, aliases, and write-watch registration.

## What changed

- Resolve `VirtualAlloc2`, `MapViewOfFile3`, and `UnmapViewOfFile2` dynamically and map direct-memory sections over exact page-granular placeholders.
- Track placeholder ownership explicitly as guest-free, guest-reserved, direct-backed, or private-backed. This enables reserve-to-fixed-direct replacement and direct-hole-to-flexible reuse without consuming another guest allocation.
- Return whole private placeholder replacements to reusable placeholders. Partial private unmap decommits only the requested 16 KiB pages, preserves neighboring content, rebuilds retained write-watch alias slices, and permits in-place flexible recommit.
- Route VEH first-touch and host file-I/O materialization through the same placeholder-aware reserved-page helper, with the legacy `VirtualAlloc` path retained for ordinary reservations.
- Apply requested protection to already committed physical pages in every newly created sparse alias, and reapply every alias's tracked protection whenever a shared page is committed later through another alias.
- Replace partial section unmap with a transaction that remaps retained prefix/suffix views at their original physical offsets, restores protections and write-watch aliases, and rolls back on failure.
- Refuse fixed direct mappings when shared backing cannot be created, and propagate host unmap failures through `sceKernelMunmap` and batch-map completion accounting.

The implementation follows Microsoft's contracts for [`VirtualAlloc2`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc2), [`MapViewOfFile3`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile3), [`UnmapViewOfFile2`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-unmapviewoffile2), and placeholder split/coalesce/release operations in [`VirtualFree`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree).

## Regression coverage

Windows tests now prove:

- a fixed direct map replaces its own reservation at an incompatible 16 KiB VA/physical delta;
- multiple virtual views remain physically alias-coherent;
- a newly mapped fixed read-only alias is actually `PAGE_READONLY` when physical pages were committed through another alias first;
- when RW and RO aliases start untouched, committing through RW also commits the RO alias with `PAGE_READONLY` intact;
- an invalid partial-unmap transaction enters rollback without losing data or aliasing;
- a valid middle-page direct unmap leaves an inaccessible, guest-untracked placeholder while retaining prefix/suffix state;
- flexible memory can replace that exact direct hole, remains private, unmaps back to a placeholder, and permits a later exact direct remap with original physical contents;
- a 64 KiB placeholder-backed flexible allocation supports 16 KiB middle-page unmap/recommit while preserving neighboring contents and fresh write-watch registrations;
- split and mixed placeholder-backed ranges unmap cleanly;
- lazy first-touch, protected reservation commit, and host file-read materialization continue to work;
- batch unmap does not count a failed host operation as complete.

## Deliberately unaffected

- Linux direct-memory behavior is unchanged.
- Fixed direct mappings never use a non-aliasing private substitute.
- No renderer or game-output path changes; snapshots are not applicable.
- Unpublished desktop-app parity is unrelated to this Windows core-memory fix.

## Exact-head gates

Head `9e480c88e9ba3ca52a1b3ce286908ad1208e6895`:

- `powershell -File prosper/tools/verify-pr.ps1 core`: PASS
- base-to-head `git diff --check`: PASS
- Linux build and ctest: PASS, 108/108
- Windows build and ctest: PASS, 82/82
- snapshots: not run (core-only change)
- independent inspection-only review: APPROVED

Verification and review comments identify this exact commit separately.