### PR TITLE
perf(renderer): defer intermediate scanout readback

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -296,9 +296,12 @@ device-image budget are separate: a hot immutable atlas can occupy space in both
 residency for lower frame time.
 
 Intermediate live color targets remain on the GPU by default. A later graphics pass that samples the
-same guest target identity, extent, and format binds the retained image directly; scanout, captures,
-pixel diagnostics, same-target feedback, and authoritative-readback spans keep the CPU path. Guest GPU
-writes invalidate overlapping retained targets through the ordered write observer. Set
+same guest target identity, extent, and format binds the retained image directly. Intermediate scanout
+spans also defer readback until the final renderer callback; a final scanout pass reads the accumulated
+target normally, while a submit that ends elsewhere materializes its cached scanout once before publishing.
+Ordered DMA producers, captures, pixel diagnostics, same-target feedback, and other authoritative-readback
+spans keep the CPU path. Guest GPU writes invalidate overlapping retained targets through the ordered write
+observer. Set `PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER=1` to restore per-span scanout readback for an A/B. Set
 `PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1` for a complete frontend A/B, or
 `PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS=1` to disable backend retention independently. The backend
 cache defaults to 256 MiB and can be changed with `PROSPER_BACKEND_TARGET_CACHE_MB=<MiB>`.

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -299,6 +299,7 @@ Intermediate live color targets remain on the GPU by default. A later graphics p
 same guest target identity, extent, and format binds the retained image directly. Intermediate scanout
 spans also defer readback until the final renderer callback; a final scanout pass reads the accumulated
 target normally, while a submit that ends elsewhere materializes its cached scanout once before publishing.
+Deferred scanouts are pinned against bounded target-cache eviction until that final callback.
 Ordered DMA producers, captures, pixel diagnostics, same-target feedback, and other authoritative-readback
 spans keep the CPU path. Guest GPU writes invalidate overlapping retained targets through the ordered write
 observer. Set `PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER=1` to restore per-span scanout readback for an A/B. Set

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -202,8 +202,9 @@ and a DMA producer is explicitly marked authoritative by the ordered executor.
 
 Intermediate non-authoritative scanout spans now remain GPU-resident. The final callback either uses the
 normal readback from a later scanout pass or materializes the cached target once if the submit ended on a
-different target. `PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER=1` restores per-span scanout readback for a same-
-binary comparison.
+different target. Deferred scanouts are pinned against the backend's bounded LRU eviction until final
+materialization, while guest writes may still invalidate their pixels.
+`PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER=1` restores per-span scanout readback for a same-binary comparison.
 
 Native Windows / RTX 4090, one RelWithDebInfo binary, separate fresh saves, native scale/cadence, and the
 documented Evergate route produced 104 dense submits in each run:

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -192,6 +192,35 @@ A second nearby pair measured 139.4 to 133.6 ms whole-submit time, confirming a 
 gain. The flat 37 ms fence wait remains the primary structural limit; packing removes CPU object handling
 and pool bookkeeping but does not change GPU work or synchronous ownership.
 
+## Evergate intermediate scanout readback (2026-07-19)
+
+Per-target timing showed that Evergate's dense transition renders the same 1080p VideoOut target in four
+graphics spans separated by compute. The first three callbacks cannot publish a frame, but each previously
+copied the whole scanout to CPU memory before the fourth and final span repeated that readback. Persistent
+color-target queue order already preserves those writes, compute consumers can materialize a target lazily,
+and a DMA producer is explicitly marked authoritative by the ordered executor.
+
+Intermediate non-authoritative scanout spans now remain GPU-resident. The final callback either uses the
+normal readback from a later scanout pass or materializes the cached target once if the submit ended on a
+different target. `PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER=1` restores per-span scanout readback for a same-
+binary comparison.
+
+Native Windows / RTX 4090, one RelWithDebInfo binary, separate fresh saves, native scale/cadence, and the
+documented Evergate route produced 104 dense submits in each run:
+
+| Measurement | Per-span scanout readback | Intermediate defer |
+|---|---:|---:|
+| Median total draws / submit | 474 | 474 |
+| Median backend execution | 77.5 ms | 72.0 ms |
+| Median GPU fence wait | 37.2 ms | 35.3 ms |
+| Median readback | 6.2 ms | 2.7 ms |
+| CPU readbacks / submit | 6 | 3 |
+
+Matched 25-submit windows near 475-482 draws improved from 127.8 ms to 124.8 ms end to end. Both runs
+completed the fresh-save route at 1920x1080 and produced direct composited frames. The remaining structural
+cost is the fence wait after every backend call; removing it requires deferred lifetime management for all
+call-local Vulkan resources and is intentionally outside this tranche.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -417,6 +417,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             using RC = prosper::gpu::ResourceClass;
             drain_guest_gpu_writes(g_rtt, invalidate_ds);
             const prosper::gpu::LiveRenderPhase phase = prosper::gpu::live_render_phase();
