### PR TITLE
perf: accelerate Evergate renderer hot paths

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -251,13 +251,15 @@ graphics and compute pools. Decoded texture scratch vectors are also retained ac
 are storage only, and every partial decode/read explicitly clears its unwritten tail.
 
 Within one renderer callback, repeated guest-backed texture descriptions reuse the first decoded
-pixel buffer. A bounded process-wide cache also covers guest-backed linear and tiled `Unorm8x4`
-sampled textures, the common sprite-atlas cases. Every cross-submit lookup compares the complete guest
-source before reusing decoded pixels; the linear path compares directly against its decoded copy while
-the tiled path retains and compares the padded tiled source. Changed bytes, a changed mapping extent,
-or address reuse invalidates the entry and creates a new content-version ID. Live render targets,
-storage images, captured host backing, and other formats remain excluded. The default budget is
-256 MiB; use `PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change it or
+pixel buffer. A bounded process-wide cache also covers guest-backed linear and tiled 2D sampled
+textures in `Unorm8` component widths 1-4 and BC1-BC7 formats. Every cross-submit lookup validates
+the exact source range before reusing decoded pixels: direct narrow sources compare their native
+bytes, tiled sources retain the padded tiled range, and block-compressed sources use their exact
+block dimensions and block size. Changed bytes, mapping/readability changes, or address reuse
+invalidates the entry and creates a new content-version ID. Live render targets, storage images,
+captured host backing, cube/volume textures, DCC surfaces, and other formats remain excluded. The
+default budget is 1 GiB, which covers Evergate's measured 835 MiB working set; use
+`PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change it or
 `PROSPER_NO_TEXTURE_DECODE_CACHE=1` for an A/B run. Timing reports cross-submit `texture_cache`
 hits/misses/invalidations separately from `textures` (all texture uses) and `reused` (both local and
 persistent decodes avoided).
@@ -279,6 +281,13 @@ current guest addresses and backing data remain on each draw and are never cache
 `PROSPER_SHADER_CACHE_MB=<MiB>` to change the byte budget. `test_shader_recompile_cache` compares
 every tested miss byte-for-byte with the direct recompiler and verifies that runtime-only resource
 changes hit while descriptor-interface changes miss.
+
+Shader code span, PC-relative dispatch metadata, and fragment interpolation discovery use a separate
+64 MiB immutable-analysis cache. Every lookup validates the complete instruction/embedded-table span
+byte-for-byte, so same-address shader patching invalidates the entry. Concrete user SGPRs, descriptor
+table bytes, guest addresses, and resource backing remain per-draw inputs and are never reused by this
+cache. Set `PROSPER_NO_SHADER_ANALYSIS_CACHE=1` for the direct-analysis A/B or
+`PROSPER_SHADER_ANALYSIS_CACHE_MB=<MiB>` to change its budget.
 
 The Vulkan backend retains graphics pipelines across render-target calls. Live draws carry a
 process-unique, never-recycled identity from the exact shader cache, so a hot lookup does not copy or

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -53,13 +53,42 @@ resolution. Its key includes a copy of the decoded shader bytes, so same-address
 detected. It is bounded to 64 MiB by default and can be disabled with
 `PROSPER_NO_SHADER_DECODE_CACHE=1`.
 
-The persistent texture cache covers only guest-backed tiled `Unorm8x4` sampled textures. It excludes
-render targets, storage images, and unsupported formats. Every hit copies and compares the complete
-padded source before reusing decoded pixels, so address reuse and in-place mutation invalidate the
-entry. In the measured scene it produced 42 persistent hits and 14 callback-local hits out of 57
-texture uses, retained 101 entries / about 75 MiB, and observed no invalidation. Disable it with
-`PROSPER_NO_TEXTURE_DECODE_CACHE=1`; its default 256 MiB budget is controlled by
+The persistent texture cache now covers guest-backed linear/tiled 2D sampled `Unorm8` textures with
+1-4 components and BC1-BC7 textures. It excludes render targets, storage images, cube/volume and DCC
+surfaces, captured host backing, and unsupported formats. Every hit validates the complete native,
+padded-tiled, or compressed-block source range, so address reuse and in-place mutation invalidate the
+entry. Its default 1 GiB budget covers Evergate's measured 835 MiB decoded working set. Disable it with
+`PROSPER_NO_TEXTURE_DECODE_CACHE=1`; the budget is controlled by
 `PROSPER_TEXTURE_DECODE_CACHE_MB`.
