### PR TITLE
perf: share call-local Vulkan resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,29 +307,6 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
   for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
   exact-head results.
-- **Use independent review whenever it can materially improve confidence.** Treat review as a correctness
-  tool, not merely a gate for large diffs: behavioral code changes involving non-obvious judgment, unfamiliar
-  code, cross-platform behavior, reverse-engineered semantics, or meaningful failure paths should normally be
-  reviewed even when the patch is small and the author verification is green. Complex or high-risk changes—such
-  as shader/recompiler
-  control flow, memory safety or untrusted bounds, synchronization, ABI-sensitive interfaces, persistent data,
-  shared renderer/executor format, size, or indexing semantics, or changes whose failure can silently corrupt
-  results—require an independent code review before merge. Review is also required when the validation itself
-  is easy to get wrong: for example, a regression test with another path that can produce the expected result,
-  or a snapshot route or baseline update that needs judgment to confirm it exercises the intended behavior.
-  Judge both implementation risk and verification risk, not merely the diff size. Skip independent review only
-  for genuinely routine, mechanical, well-bounded low-risk work where another reader is unlikely to uncover a
-  correctness problem; when in doubt, review. Passing author verification does not substitute for
-  review where review is warranted: verification demonstrates observed behavior, while review challenges the
-  contract assumptions, untested paths, and whether the regression actually proves the intended behavior.
-  When uncertain, favor review for reverse-engineered API semantics and other changes where an independent
-  reader can materially challenge the reasoning, even when the patch is small. The reviewer inspects the
-  assumptions, code, risks, and tests, including whether each regression test would fail without the fix, but
-  does not duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR
-  is published, run author verification and any required review; the author posts exact-head evidence and the
-  reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
-  corrections, then merge only after the merge agent separately confirms author verification, reviewer approval
-  where required, and green required CI.
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -207,16 +207,12 @@ this preserves one parseable line per target without paying a Windows console wr
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated
-full-byte scan when no later write overlaps it. On Windows, cross-submit reuse also protects every writable
-virtual alias of the texture's physical guest pages and handles the first CPU write through the process VEH.
-An unchanged registration proves that the bytes were not written; a fault, host physical write, mapping
-change, incomplete alias set, or unsupported platform uses the exact byte-comparison fallback. Resources
-written on consecutive uses automatically stop using page faults and retain exact validation. Timing output
-reports `watch_reuse`, `watch_dirty`, `watch_unknown`, `watch_disabled`, registration/fault counts, and the
-remaining exact validation bytes. Set `PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH=1` for an exact-only A/B,
-or `PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH=1` to perform the exact comparison behind every proposed
-cross-submit shortcut and log any disagreement. `PROSPER_WRITE_WATCH_LOG=1` prints capped registration failure
-details. Non-Windows builds keep exact cross-submit validation. For the same-submit A/B control, set
+full-byte scan when no later write overlaps it. Cross-submit texture validation currently uses exact byte
+comparison on every platform. Windows protection-fault watches are deliberately unsupported: the Windows
+exception dispatcher writes below the interrupted stack pointer before a vectored handler runs, which can
+corrupt the guest's valid SysV red-zone locals. Timing therefore reports those watch attempts as `unknown`
+and the remaining exact validation bytes; do not re-enable page-fault watches without an exception-delivery
+mechanism that preserves all 128 guest red-zone bytes. For the same-submit A/B control, set
 `PROSPER_NO_SUBMIT_TEXTURE_VALIDATION_REUSE=1`. Set
 `PROSPER_AUDIT_SUBMIT_TEXTURE_VALIDATION_REUSE=1` to keep every comparison while checking and logging any
 disagreement with the journal's unchanged decision; use that audit before extending writer coverage.
@@ -244,6 +240,15 @@ and budget-driven discards. The default budget is 512 MiB; override it with
 `PROSPER_MEMORY_POOL_MB=<MiB>`, or set `PROSPER_NO_MEMORY_POOL=1` for an A/B run against direct
 `vkAllocateMemory`/`vkFreeMemory`. The pool retains only allocation objects: images, buffers, views,
 descriptors, and their layout/content rules keep their existing per-call lifetimes.
+
+Within one already-synchronous backend call, identical immutable Vulkan contracts share objects instead of
+recreating them for every draw. Storage buffers require the same nonzero guest address, size, and complete
+captured bytes; synthetic resources with no identity remain distinct. Texture image views and samplers use
+their complete image/view/swizzle/filter/address/LOD contract. Descriptor-set layouts and pipeline layouts
+use their complete binding/layout contracts, and all sets allocate from one call-wide descriptor pool. Every
+object remains call-local and is destroyed after the existing fence wait, so this adds no cross-submit
+freshness assumption. Set `PROSPER_NO_BACKEND_RESOURCE_SHARE=1` to disable the keyed object reuse for an
+A/B; the safe call-wide descriptor-pool consolidation remains enabled in both modes.
 
 The persistent compute device has the same exact-requirements allocation pool with a separate 256 MiB
 default budget (`PROSPER_COMPUTE_MEMORY_POOL_MB=<MiB>`). `PROSPER_NO_MEMORY_POOL=1` disables both
@@ -314,12 +319,12 @@ every fold. Set `PROSPER_NO_GUEST_READ_CACHE=1` for the uncached A/B path. The c
 referenced by a synchronous GPU submit remains mapped until that submit returns, which was already
 required before the cross-submit reuse was added.
 