+            struct PinnedScanout {
+                uint64_t id = 0;
+                uint32_t width = 0, height = 0;
+                VkFormat format = VK_FORMAT_UNDEFINED;
+            };
+            static thread_local std::vector<PinnedScanout> pinned_scanouts;
+            auto release_pinned_scanouts = [&] {
+                for (const PinnedScanout& target : pinned_scanouts)
+                    prosper::test::unpin_persistent_color_target(
+                        target.id, target.width, target.height, target.format);
+                pinned_scanouts.clear();
+            };
+            // A terminal callback normally releases every pin. Recover conservatively if an earlier
+            // submit was aborted after rendering but before frontend finalization.
+            if (phase.first_span && !pinned_scanouts.empty()) release_pinned_scanouts();
             // PROSPER_RENDER_FIRST=<N>: skip the slow (~400x) Vulkan render for the first N GPU submits, so
             // the game reaches a LATE scene (e.g. the level1 cutscene, which only starts submitting after
             // ~5000 title-loop submits) at native speed before we begin rendering/dumping. Returning {}
@@ -2205,6 +2220,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             base, gw, gh, pass_format) != nullptr;
                         if (!pass_pixels->empty()) surface.rgba = pass_pixels;
                         else if (surface.gpu_valid) surface.rgba.reset();
+                        if (defer_readback && is_vo && surface.gpu_valid) {
+                            const auto already_pinned = std::find_if(
+                                pinned_scanouts.begin(), pinned_scanouts.end(),
+                                [&](const PinnedScanout& target) {
+                                    return target.id == base && target.width == gw &&
+                                           target.height == gh && target.format == pass_format;
+                                });
+                            if (already_pinned == pinned_scanouts.end()) {
+                                if (prosper::test::pin_persistent_color_target(
+                                        base, gw, gh, pass_format)) {
+                                    pinned_scanouts.push_back({base, gw, gh, pass_format});
+                                } else {
+                                    // Pinning is expected to succeed for the target just written. If
+                                    // cache state is inconsistent, preserve correctness by immediately
+                                    // restoring the authoritative CPU fallback.
+                                    std::vector<uint8_t> materialized;
+                                    std::string error;
+                                    if (prosper::test::readback_persistent_color_target(
+                                            base, gw, gh, pass_format, materialized, error))
+                                        surface.rgba =
+                                            std::make_shared<const std::vector<uint8_t>>(
+                                                std::move(materialized));
+                                }
+                            }
+                        }
                     } else if (base && !pass_pixels->empty()) {
                         RttSurf& surface = g_rtt[base];
                         surface.rgba = pass_pixels;
@@ -2516,6 +2556,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 }
                 if (scanout) selected_pixels = scanout->rgba;
             }
