### PR TITLE
gpu_replay: dump raw shaders for realized draws

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,8 @@ The #781 investigation localizes that residual pattern to the additive window-li
 depth, history-alpha, simple sampler-filter, and perspective-interpolation explanations. It remains open and
 deprioritized; see `docs/DEAD_CELLS_STATUS.md` before repeating live experiments. Successful raw RDNA2/SPIR-V
 pairs can now be captured with `PROSPER_SHADER_DUMP_SUCCESS=DIR` for offline inspection.
+Capture v19 also retains the exact bounded raw VS/FS source for every realized draw; export one offline with
+`gpu_replay --dump-realized-shader DRAW:vs|fs PATH` and inspect it with `shader_inspect`.
 
 `--bundle-final-capsule` snapshots both color RTT state and exact valid planes from persistent Vulkan
 depth/stencil images into capture v8 (#569). Capture v8 reads v1-v7 artifacts; pre-v7 failed-operation diagnostics

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -519,6 +519,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_replay_extent PRIVATE prosper_core)
   add_test(NAME gpu_replay_output_extent COMMAND test_gpu_replay_extent)
 
+  add_executable(test_gpu_replay_shader_dump tests/test_gpu_replay_shader_dump.cpp)
+  target_link_libraries(test_gpu_replay_shader_dump PRIVATE prosper_core)
+  add_test(NAME gpu_replay_shader_dump COMMAND test_gpu_replay_shader_dump)
+
   add_executable(test_gpu_dependency_graph tests/test_gpu_dependency_graph.cpp)
   target_link_libraries(test_gpu_dependency_graph PRIVATE prosper_core)
   add_test(NAME gpu_dependency_graph COMMAND test_gpu_dependency_graph)

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 18;
+constexpr uint32_t kVersion = 19;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -47,7 +47,7 @@ constexpr uint32_t kMaxComputes = 65536;
 constexpr uint32_t kMaxOperations = 131072;
 constexpr uint32_t kMaxResources = 65536;
 constexpr uint32_t kMaxShaderWords = 16u << 20;
-constexpr uint32_t kMaxRawShaderWords = 0x4000; // 64 KiB per failed stage
+constexpr uint32_t kMaxRawShaderWords = 0x4000; // 64 KiB per raw stage
 constexpr uint32_t kMaxFailureStages = 3;
 constexpr uint32_t kMaxStringBytes = 1u << 20;
 constexpr uint64_t kMaxTotalRttSeedBytes = 1ull << 30;
@@ -628,6 +628,53 @@ bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
     return true;
 }
 
