### PR TITLE
perf: pool mapped backend storage buffers

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -250,6 +250,15 @@ object remains call-local and is destroyed after the existing fence wait, so thi
 freshness assumption. Set `PROSPER_NO_BACKEND_RESOURCE_SHARE=1` to disable the keyed object reuse for an
 A/B; the safe call-wide descriptor-pool consolidation remains enabled in both modes.
 
+Host-visible storage buffers use a separate bounded pool across backend calls. The backend waits for its
+fence before returning a buffer, retains its host-coherent allocation persistently mapped, and rewrites it
+before the next use. Power-of-two capacity classes absorb changing guest buffer sizes, while each Vulkan
+descriptor keeps the exact logical byte range, so pooling does not expose capacity padding to shaders.
+The thread-local pool is capped at 4096 buffers and 256 MiB by default; set
+`PROSPER_BACKEND_BUFFER_POOL_MB=<MiB>` to change the byte budget or
+`PROSPER_NO_BACKEND_BUFFER_POOL=1` for the former create/map/destroy path. With renderer timing enabled,
+`backend_buffer_pool` reports cumulative hits, misses, cached count/bytes, and evictions.
+
 The persistent compute device has the same exact-requirements allocation pool with a separate 256 MiB
 default budget (`PROSPER_COMPUTE_MEMORY_POOL_MB=<MiB>`). `PROSPER_NO_MEMORY_POOL=1` disables both
 graphics and compute pools. Decoded texture scratch vectors are also retained across callbacks; they

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -124,6 +124,42 @@ bundles. Evergate's instances were mostly unique, so hashing/key construction co
 objects and regressed a 476-draw window to 483.9 ms; that tranche was removed. The remaining major cost is
 still structural GPU submission/fence/readback ownership, not another broad exact-hash cache.
 
+## Evergate persistent host-buffer objects (2026-07-19)
+
+Call-local sharing still created roughly 170-180 distinct host-visible storage buffers in each backend
+call during Evergate's dense transition, then destroyed them after the fence. A frontend submit contains
+about 14 such calls. Fine-grained probes showed descriptor-pool, descriptor-layout, and descriptor-update
+work together below 0.1 ms/call; storage-buffer creation/upload cost 1-4 ms/call and buffer teardown another
+2-5 ms/call. The repeated Vulkan buffer-object lifecycle, not descriptor management, was the actionable
+resource cost.
+
+The backend now pools persistently mapped host-coherent buffers after the existing fence wait. Buffers use
+power-of-two capacities to avoid exact-size shape churn, but descriptor ranges remain the exact captured
+byte count. The cache is thread-local, bounded to 4096 entries / 256 MiB by default, and contains no guest
+identity or stale-content assumption: every checkout rewrites all shader-visible bytes. Set
+`PROSPER_NO_BACKEND_BUFFER_POOL=1` for the transient-object A/B or
+`PROSPER_BACKEND_BUFFER_POOL_MB=<MiB>` to change the byte budget.
+
+Native Windows / RTX 4090, one final binary, separate fresh saves, native scale/cadence, the documented
+route, normal renderer timing only, and matched dense 25-submit windows produced:
+
+| Measurement | Pool disabled | Capacity-class pool |
+|---|---:|---:|
+| Draws / submit | 479.3 | 483.6 |
+| Whole submit | 198.6 ms | 130.3 ms |
+| Backend execution | 151.0 ms | 81.5 ms |
+| Backend resource setup | 51.3 ms | 25.7 ms |
+| Backend cleanup | 48.7 ms | 4.8 ms |
+| GPU fence wait | 37.2 ms | 38.0 ms |
+| Observed rate near frame 360 | 3.2 FPS | 4.1 FPS |
+
+An initial exact-size pool was rejected: it filled the 4096-entry cap and accumulated about 20,000
+evictions, leaving setup/cleanup unchanged. Capacity classes stabilized at 2464 buffers / 7.4 MiB with
+zero evictions in the same transition; a detailed sample reached 203,263 hits after 2,464 compulsory
+misses. The flat GPU wait confirms the measured improvement comes from CPU Vulkan object lifetime rather
+than different GPU work. The next dense-scene costs are texture-binding setup and the synchronous
+submit/fence/readback architecture.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2614,6 +2614,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.backend_pipeline_bypasses / nsub,
                             (unsigned long long)totals.backend_pipeline_entries,
                             totals.backend_pipeline_evictions / nsub);
