### PR TITLE
Fix sceKernel path operation error contracts

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1224,7 +1224,14 @@ HLE(f_ftruncate) { return (uint64_t)(int64_t)::ftruncate((int)a0, (off_t)a1); }
 HLE(f_truncate)  { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::truncate(h.c_str(), (off_t)a1); }
 #else
 HLE(f_ftruncate) { return (uint64_t)-1; }
-HLE(f_truncate)  { return (uint64_t)-1; }
+HLE(f_truncate)  { std::string h = translate(CS(a0));
+                    ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+                    int fd = ::_open(h.c_str(), _O_RDWR | _O_BINARY);
+                    if (fd < 0) return (uint64_t)(int64_t)-1;
+                    int resize_error = ::_chsize_s(fd, (__int64)a1);
+                    int close_result = ::_close(fd);
+                    if (resize_error) { errno = resize_error; return (uint64_t)(int64_t)-1; }
+                    return (uint64_t)(int64_t)close_result; }
 #endif
 
 // --- sceKernelAio* — the kernel async-IO command API (issue #312 suspect list). -----------------
@@ -1337,15 +1344,16 @@ HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
 HLE(f_fsync) { return 0; }
 #endif
 
-// The stat family has a signed 32-bit result. Kernel exports return the translated SCE error
-// directly, while the libc names retain -1 plus errno. Successful calls and output translation
-// remain shared so both namespaces keep the same guest stat layout.
-static uint64_t kernel_stat_result(uint64_t result, int error) {
+// These file APIs have signed 32-bit results. Kernel exports return the translated SCE error
+// directly, while the libc names retain -1 plus errno. Keep the base host operation shared so
+// successful behavior stays identical across both namespaces.
+static uint64_t kernel_file_result32(uint64_t result, int error) {
     return (int64_t)result < 0 ? file_sce_error(error) : result;
 }
-HLE(k_stat)  { uint64_t r = f_stat(a0, a1, a2, a3, a4, a5);  int e = errno; return kernel_stat_result(r, e); }
-HLE(k_fstat) { uint64_t r = f_fstat(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_stat_result(r, e); }
-HLE(k_lstat) { uint64_t r = f_lstat(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_stat_result(r, e); }
+HLE(k_stat)     { uint64_t r = f_stat(a0, a1, a2, a3, a4, a5);     int e = errno; return kernel_file_result32(r, e); }
+HLE(k_fstat)    { uint64_t r = f_fstat(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
+HLE(k_lstat)    { uint64_t r = f_lstat(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
+HLE(k_truncate) { uint64_t r = f_truncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32
@@ -1355,6 +1363,8 @@ HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode
 #endif
 }
 HLE(f_rmdir) { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::rmdir(h.c_str()); }
+HLE(k_mkdir) { uint64_t r = f_mkdir(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
+HLE(k_rmdir) { uint64_t r = f_rmdir(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 
 // sceKernelGetdents(int fd, char* buf, size_t nbytes) — fill FreeBSD dirent records
 // {u32 fileno; u16 reclen; u8 type; u8 namlen; char name[]} (4-aligned). Backed by the host's
@@ -1532,6 +1542,8 @@ HLE(f_unlink){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::
 // NID 52NcYU9+lEo, reached via libc.prx. ::rename is standard C (Windows + Linux).
 HLE(f_rename){ std::string from = translate(CS(a0)), to = translate(CS(a1));
                return (uint64_t)(int64_t)::rename(from.c_str(), to.c_str()); }
+HLE(k_unlink){ uint64_t r = f_unlink(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
+HLE(k_rename){ uint64_t r = f_rename(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 
 // --- APR (Async Page Read) file resolution -----------------------------------------------------
 // sceKernelAprResolveFilepathsToIdsAndFileSizes(const char** paths, int count, uint32_t* outIds,
@@ -2083,7 +2095,7 @@ void register_file_hle() {
     R("sceKernelFtruncate", f_ftruncate);   // real resize (was fake-success -> corrupt saves)
     R("lstat", f_lstat);   R("sceKernelLstat", k_lstat);     // was MISSING -> uninitialized stat buffer
     R("fsync", f_fsync);   R("sceKernelFsync", f_fsync);     // was fake-success -> no durability
-    R("sceKernelTruncate", f_truncate);      // path-based sibling (same corruption class)
+    R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements
     // its stdio/file layer (fopen/fwrite/...) on top of these, so they MUST be real (were stubbed to
@@ -2094,10 +2106,10 @@ void register_file_hle() {
     // directory / unlink (real host ops, /app0-translated)
     R("pread", f_pread);          R("sceKernelPread", k_pread);
     R("pwrite", f_pwrite);        R("sceKernelPwrite", k_pwrite);
-    R("mkdir", f_mkdir);          R("sceKernelMkdir", f_mkdir);
-    R("rmdir", f_rmdir);          R("sceKernelRmdir", f_rmdir);
-    R("unlink", f_unlink);        R("sceKernelUnlink", f_unlink);
-    R("rename", f_rename);        R("sceKernelRename", f_rename);   // real move (was fake-success -> lost atomic saves)
+    R("mkdir", f_mkdir);          R("sceKernelMkdir", k_mkdir);
+    R("rmdir", f_rmdir);          R("sceKernelRmdir", k_rmdir);
+    R("unlink", f_unlink);        R("sceKernelUnlink", k_unlink);
+    R("rename", f_rename);        R("sceKernelRename", k_rename);   // real move (was fake-success -> lost atomic saves)
     R("dup", f_dup);   R("sceKernelDup", f_dup);   R("dup2", f_dup2);   R("sceKernelDup2", f_dup2);   // were 0 = stdin
     R("fcntl", f_fcntl);          R("sceKernelFcntl", f_fcntl);       // FreeBSD commands/flags need translation
     R("sceKernelGetdents", k_getdents); R("getdents", f_getdents);

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -84,6 +84,13 @@ int main() {
     HleFn kernel_dup2_fn = Hle::lookup(nid_hash("sceKernelDup2"));
     HleFn mkdir_fn = Hle::lookup(nid_hash("mkdir"));
     HleFn kernel_mkdir_fn = Hle::lookup(nid_hash("sceKernelMkdir"));
+    HleFn rmdir_fn = Hle::lookup(nid_hash("rmdir"));
+    HleFn kernel_rmdir_fn = Hle::lookup(nid_hash("sceKernelRmdir"));
+    HleFn unlink_fn = Hle::lookup(nid_hash("unlink"));
+    HleFn kernel_unlink_fn = Hle::lookup(nid_hash("sceKernelUnlink"));
+    HleFn rename_fn = Hle::lookup(nid_hash("rename"));
+    HleFn kernel_rename_fn = Hle::lookup(nid_hash("sceKernelRename"));
+    HleFn kernel_truncate_fn = Hle::lookup(nid_hash("sceKernelTruncate"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -101,7 +108,9 @@ int main() {
               posix_readv_fn && readv_fn && posix_writev_fn && writev_fn &&
               posix_preadv_fn && preadv_fn && posix_pwritev_fn && pwritev_fn &&
               lseek_fn && posix_close_fn && close_fn && dup_fn && kernel_dup_fn &&
-              dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && getdents_fn &&
+              dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && rmdir_fn &&
+              kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
+              kernel_rename_fn && kernel_truncate_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -121,13 +130,14 @@ int main() {
         ? (int64_t)mkdir_fn((uint64_t)(uintptr_t)dir_path, 0777, 0, 0, 0, 0)
         : 0;
     int duplicate_errno = errno;
-    int64_t kernel_mkdir_duplicate = kernel_mkdir_fn
-        ? (int64_t)kernel_mkdir_fn((uint64_t)(uintptr_t)dir_path, 0777, 0, 0, 0, 0)
+    uint64_t kernel_mkdir_duplicate = kernel_mkdir_fn
+        ? kernel_mkdir_fn((uint64_t)(uintptr_t)dir_path, 0777, 0, 0, 0, 0)
         : 0;
     CHECK(mkdir_first == 0, "mkdir creates a new directory");
     CHECK(mkdir_duplicate == -1, "mkdir reports an existing directory as failure");
     CHECK(duplicate_errno == EEXIST, "mkdir preserves EEXIST for the caller");
-    CHECK(kernel_mkdir_duplicate != 0, "sceKernelMkdir does not report false success on EEXIST");
+    CHECK(kernel_mkdir_duplicate == 0x80020011u,
+          "sceKernelMkdir returns SCE_KERNEL_ERROR_EEXIST directly");
 #ifdef _WIN32
     // Windows has no CRT directory-open API, but a directory HANDLE can be attached to a CRT fd.
     // The zero-entry stub must still publish the defined starting offset through basep.
@@ -324,6 +334,70 @@ int main() {
     };
     check_missing_stat_contract("Stat", stat_fn, kernel_stat_fn);
     check_missing_stat_contract("Lstat", lstat_fn, kernel_lstat_fn);
+
+    auto check_missing_path_contract = [&](const char* operation, HleFn libc_fn,
+                                           HleFn kernel_fn) {
+        errno = 0;
+        uint64_t libc_result = libc_fn
+            ? libc_fn((uint64_t)(uintptr_t)missing_path, 0, 0, 0, 0, 0)
+            : 0;
+        const int libc_error = errno;
+        uint64_t kernel_result = kernel_fn
+            ? kernel_fn((uint64_t)(uintptr_t)missing_path, 0, 0, 0, 0, 0)
+            : 0;
+        const std::string libc_message = std::string("libc ") + operation +
+                                         " retains -1 plus ENOENT";
+        const std::string kernel_message = std::string("sceKernel") + operation +
+                                           " returns SCE_KERNEL_ERROR_ENOENT directly";
+        CHECK((int64_t)libc_result == -1 && libc_error == ENOENT, libc_message.c_str());
+        CHECK(kernel_result == 0x80020002u, kernel_message.c_str());
+    };
+    check_missing_path_contract("Rmdir", rmdir_fn, kernel_rmdir_fn);
+    check_missing_path_contract("Unlink", unlink_fn, kernel_unlink_fn);
+
+    const char* missing_rename_target = "prosper-test-file-binary-missing-renamed.tmp";
+    std::filesystem::remove(missing_rename_target, missing_remove_error);
+    errno = 0;
+    int64_t libc_missing_rename = rename_fn
+        ? (int64_t)rename_fn((uint64_t)(uintptr_t)missing_path,
+                             (uint64_t)(uintptr_t)missing_rename_target, 0, 0, 0, 0)
+        : 0;
+    const int libc_missing_rename_error = errno;
+    uint64_t kernel_missing_rename = kernel_rename_fn
+        ? kernel_rename_fn((uint64_t)(uintptr_t)missing_path,
+                           (uint64_t)(uintptr_t)missing_rename_target, 0, 0, 0, 0)
+        : 0;
+    CHECK(libc_missing_rename == -1 && libc_missing_rename_error == ENOENT,
+          "libc rename retains -1 plus ENOENT");
+    CHECK(kernel_missing_rename == 0x80020002u,
+          "sceKernelRename returns SCE_KERNEL_ERROR_ENOENT directly");
+
+    uint64_t kernel_missing_truncate = kernel_truncate_fn
+        ? kernel_truncate_fn((uint64_t)(uintptr_t)missing_path, 3, 0, 0, 0, 0)
+        : 0;
+    CHECK(kernel_missing_truncate == 0x80020002u,
+          "sceKernelTruncate returns SCE_KERNEL_ERROR_ENOENT directly");
+
+    const char* truncate_path = "prosper-test-kernel-truncate.tmp";
+    std::filesystem::remove(truncate_path, missing_remove_error);
+    FILE* truncate_out = std::fopen(truncate_path, "wb");
+    bool truncate_fixture_written = false;
+    if (truncate_out) {
+        const std::array<uint8_t, 8> truncate_bytes{{0, 1, 2, 3, 4, 5, 6, 7}};
+        truncate_fixture_written =
+            std::fwrite(truncate_bytes.data(), 1, truncate_bytes.size(), truncate_out) ==
+            truncate_bytes.size();
+        std::fclose(truncate_out);
+    }
+    uint64_t kernel_truncate_result = truncate_fixture_written && kernel_truncate_fn
+        ? kernel_truncate_fn((uint64_t)(uintptr_t)truncate_path, 3, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    std::error_code truncate_size_error;
+    uintmax_t truncated_size = std::filesystem::file_size(truncate_path, truncate_size_error);
+    CHECK(truncate_fixture_written && kernel_truncate_result == 0 && !truncate_size_error &&
+              truncated_size == 3,
+          "sceKernelTruncate resizes a path on both hosts");
+    std::filesystem::remove(truncate_path, missing_remove_error);
 
     constexpr uint64_t kGuestOWriteOnly = 0x0001;
     constexpr uint64_t kGuestOCreate = 0x0200;


### PR DESCRIPTION
## Summary

- split `sceKernelMkdir`, `sceKernelRmdir`, `sceKernelUnlink`, `sceKernelRename`, and `sceKernelTruncate` from libc-style handlers
- translate host failures to direct 32-bit FreeBSD/Orbis SCE errors while preserving libc `-1` plus `errno`
- replace the Windows truncate hard-failure stub with a guarded `_open`/`_chsize_s` implementation

## Root cause

The kernel path exports were registered directly to handlers with POSIX return semantics. Guests comparing failures against `SCE_KERNEL_ERROR_*` therefore saw `-1` and could take the wrong save or filesystem recovery path. Windows path truncate compounded that contract bug with an unconditional hard failure and stale `errno`.

## Validation

Author focused preflight passed on both supported hosts:

- Linux `test_file_binary`: PASS
- Windows `test_file_binary`: PASS
- exact EEXIST/ENOENT contract coverage for all five exports
- truncate success coverage on Linux and Windows
- `git diff --check`: PASS

The full repository PR verifier will run on this exact PR head. No snapshots are required or run for this filesystem HLE change.

Refs #389