+bool capture_raw_shader_version(uint64_t addr, const CaptureMemoryReader& reader,
+                                GpuCaptureFile& capture, uint64_t& raw_words,
+                                std::map<uint64_t, uint32_t>& index_by_address,
+                                uint32_t& index, std::string& error) {
+    index = 0xFFFFFFFFu;
+    if (!addr) return true;
+    const auto known = index_by_address.find(addr);
+    if (known != index_by_address.end()) {
+        index = known->second;
+        return true;
+    }
+    std::vector<uint32_t> words(kMaxRawShaderWords);
+    const size_t bytes_read = std::min<size_t>(
+        reader(addr, reinterpret_cast<uint8_t*>(words.data()),
+               words.size() * sizeof(uint32_t)),
+        words.size() * sizeof(uint32_t));
+    words.resize(bytes_read / sizeof(uint32_t));
+    if (words.empty()) {
+        index_by_address.emplace(addr, index);
+        return true;
+    }
+    std::vector<Rdna2Inst> instructions;
+    const size_t consumed = rdna2_walk(words.data(), words.size(), instructions);
+    if (consumed && consumed < words.size()) words.resize(consumed);
+    const bool has_endpgm = !instructions.empty() && instructions.back().is_end;
+    const uint64_t hash = shader_hash(words);
+    auto existing = std::find_if(capture.raw_shader_versions.begin(),
+                                 capture.raw_shader_versions.end(), [&](const auto& candidate) {
+        return candidate.content_hash == hash && candidate.words == words;
+    });
+    if (existing != capture.raw_shader_versions.end()) {
+        index = static_cast<uint32_t>(existing - capture.raw_shader_versions.begin());
+        index_by_address.emplace(addr, index);
+        return true;
+    }
+    if (capture.raw_shader_versions.size() >= kMaxResources ||
+        raw_words > kMaxShaderWords - words.size()) {
+        error = "raw shader data exceeds its bounded limit";
+        return false;
+    }
+    index = static_cast<uint32_t>(capture.raw_shader_versions.size());
+    raw_words += words.size();
+    capture.raw_shader_versions.push_back({hash, has_endpgm, std::move(words)});
+    index_by_address.emplace(addr, index);
+    return true;
+}
+
 bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& error) {
     if (capture.raw_shader_versions.size() > kMaxResources ||
         capture.failure_diagnostics.size() > kMaxOperations) {
@@ -638,11 +685,11 @@ bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& er
     for (const auto& shader : capture.raw_shader_versions) {
         if (shader.words.empty() || shader.words.size() > kMaxRawShaderWords ||
             raw_words > kMaxShaderWords - shader.words.size()) {
-            error = "failed-operation raw shader data exceeds its bounded limit";
+            error = "raw shader data exceeds its bounded limit";
             return false;
         }
         if (shader.content_hash != shader_hash(shader.words)) {
-            error = "failed-operation raw shader content hash mismatch";
+            error = "raw shader content hash mismatch";
             return false;
         }
         raw_words += shader.words.size();
@@ -650,6 +697,16 @@ bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& er
 
     std::set<OperationIdentity> diagnosed;
     std::vector<bool> raw_referenced(capture.raw_shader_versions.size(), false);
+    for (const auto& draw : capture.draws) {
+        for (uint32_t index : {draw.vs_raw_shader_index, draw.fs_raw_shader_index}) {
+            if (index == 0xFFFFFFFFu) continue;
+            if (index >= capture.raw_shader_versions.size()) {
+                error = "realized draw references an invalid raw shader";
+                return false;
+            }
+            raw_referenced[index] = true;
+        }
+    }
     for (const auto& diagnostic : capture.failure_diagnostics) {
         if (diagnostic.kind > SubmitOperationKind::Dispatch ||
             diagnostic.reason <= RealizationFailureReason::None ||
@@ -708,7 +765,7 @@ bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& er
         }
     }
     if (std::find(raw_referenced.begin(), raw_referenced.end(), false) != raw_referenced.end()) {
-        error = "failed-operation raw shader is not referenced";
+        error = "raw shader is not referenced";
         return false;
     }
     return true;
@@ -716,45 +773,13 @@ bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& er
 
 bool capture_failure_diagnostics(
     const std::vector<OperationRealizationFailure>& failures,
-    const CaptureMemoryReader& reader, GpuCaptureFile& capture, std::string& error) {
+    const CaptureMemoryReader& reader, GpuCaptureFile& capture, uint64_t& raw_words,
+    std::map<uint64_t, uint32_t>& raw_shader_index_by_address,
+    std::string& error) {
     if (failures.size() > kMaxOperations) {
         error = "invalid failed-operation diagnostic count";
         return false;
     }
-    uint64_t raw_words = 0;
-    auto capture_raw_shader = [&](uint64_t addr, uint32_t& index) -> bool {
-        index = 0xFFFFFFFFu;
-        if (!addr) return true;
-        std::vector<uint32_t> words(kMaxRawShaderWords);
-        const size_t bytes_read = std::min<size_t>(
-            reader(addr, reinterpret_cast<uint8_t*>(words.data()), words.size() * sizeof(uint32_t)),
-            words.size() * sizeof(uint32_t));
-        words.resize(bytes_read / sizeof(uint32_t));
-        if (words.empty()) return true;
-        std::vector<Rdna2Inst> instructions;
-        const size_t consumed = rdna2_walk(words.data(), words.size(), instructions);
-        if (consumed && consumed < words.size()) words.resize(consumed);
-        const bool has_endpgm = !instructions.empty() && instructions.back().is_end;
-        const uint64_t hash = shader_hash(words);
-        auto existing = std::find_if(capture.raw_shader_versions.begin(),
-                                     capture.raw_shader_versions.end(), [&](const auto& candidate) {
-            return candidate.content_hash == hash && candidate.words == words;
-        });
-        if (existing != capture.raw_shader_versions.end()) {
-            index = static_cast<uint32_t>(existing - capture.raw_shader_versions.begin());
-            return true;
-        }
-        if (capture.raw_shader_versions.size() >= kMaxResources ||
-            raw_words > kMaxShaderWords - words.size()) {
-            error = "failed-operation raw shader data exceeds its bounded limit";
-            return false;
-        }
-        index = static_cast<uint32_t>(capture.raw_shader_versions.size());
-        raw_words += words.size();
-        capture.raw_shader_versions.push_back({hash, has_endpgm, std::move(words)});
-        return true;
-    };
-
     for (const auto& failure : failures) {
         GpuCapturedOperationFailure diagnostic;
         diagnostic.kind = failure.kind;
@@ -782,7 +807,9 @@ bool capture_failure_diagnostics(
             stage.coverage = runtime_stage.coverage;
             stage.descriptor_issue_count = runtime_stage.descriptor_issue_count;
             stage.first_descriptor_issue = runtime_stage.first_descriptor_issue;
-            if (!capture_raw_shader(stage.program_addr, stage.raw_shader_index)) return false;
+            if (!capture_raw_shader_version(stage.program_addr, reader, capture, raw_words,
+                                            raw_shader_index_by_address,
+                                            stage.raw_shader_index, error)) return false;
             if (stage.raw_shader_index < capture.raw_shader_versions.size()) {
                 const auto& raw = capture.raw_shader_versions[stage.raw_shader_index].words;
                 stage.coverage = recompile_coverage(raw.data(), raw.size());
@@ -903,6 +930,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
             x.blob_index = static_cast<uint32_t>(existing - out.blobs.begin());
         }
     }
+    uint64_t raw_shader_words = 0;
+    std::map<uint64_t, uint32_t> raw_shader_index_by_address;
     for (const auto& d : draws) {
         GpuCapturedDraw c; c.vs = d.vs; c.gs = d.gs; c.fs = d.fs;
         c.ps = d.ps; c.vertex_count = d.vertex_count;
@@ -911,6 +940,12 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         c.color1_base = d.color1_base;
         c.color1_width = d.color1_width; c.color1_height = d.color1_height;
         c.draw_index = d.draw_index; c.command_order = d.command_order;
+        if (!capture_raw_shader_version(d.vs_guest_addr, reader, out, raw_shader_words,
+                                        raw_shader_index_by_address,
+                                        c.vs_raw_shader_index, error) ||
+            !capture_raw_shader_version(d.fs_guest_addr, reader, out, raw_shader_words,
+                                        raw_shader_index_by_address,
+                                        c.fs_raw_shader_index, error)) return false;
         if (!capture_table(d.vrt.get(), intervals, include_resource_data, c.vrt, error) ||
             !capture_table(d.prt.get(), intervals, include_resource_data, c.prt, error)) return false;
         out.draws.push_back(std::move(c));
@@ -968,7 +1003,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         out.operations.push_back({operation.kind, operation.index, operation.command_order, realized});
     }
     if (!validate_dma_copies(out, error)) return false;
-    if (!capture_failure_diagnostics(failures, reader, out, error)) return false;
+    if (!capture_failure_diagnostics(failures, reader, out, raw_shader_words,
+                                     raw_shader_index_by_address, error)) return false;
     collect_shader_versions(out);
     if (rtt_reader && include_resource_data) {
         std::vector<uint64_t> candidates;
@@ -1394,6 +1430,14 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         }
         w.u32(geometry_index);
     }
+    // v19 retains the raw RDNA2 identity for both realized graphics stages. The raw streams share
+    // the bounded content-addressed table introduced for v7 failure diagnostics; old captures leave
+    // both indices unavailable instead of inventing source bytes.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) {
+        w.u32(draw.vs_raw_shader_index);
+        w.u32(draw.fs_raw_shader_index);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1544,7 +1588,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         c.failure_diagnostics_available = true;
         uint32_t raw_count = 0;
         if (!r.u32(raw_count) || raw_count > kMaxResources) {
-            error = "invalid failed-operation raw shader count";
+            error = "invalid raw shader count";
             return false;
         }
         c.raw_shader_versions.resize(raw_count);
@@ -1553,10 +1597,10 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             uint8_t has_endpgm = 0;
             if (!r.u64(shader.content_hash) || !r.u8(has_endpgm) ||
                 !r.words_bounded(shader.words, kMaxRawShaderWords,
-                                 "invalid failed-operation raw shader length")) return false;
+                                 "invalid raw shader length")) return false;
             shader.has_endpgm = has_endpgm != 0;
             if (shader.words.empty() || raw_words > kMaxShaderWords - shader.words.size()) {
-                error = "failed-operation raw shader data exceeds its bounded limit";
+                error = "raw shader data exceeds its bounded limit";
                 return false;
             }
             raw_words += shader.words.size();
@@ -1610,7 +1654,6 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 stage.coverage.first_bad_fmt = static_cast<int32_t>(first_bad_fmt);
             }
         }
