### PR TITLE
fix(windows): keep mprotect within guest-owned mappings

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2312,7 +2312,20 @@ namespace {
         if (!raw) return nullptr;
         return (void*)(((uint64_t)raw + (align - 1)) & ~(align - 1));
     }
-    bool tracked_reservation_covers(uint64_t begin, uint64_t end) {
+    struct TrackedMappingSlice {
+        uint64_t base;
+        uint64_t size;
+        int prot;
+        bool committed;
+    };
+
+    // Snapshot the tracker coverage for a protection transaction. VirtualQuery describes every
+    // committed host allocation in the process, including allocations that do not belong to the
+    // guest. A host MEM_COMMIT result therefore cannot prove that sceKernelMprotect owns the span.
+    bool tracked_mapping_slices(uint64_t begin, uint64_t end,
+                                std::vector<TrackedMappingSlice>& slices) {
+        slices.clear();
+        if (begin >= end) return false;
         std::lock_guard<std::mutex> lk(g_mx);
         uint64_t cursor = begin;
         while (cursor < end) {
@@ -2321,11 +2334,44 @@ namespace {
                 if (cursor < mapping.base || cursor >= mapping.base + mapping.size) continue;
                 if (!best || mapping.base > best->base) best = &mapping;
             }
-            if (!best || best->committed) return false;
-            cursor = std::min<uint64_t>(end, best->base + best->size);
+            if (!best) return false;
+            const uint64_t slice_end = std::min<uint64_t>(end, best->base + best->size);
+            slices.push_back({cursor, slice_end - cursor, best->prot, best->committed});
+            cursor = slice_end;
         }
         return true;
     }
+
+    bool tracked_slices_have_commit_state(const std::vector<TrackedMappingSlice>& slices,
+                                          uint64_t begin, uint64_t end, bool committed) {
+        uint64_t cursor = begin;
+        for (const TrackedMappingSlice& slice : slices) {
+            const uint64_t slice_end = slice.base + slice.size;
+            if (slice_end <= cursor || slice.base >= end) continue;
+            if (slice.base > cursor || slice.committed != committed) return false;
+            cursor = std::min<uint64_t>(end, slice_end);
+            if (cursor == end) return true;
+        }
+        return false;
+    }
+
+    bool tracked_slices_back_host_reservation(
+        const std::vector<TrackedMappingSlice>& slices, uint64_t begin, uint64_t end) {
+        uint64_t cursor = begin;
+        for (const TrackedMappingSlice& slice : slices) {
+            const uint64_t slice_end = slice.base + slice.size;
+            if (slice_end <= cursor || slice.base >= end) continue;
+            if (slice.base > cursor) return false;
+            const uint64_t overlap_end = std::min<uint64_t>(end, slice_end);
+            // A committed tracker entry may still be MEM_RESERVE when it is a sparse section view;
+            // every other committed entry must have committed host pages.
+            if (slice.committed && !sparse_dmem_view_contains(cursor, overlap_end)) return false;
+            cursor = overlap_end;
+            if (cursor == end) return true;
+        }
+        return false;
+    }
+
     bool win_protect(uint64_t addr, uint64_t len, int hp, DWORD* error_out = nullptr) {
         if (error_out) *error_out = ERROR_SUCCESS;
         if (!addr || !len || addr > UINT64_MAX - len) {
@@ -2336,9 +2382,15 @@ namespace {
         // Validate the complete span before changing either host protection or write-watch state.
         // Reserved (uncommitted) pages accept a tracking-only protection change, matching the POSIX
         // PROT_NONE reservation path; MEM_FREE makes the whole operation fail (#387 F3).
-        struct CommittedRegion { uint64_t base, size; };
-        std::vector<CommittedRegion> committed;
         const uint64_t end = addr + len;
+        std::vector<TrackedMappingSlice> tracked;
+        if (!tracked_mapping_slices(addr, end, tracked)) {
+            if (error_out) *error_out = ERROR_INVALID_ADDRESS;
+            return false;
+        }
+
+        struct CommittedRegion { uint64_t base, size; DWORD old_protection; };
+        std::vector<CommittedRegion> committed;
         uint64_t cursor = addr;
         while (cursor < end) {
             MEMORY_BASIC_INFORMATION mbi{};
@@ -2352,14 +2404,26 @@ namespace {
                 if (error_out) *error_out = ERROR_INVALID_ADDRESS;
                 return false;
             }
-            if (mbi.State == MEM_RESERVE &&
-                !tracked_reservation_covers(cursor, region_end) &&
-                !sparse_dmem_view_contains(cursor, region_end)) {
-                if (error_out) *error_out = ERROR_INVALID_ADDRESS;
-                return false;
+            if (mbi.State == MEM_RESERVE) {
+                if (!tracked_slices_back_host_reservation(tracked, cursor, region_end)) {
+                    if (error_out) *error_out = ERROR_INVALID_ADDRESS;
+                    return false;
+                }
+            } else if (mbi.State == MEM_COMMIT) {
+                if (!tracked_slices_have_commit_state(tracked, cursor, region_end, true)) {
+                    if (error_out) *error_out = ERROR_INVALID_ADDRESS;
+                    return false;
+                }
+                // Split at tracker boundaries so rollback restores the guest protection recorded
+                // before write-watch temporarily made any pages read-only.
+                for (const TrackedMappingSlice& slice : tracked) {
+                    const uint64_t overlap_begin = std::max(cursor, slice.base);
+                    const uint64_t overlap_end = std::min(region_end, slice.base + slice.size);
+                    if (overlap_begin < overlap_end)
+                        committed.push_back({overlap_begin, overlap_end - overlap_begin,
+                                             win_page_prot(slice.prot)});
+                }
             }
-            if (mbi.State == MEM_COMMIT)
-                committed.push_back({cursor, region_end - cursor});
             cursor = region_end;
         }
 
@@ -2367,15 +2431,32 @@ namespace {
         // restores its old writable pages. Unrelated mappings leave existing watches armed.
         host::guest_write_watch_notify_direct_mapping_protection(
             addr, len, win_page_prot(hp));
+        size_t changed = 0;
         for (const auto& region : committed) {
             DWORD old = 0;
             if (!VirtualProtect((void*)(uintptr_t)region.base, (SIZE_T)region.size,
                                 win_page_prot(hp), &old)) {
                 const DWORD error = GetLastError();
-                host::guest_write_watch_notify_direct_mapping_removed(addr, len);
+                for (size_t i = changed; i > 0; --i) {
+                    const CommittedRegion& prior = committed[i - 1];
+                    DWORD ignored = 0;
+                    if (!VirtualProtect((void*)(uintptr_t)prior.base,
+                                        (SIZE_T)prior.size, prior.old_protection, &ignored)) {
+                        std::fprintf(stderr,
+                                     "[memhle] fatal: could not roll back mprotect at 0x%llx\n",
+                                     (unsigned long long)prior.base);
+                        std::abort();
+                    }
+                }
+                for (const TrackedMappingSlice& slice : tracked) {
+                    if (slice.committed)
+                        host::guest_write_watch_notify_direct_mapping_protection(
+                            slice.base, slice.size, win_page_prot(slice.prot));
+                }
                 if (error_out) *error_out = error;
                 return false;
             }
+            changed++;
         }
         return true;
     }
@@ -3041,7 +3122,14 @@ HLE(k_mprotect) {
     retrack_prot(a0, a1, prot, "mprotect");
     return 0;
 }
-HLE(k_mtypeprotect) { if (a0) { win_protect(a0, a1, host_prot(a3)); retrack_prot(a0, a1, host_prot(a3), "mtypeprotect"); } return 0; }
+HLE(k_mtypeprotect) {
+    if (!a0) return 0x80020016ull;
+    const int prot = host_prot(a3);
+    DWORD error = ERROR_SUCCESS;
+    if (!win_protect(a0, a1, prot, &error)) return sce_win_mprotect_error(error);
+    retrack_prot(a0, a1, prot, "mtypeprotect");
+    return 0;
+}
 HLE(k_dmem_size){ return kDmemTotal; }
 // sceKernelAvailableDirectMemorySize(searchStart, searchEnd, align, off_t* physOut, size_t* sizeOut)
 HLE(k_avail_dmem) {
@@ -3100,9 +3188,17 @@ HLE(k_batch_map) {
                 if (ok && start) untrack(start, len);
                 break;
             }
-            case 2: case 4:                                                              // PROTECT / TYPE_PROTECT
-                if (start) { win_protect(start, len, host_prot(prot));
-                             retrack_prot(start, len, host_prot(prot), "batch-prot"); } break;
+            case 2: case 4: {                                                            // PROTECT / TYPE_PROTECT
+                if (start) {
+                    DWORD error = ERROR_SUCCESS;
+                    ok = win_protect(start, len, host_prot(prot), &error);
+                    if (ok)
+                        retrack_prot(start, len, host_prot(prot), "batch-prot");
+                    else
+                        ret = sce_win_mprotect_error(error);
+                }
+                break;
+            }
             default: ok = false; ret = 0x80020016ull; break;
         }
         if (!ok) { if (!ret) ret = 0x8002000Cull; break; }

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -7,6 +7,9 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 using namespace prosper;
 
@@ -21,10 +24,13 @@ int main() {
     register_builtin_hle();
     auto reserve  = Hle::lookup(nid_hash("sceKernelReserveVirtualRange"));
     auto protect  = Hle::lookup(nid_hash("sceKernelMprotect"));
+    auto mtypeprotect = Hle::lookup(nid_hash("sceKernelMtypeprotect"));
+    auto batch    = Hle::lookup(nid_hash("sceKernelBatchMap"));
     auto query    = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
     auto flexible = Hle::lookup(nid_hash("sceKernelMapNamedFlexibleMemory"));
     auto unmap    = Hle::lookup(nid_hash("sceKernelMunmap"));
-    CHECK(reserve && protect && query && flexible && unmap, "memory HLE functions registered");
+    CHECK(reserve && protect && mtypeprotect && batch && query && flexible && unmap,
+          "memory HLE functions registered");
     if (fails) return 1;
 
     constexpr uint64_t page = 0x10000;
@@ -51,6 +57,76 @@ int main() {
               *(uint64_t*)(failed_info + 0x08) == base + len &&
               *(uint32_t*)(failed_info + 0x20) == 0,
           "failed mprotect leaves reservation tracking unchanged");
+
+#ifdef _WIN32
+    // #926: MEM_COMMIT says that a host allocation exists, not that it belongs to the guest. Put
+    // one tracked guest page and one unrelated host-committed page in a single host reservation so
+    // the boundary-crossing failure is deterministic regardless of the process address layout.
+    void* host_reservation = VirtualAlloc(nullptr, page * 2, MEM_RESERVE, PAGE_NOACCESS);
+    CHECK(host_reservation != nullptr, "reserve deterministic guest/host ownership test span");
+    if (host_reservation) {
+        const uint64_t host_base = (uint64_t)(uintptr_t)host_reservation;
+        uint64_t guest_page = host_base;
+        const bool guest_map_succeeded =
+            flexible((uint64_t)(uintptr_t)&guest_page, page, 0x2, 0,
+                     (uint64_t)(uintptr_t)"mprotect-ownership", 0) == 0 && guest_page;
+        const bool guest_mapped = guest_map_succeeded && guest_page == host_base;
+        CHECK(guest_mapped, "commit and track the first page as guest memory");
+
+        void* foreign_page = nullptr;
+        if (guest_mapped) {
+            foreign_page = VirtualAlloc((void*)(uintptr_t)(host_base + page), page,
+                                        MEM_COMMIT, PAGE_READWRITE);
+        }
+        CHECK(foreign_page == (void*)(uintptr_t)(host_base + page),
+              "commit the adjacent page outside the guest tracker");
+
+        if (guest_mapped && foreign_page) {
+            volatile uint32_t* guest_cell =
+                (volatile uint32_t*)(uintptr_t)(host_base + page / 4);
+            volatile uint32_t* foreign_cell =
+                (volatile uint32_t*)(uintptr_t)(host_base + page + page / 4);
+            *guest_cell = 0x9260A11Cu;
+            *foreign_cell = 0x9260F012u;
+
+            const uint64_t crossing = host_base + page / 2;
+            CHECK((uint32_t)protect(crossing, page, 0x1, 0, 0, 0) == 0x80020016u,
+                  "mprotect rejects a committed tail outside guest ownership");
+            CHECK((uint32_t)mtypeprotect(crossing, page, 0, 0x1, 0, 0) == 0x80020016u,
+                  "mtypeprotect rejects the same unowned committed tail");
+
+            alignas(8) uint8_t entry[0x20]{};
+            *(uint64_t*)(entry + 0x00) = crossing;
+            *(uint64_t*)(entry + 0x10) = page;
+            entry[0x18] = 0x1;
+            *(int32_t*)(entry + 0x1c) = 2; // PROTECT
+            int32_t done = -1;
+            CHECK((uint32_t)batch((uint64_t)(uintptr_t)entry, 1,
+                                  (uint64_t)(uintptr_t)&done, 0, 0, 0) == 0x80020016u &&
+                      done == 0,
+                  "BatchMap protection failure is not counted or retracked");
+
+            MEMORY_BASIC_INFORMATION guest_mbi{}, foreign_mbi{};
+            VirtualQuery((const void*)(uintptr_t)host_base, &guest_mbi, sizeof(guest_mbi));
+            VirtualQuery((const void*)(uintptr_t)(host_base + page), &foreign_mbi,
+                         sizeof(foreign_mbi));
+            CHECK(guest_mbi.State == MEM_COMMIT &&
+                      (guest_mbi.Protect & 0xffu) == PAGE_READWRITE &&
+                      *guest_cell == 0x9260A11Cu,
+                  "failed protection calls leave the guest page unchanged");
+            CHECK(foreign_mbi.State == MEM_COMMIT &&
+                      (foreign_mbi.Protect & 0xffu) == PAGE_READWRITE &&
+                      *foreign_cell == 0x9260F012u,
+                  "failed protection calls leave unrelated host memory unchanged");
+        }
+
+        if (guest_map_succeeded)
+            CHECK(unmap(guest_page, page, 0, 0, 0, 0) == 0,
+                  "tracked ownership-test page unmaps cleanly");
+        CHECK(VirtualFree(host_reservation, 0, MEM_RELEASE) != 0,
+              "ownership-test host reservation releases cleanly");
+    }
+#endif
 
     const uint64_t middle = base + page;
     CHECK(protect(middle, page, 0x2 /* SCE_KERNEL_PROT_CPU_RW */, 0, 0, 0) == 0,


### PR DESCRIPTION
## Summary

- require every Windows protection span to be covered by guest mapping tracking
- distinguish tracked reservations, committed guest pages, and sparse direct-memory views from unrelated host allocations
- roll back earlier host protection changes if a later region fails
- propagate failures transactionally through `sceKernelMtypeprotect` and BatchMap protect operations
- make the adjacent committed-host-page regression deterministic

## Root cause

`win_protect` treated any `MEM_COMMIT` range returned by `VirtualQuery` as authorized guest memory. A boundary-crossing guest request could therefore reach an unrelated committed host allocation, change its protection, and then retag guest tracking in callers that ignored the failure.

## Impact

Malformed or boundary-crossing protection requests now fail with `SCE_KERNEL_ERROR_EINVAL` before changing host memory or guest tracking. Valid committed, reserved, and sparse direct-memory ranges remain supported.

## Focused validation

- Windows `retrack_reservation`: passed repeatedly (20 consecutive runs)
- Windows `dmem_available`: passed
- Linux `retrack_reservation`: passed
- `git diff --check`: passed

The exact-head core verifier and inspection-only review will be posted separately. No snapshots are required because renderer output is unchanged.

Closes #926