### PR TITLE
Fix sceKernel stat error contracts

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1313,7 +1313,9 @@ HLE(k_aio_cancel) {  // (id, s32* state): nothing is in flight to cancel — rep
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct stat st; int r = ::stat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); int err = r < 0 ? errno : 0;
                if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1));
-               filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1); return (uint64_t)(int64_t)r; }
+               filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1);
+               if (r < 0) errno = err;
+               return (uint64_t)(int64_t)r; }
 // lstat: was MISSING -> the return-0 stub reported success while leaving the caller's stat buffer as
 // uninitialized garbage (wrong file type/size). We have no symlinks in the dump, so ::lstat == ::stat, but
 // the key fix is WRITING the buffer. fsync: was fake-success; flush for real save durability.
@@ -1322,15 +1324,28 @@ HLE(f_fsync) { return (uint64_t)(int64_t)::fsync((int)a0); }
 #else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fstat) { struct _stat64 st; std::string directory_path;
+               ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
                int r = windows_directory_path((int)a0, &directory_path)
                      ? ::_stat64(directory_path.c_str(), &st)
                      : ::_fstat64((int)a0, &st);
                int err = r < 0 ? errno : 0;
                if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1));
-               filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1); return (uint64_t)(int64_t)r; }
+               filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1);
+               if (r < 0) errno = err;
+               return (uint64_t)(int64_t)r; }
 HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
 HLE(f_fsync) { return 0; }
 #endif