-        if (!validate_failure_diagnostics(c, error)) return false;
     }
     if (version >= 8) {
         uint32_t seed_count = 0;
@@ -1878,6 +1921,16 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             draw.gs = c.shader_versions[geometry_index].words;
         }
     }
+    if (version >= 19) {
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid realized raw-shader draw count"; return false;
+        }
+        for (auto& draw : c.draws)
+            if (!r.u32(draw.vs_raw_shader_index) || !r.u32(draw.fs_raw_shader_index))
+                return false;
+    }
+    if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
 }
@@ -1954,6 +2007,8 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         d.color1_base = x.color1_base;
         d.color1_width = x.color1_width; d.color1_height = x.color1_height;
         d.draw_index = x.draw_index; d.command_order = x.command_order;
+        d.vs_raw_shader_index = x.vs_raw_shader_index;
+        d.fs_raw_shader_index = x.fs_raw_shader_index;
         if (!table(x.vrt, d.vrt) || !table(x.prt, d.prt)) return false;
         out.items.push_back(std::move(d));
     }

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -35,8 +35,9 @@ struct GpuCaptureShaderVersion {
     std::vector<uint32_t> words;
 };
 
-// Raw RDNA2 retained only for failed operations. Each version is capped at 64 KiB and ends at the
-// first decoded s_endpgm/unknown instruction or that cap. Equal byte streams share one version.
+// Raw RDNA2 retained for realized graphics stages and failed operations. Each version is capped at
+// 64 KiB and ends at the first decoded s_endpgm/unknown instruction or that cap. Equal byte streams
+// share one version.
 struct GpuCaptureRawShaderVersion {
     uint64_t content_hash = 0;
     bool has_endpgm = false;
@@ -72,6 +73,8 @@ struct GpuCapturedDraw {
     uint32_t color1_width = 0, color1_height = 0;
     uint64_t draw_index = 0;
     uint64_t command_order = 0;
+    uint32_t vs_raw_shader_index = 0xFFFFFFFFu;
+    uint32_t fs_raw_shader_index = 0xFFFFFFFFu;
 };
 
 struct GpuCapturedCompute {

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -41,6 +41,10 @@ struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backe
 struct DrawItem {
     std::vector<uint32_t> vs, gs, fs;                 // recompiled/generated SPIR-V
     uint64_t vs_guest_addr = 0, fs_guest_addr = 0;    // diagnostic/source identity in guest VA space
+    // Content-addressed raw RDNA2 versions owned by a materialized capture. Live draw items leave
+    // these unset; capture assigns them from the guest addresses above and replay restores them.
+    uint32_t vs_raw_shader_index = 0xFFFFFFFFu;
+    uint32_t fs_raw_shader_index = 0xFFFFFFFFu;
     // Process-unique identities supplied by the exact shader-recompile cache. Zero means the
     // shader came from an external/replay path, so persistent backend caches must compare words.
     uint64_t vs_identity = 0, fs_identity = 0;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -48,6 +48,16 @@ int main() {
     std::vector<uint8_t> memory(32);
     for (size_t i = 0; i < memory.size(); ++i) memory[i] = static_cast<uint8_t>(0x40 + i);
     auto reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        const auto read_shader = [&](const uint32_t* words, size_t bytes) -> size_t {
+            const uint64_t base = reinterpret_cast<uint64_t>(words);
+            if (addr < base || addr >= base + bytes) return 0;
+            const size_t offset = static_cast<size_t>(addr - base);
+            const size_t take = std::min(n, bytes - offset);
+            std::memcpy(dst, reinterpret_cast<const uint8_t*>(words) + offset, take);
+            return take;
+        };
+        if (const size_t read = read_shader(kDiagnosticVs, sizeof(kDiagnosticVs))) return read;
+        if (const size_t read = read_shader(kDiagnosticBadPs, sizeof(kDiagnosticBadPs))) return read;
         if (addr < 0x1000 || addr >= 0x1000 + memory.size()) return 0;
         size_t off = static_cast<size_t>(addr - 0x1000), take = std::min(n, memory.size() - off);
         std::memcpy(dst, memory.data() + off, take); return take;
@@ -67,6 +77,8 @@ int main() {
     table->resources = {a, b, dcc};
 
     DrawItem draw; draw.vs = {0x07230203, 1, 2}; draw.fs = {0x07230203, 3}; draw.vrt = table;
+    draw.vs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticVs);
+    draw.fs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticBadPs);
     draw.vertex_count = 6; draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
     draw.color0_width = 1024; draw.color0_height = 32;
     draw.color1_base = 0x3000; draw.color1_width = 1024; draw.color1_height = 32;
@@ -119,6 +131,14 @@ int main() {
     CHECK(captured.shader_versions.size() == 2 && captured.operations.size() == 1 &&
           captured.operations[0].source_index == 7 && captured.operations[0].realized,
           "capture indexes unique shaders and retains operation provenance");
+    CHECK(captured.raw_shader_versions.size() == 2 &&
+          captured.draws[0].vs_raw_shader_index < captured.raw_shader_versions.size() &&
+          captured.draws[0].fs_raw_shader_index < captured.raw_shader_versions.size() &&
+          captured.raw_shader_versions[captured.draws[0].vs_raw_shader_index].words ==
+              std::vector<uint32_t>(std::begin(kDiagnosticVs), std::end(kDiagnosticVs)) &&
+          captured.raw_shader_versions[captured.draws[0].fs_raw_shader_index].words ==
+              std::vector<uint32_t>(std::begin(kDiagnosticBadPs), std::end(kDiagnosticBadPs)),
+          "realized draw captures exact bounded VS and FS RDNA2 streams");
 
     // #636: a descriptor-looking scalar quartet with no matching MUBUF instruction is not a compute
     // resource. The capture path must therefore neither probe its guest address nor retain a blob.
@@ -157,14 +177,19 @@ int main() {
               scalar_capture.computes[0].resources.resources.empty(),
           "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
-    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v18's one-draw
-    // geometry index first, then the v17 tail, to recover a byte-exact v16 capture.
+    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v19's realized
+    // raw-stage indices, v18's geometry index, then the v17 tail to recover a byte-exact v16 capture.
+    GpuCaptureFile v16_scissor_source = captured;
+    v16_scissor_source.raw_shader_versions.clear();
+    v16_scissor_source.draws[0].vs_raw_shader_index = 0xFFFFFFFFu;
+    v16_scissor_source.draws[0].fs_raw_shader_index = 0xFFFFFFFFu;
     std::vector<uint8_t> v16_scissor_bytes;
     GpuCaptureFile v16_scissor_loaded;
-    CHECK(serialize_gpu_capture(captured, v16_scissor_bytes, error) &&
+    CHECK(serialize_gpu_capture(v16_scissor_source, v16_scissor_bytes, error) &&
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - 12); // v19 count + two raw indices
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 8); // v18 draw count + no-GS sentinel
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 25);
         v16_scissor_bytes[8] = 16;
@@ -307,6 +332,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 12); // v19 count + two raw indices
     volume_bytes.resize(volume_bytes.size() - 8); // v18 draw count + no-GS sentinel
     volume_bytes.resize(volume_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
     volume_bytes.resize(volume_bytes.size() - 21); // v16 count plus one 17-byte mip-tail state
@@ -397,6 +423,10 @@ int main() {
     CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");
+    CHECK(loaded.raw_shader_versions.size() == 2 &&
+          loaded.draws[0].vs_raw_shader_index < loaded.raw_shader_versions.size() &&
+          loaded.draws[0].fs_raw_shader_index < loaded.raw_shader_versions.size(),
+          "v19 realized raw-stage identities round-trip with their content versions");
     CHECK(loaded.rtt_seeds.size() == 1 && loaded.rtt_seeds[0].width == 2 &&
           loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rgba8Unorm &&
           loaded.rtt_seeds[0].rgba == temporal_rgba, "temporal RTT seed round-trips");
@@ -447,6 +477,9 @@ int main() {
           "an empty renderer result does not become a valid replay oracle");
     CHECK(replay.items[0].draw_index == 7 && replay.items[0].command_order == 123,
           "materialized draw retains its source operation identity");
+    CHECK(replay.items[0].vs_raw_shader_index == loaded.draws[0].vs_raw_shader_index &&
+          replay.items[0].fs_raw_shader_index == loaded.draws[0].fs_raw_shader_index,
+          "materialized replay exposes both realized raw-stage identities");
     CHECK(replay.rtt_seeds.size() == 1 && replay.rtt_seeds[0].guest_addr == draw.color0_base,
           "materialized replay owns temporal RTT seed pixels");
     CHECK(replay.ds_seeds.size() == 1 && replay.ds_seeds[0].htile_data_base == 0x800000,
@@ -692,30 +725,39 @@ int main() {
     GpuCaptureFile stale_raw = failed_capture;
     stale_raw.raw_shader_versions[0].content_hash ^= 1;
     CHECK(!serialize_gpu_capture(stale_raw, repeated, error) &&
-          error == "failed-operation raw shader content hash mismatch",
+          error == "raw shader content hash mismatch",
           "writer rejects stale failed-shader content identity");
     GpuCaptureFile bad_raw_index = failed_capture;
     bad_raw_index.failure_diagnostics[0].stages[0].raw_shader_index = 0xfffffffeu;
     CHECK(!serialize_gpu_capture(bad_raw_index, repeated, error) &&
           error == "invalid failed-stage diagnostic metadata",
           "writer rejects an out-of-range failed-shader reference");
+    GpuCaptureFile bad_realized_raw_index = captured;
+    bad_realized_raw_index.draws[0].vs_raw_shader_index = 0xfffffffeu;
+    CHECK(!serialize_gpu_capture(bad_realized_raw_index, repeated, error) &&
+          error == "realized draw references an invalid raw shader",
+          "writer rejects an out-of-range realized-shader reference");
     GpuCaptureFile oversized_raw = failed_capture;
     oversized_raw.raw_shader_versions[0].words.resize(0x4001, 0xbf810000u);
     oversized_raw.raw_shader_versions[0].content_hash = gpu_capture_hash(
         reinterpret_cast<const uint8_t*>(oversized_raw.raw_shader_versions[0].words.data()),
         oversized_raw.raw_shader_versions[0].words.size() * sizeof(uint32_t));
     CHECK(!serialize_gpu_capture(oversized_raw, repeated, error) &&
-          error == "failed-operation raw shader data exceeds its bounded limit",
+          error == "raw shader data exceeds its bounded limit",
           "writer enforces the documented 64 KiB per-stage raw bound");
 
     GpuCaptureFile legacy_source = captured; legacy_source.ds_seeds.clear();
+    legacy_source.raw_shader_versions.clear();
+    legacy_source.draws[0].vs_raw_shader_index = 0xFFFFFFFFu;
+    legacy_source.draws[0].fs_raw_shader_index = 0xFFFFFFFFu;
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 32,
-          "created a diagnostic-free v18 payload for legacy-reader fixtures");
+          "created a diagnostic-free v19 payload for legacy-reader fixtures");
     std::vector<uint8_t> v13_bytes = legacy_bytes;
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - 12); // v19 count + two raw indices
         v13_bytes.resize(v13_bytes.size() - 8); // v18 draw count + no-GS sentinel
         v13_bytes.resize(v13_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
         v13_bytes.resize(v13_bytes.size() - (4 + 17 * legacy_resource_count));
@@ -734,6 +776,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 12); // v19 count + two raw indices
         legacy_bytes.resize(legacy_bytes.size() - 8); // v18 draw count + no-GS sentinel
         legacy_bytes.resize(legacy_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
         legacy_bytes.resize(legacy_bytes.size() - (4 + 17 * legacy_resource_count));
@@ -778,9 +821,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 19;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 20;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 19",
+          error == "unsupported capture version 20",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -1,0 +1,52 @@
+#include "../tools/gpu_replay/realized_shader_dump.hpp"
+
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_replay_shader_dump ==\n");
+
+    tools::RealizedShaderSelector selector;
+    CHECK(tools::parse_realized_shader_selector("0:vs", selector) &&
+              selector.draw_index == 0 && selector.vertex,
+          "realized VS selector parses exactly");
+    CHECK(tools::parse_realized_shader_selector("0x1:fs", selector) &&
+              selector.draw_index == 1 && !selector.vertex,
+          "realized FS selector accepts an explicit numeric base");
+    CHECK(!tools::parse_realized_shader_selector("-1:vs", selector) &&
+              !tools::parse_realized_shader_selector("1junk:fs", selector) &&
+              !tools::parse_realized_shader_selector("1:ps", selector) &&
+              !tools::parse_realized_shader_selector("1:vs:extra", selector),
+          "malformed realized-shader selectors are rejected without partial parsing");
+
+    gpu::GpuReplayFrame replay;
+    replay.raw_shader_versions = {
+        {11, true, {0x11111111u, 0xbf810000u}},
+        {22, true, {0x22222222u, 0xbf810000u}},
+    };
+    gpu::DrawItem draw;
+    draw.vs_raw_shader_index = 1;
+    draw.fs_raw_shader_index = 0;
+    replay.items.push_back(draw);
+
+    std::string error;
+    const auto* vs = tools::select_realized_raw_shader(replay, "0:vs", error);
+    const auto* fs = tools::select_realized_raw_shader(replay, "0:fs", error);
+    CHECK(vs == &replay.raw_shader_versions[1] && fs == &replay.raw_shader_versions[0],
+          "selector resolves the realized draw's exact raw stage identities");
+    CHECK(!tools::select_realized_raw_shader(replay, "2:vs", error) &&
+              error.find("invalid realized-shader selector") != std::string::npos,
+          "out-of-range realized draw reports a selector error");
+    replay.items[0].fs_raw_shader_index = 0xFFFFFFFFu;
+    CHECK(!tools::select_realized_raw_shader(replay, "0:fs", error) &&
+              error.find("capture predates v19 or source was unreadable") != std::string::npos,
+          "missing legacy raw source is explicit instead of selecting unrelated bytes");
+
+    std::printf("%s\n", fails ? "FAIL" : "PASS");
+    return fails ? 1 : 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -212,6 +212,8 @@ composite/scanout draws; a single `--draw N` remains supported.
 `--dump-resource DRAW:vs|ps:BINDING PATH` writes one captured resource's exact backing bytes for
 external numeric/image inspection without dereferencing the original guest address.
 `--dump-shader DRAW:vs|fs PATH` writes the captured SPIR-V module for validation/disassembly.
+Capture v19+ also supports `--dump-realized-shader DRAW:vs|fs PATH`, which writes the exact bounded raw
+RDNA2 source for a successfully realized graphics stage; use that output with `shader_inspect`.
 `--dump-compute N PATH` writes one realized compute SPIR-V module, and
 `--dump-compute-resource N:BINDING PATH` writes its exact pre-dispatch storage-buffer bytes.
 `--compute-only N` executes one realized dispatch in isolation; combine it with

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -73,6 +73,7 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 ./build-linux/gpu_replay --dump-rtt-seed 0x7f9f504b0000 /tmp/history.bmp \
   --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
+./build-linux/gpu_replay --dump-realized-shader 18:fs /tmp/fragment-rdna2.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --compute-only 0 /tmp/submit.prgcap
 ./build-linux/gpu_replay --compute-only 0 --override-compute-spv 0 /tmp/reduced.spv \
@@ -80,6 +81,12 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 ./build-linux/gpu_replay --dump-compute-resource 0:2 /tmp/storage.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-failed-shader 0:1 /tmp/failed-fragment.bin /tmp/submit.prgcap
 ```
+
+`--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
+`--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
+draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,
+64 MiB-total store as failed-shader diagnostics. Captures v1-v18 remain readable; because they did not retain
+realized-stage source identities, this command reports the raw stream as unavailable instead of guessing.
 
 Selected draw ranges and ordered prefixes write the BMP at the final selected draw target's extent when
 the returned RGBA byte count confirms that native size. Presentation-scaled replays retain the capsule's

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -5,6 +5,7 @@
 #include "gpu/shader_resources.hpp"
 #include "live_renderer.hpp"
 #include "replay_output_extent.hpp"
+#include "realized_shader_dump.hpp"
 #include "render_runner.h"
 
 #include <algorithm>
@@ -54,6 +55,7 @@ void usage(const char* argv0) {
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
+                         "[--dump-realized-shader DRAW:vs|fs PATH] "
                          "[--override-compute-spv N PATH] "
                          "[--dump-failed-shader FAILURE:STAGE PATH] "
                          "[--dump-compute-resource N:BINDING PATH] "
@@ -1132,6 +1134,7 @@ int main(int argc, char** argv) {
     std::string compute_override_spec, compute_override_path;
     std::string compute_resource_spec, compute_resource_path;
     std::string failed_shader_spec, failed_shader_path;
+    std::string realized_shader_spec, realized_shader_path;
     std::string rtt_seed_path;
     std::string graph_json_path, prepend_path;
     std::string bundle_path, bundle_compact_path;
@@ -1221,6 +1224,9 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-shader" && i + 2 < argc) {
             shader_spec = argv[++i]; shader_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--dump-realized-shader" && i + 2 < argc) {
+            realized_shader_spec = argv[++i]; realized_shader_path = argv[++i];
+        }
         else if (std::string(argv[i]) == "--dump-compute" && i + 2 < argc) {
             compute_shader_spec = argv[++i]; compute_shader_path = argv[++i];
         }
@@ -1244,6 +1250,7 @@ int main(int argc, char** argv) {
             compute_only >= 0 ||
             warmup_repeats || !dump_spec.empty() || rtt_seed_addr ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
+            !realized_shader_spec.empty() ||
             !compute_override_spec.empty() ||
             !compute_resource_spec.empty() || !failed_shader_spec.empty() ||
             !prepend_path.empty()) {
@@ -1421,6 +1428,25 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[gpureplay] dumped %s (%zu bytes) to %s\n", shader_spec.c_str(), bytes,
                      shader_path.c_str());
     }
+    if (!realized_shader_spec.empty()) {
+        const auto* raw = prosper::tools::select_realized_raw_shader(
+            replay, realized_shader_spec, error);
+        if (!raw) {
+            std::fprintf(stderr, "gpu_replay: %s\n", error.c_str());
+            return 2;
+        }
+        FILE* f = std::fopen(realized_shader_path.c_str(), "wb");
+        const size_t bytes = raw->words.size() * sizeof(uint32_t);
+        if (!f || std::fwrite(raw->words.data(), 1, bytes, f) != bytes) {
+            if (f) std::fclose(f);
+            std::fprintf(stderr, "gpu_replay: cannot write %s\n", realized_shader_path.c_str());
+            return 2;
+        }
+        std::fclose(f);
+        std::fprintf(stderr, "[gpureplay] dumped realized shader %s (%zu bytes) to %s\n",
+                     realized_shader_spec.c_str(), bytes, realized_shader_path.c_str());
+        if (positional.size() == 1 && !inspect) return 0;
+    }
     if (!failed_shader_spec.empty()) {
         const size_t colon = failed_shader_spec.find(':');
         char* failure_end = nullptr;
@@ -1560,7 +1586,7 @@ int main(int argc, char** argv) {
                    !entry.second.empty() && entry.second != "0" && entry.second != "off";
         });
     std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu computes=%zu "
-                         "operations=%zu shaders=%zu failed=%zu raw-failed-shaders=%zu blobs=%zu "
+                         "operations=%zu shaders=%zu failed=%zu raw-shaders=%zu blobs=%zu "
                          "RTT-seeds=%zu DS-seeds=%zu oracle=%s resource-data=%s\n",
                  m.revision.c_str(), m.title_id.c_str(), static_cast<unsigned long long>(m.submit_index),
                  m.width, m.height, replay.items.size(), replay.computes.size(), replay.operations.size(),

--- a/prosper/tools/gpu_replay/realized_shader_dump.hpp
+++ b/prosper/tools/gpu_replay/realized_shader_dump.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "../../src/gpu/gpu_capture.hpp"
+
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+#include <string>
+
+namespace prosper::tools {
+
+struct RealizedShaderSelector {
+    size_t draw_index = 0;
+    bool vertex = false;
+};
+
+inline bool parse_realized_shader_selector(const std::string& spec,
+                                           RealizedShaderSelector& selector) {
+    const size_t colon = spec.find(':');
+    if (colon == std::string::npos || colon == 0 ||
+        spec.find(':', colon + 1) != std::string::npos || spec[0] == '-')
+        return false;
+    errno = 0;
+    char* end = nullptr;
+    const unsigned long long draw = std::strtoull(spec.c_str(), &end, 0);
+    if (errno == ERANGE || end != spec.c_str() + colon ||
+        draw > std::numeric_limits<size_t>::max())
+        return false;
+    const std::string stage = spec.substr(colon + 1);
+    if (stage != "vs" && stage != "fs") return false;
+    selector.draw_index = static_cast<size_t>(draw);
+    selector.vertex = stage == "vs";
+    return true;
+}
+
+inline const gpu::GpuCaptureRawShaderVersion* select_realized_raw_shader(
+    const gpu::GpuReplayFrame& replay, const std::string& spec, std::string& error) {
+    RealizedShaderSelector selector;
+    if (!parse_realized_shader_selector(spec, selector) ||
+        selector.draw_index >= replay.items.size()) {
+        error = "invalid realized-shader selector " + spec;
+        return nullptr;
+    }
+    const auto& draw = replay.items[selector.draw_index];
+    const uint32_t raw_index = selector.vertex
+        ? draw.vs_raw_shader_index : draw.fs_raw_shader_index;
+    if (raw_index >= replay.raw_shader_versions.size()) {
+        error = "realized shader " + spec +
+                " has no captured raw stream (capture predates v19 or source was unreadable)";
+        return nullptr;
+    }
+    error.clear();
+    return &replay.raw_shader_versions[raw_index];
+}
+
+} // namespace prosper::tools


### PR DESCRIPTION
## Summary

- retain the exact bounded raw RDNA2 VS/FS source for every realized draw in capture v19
- add `gpu_replay --dump-realized-shader DRAW:vs|fs PATH` with strict selector/error handling
- keep v1-v18 capture compatibility explicit and add focused cross-platform regression coverage/docs

The realized stages reuse the existing content-addressed raw-shader store and cache reads by guest program address within the selected submit.

## Focused checks before publication

- Linux: built `test_gpu_capture`, `test_gpu_replay_shader_dump`, and `gpu_replay`; both focused tests pass
- Windows: built `test_gpu_capture` and `test_gpu_replay_shader_dump`; both focused tests pass
- no snapshot workflow (tooling/capture serialization only)

Author-owned full verification and independent inspection-only review will be posted against the exact PR head.

Fixes #630