### PR TITLE
diag(loader): add module path to PROSPER_INITLOG output

### DIFF
--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -100,9 +100,10 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
     if (getenv("PROSPER_INITLOG")) {
         for (size_t i = 0; i < out.mods.size(); i++) {
             const Module& m = *out.mods[i];
-            fprintf(stderr, "[initlog] module %zu base=0x%llx init_va=0x%llx init_array_va=0x%llx entries=%llu\n",
+            fprintf(stderr, "[initlog] module %zu base=0x%llx init_va=0x%llx init_array_va=0x%llx entries=%llu path=%s\n",
                     i, (unsigned long long)out.imgs[i].base, (unsigned long long)m.init_va,
-                    (unsigned long long)m.init_array_va, (unsigned long long)(m.init_array_sz / 8));
+                    (unsigned long long)m.init_array_va, (unsigned long long)(m.init_array_sz / 8),
+                    m.path.c_str());
         }
     }
     for (size_t i = out.mods.size(); i-- > 1; ) {


### PR DESCRIPTION
## What
`PROSPER_INITLOG` printed each module's base/init_va/init_array but not its source file. Identifying *which* module owns a given init fn (e.g. when a `module_start` faults during boot) meant a separate byte-signature hunt across the dump's PRXs.

This adds `m.path` to the log line so the map directly names each module.

## Why
Used while tracing the #946 Windows module-init fault: the fault report named `init fn 0x5c0000010` but not its module. With this, one line confirms module 1 (base 0x5c0000000) is **libc.prx**:
```
[initlog] module 0 base=0x410000000 init_va=0x10 ... path=.../eboot.bin
[initlog] module 1 base=0x5c0000000 init_va=0x10 ... path=.../sce_module/libc.prx
```

## Risk
None. Opt-in diagnostic (`PROSPER_INITLOG`) already gated off by default; adds one `%s` field. No runtime/behavioral change.

## Verification
Built `prosper-app` (MinGW/Ninja) clean; ran with `PROSPER_INITLOG=1` and confirmed the path field prints for both modules (output above). Linux build unaffected (shared source, log-only).