+
+## Evergate native-render transition (2026-07-18)
+
+Evergate's title screen and new-game transition exercise roughly 1,000 sampled-texture references and
+470-490 draws per native 1920x1080 submit. On Windows / RTX 4090, full cadence and a fresh save, the
+original 256 MiB `Unorm8x4`-only cache repeatedly decoded large BC atlases and fell to about 0.9 FPS.
+BC/narrow-format coverage plus the 1 GiB default retains about 835 MiB of decoded pixels, removes
+steady-transition decode misses, and reduces frontend resource construction from about 421 ms to
+38-40 ms.
+
+After texture decoding stopped dominating, per-draw immutable shader analysis was the next hotspot.
+Shader code span, PC-relative dispatch metadata, and fragment interpolation layout are now shared from
+a 64 MiB cache only after exact validation of the complete instruction/embedded-table byte span.
+Concrete SGPRs, descriptor tables, addresses, and backing bytes are still rebuilt for every draw.
+
+Matched dense windows were:
+
+| Measurement | Texture cache only | + immutable shader analysis |
+|---|---:|---:|
+| Draws / submit | 469-474 | 470-488 |
+| Core submit | 572-579 ms | 426-449 ms |
+| Draw realization | 222-223 ms | 55-61 ms |
+| Stage tables | 93-94 ms | 20-22 ms |
+| Shader lookup/analysis | 110 ms | 17-19 ms |
+| App rate at the dense transition | 1.7-1.9 FPS | 2.1 FPS |
+
+The following lower-draw intro windows reached 2.6 FPS. Backend execution remains about 360-388 ms in
+the dense scene and is now the dominant cost. `PROSPER_NO_SHADER_ANALYSIS_CACHE=1` restores direct
+analysis for comparison; `PROSPER_SHADER_ANALYSIS_CACHE_MB=<MiB>` changes the analysis budget.
 
 ## Dead Cells backend upload duplication (2026-07-15)
 

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -215,12 +215,18 @@ bytes plus descriptor-interface semantics; `PROSPER_NO_SHADER_CACHE=1` disables 
 miss compilation time. Run `test_shader_recompile_cache` after changing the key or recompiler contract.
 Frontend windows also report texture resource uses as `textures` and callback-local duplicate decodes
 avoided as `reused`, plus exact-byte cross-submit `texture_cache` hits/misses/invalidations. The persistent
-cache is limited to guest-backed tiled `Unorm8x4` sampled textures and defaults to 256 MiB; use
+cache covers guest-backed linear/tiled 2D `Unorm8` (1-4 components) and BC1-BC7 sampled textures and
+defaults to 1 GiB; use
 `PROSPER_NO_TEXTURE_DECODE_CACHE=1` for an A/B or `PROSPER_TEXTURE_DECODE_CACHE_MB=<MiB>` to change the
 budget. Do not infer descriptor-table
 identity from shader/user-SGPR values alone:
 pointed-to guest memory is mutable, and that cache experiment stalled Messenger at its loading screen.
 See `FRONTEND_APP.md` for the invalidation requirement.
+
+Immutable shader span/dispatch/interpolation analysis is separately byte-validated and bounded to
+64 MiB. `PROSPER_NO_SHADER_ANALYSIS_CACHE=1` restores direct analysis for an A/B;
+`PROSPER_SHADER_ANALYSIS_CACHE_MB=<MiB>` changes the bound. This cache never stores concrete user
+SGPR or descriptor-table contents.
 
 Diagnostics (env, all off by default): `PROSPER_GFXLOG` (`[gfx]`/`[agc]` PM4 decode + the `NOT satisfied`
 fence log), `PROSPER_EVLOG` (`[ev]` equeue/flip/EOP), `PROSPER_SYNCLOG` (`[sync]` WaitOnAddress/Wake with

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -641,7 +641,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             static std::vector<uint8_t> persistent_validation_scratch;
             const size_t persistent_decode_limit = [] {
                 const char* value = getenv("PROSPER_TEXTURE_DECODE_CACHE_MB");
-                const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
+                const uint64_t mib = value ? strtoull(value, nullptr, 10) : 1024ull;
                 return static_cast<size_t>(std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull))) *
                        1024ull * 1024ull;
             }();
@@ -734,29 +734,45 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
-                        const bool persistent_rgba_texture =
+                        const uint32_t persistent_bc_block_bytes =
+                            prosper::gpu::bc_block_bytes(r.format);
+                        const bool persistent_unorm8_texture =
+                            r.format == prosper::gpu::DataFormat::Unorm8 &&
+                            r.num_components >= 1 && r.num_components <= 4;
+                        const bool persistent_sampled_texture =
                             !has_live_rtt && !r.host_data && r.img_dim == 1u &&
                             r.cls == RC::Texture &&
-                            r.format == prosper::gpu::DataFormat::Unorm8 &&
-                            r.num_components == 4;
+                            (persistent_unorm8_texture || persistent_bc_block_bytes != 0);
                         const bool persistent_source_is_tiled =
