### PR TITLE
perf: retain live color targets by default

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -279,6 +279,14 @@ local. The cache is bounded to 256 MiB and 1024 allocations by default. Set
 device-image budget are separate: a hot immutable atlas can occupy space in both, trading bounded
 residency for lower frame time.
 
+Intermediate live color targets remain on the GPU by default. A later graphics pass that samples the
+same guest target identity, extent, and format binds the retained image directly; scanout, captures,
+pixel diagnostics, same-target feedback, and authoritative-readback spans keep the CPU path. Guest GPU
+writes invalidate overlapping retained targets through the ordered write observer. Set
+`PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1` for a complete frontend A/B, or
+`PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS=1` to disable backend retention independently. The backend
+cache defaults to 256 MiB and can be changed with `PROSPER_BACKEND_TARGET_CACHE_MB=<MiB>`.
+
 Graphics RDNA2-to-SPIR-V results use a process-wide bounded cache (4096 entries and 128 MiB by
 default). Its key contains the shader bytes and only the resource-table fields consumed by compilation;
 current guest addresses and backing data remain on each draw and are never cached. Use

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -503,11 +503,14 @@ directly instead of reading it to CPU RGBA and uploading it again. Guest GPU wri
 entries through the same ordered write observer used by persistent depth/stencil state. Same-target feedback,
 scanout, presentation fallback, captures, replay seeds, and pixel diagnostics keep the established CPU path.
 
-The live path is initially opt-in with `PROSPER_LIVE_PERSISTENT_COLOR_TARGETS=1`. Set
+The live path is enabled by default as of 2026-07-19. Set
+`PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1` for a complete frontend A/B,
 `PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS=1` to disable backend retention independently, or change its
-256 MiB budget with `PROSPER_BACKEND_TARGET_CACHE_MB`. The backend unit contract compares direct GPU
-producer-to-sampler output byte-for-byte with CPU readback/upload, verifies a deferred-readback LOAD pass,
-and proves that invalidation uses supplied CPU pixels rather than stale GPU contents.
+256 MiB budget with `PROSPER_BACKEND_TARGET_CACHE_MB`. Captures, per-target pixel diagnostics, scanout,
+same-target feedback, and authoritative-readback spans retain the established CPU path. The backend unit
+contract compares direct GPU producer-to-sampler output byte-for-byte with CPU readback/upload, verifies a
+deferred-readback LOAD pass, and proves that invalidation uses supplied CPU pixels rather than stale GPU
+contents.
 
 Native Windows Dead Cells post-`PARSEALL` evidence used one current-master binary with submit-aligned timing.
 The animated runs did not carry identical draw counts, so the phase counters establish the mechanism more
@@ -529,6 +532,25 @@ work while completing slightly faster, but this is not yet a playable frame budg
 still cost about 9 ms, 405-draw realization costs about 40 ms, and the ordered path still executes ten target
 calls plus eight compute calls. The next architectural gain requires fewer synchronous submissions/fences or
 safe reuse of per-draw resource work; neither may weaken the captured graphics/compute dependency order.
+
+The default-on decision used a paired native-Windows Evergate fresh-save route on one current-master binary
+after call-local resource sharing. Both runs used native 1920x1080 targets and the same 75-second controller
+script. Animated windows are not draw-identical, so the mechanism counters and ranges matter more than any
+single sample:
+
+| Measurement | CPU target path | Persistent GPU targets |
+|---|---:|---:|
+| Presented frames in 75 seconds | 314 | 373 |
+| Observed heavy-scene rate | about 1.9 FPS | about 2.7 FPS |
+| Target writes / readbacks / deferred | 0 / 14 / 0 | 14 / 6 / 8 |
+| Direct target samples | 0 | 19 |
+| Heavy whole-submit windows | 450-475 ms | 317-359 ms |
+| Heavy frontend Vulkan work | 252-285 ms | 159-194 ms |
+| Heavy GPU fence waits | 59-61 ms | 34-37 ms |
+| Heavy record/upload | 13-15 ms | 1-2 ms |
+
+This is still far from the 16.7 ms frame budget, but it removes repeated GPU-to-CPU-to-GPU ownership
+round-trips from normal runs and makes the remaining per-draw realization and transient object costs clearer.
 
 ## Current frame budget
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -374,10 +374,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr ||
                                   getenv("PROSPER_RTT_SINGLE_TARGET") == nullptr;
     static const bool rtt_on = getenv("PROSPER_RTT") != nullptr || pertarget;
-    // First deployment is opt-in. Captures and per-target pixel diagnostics require authoritative
-    // CPU pixels at every pass, so they retain the established readback path even when requested.
-    static const bool live_gpu_targets = getenv("PROSPER_LIVE_PERSISTENT_COLOR_TARGETS") &&
-        pertarget && !getenv("PROSPER_GPU_CAPTURE") &&
+    // Retain intermediate color targets on the GPU by default. Captures and per-target pixel
+    // diagnostics require authoritative CPU pixels at every pass, so they retain the established
+    // readback path. The explicit opt-out keeps a direct A/B and a recovery switch for driver issues.
+    static const bool live_gpu_targets = pertarget &&
+        !getenv("PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS") && !getenv("PROSPER_GPU_CAPTURE") &&
         !getenv("PROSPER_GPU_TIMELINE_CAPTURE") && !getenv("PROSPER_GPU_REPLAY_EXPORT_RTT") &&
         !getenv("PROSPER_GPU_REPLAY_RTT_SEEDS") && !getenv("PROSPER_DUMP_SAMPLED_RTT") &&
         !getenv("PROSPER_DUMP_RTGROUPS") && !getenv("PROSPER_DUMP_RTGROUPS_RGBA") &&

