### PR TITLE
Fix sceKernel vectored I/O error contracts

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1169,11 +1169,13 @@ HLE(f_pread)  { int64_t r = win_pio((int)a0, P(a1), (size_t)a2, (uint64_t)a3, fa
                 if (r < 0) errno = error;
                 return (uint64_t)r; }
 HLE(f_pwrite) { return (uint64_t)win_pio((int)a0, P(a1), (size_t)a2, (uint64_t)a3, true); }
-HLE(f_readv)  { auto* v = (GIovec*)P(a1); int nc = (int)a2; int64_t tot = 0;
+HLE(f_readv)  { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+                auto* v = (GIovec*)P(a1); int nc = (int)a2; int64_t tot = 0;
                 for (int i = 0; i < nc; i++) { int64_t r = (int64_t)(int)::read((int)a0, v[i].base, (unsigned)v[i].len);
                     if (r < 0) return tot ? (uint64_t)tot : (uint64_t)-1; tot += r; if ((size_t)r < v[i].len) break; }
                 return (uint64_t)tot; }
-HLE(f_writev) { auto* v = (GIovec*)P(a1); int nc = (int)a2; int64_t tot = 0;
+HLE(f_writev) { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+                auto* v = (GIovec*)P(a1); int nc = (int)a2; int64_t tot = 0;
                 for (int i = 0; i < nc; i++) { int64_t w = (int64_t)(int)::write((int)a0, v[i].base, (unsigned)v[i].len);
                     if (w < 0) return tot ? (uint64_t)tot : (uint64_t)-1; tot += w; if ((size_t)w < v[i].len) break; }
                 return (uint64_t)tot; }
@@ -1200,6 +1202,10 @@ HLE(k_write)  { uint64_t r = f_write(a0, a1, a2, a3, a4, a5);  int e = errno; re
 HLE(k_lseek)  { uint64_t r = f_lseek(a0, a1, a2, a3, a4, a5);  int e = errno; return kernel_io_result(r, e); }
 HLE(k_pread)  { uint64_t r = f_pread(a0, a1, a2, a3, a4, a5);  int e = errno; return kernel_io_result(r, e); }
 HLE(k_pwrite) { uint64_t r = f_pwrite(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_io_result(r, e); }
+HLE(k_readv)  { uint64_t r = f_readv(a0, a1, a2, a3, a4, a5);  int e = errno; return kernel_io_result(r, e); }
+HLE(k_writev) { uint64_t r = f_writev(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_io_result(r, e); }
+HLE(k_preadv) { uint64_t r = f_preadv(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_io_result(r, e); }
+HLE(k_pwritev){ uint64_t r = f_pwritev(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_io_result(r, e); }
 
 // sceKernelFtruncate(fd, length): resize an open file. Was MISSING -> the return-0 stub faked success
 // without truncating, so the near-universal save idiom "overwrite with fewer bytes, then ftruncate to
@@ -2076,10 +2082,10 @@ void register_file_hle() {
     R("fcntl", f_fcntl);          R("sceKernelFcntl", f_fcntl);       // FreeBSD commands/flags need translation
     R("sceKernelGetdents", k_getdents); R("getdents", f_getdents);
     // vectored IO + getdirentries — real host ops (were MISSING -> silent-EOF / empty-dir corruption trap)
-    R("sceKernelReadv", f_readv);       R("readv", f_readv);
-    R("sceKernelWritev", f_writev);     R("writev", f_writev);
-    R("sceKernelPreadv", f_preadv);     R("preadv", f_preadv);
-    R("sceKernelPwritev", f_pwritev);   R("pwritev", f_pwritev);
+    R("sceKernelReadv", k_readv);       R("readv", f_readv);
+    R("sceKernelWritev", k_writev);     R("writev", f_writev);
+    R("sceKernelPreadv", k_preadv);     R("preadv", f_preadv);
+    R("sceKernelPwritev", k_pwritev);   R("pwritev", f_pwritev);
     R("sceKernelGetdirentries", k_getdirentries); R("getdirentries", f_getdirentries);
     // sceKernelAio* (issue #312): NIDs verified identical in shadPS4's PS4 registration table and
     // the PS5 3.20 libkernel stub dump. Raw-NID registration (names not in our NidDb).

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -66,6 +66,14 @@ int main() {
     HleFn pread_fn = Hle::lookup(nid_hash("sceKernelPread"));
     HleFn posix_pwrite_fn = Hle::lookup(nid_hash("pwrite"));
     HleFn pwrite_fn = Hle::lookup(nid_hash("sceKernelPwrite"));
+    HleFn posix_readv_fn = Hle::lookup(nid_hash("readv"));
+    HleFn readv_fn = Hle::lookup(nid_hash("sceKernelReadv"));
+    HleFn posix_writev_fn = Hle::lookup(nid_hash("writev"));
+    HleFn writev_fn = Hle::lookup(nid_hash("sceKernelWritev"));
+    HleFn posix_preadv_fn = Hle::lookup(nid_hash("preadv"));
+    HleFn preadv_fn = Hle::lookup(nid_hash("sceKernelPreadv"));
+    HleFn posix_pwritev_fn = Hle::lookup(nid_hash("pwritev"));
+    HleFn pwritev_fn = Hle::lookup(nid_hash("sceKernelPwritev"));
     HleFn posix_lseek_fn = Hle::lookup(nid_hash("lseek"));
     HleFn lseek_fn = Hle::lookup(nid_hash("sceKernelLseek"));
     HleFn close_fn = Hle::lookup(nid_hash("sceKernelClose"));
@@ -84,6 +92,8 @@ int main() {
     HleFn kernel_fcntl_fn = Hle::lookup(nid_hash("sceKernelFcntl"));
     CHECK(posix_open_fn && open_fn && posix_read_fn && read_fn && posix_write_fn && write_fn &&
               posix_pread_fn && pread_fn && posix_pwrite_fn && pwrite_fn && posix_lseek_fn &&
+              posix_readv_fn && readv_fn && posix_writev_fn && writev_fn &&
+              posix_preadv_fn && preadv_fn && posix_pwritev_fn && pwritev_fn &&
               lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn &&
@@ -468,6 +478,16 @@ int main() {
     check_bad_fd_contract("Pwrite", posix_pwrite_fn, pwrite_fn,
                           (uint64_t)(uintptr_t)io_byte.data(), io_byte.size(), 0);
     check_bad_fd_contract("Lseek", posix_lseek_fn, lseek_fn, 0, SEEK_SET, 0);
+    struct GuestIovec { void* base; size_t len; };
+    GuestIovec io_vector{io_byte.data(), io_byte.size()};
+    check_bad_fd_contract("Readv", posix_readv_fn, readv_fn,
+                          (uint64_t)(uintptr_t)&io_vector, 1, 0);
+    check_bad_fd_contract("Writev", posix_writev_fn, writev_fn,
+                          (uint64_t)(uintptr_t)&io_vector, 1, 0);
+    check_bad_fd_contract("Preadv", posix_preadv_fn, preadv_fn,
+                          (uint64_t)(uintptr_t)&io_vector, 1, 0);
+    check_bad_fd_contract("Pwritev", posix_pwritev_fn, pwritev_fn,
+                          (uint64_t)(uintptr_t)&io_vector, 1, 0);
 
     // A duplicate is a distinct descriptor for the same open file description: it shares the
     // current offset and remains usable after the original descriptor is closed.


### PR DESCRIPTION
Part of #389.

## What changed

- route `sceKernelReadv`, `sceKernelWritev`, `sceKernelPreadv`, and `sceKernelPwritev` through kernel-specific result wrappers
- translate host `errno` failures to sign-extended FreeBSD/Orbis SCE errors while leaving libc vector calls on `-1` plus `errno`
- suppress Windows UCRT invalid-parameter termination around sequential `readv`/`writev` descriptor failures
- extend the cross-platform closed-descriptor regression to all four vector exports

## Why

The kernel and libc vector names shared the same handlers. On failure, games calling the kernel exports therefore received POSIX `-1` instead of the SCE error value expected by the signed 64-bit kernel ABI. Asset I/O code using the vector imports could lose the actual failure reason and take incorrect recovery paths.

Successful and partial byte counts are deliberately unchanged. Scalar I/O was fixed separately in #938; close, stat/metadata, and path-operation contracts remain outside this PR.

## Validation so far

- Linux targeted build + `file_binary_roundtrip`: pass
- Windows targeted build + `file_binary_roundtrip`: pass
- `git diff --check`: pass
- no snapshots run

The exact-head author `core` verifier and inspection-only review will run after publication, per repository policy.