-                            persistent_rgba_texture && !getenv("PROSPER_NODETILE") &&
+                            persistent_sampled_texture && !getenv("PROSPER_NODETILE") &&
                             prosper::gpu::tile_mode_is_tiled(r.tile_mode);
                         const bool persistent_source_matches_pixels =
-                            persistent_rgba_texture &&
+                            persistent_unorm8_texture && r.num_components == 4 &&
                             !prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
                             (!getenv("PROSPER_DETILE") || atoi(getenv("PROSPER_DETILE")) == 0);
+                        const size_t persistent_source_size = [&] {
+                            if (!persistent_sampled_texture) return size_t{0};
+                            if (persistent_bc_block_bytes) {
+                                const uint32_t bw = (tw + 3) / 4;
+                                const uint32_t bh = (th + 3) / 4;
+                                return persistent_source_is_tiled
+                                    ? prosper::gpu::tiled_elements_bytes(
+                                          bw, bh, persistent_bc_block_bytes, r.tile_mode)
+                                    : static_cast<size_t>(bw) * bh * persistent_bc_block_bytes;
+                            }
+                            const uint32_t source_bpt = r.num_components;
+                            if (persistent_source_is_tiled)
+                                return prosper::gpu::tiled_surface_bytes(
+                                    tw, th, r.tile_mode, persistent_pitch, source_bpt);
+                            // Forced detiling treats a nominally linear Unorm8x4 descriptor as tiled.
+                            // Its decode source is therefore not the linear byte range computed here.
+                            if (source_bpt == 4 && !persistent_source_matches_pixels) return size_t{0};
+                            return static_cast<size_t>(tw) * th * source_bpt;
+                        }();
                         const bool persistent_cache_eligible = !fr.is_storage_image &&
                             !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
                             !r.compression_enabled &&
-                            persistent_decode_limit &&
-                            (persistent_source_is_tiled || persistent_source_matches_pixels);
-                        const size_t persistent_source_size = persistent_source_matches_pixels
-                            ? static_cast<size_t>(tw) * th * 4
-                            : (persistent_source_is_tiled
-                                ? prosper::gpu::tiled_surface_bytes(
-                                      tw, th, r.tile_mode, persistent_pitch)
-                                : 0);
+                            persistent_decode_limit && persistent_source_size != 0;
                         static const bool cross_submit_watch_enabled =
                             !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
                         static const bool audit_cross_submit_watch =

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -138,7 +138,8 @@ std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             const uint32_t* user_sgprs, uint32_t nsgpr,
                                             uint32_t user_sgpr_base,
                                             std::vector<SrtUse>* srt_uses = nullptr,
-                                            uint32_t pcrel_dispatch_target = UINT32_MAX);
+                                            uint32_t pcrel_dispatch_target = UINT32_MAX,
+                                            const PcrelDispatchInfo* pcrel_dispatch = nullptr);
 
 // Add instruction-provenance compute buffer resources to a metadata-built table. This is the exact
 // buffer-discovery path used by realize_compute_dispatches; it is exposed so tests can assert the
@@ -162,6 +163,21 @@ struct ShaderDecodeCacheStats {
 };
 ShaderDecodeCacheStats shader_decode_cache_stats();
 void clear_shader_decode_cache();
+
+// Immutable shader analysis shared by resource folding, interpolation discovery, and recompile-key
+// construction. Hits validate the complete code/table span byte-for-byte before reusing its bounds
+// and PC-relative dispatch metadata.
+struct ShaderAnalysisCacheStats {
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t bypasses = 0;
+    uint64_t invalidations = 0;
+    uint64_t evictions = 0;
+    uint64_t entries = 0;
+    uint64_t bytes = 0;
+};
+ShaderAnalysisCacheStats shader_analysis_cache_stats();
+void clear_shader_analysis_cache();
 
 // PROSPER_DYNTRACE_FAIL support (gpu_executor.cpp): while true, resolve_dynamic_fetch traces its
 // walk and build_stage_table dumps the user-data SGPR blocks. realize_draw_item sets it around a
