### PR TITLE
gpu: implement MTBUF typed buffer operations

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -5,7 +5,7 @@
 //
 // Layouts cross-checked against Kyty (PS5/RDNA2 gfx1030, same target): the SDK `Shader`/`ShaderUserData`
 // (Shader.h:911/974) and the buffer resource descriptor V# (ShaderBufferResource getters: Base48,
-// Stride[16:29], NumRecords=word2, Nfmt[12:14], Dfmt[15:18]).
+// Stride[16:29], NumRecords=word2, Format[12:18]).
 #pragma once
 #include "shader_resources.hpp"
 #include <array>
@@ -99,7 +99,8 @@ AgcPixelInputControls derive_agc_pixel_input_controls(const AgcShaderHeader* pro
                                                       const AgcShaderHeader* pixel);
 
 // A decoded buffer resource descriptor (V#, 4 dwords). base/stride/num_records per Kyty's getters;
-// format+num_components from the (dfmt,nfmt) split. `size_bytes` is the backing region size.
+// format+num_components come from gfx1030's combined seven-bit FORMAT. `size_bytes` is the backing
+// region size.
 struct DecodedBufferDescriptor {
     uint64_t   base = 0;
     uint32_t   stride = 0;
@@ -190,11 +191,6 @@ void warn_unsupported_image_view(const DecodedImageDescriptor& descriptor);
 // Map a T#'s 9-bit Gen5 IMG_FMT value to format info. Returns false (out left Unknown/zero) for
 // values not in the table — callers must not assume RGBA8 for those (#65). Pure; exposed for testing.
 bool gen5_image_format(uint32_t fmt, Gen5ImageFormatInfo* out);
-
-// Map a GCN/Gen5 buffer (DFMT, NFMT) pair to a DataFormat + component count. Pure.
-// Decode an RDNA2 (GFX10/PS5) buffer V# combined 7-bit FORMAT field (dword3 bits[18:12]) into a
-// DataFormat + component count. (Replaces the GCN dfmt/nfmt split, which is wrong for PS5 V#s.)
-void rdna2_buffer_format(uint32_t fmt, DataFormat* out_fmt, uint32_t* out_components);
 
 // FRONT-HALF DELIVERABLE: build the resource table a shader uses. `user_sgprs` is the shader's bound
 // user-data SGPR block (num_user_sgprs dwords) — the V# descriptors live there at each sharp's

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -103,6 +103,9 @@ struct DynFetch {
     // Graphics VertexBuffers need the shifted descriptor for their special vertex-index path;
     // compute ConstantBuffers keep this original descriptor and apply those terms exactly once.
     DecodedBufferDescriptor unshifted_desc;
+    // MTBUF takes its type from the instruction's combined gfx1030 BUF_FMT, not V# dword3.
+    // UINT32_MAX identifies ordinary MUBUF, whose descriptor remains authoritative.
+    uint32_t instruction_format = UINT32_MAX;
 };
 
 // One descriptor-TABLE use recovered by the same const-fold (#294): UE4 shaders load their T#/S#/V#
@@ -118,6 +121,7 @@ struct SrtUse {
                                      // recompiler then resolves the use by its instruction pc instead)
     std::array<uint32_t, 8> t8{};    // T# dwords as loaded (kind 0)
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
+    uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)
     // Minimum byte span needed by this scalar-buffer consumer, measured from V#.Base. Some PS5

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1949,19 +1949,20 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         if (u.kind != 1) continue;
         if (u.instruction_format != UINT32_MAX && ((u.v4[3] >> 12) & 0x7Fu) == 0)
             continue;
+        const bool exact_mtbuf = u.instruction_format != UINT32_MAX;
         // Keyed buffer uses dedupe by table offset; key-less live descriptors dedupe by consumer pc.
-        const uint64_t dk = u.key == 0xFFFFFFFFu
+        const uint64_t dk = exact_mtbuf || u.key == 0xFFFFFFFFu
             ? (0x8000000100000000ull | u.use_pc)
             : (0x0000000100000000ull | u.key);
         if (!seen.insert(dk).second) continue;
-        bool clash = u.key == 0xFFFFFFFFu;
+        bool clash = exact_mtbuf || u.key == 0xFFFFFFFFu;
         if (!clash)
             for (const auto& r0 : table.resources)
                 if (r0.srt_offset == u.key) { clash = true; break; }
 
         const DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
         if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
-        if (clash) {
+        if (clash && !exact_mtbuf) {
             bool piggybacked = false;
             for (auto& r0 : table.resources) {
                 if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
@@ -2208,7 +2209,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             // A SEED-fallback entry must not shadow a metadata-described DIRECT vertex buffer at the
             // same SGPRs (see DynFetch::from_seed): the direct resource resolves the fetch through
             // the faithful address path, which is the correct model for a single un-patched V#.
-            if (kv.from_seed) {
+            if (kv.from_seed && kv.instruction_format == UINT32_MAX) {
                 bool direct_exists = false;
                 for (const auto& r0 : t.resources)
                     if (r0.cls == ResourceClass::VertexBuffer && r0.sgpr_base == (uint32_t)kv.srsrc)
@@ -2292,11 +2293,12 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                 // key-less buffer uses per CONSUMING INSTRUCTION (#273 — several image ops may share
                 // one key, or have none; a key-less V# fetch resolves by its pc).
                 // Distinct namespaces: pc keys must never collide with byte-offset keys.
-                uint64_t dk = (u.kind == 0 || u.key == 0xFFFFFFFFu)
+                const bool exact_mtbuf = u.kind == 1 && u.instruction_format != UINT32_MAX;
+                uint64_t dk = (u.kind == 0 || u.key == 0xFFFFFFFFu || exact_mtbuf)
                                   ? (0x8000000000000000ull | ((uint64_t)(uint32_t)u.kind << 32) | u.use_pc)
                                   : ((uint64_t)(uint32_t)u.kind << 32) | u.key;
                 if (!srt_seen.insert(dk).second) continue;
-                bool clash = u.key == 0xFFFFFFFFu;       // key-less: never resolvable by srt_offset
+                bool clash = exact_mtbuf || u.key == 0xFFFFFFFFu;
                 if (!clash)
                     for (const auto& r0 : t.resources) if (r0.srt_offset == u.key) { clash = true; break; }
                 if (u.kind == 1) {                       // constant buffer / structured-buffer V#
@@ -2322,7 +2324,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     // A keyed use whose key already resolves keeps the existing resource; a key-less
                     // (or key-clashed) use still needs a pc-provenance entry — piggyback the pc onto
                     // an existing resource describing the SAME buffer, else create one (#273).
-                    if (clash) {
+                    if (clash && !exact_mtbuf) {
                         bool piggybacked = false;
                         for (auto& r0 : t.resources)
                             if ((r0.cls == ResourceClass::ConstantBuffer || r0.cls == ResourceClass::VertexBuffer) &&

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -437,7 +437,8 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
                                      instruction.fmt == Rdna2Format::SOPP ||
                                      instruction.fmt == Rdna2Format::SMEM ||
                                      instruction.fmt == Rdna2Format::MIMG ||
-                                     instruction.fmt == Rdna2Format::MUBUF;
+                                     instruction.fmt == Rdna2Format::MUBUF ||
+                                     instruction.fmt == Rdna2Format::MTBUF;
             if (fold_format || scalar_spill || scalar_spill_invalidation ||
                 instruction.dst.kind == OperandKind::SGPR)
                 result->instructions.push_back(instruction);
@@ -1661,13 +1662,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 }
                 break;
             }
-            case Rdna2Format::MUBUF: {
+            case Rdna2Format::MUBUF:
+            case Rdna2Format::MTBUF: {
+                const bool is_mtbuf = in.fmt == Rdna2Format::MTBUF;
                 // Buffer stores, raw loads/stores, and supported atomics need a kind-1 resource use.
                 // Format loads are intentionally handled only by DynFetch below: it snapshots the V#
                 // live at the instruction and resolves by exact pc, avoiding a duplicate stale SRT use.
-                const bool raw_buffer_use =
-                    (in.opcode >= 0x08 && in.opcode <= 0x0F) ||
-                    (in.opcode >= 0x1C && in.opcode <= 0x1E);
+                const bool raw_buffer_use = !is_mtbuf &&
+                    ((in.opcode >= 0x08 && in.opcode <= 0x0F) ||
+                     (in.opcode >= 0x1C && in.opcode <= 0x1E));
                 const bool format_store_use = in.opcode >= 0x04 && in.opcode <= 0x07;
                 const bool atomic_buffer_use = in.opcode == 0x38; // buffer_atomic_umax
                 if (srt_uses && (format_store_use || raw_buffer_use || atomic_buffer_use)) {
@@ -1684,6 +1687,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // exact; an unmodeled/incompatible write becomes unknown and fails closed
                         // instead of resurrecting the load-time descriptor snapshot.
                         SrtUse u; u.kind = 1; u.v4 = current; u.key = 0xFFFFFFFFu; u.use_pc = in.pc;
+                        if (is_mtbuf) u.instruction_format = in.mtbuf_format;
                         if (loaded_provenance) {
                             uint32_t common_key = 0;
                             bool have_common_key = true;
@@ -1704,9 +1708,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             if (have_common_key) u.key = common_key;
                         }
                         DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                        DataFormat inst_format = DataFormat::Unknown;
+                        uint32_t inst_components = 0;
+                        if (is_mtbuf)
+                            rdna2_buffer_format(in.mtbuf_format, &inst_format, &inst_components);
                         const bool format_supported = !format_store_use ||
-                            (d.format != DataFormat::Unknown && d.num_components != 0 &&
-                             !d.forbid_unknown_fallback);
+                            (is_mtbuf ? (inst_format != DataFormat::Unknown && inst_components != 0)
+                                      : (d.format != DataFormat::Unknown && d.num_components != 0 &&
+                                         !d.forbid_unknown_fallback));
                         // Byte-addressed raw/atomic V#s validly use stride zero: NUM_RECORDS is bytes.
                         // Typed format stores retain the strided record requirement.
                         const bool stride_supported = !format_store_use || d.stride != 0;
@@ -1767,7 +1776,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // decode_buffer_descriptor deliberately rejects packed formats whose selector
                         // or conversion semantics are unsupported. Do not let build_stage_table's
                         // legacy Unknown->Float32 fallback resurrect that descriptor as four raw dwords.
-                        if (d.forbid_unknown_fallback) {
+                        if (!is_mtbuf && d.forbid_unknown_fallback) {
                             if (trc) fprintf(stderr,
                                 "[dyntrace]   MUBUF pc=%u packed V# v3=0x%x unsupported -> unresolved\n",
                                 in.pc, desc_v3);
@@ -1775,6 +1784,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         }
                         DynFetch fetch{ in.pc, srsrc, with_off(d), desc_v3, from_seed };
                         fetch.unshifted_desc = d;
+                        if (is_mtbuf) fetch.instruction_format = in.mtbuf_format;
                         out.push_back(fetch);
                     };
                     if (trc) fprintf(stderr, "[dyntrace] MUBUF fetch pc=%u op=0x%x SRSRC=s%d patched=%d (k=%d%d%d%d v3=0x%x) have_descr=%d off=+0x%x soff_known=%d\n",
@@ -1817,7 +1827,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         DecodedBufferDescriptor d = decode_buffer_descriptor(sv);
                         // Plausibility: only emit a real-looking V# (mirrors the direct-resource guard).
                         if (d.base > 0x10000 && d.size_bytes != 0 && d.size_bytes <= 0x10000000u &&
-                            !d.forbid_unknown_fallback) {
+                            (is_mtbuf || !d.forbid_unknown_fallback)) {
                             if (trc) fprintf(stderr, "[dyntrace]   MUBUF pc=%u seed-V# fallback SRSRC=s%d base=0x%llx\n",
                                              in.pc, srsrc, (unsigned long long)d.base);
                             append_fetch(d, sv[3], /*from_seed=*/true);
@@ -1890,14 +1900,19 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
     // OFFSET/SOFFSET itself; `fetch.desc` is shifted for graphics' special vertex-index path.
     for (const auto& fetch : direct_fetches) {
         const DecodedBufferDescriptor& d = fetch.unshifted_desc;
+        DataFormat format = d.format;
+        uint32_t components = d.num_components;
+        if (fetch.instruction_format != UINT32_MAX)
+            rdna2_buffer_format(fetch.instruction_format, &format, &components);
         if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
-            d.format == DataFormat::Unknown || !d.num_components || d.forbid_unknown_fallback)
+            format == DataFormat::Unknown || !components ||
+            (fetch.instruction_format == UINT32_MAX && d.forbid_unknown_fallback))
             continue;
         bool mapped = false;
         for (auto& r0 : table.resources) {
             if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
-                r0.size != d.size_bytes || r0.stride != d.stride || r0.format != d.format ||
-                r0.num_components != d.num_components)
+                r0.size != d.size_bytes || r0.stride != d.stride || r0.format != format ||
+                r0.num_components != components)
                 continue;
             if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = fetch.fetch_pc;
             if (r0.fetch_pc == fetch.fetch_pc) { mapped = true; break; }
@@ -1905,8 +1920,8 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         if (mapped) continue;
         ShaderResource r;
         r.cls = ResourceClass::ConstantBuffer;
-        r.format = d.format;
-        r.num_components = d.num_components;
+        r.format = format;
+        r.num_components = components;
         r.gpu_addr = d.base;
         r.size = d.size_bytes;
         r.stride = d.stride;
@@ -1943,8 +1958,13 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         }
         ShaderResource r;
         r.cls = ResourceClass::ConstantBuffer;
-        r.format = d.format;
-        r.num_components = d.num_components ? d.num_components : 1;
+        if (u.instruction_format != UINT32_MAX) {
+            rdna2_buffer_format(u.instruction_format, &r.format, &r.num_components);
+            if (r.format == DataFormat::Unknown || r.num_components == 0) continue;
+        } else {
+            r.format = d.format;
+            r.num_components = d.num_components ? d.num_components : 1;
+        }
         r.gpu_addr = d.base;
         r.size = d.size_bytes;
         r.stride = d.stride;
@@ -2164,7 +2184,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             // Belt-and-suspenders: resolve_dynamic_fetch filters these before emitting DynFetch, but
             // never allow a deliberately rejected packed descriptor to reach the generic Float32
             // fallback if another producer constructs a DynFetch in the future.
-            if (d.forbid_unknown_fallback) continue;
+            if (kv.instruction_format == UINT32_MAX && d.forbid_unknown_fallback) continue;
             // A SEED-fallback entry must not shadow a metadata-described DIRECT vertex buffer at the
             // same SGPRs (see DynFetch::from_seed): the direct resource resolves the fetch through
             // the faithful address path, which is the correct model for a single un-patched V#.
@@ -2181,8 +2201,13 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             // computed VADDR/stride address; labeling it VertexBuffer makes the recompiler take
             // the gl_VertexIndex shortcut and rejects valid stride-2 uint16 tables (#719).
             r.cls           = is_ps ? ResourceClass::ConstantBuffer : ResourceClass::VertexBuffer;
-            r.format        = (d.format == DataFormat::Unknown) ? DataFormat::Float32 : d.format;
-            r.num_components = d.num_components ? d.num_components : 4;
+            if (kv.instruction_format != UINT32_MAX) {
+                rdna2_buffer_format(kv.instruction_format, &r.format, &r.num_components);
+                if (r.format == DataFormat::Unknown || r.num_components == 0) continue;
+            } else {
+                r.format = (d.format == DataFormat::Unknown) ? DataFormat::Float32 : d.format;
+                r.num_components = d.num_components ? d.num_components : 4;
+            }
             r.gpu_addr      = d.base;
             if (d.size_bytes) {
                 r.size = d.size_bytes;
@@ -2221,7 +2246,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                                  "compatibility size=%u\n",
                                  (unsigned long long)code_addr, kv.fetch_pc, r.size);
             }
-            if (d.format == DataFormat::Unknown) {
+            if (kv.instruction_format == UINT32_MAX && d.format == DataFormat::Unknown) {
                 static std::mutex unknown_mx;
                 static std::set<std::tuple<uint64_t, bool, uint32_t, uint32_t>> unknown_seen;
                 std::lock_guard<std::mutex> lk(unknown_mx);
@@ -2288,7 +2313,13 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     }
                     ShaderResource r;
                     r.cls = ResourceClass::ConstantBuffer;
-                    r.format = d.format; r.num_components = d.num_components ? d.num_components : 1;
+                    if (u.instruction_format != UINT32_MAX) {
+                        rdna2_buffer_format(u.instruction_format, &r.format, &r.num_components);
+                        if (r.format == DataFormat::Unknown || r.num_components == 0) continue;
+                    } else {
+                        r.format = d.format;
+                        r.num_components = d.num_components ? d.num_components : 1;
+                    }
                     r.gpu_addr = d.base; r.size = resource_size; r.stride = resource_stride;
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
                     if (clash) r.fetch_pc = u.use_pc;    // pc-only provenance (key-less/collided V#)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1712,8 +1712,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         uint32_t inst_components = 0;
                         if (is_mtbuf)
                             rdna2_buffer_format(in.mtbuf_format, &inst_format, &inst_components);
+                        // FORMAT=INVALID is the architectural unbound-resource marker. MTBUF's
+                        // instruction format controls conversion, but does not turn an unbound V#
+                        // into a valid resource.
+                        const bool descriptor_bound = !is_mtbuf ||
+                            (((u.v4[3] >> 12) & 0x7Fu) != 0);
                         const bool format_supported = !format_store_use ||
-                            (is_mtbuf ? (inst_format != DataFormat::Unknown && inst_components != 0)
+                            (is_mtbuf ? (descriptor_bound && inst_format != DataFormat::Unknown &&
+                                         inst_components != 0)
                                       : (d.format != DataFormat::Unknown && d.num_components != 0 &&
                                          !d.forbid_unknown_fallback));
                         // Byte-addressed raw/atomic V#s validly use stride zero: NUM_RECORDS is bytes.
@@ -1773,6 +1779,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     };
                     auto append_fetch = [&](DecodedBufferDescriptor d, uint32_t desc_v3,
                                             bool from_seed = false) {
+                        if (is_mtbuf && ((desc_v3 >> 12) & 0x7Fu) == 0) {
+                            if (trc) fprintf(stderr,
+                                "[dyntrace]   MTBUF pc=%u unbound V# v3=0x%x -> unresolved\n",
+                                in.pc, desc_v3);
+                            return;
+                        }
                         // decode_buffer_descriptor deliberately rejects packed formats whose selector
                         // or conversion semantics are unsupported. Do not let build_stage_table's
                         // legacy Unknown->Float32 fallback resurrect that descriptor as four raw dwords.
@@ -1900,6 +1912,9 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
     // OFFSET/SOFFSET itself; `fetch.desc` is shifted for graphics' special vertex-index path.
     for (const auto& fetch : direct_fetches) {
         const DecodedBufferDescriptor& d = fetch.unshifted_desc;
+        if (fetch.instruction_format != UINT32_MAX &&
+            ((fetch.desc_v3 >> 12) & 0x7Fu) == 0)
+            continue;
         DataFormat format = d.format;
         uint32_t components = d.num_components;
         if (fetch.instruction_format != UINT32_MAX)
@@ -1932,6 +1947,8 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
     std::set<uint64_t> seen;
     for (const auto& u : srt_uses) {
         if (u.kind != 1) continue;
+        if (u.instruction_format != UINT32_MAX && ((u.v4[3] >> 12) & 0x7Fu) == 0)
+            continue;
         // Keyed buffer uses dedupe by table offset; key-less live descriptors dedupe by consumer pc.
         const uint64_t dk = u.key == 0xFFFFFFFFu
             ? (0x8000000100000000ull | u.use_pc)
@@ -2181,6 +2198,9 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
         // (a raw 32-bit-per-component fetch, correct for float attributes like positions).
         for (auto& kv : dyn_vb) {
             const auto& d = kv.desc;
+            if (kv.instruction_format != UINT32_MAX &&
+                ((kv.desc_v3 >> 12) & 0x7Fu) == 0)
+                continue;
             // Belt-and-suspenders: resolve_dynamic_fetch filters these before emitting DynFetch, but
             // never allow a deliberately rejected packed descriptor to reach the generic Float32
             // fallback if another producer constructs a DynFetch in the future.
@@ -2281,6 +2301,9 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     for (const auto& r0 : t.resources) if (r0.srt_offset == u.key) { clash = true; break; }
                 if (u.kind == 1) {                       // constant buffer / structured-buffer V#
                     DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                    if (u.instruction_format != UINT32_MAX &&
+                        ((u.v4[3] >> 12) & 0x7Fu) == 0)
+                        continue;
                     if (d.base <= 0x10000) continue;
                     uint32_t resource_size = d.size_bytes;
                     uint32_t resource_stride = d.stride;

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -393,6 +393,22 @@ void decode_operands(Rdna2Inst& i) {
             i.literal = (w & 0xFFFu) | (((w >> 12) & 1u) << 12) | (((w >> 13) & 1u) << 13);
             i.n_src = 3; break;
         }
+        case Rdna2Format::MTBUF: {
+            // Typed buffer op. gfx1030 keeps the eight load/store opcodes in d0[18:16] and uses
+            // the Gen5 combined seven-bit BUF_FMT in d0[25:19]. Operand/address fields match
+            // MUBUF: VDATA, VADDR, SRSRC*4, SOFFSET plus OFFSET/OFFEN/IDXEN.
+            const uint32_t d1 = i.words[1];
+            i.opcode = (w >> 16) & 0x7u;
+            i.mtbuf_format = (w >> 19) & 0x7Fu;
+            i.mubuf_glc = ((w >> 14) & 1u) != 0;
+            i.dst    = vgpr(d1 >> 8);
+            i.src[0] = vgpr(d1);
+            i.src[1] = sgpr(((d1 >> 16) & 0x1Fu) << 2);
+            i.src[2] = decode_src_field((d1 >> 24) & 0xFFu);
+            i.literal = (w & 0xFFFu) | (((w >> 12) & 1u) << 12) |
+                        (((w >> 13) & 1u) << 13);
+            i.n_src = 3; break;
+        }
         case Rdna2Format::MIMG: {
             // Image op. opcode is 8 bits: MSB in dword0 bit 0, low 7 bits in [24:18] (Table 100:
             // "combine bits zero and 18-24" — dropping bit 0 aliased IMAGE_MSAA_LOAD (128) onto
@@ -439,7 +455,7 @@ void decode_operands(Rdna2Inst& i) {
             i.src[0]      = vgpr(w & 0xFFu);
             i.n_src = 1; break;
         }
-        default: break;   // MTBUF/DS/FLAT: operands not decoded at this stage
+        default: break;   // FLAT operands are not decoded at this stage
     }
 }
 }  // namespace

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -398,7 +398,9 @@ void decode_operands(Rdna2Inst& i) {
             // the Gen5 combined seven-bit BUF_FMT in d0[25:19]. Operand/address fields match
             // MUBUF: VDATA, VADDR, SRSRC*4, SOFFSET plus OFFSET/OFFEN/IDXEN.
             const uint32_t d1 = i.words[1];
-            i.opcode = (w >> 16) & 0x7u;
+            // gfx10 moves OP[3] to instruction bit 53 (dword1 bit 21) to make room for the
+            // combined seven-bit format. Opcodes 8..15 are the packed-D16 variants.
+            i.opcode = ((w >> 16) & 0x7u) | (((d1 >> 21) & 1u) << 3);
             i.mtbuf_format = (w >> 19) & 0x7Fu;
             i.mubuf_glc = ((w >> 14) & 1u) != 0;
             i.dst    = vgpr(d1 >> 8);

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -402,6 +402,7 @@ void decode_operands(Rdna2Inst& i) {
             // combined seven-bit format. Opcodes 8..15 are the packed-D16 variants.
             i.opcode = ((w >> 16) & 0x7u) | (((d1 >> 21) & 1u) << 3);
             i.mtbuf_format = (w >> 19) & 0x7Fu;
+            i.mtbuf_tfe = ((d1 >> 23) & 1u) != 0;
             i.mubuf_glc = ((w >> 14) & 1u) != 0;
             i.dst    = vgpr(d1 >> 8);
             i.src[0] = vgpr(d1);

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -104,6 +104,10 @@ struct Rdna2Inst {
     // LDS (bit 16) — transfer between LDS and memory instead of VGPRs (rejected until modeled).
     bool     mubuf_glc = false;
     bool     mubuf_lds = false;
+    // MTBUF carries the GFX10 combined 7-bit BUF_FMT at dword0[25:19], just like a Gen5 V#.
+    // Interpreting these bits as the older PS4 DFMT/NFMT split maps valid gfx1030 formats to the
+    // wrong type (for example 32_FLOAT is combined format 22).
+    uint32_t mtbuf_format = 0;
     // DS-only: GDS flag. llvm-mc gfx1030 round-trip places it at dword0 bit 17 (ds_add_u32 gds =
     // 0xd8020000 vs 0xd8000000; Table 94's "GDS [16]" is a GFX9-era erratum — it also misplaces
     // OP). Bit 16 is likewise captured so an unknown flag rejects rather than silently running

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -108,6 +108,9 @@ struct Rdna2Inst {
     // Interpreting these bits as the older PS4 DFMT/NFMT split maps valid gfx1030 formats to the
     // wrong type (for example 32_FLOAT is combined format 22).
     uint32_t mtbuf_format = 0;
+    // MTBUF Texel Fault Enable (instruction bit 55 / dword1 bit 23) writes a status VGPR after the
+    // data results. Kept explicit so the recompiler can reject until that observable write is modeled.
+    bool     mtbuf_tfe = false;
     // DS-only: GDS flag. llvm-mc gfx1030 round-trip places it at dword0 bit 17 (ds_add_u32 gds =
     // 0xd8020000 vs 0xd8000000; Table 94's "GDS [16]" is a GFX9-era erratum — it also misplaces
     // OP). Bit 16 is likewise captured so an unknown flag rejects rather than silently running

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1927,7 +1927,8 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
                  ((in.opcode >= 0x128 && in.opcode <= 0x12A) || in.opcode == 0x176));
             if (!scalar_side_effect &&
                 (in.fmt == Rdna2Format::VOP1 || in.fmt == Rdna2Format::VOP2 || in.fmt == Rdna2Format::VOP3 ||
-                 in.fmt == Rdna2Format::MIMG || in.fmt == Rdna2Format::MUBUF || in.fmt == Rdna2Format::DS ||
+                 in.fmt == Rdna2Format::MIMG || in.fmt == Rdna2Format::MUBUF ||
+                 in.fmt == Rdna2Format::MTBUF || in.fmt == Rdna2Format::DS ||
                  sopp_is_noop(in))) {
                 continue;
             }
@@ -2151,7 +2152,8 @@ std::unordered_set<uint32_t> waterfall_branches(const std::vector<Rdna2Inst>& in
             bool skip_ok =
                 (p.fmt == Rdna2Format::SOP1 && (p.opcode == 0x03 || p.opcode == 0x04)) ||   // s_mov_b32/b64
                 p.fmt == Rdna2Format::VOP1 || p.fmt == Rdna2Format::VOP2 || p.fmt == Rdna2Format::VOP3 ||
-                p.fmt == Rdna2Format::VOPC || p.fmt == Rdna2Format::MIMG || p.fmt == Rdna2Format::MUBUF ||
+                p.fmt == Rdna2Format::VOPC || p.fmt == Rdna2Format::MIMG ||
+                p.fmt == Rdna2Format::MUBUF || p.fmt == Rdna2Format::MTBUF ||
                 sopp_is_noop(p);
             if (skip_ok) continue;
             // The SCC producer: a 64-bit wave-mask logical op (s_and/or/xor/andn2_b64, SCC = result!=0).
@@ -2277,6 +2279,9 @@ uint32_t vgpr_write_count(const Rdna2Inst& in) {
                 case 0x3: case 0x7: case 0xE: return 4;
                 default: return 1;
             }
+        case Rdna2Format::MTBUF:
+            if (in.opcode >= 4u) return 0; // stores read VDATA; they do not write it
+            return in.opcode + 1u;
         case Rdna2Format::MIMG: {
             if (in.opcode == 0x47 || in.opcode == 0x57) return 4;  // gather4 always returns four texels
             uint32_t n = 0;
@@ -2924,7 +2929,7 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
                 break;
-            case Rdna2Format::MUBUF: case Rdna2Format::MIMG:
+            case Rdna2Format::MUBUF: case Rdna2Format::MTBUF: case Rdna2Format::MIMG:
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
                 break;
@@ -4663,7 +4668,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             return true;
         }
-        case Rdna2Format::MUBUF: {
+        case Rdna2Format::MUBUF:
+        case Rdna2Format::MTBUF: {
             // Untyped buffer LOAD — the per-lane fetch mechanism (vertex fetch et al.). Modeled as a
             // per-lane load from the bound constant buffer: byte addr = (offen ? VADDR : 0) + SOFFSET
             // + inst-offset; index = addr>>2; N dwords -> VDATA..+N-1. Descriptor (SRSRC), idxen*stride,
@@ -4672,7 +4678,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // VDATA VGPRs stay untouched on hardware and the data lands in LDS — translating it as
             // a VGPR load would clobber a live register AND drop the LDS write. Reject until a
             // buffer->LDS model exists.
-            if (in.mubuf_lds) { ok = false; return true; }
+            if (in.fmt == Rdna2Format::MUBUF && in.mubuf_lds) { ok = false; return true; }
             uint32_t n = 0; bool is_format = false, is_store = false, is_atomic = false;
             bool raw_subword = false, raw_signed = false;
             uint32_t raw_bits = 32;
@@ -4802,8 +4808,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 binding = res->binding;
                 stride = res->stride;
-                fmt = res->format;
-                fmt_ncomp = res->num_components;   // for the format default-fill below (#368)
+                if (in.fmt == Rdna2Format::MTBUF) {
+                    // Unlike MUBUF format ops, MTBUF owns the type in the instruction. gfx1030 uses
+                    // the same combined 7-bit BUF_FMT table as Gen5 V# descriptors.
+                    rdna2_buffer_format(in.mtbuf_format, &fmt, &fmt_ncomp);
+                    if (fmt == DataFormat::Unknown || fmt_ncomp == 0) {
+                        ok = false; return true;
+                    }
+                } else {
+                    fmt = res->format;
+                    fmt_ncomp = res->num_components;   // format default-fill below (#368)
+                }
             } else if (rt) {
                 // RAW (untyped) MUBUF with a resource table: resolve SRSRC (src[1]) exactly like the
                 // format path — a raw buffer op targets whatever buffer its V# describes, NOT a fixed
@@ -7550,6 +7565,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                 }
                 case Rdna2Format::MUBUF:  return i.opcode <= 0x07u ||                    // load/store_format_*
                                                  (i.opcode >= 0x0Cu && i.opcode <= 0x0Fu);  // load_dword/x2/x4/x3 (need the V#)
+                case Rdna2Format::MTBUF:  return i.opcode <= 0x07u;
                 case Rdna2Format::VINTRP: return true;               // handled in the fragment shell
                 default: return false;
             }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4783,19 +4783,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         dyn_vfetch = res->cls == ResourceClass::VertexBuffer &&
                                      (in.src[0].value == 0 || srsrc_rewritten);
                     }
-                    if (!res && !srsrc_rewritten)
-                        res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
-                    uint32_t srt_tag = 0;
-                    if (!res && sreg_srt_range_tag(rs, in.src[1].value, 4, srt_tag))
-                        res = rt->by_srt_offset(srt_tag);
-                    // DIRECT user-data V# of any class (#273 — DOLL's title post PSes format-fetch
-                    // through a V# the metadata labels a CONSTANT buffer sharp at s[24:27]): the class
-                    // label doesn't change the descriptor's fields. Only when the SGPR was never
-                    // REWRITTEN in-shader (no rs.sreg entry in its four-dword range) — a reloaded
-                    // register no longer holds the seed-time sharp, and trusting it would fetch through
-                    // a stale descriptor.
-                    if (!res && !srsrc_rewritten)
-                        res = rt->by_sgpr_base(in.src[1].value);
+                    // MTBUF must resolve through the exact dynamic-use entry. The fold validates the
+                    // live V# FORMAT != INVALID before publishing that pc. Falling back to an older
+                    // metadata resource here can resurrect an unbound V# that happens to share its
+                    // SGPR/SRT identity. MUBUF retains its established metadata fallbacks.
+                    if (in.fmt != Rdna2Format::MTBUF) {
+                        if (!res && !srsrc_rewritten)
+                            res = rt->by_sgpr_base_cls(in.src[1].value, ResourceClass::VertexBuffer);
+                        uint32_t srt_tag = 0;
+                        if (!res && sreg_srt_range_tag(rs, in.src[1].value, 4, srt_tag))
+                            res = rt->by_srt_offset(srt_tag);
+                        // DIRECT user-data V# of any class (#273 — DOLL's title post PSes format-fetch
+                        // through a V# the metadata labels a CONSTANT buffer sharp at s[24:27]): the class
+                        // label doesn't change the descriptor's fields. Only when the SGPR was never
+                        // REWRITTEN in-shader (no rs.sreg entry in its four-dword range) — a reloaded
+                        // register no longer holds the seed-time sharp, and trusting it would fetch through
+                        // a stale descriptor.
+                        if (!res && !srsrc_rewritten)
+                            res = rt->by_sgpr_base(in.src[1].value);
+                    }
                 }
                 if (!res) {
                     if (getenv("PROSPER_DBG")) {   // which provenance step failed for this format load

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4683,6 +4683,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // MUBUF cases below would silently apply the wrong register layout, so fail closed until
             // that packing is modeled.
             if (in.fmt == Rdna2Format::MTBUF && in.opcode >= 8u) { ok = false; return true; }
+            // TFE appends a fault/status result after the data VGPRs. Dropping that write can corrupt
+            // later register consumers, so reject until status-return semantics are implemented.
+            if (in.fmt == Rdna2Format::MTBUF && in.mtbuf_tfe) { ok = false; return true; }
             uint32_t n = 0; bool is_format = false, is_store = false, is_atomic = false;
             bool raw_subword = false, raw_signed = false;
             uint32_t raw_bits = 32;
@@ -7572,7 +7575,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                 }
                 case Rdna2Format::MUBUF:  return i.opcode <= 0x07u ||                    // load/store_format_*
                                                  (i.opcode >= 0x0Cu && i.opcode <= 0x0Fu);  // load_dword/x2/x4/x3 (need the V#)
-                case Rdna2Format::MTBUF:  return i.opcode <= 0x07u;
+                case Rdna2Format::MTBUF:  return i.opcode <= 0x07u && !i.mtbuf_tfe;
                 case Rdna2Format::VINTRP: return true;               // handled in the fragment shell
                 default: return false;
             }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4984,20 +4984,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // Store the VDATA VGPRs (in.dst..+n-1). Integer sub-dword formats (Uint8/Sint8/...) have
                 // no packing path here -> reject rather than mis-store (loads extend them; stores don't pack).
                 if (packed_word || (packed && (is_uint || is_sint))) { ok = false; return true; }
+                // MTBUF's instruction format owns the physical component count. A wider opcode still uses
+                // identity selection (for example XY00), so Z/W must not spill into adjacent memory.
+                const uint32_t store_n = in.fmt == Rdna2Format::MTBUF && fmt_ncomp < n
+                                           ? fmt_ncomp : n;
                 auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
                 if (!packed) {
                     // Raw/Float32/Uint32: one dword per component.
-                    for (uint32_t k = 0; k < n; k++) {
+                    for (uint32_t k = 0; k < store_n; k++) {
                         uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
                         b.cbuf_store(kidx, vread(in.dst.value + (int)k), binding, rs.exec_narrowed, rs.exec);
                     }
                 } else {
                     // Packed UNORM/SNORM/Float16: pack the components tightly into ceil(n*bytes/4) dwords
                     // (inverse of the packed load). Each dword ORs together the fields that land in it.
-                    const uint32_t dwords = (n * comp_bytes + 3) / 4;
+                    const uint32_t dwords = (store_n * comp_bytes + 3) / 4;
                     for (uint32_t d = 0; d < dwords; d++) {
                         uint32_t acc = b.uconst(0);
-                        for (uint32_t k = 0; k < n; k++) {
+                        for (uint32_t k = 0; k < store_n; k++) {
                             uint32_t byte_off = k * comp_bytes;
                             if (byte_off / 4 != d) continue;
                             uint32_t field = is_half ? b.pack_half_lo(vread(in.dst.value + (int)k))

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4679,6 +4679,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // a VGPR load would clobber a live register AND drop the LDS write. Reject until a
             // buffer->LDS model exists.
             if (in.fmt == Rdna2Format::MUBUF && in.mubuf_lds) { ok = false; return true; }
+            // MTBUF opcodes 8..15 pack D16 results/inputs two per VGPR. Reusing the ordinary or raw
+            // MUBUF cases below would silently apply the wrong register layout, so fail closed until
+            // that packing is modeled.
+            if (in.fmt == Rdna2Format::MTBUF && in.opcode >= 8u) { ok = false; return true; }
             uint32_t n = 0; bool is_format = false, is_store = false, is_atomic = false;
             bool raw_subword = false, raw_signed = false;
             uint32_t raw_bits = 32;
@@ -5007,16 +5011,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 int d = in.dst.value + (int)k;
                 uint32_t old = vreg_old(b, rs, d);
                 uint32_t value;
-                // Format default-fill (#368): BUFFER_LOAD_FORMAT_* returns only the components the V#'s
-                // format defines; a component the OPCODE requests beyond that (e.g. _xyzw against a
-                // 32_32_32 position, or _xyz against a 32_32 UV) is filled with the standard vector
-                // default — 0 for G/B/Z, 1 for A/W — NOT read from adjacent memory (which yielded the
-                // next vertex's bytes, or robust-0 at the buffer tail, so a vec4 read of a vec3 attribute
-                // got W = garbage/0 instead of 1.0 -> broken transforms). Only for format loads with a
-                // known component count; untyped raw MUBUF loads keep every opcode component.
+                // Format default-fill (#368): a requested component beyond the format's component
+                // count is not read from adjacent memory. MUBUF takes DST_SEL from the V# contract
+                // (0 for G/B/Z, 1 for A/W). MTBUF forces identity selection from its instruction
+                // format (X000/XY00/XYZ0/XYZW), so every absent component is zero.
                 if (is_format && fmt_ncomp && k >= fmt_ncomp) {
                     uint32_t one = fmt_is_int ? 1u : 0x3f800000u;   // integer 1 vs float 1.0 (raw bits)
-                    value = b.uconst(k == 3 ? one : 0u);            // W/A -> 1, G/B/Z -> 0
+                    value = b.uconst(in.fmt != Rdna2Format::MTBUF && k == 3 ? one : 0u);
                 } else if (raw_subword) {
                     // Raw byte/short loads use their full byte address, unlike typed packed-format
                     // loads whose component packing is descriptor-defined. A 16-bit access may begin

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -141,7 +141,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 // Recompile a pixel/fragment shader to a fragment SPIR-V module: run the VALU, and on EXP to MRT0/1
 // write vec4(src0..3) to the matching color output. NULL-only shaders retain discard/EXEC effects and
 // intentionally expose no color output. Returns {} if unsupported / no implemented export.
-// An optional ShaderResourceTable enables memory ops (SMEM/MUBUF) with resolved bindings.
+// An optional ShaderResourceTable enables memory ops (SMEM/MUBUF/MTBUF) with resolved bindings.
 std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt = nullptr,
                                          const PixelSystemInputMapping* system_inputs = nullptr,
@@ -168,7 +168,7 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
 struct RecompileCoverage {
     uint32_t total = 0, alu = 0, exports = 0, unsupported = 0;
     // Instructions the recompiler handles GIVEN the right context (a resource table for MIMG /
-    // buffer_load_format, or a fragment stage for VINTRP) but that recompile_coverage — which runs
+    // MUBUF / MTBUF, or a fragment stage for VINTRP) but that recompile_coverage — which runs
     // table-less on a compute shell — cannot exercise. Counting them apart from `unsupported` gives an
     // honest "recompilable in context" number; the table-less `alu`/`unsupported` split understates it.
     uint32_t table_dependent = 0;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -2,7 +2,8 @@
 // real GPU resources) and the recompiler back-half (which must translate the shader's memory ops
 // correctly). This is the seam that unblocks the format-dependent memory instructions:
 //   * s_buffer_load_*   — uniforms / constant buffers (multi-buffer, beyond the single-cbuf model)
-//   * buffer_load_format_* (MUBUF) — vertex attribute fetch (needs the attribute's data format)
+//   * buffer_load_format_* (MUBUF) — vertex attribute fetch (needs the descriptor data format)
+//   * tbuffer_load/store_format_* (MTBUF) — typed buffers (the instruction supplies its data format)
 //   * image_sample / image_load (MIMG) — texture reads (needs texture format + sampler)
 //
 // Why a contract: to translate `buffer_load_format_xyzw` the recompiler must know the attribute's
@@ -18,8 +19,8 @@
 
 namespace prosper::gpu {
 
-// Element data format, decoded from a V#/T# descriptor's DFMT (data format) + NFMT (number format).
-// Determines the conversion a format load / texture sample must emit. `Float32` is the common case
+// Element data format decoded from gfx1030's combined V#/T#/MTBUF format fields. Determines the
+// conversion a format load / texture sample must emit. `Float32` is the common case
 // for positions and most attributes — and for our raw-32-bit-VGPR model it is a *no-op reinterpret*,
 // so float32 format loads reduce to raw dword loads. The rest require real conversion.
 enum class DataFormat : uint32_t {
@@ -51,6 +52,10 @@ enum class DataFormat : uint32_t {
     Uint2_10_10_10,
     Sint2_10_10_10,
 };
+
+// Decode an RDNA2 (GFX10/PS5) combined seven-bit buffer FORMAT field, used by both V# descriptors
+// and MTBUF instructions, into the recompiler's data-format contract. Unknown values stay explicit.
+void rdna2_buffer_format(uint32_t fmt, DataFormat* out_fmt, uint32_t* out_components);
 
 // How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).
 uint32_t data_format_bytes(DataFormat f);

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -117,10 +117,11 @@ struct ShaderResource {
     uint32_t      srt_offset    = 0xFFFFFFFFu;
     uint32_t      sgpr_base     = 0xFFFFFFFFu;
 
-    //   * fetch_pc — PER-FETCH: the pc of the exact buffer_load_format_* instruction this descriptor was
+    //   * fetch_pc — PER-FETCH: the pc of the exact buffer/tbuffer format instruction this descriptor was
     //     resolved for. A single SRSRC SGPR is reloaded with a DIFFERENT V# per vertex attribute (position,
-    //     uv, color, …), so keying only by sgpr_base collapses them to the first. The recompiler resolves a
-    //     vertex fetch by its instruction pc first (exact), falling back to sgpr_base. 0xFFFFFFFF = unset.
+    //     uv, color, …), so keying only by sgpr_base collapses them to the first. MUBUF may fall back to
+    //     metadata provenance; MTBUF requires this validated live-V# identity so FORMAT=INVALID cannot be
+    //     resurrected through an older metadata resource. 0xFFFFFFFF = unset.
     uint32_t      fetch_pc      = 0xFFFFFFFFu;
 
     // Texture-only (cls == Texture). img_dim mirrors the MIMG dim field (1D=0, 2D=1, 3D=2, ...).

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -565,16 +565,16 @@ int main() {
           "#636: instruction-provenance table keeps the Dead Cells format-copy dispatch realizable");
 
     // MTBUF's instruction format must also survive the production compute discovery path. Both V#s
-    // deliberately carry format 0 (Unknown); the encoded gfx1030 BUF_FMT 56 supplies Unorm8x4 for
-    // the load and store independently of descriptor dword3.
+    // deliberately carry a different but valid 32_FLOAT format; the encoded gfx1030 BUF_FMT 56
+    // supplies Unorm8x4 for the load and store independently of descriptor dword3.
     const uint32_t direct_mtbuf_copy[] = {
         0xE9C32000u, 0x80000100u,   // tbuffer_load_format_xyzw ..., s[0:3], fmt 56, idxen
         0xE9C72000u, 0x80010101u,   // tbuffer_store_format_xyzw ..., s[4:7], fmt 56, idxen
         0xBF810000u,
     };
     const uint32_t direct_mtbuf_seed[8] = {
-        0x00020000u, 0x00040000u, 16u, 0u,
-        0x00030000u, 0x00040000u, 16u, 0u,
+        0x00020000u, 0x00040000u, 16u, 22u << 12,
+        0x00030000u, 0x00040000u, 16u, 22u << 12,
     };
     std::vector<SrtUse> direct_mtbuf_uses;
     const std::vector<DynFetch> direct_mtbuf_fetches = resolve_dynamic_fetch(
@@ -582,8 +582,8 @@ int main() {
         &direct_mtbuf_uses);
     CHECK(direct_mtbuf_fetches.size() == 1 &&
               direct_mtbuf_fetches[0].instruction_format == 56u &&
-              direct_mtbuf_fetches[0].desc.format == DataFormat::Unknown,
-          "MTBUF load discovery retains the instruction format over an unknown V# format");
+              direct_mtbuf_fetches[0].desc.format == DataFormat::Float32,
+          "MTBUF load discovery retains the instruction format over a different valid V# format");
     CHECK(direct_mtbuf_uses.size() == 1 &&
               direct_mtbuf_uses[0].instruction_format == 56u &&
               direct_mtbuf_uses[0].use_pc == 2,
@@ -604,6 +604,20 @@ int main() {
               !recompile_compute(direct_mtbuf_copy, std::size(direct_mtbuf_copy),
                                  &direct_mtbuf_table, direct_mtbuf_config).empty(),
           "production compute discovery emits instruction-typed MTBUF source and destination resources");
+    const uint32_t invalid_mtbuf_seed[8] = {
+        0x00020000u, 0x00040000u, 16u, 0u,
+        0x00030000u, 0x00040000u, 16u, 0u,
+    };
+    std::vector<SrtUse> invalid_mtbuf_uses;
+    const std::vector<DynFetch> invalid_mtbuf_fetches = resolve_dynamic_fetch(
+        direct_mtbuf_copy, std::size(direct_mtbuf_copy), invalid_mtbuf_seed, 8, 0,
+        &invalid_mtbuf_uses);
+    ShaderResourceTable invalid_mtbuf_table;
+    add_compute_buffer_resources(invalid_mtbuf_table, direct_mtbuf_copy,
+                                 std::size(direct_mtbuf_copy), invalid_mtbuf_seed, 8);
+    CHECK(invalid_mtbuf_fetches.empty() && invalid_mtbuf_uses.empty() &&
+              invalid_mtbuf_table.resources.empty(),
+          "MTBUF leaves FORMAT=INVALID descriptors unbound instead of replacing their format");
 
     // DynFetch shifts graphics vertex descriptors by a constant instruction offset because their
     // special address path drops the original OFFSET/SOFFSET. Compute resources use ConstantBuffer's

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -564,6 +564,47 @@ int main() {
                              &direct_copy_table, direct_copy_config).empty(),
           "#636: instruction-provenance table keeps the Dead Cells format-copy dispatch realizable");
 
+    // MTBUF's instruction format must also survive the production compute discovery path. Both V#s
+    // deliberately carry format 0 (Unknown); the encoded gfx1030 BUF_FMT 56 supplies Unorm8x4 for
+    // the load and store independently of descriptor dword3.
+    const uint32_t direct_mtbuf_copy[] = {
+        0xE9C32000u, 0x80000100u,   // tbuffer_load_format_xyzw ..., s[0:3], fmt 56, idxen
+        0xE9C72000u, 0x80010101u,   // tbuffer_store_format_xyzw ..., s[4:7], fmt 56, idxen
+        0xBF810000u,
+    };
+    const uint32_t direct_mtbuf_seed[8] = {
+        0x00020000u, 0x00040000u, 16u, 0u,
+        0x00030000u, 0x00040000u, 16u, 0u,
+    };
+    std::vector<SrtUse> direct_mtbuf_uses;
+    const std::vector<DynFetch> direct_mtbuf_fetches = resolve_dynamic_fetch(
+        direct_mtbuf_copy, std::size(direct_mtbuf_copy), direct_mtbuf_seed, 8, 0,
+        &direct_mtbuf_uses);
+    CHECK(direct_mtbuf_fetches.size() == 1 &&
+              direct_mtbuf_fetches[0].instruction_format == 56u &&
+              direct_mtbuf_fetches[0].desc.format == DataFormat::Unknown,
+          "MTBUF load discovery retains the instruction format over an unknown V# format");
+    CHECK(direct_mtbuf_uses.size() == 1 &&
+              direct_mtbuf_uses[0].instruction_format == 56u &&
+              direct_mtbuf_uses[0].use_pc == 2,
+          "MTBUF store discovery retains instruction format and exact consumer pc");
+    ShaderResourceTable direct_mtbuf_table;
+    add_compute_buffer_resources(direct_mtbuf_table, direct_mtbuf_copy,
+                                 std::size(direct_mtbuf_copy), direct_mtbuf_seed, 8);
+    assign_convention_bindings(direct_mtbuf_table, 2);
+    bool mtbuf_formats_ok = direct_mtbuf_table.resources.size() == 2;
+    for (const auto& resource : direct_mtbuf_table.resources)
+        mtbuf_formats_ok &= resource.format == DataFormat::Unorm8 &&
+                            resource.num_components == 4;
+    ComputeShaderConfig direct_mtbuf_config;
+    direct_mtbuf_config.user_sgprs.assign(direct_mtbuf_seed, direct_mtbuf_seed + 8);
+    direct_mtbuf_config.local_x = direct_mtbuf_config.local_y =
+        direct_mtbuf_config.local_z = 1;
+    CHECK(mtbuf_formats_ok &&
+              !recompile_compute(direct_mtbuf_copy, std::size(direct_mtbuf_copy),
+                                 &direct_mtbuf_table, direct_mtbuf_config).empty(),
+          "production compute discovery emits instruction-typed MTBUF source and destination resources");
+
     // DynFetch shifts graphics vertex descriptors by a constant instruction offset because their
     // special address path drops the original OFFSET/SOFFSET. Compute resources use ConstantBuffer's
     // faithful MUBUF path instead, so the production helper must retain base B and let that path add

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -618,6 +618,22 @@ int main() {
     CHECK(invalid_mtbuf_fetches.empty() && invalid_mtbuf_uses.empty() &&
               invalid_mtbuf_table.resources.empty(),
           "MTBUF leaves FORMAT=INVALID descriptors unbound instead of replacing their format");
+    // Metadata discovery may already have published the same invalid direct V# for raw SMEM use.
+    // MTBUF must not resurrect that older SGPR-keyed resource when its exact validated pc entry is
+    // absent.
+    ShaderResourceTable invalid_mtbuf_metadata;
+    { ShaderResource r{}; r.cls = ResourceClass::ConstantBuffer;
+      r.format = DataFormat::Unknown; r.num_components = 0; r.gpu_addr = 0x20000u;
+      r.size = 64u; r.stride = 4u; r.sgpr_base = 0u;
+      invalid_mtbuf_metadata.resources.push_back(r); }
+    assign_convention_bindings(invalid_mtbuf_metadata, 2);
+    ComputeShaderConfig invalid_mtbuf_config;
+    invalid_mtbuf_config.user_sgprs.assign(invalid_mtbuf_seed, invalid_mtbuf_seed + 8);
+    invalid_mtbuf_config.local_x = invalid_mtbuf_config.local_y =
+        invalid_mtbuf_config.local_z = 1;
+    CHECK(recompile_compute(direct_mtbuf_copy, std::size(direct_mtbuf_copy),
+                            &invalid_mtbuf_metadata, invalid_mtbuf_config).empty(),
+          "MTBUF cannot fall back to a metadata resource for an INVALID live V#");
 
     // DynFetch shifts graphics vertex descriptors by a constant instruction offset because their
     // special address path drops the original OFFSET/SOFFSET. Compute resources use ConstantBuffer's

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -124,6 +124,13 @@ int main() {
               mt_store.src[2].kind == OperandKind::InlineInt &&
               mt_store.src[2].value == 0 && ((mt_store.literal >> 13) & 1u),
           "MTBUF store decodes opcode, combined format, operands, and IDXEN");
+    // gfx1030 llvm-mc: tbuffer_load_format_d16_x v0, v0, s[8:11], 0
+    // format:[BUF_FMT_16_FLOAT] idxen. OP[3] lives in dword1 bit 21 on gfx10.
+    const uint32_t mtbuf_d16[] = { 0xe8682000u, 0x80220000u };
+    Rdna2Inst mt_d16 = rdna2_decode_one(mtbuf_d16, 2);
+    CHECK(mt_d16.fmt == Rdna2Format::MTBUF && mt_d16.opcode == 8u &&
+              mt_d16.mtbuf_format == 13u,
+          "MTBUF decodes the split high opcode bit instead of aliasing D16 onto ordinary loads");
     // Exact DS_READ2_B32 words from Astro Bot's loading-surface compute producer. The packed
     // offset bytes are dword indices (offset0 in the low byte, offset1 in the high byte).
     const uint32_t ds_read2_adjacent[] = { 0xd8dc0100u, 0x04000002u };

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -131,6 +131,11 @@ int main() {
     CHECK(mt_d16.fmt == Rdna2Format::MTBUF && mt_d16.opcode == 8u &&
               mt_d16.mtbuf_format == 13u,
           "MTBUF decodes the split high opcode bit instead of aliasing D16 onto ordinary loads");
+    const uint32_t mtbuf_tfe[] = { 0xe8b02000u, 0x80820100u };
+    Rdna2Inst mt_tfe = rdna2_decode_one(mtbuf_tfe, 2);
+    CHECK(mt_tfe.fmt == Rdna2Format::MTBUF && mt_tfe.opcode == 0u &&
+              mt_tfe.mtbuf_format == 22u && mt_tfe.mtbuf_tfe,
+          "MTBUF decodes TFE instead of silently dropping its status destination");
     // Exact DS_READ2_B32 words from Astro Bot's loading-surface compute producer. The packed
     // offset bytes are dword indices (offset0 in the low byte, offset1 in the high byte).
     const uint32_t ds_read2_adjacent[] = { 0xd8dc0100u, 0x04000002u };

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -103,6 +103,27 @@ int main() {
           isS(mb.src[1], 8) && ((mb.literal >> 12) & 1u), "buffer_load_dwordx4 MUBUF op/VDATA/VADDR/SRSRC/offen");
     CHECK(mb.src[2].kind == OperandKind::InlineInt && mb.src[2].value == 0,
           "MUBUF SOFFSET 0x80 decodes as inline 0, not SGPR s0");
+    // gfx1030 llvm-mc: tbuffer_load_format_xy v[4:5], v2, s[8:11], s12
+    // format:[BUF_FMT_16_16_FLOAT] offen offset:52. MTBUF uses the Gen5 combined format 29,
+    // not the old split DFMT=13/NFMT=1 interpretation of those same seven bits.
+    const uint32_t mtbuf_load[] = { 0xe8e91034u, 0x0c020402u };
+    Rdna2Inst mt_load = rdna2_decode_one(mtbuf_load, 2);
+    CHECK(mt_load.fmt == Rdna2Format::MTBUF && mt_load.opcode == 1u &&
+              mt_load.mtbuf_format == 29u && isV(mt_load.dst, 4) &&
+              isV(mt_load.src[0], 2) && isS(mt_load.src[1], 8) &&
+              isS(mt_load.src[2], 12) && (mt_load.literal & 0xfffu) == 52u &&
+              ((mt_load.literal >> 12) & 1u) && !((mt_load.literal >> 13) & 1u),
+          "MTBUF load decodes opcode, combined format, operands, offset, and OFFEN");
+    // gfx1030 llvm-mc: tbuffer_store_format_xyzw v[32:35], v8, s[32:35], 0
+    // format:[BUF_FMT_8_8_8_8_UINT] idxen.
+    const uint32_t mtbuf_store[] = { 0xe9e72000u, 0x80082008u };
+    Rdna2Inst mt_store = rdna2_decode_one(mtbuf_store, 2);
+    CHECK(mt_store.fmt == Rdna2Format::MTBUF && mt_store.opcode == 7u &&
+              mt_store.mtbuf_format == 60u && isV(mt_store.dst, 32) &&
+              isV(mt_store.src[0], 8) && isS(mt_store.src[1], 32) &&
+              mt_store.src[2].kind == OperandKind::InlineInt &&
+              mt_store.src[2].value == 0 && ((mt_store.literal >> 13) & 1u),
+          "MTBUF store decodes opcode, combined format, operands, and IDXEN");
     // Exact DS_READ2_B32 words from Astro Bot's loading-surface compute producer. The packed
     // offset bytes are dword indices (offset0 in the low byte, offset1 in the high byte).
     const uint32_t ds_read2_adjacent[] = { 0xd8dc0100u, 0x04000002u };

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -777,6 +777,29 @@ int main() {
                          sizeof(code23mt_badfmt)/sizeof(code23mt_badfmt[0]),
                          1, 1, &rt23mt).empty(),
           "MTBUF unknown combined format is rejected instead of silently read as raw dwords");
+    // gfx1030 MTBUF forces identity selection from its instruction format. A four-component opcode
+    // reading a three-component 32_32_32_FLOAT element therefore returns XYZ0 (not MUBUF's XYZ1).
+    const uint32_t code23mt_identity[] = {
+        0x7e000f00u, 0xea532000u, 0x80020100u, 0xbf810000u,
+    };
+    ShaderResourceTable rt23mt_identity;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
+      vb.num_components = 4; vb.binding = 3; vb.stride = 12; vb.sgpr_base = 8;
+      rt23mt_identity.resources.push_back(vb); }
+    std::vector<uint32_t> vbuf23mt_identity(N * 3u);
+    for (uint32_t i = 0; i < N; ++i) {
+        const float xyz[3] = { (float)i, (float)i + 1.0f, (float)i + 2.0f };
+        std::memcpy(vbuf23mt_identity.data() + i * 3u, xyz, sizeof(xyz));
+    }
+    std::vector<uint32_t> spv23mt_identity = recompile_valu(
+        code23mt_identity, sizeof(code23mt_identity)/sizeof(code23mt_identity[0]),
+        1, 4, &rt23mt_identity);
+    std::vector<float> got23mt_identity = prosper::test::run_compute(
+        spv23mt_identity, in23, N, N, {}, vbuf23mt_identity);
+    bool identity_zero = got23mt_identity.size() == N;
+    for (float w : got23mt_identity) identity_zero &= w == 0.0f;
+    CHECK(!spv23mt_identity.empty() && identity_zero,
+          "MTBUF identity selection fills absent W with zero");
 
     // A pc-keyed VertexBuffer is not necessarily the NGG v0 fetch prologue. DOLL's skinned scene
     // shaders use a direct structured V# through computed VADDRs (v4/v5/v7/...); the old shortcut

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -928,6 +928,30 @@ int main() {
     CHECK(!spv24mt_store.empty() && packed_store_out.size() == N && bad24mt_store == 0,
           "MTBUF 8_8_8_8_UNORM store packs and predicates instruction-typed components");
 
+    // A wider store opcode does not extend the physical format. BUF_FMT_16_16_FLOAT has identity
+    // XY00, so the Z/W source VGPRs must not spill into the next dword of each eight-byte record.
+    const uint32_t code24mt_store_xy00[] = {
+        0x7e020280u, 0x7e0402f0u, 0x7e0602f2u, 0x7e0802f2u, 0x7e0a0f00u,
+        0xe8ef2000u, 0x80020105u, 0xbf810000u,
+    };
+    ShaderResourceTable rt24mt_store_xy00 = rt24mt_store;
+    rt24mt_store_xy00.resources[0].stride = 8;
+    std::vector<uint32_t> spv24mt_store_xy00 = recompile_valu(
+        code24mt_store_xy00, sizeof(code24mt_store_xy00)/sizeof(code24mt_store_xy00[0]),
+        1, 0, &rt24mt_store_xy00);
+    std::vector<uint32_t> xy00_store_in(N * 2, 0xdeadbeefu), xy00_store_out;
+    prosper::test::run_compute(spv24mt_store_xy00, in24, N, N, {}, xy00_store_in,
+                               &xy00_store_out);
+    uint32_t bad24mt_store_xy00 = 0;
+    for (uint32_t i = 0; i < N && xy00_store_out.size() == N * 2; ++i) {
+        if (xy00_store_out[i * 2] != 0x38000000u ||
+            xy00_store_out[i * 2 + 1] != 0xdeadbeefu)
+            ++bad24mt_store_xy00;
+    }
+    CHECK(!spv24mt_store_xy00.empty() && xy00_store_out.size() == N * 2 &&
+              bad24mt_store_xy00 == 0,
+          "MTBUF XYZW store honors XY00 format width and leaves the adjacent dword untouched");
+
     // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
     // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
     // addr&3, so a non-aligned element base would decode the wrong bits — it must be REJECTED (the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -753,6 +753,31 @@ int main() {
     printf("  kernel23 mismatches=%u (out[5]=%g expect=6.5)\n", bad23, got23.size()==N?got23[5]:-1);
     CHECK(got23.size()==N && bad23==0, "recompiled kernel 23 (float32 vertex fetch via sgpr_base provenance) correct");
 
+    // MTBUF uses the same descriptor/address path, but its gfx1030 instruction owns the combined
+    // BUF_FMT. Deliberately give the resource misleading Uint8 metadata: tbuffer_load_format_x's
+    // encoded format 22 (32_FLOAT) must still fetch full float dwords.
+    const uint32_t code23mt[] = { 0x7e000f00u, 0xe8b02000u, 0x80020100u, 0xbf810000u };
+    ShaderResourceTable rt23mt;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Uint8;
+      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8;
+      rt23mt.resources.push_back(vb); }
+    std::vector<uint32_t> spv23mt = recompile_valu(
+        code23mt, sizeof(code23mt)/sizeof(code23mt[0]), 1, 1, &rt23mt);
+    std::vector<float> got23mt = prosper::test::run_compute(
+        spv23mt, in23, N, N, {}, vbuf23);
+    uint32_t bad23mt = 0;
+    for (uint32_t i = 0; i < N && got23mt.size() == N; ++i)
+        if (std::fabs(got23mt[i] - exp23[i]) > 1e-3f) ++bad23mt;
+    CHECK(!spv23mt.empty() && got23mt.size() == N && bad23mt == 0,
+          "MTBUF 32_FLOAT load uses the instruction format instead of V# metadata");
+    const uint32_t code23mt_badfmt[] = {
+        0x7e000f00u, 0xe8002000u, 0x80020100u, 0xbf810000u,
+    };
+    CHECK(recompile_valu(code23mt_badfmt,
+                         sizeof(code23mt_badfmt)/sizeof(code23mt_badfmt[0]),
+                         1, 1, &rt23mt).empty(),
+          "MTBUF unknown combined format is rejected instead of silently read as raw dwords");
+
     // A pc-keyed VertexBuffer is not necessarily the NGG v0 fetch prologue. DOLL's skinned scene
     // shaders use a direct structured V# through computed VADDRs (v4/v5/v7/...); the old shortcut
     // replaced all of them with gl_VertexIndex. Pin v1=1 and prove the fetch stays on record 1 for
@@ -839,6 +864,44 @@ int main() {
     uint32_t bad24 = 0; for (uint32_t i=0;i<N&&got24.size()==N;i++) if (std::fabs(got24[i]-exp24[i])>2e-3f) bad24++;
     printf("  kernel24 mismatches=%u (out[5]=%g expect=%g)\n", bad24, got24.size()==N?got24[5]:-1, got24.size()==N?exp24[5]:-1);
     CHECK(got24.size()==N && bad24==0, "recompiled kernel 24 (unorm8x4 -> 4 normalized floats) correct");
+
+    // The same packed conversion through MTBUF: opcode XYZW and combined format 56 are both carried
+    // by the instruction. Resource metadata is intentionally Float32x1 to catch accidental reuse.
+    const uint32_t code24mt[] = {
+        0x7e000f00u, 0xe9c32000u, 0x80020100u, 0x7e0a02f4u, 0x100c0505u,
+        0x06020d01u, 0x7e0a02f6u, 0x100c0905u, 0x06020d01u, 0x7e0a02ffu,
+        0x40400000u, 0x100c0705u, 0x06020d01u, 0xbf810000u,
+    };
+    ShaderResourceTable rt24mt;
+    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
+      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8;
+      rt24mt.resources.push_back(vb); }
+    std::vector<uint32_t> spv24mt = recompile_valu(
+        code24mt, sizeof(code24mt)/sizeof(code24mt[0]), 1, 1, &rt24mt);
+    std::vector<float> got24mt = prosper::test::run_compute(
+        spv24mt, in24, N, N, {}, vbuf24);
+    uint32_t bad24mt = 0;
+    for (uint32_t i = 0; i < N && got24mt.size() == N; ++i)
+        if (std::fabs(got24mt[i] - exp24[i]) > 2e-3f) ++bad24mt;
+    CHECK(!spv24mt.empty() && got24mt.size() == N && bad24mt == 0,
+          "MTBUF 8_8_8_8_UNORM load applies the instruction's packed conversion");
+
+    // Store the same constant normalized vector to every lane through MTBUF. Round-to-even maps
+    // 0.5*255 to 128, so each destination dword is RGBA = {0,128,255,255}.
+    const uint32_t code24mt_store[] = {
+        0x7e020280u, 0x7e0402f0u, 0x7e0602f2u, 0x7e0802f2u, 0x7e0a0f00u,
+        0xe9c72000u, 0x80020105u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv24mt_store = recompile_valu(
+        code24mt_store, sizeof(code24mt_store)/sizeof(code24mt_store[0]), 1, 0, &rt24mt);
+    std::vector<uint32_t> packed_store_in(N, 0), packed_store_out;
+    prosper::test::run_compute(spv24mt_store, in24, N, N, {}, packed_store_in,
+                               &packed_store_out);
+    uint32_t bad24mt_store = 0;
+    for (uint32_t word : packed_store_out)
+        if (word != 0xffff8000u) ++bad24mt_store;
+    CHECK(!spv24mt_store.empty() && packed_store_out.size() == N && bad24mt_store == 0,
+          "MTBUF 8_8_8_8_UNORM store packs and predicates instruction-typed components");
 
     // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
     // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
@@ -1068,6 +1131,23 @@ int main() {
     { float f5 = 0; if (stored_out.size()==N) std::memcpy(&f5, &stored_out[5], 4);
       printf("  kernel29 mismatches=%u (buf[5]=%g expect=10)\n", bad29, f5); }
     CHECK(stored_out.size() == N && bad29 == 0, "recompiled kernel 29 (MUBUF store writes buffer[gid]=2*gid) correct");
+
+    const uint32_t code29mt[] = {
+        0x7e040f00u, 0x06060100u, 0xe8b42000u, 0x80020302u, 0xbf810000u,
+    };
+    ShaderResourceTable rt29mt = rt29;
+    rt29mt.resources[0].format = DataFormat::Uint8; // MTBUF's encoded 32_FLOAT remains authoritative
+    std::vector<uint32_t> spv29mt = recompile_valu(
+        code29mt, sizeof(code29mt)/sizeof(code29mt[0]), 1, 0, &rt29mt);
+    std::vector<uint32_t> stored29mt(N, 0), stored29mt_out;
+    prosper::test::run_compute(spv29mt, in29, N, N, {}, stored29mt, &stored29mt_out);
+    uint32_t bad29mt = 0;
+    for (uint32_t i = 0; i < N && stored29mt_out.size() == N; ++i) {
+        float f = 0.0f; std::memcpy(&f, &stored29mt_out[i], sizeof(f));
+        if (std::fabs(f - 2.0f*(float)i) > 1e-3f) ++bad29mt;
+    }
+    CHECK(!spv29mt.empty() && stored29mt_out.size() == N && bad29mt == 0,
+          "MTBUF 32_FLOAT store writes instruction-typed dwords through descriptor provenance");
 
     // Kernel 30: EXEC-PREDICATED store. v_cmpx_lt_u32 narrows EXEC to lanes gid<4, then buffer_store_
     // format_x. Only active lanes must write (conditional store via a selection merge); lanes gid>=4

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -758,8 +758,8 @@ int main() {
     // encoded format 22 (32_FLOAT) must still fetch full float dwords.
     const uint32_t code23mt[] = { 0x7e000f00u, 0xe8b02000u, 0x80020100u, 0xbf810000u };
     ShaderResourceTable rt23mt;
-    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Uint8;
-      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8;
+    { ShaderResource vb{}; vb.cls = ResourceClass::ConstantBuffer; vb.format = DataFormat::Uint8;
+      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8; vb.fetch_pc = 1;
       rt23mt.resources.push_back(vb); }
     std::vector<uint32_t> spv23mt = recompile_valu(
         code23mt, sizeof(code23mt)/sizeof(code23mt[0]), 1, 1, &rt23mt);
@@ -783,8 +783,8 @@ int main() {
         0x7e000f00u, 0xea532000u, 0x80020100u, 0xbf810000u,
     };
     ShaderResourceTable rt23mt_identity;
-    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
-      vb.num_components = 4; vb.binding = 3; vb.stride = 12; vb.sgpr_base = 8;
+    { ShaderResource vb{}; vb.cls = ResourceClass::ConstantBuffer; vb.format = DataFormat::Float32;
+      vb.num_components = 4; vb.binding = 3; vb.stride = 12; vb.sgpr_base = 8; vb.fetch_pc = 1;
       rt23mt_identity.resources.push_back(vb); }
     std::vector<uint32_t> vbuf23mt_identity(N * 3u);
     for (uint32_t i = 0; i < N; ++i) {
@@ -896,8 +896,8 @@ int main() {
         0x40400000u, 0x100c0705u, 0x06020d01u, 0xbf810000u,
     };
     ShaderResourceTable rt24mt;
-    { ShaderResource vb{}; vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
-      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8;
+    { ShaderResource vb{}; vb.cls = ResourceClass::ConstantBuffer; vb.format = DataFormat::Float32;
+      vb.num_components = 1; vb.binding = 3; vb.stride = 4; vb.sgpr_base = 8; vb.fetch_pc = 1;
       rt24mt.resources.push_back(vb); }
     std::vector<uint32_t> spv24mt = recompile_valu(
         code24mt, sizeof(code24mt)/sizeof(code24mt[0]), 1, 1, &rt24mt);
@@ -915,8 +915,10 @@ int main() {
         0x7e020280u, 0x7e0402f0u, 0x7e0602f2u, 0x7e0802f2u, 0x7e0a0f00u,
         0xe9c72000u, 0x80020105u, 0xbf810000u,
     };
+    ShaderResourceTable rt24mt_store = rt24mt;
+    rt24mt_store.resources[0].fetch_pc = 5;
     std::vector<uint32_t> spv24mt_store = recompile_valu(
-        code24mt_store, sizeof(code24mt_store)/sizeof(code24mt_store[0]), 1, 0, &rt24mt);
+        code24mt_store, sizeof(code24mt_store)/sizeof(code24mt_store[0]), 1, 0, &rt24mt_store);
     std::vector<uint32_t> packed_store_in(N, 0), packed_store_out;
     prosper::test::run_compute(spv24mt_store, in24, N, N, {}, packed_store_in,
                                &packed_store_out);
@@ -1160,6 +1162,7 @@ int main() {
     };
     ShaderResourceTable rt29mt = rt29;
     rt29mt.resources[0].format = DataFormat::Uint8; // MTBUF's encoded 32_FLOAT remains authoritative
+    rt29mt.resources[0].fetch_pc = 2;
     std::vector<uint32_t> spv29mt = recompile_valu(
         code29mt, sizeof(code29mt)/sizeof(code29mt[0]), 1, 0, &rt29mt);
     std::vector<uint32_t> stored29mt(N, 0), stored29mt_out;

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -31,6 +31,12 @@ int main() {
     CHECK(mtbuf.total == 1 && mtbuf.table_dependent == 1 && mtbuf.unsupported == 0 &&
           mtbuf.first_bad_fmt < 0,
           "MTBUF typed loads are reported as resource-table-dependent coverage");
+    const uint32_t mtbuf_d16_code[] = { 0xe8682000u, 0x80220000u, 0xBF810000u };
+    RecompileCoverage mtbuf_d16 = recompile_coverage(
+        mtbuf_d16_code, sizeof(mtbuf_d16_code)/sizeof(mtbuf_d16_code[0]));
+    CHECK(mtbuf_d16.total == 1 && mtbuf_d16.table_dependent == 0 &&
+          mtbuf_d16.unsupported == 1 && mtbuf_d16.first_bad_op == 8u,
+          "unimplemented MTBUF D16 remains an explicit unsupported opcode");
 
     // Contains an unsupported op: v_add_f32 ; s_branch +5 (unconditional -> rejected) ; s_endpgm.
     const uint32_t bad_code[] = { 0x06000300u, 0xbf820005u, 0xBF810000u };

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -22,6 +22,16 @@ int main() {
     CHECK(a.total == 2 && a.alu == 2 && a.unsupported == 0 && a.first_bad_fmt < 0,
           "a fully-handled ALU kernel reports 100% coverage");
 
+    // tbuffer_load_format_x v0, v0, s[8:11], 0 format:32_FLOAT ; s_endpgm.
+    // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as
+    // recompilable-in-context rather than truly unsupported.
+    const uint32_t mtbuf_code[] = { 0xe8b02000u, 0x80020100u, 0xBF810000u };
+    RecompileCoverage mtbuf = recompile_coverage(mtbuf_code,
+                                                  sizeof(mtbuf_code)/sizeof(mtbuf_code[0]));
+    CHECK(mtbuf.total == 1 && mtbuf.table_dependent == 1 && mtbuf.unsupported == 0 &&
+          mtbuf.first_bad_fmt < 0,
+          "MTBUF typed loads are reported as resource-table-dependent coverage");
+
     // Contains an unsupported op: v_add_f32 ; s_branch +5 (unconditional -> rejected) ; s_endpgm.
     const uint32_t bad_code[] = { 0x06000300u, 0xbf820005u, 0xBF810000u };
     RecompileCoverage b = recompile_coverage(bad_code, sizeof(bad_code)/sizeof(bad_code[0]));

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -37,6 +37,12 @@ int main() {
     CHECK(mtbuf_d16.total == 1 && mtbuf_d16.table_dependent == 0 &&
           mtbuf_d16.unsupported == 1 && mtbuf_d16.first_bad_op == 8u,
           "unimplemented MTBUF D16 remains an explicit unsupported opcode");
+    const uint32_t mtbuf_tfe_code[] = { 0xe8b02000u, 0x80820100u, 0xBF810000u };
+    RecompileCoverage mtbuf_tfe = recompile_coverage(
+        mtbuf_tfe_code, sizeof(mtbuf_tfe_code)/sizeof(mtbuf_tfe_code[0]));
+    CHECK(mtbuf_tfe.total == 1 && mtbuf_tfe.table_dependent == 0 &&
+          mtbuf_tfe.unsupported == 1 && mtbuf_tfe.first_bad_op == 0u,
+          "MTBUF TFE remains explicit unsupported coverage until its status write is modeled");
 
     // Contains an unsupported op: v_add_f32 ; s_branch +5 (unconditional -> rejected) ; s_endpgm.
     const uint32_t bad_code[] = { 0x06000300u, 0xbf820005u, 0xBF810000u };


### PR DESCRIPTION
## Summary
- decode all eight gfx1030 MTBUF typed load/store opcodes and their operands/address fields
- use the instruction's authoritative combined seven-bit BUF_FMT while retaining existing descriptor provenance, addressing, conversions, predication, and fail-closed behavior
- carry MTBUF format metadata through graphics and compute resource discovery
- add deterministic decoder, resource-discovery, coverage, and executed SPIR-V regressions

## Author checks before publication
- Linux: rdna2_decode_walk, dynfetch_fold, recompile_coverage, rdna2_to_spirv_exec
- Windows: rdna2_decode_walk, dynfetch_fold, recompile_coverage
- git diff --check

No game/image snapshot workflow was run.

Fixes #366