+            if (phase.final_span) release_pinned_scanouts();
             if (phase.final_span && lightweight_rtt_timing && rtt_log_in_range &&
                 pending_timing.backend_draws >= rtt_timing_min_draws) {
                 std::string output;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -407,6 +407,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
         !getenv("PROSPER_DUMP_DRAWSTEPS") &&
         !getenv("PROSPER_RESOURCE_HASH_DIM") && !getenv("PROSPER_TARGET_STEP_HASH_DIM") &&
         !getenv("PROSPER_RTTLOG");
+    static const bool defer_intermediate_scanout = live_gpu_targets &&
+        !getenv("PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER");
     if (live_gpu_targets)
         fprintf(stderr, "[render] persistent GPU color targets enabled (experimental)\n");
     prosper::gpu::set_submit_renderer(
@@ -477,6 +479,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t target = 0;
                 uint32_t width = 0, height = 0;
                 size_t draws = 0;
+                bool first_span = false, final_span = false;
+                bool authoritative_readback = false, deferred_readback = false;
                 double measured_ms = 0;
                 prosper::test::BackendRenderTimingStats timing;
                 prosper::test::BackendColorTargetStats color_target;
@@ -522,11 +526,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 const int length = snprintf(
                     line, sizeof(line),
                     "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
+                    "span=%d/%d authoritative=%d deferred=%d "
                     "measured=%.2f detail=%.2f other=%.2f target_setup=%.2f "
                     "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f "
                     "readback=%.2f cleanup=%.2f gpu_target=%llu load=%llu sample=%llu cpu=%llu\n",
                     record.submit, (unsigned long long)record.target,
-                    record.width, record.height, record.draws, record.measured_ms, detail_ms,
+                    record.width, record.height, record.draws,
+                    record.first_span, record.final_span, record.authoritative_readback,
+                    record.deferred_readback, record.measured_ms, detail_ms,
                     record.measured_ms - detail_ms,
                     timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
                     timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms,
@@ -2120,12 +2127,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             inspect(items[later].prt.get());
                         }
                     }
-                    // Defer only a proven graphics-to-graphics intermediate. A same-submit DMA asks
-                    // its producer span for readback; a later-submit DMA materializes the persistent
-                    // image synchronously through the byte-range reader above.
-                    const bool defer_readback = live_gpu_targets && vo_n > 0 && base && !is_vo &&
-                        base != front_va && sampled_exact_later && !feedback_later &&
-                        !phase.authoritative_readback;
+                    // Keep intermediate scanout spans GPU-resident too: they cannot publish until the
+                    // final callback, where the cache is materialized on demand if no later scanout
+                    // pass already requested CPU pixels. A same-submit DMA asks its producer span for
+                    // authoritative readback, and compute consumers use the lazy target reader above.
+                    const bool defer_readback = live_gpu_targets && vo_n > 0 && base &&
+                        !phase.authoritative_readback &&
+                        ((is_vo && phase.allows_deferred_scanout_readback() &&
+                          defer_intermediate_scanout) ||
+                         (!is_vo && base != front_va && sampled_exact_later && !feedback_later));
                     prosper::test::BackendColorTarget backend_target{
                         base, seed_rtt, !defer_readback, pass_format};
                     const bool color1_extent_matches = base1 && !render_pass.empty() &&
@@ -2304,6 +2314,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     const RttTimingRecord rtt_timing_record{
                         g_this_submit, base, gw, gh, pass.size(),
+                        phase.first_span, phase.final_span, phase.authoritative_readback,
+                        defer_readback,
                         std::chrono::duration<double, std::milli>(
                             backend_done - build_done).count(),
                         backend_call_timing, color_target_call};
@@ -2470,10 +2482,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 auto cached_scanout = [&](uint64_t addr) -> const RttSurf* {
                     auto it = g_rtt.find(addr);
                     if (it == g_rtt.end() || it->second.w != w || it->second.h != h ||
-                        it->second.format != VK_FORMAT_R8G8B8A8_UNORM ||
-                        !it->second.rgba || it->second.rgba->size() != (size_t)w * h * 4)
+                        it->second.format != VK_FORMAT_R8G8B8A8_UNORM)
                         return nullptr;
-                    return &it->second;
+                    RttSurf& surface = it->second;
+                    const size_t expected = static_cast<size_t>(w) * h * 4;
+                    if ((!surface.rgba || surface.rgba->size() != expected) && surface.gpu_valid) {
+                        std::vector<uint8_t> materialized;
+                        std::string error;
+                        if (prosper::test::readback_persistent_color_target(
+                                addr, w, h, surface.format, materialized, error) &&
+                            materialized.size() == expected) {
+                            surface.rgba = std::make_shared<const std::vector<uint8_t>>(
+                                std::move(materialized));
+                        } else {
+                            static std::atomic<int> warned{0};
+                            if (warned.fetch_add(1) < 24)
+                                std::fprintf(stderr,
+                                             "[rtt] final scanout readback failed: base=0x%llx "
+                                             "extent=%ux%u error=%s\n",
+                                             static_cast<unsigned long long>(addr), w, h,
+                                             error.c_str());
+                            return nullptr;
+                        }
+                    }
+                    return surface.rgba && surface.rgba->size() == expected ? &surface : nullptr;
                 };
                 const int front = prosper::gpu::present_front_index();
                 const RttSurf* scanout = front >= 0

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -1150,6 +1150,10 @@ struct LiveRenderPhase {
     // The next ordered operation reads render-target bytes on the CPU. Persistent Vulkan targets
     // must synchronously read back this span instead of deferring their authoritative pixels.
     bool authoritative_readback = false;
+
+    bool allows_deferred_scanout_readback() const {
+        return !final_span && !authoritative_readback;
+    }
 };
 LiveRenderPhase live_render_phase();
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -435,6 +435,7 @@ struct PersistentColorTargetImage {
     VkDeviceSize bytes = 0;
     VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
     uint64_t last_use = 0;
+    uint32_t pin_count = 0;
     bool valid = false;
 };
 
