### PR TITLE
fix(windows): PROSPER_NULL_PAGE parity + host-code fault attribution

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -557,6 +557,11 @@ if(TARGET prosper_core)
     add_test(NAME hle_stack_args_guest_fs COMMAND test_hle_stack_args --guest-fs)
   endif()
 
+  # x86-64 low-address READ decoder used by the Windows PROSPER_NULL_PAGE emulation. Header-only, so the
+  # decode logic is verified on every platform even though the VEH caller is Windows-only.
+  add_executable(test_x86_read_decode tests/test_x86_read_decode.cpp)
+  add_test(NAME x86_read_decode COMMAND test_x86_read_decode)
+
   # End-to-end AGC submit plus fixed args 7-9 in ReleaseMem/WaitRegMem. This is cross-platform so
   # Windows validates the real fence builders behind the generated import-ABI conformance test.
   add_executable(test_agc_submit tests/test_agc_submit.cpp)

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -20,6 +20,7 @@
 #include "exec_image.hpp"
 #include "guest_write_watch.hpp"
 #include "sse4a.hpp"
+#include "x86_read_decode.hpp"
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
 
@@ -148,6 +149,13 @@ using GuestInitFn = PROSPER_SYSV_ABI void (*)(uint64_t argc, uint64_t argp);
 
 namespace {
     uint64_t g_base = 0, g_stub_base = 0, g_stub_size = 0, g_nstubs = 0;
+    uint64_t g_image_end = 0;   // g_base + max_vaddr: end of the guest module's mapped range
+    // PROSPER_NULL_PAGE: back low-address null-field READS with zero (parity with the Linux SIGSEGV
+    // handler). Windows reserves the bottom 64 KiB [0,0x10000) as the null dead-zone and VirtualAlloc
+    // cannot map it, so instead of committing a zero page we emulate the faulting read (zero the
+    // destination register, advance past the instruction). Set once; default off, matching Linux.
+    const bool g_null_page = getenv("PROSPER_NULL_PAGE") != nullptr;
+    volatile long g_null_page_count = 0;
     NidDb*   g_nid_db = nullptr;
 
     // Per-thread recovery point. A guest fault on the armed thread is turned into a longjmp back to
@@ -384,12 +392,70 @@ namespace {
         }
     }
     std::string trap_detail() {
-        char b[160];
-        snprintf(b, sizeof b, "%s at addr=0x%llx  rip=0x%llx (image+0x%llx)",
-                 g_trap_kind == 3 ? "ILLEGAL-INSN" : "ACCESS-VIOLATION",
-                 (unsigned long long)g_fault_addr, (unsigned long long)g_fault_rip,
-                 (unsigned long long)(g_base && g_fault_rip >= g_base ? g_fault_rip - g_base : g_fault_rip));
+        char b[256];
+        const char* knd = g_trap_kind == 3 ? "ILLEGAL-INSN" : "ACCESS-VIOLATION";
+        // Attribute the fault rip. A rip inside the guest module maps to eboot+off; a rip OUTSIDE it is
+        // host code (an HLE handler / renderer callback the guest called into) — resolve it against its
+        // own loaded module so the offset is addr2line-able (guest-base subtraction would be nonsense).
+        if (g_base && g_fault_rip >= g_base && (!g_image_end || g_fault_rip < g_image_end)) {
+            snprintf(b, sizeof b, "%s at addr=0x%llx  rip=0x%llx (eboot+0x%llx)", knd,
+                     (unsigned long long)g_fault_addr, (unsigned long long)g_fault_rip,
+                     (unsigned long long)(g_fault_rip - g_base));
+        } else {
+            HMODULE hmod = nullptr;
+            char modname[MAX_PATH] = {0};
+            if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                   GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                   (LPCSTR)(uintptr_t)g_fault_rip, &hmod) && hmod) {
+                char full[MAX_PATH] = {0};
+                if (GetModuleFileNameA(hmod, full, sizeof full)) {
+                    const char* bn = strrchr(full, '\\');
+                    snprintf(modname, sizeof modname, "%s", bn ? bn + 1 : full);
+                }
+                snprintf(b, sizeof b, "%s at addr=0x%llx  rip=0x%llx (host %s+0x%llx)", knd,
+                         (unsigned long long)g_fault_addr, (unsigned long long)g_fault_rip,
+                         modname[0] ? modname : "?", (unsigned long long)(g_fault_rip - (uintptr_t)hmod));
+            } else {
+                snprintf(b, sizeof b, "%s at addr=0x%llx  rip=0x%llx (host, unresolved)", knd,
+                         (unsigned long long)g_fault_addr, (unsigned long long)g_fault_rip);
+            }
+        }
         return b;
