### PR TITLE
fix(windows): guest-entry rbp terminator + don't null-emulate fs/gs TLS reads (#946)

### DIFF
--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1,4 +1,4 @@
-// exec_image_win.cpp — Windows host backing for the guest-execution substrate.
+﻿// exec_image_win.cpp — Windows host backing for the guest-execution substrate.
 //
 // The Windows sibling of exec_image_linux.cpp. It implements the same exec_image.hpp contract with
 // Win32 primitives instead of POSIX: VirtualAlloc for fixed-address guest mappings, a Vectored
@@ -76,6 +76,10 @@ __asm__(
     "    movq  %rcx, %rax\n"           // MS x64: rcx=fn, rdx=argc, r8=argp
     "    movq  %rdx, %rdi\n"           // argc -> SysV arg0
     "    movq  %r8,  %rsi\n"           // argp -> SysV arg1
+    "    xorq  %rbp, %rbp\n"           // terminate the guest frame-pointer chain at the host boundary so
+                                       // the guest's rbp-based backtrace walker (UE FP-chain) stops here
+                                       // instead of walking into host frames (MinGW omits frame pointers,
+                                       // so [rbp] there is garbage). Mirrors win_thread_trampoline. (#946)
     "    callq *%rax\n"
     "    movaps    0(%rsp), %xmm6\n"
     "    movaps   16(%rsp), %xmm7\n"
@@ -124,6 +128,7 @@ __asm__(
     "    movq  %r8,  %rsi\n"           // a1 -> SysV rsi
     "    movq  %r10, %rdx\n"           // a2 -> SysV rdx
     "    movq  48(%rbp), %rcx\n"       // a3 -> SysV rcx (5th MS argument)
+    "    xorq  %rbp, %rbp\n"           // terminate the guest FP-chain at the host boundary (#946); see sysv above
     "    callq *%rax\n"
     "    movaps    0(%rsp), %xmm6\n"
     "    movaps   16(%rsp), %xmm7\n"
@@ -439,6 +444,18 @@ namespace {
         if (fault_addr == c->Rip) return false;           // instruction fetch at null is a real endpoint
         const uint8_t* p = (const uint8_t*)(uintptr_t)c->Rip;
         if (!addr_readable((uint64_t)(uintptr_t)p)) return false;
+        // Decline segment-relative (fs/gs) accesses. A guest %fs/%gs TLS read that faults at a low linear
+        // address means the segment BASE drifted to 0 (Windows zeroes the FS base on kernel transitions),
+        // not that a null pointer was dereferenced. The fs-drift recovery below must re-apply the base and
+        // retry; emulating the read as 0 here would hand back a bogus null TCB and crash downstream
+        // (e.g. eboot+0x24d3c3c: `mov %fs:0x0,%rax ; cmpb -0x10(%rax)`). (#946)
+        for (size_t k = 0; k < 15; k++) {
+            uint8_t b = p[k];
+            if (b == 0x64 || b == 0x65) return false;                 // fs/gs override -> fs-drift recovery
+            if (b == 0x66 || b == 0x67 || b == 0xF0 || b == 0xF2 || b == 0xF3 ||
+                b == 0x2E || b == 0x36 || b == 0x3E || b == 0x26) continue;   // other legacy prefixes
+            break;                                                    // reached REX / opcode
+        }
         int reg = 0, insn_len = 0;
         // Decode via the shared, unit-tested x86 read decoder (only forms where zeroing the full dest is
         // correct for a zero source). 15 = max x86-64 instruction length; Rip is executable so it is mapped.


### PR DESCRIPTION
Advances #946 (DOLL / PPSA17942 Windows early-init hang). Two related Windows-port fixes.

## Fix 1 — zero rbp at the main-thread guest entry
`prosper_call_guest_sysv`/`_sysv4` (host→guest bridges used by `run_guest_inits`) entered guest code with `rbp` = host frame pointer; `win_thread_trampoline` (worker threads) already zeros it. UE's rbp-based frame-pointer backtrace walker (the reason `PROSPER_NULL_PAGE` exists) then walked out of guest frames into MinGW host frames (which omit frame pointers), read garbage as a saved-rbp, and drove the guest down a wrong early-init path that **deadlocked in a condvar with no worker threads created**. Linux host frames chain cleanly to null, so it never manifested. Direct comparison (same build): **Linux = 87 `pthread_create` + boot; Windows = 0 threads + hang**. Fix adds `xor %rbp,%rbp` at the boundary, mirroring the trampoline.

## Fix 2 — `PROSPER_NULL_PAGE` must not emulate fs/gs-relative reads
A guest `%fs` TLS read that faults at a low linear address means the segment **base drifted to 0** (Windows zeroes the FS base on kernel transitions), not a null-pointer deref. The VEH already has an fs-drift recovery that re-applies the base and retries — but the null-page emulator added in #947 ran first and returned 0, handing back a bogus null TCB and crashing downstream at `eboot+0x24d3c3c` (`mov %fs:0x0,%rax ; cmpb -0x10(%rax)`). `try_emulate_null_read` now declines any fs/gs-override instruction so the fs-drift recovery handles it.

## Result
DOLL now **boots past the #946 condvar deadlock and reaches UE subsystem init** — `FBootAllocator`, command-line parse (`Final commandline = …/DOLL.uproject`), and `libSceCoredump`/`libkernel`/`libScePosix`/`libSceAmpr` calls (same as Linux) — with its full task-graph thread pool created, where before it *always* hung after printing the memory layout. The `eboot+0x24d3c3c` crash is gone. Messenger (PPSA24651) still boots (unaffected — these only change the guest-entry frame-pointer register and decline fs/gs null-emulation).

## Scope / not closed here
Does **not** fully close #946: a residual **nondeterministic early-init race** still hangs a majority of runs before boot (the rbp fix reduced but didn't eliminate the deadlock trigger). Reaching UE subsystem init is the current Windows checkpoint. Tracked in #946.

Risk: hand-written asm in the two guest-entry bridges (single `xor %rbp,%rbp` after the last rbp use, before the guest `callq`, matching `win_thread_trampoline`); and a prefix-scan in the null-page emulator that only *declines* (never mis-handles). Verified across repeated runs + Messenger regression.
