### PR TITLE
fix(recompiler): structure terminal if-else arms

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1603,7 +1603,9 @@ struct SpirvCompute {
 // Immediate-end/nop-end tails remain the established early-out shape and are not rewritten.
 static bool extend_terminating_if_else(const uint32_t* code, size_t dwords,
                                        std::vector<Rdna2Inst>& instructions,
-                                       size_t* required_dwords = nullptr) {
+                                       size_t* required_dwords = nullptr,
+                                       uint32_t* synthetic_branch_pc = nullptr) {
+    if (synthetic_branch_pc) *synthetic_branch_pc = UINT32_MAX;
     if (!code || instructions.empty()) return false;
     auto first_end = std::find_if(instructions.begin(), instructions.end(),
                                   [](const Rdna2Inst& in) { return in.is_end; });
@@ -1647,6 +1649,7 @@ static bool extend_terminating_if_else(const uint32_t* code, size_t dwords,
     first_end->simm16 = static_cast<int32_t>(skip_dwords);
     first_end->words[0] = 0xbf820000u | (skip_dwords & 0xffffu);
     first_end->is_end = false;
+    if (synthetic_branch_pc) *synthetic_branch_pc = first_end->pc;
     instructions.insert(instructions.end(), tail.begin(), tail.end());
     if (required_dwords) *required_dwords = target + tail_dwords;
     return true;
@@ -7599,7 +7602,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
-    (void)extend_terminating_if_else(code, dwords, ins);
+    uint32_t synthetic_branch_pc = UINT32_MAX;
+    (void)extend_terminating_if_else(code, dwords, ins, nullptr, &synthetic_branch_pc);
 
     // A scratch builder/state so emit_alu can run; its emitted code is discarded — we only want `ok`.
     SpirvCompute b; b.begin(1);
@@ -7624,6 +7628,10 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     RecompileCoverage cov;
     for (const auto& in : ins) {
         if (in.is_end) break;
+        // The rewritten first s_endpgm is compiler-only control flow. It lets the structured emitter
+        // reuse its ordinary if/else path, but coverage describes decoded guest instructions and has
+        // always excluded s_endpgm, so do not inflate total/ALU with this synthetic arm skip.
+        if (in.pc == synthetic_branch_pc) continue;
         cov.total++;
         if (in.fmt == Rdna2Format::EXP) { cov.exports++; continue; }   // handled by the stage recompilers
         bool ok = true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1587,6 +1587,71 @@ struct SpirvCompute {
 
 }  // namespace
 
+// Extend the narrow compiler shape
+//
+//   s_cbranch_scc* ELSE
+//   THEN...
+//   s_endpgm
+// ELSE:
+//   ELSE...
+//   s_endpgm
+//
+// into the existing structured-if/else input. The first s_endpgm is represented as a synthetic
+// s_branch to the second end, which is semantically exact: it skips the other terminating arm, while
+// the shared SPIR-V shell may still converge solely to publish outputs/return. Keep this deliberately
+// conservative: one scalar conditional, adjacent straight-line else arm, and a real terminating end.
+// Immediate-end/nop-end tails remain the established early-out shape and are not rewritten.
+static bool extend_terminating_if_else(const uint32_t* code, size_t dwords,
+                                       std::vector<Rdna2Inst>& instructions,
+                                       size_t* required_dwords = nullptr) {
+    if (!code || instructions.empty()) return false;
+    auto first_end = std::find_if(instructions.begin(), instructions.end(),
+                                  [](const Rdna2Inst& in) { return in.is_end; });
+    if (first_end == instructions.end()) return false;
+
+    const Rdna2Inst* branch = nullptr;
+    for (auto it = instructions.begin(); it != first_end; ++it) {
+        if (it->fmt != Rdna2Format::SOPP) continue;
+        if (it->opcode == 0x04 || it->opcode == 0x05) {
+            if (branch) return false;
+            branch = &*it;
+        } else if (it->opcode >= 0x02 && it->opcode <= 0x09 && it->opcode != 0x03) {
+            return false;
+        }
+    }
+    if (!branch || branch->simm16 <= 0) return false;
+    const int64_t target64 = static_cast<int64_t>(branch->pc) + branch->len_dwords + branch->simm16;
+    if (target64 < 0 || static_cast<uint64_t>(target64) >= dwords) return false;
+    const uint32_t target = static_cast<uint32_t>(target64);
+    if (target != first_end->pc + first_end->len_dwords) return false;
+
+    std::vector<Rdna2Inst> tail;
+    const size_t tail_dwords = rdna2_walk(code + target, dwords - target, tail);
+    if (tail.empty() || !tail.back().is_end) return false;
+    bool has_real_else = false;
+    for (auto it = tail.begin(); it != tail.end() - 1; ++it) {
+        if (it->fmt == Rdna2Format::SOPP) {
+            if (it->opcode == 0x00) continue; // padding is harmless but not a real else arm
+            if (it->opcode >= 0x02 && it->opcode <= 0x09 && it->opcode != 0x03) return false;
+        }
+        has_real_else = true;
+    }
+    if (!has_real_else) return false;
+
+    for (auto& in : tail) in.pc += target;
+    const uint32_t merge_pc = tail.back().pc;
+    const uint32_t skip_dwords = merge_pc - (first_end->pc + first_end->len_dwords);
+    if (!skip_dwords || skip_dwords > static_cast<uint32_t>(INT16_MAX)) return false;
+    first_end->fmt = Rdna2Format::SOPP;
+    first_end->opcode = 0x02; // s_branch merge_pc: terminates the lexical then arm
+    first_end->simm16 = static_cast<int32_t>(skip_dwords);
+    first_end->words[0] = 0xbf820000u | (skip_dwords & 0xffffu);
+    first_end->is_end = false;
+    instructions.insert(instructions.end(), tail.begin(), tail.end());
+    if (required_dwords) *required_dwords = target + tail_dwords;
+    return true;
+}
+
 FragmentInterpolationLayout fragment_interpolation_layout(
         const uint32_t* code, size_t dwords,
         const PixelSystemInputMapping* system_inputs) {
@@ -5950,6 +6015,10 @@ size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     const size_t program_dwords = rdna2_walk(code, dwords, ins);
     size_t required = program_dwords;
+    std::vector<Rdna2Inst> terminating_cfg = ins;
+    size_t terminating_span = program_dwords;
+    if (extend_terminating_if_else(code, dwords, terminating_cfg, &terminating_span))
+        required = std::max(required, terminating_span);
     // Detection both proves the compiler idiom and bounds every referenced table. Do not retain an
     // arbitrary post-ENDPGM trailer: only bytes that can affect the generated SPIR-V belong in the key.
     (void)detect_pcrel_tables(ins, code, dwords, &required);
@@ -7425,6 +7494,10 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      const ShaderResourceTable* rt, uint32_t lds_bytes) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
+    // This shell publishes register state after the structured region, so both terminal arms can
+    // converge in the host SPIR-V without inventing further guest execution. Graphics exports keep
+    // separate side-effect bookkeeping and remain on the conservative reject path for this shape.
+    (void)extend_terminating_if_else(code, dwords, ins);
     SpirvCompute b;
     // Size the LDS array from the shader's real allocation when known (#130): bytes -> dwords, at
     // least the ds ops need, clamped to the RDNA2 64 KB (16384-dword) max. 0 keeps the 16 KB default.
@@ -7454,6 +7527,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ComputeShaderConfig& config) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
+    // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is
+    // only a place to finish the invocation after either guest arm has terminated.
+    (void)extend_terminating_if_else(code, dwords, ins);
     SpirvCompute b;
     if (config.lds_bytes) {
         uint32_t dw = (config.lds_bytes + 3) / 4;
@@ -7523,6 +7599,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
+    (void)extend_terminating_if_else(code, dwords, ins);
 
     // A scratch builder/state so emit_alu can run; its emitted code is discarded — we only want `ok`.
     SpirvCompute b; b.begin(1);
@@ -7539,7 +7616,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                                                           /*compute_wave_branches*/true);   // matches the compute shell (#590)
     auto cf_reconstructed = [&](const Rdna2Inst& i) {
         if (cL.found && (i.pc == cL.backedge_pc || i.pc == cL.exit_branch_pc)) return true;
-        for (const auto& F : cFs) if (i.pc == F.branch_pc) return true;
+        for (const auto& F : cFs)
+            if (i.pc == F.branch_pc || (F.has_else && i.pc == F.sb_pc)) return true;
         return false;
     };
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6024,7 +6024,7 @@ size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords) {
         required = std::max(required, terminating_span);
     // Detection both proves the compiler idiom and bounds every referenced table. Do not retain an
     // arbitrary post-ENDPGM trailer: only bytes that can affect the generated SPIR-V belong in the key.
-    (void)detect_pcrel_tables(ins, code, dwords, &required);
+    (void)detect_pcrel_tables(terminating_cfg, code, dwords, &required);
     const PcrelDispatchInfo dispatch = detect_pcrel_dispatch(ins, code, dwords, program_dwords);
     if (dispatch.valid) required = std::max(required, dispatch.required_dwords);
     return std::min(required, dwords);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2381,40 +2381,54 @@ int main() {
 
     // Kernels J1/J2/J3: forward-branch targets PAST the first s_endpgm (#129). A branch past
     // s_endpgm is a benign early-out ONLY if execution at the target immediately terminates
-    // (s_nop* then s_endpgm). Real code at the target (an else-block) used to be silently
-    // discarded by a blanket clamp — valid SPIR-V, wrong semantics; it must now REJECT.
+    // (s_nop* then s_endpgm). Real straight-line code at the target is a second terminating arm;
+    // it must execute as a structured if/else rather than being silently discarded by a clamp.
     // Shape: s0=7; s1=7|8; s_cmp_eq_u32; s_cbranch_scc0 +3 (-> pc7); v0=42.0; s_endpgm; <target...>
     //   J1: target is s_endpgm            -> accept; SCC=1 runs the block (42), SCC=0 skips (input)
-    //   J2: target is REAL code (v0=9.0)  -> REJECT (was: clamped, taken path silently lost v0=9)
+    //   J2: target is REAL code (v0=9.0)  -> accept; SCC=1 selects 42, SCC=0 selects 9
     //   J3: target is s_nop; s_endpgm     -> accept (nop padding before the end is still an early-out)
     // Encodings llvm-mc gfx1030 verified.
     const uint32_t codeJ1t[] = { 0xbe800387u, 0xbe810387u, 0xbf060100u, 0xbf840003u,
                                  0x7e0002ffu, 0x42280000u, 0xbf810000u, 0xbf810000u };
     const uint32_t codeJ1f[] = { 0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
                                  0x7e0002ffu, 0x42280000u, 0xbf810000u, 0xbf810000u };
-    const uint32_t codeJ2[]  = { 0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
+    const uint32_t codeJ2t[] = { 0xbe800387u, 0xbe810387u, 0xbf060100u, 0xbf840003u,
+                                 0x7e0002ffu, 0x42280000u, 0xbf810000u,
+                                 0x7e0002ffu, 0x41100000u, 0xbf810000u };
+    const uint32_t codeJ2e[] = { 0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
                                  0x7e0002ffu, 0x42280000u, 0xbf810000u,
                                  0x7e0002ffu, 0x41100000u, 0xbf810000u };
     const uint32_t codeJ3[]  = { 0xbe800387u, 0xbe810387u, 0xbf060100u, 0xbf840003u,
                                  0x7e0002ffu, 0x42280000u, 0xbf810000u, 0xbf800000u, 0xbf810000u };
     std::vector<uint32_t> spvJ1t = recompile_valu(codeJ1t, sizeof(codeJ1t)/sizeof(codeJ1t[0]), 1, 0);
     std::vector<uint32_t> spvJ1f = recompile_valu(codeJ1f, sizeof(codeJ1f)/sizeof(codeJ1f[0]), 1, 0);
-    std::vector<uint32_t> spvJ2  = recompile_valu(codeJ2,  sizeof(codeJ2)/sizeof(codeJ2[0]),  1, 0);
+    std::vector<uint32_t> spvJ2t = recompile_valu(codeJ2t, sizeof(codeJ2t)/sizeof(codeJ2t[0]), 1, 0);
+    std::vector<uint32_t> spvJ2e = recompile_valu(codeJ2e, sizeof(codeJ2e)/sizeof(codeJ2e[0]), 1, 0);
     std::vector<uint32_t> spvJ3  = recompile_valu(codeJ3,  sizeof(codeJ3)/sizeof(codeJ3[0]),  1, 0);
     CHECK(!spvJ1t.empty() && !spvJ1f.empty(), "kernel J1 (early-out branch to a trailing s_endpgm) -> SPIR-V");
-    CHECK(spvJ2.empty(), "kernel J2 (branch past s_endpgm into REAL code) is REJECTED, not clamped");
+    CHECK(!spvJ2t.empty() && !spvJ2e.empty(),
+          "kernel J2 (branch past s_endpgm) emits both terminating if/else arms");
+    CHECK(rdna2_recompile_code_span(codeJ2t, sizeof(codeJ2t)/sizeof(codeJ2t[0])) ==
+              sizeof(codeJ2t)/sizeof(codeJ2t[0]),
+          "kernel J2 code span includes the reachable post-endpgm else arm");
     CHECK(!spvJ3.empty(), "kernel J3 (early-out through s_nop padding) -> SPIR-V");
     std::vector<float> inJ(N);
     for (uint32_t i = 0; i < N; i++) inJ[i] = (float)i * 0.25f;
     std::vector<float> gotJt = prosper::test::run_compute(spvJ1t, inJ, N, N);
     std::vector<float> gotJf = prosper::test::run_compute(spvJ1f, inJ, N, N);
-    uint32_t badJ = 0;
+    std::vector<float> gotJ2t = prosper::test::run_compute(spvJ2t, inJ, N, N);
+    std::vector<float> gotJ2e = prosper::test::run_compute(spvJ2e, inJ, N, N);
+    uint32_t badJ = 0, badJ2 = 0;
     for (uint32_t i = 0; i < N && gotJt.size() == N; i++) if (std::fabs(gotJt[i] - 42.0f) > 1e-3f) badJ++;
     for (uint32_t i = 0; i < N && gotJf.size() == N; i++) if (std::fabs(gotJf[i] - inJ[i]) > 1e-3f) badJ++;
+    for (uint32_t i = 0; i < N && gotJ2t.size() == N; i++) if (std::fabs(gotJ2t[i] - 42.0f) > 1e-3f) badJ2++;
+    for (uint32_t i = 0; i < N && gotJ2e.size() == N; i++) if (std::fabs(gotJ2e[i] - 9.0f) > 1e-3f) badJ2++;
     printf("  kernelJ mismatches=%u (scc1->%g expect 42, scc0->%g expect %g)\n", badJ,
            gotJt.size()==N?gotJt[8]:-1, gotJf.size()==N?gotJf[8]:-1, inJ[8]);
     CHECK(gotJt.size()==N && gotJf.size()==N && badJ==0,
           "kernel J1 early-out: block runs on SCC=1 (42), skipped on SCC=0 (input)");
+    CHECK(gotJ2t.size()==N && gotJ2e.size()==N && badJ2==0,
+          "kernel J2 terminating if/else: SCC=1 selects 42 and SCC=0 selects 9");
 
     // Kernels S1/S2: v_cvt_u32_f32 / v_cvt_i32_f32 SATURATION (#135). RDNA2 saturates the
     // float->int converts (NaN -> 0, negative -> 0 for u32, out-of-range clamps to the type

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -61,8 +61,10 @@ int main() {
     };
     RecompileCoverage terminal = recompile_coverage(
         terminating_if_else, sizeof(terminating_if_else)/sizeof(terminating_if_else[0]));
-    CHECK(terminal.unsupported == 0 && terminal.first_bad_fmt < 0,
-          "a terminating post-endpgm if/else reports fully structured coverage");
+    CHECK(terminal.total == 6 && terminal.alu == 6 && terminal.exports == 0 &&
+              terminal.table_dependent == 0 && terminal.unsupported == 0 &&
+              terminal.first_bad_fmt < 0,
+          "a terminating post-endpgm if/else reports six real guest instructions as structured");
 
     // A forward VCC branch is not covered by EXEC predication. Treating it as a no-op would execute
     // the skipped block even when VCC says to branch, so the recompiler must reject it for now.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -51,6 +51,19 @@ int main() {
     CHECK(b.total == 2 && b.alu == 1 && b.unsupported == 1 && b.first_bad_fmt >= 0 && b.first_bad_op == 0x02,
           "an unconditional s_branch is reported as the first unsupported instruction");
 
+    // A scalar conditional whose target is a straight-line second arm after the first s_endpgm is
+    // structured as two terminating arms. Coverage must credit both the conditional and the synthetic
+    // arm-skip rather than reporting either branch as unsupported.
+    const uint32_t terminating_if_else[] = {
+        0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
+        0x7e0002ffu, 0x42280000u, 0xbf810000u,
+        0x7e0002ffu, 0x41100000u, 0xbf810000u,
+    };
+    RecompileCoverage terminal = recompile_coverage(
+        terminating_if_else, sizeof(terminating_if_else)/sizeof(terminating_if_else[0]));
+    CHECK(terminal.unsupported == 0 && terminal.first_bad_fmt < 0,
+          "a terminating post-endpgm if/else reports fully structured coverage");
+
     // A forward VCC branch is not covered by EXEC predication. Treating it as a no-op would execute
     // the skipped block even when VCC says to branch, so the recompiler must reject it for now.
     const uint32_t vcc_branch[] = { 0x7da80300u, 0xbf860001u, 0x4a060300u, 0xBF810000u };

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -52,8 +52,8 @@ int main() {
           "an unconditional s_branch is reported as the first unsupported instruction");
 
     // A scalar conditional whose target is a straight-line second arm after the first s_endpgm is
-    // structured as two terminating arms. Coverage must credit both the conditional and the synthetic
-    // arm-skip rather than reporting either branch as unsupported.
+    // structured as two terminating arms. Coverage credits the guest conditional while excluding the
+    // compiler-only arm skip that replaces the first s_endpgm.
     const uint32_t terminating_if_else[] = {
         0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
         0x7e0002ffu, 0x42280000u, 0xbf810000u,

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -166,6 +166,29 @@ int main() {
               stats.misses == pcrel_stats.misses + 1,
           "embedded table contents participate in the shader cache key");
 
+    // A terminal if/else may build a PC-relative V# only in the second arm, after the first
+    // s_endpgm. Span analysis must use the same extended instruction stream as emission. Stopping at
+    // span pc20 immediately after the second end would omit four table dwords that can change SPIR-V.
+    const uint32_t terminal_pcrel[] = {
+        0xbe800387u, 0xbe810388u, 0xbf060100u, 0xbf840003u,
+        0x7e0002ffu, 0x42280000u, 0xbf810000u,
+        0xbe841f00u,               // pc7: s_getpc_b64 s[4:5] (next PC byte = 32)
+        0x800404b0u,               // pc8: s_add_u32 s4, 48, s4 (table byte = 80)
+        0x82050580u,               // pc9: s_addc_u32 s5, 0, s5
+        0xbe860390u,               // pc10: s_mov_b32 s6, 16 bytes
+        0xbe8703ffu, 0x10005004u,  // pc11: s_mov_b32 s7, V# format/stride
+        0x7e020f00u,               // pc13: v_cvt_u32_f32 v1, v0
+        0x34020282u,               // pc14: v_lshlrev_b32 v1, 2, v1
+        0xe0301000u, 0x80010101u,  // pc15: buffer_load_dword v1, v1, s[4:7], 0 offen
+        0xbf8c3f70u,               // pc17: s_waitcnt vmcnt(0)
+        0x7e000d01u,               // pc18: v_cvt_f32_u32 v0, v1
+        0xbf810000u,               // pc19: second s_endpgm
+        7u, 11u, 13u, 17u,        // pc20: embedded table used only by the else arm
+    };
+    CHECK(rdna2_recompile_code_span(terminal_pcrel, std::size(terminal_pcrel)) ==
+              std::size(terminal_pcrel),
+          "terminal else-arm PC-relative table participates in the owning shader span");
+
     // Unity emits a bounded uniform jump table for uber-shader variants. The selector is loaded from
     // a direct constant buffer, adjusted by -1, clamped, scaled by eight, then used by s_setpc_b64.
     // This compact synthetic stream has two paths which set v0 differently before a common export.


### PR DESCRIPTION
## Summary
- recognize the narrow `s_cbranch_scc*` shape whose target is a self-contained second arm immediately after the first `s_endpgm`
- represent the first terminal as the arm-skip consumed by the existing structured if/else emitter, preserving both SCC paths and the full shader-cache span
- keep graphics EXP shells on their conservative reject path because their branch-external export bookkeeping needs separate treatment
- turn kernel J2 into executed SCC=1/SCC=0 regressions and report the reconstructed control flow as covered

## Author pre-publish checks
- Linux: `messenger_recompile_guard`, `recompile_coverage`, `shader_recompile_cache`, `rdna2_decode_walk`, `rdna2_spirv_struct`, `rdna2_to_spirv_exec` — 6/6 passed
- Windows: `messenger_recompile_guard`, `recompile_coverage`, `shader_recompile_cache`, `rdna2_decode_walk`, `rdna2_spirv_struct` — 5/5 passed
- `git diff --check` — clean
- no game/image snapshots run

Fixes #178