+    }
+
+    // PROSPER_NULL_PAGE (Windows): emulate a low-address (<64 KiB) DATA READ as returning zero, so the
+    // guest's null-terminated chain walks (e.g. UE's frame-pointer backtrace / init parse loops that
+    // read [null+off] and test for 0) proceed exactly as they do on Linux with a mmap'd zero page.
+    // Windows cannot map the reserved null dead-zone, so we decode the faulting instruction and zero its
+    // destination register instead. Handles ONLY the forms where writing the FULL destination to zero is
+    // provably correct: `mov r32/r64, [mem]` (0x8B, 32-bit zero-extends, 64-bit with REX.W) and
+    // movzx/movsx r, r/m8|16 (0F B6/B7/BE/BF — always full-width dest). 16-bit (0x66) and 8-bit (0x8A)
+    // partial-register forms, writes, execute-at-null, and any unrecognized opcode fall through to the
+    // normal fault path — so a genuine wild read is never silently masked. Returns true if it emulated.
+    bool try_emulate_null_read(CONTEXT* c, uint64_t fault_addr, ULONG access_type) {
+        if (!g_null_page) return false;
+        if (access_type != 0) return false;               // reads only (1=write, 8=execute must still fault)
+        if (fault_addr >= 0x10000ull) return false;       // only the 16 low pages, like Linux
+        if (fault_addr == c->Rip) return false;           // instruction fetch at null is a real endpoint
+        const uint8_t* p = (const uint8_t*)(uintptr_t)c->Rip;
+        if (!addr_readable((uint64_t)(uintptr_t)p)) return false;
+        int reg = 0, insn_len = 0;
+        // Decode via the shared, unit-tested x86 read decoder (only forms where zeroing the full dest is
+        // correct for a zero source). 15 = max x86-64 instruction length; Rip is executable so it is mapped.
+        if (!decode_low_read_dest(p, 15, &reg, &insn_len)) return false;
+        // Zero the full destination register (correct for REX.W/32-bit mov and movzx/movsx of a 0 source).
+        DWORD64* creg[16] = { &c->Rax, &c->Rcx, &c->Rdx, &c->Rbx, &c->Rsp, &c->Rbp, &c->Rsi, &c->Rdi,
+                              &c->R8, &c->R9, &c->R10, &c->R11, &c->R12, &c->R13, &c->R14, &c->R15 };
+        *creg[reg] = 0;
+        c->Rip += (uint64_t)insn_len;
+        long n = InterlockedIncrement(&g_null_page_count);
+        if (getenv("PROSPER_NULL_PAGE_LOG") && n <= 64) {
+            uint64_t off = (g_base && c->Rip >= g_base && (!g_image_end || c->Rip < g_image_end))
+                         ? c->Rip - g_base : 0;
+            fprintf(stderr, "[nullpage] #%ld addr=0x%llx rip=eboot+0x%llx (read->0)\n",
+                    n, (unsigned long long)fault_addr, (unsigned long long)off);
+        }
+        return true;
     }
 
     // AMD SSE4a INSERTQ/EXTRQ emulation (used by the PS5 guest; #UD on Intel hosts and the Intel ISA