+                    const auto backend_buffers =
+                        prosper::test::render_host_buffer_pool_stats();
+                    fprintf(stderr,
+                            "[render-timing] backend_buffer_pool hits=%llu misses=%llu cached=%zu "
+                            "%.1f MiB evictions=%llu\n",
+                            (unsigned long long)backend_buffers.hits,
+                            (unsigned long long)backend_buffers.misses,
+                            backend_buffers.cached_buffers,
+                            backend_buffers.cached_bytes / (1024.0 * 1024.0),
+                            (unsigned long long)backend_buffers.evictions);
                     fprintf(stderr,
                             "[render-timing] color_targets writes=%llu load_hits=%llu sample_hits=%llu "
                             "readbacks=%llu deferred=%llu cached=%llu %.1f MiB\n",

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -650,6 +650,148 @@ inline uint32_t render_memory_type(VkPhysicalDevice phys, uint32_t bits,
     return UINT32_MAX;
 }
 
+// Storage-buffer contents are rewritten for every synchronous render call, but their Vulkan object
+// shapes repeat heavily. Keep capacity-class host-coherent buffers mapped between calls so the hot path
+// only copies bytes; each call waits for its fence before returning the buffers, so no in-flight GPU
+// work can observe a later upload. Capacity classes reduce shape churn; descriptors retain the exact
+// logical upload range, so pooling never broadens shader-visible storage.
+struct RenderHostBuffer {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    void* mapped = nullptr;
+    VkDeviceSize bytes = 0;
+    VkDeviceSize allocation_bytes = 0;
+};
+
+struct RenderHostBufferPool {
+    std::unordered_map<VkDeviceSize, std::vector<RenderHostBuffer>> available;
+    VkDeviceSize cached_bytes = 0;
+    size_t cached_buffers = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t evictions = 0;
+};
+
+struct RenderHostBufferPoolStats {
+    VkDeviceSize cached_bytes = 0;
+    size_t cached_buffers = 0;
+    uint64_t hits = 0;
+    uint64_t misses = 0;
+    uint64_t evictions = 0;
+};
+
+inline RenderHostBufferPool& render_host_buffer_pool() {
+    static thread_local RenderHostBufferPool pool;
+    return pool;
+}
+
+inline bool render_host_buffer_pool_enabled() {
+    return getenv("PROSPER_NO_BACKEND_BUFFER_POOL") == nullptr;
+}
+
+inline VkDeviceSize render_host_buffer_pool_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = getenv("PROSPER_BACKEND_BUFFER_POOL_MB");
+        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
+
+inline void destroy_render_host_buffer(VkDevice device, RenderHostBuffer& buffer) {
+    if (buffer.mapped) vkUnmapMemory(device, buffer.memory);
+    if (buffer.buffer) vkDestroyBuffer(device, buffer.buffer, nullptr);
+    if (buffer.memory) vkFreeMemory(device, buffer.memory, nullptr);
+    buffer = {};
+}
+
+inline RenderHostBuffer acquire_render_host_buffer(const RenderVkCtx& ctx,
+                                                   VkDeviceSize bytes) {
+    if (!bytes) return {};
+    VkDeviceSize capacity = 4;
+    while (capacity < bytes && capacity <= UINT64_MAX / 2) capacity *= 2;
+    if (capacity < bytes) capacity = bytes;
+    RenderHostBufferPool& pool = render_host_buffer_pool();
+    auto found = pool.available.find(capacity);
+    if (found != pool.available.end() && !found->second.empty()) {
+        RenderHostBuffer buffer = found->second.back();
+        found->second.pop_back();
+        if (found->second.empty()) pool.available.erase(found);
+        pool.cached_bytes -= buffer.allocation_bytes;
+        --pool.cached_buffers;
+        ++pool.hits;
+        return buffer;
+    }
+    ++pool.misses;
+
+    RenderHostBuffer buffer;
+    buffer.bytes = capacity;
+    VkBufferCreateInfo info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    info.size = capacity;
+    info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    if (vkCreateBuffer(ctx.dev, &info, nullptr, &buffer.buffer) != VK_SUCCESS)
+        return {};
+    VkMemoryRequirements requirements{};
+    vkGetBufferMemoryRequirements(ctx.dev, buffer.buffer, &requirements);
+    buffer.allocation_bytes = requirements.size;
+    VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    allocation.allocationSize = requirements.size;
+    allocation.memoryTypeIndex = render_memory_type(
+        ctx.phys, requirements.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (allocation.memoryTypeIndex == UINT32_MAX ||
+        vkAllocateMemory(ctx.dev, &allocation, nullptr, &buffer.memory) != VK_SUCCESS ||
+        vkBindBufferMemory(ctx.dev, buffer.buffer, buffer.memory, 0) != VK_SUCCESS ||
+        vkMapMemory(ctx.dev, buffer.memory, 0, VK_WHOLE_SIZE, 0, &buffer.mapped) != VK_SUCCESS) {
+        destroy_render_host_buffer(ctx.dev, buffer);
+        return {};
+    }
+    return buffer;
+}
+
+inline void release_render_host_buffer(VkDevice device, RenderHostBuffer buffer) {
+    if (!buffer.buffer || !buffer.memory || !buffer.mapped) {
+        destroy_render_host_buffer(device, buffer);
+        return;
+    }
+    constexpr size_t max_cached_buffers = 4096;
+    const VkDeviceSize limit = render_host_buffer_pool_limit();
+    if (!limit || buffer.allocation_bytes > limit) {
+        destroy_render_host_buffer(device, buffer);
+        return;
+    }
+
+    std::vector<RenderHostBuffer> evicted;
+    RenderHostBufferPool& pool = render_host_buffer_pool();
+    while ((pool.cached_buffers >= max_cached_buffers ||
+            pool.cached_bytes > limit - buffer.allocation_bytes) &&
+           !pool.available.empty()) {
+        auto victim = pool.available.begin();
+        RenderHostBuffer old = victim->second.back();
+        victim->second.pop_back();
+        if (victim->second.empty()) pool.available.erase(victim);
+        pool.cached_bytes -= old.allocation_bytes;
+        --pool.cached_buffers;
+        ++pool.evictions;
+        evicted.push_back(old);
+    }
+    if (pool.cached_buffers < max_cached_buffers &&
+        pool.cached_bytes <= limit - buffer.allocation_bytes) {
+        pool.available[buffer.bytes].push_back(buffer);
+        pool.cached_bytes += buffer.allocation_bytes;
+        ++pool.cached_buffers;
+        buffer = {};
+    }
+    for (RenderHostBuffer& old : evicted) destroy_render_host_buffer(device, old);
+    if (buffer.buffer) destroy_render_host_buffer(device, buffer);
+}
+
+inline RenderHostBufferPoolStats render_host_buffer_pool_stats() {
+    RenderHostBufferPool& pool = render_host_buffer_pool();
+    return {pool.cached_bytes, pool.cached_buffers, pool.hits, pool.misses, pool.evictions};
+}
+
 struct PersistentDsKey {
     uint64_t dr = 0, dw = 0, sr = 0, sw = 0, htile = 0;
     uint32_t w = 0, h = 0, fmt = 0;
@@ -1521,6 +1663,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     }();
     const bool share_backend_resources =
         getenv("PROSPER_NO_BACKEND_RESOURCE_SHARE") == nullptr;
+    const bool reuse_host_buffers = render_host_buffer_pool_enabled();
     struct SharedBufferKey {
         const uint32_t* words = nullptr;
         size_t count = 0;
@@ -1543,6 +1686,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     struct SharedBufferUpload {
         VkBuffer buffer = VK_NULL_HANDLE;
         VkDeviceMemory memory = VK_NULL_HANDLE;
+        void* mapped = nullptr;
+        VkDeviceSize bytes = 0;
+        VkDeviceSize allocation_bytes = 0;
+        bool pooled = false;
     };
     struct TextureBindingKey {
         std::array<uint64_t, 22> words{};
@@ -2110,29 +2257,43 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         buffer_index = shared_buffers.size();
                         SharedBufferUpload upload;
                         const VkDeviceSize bytes = static_cast<VkDeviceSize>(word_count) * 4;
-                        VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                        buffer_info.size = bytes;
-                        buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-                        vkCreateBuffer(dev, &buffer_info, nullptr, &upload.buffer);
-                        VkMemoryRequirements requirements;
-                        vkGetBufferMemoryRequirements(dev, upload.buffer, &requirements);
-                        const uint32_t memory_type = pick(
-                            requirements.memoryTypeBits,
-                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                        upload.memory = allocate_transient_render_memory(
-                            dev, requirements.size, memory_type);
-                        vkBindBufferMemory(dev, upload.buffer, upload.memory, 0);
-                        void* mapped = nullptr;
-                        vkMapMemory(dev, upload.memory, 0, bytes, 0, &mapped);
-                        std::memcpy(mapped, words, static_cast<size_t>(bytes));
-                        vkUnmapMemory(dev, upload.memory);
+                        if (reuse_host_buffers) {
+                            RenderHostBuffer pooled = acquire_render_host_buffer(ctx, bytes);
+                            upload.buffer = pooled.buffer;
+                            upload.memory = pooled.memory;
+                            upload.mapped = pooled.mapped;
+                            upload.bytes = pooled.bytes;
+                            upload.allocation_bytes = pooled.allocation_bytes;
+                            upload.pooled = upload.buffer && upload.memory && upload.mapped;
+                        }
+                        if (!upload.pooled) {
+                            VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                            buffer_info.size = bytes;
+                            buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+                            vkCreateBuffer(dev, &buffer_info, nullptr, &upload.buffer);
+                            VkMemoryRequirements requirements;
+                            vkGetBufferMemoryRequirements(dev, upload.buffer, &requirements);
+                            const uint32_t memory_type = pick(
+                                requirements.memoryTypeBits,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                            upload.memory = allocate_transient_render_memory(
+                                dev, requirements.size, memory_type);
+                            vkBindBufferMemory(dev, upload.buffer, upload.memory, 0);
+                            void* mapped = nullptr;
+                            vkMapMemory(dev, upload.memory, 0, bytes, 0, &mapped);
+                            std::memcpy(mapped, words, static_cast<size_t>(bytes));
+                            vkUnmapMemory(dev, upload.memory);
+                        } else {
+                            std::memcpy(upload.mapped, words, static_cast<size_t>(bytes));
+                        }
                         shared_buffers.push_back(upload);
                         shared_buffer_indices.emplace(buffer_key, buffer_index);
                         ++resource_reuse_stats.unique_buffers;
                     }
                     v.sbuf[i] = shared_buffers[buffer_index].buffer;
-                    dbi[i] = {v.sbuf[i], 0, VK_WHOLE_SIZE};
+                    dbi[i] = {v.sbuf[i], 0,
+                              static_cast<VkDeviceSize>(word_count) * sizeof(uint32_t)};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
                 }
@@ -2749,8 +2910,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (binding.view) vkDestroyImageView(dev, binding.view, nullptr);
     }
     for (const SharedBufferUpload& upload : shared_buffers) {
-        if (upload.buffer) vkDestroyBuffer(dev, upload.buffer, nullptr);
-        if (upload.memory) release_transient_render_memory(dev, upload.memory);
+        if (upload.pooled) {
+            release_render_host_buffer(
+                dev, {upload.buffer, upload.memory, upload.mapped,
+                      upload.bytes, upload.allocation_bytes});
+        } else {
+            if (upload.buffer) vkDestroyBuffer(dev, upload.buffer, nullptr);
+            if (upload.memory) release_transient_render_memory(dev, upload.memory);
+        }
     }
     auto evict_persistent_texture = [&]() {
         auto victim = persistent_texture_images.end();
@@ -2925,6 +3092,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     pool.cached_allocations,
                     static_cast<double>(pool.cached_bytes) / (1024.0 * 1024.0),
                     (unsigned long long)pool.discarded);
+            const RenderHostBufferPoolStats buffer_pool = render_host_buffer_pool_stats();
+            fprintf(stderr,
+                    "[render-timing] backend_buffer_pool hits=%llu misses=%llu cached=%zu %.1f MiB "
+                    "evictions=%llu\n",
+                    (unsigned long long)buffer_pool.hits,
+                    (unsigned long long)buffer_pool.misses,
+                    buffer_pool.cached_buffers,
+                    static_cast<double>(buffer_pool.cached_bytes) / (1024.0 * 1024.0),
+                    (unsigned long long)buffer_pool.evictions);
             const double wn = static_cast<double>(window.calls);
             const double window_total = window.target + window.draw_setup + window.record +
                                         window.gpu_wait + window.readback + window.cleanup;

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -132,23 +132,51 @@ int main() {
         buffer.binding = 2;
         buffer.set = 0;
         buffer.buffer_identity = 0x7020000000000002ull;
-        buffer.dwords.assign(64, 0x3f800000u);
+        buffer.dwords.assign(63, 0x3f800000u); // 252 bytes -> pooled 256-byte capacity
         prosper::test::BackendDraw d0;
         d0.vs = vs; d0.fs = red; d0.ps = &opaque; d0.vcount = 3; d0.R = {buffer};
         prosper::test::BackendDraw d1;
         d1.vs = vs; d1.fs = green; d1.ps = &additive; d1.vcount = 3; d1.R = {buffer};
 
+        const auto pool_before = prosper::test::render_host_buffer_pool_stats();
         const std::vector<uint8_t> shared =
             prosper::test::render_draws_rgba({d0, d1}, W, H);
         const auto shared_stats = prosper::test::backend_resource_reuse_stats();
+        const auto pool_after_first = prosper::test::render_host_buffer_pool_stats();
         CHECK(shared_stats.buffer_references == 2 && shared_stats.unique_buffers == 1,
               "identical guest-buffer payloads share one Vulkan upload");
+        CHECK(pool_after_first.misses == pool_before.misses + 1 &&
+                  pool_after_first.cached_buffers == pool_before.cached_buffers + 1,
+              "first storage-buffer shape populates the persistent host-buffer pool");
         CHECK(shared_stats.descriptor_set_layout_references == 2 &&
                   shared_stats.unique_descriptor_set_layouts == 1 &&
                   shared_stats.pipeline_layout_references == 2 &&
                   shared_stats.unique_pipeline_layouts == 1 &&
                   shared_stats.descriptor_pools == 1,
               "identical draw contracts share layouts and one call-wide descriptor pool");
+
+        prosper::test::BackendDraw capacity_peer0 = d0;
+        prosper::test::BackendDraw capacity_peer1 = d1;
+        capacity_peer0.R[0].dwords.resize(61); // 244 bytes, same 256-byte capacity class
+        capacity_peer1.R[0].dwords.resize(61);
+        const std::vector<uint8_t> pooled_again = prosper::test::render_draws_rgba(
+            {capacity_peer0, capacity_peer1}, W, H);
+        const auto pool_after_second = prosper::test::render_host_buffer_pool_stats();
+        CHECK(pool_after_second.hits == pool_after_first.hits + 1 &&
+                  pool_after_second.misses == pool_after_first.misses &&
+                  pooled_again == shared,
+              "next logical size in the capacity class reuses the mapped buffer byte-identically");
+
+        set_env("PROSPER_NO_BACKEND_BUFFER_POOL", "1");
+        const std::vector<uint8_t> pool_bypassed =
+            prosper::test::render_draws_rgba({d0, d1}, W, H);
+        const auto pool_after_bypass = prosper::test::render_host_buffer_pool_stats();
+        set_env("PROSPER_NO_BACKEND_BUFFER_POOL", nullptr);
+        CHECK(pool_after_bypass.hits == pool_after_second.hits &&
+                  pool_after_bypass.misses == pool_after_second.misses,
+              "buffer-pool disable switch restores transient Vulkan uploads");
+        CHECK(pool_bypassed == shared,
+              "pooled and forced-transient storage buffers render byte-identically");
 
         prosper::test::BackendDraw distinct = d1;
         distinct.R[0].buffer_identity++;


### PR DESCRIPTION
## What changed

- reuse host-coherent Vulkan storage buffers across synchronous backend calls
- keep pooled allocations persistently mapped and rewrite every shader-visible byte on checkout
- use power-of-two capacity classes while preserving exact logical descriptor ranges
- bound the pool to 4096 buffers / 256 MiB by default
- add timing telemetry, an opt-out A/B switch, focused Vulkan coverage, and renderer documentation

## Why

Evergate's dense transition creates roughly 170–180 distinct storage-buffer objects per backend call and about 14 backend calls per frontend submit. Fine-grained timing showed descriptor management below 0.1 ms/call, while repeated buffer creation/upload cost 1–4 ms/call and teardown cost another 2–5 ms/call.

The pool returns buffers only after the existing fence wait, so no in-flight GPU work can observe a later upload. It does not cache guest identity or content.

Progress on #702.

## Performance

Matched native Windows / RTX 4090 dense windows from one binary and fresh saves:

| Measurement | Pool disabled | Pool enabled |
|---|---:|---:|
| Draws / submit | 479.3 | 483.6 |
| Whole submit | 198.6 ms | 130.3 ms |
| Backend execution | 151.0 ms | 81.5 ms |
| Resource setup | 51.3 ms | 25.7 ms |
| Cleanup | 48.7 ms | 4.8 ms |
| GPU fence wait | 37.2 ms | 38.0 ms |
| Observed rate near frame 360 | 3.2 FPS | 4.1 FPS |

The capacity-class pool stabilized at 2464 buffers / 7.4 MiB with zero evictions. Flat GPU wait supports that the gain is CPU-side Vulkan object lifetime rather than changed GPU work.

## Validation

- Linux build
- Linux CTest: 111/111
- Windows build
- Windows CTest: 86/86
- Messenger snapshot: 29/29 structural matches
- Evergate snapshot: 9/9 structural matches (also repeated after rebasing onto current master)
- Dead Cells snapshot: 44/44 structural matches
- Blasphemous 2 snapshot: 98/98 structural matches
- same-binary Evergate opt-out A/B
