### PR TITLE
Fix sceKernelClose error contract

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -766,6 +766,7 @@ HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
 #ifdef __APPLE__
                int r = getdents_close_fd(fd);
 #elif defined(_WIN32)
+               ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
                int r = -1;
                if (!windows_close_directory(fd, &r)) r = ::close(fd);
 #else
@@ -774,7 +775,11 @@ HLE(f_close) { if (a0 < 3) { preadlog("close-lo-ignored", a0, 0, 0); return 0; }
                int err = r < 0 ? errno : 0;
                filelog_fd_io("close", fd, 0, 0, r, err);
                if (r == 0) filelog_forget_fd(fd);
+               else errno = err;
                return (uint64_t)(int64_t)r; }
+HLE(k_close) { uint64_t result = f_close(a0, a1, a2, a3, a4, a5);
+               int error = errno;
+               return (int64_t)result < 0 ? file_sce_error(error) : result; }
 // dup/dup2 were MISSING -> the return-0 stub handed back fd 0 (a valid-looking descriptor that is actually
 // stdin), so the guest read/closed stdin thinking it was its duplicate -> the fd-0 hazard this file guards
 // against elsewhere. Back with host dup/dup2; dup keeps the result above fd 2 (same as f_open).
@@ -2058,7 +2063,7 @@ void register_file_hle() {
     R("fgetc", f_fgetc);   R("getc", f_fgetc);
     R("open", f_open);     R("close", f_close);   R("read", f_read);     R("write", f_write);
     R("lseek", f_lseek);   R("stat", f_stat);     R("fstat", f_fstat);   R("access", f_access);
-    R("sceKernelOpen", k_open);  R("sceKernelClose", f_close); R("sceKernelRead", k_read);
+    R("sceKernelOpen", k_open);  R("sceKernelClose", k_close); R("sceKernelRead", k_read);
     R("sceKernelWrite", k_write); R("sceKernelLseek", k_lseek); R("sceKernelStat", f_stat);
     R("sceKernelFtruncate", f_ftruncate);   // real resize (was fake-success -> corrupt saves)
     R("lstat", f_lstat);   R("sceKernelLstat", f_lstat);     // was MISSING -> uninitialized stat buffer

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -76,6 +76,7 @@ int main() {
     HleFn pwritev_fn = Hle::lookup(nid_hash("sceKernelPwritev"));
     HleFn posix_lseek_fn = Hle::lookup(nid_hash("lseek"));
     HleFn lseek_fn = Hle::lookup(nid_hash("sceKernelLseek"));
+    HleFn posix_close_fn = Hle::lookup(nid_hash("close"));
     HleFn close_fn = Hle::lookup(nid_hash("sceKernelClose"));
     HleFn dup_fn = Hle::lookup(nid_hash("dup"));
     HleFn kernel_dup_fn = Hle::lookup(nid_hash("sceKernelDup"));
@@ -94,7 +95,7 @@ int main() {
               posix_pread_fn && pread_fn && posix_pwrite_fn && pwrite_fn && posix_lseek_fn &&
               posix_readv_fn && readv_fn && posix_writev_fn && writev_fn &&
               posix_preadv_fn && preadv_fn && posix_pwritev_fn && pwritev_fn &&
-              lseek_fn && close_fn && dup_fn && kernel_dup_fn &&
+              lseek_fn && posix_close_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -488,6 +489,20 @@ int main() {
                           (uint64_t)(uintptr_t)&io_vector, 1, 0);
     check_bad_fd_contract("Pwritev", posix_pwritev_fn, pwritev_fn,
                           (uint64_t)(uintptr_t)&io_vector, 1, 0);
+    errno = 0;
+    int64_t libc_close_result = posix_close_fn
+        ? (int64_t)posix_close_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
+    const int libc_close_error = errno;
+    uint64_t kernel_close_result = close_fn
+        ? close_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
+    CHECK(libc_close_result == -1 && libc_close_error == EBADF,
+          "libc close retains -1 plus EBADF");
+    CHECK(kernel_close_result == 0x80020009u,
+          "sceKernelClose returns SCE_KERNEL_ERROR_EBADF directly");
+    CHECK(close_fn && close_fn(0, 0, 0, 0, 0, 0) == 0,
+          "sceKernelClose preserves reserved stdio descriptors as no-op success");
 
     // A duplicate is a distinct descriptor for the same open file description: it shares the
     // current offset and remains usable after the original descriptor is closed.


### PR DESCRIPTION
Part of #389.

## What changed

- give `sceKernelClose` a kernel-specific result wrapper instead of sharing the libc `close` registration
- translate real host close failures to the 32-bit FreeBSD/Orbis SCE error contract
- preserve `errno` across file-I/O logging for libc callers
- guard Windows invalid descriptors from UCRT invalid-parameter termination
- cover libc EBADF, kernel SCE EBADF, and prosper's deliberate descriptor 0–2 no-op behavior

## Why

`sceKernelClose` returned POSIX `-1` on a real close failure because it shared the libc handler. Games calling the kernel export expect the SCE error value directly. On Windows, retrying a closed CRT descriptor could additionally enter the invalid-parameter path instead of producing a recoverable EBADF.

Prosper deliberately treats guest closes of descriptors 0–2 as successful no-ops because games use those values as invalid-handle sentinels and the host can recycle them for live game files. That live-proven behavior is explicitly unchanged and regression-protected.

## Validation so far

- Linux targeted build + `file_binary_roundtrip`: pass
- Windows targeted build + `file_binary_roundtrip`: pass
- `git diff --check`: pass
- no snapshots run

The exact-head author `core` verifier and inspection-only review will run after publication, per repository policy.