+
+// The stat family has a signed 32-bit result. Kernel exports return the translated SCE error
+// directly, while the libc names retain -1 plus errno. Successful calls and output translation
+// remain shared so both namespaces keep the same guest stat layout.
+static uint64_t kernel_stat_result(uint64_t result, int error) {
+    return (int64_t)result < 0 ? file_sce_error(error) : result;
+}
+HLE(k_stat)  { uint64_t r = f_stat(a0, a1, a2, a3, a4, a5);  int e = errno; return kernel_stat_result(r, e); }
+HLE(k_fstat) { uint64_t r = f_fstat(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_stat_result(r, e); }
+HLE(k_lstat) { uint64_t r = f_lstat(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_stat_result(r, e); }
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32
@@ -2064,12 +2079,12 @@ void register_file_hle() {
     R("open", f_open);     R("close", f_close);   R("read", f_read);     R("write", f_write);
     R("lseek", f_lseek);   R("stat", f_stat);     R("fstat", f_fstat);   R("access", f_access);
     R("sceKernelOpen", k_open);  R("sceKernelClose", k_close); R("sceKernelRead", k_read);
-    R("sceKernelWrite", k_write); R("sceKernelLseek", k_lseek); R("sceKernelStat", f_stat);
+    R("sceKernelWrite", k_write); R("sceKernelLseek", k_lseek); R("sceKernelStat", k_stat);
     R("sceKernelFtruncate", f_ftruncate);   // real resize (was fake-success -> corrupt saves)
-    R("lstat", f_lstat);   R("sceKernelLstat", f_lstat);     // was MISSING -> uninitialized stat buffer
+    R("lstat", f_lstat);   R("sceKernelLstat", k_lstat);     // was MISSING -> uninitialized stat buffer
     R("fsync", f_fsync);   R("sceKernelFsync", f_fsync);     // was fake-success -> no durability
     R("sceKernelTruncate", f_truncate);      // path-based sibling (same corruption class)
-    R("sceKernelFstat", f_fstat);
+    R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements
     // its stdio/file layer (fopen/fwrite/...) on top of these, so they MUST be real (were stubbed to
     // 0). Same handlers/host-fd space as the unprefixed ones, so libc's fds stay consistent.

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -88,7 +88,12 @@ int main() {
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
     HleFn kernel_getdirentries_fn = Hle::lookup(nid_hash("sceKernelGetdirentries"));
-    HleFn fstat_fn = Hle::lookup(nid_hash("sceKernelFstat"));
+    HleFn stat_fn = Hle::lookup(nid_hash("stat"));
+    HleFn kernel_stat_fn = Hle::lookup(nid_hash("sceKernelStat"));
+    HleFn fstat_fn = Hle::lookup(nid_hash("fstat"));
+    HleFn kernel_fstat_fn = Hle::lookup(nid_hash("sceKernelFstat"));
+    HleFn lstat_fn = Hle::lookup(nid_hash("lstat"));
+    HleFn kernel_lstat_fn = Hle::lookup(nid_hash("sceKernelLstat"));
     HleFn fcntl_fn = Hle::lookup(nid_hash("fcntl"));
     HleFn kernel_fcntl_fn = Hle::lookup(nid_hash("sceKernelFcntl"));
     CHECK(posix_open_fn && open_fn && posix_read_fn && read_fn && posix_write_fn && write_fn &&
@@ -97,7 +102,8 @@ int main() {
               posix_preadv_fn && preadv_fn && posix_pwritev_fn && pwritev_fn &&
               lseek_fn && posix_close_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
-              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && fstat_fn &&
+              kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
+              kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
           "file HLE functions registered");
     std::array<uint8_t, 64> dir_buffer{};
@@ -212,8 +218,9 @@ int main() {
     CHECK(dents_eof == 0, "getdents preserves its per-open end cursor");
 
     std::array<uint8_t, 0x78> dir_stat{};
-    int64_t dir_stat_result = dir_fd >= 0 && fstat_fn
-        ? (int64_t)fstat_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dir_stat.data(), 0, 0, 0, 0)
+    int64_t dir_stat_result = dir_fd >= 0 && kernel_fstat_fn
+        ? (int64_t)kernel_fstat_fn((uint64_t)dir_fd, (uint64_t)(uintptr_t)dir_stat.data(),
+                                   0, 0, 0, 0)
         : -1;
     CHECK(dir_stat_result == 0 &&
               ((*(const uint16_t*)(dir_stat.data() + 8)) & 0xf000u) == 0x4000u,
@@ -285,6 +292,38 @@ int main() {
           "libc open retains the -1 plus errno contract");
     CHECK((uint32_t)kernel_missing == 0x80020002u,
           "sceKernelOpen returns SCE_KERNEL_ERROR_ENOENT directly");
+
+    // The stat-family libc names preserve -1 plus errno, while their kernel siblings return
+    // a 32-bit SCE error directly. Neither contract may overwrite the guest buffer on failure.
+    auto check_missing_stat_contract = [&](const char* operation, HleFn libc_fn,
+                                           HleFn kernel_fn) {
+        std::array<uint8_t, 0x78> libc_buffer;
+        std::array<uint8_t, 0x78> kernel_buffer;
+        libc_buffer.fill(0x5a);
+        kernel_buffer.fill(0x5a);
+        const auto untouched = libc_buffer;
+        errno = 0;
+        uint64_t libc_result = libc_fn
+            ? libc_fn((uint64_t)(uintptr_t)missing_path,
+                      (uint64_t)(uintptr_t)libc_buffer.data(), 0, 0, 0, 0)
+            : 0;
+        const int libc_error = errno;
+        uint64_t kernel_result = kernel_fn
+            ? kernel_fn((uint64_t)(uintptr_t)missing_path,
+                        (uint64_t)(uintptr_t)kernel_buffer.data(), 0, 0, 0, 0)
+            : 0;
+        const std::string libc_message = std::string("libc ") + operation +
+                                         " retains -1 plus ENOENT";
+        const std::string kernel_message = std::string("sceKernel") + operation +
+                                           " returns SCE_KERNEL_ERROR_ENOENT directly";
+        const std::string buffer_message = std::string(operation) +
+                                            " failure leaves stat buffers untouched";
+        CHECK((int64_t)libc_result == -1 && libc_error == ENOENT, libc_message.c_str());
+        CHECK(kernel_result == 0x80020002u, kernel_message.c_str());
+        CHECK(libc_buffer == untouched && kernel_buffer == untouched, buffer_message.c_str());
+    };
+    check_missing_stat_contract("Stat", stat_fn, kernel_stat_fn);
+    check_missing_stat_contract("Lstat", lstat_fn, kernel_lstat_fn);
 
     constexpr uint64_t kGuestOWriteOnly = 0x0001;
     constexpr uint64_t kGuestOCreate = 0x0200;
@@ -503,6 +542,28 @@ int main() {
           "sceKernelClose returns SCE_KERNEL_ERROR_EBADF directly");
     CHECK(close_fn && close_fn(0, 0, 0, 0, 0, 0) == 0,
           "sceKernelClose preserves reserved stdio descriptors as no-op success");
+
+    std::array<uint8_t, 0x78> libc_fstat_buffer;
+    std::array<uint8_t, 0x78> kernel_fstat_buffer;
+    libc_fstat_buffer.fill(0xa5);
+    kernel_fstat_buffer.fill(0xa5);
+    const auto untouched_fstat = libc_fstat_buffer;
+    errno = 0;
+    int64_t libc_fstat_result = fstat_fn
+        ? (int64_t)fstat_fn(closed_io_fd, (uint64_t)(uintptr_t)libc_fstat_buffer.data(),
+                            0, 0, 0, 0)
+        : 0;
+    const int libc_fstat_error = errno;
+    uint64_t kernel_fstat_result = kernel_fstat_fn
+        ? kernel_fstat_fn(closed_io_fd, (uint64_t)(uintptr_t)kernel_fstat_buffer.data(),
+                          0, 0, 0, 0)
+        : 0;
+    CHECK(libc_fstat_result == -1 && libc_fstat_error == EBADF,
+          "libc fstat retains -1 plus EBADF");
+    CHECK(kernel_fstat_result == 0x80020009u,
+          "sceKernelFstat returns SCE_KERNEL_ERROR_EBADF directly");
+    CHECK(libc_fstat_buffer == untouched_fstat && kernel_fstat_buffer == untouched_fstat,
+          "fstat failure leaves stat buffers untouched");
 
     // A duplicate is a distinct descriptor for the same open file description: it shares the
     // current offset and remains usable after the original descriptor is closed.


### PR DESCRIPTION
## Summary

- split `sceKernelStat`, `sceKernelFstat`, and `sceKernelLstat` from their libc-style handlers
- translate host failures to direct 32-bit FreeBSD/Orbis SCE errors while preserving libc `-1` plus `errno`
- preserve stat output buffers on failure and guard Windows invalid `_fstat64` descriptors from UCRT termination

## Root cause

The kernel exports were registered directly to the libc handlers. Those handlers correctly returned host-style `-1` and `errno` for libc, but that violates the `sceKernel*` ABI and breaks guest branches comparing against values such as `SCE_KERNEL_ERROR_ENOENT` or `SCE_KERNEL_ERROR_EBADF`.

## Validation

Author focused preflight passed on both supported hosts:

- Linux `test_file_binary`: PASS
- Windows `test_file_binary`: PASS
- `git diff --check`: PASS

The full repository PR verifier will run on this exact PR head. No snapshots are required or run for this filesystem HLE change.

Refs #389