### PR TITLE
file: implement fdatasync durability

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1331,6 +1331,15 @@ HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); int err = r < 0 ? 
 // the key fix is WRITING the buffer. fsync: was fake-success; flush for real save durability.
 HLE(f_lstat) { std::string h = translate(CS(a0)); struct stat st; int r = ::lstat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fsync) { return (uint64_t)(int64_t)::fsync((int)a0); }
+HLE(f_fdatasync) {
+#if defined(__APPLE__)
+    // Darwin does not expose fdatasync. fsync provides the required durability as a stronger
+    // operation while preserving the descriptor/error contract.
+    return (uint64_t)(int64_t)::fsync((int)a0);
+#else
+    return (uint64_t)(int64_t)::fdatasync((int)a0);
+#endif
+}
 #else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fstat) { struct _stat64 st; std::string directory_path;
@@ -1346,6 +1355,9 @@ HLE(f_fstat) { struct _stat64 st; std::string directory_path;
 HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
 HLE(f_fsync) { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
                return (uint64_t)(int64_t)::_commit((int)a0); }
+// The Windows CRT has no data-only durability primitive. _commit is the same stronger fallback
+// used for fsync and, unlike the missing-import stub, reports invalid descriptors truthfully.
+HLE(f_fdatasync) { return f_fsync(a0,a1,a2,a3,a4,a5); }
 #endif
 
 // These file APIs have signed 32-bit results. Kernel exports return the translated SCE error
@@ -1360,6 +1372,7 @@ HLE(k_lstat)    { uint64_t r = f_lstat(a0, a1, a2, a3, a4, a5);    int e = errno
 HLE(k_truncate) { uint64_t r = f_truncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(k_ftruncate){ uint64_t r = f_ftruncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(k_fsync)    { uint64_t r = f_fsync(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
+HLE(k_fdatasync){ uint64_t r = f_fdatasync(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32
@@ -2100,7 +2113,8 @@ void register_file_hle() {
     R("sceKernelWrite", k_write); R("sceKernelLseek", k_lseek); R("sceKernelStat", k_stat);
     R("sceKernelFtruncate", k_ftruncate);   // real resize (was fake-success -> corrupt saves)
     R("lstat", f_lstat);   R("sceKernelLstat", k_lstat);     // was MISSING -> uninitialized stat buffer
-    R("fsync", f_fsync);   R("sceKernelFsync", k_fsync);     // was fake-success -> no durability
+    R("fsync", f_fsync);       R("sceKernelFsync", k_fsync);       // real descriptor durability
+    R("fdatasync", f_fdatasync); R("sceKernelFdatasync", k_fdatasync); // data-only durability
     R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -94,6 +94,8 @@ int main() {
     HleFn kernel_ftruncate_fn = Hle::lookup(nid_hash("sceKernelFtruncate"));
     HleFn fsync_fn = Hle::lookup(nid_hash("fsync"));
     HleFn kernel_fsync_fn = Hle::lookup(nid_hash("sceKernelFsync"));
+    HleFn fdatasync_fn = Hle::lookup(nid_hash("fdatasync"));
+    HleFn kernel_fdatasync_fn = Hle::lookup(nid_hash("sceKernelFdatasync"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -114,7 +116,7 @@ int main() {
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && rmdir_fn &&
               kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
               kernel_rename_fn && kernel_truncate_fn && kernel_ftruncate_fn && fsync_fn &&
-              kernel_fsync_fn && getdents_fn &&
+              kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -423,15 +425,19 @@ int main() {
     uint64_t kernel_fsync_result = descriptor_resize_fd >= 0 && kernel_fsync_fn
         ? kernel_fsync_fn((uint64_t)descriptor_resize_fd, 0, 0, 0, 0, 0)
         : ~uint64_t{0};
+    uint64_t kernel_fdatasync_result = descriptor_resize_fd >= 0 && kernel_fdatasync_fn
+        ? kernel_fdatasync_fn((uint64_t)descriptor_resize_fd, 0, 0, 0, 0, 0)
+        : ~uint64_t{0};
     if (descriptor_resize_fd >= 0 && close_fn)
         close_fn((uint64_t)descriptor_resize_fd, 0, 0, 0, 0, 0);
     std::error_code descriptor_resize_size_error;
     uintmax_t descriptor_resize_size =
         std::filesystem::file_size(descriptor_resize_path, descriptor_resize_size_error);
     CHECK(descriptor_resize_fixture_written && kernel_ftruncate_result == 0 &&
-              kernel_fsync_result == 0 && !descriptor_resize_size_error &&
+              kernel_fsync_result == 0 && kernel_fdatasync_result == 0 &&
+              !descriptor_resize_size_error &&
               descriptor_resize_size == 3,
-          "sceKernelFtruncate and sceKernelFsync persist a resized descriptor on both hosts");
+          "sceKernelFtruncate/Fsync/Fdatasync persist a resized descriptor on both hosts");
     std::filesystem::remove(descriptor_resize_path, missing_remove_error);
 
     constexpr uint64_t kGuestOWriteOnly = 0x0001;
@@ -682,6 +688,14 @@ int main() {
     uint64_t kernel_fsync_failure = kernel_fsync_fn
         ? kernel_fsync_fn(closed_io_fd, 0, 0, 0, 0, 0)
         : 0;
+    errno = 0;
+    int64_t libc_fdatasync_result = fdatasync_fn
+        ? (int64_t)fdatasync_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
+    const int libc_fdatasync_error = errno;
+    uint64_t kernel_fdatasync_failure = kernel_fdatasync_fn
+        ? kernel_fdatasync_fn(closed_io_fd, 0, 0, 0, 0, 0)
+        : 0;
     uint64_t kernel_ftruncate_failure = kernel_ftruncate_fn
         ? kernel_ftruncate_fn(closed_io_fd, 0, 0, 0, 0, 0)
         : 0;
@@ -689,6 +703,10 @@ int main() {
           "libc fsync retains -1 plus EBADF");
     CHECK(kernel_fsync_failure == 0x80020009u,
           "sceKernelFsync returns SCE_KERNEL_ERROR_EBADF directly");
+    CHECK(libc_fdatasync_result == -1 && libc_fdatasync_error == EBADF,
+          "libc fdatasync retains -1 plus EBADF");
+    CHECK(kernel_fdatasync_failure == 0x80020009u,
+          "sceKernelFdatasync returns SCE_KERNEL_ERROR_EBADF directly");
     CHECK(kernel_ftruncate_failure == 0x80020009u,
           "sceKernelFtruncate returns SCE_KERNEL_ERROR_EBADF directly");
 


### PR DESCRIPTION
## Failure and contract

`fdatasync` and `sceKernelFdatasync` are real libkernel exports, but both were unregistered, so the generic missing-import path returned success without making file data durable. A caller could therefore believe a save/config write had reached stable storage when no flush occurred.

## Changes

- register the libc and kernel exports
- use native `fdatasync` on Linux, the stronger `fsync` fallback on macOS, and the existing guarded `_commit` durability primitive on Windows
- preserve libc `-1` + `errno` behavior while translating kernel failures to 32-bit FreeBSD/Orbis SCE errors
- cover registration, successful durability, and closed-descriptor `EBADF` behavior in the cross-platform file regression

`fsync`, truncate, path translation, and unrelated metadata operations are unchanged. The stronger macOS/Windows fallback may flush metadata too, which is safe but potentially more expensive than a native data-only operation.

## Author checks before publication

- Linux focused build + `ctest -R '^file_binary_roundtrip$'`
- Windows focused build + `ctest -R '^file_binary_roundtrip$'`
- `git diff --check`

No snapshot workflow was run or is required for this file-HLE change. Full author verification will be posted for the exact PR head while the inspection-only review runs.

Refs #389