@@ -474,6 +475,27 @@ inline PersistentColorTargetImage* find_persistent_color_target(
     return &found->second;
 }
 
+// Ordered frontend spans may need a GPU-only target to survive later backend calls until the submit's
+// final callback materializes or presents it. Pins are explicit and short-lived; invalidation still
+// makes the pixels unusable, while eviction waits until every owner releases the allocation.
+inline bool pin_persistent_color_target(uint64_t id, uint32_t width, uint32_t height,
+                                        VkFormat format) {
+    PersistentColorTargetImage* target = find_persistent_color_target(
+        id, width, height, backend_color_format(format));
+    if (!target || target->pin_count == UINT32_MAX) return false;
+    ++target->pin_count;
+    return true;
+}
+
+inline bool unpin_persistent_color_target(uint64_t id, uint32_t width, uint32_t height,
+                                          VkFormat format) {
+    auto& cache = persistent_color_target_cache();
+    auto found = cache.find({id, width, height, backend_color_format(format)});
+    if (found == cache.end() || !found->second.pin_count) return false;
+    --found->second.pin_count;
+    return true;
+}
+
 // Guest/compute writes invalidate the GPU-produced version without immediately freeing the image.
 // The next render may reuse the allocation, but it cannot LOAD or sample stale pixels.
 inline void invalidate_persistent_color_target(uint64_t id) {
@@ -505,7 +527,7 @@ inline bool evict_persistent_color_target(const RenderVkCtx& ctx, uint64_t curre
     auto& cache = persistent_color_target_cache();
     auto victim = cache.end();
     for (auto it = cache.begin(); it != cache.end(); ++it) {
-        if (it->second.last_use == current_generation) continue;
+        if (it->second.last_use == current_generation || it->second.pin_count) continue;
         if (victim == cache.end() || it->second.last_use < victim->second.last_use)
             victim = it;
     }

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -219,6 +219,9 @@ int main() {
               phases[0].first_span && !phases[0].final_span &&
               !phases[1].first_span && phases[1].final_span,
               "ordered executor brackets one submit across two graphics spans");
+        CHECK(phases[0].allows_deferred_scanout_readback() &&
+              !phases[1].allows_deferred_scanout_readback(),
+              "only a non-final graphics span may defer scanout readback across compute");
         CHECK(overlapping == GuestGpuWriteQuery::Overlap &&
               unrelated == GuestGpuWriteQuery::Unchanged,
               "write journal distinguishes overlapping and unrelated in-submit GPU writes");
@@ -260,6 +263,9 @@ int main() {
         CHECK(dma_phases.size() == 2 && dma_phases[0].authoritative_readback &&
               !dma_phases[1].authoritative_readback,
               "the graphics span immediately before DMA requests authoritative target readback");
+        CHECK(!dma_phases[0].allows_deferred_scanout_readback() &&
+              !dma_phases[1].allows_deferred_scanout_readback(),
+              "DMA producers and final spans cannot defer scanout readback");
     }
 
     // A rendered target's authoritative bytes can live only in the backend cache. Resolve the
@@ -541,6 +547,9 @@ int main() {
         CHECK(phases[0].first_span && !phases[0].final_span &&
               !phases[1].first_span && phases[1].final_span,
               "lazy-span terminal callback closes the submit exactly once");
+        CHECK(phases[0].allows_deferred_scanout_readback() == failed_first &&
+              !phases[1].allows_deferred_scanout_readback(),
+              "terminal finalization preserves the prior span's readback requirement");
     }
 
     CHECK(!have_submit_renderer(), "no live renderer registered by default (game path stays inert)");

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -264,17 +264,30 @@ int main() {
         std::vector<uint8_t> deferred = prosper::test::render_draws_rgba(
             {add_green}, W, H, nullptr, nullptr, false, &deferred_target);
         const auto deferred_stats = prosper::test::backend_color_target_stats();
+        const bool pinned = prosper::test::pin_persistent_color_target(
+            target_id, W, H, VK_FORMAT_R8G8B8A8_UNORM);
+        // Exceed the 64-entry target-cache cap after the deferred target becomes the oldest live
+        // entry. Without the submit-lifetime pin, normal LRU pressure discards its only current pixels
+        // before the frontend's final callback can materialize them.
+        for (uint64_t pressure = 0; pressure < 70; ++pressure) {
+            prosper::test::BackendColorTarget pressure_target{
+                target_id + 0x1000 + pressure, false, false};
+            prosper::test::render_draws_rgba(
+                {producer}, W, H, nullptr, nullptr, false, &pressure_target);
+        }
         std::vector<uint8_t> materialized;
         std::string materialize_error;
         const bool materialized_ok = prosper::test::readback_persistent_color_target(
             target_id, W, H, VK_FORMAT_R8G8B8A8_UNORM, materialized, materialize_error);
+        const bool unpinned = prosper::test::unpin_persistent_color_target(
+            target_id, W, H, VK_FORMAT_R8G8B8A8_UNORM);
         std::vector<uint8_t> deferred_sample = prosper::test::render_draws_rgba(
             {gpu_sample}, W, H);
         CHECK(deferred.empty() && deferred_stats.write_hits == 1 &&
                   deferred_stats.readbacks == 0,
               "persistent LOAD pass can complete without allocating a CPU readback");
-        CHECK(materialized_ok && materialized == cpu_accumulated,
-              "GPU-only persistent target can be materialized on demand for an ordered consumer");
+        CHECK(pinned && materialized_ok && materialized == cpu_accumulated && unpinned,
+              "pinned GPU-only target survives eviction pressure until ordered materialization");
         CHECK(!deferred_sample.empty() && deferred_sample == cpu_accumulated_sample,
               "deferred-readback accumulation matches the CPU reference after sampling");
 


### PR DESCRIPTION
Refs #702

## Problem

Evergate's dense native-render transition issues four consecutive graphics spans to the same 1080p VideoOut target. The first three callbacks cannot publish, but each synchronously copied the scanout to CPU memory before the final span repeated the readback.

## Contract and approach

- Defer scanout readback only for a non-final, non-authoritative graphics span.
- Preserve authoritative CPU pixels before ordered DMA; compute consumers retain the existing lazy materialization path.
- On the final callback, use a later scanout pass's normal readback or materialize the cached GPU target once when the submit ends elsewhere.
- Keep capture, replay, pixel-diagnostic, and full persistent-target opt-out behavior unchanged.
- Add a same-binary recovery switch: `PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER=1`.
- Extend gated per-target timing with span/readback-policy fields.

## Measured result

Native Windows / RTX 4090, one RelWithDebInfo binary, separate fresh saves, native 1920x1080 scale/cadence, documented Evergate route, 104 dense submits per run:

| Measurement | Per-span readback | Intermediate defer |
|---|---:|---:|
| Median total draws / submit | 474 | 474 |
| Median backend execution | 77.5 ms | 72.0 ms |
| Median GPU fence wait | 37.2 ms | 35.3 ms |
| Median readback | 6.2 ms | 2.7 ms |
| CPU readbacks / submit | 6 | 3 |

A matched 25-submit window near 475-482 draws improved from 127.8 ms to 124.8 ms end to end. Both routed runs completed and produced direct composited 1920x1080 frames with intact visible output.

## Risks and unaffected behavior

The change relies on ordered Vulkan queue execution and the existing persistent color-target lifetime. It does not remove any backend fence, change graphics/compute/DMA order, or make captures asynchronous. Final and DMA-authoritative spans remain synchronous. The larger deferred-cleanup/fence-lifetime refactor is deliberately outside this PR.

## Verification

- `git diff --check` — pass
- Linux build and CTest — 112/112 pass
- Windows build and CTest — 87/87 pass
- Evergate routed title guard — 9/9 qualifying, 8 pixel changes
- same-binary native Evergate A/B — pass at 1920x1080
- cross-title guards — Evergate, Dead Cells, and Blasphemous 2 pass; Messenger passed 29/29 with 8 pixel changes on the default treatment repeat and on the per-span-readback control. One preceding treatment run reached the name screen but missed the wall-clock route's late transition while continuing to publish frames, so it is retained as nondeterministic route-timing evidence rather than hidden.