### PR TITLE
fix(gpu): support static scratch spill/fill

### DIFF
--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -413,7 +413,8 @@ void decode_operands(Rdna2Inst& i) {
             i.n_src = 3; break;
         }
         case Rdna2Format::FLAT: {
-            // gfx10 FLAT/GLOBAL/SCRATCH. OP d0[24:18], SEG d0[15:14], signed byte OFFSET d0[11:0];
+            // gfx10 FLAT/GLOBAL/SCRATCH. OP d0[24:18], SEG d0[15:14], LDS d0[13],
+            // signed byte OFFSET d0[11:0];
             // d1 holds VADDR[7:0], VDATA[15:8], SADDR[22:16], and VDST[31:24]. A scratch instruction
             // uses either `off, sN` (SADDR != NULL; canonical VADDR field 0) or `vN, off`
             // (SADDR=NULL=125). Global/flat address forms retain their operands for diagnostics but
@@ -424,6 +425,7 @@ void decode_operands(Rdna2Inst& i) {
             i.flat_glc = ((w >> 16) & 1u) != 0;
             i.flat_slc = ((w >> 17) & 1u) != 0;
             i.flat_dlc = ((w >> 12) & 1u) != 0;
+            i.flat_lds = ((w >> 13) & 1u) != 0;
             const uint32_t off12 = w & 0xFFFu;
             i.literal = (off12 & 0x800u) ? (off12 | 0xFFFFF000u) : off12;
             const uint32_t vaddr = d1 & 0xFFu;

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -412,6 +412,34 @@ void decode_operands(Rdna2Inst& i) {
                         (((w >> 13) & 1u) << 13);
             i.n_src = 3; break;
         }
+        case Rdna2Format::FLAT: {
+            // gfx10 FLAT/GLOBAL/SCRATCH. OP d0[24:18], SEG d0[15:14], signed byte OFFSET d0[11:0];
+            // d1 holds VADDR[7:0], VDATA[15:8], SADDR[22:16], and VDST[31:24]. A scratch instruction
+            // uses either `off, sN` (SADDR != NULL; canonical VADDR field 0) or `vN, off`
+            // (SADDR=NULL=125). Global/flat address forms retain their operands for diagnostics but
+            // remain fail-closed in the recompiler until arbitrary guest pointers are modeled.
+            const uint32_t d1 = i.words[1];
+            i.opcode = (w >> 18) & 0x7Fu;
+            i.flat_segment = (w >> 14) & 0x3u;
+            i.flat_glc = ((w >> 16) & 1u) != 0;
+            i.flat_slc = ((w >> 17) & 1u) != 0;
+            i.flat_dlc = ((w >> 12) & 1u) != 0;
+            const uint32_t off12 = w & 0xFFFu;
+            i.literal = (off12 & 0x800u) ? (off12 | 0xFFFFF000u) : off12;
+            const uint32_t vaddr = d1 & 0xFFu;
+            const uint32_t vdata = (d1 >> 8) & 0xFFu;
+            const uint32_t saddr = (d1 >> 16) & 0x7Fu;
+            const uint32_t vdst = (d1 >> 24) & 0xFFu;
+            const bool store = i.opcode >= 0x18u && i.opcode <= 0x1Fu;
+            i.dst = vgpr(store ? vdata : vdst);
+            if (i.flat_segment == 1u && saddr != 125u && vaddr == 0u)
+                i.src[0] = {};                         // canonical scratch `off, sN`
+            else
+                i.src[0] = vgpr(vaddr);
+            i.src[1] = decode_src_field(saddr);
+            i.n_src = 2;
+            break;
+        }
         case Rdna2Format::MIMG: {
             // Image op. opcode is 8 bits: MSB in dword0 bit 0, low 7 bits in [24:18] (Table 100:
             // "combine bits zero and 18-24" — dropping bit 0 aliased IMAGE_MSAA_LOAD (128) onto

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -71,9 +71,9 @@ struct Rdna2Inst {
     // 4/5 = WORD_0/WORD_1. Only combos the recompiler models clear has_modifier.
     uint8_t     sdwa_dst_sel = 6, sdwa_dst_unused = 0, sdwa_src0_sel = 6, sdwa_src1_sel = 6;
 
-    // Decoded operands (filled for the ALU formats: SOP1/2/K, VOP1/2/C, VOP3). `opcode` is the
-    // format-local opcode; `dst` the destination; `src[0..n_src-1]` the sources. simm16 holds the
-    // signed 16-bit immediate for SOPK/SOPP. Memory/interp/export formats leave these unset (fmt only).
+    // Decoded operands. `opcode` is the format-local opcode; `dst` the destination (or VDATA source
+    // base for memory stores); `src[0..n_src-1]` the remaining sources. simm16 holds the signed
+    // 16-bit immediate for SOPK/SOPP. Most memory/interp/export formats populate the same fields.
     uint32_t opcode = 0;
     Operand  dst;
     Operand  src[4];        // up to 4 (EXP has 4 VGPR sources; VOP3 uses 3)
@@ -111,6 +111,14 @@ struct Rdna2Inst {
     // MTBUF Texel Fault Enable (instruction bit 55 / dword1 bit 23) writes a status VGPR after the
     // data results. Kept explicit so the recompiler can reject until that observable write is modeled.
     bool     mtbuf_tfe = false;
+    // FLAT/GLOBAL/SCRATCH share the 0x37 encoding. Segment 0=flat, 1=scratch, 2=global; OFFSET is a
+    // signed 12-bit byte immediate stored sign-extended in `literal`. src[0] is VADDR (None for the
+    // canonical scratch `off, sN` form), src[1] is the seven-bit SADDR field, and dst is VDST for
+    // loads or VDATA for stores. Cache-policy flags do not change private scratch data semantics.
+    uint32_t flat_segment = 0;
+    bool     flat_glc = false;
+    bool     flat_slc = false;
+    bool     flat_dlc = false;
     // DS-only: GDS flag. llvm-mc gfx1030 round-trip places it at dword0 bit 17 (ds_add_u32 gds =
     // 0xd8020000 vs 0xd8000000; Table 94's "GDS [16]" is a GFX9-era erratum — it also misplaces
     // OP). Bit 16 is likewise captured so an unknown flag rejects rather than silently running

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -114,11 +114,13 @@ struct Rdna2Inst {
     // FLAT/GLOBAL/SCRATCH share the 0x37 encoding. Segment 0=flat, 1=scratch, 2=global; OFFSET is a
     // signed 12-bit byte immediate stored sign-extended in `literal`. src[0] is VADDR (None for the
     // canonical scratch `off, sN` form), src[1] is the seven-bit SADDR field, and dst is VDST for
-    // loads or VDATA for stores. Cache-policy flags do not change private scratch data semantics.
+    // loads or VDATA for stores. Cache-policy flags do not change private scratch data semantics;
+    // LDS requests a memory-to/from-LDS transfer and must not be treated as an ordinary VGPR access.
     uint32_t flat_segment = 0;
     bool     flat_glc = false;
     bool     flat_slc = false;
     bool     flat_dlc = false;
+    bool     flat_lds = false;
     // DS-only: GDS flag. llvm-mc gfx1030 round-trip places it at dword0 bit 17 (ds_add_u32 gds =
     // 0xd8020000 vs 0xd8000000; Table 94's "GDS [16]" is a GFX9-era erratum — it also misplaces
     // OP). Bit 16 is likewise captured so an unknown flag rejects rather than silently running

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -92,6 +92,89 @@ enum : uint32_t {
 
 uint32_t fbits(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
 
+struct FlatAccessInfo {
+    bool valid = false;
+    bool store = false;
+    bool sign_extend = false;
+    uint32_t bits = 0;
+    uint32_t components = 0;
+    uint32_t bytes() const { return (bits / 8u) * components; }
+};
+
+FlatAccessInfo flat_access_info(uint32_t opcode) {
+    switch (opcode) {
+        case 0x08: return {true, false, false, 8, 1};   // *_load_ubyte
+        case 0x09: return {true, false, true,  8, 1};   // *_load_sbyte
+        case 0x0a: return {true, false, false, 16, 1};  // *_load_ushort
+        case 0x0b: return {true, false, true,  16, 1};  // *_load_sshort
+        case 0x0c: return {true, false, false, 32, 1};  // *_load_dword
+        case 0x0d: return {true, false, false, 32, 2};
+        case 0x0e: return {true, false, false, 32, 4};
+        case 0x0f: return {true, false, false, 32, 3};
+        case 0x18: return {true, true,  false, 8, 1};   // *_store_byte
+        case 0x1a: return {true, true,  false, 16, 1};  // *_store_short
+        case 0x1c: return {true, true,  false, 32, 1};  // *_store_dword
+        case 0x1d: return {true, true,  false, 32, 2};
+        case 0x1e: return {true, true,  false, 32, 4};
+        case 0x1f: return {true, true,  false, 32, 3};
+        default: return {};
+    }
+}
+
+struct StaticScratchLayout {
+    bool valid = true;
+    bool used = false;
+    int32_t min_byte = 0;
+    uint32_t dwords = 0;
+    int32_t saddr = -1;
+};
+
+StaticScratchLayout analyze_static_scratch(const std::vector<Rdna2Inst>& ins) {
+    StaticScratchLayout out;
+    int32_t min_byte = INT32_MAX, max_byte = INT32_MIN;
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::FLAT) continue;
+        const FlatAccessInfo access = flat_access_info(in.opcode);
+        // The common compiler spill form is a static byte offset from one entry-provided scratch
+        // base: `scratch_* ..., off, sN`. Dynamic VADDR, multiple/rewritten bases, D16-high forms,
+        // atomics, and arbitrary flat/global pointers stay fail-closed.
+        if (in.flat_segment != 1u || !access.valid || in.src[0].kind != OperandKind::None ||
+            in.src[1].kind != OperandKind::SGPR) {
+            out.valid = false;
+            return out;
+        }
+        if (out.saddr < 0) out.saddr = in.src[1].value;
+        else if (out.saddr != in.src[1].value) {
+            out.valid = false;
+            return out;
+        }
+        const int32_t begin = static_cast<int32_t>(in.literal);
+        const int32_t end = begin + static_cast<int32_t>(access.bytes());
+        min_byte = std::min(min_byte, begin);
+        max_byte = std::max(max_byte, end);
+        out.used = true;
+    }
+    if (!out.used) return out;
+    auto floor4 = [](int32_t value) {
+        return value >= 0 ? (value / 4) * 4 : -(((-value + 3) / 4) * 4);
+    };
+    auto ceil4 = [](int32_t value) {
+        return value >= 0 ? ((value + 3) / 4) * 4 : -((-value / 4) * 4);
+    };
+    const int32_t aligned_min = floor4(min_byte);
+    const int32_t aligned_max = ceil4(max_byte);
+    // The signed 12-bit instruction offset spans 4096 bytes, and a vector access at the positive
+    // edge can extend by another 16 bytes. Keep a modest ceiling while accepting that full range.
+    if (aligned_max <= aligned_min || aligned_max - aligned_min > 8192) {
+        out.valid = false;
+        return out;
+    }
+    out.min_byte = aligned_min;
+    out.dwords = static_cast<uint32_t>((aligned_max - aligned_min) / 4);
+    return out;
+}
+
 // The f16 bit pattern an inline float constant supplies in a 16-bit operand position (ISA Table 10
 // lists per-width encodings: "0.5 ... half: 0x3800" etc.). Only 1/(2*pi) (code 248, 0x3118) differs
 // from rounding the f32 value — the f32 table entry 0.15915494 would round to a different last bit
@@ -122,6 +205,9 @@ struct SpirvCompute {
     uint32_t v_push_constants = 0, t_ptr_push_u32 = 0;
     uint32_t linear_localid = 0, local_count = 64, wave_size = 64;
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
+    uint32_t guest_scratch=0, t_ptr_guest_scratch_u32=0;
+    int32_t guest_scratch_min_byte=0, guest_scratch_saddr=-1;
+    uint32_t guest_scratch_dwords=0;
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
@@ -242,6 +328,88 @@ struct SpirvCompute {
                     decl.begin(), decl.end());
         function_var_insert += decl.size();
         return var;
+    }
+    void declare_guest_scratch(const StaticScratchLayout& layout) {
+        if (!layout.valid || !layout.used || !layout.dwords || guest_scratch) return;
+        guest_scratch_min_byte = layout.min_byte;
+        guest_scratch_saddr = layout.saddr;
+        guest_scratch_dwords = layout.dwords;
+        const uint32_t array = id();
+        put(types, Op_TypeArray, {array, t_u32, uconst(layout.dwords)});
+        uint32_t ptr_array = 0;
+        guest_scratch = function_var(array, ptr_array);
+        t_ptr_guest_scratch_u32 = id();
+        put(types, Op_TypePointer, {t_ptr_guest_scratch_u32, SC_Function, t_u32});
+    }
+    uint32_t guest_scratch_load_word(uint32_t index) {
+        uint32_t pointer = id();
+        putv(code, Op_AccessChain,
+             {t_ptr_guest_scratch_u32, pointer, guest_scratch, uconst(index)});
+        uint32_t value = id();
+        put(code, Op_Load, {t_u32, value, pointer});
+        return value;
+    }
+    void guest_scratch_store_word(uint32_t index, uint32_t value,
+                                  bool predicated, uint32_t pred) {
+        auto store = [&]() {
+            uint32_t pointer = id();
+            putv(code, Op_AccessChain,
+                 {t_ptr_guest_scratch_u32, pointer, guest_scratch, uconst(index)});
+            put(code, Op_Store, {pointer, value});
+        };
+        if (!predicated) { store(); return; }
+        const uint32_t then_label = id(), merge_label = id();
+        emit_selmerge(merge_label);
+        emit_condbranch(pred, then_label, merge_label);
+        emit_label(then_label);
+        store();
+        emit_branch(merge_label);
+        emit_label(merge_label);
+    }
+    uint32_t guest_scratch_load_bits(int32_t byte_offset, uint32_t bits, bool sign_extend) {
+        const uint32_t relative = static_cast<uint32_t>(byte_offset - guest_scratch_min_byte);
+        const uint32_t index = relative / 4u, shift = (relative & 3u) * 8u;
+        uint32_t value = guest_scratch_load_word(index);
+        if (shift + bits <= 32u)
+            return sign_extend ? bfe_s(value, uconst(shift), uconst(bits))
+                               : bfe_u(value, uconst(shift), uconst(bits));
+        const uint32_t low_bits = 32u - shift, high_bits = bits - low_bits;
+        const uint32_t low = ibin(Op_ShiftRightLogical, value, uconst(shift));
+        const uint32_t high_word = guest_scratch_load_word(index + 1u);
+        const uint32_t high = bfe_u(high_word, uconst(0), uconst(high_bits));
+        const uint32_t joined = ibin(Op_BitwiseOr, low,
+                                     ibin(Op_ShiftLeftLogical, high, uconst(low_bits)));
+        return sign_extend ? bfe_s(joined, uconst(0), uconst(bits)) : joined;
+    }
+    void guest_scratch_store_bits(int32_t byte_offset, uint32_t bits, uint32_t value,
+                                  bool predicated, uint32_t pred) {
+        const uint32_t relative = static_cast<uint32_t>(byte_offset - guest_scratch_min_byte);
+        const uint32_t index = relative / 4u, shift = (relative & 3u) * 8u;
+        auto bit_mask = [](uint32_t width) {
+            return width == 32u ? 0xffffffffu : ((1u << width) - 1u);
+        };
+        auto replace = [&](uint32_t word_index, uint32_t dst_shift,
+                           uint32_t width, uint32_t source_shift) {
+            const uint32_t mask = bit_mask(width) << dst_shift;
+            const uint32_t old = guest_scratch_load_word(word_index);
+            uint32_t field = source_shift
+                ? ibin(Op_ShiftRightLogical, value, uconst(source_shift)) : value;
+            if (dst_shift) field = ibin(Op_ShiftLeftLogical, field, uconst(dst_shift));
+            field = ibin(Op_BitwiseAnd, field, uconst(mask));
+            const uint32_t retained = ibin(Op_BitwiseAnd, old, uconst(~mask));
+            guest_scratch_store_word(word_index, ibin(Op_BitwiseOr, retained, field),
+                                     predicated, pred);
+        };
+        if (shift + bits <= 32u) {
+            if (bits == 32u && shift == 0u)
+                guest_scratch_store_word(index, value, predicated, pred);
+            else
+                replace(index, shift, bits, 0);
+            return;
+        }
+        const uint32_t low_bits = 32u - shift;
+        replace(index, shift, low_bits, 0);
+        replace(index + 1u, 0, bits - low_bits, low_bits);
     }
     uint32_t load_function(uint32_t type, uint32_t var) {
         uint32_t value = id(); put(code, Op_Load, {type, value, var}); return value;
@@ -1206,6 +1374,7 @@ struct SpirvCompute {
         if (with_cbufs) declare_cbufs(rt);   // only when the shader has memory ops (keeps no-op renders binding-free)
         put(code, Op_Function, {t_void, f_main, FC_None, t_fn});
         put(code, Op_Label, {lbl}); cur_block = lbl;
+        function_var_insert = code.size();
     }
     // Write a vec4(r,g,b,a) (bit-operands) to the matching fragment color output.
     void export_color(uint32_t mrt, uint32_t r, uint32_t g, uint32_t bl, uint32_t a) {
@@ -1262,6 +1431,7 @@ struct SpirvCompute {
         if (with_cbufs) declare_cbufs(rt);   // vertex fetch (buffer_load_format_*) reads these
         put(code, Op_Function, {t_void, f_main, FC_None, t_fn});
         put(code, Op_Label, {lbl}); cur_block = lbl;
+        function_var_insert = code.size();
     }
     // Load gl_VertexIndex as raw bits (VGPR v0 for a vertex shader).
     uint32_t load_vertex_index() { uint32_t r = id(); put(code, Op_Load, {t_i32, r, v_vid}); return i2u(r); }
@@ -1997,6 +2167,7 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
                 (in.fmt == Rdna2Format::VOP1 || in.fmt == Rdna2Format::VOP2 || in.fmt == Rdna2Format::VOP3 ||
                  in.fmt == Rdna2Format::MIMG || in.fmt == Rdna2Format::MUBUF ||
                  in.fmt == Rdna2Format::MTBUF || in.fmt == Rdna2Format::DS ||
+                 in.fmt == Rdna2Format::FLAT ||
                  sopp_is_noop(in))) {
                 continue;
             }
@@ -2222,6 +2393,7 @@ std::unordered_set<uint32_t> waterfall_branches(const std::vector<Rdna2Inst>& in
                 p.fmt == Rdna2Format::VOP1 || p.fmt == Rdna2Format::VOP2 || p.fmt == Rdna2Format::VOP3 ||
                 p.fmt == Rdna2Format::VOPC || p.fmt == Rdna2Format::MIMG ||
                 p.fmt == Rdna2Format::MUBUF || p.fmt == Rdna2Format::MTBUF ||
+                p.fmt == Rdna2Format::FLAT ||
                 sopp_is_noop(p);
             if (skip_ok) continue;
             // The SCC producer: a 64-bit wave-mask logical op (s_and/or/xor/andn2_b64, SCC = result!=0).
@@ -2350,6 +2522,10 @@ uint32_t vgpr_write_count(const Rdna2Inst& in) {
         case Rdna2Format::MTBUF:
             if (in.opcode >= 4u) return 0; // stores read VDATA; they do not write it
             return in.opcode + 1u;
+        case Rdna2Format::FLAT: {
+            const FlatAccessInfo access = flat_access_info(in.opcode);
+            return access.valid && !access.store ? access.components : 0;
+        }
         case Rdna2Format::MIMG: {
             if (in.opcode == 0x47 || in.opcode == 0x57) return 4;  // gather4 always returns four texels
             uint32_t n = 0;
@@ -2998,6 +3174,7 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                     vregs.insert(in.dst.value + (int)k);
                 break;
             case Rdna2Format::MUBUF: case Rdna2Format::MTBUF: case Rdna2Format::MIMG:
+            case Rdna2Format::FLAT:
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
                 break;
@@ -4733,6 +4910,42 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             } else {
                 // Scalar data loads overwrite the destination; they do not carry descriptor identity.
                 for (uint32_t k = 0; k < n; k++) rs.sreg_srt.erase(in.dst.value + (int)k);
+            }
+            return true;
+        }
+        case Rdna2Format::FLAT: {
+            const FlatAccessInfo access = flat_access_info(in.opcode);
+            // Model the compiler's private spill area only. Each generated shader invocation owns
+            // one Function-storage array, so the entry-provided hardware base has no host-visible
+            // address to preserve. Other FLAT/GLOBAL forms remain deliberately unsupported.
+            if (!access.valid || in.flat_segment != 1u || !b.guest_scratch ||
+                in.src[0].kind != OperandKind::None || in.src[1].kind != OperandKind::SGPR ||
+                in.src[1].value != b.guest_scratch_saddr ||
+                rs.sreg_written.count(in.src[1].value)) {
+                ok = false;
+                return true;
+            }
+            const int32_t base = static_cast<int32_t>(in.literal);
+            const int64_t storage_begin = b.guest_scratch_min_byte;
+            const int64_t storage_end = storage_begin + static_cast<int64_t>(b.guest_scratch_dwords) * 4;
+            for (uint32_t component = 0; component < access.components; ++component) {
+                const int32_t byte_offset = base +
+                    static_cast<int32_t>(component * (access.bits / 8u));
+                const int64_t access_end = static_cast<int64_t>(byte_offset) + access.bits / 8u;
+                if (byte_offset < storage_begin || access_end > storage_end) {
+                    ok = false;
+                    return true;
+                }
+                const int reg = in.dst.value + static_cast<int>(component);
+                if (access.store) {
+                    b.guest_scratch_store_bits(byte_offset, access.bits, vreg_old(b, rs, reg),
+                                               rs.exec_narrowed, rs.exec);
+                } else {
+                    const uint32_t old_value = vreg_old(b, rs, reg);
+                    rs.vreg[reg] = b.guest_scratch_load_bits(byte_offset, access.bits,
+                                                            access.sign_extend);
+                    predicate_write(b, rs, reg, old_value);
+                }
             }
             return true;
         }
@@ -7501,6 +7714,7 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     // converge in the host SPIR-V without inventing further guest execution. Graphics exports keep
     // separate side-effect bookkeeping and remain on the conservative reject path for this shape.
     (void)extend_terminating_if_else(code, dwords, ins);
+    const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     // Size the LDS array from the shader's real allocation when known (#130): bytes -> dwords, at
     // least the ds ops need, clamped to the RDNA2 64 KB (16384-dword) max. 0 keeps the 16 KB default.
@@ -7509,6 +7723,7 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
         b.lds_dwords = dw > 16384u ? 16384u : (dw ? dw : 1u);
     }
     b.begin(num_inputs ? num_inputs : 1, rt);
+    b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);   // readfirstlane waterfalls (#273)
@@ -7533,6 +7748,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is
     // only a place to finish the invocation after either guest arm has terminated.
     (void)extend_terminating_if_else(code, dwords, ins);
+    const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     if (config.lds_bytes) {
         uint32_t dw = (config.lds_bytes + 3) / 4;
@@ -7544,6 +7760,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));
+    b.declare_guest_scratch(scratch);
     const bool has_partial_workgroup = config.threads_x % local_x != 0 ||
                                        config.threads_y % local_y != 0 ||
                                        config.threads_z % local_z != 0;
@@ -7604,9 +7821,11 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     rdna2_walk(code, dwords, ins);
     uint32_t synthetic_branch_pc = UINT32_MAX;
     (void)extend_terminating_if_else(code, dwords, ins, nullptr, &synthetic_branch_pc);
+    const StaticScratchLayout scratch = analyze_static_scratch(ins);
 
     // A scratch builder/state so emit_alu can run; its emitted code is discarded — we only want `ok`.
     SpirvCompute b; b.begin(1);
+    b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);   // readfirstlane waterfalls (#273)
@@ -7716,6 +7935,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
             return {};
         }
     }
+    const StaticScratchLayout scratch = analyze_static_scratch(ins);
 
     // Preserve hardware target locations. MRT0 and MRT1 are backed by real Vulkan attachments; later
     // targets remain unsupported and must never be silently remapped to location 0 (#635).
@@ -7742,6 +7962,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     if (!derived_interpolation.valid) return {};
     SpirvCompute b;
     b.begin_fragment(rt, color_mask);
+    b.declare_guest_scratch(scratch);
     b.fragment_interpolation = &derived_interpolation;
     // P0-only attributes retain the cheap Flat varying path. Mixed smooth/explicit-parameter reads
     // are legal with the portable geometry stage and use separate packed locations there.
@@ -7855,9 +8076,11 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                                        const PixelInputMapping* pixel_inputs) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
+    const StaticScratchLayout scratch = analyze_static_scratch(ins);
 
     SpirvCompute b;
     b.begin_vertex(rt);
+    b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);   // readfirstlane waterfalls (#273)

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -139,7 +139,8 @@ StaticScratchLayout analyze_static_scratch(const std::vector<Rdna2Inst>& ins) {
         // The common compiler spill form is a static byte offset from one entry-provided scratch
         // base: `scratch_* ..., off, sN`. Dynamic VADDR, multiple/rewritten bases, D16-high forms,
         // atomics, and arbitrary flat/global pointers stay fail-closed.
-        if (in.flat_segment != 1u || !access.valid || in.src[0].kind != OperandKind::None ||
+        if (in.flat_segment != 1u || in.flat_lds || !access.valid ||
+            in.src[0].kind != OperandKind::None ||
             in.src[1].kind != OperandKind::SGPR) {
             out.valid = false;
             return out;
@@ -4918,7 +4919,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // Model the compiler's private spill area only. Each generated shader invocation owns
             // one Function-storage array, so the entry-provided hardware base has no host-visible
             // address to preserve. Other FLAT/GLOBAL forms remain deliberately unsupported.
-            if (!access.valid || in.flat_segment != 1u || !b.guest_scratch ||
+            if (!access.valid || in.flat_segment != 1u || in.flat_lds || !b.guest_scratch ||
                 in.src[0].kind != OperandKind::None || in.src[1].kind != OperandKind::SGPR ||
                 in.src[1].value != b.guest_scratch_saddr ||
                 rs.sreg_written.count(in.src[1].value)) {

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -136,6 +136,34 @@ int main() {
     CHECK(mt_tfe.fmt == Rdna2Format::MTBUF && mt_tfe.opcode == 0u &&
               mt_tfe.mtbuf_format == 22u && mt_tfe.mtbuf_tfe,
           "MTBUF decodes TFE instead of silently dropping its status destination");
+    // gfx1030 llvm-mc exact words. FLAT's dword1 places SADDR and VDST differently from MUBUF;
+    // scratch `off, sN` also uses a real absent VADDR, not an accidental read of v0.
+    const uint32_t scratch_load_x2[] = { 0xdc344020u, 0x08060000u };
+    Rdna2Inst scratch_l2 = rdna2_decode_one(scratch_load_x2, 2);
+    CHECK(scratch_l2.fmt == Rdna2Format::FLAT && scratch_l2.flat_segment == 1u &&
+              scratch_l2.opcode == 0x0du && scratch_l2.literal == 32u &&
+              isV(scratch_l2.dst, 8) && scratch_l2.src[0].kind == OperandKind::None &&
+              isS(scratch_l2.src[1], 6),
+          "scratch_load_dwordx2 decodes segment, signed offset, VDST, absent VADDR, and SADDR");
+    const uint32_t scratch_store_x2[] = { 0xdc744020u, 0x00060a00u };
+    Rdna2Inst scratch_s2 = rdna2_decode_one(scratch_store_x2, 2);
+    CHECK(scratch_s2.fmt == Rdna2Format::FLAT && scratch_s2.flat_segment == 1u &&
+              scratch_s2.opcode == 0x1du && isV(scratch_s2.dst, 10) &&
+              scratch_s2.src[0].kind == OperandKind::None && isS(scratch_s2.src[1], 6),
+          "scratch_store_dwordx2 decodes VDATA rather than the load-only VDST field");
+    const uint32_t scratch_negative[] = { 0xdc304ffcu, 0x00000000u };
+    Rdna2Inst scratch_neg = rdna2_decode_one(scratch_negative, 2);
+    CHECK(scratch_neg.flat_segment == 1u && static_cast<int32_t>(scratch_neg.literal) == -4,
+          "scratch signed 12-bit OFFSET is sign-extended");
+    const uint32_t global_load[] = { 0xdc308000u, 0x007d0002u };
+    const uint32_t flat_load[]   = { 0xdc300000u, 0x007d0002u };
+    Rdna2Inst global_l = rdna2_decode_one(global_load, 2);
+    Rdna2Inst flat_l = rdna2_decode_one(flat_load, 2);
+    CHECK(global_l.flat_segment == 2u && isV(global_l.src[0], 2) &&
+              global_l.src[1].kind == OperandKind::Special && global_l.src[1].value == 125,
+          "global_load_dword retains its VGPR address and NULL SADDR for fail-closed diagnostics");
+    CHECK(flat_l.flat_segment == 0u && isV(flat_l.src[0], 2),
+          "flat_load_dword remains distinct from global and scratch segments");
     // Exact DS_READ2_B32 words from Astro Bot's loading-surface compute producer. The packed
     // offset bytes are dword indices (offset0 in the low byte, offset1 in the high byte).
     const uint32_t ds_read2_adjacent[] = { 0xd8dc0100u, 0x04000002u };

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -155,6 +155,10 @@ int main() {
     Rdna2Inst scratch_neg = rdna2_decode_one(scratch_negative, 2);
     CHECK(scratch_neg.flat_segment == 1u && static_cast<int32_t>(scratch_neg.literal) == -4,
           "scratch signed 12-bit OFFSET is sign-extended");
+    const uint32_t scratch_lds[] = { 0xdc306000u, 0x00000000u };
+    Rdna2Inst scratch_to_lds = rdna2_decode_one(scratch_lds, 2);
+    CHECK(scratch_to_lds.flat_segment == 1u && scratch_to_lds.flat_lds,
+          "scratch LDS-transfer flag is retained for fail-closed recompilation");
     const uint32_t global_load[] = { 0xdc308000u, 0x007d0002u };
     const uint32_t flat_load[]   = { 0xdc300000u, 0x007d0002u };
     Rdna2Inst global_l = rdna2_decode_one(global_load, 2);

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -16,6 +16,7 @@ enum : uint32_t {
     OpTypeInt = 21,
     OpTypeFloat = 22,
     OpTypeVector = 23,
+    OpTypeArray = 28,
     OpTypeRuntimeArray = 29,
     OpTypeStruct = 30,
     OpTypePointer = 32,
@@ -29,6 +30,7 @@ bool is_type_decl(uint32_t op) {
         case OpTypeInt:
         case OpTypeFloat:
         case OpTypeVector:
+        case OpTypeArray:
         case OpTypeRuntimeArray:
         case OpTypeStruct:
         case OpTypePointer:
@@ -177,6 +179,47 @@ int main() {
         return 1;
     }
     printf("  [ok]   signed kernel SPIR-V declares signed i32 with a nonzero id\n");
+
+    // Fixed-offset private spill/fill must also produce structurally valid graphics-stage modules.
+    // This exercises Function-variable placement in the fragment and vertex shells, independently
+    // of the compute execution tests.
+    const uint32_t scratch_fragment[] = {
+        0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
+        0x7e000280u,              // v_mov_b32 v0, 0
+        0xdc304010u, 0x00000000u, // scratch_load_dword v0, off, s0 offset:16
+        0xf800000fu, 0x00000000u, // exp mrt0 v0, v0, v0, v0
+        0xBF810000u,
+    };
+    const auto scratch_fragment_spv = recompile_fragment(
+        scratch_fragment, sizeof(scratch_fragment) / sizeof(scratch_fragment[0]));
+    uint32_t scratch_fragment_bad_op = 0;
+    if (scratch_fragment_spv.empty() || !has_opcode(scratch_fragment_spv, 28) ||
+        !type_result_ids_are_nonzero(scratch_fragment_spv, &scratch_fragment_bad_op) ||
+        !phi_ids_are_nonzero(scratch_fragment_spv)) {
+        printf("  [FAIL] fragment private spill/fill emitted invalid SPIR-V (op=%u)\n",
+               scratch_fragment_bad_op);
+        return 1;
+    }
+    printf("  [ok]   fragment private spill/fill emits structurally valid Function storage\n");
+
+    const uint32_t scratch_vertex[] = {
+        0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
+        0x7e000280u,              // v_mov_b32 v0, 0
+        0xdc304010u, 0x00000000u, // scratch_load_dword v0, off, s0 offset:16
+        0xf80008cfu, 0x00000000u, // exp pos0 v0, v0, v0, v0
+        0xBF810000u,
+    };
+    const auto scratch_vertex_spv = recompile_vertex(
+        scratch_vertex, sizeof(scratch_vertex) / sizeof(scratch_vertex[0]));
+    uint32_t scratch_vertex_bad_op = 0;
+    if (scratch_vertex_spv.empty() || !has_opcode(scratch_vertex_spv, 28) ||
+        !type_result_ids_are_nonzero(scratch_vertex_spv, &scratch_vertex_bad_op) ||
+        !phi_ids_are_nonzero(scratch_vertex_spv)) {
+        printf("  [FAIL] vertex private spill/fill emitted invalid SPIR-V (op=%u)\n",
+               scratch_vertex_bad_op);
+        return 1;
+    }
+    printf("  [ok]   vertex private spill/fill emits structurally valid Function storage\n");
 
     // NGG wave packing writes EXEC through s_lshr_b64 before later structured control flow. The
     // instruction is mask-domain only; inserting rs.sreg[EXEC] left an SSA id 0 that a later merge

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3533,6 +3533,54 @@ int main() {
     CHECK(!spvA9b.empty(),
           "A9b: a real s_cmp between the mask op and the consumer re-arms SCC (recompiles)");
 
+    // A10 (#458): a fixed-offset compiler spill/fill preserves the exact per-invocation VGPR bits.
+    const uint32_t codeA10[] = {
+        0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
+        0x7e000280u,              // v_mov_b32 v0, 0
+        0xdc304010u, 0x00000000u, // scratch_load_dword v0, off, s0 offset:16
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvA10 = recompile_valu(codeA10, std::size(codeA10), 1, 0);
+    CHECK(!spvA10.empty(), "A10: fixed-offset private dword spill/fill recompiles");
+    const std::vector<float> scratch_in = {-7.25f, 0.0f, 3.5f, 1234.0f};
+    std::vector<float> gotA10 = prosper::test::run_compute(
+        spvA10, scratch_in, static_cast<uint32_t>(scratch_in.size()),
+        static_cast<uint32_t>(scratch_in.size()));
+    CHECK(gotA10 == scratch_in,
+          "A10: private dword spill/fill round-trips exact values for every invocation");
+
+    // A11 (#458): vector forms use consecutive VGPRs while retaining one private offset range.
+    const uint32_t codeA11[] = {
+        0xdc744020u, 0x00060000u, // scratch_store_dwordx2 off, v[0:1], s6 offset:32
+        0x7e000280u, 0x7e020280u, // clear v0/v1
+        0xdc344020u, 0x00060000u, // scratch_load_dwordx2 v[0:1], off, s6 offset:32
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvA11 = recompile_valu(codeA11, std::size(codeA11), 2, 1);
+    CHECK(!spvA11.empty(), "A11: fixed-offset private dwordx2 spill/fill recompiles");
+    const std::vector<float> scratch_pair_in = {
+        1.0f, 11.0f, 2.0f, 12.0f, 3.0f, 13.0f, 4.0f, 14.0f,
+    };
+    const std::vector<float> scratch_pair_expect = {11.0f, 12.0f, 13.0f, 14.0f};
+    std::vector<float> gotA11 = prosper::test::run_compute(spvA11, scratch_pair_in, 4, 4);
+    CHECK(gotA11 == scratch_pair_expect,
+          "A11: private dwordx2 spill/fill restores the second consecutive VGPR");
+
+    // A12 (#458): a signed 16-bit spill crossing a dword boundary is reconstructed exactly.
+    const uint32_t codeA12[] = {
+        0x7e0002ffu, 0x00008001u, // v_mov_b32 v0, 0x8001
+        0xdc684003u, 0x00000000u, // scratch_store_short off, v0, s0 offset:3
+        0x7e000280u,              // v_mov_b32 v0, 0
+        0xdc2c4003u, 0x00000000u, // scratch_load_sshort v0, off, s0 offset:3
+        0x7e000b00u,              // v_cvt_f32_i32 v0, v0
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvA12 = recompile_valu(codeA12, std::size(codeA12), 0, 0);
+    CHECK(!spvA12.empty(), "A12: unaligned signed private short spill/fill recompiles");
+    std::vector<float> gotA12 = prosper::test::run_compute(spvA12, {0.0f}, 1, 1);
+    CHECK(gotA12.size() == 1 && gotA12[0] == -32767.0f,
+          "A12: straddling signed private short reloads with correct sign extension");
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -44,6 +44,48 @@ int main() {
           mtbuf_tfe.unsupported == 1 && mtbuf_tfe.first_bad_op == 0u,
           "MTBUF TFE remains explicit unsupported coverage until its status write is modeled");
 
+    // The common compiler spill/fill form uses a fixed byte offset and one unmodified scalar base.
+    // The host shader maps that private storage to one per-invocation Function array.
+    const uint32_t scratch_static[] = {
+        0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
+        0xdc304010u, 0x00000000u, // scratch_load_dword v0, off, s0 offset:16
+        0xBF810000u,
+    };
+    RecompileCoverage scratch = recompile_coverage(
+        scratch_static, sizeof(scratch_static) / sizeof(scratch_static[0]));
+    CHECK(scratch.total == 2 && scratch.alu == 2 && scratch.unsupported == 0 &&
+              scratch.first_bad_fmt < 0,
+          "static private spill/fill instructions report full recompiler coverage");
+
+    const uint32_t scratch_dynamic[] = {
+        0xdc304000u, 0x007d0002u, // scratch_load_dword v0, v2, off
+        0xBF810000u,
+    };
+    RecompileCoverage dynamic = recompile_coverage(
+        scratch_dynamic, sizeof(scratch_dynamic) / sizeof(scratch_dynamic[0]));
+    CHECK(dynamic.total == 1 && dynamic.unsupported == 1 && dynamic.first_bad_op == 0x0cu,
+          "dynamic private addresses remain explicit unsupported coverage");
+
+    const uint32_t global_address[] = {
+        0xdc308000u, 0x007d0002u, // global_load_dword v0, v[2:3], off
+        0xBF810000u,
+    };
+    RecompileCoverage global = recompile_coverage(
+        global_address, sizeof(global_address) / sizeof(global_address[0]));
+    CHECK(global.total == 1 && global.unsupported == 1 && global.first_bad_op == 0x0cu,
+          "arbitrary global addresses remain explicit unsupported coverage");
+
+    const uint32_t rewritten_scratch_base[] = {
+        0xbe800384u,               // s_mov_b32 s0, 4
+        0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
+        0xdc304010u, 0x00000000u, // scratch_load_dword v0, off, s0 offset:16
+        0xBF810000u,
+    };
+    CHECK(recompile_valu(rewritten_scratch_base,
+                         sizeof(rewritten_scratch_base) / sizeof(rewritten_scratch_base[0]),
+                         1, 0).empty(),
+          "a shader-written private-storage base rejects instead of aliasing the entry spill area");
+
     // Contains an unsupported op: v_add_f32 ; s_branch +5 (unconditional -> rejected) ; s_endpgm.
     const uint32_t bad_code[] = { 0x06000300u, 0xbf820005u, 0xBF810000u };
     RecompileCoverage b = recompile_coverage(bad_code, sizeof(bad_code)/sizeof(bad_code[0]));

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -75,6 +75,17 @@ int main() {
     CHECK(global.total == 1 && global.unsupported == 1 && global.first_bad_op == 0x0cu,
           "arbitrary global addresses remain explicit unsupported coverage");
 
+    const uint32_t scratch_lds[] = {
+        0xdc306000u, 0x00000000u, // scratch_load_dword off, s0 lds
+        0xBF810000u,
+    };
+    RecompileCoverage lds_transfer = recompile_coverage(
+        scratch_lds, sizeof(scratch_lds) / sizeof(scratch_lds[0]));
+    CHECK(lds_transfer.total == 1 && lds_transfer.unsupported == 1 &&
+              lds_transfer.first_bad_op == 0x0cu &&
+              recompile_valu(scratch_lds, sizeof(scratch_lds) / sizeof(scratch_lds[0]), 0, 0).empty(),
+          "scratch LDS-transfer packets remain explicit unsupported coverage");
+
     const uint32_t rewritten_scratch_base[] = {
         0xbe800384u,               // s_mov_b32 s0, 4
         0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -42,13 +42,25 @@ int main(int argc, char** argv) {
     // Compute + SMEM constant-buffer load (s_buffer_load_dword; routes to binding 2).
     { const uint32_t c[] = {0xf4000000u, 0xfa000004u, 0x7e000200u, 0xbf810000u};
       dump(dir, "compute_smem", recompile_valu(c, sizeof(c)/4, 1, 0)); }
+    // Compute private spill/fill, including a signed short crossing a dword boundary.
+    { const uint32_t c[] = {0x7e0002ffu,0x00008001u,0xdc684003u,0x00000000u,0x7e000280u,
+                            0xdc2c4003u,0x00000000u,0x7e000b00u,0xBF810000u};
+      dump(dir, "compute_private_spill", recompile_valu(c, sizeof(c)/4, 0, 0)); }
     // Fragment: solid green (EXP MRT0).
     { const uint32_t c[] = {0x7E000280u,0x7E0202F2u,0x7E040280u,0x7E0602F2u,0xF800180Fu,0x03020100u,0xBF810000u};
       dump(dir, "fragment_color", recompile_fragment(c, sizeof(c)/4)); }
+    // Fragment private spill/fill (Function-storage declaration in the graphics shell).
+    { const uint32_t c[] = {0xdc704010u,0x00000000u,0x7e000280u,0xdc304010u,0x00000000u,
+                            0xf800000fu,0x00000000u,0xBF810000u};
+      dump(dir, "fragment_private_spill", recompile_fragment(c, sizeof(c)/4)); }
     // Vertex: fullscreen triangle from gl_VertexIndex (EXP POS0).
     { const uint32_t c[] = {0x36020081u,0x2C040081u,0x7E020D01u,0x7E040D02u,0x7E0A02F6u,0x7E0C02F2u,0x10020B01u,
                             0x08020D01u,0x10040B02u,0x08040D02u,0x7E060280u,0x7E0802F2u,0xF80008CFu,0x04030201u,0xBF810000u};
       dump(dir, "vertex_fullscreen", recompile_vertex(c, sizeof(c)/4)); }
+    // Vertex private spill/fill (Function-storage declaration in the graphics shell).
+    { const uint32_t c[] = {0xdc704010u,0x00000000u,0x7e000280u,0xdc304010u,0x00000000u,
+                            0xf80008cfu,0x00000000u,0xBF810000u};
+      dump(dir, "vertex_private_spill", recompile_vertex(c, sizeof(c)/4)); }
     // Vertex fetch (buffer_load_format_xy from a V# in user-data s[8:11]).
     { const uint32_t c[] = {0x7e060280u,0x7e0802f2u,0xe0042000u,0x80020100u,0xf80008cfu,0x04030201u,0xbf810000u};
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;


### PR DESCRIPTION
Fixes #458.

## Failure and contract

GFX10 FLAT packets were classified but had no operand decode or recompiler path, so a shader using compiler-generated private spill/fill instructions was rejected in full. This change supports the bounded, common `off, sN` form while preserving explicit rejection for address forms that cannot be represented safely.

## Implementation

- Decode FLAT/SCRATCH/GLOBAL segment, opcode, cache flags, signed byte offset, VADDR, VDATA, SADDR, and VDST fields.
- Analyze supported fixed-offset scratch accesses and allocate one Function-storage array per generated shader invocation.
- Lower byte, short, dword, and dwordx2/x3/x4 loads/stores, including negative/unaligned offsets, sign extension, cross-dword subword accesses, and EXEC-predicated effects.
- Require one unchanged scalar base register. Dynamic VADDR scratch, rewritten/multiple bases, LDS-transfer packets, D16-high variants, arbitrary FLAT/GLOBAL pointers, and atomics remain fail-closed.
- Include scratch loads in register/structured-control-flow inventories and strict SPIR-V validation coverage.

## Risk and unaffected behavior

The private base is intentionally normalized away only when every supported access shares the same entry-provided, unmodified SADDR; relative offsets retain the guest layout. Unsupported pointer-bearing forms still return an empty recompile rather than being guessed. Resource-backed buffer/image paths are unchanged.

This is deterministic shader compatibility work, not a claimed visible game-progression change. Per project direction, no game/image snapshot route was run.

## Focused pre-publish verification

- Linux: `test_rdna2_decode`, `test_rdna2_spirv_struct`, `test_recompile_coverage`, and Vulkan-backed `test_rdna2_to_spirv` — PASS.
- Linux: `spv_validate` — all representative modules pass `spirv-val`, including new compute/fragment/vertex private-storage cases.
- Windows: built and ran `test_rdna2_decode`, `test_rdna2_spirv_struct`, and `test_recompile_coverage` — PASS.

The author full verifier and independent inspection review will be posted against the exact PR head.