### PR TITLE
kernel: report direct backing in virtual queries (#387)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1395,6 +1395,10 @@ HLE(k_batch_map) {
         MLOG("bm op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
              op, (unsigned long long)start, (unsigned long long)phys,
              (unsigned long long)len, prot);
+        if (!len) {
+            ret = 0x80020016ull;
+            break;
+        }
         bool ok = true;
         switch (op) {
             case 0: {                               // MAP_DIRECT: phys-backed (aliasing preserved)
@@ -3779,6 +3783,10 @@ HLE(k_batch_map) {
         MLOG("bm op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
              op, (unsigned long long)start, (unsigned long long)phys,
              (unsigned long long)len, prot);
+        if (!len) {
+            ret = 0x80020016ull;
+            break;
+        }
         bool ok = true;
         switch (op) {
             case 0: {                               // MAP_DIRECT: shared physical backing

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -779,11 +779,12 @@ HLE(k_map_dmem) {
 }
 
 // sceKernelVirtualQuery(const void* addr, int flags, SceKernelVirtualQueryInfo* info, size_t infoSize)
-//   0x00 start; 0x08 end; 0x10 offset; 0x18 i32 prot; 0x1C i32 memType; 0x20 u32 flags; 0x24 name[32]
+//   0x00 start; 0x08 end; 0x10 offset; 0x18 i32 prot; 0x1C i32 memType;
+//   0x20 u8 classification; 0x21 name[32]
 HLE(k_virtual_query) {
     if (!a2) return 0x80020016ull;   // EINVAL (null out-param)
     uint8_t* info = (uint8_t*)a2;
-    uint64_t sz = a3 ? (a3 > 0x48 ? 0x48 : a3) : 0x48;
+    uint64_t sz = a3 ? (a3 > 0x41 ? 0x41 : a3) : 0x41;
     memset(info, 0, sz);
     Mapping mapping{};
     const bool found = snapshot_mapping(a0, mapping);
@@ -811,8 +812,8 @@ HLE(k_virtual_query) {
     if (sz >= 0x18) *(uint64_t*)(info + 0x10) = offset;
     if (sz >= 0x1c) *(int32_t*)(info + 0x18) = prot;
     if (sz >= 0x20) *(int32_t*)(info + 0x1c) = memory_type;
-    if (sz >= 0x24) *(uint32_t*)(info + 0x20) = flags;
-    if (sz >= 0x44 && found && mapping.name[0]) memcpy(info + 0x24, mapping.name, 32);
+    if (sz >= 0x21) info[0x20] = static_cast<uint8_t>(flags);
+    if (sz >= 0x41 && found && mapping.name[0]) memcpy(info + 0x21, mapping.name, 32);
     MLOG("virtual_query(0x%llx,f=0x%llx) -> [0x%llx,0x%llx) %s\n",
          (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)start, (unsigned long long)end, how);
     return 0;
@@ -3847,11 +3848,11 @@ HLE(k_batch_map) {
 }
 
 // sceKernelVirtualQuery(addr, flags, info*, infoSize): 0x00 start; 0x08 end; 0x10
-// physical offset; 0x18 protection; 0x1c memory type; 0x20 classification flags; 0x24 name.
+// physical offset; 0x18 protection; 0x1c memory type; 0x20 u8 classification; 0x21 name[32].
 HLE(k_virtual_query) {
     if (!a2) return 0x80020016ull;
     uint8_t* info = (uint8_t*)a2;
-    uint64_t sz = a3 ? (a3 > 0x48 ? 0x48 : a3) : 0x48;
+    uint64_t sz = a3 ? (a3 > 0x41 ? 0x41 : a3) : 0x41;
     memset(info, 0, sz);
     Mapping mapping{};
     const bool found = snapshot_mapping(a0, mapping);
@@ -3875,8 +3876,8 @@ HLE(k_virtual_query) {
     if (sz >= 0x18) *(uint64_t*)(info + 0x10) = offset;
     if (sz >= 0x1c) *(int32_t*)(info + 0x18) = prot;
     if (sz >= 0x20) *(int32_t*)(info + 0x1c) = memory_type;
-    if (sz >= 0x24) *(uint32_t*)(info + 0x20) = flags;
-    if (sz >= 0x44 && found && mapping.name[0]) memcpy(info + 0x24, mapping.name, 32);
+    if (sz >= 0x21) info[0x20] = static_cast<uint8_t>(flags);
+    if (sz >= 0x41 && found && mapping.name[0]) memcpy(info + 0x21, mapping.name, 32);
     return 0;
 }
 

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -48,6 +48,21 @@ namespace {
     constexpr uint32_t kVirtualQueryFlexible = 0x01;
     constexpr uint32_t kVirtualQueryDirect   = 0x02;
     constexpr uint32_t kVirtualQueryCommitted = 0x10;
+    constexpr uint64_t kGuestPageSize = 0x4000;
+
+    bool normalize_guest_page_range(uint64_t addr, uint64_t len,
+                                    uint64_t& base_out, uint64_t& len_out) {
+        constexpr uint64_t mask = kGuestPageSize - 1;
+        if (len > UINT64_MAX - addr) return false;
+        const uint64_t raw_end = addr + len;
+        if (raw_end > UINT64_MAX - mask) return false;
+        const uint64_t base = addr & ~mask;
+        const uint64_t end = (raw_end + mask) & ~mask;
+        if (end <= base) return false;
+        base_out = base;
+        len_out = end - base;
+        return true;
+    }
 
     struct Mapping {
         uint64_t base, size, offset;
@@ -960,10 +975,12 @@ HLE7(k_map_dmem2) {
 // memory type (a2). Only publish either change after the host protection operation succeeds.
 HLE(k_mtypeprotect) {
     if (!a0) return 0x80020016ull;
+    uint64_t base = 0, len = 0;
+    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
     const int prot = host_prot(a3);
-    if (mprotect((void*)a0, a1, prot) != 0) return sce_mprotect_error(errno);
-    retrack_prot(a0, a1, prot, static_cast<uint32_t>(a3), "mtypeprotect");
-    retrack_type(a0, a1, static_cast<int32_t>(a2));
+    if (mprotect((void*)base, len, prot) != 0) return sce_mprotect_error(errno);
+    retrack_prot(base, len, prot, static_cast<uint32_t>(a3), "mtypeprotect");
+    retrack_type(base, len, static_cast<int32_t>(a2));
     return 0;
 }
 HLE(k_dmem_size){ return kDmemTotal; }   // sparse-backed; allocation failures enforce this bound
@@ -1541,6 +1558,21 @@ namespace {
     constexpr uint32_t kVirtualQueryFlexible = 0x01;
     constexpr uint32_t kVirtualQueryDirect   = 0x02;
     constexpr uint32_t kVirtualQueryCommitted = 0x10;
+    constexpr uint64_t kGuestPageSize = 0x4000;
+
+    bool normalize_guest_page_range(uint64_t addr, uint64_t len,
+                                    uint64_t& base_out, uint64_t& len_out) {
+        constexpr uint64_t mask = kGuestPageSize - 1;
+        if (len > UINT64_MAX - addr) return false;
+        const uint64_t raw_end = addr + len;
+        if (raw_end > UINT64_MAX - mask) return false;
+        const uint64_t base = addr & ~mask;
+        const uint64_t end = (raw_end + mask) & ~mask;
+        if (end <= base) return false;
+        base_out = base;
+        len_out = end - base;
+        return true;
+    }
 
     struct Mapping {
         uint64_t base, size, offset;
@@ -3691,11 +3723,13 @@ HLE(k_mprotect) {
 }
 HLE(k_mtypeprotect) {
     if (!a0) return 0x80020016ull;
+    uint64_t base = 0, len = 0;
+    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
     const int prot = host_prot(a3);
     DWORD error = ERROR_SUCCESS;
-    if (!win_protect(a0, a1, prot, &error)) return sce_win_mprotect_error(error);
-    retrack_prot(a0, a1, prot, static_cast<uint32_t>(a3), "mtypeprotect");
-    retrack_type(a0, a1, static_cast<int32_t>(a2));
+    if (!win_protect(base, len, prot, &error)) return sce_win_mprotect_error(error);
+    retrack_prot(base, len, prot, static_cast<uint32_t>(a3), "mtypeprotect");
+    retrack_type(base, len, static_cast<int32_t>(a2));
     return 0;
 }
 HLE(k_dmem_size){ return kDmemTotal; }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <atomic>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace prosper {
@@ -44,10 +45,16 @@ namespace {
     bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
     #define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
 
+    constexpr uint32_t kVirtualQueryFlexible = 0x01;
+    constexpr uint32_t kVirtualQueryDirect   = 0x02;
+    constexpr uint32_t kVirtualQueryCommitted = 0x10;
+
     struct Mapping {
-        uint64_t base, size;
+        uint64_t base, size, offset;
         int prot;                  // normalized host CPU-access mask
         uint32_t guest_prot;       // exact SCE protection enum/bits returned to the guest
+        int32_t memory_type;        // direct-memory type; meaningful only with is_direct
+        uint32_t query_flags;       // is_flexible / is_direct bits (commit state is separate)
         bool committed;
         char name[32];
     };
@@ -66,6 +73,12 @@ namespace {
     struct DMem { uint64_t start, end; int type; };
     std::mutex g_dmx;
     std::vector<DMem> g_dmem;
+
+    void rebase_mapping(Mapping& mapping, uint64_t new_base) {
+        if ((mapping.query_flags & kVirtualQueryDirect) && new_base > mapping.base)
+            mapping.offset += new_base - mapping.base;
+        mapping.base = new_base;
+    }
 
     // Claim `sz` bytes of direct memory at `align`, first-fit over the pool's free gaps WITHIN the
     // caller's [lo, hi) search window (default = the whole pool). False (no state change) when
@@ -138,10 +151,44 @@ namespace {
         g_dmem.swap(out);
     }
 
+    bool dmem_type_at(uint64_t offset, int32_t& type_out) {
+        std::lock_guard<std::mutex> lk(g_dmx);
+        for (const auto& d : g_dmem) {
+            if (offset >= d.start && offset < d.end) {
+                type_out = d.type;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Change the memory type of an allocated physical subrange. Carving the allocation keeps
+    // GetDirectMemoryType/DirectMemoryQuery truthful after Mtypeprotect or MapDirectMemory2.
+    void dmem_retype(uint64_t start, uint64_t len, int32_t type) {
+        if (!len || start > UINT64_MAX - len) return;
+        const uint64_t end = start + len;
+        std::lock_guard<std::mutex> lk(g_dmx);
+        std::vector<DMem> out;
+        out.reserve(g_dmem.size() + 2);
+        for (const auto& d : g_dmem) {
+            if (d.end <= start || d.start >= end) {
+                out.push_back(d);
+                continue;
+            }
+            if (d.start < start) out.push_back({d.start, start, d.type});
+            const uint64_t changed_start = d.start < start ? start : d.start;
+            const uint64_t changed_end = d.end > end ? end : d.end;
+            out.push_back({changed_start, changed_end, type});
+            if (d.end > end) out.push_back({end, d.end, d.type});
+        }
+        g_dmem.swap(out);
+    }
+
     // A successful host map replaces any reservation record under it. Keeping both as overlays
     // lets the older uncommitted record win same-base queries after the real commit.
     void track(uint64_t base, uint64_t size, int prot, uint32_t guest_prot,
-               bool committed, const char* nm) {
+               bool committed, const char* nm, uint32_t query_flags = 0,
+               uint64_t offset = 0, int32_t memory_type = 0) {
         if (!size || base > UINT64_MAX - size) return;
         const uint64_t end = base + size;
         {
@@ -155,10 +202,21 @@ namespace {
                     Mapping lo = old; lo.size = base - old.base; out.push_back(lo);
                 }
                 if (old_end > end) {
-                    Mapping hi = old; hi.base = end; hi.size = old_end - end; out.push_back(hi);
+                    Mapping hi = old;
+                    rebase_mapping(hi, end);
+                    hi.size = old_end - end;
+                    out.push_back(hi);
                 }
             }
-            Mapping m{ base, size, prot, guest_prot, committed, {0} };
+            Mapping m{};
+            m.base = base;
+            m.size = size;
+            m.offset = offset;
+            m.prot = prot;
+            m.guest_prot = guest_prot;
+            m.memory_type = memory_type;
+            m.query_flags = query_flags;
+            m.committed = committed;
             if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
             out.push_back(m);
             g_maps.swap(out);
@@ -181,7 +239,12 @@ namespace {
             uint64_t me = m.base + m.size;
             if (me <= base || m.base >= end) { out.push_back(m); continue; }
             if (m.base < base) { Mapping lo = m; lo.size = base - m.base; out.push_back(lo); }
-            if (me > end)      { Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi); }
+            if (me > end) {
+                Mapping hi = m;
+                rebase_mapping(hi, end);
+                hi.size = me - end;
+                out.push_back(hi);
+            }
         }
         g_maps.swap(out);
         host::notify_guest_mapping_removed(base, len);
@@ -205,7 +268,7 @@ namespace {
                     Mapping lo = m; lo.size = base - m.base; out.push_back(lo);
                 }
                 Mapping changed = m;
-                changed.base = m.base < base ? base : m.base;
+                rebase_mapping(changed, m.base < base ? base : m.base);
                 const uint64_t changed_end = me > end ? end : me;
                 changed.size = changed_end - changed.base;
                 changed.prot = prot;
@@ -215,13 +278,21 @@ namespace {
                 out.push_back(changed);
                 retagged.push_back(changed);
                 if (me > end) {
-                    Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi);
+                    Mapping hi = m;
+                    rebase_mapping(hi, end);
+                    hi.size = me - end;
+                    out.push_back(hi);
                 }
             }
             // Preserve the prior treatment of a successful protection change over an otherwise
             // untracked host mapping: begin tracking it as committed.
             if (retagged.empty()) {
-                Mapping changed{base, len, prot, guest_prot, true, {0}};
+                Mapping changed{};
+                changed.base = base;
+                changed.size = len;
+                changed.prot = prot;
+                changed.guest_prot = guest_prot;
+                changed.committed = true;
                 if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
                 out.push_back(changed);
                 retagged.push_back(changed);
@@ -231,6 +302,48 @@ namespace {
         host::notify_guest_mapping_removed(base, len);
         for (const auto& m : retagged)
             host::notify_guest_mapping_added(m.base, m.size, m.committed && (prot & 0x1));
+    }
+
+    // Re-tag direct mappings with a new memory type while preserving virtual-to-physical offset
+    // correspondence across every carved prefix/suffix. Flexible/reserved mappings have no type.
+    void retrack_type(uint64_t base, uint64_t len, int32_t memory_type) {
+        if (!len || base > UINT64_MAX - len) return;
+        const uint64_t end = base + len;
+        std::vector<std::pair<uint64_t, uint64_t>> physical_ranges;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            std::vector<Mapping> out;
+            out.reserve(g_maps.size() + 2);
+            for (const auto& mapping : g_maps) {
+                const uint64_t mapping_end = mapping.base + mapping.size;
+                if (mapping_end <= base || mapping.base >= end ||
+                    !(mapping.query_flags & kVirtualQueryDirect)) {
+                    out.push_back(mapping);
+                    continue;
+                }
+                if (mapping.base < base) {
+                    Mapping prefix = mapping;
+                    prefix.size = base - mapping.base;
+                    out.push_back(prefix);
+                }
+                Mapping changed = mapping;
+                rebase_mapping(changed, mapping.base < base ? base : mapping.base);
+                const uint64_t changed_end = mapping_end > end ? end : mapping_end;
+                changed.size = changed_end - changed.base;
+                changed.memory_type = memory_type;
+                physical_ranges.emplace_back(changed.offset, changed.size);
+                out.push_back(changed);
+                if (mapping_end > end) {
+                    Mapping suffix = mapping;
+                    rebase_mapping(suffix, end);
+                    suffix.size = mapping_end - end;
+                    out.push_back(suffix);
+                }
+            }
+            g_maps.swap(out);
+        }
+        for (const auto& range : physical_ranges)
+            dmem_retype(range.first, range.second, memory_type);
     }
     bool snapshot_mapping(uint64_t addr, Mapping& out) {
         std::lock_guard<std::mutex> lk(g_mx);
@@ -542,7 +655,7 @@ HLE(k_map_flexible) {
     if (!p) { MLOG("mapflexible hint=0x%llx len=0x%llx FAILED\n", (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; } // ENOMEM
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), static_cast<uint32_t>(a2), true,
-          a4 ? (const char*)a4 : "flexible");
+          a4 ? (const char*)a4 : "flexible", kVirtualQueryFlexible);
     MLOG("mapflexible -> 0x%llx len=0x%llx prot=0x%llx name=%s\n",
          (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a2, a4 ? (const char*)a4 : "");
     return 0;
@@ -623,21 +736,31 @@ HLE(k_direct_memory_query) {
     return 0;
 }
 
+static uint64_t map_dmem_impl(uint64_t addr_in_out, uint64_t len, uint64_t prot,
+                              uint64_t flags, uint64_t phys, uint64_t align,
+                              int32_t memory_type, bool set_memory_type) {
+    uint64_t hint = addr_in_out ? *(uint64_t*)addr_in_out : 0;
+    const bool fixed = (flags & 0x10) != 0;
+    void* p = map_phys_at(hint, len, host_prot(prot), phys, align, fixed);
+    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx flags=0x%llx phys=0x%llx align=0x%llx FAILED\n",
+                   (unsigned long long)hint, (unsigned long long)len,
+                   (unsigned long long)flags, (unsigned long long)phys,
+                   (unsigned long long)align); return 0x8002000cull; } // ENOMEM
+    if (set_memory_type) dmem_retype(phys, len, memory_type);
+    if (addr_in_out) *(uint64_t*)addr_in_out = (uint64_t)p;
+    track((uint64_t)p, len, host_prot(prot), static_cast<uint32_t>(prot), true,
+          "direct", kVirtualQueryDirect, phys, memory_type);
+    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
+         (unsigned long long)p, (unsigned long long)len, (unsigned long long)phys,
+         (unsigned long long)prot, (unsigned long long)flags, (unsigned long long)align);
+    return 0;
+}
+
 // sceKernelMapDirectMemory(void** addrInOut, size_t len, int prot, int flags, off_t phys, size_t align)
 HLE(k_map_dmem) {
-    uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
-    const bool fixed = (a3 & 0x10) != 0;
-    void* p = map_phys_at(hint, a1, host_prot(a2), a4, a5, fixed);
-    if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx flags=0x%llx phys=0x%llx align=0x%llx FAILED\n",
-                   (unsigned long long)hint, (unsigned long long)a1,
-                   (unsigned long long)a3, (unsigned long long)a4,
-                   (unsigned long long)a5); return 0x8002000cull; } // ENOMEM
-    if (a0) *(uint64_t*)a0 = (uint64_t)p;
-    track((uint64_t)p, a1, host_prot(a2), static_cast<uint32_t>(a2), true, "direct");
-    MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
-         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4,
-         (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)a5);
-    return 0;
+    int32_t memory_type = 0;
+    dmem_type_at(a4, memory_type);
+    return map_dmem_impl(a0, a1, a2, a3, a4, a5, memory_type, false);
 }
 
 // sceKernelVirtualQuery(const void* addr, int flags, SceKernelVirtualQueryInfo* info, size_t infoSize)
@@ -649,7 +772,7 @@ HLE(k_virtual_query) {
     memset(info, 0, sz);
     Mapping mapping{};
     const bool found = snapshot_mapping(a0, mapping);
-    uint64_t start, end; int prot; uint32_t flags;
+    uint64_t start, end, offset = 0; int prot, memory_type = 0; uint32_t flags;
     const char* how;
     if (found) {                               // inside a real mapping
         // Report the mapping's REAL commit state: a reserved-but-uncommitted range has NO access
@@ -659,7 +782,10 @@ HLE(k_virtual_query) {
         // Keep Sony's exact protection value: CPU_RW is enum 0x02 (not host R|W 0x03), and
         // GPU-only bits have no host-page-protection equivalent but remain guest-visible state.
         prot = mapping.committed ? static_cast<int>(mapping.guest_prot) : 0x0;
-        flags = mapping.committed ? 0x10 : 0x0; how = "tracked";
+        offset = (mapping.query_flags & kVirtualQueryDirect) ? mapping.offset : 0;
+        memory_type = (mapping.query_flags & kVirtualQueryDirect) ? mapping.memory_type : 0;
+        flags = mapping.query_flags |
+                (mapping.committed ? kVirtualQueryCommitted : 0); how = "tracked";
     } else {                                   // unmapped: report the whole hole to the next mapping
         uint64_t nb = next_base(a0);
         if (!nb) { MLOG("virtual_query(0x%llx) -> end-of-space (EACCES)\n", (unsigned long long)a0); return 0x8002000e; }
@@ -667,7 +793,9 @@ HLE(k_virtual_query) {
     }
     if (sz >= 0x08) *(uint64_t*)(info + 0x00) = start;
     if (sz >= 0x10) *(uint64_t*)(info + 0x08) = end;
+    if (sz >= 0x18) *(uint64_t*)(info + 0x10) = offset;
     if (sz >= 0x1c) *(int32_t*)(info + 0x18) = prot;
+    if (sz >= 0x20) *(int32_t*)(info + 0x1c) = memory_type;
     if (sz >= 0x24) *(uint32_t*)(info + 0x20) = flags;
     if (sz >= 0x44 && found && mapping.name[0]) memcpy(info + 0x24, mapping.name, 32);
     MLOG("virtual_query(0x%llx,f=0x%llx) -> [0x%llx,0x%llx) %s\n",
@@ -823,20 +951,21 @@ HLE(k_mprotect) {
     return 0;
 }
 
-// sceKernelMapDirectMemory2(void** addrInOut, len, type, prot, flags, phys, align) inserts a
-// memory-type argument before the ordinary mapper's protection argument. The current VA tracker
-// does not expose per-mapping memory types yet, but mapping must still consume the shifted
-// protection/flags/physical-offset/alignment arguments rather than silently returning success.
+// sceKernelMapDirectMemory2 inserts a memory-type argument before protection. A successful map
+// applies that explicit type to both this VMA and the corresponding physical-allocation range.
 HLE7(k_map_dmem2) {
-    (void)a2;   // Memory-type reporting is tracked separately in #387.
-    return k_map_dmem(a0, a1, a3, a4, a5, a6);
+    return map_dmem_impl(a0, a1, a3, a4, a5, a6, static_cast<int32_t>(a2), true);
 }
 // sceKernelMtypeprotect(addr, size, mtype, prot): apply the CPU protection (arg a3) then set the direct-
-// memory type (a2). Was MISSING -> the stub returned success without applying EITHER, so a later access
-// under the wrong protection faults (write to a still-RO page / exec of a still-NX page) -- the same class
-// as the batch-map TYPE_PROTECT op. We don't track memoryType yet, so apply the protection (the load-
-// bearing half). NOTE prot is arg a3 here, not a2.
-HLE(k_mtypeprotect) { if (a0) { mprotect((void*)a0, a1, host_prot(a3)); retrack_prot(a0, a1, host_prot(a3), static_cast<uint32_t>(a3), "mtypeprotect"); } return 0; }
+// memory type (a2). Only publish either change after the host protection operation succeeds.
+HLE(k_mtypeprotect) {
+    if (!a0) return 0x80020016ull;
+    const int prot = host_prot(a3);
+    if (mprotect((void*)a0, a1, prot) != 0) return sce_mprotect_error(errno);
+    retrack_prot(a0, a1, prot, static_cast<uint32_t>(a3), "mtypeprotect");
+    retrack_type(a0, a1, static_cast<int32_t>(a2));
+    return 0;
+}
 HLE(k_dmem_size){ return kDmemTotal; }   // sparse-backed; allocation failures enforce this bound
 // sceKernelAvailableDirectMemorySize(searchStart, searchEnd, alignment, off_t* physAddrOut,
 // size_t* sizeOut) — report the LARGEST free aligned direct-memory block in [searchStart, searchEnd).
@@ -1157,7 +1286,9 @@ HLE(k_ampr_push_map) {
         bool have_phys = dmem_take(a2, 0x10000, 0x0c, phys);
         void* p = have_phys ? map_phys_at(a1, a2, PROT_READ | PROT_WRITE, phys)
                             : map_at(a1, a2, PROT_READ | PROT_WRITE);
-        if (p) track((uint64_t)p, a2, PROT_READ | PROT_WRITE, 0x2, true, "ampr-map");
+        if (p) track((uint64_t)p, a2, PROT_READ | PROT_WRITE, 0x2, true, "ampr-map",
+                     have_phys ? kVirtualQueryDirect : 0, have_phys ? phys : 0,
+                     have_phys ? 0x0c : 0);
         if (p && have_phys && a1 > 0x540000000ull + 0x1000000000ull) {
             uint64_t mirror = a1 - 0x540000000ull;
             // issue #107: the mirror is a LOW-confidence heuristic (the 0x540000000 rule was pinned
@@ -1183,7 +1314,8 @@ HLE(k_ampr_push_map) {
                      (unsigned long long)a1, (unsigned long long)mirror);
             } else {
                 q = map_phys_at(mirror, a2, PROT_READ | PROT_WRITE, phys);
-                if (q) track((uint64_t)q, a2, PROT_READ | PROT_WRITE, 0x2, true, "ampr-mirror");
+                if (q) track((uint64_t)q, a2, PROT_READ | PROT_WRITE, 0x2, true,
+                             "ampr-mirror", kVirtualQueryDirect, phys, 0x0c);
             }
             MLOG("ampr push-map va=0x%llx len=0x%llx phys=0x%llx mirror=0x%llx -> %s/%s\n",
                  (unsigned long long)a1, (unsigned long long)a2, (unsigned long long)phys,
@@ -1238,6 +1370,7 @@ HLE(k_batch_map) {
         uint64_t phys  = *(const uint64_t*)(e + 0x08);
         uint64_t len   = *(const uint64_t*)(e + 0x10);
         uint8_t  prot  = e[0x18];
+        int32_t  type  = e[0x19];
         int32_t  op    = *(const int32_t*)(e + 0x1c);
         // Per-entry phys trace (#312 alias hunt): log map/unmap WITH the phys offset so an offline
         // pass can prove/disprove two live VAs aliasing one phys range through the shared memfd.
@@ -1249,19 +1382,32 @@ HLE(k_batch_map) {
             case 0: {                               // MAP_DIRECT: phys-backed (aliasing preserved)
                 void* p = map_phys_at(start, len, host_prot(prot), phys);
                 ok = (p != nullptr);
-                if (ok) track((uint64_t)p, len, host_prot(prot), prot, true, "batch-direct");
+                int32_t memory_type = 0;
+                dmem_type_at(phys, memory_type);
+                if (ok) track((uint64_t)p, len, host_prot(prot), prot, true,
+                              "batch-direct", kVirtualQueryDirect, phys, memory_type);
                 break;
             }
             case 3: {                               // MAP_FLEXIBLE: anonymous
                 void* p = map_at(start, len, host_prot(prot));
                 ok = (p != nullptr);
-                if (ok) track((uint64_t)p, len, host_prot(prot), prot, true, "batch-flex");
+                if (ok) track((uint64_t)p, len, host_prot(prot), prot, true,
+                              "batch-flex", kVirtualQueryFlexible);
                 break;
             }
             case 1: if (start) { munmap((void*)(uintptr_t)start, len); untrack(start, len); } break;  // UNMAP
-            case 2: case 4:                                                              // PROTECT / TYPE_PROTECT
-                if (start) { mprotect((void*)(uintptr_t)start, len, host_prot(prot));
-                             retrack_prot(start, len, host_prot(prot), prot, "batch-prot"); } break;
+            case 2: case 4: {                                                            // PROTECT / TYPE_PROTECT
+                if (start) {
+                    if (mprotect((void*)(uintptr_t)start, len, host_prot(prot)) != 0) {
+                        ok = false;
+                        ret = sce_mprotect_error(errno);
+                    } else {
+                        retrack_prot(start, len, host_prot(prot), prot, "batch-prot");
+                        if (op == 4) retrack_type(start, len, type);
+                    }
+                }
+                break;
+            }
             default: ok = false; ret = 0x80020016ull; break;
         }
         if (!ok) { if (!ret) ret = 0x8002000Cull; break; }   // ENOMEM on a failed map
@@ -1377,6 +1523,7 @@ void register_kernel_mem_hle() {
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace prosper {
@@ -1391,10 +1538,16 @@ namespace {
     #define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
 
     // --- VA tracker + direct-memory pool: PURE logic, copied verbatim from the Linux path -----
+    constexpr uint32_t kVirtualQueryFlexible = 0x01;
+    constexpr uint32_t kVirtualQueryDirect   = 0x02;
+    constexpr uint32_t kVirtualQueryCommitted = 0x10;
+
     struct Mapping {
-        uint64_t base, size;
+        uint64_t base, size, offset;
         int prot;                  // normalized host CPU mask
         uint32_t guest_prot;       // exact SCE protection enum/bits returned to the guest
+        int32_t memory_type;        // direct-memory type; meaningful only with is_direct
+        uint32_t query_flags;       // is_flexible / is_direct bits (commit state is separate)
         bool committed;
         char name[32];
     };
@@ -1406,6 +1559,12 @@ namespace {
     struct DMem { uint64_t start, end; int type; };
     std::mutex g_dmx;
     std::vector<DMem> g_dmem;
+
+    void rebase_mapping(Mapping& mapping, uint64_t new_base) {
+        if ((mapping.query_flags & kVirtualQueryDirect) && new_base > mapping.base)
+            mapping.offset += new_base - mapping.base;
+        mapping.base = new_base;
+    }
 
     // First-fit claim of `sz` bytes at `align` within [lo,hi) — identical to the Linux allocator.
     bool dmem_take(uint64_t sz, uint64_t align, int type, uint64_t& off_out,
@@ -1460,9 +1619,42 @@ namespace {
         }
         g_dmem.swap(out);
     }
+
+    bool dmem_type_at(uint64_t offset, int32_t& type_out) {
+        std::lock_guard<std::mutex> lk(g_dmx);
+        for (const auto& d : g_dmem) {
+            if (offset >= d.start && offset < d.end) {
+                type_out = d.type;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void dmem_retype(uint64_t start, uint64_t len, int32_t type) {
+        if (!len || start > UINT64_MAX - len) return;
+        const uint64_t end = start + len;
+        std::lock_guard<std::mutex> lk(g_dmx);
+        std::vector<DMem> out;
+        out.reserve(g_dmem.size() + 2);
+        for (const auto& d : g_dmem) {
+            if (d.end <= start || d.start >= end) {
+                out.push_back(d);
+                continue;
+            }
+            if (d.start < start) out.push_back({d.start, start, d.type});
+            const uint64_t changed_start = d.start < start ? start : d.start;
+            const uint64_t changed_end = d.end > end ? end : d.end;
+            out.push_back({changed_start, changed_end, type});
+            if (d.end > end) out.push_back({end, d.end, d.type});
+        }
+        g_dmem.swap(out);
+    }
     // Keep tracking non-overlapping when a commit replaces part of an existing reservation.
     void track(uint64_t base, uint64_t size, int prot, uint32_t guest_prot,
-               bool committed, const char* nm, bool host_readable = true) {
+               bool committed, const char* nm, uint32_t query_flags = 0,
+               uint64_t offset = 0, int32_t memory_type = 0,
+               bool host_readable = true) {
         if (!size || base > UINT64_MAX - size) return;
         const uint64_t end = base + size;
         {
@@ -1476,10 +1668,21 @@ namespace {
                     Mapping lo = old; lo.size = base - old.base; out.push_back(lo);
                 }
                 if (old_end > end) {
-                    Mapping hi = old; hi.base = end; hi.size = old_end - end; out.push_back(hi);
+                    Mapping hi = old;
+                    rebase_mapping(hi, end);
+                    hi.size = old_end - end;
+                    out.push_back(hi);
                 }
             }
-            Mapping m{ base, size, prot, guest_prot, committed, {0} };
+            Mapping m{};
+            m.base = base;
+            m.size = size;
+            m.offset = offset;
+            m.prot = prot;
+            m.guest_prot = guest_prot;
+            m.memory_type = memory_type;
+            m.query_flags = query_flags;
+            m.committed = committed;
             if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
             out.push_back(m);
             g_maps.swap(out);
@@ -1497,7 +1700,12 @@ namespace {
             uint64_t me = m.base + m.size;
             if (me <= base || m.base >= end) { out.push_back(m); continue; }
             if (m.base < base) { Mapping lo = m; lo.size = base - m.base; out.push_back(lo); }
-            if (me > end)      { Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi); }
+            if (me > end) {
+                Mapping hi = m;
+                rebase_mapping(hi, end);
+                hi.size = me - end;
+                out.push_back(hi);
+            }
         }
         g_maps.swap(out);
         host::notify_guest_mapping_removed(base, len);
@@ -1518,7 +1726,7 @@ namespace {
                     Mapping lo = m; lo.size = base - m.base; out.push_back(lo);
                 }
                 Mapping changed = m;
-                changed.base = m.base < base ? base : m.base;
+                rebase_mapping(changed, m.base < base ? base : m.base);
                 const uint64_t changed_end = me > end ? end : me;
                 changed.size = changed_end - changed.base;
                 changed.prot = prot;
@@ -1528,11 +1736,19 @@ namespace {
                 out.push_back(changed);
                 retagged.push_back(changed);
                 if (me > end) {
-                    Mapping hi = m; hi.base = end; hi.size = me - end; out.push_back(hi);
+                    Mapping hi = m;
+                    rebase_mapping(hi, end);
+                    hi.size = me - end;
+                    out.push_back(hi);
                 }
             }
             if (retagged.empty()) {
-                Mapping changed{base, len, prot, guest_prot, true, {0}};
+                Mapping changed{};
+                changed.base = base;
+                changed.size = len;
+                changed.prot = prot;
+                changed.guest_prot = guest_prot;
+                changed.committed = true;
                 if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
                 out.push_back(changed);
                 retagged.push_back(changed);
@@ -1547,6 +1763,46 @@ namespace {
             host::notify_guest_mapping_added(
                 m.base, m.size, m.committed && host_readable && (prot & 0x1));
         }
+    }
+
+    void retrack_type(uint64_t base, uint64_t len, int32_t memory_type) {
+        if (!len || base > UINT64_MAX - len) return;
+        const uint64_t end = base + len;
+        std::vector<std::pair<uint64_t, uint64_t>> physical_ranges;
+        {
+            std::lock_guard<std::mutex> lk(g_mx);
+            std::vector<Mapping> out;
+            out.reserve(g_maps.size() + 2);
+            for (const auto& mapping : g_maps) {
+                const uint64_t mapping_end = mapping.base + mapping.size;
+                if (mapping_end <= base || mapping.base >= end ||
+                    !(mapping.query_flags & kVirtualQueryDirect)) {
+                    out.push_back(mapping);
+                    continue;
+                }
+                if (mapping.base < base) {
+                    Mapping prefix = mapping;
+                    prefix.size = base - mapping.base;
+                    out.push_back(prefix);
+                }
+                Mapping changed = mapping;
+                rebase_mapping(changed, mapping.base < base ? base : mapping.base);
+                const uint64_t changed_end = mapping_end > end ? end : mapping_end;
+                changed.size = changed_end - changed.base;
+                changed.memory_type = memory_type;
+                physical_ranges.emplace_back(changed.offset, changed.size);
+                out.push_back(changed);
+                if (mapping_end > end) {
+                    Mapping suffix = mapping;
+                    rebase_mapping(suffix, end);
+                    suffix.size = mapping_end - end;
+                    out.push_back(suffix);
+                }
+            }
+            g_maps.swap(out);
+        }
+        for (const auto& range : physical_ranges)
+            dmem_retype(range.first, range.second, memory_type);
     }
     bool snapshot_mapping(uint64_t addr, Mapping& out) {
         std::lock_guard<std::mutex> lk(g_mx);
@@ -3318,7 +3574,7 @@ HLE(k_map_flexible) {
                    (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; }
     if (a0) *(uint64_t*)a0 = (uint64_t)p;
     track((uint64_t)p, a1, host_prot(a2), static_cast<uint32_t>(a2), true,
-          a4 ? (const char*)a4 : "flexible");
+          a4 ? (const char*)a4 : "flexible", kVirtualQueryFlexible);
     MLOG("mapflexible -> 0x%llx len=0x%llx prot=0x%llx\n",
          (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a2);
     return 0;
@@ -3380,29 +3636,36 @@ HLE(k_direct_memory_query) {
     return 0;
 }
 
-// sceKernelMapDirectMemory(void** addrInOut, len, prot, flags, off_t phys, size_t align)
-HLE(k_map_dmem) {
-    uint64_t hint = a0 ? *(uint64_t*)a0 : 0;
-    const bool fixed = (a3 & 0x10) != 0;
-    void* p = win_map_phys(hint, a1, host_prot(a2), a4, a5, fixed);
+static uint64_t map_dmem_impl(uint64_t addr_in_out, uint64_t len, uint64_t prot,
+                              uint64_t flags, uint64_t phys, uint64_t align,
+                              int32_t memory_type, bool set_memory_type) {
+    uint64_t hint = addr_in_out ? *(uint64_t*)addr_in_out : 0;
+    const bool fixed = (flags & 0x10) != 0;
+    void* p = win_map_phys(hint, len, host_prot(prot), phys, align, fixed);
     if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx FAILED\n",
-                   (unsigned long long)hint, (unsigned long long)a1); return 0x8002000cull; }
-    if (a0) *(uint64_t*)a0 = (uint64_t)p;
-    const bool sparse = sparse_dmem_view_contains((uint64_t)p, (uint64_t)p + a1);
-    track((uint64_t)p, a1, host_prot(a2), static_cast<uint32_t>(a2), true,
-          "direct", !sparse);
+                   (unsigned long long)hint, (unsigned long long)len); return 0x8002000cull; }
+    if (set_memory_type) dmem_retype(phys, len, memory_type);
+    if (addr_in_out) *(uint64_t*)addr_in_out = (uint64_t)p;
+    const bool sparse = sparse_dmem_view_contains((uint64_t)p, (uint64_t)p + len);
+    track((uint64_t)p, len, host_prot(prot), static_cast<uint32_t>(prot), true,
+          "direct", kVirtualQueryDirect, phys, memory_type, !sparse);
     MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
-         (unsigned long long)p, (unsigned long long)a1, (unsigned long long)a4,
-         (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)a5);
+         (unsigned long long)p, (unsigned long long)len, (unsigned long long)phys,
+         (unsigned long long)prot, (unsigned long long)flags, (unsigned long long)align);
     return 0;
 }
 
-// sceKernelMapDirectMemory2 inserts `type` before prot/flags/phys/align. Windows uses the same
-// direct-memory view mapper after shifting those arguments; memory-type queries remain separate
-// #387 tracking work.
+// sceKernelMapDirectMemory(void** addrInOut, len, prot, flags, off_t phys, size_t align)
+HLE(k_map_dmem) {
+    int32_t memory_type = 0;
+    dmem_type_at(a4, memory_type);
+    return map_dmem_impl(a0, a1, a2, a3, a4, a5, memory_type, false);
+}
+
+// sceKernelMapDirectMemory2 inserts `type` before prot/flags/phys/align and applies it to the
+// mapped VMA plus the corresponding physical-allocation range.
 HLE7(k_map_dmem2) {
-    (void)a2;
-    return k_map_dmem(a0, a1, a3, a4, a5, a6);
+    return map_dmem_impl(a0, a1, a3, a4, a5, a6, static_cast<int32_t>(a2), true);
 }
 
 HLE(k_munmap)   { if (!a1) return 0x80020016ull;
@@ -3432,6 +3695,7 @@ HLE(k_mtypeprotect) {
     DWORD error = ERROR_SUCCESS;
     if (!win_protect(a0, a1, prot, &error)) return sce_win_mprotect_error(error);
     retrack_prot(a0, a1, prot, static_cast<uint32_t>(a3), "mtypeprotect");
+    retrack_type(a0, a1, static_cast<int32_t>(a2));
     return 0;
 }
 HLE(k_dmem_size){ return kDmemTotal; }
@@ -3464,6 +3728,7 @@ HLE(k_batch_map) {
         uint64_t phys  = *(const uint64_t*)(e + 0x08);
         uint64_t len   = *(const uint64_t*)(e + 0x10);
         uint8_t  prot  = e[0x18];
+        int32_t  type  = e[0x19];
         int32_t  op    = *(const int32_t*)(e + 0x1c);
         MLOG("bm op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
              op, (unsigned long long)start, (unsigned long long)phys,
@@ -3476,8 +3741,10 @@ HLE(k_batch_map) {
                 if (ok) {
                     const bool sparse = sparse_dmem_view_contains(
                         (uint64_t)p, (uint64_t)p + len);
+                    int32_t memory_type = 0;
+                    dmem_type_at(phys, memory_type);
                     track((uint64_t)p, len, host_prot(prot), prot, true,
-                          "batch-direct", !sparse);
+                          "batch-direct", kVirtualQueryDirect, phys, memory_type, !sparse);
                 }
                 break;
             }
@@ -3485,7 +3752,7 @@ HLE(k_batch_map) {
                 void* p = win_commit(start, len, host_prot(prot));
                 ok = (p != nullptr);
                 if (ok) track((uint64_t)p, len, host_prot(prot), prot, true,
-                              "batch-flex");
+                              "batch-flex", kVirtualQueryFlexible);
                 break;
             }
             case 1: {                               // UNMAP
@@ -3497,10 +3764,12 @@ HLE(k_batch_map) {
                 if (start) {
                     DWORD error = ERROR_SUCCESS;
                     ok = win_protect(start, len, host_prot(prot), &error);
-                    if (ok)
+                    if (ok) {
                         retrack_prot(start, len, host_prot(prot), prot, "batch-prot");
-                    else
+                        if (op == 4) retrack_type(start, len, type);
+                    } else {
                         ret = sce_win_mprotect_error(error);
+                    }
                 }
                 break;
             }
@@ -3514,7 +3783,8 @@ HLE(k_batch_map) {
     return ret;
 }
 
-// sceKernelVirtualQuery(addr, flags, info*, infoSize): 0x00 start;0x08 end;0x18 i32 prot;0x20 u32 flags;0x24 name[32]
+// sceKernelVirtualQuery(addr, flags, info*, infoSize): 0x00 start; 0x08 end; 0x10
+// physical offset; 0x18 protection; 0x1c memory type; 0x20 classification flags; 0x24 name.
 HLE(k_virtual_query) {
     if (!a2) return 0x80020016ull;
     uint8_t* info = (uint8_t*)a2;
@@ -3522,13 +3792,16 @@ HLE(k_virtual_query) {
     memset(info, 0, sz);
     Mapping mapping{};
     const bool found = snapshot_mapping(a0, mapping);
-    uint64_t start, end; int prot; uint32_t flags;
+    uint64_t start, end, offset = 0; int prot, memory_type = 0; uint32_t flags;
     if (found) {
         start = mapping.base; end = mapping.base + mapping.size;
         // CPU read/write is an SCE enum (RW is 0x2, not host READ|WRITE 0x3), and the GPU bits
         // have no host-page equivalent. Return the original guest protection value verbatim.
         prot = mapping.committed ? static_cast<int>(mapping.guest_prot) : 0x0;
-        flags = mapping.committed ? 0x10 : 0x0;
+        offset = (mapping.query_flags & kVirtualQueryDirect) ? mapping.offset : 0;
+        memory_type = (mapping.query_flags & kVirtualQueryDirect) ? mapping.memory_type : 0;
+        flags = mapping.query_flags |
+                (mapping.committed ? kVirtualQueryCommitted : 0);
     } else {
         uint64_t nb = next_base(a0);
         if (!nb) return 0x8002000eull;
@@ -3536,7 +3809,9 @@ HLE(k_virtual_query) {
     }
     if (sz >= 0x08) *(uint64_t*)(info + 0x00) = start;
     if (sz >= 0x10) *(uint64_t*)(info + 0x08) = end;
+    if (sz >= 0x18) *(uint64_t*)(info + 0x10) = offset;
     if (sz >= 0x1c) *(int32_t*)(info + 0x18) = prot;
+    if (sz >= 0x20) *(int32_t*)(info + 0x1c) = memory_type;
     if (sz >= 0x24) *(uint32_t*)(info + 0x20) = flags;
     if (sz >= 0x44 && found && mapping.name[0]) memcpy(info + 0x24, mapping.name, 32);
     return 0;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -58,7 +58,7 @@ namespace {
         if (raw_end > UINT64_MAX - mask) return false;
         const uint64_t base = addr & ~mask;
         const uint64_t end = (raw_end + mask) & ~mask;
-        if (end <= base) return false;
+        if (end < base) return false;
         base_out = base;
         len_out = end - base;
         return true;
@@ -977,6 +977,7 @@ HLE(k_mtypeprotect) {
     if (!a0) return 0x80020016ull;
     uint64_t base = 0, len = 0;
     if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
+    if (!len) return 0;
     const int prot = host_prot(a3);
     if (mprotect((void*)base, len, prot) != 0) return sce_mprotect_error(errno);
     retrack_prot(base, len, prot, static_cast<uint32_t>(a3), "mtypeprotect");
@@ -1415,12 +1416,22 @@ HLE(k_batch_map) {
             case 1: if (start) { munmap((void*)(uintptr_t)start, len); untrack(start, len); } break;  // UNMAP
             case 2: case 4: {                                                            // PROTECT / TYPE_PROTECT
                 if (start) {
-                    if (mprotect((void*)(uintptr_t)start, len, host_prot(prot)) != 0) {
+                    uint64_t protect_start = start, protect_len = len;
+                    if (op == 4 && !normalize_guest_page_range(
+                                       start, len, protect_start, protect_len)) {
+                        ok = false;
+                        ret = 0x80020016ull;
+                        break;
+                    }
+                    if (!protect_len) break;
+                    if (mprotect((void*)(uintptr_t)protect_start, protect_len,
+                                 host_prot(prot)) != 0) {
                         ok = false;
                         ret = sce_mprotect_error(errno);
                     } else {
-                        retrack_prot(start, len, host_prot(prot), prot, "batch-prot");
-                        if (op == 4) retrack_type(start, len, type);
+                        retrack_prot(protect_start, protect_len, host_prot(prot), prot,
+                                     "batch-prot");
+                        if (op == 4) retrack_type(protect_start, protect_len, type);
                     }
                 }
                 break;
@@ -1568,7 +1579,7 @@ namespace {
         if (raw_end > UINT64_MAX - mask) return false;
         const uint64_t base = addr & ~mask;
         const uint64_t end = (raw_end + mask) & ~mask;
-        if (end <= base) return false;
+        if (end < base) return false;
         base_out = base;
         len_out = end - base;
         return true;
@@ -3725,6 +3736,7 @@ HLE(k_mtypeprotect) {
     if (!a0) return 0x80020016ull;
     uint64_t base = 0, len = 0;
     if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
+    if (!len) return 0;
     const int prot = host_prot(a3);
     DWORD error = ERROR_SUCCESS;
     if (!win_protect(base, len, prot, &error)) return sce_win_mprotect_error(error);
@@ -3796,11 +3808,20 @@ HLE(k_batch_map) {
             }
             case 2: case 4: {                                                            // PROTECT / TYPE_PROTECT
                 if (start) {
+                    uint64_t protect_start = start, protect_len = len;
+                    if (op == 4 && !normalize_guest_page_range(
+                                       start, len, protect_start, protect_len)) {
+                        ok = false;
+                        ret = 0x80020016ull;
+                        break;
+                    }
+                    if (!protect_len) break;
                     DWORD error = ERROR_SUCCESS;
-                    ok = win_protect(start, len, host_prot(prot), &error);
+                    ok = win_protect(protect_start, protect_len, host_prot(prot), &error);
                     if (ok) {
-                        retrack_prot(start, len, host_prot(prot), prot, "batch-prot");
-                        if (op == 4) retrack_type(start, len, type);
+                        retrack_prot(protect_start, protect_len, host_prot(prot), prot,
+                                     "batch-prot");
+                        if (op == 4) retrack_type(protect_start, protect_len, type);
                     } else {
                         ret = sce_win_mprotect_error(error);
                     }

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -267,6 +267,29 @@ int main() {
               direct_end == phys + 0xc000,
           "TYPE_PROTECT carves the same type range in physical allocation queries");
 
+    CHECK(mtypeprotect(va1 + 0xc123, 0x100, 13, 0x1, 0, 0) == 0,
+          "Mtypeprotect accepts an unaligned sub-page range");
+    memset(direct_info, 0, sizeof(direct_info));
+    CHECK(query(va1 + 0xd000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x00) == va1 + 0xc000 &&
+              *(uint64_t*)(direct_info + 0x08) == va1 + 0x10000 &&
+              *(uint64_t*)(direct_info + 0x10) == phys + 0xc000 &&
+              *(int32_t*)(direct_info + 0x18) == 0x1 &&
+              *(int32_t*)(direct_info + 0x1c) == 13 &&
+              *(uint32_t*)(direct_info + 0x20) == 0x12,
+          "unaligned Mtypeprotect normalizes VA metadata to the 16 KiB guest page");
+    direct_type = -1; direct_start = direct_end = 0;
+    CHECK(get_type(phys + 0xd000, (uint64_t)(uintptr_t)&direct_type,
+                   (uint64_t)(uintptr_t)&direct_start,
+                   (uint64_t)(uintptr_t)&direct_end, 0, 0) == 0 &&
+              direct_type == 13 && direct_start == phys + 0xc000 &&
+              direct_end == phys + 0x10000,
+          "unaligned Mtypeprotect normalizes physical type metadata to the same page");
+    CHECK((uint32_t)mtypeprotect(UINT64_MAX - 0x1000, 0x2000, 13, 0x1, 0, 0) ==
+              0x80020016u,
+          "Mtypeprotect rejects an overflowing guest range");
+
     uint64_t hinted = va1;
     CHECK(map((uint64_t)(uintptr_t)&hinted, dlen, 0x2, 0, phys, dlen) == 0 &&
               hinted && hinted != va1,
@@ -764,6 +787,28 @@ int main() {
                   direct_type == 11 && direct_start == p + 0x8000 &&
                   direct_end == p + 0xc000,
               "TYPE_PROTECT carves the same type range in physical allocation queries");
+
+        CHECK(mtypeprotect(va + 0xc123, 0x100, 13, 0x1, 0, 0) == 0,
+              "Mtypeprotect accepts an unaligned sub-page range");
+        memset(info, 0, sizeof(info));
+        CHECK(query(va + 0xd000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(uint64_t*)(info + 0x00) == va + 0xc000 &&
+                  *(uint64_t*)(info + 0x08) == va + 0x10000 &&
+                  *(uint64_t*)(info + 0x10) == p + 0xc000 &&
+                  *(int32_t*)(info + 0x18) == 0x1 &&
+                  *(int32_t*)(info + 0x1c) == 13 &&
+                  *(uint32_t*)(info + 0x20) == 0x12,
+              "unaligned Mtypeprotect normalizes VA metadata to the 16 KiB guest page");
+        direct_type = -1; direct_start = direct_end = 0;
+        CHECK(get_type(p + 0xd000, (uint64_t)(uintptr_t)&direct_type,
+                       (uint64_t)(uintptr_t)&direct_start,
+                       (uint64_t)(uintptr_t)&direct_end, 0, 0) == 0 &&
+                  direct_type == 13 && direct_start == p + 0xc000 &&
+                  direct_end == p + 0x10000,
+              "unaligned Mtypeprotect normalizes physical type metadata to the same page");
+        CHECK((uint32_t)mtypeprotect(UINT64_MAX - 0x1000, 0x2000, 13, 0x1, 0, 0) ==
+                  0x80020016u,
+              "Mtypeprotect rejects an overflowing guest range");
         if (va) munmap((void*)(uintptr_t)va, 0x10000);
         if (alias) munmap((void*)(uintptr_t)alias, 0x10000);
         if (p) release(p, 0x10000, 0, 0, 0, 0);

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -16,6 +16,7 @@ extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
 #endif
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #ifdef __linux__
 #include <sys/mman.h>
 #endif
@@ -52,6 +53,7 @@ int main() {
     auto map2    = reinterpret_cast<Hle7Fn>(
         Hle::lookup(nid_hash("sceKernelMapDirectMemory2")));
     auto protect = Hle::lookup(nid_hash("sceKernelMprotect"));
+    auto mtypeprotect = Hle::lookup(nid_hash("sceKernelMtypeprotect"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
     auto query   = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
     auto get_type = Hle::lookup(nid_hash("sceKernelGetDirectMemoryType"));
@@ -61,7 +63,7 @@ int main() {
     CHECK(nid_hash("sceKernelGetDirectMemoryType") == "BC+OG5m9+bw",
           "sceKernelGetDirectMemoryType hashes to the PS5 3.20 import NID");
     CHECK(reserve && flexible && unmap && alloc && alloc_main && map && map2 && protect &&
-              release && query && get_type && batch,
+              mtypeprotect && release && query && get_type && batch,
           "memory HLE functions registered");
     if (fails) return 1;
 
@@ -186,7 +188,7 @@ int main() {
 #endif
     CHECK(map((uint64_t)(uintptr_t)&va2, dlen, 0x2, 0, phys, dlen) == 0 && va2 && va2 != va1,
           "map second direct-memory view");
-    CHECK(map2((uint64_t)(uintptr_t)&va_map2, dlen, 0 /* type */, 0x2 /* RW */, 0,
+    CHECK(map2((uint64_t)(uintptr_t)&va_map2, dlen, 3 /* type */, 0x2 /* RW */, 0,
                phys, dlen) == 0 && va_map2 && va_map2 != va1 && va_map2 != va2,
           "MapDirectMemory2 consumes shifted prot/flags/phys/alignment arguments");
     if (va1 && va2) {
@@ -194,9 +196,76 @@ int main() {
         CHECK(*(volatile uint64_t*)(uintptr_t)(va2 + 0x1230) == 0x6310CAFEDEADC0DEull,
               "two virtual mappings of one physical offset alias the same bytes");
         CHECK(va_map2 && *(volatile uint64_t*)(uintptr_t)(va_map2 + 0x1230) ==
-                         0x6310CAFEDEADC0DEull,
-              "MapDirectMemory2 view aliases the requested physical range");
+                          0x6310CAFEDEADC0DEull,
+               "MapDirectMemory2 view aliases the requested physical range");
     }
+
+    uint8_t direct_info[0x48]{};
+    CHECK(query(va1 + 0x2000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x00) == va1 &&
+              *(uint64_t*)(direct_info + 0x08) == va1 + dlen &&
+              *(uint64_t*)(direct_info + 0x10) == phys &&
+              *(int32_t*)(direct_info + 0x1c) == 7 &&
+              *(uint32_t*)(direct_info + 0x20) == 0x12,
+          "VirtualQuery reports ordinary direct mapping offset/type/classification");
+    memset(direct_info, 0, sizeof(direct_info));
+    CHECK(query(va_map2 + 0x2000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x10) == phys &&
+              *(int32_t*)(direct_info + 0x1c) == 3 &&
+              *(uint32_t*)(direct_info + 0x20) == 0x12,
+          "MapDirectMemory2 publishes its explicit type in VirtualQuery");
+    direct_type = -1; direct_start = direct_end = 0;
+    CHECK(get_type(phys + 0x2000, (uint64_t)(uintptr_t)&direct_type,
+                   (uint64_t)(uintptr_t)&direct_start,
+                   (uint64_t)(uintptr_t)&direct_end, 0, 0) == 0 &&
+              direct_type == 3 && direct_start == phys && direct_end == phys + dlen,
+          "MapDirectMemory2 updates the physical allocation type");
+
+    CHECK(mtypeprotect(va1 + 0x4000, 0x4000, 9, 0x1, 0, 0) == 0,
+          "Mtypeprotect changes one direct-mapping page");
+    memset(direct_info, 0, sizeof(direct_info));
+    CHECK(query(va1 + 0x5000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x00) == va1 + 0x4000 &&
+              *(uint64_t*)(direct_info + 0x08) == va1 + 0x8000 &&
+              *(uint64_t*)(direct_info + 0x10) == phys + 0x4000 &&
+              *(int32_t*)(direct_info + 0x18) == 0x1 &&
+              *(int32_t*)(direct_info + 0x1c) == 9 &&
+              *(uint32_t*)(direct_info + 0x20) == 0x12,
+          "Mtypeprotect preserves the carved page's physical offset and publishes its type");
+
+    alignas(8) uint8_t type_entry[0x20]{};
+    *(uint64_t*)(type_entry + 0x00) = va1 + 0x8000;
+    *(uint64_t*)(type_entry + 0x10) = 0x4000;
+    type_entry[0x18] = 0x2;
+    type_entry[0x19] = 11;
+    *(int32_t*)(type_entry + 0x1c) = 4; // TYPE_PROTECT
+    int32_t type_done = -1;
+    CHECK(batch((uint64_t)(uintptr_t)type_entry, 1,
+                (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0 && type_done == 1,
+          "BatchMap TYPE_PROTECT changes one direct-mapping page");
+    memset(direct_info, 0, sizeof(direct_info));
+    CHECK(query(va1 + 0x9000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x10) == phys + 0x8000 &&
+              *(int32_t*)(direct_info + 0x1c) == 11 &&
+              *(uint32_t*)(direct_info + 0x20) == 0x12,
+          "BatchMap TYPE_PROTECT publishes the carved page's offset and type");
+    memset(direct_info, 0, sizeof(direct_info));
+    CHECK(query(va1 + 0xd000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x10) == phys + 0xc000 &&
+              *(int32_t*)(direct_info + 0x1c) == 7,
+          "tracker suffix keeps its original type and rebased physical offset");
+    direct_type = -1; direct_start = direct_end = 0;
+    CHECK(get_type(phys + 0x9000, (uint64_t)(uintptr_t)&direct_type,
+                   (uint64_t)(uintptr_t)&direct_start,
+                   (uint64_t)(uintptr_t)&direct_end, 0, 0) == 0 &&
+              direct_type == 11 && direct_start == phys + 0x8000 &&
+              direct_end == phys + 0xc000,
+          "TYPE_PROTECT carves the same type range in physical allocation queries");
 
     uint64_t hinted = va1;
     CHECK(map((uint64_t)(uintptr_t)&hinted, dlen, 0x2, 0, phys, dlen) == 0 &&
@@ -251,8 +320,9 @@ int main() {
         uint8_t guest_query[0x48]{};
         CHECK(query(sparse_va1 + 0x01000000, 0,
                     (uint64_t)(uintptr_t)guest_query, sizeof(guest_query), 0, 0) == 0 &&
-                  *(uint32_t*)(guest_query + 0x20) == 0x10,
-              "guest VirtualQuery reports the sparse direct view as committed");
+                  *(uint64_t*)(guest_query + 0x10) == sparse_phys &&
+                  *(uint32_t*)(guest_query + 0x20) == 0x12,
+              "guest VirtualQuery reports sparse direct backing and classification");
         host::GuestReadableRange persistent_range{};
         CHECK(host::guest_readable_mapping_containing(
                   sparse_va1 + 0x4000, sparse_va1 + 0x8000, persistent_range),
@@ -427,6 +497,15 @@ int main() {
               *(volatile uint64_t*)(uintptr_t)(fixed_va + 0xc100) ==
                   0x9999aaaabbbbccccull,
               "partial unmap preserves the prefix and suffix views");
+        uint8_t suffix_query[0x48]{};
+        CHECK(query(fixed_va + 0xc000, 0, (uint64_t)(uintptr_t)suffix_query,
+                    sizeof(suffix_query), 0, 0) == 0 &&
+                  *(uint64_t*)(suffix_query + 0x00) == fixed_va + 0x8000 &&
+                  *(uint64_t*)(suffix_query + 0x08) == fixed_va + fixed_len &&
+                  *(uint64_t*)(suffix_query + 0x10) == fixed_phys + 0x8000 &&
+                  *(int32_t*)(suffix_query + 0x1c) == 0 &&
+                  *(uint32_t*)(suffix_query + 0x20) == 0x12,
+              "partial direct unmap rebases the retained suffix's physical offset");
 
         uint64_t flexible_hole = hole;
         const bool flexible_mapped =
@@ -489,15 +568,20 @@ int main() {
     auto map     = Hle::lookup(nid_hash("sceKernelMapDirectMemory"));
     auto map2    = reinterpret_cast<Hle7Fn>(
         Hle::lookup(nid_hash("sceKernelMapDirectMemory2")));
+    auto query   = Hle::lookup(nid_hash("sceKernelVirtualQuery"));
+    auto mtypeprotect = Hle::lookup(nid_hash("sceKernelMtypeprotect"));
+    auto batch   = Hle::lookup(nid_hash("sceKernelBatchMap"));
     auto release = Hle::lookup(nid_hash("sceKernelReleaseDirectMemory"));
     auto get_type = Hle::lookup(nid_hash("sceKernelGetDirectMemoryType"));
     CHECK(nid_hash("sceKernelMapDirectMemory2") == "BQQniolj9tQ",
           "sceKernelMapDirectMemory2 hashes to the PS5 3.20 import NID");
     CHECK(nid_hash("sceKernelGetDirectMemoryType") == "BC+OG5m9+bw",
           "sceKernelGetDirectMemoryType hashes to the PS5 3.20 import NID");
-    CHECK(avail && alloc && alloc_main && map && map2 && release && get_type,
+    CHECK(avail && alloc && alloc_main && map && map2 && query && mtypeprotect && batch &&
+              release && get_type,
           "dmem fns registered");
-    if (!(avail && alloc && alloc_main && map && map2 && release && get_type)) {
+    if (!(avail && alloc && alloc_main && map && map2 && query && mtypeprotect && batch &&
+          release && get_type)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -606,15 +690,15 @@ int main() {
         if (p) release(p, 0x10000, 0, 0, 0, 0);
     }
 
-    // MapDirectMemory2 inserts `type` before prot/flags/phys/alignment. Type zero deliberately
-    // differs from RW protection so an unshifted six-argument alias cannot pass this write/alias
-    // check, and the seventh alignment argument is exercised by the real fixed-arity prototype.
+    // MapDirectMemory2 inserts `type` before prot/flags/phys/alignment. The explicit type must
+    // reach both VirtualQuery and the physical allocation table. Later type-protect operations
+    // carve metadata without losing the virtual-to-physical offset of suffix pages.
     {
         uint64_t p = 0, va = 0, alias = 0;
-        uint64_t rr = alloc(0, kEnd, 0x10000, 0x10000, 0,
+        uint64_t rr = alloc(0, kEnd, 0x10000, 0x10000, 6,
                             (uint64_t)(uintptr_t)&p);
         CHECK(rr == 0, "allocate direct page for MapDirectMemory2");
-        rr = map2((uint64_t)(uintptr_t)&va, 0x10000, 0 /* type */, 0x2 /* RW */, 0,
+        rr = map2((uint64_t)(uintptr_t)&va, 0x10000, 3 /* type */, 0x2 /* RW */, 0,
                   p, 0x10000);
         CHECK(rr == 0 && va && (va & 0xffff) == 0,
               "MapDirectMemory2 consumes shifted arguments and seventh-argument alignment");
@@ -623,8 +707,63 @@ int main() {
         if (va && alias) {
             *(volatile uint64_t*)(uintptr_t)(va + 0x120) = 0xB002D1EC7A11A5ull;
             CHECK(*(volatile uint64_t*)(uintptr_t)(alias + 0x120) == 0xB002D1EC7A11A5ull,
-                  "MapDirectMemory2 maps the requested physical offset as writable shared memory");
+                   "MapDirectMemory2 maps the requested physical offset as writable shared memory");
         }
+
+        uint8_t info[0x48]{};
+        CHECK(query(va + 0x2000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(uint64_t*)(info + 0x00) == va &&
+                  *(uint64_t*)(info + 0x08) == va + 0x10000 &&
+                  *(uint64_t*)(info + 0x10) == p &&
+                  *(int32_t*)(info + 0x1c) == 3 &&
+                  *(uint32_t*)(info + 0x20) == 0x12,
+              "VirtualQuery reports direct offset, explicit type, and classification");
+        direct_type = -1; direct_start = direct_end = 0;
+        CHECK(get_type(p + 0x2000, (uint64_t)(uintptr_t)&direct_type,
+                       (uint64_t)(uintptr_t)&direct_start,
+                       (uint64_t)(uintptr_t)&direct_end, 0, 0) == 0 &&
+                  direct_type == 3 && direct_start == p && direct_end == p + 0x10000,
+              "MapDirectMemory2 updates the physical allocation type");
+
+        CHECK(mtypeprotect(va + 0x4000, 0x4000, 9, 0x1, 0, 0) == 0,
+              "Mtypeprotect changes one direct-mapping page");
+        memset(info, 0, sizeof(info));
+        CHECK(query(va + 0x5000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(uint64_t*)(info + 0x00) == va + 0x4000 &&
+                  *(uint64_t*)(info + 0x08) == va + 0x8000 &&
+                  *(uint64_t*)(info + 0x10) == p + 0x4000 &&
+                  *(int32_t*)(info + 0x18) == 0x1 &&
+                  *(int32_t*)(info + 0x1c) == 9 &&
+                  *(uint32_t*)(info + 0x20) == 0x12,
+              "Mtypeprotect publishes the carved page's rebased offset and type");
+
+        alignas(8) uint8_t type_entry[0x20]{};
+        *(uint64_t*)(type_entry + 0x00) = va + 0x8000;
+        *(uint64_t*)(type_entry + 0x10) = 0x4000;
+        type_entry[0x18] = 0x2;
+        type_entry[0x19] = 11;
+        *(int32_t*)(type_entry + 0x1c) = 4; // TYPE_PROTECT
+        int32_t type_done = -1;
+        CHECK(batch((uint64_t)(uintptr_t)type_entry, 1,
+                    (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0 && type_done == 1,
+              "BatchMap TYPE_PROTECT changes one direct-mapping page");
+        memset(info, 0, sizeof(info));
+        CHECK(query(va + 0x9000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(uint64_t*)(info + 0x10) == p + 0x8000 &&
+                  *(int32_t*)(info + 0x1c) == 11,
+              "BatchMap TYPE_PROTECT publishes its carved offset and type");
+        memset(info, 0, sizeof(info));
+        CHECK(query(va + 0xd000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(uint64_t*)(info + 0x10) == p + 0xc000 &&
+                  *(int32_t*)(info + 0x1c) == 3,
+              "tracker suffix keeps its original type and rebased physical offset");
+        direct_type = -1; direct_start = direct_end = 0;
+        CHECK(get_type(p + 0x9000, (uint64_t)(uintptr_t)&direct_type,
+                       (uint64_t)(uintptr_t)&direct_start,
+                       (uint64_t)(uintptr_t)&direct_end, 0, 0) == 0 &&
+                  direct_type == 11 && direct_start == p + 0x8000 &&
+                  direct_end == p + 0xc000,
+              "TYPE_PROTECT carves the same type range in physical allocation queries");
         if (va) munmap((void*)(uintptr_t)va, 0x10000);
         if (alias) munmap((void*)(uintptr_t)alias, 0x10000);
         if (p) release(p, 0x10000, 0, 0, 0, 0);

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -207,14 +207,28 @@ int main() {
               *(uint64_t*)(direct_info + 0x08) == va1 + dlen &&
               *(uint64_t*)(direct_info + 0x10) == phys &&
               *(int32_t*)(direct_info + 0x1c) == 7 &&
-              *(uint32_t*)(direct_info + 0x20) == 0x12,
+              direct_info[0x20] == 0x12,
           "VirtualQuery reports ordinary direct mapping offset/type/classification");
+    uint8_t short_query_info[0x22];
+    memset(short_query_info, 0xa5, sizeof(short_query_info));
+    CHECK(query(va1 + 0x2000, 0, (uint64_t)(uintptr_t)short_query_info,
+                0x21, 0, 0) == 0 &&
+              short_query_info[0x20] == 0x12 && short_query_info[0x21] == 0xa5,
+          "VirtualQuery writes the one-byte classification at exact infoSize 0x21");
+    uint8_t exact_query_info[0x42];
+    memset(exact_query_info, 0xa5, sizeof(exact_query_info));
+    CHECK(query(va1 + 0x2000, 0, (uint64_t)(uintptr_t)exact_query_info,
+                0x41, 0, 0) == 0 &&
+              exact_query_info[0x20] == 0x12 &&
+              memcmp(exact_query_info + 0x21, "direct", 7) == 0 &&
+              exact_query_info[0x41] == 0xa5,
+          "VirtualQuery writes name[32] at 0x21 within the exact ABI size");
     memset(direct_info, 0, sizeof(direct_info));
     CHECK(query(va_map2 + 0x2000, 0, (uint64_t)(uintptr_t)direct_info,
                 sizeof(direct_info), 0, 0) == 0 &&
               *(uint64_t*)(direct_info + 0x10) == phys &&
               *(int32_t*)(direct_info + 0x1c) == 3 &&
-              *(uint32_t*)(direct_info + 0x20) == 0x12,
+              direct_info[0x20] == 0x12,
           "MapDirectMemory2 publishes its explicit type in VirtualQuery");
     direct_type = -1; direct_start = direct_end = 0;
     CHECK(get_type(phys + 0x2000, (uint64_t)(uintptr_t)&direct_type,
@@ -233,7 +247,7 @@ int main() {
               *(uint64_t*)(direct_info + 0x10) == phys + 0x4000 &&
               *(int32_t*)(direct_info + 0x18) == 0x1 &&
               *(int32_t*)(direct_info + 0x1c) == 9 &&
-              *(uint32_t*)(direct_info + 0x20) == 0x12,
+              direct_info[0x20] == 0x12,
           "Mtypeprotect preserves the carved page's physical offset and publishes its type");
     CHECK(mtypeprotect(va1 + 0x4000, 0, 14, 0x2, 0, 0) == 0,
           "aligned zero-length Mtypeprotect is a successful no-op");
@@ -268,7 +282,7 @@ int main() {
               *(uint64_t*)(direct_info + 0x10) == phys + 0x8000 &&
               *(int32_t*)(direct_info + 0x18) == 0x2 &&
               *(int32_t*)(direct_info + 0x1c) == 11 &&
-              *(uint32_t*)(direct_info + 0x20) == 0x12,
+              direct_info[0x20] == 0x12,
           "BatchMap TYPE_PROTECT normalizes protection and metadata to the guest page");
     memset(direct_info, 0, sizeof(direct_info));
     CHECK(query(va1 + 0xd000, 0, (uint64_t)(uintptr_t)direct_info,
@@ -294,7 +308,7 @@ int main() {
               *(uint64_t*)(direct_info + 0x10) == phys + 0xc000 &&
               *(int32_t*)(direct_info + 0x18) == 0x1 &&
               *(int32_t*)(direct_info + 0x1c) == 13 &&
-              *(uint32_t*)(direct_info + 0x20) == 0x12,
+              direct_info[0x20] == 0x12,
           "unaligned Mtypeprotect normalizes VA metadata to the 16 KiB guest page");
     direct_type = -1; direct_start = direct_end = 0;
     CHECK(get_type(phys + 0xd000, (uint64_t)(uintptr_t)&direct_type,
@@ -361,7 +375,7 @@ int main() {
         CHECK(query(sparse_va1 + 0x01000000, 0,
                     (uint64_t)(uintptr_t)guest_query, sizeof(guest_query), 0, 0) == 0 &&
                   *(uint64_t*)(guest_query + 0x10) == sparse_phys &&
-                  *(uint32_t*)(guest_query + 0x20) == 0x12,
+                  guest_query[0x20] == 0x12,
               "guest VirtualQuery reports sparse direct backing and classification");
         host::GuestReadableRange persistent_range{};
         CHECK(host::guest_readable_mapping_containing(
@@ -544,7 +558,7 @@ int main() {
                   *(uint64_t*)(suffix_query + 0x08) == fixed_va + fixed_len &&
                   *(uint64_t*)(suffix_query + 0x10) == fixed_phys + 0x8000 &&
                   *(int32_t*)(suffix_query + 0x1c) == 0 &&
-                  *(uint32_t*)(suffix_query + 0x20) == 0x12,
+                  suffix_query[0x20] == 0x12,
               "partial direct unmap rebases the retained suffix's physical offset");
 
         uint64_t flexible_hole = hole;
@@ -756,8 +770,22 @@ int main() {
                   *(uint64_t*)(info + 0x08) == va + 0x10000 &&
                   *(uint64_t*)(info + 0x10) == p &&
                   *(int32_t*)(info + 0x1c) == 3 &&
-                  *(uint32_t*)(info + 0x20) == 0x12,
+                  info[0x20] == 0x12,
               "VirtualQuery reports direct offset, explicit type, and classification");
+        uint8_t short_query_info[0x22];
+        memset(short_query_info, 0xa5, sizeof(short_query_info));
+        CHECK(query(va + 0x2000, 0, (uint64_t)(uintptr_t)short_query_info,
+                    0x21, 0, 0) == 0 &&
+                  short_query_info[0x20] == 0x12 && short_query_info[0x21] == 0xa5,
+              "VirtualQuery writes the one-byte classification at exact infoSize 0x21");
+        uint8_t exact_query_info[0x42];
+        memset(exact_query_info, 0xa5, sizeof(exact_query_info));
+        CHECK(query(va + 0x2000, 0, (uint64_t)(uintptr_t)exact_query_info,
+                    0x41, 0, 0) == 0 &&
+                  exact_query_info[0x20] == 0x12 &&
+                  memcmp(exact_query_info + 0x21, "direct", 7) == 0 &&
+                  exact_query_info[0x41] == 0xa5,
+              "VirtualQuery writes name[32] at 0x21 within the exact ABI size");
         direct_type = -1; direct_start = direct_end = 0;
         CHECK(get_type(p + 0x2000, (uint64_t)(uintptr_t)&direct_type,
                        (uint64_t)(uintptr_t)&direct_start,
@@ -774,7 +802,7 @@ int main() {
                   *(uint64_t*)(info + 0x10) == p + 0x4000 &&
                   *(int32_t*)(info + 0x18) == 0x1 &&
                   *(int32_t*)(info + 0x1c) == 9 &&
-                  *(uint32_t*)(info + 0x20) == 0x12,
+                  info[0x20] == 0x12,
               "Mtypeprotect publishes the carved page's rebased offset and type");
         CHECK(mtypeprotect(va + 0x4000, 0, 14, 0x2, 0, 0) == 0,
               "aligned zero-length Mtypeprotect is a successful no-op");
@@ -830,7 +858,7 @@ int main() {
                   *(uint64_t*)(info + 0x10) == p + 0xc000 &&
                   *(int32_t*)(info + 0x18) == 0x1 &&
                   *(int32_t*)(info + 0x1c) == 13 &&
-                  *(uint32_t*)(info + 0x20) == 0x12,
+                  info[0x20] == 0x12,
               "unaligned Mtypeprotect normalizes VA metadata to the 16 KiB guest page");
         direct_type = -1; direct_start = direct_end = 0;
         CHECK(get_type(p + 0xd000, (uint64_t)(uintptr_t)&direct_type,

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -235,24 +235,35 @@ int main() {
               *(int32_t*)(direct_info + 0x1c) == 9 &&
               *(uint32_t*)(direct_info + 0x20) == 0x12,
           "Mtypeprotect preserves the carved page's physical offset and publishes its type");
+    CHECK(mtypeprotect(va1 + 0x4000, 0, 14, 0x2, 0, 0) == 0,
+          "aligned zero-length Mtypeprotect is a successful no-op");
+    memset(direct_info, 0, sizeof(direct_info));
+    CHECK(query(va1 + 0x5000, 0, (uint64_t)(uintptr_t)direct_info,
+                sizeof(direct_info), 0, 0) == 0 &&
+              *(int32_t*)(direct_info + 0x18) == 0x1 &&
+              *(int32_t*)(direct_info + 0x1c) == 9,
+          "zero-length Mtypeprotect leaves protection and type metadata unchanged");
 
     alignas(8) uint8_t type_entry[0x20]{};
-    *(uint64_t*)(type_entry + 0x00) = va1 + 0x8000;
-    *(uint64_t*)(type_entry + 0x10) = 0x4000;
+    *(uint64_t*)(type_entry + 0x00) = va1 + 0x8123;
+    *(uint64_t*)(type_entry + 0x10) = 0x100;
     type_entry[0x18] = 0x2;
     type_entry[0x19] = 11;
     *(int32_t*)(type_entry + 0x1c) = 4; // TYPE_PROTECT
     int32_t type_done = -1;
     CHECK(batch((uint64_t)(uintptr_t)type_entry, 1,
                 (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0 && type_done == 1,
-          "BatchMap TYPE_PROTECT changes one direct-mapping page");
+          "BatchMap TYPE_PROTECT accepts an unaligned sub-page range");
     memset(direct_info, 0, sizeof(direct_info));
     CHECK(query(va1 + 0x9000, 0, (uint64_t)(uintptr_t)direct_info,
                 sizeof(direct_info), 0, 0) == 0 &&
+              *(uint64_t*)(direct_info + 0x00) == va1 + 0x8000 &&
+              *(uint64_t*)(direct_info + 0x08) == va1 + 0xc000 &&
               *(uint64_t*)(direct_info + 0x10) == phys + 0x8000 &&
+              *(int32_t*)(direct_info + 0x18) == 0x2 &&
               *(int32_t*)(direct_info + 0x1c) == 11 &&
               *(uint32_t*)(direct_info + 0x20) == 0x12,
-          "BatchMap TYPE_PROTECT publishes the carved page's offset and type");
+          "BatchMap TYPE_PROTECT normalizes protection and metadata to the guest page");
     memset(direct_info, 0, sizeof(direct_info));
     CHECK(query(va1 + 0xd000, 0, (uint64_t)(uintptr_t)direct_info,
                 sizeof(direct_info), 0, 0) == 0 &&
@@ -759,22 +770,32 @@ int main() {
                   *(int32_t*)(info + 0x1c) == 9 &&
                   *(uint32_t*)(info + 0x20) == 0x12,
               "Mtypeprotect publishes the carved page's rebased offset and type");
+        CHECK(mtypeprotect(va + 0x4000, 0, 14, 0x2, 0, 0) == 0,
+              "aligned zero-length Mtypeprotect is a successful no-op");
+        memset(info, 0, sizeof(info));
+        CHECK(query(va + 0x5000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(int32_t*)(info + 0x18) == 0x1 &&
+                  *(int32_t*)(info + 0x1c) == 9,
+              "zero-length Mtypeprotect leaves protection and type metadata unchanged");
 
         alignas(8) uint8_t type_entry[0x20]{};
-        *(uint64_t*)(type_entry + 0x00) = va + 0x8000;
-        *(uint64_t*)(type_entry + 0x10) = 0x4000;
+        *(uint64_t*)(type_entry + 0x00) = va + 0x8123;
+        *(uint64_t*)(type_entry + 0x10) = 0x100;
         type_entry[0x18] = 0x2;
         type_entry[0x19] = 11;
         *(int32_t*)(type_entry + 0x1c) = 4; // TYPE_PROTECT
         int32_t type_done = -1;
         CHECK(batch((uint64_t)(uintptr_t)type_entry, 1,
                     (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0 && type_done == 1,
-              "BatchMap TYPE_PROTECT changes one direct-mapping page");
+              "BatchMap TYPE_PROTECT accepts an unaligned sub-page range");
         memset(info, 0, sizeof(info));
         CHECK(query(va + 0x9000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+                  *(uint64_t*)(info + 0x00) == va + 0x8000 &&
+                  *(uint64_t*)(info + 0x08) == va + 0xc000 &&
                   *(uint64_t*)(info + 0x10) == p + 0x8000 &&
+                  *(int32_t*)(info + 0x18) == 0x2 &&
                   *(int32_t*)(info + 0x1c) == 11,
-              "BatchMap TYPE_PROTECT publishes its carved offset and type");
+              "BatchMap TYPE_PROTECT normalizes protection and metadata to the guest page");
         memset(info, 0, sizeof(info));
         CHECK(query(va + 0xd000, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
                   *(uint64_t*)(info + 0x10) == p + 0xc000 &&

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -245,12 +245,18 @@ int main() {
           "zero-length Mtypeprotect leaves protection and type metadata unchanged");
 
     alignas(8) uint8_t type_entry[0x20]{};
-    *(uint64_t*)(type_entry + 0x00) = va1 + 0x8123;
-    *(uint64_t*)(type_entry + 0x10) = 0x100;
+    *(uint64_t*)(type_entry + 0x00) = va1 + 0x8000;
     type_entry[0x18] = 0x2;
     type_entry[0x19] = 11;
     *(int32_t*)(type_entry + 0x1c) = 4; // TYPE_PROTECT
     int32_t type_done = -1;
+    CHECK((uint32_t)batch((uint64_t)(uintptr_t)type_entry, 1,
+                          (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0x80020016u &&
+              type_done == 0,
+          "BatchMap rejects a zero-length type-protect entry without counting it");
+    *(uint64_t*)(type_entry + 0x00) = va1 + 0x8123;
+    *(uint64_t*)(type_entry + 0x10) = 0x100;
+    type_done = -1;
     CHECK(batch((uint64_t)(uintptr_t)type_entry, 1,
                 (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0 && type_done == 1,
           "BatchMap TYPE_PROTECT accepts an unaligned sub-page range");
@@ -779,12 +785,18 @@ int main() {
               "zero-length Mtypeprotect leaves protection and type metadata unchanged");
 
         alignas(8) uint8_t type_entry[0x20]{};
-        *(uint64_t*)(type_entry + 0x00) = va + 0x8123;
-        *(uint64_t*)(type_entry + 0x10) = 0x100;
+        *(uint64_t*)(type_entry + 0x00) = va + 0x8000;
         type_entry[0x18] = 0x2;
         type_entry[0x19] = 11;
         *(int32_t*)(type_entry + 0x1c) = 4; // TYPE_PROTECT
         int32_t type_done = -1;
+        CHECK((uint32_t)batch((uint64_t)(uintptr_t)type_entry, 1,
+                              (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0x80020016u &&
+                  type_done == 0,
+              "BatchMap rejects a zero-length type-protect entry without counting it");
+        *(uint64_t*)(type_entry + 0x00) = va + 0x8123;
+        *(uint64_t*)(type_entry + 0x10) = 0x100;
+        type_done = -1;
         CHECK(batch((uint64_t)(uintptr_t)type_entry, 1,
                     (uint64_t)(uintptr_t)&type_done, 0, 0, 0) == 0 && type_done == 1,
               "BatchMap TYPE_PROTECT accepts an unaligned sub-page range");

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -286,9 +286,10 @@ int main() {
     }
     memset(info, 0, sizeof(info));
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
+              *(uint64_t*)(info + 0x10) == 0 && *(int32_t*)(info + 0x1c) == 0 &&
               *(int32_t*)(info + 0x18) == 0x2 &&
-              *(uint32_t*)(info + 0x20) == 0x10,
-          "VirtualQuery reports the committed page's exact guest read/write protection");
+              *(uint32_t*)(info + 0x20) == 0x11,
+          "VirtualQuery reports flexible metadata without physical backing fields");
     uint64_t protection_start = UINT64_MAX;
     uint64_t protection_end = UINT64_MAX;
     uint32_t protection_value = UINT32_MAX;
@@ -306,7 +307,7 @@ int main() {
     memset(info, 0, sizeof(info));
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
               *(int32_t*)(info + 0x18) == 0x11 &&
-              *(uint32_t*)(info + 0x20) == 0x10,
+              *(uint32_t*)(info + 0x20) == 0x11,
           "VirtualQuery preserves guest-only GPU protection bits");
     protection_value = UINT32_MAX;
     CHECK(query_protection(middle + page / 2, 0, 0,
@@ -323,7 +324,7 @@ int main() {
     memset(info, 0, sizeof(info));
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
               *(int32_t*)(info + 0x18) == 0x1 &&
-              *(uint32_t*)(info + 0x20) == 0x10,
+              *(uint32_t*)(info + 0x20) == 0x11,
           "range protection keeps the middle page committed and reports read-only access");
     memset(info, 0, sizeof(info));
     CHECK(query(middle + page, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -182,7 +182,7 @@ int main() {
                 sizeof(failed_info), 0, 0) == 0 &&
               *(uint64_t*)(failed_info + 0x00) == base &&
               *(uint64_t*)(failed_info + 0x08) == base + len &&
-              *(uint32_t*)(failed_info + 0x20) == 0,
+              failed_info[0x20] == 0,
           "failed mprotect leaves reservation tracking unchanged");
 
 #ifdef _WIN32
@@ -270,7 +270,7 @@ int main() {
     CHECK(*(uint64_t*)(info + 0x00) == middle &&
               *(uint64_t*)(info + 0x08) == middle + page,
           "protection tracking splits the reservation at the requested bounds");
-    CHECK(*(int32_t*)(info + 0x18) == 0 && *(uint32_t*)(info + 0x20) == 0,
+    CHECK(*(int32_t*)(info + 0x18) == 0 && info[0x20] == 0,
           "VirtualQuery still reports the protected reservation as uncommitted");
     CHECK(prosper_reserved_range_state(middle) == 1,
           "the lazy-commit probe still classifies the page as reserved");
@@ -288,7 +288,7 @@ int main() {
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
               *(uint64_t*)(info + 0x10) == 0 && *(int32_t*)(info + 0x1c) == 0 &&
               *(int32_t*)(info + 0x18) == 0x2 &&
-              *(uint32_t*)(info + 0x20) == 0x11,
+              info[0x20] == 0x11,
           "VirtualQuery reports flexible metadata without physical backing fields");
     uint64_t protection_start = UINT64_MAX;
     uint64_t protection_end = UINT64_MAX;
@@ -307,7 +307,7 @@ int main() {
     memset(info, 0, sizeof(info));
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
               *(int32_t*)(info + 0x18) == 0x11 &&
-              *(uint32_t*)(info + 0x20) == 0x11,
+              info[0x20] == 0x11,
           "VirtualQuery preserves guest-only GPU protection bits");
     protection_value = UINT32_MAX;
     CHECK(query_protection(middle + page / 2, 0, 0,
@@ -319,16 +319,16 @@ int main() {
           "mprotect accepts a range spanning reserved and committed pages");
     memset(info, 0, sizeof(info));
     CHECK(query(base, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
-              *(uint32_t*)(info + 0x20) == 0,
+              info[0x20] == 0,
           "range protection keeps the leading page uncommitted");
     memset(info, 0, sizeof(info));
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
               *(int32_t*)(info + 0x18) == 0x1 &&
-              *(uint32_t*)(info + 0x20) == 0x11,
+              info[0x20] == 0x11,
           "range protection keeps the middle page committed and reports read-only access");
     memset(info, 0, sizeof(info));
     CHECK(query(middle + page, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
-              *(uint32_t*)(info + 0x20) == 0,
+              info[0x20] == 0,
           "range protection keeps the trailing page uncommitted");
 
     CHECK(unmap(base, len, 0, 0, 0, 0) == 0, "the test reservation unmaps cleanly");


### PR DESCRIPTION
Part of #387. This resolves the remaining `sceKernelVirtualQuery` physical-backing/type metadata slice; unrelated error-contract findings, if any, stay separate.

## What changed
- retain direct mappings' physical offset and memory type in the Linux/Windows VA trackers
- preserve offset correspondence when mappings are split by protection/type changes, replacement, or partial unmap
- report `offset`, `memoryType`, and the ABI's direct/flexible/committed classification bits from `sceKernelVirtualQuery`
- make `sceKernelMapDirectMemory2` apply its explicit type to both the new VMA and the physical allocation table
- propagate `sceKernelMtypeprotect` and BatchMap `TYPE_PROTECT` into VMA and physical-query metadata after host protection succeeds
- retain zero offset/type for flexible and reserved mappings
- add cross-platform lifecycle regressions, including Windows partial direct unmap suffix rebasing

The field layout and behavior were cross-checked against the upstream shadPS4 `OrbisVirtualQueryInfo`, `VirtualQuery`, `MapDirectMemory2`, and `SetDirectMemoryType` implementations.

## Author preflight
- Windows targeted builds: `test_dmem`, `test_retrack_reservation`
- Windows targeted CTest: 2/2 passed
- Linux targeted builds: `test_dmem`, `test_retrack_reservation`
- Linux targeted CTest: 2/2 passed
- `git diff --check` passed
- no game/image snapshots were run

The full author-owned verifier and an independent inspection-only review will be posted against the exact PR head.