### PR TITLE
kernel: validate direct memory allocations (#387)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -418,6 +418,22 @@ namespace {
     }
     uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
 
+    constexpr uint64_t kMaxDirectMemoryType = 10;
+    bool valid_dmem_allocation(uint64_t len, uint64_t alignment,
+                               uint64_t memory_type, uint64_t phys_out) {
+        // The direct-memory ABI is 16 KiB-granular. Do not round a malformed request up: doing so
+        // consumes a different physical range than the guest requested. Alignment zero selects the
+        // default page alignment; explicit alignments must also be powers of two because dmem_take's
+        // first-fit alignment arithmetic has that contract.
+        if (!len || (len & (kGuestPageSize - 1)) != 0) return false;
+        if (alignment && ((alignment & (kGuestPageSize - 1)) != 0 ||
+                          (alignment & (alignment - 1)) != 0)) return false;
+        if (memory_type > kMaxDirectMemoryType) return false;
+        // Low values are not plausible guest pointers. The old code accepted them, allocated from
+        // the pool, then skipped the guarded write -- false success plus leaked physical capacity.
+        return phys_out > 0xffff;
+    }
+
     // The console chooses automatic mappings from its guest user-VA space.  Letting mmap(nullptr)
     // choose instead leaks a host VA (commonly 0x7f...) to the guest.  Besides being outside the PS5
     // address model, Sony libc explicitly rejects such an address as mspace backing.  Search a quiet
@@ -690,9 +706,10 @@ HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0
 
 // sceKernelAllocateDirectMemory(off_t start, off_t end, size_t len, size_t align, int memType, off_t* physOut)
 HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, physAddrOut)
-    if (!a5) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
+    if (!valid_dmem_allocation(a2, a3, a4, a5))
+        return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     uint64_t align = a3 ? a3 : 0x4000;
-    uint64_t sz = align_up(a2, align);
+    uint64_t sz = a2;
     uint64_t off;
     // Honor the [searchStart, searchEnd) window (a0/a1) — dropping it handed the guest an offset
     // outside the window it asked for.
@@ -703,7 +720,7 @@ HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, ph
         return 0x8002000Cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
     dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
