### PR TITLE
docs: restore risk-based review workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,29 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   authorizes it. The PR author owns verification; prefer `powershell -File prosper/tools/verify-pr.ps1 core` or,
   for renderer changes, `powershell -File prosper/tools/verify-pr.ps1 renderer -Snapshot <name>`, and post the
   exact-head results.
+- **Use independent review whenever it can materially improve confidence.** Treat review as a correctness
+  tool, not merely a gate for large diffs: behavioral code changes involving non-obvious judgment, unfamiliar
+  code, cross-platform behavior, reverse-engineered semantics, or meaningful failure paths should normally be
+  reviewed even when the patch is small and the author verification is green. Complex or high-risk changes—such
+  as shader/recompiler
+  control flow, memory safety or untrusted bounds, synchronization, ABI-sensitive interfaces, persistent data,
+  shared renderer/executor format, size, or indexing semantics, or changes whose failure can silently corrupt
+  results—require an independent code review before merge. Review is also required when the validation itself
+  is easy to get wrong: for example, a regression test with another path that can produce the expected result,
+  or a snapshot route or baseline update that needs judgment to confirm it exercises the intended behavior.
+  Judge both implementation risk and verification risk, not merely the diff size. Skip independent review only
+  for genuinely routine, mechanical, well-bounded low-risk work where another reader is unlikely to uncover a
+  correctness problem; when in doubt, review. Passing author verification does not substitute for
+  review where review is warranted: verification demonstrates observed behavior, while review challenges the
+  contract assumptions, untested paths, and whether the regression actually proves the intended behavior.
+  When uncertain, favor review for reverse-engineered API semantics and other changes where an independent
+  reader can materially challenge the reasoning, even when the patch is small. The reviewer inspects the
+  assumptions, code, risks, and tests, including whether each regression test would fail without the fix, but
+  does not duplicate the author's builds, tests, snapshots, or CI jobs. Once the author is satisfied and the PR
+  is published, run author verification and any required review; the author posts exact-head evidence and the
+  reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
+  corrections, then merge only after the merge agent separately confirms author verification, reviewer approval
+  where required, and green required CI.
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and


### PR DESCRIPTION
Fixes #964.

Restores the accepted risk-based independent-review paragraph from PR #905 that was unintentionally deleted during the unrelated PR #949 merge resolution.

The restored workflow makes the split explicit:

- the PR author owns builds/tests/snapshots and posts exact-head evidence;
- an independent reviewer inspects assumptions, code, risks, and whether regressions prove the intended behavior without duplicating verification;
- complex/high-risk or deceptively validated changes require review, while genuinely routine mechanical work may skip it;
- authored corrections invalidate approval and require exact-head re-review; and
- merge waits for applicable review, author verification, and green required CI.

This is an exact restoration, not new policy wording. The unpublished desktop-app parity rule remains immediately adjacent and unchanged.

## Author verification

- PASS: restored review block is byte-for-byte identical when both current `HEAD:CLAUDE.md` and accepted `669145c:CLAUDE.md` are read through Git (`EXACT_REVIEW_BLOCK=True`).
- PASS: `git diff --check origin/master...HEAD`.
- Scope: `CLAUDE.md` only, 23 inserted lines.
- Binary builds/tests and snapshots were not run because they do not exercise a Markdown-only exact restoration. Required CI still runs normally.

An inspection-only reviewer will check the history, exact wording, placement, and internal consistency without rerunning author verification.