### PR TITLE
perf(renderer): pack storage uploads into mapped arenas

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -250,12 +250,15 @@ object remains call-local and is destroyed after the existing fence wait, so thi
 freshness assumption. Set `PROSPER_NO_BACKEND_RESOURCE_SHARE=1` to disable the keyed object reuse for an
 A/B; the safe call-wide descriptor-pool consolidation remains enabled in both modes.
 
-Host-visible storage buffers use a separate bounded pool across backend calls. The backend waits for its
-fence before returning a buffer, retains its host-coherent allocation persistently mapped, and rewrites it
-before the next use. Power-of-two capacity classes absorb changing guest buffer sizes, while each Vulkan
-descriptor keeps the exact logical byte range, so pooling does not expose capacity padding to shaders.
-The thread-local pool is capped at 4096 buffers and 256 MiB by default; set
-`PROSPER_BACKEND_BUFFER_POOL_MB=<MiB>` to change the byte budget or
+Host-visible storage buffers use a separate bounded pool across backend calls. By default, the backend
+packs call-local logical uploads into non-overlapping slices of a persistently mapped host-coherent arena,
+using the device's storage-buffer offset alignment. Each Vulkan descriptor keeps the exact aligned offset
+and logical byte range, and every slice is rewritten before use. The backend waits for its fence before
+returning arenas to the pool, so later uploads cannot race in-flight work. Arenas start at 1 MiB; set
+`PROSPER_BACKEND_BUFFER_ARENA_KB=<KiB>` to tune that target or
+`PROSPER_NO_BACKEND_BUFFER_ARENA=1` to restore one pooled buffer per logical upload. Oversized uploads and
+the fallback path still use power-of-two capacity classes. The thread-local pool is capped at 4096 buffers
+and 256 MiB by default; set `PROSPER_BACKEND_BUFFER_POOL_MB=<MiB>` to change the byte budget or
 `PROSPER_NO_BACKEND_BUFFER_POOL=1` for the former create/map/destroy path. With renderer timing enabled,
 `backend_buffer_pool` reports cumulative hits, misses, cached count/bytes, and evictions.
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -160,6 +160,38 @@ misses. The flat GPU wait confirms the measured improvement comes from CPU Vulka
 than different GPU work. The next dense-scene costs are texture-binding setup and the synchronous
 submit/fence/readback architecture.
 
