### PR TITLE
fix(hle/mem): honor flexible mapping hints

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2266,7 +2266,7 @@ namespace {
 
     enum class FlexibleHintState { Unavailable, Free, GuestReservation };
 
-    bool guest_reservation_covers(uint64_t begin, uint64_t end) {
+    bool hle_reservation_covers(uint64_t begin, uint64_t end) {
         if (begin >= end) return false;
         {
             std::lock_guard<std::mutex> lk(g_mx);
@@ -2285,6 +2285,10 @@ namespace {
         std::lock_guard<std::mutex> lk(g_dview_mx);
         if (private_placeholder_view_containing_locked(begin, end)) return true;
         for (const PlaceholderSpan& span : g_guest_placeholders)
+            if (begin >= span.base && end <= span.base + span.size) return true;
+        // A partial direct-memory unmap returns its hole to the HLE-owned free-placeholder
+        // registry. Flexible memory may claim that exact hole just like direct memory can.
+        for (const PlaceholderSpan& span : g_free_placeholders)
             if (begin >= span.base && end <= span.base + span.size) return true;
         return false;
     }
@@ -2319,7 +2323,7 @@ namespace {
             if (region_end <= cursor || mbi.State == MEM_COMMIT)
                 return FlexibleHintState::Unavailable;
             if (mbi.State == MEM_RESERVE) {
-                if (!guest_reservation_covers(cursor, std::min<uint64_t>(end, region_end)))
+                if (!hle_reservation_covers(cursor, std::min<uint64_t>(end, region_end)))
                     return FlexibleHintState::Unavailable;
                 saw_reservation = true;
             }
@@ -2413,9 +2417,27 @@ namespace {
         if (state != FlexibleHintState::Free) return nullptr;
 
         const DWORD pp = win_page_prot(hp);
-        void* result = VirtualAlloc(
-            reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
-            static_cast<SIZE_T>(len), MEM_RESERVE | MEM_COMMIT, pp);
+        void* result = nullptr;
+        {
+            // VirtualAlloc reservations round a free address down to 64 KiB. Use the placeholder
+            // splitter first so a fixed 16 KiB-aligned guest hint is either mapped exactly or not
+            // at all; the retained prefix/suffix become reusable HLE-owned placeholders.
+            std::lock_guard<std::mutex> lk(g_dview_mx);
+            AcquiredPlaceholder acquired =
+                acquire_placeholder_locked(hint, len, 0x4000, false);
+            if (acquired.address ==
+                reinterpret_cast<void*>(static_cast<uintptr_t>(hint)))
+                result = replace_placeholder_with_private_locked(
+                    hint, len, hp, acquired.owner);
+            else if (acquired.address)
+                restore_placeholder_owner_locked(
+                    acquired.owner,
+                    static_cast<uint64_t>(reinterpret_cast<uintptr_t>(acquired.address)), len);
+        }
+        if (!result && (hint & (kWinAllocationGranularity - 1)) == 0)
+            result = VirtualAlloc(
+                reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+                static_cast<SIZE_T>(len), MEM_RESERVE | MEM_COMMIT, pp);
         if (result)
             host::guest_write_watch_notify_direct_mapping_added(
                 static_cast<uint64_t>(reinterpret_cast<uintptr_t>(result)), len,

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -286,13 +286,16 @@ namespace {
     // collision can skip directly past them instead of probing every 64 KiB page.
     constexpr uint64_t kGuestAutoMapBase  = 0x2000000000ull;
     constexpr uint64_t kGuestAutoMapLimit = 0x40000000000ull;
-    void* map_guest_auto(uint64_t len, int prot, uint64_t align) {
+    void* map_guest_from(uint64_t start, uint64_t len, int prot, uint64_t align) {
         const uint64_t page = (uint64_t)sysconf(_SC_PAGESIZE);
         if (align < page) align = page;
-        if (!len || (align & (align - 1)) != 0 || len > kGuestAutoMapLimit - kGuestAutoMapBase)
+        if (!len || (align & (align - 1)) != 0 ||
+            start > UINT64_MAX - (align - 1))
             return nullptr;
         const uint64_t step = align > 0x10000 ? align : 0x10000;
-        uint64_t cand = align_up(kGuestAutoMapBase, align);
+        uint64_t cand = align_up(start, align);
+        if (cand >= kGuestAutoMapLimit || len > kGuestAutoMapLimit - cand)
+            return nullptr;
         while (cand <= kGuestAutoMapLimit - len) {
             void* p = prosper_mmap_noreplace((void*)cand, len, prot,
                                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -314,6 +317,10 @@ namespace {
             cand = next;
         }
         return nullptr;
+    }
+
+    void* map_guest_auto(uint64_t len, int prot, uint64_t align) {
+        return map_guest_from(kGuestAutoMapBase, len, prot, align);
     }
 
     void* map_at(uint64_t hint, uint64_t len, int prot) {
@@ -516,7 +523,11 @@ HLE(k_reserve_vrange) {
 // sceKernelMapNamedFlexibleMemory(void** addrInOut, size_t len, int prot, int flags, const char* name)
 HLE(k_map_flexible) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
+    const bool fixed = (a3 & 0x10) != 0;   // SCE_KERNEL_MAP_FIXED
+    if (fixed && !hint) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     void* p = map_at(hint, a1, host_prot(a2));
+    if (!p && hint && !fixed)
+        p = map_guest_from(hint, a1, host_prot(a2), 0x4000);
     if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), true, a4 ? (const char*)a4 : "flexible");
@@ -1482,6 +1493,15 @@ namespace {
                 if (!best || m.base > best->base) best = &m;
         return best;
     }
+    bool committed_mapping_overlaps(uint64_t base, uint64_t len) {
+        if (!len || base > UINT64_MAX - len) return true;
+        const uint64_t end = base + len;
+        std::lock_guard<std::mutex> lk(g_mx);
+        for (const auto& m : g_maps)
+            if (m.committed && m.base < end && m.base + m.size > base)
+                return true;
+        return false;
+    }
     uint64_t next_base(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);
         uint64_t n = 0;
@@ -2329,6 +2349,55 @@ namespace {
                 (uint64_t)(uintptr_t)result, len, (uint64_t)(uintptr_t)result, pp);
         return result;
     }
+
+    // Map flexible memory at the first host-free address at or above a guest hint. Windows'
+    // default VirtualAlloc(nullptr, ...) placement is not a search-from-hint operation and may
+    // also land in the 1-8 TiB aperture rejected by Sony libc. Probe the valid low guest aperture
+    // explicitly; VirtualAlloc at the selected candidate makes each probe race-safe.
+    void* win_commit_from(uint64_t start, uint64_t len, int hp) {
+        if (!len || len > kGuestAutoVaMax - kGuestAutoVaMin + 1)
+            return nullptr;
+        const uint64_t first = std::max<uint64_t>(start, kGuestAutoVaMin);
+        if (first > UINT64_MAX - (kWinAllocationGranularity - 1))
+            return nullptr;
+        uint64_t cursor = align_up(first, kWinAllocationGranularity);
+        const uint64_t last = kGuestAutoVaMax - len + 1;
+        const DWORD pp = win_page_prot(hp);
+        while (cursor <= last) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                              &mbi, sizeof(mbi)))
+                return nullptr;
+            const uint64_t region_base =
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress));
+            const uint64_t region_end =
+                region_base > UINT64_MAX - mbi.RegionSize
+                    ? UINT64_MAX
+                    : region_base + static_cast<uint64_t>(mbi.RegionSize);
+            if (mbi.State == MEM_FREE) {
+                const uint64_t candidate = align_up(std::max(cursor, region_base),
+                                                    kWinAllocationGranularity);
+                if (candidate <= last && candidate <= region_end &&
+                    len <= region_end - candidate) {
+                    if (void* result = VirtualAlloc(
+                            reinterpret_cast<void*>(static_cast<uintptr_t>(candidate)),
+                            static_cast<SIZE_T>(len), MEM_RESERVE | MEM_COMMIT, pp)) {
+                        host::guest_write_watch_notify_direct_mapping_added(
+                            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(result)), len,
+                            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(result)), pp);
+                        return result;
+                    }
+                }
+            }
+            uint64_t next = region_end > cursor
+                ? region_end
+                : cursor + kWinAllocationGranularity;
+            if (next <= cursor || next > UINT64_MAX - (kWinAllocationGranularity - 1))
+                return nullptr;
+            cursor = align_up(next, kWinAllocationGranularity);
+        }
+        return nullptr;
+    }
     void* win_map_phys(uint64_t hint, uint64_t len, int hp, uint64_t phys, uint64_t align,
                        bool fixed) {
         if (void* p = map_section_view(hint, len, hp, phys, align)) return p;
@@ -3080,7 +3149,16 @@ HLE(k_reserve_vrange) {
 // sceKernelMapNamedFlexibleMemory(void** addrInOut, size_t len, int prot, int flags, const char* name)
 HLE(k_map_flexible) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
-    void* p = win_commit(hint, a1, host_prot(a2));
+    const bool fixed = (a3 & 0x10) != 0;   // SCE_KERNEL_MAP_FIXED
+    if (fixed && !hint) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
+    // win_commit() deliberately recommits/reprotects an existing private placeholder view for
+    // partial-unmap support. That is correct for a hole or uncommitted reservation, but a new map
+    // must not mistake an already committed guest mapping for available space.
+    void* p = hint && !committed_mapping_overlaps(hint, a1)
+        ? win_commit(hint, a1, host_prot(a2))
+        : nullptr;
+    if (!p && !fixed)
+        p = win_commit_from(hint ? hint : kGuestAutoVaMin, a1, host_prot(a2));
     if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n",
                    (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; }
     if (a0) *(uint64_t*)a0 = (uint64_t)p;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1493,15 +1493,6 @@ namespace {
                 if (!best || m.base > best->base) best = &m;
         return best;
     }
-    bool committed_mapping_overlaps(uint64_t base, uint64_t len) {
-        if (!len || base > UINT64_MAX - len) return true;
-        const uint64_t end = base + len;
-        std::lock_guard<std::mutex> lk(g_mx);
-        for (const auto& m : g_maps)
-            if (m.committed && m.base < end && m.base + m.size > base)
-                return true;
-        return false;
-    }
     uint64_t next_base(uint64_t addr) {
         std::lock_guard<std::mutex> lk(g_mx);
         uint64_t n = 0;
@@ -2273,6 +2264,71 @@ namespace {
         return result;
     }
 
+    enum class FlexibleHintState { Unavailable, Free, GuestReservation };
+
+    bool guest_reservation_covers(uint64_t begin, uint64_t end) {
+        if (begin >= end) return false;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            uint64_t cursor = begin;
+            while (cursor < end) {
+                const Mapping* cover = nullptr;
+                for (const auto& m : g_maps) {
+                    if (cursor < m.base || cursor >= m.base + m.size) continue;
+                    if (!cover || m.base > cover->base) cover = &m;
+                }
+                if (!cover || cover->committed) break;
+                cursor = std::min<uint64_t>(end, cover->base + cover->size);
+            }
+            if (cursor == end) return true;
+        }
+        std::lock_guard<std::mutex> lk(g_dview_mx);
+        if (private_placeholder_view_containing_locked(begin, end)) return true;
+        for (const PlaceholderSpan& span : g_guest_placeholders)
+            if (begin >= span.base && end <= span.base + span.size) return true;
+        return false;
+    }
+
+    // Classify an exact flexible-memory hint without treating arbitrary host reservations as guest
+    // storage. In particular, VirtualAlloc(..., MEM_COMMIT) succeeds on already committed pages;
+    // checking only the HLE tracker would therefore let an untracked image/host allocation be
+    // adopted. MEM_RESERVE is eligible only when the guest owns the reservation or placeholder.
+    FlexibleHintState flexible_hint_state(uint64_t base, uint64_t len) {
+        if (!len || base > UINT64_MAX - len) return FlexibleHintState::Unavailable;
+        const uint64_t end = base + len;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            for (const auto& m : g_maps)
+                if (m.committed && m.base < end && m.base + m.size > base)
+                    return FlexibleHintState::Unavailable;
+        }
+
+        bool saw_reservation = false;
+        uint64_t cursor = base;
+        while (cursor < end) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                              &mbi, sizeof(mbi)))
+                return FlexibleHintState::Unavailable;
+            const uint64_t region_base =
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress));
+            const uint64_t region_end =
+                region_base > UINT64_MAX - mbi.RegionSize
+                    ? UINT64_MAX
+                    : region_base + static_cast<uint64_t>(mbi.RegionSize);
+            if (region_end <= cursor || mbi.State == MEM_COMMIT)
+                return FlexibleHintState::Unavailable;
+            if (mbi.State == MEM_RESERVE) {
+                if (!guest_reservation_covers(cursor, std::min<uint64_t>(end, region_end)))
+                    return FlexibleHintState::Unavailable;
+                saw_reservation = true;
+            }
+            cursor = std::min<uint64_t>(end, region_end);
+        }
+        return saw_reservation ? FlexibleHintState::GuestReservation
+                               : FlexibleHintState::Free;
+    }
+
     // Commit `len` at `hint` (0 = OS chooses). Placeholder-backed guest reservations and holes
     // are replaced with ordinary private pages so the same 16 KiB address can later be reused by
     // either flexible or direct memory. Legacy VirtualAlloc reservations retain their old path.
