### PR TITLE
perf: compare cached texture sources directly

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -268,6 +268,10 @@ default budget is 1 GiB, which covers Evergate's measured 835 MiB working set; u
 `PROSPER_NO_TEXTURE_DECODE_CACHE=1` for an A/B run. Timing reports cross-submit `texture_cache`
 hits/misses/invalidations separately from `textures` (all texture uses) and `reused` (both local and
 persistent decodes avoided).
+Complete readable source ranges are compared directly against the cache's retained encoded bytes;
+partial sparse ranges keep the guarded scratch-copy fallback. This preserves the same exact byte and
+readability checks without copying large texture sources before comparing them. Set
+`PROSPER_TEXTURE_VALIDATION_SCRATCH_COPY=1` for an A/B against the previous copy-then-compare path.
 
 The Vulkan backend may retain an optimal sampled image only when that exact frontend validation
 supplies a nonzero content-version ID. Cache hits skip image allocation, staging allocation, pixel

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -798,6 +798,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                             cached->second.pixels.data(), r.gpu_addr,
                                             persistent_source_size, validated_bytes) &&
                                             validated_bytes == cached->second.source_prefix_size;
+                                    } else if (!getenv("PROSPER_TEXTURE_VALIDATION_SCRATCH_COPY") &&
+                                               cached->second.source_prefix.size() ==
+                                                   persistent_source_size) {
+                                        // The cached prefix owns the complete encoded texture. Compare
+                                        // guest memory directly against it: copying the same 100+ MiB
+                                        // working set into a scratch buffer before memcmp doubled the
+                                        // validation traffic on every Evergate frame. safe_equal keeps
+                                        // the same sparse-page/readability guards and exact byte check.
+                                        matches = safe_equal(
+                                            cached->second.source_prefix.data(), r.gpu_addr,
+                                            persistent_source_size, validated_bytes) &&
+                                            validated_bytes == persistent_source_size;
                                     } else {
                                         persistent_validation_scratch.resize(persistent_source_size);
                                         validated_bytes = copy_resource(


### PR DESCRIPTION
Closes #702.

## Problem

Evergate's heavy 450-490 draw submits validate about 128 MiB of unchanged sampled-texture source data every frame. For tiled and compressed sources, the persistent decode cache copied the complete guest range into a scratch vector and then compared that copy with the retained encoded bytes. This doubled full-working-set memory traffic before an otherwise valid cache hit.

## Change

When a cache entry owns the complete encoded source range, compare guest memory directly against those retained bytes with the existing sparse-safe exact comparator. Partial/sparse source prefixes retain the guarded copy-and-compare fallback. Shader resources, decoded pixels, content-version IDs, invalidation rules, and cross-submit freshness semantics are unchanged.

`PROSPER_TEXTURE_VALIDATION_SCRATCH_COPY=1` restores the previous path for an A/B.

## Performance

Paired native Windows fresh-save runs used the same binary, route, native resolution, render-every-submit pacing, and 60-second window.

- Previous scratch path: heavy texture resource work 40.7-43.9 ms/submit.
- Direct exact comparison: 25.6-32.2 ms/submit.
- Saving: about 12-15 ms/submit while validating the same ~128 MiB/submit.
- Both paths reported zero texture-cache invalidations; the treatment reached 540 presented frames versus 360 in the same wall-clock window (scene cadence varies, so the resource-specific timings are the primary comparison).

## Correctness and scope

- Complete readable ranges still require an exact byte-for-byte match.
- Readability/mapping changes still fail the complete-range check.
- Partial sparse sources keep the prior guarded scratch fallback.
- Windows protection-fault write watches remain disabled; this does not change the SysV red-zone safety contract.

## Verification

- Linux build and 111/111 tests passed.
- Windows build and 86/86 tests passed.
- Full local snapshot matrix completed successfully: Messenger, Evergate, Dead Cells, and Blasphemous 2.