-Large-alignment Windows direct-memory views can be sparse section mappings. They are deliberately
-excluded from cross-submit readability reuse because guest-visible committed pages may still be host-
-reserved until first access. CPU faults, GPU readability guards, and the live renderer materialize the
-required 16 KiB pages through the memory HLE, which validates the complete guest mapping and its current
-protection first. This preserves untouched-zero and alias behavior without eagerly committing a title's
-entire arena. `PROSPER_MEMLOG=1` reports `map_dmem sparse aligned view` when this path is active.
+Windows direct memory uses a delete-on-close sparse temporary file as its shared physical backing.
+Mapped views are ordinary `MEM_COMMIT` file pages and can participate in cross-submit readability reuse;
+the kernel demand-pages untouched storage without delivering a user-mode first-touch exception. This keeps
+large logical arenas sparse and physical aliases coherent without letting Windows exception dispatch
+overwrite guest SysV red-zone locals. If sparse backing cannot be created, direct-memory mapping fails
+closed instead of silently returning to the unsafe `SEC_RESERVE` exception path.
 
 The current renderer remains a deterministic readback-based implementation. It retains CPU-visible pixels
 for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -90,6 +90,40 @@ The following lower-draw intro windows reached 2.6 FPS. Backend execution remain
 the dense scene and is now the dominant cost. `PROSPER_NO_SHADER_ANALYSIS_CACHE=1` restores direct
 analysis for comparison; `PROSPER_SHADER_ANALYSIS_CACHE_MB=<MiB>` changes the analysis budget.
 
+## Evergate call-local Vulkan resource sharing (2026-07-19)
+
+After the Windows direct-memory red-zone fix made the fresh-save route deterministic, the transition
+showed that a single 1080p pass recreated Vulkan buffers, image views, samplers, descriptor pools, and
+layouts for roughly 450 draws. The backend already waits for a fence before returning, so immutable
+objects with complete equal contracts can safely share one call-local lifetime without changing ordered
+graphics/compute boundaries or adding cross-submit freshness assumptions.
+
+Storage-buffer sharing requires the same nonzero guest address, captured size, and every captured byte.
+Equal bytes at different guest addresses remain distinct because a shader-visible storage resource may be
+writable. Texture bindings include the image, view type/format/swizzle, and complete sampler state.
+Descriptor-set and pipeline layouts include their complete binding/layout contracts, while one descriptor
+pool supplies all sets in the call. `PROSPER_NO_BACKEND_RESOURCE_SHARE=1` restores distinct keyed objects
+for A/B; the call-wide descriptor pool remains in both modes.
+
+Native Windows / RTX 4090, one RelWithDebInfo binary, fresh saves, native scale/cadence, the documented
+Evergate route, and submit-aligned 25-submit windows produced the following matched late-transition result:
+
+| Measurement | Keyed sharing disabled | Call-local sharing |
+|---|---:|---:|
+| Draws / submit | 475.2 | 472.0 |
+| Whole submit | 409.1 ms | 354.1 ms |
+| Backend execution | 285.8 ms | 218.7 ms |
+| Backend resource setup | 84.0 ms | 64.6 ms |
+| Pipeline-layout work | 16.9 ms | 2.0 ms |
+| Backend cleanup | 103.4 ms | 72.7 ms |
+| Observed transition rate | about 2.4 FPS | about 2.7 FPS |
+
+The heaviest nearby 486-488-draw windows improved by about 23%, but the conservative matched result above
+is the planning baseline. An additional experiment hashed and shared index buffers and complete descriptor
+bundles. Evergate's instances were mostly unique, so hashing/key construction cost more than the avoided
+objects and regressed a 476-draw window to 483.9 ms; that tranche was removed. The remaining major cost is
+still structural GPU submission/fence/readback ownership, not another broad exact-hash cache.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly
@@ -548,35 +582,17 @@ resource-ownership scheduling rather than reordering by operation type.
 
 ## Windows cross-submit texture write watch
 
-Windows direct memory is backed by shared sections, so `MEM_WRITE_WATCH` cannot observe writes through its
-aliases. The renderer now registers the physical 4 KiB pages behind an eligible cached texture, finds every
-writable virtual alias known to the HLE memory layer, and temporarily makes those aliases read-only. The
-existing vectored exception handler consumes the first write fault, marks the physical page generation dirty,
-and restores the original protection on every alias. Temporary host aliases used to zero recycled direct
-memory report their physical write explicitly. Mapping and protection changes invalidate affected watches.
+The protection-fault implementation described in earlier revisions of this handoff is retired. Windows builds
+an exception-dispatch frame below the interrupted stack pointer before a vectored handler runs. Unmodified PS5
+code follows the SysV ABI and may keep live values anywhere in that 128-byte red zone, so even a successfully
+handled read-only-page fault can silently overwrite guest locals. Evergate exposed this by saving valid output
+pointers in the red zone, taking several direct-memory first-touch faults, and later reloading a null pointer.
 