@@ -2347,6 +2403,23 @@ namespace {
         if (result)
             host::guest_write_watch_notify_direct_mapping_added(
                 (uint64_t)(uintptr_t)result, len, (uint64_t)(uintptr_t)result, pp);
+        return result;
+    }
+
+    void* win_commit_flexible_exact(uint64_t hint, uint64_t len, int hp) {
+        const FlexibleHintState state = flexible_hint_state(hint, len);
+        if (state == FlexibleHintState::GuestReservation)
+            return win_commit(hint, len, hp);
+        if (state != FlexibleHintState::Free) return nullptr;
+
+        const DWORD pp = win_page_prot(hp);
+        void* result = VirtualAlloc(
+            reinterpret_cast<void*>(static_cast<uintptr_t>(hint)),
+            static_cast<SIZE_T>(len), MEM_RESERVE | MEM_COMMIT, pp);
+        if (result)
+            host::guest_write_watch_notify_direct_mapping_added(
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(result)), len,
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(result)), pp);
         return result;
     }
 
@@ -3151,12 +3224,7 @@ HLE(k_map_flexible) {
     uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
     const bool fixed = (a3 & 0x10) != 0;   // SCE_KERNEL_MAP_FIXED
     if (fixed && !hint) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
-    // win_commit() deliberately recommits/reprotects an existing private placeholder view for
-    // partial-unmap support. That is correct for a hole or uncommitted reservation, but a new map
-    // must not mistake an already committed guest mapping for available space.
-    void* p = hint && !committed_mapping_overlaps(hint, a1)
-        ? win_commit(hint, a1, host_prot(a2))
-        : nullptr;
+    void* p = hint ? win_commit_flexible_exact(hint, a1, host_prot(a2)) : nullptr;
     if (!p && !fixed)
         p = win_commit_from(hint ? hint : kGuestAutoVaMin, a1, host_prot(a2));
     if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n",

--- a/prosper/tests/test_map_noreplace.cpp
+++ b/prosper/tests/test_map_noreplace.cpp
@@ -2,8 +2,8 @@
 // map_at/map_phys_at forced MAP_FIXED for any non-zero hint, so a MapFlexible/MapDirectMemory
 // whose hint overlapped a committed mapping (or a loaded guest image) destroyed it. The fix:
 // MAP_FIXED_NOREPLACE, upgraded to MAP_FIXED only when the hint is entirely our own uncommitted
-// reservation. This drives the real HLE handlers and asserts a committed range survives a
-// colliding map, that committing an OWN reservation still works, and that a free hint is honored.
+// reservation. This drives the real HLE handlers and asserts a non-fixed collision relocates, a
+// fixed collision fails without clobbering, and committing an OWN reservation still works.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <cstdio>
@@ -35,12 +35,22 @@ int main() {
     volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)va;
     *cell = 0xC0FFEE42u;
 
-    // 2. Map AGAIN at the same (now COMMITTED) hint. The old code MAP_FIXED'd fresh zero pages over
-    //    it, erasing the sentinel; the fix refuses (the range is committed, not a free reservation).
+    // 2. Map AGAIN at the same (now COMMITTED) non-fixed hint. The address is a search start, so
+    //    the mapping relocates forward rather than overwriting the live range or returning ENOMEM.
     uint64_t va2 = va;
     uint64_t r2 = flexible(U(&va2), LEN, 0x2, 0, U("colliding"), 0);
-    CHECK(r2 != 0, "MapFlexible over a COMMITTED hint fails (does not clobber)");
-    CHECK(*cell == 0xC0FFEE42u, "the committed range's contents SURVIVED the colliding map");
+    CHECK(r2 == 0 && va2 > va,
+          "non-fixed MapFlexible over a committed hint relocates forward");
+    CHECK(*cell == 0xC0FFEE42u,
+          "the committed range's contents survive the relocated map");
+
+    uint64_t fixed = va;
+    uint64_t rf = flexible(U(&fixed), LEN, 0x2, 0x10 /*SCE_KERNEL_MAP_FIXED*/,
+                           U("fixed-colliding"), 0);
+    CHECK(rf != 0 && fixed == va,
+          "fixed MapFlexible over a committed hint fails without relocating");
+    CHECK(*cell == 0xC0FFEE42u,
+          "the committed range's contents survive the failed fixed map");
 
     // 3. Committing an OWN reservation must still work: reserve fixed, then map into it.
     //    Find a free high VA by probing with the host mmap the handler uses.

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -71,6 +71,21 @@ int main() {
               null_fixed == 0,
           "MapFlexible rejects MAP_FIXED with a null address");
 
+#ifdef _WIN32
+    const uint64_t free_cover = find_free_guest_span(page * 2);
+    uint64_t unaligned_fixed = free_cover ? free_cover + 0x4000 : 0;
+    const bool unaligned_fixed_mapped = unaligned_fixed &&
+        flexible((uint64_t)(uintptr_t)&unaligned_fixed, page, 0x2,
+                 0x10 /* SCE_KERNEL_MAP_FIXED */,
+                 (uint64_t)(uintptr_t)"unaligned-fixed", 0) == 0 &&
+        unaligned_fixed == free_cover + 0x4000;
+    CHECK(unaligned_fixed_mapped,
+          "fixed free 16 KiB hint maps exactly instead of rounding down to 64 KiB");
+    if (unaligned_fixed_mapped)
+        CHECK(unmap(unaligned_fixed, page, 0, 0, 0, 0) == 0,
+              "fixed 16 KiB flexible mapping unmaps cleanly");
+#endif
+
     uint64_t first_flexible = 0;
     const bool first_flexible_mapped =
         flexible((uint64_t)(uintptr_t)&first_flexible, page, 0x2, 0,
@@ -168,24 +183,29 @@ int main() {
           "failed mprotect leaves reservation tracking unchanged");
 
 #ifdef _WIN32
-    // #926: MEM_COMMIT says that a host allocation exists, not that it belongs to the guest. Put
-    // one tracked guest page and one unrelated host-committed page in a single host reservation so
-    // the boundary-crossing failure is deterministic regardless of the process address layout.
-    const uint64_t host_base = find_free_guest_span(page * 2);
-    CHECK(host_base != 0, "find deterministic guest/host ownership test span");
-    if (host_base) {
-        uint64_t guest_page = host_base;
-        const bool guest_map_succeeded =
-            flexible((uint64_t)(uintptr_t)&guest_page, page, 0x2,
-                     0x10 /* SCE_KERNEL_MAP_FIXED */,
-                     (uint64_t)(uintptr_t)"mprotect-ownership", 0) == 0 && guest_page;
-        const bool guest_mapped = guest_map_succeeded && guest_page == host_base;
+    // #926: MEM_COMMIT says that a host allocation exists, not that it belongs to the guest. Keep
+    // both pages in ONE host reservation, then use BatchMap's exact flexible operation to commit
+    // and track only the first page. This makes a boundary-crossing ownership failure independent
+    // of Windows' separate-allocation VirtualProtect restriction.
+    void* host_reservation = VirtualAlloc(nullptr, page * 2, MEM_RESERVE, PAGE_NOACCESS);
+    CHECK(host_reservation != nullptr, "reserve deterministic guest/host ownership test span");
+    if (host_reservation) {
+        const uint64_t host_base = (uint64_t)(uintptr_t)host_reservation;
+        alignas(8) uint8_t map_entry[0x20]{};
+        *(uint64_t*)(map_entry + 0x00) = host_base;
+        *(uint64_t*)(map_entry + 0x10) = page;
+        map_entry[0x18] = 0x2;
+        *(int32_t*)(map_entry + 0x1c) = 3; // MAP_FLEXIBLE
+        int32_t map_done = -1;
+        const bool guest_mapped =
+            batch((uint64_t)(uintptr_t)map_entry, 1,
+                  (uint64_t)(uintptr_t)&map_done, 0, 0, 0) == 0 && map_done == 1;
         CHECK(guest_mapped, "commit and track the first page as guest memory");
 
         void* foreign_page = nullptr;
         if (guest_mapped) {
             foreign_page = VirtualAlloc((void*)(uintptr_t)(host_base + page), page,
-                                        MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+                                        MEM_COMMIT, PAGE_READWRITE);
         }
         CHECK(foreign_page == (void*)(uintptr_t)(host_base + page),
               "commit the adjacent page outside the guest tracker");
@@ -229,12 +249,11 @@ int main() {
                   "failed protection calls leave unrelated host memory unchanged");
         }
 
-        if (guest_map_succeeded)
-            CHECK(unmap(guest_page, page, 0, 0, 0, 0) == 0,
+        if (guest_mapped)
+            CHECK(unmap(host_base, page, 0, 0, 0, 0) == 0,
                   "tracked ownership-test page unmaps cleanly");
-        if (foreign_page)
-            CHECK(VirtualFree(foreign_page, 0, MEM_RELEASE) != 0,
-                  "ownership-test foreign page releases cleanly");
+        CHECK(VirtualFree(host_reservation, 0, MEM_RELEASE) != 0,
+              "ownership-test host reservation releases cleanly");
     }
 #endif
 

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -19,6 +19,30 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+#ifdef _WIN32
+static uint64_t find_free_guest_span(uint64_t len) {
+    constexpr uint64_t kGranule = 0x10000;
+    constexpr uint64_t kGuestVaBegin = 0x2000000000ull;
+    constexpr uint64_t kGuestVaEnd = 0xfc00000000ull;
+    uint64_t cursor = kGuestVaBegin;
+    while (cursor <= kGuestVaEnd - len) {
+        MEMORY_BASIC_INFORMATION mbi{};
+        if (!VirtualQuery((void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) break;
+        const uint64_t region_base = (uint64_t)(uintptr_t)mbi.BaseAddress;
+        const uint64_t region_end = region_base + (uint64_t)mbi.RegionSize;
+        if (mbi.State == MEM_FREE) {
+            uint64_t candidate = cursor > region_base ? cursor : region_base;
+            candidate = (candidate + kGranule - 1) & ~(kGranule - 1);
+            if (candidate <= kGuestVaEnd - len && candidate + len <= region_end)
+                return candidate;
+        }
+        if (region_end <= cursor) break;
+        cursor = (region_end + kGranule - 1) & ~(kGranule - 1);
+    }
+    return 0;
+}
+#endif
+
 int main() {
     printf("== test_retrack_reservation ==\n");
     register_builtin_hle();
@@ -80,6 +104,45 @@ int main() {
               "original flexible page unmaps cleanly");
     }
 
+#ifdef _WIN32
+    // A loaded image or host allocation is not represented in the HLE mapping tracker. Windows
+    // nevertheless lets VirtualAlloc(MEM_COMMIT) succeed on an already committed range, so the
+    // exact-hint path must consult host VA state before it adopts and tracks an address.
+    const uint64_t foreign_base = find_free_guest_span(page);
+    void* foreign_page = foreign_base
+        ? VirtualAlloc((void*)(uintptr_t)foreign_base, page,
+                       MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE)
+        : nullptr;
+    CHECK(foreign_page != nullptr,
+          "create an untracked committed page in the guest VA aperture");
+    if (foreign_page) {
+        auto* foreign_cell = (volatile uint32_t*)foreign_page;
+        *foreign_cell = 0x387F60F1u;
+        const uint64_t foreign_address = (uint64_t)(uintptr_t)foreign_page;
+
+        uint64_t relocated = foreign_address;
+        const bool foreign_relocated =
+            flexible_noname((uint64_t)(uintptr_t)&relocated, page, 0x2, 0, 0, 0) == 0 &&
+            relocated > foreign_address;
+        CHECK(foreign_relocated,
+              "non-fixed untracked committed hint relocates forward");
+        CHECK(*foreign_cell == 0x387F60F1u,
+              "relocation preserves the untracked committed page");
+
+        uint64_t fixed_foreign = foreign_address;
+        CHECK(flexible_noname((uint64_t)(uintptr_t)&fixed_foreign, page, 0x2,
+                              0x10 /* SCE_KERNEL_MAP_FIXED */, 0, 0) != 0 &&
+                  fixed_foreign == foreign_address && *foreign_cell == 0x387F60F1u,
+              "fixed untracked committed hint fails without adopting it");
+
+        if (foreign_relocated)
+            CHECK(unmap(relocated, page, 0, 0, 0, 0) == 0,
+                  "mapping relocated from an untracked page unmaps cleanly");
+        CHECK(VirtualFree(foreign_page, 0, MEM_RELEASE) != 0,
+              "untracked committed page releases cleanly");
+    }
+#endif
+
     constexpr uint64_t len = page * 3;
     uint64_t base = 0;
     CHECK(reserve((uint64_t)(uintptr_t)&base, len, 0, page, 0, 0) == 0 && base,
@@ -108,13 +171,13 @@ int main() {
     // #926: MEM_COMMIT says that a host allocation exists, not that it belongs to the guest. Put
     // one tracked guest page and one unrelated host-committed page in a single host reservation so
     // the boundary-crossing failure is deterministic regardless of the process address layout.
-    void* host_reservation = VirtualAlloc(nullptr, page * 2, MEM_RESERVE, PAGE_NOACCESS);
-    CHECK(host_reservation != nullptr, "reserve deterministic guest/host ownership test span");
-    if (host_reservation) {
-        const uint64_t host_base = (uint64_t)(uintptr_t)host_reservation;
+    const uint64_t host_base = find_free_guest_span(page * 2);
+    CHECK(host_base != 0, "find deterministic guest/host ownership test span");
+    if (host_base) {
         uint64_t guest_page = host_base;
         const bool guest_map_succeeded =
-            flexible((uint64_t)(uintptr_t)&guest_page, page, 0x2, 0,
+            flexible((uint64_t)(uintptr_t)&guest_page, page, 0x2,
+                     0x10 /* SCE_KERNEL_MAP_FIXED */,
                      (uint64_t)(uintptr_t)"mprotect-ownership", 0) == 0 && guest_page;
         const bool guest_mapped = guest_map_succeeded && guest_page == host_base;
         CHECK(guest_mapped, "commit and track the first page as guest memory");
@@ -122,7 +185,7 @@ int main() {
         void* foreign_page = nullptr;
         if (guest_mapped) {
             foreign_page = VirtualAlloc((void*)(uintptr_t)(host_base + page), page,
-                                        MEM_COMMIT, PAGE_READWRITE);
+                                        MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
         }
         CHECK(foreign_page == (void*)(uintptr_t)(host_base + page),
               "commit the adjacent page outside the guest tracker");
@@ -169,8 +232,9 @@ int main() {
         if (guest_map_succeeded)
             CHECK(unmap(guest_page, page, 0, 0, 0, 0) == 0,
                   "tracked ownership-test page unmaps cleanly");
-        CHECK(VirtualFree(host_reservation, 0, MEM_RELEASE) != 0,
-              "ownership-test host reservation releases cleanly");
+        if (foreign_page)
+            CHECK(VirtualFree(foreign_page, 0, MEM_RELEASE) != 0,
+                  "ownership-test foreign page releases cleanly");
     }
 #endif
 

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -28,12 +28,58 @@ int main() {
     auto batch    = Hle::lookup(nid_hash("sceKernelBatchMap"));
     auto query    = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
     auto flexible = Hle::lookup(nid_hash("sceKernelMapNamedFlexibleMemory"));
+    auto flexible_noname = Hle::lookup(nid_hash("sceKernelMapFlexibleMemory"));
     auto unmap    = Hle::lookup(nid_hash("sceKernelMunmap"));
-    CHECK(reserve && protect && mtypeprotect && batch && query && flexible && unmap,
+    CHECK(reserve && protect && mtypeprotect && batch && query && flexible &&
+              flexible_noname && unmap,
           "memory HLE functions registered");
     if (fails) return 1;
 
     constexpr uint64_t page = 0x10000;
+
+    // #387 F6: without MAP_FIXED a nonzero address is a search hint. An occupied hint must
+    // relocate forward without clobbering the existing mapping; MAP_FIXED retains exact-address
+    // behavior and cannot be combined with a null address.
+    uint64_t null_fixed = 0;
+    CHECK((uint32_t)flexible((uint64_t)(uintptr_t)&null_fixed, page, 0x2,
+                             0x10 /* SCE_KERNEL_MAP_FIXED */,
+                             (uint64_t)(uintptr_t)"null-fixed", 0) == 0x80020016u &&
+              null_fixed == 0,
+          "MapFlexible rejects MAP_FIXED with a null address");
+
+    uint64_t first_flexible = 0;
+    const bool first_flexible_mapped =
+        flexible((uint64_t)(uintptr_t)&first_flexible, page, 0x2, 0,
+                 (uint64_t)(uintptr_t)"flexible-hint-first", 0) == 0 &&
+        first_flexible;
+    CHECK(first_flexible_mapped, "map an automatic flexible page for hint collision");
+    if (first_flexible_mapped) {
+        volatile uint32_t* first_cell =
+            (volatile uint32_t*)(uintptr_t)first_flexible;
+        *first_cell = 0x387F6001u;
+
+        uint64_t relocated = first_flexible;
+        const bool relocated_mapped =
+            flexible_noname((uint64_t)(uintptr_t)&relocated, page, 0x2, 0, 0, 0) == 0 &&
+            relocated > first_flexible;
+        CHECK(relocated_mapped,
+              "non-fixed occupied flexible-memory hint relocates forward");
+        CHECK(*first_cell == 0x387F6001u,
+              "relocated flexible mapping preserves the occupied hint");
+
+        uint64_t fixed_collision = first_flexible;
+        CHECK(flexible_noname((uint64_t)(uintptr_t)&fixed_collision, page, 0x2,
+                              0x10 /* SCE_KERNEL_MAP_FIXED */, 0, 0) != 0 &&
+                  fixed_collision == first_flexible && *first_cell == 0x387F6001u,
+              "fixed occupied flexible-memory hint fails without clobbering it");
+
+        if (relocated_mapped)
+            CHECK(unmap(relocated, page, 0, 0, 0, 0) == 0,
+                  "relocated flexible page unmaps cleanly");
+        CHECK(unmap(first_flexible, page, 0, 0, 0, 0) == 0,
+              "original flexible page unmaps cleanly");
+    }
+
     constexpr uint64_t len = page * 3;
     uint64_t base = 0;
     CHECK(reserve((uint64_t)(uintptr_t)&base, len, 0, page, 0, 0) == 0 && base,


### PR DESCRIPTION
Fixes the flexible-memory portion of #387 F6.

`SCE_KERNEL_MAP_FIXED` now controls exact placement for both `sceKernelMapFlexibleMemory` and `sceKernelMapNamedFlexibleMemory`. Without it, an occupied nonzero address relocates forward instead of returning ENOMEM; with it, a null address returns `SCE_KERNEL_ERROR_EINVAL` and an occupied range remains untouched.

The Windows path searches the valid low guest VA aperture, distinguishes committed guest/foreign mappings from HLE-owned reservation and placeholder holes, and preserves exact 16 KiB placement through the placeholder splitter. Linux uses the existing no-clobber guest-VA search discipline.

Exact-head gates for `832103e4f5792a4f68450dea8305f55bf1d9cc9e`:
- inspection-only approval: https://github.com/mattias800/ps5ys/pull/948#issuecomment-5013333802
- author verification: https://github.com/mattias800/ps5ys/pull/948#issuecomment-5013340170 (Linux 108/108; Windows 82/82)

No snapshots were run for this PR.