### PR TITLE
feat(frontend): route save dialogs through platform UI

### DIFF
--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -1,6 +1,7 @@
 // dialog_helpers.cpp — see dialog_helpers.hpp. Pure struct parsing (no SDL). memcpy is used for every
 // guest read/write so unaligned guest structs and strict aliasing are both safe.
 #include "dialog_helpers.hpp"
+#include <cstdio>
 #include <cstring>
 
 namespace prosper {
@@ -47,6 +48,157 @@ uint32_t read_error_code(uint64_t param) {
     uint32_t code = 0;
     if (param) std::memcpy(&code, (const void*)(uintptr_t)(param + 4), 4);
     return code;
+}
+
+// --- SaveDataDialog ---
+
+namespace {
+
+uint32_t read_u32(uint64_t address) {
+    uint32_t value = 0;
+    std::memcpy(&value, (const void*)(uintptr_t)address, sizeof value);
+    return value;
+}
+
+uint64_t read_u64(uint64_t address) {
+    uint64_t value = 0;
+    std::memcpy(&value, (const void*)(uintptr_t)address, sizeof value);
+    return value;
+}
+
+std::string guest_string(uint64_t address) {
+    if (!address) return {};
+    const char* text = (const char*)(uintptr_t)address;
+    size_t length = 0;
+    while (length < 4096 && text[length]) ++length;
+    return std::string(text, length);
+}
+
+MsgButtons save_user_buttons(uint32_t type) {
+    switch (type) {
+    case 0: return {1, {"OK", nullptr, nullptr}, {1, 0, 0}};
+    case 1: return {2, {"Yes", "No", nullptr}, {1, 2, 0}};
+    case 3: return {2, {"OK", "Cancel", nullptr}, {1, 0, 0}};
+    default: return {0, {nullptr, nullptr, nullptr}, {0, 0, 0}};
+    }
+}
+
+const char* save_action(uint32_t display_type) {
+    switch (display_type) {
+    case 1: return "save";
+    case 2: return "load";
+    case 3: return "delete";
+    default: return "continue";
+    }
+}
+
+} // namespace
+
+SaveDataRequest read_savedata_request(uint64_t param) {
+    SaveDataRequest request;
+    if (!param) return request;
+    if (read_u64(param) != 0x30 || read_u32(param + 0x30) != 0x98)
+        return request;
+    request.mode = read_u32(param + 0x34);
+    request.displayType = read_u32(param + 0x38);
+    request.userData = read_u64(param + 0x70);
+
+    if (request.mode == SAVE_DATA_DIALOG_MODE_USER_MSG) {
+        const uint64_t user = read_u64(param + 0x50);
+        if (!user) return request;
+        request.buttons = save_user_buttons(read_u32(user));
+        if (request.buttons.count == 0) return request;
+        request.error = read_u32(user + 4) == 1;
+        request.message = guest_string(read_u64(user + 8));
+        request.supported = true;
+        return request;
+    }
+
+    if (request.mode == SAVE_DATA_DIALOG_MODE_SYSTEM_MSG) {
+        const uint64_t system = read_u64(param + 0x58);
+        if (!system) return request;
+        const uint32_t type = read_u32(system);
+        const char* action = save_action(request.displayType);
+        char message[192] = {};
+        switch (type) {
+        case 1: // NODATA
+            request.message = "There is no saved data.";
+            request.buttons = save_user_buttons(0);
+            break;
+        case 2: // CONFIRM
+            std::snprintf(message, sizeof message, "Do you want to %s this saved data?", action);
+            request.message = message;
+            request.buttons = save_user_buttons(1);
+            break;
+        case 3: // OVERWRITE
+            request.message = "Do you want to overwrite the existing saved data?";
+            request.buttons = save_user_buttons(1);
+            break;
+        case 4: case 8: // NOSPACE / NOSPACE_CONTINUABLE
+            request.message = "There is not enough space for this saved data operation.";
+            request.buttons = save_user_buttons(0);
+            request.error = true;
+            break;
+        case 6: // FILE_CORRUPTED
+            request.message = "The saved data is corrupted.";
+            request.buttons = save_user_buttons(0);
+            request.error = true;
+            break;
+        case 7: // FINISHED
+            std::snprintf(message, sizeof message, "Saved data %s completed.", action);
+            request.message = message;
+            request.buttons = save_user_buttons(0);
+            break;
+        case 10: // CORRUPTED_AND_DELETED
+            request.message = "The saved data is corrupted and will be deleted.";
+            request.buttons = save_user_buttons(3);
+            request.error = true;
+            break;
+        case 11: // CORRUPTED_AND_CREATED
+            request.message = "The corrupted saved data will be replaced with new saved data.";
+            request.buttons = save_user_buttons(3);
+            request.error = true;
+            break;
+        case 13: // CORRUPTED_AND_RESTORE
+            request.message = "The corrupted saved data will be restored from its backup.";
+            request.buttons = save_user_buttons(3);
+            request.error = true;
+            break;
+        case 14: // TOTAL_SIZE_EXCEEDED
+            request.message = "Cannot create more saved data.";
+            request.buttons = save_user_buttons(0);
+            request.error = true;
+            break;
+        default:
+            return request; // PROGRESS and unknown modes need a non-modal/dedicated UI
+        }
+        request.supported = true;
+        return request;
+    }
+
+    if (request.mode == SAVE_DATA_DIALOG_MODE_ERROR_CODE) {
+        const uint64_t error = read_u64(param + 0x60);
+        if (!error) return request;
+        const uint32_t code = read_u32(error);
+        char message[96];
+        std::snprintf(message, sizeof message, "An error occurred.\n\nError code: 0x%08X", code);
+        request.message = message;
+        request.buttons = save_user_buttons(0);
+        request.error = true;
+        request.supported = true;
+    }
+    return request;
+}
+
+void write_savedata_result(uint64_t result, const SaveDataRequest& request,
+                           uint32_t buttonId, bool canceled) {
+    if (!result) return;
+    const uint32_t common_result = canceled ? 1u : 0u;
+    const uint32_t guest_button = canceled ? 0u : buttonId;
+    std::memcpy((void*)(uintptr_t)(result + 0x00), &request.mode, sizeof request.mode);
+    std::memcpy((void*)(uintptr_t)(result + 0x04), &common_result, sizeof common_result);
+    std::memcpy((void*)(uintptr_t)(result + 0x08), &guest_button, sizeof guest_button);
+    std::memcpy((void*)(uintptr_t)(result + 0x20), &request.userData, sizeof request.userData);
 }
 
 // --- ImeDialog text entry ---

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdio>
 #include <cstring>
+#include <utility>
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -127,7 +128,7 @@ MsgButtons save_user_buttons(uint32_t type) {
     switch (type) {
     case 0: return {1, {"OK", nullptr, nullptr}, {1, 0, 0}};
     case 1: return {2, {"Yes", "No", nullptr}, {1, 2, 0}};
-    case 3: return {2, {"OK", "Cancel", nullptr}, {1, 2, 0}};
+    case 3: return {2, {"OK", "Cancel", nullptr}, {1, 0, 0}};
     default: return {0, {nullptr, nullptr, nullptr}, {0, 0, 0}};
     }
 }
@@ -264,6 +265,56 @@ void write_savedata_result(uint64_t result, const SaveDataRequest& request,
     (void)guest_write_bytes(result + 0x04, &common_result, sizeof common_result);
     (void)guest_write_bytes(result + 0x08, &guest_button, sizeof guest_button);
     (void)guest_write_bytes(result + 0x20, &request.userData, sizeof request.userData);
+}
+
+void SaveDataDialogState::open(SaveDataRequest request) {
+    std::lock_guard<std::mutex> lock(mx_);
+    ++generation_;
+    if (!generation_) ++generation_; // zero is reserved for "no ticket"
+    request_ = std::move(request);
+    button_ = 0;
+    canceled_ = false;
+    status_ = 2 /*RUNNING*/;
+    pending_generation_ = generation_;
+}
+
+int SaveDataDialogState::status() const {
+    std::lock_guard<std::mutex> lock(mx_);
+    return status_;
+}
+
+void SaveDataDialogState::close() {
+    std::lock_guard<std::mutex> lock(mx_);
+    ++generation_;
+    if (!generation_) ++generation_;
+    pending_generation_ = 0;
+    status_ = 0 /*NONE*/;
+}
+
+SaveDataModalTicket SaveDataDialogState::take_pending() {
+    std::lock_guard<std::mutex> lock(mx_);
+    const uint64_t pending = pending_generation_;
+    pending_generation_ = 0;
+    if (!pending || pending != generation_ || status_ != 2 /*RUNNING*/) return {};
+    return {pending, request_};
+}
+
+bool SaveDataDialogState::active(uint64_t generation) const {
+    std::lock_guard<std::mutex> lock(mx_);
+    return generation && generation_ == generation && status_ == 2 /*RUNNING*/;
+}
+
+void SaveDataDialogState::complete(uint64_t generation, int clicked) {
+    std::lock_guard<std::mutex> lock(mx_);
+    if (!generation || generation_ != generation || status_ != 2 /*RUNNING*/) return;
+    canceled_ = clicked <= 0;
+    button_ = canceled_ ? 0u : (uint32_t)clicked;
+    status_ = 3 /*FINISHED*/;
+}
+
+SaveDataResultSnapshot SaveDataDialogState::result_snapshot() const {
+    std::lock_guard<std::mutex> lock(mx_);
+    return {request_, button_, canceled_};
 }
 
 // --- ImeDialog text entry ---

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -1,8 +1,23 @@
-// dialog_helpers.cpp — see dialog_helpers.hpp. Pure struct parsing (no SDL). memcpy is used for every
-// guest read/write so unaligned guest structs and strict aliasing are both safe.
+// dialog_helpers.cpp — see dialog_helpers.hpp. Pure struct parsing (no SDL). SaveData's nested guest
+// pointers use fault-contained OS copies; memcpy keeps local unaligned fields alias-safe.
 #include "dialog_helpers.hpp"
+#include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstring>
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include "../../src/host/posix_shim.hpp"
+#include <sys/uio.h>
+#include <unistd.h>
+#endif
 
 namespace prosper {
 
@@ -54,31 +69,65 @@ uint32_t read_error_code(uint64_t param) {
 
 namespace {
 
-uint32_t read_u32(uint64_t address) {
-    uint32_t value = 0;
-    std::memcpy(&value, (const void*)(uintptr_t)address, sizeof value);
+bool guest_read_bytes(uint64_t address, void* destination, size_t size) {
+    if (!address || !destination || !size || address > UINT64_MAX - (size - 1)) return false;
+#ifdef _WIN32
+    SIZE_T copied = 0;
+    return ReadProcessMemory(GetCurrentProcess(), (const void*)(uintptr_t)address,
+                             destination, size, &copied) && copied == size;
+#else
+    iovec local{destination, size};
+    iovec remote{(void*)(uintptr_t)address, size};
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)size;
+#endif
+}
+
+bool guest_write_bytes(uint64_t address, const void* source, size_t size) {
+    if (!address || !source || !size || address > UINT64_MAX - (size - 1)) return false;
+#ifdef _WIN32
+    SIZE_T copied = 0;
+    return WriteProcessMemory(GetCurrentProcess(), (void*)(uintptr_t)address,
+                              source, size, &copied) && copied == size;
+#else
+    iovec local{const_cast<void*>(source), size};
+    iovec remote{(void*)(uintptr_t)address, size};
+    return process_vm_writev(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)size;
+#endif
+}
+
+template<typename T, size_t N>
+T local_field(const std::array<uint8_t, N>& bytes, size_t offset) {
+    T value{};
+    std::memcpy(&value, bytes.data() + offset, sizeof value);
     return value;
 }
 
-uint64_t read_u64(uint64_t address) {
-    uint64_t value = 0;
-    std::memcpy(&value, (const void*)(uintptr_t)address, sizeof value);
-    return value;
-}
-
-std::string guest_string(uint64_t address) {
-    if (!address) return {};
-    const char* text = (const char*)(uintptr_t)address;
-    size_t length = 0;
-    while (length < 4096 && text[length]) ++length;
-    return std::string(text, length);
+bool guest_string(uint64_t address, std::string& out) {
+    out.clear();
+    if (!address) return true;
+    constexpr size_t CAP = 4096;
+    std::array<char, 256> chunk{};
+    size_t consumed = 0;
+    while (consumed < CAP) {
+        if (address > UINT64_MAX - consumed) return false;
+        const uint64_t current = address + consumed;
+        const size_t page_left = 0x1000u - (size_t)(current & 0xfffu);
+        const size_t count = std::min({chunk.size(), page_left, CAP - consumed});
+        if (!guest_read_bytes(current, chunk.data(), count)) return false;
+        const void* nul = std::memchr(chunk.data(), 0, count);
+        const size_t length = nul ? (size_t)((const char*)nul - chunk.data()) : count;
+        out.append(chunk.data(), length);
+        if (nul) return true;
+        consumed += count;
+    }
+    return false;
 }
 
 MsgButtons save_user_buttons(uint32_t type) {
     switch (type) {
     case 0: return {1, {"OK", nullptr, nullptr}, {1, 0, 0}};
     case 1: return {2, {"Yes", "No", nullptr}, {1, 2, 0}};
-    case 3: return {2, {"OK", "Cancel", nullptr}, {1, 0, 0}};
+    case 3: return {2, {"OK", "Cancel", nullptr}, {1, 2, 0}};
     default: return {0, {nullptr, nullptr, nullptr}, {0, 0, 0}};
     }
 }
@@ -97,27 +146,34 @@ const char* save_action(uint32_t display_type) {
 SaveDataRequest read_savedata_request(uint64_t param) {
     SaveDataRequest request;
     if (!param) return request;
-    if (read_u64(param) != 0x30 || read_u32(param + 0x30) != 0x98)
+    std::array<uint8_t, 0x98> outer{};
+    if (!guest_read_bytes(param, outer.data(), outer.size())) return request;
+    if (local_field<uint64_t>(outer, 0x00) != 0x30 ||
+        local_field<uint32_t>(outer, 0x30) != 0x98)
         return request;
-    request.mode = read_u32(param + 0x34);
-    request.displayType = read_u32(param + 0x38);
-    request.userData = read_u64(param + 0x70);
+    request.mode = local_field<uint32_t>(outer, 0x34);
+    request.displayType = local_field<uint32_t>(outer, 0x38);
+    request.userData = local_field<uint64_t>(outer, 0x70);
 
     if (request.mode == SAVE_DATA_DIALOG_MODE_USER_MSG) {
-        const uint64_t user = read_u64(param + 0x50);
+        const uint64_t user = local_field<uint64_t>(outer, 0x50);
         if (!user) return request;
-        request.buttons = save_user_buttons(read_u32(user));
+        std::array<uint8_t, 16> user_param{};
+        if (!guest_read_bytes(user, user_param.data(), user_param.size())) return request;
+        request.buttons = save_user_buttons(local_field<uint32_t>(user_param, 0x00));
         if (request.buttons.count == 0) return request;
-        request.error = read_u32(user + 4) == 1;
-        request.message = guest_string(read_u64(user + 8));
+        request.error = local_field<uint32_t>(user_param, 0x04) == 1;
+        if (!guest_string(local_field<uint64_t>(user_param, 0x08), request.message))
+            return request;
         request.supported = true;
         return request;
     }
 
     if (request.mode == SAVE_DATA_DIALOG_MODE_SYSTEM_MSG) {
-        const uint64_t system = read_u64(param + 0x58);
+        const uint64_t system = local_field<uint64_t>(outer, 0x58);
         if (!system) return request;
-        const uint32_t type = read_u32(system);
+        uint32_t type = 0;
+        if (!guest_read_bytes(system, &type, sizeof type)) return request;
         const char* action = save_action(request.displayType);
         char message[192] = {};
         switch (type) {
@@ -151,17 +207,14 @@ SaveDataRequest read_savedata_request(uint64_t param) {
             break;
         case 10: // CORRUPTED_AND_DELETED
             request.message = "The saved data is corrupted and will be deleted.";
-            request.buttons = save_user_buttons(3);
             request.error = true;
             break;
         case 11: // CORRUPTED_AND_CREATED
             request.message = "The corrupted saved data will be replaced with new saved data.";
-            request.buttons = save_user_buttons(3);
             request.error = true;
             break;
         case 13: // CORRUPTED_AND_RESTORE
             request.message = "The corrupted saved data will be restored from its backup.";
-            request.buttons = save_user_buttons(3);
             request.error = true;
             break;
         case 14: // TOTAL_SIZE_EXCEEDED
@@ -172,14 +225,26 @@ SaveDataRequest read_savedata_request(uint64_t param) {
         default:
             return request; // PROGRESS and unknown modes need a non-modal/dedicated UI
         }
+        if (type == 10 || type == 11 || type == 13) {
+            bool back_enabled = true; // OptionBack defaults to ENABLE when the pointer is absent.
+            const uint64_t option = local_field<uint64_t>(outer, 0x78);
+            if (option) {
+                uint32_t option_back = 0;
+                if (!guest_read_bytes(option, &option_back, sizeof option_back)) return request;
+                back_enabled = option_back == 0; // ENABLE=0, DISABLE=1
+            }
+            request.cancelable = back_enabled;
+            request.buttons = save_user_buttons(back_enabled ? 3u : 0u);
+        }
         request.supported = true;
         return request;
     }
 
     if (request.mode == SAVE_DATA_DIALOG_MODE_ERROR_CODE) {
-        const uint64_t error = read_u64(param + 0x60);
+        const uint64_t error = local_field<uint64_t>(outer, 0x60);
         if (!error) return request;
-        const uint32_t code = read_u32(error);
+        uint32_t code = 0;
+        if (!guest_read_bytes(error, &code, sizeof code)) return request;
         char message[96];
         std::snprintf(message, sizeof message, "An error occurred.\n\nError code: 0x%08X", code);
         request.message = message;
@@ -192,13 +257,13 @@ SaveDataRequest read_savedata_request(uint64_t param) {
 
 void write_savedata_result(uint64_t result, const SaveDataRequest& request,
                            uint32_t buttonId, bool canceled) {
-    if (!result) return;
+    if (!result || result > UINT64_MAX - 0x20) return;
     const uint32_t common_result = canceled ? 1u : 0u;
     const uint32_t guest_button = canceled ? 0u : buttonId;
-    std::memcpy((void*)(uintptr_t)(result + 0x00), &request.mode, sizeof request.mode);
-    std::memcpy((void*)(uintptr_t)(result + 0x04), &common_result, sizeof common_result);
-    std::memcpy((void*)(uintptr_t)(result + 0x08), &guest_button, sizeof guest_button);
-    std::memcpy((void*)(uintptr_t)(result + 0x20), &request.userData, sizeof request.userData);
+    (void)guest_write_bytes(result + 0x00, &request.mode, sizeof request.mode);
+    (void)guest_write_bytes(result + 0x04, &common_result, sizeof common_result);
+    (void)guest_write_bytes(result + 0x08, &guest_button, sizeof guest_button);
+    (void)guest_write_bytes(result + 0x20, &request.userData, sizeof request.userData);
 }
 
 // --- ImeDialog text entry ---

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -10,6 +10,7 @@
 //   ErrorDialog param:    s32 size @0 ; s32 errorCode @4 ; s32 userId @8 ; s32 reserved @12
 #pragma once
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 namespace prosper {
@@ -59,6 +60,40 @@ struct SaveDataRequest {
     uint64_t userData = 0;
     std::string message;
     MsgButtons buttons{0, {nullptr, nullptr, nullptr}, {0, 0, 0}};
+};
+
+// SDL-free lifecycle seam shared by the frontend and unit tests. A pending ticket is consumed once;
+// Close or a newer Open invalidates every older generation, including one already visible.
+struct SaveDataModalTicket {
+    uint64_t generation = 0;
+    SaveDataRequest request{};
+    explicit operator bool() const { return generation != 0; }
+};
+
+struct SaveDataResultSnapshot {
+    SaveDataRequest request{};
+    uint32_t buttonId = 0;
+    bool canceled = false;
+};
+
+class SaveDataDialogState {
+public:
+    void open(SaveDataRequest request);
+    int status() const;
+    void close();
+    SaveDataModalTicket take_pending();
+    bool active(uint64_t generation) const;
+    void complete(uint64_t generation, int clicked);
+    SaveDataResultSnapshot result_snapshot() const;
+
+private:
+    mutable std::mutex mx_;
+    SaveDataRequest request_{};
+    int status_ = 0;
+    uint32_t button_ = 0;
+    bool canceled_ = false;
+    uint64_t generation_ = 0;
+    uint64_t pending_generation_ = 0;
 };
 
 // Parse the supported non-list modes into an owned request safe to retain until the SDL main-thread

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -36,6 +36,41 @@ void write_msg_result(uint64_t result, uint32_t buttonId);
 // Read errorCode (@4) from a guest OrbisErrorDialogParam*.
 uint32_t read_error_code(uint64_t param);
 
+// --- SaveDataDialog ---
+// Param layout (0x98 bytes): CommonDialog::BaseParam[0x30], size@0x30, mode@0x34,
+// dispType@0x38, then nested pointers userMsg@0x50, systemMsg@0x58, errorCode@0x60,
+// progress@0x68, userData@0x70, option@0x78. Result layout (0x48 bytes):
+// mode/result/buttonId @0/4/8, caller-owned dirName/param pointers @0x10/0x18,
+// userData @0x20, reserved[32] @0x28. These offsets match the PS4/PS5 inherited ABI.
+enum : uint32_t {
+    SAVE_DATA_DIALOG_MODE_LIST = 1,
+    SAVE_DATA_DIALOG_MODE_USER_MSG = 2,
+    SAVE_DATA_DIALOG_MODE_SYSTEM_MSG = 3,
+    SAVE_DATA_DIALOG_MODE_ERROR_CODE = 4,
+    SAVE_DATA_DIALOG_MODE_PROGRESS_BAR = 5,
+};
+
+struct SaveDataRequest {
+    bool supported = false;       // false -> frontend declines ownership; core keeps headless policy
+    bool error = false;           // choose the error rather than information message-box style
+    uint32_t mode = 0;
+    uint32_t displayType = 0;     // 1=SAVE, 2=LOAD, 3=DELETE
+    uint64_t userData = 0;
+    std::string message;
+    MsgButtons buttons{0, {nullptr, nullptr, nullptr}, {0, 0, 0}};
+};
+
+// Parse the supported non-list modes into an owned request safe to retain until the SDL main-thread
+// pump runs. USER_MSG, ordinary SYSTEM_MSG confirmations/notices, and ERROR_CODE are supported.
+// LIST and progress/no-button modes deliberately return supported=false until their dedicated UI exists.
+SaveDataRequest read_savedata_request(uint64_t param);
+
+// Write only fields owned by the service: mode/result/buttonId/userData. Caller-provided dirName and
+// param output pointers, the ABI pad, and all reserved bytes remain untouched. `canceled` writes
+// CommonDialog::Result::USER_CANCELED and ButtonId::INVALID.
+void write_savedata_result(uint64_t result, const SaveDataRequest& request,
+                           uint32_t buttonId, bool canceled);
+
 // --- ImeDialog (text entry) --- offsets from shadPS4 ime/ime_common.h OrbisImeDialogParam:
 //   user_id@0 type@4 ... max_text_length@36(u32) input_text_buffer@40(char16_t*) ... title@72(char16_t*)
 struct ImeRequest {

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -53,6 +53,7 @@ enum : uint32_t {
 struct SaveDataRequest {
     bool supported = false;       // false -> frontend declines ownership; core keeps headless policy
     bool error = false;           // choose the error rather than information message-box style
+    bool cancelable = true;       // false when OptionBack::DISABLE forbids a back/cancel outcome
     uint32_t mode = 0;
     uint32_t displayType = 0;     // 1=SAVE, 2=LOAD, 3=DELETE
     uint64_t userData = 0;
@@ -67,7 +68,7 @@ SaveDataRequest read_savedata_request(uint64_t param);
 
 // Write only fields owned by the service: mode/result/buttonId/userData. Caller-provided dirName and
 // param output pointers, the ABI pad, and all reserved bytes remain untouched. `canceled` writes
-// CommonDialog::Result::USER_CANCELED and ButtonId::INVALID.
+// CommonDialog::Result::USER_CANCELED and ButtonId::INVALID. An unreadable result pointer is ignored.
 void write_savedata_result(uint64_t result, const SaveDataRequest& request,
                            uint32_t buttonId, bool canceled);
 

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -192,49 +192,21 @@ struct SdlPlatformUi : PlatformUi {
     // SaveDataDialog. Open copies the guest request; the prosper-app main-thread pump owns SDL UI.
     // LIST/progress modes are declined until their dedicated virtual-slot UI exists, preserving the
     // core's established headless auto-dismiss for those modes.
-    std::mutex      save_mx;
-    SaveDataRequest save_request{};
-    int             save_status = 0 /*NONE*/;
-    uint32_t        save_button = 0 /*INVALID*/;
-    bool            save_canceled = false;
-    uint64_t        save_generation = 0;
-    uint64_t        save_pending_generation = 0;
+    SaveDataDialogState save_state;
 
     bool saveDataDialogOpen(uint64_t param) override {
         SaveDataRequest request = read_savedata_request(param);
         if (!request.supported) return false;
-        std::lock_guard<std::mutex> lk(save_mx);
-        ++save_generation;
-        save_request = std::move(request);
-        save_button = 0;
-        save_canceled = false;
-        save_status = 2 /*RUNNING*/;
-        save_pending_generation = save_generation;
+        save_state.open(std::move(request));
         return true;
     }
-    int saveDataDialogStatus() override {
-        std::lock_guard<std::mutex> lk(save_mx);
-        return save_status;
-    }
+    int saveDataDialogStatus() override { return save_state.status(); }
     int saveDataDialogResult(uint64_t result) override {
-        SaveDataRequest request;
-        uint32_t button = 0;
-        bool canceled = false;
-        {
-            std::lock_guard<std::mutex> lk(save_mx);
-            request = save_request;
-            button = save_button;
-            canceled = save_canceled;
-        }
-        write_savedata_result(result, request, button, canceled);
-        return (int)button;
+        const SaveDataResultSnapshot snapshot = save_state.result_snapshot();
+        write_savedata_result(result, snapshot.request, snapshot.buttonId, snapshot.canceled);
+        return (int)snapshot.buttonId;
     }
-    void saveDataDialogClose() override {
-        std::lock_guard<std::mutex> lk(save_mx);
-        ++save_generation; // makes a visible modal's active predicate fail
-        save_pending_generation = 0;
-        save_status = 0 /*NONE*/;
-    }
+    void saveDataDialogClose() override { save_state.close(); }
 
     // Ime keyboard presence: a windowed session runs on a host with a keyboard, so report one (#347).
     // This makes sceImeKeyboardGetResourceId/GetInfo report a connected keyboard, enabling a title's
@@ -274,31 +246,13 @@ struct SdlPlatformUi : PlatformUi {
     // MAIN-thread: if a text dialog is pending, run its modal to completion (writes the guest buffer,
     // then flips status to FINISHED so the guest's next poll — and its buffer read — see it).
     void pump() {
-        uint64_t generation = 0;
-        SaveDataRequest request;
-        {
-            std::lock_guard<std::mutex> lk(save_mx);
-            generation = save_pending_generation;
-            if (generation) {
-                request = save_request;
-                save_pending_generation = 0; // consume this exact generation once
-            }
-        }
-        if (generation) {
-            auto active = [this, generation] {
-                std::lock_guard<std::mutex> lk(save_mx);
-                return save_generation == generation && save_status == 2 /*RUNNING*/;
+        const SaveDataModalTicket ticket = save_state.take_pending();
+        if (ticket) {
+            auto active = [this, generation = ticket.generation] {
+                return save_state.active(generation);
             };
-            const int clicked = run_savedata_modal(request, active);
-            if (clicked != -2) {
-                const bool canceled = clicked <= 0;
-                std::lock_guard<std::mutex> lk(save_mx);
-                if (save_generation == generation && save_status == 2 /*RUNNING*/) {
-                    save_button = canceled ? 0u : (uint32_t)clicked;
-                    save_canceled = canceled;
-                    save_status = 3 /*FINISHED*/;
-                }
-            }
+            const int clicked = run_savedata_modal(ticket.request, active);
+            if (clicked != -2) save_state.complete(ticket.generation, clicked);
         }
         if (ime_pending.exchange(false)) {
             ImeRequest r; { std::lock_guard<std::mutex> lk(ime_mx); r = ime_req; }
@@ -319,8 +273,8 @@ bool install_sdl3_platform_ui() {
     return true;
 }
 void shutdown_sdl3_platform_ui() {
-    g_sdl_ui.saveDataDialogClose();
     set_platform_ui(nullptr);
+    g_sdl_ui.saveDataDialogClose();
 }
 void sdl_platform_ui_pump() { g_sdl_ui.pump(); }
 

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -107,6 +107,38 @@ struct SdlPlatformUi : PlatformUi {
     int  errorDialogStatus() override { return err_status.load(); }
     void errorDialogClose() override { err_status.store(0); }
 
+    // SaveDataDialog. Open copies the guest request; the prosper-app main-thread pump owns SDL UI.
+    // LIST/progress modes are declined until their dedicated virtual-slot UI exists, preserving the
+    // core's established headless auto-dismiss for those modes.
+    std::mutex            save_mx;
+    SaveDataRequest       save_request{};
+    std::atomic<int>      save_status{0 /*NONE*/};
+    std::atomic<bool>     save_pending{false};
+    std::atomic<uint32_t> save_button{0 /*INVALID*/};
+    std::atomic<bool>     save_canceled{false};
+
+    bool saveDataDialogOpen(uint64_t param) override {
+        SaveDataRequest request = read_savedata_request(param);
+        if (!request.supported) return false;
+        { std::lock_guard<std::mutex> lk(save_mx); save_request = request; }
+        save_button.store(0);
+        save_canceled.store(false);
+        save_status.store(2 /*RUNNING*/);
+        save_pending.store(true);
+        return true;
+    }
+    int saveDataDialogStatus() override { return save_status.load(); }
+    int saveDataDialogResult(uint64_t result) override {
+        SaveDataRequest request;
+        { std::lock_guard<std::mutex> lk(save_mx); request = save_request; }
+        write_savedata_result(result, request, save_button.load(), save_canceled.load());
+        return (int)save_button.load();
+    }
+    void saveDataDialogClose() override {
+        save_pending.store(false);
+        save_status.store(0 /*NONE*/);
+    }
+
     // Ime keyboard presence: a windowed session runs on a host with a keyboard, so report one (#347).
     // This makes sceImeKeyboardGetResourceId/GetInfo report a connected keyboard, enabling a title's
     // keyboard-input option. (Delivering the raw key events to the guest handler is a further step.)
@@ -145,11 +177,24 @@ struct SdlPlatformUi : PlatformUi {
     // MAIN-thread: if a text dialog is pending, run its modal to completion (writes the guest buffer,
     // then flips status to FINISHED so the guest's next poll — and its buffer read — see it).
     void pump() {
-        if (!ime_pending.exchange(false)) return;
-        ImeRequest r; { std::lock_guard<std::mutex> lk(ime_mx); r = ime_req; }
-        int es = run_ime_modal(r);
-        ime_endstatus.store(es);
-        ime_status.store(2 /*Finished*/);
+        if (save_pending.exchange(false)) {
+            SaveDataRequest request;
+            { std::lock_guard<std::mutex> lk(save_mx); request = save_request; }
+            const int clicked = show_box(request.error ? SDL_MESSAGEBOX_ERROR
+                                                       : SDL_MESSAGEBOX_INFORMATION,
+                                         "prosper - Saved Data", request.message.c_str(),
+                                         request.buttons);
+            const bool canceled = clicked <= 0;
+            save_button.store(canceled ? 0u : (uint32_t)clicked);
+            save_canceled.store(canceled);
+            save_status.store(3 /*FINISHED*/);
+        }
+        if (ime_pending.exchange(false)) {
+            ImeRequest r; { std::lock_guard<std::mutex> lk(ime_mx); r = ime_req; }
+            int es = run_ime_modal(r);
+            ime_endstatus.store(es);
+            ime_status.store(2 /*Finished*/);
+        }
     }
 };
 
@@ -159,7 +204,7 @@ SdlPlatformUi g_sdl_ui;
 
 bool install_sdl3_platform_ui() {
     set_platform_ui(&g_sdl_ui);
-    SDL_Log("prosper: SDL3 dialog backend installed (MsgDialog/ErrorDialog + ImeDialog text entry)");
+    SDL_Log("prosper: SDL3 dialog backend installed (Msg/Error/SaveData + Ime text entry)");
     return true;
 }
 void shutdown_sdl3_platform_ui() { set_platform_ui(nullptr); }

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -116,11 +116,13 @@ struct SdlPlatformUi : PlatformUi {
     std::atomic<bool>     save_pending{false};
     std::atomic<uint32_t> save_button{0 /*INVALID*/};
     std::atomic<bool>     save_canceled{false};
+    std::atomic<uint64_t> save_generation{0};
 
     bool saveDataDialogOpen(uint64_t param) override {
         SaveDataRequest request = read_savedata_request(param);
         if (!request.supported) return false;
         { std::lock_guard<std::mutex> lk(save_mx); save_request = request; }
+        save_generation.fetch_add(1);
         save_button.store(0);
         save_canceled.store(false);
         save_status.store(2 /*RUNNING*/);
@@ -135,7 +137,9 @@ struct SdlPlatformUi : PlatformUi {
         return (int)save_button.load();
     }
     void saveDataDialogClose() override {
+        save_generation.fetch_add(1); // invalidate a modal already running on the main thread
         save_pending.store(false);
+        std::lock_guard<std::mutex> lk(save_mx);
         save_status.store(0 /*NONE*/);
     }
 
@@ -178,6 +182,7 @@ struct SdlPlatformUi : PlatformUi {
     // then flips status to FINISHED so the guest's next poll — and its buffer read — see it).
     void pump() {
         if (save_pending.exchange(false)) {
+            const uint64_t generation = save_generation.load();
             SaveDataRequest request;
             { std::lock_guard<std::mutex> lk(save_mx); request = save_request; }
             const int clicked = show_box(request.error ? SDL_MESSAGEBOX_ERROR
@@ -185,9 +190,12 @@ struct SdlPlatformUi : PlatformUi {
                                          "prosper - Saved Data", request.message.c_str(),
                                          request.buttons);
             const bool canceled = clicked <= 0;
-            save_button.store(canceled ? 0u : (uint32_t)clicked);
-            save_canceled.store(canceled);
-            save_status.store(3 /*FINISHED*/);
+            std::lock_guard<std::mutex> lk(save_mx);
+            if (save_generation.load() == generation && save_status.load() == 2 /*RUNNING*/) {
+                save_button.store(canceled ? 0u : (uint32_t)clicked);
+                save_canceled.store(canceled);
+                save_status.store(3 /*FINISHED*/);
+            }
         }
         if (ime_pending.exchange(false)) {
             ImeRequest r; { std::lock_guard<std::mutex> lk(ime_mx); r = ime_req; }

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -76,6 +76,88 @@ int run_ime_modal(const ImeRequest& req) {
     return endstatus;
 }
 
+// Unlike SDL_ShowMessageBox, this SaveData modal can be invalidated while it is visible. The guest
+// is allowed to Close or re-Open from its polling thread; `active` notices the generation change and
+// destroys the stale window before pump() presents a replacement. Returns -2 when invalidated.
+template<typename Active>
+int run_savedata_modal(const SaveDataRequest& req, Active&& active) {
+    if (!active()) return -2;
+    SDL_Window* win = nullptr;
+    SDL_Renderer* ren = nullptr;
+    if (!SDL_CreateWindowAndRenderer("prosper - Saved Data", 560, 220, 0, &win, &ren)) {
+        SDL_Log("prosper: saved-data window failed: %s", SDL_GetError());
+        return -1;
+    }
+    const SDL_WindowID window_id = SDL_GetWindowID(win);
+    constexpr float button_w = 120.0f, button_h = 36.0f, gap = 12.0f;
+    const float total_w = req.buttons.count * button_w + (req.buttons.count - 1) * gap;
+    const float first_x = (560.0f - total_w) * 0.5f;
+    int clicked = -1;
+    bool done = false;
+    while (!done && active()) {
+        SDL_Event ev;
+        while (SDL_PollEvent(&ev)) {
+            if (ev.type == SDL_EVENT_QUIT) {
+                done = true;
+            } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
+                       ev.window.windowID == window_id && req.cancelable) {
+                done = true;
+            } else if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.windowID == window_id) {
+                if (ev.key.key == SDLK_RETURN || ev.key.key == SDLK_KP_ENTER) {
+                    clicked = (int)req.buttons.id[0];
+                    done = true;
+                } else if (ev.key.key == SDLK_ESCAPE && req.cancelable) {
+                    clicked = req.buttons.count > 1 ? (int)req.buttons.id[req.buttons.count - 1] : -1;
+                    done = true;
+                }
+            } else if (ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
+                       ev.button.windowID == window_id) {
+                for (int i = 0; i < req.buttons.count; ++i) {
+                    SDL_FRect button{first_x + i * (button_w + gap), 164.0f, button_w, button_h};
+                    if (ev.button.x >= button.x && ev.button.x <= button.x + button.w &&
+                        ev.button.y >= button.y && ev.button.y <= button.y + button.h) {
+                        clicked = (int)req.buttons.id[i];
+                        done = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        SDL_SetRenderDrawColor(ren, req.error ? 52 : 28, 30, 40, 255);
+        SDL_RenderClear(ren);
+        SDL_SetRenderDrawColor(ren, 235, 235, 240, 255);
+        float text_y = 28.0f;
+        size_t line_start = 0;
+        do {
+            const size_t line_end = req.message.find('\n', line_start);
+            const std::string line = req.message.substr(
+                line_start, line_end == std::string::npos ? std::string::npos : line_end - line_start);
+            SDL_RenderDebugText(ren, 24.0f, text_y, line.c_str());
+            text_y += 18.0f;
+            if (line_end == std::string::npos) break;
+            line_start = line_end + 1;
+        } while (line_start <= req.message.size());
+
+        for (int i = 0; i < req.buttons.count; ++i) {
+            SDL_FRect button{first_x + i * (button_w + gap), 164.0f, button_w, button_h};
+            SDL_SetRenderDrawColor(ren, 66, 72, 92, 255);
+            SDL_RenderFillRect(ren, &button);
+            SDL_SetRenderDrawColor(ren, 220, 220, 230, 255);
+            SDL_RenderRect(ren, &button);
+            const char* label = req.buttons.label[i] ? req.buttons.label[i] : "";
+            const float label_x = button.x + (button.w - 8.0f * std::strlen(label)) * 0.5f;
+            SDL_RenderDebugText(ren, label_x, button.y + 14.0f, label);
+        }
+        SDL_RenderPresent(ren);
+        SDL_Delay(8);
+    }
+    const bool still_active = active();
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    return still_active ? clicked : -2;
+}
+
 struct SdlPlatformUi : PlatformUi {
     std::atomic<int>      msg_status{0}, err_status{0};
     std::atomic<uint32_t> msg_btn{1 /*OK*/};
@@ -110,37 +192,48 @@ struct SdlPlatformUi : PlatformUi {
     // SaveDataDialog. Open copies the guest request; the prosper-app main-thread pump owns SDL UI.
     // LIST/progress modes are declined until their dedicated virtual-slot UI exists, preserving the
     // core's established headless auto-dismiss for those modes.
-    std::mutex            save_mx;
-    SaveDataRequest       save_request{};
-    std::atomic<int>      save_status{0 /*NONE*/};
-    std::atomic<bool>     save_pending{false};
-    std::atomic<uint32_t> save_button{0 /*INVALID*/};
-    std::atomic<bool>     save_canceled{false};
-    std::atomic<uint64_t> save_generation{0};
+    std::mutex      save_mx;
+    SaveDataRequest save_request{};
+    int             save_status = 0 /*NONE*/;
+    uint32_t        save_button = 0 /*INVALID*/;
+    bool            save_canceled = false;
+    uint64_t        save_generation = 0;
+    uint64_t        save_pending_generation = 0;
 
     bool saveDataDialogOpen(uint64_t param) override {
         SaveDataRequest request = read_savedata_request(param);
         if (!request.supported) return false;
-        { std::lock_guard<std::mutex> lk(save_mx); save_request = request; }
-        save_generation.fetch_add(1);
-        save_button.store(0);
-        save_canceled.store(false);
-        save_status.store(2 /*RUNNING*/);
-        save_pending.store(true);
+        std::lock_guard<std::mutex> lk(save_mx);
+        ++save_generation;
+        save_request = std::move(request);
+        save_button = 0;
+        save_canceled = false;
+        save_status = 2 /*RUNNING*/;
+        save_pending_generation = save_generation;
         return true;
     }
-    int saveDataDialogStatus() override { return save_status.load(); }
+    int saveDataDialogStatus() override {
+        std::lock_guard<std::mutex> lk(save_mx);
+        return save_status;
+    }
     int saveDataDialogResult(uint64_t result) override {
         SaveDataRequest request;
-        { std::lock_guard<std::mutex> lk(save_mx); request = save_request; }
-        write_savedata_result(result, request, save_button.load(), save_canceled.load());
-        return (int)save_button.load();
+        uint32_t button = 0;
+        bool canceled = false;
+        {
+            std::lock_guard<std::mutex> lk(save_mx);
+            request = save_request;
+            button = save_button;
+            canceled = save_canceled;
+        }
+        write_savedata_result(result, request, button, canceled);
+        return (int)button;
     }
     void saveDataDialogClose() override {
-        save_generation.fetch_add(1); // invalidate a modal already running on the main thread
-        save_pending.store(false);
         std::lock_guard<std::mutex> lk(save_mx);
-        save_status.store(0 /*NONE*/);
+        ++save_generation; // makes a visible modal's active predicate fail
+        save_pending_generation = 0;
+        save_status = 0 /*NONE*/;
     }
 
     // Ime keyboard presence: a windowed session runs on a host with a keyboard, so report one (#347).
@@ -181,20 +274,30 @@ struct SdlPlatformUi : PlatformUi {
     // MAIN-thread: if a text dialog is pending, run its modal to completion (writes the guest buffer,
     // then flips status to FINISHED so the guest's next poll — and its buffer read — see it).
     void pump() {
-        if (save_pending.exchange(false)) {
-            const uint64_t generation = save_generation.load();
-            SaveDataRequest request;
-            { std::lock_guard<std::mutex> lk(save_mx); request = save_request; }
-            const int clicked = show_box(request.error ? SDL_MESSAGEBOX_ERROR
-                                                       : SDL_MESSAGEBOX_INFORMATION,
-                                         "prosper - Saved Data", request.message.c_str(),
-                                         request.buttons);
-            const bool canceled = clicked <= 0;
+        uint64_t generation = 0;
+        SaveDataRequest request;
+        {
             std::lock_guard<std::mutex> lk(save_mx);
-            if (save_generation.load() == generation && save_status.load() == 2 /*RUNNING*/) {
-                save_button.store(canceled ? 0u : (uint32_t)clicked);
-                save_canceled.store(canceled);
-                save_status.store(3 /*FINISHED*/);
+            generation = save_pending_generation;
+            if (generation) {
+                request = save_request;
+                save_pending_generation = 0; // consume this exact generation once
+            }
+        }
+        if (generation) {
+            auto active = [this, generation] {
+                std::lock_guard<std::mutex> lk(save_mx);
+                return save_generation == generation && save_status == 2 /*RUNNING*/;
+            };
+            const int clicked = run_savedata_modal(request, active);
+            if (clicked != -2) {
+                const bool canceled = clicked <= 0;
+                std::lock_guard<std::mutex> lk(save_mx);
+                if (save_generation == generation && save_status == 2 /*RUNNING*/) {
+                    save_button = canceled ? 0u : (uint32_t)clicked;
+                    save_canceled = canceled;
+                    save_status = 3 /*FINISHED*/;
+                }
             }
         }
         if (ime_pending.exchange(false)) {
@@ -215,7 +318,10 @@ bool install_sdl3_platform_ui() {
     SDL_Log("prosper: SDL3 dialog backend installed (Msg/Error/SaveData + Ime text entry)");
     return true;
 }
-void shutdown_sdl3_platform_ui() { set_platform_ui(nullptr); }
+void shutdown_sdl3_platform_ui() {
+    g_sdl_ui.saveDataDialogClose();
+    set_platform_ui(nullptr);
+}
 void sdl_platform_ui_pump() { g_sdl_ui.pump(); }
 
 } // namespace prosper

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -97,6 +97,29 @@ int main() {
                   request.buttons.count == 2 && request.buttons.id[1] == 2,
               "SaveDataDialog SYSTEM_MSG confirmation maps display type to DELETE + YES/NO");
 
+        uint8_t option[36] = {};
+        uint32_t option_back = 1 /*DISABLE*/;
+        uint64_t option_ptr = (uint64_t)(uintptr_t)option;
+        system_type = 10 /*CORRUPTED_AND_DELETED*/;
+        std::memcpy(system, &system_type, 4);
+        std::memcpy(option, &option_back, 4);
+        std::memcpy(save_param + 0x78, &option_ptr, 8);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && !request.cancelable && request.buttons.count == 1 &&
+                  request.buttons.id[0] == 1,
+              "SaveDataDialog OptionBack::DISABLE removes the SYSTEM_MSG cancel path");
+        option_back = 0 /*ENABLE*/;
+        std::memcpy(option, &option_back, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.cancelable && request.buttons.count == 2 &&
+                  request.buttons.id[1] == 2,
+              "SaveDataDialog OptionBack::ENABLE exposes OK + Cancel with the ABI button ids");
+
+        option_ptr = 1; std::memcpy(save_param + 0x78, &option_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog rejects a non-null unreadable option pointer without crashing");
+        option_ptr = 0; std::memcpy(save_param + 0x78, &option_ptr, 8);
+
         system_type = 5 /*PROGRESS*/; std::memcpy(system, &system_type, 4);
         CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
               "SaveDataDialog progress message declines modal ownership");
@@ -116,6 +139,8 @@ int main() {
 
         CHECK(!read_savedata_request(0).supported,
               "SaveDataDialog null outer param declines ownership without dereference");
+        CHECK(!read_savedata_request(1).supported,
+              "SaveDataDialog unreadable outer param declines ownership without crashing");
         param_size = 0; std::memcpy(save_param + 0x30, &param_size, 4);
         CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
               "SaveDataDialog malformed outer size declines ownership");
@@ -123,6 +148,25 @@ int main() {
         error_ptr = 0; std::memcpy(save_param + 0x60, &error_ptr, 8);
         CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
               "SaveDataDialog null nested mode param declines ownership without dereference");
+        error_ptr = 1; std::memcpy(save_param + 0x60, &error_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog unreadable ERROR_CODE pointer declines without crashing");
+
+        save_mode = SAVE_DATA_DIALOG_MODE_USER_MSG;
+        user_ptr = 1;
+        std::memcpy(save_param + 0x34, &save_mode, 4);
+        std::memcpy(save_param + 0x50, &user_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog unreadable USER_MSG pointer declines without crashing");
+        user_ptr = (uint64_t)(uintptr_t)user;
+        save_message_ptr = 1;
+        std::memcpy(save_param + 0x50, &user_ptr, 8);
+        std::memcpy(user + 8, &save_message_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog unreadable nested message pointer declines without crashing");
+        save_message_ptr = (uint64_t)(uintptr_t)save_message;
+        std::memcpy(user + 8, &save_message_ptr, 8);
+
         save_mode = SAVE_DATA_DIALOG_MODE_LIST;
         std::memcpy(save_param + 0x34, &save_mode, 4);
         CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
@@ -150,6 +194,8 @@ int main() {
         std::memcpy(&result_button, save_result + 0x08, 4);
         CHECK(common_result == 1 && result_button == 0,
               "SaveDataDialog canceled result returns USER_CANCELED + INVALID button");
+        write_savedata_result(1, request, 1, false);
+        CHECK(true, "SaveDataDialog unreadable result pointer is ignored without crashing");
     }
 
     // --- ImeDialog: read_ime_request from a synthetic OrbisImeDialogParam (96 bytes) ---

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -56,6 +56,102 @@ int main() {
     CHECK(read_error_code((uint64_t)(uintptr_t)ep) == 0x80AABBCC, "read_error_code: errorCode @4");
     CHECK(read_error_code(0) == 0, "read_error_code(NULL) -> 0 (no deref)");
 
+    // --- SaveDataDialog: supported message/confirmation/error modes use the ABI's nested pointers. ---
+    {
+        const char* save_message = "Overwrite this slot?";
+        uint8_t user[48] = {};
+        uint32_t button_type = 1 /*YESNO*/, message_type = 0 /*NORMAL*/;
+        uint64_t save_message_ptr = (uint64_t)(uintptr_t)save_message;
+        std::memcpy(user + 0, &button_type, 4);
+        std::memcpy(user + 4, &message_type, 4);
+        std::memcpy(user + 8, &save_message_ptr, 8);
+
+        uint8_t save_param[0x98] = {};
+        uint32_t save_mode = SAVE_DATA_DIALOG_MODE_USER_MSG, display_type = 1 /*SAVE*/;
+        uint64_t user_ptr = (uint64_t)(uintptr_t)user, user_data = 0x1122334455667788ull;
+        uint64_t base_size = 0x30;
+        uint32_t param_size = 0x98;
+        std::memcpy(save_param + 0x00, &base_size, 8);
+        std::memcpy(save_param + 0x30, &param_size, 4);
+        std::memcpy(save_param + 0x34, &save_mode, 4);
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        std::memcpy(save_param + 0x50, &user_ptr, 8);
+        std::memcpy(save_param + 0x70, &user_data, 8);
+        SaveDataRequest request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.mode == SAVE_DATA_DIALOG_MODE_USER_MSG &&
+                  request.message == save_message && request.buttons.count == 2 &&
+                  request.buttons.id[0] == 1 && request.buttons.id[1] == 2 &&
+                  request.userData == user_data,
+              "SaveDataDialog USER_MSG parses text, YES/NO buttons, mode, and userData");
+
+        uint8_t system[48] = {};
+        uint32_t system_type = 2 /*CONFIRM*/;
+        std::memcpy(system, &system_type, 4);
+        save_mode = SAVE_DATA_DIALOG_MODE_SYSTEM_MSG; display_type = 3 /*DELETE*/;
+        uint64_t system_ptr = (uint64_t)(uintptr_t)system;
+        std::memcpy(save_param + 0x34, &save_mode, 4);
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        std::memcpy(save_param + 0x58, &system_ptr, 8);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.message.find("delete") != std::string::npos &&
+                  request.buttons.count == 2 && request.buttons.id[1] == 2,
+              "SaveDataDialog SYSTEM_MSG confirmation maps display type to DELETE + YES/NO");
+
+        system_type = 5 /*PROGRESS*/; std::memcpy(system, &system_type, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog progress message declines modal ownership");
+
+        uint8_t error[36] = {};
+        uint32_t error_code = 0x809F000F;
+        std::memcpy(error, &error_code, 4);
+        uint64_t error_ptr = (uint64_t)(uintptr_t)error;
+        save_mode = SAVE_DATA_DIALOG_MODE_ERROR_CODE;
+        std::memcpy(save_param + 0x34, &save_mode, 4);
+        std::memcpy(save_param + 0x60, &error_ptr, 8);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.error &&
+                  request.message.find("0x809F000F") != std::string::npos &&
+                  request.buttons.count == 1,
+              "SaveDataDialog ERROR_CODE maps to an error box with bounded code text");
+
+        CHECK(!read_savedata_request(0).supported,
+              "SaveDataDialog null outer param declines ownership without dereference");
+        param_size = 0; std::memcpy(save_param + 0x30, &param_size, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog malformed outer size declines ownership");
+        param_size = 0x98; std::memcpy(save_param + 0x30, &param_size, 4);
+        error_ptr = 0; std::memcpy(save_param + 0x60, &error_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog null nested mode param declines ownership without dereference");
+        save_mode = SAVE_DATA_DIALOG_MODE_LIST;
+        std::memcpy(save_param + 0x34, &save_mode, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog LIST declines until the virtual-slot UI is implemented");
+
+        request.mode = SAVE_DATA_DIALOG_MODE_USER_MSG;
+        request.userData = user_data;
+        uint8_t save_result[0x48]; std::memset(save_result, 0xAB, sizeof save_result);
+        write_savedata_result((uint64_t)(uintptr_t)save_result, request, 2 /*NO*/, false);
+        uint32_t result_mode = 0, common_result = 0, result_button = 0;
+        uint64_t result_user_data = 0;
+        std::memcpy(&result_mode, save_result + 0x00, 4);
+        std::memcpy(&common_result, save_result + 0x04, 4);
+        std::memcpy(&result_button, save_result + 0x08, 4);
+        std::memcpy(&result_user_data, save_result + 0x20, 8);
+        CHECK(result_mode == SAVE_DATA_DIALOG_MODE_USER_MSG && common_result == 0 &&
+                  result_button == 2 && result_user_data == user_data,
+              "SaveDataDialog result returns mode/OK/NO/userData");
+        CHECK(save_result[0x0c] == 0xAB && save_result[0x10] == 0xAB &&
+                  save_result[0x18] == 0xAB && save_result[0x28] == 0xAB &&
+                  save_result[0x47] == 0xAB,
+              "SaveDataDialog result preserves pad, caller output pointers, and reserved tail");
+        write_savedata_result((uint64_t)(uintptr_t)save_result, request, 1, true);
+        std::memcpy(&common_result, save_result + 0x04, 4);
+        std::memcpy(&result_button, save_result + 0x08, 4);
+        CHECK(common_result == 1 && result_button == 0,
+              "SaveDataDialog canceled result returns USER_CANCELED + INVALID button");
+    }
+
     // --- ImeDialog: read_ime_request from a synthetic OrbisImeDialogParam (96 bytes) ---
     {
         char16_t title[] = u"Enter name";

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -84,6 +84,19 @@ int main() {
                   request.userData == user_data,
               "SaveDataDialog USER_MSG parses text, YES/NO buttons, mode, and userData");
 
+        button_type = 3 /*OK_CANCEL*/; std::memcpy(user + 0, &button_type, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        uint8_t cancel_result[0x48] = {};
+        write_savedata_result((uint64_t)(uintptr_t)cancel_result, request,
+                              request.buttons.id[1], request.buttons.id[1] == 0);
+        uint32_t cancel_common = 0, cancel_button = 99;
+        std::memcpy(&cancel_common, cancel_result + 4, 4);
+        std::memcpy(&cancel_button, cancel_result + 8, 4);
+        CHECK(request.supported && request.buttons.count == 2 && request.buttons.id[1] == 0 &&
+                  cancel_common == 1 && cancel_button == 0,
+              "SaveDataDialog USER_MSG OK_CANCEL writes USER_CANCELED + INVALID for Cancel");
+        button_type = 1 /*YESNO*/; std::memcpy(user + 0, &button_type, 4);
+
         uint8_t system[48] = {};
         uint32_t system_type = 2 /*CONFIRM*/;
         std::memcpy(system, &system_type, 4);
@@ -112,8 +125,21 @@ int main() {
         std::memcpy(option, &option_back, 4);
         request = read_savedata_request((uint64_t)(uintptr_t)save_param);
         CHECK(request.supported && request.cancelable && request.buttons.count == 2 &&
-                  request.buttons.id[1] == 2,
-              "SaveDataDialog OptionBack::ENABLE exposes OK + Cancel with the ABI button ids");
+                  request.buttons.id[1] == 0,
+              "SaveDataDialog OptionBack::ENABLE exposes OK + Cancel with INVALID for Cancel");
+        std::memset(cancel_result, 0, sizeof cancel_result);
+        write_savedata_result((uint64_t)(uintptr_t)cancel_result, request,
+                              request.buttons.id[1], request.buttons.id[1] == 0);
+        std::memcpy(&cancel_common, cancel_result + 4, 4);
+        std::memcpy(&cancel_button, cancel_result + 8, 4);
+        CHECK(cancel_common == 1 && cancel_button == 0,
+              "SaveDataDialog OptionBack-enabled Cancel writes USER_CANCELED + INVALID");
+
+        option_ptr = 0; std::memcpy(save_param + 0x78, &option_ptr, 8);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.cancelable && request.buttons.count == 2 &&
+                  request.buttons.id[1] == 0,
+              "SaveDataDialog absent OptionBack defaults to enabled OK + Cancel");
 
         option_ptr = 1; std::memcpy(save_param + 0x78, &option_ptr, 8);
         CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
@@ -196,6 +222,49 @@ int main() {
               "SaveDataDialog canceled result returns USER_CANCELED + INVALID button");
         write_savedata_result(1, request, 1, false);
         CHECK(true, "SaveDataDialog unreadable result pointer is ignored without crashing");
+    }
+
+    // SaveData lifecycle seam: pending tickets are single-consumer and generations invalidate both
+    // queued and already-visible stale modals without allowing their completion to overwrite state.
+    {
+        SaveDataRequest a; a.supported = true; a.message = "A"; a.userData = 1;
+        SaveDataRequest b; b.supported = true; b.message = "B"; b.userData = 2;
+        SaveDataDialogState state;
+
+        state.open(a);
+        state.close();
+        CHECK(!state.take_pending() && state.status() == 0,
+              "SaveData lifecycle Close-before-pump removes the pending modal");
+
+        state.open(a);
+        SaveDataModalTicket visible = state.take_pending();
+        state.close();
+        state.complete(visible.generation, 1);
+        CHECK(visible && !state.active(visible.generation) && state.status() == 0,
+              "SaveData lifecycle Close-while-visible invalidates stale completion");
+
+        state.open(a);
+        SaveDataModalTicket old = state.take_pending();
+        state.open(b);
+        state.complete(old.generation, 1);
+        SaveDataModalTicket current = state.take_pending();
+        SaveDataModalTicket duplicate = state.take_pending();
+        CHECK(old && !state.active(old.generation) && current &&
+                  current.request.userData == 2 && !duplicate,
+              "SaveData lifecycle re-Open invalidates old UI and exposes the new request exactly once");
+        state.complete(current.generation, 0 /*Cancel*/);
+        SaveDataResultSnapshot snapshot = state.result_snapshot();
+        CHECK(state.status() == 3 && snapshot.request.userData == 2 &&
+                  snapshot.canceled && snapshot.buttonId == 0,
+              "SaveData lifecycle publishes only the current generation's canceled result");
+        uint8_t lifecycle_result[0x48] = {};
+        write_savedata_result((uint64_t)(uintptr_t)lifecycle_result, snapshot.request,
+                              snapshot.buttonId, snapshot.canceled);
+        uint32_t lifecycle_common = 0, lifecycle_button = 99;
+        std::memcpy(&lifecycle_common, lifecycle_result + 4, 4);
+        std::memcpy(&lifecycle_button, lifecycle_result + 8, 4);
+        CHECK(lifecycle_common == 1 && lifecycle_button == 0,
+              "SaveData lifecycle canceled completion writes USER_CANCELED + INVALID");
     }
 
     // --- ImeDialog: read_ime_request from a synthetic OrbisImeDialogParam (96 bytes) ---

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1159,54 +1159,90 @@ HLE(s_dialog_result) {
 // matches MsgDialog above: Open auto-dismisses to FINISHED so the guest can consume a neutral result.
 //
 // PS4/PS5 SDK layout used below (also used by shadPS4): param.mode is u32 at +0x34 and param.userData
-// is a pointer at +0x70. Result begins with mode/result/buttonId/pad followed by three pointers. Write
-// only that proven 0x28-byte prefix; the remaining 32 reserved bytes belong to the caller.
+// is a pointer at +0x70. Result begins with mode/result/buttonId/pad followed by three pointers. The
+// dirName/param pointer slots are caller-owned output destinations, not fields for the service to
+// replace. Write only mode/result/buttonId/userData and preserve every padding, pointer, and reserved
+// byte. A PlatformUi that accepts Open remains the owner even if the global registration later changes.
 namespace {
     std::atomic<int> g_savedatadialog_status{0 /*NONE*/};
     std::atomic<uint32_t> g_savedatadialog_mode{0 /*INVALID*/};
     std::atomic<uint64_t> g_savedatadialog_user_data{0};
+    std::atomic<PlatformUi*> g_savedatadialog_ui{nullptr};
 }
 HLE(s_savedlg_initialize) {
+    if (auto* ui = g_savedatadialog_ui.exchange(nullptr)) ui->saveDataDialogClose();
     g_savedatadialog_mode.store(0);
     g_savedatadialog_user_data.store(0);
     g_savedatadialog_status.store(1 /*INITIALIZED*/);
     return 0;
 }
 HLE(s_savedlg_open) {
+    if (auto* old_ui = g_savedatadialog_ui.exchange(nullptr)) old_ui->saveDataDialogClose();
     if (a0) {
         const uint8_t* param = (const uint8_t*)PW(a0);
-        g_savedatadialog_mode.store(*(const uint32_t*)(param + 0x34));
-        g_savedatadialog_user_data.store(*(const uint64_t*)(param + 0x70));
+        uint32_t mode = 0;
+        uint64_t user_data = 0;
+        memcpy(&mode, param + 0x34, sizeof mode);
+        memcpy(&user_data, param + 0x70, sizeof user_data);
+        g_savedatadialog_mode.store(mode);
+        g_savedatadialog_user_data.store(user_data);
     } else {
         g_savedatadialog_mode.store(0);
         g_savedatadialog_user_data.store(0);
     }
+    if (auto* ui = platform_ui(); ui && ui->saveDataDialogOpen(a0)) {
+        g_savedatadialog_ui.store(ui);
+        return 0;
+    }
     g_savedatadialog_status.store(3 /*FINISHED (auto-dismiss)*/);
     return 0;
 }
-HLE(s_savedlg_status) { return (uint64_t)(unsigned)g_savedatadialog_status.load(); }
+HLE(s_savedlg_status) {
+    if (auto* ui = g_savedatadialog_ui.load())
+        return (uint64_t)(unsigned)ui->saveDataDialogStatus();
+    return (uint64_t)(unsigned)g_savedatadialog_status.load();
+}
 HLE(s_savedlg_result) {
+    if (auto* ui = g_savedatadialog_ui.load()) {
+        (void)ui->saveDataDialogResult(a0);
+        return 0;
+    }
     if (a0) {
         uint8_t* result = (uint8_t*)PW(a0);
-        *(uint32_t*)(result + 0x00) = g_savedatadialog_mode.load();
-        *(uint32_t*)(result + 0x04) = 0 /*CommonDialogResult::OK*/;
-        *(uint32_t*)(result + 0x08) = 0 /*ButtonId::INVALID*/;
-        *(uint32_t*)(result + 0x0c) = 0;
-        *(uint64_t*)(result + 0x10) = 0 /*dirName*/;
-        *(uint64_t*)(result + 0x18) = 0 /*save param*/;
-        *(uint64_t*)(result + 0x20) = g_savedatadialog_user_data.load();
+        const uint32_t mode = g_savedatadialog_mode.load();
+        const uint32_t ok = 0 /*CommonDialogResult::OK*/;
+        const uint32_t invalid = 0 /*ButtonId::INVALID*/;
+        const uint64_t user_data = g_savedatadialog_user_data.load();
+        memcpy(result + 0x00, &mode, sizeof mode);
+        memcpy(result + 0x04, &ok, sizeof ok);
+        memcpy(result + 0x08, &invalid, sizeof invalid);
+        memcpy(result + 0x20, &user_data, sizeof user_data);
     }
     return 0;
 }
-HLE(s_savedlg_close) { g_savedatadialog_status.store(0 /*NONE*/); return 0; }
+HLE(s_savedlg_close) {
+    if (auto* ui = g_savedatadialog_ui.exchange(nullptr)) ui->saveDataDialogClose();
+    g_savedatadialog_status.store(0 /*NONE*/);
+    return 0;
+}
 HLE(s_savedlg_terminate) {
+    if (auto* ui = g_savedatadialog_ui.exchange(nullptr)) ui->saveDataDialogClose();
     g_savedatadialog_status.store(0 /*NONE*/);
     g_savedatadialog_mode.store(0);
     g_savedatadialog_user_data.store(0);
     return 0;
 }
 HLE(s_savedlg_ready) { return 1; }
-HLE(s_savedlg_progress) { return 0; }
+HLE(s_savedlg_progress_inc) {
+    if (auto* ui = g_savedatadialog_ui.load())
+        ui->saveDataDialogProgressBarInc((uint32_t)a0, (uint32_t)a1);
+    return 0;
+}
+HLE(s_savedlg_progress_set) {
+    if (auto* ui = g_savedatadialog_ui.load())
+        ui->saveDataDialogProgressBarSetValue((uint32_t)a0, (uint32_t)a1);
+    return 0;
+}
 
 // --- libSceImeDialog (on-screen text-entry dialog) (#191). We have no keyboard UI, so the dialog
 // auto-completes: Init -> FINISHED immediately, so the game's "poll GetStatus until Finished" loop
@@ -2014,8 +2050,8 @@ void register_service_hle() {
     Hle::register_fn("s9e3+YpRnzw", (HleFn)s_savedlg_initialize, "sceSaveDataDialogInitialize");
     Hle::register_fn("en7gNVnh878", (HleFn)s_savedlg_ready,      "sceSaveDataDialogIsReadyToDisplay");
     Hle::register_fn("4tPhsP6FpDI", (HleFn)s_savedlg_open,       "sceSaveDataDialogOpen");
-    Hle::register_fn("V-uEeFKARJU", (HleFn)s_savedlg_progress,   "sceSaveDataDialogProgressBarInc");
-    Hle::register_fn("hay1CfTmLyA", (HleFn)s_savedlg_progress,   "sceSaveDataDialogProgressBarSetValue");
+    Hle::register_fn("V-uEeFKARJU", (HleFn)s_savedlg_progress_inc, "sceSaveDataDialogProgressBarInc");
+    Hle::register_fn("hay1CfTmLyA", (HleFn)s_savedlg_progress_set, "sceSaveDataDialogProgressBarSetValue");
     Hle::register_fn("YuH2FA7azqQ", (HleFn)s_savedlg_terminate,  "sceSaveDataDialogTerminate");
     Hle::register_fn("KK3Bdg1RWK0", (HleFn)s_savedlg_status,     "sceSaveDataDialogUpdateStatus");
     // libSceImeDialog (#191): auto-completing text-entry dialog (no keyboard UI). Raw NIDs.

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -57,6 +57,30 @@ namespace { std::atomic<uint64_t> g_handle{1}; }
 namespace {
 bool svclog() { static int v = getenv("PROSPER_SVCLOG") ? 1 : 0; return v; }
 bool svc_ptrish(uint64_t v) { return v >= 0x10000 && v < 0x7fffffffffffull; }
+bool svc_copy_bytes(uint64_t src, void* dst, size_t bytes) {
+    if (!src || !dst || !bytes || src > UINT64_MAX - (bytes - 1)) return false;
+#ifdef _WIN32
+    SIZE_T copied = 0;
+    return ReadProcessMemory(GetCurrentProcess(), (const void*)(uintptr_t)src, dst, bytes, &copied) &&
+           copied == bytes;
+#else
+    iovec local{dst, bytes};
+    iovec remote{(void*)(uintptr_t)src, bytes};
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)bytes;
+#endif
+}
+bool svc_write_bytes(uint64_t dst, const void* src, size_t bytes) {
+    if (!dst || !src || !bytes || dst > UINT64_MAX - (bytes - 1)) return false;
+#ifdef _WIN32
+    SIZE_T copied = 0;
+    return WriteProcessMemory(GetCurrentProcess(), (void*)(uintptr_t)dst, src, bytes, &copied) &&
+           copied == bytes;
+#else
+    iovec local{const_cast<void*>(src), bytes};
+    iovec remote{(void*)(uintptr_t)dst, bytes};
+    return process_vm_writev(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)bytes;
+#endif
+}
 size_t svc_copy_words(uint64_t src, uint64_t* dst, size_t words) {
     const size_t bytes = words * sizeof(uint64_t);
 #ifdef _WIN32
@@ -1162,71 +1186,96 @@ HLE(s_dialog_result) {
 // is a pointer at +0x70. Result begins with mode/result/buttonId/pad followed by three pointers. The
 // dirName/param pointer slots are caller-owned output destinations, not fields for the service to
 // replace. Write only mode/result/buttonId/userData and preserve every padding, pointer, and reserved
-// byte. A PlatformUi that accepts Open remains the owner even if the global registration later changes.
+// byte. A PlatformUi that accepts Open remains the intended owner, but every callback obtains a
+// registry lease first: unregistering the backend safely abandons the dialog instead of dereferencing
+// a stale non-owning pointer or rerouting the dialog to a replacement backend.
 namespace {
     std::atomic<int> g_savedatadialog_status{0 /*NONE*/};
     std::atomic<uint32_t> g_savedatadialog_mode{0 /*INVALID*/};
     std::atomic<uint64_t> g_savedatadialog_user_data{0};
     std::atomic<PlatformUi*> g_savedatadialog_ui{nullptr};
+
+    void savedlg_close_owner() {
+        PlatformUi* expected = g_savedatadialog_ui.exchange(nullptr);
+        if (!expected) return;
+        auto ui = platform_ui_lease(expected);
+        if (ui) ui->saveDataDialogClose();
+    }
+
+    PlatformUiLease savedlg_owner_lease(PlatformUi*& expected) {
+        expected = g_savedatadialog_ui.load(std::memory_order_acquire);
+        if (!expected) return {};
+        return platform_ui_lease(expected);
+    }
+
+    void savedlg_abandon_owner(PlatformUi* expected) {
+        if (expected && g_savedatadialog_ui.compare_exchange_strong(expected, nullptr))
+            g_savedatadialog_status.store(3 /*FINISHED: safe headless fallback*/);
+    }
 }
 HLE(s_savedlg_initialize) {
-    if (auto* ui = g_savedatadialog_ui.exchange(nullptr)) ui->saveDataDialogClose();
+    savedlg_close_owner();
     g_savedatadialog_mode.store(0);
     g_savedatadialog_user_data.store(0);
     g_savedatadialog_status.store(1 /*INITIALIZED*/);
     return 0;
 }
 HLE(s_savedlg_open) {
-    if (auto* old_ui = g_savedatadialog_ui.exchange(nullptr)) old_ui->saveDataDialogClose();
-    if (a0) {
-        const uint8_t* param = (const uint8_t*)PW(a0);
+    savedlg_close_owner();
+    if (a0 && a0 <= UINT64_MAX - 0x78) {
         uint32_t mode = 0;
         uint64_t user_data = 0;
-        memcpy(&mode, param + 0x34, sizeof mode);
-        memcpy(&user_data, param + 0x70, sizeof user_data);
+        (void)svc_copy_bytes(a0 + 0x34, &mode, sizeof mode);
+        (void)svc_copy_bytes(a0 + 0x70, &user_data, sizeof user_data);
         g_savedatadialog_mode.store(mode);
         g_savedatadialog_user_data.store(user_data);
     } else {
         g_savedatadialog_mode.store(0);
         g_savedatadialog_user_data.store(0);
     }
-    if (auto* ui = platform_ui(); ui && ui->saveDataDialogOpen(a0)) {
-        g_savedatadialog_ui.store(ui);
+    auto ui = platform_ui_lease();
+    if (ui && ui->saveDataDialogOpen(a0)) {
+        g_savedatadialog_ui.store(ui.get(), std::memory_order_release);
         return 0;
     }
     g_savedatadialog_status.store(3 /*FINISHED (auto-dismiss)*/);
     return 0;
 }
 HLE(s_savedlg_status) {
-    if (auto* ui = g_savedatadialog_ui.load())
+    PlatformUi* expected = nullptr;
+    auto ui = savedlg_owner_lease(expected);
+    if (expected && ui)
         return (uint64_t)(unsigned)ui->saveDataDialogStatus();
+    savedlg_abandon_owner(expected);
     return (uint64_t)(unsigned)g_savedatadialog_status.load();
 }
 HLE(s_savedlg_result) {
-    if (auto* ui = g_savedatadialog_ui.load()) {
+    PlatformUi* expected = nullptr;
+    auto ui = savedlg_owner_lease(expected);
+    if (expected && ui) {
         (void)ui->saveDataDialogResult(a0);
         return 0;
     }
-    if (a0) {
-        uint8_t* result = (uint8_t*)PW(a0);
+    savedlg_abandon_owner(expected);
+    if (a0 && a0 <= UINT64_MAX - 0x20) {
         const uint32_t mode = g_savedatadialog_mode.load();
         const uint32_t ok = 0 /*CommonDialogResult::OK*/;
         const uint32_t invalid = 0 /*ButtonId::INVALID*/;
         const uint64_t user_data = g_savedatadialog_user_data.load();
-        memcpy(result + 0x00, &mode, sizeof mode);
-        memcpy(result + 0x04, &ok, sizeof ok);
-        memcpy(result + 0x08, &invalid, sizeof invalid);
-        memcpy(result + 0x20, &user_data, sizeof user_data);
+        (void)svc_write_bytes(a0 + 0x00, &mode, sizeof mode);
+        (void)svc_write_bytes(a0 + 0x04, &ok, sizeof ok);
+        (void)svc_write_bytes(a0 + 0x08, &invalid, sizeof invalid);
+        (void)svc_write_bytes(a0 + 0x20, &user_data, sizeof user_data);
     }
     return 0;
 }
 HLE(s_savedlg_close) {
-    if (auto* ui = g_savedatadialog_ui.exchange(nullptr)) ui->saveDataDialogClose();
+    savedlg_close_owner();
     g_savedatadialog_status.store(0 /*NONE*/);
     return 0;
 }
 HLE(s_savedlg_terminate) {
-    if (auto* ui = g_savedatadialog_ui.exchange(nullptr)) ui->saveDataDialogClose();
+    savedlg_close_owner();
     g_savedatadialog_status.store(0 /*NONE*/);
     g_savedatadialog_mode.store(0);
     g_savedatadialog_user_data.store(0);
@@ -1234,13 +1283,21 @@ HLE(s_savedlg_terminate) {
 }
 HLE(s_savedlg_ready) { return 1; }
 HLE(s_savedlg_progress_inc) {
-    if (auto* ui = g_savedatadialog_ui.load())
+    PlatformUi* expected = nullptr;
+    auto ui = savedlg_owner_lease(expected);
+    if (expected && ui)
         ui->saveDataDialogProgressBarInc((uint32_t)a0, (uint32_t)a1);
+    else
+        savedlg_abandon_owner(expected);
     return 0;
 }
 HLE(s_savedlg_progress_set) {
-    if (auto* ui = g_savedatadialog_ui.load())
+    PlatformUi* expected = nullptr;
+    auto ui = savedlg_owner_lease(expected);
+    if (expected && ui)
         ui->saveDataDialogProgressBarSetValue((uint32_t)a0, (uint32_t)a1);
+    else
+        savedlg_abandon_owner(expected);
     return 0;
 }
 

--- a/prosper/src/hle/platform_ui.cpp
+++ b/prosper/src/hle/platform_ui.cpp
@@ -5,9 +5,21 @@
 
 namespace prosper {
 
-namespace { std::atomic<PlatformUi*> g_platform_ui{nullptr}; }
+namespace {
+std::atomic<PlatformUi*> g_platform_ui{nullptr};
+std::mutex g_platform_ui_mx;
+}
 
 PlatformUi* platform_ui() { return g_platform_ui.load(std::memory_order_acquire); }
-void        set_platform_ui(PlatformUi* ui) { g_platform_ui.store(ui, std::memory_order_release); }
+PlatformUiLease platform_ui_lease(PlatformUi* expected) {
+    std::unique_lock<std::mutex> lock(g_platform_ui_mx);
+    PlatformUi* ui = g_platform_ui.load(std::memory_order_acquire);
+    if (expected && ui != expected) ui = nullptr;
+    return PlatformUiLease(std::move(lock), ui);
+}
+void set_platform_ui(PlatformUi* ui) {
+    std::lock_guard<std::mutex> lock(g_platform_ui_mx);
+    g_platform_ui.store(ui, std::memory_order_release);
+}
 
 } // namespace prosper

--- a/prosper/src/hle/platform_ui.hpp
+++ b/prosper/src/hle/platform_ui.hpp
@@ -14,6 +14,8 @@
 // Status values are the shared SceCommonDialogStatus: 0=NONE, 1=INITIALIZED, 2=RUNNING, 3=FINISHED.
 #pragma once
 #include <cstdint>
+#include <mutex>
+#include <utility>
 
 namespace prosper {
 
@@ -75,6 +77,34 @@ struct PlatformUi {
     virtual int keyboardResourceIds(int32_t userId, uint32_t* outIds, int max) {
         (void)userId; (void)outIds; (void)max; return 0;
     }
+};
+
+// A short-lived, registry-locked reference to the current backend. The frontend must unregister
+// itself before destroying its PlatformUi; set_platform_ui() then waits for every outstanding lease,
+// so an HLE callback cannot race backend destruction. Supplying `expected` additionally prevents an
+// open dialog from being rerouted to a different backend registered later.
+class PlatformUiLease;
+PlatformUiLease platform_ui_lease(PlatformUi* expected = nullptr);
+
+class PlatformUiLease {
+public:
+    PlatformUiLease() = default;
+    PlatformUiLease(PlatformUiLease&&) noexcept = default;
+    PlatformUiLease& operator=(PlatformUiLease&&) noexcept = default;
+    PlatformUiLease(const PlatformUiLease&) = delete;
+    PlatformUiLease& operator=(const PlatformUiLease&) = delete;
+
+    PlatformUi* get() const { return ui_; }
+    PlatformUi* operator->() const { return ui_; }
+    explicit operator bool() const { return ui_ != nullptr; }
+
+private:
+    friend PlatformUiLease platform_ui_lease(PlatformUi* expected);
+    PlatformUiLease(std::unique_lock<std::mutex>&& lock, PlatformUi* ui)
+        : lock_(std::move(lock)), ui_(ui) {}
+
+    std::unique_lock<std::mutex> lock_;
+    PlatformUi* ui_ = nullptr;
 };
 
 // The registered backend, or nullptr when headless. The frontend calls set_platform_ui once at startup

--- a/prosper/src/hle/platform_ui.hpp
+++ b/prosper/src/hle/platform_ui.hpp
@@ -45,6 +45,21 @@ struct PlatformUi {
     virtual int  msgDialogResult(uint64_t result) { (void)result; return 0; }
     virtual void msgDialogClose() {}
 
+    // --- libSceSaveDataDialog (save/load/delete confirmation and save-slot UI) ---
+    // `param` is the guest SceSaveDataDialogParam*. Return true to own this Open; the core then
+    // routes every status/result/progress/close call to this same backend instance. Returning false
+    // preserves the headless policy: Open auto-completes with a neutral result.
+    virtual bool saveDataDialogOpen(uint64_t param) { (void)param; return false; }
+    virtual int  saveDataDialogStatus() { return 3 /*FINISHED*/; }
+    virtual int  saveDataDialogResult(uint64_t result) { (void)result; return 0; }
+    virtual void saveDataDialogProgressBarInc(uint32_t target, uint32_t delta) {
+        (void)target; (void)delta;
+    }
+    virtual void saveDataDialogProgressBarSetValue(uint32_t target, uint32_t value) {
+        (void)target; (void)value;
+    }
+    virtual void saveDataDialogClose() {}
+
     // --- libSceErrorDialog (single-button error message; no result struct) ---
     // Show an error dialog. `param` is the guest sceErrorDialogOpen argument (opaque). Return true to
     // OWN it; false -> the core auto-dismisses headlessly (and logs the errorCode).

--- a/prosper/tests/test_platform_ui.cpp
+++ b/prosper/tests/test_platform_ui.cpp
@@ -7,6 +7,7 @@
 #include "../src/hle/nid.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 
 using namespace prosper;
 
@@ -42,14 +43,14 @@ struct MockUi : PlatformUi {
 
     // SaveDataDialog
     bool save_accept = true;
-    int save_status = 2, save_opens = 0, save_closes = 0, save_results = 0;
+    int save_status = 2, save_opens = 0, save_closes = 0, save_results = 0, save_status_calls = 0;
     int save_incs = 0, save_sets = 0;
     uint64_t save_last_param = 0, save_last_result = 0;
     uint32_t save_last_target = 0, save_last_value = 0;
     bool saveDataDialogOpen(uint64_t param) override {
         save_opens++; save_last_param = param; save_status = 2; return save_accept;
     }
-    int saveDataDialogStatus() override { return save_status; }
+    int saveDataDialogStatus() override { save_status_calls++; return save_status; }
     int saveDataDialogResult(uint64_t result) override {
         save_results++; save_last_result = result;
         if (result) *(uint32_t*)result = 4 /*ERROR_CODE marker*/;
@@ -170,9 +171,6 @@ int main() {
         CHECK(ui.save_opens == 2 && ui.save_last_param == (uint64_t)(uintptr_t)save_param &&
                   s_status(0,0,0,0,0,0) == 2,
               "SaveDataDialog accepted ownership forwards Open and backend RUNNING status");
-        set_platform_ui(nullptr); // ownership must remain with the backend that accepted Open
-        CHECK(s_status(0,0,0,0,0,0) == 2,
-              "SaveDataDialog status remains bound to accepting backend after registry changes");
         s_inc(7, 4,0,0,0,0); s_set(7, 65,0,0,0,0);
         CHECK(ui.save_incs == 1 && ui.save_sets == 1 && ui.save_last_target == 7 &&
                   ui.save_last_value == 65,
@@ -185,6 +183,37 @@ int main() {
         s_term(0,0,0,0,0,0);
         CHECK(ui.save_closes == 1 && s_status(0,0,0,0,0,0) == 0,
               "SaveDataDialog Term closes accepting backend and returns to NONE");
+
+        // Replacing/unregistering the non-owning registry pointer must never leave a callable stale
+        // owner. The outstanding dialog falls back to neutral headless completion, and is not
+        // accidentally rerouted to the replacement backend.
+        s_init(0,0,0,0,0,0);
+        s_open((uint64_t)(uintptr_t)save_param,0,0,0,0,0);
+        CHECK(ui.save_opens == 3 && s_status(0,0,0,0,0,0) == 2,
+              "SaveDataDialog can open a second backend-owned request");
+        const int old_status_calls = ui.save_status_calls;
+        MockUi replacement;
+        set_platform_ui(nullptr);
+        set_platform_ui(&replacement);
+        CHECK(s_status(0,0,0,0,0,0) == 3 && ui.save_status_calls == old_status_calls &&
+                  replacement.save_status_calls == 0,
+              "SaveDataDialog safely abandons an unregistered owner without rerouting it");
+        s_inc(3, 9,0,0,0,0); s_set(3, 17,0,0,0,0);
+        CHECK(ui.save_incs == 1 && ui.save_sets == 1 && replacement.save_incs == 0 &&
+                  replacement.save_sets == 0,
+              "SaveDataDialog progress never calls an unregistered or replacement backend");
+        std::memset(save_result, 0xAB, sizeof save_result);
+        s_result((uint64_t)(uintptr_t)save_result,0,0,0,0,0);
+        CHECK(ui.save_results == 1 && replacement.save_results == 0 &&
+                  *(uint32_t*)save_result == 3 && *(uint32_t*)(save_result + 4) == 0,
+              "SaveDataDialog abandoned owner returns the neutral headless result");
+        s_result(1,0,0,0,0,0);
+        CHECK(true, "SaveDataDialog neutral result ignores an unreadable guest pointer");
+        s_term(0,0,0,0,0,0);
+        CHECK(ui.save_closes == 1 && replacement.save_closes == 0 &&
+                  s_status(0,0,0,0,0,0) == 0,
+              "SaveDataDialog Term does not dereference an unregistered owner");
+        set_platform_ui(nullptr);
     }
     set_platform_ui(nullptr);
 

--- a/prosper/tests/test_platform_ui.cpp
+++ b/prosper/tests/test_platform_ui.cpp
@@ -39,6 +39,29 @@ struct MockUi : PlatformUi {
     bool errorDialogOpen(uint64_t param) override { err_opens++; err_last_param = param; err_status = 2; return true; }
     int  errorDialogStatus() override { return err_status; }
     void errorDialogClose() override { err_closes++; err_status = 0; }
+
+    // SaveDataDialog
+    bool save_accept = true;
+    int save_status = 2, save_opens = 0, save_closes = 0, save_results = 0;
+    int save_incs = 0, save_sets = 0;
+    uint64_t save_last_param = 0, save_last_result = 0;
+    uint32_t save_last_target = 0, save_last_value = 0;
+    bool saveDataDialogOpen(uint64_t param) override {
+        save_opens++; save_last_param = param; save_status = 2; return save_accept;
+    }
+    int saveDataDialogStatus() override { return save_status; }
+    int saveDataDialogResult(uint64_t result) override {
+        save_results++; save_last_result = result;
+        if (result) *(uint32_t*)result = 4 /*ERROR_CODE marker*/;
+        return 1;
+    }
+    void saveDataDialogProgressBarInc(uint32_t target, uint32_t delta) override {
+        save_incs++; save_last_target = target; save_last_value = delta;
+    }
+    void saveDataDialogProgressBarSetValue(uint32_t target, uint32_t value) override {
+        save_sets++; save_last_target = target; save_last_value = value;
+    }
+    void saveDataDialogClose() override { save_closes++; save_status = 0; }
 };
 
 int main() {
@@ -117,6 +140,51 @@ int main() {
         CHECK(ui.err_opens == 1 && ui.err_last_param == 0xBBBB, "ErrorDialog backend: Open forwards the param");
         CHECK(e_status(0,0,0,0,0,0) == 2, "ErrorDialog backend: status follows the frontend (RUNNING)");
         if (e_term) { e_term(0,0,0,0,0,0); CHECK(ui.err_closes == 1, "ErrorDialog backend: Term routes to errorDialogClose"); }
+    }
+
+    // --- SaveDataDialog: declined ownership keeps headless behavior; accepted ownership stays bound
+    // to the exact backend that accepted Open, including progress, result, and Term. ---
+    HleFn s_init = Hle::lookup("s9e3+YpRnzw"), s_open = Hle::lookup("4tPhsP6FpDI"),
+          s_status = Hle::lookup("ERKzksauAJA"), s_result = Hle::lookup("yEiJ-qqr6Cg"),
+          s_close = Hle::lookup("fH46Lag88XY"), s_term = Hle::lookup("YuH2FA7azqQ"),
+          s_inc = Hle::lookup("V-uEeFKARJU"), s_set = Hle::lookup("hay1CfTmLyA");
+    CHECK(s_init && s_open && s_status && s_result && s_close && s_term && s_inc && s_set,
+          "SaveDataDialog handlers registered");
+    if (s_init && s_open && s_status && s_result && s_close && s_term && s_inc && s_set) {
+        uint8_t save_param[0x98] = {};
+        *(uint32_t*)(save_param + 0x34) = 3 /*SYSTEM_MSG*/;
+        *(uint64_t*)(save_param + 0x70) = 0x12345678;
+
+        set_platform_ui(&ui);
+        ui.save_accept = false;
+        s_init(0,0,0,0,0,0);
+        s_open((uint64_t)(uintptr_t)save_param,0,0,0,0,0);
+        CHECK(ui.save_opens == 1 && s_status(0,0,0,0,0,0) == 3,
+              "SaveDataDialog declined ownership falls back to headless FINISHED");
+        s_close(0,0,0,0,0,0);
+        CHECK(ui.save_closes == 0, "SaveDataDialog declined ownership is not closed through backend");
+
+        ui.save_accept = true;
+        s_init(0,0,0,0,0,0);
+        s_open((uint64_t)(uintptr_t)save_param,0,0,0,0,0);
+        CHECK(ui.save_opens == 2 && ui.save_last_param == (uint64_t)(uintptr_t)save_param &&
+                  s_status(0,0,0,0,0,0) == 2,
+              "SaveDataDialog accepted ownership forwards Open and backend RUNNING status");
+        set_platform_ui(nullptr); // ownership must remain with the backend that accepted Open
+        CHECK(s_status(0,0,0,0,0,0) == 2,
+              "SaveDataDialog status remains bound to accepting backend after registry changes");
+        s_inc(7, 4,0,0,0,0); s_set(7, 65,0,0,0,0);
+        CHECK(ui.save_incs == 1 && ui.save_sets == 1 && ui.save_last_target == 7 &&
+                  ui.save_last_value == 65,
+              "SaveDataDialog progress callbacks route to accepting backend");
+        uint8_t save_result[0x48] = {};
+        s_result((uint64_t)(uintptr_t)save_result,0,0,0,0,0);
+        CHECK(ui.save_results == 1 && ui.save_last_result == (uint64_t)(uintptr_t)save_result &&
+                  *(uint32_t*)save_result == 4,
+              "SaveDataDialog GetResult routes to accepting backend");
+        s_term(0,0,0,0,0,0);
+        CHECK(ui.save_closes == 1 && s_status(0,0,0,0,0,0) == 0,
+              "SaveDataDialog Term closes accepting backend and returns to NONE");
     }
     set_platform_ui(nullptr);
 

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -146,6 +146,9 @@ int main() {
                   "SaveDataDialog result reports mode and neutral OK/INVALID outcome");
             CHECK(*(uint64_t*)(out + 0x20) == 0x123456789abcdef0ull,
                   "SaveDataDialog result preserves caller userData");
+            CHECK(out[0x0c] == 0xAB && *(uint64_t*)(out + 0x10) == 0xABABABABABABABABull &&
+                  *(uint64_t*)(out + 0x18) == 0xABABABABABABABABull,
+                  "SaveDataDialog result preserves ABI padding and caller-owned output pointers");
             CHECK(out[0x28] == 0xAB && out[0x4f] == 0xAB,
                   "SaveDataDialog result does not overwrite its reserved tail");
             close(0,0,0,0,0,0);


### PR DESCRIPTION
Addresses the first interactive frontend slice of #772.

What changes:
- extends `PlatformUi` with an optional SaveDataDialog lifecycle and binds status/result/progress/close to the exact registered backend that accepted `Open`
- adds a registry lease so backend unregistration cannot race an in-flight callback; an unregistered owner falls back neutrally and is never dereferenced or rerouted
- preserves the existing headless `Initialize -> Open -> FINISHED` path used by Dead Cells
- parses the inherited 0x98-byte parameter and 0x48-byte result layouts outside `prosper_core`, using fault-contained reads/writes for outer, nested, string, option, and result guest pointers
- preserves caller-owned output pointers, ABI padding, and reserved result bytes
- adds SDL main-thread USER_MSG, ordinary SYSTEM_MSG confirmation/notice, and ERROR_CODE dialogs
- uses a mutex-protected, SDL-free request/generation state seam and an interruptible SDL modal, so Close/re-Open tears down stale UI and exposes each new request exactly once
- unregisters the SDL backend before closing its state, preventing a new accepted Open during shutdown
- honors `OptionBack::DISABLE` for SYSTEM_MSG types 10/11/13 and encodes every explicit Cancel as `USER_CANCELED + ButtonId::INVALID`
- regression-tests close-before-pump, close-while-visible, re-Open/stale completion, exactly-once pending consumption, enabled/disabled/absent OptionBack, and malformed guest pointers
- deliberately declines LIST and progress/no-button presentation until a virtual-save-slot/non-modal UI exists; no arbitrary host file picker

ABI reference: https://github.com/shadps4-emu/shadPS4/blob/bfb0122bbe3c1dc7c71d4973d321869c0eb5e015/src/core/libraries/save_data/dialog/savedatadialog_ui.h

Exact-head author verification for `8258fc71d042cc9f67130444b9271e2b1d0edc7f`:
- `powershell -NoProfile -File prosper/tools/verify-pr.ps1 core -Pr 951`: PASS
- Linux build and 108/108 tests: passed
- Windows build and 82/82 tests: passed
- base-to-head `git diff --check`: passed
- focused MinGW app check: `cmake --build prosper/build-mingw-app --target prosper-app --parallel 8`: passed
- evidence: https://github.com/mattias800/ps5ys/pull/951#issuecomment-5013534197

Exact-head inspection-only approval: https://github.com/mattias800/ps5ys/pull/951#issuecomment-5013537492

The verifier comments for `00623822...`, `36d40466...`, and `96e5bb4b...` are superseded by this exact-head result. All six required GitHub CI jobs passed. No image/game snapshot workflow was run.