--- a/prosper/scripts/messenger/reach-first-level.pad
+++ b/prosper/scripts/messenger/reach-first-level.pad
@@ -40,3 +40,10 @@
 242-244:up
 246-248:cross
 250-252:cross
+254-256:cross
+258-260:cross
+262-264:cross
+266-268:cross
+270-272:cross
+274-276:cross
+278-280:cross

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -5,7 +5,7 @@
       "dump": "PPSA24651-app0",
       "scale": 4,
       "timeout": 320,
-      "capture_after_seconds": 270,
+      "capture_after_seconds": 290,
       "capture_before_seconds": 319,
       "pad_script": "scripts/messenger/reach-first-level.pad",
       "savedata_policy": "fresh",
@@ -21,7 +21,7 @@
         270
       ],
       "review": "Approved 16 composited images from two independent runs on 2026-07-16; intended scene, layers, and progression visually confirmed.",
-      "_note": "Reviewed presented-frame guard for The Messenger's first level. A late idempotent Up/Cross recovery sequence tolerates cold full-render stalls that can skip early menu polls. Both independent runs show the player, terrain/structures, sky, water, HUD, and animation progression in every retained frame.",
+      "_note": "Reviewed presented-frame guard for The Messenger's first level. A late idempotent Up/Cross recovery sequence tolerates cold full-render stalls that can skip early menu polls and continues through 280 seconds so variable dialogue timing clears before capture. Both independent baseline runs show the player, terrain/structures, sky, water, HUD, and animation progression in every retained frame.",
       "structural_references": [
         {
           "luma16x9": "1e00000000000000000000000000001146292929272929292929292a516a755f465c539087213929262c432c466c6b35414f62854f2f3331414e3130414e33313131354c1d1e2b31312f1e2b31313131313131312f1918282f1e161f262a2f31313132393623161e221b201c1d1a282b242c2f262e2a2f2c2c2c2a2f2c2c2a2f3838363833343a373636343a36363735",


### PR DESCRIPTION
## Summary
- enable the existing persistent GPU color-target path by default for normal live rendering
- keep conservative CPU readback for scanout, captures, pixel diagnostics, same-target feedback, and authoritative-readback spans
- add `PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1` as a complete frontend A/B and recovery switch
- harden Messenger's late idempotent snapshot recovery after one run retained a correctly rendered dialogue scene into the capture window
- document the lifetime/invalidation contract and the paired Evergate profile

Progress on #702.

## Evergate result

Paired native-Windows fresh-save runs used one current-master binary and the same 75-second controller route:

| measurement | CPU target path | persistent GPU targets |
| --- | ---: | ---: |
| presented frames | 314 | 373 |
| observed heavy-scene rate | ~1.9 FPS | ~2.7 FPS |
| target writes / readbacks / deferred | 0 / 14 / 0 | 14 / 6 / 8 |
| direct target samples | 0 | 19 |
| heavy whole-submit windows | 450-475 ms | 317-359 ms |
| frontend Vulkan work | 252-285 ms | 159-194 ms |
| GPU fence waits | 59-61 ms | 34-37 ms |
| record/upload | 13-15 ms | 1-2 ms |

The animated windows are not draw-identical, so the mechanism counters, elapsed ranges, and total presented frames are reported together. This is a meaningful improvement, but not a claim that Evergate is near 60 FPS yet.

## Correctness contract
- retained targets are keyed by exact guest identity, extent, and format
- ordered guest GPU writes invalidate overlapping entries
- later graphics consumers bind the retained image directly only for exact compatible targets
- captures and diagnostic modes continue to require authoritative CPU pixels
- the existing backend tests compare GPU producer-to-sampler output byte-for-byte with CPU readback/upload, cover deferred LOAD, and prove invalidation does not reuse stale pixels

## Messenger route finding

One all-title verifier run captured a correctly rendered first-level dialogue scene instead of the approved post-dialogue gameplay structure. The route stopped pressing Cross 18 seconds before capture; it was a time-based route failure, not target corruption. The late Cross recovery now continues through 280 seconds and capture begins at 290 seconds. Cross advances remaining dialogue or is an ordinary jump after gameplay, so the route remains idempotent. No baseline or threshold changed.

## Verification
Exact head `7246dbc3c9cfeb1ddd3e4d33ec6bf6a0be37a626`:
- repository renderer author verification: PASS
- Linux full build + 111/111 tests: PASS
- Windows full build + 86/86 tests: PASS
- Messenger: 29/29 structural and non-black matches, animation passed
- Evergate: 9/9 structural and non-black matches, animation passed

Additional integration evidence on the same renderer change before final no-overlap base rebases:
- full four-title matrix: PASS
  - Messenger: 49/49
  - Evergate: 9/9
  - Dead Cells: 44/44
  - Blasphemous 2: 99/99
- a second all-title run again passed Evergate 9/9, Dead Cells 44/44, and Blasphemous 2 99/99; its Messenger dialogue-state finding led to the route fix above
- hardened Messenger route: four consecutive fresh-save 29/29 passes across the final base rebases

No snapshot baseline changed; the new default preserves the approved output while eliminating avoidable target ownership round-trips.