@@ -256,6 +272,10 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        uint64_t* cache_identity = nullptr);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
+
+FragmentInterpolationLayout fragment_interpolation_layout_cached(
+    const uint32_t* code, size_t dwords,
+    const PixelSystemInputMapping* system_inputs = nullptr);
 
 struct DrawRealizationPhaseStats {
     uint64_t draws = 0;
@@ -547,7 +567,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const PixelSystemInputMapping* system_input_ptr =
         (system_inputs.ena || system_inputs.addr) ? &system_inputs : nullptr;
     const ResolvedPipelineState resolved_pipeline = resolve_pipeline_state(rs);
-    const FragmentInterpolationLayout interpolation = fragment_interpolation_layout(
+    const FragmentInterpolationLayout interpolation = fragment_interpolation_layout_cached(
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
         max_shader_dwords, system_input_ptr);
     uint64_t vs_identity = 0, fs_identity = 0;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -61,6 +61,7 @@ struct GuestGpuWriteJournal {
 };
 thread_local GuestGpuWriteJournal g_guest_gpu_writes;
 std::atomic<uint64_t> g_next_guest_gpu_submit_serial{0};
+std::atomic<uint64_t> g_next_shader_analysis_identity{0};
 
 bool ranges_overlap(uint64_t a, uint64_t a_size, uint64_t b, uint64_t b_size) {
     if (!a_size || !b_size) return false;
@@ -224,6 +225,60 @@ struct ShaderDecodeCache {
     uint64_t use_counter = 0;
 };
 
+struct ShaderCodeAnalysis {
+    std::vector<uint32_t> code;
+    PcrelDispatchInfo pcrel_dispatch;
+    uint64_t identity = 0;
+    size_t source_dwords = 0;
+    bool bounded_span = false;
+    uint64_t bytes = 0;
+};
+
+struct ShaderCodeAnalysisEntry {
+    std::shared_ptr<const ShaderCodeAnalysis> analysis;
+    uint64_t last_use = 0;
+};
+
+struct ShaderAnalysisCache {
+    std::mutex mutex;
+    std::unordered_map<uintptr_t, ShaderCodeAnalysisEntry> entries;
+    ShaderAnalysisCacheStats stats;
+    uint64_t use_counter = 0;
+};
+
+struct InterpolationCacheKey {
+    uint64_t analysis_identity = 0;
+    PixelSystemInputMapping system_inputs{};
+    bool has_system_inputs = false;
+
+    bool operator==(const InterpolationCacheKey&) const = default;
+};
+
+struct InterpolationCacheKeyHash {
+    size_t operator()(const InterpolationCacheKey& key) const {
+        uint64_t hash = 1469598103934665603ull;
+        hash = hash_mix(hash, key.analysis_identity);
+        hash = hash_mix(hash, key.has_system_inputs);
+        if (key.has_system_inputs) {
+            hash = hash_mix(hash, key.system_inputs.ena);
+            hash = hash_mix(hash, key.system_inputs.addr);
+        }
+        return static_cast<size_t>(hash);
+    }
+};
+
+struct CachedInterpolationLayout {
+    FragmentInterpolationLayout layout;
+    uint64_t last_use = 0;
+};
+
+struct InterpolationCache {
+    std::mutex mutex;
+    std::unordered_map<InterpolationCacheKey, CachedInterpolationLayout,
+                       InterpolationCacheKeyHash> entries;
+    uint64_t use_counter = 0;
+};
+
 struct StageFoldProfileEntry {
     uint64_t code = 0;
     uint32_t user_base = 0;
@@ -320,6 +375,16 @@ void record_stage_fold_profile(uint64_t code, uint32_t user_base, size_t code_dw
 
 ShaderDecodeCache& shader_decode_cache() {
     static ShaderDecodeCache cache;
+    return cache;
+}
+
+ShaderAnalysisCache& shader_analysis_cache() {
+    static ShaderAnalysisCache cache;
+    return cache;
+}
+
+InterpolationCache& interpolation_cache() {
+    static InterpolationCache cache;
     return cache;
 }
 
@@ -434,6 +499,89 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
     return decoded;
 }
 
+uint64_t shader_analysis_cache_limit_bytes() {
+    constexpr uint64_t default_bytes = 64ull * 1024 * 1024;
+    const char* value = getenv("PROSPER_SHADER_ANALYSIS_CACHE_MB");
+    if (!value || !*value) return default_bytes;
+    char* end = nullptr;
+    const unsigned long long mib = strtoull(value, &end, 10);
+    if (end == value || *end != '\0') return default_bytes;
+    return std::min<uint64_t>(mib, 1024ull) * 1024 * 1024;
+}
+
+std::shared_ptr<const ShaderCodeAnalysis> analyze_shader_code_cached(const uint32_t* code,
+                                                                      size_t dwords) {
+    auto analyze = [&] {
+        auto result = std::make_shared<ShaderCodeAnalysis>();
+        result->identity = ++g_next_shader_analysis_identity;
+        result->source_dwords = dwords;
+        const size_t span = rdna2_recompile_code_span(code, dwords);
+        result->bounded_span = span < dwords;
+        if (code && span) result->code.assign(code, code + span);
+        result->pcrel_dispatch = rdna2_pcrel_dispatch_info(code, dwords);
+        result->bytes = static_cast<uint64_t>(result->code.size()) * sizeof(uint32_t) +
+                        static_cast<uint64_t>(result->pcrel_dispatch.target_pcs.size()) *
+                            sizeof(uint32_t) +
+                        static_cast<uint64_t>(result->pcrel_dispatch.setup_pcs.size()) *
+                            sizeof(uint32_t);
+        return result;
+    };
+
+    if (!code || !dwords) return analyze();
+    auto& cache = shader_analysis_cache();
+    if (getenv("PROSPER_NO_SHADER_ANALYSIS_CACHE")) {
+        std::lock_guard lock(cache.mutex);
+        ++cache.stats.bypasses;
+        return analyze();
+    }
+
+    const uintptr_t address = reinterpret_cast<uintptr_t>(code);
+    {
+        std::lock_guard lock(cache.mutex);
+        auto found = cache.entries.find(address);
+        if (found != cache.entries.end()) {
+            const auto& cached = found->second.analysis;
+            const bool compatible_length = cached->bounded_span
+                ? cached->code.size() <= dwords : cached->source_dwords == dwords;
+            const uint64_t code_bytes = static_cast<uint64_t>(cached->code.size()) * sizeof(uint32_t);
+            const bool readable = code_bytes == 0 ||
+                                  (code_bytes <= UINT32_MAX &&
+                                   guest_readable(address, static_cast<uint32_t>(code_bytes)));
+            if (compatible_length && readable &&
+                (code_bytes == 0 ||
+                 memcmp(code, cached->code.data(), static_cast<size_t>(code_bytes)) == 0)) {
+                ++cache.stats.hits;
+                found->second.last_use = ++cache.use_counter;
+                return cached;
+            }
+            cache.stats.bytes -= cached->bytes;
+            cache.entries.erase(found);
+            ++cache.stats.invalidations;
+        }
+        ++cache.stats.misses;
+    }
+
+    auto analysis = analyze();
+    std::lock_guard lock(cache.mutex);
+    constexpr size_t max_entries = 4096;
+    const uint64_t limit = shader_analysis_cache_limit_bytes();
+    while (!cache.entries.empty() &&
+           (cache.entries.size() >= max_entries || cache.stats.bytes + analysis->bytes > limit)) {
+        auto oldest = cache.entries.begin();
+        for (auto it = std::next(cache.entries.begin()); it != cache.entries.end(); ++it)
+            if (it->second.last_use < oldest->second.last_use) oldest = it;
+        cache.stats.bytes -= oldest->second.analysis->bytes;
+        cache.entries.erase(oldest);
+        ++cache.stats.evictions;
+    }
+    if (analysis->bytes <= limit && max_entries != 0) {
+        cache.entries[address] = {analysis, ++cache.use_counter};
+        cache.stats.bytes += analysis->bytes;
+    }
+    cache.stats.entries = cache.entries.size();
+    return analysis;
+}
+
 uint64_t shader_cache_limit_bytes() {
     constexpr uint64_t default_bytes = 128ull * 1024 * 1024;
     const char* value = getenv("PROSPER_SHADER_CACHE_MB");
@@ -461,10 +609,12 @@ struct PcrelDispatchSelection {
 };
 
 PcrelDispatchSelection select_pcrel_dispatch(const uint32_t* code, size_t dwords,
-                                              const ShaderResourceTable* resources) {
+                                              const ShaderResourceTable* resources,
+                                              const ShaderCodeAnalysis* analysis = nullptr) {
     PcrelDispatchSelection selection;
     if (!code || !dwords || !resources) return selection;
-    selection.dispatch = rdna2_pcrel_dispatch_info(code, dwords);
+    selection.dispatch = analysis ? analysis->pcrel_dispatch
+                                  : rdna2_pcrel_dispatch_info(code, dwords);
     if (!selection.dispatch.valid) return selection;
 
     selection.resource = resources->by_sgpr_base_cls(
@@ -515,8 +665,11 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
     key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
     if (key.has_system_inputs) key.system_inputs = *system_inputs;
+    const std::shared_ptr<const ShaderCodeAnalysis> analysis =
+        code && dwords ? analyze_shader_code_cached(code, dwords) : nullptr;
     if (stage == ShaderProgramStage::Fragment && code && dwords && resources) {
-        const PcrelDispatchSelection selection = select_pcrel_dispatch(code, dwords, resources);
+        const PcrelDispatchSelection selection =
+            select_pcrel_dispatch(code, dwords, resources, analysis.get());
         const PcrelDispatchInfo& dispatch = selection.dispatch;
         if (dispatch.valid) {
             if (selection.target != UINT32_MAX) {
@@ -548,12 +701,11 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             }
         }
     }
-    if (code && dwords) {
+    if (analysis) {
         // Most shaders end at S_ENDPGM. A compiler-generated s_getpc_b64 V# may instead address an
         // embedded lookup table after ENDPGM; retain that proven tail so cached recompilation sees the
         // same blob as the direct path and table contents participate in the cache identity.
-        const size_t span = rdna2_recompile_code_span(code, dwords);
-        key.code.assign(code, code + span);
+        key.code = analysis->code;
     }
     if (resources) {
         key.resources.reserve(resources->resources.size());
@@ -641,6 +793,63 @@ void clear_shader_decode_cache() {
     cache.entries.clear();
     cache.stats = {};
     cache.use_counter = 0;
+}
+
+ShaderAnalysisCacheStats shader_analysis_cache_stats() {
+    auto& cache = shader_analysis_cache();
+    std::lock_guard lock(cache.mutex);
+    ShaderAnalysisCacheStats stats = cache.stats;
+    stats.entries = cache.entries.size();
+    return stats;
+}
+
+void clear_shader_analysis_cache() {
+    {
+        auto& cache = shader_analysis_cache();
+        std::lock_guard lock(cache.mutex);
+        cache.entries.clear();
+        cache.stats = {};
+        cache.use_counter = 0;
+    }
+    {
+        auto& cache = interpolation_cache();
+        std::lock_guard lock(cache.mutex);
+        cache.entries.clear();
+        cache.use_counter = 0;
+    }
+}
+
+FragmentInterpolationLayout fragment_interpolation_layout_cached(
+        const uint32_t* code, size_t dwords,
+        const PixelSystemInputMapping* system_inputs) {
+    const auto analysis = analyze_shader_code_cached(code, dwords);
+    if (!analysis || getenv("PROSPER_NO_SHADER_ANALYSIS_CACHE"))
+        return fragment_interpolation_layout(code, dwords, system_inputs);
+
+    InterpolationCacheKey key;
+    // Use the immutable analysis version, without retaining its shader-byte allocation beyond the
+    // analysis cache's own memory bound. A same-address shader mutation receives a new identity.
+    key.analysis_identity = analysis->identity;
+    key.has_system_inputs = system_inputs != nullptr;
+    if (system_inputs) key.system_inputs = *system_inputs;
+    auto& cache = interpolation_cache();
+    std::lock_guard lock(cache.mutex);
+    auto found = cache.entries.find(key);
+    if (found != cache.entries.end()) {
+        found->second.last_use = ++cache.use_counter;
+        return found->second.layout;
+    }
+    const FragmentInterpolationLayout layout =
+        fragment_interpolation_layout(code, dwords, system_inputs);
+    constexpr size_t max_entries = 4096;
+    while (cache.entries.size() >= max_entries && !cache.entries.empty()) {
+        auto oldest = cache.entries.begin();
+        for (auto it = std::next(cache.entries.begin()); it != cache.entries.end(); ++it)
+            if (it->second.last_use < oldest->second.last_use) oldest = it;
+        cache.entries.erase(oldest);
+    }
+    cache.entries.emplace(std::move(key), CachedInterpolationLayout{layout, ++cache.use_counter});
+    return layout;
 }
 
 std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
@@ -990,7 +1199,8 @@ size_t registered_shader_dwords(const AgcShaderHeader& header, uint64_t code_add
 std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
                       uint32_t user_sgpr_base, std::vector<SrtUse>* srt_uses,
-                      uint32_t pcrel_dispatch_target) {
+                      uint32_t pcrel_dispatch_target,
+                      const PcrelDispatchInfo* pcrel_dispatch) {
     using FoldClock = std::chrono::steady_clock;
     static const bool profile_fold = std::getenv("PROSPER_STAGE_FOLD_PROFILE") != nullptr;
     const auto fold_start = profile_fold ? FoldClock::now() : FoldClock::time_point{};
@@ -1004,7 +1214,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     const std::vector<Rdna2Inst>* fold_instructions = &decoded->instructions;
     if (pcrel_dispatch_target != UINT32_MAX) {
         specialized = decoded->instructions;
-        const PcrelDispatchInfo dispatch = rdna2_pcrel_dispatch_info(code, dwords);
+        const PcrelDispatchInfo dispatch = pcrel_dispatch
+            ? *pcrel_dispatch : rdna2_pcrel_dispatch_info(code, dwords);
         if (!rdna2_specialize_pcrel_dispatch(specialized, dispatch,
                                              pcrel_dispatch_target)) {
             // The fragment recompiler will reject the same unprovable specialization. Do not walk all
@@ -1880,15 +2091,19 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     ShaderResourceTable primary_resources =
         build_shader_resources(*hdr, primary_sgprs, kUserSgprs, user_sgpr_base);
     PcrelDispatchSelection dispatch_selection;
+    std::shared_ptr<const ShaderCodeAnalysis> shader_analysis;
     if (is_ps) {
+        shader_analysis = analyze_shader_code_cached(
+            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)), shader_dwords);
         dispatch_selection = select_pcrel_dispatch(
-            (const uint32_t*)(uintptr_t)code_addr, shader_dwords, &primary_resources);
+            (const uint32_t*)(uintptr_t)code_addr, shader_dwords, &primary_resources,
+            shader_analysis.get());
     }
     const auto metadata_done = phase_timing ? StageClock::now() : StageClock::time_point{};
     if (is_ps) {
         dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
                                        primary_sgprs, kUserSgprs, 0, &srt_uses,
-                                       dispatch_selection.target);
+                                       dispatch_selection.target, &dispatch_selection.dispatch);
     } else {
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
         // shader's s[8:11]/s[24:25] descriptor pointers to the register file at GS_0+offset).

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -4,6 +4,7 @@
 #include "../src/gpu/videoout_present.hpp"
 #include "../src/hle/dispatch.hpp"
 #include "../frontends/shared/live_renderer.hpp"
+#include "render_runner.h"
 
 #include <algorithm>
 #include <chrono>
@@ -231,6 +232,77 @@ int main() {
         CHECK(packed_red,
               "reused scratch converts and uploads the current packed R10G10B10A2 texture");
     }
+
+#if defined(_WIN32) || defined(__linux__)
+    // Evergate's dominant sampled resources are guest-backed BC textures. The frontend must retain
+    // their decoded pixels under an exact source-content version so the backend can retain the
+    // uploaded image too. A second unchanged callback previously decoded and uploaded BC again.
+    {
+        auto map_flexible = prosper::Hle::lookup(
+            prosper::nid_hash("sceKernelMapNamedFlexibleMemory"));
+        auto unmap = prosper::Hle::lookup(prosper::nid_hash("sceKernelMunmap"));
+        constexpr uint64_t source_mapping_size = 0x10000;
+        uint64_t source_va = 0;
+        const uint64_t source_name = reinterpret_cast<uint64_t>("bc-cache-test");
+        CHECK(map_flexible && unmap &&
+                  map_flexible(reinterpret_cast<uint64_t>(&source_va), source_mapping_size,
+                               0x2 /* RW */, 0, source_name, 0) == 0 && source_va,
+              "persistent BC test maps guest-readable source memory");
+        if (source_va) {
+            const uint8_t bc3_red[16] = {
+                0xff, 0x00, 0x88, 0xc6, 0xfa, 0x88, 0xc6, 0xfa,
+                0x00, 0xf8, 0x1f, 0x00, 0x00, 0x00, 0x00, 0x00,
+            };
+            std::memcpy(reinterpret_cast<void*>(source_va), bc3_red, sizeof(bc3_red));
+
+            DrawItem bc_draw = replay.items[0];
+            bc_draw.color0_base = 0xd60000;
+            auto bc_table = std::make_shared<ShaderResourceTable>(*bc_draw.prt);
+            ShaderResource& bc_resource = bc_table->resources[0];
+            bc_resource.gpu_addr = source_va;
+            bc_resource.host_data = nullptr;
+            bc_resource.host_data_size = 0;
+            bc_resource.size = sizeof(bc3_red);
+            bc_resource.width = bc_resource.height = 4;
+            bc_resource.depth = 1;
+            bc_resource.img_dim = 1;
+            bc_resource.tile_mode = 0;
+            bc_resource.format = DataFormat::Bc3;
+            bc_resource.num_components = 4;
+            bc_resource.compression_enabled = false;
+            bc_draw.prt = std::move(bc_table);
+
+            const std::vector<uint8_t> first_bc = render_submit_items({bc_draw}, W, H);
+            const auto first_bc_stats = prosper::test::backend_texture_upload_stats();
+            const std::vector<uint8_t> reused_bc = render_submit_items({bc_draw}, W, H);
+            const auto reused_bc_stats = prosper::test::backend_texture_upload_stats();
+            CHECK(first_bc_stats.persistent_misses == 1 &&
+                      first_bc_stats.unique_uploads == 1,
+                  "first exact-validated BC version enters the persistent backend cache");
+            CHECK(reused_bc_stats.persistent_hits == 1 &&
+                      reused_bc_stats.unique_uploads == 0 && reused_bc_stats.upload_bytes == 0,
+                  "unchanged guest-backed BC texture skips its next decode/upload callback");
+            CHECK(!first_bc.empty() && first_bc == reused_bc,
+                  "persistent BC reuse remains pixel-identical to the initial decode");
+#ifdef __linux__
+            // The cache write-watch may protect this page after the first validation. A real guest
+            // write must fault/rearm normally, invalidate the content version, and upload new pixels.
+            auto* mutable_bc = reinterpret_cast<uint8_t*>(source_va);
+            mutable_bc[8] = 0xe0;
+            mutable_bc[9] = 0x07;  // BC3 color endpoint 0: red -> green
+            const std::vector<uint8_t> changed_bc = render_submit_items({bc_draw}, W, H);
+            const auto changed_bc_stats = prosper::test::backend_texture_upload_stats();
+            CHECK(changed_bc_stats.persistent_misses == 1 &&
+                      changed_bc_stats.unique_uploads == 1,
+                  "guest BC mutation invalidates the decoded and uploaded content version");
+            CHECK(!changed_bc.empty() && changed_bc != reused_bc,
+                  "guest BC mutation publishes newly decoded pixels instead of stale cache data");
+#endif
+            CHECK(unmap(source_va, source_mapping_size, 0, 0, 0, 0) == 0,
+                  "persistent BC test unmaps its guest source");
+        }
+    }
+#endif
 
     // A non-VideoOut producer must render at CB_COLOR0_ATTRIB2's extent, be cached under its
     // target address, and feed a later pass. Before #526 both passes used the global 64x64 extent.

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -47,6 +47,7 @@ static const uint32_t kPs[] = {
 int main() {
     std::printf("== test_shader_recompile_cache ==\n");
     clear_shader_recompile_cache();
+    clear_shader_analysis_cache();
 
     ShaderResource resource;
     resource.cls = ResourceClass::VertexBuffer;
@@ -90,6 +91,10 @@ int main() {
           "identical code and descriptor semantics hit the cache");
     CHECK(first_identity != 0 && repeated_identity == first_identity,
           "shader cache hits preserve a non-zero compiled-shader identity");
+    auto analysis_stats = shader_analysis_cache_stats();
+    CHECK(analysis_stats.misses == 1 && analysis_stats.hits == 1 &&
+              analysis_stats.entries == 1,
+          "repeated recompilation reuses byte-validated immutable shader analysis");
     CHECK(count_extension(dump_directory, ".bin") == 1 &&
               count_extension(dump_directory, ".spv") == 1,
           "successful shader diagnostics deduplicate cache hits");
@@ -284,6 +289,21 @@ int main() {
         &identity_after_clear);
     CHECK(identity_after_clear > identity_before_clear,
           "cache reset never recycles compiled-shader identities");
+
+    clear_shader_recompile_cache();
+    clear_shader_analysis_cache();
+    std::vector<uint32_t> mutable_ps(kPs, kPs + std::size(kPs));
+    (void)recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, mutable_ps.data(), mutable_ps.size(), nullptr);
+    (void)recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, mutable_ps.data(), mutable_ps.size(), nullptr);
+    mutable_ps[0] ^= 1u;  // same allocation, changed instruction bytes
+    (void)recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, mutable_ps.data(), mutable_ps.size(), nullptr);
+    analysis_stats = shader_analysis_cache_stats();
+    CHECK(analysis_stats.hits == 1 && analysis_stats.misses == 2 &&
+              analysis_stats.invalidations == 1,
+          "same-address shader mutation invalidates immutable analysis before reuse");
 
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);


### PR DESCRIPTION
## Summary

- expand the exact-validated decoded-texture cache to guest-backed 2D Unorm8 (1-4 components) and BC1-BC7 textures
- raise the default decoded-texture budget to 1 GiB so Evergate's measured 835 MiB working set does not thrash
- cache immutable shader span, PC-relative dispatch, and interpolation analysis behind byte-exact mutation validation
- add same-address mutation and BC decode/upload reuse regressions, plus document the controls and measurements

## Impact

In matched native 1920x1080 dense-transition windows on Windows / RTX 4090:

- core submit: 572-579 ms -> 426-449 ms
- draw realization: 222-223 ms -> 55-61 ms
- stage tables: 93-94 ms -> 20-22 ms
- shader lookup/analysis: about 110 ms -> 17-19 ms
- application rate: 1.7-1.9 FPS -> 2.1 FPS, reaching 2.6 FPS in the following lower-draw intro

The backend is now the dominant remaining cost at roughly 360-388 ms per dense submit.

## Validation

- Windows MinGW prosper-app build
- Linux full suite: 110/110 passed
- focused shader same-address invalidation and guest BC mutation/reuse tests
- Evergate title snapshot: 480x270, 9/9 qualifying structural and nonblack matches