### PR TITLE
fix(windows): avoid guest red-zone corruption

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1282,7 +1282,8 @@ void register_kernel_mem_hle() {
 //
 // What DIFFERS: the OS primitives. Linux uses mmap over a shared memfd so a phys offset can be
 // mapped at two VAs that ALIAS the same bytes (unified-physical-memory contract). One sparse
-// paging-file section backs the entire pool, matching the POSIX memfd implementation. Windows
+// temporary file backs the entire pool, matching the POSIX memfd implementation without requiring
+// guest-time access violations to commit SEC_RESERVE pages. Windows
 // ordinary file views require 64 KiB-aligned offsets and bases. Modern placeholder replacement
 // removes that restriction: MapViewOfFile3 accepts page-aligned offsets/bases when replacing an
 // exact placeholder, so every 16 KiB guest mapping can preserve physical aliasing. The legacy
@@ -1299,6 +1300,7 @@ void register_kernel_mem_hle() {
 #define _WIN32_WINNT 0x0A00   // Win10: WaitOnAddress/WakeByAddress* need >= 0x0602 (Win8)
 #endif
 #include <windows.h>
+#include <winioctl.h>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -1516,18 +1518,78 @@ namespace {
     constexpr uint64_t kGuestAutoVaMin = 0x2000000000ull;   // 128 GiB
     constexpr uint64_t kGuestAutoVaMax = 0xfbffffffffull;  // inclusive; one byte below a 64 KiB boundary
 
-    // One sparse paging-file section is the Windows equivalent of the POSIX direct-memory memfd.
-    // SEC_RESERVE avoids charging 16 GiB of host commit up front; each view commits only its guest span.
-    HANDLE dmem_section() {
-        static HANDLE section = [] {
-            HANDLE h = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr,
-                                          PAGE_READWRITE | SEC_RESERVE,
-                                          (DWORD)(kDmemTotal >> 32),
-                                          (DWORD)(kDmemTotal & 0xffffffffu), nullptr);
-            if (!h) MLOG("CreateFileMapping(dmem) failed error=%lu\n", GetLastError());
-            return h;
+    // A paging-file SEC_RESERVE section avoids a 16 GiB commit charge, but every first guest touch
+    // raises a Windows access violation. Windows builds its exception-dispatch frame below RSP
+    // before the VEH runs, overwriting the 128-byte SysV red zone used by unmodified PS5 code.
+    // Back the aperture with a delete-on-close sparse file instead: mapped pages are ordinary
+    // demand-paged file data (MEM_COMMIT from the guest's perspective), untouched ranges consume no
+    // disk clusters, aliases remain coherent, and guest execution never needs a lazy-commit fault.
+    struct DmemSectionState {
+        HANDLE file = INVALID_HANDLE_VALUE;
+        HANDLE section = nullptr;
+    };
+
+    const DmemSectionState& dmem_section_state() {
+        static const DmemSectionState state = [] {
+            wchar_t temp_dir[MAX_PATH + 1]{};
+            wchar_t temp_path[MAX_PATH + 1]{};
+            const DWORD temp_len = GetTempPathW(MAX_PATH, temp_dir);
+            if (temp_len && temp_len <= MAX_PATH &&
+                GetTempFileNameW(temp_dir, L"ps5", 0, temp_path)) {
+                HANDLE file = CreateFileW(
+                    temp_path, GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE |
+                        FILE_FLAG_RANDOM_ACCESS,
+                    nullptr);
+                if (file != INVALID_HANDLE_VALUE) {
+                    DWORD ignored = 0;
+                    LARGE_INTEGER size{};
+                    size.QuadPart = static_cast<LONGLONG>(kDmemTotal);
+                    if (DeviceIoControl(file, FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0,
+                                        &ignored, nullptr) &&
+                        SetFilePointerEx(file, size, nullptr, FILE_BEGIN) && SetEndOfFile(file)) {
+                        HANDLE section = CreateFileMappingW(
+                            file, nullptr, PAGE_READWRITE,
+                            static_cast<DWORD>(kDmemTotal >> 32),
+                            static_cast<DWORD>(kDmemTotal & 0xffffffffu), nullptr);
+                        if (section) return DmemSectionState{file, section};
+                    }
+                    CloseHandle(file); // FILE_FLAG_DELETE_ON_CLOSE removes the temporary file.
+                } else {
+                    DeleteFileW(temp_path);
+                }
+            }
+
+            std::fprintf(stderr,
+                         "[memhle] Windows direct memory requires a sparse temporary file\n");
+            return DmemSectionState{};
         }();
-        return section;
+        return state;
+    }
+
+    HANDLE dmem_section() { return dmem_section_state().section; }
+
+    bool ensure_section_pages_committed(uint64_t base, uint64_t len, int hp) {
+        if (!len || base > UINT64_MAX - len) return false;
+        const uint64_t end = base + len;
+        uint64_t cursor = base;
+        while (cursor < end) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                              &mbi, sizeof(mbi))) return false;
+            const uint64_t region_end = std::min<uint64_t>(
+                end, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress)) +
+                         mbi.RegionSize);
+            if (region_end <= cursor || mbi.State == MEM_FREE) return false;
+            if (mbi.State == MEM_RESERVE && !VirtualAlloc(
+                    reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                    static_cast<SIZE_T>(region_end - cursor), MEM_COMMIT,
+                    win_page_prot(hp))) return false;
+            cursor = region_end;
+        }
+        return true;
     }
 
     struct DmemView {
@@ -1809,7 +1871,8 @@ namespace {
         // Placeholder replacement is page-granular, unlike MapViewOfFileEx. Map the guest range
         // directly at its physical-section offset, with no 64 KiB congruence requirement.
         view = map_placeholder_section_view(section, hint, rel, len, requested_align, hp);
-        sparse = placeholder = view != nullptr;
+        placeholder = view != nullptr;
+        sparse = false;
         if (!view) {
             void* requested = nullptr;
             if (hint) {
@@ -1850,7 +1913,9 @@ namespace {
             }
             return nullptr;
         }
-        if (!sparse && !VirtualAlloc(guest, (SIZE_T)len, MEM_COMMIT, PAGE_READWRITE)) {
+        if (!sparse && !ensure_section_pages_committed(
+                           static_cast<uint64_t>(reinterpret_cast<uintptr_t>(guest)),
+                           len, HP_R | HP_W)) {
             MLOG("section commit va=0x%llx len=0x%llx failed error=%lu\n",
                  (unsigned long long)(uintptr_t)guest, (unsigned long long)len, GetLastError());
             UnmapViewOfFile(view);
@@ -2106,7 +2171,9 @@ namespace {
             return;
         }
         uint8_t* bytes = (uint8_t*)view + delta;
-        if (VirtualAlloc(bytes, (SIZE_T)len, MEM_COMMIT, PAGE_READWRITE)) {
+        if (ensure_section_pages_committed(
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(bytes)),
+                len, HP_R | HP_W)) {
             memset(bytes, 0, (size_t)len);
             bool protections_ok = true;
             {
@@ -2548,10 +2615,13 @@ namespace {
             remember_free_placeholder_locked(base, size);
             return false;
         }
-        out = DmemView{base, size, phys, mapped, size, true, true};
-        const uint64_t pages = (size + 0x3fff) / 0x4000;
-        out.committed_pages.resize((pages + 63) / 64);
-        out.page_cache_generation = host::guest_mapping_generation();
+        const bool sparse = false;
+        out = DmemView{base, size, phys, mapped, size, sparse, true};
+        if (sparse) {
+            const uint64_t pages = (size + 0x3fff) / 0x4000;
+            out.committed_pages.resize((pages + 63) / 64);
+            out.page_cache_generation = host::guest_mapping_generation();
+        }
         return true;
     }
 
@@ -2579,9 +2649,8 @@ namespace {
             if (mapped) UnmapViewOfFile(mapped);
             return false;
         }
-        if (!VirtualAlloc(reinterpret_cast<void*>(static_cast<uintptr_t>(original.guest_base)),
-                          static_cast<SIZE_T>(original.guest_size), MEM_COMMIT,
-                          PAGE_READWRITE) ||
+        if (!ensure_section_pages_committed(original.guest_base, original.guest_size,
+                                            HP_R | HP_W) ||
             !restore_view_protections(original)) {
             UnmapViewOfFile(mapped);
             return false;

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -262,83 +262,13 @@ GuestWriteWatch& GuestWriteWatch::operator=(GuestWriteWatch&& other) noexcept {
 
 GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
     stats().create_attempts.fetch_add(1, std::memory_order_relaxed);
-    if (!addr || !size || addr > UINT64_MAX - size) return {};
-    const uint64_t begin = addr & ~(kPageSize - 1);
-    const uint64_t range_end = addr + size;
-    if (range_end > UINT64_MAX - (kPageSize - 1)) return {};
-    const uint64_t end = (range_end + kPageSize - 1) & ~(kPageSize - 1);
-    if (end <= begin) return {};
-
-    WatchState& watch = state();
-    std::lock_guard lock(watch.mutex);
-
-    Registration registration;
-    registration.pages.reserve(static_cast<size_t>((end - begin) / kPageSize));
-    auto rollback = [&] {
-        for (auto it = registration.pages.rbegin(); it != registration.pages.rend(); ++it) {
-            WatchedPage* page = it->page;
-            if (!page || !page->references || --page->references) continue;
-            if (page->armed) restore_page(*page);
-            for (const PageAlias& alias : page->aliases) watch.pages_by_addr.erase(alias.addr);
-            watch.pages_by_phys.erase(page->phys);
-        }
-        registration.pages.clear();
-    };
-    for (uint64_t page_addr = begin; page_addr < end; page_addr += kPageSize) {
-        const AliasRange* source = alias_at(watch, page_addr);
-        if (!source) {
-            stats().create_no_mapping.fetch_add(1, std::memory_order_relaxed);
-            log_create_failure("no-mapping", addr, size, page_addr);
-            rollback();
-            return {};
-        }
-        const uint64_t phys = source->phys + (page_addr - source->addr);
-        auto found = watch.pages_by_phys.find(phys);
-        WatchedPage* page = found == watch.pages_by_phys.end() ? nullptr : found->second.get();
-        if (!page) {
-            auto owned = std::make_unique<WatchedPage>();
-            owned->phys = phys;
-            if (!collect_aliases(watch, phys, owned->aliases)) {
-                stats().create_incomplete_aliases.fetch_add(1, std::memory_order_relaxed);
-                log_create_failure("incomplete-aliases", addr, size, page_addr);
-                rollback();
-                return {};
-            }
-            const bool source_alias_present = std::any_of(
-                owned->aliases.begin(), owned->aliases.end(),
-                [&](const PageAlias& alias) { return alias.addr == page_addr; });
-            if (!source_alias_present) {
-                stats().create_incomplete_aliases.fetch_add(1, std::memory_order_relaxed);
-                log_create_failure("source-alias-missing", addr, size, page_addr);
-                rollback();
-                return {};
-            }
-            page = owned.get();
-            watch.pages_by_phys.emplace(phys, std::move(owned));
-            for (const PageAlias& alias : page->aliases)
-                watch.pages_by_addr[alias.addr] = page;
-        }
-        ++page->references;
-        registration.pages.push_back({page, page->generation});
-    }
-
-    std::vector<WatchedPage*> pages;
-    pages.reserve(registration.pages.size());
-    for (const RegistrationPage& registered : registration.pages)
-        pages.push_back(registered.page);
-    if (!set_pages_armed(pages, true)) {
-        stats().create_protect_failures.fetch_add(1, std::memory_order_relaxed);
-        log_create_failure("protect", addr, size, begin);
-        rollback();
-        return {};
-    }
-
-    uint64_t id = ++watch.next_id;
-    if (!id) id = ++watch.next_id;
-    watch.registrations.emplace(id, std::move(registration));
-    stats().registrations.fetch_add(1, std::memory_order_relaxed);
-    stats().registered_pages.fetch_add((end - begin) / kPageSize, std::memory_order_relaxed);
-    return GuestWriteWatch(id);
+    (void)addr;
+    (void)size;
+    // Windows constructs an exception-dispatch frame below the interrupted RSP before a vectored
+    // handler can restore a watched page. Guest code follows the SysV ABI and may keep live locals
+    // in that 128-byte red zone, so page-protection write watches can silently corrupt the guest.
+    // Report unsupported and let renderer callers use their exact byte-comparison fallback.
+    return {};
 }
 
 GuestWriteWatchQuery GuestWriteWatch::query() const {
@@ -366,22 +296,7 @@ GuestWriteWatchQuery GuestWriteWatch::query() const {
 }
 
 bool GuestWriteWatch::rearm() {
-    if (!id_) return false;
-    WatchState& watch = state();
-    std::lock_guard lock(watch.mutex);
-    auto found = watch.registrations.find(id_);
-    if (found == watch.registrations.end()) return false;
-    std::vector<WatchedPage*> pages;
-    pages.reserve(found->second.pages.size());
-    for (const RegistrationPage& registered : found->second.pages)
-        pages.push_back(registered.page);
-    if (!set_pages_armed(pages, true)) return false;
-    for (RegistrationPage& registered : found->second.pages) {
-        if (!registered.page) return false;
-        registered.generation = registered.page->generation;
-    }
-    stats().rearms.fetch_add(1, std::memory_order_relaxed);
-    return true;
+    return false;
 }
 
 void GuestWriteWatch::reset() {
@@ -487,16 +402,8 @@ void guest_write_watch_invalidate_all() {
 }
 
 bool guest_write_watch_handle_fault(uint64_t addr) {
-    WatchState& watch = state();
-    std::lock_guard lock(watch.mutex);
-    const uint64_t page_addr = addr & ~(kPageSize - 1);
-    auto found = watch.pages_by_addr.find(page_addr);
-    if (found == watch.pages_by_addr.end() || !found->second || !found->second->armed) return false;
-    WatchedPage& page = *found->second;
-    ++page.generation;
-    restore_page(page);
-    stats().faults.fetch_add(1, std::memory_order_relaxed);
-    return true;
+    (void)addr;
+    return false;
 }
 
 } // namespace prosper::host

--- a/prosper/src/host/guest_write_watch.hpp
+++ b/prosper/src/host/guest_write_watch.hpp
@@ -27,11 +27,10 @@ struct GuestWriteWatchStats {
     uint64_t rearms = 0;
 };
 
-// Windows direct memory is section-backed so MEM_WRITE_WATCH cannot observe it. This registration
-// instead makes every writable alias of the covered physical pages read-only. The process VEH marks
-// the page dirty and restores its original protection on the first write. Unsupported platforms,
-// incomplete aliases and mapping changes report Unknown so callers retain their exact byte-comparison
-// fallback. Private mappings are tracked with their virtual page as their unique physical identity.
+// Windows direct memory is section-backed so MEM_WRITE_WATCH cannot observe it. Page-protection
+// watches are deliberately unsupported: Windows writes its exception-dispatch frame into the guest
+// SysV red zone before a vectored handler can restore the page, corrupting valid guest locals.
+// Callers receive Unknown and retain their exact byte-comparison fallback.
 class GuestWriteWatch {
 public:
     GuestWriteWatch() = default;
@@ -64,7 +63,8 @@ void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t 
 void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
 void guest_write_watch_invalidate_all();
 
-// Called first from the Windows vectored exception handler for write access violations.
+// Retained for the platform-neutral VEH interface; Windows currently returns false because
+// page-fault write watches are unsafe for SysV guest code.
 bool guest_write_watch_handle_fault(uint64_t addr);
 
 } // namespace prosper::host

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -115,10 +115,10 @@ int main() {
         auto flexible_prefix_watch = host::GuestWriteWatch::create(flexible_base, 0x4000);
         auto flexible_suffix_watch = host::GuestWriteWatch::create(
             flexible_base + 0xc000, 0x4000);
-        CHECK(flexible_prefix_watch && flexible_suffix_watch &&
-                  flexible_prefix_watch.query() == host::GuestWriteWatchQuery::Unchanged &&
-                  flexible_suffix_watch.query() == host::GuestWriteWatchQuery::Unchanged,
-              "partial flexible unmap rebuilds retained write-watch aliases");
+        CHECK(!flexible_prefix_watch && !flexible_suffix_watch &&
+                  flexible_prefix_watch.query() == host::GuestWriteWatchQuery::Unknown &&
+                  flexible_suffix_watch.query() == host::GuestWriteWatchQuery::Unknown,
+              "partial flexible unmap retains the safe exact-comparison fallback");
         uint64_t flexible_hole = flexible_base + 0x4000;
         const bool flexible_hole_mapped =
             flexible((uint64_t)(uintptr_t)&flexible_hole, 0x4000, 0x2, 0,
@@ -206,10 +206,10 @@ int main() {
     if (hinted) CHECK(unmap(hinted, dlen, 0, 0, 0, 0) == 0, "unmap relocated direct-memory view");
     if (reused_phys) release(reused_phys, dlen, 0, 0, 0, 0);
 
-    // Large zero-hint alignments use a placeholder-backed SEC_RESERVE view. Dead Cells requests
-    // one 3 GiB mapping at 2 MiB alignment; committing that whole range made private memory exceed
-    // 4.5 GiB. Prove that placement is aligned, untouched pages remain sparse, host GPU reads
-    // materialize exactly their range, and a second VA still aliases the same physical bytes.
+    // Large zero-hint alignments use a placeholder-backed sparse-file view. Dead Cells requests
+    // one 3 GiB mapping at 2 MiB alignment; a paging-file mapping would charge that whole range as
+    // private commit. File-backed demand paging keeps untouched storage sparse without guest-time
+    // access violations, and a second VA must still alias the same physical bytes.
     constexpr uint64_t sparse_len = 0x02000000;
     constexpr uint64_t sparse_align = 0x00200000;
     constexpr uint64_t sparse_window = kBase + 0x10000000;
@@ -229,24 +229,24 @@ int main() {
                   *(uint32_t*)(guest_query + 0x20) == 0x10,
               "guest VirtualQuery reports the sparse direct view as committed");
         host::GuestReadableRange persistent_range{};
-        CHECK(!host::guest_readable_mapping_containing(
+        CHECK(host::guest_readable_mapping_containing(
                   sparse_va1 + 0x4000, sparse_va1 + 0x8000, persistent_range),
-              "sparse view is excluded from cross-submit host-readability reuse");
+              "file-backed direct view supports cross-submit host-readability reuse");
         VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x4000), &near_before,
                      sizeof(near_before));
         VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x01000000), &far_before,
                      sizeof(far_before));
-        CHECK(near_before.State == MEM_RESERVE && far_before.State == MEM_RESERVE,
-              "untouched sparse direct pages carry no host commit");
+        CHECK(near_before.State == MEM_COMMIT && far_before.State == MEM_COMMIT,
+              "untouched direct pages need no guest-time lazy-commit fault");
         CHECK(gpu::guest_readable(sparse_va1 + 0x4000, 0x4000),
-              "GPU guest-read guard materializes an untouched zero page");
+              "GPU guest-read guard accepts an untouched file-backed zero page");
         MEMORY_BASIC_INFORMATION near_after{}, far_after{};
         VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x4000), &near_after,
                      sizeof(near_after));
         VirtualQuery((void*)(uintptr_t)(sparse_va1 + 0x01000000), &far_after,
                      sizeof(far_after));
-        CHECK(near_after.State == MEM_COMMIT && far_after.State == MEM_RESERVE,
-              "host read commits only the requested 16 KiB guest page");
+        CHECK(near_after.State == MEM_COMMIT && far_after.State == MEM_COMMIT,
+              "host read leaves the fault-free direct mapping committed");
         CHECK(*(volatile uint32_t*)(uintptr_t)(sparse_va1 + 0x4120) == 0,
               "virgin sparse direct-memory page reads as zero");
 
@@ -256,22 +256,17 @@ int main() {
         MEMORY_BASIC_INFORMATION protected_before{};
         VirtualQuery((void*)(uintptr_t)protected_page, &protected_before,
                      sizeof(protected_before));
-        CHECK(protected_before.State == MEM_RESERVE,
-              "mprotect does not materialize an untouched sparse page");
-        CHECK(!prosper_try_commit_dmem(protected_page, 0x4000, 1),
-              "read-only sparse mapping rejects host write materialization");
-        CHECK(prosper_try_commit_dmem(protected_page, 0x4000, 0),
-              "read-only sparse mapping permits host read materialization");
+        CHECK(protected_before.State == MEM_COMMIT &&
+                  (protected_before.Protect & 0xff) == PAGE_READONLY,
+              "mprotect updates an untouched file-backed page without materialization");
         MEMORY_BASIC_INFORMATION protected_after{};
         VirtualQuery((void*)(uintptr_t)protected_page, &protected_after,
                      sizeof(protected_after));
         CHECK(protected_after.State == MEM_COMMIT &&
                   (protected_after.Protect & 0xff) == PAGE_READONLY,
-              "first touch applies the tracked read-only protection");
+              "read-only protection remains visible without a first-touch fault");
         CHECK(protect(protected_page, 0x4000, 0x2, 0, 0, 0) == 0,
               "mprotect restores read/write on a materialized sparse page");
-        CHECK(prosper_try_commit_dmem(protected_page, 0x4000, 1),
-              "mapping-generation invalidation permits a cached sparse-page write");
         MEMORY_BASIC_INFORMATION writable_after{};
         VirtualQuery((void*)(uintptr_t)protected_page, &writable_after,
                      sizeof(writable_after));
@@ -294,8 +289,8 @@ int main() {
                      &late_rw_before, sizeof(late_rw_before));
         VirtualQuery((void*)(uintptr_t)(sparse_va2 + late_commit_offset),
                      &late_ro_before, sizeof(late_ro_before));
-        CHECK(late_rw_before.State == MEM_RESERVE && late_ro_before.State == MEM_RESERVE,
-              "inverse-order alias test starts with the physical page untouched");
+        CHECK(late_rw_before.State == MEM_COMMIT && late_ro_before.State == MEM_COMMIT,
+              "inverse-order alias test starts with fault-free mapped pages");
         *(volatile uint64_t*)(uintptr_t)(sparse_va1 + late_commit_offset + 0x120) =
             0x1a7ec0de6310cafeull;
         MEMORY_BASIC_INFORMATION late_ro_after{};
@@ -303,7 +298,7 @@ int main() {
                      &late_ro_after, sizeof(late_ro_after));
         CHECK(late_ro_after.State == MEM_COMMIT &&
                   (late_ro_after.Protect & 0xff) == PAGE_READONLY,
-              "late physical commit reapplies the untouched alias's read-only protection");
+              "write through one alias preserves the other alias's read-only protection");
         CHECK(*(volatile uint64_t*)(uintptr_t)(sparse_va2 + late_commit_offset + 0x120) ==
                   0x1a7ec0de6310cafeull,
               "late-committed read-only alias remains physically coherent");

--- a/prosper/tests/test_guest_write_watch.cpp
+++ b/prosper/tests/test_guest_write_watch.cpp
@@ -17,15 +17,6 @@ int failures = 0;
     if (!(cond)) { std::fprintf(stderr, "FAIL: %s\n", msg); ++failures; } \
 } while (0)
 
-LONG CALLBACK watch_veh(EXCEPTION_POINTERS* exception) {
-    const EXCEPTION_RECORD* record = exception->ExceptionRecord;
-    if (record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
-        record->NumberParameters >= 2 && record->ExceptionInformation[0] == 1 &&
-        prosper::host::guest_write_watch_handle_fault(
-            static_cast<uint64_t>(record->ExceptionInformation[1])))
-        return EXCEPTION_CONTINUE_EXECUTION;
-    return EXCEPTION_CONTINUE_SEARCH;
-}
 } // namespace
 
 int main() {
@@ -44,8 +35,6 @@ int main() {
         return 1;
     }
 
-    void* handler = AddVectoredExceptionHandler(1, watch_veh);
-    CHECK(handler != nullptr, "test write-watch VEH installed");
     constexpr uint64_t kPhys = 0x10000000;
     prosper::host::guest_write_watch_notify_direct_mapping_added(
         reinterpret_cast<uint64_t>(first), kSize, kPhys, PAGE_READWRITE);
@@ -55,30 +44,20 @@ int main() {
     first[0x180] = 0x11;
     GuestWriteWatch watch = GuestWriteWatch::create(
         reinterpret_cast<uint64_t>(first + 0x100), 0x2100);
-    CHECK(static_cast<bool>(watch), "section-backed range is watchable");
-    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged,
-          "new registration starts unchanged");
+    CHECK(!static_cast<bool>(watch),
+          "Windows rejects page-fault watches that can corrupt the guest SysV red zone");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unknown,
+          "unsupported watch selects the caller's exact-comparison fallback");
+    CHECK(!watch.rearm(), "unsupported watch cannot arm read-only fault pages");
 
     second[0x180] = 0x22;
     CHECK(first[0x180] == 0x22, "write through second alias updates first alias");
-    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
-          "write through any physical alias dirties the registration");
-    CHECK(watch.rearm(), "dirty registration rearms after exact validation");
-    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged,
-          "rearmed registration has a fresh generation");
-
-    first[0x1180] = 0x33;
-    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
-          "write through the original alias dirties another covered page");
-    CHECK(watch.rearm(), "registration rearms before a host physical write");
     prosper::host::guest_write_watch_notify_physical_write(kPhys + 0x1000, 0x1000);