+## Evergate packed host-buffer arenas (2026-07-19)
+
+The persistent buffer pool removed allocation and destruction, but dense backend calls still checked out
+about 179 distinct Vulkan buffers for roughly 267 storage-buffer references. A count-only probe also found
+about 80 texture references collapsing to only five unique texture binding objects, plus 2.5 descriptor-set
+layouts and 1.4 pipeline layouts per call. The remaining resource setup was therefore dominated by the
+large number of logical storage uploads, not texture view/sampler or layout object counts.
+
+The backend now suballocates those logical uploads from aligned slices of a 1 MiB mapped arena. Descriptor
+offsets follow `minStorageBufferOffsetAlignment`, descriptor ranges remain the exact logical byte count,
+and distinct logical resources never overlap. The arena is returned to the existing bounded pool only after
+the backend fence wait. `PROSPER_NO_BACKEND_BUFFER_ARENA=1` restores the per-logical-buffer pooled path for
+an A/B, while `PROSPER_BACKEND_BUFFER_ARENA_KB=<KiB>` changes the target arena size.
+
+Native Windows / RTX 4090, one final binary, separate fresh saves, native scale/cadence, the documented
+route, and matched dense timing windows produced:
+
+| Measurement | Per-logical pool | Packed arena |
+|---|---:|---:|
+| Draws / submit | 489.6 | 485.4 |
+| Whole submit | 135.9 ms | 131.9 ms |
+| Backend execution | 83.7 ms | 81.0 ms |
+| Backend resource setup | 26.9 ms | 25.3 ms |
+| Backend cleanup | 5.1 ms | 4.7 ms |
+| GPU fence wait | 37.3 ms | 37.4 ms |
+| Persistent buffer objects | 2,434 | 4 |
+| Persistent mapped bytes | 6.7 MiB | 4.0 MiB |
+
+A second nearby pair measured 139.4 to 133.6 ms whole-submit time, confirming a modest 3-4% end-to-end
+gain. The flat 37 ms fence wait remains the primary structural limit; packing removes CPU object handling
+and pool bookkeeping but does not change GPU work or synchronous ownership.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -335,6 +335,7 @@ inline BackendRenderTimingStats backend_render_timing_stats() {
 struct RenderVkCtx {
     VkInstance inst = VK_NULL_HANDLE; VkPhysicalDevice phys = VK_NULL_HANDLE;
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
+    VkDeviceSize storage_buffer_alignment = 1;
     bool aniso_enabled = false; float max_aniso_limit = 1.0f; bool ok = false;
 };
 inline const RenderVkCtx& render_vk_ctx() {
@@ -364,6 +365,8 @@ inline const RenderVkCtx& render_vk_ctx() {
         // samplerAnisotropy (#275): enable only if advertised; maxSamplerAnisotropy is the clamp ceiling.
         VkPhysicalDeviceFeatures supported{}; vkGetPhysicalDeviceFeatures(r.phys, &supported);
         VkPhysicalDeviceProperties phys_props{}; vkGetPhysicalDeviceProperties(r.phys, &phys_props);
+        r.storage_buffer_alignment = std::max<VkDeviceSize>(
+            1, phys_props.limits.minStorageBufferOffsetAlignment);
         r.aniso_enabled = supported.samplerAnisotropy;
         r.max_aniso_limit = phys_props.limits.maxSamplerAnisotropy;
         if (r.aniso_enabled) feats.samplerAnisotropy = VK_TRUE;
@@ -652,9 +655,10 @@ inline uint32_t render_memory_type(VkPhysicalDevice phys, uint32_t bits,
 
 // Storage-buffer contents are rewritten for every synchronous render call, but their Vulkan object
 // shapes repeat heavily. Keep capacity-class host-coherent buffers mapped between calls so the hot path
-// only copies bytes; each call waits for its fence before returning the buffers, so no in-flight GPU
-// work can observe a later upload. Capacity classes reduce shape churn; descriptors retain the exact
-// logical upload range, so pooling never broadens shader-visible storage.
+// only copies bytes. The backend normally packs call-local logical uploads into aligned slices of a few
+// pooled arenas; the same pool also backs the per-upload fallback. Each call waits for its fence before
+// returning buffers, so no in-flight GPU work can observe a later upload. Descriptors retain exact
+// logical offsets and ranges, so capacity padding and neighboring arena slices remain shader-inaccessible.
 struct RenderHostBuffer {
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
@@ -697,6 +701,16 @@ inline VkDeviceSize render_host_buffer_pool_limit() {
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
     return limit;
+}
+
+inline VkDeviceSize render_host_buffer_arena_size() {
+    static const VkDeviceSize bytes = []() -> VkDeviceSize {
+        const char* value = getenv("PROSPER_BACKEND_BUFFER_ARENA_KB");
+        const uint64_t kib = value ? strtoull(value, nullptr, 10) : 1024ull;
+        if (kib > UINT64_MAX / 1024ull) return VkDeviceSize{UINT64_MAX};
+        return std::max<VkDeviceSize>(4, static_cast<VkDeviceSize>(kib) * 1024ull);
+    }();
+    return bytes;
 }
 
 inline void destroy_render_host_buffer(VkDevice device, RenderHostBuffer& buffer) {
@@ -1687,9 +1701,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkBuffer buffer = VK_NULL_HANDLE;
         VkDeviceMemory memory = VK_NULL_HANDLE;
         void* mapped = nullptr;
+        VkDeviceSize offset = 0;
         VkDeviceSize bytes = 0;
         VkDeviceSize allocation_bytes = 0;
         bool pooled = false;
+        bool arena = false;
+    };
+    struct SharedBufferArena {
+        RenderHostBuffer buffer;
+        VkDeviceSize used = 0;
     };
     struct TextureBindingKey {
         std::array<uint64_t, 22> words{};
@@ -1720,6 +1740,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
     };
     std::vector<SharedBufferUpload> shared_buffers;
+    std::vector<SharedBufferArena> shared_buffer_arenas;
     std::unordered_map<SharedBufferKey, size_t, SharedBufferKeyHash> shared_buffer_indices;
     std::vector<SharedTextureBinding> shared_texture_bindings;
     std::unordered_map<TextureBindingKey, size_t, TextureBindingKeyHash>
@@ -1730,6 +1751,42 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         shared_pipeline_layouts;
     uint64_t resource_unique_tag = 0;
     const uint32_t zero_buffer_word = 0;
+    const VkDeviceSize storage_buffer_alignment = ctx.storage_buffer_alignment;
+    const bool use_buffer_arena = reuse_host_buffers &&
+        getenv("PROSPER_NO_BACKEND_BUFFER_ARENA") == nullptr;
+    auto align_storage_offset = [storage_buffer_alignment](VkDeviceSize value) {
+        const VkDeviceSize remainder = value % storage_buffer_alignment;
+        if (!remainder) return value;
+        const VkDeviceSize padding = storage_buffer_alignment - remainder;
+        return value <= UINT64_MAX - padding ? value + padding : VkDeviceSize{UINT64_MAX};
+    };
+    auto acquire_buffer_arena_slice = [&](VkDeviceSize bytes, SharedBufferUpload& upload) {
+        for (SharedBufferArena& arena : shared_buffer_arenas) {
+            const VkDeviceSize offset = align_storage_offset(arena.used);
+            if (offset != UINT64_MAX && offset <= arena.buffer.bytes &&
+                bytes <= arena.buffer.bytes - offset) {
+                upload.buffer = arena.buffer.buffer;
+                upload.mapped = arena.buffer.mapped;
+                upload.offset = offset;
+                upload.arena = true;
+                arena.used = offset + bytes;
+                return true;
+            }
+        }
+        VkDeviceSize request = std::max(render_host_buffer_arena_size(), bytes);
+        if (request < bytes) request = bytes;
+        RenderHostBuffer buffer = acquire_render_host_buffer(ctx, request);
+        if (!buffer.buffer || !buffer.memory || !buffer.mapped) {
+            destroy_render_host_buffer(ctx.dev, buffer);
+            return false;
+        }
+        shared_buffer_arenas.push_back({buffer, bytes});
+        upload.buffer = buffer.buffer;
+        upload.mapped = buffer.mapped;
+        upload.offset = 0;
+        upload.arena = true;
+        return true;
+    };
     auto handle_bits = [](auto handle) {
         uint64_t bits = 0;
         static_assert(sizeof(handle) <= sizeof(bits));
@@ -2257,7 +2314,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         buffer_index = shared_buffers.size();
                         SharedBufferUpload upload;
                         const VkDeviceSize bytes = static_cast<VkDeviceSize>(word_count) * 4;
-                        if (reuse_host_buffers) {
+                        if (use_buffer_arena)
+                            acquire_buffer_arena_slice(bytes, upload);
+                        if (!upload.arena && reuse_host_buffers) {
                             RenderHostBuffer pooled = acquire_render_host_buffer(ctx, bytes);
                             upload.buffer = pooled.buffer;
                             upload.memory = pooled.memory;
@@ -2266,7 +2325,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             upload.allocation_bytes = pooled.allocation_bytes;
                             upload.pooled = upload.buffer && upload.memory && upload.mapped;
                         }
-                        if (!upload.pooled) {
+                        if (!upload.arena && !upload.pooled) {
                             VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                             buffer_info.size = bytes;
                             buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
@@ -2285,14 +2344,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             std::memcpy(mapped, words, static_cast<size_t>(bytes));
                             vkUnmapMemory(dev, upload.memory);
                         } else {
-                            std::memcpy(upload.mapped, words, static_cast<size_t>(bytes));
+                            std::memcpy(static_cast<uint8_t*>(upload.mapped) + upload.offset,
+                                        words, static_cast<size_t>(bytes));
                         }
                         shared_buffers.push_back(upload);
                         shared_buffer_indices.emplace(buffer_key, buffer_index);
                         ++resource_reuse_stats.unique_buffers;
                     }
                     v.sbuf[i] = shared_buffers[buffer_index].buffer;
-                    dbi[i] = {v.sbuf[i], 0,
+                    dbi[i] = {v.sbuf[i], shared_buffers[buffer_index].offset,
                               static_cast<VkDeviceSize>(word_count) * sizeof(uint32_t)};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
@@ -2910,7 +2970,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (binding.view) vkDestroyImageView(dev, binding.view, nullptr);
     }
     for (const SharedBufferUpload& upload : shared_buffers) {
-        if (upload.pooled) {
+        if (upload.arena) {
+            continue;
+        } else if (upload.pooled) {
             release_render_host_buffer(
                 dev, {upload.buffer, upload.memory, upload.mapped,
                       upload.bytes, upload.allocation_bytes});
@@ -2919,6 +2981,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             if (upload.memory) release_transient_render_memory(dev, upload.memory);
         }
     }
+    for (SharedBufferArena& arena : shared_buffer_arenas)
+        release_render_host_buffer(dev, arena.buffer);
     auto evict_persistent_texture = [&]() {
         auto victim = persistent_texture_images.end();
         for (auto it = persistent_texture_images.begin();
@@ -3015,6 +3079,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             uint64_t calls = 0, draws = 0;
             uint64_t texture_references = 0, texture_uploads = 0, texture_upload_bytes = 0;
             uint64_t persistent_hits = 0, persistent_misses = 0, persistent_cached_bytes = 0;
+            uint64_t texture_binding_references = 0, unique_texture_bindings = 0;
+            uint64_t buffer_references = 0, unique_buffers = 0;
+            uint64_t descriptor_layout_references = 0, unique_descriptor_layouts = 0;
+            uint64_t pipeline_layout_references = 0, unique_pipeline_layouts = 0;
             uint64_t pipeline_references = 0, pipeline_hits = 0, pipeline_misses = 0;
             uint64_t pipeline_bypasses = 0, pipeline_entries = 0, pipeline_evictions = 0;
             double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
@@ -3031,6 +3099,16 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             timing.persistent_hits += texture_stats.persistent_hits;
             timing.persistent_misses += texture_stats.persistent_misses;
             timing.persistent_cached_bytes = texture_stats.persistent_cached_bytes;
+            timing.texture_binding_references += resource_reuse_stats.texture_binding_references;
+            timing.unique_texture_bindings += resource_reuse_stats.unique_texture_bindings;
+            timing.buffer_references += resource_reuse_stats.buffer_references;
+            timing.unique_buffers += resource_reuse_stats.unique_buffers;
+            timing.descriptor_layout_references +=
+                resource_reuse_stats.descriptor_set_layout_references;
+            timing.unique_descriptor_layouts +=
+                resource_reuse_stats.unique_descriptor_set_layouts;
+            timing.pipeline_layout_references += resource_reuse_stats.pipeline_layout_references;
+            timing.unique_pipeline_layouts += resource_reuse_stats.unique_pipeline_layouts;
             timing.pipeline_references += pipeline_stats.references;
             timing.pipeline_hits += pipeline_stats.hits;
             timing.pipeline_misses += pipeline_stats.misses;
@@ -3121,6 +3199,17 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     window.texture_upload_bytes / (wn * 1024.0 * 1024.0),
                     window.persistent_hits / wn, window.persistent_misses / wn,
                     window.persistent_cached_bytes / (1024.0 * 1024.0));
+            fprintf(stderr,
+                    "[render-window] backend resources texture_bindings=%.1f/%.1f "
+                    "buffers=%.1f/%.1f descriptor_layouts=%.1f/%.1f "
+                    "pipeline_layouts=%.1f/%.1f\n",
+                    window.texture_binding_references / wn,
+                    window.unique_texture_bindings / wn,
+                    window.buffer_references / wn, window.unique_buffers / wn,
+                    window.descriptor_layout_references / wn,
+                    window.unique_descriptor_layouts / wn,
+                    window.pipeline_layout_references / wn,
+                    window.unique_pipeline_layouts / wn);
             fprintf(stderr,
                     "[render-window] backend pipelines refs=%.1f hits=%.1f misses=%.1f bypass=%.1f "
                     "entries=%llu evictions=%.1f\n",

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -6,11 +6,14 @@
 // game's per-draw register-snapshot resolution.
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/render_state.hpp"
+#include "../src/gpu/shader_resources.hpp"
 #include "render_runner.h"
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -128,26 +131,62 @@ int main() {
     // A synchronous backend call may share those immutable objects after exact comparison, while the
     // disable switch provides a byte-identical one-object-per-reference control.
     {
+        const uint32_t fetch_vs[] = {
+            0x7e060280u, 0x7e0802f2u, 0xe0042000u, 0x80020100u,
+            0xf80008cfu, 0x04030201u, 0xbf810000u,
+        };
+        ShaderResourceTable fetch_resources;
+        ShaderResource vertex_resource{};
+        vertex_resource.cls = ResourceClass::VertexBuffer;
+        vertex_resource.format = DataFormat::Float32;
+        vertex_resource.num_components = 2;
+        vertex_resource.binding = 3;
+        vertex_resource.stride = 8;
+        vertex_resource.sgpr_base = 8;
+        fetch_resources.resources.push_back(vertex_resource);
+        const std::vector<uint32_t> buffer_vs = recompile_vertex(
+            fetch_vs, sizeof(fetch_vs) / sizeof(fetch_vs[0]), &fetch_resources);
+        CHECK(!buffer_vs.empty(), "storage-buffer-reading vertex shader available");
+        auto f = [](float value) {
+            union { float f; uint32_t u; } bits{value};
+            return bits.u;
+        };
+        prosper::test::FrameResource filler;
+        filler.binding = 2;
+        filler.set = 0;
+        filler.buffer_identity = 0x7020000000000002ull;
+        filler.dwords.assign(17, 0x40000000u);
         prosper::test::FrameResource buffer;
-        buffer.binding = 2;
+        buffer.binding = 3;
         buffer.set = 0;
-        buffer.buffer_identity = 0x7020000000000002ull;
-        buffer.dwords.assign(63, 0x3f800000u); // 252 bytes -> pooled 256-byte capacity
+        buffer.buffer_identity = 0x7020000000000003ull;
+        buffer.dwords.assign(63, 0u);
+        const uint32_t fullscreen_triangle[] = {
+            f(-1.0f), f(-1.0f), f(3.0f), f(-1.0f), f(-1.0f), f(3.0f),
+        };
+        std::copy(std::begin(fullscreen_triangle), std::end(fullscreen_triangle),
+                  buffer.dwords.begin());
         prosper::test::BackendDraw d0;
-        d0.vs = vs; d0.fs = red; d0.ps = &opaque; d0.vcount = 3; d0.R = {buffer};
+        d0.vs = buffer_vs; d0.fs = red; d0.ps = &opaque; d0.vcount = 3;
+        d0.R = {filler, buffer};
         prosper::test::BackendDraw d1;
-        d1.vs = vs; d1.fs = green; d1.ps = &additive; d1.vcount = 3; d1.R = {buffer};
+        d1.vs = buffer_vs; d1.fs = green; d1.ps = &additive; d1.vcount = 3;
+        d1.R = {filler, buffer};
 
         const auto pool_before = prosper::test::render_host_buffer_pool_stats();
         const std::vector<uint8_t> shared =
             prosper::test::render_draws_rgba({d0, d1}, W, H);
         const auto shared_stats = prosper::test::backend_resource_reuse_stats();
         const auto pool_after_first = prosper::test::render_host_buffer_pool_stats();
-        CHECK(shared_stats.buffer_references == 2 && shared_stats.unique_buffers == 1,
-              "identical guest-buffer payloads share one Vulkan upload");
+        CHECK(shared_stats.buffer_references == 4 && shared_stats.unique_buffers == 2,
+              "identical guest-buffer payloads share two arena slices across draws");
         CHECK(pool_after_first.misses == pool_before.misses + 1 &&
                   pool_after_first.cached_buffers == pool_before.cached_buffers + 1,
-              "first storage-buffer shape populates the persistent host-buffer pool");
+              "two logical uploads populate one persistent host-buffer arena");
+        const uint8_t* shared_center = center(shared);
+        CHECK(shared_center && shared_center[0] > 0xC0 && shared_center[1] > 0xC0 &&
+                  shared_center[2] < 0x40,
+              "shader reads the fullscreen vertex payload from a nonzero arena offset");
         CHECK(shared_stats.descriptor_set_layout_references == 2 &&
                   shared_stats.unique_descriptor_set_layouts == 1 &&
                   shared_stats.pipeline_layout_references == 2 &&
@@ -157,15 +196,15 @@ int main() {
 
         prosper::test::BackendDraw capacity_peer0 = d0;
         prosper::test::BackendDraw capacity_peer1 = d1;
-        capacity_peer0.R[0].dwords.resize(61); // 244 bytes, same 256-byte capacity class
-        capacity_peer1.R[0].dwords.resize(61);
+        capacity_peer0.R[1].dwords.resize(61);
+        capacity_peer1.R[1].dwords.resize(61);
         const std::vector<uint8_t> pooled_again = prosper::test::render_draws_rgba(
             {capacity_peer0, capacity_peer1}, W, H);
         const auto pool_after_second = prosper::test::render_host_buffer_pool_stats();
         CHECK(pool_after_second.hits == pool_after_first.hits + 1 &&
                   pool_after_second.misses == pool_after_first.misses &&
                   pooled_again == shared,
-              "next logical size in the capacity class reuses the mapped buffer byte-identically");
+              "next logical size reuses the mapped arena byte-identically");
 
         set_env("PROSPER_NO_BACKEND_BUFFER_POOL", "1");
         const std::vector<uint8_t> pool_bypassed =
@@ -179,11 +218,11 @@ int main() {
               "pooled and forced-transient storage buffers render byte-identically");
 
         prosper::test::BackendDraw distinct = d1;
-        distinct.R[0].buffer_identity++;
+        distinct.R[1].buffer_identity++;
         const std::vector<uint8_t> distinct_output =
             prosper::test::render_draws_rgba({d0, distinct}, W, H);
         const auto distinct_stats = prosper::test::backend_resource_reuse_stats();
-        CHECK(distinct_stats.buffer_references == 2 && distinct_stats.unique_buffers == 2 &&
+        CHECK(distinct_stats.buffer_references == 4 && distinct_stats.unique_buffers == 3 &&
                   distinct_output == shared,
               "equal bytes at different guest buffer identities remain distinct");
 
@@ -192,7 +231,7 @@ int main() {
             prosper::test::render_draws_rgba({d0, d1}, W, H);
         const auto unshared_stats = prosper::test::backend_resource_reuse_stats();
         set_env("PROSPER_NO_BACKEND_RESOURCE_SHARE", nullptr);
-        CHECK(unshared_stats.buffer_references == 2 && unshared_stats.unique_buffers == 2 &&
+        CHECK(unshared_stats.buffer_references == 4 && unshared_stats.unique_buffers == 4 &&
                   unshared_stats.unique_descriptor_set_layouts == 2 &&
                   unshared_stats.unique_pipeline_layouts == 2,
               "resource-share disable switch restores distinct per-draw immutable objects");


### PR DESCRIPTION
Continues the Evergate performance work tracked in #702.

## Problem

After pooling host-visible storage buffers, dense Evergate backend calls still checked out roughly 179 distinct Vulkan buffers for about 267 storage-buffer references. The repeated object and pool bookkeeping remained measurable even though allocation and teardown had already been removed.

The separately reported percentage-loading stall was investigated on current master with a fresh save and the normal first-gameplay route. A 240-second native Windows run progressed through the intro to the `HOLD X TO JUMP HIGHER` tutorial. That means the recent merged PRs do not deterministically cause the stall; it remains timing/state-dependent or a loader-starvation symptom, and this PR does not claim to fix it.

## Change

- Pack call-local logical storage uploads into non-overlapping slices of persistently mapped host-buffer arenas.
- Align every slice to `minStorageBufferOffsetAlignment` while retaining each descriptor's exact logical range.
- Return arenas to the existing bounded pool only after the backend fence wait.
- Preserve the former per-logical pooled path behind `PROSPER_NO_BACKEND_BUFFER_ARENA=1`; `PROSPER_BACKEND_BUFFER_ARENA_KB` tunes the 1 MiB default.
- Add gated resource-count telemetry and document the mechanism, controls, and measurements.
- Strengthen the focused Vulkan regression so the shader reads a buffer at a nonzero arena offset and verifies byte-identical pooled/transient output.

## Performance evidence

Native Windows / RTX 4090, one binary, separate fresh saves, native scale/cadence, and matched dense Evergate windows:

| Measurement | Per-logical pool | Packed arena |
|---|---:|---:|
| Draws / submit | 489.6 | 485.4 |
| Whole submit | 135.9 ms | 131.9 ms |
| Backend execution | 83.7 ms | 81.0 ms |
| Resource setup | 26.9 ms | 25.3 ms |
| Cleanup | 5.1 ms | 4.7 ms |
| GPU fence wait | 37.3 ms | 37.4 ms |
| Persistent buffers | 2,434 | 4 |
| Persistent mapped bytes | 6.7 MiB | 4.0 MiB |

A second nearby pair measured 139.4 to 133.6 ms whole-submit time. This is a modest 3-4% end-to-end improvement; the flat GPU wait remains the structural ceiling.

## Invariants and risk

The main risk is descriptor aliasing after many logical resources share one physical buffer. Slices never overlap, offsets use the physical device's required alignment, ranges remain exact, all shader-visible bytes are rewritten, and the arena is not recycled until the existing synchronous fence wait completes. Oversized uploads and allocation failure retain safe pooled/transient fallbacks.

## Verification

Corrected exact head `5598b0fcd71b7fe068024a5828407351d121225f` after review:

- `git diff --check` against immutable base `99f0891741ff2f82550eaea4e255021b764768b2`
- Linux full build
- Linux CTest: 112/112 passed
- Windows full build
- Windows CTest: 87/87 passed
- Evergate title snapshot guard: 9/9 qualifying and nonblack frames, 8 pixel changes
- Independent static review: approved on the exact head after one P2 test-coverage finding was corrected
- Mutation check: forcing arena descriptor offsets to zero fails the new observable-pixel assertion; restored implementation passes

The same production patch on the immediately preceding master head also passed the full routed matrix:

- Messenger: 29/29 qualifying, 8 pixel changes
- Evergate: 9/9 qualifying, 8 pixel changes
- Dead Cells: 44/44 qualifying, 43 pixel changes
- Blasphemous 2: 98/98 qualifying, 97 pixel changes

No snapshot baselines or expected pixels changed. Required CI is pending.