### PR TITLE
Fix sceKernel descriptor durability errors

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1223,7 +1223,10 @@ HLE(f_ftruncate) { return (uint64_t)(int64_t)::ftruncate((int)a0, (off_t)a1); }
 // corruption class (NID WlyEA-sLDf0, reached via libc.prx). Translate the path through the mount layer.
 HLE(f_truncate)  { std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::truncate(h.c_str(), (off_t)a1); }
 #else
-HLE(f_ftruncate) { return (uint64_t)-1; }
+HLE(f_ftruncate) { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+                    int error = ::_chsize_s((int)a0, (__int64)a1);
+                    if (error) { errno = error; return (uint64_t)(int64_t)-1; }
+                    return 0; }
 HLE(f_truncate)  { std::string h = translate(CS(a0));
                     ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
                     int fd = ::_open(h.c_str(), _O_RDWR | _O_BINARY);
@@ -1341,7 +1344,8 @@ HLE(f_fstat) { struct _stat64 st; std::string directory_path;
                if (r < 0) errno = err;
                return (uint64_t)(int64_t)r; }
 HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
-HLE(f_fsync) { return 0; }
+HLE(f_fsync) { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+               return (uint64_t)(int64_t)::_commit((int)a0); }
 #endif
 
 // These file APIs have signed 32-bit results. Kernel exports return the translated SCE error
@@ -1354,6 +1358,8 @@ HLE(k_stat)     { uint64_t r = f_stat(a0, a1, a2, a3, a4, a5);     int e = errno
 HLE(k_fstat)    { uint64_t r = f_fstat(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
 HLE(k_lstat)    { uint64_t r = f_lstat(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
 HLE(k_truncate) { uint64_t r = f_truncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
+HLE(k_ftruncate){ uint64_t r = f_ftruncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
+HLE(k_fsync)    { uint64_t r = f_fsync(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32
@@ -2092,9 +2098,9 @@ void register_file_hle() {
     R("lseek", f_lseek);   R("stat", f_stat);     R("fstat", f_fstat);   R("access", f_access);
     R("sceKernelOpen", k_open);  R("sceKernelClose", k_close); R("sceKernelRead", k_read);
     R("sceKernelWrite", k_write); R("sceKernelLseek", k_lseek); R("sceKernelStat", k_stat);
-    R("sceKernelFtruncate", f_ftruncate);   // real resize (was fake-success -> corrupt saves)
+    R("sceKernelFtruncate", k_ftruncate);   // real resize (was fake-success -> corrupt saves)
     R("lstat", f_lstat);   R("sceKernelLstat", k_lstat);     // was MISSING -> uninitialized stat buffer
-    R("fsync", f_fsync);   R("sceKernelFsync", f_fsync);     // was fake-success -> no durability
+    R("fsync", f_fsync);   R("sceKernelFsync", k_fsync);     // was fake-success -> no durability
     R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -91,6 +91,9 @@ int main() {
     HleFn rename_fn = Hle::lookup(nid_hash("rename"));
     HleFn kernel_rename_fn = Hle::lookup(nid_hash("sceKernelRename"));
     HleFn kernel_truncate_fn = Hle::lookup(nid_hash("sceKernelTruncate"));
+    HleFn kernel_ftruncate_fn = Hle::lookup(nid_hash("sceKernelFtruncate"));
+    HleFn fsync_fn = Hle::lookup(nid_hash("fsync"));
+    HleFn kernel_fsync_fn = Hle::lookup(nid_hash("sceKernelFsync"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -110,7 +113,8 @@ int main() {
               lseek_fn && posix_close_fn && close_fn && dup_fn && kernel_dup_fn &&
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && rmdir_fn &&
               kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
-              kernel_rename_fn && kernel_truncate_fn && getdents_fn &&
+              kernel_rename_fn && kernel_truncate_fn && kernel_ftruncate_fn && fsync_fn &&
+              kernel_fsync_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -399,6 +403,37 @@ int main() {
           "sceKernelTruncate resizes a path on both hosts");
     std::filesystem::remove(truncate_path, missing_remove_error);
 
+    const char* descriptor_resize_path = "prosper-test-kernel-ftruncate.tmp";
+    std::filesystem::remove(descriptor_resize_path, missing_remove_error);
+    FILE* descriptor_resize_out = std::fopen(descriptor_resize_path, "wb");
+    bool descriptor_resize_fixture_written = false;
+    if (descriptor_resize_out) {
+        const std::array<uint8_t, 8> resize_bytes{{0, 1, 2, 3, 4, 5, 6, 7}};
+        descriptor_resize_fixture_written =
+            std::fwrite(resize_bytes.data(), 1, resize_bytes.size(), descriptor_resize_out) ==
+            resize_bytes.size();
+        std::fclose(descriptor_resize_out);
+    }
+    int64_t descriptor_resize_fd = descriptor_resize_fixture_written && open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)descriptor_resize_path, 2, 0, 0, 0, 0)
+        : -1;
+    uint64_t kernel_ftruncate_result = descriptor_resize_fd >= 0 && kernel_ftruncate_fn
+        ? kernel_ftruncate_fn((uint64_t)descriptor_resize_fd, 3, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    uint64_t kernel_fsync_result = descriptor_resize_fd >= 0 && kernel_fsync_fn
+        ? kernel_fsync_fn((uint64_t)descriptor_resize_fd, 0, 0, 0, 0, 0)
+        : ~uint64_t{0};
+    if (descriptor_resize_fd >= 0 && close_fn)
+        close_fn((uint64_t)descriptor_resize_fd, 0, 0, 0, 0, 0);
+    std::error_code descriptor_resize_size_error;
+    uintmax_t descriptor_resize_size =
+        std::filesystem::file_size(descriptor_resize_path, descriptor_resize_size_error);
+    CHECK(descriptor_resize_fixture_written && kernel_ftruncate_result == 0 &&
+              kernel_fsync_result == 0 && !descriptor_resize_size_error &&
+              descriptor_resize_size == 3,
+          "sceKernelFtruncate and sceKernelFsync persist a resized descriptor on both hosts");
+    std::filesystem::remove(descriptor_resize_path, missing_remove_error);
+
     constexpr uint64_t kGuestOWriteOnly = 0x0001;
     constexpr uint64_t kGuestOCreate = 0x0200;
     constexpr uint64_t kGuestOExclusive = 0x0800;
@@ -638,6 +673,24 @@ int main() {
           "sceKernelFstat returns SCE_KERNEL_ERROR_EBADF directly");
     CHECK(libc_fstat_buffer == untouched_fstat && kernel_fstat_buffer == untouched_fstat,
           "fstat failure leaves stat buffers untouched");
+
+    errno = 0;
+    int64_t libc_fsync_result = fsync_fn
+        ? (int64_t)fsync_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
+    const int libc_fsync_error = errno;
+    uint64_t kernel_fsync_failure = kernel_fsync_fn
+        ? kernel_fsync_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
+    uint64_t kernel_ftruncate_failure = kernel_ftruncate_fn
+        ? kernel_ftruncate_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
+    CHECK(libc_fsync_result == -1 && libc_fsync_error == EBADF,
+          "libc fsync retains -1 plus EBADF");
+    CHECK(kernel_fsync_failure == 0x80020009u,
+          "sceKernelFsync returns SCE_KERNEL_ERROR_EBADF directly");
+    CHECK(kernel_ftruncate_failure == 0x80020009u,
+          "sceKernelFtruncate returns SCE_KERNEL_ERROR_EBADF directly");
 
     // A duplicate is a distinct descriptor for the same open file description: it shares the
     // current offset and remains usable after the original descriptor is closed.


### PR DESCRIPTION
## Summary

- split `sceKernelFtruncate` and `sceKernelFsync` from libc-style return handling
- return translated direct 32-bit FreeBSD/Orbis SCE errors from both kernel exports
- implement Windows descriptor resize with guarded `_chsize_s` and real durability flush with guarded `_commit`

## Root cause

Linux performed both host operations but exposed `-1` instead of the direct `SCE_KERNEL_ERROR_*` values expected by the kernel ABI. Windows additionally hard-failed every descriptor truncate and falsely reported every fsync as successful, so save durability and stale-tail handling diverged by host.

## Validation

Author focused preflight passed on both supported hosts:

- Linux `test_file_binary`: PASS
- Windows `test_file_binary`: PASS
- real resize + flush success on both hosts
- closed-descriptor EBADF contracts for libc fsync and both kernel exports
- `git diff --check`: PASS

The full repository PR verifier will run on this exact PR head. No snapshots are required or run for this filesystem HLE change.

Refs #389