-    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
-          "temporary physical-section writes dirty overlapping registrations");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unknown,
+          "physical writes leave an unsupported watch on the exact fallback");
 
     prosper::host::guest_write_watch_notify_direct_mapping_removed(
         reinterpret_cast<uint64_t>(second), kSize);
-    CHECK(watch.query() == GuestWriteWatchQuery::Unknown,
-          "alias topology changes invalidate existing registrations");
     watch.reset();
 
     first[0x180] = 0x44;
@@ -86,15 +65,14 @@ int main() {
 
     prosper::host::guest_write_watch_notify_direct_mapping_removed(
         reinterpret_cast<uint64_t>(first), kSize);
-    if (handler) RemoveVectoredExceptionHandler(handler);
     UnmapViewOfFile(second);
     UnmapViewOfFile(first);
     CloseHandle(section);
 
     const auto stats = prosper::host::guest_write_watch_stats();
-    CHECK(stats.faults >= 2, "write faults were handled");
-    CHECK(stats.rearms >= 1, "rearm was counted");
-    CHECK(stats.physical_writes >= 1, "physical write was counted");
+    CHECK(stats.create_attempts >= 1, "unsupported watch attempts remain observable");
+    CHECK(stats.registrations == 0 && stats.faults == 0 && stats.rearms == 0,
+          "safe Windows fallback never arms or handles guest page faults");
     if (failures) return 1;
     std::puts("== PASS ==");
     return 0;


### PR DESCRIPTION
## Summary

- replace the Windows `SEC_RESERVE` direct-memory backing with a delete-on-close sparse file
- prevent direct-memory first touches from entering the Windows exception dispatcher while guest code is running
- disable protection-fault guest write watches on Windows and retain the renderer's exact-comparison fallback
- preserve direct-memory alias coherence, protections, partial unmaps, and persistent host readability

## Root cause

Evergate's apparent loading hang was a guest main-thread null write. The crashing function saved non-null output pointers in the 128-byte SysV red zone, handled several ordinary direct-memory first-touch access violations, and later reloaded a zero pointer from one of those slots.

Windows constructs its exception-dispatch frame below the interrupted stack pointer before a vectored handler executes. That overwrites red-zone locals even when the handler successfully commits a page and resumes guest execution. The same mechanism makes protection-fault write watches unsafe for unmodified PS5/SysV code.

An automated bisect landed on the recently merged Windows `mprotect` containment change, but instrumentation showed that no `mprotect` call occurred before this crash. That merge changed exposure/timing; it did not introduce the underlying corruption, so this PR does not revert it.

## Validation

- `cmake --build prosper/build-mingw-app --target test_dmem test_guest_write_watch prosper-app -j 8`
- `ctest --test-dir prosper/build-mingw-app --output-on-failure -j 8` — 85/85 passed
- four independent Evergate fresh-save gameplay-route runs, 25 seconds each — zero guest crashes; 212–238 frames presented per run

Windows-only runtime change; Linux direct memory is unchanged.