-    if (a5 > 0xffff) *(uint64_t*)a5 = off;   // only write through a plausible out-pointer
+    *(uint64_t*)a5 = off;
     MLOG("alloc_dmem range=[0x%llx,0x%llx) len=0x%llx align=0x%llx type=0x%llx -> phys=0x%llx\n",
          (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
          (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)off);
@@ -714,16 +731,17 @@ HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, ph
 // DIFFERENT signature (4 args) from AllocateDirectMemory: physOut is arg3, not arg5. Aliasing them
 // to one handler wrote the result through arg5 (uninitialized garbage, e.g. 0xa) -> crash.
 HLE(k_alloc_main_dmem) {
-    if (!a3) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
+    if (!valid_dmem_allocation(a0, a1, a2, a3))
+        return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     uint64_t align = a1 ? a1 : 0x4000;
-    uint64_t sz = align_up(a0, align);
+    uint64_t sz = a0;
     uint64_t off;
     if (!dmem_take(sz, align, (int)a2, off)) {
         MLOG("alloc_main_dmem len=0x%llx -> ENOMEM (pool exhausted)\n", (unsigned long long)a0);
         return 0x8002000Cull;   // SCE_KERNEL_ERROR_ENOMEM
     }
     dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
-    if (a3 > 0xffff) *(uint64_t*)a3 = off;
+    *(uint64_t*)a3 = off;
     MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
     return 0;
 }
@@ -1876,6 +1894,16 @@ namespace {
         return n;
     }
     uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
+
+    constexpr uint64_t kMaxDirectMemoryType = 10;
+    bool valid_dmem_allocation(uint64_t len, uint64_t alignment,
+                               uint64_t memory_type, uint64_t phys_out) {
+        if (!len || (len & (kGuestPageSize - 1)) != 0) return false;
+        if (alignment && ((alignment & (kGuestPageSize - 1)) != 0 ||
+                          (alignment & (alignment - 1)) != 0)) return false;
+        if (memory_type > kMaxDirectMemoryType) return false;
+        return phys_out > 0xffff;
+    }
 
     // Guest Orbis protection bits (READ=1, WRITE=2 [implies read], EXEC=4). WRITE implies READ,
     // and prot 0 is a legitimate no-access guard page (matches the Linux host_prot #342 fix).
@@ -3640,9 +3668,10 @@ HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0
 
 // sceKernelAllocateDirectMemory(start, end, len, align, memType, off_t* physOut)
 HLE(k_alloc_dmem) {
-    if (!a5) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
+    if (!valid_dmem_allocation(a2, a3, a4, a5))
+        return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     uint64_t align = a3 ? a3 : 0x4000;
-    uint64_t sz = align_up(a2, align);
+    uint64_t sz = a2;
     uint64_t off;
     if (!dmem_take(sz, align, (int)a4, off, a0, a1 ? a1 : ~0ull)) {
         MLOG("alloc_dmem len=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
@@ -3650,22 +3679,23 @@ HLE(k_alloc_dmem) {
         return 0x8002000Cull;
     }
     dmem_prepare_allocation(off, sz);
-    if (a5 > 0xffff) *(uint64_t*)a5 = off;
+    *(uint64_t*)a5 = off;
     MLOG("alloc_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a2, (unsigned long long)off);
     return 0;
 }
 // sceKernelAllocateMainDirectMemory(len, align, memType, off_t* physOut) — physOut at arg3.
 HLE(k_alloc_main_dmem) {
-    if (!a3) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL: required physAddrOut
+    if (!valid_dmem_allocation(a0, a1, a2, a3))
+        return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     uint64_t align = a1 ? a1 : 0x4000;
-    uint64_t sz = align_up(a0, align);
+    uint64_t sz = a0;
     uint64_t off;
     if (!dmem_take(sz, align, (int)a2, off)) {
         MLOG("alloc_main_dmem len=0x%llx -> ENOMEM\n", (unsigned long long)a0);
         return 0x8002000Cull;
     }
     dmem_prepare_allocation(off, sz);
-    if (a3 > 0xffff) *(uint64_t*)a3 = off;
+    *(uint64_t*)a3 = off;
     MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
     return 0;
 }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -50,6 +50,15 @@ namespace {
     constexpr uint32_t kVirtualQueryCommitted = 0x10;
     constexpr uint64_t kGuestPageSize = 0x4000;
 
+    bool align_up_multiple(uint64_t value, uint64_t alignment, uint64_t& out) {
+        if (!alignment) { out = value; return true; }
+        const uint64_t remainder = value % alignment;
+        const uint64_t delta = remainder ? alignment - remainder : 0;
+        if (delta > UINT64_MAX - value) return false;
+        out = value + delta;
+        return true;
+    }
+
     bool normalize_guest_page_range(uint64_t addr, uint64_t len,
                                     uint64_t& base_out, uint64_t& len_out) {
         constexpr uint64_t mask = kGuestPageSize - 1;
@@ -118,8 +127,10 @@ namespace {
             // Clip the free gap to the search window, then align the start.
             uint64_t beg = gap_beg < lo ? lo : gap_beg;
             uint64_t end = gap_end > hi ? hi : gap_end;
-            uint64_t off = (beg + align - 1) & ~(align - 1);
-            if (off + sz <= end) { insert_at = i; off_out = off; goto found; }
+            uint64_t off = 0;
+            if (align_up_multiple(beg, align, off) && off <= end && sz <= end - off) {
+                insert_at = i; off_out = off; goto found;
+            }
             if (i < g_dmem.size()) cursor = g_dmem[i].end;
         }
         return false;
@@ -145,8 +156,11 @@ namespace {
             // Clip the free gap to the caller's search window, then align its start.
             uint64_t beg = gap_beg < lo ? lo : gap_beg;
             uint64_t end = gap_end > hi ? hi : gap_end;
-            uint64_t aligned = (beg + align - 1) & ~(align - 1);
-            if (end > aligned && end - aligned > size_out) { off_out = aligned; size_out = end - aligned; }
+            uint64_t aligned = 0;
+            if (align_up_multiple(beg, align, aligned) && end > aligned &&
+                end - aligned > size_out) {
+                off_out = aligned; size_out = end - aligned;
+            }
             if (i < g_dmem.size()) cursor = g_dmem[i].end;
         }
     }
@@ -423,11 +437,9 @@ namespace {
                                uint64_t memory_type, uint64_t phys_out) {
         // The direct-memory ABI is 16 KiB-granular. Do not round a malformed request up: doing so
         // consumes a different physical range than the guest requested. Alignment zero selects the
-        // default page alignment; explicit alignments must also be powers of two because dmem_take's
-        // first-fit alignment arithmetic has that contract.
+        // default page alignment; the allocator supports every explicit 16 KiB multiple.
         if (!len || (len & (kGuestPageSize - 1)) != 0) return false;
-        if (alignment && ((alignment & (kGuestPageSize - 1)) != 0 ||
-                          (alignment & (alignment - 1)) != 0)) return false;
+        if (alignment && (alignment & (kGuestPageSize - 1)) != 0) return false;
         if (memory_type > kMaxDirectMemoryType) return false;
         // Low values are not plausible guest pointers. The old code accepted them, allocated from
         // the pool, then skipped the guarded write -- false success plus leaked physical capacity.
@@ -1600,6 +1612,15 @@ namespace {
     constexpr uint32_t kVirtualQueryCommitted = 0x10;
     constexpr uint64_t kGuestPageSize = 0x4000;
 
+    bool align_up_multiple(uint64_t value, uint64_t alignment, uint64_t& out) {
+        if (!alignment) { out = value; return true; }
+        const uint64_t remainder = value % alignment;
+        const uint64_t delta = remainder ? alignment - remainder : 0;
+        if (delta > UINT64_MAX - value) return false;
+        out = value + delta;
+        return true;
+    }
+
     bool normalize_guest_page_range(uint64_t addr, uint64_t len,
                                     uint64_t& base_out, uint64_t& len_out) {
         constexpr uint64_t mask = kGuestPageSize - 1;
@@ -1653,8 +1674,10 @@ namespace {
             uint64_t gap_end = (i < g_dmem.size()) ? g_dmem[i].start : kDmemBase + kDmemTotal;
             uint64_t beg = gap_beg < lo ? lo : gap_beg;
             uint64_t end = gap_end > hi ? hi : gap_end;
-            uint64_t off = (beg + align - 1) & ~(align - 1);
-            if (off + sz <= end) { insert_at = i; off_out = off; goto found; }
+            uint64_t off = 0;
+            if (align_up_multiple(beg, align, off) && off <= end && sz <= end - off) {
+                insert_at = i; off_out = off; goto found;
+            }
             if (i < g_dmem.size()) cursor = g_dmem[i].end;
         }
         return false;
@@ -1674,8 +1697,11 @@ namespace {
             uint64_t gap_end = (i < g_dmem.size()) ? g_dmem[i].start : kDmemBase + kDmemTotal;
             uint64_t beg = gap_beg < lo ? lo : gap_beg;
             uint64_t end = gap_end > hi ? hi : gap_end;
-            uint64_t aligned = (beg + align - 1) & ~(align - 1);
-            if (end > aligned && end - aligned > size_out) { off_out = aligned; size_out = end - aligned; }
+            uint64_t aligned = 0;
+            if (align_up_multiple(beg, align, aligned) && end > aligned &&
+                end - aligned > size_out) {
+                off_out = aligned; size_out = end - aligned;
+            }
             if (i < g_dmem.size()) cursor = g_dmem[i].end;
         }
     }
@@ -1899,8 +1925,7 @@ namespace {
     bool valid_dmem_allocation(uint64_t len, uint64_t alignment,
                                uint64_t memory_type, uint64_t phys_out) {
         if (!len || (len & (kGuestPageSize - 1)) != 0) return false;
-        if (alignment && ((alignment & (kGuestPageSize - 1)) != 0 ||
-                          (alignment & (alignment - 1)) != 0)) return false;
+        if (alignment && (alignment & (kGuestPageSize - 1)) != 0) return false;
         if (memory_type > kMaxDirectMemoryType) return false;
         return phys_out > 0xffff;
     }

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -175,13 +175,39 @@ int main() {
     // releases and reuses small physical ranges aggressively; independent Windows allocations
     // let its allocator observe different metadata through two aliases and corrupt adjacent VA.
     constexpr uint64_t dlen = 0x10000;
+    uint64_t invalid_phys = 0xfeedfacecafebeefull;
     CHECK((uint32_t)alloc(0, kEnd, dlen, dlen, 0, 0) == 0x80020016u,
           "AllocateDirectMemory(null physAddrOut) -> EINVAL");
     CHECK((uint32_t)alloc_main(dlen, dlen, 0, 0, 0, 0) == 0x80020016u,
           "AllocateMainDirectMemory(null physAddrOut) -> EINVAL");
+    CHECK((uint32_t)alloc(0, kEnd, 0, dlen, 0, (uint64_t)(uintptr_t)&invalid_phys) ==
+              0x80020016u && invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(zero length) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, dlen - 1, dlen, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(non-page length) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, dlen, 0x2000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(non-page alignment) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, dlen, 0xc000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(non-power-of-two alignment) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, dlen, dlen, 11,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(out-of-range memory type) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, dlen, dlen, 0, 1) == 0x80020016u,
+          "AllocateDirectMemory(low invalid physAddrOut) -> EINVAL");
+    CHECK((uint32_t)alloc_main(dlen - 1, dlen, 0,
+                               (uint64_t)(uintptr_t)&invalid_phys, 0, 0) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateMainDirectMemory validates the shared direct-memory request contract");
     uint64_t phys = 0, va1 = 0, va2 = 0, va_map2 = 0;
     CHECK(alloc(0, kEnd, dlen, dlen, 7, (uint64_t)(uintptr_t)&phys) == 0 && phys == kBase,
-          "allocate one 64 KiB direct-memory page");
+          "invalid allocations leave the pool untouched before a valid allocation");
     int32_t direct_type = -1;
     uint64_t direct_start = UINT64_MAX, direct_end = UINT64_MAX;
     CHECK(get_type(phys + 0x4000, (uint64_t)(uintptr_t)&direct_type,
@@ -666,12 +692,39 @@ int main() {
               0x80020016u,
           "Munmap rejects an overflowing guest range");
 
-    // Both allocation APIs require their physical-address output. Reject before taking from
-    // the pool so an unobservable allocation cannot leak capacity.
+    // Both allocation APIs validate the complete 16 KiB-granular request before taking from the
+    // pool, so a rejected call cannot write its output or leak capacity.
+    uint64_t invalid_phys = 0xfeedfacecafebeefull;
     CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0x4000, 0, 0) == 0x80020016u,
           "AllocateDirectMemory(null physAddrOut) -> EINVAL");
     CHECK((uint32_t)alloc_main(0x4000, 0x4000, 0, 0, 0, 0) == 0x80020016u,
           "AllocateMainDirectMemory(null physAddrOut) -> EINVAL");
+    CHECK((uint32_t)alloc(0, kEnd, 0, 0x4000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(zero length) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, 0x4001, 0x4000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(non-page length) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0x2000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(non-page alignment) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0xc000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(non-power-of-two alignment) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0x4000, 11,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateDirectMemory(out-of-range memory type) -> EINVAL without writing output");
+    CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0x4000, 0, 1) == 0x80020016u,
+          "AllocateDirectMemory(low invalid physAddrOut) -> EINVAL");
+    CHECK((uint32_t)alloc_main(0x4001, 0x4000, 0,
+                               (uint64_t)(uintptr_t)&invalid_phys, 0, 0) == 0x80020016u &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateMainDirectMemory validates the shared direct-memory request contract");
 
     // Fresh pool: the largest free block is the whole pool, and BOTH out-params are written.
     uint64_t phys = 0xdead, size = 0xdead;
@@ -689,7 +742,8 @@ int main() {
     // Allocate 1 MiB (args: searchStart, searchEnd, len, align, type, physOut) at the pool base.
     uint64_t ap = 0;
     uint64_t ar = alloc(0, kEnd, 0x100000, 0x4000, 6, (uint64_t)(uintptr_t)&ap);
-    CHECK(ar == 0 && ap == kBase, "allocate 1MiB -> phys at pool base");
+    CHECK(ar == 0 && ap == kBase,
+          "invalid allocations leave the pool untouched before a valid allocation");
     int32_t direct_type = -1;
     uint64_t direct_start = UINT64_MAX, direct_end = UINT64_MAX;
     CHECK(get_type(ap + 0x80000, (uint64_t)(uintptr_t)&direct_type,

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -191,10 +191,10 @@ int main() {
                           (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
               invalid_phys == 0xfeedfacecafebeefull,
           "AllocateDirectMemory(non-page alignment) -> EINVAL without writing output");
-    CHECK((uint32_t)alloc(0, kEnd, dlen, 0xc000, 0,
-                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+    CHECK((uint32_t)alloc(0, kEnd, UINT64_MAX & ~0x3fffull, dlen, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x8002000cu &&
               invalid_phys == 0xfeedfacecafebeefull,
-          "AllocateDirectMemory(non-power-of-two alignment) -> EINVAL without writing output");
+          "AllocateDirectMemory(overflowing size) fails without writing output");
     CHECK((uint32_t)alloc(0, kEnd, dlen, dlen, 11,
                           (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
               invalid_phys == 0xfeedfacecafebeefull,
@@ -205,6 +205,18 @@ int main() {
                                (uint64_t)(uintptr_t)&invalid_phys, 0, 0) == 0x80020016u &&
               invalid_phys == 0xfeedfacecafebeefull,
           "AllocateMainDirectMemory validates the shared direct-memory request contract");
+    CHECK((uint32_t)alloc_main(UINT64_MAX & ~0x3fffull, dlen, 0,
+                               (uint64_t)(uintptr_t)&invalid_phys, 0, 0) == 0x8002000cu &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateMainDirectMemory(overflowing size) fails without writing output");
+    uint64_t multiple_align_phys = 0;
+    CHECK(alloc(0, kEnd, 0x4000, 0xc000, 0,
+                (uint64_t)(uintptr_t)&multiple_align_phys) == 0 &&
+              multiple_align_phys % 0xc000 == 0,
+          "AllocateDirectMemory accepts a 16-KiB-multiple non-power-of-two alignment");
+    if (multiple_align_phys)
+        CHECK(release(multiple_align_phys, 0x4000, 0, 0, 0, 0) == 0,
+              "release the non-power-of-two-aligned allocation");
     uint64_t phys = 0, va1 = 0, va2 = 0, va_map2 = 0;
     CHECK(alloc(0, kEnd, dlen, dlen, 7, (uint64_t)(uintptr_t)&phys) == 0 && phys == kBase,
           "invalid allocations leave the pool untouched before a valid allocation");
@@ -711,10 +723,10 @@ int main() {
                           (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
               invalid_phys == 0xfeedfacecafebeefull,
           "AllocateDirectMemory(non-page alignment) -> EINVAL without writing output");
-    CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0xc000, 0,
-                          (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
+    CHECK((uint32_t)alloc(0, kEnd, UINT64_MAX & ~0x3fffull, 0x4000, 0,
+                          (uint64_t)(uintptr_t)&invalid_phys) == 0x8002000cu &&
               invalid_phys == 0xfeedfacecafebeefull,
-          "AllocateDirectMemory(non-power-of-two alignment) -> EINVAL without writing output");
+          "AllocateDirectMemory(overflowing size) fails without writing output");
     CHECK((uint32_t)alloc(0, kEnd, 0x4000, 0x4000, 11,
                           (uint64_t)(uintptr_t)&invalid_phys) == 0x80020016u &&
               invalid_phys == 0xfeedfacecafebeefull,
@@ -725,6 +737,18 @@ int main() {
                                (uint64_t)(uintptr_t)&invalid_phys, 0, 0) == 0x80020016u &&
               invalid_phys == 0xfeedfacecafebeefull,
           "AllocateMainDirectMemory validates the shared direct-memory request contract");
+    CHECK((uint32_t)alloc_main(UINT64_MAX & ~0x3fffull, 0x4000, 0,
+                               (uint64_t)(uintptr_t)&invalid_phys, 0, 0) == 0x8002000cu &&
+              invalid_phys == 0xfeedfacecafebeefull,
+          "AllocateMainDirectMemory(overflowing size) fails without writing output");
+    uint64_t multiple_align_phys = 0;
+    CHECK(alloc(0, kEnd, 0x4000, 0xc000, 0,
+                (uint64_t)(uintptr_t)&multiple_align_phys) == 0 &&
+              multiple_align_phys % 0xc000 == 0,
+          "AllocateDirectMemory accepts a 16-KiB-multiple non-power-of-two alignment");
+    if (multiple_align_phys)
+        CHECK(release(multiple_align_phys, 0x4000, 0, 0, 0, 0) == 0,
+              "release the non-power-of-two-aligned allocation");
 
     // Fresh pool: the largest free block is the whole pool, and BOTH out-params are written.
     uint64_t phys = 0xdead, size = 0xdead;


### PR DESCRIPTION
## Summary

- reject zero or non-16-KiB direct-memory lengths on Linux and Windows
- reject invalid explicit alignments, memory types above 10, and implausible/null output pointers before pool mutation
- stop silently rounding allocation sizes and cover failure atomicity for both allocation APIs

## Verification

Author verification will be posted on the exact PR head with the repository's `prosper/tools/verify-pr.ps1 core` workflow. The reviewer is inspection-only and will not run builds or tests.

No game/image snapshots are part of this change.

Closes the remaining F10 slice of #387.