@@ -916,6 +982,10 @@ namespace {
         if (code == EXCEPTION_ACCESS_VIOLATION && ep->ExceptionRecord->NumberParameters >= 2 &&
             ep->ExceptionRecord->ExceptionInformation[0] != 8) {
             uint64_t a = (uint64_t)ep->ExceptionRecord->ExceptionInformation[1];
+            // PROSPER_NULL_PAGE parity: a low-address null-field read returns zero (emulated). Kept before
+            // the other handlers because it is cheap and strictly scoped to reads below 64 KiB.
+            if (try_emulate_null_read(c, a, (ULONG)ep->ExceptionRecord->ExceptionInformation[0]))
+                return EXCEPTION_CONTINUE_EXECUTION;
             if (ep->ExceptionRecord->ExceptionInformation[0] == 1 &&
                 host::guest_write_watch_handle_fault(a))
                 return EXCEPTION_CONTINUE_EXECUTION;
@@ -1014,6 +1084,7 @@ bool map_image(const LoadedImage& img, std::string* err) {
     memcpy(got, img.mem.data(), sz);
     if (!g_base) {
         g_base = img.base;
+        g_image_end = img.base + img.max_vaddr;   // guest module extent, for host-vs-guest fault attribution
         const uint64_t cache_address =
             (img.base + img.max_vaddr + 0xffffull) & ~0xffffull;
         g_sse4a_fastpath_cache = (uint8_t*)VirtualAlloc(

--- a/prosper/src/host/x86_read_decode.hpp
+++ b/prosper/src/host/x86_read_decode.hpp
@@ -1,0 +1,77 @@
+// x86_read_decode.hpp — minimal x86-64 decoder for "memory READ into a general register" instructions.
+//
+// Purpose: the Windows PROSPER_NULL_PAGE path (exec_image_win.cpp) cannot map the reserved bottom-64 KiB
+// null dead-zone, so when the guest faults reading a low null-field address it must EMULATE the read as
+// returning zero — parity with the Linux SIGSEGV handler's mmap'd zero page. To do that it needs the
+// faulting instruction's destination register and total length. This header isolates that decode as a
+// pure, host-independent function so it can be unit-tested on any platform (the Windows VEH is not).
+//
+// Scope is deliberately narrow and conservative: it ONLY recognizes forms where writing the FULL 64-bit
+// destination register to zero is provably correct for a zero source operand:
+//   * mov r32/r64, r/m   (opcode 0x8B) — 64-bit needs REX.W; 32-bit zero-extends to 64. NOT 16-bit (0x66).
+//   * movzx r, r/m8|r/m16 (0F B6 / 0F B7) — always zero-extends into the full dest.
+//   * movsx r, r/m8|r/m16 (0F BE / 0F BF) — sign-extends; sign of 0 is 0, so full-dest zero is correct.
+// Everything else — 8-bit (0x8A) and 16-bit (0x66-prefixed) partial-register writes, RIP-relative-only
+// oddities aside, any other opcode, and register-source (ModRM.mod==3) forms — returns false so the
+// caller falls through to the normal fault path and never silently mishandles an instruction.
+#pragma once
+#include <cstdint>
+#include <cstddef>
+
+namespace prosper {
+
+// Decode the instruction at `p` (which must point to at least `avail` readable bytes). On success,
+// sets *dest_reg to the x86 register encoding (0=rax,1=rcx,2=rdx,3=rbx,4=rsp,5=rbp,6=rsi,7=rdi,8..15=r8..r15)
+// and *insn_len to the instruction's byte length, then returns true. Returns false for any unsupported or
+// non-memory-read form, or if the instruction would need more than `avail` bytes.
+inline bool decode_low_read_dest(const uint8_t* p, size_t avail, int* dest_reg, int* insn_len) {
+    size_t i = 0;
+    auto need = [&](size_t n) { return i + n <= avail; };
+    bool opsize16 = false;
+    // Legacy prefixes. 0x66 selects 16-bit operand size (a partial-register write — declined below).
+    for (;;) {
+        if (!need(1)) return false;
+        uint8_t b = p[i];
+        if (b == 0x66) { opsize16 = true; i++; continue; }
+        if (b == 0x67 || b == 0xF0 || b == 0xF2 || b == 0xF3 ||
+            b == 0x2E || b == 0x36 || b == 0x3E || b == 0x26 || b == 0x64 || b == 0x65) { i++; continue; }
+        break;
+    }
+    if (!need(1)) return false;
+    uint8_t rex = 0;
+    if ((p[i] & 0xF0) == 0x40) { rex = p[i]; i++; }
+    if (!need(1)) return false;
+    uint8_t op = p[i++];
+    if (op == 0x0F) {
+        if (!need(1)) return false;
+        uint8_t op2 = p[i++];
+        if (op2 != 0xB6 && op2 != 0xB7 && op2 != 0xBE && op2 != 0xBF) return false;  // not movzx/movsx
+    } else if (op != 0x8B) {
+        return false;                                            // unsupported (incl. 0x8A 8-bit)
+    }
+    // A 0x66 operand-size prefix makes the destination a 16-bit partial-register write (which zeroing the
+    // full 64-bit register would corrupt) — for both `mov` and movzx/movsx. REX.W (64-bit) overrides 0x66,
+    // so decline only the genuine 16-bit-dest case. (0x66 without REX.W: reject; 0x66 + REX.W: 64-bit, ok.)
+    if (opsize16 && !(rex & 8)) return false;
+    if (!need(1)) return false;
+    uint8_t modrm = p[i++];
+    int mod = modrm >> 6;
+    if (mod == 3) return false;                                  // register source, not a memory read
+    int reg = ((modrm >> 3) & 7) | ((rex & 4) ? 8 : 0);
+    int rm  = modrm & 7;
+    if (rm == 4) {                                               // SIB present
+        if (!need(1)) return false;
+        uint8_t sib = p[i++];
+        if (mod == 0 && (sib & 7) == 5) { i += 4; }              // base==5, mod==0 -> disp32
+    } else if (mod == 0 && rm == 5) {
+        i += 4;                                                  // RIP-relative disp32
+    }
+    if (mod == 1) i += 1;                                        // disp8
+    else if (mod == 2) i += 4;                                   // disp32
+    if (i > avail) return false;
+    *dest_reg = reg;
+    *insn_len = (int)i;
+    return true;
+}
+
+} // namespace prosper

--- a/prosper/tests/test_x86_read_decode.cpp
+++ b/prosper/tests/test_x86_read_decode.cpp
@@ -1,0 +1,78 @@
+// test_x86_read_decode - the Windows PROSPER_NULL_PAGE path emulates a faulting low-address READ by
+// zeroing the instruction's destination register and advancing past it. decode_low_read_dest() must
+// therefore (a) recognize exactly the forms where zeroing the FULL 64-bit dest is correct, (b) report the
+// right destination register and instruction length, and (c) REJECT every other form so the caller falls
+// through to the real fault path. A wrong length or register would silently corrupt guest state.
+#include "../src/host/x86_read_decode.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace prosper;
+
+namespace {
+int g_fail = 0;
+
+void expect_ok(const char* name, std::vector<uint8_t> bytes, int want_reg, int want_len) {
+    int reg = -1, len = -1;
+    bool ok = decode_low_read_dest(bytes.data(), bytes.size(), &reg, &len);
+    if (!ok || reg != want_reg || len != want_len) {
+        fprintf(stderr, "FAIL %-28s: ok=%d reg=%d(want %d) len=%d(want %d)\n",
+                name, (int)ok, reg, want_reg, len, want_len);
+        g_fail++;
+    }
+}
+
+void expect_reject(const char* name, std::vector<uint8_t> bytes) {
+    int reg = -1, len = -1;
+    if (decode_low_read_dest(bytes.data(), bytes.size(), &reg, &len)) {
+        fprintf(stderr, "FAIL %-28s: expected reject but decoded reg=%d len=%d\n", name, reg, len);
+        g_fail++;
+    }
+}
+} // namespace
+
+int main() {
+    // --- Accepted: the exact instructions observed faulting in DOLL's init walk. ---
+    expect_ok("mov (%rdx),%rdx",        {0x48,0x8b,0x12},              2, 3);  // reg=rdx
+    expect_ok("mov 0x8(%rdx),%rax",     {0x48,0x8b,0x42,0x08},         0, 4);  // reg=rax, disp8
+    expect_ok("mov disp32(%rdx),%rax",  {0x48,0x8b,0x82,0x34,0x12,0,0},0, 7);  // disp32
+    // --- Accepted: register-extension and size variants where full-dest zero is correct. ---
+    expect_ok("mov r8,(%rsi) [REX.R]",  {0x4c,0x8b,0x06},              8, 3);  // REX.WR -> r8
+    expect_ok("mov ecx,(%rax) [32-bit]",{0x8b,0x08},                   1, 2);  // 32-bit zero-extends
+    expect_ok("movzx eax,BYTE(%rsi)",   {0x0f,0xb6,0x06},              0, 3);
+    expect_ok("movzx eax,WORD(%rsi)",   {0x0f,0xb7,0x06},              0, 3);
+    expect_ok("movsx rax,BYTE(%rsi)",   {0x48,0x0f,0xbe,0x06},         0, 4);
+    // --- Accepted: SIB / RIP-relative addressing (length must include the extra bytes). ---
+    expect_ok("mov rax,[disp32] (SIB)", {0x48,0x8b,0x04,0x25,0,0,0,0}, 0, 8);  // SIB base=5,mod=0 disp32
+    expect_ok("mov rax,[rax+rcx+8]",    {0x48,0x8b,0x44,0x08,0x10},    0, 5);  // SIB + disp8
+    expect_ok("mov rax,[rip+0]",        {0x48,0x8b,0x05,0,0,0,0},      0, 7);  // RIP-relative disp32
+    // SIB with base==5 at mod==1/mod==2 must still consume its disp8/disp32 (the mod==0 disp32 special
+    // case must NOT fire here). rbp/r13-relative addressing is exactly this encoding.
+    expect_ok("mov rax,[rbp+0x10] (SIB)",  {0x48,0x8b,0x44,0x25,0x10},          0, 5); // SIB base=5,mod=1
+    expect_ok("mov rax,[rbp+disp32] (SIB)",{0x48,0x8b,0x84,0x25,0,0,0,0},        0, 8); // SIB base=5,mod=2
+    // REX.W overrides a 0x66 prefix -> 64-bit dest, so full-dest zero is correct and these are accepted.
+    expect_ok("mov rax,(%rsi) [66+REX.W]", {0x66,0x48,0x8b,0x06},               0, 4);
+    expect_ok("movzx rax,WORD [66+REX.W]", {0x66,0x48,0x0f,0xb7,0x06},          0, 5);
+
+    // --- Rejected: partial-register writes (zeroing the full dest would be wrong). ---
+    expect_reject("mov cx,(%rax) [16-bit]", {0x66,0x8b,0x08});
+    expect_reject("mov cl,(%rax) [8-bit]",  {0x8a,0x08});
+    // 0x66-prefixed movzx/movsx have a 16-bit DEST too — must be rejected (regression guard: the 0F
+    // branch originally skipped the opsize16 check, which would have zeroed the full 64-bit register).
+    expect_reject("movzx ax,BYTE(%rsi) [66]", {0x66,0x0f,0xb6,0x06});
+    expect_reject("movzx ax,WORD(%rsi) [66]", {0x66,0x0f,0xb7,0x06});
+    expect_reject("movsx ax,BYTE(%rsi) [66]", {0x66,0x0f,0xbe,0x06});
+    // --- Rejected: not a memory read. ---
+    expect_reject("mov rax,rcx [reg src]",  {0x48,0x8b,0xc1});         // ModRM.mod==3
+    expect_reject("mov (%rsi),%rax [WRITE]",{0x48,0x89,0x06});         // store opcode 0x89
+    expect_reject("lea rax,(%rdx)",         {0x48,0x8d,0x02});         // 0x8D not handled
+    expect_reject("add rax,(%rdx)",         {0x48,0x03,0x02});         // arithmetic read not handled
+    // --- Rejected: truncated instruction (fewer bytes than the encoding needs). ---
+    expect_reject("truncated disp8",        {0x48,0x8b,0x42});         // needs a disp8 byte
+
+    if (g_fail) { fprintf(stderr, "test_x86_read_decode: %d failure(s)\n", g_fail); return 1; }
+    printf("test_x86_read_decode: all cases passed\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #945.

## Problem
Two gaps in the Windows exec substrate, found bringing up DRAGON QUEST VII Reimagined (PPSA17942 / DOLL) on `prosper-app.exe`:

1. **`PROSPER_NULL_PAGE` is a silent no-op on Windows.** The Linux SIGSEGV handler backs low-address (`<0x10000`) null-field READs with a zero page, so the guest's null-terminated chain walks (UE's frame-pointer backtrace walker, init parse loops) read 0 and terminate. CLAUDE.md states DOLL *requires* NULL_PAGE. Windows cannot `VirtualAlloc` the bottom-64 KiB null dead-zone (exactly the range Linux backs), so this was simply missing.
2. **Host-code faults print a nonsense offset.** `trap_detail()` computed `rip - g_base` for any `rip >= g_base`, so a fault in *host* code (an HLE/renderer callback the guest called into, `rip` in the `0x7ff…` range) reported `image+0x7ff3…` — un-symbolicatable.

## Failure scenario
`PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 -force-gfx-direct prosper-app.exe --dump …/PPSA17942-app0`:
a guest init fn reads a near-null field (`addr=0x9c24`) at `eboot+0x22ebe7f`. On Linux the zero page makes it read 0 and init completes; on Windows it faults, `run_guest_inits` swallows it, and the half-initialized state later crashes in `k_mutex_lock` called with a garbage near-null pointer — reported (before this change) as the meaningless `rip=0x7ff…f103 (image+0x7ff3…)`.

## Change
- **VEH NULL_PAGE emulation** (`exec_image_win.cpp`): on an ACCESS-VIOLATION READ below 64 KiB (and `addr != rip`, so execute-through-null still faults), decode the faulting instruction and **zero its destination register**, then advance past it — the same observable result as Linux's zero page. Only forms where zeroing the full 64-bit dest is provably correct for a zero source are handled (`mov r32/r64,[mem]`; `movzx/movsx r,[m8/m16]`); 8/16-bit partial writes, stores, and unknown opcodes fall through to the real fault path, so a genuine wild read is never masked. Off by default (parity with Linux); `PROSPER_NULL_PAGE_LOG=1` traces emulations.
- **Host-module fault attribution** (`trap_detail()`): a rip outside the guest module `[g_base, g_base+max_vaddr)` is resolved against its own loaded module (`host <name>+0x<off>`) via `GetModuleHandleExA`. This is what localized the crash to `k_mutex_lock`.
- **Pure, unit-tested decoder** (`x86_read_decode.hpp` + `tests/test_x86_read_decode.cpp`): the decode logic is isolated so it runs on every platform, though the VEH caller is Windows-only. Tests cover the accepted forms, the partial-register/store/reg-source/unknown rejections, SIB and RIP-relative length, and truncation.

## Behavioral scope
- **Affected only when `PROSPER_NULL_PAGE=1`** (a DOLL-specific switch). No other title sets it, so Messenger/Astro/etc. are byte-for-byte unaffected.
- `trap_detail()` only runs when a fault has already been decided — it changes the crash *message*, never control flow.
- **This does NOT make DOLL boot on Windows.** It removes the specific init-fault→`k_mutex_lock(0x1c08)` crash; with NULL_PAGE active DOLL then reaches a *separate, pre-existing* Windows HLE divergence (a null base pointer at the module-1 init → `eboot+0x22ebe7f` structure walk) that hangs in init — tracked in **#946**. Landing NULL_PAGE parity + the host-fault diagnostic is the correct foundation for that follow-up.

## Risk
The only non-trivial logic is the instruction decoder (an emulation path). It is conservative (whitelist of provably-safe forms; everything else falls through) and unit-tested. Because recompiler/emulation edge behavior is easy to get subtly wrong, an independent review of the decoder + VEH gating is warranted.

## Verification (branch head `0dc4d58`)
- `test_x86_read_decode` — all cases pass (Linux, in-tree ctest and standalone `-Wall -Wextra`).
- Windows/MinGW app rebuilt; DOLL: **4/4 runs no longer crash** (was a ~2s crash every run); `[nullpage] … (read->0)` fires and `init fn … faulted` is gone.
- Messenger Windows bare-boot behavior unchanged (its pre-existing near-null crash at `eboot+0x13cfb6b` is control-flow-independent of these changes; NULL_PAGE off for it).
- Full CI matrix (Linux/Windows/macOS + apps) pending on this PR.