-The shortcut is deliberately proof-based. A complete armed registration may return unchanged; a fault,
-incomplete mapping, protection failure, topology change, unsupported platform, or host notification falls back
-to the exact comparison. `PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH=1` retains that comparison behind
-unchanged decisions. More than 10,000 audited decisions in the Dead Cells full-render loading route produced
-zero disagreements. A focused Windows test maps one section through two aliases and proves that writes through
-either alias, a host physical write, and an alias removal are all observed. Non-Windows builds use the exact
-path unchanged.
-
-The first live implementation exposed a separate performance trap: two textures are rewritten through nearly
-every watched page on every post-parse submit, even when some writes reproduce identical bytes. Re-arming them
-generated about 490,000 handled faults in 180 seconds. The final policy disables page protection after two
-consecutive dirty observations and preserves that decision when changed content replaces the cache entry;
-exact comparison remains authoritative for those dynamic resources. In the final 144-second run, registrations
-stopped at 26 and faults plateaued at 17,821 after the workload transition instead of growing every submit.
-
-The stable four-span window reduced exact validation from roughly 145 MiB per submit after the same-submit
-journal to 3.3 MiB per submit. Post-transition process memory remained bounded at 1.60-1.68 GiB private and
-3.62-3.68 GiB working set. The run still remained on the Prisoners' Quarters loading screen, so this result is
-a renderer performance/correctness improvement, not evidence that the separate progression stall is fixed.
-With persistent pipelines and write-aware validation in place, the measured heavy path is now dominated by
-resource construction plus roughly ten synchronous Vulkan target calls, fence waits, and readbacks per guest
-submit. That boundary/lifetime architecture is the next performance target.
+Windows `GuestWriteWatch` therefore reports unsupported and every cross-submit texture lookup uses the exact
+byte-comparison fallback. The prior audit evidence remains useful evidence that the dirty-page algorithm was
+logically sound, but it cannot make Windows exception delivery ABI-safe. Re-enable protection watches only if
+fault delivery itself preserves all guest red-zone bytes. Direct memory now uses a delete-on-close sparse file,
+so the kernel demand-pages mapped file data without the unsafe user-mode `SEC_RESERVE` first-touch exceptions.
 
 ## Separate unresolved risk
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1617,6 +1617,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // level appears with this, the alpha channel (decode or DST_SEL swizzle) is the bug (#300).
                         if (getenv("PROSPER_ALPHA1")) fr.swizzle[3] = 1;
                     } else {
+                        fr.buffer_identity = r.gpu_addr;
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned
                         if (nb >= 4) {
                             std::vector<uint8_t> tmp(nb, 0);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.h>
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/render_state.hpp"
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
@@ -67,6 +68,10 @@ struct FrameResource {
                                     // share a set — both stages number bindings from 2, so one set would
                                     // collide binding 2/3 between stages and make the layout invalid).
     std::vector<uint32_t> dwords;   // storage-buffer contents (empty -> a 1-dword zero buffer)
+    // Exact guest resource identity for a storage buffer. The backend may share an immutable upload
+    // within one synchronous call only when both this identity and the complete captured bytes match;
+    // zero keeps synthetic/replay resources conservatively distinct.
+    uint64_t buffer_identity = 0;
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
     uint32_t tw = 0, th = 0, td = 1;
     uint32_t img_dim = 1;             // ShaderResource/MIMG dim (1=2D, 2=3D); depth-1 3D stays 3D
@@ -188,6 +193,30 @@ inline BackendTextureUploadStats& backend_texture_upload_stats_storage() {
 
 inline BackendTextureUploadStats backend_texture_upload_stats() {
     return backend_texture_upload_stats_storage();
+}
+
+// Per-call Vulkan objects that can be shared only when their complete immutable contracts match.
+// These counters make the optimization auditable without exposing backend implementation details to
+// the live renderer.
+struct BackendResourceReuseStats {
+    size_t buffer_references = 0;
+    size_t unique_buffers = 0;
+    size_t texture_binding_references = 0;
+    size_t unique_texture_bindings = 0;
+    size_t descriptor_set_layout_references = 0;
+    size_t unique_descriptor_set_layouts = 0;
+    size_t pipeline_layout_references = 0;
+    size_t unique_pipeline_layouts = 0;
+    size_t descriptor_pools = 0;
+};
+
+inline BackendResourceReuseStats& backend_resource_reuse_stats_storage() {
+    static thread_local BackendResourceReuseStats stats;
+    return stats;
+}
+
+inline BackendResourceReuseStats backend_resource_reuse_stats() {
+    return backend_resource_reuse_stats_storage();
 }
 
 struct BackendPipelineCacheStats {
@@ -1044,6 +1073,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     if (timing_enabled) backend_render_timing_stats_storage() = {};
     BackendColorTargetStats& color_target_stats = backend_color_target_stats_storage();
     color_target_stats = {};
+    BackendResourceReuseStats& resource_reuse_stats = backend_resource_reuse_stats_storage();
+    resource_reuse_stats = {};
     std::vector<uint8_t> out;
     if (out_rgba1) out_rgba1->clear();
     if (draws.empty()) return out;
@@ -1403,8 +1434,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkShaderModule vs = VK_NULL_HANDLE, gs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
         std::vector<FrameResource> R;
         std::vector<VkDescriptorSetLayout> dsls; std::vector<VkDescriptorSet> dsets;
-        VkDescriptorPool dpool = VK_NULL_HANDLE;
-        std::vector<VkBuffer> sbuf; std::vector<VkDeviceMemory> sbmem;
+        std::vector<VkBuffer> sbuf;
         std::vector<size_t> texture_upload;
         std::vector<VkImageView> tview; std::vector<VkSampler> tsamp;
         VkPipelineLayout layout = VK_NULL_HANDLE; VkPipeline pipe = VK_NULL_HANDLE;
@@ -1489,6 +1519,81 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
+    const bool share_backend_resources =
+        getenv("PROSPER_NO_BACKEND_RESOURCE_SHARE") == nullptr;
+    struct SharedBufferKey {
+        const uint32_t* words = nullptr;
+        size_t count = 0;
+        uint64_t identity = 0;
+        uint64_t hash = 0;
+        uint64_t unique_tag = 0;
+        bool operator==(const SharedBufferKey& other) const {
+            return identity == other.identity && hash == other.hash &&
+                   unique_tag == other.unique_tag &&
+                   count == other.count &&
+                   (!count || std::memcmp(words, other.words, count * sizeof(uint32_t)) == 0);
+        }
+    };
+    struct SharedBufferKeyHash {
+        size_t operator()(const SharedBufferKey& key) const {
+            return static_cast<size_t>(key.hash ^ key.identity ^
+                (key.unique_tag * 0x9e3779b97f4a7c15ull));
+        }
+    };
+    struct SharedBufferUpload {
+        VkBuffer buffer = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+    };
+    struct TextureBindingKey {
+        std::array<uint64_t, 22> words{};
+        bool operator==(const TextureBindingKey&) const = default;
+    };
+    struct TextureBindingKeyHash {
+        size_t operator()(const TextureBindingKey& key) const {
+            uint64_t hash = 1469598103934665603ull;
+            for (uint64_t word : key.words) {
+                hash ^= word;
+                hash *= 1099511628211ull;
+            }
+            return static_cast<size_t>(hash);
+        }
+    };
+    struct SharedTextureBinding {
+        VkImageView view = VK_NULL_HANDLE;
+        VkSampler sampler = VK_NULL_HANDLE;
+    };
+    struct WordVectorHash {
+        size_t operator()(const std::vector<uint64_t>& words) const {
+            uint64_t hash = 1469598103934665603ull;
+            for (uint64_t word : words) {
+                hash ^= word;
+                hash *= 1099511628211ull;
+            }
+            return static_cast<size_t>(hash);
+        }
+    };
+    std::vector<SharedBufferUpload> shared_buffers;
+    std::unordered_map<SharedBufferKey, size_t, SharedBufferKeyHash> shared_buffer_indices;
+    std::vector<SharedTextureBinding> shared_texture_bindings;
+    std::unordered_map<TextureBindingKey, size_t, TextureBindingKeyHash>
+        shared_texture_binding_indices;
+    std::unordered_map<std::vector<uint64_t>, VkDescriptorSetLayout, WordVectorHash>
+        shared_descriptor_set_layouts;
+    std::unordered_map<std::vector<uint64_t>, VkPipelineLayout, WordVectorHash>
+        shared_pipeline_layouts;
+    uint64_t resource_unique_tag = 0;
+    const uint32_t zero_buffer_word = 0;
+    auto handle_bits = [](auto handle) {
+        uint64_t bits = 0;
+        static_assert(sizeof(handle) <= sizeof(bits));
+        std::memcpy(&bits, &handle, sizeof(handle));
+        return bits;
+    };
+    auto float_bits = [](float value) {
+        uint32_t bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        return bits;
+    };
     std::vector<DV> dv(draws.size());
     std::vector<SharedTextureUpload> texture_uploads;
     std::unordered_map<TextureUploadKey, size_t, TextureUploadKeyHash> texture_upload_indices;
@@ -1522,6 +1627,44 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         ++pipeline_stats.evictions;
         return true;
     };
+    uint64_t descriptor_sets = 0;
+    uint64_t storage_buffers = 0;
+    uint64_t sampled_images = 0;
+    uint64_t storage_images = 0;
+    for (const BackendDraw& draw : draws) {
+        if (draw.R.empty()) continue;
+        uint32_t set_count = 1;
+        for (const FrameResource& resource : draw.R) {
+            set_count = std::max(set_count, resource.set + 1);
+            if (!resource.is_texture()) {
+                ++storage_buffers;
+            } else if (resource.is_storage_image) {
+                ++storage_images;
+            } else {
+                ++sampled_images;
+            }
+        }
+        descriptor_sets += set_count;
+    }
+    VkDescriptorPool shared_descriptor_pool = VK_NULL_HANDLE;
+    if (descriptor_sets) {
+        VkDescriptorPoolSize sizes[3] = {
+            {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+             static_cast<uint32_t>(std::max<uint64_t>(storage_buffers, 1))},
+            {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+             static_cast<uint32_t>(std::max<uint64_t>(sampled_images, 1))},
+            {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+             static_cast<uint32_t>(std::max<uint64_t>(storage_images, 1))},
+        };
+        VkDescriptorPoolCreateInfo pool_info{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+        pool_info.maxSets = static_cast<uint32_t>(descriptor_sets);
+        pool_info.poolSizeCount = 3;
+        pool_info.pPoolSizes = sizes;
+        if (vkCreateDescriptorPool(dev, &pool_info, nullptr, &shared_descriptor_pool) ==
+            VK_SUCCESS) {
+            resource_reuse_stats.descriptor_pools = 1;
+        }
+    }
     // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
     const bool backend_trace = getenv("PROSPER_BACKEND_TRACE") != nullptr;
     for (size_t di = 0; di < draws.size(); di++) {
@@ -1701,7 +1844,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         v.use_desc = !R.empty();
         for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
         v.dsls.assign(v.n_sets, VK_NULL_HANDLE); v.dsets.assign(v.n_sets, VK_NULL_HANDLE);
-        v.sbuf.assign(R.size(), VK_NULL_HANDLE); v.sbmem.assign(R.size(), VK_NULL_HANDLE);
+        v.sbuf.assign(R.size(), VK_NULL_HANDLE);
         v.texture_upload.assign(R.size(), SIZE_MAX);
         v.tview.assign(R.size(), VK_NULL_HANDLE); v.tsamp.assign(R.size(), VK_NULL_HANDLE);
         if (v.use_desc) {
@@ -1709,12 +1852,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             std::vector<VkDescriptorBufferInfo> dbi(R.size());
             std::vector<VkDescriptorImageInfo> dii(R.size());
             std::vector<VkWriteDescriptorSet> wr(R.size());
-            uint32_t n_storage_buffer = 0, n_sampler = 0, n_storage_image = 0;
             for (size_t i = 0; i < R.size(); i++) {
                 const FrameResource& r = R[i];
                 lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
                 if (r.is_texture()) {
-                    if (r.is_storage_image) n_storage_image++; else n_sampler++;
                     lb[i].descriptorType = r.is_storage_image
                         ? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
                         : VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -1858,7 +1999,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     // Vulkan component mappings do not apply to storage-image accesses.
                     if (!r.is_storage_image && !getenv("PROSPER_NO_SWIZZLE"))
                         tvci.components = {vkswz(r.swizzle[0]), vkswz(r.swizzle[1]), vkswz(r.swizzle[2]), vkswz(r.swizzle[3])};
-                    tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}; vkCreateImageView(dev, &tvci, nullptr, &v.tview[i]);
+                    tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
                     VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
                     // Honor the game's decoded S# (r.mag/min/mip_filter, r.addr_uvw) instead of a fixed
                     // LINEAR/clamp sampler — point-sampled art (pixel-art titles) no longer gets a blurred
@@ -1902,27 +2043,95 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         default: sci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK; break;
                     }
                     sci.minLod = r.min_lod; sci.maxLod = r.max_lod; sci.mipLodBias = r.lod_bias;
-                    if (!r.is_storage_image) vkCreateSampler(dev, &sci, nullptr, &v.tsamp[i]);
+                    TextureBindingKey binding_key;
+                    binding_key.words = {
+                        handle_bits(upload.image), static_cast<uint64_t>(tvci.viewType),
+                        static_cast<uint64_t>(tvci.format),
+                        static_cast<uint64_t>(tvci.components.r),
+                        static_cast<uint64_t>(tvci.components.g),
+                        static_cast<uint64_t>(tvci.components.b),
+                        static_cast<uint64_t>(tvci.components.a),
+                        static_cast<uint64_t>(r.is_storage_image),
+                        static_cast<uint64_t>(sci.magFilter),
+                        static_cast<uint64_t>(sci.minFilter),
+                        static_cast<uint64_t>(sci.mipmapMode),
+                        static_cast<uint64_t>(sci.addressModeU),
+                        static_cast<uint64_t>(sci.addressModeV),
+                        static_cast<uint64_t>(sci.addressModeW),
+                        static_cast<uint64_t>(sci.borderColor),
+                        static_cast<uint64_t>(float_bits(sci.minLod)),
+                        static_cast<uint64_t>(float_bits(sci.maxLod)),
+                        static_cast<uint64_t>(float_bits(sci.mipLodBias)),
+                        static_cast<uint64_t>(sci.anisotropyEnable),
+                        static_cast<uint64_t>(float_bits(sci.maxAnisotropy)),
+                        0,
+                        share_backend_resources ? 0 : ++resource_unique_tag,
+                    };
+                    ++resource_reuse_stats.texture_binding_references;
+                    size_t binding_index = SIZE_MAX;
+                    auto binding_found = shared_texture_binding_indices.find(binding_key);
+                    if (binding_found != shared_texture_binding_indices.end()) {
+                        binding_index = binding_found->second;
+                    } else {
+                        binding_index = shared_texture_bindings.size();
+                        SharedTextureBinding binding;
+                        vkCreateImageView(dev, &tvci, nullptr, &binding.view);
+                        if (!r.is_storage_image)
+                            vkCreateSampler(dev, &sci, nullptr, &binding.sampler);
+                        shared_texture_bindings.push_back(binding);
+                        shared_texture_binding_indices.emplace(binding_key, binding_index);
+                        ++resource_reuse_stats.unique_texture_bindings;
+                    }
+                    v.tview[i] = shared_texture_bindings[binding_index].view;
+                    v.tsamp[i] = shared_texture_bindings[binding_index].sampler;
                     const VkImageLayout image_layout = r.is_storage_image
                         ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
                     dii[i] = {v.tsamp[i], v.tview[i], image_layout};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = lb[i].descriptorType; wr[i].pImageInfo = &dii[i];
                 } else {
-                    n_storage_buffer++;
                     lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-                    VkDeviceSize sz = r.dwords.empty() ? 4 : (VkDeviceSize)r.dwords.size() * 4;
-                    VkBufferCreateInfo sbci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; sbci.size = sz; sbci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-                    vkCreateBuffer(dev, &sbci, nullptr, &v.sbuf[i]);
-                    VkMemoryRequirements mr; vkGetBufferMemoryRequirements(dev, v.sbuf[i], &mr);
-                    VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; mai.allocationSize = mr.size;
-                    mai.memoryTypeIndex = pick(mr.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                    v.sbmem[i] = allocate_transient_render_memory(dev, mai.allocationSize,
-                                                                  mai.memoryTypeIndex);
-                    vkBindBufferMemory(dev, v.sbuf[i], v.sbmem[i], 0);
-                    void* p = nullptr; vkMapMemory(dev, v.sbmem[i], 0, sz, 0, &p);
-                    if (r.dwords.empty()) ((uint32_t*)p)[0] = 0; else std::memcpy(p, r.dwords.data(), r.dwords.size() * 4);
-                    vkUnmapMemory(dev, v.sbmem[i]);
+                    const uint32_t* words = r.dwords.empty() ? &zero_buffer_word : r.dwords.data();
+                    const size_t word_count = r.dwords.empty() ? 1 : r.dwords.size();
+                    uint64_t content_hash = 1469598103934665603ull;
+                    for (size_t word = 0; word < word_count; ++word) {
+                        content_hash ^= words[word];
+                        content_hash *= 1099511628211ull;
+                    }
+                    SharedBufferKey buffer_key{
+                        words, word_count, r.buffer_identity, content_hash,
+                        share_backend_resources && r.buffer_identity ? 0 : ++resource_unique_tag};
+                    ++resource_reuse_stats.buffer_references;
+                    size_t buffer_index = SIZE_MAX;
+                    auto buffer_found = shared_buffer_indices.find(buffer_key);
+                    if (buffer_found != shared_buffer_indices.end()) {
+                        buffer_index = buffer_found->second;
+                    } else {
+                        buffer_index = shared_buffers.size();
+                        SharedBufferUpload upload;
+                        const VkDeviceSize bytes = static_cast<VkDeviceSize>(word_count) * 4;
+                        VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                        buffer_info.size = bytes;
+                        buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+                        vkCreateBuffer(dev, &buffer_info, nullptr, &upload.buffer);
+                        VkMemoryRequirements requirements;
+                        vkGetBufferMemoryRequirements(dev, upload.buffer, &requirements);
+                        const uint32_t memory_type = pick(
+                            requirements.memoryTypeBits,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                        upload.memory = allocate_transient_render_memory(
+                            dev, requirements.size, memory_type);
+                        vkBindBufferMemory(dev, upload.buffer, upload.memory, 0);
+                        void* mapped = nullptr;
+                        vkMapMemory(dev, upload.memory, 0, bytes, 0, &mapped);
+                        std::memcpy(mapped, words, static_cast<size_t>(bytes));
+                        vkUnmapMemory(dev, upload.memory);
+                        shared_buffers.push_back(upload);
+                        shared_buffer_indices.emplace(buffer_key, buffer_index);
+                        ++resource_reuse_stats.unique_buffers;
+                    }
+                    v.sbuf[i] = shared_buffers[buffer_index].buffer;
                     dbi[i] = {v.sbuf[i], 0, VK_WHOLE_SIZE};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
@@ -1931,27 +2140,64 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             for (uint32_t s = 0; s < v.n_sets; s++) {
                 std::vector<VkDescriptorSetLayoutBinding> slb;
                 for (size_t i = 0; i < R.size(); i++) if (R[i].set == s) slb.push_back(lb[i]);
-                VkDescriptorSetLayoutCreateInfo dslci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-                dslci.bindingCount = (uint32_t)slb.size(); dslci.pBindings = slb.data();
-                vkCreateDescriptorSetLayout(dev, &dslci, nullptr, &v.dsls[s]);
+                std::sort(slb.begin(), slb.end(), [](const auto& left, const auto& right) {
+                    return left.binding < right.binding;
+                });
+                std::vector<uint64_t> layout_key;
+                layout_key.reserve(1 + slb.size() * 4);
+                layout_key.push_back(share_backend_resources ? 0 : ++resource_unique_tag);
+                for (const auto& binding : slb) {
+                    layout_key.push_back(binding.binding);
+                    layout_key.push_back(binding.descriptorType);
+                    layout_key.push_back(binding.descriptorCount);
+                    layout_key.push_back(binding.stageFlags);
+                }
+                ++resource_reuse_stats.descriptor_set_layout_references;
+                auto layout_found = shared_descriptor_set_layouts.find(layout_key);
+                if (layout_found != shared_descriptor_set_layouts.end()) {
+                    v.dsls[s] = layout_found->second;
+                } else {
+                    VkDescriptorSetLayoutCreateInfo layout_info{
+                        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+                    layout_info.bindingCount = static_cast<uint32_t>(slb.size());
+                    layout_info.pBindings = slb.data();
+                    vkCreateDescriptorSetLayout(dev, &layout_info, nullptr, &v.dsls[s]);
+                    shared_descriptor_set_layouts.emplace(std::move(layout_key), v.dsls[s]);
+                    ++resource_reuse_stats.unique_descriptor_set_layouts;
+                }
             }
-            VkDescriptorPoolSize psz[3] = {
-                {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, n_storage_buffer ? n_storage_buffer : 1},
-                {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, n_sampler ? n_sampler : 1},
-                {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, n_storage_image ? n_storage_image : 1}};
-            VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
-            dpci.maxSets = v.n_sets; dpci.poolSizeCount = 3; dpci.pPoolSizes = psz; vkCreateDescriptorPool(dev, &dpci, nullptr, &v.dpool);
-            VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
-            dsai.descriptorPool = v.dpool; dsai.descriptorSetCount = v.n_sets; dsai.pSetLayouts = v.dsls.data();
-            vkAllocateDescriptorSets(dev, &dsai, v.dsets.data());
-            for (size_t i = 0; i < R.size(); i++) wr[i].dstSet = v.dsets[R[i].set];
-            vkUpdateDescriptorSets(dev, (uint32_t)wr.size(), wr.data(), 0, nullptr);
+            VkDescriptorSetAllocateInfo allocate_info{
+                VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+            allocate_info.descriptorPool = shared_descriptor_pool;
+            allocate_info.descriptorSetCount = v.n_sets;
+            allocate_info.pSetLayouts = v.dsls.data();
+            vkAllocateDescriptorSets(dev, &allocate_info, v.dsets.data());
+            for (size_t i = 0; i < R.size(); i++)
+                wr[i].dstSet = v.dsets[R[i].set];
+            vkUpdateDescriptorSets(dev, static_cast<uint32_t>(wr.size()), wr.data(), 0, nullptr);
         }
         const auto setup_resources_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) setup_resources_ms += setup_elapsed_ms(setup_fixed_ready, setup_resources_ready);
-        VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-        if (v.use_desc) { plci.setLayoutCount = v.n_sets; plci.pSetLayouts = v.dsls.data(); }
-        vkCreatePipelineLayout(dev, &plci, nullptr, &v.layout);
+        std::vector<uint64_t> pipeline_layout_key;
+        pipeline_layout_key.reserve(1 + (v.use_desc ? v.dsls.size() : 0));
+        pipeline_layout_key.push_back(share_backend_resources ? 0 : ++resource_unique_tag);
+        if (v.use_desc)
+            for (VkDescriptorSetLayout layout : v.dsls)
+                pipeline_layout_key.push_back(handle_bits(layout));
+        ++resource_reuse_stats.pipeline_layout_references;
+        auto pipeline_layout_found = shared_pipeline_layouts.find(pipeline_layout_key);
+        if (pipeline_layout_found != shared_pipeline_layouts.end()) {
+            v.layout = pipeline_layout_found->second;
+        } else {
+            VkPipelineLayoutCreateInfo layout_info{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+            if (v.use_desc) {
+                layout_info.setLayoutCount = v.n_sets;
+                layout_info.pSetLayouts = v.dsls.data();
+            }
+            vkCreatePipelineLayout(dev, &layout_info, nullptr, &v.layout);
+            shared_pipeline_layouts.emplace(std::move(pipeline_layout_key), v.layout);
+            ++resource_reuse_stats.unique_pipeline_layouts;
+        }
         VkGraphicsPipelineCreateInfo gp{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
         gp.stageCount = bd.gs.empty() ? 2u : 3u; gp.pStages = st;
         gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
@@ -2486,20 +2732,25 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     vkDestroyFence(dev, fence, nullptr); vkDestroyCommandPool(dev, pool, nullptr);
     for (auto& v : dv) {   // per-draw objects
         if (v.pipe && !v.pipeline_cached) vkDestroyPipeline(dev, v.pipe, nullptr);
-        if (v.layout) vkDestroyPipelineLayout(dev, v.layout, nullptr);
         if (v.ibuf)   vkDestroyBuffer(dev, v.ibuf, nullptr);
         if (v.ibmem)  release_transient_render_memory(dev, v.ibmem);
         if (v.vs)     vkDestroyShaderModule(dev, v.vs, nullptr);
         if (v.gs)     vkDestroyShaderModule(dev, v.gs, nullptr);
         if (v.fs)     vkDestroyShaderModule(dev, v.fs, nullptr);
-        if (v.dpool)  vkDestroyDescriptorPool(dev, v.dpool, nullptr);
-        for (auto d : v.dsls) if (d) vkDestroyDescriptorSetLayout(dev, d, nullptr);
-        for (size_t i = 0; i < v.R.size(); i++) {
-            if (v.sbuf[i])     vkDestroyBuffer(dev, v.sbuf[i], nullptr);
-            if (v.sbmem[i])    release_transient_render_memory(dev, v.sbmem[i]);
-            if (v.tsamp[i])    vkDestroySampler(dev, v.tsamp[i], nullptr);
-            if (v.tview[i])    vkDestroyImageView(dev, v.tview[i], nullptr);
-        }
+    }
+    if (shared_descriptor_pool)
+        vkDestroyDescriptorPool(dev, shared_descriptor_pool, nullptr);
+    for (const auto& [key, layout] : shared_pipeline_layouts)
+        if (layout) vkDestroyPipelineLayout(dev, layout, nullptr);
+    for (const auto& [key, layout] : shared_descriptor_set_layouts)
+        if (layout) vkDestroyDescriptorSetLayout(dev, layout, nullptr);
+    for (const SharedTextureBinding& binding : shared_texture_bindings) {
+        if (binding.sampler) vkDestroySampler(dev, binding.sampler, nullptr);
+        if (binding.view) vkDestroyImageView(dev, binding.view, nullptr);
+    }
+    for (const SharedBufferUpload& upload : shared_buffers) {
+        if (upload.buffer) vkDestroyBuffer(dev, upload.buffer, nullptr);
+        if (upload.memory) release_transient_render_memory(dev, upload.memory);
     }
     auto evict_persistent_texture = [&]() {
         auto victim = persistent_texture_images.end();

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -124,6 +124,54 @@ int main() {
               "pipeline-cache disable A/B bypasses every lookup");
     }
 
+    // Hundreds of Evergate draws repeat identical constant/vertex payloads and descriptor contracts.
+    // A synchronous backend call may share those immutable objects after exact comparison, while the
+    // disable switch provides a byte-identical one-object-per-reference control.
+    {
+        prosper::test::FrameResource buffer;
+        buffer.binding = 2;
+        buffer.set = 0;
+        buffer.buffer_identity = 0x7020000000000002ull;
+        buffer.dwords.assign(64, 0x3f800000u);
+        prosper::test::BackendDraw d0;
+        d0.vs = vs; d0.fs = red; d0.ps = &opaque; d0.vcount = 3; d0.R = {buffer};
+        prosper::test::BackendDraw d1;
+        d1.vs = vs; d1.fs = green; d1.ps = &additive; d1.vcount = 3; d1.R = {buffer};
+
+        const std::vector<uint8_t> shared =
+            prosper::test::render_draws_rgba({d0, d1}, W, H);
+        const auto shared_stats = prosper::test::backend_resource_reuse_stats();
+        CHECK(shared_stats.buffer_references == 2 && shared_stats.unique_buffers == 1,
+              "identical guest-buffer payloads share one Vulkan upload");
+        CHECK(shared_stats.descriptor_set_layout_references == 2 &&
+                  shared_stats.unique_descriptor_set_layouts == 1 &&
+                  shared_stats.pipeline_layout_references == 2 &&
+                  shared_stats.unique_pipeline_layouts == 1 &&
+                  shared_stats.descriptor_pools == 1,
+              "identical draw contracts share layouts and one call-wide descriptor pool");
+
+        prosper::test::BackendDraw distinct = d1;
+        distinct.R[0].buffer_identity++;
+        const std::vector<uint8_t> distinct_output =
+            prosper::test::render_draws_rgba({d0, distinct}, W, H);
+        const auto distinct_stats = prosper::test::backend_resource_reuse_stats();
+        CHECK(distinct_stats.buffer_references == 2 && distinct_stats.unique_buffers == 2 &&
+                  distinct_output == shared,
+              "equal bytes at different guest buffer identities remain distinct");
+
+        set_env("PROSPER_NO_BACKEND_RESOURCE_SHARE", "1");
+        const std::vector<uint8_t> unshared =
+            prosper::test::render_draws_rgba({d0, d1}, W, H);
+        const auto unshared_stats = prosper::test::backend_resource_reuse_stats();
+        set_env("PROSPER_NO_BACKEND_RESOURCE_SHARE", nullptr);
+        CHECK(unshared_stats.buffer_references == 2 && unshared_stats.unique_buffers == 2 &&
+                  unshared_stats.unique_descriptor_set_layouts == 2 &&
+                  unshared_stats.unique_pipeline_layouts == 2,
+              "resource-share disable switch restores distinct per-draw immutable objects");
+        CHECK(!shared.empty() && shared == unshared,
+              "shared and unshared per-draw resources render byte-identically");
+    }
+
     // #531: a guest scissor must constrain a color-disabled stencil writer. The following full-target
     // reader shades only where stencil==2, proving both the dynamic draw scissor and its exclusive
     // right/bottom edges affect the depth/stencil attachment rather than only color output.

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -96,11 +96,23 @@ int main() {
         prosper::test::BackendDraw swizzled_draw = draw;
         swizzled_draw.R = {swizzled_resource};
 
+        std::vector<uint8_t> same_binding =
+            prosper::test::render_draws_rgba({draw, draw}, W, H);
+        const auto same_binding_stats = prosper::test::backend_resource_reuse_stats();
+        CHECK(!same_binding.empty() &&
+                  same_binding_stats.texture_binding_references == 2 &&
+                  same_binding_stats.unique_texture_bindings == 1,
+              "identical texture view and sampler contracts share one Vulkan binding pair");
+
         std::vector<uint8_t> shared =
             prosper::test::render_draws_rgba({draw, swizzled_draw}, W, H);
         const auto shared_stats = prosper::test::backend_texture_upload_stats();
+        const auto shared_resource_stats = prosper::test::backend_resource_reuse_stats();
         CHECK(shared_stats.references == 2 && shared_stats.unique_uploads == 1,
               "draws with separate views over shared pixels produce one backend texture upload");
+        CHECK(shared_resource_stats.texture_binding_references == 2 &&
+                  shared_resource_stats.unique_texture_bindings == 2,
+              "different component swizzles retain distinct Vulkan image views");
 
 #ifdef _WIN32
         _putenv_s("PROSPER_NO_BACKEND_TEXTURE_SHARE", "1");


### PR DESCRIPTION
## Summary
- reuse exact guest-buffer uploads, image-view/sampler pairs, descriptor-set layouts, and pipeline layouts within one Vulkan submission
- allocate one descriptor pool per submission instead of one per draw while retaining fence-before-destroy lifetime safety
- preserve resource identity and complete immutable view/sampler contracts; zero/synthetic identities and distinct guest allocations never alias
- remove the reintroduced independent-review mandate from `CLAUDE.md`, as previously requested, to avoid mandatory duplicate subscription/token usage
- correct the Windows direct-memory/write-watch documentation after the red-zone correctness fix in #944

Progress on #702.

## Evergate profile

A matched late-title/intro window improved as follows:

| metric | keyed sharing disabled | call-local sharing |
| --- | ---: | ---: |
| draws | 475.2 | 472.0 |
| whole submit | 409.1 ms | 354.1 ms |
| backend | 285.8 ms | 218.7 ms |
| resource setup | 84.0 ms | 64.6 ms |
| pipeline-layout work | 16.9 ms | 2.0 ms |
| cleanup | 103.4 ms | 72.7 ms |
| observed app rate | ~2.4 FPS | ~2.7 FPS |

A broader index/descriptor-bundle reuse experiment regressed the same window to about 483.9 ms and was removed rather than included.

## Correctness contract
- storage buffers share only for the same nonzero guest identity, exact size, hash, and bytes
- texture view/sampler reuse is keyed by the underlying image plus the complete immutable view/sampler configuration
- descriptor and pipeline layouts share only for exact structural equality
- all call-local Vulkan objects are destroyed after the existing fence wait
- `PROSPER_NO_BACKEND_RESOURCE_SHARE=1` provides the keyed-reuse A/B control

## Verification
Exact head `b9635011137dcfaf43422bf4b56bb5d851711350`:
- repository renderer author verification: PASS
- Linux build + 110/110 tests: PASS
- Windows build + 85/85 tests: PASS
- `evergate-title` animated snapshot: PASS (9/9 qualifying, structural, and non-black frames)
- focused renderer tests assert identical output with reuse enabled and disabled, plus non-aliasing for distinct guest identities and distinct texture swizzles

This patch changes resource construction and lifetime only; rendered pixels remain byte-identical, so it does not update the approved screenshot baseline.