### PR TITLE
docs: keep realtime runs at native rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,10 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
 - **Reaching the running frame loop** needs two gated switches (off by default, so the default boot stays
   stable): `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`. Add `PROSPER_RENDER=1` to run the
   live renderer, `PROSPER_GFXLOG=1` for graphics diagnostics.
+- **Do not reuse snapshot acceleration for interactive or performance runs.** `PROSPER_RENDER_SCALE>1`,
+  `PROSPER_RENDER_EVERY>1`, and `PROSPER_RENDER_EVERY_FOR_MS` deliberately reduce resolution or skip
+  graphics submits. Keep the defaults (`PROSPER_RENDER_SCALE=1`, `PROSPER_RENDER_EVERY=1`, and no timed
+  sampling window) unless the run is explicitly a headless capture or sampling experiment.
 - **Correctness-first:** implement real behavior from primary evidence: live captures/traces, guest
   disassembly, published platform contracts, firmware symbol data, and focused tests. Do not ship shims
   that fake output. Mark genuinely uncertain code with `CONFIDENCE: HIGH/MED/LOW`.

--- a/prosper/scripts/evergate/README.md
+++ b/prosper/scripts/evergate/README.md
@@ -31,17 +31,23 @@ python3 tools/snapshot/snapshot.py check evergate-title
 
 ## Realtime harness
 
+Realtime and performance runs must render every submit at the guest's native resolution. The
+`--render-every 500` and `PROSPER_RENDER_SCALE=4` settings above are snapshot-only acceleration:
+carrying them into `prosper-app` skips visible updates during the opening and renders Evergate's
+1920x1080 output at 480x270 before scaling it to the window.
+
 ```sh
 PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
-PROSPER_RENDER_EVERY=500 \
-PROSPER_RENDER_EVERY_FOR_MS=90000 \
-PROSPER_RENDER_SCALE=4 \
+PROSPER_RENDER_EVERY=1 \
+PROSPER_RENDER_SCALE=1 \
 PROSPER_PAD_SCRIPT=@scripts/evergate/reach-first-gameplay.pad \
   ./build-linux-app/prosper-app --dump /path/to/PPSA01885-app0
 ```
 
 Use the equivalent environment variables with `prosper-app.exe` on Windows. The scripted input is
 composed with the normal SDL keyboard/controller backend, so the window remains interactive after
-the route reaches gameplay. Set `PROSPER_APP_DUMP_FRAMES=1` and `PROSPER_FRAME_DIR=/path/to/frames`
-to retain the exact composited frames consumed by the realtime harness.
+the route reaches gameplay. Ensure `PROSPER_RENDER_EVERY_FOR_MS` is unset if the process inherits a
+shell used for snapshot capture. Set `PROSPER_APP_DUMP_FRAMES=1` and
+`PROSPER_FRAME_DIR=/path/to/frames` to retain the exact composited frames consumed by the realtime
+harness.


### PR DESCRIPTION
## Summary

- keep Evergate realtime runs at native resolution and full render cadence
- document that snapshot sampling flags are unsuitable for interactive play or profiling
- add the same guardrail to the project-wide agent instructions

## Root cause

The realtime recipe copied `PROSPER_RENDER_SCALE=4` and the temporary one-in-500-submit snapshot cadence. For Evergate's 1920x1080 output, that produced a 480x270 rendered frame and sparse visible updates during the opening.

The emulator defaults remain unchanged. Headless snapshot configuration remains intentionally sampled and reduced-resolution.

## Verification

- `git diff --check`
- inspected the effective defaults in `hle_agc.cpp` (`PROSPER_RENDER_SCALE=1`, `PROSPER_RENDER_EVERY=1` when unset)